### PR TITLE
Fix punctuation typo in exploit/windows/http/exchange_ecp_viewstate documentation

### DIFF
--- a/documentation/modules/exploit/windows/http/exchange_ecp_viewstate.md
+++ b/documentation/modules/exploit/windows/http/exchange_ecp_viewstate.md
@@ -3,7 +3,7 @@
 This module exploits a .NET serialization vulnerability in the Exchange Control
 Panel (ECP) web page. The vulnerability is due to Microsoft Exchange Server not
 randomizing the keys on a per-installation basis resulting in them using the
-same validationKey and decryptionKey values. With knowledge of these, values an
+same validationKey and decryptionKey values. With knowledge of these values, an
 attacker can craft a special viewstate to cause an OS command to be executed by
 NT_AUTHORITY\SYSTEM using .NET deserialization.
 

--- a/modules/exploits/windows/http/exchange_ecp_viewstate.rb
+++ b/modules/exploits/windows/http/exchange_ecp_viewstate.rb
@@ -23,7 +23,7 @@ class MetasploitModule < Msf::Exploit::Remote
         Exchange Control Panel (ECP) web page. The vulnerability is due to
         Microsoft Exchange Server not randomizing the keys on a
         per-installation basis resulting in them using the same validationKey
-        and decryptionKey values. With knowledge of these, values an attacker
+        and decryptionKey values. With knowledge of these values, an attacker
         can craft a special ViewState to cause an OS command to be executed
         by NT_AUTHORITY\SYSTEM using .NET deserialization.
       },


### PR DESCRIPTION
I missed this in #13014 due to not paying attention.

> With knowledge of **these, values**
> With knowledge of **these values,**

There are some other non-typo punctuation fixes, but I left them out unless you want them. Since it seems you're wrapping your module doc at 80 columns, I would have to reformat.