### PR TITLE
Bump payloads to 1.3.87

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,7 +27,7 @@ PATH
       metasploit-concern (~> 2.0.0)
       metasploit-credential (~> 3.0.0)
       metasploit-model (~> 2.0.4)
-      metasploit-payloads (= 1.3.86)
+      metasploit-payloads (= 1.3.87)
       metasploit_data_models (~> 3.0.10)
       metasploit_payloads-mettle (= 0.5.21)
       mqtt
@@ -214,7 +214,7 @@ GEM
       activemodel (~> 4.2.6)
       activesupport (~> 4.2.6)
       railties (~> 4.2.6)
-    metasploit-payloads (1.3.86)
+    metasploit-payloads (1.3.87)
     metasploit_data_models (3.0.10)
       activerecord (~> 4.2.6)
       activesupport (~> 4.2.6)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -70,7 +70,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model', '~> 2.0.4'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '1.3.86'
+  spec.add_runtime_dependency 'metasploit-payloads', '1.3.87'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '0.5.21'
   # Needed by msfgui and other rpc components


### PR DESCRIPTION
This PR bumps the payloads version to the new Gem to bring in the changes in https://github.com/rapid7/metasploit-payloads/pull/377

## Verification
- [x] Verify tests
