### PR TITLE
Adds tag functionality for hosts

### DIFF
--- a/lib/metasploit/framework/data_service/proxy/host_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/host_data_proxy.rb
@@ -72,15 +72,33 @@ module HostDataProxy
   end
 
   def get_host_tags(opts)
-    use_id_or_get_id_from_host_address(opts, :get_host_tags)
+    if add_host_id_to_opts(opts)
+      self.data_service_operation do |data_service|
+        return data_service.get_host_tags(opts)
+      end
+    else
+      nil
+    end
   end
 
   def add_host_tag(opts)
-    use_id_or_get_id_from_host_address(opts, :add_host_tag)
+    if add_host_id_to_opts(opts)
+      self.data_service_operation do |data_service|
+        return data_service.add_host_tag(opts)
+      end
+    else
+      nil
+    end
   end
 
   def delete_host_tag(opts)
-    use_id_or_get_id_from_host_address(opts, :delete_host_tag)
+    if add_host_id_to_opts(opts)
+      self.data_service_operation do |data_service|
+        return data_service.delete_host_tag(opts)
+      end
+    else
+      nil
+    end
   end
 
   private
@@ -100,25 +118,22 @@ module HostDataProxy
     return true
   end
 
-  def use_id_or_get_id_from_host_address(opts, method)
-    begin
-      if opts[:id]
-        self.data_service_operation do |data_service|
-          data_service.send(method, opts)
-        end
-      elsif opts[:address]
-        self.data_service_operation do |data_service|
-          host = data_service.get_host(opts)
+  def add_host_id_to_opts(opts)
+    if opts[:id]
+      return true
+    end
 
-          if host
-            opts[:id] = host.id
-            data_service.send(method, opts.reject {|k,v| k==:address})
-          end
+    if opts[:address]
+      self.data_service_operation do |data_service|
+        host = data_service.get_host(opts)
+
+        if host
+          opts[:id] = host.id
         end
       end
-    rescue => e
-      self.log_error(e, "Problem calling #{method.to_s} method.")
     end
+
+    opts.key?(:id)
   end
 
 end

--- a/lib/metasploit/framework/data_service/proxy/host_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/host_data_proxy.rb
@@ -71,6 +71,18 @@ module HostDataProxy
     end
   end
 
+  def get_host_tags(opts)
+    use_id_or_get_id_from_host_address(opts, :get_host_tags)
+  end
+
+  def add_host_tag(opts)
+    use_id_or_get_id_from_host_address(opts, :add_host_tag)
+  end
+
+  def delete_host_tag(opts)
+    use_id_or_get_id_from_host_address(opts, :delete_host_tag)
+  end
+
   private
 
   def valid(opts)
@@ -86,6 +98,27 @@ module HostDataProxy
     end
 
     return true
+  end
+
+  def use_id_or_get_id_from_host_address(opts, method)
+    begin
+      if opts[:id]
+        self.data_service_operation do |data_service|
+          data_service.send(method, opts)
+        end
+      elsif opts[:address]
+        self.data_service_operation do |data_service|
+          host = data_service.get_host(opts)
+
+          if host
+            opts[:id] = host.id
+            data_service.send(method, opts.reject {|k,v| k==:address})
+          end
+        end
+      end
+    rescue => e
+      self.log_error(e, "Problem retrieving host")
+    end
   end
 
 end

--- a/lib/metasploit/framework/data_service/proxy/host_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/host_data_proxy.rb
@@ -117,7 +117,7 @@ module HostDataProxy
         end
       end
     rescue => e
-      self.log_error(e, "Problem retrieving host")
+      self.log_error(e, "Problem calling #{method.to_s} method.")
     end
   end
 

--- a/lib/metasploit/framework/data_service/remote/http/remote_host_data_service.rb
+++ b/lib/metasploit/framework/data_service/remote/http/remote_host_data_service.rb
@@ -35,17 +35,17 @@ module RemoteHostDataService
   end
 
   def get_host_tags(opts)
-    path = get_path_select(opts, HOST_API_PATH) + '/tag'
+    path = get_path_select(opts, HOST_API_PATH) + '/tags'
     json_to_mdm_object(self.get_data(path, opts, nil), TAG_MDM_CLASS)
   end
 
   def add_host_tag(opts)
-    path = get_path_select(opts, HOST_API_PATH) + '/tag'
+    path = get_path_select(opts, HOST_API_PATH) + '/tags'
     json_to_mdm_object(self.post_data(path, opts, nil), TAG_MDM_CLASS)
   end
 
   def delete_host_tag(opts)
