### PR TITLE
Remove the --help-formats option

### DIFF
--- a/external/zsh/_msfvenom
+++ b/external/zsh/_msfvenom
@@ -214,7 +214,6 @@ _arguments \
   "--encrypt[The type of encryption or encoding to apply to the shellcode]:value" \
   "--encrypt-key[A key to be used for --encrypt]:value" \
   "--encrypt-iv[An initialization vector for --encrypt]:value" \
-  "--help-formats[List available formats]" \
   "--list-options[List --payload <value>'s standard, advanced and evasion options]" \
   "--pad-nops[Use nopsled size specified by -n \<length\> as the total payload size, auto-prepending a nopsled of quantity (nops minus payload length)]" \
   "--platform[The platform for --payload (use --list platforms to list)]:target platform:_msfvenom_platform" \


### PR DESCRIPTION
Fix #12969 by removing the `--help-formats` completion option for `msfvenom` since it no longer exists. This time I checked that the lengths of the parameter lists match where as when I updated the completions I just pulled additions from `msfvenom` and `msfconsole`.

## Testing
1. Update your msfvenom zsh completion
1. Tab it out and *do not* see `--help-formats` suggested as an option