### PR TITLE
remove inappropriate python files from issue_finder

### DIFF
--- a/tools/docs/issue_finder.py
+++ b/tools/docs/issue_finder.py
@@ -38,6 +38,9 @@ else:
 for doc in list_docs:
     docs.append(doc.split('.')[0].replace('/documentation/','/'))
 for module in list_modules:
+    # skip compiled python code, and python internal use files
+    if module.split('.')[1] == 'pyc': continue
+    if '/_' in module.split('.')[0]: continue
     modules.append(module.split('.')[0])
 
 missings = 0


### PR DESCRIPTION
https://github.com/rapid7/metasploit-framework/issues/12389#issuecomment-605544096

@tekwizz123 noticed a bug in the `issue_finder.py` code where `_msf_impacket.py` and `_msf_impacket.pyc` were being listed as needing docs.  Obvi they don't, so this patch will remove all `.pyc` and files that contain with an underscore `/_`.