### PR TITLE
Optimize network libs

### DIFF
--- a/lib/msf/core/auxiliary/brocade.rb
+++ b/lib/msf/core/auxiliary/brocade.rb
@@ -57,6 +57,7 @@ module Auxiliary::Brocade
       protocol: 'tcp',
       workspace_id: myworkspace.id,
       origin_type: :service,
+      private_type: :nonreplayable_hash,
       service_name: '',
       module_fullname: self.fullname,
       status: Metasploit::Model::Login::Status::UNTRIED
@@ -81,7 +82,6 @@ module Auxiliary::Brocade
         cred = credential_data.dup
         cred[:username] = 'enable'
         cred[:private_data] = admin_hash
-        cred[:private_type] = :nonreplayable_hash
         create_credential_and_login(cred)
       end
     end
@@ -98,7 +98,6 @@ module Auxiliary::Brocade
         cred = credential_data.dup
         cred[:username] = user_name
         cred[:private_data] = user_hash
-        cred[:private_type] = :nonreplayable_hash
         create_credential_and_login(cred)
       end
     end
@@ -117,7 +116,6 @@ module Auxiliary::Brocade
         cred[:port] = 161
         cred[:service_name] = 'snmp'
         cred[:private_data] = snmp_community
-        cred[:private_type] = :nonreplayable_hash
         create_credential_and_login(cred)
       end
     end

--- a/lib/msf/core/auxiliary/cisco.rb
+++ b/lib/msf/core/auxiliary/cisco.rb
@@ -41,6 +41,7 @@ module Auxiliary::Cisco
       protocol: 'tcp',
       workspace_id: myworkspace.id,
       origin_type: :service,
+      private_type: :password,
       service_name: '',
       module_fullname: self.fullname,
       status: Metasploit::Model::Login::Status::UNTRIED
@@ -95,7 +96,6 @@ module Auxiliary::Cisco
 
             cred = credential_data.dup
             cred[:private_data] = shash
-            cred[:private_type] = :password
             create_credential_and_login(cred)
 
           end
@@ -107,7 +107,6 @@ module Auxiliary::Cisco
 
             cred = credential_data.dup
             cred[:private_data] = shash
-            cred[:private_type] = :password
             create_credential_and_login(cred)
           end
 
@@ -117,7 +116,6 @@ module Auxiliary::Cisco
 
           cred = credential_data.dup
           cred[:private_data] = spass
-          cred[:private_type] = :password
           create_credential_and_login(cred)
 
 #
@@ -137,7 +135,6 @@ module Auxiliary::Cisco
           cred[:protocol] = "udp"
           cred[:port] = 161
           cred[:private_data] = scomm
-          cred[:private_type] = :password
           create_credential_and_login(cred)
 #
 # VTY Passwords
@@ -150,7 +147,6 @@ module Auxiliary::Cisco
 
           cred = credential_data.dup
           cred[:private_data] = spass
-          cred[:private_type] = :password
           create_credential_and_login(cred)
 
 
@@ -171,7 +167,6 @@ module Auxiliary::Cisco
 
           cred = credential_data.dup
           cred[:private_data] = spass
-          cred[:private_type] = :password
           create_credential_and_login(cred)
 
 #
@@ -202,7 +197,6 @@ module Auxiliary::Cisco
             store_loot("cisco.ios.wireless_wpapsk", "text/plain", thost, spass, "wireless_wpapsk.txt", "Cisco IOS Wireless WPA-PSK Password")
             cred = credential_data.dup
             cred[:private_data] = spass
-            cred[:private_type] = :password
             create_credential_and_login(cred)
           end
 
@@ -212,7 +206,6 @@ module Auxiliary::Cisco
             store_loot("cisco.ios.wireless_wpapsk", "text/plain", thost, spass, "wireless_wpapsk.txt", "Cisco IOS Wireless WPA-PSK Decrypted Password")
             cred = credential_data.dup
             cred[:private_data] = spass
-            cred[:private_type] = :password
             create_credential_and_login(cred)
           end
 
@@ -286,7 +279,6 @@ module Auxiliary::Cisco
             cred = credential_data.dup
             cred[:username] = user.to_s
             cred[:private_data] = spass
-            cred[:private_type] = :password
             create_credential_and_login(cred)
           end
 
@@ -298,7 +290,6 @@ module Auxiliary::Cisco
             cred = credential_data.dup
             cred[:username] = user.to_s
             cred[:private_data] = spass
-            cred[:private_type] = :password
             create_credential_and_login(cred)
           end
 
@@ -314,7 +305,6 @@ module Auxiliary::Cisco
           cred = credential_data.dup
           cred[:username] = user.to_s
           cred[:private_data] = spass
-          cred[:private_type] = :password
           create_credential_and_login(cred)
 
         when /^\s*username ([^\s]+) (secret|password) (\d+) ([^\s]+)/i
@@ -340,7 +330,6 @@ module Auxiliary::Cisco
             cred = credential_data.dup
             cred[:username] = user.to_s
             cred[:private_data] = spass
-            cred[:private_type] = :password
             create_credential_and_login(cred)
           end
 
@@ -352,18 +341,15 @@ module Auxiliary::Cisco
             cred = credential_data.dup
             cred[:username] = user.to_s
             cred[:private_data] = spass
-            cred[:private_type] = :password
             create_credential_and_login(cred)
           end
 
         # https://www.cisco.com/c/en/us/td/docs/voice_ip_comm/cucme/command/reference/cme_cr/cme_cr_chapter_010101.html#wp3722577363
         when /^\s*web admin (customer|system) name ([^\s]+) (secret [0|5]|password) ([^\s]+)/i
-          puts "GOTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT"
           login = $1
           suser = $2
           stype = $3
           spass = $4
-          puts stype.to_s
           if stype == 'secret 5'
             print_good("#{thost}:#{tport} Web Admin Username: #{suser} Type: #{login} MD5 Encrypted Password: #{spass}")
             store_loot("cisco.ios.web_username_password_hash", "text/plain", thost, "#{suser}:#{spass}", "web_username_password_hash.txt", "Cisco IOS Web Username and Password Hash (MD5)")
@@ -383,7 +369,6 @@ module Auxiliary::Cisco
             cred = credential_data.dup
             cred[:username] = suser.to_s
             cred[:private_data] = spass
-            cred[:private_type] = :password
             create_credential_and_login(cred)
           end
 
@@ -412,7 +397,6 @@ module Auxiliary::Cisco
             cred = credential_data.dup
             cred[:username] = suser.to_s
             cred[:private_data] = spass
-            cred[:private_type] = :password
             create_credential_and_login(cred)
           end
 
@@ -424,7 +408,6 @@ module Auxiliary::Cisco
             cred = credential_data.dup
             cred[:username] = suser.to_s
             cred[:private_data] = spass
-            cred[:private_type] = :password
             create_credential_and_login(cred)
           end
 
@@ -448,7 +431,6 @@ module Auxiliary::Cisco
 
             cred = credential_data.dup
             cred[:private_data] = spass
-            cred[:private_type] = :password
             create_credential_and_login(cred)
           end
 
@@ -459,7 +441,6 @@ module Auxiliary::Cisco
 
             cred = credential_data.dup
             cred[:private_data] = spass
-            cred[:private_type] = :password
             create_credential_and_login(cred)
           end
       end

