### PR TITLE
Add rest api file manager

### DIFF
--- a/documentation/api/v1/file_api_doc.rb
+++ b/documentation/api/v1/file_api_doc.rb
@@ -1,0 +1,321 @@
+require 'swagger/blocks'
+
+module FileApiDoc
+  include Swagger::Blocks
+
+  FILE_DESC = 'Specify a file.'.freeze
+
+  # Swagger documentation for File model
+  swagger_schema :File do
+    property :path, type: :string, description: FILE_DESC
+  end
+
+  swagger_path '/api/v1/files/file' do
+    # Swagger documentation for /api/v1/files/file GET
+    operation :get do
+      key :description, 'Download the file in the specified path.'
+      key :tags, [ 'file' ]
+
+      parameter do
+        key :in, :query
+        key :name, :path
+        key :required, true
+        key :description, FILE_DESC
+      end
+
+      response 200 do
+        key :description, 'Return downloaded file.'
+        schema do
+          property :data do
+            key :type, :string
+          end
+        end
+      end
+
+      response 401 do
+        key :description, RootApiDoc::DEFAULT_RESPONSE_401
+        schema do
+          key :'$ref', :AuthErrorModel
+        end
+      end
+
+      response 500 do
+        key :description, RootApiDoc::DEFAULT_RESPONSE_500
+        schema do
+          key :'$ref', :ErrorModel
+        end
+      end
+    end
+
+    # Swagger documentation for /api/v1/files/file POST
+    operation :post do
+      key :description, 'Upload file to the specified path.'
+      key :tags, [ 'file' ]
+
+      parameter do
+        key :in, :body
+        key :name, :body
+        key :description, 'Specify a path.'
+        key :required, true
+        schema do
+          property :path, type: :string, required: true, description: FILE_DESC
+        end
+      end
+
+      response 200 do
+        key :description, 'Return the path of the file'
+        schema do
+          property :data do
+            key :type, :string
+          end
+        end
+      end
+
+      response 401 do
+        key :description, RootApiDoc::DEFAULT_RESPONSE_401
+        schema do
+          key :'$ref', :AuthErrorModel
+        end
+      end
+
+      response 500 do
+        key :description, RootApiDoc::DEFAULT_RESPONSE_500
+        schema do
+          key :'$ref', :ErrorModel
+        end
+      end
+    end
+    # Swagger documentation for /api/v1/files/file PUT
+    operation :put do
+      key :description, 'Rename the file at the specified path.'
+      key :tags, [ 'file' ]
+
+      parameter do
+        key :in, :body
+        key :name, :body
+        key :description, 'Original file path.'
+        key :required, true
+        schema do
+          property :path, type: :string, required: true, description: FILE_DESC
+          property :new_path, type: :string, required: true, description: FILE_DESC
+        end
+      end
+
+      response 200 do
+        key :description, RootApiDoc::DEFAULT_RESPONSE_200
+        schema do
+          property :data do
+            key :type, :string
+          end
+        end
+      end
+
+      response 401 do
+        key :description, RootApiDoc::DEFAULT_RESPONSE_401
+        schema do
+          key :'$ref', :AuthErrorModel
+        end
+      end
+
+      response 500 do
+        key :description, RootApiDoc::DEFAULT_RESPONSE_500
+        schema do
+          key :'$ref', :ErrorModel
+        end
+      end
+    end
+    # Swagger documentation for /api/v1/files/file DELETE
+    operation :delete do
+      key :description, 'Delete the file in the specified path.'
+      key :tags, [ 'file' ]
+
+      parameter do
+        key :in, :body
+        key :name, :path
+        key :description, FILE_DESC
+        key :required, true
+        schema do
+          property :path, type: :string, required: true, description: FILE_DESC
+        end
+      end
+
+      response 200 do
+        key :description, RootApiDoc::DEFAULT_RESPONSE_200
+        schema do
+          property :data do
+            key :type, :string
+          end
+        end
+      end
+
+      response 401 do
+        key :description, RootApiDoc::DEFAULT_RESPONSE_401
+        schema do
+          key :'$ref', :AuthErrorModel
+        end
+      end
+
+      response 500 do
+        key :description, RootApiDoc::DEFAULT_RESPONSE_500
+        schema do
+          key :'$ref', :ErrorModel
+        end
+      end
+    end
+  end
+
+  swagger_path '/api/v1/files/dir' do
+    # Swagger documentation for api/v1/files/dir GET
+    operation :get do
+      key :description, 'List the files in the specified path.'
+      key :tags, [ 'file' ]
+
+      parameter do
+        key :name, :path
+        key :in, :query
+        key :description, 'Specify a directory.'
+        key :required, false
+      end
+
+      response 200 do
+        key :description, 'Returns file data.'
+        schema do
+          property :data do
+            key :type, :string
+          end
+        end
+      end
+
+      response 401 do
+        key :description, RootApiDoc::DEFAULT_RESPONSE_401
+        schema do
+          key :'$ref', :AuthErrorModel
+        end
+      end
+
+      response 500 do
+        key :description, RootApiDoc::DEFAULT_RESPONSE_500
+        schema do
+          key :'$ref', :ErrorModel
+        end
+      end
+    end
+
+    # Swagger documentation for api/v1/files/dir POST
+    operation :post do
+      key :description, 'Create a directory to the specified path.'
+      key :tags, [ 'file' ]
+
+      parameter do
+        key :name, :body
+        key :in, :body
+        key :description, 'Specify a directory.'
+        key :required, true
+        schema do
+          property :path, type: :string, required: true, description: FILE_DESC
+        end
+      end
+
+      response 200 do
+        key :description, 'Return to the successfully created path.'
+        schema do
+          property :data do
+            key :type, :string
+          end
+        end
+      end
+
+      response 401 do
+        key :description, RootApiDoc::DEFAULT_RESPONSE_401
+        schema do
+          key :'$ref', :AuthErrorModel
+        end
+      end
+
+      response 500 do
+        key :description, RootApiDoc::DEFAULT_RESPONSE_500
+        schema do
+          key :'$ref', :ErrorModel
+        end
+      end
+    end
+
+    # Swagger documentation for /api/v1/hosts/:id PUT
+    operation :put do
+      key :description, 'Rename the specified directory.'
+      key :tags, [ 'file' ]
+
+      parameter do
+        key :in, :body
+        key :name, :body
+        key :description, 'Original directory path.'
+        key :required, true
+        schema do
+          property :path, type: :string, required: true, description: FILE_DESC
+          property :new_path, type: :string, required: true, description: FILE_DESC
+        end
+      end
+
+      response 200 do
+        key :description, RootApiDoc::DEFAULT_RESPONSE_200
+        schema do
+          property :data do
+            key :type, :string
+          end
+        end
+      end
+
+      response 401 do
+        key :description, RootApiDoc::DEFAULT_RESPONSE_401
+        schema do
+          key :'$ref', :AuthErrorModel
+        end
+      end
+
+      response 500 do
+        key :description, RootApiDoc::DEFAULT_RESPONSE_500
+        schema do
+          key :'$ref', :ErrorModel
+        end
+      end
+    end
+    # Swagger documentation for /api/v1/hosts/:id DELETE
+    operation :delete do
+      key :description, 'Delete the specified path directory.'
+      key :tags, [ 'file' ]
+
+      parameter do
+        key :in, :body
+        key :name, :path
+        key :description, 'Specify a directory.'
+        key :required, true
+        schema do
+          property :path, type: :string, required: true, description: FILE_DESC
+        end
+      end
+
+      response 200 do
+        key :description, RootApiDoc::DEFAULT_RESPONSE_200
+        schema do
+          property :data do
+            key :type, :string
+          end
+        end
+      end
+
+      response 401 do
+        key :description, RootApiDoc::DEFAULT_RESPONSE_401
+        schema do
+          key :'$ref', :AuthErrorModel
+        end
+      end
+
+      response 500 do
+        key :description, RootApiDoc::DEFAULT_RESPONSE_500
+        schema do
+          key :'$ref', :ErrorModel
+        end
+      end
+    end
+  end
+end

