### PR TITLE
Colorize HttpTrace output, add an option to show headers only, and refactor send_request_cgi

### DIFF
--- a/lib/msf/core/exploit/http/client.rb
+++ b/lib/msf/core/exploit/http/client.rb
@@ -336,11 +336,18 @@ module Exploit::Remote::HttpClient
         print_line('#' * 20)
         print_line('# Response:')
         print_line('#' * 20)
-        res ? print_line(res.to_terminal_output) :
-              print_line('No response received')
+
+        if res
+          print_line(res.to_terminal_output)
+        else
+          print_line('No response received')
+        end
       when 'color'
-        res ? print_line("%clr%bld%blu#{res.to_terminal_output}%clr") :
-              print_line('No response received')
+        if res
+          print_line("%clr%bld%blu#{res.to_terminal_output}%clr")
+        else
+          print_line('No response received')
+        end
       end
 
       disconnect(c) if disconnect
@@ -393,11 +400,18 @@ module Exploit::Remote::HttpClient
         print_line('#' * 20)
         print_line('# Response:')
         print_line('#' * 20)
-        res ? print_line(res.to_terminal_output) :
-              print_line('No response received')
+
+        if res
+          print_line(res.to_terminal_output)
+        else
+          print_line('No response received')
+        end
       when 'color'
-        res ? print_line("%clr%bld%blu#{res.to_terminal_output}%clr") :
-              print_line('No response received')
+        if res
+          print_line("%clr%bld%blu#{res.to_terminal_output}%clr")
+        else
+          print_line('No response received')
+        end
       end
 
       disconnect(c) if disconnect

--- a/lib/msf/core/exploit/http/client.rb
+++ b/lib/msf/core/exploit/http/client.rb
@@ -44,7 +44,9 @@ module Exploit::Remote::HttpClient
         OptString.new('DOMAIN', [ true, 'The domain to use for windows authentification', 'WORKSTATION']),
         OptFloat.new('HttpClientTimeout', [false, 'HTTP connection and receive timeout']),
         OptBool.new('HttpPartialResponses', [false, 'Return partial HTTP responses despite timeouts', false]),
-        OptEnum.new('HttpTrace', [false, 'Show the raw HTTP requests and responses', 'false', ['true', 'false', 'color']])
+        OptEnum.new('HttpTrace', [false, 'Show the raw HTTP requests and responses', 'false', ['true', 'false', 'color']]),
+        OptString.new('HttpTraceColors', [true, 'HTTP request and response colors for HttpTrace', 'red/blu']),
+        OptBool.new('HttpTraceHeadersOnly', [false, 'Show HTTP headers only in HttpTrace', false])
       ], self.class
     )
 
@@ -319,34 +321,49 @@ module Exploit::Remote::HttpClient
       c = connect(opts)
       r = c.request_raw(opts)
 
-      case datastore['HttpTrace']
-      when 'true'
-        print_line('#' * 20)
-        print_line('# Request:')
-        print_line('#' * 20)
-        print_line(r.to_s)
-      when 'color'
-        print_line("%clr%bld%red#{r.to_s}%clr")
+      if datastore['HttpTrace']
+        request_color, response_color =
+          datastore['HttpTraceColors'].split('/').map { |color| "%#{color}" }
+
+        if datastore['HttpTraceHeadersOnly']
+          request = r.to_s(headers_only: true)
+        else
+          request = r.to_s
+        end
+
+        case datastore['HttpTrace']
+        when 'true'
+          print_line('#' * 20)
+          print_line('# Request:')
+          print_line('#' * 20)
+          print_line(request)
+        when 'color'
+          print_line("%clr%bld#{request_color}#{request}%clr")
+        end
       end
 
       res = c.send_recv(r, actual_timeout)
 
-      case datastore['HttpTrace']
-      when 'true'
-        print_line('#' * 20)
-        print_line('# Response:')
-        print_line('#' * 20)
+      if datastore['HttpTrace']
+        response =
+          if res
+            if datastore['HttpTraceHeadersOnly']
+              res.to_terminal_output(headers_only: true)
+            else
+              res.to_terminal_output
+            end
+          else
+            'No response received'
+          end
 
