### PR TITLE
Cisco DCNM Upload 2019 Correction

### DIFF
--- a/modules/exploits/multi/http/cisco_dcnm_upload_2019.rb
+++ b/modules/exploits/multi/http/cisco_dcnm_upload_2019.rb
@@ -206,7 +206,7 @@ class MetasploitModule < Msf::Exploit::Remote
         zis.each do |entry|
           if entry.name =~ /jboss[0-9]*\.log/
             fdata = zis.read(entry)
-            if fdata[/Started FileSystemDeploymentService for directory ([\w\/\\\-\.:]*)/]
+            if fdata[/Started FileSystemDeploymentService for directory ([\w\/\\\-\.: ]+)/]
               tmp.close
               tmp.unlink
               return $1.strip


### PR DESCRIPTION
When attacking a system where the correct WAR file deployment path is something with a space,

`C:\Cisco System\blah\`

The module's regex filter would only grab

`C:\Cisco`

and attempt to upload. With the new regex correction, the correct directory is uploaded to.

## Verification

- [ ] Start `msfconsole`
- [ ] `use exploit/multi/http/cisco_dcnm_upload_2019`
- [ ] `set rhosts 127.0.0.1`
- [ ] `run`
- [ ] **Verify** The discovered upload directory is correct and pointing where it should. This can be further verified using the log file disclosure vulnerability manually to ensure correct upload location.
