### PR TITLE
PR to fix two modules for CVE-2020-12720 not properly handling vBulletin table prefixes

### DIFF
--- a/modules/auxiliary/gather/vbulletin_getindexablecontent_sqli.rb
+++ b/modules/auxiliary/gather/vbulletin_getindexablecontent_sqli.rb
@@ -252,7 +252,6 @@ class MetasploitModule < Msf::Auxiliary
 
     # Get vBulletin table prefix (from known vb table 'language')
     table_prfx = get_table_prefix(node_id)
-    fail_with(Failure::UnexpectedReply, 'Could not determine the table prefix for the vBulletin install.') unless table_prfx
 
     tables = action.name == 'DumpAll' ? get_all_tables(node_id, table_prfx) : ["#{table_prfx}user"]
     tables.each do |table|

--- a/modules/exploits/multi/http/vbulletin_getindexablecontent.rb
+++ b/modules/exploits/multi/http/vbulletin_getindexablecontent.rb
@@ -500,7 +500,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # Get vBulletin table prefix
     table_prfx = get_table_prefix(node_id)
-    fail_with(Failure::UnexpectedReply, 'Could not determine the table prefix for the vBulletin install.') unless table_prfx
 
     # Get admin info (email, uid, token)
     admin_uid, admin_user, admin_token, admin_email = get_admin_info(node_id, table_prfx)


### PR DESCRIPTION
This PR fixes a bug disclosed to me about my 2 modules leveraging CVE-2020-12720 (`gather/vbulletin_getindexablecontent_sqli` & `multi/http/vbulletin_getindexablecontent`) . Specifically in the functionality used to determine the table prefixes for the vBulletin install. The fix supplied in this PR removes the guard clause outside of the get_table_prefix function, which is actually semi-redundant in that the results of the SQLi attack are checked within the get_table_prefix method.

## Verification

### Testing Exploit Module

- [x] Start `msfconsole`
- [x] `use exploit/multi/http/vbulletin_getindexablecontent`
- [x] `set RHOSTS [IP]`
- [x] `set VHOST [HOSTNAME]`
- [x] `set TARGETURI [PATH]`
- [x] `check`
- [ ] Verify target is marked as vulnerable
- [x] `run`
- [ ]  Verify shell is spawned

### Testing Auxillary Module

- [x] Start `msfconsole`
- [x] `use auxiliary/gather/vbulletin_getindexablecontent_sqli`
- [x] `set RHOSTS [IP]`
- [x] `set VHOST [HOSTNAME]`
- [x] `set TARGETURI [PATH]`
- [x] `run`
- [ ]  Verify user table data is dumped to disk

