### PR TITLE
Fix winrm_login module

### DIFF
--- a/lib/metasploit/framework/login_scanner/http.rb
+++ b/lib/metasploit/framework/login_scanner/http.rb
@@ -261,8 +261,10 @@ module Metasploit
         #
         # @param credential [Credential] The credential object to attempt to
         #   login with.
+        # @param success_codes [Array] The HTTP codes that indicate login success
+        #
         # @return [Result] A Result object indicating success or failure
-        def attempt_login(credential)
+        def attempt_login(credential, success_codes=[200])
           result_opts = {
             credential: credential,
             status: Metasploit::Model::Login::Status::INCORRECT,
@@ -280,7 +282,7 @@ module Metasploit
 
           begin
             response = send_request('credential'=>credential, 'uri'=>uri, 'method'=>method)
-            if response && response.code == 200
+            if response && success_codes.any?{|code| response.code == code}
               result_opts.merge!(status: Metasploit::Model::Login::Status::SUCCESSFUL, proof: response.headers)
             end
           rescue Rex::ConnectionError => e

--- a/lib/metasploit/framework/login_scanner/http.rb
+++ b/lib/metasploit/framework/login_scanner/http.rb
@@ -282,7 +282,7 @@ module Metasploit
 
           begin
             response = send_request('credential'=>credential, 'uri'=>uri, 'method'=>method)
-            if response && success_codes.any?{|code| response.code == code}
+            if response && success_codes.include?(response.code)
               result_opts.merge!(status: Metasploit::Model::Login::Status::SUCCESSFUL, proof: response.headers)
             end
           rescue Rex::ConnectionError => e

--- a/lib/metasploit/framework/login_scanner/http.rb
+++ b/lib/metasploit/framework/login_scanner/http.rb
@@ -261,10 +261,9 @@ module Metasploit
         #
         # @param credential [Credential] The credential object to attempt to
         #   login with.
-        # @param success_codes [Array] The HTTP codes that indicate login success
         #
         # @return [Result] A Result object indicating success or failure
-        def attempt_login(credential, success_codes=[200])
+        def attempt_login(credential)
           result_opts = {
             credential: credential,
             status: Metasploit::Model::Login::Status::INCORRECT,
@@ -282,7 +281,7 @@ module Metasploit
 
           begin
             response = send_request('credential'=>credential, 'uri'=>uri, 'method'=>method)
-            if response && success_codes.include?(response.code)
+            if response && response.code == 200
               result_opts.merge!(status: Metasploit::Model::Login::Status::SUCCESSFUL, proof: response.headers)
             end
           rescue Rex::ConnectionError => e

--- a/lib/metasploit/framework/login_scanner/winrm.rb
+++ b/lib/metasploit/framework/login_scanner/winrm.rb
@@ -38,7 +38,11 @@ module Metasploit
 
           super
         end
-
+		
+		def attempt_login(credential)
+          # call the attempt_login method of HTTP, but accept "411 Length Required" as a success code
+          super(credential, [200, 411]);
+		end
         # The method *must* be "POST", so don't let the user change it
         # @raise [RuntimeError] Unconditionally
         def method=(_)

--- a/lib/metasploit/framework/login_scanner/winrm.rb
+++ b/lib/metasploit/framework/login_scanner/winrm.rb
@@ -39,10 +39,10 @@ module Metasploit
           super
         end
 		
-		def attempt_login(credential)
+        def attempt_login(credential)
           # call the attempt_login method of HTTP, but accept "411 Length Required" as a success code
           super(credential, [200, 411]);
-		end
+        end
         # The method *must* be "POST", so don't let the user change it
         # @raise [RuntimeError] Unconditionally
         def method=(_)

--- a/lib/metasploit/framework/login_scanner/winrm.rb
+++ b/lib/metasploit/framework/login_scanner/winrm.rb
@@ -38,17 +38,27 @@ module Metasploit
 
           super
         end
-		
-        def attempt_login(credential)
-          # call the attempt_login method of HTTP, but accept "411 Length Required" as a success code
-          super(credential, [200, 411]);
+
+        # send an HTTP request that WinRM would consider as 
+        def send_request(opts)
+            opts['headers'] ||= { }
+            opts['ctype'] = 'application/soap+xml;charset=UTF-8'
+            opts['data'] = wsman_identity_request
+            opts['headers']['Content-Length'] = opts['data'].length
+            super
         end
+
         # The method *must* be "POST", so don't let the user change it
         # @raise [RuntimeError] Unconditionally
         def method=(_)
           raise RuntimeError, "Method must be POST for WinRM"
         end
 
+        private
+
+        def wsman_identity_request
+          %Q{<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope" xmlns:wsmid="http://schemas.dmtf.org/wbem/wsman/identity/1/wsmanidentity.xsd"><s:Header/><s:Body><wsmid:Identify/></s:Body></s:Envelope>}
+        end
       end
     end
   end

--- a/lib/metasploit/framework/login_scanner/winrm.rb
+++ b/lib/metasploit/framework/login_scanner/winrm.rb
@@ -39,7 +39,7 @@ module Metasploit
           super
         end
 
-        # send an HTTP request that WinRM would consider as 
+        # send an HTTP request that WinRM would consider as valid  (SOAP XML in the message matching the XML schema definition)
         def send_request(opts)
             opts['headers'] ||= { }
             opts['ctype'] = 'application/soap+xml;charset=UTF-8'


### PR DESCRIPTION
## The bug

The issue was reported by a few users here [here](https://github.com/rapid7/metasploit-framework/issues/6398#issuecomment-508536604), I tried running Wireshark to troubleshoot the problem, and noticed that the issue seems to be coming from the Content-Length being 0, on successful login, the server returns (HTTP 411 - Length Required) and not (200 OK).

The issue is closed, but it's still not working as tested (on Windows 7 x64 and Windows 8)

## My workaround
 
In the `HTTP` login scanner, I added an argument `success_codes`, which is an array of HTTP codes that indicate login success, with a default value of `[200]`, from the `winrm` login scanner, I made an override on the method, to indicate that `411` also denotes success in the case of WinRM.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use auxiliary/windows/winrm/winrm_login`
- [ ] ... (set parameters like wordlists etc.)
- [ ] `run`
- [ ] **Check if it reports the correct credentials as correct**

## First PR

This is my first pull-request to the project, any feedback is welcome, if it would be better to find another workaround, craft requests that yield a response code of `200 OK`, feel free to comment below. (I didn't check the details of the protocol specifications of `WinRM`)