### PR TITLE
Update msf json rpc framework path to be relative

### DIFF
--- a/msf-json-rpc.ru
+++ b/msf-json-rpc.ru
@@ -4,7 +4,7 @@
 #
 
 require 'pathname'
-@framework_path = '.'
+@framework_path = File.expand_path(File.dirname(__FILE__))
 root = Pathname.new(@framework_path).expand_path
 @framework_lib_path = root.join('lib')
 $LOAD_PATH << @framework_lib_path unless $LOAD_PATH.include?(@framework_lib_path)


### PR DESCRIPTION
### Before

When running msf-json-rpc from a folder other than `metasploit-framework`, it results in the following error:

```
$ thin --rackup metasploit-framework/msf-json-rpc.ru --address localhost --port 8081 --environment development --tag msf-json-rpc --debug start 
Traceback (most recent call last):
	17: from /Users/user/.rvm/gems/ruby-2.6.5/bin/ruby_executable_hooks:24:in `<main>'
	16: from /Users/user/.rvm/gems/ruby-2.6.5/bin/ruby_executable_hooks:24:in `eval'
	15: from /Users/user/.rvm/gems/ruby-2.6.5/bin/thin:23:in `<main>'
	14: from /Users/user/.rvm/gems/ruby-2.6.5/bin/thin:23:in `load'
	13: from /Users/user/.rvm/gems/ruby-2.6.5/gems/thin-1.7.2/bin/thin:6:in `<top (required)>'
	12: from /Users/user/.rvm/gems/ruby-2.6.5/gems/thin-1.7.2/lib/thin/runner.rb:159:in `run!'
	11: from /Users/user/.rvm/gems/ruby-2.6.5/gems/thin-1.7.2/lib/thin/runner.rb:203:in `run_command'
	10: from /Users/user/.rvm/gems/ruby-2.6.5/gems/thin-1.7.2/lib/thin/controllers/controller.rb:72:in `start'
	 9: from /Users/user/.rvm/gems/ruby-2.6.5/gems/thin-1.7.2/lib/thin/controllers/controller.rb:182:in `load_rackup_config'
	 8: from /Users/user/.rvm/gems/ruby-2.6.5/gems/thin-1.7.2/lib/rack/adapter/loader.rb:33:in `load'
	 7: from /Users/user/.rvm/gems/ruby-2.6.5/gems/thin-1.7.2/lib/rack/adapter/loader.rb:33:in `eval'
	 6: from metasploit-framework/msf-json-rpc.ru:1:in `<main>'
	 5: from metasploit-framework/msf-json-rpc.ru:1:in `new'
	 4: from /Users/user/.rvm/gems/ruby-2.6.5/gems/rack-2.2.2/lib/rack/builder.rb:125:in `initialize'
	 3: from /Users/user/.rvm/gems/ruby-2.6.5/gems/rack-2.2.2/lib/rack/builder.rb:125:in `instance_eval'
	 2: from metasploit-framework/msf-json-rpc.ru:12:in `block in <main>'
	 1: from /Users/user/.rvm/rubies/ruby-2.6.5/lib/ruby/site_ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'
/Users/user/.rvm/rubies/ruby-2.6.5/lib/ruby/site_ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require': cannot load such file -- msfenv (LoadError)
```

### After

The `framework_path` is calculated based on the location of `msf-json-rpc.ru`, and no longer results in an error:

```
$ thin --rackup metasploit-framework/msf-json-rpc.ru --address localhost --port 8081 --environment development --tag msf-json-rpc --debug start 
Thin web server (v1.7.2 codename Bachmanity)
Debugging ON
Maximum connections set to 1024
Listening on localhost:8081, CTRL+C to stop
```

## Verification

List the steps needed to make sure this thing works

- [x] **Verify** `msf-json-rpc` can be called from an arbitrary directory
- [x] **Verify** `msf-json-rpc` can be called from the main framework directory
- [x] **Verify** the existing rpcd hasn't changed functionality, I believe: `bundle exec ruby ./msfrpcd -j -f -p 8080 -U msfuser -P msfpassword -a 0.0.0.0`

