### PR TITLE
ZDI Public numbers should be limited to 4 digits

### DIFF
--- a/tools/dev/msftidy.rb
+++ b/tools/dev/msftidy.rb
@@ -178,7 +178,7 @@ class Msftidy
         when 'US-CERT-VU'
           warn("Invalid US-CERT-VU reference") if value !~ /^\d+$/
         when 'ZDI'
-          warn("Invalid ZDI reference") if value !~ /^\d{2}-\d{3,}$/
+          warn("Invalid ZDI reference") if value !~ /^\d{2}-\d{3,4}$/
         when 'WPVDB'
           warn("Invalid WPVDB reference") if value !~ /^\d+$/
         when 'PACKETSTORM'


### PR DESCRIPTION
to avoid false negatives per the discussion at #13311

changes the msftidy ZDI ref regex from `/^\d{2}-\d{3,}$/` to `/^\d{2-\d{3,4}$/`
because the ZDI base number resets every year and is unlikely to exceed 9999 in our lifetimes
And, because I screwed up the first PR on this, which @wvu-r7 tried to remedy and got very close

comparable Ruby code that displays the public numbers is: `"num_as_string".ljust(3, '0')`

## Verification

List the steps needed to make sure this thing works

- [x] Run msftidy, nothing related to the ZDI Refs should fail
- [x] Change one of the ZDI Public numbers to something like 20-01, msftidy should complain
- [x] Change one of the ZDI Public numbers to something like 20-11111, msftidy should complain

