### PR TITLE
Fix broken module documentation link

### DIFF
--- a/lib/msf/util/document_generator/normalizer.rb
+++ b/lib/msf/util/document_generator/normalizer.rb
@@ -67,7 +67,7 @@ module Msf
         EVASION_DEMO_TEMPLATE           = 'evasion_demo_template.erb'
 
         # Special messages
-        NO_CVE_MESSAGE = %Q|CVE: [Not available](https://github.com/rapid7/metasploit-framework/wiki/Why-is-a-CVE-Not-Available%3F)|
+        NO_CVE_MESSAGE = %Q|CVE: [Not available](https://github.com/rapid7/metasploit-framework/wiki/Why-CVE-is-not-available)|
 
 
         # Returns the module document in HTML form.


### PR DESCRIPTION
Fix previously broken documentation link

## Verification

- [ ] Start `msfconsole`
- [ ] `use auxiliary/docx/word_unc_injector`
- [ ] `info -d`
- [ ] **Verify** the `CVE: Not available` link takes you to valid documentation

