### PR TITLE
Fix error handling when a plugin load fails

### DIFF
--- a/lib/msf/core/rpc/v10/rpc_plugin.rb
+++ b/lib/msf/core/rpc/v10/rpc_plugin.rb
@@ -41,7 +41,7 @@ class RPC_Plugin < RPC_Base
         return { "result" => "success" }
       end
     rescue ::Exception => e
-      elog("Error loading plugin #{path}: #{e}\n\n#{e.backtrace.join("\n")}", 'core', 0, caller)
+      elog("Error loading plugin #{path}: #{e}\n\n#{e.backtrace.join("\n")}", 'core', 0)
       return { "result" => "failure" }
     end
 

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -754,7 +754,7 @@ class Core
         print_status("Successfully loaded plugin: #{inst.name}")
       end
     rescue ::Exception => e
-      elog("Error loading plugin #{path}: #{e}\n\n#{e.backtrace.join("\n")}", 'core', 0, caller)
+      elog("Error loading plugin #{path}: #{e}\n\n#{e.backtrace.join("\n")}", 'core', 0)
       print_error("Failed to load plugin from #{path}: #{e}")
     end
   end


### PR DESCRIPTION
This PR fixes error handling when a plugin load fails. The user is now correctly told the failure reason as expected.

Full context here: https://github.com/rapid7/metasploit-framework/issues/12993#issuecomment-592946958

### Before:

```
msf5 > load wmap
[-] Error while running command load: wrong number of arguments (given 4, expected 1..3)

Call stack:
/Users/adfoster/Documents/code/metasploit-framework/lib/rex/logging/log_dispatcher.rb:137:in `elog'
/Users/adfoster/Documents/code/metasploit-framework/lib/msf/ui/console/command_dispatcher/core.rb:757:in `rescue in load_plugin'
/Users/adfoster/Documents/code/metasploit-framework/lib/msf/ui/console/command_dispatcher/core.rb:752:in `load_plugin'
/Users/adfoster/Documents/code/metasploit-framework/lib/msf/ui/console/command_dispatcher/core.rb:775:in `cmd_load'
/Users/adfoster/Documents/code/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:523:in `run_command'
/Users/adfoster/Documents/code/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:474:in `block in run_single'
/Users/adfoster/Documents/code/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:468:in `each'
/Users/adfoster/Documents/code/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:468:in `run_single'
/Users/adfoster/Documents/code/metasploit-framework/lib/rex/ui/text/shell.rb:158:in `run'
/Users/adfoster/Documents/code/metasploit-framework/lib/metasploit/framework/command/console.rb:48:in `start'
/Users/adfoster/Documents/code/metasploit-framework/lib/metasploit/framework/command/base.rb:82:in `start'
./msfconsole:49:in `<main>'
```

### After:

```
msf5 > load wmap
[-] Failed to load plugin from /Users/adfoster/Documents/code/metasploit-framework/plugins/wmap: Database not connected (try db_connect)
```

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole` without a database connected
- [ ] `load wmap`
- [ ] **Verify** the user is told the reason for failing to load a plugin: `msf5 > load wmap
[-] Failed to load plugin from /Users/adfoster/Documents/code/metasploit-framework/plugins/wmap: Database not connected (try db_connect)`
- [ ] **Verify** the user does _not_ see an internal metasploit error: `Error while running command load: wrong number of arguments (given 4, expected 1..3)`

