### PR TITLE
Updates faraday gem to version with disabled warnings

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,7 @@ PATH
       em-http-request
       eventmachine
       faker
-      faraday (= 0.17.3)
+      faraday
       faye-websocket
       filesize
       hrr_rb_ssh (= 0.3.0.pre2)
@@ -173,7 +173,7 @@ GEM
       railties (>= 4.2.0)
     faker (2.2.1)
       i18n (>= 0.8)
-    faraday (0.17.3)
+    faraday (1.0.0)
       multipart-post (>= 1.2, < 3)
     faye-websocket (0.10.9)
       eventmachine (>= 0.12.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,7 @@ PATH
       em-http-request
       eventmachine
       faker
-      faraday (<= 0.17.0)
+      faraday (= 0.17.3)
       faye-websocket
       filesize
       hrr_rb_ssh (= 0.3.0.pre2)
@@ -119,8 +119,8 @@ GEM
       activerecord (>= 3.1.0, < 7)
     ast (2.4.0)
     aws-eventstream (1.0.3)
-    aws-partitions (1.285.0)
-    aws-sdk-core (3.91.1)
+    aws-partitions (1.287.0)
+    aws-sdk-core (3.92.0)
       aws-eventstream (~> 1.0, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)
       aws-sigv4 (~> 1.1)
@@ -173,7 +173,7 @@ GEM
       railties (>= 4.2.0)
     faker (2.2.1)
       i18n (>= 0.8)
-    faraday (0.17.0)
+    faraday (0.17.3)
       multipart-post (>= 1.2, < 3)
     faye-websocket (0.10.9)
       eventmachine (>= 0.12.0)
@@ -330,7 +330,7 @@ GEM
       metasm
       rex-core
       rex-text
-    rex-socket (0.1.22)
+    rex-socket (0.1.23)
       rex-core
     rex-sslscan (0.1.5)
       rex-core

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -211,6 +211,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'eventmachine'
 
   # Earlier than latest Faraday gem is used to prevent upstream Octokit errors
-  spec.add_runtime_dependency 'faraday', '<= 0.17.0'
+  spec.add_runtime_dependency 'faraday', '0.17.3'
 
 end

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -211,6 +211,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'eventmachine'
 
   # Earlier than latest Faraday gem is used to prevent upstream Octokit errors
-  spec.add_runtime_dependency 'faraday', '0.17.3'
+  spec.add_runtime_dependency 'faraday'
 
 end


### PR DESCRIPTION
Faraday gem was originally set to version 0.17.0 to avoid octosploit warnings, this bug was fixed in later versions which also disable deprecation warnings when using Ruby 2.7.0.

By bumping faraday to 0.01703, we can disable the majority of warnings that are displayed when running MS in ruby 2.7.0. The rest of the warnings will be fixed once we bump the Rails versions.

All version bumps excluding faraday are automatic and required.   

Original PRs changing faraday version:
https://github.com/rapid7/metasploit-framework/pull/12658 and https://github.com/rapid7/metasploit-framework/pull/12659
https://github.com/rapid7/metasploit-framework/pull/12658 and https://github.com/rapid7/metasploit-framework/pull/12659

Ruby 2.7.0 deprecation warning Issue:
https://github.com/rapid7/metasploit-framework/issues/12809