### PR TITLE
Avoid auto-encoding payloads free of badchars

### DIFF
--- a/lib/msf/core/encoded_payload.rb
+++ b/lib/msf/core/encoded_payload.rb
@@ -127,7 +127,7 @@ class EncodedPayload
   def encode
     # If the exploit has bad characters, we need to run the list of encoders
     # in ranked precedence and try to encode without them.
-    if reqs['BadChars'].to_s.length > 0 or reqs['Encoder'] or reqs['ForceEncode']
+    if reqs['Encoder'] || reqs['ForceEncode'] || has_chars?(reqs['BadChars'])
       encoders = pinst.compatible_encoders
 
       # Make sure the encoder name from the user has the same String#encoding
@@ -276,6 +276,10 @@ class EncodedPayload
     # If there are no bad characters, then the raw is the same as the
     # encoded
     else
+      unless reqs['BadChars'].blank?
+        ilog("#{pinst.refname}: payload contains no badchars, skipping automatic encoding", 'core', LEV_0)
+      end
+
       self.encoded = raw
     end
 
@@ -512,6 +516,15 @@ protected
   #
   attr_accessor :reqs
 
+  def has_chars?(chars)
+    return false if chars.blank? || self.raw.blank?
+
+    chars.each_byte do |bad|
+      return true if self.raw.index(bad.chr(Encoding::ASCII_8BIT))
+    end
+
+    false
+  end
 end
 
 end

--- a/spec/lib/msf/core/encoded_payload_spec.rb
+++ b/spec/lib/msf/core/encoded_payload_spec.rb
@@ -121,12 +121,20 @@ RSpec.describe Msf::EncodedPayload do
     context 'with bad characters: "\\0"' do
       let(:badchars) { "\0".force_encoding('binary') }
 
-      specify 'chooses x86/shikata_ga_nai' do
-        expect(encoded_payload.encoder.refname).to eq("x86/shikata_ga_nai")
+      context 'when the payload contains the bad characters' do
+        specify 'chooses x86/shikata_ga_nai' do
+          expect(encoded_payload.encoder.refname).to eq("x86/shikata_ga_nai")
+        end
+
+        specify do
+          expect(encoded_payload.encoded).not_to include(badchars)
+        end
       end
 
-      specify do
-        expect(encoded_payload.encoded).not_to include(badchars)
+      context 'when the payload does not contain the bad characters' do
+        specify 'returns the raw value' do
+          expect(encoded_payload.generate("RAW")).to eql("RAW")
+        end
       end
 
     end

--- a/spec/lib/msf/core/payload_generator_spec.rb
+++ b/spec/lib/msf/core/payload_generator_spec.rb
@@ -832,17 +832,18 @@ RSpec.describe Msf::PayloadGenerator do
           template: File.join(Msf::Config.data_directory, 'templates', 'template_x86_windows.exe')
       }
     }
+    let(:shellcode) { "a test payload" }
     context 'when an encoder is selected' do
       it 'returns an array' do
-        expect(payload_generator.get_encoders).to be_kind_of Array
+        expect(payload_generator.get_encoders(shellcode)).to be_kind_of Array
       end
 
       it 'returns an array with only one element' do
-        expect(payload_generator.get_encoders.count).to eq 1
+        expect(payload_generator.get_encoders(shellcode).count).to eq 1
       end
 
       it 'returns the correct encoder in the array' do
-        expect(payload_generator.get_encoders.first.name).to eq encoder_names[0]
+        expect(payload_generator.get_encoders(shellcode).first.name).to eq encoder_names[0]
       end
     end
 
@@ -890,17 +891,17 @@ RSpec.describe Msf::PayloadGenerator do
       end
 
       it 'returns an array of the right size' do
-        expect(payload_generator.get_encoders.count).to eq 2
+        expect(payload_generator.get_encoders(shellcode).count).to eq 2
       end
 
       it 'returns each of the selected encoders in the array' do
-        payload_generator.get_encoders.each do |msf_encoder|
+        payload_generator.get_encoders(shellcode).each do |msf_encoder|
           expect(encoder_names).to include msf_encoder.name
         end
       end
 
       it 'returns the encoders in order of rank high to low' do
-        expect(payload_generator.get_encoders[0].rank).to be > payload_generator.get_encoders[1].rank
+        expect(payload_generator.get_encoders(shellcode)[0].rank).to be > payload_generator.get_encoders(shellcode)[1].rank
       end
     end
 
@@ -927,8 +928,14 @@ RSpec.describe Msf::PayloadGenerator do
       }
 
       it 'returns an array of all encoders with a compatible arch' do
-        payload_generator.get_encoders.each do |my_encoder|
+        payload_generator.get_encoders(shellcode).each do |my_encoder|
           expect(my_encoder.arch).to include 'x86'
+        end
+      end
+      context 'when badchars are specified but are not present in the payload' do
+        let(:shellcode) { "nobadchars" }
+        it 'returns an empty array' do
+          expect(payload_generator.get_encoders(shellcode)).to be_empty
         end
       end
     end
@@ -961,7 +968,7 @@ RSpec.describe Msf::PayloadGenerator do
         }
 
       it 'returns an empty array' do
-        expect(payload_generator.get_encoders).to be_empty
+        expect(payload_generator.get_encoders(shellcode)).to be_empty
       end
     end
   end


### PR DESCRIPTION
Payloads without any of the specified badchars will no longer be encoded
by default. This should hopefully lead to less surprising results when
using simple payloads (especially commands. Things that had incomplete
badchar analysis may break as a result, since not everything will be
encoded by default anymore. Sorry in advance if they do.

Fixes #13177 

Verification
=========

#### msfvenom
- [x] `ruby ./msfvenom -b '\x00' -p cmd/windows/generic CMD=calc.exe`
- [x] Verify that `calc.exe` is not encoded
- [x] `ruby ./msfvenom -b '.' -p cmd/windows/generic CMD=calc.exe`
- [x] Verify the command is encoded

#### payload.encoded
- [x]  `./msfconsole`
- [x] `use exploit/multi/misc/ibm_tm1_unauth_rce`
- [x] `set target 1` (the important thing is a command target with badchars)
- [x] `edit` the module to print `payload.encoded` at the start of the `exploit` method and `reload`
- [x] `set payload cmd/windows/generic`
- [x] `set cmd calc.exe`
- [x] `set rhosts 127.0.0.1`
- [x] `run`
- [x] Verify `calc.exe` is not encoded
- [x] `set cmd calc.exe%`(or whatever badchar you wish)
- [x] `run`
- [x] Verify the command is encoded