### PR TITLE
Update example_linux_priv_esc.rb

### DIFF
--- a/modules/exploits/example_linux_priv_esc.rb
+++ b/modules/exploits/example_linux_priv_esc.rb
@@ -12,12 +12,21 @@
 class MetasploitModule < Msf::Exploit::Local
   Rank = NormalRanking
 
+  # includes: is_root?
   include Msf::Post::Linux::Priv
+  # includes: has_gcc?
   include Msf::Post::Linux::System
+  # includes: kernel_release
   include Msf::Post::Linux::Kernel
+  # includes writable?, upload_file, upload_and_chmodx, exploit_data
   include Msf::Post::File
+  # includes generate_payload_exe
   include Msf::Exploit::EXE
+  # includes register_files_for_cleanup
   include Msf::Exploit::FileDropper
+  # includes: COMPILE option, live_compile?, upload_and_compile
+  # strip_comments
+  include Msf::Post::Linux::Compile
 
   def initialize(info = {})
     super(
@@ -70,11 +79,6 @@ class MetasploitModule < Msf::Exploit::Local
         'DefaultTarget'  => 0
       )
     )
-    # We typically drop a pre-compiled exploit to disk and run it, however the option
-    # is left for the user to gcc it themselves if there is an add OS or other dependency
-    register_options [
-      OptEnum.new('COMPILE', [ true, 'Compile on target', 'Auto', %w[Auto True False] ])
-    ]
     # force exploit is used to bypass the check command results
     register_advanced_options [
       OptBool.new('ForceExploit',  [ false, 'Override check result', false ]),
@@ -86,62 +90,6 @@ class MetasploitModule < Msf::Exploit::Local
   # Simplify pulling the writable directory variable
   def base_dir
     datastore['WritableDir'].to_s
-  end
-
-  # Simplify and standardize uploading a file
-  def upload(path, data)
-    print_status "Writing '#{path}' (#{data.size} bytes) ..."
-    write_file path, data
-  end
-
-  # Simplify uploading and chmoding a file
-  def upload_and_chmodx(path, data)
-    upload path, data
-    chmod path
-    register_file_for_cleanup path
-  end
-
-  # Simplify uploading and compiling a file
-  def upload_and_compile(path, data, gcc_args='')
-    upload "#{path}.c", data
-
-    gcc_cmd = "gcc -o #{path} #{path}.c"
-    if session.type.eql? 'shell'
-      gcc_cmd = "PATH=$PATH:/usr/bin/ #{gcc_cmd}"
-    end
-
-    if gcc_args.to_s.blank?
-      gcc_cmd << " #{gcc_args}"
-    end
-
-    output = cmd_exec gcc_cmd
-
-    unless output.blank?
-      print_error output
-      fail_with Failure::Unknown, "#{path}.c failed to compile"
-    end
-
-    register_file_for_cleanup path
-    chmod path
-  end
-
-  # Pull the exploit binary or file (.c typically) from our system
-  def exploit_data(file)
-    ::File.binread ::File.join(Msf::Config.data_directory, 'exploits', 'DOES_NOT_EXIST', file)
-  end
-
-  # If we're going to live compile on the system, check gcc is installed
-  def live_compile?
-    return false unless datastore['COMPILE'].eql?('Auto') || datastore['COMPILE'].eql?('True')
-
-    if has_gcc?
-      vprint_good 'gcc is installed'
-      return true
-    end
-
-    unless datastore['COMPILE'].eql? 'Auto'
-      fail_with Failure::BadConfig, 'gcc is not installed. Compiling will fail.'
-    end
   end
 
   def check

--- a/modules/exploits/example_linux_priv_esc.rb
+++ b/modules/exploits/example_linux_priv_esc.rb
@@ -36,52 +36,52 @@ class MetasploitModule < Msf::Exploit::Local
         # vuln type, class. Preferably apply
         # some search optimization so people can actually find the module.
         # We encourage consistency between module name and file name.
-        'Name'           => 'Sample Linux Priv Esc',
-        'Description'    => %q(
-            This exploit module illustrates how a vulnerability could be exploited
+        'Name' => 'Sample Linux Priv Esc',
+        'Description' => %q{
+          This exploit module illustrates how a vulnerability could be exploited
           in an linux command for priv esc.
-        ),
-        'License'        => MSF_LICENSE,
+        },
+        'License' => MSF_LICENSE,
         # The place to add your name/handle and email.  Twitter and other contact info isn't handled here.
         # Add reference to additional authors, like those creating original proof of concepts or
         # reference materials.
         # It is also common to comment in who did what (PoC vs metasploit module, etc)
-        'Author'         =>
+        'Author' =>
           [
             'h00die <mike@stcyrsecurity.com>', # msf module
             'researcher' # original PoC, analysis
           ],
-        'Platform'       => [ 'linux' ],
+        'Platform' => [ 'linux' ],
         # from underlying architecture of the system.  typically ARCH_X64 or ARCH_X86, but the exploit
         # may only apply to say ARCH_PPC or something else, where a specific arch is required.
         # A full list is available in lib/msf/core/payload/uuid.rb
-        'Arch'           => [ ARCH_X86, ARCH_X64 ],
+        'Arch' => [ ARCH_X86, ARCH_X64 ],
         # What types of sessions we can use this module in conjunction with.  Most modules use libraries
         # which work on shell and meterpreter, but there may be a nuance between one of them, so best to
         # test both to ensure compatibility.
-        'SessionTypes'   => [ 'shell', 'meterpreter' ],
-        'Targets'        => [[ 'Auto', {} ]],
+        'SessionTypes' => [ 'shell', 'meterpreter' ],
+        'Targets' => [[ 'Auto', {} ]],
         # from lib/msf/core/module/privileged, denotes if this requires or gives privileged access
         # since privilege escalation modules typically result in elevated privileges, this is
         # generally set to true
-        'Privileged'     => true,
-        'References'     =>
+        'Privileged' => true,
+        'References' =>
           [
             [ 'OSVDB', '12345' ],
             [ 'EDB', '12345' ],
             [ 'URL', 'http://www.example.com'],
             [ 'CVE', '1978-1234']
           ],
-        'DisclosureDate' => "Nov 29 2019",
+        'DisclosureDate' => 'Nov 29 2019',
         # Note that DefaultTarget refers to the index of an item in Targets, rather than name.
         # It's generally easiest just to put the default at the beginning of the list and skip this
         # entirely.
-        'DefaultTarget'  => 0
+        'DefaultTarget' => 0
       )
     )
     # force exploit is used to bypass the check command results
     register_advanced_options [
-      OptBool.new('ForceExploit',  [ false, 'Override check result', false ]),
+      OptBool.new('ForceExploit', [ false, 'Override check result', false ]),
       OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ])
     ]
 
