### PR TITLE
Fix invalid customization and Customizing the webconsole prompt

### DIFF
--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -433,9 +433,18 @@ class Driver < Msf::Ui::Driver
   #
   # Proxies to shell.rb's update prompt with our own extras
   #
-  def update_prompt(p, pchar)
-    p = "#{p} #{active_module.type}(%bld%red#{active_module.promptname}%clr)" if active_module
-    super(p, pchar)
+  def update_prompt(old_prompt, old_prompt_char)
+    if active_module && !old_prompt.include?(active_module.promptname.to_s)
+      framework.datastore['Prompt'] = old_prompt
+      framework.datastore['PromptChar'] = old_prompt_char
+      new_prompt = "#{old_prompt} #{active_module.type}(#{active_module.promptname})"
+      new_prompt = "#{old_prompt} #{active_module.type}(%bld%red#{active_module.promptname}%clr)" if supports_color?
+      new_prompt_char = old_prompt_char
+    else
+      new_prompt = framework.datastore['Prompt'] || prompt
+      new_prompt_char = framework.datastore['PromptChar'] || prompt_char
+    end
+    super(new_prompt, new_prompt_char)
   end
 
   #

--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -433,20 +433,19 @@ class Driver < Msf::Ui::Driver
   #
   # Proxies to shell.rb's update prompt with our own extras
   #
-  def update_prompt(old_prompt, old_prompt_char)
-    if active_module && !old_prompt.include?(active_module.promptname.to_s)
-      framework.datastore['Prompt'] = old_prompt
-      framework.datastore['PromptChar'] = old_prompt_char
-      new_prompt = "#{old_prompt} #{active_module.type}(#{active_module.promptname})"
-      new_prompt = "#{old_prompt} #{active_module.type}(%bld%red#{active_module.promptname}%clr)" if supports_color?
-      new_prompt_char = old_prompt_char
+  def update_prompt(*args)
+    if args.empty?
+      pchar = framework.datastore['PromptChar'] || DefaultPromptChar
+      p = framework.datastore['Prompt'] || DefaultPrompt
+      p = "#{p} #{active_module.type}(%bld%red#{active_module.promptname}%clr)" if active_module
+      super(p, pchar)
     else
-      new_prompt = framework.datastore['Prompt'] || prompt
-      new_prompt_char = framework.datastore['PromptChar'] || prompt_char
+      framework.datastore['PromptChar'] = args[1]
+      framework.datastore['Prompt'] = args[0]
+      # Don't squash calls from within lib/rex/ui/text/shell.rb
+      super(*args)
     end
-    super(new_prompt, new_prompt_char)
   end
-
   #
   # The framework instance associated with this driver.
   #

--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -433,16 +433,9 @@ class Driver < Msf::Ui::Driver
   #
   # Proxies to shell.rb's update prompt with our own extras
   #
-  def update_prompt(*args)
-    if args.empty?
-      pchar = framework.datastore['PromptChar'] || DefaultPromptChar
-      p = framework.datastore['Prompt'] || DefaultPrompt
-      p = "#{p} #{active_module.type}(%bld%red#{active_module.promptname}%clr)" if active_module
-      super(p, pchar)
-    else
-      # Don't squash calls from within lib/rex/ui/text/shell.rb
-      super(*args)
-    end
+  def update_prompt(p, pchar)
+    p = "#{p} #{active_module.type}(%bld%red#{active_module.promptname}%clr)" if active_module
+    super(p, pchar)
   end
 
   #

--- a/lib/msf/ui/web/console.rb
+++ b/lib/msf/ui/web/console.rb
@@ -58,7 +58,7 @@ class WebConsole
     end
 
     # Initialize the console with our pipe
