### PR TITLE
Fix has_check? conflict in exploit/linux/redis/redis_unauth_exec

### DIFF
--- a/lib/msf/base/simple/exploit.rb
+++ b/lib/msf/base/simple/exploit.rb
@@ -195,7 +195,7 @@ module Exploit
 
     if opts['RunAsJob']
       mod.job_id = mod.framework.jobs.start_bg_job(
-        "Auxiliary: #{mod.refname} check",
+        "Exploit: #{mod.refname} check",
         ctx,
         Proc.new { |ctx_| self.job_check_proc(ctx_) },
         Proc.new { |ctx_| nil }

--- a/modules/exploits/linux/redis/redis_unauth_exec.rb
+++ b/modules/exploits/linux/redis/redis_unauth_exec.rb
@@ -96,6 +96,10 @@ class MetasploitModule < Msf::Exploit::Remote
     disconnect
   end
 
+  def has_check?
+    true # Overrides the override in Msf::Auxiliary::Scanner imported by Msf::Auxiliary::Redis
+  end
+
   def exploit
     if check_custom
       @module_init_name = datastore['RedisModuleInit']    || Rex::Text.rand_text_alpha_lower(4..8)


### PR DESCRIPTION
It turns out `Msf::Auxiliary::Redis` imports `Msf::Auxiliary::Scanner` which overrides the default module `has_check?` method with one that looks for the module to define `check_host` (as is customary in scanners) instead of `check` (as is customary in other modules). This overrides the overridden `has_check?` to allow normal operation of `check`.

Fixes #13095.

Verification
=========

- [ ] `./msfconsole`
- [ ] `use exploit/linux/redis/redis_unauth_exec`
- [ ] `set RHOST X`
- [ ] `check`
- [ ] Verify the message does not complain about `check` being unsupported.