--- a/documentation/api/v1/file_api_doc.rb
+++ b/documentation/api/v1/file_api_doc.rb
@@ -4,6 +4,7 @@ module FileApiDoc
   include Swagger::Blocks
 
   FILE_DESC = 'Specify a file.'.freeze
+  PATH_DESC = 'Specify a path.'.freeze
 
   # Swagger documentation for File model
   swagger_schema :File do
@@ -297,6 +298,75 @@ module FileApiDoc
 
       response 200 do
         key :description, RootApiDoc::DEFAULT_RESPONSE_200
+        schema do
+          property :data do
+            key :type, :string
+          end
+        end
+      end
+
+      response 401 do
+        key :description, RootApiDoc::DEFAULT_RESPONSE_401
+        schema do
+          key :'$ref', :AuthErrorModel
+        end
+      end
+
+      response 500 do
+        key :description, RootApiDoc::DEFAULT_RESPONSE_500
+        schema do
+          key :'$ref', :ErrorModel
+        end
+      end
+    end
+  end
+  swagger_path '/api/v1/files/root' do
+    # Swagger documentation for api/v1/files/root GET
+    operation :get do
+      key :description, 'Return rest_file directory path.'
+      key :tags, [ 'file' ]
+
+      response 200 do
+        key :description, 'Return rest_file directory path.'
+        schema do
+          property :data do
+            key :type, :string
+          end
+        end
+      end
+
+      response 401 do
+        key :description, RootApiDoc::DEFAULT_RESPONSE_401
+        schema do
+          key :'$ref', :AuthErrorModel
+        end
+      end
+
+      response 500 do
+        key :description, RootApiDoc::DEFAULT_RESPONSE_500
+        schema do
+          key :'$ref', :ErrorModel
+        end
+      end
+    end
+  end
+  swagger_path '/api/v1/files/search' do
+    # Swagger documentation for api/v1/files/search GET
+    operation :get do
+      key :description, 'Return search keywords file path.'
+      key :tags, [ 'file' ]
+      parameter do
+        key :in, :query
+        key :name, :path
+        key :description, PATH_DESC
+      end
+      parameter do
+        key :in, :query
+        key :name, :search_term
+        key :description, 'search keywords'
+      end
+      response 200 do
+        key :description, 'Returns file data.'
         schema do
           property :data do
             key :type, :string

