### PR TITLE
Updating GPG keys needed for install binaries. Fixes #12913.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -28,7 +28,7 @@ Vagrant.configure(2) do |config|
     config.vm.provision "shell", inline: step
   end
 
-  [ "gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3",
+  [ "gpg2 --keyserver hkp://pool.sks-keyservers.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB",
     "curl -L https://get.rvm.io | bash -s stable",
     "source ~/.rvm/scripts/rvm && cd /vagrant && rvm install `cat .ruby-version`",
     "source ~/.rvm/scripts/rvm && cd /vagrant && bundle",

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -28,7 +28,7 @@ Vagrant.configure(2) do |config|
     config.vm.provision "shell", inline: step
   end
 
-  [ "gpg2 --keyserver hkp://pool.sks-keyservers.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB",
+  [ "gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB",
     "curl -L https://get.rvm.io | bash -s stable",
     "source ~/.rvm/scripts/rvm && cd /vagrant && rvm install `cat .ruby-version`",
     "source ~/.rvm/scripts/rvm && cd /vagrant && bundle",


### PR DESCRIPTION
Updated Vagrantfile shell provisioning commands to install updated GPG keys required for binaries install.

## Verification

- [x] Install Vagrant
- [x] Run `vagrant up`
- [x] **Verify** that the Vagrant provisioning completes without any error