-    path = get_path_select(opts, HOST_API_PATH) + '/tag'
+    path = get_path_select(opts, HOST_API_PATH) + '/tags'
     json_to_mdm_object(self.delete_data(path, opts, nil), TAG_MDM_CLASS)
   end
 

--- a/lib/metasploit/framework/data_service/remote/http/remote_host_data_service.rb
+++ b/lib/metasploit/framework/data_service/remote/http/remote_host_data_service.rb
@@ -41,12 +41,12 @@ module RemoteHostDataService
 
   def add_host_tag(opts)
     path = get_path_select(opts, HOST_API_PATH) + '/tag'
-    json_to_mdm_object(self.post_data(path, opts, nil), HOST_MDM_CLASS)
+    json_to_mdm_object(self.post_data(path, opts, nil), TAG_MDM_CLASS)
   end
 
   def delete_host_tag(opts)
     path = get_path_select(opts, HOST_API_PATH) + '/tag'
-    json_to_mdm_object(self.delete_data(path, opts, nil), HOST_MDM_CLASS)
+    json_to_mdm_object(self.delete_data(path, opts, nil), TAG_MDM_CLASS)
   end
 
 end

--- a/lib/metasploit/framework/data_service/remote/http/remote_host_data_service.rb
+++ b/lib/metasploit/framework/data_service/remote/http/remote_host_data_service.rb
@@ -6,6 +6,7 @@ module RemoteHostDataService
   HOST_API_PATH = '/api/v1/hosts'
   HOST_SEARCH_PATH = HOST_API_PATH + "/search"
   HOST_MDM_CLASS = 'Mdm::Host'
+  TAG_MDM_CLASS = 'Mdm::Tag'
 
   def hosts(opts)
     path = get_path_select(opts, HOST_API_PATH)
@@ -32,4 +33,20 @@ module RemoteHostDataService
   def delete_host(opts)
     json_to_mdm_object(self.delete_data(HOST_API_PATH, opts), HOST_MDM_CLASS)
   end
+
+  def get_host_tags(opts)
+    path = get_path_select(opts, HOST_API_PATH) + '/tag'
+    json_to_mdm_object(self.get_data(path, opts, nil), TAG_MDM_CLASS)
+  end
+
+  def add_host_tag(opts)
+    path = get_path_select(opts, HOST_API_PATH) + '/tag'
+    json_to_mdm_object(self.post_data(path, opts, nil), HOST_MDM_CLASS)
+  end
+
+  def delete_host_tag(opts)
+    path = get_path_select(opts, HOST_API_PATH) + '/tag'
+    json_to_mdm_object(self.delete_data(path, opts, nil), HOST_MDM_CLASS)
+  end
+
 end

--- a/lib/metasploit/framework/data_service/stubs/host_data_service.rb
+++ b/lib/metasploit/framework/data_service/stubs/host_data_service.rb
@@ -27,4 +27,16 @@ module HostDataService
   def delete_host(opts)
     raise 'HostDataService#delete_host is not implemented'
   end
+
+  def get_host_tags(opts)
+    raise 'HostDataService#get_host_tags is not implemented'
+  end
+
+  def add_host_tag(opts)
+    raise 'HostDataService#add_host_tag is not implemented'
+  end
+
+  def delete_host_tag(opts)
+    raise 'HostDataService#delete_host_tag is not implemented'
+  end
 end

--- a/lib/msf/core/db_manager/host.rb
+++ b/lib/msf/core/db_manager/host.rb
@@ -55,45 +55,51 @@ module Msf::DBManager::Host
   def add_host_tag(opts)
     wspace = Msf::Util::DBManager.process_opts_workspace(opts, framework)
 
-    ip = opts[:ip]
+    host_id = opts[:id]
     tag_name = opts[:tag_name]
 
-    host = get_host(workspace: wspace, address: ip)
+    host = wspace.hosts.find(host_id)
     if host
-      possible_tags = Mdm::Tag.joins(:hosts).where("hosts.workspace_id = ? and hosts.address = ? and tags.name = ?", wspace.id, ip, tag_name).order("tags.id DESC").limit(1)
+      possible_tags = Mdm::Tag.joins(:hosts).where("hosts.workspace_id = ? and hosts.id = ? and tags.name = ?", wspace.id, host_id, tag_name).order("tags.id DESC").limit(1)
       tag = (possible_tags.blank? ? Mdm::Tag.new : possible_tags.first)
       tag.name = tag_name
       tag.hosts = [host]
       tag.save! if tag.changed?
+      tag
     end
   end
 
+  #@todo This will have to be pulled out if tags are used for more than just hosts
+  # ATM it will delete the tag from the tag table, not the host<->tag link
   def delete_host_tag(opts)
