### PR TITLE
Fix aux modules check command on mac

### DIFF
--- a/lib/msf/core/auxiliary/scanner.rb
+++ b/lib/msf/core/auxiliary/scanner.rb
@@ -34,7 +34,6 @@ end
 
 def check
   nmod = replicant
-  nmod.datastore['RHOST'] = @original_rhost
   begin
     nmod.check_host(datastore['RHOST'])
   rescue NoMethodError


### PR DESCRIPTION
This line was causing RHOST to be nil which causes `simple_client.login` to hang on a mac.

This PR fixes the hang for this particular scenario, but there may be another underlying issue that needs fixed too.

## Investigating the hang

Why does it hang on mac? For this particular module, it seems to hang on the smb client:

![image](https://user-images.githubusercontent.com/60357436/74959364-4efb9600-5402-11ea-953e-34f0dd77aaa5.png)

Poking further, it seems like smb client attempts to write to a socket without a timeout set:

![image](https://user-images.githubusercontent.com/60357436/74960334-12c93500-5404-11ea-8d63-6ac29b4645dd.png)

The writing mechanism uses a simple while loop to ensure that all data is written, I have added extra logs for demonstration purposes:

```ruby
# ruby-2.6.5@metasploit-framework/gems/rex-core-0.1.13/lib/rex/io/stream.rb

  def write(buf, opts = {})
    total_sent   = 0
    total_length = buf.length
    block_size   = 32768

    require 'pry'
    binding.pry
    $stderr.puts "Beginning to write"

    begin
      while( total_sent < total_length )
        s = Rex::ThreadSafe.select( nil, [ fd ], nil, 0.2 )
        $stderr.puts "#{total_sent} / #{total_length}, the result of s was #{s.inspect}"
        if( s == nil || s[0] == nil )
          next
        end
        data = buf[total_sent, block_size]
        sent = fd.write_nonblock( data )
        if sent > 0
          total_sent += sent
        end
      end
```

With the additional logging in place:

![image](https://user-images.githubusercontent.com/60357436/74965021-5aec5580-540c-11ea-9d18-bbc0920df651.png)

The above shows an indefinite loop; but I'm not sure of the OS semantics here.

## Verification

List the steps needed to make sure this thing works

- [ ] On a mac
- [ ] Start `msfconsole`
- [ ] `use auxiliary/scanner/smb/smb_uninit_cred`
- [ ] `set RHOSTS x.x.x.x`
- [ ] **Verify** the `check` command works as expected


