### PR TITLE
Enable usage of usernames in cred collections

### DIFF
--- a/lib/msf/core/auxiliary/auth_brute.rb
+++ b/lib/msf/core/auxiliary/auth_brute.rb
@@ -82,6 +82,17 @@ module Auxiliary::AuthBrute
     end
   end
 
+  # Yields each Metasploit::Credential::Core in the Mdm::Workspace with
+  # a private type of 'nil'
+  #
+  # @yieldparam [Metasploit::Credential::Core]
+  def each_username_cred
+    creds = framework.db.creds(type: nil, workspace: myworkspace.name)
+    creds.each do |cred|
+      yield cred
+    end
+  end
+
   # Checks whether we should be adding creds from the DB to a CredCollection
   #
   # @return [TrueClass] if any of the datastore options for db creds are selected and the db is active
@@ -129,6 +140,21 @@ module Auxiliary::AuthBrute
   def prepend_db_passwords(cred_collection)
     if prepend_db_creds?
       each_password_cred do |cred|
+        process_cred_for_collection(cred_collection,cred)
+      end
+    end
+    cred_collection
+  end
+
+  # This method takes a Metasploit::Framework::CredentialCollection and prepends existing Usernames
+  # from the database. This allows the users to use the DB_ALL_USERS option.
+  #
+  # @param cred_collection [Metasploit::Framework::CredentialCollection]
+  #    the credential collection to add to
+  # @return [Metasploit::Framework::CredentialCollection] the modified Credentialcollection
+  def prepend_db_usernames(cred_collection)
+    if prepend_db_creds?
+      each_username_cred do |cred|
         process_cred_for_collection(cred_collection,cred)
       end
     end

--- a/modules/auxiliary/scanner/smb/smb_login.rb
+++ b/modules/auxiliary/scanner/smb/smb_login.rb
@@ -112,6 +112,7 @@ class MetasploitModule < Msf::Auxiliary
 
     cred_collection = prepend_db_passwords(cred_collection)
     cred_collection = prepend_db_hashes(cred_collection)
+    cred_collection = prepend_db_usernames(cred_collection)
 
     @scanner.cred_details = cred_collection
 

--- a/modules/auxiliary/scanner/smb/smb_login.rb
+++ b/modules/auxiliary/scanner/smb/smb_login.rb
@@ -145,6 +145,7 @@ class MetasploitModule < Msf::Auxiliary
             private: result.credential.private,
             realm_key: Metasploit::Model::Realm::Key::ACTIVE_DIRECTORY_DOMAIN,
             realm_value: result.credential.realm,
+            last_attempted_at: DateTime.now,
             status: result.status
         )
         :abort
@@ -160,6 +161,7 @@ class MetasploitModule < Msf::Auxiliary
           private: result.credential.private,
           realm_key: Metasploit::Model::Realm::Key::ACTIVE_DIRECTORY_DOMAIN,
           realm_value: result.credential.realm,
+          last_attempted_at: DateTime.now,
           status: result.status
         )
       end


### PR DESCRIPTION
This adds two methods that will allow a user to use stored usernames in the database with login scanner modules Ex. `auxiliary/scanner/smb/smb_login`. PR #12929 relies on this due to the stored usernames not being added to the credential_collection that is created to scan with.

This also fixes #12274 by setting `last_attempted_at` in `smb_login`.

## Verification

- [x] Start `msfconsole`
- [x] Add some user names to the database
- [x] Use `auxiliary/scanner/smb/smb_login`
- [x] Set `DB_ALL_USERS` true
- [ ] Set `SMBPASS` PASSWORD
- [ ] **Verify** that the usernames are included in the scanner's `cred_collection`
- [ ] **Verify** that the following errors are not in the module's output:

```
Error: 192.168.37.158: Metasploit::Framework::LoginScanner::Invalid Cred details can't be blank, Cred details can't be blank 
```

```
ActiveRecord::RecordInvalid Validation failed: Last attempted at can't be nil if status is tried
```

## Scenarios

On `master`:

