### PR TITLE
cleanup windows/gather/enum_patches

### DIFF
--- a/modules/post/windows/gather/enum_patches.rb
+++ b/modules/post/windows/gather/enum_patches.rb
@@ -10,21 +10,12 @@ class MetasploitModule < Msf::Post
   include Msf::Post::Common
   include Msf::Post::Windows::ExtAPI
 
-  MSF_MODULES = {
-    'KB977165'  => "KB977165 - Possibly vulnerable to MS10-015 kitrap0d if Windows 2K SP4 - Windows 7 (x86)",
-    'KB2305420' => "KB2305420 - Possibly vulnerable to MS10-092 schelevator if Vista, 7, and 2008",
-    'KB2592799' => "KB2592799 - Possibly vulnerable to MS11-080 afdjoinleaf if XP SP2/SP3 Win 2k3 SP2",
-    'KB2778930' => "KB2778930 - Possibly vulnerable to MS13-005 hwnd_broadcast, elevates from Low to Medium integrity",
-    'KB2850851' => "KB2850851 - Possibly vulnerable to MS13-053 schlamperei if x86 Win7 SP0/SP1",
-    'KB2870008' => "KB2870008 - Possibly vulnerable to MS13-081 track_popup_menu if x86 Windows 7 SP0/SP1"
-  }
-
   def initialize(info={})
     super(update_info(info,
       'Name'            => "Windows Gather Applied Patches",
       'Description'     => %q{
           This module will attempt to enumerate which patches are applied to a windows system
-          based on the result of the WMI query: SELECT HotFixID FROM Win32_QuickFixEngineering
+          based on the result of the WMI query: SELECT HotFixID FROM Win32_QuickFixEngineering.
         },
       'License'         => MSF_LICENSE,
       'Platform'        => ['win'],
@@ -39,22 +30,9 @@ class MetasploitModule < Msf::Post
           ['URL', 'http://msdn.microsoft.com/en-us/library/aa394391(v=vs.85).aspx']
         ]
     ))
-
-    register_options(
-      [
-        OptBool.new('MSFLOCALS', [ true, 'Search for missing patches for which there is a MSF local module', true]),
-        OptString.new('KB',  [ true, 'A comma separated list of KB patches to search for', 'KB2871997, KB2928120'])
-      ])
   end
 
-  # The sauce starts here
   def run
-    patches = datastore['KB'].split(',').map(&:strip)
-
-    if datastore['MSFLOCALS']
-      patches.concat MSF_MODULES.keys
-    end
-
     unless load_extapi
       print_error 'ExtAPI failed to load'
       return
@@ -75,22 +53,13 @@ class MetasploitModule < Msf::Post
 
     if kb_ids.empty?
       print_status 'Found no patches installed'
+      return
     end
 
-    report_info(patches, kb_ids)
-  end
-
-  def report_info(patches, kb_ids)
-    patches.each do |kb|
-      if kb_ids.include?(kb)
-        print_status("#{kb} applied")
-      else
-        if MSF_MODULES.include?(kb)
-          print_good(MSF_MODULES[kb])
-        else
-          print_good("#{kb} is missing")
-        end
-      end
+    l = store_loot('enum_patches', 'text/plain', session, kb_ids.join("\n"))
+    print_status("Patch list saved to #{l}")
+    kb_ids.each do |kb|
+      print_status("#{kb} applied")
     end
   end
 end


### PR DESCRIPTION
After discussion with @busterb , the `MSF_MODULES` portion in `enum_patches` was 6yrs old and unlikely to be updated since automating it would be VERY cumbersome.  People should use `local_exploit_suggestor` instead, and most likely are.

Changed how this module works entirely so it prints the patches listed by the system and stores the output to loot.

## Verification

List the steps needed to make sure this thing works

- [ ] get a shell
- [ ] `use post/windows/gather/enum_patches`
- [ ] `run`
- [ ] **Verify** make sure it lists all applied patches

