### PR TITLE
Change OptString of RPORT to OptPort

### DIFF
--- a/lib/msf/core/exploit/oracle.rb
+++ b/lib/msf/core/exploit/oracle.rb
@@ -23,7 +23,7 @@ module Exploit::ORACLE
     register_options(
       [
         OptString.new('RHOST',  [ true, 'The Oracle host.',                   '']),
-        OptString.new('RPORT',  [ true, 'The TNS port.',                      '1521']),
+        OptPort.new('RPORT',  [ true, 'The TNS port.',                      1521]),
         OptString.new('SID',    [ true, 'The sid to authenticate with.',      'ORCL']),
         OptString.new('DBUSER', [ true, 'The username to authenticate with.', 'SCOTT']),
         OptString.new('DBPASS', [ true, 'The password to authenticate with.', 'TIGER']),

--- a/lib/msf/core/exploit/smb/client/psexec_ms17_010.rb
+++ b/lib/msf/core/exploit/smb/client/psexec_ms17_010.rb
@@ -12,7 +12,7 @@ module Exploit::Remote::SMB::Client::Psexec_MS17_010
     register_options([
       OptString.new('NAMEDPIPE', [false, 'A named pipe that can be connected to (leave blank for auto)', '']),
       OptInt.new('LEAKATTEMPTS', [true, 'How many times to try to leak transaction', 99]), # Win10 can get stubborn
-      OptString.new('RPORT', [true, 'The Target port', 445]),
+      OptPort.new('RPORT', [true, 'The Target port', 445]),
       OptBool.new('DBGTRACE', [ true, "Show extra debug trace info", false ]),
     ])
   end

--- a/modules/auxiliary/admin/aws/aws_launch_instances.rb
+++ b/modules/auxiliary/admin/aws/aws_launch_instances.rb
@@ -41,7 +41,7 @@ class MetasploitModule < Msf::Auxiliary
     )
     register_advanced_options(
       [
-        OptString.new('RPORT', [true, 'AWS EC2 Endpoint TCP Port', 443]),
+        OptPort.new('RPORT', [true, 'AWS EC2 Endpoint TCP Port', 443]),
         OptBool.new('SSL', [true, 'AWS EC2 Endpoint SSL', true]),
         OptString.new('INSTANCE_TYPE', [true, 'The instance type', 'm3.medium']),
         OptString.new('ROLE_NAME', [false, 'The instance profile/role name', '']),

--- a/modules/auxiliary/admin/smb/ms17_010_command.rb
+++ b/modules/auxiliary/admin/smb/ms17_010_command.rb
@@ -55,7 +55,7 @@ class MetasploitModule < Msf::Auxiliary
     register_options([
       OptString.new('SMBSHARE', [true, 'The name of a writeable share on the server', 'C$']),
       OptString.new('COMMAND', [true, 'The command you want to execute on the remote host', 'net group "Domain Admins" /domain']),
-      OptString.new('RPORT', [true, 'The Target port', 445]),
+      OptPort.new('RPORT', [true, 'The Target port', 445]),
       OptString.new('WINPATH', [true, 'The name of the remote Windows directory', 'WINDOWS']),
     ])
 

--- a/modules/auxiliary/admin/smb/psexec_command.rb
+++ b/modules/auxiliary/admin/smb/psexec_command.rb
@@ -41,7 +41,7 @@ class MetasploitModule < Msf::Auxiliary
     register_options([
       OptString.new('SMBSHARE', [true, 'The name of a writeable share on the server', 'C$']),
       OptString.new('COMMAND', [true, 'The command you want to execute on the remote host', 'net group "Domain Admins" /domain']),
-      OptString.new('RPORT', [true, 'The Target port', 445]),
+      OptPort.new('RPORT', [true, 'The Target port', 445]),
       OptString.new('WINPATH', [true, 'The name of the remote Windows directory', 'WINDOWS']),
     ])
 

--- a/modules/auxiliary/client/smtp/emailer.rb
+++ b/modules/auxiliary/client/smtp/emailer.rb
@@ -31,7 +31,7 @@ class MetasploitModule < Msf::Auxiliary
       register_options(
         [
           OptString.new('RHOST', [true, "SMTP server address",'127.0.0.1']),
-          OptString.new('RPORT', [true, "SMTP server port",'25']),
+          OptPort.new('RPORT', [true, "SMTP server port", 25]),
           OptString.new('YAML_CONFIG', [true, "Full path to YAML Configuration file",
             File.join(Msf::Config.data_directory,"emailer_config.yaml")]),
         ])

--- a/modules/auxiliary/scanner/smb/psexec_loggedin_users.rb
+++ b/modules/auxiliary/scanner/smb/psexec_loggedin_users.rb
@@ -39,7 +39,7 @@ class MetasploitModule < Msf::Auxiliary
     register_options([
       OptString.new('SMBSHARE', [true, 'The name of a writeable share on the server', 'C$']),
       OptString.new('USERNAME', [false, 'The name of a specific user to search for', '']),
-      OptString.new('RPORT', [true, 'The Target port', 445]),
+      OptPort.new('RPORT', [true, 'The Target port', 445]),
       OptString.new('WINPATH', [true, 'The name of the Windows directory', 'WINDOWS']),
     ])
   end

--- a/modules/auxiliary/scanner/smb/smb_enum_gpp.rb
+++ b/modules/auxiliary/scanner/smb/smb_enum_gpp.rb
@@ -40,7 +40,7 @@ class MetasploitModule < Msf::Auxiliary
     )
     register_options([
       OptString.new('SMBSHARE', [true, 'The name of the share on the server', 'SYSVOL']),
-      OptString.new('RPORT', [true, 'The Target port', 445]),
+      OptPort.new('RPORT', [true, 'The Target port', 445]),
       OptBool.new('STORE', [true, 'Store the enumerated files in loot.', true])
     ])
   end

--- a/modules/auxiliary/server/jsse_skiptls_mitm_proxy.rb
+++ b/modules/auxiliary/server/jsse_skiptls_mitm_proxy.rb
@@ -52,7 +52,7 @@ class MetasploitModule < Msf::Auxiliary
         OptString.new('FAKEHOST', [ false, 'The fake server address', nil]),
         OptString.new('FAKEPORT', [ false, 'The fake server port', 443]),
         OptString.new('HOST', [ true, 'The server address', nil]),
-        OptString.new('PORT', [ true, 'The server port', 443]),
+        OptPort.new('PORT', [ true, 'The server port', 443]),
         OptString.new('SRVHOST', [ true, 'The proxy address', '0.0.0.0']),
         OptString.new('SRVPORT', [ true, 'The proxy port', 443])
       ])

