### PR TITLE
Fix memory leak in ms01_026_dbldecode

### DIFF
--- a/modules/exploits/windows/iis/ms01_026_dbldecode.rb
+++ b/modules/exploits/windows/iis/ms01_026_dbldecode.rb
@@ -49,8 +49,6 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('CMD', [ false, 'Execute this command instead of using command stager', nil ])
       ])
 
-    framework.events.add_exploit_subscriber(self)
-
     self.needs_cleanup = true
   end
 
@@ -242,9 +240,5 @@ class MetasploitModule < Msf::Exploit::Remote
     rescue ::Exception => e
       print_error("Exception: #{e.inspect}")
     end
-  end
-
-  def cleanup
-    framework.events.remove_exploit_subscriber(self)
   end
 end


### PR DESCRIPTION
## Context / Debugging

As part an investigation of Metasploit's performance, a collection of ~50 modules were ran for ~12 hours against target machines. Specifically the `check` functionality was tested via the JSON RPC service that Metasploit provides. An example request being:

```js
// POST http://localhost:8081/api/v1/json-rpc
{
  "jsonrpc": "2.0",
  "method": "module.check",
  "id": 1,
  "params": [
    "auxiliary",
    "auxiliary/scanner/ssl/openssl_heartbleed",
    {
      "RHOSTS": "x.x.x.x",
      "RPORT": "80"
    }
  ]
}
```

After monitoring the results, it became apparent that there was a memory leak present in Metasploit Framework. The Resident Set Size (RSS), which represents how much of the current processes memory is held on RAM, increased from 200mb to over 1gb in 11 hours:

