### PR TITLE
DisablePayloadHandler replace strings with bools

### DIFF
--- a/modules/exploits/linux/local/apt_package_manager_persistence.rb
+++ b/modules/exploits/linux/local/apt_package_manager_persistence.rb
@@ -34,7 +34,7 @@ class MetasploitModule < Msf::Exploit::Local
           ARCH_MIPSBE
         ],
       'SessionTypes'   => ['shell', 'meterpreter'],
-      'DefaultOptions' => { 'WfsDelay' => 0, 'DisablePayloadHandler' => 'true' },
+      'DefaultOptions' => { 'WfsDelay' => 0, 'DisablePayloadHandler' => true },
       'DisclosureDate' => '1999-03-09', # Date APT package manager was included in Debian
       'References'     => ['URL', 'https://unix.stackexchange.com/questions/204414/how-to-run-a-command-before-download-with-apt-get'],
       'Targets'        => [['Automatic', {}]],

--- a/modules/exploits/linux/local/autostart_persistence.rb
+++ b/modules/exploits/linux/local/autostart_persistence.rb
@@ -28,7 +28,7 @@ class MetasploitModule < Msf::Exploit::Local
         }
       },
       'SessionTypes'   => [ 'shell', 'meterpreter' ],
-      'DefaultOptions' => { 'WfsDelay' => 0, 'DisablePayloadHandler' => 'true' },
+      'DefaultOptions' => { 'WfsDelay' => 0, 'DisablePayloadHandler' => true },
       'DisclosureDate' => 'Feb 13 2006', # Date of the 0.5 doc for autostart
       'Targets'        => [ ['Automatic', {}] ],
       'DefaultTarget'  => 0

--- a/modules/exploits/linux/local/bash_profile_persistence.rb
+++ b/modules/exploits/linux/local/bash_profile_persistence.rb
@@ -29,7 +29,7 @@ class MetasploitModule < Msf::Exploit::Local
         'Platform'       => ['unix', 'linux'],
         'Arch'           => ARCH_CMD,
         'SessionTypes'   => ['meterpreter', 'shell'],
-        'DefaultOptions' => { 'WfsDelay' => 0, 'DisablePayloadHandler' => 'true' },
+        'DefaultOptions' => { 'WfsDelay' => 0, 'DisablePayloadHandler' => true },
         'Targets'        =>
           [
             ['Automatic', {}]

--- a/modules/exploits/linux/local/rc_local_persistence.rb
+++ b/modules/exploits/linux/local/rc_local_persistence.rb
@@ -28,7 +28,7 @@ class MetasploitModule < Msf::Exploit::Local
         }
       },
       'SessionTypes'   => [ 'shell', 'meterpreter' ],
-      'DefaultOptions' => { 'WfsDelay' => 0, 'DisablePayloadHandler' => 'true' },
+      'DefaultOptions' => { 'WfsDelay' => 0, 'DisablePayloadHandler' => true },
       'DisclosureDate' => 'Oct 01 1980', # The rc command appeared in 4.0BSD.
       'Targets'        => [ ['Automatic', {}] ],
       'DefaultTarget'  => 0

--- a/modules/exploits/linux/local/yum_package_manager_persistence.rb
+++ b/modules/exploits/linux/local/yum_package_manager_persistence.rb
@@ -36,7 +36,7 @@ class MetasploitModule < Msf::Exploit::Local
         ],
       'SessionTypes'   => ['shell', 'meterpreter'],
       'DefaultOptions' => {
-                            'WfsDelay' => 0, 'DisablePayloadHandler' => 'true',
+                            'WfsDelay' => 0, 'DisablePayloadHandler' => true,
                             'Payload'  => 'cmd/unix/reverse_python'
                           },
       'DisclosureDate' => '2003-12-17', # Date published, Robert G. Browns documentation on Yum

--- a/modules/exploits/multi/http/vbulletin_widgetconfig_rce.rb
+++ b/modules/exploits/multi/http/vbulletin_widgetconfig_rce.rb
@@ -39,7 +39,7 @@ class MetasploitModule < Msf::Exploit::Remote
           },
           'DefaultOptions' => {
             'PAYLOAD' => 'php/meterpreter/reverse_tcp',
-            'DisablePayloadHandler' => 'false'
+            'DisablePayloadHandler' => false
           }
         ],
         ['Unix (CMD In-Memory)',
@@ -48,7 +48,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'Type' => :unix_cmd,
           'DefaultOptions' => {
             'PAYLOAD' => 'cmd/unix/generic',
-            'DisablePayloadHandler' => 'true'
+            'DisablePayloadHandler' => true
           }
         ],
         ['Windows (CMD In-Memory)',
@@ -57,7 +57,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'Type' => :windows_cmd,
           'DefaultOptions' => {
             'PAYLOAD' => 'cmd/windows/generic',
-            'DisablePayloadHandler' => 'true'
+            'DisablePayloadHandler' => true
           }
         ]
       ],

