### PR TITLE
Add additional pry dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,8 @@ group :development do
   gem 'yard'
   # for development and testing purposes
   gem 'pry'
+  gem 'pry-nav'
+  gem 'pry-stack_explorer'
   # module documentation
   gem 'octokit'
   # Metasploit::Aggregator external session proxy

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,6 +142,8 @@ GEM
     bcrypt (3.1.12)
     bcrypt_pbkdf (1.0.1)
     bindata (2.4.5)
+    binding_of_caller (0.8.0)
+      debug_inspector (>= 0.0.1)
     bit-struct (0.16)
     builder (3.2.4)
     coderay (1.1.2)
@@ -149,6 +151,7 @@ GEM
     cookiejar (0.3.3)
     crass (1.0.6)
     daemons (1.3.1)
+    debug_inspector (0.0.3)
     diff-lcs (1.3)
     dnsruby (1.61.3)
       addressable (~> 2.5)
@@ -258,6 +261,11 @@ GEM
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
+    pry-nav (0.3.0)
+      pry (>= 0.9.10, < 0.13.0)
+    pry-stack_explorer (0.4.9.3)
+      binding_of_caller (>= 0.7)
+      pry (>= 0.9.11)
     public_suffix (4.0.3)
     rack (1.6.13)
     rack-protection (1.5.5)
@@ -409,6 +417,8 @@ DEPENDENCIES
   metasploit-framework!
   octokit
   pry
+  pry-nav
+  pry-stack_explorer
   rake
   redcarpet
   rspec-rails


### PR DESCRIPTION
Adding additional dependencies that pair well with pry:

- [pry-nav](https://github.com/nixme/pry-nav) - Adds code stepping commands, such as `next`, `step`, `continue`
- [pry-stack_explorer](https://github.com/pry/pry-stack_explorer) - Add simple stack exploration commands, `up`, `down`, `show-stack`