### PR TITLE
Fix DisablePayloadHandler warning once and for all

### DIFF
--- a/documentation/modules/exploit/windows/local/persistence_image_exec_options.md
+++ b/documentation/modules/exploit/windows/local/persistence_image_exec_options.md
@@ -58,7 +58,7 @@ Payload options (windows/x64/meterpreter/reverse_tcp):
    LHOST     192.168.135.168  yes       The listen address (an interface may be specified)
    LPORT     4545             yes       The listen port
 
-   **DisablePayloadHandler: True   (payload settings will be ignored!)**
+   **DisablePayloadHandler: True   (no handler will be created!)**
 
 
 Exploit target:

--- a/documentation/modules/exploit/windows/local/persistence_image_exec_options.md
+++ b/documentation/modules/exploit/windows/local/persistence_image_exec_options.md
@@ -58,7 +58,7 @@ Payload options (windows/x64/meterpreter/reverse_tcp):
    LHOST     192.168.135.168  yes       The listen address (an interface may be specified)
    LPORT     4545             yes       The listen port
 
-   **DisablePayloadHandler: True   (RHOST and RPORT settings will be ignored!)**
+   **DisablePayloadHandler: True   (payload settings will be ignored!)**
 
 
 Exploit target:

--- a/lib/msf/core/exploit/exe.rb
+++ b/lib/msf/core/exploit/exe.rb
@@ -40,7 +40,7 @@ module Exploit::EXE
 
   def get_custom_exe(path = nil)
     path ||= datastore['EXE::Custom']
-    print_status("Using custom payload #{path}, RHOST and RPORT settings will be ignored!")
+    print_status("Using custom payload #{path}, payload settings will be ignored!")
     datastore['DisablePayloadHandler'] = true
     exe = nil
     ::File.open(path,'rb') {|f| exe = f.read(f.stat.size)}

--- a/lib/msf/core/exploit/exe.rb
+++ b/lib/msf/core/exploit/exe.rb
@@ -40,7 +40,7 @@ module Exploit::EXE
 
   def get_custom_exe(path = nil)
     path ||= datastore['EXE::Custom']
-    print_status("Using custom payload #{path}, payload settings will be ignored!")
+    print_status("Using custom payload #{path}, no handler will be created!")
     datastore['DisablePayloadHandler'] = true
     exe = nil
     ::File.open(path,'rb') {|f| exe = f.read(f.stat.size)}

--- a/lib/msf/ui/console/command_dispatcher/common.rb
+++ b/lib/msf/ui/console/command_dispatcher/common.rb
@@ -119,7 +119,7 @@ module Common
       if (p)
         p_opt = Serializer::ReadableText.dump_options(p, '   ')
         print("\nPayload options (#{mod.datastore['PAYLOAD']}):\n\n#{p_opt}\n") if (p_opt and p_opt.length > 0)
-        print("   **DisablePayloadHandler: True   (RHOST and RPORT settings will be ignored!)**\n\n") if mod.datastore['DisablePayloadHandler'].to_s == 'true'
+        print("   **DisablePayloadHandler: True   (payload settings will be ignored!)**\n\n") if mod.datastore['DisablePayloadHandler'].to_s == 'true'
       end
     end
 

--- a/lib/msf/ui/console/command_dispatcher/common.rb
+++ b/lib/msf/ui/console/command_dispatcher/common.rb
@@ -119,7 +119,7 @@ module Common
       if (p)
         p_opt = Serializer::ReadableText.dump_options(p, '   ')
         print("\nPayload options (#{mod.datastore['PAYLOAD']}):\n\n#{p_opt}\n") if (p_opt and p_opt.length > 0)
-        print("   **DisablePayloadHandler: True   (payload settings will be ignored!)**\n\n") if mod.datastore['DisablePayloadHandler'].to_s == 'true'
+        print("   **DisablePayloadHandler: True   (no handler will be created!)**\n\n") if mod.datastore['DisablePayloadHandler'].to_s == 'true'
       end
     end
 


### PR DESCRIPTION
End the chain of copy and paste. Uses a payload-agnostic message. It's a little redundant now, but it's precise.

Resolves #8934 and https://github.com/rapid7/metasploit-framework/pull/9731#discussion_r184194469. 🤦‍♂

```
msf5 exploit(multi/script/web_delivery) > options

Module options (exploit/multi/script/web_delivery):

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   SRVHOST  0.0.0.0          yes       The local host to listen on. This must be an address on the local machine or 0.0.0.0
   SRVPORT  8080             yes       The local port to listen on.
   SSL      false            no        Negotiate SSL for incoming connections
   SSLCert                   no        Path to a custom SSL certificate (default is randomly generated)
   URIPATH                   no        The URI to use for this exploit (default is random)


Payload options (python/meterpreter/reverse_tcp):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST                   yes       The listen address (an interface may be specified)
   LPORT  4444             yes       The listen port

   **DisablePayloadHandler: True   (no handler will be created!)**


Exploit target:

   Id  Name
   --  ----
   0   Python


msf5 exploit(multi/script/web_delivery) >
```

RIP Larry Tesler.