### PR TITLE
Remove safe navigation rubocop rule

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -228,6 +228,16 @@ Style/RedundantBegin:
     # end
     - 'modules/**/*'
 
+Style/SafeNavigation:
+  Description: >-
+    This cop transforms usages of a method call safeguarded by
+    a check for the existence of the object to
+    safe navigation (`&.`).
+
+    This has been disabled as in some scenarios it produced invalid code, and disobeyed the 'AllowedMethods'
+    configuration.
+  Enabled: false
+
 Documentation:
   Exclude:
     - 'modules/**/*'


### PR DESCRIPTION
In certain scenarios it's possible for this Rubocop rule to produce broken Ruby code.

I believe rubocop is only meant to perform this transform for [specific methods](
https://github.com/rubocop-hq/rubocop/blob/89671c5120bacda304ab3861fef166550758db8e/config/default.yml#L3651-L3667), but it doesn't appear to work:

```yaml
  AllowedMethods:
    - present?
    - blank?
    - presence
    - try
    - try!
```

Let's disable the rule for now, and I've raised an issue with Rubocop

Full context: https://github.com/rapid7/metasploit-framework/pull/13291#discussion_r414480775
Rubocop issue: https://github.com/rubocop-hq/rubocop/issues/7914