### PR TITLE
Fix find_ysoserial_offsets.rb and incorrect serialVersionUID patching

### DIFF
--- a/lib/msf/util/java_deserialization.rb
+++ b/lib/msf/util/java_deserialization.rb
@@ -12,7 +12,7 @@ class JavaDeserialization
 
   PAYLOAD_FILENAME = "ysoserial_payloads.json"
 
-  def self.ysoserial_payload(payload_name, command=nil, serial_version_uid: nil)
+  def self.ysoserial_payload(payload_name, command=nil)
     # Open the JSON file and parse it
     begin
       path = File.join(Msf::Config.data_directory, PAYLOAD_FILENAME)
@@ -54,20 +54,6 @@ class JavaDeserialization
         bytes[(length_offset-1)..length_offset] = length
       end
 
-      # HACK: Update serialVersionUID if specified
-      if serial_version_uid
-        unless serial_version_uid.is_a?(String)
-          raise ArgumentError, 'serial_version_uid must be a string'
-        end
-
-        if serial_version_uid.length != 8
-          raise ArgumentError, 'serial_version_uid must be 8 bytes'
-        end
-
-        # XXX: This hardcoded value may change!
-        bytes.sub!("\xe3\xa1\x88\xea\x73\x22\xa4\x48", serial_version_uid)
-      end
-
       # Replace "ysoserial\/Pwner" timestamp string with randomness for evasion
       bytes.gsub!(/ysoserial\/Pwner00000000000000/, Rex::Text.rand_text_alphanumeric(29))
 
@@ -76,6 +62,7 @@ class JavaDeserialization
       raise RuntimeError, 'Malformed JSON file'
     end
   end
+
 end
 end
 end

--- a/modules/exploits/windows/http/desktopcentral_deserialization.rb
+++ b/modules/exploits/windows/http/desktopcentral_deserialization.rb
@@ -134,9 +134,11 @@ class MetasploitModule < Msf::Exploit::Remote
     # I identified mr_me's binary blob as the CommonsBeanutils1 payload :)
     serialized_payload = Msf::Util::JavaDeserialization.ysoserial_payload(
       'CommonsBeanutils1',
-      cmd,
-      serial_version_uid: "\xcf\x8e\x01\x82\xfe\x4e\xf1\x7e"
+      cmd
     )
+
+    # XXX: Patch in expected serialVersionUID
+    serialized_payload[140, 8] = "\xcf\x8e\x01\x82\xfe\x4e\xf1\x7e"
 
     # Rock 'n' roll!
     upload_serialized_payload(serialized_payload)

--- a/tools/payloads/ysoserial/find_ysoserial_offsets.rb
+++ b/tools/payloads/ysoserial/find_ysoserial_offsets.rb
@@ -22,8 +22,8 @@ if ARGV.include?("-h")
 end
 
 debug = ARGV.include?('-d')
-ysoserial_modified = ARGV.include?('-m')
-if ysoserial_modified
+@ysoserial_modified = ARGV.include?('-m')
+if @ysoserial_modified
   payload_type = ARGV[ARGV.find_index('-m')+1]
   unless ['cmd', 'bash', 'powershell', 'none'].include?(payload_type)
     STDERR.puts 'ERROR: Invalid payload type specified'
@@ -36,7 +36,7 @@ def generate_payload(payload_name,search_string_length)
   searchString = 'A' * search_string_length
 
   # Build the command line with ysoserial parameters
-  if ysoserial_modified
+  if @ysoserial_modified
     stdout, stderr, status = Open3.capture3('java','-jar','ysoserial-modified.jar',payload_name.to_s,payload_type.to_s,searchString.to_s)
   else
     stdout, stderr, status = Open3.capture3('java','-jar','ysoserial-original.jar',payload_name.to_s,searchString.to_s)
@@ -156,7 +156,7 @@ payloadList.each do |payload|
     diffs = diff(payload_array[i],payload_array[i+1])
 
     break if diffs.nil?
- 
+
     # Iterate through each diff, searching for offsets of the length and the payload
     (0..diffs.length-1).each do |j|
       current_byte = diffs[j]
@@ -218,7 +218,7 @@ results.each do |k,v|
 end
 
 unless debug
-  puts JSON.generate(results)
+  puts JSON.pretty_generate(results)
 end
 
 STDERR.puts "DONE!  Successfully generated #{payloadCount['static']} static payloads and #{payloadCount['dynamic']} dynamic payloads.  Skipped #{payloadCount['skipped']} unsupported payloads."


### PR DESCRIPTION
```
/find_ysoserial_offsets.rb:39:in `generate_payload': undefined local variable or method `ysoserial_modified' for main:Object (NameError)
	from /find_ysoserial_offsets.rb:140:in `block in <main>'
	from /find_ysoserial_offsets.rb:137:in `each'
	from /find_ysoserial_offsets.rb:137:in `<main>'
```

```
Invalid payload type 'Payload'
```

```
Invalid payload type '-------'
```

I did not update `data/ysoserial_payloads.json` because it seems to break the `CommonsBeanutils1` payload used in [exploit/windows/http/desktopcentral_deserialization](https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/windows/http/desktopcentral_deserialization.rb). We will have to address that in a later PR.

Fixes #11125 and #13071. See also: #11359.