### PR TITLE
Bump Rails version constraint to '~> 4.2.11'

### DIFF
--- a/lib/metasploit/framework/rails_version_constraint.rb
+++ b/lib/metasploit/framework/rails_version_constraint.rb
@@ -4,8 +4,8 @@ module Metasploit
   module Framework
     module RailsVersionConstraint
 
-      # The Metasploit ecosystem is not yet ready for Rails 4.1:
-      RAILS_VERSION =  '~> 4.2.6'
+      # The Metasploit ecosystem is not yet ready for 2020:
+      RAILS_VERSION = '~> 4.2.11'
     end
   end
 end


### PR DESCRIPTION
#13175

I have no idea what this breaks. `bundle install` still works and I can get a session.