### PR TITLE
Remove preceding whitespace from module name

### DIFF
--- a/modules/exploits/windows/iis/iis_webdav_scstoragepathfromurl.rb
+++ b/modules/exploits/windows/iis/iis_webdav_scstoragepathfromurl.rb
@@ -10,7 +10,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => ' Microsoft IIS WebDav ScStoragePathFromUrl Overflow',
+      'Name'           => 'Microsoft IIS WebDav ScStoragePathFromUrl Overflow',
       'Description'    => %q{
           Buffer overflow in the ScStoragePathFromUrl function
           in the WebDAV service in Internet Information Services (IIS) 6.0


### PR DESCRIPTION
Small tidy up of a module name that contained preceding whitespace