### PR TITLE
Add BASE_DN and ROOT_KEY options to VMware vCenter vmdir and SaltStack Salt modules

### DIFF
--- a/documentation/modules/auxiliary/admin/ldap/vmware_vcenter_vmdir_auth_bypass.md
+++ b/documentation/modules/auxiliary/admin/ldap/vmware_vcenter_vmdir_auth_bypass.md
@@ -23,6 +23,10 @@ Add an admin user to the vCenter Server.
 
 ## Options
 
+### BASE_DN
+
+If you already have the LDAP base DN, you may set it in this option.
+
 ### USERNAME
 
 Set this to the username for the new admin user.
@@ -48,6 +52,7 @@ Module options (auxiliary/admin/ldap/vmware_vcenter_vmdir_auth_bypass):
 
    Name      Current Setting  Required  Description
    ----      ---------------  --------  -----------
+   BASE_DN                    no        LDAP base DN if you already have it
    PASSWORD                   no        Password of admin user to add
    RHOSTS                     yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
    RPORT     389              yes       The target port

--- a/documentation/modules/auxiliary/gather/vmware_vcenter_vmdir_ldap.md
+++ b/documentation/modules/auxiliary/gather/vmware_vcenter_vmdir_ldap.md
@@ -23,6 +23,10 @@ Dump all LDAP data from the vCenter Server.
 
 ## Options
 
+### BASE_DN
+
+If you already have the LDAP base DN, you may set it in this option.
+
 ### ConnectTimeout
 
 You may configure the timeout for LDAP connects if necessary. The
@@ -38,10 +42,11 @@ msf5 auxiliary(gather/vmware_vcenter_vmdir_ldap) > options
 
 Module options (auxiliary/gather/vmware_vcenter_vmdir_ldap):
 
-   Name    Current Setting  Required  Description
-   ----    ---------------  --------  -----------
-   RHOSTS                   yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
-   RPORT   389              yes       The target port
+   Name     Current Setting  Required  Description
+   ----     ---------------  --------  -----------
+   BASE_DN                   no        LDAP base DN if you already have it
+   RHOSTS                    yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
+   RPORT    389              yes       The target port
 
 
 Auxiliary action:

--- a/documentation/modules/exploit/linux/misc/saltstack_salt_unauth_rce.md
+++ b/documentation/modules/exploit/linux/misc/saltstack_salt_unauth_rce.md
@@ -82,6 +82,11 @@ This executes a Unix command payload on the minions specified by the
 
 ## Options
 
+### ROOT_KEY
+
+If you already have the master's root key, you may set it in this
+option. Note that the master regenerates the root key on each startup.
+
 ### MINIONS
 
 This is the PCRE regex of minions to execute the payload on. Defaults to
@@ -117,16 +122,17 @@ msf5 exploit(linux/misc/saltstack_salt_unauth_rce) > options
 
 Module options (exploit/linux/misc/saltstack_salt_unauth_rce):
 
-   Name     Current Setting  Required  Description
-   ----     ---------------  --------  -----------
-   MINIONS  .*               yes       PCRE regex of minions to target
-   RHOSTS                    yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
-   RPORT    4506             yes       The target port (TCP)
-   SRVHOST  0.0.0.0          yes       The local host to listen on. This must be an address on the local machine or 0.0.0.0
-   SRVPORT  8080             yes       The local port to listen on.
-   SSL      false            no        Negotiate SSL for incoming connections
-   SSLCert                   no        Path to a custom SSL certificate (default is randomly generated)
-   URIPATH                   no        The URI to use for this exploit (default is random)
+   Name      Current Setting  Required  Description
+   ----      ---------------  --------  -----------
+   MINIONS   .*               yes       PCRE regex of minions to target
+   RHOSTS                     yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
+   ROOT_KEY                   no        Master's root key if you have it
+   RPORT     4506             yes       The target port (TCP)
+   SRVHOST   0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
+   SRVPORT   8080             yes       The local port to listen on.
+   SSL       false            no        Negotiate SSL for incoming connections
+   SSLCert                    no        Path to a custom SSL certificate (default is randomly generated)
+   URIPATH                    no        The URI to use for this exploit (default is random)
 
 
 Payload options (python/meterpreter/reverse_https):
@@ -169,7 +175,6 @@ msf5 exploit(linux/misc/saltstack_salt_unauth_rce) > run
 [+] 172.28.128.5:4506 - Received serialized auth info
 [+] 172.28.128.5:4506 - Root key: bv2Ra72DXzkrbFVYNPHrOe9CqM2aKBdl+E46/m/kaxvDsiLxhG+0PS55u704MyOi2/PgD/EadGk=
 [*] 172.28.128.5:4506 - Disconnecting from 172.28.128.5:4506