--- a/lib/msf/core/auxiliary/cisco.rb
+++ b/lib/msf/core/auxiliary/cisco.rb
@@ -82,7 +82,6 @@ module Auxiliary::Cisco
 
           if stype == 5
             print_good("#{thost}:#{tport} MD5 Encrypted Enable Password: #{shash}")
-            store_loot("cisco.ios.enable_hash", "text/plain", thost, shash, "enable_password_hash.txt", "Cisco IOS Enable Password Hash (MD5)")
             cred = credential_data.dup
             cred[:jtr_format] = 'md5'
             cred[:private_data] = shash
@@ -92,19 +91,14 @@ module Auxiliary::Cisco
 
           if stype == 0 #unencrypted
             print_good("#{thost}:#{tport} Enable Password: #{shash}")
-            store_loot("cisco.ios.enable_pass", "text/plain", thost, shash, "enable_password.txt", "Cisco IOS Enable Password")
-
             cred = credential_data.dup
             cred[:private_data] = shash
             create_credential_and_login(cred)
-
           end
 
           if stype == 7
             shash = cisco_ios_decrypt7(shash) rescue shash
             print_good("#{thost}:#{tport} Decrypted Enable Password: #{shash}")
-            store_loot("cisco.ios.enable_pass", "text/plain", thost, shash, "enable_password.txt", "Cisco IOS Enable Password")
-
             cred = credential_data.dup
             cred[:private_data] = shash
             create_credential_and_login(cred)
@@ -153,8 +147,6 @@ module Auxiliary::Cisco
         when /^\s*(password|secret) 5 (.*)/i
           shash = $2.strip
           print_good("#{thost}:#{tport} MD5 Encrypted VTY Password: #{shash}")
-          store_loot("cisco.ios.vty_password", "text/plain", thost, shash, "vty_password_hash.txt", "Cisco IOS VTY Password Hash (MD5)")
-
           cred = credential_data.dup
           cred[:jtr_format] = 'md5'
           cred[:private_data] = shash
@@ -175,7 +167,6 @@ module Auxiliary::Cisco
         when /^\s*encryption key \d+ size \d+bit (\d+) ([^\s]+)/
           spass = $2.strip
           print_good("#{thost}:#{tport} Wireless WEP Key: #{spass}")
-          store_loot("cisco.ios.wireless_wep", "text/plain", thost, spass, "wireless_wep.txt", "Cisco IOS Wireless WEP Key")
 
         when /^\s*wpa-psk (ascii|hex) (\d+) ([^\s]+)/i
 
@@ -184,7 +175,6 @@ module Auxiliary::Cisco
 
           if stype == 5
             print_good("#{thost}:#{tport} Wireless WPA-PSK MD5 Password Hash: #{spass}")
-            store_loot("cisco.ios.wireless_wpapsk_hash", "text/plain", thost, spass, "wireless_wpapsk_hash.txt", "Cisco IOS Wireless WPA-PSK Password Hash (MD5)")
             cred = credential_data.dup
             cred[:jtr_format] = 'md5'
             cred[:private_data] = spass
@@ -194,7 +184,6 @@ module Auxiliary::Cisco
 
           if stype == 0
             print_good("#{thost}:#{tport} Wireless WPA-PSK Password: #{spass}")
-            store_loot("cisco.ios.wireless_wpapsk", "text/plain", thost, spass, "wireless_wpapsk.txt", "Cisco IOS Wireless WPA-PSK Password")
             cred = credential_data.dup
             cred[:private_data] = spass
             create_credential_and_login(cred)
@@ -203,7 +192,6 @@ module Auxiliary::Cisco
           if stype == 7
             spass = cisco_ios_decrypt7(spass) rescue spass
             print_good("#{thost}:#{tport} Wireless WPA-PSK Decrypted Password: #{spass}")
-            store_loot("cisco.ios.wireless_wpapsk", "text/plain", thost, spass, "wireless_wpapsk.txt", "Cisco IOS Wireless WPA-PSK Decrypted Password")
             cred = credential_data.dup
             cred[:private_data] = spass
             create_credential_and_login(cred)
@@ -217,8 +205,6 @@ module Auxiliary::Cisco
           shost  = $2
 
           print_good("#{thost}:#{tport} VPN IPSEC ISAKMP Key '#{spass}' Host '#{shost}'")
-          store_loot("cisco.ios.vpn_ipsec_key", "text/plain", thost, "#{spass}", "vpn_ipsec_key.txt", "Cisco VPN IPSEC Key")
-
           cred = credential_data.dup
           cred[:private_data] = spass
           cred[:private_type] = :nonreplayable_hash
@@ -232,8 +218,6 @@ module Auxiliary::Cisco
           siface = tuniface
 
           print_good("#{thost}:#{tport} GRE Tunnel Key #{spass} for Interface Tunnel #{siface}")
-          store_loot("cisco.ios.gre_tunnel_key", "text/plain", thost, "tunnel#{siface}_#{spass}", "gre_tunnel_key.txt", "Cisco GRE Tunnel Key")
-
           cred = credential_data.dup
           cred[:private_data] = spass
           cred[:private_type] = :nonreplayable_hash
@@ -244,8 +228,6 @@ module Auxiliary::Cisco
           siface = tuniface
 
           print_good("#{thost}:#{tport} NHRP Authentication Key #{spass} for Interface Tunnel #{siface}")
-          store_loot("cisco.ios.nhrp_tunnel_key", "text/plain", thost, "tunnel#{siface}_#{spass}", "nhrp_tunnel_key.txt", "Cisco NHRP Authentication Key")
-
           cred = credential_data.dup
           cred[:private_data] = spass
           cred[:private_type] = :nonreplayable_hash
@@ -263,7 +245,6 @@ module Auxiliary::Cisco
 
           if stype == 5
             print_good("#{thost}:#{tport} Username '#{user}' with MD5 Encrypted Password: #{spass}")
-            store_loot("cisco.ios.username_password_hash", "text/plain", thost, "#{user}_level#{priv}:#{spass}", "username_password_hash.txt", "Cisco IOS Username and Password Hash (MD5)")
             cred = credential_data.dup
             cred[:jtr_format] = 'md5'
             cred[:username] = user.to_s
@@ -274,8 +255,6 @@ module Auxiliary::Cisco
 
           if stype == 0
             print_good("#{thost}:#{tport} Username '#{user}' with Password: #{spass}")
-            store_loot("cisco.ios.username_password", "text/plain", thost, "#{user}_level#{priv}:#{spass}", "username_password.txt", "Cisco IOS Username and Password")
-
             cred = credential_data.dup
             cred[:username] = user.to_s
             cred[:private_data] = spass
@@ -285,8 +264,6 @@ module Auxiliary::Cisco
           if stype == 7
             spass = cisco_ios_decrypt7(spass) rescue spass
             print_good("#{thost}:#{tport} Username '#{user}' with Decrypted Password: #{spass}")
-            store_loot("cisco.ios.username_password", "text/plain", thost, "#{user}_level#{priv}:#{spass}", "username_password.txt", "Cisco IOS Username and Password")
-
             cred = credential_data.dup
             cred[:username] = user.to_s
             cred[:private_data] = spass
@@ -301,7 +278,6 @@ module Auxiliary::Cisco
           user  = $1
           spass = $2
           print_good("#{thost}:#{tport} ePhone Username '#{user}' with Password: #{spass}")