-        if res
-          print_line(res.to_terminal_output)
-        else
-          print_line('No response received')
-        end
-      when 'color'
-        if res
-          print_line("%clr%bld%blu#{res.to_terminal_output}%clr")
-        else
-          print_line('No response received')
+        case datastore['HttpTrace']
+        when 'true'
+          print_line('#' * 20)
+          print_line('# Response:')
+          print_line('#' * 20)
+          print_line(response)
+        when 'color'
+          print_line("%clr%bld#{response_color}#{response}%clr")
         end
       end
 
@@ -383,34 +400,49 @@ module Exploit::Remote::HttpClient
       c = connect(opts)
       r = c.request_cgi(opts)
 
-      case datastore['HttpTrace']
-      when 'true'
-        print_line('#' * 20)
-        print_line('# Request:')
-        print_line('#' * 20)
-        print_line(r.to_s)
-      when 'color'
-        print_line("%clr%bld%red#{r.to_s}%clr")
+      if datastore['HttpTrace']
+        request_color, response_color =
+          datastore['HttpTraceColors'].split('/').map { |color| "%#{color}" }
+
+        if datastore['HttpTraceHeadersOnly']
+          request = r.to_s(headers_only: true)
+        else
+          request = r.to_s
+        end
+
+        case datastore['HttpTrace']
+        when 'true'
+          print_line('#' * 20)
+          print_line('# Request:')
+          print_line('#' * 20)
+          print_line(request)
+        when 'color'
+          print_line("%clr%bld#{request_color}#{request}%clr")
+        end
       end
 
       res = c.send_recv(r, actual_timeout)
 
-      case datastore['HttpTrace']
-      when 'true'
-        print_line('#' * 20)
-        print_line('# Response:')
-        print_line('#' * 20)
+      if datastore['HttpTrace']
+        response =
+          if res
+            if datastore['HttpTraceHeadersOnly']
+              res.to_terminal_output(headers_only: true)
+            else
+              res.to_terminal_output
+            end
+          else
+            'No response received'
+          end
 
-        if res
-          print_line(res.to_terminal_output)
-        else
-          print_line('No response received')
-        end
-      when 'color'
-        if res
-          print_line("%clr%bld%blu#{res.to_terminal_output}%clr")
-        else
-          print_line('No response received')
+        case datastore['HttpTrace']
+        when 'true'
+          print_line('#' * 20)
+          print_line('# Response:')
+          print_line('#' * 20)
+          print_line(response)
+        when 'color'
+          print_line("%clr%bld#{response_color}#{response}%clr")
         end
       end
 

--- a/lib/msf/core/exploit/http/client.rb
+++ b/lib/msf/core/exploit/http/client.rb
@@ -44,7 +44,7 @@ module Exploit::Remote::HttpClient
         OptString.new('DOMAIN', [ true, 'The domain to use for windows authentification', 'WORKSTATION']),
         OptFloat.new('HttpClientTimeout', [false, 'HTTP connection and receive timeout']),
         OptBool.new('HttpPartialResponses', [false, 'Return partial HTTP responses despite timeouts', false]),
-        OptBool.new('HttpTrace', [false, 'Show the raw HTTP requests and responses', false])
+        OptEnum.new('HttpTrace', [false, 'Show the raw HTTP requests and responses', 'false', ['true', 'false', 'color']])
       ], self.class
     )
 
@@ -319,24 +319,28 @@ module Exploit::Remote::HttpClient
       c = connect(opts)
       r = c.request_raw(opts)
 
-      if datastore['HttpTrace']
+      case datastore['HttpTrace']
+      when 'true'
         print_line('#' * 20)
         print_line('# Request:')
         print_line('#' * 20)
         print_line(r.to_s)
+      when 'color'
+        print_line("%clr%bld%red#{r.to_s}%clr")
       end
 
       res = c.send_recv(r, actual_timeout)
 
-      if datastore['HttpTrace']
+      case datastore['HttpTrace']
+      when 'true'
         print_line('#' * 20)
         print_line('# Response:')
         print_line('#' * 20)
