### PR TITLE
Fix args when directly opening a channel

### DIFF
--- a/lib/rex/post/meterpreter/extensions/extapi/ntds/ntds.rb
+++ b/lib/rex/post/meterpreter/extensions/extapi/ntds/ntds.rb
@@ -28,7 +28,7 @@ class Ntds
     if channel_id.nil?
       raise Exception, "We did not get a channel back!"
     end
-    Rex::Post::Meterpreter::Channels::Pool.new(client, channel_id, "extapi_ntds", CHANNEL_FLAG_SYNCHRONOUS)
+    Rex::Post::Meterpreter::Channels::Pool.new(client, channel_id, "extapi_ntds", CHANNEL_FLAG_SYNCHRONOUS, response)
   end
 
   attr_accessor :client

--- a/lib/rex/post/meterpreter/extensions/networkpug/networkpug.rb
+++ b/lib/rex/post/meterpreter/extensions/networkpug/networkpug.rb
@@ -39,7 +39,8 @@ class NetworkPug < Extension
         client,
         channel_id,
         "networkpug_interface",
-        CHANNEL_FLAG_SYNCHRONOUS
+        CHANNEL_FLAG_SYNCHRONOUS,
+        response
       )
     end
 

--- a/lib/rex/post/meterpreter/extensions/powershell/powershell.rb
+++ b/lib/rex/post/meterpreter/extensions/powershell/powershell.rb
@@ -75,7 +75,7 @@ class Powershell < Extension
     if channel_id.nil?
       raise Exception, "We did not get a channel back!"
     end
-    Rex::Post::Meterpreter::Channels::Pools::StreamPool.new(client, channel_id, 'powershell_psh', CHANNEL_FLAG_SYNCHRONOUS)
+    Rex::Post::Meterpreter::Channels::Pools::StreamPool.new(client, channel_id, 'powershell_psh', CHANNEL_FLAG_SYNCHRONOUS, response)
   end
 
 end

--- a/lib/rex/post/meterpreter/extensions/stdapi/mic/mic.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/mic/mic.rb
@@ -43,7 +43,7 @@ module Rex
                 response = client.send_request(request)
                 return nil unless response.result == 0
 
-                channel = Channel.create(client, 'audio_mic', Rex::Post::Meterpreter::Channels::Pools::StreamPool, CHANNEL_FLAG_SYNCHRONOUS)
+                channel = Channel.create(client, 'audio_mic', Rex::Post::Meterpreter::Channels::Pools::StreamPool, CHANNEL_FLAG_SYNCHRONOUS, response)
               end
 
               # Stop recording from microphone

--- a/lib/rex/post/meterpreter/extensions/stdapi/sys/process.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/sys/process.rb
@@ -179,7 +179,7 @@ class Process < Rex::Post::Process
     # If we were creating a channel out of this
     if (channel_id != nil)
       channel = Rex::Post::Meterpreter::Channels::Pools::StreamPool.new(client,
-          channel_id, "stdapi_process", CHANNEL_FLAG_SYNCHRONOUS, nil)
+          channel_id, "stdapi_process", CHANNEL_FLAG_SYNCHRONOUS, response)
     end
 
     # Return a process instance

--- a/lib/rex/post/meterpreter/extensions/winpmem/winpmem.rb
+++ b/lib/rex/post/meterpreter/extensions/winpmem/winpmem.rb
@@ -46,7 +46,7 @@ class Winpmem < Extension
 
     # Open the compressed Channel
     channel = Rex::Post::Meterpreter::Channels::Pool.new(client, channel_id, "winpmem",
-      CHANNEL_FLAG_SYNCHRONOUS | CHANNEL_FLAG_COMPRESS)
+      CHANNEL_FLAG_SYNCHRONOUS | CHANNEL_FLAG_COMPRESS, response)
     return memory_size, response_code, channel
   end
 end

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/audio_output.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/audio_output.rb
@@ -22,7 +22,7 @@ class Console::CommandDispatcher::Stdapi::AudioOutput
   #
   def commands
     all = {
-      'play' => 'play an audio file on target system, nothing written on disk'
+      'play' => 'play a waveform audio file (.wav) on the target system'
     }
     reqs = {
       'play' => []


### PR DESCRIPTION
This PR fixes the arguments when a channel is directly created instead of using `Channel.create`. The changes I made in #12984 added the `response` packet as an additional required argument. While most code paths use `Channel.create` to create their channels and this path was updated, paths which directly instantiated their desired class were missed. This fixes that allowing those channels to be created as well. This notably fixes the `powershell_shell` Meterpreter command from the `powershell` extension.

## Verification

- [ ] Get a native-Windows Meterpreter session on Windows
  - [ ] Test that the `shell` command works, showing that the process channel is created correct
  - [ ] Test the `powershell_shell` command works
  - [ ] Test that the `play` command works (use a .WAV file such as [this example](https://file-examples.com/wp-content/uploads/2017/11/file_example_WAV_1MG.wav))