### PR TITLE
Update module doc template

### DIFF
--- a/documentation/modules/module_doc_template.md
+++ b/documentation/modules/module_doc_template.md
@@ -1,16 +1,12 @@
-The following is the recommended format for module documentation.
-But feel free to add more content/sections to this.
+The following is the recommended format for module documentation. But feel free to add more content/sections to this.
 One of the general ideas behind these documents is to help someone troubleshoot the module if it were to stop
 functioning in 5+ years, so giving links or specific examples can be VERY helpful.
 
-## Vulnerable Application
+## Vulnerable Applications
 
-  Instructions to get the vulnerable application.  If applicable, include links to the vulnerable install files,
-  as well as instructions on installing/configuring the environment if it is different than a standard install.
-  Much of this will come from the PR, and can be copy/pasted.
+Instructions to get the vulnerable application.  If applicable, include links to the vulnerable install files, as well as instructions on installing/configuring the environment if it is different than a standard install. Much of this will come from the PR, and can be copy/pasted.
 
 ## Verification Steps
-
   Example steps in this format (is also in the PR):
 
   1. Install the application
@@ -18,18 +14,19 @@ functioning in 5+ years, so giving links or specific examples can be VERY helpfu
   3. Do: ```use [module path]```
   4. Do: ```run```
   5. You should get a shell.
-
+ 
 ## Options
+List each option and how to use it. 
 
-  **Option name**
+### Option Name
 
-  Talk about what it does, and how to use it appropriately.  If the default value is likely to change, include the default value here.
+Talk about what it does, and how to use it appropriately.  If the default value is likely to change, include the default value here.
 
 ## Scenarios
+Specific demo of using the module that might be useful in a real world scenario.
 
-### Version of software and OS as applicable
 
-  Specific demo of using the module that might be useful in a real world scenario.
+### Version and OS
 
   ```
   code or console output

--- a/documentation/modules/module_doc_template.md
+++ b/documentation/modules/module_doc_template.md
@@ -2,7 +2,7 @@ The following is the recommended format for module documentation. But feel free 
 One of the general ideas behind these documents is to help someone troubleshoot the module if it were to stop
 functioning in 5+ years, so giving links or specific examples can be VERY helpful.
 
-## Vulnerable Applications
+## Vulnerable Application
 
 Instructions to get the vulnerable application.  If applicable, include links to the vulnerable install files, as well as instructions on installing/configuring the environment if it is different than a standard install. Much of this will come from the PR, and can be copy/pasted.
 


### PR DESCRIPTION
This builds on the changes to standardize the module documentation. The template was updated to use the new heading names. @h00die and @wvu-r7 this is also a good opportunity to see if we want to expand on the section explanations. 

- https://github.com/rapid7/metasploit-framework/pull/12831
- https://github.com/rapid7/metasploit-framework/pull/12878 





