### PR TITLE
Process updates to socket parameters when opening channels

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,9 +26,9 @@ PATH
       metasploit-concern (~> 2.0.0)
       metasploit-credential (~> 3.0.0)
       metasploit-model (~> 2.0.4)
-      metasploit-payloads (= 1.3.84)
+      metasploit-payloads (= 1.3.85)
       metasploit_data_models (~> 3.0.10)
-      metasploit_payloads-mettle (= 0.5.16)
+      metasploit_payloads-mettle (= 0.5.19)
       mqtt
       msgpack
       nessus_rest
@@ -207,7 +207,7 @@ GEM
       activemodel (~> 4.2.6)
       activesupport (~> 4.2.6)
       railties (~> 4.2.6)
-    metasploit-payloads (1.3.84)
+    metasploit-payloads (1.3.85)
     metasploit_data_models (3.0.10)
       activerecord (~> 4.2.6)
       activesupport (~> 4.2.6)
@@ -218,7 +218,7 @@ GEM
       postgres_ext
       railties (~> 4.2.6)
       recog (~> 2.0)
-    metasploit_payloads-mettle (0.5.16)
+    metasploit_payloads-mettle (0.5.19)
     method_source (0.9.2)
     mini_portile2 (2.4.0)
     minitest (5.14.0)

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -397,7 +397,8 @@ class Core
       return false
     end
 
-    print_status("Connected to #{host}:#{port}")
+    _, lhost, lport = sock.getlocalname()
+    print_status("Connected to #{host}:#{port} (via: #{lhost}:#{lport})")
 
     if justconn
       sock.close

--- a/lib/rex/post/meterpreter/channel.rb
+++ b/lib/rex/post/meterpreter/channel.rb
@@ -45,7 +45,6 @@ CHANNEL_DIO_CLOSE        = 'close'
 #
 ###
 class Channel
-
   # Class modifications to support global channel message
   # dispatching without having to register a per-instance handler
   class << self
@@ -94,7 +93,7 @@ class Channel
   # based on a given type.
   #
   def Channel.create(client, type = nil, klass = nil,
-      flags = CHANNEL_FLAG_SYNCHRONOUS, addends = nil)
+      flags = CHANNEL_FLAG_SYNCHRONOUS, addends = nil, klass_args = nil)
     request = Packet.create_request('core_channel_open')
 
     # Set the type of channel that we're allocating
@@ -109,7 +108,7 @@ class Channel
 
     request.add_tlv(TLV_TYPE_CHANNEL_CLASS, klass.cls)
     request.add_tlv(TLV_TYPE_FLAGS, flags)
-    request.add_tlvs(addends);
+    request.add_tlvs(addends)
 
     # Transmit the request and wait for the response
     cid = nil
@@ -122,7 +121,7 @@ class Channel
     end
 
     # Create the channel instance
-    klass.new(client, cid, type, flags)
+    klass.new(client, cid, type, flags, response, klass_args)
   end
 
   ##
@@ -135,7 +134,7 @@ class Channel
   # Initializes the instance's attributes, such as client context,
   # class identifier, type, and flags.
   #
-  def initialize(client, cid, type, flags)
+  def initialize(client, cid, type, flags, response, klass_args = nil)
     self.client = client
     self.cid    = cid
     self.type   = type
@@ -157,6 +156,23 @@ class Channel
         self._close(client, cid)
       end
     }
+  end
+
+  def self.params_hash_from_response(response)
+    tlv_param_map = {
+      TLV_TYPE_CONNECT_RETRIES => 'Retries',
+      TLV_TYPE_LOCAL_HOST      => 'LocalHost',
+      TLV_TYPE_LOCAL_PORT      => 'LocalPort',
+      TLV_TYPE_PEER_HOST       => 'PeerHost',
+      TLV_TYPE_PEER_PORT       => 'PeerPort'
+    }
+    params = {}
+    tlv_param_map.each do |tlv_type, param_key|
+      value = response.get_tlv(tlv_type)
+      next if value.nil?
+      params[param_key] = value
+    end
+    params
   end
 
   ##

--- a/lib/rex/post/meterpreter/channel.rb
+++ b/lib/rex/post/meterpreter/channel.rb
@@ -158,23 +158,6 @@ class Channel
     }
   end
 
-  def self.params_hash_from_response(response)
-    tlv_param_map = {
-      TLV_TYPE_CONNECT_RETRIES => 'Retries',
-      TLV_TYPE_LOCAL_HOST      => 'LocalHost',
-      TLV_TYPE_LOCAL_PORT      => 'LocalPort',
-      TLV_TYPE_PEER_HOST       => 'PeerHost',
-      TLV_TYPE_PEER_PORT       => 'PeerPort'
-    }
-    params = {}
-    tlv_param_map.each do |tlv_type, param_key|
-      value = response.get_tlv(tlv_type)
-      next if value.nil?
-      params[param_key] = value
-    end
-    params
-  end
-
   ##
   #
   # Channel interaction

--- a/lib/rex/post/meterpreter/channel.rb
+++ b/lib/rex/post/meterpreter/channel.rb
@@ -93,7 +93,7 @@ class Channel
   # based on a given type.
   #
   def Channel.create(client, type = nil, klass = nil,
-      flags = CHANNEL_FLAG_SYNCHRONOUS, addends = nil, klass_args = nil)
+      flags = CHANNEL_FLAG_SYNCHRONOUS, addends = nil, **klass_kwargs)
     request = Packet.create_request('core_channel_open')
 
     # Set the type of channel that we're allocating
@@ -121,7 +121,7 @@ class Channel
     end
 
     # Create the channel instance
-    klass.new(client, cid, type, flags, response, klass_args)
+    klass.new(client, cid, type, flags, response, **klass_kwargs)
   end
 
   ##
@@ -134,7 +134,7 @@ class Channel
   # Initializes the instance's attributes, such as client context,
   # class identifier, type, and flags.
   #
