### PR TITLE
Suggest valid options in Msf::OptAddressRange (RHOSTS) tab completion

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -2303,9 +2303,7 @@ class Core
         res << str+str[0, str.length - 1]
       else
         option_values_target_addrs().each do |addr|
-          res << addr+'/32'
-          res << addr+'/24'
-          res << addr+'/16'
+          res << addr
         end
       end
 


### PR DESCRIPTION
This changes the tab completion behavior when completing `OptAddressRange` entries to **not** over standard cidr notation of `/24`, `/16`, `/8`. The reason is that the underlying logic that populates the array (`option_values_target_addrs`) returns hosts and not networks. Because of this, it doesn't make a lot of sense to complete the standard cidr range suffixes because in doing so a single slash is typically returned which is not a valid address.

If we don't like this solution, I'd alternatively propose adding the suffix `/32` to all the results returned from `option_values_target_addrs` because again, that's yielding host IPs not network ranges.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use exploit/windows/smb/ms08_067_netapi`
- [x] Type `set RHOSTS 192.168.250.<TAB>` where `192.168.250.` are the first 3 octets of an IP address bound to a local interface. There should be only one interface on that network (so the first 3 octets are unique).

## Example Output
In both of these examples, the user types `set RHOSTS 192.168.250.` before hitting `TAB`, then `ENTER`.

### Example Output (Patched)
```
msf5 > use exploit/windows/smb/ms08_067_netapi 
msf5 exploit(windows/smb/ms08_067_netapi) > set RHOSTS 192.168.250.95 
RHOSTS => 192.168.250.95
msf5 exploit(windows/smb/ms08_067_netapi) > 
```

### Example Output (Unpatched)
```
msf5 > use exploit/windows/smb/ms08_067_netapi 
msf5 exploit(windows/smb/ms08_067_netapi) > set RHOSTS 192.168.250.95/
RHOSTS => 192.168.250.95/
msf5 exploit(windows/smb/ms08_067_netapi) > exploit

[-] 192.168.250.95/:445 - Exploit failed: One or more options failed to validate: RHOSTS.
[*] Exploit completed, but no session was created.
msf5 exploit(windows/smb/ms08_067_netapi) >
```

