### PR TITLE
Fix edge case in rubocop module description rule

### DIFF
--- a/lib/rubocop/cop/layout/module_description_indentation.rb
+++ b/lib/rubocop/cop/layout/module_description_indentation.rb
@@ -51,8 +51,8 @@ module RuboCop
           content_whitespace = indentation(description_key)
           final_line_whitespace = offset(description_key)
 
-          description_content = description_value.source.lines[1...-1]
-          indented_description = description_content.map do |line|
+          description_lines = node_content(description_value).strip.lines
+          indented_description = description_lines.map do |line|
             cleaned_content = line.strip
             if cleaned_content.empty?
               "\n"
@@ -67,6 +67,16 @@ module RuboCop
           new_literal <<= '}'
 
           new_literal
+        end
+
+        def node_content(node)
+          if node.str_type?
+            node.value
+          elsif node.dstr_type?
+            node.children.map(&:value).join
+          else
+            raise "Module description should be a string, instead found '#{node.type}'"
+          end
         end
 
         def hash_arg?(node)

--- a/modules/auxiliary/scanner/http/limesurvey_zip_traversals.rb
+++ b/modules/auxiliary/scanner/http/limesurvey_zip_traversals.rb
@@ -24,7 +24,6 @@ class MetasploitModule < Msf::Auxiliary
           for arbitrary file download.
           Verified against 4.1.11-200316, 3.15.0-181008, 3.9.0-180604, 3.6.0-180328,
           3.0.0-171222, and 2.70.0-170921.
-
         },
         'License' => MSF_LICENSE,
         'Author' =>

--- a/modules/exploits/windows/misc/ais_esel_server_rce.rb
+++ b/modules/exploits/windows/misc/ais_esel_server_rce.rb
@@ -39,7 +39,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
           NOTE: This module will leave a payload executable on the target system when the
           attack is finished.
