### PR TITLE
fix #10181, add error when an android stageless payload is used with -x

### DIFF
--- a/lib/msf/core/payload_generator.rb
+++ b/lib/msf/core/payload_generator.rb
@@ -384,6 +384,9 @@ module Msf
         encoded_payload = raw_payload
         gen_payload = raw_payload
       elsif payload.start_with? "android/" and not template.blank?
+        if payload.start_with? "android/meterpreter_"
+          raise PayloadGeneratorError, "Stageless Android payloads (e.g #{payload}) are not compatible with injection (-x)"
+        end
         cli_print "Using APK template: #{template}"
         apk_backdoor = ::Msf::Payload::Apk.new
         raw_payload = apk_backdoor.backdoor_apk(template, generate_raw_payload)


### PR DESCRIPTION
fix #10181 by showing a warning when an incompatible Android payload is used with msfvenom -x

## Verification

- [ ] `wget https://github.com/heavysixer/phonegap-camera-sample/blob/master/bin/CameraSample.apk?raw=true -O input.apk`
- [ ] `./msfvenom -x input.apk -p android/meterpreter_reverse_tcp LHOST=192.168.0.1 LPORT=4444 -o out.apk`
- [ ] **Verify** an error is shown