-    web_prompt = opts['PROMPT'] || 'web_msf'
+    web_prompt = opts['PROMPT'] || 'msf'
     web_prompt_char =  opts['PROMPTCHAR'] || '>'
     self.console = Msf::Ui::Console::Driver.new(web_prompt, web_prompt_char,
       opts.merge({

--- a/lib/msf/ui/web/console.rb
+++ b/lib/msf/ui/web/console.rb
@@ -58,9 +58,9 @@ class WebConsole
     end
 
     # Initialize the console with our pipe
-    self.console = Msf::Ui::Console::Driver.new(
-      'msf',
-      '>',
+    web_prompt = opts['PROMPT'] || 'web_msf'
+    web_prompt_char =  opts['PROMPTCHAR'] || '>'
+    self.console = Msf::Ui::Console::Driver.new(web_prompt, web_prompt_char,
       opts.merge({
         'Framework'   => self.framework,
         'LocalInput'  => self.pipe,

--- a/lib/rex/ui/text/shell.rb
+++ b/lib/rex/ui/text/shell.rb
@@ -136,7 +136,9 @@ module Shell
         break if self.stop_flag || self.stop_count > 1
 
         init_tab_complete
-        update_prompt
+        pchar = framework.datastore['PromptChar'] || prompt_char
+        p = framework.datastore['Prompt'] || prompt
+        update_prompt(p, pchar)
 
         line = get_input_line
 

--- a/lib/rex/ui/text/shell.rb
+++ b/lib/rex/ui/text/shell.rb
@@ -136,8 +136,8 @@ module Shell
         break if self.stop_flag || self.stop_count > 1
 
         init_tab_complete
-        pchar = framework.datastore['PromptChar'] || prompt_char
         p = framework.datastore['Prompt'] || prompt
+        pchar = framework.datastore['PromptChar'] || prompt_char
         update_prompt(p, pchar)
 
         line = get_input_line

--- a/lib/rex/ui/text/shell.rb
+++ b/lib/rex/ui/text/shell.rb
@@ -48,6 +48,7 @@ module Shell
     self.stop_count     = 0
 
     # Initialize the prompt
+    self.first_run_flag = true
     self.cont_prompt = ' > '
     self.cont_flag = false
     self.prompt = prompt
@@ -136,10 +137,8 @@ module Shell
         break if self.stop_flag || self.stop_count > 1
 
         init_tab_complete
-        p = framework.datastore['Prompt'] || prompt
-        pchar = framework.datastore['PromptChar'] || prompt_char
-        update_prompt(p, pchar)
-
+        first_run_flag ? update_prompt(prompt, prompt_char): update_prompt
+        self.first_run_flag = false
         line = get_input_line
 
         # If you have sessions active, this will give you a shot to exit
@@ -480,7 +479,7 @@ protected
 
   attr_writer   :input, :output # :nodoc:
   attr_writer   :prompt, :prompt_char # :nodoc:
-  attr_accessor :stop_flag, :cont_prompt # :nodoc:
+  attr_accessor :stop_flag, :cont_prompt, :first_run_flag # :nodoc:
   attr_accessor :tab_complete_proc # :nodoc:
   attr_accessor :histfile # :nodoc:
   attr_accessor :hist_last_saved # the number of history lines when last saved/loaded


### PR DESCRIPTION
# Fix invalid customization
## Steps to reproduce
- You can change the ‘msf’ in the code to any character,like 'KT'

``` ruby
# lib/msf/ui/web/console.rb
# Initialize the console with our pipe
self.console = Msf::Ui::Console::Driver.new(
  'KT',
  '#',
  opts.merge({
    'Framework'   => self.framework,
    'LocalInput'  => self.pipe,
    'LocalOutput' => self.pipe,
    'AllowCommandPassthru' => true,
    'Resource'    => [],
  })
)
```
- start json-rpc service
```
bundle exec thin --rackup msf-json-rpc.ru --address rpc.kali-team.cn --port 8081 --ssl --ssl-key-file /home/kali-team/.msf4/msf-ws-key.pem --ssl-cert-file /home/kali-team/.msf4/msf-ws-cert.pem --ssl-disable-verify --environment development --log /home/kali-team/.msf4/logs/msf-ws.log --pid /home/kali-team/.msf4/msf-ws.pid --tag msf-json-rpc --debug start --threaded
```
- create a console
```
curl --request POST \
  --url https://rpc.kali-team.cn:8081/api/v1/json-rpc \
  --header 'authorization: Bearer 4609b894a5df47bc165f33ae9359ddf4b077fe83803fc390848d45652d4991b7c918c2055a9b3654' \
  --header 'content-type: application/json' \
  --data '{
	"jsonrpc": "2.0",
	"method": "console.create",
	"id": 0
}'
```
- list console
```
curl --request POST \
  --url https://rpc.kali-team.cn:8081/api/v1/json-rpc \
  --header 'authorization: Bearer 4609b894a5df47bc165f33ae9359ddf4b077fe83803fc390848d45652d4991b7c918c2055a9b3654' \
  --header 'content-type: application/json' \
  --data '{
	"jsonrpc": "2.0",
	"method": "console.list",
	"id": 0
}'
```
- response
```
{
  "jsonrpc": "2.0",
  "result": {
    "consoles": [
      {
        "id": "0",
        "prompt": "msf5 > ",
        "busy": false
      }
    ]
  },
  "id": 0
}
```
- The default prompt will be returned no matter what character is modified
- After fixing the bug
```
{
  "jsonrpc": "2.0",
  "result": {
    "consoles": [
      {
        "id": "0",
        "prompt": "web_msf > ",
        "busy": false
      }
    ]
  },
  "id": 0
}
```
# Customizing the webconsole prompt
- create console,The custom prompt is 'KT', prompt_char is '#'
```
curl --request POST \
  --url https://rpc.kali-team.cn:8081/api/v1/json-rpc \
  --header 'authorization: Bearer 4609b894a5df47bc165f33ae9359ddf4b077fe83803fc390848d45652d4991b7c918c2055a9b3654' \
  --header 'content-type: application/json' \
  --data '{
	"jsonrpc": "2.0",
	"method": "console.create",
	"params": [
		{
			"PROMPT": "KT",
			"PROMPTCHAR": "#"
		}
	],
	"id": 0
}'
```
- response
```
{
  "jsonrpc": "2.0",
  "result": {
    "consoles": [
      {
        "id": "0",
        "prompt": "web_msf > ",
        "busy": false
      },
      {
        "id": "1",
        "prompt": "KT # ",
        "busy": false
      }
    ]
  },
  "id": 0
}
```
Thank you for your guidance @timwr 