### PR TITLE
silence warnings for all users

### DIFF
--- a/msfconsole
+++ b/msfconsole
@@ -8,7 +8,8 @@
 require 'pathname'
 
 begin
-  # TODO: Temporary until warnings can be turned on only for developers to prevent confusion for end users
+
+  # Silences warnings as they only serve to confuse end users
   if defined?(Warning) && Warning.respond_to?(:[]=)
     Warning[:deprecated] = false
   end

--- a/msfvenom
+++ b/msfvenom
@@ -8,6 +8,11 @@ class UsageError < MsfVenomError; end
 require 'optparse'
 require 'timeout'
 
+# Silences warnings as they only serve to confuse end users
+if defined?(Warning) && Warning.respond_to?(:[]=)
+  Warning[:deprecated] = false
+end
+
 msfbase = __FILE__
 while File.symlink?(msfbase)
   msfbase = File.expand_path(File.readlink(msfbase), File.dirname(msfbase))


### PR DESCRIPTION
Turns off warnings for all users, this is a temporary measure to limit the confusion we're seeing with end users on ruby 2.7.0 that now produces several warnings.
There will be another PR up soon to enable warnings only when msf is being used in a development environment

- [ ] Switch to ruby 2.7.0
- [ ] Start up msfconsole/msfvenom
- [ ] Observe the warnings
- [ ] Checkout this branch
- [ ] Start up msfconsole/msfvenom
- [ ] Warnings should be gone
- [ ] Check this doesn't break with < ruby 2.7.0 
