### PR TITLE
Limit Option Sizes When Appropriate

### DIFF
--- a/lib/msf/core/exceptions.rb
+++ b/lib/msf/core/exceptions.rb
@@ -302,4 +302,27 @@ class PluginLoadError < RuntimeError
   end
 end
 
+##
+#
+# This exception is raised if an payload option string exceeds the maximum allowed size
+# during the payload generation.
+#
+##
+  class PayloadItemSizeError < ArgumentError
+    include Exception
+
+    def initialize(item = nil, max_size = nil)
+      @item = item
+      @maxSize = max_size
+    end
+
+    def to_s
+      "Option value: #{item.slice(0..30)} is to big (Current length: #{item.length}). Maximum length: #{maxSize}"
+    end
+
+    attr_reader :item # The content of the payload option (for example a URL)
+    attr_reader :maxSize # The maximum allowed size of the payload option
+  end
+
+
 end

--- a/lib/msf/core/exceptions.rb
+++ b/lib/msf/core/exceptions.rb
@@ -304,25 +304,24 @@ end
 
 ##
 #
-# This exception is raised if an payload option string exceeds the maximum allowed size
-# during the payload generation.
+# This exception is raised if a payload option string exceeds the maximum
+# allowed size during the payload generation.
 #
 ##
-  class PayloadItemSizeError < ArgumentError
-    include Exception
+class PayloadItemSizeError < ArgumentError
+  include Exception
 
-    def initialize(item = nil, max_size = nil)
-      @item = item
-      @maxSize = max_size
-    end
-
-    def to_s
-      "Option value: #{item.slice(0..30)} is to big (Current length: #{item.length}). Maximum length: #{maxSize}"
-    end
-
-    attr_reader :item # The content of the payload option (for example a URL)
-    attr_reader :maxSize # The maximum allowed size of the payload option
+  def initialize(item = nil, max_size = nil)
+    @item = item
+    @max_size = max_size
   end
 
+  def to_s
+    "Option value: #{item.slice(0..30)} is too big (Current length: #{item.length}, Maximum length: #{max_size})."
+  end
+
+  attr_reader :item # The content of the payload option (for example a URL)
+  attr_reader :max_size # The maximum allowed size of the payload option
+end
 
 end

