### PR TITLE
add a test for stderr output to the cmd_exec tests

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,7 +28,7 @@ PATH
       metasploit-concern (~> 2.0.0)
       metasploit-credential (~> 3.0.0)
       metasploit-model (~> 2.0.4)
-      metasploit-payloads (= 1.4.1)
+      metasploit-payloads (= 1.4.2)
       metasploit_data_models (~> 3.0.10)
       metasploit_payloads-mettle (= 0.5.21)
       mqtt
@@ -217,7 +217,7 @@ GEM
       activemodel (~> 4.2.6)
       activesupport (~> 4.2.6)
       railties (~> 4.2.6)
-    metasploit-payloads (1.4.1)
+    metasploit-payloads (1.4.2)
     metasploit_data_models (3.0.10)
       activerecord (~> 4.2.6)
       activesupport (~> 4.2.6)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -70,7 +70,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model', '~> 2.0.4'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '1.4.1'
+  spec.add_runtime_dependency 'metasploit-payloads', '1.4.2'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '0.5.21'
   # Needed by msfgui and other rpc components

--- a/test/modules/post/test/cmd_exec.rb
+++ b/test/modules/post/test/cmd_exec.rb
@@ -93,4 +93,20 @@ class MetasploitModule < Msf::Post
       end
     end
   end
+
+  def test_cmd_exec_stderr
+    vprint_status("Starting cmd_exec stderr tests")
+
+    it "should return the stderr output" do
+      test_string = Rex::Text.rand_text_alpha(4)
+      if session.platform.eql? 'windows'
+        output = cmd_exec("cmd.exe", "/c echo #{test_string} 1>&2")
+        output.rstrip == test_string
+      else
+        output = cmd_exec("echo #{test_string} 1>&2")
+        output == test_string
+      end
+    end
+
+  end
 end


### PR DESCRIPTION
This change adds a test to ensure the stderr output can be seen when running cmd_exec.
This was broken on Java and fixed with https://github.com/rapid7/metasploit-payloads/pull/393
Additionally this was broken on the `cmd/windows/reverse_powershell` payload before https://github.com/rapid7/metasploit-framework/pull/12985 fixed it.

## Verification

List the steps needed to make sure this thing works

- [x] Get a java meterpreter session (on Windows or Linux) `msfconsole -qx "use exploit/multi/handler; set payload java/meterpreter/reverse_tcp; set lhost $LHOST; set lport 4444; set ExitOnSession false; run -j"`
- [x] Run the following:
```
loadpath test/modules
use post/test/cmd_exec 
set SESSION -1
run
```
- [x] **Verify** the tests all pass