--- a/modules/exploits/windows/fileformat/a_pdf_wav_to_mp3.rb
+++ b/modules/exploits/windows/fileformat/a_pdf_wav_to_mp3.rb
@@ -33,7 +33,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'seh',
-          'DisablePayloadHandler' => 'true',
+          'DisablePayloadHandler' => true
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/fileformat/acdsee_fotoslate_string.rb
+++ b/modules/exploits/windows/fileformat/acdsee_fotoslate_string.rb
@@ -34,7 +34,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'DisablePayloadHandler' => 'true'
+          'DisablePayloadHandler' => true
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/fileformat/acdsee_xpm.rb
+++ b/modules/exploits/windows/fileformat/acdsee_xpm.rb
@@ -29,7 +29,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'DisablePayloadHandler' => 'true',
+          'DisablePayloadHandler' => true,
           'AllowWin32SEH' => true
         },
       'Payload'        =>

--- a/modules/exploits/windows/fileformat/activepdf_webgrabber.rb
+++ b/modules/exploits/windows/fileformat/activepdf_webgrabber.rb
@@ -28,7 +28,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'DisablePayloadHandler' => 'true',
+          'DisablePayloadHandler' => true
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/fileformat/adobe_collectemailinfo.rb
+++ b/modules/exploits/windows/fileformat/adobe_collectemailinfo.rb
@@ -28,7 +28,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'DisablePayloadHandler' => 'true',
+          'DisablePayloadHandler' => true
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/fileformat/adobe_cooltype_sing.rb
+++ b/modules/exploits/windows/fileformat/adobe_cooltype_sing.rb
@@ -36,7 +36,7 @@ class MetasploitModule < Msf::Exploit::Remote
         {
           'EXITFUNC'             => 'process',
           'InitialAutoRunScript' => 'post/windows/manage/priv_migrate',
-          'DisablePayloadHandler' => 'true',
+          'DisablePayloadHandler' => true
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/fileformat/adobe_flashplayer_button.rb
+++ b/modules/exploits/windows/fileformat/adobe_flashplayer_button.rb
@@ -47,7 +47,7 @@ class MetasploitModule < Msf::Exploit::Remote
         {
           'EXITFUNC'             => 'process',
           'InitialAutoRunScript' => 'post/windows/manage/priv_migrate',
-          'DisablePayloadHandler' => 'true',
+          'DisablePayloadHandler' => true
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/fileformat/adobe_flashplayer_newfunction.rb
+++ b/modules/exploits/windows/fileformat/adobe_flashplayer_newfunction.rb
@@ -45,7 +45,7 @@ class MetasploitModule < Msf::Exploit::Remote
         {
           'EXITFUNC'             => 'process',
           'InitialAutoRunScript' => 'post/windows/manage/priv_migrate',
-          'DisablePayloadHandler' => 'true',
+          'DisablePayloadHandler' => true
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/fileformat/adobe_flatedecode_predictor02.rb
+++ b/modules/exploits/windows/fileformat/adobe_flatedecode_predictor02.rb
@@ -35,7 +35,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'DisablePayloadHandler' => 'true',
+          'DisablePayloadHandler' => true
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/fileformat/adobe_geticon.rb
+++ b/modules/exploits/windows/fileformat/adobe_geticon.rb
@@ -37,7 +37,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'DisablePayloadHandler' => 'true',
+          'DisablePayloadHandler' => true
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/fileformat/adobe_illustrator_v14_eps.rb
+++ b/modules/exploits/windows/fileformat/adobe_illustrator_v14_eps.rb
@@ -30,7 +30,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'seh',
-          'DisablePayloadHandler' => 'true',
+          'DisablePayloadHandler' => true,
           'AllowWin32SEH' => true
         },
       'Payload'        =>

--- a/modules/exploits/windows/fileformat/adobe_jbig2decode.rb
+++ b/modules/exploits/windows/fileformat/adobe_jbig2decode.rb
@@ -35,7 +35,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'DisablePayloadHandler' => 'true',
+          'DisablePayloadHandler' => true
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/fileformat/adobe_libtiff.rb
+++ b/modules/exploits/windows/fileformat/adobe_libtiff.rb
@@ -38,7 +38,7 @@ class MetasploitModule < Msf::Exploit::Remote
         {
           'EXITFUNC' => 'process',
           'InitialAutoRunScript' => 'post/windows/manage/priv_migrate',
-          'DisablePayloadHandler' => 'true',
+          'DisablePayloadHandler' => true
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/fileformat/adobe_media_newplayer.rb
+++ b/modules/exploits/windows/fileformat/adobe_media_newplayer.rb
@@ -35,7 +35,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'DisablePayloadHandler' => 'true',
+          'DisablePayloadHandler' => true
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/fileformat/adobe_reader_u3d.rb
+++ b/modules/exploits/windows/fileformat/adobe_reader_u3d.rb
@@ -43,7 +43,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'DisablePayloadHandler' => 'true',
+          'DisablePayloadHandler' => true
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/fileformat/adobe_u3d_meshdecl.rb
+++ b/modules/exploits/windows/fileformat/adobe_u3d_meshdecl.rb
@@ -34,7 +34,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'DisablePayloadHandler' => 'true',
+          'DisablePayloadHandler' => true
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/fileformat/adobe_utilprintf.rb
+++ b/modules/exploits/windows/fileformat/adobe_utilprintf.rb
@@ -28,7 +28,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'DisablePayloadHandler' => 'true',
+          'DisablePayloadHandler' => true
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/fileformat/altap_salamander_pdb.rb
+++ b/modules/exploits/windows/fileformat/altap_salamander_pdb.rb
@@ -31,7 +31,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'DisablePayloadHandler' => 'true',
+          'DisablePayloadHandler' => true
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/fileformat/aol_phobos_bof.rb
+++ b/modules/exploits/windows/fileformat/aol_phobos_bof.rb
@@ -56,7 +56,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'DisablePayloadHandler' => 'true',
+          'DisablePayloadHandler' => true
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/fileformat/apple_quicktime_pnsize.rb
+++ b/modules/exploits/windows/fileformat/apple_quicktime_pnsize.rb
@@ -32,7 +32,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'DisablePayloadHandler' => 'true',
+          'DisablePayloadHandler' => true
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/fileformat/audio_wkstn_pls.rb
+++ b/modules/exploits/windows/fileformat/audio_wkstn_pls.rb
@@ -29,7 +29,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'seh',
-          'DisablePayloadHandler' => 'true',
+          'DisablePayloadHandler' => true,
           'AllowWin32SEH' => true
         },
       'Payload'        =>

--- a/modules/exploits/windows/fileformat/ca_cab.rb
+++ b/modules/exploits/windows/fileformat/ca_cab.rb
@@ -28,7 +28,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'thread',
-          'DisablePayloadHandler' => 'true',
+          'DisablePayloadHandler' => true,
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/fileformat/ccmplayer_m3u_bof.rb
+++ b/modules/exploits/windows/fileformat/ccmplayer_m3u_bof.rb
@@ -30,7 +30,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'DisablePayloadHandler' => 'true',
+          'DisablePayloadHandler' => true
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/fileformat/cyberlink_lpp_bof.rb
+++ b/modules/exploits/windows/fileformat/cyberlink_lpp_bof.rb
@@ -32,7 +32,7 @@ class MetasploitModule < Msf::Exploit
         {
           'FILENAME' => 'msf.lpp',
           'EXITFUNC' => 'seh',
-          'DisablePayloadHandler' => 'true',
+          'DisablePayloadHandler' => true,
           'PAYLOAD' => 'windows/meterpreter/reverse_tcp'
         },
       'Platform'        => 'win',

--- a/modules/exploits/windows/fileformat/cytel_studio_cy3.rb
+++ b/modules/exploits/windows/fileformat/cytel_studio_cy3.rb
@@ -32,7 +32,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'DisablePayloadHandler' => 'true',
+          'DisablePayloadHandler' => true
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/fileformat/djvu_imageurl.rb
+++ b/modules/exploits/windows/fileformat/djvu_imageurl.rb
@@ -28,7 +28,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'DisablePayloadHandler' => 'true',
+          'DisablePayloadHandler' => true
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/fileformat/dupscout_xml.rb
+++ b/modules/exploits/windows/fileformat/dupscout_xml.rb
@@ -28,7 +28,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions'  =>
         {
           'EXITFUNC' => 'seh',
-          'DisablePayloadHandler' => 'true'
+          'DisablePayloadHandler' => true
         },
       'Platform'        => 'win',
       'Payload'         =>

--- a/modules/exploits/windows/fileformat/emc_appextender_keyworks.rb
+++ b/modules/exploits/windows/fileformat/emc_appextender_keyworks.rb
@@ -27,7 +27,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'DisablePayloadHandler' => 'true',
+          'DisablePayloadHandler' => true
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/fileformat/fatplayer_wav.rb
+++ b/modules/exploits/windows/fileformat/fatplayer_wav.rb
@@ -32,7 +32,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'seh',
-          'DisablePayloadHandler' => 'true',
+          'DisablePayloadHandler' => true
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/fileformat/fdm_torrent.rb
+++ b/modules/exploits/windows/fileformat/fdm_torrent.rb
@@ -36,7 +36,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'seh',
-          'DisablePayloadHandler' => 'true',
+          'DisablePayloadHandler' => true
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/fileformat/feeddemon_opml.rb
+++ b/modules/exploits/windows/fileformat/feeddemon_opml.rb
@@ -39,7 +39,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'DisablePayloadHandler' => 'true',
+          'DisablePayloadHandler' => true
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/fileformat/foxit_reader_filewrite.rb
+++ b/modules/exploits/windows/fileformat/foxit_reader_filewrite.rb
@@ -36,7 +36,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'DisablePayloadHandler' => true,
+          'DisablePayloadHandler' => true
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/fileformat/foxit_reader_launch.rb
+++ b/modules/exploits/windows/fileformat/foxit_reader_launch.rb
@@ -35,7 +35,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'DisablePayloadHandler' => true,
+          'DisablePayloadHandler' => true
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/fileformat/free_mp3_ripper_wav.rb
+++ b/modules/exploits/windows/fileformat/free_mp3_ripper_wav.rb
@@ -35,7 +35,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'DisablePayloadHandler' => true,
+          'DisablePayloadHandler' => true
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/fileformat/galan_fileformat_bof.rb
+++ b/modules/exploits/windows/fileformat/galan_fileformat_bof.rb
@@ -30,7 +30,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'DisablePayloadHandler' => true,
+          'DisablePayloadHandler' => true
         },
       'Payload' =>
         {

--- a/modules/exploits/windows/fileformat/hhw_hhp_compiledfile_bof.rb
+++ b/modules/exploits/windows/fileformat/hhw_hhp_compiledfile_bof.rb
@@ -29,7 +29,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'DisablePayloadHandler' => true,
+          'DisablePayloadHandler' => true
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/fileformat/hhw_hhp_contentfile_bof.rb
+++ b/modules/exploits/windows/fileformat/hhw_hhp_contentfile_bof.rb
@@ -28,7 +28,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'DisablePayloadHandler' => true,
+          'DisablePayloadHandler' => true
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/fileformat/hhw_hhp_indexfile_bof.rb
+++ b/modules/exploits/windows/fileformat/hhw_hhp_indexfile_bof.rb
@@ -29,7 +29,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'DisablePayloadHandler' => true,
+          'DisablePayloadHandler' => true
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/fileformat/ideal_migration_ipj.rb
+++ b/modules/exploits/windows/fileformat/ideal_migration_ipj.rb
@@ -34,7 +34,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'seh',
-          'DisablePayloadHandler' => true,
+          'DisablePayloadHandler' => true
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/fileformat/mcafee_hercules_deletesnapshot.rb
+++ b/modules/exploits/windows/fileformat/mcafee_hercules_deletesnapshot.rb
@@ -27,7 +27,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'DisablePayloadHandler' => true,
+          'DisablePayloadHandler' => true
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/fileformat/mcafee_showreport_exec.rb
+++ b/modules/exploits/windows/fileformat/mcafee_showreport_exec.rb
@@ -44,7 +44,7 @@ class MetasploitModule < Msf::Exploit::Remote
         {
           'EXITFUNC' => "none",
           #'InitialAutoRunScript' => 'migrate -f',
-          'DisablePayloadHandler' => false,
+          'DisablePayloadHandler' => false
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/fileformat/mediajukebox.rb
+++ b/modules/exploits/windows/fileformat/mediajukebox.rb
@@ -30,7 +30,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'seh',
-          'DisablePayloadHandler' => true,
+          'DisablePayloadHandler' => true
         },
       'Payload' =>
         {

--- a/modules/exploits/windows/fileformat/microp_mppl.rb
+++ b/modules/exploits/windows/fileformat/microp_mppl.rb
@@ -28,7 +28,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'DisablePayloadHandler' => true,
+          'DisablePayloadHandler' => true
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/fileformat/millenium_mp3_pls.rb
+++ b/modules/exploits/windows/fileformat/millenium_mp3_pls.rb
@@ -30,7 +30,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'DisablePayloadHandler' => 'true',
+          'DisablePayloadHandler' => true
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/fileformat/mini_stream_pls_bof.rb
+++ b/modules/exploits/windows/fileformat/mini_stream_pls_bof.rb
@@ -33,7 +33,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'DisablePayloadHandler' => 'true',
+          'DisablePayloadHandler' => true
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/fileformat/moxa_mediadbplayback.rb
+++ b/modules/exploits/windows/fileformat/moxa_mediadbplayback.rb
@@ -27,7 +27,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'DisablePayloadHandler' => 'true',
+          'DisablePayloadHandler' => true
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/fileformat/mplayer_sami_bof.rb
+++ b/modules/exploits/windows/fileformat/mplayer_sami_bof.rb
@@ -34,7 +34,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'DisablePayloadHandler' => 'true',
+          'DisablePayloadHandler' => true
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/fileformat/ms09_067_excel_featheader.rb
+++ b/modules/exploits/windows/fileformat/ms09_067_excel_featheader.rb
@@ -45,7 +45,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'DisablePayloadHandler' => 'true',
+          'DisablePayloadHandler' => true
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/fileformat/ms10_004_textbytesatom.rb
+++ b/modules/exploits/windows/fileformat/ms10_004_textbytesatom.rb
@@ -40,7 +40,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'DisablePayloadHandler' => 'true',
+          'DisablePayloadHandler' => true
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/fileformat/ms10_038_excel_obj_bof.rb
+++ b/modules/exploits/windows/fileformat/ms10_038_excel_obj_bof.rb
@@ -39,7 +39,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions'  =>
         {
           'EXITFUNC'          => 'process',
-          'DisablePayloadHandler' => 'true'
+          'DisablePayloadHandler' => true
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/fileformat/ms11_021_xlb_bof.rb
+++ b/modules/exploits/windows/fileformat/ms11_021_xlb_bof.rb
@@ -40,7 +40,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions'  =>
         {
           'EXITFUNC'          => "process",
-          'DisablePayloadHandler' => 'true',
+          'DisablePayloadHandler' => true,
           'InitialAutoRunScript'  => 'post/windows/manage/priv_migrate'
         },
       'Platform'       => 'win',

--- a/modules/exploits/windows/fileformat/ms_visual_basic_vbp.rb
+++ b/modules/exploits/windows/fileformat/ms_visual_basic_vbp.rb
@@ -28,7 +28,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'DisablePayloadHandler' => 'true',
+          'DisablePayloadHandler' => true
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/fileformat/msworks_wkspictureinterface.rb
+++ b/modules/exploits/windows/fileformat/msworks_wkspictureinterface.rb
@@ -28,7 +28,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'DisablePayloadHandler' => 'true',
+          'DisablePayloadHandler' => true
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/fileformat/mymp3player_m3u.rb
+++ b/modules/exploits/windows/fileformat/mymp3player_m3u.rb
@@ -30,7 +30,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'DisablePayloadHandler' => 'true',
+          'DisablePayloadHandler' => true
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/fileformat/netop.rb
+++ b/modules/exploits/windows/fileformat/netop.rb
@@ -29,7 +29,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'DisablePayloadHandler' => 'true'
+          'DisablePayloadHandler' => true
         },
       'Platform'       => 'win',
       'Payload'        =>

--- a/modules/exploits/windows/fileformat/openoffice_ole.rb
+++ b/modules/exploits/windows/fileformat/openoffice_ole.rb
@@ -40,7 +40,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions'  =>
         {
           'EXITFUNC'          => 'process',
-          'DisablePayloadHandler' => 'true'
+          'DisablePayloadHandler' => true
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/fileformat/proshow_cellimage_bof.rb
+++ b/modules/exploits/windows/fileformat/proshow_cellimage_bof.rb
@@ -28,7 +28,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'DisablePayloadHandler' => 'true',
+          'DisablePayloadHandler' => true
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/fileformat/safenet_softremote_groupname.rb
+++ b/modules/exploits/windows/fileformat/safenet_softremote_groupname.rb
@@ -29,7 +29,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'DisablePayloadHandler' => 'true',
+          'DisablePayloadHandler' => true,
           'AllowWin32SEH' => true
         },
       'Payload'        =>

--- a/modules/exploits/windows/fileformat/sascam_get.rb
+++ b/modules/exploits/windows/fileformat/sascam_get.rb
@@ -29,7 +29,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'DisablePayloadHandler' => 'true',
+          'DisablePayloadHandler' => true
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/fileformat/shadow_stream_recorder_bof.rb
+++ b/modules/exploits/windows/fileformat/shadow_stream_recorder_bof.rb
@@ -33,7 +33,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions'  =>
         {
           'EXITFUNC' => 'process',
-          'DisablePayloadHandler' => 'true'
+          'DisablePayloadHandler' => true
         },
       'Platform'        => 'win',
       'Payload'         =>

--- a/modules/exploits/windows/fileformat/somplplayer_m3u.rb
+++ b/modules/exploits/windows/fileformat/somplplayer_m3u.rb
@@ -30,7 +30,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'DisablePayloadHandler' => 'true',
+          'DisablePayloadHandler' => true
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/fileformat/syncbreeze_xml.rb
+++ b/modules/exploits/windows/fileformat/syncbreeze_xml.rb
@@ -29,7 +29,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions'  =>
         {
           'EXITFUNC' => 'seh',
-          'DisablePayloadHandler' => 'true'
+          'DisablePayloadHandler' => true
         },
       'Platform'        => 'win',
       'Payload'         =>

--- a/modules/exploits/windows/fileformat/ursoft_w32dasm.rb
+++ b/modules/exploits/windows/fileformat/ursoft_w32dasm.rb
@@ -30,7 +30,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'DisablePayloadHandler' => 'true',
+          'DisablePayloadHandler' => true
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/fileformat/varicad_dwb.rb
+++ b/modules/exploits/windows/fileformat/varicad_dwb.rb
@@ -39,7 +39,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'DisablePayloadHandler' => 'true',
+          'DisablePayloadHandler' => true
         },
       'Platform'       => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/fileformat/visio_dxf_bof.rb
+++ b/modules/exploits/windows/fileformat/visio_dxf_bof.rb
@@ -38,7 +38,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'DisablePayloadHandler' => 'true',
+          'DisablePayloadHandler' => true
         },
       'Payload' =>
         {

--- a/modules/exploits/windows/fileformat/vuplayer_cue.rb
+++ b/modules/exploits/windows/fileformat/vuplayer_cue.rb
@@ -26,7 +26,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'DisablePayloadHandler' => 'true',
+          'DisablePayloadHandler' => true,
           'AllowWin32SEH' => true
         },
       'Payload'        =>

--- a/modules/exploits/windows/fileformat/vuplayer_m3u.rb
+++ b/modules/exploits/windows/fileformat/vuplayer_m3u.rb
@@ -26,7 +26,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'process',
-          'DisablePayloadHandler' => 'true',
+          'DisablePayloadHandler' => true,
           'AllowWin32SEH' => true
         },
       'Payload'        =>

