### PR TITLE
SMBv3 integration with Framework

### DIFF
--- a/lib/msf/core/exploit/smb/client.rb
+++ b/lib/msf/core/exploit/smb/client.rb
@@ -358,6 +358,7 @@ module Msf
         # Connect to the server if needed
         if not self.simple
           # native_lm/native_os is only available with SMB1
+          vprint_status('Force SMB1 since SMB fingerprint needs native_lm/native_os information')
           connect(versions: [1])
           # The login method can throw any number of exceptions, we don't
           # care since we still get the native_lm/native_os.

--- a/lib/msf/core/exploit/smb/client.rb
+++ b/lib/msf/core/exploit/smb/client.rb
@@ -59,8 +59,25 @@ module Msf
           #
           OptString.new('SMB::Native_OS', [ true, 'The Native OS to send during authentication', 'Windows 2000 2195']),
           OptString.new('SMB::Native_LM', [ true, 'The Native LM to send during authentication', 'Windows 2000 5.0']),
-          OptString.new('SMB::ProtocolVersion', [true, 'One or a list of coma-separated SMB protocol versions to negotiate (e.g. "1" or "1,2" or "2,3,1")', '1,2,3'], regex: '^[123](?:,[123])*$'),
-
+          OptString.new(
+            'SMB::ProtocolVersion',
+            [
+              true,
+              'One or a list of coma-separated SMB protocol versions to '\
+              'negotiate (e.g. "1" or "1,2" or "2,3,1")', '1,2,3'
+            ],
+            regex: '^[123](?:,[123])*$'
+          ),
+          OptBool.new(
+            'SMB::AlwaysEncrypt',
+            [
+              true,
+              'Enforces encryption even if the server does not require it (SMB3.x only). '\
+              'Note that when it is set to false, the SMB client will still '\
+              'encrypt the communication if the server requires it',
+              true
+            ]
+          )
         ], Msf::Exploit::Remote::SMB::Client)
 
         register_options(
@@ -97,7 +114,7 @@ module Msf
           direct = false
         end
 
-        c = Rex::Proto::SMB::SimpleClient.new(s, direct, versions)
+        c = Rex::Proto::SMB::SimpleClient.new(s, direct, versions, always_encrypt: datastore['SMB::AlwaysEncrypt'])
 
         # setup pipe evasion foo
         if datastore['SMB::pipe_evasion']
@@ -148,6 +165,7 @@ module Msf
           datastore['SMB::Native_LM'],
           {:use_spn => datastore['NTLM::SendSPN'], :name =>  self.rhost}
         )
+        # XXX: Any reason to connect to the IPC$ share in this method?
         simple_client.connect("\\\\#{datastore['RHOST']}\\IPC$")
       end
 
@@ -334,14 +352,16 @@ module Msf
 
         # Connect to the server if needed
         if not self.simple
-          connect()
+          # native_lm/native_os is only available with SMB1
+          connect(versions: [1])
           # The login method can throw any number of exceptions, we don't
           # care since we still get the native_lm/native_os.
           begin
             smb_login()
           rescue ::Rex::Proto::SMB::Exceptions::NoReply,
                  ::Rex::Proto::SMB::Exceptions::ErrorCode,
-                 ::Rex::Proto::SMB::Exceptions::LoginError
+                 ::Rex::Proto::SMB::Exceptions::LoginError => e
+            dlog("Error with SMB fingerprint: #{e.message}")
           end
         end
 
@@ -709,9 +729,10 @@ module Msf
       def smb_netshareenumall
         begin
           return smb_srvsvc_netshareenumall
-        rescue Rex::Proto::SMB::Exceptions::ErrorCode => e
-          vprint_error("Warning: NetShareEnumAll failed via Server Service, falling back to LANMAN: #{e}")
-          fail_with(Failure::NoTarget, "No matching target")
+        rescue Rex::Proto::SMB::Exceptions::ErrorCode, RubySMB::Error::RubySMBError => e
+          vprint_error("Warning: NetShareEnumAll failed via Server Service: #{e}")
+          return [] if self.simple.client.is_a?(RubySMB::Client)
+          vprint_error("Falling back to LANMAN")
           return smb_lanman_netshareenumall
         end
       end
@@ -801,6 +822,7 @@ module Msf
       def smb_lanman_netshareenumall
         shares = []
         begin
+          # XXX: #trans is not supported by RubySMB
           res = self.simple.client.trans(
             "\\PIPE\\LANMAN",
             (

--- a/lib/msf/core/exploit/smb/client.rb
+++ b/lib/msf/core/exploit/smb/client.rb
@@ -687,7 +687,7 @@ module Msf
         handle = dcerpc_handle('4b324fc8-1670-01d3-1278-5a47bf6ee188', '3.0', 'ncacn_np', ["\\srvsvc"])
         begin
           dcerpc_bind(handle)
-        rescue Rex::Proto::SMB::Exceptions::ErrorCode => e
+        rescue Rex::Proto::SMB::Exceptions::ErrorCode, RubySMB::Error::RubySMBError => e
           vprint_error(e.message)
           return []
         end
@@ -749,7 +749,7 @@ module Msf
         handle = dcerpc_handle('4b324fc8-1670-01d3-1278-5a47bf6ee188', '3.0', 'ncacn_np', ["\\srvsvc"])
         begin
           dcerpc_bind(handle)
-        rescue Rex::Proto::SMB::Exceptions::ErrorCode => e
+        rescue Rex::Proto::SMB::Exceptions::ErrorCode, RubySMB::Error::RubySMBError => e
           vprint_error(e.message)
           return []
         end

--- a/lib/msf/core/exploit/smb/client.rb
+++ b/lib/msf/core/exploit/smb/client.rb
@@ -169,14 +169,19 @@ module Msf
         simple_client.connect("\\\\#{datastore['RHOST']}\\IPC$")
       end
 
-
       # This method returns the native operating system of the peer
       def smb_peer_os
+        unless self.simple.negotiated_smb_version == 1
+          print_warning("peer_native_os is only available with SMB1 (current version: SMB#{self.simple.negotiated_smb_version})")
+        end
         self.simple.client.peer_native_os
       end
 
       # This method returns the native lanman version of the peer
       def smb_peer_lm
+        unless self.simple.negotiated_smb_version == 1
+          print_warning("peer_native_lm is only available with SMB1 (current version: SMB#{self.simple.negotiated_smb_version})")
+        end
         self.simple.client.peer_native_lm
       end
 

--- a/lib/msf/core/exploit/smb/client.rb
+++ b/lib/msf/core/exploit/smb/client.rb
@@ -59,6 +59,7 @@ module Msf
           #
           OptString.new('SMB::Native_OS', [ true, 'The Native OS to send during authentication', 'Windows 2000 2195']),
           OptString.new('SMB::Native_LM', [ true, 'The Native LM to send during authentication', 'Windows 2000 5.0']),
+          OptString.new('SMB::ProtocolVersion', [true, 'One or a list of coma-separated SMB protocol versions to negotiate (e.g. "1" or "1,2" or "2,3,1")', '1,2,3'], regex: '^[123](?:,[123])*$'),
 
         ], Msf::Exploit::Remote::SMB::Client)
 
@@ -79,7 +80,10 @@ module Msf
       #
       # @param (see Exploit::Remote::Tcp#connect)
       # @return (see Exploit::Remote::Tcp#connect)
-      def connect(global=true, versions: [1])
+      def connect(global=true, versions: [])
+        if versions.nil? || versions.empty?
+          versions = datastore['SMB::ProtocolVersion'].split(',').map(&:to_i)
+        end
 
         disconnect() if global
 

--- a/lib/msf/core/exploit/smb/client/psexec.rb
+++ b/lib/msf/core/exploit/smb/client/psexec.rb
@@ -80,7 +80,7 @@ module Exploit::Remote::SMB::Client::Psexec
       file.close
       simple.disconnect("\\\\#{host}\\#{smbshare}")
       return contents
-    rescue Rex::Proto::SMB::Exceptions::ErrorCode => e
+    rescue Rex::Proto::SMB::Exceptions::ErrorCode, RubySMB::Error::RubySMBError => e
       print_error("Unable to read file #{file}. #{e.class}: #{e}.")
       return nil
     end
@@ -226,7 +226,7 @@ module Exploit::Remote::SMB::Client::Psexec
     vprint_status("Executing the command...")
     begin
       return psexec(execute)
-    rescue Rex::Proto::DCERPC::Exceptions::Error, Rex::Proto::SMB::Exceptions::Error => e
+    rescue Rex::Proto::DCERPC::Exceptions::Error, Rex::Proto::SMB::Exceptions::Error, RubySMB::Error::RubySMBError => e
       elog("#{e.class} #{e.message}\n#{e.backtrace * "\n"}", 'rex', LEV_3)
       print_error("Unable to execute specified command: #{e}")
       return false
