### PR TITLE
Fix typo and RuboCop errors in lib/msf/core/encoder/alphanum.rb

### DIFF
--- a/lib/msf/core/encoder/alphanum.rb
+++ b/lib/msf/core/encoder/alphanum.rb
@@ -13,12 +13,10 @@ module Msf
     def initialize(info)
       super(info)
 
-      off = 0
-
       register_options(
         [
           OptString.new('BufferRegister', [ false, 'The register that points to the encoded payload' ]),
-          OptInt.new('BufferOffset', [ false, 'The offset to the buffer from the start of the register', off ]),
+          OptInt.new('BufferOffset', [ false, 'The offset to the buffer from the start of the register', 0 ]),
           OptBool.new('AllowWin32SEH', [ true, 'Use SEH to determine the address of the stub (Windows only)', false ])
         ], Msf::Encoder::Alphanum
       )

--- a/lib/msf/core/encoder/alphanum.rb
+++ b/lib/msf/core/encoder/alphanum.rb
@@ -1,29 +1,28 @@
 # -*- coding: binary -*-
+
 require 'msf/core'
 
 module Msf
+  ###
+  #
+  # This class provides common options for certain alphanumeric encoders.
+  #
+  ###
+  class Encoder::Alphanum < Msf::Encoder
 
-###
-#
-# This class provides common options for certain alphanumeric encoders.
-#
-###
-class Encoder::Alphanum < Msf::Encoder
+    def initialize(info)
+      super(info)
 
-  def initialize(info)
-    super(info)
+      off = 0
 
-    off = 0
+      register_options(
+        [
+          OptString.new('BufferRegister', [ false, 'The register that points to the encoded payload' ]),
+          OptInt.new('BufferOffset', [ false, 'The offset to the buffer from the start of the register', off ]),
+          OptBool.new('AllowWin32SEH', [ true, 'Use SEH to determine the address of the stub (Windows only)', false ])
+        ], Msf::Encoder::Alphanum
+      )
+    end
 
-    register_options(
-      [
-        OptString.new('BufferRegister', [ false, 'The register that points to the encoded payload' ]),
-        OptInt.new('BufferOffset', [ false, 'The offset to the buffer from the start of the register', off ]),
-        OptBool.new('AllowWin32SEH', [ true, 'Use SEH to determine the address of the stub (Windows only)', false ])
-      ], Msf::Encoder::Alphanum)
   end
-
 end
-
-end
-

--- a/lib/msf/core/encoder/alphanum.rb
+++ b/lib/msf/core/encoder/alphanum.rb
@@ -17,9 +17,9 @@ class Encoder::Alphanum < Msf::Encoder
 
     register_options(
       [
-        OptString.new('BufferRegister', [ false, "The register that pointers to the encoded payload" ]),
-        OptInt.new('BufferOffset', [ false, "The offset to the buffer from the start of the register", off ]),
-        OptBool.new('AllowWin32SEH', [ true, "Use SEH to determine the address of the stub (Windows only)", false ])
+        OptString.new('BufferRegister', [ false, 'The register that points to the encoded payload' ]),
+        OptInt.new('BufferOffset', [ false, 'The offset to the buffer from the start of the register', off ]),
+        OptBool.new('AllowWin32SEH', [ true, 'Use SEH to determine the address of the stub (Windows only)', false ])
       ], Msf::Encoder::Alphanum)
   end
 

