### PR TITLE
Update octokit to latest rubygem available.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -238,7 +238,7 @@ GEM
     nexpose (7.2.1)
     nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
-    octokit (4.17.0)
+    octokit (4.18.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
     openssl-ccm (1.2.2)


### PR DESCRIPTION
4.17.0 went away, see https://github.com/octokit/octokit.rb/issues/1219

## Verification

List the steps needed to make sure this thing works

- [ ] `bundle install` to pick up the new octokit (4.18.0)
- [ ] **Verify** no errors
- [ ] Start `msfconsole`
- [ ] **Verify** you get the console prompt with no errors


