### PR TITLE
Filter payloads by platform and arch for msfvenom

### DIFF
--- a/lib/msf/core/module/platform_list.rb
+++ b/lib/msf/core/module/platform_list.rb
@@ -23,7 +23,7 @@ class Msf::Module::PlatformList
   #
   # Transformation method, just accept an array or a single entry.
   # This is just to make defining platform lists in a module more
-  # convenient, skape's a girl like that.
+  # convenient.
   #
   def self.transform(src)
     if (src.kind_of?(Array))

--- a/msfvenom
+++ b/msfvenom
@@ -318,7 +318,7 @@ def dump_formats
   "\n" + tbl1.to_s + "\n" + tbl2.to_s + "\n"
 end
 
-def dump_payloads
+def dump_payloads(platform = nil, arch = nil)
   init_framework(:module_types => [ :payload ])
   tbl = Rex::Text::Table.new(
     'Indent'  => 4,
@@ -329,9 +329,11 @@ def dump_payloads
       "Description"
     ])
 
-  framework.payloads.each_module { |name, mod|
-    tbl << [ name, mod.new.description.split.join(' ') ]
-  }
+  framework.payloads.each_module(
+    'Platform' => platform ? Msf::Module::PlatformList.transform(platform.split(',')) : nil,
+    'Arch'     => arch ? arch.split(',') : nil) do |name, mod|
+      tbl << [ name, mod.new.description.split.join(' ') ]
+  end
 
   "\n" + tbl.to_s + "\n"
 end
@@ -350,11 +352,11 @@ def dump_encoders(arch = nil)
   cnt = 0
 
   framework.encoders.each_module(
-    'Arch' => arch ? arch.split(',') : nil) { |name, mod|
+    'Arch' => arch ? arch.split(',') : nil) do |name, mod|
       tbl << [ name, mod.rank_to_s, mod.new.name ]
 
       cnt += 1
-    }
+  end
 
     (cnt > 0) ? "\n" + tbl.to_s + "\n" : "\nNo compatible encoders found.\n\n"
 end
@@ -370,9 +372,9 @@ def dump_nops
       "Description"
     ])
 
-  framework.nops.each_module { |name, mod|
+  framework.nops.each_module do |name, mod|
     tbl << [ name, mod.new.description.split.join(' ') ]
-  }
+  end
 
   "\n" + tbl.to_s + "\n"
 end
@@ -392,7 +394,7 @@ if generator_opts[:list]
   generator_opts[:list].each do |mod|
     case mod.downcase
     when "payloads", "payload", "p"
-      $stdout.puts dump_payloads
+      $stdout.puts dump_payloads(generator_opts[:platform], generator_opts[:arch])
     when "encoders", "encoder", "e"
       $stdout.puts dump_encoders(generator_opts[:arch])
     when "nops", "nop", "n"


### PR DESCRIPTION
Expected behavior when specifying platform or arch while listing payloads:

```
wvu@kharak:/rapid7/metasploit-framework:feature/msfvenom$ ./msfvenom -l payloads -a x64 --platform linux

Framework Payloads (559 total) [--payload <value>]
==================================================

    Name                                  Description
    ----                                  -----------
    generic/custom                        Use custom string or file as payload. Set either PAYLOADFILE or PAYLOADSTR.
    generic/shell_bind_tcp                Listen for a connection and spawn a command shell
    generic/shell_reverse_tcp             Connect back to attacker and spawn a command shell
    linux/x64/exec                        Execute an arbitrary command
    linux/x64/meterpreter/bind_tcp        Inject the mettle server payload (staged). Listen for a connection
    linux/x64/meterpreter/reverse_tcp     Inject the mettle server payload (staged). Connect back to the attacker
    linux/x64/meterpreter_reverse_http    Run the Meterpreter / Mettle server payload (stageless)
    linux/x64/meterpreter_reverse_https   Run the Meterpreter / Mettle server payload (stageless)
    linux/x64/meterpreter_reverse_tcp     Run the Meterpreter / Mettle server payload (stageless)
    linux/x64/pingback_bind_tcp           Accept a connection from attacker and report UUID (Linux x64)
    linux/x64/pingback_reverse_tcp        Connect back to attacker and report UUID (Linux x64)
    linux/x64/shell/bind_tcp              Spawn a command shell (staged). Listen for a connection
    linux/x64/shell/reverse_tcp           Spawn a command shell (staged). Connect back to the attacker
    linux/x64/shell_bind_ipv6_tcp         Listen for an IPv6 connection and spawn a command shell
    linux/x64/shell_bind_tcp              Listen for a connection and spawn a command shell
    linux/x64/shell_bind_tcp_random_port  Listen for a connection in a random port and spawn a command shell. Use nmap to discover the open port: 'nmap -sS target -p-'.
    linux/x64/shell_find_port             Spawn a shell on an established connection
    linux/x64/shell_reverse_ipv6_tcp      Connect back to attacker and spawn a command shell over IPv6
    linux/x64/shell_reverse_tcp           Connect back to attacker and spawn a command shell

wvu@kharak:/rapid7/metasploit-framework:feature/msfvenom$
```

Fixes #12250.