### PR TITLE
Fix incorrect method call when checking results

### DIFF
--- a/lib/msf/core/rpc/v10/rpc_module.rb
+++ b/lib/msf/core/rpc/v10/rpc_module.rb
@@ -539,7 +539,7 @@ class RPC_Module < RPC_Base
       end
     elsif self.framework.job_state_tracker.running? uuid
       {"status" => "running"}
-    elsif self.framework.job_state_tracker.waiting uuid
+    elsif self.framework.job_state_tracker.waiting? uuid
       {"status" => "ready"}
     else
       error(404, "Results not found for module instance #{uuid}")


### PR DESCRIPTION
### Before

An unknown job uuid would me marked as ready

```
curl --request POST \
  --url http://localhost:8081/api/v1/json-rpc \
  --header 'content-type: application/json' \
  --data '{
	"jsonrpc": "2.0",
	"method": "module.results",
	"id": 1,
	"params": ["invald_uuid"]
}'  | jq
```

```
{
  "jsonrpc": "2.0",
  "result": {
    "status": "ready"
  },
  "id": 1
}
```

### After

An unknown job uuid triggers an error

```
curl --request POST \
  --url http://localhost:8081/api/v1/json-rpc \
  --header 'content-type: application/json' \
  --data '{
	"jsonrpc": "2.0",
	"method": "module.results",
	"id": 1,
	"params": ["invald_uuid"]
}'  | jq
```

```
{
  "jsonrpc": "2.0",
  "error": {
    "code": -32000,
    "message": "Application server error: Results not found for module instance invald_uuid",
    "data": {
      "code": 404
    }
  },
  "id": 1
}
```

## Verification

List the steps needed to make sure this thing works

- [ ] Start `bundle exec thin --rackup msf-json-rpc.ru --address localhost --port 8081 --environment development --tag msf-json-rpc --debug start`
- [ ] Run `curl --request POST --url http://localhost:8081/api/v1/json-rpc --header 'content-type: application/json' --data '{ "jsonrpc": "2.0", "method": "module.results", "id": 1, "params": ["invald_uuid"] }'`
- [ ] **Verify** that the uuid does not exist: `{"jsonrpc":"2.0","error":{"code":-32000,"message":"Application server error: Results not found for module instance invald_uuid","data":{"code":404}},"id":1}`