### PR TITLE
add default username to my/mssql login

### DIFF
--- a/modules/auxiliary/scanner/mssql/mssql_login.rb
+++ b/modules/auxiliary/scanner/mssql/mssql_login.rb
@@ -22,13 +22,14 @@ class MetasploitModule < Msf::Auxiliary
         [
           [ 'CVE', '1999-0506'] # Weak password
         ],
-      'License'        => MSF_LICENSE
+      'License'        => MSF_LICENSE,
+      # some overrides from authbrute since there is a default username and a blank password
+      'DefaultOptions' =>
+        {
+          'USERNAME' => 'sa',
+          'BLANK_PASSWORDS' => true
+        }
     )
-
-    register_options(
-      [
-        OptString.new('USERNAME', [false, 'A specific username to authenticate as', 'sa']),
-      ])
 
     deregister_options('PASSWORD_SPRAY')
   end

--- a/modules/auxiliary/scanner/mssql/mssql_login.rb
+++ b/modules/auxiliary/scanner/mssql/mssql_login.rb
@@ -25,6 +25,11 @@ class MetasploitModule < Msf::Auxiliary
       'License'        => MSF_LICENSE
     )
 
+    register_options(
+      [
+        OptString.new('USERNAME', [false, 'A specific username to authenticate as', 'sa']),
+      ])
+
     deregister_options('PASSWORD_SPRAY')
   end
 

--- a/modules/auxiliary/scanner/mysql/mysql_login.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_login.rb
@@ -22,12 +22,17 @@ class MetasploitModule < Msf::Auxiliary
       'References'      =>
         [
           [ 'CVE', '1999-0502'] # Weak password
-        ]
+        ],
+      # some overrides from authbrute since there is a default username and a blank password
+      'DefaultOptions' =>
+        {
+          'USERNAME' => 'root',
+          'BLANK_PASSWORDS' => true
+        }
     ))
 
     register_options(
       [
-        OptString.new('USERNAME', [false, 'A specific username to authenticate as', 'root']),
         Opt::Proxies
       ])
 

--- a/modules/auxiliary/scanner/mysql/mysql_login.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_login.rb
@@ -27,6 +27,7 @@ class MetasploitModule < Msf::Auxiliary
 
     register_options(
       [
+        OptString.new('USERNAME', [false, 'A specific username to authenticate as', 'root']),
         Opt::Proxies
       ])
 


### PR DESCRIPTION
Fixes #12891 
Adds default username field (as per module info) to mysql and mssql login fields.

## Verification

- [ ] Start `msfconsole`
- [ ] `use auxiliary/scanner/mssql/mssql_login`
- [ ] **Verify** username is 'sa' by defeault
- [ ] `use auxiliary/scanner/mysql/mysql_login`
- [ ] **Verify** username is 'root' by defeault

@digininja can you test this out?