### PR TITLE
ssh_login windows 10/2019 friendly, and 'submit unknown' banner.

### DIFF
--- a/lib/metasploit/framework/login_scanner/ssh.rb
+++ b/lib/metasploit/framework/login_scanner/ssh.rb
@@ -152,6 +152,14 @@ module Metasploit
                   if proof =~ /Version:(?<os_version>.+).+HW: (?<hardware>)/mi
                     proof = "Model: #{hardware}, OS: #{os_version}"
                   end
+                # Windows
+                elsif proof =~ /is not recognized as an internal or external command/
+                  proof = ssh_socket.exec!("systeminfo\n").to_s
+                  /OS Name:\s+(?<os_name>.+)$/ =~ proof
+                  /OS Version:\s+(?<os_num>.+)$/ =~ proof
+                  if os_name && os_num
+                    proof = "#{os_name.chomp} #{os_num.chomp}"
+                  end
                 else
                   proof << ssh_socket.exec!("help\n?\n\n\n").to_s
                 end
@@ -186,7 +194,7 @@ module Metasploit
             'hpux'
           when /AIX/
             'aix'
-          when /Win32|Windows/
+          when /Win32|Windows|Microsoft/
             'windows'
           when /Unknown command or computer name|Line has invalid autocommand/
             'cisco-ios'

--- a/modules/auxiliary/scanner/ssh/ssh_login.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_login.rb
@@ -132,6 +132,12 @@ class MetasploitModule < Msf::Auxiliary
         credential_data[:core] = credential_core
         create_credential_login(credential_data)
         session_setup(result, scanner) if datastore['CreateSession']
+        if datastore['GatherProof'] && scanner.get_platform(result.proof) == 'unknown'
+          msg = "While a session may have opened, it may be bugged.  If you experience issues with it, re-run this module with"
+          msg << " 'set gatherproof off'.  Also consider submitting an issue at github.com/rapid7/metasploit-framework with"
+          msg << " device details so it can be handled in the future."
+          print_brute :level => :error, :ip => ip, :msg => msg
+        end
         :next_user
       when Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
         vprint_brute :level => :verror, :ip => ip, :msg => "Could not connect: #{result.proof}"

--- a/modules/auxiliary/scanner/ssh/ssh_login_pubkey.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_login_pubkey.rb
@@ -155,6 +155,12 @@ class MetasploitModule < Msf::Auxiliary
           tmp_key = result.credential.private
           ssh_key = SSHKey.new tmp_key
           session_setup(result, scanner, ssh_key.fingerprint) if datastore['CreateSession']
+          if datastore['GatherProof'] && scanner.get_platform(result.proof) == 'unknown'
+            msg = "While a session may have opened, it may be bugged.  If you experience issues with it, re-run this module with"
+            msg << " 'set gatherproof off'.  Also consider submitting an issue at github.com/rapid7/metasploit-framework with"
+            msg << " device details so it can be handled in the future."
+            print_brute :level => :error, :ip => ip, :msg => msg
+          end
           :next_user
         when Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
           if datastore['VERBOSE']


### PR DESCRIPTION
Part 2 of #13315

This updates `ssh_login` to work with OpenSSH on Windows as per https://docs.microsoft.com/en-us/windows-server/administration/openssh/openssh_install_firstuse
It also adds that if you `gatherproof` (default) and the session comes back as `unknown`, to submit an issue so we can get it added.