### PR TITLE
fakedns: specificy in help the wildcard character

### DIFF
--- a/modules/auxiliary/server/fakedns.rb
+++ b/modules/auxiliary/server/fakedns.rb
@@ -34,7 +34,7 @@ class MetasploitModule < Msf::Auxiliary
         OptAddress.new('SRVHOST',   [ true, "The local host to listen on.", '0.0.0.0' ]),
         OptPort.new('SRVPORT',      [ true, "The local port to listen on.", 53 ]),
         OptAddress.new('TARGETHOST', [ false, "The address that all names should resolve to", nil ]),
-        OptString.new('TARGETDOMAIN', [ true, "The list of target domain names we want to fully resolve (BYPASS) or fake resolve (FAKE)", 'www.google.com']),
+        OptString.new('TARGETDOMAIN', [ true, "The list of target domain names we want to fully resolve (BYPASS) or fake resolve (FAKE). Use '*' for wildcard.", 'www.google.com']),
         OptEnum.new('TARGETACTION', [ true, "Action for TARGETDOMAIN", "BYPASS", %w{FAKE BYPASS}]),
       ])
 


### PR DESCRIPTION
I think many people use "fakedns" to target any domain, so specifying explicitly which is the the wildcard character (is it "" or "*" or ".*" ?) is a nice hint to have.
Proof that '*' is the intended wildcard:
https://github.com/rapid7/metasploit-framework/blob/4a853beb8d8be4369cdef67d3d655385d1edfa00/modules/auxiliary/server/fakedns.rb#L119-L120