### PR TITLE
Fix broken ubiquiti spec

### DIFF
--- a/lib/msf/core/auxiliary/ubiquiti.rb
+++ b/lib/msf/core/auxiliary/ubiquiti.rb
@@ -243,7 +243,7 @@ module Auxiliary::Ubiquiti
           cred[:private_data] = admin_password_hash
           cred[:private_type] = :nonreplayable_hash
           login = create_credential_and_login(cred)
-          unless admin_password.empty?
+          if login.present? && admin_password.present?
             create_cracked_credential(username: admin_name, password: admin_password, core_id: login.core.id)
           end
           line['x_ssh_keys'].each do |key|


### PR DESCRIPTION
## Before

The RSpec tests for the new ubiquiti module currently fail, which has been recently added via https://github.com/rapid7/metasploit-framework/pull/12594

```
  1) Msf::Auxiliary::Ubiquiti handles ssh configurations with passwords
     Failure/Error: create_cracked_credential(username: admin_name, password: admin_password, core_id: login.core.id)
     
     NoMethodError:
       undefined method `core' for nil:NilClass
     # ./lib/msf/core/auxiliary/ubiquiti.rb:247:in `block in process_settings'
     # ./lib/msf/core/auxiliary/ubiquiti.rb:198:in `each'
     # ./lib/msf/core/auxiliary/ubiquiti.rb:198:in `process_settings'
     # ./lib/msf/core/auxiliary/ubiquiti.rb:328:in `block in unifi_config_eater'
     # ./lib/msf/core/auxiliary/ubiquiti.rb:321:in `each'
     # ./lib/msf/core/auxiliary/ubiquiti.rb:321:in `unifi_config_eater'
     # ./spec/lib/msf/core/auxiliary/ubiquiti_spec.rb:379:in `block (3 levels) in <top (required)>'
```

```
  2) Msf::Auxiliary::Ubiquiti handles ssh configurations with keys
     Failure/Error: create_cracked_credential(username: admin_name, password: admin_password, core_id: login.core.id)
     
     NoMethodError:
       undefined method `core' for nil:NilClass
     # ./lib/msf/core/auxiliary/ubiquiti.rb:247:in `block in process_settings'
     # ./lib/msf/core/auxiliary/ubiquiti.rb:198:in `each'
     # ./lib/msf/core/auxiliary/ubiquiti.rb:198:in `process_settings'
     # ./lib/msf/core/auxiliary/ubiquiti.rb:328:in `block in unifi_config_eater'
     # ./lib/msf/core/auxiliary/ubiquiti.rb:321:in `each'
     # ./lib/msf/core/auxiliary/ubiquiti.rb:321:in `unifi_config_eater'
     # ./spec/lib/msf/core/auxiliary/ubiquiti_spec.rb:408:in `block (3 levels) in <top (required)>'
     # ./vendor/bundle/ruby/2.6.0/gems/rspec-core-3.9.1/lib/rspec/core/example.rb:257:in `instance_exec'
```

## After

The `create_credential_and_login` method returning nil is now correctly handled.