--- a/modules/exploits/windows/fileformat/wm_downloader_m3u.rb
+++ b/modules/exploits/windows/fileformat/wm_downloader_m3u.rb
@@ -30,7 +30,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'seh',
-          'DisablePayloadHandler' => 'true',
+          'DisablePayloadHandler' => true
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/fileformat/xenorate_xpl_bof.rb
+++ b/modules/exploits/windows/fileformat/xenorate_xpl_bof.rb
@@ -32,7 +32,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'seh',
-          'DisablePayloadHandler' => 'true',
+          'DisablePayloadHandler' => true
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/fileformat/xradio_xrl_sehbof.rb
+++ b/modules/exploits/windows/fileformat/xradio_xrl_sehbof.rb
@@ -32,7 +32,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions'  =>
         {
           'EXITFUNC' => 'seh',
-          'DisablePayloadHandler' => 'true'
+          'DisablePayloadHandler' => true
         },
       'Platform'        => 'win',
       'Payload'         =>

--- a/modules/exploits/windows/ftp/scriptftp_list.rb
+++ b/modules/exploits/windows/ftp/scriptftp_list.rb
@@ -40,7 +40,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'thread',
-          'DisablePayloadHandler' => false,
+          'DisablePayloadHandler' => false
         },
       'Payload'        =>
         {

--- a/modules/exploits/windows/local/mov_ss.rb
+++ b/modules/exploits/windows/local/mov_ss.rb
@@ -56,7 +56,7 @@ class MetasploitModule < Msf::Exploit::Local
         ],
       'DefaultOptions' =>
         {
-          'DisablePayloadHandler' => 'False'
+          'DisablePayloadHandler' => false
         }
     ))
 