--- a/documentation/api/v1/file_api_doc.rb
+++ b/documentation/api/v1/file_api_doc.rb
@@ -59,6 +59,7 @@ module FileApiDoc
         key :required, true
         schema do
           property :path, type: :string, required: true, description: FILE_DESC
+          property :file, type: :string, format: :binary, required: true, description: 'Please upload a file'
         end
       end
 

--- a/documentation/api/v1/root_api_doc.rb
+++ b/documentation/api/v1/root_api_doc.rb
@@ -80,6 +80,7 @@ module RootApiDoc
     tag name: 'vuln', description: 'Vuln operations.'
     tag name: 'vuln_attempt', description: 'Vuln Attempt operations.'
     tag name: 'workspace', description: 'Workspace operations.'
+    tag name: 'file', description: 'file operations.'
 
     #################################
     #

--- a/lib/metasploit/framework/data_service.rb
+++ b/lib/metasploit/framework/data_service.rb
@@ -10,6 +10,7 @@ require 'metasploit/framework/data_service/stubs/session_event_service'
 require 'metasploit/framework/data_service/stubs/exploit_data_service'
 require 'metasploit/framework/data_service/stubs/loot_data_service'
 require 'metasploit/framework/data_service/stubs/msf_data_service'
+require 'metasploit/framework/data_service/stubs/file_data_service'
 
 #
 # All data service implementations should include this module to ensure proper implementation
@@ -29,6 +30,7 @@ module DataService
   include ExploitDataService
   include LootDataService
   include MsfDataService
+  include FileDataService
 
   def name
     raise 'DataService#name is not implemented';

--- a/lib/metasploit/framework/data_service/stubs/file_data_service.rb
+++ b/lib/metasploit/framework/data_service/stubs/file_data_service.rb
@@ -1,0 +1,14 @@
+module FileDataService
+
+  def list_local_path(opts)
+    raise 'FileDataService#list_local_path is not implemented'
+  end
+
+  def safe_expand_path?(opts)
+    raise 'FileDataService#find_or_create_note is not implemented'
+  end
+
+  def rest_files_directory?(opts)
+    raise 'FileDataService#report_note is not implemented'
+  end
+end

--- a/lib/msf/base/config.rb
+++ b/lib/msf/base/config.rb
@@ -146,6 +146,13 @@ class Config < Hash
     self.new.session_log_directory
   end
 
+  # Returns the directory in which rest files are to reside.
+  #
+  # @return [String] path to rest file directory.
+  def self.rest_files_directory
+    self.new.rest_files_directory
+  end
+
   # Returns the directory in which captured data will reside.
   #
   # @return [String] path to loot directory.
@@ -349,6 +356,13 @@ class Config < Hash
     config_directory + FileSep + self['LocalDirectory']
   end
 
+  # Returns the user-specific rest file path.
+  #
+  # @return [String] path to rest file directory.
+  def rest_files_directory
+    config_directory + FileSep + 'rest_files'
+  end
+
   # Return the user-specific directory that logo files should be loaded from.
   #
   # @return [String] path to the logos directory.
