### PR TITLE
Add hex-noslashes to Rex::Proto::Http::Client

### DIFF
--- a/lib/rex/proto/http/client.rb
+++ b/lib/rex/proto/http/client.rb
@@ -42,7 +42,7 @@ class Client
 
     # XXX: This info should all be controlled by ClientRequest
     self.config_types = {
-      'uri_encode_mode'        => ['hex-normal', 'hex-all', 'hex-random', 'u-normal', 'u-random', 'u-all'],
+      'uri_encode_mode'        => ['hex-normal', 'hex-all', 'hex-random', 'hex-noslashes', 'u-normal', 'u-random', 'u-all'],
       'uri_encode_count'       => 'integer',
       'uri_full_url'           => 'bool',
       'pad_method_uri_count'   => 'integer',


### PR DESCRIPTION
```
msf5 exploit([redacted]) > set http::uri_encode_mode hex-
set http::uri_encode_mode hex-all        set http::uri_encode_mode hex-normal     set http::uri_encode_mode hex-noslashes  set http::uri_encode_mode hex-random
msf5 exploit([redacted]) > set http::uri_encode_mode hex-noslashes
http::uri_encode_mode => hex-noslashes
msf5 exploit([redacted]) > run

The specified value for uri_encode_mode is not one of the valid choices
[-] Exploit failed: Rex::RuntimeError The specified value for uri_encode_mode is not one of the valid choices
[*] Exploit completed, but no session was created.
msf5 exploit([redacted]) >
```

Fixes #3353.