--- a/modules/exploits/windows/local/ms16_016_webdav.rb
+++ b/modules/exploits/windows/local/ms16_016_webdav.rb
@@ -34,7 +34,7 @@ class MetasploitModule < Msf::Exploit::Local
       'DefaultOptions' =>
         {
           'EXITFUNC' => 'thread',
-          'DisablePayloadHandler' => 'false'
+          'DisablePayloadHandler' => false
         },
       'Targets'        =>
         [

--- a/modules/exploits/windows/local/persistence.rb
+++ b/modules/exploits/windows/local/persistence.rb
@@ -39,7 +39,7 @@ class MetasploitModule < Msf::Exploit::Local
       'DisclosureDate' => "Oct 19 2011",
       'DefaultOptions' =>
         {
-          'DisablePayloadHandler' => 'true'
+          'DisablePayloadHandler' => true
         }
     ))
 

--- a/modules/exploits/windows/local/persistence_image_exec_options.rb
+++ b/modules/exploits/windows/local/persistence_image_exec_options.rb
@@ -43,7 +43,7 @@ class MetasploitModule < Msf::Exploit::Local
         ],
       'DefaultOptions' =>
         {
-          'DisablePayloadHandler' => 'true'
+          'DisablePayloadHandler' => true
         }
     ))
     register_options([

--- a/modules/exploits/windows/local/registry_persistence.rb
+++ b/modules/exploits/windows/local/registry_persistence.rb
@@ -37,7 +37,7 @@ class MetasploitModule < Msf::Exploit::Local
       'DisclosureDate' => "Jul 1 2015",
       'DefaultOptions' =>
         {
-          'DisablePayloadHandler' => 'true'
+          'DisablePayloadHandler' => true
         }
     ))
 

