### PR TITLE
Show automatically selected payload in module options and refactor default payload selection

### DIFF
--- a/lib/msf/core/evasion.rb
+++ b/lib/msf/core/evasion.rb
@@ -123,12 +123,19 @@ module Msf
 
       c_platform, c_arch = normalize_platform_arch
 
-      framework.payloads.each_module(
-        'Arch' => c_arch, 'Platform' => c_platform) { |name, mod|
-        payloads << [ name, mod ] if is_payload_compatible?(name)
-      }
+      results = Msf::Modules::Metadata::Cache.instance.find(
+        'type'     => [['payload'], []],
+        'platform' => [[*c_platform.names, 'All'], []], # "All" for generic
+        'arch'     => [c_arch, []]
+      )
 
-      return payloads
+      results.each do |res|
+        if is_payload_compatible?(res.ref_name)
+          payloads << [res.ref_name, framework.payloads[res.ref_name]]
+        end
+      end
+
+      payloads
     end
 
     def run

--- a/lib/msf/ui/console/command_dispatcher/evasion.rb
+++ b/lib/msf/ui/console/command_dispatcher/evasion.rb
@@ -24,7 +24,7 @@ class Evasion
   def cmd_run(*args)
     opts = {
       'Encoder'    => mod.datastore['ENCODER'],
-      'Payload'    => mod.datastore['PAYLOAD'] || Evasion.choose_payload(mod),
+      'Payload'    => mod.datastore['PAYLOAD'],
       'Nop'        => mod.datastore['NOP'],
       'LocalInput' => driver.input,
       'LocalOutput' => driver.output
@@ -86,51 +86,9 @@ class Evasion
     print_status "Payload Handler Started as Job #{job_id}"
   end
 
-  private
-
+  # This is the same functionality as Exploit::choose_payload, so call it
   def self.choose_payload(mod)
-
-    # Choose either the real target or an invalid address
-    # This is used to determine the LHOST value
-    rhost = mod.datastore['RHOST'] || '50.50.50.50'
-
-    # A list of preferred payloads in the best-first order
-    pref = [
-      'windows/meterpreter/reverse_https',
-      'windows/meterpreter/reverse_tcp_rc4',
-      'windows/meterpreter/reverse_tcp',
-      'windows/x64/meterpreter/reverse_https',
-      'windows/x64/meterpreter/reverse_tcp_rc4',
-      'windows/x64/meterpreter/reverse_tcp',
-      'linux/x86/meterpreter/reverse_tcp',
-      'java/meterpreter/reverse_tcp',
-      'php/meterpreter/reverse_tcp',
-      'php/meterpreter_reverse_tcp',
-      'ruby/shell_reverse_tcp',
-      'nodejs/shell_reverse_tcp',
-      'cmd/unix/interact',
-      'cmd/unix/reverse',
-      'cmd/unix/reverse_perl',
-      'cmd/unix/reverse_netcat_gaping',
-      'cmd/unix/reverse_stub',
-      'cmd/unix/bind_stub',
-      'windows/meterpreter/reverse_nonx_tcp',
-      'windows/meterpreter/reverse_ord_tcp',
-      'windows/shell/reverse_tcp',
-      'generic/shell_reverse_tcp'
-    ]
-    pset = mod.compatible_payloads.map{|x| x[0] }
-    pref.each do |n|
-      if(pset.include?(n))
-        mod.datastore['PAYLOAD'] = n
-        if n.index('reverse')
-          mod.datastore['LHOST'] = Rex::Socket.source_address(rhost)
-        end
-        return n
-      end
-    end
-
-    return
+    Msf::Ui::Console::CommandDispatcher::Exploit.choose_payload(mod)
   end
 
 end

--- a/lib/msf/ui/console/command_dispatcher/exploit.rb
+++ b/lib/msf/ui/console/command_dispatcher/exploit.rb
@@ -303,6 +303,9 @@ class Exploit
       generic/shell_bind_tcp
     ]
 
+    # XXX: Determine LHOST based on RHOST or an arbitrary internet address
+    lhost = Rex::Socket.source_address(mod.datastore['RHOST'] || '50.50.50.50')
+
     # XXX: This is not efficient in the slightest
     preferred_payloads.each do |type|
       payload = compatible_payloads.find { |name| name.end_with?(type) }
@@ -311,11 +314,9 @@ class Exploit
 
       mod.datastore['PAYLOAD'] = payload
 
+      # Set LHOST if this is a reverse payload
       if payload.index('reverse')
-        # XXX: Determine LHOST based on RHOST or an arbitrary internet address
-        rhost = mod.datastore['RHOST'] || '50.50.50.50'
-
-        mod.datastore['LHOST'] = Rex::Socket.source_address(rhost)
+        mod.datastore['LHOST'] = lhost
       end
 
       return payload

--- a/lib/msf/ui/console/command_dispatcher/exploit.rb
+++ b/lib/msf/ui/console/command_dispatcher/exploit.rb
@@ -160,10 +160,6 @@ class Exploit
       end
     end
 
-    if !opts['Payload']
-      opts['Payload'] = Exploit.choose_payload(mod, opts['Target'])
-    end
-
     rhosts = mod.datastore['RHOSTS']
     if rhosts
       rhosts_opt = Msf::OptAddressRange.new('RHOSTS')
@@ -291,57 +287,41 @@ class Exploit
 
   alias cmd_rerun_help cmd_rexploit_help
 