@@ -397,6 +411,7 @@ class Config < Hash
     FileUtils.mkdir_p(user_logos_directory)
     FileUtils.mkdir_p(user_module_directory)
     FileUtils.mkdir_p(user_plugin_directory)
+    FileUtils.mkdir_p(rest_files_directory)
   end
 
   # Loads configuration from the supplied file path, or the default one if

--- a/lib/msf/core/db_manager.rb
+++ b/lib/msf/core/db_manager.rb
@@ -62,6 +62,7 @@ class Msf::DBManager
   autoload :WMAP, 'msf/core/db_manager/wmap'
   autoload :Web, 'msf/core/db_manager/web'
   autoload :Workspace, 'msf/core/db_manager/workspace'
+  autoload :FileManager, 'msf/core/db_manager/file'
 
   optionally_include_metasploit_credential_creation
 
@@ -101,6 +102,7 @@ class Msf::DBManager
   include Msf::DBManager::WMAP
   include Msf::DBManager::Web
   include Msf::DBManager::Workspace
+  include Msf::DBManager::FileManager
 
   # Provides :framework and other accessors
   include Msf::Framework::Offspring

--- a/lib/msf/core/db_manager/file.rb
+++ b/lib/msf/core/db_manager/file.rb
@@ -1,0 +1,35 @@
+require 'fileutils'
+# FileManager
+module Msf::DBManager::FileManager
+  def list_local_path(path)
+    # Enumerate each item...
+    tbl = []
+    files = Dir.entries(path)
+    files.each do |file|
+      file_path = File.join(path, file)
+      stat = File.stat(file_path)
+      row = {
+        name: file.force_encoding('UTF-8'),
+        type: stat.ftype || '',
+        size: stat.size ? stat.size.to_s : '',
+        last_modified: stat.mtime || ''
+      }
+      next unless file != '.' && file != '..'
+
+      tbl << row
+    end
+    return tbl
+  end
+
+  def safe_expand_path?(path)
+    current_directory = File.expand_path(Msf::Config.rest_files_directory) + File::SEPARATOR
+    tested_path = File.expand_path(path) + File::SEPARATOR
+    tested_path.starts_with?(current_directory)
+  end
+
+  def rest_files_directory?(path)
+    tested_path = File.expand_path(path) + File::SEPARATOR
+    current_directory = File.expand_path(Msf::Config.rest_files_directory) + File::SEPARATOR
+    tested_path == current_directory
+  end
+end

--- a/lib/msf/core/web_services/metasploit_api_app.rb
+++ b/lib/msf/core/web_services/metasploit_api_app.rb
@@ -27,6 +27,7 @@ require 'msf/core/web_services/servlet/user_servlet'
 require 'msf/core/web_services/servlet/payload_servlet'
 require 'msf/core/web_services/servlet/module_search_servlet'
 require 'msf/core/web_services/servlet/db_import_servlet'
+require 'msf/core/web_services/servlet/file_servlet'
 
 class MetasploitApiApp < Sinatra::Base
   helpers ServletHelper
@@ -55,6 +56,7 @@ class MetasploitApiApp < Sinatra::Base
   register PayloadServlet
   register ModuleSearchServlet
   register DbImportServlet
+  register FileServlet
 
   configure do
     set :sessions, {key: 'msf-ws.session', expire_after: 300}

--- a/lib/msf/core/web_services/servlet/api_docs_servlet.rb
+++ b/lib/msf/core/web_services/servlet/api_docs_servlet.rb
@@ -20,6 +20,7 @@ load 'documentation/api/v1/user_api_doc.rb'
 load 'documentation/api/v1/vuln_api_doc.rb'
 load 'documentation/api/v1/vuln_attempt_api_doc.rb'
 load 'documentation/api/v1/workspace_api_doc.rb'
+load 'documentation/api/v1/file_api_doc.rb'
 
 
 module ApiDocsServlet
@@ -65,7 +66,8 @@ module ApiDocsServlet
           UserApiDoc,
           VulnApiDoc,
           VulnAttemptApiDoc,
-          WorkspaceApiDoc
+          WorkspaceApiDoc,
+          FileApiDoc
       ].freeze
       json = Swagger::Blocks.build_root_json(swaggered_classes)
       set_json_response(json, [])

