### PR TITLE
Update logic for ForceExploit in my modules

### DIFF
--- a/modules/auxiliary/admin/wemo/crockpot.rb
+++ b/modules/auxiliary/admin/wemo/crockpot.rb
@@ -74,9 +74,11 @@ class MetasploitModule < Msf::Auxiliary
 
     checkcode = check
 
-    unless checkcode == Exploit::CheckCode::Appears || datastore['ForceExploit']
-      print_error("#{checkcode[1]}. Set ForceExploit to override.")
-      return
+    unless datastore['ForceExploit']
+      unless checkcode == Exploit::CheckCode::Appears
+        print_error("#{checkcode[1]}. Set ForceExploit to override.")
+        return
+      end
     end
 
     case action.name

--- a/modules/exploits/linux/http/hp_van_sdn_cmd_inject.rb
+++ b/modules/exploits/linux/http/hp_van_sdn_cmd_inject.rb
@@ -104,12 +104,10 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    if [CheckCode::Safe, CheckCode::Unknown].include?(check)
-      if datastore['ForceExploit']
-        print_warning('ForceExploit set! Exploiting anyway!')
-      else
-        fail_with(Failure::NotVulnerable, 'Set ForceExploit to override')
-      end
+    if datastore['ForceExploit']
+      print_warning('ForceExploit set! Exploiting anyway!')
+    elsif [CheckCode::Safe, CheckCode::Unknown].include?(check)
+      fail_with(Failure::NotVulnerable, 'Set ForceExploit to override')
     end
 
     if target['Type'] == :unix_memory

--- a/modules/exploits/linux/http/webmin_backdoor.rb
+++ b/modules/exploits/linux/http/webmin_backdoor.rb
@@ -150,8 +150,10 @@ class MetasploitModule < Msf::Exploit::Remote
       CheckCode::Vulnerable
     ]
 
-    unless checkcodes.include?(check) || datastore['ForceExploit']
-      fail_with(Failure::NotVulnerable, 'Set ForceExploit to override')
+    unless datastore['ForceExploit']
+      unless checkcodes.include?(check)
+        fail_with(Failure::NotVulnerable, 'Set ForceExploit to override')
+      end
     end
 
     print_status("Configuring #{target.name} target")

--- a/modules/exploits/linux/upnp/belkin_wemo_upnp_exec.rb
+++ b/modules/exploits/linux/upnp/belkin_wemo_upnp_exec.rb
@@ -117,8 +117,10 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     checkcode = check
 
-    unless checkcode == CheckCode::Appears || datastore['ForceExploit']
-      fail_with(Failure::NotVulnerable, 'Set ForceExploit to override')
+    unless datastore['ForceExploit']
+      unless checkcode == CheckCode::Appears
+        fail_with(Failure::NotVulnerable, 'Set ForceExploit to override')
+      end
     end
 
     case target['Type']

--- a/modules/exploits/multi/http/jenkins_metaprogramming.rb
+++ b/modules/exploits/multi/http/jenkins_metaprogramming.rb
@@ -135,8 +135,10 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    unless check == CheckCode::Vulnerable || datastore['ForceExploit']
-      fail_with(Failure::NotVulnerable, 'Set ForceExploit to override')
+    unless datastore['ForceExploit']
+      unless check == CheckCode::Vulnerable
+        fail_with(Failure::NotVulnerable, 'Set ForceExploit to override')
+      end
     end
 
     print_status("Configuring #{target.name} target")

--- a/modules/exploits/unix/webapp/drupal_drupalgeddon2.rb
+++ b/modules/exploits/unix/webapp/drupal_drupalgeddon2.rb
@@ -183,8 +183,10 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    if check == CheckCode::Safe && !datastore['ForceExploit']
-      fail_with(Failure::NotVulnerable, 'Set ForceExploit to override')
+    unless datastore['ForceExploit']
+      if check == CheckCode::Safe
+        fail_with(Failure::NotVulnerable, 'Set ForceExploit to override')
+      end
     end
 
     unless @version

--- a/modules/exploits/unix/webapp/drupal_restws_unserialize.rb
+++ b/modules/exploits/unix/webapp/drupal_restws_unserialize.rb
@@ -140,12 +140,10 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    if [CheckCode::Safe, CheckCode::Unknown].include?(check)
-      if datastore['ForceExploit']
-        print_warning('ForceExploit set! Exploiting anyway!')
-      else
-        fail_with(Failure::NotVulnerable, 'Set ForceExploit to override')
-      end
+    if datastore['ForceExploit']
+      print_warning('ForceExploit set! Exploiting anyway!')
+    elsif [CheckCode::Safe, CheckCode::Unknown].include?(check)
+      fail_with(Failure::NotVulnerable, 'Set ForceExploit to override')
     end
 
     if datastore['PAYLOAD'] == 'cmd/unix/generic'


### PR DESCRIPTION
This lets the user opt out of running `check` completely. Though the option was originally designed to skip the _results_ of `check`, this is a better user experience. Typically, the user will have already seen the `check` results.

This is the next stage after adding the `AutoCheck` mixin in #12853 and is part of an ongoing Jira ticket. Please see the referenced PR for more context. It's not necessarily the final form.

**Note that this PR is limited to only the logic updates. I didn't want to change the logic too much and break the checks. There will be further refactors down the line.**