### PR TITLE
Adding alias of ftp_connect

### DIFF
--- a/lib/msf/core/exploit/ftp.rb
+++ b/lib/msf/core/exploit/ftp.rb
@@ -136,7 +136,7 @@ module Exploit::Remote::Ftp
   def connect_login(global = true, verbose = nil)
     verbose ||= datastore['FTPDEBUG']
     verbose ||= datastore['VERBOSE']
-    ftpsock = connect(global, verbose)
+    ftpsock = ftp_connect(global, verbose)
 
     if !(user and pass)
       print_error("No username and password were supplied, unable to login")
@@ -370,6 +370,8 @@ module Exploit::Remote::Ftp
   def ftp_data_timeout
     (datastore['FTPDataTimeout'] || 1).to_i
   end
+
+  alias ftp_connect connect
 
 protected
 


### PR DESCRIPTION
Signed-off-by: Mehmet İnce <mehmet@mehmetince.net>

This PR solves issue mention at #13090 . This PR solved a method name collusions specially that occurs when `Msf::Exploit::Remote::HttpClient` and `Msf::Exploit::Remote::Ftp` included in same module.

Of course I am open to discuss different approaches 👍🏻 

Cheers.