-  #
-  # Picks a reasonable payload and minimally configures it
-  #
-  def self.choose_payload(mod, target)
+  # Select a reasonable default payload and minimally configure it
+  # TODO: Move this somewhere better or make it more dynamic?
+  def self.choose_payload(mod)
+    compatible_payloads = mod.compatible_payloads.map(&:first)
 
-    # Choose either the real target or an invalid address
-    # This is used to determine the LHOST value
-    rhost = mod.datastore['RHOST'] || '50.50.50.50'
-
-    # A list of preferred payloads in the best-first order
-    pref = [
-      'windows/meterpreter/reverse_tcp',
-      'linux/x86/meterpreter/reverse_tcp',
-      'java/meterpreter/reverse_tcp',
-      'php/meterpreter/reverse_tcp',
-      'php/meterpreter_reverse_tcp',
-      'ruby/shell_reverse_tcp',
-      'nodejs/shell_reverse_tcp',
-
-      #
-      # The interact payload is a do-nothing stub that hijacks an existing connection
-      #
-      'cmd/unix/interact',
-
-      'cmd/unix/reverse',
-      'cmd/unix/reverse_perl',
-      'cmd/unix/reverse_netcat_gaping',
-
-      #
-      # These stubs are used in exploits which provide their own payloads
-      #
-      'cmd/unix/reverse_stub',
-      'cmd/unix/bind_stub',
-
-      'windows/meterpreter/reverse_nonx_tcp',
-      'windows/meterpreter/reverse_ord_tcp',
-      'windows/shell/reverse_tcp',
-      'generic/shell_reverse_tcp'
+    # XXX: This approach is subpar, but at least this list has been reevaluated
+    preferred_payloads = %w[
+      meterpreter/reverse_https
+      meterpreter/reverse_http
+      meterpreter/reverse_tcp
+      shell_reverse_tcp
+      shell/reverse_tcp
+      generic/shell_reverse_tcp
+      generic/shell_bind_tcp
     ]
-    pset = mod.compatible_payloads.map{|x| x[0] }
-    pref.each do |n|
-      if(pset.include?(n))
-        mod.datastore['PAYLOAD'] = n
-        if n.index('reverse')
-          mod.datastore['LHOST'] = Rex::Socket.source_address(rhost)
-        end
-        return n
+
+    # XXX: This is not efficient in the slightest
+    preferred_payloads.each do |type|
+      payload = compatible_payloads.find { |name| name.end_with?(type) }
+
+      next unless payload
+
+      mod.datastore['PAYLOAD'] = payload
+
+      if payload.index('reverse')
+        # XXX: Determine LHOST based on RHOST or an arbitrary internet address
+        rhost = mod.datastore['RHOST'] || '50.50.50.50'
+
+        mod.datastore['LHOST'] = Rex::Socket.source_address(rhost)
       end
+
+      return payload
     end
 
-    return
+    nil
   end
 
 end

--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -768,6 +768,16 @@ module Msf
               active_module.datastore.update(@dscache[active_module.fullname])
             end
 
+            # Choose a default payload when the module is used, not run
+            if mod.datastore['PAYLOAD'].nil? && dispatcher.respond_to?(:choose_payload)
+              chosen_payload = dispatcher.choose_payload(mod)
+
+              # XXX: No vprint_status in this context
+              if framework.datastore['VERBOSE'].to_s == 'true' && chosen_payload
+                print_status("No payload configured, defaulting to #{chosen_payload}")
+              end
+            end
+
             mod.init_ui(driver.input, driver.output)
           end
 


### PR DESCRIPTION
By choosing a default payload when the module is used, not run. See https://github.com/rapid7/metasploit-framework/pull/13566#discussion_r436808105.

Note that this may slow down overall time-to-exploit if a payload is set manually _without `show payloads` or tab completion_. Regardless, it is a better user experience to know what payload will be used before yeeting the exploit at a live target.

```
msf5 > use exploit/windows/smb/ms17_010_eternalblue
[*] No payload configured, defaulting to windows/x64/meterpreter/reverse_https
msf5 exploit(windows/smb/ms17_010_eternalblue) > options

Module options (exploit/windows/smb/ms17_010_eternalblue):

   Name           Current Setting  Required  Description
   ----           ---------------  --------  -----------
   RHOSTS                          yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
   RPORT          445              yes       The target port (TCP)
   SMBDomain      .                no        (Optional) The Windows domain to use for authentication
   SMBPass                         no        (Optional) The password for the specified username
   SMBUser                         no        (Optional) The username to authenticate as
   VERIFY_ARCH    true             yes       Check if remote architecture matches exploit Target.
   VERIFY_TARGET  true             yes       Check if remote OS matches exploit Target.


Payload options (windows/x64/meterpreter/reverse_https):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   EXITFUNC  thread           yes       Exit technique (Accepted: '', seh, thread, process, none)
   LHOST     192.168.1.2      yes       The local listener hostname
   LPORT     8443             yes       The local listener port
   LURI                       no        The HTTP Path


Exploit target:

   Id  Name
   --  ----
   0   Windows 7 and Server 2008 R2 (x64) All Service Packs


msf5 exploit(windows/smb/ms17_010_eternalblue) >
```

Personally, I'm inclined to remove this code altogether, since I think a user should be explicit about setting a payload, but people seem to like this feature when it works. In my modules, I prefer to set a payload per target.

Updates #11768, in a sense. Turns out evasion modules were slow af because they weren't using the module cache.