### PR TITLE
Turn off Ruby deprecation warnings for all users

### DIFF
--- a/msfconsole
+++ b/msfconsole
@@ -8,6 +8,9 @@
 require 'pathname'
 
 begin
+  # TODO: Temporary until warnings can be turned on only for developers to prevent confusion for end users
+  Warning[:deprecated] = false
+
   # @see https://github.com/rails/rails/blob/v3.2.17/railties/lib/rails/generators/rails/app/templates/script/rails#L3-L5
   require Pathname.new(__FILE__).realpath.expand_path.parent.join('config', 'boot')
   require 'metasploit/framework/profiler'


### PR DESCRIPTION
Turns off warnings for all users, this is a temporary measure to limit the confusion we're seeing with end users on ruby 2.7.0 that now produces several warnings.
There will be another PR up soon to enable warnings only when msf is being used in a development environment

- [ ] Switch to ruby 2.7.0
- [ ] Start up msfconsole
- [ ] Observe the warnings
- [ ] Checkout this branch
- [ ] Start up msfconsole
- [ ] Warnings should be gone