### PR TITLE
Fix memcached extractor issue 12884

### DIFF
--- a/modules/auxiliary/gather/memcached_extractor.rb
+++ b/modules/auxiliary/gather/memcached_extractor.rb
@@ -58,8 +58,8 @@ class MetasploitModule < Msf::Auxiliary
         sock.send("stats cachedump #{sid} #{max_keys}\r\n", 0)
         data = sock.recv(4096)
         break if !data || data.length == 0
-        matches = /^ITEM (?<key>.*) \[/.match(data)
-        keys << matches[:key] if matches
+        matches = data.scan(/^ITEM (?<key>.*) \[/)
+        keys = keys + matches.flatten! if matches
         break if data =~ /^END/
       end
     end

--- a/modules/auxiliary/gather/memcached_extractor.rb
+++ b/modules/auxiliary/gather/memcached_extractor.rb
@@ -86,7 +86,7 @@ class MetasploitModule < Msf::Auxiliary
     sock.send("lru_crawler metadump all\r\n", 0)
     loop do
       data = sock.recv(4096)
-      break if !data || data.length == 0
+      break if !data || data.length == 0 || data == "END\r\n"
       matches = data.scan(/^key=(?<key>.*) exp=/)
       keys = keys + matches.flatten! if matches
       break if data =~ /^END/

--- a/modules/auxiliary/gather/memcached_extractor.rb
+++ b/modules/auxiliary/gather/memcached_extractor.rb
@@ -81,6 +81,20 @@ class MetasploitModule < Msf::Auxiliary
     slab_ids.uniq! || []
   end
 
+  def enumerate_keys_lru
+    keys = []
+    sock.send("lru_crawler metadump all\r\n", 0)
+    loop do
+      data = sock.recv(4096)
+      break if !data || data.length == 0
+      matches = data.scan(/^key=(?<key>.*) exp=/)
+      keys = keys + matches.flatten! if matches
+      break if data =~ /^END/
+      data = ''
+    end
+    keys
+  end
+
   def data_for_keys(keys = [])
     all_data = {}
     keys.each do |key|
@@ -114,6 +128,12 @@ class MetasploitModule < Msf::Auxiliary
       connect
       if (version = determine_version)
         vprint_good("Connected to memcached version #{version}")
+        if (Gem::Version.new(version) >= Gem::Version.new('1.5.4'))
+          command_string = "lru_crawler"
+        else
+          command_string = 'cachedump'
+        end
+        vprint_status("Using #{command_string} to enumerate keys")
         unless localhost?(ip)
           report_service(
             host: ip,
@@ -127,7 +147,11 @@ class MetasploitModule < Msf::Auxiliary
         print_error("unable to determine memcached protocol version")
         return
       end
-      keys = enumerate_keys
+      if(command_string=='cachedump')
+        keys = enumerate_keys
+      else
+        keys = enumerate_keys_lru
+      end
       print_good("Found #{keys.size} keys")
       return if keys.size == 0
 

--- a/modules/auxiliary/gather/memcached_extractor.rb
+++ b/modules/auxiliary/gather/memcached_extractor.rb
@@ -57,7 +57,7 @@ class MetasploitModule < Msf::Auxiliary
       loop do
         sock.send("stats cachedump #{sid} #{max_keys}\r\n", 0)
         data = sock.recv(4096)
-        break if !data || data.length == 0
+        break if !data || data.length == 0 || data == "END\r\n"
         matches = data.scan(/^ITEM (?<key>.*) \[/)
         keys = keys + matches.flatten! if matches
         break if data =~ /^END/


### PR DESCRIPTION
This change resolves #12884 for recent versions of memcached.

Please ensure you are submitting **from a unique branch** in your [repository](https://github.com/rapid7/metasploit-framework/pull/11086#issuecomment-445506416) to master in Rapid7's.

## Verification


[test_memcached_extractor.sh.zip](https://github.com/rapid7/metasploit-framework/files/4637513/test_memcached_extractor.sh.zip)
Use script to test:
- [ ] Install memcached
- [ ] Seed cache with data
- [ ] Recall items from cache to mark them as warm
- [ ] Start `msfconsole`
- [ ] `use auxiliary/gather/memcached_extractor`
- [ ] Set IP, Port
- [ ] Run
- [ ] All keys (20) added returned in scan

Versions of memcached prior to 1.5.4 have no or an incomplete lru_crawler function. Cachedump will be used in this case. 

## Sample test output - cachedump

```bash
STAT version 1.4.23

STAT items:2:number 20
STAT items:2:age 0
STAT items:2:evicted 0

-------------------

[*] 127.0.0.1:11211       - Connecting to memcached server...
[+] 127.0.0.1:11211       - Connected to memcached version 1.4.23
[*] 127.0.0.1:11211       - Using cachedump to enumerate keys
[+] 127.0.0.1:11211       - Found 20 keys

Keys/Values Found for 127.0.0.1:11211
=====================================

 Key    Value
 ---    -----
 key11  "VALUE key11 0 27\r\nsome data to be cached.....\r\nEND\r\n"
 key12  "VALUE key12 0 27\r\nsome data to be cached.....\r\nEND\r\n"
 key13  "VALUE key13 0 27\r\nsome data to be cached.....\r\nEND\r\n"
 key14  "VALUE key14 0 27\r\nsome data to be cached.....\r\nEND\r\n"
 key15  "VALUE key15 0 27\r\nsome data to be cached.....\r\nEND\r\n"
 key16  "VALUE key16 0 27\r\nsome data to be cached.....\r\nEND\r\n"
 key17  "VALUE key17 0 27\r\nsome data to be cached.....\r\nEND\r\n"
 key18  "VALUE key18 0 27\r\nsome data to be cached.....\r\nEND\r\n"
 key19  "VALUE key19 0 27\r\nsome data to be cached.....\r\nEND\r\n"
 key20  "VALUE key20 0 27\r\nsome data to be cached.....\r\nEND\r\n"

[*] 127.0.0.1:11211       - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
geoff@ubuntu-dev:~/source/metasploit-framework/modules$ 
```
## Sample test output - lru_crawler
```bash
STAT version 1.6.6

STAT items:1:number 20
STAT items:1:number_hot 20
STAT items:1:number_warm 0
STAT items:1:number_cold 0

-------------------

[*] 127.0.0.1:11211       - Connecting to memcached server...
[+] 127.0.0.1:11211       - Connected to memcached version 1.6.6
[*] 127.0.0.1:11211       - Using lru_crawler to enumerate keys
[+] 127.0.0.1:11211       - Found 20 keys

Keys/Values Found for 127.0.0.1:11211
=====================================

 Key    Value
 ---    -----
 key01  "VALUE key01 0 27\r\nsome data to be cached.....\r\nEND\r\n"
 key02  "VALUE key02 0 27\r\nsome data to be cached.....\r\nEND\r\n"
 key03  "VALUE key03 0 27\r\nsome data to be cached.....\r\nEND\r\n"
 key04  "VALUE key04 0 27\r\nsome data to be cached.....\r\nEND\r\n"
 key05  "VALUE key05 0 27\r\nsome data to be cached.....\r\nEND\r\n"
 key06  "VALUE key06 0 27\r\nsome data to be cached.....\r\nEND\r\n"
 key07  "VALUE key07 0 27\r\nsome data to be cached.....\r\nEND\r\n"
 key08  "VALUE key08 0 27\r\nsome data to be cached.....\r\nEND\r\n"
 key19  "VALUE key19 0 27\r\nsome data to be cached.....\r\nEND\r\n"
 key20  "VALUE key20 0 27\r\nsome data to be cached.....\r\nEND\r\n"

[*] 127.0.0.1:11211       - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
geoff@ubuntu-dev:~/source/metasploit-framework/modules$ 
```
