### PR TITLE
Fix msftidy warnings

### DIFF
--- a/modules/exploits/linux/http/zenoss_showdaemonxmlconfig_exec.rb
+++ b/modules/exploits/linux/http/zenoss_showdaemonxmlconfig_exec.rb
@@ -22,7 +22,6 @@ class MetasploitModule < Msf::Exploit::Remote
         [
           ['URL', 'http://itsecuritysolutions.org/2012-07-30-zenoss-3.2.1-multiple-security-vulnerabilities/'],
           ['OSVDB', '84408']
-          #['CVE', 'None'],
         ],
       'Author'         =>
         [

--- a/modules/exploits/windows/browser/teechart_pro.rb
+++ b/modules/exploits/windows/browser/teechart_pro.rb
@@ -43,7 +43,6 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'References'     =>
         [
-          #[ 'CVE', '?' ],
           [ 'OSVDB', '74446'],
           [ 'URL', 'http://www.stratsec.net/Research/Advisories/TeeChart-Professional-Integer-Overflow'],
         ],

--- a/modules/exploits/windows/fileformat/vlc_modplug_s3m.rb
+++ b/modules/exploits/windows/fileformat/vlc_modplug_s3m.rb
@@ -30,7 +30,6 @@ class MetasploitModule < Msf::Exploit::Remote
         [
           [ 'CVE', '2011-1574' ],
           [ 'OSVDB', '72143' ],
-          #[ 'BID', 'xxx' ],
           [ 'URL', 'http://modplug-xmms.git.sourceforge.net/git/gitweb.cgi?p=modplug-xmms/modplug-xmms;a=commitdiff;h=aecef259828a89bb00c2e6f78e89de7363b2237b' ],
           [ 'URL', 'https://seclists.org/fulldisclosure/2011/Apr/113' ]
         ],

--- a/modules/exploits/windows/http/novell_imanager_upload.rb
+++ b/modules/exploits/windows/http/novell_imanager_upload.rb
@@ -25,7 +25,6 @@ class MetasploitModule < Msf::Exploit::Remote
       'Privileged'     => true,
       'References'     =>
         [
-          #[ 'CVE', '2010-??' ],
           [ 'OSVDB', '68320'],
           [ 'ZDI', '10-190' ],
           [ 'URL', 'http://www.novell.com/support/viewContent.do?externalId=7006515&sliceId=2' ],


### PR DESCRIPTION
Fixing some msftidy warnings that break CI when you modify these files:

```
modules/exploits/linux/http/zenoss_showdaemonxmlconfig_exec.rb - [WARNING] Invalid CVE format: 'None'
modules/exploits/windows/browser/teechart_pro.rb - [WARNING] Invalid CVE format: '?'
modules/exploits/windows/fileformat/vlc_modplug_s3m.rb - [WARNING] Invalid BID format: 'xxx'
modules/exploits/windows/http/novell_imanager_upload.rb - [WARNING] Invalid CVE format: '2010-??'
```

These comments are fine to be here IMO, but it's less effort deleting these lines than fixing msftidy to be aware of comments - I'd imagine.