--- a/lib/msf/core/web_services/servlet/file_servlet.rb
+++ b/lib/msf/core/web_services/servlet/file_servlet.rb
@@ -1,0 +1,205 @@
+#
+# Standard Library
+#
+
+require 'fileutils'
+module FileServlet
+  def self.api_path
+    '/api/v1/files'
+  end
+
+  def self.api_path_for_file
+    "#{FileServlet.api_path}/file"
+  end
+
+  def self.api_path_for_dir
+    "#{FileServlet.api_path}/dir"
+  end
+
+  def self.registered(app)
+    app.get FileServlet.api_path_for_file, &file_download
+    app.post FileServlet.api_path_for_file, &file_upload
+    app.put FileServlet.api_path_for_file, &file_rename
+    app.delete FileServlet.api_path_for_file, &file_delete
+
+    app.get FileServlet.api_path_for_dir, &dir_entries
+    app.post FileServlet.api_path_for_dir, &dir_mkdir
+    app.put FileServlet.api_path_for_dir, &dir_rename
+    app.delete FileServlet.api_path_for_dir, &dir_delete
+  end
+  #######
+
+  #######
+  # file
+  def self.file_download
+    warden.authenticate!
+    lambda {
+      sanitized_params = sanitize_params(params, env['rack.request.query_hash'])
+      opts_path = sanitized_params[:path] || ''
+      path = File.join(Msf::Config.rest_files_directory, opts_path)
+      if safe_expand_path?(path) && File.exist?(path) && !File.directory?(path)
+        send_file(path, buffer_size: 4096, stream: true)
+      else
+        result = { message: 'No such file' }
+        set_json_data_response(response: result)
+      end
+    }
+  end
+
+  def self.file_upload
+    warden.authenticate!
+    lambda {
+      sanitized_params = sanitize_params(params, env['rack.request.query_hash'])
+      if sanitized_params[:filename]
+        opts_path = sanitized_params[:path] || ''
+        path = File.join(Msf::Config.rest_files_directory, opts_path)
+        temp_path = sanitized_params[:filename][:tempfile].path
+        if safe_expand_path?(path) && !File.exist?(path)
+          FileUtils.mkdir_p(File.dirname(path))
+          FileUtils.cp_r(temp_path, path)
+          result = { path: path }
+        else
+          result = { message: 'The file already exists' }
+        end
+        FileUtils.rm_rf(temp_path) if File.exist?(temp_path)
+      else
+        result = { message: 'Please upload a file' }
+      end
+      set_json_data_response(response: result)
+    }
+  end
+
+  def self.file_delete
+    warden.authenticate!
+    lambda {
+      opts = parse_json_request(request, true)
+      opts_path = opts[:path] || ''
+      path = File.join(Msf::Config.rest_files_directory, opts_path)
+      if !rest_files_directory?(path) && !File.directory?(path) && safe_expand_path?(path)
+        FileUtils.rm_rf(path)
+        result = { path: path }
+      else
+        result = { message: 'No such file' }
+      end
+      set_json_data_response(response: result)
+    }
+  end
+
+  def self.file_rename
+    warden.authenticate!
+    lambda {
+      opts = parse_json_request(request, true)
+      opts_path = opts[:path] || ''
+      opts_new_path = opts[:new_path] || ''
+      path = File.join(Msf::Config.rest_files_directory, opts_path)
+      new_path = File.join(Msf::Config.rest_files_directory, opts_new_path)
+      if (!File.directory?(path) && safe_expand_path?(path)) && File.exist?(path) \
+        && (!File.directory?(new_path) && safe_expand_path?(new_path))
+        FileUtils.mv(path, new_path)
+        result = { path: new_path }
+      else
+        result = { message: 'No such file' }
+      end
+      set_json_data_response(response: result)
+    }
+  end
+
+  # dir
+  def self.dir_entries
+    warden.authenticate!
+    lambda {
+      sanitized_params = sanitize_params(params, env['rack.request.query_hash'])
+      opts_path = sanitized_params[:path] || ''
+      path = File.join(Msf::Config.rest_files_directory, opts_path)
+      if safe_expand_path?(path) && File.directory?(path)
+        result = list_local_path(path)
+      else
+        result = { message: 'No such directory' }
+      end
+      set_json_data_response(response: result)
+    }
+  end
+
+  def self.dir_mkdir
+    warden.authenticate!
+    lambda {
+      opts = parse_json_request(request, true)
+      opts_path = opts[:path] || ''
+      path = File.join(Msf::Config.rest_files_directory, opts_path)
+      if safe_expand_path?(path)
+        FileUtils.mkdir_p(path)
+        result = { path: path }
+      else
+        result = { message: 'Failed to create folder' }
+      end
+      set_json_data_response(response: result)
+    }
+  end
+
+  def self.dir_delete
+    warden.authenticate!
+    lambda {
+      opts = parse_json_request(request, true)
+      opts_path = opts[:path] || ''
+      path = File.join(Msf::Config.rest_files_directory, opts_path)
+      if !rest_files_directory?(path) && safe_expand_path?(path) && File.directory?(path)
+        FileUtils.rm_rf(path)
+        result = { path: path }
+      else
+        result = { message: 'No such directory' }
+      end
+      set_json_data_response(response: result)
+    }
+  end
+
+  def self.dir_rename
+    warden.authenticate!
+    lambda {
+      opts = parse_json_request(request, true)
+      opts_path = opts[:path] || ''
+      opts_new_path = opts[:new_path] || ''
+      path = File.join(Msf::Config.rest_files_directory, opts_path)
+      new_path = File.join(Msf::Config.rest_files_directory, opts_new_path)
+      if (!rest_files_directory?(path) && safe_expand_path?(path) && File.directory?(path)) \
+        && (!rest_files_directory?(new_path) && safe_expand_path?(new_path))
+        FileUtils.mv(path, new_path)
+        result = { path: new_path }
+      else
+        result = { message: 'No such directory' }
+      end
+      set_json_data_response(response: result)
+    }
+  end
+end
+
+def list_local_path(path)
+  # Enumerate each item...
+  tbl = []
+  files = Dir.entries(path)
+  files.each do |file|
+    file_path = File.join(path, file)
+    stat = File.stat(file_path)
+    row = {
+      name: file,
+      type: stat.ftype || '',
+      size: stat.size ? stat.size.to_s : '',
+      last_modified: stat.mtime || ''
+    }
+    next unless file != '.' && file != '..'
+
+    tbl << row
+  end
+  return tbl
+end
+
+def safe_expand_path?(path)
+  current_directory = File.expand_path(Msf::Config.rest_files_directory)
+  tested_path = File.expand_path(path)
+  tested_path.starts_with?(current_directory)
+end
+
+def rest_files_directory?(path)
+  tested_path = File.expand_path(path)
+  current_directory = File.expand_path(Msf::Config.rest_files_directory)
+  tested_path == current_directory
+end

