### PR TITLE
add module description to the Android binder_uaf module

### DIFF
--- a/modules/exploits/android/local/binder_uaf.rb
+++ b/modules/exploits/android/local/binder_uaf.rb
@@ -15,6 +15,16 @@ class MetasploitModule < Msf::Exploit::Local
     super( update_info( info, {
         'Name'          => "Android Binder Use-After-Free Exploit",
         'Description'   => %q{
+          This module exploits CVE-2019-2215, which is a use-after-free in Binder in the
+          Android kernel. The bug is a local privilege escalation vulnerability that
+          allows for a full compromise of a vulnerable device. If chained with a browser
+          renderer exploit, this bug could fully compromise a device through a malicious
+          website.
+          The freed memory is replaced with an iovec structure in order to leak a pointer
+          to the task_struct. Finally the bug is triggered again in order to overwrite
+          the addr_limit, making all memory (including kernel memory) accessible as part
+          of the user-space memory range in our process and allowing arbitrary reading
+          and writing of kernel memory.
         },
         'License'       => MSF_LICENSE,
         'Author'        => [
@@ -26,6 +36,7 @@ class MetasploitModule < Msf::Exploit::Local
         'References'    => [
             [ 'CVE', '2019-2215' ],
             [ 'URL', 'https://bugs.chromium.org/p/project-zero/issues/detail?id=1942' ],
+            [ 'URL', 'https://googleprojectzero.blogspot.com/2019/11/bad-binder-android-in-wild-exploit.html' ],
             [ 'URL', 'https://hernan.de/blog/2019/10/15/tailoring-cve-2019-2215-to-achieve-root/' ],
             [ 'URL', 'https://github.com/grant-h/qu1ckr00t/blob/master/native/poc.c' ],
         ],


### PR DESCRIPTION
I forgot to add a description to this module because I intended to improve it by adding it as part of a full chain for Android. Unfortunately I couldn't get the full chain working on chrome stable (because it runs as a 32bit process, which requires re-writing the exploit). It does however work as a full chain from the dev (64bit) version of chrome, so if anyone is interested those changes are here: https://github.com/rapid7/metasploit-framework/compare/master...timwr:chrome_binder_aarch64
