### PR TITLE
Fix #12813, Twitter handle correction

### DIFF
--- a/modules/auxiliary/scanner/http/citrix_dir_traversal.rb
+++ b/modules/auxiliary/scanner/http/citrix_dir_traversal.rb
@@ -20,7 +20,7 @@ class MetasploitModule < Msf::Auxiliary
       },
       'Author'         => [
         'Erik Wynter', # @wyntererik
-        'altonjx'      # @altjx
+        'altonjx'      # @altonjx
       ],
       'References'     => [
         ['CVE', '2019-19781'],


### PR DESCRIPTION
Fixes https://github.com/rapid7/metasploit-framework/pull/12813#issuecomment-573963426. @altjx is the GitHub handle.