### PR TITLE
beSECURE integration

### DIFF
--- a/plugins/besecure.rb
+++ b/plugins/besecure.rb
@@ -28,7 +28,7 @@ class Plugin::BeSECURE < Msf::Plugin
         'besecure_hostname' => "Set the beSECURE Hostname",
         'besecure_debug' => "Enable/Disable debugging",
 
-        'besecure_target_list' => "Display list of targets",
+        'besecure_report_list' => "Display list of reports",
 
         'besecure_report_download' => "Save a report to disk",
         'besecure_report_import' => "Import report specified by ID into framework",
@@ -43,12 +43,9 @@ class Plugin::BeSECURE < Msf::Plugin
       print_status("besecure_hostname              Set the beSECURE Hostname")
 
       print_status
-      print_status("TARGETS")
-      print_status("=======")
-      print_status("besecure_target_list           Lists targets")
-      print_status
       print_status("REPORTS")
       print_status("=======")
+      print_status("besecure_report_list           Lists reports")
       print_status("besecure_report_download       Downloads an beSECURE report specified by ID")
       print_status("besecure_report_import         Import report specified by ID into framework")
     end
@@ -145,9 +142,10 @@ class Plugin::BeSECURE < Msf::Plugin
   end
 
   #--------------------------
-  # Target Functions
+  # Report Functions
   #--------------------------
-    def cmd_besecure_target_list(*args)
+  
+    def cmd_besecure_report_list(*args)
       tbl = Rex::Text::Table.new(
             'Columns' => ["ID", "Name", "Hosts"])
       
@@ -192,15 +190,12 @@ class Plugin::BeSECURE < Msf::Plugin
 
       # print_good(body)
   
-      print_good("beSECURE list of targets")
+      print_good("beSECURE list of reports")
       print_line
       print_line tbl.to_s
       print_line
     end
 
-  #--------------------------
-  # Report Functions
-  #--------------------------
     def cmd_besecure_report_download(*args)
       if args?(args, 4)
         req = Net::HTTP::Post.new('/json.cgi', initheader={'Host'=>@hostname})

