### PR TITLE
limit compatible gems

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,11 +23,11 @@ PATH
       jsobfu
       json
       metasm
-      metasploit-concern
-      metasploit-credential
-      metasploit-model
+      metasploit-concern (~> 2.0.0)
+      metasploit-credential (~> 3.0.0)
+      metasploit-model (~> 2.0.4)
       metasploit-payloads (= 1.3.83)
-      metasploit_data_models (= 3.0.10)
+      metasploit_data_models (~> 3.0.10)
       metasploit_payloads-mettle (= 0.5.16)
       mqtt
       msgpack

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -61,14 +61,14 @@ Gem::Specification.new do |spec|
   # Metasm compiler/decompiler/assembler
   spec.add_runtime_dependency 'metasm'
   # Metasploit::Concern hooks
-  spec.add_runtime_dependency 'metasploit-concern'
+  spec.add_runtime_dependency 'metasploit-concern', '~> 2.0.0'
   # Metasploit::Credential database models
-  spec.add_runtime_dependency 'metasploit-credential'
+  spec.add_runtime_dependency 'metasploit-credential', '~> 3.0.0'
   # Database models shared between framework and Pro.
-  spec.add_runtime_dependency 'metasploit_data_models', '3.0.10'
+  spec.add_runtime_dependency 'metasploit_data_models', '~> 3.0.10'
   # Things that would normally be part of the database model, but which
   # are needed when there's no database
-  spec.add_runtime_dependency 'metasploit-model'
+  spec.add_runtime_dependency 'metasploit-model', '~> 2.0.4'
   # Needed for Meterpreter
   spec.add_runtime_dependency 'metasploit-payloads', '1.3.83'
   # Needed for the next-generation POSIX Meterpreter


### PR DESCRIPTION
Limit compatible gems in preparation for Rails 5 or greater

This change allows for possible release of gem dependencies using semantic versioning to support testing upgrade to Rails 5.2 or greater now that Rails 4.2 is officially unsupported for security updates.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] **Verify** basic functions
