### PR TITLE
Fix broken links to http://jedicorp.com/?p=534 with archive.org

### DIFF
--- a/modules/auxiliary/docx/word_unc_injector.rb
+++ b/modules/auxiliary/docx/word_unc_injector.rb
@@ -34,7 +34,7 @@ class MetasploitModule < Msf::Auxiliary
       'License'        => MSF_LICENSE,
       'References'     =>
         [
-          [ 'URL', 'http://jedicorp.com/?p=534' ]
+          [ 'URL', 'https://web.archive.org/web/20140527232608/http://jedicorp.com/?p=534' ]
         ],
       'Author'         =>
         [

--- a/modules/post/windows/gather/word_unc_injector.rb
+++ b/modules/post/windows/gather/word_unc_injector.rb
@@ -33,7 +33,7 @@ class MetasploitModule < Msf::Post
       'License'        => MSF_LICENSE,
       'References'     =>
         [
-          [ 'URL', 'http://jedicorp.com/?p=534' ]
+          [ 'URL', 'https://web.archive.org/web/20140527232608/http://jedicorp.com/?p=534' ]
         ],
       'Platform'	=> ['win'],
       'SessionTypes'	=> ['meterpreter'],


### PR DESCRIPTION
Hello,

This PR fix broken links to http://jedicorp.com/?p=534 by using archive.org (new link https://web.archive.org/web/20140527232608/http://jedicorp.com/?p=534)

Please ensure you are submitting **from a unique branch** in your [repository](https://github.com/rapid7/metasploit-framework/pull/11086#issuecomment-445506416) to master in Rapid7's.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/windows/smb/ms08_067_netapi`
- [ ] ...
- [ ] **Verify** the thing does what it should
- [ ] **Verify** the thing does not do what it should not
- [ ] **Document** the thing and how it works ([Example](https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/post/multi/gather/aws_keys.md))