-  def initialize(client, cid, type, flags, response, klass_args = nil)
+  def initialize(client, cid, type, flags, packet, **_)
     self.client = client
     self.cid    = cid
     self.type   = type

--- a/lib/rex/post/meterpreter/channels/pool.rb
+++ b/lib/rex/post/meterpreter/channels/pool.rb
@@ -37,8 +37,8 @@ class Pool < Rex::Post::Meterpreter::Channel
   #
   # Passes the initialization information up to the base class
   #
-  def initialize(client, cid, type, flags)
-    super(client, cid, type, flags)
+  def initialize(client, cid, type, flags, response, klass_args)
+    super(client, cid, type, flags, response, klass_args)
   end
 
   ##

--- a/lib/rex/post/meterpreter/channels/pool.rb
+++ b/lib/rex/post/meterpreter/channels/pool.rb
@@ -37,8 +37,8 @@ class Pool < Rex::Post::Meterpreter::Channel
   #
   # Passes the initialization information up to the base class
   #
-  def initialize(client, cid, type, flags, response, klass_args)
-    super(client, cid, type, flags, response, klass_args)
+  def initialize(client, cid, type, flags, packet, klass_args)
+    super(client, cid, type, flags, packet, klass_args)
   end
 
   ##

--- a/lib/rex/post/meterpreter/channels/pool.rb
+++ b/lib/rex/post/meterpreter/channels/pool.rb
@@ -37,8 +37,8 @@ class Pool < Rex::Post::Meterpreter::Channel
   #
   # Passes the initialization information up to the base class
   #
-  def initialize(client, cid, type, flags, packet, klass_args)
-    super(client, cid, type, flags, packet, klass_args)
+  def initialize(client, cid, type, flags, packet, **_)
+    super(client, cid, type, flags, packet)
   end
 
   ##

--- a/lib/rex/post/meterpreter/channels/pools/file.rb
+++ b/lib/rex/post/meterpreter/channels/pools/file.rb
@@ -52,8 +52,8 @@ class File < Rex::Post::Meterpreter::Channels::Pool
   ##
 
   # Initializes the file channel instance
-  def initialize(client, cid, type, flags)
-    super(client, cid, type, flags)
+  def initialize(client, cid, type, flags, response, klass_args)
+    super(client, cid, type, flags, response, klass_args)
   end
 
 end

--- a/lib/rex/post/meterpreter/channels/pools/file.rb
+++ b/lib/rex/post/meterpreter/channels/pools/file.rb
@@ -52,8 +52,8 @@ class File < Rex::Post::Meterpreter::Channels::Pool
   ##
 
   # Initializes the file channel instance
-  def initialize(client, cid, type, flags, response, klass_args)
-    super(client, cid, type, flags, response, klass_args)
+  def initialize(client, cid, type, flags, packet, klass_args)
+    super(client, cid, type, flags, packet, klass_args)
   end
 
 end

--- a/lib/rex/post/meterpreter/channels/pools/file.rb
+++ b/lib/rex/post/meterpreter/channels/pools/file.rb
@@ -31,18 +31,18 @@ class File < Rex::Post::Meterpreter::Channels::Pool
   # from, written to, seeked on, and other interacted with.
   #
   def File.open(client, name, mode = "r", perm = 0)
-    return Channel.create(client, 'stdapi_fs_file',
-        self, CHANNEL_FLAG_SYNCHRONOUS,
-        [
-          {
-            'type'  => Rex::Post::Meterpreter::Extensions::Stdapi::TLV_TYPE_FILE_PATH,
-            'value' => client.unicode_filter_decode( name )
-          },
-          {
-            'type'  => Rex::Post::Meterpreter::Extensions::Stdapi::TLV_TYPE_FILE_MODE,
-            'value' => mode + "b"
-          },
-        ])
+    Channel.create(client, 'stdapi_fs_file',
+      self, CHANNEL_FLAG_SYNCHRONOUS,
+      [
+        {
+          'type'  => Rex::Post::Meterpreter::Extensions::Stdapi::TLV_TYPE_FILE_PATH,
+          'value' => client.unicode_filter_decode( name )
+        },
+        {
+          'type'  => Rex::Post::Meterpreter::Extensions::Stdapi::TLV_TYPE_FILE_MODE,
+          'value' => mode + "b"
+        },
+      ])
   end
 
   ##
@@ -52,8 +52,8 @@ class File < Rex::Post::Meterpreter::Channels::Pool
   ##
 
   # Initializes the file channel instance
-  def initialize(client, cid, type, flags, packet, klass_args)
-    super(client, cid, type, flags, packet, klass_args)
+  def initialize(client, cid, type, flags, packet, **_)
+    super(client, cid, type, flags, packet)
   end
 
 end

--- a/lib/rex/post/meterpreter/channels/pools/stream_pool.rb
+++ b/lib/rex/post/meterpreter/channels/pools/stream_pool.rb
@@ -33,8 +33,8 @@ class StreamPool < Rex::Post::Meterpreter::Channels::Pool
   ##
 
   # Initializes the file channel instance
-  def initialize(client, cid, type, flags)
-    super(client, cid, type, flags)
+  def initialize(client, cid, type, flags, response, klass_args)
+    super(client, cid, type, flags, response, klass_args)
 
     initialize_abstraction
   end

--- a/lib/rex/post/meterpreter/channels/pools/stream_pool.rb
+++ b/lib/rex/post/meterpreter/channels/pools/stream_pool.rb
@@ -33,8 +33,8 @@ class StreamPool < Rex::Post::Meterpreter::Channels::Pool
   ##
 
   # Initializes the file channel instance
-  def initialize(client, cid, type, flags, packet, klass_args)
-    super(client, cid, type, flags, packet, klass_args)
+  def initialize(client, cid, type, flags, packet, **_)
+    super(client, cid, type, flags, packet)
 
     initialize_abstraction
   end

