### PR TITLE
Add useful tips when starting up metasploit

### DIFF
--- a/lib/msf/ui.rb
+++ b/lib/msf/ui.rb
@@ -6,6 +6,7 @@ end
 
 require 'rex/ui'
 require 'msf/ui/banner'
+require 'msf/ui/tip'
 require 'msf/ui/driver'
 require 'msf/ui/common'
 require 'msf/ui/console'

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -69,6 +69,10 @@ class Core
     "-l" => [ false, "List all background threads."                   ],
     "-v" => [ false, "Print more detailed info.  Use with -i and -l"  ])
 
+  @@tip_opts = Rex::Parser::Arguments.new(
+    "-h" => [ false, "Help banner."                                   ],
+    "-l" => [ false, "List all available tips."                       ])
+
   @@connect_opts = Rex::Parser::Arguments.new(
     "-h" => [ false, "Help banner."                                   ],
     "-p" => [ true,  "List of proxies to use."                        ],
@@ -115,6 +119,7 @@ class Core
       "set"        => "Sets a context-specific variable to a value",
       "setg"       => "Sets a global variable to a value",
       "sleep"      => "Do nothing for the specified number of seconds",
+      "tip"        => "Show a useful productivity tip",
       "threads"    => "View and manipulate background threads",
       "unload"     => "Unload a framework plugin",
       "unset"      => "Unsets one or more context-specific variables",
@@ -217,24 +222,6 @@ class Core
   def cmd_banner(*args)
     banner  = "%cya" + Banner.to_s + "%clr\n\n"
 
-    # These messages should /not/ show up when you're on a git checkout;
-    # you're a developer, so you already know all this.
-    if (is_apt || binary_install)
-      content = [
-        "Trouble managing data? List, sort, group, tag and search your pentest data\nin Metasploit Pro -- learn more on http://rapid7.com/metasploit",
-        "Frustrated with proxy pivoting? Upgrade to layer-2 VPN pivoting with\nMetasploit Pro -- learn more on http://rapid7.com/metasploit",
-        "Payload caught by AV? Fly under the radar with Dynamic Payloads in\nMetasploit Pro -- learn more on http://rapid7.com/metasploit",
-        "Easy phishing: Set up email templates, landing pages and listeners\nin Metasploit Pro -- learn more on http://rapid7.com/metasploit",
-        "Taking notes in notepad? Have Metasploit Pro track & report\nyour progress and findings -- learn more on http://rapid7.com/metasploit",
-        "Tired of typing 'set RHOSTS'? Click & pwn with Metasploit Pro\nLearn more on http://rapid7.com/metasploit",
-        "Love leveraging credentials? Check out bruteforcing\nin Metasploit Pro -- learn more on http://rapid7.com/metasploit",
-        "Save 45% of your time on large engagements with Metasploit Pro\nLearn more on http://rapid7.com/metasploit",
-        "Validate lots of vulnerabilities to demonstrate exposure\nwith Metasploit Pro -- Learn more on http://rapid7.com/metasploit"
-      ]
-      banner << content.sample # Ruby 1.9-ism!
-      banner << "\n\n"
-    end
-
     avdwarn = nil
 
     stats       = framework.stats
@@ -248,6 +235,9 @@ class Core
     banner << ("+ -- --=[ %-#{padding}s]\n" % exp_aux_pos)
     banner << ("+ -- --=[ %-#{padding}s]\n" % pay_enc_nop)
     banner << ("+ -- --=[ %-#{padding}s]\n" % eva)
+
+    banner << "\n"
+    banner << "Metasploit tip: #{Tip.sample}\n"
 
     if ::Msf::Framework::EICARCorrupted
       avdwarn = []
@@ -265,6 +255,35 @@ class Core
       avdwarn.map{|line| print_error(line) }
     end
 
+  end
+
+  def cmd_tip_help
+    print_line "Usage: tip [options]"
+    print_line
+    print_line "Print a useful tip on how to use Metasploit"
+    print @@tip_opts.usage
+  end
+
+  #
+  # Display a useful productivity tip to the user.
+  #
+  def cmd_tip(*args)
+    if args.include?("-h")
+      cmd_tip_help
+    elsif args.include?("-l")
+      tbl = Table.new(
+        Table::Style::Default,
+        'Columns' => %w[Id Tip]
+      )
+
+      Tip.all.each_with_index do |tip, index|
+        tbl << [ index, tip ]
+      end
+
+      print(tbl.to_s)
+    else
+      print_line Tip.sample
+    end
   end
 
   def cmd_connect_help
@@ -2456,26 +2475,6 @@ class Core
       print_error("Invalid session identifier: #{session_id}") unless quiet
       nil
     end
-  end
-
-  # Determines if this is an apt-based install
-  def is_apt
-    File.exist?(File.expand_path(File.join(Msf::Config.install_root, '.apt')))
-  end
-
-  # Determines if we're a Metasploit Pro/Community/Express
-  # installation or a tarball/git checkout
-  #
-  # XXX This will need to be update when we embed framework as a gem in
-  # commercial packages
-  #
-  # @return [Boolean] true if we are a binary install
-  def binary_install
-    binary_paths = [
-      'C:/metasploit/apps/pro/msf3',
-      '/opt/metasploit/apps/pro/msf3'
-    ]
-    return binary_paths.include? Msf::Config.install_root
   end
 
   #

--- a/lib/msf/ui/tip.rb
+++ b/lib/msf/ui/tip.rb
@@ -1,0 +1,57 @@
+# -*- coding: binary -*-
+# frozen_string_literal: true
+
+module Msf
+  module Ui
+    ###
+    #
+    # Module that contains some most excellent tips.
+    #
+    ###
+    module Tip
+      def self.highlight(string)
+        "%grn#{string}%clr"
+      end
+
+      COMMON_TIPS = [
+        "View useful productivity tips with the #{highlight('tip')} command, or view them all with #{highlight('tip -l')}",
+        "Enable verbose logging with #{highlight('set VERBOSE true')}",
+        "When in a module, use #{highlight('back')} to go back to the top level prompt",
+        "Tired of setting RHOSTS for modules? Try globally setting it with #{highlight('setg RHOSTS x.x.x.x')}",
+        "Enable HTTP request and response logging with #{highlight('set HttpTrace true')}",
+        "You can upgrade a shell to a Meterpreter session on many platforms using #{highlight('sessions -u <session_id>')}",
+        "Open an interactive Ruby terminal with #{highlight('irb')}",
+        "Use the #{highlight('resource')} command to run commands from a file",
+        "To save all commands executed since start up to a file, use the #{highlight('makerc')} command",
+        "View advanced module options with #{highlight('advanced')}",
+        "You can use #{highlight('help')} to view all available commands",
+        "Use #{highlight('help <command>')} to learn more about any command",
+        "View a module's description using #{highlight('info')}, or view it in your browser with #{highlight('info -d')}",
+        "After running #{highlight('db_nmap')}, be sure to check out the result of #{highlight('hosts')} and #{highlight('services')}",
+        "Save the current environment with the #{highlight('save')} command, future console restarts will use this environment again",
+        "Search can apply complex filters such as #{highlight('search cve:2009 type:exploit')}, see all the filters with #{highlight('help search')}",
+        "Metasploit can be configured at startup, see #{highlight('msfconsole --help')} to learn more",
+        "Display the Framework log using the #{highlight('log')} command, learn more with #{highlight('help log')}",
+        "Adapter names can be used for IP params #{highlight('set LHOST eth0')}",
+      ].freeze
+      private_constant :COMMON_TIPS
+
+      DEVELOPER_TIPS = [
+        "Writing a custom module? After editing your module, why not try the #{highlight('reload')} command",
+        "Use the #{highlight('edit')} command to open the currently active module in your editor",
+      ].freeze
+      private_constant :DEVELOPER_TIPS
+
+      ALL_TIPS = COMMON_TIPS + DEVELOPER_TIPS
+      private_constant :ALL_TIPS
+
+      def self.all
+        ALL_TIPS
+      end
+
+      def self.sample
+        ALL_TIPS.sample
+      end
+    end
+  end
+end


### PR DESCRIPTION
When loading metasploit, we now offer useful productivity tips to the user. Hopefully this will help improve the discoverability of metasploit's awesome features:

![image](https://user-images.githubusercontent.com/60357436/76081882-03b8ba00-5fa2-11ea-8064-7b1128cd6826.png)

There's also the chance of the random tip suggesting how to learn more tips:

![image](https://user-images.githubusercontent.com/60357436/76081138-6446f780-5fa0-11ea-820e-0a6d6188710a.png)

![image](https://user-images.githubusercontent.com/60357436/76081149-67da7e80-5fa0-11ea-9751-68506086a63b.png)

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] **Verify** A random tip shows
- [x] Run `tip`
- [x] **Verify** a random tip is output
- [x] Run `tip -l`
- [x] **Verify** all tips are output
- [x] Run `tip -h`
- [x] **Verify** the help message is output