### PR TITLE
Fix following redirects from send_request_cgi!

### DIFF
--- a/lib/msf/core/exploit/http/client.rb
+++ b/lib/msf/core/exploit/http/client.rb
@@ -410,11 +410,18 @@ module Exploit::Remote::HttpClient
     location = res.redirection
 
     if location.relative?
-      parent_path = File.dirname(opts['uri'].to_s)
-      parent_path = '/' if parent_path == '.'
-      new_redirect_uri = normalize_uri(parent_path, location.path.gsub(/^\./, ''))
-      opts['redirect_uri'] = new_redirect_uri
-      opts['uri'] = new_redirect_uri
+      if location.path.start_with?('/')
+        # path starting with /, not relative to the current path, but starts from the root
+        opts['redirect_uri'] = location.path
+        opts['uri'] = location.path
+      else
+        parent_path = File.dirname(opts['uri'].to_s)
+        parent_path = '/' if parent_path == '.'
+        new_redirect_uri = normalize_uri(parent_path, location.path.gsub(/^\./, ''))
+        opts['redirect_uri'] = new_redirect_uri
+        opts['uri'] = new_redirect_uri
+      end
+      
       opts['rhost'] = datastore['RHOST']
       opts['vhost'] = opts['vhost'] || opts['rhost'] || self.vhost()
       opts['rport'] = datastore['RPORT']


### PR DESCRIPTION
closes #13092 

## Verification

Run the `send_request_cgi!` method of `Msf::Exploit::Remote::HttpClient`, with a non-zero redirect depth, where the Location header starts with `/`, it will no longer start the path from the parent directory of the current server URI, will start from the web root instead.