--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -69,9 +69,10 @@ module ReverseHttp
           'When OverrideRequestHost is set, use this value as the scheme for secondary requests, e.g http or https'
         ),
         OptString.new('HttpUserAgent',
-          'The user-agent that the payload should use for communication',
+          'The user-agent that the payload should use for communication. (Max length 127 characters)',
           default: Rex::UserAgent.shortest,
-          aliases: ['MeterpreterUserAgent']
+          aliases: ['MeterpreterUserAgent'],
+          max_length: 256
         ),
         OptString.new('HttpServerName',
           'The server header that the handler will send in response to requests',

--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -69,7 +69,7 @@ module ReverseHttp
           'When OverrideRequestHost is set, use this value as the scheme for secondary requests, e.g http or https'
         ),
         OptString.new('HttpUserAgent',
-          'The user-agent that the payload should use for communication.',
+          'The user-agent that the payload should use for communication',
           default: Rex::UserAgent.shortest,
           aliases: ['MeterpreterUserAgent'],
           max_length: 255

--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -69,10 +69,10 @@ module ReverseHttp
           'When OverrideRequestHost is set, use this value as the scheme for secondary requests, e.g http or https'
         ),
         OptString.new('HttpUserAgent',
-          'The user-agent that the payload should use for communication. (Max length 127 characters)',
+          'The user-agent that the payload should use for communication.',
           default: Rex::UserAgent.shortest,
           aliases: ['MeterpreterUserAgent'],
-          max_length: 256
+          max_length: 127
         ),
         OptString.new('HttpServerName',
           'The server header that the handler will send in response to requests',

--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -72,7 +72,7 @@ module ReverseHttp
           'The user-agent that the payload should use for communication.',
           default: Rex::UserAgent.shortest,
           aliases: ['MeterpreterUserAgent'],
-          max_length: 127
+          max_length: 255
         ),
         OptString.new('HttpServerName',
           'The server header that the handler will send in response to requests',

--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -72,7 +72,7 @@ module ReverseHttp
           'The user-agent that the payload should use for communication',
           default: Rex::UserAgent.shortest,
           aliases: ['MeterpreterUserAgent'],
-          max_length: 255
+          max_length: Rex::Payloads::Meterpreter::Config::UA_SIZE - 1
         ),
         OptString.new('HttpServerName',
           'The server header that the handler will send in response to requests',

--- a/lib/msf/core/opt.rb
+++ b/lib/msf/core/opt.rb
@@ -85,10 +85,12 @@ module Msf
           aliases: ['PayloadProxyPort']
         ),
         OptString.new('HttpProxyUser', 'An optional proxy server username',
-          aliases: ['PayloadProxyUser']
+          aliases: ['PayloadProxyUser'],
+          max_length: Rex::Payloads::Meterpreter::Config::PROXY_USER_SIZE - 1
         ),
         OptString.new('HttpProxyPass', 'An optional proxy server password',
-          aliases: ['PayloadProxyPass']
+          aliases: ['PayloadProxyPass'],
+          max_length: Rex::Payloads::Meterpreter::Config::PROXY_PASS_SIZE - 1
         ),
         OptEnum.new('HttpProxyType', 'The type of HTTP proxy',
           enums: ['HTTP', 'SOCKS'],

--- a/lib/msf/core/opt_base.rb
+++ b/lib/msf/core/opt_base.rb
@@ -31,7 +31,7 @@ module Msf
       self.advanced = false
       self.evasion  = false
       self.aliases  = aliases
-      self.maxLength = Integer(max_length)
+      self.max_length = Integer(max_length)
 
       if attrs.is_a?(String) || attrs.length == 0
         self.required = required
@@ -152,8 +152,8 @@ module Msf
     # Returns true if the value supplied is longer then the max allowed length
     #
     def max_length_value?(value)
-      if !value.nil? && maxLength != 0
-        value.length > maxLength
+      if !value.nil? && max_length != 0
+        value.length > max_length
       end
     end
 
@@ -204,7 +204,7 @@ module Msf
     # 
     # The max length of the input value
     #
-    attr_accessor :maxLength
+    attr_accessor :max_length
     
     protected
 

--- a/lib/msf/core/opt_base.rb
+++ b/lib/msf/core/opt_base.rb
@@ -26,11 +26,12 @@ module Msf
     # also be a string as standin for the required description field.
     #
     def initialize(in_name, attrs = [],
-                   required: false, desc: nil, default: nil, enums: [], regex: nil, aliases: [])
+                   required: false, desc: nil, default: nil, enums: [], regex: nil, aliases: [], max_length: 0)
       self.name     = in_name
       self.advanced = false
       self.evasion  = false
       self.aliases  = aliases
+      self.maxLength = Integer(max_length)
 
       if attrs.is_a?(String) || attrs.length == 0
         self.required = required
@@ -55,6 +56,10 @@ module Msf
         regex_temp    = attrs[4] || regex
       end
 
+      if max_length != 0
+        self.desc += " Max parameter length: #{max_length} characters"
+      end
+      
       if regex_temp
         # convert to string
         regex_temp = regex_temp.to_s if regex_temp.is_a? Regexp
@@ -144,6 +149,15 @@ module Msf
     end
 
     #
+    # Returns true if the value supplied is longer then the max allowed length
+    #
+    def max_length_value?(value)
+      if !value.nil? && maxLength != 0
+        value.length > maxLength
+      end
+    end
+
+    #
     # The name of the option.
     #
     attr_reader   :name
@@ -187,7 +201,11 @@ module Msf
     # Aliases for this option for backward compatibility
     #
     attr_accessor :aliases
-
+    # 
+    # The max length of the input value
+    #
+    attr_accessor :maxLength
+    
     protected
 
     attr_writer   :required, :desc, :default # :nodoc:

--- a/lib/msf/core/opt_base.rb
+++ b/lib/msf/core/opt_base.rb
@@ -26,12 +26,12 @@ module Msf
     # also be a string as standin for the required description field.
     #
     def initialize(in_name, attrs = [],
-                   required: false, desc: nil, default: nil, enums: [], regex: nil, aliases: [], max_length: 0)
+                   required: false, desc: nil, default: nil, enums: [], regex: nil, aliases: [], max_length: nil)
       self.name     = in_name
       self.advanced = false
       self.evasion  = false
       self.aliases  = aliases
-      self.max_length = Integer(max_length)
+      self.max_length = max_length
 
       if attrs.is_a?(String) || attrs.length == 0
         self.required = required
@@ -56,7 +56,7 @@ module Msf
         regex_temp    = attrs[4] || regex
       end
 
-      if max_length != 0
+      unless max_length.nil?
         self.desc += " Max parameter length: #{max_length} characters"
       end
       
@@ -151,8 +151,8 @@ module Msf
     #
     # Returns true if the value supplied is longer then the max allowed length
     #
-    def max_length_value?(value)
-      if !value.nil? && max_length != 0
+    def invalid_value_length?(value)
+      if !value.nil? && !max_length.nil?
         value.length > max_length
       end
     end

--- a/lib/msf/core/opt_string.rb
+++ b/lib/msf/core/opt_string.rb
@@ -8,12 +8,19 @@ module Msf
 #
 ###
 class OptString < OptBase
+
+  # This adds a length parameter to check for the maximum length of strings.
+  def initialize(in_name, attrs = [],
+               required: false, desc: nil, default: nil, enums: [], regex: nil, aliases: [], max_length: 0)
+    super
+  end
+
   def type
     return 'string'
   end
 
   def validate_on_assignment?
-    false
+    true
   end
 
   def normalize(value)
@@ -31,6 +38,7 @@ class OptString < OptBase
   def valid?(value=self.value, check_empty: true)
     value = normalize(value)
     return false if check_empty && empty_required_value?(value)
+    return false if max_length_value?(value)
     return super(value, check_empty: false)
   end
 end

--- a/lib/msf/core/opt_string.rb
+++ b/lib/msf/core/opt_string.rb
@@ -11,7 +11,7 @@ class OptString < OptBase
 
   # This adds a length parameter to check for the maximum length of strings.
   def initialize(in_name, attrs = [],
-               required: false, desc: nil, default: nil, enums: [], regex: nil, aliases: [], max_length: 0)
+               required: false, desc: nil, default: nil, enums: [], regex: nil, aliases: [], max_length: nil)
     super
   end
 
@@ -38,7 +38,7 @@ class OptString < OptBase
   def valid?(value=self.value, check_empty: true)
     value = normalize(value)
     return false if check_empty && empty_required_value?(value)
-    return false if max_length_value?(value)
+    return false if invalid_value_length?(value)
     return super(value, check_empty: false)
   end
 end

--- a/lib/msf/core/payload.rb
+++ b/lib/msf/core/payload.rb
@@ -210,7 +210,9 @@ class Payload < Msf::Module
     pl = nil
     begin
       pl = generate()
-    rescue NoCompatiblePayloadError, Metasploit::Framework::Compiler::Mingw::UncompilablePayloadError
+    rescue Metasploit::Framework::Compiler::Mingw::UncompilablePayloadError
+    rescue NoCompatiblePayloadError
+    rescue PayloadItemSizeError
     end
     pl ||= ''
     pl.length
@@ -688,7 +690,6 @@ protected
   # Merge the name to prefix the existing one and separate them
   # with a comma
   #
-
   def merge_name(info, val)
     if (info['Name'])
       info['Name'] = val + ',' + info['Name']

--- a/lib/rex/payloads/meterpreter/config.rb
+++ b/lib/rex/payloads/meterpreter/config.rb
@@ -36,8 +36,8 @@ private
   end
 
   def to_str(item, size)
-    if  (item.size > size-1)
-      item = item.slice(0..(size-1)) # TODO silently fix things or throw error?
+    if (item.size >= size) # ">=" instead of only ">", because we need space for a terminating null byte (for string handling in C)
+      raise Msf::PayloadItemSizeError.new(item, size-1)
     end
     @to_str.call(item, size)
   end