-        if res.nil?
-          print_line("No response received")
-        else
-          print_line(res.to_terminal_output)
-        end
+        res ? print_line(res.to_terminal_output) :
+              print_line('No response received')
+      when 'color'
+        res ? print_line("%clr%bld%blu#{res.to_terminal_output}%clr") :
+              print_line('No response received')
       end
 
       disconnect(c) if disconnect
@@ -368,30 +372,32 @@ module Exploit::Remote::HttpClient
       actual_timeout =  opts[:timeout] || timeout
     end
 
-    print_line("*" * 20) if datastore['HttpTrace']
-
     begin
       c = connect(opts)
       r = c.request_cgi(opts)
 
-      if datastore['HttpTrace']
+      case datastore['HttpTrace']
+      when 'true'
         print_line('#' * 20)
         print_line('# Request:')
         print_line('#' * 20)
         print_line(r.to_s)
+      when 'color'
+        print_line("%clr%bld%red#{r.to_s}%clr")
       end
 
       res = c.send_recv(r, actual_timeout)
 
-      if datastore['HttpTrace']
+      case datastore['HttpTrace']
+      when 'true'
         print_line('#' * 20)
         print_line('# Response:')
         print_line('#' * 20)
-        if res.nil?
-          print_line("No response received")
-        else
-          print_line(res.to_terminal_output)
-        end
+        res ? print_line(res.to_terminal_output) :
+              print_line('No response received')
+      when 'color'
+        res ? print_line("%clr%bld%blu#{res.to_terminal_output}%clr") :
+              print_line('No response received')
       end
 
       disconnect(c) if disconnect

--- a/lib/msf/core/exploit/http/client.rb
+++ b/lib/msf/core/exploit/http/client.rb
@@ -319,7 +319,7 @@ module Exploit::Remote::HttpClient
 
     begin
       c = connect(opts)
-      r = c.request_raw(opts)
+      r = opts[:cgi] ? c.request_cgi(opts) : c.request_raw(opts)
 
       if datastore['HttpTrace']
         request_color, response_color =
@@ -372,57 +372,7 @@ module Exploit::Remote::HttpClient
   #
   # @return (see Rex::Proto::Http::Client#send_recv))
   def send_request_cgi(opts={}, timeout = 20, disconnect = true)
-    if datastore['HttpClientTimeout'] && datastore['HttpClientTimeout'] > 0
-      actual_timeout = datastore['HttpClientTimeout']
-    else
-      actual_timeout =  opts[:timeout] || timeout
-    end
-
-    begin
-      c = connect(opts)
-      r = c.request_cgi(opts)
-
-      if datastore['HttpTrace']
-        request_color, response_color =
-          (datastore['HttpTraceColors'] || '').split('/').map { |color| "%bld%#{color}" }
-
-        request = r.to_s(headers_only: datastore['HttpTraceHeaders'])
-
-        print_line('#' * 20)
-        print_line('# Request:')
-        print_line('#' * 20)
-        print_line("%clr#{request_color}#{request}%clr")
-      end
-
-      res = c.send_recv(r, actual_timeout)
-
-      if datastore['HttpTrace']
-        print_line('#' * 20)
-        print_line('# Response:')
-        print_line('#' * 20)
-
-        if res
-          response = res.to_terminal_output(headers_only: datastore['HttpTraceHeadersOnly'])
-
-          print_line("%clr#{response_color}#{response}%clr")
-        else
-          print_line('No response received')
-        end
-      end
-
-      disconnect(c) if disconnect
-
-      res
-    rescue ::Errno::EPIPE, ::Timeout::Error => e
-      print_line(e.message) if datastore['HttpTrace']
-      nil
-    rescue Rex::ConnectionError => e
-      vprint_error(e.to_s)
-      nil
-    rescue ::Exception => e
-      print_line(e.message) if datastore['HttpTrace']
-      raise e
-    end
+    send_request_raw(opts.merge(cgi: true), timeout, disconnect)
   end
 
   # Connects to the server, creates a request, sends the request, reads the