@@ -391,7 +391,7 @@ module Exploit::Remote::SMB::Client::Psexec
   def exclusive_access(*files, smb_share, r_ip)
     begin
       simple.connect("\\\\#{r_ip}\\#{smb_share}")
-    rescue Rex::Proto::SMB::Exceptions::ErrorCode => accesserror
+    rescue Rex::Proto::SMB::Exceptions::ErrorCode, RubySMB::Error::RubySMBError => accesserror
       print_error("Unable to get handle: #{accesserror}")
       return false
     end
@@ -400,7 +400,7 @@ module Exploit::Remote::SMB::Client::Psexec
         print_status("checking if the file is unlocked")
         fd = smb_open(file, 'rwo')
         fd.close
-      rescue Rex::Proto::SMB::Exceptions::ErrorCode => accesserror
+      rescue Rex::Proto::SMB::Exceptions::ErrorCode, RubySMB::Error::RubySMBError => accesserror
         print_error("Unable to get handle: #{accesserror}")
         return false
       end
@@ -412,7 +412,7 @@ module Exploit::Remote::SMB::Client::Psexec
   def cleanup_after(*files, smb_share, r_ip)
     begin
       simple.connect("\\\\#{r_ip}\\#{smb_share}")
-    rescue Rex::Proto::SMB::Exceptions::ErrorCode => accesserror
+    rescue Rex::Proto::SMB::Exceptions::ErrorCode, RubySMB::Error::RubySMBError => accesserror
       print_error("Unable to connect for cleanup: #{accesserror}. Maybe you'll need to manually remove #{files.join(", "
 )} from the target.")
       return
@@ -421,7 +421,7 @@ module Exploit::Remote::SMB::Client::Psexec
     files.each do |file|
       begin
         smb_file_rm(file)
-      rescue Rex::Proto::SMB::Exceptions::ErrorCode => cleanuperror
+      rescue Rex::Proto::SMB::Exceptions::ErrorCode, RubySMB::Error::RubySMBError => cleanuperror
         print_error("Unable to cleanup #{file}. Error: #{cleanuperror}")
       end
     end

--- a/lib/msf/core/exploit/smb/client/psexec_ms17_010.rb
+++ b/lib/msf/core/exploit/smb/client/psexec_ms17_010.rb
@@ -26,7 +26,7 @@ module Exploit::Remote::SMB::Client::Psexec_MS17_010
     @ctx['rekt'] = false  # set if we need to clean up the token
     @ctx['ip'] = ip
 
-    connect()
+    connect(versions: [1])
 
     self.simple.client.default_max_buffer_size = 4356   # this took way too damn long to debug
     self.simple.client.socket.setsockopt(::Socket::SOL_SOCKET, ::Socket::SO_KEEPALIVE, 1)

--- a/lib/msf/core/handler/bind_named_pipe.rb
+++ b/lib/msf/core/handler/bind_named_pipe.rb
@@ -161,7 +161,7 @@ end
 class SimpleClientPipe < Rex::Proto::SMB::SimpleClient
   attr_accessor :pipe
 
-  def initialize(socket, direct, versions = [1, 2])
+  def initialize(socket, direct, versions = [1, 2, 3])
     super(socket, direct, versions)
     self.pipe = nil
   end

--- a/lib/rex/proto/dcerpc/client.rb
+++ b/lib/rex/proto/dcerpc/client.rb
@@ -188,7 +188,7 @@ require 'rex/proto/smb/exceptions'
     if (self.socket.class == Rex::Proto::SMB::SimpleClient::OpenPipe)
       while(idx < data.length)
         bsize = (rand(max_write-min_write)+min_write).to_i
-        len = self.socket.write(data[idx, bsize], rand(1024)+1)
+        len = self.socket.write(data[idx, bsize])
         idx += bsize
       end
     else

--- a/lib/rex/proto/smb/simpleclient.rb
+++ b/lib/rex/proto/smb/simpleclient.rb
@@ -31,17 +31,23 @@ attr_accessor :last_error, :server_max_buffer_size
 attr_accessor :socket, :client, :direct, :shares, :last_share, :versions
 
   # Pass the socket object and a boolean indicating whether the socket is netbios or cifs
-  def initialize(socket, direct = false, versions = [1])
+  def initialize(socket, direct = false, versions = [1, 2, 3])
     self.socket = socket
     self.direct = direct
     self.versions = versions
     self.shares = {}
     self.server_max_buffer_size = 1024 # 4356 (workstation) or 16644 (server) expected
 
-    if self.versions.include?(2)
+    if self.versions == [1]
+      self.client = Rex::Proto::SMB::Client.new(socket)
+    else
       self.client = RubySMB::Client.new(RubySMB::Dispatcher::Socket.new(self.socket, read_timeout: 60),
                                         username: '',
-                                        password: '')#Rex::Proto::SMB::Client.new(socket)
+                                        password: '',
+                                        smb1: self.versions.include?(1),
+                                        smb2: self.versions.include?(2),
+                                        smb3: self.versions.include?(3)
+                    )
       self.client.evasion_opts = {
         # Padding is performed between packet headers and data
         'pad_data' => EVADE::EVASION_NONE,
@@ -50,8 +56,6 @@ attr_accessor :socket, :client, :direct, :shares, :last_share, :versions
         # Modify the \PIPE\ string in trans_named_pipe calls
         'obscure_trans_pipe' => EVADE::EVASION_NONE,
       }
-    else
-      self.client = Rex::Proto::SMB::Client.new(socket)
     end
   end
 
@@ -74,11 +78,14 @@ attr_accessor :socket, :client, :direct, :shares, :last_share, :versions
       self.client.use_lanman_key =  use_lanman_key
       self.client.send_ntlm = send_ntlm
 
+      dlog("SMB version(s) to negotiate: #{self.versions}")
       ok = self.client.negotiate
-      if self.versions.include?(2)
-        self.server_max_buffer_size = self.client.server_max_buffer_size
-      else
+      dlog("Negotiated SMB version: #{self.client.is_a?(Rex::Proto::SMB::Client) ? 'SMB1' : ok}")
+
+      if self.versions == [1]
         self.server_max_buffer_size = ok['Payload'].v['MaxBuff']
+      else
+        self.server_max_buffer_size = self.client.server_max_buffer_size
       end
 
       # Disable NTLMv2 Session for Windows 2000 (breaks authentication on some systems)
@@ -94,10 +101,10 @@ attr_accessor :socket, :client, :direct, :shares, :last_share, :versions
       # always a string
       pass ||= ''
 
-      if self.versions.include?(2)
-        ok = self.client.session_setup(user, pass, domain, true)
-      else
+      if self.versions == [1]
         ok = self.client.session_setup(user, pass, domain)
+      else
+        ok = self.client.session_setup(user, pass, domain, true)
       end
     rescue ::Interrupt
       raise $!
@@ -162,10 +169,10 @@ attr_accessor :socket, :client, :direct, :shares, :last_share, :versions
   def connect(share)
     ok = self.client.tree_connect(share)
 
-    if self.versions.include?(2)
-      tree_id = ok.id
-    else
+    if self.versions == [1]
       tree_id = ok['Payload']['SMB'].v['TreeID']
+    else
+      tree_id = ok.id
     end
 
     self.shares[share] = tree_id
@@ -182,7 +189,13 @@ attr_accessor :socket, :client, :direct, :shares, :last_share, :versions
   end
 
   def open(path, perm, chunk_size = 48000, read: true, write: false)