-          store_loot("cisco.ios.ephone.username_password", "text/plain", thost, "#{user}:#{spass}", "ephone_username_password.txt", "Cisco IOS ephone Username and Password")
           cred = credential_data.dup
           cred[:username] = user.to_s
           cred[:private_data] = spass
@@ -314,7 +290,6 @@ module Auxiliary::Cisco
 
           if stype == 5
             print_good("#{thost}:#{tport} Username '#{user}' with MD5 Encrypted Password: #{spass}")
-            store_loot("cisco.ios.username_password_hash", "text/plain", thost, "#{user}:#{spass}", "username_password_hash.txt", "Cisco IOS Username and Password Hash (MD5)")
             cred = credential_data.dup
             cred[:jtr_format] = 'md5'
             cred[:username] = user.to_s
@@ -325,8 +300,6 @@ module Auxiliary::Cisco
 
           if stype == 0
             print_good("#{thost}:#{tport} Username '#{user}' with Password: #{spass}")
-            store_loot("cisco.ios.username_password", "text/plain", thost, "#{user}:#{spass}", "username_password.txt", "Cisco IOS Username and Password")
-
             cred = credential_data.dup
             cred[:username] = user.to_s
             cred[:private_data] = spass
@@ -336,8 +309,6 @@ module Auxiliary::Cisco
           if stype == 7
             spass = cisco_ios_decrypt7(spass) rescue spass
             print_good("#{thost}:#{tport} Username '#{user}' with Decrypted Password: #{spass}")
-            store_loot("cisco.ios.username_password", "text/plain", thost, "#{user}:#{spass}", "username_password.txt", "Cisco IOS Username and Password")
-
             cred = credential_data.dup
             cred[:username] = user.to_s
             cred[:private_data] = spass
@@ -352,8 +323,6 @@ module Auxiliary::Cisco
           spass = $4
           if stype == 'secret 5'
             print_good("#{thost}:#{tport} Web Admin Username: #{suser} Type: #{login} MD5 Encrypted Password: #{spass}")
-            store_loot("cisco.ios.web_username_password_hash", "text/plain", thost, "#{suser}:#{spass}", "web_username_password_hash.txt", "Cisco IOS Web Username and Password Hash (MD5)")
-
             cred = credential_data.dup
             cred[:jtr_format] = 'md5'
             cred[:username] = suser.to_s
@@ -364,8 +333,6 @@ module Auxiliary::Cisco
 
           if stype == 'secret 0' || stype == 'password'
             print_good("#{thost}:#{tport} Web Username: #{suser} Type: #{login} Password: #{spass}")
-            store_loot("cisco.ios.web_username_password", "text/plain", thost, "#{suser}:#{spass}", "web_username_password.txt", "Cisco IOS Web Username and Password")
-
             cred = credential_data.dup
             cred[:username] = suser.to_s
             cred[:private_data] = spass
@@ -380,8 +347,6 @@ module Auxiliary::Cisco
 
           if stype == 5
             print_good("#{thost}:#{tport} PPP Username #{suser} MD5 Encrypted Password: #{spass}")
-            store_loot("cisco.ios.ppp_username_password_hash", "text/plain", thost, "#{suser}:#{spass}", "ppp_username_password_hash.txt", "Cisco IOS PPP Username and Password Hash (MD5)")
-
             cred = credential_data.dup
             cred[:jtr_format] = 'md5'
             cred[:username] = suser.to_s
@@ -392,8 +357,6 @@ module Auxiliary::Cisco
 
           if stype == 0
             print_good("#{thost}:#{tport} PPP Username: #{suser} Password: #{spass}")
-            store_loot("cisco.ios.ppp_username_password", "text/plain", thost, "#{suser}:#{spass}", "ppp_username_password.txt", "Cisco IOS PPP Username and Password")
-
             cred = credential_data.dup
             cred[:username] = suser.to_s
             cred[:private_data] = spass
@@ -403,8 +366,6 @@ module Auxiliary::Cisco
           if stype == 7
             spass = cisco_ios_decrypt7(spass) rescue spass
             print_good("#{thost}:#{tport} PPP Username: #{suser} Decrypted Password: #{spass}")
-            store_loot("cisco.ios.ppp_username_password", "text/plain", thost, "#{suser}:#{spass}", "ppp_username_password.txt", "Cisco IOS PPP Username and Password")
-
             cred = credential_data.dup
             cred[:username] = suser.to_s
             cred[:private_data] = spass
@@ -417,7 +378,6 @@ module Auxiliary::Cisco
 
           if stype == 5
             print_good("#{thost}:#{tport} PPP CHAP MD5 Encrypted Password: #{spass}")
-            store_loot("cisco.ios.ppp_password_hash", "text/plain", thost, spass, "ppp_password_hash.txt", "Cisco IOS PPP Password Hash (MD5)")
             cred = credential_data.dup
             cred[:jtr_format] = 'md5'
             cred[:private_data] = spass
@@ -427,8 +387,6 @@ module Auxiliary::Cisco
 
           if stype == 0
             print_good("#{thost}:#{tport} Password: #{spass}")
-            store_loot("cisco.ios.ppp_password", "text/plain", thost, spass, "ppp_password.txt", "Cisco IOS PPP Password")
-
             cred = credential_data.dup
             cred[:private_data] = spass
             create_credential_and_login(cred)
@@ -437,8 +395,6 @@ module Auxiliary::Cisco
           if stype == 7
             spass = cisco_ios_decrypt7(spass) rescue spass
             print_good("#{thost}:#{tport} PPP Decrypted Password: #{spass}")
-            store_loot("cisco.ios.ppp_password", "text/plain", thost, spass, "ppp_password.txt", "Cisco IOS PPP Password")
-
             cred = credential_data.dup
             cred[:private_data] = spass
             create_credential_and_login(cred)

--- a/lib/msf/core/auxiliary/juniper.rb
+++ b/lib/msf/core/auxiliary/juniper.rb
@@ -33,6 +33,7 @@ module Auxiliary::Juniper
       workspace_id: myworkspace.id,
       origin_type: :service,
       service_name: '',
+      private_type: :nonreplayable_hash,
       module_fullname: self.fullname,
       status: Metasploit::Model::Login::Status::UNTRIED
     }
@@ -50,7 +51,6 @@ module Auxiliary::Juniper
       cred = credential_data.dup
       cred[:username] = admin_name
       cred[:private_data] = admin_hash
-      cred[:private_type] = :nonreplayable_hash
       create_credential_and_login(cred)
     end
 
@@ -70,7 +70,6 @@ module Auxiliary::Juniper
       cred[:username] = user_name
       cred[:jtr_format] = 'sha1'
       cred[:private_data] = user_hash
-      cred[:private_type] = :nonreplayable_hash
       create_credential_and_login(cred)
     end
 
@@ -111,7 +110,6 @@ module Auxiliary::Juniper
       cred[:private_data] = ppp_hash
       cred[:service_name] = 'PPTP'
       cred[:port] = 1723
-      cred[:private_type] = :nonreplayable_hash
       create_credential_and_login(cred)
     end
 
@@ -151,6 +149,7 @@ module Auxiliary::Juniper
       protocol: 'tcp',
       workspace_id: myworkspace.id,
       origin_type: :service,
