### PR TITLE
Warn the user that changing the SSL option's value may require changing RPORT

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1637,9 +1637,9 @@ class Core
       active_module.import_target_defaults
     end
 
-    # Warn the user that setting SSL may require changing RPORT
-    if name.upcase == 'SSL' && datastore[name] == true
-      print_warning('Setting the SSL option may require changing the RPORT value!')
+    # Warn the user that changing the SSL value may require changing RPORT
+    if name.casecmp('SSL') == 0 && datastore[name] != value
+      print_warning('Changing the SSL option may require changing the RPORT value!')
     end
 
     print_line("#{name} => #{datastore[name]}")

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1637,6 +1637,11 @@ class Core
       active_module.import_target_defaults
     end
 
+    # Warn the user that setting SSL may require changing RPORT
+    if name.upcase == 'SSL' && datastore[name] == true
+      print_warning('Setting the SSL option may require changing the RPORT value!')
+    end
+
     print_line("#{name} => #{datastore[name]}")
   end
 

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1621,6 +1621,9 @@ class Core
       return false
     end
 
+    # Save the old value before changing it, in case we need to compare it
+    old_value = datastore[name]
+
     begin
       if append
         datastore[name] = datastore[name] + value
@@ -1637,9 +1640,9 @@ class Core
       active_module.import_target_defaults
     end
 
-    # Warn the user that changing the SSL value may require changing RPORT
-    if name.casecmp('SSL') == 0 && datastore[name] != value
-      print_warning('Changing the SSL option may require changing the RPORT value!')
+    # If the new SSL value already set in datastore[name] is different from the old value, warn the user
+    if name.casecmp('SSL') == 0 && datastore[name] != old_value
+      print_warning("Changing the SSL option's value may require changing RPORT!")
     end
 
     print_line("#{name} => #{datastore[name]}")


### PR DESCRIPTION
This warns the user that the two options must be changed separately.

In the past, we've discussed automatically changing one from the other, but that led to some serious side effects. This may be a compromise that's more productive than all the bikeshedding we did.

```
msf5 exploit(windows/misc/veeam_one_agent_deserialization) > set ssl
ssl => false
msf5 exploit(windows/misc/veeam_one_agent_deserialization) > set ssl true
[!] Changing the SSL option's value may require changing RPORT!
ssl => true
msf5 exploit(windows/misc/veeam_one_agent_deserialization) > set ssl true
ssl => true
msf5 exploit(windows/misc/veeam_one_agent_deserialization) > set ssl false
[!] Changing the SSL option's value may require changing RPORT!
ssl => false
msf5 exploit(windows/misc/veeam_one_agent_deserialization) > set ssl false
ssl => false
msf5 exploit(windows/misc/veeam_one_agent_deserialization) > set ssl true
[!] Changing the SSL option's value may require changing RPORT!
ssl => true
msf5 exploit(windows/misc/veeam_one_agent_deserialization) > set rport 443
rport => 443
msf5 exploit(windows/misc/veeam_one_agent_deserialization) >
```

This arose as part of a debugging effort we did on Slack.