### PR TITLE
Add additional logging for unknown postgres authtypes

### DIFF
--- a/lib/msf/core/exploit/postgres.rb
+++ b/lib/msf/core/exploit/postgres.rb
@@ -231,6 +231,7 @@ module Exploit::Remote::Postgres
     begin
       self.postgres_conn = Connection.new(db,username,password,uri)
     rescue RuntimeError => e
+      vprint_error e.to_s
       version_hash = analyze_auth_error e
       return version_hash
     end

--- a/lib/postgres/postgres-pr/connection.rb
+++ b/lib/postgres/postgres-pr/connection.rb
@@ -93,6 +93,9 @@ class Connection
 
         @conn << PasswordMessage.new(m).dump
 
+      when UnknownAuthType
+        raise "unknown auth type '#{msg.auth_type}' with buffer content:\n#{Rex::Text.to_hex_dump(msg.buffer.content)}"
+
       when AuthentificationKerberosV4, AuthentificationKerberosV5, AuthentificationSCMCredential
         raise "unsupported authentification"
 

--- a/lib/postgres/postgres-pr/message.rb
+++ b/lib/postgres/postgres-pr/message.rb
@@ -105,11 +105,15 @@ end
 class Authentification < Message
   register_message_type 'R'
 
-  AuthTypeMap = Hash.new { UnknownAuthType }
+  AuthTypeMap = {}
 
   def self.create(buffer)
     buffer.position = 5
     authtype = buffer.read_int32_network
+    unless AuthTypeMap.key? authtype
+      return UnknownAuthType.new(authtype, buffer)
+    end
+
     klass = AuthTypeMap[authtype]
     obj = klass.allocate
     obj.parse(buffer)
@@ -142,6 +146,13 @@ class Authentification < Message
 end
 
 class UnknownAuthType < Authentification
+  attr_reader :auth_type
+  attr_reader :buffer
+
+  def initialize(auth_type, buffer)
+    @auth_type = auth_type
+    @buffer = buffer
+  end
 end
 
 class AuthentificationOk < Authentification 


### PR DESCRIPTION
Add additional logging for unknown postgres authtypes.

### Before

Unknown postgres authtypes result in a crash:

```
msf5 auxiliary(scanner/postgres/postgres_version) > run

[*] 127.0.0.1:8200 Postgres - Trying username:'postgres' with password:'postgres' against 127.0.0.1:8200 on database 'template1'
[-] Auxiliary failed: NoMethodError undefined method `auth_type' for #<Msf::Db::PostgresPR::UnknownAuthType:0x00007f88e11da198>
[-] Call stack:
[-]   /Users/adfoster/Documents/code/metasploit-framework/lib/postgres/postgres-pr/message.rb:139:in `block in parse'
[-]   /Users/adfoster/Documents/code/metasploit-framework/lib/postgres/postgres-pr/message.rb:81:in `parse'
[-]   /Users/adfoster/Documents/code/metasploit-framework/lib/postgres/postgres-pr/message.rb:137:in `parse'
[-]   /Users/adfoster/Documents/code/metasploit-framework/lib/postgres/postgres-pr/message.rb:116:in `create'
[-]   /Users/adfoster/Documents/code/metasploit-framework/lib/postgres/postgres-pr/message.rb:57:in `read'
[-]   /Users/adfoster/Documents/code/metasploit-framework/lib/postgres/postgres-pr/connection.rb:71:in `block in initialize'
[-]   /Users/adfoster/Documents/code/metasploit-framework/lib/postgres/postgres-pr/connection.rb:70:in `loop'
[-]   /Users/adfoster/Documents/code/metasploit-framework/lib/postgres/postgres-pr/connection.rb:70:in `initialize'
[-]   /Users/adfoster/Documents/code/metasploit-framework/lib/msf/core/exploit/postgres.rb:232:in `new'
[-]   /Users/adfoster/Documents/code/metasploit-framework/lib/msf/core/exploit/postgres.rb:232:in `postgres_fingerprint'
[-]   /Users/adfoster/Documents/code/metasploit-framework/modules/auxiliary/scanner/postgres/postgres_version.rb:80:in `do_fingerprint'
[-]   /Users/adfoster/Documents/code/metasploit-framework/modules/auxiliary/scanner/postgres/postgres_version.rb:36:in `run_host'
[-]   /Users/adfoster/Documents/code/metasploit-framework/lib/msf/core/auxiliary/scanner.rb:118:in `block (2 levels) in run'
[-]   /Users/adfoster/Documents/code/metasploit-framework/lib/msf/core/thread_manager.rb:106:in `block in spawn'
[*] Auxiliary module execution completed
```

### After

Unknown postgres authtypes no longer crash and show additional logging information:

Without verbose true:

```
[*] 127.0.0.1:8200 Postgres - Trying username:'postgres' with password:'postgres' against 127.0.0.1:8200 on database 'template1'
[-] unknown auth type '1337' with buffer content:
52 00 00 00 0c 00 00 00 05 35 76 0f f5    |R........5v..|


[*] 127.0.0.1:8200 Postgres - Authentication Error Fingerprint: ::
[*] 127.0.0.1:8200 Postgres - Version Unknown (Pre-Auth)
[*] 127.0.0.1:8200 Postgres - Disconnected
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

With verbose true:

```
run

[*] 127.0.0.1:8200 Postgres - Version Unknown (Pre-Auth)
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

## Verification

List the steps needed to make sure this thing works

- [x] Start a database with an unknown authtype on port 5432
- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/postgres/postgres_version`
- [x] `set RHOSTS 127.0.0.1`
- [x] `set verbose true`
- [x] **Verify** there is no module crash.
- [x] **Verify** the details are logged correctly.

