### PR TITLE
Set default action in auxiliary/admin/http/ibm_drm_download

### DIFF
--- a/modules/auxiliary/admin/http/ibm_drm_download.rb
+++ b/modules/auxiliary/admin/http/ibm_drm_download.rb
@@ -40,7 +40,11 @@ class MetasploitModule < Msf::Auxiliary
             [ 'URL', 'https://github.com/pedrib/PoC/blob/master/advisories/IBM/ibm_drm/ibm_drm_rce.md' ],
             [ 'URL', 'https://seclists.org/fulldisclosure/2020/Apr/33' ]
           ],
-        'DisclosureDate' => '2020-04-21'
+        'DisclosureDate' => '2020-04-21',
+        'Actions' => [
+          ['Download', 'Description' => 'Download arbitrary file']
+        ],
+        'DefaultAction' => 'Download'
       )
     )
 


### PR DESCRIPTION
I forgot to commit this, apparently. See https://github.com/rapid7/metasploit-framework/pull/13301/files#r421485826 and #13403.

```
msf5 auxiliary(admin/http/ibm_drm_download) > show actions

Auxiliary actions:

   Name      Description
   ----      -----------
   Download  Download arbitrary file


msf5 auxiliary(admin/http/ibm_drm_download) > options

Module options (auxiliary/admin/http/ibm_drm_download):

   Name       Current Setting                                                               Required  Description
   ----       ---------------                                                               --------  -----------
   FILEPATH   /home/a3user/Tomcat/webapps/albatross/WEB-INF/classes/application.properties  no        Path of the file to download
   Proxies                                                                                  no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS                                                                                   yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
   RPORT      8443                                                                          yes       The target port (TCP)
   SSL        true                                                                          no        Negotiate SSL/TLS for outgoing connections
   TARGETURI  /                                                                             yes       Default server path
   VHOST                                                                                    no        HTTP server virtual host


Auxiliary action:

   Name      Description
   ----      -----------
   Download  Download arbitrary file


msf5 auxiliary(admin/http/ibm_drm_download) >
```

cc @pedrib, @cnotin

Fixes #13301.