--- a/lib/rex/post/meterpreter/channels/pools/stream_pool.rb
+++ b/lib/rex/post/meterpreter/channels/pools/stream_pool.rb
@@ -33,8 +33,8 @@ class StreamPool < Rex::Post::Meterpreter::Channels::Pool
   ##
 
   # Initializes the file channel instance
-  def initialize(client, cid, type, flags, response, klass_args)
-    super(client, cid, type, flags, response, klass_args)
+  def initialize(client, cid, type, flags, packet, klass_args)
+    super(client, cid, type, flags, packet, klass_args)
 
     initialize_abstraction
   end

--- a/lib/rex/post/meterpreter/channels/socket_abstraction.rb
+++ b/lib/rex/post/meterpreter/channels/socket_abstraction.rb
@@ -86,13 +86,13 @@ module SocketAbstraction
   #
   # Passes the initialization information up to the base class
   #
-  def initialize(client, cid, type, flags)
+  def initialize(client, cid, type, flags, response, klass_args)
     # sf: initialize_abstraction() before super() as we can get a scenario where dio_write_handler() is called
     # with data to write to the rsock but rsock has not yet been initialized. This happens if the channel
     # is registered (client.add_channel(self) in Channel.initialize) to a session and a 'core_channel_write'
     # request comes in before we have called self.initialize_abstraction()
     initialize_abstraction
-    super(client, cid, type, flags)
+    super(client, cid, type, flags, response, klass_args)
   end
 
   ##

--- a/lib/rex/post/meterpreter/channels/socket_abstraction.rb
+++ b/lib/rex/post/meterpreter/channels/socket_abstraction.rb
@@ -86,13 +86,13 @@ module SocketAbstraction
   #
   # Passes the initialization information up to the base class
   #
-  def initialize(client, cid, type, flags, packet, klass_args)
+  def initialize(client, cid, type, flags, packet, **_)
     # sf: initialize_abstraction() before super() as we can get a scenario where dio_write_handler() is called
     # with data to write to the rsock but rsock has not yet been initialized. This happens if the channel
     # is registered (client.add_channel(self) in Channel.initialize) to a session and a 'core_channel_write'
     # request comes in before we have called self.initialize_abstraction()
     initialize_abstraction
-    super(client, cid, type, flags, packet, klass_args)
+    super(client, cid, type, flags, packet)
   end
 
   ##

--- a/lib/rex/post/meterpreter/channels/socket_abstraction.rb
+++ b/lib/rex/post/meterpreter/channels/socket_abstraction.rb
@@ -86,13 +86,13 @@ module SocketAbstraction
   #
   # Passes the initialization information up to the base class
   #
-  def initialize(client, cid, type, flags, response, klass_args)
+  def initialize(client, cid, type, flags, packet, klass_args)
     # sf: initialize_abstraction() before super() as we can get a scenario where dio_write_handler() is called
     # with data to write to the rsock but rsock has not yet been initialized. This happens if the channel
     # is registered (client.add_channel(self) in Channel.initialize) to a session and a 'core_channel_write'
     # request comes in before we have called self.initialize_abstraction()
     initialize_abstraction
-    super(client, cid, type, flags, response, klass_args)
+    super(client, cid, type, flags, packet, klass_args)
   end
 
   ##

--- a/lib/rex/post/meterpreter/extensions/stdapi/net/socket.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/net/socket.rb
@@ -25,6 +25,13 @@ module Net
 #
 ###
 class Socket
+  TLV_PARAM_MAP = {
+    TLV_TYPE_CONNECT_RETRIES => 'Retries',
+    TLV_TYPE_LOCAL_HOST      => 'LocalHost',
+    TLV_TYPE_LOCAL_PORT      => 'LocalPort',
+    TLV_TYPE_PEER_HOST       => 'PeerHost',
+    TLV_TYPE_PEER_PORT       => 'PeerPort'
+  }
 
   ##
   #
@@ -50,6 +57,20 @@ class Socket
   #
   def shutdown
     client.deregister_inbound_handler(Rex::Post::Meterpreter::Extensions::Stdapi::Net::SocketSubsystem::TcpServerChannel)
+  end
+
+  #
+  # Process a response packet and extract TLVs that are relevant for updating
+  # socket parameters.
+  #
+  def self.params_hash_from_response(response)
+    params = {}
+    TLV_PARAM_MAP.each do |tlv_type, param_key|
+      value = response.get_tlv_value(tlv_type)
+      next if value.nil?
+      params[param_key] = value
+    end
+    params
   end
 
   ##

--- a/lib/rex/post/meterpreter/extensions/stdapi/net/socket.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/net/socket.rb
@@ -63,14 +63,14 @@ class Socket
   # Process a response packet and extract TLVs that are relevant for updating
   # socket parameters.
   #
-  def self.params_hash_from_response(response)
+  def self.parameters_from_response(response)
     params = {}
     TLV_PARAM_MAP.each do |tlv_type, param_key|
       value = response.get_tlv_value(tlv_type)
       next if value.nil?
       params[param_key] = value
     end
-    params
+    Rex::Socket::Parameters.from_hash(params)
   end
 
   ##

--- a/lib/rex/post/meterpreter/extensions/stdapi/net/socket_subsystem/tcp_client_channel.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/net/socket_subsystem/tcp_client_channel.rb
@@ -78,7 +78,7 @@ class TcpClientChannel < Rex::Post::Meterpreter::Stream
 
     rsock.extend(SocketInterface)
     rsock.channel = self
-    @params = klass_args[:sock_params].merge_hash(Channel.params_hash_from_response(response))
+    @params = klass_args[:sock_params].merge_hash(Socket.params_hash_from_response(response))
   end
 
   #

--- a/lib/rex/post/meterpreter/extensions/stdapi/net/socket_subsystem/tcp_client_channel.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/net/socket_subsystem/tcp_client_channel.rb
@@ -33,7 +33,7 @@ class TcpClientChannel < Rex::Post::Meterpreter::Stream
   # Opens a TCP client channel using the supplied parameters.
   #
   def TcpClientChannel.open(client, params)
