### PR TITLE
Fix #13150 Search command unicode support

### DIFF
--- a/lib/msf/core/module/search.rb
+++ b/lib/msf/core/module/search.rb
@@ -53,7 +53,12 @@ module Msf::Module::Search
           match = false if mode == 0
 
           # Convert into a case-insensitive regex
-          r = Regexp.new(Regexp.escape(w.force_encoding('UTF-8')), true)
+          utf8_buf = w.dup.force_encoding('UTF-8')
+          if utf8_buf.valid_encoding?
+            r = Regexp.new(Regexp.escape(utf8_buf), true)
+          else
+            return false
+          end
 
           case t
             when 'text'

--- a/lib/msf/core/module/search.rb
+++ b/lib/msf/core/module/search.rb
@@ -53,7 +53,7 @@ module Msf::Module::Search
           match = false if mode == 0
 
           # Convert into a case-insensitive regex
-          r = Regexp.new(Regexp.escape(w), true)
+          r = Regexp.new(Regexp.escape(w.force_encoding('UTF-8')), true)
 
           case t
             when 'text'

--- a/lib/msf/core/modules/metadata/search.rb
+++ b/lib/msf/core/modules/metadata/search.rb
@@ -44,8 +44,12 @@ module Msf::Modules::Metadata::Search
           match = false if mode == 0
 
           # Convert into a case-insensitive regex
-          regex = Regexp.new(Regexp.escape(search_term.force_encoding('UTF-8')), true)
-
+          utf8_buf = search_term.dup.force_encoding('UTF-8')
+          if utf8_buf.valid_encoding?
+            regex = Regexp.new(Regexp.escape(utf8_buf), true)
+          else
+            return false
+          end
           case keyword
             when 'aka'
               match = [keyword, search_term] if (module_metadata.notes['AKA'] || []).any? { |aka| aka =~ regex }

--- a/lib/msf/core/modules/metadata/search.rb
+++ b/lib/msf/core/modules/metadata/search.rb
@@ -44,7 +44,7 @@ module Msf::Modules::Metadata::Search
           match = false if mode == 0
 
           # Convert into a case-insensitive regex
-          regex = Regexp.new(Regexp.escape(search_term), true)
+          regex = Regexp.new(Regexp.escape(search_term.force_encoding('UTF-8')), true)
 
           case keyword
             when 'aka'


### PR DESCRIPTION
1. Open up msfconsole
2. Type in "search author:István" (sans the quotes)
```
msf5 > search author:István

Matching Modules
================

   #  Name                                              Disclosure Date  Rank    Check  Description
   -  ----                                              ---------------  ----    -----  -----------
   0  exploit/multi/browser/chrome_array_map            2019-03-07       manual  No     Google Chrome 72 and 73 Array.map exploit
   1  exploit/multi/browser/chrome_jscreate_sideeffect  2020-02-19       manual  No     Google Chrome 80 JSCreate side-effect type confusion exploit
   2  exploit/windows/browser/chrome_filereader_uaf     2019-03-21       manual  No     Chrome 72.0.3626.119 FileReader UaF exploit for Windows 7 x86

```
Fixed [#13150](https://github.com/rapid7/metasploit-framework/issues/13150).