-    if self.versions.include?(2)
+    if self.versions == [1]
+      mode = UTILS.open_mode_to_mode(perm)
+      access = UTILS.open_mode_to_access(perm)
+
+      ok = self.client.open(path, mode, access)
+      file_id = ok['Payload'].v['FileID']
+    else
       mode = 0
       perm.each_byte { |c|
         case [c].pack('C').downcase
@@ -200,12 +213,6 @@ attr_accessor :socket, :client, :direct, :shares, :last_share, :versions
       else
         file_id = self.client.open(path, mode, read: true)
       end
-    else
-      mode = UTILS.open_mode_to_mode(perm)
-      access = UTILS.open_mode_to_access(perm)
-
-      ok = self.client.open(path, mode, access)
-      file_id = ok['Payload'].v['FileID']
     end
 
     fh = OpenFile.new(self.client, path, self.client.last_tree_id, file_id, self.versions)
@@ -214,10 +221,10 @@ attr_accessor :socket, :client, :direct, :shares, :last_share, :versions
   end
 
   def delete(*args)
-    if self.versions.include?(2)
-      self.client.delete(args[0])
-    else
+    if self.versions == [1]
       self.client.delete(*args)
+    else
+      self.client.delete(args[0])
     end
   end
 
@@ -225,10 +232,10 @@ attr_accessor :socket, :client, :direct, :shares, :last_share, :versions
     disposition = UTILS.create_mode_to_disposition(perm)
     ok = self.client.create_pipe(path, disposition)
 
-    if self.versions.include?(2)
-      file_id = ok
-    else
+    if self.versions == [1]
       file_id = ok['Payload'].v['FileID']
+    else
+      file_id = ok
     end
 
     fh = OpenPipe.new(self.client, path, self.client.last_tree_id, file_id, self.versions)

--- a/lib/rex/proto/smb/simpleclient.rb
+++ b/lib/rex/proto/smb/simpleclient.rb
@@ -235,7 +235,7 @@ attr_accessor :socket, :client, :direct, :shares, :last_share, :versions
     end
   end
 
-  def create_pipe(path, perm = 'c')
+  def create_pipe(path, perm = 'o')
     disposition = UTILS.create_mode_to_disposition(perm)
     ok = self.client.create_pipe(path, disposition)
 

--- a/lib/rex/proto/smb/simpleclient/open_file.rb
+++ b/lib/rex/proto/smb/simpleclient/open_file.rb
@@ -99,10 +99,10 @@ module Rex::Proto::SMB
 
       # Read data from the file
       def read(length = nil, offset = 0)
-        if versions == [1]
-          read_rex_smb(length, offset)
-        else
+        if self.client.is_a?(RubySMB::Client)
           read_ruby_smb(length, offset)
+        else
+          read_rex_smb(length, offset)
         end
       end
 
@@ -124,10 +124,10 @@ module Rex::Proto::SMB
         # Keep writing data until we run out
         until chunk.empty?
           ok = client.write(file_id, fptr, chunk)
-          if versions == [1]
-            cl = ok['Payload'].v['CountLow']
-          else
+          if self.client.is_a?(RubySMB::Client)
             cl = ok
+          else
+            cl = ok['Payload'].v['CountLow']
           end
 
           # Partial write, push the failed data back into the queue

--- a/lib/rex/proto/smb/simpleclient/open_file.rb
+++ b/lib/rex/proto/smb/simpleclient/open_file.rb
@@ -99,10 +99,10 @@ module Rex::Proto::SMB
 
       # Read data from the file
       def read(length = nil, offset = 0)
-        if versions.include?(2)
-          read_ruby_smb(length, offset)
-        else
+        if versions == [1]
           read_rex_smb(length, offset)
+        else
+          read_ruby_smb(length, offset)
         end
       end
 
@@ -124,10 +124,10 @@ module Rex::Proto::SMB
         # Keep writing data until we run out
         until chunk.empty?
           ok = client.write(file_id, fptr, chunk)
-          if versions.include?(2)
-            cl = ok
-          else
+          if versions == [1]
             cl = ok['Payload'].v['CountLow']
+          else
+            cl = ok
           end
 
           # Partial write, push the failed data back into the queue

--- a/lib/rex/proto/smb/simpleclient/open_pipe.rb
+++ b/lib/rex/proto/smb/simpleclient/open_pipe.rb
@@ -33,9 +33,13 @@ class OpenPipe < OpenFile
   end
 
   def write(data, offset = 0)
+
     case self.mode
 
     when 'trans'
+      if self.client.is_a?(RubySMB::Client)
+        raise ArgumentError, '\'trans\' mode is not supported by RubySMB'
+      end
       write_trans(data, offset)
     when 'rw'
       super(data, offset)

--- a/lib/rex/proto/smb/simpleclient/open_pipe.rb
+++ b/lib/rex/proto/smb/simpleclient/open_pipe.rb
@@ -38,7 +38,7 @@ class OpenPipe < OpenFile
 
     when 'trans'
       if self.client.is_a?(RubySMB::Client)
-        raise ArgumentError, '\'trans\' mode is not supported by RubySMB'
+        raise NotImplementedError, '\'trans\' mode is not supported by RubySMB'
       end
       write_trans(data, offset)
     when 'rw'

--- a/lib/rex/proto/smb/simpleclient/open_pipe.rb
+++ b/lib/rex/proto/smb/simpleclient/open_pipe.rb
@@ -78,10 +78,10 @@ class OpenPipe < OpenFile
   end
 
   def peek
-    if versions.include?(2)
-      avail = peek_ruby_smb
-    else
+    if versions == [1]
       avail = peek_rex_smb
+    else
+      avail = peek_ruby_smb
     end
     avail
   end

--- a/lib/rex/proto/smb/simpleclient/open_pipe.rb
+++ b/lib/rex/proto/smb/simpleclient/open_pipe.rb
@@ -78,10 +78,10 @@ class OpenPipe < OpenFile
   end
 
   def peek
-    if versions == [1]
-      avail = peek_rex_smb
-    else
+    if self.client.is_a?(RubySMB::Client)
       avail = peek_ruby_smb
+    else
+      avail = peek_rex_smb
     end
     avail
   end

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -136,7 +136,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'net-ssh'
   spec.add_runtime_dependency 'ed25519' # Adds ed25519 keys for net-ssh
   spec.add_runtime_dependency 'bcrypt_pbkdf'
-  spec.add_runtime_dependency 'ruby_smb', '~> 1.1'
+  spec.add_runtime_dependency 'ruby_smb', '~> 2.0'
   spec.add_runtime_dependency 'net-ldap'
 
   #

--- a/modules/auxiliary/admin/db2/db2rcmd.rb
+++ b/modules/auxiliary/admin/db2/db2rcmd.rb
@@ -31,12 +31,14 @@ class MetasploitModule < Msf::Auxiliary
           OptString.new('SMBUser', [ true, 'The username to authenticate as', 'db2admin']),
           OptString.new('SMBPass', [ true, 'The password for the specified username', 'db2admin'])
         ])
+
+      deregister_options('SMB::ProtocolVersion')
   end
 
   def run
 
     print_status("Connecting to the server...")
-    connect()
+    connect(versions: [1])
 
     print_status("Authenticating as user '#{datastore['SMBUser']}' with pass '#{datastore['SMBPass']}'...")
 

--- a/modules/auxiliary/admin/smb/check_dir_file.rb
+++ b/modules/auxiliary/admin/smb/check_dir_file.rb
@@ -52,7 +52,12 @@ class MetasploitModule < Msf::Auxiliary
         fd.close
       end
     rescue ::Rex::Proto::SMB::Exceptions::ErrorCode => e
-      case e.get_error(e.error_code)
+      error_name = e.get_error(e.error_code)
+    rescue ::RubySMB::Error::UnexpectedStatusCode => e
+      error_name = e.status_code.name
+    end
+    if error_name
+      case error_name
       when "STATUS_FILE_IS_A_DIRECTORY"
         print_good("Directory FOUND: \\\\#{rhost}\\#{datastore['SMBSHARE']}\\#{path}")
       when "STATUS_OBJECT_NAME_NOT_FOUND"
@@ -66,7 +71,7 @@ class MetasploitModule < Msf::Auxiliary
       when "STATUS_INSUFF_SERVER_RESOURCES"
         vprint_error("Host rejected with insufficient resources!")
       when "STATUS_OBJECT_NAME_INVALID"
-        vprint_error("opeining \\#{path} bad filename")
+        vprint_error("opening \\#{path} bad filename")
       else
         raise e
       end

--- a/modules/auxiliary/admin/smb/delete_file.rb
+++ b/modules/auxiliary/admin/smb/delete_file.rb
@@ -52,7 +52,7 @@ class MetasploitModule < Msf::Auxiliary
 
         # If there's no exception raised at this point, we assume the file has been removed.
         print_good("Deleted: #{remote_path}")
-      rescue Rex::Proto::SMB::Exceptions::ErrorCode => e
+      rescue Rex::Proto::SMB::Exceptions::ErrorCode, RubySMB::Error::RubySMBError => e
         elog("#{e.class} #{e.message}\n#{e.backtrace * "\n"}")
         print_error("Cannot delete #{remote_path}: #{e.message}")
       end

--- a/modules/auxiliary/admin/smb/download_file.rb
+++ b/modules/auxiliary/admin/smb/download_file.rb
@@ -34,7 +34,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def smb_download
     vprint_status("Connecting...")
-    connect(versions: [1, 2])
+    connect
     smb_login()
 
     vprint_status("#{peer}: Mounting the remote share \\\\#{rhost}\\#{datastore['SMBSHARE']}'...")

--- a/modules/auxiliary/admin/smb/list_directory.rb
+++ b/modules/auxiliary/admin/smb/list_directory.rb
@@ -39,6 +39,7 @@ class MetasploitModule < Msf::Auxiliary
       OptString.new('RPATH', [false, 'The name of the remote directory relative to the share']),
     ])
 
+    deregister_options('SMB::ProtocolVersion')
   end
 
   def as_size( s )
@@ -55,7 +56,7 @@ class MetasploitModule < Msf::Auxiliary
   def run
     print_status("Connecting to the server...")
     begin
-      connect()
+      connect(versions: [1])
       smb_login()
       print_status("Mounting the remote share \\\\#{datastore['RHOST']}\\#{datastore['SMBSHARE']}'...")
             self.simple.connect("\\\\#{datastore['RHOST']}\\#{datastore['SMBSHARE']}")

