### PR TITLE
Add meterpreter command execute for rpc

### DIFF
--- a/lib/msf/core/rpc/v10/rpc_session.rb
+++ b/lib/msf/core/rpc/v10/rpc_session.rb
@@ -280,7 +280,6 @@ class RPC_Session < RPC_Base
   end
 
   def rpc_meterpreter_execute(sid, data)
-    # binding.pry
     s = _valid_session(sid, "meterpreter")
 
     s.single_session_mutex.synchronize {

--- a/lib/msf/core/session.rb
+++ b/lib/msf/core/session.rb
@@ -1,5 +1,6 @@
 # -*- coding: binary -*-
 require 'msf/core'
+require 'thread'
 
 module Msf
 
@@ -81,6 +82,7 @@ module Session
     self.alive = true
     self.uuid  = Rex::Text.rand_text_alphanumeric(8).downcase
     @routes = RouteArray.new(self)
+    @single_session_mutex=Mutex.new
     #self.routes = []
   end
 
@@ -406,6 +408,10 @@ module Session
   # This session's associated database record
   #
   attr_accessor :db_record
+  #
+  # An mutex for single sesssion for special session_id
+  #
+  attr_accessor :single_session_mutex
 protected
 
   attr_accessor :via # :nodoc:


### PR DESCRIPTION
origin way to execute command by write and read, from https://github.com/rapid7/metasploit-framework/issues/13462#issuecomment-629813203, I saw the possibility of executing commands synchronously. Because og the session single buffer, we need the mutex lock for session.

## Verification

List the steps needed to make sure this thing works

- [x] start rpc server to test(msfrpcd -P xxx -S), or Start `thin --rackup msf-json-rpc.ru --address 0.0.0.0 --port 8081 --environment development --tag msf-json-rpc --threaded start` to feel the pleasure.
- [x] use rpc client you like, then rpc.call('session.meterpreter_execute', 1, 'getuid'), and you can get the result, {'data': 'Server username: DESKTOP-xxxx\\xxxx\n'}