--- a/modules/exploits/windows/local/wmi_persistence.rb
+++ b/modules/exploits/windows/local/wmi_persistence.rb
@@ -43,7 +43,7 @@ class MetasploitModule < Msf::Exploit::Local
       'DefaultTarget'    => 0,
       'DefaultOptions' =>
         {
-          'DisablePayloadHandler' => 'true'
+          'DisablePayloadHandler' => true
         },
       'References' => [
         ['URL', 'https://www.blackhat.com/docs/us-15/materials/us-15-Graeber-Abusing-Windows-Management-Instrumentation-WMI-To-Build-A-Persistent%20Asynchronous-And-Fileless-Backdoor-wp.pdf'],

--- a/modules/exploits/windows/mysql/mysql_start_up.rb
+++ b/modules/exploits/windows/mysql/mysql_start_up.rb
@@ -27,7 +27,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'DefaultOptions' =>
         {
-          'DisablePayloadHandler' =>  'true'
+          'DisablePayloadHandler' => true
         },
       'License'        => MSF_LICENSE,
       'References'     =>

--- a/modules/exploits/windows/scada/codesys_web_server.rb
+++ b/modules/exploits/windows/scada/codesys_web_server.rb
@@ -39,7 +39,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions'  =>
         {
           'EXITFUNC' => 'process',
-          'DisablePayloadHandler' => false,
+          'DisablePayloadHandler' => false
         },
       'Platform'        => 'win',
       'Payload'         =>


### PR DESCRIPTION
Fixes #12741 

This replaces inconsistent DisablePayloadHandler options that were strings with Boolean values. I also removed trailing commas that were unnecessary for the same DisablePayloadHandler options I was reviewing. 

## Verification
Due to the nature of these changes I did not run every module manually to verify they worked. 
 - All checks passed with msftidy
 - Ran rake spec with no issues