--- a/modules/auxiliary/admin/smb/ms17_010_command.rb
+++ b/modules/auxiliary/admin/smb/ms17_010_command.rb
@@ -64,6 +64,8 @@ class MetasploitModule < Msf::Auxiliary
       OptInt.new('DELAY', [true, 'Wait this many seconds before reading output and cleaning up', 0]),
       OptInt.new('RETRY', [true, 'Retry this many times to check if the process is complete', 0]),
     ])
+
+    deregister_options('SMB::ProtocolVersion')
   end
 
   def run_host(ip)

--- a/modules/auxiliary/admin/smb/samba_symlink_traversal.rb
+++ b/modules/auxiliary/admin/smb/samba_symlink_traversal.rb
@@ -42,12 +42,13 @@ class MetasploitModule < Msf::Auxiliary
       OptString.new('SMBTARGET', [true, 'The name of the directory that should point to the root filesystem', 'rootfs'])
     ])
 
+    deregister_options('SMB::ProtocolVersion')
   end
 
 
   def run
     print_status("Connecting to the server...")
-    connect()
+    connect(versions: [1])
     smb_login()
 
     print_status("Trying to mount writeable share '#{datastore['SMBSHARE']}'...")

--- a/modules/auxiliary/admin/smb/upload_file.rb
+++ b/modules/auxiliary/admin/smb/upload_file.rb
@@ -40,7 +40,7 @@ class MetasploitModule < Msf::Auxiliary
   def run_host(_ip)
     begin
       vprint_status("Connecting to the server...")
-      connect(versions: [1, 2])
+      connect
       smb_login()
 
       vprint_status("Mounting the remote share \\\\#{datastore['RHOST']}\\#{datastore['SMBSHARE']}'...")
@@ -57,7 +57,7 @@ class MetasploitModule < Msf::Auxiliary
         begin
           vprint_status("Trying to upload #{local_path} to #{remote_path}...")
 
-          fd = simple.open("#{remote_path}", 's', write: true)
+          fd = simple.open("#{remote_path}", 'wct', write: true)
           data = ::File.read(datastore['LPATH'], ::File.size(datastore['LPATH']))
           fd.write(data)
           fd.close

--- a/modules/auxiliary/dos/samba/read_nttrans_ea_list.rb
+++ b/modules/auxiliary/dos/samba/read_nttrans_ea_list.rb
@@ -57,6 +57,7 @@ class MetasploitModule < Msf::Auxiliary
         OptInt.new('Tries', [true, 'Number of DOS tries', 40]),
       ])
 
+    deregister_options('SMB::ProtocolVersion')
   end
 
   def get_fid
@@ -102,7 +103,7 @@ class MetasploitModule < Msf::Auxiliary
   def run
     print_status("Trying a max of #{datastore['Tries']} times...")
     datastore['Tries'].times do
-      connect()
+      connect(versions: [1])
       smb_login()
       self.simple.connect("\\\\#{rhost}\\#{datastore['SMBSHARE']}")
 

--- a/modules/auxiliary/dos/windows/smb/ms06_035_mailslot.rb
+++ b/modules/auxiliary/dos/windows/smb/ms06_035_mailslot.rb
@@ -42,6 +42,7 @@ class MetasploitModule < Msf::Auxiliary
         OptString.new('MAILSLOT', [ true,  "The mailslot name to use", 'Alerter']),
       ])
 
+    deregister_options('SMB::ProtocolVersion')
   end
 
   # MAILSLOT: HydraLsServer
@@ -55,7 +56,7 @@ class MetasploitModule < Msf::Auxiliary
 
       print_status("Mangling the kernel, two bytes at a time...");
 
-      connect
+      connect(versions: [1])
       smb_login
 
       1.upto(1024) do |i|

--- a/modules/auxiliary/dos/windows/smb/ms06_063_trans.rb
+++ b/modules/auxiliary/dos/windows/smb/ms06_063_trans.rb
@@ -27,13 +27,14 @@ class MetasploitModule < Msf::Auxiliary
         ]
     ))
 
+    deregister_options('SMB::ProtocolVersion')
   end
 
   def run
 
     print_status("Connecting to the target system...");
 
-    connect
+    connect(versions: [1])
     smb_login
 
     begin

--- a/modules/auxiliary/dos/windows/smb/ms09_001_write.rb
+++ b/modules/auxiliary/dos/windows/smb/ms09_001_write.rb
@@ -28,12 +28,14 @@ class MetasploitModule < Msf::Auxiliary
         ]
       )
     )
+
+    deregister_options('SMB::ProtocolVersion')
   end
 
 
   def send_smb_pkt(dlenlow, doffset,fillersize)
 
-    connect()
+    connect(versions: [1])
     smb_login()
 
     pkt = CONST::SMB_CREATE_PKT.make_struct

--- a/modules/auxiliary/dos/windows/smb/ms10_054_queryfs_pool_overflow.rb
+++ b/modules/auxiliary/dos/windows/smb/ms10_054_queryfs_pool_overflow.rb
@@ -34,6 +34,8 @@ class MetasploitModule < Msf::Auxiliary
         Opt::RPORT(445),
         OptString.new('SMBSHARE', [ true, "The name of a readable share on the server" ])
       ])
+
+    deregister_options('SMB::ProtocolVersion')
   end
 
   # Perform a transaction2 request using the specified subcommand, parameters, and data
@@ -88,7 +90,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def run
 
-    connect()
+    connect(versions: [1])
 
     simple.login(
       datastore['SMBName'],

--- a/modules/auxiliary/fuzzers/smb/smb_create_pipe_corrupt.rb
+++ b/modules/auxiliary/fuzzers/smb/smb_create_pipe_corrupt.rb
@@ -20,11 +20,13 @@ class MetasploitModule < Msf::Auxiliary
       OptInt.new('MAXDEPTH', [false, 'Specify a maximum byte depth to test']),
       OptString.new('SMBPIPE', [true, 'Specify the pipe name to corrupt', "\\BROWSER"])
     ])
+
+    deregister_options('SMB::ProtocolVersion')
   end
 
   def do_smb_login(pkt,opts={})
     @connected = false
-    connect
+    connect(versions: [1])
     smb_login
 
     @connected = true
@@ -35,7 +37,7 @@ class MetasploitModule < Msf::Auxiliary
   def run
 
     # Connect in order to get the server-assigned user-id/tree-id
-    connect
+    connect(versions: [1])
     smb_login
     pkt = make_smb_create
     disconnect

--- a/modules/auxiliary/fuzzers/smb/smb_ntlm1_login_corrupt.rb
+++ b/modules/auxiliary/fuzzers/smb/smb_ntlm1_login_corrupt.rb
@@ -21,11 +21,12 @@ class MetasploitModule < Msf::Auxiliary
       Opt::RPORT(445),
       OptInt.new('MAXDEPTH', [false, 'Specify a maximum byte depth to test'])
     ])
+    deregister_options('SMB::ProtocolVersion')
   end
 
   def do_smb_login(pkt,opts={})
     @connected = false
-    connect
+    connect(versions: [1])
     simple.client.negotiate(false)
 
     @connected = true

--- a/modules/auxiliary/fuzzers/smb/smb_tree_connect_corrupt.rb
+++ b/modules/auxiliary/fuzzers/smb/smb_tree_connect_corrupt.rb
@@ -20,11 +20,13 @@ class MetasploitModule < Msf::Auxiliary
       OptInt.new('MAXDEPTH', [false, 'Specify a maximum byte depth to test']),
       OptString.new('SMBTREE', [true, 'Specify the tree name to corrupt', "\\\\SERVER\\IPC$"])
     ])
+
+    deregister_options('SMB::ProtocolVersion')
   end
 
   def do_smb_tree(pkt,opts={})
     @connected = false
