### PR TITLE
Reduce Unknown commands handling from 1 second to 0.5 seconds

### DIFF
--- a/lib/msf/core/module_manager.rb
+++ b/lib/msf/core/module_manager.rb
@@ -96,7 +96,7 @@ module Msf
             module_instance = create(aliased, aliased_as: "#{type}/#{name}")
           else
             module_reference_name = names.join("/")
-            module_instance = set.has_key?(module_reference_name) ? set.create(module_reference_name) : nil
+            module_instance = set.create(module_reference_name)
           end
           break if module_instance
         end

--- a/lib/msf/core/module_manager.rb
+++ b/lib/msf/core/module_manager.rb
@@ -96,7 +96,7 @@ module Msf
             module_instance = create(aliased, aliased_as: "#{type}/#{name}")
           else
             module_reference_name = names.join("/")
-            module_instance = set.create(module_reference_name)
+            module_instance = set.has_key?(module_reference_name) ? set.create(module_reference_name) : nil
           end
           break if module_instance
         end


### PR DESCRIPTION
Cuts down unknown command time from 1 second to 0.5 seconds

Creates a class instance key for signing JARs. This cuts down on creation time for new android modules and as a result speeds up boot and incorrect command reset times by 0.5 seconds.

## Verification

- [ ] Start `msfconsole`
- [ ] `jimbob`
- [ ] `[-] Unknown command: jimbob.` Should be output instantly
- [ ] `exploit/windows/misc/crosschex_device_bof`
- [ ] `[-] Unknown command: exploit/windows/misc/crosschex_device_bof.`
- [ ] `This is a module we can load. Do you want to use exploit/windows/misc/crosschex_device_bof? [y/N]` Should be output instantly

## TL;DR
- Implementing a constant signing key of size 2048 cuts down incorrect command time down by half. Still feels a little slow but it’s a definite improvement.
- Constant signing key of size 1024 seems to improve speed by roughly 0.1s over size 2048. Whether it’s worth it depends on what we get out of the larger key. IMO I’d keep the larger key, with all the difference cutting down the size makes in time.
- Using the key lookup is by far the fastest method, by virtue of avoiding module creation and JAR signing altogether. However I’ve no idea if that breaks any functionality so can’t recommend it atm. Most likely another PR.