### PR TITLE
Fix ExitOnSession usage in to_handler

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/evasion.rb
+++ b/lib/msf/ui/console/command_dispatcher/evasion.rb
@@ -70,11 +70,13 @@ class Evasion
     handler = framework.modules.create('exploit/multi/handler')
 
     handler_opts = {
-      'Payload'        => mod.datastore['PAYLOAD'],
-      'LocalInput'     => driver.input,
-      'LocalOutput'    => driver.output,
-      'ExitOnSession'  => false,
-      'RunAsJob'       => true
+      'Payload'     => mod.datastore['PAYLOAD'],
+      'LocalInput'  => driver.input,
+      'LocalOutput' => driver.output,
+      'RunAsJob'    => true,
+      'Options'     => {
+        'ExitOnSession' => false,
+      }
     }
 
     handler.share_datastore(mod.datastore)

--- a/lib/msf/ui/console/command_dispatcher/payload.rb
+++ b/lib/msf/ui/console/command_dispatcher/payload.rb
@@ -49,11 +49,13 @@ module Msf
             handler = framework.modules.create('exploit/multi/handler')
 
             handler_opts = {
-              'Payload'        => mod.refname,
-              'LocalInput'     => driver.input,
-              'LocalOutput'    => driver.output,
-              'ExitOnSession'  => false,
-              'RunAsJob'       => true
+              'Payload'     => mod.refname,
+              'LocalInput'  => driver.input,
+              'LocalOutput' => driver.output,
+              'RunAsJob'    => true,
+              'Options'     => {
+                'ExitOnSession' => false,
+              }
             }
 
             handler.datastore.merge!(mod.datastore)


### PR DESCRIPTION
So the current implementation of the `to_handler` command for payload and evasion modules exits after the first session is opened. While looking through the source code, it looks like this is not the intended behavior due to `ExitOnSession` being set to `false`. Note that `ExitOnSession` is used because this command is actually backed by the `exploit/multi/handler` module.

This Pull Request fixes this usage so the option is properly set for the underlying module, causing it to stay active after a session is opened. The modules datastore options needs to be passed in an `Options` sub-hash, see: [`Msf::Simple::Module#_import_extra_options`](https://github.com/rapid7/metasploit-framework/blob/129d15b8eb092b061e50f2e96a03b6a1a7b642b5/lib/msf/base/simple/module.rb#L19-L27).

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use payload/your/favorite/payload`
- [ ] Set the options appropriately and generate it
- [ ] Start the handler with `to_handler`
- [ ] Get a session, see that the handler is still running with `jobs`
    * The unpatched version will show that the job has exited
- [ ] Get a second session without having to re-run `to_handler`

## Example Output
```
msf5 > use payload/python/meterpreter/reverse_tcp
msf5 payload(python/meterpreter/reverse_tcp) > set LHOST 192.168.250.67
LHOST => 192.168.250.67
msf5 payload(python/meterpreter/reverse_tcp) > to_handler 
[*] Payload Handler Started as Job 0
msf5 payload(python/meterpreter/reverse_tcp) > 
[*] Started reverse TCP handler on 192.168.250.67:4444 
[*] Sending stage (53755 bytes) to 192.168.250.67
[*] Meterpreter session 1 opened (192.168.250.67:4444 -> 192.168.250.67:42658) at 2020-04-20 20:20:18 -0400
[*] Sending stage (53755 bytes) to 192.168.250.67
[*] Meterpreter session 2 opened (192.168.250.67:4444 -> 192.168.250.67:42664) at 2020-04-20 20:20:19 -0400

msf5 payload(python/meterpreter/reverse_tcp) > sessions 

Active sessions
===============

  Id  Name  Type                      Information                      Connection
  --  ----  ----                      -----------                      ----------
  1         meterpreter python/linux  steiner @ localhost.localdomain  192.168.250.67:4444 -> 192.168.250.67:42658 (192.168.250.67)
  2         meterpreter python/linux  steiner @ localhost.localdomain  192.168.250.67:4444 -> 192.168.250.67:42664 (192.168.250.67)

msf5 payload(python/meterpreter/reverse_tcp) > jobs

Jobs
====

  Id  Name                    Payload                         Payload opts
  --  ----                    -------                         ------------
  0   Exploit: multi/handler  python/meterpreter/reverse_tcp  tcp://192.168.250.67:4444

msf5 payload(python/meterpreter/reverse_tcp) >
```