### PR TITLE
add test for reverse_tcp_uuid stager with osx

### DIFF
--- a/spec/modules/payloads_spec.rb
+++ b/spec/modules/payloads_spec.rb
@@ -2173,6 +2173,17 @@ RSpec.describe 'modules/payloads', :content do
                           reference_name: 'osx/x64/meterpreter/reverse_tcp'
   end
 
+  context 'osx/x64/meterpreter/reverse_tcp_uuid' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                              'stagers/osx/x64/reverse_tcp_uuid',
+                              'stages/osx/x64/meterpreter'
+                          ],
+                          dynamic_size: false,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'osx/x64/meterpreter/reverse_tcp_uuid'
+  end
+
   context 'osx/x64/meterpreter_reverse_http' do
     it_should_behave_like 'payload cached size is consistent',
                           ancestor_reference_names: [


### PR DESCRIPTION
add test for reverse_tcp_uuid stager with osx

## Verification

List the steps needed to make sure this thing works

- [ ] **Verify** rake rspec pass and no longer reports missing payloads