![image](https://user-images.githubusercontent.com/60357436/82389867-20a74a00-9a35-11ea-978b-1646d2e5d709.png)

The top line shows that Metasploit’s RSS usage increasing over time, indicating a memory leak.

The first point of investigation was to verify that there was no leak in the RPC's job tracking functionality. This was previously identified as having a memory leak, as it could store references to sockets/file descriptors. To confirm that this was fixed, the job counts were tracked:

![image](https://user-images.githubusercontent.com/60357436/82389928-416f9f80-9a35-11ea-8e63-fb83f1566967.png)

The top line shows unacknowledged jobs over time. The Client chosen for the performance test was not correctly ack’ing jobs. Pruning of the jobs results cache happens at ~35mb, explaining the sawtooth pattern. If this line trended upwards indefinitely, it would have indicated an issue in Metasploit's job tracking functionality.

To investigate if the memory issue was memory bloat/fragmentation or memory leak, [Ruby's ObjectSpace](https://ruby-doc.org/core-2.6.6/ObjectSpace.html) was plotted:

![image](https://user-images.githubusercontent.com/60357436/82390230-146fbc80-9a36-11ea-850d-8c918fbac95b.png)

The total size of all Ruby objects in memory, increasing over time. Similarly a breakdown of `ObjectSpace.count_objects` separately, shows an upward trend of allocated Ruby Types:

![image](https://user-images.githubusercontent.com/60357436/82390253-25b8c900-9a36-11ea-8c4f-555df864b145.png)

Each colored dot represents the total count of different Ruby types in memory - strings, arrays, objects etc. The blue dots represent allocated strings starting from 400k strings and increasing to 5.3m. The orange dots representing array allocations increasing from 380k to 4m allocations.

From the above graphs it is clear that this is a memory leak in Metasploit framework, rather than a fragmentation issue. We know this as the top value for the total ObjectSpace at a given time aligns closely to the RSS value, showing that there was no allocation outside of Ruby’s knowledge - or that fragmentation occurred. If fragmentation was present, the RSS value would be much higher than Ruby’s ObjectSpace value. For a great article on the differences between Bloat and Leaks, see [What causes Ruby memory bloat?](https://www.google.com/url?q=https://www.joyfulbikeshedding.com/blog/2019-03-14-what-causes-ruby-memory-bloat.html&sa=D&ust=1589936317361000)

To investigate the memory leak, an additional endpoint was temporarily added to the RPC service which triggered a dump of Ruby’s ObjectSpace to file for analyzing purposes. It should have been possible to use [rbtrace](https://github.com/tmm1/rbtrace ) too.

The code was:

```ruby
require "objspace"
 
def rpc_dump_objspace
    dump_location = File.expand_path("./ruby-heap-#{Time.now.to_i}.jsonl")
    Thread.new do
        GC.start
        File.open(dump_location, "w") do |file|
            ObjectSpace.dump_all(output: file)
        end
    end

    {
        "dump_location": dump_location
    }
end
```

Once the ObjectSpace dump is complete a new file file is generated in [json lines](http://jsonlines.org/) format. Each line is a separate JSON object representing the Ruby object in memory. For instance, one JSON line representing a string in memory:

```json
{"address":"0x7fca6d63d6e0", "type":"STRING", "class":"0x7fca771f7ba8", "embedded":true, "bytesize":14, "value":"hdm <x@hdm.io>", "encoding":"UTF-8", "memsize":40, "flags":{"wb_protected":true, "old":true, "uncollectible":true, "marked":true}}
```
 
It’s possible to use tools such as TenderLove’s [heap-analyzer](http://tenderlove.github.io/heap-analyzer/,) or [heapy](https://github.com/schneems/heapy) to process these files. These tools didn’t seem to handle the 1gb Ruby heap dump gracefully.

Instead, the file was loaded up in Ruby, and with Ruby 2.7’s new tally method it was possible to see how many different types of Ruby objects were in memory:

```ruby
> parsed_heap_dump.map { |obj| obj['type'] }.tally.sort_by { |type, count| -count }
=> [["STRING", 1812114],
["ARRAY", 1785576],
["OBJECT", 596901],
["HASH", 214615],
["IMEMO", 173638],
["ICLASS", 36600],
["CLASS", 26304],
["DATA", 19805],
["REGEXP", 3590],
["MODULE", 2886],
["STRUCT", 872],
["SYMBOL", 589],
["FILE", 567],
["MATCH", 132],
["BIGNUM", 67],
["RATIONAL", 60],
["FLOAT", 12],
["ROOT", 4],
["COMPLEX", 1]]
```

The String count is clearly high. We must be allocating lots of strings. I investigated further to see what the values of these strings are:

```ruby
> parsed_heap_dump.lazy.select { |obj| obj["type"] == 'STRING' }.map { |obj| obj["value"] }.tally.sort_by { |k, v| -v }.take(100)
=> [[nil, 520580],
["PEER", 20220],
["none", 20147],
["auto", 19811],
["self", 11632],
["win", 10835],
["0", 10826],
["VERBOSE", 10798],
["WORKSPACE", 10781],
["URL", 10556],
["Automatic", 10502],
["0.0.0.0", 10485],
["rhosts", 10405],
["SSL", 10358],
["DisablePayloadHandler", 10354],
["EnableContextEncoding", 10353],
["CVE", 10352],
["ContextInformationFile", 10351],
["ebp", 10344],
["esp", 10344],
["RPORT", 10343],
["The target port", 10336],
["WfsDelay", 10332],
["HTTP::header_folding", 10142],
["TCP::max_send_size", 10130],
["TCP::send_delay", 10130],
["NONE", 10113],
["SSLCipher", 10112],
["CLIENT_ONCE", 10111],
["FAIL_IF_NO_PEER_CERT", 10111],
["SSLVerifyMode", 10111],
["ConnectTimeout", 10111],
["SSL verification method", 10109],
["BID", 10096],
["OSVDB", 10095],
["CMD", 9945],
...]
```

The String object’s value is nil? On closer inspection it seems that Ruby’s String objects can reference existing strings and therefore won't have a value set:

```json
{"address":"0x7f1f057ff078", "type":"STRING", "class":"0x7f1f9ebf7ba0", "shared":true, "references":["0x7f1f93b9cb20"], "memsize":40, "flags":{"wb_protected":true, "old":true, "uncollectible":true, "marked":true}}
```

After correctly mapping the memory location to its count and referenced string:

```ruby
=> [["0x7f1f93b9cb20", 10781, "Enable detailed status messages"],
["0x7f1f93b9cfa8", 10779, "Specify the workspace for this module"],
["0x7f1f911bb4a0", 10352, "Disable the handler code for the selected payload"],
["0x7f1f911bb518", 10351, "Use transient context when encoding payloads"],
["0x7f1f911bb4f0", 10349, "The information file that contains context information"],
["0x7f1f911bb540", 10331, "Additional delay when waiting for a session"],
["0x7f1f90590f68", 10141, "Enable folding of HTTP headers"],
["0x7f1f904b4018", 10108, "Delays inserted before every send.  (0 = disable)"],
["0x7f1f91df0ab8", 10108, "Maximum number of seconds to establish a TCP connection"],
["0x7f1f904b4180", 9921, "String for SSL cipher spec - \"DHE-RSA-AES256-SHA\" or \"ADH\""],
["0x7f1f904b4248", 9921, "The specific communication channel to use for this service"],
["0x7f1f904f7f98", 9921, "The local port to listen on."],
["0x7f1f904b4338", 9921, "Negotiate SSL for incoming connections"],
["0x7f1f904e52d0", 9921, "The local host to listen on. This must be an address on the local machine or 0.0.0.0"],
["0x7f1f904b42c0", 9921, "Path to a custom SSL certificate (default is randomly generated)"],
["0x7f1f904b41f8", 9921, "Enable SSL/TLS-level compression"],
["0x7f1f904b4108", 9921, "Maximum tcp segment size.  (0 = disable)"],
["0x7f1f92423160", 9907, "Generate an EICAR file instead of regular payload exe"],
["0x7f1f924230c0", 9906, "Set to preserve the original EXE function"],
["0x7f1f92422f80", 9906, "The directory in which to look for the msi template"],
["0x7f1f92422f30", 9906, "The msi template file name"],
["0x7f1f92422ee0", 9906, "Create an MSI with a UAC prompt (elevation to SYSTEM if accepted)"],
["0x7f1f92423138", 9906, "Use custom exe instead of automatically generating a payload exe"],
["0x7f1f92422fd0", 9906, "Use custom msi instead of automatically generating a payload msi"],
["0x7f1f92423110", 9906, "The directory in which to look for the executable template"],
["0x7f1f92423020", 9906, "Generate an EICAR file instead of regular payload msi"],
["0x7f1f92423070", 9906, "Use the default template in case the specified one is missing"],
["0x7f1f924230e8", 9906, "The executable template file name."],
["0x7f1f92423098", 9906, "Set to use the substitution EXE generation method."],
["0x7f1f905909f0", 9904, "Port to use in URI (useful for tunnels)"],
...]
```

It seems that the module’s descriptions/default options are being replicated and held indefinitely in memory. After the realisation that modules are generally cloned by Metasploit framework, I revisited the original object counts in memory:

```ruby
> parsed_heap_dump.map { |obj| obj['type'] }.tally.sort_by { |type, count| -count }
=> [["STRING", 1812114],
["ARRAY", 1785576],
["OBJECT", 596901],
["HASH", 214615],
["IMEMO", 173638],
["ICLASS", 36600],
["CLASS", 26304],
["DATA", 19805],
["REGEXP", 3590],
["MODULE", 2886],
["STRUCT", 872],
["SYMBOL", 589],
["FILE", 567],
["MATCH", 132],
["BIGNUM", 67],
["RATIONAL", 60],
["FLOAT", 12],
["ROOT", 4],
["COMPLEX", 1]]
 ```

Specifically there are a lot more Ruby class and iclass objects in memory than I expected:

```ruby
["ICLASS", 36600],
["CLASS", 26304]
```

Tallying the counts of class names, we can clearly see an outlier: 

```ruby
=> [["Msf::Modules::Exploit__Windows__Iis__Ms01_026_dbldecode::MetasploitModule", 9905],
["Class", 7678],
["Module", 1076],
["Socket", 418],
["Msf::Modules::Exploit__Windows__Ftp__Servu_chmod::MetasploitModule", 188],
["Thin::Connection", 147],
["Msf::Modules::Exploit__Multi__Misc__Weblogic_deserialize_asyncresponseservice::MetasploitModule", 123],
["Msf::Modules::Exploit__Multi__Http__Tomcat_jsp_upload_bypass::MetasploitModule", 111],
["Msf::Modules::Exploit__Multi__Misc__Weblogic_deserialize::MetasploitModule", 18],
["Object", 7],
["BinData::DSLMixin::DSLParser", 5],
["ActiveRecord::AttributeMethods::GeneratedAttributeMethods", 3],
["Msf::Modules::Exploit__Multi__Http__Struts_include_params::MetasploitModule", 3],
["Hash", 2],
["Bundler::FeatureFlag", 2],
["Gem::Specification", 2],
["MetasploitDataModels::Engine", 2],
["Msf::PluginManager", 2],
["Msf::Framework", 2],
["ActiveSupport::Logger", 2],
["ActiveSupport::Logger::SimpleFormatter", 2],
```

It seems that there are 9,905 `ms01_026_dbldecode` class objects in memory. On investigation the module registers itself with the framework’s event system, but in the context of check methods - never unsubscribes. This would mean the framework object would reference the module instance, and therefore all corresponding strings/arrays/etc would remain in memory indefinitely:

https://github.com/rapid7/metasploit-framework/blob/3b30b537725171d5fd8b9f441b9ab2440d84f3a8/modules/exploits/windows/iis/ms01_026_dbldecode.rb#L52

## Before

This module was ran in isolation to replicate the memory leak. In under 10 minutes of running 200 requests in parallel via the test client, Ruby permanently allocated >1gb, and continued to increase indefinitely:

![image](https://user-images.githubusercontent.com/60357436/82390412-8d6f1400-9a36-11ea-9281-962175e364d3.png)

The previous RSS usage for all 50 modules:

![image](https://user-images.githubusercontent.com/60357436/82390460-ab3c7900-9a36-11ea-9a65-91eca6a5dd06.png)

## After

With the subscription mechanism removed, the graph now shows that Ruby is no longer additionally creating and retaining Ruby Objects when ran in isolation:

![image](https://user-images.githubusercontent.com/60357436/82390439-9d86f380-9a36-11ea-8275-a7d3ba6e1760.png)

Running the original ~50 modules in rotation again shows that the RSS now remains flat:

![image](https://user-images.githubusercontent.com/60357436/82391701-dbd1e200-9a39-11ea-9859-a3fcb5df2441.png)

The ObjectSpace counts remain flat now too:

![image](https://user-images.githubusercontent.com/60357436/82390453-a5df2e80-9a36-11ea-8246-11485c7350ef.png)

![image](https://user-images.githubusercontent.com/60357436/82394308-96fd7980-9a40-11ea-9583-a1ddced23072.png)


-- 

Snippets

```
require 'objspace'
ObjectSpace.trace_object_allocations_start

parsed.lazy.select { |obj| obj["type"] == 'CLASS' && obj['name'].nil? && obj['real_class_name'].nil? }.first
parsed.lazy.select { |obj| obj["type"] == 'CLASS' }.map { |obj| obj['name'] || obj['real_class_name'] }.tally.sort_by { |k,v| -v }.take(100)

parsed.lazy.select { |obj| obj["type"] == 'CLASS' && obj['name'].nil? }.first

parsed.lazy.select { |obj| obj["type"] == 'CLASS' }.map { |obj| obj['name'] }.tally.sort_by { |k,v| -v }.take(100)

parsed.lazy.select { |obj| obj["type"] == 'ICLASS' }.first

lookup = parsed.each_with_object({}) { |row, acc| acc[row['address']] = row }; nil

require 'json'; parsed = File.binread('./heap_dump.json').lines.map {|line| JSON.parse(line)}; nil

<ruby>
require 'objspace'
    file_name = "heap_dump.json"
    File.open(file_name, 'w') do |f|
      ObjectSpace.dump_all(output: f, full: true) # `full: true` includes empty slots
    end
</ruby>

parsed.lazy.select { |obj|( obj["type"] == 'CLASS' || obj['type'] == 'ICLASS') && obj['file'].to_s.include?('wp_')}.map do |obj|
 if obj['file']
     "#{obj['file']}:#{obj['line']}::#{obj['address']}:::#{obj['name'] || obj['real_class_name']}"
   else
     obj['name'] || obj['real_class_name']
   end
end.tally.sort_by { |k,v| k }
```