### PR TITLE
Update PaX detection

### DIFF
--- a/lib/msf/core/post/linux/kernel.rb
+++ b/lib/msf/core/post/linux/kernel.rb
@@ -250,7 +250,7 @@ module Kernel
   # Returns true if PaX is installed
   #
   def pax_installed?
-    cmd_exec('test -x /sbin/paxctl && echo true').to_s.strip.include? 'true'
+    cmd_exec('/bin/grep -q "PaX:" /proc/self/status && echo true').to_s.strip.include? 'true'
   rescue
     raise 'Could not determine PaX status'
   end

--- a/modules/post/linux/gather/enum_protections.rb
+++ b/modules/post/linux/gather/enum_protections.rb
@@ -137,6 +137,7 @@ class MetasploitModule < Msf::Post
       rkhunter tcpdump webmin jailkit pwgen proxychains bastille
       psad wireshark nagios apparmor oz-seccomp honeyd thpot
       aa-status gradm gradm2 getenforce aide tripwire paxctl
+      paxctld paxtest firejail auditd
     )
 
     apps.each do |app|


### PR DESCRIPTION
The use of paxctld makes paxctl unnecessary. This improve the PaX detection.
Add some binaries to enum_protections (paxctld, paxtest, firejail & auditd)
