### PR TITLE
Deprecate the psexec_psh module

### DIFF
--- a/lib/msf/core/module/deprecated.rb
+++ b/lib/msf/core/module/deprecated.rb
@@ -6,21 +6,29 @@ module Msf::Module::Deprecated
   module ClassMethods
     attr_accessor :deprecation_date
     attr_accessor :deprecated_names
+    attr_accessor :deprecation_reason
 
     # Mark this module as deprecated
     #
     # Any time this module is run it will print warnings to that effect.
     #
-    # @param deprecation_date [Date,#to_s] The date on which this module will
+    # @param date [Date,#to_s] The date on which this module will
     #   be removed
+    # @param reason [String] A description reason for this module being deprecated
     # @return [void]
-    def deprecated(date)
+    def deprecated(date, reason = nil)
       self.deprecation_date = date
+      self.deprecation_reason = reason
 
       # NOTE: fullname isn't set until a module has been added to a set, which is after it is evaluated
       add_warning do
-        [ "*%red" + "The module #{fullname} is deprecated!".center(88) + "%clr*",
-          "*" + "This module will be removed on or about #{self.class.deprecation_date}".center(88) + "*" ]
+        details = [
+          "*%red" + "The module #{fullname} is deprecated!".center(88) + "%clr*",
+          "*" + "This module will be removed on or about #{date}".center(88) + "*"
+        ]
+        details << "*#{reason.center(88)}*" if reason.present?
+
+        details
       end
     end
 

--- a/modules/exploits/windows/smb/psexec_psh.rb
+++ b/modules/exploits/windows/smb/psexec_psh.rb
@@ -14,6 +14,10 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::SMB::Client::Psexec
   include Msf::Exploit::Powershell
 
+  include Msf::Module::Deprecated
+  # Use exploit/windows/smb/psexec and the 'PowerShell' target
+  deprecated(Date.new(2020, 9, 16))
+
   def initialize(info = {})
     super(update_info(info,
       'Name'             => 'Microsoft Windows Authenticated Powershell Command Execution',

--- a/modules/exploits/windows/smb/psexec_psh.rb
+++ b/modules/exploits/windows/smb/psexec_psh.rb
@@ -15,8 +15,10 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Powershell
 
   include Msf::Module::Deprecated
-  # Use exploit/windows/smb/psexec and the 'PowerShell' target
-  deprecated(Date.new(2020, 9, 16))
+  deprecated(
+    Date.new(2020, 9, 16),
+    reason = "Use exploit/windows/smb/psexec and the 'PowerShell' target"
+  )
 
   def initialize(info = {})
     super(update_info(info,


### PR DESCRIPTION
From what I can tell, this module is redundant with the main `exploit/windows/smb/psexec` module and it's `PowerShell` target (which will be selected by the default "Automatic" target). It was mentioned to me that at one point there was an issue with `exploit/windows/smb/psexec` not deploying x64 payloads, but that does not seem to be the case any more.

See a note in reverting the original deprecation attempt in commit fed2ed444f74759afa56c42905645ddc61ddf85f.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/windows/smb/psexec_psh`
- [ ] See the deprecation warning
