### PR TITLE
Restrict the ruby_smb gem version until v2.0 has been tested more

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,7 +71,7 @@ PATH
       rex-text
       rex-zip
       ruby-macho
-      ruby_smb
+      ruby_smb (~> 1.1)
       rubyntlm
       rubyzip
       sinatra

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -136,7 +136,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'net-ssh'
   spec.add_runtime_dependency 'ed25519' # Adds ed25519 keys for net-ssh
   spec.add_runtime_dependency 'bcrypt_pbkdf'
-  spec.add_runtime_dependency 'ruby_smb'
+  spec.add_runtime_dependency 'ruby_smb', '~> 1.1'
   spec.add_runtime_dependency 'net-ldap'
 
   #


### PR DESCRIPTION
We're moving forward with SMB3 support for the upcoming v6 work. Since rapid7/ruby_smb#154 has been landed, the gem version has been bumped to 2.0.0. Until we've had a chance to more thoroughly test those changes with framework, we should restrict the version. This adds a restriction per @jmartin-r7's recommendation to `~> 1.1` to prevent it from being automatically bumped.

