### PR TITLE
Reorder Expect mixin's send_expect parameters

### DIFF
--- a/lib/msf/core/exploit/expect.rb
+++ b/lib/msf/core/exploit/expect.rb
@@ -13,10 +13,10 @@ module Msf::Exploit::Expect
   # @param line [String] Line to send
   # @param pattern [Regexp] Pattern to expect
   # @param sock [Socket] Socket to send/expect on
-  # @param timeout [Float] Seconds to expect pattern
   # @param newline [String] Newline character(s)
+  # @param timeout [Float] Seconds to expect pattern
   # @return [void]
-  def send_expect(line, pattern, sock:, timeout: 3.5, newline: "\n")
+  def send_expect(line, pattern, sock:, newline: "\n", timeout: 3.5)
     unless sock.respond_to?(:put) && sock.respond_to?(:expect)
       raise ArgumentError, 'sock does not appear to be a socket'
     end

--- a/modules/exploits/unix/smtp/opensmtpd_mail_from_rce.rb
+++ b/modules/exploits/unix/smtp/opensmtpd_mail_from_rce.rb
@@ -113,8 +113,8 @@ class MetasploitModule < Msf::Exploit::Remote
         line,
         pattern,
         sock:    sock,
-        timeout: datastore['ExpectTimeout'],
-        newline: "\r\n"
+        newline: "\r\n",
+        timeout: datastore['ExpectTimeout']
       )
     end
   rescue Rex::ConnectionError => e


### PR DESCRIPTION
Mostly for style/readability. Must have forgotten to reorder the parameters when I added `newline`.

Fixes #12889.