--- a/lib/msf/core/exploit/http/client.rb
+++ b/lib/msf/core/exploit/http/client.rb
@@ -44,9 +44,9 @@ module Exploit::Remote::HttpClient
         OptString.new('DOMAIN', [ true, 'The domain to use for windows authentification', 'WORKSTATION']),
         OptFloat.new('HttpClientTimeout', [false, 'HTTP connection and receive timeout']),
         OptBool.new('HttpPartialResponses', [false, 'Return partial HTTP responses despite timeouts', false]),
-        OptEnum.new('HttpTrace', [false, 'Show the raw HTTP requests and responses', 'false', ['true', 'false', 'color']]),
-        OptString.new('HttpTraceColors', [true, 'HTTP request and response colors for HttpTrace', 'red/blu']),
-        OptBool.new('HttpTraceHeadersOnly', [false, 'Show HTTP headers only in HttpTrace', false])
+        OptBool.new('HttpTrace', [false, 'Show the raw HTTP requests and responses', false]),
+        OptBool.new('HttpTraceHeadersOnly', [false, 'Show HTTP headers only in HttpTrace', false]),
+        OptString.new('HttpTraceColors', [false, 'HTTP request and response colors for HttpTrace', 'red/blu'])
       ], self.class
     )
 
@@ -323,47 +323,29 @@ module Exploit::Remote::HttpClient
 
       if datastore['HttpTrace']
         request_color, response_color =
-          datastore['HttpTraceColors'].split('/').map { |color| "%#{color}" }
+          (datastore['HttpTraceColors'] || '').split('/').map { |color| "%bld%#{color}" }
 
-        if datastore['HttpTraceHeadersOnly']
-          request = r.to_s(headers_only: true)
-        else
-          request = r.to_s
-        end
+        request = r.to_s(headers_only: datastore['HttpTraceHeaders'])
 
-        case datastore['HttpTrace']
-        when 'true'
-          print_line('#' * 20)
-          print_line('# Request:')
-          print_line('#' * 20)
-          print_line(request)
-        when 'color'
-          print_line("%clr%bld#{request_color}#{request}%clr")
-        end
+        print_line('#' * 20)
+        print_line('# Request:')
+        print_line('#' * 20)
+        print_line("%clr#{request_color}#{request}%clr")
       end
 
       res = c.send_recv(r, actual_timeout)
 
       if datastore['HttpTrace']
-        response =
-          if res
-            if datastore['HttpTraceHeadersOnly']
-              res.to_terminal_output(headers_only: true)
-            else
-              res.to_terminal_output
-            end
-          else
-            'No response received'
-          end
+        print_line('#' * 20)
+        print_line('# Response:')
+        print_line('#' * 20)
 
-        case datastore['HttpTrace']
-        when 'true'
-          print_line('#' * 20)
-          print_line('# Response:')
-          print_line('#' * 20)
-          print_line(response)
-        when 'color'
-          print_line("%clr%bld#{response_color}#{response}%clr")
+        if res
+          response = res.to_terminal_output(headers_only: datastore['HttpTraceHeadersOnly'])
+
+          print_line("%clr#{response_color}#{response}%clr")
+        else
+          print_line('No response received')
         end
       end
 
@@ -402,47 +384,29 @@ module Exploit::Remote::HttpClient
 
       if datastore['HttpTrace']
         request_color, response_color =
-          datastore['HttpTraceColors'].split('/').map { |color| "%#{color}" }
+          (datastore['HttpTraceColors'] || '').split('/').map { |color| "%bld%#{color}" }
 
-        if datastore['HttpTraceHeadersOnly']
-          request = r.to_s(headers_only: true)
-        else
-          request = r.to_s
-        end
+        request = r.to_s(headers_only: datastore['HttpTraceHeaders'])
 
-        case datastore['HttpTrace']
-        when 'true'
-          print_line('#' * 20)
-          print_line('# Request:')
-          print_line('#' * 20)
-          print_line(request)
-        when 'color'
-          print_line("%clr%bld#{request_color}#{request}%clr")
-        end
+        print_line('#' * 20)
+        print_line('# Request:')
+        print_line('#' * 20)
+        print_line("%clr#{request_color}#{request}%clr")
       end
 
       res = c.send_recv(r, actual_timeout)
 
       if datastore['HttpTrace']