-    connect
+    connect(versions: [1])
     simple.login(
       datastore['SMBName'],
       datastore['SMBUser'],
@@ -40,7 +42,7 @@ class MetasploitModule < Msf::Auxiliary
   def run
 
     # Connect in order to get the server-assigned user-id
-    connect
+    connect(versions: [1])
     smb_login
     pkt = make_smb_tree
     disconnect

--- a/modules/auxiliary/gather/windows_deployment_services_shares.rb
+++ b/modules/auxiliary/gather/windows_deployment_services_shares.rb
@@ -136,7 +136,7 @@ class MetasploitModule < Msf::Auxiliary
     deploy_shares = []
 
     begin
-      connect
+      connect(versions: [1])
       smb_login
       srvsvc_netshareenum.each do |share|
         # Ghetto unicode to ascii conversation

--- a/modules/auxiliary/scanner/smb/pipe_auditor.rb
+++ b/modules/auxiliary/scanner/smb/pipe_auditor.rb
@@ -36,7 +36,7 @@ class MetasploitModule < Msf::Auxiliary
       datastore['SMBDirect'] = info[1]
 
       begin
-        connect(versions: [1, 2])
+        connect
         smb_login()
         check_named_pipes.each do |pipe_name, _|
           pipes.push(pipe_name)
@@ -45,7 +45,7 @@ class MetasploitModule < Msf::Auxiliary
         disconnect()
 
         break
-      rescue Rex::Proto::SMB::Exceptions::SimpleClientError => e
+      rescue Rex::Proto::SMB::Exceptions::SimpleClientError, Rex::ConnectionError => e
         vprint_error("SMB client Error with RPORT=#{info[0]} SMBDirect=#{info[1]}: #{e.to_s}")
       end
     end

--- a/modules/auxiliary/scanner/smb/smb_enum_gpp.rb
+++ b/modules/auxiliary/scanner/smb/smb_enum_gpp.rb
@@ -43,6 +43,8 @@ class MetasploitModule < Msf::Auxiliary
       OptPort.new('RPORT', [true, 'The Target port', 445]),
       OptBool.new('STORE', [true, 'Store the enumerated files in loot.', true])
     ])
+
+    deregister_options('SMB::ProtocolVersion')
   end
 
   def check_path(ip, path)
@@ -165,7 +167,7 @@ class MetasploitModule < Msf::Auxiliary
   def run_host(ip)
     print_status('Connecting to the server...')
     begin
-      connect
+      connect(versions: [1])
       smb_login
       print_status("Mounting the remote share \\\\#{ip}\\#{datastore['SMBSHARE']}'...")
       simple.connect("\\\\#{ip}\\#{datastore['SMBSHARE']}")

--- a/modules/auxiliary/scanner/smb/smb_enumshares.rb
+++ b/modules/auxiliary/scanner/smb/smb_enumshares.rb
@@ -355,9 +355,7 @@ class MetasploitModule < Msf::Auxiliary
           )
 
           if datastore['SpiderShares']
-            # This feature is not available with RubySMB client.
-            # Force using Rex client by setting SMBv1 as the only version to negotiate.
-            # So, this won't work if SMBv1 is disabled on the target.
+            vprint_status('Use Rex client (SMB1 only) for SpiderShares, since it is not compatible with RubySMB client')
             connect(versions: [1])
             smb_login
             get_files_info(ip, rport, shares, info)

--- a/modules/auxiliary/scanner/smb/smb_enumshares.rb
+++ b/modules/auxiliary/scanner/smb/smb_enumshares.rb
@@ -85,6 +85,7 @@ class MetasploitModule < Msf::Auxiliary
     self.simple.connect("\\\\#{ip}\\#{share}")
 
     begin
+      # XXX: not implemented with RubySMB client, should I implement it?
       device_type = self.simple.client.queryfs_fs_device['device_type']
       unless device_type
         vprint_error("\\\\#{ip}\\#{share}: Error querying filesystem device type")
@@ -330,7 +331,7 @@ class MetasploitModule < Msf::Auxiliary
       @smb_redirect = info[1]
 
       begin
-        connect(versions: [2,1])
+        connect
         smb_login
         shares = smb_netshareenumall
 
@@ -354,6 +355,11 @@ class MetasploitModule < Msf::Auxiliary
           )
 
           if datastore['SpiderShares']
+            # This feature is not available with RubySMB client.
+            # Force using Rex client by setting SMBv1 as the only version to negotiate.
+            # So, this won't work if SMBv1 is disabled on the target.
+            connect(versions: [1])
+            smb_login
             get_files_info(ip, rport, shares, info)
           end
 

--- a/modules/auxiliary/scanner/smb/smb_enumshares.rb
+++ b/modules/auxiliary/scanner/smb/smb_enumshares.rb
@@ -355,10 +355,17 @@ class MetasploitModule < Msf::Auxiliary
           )
 
           if datastore['SpiderShares']
-            vprint_status('Use Rex client (SMB1 only) for SpiderShares, since it is not compatible with RubySMB client')
-            connect(versions: [1])
-            smb_login
-            get_files_info(ip, rport, shares, info)
+            begin
+              connect(versions: [1])
+              smb_login
+              get_files_info(ip, rport, shares, info)
+            rescue ::Rex::Proto::SMB::Exceptions::Error, Errno::ECONNRESET => e
+              print_error(
+                "Error when Spidering shares recursively (#{e}). This feature "\
+                "is only available with Rex client (SMB1 only) and the host "\
+                "probably doesn't support SMB1."
+              )
+            end
           end
 
           break if rport == 139

--- a/modules/auxiliary/scanner/smb/smb_ms17_010.rb
+++ b/modules/auxiliary/scanner/smb/smb_ms17_010.rb
@@ -165,7 +165,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def do_smb_setup_tree(ipc_share)
-    connect
+    connect(versions: [1])
 
     # logon as user \
     simple.login(datastore['SMBName'], datastore['SMBUser'], datastore['SMBPass'], datastore['SMBDomain'])

--- a/modules/auxiliary/scanner/smb/smb_version.rb
+++ b/modules/auxiliary/scanner/smb/smb_version.rb
@@ -27,6 +27,7 @@ class MetasploitModule < Msf::Auxiliary
 
     deregister_options('RPORT')
     deregister_options('SMBDIRECT')
+    deregister_options('SMB::ProtocolVersion')
     @smb_port = 445
   end
 

--- a/modules/auxiliary/server/http_ntlmrelay.rb
+++ b/modules/auxiliary/server/http_ntlmrelay.rb
@@ -328,7 +328,7 @@ class MetasploitModule < Msf::Auxiliary
       print_error("Could not connect to target host (#{target_host})")
       return
     end
-    ser_sock = Rex::Proto::SMB::SimpleClient.new(rsock, rport == 445 ? true : false)
+    ser_sock = Rex::Proto::SMB::SimpleClient.new(rsock, rport == 445 ? true : false, [1])
 
     if (datastore['RPORT'] == '139')
       ser_sock.client.session_request()

--- a/modules/exploits/freebsd/samba/trans2open.rb
+++ b/modules/exploits/freebsd/samba/trans2open.rb
@@ -61,6 +61,8 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         Opt::RPORT(139)
       ])
+
+    deregister_options('SMB::ProtocolVersion')
   end
 
   def brute_exploit(addrs)
@@ -69,7 +71,7 @@ class MetasploitModule < Msf::Exploit::Remote
     begin
       print_status("Trying return address 0x%.8x..." %  curr_ret)
 
-      connect
+      connect(versions: [1])
       smb_login
 
       # This value *must* be 1988 to allow findrecv shellcode to work

--- a/modules/exploits/linux/samba/chain_reply.rb
+++ b/modules/exploits/linux/samba/chain_reply.rb
@@ -87,6 +87,8 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         Opt::RPORT(139)
       ])
+
+    deregister_options('SMB::ProtocolVersion')
   end
 
   #
@@ -133,7 +135,7 @@ class MetasploitModule < Msf::Exploit::Remote
       begin
         print_status("Trying return address 0x%.8x..." %  curr_ret)
 
-        connect
+        connect(versions: [1])
         self.simple.client.session_id = rand(31337)
 
         #select(nil,nil,nil,2)

--- a/modules/exploits/linux/samba/is_known_pipename.rb
+++ b/modules/exploits/linux/samba/is_known_pipename.rb
@@ -273,14 +273,14 @@ class MetasploitModule < Msf::Exploit::Remote
       rescue Rex::Proto::SMB::Exceptions::ErrorCode => e
         # Look for STATUS_OBJECT_PATH_INVALID indicating our interact payload loaded
         if e.error_code == 0xc0000039 ||
-          pwd
+          pwn
           return true
         else
           print_error("  >> Failed to load #{e.error_name}")
         end
       rescue RubySMB::Error::UnexpectedStatusCode => e
         if e.status_code == ::WindowsError::NTStatus::STATUS_OBJECT_PATH_INVALID
-          pwd
+          pwn
           return true
         else
           print_error("  >> Failed to load #{e.status_code.name}")

--- a/modules/exploits/linux/samba/is_known_pipename.rb
+++ b/modules/exploits/linux/samba/is_known_pipename.rb
@@ -82,6 +82,7 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('SMB_SHARE_NAME', [false, 'The name of the SMB share containing a writeable directory']),
         OptString.new('SMB_FOLDER', [false, 'The directory to use within the writeable SMB share']),
       ])
+
   end
 
   def post_auth?
@@ -123,6 +124,9 @@ class MetasploitModule < Msf::Exploit::Remote
   # List all top-level directories within a given share
   def enumerate_directories(share)
     begin
+      vprint_status('Use Rex client (SMB1 only) to enumerate directories, since it is not compatible with RubySMB client')
+      connect(versions: [1])
+      smb_login
       self.simple.connect("\\\\#{rhost}\\#{share}")
       stuff = self.simple.client.find_first("\\*")
       directories = [""]