-    c = Channel.create(client, 'stdapi_net_tcp_client', self, CHANNEL_FLAG_SYNCHRONOUS,
+    Channel.create(client, 'stdapi_net_tcp_client', self, CHANNEL_FLAG_SYNCHRONOUS,
       [
         {
           'type'  => TLV_TYPE_PEER_HOST,
@@ -55,11 +55,9 @@ class TcpClientChannel < Rex::Post::Meterpreter::Stream
           'type'  => TLV_TYPE_CONNECT_RETRIES,
           'value' => params.retries
         }
-      ])
-    if c
-      c.params = params
-    end
-    c
+      ],
+      klass_args = {:sock_params => params}
+    )
   end
 
   ##
@@ -71,8 +69,8 @@ class TcpClientChannel < Rex::Post::Meterpreter::Stream
   #
   # Passes the channel initialization information up to the base class.
   #
-  def initialize(client, cid, type, flags)
-    super(client, cid, type, flags)
+  def initialize(client, cid, type, flags, response, klass_args)
+    super(client, cid, type, flags, response, klass_args)
 
     lsock.extend(SocketInterface)
     lsock.extend(DirectChannelWrite)
@@ -80,7 +78,7 @@ class TcpClientChannel < Rex::Post::Meterpreter::Stream
 
     rsock.extend(SocketInterface)
     rsock.channel = self
-
+    @params = klass_args[:sock_params].merge_hash(Channel.params_hash_from_response(response))
   end
 
   #

--- a/lib/rex/post/meterpreter/extensions/stdapi/net/socket_subsystem/tcp_client_channel.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/net/socket_subsystem/tcp_client_channel.rb
@@ -69,8 +69,8 @@ class TcpClientChannel < Rex::Post::Meterpreter::Stream
   #
   # Passes the channel initialization information up to the base class.
   #
-  def initialize(client, cid, type, flags, response, klass_args)
-    super(client, cid, type, flags, response, klass_args)
+  def initialize(client, cid, type, flags, packet, klass_args)
+    super(client, cid, type, flags, packet, klass_args)
 
     lsock.extend(SocketInterface)
     lsock.extend(DirectChannelWrite)
@@ -78,7 +78,7 @@ class TcpClientChannel < Rex::Post::Meterpreter::Stream
 
     rsock.extend(SocketInterface)
     rsock.channel = self
-    @params = klass_args[:sock_params].merge_hash(Socket.params_hash_from_response(response))
+    @params = klass_args[:sock_params].merge(Socket.parameters_from_response(packet))
   end
 
   #

--- a/lib/rex/post/meterpreter/extensions/stdapi/net/socket_subsystem/tcp_client_channel.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/net/socket_subsystem/tcp_client_channel.rb
@@ -56,7 +56,7 @@ class TcpClientChannel < Rex::Post::Meterpreter::Stream
           'value' => params.retries
         }
       ],
-      klass_args = {:sock_params => params}
+      sock_params: params
     )
   end
 
@@ -69,8 +69,8 @@ class TcpClientChannel < Rex::Post::Meterpreter::Stream
   #
   # Passes the channel initialization information up to the base class.
   #
-  def initialize(client, cid, type, flags, packet, klass_args)
-    super(client, cid, type, flags, packet, klass_args)
+  def initialize(client, cid, type, flags, packet, sock_params: nil)
+    super(client, cid, type, flags, packet)
 
     lsock.extend(SocketInterface)
     lsock.extend(DirectChannelWrite)
@@ -78,7 +78,10 @@ class TcpClientChannel < Rex::Post::Meterpreter::Stream
 
     rsock.extend(SocketInterface)
     rsock.channel = self
-    @params = klass_args[:sock_params].merge(Socket.parameters_from_response(packet))
+
+    unless sock_params.nil?
+      @params = sock_params.merge(Socket.parameters_from_response(packet))
+    end
   end
 
   #

--- a/lib/rex/post/meterpreter/extensions/stdapi/net/socket_subsystem/tcp_server_channel.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/net/socket_subsystem/tcp_server_channel.rb
@@ -38,10 +38,6 @@ class TcpServerChannel < Rex::Post::Meterpreter::Channel
 
     cid       = packet.get_tlv_value( TLV_TYPE_CHANNEL_ID )
     pid       = packet.get_tlv_value( TLV_TYPE_CHANNEL_PARENTID )
-    localhost = packet.get_tlv_value( TLV_TYPE_LOCAL_HOST )
-    localport = packet.get_tlv_value( TLV_TYPE_LOCAL_PORT )
-    peerhost  = packet.get_tlv_value( TLV_TYPE_PEER_HOST )
-    peerport  = packet.get_tlv_value( TLV_TYPE_PEER_PORT )
 
     return false if cid.nil? || pid.nil?
 
@@ -52,15 +48,11 @@ class TcpServerChannel < Rex::Post::Meterpreter::Channel
     params = Rex::Socket::Parameters.from_hash(
       {
         'Proto'     => 'tcp',
-        'LocalHost' => localhost,
-        'LocalPort' => localport,
-        'PeerHost'  => peerhost,
-        'PeerPort'  => peerport,
         'Comm'      => server_channel.client
       }
     )
 
-    client_channel = TcpClientChannel.new(client, cid, TcpClientChannel, CHANNEL_FLAG_SYNCHRONOUS)
+    client_channel = TcpClientChannel.new(client, cid, TcpClientChannel, CHANNEL_FLAG_SYNCHRONOUS, packet, {:sock_params => params})
 
     client_channel.params = params
 

--- a/lib/rex/post/meterpreter/extensions/stdapi/net/socket_subsystem/tcp_server_channel.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/net/socket_subsystem/tcp_server_channel.rb
@@ -79,13 +79,13 @@ class TcpServerChannel < Rex::Post::Meterpreter::Channel
   #
   # @return [Channel]
   def self.open(client, params)
