### PR TITLE
Update set command help for PAYLOAD by index

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1511,7 +1511,7 @@ class Core
     print_line "If both are omitted, print options that are currently set."
     print_line
     print_line "If run from a module context, this will set the value in the module's"
-    print_line "datastore.  Use -g to operate on the global datastore"
+    print_line "datastore.  Use -g to operate on the global datastore."
     print_line
     print_line "If setting a PAYLOAD, this command can take an index from `show payloads'."
     print_line

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1513,6 +1513,8 @@ class Core
     print_line "If run from a module context, this will set the value in the module's"
     print_line "datastore.  Use -g to operate on the global datastore"
     print_line
+    print_line "If setting a PAYLOAD, this command can take an index from `show payloads'."
+    print_line
   end
 
   #


### PR DESCRIPTION
@jmartin-r7: Can you confirm that this is `msf5` because #12126 was, even though this PR doesn't touch any evasion code?

```
msf5 > help set
Usage: set [option] [value]

Set the given option to value.  If value is omitted, print the current value.
If both are omitted, print options that are currently set.

If run from a module context, this will set the value in the module's
datastore.  Use -g to operate on the global datastore

If setting a PAYLOAD, this command can take an index from `show payloads'.

msf5 >
```

Fixes #12126.