@@ -140,6 +144,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     ensure
       simple.disconnect("\\\\#{rhost}\\#{share}")
+      smb_connect
     end
   end
 
@@ -158,7 +163,7 @@ class MetasploitModule < Msf::Exploit::Remote
       simple.delete(filename)
       return true
 
-    rescue ::Rex::Proto::SMB::Exceptions::ErrorCode => e
+    rescue ::Rex::Proto::SMB::Exceptions::ErrorCode, RubySMB::Error::RubySMBError => e
       vprint_error("Write #{share}#{filename}: #{e}")
       return false
 
@@ -266,18 +271,19 @@ class MetasploitModule < Msf::Exploit::Remote
         # Common errors we can safely ignore
 
       rescue Rex::Proto::SMB::Exceptions::ErrorCode => e
-
         # Look for STATUS_OBJECT_PATH_INVALID indicating our interact payload loaded
-        if e.error_code == 0xc0000039
-          print_good("Probe response indicates the interactive payload was loaded...")
-
-          smb_shell = self.sock
-          self.sock = nil
-          remove_socket(sock)
-          handler(smb_shell)
+        if e.error_code == 0xc0000039 ||
+          pwd
           return true
         else
           print_error("  >> Failed to load #{e.error_name}")
+        end
+      rescue RubySMB::Error::UnexpectedStatusCode => e
+        if e.status_code == ::WindowsError::NTStatus::STATUS_OBJECT_PATH_INVALID
+          pwd
+          return true
+        else
+          print_error("  >> Failed to load #{e.status_code.name}")
         end
       end
 
@@ -286,6 +292,14 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     false
+  end
+
+  def pwn
+    print_good("Probe response indicates the interactive payload was loaded...")
+    smb_shell = self.sock
+    self.sock = nil
+    remove_socket(sock)
+    handler(smb_shell)
   end
 
   # Use fancy payload wrappers to make exploitation a joyously lazy exercise

--- a/modules/exploits/linux/samba/lsa_transnames_heap.rb
+++ b/modules/exploits/linux/samba/lsa_transnames_heap.rb
@@ -201,11 +201,12 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('SMBPIPE', [ true,  "The pipe name to use", 'LSARPC']),
       ])
 
+    deregister_options('SMB::ProtocolVersion')
   end
 
   def check
     begin
-      connect()
+      connect(versions: [1])
       smb_login()
       disconnect()
       if (smb_peer_lm() =~ /Samba/i)
@@ -237,7 +238,7 @@ class MetasploitModule < Msf::Exploit::Remote
     pipe = datastore['SMBPIPE'].downcase
 
     print_status("Connecting to the SMB service...")
-    connect()
+    connect(versions: [1])
     smb_login()
 
     if ! @checked_peerlm

--- a/modules/exploits/linux/samba/setinfopolicy_heap.rb
+++ b/modules/exploits/linux/samba/setinfopolicy_heap.rb
@@ -168,6 +168,7 @@ class MetasploitModule < Msf::Exploit::Remote
       OptInt.new("StopBrute", [ false, "Stop Address For Brute Forcing" ])
     ])
 
+    deregister_options('SMB::ProtocolVersion')
   end
 
   def exploit
@@ -198,8 +199,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
     pipe = "lsarpc"
 
-
-    connect()
+    vprint_status('Use Rex client (SMB1 only) since this module is not compatible with RubySMB client')
+    connect(versions: [1])
     smb_login()
 
     handle = dcerpc_handle('12345778-1234-abcd-ef00-0123456789ab', '0.0', 'ncacn_np', ["\\#{pipe}"])
@@ -272,7 +273,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     begin
-      connect()
+      vprint_status('Connect with SMB1 for the check method, since it needs native_lm info')
+      connect(versions: [1])
       smb_login()
       disconnect()
 

--- a/modules/exploits/linux/samba/trans2open.rb
+++ b/modules/exploits/linux/samba/trans2open.rb
@@ -65,6 +65,8 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         Opt::RPORT(139)
       ])
+
+    deregister_options('SMB::ProtocolVersion')
   end
 
   def brute_exploit(addrs)
@@ -73,7 +75,8 @@ class MetasploitModule < Msf::Exploit::Remote
     begin
       print_status("Trying return address 0x%.8x..." %  curr_ret)
 
-      connect
+      vprint_status('Connect with SMB1 since it needs native_lm info')
+      connect(versions: [1])
       smb_login
 
       if ! @checked_peerlm

--- a/modules/exploits/multi/samba/nttrans.rb
+++ b/modules/exploits/multi/samba/nttrans.rb
@@ -54,6 +54,8 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         Opt::RPORT(139)
       ])
+
+    deregister_options('SMB::ProtocolVersion')
   end
 
   def exploit
@@ -67,7 +69,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # 0x081b8138
 
-    connect
+    connect(versions: [1])
     smb_login
 
     targ_address = 0xfffbb7d0

--- a/modules/exploits/multi/samba/usermap_script.rb
+++ b/modules/exploits/multi/samba/usermap_script.rb
@@ -60,12 +60,15 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         Opt::RPORT(139)
       ])
+
+    deregister_options('SMB::ProtocolVersion')
   end
 
 
   def exploit
 
-    connect
+    vprint_status('Use Rex client (SMB1 only) since this module is not compatible with RubySMB client')
+    connect(versions: [1])
 
     # lol?
     username = "/=`nohup " + payload.encoded + "`"

--- a/modules/exploits/osx/samba/trans2open.rb
+++ b/modules/exploits/osx/samba/trans2open.rb
@@ -57,6 +57,8 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         Opt::RPORT(139)
       ])
+
+    deregister_options('SMB::ProtocolVersion')
   end
 
   # Need to perform target detection
@@ -70,7 +72,7 @@ class MetasploitModule < Msf::Exploit::Remote
     begin
       print_status("Trying return address 0x%.8x..." %  curr_ret)
 
-      connect
+      connect(versions: [1])
       smb_login
 
       # 1988 is required for findrecv shellcode

--- a/modules/exploits/solaris/samba/trans2open.rb
+++ b/modules/exploits/solaris/samba/trans2open.rb
@@ -73,6 +73,8 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         Opt::RPORT(139)
       ])
+
+    deregister_options('SMB::ProtocolVersion')
   end
 
   def brute_exploit(addrs)
@@ -81,7 +83,7 @@ class MetasploitModule < Msf::Exploit::Remote
     begin
       print_status("Trying return address 0x%.8x..." %  curr_ret)
 
-      connect
+      connect(versions: [1])
       smb_login
 
       #

--- a/modules/exploits/windows/smb/ipass_pipe_exec.rb
+++ b/modules/exploits/windows/smb/ipass_pipe_exec.rb
@@ -72,7 +72,10 @@ class MetasploitModule < Msf::Exploit::Remote
       vprint_error("Connection failed: #{e.class}: #{e}")
       return Msf::Exploit::CheckCode::Unknown
     rescue Rex::Proto::SMB::Exceptions::LoginError => e
-      vprint_error('Connection reset during login')
+      vprint_error("Error during login: #{e}")
+      return Msf::Exploit::CheckCode::Unknown
+    rescue Rex::Proto::SMB::Exceptions::ErrorCode, RubySMB::Error::RubySMBError => e
+      vprint_error(e.to_s)
       return Msf::Exploit::CheckCode::Unknown
     end
   end

--- a/modules/exploits/windows/smb/ms04_007_killbill.rb
+++ b/modules/exploits/windows/smb/ms04_007_killbill.rb
@@ -75,6 +75,8 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options [
       OptEnum.new('PROTO', [true, 'Which protocol to use', 'smb', %w[smb http]]),
     ]
+
+    deregister_options('SMB::ProtocolVersion')
   end
 
   # This exploit is too destructive to use during automated exploitation.

--- a/modules/exploits/windows/smb/ms04_011_lsass.rb
+++ b/modules/exploits/windows/smb/ms04_011_lsass.rb
@@ -68,11 +68,13 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'DefaultTarget'  => 0,
       'DisclosureDate' => 'Apr 13 2004'))
+
+    deregister_options('SMB::ProtocolVersion')
   end
 
   def exploit
 
-    connect()
+    connect(versions: [1])
     smb_login()
 
     handle = dcerpc_handle('3919286a-b10c-11d0-9ba8-00c04fd92ef5', '0.0', 'ncacn_np', ['\lsarpc'])

--- a/modules/exploits/windows/smb/ms06_025_rras.rb
+++ b/modules/exploits/windows/smb/ms06_025_rras.rb
@@ -55,6 +55,8 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         OptString.new('SMBPIPE', [ true,  "The pipe name to use (ROUTER, SRVSVC)", 'ROUTER']),
       ])
+
+    deregister_options('SMB::ProtocolVersion')
   end
 
   # Post authentication bugs are rarely useful during automation
@@ -64,7 +66,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
 