--- a/lib/msf/core/web_services/servlet/file_servlet.rb
+++ b/lib/msf/core/web_services/servlet/file_servlet.rb
@@ -32,8 +32,8 @@ module FileServlet
   #######
   # file
   def self.file_download
-    warden.authenticate!
     lambda {
+      warden.authenticate!
       sanitized_params = sanitize_params(params, env['rack.request.query_hash'])
       opts_path = sanitized_params[:path] || ''
       path = File.join(Msf::Config.rest_files_directory, opts_path)
@@ -47,8 +47,8 @@ module FileServlet
   end
 
   def self.file_upload
-    warden.authenticate!
     lambda {
+      warden.authenticate!
       sanitized_params = sanitize_params(params, env['rack.request.query_hash'])
       if sanitized_params[:filename]
         opts_path = sanitized_params[:path] || ''
@@ -70,8 +70,8 @@ module FileServlet
   end
 
   def self.file_delete
-    warden.authenticate!
     lambda {
+      warden.authenticate!
       opts = parse_json_request(request, true)
       opts_path = opts[:path] || ''
       path = File.join(Msf::Config.rest_files_directory, opts_path)
@@ -86,8 +86,8 @@ module FileServlet
   end
 
   def self.file_rename
-    warden.authenticate!
     lambda {
+      warden.authenticate!
       opts = parse_json_request(request, true)
       opts_path = opts[:path] || ''
       opts_new_path = opts[:new_path] || ''
@@ -106,8 +106,8 @@ module FileServlet
 
   # dir
   def self.dir_entries
-    warden.authenticate!
     lambda {
+      warden.authenticate!
       sanitized_params = sanitize_params(params, env['rack.request.query_hash'])
       opts_path = sanitized_params[:path] || ''
       path = File.join(Msf::Config.rest_files_directory, opts_path)
@@ -121,8 +121,8 @@ module FileServlet
   end
 
   def self.dir_mkdir
-    warden.authenticate!
     lambda {
+      warden.authenticate!
       opts = parse_json_request(request, true)
       opts_path = opts[:path] || ''
       path = File.join(Msf::Config.rest_files_directory, opts_path)
@@ -137,8 +137,8 @@ module FileServlet
   end
 
   def self.dir_delete
-    warden.authenticate!
     lambda {
+      warden.authenticate!
       opts = parse_json_request(request, true)
       opts_path = opts[:path] || ''
       path = File.join(Msf::Config.rest_files_directory, opts_path)
@@ -153,8 +153,8 @@ module FileServlet
   end
 
   def self.dir_rename
-    warden.authenticate!
     lambda {
+      warden.authenticate!
       opts = parse_json_request(request, true)
       opts_path = opts[:path] || ''
       opts_new_path = opts[:new_path] || ''

--- a/lib/msf/core/web_services/servlet/file_servlet.rb
+++ b/lib/msf/core/web_services/servlet/file_servlet.rb
@@ -50,10 +50,10 @@ module FileServlet
     lambda {
       warden.authenticate!
       sanitized_params = sanitize_params(params, env['rack.request.query_hash'])
-      if sanitized_params[:filename]
+      if sanitized_params[:file]
         opts_path = sanitized_params[:path] || ''
         path = File.join(Msf::Config.rest_files_directory, opts_path)
-        temp_path = sanitized_params[:filename][:tempfile].path
+        temp_path = sanitized_params[:file][:tempfile].path
         if safe_expand_path?(path) && !File.exist?(path)
           FileUtils.mkdir_p(File.dirname(path))
           FileUtils.cp_r(temp_path, path)

--- a/lib/msf/core/web_services/servlet/file_servlet.rb
+++ b/lib/msf/core/web_services/servlet/file_servlet.rb
@@ -193,13 +193,13 @@ def list_local_path(path)
 end
 
 def safe_expand_path?(path)
-  current_directory = File.expand_path(Msf::Config.rest_files_directory)
-  tested_path = File.expand_path(path)
+  current_directory = File.expand_path(Msf::Config.rest_files_directory) + File::SEPARATOR
+  tested_path = File.expand_path(path) + File::SEPARATOR
   tested_path.starts_with?(current_directory)
 end
 
 def rest_files_directory?(path)
-  tested_path = File.expand_path(path)
-  current_directory = File.expand_path(Msf::Config.rest_files_directory)
+  tested_path = File.expand_path(path) + File::SEPARATOR
+  current_directory = File.expand_path(Msf::Config.rest_files_directory) + File::SEPARATOR
   tested_path == current_directory
 end

--- a/spec/lib/msf/db_manager_spec.rb
+++ b/spec/lib/msf/db_manager_spec.rb
@@ -47,6 +47,7 @@ RSpec.describe Msf::DBManager do
   it_should_behave_like 'Msf::DBManager::WMAP'
   it_should_behave_like 'Msf::DBManager::Web'
   it_should_behave_like 'Msf::DBManager::Workspace'
+  it_should_behave_like 'Msf::DBManager::FileManager'
 
   # Not implemented in remote data service
   unless ENV['REMOTE_DB']

--- a/spec/lib/msf/db_manager_spec.rb
+++ b/spec/lib/msf/db_manager_spec.rb
@@ -47,7 +47,6 @@ RSpec.describe Msf::DBManager do
   it_should_behave_like 'Msf::DBManager::WMAP'
   it_should_behave_like 'Msf::DBManager::Web'
   it_should_behave_like 'Msf::DBManager::Workspace'
-  it_should_behave_like 'Msf::DBManager::FileManager'
 
   # Not implemented in remote data service
   unless ENV['REMOTE_DB']


### PR DESCRIPTION
When I call brute force password cracking on the RPC interface, I need to specify a wordlist file, I had to use other methods to upload the wordlist file to the server to use it, so I added the file manager function to the rest api, and it would be easy to manage the files on the server.

- It will create a rest_files directory in the MSF configuration folder
```
➜  .msf4 pwd
/home/kali-team/.msf4
➜  .msf4 ls --icon never
database.yml  db  history  local  logos  logs  loot  modules  msf-ws-cert.pem  msf-ws-key.pem  msf-ws.pid  plugins  rest_files  store
➜  .msf4 
```
## File operating
### download file
```
➜  ~ curl -k -X GET "https://api.kali-team.cn:5443/api/v1/files/file?path=A.txt" -H "accept: application/json" -H "Authorization: Bearer 15f96b3959677f6e45c2efaa1b42ae46cdcac96a2c0e41d3e2033d001af534d10842f40fe58ee081"
A
```
### upload file
- key name for uploaded file is `file`
```
➜  ~ curl -k -F "path=/password/TOP1000.txt" -F "file=@TOP1000.txt" https://api.kali-team.cn:5443/api/v1/files/file -H "Authorization: Bearer 15f96b3959677f6e45c2efaa1b42ae46cdcac96a2c0e41d3e2033d001af534d10842f40fe58ee081"
{"data":{"path":"/home/kali-team/.msf4/rest_files/password/TOP1000.txt"}}% 
➜  ~ cd .msf4/rest_files 
➜  rest_files ls
 A.jpg  A.txt   password  pic
➜  rest_files cd password 
➜  password ls
TOP1000.txt
➜  password 
```
### rename file
- rename B.txt to A.txt
```
➜  rest_files ls
  A.jpg   B.txt   password   pic
➜  rest_files curl -k -X PUT "https://api.kali-team.cn:5443/api/v1/files/file" -H "accept: application/json" -H "Authorization: Bearer 15f96b3959677f6e45c2efaa1b42ae46cdcac96a2c0e41d3e2033d001af534d10842f40fe58ee081" -H "Content-Type: application/json" -d "{ \"path\": \"B.txt\", \"new_path\": \"A.txt\"}"
{"data":{"path":"/home/kali-team/.msf4/rest_files/A.txt"}}%                                                                                                                   ➜  rest_files ls
  A.jpg   A.txt   password   pic
➜  rest_files 
```
### delete file
- remove A.txt
```
➜  rest_files ls --icon never
A.jpg  A.txt  password  pic
➜  rest_files curl -k -X DELETE "https://api.kali-team.cn:5443/api/v1/files/file" -H "accept: application/json" -H "Authorization: Bearer 15f96b3959677f6e45c2efaa1b42ae46cdcac96a2c0e41d3e2033d001af534d10842f40fe58ee081" -H "Content-Type: application/json" -d "{ \"path\": \"A.txt\"}"
{"data":{"path":"/home/kali-team/.msf4/rest_files/A.txt"}}%                                                                                                                   ➜  rest_files ls
  A.jpg    password   pic
➜  rest_files 
```

## Dir operating
### list
```
curl -X GET "https://api.kali-team.cn:5443/api/v1/files/dir" -H "accept: application/json" -H "Authorization: Bearer 15f96b3959677f6e45c2efaa1b42ae46cdcac96a2c0e41d3e2033d001af534d10842f40fe58ee081"
```
- response
``` json
{
  "data": [
    {
      "name": "password",
      "type": "directory",
      "size": "4096",
      "last_modified": "2020-06-02T16:56:26.185+08:00"
    },
    {
      "name": "pic",
      "type": "directory",
      "size": "4096",
      "last_modified": "2020-06-02T16:10:21.978+08:00"
    },
    {
      "name": "A.jpg",
      "type": "file",
      "size": "3642",
      "last_modified": "2020-06-02T15:59:00.698+08:00"
    }
  ]
}
```
### Create a directory
```
curl -X POST "https://api.kali-team.cn:5443/api/v1/files/dir" -H "accept: application/json" -H "Authorization: Bearer 15f96b3959677f6e45c2efaa1b42ae46cdcac96a2c0e41d3e2033d001af534d10842f40fe58ee081" -H "Content-Type: application/json" -d "{ \"path\": \"new\"}"
```
- response
```
{
  "data": {
    "path": "/home/kali-team/.msf4/rest_files/new"
  }
}
```
### Rename directory
```
curl -X PUT "https://api.kali-team.cn:5443/api/v1/files/dir" -H "accept: application/json" -H "Authorization: Bearer 15f96b3959677f6e45c2efaa1b42ae46cdcac96a2c0e41d3e2033d001af534d10842f40fe58ee081" -H "Content-Type: application/json" -d "{ \"path\": \"new\", \"new_path\": \"new_old\"}"
```
- response
```
{
  "data": {
    "path": "/home/kali-team/.msf4/rest_files/new_old"
  }
}
```
### delete directory
```
curl -X DELETE "https://api.kali-team.cn:5443/api/v1/files/dir" -H "accept: application/json" -H "Authorization: Bearer 15f96b3959677f6e45c2efaa1b42ae46cdcac96a2c0e41d3e2033d001af534d10842f40fe58ee081" -H "Content-Type: application/json" -d "{ \"path\": \"new_old\"}"
```
- response
```
{
  "data": {
    "path": "/home/kali-team/.msf4/rest_files/new_old"
  }
}
```