### PR TITLE
Fix miscellaneous things in ThinkPHP and ManageEngine exploits

### DIFF
--- a/modules/exploits/unix/webapp/thinkphp_rce.rb
+++ b/modules/exploits/unix/webapp/thinkphp_rce.rb
@@ -220,7 +220,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     return unless res && res.code == 200
 
-    vprint_good("Successfully executed command: #{cmd}")
+    print_good("Successfully executed command: #{cmd}")
 
     return unless datastore['PAYLOAD'] == 'cmd/unix/generic'
 
@@ -274,7 +274,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     return unless res && res.code == 200
 
-    vprint_good("Successfully executed command: #{cmd}")
+    print_good("Successfully executed command: #{cmd}")
 
     return unless datastore['PAYLOAD'] == 'cmd/unix/generic'
 

--- a/modules/exploits/windows/http/desktopcentral_deserialization.rb
+++ b/modules/exploits/windows/http/desktopcentral_deserialization.rb
@@ -59,6 +59,7 @@ class MetasploitModule < Msf::Exploit::Remote
             'Windows Dropper',
             'Arch' => [ARCH_X86, ARCH_X64],
             'Type' => :win_dropper,
+            'CmdStagerFlavor' => :certutil, # This works without issue
             'DefaultOptions' => {
               'PAYLOAD' => 'windows/x64/meterpreter/reverse_tcp'
             }
@@ -77,7 +78,6 @@ class MetasploitModule < Msf::Exploit::Remote
           'SSL' => true,
           'WfsDelay' => 60 # It can take a little while to trigger
         },
-        'CmdStagerFlavor' => :certutil, # This works without issue
         'Notes' => {
           'Stability' => [SERVICE_RESOURCE_LOSS], # May 404 the upload page?
           'Reliability' => [FIRST_ATTEMPT_FAIL], # Payload upload may fail


### PR DESCRIPTION
#### `exploit/unix/webapp/thinkphp_rce`

> Current pattern is `print_good` instead of `vprint_good` for this particular message directly or indirectly called by `execute_command`.

#### `exploit/windows/http/desktopcentral_deserialization`

> `CmdStagerFlavor` is checked at the top level, but it is also checked per target. Moving this to where it's more appropriate.

For #13071 and #13240.