### PR TITLE
update to ruby 2.7.1 on alpine 3.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6.6-alpine3.10 AS builder
+FROM ruby:2.7.1-alpine3.11 AS builder
 LABEL maintainer="Rapid7"
 
 ARG BUNDLER_ARGS="--jobs=8 --without development test coverage"
@@ -36,7 +36,7 @@ RUN apk add --no-cache \
     && chmod -R a+r /usr/local/bundle
 
 
-FROM ruby:2.6.5-alpine3.10
+FROM ruby:2.7.1-alpine3.11
 LABEL maintainer="Rapid7"
 
 ENV APP_HOME=/usr/src/metasploit-framework


### PR DESCRIPTION
Update docker image to use latest version of ruby 2.7.1 and latest alpine 3.11 release

## Verification

List the steps needed to make sure this thing works

- [ x ] Start `msfconsole`
- [ x ] `use exploit/windows/smb/ms08_067_netapi`
- [ ] ...
- [ x ] **Verify** the thing does what it should
- [ x ] **Verify** the thing does not do what it should not
- [ ] **Document** the thing and how it works ([Example](https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/post/multi/gather/aws_keys.md))