-    c = Channel.create(client, 'stdapi_net_tcp_server', self, CHANNEL_FLAG_SYNCHRONOUS,
+    Channel.create(client, 'stdapi_net_tcp_server', self, CHANNEL_FLAG_SYNCHRONOUS,
       [
         {'type'  => TLV_TYPE_LOCAL_HOST, 'value' => params.localhost},
         {'type'  => TLV_TYPE_LOCAL_PORT, 'value' => params.localport}
-      ] )
-    c.params = params
-    c
+      ],
+      klass_args = {:sock_params => params}
+    )
   end
 
   #
@@ -93,6 +93,7 @@ class TcpServerChannel < Rex::Post::Meterpreter::Channel
   #
   def initialize(client, cid, type, flags, response, klass_args)
     super(client, cid, type, flags, response, klass_args)
+    @params = klass_args[:sock_params].merge_hash(Socket.params_hash_from_response(response))
     # add this instance to the class variables dictionary of tcp server channels
     @@server_channels[self] ||= ::Queue.new
   end

--- a/lib/rex/post/meterpreter/extensions/stdapi/net/socket_subsystem/tcp_server_channel.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/net/socket_subsystem/tcp_server_channel.rb
@@ -91,8 +91,8 @@ class TcpServerChannel < Rex::Post::Meterpreter::Channel
   #
   # Simply initialize this instance.
   #
-  def initialize(client, cid, type, flags)
-    super(client, cid, type, flags)
+  def initialize(client, cid, type, flags, response, klass_args)
+    super(client, cid, type, flags, response, klass_args)
     # add this instance to the class variables dictionary of tcp server channels
     @@server_channels[self] ||= ::Queue.new
   end

--- a/lib/rex/post/meterpreter/extensions/stdapi/net/socket_subsystem/tcp_server_channel.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/net/socket_subsystem/tcp_server_channel.rb
@@ -54,8 +54,6 @@ class TcpServerChannel < Rex::Post::Meterpreter::Channel
 
     client_channel = TcpClientChannel.new(client, cid, TcpClientChannel, CHANNEL_FLAG_SYNCHRONOUS, packet, {:sock_params => params})
 
-    client_channel.params = params
-
     @@server_channels[server_channel] ||= ::Queue.new
     @@server_channels[server_channel].enq(client_channel)
 
@@ -83,9 +81,9 @@ class TcpServerChannel < Rex::Post::Meterpreter::Channel
   #
   # Simply initialize this instance.
   #
-  def initialize(client, cid, type, flags, response, klass_args)
-    super(client, cid, type, flags, response, klass_args)
-    @params = klass_args[:sock_params].merge_hash(Socket.params_hash_from_response(response))
+  def initialize(client, cid, type, flags, packet, klass_args)
+    super(client, cid, type, flags, packet, klass_args)
+    @params = klass_args[:sock_params].merge(Socket.parameters_from_response(packet))
     # add this instance to the class variables dictionary of tcp server channels
     @@server_channels[self] ||= ::Queue.new
   end

--- a/lib/rex/post/meterpreter/extensions/stdapi/net/socket_subsystem/tcp_server_channel.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/net/socket_subsystem/tcp_server_channel.rb
@@ -74,18 +74,22 @@ class TcpServerChannel < Rex::Post::Meterpreter::Channel
         {'type'  => TLV_TYPE_LOCAL_HOST, 'value' => params.localhost},
         {'type'  => TLV_TYPE_LOCAL_PORT, 'value' => params.localport}
       ],
-      klass_args = {:sock_params => params}
+      sock_params: params
     )
   end
 
   #
   # Simply initialize this instance.
   #
-  def initialize(client, cid, type, flags, packet, klass_args)
-    super(client, cid, type, flags, packet, klass_args)
-    @params = klass_args[:sock_params].merge(Socket.parameters_from_response(packet))
+  def initialize(client, cid, type, flags, packet, sock_params: nil)
+    super(client, cid, type, flags, packet)
+
     # add this instance to the class variables dictionary of tcp server channels
     @@server_channels[self] ||= ::Queue.new
+
+    unless sock_params.nil?
+      @params = sock_params.merge(Socket.parameters_from_response(packet))
+    end
   end
 
   #

--- a/lib/rex/post/meterpreter/extensions/stdapi/net/socket_subsystem/udp_channel.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/net/socket_subsystem/udp_channel.rb
@@ -35,27 +35,27 @@ class UdpChannel < Rex::Post::Meterpreter::Datagram
   #
   # @return [Channel]
   def self.open(client, params)
-    c = Channel.create(client, 'stdapi_net_udp_client', self, CHANNEL_FLAG_SYNCHRONOUS,
+    Channel.create(client, 'stdapi_net_udp_client', self, CHANNEL_FLAG_SYNCHRONOUS,
     [
-      {
-        'type'  => TLV_TYPE_LOCAL_HOST,
-        'value' => params.localhost
-      },
-      {
-        'type'  => TLV_TYPE_LOCAL_PORT,
-        'value' => params.localport
-      },
-      {
-        'type'  => TLV_TYPE_PEER_HOST,
-        'value' => params.peerhost
-      },
-      {
-        'type'  => TLV_TYPE_PEER_PORT,
-        'value' => params.peerport
-      }
-    ] )
-    c.params = params
-    c
+        {
+          'type'  => TLV_TYPE_LOCAL_HOST,
+          'value' => params.localhost
+        },
+        {
+          'type'  => TLV_TYPE_LOCAL_PORT,
+          'value' => params.localport
+        },
+        {
+          'type'  => TLV_TYPE_PEER_HOST,
+          'value' => params.peerhost
+        },
+        {
+          'type'  => TLV_TYPE_PEER_PORT,
+          'value' => params.peerport
+        }
+      ],
+      klass_args = {:sock_params => params}
+    )
   end
 
   #
@@ -73,6 +73,7 @@ class UdpChannel < Rex::Post::Meterpreter::Datagram
     # rsock.extend( Rex::Socket::Udp )
     rsock.extend(SocketInterface)
     rsock.channel = self
