### PR TITLE
ZDI Public Numbers can be 4 digits, ZDI-19-1045

### DIFF
--- a/tools/dev/msftidy.rb
+++ b/tools/dev/msftidy.rb
@@ -178,7 +178,7 @@ class Msftidy
         when 'US-CERT-VU'
           warn("Invalid US-CERT-VU reference") if value !~ /^\d+$/
         when 'ZDI'
-          warn("Invalid ZDI reference") if value !~ /^\d{2}-\d{3}$/
+          warn("Invalid ZDI reference") if value !~ /^\d{3}-\d{4}$/
         when 'WPVDB'
           warn("Invalid WPVDB reference") if value !~ /^\d+$/
         when 'PACKETSTORM'


### PR DESCRIPTION
ZDI Public Numbers will always have a min of 3 digits.
The number is essentially `"num_as_string".ljust(3, '0')`, so this should be {3,4}
or {3,5} if they ever get that high ;) I could find no ZDI references that only had
2 digits in the last number part

references:
* https://www.zerodayinitiative.com/advisories/ZDI-19-1045/
* https://www.zerodayinitiative.com/advisories/ZDI-05-001/

## Verification

List the steps needed to make sure this thing works

run msftidy
change one of the ZDI references to be something like ZDI-19-01
run msftidy and make sure it complains.

*ALSO* the wiki should be changed at https://github.com/rapid7/metasploit-framework/wiki/Msftidy#zdi 