--- a/lib/rex/payloads/meterpreter/config.rb
+++ b/lib/rex/payloads/meterpreter/config.rb
@@ -36,6 +36,10 @@ private
   end
 
   def to_str(item, size)
+    if  (item.size > size-1)
+      print("Option string: #{item} was to long to fit. Max size: #{size-1}. Automatic resizing... (you might want to adjust your options)\n")
+      item = item.slice(0..(size-1))
+    end
     @to_str.call(item, size)
   end
 

--- a/lib/rex/payloads/meterpreter/config.rb
+++ b/lib/rex/payloads/meterpreter/config.rb
@@ -37,8 +37,7 @@ private
 
   def to_str(item, size)
     if  (item.size > size-1)
-      print("Option string: #{item} was to long to fit. Max size: #{size-1}. Automatic resizing... (you might want to adjust your options)\n")
-      item = item.slice(0..(size-1))
+      item = item.slice(0..(size-1)) # TODO silently fix things or throw error?
     end
     @to_str.call(item, size)
   end

--- a/lib/rex/payloads/meterpreter/config.rb
+++ b/lib/rex/payloads/meterpreter/config.rb
@@ -36,8 +36,8 @@ private
   end
 
   def to_str(item, size)
-    if (item.size >= size) # ">=" instead of only ">", because we need space for a terminating null byte (for string handling in C)
-      raise Msf::PayloadItemSizeError.new(item, size-1)
+    if item.size >= size  # ">=" instead of only ">", because we need space for a terminating null byte (for string handling in C)
+      raise Msf::PayloadItemSizeError.new(item, size - 1)
     end
     @to_str.call(item, size)
   end

--- a/modules/payloads/singles/windows/messagebox.rb
+++ b/modules/payloads/singles/windows/messagebox.rb
@@ -27,8 +27,8 @@ module MetasploitModule
     # Register MessageBox options
     register_options(
       [
-        OptString.new('TITLE', [ true, "Messagebox Title (max 255 chars)", "MessageBox" ]),
-        OptString.new('TEXT', [ true, "Messagebox Text (max 255 chars)", "Hello, from MSF!" ]),
+        OptString.new('TITLE', [ true, "Messagebox Title (max 255 chars)", "MessageBox" ], max_length: 255),
+        OptString.new('TEXT', [ true, "Messagebox Text (max 255 chars)", "Hello, from MSF!" ], max_length: 255),
         OptString.new('ICON', [ true, "Icon type can be NO, ERROR, INFORMATION, WARNING or QUESTION", "NO" ])
       ])
   end
@@ -42,16 +42,10 @@ module MetasploitModule
     if (strTitle.length < 1)
       raise ArgumentError, "You must specify a title"
     end
-    if (strTitle.length >= 256)
-      raise ArgumentError, "The title must be less than 256 characters long."
-    end
 
     strText = datastore['TEXT'] + "X"
     if (strText.length < 1)
       raise ArgumentError, "You must specify the text of the MessageBox"
-    end
-    if (strText.length >= 256)
-      raise ArgumentError, "The text must be less than 256 characters long."
     end
 
     # exitfunc process or thread ?


### PR DESCRIPTION
This PR limits the size of string options when appropriate to ensure they will fit in defined buffers. This will notably make sure that the proxy related options and user agent string will not exceed the size allowed by Meterpreter. I also added the usage to the messagebox payload where similar restrictions are in place and had been checked at payload runtime.

The noteworthy disadvantage to this is that the proxy options are effectively size-restricted framework wide to ensure Meterpreter compatibility. I think this is acceptable given the size of 255.

This PR:
  * Replaces #11751 
  * Fixes #11750 

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] Use a Meterpreter payload with the reverse_http stager
    - [x] Set a very large `HttpUserAgent` option (>255)
- [x] Generate a Meterpreter payload using the reverse_http stager
- [x] See an error stating that the option is invalid
- [x] Use a smaller `HttpUserAgent` option and regenerate a working payload