-        response =
-          if res
-            if datastore['HttpTraceHeadersOnly']
-              res.to_terminal_output(headers_only: true)
-            else
-              res.to_terminal_output
-            end
-          else
-            'No response received'
-          end
+        print_line('#' * 20)
+        print_line('# Response:')
+        print_line('#' * 20)
 
-        case datastore['HttpTrace']
-        when 'true'
-          print_line('#' * 20)
-          print_line('# Response:')
-          print_line('#' * 20)
-          print_line(response)
-        when 'color'
-          print_line("%clr%bld#{response_color}#{response}%clr")
+        if res
+          response = res.to_terminal_output(headers_only: datastore['HttpTraceHeadersOnly'])
+
+          print_line("%clr#{response_color}#{response}%clr")
+        else
+          print_line('No response received')
         end
       end
 

--- a/lib/msf/core/exploit/http/client.rb
+++ b/lib/msf/core/exploit/http/client.rb
@@ -46,7 +46,7 @@ module Exploit::Remote::HttpClient
         OptBool.new('HttpPartialResponses', [false, 'Return partial HTTP responses despite timeouts', false]),
         OptBool.new('HttpTrace', [false, 'Show the raw HTTP requests and responses', false]),
         OptBool.new('HttpTraceHeadersOnly', [false, 'Show HTTP headers only in HttpTrace', false]),
-        OptString.new('HttpTraceColors', [false, 'HTTP request and response colors for HttpTrace', 'red/blu'])
+        OptString.new('HttpTraceColors', [false, 'HTTP request and response colors for HttpTrace (unset to disable)', 'red/blu'])
       ], self.class
     )
 

--- a/lib/rex/proto/http/client_request.rb
+++ b/lib/rex/proto/http/client_request.rb
@@ -90,8 +90,7 @@ class ClientRequest
     @opts['headers'] ||= {}
   end
 
-  def to_s
-
+  def to_s(headers_only: false)
     # Start GET query string
     qstr = opts['query'] ? opts['query'].dup : ""
 
@@ -202,7 +201,9 @@ class ClientRequest
     req << set_content_len_header(pstr.length)
     req << set_chunked_header
     req << opts['raw_headers']
-    req << set_body(pstr)
+    req << set_body(pstr) unless headers_only
+
+    req
   end
 
   protected

--- a/lib/rex/proto/http/packet.rb
+++ b/lib/rex/proto/http/packet.rb
@@ -166,22 +166,22 @@ class Packet
   #
   # Outputs a readable string of the packet for terminal output
   #
-  def to_terminal_output
-    output_packet(true)
+  def to_terminal_output(headers_only: false)
+    output_packet(true, headers_only: headers_only)
   end
 
   #
   # Converts the packet to a string.
   #
-  def to_s
-    output_packet(false)
+  def to_s(headers_only: false)
+    output_packet(false, headers_only: headers_only)
   end
 
   #
   # Converts the packet to a string.
   # If ignore_chunk is set the chunked encoding is omitted (for pretty print)
   #
-  def output_packet(ignore_chunk=false)
+  def output_packet(ignore_chunk = false, headers_only: false)
     content = self.body.to_s.dup
 
     # Update the content length field in the header with the body length.
@@ -220,7 +220,9 @@ class Packet
     end
 
     str  = self.headers.to_s(cmd_string)
-    str += content || ''
+    str += content || '' unless headers_only
+
+    str
   end
 
   #


### PR DESCRIPTION
We decided that keeping the banners and leaving color on by default was the best choice.

Note that you can disable color by either unsetting `HttpTraceColors` or running `color false` to disable color in the console driver.

## What it looks like

![](https://user-images.githubusercontent.com/4551878/75069375-aa875b80-54b6-11ea-81f2-6a611b47c4f9.png)

## What I stole it from

![](https://www.wireshark.org/docs/wsug_html_chunked/wsug_graphics/ws-follow-stream.png)

## Verification steps

- [ ] Make sure the tests pass
- [ ] Test `send_request_raw`
- [ ] Test `send_request_cgi`
- [ ] Test `send_request_cgi!`

This PR continues a refactor started in #12510.