### PR TITLE
Allows use of type:aux in search

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -8,6 +8,13 @@ module Msf
       module CommandDispatcher
 
         #
+        # Module Type Shorthands
+        #
+        MODULE_TYPE_SHORTHANDS = {
+          "aux" => Msf::MODULE_AUX
+        }
+
+        #
         # {CommandDispatcher} for commands related to background jobs in Metasploit Framework.
         #
         class Modules
@@ -470,6 +477,11 @@ module Msf
               next if search_term.length == 0
               keyword.downcase!
               search_term.downcase!
+
+              if keyword == "type"
+                search_term = MODULE_TYPE_SHORTHANDS[search_term] if MODULE_TYPE_SHORTHANDS.key?(search_term)
+              end
+
               res[keyword] ||=[   [],    []   ]
               if search_term[0,1] == "-"
                 next if search_term.length == 1


### PR DESCRIPTION
Small change to allow users to use `type:aux` in place of `type:auxiliary`. String comparison and substitution are performed once when `search` is called then passed to `modules/metadata/search.rb` as normal. 

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `search type:aux`
- [ ] **Verify** error is not returned and all auxiliary modules are displayed