### PR TITLE
Rename tip command to tips

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -70,8 +70,7 @@ class Core
     "-v" => [ false, "Print more detailed info.  Use with -i and -l"  ])
 
   @@tip_opts = Rex::Parser::Arguments.new(
-    "-h" => [ false, "Help banner."                                   ],
-    "-l" => [ false, "List all available tips."                       ])
+    "-h" => [ false, "Help banner."                                   ])
 
   @@connect_opts = Rex::Parser::Arguments.new(
     "-h" => [ false, "Help banner."                                   ],
@@ -119,7 +118,7 @@ class Core
       "set"        => "Sets a context-specific variable to a value",
       "setg"       => "Sets a global variable to a value",
       "sleep"      => "Do nothing for the specified number of seconds",
-      "tip"        => "Show a useful productivity tip",
+      "tips"       => "Show a list of useful productivity tips",
       "threads"    => "View and manipulate background threads",
       "unload"     => "Unload a framework plugin",
       "unset"      => "Unsets one or more context-specific variables",
@@ -139,6 +138,10 @@ class Core
     @previous_module = nil
     @previous_target = nil
     @history_limit = 100
+  end
+
+  def deprecated_commands
+    ['tip']
   end
 
   #
@@ -257,20 +260,22 @@ class Core
 
   end
 
-  def cmd_tip_help
-    print_line "Usage: tip [options]"
+  def cmd_tips_help
+    print_line "Usage: tips [options]"
     print_line
-    print_line "Print a useful tip on how to use Metasploit"
+    print_line "Print a useful list of productivity tips on how to use Metasploit"
     print @@tip_opts.usage
   end
 
+  alias cmd_tip_help cmd_tips_help
+
   #
-  # Display a useful productivity tip to the user.
+  # Display useful productivity tips to the user.
   #
-  def cmd_tip(*args)
+  def cmd_tips(*args)
     if args.include?("-h")
       cmd_tip_help
-    elsif args.include?("-l")
+    else
       tbl = Table.new(
         Table::Style::Default,
         'Columns' => %w[Id Tip]
@@ -281,10 +286,10 @@ class Core
       end
 
       print(tbl.to_s)
-    else
-      print_line Tip.sample
     end
   end
+
+  alias cmd_tip cmd_tips
 
   def cmd_connect_help
     print_line "Usage: connect [options] <host> <port>"

--- a/lib/msf/ui/tip.rb
+++ b/lib/msf/ui/tip.rb
@@ -14,7 +14,7 @@ module Msf
       end
 
       COMMON_TIPS = [
-        "View useful productivity tips with the #{highlight('tip')} command, or view them all with #{highlight('tip -l')}",
+        "View all productivity tips with the #{highlight('tips')} command",
         "Enable verbose logging with #{highlight('set VERBOSE true')}",
         "When in a module, use #{highlight('back')} to go back to the top level prompt",
         "Tired of setting RHOSTS for modules? Try globally setting it with #{highlight('setg RHOSTS x.x.x.x')}",


### PR DESCRIPTION
Closes https://github.com/rapid7/metasploit-framework/issues/13151

It's now possible to use `tips` to view all productivity tips instead of `tip -l`

![image](https://user-images.githubusercontent.com/60357436/79513318-7609c900-803b-11ea-98fe-dcef5db3b09e.png)

## Verification

- [ ] Start `msfconsole`
- [ ] `tips`
- [ ] **Verify** a list of useful productivity tips are available