```
msf5 > creds add user:test_user
msf5 > creds add user:another_user
msf5 > creds add user:administrator
msf5 > use smb_login

Matching Modules
================

   #  Name                             Disclosure Date  Rank    Check  Description
   -  ----                             ---------------  ----    -----  -----------
   0  auxiliary/scanner/smb/smb_login                   normal  No     SMB Login Check Scanner


[*] Using auxiliary/scanner/smb/smb_login
msf5 auxiliary(scanner/smb/smb_login) > set rhosts 192.168.37.158
rhosts => 192.168.37.158
msf5 auxiliary(scanner/smb/smb_login) > set smb_pass password
smb_pass => password
msf5 auxiliary(scanner/smb/smb_login) > set db_all_users true
db_all_users => true
msf5 auxiliary(scanner/smb/smb_login) > run

[*] 192.168.37.158:445    - 192.168.37.158:445 - Starting SMB login bruteforce
[*] 192.168.37.158:445    - Error: 192.168.37.158: Metasploit::Framework::LoginScanner::Invalid Cred details can't be blank, Cred details can't be blank (Metasploit::Framework::LoginScanner::SMB)
[*] 192.168.37.158:445    - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf5 auxiliary(scanner/smb/smb_login) > edit
msf5 auxiliary(scanner/smb/smb_login) > rerun
[*] Reloading module...

[*] 192.168.37.158:445    - 192.168.37.158:445 - Starting SMB login bruteforce

From: /Users/space/metasploit-framework/modules/auxiliary/scanner/smb/smb_login.rb @ line 117 Msf::Modules::Auxiliary__Scanner__Smb__Smb_login::MetasploitModule#run_host:

    112: 
    113:     cred_collection = prepend_db_passwords(cred_collection)
    114:     cred_collection = prepend_db_hashes(cred_collection)
    115:     require 'pry';binding.pry
    116: 
 => 117:     @scanner.cred_details = cred_collection
    118: 
    119:     @scanner.scan! do |result|
    120:       case result.status
    121:       when Metasploit::Model::Login::Status::LOCKED_OUT
    122:         if datastore['ABORT_ON_LOCKOUT']

[1] pry(#<Msf::Modules::Auxiliary__Scanner__Smb__Smb_login::MetasploitModule>)> cred_collection
=> #<Metasploit::Framework::CredentialCollection:0x00007fd91a419c68
 @additional_privates=[],
 @additional_publics=[],
 @blank_passwords=false,
 @pass_file=nil,
 @password="",
 @prepended_creds=[],
 @realm=".",
 @user_as_pass=false,
 @user_file=nil,
 @username="",
 @userpass_file=nil>
[2] pry(#<Msf::Modules::Auxiliary__Scanner__Smb__Smb_login::MetasploitModule>)> exit
[*] 192.168.37.158:445    - Error: 192.168.37.158: Metasploit::Framework::LoginScanner::Invalid Cred details can't be blank, Cred details can't be blank (Metasploit::Framework::LoginScanner::SMB)
[*] 192.168.37.158:445    - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

With changes:

```
msf5 > creds
Credentials
===========

host  origin  service  public         private  realm  private_type  JtR Format
----  ------  -------  ------         -------  -----  ------------  ----------
                       test_user                                    
                       another_user                                 
                       administrator                                

msf5 > use smb_login

Matching Modules
================

   #  Name                             Disclosure Date  Rank    Check  Description
   -  ----                             ---------------  ----    -----  -----------
   0  auxiliary/scanner/smb/smb_login                   normal  No     SMB Login Check Scanner


[*] Using auxiliary/scanner/smb/smb_login
msf5 auxiliary(scanner/smb/smb_login) > edit
msf5 auxiliary(scanner/smb/smb_login) > git diff
[*] exec: git diff

diff --git a/modules/auxiliary/scanner/smb/smb_login.rb b/modules/auxiliary/scanner/smb/smb_login.rb
index 0fbd2cf7f1..761f13aa72 100644
--- a/modules/auxiliary/scanner/smb/smb_login.rb
+++ b/modules/auxiliary/scanner/smb/smb_login.rb
@@ -112,6 +112,8 @@ class MetasploitModule < Msf::Auxiliary
 
     cred_collection = prepend_db_passwords(cred_collection)
     cred_collection = prepend_db_hashes(cred_collection)
+    cred_collection = prepend_db_usernames(cred_collection)
+    require 'pry';binding.pry
 
     @scanner.cred_details = cred_collection
 
msf5 auxiliary(scanner/smb/smb_login) > reload
[*] Reloading module...
msf5 auxiliary(scanner/smb/smb_login) > set rhosts 192.168.37.158
rhosts => 192.168.37.158
msf5 auxiliary(scanner/smb/smb_login) > set db_all_users true
db_all_users => true
msf5 auxiliary(scanner/smb/smb_login) > set smbpass password
smbpass => password
msf5 auxiliary(scanner/smb/smb_login) > run

[*] 192.168.37.158:445    - 192.168.37.158:445 - Starting SMB login bruteforce

From: /Users/space/metasploit-framework/modules/auxiliary/scanner/smb/smb_login.rb @ line 118 Msf::Modules::Auxiliary__Scanner__Smb__Smb_login::MetasploitModule#run_host:

    113:     cred_collection = prepend_db_passwords(cred_collection)
    114:     cred_collection = prepend_db_hashes(cred_collection)
    115:     cred_collection = prepend_db_usernames(cred_collection)
    116:     require 'pry';binding.pry
    117: 
 => 118:     @scanner.cred_details = cred_collection
    119: 
    120:     @scanner.scan! do |result|
    121:       case result.status
    122:       when Metasploit::Model::Login::Status::LOCKED_OUT
    123:         if datastore['ABORT_ON_LOCKOUT']

[1] pry(#<Msf::Modules::Auxiliary__Scanner__Smb__Smb_login::MetasploitModule>)> cred_collection
=> #<Metasploit::Framework::CredentialCollection:0x00007fb1df87fb98
 @additional_privates=[],
 @additional_publics=["test_user", "another_user", "administrator"],
 @blank_passwords=false,
 @pass_file=nil,
 @password="password",
 @prepended_creds=[],
 @realm=".",
 @user_as_pass=false,
 @user_file=nil,
 @username="",
 @userpass_file=nil>
[2] pry(#<Msf::Modules::Auxiliary__Scanner__Smb__Smb_login::MetasploitModule>)> exit
[-] 192.168.37.158:445    - 192.168.37.158:445 - Failed: '.\test_user:password',
[-] 192.168.37.158:445    - 192.168.37.158:445 - Failed: '.\another_user:password',
[+] 192.168.37.158:445    - 192.168.37.158:445 - Success: '.\administrator:password' Administrator
[*] 192.168.37.158:445    - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf5 auxiliary(scanner/smb/smb_login) > 
```