### PR TITLE
Add description udp listening information

### DIFF
--- a/lib/msf/core/handler/reverse_udp.rb
+++ b/lib/msf/core/handler/reverse_udp.rb
@@ -42,6 +42,23 @@ module ReverseUdp
     "reverse UDP"
   end
 
+  # A URI describing what the payload is configured to use for transport
+  def payload_uri
+    addr = datastore['LHOST']
+    uri_host = Rex::Socket.is_ipv6?(addr) ? "[#{addr}]" : addr
+    "udp://#{uri_host}:#{datastore['LPORT']}"
+  end
+
+  # A URI describing where we are listening
+  #
+  # @param addr [String] the address that
+  # @return [String] A URI of the form +scheme://host:port/+
+  def listener_uri(addr = datastore['ReverseListenerBindAddress'])
+    addr = datastore['LHOST'] if addr.nil? || addr.empty?
+    uri_host = Rex::Socket.is_ipv6?(addr) ? "[#{addr}]" : addr
+    "udp://#{uri_host}:#{bind_port}"
+  end
+
   #
   # Initializes the reverse UDP handler and ads the options that are required
   # for all reverse UDP payloads, like local host and local port.


### PR DESCRIPTION
Add listening description for `reverse udp`

## Verification

```ruby
msf5 > handler -p cmd/unix/reverse_bash_udp -H 192.168.1.1 -P 7777
[*] Payload handler running as background job 0.

[*] Started reverse UDP handler on 192.168.1.1:7777
msf5 > jobs

Jobs
====

  Id  Name                    Payload                    Payload opts
  --  ----                    -------                    ------------
  0   Exploit: multi/handler  cmd/unix/reverse_bash_udp  udp://192.168.1.1:7777

msf5 >
```