-
         },
         'Author' =>
           [

--- a/spec/rubocop/cop/layout/module_description_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/module_description_indentation_spec.rb
@@ -59,6 +59,108 @@ RSpec.describe RuboCop::Cop::Layout::ModuleDescriptionIndentation do
     RUBY
   end
 
+  it 'registers an offense when a multiline description requires a preceeding new line' do
+    expect_offense(<<~RUBY)
+      class DummyModule
+        def initialize(info = {})
+          super(
+            update_info(
+              info,
+              'Name'           => 'Simple module name',
+              'Description'    => %q(Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque efficitur pulvinar arcu eget ultrices.
+            Vestibulum at risus at nisi convallis laoreet a sed libero. Nam vestibulum euismod dictum. Pellentesque
+            eu nunc vitae mi volutpat viverra in id ipsum. Maecenas fermentum condimentum dapibus.),
+                                                                                                  ^ Module descriptions should be properly aligned to the 'Description' key, and within %q{ ... }
+              'Author'        => [
+                'example1',
+                'example2'
+              ],
+              'License'       => MSF_LICENSE,
+              'Platform'      => 'win',
+              'Arch'          => ARCH_X86,
+            )
+          )
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class DummyModule
+        def initialize(info = {})
+          super(
+            update_info(
+              info,
+              'Name'           => 'Simple module name',
+              'Description'    => %q{
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque efficitur pulvinar arcu eget ultrices.
+                Vestibulum at risus at nisi convallis laoreet a sed libero. Nam vestibulum euismod dictum. Pellentesque
+                eu nunc vitae mi volutpat viverra in id ipsum. Maecenas fermentum condimentum dapibus.
+              },
+              'Author'        => [
+                'example1',
+                'example2'
+              ],
+              'License'       => MSF_LICENSE,
+              'Platform'      => 'win',
+              'Arch'          => ARCH_X86,
+            )
+          )
+        end
+      end
+    RUBY
+  end
+
+  it 'registers an offense when a multiline description requires a preceeding new line' do
+    expect_offense(<<~RUBY)
+      class DummyModule
+        def initialize(info = {})
+          super(
+            update_info(
+              info,
+              'Name'           => 'Simple module name',
+              'Description'    => "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque efficitur pulvinar arcu eget ultrices.
+            Vestibulum at risus at nisi convallis laoreet a sed libero. Nam vestibulum euismod dictum. Pellentesque
+            eu nunc vitae mi volutpat viverra in id ipsum. Maecenas fermentum condimentum dapibus.",
+                                                                                                  ^ Module descriptions should be properly aligned to the 'Description' key, and within %q{ ... }
+              'Author'        => [
+                'example1',
+                'example2'
+              ],
+              'License'       => MSF_LICENSE,
+              'Platform'      => 'win',
+              'Arch'          => ARCH_X86,
+            )
+          )
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class DummyModule
+        def initialize(info = {})
+          super(
+            update_info(
+              info,
+              'Name'           => 'Simple module name',
+              'Description'    => %q{
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque efficitur pulvinar arcu eget ultrices.
+                Vestibulum at risus at nisi convallis laoreet a sed libero. Nam vestibulum euismod dictum. Pellentesque
+                eu nunc vitae mi volutpat viverra in id ipsum. Maecenas fermentum condimentum dapibus.
+              },
+              'Author'        => [
+                'example1',
+                'example2'
+              ],
+              'License'       => MSF_LICENSE,
+              'Platform'      => 'win',
+              'Arch'          => ARCH_X86,
+            )
+          )
+        end
+      end
+    RUBY
+  end
+
   it 'registers an offense when descriptions are incorrectly indented' do
     expect_offense(<<~RUBY)
       class DummyModule
@@ -124,6 +226,65 @@ RSpec.describe RuboCop::Cop::Layout::ModuleDescriptionIndentation do
             Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque efficitur pulvinar arcu eget ultrices.
             Vestibulum at risus at nisi convallis laoreet a sed libero. Nam vestibulum euismod dictum. Pellentesque
             eu nunc vitae mi volutpat viverra in id ipsum. Maecenas fermentum condimentum dapibus.
+            ),
+            ^ Module descriptions should be properly aligned to the 'Description' key, and within %q{ ... }
+              'Author'        => [
+                'example1',
+                'example2'
+              ],
+              'License'       => MSF_LICENSE,
+              'Platform'      => 'win',
+              'Arch'          => ARCH_X86,
+            )
+          )
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class DummyModule
+        def initialize(info = {})
+          super(
+            merge_info(
+              info,
+              'Name'           => 'Simple module name',
+              'Description'    => %q{
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque efficitur pulvinar arcu eget ultrices.
+                Vestibulum at risus at nisi convallis laoreet a sed libero. Nam vestibulum euismod dictum. Pellentesque
+                eu nunc vitae mi volutpat viverra in id ipsum. Maecenas fermentum condimentum dapibus.
+              },
+              'Author'        => [
+                'example1',
+                'example2'
+              ],
+              'License'       => MSF_LICENSE,
+              'Platform'      => 'win',
+              'Arch'          => ARCH_X86,
+            )
+          )
+        end
+      end
+    RUBY
+  end
+
+  it 'registers an offense when there is additional whitespace', focus: true do
+    expect_offense(<<~RUBY)
+      class DummyModule
+        def initialize(info = {})
+          super(
+            merge_info(
+              info,
+              'Name'           => 'Simple module name',
+              'Description'    => %q(
+
+
+
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque efficitur pulvinar arcu eget ultrices.
+            Vestibulum at risus at nisi convallis laoreet a sed libero. Nam vestibulum euismod dictum. Pellentesque
+            eu nunc vitae mi volutpat viverra in id ipsum. Maecenas fermentum condimentum dapibus.
+
+
+
             ),
             ^ Module descriptions should be properly aligned to the 'Description' key, and within %q{ ... }
               'Author'        => [


### PR DESCRIPTION
### Input

When running rubocop on [cve_2020_0668_service_tracing](https://github.com/rapid7/metasploit-framework/blob/b4e2599921887e12a4da0dfb8be7db7ad2b4413b/modules/exploits/windows/local/cve_2020_0668_service_tracing.rb), content is unintentionally lost.

```ruby
                      'Description'    => %q(This module leverages a
                                             trusted file overwrite with
                                             a dll hijacking
                                             vulnerability to gain
                                             SYSTEM-level access on
                                             vulnerable Windows 10 x64
                                             targets),
```

### Before

The first and last line are dropped:

```
        'Description' => %q{
          trusted file overwrite with
          a dll hijacking
          vulnerability to gain
          SYSTEM-level access on
          vulnerable Windows 10 x64
        },
```

### After

No content is lost. Note that the formatted output is still 'weird', as this custom rubocop rule just fixes indentation - and doesn't enforce line length / word wrapping.

```ruby
        'Description' => %q{
          This module leverages a
          trusted file overwrite with
          a dll hijacking
          vulnerability to gain
          SYSTEM-level access on
          vulnerable Windows 10 x64
          targets
        },
```

### Context

The current rubocop description linter assumed that the input would be:

```ruby
'Description' => %q{
   line1
   line2
   line3
}
```

Behind the seens the rubocop rule used`description_value.source` retrieve `%q{\nline1\nline2\nline3\n}` and `description_value.source.lines[1...-1]` to extract `['line1', 'line2', 'line3']` to format the new description.

Unfortunately this assumption breaks when `%q{` and `}` are not on there own lines, meaning the first and last lines were being dropped when applying formatting rules.

Rubocop would convert:

```ruby
'Description' => %q{line1
   line2
   line3}
```

Into:

```
'Description' => %q{
   line2
}
```

This PR fixes this edge case to format correctly as:

```
'Description' => %q{
   line1
   line2
   line3
}
```

### Verification

List the steps needed to make sure this thing works

- [x] Ran `rubocop -a modules/exploits/windows/local/cve_2020_0668_service_tracing.rb` - particularly the older version: [cve_2020_0668_service_tracing](https://github.com/rapid7/metasploit-framework/blob/b4e2599921887e12a4da0dfb8be7db7ad2b4413b/modules/exploits/windows/local/cve_2020_0668_service_tracing.rb) and verified no lines were dropped
- [ ] Ran `rubocop -a modules/auxiliary/ --only Layout/ModuleDescriptionIndentation` and verified there were no explosions / crazy changes