### PR TITLE
Surface developer provided exception messages to users

### DIFF
--- a/lib/msf/base/simple/evasion.rb
+++ b/lib/msf/base/simple/evasion.rb
@@ -22,7 +22,7 @@ module Evasion
 
       # Make sure parameters are valid.
       if (opts['Payload'] == nil)
-        raise MissingPayloadError.new, caller
+        raise MissingPayloadError.new, 'A payload has not been selected.', caller
       end
 
       # Verify the options

--- a/lib/msf/base/simple/exploit.rb
+++ b/lib/msf/base/simple/exploit.rb
@@ -69,7 +69,7 @@ module Exploit
 
       # Make sure parameters are valid.
       if (opts['Payload'] == nil)
-        raise MissingPayloadError.new, caller
+        raise MissingPayloadError, 'A payload has not been selected.', caller
       end
 
       # Verify the options

--- a/lib/msf/core/auxiliary/drdos.rb
+++ b/lib/msf/core/auxiliary/drdos.rb
@@ -20,7 +20,7 @@ module Auxiliary::DRDoS
   def setup
     super
     if spoofed? && datastore['NUM_REQUESTS'] < 1
-      raise Msf::OptionValidateError.new(['NUM_REQUESTS']), 'The number of requests must be >= 1'
+      raise Msf::OptionValidateError.new(['NUM_REQUESTS - The number of requests must be >= 1'])
     end
   end
 

--- a/lib/msf/core/evasion_driver.rb
+++ b/lib/msf/core/evasion_driver.rb
@@ -50,7 +50,7 @@ class EvasionDriver
 
     # Make sure the payload is compatible after all
     if (compatible_payload?(payload) == false)
-      raise IncompatiblePayloadError.new(payload.refname), "Incompatible payload", caller
+      raise IncompatiblePayloadError.new(payload.refname), "#{payload.refname} is not a compatible payload.", caller
     end
 
     # Associate the payload instance with the evasion

--- a/lib/msf/core/exceptions.rb
+++ b/lib/msf/core/exceptions.rb
@@ -26,10 +26,7 @@ class OptionValidateError < ArgumentError
 
   def initialize(options = [])
     @options = options
-  end
-
-  def to_s
-    "The following options failed to validate: #{options.join(', ')}."
+    super("The following options failed to validate: #{options.join(', ')}.")
   end
 
   attr_reader :options
@@ -43,8 +40,8 @@ end
 class ValidationError < ArgumentError
   include Exception
 
-  def to_s
-    "One or more requirements could not be validated."
+  def initialize(msg="One or more requirements could not be validated.")
+    super(msg)
   end
 end
 
@@ -72,8 +69,8 @@ end
 class EncodingError < RuntimeError
   include Exception
 
-  def to_s
-    "An encoding exception occurred."
+  def initialize(msg = "An encoding exception occurred.")
+    super(msg)
   end
 end
 
@@ -83,8 +80,8 @@ end
 #
 ###
 class NoKeyError < EncodingError
-  def to_s
-    "A valid encoding key could not be found."
+  def initialize(msg="A valid encoding key could not be found.")
+    super(msg)
   end
 end
 
@@ -125,9 +122,8 @@ end
 #
 ###
 class NoEncodersSucceededError < EncodingError
-
-  def to_s
-    "No encoders encoded the buffer successfully."
+  def initialize(msg="No encoders encoded the buffer successfully.")
+    super(msg)
   end
 end
 
@@ -137,8 +133,8 @@ end
 #
 ###
 class BadGenerateError < EncodingError
-  def to_s
-    "A valid opcode permutation could not be found."
+  def initialize(msg="A valid opcode permutation could not be found.")
+    super(msg)
   end
 end
 
@@ -169,8 +165,8 @@ end
 module AuxiliaryError
   include Exception
 
-  def to_s
-    "An auxiliary error occurred."
+  def initialize(msg="An auxiliary error occurred.")
+    super(msg)
   end
 end
 
@@ -183,8 +179,8 @@ end
 class MissingTargetError < ArgumentError
   include ExploitError
 
-  def to_s
-    "A target has not been selected."
+  def initialize(msg="A target has not been selected.")
+    super(msg)
   end
 end
 
@@ -197,8 +193,8 @@ end
 class MissingPayloadError < ArgumentError
   include ExploitError
 
-  def to_s
-    "A payload has not been selected."
+  def initialize(msg="A payload has not been selected.")
+    super(msg)
   end
 end
 
@@ -213,12 +209,8 @@ class MissingActionError < ArgumentError
   attr_accessor :reason
 
   def initialize(reason='')
-    self.reason = reason
-    super
-  end
-
-  def to_s
-    "Invalid action: #{reason}"
+    @reason = reason
+    super("Invalid action: #{@reason}")
   end
 end
 
@@ -233,10 +225,7 @@ class IncompatiblePayloadError < ArgumentError
 
   def initialize(pname = nil)
     @pname = pname
-  end
-
-  def to_s
-    "#{pname} is not a compatible payload."
+    super("#{pname} is not a compatible payload.")
   end
 
   #
@@ -263,8 +252,8 @@ end
 module NopError
   include Exception
 
-  def to_s
-    "A NOP generator error occurred."
+  def initialize(msg="A NOP generator error occurred.")
+    super(msg)
   end
 end
 
@@ -277,8 +266,8 @@ end
 class NoNopsSucceededError < RuntimeError
   include NopError
 
