### PR TITLE
Add guard clause to ruby warning supression

### DIFF
--- a/msfconsole
+++ b/msfconsole
@@ -9,7 +9,9 @@ require 'pathname'
 
 begin
   # TODO: Temporary until warnings can be turned on only for developers to prevent confusion for end users
-  Warning[:deprecated] = false
+  if defined?(Warning) && Warning.respond_to?(:[]=)
+    Warning[:deprecated] = false
+  end
 
   # @see https://github.com/rails/rails/blob/v3.2.17/railties/lib/rails/generators/rails/app/templates/script/rails#L3-L5
   require Pathname.new(__FILE__).realpath.expand_path.parent.join('config', 'boot')


### PR DESCRIPTION
Currently when booting up msfconsole in Ruby 2.6.x

```
$ bundle exec ruby ./msfconsole
Traceback (most recent call last):
./msfconsole:12:in `<main>': undefined method `[]=' for Warning:Module (NoMethodError)
```

It turns out that not all versions of ruby support `Warning[:deprecated]`. This PR adds a guard clause so that msfconsole boots up as expected:

```
$ docker run -it --rm -v $(pwd):$(pwd) -w $(pwd) ruby:2.6 /bin/bash
root@8b023f88ce8d:/Users/adfoster/Documents/code/metasploit-framework# irb
irb(main):001:0> Warning[:deprecated] = false
Traceback (most recent call last):
        4: from /usr/local/bin/irb:23:in `<main>'
        3: from /usr/local/bin/irb:23:in `load'
        2: from /usr/local/lib/ruby/gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
        1: from (irb):1
NoMethodError (undefined method `[]=' for Warning:Module)
```

This is a continuation of https://github.com/rapid7/metasploit-framework/pull/13360

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole` in Ruby 2.6.x
- [ ] **Verify** that it works
- [ ] Start `msfconsole` in Ruby 2.7.x
- [ ] **Verify** that it works