### PR TITLE
Ensure that a module's setup failure is tracked successfully

### DIFF
--- a/lib/msf/base/simple/auxiliary.rb
+++ b/lib/msf/base/simple/auxiliary.rb
@@ -166,10 +166,10 @@ protected
     mod = ctx[0]
     run_uuid = ctx[1]
     begin
-      mod.setup
-      mod.framework.events.on_module_run(mod)
       begin
         mod.framework.job_state_tracker.start run_uuid
+        mod.setup
+        mod.framework.events.on_module_run(mod)
         result = block.call(mod)
         mod.framework.job_state_tracker.completed(run_uuid, result)
       rescue ::Exception => e

--- a/lib/msf/base/simple/exploit.rb
+++ b/lib/msf/base/simple/exploit.rb
@@ -219,8 +219,8 @@ module Exploit
     mod = ctx[0]
     run_uuid = ctx[1]
     begin
-      mod.setup
       mod.framework.job_state_tracker.start run_uuid
+      mod.setup
       result = mod.has_check? ? mod.check : Msf::Exploit::CheckCode::Unsupported
       mod.framework.job_state_tracker.completed(run_uuid, result)
     rescue => e


### PR DESCRIPTION
It's possible for a module's `setup` method to fail. In particular the http module can reach out to perform fingerprinting and fail immediately, causing the job tracking status to be stuck indefinitely in the waiting/ready state.

### Before

An exploit could fail during the `mod.setup` stage, for instance:

`[03/02/2020 18:45:19] [e(0)] core: Auxiliary failed: Msf::Exploit::Failed The target server did not respond to fingerprinting, use 'set FingerprintCheck false' to disable this check.`

And in this scenario, the job tracker wouldn't know that the job has started or failed.

### After

The job tracker is now aware of a module running earlier, and the rescue functionality is now in the right place to handle this error.
 
## Verification

List the steps needed to make sure this thing works

- [ ] Start `bundle exec thin --rackup msf-json-rpc.ru --address localhost --port 8081 --environment development --tag msf-json-rpc --debug start`
- [ ] Run curl:

```
curl --request POST \
  --url http://localhost:8081/api/v1/json-rpc \
  --header 'content-type: application/json' \
  --data '{
	"jsonrpc": "2.0",
	"method": "module.check",
	"id": 1,
	"params": [
		"exploit",
		"exploit/windows/oracle/client_system_analyzer_upload",
		{
			"RHOSTS": "x.x.x.x",
			"RPORT": "80"
		}
	]
}'
``` 

- [ ] Verify the job status isn't in limbo