### PR TITLE
Add profiling tools

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,10 @@ group :development do
   gem 'pry-byebug'
   # module documentation
   gem 'octokit'
+  # memory profiling
+  gem 'memory_profiler'
+  # cpu profiling
+  gem 'ruby-prof'
   # Metasploit::Aggregator external session proxy
   # disabled during 2.5 transition until aggregator is available
   #gem 'metasploit-aggregator'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -194,6 +194,7 @@ GEM
     loofah (2.4.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
+    memory_profiler (0.9.14)
     metasm (1.0.4)
     metasploit-concern (2.0.5)
       activemodel (~> 4.2.6)
@@ -373,6 +374,7 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
     ruby-macho (2.2.0)
+    ruby-prof (1.3.0)
     ruby-progressbar (1.10.1)
     ruby-rc4 (0.1.5)
     ruby_smb (1.1.0)
@@ -427,6 +429,7 @@ PLATFORMS
 DEPENDENCIES
   factory_bot_rails
   fivemat
+  memory_profiler
   metasploit-framework!
   octokit
   pry-byebug
@@ -435,6 +438,7 @@ DEPENDENCIES
   rspec-rails
   rspec-rerun
   rubocop
+  ruby-prof
   simplecov (= 0.18.2)
   sqlite3 (~> 1.3.0)
   swagger-blocks

--- a/lib/metasploit/framework/command/console.rb
+++ b/lib/metasploit/framework/command/console.rb
@@ -39,56 +39,12 @@ class Metasploit::Framework::Command::Console < Metasploit::Framework::Command::
     end
   end
 
-  def start_profiler
-    root_path = Pathname.new(Msf::Config::install_root)
-    tmp_directory = root_path.join('tmp')
-    timestamp = Time.now.strftime('%Y%m%d%H%M%S')
-
-    if ENV['METASPLOIT_CPU_PROFILE']
-      require 'ruby-prof'
-
-      dump_path = tmp_directory.join("#{timestamp}-cpu")
-      ::FileUtils.mkdir_p(dump_path)
-
-      RubyProf.start
-
-      at_exit do
-        puts "Generating CPU dump #{dump_path}"
-        result = RubyProf.stop
-        printer = RubyProf::MultiPrinter.new(result, [:flat, :graph_html, :tree, :stack])
-        printer.print(path: dump_path)
-
-        Rex::Compat.open_file(dump_path)
-      end
-    end
-
-    if ENV['METASPLOIT_MEMORY_PROFILE']
-      require 'memory_profiler'
-
-      ::FileUtils.mkdir_p(tmp_directory)
-      report_name = "#{timestamp}-memory.profile"
-      report_path = tmp_directory.join(report_name)
-
-      MemoryProfiler.start
-
-      at_exit do
-        puts "Generating memory report #{dump_path}"
-        report = MemoryProfiler.stop
-        report.pretty_print(to_file: report_path)
-
-        puts "Memory report saved to #{report_path}"
-        Rex::Compat.open_file(report_path)
-      end
-    end
-  end
-
   def start
     case parsed_options.options.subcommand
     when :version
       $stderr.puts "Framework Version: #{Metasploit::Framework::VERSION}"
     else
       spinner unless parsed_options.options.console.quiet
-      start_profiler
       driver.run
     end
   end

--- a/lib/metasploit/framework/profiler.rb
+++ b/lib/metasploit/framework/profiler.rb
@@ -1,0 +1,64 @@
+require 'pathname'
+require 'tmpdir'
+
+module Metasploit
+  module Framework
+    module Profiler
+      class << self
+        def start
+          return unless record_cpu? || record_memory?
+
+          timestamp = Time.now.strftime('%Y%m%d%H%M%S')
+          tmp_directory = Dir.mktmpdir("msf-profile-#{timestamp}")
+          tmp_path = Pathname.new(tmp_directory)
+
+          if record_cpu?
+            require 'ruby-prof'
+            require 'rex/compat'
+
+            dump_path = tmp_path.join("cpu")
+            ::FileUtils.mkdir_p(dump_path)
+
+            RubyProf.start
+
+            at_exit do
+              puts "Generating CPU dump #{dump_path}"
+              result = RubyProf.stop
+              printer = RubyProf::MultiPrinter.new(result, %i[flat graph_html tree stack])
+              printer.print(path: dump_path)
+
+              Rex::Compat.open_file(dump_path)
+            end
+          end
+
+          if record_memory?
+            require 'memory_profiler'
+            require 'rex/compat'
+
+            report_name = "memory.profile"
+            report_path = tmp_path.join(report_name)
+
+            MemoryProfiler.start
+
+            at_exit do
+              puts "Generating memory report #{dump_path}"
+              report = MemoryProfiler.stop
+              report.pretty_print(to_file: report_path)
+
+              puts "Memory report saved to #{report_path}"
+              Rex::Compat.open_file(report_path)
+            end
+          end
+        end
+
+        def record_cpu?
+          ENV['METASPLOIT_CPU_PROFILE']
+        end
+
+        def record_memory?
+          ENV['METASPLOIT_MEMORY_PROFILE']
+        end
+      end
+    end
+  end
+end

--- a/msfconsole
+++ b/msfconsole
@@ -5,44 +5,10 @@
 # framework.
 #
 
-#
-# Standard Library
-#
-
 require 'pathname'
 
-if ENV['METASPLOIT_FRAMEWORK_PROFILE'] == 'true'
-  gem 'perftools.rb'
-  require 'perftools'
-
-  formatted_time = Time.now.strftime('%Y%m%d%H%M%S')
-  root = Pathname.new(__FILE__).parent
-  profile_pathname = root.join('tmp', 'profiles', 'msfconsole', formatted_time)
-
-  profile_pathname.parent.mkpath
-  PerfTools::CpuProfiler.start(profile_pathname.to_path)
-
-  at_exit {
-    PerfTools::CpuProfiler.stop
-
-    puts "Generating pdf"
-
-    pdf_path = "#{profile_pathname}.pdf"
-
-    if Bundler.clean_system("pprof.rb --pdf #{profile_pathname} > #{pdf_path}")
-      puts "PDF saved to #{pdf_path}"
-
-      Rex::Compat.open_file(pdf_path)
-    end
-  }
-end
-
-#
-# Project
-#
-
-# @see https://github.com/rails/rails/blob/v3.2.17/railties/lib/rails/generators/rails/app/templates/script/rails#L3-L5
 begin
+  # @see https://github.com/rails/rails/blob/v3.2.17/railties/lib/rails/generators/rails/app/templates/script/rails#L3-L5
   require Pathname.new(__FILE__).realpath.expand_path.parent.join('config', 'boot')
   require 'metasploit/framework/command/console'
   require 'msf/core/payload_generator'

--- a/msfconsole
+++ b/msfconsole
@@ -10,8 +10,10 @@ require 'pathname'
 begin
   # @see https://github.com/rails/rails/blob/v3.2.17/railties/lib/rails/generators/rails/app/templates/script/rails#L3-L5
   require Pathname.new(__FILE__).realpath.expand_path.parent.join('config', 'boot')
+  require 'metasploit/framework/profiler'
   require 'metasploit/framework/command/console'
   require 'msf/core/payload_generator'
+  Metasploit::Framework::Profiler.start
   Metasploit::Framework::Command::Console.start
 rescue Interrupt
   puts "\nAborting..."

--- a/msfvenom
+++ b/msfvenom
@@ -8,13 +8,17 @@ class UsageError < MsfVenomError; end
 require 'optparse'
 require 'timeout'
 
-def require_deps
-  msfbase = __FILE__
-  while File.symlink?(msfbase)
-    msfbase = File.expand_path(File.readlink(msfbase), File.dirname(msfbase))
-  end
+msfbase = __FILE__
+while File.symlink?(msfbase)
+  msfbase = File.expand_path(File.readlink(msfbase), File.dirname(msfbase))
+end
 
-  $:.unshift(File.expand_path(File.join(File.dirname(msfbase), 'lib')))
+$:.unshift(File.expand_path(File.join(File.dirname(msfbase), 'lib')))
+
+require 'metasploit/framework/profiler'
+Metasploit::Framework::Profiler.start
+
+def require_deps
   require 'msfenv'
 
   $:.unshift(ENV['MSF_LOCAL_LIB']) if ENV['MSF_LOCAL_LIB']


### PR DESCRIPTION
Continuing on the awesome work from #12652 this PR adds profiling tools for CPU and memory. 

## METASPLOIT_CPU_PROFILE

Generates various useful reports.

### Stack view

![image](https://user-images.githubusercontent.com/60357436/76421882-3e549500-639c-11ea-8e5d-804d654f1497.png)

### Graph view

![image](https://user-images.githubusercontent.com/60357436/76421926-4e6c7480-639c-11ea-82a3-2dabe8dc3ad6.png)

There is also an ascii flat view.

*Note* This uses [ruby-prof](https://ruby-prof.github.io/) under the hood, to generate a different style of report you can supply additional ENV args. The default value is RubyProf::WALL_TIME. You may can specify the measure mode by using the RUBY_PROF_MEASURE_MODE environment variable:

```
export RUBY_PROF_MEASURE_MODE=wall
export RUBY_PROF_MEASURE_MODE=process
export RUBY_PROF_MEASURE_MODE=allocations
export RUBY_PROF_MEASURE_MODE=memory
```

## METASPLOIT_MEMORY_PROFILE

Although the cpu/ruby-prof report can give similar insights, the memory profile can be easier to understand:

```
Total allocated: 359069342 bytes (4122901 objects)
Total retained:  56207062 bytes (367424 objects)

allocated memory by gem
-----------------------------------
 198248069  metasploit-framework/lib
  38101324  activesupport-4.2.11.1
  37770426  pathname
  16573387  aws-sdk-ec2-1.146.0

...
```

## Enabling

After setting the environment variables, metasploit will now begin profiling.

- `METASPLOIT_CPU_PROFILE=true ./msfconsole`
- `METASPLOIT_MEMORY_PROFILE=true ./msfconsole`

The report will be generated when metasploit exits.

## Verification

List the steps needed to make sure this thing works

- [ ] Verify `METASPLOIT_CPU_PROFILE=true ./msfconsole -x 'exit'` creates various CPU profile reports
- [ ] Verify `METASPLOIT_MEMORY_PROFILE=true ./msfconsole -x 'exit'` creates various memory profile reports

- [ ] Verify `METASPLOIT_CPU_PROFILE=true ./msfvenom -x 'exit'` creates various CPU profile reports
- [ ] Verify `METASPLOIT_MEMORY_PROFILE=true ./msfvenom -x 'exit'` creates various memory profile reports
