### PR TITLE
Add Post::Windows::Services.service_exists? method

### DIFF
--- a/lib/msf/core/post/windows/services.rb
+++ b/lib/msf/core/post/windows/services.rb
@@ -250,6 +250,29 @@ module Services
   end
 
   #
+  # Check if the specified Windows service exists.
+  #
+  # @param name [String] The target service's name (not to be confused
+  #   with Display Name). Case sensitive.
+  #
+  # @return [Boolean]
+  #
+  def service_exists?(service)
+    srv_info = service_info(service)
+
+    if srv_info.nil?
+      vprint_error('Unable to enumerate Windows services')
+      return false
+    end
+
+    if srv_info && srv_info[:display].empty?
+      return false
+    end
+
+    true
+  end
+
+  #
   # Changes a given service startup mode, name must be provided and the mode.
   #
   # Mode is a string with either auto, manual or disable for the

--- a/modules/exploits/windows/local/ikeext_service.rb
+++ b/modules/exploits/windows/local/ikeext_service.rb
@@ -59,24 +59,8 @@ class MetasploitModule < Msf::Exploit::Local
     @non_existant_dirs = []
   end
 
-  def check_service_exists?(service)
-    srv_info = service_info(service)
-
-    if srv_info.nil?
-      vprint_warning("Unable to enumerate services.")
-      return false
-    end
-
-    if srv_info && srv_info[:display].empty?
-      vprint_warning("Service #{service} does not exist.")
-      return false
-    else
-      return true
-    end
-  end
-
   def check
-    if !check_service_exists?(@service_name)
+    if !service_exists?(@service_name)
       return Exploit::CheckCode::Safe
     end
 
@@ -204,7 +188,7 @@ class MetasploitModule < Msf::Exploit::Local
     end
 
     print_status("Checking service exists...")
-    if !check_service_exists?(@service_name)
+    if !service_exists?(@service_name)
       fail_with(Failure::NoTarget, "The service doesn't exist.")
     end
 

--- a/modules/exploits/windows/local/plantronics_hub_spokesupdateservice_privesc.rb
+++ b/modules/exploits/windows/local/plantronics_hub_spokesupdateservice_privesc.rb
@@ -59,21 +59,6 @@ class MetasploitModule < Msf::Exploit::Local
     datastore['WritableDir'].blank? ? session.sys.config.getenv('TEMP') : datastore['WritableDir'].to_s
   end
 
-  def service_exists?(service)
-    srv_info = service_info(service)
-
-    if srv_info.nil?
-      vprint_warning 'Unable to enumerate Windows services'
-      return false
-    end
-
-    if srv_info && srv_info[:display].empty?
-      return false
-    end
-
-    true
-  end
-
   def check
     service = 'PlantronicsUpdateService'
 

--- a/modules/exploits/windows/local/webexec.rb
+++ b/modules/exploits/windows/local/webexec.rb
@@ -69,24 +69,8 @@ class MetasploitModule < Msf::Exploit::Local
     end
   end
 
-  def check_service_exists?(service)
-    srv_info = service_info(service)
-
-    if srv_info.nil?
-      vprint_warning("Unable to enumerate services.")
-      return false
-    end
-
-    if srv_info && srv_info[:display].empty?
-      vprint_warning("Service #{service} does not exist.")
-      return false
-    else
-      return true
-    end
-  end
-
   def check
-    unless check_service_exists?(@service_name)
+    unless service_exists?(@service_name)
       return Exploit::CheckCode::Safe
     end
 
@@ -141,7 +125,7 @@ class MetasploitModule < Msf::Exploit::Local
     end
 
     print_status("Checking service exists...")
-    if !check_service_exists?(@service_name)
+    if !service_exists?(@service_name)
       fail_with(Failure::NoTarget, "The service doesn't exist.")
     end
 

--- a/modules/exploits/windows/local/windscribe_windscribeservice_priv_esc.rb
+++ b/modules/exploits/windows/local/windscribe_windscribeservice_priv_esc.rb
@@ -62,21 +62,6 @@ class MetasploitModule < Msf::Exploit::Local
     datastore['WritableDir'].blank? ? session.sys.config.getenv('TEMP') : datastore['WritableDir'].to_s
   end
 
-  def service_exists?(service)
-    srv_info = service_info(service)
-
-    if srv_info.nil?
-      vprint_warning 'Unable to enumerate Windows services'
-      return false
-    end
-
-    if srv_info && srv_info[:display].empty?
-      return false
-    end
-
-    true
-  end
-
   def write_named_pipe(pipe, command)
     kt = "\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
     kt << "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"


### PR DESCRIPTION
Add `Post::Windows::Services.service_exists?` method.

This code pattern exists in a few modules and a couple of open module PRs. May as well standardise it.

```
$  grep -rn "if srv_info && srv_info" modules/
modules/exploits/windows/local/plantronics_hub_spokesupdateservice_privesc.rb:70:    if srv_info && srv_info[:display].empty?
modules/exploits/windows/local/webexec.rb:80:    if srv_info && srv_info[:display].empty?
modules/exploits/windows/local/ikeext_service.rb:70:    if srv_info && srv_info[:display].empty?
modules/exploits/windows/local/windscribe_windscribeservice_priv_esc.rb:73:    if srv_info && srv_info[:display].empty?
```

```
$ grep -rn "check_service_exists?" modules/
modules/exploits/windows/local/webexec.rb:72:  def check_service_exists?(service)
modules/exploits/windows/local/webexec.rb:89:    unless check_service_exists?(@service_name)
modules/exploits/windows/local/webexec.rb:144:    if !check_service_exists?(@service_name)
modules/exploits/windows/local/ikeext_service.rb:62:  def check_service_exists?(service)
modules/exploits/windows/local/ikeext_service.rb:79:    if !check_service_exists?(@service_name)
modules/exploits/windows/local/ikeext_service.rb:207:    if !check_service_exists?(@service_name)
```