+      private_type: :nonreplayable_hash,
       service_name: '',
       module_fullname: self.fullname,
       status: Metasploit::Model::Login::Status::UNTRIED
@@ -176,7 +175,6 @@ module Auxiliary::Juniper
       cred[:username] = 'root'
       cred[:jtr_format] = jtr_format
       cred[:private_data] = root_hash
-      cred[:private_type] = :nonreplayable_hash
       create_credential_and_login(cred)
     end
 
@@ -193,7 +191,6 @@ module Auxiliary::Juniper
       cred[:username] = user_name
       cred[:jtr_format] = jtr_format
       cred[:private_data] = user_hash
-      cred[:private_type] = :nonreplayable_hash
       create_credential_and_login(cred)
     end
 
@@ -225,7 +222,6 @@ module Auxiliary::Juniper
       cred[:port] = 1812
       cred[:protocol] = 'udp'
       cred[:private_data] = radius_hash
-      cred[:private_type] = :nonreplayable_hash
       cred[:service_name] = 'radius'
       create_credential_and_login(cred)
     end
@@ -239,7 +235,6 @@ module Auxiliary::Juniper
       cred[:private_data] = ppp_hash
       cred[:service_name] = 'pptp'
       cred[:port] = 1723
-      cred[:private_type] = :nonreplayable_hash
       create_credential_and_login(cred)
     end
 

--- a/lib/msf/core/auxiliary/ubiquiti.rb
+++ b/lib/msf/core/auxiliary/ubiquiti.rb
@@ -98,17 +98,19 @@ module Auxiliary::Ubiquiti
     # {"__cmd"=>"select", "collection"=>"heatmap"}
     # we can pull the relevant section name via the collection value.
 