-  def to_s
-    "No NOP generators succeeded."
+  def initialize(msg="No NOP generators succeeded.")
+    super(msg)
   end
 end
 
@@ -293,12 +282,8 @@ class PluginLoadError < RuntimeError
   attr_accessor :reason
 
   def initialize(reason='')
-    self.reason = reason
-    super
-  end
-
-  def to_s
-    "This plugin failed to load:  #{reason}"
+    @reason = reason
+    super("This plugin failed to load: #{reason}")
   end
 end
 

--- a/lib/msf/core/exploit/brute.rb
+++ b/lib/msf/core/exploit/brute.rb
@@ -93,7 +93,7 @@ module Exploit::Brute
         step = payload.nop_sled_size
 
         if step == 0
-          raise OptionValidateError.new(['BruteStep']), "The step size for this exploit is invalid"
+          raise OptionValidateError.new(['BruteStep - The step size for this exploit is invalid'])
         end
       end
 

--- a/lib/msf/core/exploit_driver.rb
+++ b/lib/msf/core/exploit_driver.rb
@@ -86,7 +86,7 @@ class ExploitDriver
     # Make sure the payload is compatible after all
     if (compatible_payload?(payload) == false)
       raise IncompatiblePayloadError.new(payload.refname),
-        "Incompatible payload", caller
+        "#{payload.refname} is not a compatible payload.", caller
     end
 
     # Associate the payload instance with the exploit

--- a/lib/msf/core/option_container.rb
+++ b/lib/msf/core/option_container.rb
@@ -214,7 +214,7 @@ module Msf
 
       if (errors.empty? == false)
         raise OptionValidateError.new(errors),
-          "One or more options failed to validate", caller
+          "One or more options failed to validate: #{errors.join(', ')}.", caller
       end
 
       return true


### PR DESCRIPTION
## Context

We currently raise error messages with detailed information:

```ruby
raise EncodingError, "Need BufferRegister"
```

But it seems that the Exceptions that Metasploit framework provide overwrite the `to_s` method, discarding the original `message` passed in when it is shown to the user.

```ruby
class EncodingError < RuntimeError
  include Exception

  def to_s
    "An encoding exception occurred."
  end
end
```

Causing `msfvenom` to lose the developer provided error message:

```
x86/unicode_upper failed with **An encoding exception occurred**.
```

The default implementation of Exception is:

- [message](https://apidock.com/ruby/v2_5_5/Exception/message) - Returns the result of invoking exception.to_s. Normally this returns the exception’s message or name.
- [to_s](https://apidock.com/ruby/Exception/to_s) - Returns exception’s message (or the name of the exception if no message is set).

The implementation seems intentional, so I'm setting this as a draft as a RFC for now. This might also be a difference in error handling between msfvenom and msfconsole.

## Before

```
$ bundle exec ./msfvenom -a x86 --platform windows -p windows/meterpreter/reverse_tcp lhost=192.168.0.1 exitfunc=seh -e x86/unicode_upper -f raw

Found 1 compatible encoders
Attempting to encode payload with 1 iterations of x86/unicode_upper
x86/unicode_upper failed with An encoding exception occurred.
Error: An encoding exception occurred.
```

## After

```
$ bundle exec ./msfvenom -a x86 --platform windows -p windows/meterpreter/reverse_tcp lhost=192.168.0.1 exitfunc=seh -e x86/unicode_upper -f raw

Found 1 compatible encoders
Attempting to encode payload with 1 iterations of x86/unicode_upper
x86/unicode_upper failed with Need BufferRegister
Error: No Encoder Succeeded
```

## Difference

`msfvenom` now correctly shows the original error message:

```diff
 $ bundle exec ./msfvenom -a x86 --platform windows -p windows/meterpreter/reverse_tcp lhost=192.168.0.1 exitfunc=seh -e x86/unicode_upper -f raw

 Found 1 compatible encoders
 Attempting to encode payload with 1 iterations of x86/unicode_upper
- x86/unicode_upper failed with An encoding exception occurred.
+ x86/unicode_upper failed with Need BufferRegister
 Error: An encoding exception occurred.
```

## Verification

Verify that the msfvenom output is now more detailed:

```
 $ bundle exec ./msfvenom -a x86 --platform windows -p windows/meterpreter/reverse_tcp lhost=192.168.0.1 exitfunc=seh -e x86/unicode_upper -f raw
```

Verifying the error handling in msfconsole:

```diff
  msf5 > use auxiliary/scanner/ntp/ntp_unsettrap_dos
  msf5 auxiliary(scanner/ntp/ntp_unsettrap_dos) > set RHOSTS 127.0.0.1
  RHOSTS => 127.0.0.1
  msf5 auxiliary(scanner/ntp/ntp_unsettrap_dos) > set SRCIP 127.0.0.1
  SRCIP => 127.0.0.1
  msf5 auxiliary(scanner/ntp/ntp_unsettrap_dos) > set NUM_REQUESTS 0
  NUM_REQUESTS => 0
  msf5 auxiliary(scanner/ntp/ntp_unsettrap_dos) > run
- [-] Auxiliary failed: Msf::OptionValidateError The following options failed to validate: NUM_REQUESTS.
+ [-] Auxiliary failed: Msf::OptionValidateError The following options failed to validate: NUM_REQUESTS - The number of requests must be >= 1.
  [*] Auxiliary module execution completed
  [*] Auxiliary module execution completed
```