-    connect()
+    connect(versions: [1])
     smb_login()
 
     handle = dcerpc_handle('20610036-fa22-11cf-9823-00a0c911e5df', '1.0', 'ncacn_np', ["\\#{datastore['SMBPIPE']}"])

--- a/modules/exploits/windows/smb/ms06_040_netapi.rb
+++ b/modules/exploits/windows/smb/ms06_040_netapi.rb
@@ -96,11 +96,12 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('SMBPIPE', [ true,  "The pipe name to use (BROWSER, SRVSVC)", 'BROWSER']),
       ])
 
+    deregister_options('SMB::ProtocolVersion')
   end
 
   def exploit
 
-    connect()
+    connect(versions: [1])
     smb_login()
 
     mytarget = target

--- a/modules/exploits/windows/smb/ms06_070_wkssvc.rb
+++ b/modules/exploits/windows/smb/ms06_070_wkssvc.rb
@@ -75,11 +75,13 @@ class MetasploitModule < Msf::Exploit::Remote
         # NOTE: a valid domain name is required. See description.
         OptString.new('DOMAIN', [ true,  "The domain to validate prior to joining it."])
       ])
+
+    deregister_options('SMB::ProtocolVersion')
   end
 
   def exploit
 
-    connect()
+    connect(versions: [1])
     smb_login()
 
     mytarget = nil

--- a/modules/exploits/windows/smb/ms07_029_msdns_zonename.rb
+++ b/modules/exploits/windows/smb/ms07_029_msdns_zonename.rb
@@ -79,6 +79,8 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         OptString.new('Locale', [ true,  "Locale for automatic target (English, French, Italian, ...)", 'English'])
       ])
+
+    deregister_options('SMB::ProtocolVersion')
   end
 
 
@@ -96,7 +98,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
 
-    connect()
+    connect(versions: [1])
     smb_login()
 
     if target.name =~ /Automatic/

--- a/modules/exploits/windows/smb/ms08_067_netapi.rb
+++ b/modules/exploits/windows/smb/ms08_067_netapi.rb
@@ -751,6 +751,8 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         OptString.new('SMBPIPE', [true,  'The pipe name to use (BROWSER, SRVSVC)', 'BROWSER']),
       ])
+
+    deregister_options('SMB::ProtocolVersion')
   end
 
   #
@@ -837,7 +839,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     begin
-      connect
+      connect(versions: [1])
       smb_login
     rescue Rex::Proto::SMB::Exceptions::LoginError => e
       if e.message =~ /Connection reset/
@@ -1084,7 +1086,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     begin
-      connect
+      connect(versions: [1])
       smb_login
     rescue Rex::ConnectionError => e
       vprint_error("Connection failed: #{e.class}: #{e}")

--- a/modules/exploits/windows/smb/ms10_061_spoolss.rb
+++ b/modules/exploits/windows/smb/ms10_061_spoolss.rb
@@ -62,12 +62,14 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('SMBPIPE', [ false,  "The named pipe for the spooler service", "spoolss"]),
         OptString.new('PNAME',   [ false,  "The printer share name to use on the target" ]),
       ])
+
+    deregister_options('SMB::ProtocolVersion')
   end
 
 
   def exploit
 
-    connect()
+    connect(versions: [1])
     login_time = Time.now
     smb_login()
 

--- a/modules/exploits/windows/smb/ms17_010_eternalblue.rb
+++ b/modules/exploits/windows/smb/ms17_010_eternalblue.rb
@@ -337,7 +337,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def smb1_anonymous_connect_ipc
     sock = connect(false)
     dispatcher = RubySMB::Dispatcher::Socket.new(sock)
-    client = RubySMB::Client.new(dispatcher, smb1: true, smb2: false, username: smb_user, domain: smb_domain, password: smb_pass)
+    client = RubySMB::Client.new(dispatcher, smb1: true, smb2: false, smb3: false, username: smb_user, domain: smb_domain, password: smb_pass)
     response_code = client.login
 
     unless response_code == ::WindowsError::NTStatus::STATUS_SUCCESS
@@ -381,7 +381,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def smb1_free_hole(start)
     sock = connect(false)
     dispatcher = RubySMB::Dispatcher::Socket.new(sock)
-    client = RubySMB::Client.new(dispatcher, smb1: true, smb2: false, username: smb_user, domain: smb_domain, password: smb_pass)
+    client = RubySMB::Client.new(dispatcher, smb1: true, smb2: false, smb3: false, username: smb_user, domain: smb_domain, password: smb_pass)
     client.negotiate
 
     pkt = ''

--- a/modules/exploits/windows/smb/ms17_010_psexec.rb
+++ b/modules/exploits/windows/smb/ms17_010_psexec.rb
@@ -100,6 +100,8 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('PSH_PATH', [false, 'Path to powershell.exe', 'Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe']),
         OptString.new('SERVICE_STUB_ENCODER', [false, "Encoder to use around the service registering stub",nil])
       ])
+
+    deregister_options('SMB::ProtocolVersion')
   end
 
   def exploit

--- a/modules/exploits/windows/smb/netidentity_xtierrpcpipe.rb
+++ b/modules/exploits/windows/smb/netidentity_xtierrpcpipe.rb
@@ -51,6 +51,8 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('SMBUser', [ true, 'The username to authenticate as', 'metasploit']),
         OptString.new('SMBPass', [ true, 'The password for the specified username', 'metasploit'])
       ])
+
+    deregister_options('SMB::ProtocolVersion')
   end
 
   # don't bother with this module for autoexploitation, it creates
@@ -61,7 +63,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def mem_leak
     print_status("Connecting to the server...")
-    connect()
+    connect(versions: [1])
 
     print_status("Authenticating as user '#{datastore['SMBUser']}' with pass '#{datastore['SMBPass']}'...")
 
@@ -131,7 +133,7 @@ class MetasploitModule < Msf::Exploit::Remote
     sploit << rand_text_alpha_upper(110)
 
     print_status("Connecting to the server...")
-    connect()
+    connect(versions: [1])
 
     print_status("Authenticating as user '#{datastore['SMBUser']}' with pass '#{datastore['SMBPass']}'...")
 

--- a/modules/exploits/windows/smb/psexec.rb
+++ b/modules/exploits/windows/smb/psexec.rb
@@ -101,7 +101,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     print_status("Connecting to the server...")
-    connect(versions: [2,1])
+    connect
 
     print_status("Authenticating to #{smbhost} as user '#{splitname(datastore['SMBUser'])}'...")
     smb_login

--- a/modules/exploits/windows/smb/psexec_psh.rb
+++ b/modules/exploits/windows/smb/psexec_psh.rb
@@ -81,7 +81,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # Try and authenticate with given credentials
     if connect
       begin
-        connect(versions: [2,1])
+        connect
         smb_login
       rescue StandardError => autherror
         fail_with(Failure::NoAccess, "#{peer} - Unable to authenticate with given credentials: #{autherror}")

--- a/modules/exploits/windows/smb/smb_doublepulsar_rce.rb
+++ b/modules/exploits/windows/smb/smb_doublepulsar_rce.rb
@@ -85,6 +85,7 @@ class MetasploitModule < Msf::Exploit::Remote
       OptBool.new('DefangedMode',  [true, 'Run in defanged mode', true]),
       OptString.new('ProcessName', [true, 'Process to inject payload into', 'spoolsv.exe'])
     ])
+    deregister_options('SMB::ProtocolVersion')
   end
 
   OPCODES = {
@@ -234,7 +235,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def do_smb_setup_tree(ipc_share)
-    connect
+    connect(versions: [1])
 
     # logon as user \
     simple.login(datastore['SMBName'], datastore['SMBUser'], datastore['SMBPass'], datastore['SMBDomain'])

--- a/modules/exploits/windows/smb/timbuktu_plughntcommand_bof.rb
+++ b/modules/exploits/windows/smb/timbuktu_plughntcommand_bof.rb
@@ -63,13 +63,15 @@ class MetasploitModule < Msf::Exploit::Remote
       'Privileged'		=> true,
       'DisclosureDate'	=> 'Jun 25 2009',
       'DefaultTarget'	=> 0))
+
+    deregister_options('SMB::ProtocolVersion')
   end
 
 
   # we make two connections this code just wraps the process
   def smb_connection
 
-    connect()
+    connect(versions: [1])
     smb_login()
 
     print_status("Connecting to \\\\#{datastore['RHOST']}\\PlughNTCommand named pipe")

--- a/modules/exploits/windows/smb/webexec.rb
+++ b/modules/exploits/windows/smb/webexec.rb
@@ -98,7 +98,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     print_status("Connecting to the server...")
-    connect(versions: [2,1])
+    connect
 
     print_status("Authenticating to #{smbhost} as user '#{splitname(datastore['SMBUser'])}'...")
     smb_login


