### PR TITLE
Enable CPU & Memory profilers to work with Individual Code Blocks

### DIFF
--- a/lib/metasploit/framework/profiler.rb
+++ b/lib/metasploit/framework/profiler.rb
@@ -32,6 +32,7 @@ module Metasploit
             profile.start
 
             at_exit do
+              puts "Generating memory dump #{results_path}"
               result = profile.stop
               save_memory_result(result, path: results_path)
             end
@@ -104,8 +105,6 @@ module Metasploit
 
         def save_memory_result(result, path:)
           require 'rex/compat'
-
-          puts "Generating memory dump #{path}"
 
           result.pretty_print(to_file: path)
           Rex::Compat.open_file(path)


### PR DESCRIPTION
Allows developers to test CPU and Memory usage for blocks of code using the below syntax:

```
Metasploit::Framework::Profiler.record_cpu do
   ...
end
```
```
Metasploit::Framework::Profiler.record_memory do
   ...
end
```

When recording CPU usage with `record_cpu`, the above changes do not affect setting the `METASPLOIT_CPU_PROFILE` flag and it's original functionality. However, devs will be unable to combine `record_memory` and `METASPLOIT_MEMORY_PROFILE` flag, as a memory profile will fail to be generated on calling `exit`. This is believed to be a result of [memory profiler](https://github.com/SamSaffron/memory_profiler) not supporting instantiation. 

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] Wrap any code you wish to test with `record_cpu` or `record_memory` as shown above.
- [ ] **Verify** reports are generated correctly

Additionally verify there's no regression to the previous functionality of https://github.com/rapid7/metasploit-framework/pull/13057:

- [ ] Verify `METASPLOIT_CPU_PROFILE=true ./msfconsole -x 'exit'` creates various CPU profile reports
- [ ] Verify `METASPLOIT_MEMORY_PROFILE=true ./msfconsole -x 'exit'` creates various memory profile reports

- [ ] Verify `METASPLOIT_CPU_PROFILE=true ./msfvenom -x 'exit'` creates various CPU profile reports
- [ ] Verify `METASPLOIT_MEMORY_PROFILE=true ./msfvenom -x 'exit'` creates various memory profile reports


