### PR TITLE
Allows `set PAYLOAD` parameters to begin with `/`, `payload/`, & `/payload/`

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1579,9 +1579,9 @@ class Core
 
     # Set PAYLOAD
     if name.upcase == 'PAYLOAD' && active_module && (active_module.exploit? || active_module.evasion?)
-      if value.start_with?(/^\/?(payload\/)?/i)
-        # Trimming `/payload/`
-        value = value.gsub(/^\/?(payload\/)?/i, "")
+      if value.match(/^(\/?payload\/)|^\//i)
+        # Trims starting `/`, `payload/`, `/payload/` from user input
+        value = value.gsub(/^(\/?payload\/)|^\//i, "")
       else
         # Checking set PAYLOAD by index
         index_from_list(payload_show_results, value) do |mod|

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1579,7 +1579,7 @@ class Core
 
     # Set PAYLOAD
     if name.upcase == 'PAYLOAD' && active_module && (active_module.exploit? || active_module.evasion?)
-      if value.start_with?(%r{^(/?payload/)|^/}i)
+      if value.start_with?('/', 'payload/')
         # Trims starting `/`, `payload/`, `/payload/` from user input
         value.sub!(%r{^(/?payload/)|^/}i, "")
       else

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1577,21 +1577,16 @@ class Core
     name  = args[0]
     value = args[1, args.length-1].join(' ')
 
-    # Set PAYLOAD by index
+    # Set PAYLOAD
     if name.upcase == 'PAYLOAD' && active_module && (active_module.exploit? || active_module.evasion?)
-      list_item = index_from_list(payload_show_results, value)
-
-      if list_item.nil?
-        if value.start_with?("/")
-          value = value[1,value.length]
-        end
-
-        if value.start_with?("payload/")
-          value = value["payload/".length, value.length]
-        end
+      if value.start_with?(/^\/?(payload\/)?/i)
+        # Trimming `/payload/`
+        value = value.gsub(/^\/?(payload\/)?/i, "")
       else
-        list_item do |mod|
-            return false unless mod && mod.respond_to?(:first)
+        # Checking set PAYLOAD by index
+        index_from_list(payload_show_results, value) do |mod|
+          return false unless mod && mod.respond_to?(:first)
+
           # [name, class] from payload_show_results
           value = mod.first
         end

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1579,11 +1579,22 @@ class Core
 
     # Set PAYLOAD by index
     if name.upcase == 'PAYLOAD' && active_module && (active_module.exploit? || active_module.evasion?)
-      index_from_list(payload_show_results, value) do |mod|
-        return false unless mod && mod.respond_to?(:first)
+      list_item = index_from_list(payload_show_results, value)
 
-        # [name, class] from payload_show_results
-        value = mod.first
+      if list_item.nil?
+        if value.start_with?("/")
+          value = value[1,value.length]
+        end
+
+        if value.start_with?("payload/")
+          value = value["payload/".length, value.length]
+        end
+      else
+        list_item do |mod|
+            return false unless mod && mod.respond_to?(:first)
+          # [name, class] from payload_show_results
+          value = mod.first
+        end
       end
     end
 

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1579,9 +1579,9 @@ class Core
 
     # Set PAYLOAD
     if name.upcase == 'PAYLOAD' && active_module && (active_module.exploit? || active_module.evasion?)
-      if value.match(/^(\/?payload\/)|^\//i)
+      if value.start_with?(%r{^(/?payload/)|^/}i)
         # Trims starting `/`, `payload/`, `/payload/` from user input
-        value = value.gsub(/^(\/?payload\/)|^\//i, "")
+        value.sub!(%r{^(/?payload/)|^/}i, "")
       else
         # Checking set PAYLOAD by index
         index_from_list(payload_show_results, value) do |mod|

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1581,7 +1581,7 @@ class Core
     if name.upcase == 'PAYLOAD' && active_module && (active_module.exploit? || active_module.evasion?)
       if value.start_with?('/', 'payload/')
         # Trims starting `/`, `payload/`, `/payload/` from user input
-        value.sub!(%r{^(/?payload/)|^/}i, "")
+        value.sub!(%r{^/?(?:payload/)?}, "")
       else
         # Checking set PAYLOAD by index
         index_from_list(payload_show_results, value) do |mod|


### PR DESCRIPTION
When setting a module `PAYLOAD` value, you are currently unable to set a payload if it's path begins with `/`, `payload/`, & `/payload/`. This is a pain when copy pasting full paths into `set PAYLOAD` commands.

This PR adds a regex statement to catch and remove the above three path beginnings to the `command_dispatcher/core.rb`, allowing the underlying code to retrieve the payload correctly without the user having to change their input.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use crosschex`
- [x] `set PAYLOAD /payload/windows/x64/vncinject/reverse_winhttps`
- [x] `set PAYLOAD payload/windows/x64/vncinject/reverse_winhttps`
- [x] `set PAYLOAD /windows/x64/vncinject/reverse_winhttps`
- [x] `set PAYLOAD windows/x64/vncinject/reverse_winhttps`
- [x] Verify all four of the above inputs return `PAYLOAD => windows/x64/vncinject/reverse_winhttps`