### PR DESCRIPTION
This adds SMBv3 support to Framework by including the latest changes to the `ruby_smb` library. ~~**It depends on [this PR](https://github.com/rapid7/ruby_smb/pull/154) to be merged.**~~
EDIT: The `ruby_smb` PR is merged now.

This also adds two new options for the SMB client:
- `SMB::ProtocolVersion`: One or a list of comma-separated SMB protocol versions to negotiate (e.g. "1" or "1,2" or "2,3,1")
- `SMB::AlwaysEncrypt`: Enforces encryption even if the server does not require it (SMB3.x only). Note that when it is set to false, the SMB client will still encrypt the communication if the server requires it

One of the biggest changes is that `ruby_smb` is now the default client, which means SMB versions 1, 2 and 3 are automatically negotiated, unless specified otherwise. Some modules still require `Rex` SMB client and were updated to force its use. As a consequence, these modules will only be able to use SMBv1.


## Verification Steps

### Windows target setup
- SMB2 support from Windows Vista and Server 2008.
- SMB3 support from Windows 8 and Windows Server 2012.
- Best to test against multiple Windows supporting different SMB versions.
- Note that encryption is only available with SMBv3.
- Setup at least one share folder and give an administrator user full permissions (you can also restrict permissions for testing access control)

To get the current configuration state of the SMB server, run this in Powershell:
```
Get-SmbServerConfiguration
```

To disable SMBv1, run this in an elevated Powershell:
```
Set-SmbServerConfiguration -EnableSMB1Protocol $false
```

To disable SMBv2 and SMBv3 (it is not possible to disable one separately), run this in an elevated Powershell:
```
Set-SmbServerConfiguration -EnableSMB2Protocol $false
```

Change `$false` to `$true` to re-enable the protocol versions using the same Powershell command.

To require encryption on the server (SMB3), run this in an elevated Powershell:
```
C:\> Set-SmbServerConfiguration -EncryptData $true
```

To enable per-share encryption on the server (SMB3), run this in an elevated Powershell:
```
C:\ Set-SmbServerConfiguration -EncryptData $false
C:\ Set-SmbShare -Name <share name> -EncryptData 1
```

### Samba target setup
The easiest way is to use docker and [dperson/samba](https://github.com/dperson/samba).
The following command will create and start a container running on ports 139 and 445, with user `smbuser` (password `123456`) and with a share called `home` (sharing local path `/share`). Note that `-S` will disable SMB2 minimum version, which means SMB1 will be available. Remove it if you don't want SMB1 support.
```
docker run --name samba_container --rm -it -p 139:139 -p 445:445 -d dperson/samba -p -u 'smbuser;123456' -s 'home;/share' -S
```

### Monitoring setup
I recommend using Wireshark filtering port 139 and 445 with displaying only SMB packets:
- Capture filter: `tcp port 445 || tcp port 139`
- Display filter: `smb||smb2`

Also, open a separate terminal to check the logs:
```
tail -f ~/.msf4/logs/framework.log
```

### Tests
Example with `modules/auxiliary/scanner/smb/smb_enumusers` module.

```
msf5 > use modules/auxiliary/scanner/smb/smb_enumusers
msf5 auxiliary(scanner/smb/smb_enumusers) > set SMBUser smbtest
SMBUser => smbtest
msf5 auxiliary(scanner/smb/smb_enumusers) > set SMBPass 123456
SMBPass => 123456
msf5 auxiliary(scanner/smb/smb_enumusers) > set verbose true
verbose => true
msf5 auxiliary(scanner/smb/smb_enumusers) > set RHOSTS 172.16.60.218
RHOSTS => 172.16.60.218
msf5 auxiliary(scanner/smb/smb_enumusers) > show options

Module options (auxiliary/scanner/smb/smb_enumusers):

   Name          Current Setting  Required  Description
   ----          ---------------  --------  -----------
   DB_ALL_USERS  false            no        Add all enumerated usernames to the database
   RHOSTS        172.16.60.218    yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
   SMBDomain     .                no        The Windows domain to use for authentication
   SMBPass       123456           no        The password for the specified username
   SMBUser       smbtest          no        The username to authenticate as
   THREADS       1                yes       The number of concurrent threads (max one per host)

msf5 auxiliary(scanner/smb/smb_enumusers) > run

[+] 172.16.60.218:445     - WIN-POFO2P6ER44 [ Administrator, DefaultAccount, Guest, user11, smbtest, sqltest ] ( LockoutTries=0 PasswordMin=0 )
[*] 172.16.60.218:        - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

Verify the SMB version that has been negotiated in the logs:
```
[05/29/2020 12:25:00] [d(0)] core: SMB version(s) to negotiate: [1, 2, 3]
[05/29/2020 12:25:00] [d(0)] core: Negotiated SMB version: SMB3
```
In this case, the client asked for version 1, 2 or 3 and the server picked SMBv3. The communication should be encrypted by default. You can verify this in a Wireshark:
```
No.	Time	Stream	Source	Src port	Destination	Dst port	Protocol	Length	Info	SMB dialect
38	95.942267	3	172.16.60.1	65451	172.16.60.218	445	SMB	139	Negotiate Protocol Request	NT LM 0.12,SMB 2.002,SMB 2.???
39	95.942637	3	172.16.60.218	445	172.16.60.1	65451	SMB2	240	Negotiate Protocol Response	SMB2 wildcard
41	95.951575	3	172.16.60.1	65451	172.16.60.218	445	SMB2	270	Negotiate Protocol Request	SMB 2.0.2,SMB 2.1,SMB 3.0,SMB 3.0.2,SMB 3.1.1
42	95.951969	3	172.16.60.218	445	172.16.60.1	65451	SMB2	306	Negotiate Protocol Response	SMB 3.1.1
44	95.957149	3	172.16.60.1	65451	172.16.60.218	445	SMB2	236	Session Setup Request, NTLMSSP_NEGOTIATE	
45	95.957496	3	172.16.60.218	445	172.16.60.1	65451	SMB2	413	Session Setup Response, Error: STATUS_MORE_PROCESSING_REQUIRED, NTLMSSP_CHALLENGE	
47	95.960708	3	172.16.60.1	65451	172.16.60.218	445	SMB2	516	Session Setup Request, NTLMSSP_AUTH, User: .\smbtest	
49	95.977647	3	172.16.60.218	445	172.16.60.1	65451	SMB2	151	Session Setup Response	
51	95.982281	3	172.16.60.1	65451	172.16.60.218	445	SMB2	234	Encrypted SMB3	
52	95.986995	3	172.16.60.218	445	172.16.60.1	65451	SMB2	202	Encrypted SMB3	
54	95.993498	3	172.16.60.1	65451	172.16.60.218	445	SMB2	254	Encrypted SMB3	
55	95.999835	3	172.16.60.218	445	172.16.60.1	65451	SMB2	274	Encrypted SMB3	
...
```
Note that encryption should occur only after the session setup.

You can test the two new options (when available):
- Test SMBv1 only:
  ```
  msf5 auxiliary(scanner/smb/smb_enumusers) > set SMB::ProtocolVersion 1
  ```
- Verify the log shows the correct version:
  ```
  [05/29/2020 12:32:14] [d(0)] core: SMB version(s) to negotiate: [1]
  [05/29/2020 12:32:14] [d(0)] core: Negotiated SMB version: SMB1
  ```
- Verify the packet capture shows only SMB1 packets.
- Test SMBv1 and SMBv2:
  ```
  msf5 auxiliary(scanner/smb/smb_enumusers) > set SMB::ProtocolVersion 1,2
  ```
- Verify the log shows the correct version:
  ```
  [05/29/2020 12:36:02] [d(0)] core: SMB version(s) to negotiate: [1, 2]
  [05/29/2020 12:36:02] [d(0)] core: Negotiated SMB version: SMB2
  ```
- Verify the packet capture shows only SMB2 packets.

- Disable SMB2 (see **Windows target setup**) and re-run the test.
- Verify the log shows the correct version:
  ```
  [05/29/2020 12:38:02] [d(0)] core: SMB version(s) to negotiate: [1, 2]
  [05/29/2020 12:38:02] [d(0)] core: Negotiated SMB version: SMB1
  ```
- Verify the packet capture shows only SMB1 packets.
- Try other combinations
- Test SMB3 without encryption (SMB3 and encryption should be enabled on the server):
  ```
  msf5 auxiliary(scanner/smb/smb_enumusers) > set SMB::ProtocolVersion 1,2,3
  SMB::ProtocolVersion => 1,2,3
  msf5 auxiliary(scanner/smb/smb_enumusers) > set SMB::AlwaysEncrypt false
  SMB::AlwaysEncrypt => false
  ```
- Verify the SMB version that has been negotiated in the logs:
  ```
  [05/29/2020 12:25:00] [d(0)] core: SMB version(s) to negotiate: [1, 2, 3]
  [05/29/2020 12:25:00] [d(0)] core: Negotiated SMB version: SMB3
  ```
- Verify the packet capture shows only SMB3 packets without encryption.