### PR TITLE
Fix for issue #13372, buffer register option in unicode encoders

### DIFF
--- a/modules/encoders/x86/unicode_mixed.rb
+++ b/modules/encoders/x86/unicode_mixed.rb
@@ -23,6 +23,11 @@ class MetasploitModule < Msf::Encoder::Alphanum
         {
           'BlockSize' => 1,
         })
+    register_options(
+      [
+        OptBase.new('BufferRegister',[true, "Register pointing to our shellcode", "ECX"])
+      ]
+    )
   end
 
   #

--- a/modules/encoders/x86/unicode_mixed.rb
+++ b/modules/encoders/x86/unicode_mixed.rb
@@ -12,7 +12,7 @@ class MetasploitModule < Msf::Encoder::Alphanum
     super(
       'Name'             => "Alpha2 Alphanumeric Unicode Mixedcase Encoder",
       'Description'      => %q{
-        Encodes payloads as unicode-safe mixedcase text.  This encoder uses
+        Encodes payload as unicode-safe mixedcase text.  This encoder uses
         SkyLined's Alpha2 encoding suite.
       },
       'Author'           => [ 'pusscat', 'skylined' ],
@@ -25,7 +25,7 @@ class MetasploitModule < Msf::Encoder::Alphanum
         })
     register_options(
       [
-        OptBase.new('BufferRegister',[true, "The register that points to the encoded payload", "ECX"])
+        OptString.new('BufferRegister',[true, "The register that points to the encoded payload", "ECX"])
       ]
     )
   end

--- a/modules/encoders/x86/unicode_mixed.rb
+++ b/modules/encoders/x86/unicode_mixed.rb
@@ -25,7 +25,7 @@ class MetasploitModule < Msf::Encoder::Alphanum
         })
     register_options(
       [
-        OptBase.new('BufferRegister',[true, "Register pointing to our shellcode", "ECX"])
+        OptBase.new('BufferRegister',[true, "The register that points to the encoded payload", "ECX"])
       ]
     )
   end

--- a/modules/encoders/x86/unicode_upper.rb
+++ b/modules/encoders/x86/unicode_upper.rb
@@ -12,7 +12,7 @@ class MetasploitModule < Msf::Encoder::Alphanum
     super(
       'Name'             => "Alpha2 Alphanumeric Unicode Uppercase Encoder",
       'Description'      => %q{
-        Encodes payload as unicode-safe uppercase text.  This encoder uses
+        Encodes payloads as unicode-safe uppercase text.  This encoder uses
         SkyLined's Alpha2 encoding suite.
       },
       'Author'           => [ 'pusscat', 'skylined' ],
@@ -23,6 +23,11 @@ class MetasploitModule < Msf::Encoder::Alphanum
         {
           'BlockSize' => 1,
         })
+    register_options(
+      [
+        OptBase.new('BufferRegister',[true, "Register pointing to our shellcode", "ECX"])
+      ]
+    )
   end
 
   #

--- a/modules/encoders/x86/unicode_upper.rb
+++ b/modules/encoders/x86/unicode_upper.rb
@@ -25,7 +25,7 @@ class MetasploitModule < Msf::Encoder::Alphanum
         })
     register_options(
       [
-        OptBase.new('BufferRegister',[true, "Register pointing to our shellcode", "ECX"])
+        OptBase.new('BufferRegister',[true, "The register that points to the encoded payload", "ECX"])
       ]
     )
   end

--- a/modules/encoders/x86/unicode_upper.rb
+++ b/modules/encoders/x86/unicode_upper.rb
@@ -12,7 +12,7 @@ class MetasploitModule < Msf::Encoder::Alphanum
     super(
       'Name'             => "Alpha2 Alphanumeric Unicode Uppercase Encoder",
       'Description'      => %q{
-        Encodes payloads as unicode-safe uppercase text.  This encoder uses
+        Encodes payload as unicode-safe uppercase text.  This encoder uses
         SkyLined's Alpha2 encoding suite.
       },
       'Author'           => [ 'pusscat', 'skylined' ],
@@ -25,7 +25,7 @@ class MetasploitModule < Msf::Encoder::Alphanum
         })
     register_options(
       [
-        OptBase.new('BufferRegister',[true, "The register that points to the encoded payload", "ECX"])
+        OptString.new('BufferRegister',[true, "The register that points to the encoded payload", "ECX"])
       ]
     )
   end


### PR DESCRIPTION
Fixes #13372 

- `encoder/x86/unicode_upper`
- `encoder/x86/unicode_mixed`

This should be enough to fix mentioned issue, unfortunately it doesn't seems to affect `msfvenom` usage

## Verification
- [x] Start `msfconsole`
- [x] `use encoder/x86/unicode_upper ` or  `use encoder/x86/unicode_mixed `
- [x] `show options`
- [x] **Verify** that the `BufferRegister` options is required and set to a default
- [x] **Verify** that ECX register can be used as default

```
msf5 > use encoder/x86/unicode_upper 
msf5 encoder(x86/unicode_upper) > show options

Module options (encoder/x86/unicode_upper):

   Name            Current Setting  Required  Description
   ----            ---------------  --------  -----------
   AllowWin32SEH   false            yes       Use SEH to determine the address of the stub (Windows only)
   BufferOffset    0                no        The offset to the buffer from the start of the register
   BufferRegister  ECX              yes       The register that points to the encoded payload
```

