### PR TITLE
Updates activerecord version check for deprecated_constants

### DIFF
--- a/lib/pg/deprecated_constants.rb
+++ b/lib/pg/deprecated_constants.rb
@@ -16,21 +16,21 @@
 #
 # config.autoload_paths << Rails.root.join('lib')
 #
-if PG::VERSION != '0.21.0' || ActiveRecord.version.to_s != '4.2.11.1'
-  puts <<MSG
------------------------------------------------------------------------------------
-The pg and/or activerecord gem version has changed, meaning deprecated pg constants
-may no longer be in use, so try deleting this file to see if the
-'The PGconn, PGresult, and PGError constants are deprecated...' message has gone:
-#{__FILE__}
------------------------------------------------------------------------------------
-
-MSG
+if PG::VERSION != '0.21.0' || ActiveRecord.version.to_s != '4.2.11.3'
+  puts <<~MSG
+    -----------------------------------------------------------------------------------
+    The pg and/or activerecord gem version has changed, meaning deprecated pg constants
+    may no longer be in use, so try deleting this file to see if the
+    'The PGconn, PGresult, and PGError constants are deprecated...' message has gone:
+    #{__FILE__}
+    -----------------------------------------------------------------------------------
+    
+  MSG
 end
 
-# Declare the deprecated constants as is done in the original 
+# Declare the deprecated constants as is done in the original
 # pg/deprecated_constants.rb so they can still be used by older
 # versions of gems such as activerecord.
-PGconn   = PG::Connection
+PGconn = PG::Connection
 PGresult = PG::Result
-PGError  = PG::Error
+PGError = PG::Error


### PR DESCRIPTION
Closes https://github.com/rapid7/metasploit-framework/issues/13548 

`deprecated_constants` overrides the pg gem's pg/deprecated_constants.rb file and ensures a  warning message is not printed on startup.

This fix bumps the activerecord version `deprecated_constants` checks for  to `4.2.11.3`, in line with a recent version bump for Rails.

This bump is needed because deleting `deprecated_constants` as the warning message suggests results in another warning message being displayed on startup.

Also ran rubocop because neatness.

## Verification

- [x] Start `msfconsole`
- [x] Ensure the warning shown below isn't displayed
```
-----------------------------------------------------------------------------------
The pg and/or activerecord gem version has changed, meaning deprecated pg constants
may no longer be in use, so try deleting this file to see if the
'The PGconn, PGresult, and PGError constants are deprecated...' message has gone:
/usr/share/metasploit-framework/lib/pg/deprecated_constants.rb
-----------------------------------------------------------------------------------
```

