### PR TITLE
Fix multiple DNS enumeration related bugs

### DIFF
--- a/lib/net/dns/packet.rb
+++ b/lib/net/dns/packet.rb
@@ -520,9 +520,16 @@ module Net # :nodoc:
         
         @answer = []
         @header.anCount.times do
-          rrobj,offset = Net::DNS::RR.parse_packet(data,offset)
-          @answer << rrobj
-          @logger.debug rrobj.inspect
+          if (rrobj, new_offset = Net::DNS::RR.parse_packet(data, offset))
+            @answer << rrobj
+            @logger.debug rrobj.inspect
+            offset = new_offset
+          else
+            @logger.warn "Failed to parse RR packet from offset: #{offset}"
+            _, offset = dn_expand(data, offset)
+            _, _, _, rdlength = data.unpack("@#{offset} n2 N n")
+            offset += RRFIXEDSZ + rdlength
+          end
         end
 
         #------------------------------------------------------------

--- a/lib/rex/proto/dns/resolver.rb
+++ b/lib/rex/proto/dns/resolver.rb
@@ -132,8 +132,8 @@ module DNS
       end
 
       # Store packet_data for performance improvements,
-      # so methods don't keep on calling Packet#encode
-      packet_data = packet.encode
+      # so methods don't keep on calling Packet#data
+      packet_data = packet.data
       packet_size = packet_data.size
 
       # Choose whether use TCP, UDP
@@ -155,7 +155,7 @@ module DNS
         method = :send_tcp
       end
 
-      ans = self.__send__(method,packet_data)
+      ans = self.__send__(method,packet,packet_data)
 
       unless (ans and ans[0].length > 0)
         @logger.fatal "No response from nameservers list: aborting"
@@ -183,11 +183,12 @@ module DNS
     #
     # Send request over TCP
     #
+    # @param packet [Net::DNS::Packet] Packet associated with packet_data
     # @param packet_data [String] Data segment of DNS request packet
     # @param prox [String] Proxy configuration for TCP socket
     #
     # @return ans [String] Raw DNS reply
-    def send_tcp(packet_data,prox = @config[:proxies])
+    def send_tcp(packet,packet_data,prox = @config[:proxies])
       ans = nil
       length = [packet_data.size].pack("n")
       @config[:nameservers].each do |ns|
@@ -270,10 +271,11 @@ module DNS
     #
     # Send request over UDP
     #
+    # @param packet [Net::DNS::Packet] Packet associated with packet_data
     # @param packet_data [String] Data segment of DNS request packet
     #
     # @return ans [String] Raw DNS reply
-    def send_udp(packet_data)
+    def send_udp(packet,packet_data)
       ans = nil
       response = ""
       @config[:nameservers].each do |ns|

--- a/modules/auxiliary/gather/enum_dns.rb
+++ b/modules/auxiliary/gather/enum_dns.rb
@@ -417,7 +417,6 @@ class MetasploitModule < Msf::Auxiliary
       print_good("#{domain} Zone Transfer: #{zone}")
     end
     return if records.blank?
-    save_note(domain, 'DNS AXFR recods', records)
     records
   end
 


### PR DESCRIPTION
This fixes the following issues related to DNS enumeration:

1. The `Rex::Proto::DNS::Resolver` class should utilize `packet.data` instead of `packet.encode` to translate the packet into binary data for transmitting over the socket. This correct behavior can be seen [used](https://github.com/rapid7/metasploit-framework/blob/ffa01f56fcf72c7aba069b2d60d1cc1d219d500a/lib/net/dns/resolver.rb#L943) in the [parent class](https://github.com/rapid7/metasploit-framework/blob/ffa01f56fcf72c7aba069b2d60d1cc1d219d500a/lib/rex/proto/dns/resolver.rb#L13).
1. The signatures for the `Rex::Proto::DNS::Resolver`'s `send_udp` and `send_tcp` methods are updated to be consistent with the [`Net::DNS::Resolver`](https://github.com/rapid7/metasploit-framework/blob/ffa01f56fcf72c7aba069b2d60d1cc1d219d500a/lib/net/dns/resolver.rb#L1236) parent class. This allows methods inherited from the parent class (such as `#axfr`) to function correctly.
1. This removes adding notes to the database for zone transfers in `auxiliary/gather/enum_dns` because they are throwing an exception<sup>1</sup> due to the zone data.
1. Updates `Net::DNS::Packet#new_from_data` to ignore unknown RRs and move on. Without this, the zone transfer fails to process *any* data when the presence of a single RR is not understood causing a `NoResponseError`<sup>2</sup> to be raised from `#axfr`. For example, this would break on the "AFSDB" RR from the public zonetransfer.me example, causing no data to be returned.

But why? #12234 needs DNS enumeration capabilities which were migrated from `auxiliary/gather/enum_dns` to a mixin. To avoid adding yet another one, it makes sense to utilize the existing Rex-based `Msf::Remote::Exploit::DNS::Client` one as opposed to implementing a new `Net::DNS` based one.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
* Run a test using the `Net::DNS::Resolver`
- [ ] `use auxilary/gather/enum_dns`
- [ ] Set the domain with `set DOMAIN zonetransfer.me` and run the module
    - [ ] See correct output, **specifically including the zone transfer data**
* Run a manual test using the `Rex::Proto::DNS::Resolver` class
- [ ] Start irb using `irb`
- [ ] Run a zone transfer using the following snippet

```
dns = Rex::Proto::DNS::Resolver.new
dns.nameservers = [
  ::Rex::Socket.resolv_to_dotted('nsztm1.digi.ninja.'),
  ::Rex::Socket.resolv_to_dotted('nsztm2.digi.ninja.')
]
dns.axfr('zonetransfer.me')
```
- [ ] See a proper zone transfer after a few seconds

## Appendix
The following are stack traces of referenced issues.
<details>
<summary>1. <code>save_note</code> exception in <code>auxiliary/gather/enum_dns</code> stack trace for reference</summary>

```
[-] Auxiliary failed: TypeError can't dump IO
[-] Call stack:
[-]   /home/smcintyre/.rvm/gems/ruby-2.6.6@metasploit-framework/gems/metasploit_data_models-3.0.10/lib/metasploit_data_models/base64_serializer.rb:57:in `dump'
[-]   /home/smcintyre/.rvm/gems/ruby-2.6.6@metasploit-framework/gems/metasploit_data_models-3.0.10/lib/metasploit_data_models/base64_serializer.rb:57:in `dump'
[-]   /home/smcintyre/.rvm/gems/ruby-2.6.6@metasploit-framework/gems/activerecord-4.2.11.1/lib/active_record/type/serialized.rb:26:in `type_cast_for_database'
[-]   /home/smcintyre/.rvm/gems/ruby-2.6.6@metasploit-framework/gems/activerecord-4.2.11.1/lib/active_record/type/mutable.rb:5:in `type_cast_from_user'
[-]   /home/smcintyre/.rvm/gems/ruby-2.6.6@metasploit-framework/gems/activerecord-4.2.11.1/lib/active_record/attribute.rb:110:in `type_cast'
[-]   /home/smcintyre/.rvm/gems/ruby-2.6.6@metasploit-framework/gems/activerecord-4.2.11.1/lib/active_record/attribute.rb:42:in `original_value'
[-]   /home/smcintyre/.rvm/gems/ruby-2.6.6@metasploit-framework/gems/activerecord-4.2.11.1/lib/active_record/attribute.rb:37:in `value'
[-]   /home/smcintyre/.rvm/gems/ruby-2.6.6@metasploit-framework/gems/activerecord-4.2.11.1/lib/active_record/attribute.rb:50:in `changed_from?'
[-]   /home/smcintyre/.rvm/gems/ruby-2.6.6@metasploit-framework/gems/activerecord-4.2.11.1/lib/active_record/attribute_methods/dirty.rb:143:in `_field_changed?'
[-]   /home/smcintyre/.rvm/gems/ruby-2.6.6@metasploit-framework/gems/activerecord-4.2.11.1/lib/active_record/attribute_methods/dirty.rb:116:in `save_changed_attribute'
[-]   /home/smcintyre/.rvm/gems/ruby-2.6.6@metasploit-framework/gems/activerecord-4.2.11.1/lib/active_record/attribute_methods/dirty.rb:99:in `write_attribute'
[-]   /home/smcintyre/.rvm/gems/ruby-2.6.6@metasploit-framework/gems/activerecord-4.2.11.1/lib/active_record/attribute_methods.rb:50:in `__temp__46164716'
[-]   /home/smcintyre/.rvm/gems/ruby-2.6.6@metasploit-framework/gems/activerecord-4.2.11.1/lib/active_record/attribute_assignment.rb:54:in `public_send'
[-]   /home/smcintyre/.rvm/gems/ruby-2.6.6@metasploit-framework/gems/activerecord-4.2.11.1/lib/active_record/attribute_assignment.rb:54:in `_assign_attribute'
[-]   /home/smcintyre/.rvm/gems/ruby-2.6.6@metasploit-framework/gems/activerecord-4.2.11.1/lib/active_record/attribute_assignment.rb:65:in `block in assign_nested_parameter_attributes'
[-]   /home/smcintyre/.rvm/gems/ruby-2.6.6@metasploit-framework/gems/activerecord-4.2.11.1/lib/active_record/attribute_assignment.rb:65:in `each'
[-]   /home/smcintyre/.rvm/gems/ruby-2.6.6@metasploit-framework/gems/activerecord-4.2.11.1/lib/active_record/attribute_assignment.rb:65:in `assign_nested_parameter_attributes'
[-]   /home/smcintyre/.rvm/gems/ruby-2.6.6@metasploit-framework/gems/activerecord-4.2.11.1/lib/active_record/attribute_assignment.rb:45:in `assign_attributes'
[-]   /home/smcintyre/.rvm/gems/ruby-2.6.6@metasploit-framework/gems/activerecord-4.2.11.1/lib/active_record/core.rb:566:in `init_attributes'
[-]   /home/smcintyre/.rvm/gems/ruby-2.6.6@metasploit-framework/gems/activerecord-4.2.11.1/lib/active_record/core.rb:281:in `initialize'
[-]   /home/smcintyre/.rvm/gems/ruby-2.6.6@metasploit-framework/gems/activerecord-4.2.11.1/lib/active_record/inheritance.rb:61:in `new'
[-]   /home/smcintyre/.rvm/gems/ruby-2.6.6@metasploit-framework/gems/activerecord-4.2.11.1/lib/active_record/inheritance.rb:61:in `new'
[-]   /home/smcintyre/.rvm/gems/ruby-2.6.6@metasploit-framework/gems/activerecord-4.2.11.1/lib/active_record/reflection.rb:141:in `build_association'
[-]   /home/smcintyre/.rvm/gems/ruby-2.6.6@metasploit-framework/gems/activerecord-4.2.11.1/lib/active_record/associations/association.rb:250:in `build_record'
[-]   /home/smcintyre/.rvm/gems/ruby-2.6.6@metasploit-framework/gems/activerecord-4.2.11.1/lib/active_record/associations/collection_association.rb:157:in `build'
[-]   /home/smcintyre/.rvm/gems/ruby-2.6.6@metasploit-framework/gems/activerecord-4.2.11.1/lib/active_record/associations/collection_proxy.rb:259:in `build'
[-]   /home/smcintyre/Repositories/metasploit-framework/lib/msf/core/db_manager/note.rb:171:in `block in report_note'
[-]   /home/smcintyre/.rvm/gems/ruby-2.6.6@metasploit-framework/gems/activerecord-4.2.11.1/lib/active_record/connection_adapters/abstract/connection_pool.rb:292:in `with_connection'
[-]   /home/smcintyre/Repositories/metasploit-framework/lib/msf/core/db_manager/note.rb:81:in `report_note'
[-]   /home/smcintyre/Repositories/metasploit-framework/lib/metasploit/framework/data_service/proxy/note_data_proxy.rb:40:in `block in report_note'
[-]   /home/smcintyre/Repositories/metasploit-framework/lib/metasploit/framework/data_service/proxy/core.rb:166:in `data_service_operation'
[-]   /home/smcintyre/Repositories/metasploit-framework/lib/metasploit/framework/data_service/proxy/note_data_proxy.rb:38:in `report_note'
[-]   /home/smcintyre/Repositories/metasploit-framework/lib/msf/core/auxiliary/report.rb:177:in `report_note'
[-]   /home/smcintyre/Repositories/metasploit-framework/modules/auxiliary/gather/enum_dns.rb:426:in `save_note'
[-]   /home/smcintyre/Repositories/metasploit-framework/modules/auxiliary/gather/enum_dns.rb:421:in `axfr'
[-]   /home/smcintyre/Repositories/metasploit-framework/modules/auxiliary/gather/enum_dns.rb:63:in `run'
[*] Auxiliary module execution completed
```

</details>

<details>
<summary>2. The `NoResponseError` due to the failure to process a response including an unknown RR</summary>

```
>> dns = Rex::Proto::DNS::Resolver.new
=> ;; RESOLVER state:
;; config_file: /dev/null 	log_file: /dev/null 	
;; port: 53 	searchlist: [] 	
;; nameservers: ["127.0.0.1"] 	domain: "" 	
;; source_port: 0 	source_address: 0.0.0.0 	
;; retry_interval: 5 	retry_number: 4 	
;; recursive: true 	defname: true 	
;; dns_search: true 	use_tcp: false 	
;; ignore_truncated: false 	packet_size: 512 	
;; tcp_timeout: 30 	udp_timeout: 30 	
;; context:  	comm:  	
;; 
>> dns.nameservers = [
?>   ::Rex::Socket.resolv_to_dotted('nsztm1.digi.ninja.'),
?>   ::Rex::Socket.resolv_to_dotted('nsztm2.digi.ninja.')
>> ]
=> ["81.4.108.41", "34.225.33.2"]
>> dns.axfr('zonetransfer.me')
Traceback (most recent call last):
       14: from ./msfconsole:49:in `<main>'
       13: from /home/smcintyre/Repositories/metasploit-framework.pr/lib/metasploit/framework/command/base.rb:82:in `start'
       12: from /home/smcintyre/Repositories/metasploit-framework.pr/lib/metasploit/framework/command/console.rb:48:in `start'
       11: from /home/smcintyre/Repositories/metasploit-framework.pr/lib/rex/ui/text/shell.rb:151:in `run'
       10: from /home/smcintyre/Repositories/metasploit-framework.pr/lib/rex/ui/text/dispatcher_shell.rb:468:in `run_single'
        9: from /home/smcintyre/Repositories/metasploit-framework.pr/lib/rex/ui/text/dispatcher_shell.rb:468:in `each'
        8: from /home/smcintyre/Repositories/metasploit-framework.pr/lib/rex/ui/text/dispatcher_shell.rb:474:in `block in run_single'
        7: from /home/smcintyre/Repositories/metasploit-framework.pr/lib/rex/ui/text/dispatcher_shell.rb:523:in `run_command'
        6: from /home/smcintyre/Repositories/metasploit-framework.pr/lib/msf/ui/console/command_dispatcher/developer.rb:114:in `cmd_irb'
        5: from /home/smcintyre/Repositories/metasploit-framework.pr/lib/rex/ui/text/irb_shell.rb:52:in `run'
        4: from /home/smcintyre/Repositories/metasploit-framework.pr/lib/rex/ui/text/irb_shell.rb:52:in `catch'
        3: from /home/smcintyre/Repositories/metasploit-framework.pr/lib/rex/ui/text/irb_shell.rb:53:in `block in run'
        2: from (irb):6
        1: from /home/smcintyre/Repositories/metasploit-framework.pr/lib/net/dns/resolver.rb:1049:in `axfr'
NoResponseError (NoResponseError)
```
</details>