### PR TITLE
Fix #13318, Expand Environment Variables In Meterpreter's ls Command

### DIFF
--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
@@ -711,11 +711,8 @@ class Console::CommandDispatcher::Stdapi::Fs
         cmd_ls_help
         return 0
       when nil
-        if client.platform == 'windows' && val.include?('%')
-          path = client.fs.file.expand_path(val)
-        else
-          path = val
-        end
+        path = val
+        path = client.fs.file.expand_path(path) if path =~ PATH_EXPAND_REGEX
       end
     }
 

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
@@ -711,7 +711,7 @@ class Console::CommandDispatcher::Stdapi::Fs
         cmd_ls_help
         return 0
       when nil
-        path = val
+        path = client.fs.file.expand_path(val)
       end
     }
 

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
@@ -711,7 +711,11 @@ class Console::CommandDispatcher::Stdapi::Fs
         cmd_ls_help
         return 0
       when nil
-        path = client.fs.file.expand_path(val)
+        if client.platform == 'windows' && val.include?('%')
+          path = client.fs.file.expand_path(val)
+        else
+          path = val
+        end
       end
     }
 


### PR DESCRIPTION
see [#13318](https://github.com/rapid7/metasploit-framework/issues/13318)

```
meterpreter > ls -R %USERPROFILE%/Desktop                                                  
Listing: C:\Users\Administrator/Desktop/dir                                                
===========================================                                                
                                                                                           
Mode              Size  Type  Last modified              Name                              
----              ----  ----  -------------              ----                              
100666/rw-rw-rw-  0     fil   2020-04-24 11:11:43 +0800  file.txt                          
                                                                                           
Listing: C:\Users\Administrator/Desktop                                                    
=======================================                                                    
                                                                                           
Mode              Size      Type  Last modified              Name                          
----              ----      ----  -------------              ----                          
100777/rwxrwxrwx  73802     fil   2020-04-02 19:44:05 +0800  32.exe                        
100777/rwxrwxrwx  7168      fil   2020-03-14 00:11:23 +0800  64.exe                        
100666/rw-rw-rw-  475424    fil   2020-04-02 23:03:29 +0800  DebugView.zip                 
100666/rw-rw-rw-  49210     fil   1998-06-17 00:00:00 +0800  SPYHK55.DLL                   
100666/rw-rw-rw-  194       fil   2020-04-04 20:45:31 +0800  debug.txt                     
100666/rw-rw-rw-  282       fil   2020-02-26 07:54:53 +0800  desktop.ini                   
40777/rwxrwxrwx   0         dir   2020-04-24 11:11:36 +0800  dir                           
100666/rw-rw-rw-  15650     fil   2020-03-26 15:34:03 +0800  payload.asm                   
100666/rw-rw-rw-  796       fil   2020-03-26 15:34:03 +0800  payload.bin                   
100666/rw-rw-rw-  279       fil   2020-04-12 17:46:04 +0800  rdpv.cfg                      
100666/rw-rw-rw-  31867697  fil   2020-02-27 20:08:04 +0800  snapshot_2020-01-08_01-50.zip 
100666/rw-rw-rw-  1764      fil   2020-02-27 20:08:54 +0800  x32dbg.lnk                    
100666/rw-rw-rw-  1764      fil   2020-02-27 20:08:54 +0800  x64dbg.lnk                    

```