### PR TITLE
Adds RPC call for total modules running, ready, and with results

### DIFF
--- a/lib/msf/core/rpc/v10/rpc_module.rb
+++ b/lib/msf/core/rpc/v10/rpc_module.rb
@@ -409,8 +409,8 @@ class RPC_Module < RPC_Base
   #  * 'running' [Integer] The number of modules currently in progress.
   #  * 'results' [Integer] The number of module run/check results.
   # @exampleHere's how you would use this from the client:
-  #  rpc.call('module.running_module_stats')
-  def rpc_running_module_stats
+  #  rpc.call('module.module_stats')
+  def rpc_module_stats
     {
         "ready" => self.framework.ready.size,
         "running" => self.framework.running.size,

--- a/lib/msf/core/rpc/v10/rpc_module.rb
+++ b/lib/msf/core/rpc/v10/rpc_module.rb
@@ -409,8 +409,8 @@ class RPC_Module < RPC_Base
   #  * 'running' [Integer] The number of modules currently in progress.
   #  * 'results' [Integer] The number of module run/check results.
   # @exampleHere's how you would use this from the client:
-  #  rpc.call('module.running_modules_stats')
-  def rpc_running_modules_stats
+  #  rpc.call('module.running_module_stats')
+  def rpc_running_module_stats
     {
         "ready" => self.framework.ready.size,
         "running" => self.framework.running.size,

--- a/lib/msf/core/rpc/v10/rpc_module.rb
+++ b/lib/msf/core/rpc/v10/rpc_module.rb
@@ -402,6 +402,22 @@ class RPC_Module < RPC_Base
     res
   end
 
+  # Returns the total modules in each state.
+  #
+  # @return [Hash] Running module stats that contain the following keys:
+  #  * 'ready' [Integer] The number of modules waiting to be kicked off.
+  #  * 'running' [Integer] The number of modules currently in progress.
+  #  * 'results' [Integer] The number of module run/check results.
+  # @exampleHere's how you would use this from the client:
+  #  rpc.call('module.running_modules_stats')
+  def rpc_running_modules_stats
+    {
+        "ready" => self.framework.ready.size,
+        "running" => self.framework.running.size,
+        "results" => self.framework.results.size,
+    }
+  end
+
 
   # Returns the module's datastore options.
   #

--- a/lib/msf/core/rpc/v10/rpc_module.rb
+++ b/lib/msf/core/rpc/v10/rpc_module.rb
@@ -409,8 +409,8 @@ class RPC_Module < RPC_Base
   #  * 'running' [Integer] The number of modules currently in progress.
   #  * 'results' [Integer] The number of module run/check results.
   # @exampleHere's how you would use this from the client:
-  #  rpc.call('module.module_stats')
-  def rpc_module_stats
+  #  rpc.call('module.running_stats')
+  def rpc_running_stats
     {
         "ready" => self.framework.ready.size,
         "running" => self.framework.running.size,


### PR DESCRIPTION
Adds a call to the Metasploit RPC client allowing users to retrieve the total number of modules that are`ready`,`running`, or which have `results`.

## Verification
- [ ] Start `./msfrpcd -U msf -P letmein`
- [ ] Start `./msfrpc -a 0.0.0.0 -U msf -P letmein`
- [ ] `rpc.call("module.module_stats")`
- [ ] **Verify** output is `{"ready"=>0, "running"=>0, "results"=>0}`
- [ ] `rpc.call("module.check", "auxiliary", "auxiliary/scanner/ssl/openssl_heartbleed", {"RHOSTS": "192.168.0.0" })`
- [ ] **Verify** output is `{"job_id"=>1, "uuid"=>[UUID]}`
- [ ] `rpc.call("module.module_stats")`
- [ ] **Verify** output is `{"ready"=>0, "running"=>1, "results"=>0}`
- [ ] Repeatedly call `rpc.call("module.module_stats")`
- [ ] **Verify** output should eventually read `{"ready"=>0, "running"=>0, "results"=>1}`
