### PR TITLE
handle Ranges with rand_text while in debug mode

### DIFF
--- a/lib/msf/core/exploit.rb
+++ b/lib/msf/core/exploit.rb
@@ -1207,13 +1207,17 @@ class Exploit < Msf::Module
   #
   ##
 
+  def rand_text_debug(length, char = 'A')
+    char * (length.kind_of?(Range) ? length.first : length)
+  end
+
   #
   # Generate random text characters avoiding the exploit's bad
   # characters.
   #
   def rand_text(length, bad=payload_badchars)
     if debugging?
-      "A" * length
+      rand_text_debug(length)
     else
       Rex::Text.rand_text(length, bad)
     end
@@ -1225,7 +1229,7 @@ class Exploit < Msf::Module
   #
   def rand_text_english(length, bad=payload_badchars)
     if debugging?
-      "A" * length
+      rand_text_debug(length)
     else
       Rex::Text.rand_text_english(length, bad)
     end
@@ -1237,7 +1241,7 @@ class Exploit < Msf::Module
   #
   def rand_text_highascii(length, bad=payload_badchars)
     if debugging?
-      "A" * length
+      rand_text_debug(length)
     else
       Rex::Text.rand_text_highascii(length, bad)
     end
@@ -1249,7 +1253,7 @@ class Exploit < Msf::Module
   #
   def rand_text_alpha(length, bad=payload_badchars)
     if debugging?
-      "A" * length
+      rand_text_debug(length)
     else
       Rex::Text.rand_text_alpha(length, bad)
     end
@@ -1261,7 +1265,7 @@ class Exploit < Msf::Module
   #
   def rand_text_alpha_upper(length, bad=payload_badchars)
     if debugging?
-      "A" * length
+      rand_text_debug(length)
     else
       Rex::Text.rand_text_alpha_upper(length, bad)
     end
@@ -1273,7 +1277,7 @@ class Exploit < Msf::Module
   #
   def rand_text_alpha_lower(length, bad=payload_badchars)
     if debugging?
-      "a" * length
+      rand_text_debug(length, 'a')
     else
       Rex::Text.rand_text_alpha_lower(length, bad)
     end
@@ -1285,7 +1289,7 @@ class Exploit < Msf::Module
   #
   def rand_text_alphanumeric(length, bad=payload_badchars)
     if debugging?
-      "A" * length
+      rand_text_debug(length)
     else
       Rex::Text.rand_text_alphanumeric(length, bad)
     end
@@ -1297,7 +1301,7 @@ class Exploit < Msf::Module
   #
   def rand_text_numeric(length, bad=payload_badchars)
     if debugging?
-      "0" * length
+      rand_text_debug(length, '0')
     else
       Rex::Text.rand_text_numeric(length, bad)
     end


### PR DESCRIPTION
Noticed while testing #12751 if debug is turned on, rand_text* in the exploit class didn't handle ranges. This adds support.

## Verification

- [ ] Start `msfconsole`
- [ ] `set DEBUG true`
- [ ] Use a module that has a rand_text* range
- [ ] **Verify** the module works as expected

```
exploit(linux/local/rds_atomic_free_op_null_pointer_deref_priv_esc) > run

[!] SESSION may not be compatible with this module.
[*] Started reverse TCP handler on 172.28.128.1:4444 
[+] System architecture x86_64 is supported
[+] Linux kernel 4.4.0-21-generic #37-Ubuntu is vulnerable
[+] SMAP is not enabled
[+] LKRG is not installed
[+] grsecurity is not in use
[+] rds.ko kernel module is loaded
[*] Dropping pre-compiled exploit on system...
[*] Writing '/tmp/.aaaaa' (860128 bytes) ...
[*] Max line length is 65537
[*] Writing 860128 bytes in 53 chunks of 55176 bytes (octal-encoded), using printf
```