@@ -104,7 +104,7 @@ class MetasploitModule < Msf::Exploit::Local
 
     # Check the app is installed and the version, debian based example
     package = cmd_exec('dpkg -l example | grep \'^ii\'')
-    if package && package.include?('1:2015.3.14AR.1-1build1')
+    if package&.include?('1:2015.3.14AR.1-1build1')
       print_good("Vulnerable app version #{package} detected")
       CheckCode::Appears
     end
@@ -155,7 +155,7 @@ class MetasploitModule < Msf::Exploit::Local
     # Launch exploit with a timeout.  We also have a vprint_status so if the user wants all the
     # output from the exploit being run, they can optionally see it
     timeout = 30
-    print_status "Launching exploit..."
+    print_status 'Launching exploit...'
     output = cmd_exec "echo '#{payload_path} & exit' | #{executable_path}", nil, timeout
     output.each_line { |line| vprint_status line.chomp }
   end


### PR DESCRIPTION
This fixes things @bcoles has previously mentioned as being outdated in the `example_linux_priv_esc.rb` https://github.com/rapid7/metasploit-framework/issues/13116#issuecomment-602555369

I used the example as the template for #13290 and it resulted in duplicate comments (being mentioned about the example, then about my module). So lets just get this fixed.

Also ran `rubocop -a`.