+    @params = klass_args[:sock_params].merge_hash(Socket.params_hash_from_response(response))
 
   end
 

--- a/lib/rex/post/meterpreter/extensions/stdapi/net/socket_subsystem/udp_channel.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/net/socket_subsystem/udp_channel.rb
@@ -61,8 +61,8 @@ class UdpChannel < Rex::Post::Meterpreter::Datagram
   #
   # Simply initialize this instance.
   #
-  def initialize(client, cid, type, flags)
-    super(client, cid, type, flags)
+  def initialize(client, cid, type, flags, response, klass_args)
+    super(client, cid, type, flags, response, klass_args)
 
     lsock.extend(Rex::Socket::Udp)
     lsock.initsock

--- a/lib/rex/post/meterpreter/extensions/stdapi/net/socket_subsystem/udp_channel.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/net/socket_subsystem/udp_channel.rb
@@ -61,8 +61,8 @@ class UdpChannel < Rex::Post::Meterpreter::Datagram
   #
   # Simply initialize this instance.
   #
-  def initialize(client, cid, type, flags, response, klass_args)
-    super(client, cid, type, flags, response, klass_args)
+  def initialize(client, cid, type, flags, packet, klass_args)
+    super(client, cid, type, flags, packet, klass_args)
 
     lsock.extend(Rex::Socket::Udp)
     lsock.initsock
@@ -73,8 +73,7 @@ class UdpChannel < Rex::Post::Meterpreter::Datagram
     # rsock.extend( Rex::Socket::Udp )
     rsock.extend(SocketInterface)
     rsock.channel = self
-    @params = klass_args[:sock_params].merge_hash(Socket.params_hash_from_response(response))
-
+    @params = klass_args[:sock_params].merge(Socket.parameters_from_response(packet))
   end
 
   #

--- a/lib/rex/post/meterpreter/extensions/stdapi/net/socket_subsystem/udp_channel.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/net/socket_subsystem/udp_channel.rb
@@ -54,15 +54,15 @@ class UdpChannel < Rex::Post::Meterpreter::Datagram
           'value' => params.peerport
         }
       ],
-      klass_args = {:sock_params => params}
+      sock_params: params
     )
   end
 
   #
   # Simply initialize this instance.
   #
-  def initialize(client, cid, type, flags, packet, klass_args)
-    super(client, cid, type, flags, packet, klass_args)
+  def initialize(client, cid, type, flags, packet, sock_params: nil)
+    super(client, cid, type, flags, packet)
 
     lsock.extend(Rex::Socket::Udp)
     lsock.initsock
@@ -73,7 +73,10 @@ class UdpChannel < Rex::Post::Meterpreter::Datagram
     # rsock.extend( Rex::Socket::Udp )
     rsock.extend(SocketInterface)
     rsock.channel = self
-    @params = klass_args[:sock_params].merge(Socket.parameters_from_response(packet))
+
+    unless sock_params.nil?
+      @params = sock_params.merge(Socket.parameters_from_response(packet))
+    end
   end
 
   #

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/net.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/net.rb
@@ -463,11 +463,12 @@ class Console::CommandDispatcher::Stdapi::Net
             )
 
             # Start the local TCP reverse relay in association with this stream
-            service.start_reverse_tcp_relay(channel,
-              'LocalPort'         => rport,
+            relay = service.start_reverse_tcp_relay(channel,
+              'LocalPort'         => channel.params.localport,
               'PeerHost'          => lhost,
               'PeerPort'          => lport,
               'MeterpreterRelay'  => true)
+            rport = relay.opts['LocalPort']
           rescue Exception => e
             print_error("Failed to create relay: #{e.to_s}")
             return false
@@ -481,12 +482,13 @@ class Console::CommandDispatcher::Stdapi::Net
           end
 
           # Start the local TCP relay in association with this stream
-          service.start_tcp_relay(lport,
+          relay = service.start_tcp_relay(lport,
             'LocalHost'         => lhost,
             'PeerHost'          => rhost,
             'PeerPort'          => rport,
             'MeterpreterRelay'  => true,
             'OnLocalConnection' => Proc.new { |relay, lfd| create_tcp_channel(relay) })
+          lport = relay.opts['LocalPort']
         end
 
         print_status("Local TCP relay created: #{lhost}:#{lport} <-> #{rhost}:#{rport}")

--- a/lib/rex/services/local_relay.rb
+++ b/lib/rex/services/local_relay.rb
@@ -238,6 +238,7 @@ class LocalRelay
       self.relays[name] = relay
       self.rev_chans << channel
     }
+    relay
   end
 
   #
@@ -260,10 +261,12 @@ class LocalRelay
       'LocalHost' => opts['LocalHost'],
       'LocalPort' => lport)
 
+    _, lhost, lport = listener.getlocalname()
+    opts['LocalHost']   = lhost
     opts['LocalPort']   = lport
     opts['__RelayType'] = 'tcp'
 
-    start_relay(listener, lport.to_s + (opts['LocalHost'] || '0.0.0.0'), opts)
+    start_relay(listener, lport.to_s + opts['LocalHost'], opts)
   end
 
   #
@@ -284,6 +287,7 @@ class LocalRelay
 
       self.rfds << stream_server
     }
+    relay
   end
 
   #

--- a/lib/rex/services/local_relay.rb
+++ b/lib/rex/services/local_relay.rb
@@ -128,7 +128,7 @@ class LocalRelay
       end
     end
 
-    def shudown
+    def shutdown
       # don't need to do anything here, it's only "close" we care about
     end
 

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -70,9 +70,9 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model', '~> 2.0.4'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '1.3.84'
+  spec.add_runtime_dependency 'metasploit-payloads', '1.3.85'
   # Needed for the next-generation POSIX Meterpreter
-  spec.add_runtime_dependency 'metasploit_payloads-mettle', '0.5.16'
+  spec.add_runtime_dependency 'metasploit_payloads-mettle', '0.5.19'
   # Needed by msfgui and other rpc components
   spec.add_runtime_dependency 'msgpack'
   # get list of network interfaces, like eth* from OS.

