### PR TITLE
show search help when args and module_search_results are empty

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -391,9 +391,9 @@ module Msf
               if @module_search_results.empty?
                 cmd_search_help
                 return false
-              else
-                cached = true
               end
+
+              cached = true
             end
 
             # Display the table of matches

--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -387,7 +387,14 @@ module Msf
               end
             end
 
-            cached = true if args.empty?
+            if args.empty?
+              if @module_search_results.empty?
+                cmd_search_help
+                return false
+              else
+                cached = true
+              end
+            end
 
             # Display the table of matches
             tbl = generate_module_table('Matching Modules', search_term)


### PR DESCRIPTION
This avoids case where method assumes that module_search_results is not empty and outputs

```
msf5 > search
[*] Displaying cached results
[-] No results from search
msf5 >
```

## Verification

check if `search` displays help when there are no cached search results and no arguments are provided

#12023