--- a/plugins/besecure.rb
+++ b/plugins/besecure.rb
@@ -1,0 +1,315 @@
+#
+# This plugin provides integration with beSECURE. Written by Noam Rathaus.
+#
+# Distributed under MIT license:
+# http://www.opensource.org/licenses/mit-license.php
+#
+# Version 10.4.9
+
+require "base64"
+require "zlib"
+require 'tempfile'
+require 'pathname'
+
+module Msf
+class Plugin::BeSECURE < Msf::Plugin
+  class BeSECURECommandDispatcher
+    include Msf::Ui::Console::CommandDispatcher
+
+    def name
+      "beSECURE"
+    end
+
+    def commands
+      {
+        'besecure_help' => "Displays help",
+        'besecure_version' => "Display the version of the beSECURE server",
+        'besecure_apikey' => "Set the beSECURE API Key",
+        'besecure_hostname' => "Set the beSECURE Hostname",
+        'besecure_debug' => "Enable/Disable debugging",
+
+        'besecure_target_list' => "Display list of targets",
+
+        'besecure_report_download' => "Save a report to disk",
+        'besecure_report_import' => "Import report specified by ID into framework",
+      }
+    end
+
+    def cmd_besecure_help()
+      print_status("besecure_help                  Display this help")
+      print_status("besecure_debug                 Enable/Disable debugging")
+      print_status("besecure_version               Display the version of the beSECURE server")
+      print_status("besecure_apikey                Set the beSECURE API Key")
+      print_status("besecure_hostname              Set the beSECURE Hostname")
+
+      print_status
+      print_status("TARGETS")
+      print_status("=======")
+      print_status("besecure_target_list           Lists targets")
+      print_status
+      print_status("REPORTS")
+      print_status("=======")
+      print_status("besecure_report_download       Downloads an beSECURE report specified by ID")
+      print_status("besecure_report_import         Import report specified by ID into framework")
+    end
+
+    # Verify the database is connected and usable
+    def database?
+      if !(framework.db and framework.db.usable)
+        return false
+      else
+        return true
+      end
+    end
+
+    # Verify correct number of arguments and verify -h was not given. Return
+    # true if correct number of arguments and help was not requested.
+    def args?(args, min=1, max=nil)
+      if not max then max = min end
+      if (args.length < min or args.length > max or args[0] == "-h")
+        return false
+      end
+
+      return true
+    end
+
+  #--------------------------
+  # Basic Functions
+  #--------------------------
+  def cmd_besecure_hostname(*args)
+    if args?(args)
+      @hostname = args[0]
+      print_good(@hostname)
+    else
+      print_status("Usage:")
+      print_status("besecure_hostname string")
+    end
+  end
+
+  def cmd_besecure_apikey(*args)
+    if args?(args)
+      @apikey = args[0]
+      print_good(@apikey)
+    else
+      print_status("Usage:")
+      print_status("besecure_apikey string")
+    end
+  end
+
+  def cmd_besecure_debug(*args)
+    if args?(args)
+      @debug = args[0].to_i
+      print_good(@debug)
+    else
+      print_status("Usage:")
+      print_status("besecure_debug integer")
+    end
+  end
+
+  def cmd_besecure_version()
+    req = Net::HTTP::Post.new('/json.cgi', initheader={'Host'=>@hostname})
+    req.set_form_data({'apikey' => @apikey, 'primary' => 'interface'})
+
+    if @debug
+      print_status(req.body)
+    end
+      
+    http = Net::HTTP::new(@hostname, 443)
+    http.use_ssl = true
+    res = http.start {|http| http.request(req)}
+
+    unless res
+      print_error("#{@hostname} - Connection timed out")
+      return ''
+    end
+
+    if @debug
+      print_status(res)
+    end
+
+    body = ''
+    begin
+      body = JSON.parse(res.body)
+    rescue JSON::ParserError
+      print_error("#{@hostname} - Unable to parse the response")
+      return ''
+    end
+
+    if body['error']
+      print_error("#{@hostname} - An error occured:")
+      print_error(body)
+      return ''
+    end
+
+    print_good(body['version'])
+  end
+
+  #--------------------------
+  # Target Functions
+  #--------------------------
+    def cmd_besecure_target_list(*args)
+      tbl = Rex::Text::Table.new(
+            'Columns' => ["ID", "Name", "Hosts"])
+      
+      req = Net::HTTP::Post.new('/json.cgi', initheader={'Host'=>@hostname})
+      req.set_form_data({'apikey' => @apikey, 'primary' => 'admin', 'secondary' => 'networks', 'action' => 'returnnetworks', 'search_limit' => 10000 })
+
+      if @debug
+        print_status(req.body)
+      end
+
+      http = Net::HTTP::new(@hostname, 443)
+      http.use_ssl = true
+      res = http.start {|http| http.request(req)}
+
+      unless res
+        print_error("#{@hostname} - Connection timed out")
+        return ''
+      end
+      
+      if @debug
+        print_status(res)
+      end
+
+      body = ''
+      begin
+        body = JSON.parse(res.body)
+      rescue JSON::ParserError
+        print_error("#{@hostname} - Unable to parse the response")
+        return ''
+      end
+  
+      if body['error']
+        print_error("#{@hostname} - An error occured:")
+        print_error(body)
+        return ''
+      end
+
+      data = body['data']
+      data.each do |item|
+        tbl << [ item['ID'], item['Name'], item['PrettyRange']]
+      end
+
+      # print_good(body)
+  
+      print_good("beSECURE list of targets")
+      print_line
+      print_line tbl.to_s
+      print_line
+    end
+
+  #--------------------------
+  # Report Functions
+  #--------------------------
+    def cmd_besecure_report_download(*args)
+      if args?(args, 4)
+        req = Net::HTTP::Post.new('/json.cgi', initheader={'Host'=>@hostname})
+        format_file = args[1]
+        req.set_form_data({'apikey' => @apikey, 'primary' => 'vulnerabilities', 'secondary' => 'report', 'action' => 'getreport', 'network' => args[0], 'format' => format_file})
+
+        if @debug
+          print_status(req.body)
+        end
+
+        http = Net::HTTP::new(@hostname, 443)
+        http.use_ssl = true
+        res = http.start {|http| http.request(req)}
+
+        unless res
+          print_error("#{@hostname} - Connection timed out")
+          return ''
+        end
+        
+        if @debug
+          print_status(res)
+        end
+
+        body = ''
+        begin
+          body = JSON.parse(res.body)
+        rescue JSON::ParserError
+          print_error("#{@hostname} - Unable to parse the response")
+          return ''
+        end
+    
+        if body['error']
+          print_error("#{@hostname} - An error occured:")
+          print_error(body)
+          return ''
+        end
+
+        # if @debug
+        #   print_status(body)
+        # end
+
+        decompressed = ''
+        if format_file != 'json'
+          compressed_base64 = body["compresseddata"]
+          compressed = Base64.decode64(compressed_base64)
+          decompressed = Zlib::Inflate.inflate(compressed)
+        else
+          decompressed = body
+        end
+
+        if @debug
+          print_status(decompressed)
+        end
+
+        ::FileUtils.mkdir_p(args[2])
+        name = ::File.join(args[2], args[3])
+        print_status("Saving report to #{name}")
+        output = ::File.new(name, "w")
+        output.puts(decompressed)
+        output.close
+      else
+        print_status("Usage: besecure_report_download <network_id> <format_name> <path> <report_name>")
+      end
+    end
+
+    def cmd_besecure_report_import(*args)
+      if args?(args, 2)
+        tempfile = Tempfile.new('results')
+
+        cmd_besecure_report_download(args[0], 'nbe', File.dirname(tempfile) + "/", File.basename(tempfile) )
+
+        print_status("Importing report to database.")
+        framework.db.import_file({:filename => tempfile})
+
+        tempfile.unlink
+      else
+        print_status("Usage: besecure_report_import <network_id> <format_name>")
+        print_status("Only the NBE and XML formats are supported for importing.")
+      end
+    end
+  end # End beSECURE class
+
+#------------------------------
+# Plugin initialization
+#------------------------------
+
+  def initialize(framework, opts)
+    super
+    add_console_dispatcher(BeSECURECommandDispatcher)
+    print_status("Welcome to beSECURE integration by Noam Rathaus.")
+    print_status
+    print_status("beSECURE integration requires a database connection. Once the ")
+    print_status("database is ready, connect to the beSECURE server using besecure_connect.")
+    print_status("For additional commands use besecure_help.")
+    print_status
+
+    @debug = nil
+  end
+
+  def cleanup
+    remove_console_dispatcher('beSECURE')
+  end
+
+  def name
+    "beSECURE"
+  end
+
+  def desc
+    "Integrates with the beSECURE - open source vulnerability management"
+  end
+end
+end

