### PR TITLE
Prevents HTML being returned by RPC

### DIFF
--- a/lib/msf/core/rpc.rb
+++ b/lib/msf/core/rpc.rb
@@ -1,4 +1,5 @@
 # -*- coding: binary -*-
+
 module Msf::RPC
   require 'msf/core/rpc/v10/constants'
 
@@ -40,6 +41,5 @@ module Msf::RPC
     autoload :InvalidResponse, 'msf/core/rpc/json/error'
     autoload :JSONParseError, 'msf/core/rpc/json/error'
     autoload :ErrorResponse, 'msf/core/rpc/json/error'
-
   end
 end

--- a/lib/msf/core/rpc/json/error.rb
+++ b/lib/msf/core/rpc/json/error.rb
@@ -14,14 +14,14 @@ module Msf::RPC::JSON
 
   # JSON-RPC 2.0 Error Messages
   ERROR_MESSAGES = {
-      # Specification errors:
-      PARSE_ERROR => 'Invalid JSON was received by the server. An error occurred on the server while parsing the JSON text.',
-      INVALID_REQUEST => 'The JSON sent is not a valid Request object.',
-      METHOD_NOT_FOUND => 'The method %<name>s does not exist.',
-      INVALID_PARAMS => 'Invalid method parameter(s).',
-      INTERNAL_ERROR => 'Internal JSON-RPC error',
-      # Implementation-defined server-errors:
-      APPLICATION_SERVER_ERROR => 'Application server error: %<msg>s',
+    # Specification errors:
+    PARSE_ERROR => 'Invalid JSON was received by the server. An error occurred on the server while parsing the JSON text.',
+    INVALID_REQUEST => 'The JSON sent is not a valid Request object.',
+    METHOD_NOT_FOUND => 'The method %<name>s does not exist.',
+    INVALID_PARAMS => 'Invalid method parameter(s).',
+    INTERNAL_ERROR => 'Internal JSON-RPC error',
+    # Implementation-defined server-errors:
+    APPLICATION_SERVER_ERROR => 'Application server error: %<msg>s'
   }
 
   # Base class for all Msf::RPC::JSON exceptions.

--- a/lib/msf/core/web_services/json_rpc_app.rb
+++ b/lib/msf/core/web_services/json_rpc_app.rb
@@ -8,6 +8,7 @@ require 'msf/core/web_services/framework_extension'
 require 'msf/core/web_services/servlet_helper'
 require 'msf/core/web_services/servlet/auth_servlet'
 require 'msf/core/web_services/servlet/json_rpc_servlet'
+require 'msf/core/web_services/json_rpc_exception_handling'
 
 module Msf::WebServices
   class JsonRpcApp < Sinatra::Base
@@ -21,8 +22,14 @@ module Msf::WebServices
     register AuthServlet
     register JsonRpcServlet
 
+    # Custom error handling
+    register JsonRpcExceptionHandling::SinatraExtension
+
     configure do
       set :dispatchers, {}
+
+      # Disables Sinatra HTML Error Responses
+      set :show_exceptions, false
 
       set :sessions, {key: 'msf-ws.session', expire_after: 300}
       set :session_secret, ENV.fetch('MSF_WS_SESSION_SECRET', SecureRandom.hex(16))
@@ -85,5 +92,11 @@ module Msf::WebServices
       false
     end
 
+    def self.setup_default_middleware(builder)
+      super
+      # Insertion at pos 1 needed to immediately follow Sinatra::ExtendedBase
+      # proc block identical to one used in 'use' method lib/rack/builder:86
+      builder.instance_variable_get(:@use).insert(1, proc { |app| JsonRpcExceptionHandling::RackMiddleware.new(app) })
+    end
   end
 end

--- a/lib/msf/core/web_services/json_rpc_exception_handling.rb
+++ b/lib/msf/core/web_services/json_rpc_exception_handling.rb
@@ -1,0 +1,76 @@
+require 'msf/core/rpc'
+
+module Msf::WebServices::JsonRpcExceptionHandling
+  class RackMiddleware
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      begin
+        @app.call(env)
+      rescue Exception => e
+        req = Rack::Request.new(env)
+        ErrorHandler.get_response(e, req)
+      end
+    end
+  end
+
+  module SinatraExtension
+    def self.registered(app)
+      app.error do |err|
+        ErrorHandler.get_response(err, self.request)
+      end
+    end
+  end
+
+  class ErrorHandler
+    class << self
+      def get_response(err, request)
+        parsed_request = parse_request(request)
+        data = get_data(err)
+
+        response = Msf::RPC::JSON::Dispatcher::create_error_response(
+          Msf::RPC::JSON::ApplicationServerError.new(
+            err,
+            data: data
+          ),
+          parsed_request
+        )
+
+        Rack::Response.new(
+          response.to_json,
+          500,
+          {'Content-type' => 'application/json'}
+        ).finish
+      end
+
+      private
+
+      def get_data(err)
+        return nil unless development?
+
+        {
+          "backtrace" => err.backtrace
+        }
+      end
+
+      def parse_request(req)
+        begin
+          body = req.body.tap(&:rewind).read
+          JSON.parse(body, symbolize_names: true)
+        rescue JSON::ParserError
+          nil
+        end
+      end
+
+      def development?
+        environment == :development
+      end
+
+      def environment
+        (ENV['RACK_ENV'] || :development).to_sym
+      end
+    end
+  end
+end


### PR DESCRIPTION
This replaces the default HTML Sinatra returns when an unhandled exception occurs with json. The json comes in the below format:

`"error" => {
"code" => -32001,
"message" => "Internal server error: Something imploded",
"data" => {
  "backtrace" => [Backtrace of exception]
}
  }
        }`

## Verification
Verification requires code changes for simplicity of triggering an unhandled exception

- [ ] Add `raise Exception` to `running_stats` method of `rpc_module.rb` and overwrite `dispatcher.rb` line 115 waith `raise Exception`
- [ ] Start `./msfrpcd -U msf -P letmein`
- [ ] Start `./msfrpc -a 0.0.0.0 -U msf -P letmein`
- [ ] `rpc.call("module.running_stats")`
- [ ] **Verify** Json returned matches above format with `"message" => "Internal server error: Exception"`