### PR TITLE
Adds payload completion and fixes format completion

### DIFF
--- a/external/zsh/_msfvenom
+++ b/external/zsh/_msfvenom
@@ -211,8 +211,13 @@ _msfvenom_payload() {
   local cacheFile="$HOME/.msf4/store/modules_metadata.json"
   local -a _msfvenom_payloads_list
   [ -f "$cacheFile" ] || cacheFile="/opt/metasploit/db/modules_metadata_base.json"
-  _msfvenom_payloads_list=("${(f)$(sed -n '/"type": "payload"/,/"ref_name"/p' "$cacheFile" | grep -E '(ref_name|description)' | cut -d '"' -f 4 | sed -n 'h;n;p;g;p' | sed 'N;s/\n/:/')}")
-  _describe -t payloads 'available payloads' _msfvenom_payloads_list || compadd "$@"
+  if [ ! -f "$cacheFile" ]; then
+    _message -r "Cannot find metasploit cache file. Run msfconsole to populate it"
+    compadd "$@"
+  else
+    _msfvenom_payloads_list=("${(f)$(sed -n '/"type": "payload"/,/"ref_name"/p' "$cacheFile" | grep -E '(ref_name|description)' | cut -d '"' -f 4 | sed -n 'h;n;p;g;p' | sed 'N;s/\n/:/')}")
+    _describe -t payloads 'available payloads' _msfvenom_payloads_list || compadd "$@"
+  fi
 }
 
 _arguments \

--- a/external/zsh/_msfvenom
+++ b/external/zsh/_msfvenom
@@ -207,22 +207,24 @@ _msfvenom_platform() {
   _describe -t platforms 'available platforms' _msfvenom_platforms_list || compadd "$@"
 }
 
-local -a _msfvenom_payloads_list
-
-if [ -f "$HOME/.local/cache/msfvenom/payloads.txt" ]; then
+_msfvenom_payload() {
+  local cacheFile="${XDG_CACHE_HOME:-$HOME/.cache}/metasploit/payloads.txt"
+  local -a _msfvenom_payloads_list
+  if [ ! -f "$cacheFile" ]; then
+    mkdir -p $(dirname "$cacheFile")
+    msfvenom --list payloads 2> /dev/null | tail -n +5 | sed '2d' | awk -F '  +' '{print $2 ":" $3}' > "$cacheFile"
+  else
+    local lastModified="$(date +%s -r "$cacheFile")"
+    local currentDate="$(date +%s)"
+    if [ $(( $currentDate - $lastModified )) -gt "604800" ]; then # 604800 = Seconds in a week
+      msfvenom --list payloads 2> /dev/null | tail -n +5 | sed '2d' | awk -F '  +' '{print $2 ":" $3}' > "$cacheFile"
+    fi
+  fi
   while read line; do
     _msfvenom_payloads_list+=("$line")
-  done < "$HOME/.local/cache/msfvenom/payloads.txt"
-fi
-
-_msfvenom_payload() {
+  done < "$cacheFile"
   if [ ${#_msfvenom_payloads_list[@]} -ne 0 ]; then
     _describe -t payloads 'available payloads' _msfvenom_payloads_list || compadd "$@"
-  else
-    _message -r "You need to pre-populate the payload cache, run the following commands:"
-    _message -r ""
-    _message -r "mkdir -p \$HOME/.local/cache/msfvenom/"
-    _message -r "msfvenom --list payloads 2> /dev/null | tail -n +5 | sed '2d' | awk -F '  +' '{print \$2 \":\" \$3}' > \$HOME/.local/cache/msfvenom/payloads.txt"
   fi
 }
 

--- a/external/zsh/_msfvenom
+++ b/external/zsh/_msfvenom
@@ -164,7 +164,7 @@ _msfvenom_formats_list=(
   'vbscript'
 )
 
-_msfvenom_format() {
+_msfvenom_formats() {
   _describe -t formats 'available formats' _msfvenom_formats_list || compadd "$@"
 }
 
@@ -207,6 +207,25 @@ _msfvenom_platform() {
   _describe -t platforms 'available platforms' _msfvenom_platforms_list || compadd "$@"
 }
 
+local -a _msfvenom_payloads_list
+
+if [ -f "$HOME/.local/cache/msfvenom/payloads.txt" ]; then
+  while read line; do
+    _msfvenom_payloads_list+=("$line")
+  done < "$HOME/.local/cache/msfvenom/payloads.txt"
+fi
+
+_msfvenom_payload() {
+  if [ ${#_msfvenom_payloads_list[@]} -ne 0 ]; then
+    _describe -t payloads 'available payloads' _msfvenom_payloads_list || compadd "$@"
+  else
+    _message -r "You need to pre-populate the payload cache, run the following commands:"
+    _message -r ""
+    _message -r "mkdir -p \$HOME/.local/cache/msfvenom/"
+    _message -r "msfvenom --list payloads 2> /dev/null | tail -n +5 | sed '2d' | awk -F '  +' '{print \$2 \":\" \$3}' > \$HOME/.local/cache/msfvenom/payloads.txt"
+  fi
+}
+
 _arguments \
   "--smallest[Generate the smallest possible payload using all available encoders]" \
   "--sec-name[The new section name to use when generating large Windows binaries. Default: random 4-character alpha string]" \
@@ -228,7 +247,7 @@ _arguments \
   {-l,--list}"[List all modules for \[type\]]:module type:(payloads encoders nops platforms archs encrypt formats all)" \
   {-n,--nopsled}"[Prepend a nopsled of \[length\] size on to the payload]:nopsled length" \
   {-o,--out}"[Save the payload to a file]:output file:_files" \
-  {-p,--payload}"[Payload to use (--list payloads to list, --list-options for arguments). Specify '-' or STDIN for custom]:payload" \
+  {-p,--payload}"[Payload to use (--list payloads to list, --list-options for arguments). Specify '-' or STDIN for custom]:target payload:_msfvenom_payload" \
   {-s,--space}"[The maximum size of the resulting payload]:length" \
   {-t,--timeout}"[The number of seconds to wait when reading the payload from STDIN (default 30, 0 to disable)]:second" \
   {-v,--var-name}"[Specify a custom variable name to use for certain output formats]:value" \

--- a/external/zsh/_msfvenom
+++ b/external/zsh/_msfvenom
@@ -211,12 +211,11 @@ _msfvenom_payload() {
   local cacheFile="$HOME/.msf4/store/modules_metadata.json"
   local -a _msfvenom_payloads_list
   [ -f "$cacheFile" ] || cacheFile="/opt/metasploit/db/modules_metadata_base.json"
-  [ -f "$cacheFile" ] || cacheFile="./db/modules_metadata_base.json"
   if [ ! -f "$cacheFile" ]; then
     _message -r "Cannot find metasploit cache file. Run msfconsole to populate it"
     compadd "$@"
   else
-    _msfvenom_payloads_list=("${(f)$(sed -n '/"type": "payload"/,/"ref_name"/p' "$cacheFile" | grep -E '(ref_name|description)' | cut -d '"' -f 4 | sed -n 'h;n;p;g;p' | sed 'N;s/\n/:/')}")
+    _msfvenom_payloads_list=("${(f)$(sed -n '/"type": "payload"/,/"ref_name"/p' "$cacheFile" | grep -E '(ref_name|description)' | cut -d '"' -f 4 | sed -n 'h;n;p;g;p' | sed 'N;s/\n/:/; s/\\n.*$//')}")
     _describe -t payloads 'available payloads' _msfvenom_payloads_list || compadd "$@"
   fi
 }

--- a/external/zsh/_msfvenom
+++ b/external/zsh/_msfvenom
@@ -208,24 +208,11 @@ _msfvenom_platform() {
 }
 
 _msfvenom_payload() {
-  local cacheFile="${XDG_CACHE_HOME:-$HOME/.cache}/metasploit/payloads.txt"
+  local cacheFile="$HOME/.msf4/store/modules_metadata.json"
   local -a _msfvenom_payloads_list
-  if [ ! -f "$cacheFile" ]; then
-    mkdir -p $(dirname "$cacheFile")
-    msfvenom --list payloads 2> /dev/null | tail -n +5 | sed '2d' | awk -F '  +' '{print $2 ":" $3}' > "$cacheFile"
-  else
-    local lastModified="$(date +%s -r "$cacheFile")"
-    local currentDate="$(date +%s)"
-    if [ $(( $currentDate - $lastModified )) -gt "604800" ]; then # 604800 = Seconds in a week
-      msfvenom --list payloads 2> /dev/null | tail -n +5 | sed '2d' | awk -F '  +' '{print $2 ":" $3}' > "$cacheFile"
-    fi
-  fi
-  while read line; do
-    _msfvenom_payloads_list+=("$line")
-  done < "$cacheFile"
-  if [ ${#_msfvenom_payloads_list[@]} -ne 0 ]; then
-    _describe -t payloads 'available payloads' _msfvenom_payloads_list || compadd "$@"
-  fi
+  [ -f "$cacheFile" ] || cacheFile="/opt/metasploit/db/modules_metadata_base.json"
+  _msfvenom_payloads_list=("${(f)$(sed -n '/"type": "payload"/,/"ref_name"/p' "$cacheFile" | grep -E '(ref_name|description)' | cut -d '"' -f 4 | sed -n 'h;n;p;g;p' | sed 'N;s/\n/:/')}")
+  _describe -t payloads 'available payloads' _msfvenom_payloads_list || compadd "$@"
 }
 
 _arguments \

--- a/external/zsh/_msfvenom
+++ b/external/zsh/_msfvenom
@@ -211,6 +211,7 @@ _msfvenom_payload() {
   local cacheFile="$HOME/.msf4/store/modules_metadata.json"
   local -a _msfvenom_payloads_list
   [ -f "$cacheFile" ] || cacheFile="/opt/metasploit/db/modules_metadata_base.json"
+  [ -f "$cacheFile" ] || cacheFile="./db/modules_metadata_base.json"
   if [ ! -f "$cacheFile" ]; then
     _message -r "Cannot find metasploit cache file. Run msfconsole to populate it"
     compadd "$@"


### PR DESCRIPTION
Payload completion.

On first run it will ask the user to create and populate a cache file
that will be used in the future for completions

Format completion

There was a mis-type of the name of one of the functions

Pull request for issue #13117 

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use exploit/windows/smb/ms08_067_netapi`
- [x] **Verify** the thing does what it should
- [x] **Verify** the thing does not do what it should not
- [ ] **Document** the thing and how it works ([Example](https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/post/multi/gather/aws_keys.md))

Couldn't find where this should be documented - Happy to do so if someone can point me in the right direction



