### PR TITLE
Add custom service name support to msfvenom's exe-service generator

### DIFF
--- a/external/zsh/_msfvenom
+++ b/external/zsh/_msfvenom
@@ -223,6 +223,7 @@ _msfvenom_payload() {
 _arguments \
   "--smallest[Generate the smallest possible payload using all available encoders]" \
   "--sec-name[The new section name to use when generating large Windows binaries. Default: random 4-character alpha string]" \
+  "--service-name[The service name to use when generating a service binary]:value" \
   "--encoder-space[The maximum size of the encoded payload (defaults to the -s value)]:length" \
   "--encrypt[The type of encryption or encoding to apply to the shellcode]:value" \
   "--encrypt-key[A key to be used for --encrypt]:value" \

--- a/lib/msf/core/payload_generator.rb
+++ b/lib/msf/core/payload_generator.rb
@@ -48,6 +48,9 @@ module Msf
     # @!attribute  secname
     #   @return [String] The name of the new section within the generated Windows binary
     attr_accessor :secname
+    # @!attribute  servicename
+    #   @return [String] The name of the service to be associated with the generated Windows binary
+    attr_accessor :servicename
     # @!attribute  format
     #   @return [String] The format you want the payload returned in
     attr_accessor :format
@@ -133,6 +136,7 @@ module Msf
       @datastore  = opts.fetch(:datastore, {})
       @encoder    = opts.fetch(:encoder, '')
       @secname    = opts.fetch(:secname, '')
+      @servicename = opts.fetch(:servicename, '')
       @format     = opts.fetch(:format, 'raw')
       @iterations = opts.fetch(:iterations, 1)
       @keep       = opts.fetch(:keep, false)
@@ -302,6 +306,9 @@ module Msf
       end
       unless secname.blank?
         opts[:secname]       = secname
+      end
+      unless servicename.blank?
+        opts[:servicename] = servicename
       end
       opts
     end

--- a/lib/msf/core/payload_generator.rb
+++ b/lib/msf/core/payload_generator.rb
@@ -51,6 +51,9 @@ module Msf
     # @!attribute  servicename
     #   @return [String] The name of the service to be associated with the generated Windows binary
     attr_accessor :servicename
+    # @!attribute  sub_method
+    #   @return [Boolean] Whether or not this binary needs the x86 sub_method applied or not.
+    attr_accessor :sub_method
     # @!attribute  format
     #   @return [String] The format you want the payload returned in
     attr_accessor :format
@@ -137,6 +140,7 @@ module Msf
       @encoder    = opts.fetch(:encoder, '')
       @secname    = opts.fetch(:secname, '')
       @servicename = opts.fetch(:servicename, '')
+      @sub_method = opts.fetch(:sub_method, false)
       @format     = opts.fetch(:format, 'raw')
       @iterations = opts.fetch(:iterations, 1)
       @keep       = opts.fetch(:keep, false)
@@ -309,6 +313,11 @@ module Msf
       end
       unless servicename.blank?
         opts[:servicename] = servicename
+      end
+      if sub_method.nil?
+        opts[:sub_method] = false
+      else
+        opts[:sub_method] = sub_method
       end
       opts
     end

--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -529,7 +529,6 @@ require 'msf/core/exe/segment_appender'
   # @option opts [Boolean] :sub_method
   # @return      [String]
   def self.exe_sub_method(code,opts ={})
-    require 'pry'; binding.pry
     pe = self.get_file_contents(opts[:template])
 
     case opts[:exe_type]
@@ -668,7 +667,6 @@ require 'msf/core/exe/segment_appender'
   def self.to_win64pe_service(framework, code, opts = {})
     # Allow the user to specify their own service EXE template
     set_template_default(opts, "template_x64_windows_svc.exe")
-    require 'pry'; binding.pry
     opts[:exe_type] = :service_exe
     exe_sub_method(code,opts)
   end
@@ -1152,7 +1150,7 @@ require 'msf/core/exe/segment_appender'
   def self.to_linux_armle_elf_dll(framework, code, opts = {})
     to_exe_elf(framework, opts, "template_armle_linux_dll.bin", code)
   end
-  
+
   # self.to_linux_aarch64_elf
   #
   # @param framework [Msf::Framework]

--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -529,6 +529,7 @@ require 'msf/core/exe/segment_appender'
   # @option opts [Boolean] :sub_method
   # @return      [String]
   def self.exe_sub_method(code,opts ={})
+    require 'pry'; binding.pry
     pe = self.get_file_contents(opts[:template])
 
     case opts[:exe_type]
@@ -667,6 +668,7 @@ require 'msf/core/exe/segment_appender'
   def self.to_win64pe_service(framework, code, opts = {})
     # Allow the user to specify their own service EXE template
     set_template_default(opts, "template_x64_windows_svc.exe")
+    require 'pry'; binding.pry
     opts[:exe_type] = :service_exe
     exe_sub_method(code,opts)
   end

--- a/msfvenom
+++ b/msfvenom
@@ -108,6 +108,8 @@ def parse_args(args)
 
   opt.on('--service-name    <value>', String, 'The service name to use when generating a service binary.') do |s|
     opts[:servicename] = s
+    opts[:sub_method] = true # Needed to ensure that to_win32pe_service() will call
+                             # exe_sub_method() for x86 binaries, not needed and ignored for x64 binaries.
   end
 
   opt.on('--sec-name        <value>', String, 'The new section name to use when generating large Windows binaries. Default: random 4-character alpha string') do |s|

--- a/msfvenom
+++ b/msfvenom
@@ -106,6 +106,10 @@ def parse_args(args)
     opts[:encoder] = e
   end
 
+  opt.on('--service-name    <value>', String, 'The service name to use when generating a service binary.') do |s|
+    opts[:servicename] = s
+  end
+
   opt.on('--sec-name        <value>', String, 'The new section name to use when generating large Windows binaries. Default: random 4-character alpha string') do |s|
     opts[:secname] = s
   end

--- a/msfvenom
+++ b/msfvenom
@@ -106,7 +106,7 @@ def parse_args(args)
     opts[:encoder] = e
   end
 
-  opt.on('--service-name    <value>', String, 'The service name to use when generating a service binary.') do |s|
+  opt.on('--service-name    <value>', String, 'The service name to use when generating a service binary') do |s|
     opts[:servicename] = s
     opts[:sub_method] = true # Needed to ensure that to_win32pe_service() will call
                              # exe_sub_method() for x86 binaries, not needed and ignored for x64 binaries.


### PR DESCRIPTION
Fixes #13229 by adding support to msfvenom, and several associated internal library files such as `payload_generator.rb` and `exe.rb` to allow users to generate x86 and x64 `exe-service` payloads with arbitrary service names.

I still believe the x86 version of this code may be broken in non-metasploit versions and that we should just switch to having both `to_win32pe_service` and `to_win64pe_service` call `exe_sub_method` all the time but for some odd reason  `to_win32pe_service` seems use the `opts[:serviceencoder]` option, which is only used by https://github.com/rapid7/metasploit-framework/blob/aa6624e7f863f41ecc0494b20f6aa177b54b24f7/lib/msf/core/exploit/smb/client/psexec.rb#L293 and the `opts[:sub_method]` option, which is set via https://github.com/rapid7/metasploit-framework/blob/405e7b108b04f6a8b92fd98b02bea4428429c281/lib/msf/core/exploit/exe.rb#L24. 

For this reason I didn't make more extensive edits to the x86 code but I still find it incredibly weird that we are making exceptions just for that architecture of Windows. I think this was due to some of @agix commited, namely https://github.com/rapid7/metasploit-framework/commit/378208bc3db6f3ebd39f03a36d705c25b70e99ce#diff-0f5729034d8b0b321e738f2fc047854f, which seems to have changed this all around. Seems like x64 wasn't taken into account then as we also have the creation of the `modules/encoders/x86/service.rb` encoder around this time, which is weirdly only used to encode x86 service payloads and we don't have an equivalent encoder for x64.

Anyway that is enough of that, hopefully these changes should be fairly straight forward to review as I tried to keep the changes minimal. I may have left some extra comments in so I'll likely go back and edit it up to remove those seeing as this is library code.

## Verification

List the steps needed to make sure this thing works

- [ ] Try run `./msfvenom -f exe-service -p windows/meterpreter/bind_tcp --service-name CHUCKLY -o test666a.exe`
- [ ] Open the binary in IDA Pro or Binary Ninja.
- [ ] Search for the function `RegisterServiceCtrlHandlerA`, and verify that the service name `CHUCKLY` is being passed to it.
- [ ] Verify you do not see any instances of `PAYLOAD:` or `SERVICE_NAME` in the strings view.
- [ ] Repeat the steps above using the command `./msfvenom -f exe-service -p windows/x64/meterpreter/bind_tcp --service-name CHUCKLY -o test666a.exe`