-    credential_data = {
-      address: thost,
-      port: tport,
-      protocol: 'tcp',
-      workspace_id: myworkspace.id,
-      origin_type: :service,
-      private_type: :password,
-      service_name: '',
-      module_fullname: self.fullname,
-      status: Metasploit::Model::Login::Status::UNTRIED
-    }
+    def creds_template(thost, tport)
+      {
+        address: thost,
+        port: tport,
+        protocol: 'tcp',
+        workspace_id: myworkspace.id,
+        origin_type: :service,
+        private_type: :password,
+        service_name: '',
+        module_fullname: self.fullname,
+        status: Metasploit::Model::Login::Status::UNTRIED
+      }
+    end
 
     report_host({
       :host => thost,
@@ -120,13 +122,13 @@ module Auxiliary::Ubiquiti
     # Example BSON lines
     # {"__cmd"=>"select", "collection"=>"admin"}
     # {"_id"=>BSON::ObjectId('5c7f23af3825ce2067a1d9ce'), "name"=>"adminuser", "email"=>"admin@admin.com", "x_shadow"=>"$6$R4qnAaaF$AAAlL2t.fXu0aaa9z3uvcIm3ujbtJLhIO.lN1xZqHZPQoUAXs2BUTmI5UbuBo2/8t3epzbVLib17Ls7GCVx7V.", "time_created"=>1551825823, "last_site_name"=>"default", "ubic_name"=>"admin@admin.com", "ubic_uuid"=>"c23da064-3f4d-282f-1dc9-7e25f9c6812c", "ui_settings"=>{"dashboardConfig"=>{"lastActiveDashboardId"=>"2c7f2d213813ce2487d1ac38", "dashboards"=>{"3c7f678a3815ce2021d1d9c7"=>{"order"=>1}, "5b4f2d269115ce2087d1abb9"=>{}}}}}
-    def process_admin(lines, credential_data)
+    def process_admin(lines, cred_template)
       lines.each do |line|
         admin_name = line['name']
         admin_email = line['email']
         admin_password_hash = line['x_shadow']
         print_good("Admin user #{admin_name} with email #{admin_email} found with password hash #{admin_password_hash}")
-        cred = credential_data.dup
+        cred = cred_template
         cred[:username] = admin_name
         cred[:private_data] = admin_password_hash
         cred[:private_type] = :nonreplayable_hash
@@ -137,7 +139,7 @@ module Auxiliary::Ubiquiti
     # Example BSON lines
     # {"__cmd"=>"select", "collection"=>"firewallrule"}
     # {"_id"=>BSON::ObjectId('5c7f23af3825ce2067a1d9ce'), "ruleset" => "WAN_OUT", "rule_index" => "2000", "name" => "Block Example", "enabled" => true, "action" => "reject", "protocol_match_excepted" => false, "logging" => false, "state_new" => false, "state_established" => false, "state_invalid" => false, "state_related" => false, "ipsec" => "", "src_firewallgroup_ids" => ["1a1c15a11111ce14b1f1111a"], "src_mac_address" => "", "dst_firewallgroup_ids" => [], "dst_address" => "", "src_address" => "", "protocol" => "all", "icmp_typename" => "", "src_networkconf_id" => "", "src_networkconf_type" => "NETv4", "dst_networkconf_id" => "", "dst_networkconf_type" => "NETv4", "site_id" => "1c1f208b3815ce1111a1a1a1"}
-    def process_firewallrule(lines)
+    def process_firewallrule(lines, _)
       lines.each do |line|
         rule = "#{line['action']}"
         unless line['dst_address'].empty?
@@ -161,7 +163,7 @@ module Auxiliary::Ubiquiti
     # Example BSON lines
     # {"__cmd"=>"select", "collection"=>"radiusprofile"}
     # {"_id"=>BSON::ObjectId('2c7a318c38c5ce2f86d179cb'), "attr_no_delete"=>true, "attr_hidden_id"=>"Default", "name"=>"Default", "site_id"=>"3c7f226b2315be2087a1d5b2", "use_usg_auth_server"=>true, "auth_servers"=>[{"ip"=>"192.168.0.1", "port"=>1812, "x_secret"=>""}], "acct_servers"=>[]}
-    def process_radiusprofile(lines, credential_data)
+    def process_radiusprofile(lines, cred_template)
       lines.each do |line|
         line['auth_servers'].each do |server|
           report_service(
@@ -172,7 +174,7 @@ module Auxiliary::Ubiquiti
           )
           if server['x_secret'] # no need to output if the secret is blank, therefore its not configured
             print_good("Radius server: #{server['ip']}:#{server['port']} with secret '#{server['x_secret']}'")
-            cred = credential_data.dup
+            cred = cred_template
             cred[:username] = ''
             cred[:private_data] = server['x_secret']
             cred[:address] = server['ip']
@@ -194,11 +196,11 @@ module Auxiliary::Ubiquiti
     # {"_id"=>BSON::ObjectId('3c3e21ac3715ce20a721d9bb'), "site_id"=>"3c2f215b3825ca2087c1dfb6", "key"=>"mgmt", "advanced_feature_enabled"=>false, "x_ssh_enabled"=>true, "x_ssh_bind_wildcard"=>false, "x_ssh_auth_password_enabled"=>true, "unifi_idp_enabled"=>true, "x_mgmt_key"=>"ba6cbe170f8276cd86b24ac79ab29afc", "x_ssh_username"=>"admin", "x_ssh_password"=>"16xoB6F2UyAcU6fP", "x_ssh_keys"=>[], "x_ssh_sha512passwd"=>"$6$R4qnAaaF$AAAlL2t.fXu0aaa9z3uvcIm3ujbtJLhIO.lN1xZqHZPQoUAXs2BUTmI5UbuBo2/8t3epzbVLib17Ls7GCVx7V."}
     # {"_id"=>BSON::ObjectId('3c3e21ac3715ce20a721d9bc'), "site_id"=>"3c2f215b3825ca2087c1dfb6", "key"=>"connectivity", "enabled"=>true, "uplink_type"=>"gateway", "x_mesh_essid"=>"vwire-851237d214c8c6ba", "x_mesh_psk"=>"523a9b872b4624c7894f96c3ae22cdfa"}
     # {"_id"=>BSON::ObjectId('3c3e21ac3715ce20a721d9bd'), "site_id"=>"3c2f215b3825ca2087c1dfb6", "key"=>"snmp", "community": "public", "enabled": true, "enabledV3": true, "username": "usernamesnmpv3", "x_password": "passwordsnmpv3"}
-    def process_settings(lines, credential_data)
+    def process_setting(lines, cred_template)
       lines.each do |line|
         case line['key']
         when 'snmp'
-          cred = credential_data.dup
+          cred = cred_template
           cred[:protocol] = 'udp'
           cred[:port] = 161
           cred[:service_name] = 'snmp'
@@ -214,7 +216,7 @@ module Auxiliary::Ubiquiti
             print_good("SNMP v3 #{line['enabledV3'] ? 'enabled' : 'disabled'} with username #{line['username']} password #{line['x_password']}")
           end
         when 'connectivity'
-          cred = credential_data.dup
+          cred = cred_template
           cred[:username] = line['x_mesh_essid']
           cred[:private_data] = line['x_mesh_psk']
           create_credential_and_login(cred)
@@ -236,7 +238,7 @@ module Auxiliary::Ubiquiti
           admin_password_hash = line['x_ssh_sha512passwd']
           admin_password = line['x_ssh_password']
           print_good("SSH user #{admin_name} found with password #{admin_password} and hash #{admin_password_hash}")
-          cred = credential_data.dup
+          cred = cred_template
           cred[:username] = admin_name
           cred[:private_data] = admin_password_hash
           cred[:private_type] = :nonreplayable_hash
@@ -254,12 +256,12 @@ module Auxiliary::Ubiquiti
     # Example lines
     # {"__cmd"=>"select", "collection"=>"wlanconf"}
     # {"_id"=>BSON::ObjectId('3c3e21ac3715ce20a721d9ba'), "enabled" => true, "security" => "wpapsk", "wep_idx" => 1, "wpa_mode" => "wpa2", "wpa_enc" => "ccmp", "usergroup_id" => "5a7f111a3815ce1111a1d1c3", "dtim_mode" => "default", "dtim_ng" => 1, "dtim_na" => 1, "minrate_ng_enabled" => false, "minrate_ng_advertising_rates" => false, "minrate_ng_data_rate_kbps" => 1000, "minrate_ng_cck_rates_enabled" => true, "minrate_na_enabled" => false, "minrate_na_advertising_rates" => false, "minrate_na_data_rate_kbps" => 6000, "mac_filter_enabled" => false, "mac_filter_policy" => "allow", "mac_filter_list" => [], "bc_filter_enabled" => false, "bc_filter_list" => [], "group_rekey" => 3600, "name" => "ssid_name", "x_passphrase" => "supersecret", "wlangroup_id" => "5c7f208c3815ce2087d1d9c4", "schedule" => [], "minrate_ng_mgmt_rate_kbps" => 1000, "minrate_na_mgmt_rate_kbps" => 6000, "minrate_ng_beacon_rate_kbps" => 1000, "minrate_na_beacon_rate_kbps" => 6000, "site_id" => "5c7f208b3815ce2087d1d9b6", "x_iapp_key" => "d11a1c86df1111be86aaa69e8aa1c57f", "no2ghz_oui" => true}
-    def process_wlanconf(lines, credential_data)
+    def process_wlanconf(lines, cred_template)
       lines.each do |line|
         ssid = line['name']
         mode = line['security']
         password = line['x_passphrase']
-        cred = credential_data.dup
+        cred = cred_template
         cred[:username] = ssid
         cred[:private_data] = password
         create_credential_and_login(cred)
@@ -270,7 +272,7 @@ module Auxiliary::Ubiquiti
     # Example lines
     # {"__cmd"=>"select", "collection"=>"firewallgroup"}
     # {"_id"=>BSON::ObjectId('3c3e21ac3715ce20a721d9ba'), "name" => "Cameras", "group_type" => "address-group", "group_members" => ["1.1.1.1"], "site_id" => "5c7f111b3815ce208aaa111a"}
-    def process_firewallgroup(lines)
+    def process_firewallgroup(lines, _)
       lines.each do |line|
         print_status("Firewall Group: #{line['name']}, group type: #{line['group_type']}, members: #{line['group_members'].join(', ')}")
       end
@@ -279,7 +281,7 @@ module Auxiliary::Ubiquiti
     # Example lines
     # {"__cmd"=>"select", "collection"=>"device"}
     # {"_id"=>BSON::ObjectId('3c3e21ac3715ce20a721d9ba'), "ip" => "5.5.5.5", "mac" => "cc:cc:cc:cc:cc:cc", "model" => "UGW3", "type" => "ugw", "version" => "4.4.44.5213844", "adopted" => true, "site_id" => "5aaaaaabaaaaae1117d1d1b6", "x_authkey" => "eaaaaaaa63e59ab89c111e11d6e11aa1", "cfgversion" => "aaa4b11b1df1a111", "config_network" => {"type" => "dhcp", "ip" => "1.1.1.1"}, "license_state" => "registered", "two_phase_adopt" => false, "unsupported" => false, "unsupported_reason" => 0, "x_fingerprint" => "aa:aa:11:aa:11:11:11:11:11:11:11:11:11:11:11:11", "x_ssh_hostkey" => "MIIBIjANBgkAhkiG9w0AAQEFAAOCAQ8AMIIBCgKCAQEAAU4S/7r548xvtGuHlgAAAKzkrL+t97ZWAZru8wQFbltEB4111HiIAkzt041td8V+P7c1bQtn3YQdViAuH2h2sgt8feAvMWo56OskAoDvHwAEv5AWqmPKy/xmKbdfgA5wTzvSztPGFA4QuOuA1YxQICf1MgpoOtplAAA31JxAYF/t7n8qgvJlm1JRv2AAAZHHtSiz1IaxzOO9LAAAqCfHvHugPcZYk2yAAAP7JrnnR1fAVj9F4aaYaA0eSjvDTAglykXHCbh1EWAAAecqHZ/SWn9cjmuAAArZxxG6m6Eu/aj9we82/PmtKzQGN0RWUsgrxajQowtNpVsNTnaOglUsfQIDAAAA", "x_ssh_hostkey_fingerprint" => "11:11:11:11:11:11:11:11:11:11:11:11:11:11:11:11", "inform_url" => "http://1.1.2.2:8080/inform", "inform_ip" => "1.1.1.1", "serial" => "AAAAAAAAAAAA", "required_version" => "4.0.0", "ethernet_table" => [{ "mac" => "b4:fb:e4:cc:cc:cc", "num_port" => 1, "name" => "eth0"}, {"mac" => "b4:fb:e4:bb:bb:bb", "num_port" => 1, "name" => "eth1"}, {"mac" => "b4:fb:e4:aa:aa:aa", "num_port" => 1, "name" => "eth2"}], "fw_caps" => 184323, "hw_caps" => 0, "usg_caps" => 786431, "board_rev" => 16, "x_aes_gcm" => true, "ethernet_overrides" => [{"ifname" => "eth1", "networkgroup" => "LAN"}, {"ifname" => "eth0", "networkgroup" => "WAN"}], "led_override" => "default", "led_override_color" => "#0000ff", "led_override_color_brightness" => 100, "outdoor_mode_override" => "default", "name" => "USG", "map_id" => "1a111c2e1111ce2087d1e199", "x" => -22.11111198630405, "y" => -41.1111113859866, "heightInMeters" => 2.4}
-    def process_device(lines)
+    def process_device(lines, _)
       lines.each do |line|
         report_host({
          :host => line['ip'],
@@ -294,7 +296,7 @@ module Auxiliary::Ubiquiti
     # Example lines
     # {"__cmd"=>"select", "collection"=>"user"}
     # {"_id"=>BSON::ObjectId('3c3e21ac3715ce20a721d9ba'), "mac" => "00:0c:29:11:aa:11", "site_id" => "5c7f111b1111aa2087d11111", "oui" => "Vmware", "is_guest" => false, "first_seen" => 1551111161, "last_seen" => 1561621747, "is_wired" => true, "hostname" => "android", "usergroup_id" => "", "name" => "example device", "noted" => true, "use_fixedip" =>  true, "network_id" => "1c7f111a1115aa2087aaa9aa", "fixed_ip" => "7.7.7.7"}
-    def process_user_device(lines)
+    def process_user(lines, _)
       lines.each do |line|
         host_hash = {
          :name => line['hostname'],
@@ -316,26 +318,10 @@ module Auxiliary::Ubiquiti
 
     # here is where we actually process the file
     config.each do |key,value|
-      case key
-      when 'admin'
-        process_admin(value, credential_data)
-      when 'radiusprofile'
-        process_radiusprofile(value, credential_data)
-      when 'setting'
-        process_settings(value, credential_data)
-      when 'firewallrule'
-        process_firewallrule(value)
-      when 'wlanconf'
-        process_wlanconf(value, credential_data)
-      when 'firewallgroup'
-        process_firewallgroup(value)
-      when 'device'
-        process_device(value)
-      when 'user'
-        process_user_device(value)
-      end
+      next unless self.respond_to?("process_#{key}")
+      cred = creds_template(thost, tport)
+      self.send("process_#{key}", value, cred)
     end
-
   end
 end
 end

--- a/lib/msf/core/auxiliary/ubiquiti.rb
+++ b/lib/msf/core/auxiliary/ubiquiti.rb
@@ -104,6 +104,7 @@ module Auxiliary::Ubiquiti
       protocol: 'tcp',
       workspace_id: myworkspace.id,
       origin_type: :service,
+      private_type: :password,
       service_name: '',
       module_fullname: self.fullname,
       status: Metasploit::Model::Login::Status::UNTRIED
@@ -174,7 +175,6 @@ module Auxiliary::Ubiquiti
             cred = credential_data.dup
             cred[:username] = ''
             cred[:private_data] = server['x_secret']
-            cred[:private_type] = :password
             cred[:address] = server['ip']
             cred[:port] = server['port']
             create_credential_and_login(cred)
@@ -202,7 +202,6 @@ module Auxiliary::Ubiquiti
           cred[:protocol] = 'udp'
           cred[:port] = 161
           cred[:service_name] = 'snmp'
-          cred[:private_type] = :password
           unless line['community'].blank?
             cred[:private_data] = line['community']
             create_credential_and_login(cred)
@@ -218,7 +217,6 @@ module Auxiliary::Ubiquiti
           cred = credential_data.dup
           cred[:username] = line['x_mesh_essid']
           cred[:private_data] = line['x_mesh_psk']
-          cred[:private_type] = :password
           create_credential_and_login(cred)
           print_good("Mesh Wifi Network #{line['x_mesh_essid']} password #{line['x_mesh_psk']}")
         when 'ntp'
@@ -264,7 +262,6 @@ module Auxiliary::Ubiquiti
         cred = credential_data.dup
         cred[:username] = ssid
         cred[:private_data] = password
-        cred[:private_type] = :password
         create_credential_and_login(cred)
         print_good("#{line['enabled'] ? 'Enabled' : 'Disabled'} wifi #{ssid} on #{mode}(#{line['wpa_mode']},#{line['wpa_enc']}) has password #{password}")
       end

--- a/spec/lib/msf/core/auxiliary/cisco_spec.rb
+++ b/spec/lib/msf/core/auxiliary/cisco_spec.rb
@@ -109,9 +109,6 @@ RSpec.describe Msf::Auxiliary::Cisco do
         expect(aux_cisco).to receive(:print_good).with('127.0.0.1:1337 Enable Password: 1511021F0725')
         expect(aux_cisco).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Cisco IOS'})
         expect(aux_cisco).to receive(:store_loot).with(
-          "cisco.ios.enable_pass", "text/plain", "127.0.0.1", "1511021F0725", "enable_password.txt", "Cisco IOS Enable Password"
-        )
-        expect(aux_cisco).to receive(:store_loot).with(
           "cisco.ios.config", "text/plain", "127.0.0.1", "enable password 0 1511021F0725", "config.txt", "Cisco IOS Configuration"
         )
         expect(aux_cisco).to receive(:create_credential_and_login).with(
@@ -156,9 +153,6 @@ RSpec.describe Msf::Auxiliary::Cisco do
       it 'with password type 7' do
         expect(aux_cisco).to receive(:print_good).with('127.0.0.1:1337 Decrypted Enable Password: cisco')
         expect(aux_cisco).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Cisco IOS'})
-        expect(aux_cisco).to receive(:store_loot).with(
-          "cisco.ios.enable_pass", "text/plain", "127.0.0.1", "cisco", "enable_password.txt", "Cisco IOS Enable Password"
-        )
         expect(aux_cisco).to receive(:store_loot).with(
           "cisco.ios.config", "text/plain", "127.0.0.1", "enable password 7 1511021F0725", "config.txt", "Cisco IOS Configuration"
         )
@@ -253,9 +247,6 @@ RSpec.describe Msf::Auxiliary::Cisco do
     it 'password 7' do
       expect(aux_cisco).to receive(:print_good).with('127.0.0.1:1337 Decrypted VTY Password: cisco')
       expect(aux_cisco).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Cisco IOS'})
-      expect(aux_cisco).to receive(:store_loot).with(
-        "cisco.ios.config", "text/plain", "127.0.0.1", "password 7 1511021F0725", "config.txt", "Cisco IOS Configuration"
-      )
       expect(aux_cisco).to receive(:create_credential_and_login).with(
         {
           address: "127.0.0.1",
@@ -276,9 +267,6 @@ RSpec.describe Msf::Auxiliary::Cisco do
     it 'password|secret 5' do
       expect(aux_cisco).to receive(:print_good).with('127.0.0.1:1337 MD5 Encrypted VTY Password: 1511021F0725')
       expect(aux_cisco).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Cisco IOS'})
-      expect(aux_cisco).to receive(:store_loot).with(
-        "cisco.ios.vty_password", "text/plain", "127.0.0.1", "1511021F0725", "vty_password_hash.txt", "Cisco IOS VTY Password Hash (MD5)"
-      )
       expect(aux_cisco).to receive(:store_loot).with(
         "cisco.ios.config", "text/plain", "127.0.0.1", "password 5 1511021F0725", "config.txt", "Cisco IOS Configuration"
       )
@@ -352,9 +340,6 @@ RSpec.describe Msf::Auxiliary::Cisco do
       expect(aux_cisco).to receive(:store_loot).with(
         "cisco.ios.config", "text/plain", "127.0.0.1", "encryption key 777 size 8bit 8 1511021F0725", "config.txt", "Cisco IOS Configuration"
       )
-      expect(aux_cisco).to receive(:store_loot).with(
-        "cisco.ios.wireless_wep", "text/plain", "127.0.0.1", "1511021F0725", "wireless_wep.txt", "Cisco IOS Wireless WEP Key"
-      )
       aux_cisco.cisco_ios_config_eater('127.0.0.1',1337,'encryption key 777 size 8bit 8 1511021F0725')
     end
 
@@ -364,9 +349,6 @@ RSpec.describe Msf::Auxiliary::Cisco do
         expect(aux_cisco).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Cisco IOS'})
         expect(aux_cisco).to receive(:store_loot).with(
           "cisco.ios.config", "text/plain", "127.0.0.1", "wpa-psk ascii 0 1511021F0725", "config.txt", "Cisco IOS Configuration"
-        )
-        expect(aux_cisco).to receive(:store_loot).with(
-          "cisco.ios.wireless_wpapsk", "text/plain", "127.0.0.1", "1511021F0725", "wireless_wpapsk.txt", "Cisco IOS Wireless WPA-PSK Password"
         )
         expect(aux_cisco).to receive(:create_credential_and_login).with(
           {
@@ -391,9 +373,6 @@ RSpec.describe Msf::Auxiliary::Cisco do
         expect(aux_cisco).to receive(:store_loot).with(
           "cisco.ios.config", "text/plain", "127.0.0.1", "wpa-psk ascii 5 1511021F0725", "config.txt", "Cisco IOS Configuration"
         )
-        expect(aux_cisco).to receive(:store_loot).with(
-          "cisco.ios.wireless_wpapsk_hash", "text/plain", "127.0.0.1", "1511021F0725", "wireless_wpapsk_hash.txt", "Cisco IOS Wireless WPA-PSK Password Hash (MD5)"
-        )
         expect(aux_cisco).to receive(:create_credential_and_login).with(
           {
             address: "127.0.0.1",
@@ -417,9 +396,6 @@ RSpec.describe Msf::Auxiliary::Cisco do
         expect(aux_cisco).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Cisco IOS'})
         expect(aux_cisco).to receive(:store_loot).with(
           "cisco.ios.config", "text/plain", "127.0.0.1", "wpa-psk ascii 7 1511021F0725", "config.txt", "Cisco IOS Configuration"
-        )
-        expect(aux_cisco).to receive(:store_loot).with(
-          "cisco.ios.wireless_wpapsk", "text/plain", "127.0.0.1", "cisco", "wireless_wpapsk.txt", "Cisco IOS Wireless WPA-PSK Decrypted Password"
         )
         expect(aux_cisco).to receive(:create_credential_and_login).with(
           {
@@ -446,9 +422,6 @@ RSpec.describe Msf::Auxiliary::Cisco do
       expect(aux_cisco).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Cisco IOS'})
       expect(aux_cisco).to receive(:store_loot).with(
         "cisco.ios.config", "text/plain", "127.0.0.1",  "crypto isakmp key 1511021F0725 address someaddress", "config.txt", "Cisco IOS Configuration"
-      )
-      expect(aux_cisco).to receive(:store_loot).with(
-        "cisco.ios.vpn_ipsec_key", "text/plain", "127.0.0.1", "1511021F0725", "vpn_ipsec_key.txt", "Cisco VPN IPSEC Key"
       )
       expect(aux_cisco).to receive(:create_credential_and_login).with(
         {
@@ -480,9 +453,6 @@ RSpec.describe Msf::Auxiliary::Cisco do
       expect(aux_cisco).to receive(:print_good).with("127.0.0.1:1337 GRE Tunnel Key 1511021F0725 for Interface Tunnel ")
       expect(aux_cisco).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Cisco IOS'})
       expect(aux_cisco).to receive(:store_loot).with(
-        "cisco.ios.gre_tunnel_key", "text/plain", "127.0.0.1", "tunnel_1511021F0725", "gre_tunnel_key.txt", "Cisco GRE Tunnel Key"
-      )
-      expect(aux_cisco).to receive(:store_loot).with(
         "cisco.ios.config", "text/plain", "127.0.0.1",  "tunnel key 1511021F0725", "config.txt", "Cisco IOS Configuration"
       )
       expect(aux_cisco).to receive(:create_credential_and_login).with(
@@ -508,9 +478,6 @@ RSpec.describe Msf::Auxiliary::Cisco do
       expect(aux_cisco).to receive(:store_loot).with(
         "cisco.ios.config", "text/plain", "127.0.0.1", "ip nhrp authentication 1511021F0725", "config.txt", "Cisco IOS Configuration"
       )
-      expect(aux_cisco).to receive(:store_loot).with(
-        "cisco.ios.nhrp_tunnel_key", "text/plain", "127.0.0.1", "tunnel_1511021F0725", "nhrp_tunnel_key.txt", "Cisco NHRP Authentication Key"
-      )
       expect(aux_cisco).to receive(:create_credential_and_login).with(
         {
           address: "127.0.0.1",
@@ -534,9 +501,6 @@ RSpec.describe Msf::Auxiliary::Cisco do
         expect(aux_cisco).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Cisco IOS'})
         expect(aux_cisco).to receive(:store_loot).with(
           "cisco.ios.config", "text/plain", "127.0.0.1", "username someusername privilege 0 secret 0 1511021F0725", "config.txt", "Cisco IOS Configuration"
-        )
-        expect(aux_cisco).to receive(:store_loot).with(
-          "cisco.ios.username_password", "text/plain", "127.0.0.1", "someusername_level0:1511021F0725", "username_password.txt", "Cisco IOS Username and Password"
         )
         expect(aux_cisco).to receive(:create_credential_and_login).with(
           {
@@ -562,10 +526,6 @@ RSpec.describe Msf::Auxiliary::Cisco do
         expect(aux_cisco).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Cisco IOS'})
         expect(aux_cisco).to receive(:store_loot).with(
           "cisco.ios.config", "text/plain", "127.0.0.1", "username someusername privilege 0 secret 5 1511021F0725", "config.txt", "Cisco IOS Configuration"
-        )
-        expect(aux_cisco).to receive(:store_loot).with(
-          "cisco.ios.username_password_hash", "text/plain", "127.0.0.1", "someusername_level0:1511021F0725",
-          "username_password_hash.txt", "Cisco IOS Username and Password Hash (MD5)"
         )
         expect(aux_cisco).to receive(:create_credential_and_login).with(
           {
@@ -593,9 +553,6 @@ RSpec.describe Msf::Auxiliary::Cisco do
         expect(aux_cisco).to receive(:store_loot).with(
           "cisco.ios.config", "text/plain", "127.0.0.1", "username someusername privilege 0 secret 7 1511021F0725", "config.txt", "Cisco IOS Configuration"
         )
-        expect(aux_cisco).to receive(:store_loot).with(
-          "cisco.ios.username_password", "text/plain", "127.0.0.1", "someusername_level0:cisco", "username_password.txt", "Cisco IOS Username and Password"
-        )
         expect(aux_cisco).to receive(:create_credential_and_login).with(
           {
             address: "127.0.0.1",
@@ -622,10 +579,6 @@ RSpec.describe Msf::Auxiliary::Cisco do
         expect(aux_cisco).to receive(:store_loot).with(
           "cisco.ios.config", "text/plain", "127.0.0.1", "username someusername secret 0 1511021F0725", "config.txt", "Cisco IOS Configuration"
         )
-        expect(aux_cisco).to receive(:store_loot).with(
-          "cisco.ios.username_password", "text/plain", "127.0.0.1", "someusername:1511021F0725", "username_password.txt",
-          "Cisco IOS Username and Password"
-        )
         expect(aux_cisco).to receive(:create_credential_and_login).with(
           {
             address: "127.0.0.1",
@@ -649,10 +602,6 @@ RSpec.describe Msf::Auxiliary::Cisco do
         expect(aux_cisco).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Cisco IOS'})
         expect(aux_cisco).to receive(:store_loot).with(
           "cisco.ios.config", "text/plain", "127.0.0.1", "username someusername secret 5 1511021F0725", "config.txt", "Cisco IOS Configuration"
-        )
-        expect(aux_cisco).to receive(:store_loot).with(
-          "cisco.ios.username_password_hash", "text/plain", "127.0.0.1", "someusername:1511021F0725", "username_password_hash.txt",
-          "Cisco IOS Username and Password Hash (MD5)"
         )
         expect(aux_cisco).to receive(:create_credential_and_login).with(
           {
@@ -680,10 +629,6 @@ RSpec.describe Msf::Auxiliary::Cisco do
         expect(aux_cisco).to receive(:store_loot).with(
           "cisco.ios.config", "text/plain", "127.0.0.1", "username someusername secret 7 1511021F0725", "config.txt", "Cisco IOS Configuration"
         )
-        expect(aux_cisco).to receive(:store_loot).with(
-          "cisco.ios.username_password", "text/plain", "127.0.0.1", "someusername:cisco", "username_password.txt",
-          "Cisco IOS Username and Password"
-        )
         expect(aux_cisco).to receive(:create_credential_and_login).with(
           {
             address: "127.0.0.1",
@@ -710,10 +655,6 @@ RSpec.describe Msf::Auxiliary::Cisco do
         expect(aux_cisco).to receive(:store_loot).with(
           "cisco.ios.config", "text/plain", "127.0.0.1", "ppp123username someusername secret 0 1511021F0725", "config.txt", "Cisco IOS Configuration"
         )
-        expect(aux_cisco).to receive(:store_loot).with(
-          "cisco.ios.ppp_username_password", "text/plain", "127.0.0.1", "someusername:1511021F0725", "ppp_username_password.txt",
-          "Cisco IOS PPP Username and Password"
-        )
         expect(aux_cisco).to receive(:create_credential_and_login).with(
           {
             address: "127.0.0.1",
@@ -737,10 +678,6 @@ RSpec.describe Msf::Auxiliary::Cisco do
         expect(aux_cisco).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Cisco IOS'})
         expect(aux_cisco).to receive(:store_loot).with(
           "cisco.ios.config", "text/plain", "127.0.0.1", "ppp123username someusername secret 5 1511021F0725", "config.txt", "Cisco IOS Configuration"
-        )
-        expect(aux_cisco).to receive(:store_loot).with(
-          "cisco.ios.ppp_username_password_hash", "text/plain", "127.0.0.1", "someusername:1511021F0725", "ppp_username_password_hash.txt",
-          "Cisco IOS PPP Username and Password Hash (MD5)"
         )
         expect(aux_cisco).to receive(:create_credential_and_login).with(
           {
@@ -768,10 +705,6 @@ RSpec.describe Msf::Auxiliary::Cisco do
         expect(aux_cisco).to receive(:store_loot).with(
           "cisco.ios.config", "text/plain", "127.0.0.1", "ppp123username someusername secret 7 1511021F0725", "config.txt", "Cisco IOS Configuration"
         )
-        expect(aux_cisco).to receive(:store_loot).with(
-          "cisco.ios.ppp_username_password", "text/plain", "127.0.0.1", "someusername:cisco", "ppp_username_password.txt",
-          "Cisco IOS PPP Username and Password"
-        )
         expect(aux_cisco).to receive(:create_credential_and_login).with(
           {
             address: "127.0.0.1",
@@ -798,9 +731,6 @@ RSpec.describe Msf::Auxiliary::Cisco do
         expect(aux_cisco).to receive(:store_loot).with(
           "cisco.ios.config", "text/plain", "127.0.0.1", "ppp chap secret 0 1511021F0725", "config.txt", "Cisco IOS Configuration"
         )
-        expect(aux_cisco).to receive(:store_loot).with(
-          "cisco.ios.ppp_password", "text/plain", "127.0.0.1", "1511021F0725", "ppp_password.txt", "Cisco IOS PPP Password"
-        )
         expect(aux_cisco).to receive(:create_credential_and_login).with(
           {
             address: "127.0.0.1",
@@ -823,10 +753,6 @@ RSpec.describe Msf::Auxiliary::Cisco do
         expect(aux_cisco).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Cisco IOS'})
         expect(aux_cisco).to receive(:store_loot).with(
           "cisco.ios.config", "text/plain", "127.0.0.1", "ppp chap secret 5 1511021F0725", "config.txt", "Cisco IOS Configuration"
-        )
-        expect(aux_cisco).to receive(:store_loot).with(
-          "cisco.ios.ppp_password_hash", "text/plain", "127.0.0.1", "1511021F0725", "ppp_password_hash.txt",
-          "Cisco IOS PPP Password Hash (MD5)"
         )
         expect(aux_cisco).to receive(:create_credential_and_login).with(
           {
@@ -852,9 +778,6 @@ RSpec.describe Msf::Auxiliary::Cisco do
         expect(aux_cisco).to receive(:report_host).with({:host => '127.0.0.1', :os_name => 'Cisco IOS'})
         expect(aux_cisco).to receive(:store_loot).with(
           "cisco.ios.config", "text/plain", "127.0.0.1", "ppp chap secret 7 1511021F0725", "config.txt", "Cisco IOS Configuration"
-        )
-        expect(aux_cisco).to receive(:store_loot).with(
-          "cisco.ios.ppp_password", "text/plain", "127.0.0.1", "cisco", "ppp_password.txt", "Cisco IOS PPP Password"
         )
         expect(aux_cisco).to receive(:create_credential_and_login).with(
           {


### PR DESCRIPTION
This PR addresses some of the changes @smcintyre-r7 had in #12594 specifically to:

1. optimize some of the calls within the Ubiquity library
2. optimize the creds `private_type` (across all router libs)
3. (unrelated to #12594) Remove the excessive `store_loot` in the cisco lib since the main config is already stored, and the creds its saving are all added to the db anyways.