### PR TITLE
Add automated comments to needs-docs label

### DIFF
--- a/.github/label-commenter-config.yml
+++ b/.github/label-commenter-config.yml
@@ -1,0 +1,15 @@
+labels:
+  - name: needs-docs
+    labeled:
+      pr:
+        body: |
+          Thanks for your pull request, before this can be merged - corresponding documentation for your module is required:
+          - [Writing Module Documentation](https://github.com/rapid7/metasploit-framework/wiki/Writing-Module-Documentation)
+          - [Template](https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/module_doc_template.md)
+          - [Examples](https://github.com/rapid7/metasploit-framework/tree/master/documentation/modules)
+        action: open
+    unlabeled:
+      issue:
+        body: |
+          Thank you for adding module documentation :tada:
+        action: open

--- a/.github/label-commenter-config.yml
+++ b/.github/label-commenter-config.yml
@@ -9,7 +9,7 @@ labels:
           - [Examples](https://github.com/rapid7/metasploit-framework/tree/master/documentation/modules)
         action: open
     unlabeled:
-      issue:
+      pr:
         body: |
           Thank you for adding module documentation :tada:
         action: open

--- a/.github/workflows/label-commenter.yml
+++ b/.github/workflows/label-commenter.yml
@@ -22,7 +22,8 @@ jobs:
           ref: master
 
       - name: Label Commenter
-        uses: peaceiris/actions-label-commenter@v1
+        # Note: Using SHA explicitly for v1.2.3 - https://julienrenaux.fr/2019/12/20/github-actions-security-risk/
+        uses: peaceiris/actions-label-commenter@691a9c6c236005321e8b1cf4f0a021447634d001
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           config_file: .github/label-commenter-config.yml

--- a/.github/workflows/label-commenter.yml
+++ b/.github/workflows/label-commenter.yml
@@ -1,0 +1,28 @@
+#
+# Automatically respond to any issues/pull requests that have the given labels assigned.
+#
+name: Label Commenter
+
+on:
+  issues:
+    types:
+      - labeled
+      - unlabeled
+  pull_request:
+    types:
+      - labeled
+      - unlabeled
+
+jobs:
+  comment:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: master
+
+      - name: Label Commenter
+        uses: peaceiris/actions-label-commenter@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          config_file: .github/label-commenter-config.yml


### PR DESCRIPTION
Let's automate the process of asking contributors to provide module documentation. In the future our automated comment rules can be expanded upon.

### Before

Adding the `needs-docs` label to pull requests that are missing module documentation currently requires an additional manual comment from maintainers to link to docs / ask for this.

### After

Github should now handle this for us. When the `needs-docs` label is added:

![image](https://user-images.githubusercontent.com/60357436/76810502-3eaebf00-67e6-11ea-8195-bcd1b08c8982.png)

When the `needs-docs` label is removed:

![image](https://user-images.githubusercontent.com/60357436/76810515-4a9a8100-67e6-11ea-9787-fafa16bde968.png)