-    workspace = opts[:workspace]
-    if workspace.kind_of? String
-      workspace = framework.db.find_workspace(workspace)
-    end
+    wspace = Msf::Util::DBManager.process_opts_workspace(opts, framework)
 
-    ip = opts[:rws]
+    host_id = opts[:id]
     tag_name = opts[:tag_name]
-
     tag_ids = []
-    if ip.nil?
-      found_tags = Mdm::Tag.joins(:hosts).where("hosts.workspace_id = ? and tags.name = ?", workspace.id, tag_name)
+
+    host = wspace.hosts.find(host_id)
+    if host
+      found_tags = Mdm::Tag.joins(:hosts).where("hosts.workspace_id = ? and hosts.id = ? and tags.name = ?", wspace.id, host.id, tag_name)
       found_tags.each do |t|
         tag_ids << t.id
       end
-    else
-      found_tags = Mdm::Tag.joins(:hosts).where("hosts.workspace_id = ? and hosts.address = ? and tags.name = ?", workspace.id, ip, tag_name)
-      found_tags.each do |t|
-        tag_ids << t.id
+
+      tag_ids.each do |id|
+        tag = Mdm::Tag.find_by_id(id)
+        tag.hosts.delete
+        tag.destroy
       end
     end
+  end
 
-    tag_ids.each do |id|
-      tag = Mdm::Tag.find_by_id(id)
-      tag.hosts.delete
-      tag.destroy
+  def get_host_tags(opts)
+    wspace = Msf::Util::DBManager.process_opts_workspace(opts, framework)
+    host_id = opts[:id]
+
+    host = wspace.hosts.find(host_id)
+    if host
+      Mdm::Tag.joins(:hosts).where(id: host.id)
     end
   end
 

--- a/lib/msf/core/db_manager/host.rb
+++ b/lib/msf/core/db_manager/host.rb
@@ -85,11 +85,15 @@ module Msf::DBManager::Host
         tag_ids << t.id
       end
 
+      deleted_tags = []
+
       tag_ids.each do |id|
         tag = Mdm::Tag.find_by_id(id)
-        tag.hosts.delete
+        deleted_tags << tag
         tag.destroy
       end
+
+      deleted_tags
     end
   end
 
@@ -99,7 +103,7 @@ module Msf::DBManager::Host
 
     host = wspace.hosts.find(host_id)
     if host
-      Mdm::Tag.joins(:hosts).where(id: host.id)
+      host.tags
     end
   end
 

--- a/lib/msf/core/web_services/servlet/host_servlet.rb
+++ b/lib/msf/core/web_services/servlet/host_servlet.rb
@@ -9,7 +9,7 @@ module HostServlet
   end
 
   def self.api_path_with_id_and_tags
-    "#{HostServlet.api_path_with_id}/tag"
+    "#{HostServlet.api_path_with_id}/tags"
   end
 
   def self.api_search_path

--- a/lib/msf/core/web_services/servlet/host_servlet.rb
+++ b/lib/msf/core/web_services/servlet/host_servlet.rb
@@ -98,7 +98,7 @@ module HostServlet
         data = get_db.get_host_tags(opts)
         set_json_data_response(response: data)
       rescue => e
-        print_error_and_create_response(error: e, message: 'There was an error adding the host tag:', code: 500)
+        print_error_and_create_response(error: e, message: 'There was an error retrieving the host tag(s):', code: 500)
       end
     }
   end

--- a/lib/msf/core/web_services/servlet/host_servlet.rb
+++ b/lib/msf/core/web_services/servlet/host_servlet.rb
@@ -8,6 +8,10 @@ module HostServlet
     "#{HostServlet.api_path}/?:id?"
   end
 
+  def self.api_path_with_id_and_tags
+    "#{HostServlet.api_path_with_id}/tag"
+  end
+
   def self.api_search_path
     "#{HostServlet.api_path}/search"
   end
@@ -18,6 +22,9 @@ module HostServlet
     app.put HostServlet.api_path_with_id, &update_host
     app.delete HostServlet.api_path, &delete_host
     app.post HostServlet.api_search_path, &search
+    app.get HostServlet.api_path_with_id_and_tags, &get_host_tags
+    app.post HostServlet.api_path_with_id_and_tags, &add_host_tag
+    app.delete HostServlet.api_path_with_id_and_tags, &delete_host_tag
   end
 
   #######
@@ -76,6 +83,53 @@ module HostServlet
         set_json_data_response(response: data)
       rescue => e
         print_error_and_create_response(error: e, message: 'There was an error deleting hosts:', code: 500)
