### PR TITLE
rollback simplecov version due to error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'sqlite3', '~>1.3.0'
 # separate from test as simplecov is not run on travis-ci
 group :coverage do
   # code coverage for tests
-  gem 'simplecov'
+  gem 'simplecov', '0.18.2'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -384,7 +384,7 @@ GEM
     sawyer (0.8.2)
       addressable (>= 2.3.5)
       faraday (> 0.8, < 2.0)
-    simplecov (0.18.5)
+    simplecov (0.18.2)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
     simplecov-html (0.12.2)
@@ -435,7 +435,7 @@ DEPENDENCIES
   rspec-rails
   rspec-rerun
   rubocop
-  simplecov
+  simplecov (= 0.18.2)
   sqlite3 (~> 1.3.0)
   swagger-blocks
   timecop


### PR DESCRIPTION
The issue found looks similar to https://stackoverflow.com/questions/55631720/simplecov-rcov-is-throwing-a-encodingundefinedconversionerror.
Also https://github.com/fguillen/simplecov-rcov/issues/20 suggest may be related to file open permissions set.

When running rspec test with `bundle exec rake spec` the following stack traces is seen.

```
Traceback (most recent call last):
	27: from /home/msfuser/.rvm/gems/ruby-2.6.5@metasploit-framework/gems/simplecov-0.18.5/lib/simplecov/defaults.rb:27:in `block in <top (required)>'
	26: from /home/msfuser/.rvm/gems/ruby-2.6.5@metasploit-framework/gems/simplecov-0.18.5/lib/simplecov.rb:202:in `at_exit_behavior'
	25: from /home/msfuser/.rvm/gems/ruby-2.6.5@metasploit-framework/gems/simplecov-0.18.5/lib/simplecov.rb:214:in `run_exit_tasks!'
	24: from /home/msfuser/.rvm/gems/ruby-2.6.5@metasploit-framework/gems/simplecov-0.18.5/lib/simplecov/configuration.rb:196:in `block in at_exit'
	23: from /home/msfuser/.rvm/gems/ruby-2.6.5@metasploit-framework/gems/simplecov-0.18.5/lib/simplecov/result.rb:49:in `format!'
	22: from /home/msfuser/.rvm/gems/ruby-2.6.5@metasploit-framework/gems/simplecov-html-0.12.2/lib/simplecov-html.rb:28:in `format'
	21: from /home/msfuser/.rvm/gems/ruby-2.6.5@metasploit-framework/gems/simplecov-html-0.12.2/lib/simplecov-html.rb:28:in `open'
	20: from /home/msfuser/.rvm/gems/ruby-2.6.5@metasploit-framework/gems/simplecov-html-0.12.2/lib/simplecov-html.rb:29:in `block in format'
	19: from /home/msfuser/.rvm/rubies/ruby-2.6.5/lib/ruby/2.6.0/erb.rb:901:in `result'
	18: from /home/msfuser/.rvm/rubies/ruby-2.6.5/lib/ruby/2.6.0/erb.rb:901:in `eval'
	17: from (erb):8:in `block in format'
	16: from /home/msfuser/.rvm/gems/ruby-2.6.5@metasploit-framework/gems/simplecov-0.18.5/lib/simplecov/file_list.rb:73:in `covered_percent'
	15: from /home/msfuser/.rvm/gems/ruby-2.6.5@metasploit-framework/gems/simplecov-0.18.5/lib/simplecov/file_list.rb:27:in `coverage_statistics'
	14: from /home/msfuser/.rvm/gems/ruby-2.6.5@metasploit-framework/gems/simplecov-0.18.5/lib/simplecov/file_list.rb:104:in `compute_coverage_statistics'
	13: from /home/msfuser/.rvm/gems/ruby-2.6.5@metasploit-framework/gems/simplecov-0.18.5/lib/simplecov/file_list.rb:104:in `each_with_object'
	12: from /home/msfuser/.rvm/gems/ruby-2.6.5@metasploit-framework/gems/simplecov-0.18.5/lib/simplecov/file_list.rb:104:in `each'
	11: from /home/msfuser/.rvm/gems/ruby-2.6.5@metasploit-framework/gems/simplecov-0.18.5/lib/simplecov/file_list.rb:105:in `block in compute_coverage_statistics'
	10: from /home/msfuser/.rvm/gems/ruby-2.6.5@metasploit-framework/gems/simplecov-0.18.5/lib/simplecov/source_file.rb:35:in `coverage_statistics'
	 9: from /home/msfuser/.rvm/gems/ruby-2.6.5@metasploit-framework/gems/simplecov-0.18.5/lib/simplecov/source_file.rb:333:in `line_coverage_statistics'
	 8: from /home/msfuser/.rvm/gems/ruby-2.6.5@metasploit-framework/gems/simplecov-0.18.5/lib/simplecov/source_file.rb:241:in `lines_strength'
	 7: from /home/msfuser/.rvm/gems/ruby-2.6.5@metasploit-framework/gems/simplecov-0.18.5/lib/simplecov/source_file.rb:43:in `lines'
	 6: from /home/msfuser/.rvm/gems/ruby-2.6.5@metasploit-framework/gems/simplecov-0.18.5/lib/simplecov/source_file.rb:224:in `build_lines'
	 5: from /home/msfuser/.rvm/gems/ruby-2.6.5@metasploit-framework/gems/simplecov-0.18.5/lib/simplecov/source_file.rb:28:in `src'
	 4: from /home/msfuser/.rvm/gems/ruby-2.6.5@metasploit-framework/gems/simplecov-0.18.5/lib/simplecov/source_file.rb:181:in `load_source'
	 3: from /home/msfuser/.rvm/gems/ruby-2.6.5@metasploit-framework/gems/simplecov-0.18.5/lib/simplecov/source_file.rb:181:in `open'
	 2: from /home/msfuser/.rvm/gems/ruby-2.6.5@metasploit-framework/gems/simplecov-0.18.5/lib/simplecov/source_file.rb:189:in `block in load_source'
	 1: from /home/msfuser/.rvm/gems/ruby-2.6.5@metasploit-framework/gems/simplecov-0.18.5/lib/simplecov/source_file.rb:202:in `read_lines'
/home/msfuser/.rvm/gems/ruby-2.6.5@metasploit-framework/gems/simplecov-0.18.5/lib/simplecov/source_file.rb:202:in `readlines': U+2713 from UTF-8 to ASCII-8BIT (Encoding::UndefinedConversionError)
/home/msfuser/.rvm/rubies/ruby-2.6.5/bin/ruby -I/home/msfuser/.rvm/gems/ruby-2.6.5@metasploit-framework/gems/rspec-core-3.9.1/lib:/home/msfuser/.rvm/gems/ruby-2.6.5@metasploit-framework/gems/rspec-support-3.9.2/lib /home/msfuser/.rvm/gems/ruby-2.6.5@metasploit-framework/gems/rspec-core-3.9.1/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb failed
```

Since we expect to support non-ASCII characters in some locations locking the version until a solution is found.  The issue linked above suggest that a test helper may be able to override the open permissions, however since `rake spec` in Travis runs without the simplecov gem this may require some finesse to implement.

## Verification

List the steps needed to make sure this thing works

- [x] `bundle exec rake spec`
- [x] **Verify** tests and coverage complete without error.

