### PR TITLE
Shortened URL linking to the msfdb help page

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -2051,7 +2051,7 @@ class Db
     unless framework.db.active
       err_msg = 'No local database connected, meaning some Metasploit features will not be available. A full list of '\
       'the affected features & database setup instructions can be found here: '\
-      'https://github.com/rapid7/metasploit-framework/wiki/msfdb:-Database-Features-&-How-to-Set-up-a-Database-for-Metasploit'
+      'https://r-7.co/msfdb-features-and-setup'
 
       print_error(err_msg)
       return


### PR DESCRIPTION
Shortens URL link to [msfdb Features and setup guide](https://github.com/rapid7/metasploit-framework/wiki/msfdb:-Database-Features-&-How-to-Set-up-a-Database-for-Metasploit) to make it more copy & paste friendly. 

Link is displayed in an Error message generated when users cannot connect to a database correctly. This error message is usually shown at startup but can also be displayed when running `db_connect`. 

