### PR TITLE
Fix Events rest api Encoding

### DIFF
--- a/documentation/modules/payload/windows/meterpreter/reverse_tcp.md
+++ b/documentation/modules/payload/windows/meterpreter/reverse_tcp.md
@@ -580,7 +580,7 @@ The route command in Meterpreter allows you change the routing table that is on 
 The portfwd command allows you to talk to a remote service like it's local. For example, if you are able to compromise a host via SMB, but are not able to connect to the remote desktop service, then you can do:
 
 ```
-meterpreter > portfwd add –l 3389 –p 3389 –r [Target Host]
+meterpreter > portfwd add -l 3389 -p 3389 -r [Target Host]
 ```
 
 And that should allow you to connect to remote desktop this way on the attacker's box:

--- a/lib/msf/core/framework.rb
+++ b/lib/msf/core/framework.rb
@@ -393,6 +393,10 @@ class FrameworkEventSubscriber
 
     if framework.db.active
       ws = framework.db.find_workspace(session.workspace)
+      opts.each_key do |attr|
+        opts[attr].force_encoding('UTF-8') if opts[attr].class == String
+      end
+
       event = {
         :workspace => ws,
         :username  => session.username,

--- a/lib/msf/core/framework.rb
+++ b/lib/msf/core/framework.rb
@@ -394,7 +394,7 @@ class FrameworkEventSubscriber
     if framework.db.active
       ws = framework.db.find_workspace(session.workspace)
       opts.each_key do |attr|
-        opts[attr].force_encoding('UTF-8') if opts[attr].class == String
+        opts[attr].force_encoding('UTF-8') if opts[attr].is_a?(String)
       end
 
       event = {

--- a/lib/msf/util/document_generator.rb
+++ b/lib/msf/util/document_generator.rb
@@ -73,7 +73,7 @@ module Msf
           items[:mod_targets] = mod.targets
         end
 
-        n.get_md_content(items, kb)
+        n.get_md_content(items, kb).force_encoding('UTF-8')
       end
 
     end

--- a/modules/exploits/linux/http/nagios_xi_magpie_debug.rb
+++ b/modules/exploits/linux/http/nagios_xi_magpie_debug.rb
@@ -18,7 +18,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Description'    => %q{
          This module exploits two vulnerabilities in Nagios XI 5.5.6:
          CVE-2018-15708 which allows for unauthenticated remote code execution
-         and CVE 2018–15710 which allows for local privilege escalation.
+         and CVE 2018-15710 which allows for local privilege escalation.
          When combined, these two vulnerabilities give us a root reverse shell.
       },
       'License'        => MSF_LICENSE,


### PR DESCRIPTION
# Fix Events rest api Encoding BUG

## how to reproducing

- [x] Connect to the database and get a meterpreter session
- [x] Create a Unicode filename on the target , like `中文.txt`

### Get test data

```bash
meterpreter > ls                                                                          
Listing: C:\Documents and Settings\Administrator\桌面                                     
=======================================================                                   
                                                                                          
Mode              Size    Type  Last modified              Name                           
----              ----    ----  -------------              ----                           
100666/rw-rw-rw-  192     fil   2020-04-20 14:44:26 +0800  2.txt                          
100666/rw-rw-rw-  192     fil   2020-04-20 14:44:26 +0800  3.txt
100777/rwxrwxrwx  73802   fil   2020-04-03 11:00:16 +0800  32.exe
100666/rw-rw-rw-  1657    fil   2020-02-05 22:03:04 +0800  MSDN Library - October 2001.lnk
100666/rw-rw-rw-  921     fil   2020-02-05 12:21:55 +0800  Microsoft Visual C++ 6.0.lnk 
40777/rwxrwxrwx   0       dir   2020-02-05 12:25:36 +0800  MyProjects
100777/rwxrwxrwx  253952  fil   2020-04-20 14:43:14 +0800  fastcoll_v1.0.0.5.exe
100666/rw-rw-rw-  1728    fil   2020-03-26 10:08:08 +0800  x32dbg.lnk
100666/rw-rw-rw-  1       fil   2020-04-20 14:43:18 +0800  中文.txt
```

Or insert the following data into the database

``` sql
INSERT INTO public.events (workspace_id,host_id,created_at,name,updated_at,critical,seen,username,info) VALUES 
(1,342,'2020-05-01 01:36:50.402','session_output','2020-05-01 01:36:50.402',NULL,NULL,'kali-team','BAh7EDoPc2Vzc2lvbl9pZGkGOhFzZXNzaW9uX2luZm8iNEtULTc0NDVCQzgy
MjUyNlxBZG1pbmlzdHJhdG9yIEAgS1QtNzQ0NUJDODIyNTI2OhFzZXNzaW9u
X3V1aWQiDXc0NW13aHV0OhFzZXNzaW9uX3R5cGUiEG1ldGVycHJldGVyOg11
c2VybmFtZSIOa2FsaS10ZWFtOhB0YXJnZXRfaG9zdCITMTkyLjE2OC43Ni4x
Mjg6EHZpYV9leHBsb2l0IhpleHBsb2l0L211bHRpL2hhbmRsZXI6EHZpYV9w
YXlsb2FkIixwYXlsb2FkL3dpbmRvd3MvbWV0ZXJwcmV0ZXIvcmV2ZXJzZV90
Y3A6EHR1bm5lbF9wZWVyIhgxOTIuMTY4Ljc2LjEyODoxMDMyOhFleHBsb2l0
X3V1aWQiDXplZWQwcmNuOgtvdXRwdXQiAosDTGlzdGluZzogQzpcRG9jdW1l
bnRzIGFuZCBTZXR0aW5nc1xBZG1pbmlzdHJhdG9yXOahjOmdogo9PT09PT09
PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09
PT09CgpNb2RlICAgICAgICAgICAgICBTaXplICAgIFR5cGUgIExhc3QgbW9k
aWZpZWQgICAgICAgICAgICAgIE5hbWUKLS0tLSAgICAgICAgICAgICAgLS0t
LSAgICAtLS0tICAtLS0tLS0tLS0tLS0tICAgICAgICAgICAgICAtLS0tCjEw
MDY2Ni9ydy1ydy1ydy0gIDE5MiAgICAgZmlsICAgMjAyMC0wNC0yMCAxNDo0
NDoyNiArMDgwMCAgMi50eHQKMTAwNjY2L3J3LXJ3LXJ3LSAgMTkyICAgICBm
aWwgICAyMDIwLTA0LTIwIDE0OjQ0OjI2ICswODAwICAzLnR4dAoxMDA3Nzcv
cnd4cnd4cnd4ICA3MzgwMiAgIGZpbCAgIDIwMjAtMDQtMDMgMTE6MDA6MTYg
KzA4MDAgIDMyLmV4ZQoxMDA2NjYvcnctcnctcnctICAxNjU3ICAgIGZpbCAg
IDIwMjAtMDItMDUgMjI6MDM6MDQgKzA4MDAgIE1TRE4gTGlicmFyeSAtIE9j
dG9iZXIgMjAwMS5sbmsKMTAwNjY2L3J3LXJ3LXJ3LSAgOTIxICAgICBmaWwg
ICAyMDIwLTAyLTA1IDEyOjIxOjU1ICswODAwICBNaWNyb3NvZnQgVmlzdWFs
IEMrKyA2LjAubG5rCjQwNzc3L3J3eHJ3eHJ3eCAgIDAgICAgICAgZGlyICAg
MjAyMC0wMi0wNSAxMjoyNTozNiArMDgwMCAgTXlQcm9qZWN0cwoxMDA3Nzcv
cnd4cnd4cnd4ICAyNTM5NTIgIGZpbCAgIDIwMjAtMDQtMjAgMTQ6NDM6MTQg
KzA4MDAgIGZhc3Rjb2xsX3YxLjAuMC41LmV4ZQoxMDA2NjYvcnctcnctcnct
ICAxNzI4ICAgIGZpbCAgIDIwMjAtMDMtMjYgMTA6MDg6MDggKzA4MDAgIHgz
MmRiZy5sbmsKMTAwNjY2L3J3LXJ3LXJ3LSAgMSAgICAgICBmaWwgICAyMDIw
LTA0LTIwIDE0OjQzOjE4ICswODAwICDkuK3mlocudHh0Cg==
')
;
```

- Check database

|id|workspace_id|host_id|created_at|name|updated_at|critical|seen|username|info|
|--|------------|-------|----------|----|----------|--------|----|--------|----|
|1691|1|342|2020-05-01 01:36:50|session_output|2020-05-01 01:36:50|||kali-team|BAh7EDoPc2Vzc2lvbl9pZGkGOhFzZXNzaW9uX2luZm8iNEtULTc0NDVCQzgy<br/>MjUyNlxBZG1pbmlzdHJhdG9yIEAgS1QtNzQ0NUJDODIyNTI2OhFzZXNzaW9u<br/>X3V1aWQiDXc0NW13aHV0OhFzZXNzaW9uX3R5cGUiEG1ldGVycHJldGVyOg11<br/>c2VybmFtZSIOa2FsaS10ZWFtOhB0YXJnZXRfaG9zdCITMTkyLjE2OC43Ni4x<br/>Mjg6EHZpYV9leHBsb2l0IhpleHBsb2l0L211bHRpL2hhbmRsZXI6EHZpYV9w<br/>YXlsb2FkIixwYXlsb2FkL3dpbmRvd3MvbWV0ZXJwcmV0ZXIvcmV2ZXJzZV90<br/>Y3A6EHR1bm5lbF9wZWVyIhgxOTIuMTY4Ljc2LjEyODoxMDMyOhFleHBsb2l0<br/>X3V1aWQiDXplZWQwcmNuOgtvdXRwdXQiAosDTGlzdGluZzogQzpcRG9jdW1l<br/>bnRzIGFuZCBTZXR0aW5nc1xBZG1pbmlzdHJhdG9yXOahjOmdogo9PT09PT09<br/>PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09<br/>PT09CgpNb2RlICAgICAgICAgICAgICBTaXplICAgIFR5cGUgIExhc3QgbW9k<br/>aWZpZWQgICAgICAgICAgICAgIE5hbWUKLS0tLSAgICAgICAgICAgICAgLS0t<br/>LSAgICAtLS0tICAtLS0tLS0tLS0tLS0tICAgICAgICAgICAgICAtLS0tCjEw<br/>MDY2Ni9ydy1ydy1ydy0gIDE5MiAgICAgZmlsICAgMjAyMC0wNC0yMCAxNDo0<br/>NDoyNiArMDgwMCAgMi50eHQKMTAwNjY2L3J3LXJ3LXJ3LSAgMTkyICAgICBm<br/>aWwgICAyMDIwLTA0LTIwIDE0OjQ0OjI2ICswODAwICAzLnR4dAoxMDA3Nzcv<br/>cnd4cnd4cnd4ICA3MzgwMiAgIGZpbCAgIDIwMjAtMDQtMDMgMTE6MDA6MTYg<br/>KzA4MDAgIDMyLmV4ZQoxMDA2NjYvcnctcnctcnctICAxNjU3ICAgIGZpbCAg<br/>IDIwMjAtMDItMDUgMjI6MDM6MDQgKzA4MDAgIE1TRE4gTGlicmFyeSAtIE9j<br/>dG9iZXIgMjAwMS5sbmsKMTAwNjY2L3J3LXJ3LXJ3LSAgOTIxICAgICBmaWwg<br/>ICAyMDIwLTAyLTA1IDEyOjIxOjU1ICswODAwICBNaWNyb3NvZnQgVmlzdWFs<br/>IEMrKyA2LjAubG5rCjQwNzc3L3J3eHJ3eHJ3eCAgIDAgICAgICAgZGlyICAg<br/>MjAyMC0wMi0wNSAxMjoyNTozNiArMDgwMCAgTXlQcm9qZWN0cwoxMDA3Nzcv<br/>cnd4cnd4cnd4ICAyNTM5NTIgIGZpbCAgIDIwMjAtMDQtMjAgMTQ6NDM6MTQg<br/>KzA4MDAgIGZhc3Rjb2xsX3YxLjAuMC41LmV4ZQoxMDA2NjYvcnctcnctcnct<br/>ICAxNzI4ICAgIGZpbCAgIDIwMjAtMDMtMjYgMTA6MDg6MDggKzA4MDAgIHgz<br/>MmRiZy5sbmsKMTAwNjY2L3J3LXJ3LXJ3LSAgMSAgICAgICBmaWwgICAyMDIw<br/>LTA0LTIwIDE0OjQzOjE4ICswODAwICDkuK3mlocudHh0Cg==|

### request api

- Limit return to 1, get a correct data, ID 1692

```json
➜  ~ curl -s -k -X GET "https://api.kali-team.cn:5443/api/v1/events?workspace=default&limit=1&offset=5&order=desc" -H "accept: application/json" -H "Authorization: Bearer e16aeb520175ab2f359c463148b185968c703f25669c12d36ffd31120f4330bb0506f80690e882b0"|python -m json.tool
{
    "data": [
        {
            "id": 1692,
            "workspace_id": 1,
            "host_id": 342,
            "created_at": "2020-05-01T01:41:29.747Z",
            "name": "session_command",
            "updated_at": "2020-05-01T01:41:29.747Z",
            "critical": null,
            "seen": null,
            "username": "kali-team",
            "info": {
                "session_id": 1,
                "session_info": "KT-7445BC822526\\Administrator @ KT-7445BC822526",
                "session_uuid": "w45mwhut",
                "session_type": "meterpreter",
                "username": "kali-team",
                "target_host": "192.168.76.128",
                "via_exploit": "exploit/multi/handler",
                "via_payload": "payload/windows/meterpreter/reverse_tcp",
                "tunnel_peer": "192.168.76.128:1032",
                "exploit_uuid": "zeed0rcn",
                "command": "background"
            }
        }
    ]
}
➜  ~ 
```

- Modify offset add 1, get ID 1691, error found

```json
➜  ~ curl -s -k -X GET "https://api.kali-team.cn:5443/api/v1/events?workspace=default&limit=1&offset=6&order=desc" -H "accept: application/json" -H "Authorization: Bearer e16aeb520175ab2f359c463148b185968c703f25669c12d36ffd31120f4330bb0506f80690e882b0"|python -m json.tool
{
    "error": {
        "code": 500,
        "message": "There was an error retrieving events: \"\\xE6\" from ASCII-8BIT to UTF-8"
    }
}
➜  ~ 

```

## breakpoint debugging

```ruby
From: /home/kali-team/Projects/RubyProjects/metasploit-framework/lib/msf/core/web_services/servlet_helper.rb:186 ServletHelper#to_json:

    183: def to_json(data, includes = nil)
    184:   return '{}' if data.nil?
    185:   require 'pry'; binding.pry
 => 186:   json = includes.nil? ? data.to_json : data.to_json(include:  includes)
    187:   return json.to_s
    188: end

[1] pry(#<MetasploitApiApp>)> 
```

-  run `data[0].info[:output].to_json`

``` ruby
1] pry(#<MetasploitApiApp>)> data[0].info[:output].to_json
Encoding::UndefinedConversionError: "\xE6" from ASCII-8BIT to UTF-8
from /home/kali-team/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/activesupport-4.2.11.1/lib/active_support/core_ext/object/json.rb:34:in `to_json'
[2] pry(#<MetasploitApiApp>)> 
```

## Fix Bug

- I think we should use UTF-8 encoding before inserting text into the database,This can solve the problem from the source

```json
➜  ~ curl -s -k  -X GET "https://api.kali-team.cn:5443/api/v1/events?workspace=default&limit=1&offset=5&order=desc" -H "accept: application/json" -H "Authorization: Bearer e16aeb520175ab2f359c463148b185968c703f25669c12d36ffd31120f4330bb0506f80690e882b0" |python -m json.tool
{
    "data": [
        {
            "id": 1691,
            "workspace_id": 1,
            "host_id": 342,
            "created_at": "2020-05-01T10:36:31.386Z",
            "name": "session_output",
            "updated_at": "2020-05-01T10:36:31.386Z",
            "critical": null,
            "seen": null,
            "username": "kali-team",
            "info": {
                "session_id": 1,
                "session_info": "KT-7445BC822526\\Administrator @ KT-7445BC822526",
                "session_uuid": "9ceehxmp",
                "session_type": "meterpreter",
                "username": "kali-team",
                "target_host": "192.168.76.128",
                "via_exploit": "exploit/multi/handler",
                "via_payload": "payload/windows/meterpreter/reverse_tcp",
                "tunnel_peer": "192.168.76.128:1107",
                "exploit_uuid": "bnyzroe0",
                "output": "Listing: C:\\Documents and Settings\\Administrator\\\u684c\u9762\n=======================================================\n\nMode              Size    Type  Last modified              Name\n----              ----    ----  -------------              ----\n100666/rw-rw-rw-  192     fil   2020-04-20 14:44:26 +0800  2.txt\n100666/rw-rw-rw-  192     fil   2020-04-20 14:44:26 +0800  3.txt\n100777/rwxrwxrwx  73802   fil   2020-04-03 11:00:16 +0800  32.exe\n100666/rw-rw-rw-  1657    fil   2020-02-05 22:03:04 +0800  MSDN Library - October 2001.lnk\n100666/rw-rw-rw-  921     fil   2020-02-05 12:21:55 +0800  Microsoft Visual C++ 6.0.lnk\n40777/rwxrwxrwx   0       dir   2020-02-05 12:25:36 +0800  MyProjects\n100777/rwxrwxrwx  253952  fil   2020-04-20 14:43:14 +0800  fastcoll_v1.0.0.5.exe\n100666/rw-rw-rw-  1728    fil   2020-03-26 10:08:08 +0800  x32dbg.lnk\n100666/rw-rw-rw-  1       fil   2020-04-20 14:43:18 +0800  \u4e2d\u6587.txt\n"
            }
        }
    ]
}

```