-[+] 172.28.128.5:4506 - Successfully obtained root key: bv2Ra72DXzkrbFVYNPHrOe9CqM2aKBdl+E46/m/kaxvDsiLxhG+0PS55u704MyOi2/PgD/EadGk=
 [*] 172.28.128.5:4506 - Connecting to ZeroMQ service at 172.28.128.5:4506
 [*] 172.28.128.5:4506 - Negotiating signature
 [+] 172.28.128.5:4506 - Received valid signature: "\xFF\x00\x00\x00\x00\x00\x00\x00\x01\x7F"

--- a/modules/auxiliary/admin/ldap/vmware_vcenter_vmdir_auth_bypass.rb
+++ b/modules/auxiliary/admin/ldap/vmware_vcenter_vmdir_auth_bypass.rb
@@ -46,6 +46,7 @@ class MetasploitModule < Msf::Auxiliary
     )
 
     register_options([
+      OptString.new('BASE_DN', [false, 'LDAP base DN if you already have it']),
       OptString.new('USERNAME', [false, 'Username of admin user to add']),
       OptString.new('PASSWORD', [false, 'Password of admin user to add'])
     ])
@@ -86,8 +87,12 @@ class MetasploitModule < Msf::Auxiliary
 
     return unless checkcode == Exploit::CheckCode::Vulnerable
 
-    # HACK: We stashed the detected base DN in the CheckCode's reason
-    @base_dn = checkcode.reason
+    if (@base_dn = datastore['BASE_DN'])
+      print_status("User-specified base DN: #{base_dn}")
+    else
+      # HACK: We stashed the detected base DN in the CheckCode's reason
+      @base_dn = checkcode.reason
+    end
 
     opts = {
       host: rhost,

--- a/modules/auxiliary/gather/vmware_vcenter_vmdir_ldap.rb
+++ b/modules/auxiliary/gather/vmware_vcenter_vmdir_ldap.rb
@@ -39,6 +39,10 @@ class MetasploitModule < Msf::Auxiliary
       )
     )
 
+    register_options([
+      OptString.new('BASE_DN', [false, 'LDAP base DN if you already have it'])
+    ])
+
     register_advanced_options([
       OptFloat.new('ConnectTimeout', [false, 'Timeout for LDAP connect', 10.0])
     ])
@@ -69,10 +73,14 @@ class MetasploitModule < Msf::Auxiliary
     entries = nil
 
     Net::LDAP.open(opts) do |ldap|
-      print_status('Discovering base DN automatically')
+      if (@base_dn = datastore['BASE_DN'])
+        print_status("User-specified base DN: #{base_dn}")
+      else
+        print_status('Discovering base DN automatically')
 
-      unless (@base_dn = discover_base_dn(ldap))
-        print_warning('Falling back on default base DN of dc=vsphere,dc=local')
+        unless (@base_dn = discover_base_dn(ldap))
+          print_warning('Falling back on default base DN dc=vsphere,dc=local')
+        end
       end
 
       print_status("Dumping LDAP data from vmdir service at #{peer}")

--- a/modules/exploits/linux/misc/saltstack_salt_unauth_rce.rb
+++ b/modules/exploits/linux/misc/saltstack_salt_unauth_rce.rb
@@ -95,6 +95,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options([
       Opt::RPORT(4506),
+      OptString.new('ROOT_KEY', [false, "Master's root key if you have it"]),
       OptRegexp.new('MINIONS', [true, 'PCRE regex of minions to target', /.*/])
     ])
 
@@ -109,14 +110,18 @@ class MetasploitModule < Msf::Exploit::Remote
   # NOTE: check is provided by auxiliary/gather/saltstack_salt_root_key
 
   def exploit
-    # check.reason is from auxiliary/gather/saltstack_salt_root_key
     if target.name.start_with?('Master')
-      unless (root_key = check.reason)
+      if (root_key = datastore['ROOT_KEY'])
+        print_status("User-specified root key: #{root_key}")
+      else
+        # check.reason is from auxiliary/gather/saltstack_salt_root_key
+        root_key = check.reason
+      end
+
+      unless root_key
         fail_with(Failure::BadConfig,
                   "#{target['Description']} requires a root key")
       end
-
-      print_good("Successfully obtained root key: #{root_key}")
     end
 
     # These are from Msf::Exploit::Remote::ZeroMQ


### PR DESCRIPTION
These options offer increased configurability with `CheckModule`. I left them out in the original PRs to reduce complexity (I was lazy), but this should be the pattern going forward.

Since I've retested the changes, I'll land this unless someone is feeling ambitious.

Updates #13253 and #13401. Also see #13384.