### PR TITLE
Prioritise incomplete packets in the dispatch loop

### DIFF
--- a/lib/rex/post/meterpreter/packet_dispatcher.rb
+++ b/lib/rex/post/meterpreter/packet_dispatcher.rb
@@ -290,8 +290,11 @@ module PacketDispatcher
 
     self.waiters = []
 
-    @pqueue = ::Queue.new
-    @iqueue = ::Queue.new
+    # This queue is where the new incoming packets end up
+    @new_packet_queue = ::Queue.new
+    # This is where we put packets that aren't new, but haven't
+    # yet been handled.
+    @incomplete_queue = ::Queue.new
     @ping_sent = false
 
     # Spawn a thread for receiving packets
@@ -301,8 +304,9 @@ module PacketDispatcher
           rv = Rex::ThreadSafe.select([ self.sock.fd ], nil, nil, PING_TIME)
           if rv
             packet = receive_packet
-            @pqueue << decrypt_inbound_packet(packet) if packet
-          elsif self.send_keepalives && @pqueue.empty?
+            # Always enqueue the new packets onto the new packet queue
+            @new_packet_queue << decrypt_inbound_packet(packet) if packet
+          elsif self.send_keepalives && @new_packet_queue.empty?
             keepalive
           end
         rescue ::Exception => e
@@ -318,21 +322,34 @@ module PacketDispatcher
     self.dispatcher_thread = Rex::ThreadFactory.spawn("MeterpreterDispatcher", false) do
       begin
       while (self.alive)
+        # This is where we'll store incomplete packets on
+        # THIS iteration
         incomplete = []
+        # The backlog is the full list of packets that aims
+        # to be handled this iteration
         backlog    = []
 
-        # prioritise existing/incomplete packets
-        while @iqueue.length > 0
-          backlog << @iqueue.pop
+        # If we have any left over packets from the previous
+        # iteration, we need to prioritise them over the new
+        # packets. If we don't do this, then we end up in
+        # situations where data on channels can be processed
+        # out of order. We don't do a blocking wait here via
+        # the .pop method because we don't want to block, we
+        # just want to dump the queue.
+        while @incomplete_queue.length > 0
+          backlog << @incomplete_queue.pop
         end
 
-
-        # Perform a blocking wait via Queue.pop if we don't have any
-        # left over packets to handle.
-        backlog << @pqueue.pop if backlog.length == 0
-        # When we get here, always clear the incoming queue.
-        while @pqueue.length > 0
-          backlog << @pqueue.pop
+        # If the backlog is empty, we don't have old/stale
+        # packets hanging around, so perform a blocking wait
+        # for the next packet
+        backlog << @new_packet_queue.pop if backlog.length == 0
+        # At this point we either received a packet off the wire
+        # or we had a backlog to process. In either case, we
+        # perform a non-blocking queue dump to fill the backlog
+        # with every packet we have.
+        while @new_packet_queue.length > 0
+          backlog << @new_packet_queue.pop
         end
 
         #
@@ -388,7 +405,7 @@ module PacketDispatcher
         # If the backlog and incomplete arrays are the same, it means
         # dispatch_inbound_packet wasn't able to handle any of the
         # packets. When that's the case, we can get into a situation
-        # where @pqueue is not empty and, since nothing else bounds this
+        # where @new_packet_queue is not empty and, since nothing else bounds this
         # loop, we spin CPU trying to handle packets that can't be
         # handled. Sleep here to treat that situation as though the
         # queue is empty.
@@ -396,14 +413,19 @@ module PacketDispatcher
           ::IO.select(nil, nil, nil, 0.10)
         end
 
+        # If we have any packets that weren't handled, they go back
+        # on the incomplete queue so that they're prioritised over
+        # new packets that are coming in off the wire.
         while incomplete.length > 0
-          @iqueue << incomplete.shift
+          @incomplete_queue << incomplete.shift
         end
 
-        if(@iqueue.length > 100)
+        # If the old queue of packets gets too big...
+        if(@incomplete_queue.length > 100)
           removed = []
+          # Drop a bunch of them.
           (1..25).each {
-            removed << @iqueue.pop
+            removed << @incomplete_queue.pop
           }
           dlog("Backlog has grown to over 100 in monitor_socket, dropping older packets: #{removed.map{|x| x.inspect}.join(" - ")}", 'meterpreter', LEV_1)
         end

--- a/lib/rex/post/meterpreter/packet_dispatcher.rb
+++ b/lib/rex/post/meterpreter/packet_dispatcher.rb
@@ -322,10 +322,8 @@ module PacketDispatcher
         backlog    = []
 
         # prioritise existing/incomplete packets
-        if @iqueue.length > 0
-          while @iqueue.length > 0
-            backlog << @iqueue.pop
-          end
+        while @iqueue.length > 0
+          backlog << @iqueue.pop
         end
 
 
@@ -405,7 +403,7 @@ module PacketDispatcher
         if(@iqueue.length > 100)
           removed = []
           (1..25).each {
-            removed << @pqueue.pop
+            removed << @iqueue.pop
           }
           dlog("Backlog has grown to over 100 in monitor_socket, dropping older packets: #{removed.map{|x| x.inspect}.join(" - ")}", 'meterpreter', LEV_1)
         end


### PR DESCRIPTION
# Introduction

RIP my evening. It's 2am and I just managed to fix this. I hope tomorrow's coffee is going to be good or my family are going to hate me.

# Description

Packet dispatching on TCP sockets is a quirky beast. Due to the speed at which the packets come in, we often find ourselves in the position where data comes in on channels before an appropriate packet handler is registered with the framework. A sample scenario is that we can create a TCP client channel, and data gets passed back through the socket in a `core_channel_write` message before the TCP client instance has finished being wired in.

In this scenario, the packet isn't able to be appropriately handled, and the dispatch mechanism attempts to handle this case by re-queuing any packets that weren't handled. There was a slight flaw with this implementation.

When a packet is received is put on a queue called `@pqueue` on a receiver thread. Meanwhile, a processing thread is waiting for packets to arrive on that very same queue. When a packet finally arrives, the processing thread's call to `@pqueue.pop` finally returns and the packet handlers are invoked. When the handlers all fail, because nothing is read to handle the packet yet, the processing thread puts the packet back on the queue via `@pqueue << incomplete.shift`, where `incomplete` is a list of packets that weren't handled.

This all works fine until the _receiver_ thread calls `@pqueue << packet` as a result of a new packet arriving on the socket **before the incomplete packet is re-queued**. If this happens then packet `B` is put in `@pqueue` on the receiver thread, then packet `A` is re-queued on `@pqueue` on the processing thread. The next iteration of processing results in `B` being handled before `A`, and hence we have packets being processed out of order. This is a big problem, especially for things like TCP socket channels!

This PR implements an extra queue, called `@iqueue` (for "incomplete" queue). Packets that are marked as incomplete end up on this queue. When the next round of processing occurs, this queue is emptied before the `@pqueue` instance is. This maintains the order of packets, and hence the sequencing problem goes away.

**This is important** and hence I would appreciate this being looked at and landed as quickly as possible.

# Verification

- [ ] Basically go through the steps shown in #7403 and you'll see it's no longer a problem!

# Sample Run

![image](https://user-images.githubusercontent.com/28896/82071485-7d46f400-9719-11ea-9b92-1d91cf668d32.png)

# Conclusion

I'm going to bed.

![download](https://user-images.githubusercontent.com/28896/82072545-3bb74880-971b-11ea-9c02-d5a0700a35b9.gif)

Fixes #7403