+      end
+    }
+  end
+
+  def self.get_host_tags
+    lambda {
+      warden.authenticate!
+      begin
+        opts = parse_json_request(request, false)
+
+        tmp_params = sanitize_params(params)
+        opts[:id] = tmp_params[:id] if tmp_params[:id]
+        data = get_db.get_host_tags(opts)
+        set_json_data_response(response: data)
+      rescue => e
+        print_error_and_create_response(error: e, message: 'There was an error adding the host tag:', code: 500)
+      end
+    }
+  end
+
+  def self.add_host_tag
+    lambda {
+      warden.authenticate!
+      begin
+        opts = parse_json_request(request, false)
+
+        tmp_params = sanitize_params(params)
+        opts[:id] = tmp_params[:id] if tmp_params[:id]
+        data = get_db.add_host_tag(opts)
+        set_json_data_response(response: data)
+      rescue => e
+        print_error_and_create_response(error: e, message: 'There was an error adding the host tag:', code: 500)
+      end
+    }
+  end
+
+  def self.delete_host_tag
+    lambda {
+      warden.authenticate!
+      begin
+        opts = parse_json_request(request, false)
+        tmp_params = sanitize_params(params)
+        opts[:id] = tmp_params[:id] if tmp_params[:id]
+        data = get_db.delete_host_tag(opts)
+        set_json_data_response(response: data)
+      rescue => e
+        print_error_and_create_response(error: e, message: 'There was an error deleting the host tag:', code: 500)
       end
     }
   end

--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -312,27 +312,18 @@ class Db
 
     rws.each do |rw|
       rw.each do |ip|
-        opts[:ip] = ip
+        opts[:address] = ip
         framework.db.add_host_tag(opts)
       end
     end
   end
 
-  def find_hosts_with_tag(workspace_id, host_address, tag_name)
+  def find_host_tags(workspace, host_id)
     opts = Hash.new()
-    opts[:workspace_id] = workspace_id
-    opts[:host_address] = host_address
-    opts[:tag_name] = tag_name
+    opts[:workspace] = workspace
+    opts[:id] = host_id
 
-    framework.db.find_hosts_with_tag(opts)
-  end
-
-  def find_host_tags(workspace_id, host_address)
-    opts = Hash.new()
-    opts[:workspace_id] = workspace_id
-    opts[:host_address] = host_address
-
-    framework.db.find_host_tags(opts)
+    framework.db.get_host_tags(opts)
   end
 
   def delete_host_tag(rws, tag_name)
@@ -345,7 +336,7 @@ class Db
     else
       rws.each do |rw|
         rw.each do |ip|
-          opts[:ip] = ip
+          opts[:address] = ip
           framework.db.delete_host_tag(opts)
         end
       end
@@ -554,7 +545,7 @@ class Db
             when "vulns";     host.vuln_count
             when "workspace"; host.workspace.name
             when "tags"
-              found_tags = find_host_tags(framework.db.workspace.id, host.address)
+              found_tags = find_host_tags(framework.db.workspace, host.id)
               tag_names = []
               found_tags.each { |t| tag_names << t.name }
               found_tags * ", "

--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -313,7 +313,9 @@ class Db
     rws.each do |rw|
       rw.each do |ip|
         opts[:address] = ip
-        framework.db.add_host_tag(opts)
+        unless framework.db.add_host_tag(opts)
+          print_error("Host #{ip} could not be found.")
+        end
       end
     end
   end
@@ -332,12 +334,16 @@ class Db
     opts[:tag_name] = tag_name
 
     if rws == [nil]
-      framework.db.delete_host_tag(opts)
+      unless framework.db.delete_host_tag(opts)
+        print_error("Host #{opts[:address].to_s + " " if opts[:address]}could not be found.")
+      end
     else
       rws.each do |rw|
         rw.each do |ip|
           opts[:address] = ip
-          framework.db.delete_host_tag(opts)
+          unless framework.db.delete_host_tag(opts)
+            print_error("Host #{ip} could not be found.")
+          end
         end
       end
     end


### PR DESCRIPTION
Fixes https://github.com/rapid7/metasploit-framework/issues/13125

Tag functionality for Hosts, (the ability to add a `tag` to multiple Host entries and use said tag to search for Hosts) was not updated to work correctly with the `RemoteHttpDataService` added some time in 2018.

This PR adds back the expected tag functionality for Hosts allowing users to:
-  Add tag to host `hosts -t jim 192.168.56.0`
-  Display tags of all Hosts `hosts -c tags`
-  Search hosts using a tag `hosts -S jim`
-  Delete tag from Host `hosts -d -t jim 192.168.56.0`