### PR TITLE
Fix PHP-FPM RCE module issue when calling check and exploit multiple times

### DIFF
--- a/modules/exploits/multi/http/php_fpm_rce.rb
+++ b/modules/exploits/multi/http/php_fpm_rce.rb
@@ -378,6 +378,8 @@ class MetasploitModule < Msf::Exploit::Remote
     print_good("Parameters found: QSL=#{@params[:qsl]}, customh_length=#{@params[:customh_length]}")
     print_good("Target is vulnerable!")
     CheckCode::Vulnerable
+  ensure
+    disconnect(client) if client&.conn?
   end
 
   def exploit


### PR DESCRIPTION
The client is left connected after calling `check`, whereas it is successful or not. This causes the exploit to fail when calling `exploit` next.

This fix simply ensure the client is always disconnected when leaving the `check` method.