--- a/modules/auxiliary/server/openssl_altchainsforgery_mitm_proxy.rb
+++ b/modules/auxiliary/server/openssl_altchainsforgery_mitm_proxy.rb
@@ -58,7 +58,7 @@ class MetasploitModule < Msf::Auxiliary
         OptString.new('PASSPHRASE', [ false, "The pass phrase for the leaf certificate's private key", nil]),
         OptString.new('SUBJECT', [ false, 'The subject field for the fake certificate', '/C=US/ST=California/L=Mountain View/O=Example Inc/CN=*.example.com']),
         OptString.new('HOST', [ true, 'The server address', nil]),
-        OptString.new('PORT', [ true, 'The server port', 443]),
+        OptPort.new('PORT', [ true, 'The server port', 443]),
         OptString.new('SRVHOST', [ true, 'The proxy address', '0.0.0.0']),
         OptString.new('SRVPORT', [ true, 'The proxy port', 443])
       ])

--- a/modules/auxiliary/vsploit/pii/email_pii.rb
+++ b/modules/auxiliary/vsploit/pii/email_pii.rb
@@ -24,7 +24,7 @@ class MetasploitModule < Msf::Auxiliary
       register_options(
         [
           OptString.new('RHOST', [true, "SMTP server address",'127.0.0.1']),
-          OptString.new('RPORT', [true, "SMTP server port",'25'])
+          OptPort.new('RPORT', [true, "SMTP server port", 25])
         ])
   end
 

--- a/modules/post/multi/escalate/aws_create_iam_user.rb
+++ b/modules/post/multi/escalate/aws_create_iam_user.rb
@@ -47,7 +47,7 @@ class MetasploitModule < Msf::Post
       [
         OptString.new('METADATA_IP', [true, 'The metadata service IP', '169.254.169.254']),
         OptString.new('RHOST', [true, 'AWS IAM Endpoint', 'iam.amazonaws.com']),
-        OptString.new('RPORT', [true, 'AWS IAM Endpoint TCP Port', 443]),
+        OptPort.new('RPORT', [true, 'AWS IAM Endpoint TCP Port', 443]),
         OptString.new('SSL', [true, 'AWS IAM Endpoint SSL', true]),
         OptString.new('IAM_GROUP_POL', [true, 'IAM group policy to use', '{"Version": "2012-10-17", "Statement": [{"Effect": "Allow", "Action": "*", "Resource": "*" }]}']),
         OptString.new('Region', [true, 'The default region', 'us-east-1' ])


### PR DESCRIPTION
- rpc interface requests module.option methods, Rport type should be port not string
- request
```
{
	"jsonrpc": "2.0",
	"method": "module.options",
	"params": [
		"exploit",
		"exploit/windows/smb/ms17_010_psexec"
	],
	"id": 0
}
```

## before
```
[
  "RPORT": {
    "type": "string",
    "required": true,
    "advanced": false,
    "evasion": false,
    "desc": "The Target port",
    "default": 445
  }
]
```

## after
- response
``` json
[
 "RPORT": {
    "type": "port",
    "required": true,
    "advanced": false,
    "evasion": false,
    "desc": "The Target port",
    "default": 445
  }
]
```