--- a/plugins/besecure.rb
+++ b/plugins/besecure.rb
@@ -4,7 +4,7 @@
 # Distributed under MIT license:
 # http://www.opensource.org/licenses/mit-license.php
 #
-# Version 10.4.9
+# Version 10.5.17
 
 require "base64"
 require "zlib"
@@ -148,6 +148,11 @@ class Plugin::BeSECURE < Msf::Plugin
     def cmd_besecure_report_list(*args)
       tbl = Rex::Text::Table.new(
             'Columns' => ["ID", "Name", "Hosts"])
+      
+      if @hostname.empty?
+        print_error("Missing host value")
+        return ''
+      end
       
       req = Net::HTTP::Post.new('/json.cgi', initheader={'Host'=>@hostname})
       req.set_form_data({'apikey' => @apikey, 'primary' => 'admin', 'secondary' => 'networks', 'action' => 'returnnetworks', 'search_limit' => 10000 })

--- a/plugins/besecure.rb
+++ b/plugins/besecure.rb
@@ -261,9 +261,15 @@ class Plugin::BeSECURE < Msf::Plugin
         output = ::File.new(name, "w")
         output.puts(decompressed)
         output.close
+       
+        ###
+        # Return the report
+        return decompressed
       else
         print_status("Usage: besecure_report_download <network_id> <format_name> <path> <report_name>")
       end
+      
+      return ''
     end
 
     def cmd_besecure_report_import(*args)
@@ -275,7 +281,11 @@ class Plugin::BeSECURE < Msf::Plugin
         
         tempfile = Tempfile.new('results')
 
-        cmd_besecure_report_download(args[0], 'nbe', File.dirname(tempfile) + "/", File.basename(tempfile) )
+        res = cmd_besecure_report_download(args[0], 'nbe', File.dirname(tempfile) + "/", File.basename(tempfile) )
+        if res.empty?
+          print_error("An empty report has been received")
+          return ''
+        end
 
         print_status("Importing report to database.")
         framework.db.import_file({:filename => tempfile})

--- a/plugins/besecure.rb
+++ b/plugins/besecure.rb
@@ -268,6 +268,11 @@ class Plugin::BeSECURE < Msf::Plugin
 
     def cmd_besecure_report_import(*args)
       if args?(args, 2)
+        if !database?
+          print_error("Database not ready")
+          return ''
+        end
+        
         tempfile = Tempfile.new('results')
 
         cmd_besecure_report_download(args[0], 'nbe', File.dirname(tempfile) + "/", File.basename(tempfile) )


### PR DESCRIPTION
The following commit provides a plugin that allows Metasploit to pull reports from the beSECURE system and use that information for launch exploits against targets.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `load besecure`
- [ ] `besecure_debug 1`
- [ ] `besecure_hostname cloudX.beyondsecurity.com`
- [ ] `besecure_apikey 4D795158-XXXX-XXXX-XXXX-8A97262D75CB`
- [ ] `besecure_report_list`
- [ ] `besecure_report_import 436D39F9 nbe`
- [ ] The plugin should be pulling a report from cloudX server and integrating the finding into the target list of Metasploit while highlighting relevant attacks (based on CVEs)
- [ ] The plugin should not report an error while connecting to cloudX , or report an error while trying to pull the report
- [ ] The plugin uses RESTful API to connect to beSECURE server, list possible scan reports that we can incorporate into metasploit and finally incorporates a report into the target list of metasploit for further exploitation

