### PR TITLE
Use VHOST instead of RHOST

### DIFF
--- a/modules/exploits/windows/http/exchange_ecp_viewstate.rb
+++ b/modules/exploits/windows/http/exchange_ecp_viewstate.rb
@@ -141,7 +141,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'vars_post'     => {
         'password'    => datastore['PASSWORD'],
         'flags'       => '4',
-        'destination' => full_uri(normalize_uri(target_uri.path, 'owa')),
+        'destination' => full_uri(normalize_uri(target_uri.path, 'owa'), vhost_uri: true),
         'username'    => datastore['USERNAME']
       }
     })


### PR DESCRIPTION
The 'vhost_uri: true' enables the successfully exploitation of this vulnerability in environments where you can't use an IP address (RHOST) to access the OWA web page.

#11485