### PR TITLE
Check that ctx[1] has a datastore attribute

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/jobs.rb
+++ b/lib/msf/ui/console/command_dispatcher/jobs.rb
@@ -212,8 +212,9 @@ module Msf
               # Remove persistence by job id.
               job_list.map(&:to_s).each do |job|
                 if framework.jobs.key?(job)
-                  next unless framework.jobs[job.to_s].ctx[1] # next if no payload context in the job
-                  payload_option = framework.jobs[job.to_s].ctx[1].datastore
+                  ctx_1 = framework.jobs[job.to_s].ctx[1]
+                  next if ctx_1.nil? || !ctx_1.respond_to?(:datastore)  # next if no payload context in the job
+                  payload_option = ctx_1.datastore
                   persist_list.delete_if{|pjob|pjob['mod_options']['Options'] == payload_option}
                 end
               end


### PR DESCRIPTION
Fixes #13593

So there's a bug that occurs when a user tries to kill a job by ID when that job is a running auxiliary module (like any of the servers). The issue appears to be due to the `job.ctx` attribute being an array where the second element is either a payload instance<sup>[1](https://github.com/rapid7/metasploit-framework/blob/71af59af8e1a46f6183b72b22fd6bf658cd5bd5f/lib/msf/core/exploit_driver.rb#L166)</sup>, <sup>[2](https://github.com/rapid7/metasploit-framework/blob/71af59af8e1a46f6183b72b22fd6bf658cd5bd5f/lib/msf/core/exploit_driver.rb#L148)</sup> or a run UUID<sup>[3](https://github.com/rapid7/metasploit-framework/blob/71af59af8e1a46f6183b72b22fd6bf658cd5bd5f/lib/msf/base/simple/auxiliary.rb#L73)</sup>, <sup>[4](https://github.com/rapid7/metasploit-framework/blob/71af59af8e1a46f6183b72b22fd6bf658cd5bd5f/lib/msf/base/simple/exploit.rb#L194)</sup>. In the event that its a run UUID, it's a string which means it does not have a `datastore` attribute which is what is causing the original error.

This is a total hack. I think a more elegant solution would be to replace the array with a hash that could define `payload`, `run_uuid` keys etc, but I'm concerned there may be implications with that approach which would affect the RPC layer.

Testing this can be done using the reproduction steps from the ticket #13593. 

1. Copy the contents of the RC script to `test.rc`
1. Run `./msfconsole -r test.rc`
1. See that the job was stopped
1. Do not see a stack trace

<details>
<summary>RC Script</summary>

```
use auxiliary/server/socks5
run
jobs
sleep 5
jobs -k 0
exit
```
</details>