### PR TITLE
Colorizes search text matches and module ranks 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -330,7 +330,7 @@ GEM
       rex-socket
       rex-text
     rex-struct2 (0.1.2)
-    rex-text (0.2.24)
+    rex-text (0.2.25)
     rex-zip (0.1.3)
       rex-text
     rkelly-remix (0.0.7)

--- a/lib/msf/ui/console/table_print/highlight_substring_styler.rb
+++ b/lib/msf/ui/console/table_print/highlight_substring_styler.rb
@@ -1,0 +1,32 @@
+# -*- coding: binary -*-
+
+module Msf
+  module Ui
+    module Console
+      module TablePrint
+        class HighlightSubstringStyler
+          COLOR = '%bgmag'
+
+          def initialize(substrings)
+            @substrings = substrings
+          end
+
+          def style(value)
+            value_cp = value.clone
+
+            @substrings.each do |s|
+              # Regex used to pull out matches and preserve case sensitivity
+              matches = value_cp.scan(%r{#{Regexp.escape(s)}}i)
+
+              matches.each do |m|
+                value_cp.gsub!(m, COLOR + m + '%clr')
+              end
+            end
+
+            value_cp
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/msf/ui/console/table_print/rank_formatter.rb
+++ b/lib/msf/ui/console/table_print/rank_formatter.rb
@@ -1,0 +1,20 @@
+# -*- coding: binary -*-
+
+module Msf
+  module Ui
+    module Console
+      module TablePrint
+        class RankFormatter
+
+          def format(rank)
+            if (rank.respond_to? :to_i) && (Msf::RankingName.key?(rank.to_i))
+              Msf::RankingName[rank.to_i]
+            else
+              rank
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/msf/ui/console/table_print/rank_styler.rb
+++ b/lib/msf/ui/console/table_print/rank_styler.rb
@@ -1,0 +1,23 @@
+# -*- coding: binary -*-
+
+module Msf
+  module Ui
+    module Console
+      module TablePrint
+        class RankStyler
+
+          def style(rank)
+            case rank
+            when Msf::RankingName[Msf::GreatRanking]
+              "%grn#{rank}%clr"
+            when Msf::RankingName[Msf::ExcellentRanking]
+              "%grn#{rank}%clr"
+            else
+              rank.to_s
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/msf/ui/console/table_print/highlight_substring_styler_spec.rb
+++ b/spec/lib/msf/ui/console/table_print/highlight_substring_styler_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+require 'msf/ui/console/table_print/highlight_substring_styler'
+
+RSpec.describe Msf::Ui::Console::TablePrint::HighlightSubstringStyler do
+  describe 'style' do
+    it 'should highlight a given sub-string magenta' do
+      str = ('A' * 5) + ('B' * 3) + ('A' * 5)
+      styler = described_class.new(['BBB'])
+
+      expect(styler.style(str)).to eql "AAAAA%bgmagBBB%clrAAAAA"
+    end
+
+    it 'should highlight a multiple given sub-strings magenta' do
+      str = ('A' * 5) + ('B' * 3) + ('A' * 5) + ('C' * 3)
+      styler = described_class.new(%w(BBB CCC))
+
+      expect(styler.style(str)).to eql "AAAAA%bgmagBBB%clrAAAAA%bgmagCCC%clr"
+    end
+
+    it 'should highlight a multiple given sub-strings magenta regardless of case' do
+      str = ('A' * 5) + ('B' * 3) + ('A' * 5) + ('C' * 3)
+      styler = described_class.new(%w(BbB ccC))
+
+      expect(styler.style(str)).to eql "AAAAA%bgmagBBB%clrAAAAA%bgmagCCC%clr"
+    end
+  end
+end

--- a/spec/lib/msf/ui/console/table_print/rank_formatter_spec.rb
+++ b/spec/lib/msf/ui/console/table_print/rank_formatter_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+require 'msf/ui/console/table_print/rank_formatter'
+
+RSpec.describe Msf::Ui::Console::TablePrint::RankFormatter do
+  describe 'format' do
+    it 'should return the plaintext equivalent of all numerical rankings' do
+      formatter = described_class.new
+
+      expect(formatter.format(Msf::ManualRanking)).to eql Msf::RankingName[Msf::ManualRanking]
+      expect(formatter.format(Msf::LowRanking)).to eql Msf::RankingName[Msf::LowRanking]
+      expect(formatter.format(Msf::AverageRanking)).to eql Msf::RankingName[Msf::AverageRanking]
+      expect(formatter.format(Msf::NormalRanking)).to eql Msf::RankingName[Msf::NormalRanking]
+      expect(formatter.format(Msf::GoodRanking)).to eql Msf::RankingName[Msf::GoodRanking]
+      expect(formatter.format(Msf::GreatRanking)).to eql Msf::RankingName[Msf::GreatRanking]
+      expect(formatter.format(Msf::ExcellentRanking)).to eql Msf::RankingName[Msf::ExcellentRanking]
+    end
+
+    it 'should return an unrecognized numerical ranking unchanged' do
+      formatter = described_class.new
+
+      expect(formatter.format(42)).to eql 42
+      expect(formatter.format([])).to eql []
+      expect(formatter.format({})).to eql Hash.new
+    end
+  end
+end

--- a/spec/lib/msf/ui/console/table_print/rank_styler_spec.rb
+++ b/spec/lib/msf/ui/console/table_print/rank_styler_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+require 'msf/ui/console/table_print/rank_styler'
+
+RSpec.describe Msf::Ui::Console::TablePrint::RankStyler do
+  describe 'style' do
+    it 'should color all ranks above Good green' do
+      str1 = Msf::RankingName[Msf::GreatRanking]
+      str2 = Msf::RankingName[Msf::ExcellentRanking]
+      styler = described_class.new
+
+      expect(styler.style(str1)).to eql "%grngreat%clr"
+      expect(styler.style(str2)).to eql "%grnexcellent%clr"
+    end
+
+
+    it 'should return all ranks below Good unchanged' do
+      str1 = Msf::RankingName[Msf::ManualRanking]
+      str2 = Msf::RankingName[Msf::LowRanking]
+      str3 = Msf::RankingName[Msf::AverageRanking ]
+      str4 = Msf::RankingName[Msf::NormalRanking]
+      str5 = Msf::RankingName[Msf::GoodRanking]
+      styler = described_class.new
+
+      expect(styler.style(str1)).to eql str1
+      expect(styler.style(str2)).to eql str2
+      expect(styler.style(str3)).to eql str3
+      expect(styler.style(str4)).to eql str4
+      expect(styler.style(str5)).to eql str5
+    end
+  end
+
+
+end


### PR DESCRIPTION
Reliant on changes to [rex-text tables](https://github.com/rapid7/rex-text/pull/27).

Adds different colors for search terms and ranks:

![image](https://user-images.githubusercontent.com/60357436/77350485-7eb8f900-6d34-11ea-86bd-6b7f6ebf4c26.png)

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `search crosschex`
- [ ] **Verify** crosschex is highlighted in both capitalizations 

