### PR TITLE
Fix getsockname usage in the SOCKS5 server

### DIFF
--- a/lib/rex/post/meterpreter/channels/socket_abstraction.rb
+++ b/lib/rex/post/meterpreter/channels/socket_abstraction.rb
@@ -33,7 +33,7 @@ module SocketAbstraction
       _address_family,caddr,_cport = csock.getsockname
       address_family,raddr,_rport = csock.getpeername_as_array
       _maddr,mport = [ channel.params.localhost, channel.params.localport ]
-      [ address_family, "#{caddr}#{(hops > 0) ? "-_#{hops}_" : ""}-#{raddr}", "#{mport}" ]
+      [ address_family, "#{caddr}#{(hops > 0) ? "-_#{hops}_" : ""}-#{raddr}", mport ]
     end
 
     def getpeername

--- a/lib/rex/proto/proxy/socks5/server_client.rb
+++ b/lib/rex/proto/proxy/socks5/server_client.rb
@@ -247,7 +247,7 @@ module Socks5
       setup_tcp_relay
       response              = ResponsePacket.new
       response.command      = REPLY_SUCCEEDED
-      response.address      = @rsock.getlocalname[HOST]
+      response.address      = @rsock.getlocalname[HOST].split('-')[-1]
       response.port         = @rsock.getlocalname[PORT]
       response
     end


### PR DESCRIPTION
This PR fixes the usage of `getsockname` / `getlocalname` for the SOCKS5 server when used with Rex Sockets backed by a meterpreter channel.

The underlying issue was that `getlocalname` was not returning appropriate information for reporting back to the SOCKS client. The hostname or IP address portion was two IP addresses joined by a dash and the port was a string instead of an integer. This fixes the issue by parsing the remote IP address out and keeping the port as an integer.

This fixes issue #11513. It should be noted that while this does allow the socks5 client to function in my testing, the information reported back in the acknowledgement of the connect command is technically inaccurate. It should, from my understanding, reflect the local bind information on the host through which metasploit is pivoting. This information is currently not exposed through meterpreter and exposing it would require adding `getsockname` to each of the meterpreter implementations or returning the local host and local port in the response when opening a TCP client connection.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] Start the SOCKS5 server module
- [ ] Use a curl command and the `--socks5` flag to validate that the SOCKS5 server is working
- [ ] Open a session and add a route through it
- [ ] Repeat the curl command to ensure that the SOCKS5 server *is still working, this time with the session*

### Appendix
This script can be used to set things up for testing pretty easily. Just update the `LHOST` value on L9 and open a session while it's sleeping.
```
use auxiliary/server/socks4a 
set SRVPORT 4000
run 
use auxiliary/server/socks5 
set SRVPORT 5000
run

use payload/python/meterpreter/reverse_tcp
set LHOST 192.168.159.128
to_handler
sleep 12

route add 0.0.0.0 0.0.0.0 -1
```
