### PR TITLE
Bump payloads to 1.3.91

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,7 +28,7 @@ PATH
       metasploit-concern (~> 2.0.0)
       metasploit-credential (~> 3.0.0)
       metasploit-model (~> 2.0.4)
-      metasploit-payloads (= 1.3.90)
+      metasploit-payloads (= 1.3.91)
       metasploit_data_models (~> 3.0.10)
       metasploit_payloads-mettle (= 0.5.21)
       mqtt
@@ -216,7 +216,7 @@ GEM
       activemodel (~> 4.2.6)
       activesupport (~> 4.2.6)
       railties (~> 4.2.6)
-    metasploit-payloads (1.3.90)
+    metasploit-payloads (1.3.91)
     metasploit_data_models (3.0.10)
       activerecord (~> 4.2.6)
       activesupport (~> 4.2.6)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -70,7 +70,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model', '~> 2.0.4'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '1.3.90'
+  spec.add_runtime_dependency 'metasploit-payloads', '1.3.91'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '0.5.21'
   # Needed by msfgui and other rpc components


### PR DESCRIPTION
This bumps payloads to fix the java payloads issue from https://github.com/rapid7/metasploit-payloads/pull/387
fixes https://github.com/rapid7/metasploit-framework/issues/12580
## Verification

List the steps needed to make sure this thing works

- [x] Let automated tests finish
- [x] Run targeted testing
