### PR TITLE
Pipe Auditor - add support to SMBv2

### DIFF
--- a/lib/msf/core/exploit/smb/client/pipe_auditor.rb
+++ b/lib/msf/core/exploit/smb/client/pipe_auditor.rb
@@ -57,7 +57,7 @@ module Exploit::Remote::SMB::Client::PipeAuditor
         return pipe_name, pipe_handle if return_first
 
         @found_pipes << [pipe_name, pipe_handle]
-      rescue Rex::Proto::SMB::Exceptions::ErrorCode => e
+      rescue Rex::Proto::SMB::Exceptions::ErrorCode, RubySMB::Error::RubySMBError => e
         vprint_error("Inaccessible named pipe: #{pipe_name} - #{e.message}")
       end
     end

--- a/modules/auxiliary/scanner/smb/pipe_auditor.rb
+++ b/modules/auxiliary/scanner/smb/pipe_auditor.rb
@@ -22,7 +22,7 @@ class MetasploitModule < Msf::Auxiliary
       'License'     => MSF_LICENSE
     )
 
-    deregister_options('RPORT')
+    deregister_options('RPORT', 'SMBDirect')
   end
 
   # Fingerprint a single host
@@ -32,23 +32,22 @@ class MetasploitModule < Msf::Auxiliary
 
     [[139, false], [445, true]].each do |info|
 
-    datastore['RPORT'] = info[0]
-    datastore['SMBDirect'] = info[1]
+      datastore['RPORT'] = info[0]
+      datastore['SMBDirect'] = info[1]
 
-    begin
-      connect()
-      smb_login()
-      check_named_pipes.each do |pipe_name, _|
-        pipes.push(pipe_name)
+      begin
+        connect(versions: [1, 2])
+        smb_login()
+        check_named_pipes.each do |pipe_name, _|
+          pipes.push(pipe_name)
+        end
+
+        disconnect()
+
+        break
+      rescue Rex::Proto::SMB::Exceptions::SimpleClientError => e
+        vprint_bad("SMB client Error with RPORT=#{info[0]} SMBDirect=#{info[1]}: #{e.to_s}")
       end
-
-      disconnect()
-
-      break
-    rescue ::Exception => e
-      #print_line($!.to_s)
-      #print_line($!.backtrace.join("\n"))
-    end
     end
 
     if(pipes.length > 0)

--- a/modules/auxiliary/scanner/smb/pipe_auditor.rb
+++ b/modules/auxiliary/scanner/smb/pipe_auditor.rb
@@ -46,7 +46,7 @@ class MetasploitModule < Msf::Auxiliary
 
         break
       rescue Rex::Proto::SMB::Exceptions::SimpleClientError => e
-        vprint_bad("SMB client Error with RPORT=#{info[0]} SMBDirect=#{info[1]}: #{e.to_s}")
+        vprint_error("SMB client Error with RPORT=#{info[0]} SMBDirect=#{info[1]}: #{e.to_s}")
       end
     end
 


### PR DESCRIPTION
`pipe_auditor` auxiliary module only support SMB1 and fails with modern Windows, which only support SMBv2.

This PR add support to SMBv2.

## Verification
Use a Windows 10 as a target with default configuration (SMBv1 disabled).

- [ ] Start `msfconsole`
- [ ] `use auxiliary/scanner/smb/pipe_auditor`
- [ ] `set RHOSTS <host>`
- [ ] `set SMBUser <username>`
- [ ] `set SMBPass <password>`
- [ ] `run`
- [ ] **Verify** the accessible named pipes are listed 
