### PR TITLE
quick fix for rapid7/metasploit-framework#13060 (meterpreter > shell)

### DIFF
--- a/lib/rex/post/meterpreter/extensions/stdapi/sys/process.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/sys/process.rb
@@ -179,7 +179,7 @@ class Process < Rex::Post::Process
     # If we were creating a channel out of this
     if (channel_id != nil)
       channel = Rex::Post::Meterpreter::Channels::Pools::StreamPool.new(client,
-          channel_id, "stdapi_process", CHANNEL_FLAG_SYNCHRONOUS)
+          channel_id, "stdapi_process", CHANNEL_FLAG_SYNCHRONOUS, nil)
     end
 
     # Return a process instance


### PR DESCRIPTION
Quick fix for https://github.com/rapid7/metasploit-framework/issues/13060

## Verification

- [ ] Get a (windows) meterpreter session
- [ ] `meterpreter > shell`
- [ ] **Verify**:
```
meterpreter > shell
Process 1337 created.
Channel 1 created.
Microsoft Windows [Version 10.0.17763.379]
(c) 2018 Microsoft Corporation. All rights reserved.

C:\Users\User>exit
exit
meterpreter >
```
Before fix:
```
meterpreter > shell
[-] Failed to spawn shell with thread impersonation. Retrying without it.
[-] Error running command shell: ArgumentError wrong number of arguments (given 4, expected 5)
meterpreter >

```

