### PR TITLE
Add module notes to my recent WordPress and OpenSMTPD modules

### DIFF
--- a/modules/exploits/unix/smtp/opensmtpd_mail_from_rce.rb
+++ b/modules/exploits/unix/smtp/opensmtpd_mail_from_rce.rb
@@ -38,7 +38,12 @@ class MetasploitModule < Msf::Exploit::Remote
         ]
       ],
       'DefaultTarget'  => 0,
-      'DefaultOptions' => {'PAYLOAD' => 'cmd/unix/reverse_netcat'}
+      'DefaultOptions' => {'PAYLOAD' => 'cmd/unix/reverse_netcat'},
+      'Notes'          => {
+        'Stability'    => [CRASH_SAFE],
+        'Reliability'  => [REPEATABLE_SESSION],
+        'SideEffects'  => [IOC_IN_LOGS]
+      }
     ))
 
     register_options([

--- a/modules/exploits/unix/webapp/wp_infinitewp_auth_bypass.rb
+++ b/modules/exploits/unix/webapp/wp_infinitewp_auth_bypass.rb
@@ -45,7 +45,12 @@ class MetasploitModule < Msf::Exploit::Remote
       'Privileged'     => false,
       'Targets'        => [['InfiniteWP Client < 1.9.4.5', {}]],
       'DefaultTarget'  => 0,
-      'DefaultOptions' => {'PAYLOAD' => 'php/meterpreter/reverse_tcp'}
+      'DefaultOptions' => {'PAYLOAD' => 'php/meterpreter/reverse_tcp'},
+      'Notes'          => {
+        'Stability'    => [CRASH_SAFE],
+        'Reliability'  => [REPEATABLE_SESSION],
+        'SideEffects'  => [IOC_IN_LOGS, CONFIG_CHANGES]
+      }
     ))
 
     register_options([


### PR DESCRIPTION
Oops, I forgot these. I probably copypasta'd an older module of mine without notes.

Fixes #12853 and #12889.