### PR TITLE
Optionally store enumerated SMB usernames in DB

### DIFF
--- a/modules/auxiliary/scanner/smb/smb_enumusers.rb
+++ b/modules/auxiliary/scanner/smb/smb_enumusers.rb
@@ -26,6 +26,11 @@ class MetasploitModule < Msf::Auxiliary
       }
     )
 
+    register_options(
+      [
+        OptBool.new('DB_ALL_USERS', [ false, "Add all enumerated usernames to the database", false ]),
+      ])
+
     deregister_options('RPORT')
   end
 
@@ -309,6 +314,11 @@ class MetasploitModule < Msf::Auxiliary
           extra << ")"
         end
         print_good("#{domain.upcase} [ #{users.keys.map{|k| users[k]}.join(", ")} ] #{extra}")
+        if datastore['DB_ALL_USERS']
+          users.each { |user|
+            store_username(user, domain, ip, rport, resp)
+          }
+        end
       end
 
       # cleanup
@@ -326,5 +336,31 @@ class MetasploitModule < Msf::Auxiliary
     end
   end
 
+
+  def store_username(username, domain, ip, rport, resp)
+    service_data = {
+      address: ip,
+      port: rport,
+      service_name: 'smb',
+      protocol: 'tcp',
+      workspace_id: myworkspace_id,
+      proof: resp
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: username[1],
+      realm_key: Metasploit::Model::Realm::Key::ACTIVE_DIRECTORY_DOMAIN,
+      realm_value: domain,
+    }.merge(service_data)
+
+    login_data = {
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::UNTRIED
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
 
 end


### PR DESCRIPTION
This responds to issue #12359, where it was noted that enumerated usernames from this module were not being stored in the database. Since they are not a credential pair of user:pass, I have made it an optional feature with 'DB_ALL_USERS', which is consistent with other scanning modules.

## Verification

Default functionality (unchanged):
```
msf5 > creds -d
Credentials
===========

host  origin  service  public  private  realm  private_type  JtR Format
----  ------  -------  ------  -------  -----  ------------  ----------

msf5 > use auxiliary/scanner/smb/smb_enumusers
msf5 auxiliary(scanner/smb/smb_enumusers) > set RHOSTS 192.168.56.110
RHOSTS => 192.168.56.110
msf5 auxiliary(scanner/smb/smb_enumusers) > run

[+] 192.168.56.110:445    - USER-E74BC7C1A0 [ Administrator, Guest, SUPPORT_388945a0 ] ( LockoutTries=0 PasswordMin=0 )
[*] 192.168.56.110:       - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf5 auxiliary(scanner/smb/smb_enumusers) > creds
Credentials
===========

host  origin  service  public  private  realm  private_type  JtR Format
----  ------  -------  ------  -------  -----  ------------  ----------

msf5 auxiliary(scanner/smb/smb_enumusers) >
```

Set `DB_ALL_USERS` to true in order to save the usernames in the database:

```
msf5 auxiliary(scanner/smb/smb_enumusers) > show options

Module options (auxiliary/scanner/smb/smb_enumusers):

   Name          Current Setting  Required  Description
   ----          ---------------  --------  -----------
   DB_ALL_USERS  false            no        Add all enumerated usernames to the database
   RHOSTS        192.168.56.110   yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
   SMBDomain     .                no        The Windows domain to use for authentication
   SMBPass                        no        The password for the specified username
   SMBUser                        no        The username to authenticate as
   THREADS       1                yes       The number of concurrent threads (max one per host)

msf5 auxiliary(scanner/smb/smb_enumusers) > set DB_ALL_USERS true
DB_ALL_USERS => true
msf5 auxiliary(scanner/smb/smb_enumusers) > run

[+] 192.168.56.110:445    - USER-E74BC7C1A0 [ Administrator, Guest, SUPPORT_388945a0 ] ( LockoutTries=0 PasswordMin=0 )
[*] 192.168.56.110:       - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf5 auxiliary(scanner/smb/smb_enumusers) > creds
Credentials
===========

host            origin          service        public            private  realm            private_type  JtR Format
----            ------          -------        ------            -------  -----            ------------  ----------
192.168.56.110  192.168.56.110  445/tcp (smb)  SUPPORT_388945a0           USER-E74BC7C1A0
192.168.56.110  192.168.56.110  445/tcp (smb)  Guest                      USER-E74BC7C1A0
192.168.56.110  192.168.56.110  445/tcp (smb)  Administrator              USER-E74BC7C1A0

msf5 auxiliary(scanner/smb/smb_enumusers) > 
```

## Possible Bug?

Now, I would expect that I should be able to use these enumerated usernames in `auxiliary/scanner/smb/smb_login` in the same fashion I can with the SSH equivalents. However, this is what currently happens:

```
msf5 auxiliary(scanner/smb/smb_enumusers) > use auxiliary/scanner/smb/smb_login
msf5 auxiliary(scanner/smb/smb_login) > set DB_ALL_CREDS true
DB_ALL_CREDS => true
msf5 auxiliary(scanner/smb/smb_login) > set RHOSTS 192.168.56.110
RHOSTS => 192.168.56.110
msf5 auxiliary(scanner/smb/smb_login) > run

[*] 192.168.56.110:445    - 192.168.56.110:445 - Starting SMB login bruteforce
[*] 192.168.56.110:445    - Error: 192.168.56.110: Metasploit::Framework::LoginScanner::Invalid Cred details can't be blank, Cred details can't be blank (Metasploit::Framework::LoginScanner::SMB)
[*] 192.168.56.110:445    - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf5 auxiliary(scanner/smb/smb_login) > set SMBPass test
SMBPass => test
msf5 auxiliary(scanner/smb/smb_login) > set USER_AS_PASS true
USER_AS_PASS => true
msf5 auxiliary(scanner/smb/smb_login) > set BLANK_PASSWORDS true
BLANK_PASSWORDS => true
msf5 auxiliary(scanner/smb/smb_login) > run

[*] 192.168.56.110:445    - 192.168.56.110:445 - Starting SMB login bruteforce
[*] 192.168.56.110:445    - Error: 192.168.56.110: Metasploit::Framework::LoginScanner::Invalid Cred details can't be blank, Cred details can't be blank (Metasploit::Framework::LoginScanner::SMB)
[*] 192.168.56.110:445    - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf5 auxiliary(scanner/smb/smb_login) >
```

So disclaimer, I'm a very new contributor to Metasploit and a Ruby newbie in general. Poking around at the source of the LoginScanner and AuthBrute modules kinda make me think that its more likely I'm putting the data in the database wrong, but I'm not quite sure what I'm missing - feedback or suggestions of 'go and look at this bit' are welcome. I did note that if I make the module insert a fixed string like so:

```
diff --git a/modules/auxiliary/scanner/smb/smb_enumusers.rb b/modules/auxiliary/scanner/smb/smb_enumusers.rb
index 4ce773cf88..05402b97fa 100644
--- a/modules/auxiliary/scanner/smb/smb_enumusers.rb
+++ b/modules/auxiliary/scanner/smb/smb_enumusers.rb
@@ -351,6 +351,8 @@ class MetasploitModule < Msf::Auxiliary
       origin_type: :service,
       module_fullname: fullname,
       username: username[1],
+      private_data: "test",
+      private_type: :password,
       realm_key: Metasploit::Model::Realm::Key::ACTIVE_DIRECTORY_DOMAIN,
       realm_value: domain,
     }.merge(service_data)
```

meterpreter was pretty happy with that:
```
msf5 auxiliary(scanner/smb/smb_enumusers) > rexploit
[*] Reloading module...

[+] 192.168.56.110:445    - USER-E74BC7C1A0 [ Administrator, Guest, SUPPORT_388945a0 ] ( LockoutTries=0 PasswordMin=0 )
[*] 192.168.56.110:       - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf5 auxiliary(scanner/smb/smb_enumusers) > creds
Credentials
===========

host            origin          service        public            private  realm            private_type  JtR Format
----            ------          -------        ------            -------  -----            ------------  ----------
192.168.56.110  192.168.56.110  445/tcp (smb)  SUPPORT_388945a0  test     USER-E74BC7C1A0  Password
192.168.56.110  192.168.56.110  445/tcp (smb)  Guest             test     USER-E74BC7C1A0  Password
192.168.56.110  192.168.56.110  445/tcp (smb)  Administrator     test     USER-E74BC7C1A0  Password

msf5 auxiliary(scanner/smb/smb_enumusers) > use auxiliary/scanner/smb/smb_login
msf5 auxiliary(scanner/smb/smb_login) > run

[*] 192.168.56.110:445    - 192.168.56.110:445 - Starting SMB login bruteforce
[-] 192.168.56.110:445    - 192.168.56.110:445 - Failed: 'USER-E74BC7C1A0\SUPPORT_388945a0:test'
[-] 192.168.56.110:445    - 192.168.56.110:445 - Failed: 'USER-E74BC7C1A0\Guest:test',
[-] 192.168.56.110:445    - 192.168.56.110:445 - Failed: 'USER-E74BC7C1A0\Administrator:test',
[*] 192.168.56.110:445    - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

Thoughts? If you know what I might be getting wrong please point me in the right direction and I'll try and fix it up in this PR - but asking for feedback is better than not doing so. This is only my second PR, constructive feedback and suggestions welcome. Thanks!