### PR TITLE
Changed 'exit' to 'return' in bind_named_pipe handler

### DIFF
--- a/lib/msf/core/handler/bind_named_pipe.rb
+++ b/lib/msf/core/handler/bind_named_pipe.rb
@@ -286,7 +286,7 @@ module Msf
 
           if not sock
             print_error("Failed to connect socket #{rhost}:#{lport}")
-            exit
+            return
           end
 
           # Perform SMB logon
@@ -297,7 +297,7 @@ module Msf
             vprint_status("SMB login Success #{smbdomain}\\#{smbuser}:#{smbpass} #{rhost}:#{lport}")
           rescue
             print_error("SMB login Failure #{smbdomain}\\#{smbuser}:#{smbpass} #{rhost}:#{lport}")
-            exit
+            return
           end
 
           # Connect to the IPC$ share so we can use named pipes.
@@ -316,7 +316,7 @@ module Msf
               error_name = e.get_error(e.error_code)
               unless ['STATUS_OBJECT_NAME_NOT_FOUND', 'STATUS_PIPE_NOT_AVAILABLE'].include? error_name
                 print_error("Error connecting to #{pipe_name}: #{error_name}")
-                exit
+                return
               else
                 # Stager pipe may not be ready
                 vprint_status("Error connecting to #{pipe_name}: #{error_name}")
@@ -331,7 +331,7 @@ module Msf
 
           if not pipe
             print_error("Failed to connect to pipe \\#{pipe_name} on #{rhost}")
-            exit
+            return
           end
 
           vprint_status("Opened pipe \\#{pipe_name}")


### PR DESCRIPTION
Remove explicit `exit` calls in favour of `return` from bind_named_pipe handler code in error cases. This is because when calling the handler from a passive exploit, the `exit`'s would cause *Metasploit* to exit silently when an error happens.

E.g., the following shows an example of this:

```
msf5 > use multi/handler
msf5 exploit(multi/handler) > set payload windows/x64/meterpreter/bind_named_pipe 
payload => windows/x64/meterpreter/bind_named_pipe
msf5 exploit(multi/handler) > set rhost 10.11.0.1
rhost => 10.11.0.1
msf5 exploit(multi/handler) > edit    (change the payload from aggressive to passive)
msf5 exploit(multi/handler) > reload
[*] Reloading module...
msf5 exploit(multi/handler) > run
[*] Exploit running as background job 0.
[*] Exploit completed, but no session was created.
msf5 exploit(multi/handler) > 
[*] Started bind named pipe handler against 10.11.0.1:445
[-] Failed to connect socket 10.11.0.1:445
root@3a96fcbf5d69:/# 
```
Notice, directly after an error during connection happens *Meterpreter* exits. When the exploit is aggressive, this does not cause *Meterpreter* to exit and instead it catches the `SystemExit` error.

From looking at the other bind handlers, they dont call `exit` so this PR brings the named pipe handler into alignment.

While this PR is a fix, there is probably deeper issue of why the `exit` is handled differently in threads spawned by aggressive and passive exploits. I did try and look into it, but it was not clear.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use multi/handler`
- [ ] `edit` change exploit to passive (i.e. add `'Stance' => Msf::Exploit::Stance::Passive,` to the `update_info` section of `modules/exploits/multi/handler.rb`)
- [ ] `reload`
- [ ] `set payload windows/x64/meterpreter/bind_named_pipe`
- [ ] `set rhost 10.11.0.1`  (set a non-existent host to make raise error condition in handler)
- [ ] `run` after a connection error, Meterpreter shell should still be running.

