### PR TITLE
Fix uri escape in rex request for reverse http/https meterpreter shells

### DIFF
--- a/lib/rex/proto/http/request.rb
+++ b/lib/rex/proto/http/request.rb
@@ -76,7 +76,7 @@ class Request < Packet
   def update_cmd_parts(str)
     if (md = str.match(/^(.+?)\s+(.+?)\s+HTTP\/(.+?)\r?\n?$/i))
       self.method  = md[1]
-      self.raw_uri = URI.decode(md[2])
+      self.raw_uri = CGI.unescape(md[2])
       self.proto   = md[3]
 
       update_uri_parts


### PR DESCRIPTION
Fixes deprecation warnings on Ruby 2.7 when using a a reverse http/https meterpreter shell:

![image](https://user-images.githubusercontent.com/60357436/80639324-c0d30a00-8a59-11ea-8707-237c92a82511.png)

There are more deprecations in the codebase to fix, but I'll review them individually in a future pull request. For now the main reported problem is reverse http/https meterpreter shells.

## Verification

Test with both Ruby 2.7 and Ruby 2.6

- [x] Start `msfconsole`
- [x] Set up a reverse http meterpereter session, for example on mac:
```
use payload/osx/x64/meterpreter_reverse_https
set LHOST 127.0.0.1
set LPORT 4445
set SessionCommunicationTimeout 0
set ExitOnSession false

generate -o reverse_shell -f macho

to_handler
```
- [x] Open a new tab, run the `reverse_shell`
- [x] **Verify** that there is no longer any warning messages
- [ ] **Verify** that other calls to the rex requests do not break
