### PR TITLE
Explain CVEs and "fix" CMDSTAGER::FLAVOR in ThinkPHP exploit

### DIFF
--- a/modules/exploits/unix/webapp/thinkphp_rce.rb
+++ b/modules/exploits/unix/webapp/thinkphp_rce.rb
@@ -30,8 +30,8 @@ class MetasploitModule < Msf::Exploit::Remote
       ],
       'References'              => [
         # https://www.google.com/search?q=thinkphp+rce, tbh
-        ['CVE', '2018-20062'],
-        ['CVE', '2019-9082'],
+        ['CVE', '2018-20062'], # NoneCMS 1.3 using ThinkPHP
+        ['CVE', '2019-9082'],  # Open Source BMS 1.1.1 using ThinkPHP
         ['URL', 'https://github.com/vulhub/vulhub/tree/master/thinkphp/5-rce'],
         ['URL', 'https://github.com/vulhub/vulhub/tree/master/thinkphp/5.0.23-rce']
       ],
@@ -75,6 +75,9 @@ class MetasploitModule < Msf::Exploit::Remote
       OptFloat.new('CmdOutputTimeout',
                    [true, 'Timeout for cmd/unix/generic output', 3.5])
     ])
+
+    # XXX: https://github.com/rapid7/metasploit-framework/issues/12963
+    import_target_defaults
   end
 
 =begin


### PR DESCRIPTION
```
msf5 > use thinkphp

Matching Modules
================

   #  Name                              Disclosure Date  Rank       Check  Description
   -  ----                              ---------------  ----       -----  -----------
   0  exploit/unix/webapp/thinkphp_rce  2018-12-10       excellent  Yes    ThinkPHP Multiple PHP Injection RCEs


[*] Using exploit/unix/webapp/thinkphp_rce
msf5 exploit(unix/webapp/thinkphp_rce) > set cmdstager::flavor
cmdstager::flavor => curl
msf5 exploit(unix/webapp/thinkphp_rce) >
```

Fixes #13240, specifically https://github.com/rapid7/metasploit-framework/pull/13240#discussion_r407473346 and https://github.com/rapid7/metasploit-framework/pull/13240#discussion_r407534271. See #12963 for the target `DefaultOptions` bug.