### PR TITLE
Added gsub regex for Banner Sanitization

### DIFF
--- a/modules/auxiliary/scanner/ftp/ftp_version.rb
+++ b/modules/auxiliary/scanner/ftp/ftp_version.rb
@@ -30,6 +30,7 @@ class MetasploitModule < Msf::Auxiliary
 
     if(banner)
       banner_sanitized = Rex::Text.to_hex_ascii(self.banner.to_s)
+      banner_sanitized.gsub!(/\\.*/,'')
       print_good("FTP Banner: '#{banner_sanitized}'")
       report_service(:host => rhost, :port => rport, :name => "ftp", :info => banner_sanitized)
     end

--- a/modules/auxiliary/scanner/imap/imap_version.rb
+++ b/modules/auxiliary/scanner/imap/imap_version.rb
@@ -21,6 +21,7 @@ class MetasploitModule < Msf::Auxiliary
     begin
       connect
       banner_sanitized = Rex::Text.to_hex_ascii(banner.to_s)
+      banner_sanitized.gsub!(/\\.*/,'')
       print_good("#{ip}:#{rport} IMAP #{banner_sanitized}")
       report_service(:host => rhost, :port => rport, :name => "imap", :info => banner)
     rescue ::Rex::ConnectionError

--- a/modules/auxiliary/scanner/pop3/pop3_version.rb
+++ b/modules/auxiliary/scanner/pop3/pop3_version.rb
@@ -25,6 +25,7 @@ class MetasploitModule < Msf::Auxiliary
       connect
       banner = sock.get_once(-1, 30)
       banner_sanitized = Rex::Text.to_hex_ascii(banner.to_s)
+      banner_sanitized.gsub!(/\\.*/,'')
       print_good("#{ip}:#{rport} POP3 #{banner_sanitized}")
       report_service(:host => rhost, :port => rport, :name => "pop3", :info => banner)
     rescue ::Rex::ConnectionError

--- a/modules/auxiliary/scanner/smtp/smtp_relay.rb
+++ b/modules/auxiliary/scanner/smtp/smtp_relay.rb
@@ -39,6 +39,7 @@ class MetasploitModule < Msf::Auxiliary
     begin
       connect
       banner_sanitized = Rex::Text.to_hex_ascii(banner.to_s)
+      banner_sanitized.gsub!(/\\.*/,'')
       print_good("SMTP #{banner_sanitized}")
       report_service(:host => rhost, :port => rport, :name => "smtp", :info => banner)
 

--- a/modules/auxiliary/scanner/smtp/smtp_version.rb
+++ b/modules/auxiliary/scanner/smtp/smtp_version.rb
@@ -25,6 +25,7 @@ class MetasploitModule < Msf::Auxiliary
   def run_host(ip)
     res = connect
     banner_sanitized = Rex::Text.to_hex_ascii(banner.to_s)
+    banner_sanitized.gsub!(/\\.*/,'')
     print_good("#{ip}:#{rport} SMTP #{banner_sanitized}")
     report_service(:host => rhost, :port => rport, :name => "smtp", :info => banner)
   end


### PR DESCRIPTION
Tell us what this change does. If you're fixing a bug, please mention
the github issue number.

Please ensure you are submitting **from a unique branch** in your [repository](https://github.com/rapid7/metasploit-framework/pull/11086#issuecomment-445506416) to master in Rapid7's.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use exploit/windows/smb/ms08_067_netapi`
- [x] ...
- [x] **Verify** the thing does what it should
- [x] **Verify** the thing does not do what it should not
- [x] **Document** the thing and how it works ([Example](https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/post/multi/gather/aws_keys.md))