--- a/modules/payloads/singles/apple_ios/aarch64/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/apple_ios/aarch64/meterpreter_reverse_http.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_aarch64_apple_ios'
 
 module MetasploitModule
 
-  CachedSize = 796364
+  CachedSize = 795780
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/apple_ios/aarch64/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/apple_ios/aarch64/meterpreter_reverse_https.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_aarch64_apple_ios'
 
 module MetasploitModule
 
-  CachedSize = 796364
+  CachedSize = 795780
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/apple_ios/aarch64/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/apple_ios/aarch64/meterpreter_reverse_tcp.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_aarch64_apple_ios'
 
 module MetasploitModule
 
-  CachedSize = 796364
+  CachedSize = 795780
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/apple_ios/armle/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/apple_ios/armle/meterpreter_reverse_http.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_armle_apple_ios'
 
 module MetasploitModule
 
-  CachedSize = 623228
+  CachedSize = 639348
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/apple_ios/armle/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/apple_ios/armle/meterpreter_reverse_https.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_armle_apple_ios'
 
 module MetasploitModule
 
-  CachedSize = 623228
+  CachedSize = 639348
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/apple_ios/armle/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/apple_ios/armle/meterpreter_reverse_tcp.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_armle_apple_ios'
 
 module MetasploitModule
 
-  CachedSize = 623228
+  CachedSize = 639348
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/aarch64/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/aarch64/meterpreter_reverse_http.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_aarch64_linux'
 
 module MetasploitModule
 
-  CachedSize = 1102416
+  CachedSize = 1102904
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/aarch64/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/aarch64/meterpreter_reverse_https.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_aarch64_linux'
 
 module MetasploitModule
 
-  CachedSize = 1102416
+  CachedSize = 1102904
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/aarch64/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/aarch64/meterpreter_reverse_tcp.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_aarch64_linux'
 
 module MetasploitModule
 
-  CachedSize = 1102416
+  CachedSize = 1102904
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/armbe/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/armbe/meterpreter_reverse_http.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_armbe_linux'
 
 module MetasploitModule
 
-  CachedSize = 1031992
+  CachedSize = 1032216
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/armbe/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/armbe/meterpreter_reverse_https.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_armbe_linux'
 
 module MetasploitModule
 
-  CachedSize = 1031992
+  CachedSize = 1032216
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/armbe/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/armbe/meterpreter_reverse_tcp.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_armbe_linux'
 
 module MetasploitModule
 
-  CachedSize = 1031992
+  CachedSize = 1032216
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/armle/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/armle/meterpreter_reverse_http.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_armle_linux'
 
 module MetasploitModule
 
-  CachedSize = 1030744
+  CachedSize = 1032540
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/armle/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/armle/meterpreter_reverse_https.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_armle_linux'
 
 module MetasploitModule
 
-  CachedSize = 1030744
+  CachedSize = 1032540
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/armle/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/armle/meterpreter_reverse_tcp.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_armle_linux'
 
 module MetasploitModule
 
-  CachedSize = 1030744
+  CachedSize = 1032540
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/mips64/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/mips64/meterpreter_reverse_http.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_mips64_linux'
 
 module MetasploitModule
 
-  CachedSize = 1580448
+  CachedSize = 1584256
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/mips64/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/mips64/meterpreter_reverse_https.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_mips64_linux'
 
 module MetasploitModule
 
-  CachedSize = 1580448
+  CachedSize = 1584256
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/mips64/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/mips64/meterpreter_reverse_tcp.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_mips64_linux'
 
 module MetasploitModule
 
-  CachedSize = 1580448
+  CachedSize = 1584256
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/mipsbe/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/mipsbe/meterpreter_reverse_http.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_mipsbe_linux'
 
 module MetasploitModule
 
-  CachedSize = 1470620
+  CachedSize = 1471980
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/mipsbe/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/mipsbe/meterpreter_reverse_https.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_mipsbe_linux'
 
 module MetasploitModule
 
-  CachedSize = 1470620
+  CachedSize = 1471980
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/mipsbe/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/mipsbe/meterpreter_reverse_tcp.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_mipsbe_linux'
 
 module MetasploitModule
 
-  CachedSize = 1470620
+  CachedSize = 1471980
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/mipsle/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/mipsle/meterpreter_reverse_http.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_mipsle_linux'
 
 module MetasploitModule
 
-  CachedSize = 1472680
+  CachedSize = 1474036
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/mipsle/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/mipsle/meterpreter_reverse_https.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_mipsle_linux'
 
 module MetasploitModule
 
-  CachedSize = 1472680
+  CachedSize = 1474036
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/mipsle/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/mipsle/meterpreter_reverse_tcp.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_mipsle_linux'
 
 module MetasploitModule
 
-  CachedSize = 1472680
+  CachedSize = 1474036
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/ppc/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/ppc/meterpreter_reverse_http.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_ppc_linux'
 
 module MetasploitModule
 
-  CachedSize = 1212388
+  CachedSize = 1212484
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/ppc/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/ppc/meterpreter_reverse_https.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_ppc_linux'
 
 module MetasploitModule
 
-  CachedSize = 1212388
+  CachedSize = 1212484
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/ppc/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/ppc/meterpreter_reverse_tcp.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_ppc_linux'
 
 module MetasploitModule
 
-  CachedSize = 1212388
+  CachedSize = 1212484
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/ppc64le/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/ppc64le/meterpreter_reverse_http.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_ppc64le_linux'
 
 module MetasploitModule
 
-  CachedSize = 1236640
+  CachedSize = 1236760
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/ppc64le/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/ppc64le/meterpreter_reverse_https.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_ppc64le_linux'
 
 module MetasploitModule
 
-  CachedSize = 1236640
+  CachedSize = 1236760
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/ppc64le/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/ppc64le/meterpreter_reverse_tcp.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_ppc64le_linux'
 
 module MetasploitModule
 
