### PR TITLE
Reference URL is broken

### DIFF
--- a/modules/post/windows/gather/netlm_downgrade.rb
+++ b/modules/post/windows/gather/netlm_downgrade.rb
@@ -25,7 +25,7 @@ class MetasploitModule < Msf::Post
       'SessionTypes'   => [ 'meterpreter' ],
       'References'     =>
         [
-          [ 'URL', 'http://www.fishnetsecurity.com/6labs/blog/post-exploitation-using-netntlm-downgrade-attacks']
+          [ 'URL', 'https://www.optiv.com/blog/post-exploitation-using-netntlm-downgrade-attacks']
         ]
     ))
 


### PR DESCRIPTION
The URL http://www.fishnetsecurity.com/6labs/blog/post-exploitation-using-netntlm-downgrade-attacks redirects to the www.optiv.com homepage.

The correct current URL is https://www.optiv.com/blog/post-exploitation-using-netntlm-downgrade-attacks


Tell us what this change does. If you're fixing a bug, please mention
the github issue number.

Please ensure you are submitting **from a unique branch** in your [repository](https://github.com/rapid7/metasploit-framework/pull/11086#issuecomment-445506416) to master in Rapid7's.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/windows/smb/ms08_067_netapi`
- [ ] ...
- [ ] **Verify** the thing does what it should
- [ ] **Verify** the thing does not do what it should not
- [ ] **Document** the thing and how it works ([Example](https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/post/multi/gather/aws_keys.md))

