### PR TITLE
Cut unknown command handling time in half

### DIFF
--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -503,14 +503,16 @@ protected
         end
         self.busy = false
         return
-      elsif framework.modules.create(method)
-        super
-        if prompt_yesno "This is a module we can load. Do you want to use #{method}?"
-          run_single "use #{method}"
-        end
-
-        return
       end
+    end
+
+    if framework.modules.create(method)
+      super
+      if prompt_yesno "This is a module we can load. Do you want to use #{method}?"
+        run_single "use #{method}"
+      end
+
+      return
     end
 
     super


### PR DESCRIPTION
When entering invalid commands to the metasploit console, it can take ~2 seconds to finally output the message:

```
[-] Unknown command: foo.
```

It seems like the majority of this time is spent checking to see if the invalid command is a module name. On closer inspection, it seemed like this check is being ran twice. This PR reduces the double lookup.

It's a separate effort to investigate why creating a missing module is so slow 🕵 

_Edit_: It seems like the full second is spent calling off to the recalculate method within the module manager's `create(name, aliased_as: nil)` method. This seems to get recalculated on every missing command call:

```
Msf::PayloadSet recalculate time = 0.960764s
```

### Before

When putting a timer around the `unknown_command` method:

```
Time: 2.104432
```

### After

```
Time: 0.905397
```

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] **Verify** valid commands work
- [x] **Verify** missing commands work
- [x] **Verify** a module name prompts the user to load it
