### PR TITLE
Fix fail with call in vmware fusion lpe

### DIFF
--- a/modules/exploits/osx/local/vmware_fusion_lpe.rb
+++ b/modules/exploits/osx/local/vmware_fusion_lpe.rb
@@ -219,7 +219,7 @@ class MetasploitModule < Msf::Exploit::Local
     # Make sure we can write our payload to the remote system
     rm_rf content_dir # live dangerously.
     if directory? content_dir
-      fail_with Filure::BadConfig, "#{content_dir} exists. Unable to delete automatically.  Please delete or exploit will fail."
+      fail_with Failure::BadConfig, "#{content_dir} exists. Unable to delete automatically.  Please delete or exploit will fail."
     end
     cmd_exec "mkdir -p #{base_dir}"
     register_dirs_for_cleanup content_dir


### PR DESCRIPTION
Msf tidy was unhappy with this module:

> modules/exploits/osx/local/vmware_fusion_lpe.rb:222 - [ERROR] fail_with requires a valid Failure:: reason as first parameter: fail_with(Filure::BadConfig, "#{content_dir} exists. Unable to delete automatically. Please delete or exploit will fail.")