### PR TITLE
more iis internal ip info

### DIFF
--- a/modules/auxiliary/scanner/http/iis_internal_ip.rb
+++ b/modules/auxiliary/scanner/http/iis_internal_ip.rb
@@ -7,26 +7,29 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::HttpClient
   include Msf::Auxiliary::Scanner
 
-  def initialize(info={})
-    super(update_info(info,
-      'Name'        => 'Microsoft IIS HTTP Internal IP Disclosure',
-      'Description' => %q{
-        Collect any leaked internal IPs by requesting commonly redirected locations from IIS.
-        CVE-2000-0649 references IIS 5.1 (win2k, XP) and older.  However, in newer servers
-        such as IIS 7+, this occurs when the alternateHostName is not set or misconfigured.
-      },
-      'Author'       => ['Heather Pilkington'],
-      'License'     => MSF_LICENSE,
-      'References'     =>
-        [
-          ['CVE', '2000-0649'],
-          ['BID', '1499'],
-          ['EDB', '20096'],
-          ['URL', 'https://support.microsoft.com/en-us/help/218180/internet-information-server-returns-ip-address-in-http-header-content'], #iis 4,5,5.1
-          ['URL', 'https://support.microsoft.com/en-us/help/967342/fix-the-internal-ip-address-of-an-iis-7-0-server-is-revealed-if-an-htt'], #iis 7+
-          ['URL', 'https://techcommunity.microsoft.com/t5/iis-support-blog/iis-web-servers-running-in-windows-azure-may-reveal-their/ba-p/826500']
-        ]
-    ))
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Microsoft IIS HTTP Internal IP Disclosure',
+        'Description' => %q{
+          Collect any leaked internal IPs by requesting commonly redirected locations from IIS.
+          CVE-2000-0649 references IIS 5.1 (win2k, XP) and older.  However, in newer servers
+          such as IIS 7+, this occurs when the alternateHostName is not set or misconfigured.
+        },
+        'Author' => ['Heather Pilkington'],
+        'License' => MSF_LICENSE,
+        'References' =>
+          [
+            ['CVE', '2000-0649'],
+            ['BID', '1499'],
+            ['EDB', '20096'],
+            ['URL', 'https://support.microsoft.com/en-us/help/218180/internet-information-server-returns-ip-address-in-http-header-content'], # iis 4,5,5.1
+            ['URL', 'https://support.microsoft.com/en-us/help/967342/fix-the-internal-ip-address-of-an-iis-7-0-server-is-revealed-if-an-htt'], # iis 7+
+            ['URL', 'https://techcommunity.microsoft.com/t5/iis-support-blog/iis-web-servers-running-in-windows-azure-may-reveal-their/ba-p/826500']
+          ]
+      )
+    )
   end
 
   def run_host(target_host)

--- a/modules/auxiliary/scanner/http/iis_internal_ip.rb
+++ b/modules/auxiliary/scanner/http/iis_internal_ip.rb
@@ -7,24 +7,26 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::HttpClient
   include Msf::Auxiliary::Scanner
 
-  def initialize(info = {})
-    super(
-      update_info(
-        info,
-        'Name' => 'Microsoft IIS HTTP Internal IP Disclosure',
-        'Description' => %q{
-          Collect any leaked internal IPs by requesting commonly redirected locations from IIS.
-        },
-        'Author' => ['Heather Pilkington'],
-        'License' => MSF_LICENSE,
-        'References' =>
-          [
-            ['CVE', '2000-0649'],
-            ['BID', '1499'],
-            ['EDB', '20096']
-          ]
-      )
-    )
+  def initialize(info={})
+    super(update_info(info,
+      'Name'        => 'Microsoft IIS HTTP Internal IP Disclosure',
+      'Description' => %q{
+        Collect any leaked internal IPs by requesting commonly redirected locations from IIS.
+        CVE-2000-0649 references IIS 5.1 (win2k, XP) and older.  However, in newer servers
+        such as IIS 7+, this occurs when the alternateHostName is not set or misconfigured.
+      },
+      'Author'       => ['Heather Pilkington'],
+      'License'     => MSF_LICENSE,
+      'References'     =>
+        [
+          ['CVE', '2000-0649'],
+          ['BID', '1499'],
+          ['EDB', '20096'],
+          ['URL', 'https://support.microsoft.com/en-us/help/218180/internet-information-server-returns-ip-address-in-http-header-content'], #iis 4,5,5.1
+          ['URL', 'https://support.microsoft.com/en-us/help/967342/fix-the-internal-ip-address-of-an-iis-7-0-server-is-revealed-if-an-htt'], #iis 7+
+          ['URL', 'https://techcommunity.microsoft.com/t5/iis-support-blog/iis-web-servers-running-in-windows-azure-may-reveal-their/ba-p/826500']
+        ]
+    ))
   end
 
   def run_host(target_host)


### PR DESCRIPTION
After talking some with @bwatters-r7 , the module's info is slightly confusing.  Yes it happens on OLD IIS installs, but it also happens on newer installs.  The new problem isn't related to the CVE, its related to a configuration issue.  This PR adds some information to the description to explain this, as well as some links to explain why modern IIS has this issue and how to resolve it.