### PR TITLE
Improves "No DB Connected" error message

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -2052,7 +2052,11 @@ class Db
   def db_connect_http(opts)
     # local database is required to use Mdm objects
     unless framework.db.active
-      print_error("No local database connected. Please connect to a local database before connecting to a remote data service.")
+      err_msg = 'No local database connected, meaning some Metasploit features will not be available. A full list of '\
+      'the affected features & database setup instructions can be found here: '\
+      'https://github.com/rapid7/metasploit-framework/wiki/msfdb:-Database-Features-&-How-to-Set-up-a-Database-for-Metasploit'
+
+      print_error(err_msg)
       return
     end
 


### PR DESCRIPTION
Updates the No Db Connected error message to specify that some features won't work as expected, and link to a wiki article giving more information, and instructions on how to set up a local db correctly with `msfdb`.  Wiki article can be found [here](https://github.com/rapid7/metasploit-framework/wiki/msfdb:-Database-Features-&-How-to-Set-up-a-Database-for-Metasploit).

## Verification

List the steps needed to make sure this thing works

- [x] `msfdb stop`
- [x] Start `msfconsole`
- [x] Ensure `[!] No local database connected, meaning some Metasploit features will not be available. A full list of the affected features & database setup instructions can be found here: https://github.com/rapid7/metasploit-framework/wiki/msfdb:-Database-Features-&-How-to-Set-up-a-Database-for-Metasploit'` is displayed correctly.

