### PR TITLE
Integrate pry-byebug

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,9 +17,7 @@ group :development do
   # generating documentation
   gem 'yard'
   # for development and testing purposes
-  gem 'pry'
-  gem 'pry-nav'
-  gem 'pry-stack_explorer'
+  gem 'pry-byebug'
   # module documentation
   gem 'octokit'
   # Metasploit::Aggregator external session proxy

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,16 +142,14 @@ GEM
     bcrypt (3.1.12)
     bcrypt_pbkdf (1.0.1)
     bindata (2.4.5)
-    binding_of_caller (0.8.0)
-      debug_inspector (>= 0.0.1)
     bit-struct (0.16)
     builder (3.2.4)
+    byebug (11.1.1)
     coderay (1.1.2)
     concurrent-ruby (1.0.5)
     cookiejar (0.3.3)
     crass (1.0.6)
     daemons (1.3.1)
-    debug_inspector (0.0.3)
     diff-lcs (1.3)
     dnsruby (1.61.3)
       addressable (~> 2.5)
@@ -261,11 +259,9 @@ GEM
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
-    pry-nav (0.3.0)
-      pry (>= 0.9.10, < 0.13.0)
-    pry-stack_explorer (0.4.9.3)
-      binding_of_caller (>= 0.7)
-      pry (>= 0.9.11)
+    pry-byebug (3.8.0)
+      byebug (~> 11.0)
+      pry (~> 0.10)
     public_suffix (4.0.3)
     rack (1.6.13)
     rack-protection (1.5.5)
@@ -416,9 +412,7 @@ DEPENDENCIES
   fivemat
   metasploit-framework!
   octokit
-  pry
-  pry-nav
-  pry-stack_explorer
+  pry-byebug
   rake
   redcarpet
   rspec-rails


### PR DESCRIPTION
`pry-byebug` has a superset of the functionality of `pry-nav` and `pry-stack_explorer`.

This means:

- Code stepping commands, such as `next`, `step`, `continue`
- Stack exploration commands, `up`, `down`, `backtrace`
- Adding [breakpoints](https://github.com/deivid-rodriguez/pry-byebug/tree/6021d2c01b2d9d00bbf7caace7beab9bf312d988#breakpoints) from within a session, `break SomeClass#run`

Previous PR:
- #12952

## Verification

List the steps needed to make sure this thing works

- [x] Run metasploit/tests with a `binding.pry` in place
- [x] **Verify** Basic code exploration works as expected, next, step, continue, up, down, etc