### PR TITLE
ms-5185 Add validation for rpc module selection

### DIFF
--- a/lib/msf/core/rpc/v10/rpc_module.rb
+++ b/lib/msf/core/rpc/v10/rpc_module.rb
@@ -719,11 +719,13 @@ private
 
     if mname !~ /^(exploit|payload|nop|encoder|auxiliary|post|evasion)\//
       mname = mtype + "/" + mname
+    elsif !mname.start_with?(mtype)
+      error(400, "Client provided module type '#{mtype}' did not match expected type for '#{mname}'")
     end
 
     mod = self.framework.modules.create(mname)
 
-    error(500, "Invalid Module") if not mod
+    error(500, "Invalid Module") unless mod
     mod
   end
 


### PR DESCRIPTION
Validates that the module type in an RPC request matches the type used in the module name if provided

