### PR TITLE
Fix ruby 2.7 rex http client warnings

### DIFF
--- a/lib/rex/proto/http/client.rb
+++ b/lib/rex/proto/http/client.rb
@@ -93,7 +93,7 @@ class Client
       # config.
 
       if(typ == 'bool')
-        val = (val =~ /^(t|y|1)/i ? true : false || val === true)
+        val = (val == true || val.to_s =~ /^(t|y|1)/i)
       end
 
       if(typ == 'integer')


### PR DESCRIPTION
Fixes ruby 2.7 warnings spotted in https://github.com/rapid7/metasploit-framework/issues/13391 :

> /Users/user/Documents/code/metasploit-framework/lib/rex/proto/http/client.rb:95: warning: deprecated Object#=~ is called on FalseClass; it always returns nil

Note - current master doesn't print these errors, as the errors are disabled with `Warning[:deprecated] = false`.

## Verification

List the steps needed to make sure this thing works

- [ ] Start with Ruby 2.7
- [ ] Open msfconsole
- [ ] `irb`
- [ ] `Warning[:deprecated] = true` - Enable deprecated warnings again
- [ ] `exit` - close irb
- [ ] `use auxiliary/scanner/http/wordpress_scanner`
- [ ]  `set RHOSTS 127.0.0.1`
- [ ] `run`
- [ ] **Verify** no warnings or errors occur
- [ ] **Verify** Ruby 2.6 works as before
