### PR TITLE
Add Cisco CML and VIRL-PE advisory to Salt modules

### DIFF
--- a/documentation/modules/auxiliary/gather/saltstack_salt_root_key.md
+++ b/documentation/modules/auxiliary/gather/saltstack_salt_root_key.md
@@ -7,8 +7,11 @@ method in the SaltStack Salt master's ZeroMQ request server, for
 versions 2019.2.3 and earlier and 3000.1 and earlier, to disclose the
 root key used to authenticate administrative commands to the master.
 
-VMware vRealize Operations Manager versions 7.5.0 through 8.1.0 are
-known to be affected by the Salt vulnerabilities.
+VMware vRealize Operations Manager versions 7.5.0 through 8.1.0, as
+well as Cisco Modeling Labs Corporate Edition (CML) and Cisco Virtual
+Internet Routing Lab Personal Edition (VIRL-PE), for versions 1.2,
+1.3, 1.5, and 1.6 in certain configurations, are known to be affected
+by the Salt vulnerabilities.
 
 Tested against SaltStack Salt 2019.2.3 and 3000.1 on Ubuntu 18.04, as
 well as Vulhub's Docker image.

--- a/documentation/modules/exploit/linux/misc/saltstack_salt_unauth_rce.md
+++ b/documentation/modules/exploit/linux/misc/saltstack_salt_unauth_rce.md
@@ -7,8 +7,11 @@ This module exploits unauthenticated access to the `runner()` and
 server, for versions 2019.2.3 and earlier and 3000.1 and earlier, to
 execute code as root on either the master or on select minions.
 
-VMware vRealize Operations Manager versions 7.5.0 through 8.1.0 are
-known to be affected by the Salt vulnerabilities.
+VMware vRealize Operations Manager versions 7.5.0 through 8.1.0, as
+well as Cisco Modeling Labs Corporate Edition (CML) and Cisco Virtual
+Internet Routing Lab Personal Edition (VIRL-PE), for versions 1.2,
+1.3, 1.5, and 1.6 in certain configurations, are known to be affected
+by the Salt vulnerabilities.
 
 Tested against SaltStack Salt 2019.2.3 and 3000.1 on Ubuntu 18.04, as
 well as Vulhub's Docker image.

--- a/modules/auxiliary/gather/saltstack_salt_root_key.rb
+++ b/modules/auxiliary/gather/saltstack_salt_root_key.rb
@@ -19,8 +19,11 @@ class MetasploitModule < Msf::Auxiliary
           versions 2019.2.3 and earlier and 3000.1 and earlier, to disclose the
           root key used to authenticate administrative commands to the master.
 
-          VMware vRealize Operations Manager versions 7.5.0 through 8.1.0 are
-          known to be affected by the Salt vulnerabilities.
+          VMware vRealize Operations Manager versions 7.5.0 through 8.1.0, as
+          well as Cisco Modeling Labs Corporate Edition (CML) and Cisco Virtual
+          Internet Routing Lab Personal Edition (VIRL-PE), for versions 1.2,
+          1.3, 1.5, and 1.6 in certain configurations, are known to be affected
+          by the Salt vulnerabilities.
 
           Tested against SaltStack Salt 2019.2.3 and 3000.1 on Ubuntu 18.04, as
           well as Vulhub's Docker image.
@@ -35,6 +38,7 @@ class MetasploitModule < Msf::Auxiliary
           ['URL', 'https://labs.f-secure.com/advisories/saltstack-authorization-bypass'],
           ['URL', 'https://community.saltstack.com/blog/critical-vulnerabilities-update-cve-2020-11651-and-cve-2020-11652/'],
           ['URL', 'https://www.vmware.com/security/advisories/VMSA-2020-0009.html'],
+          ['URL', 'https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-salt-2vx545AG'],
           ['URL', 'https://github.com/saltstack/salt/blob/master/tests/integration/master/test_clear_funcs.py']
         ],
         'DisclosureDate' => '2020-04-30', # F-Secure advisory

--- a/modules/exploits/linux/misc/saltstack_salt_unauth_rce.rb
+++ b/modules/exploits/linux/misc/saltstack_salt_unauth_rce.rb
@@ -23,8 +23,11 @@ class MetasploitModule < Msf::Exploit::Remote
           server, for versions 2019.2.3 and earlier and 3000.1 and earlier, to
           execute code as root on either the master or on select minions.
 
-          VMware vRealize Operations Manager versions 7.5.0 through 8.1.0 are
-          known to be affected by the Salt vulnerabilities.
+          VMware vRealize Operations Manager versions 7.5.0 through 8.1.0, as
+          well as Cisco Modeling Labs Corporate Edition (CML) and Cisco Virtual
+          Internet Routing Lab Personal Edition (VIRL-PE), for versions 1.2,
+          1.3, 1.5, and 1.6 in certain configurations, are known to be affected
+          by the Salt vulnerabilities.
 
           Tested against SaltStack Salt 2019.2.3 and 3000.1 on Ubuntu 18.04, as
           well as Vulhub's Docker image.
@@ -39,6 +42,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ['URL', 'https://labs.f-secure.com/advisories/saltstack-authorization-bypass'],
           ['URL', 'https://community.saltstack.com/blog/critical-vulnerabilities-update-cve-2020-11651-and-cve-2020-11652/'],
           ['URL', 'https://www.vmware.com/security/advisories/VMSA-2020-0009.html'],
+          ['URL', 'https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-salt-2vx545AG'],
           ['URL', 'https://github.com/saltstack/salt/blob/master/tests/integration/master/test_clear_funcs.py']
         ],
         'DisclosureDate' => '2020-04-30', # F-Secure advisory


### PR DESCRIPTION
See https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-salt-2vx545AG.

Hat tip @brudis-r7!

Updates #13401.