-  CachedSize = 1236640
+  CachedSize = 1236760
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/ppce500v2/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/ppce500v2/meterpreter_reverse_http.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_ppce500v2_linux'
 
 module MetasploitModule
 
-  CachedSize = 1165068
+  CachedSize = 1165164
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/ppce500v2/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/ppce500v2/meterpreter_reverse_https.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_ppce500v2_linux'
 
 module MetasploitModule
 
-  CachedSize = 1165068
+  CachedSize = 1165164
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/ppce500v2/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/ppce500v2/meterpreter_reverse_tcp.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_ppce500v2_linux'
 
 module MetasploitModule
 
-  CachedSize = 1165068
+  CachedSize = 1165164
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/x64/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/x64/meterpreter_reverse_http.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_x64_linux'
 
 module MetasploitModule
 
-  CachedSize = 1046512
+  CachedSize = 1046632
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/x64/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/x64/meterpreter_reverse_https.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_x64_linux'
 
 module MetasploitModule
 
-  CachedSize = 1046512
+  CachedSize = 1046632
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/x64/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/x64/meterpreter_reverse_tcp.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_x64_linux'
 
 module MetasploitModule
 
-  CachedSize = 1046512
+  CachedSize = 1046632
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/x86/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/x86/meterpreter_reverse_http.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_x86_linux'
 
 module MetasploitModule
 
-  CachedSize = 1107588
+  CachedSize = 1111784
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/x86/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/x86/meterpreter_reverse_https.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_x86_linux'
 
 module MetasploitModule
 
-  CachedSize = 1107588
+  CachedSize = 1111784
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/x86/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/x86/meterpreter_reverse_tcp.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_x86_linux'
 
 module MetasploitModule
 
-  CachedSize = 1107588
+  CachedSize = 1111784
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/zarch/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/zarch/meterpreter_reverse_http.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_zarch_linux'
 
 module MetasploitModule
 
-  CachedSize = 1240720
+  CachedSize = 1240840
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/zarch/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/zarch/meterpreter_reverse_https.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_zarch_linux'
 
 module MetasploitModule
 
-  CachedSize = 1240720
+  CachedSize = 1240840
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/zarch/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/zarch/meterpreter_reverse_tcp.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_zarch_linux'
 
 module MetasploitModule
 
-  CachedSize = 1240720
+  CachedSize = 1240840
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/osx/x64/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/osx/x64/meterpreter_reverse_http.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_x64_osx'
 
 module MetasploitModule
 
-  CachedSize = 813560
+  CachedSize = 818064
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/osx/x64/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/osx/x64/meterpreter_reverse_https.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_x64_osx'
 
 module MetasploitModule
 
-  CachedSize = 813560
+  CachedSize = 818064
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/osx/x64/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/osx/x64/meterpreter_reverse_tcp.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/meterpreter_x64_osx'
 
 module MetasploitModule
 
-  CachedSize = 813560
+  CachedSize = 818064
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/windows/encrypted_shell_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/encrypted_shell_reverse_tcp.rb
@@ -11,7 +11,7 @@ require 'msf/core/payload/windows/encrypted_payload_opts'
 
 module MetasploitModule
 
-  CachedSize = 4336
+  CachedSize = 4352
 
   include Msf::Payload::Windows
   include Msf::Payload::Single


### PR DESCRIPTION
This pull requests introduces the framework side changes necessary to update the `Rex::Socket::Parameters` information with the proper bind address. It does this by allowing the meterpreter side to return additional TLVs containing extra information when a channel is opened.

These changes, when coupled with a meterpreter implementation which leverages them (currently windows, python, and mettle) will properly report the remote bind address of sockets. **This information fixes the CONNECT response of the SOCKS5 module to match the RFC** and the information reported by the `portfwd` and `connect` commands when a port of zero is specified by the user.

This pull request requires the changes introduced in the following pull requests:

* [rapid7/metasploit-payloads#380](https://github.com/rapid7/metasploit-payloads/pull/380)
* [rapid7/mettle#193](https://github.com/rapid7/mettle/pull/193)
* [rapid7/rex-socket#22](https://github.com/rapid7/rex-socket/pull/22)

On a side note, we could use this functionality for modules which require a server for a connection that is controlled by the module. The remote server could select a random port for us which the module would then leverage for whatever it needs without us worrying about conflicts.

## Testing Steps

- [x] Open a session with a supported meterpreter implementation
     - [x] Windows Native
     - [x] Python
     - [x] mettle
- [x] Add a reverse port forward, binding to port `0` (use `-p 0`)
    * *This demonstrates that the tcp server channel reports its information*
    - [x] See that Metasploit shows a real, high port number in the output
    - [x] Verify on the target with netstat that the port is correct and is in
      use by the Meterpreter process
    - [x] Connect to and test that the port forward is functioning
- [x] Use the `connect` command, specifying a comm (use `-c`) and a local port
  of 0 (use `-P 0`)
  * *This demonstrates that the tcp client channel reports its information*
  - [x] See that Metasploit shows a real, high port number in the output
  - [x] Verify on the target with netstat that the port is correct and is in
    use by the Meterpreter process
  - [x] Verify that the connection is working (see an SSH banner, issue an HTTP
    request, etc.)

## Example Output (New)
```
msf5 payload(linux/x86/meterpreter_reverse_tcp) > sessions -i -1
[*] Starting interaction with 1...

meterpreter > portfwd add -L scanme.nmap.org -R -l 22 -p 0
[*] Local TCP relay created: scanme.nmap.org:22 <-> :44685
meterpreter > background
[*] Backgrounding session 1...
msf5 payload(linux/x86/meterpreter_reverse_tcp) > connect localhost 44685
[*] Connected to localhost:44685
SSH-2.0-OpenSSH_6.6.1p1 Ubuntu-2ubuntu2.13
^Cmsf5 payload(linux/x86/meterpreter_reverse_tcp) >
```
Notice the port is shown as `44685` and not 0 showing that Metasploit knows where this socket is bound.