--- a/modules/encoders/x86/unicode_mixed.rb
+++ b/modules/encoders/x86/unicode_mixed.rb
@@ -10,18 +10,18 @@ class MetasploitModule < Msf::Encoder::Alphanum
 
   def initialize
     super(
-      'Name'             => "Alpha2 Alphanumeric Unicode Mixedcase Encoder",
-      'Description'      => %q{
+      'Name' => 'Alpha2 Alphanumeric Unicode Mixedcase Encoder',
+      'Description' => %q{
         Encodes payload as unicode-safe mixedcase text.  This encoder uses
         SkyLined's Alpha2 encoding suite.
       },
-      'Author'           => [ 'pusscat', 'skylined' ],
-      'Arch'             => ARCH_X86,
-      'License'          => BSD_LICENSE,
-      'EncoderType'      => Msf::Encoder::Type::AlphanumUnicodeMixed,
-      'Decoder'          =>
+      'Author' => [ 'pusscat', 'skylined' ],
+      'Arch' => ARCH_X86,
+      'License' => BSD_LICENSE,
+      'EncoderType' => Msf::Encoder::Type::AlphanumUnicodeMixed,
+      'Decoder' =>
         {
-          'BlockSize' => 1,
+          'BlockSize' => 1
         })
     register_options(
       [
@@ -34,13 +34,14 @@ class MetasploitModule < Msf::Encoder::Alphanum
   # Returns the decoder stub that is adjusted for the size of the buffer
   # being encoded.
   #
-  def decoder_stub(state)
-    reg    = datastore['BufferRegister']
+  def decoder_stub(_state)
+    reg = datastore['BufferRegister']
     offset = datastore['BufferOffset'].to_i || 0
-    if (not reg)
-      raise EncodingError, "Need BufferRegister"
+    if !reg
+      raise EncodingError, 'Need BufferRegister'
     end
-    Rex::Encoder::Alpha2::UnicodeMixed::gen_decoder(reg, offset)
+
+    Rex::Encoder::Alpha2::UnicodeMixed.gen_decoder(reg, offset)
   end
 
   #
@@ -48,14 +49,14 @@ class MetasploitModule < Msf::Encoder::Alphanum
   # payload.
   #
   def encode_block(state, block)
-    Rex::Encoder::Alpha2::UnicodeMixed::encode_byte(block.unpack('C')[0], state.badchars)
+    Rex::Encoder::Alpha2::UnicodeMixed.encode_byte(block.unpack1('C'), state.badchars)
   end
 
   #
   # Tack on our terminator
   #
   def encode_end(state)
-    state.encoded += Rex::Encoder::Alpha2::UnicodeMixed::add_terminator()
+    state.encoded += Rex::Encoder::Alpha2::UnicodeMixed.add_terminator
   end
 
   #

--- a/modules/encoders/x86/unicode_mixed.rb
+++ b/modules/encoders/x86/unicode_mixed.rb
@@ -25,7 +25,7 @@ class MetasploitModule < Msf::Encoder::Alphanum
         })
     register_options(
       [
-        OptString.new('BufferRegister',[true, "The register that points to the encoded payload", "ECX"])
+        OptString.new('BufferRegister', [true, 'The register that points to the encoded payload', 'ECX'])
       ]
     )
   end

--- a/modules/encoders/x86/unicode_upper.rb
+++ b/modules/encoders/x86/unicode_upper.rb
@@ -10,18 +10,18 @@ class MetasploitModule < Msf::Encoder::Alphanum
 
   def initialize
     super(
-      'Name'             => "Alpha2 Alphanumeric Unicode Uppercase Encoder",
-      'Description'      => %q{
+      'Name' => 'Alpha2 Alphanumeric Unicode Uppercase Encoder',
+      'Description' => %q{
         Encodes payload as unicode-safe uppercase text.  This encoder uses
         SkyLined's Alpha2 encoding suite.
       },
-      'Author'           => [ 'pusscat', 'skylined' ],
-      'Arch'             => ARCH_X86,
-      'License'          => BSD_LICENSE,
-      'EncoderType'      => Msf::Encoder::Type::AlphanumUnicodeUpper,
-      'Decoder'          =>
+      'Author' => [ 'pusscat', 'skylined' ],
+      'Arch' => ARCH_X86,
+      'License' => BSD_LICENSE,
+      'EncoderType' => Msf::Encoder::Type::AlphanumUnicodeUpper,
+      'Decoder' =>
         {
-          'BlockSize' => 1,
+          'BlockSize' => 1
         })
     register_options(
       [
@@ -34,13 +34,14 @@ class MetasploitModule < Msf::Encoder::Alphanum
   # Returns the decoder stub that is adjusted for the size of the buffer
   # being encoded.
   #
-  def decoder_stub(state)
-    reg    = datastore['BufferRegister']
+  def decoder_stub(_state)
+    reg = datastore['BufferRegister']
     offset = datastore['BufferOffset'].to_i || 0
-    if (not reg)
-      raise EncodingError, "Need BufferRegister"
+    if !reg
+      raise EncodingError, 'Need BufferRegister'
     end
-    Rex::Encoder::Alpha2::UnicodeUpper::gen_decoder(reg, offset)
+
+    Rex::Encoder::Alpha2::UnicodeUpper.gen_decoder(reg, offset)
   end
 
   #
@@ -48,14 +49,14 @@ class MetasploitModule < Msf::Encoder::Alphanum
   # payload.
   #
   def encode_block(state, block)
-    Rex::Encoder::Alpha2::UnicodeUpper::encode_byte(block.unpack('C')[0], state.badchars)
+    Rex::Encoder::Alpha2::UnicodeUpper.encode_byte(block.unpack1('C'), state.badchars)
   end
 
   #
   # Tack on our terminator
   #
   def encode_end(state)
-    state.encoded += Rex::Encoder::Alpha2::UnicodeUpper::add_terminator()
+    state.encoded += Rex::Encoder::Alpha2::UnicodeUpper.add_terminator
   end
 
   #

--- a/modules/encoders/x86/unicode_upper.rb
+++ b/modules/encoders/x86/unicode_upper.rb
@@ -25,7 +25,7 @@ class MetasploitModule < Msf::Encoder::Alphanum
         })
     register_options(
       [
-        OptString.new('BufferRegister',[true, "The register that points to the encoded payload", "ECX"])
+        OptString.new('BufferRegister', [true, 'The register that points to the encoded payload', 'ECX'])
       ]
     )
   end


### PR DESCRIPTION
This PR will fix the issues mentioned by @wvu-r7 at https://github.com/rapid7/metasploit-framework/pull/13375#discussion_r419027365, namely a typo in one of the lines of `lib/msf/core/encoder/alphanum.rb`, to ensure it outputs the same line for the `BufferRegister` option as other modules are currently doing, and also changes a number of literal strings from double quotes to single quotes to meet style changes that we enforce with RuboCop.

This PR also fixes `modules/encoders/x86/unicode_mixed.rb` and `modules/encoders/x86/unicode_upper.rb` to meet our RuboCop standards on double vs single quotes.