### PR TITLE
Fix regression in psexec mixing filename and encoder

### DIFF
--- a/lib/msf/core/exploit/smb/client/psexec.rb
+++ b/lib/msf/core/exploit/smb/client/psexec.rb
@@ -392,7 +392,7 @@ module Exploit::Remote::SMB::Client::Psexec
     begin
       simple.connect("\\\\#{r_ip}\\#{smb_share}")
     rescue Rex::Proto::SMB::Exceptions::ErrorCode => accesserror
-      print_status("Unable to get handle: #{accesserror}")
+      print_error("Unable to get handle: #{accesserror}")
       return false
     end
     files.each do |file|
@@ -401,7 +401,7 @@ module Exploit::Remote::SMB::Client::Psexec
         fd = smb_open(file, 'rwo')
         fd.close
       rescue Rex::Proto::SMB::Exceptions::ErrorCode => accesserror
-        print_status("Unable to get handle: #{accesserror}")
+        print_error("Unable to get handle: #{accesserror}")
         return false
       end
       simple.disconnect("\\\\#{r_ip}\\#{smb_share}")

--- a/lib/msf/core/exploit/smb/client/psexec.rb
+++ b/lib/msf/core/exploit/smb/client/psexec.rb
@@ -269,10 +269,7 @@ module Exploit::Remote::SMB::Client::Psexec
     end
   end
 
-  def native_upload(smb_share)
-    filename = "#{Rex::Text.rand_text_alpha(8)}.exe"
-    serviceencoder = ''
-
+  def native_upload(smb_share, filename, service_encoder)
     # Upload the shellcode to a file
     print_status("Uploading payload... #{filename}")
     smbshare = smb_share
@@ -293,7 +290,7 @@ module Exploit::Remote::SMB::Client::Psexec
       fd = smb_open("#{filename}", 'rwct', write: true)
     end
     exe = ''
-    opts = { :servicename => service_name, :serviceencoder => serviceencoder}
+    opts = { :servicename => service_name, :serviceencoder => service_encoder}
     begin
       exe = generate_payload_exe_service(opts)
 

--- a/modules/exploits/windows/smb/ms17_010_psexec.rb
+++ b/modules/exploits/windows/smb/ms17_010_psexec.rb
@@ -128,6 +128,9 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def smb_pwn()
+    service_filename = datastore['SERVICE_FILENAME'] || Rex::Text.rand_text_alpha(8) + ".exe"
+    service_encoder = datastore['SERVICE_STUB_ENCODER'] || ''
+
     case target.name
     when 'Automatic'
       if powershell_installed?(datastore['SHARE'], datastore['PSH_PATH'])
@@ -135,12 +138,12 @@ class MetasploitModule < Msf::Exploit::Remote
         execute_powershell_payload
       else
         print_status('Selecting native target')
-        native_upload(datastore['SHARE'])
+        native_upload(datastore['SHARE'], service_filename, service_encoder)
       end
     when 'PowerShell'
       execute_powershell_payload
     when 'Native upload'
-      native_upload(datastore['SHARE'])
+      native_upload(datastore['SHARE'], service_filename, service_encoder)
     when 'MOF upload'
       mof_upload(datastore['SHARE'])
     end

--- a/modules/exploits/windows/smb/ms17_010_psexec.rb
+++ b/modules/exploits/windows/smb/ms17_010_psexec.rb
@@ -127,8 +127,8 @@ class MetasploitModule < Msf::Exploit::Remote
     end
   end
 
-  def smb_pwn()
-    service_filename = datastore['SERVICE_FILENAME'] || Rex::Text.rand_text_alpha(8) + ".exe"
+  def smb_pwn
+    service_filename = datastore['SERVICE_FILENAME'] || "#{rand_text_alpha(8)}.exe"
     service_encoder = datastore['SERVICE_STUB_ENCODER'] || ''
 
     case target.name

--- a/modules/exploits/windows/smb/psexec.rb
+++ b/modules/exploits/windows/smb/psexec.rb
@@ -87,7 +87,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def native_upload_with_workaround
-    service_filename = datastore['SERVICE_FILENAME'] || Rex::Text.rand_text_alpha(8) + ".exe"
+    service_filename = datastore['SERVICE_FILENAME'] || "#{rand_text_alpha(8)}.exe"
     service_encoder = datastore['SERVICE_STUB_ENCODER'] || ''
 
     # Avoid implementing NTLMSSP on Windows XP

--- a/modules/exploits/windows/smb/psexec.rb
+++ b/modules/exploits/windows/smb/psexec.rb
@@ -87,13 +87,16 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def native_upload_with_workaround
+    service_filename = datastore['SERVICE_FILENAME'] || Rex::Text.rand_text_alpha(8) + ".exe"
+    service_encoder = datastore['SERVICE_STUB_ENCODER'] || ''
+
     # Avoid implementing NTLMSSP on Windows XP
     # https://seclists.org/metasploit/2009/q1/6
     if smb_peer_os == "Windows 5.1"
       connect(versions: [1])
       smb_login
     end
-    native_upload(datastore['SHARE'])
+    native_upload(datastore['SHARE'], service_filename, service_encoder)
   end
 
   def exploit


### PR DESCRIPTION
Closes #13407

Fixes regressions in psexec mixin, two parameters were ignored:
* `SERVICE_FILENAME`
* `SERVICE_STUB_ENCODER`

I added those two as parameters to `native_upload` as suggested by @jmartin-r7 and @Auxilus -> https://github.com/rapid7/metasploit-framework/issues/13407#issuecomment-625341902
I also could have added to the mixin, but they're only relevant with native upload and not other, for example they aren't used by psexec_command modules.

## Verification

* See before how the SERVICE_FILENAME was ignored:
![image](https://user-images.githubusercontent.com/550823/81616768-67b58f80-93e4-11ea-9996-abc00f740000.png)
![image](https://user-images.githubusercontent.com/550823/81616784-6f753400-93e4-11ea-96c5-4e75f8439682.png)

* And after:
![image](https://user-images.githubusercontent.com/550823/81617009-e3afd780-93e4-11ea-8526-cf50c1314c41.png)
![image](https://user-images.githubusercontent.com/550823/81617014-e5799b00-93e4-11ea-9aa2-f7077843394f.png)

The SERVICE_STUB_ENCODER effect isn't directly visible.
However we can use a bug #13435 to make it visible
* Before: no error when choosing an invalid encoder (meaning it was ignored)
![image](https://user-images.githubusercontent.com/550823/81617273-6a64b480-93e5-11ea-9f5a-58160a607baa.png)

* After: we get an error so it was taken into account:
![image](https://user-images.githubusercontent.com/550823/81617293-72bcef80-93e5-11ea-963f-c60006454db3.png)


- [ ] Start `msfconsole`
- [ ] `use use exploit/windows/smb/psexec`
- [ ] set login/pwd/rhost as you'd like
- [ ] `set target 2` (native upload)
- [ ] `set SERVICE_FILENAME test1.exe`
- [ ] **Verify** that the created file is indeed "test1.exe"

- [ ] **Please test** with module ms17_010_psexec as I don't have a target with me (but the code should be good :))