### PR TITLE
Correct version in vmware_fusion_lpe module doc

### DIFF
--- a/documentation/modules/exploit/osx/local/vmware_fusion_lpe.md
+++ b/documentation/modules/exploit/osx/local/vmware_fusion_lpe.md
@@ -1,6 +1,6 @@
 ## Vulnerable Application
 
-This exploits an improper use of setuid binaries within VMware Fusion 10.1.3 - 11.5.2. The `Open VMware USB Arbitrator Service` can be
+This exploits an improper use of setuid binaries within VMware Fusion 10.1.3 - 11.5.3. The `Open VMware USB Arbitrator Service` can be
 launched outide of its standard path which allows loading of an attacker controlled binary. By creating a payload in the user home
 directory in a specific folder, and creating a hard link to the `Open VMware USB Arbitrator Service`, we're able to launch it
 temporarily to start our payload with an effective UID of 0.


### PR DESCRIPTION
The terminating version is wrong. It should be 11.5.3, not 11.5.2.

Fixes #13123.