### PR TITLE
Standardise Error Logging

### DIFF
--- a/lib/metasploit/framework/data_service/proxy/core.rb
+++ b/lib/metasploit/framework/data_service/proxy/core.rb
@@ -167,8 +167,7 @@ class DataProxy
   end
 
   def log_error(exception, ui_message)
-    elog "#{ui_message}: #{exception.message}"
-    exception.backtrace.each { |line| elog "#{line}" }
+    elog(ui_message, error: exception)
     # TODO: We should try to surface the original exception, instead of just a generic one.
     # This should not display the full backtrace, only the message.
     raise exception

--- a/lib/metasploit/framework/ntds/parser.rb
+++ b/lib/metasploit/framework/ntds/parser.rb
@@ -56,7 +56,7 @@ module Metasploit
           begin
             raw_batch_data = channel.read(BATCH_SIZE)
           rescue EOFError => e
-            elog("NTDS Parser: Error pulling batch - #{e}")
+            elog('NTDS Parser: Error pulling batch', error: e)
             raw_batch_data = nil
           end
           raw_batch_data

--- a/lib/msf/base/sessions/meterpreter.rb
+++ b/lib/msf/base/sessions/meterpreter.rb
@@ -559,7 +559,7 @@ class Meterpreter < Rex::Post::Meterpreter::Client
     rescue ::Exception => e
       # Log the error but otherwise ignore it so we don't kill the
       # session if reporting failed for some reason
-      elog("Error loading sysinfo: #{e.class}: #{e}")
+      elog('Error loading sysinfo', error: e)
       dlog("Call stack:\n#{e.backtrace.join("\n")}")
     end
   end

--- a/lib/msf/base/sessions/pingback.rb
+++ b/lib/msf/base/sessions/pingback.rb
@@ -70,10 +70,7 @@ class Pingback
       rescue => e
         # TODO: Can we have a more specific exception handler?
         # Test: what if we send no bytes back?  What if we send less than 16 bytes?  Or more than?
-        elog("Can't get original UUID")
-        elog("Exception Class: #{e.class.name}")
-        elog("Exception Message: #{e.message}")
-        elog("Exception Backtrace: #{e.backtrace}")
+        elog('Can\'t get original UUID', error: e)
       end
     else
       print_warning("WARNING: UUID verification and logging is not available, because the database is not active.")

--- a/lib/msf/base/simple/auxiliary.rb
+++ b/lib/msf/base/simple/auxiliary.rb
@@ -212,9 +212,7 @@ protected
         end
       end
 
-      elog("Auxiliary failed: #{e.class} #{e}", 'core', LEV_0)
-      dlog("Call stack:\n#{$@.join("\n")}", 'core', LEV_3)
-
+      elog('Auxiliary failed', error: e)
       mod.cleanup
 
     end

--- a/lib/msf/base/simple/evasion.rb
+++ b/lib/msf/base/simple/evasion.rb
@@ -95,8 +95,7 @@ module Evasion
     rescue ::Exception => e
       evasion.error = e
       evasion.print_error("evasion failed: #{e}")
-      elog("Evasion failed (#{evasion.refname}): #{e}", 'core', LEV_0)
-      dlog("Call stack:\n#{e.backtrace.join("\n")}", 'core', LEV_3)
+      elog("Evasion failed (#{evasion.refname})", error: e)
     end
 
     nil

--- a/lib/msf/base/simple/exploit.rb
+++ b/lib/msf/base/simple/exploit.rb
@@ -150,8 +150,7 @@ module Exploit
     rescue ::Exception => e
       exploit.error = e
       exploit.print_error("Exploit failed: #{e}")
-      elog("Exploit failed (#{exploit.refname}): #{e}", 'core', LEV_0)
-      dlog("Call stack:\n#{e.backtrace.join("\n")}", 'core', LEV_3)
+      elog("Exploit failed (#{exploit.refname})", error: e)
     end
 
     return driver.session if driver

--- a/lib/msf/base/simple/post.rb
+++ b/lib/msf/base/simple/post.rb
@@ -137,9 +137,7 @@ protected
         end
       end
 
-      elog("Post failed: #{e.class} #{e}", 'core', LEV_0)
-      dlog("Call stack:\n#{$@.join("\n")}", 'core', LEV_3)
-
+      elog('Post failed', error: e)
       mod.cleanup
 
       return
@@ -162,4 +160,3 @@ end
 
 end
 end
-

--- a/lib/msf/core/auxiliary/scanner.rb
+++ b/lib/msf/core/auxiliary/scanner.rb
@@ -124,7 +124,7 @@ def run
             raise $!
           rescue ::Exception => e
             print_status("Error: #{targ}: #{e.class} #{e.message}")
-            elog("Error running against host #{targ}: #{e.message}\n#{e.backtrace.join("\n")}")
+            elog("Error running against host #{targ}", error: e)
           ensure
             nmod.cleanup
           end

--- a/lib/msf/core/db_manager.rb
+++ b/lib/msf/core/db_manager.rb
@@ -169,7 +169,7 @@ class Msf::DBManager
 
     rescue ::Exception => e
       self.error = e
-      elog("DB is not enabled due to load error: #{e}")
+      elog('DB is not enabled due to load error', error: e)
       return false
     end
 
@@ -221,20 +221,24 @@ class Msf::DBManager
     # already true or if framework.db.connect called after_establish_connection.
     if !! error
       if error.to_s =~ /RubyGem version.*pg.*0\.11/i
-        elog("***")
-        elog("*")
-        elog("* Metasploit now requires version 0.11 or higher of the 'pg' gem for database support")
-        elog("* There a three ways to accomplish this upgrade:")
-        elog("* 1. If you run Metasploit with your system ruby, simply upgrade the gem:")
-        elog("*    $ rvmsudo gem install pg ")
-        elog("* 2. Use the Community Edition web interface to apply a Software Update")
-        elog("* 3. Uninstall, download the latest version, and reinstall Metasploit")
-        elog("*")
-        elog("***")
-        elog("")
-        elog("")
+        err_msg = <<~ERROR
+        ***
+        *
+        * Metasploit now requires version 0.11 or higher of the 'pg' gem for database support
+        * There are three ways to accomplish this upgrade:
+        * 1. If you run Metasploit with your system ruby, simply upgrade the gem:
+        *    $ rvmsudo gem install pg
+        * 2. Use the Community Edition web interface to apply a Software Update
+        * 3. Uninstall, download the latest version, and reinstall Metasploit
+        *
+        ***
+        
+
+        ERROR
+        elog(err_msg)
       end
 
+      # +error+ is not an instance of +Exception+, it is, in fact, a +String+
       elog("Failed to connect to the database: #{error}")
     end
 

--- a/lib/msf/core/db_manager/connection.rb
+++ b/lib/msf/core/db_manager/connection.rb
@@ -18,8 +18,7 @@ module Msf::DBManager::Connection
       migrate
     rescue ::Exception => exception
       self.error = exception
-      elog("DB.connect threw an exception: #{exception}")
-      dlog("Call stack: #{exception.backtrace.join("\n")}", LEV_1)
+      elog('DB.connect threw an exception', error: exception)
 
       # remove connection to prevent issues when re-establishing connection
       ActiveRecord::Base.remove_connection
@@ -59,8 +58,7 @@ module Msf::DBManager::Connection
       end
     rescue ::Exception => e
       self.error = e
-      elog("DB.connect threw an exception: #{e}")
-      dlog("Call stack: #{$@.join"\n"}", LEV_1)
+      elog('DB.connect threw an exception', error: e)
       return false
     ensure
       after_establish_connection
@@ -135,7 +133,7 @@ module Msf::DBManager::Connection
       self.modules_cached = false
     rescue ::Exception => e
       self.error = e
-      elog("DB.disconnect threw an exception: #{e}")
+      elog('DB.disconnect threw an exception:', error: e)
     end
   end
 end

--- a/lib/msf/core/db_manager/migration.rb
+++ b/lib/msf/core/db_manager/migration.rb
@@ -46,8 +46,7 @@ module Msf::DBManager::Migration
           # as StandardError
       rescue StandardError => error
         self.error = error
-        elog("DB.migrate threw an exception: #{error}")
-        dlog("Call stack:\n#{error.backtrace.join "\n"}")
+        elog('DB.migrate threw an exception', error: error)
       end
     end
 

--- a/lib/msf/core/db_manager/module_cache.rb
+++ b/lib/msf/core/db_manager/module_cache.rb
@@ -307,8 +307,8 @@ module Msf::DBManager::ModuleCache
           next if not obj
           begin
             update_module_details(obj)
-          rescue ::Exception
-            elog("Error updating module details for #{obj.fullname}: #{$!.class} #{$!}")
+          rescue ::Exception => e
+            elog("Error updating module details for #{obj.fullname}", error: e)
           end
         end
       end

--- a/lib/msf/core/encoded_payload.rb
+++ b/lib/msf/core/encoded_payload.rb
@@ -235,9 +235,8 @@ class EncodedPayload
             next_encoder = true
             break
 
-          rescue ::Exception
-            elog("#{err_start}: Broken encoder #{encoder.refname}: #{$!}", 'core', LEV_0)
-            dlog("#{err_start}: Call stack\n#{$@.join("\n")}", 'core', LEV_1)
+          rescue ::Exception => e
+            elog("Broken encoder #{encoder.refname}", error: e)
             next_encoder = true
             break
           end

--- a/lib/msf/core/exploit.rb
+++ b/lib/msf/core/exploit.rb
@@ -1482,26 +1482,22 @@ class Exploit < Msf::Module
       when Rex::ConnectionError
         self.fail_reason = Msf::Exploit::Failure::Unreachable
         self.print_error("Exploit failed [#{self.fail_reason}]: #{msg}")
-        elog("Exploit failed (#{self.refname}): #{msg}", 'core', LEV_0)
-        dlog("Call stack:\n#{e.backtrace.join("\n")}", 'core', LEV_3)
+        elog("Exploit failed (#{self.refname}): #{msg}", error: e)
 
       when Rex::BindFailed
         self.fail_reason = Msf::Exploit::Failure::BadConfig
         self.print_error("Exploit failed [#{self.fail_reason}]: #{msg}")
-        elog("Exploit failed (#{self.refname}): #{msg}", 'core', LEV_0)
-        dlog("Call stack:\n#{e.backtrace.join("\n")}", 'core', LEV_3)
+        elog("Exploit failed (#{self.refname}): #{msg}", error: e)
 
       when Timeout::Error
         self.fail_reason = Msf::Exploit::Failure::TimeoutExpired
         self.print_error("Exploit failed [#{self.fail_reason}]: #{msg}")
-        elog("Exploit failed (#{self.refname}): #{msg}", 'core', LEV_0)
-        dlog("Call stack:\n#{e.backtrace.join("\n")}", 'core', LEV_3)
+        elog("Exploit failed (#{self.refname}): #{msg}", error: e)
 
       when ::Interrupt
         self.fail_reason = Msf::Exploit::Failure::UserInterrupt
         self.print_error("Exploit failed [#{self.fail_reason}]: #{msg}")
-        elog("Exploit failed (#{self.refname}): #{msg}", 'core', LEV_0)
-        dlog("Call stack:\n#{e.backtrace.join("\n")}", 'core', LEV_3)
+        elog("Exploit failed (#{self.refname}): #{msg}", error: e)
       else
 
         # Compare as a string since not all error classes may be loaded
@@ -1531,8 +1527,7 @@ class Exploit < Msf::Module
           self.print_error("Exploit failed [#{self.fail_reason}]: #{msg}")
         end
 
-        elog("Exploit failed (#{self.refname}): #{msg}", 'core', LEV_0)
-        dlog("Call stack:\n#{e.backtrace.join("\n")}", 'core', LEV_3)
+        elog("Exploit failed (#{self.refname}): #{msg}", error: e)
     end
 
     # Record the error to various places

--- a/lib/msf/core/exploit/file_dropper.rb
+++ b/lib/msf/core/exploit/file_dropper.rb
@@ -108,8 +108,7 @@ module Exploit::FileDropper
           file_rm(file)
         rescue ::Exception => e
           vprint_error("Failed to delete #{file}: #{e}")
-          elog("Failed to delete #{file}: #{e.class}: #{e}")
-          elog("Call stack:\n#{e.backtrace.join("\n")}")
+          elog("Failed to delete #{file}", error: e)
         end
       end
     end
@@ -125,8 +124,7 @@ module Exploit::FileDropper
           dir_rm(dir)
         rescue ::Exception => e
           vprint_error("Failed to delete #{dir}: #{e}")
-          elog("Failed to delete #{dir}: #{e.class}: #{e}")
-          elog("Call stack:\n#{e.backtrace.join("\n")}")
+          elog("Failed to delete #{dir}", error: e)
         end
       end
     end

--- a/lib/msf/core/exploit/remote/browser_exploit_server.rb
+++ b/lib/msf/core/exploit/remote/browser_exploit_server.rb
@@ -601,7 +601,7 @@ module Msf
             begin
               method(:on_request_exploit).call(cli, request, browser_info)
             rescue BESException => e
-              elog("BESException: #{e.message}\n#{e.backtrace * "\n"}")
+              elog('BESException', error: e)
               send_not_found(cli)
               print_error("BESException: #{e.message}")
             end

--- a/lib/msf/core/exploit/smb/client/psexec.rb
+++ b/lib/msf/core/exploit/smb/client/psexec.rb
@@ -227,7 +227,7 @@ module Exploit::Remote::SMB::Client::Psexec
     begin
       return psexec(execute)
     rescue Rex::Proto::DCERPC::Exceptions::Error, Rex::Proto::SMB::Exceptions::Error => e
-      elog("#{e.class} #{e.message}\n#{e.backtrace * "\n"}", 'rex', LEV_3)
+      elog('Unable to execute specified command', 'rex', LEV_3, error: e)
       print_error("Unable to execute specified command: #{e}")
       return false
     end

--- a/lib/msf/core/framework.rb
+++ b/lib/msf/core/framework.rb
@@ -386,8 +386,7 @@ class FrameworkEventSubscriber
     address = session.session_host
 
     if not (address and address.length > 0)
-      elog("Session with no session_host/target_host/tunnel_peer")
-      dlog("#{session.inspect}", LEV_3)
+      elog("Session with no session_host/target_host/tunnel_peer. Session Info: #{session.inspect}")
       return
     end
 

--- a/lib/msf/core/handler.rb
+++ b/lib/msf/core/handler.rb
@@ -210,7 +210,7 @@ protected
       rescue ::Exception => e
         # We just wanna show and log the error, not trying to swallow it.
         print_error("#{e.class} #{e.message}")
-        elog("#{e.class} #{e.message}\n#{e.backtrace * "\n"}")
+        elog('Could not allocate a new Session.', error: e)
         raise e
       end
 

--- a/lib/msf/core/handler/bind_named_pipe.rb
+++ b/lib/msf/core/handler/bind_named_pipe.rb
@@ -352,7 +352,7 @@ module Msf
             begin
               session = handle_connection(simple_copy.pipe, opts)
             rescue => e
-              elog("Exception raised from BindNamedPipe.handle_connection: #{$!}")
+              elog('Exception raised from BindNamedPipe.handle_connection', error: e)
             end
           }
         }

--- a/lib/msf/core/handler/bind_tcp.rb
+++ b/lib/msf/core/handler/bind_tcp.rb
@@ -163,8 +163,8 @@ module BindTcp
         conn_threads << framework.threads.spawn("BindTcpHandlerSession", false, client) { |client_copy|
           begin
             handle_connection(wrap_aes_socket(client_copy), opts)
-          rescue
-            elog("Exception raised from BindTcp.handle_connection: #{$!}")
+          rescue => e
+            elog('Exception raised from BindTcp.handle_connection', error: e)
           end
         }
       else

--- a/lib/msf/core/handler/bind_udp.rb
+++ b/lib/msf/core/handler/bind_udp.rb
@@ -182,8 +182,8 @@ module BindUdp
         conn_threads << framework.threads.spawn("BindUdpHandlerSession", false, client) { |client_copy|
           begin
             handle_connection(client_copy, opts)
-          rescue
-            elog("Exception raised from BindUdp.handle_connection: #{$!}")
+          rescue => e
+            elog('Exception raised from BindUdp.handle_connection', error: e)
           end
         }
       else

--- a/lib/msf/core/handler/reverse_tcp.rb
+++ b/lib/msf/core/handler/reverse_tcp.rb
@@ -159,8 +159,8 @@ module ReverseTcp
           else
             handle_connection(wrap_aes_socket(client), opts)
           end
-        rescue StandardError
-          elog("Exception raised from handle_connection: #{$ERROR_INFO.class}: #{$ERROR_INFO}\n\n#{$ERROR_POSITION.join("\n")}")
+        rescue StandardError => e
+          elog('Exception raised from handle_connection', error: e)
         end
       end
     }

--- a/lib/msf/core/handler/reverse_tcp_double.rb
+++ b/lib/msf/core/handler/reverse_tcp_double.rb
@@ -97,8 +97,8 @@ module ReverseTcpDouble
             sock_inp, sock_out = detect_input_output(client_a_copy, client_b_copy)
             chan = TcpReverseDoubleSessionChannel.new(framework, sock_inp, sock_out)
             handle_connection(chan.lsock, { datastore: datastore })
-          rescue
-            elog("Exception raised from handle_connection: #{$!}\n\n#{$@.join("\n")}")
+          rescue => e
+            elog('Exception raised from handle_connection', error: e)
           end
         }
       end while true

--- a/lib/msf/core/handler/reverse_tcp_double_ssl.rb
+++ b/lib/msf/core/handler/reverse_tcp_double_ssl.rb
@@ -146,8 +146,8 @@ module ReverseTcpDoubleSSL
             sock_inp, sock_out = detect_input_output(client_a_copy, client_b_copy)
             chan = TcpReverseDoubleSSLSessionChannel.new(framework, sock_inp, sock_out)
             handle_connection(chan.lsock, { datastore: datastore })
-          rescue
-            elog("Exception raised from handle_connection: #{$!}\n\n#{$@.join("\n")}")
+          rescue => e
+            elog('Exception raised from handle_connection', error: e)
           end
         }
       end while true

--- a/lib/msf/core/handler/reverse_udp.rb
+++ b/lib/msf/core/handler/reverse_udp.rb
@@ -222,8 +222,8 @@ module ReverseUdp
           else
             handle_connection(client, opts)
           end
-        rescue ::Exception
-          elog("Exception raised from handle_connection: #{$!.class}: #{$!}\n\n#{$@.join("\n")}")
+        rescue ::Exception => e
+          elog('Exception raised from handle_connection', error: e)
         end
       end
     }

--- a/lib/msf/core/module/external.rb
+++ b/lib/msf/core/module/external.rb
@@ -19,7 +19,7 @@ module Msf::Module::External
       rescue Interrupt => e
         raise e
       rescue Exception => e
-        elog e.backtrace.join("\n")
+        elog('Unable to execute External Module', error: e)
         fail_with Msf::Module::Failure::Unknown, e.message
       end
     end

--- a/lib/msf/core/modules/loader/base.rb
+++ b/lib/msf/core/modules/loader/base.rb
@@ -304,7 +304,7 @@ class Msf::Modules::Loader::Base
           reloaded_module_instance.datastore.update(original_metasploit_instance.datastore)
         end
       else
-        elog("Failed to create instance of #{original_metasploit_class_or_instance.refname} after reload.", 'core')
+        elog("Failed to create instance of #{original_metasploit_class_or_instance.refname} after reload.")
 
         # Return the old module instance to avoid an strace trace
         return original_metasploit_class_or_instance

--- a/lib/msf/core/modules/loader/executable.rb
+++ b/lib/msf/core/modules/loader/executable.rb
@@ -93,7 +93,7 @@ class Msf::Modules::Loader::Executable < Msf::Modules::Loader::Base
         return ''
       end
     rescue ::Exception => e
-      elog "Unable to load module #{full_path} #{e.class} #{e} #{e.backtrace.join "\n"}"
+      elog("Unable to load module #{full_path}", error: e)
       # XXX migrate this to a full load_error when we can tell the user why the
       # module did not load and/or how to resolve it.
       # load_error(full_path, e)

--- a/lib/msf/core/modules/metadata/cache.rb
+++ b/lib/msf/core/modules/metadata/cache.rb
@@ -76,7 +76,7 @@ class Cache
             refresh_metadata_instance_internal(module_instance)
             has_changes = true
           rescue Exception => e
-            elog("Error updating module details for #{module_instance.fullname}: #{$!.class} #{$!} : #{e.message}")
+            elog("Error updating module details for #{module_instance.fullname}", error: e)
           end
         end
       end

--- a/lib/msf/core/modules/metadata/store.rb
+++ b/lib/msf/core/modules/metadata/store.rb
@@ -39,7 +39,7 @@ module Msf::Modules::Metadata::Store
         end
       }
     rescue => e
-      elog("Unable to update metadata store: #{e.message}")
+      elog('Unable to update metadata store', error: e)
     end
   end
 
@@ -60,7 +60,7 @@ module Msf::Modules::Metadata::Store
         retry
       else
         @console.print_warning('Unable to load module metadata from disk see error log')
-        elog("Unable to load module metadata: #{e.message}")
+        elog('Unable to load module metadata', error: e)
       end
     end
 
@@ -120,10 +120,9 @@ module Msf::Modules::Metadata::Store
       begin
         @module_metadata_cache[k] =  Msf::Modules::Metadata::Obj.from_hash(v)
       rescue => e
-        elog("Unable to load module metadata object with key: #{k}")
+        elog("Unable to load module metadata object with key: #{k}", error: e)
       end
     }
   end
 
 end
-

--- a/lib/msf/core/post/windows/dotnet.rb
+++ b/lib/msf/core/post/windows/dotnet.rb
@@ -21,7 +21,7 @@ module Msf::Post::Windows::Dotnet
       subkeys = registry_enumvals(dotnet_subkey)
     rescue Rex::Post::Meterpreter::RequestError => e
       print_status("Encountered exception in search_for_version: #{e.class} #{e}")
-      elog("#{e.class} #{e.message}\n#{e.backtrace * "\n"}")
+      elog(e)
     end
     unless subkeys.nil?
       subkeys.each do |subkey|
@@ -44,7 +44,7 @@ module Msf::Post::Windows::Dotnet
       subkeys = registry_enumkeys(dotnet_vkey)
     rescue Rex::Post::Meterpreter::RequestError => e
       print_status("Encountered exception in get_versionception: #{e.class} #{e}")
-      elog("#{e.class} #{e.message}\n#{e.backtrace * "\n"}")
+      elog(e)
     end
     unless subkeys.nil?
       subkeys.each do |subkey|
@@ -69,7 +69,7 @@ module Msf::Post::Windows::Dotnet
       dotnet_keys = registry_enumkeys(key)
     rescue Rex::Post::Meterpreter::RequestError => e
       print_status("Encountered exception in get_dotnet_version: #{e.class} #{e}")
-      elog("#{e.class} #{e.message}\n#{e.backtrace * "\n"}")
+      elog(e)
     end
     unless dotnet_keys.nil?
       dotnet_keys.each do |temp_key|

--- a/lib/msf/core/post/windows/priv.rb
+++ b/lib/msf/core/post/windows/priv.rb
@@ -78,7 +78,7 @@ module Msf::Post::Windows::Priv
     rescue Rex::Post::Meterpreter::RequestError => e
       # It could raise an exception even when the token is successfully stolen,
       # so we will just log the exception and move on.
-      elog("#{e.class} #{e.message}\n#{e.backtrace * "\n"}")
+      elog(e)
     end
 
     true

--- a/lib/msf/core/rpc/v10/rpc_plugin.rb
+++ b/lib/msf/core/rpc/v10/rpc_plugin.rb
@@ -41,7 +41,7 @@ class RPC_Plugin < RPC_Base
         return { "result" => "success" }
       end
     rescue ::Exception => e
-      elog("Error loading plugin #{path}: #{e}\n\n#{e.backtrace.join("\n")}", 'core', 0)
+      elog("Error loading plugin #{path}:", error: e)
       return { "result" => "failure" }
     end
 

--- a/lib/msf/core/rpc/v10/service.rb
+++ b/lib/msf/core/rpc/v10/service.rb
@@ -92,7 +92,7 @@ class Service
     begin
       res.body = process(req).to_msgpack
     rescue Msf::RPC::Exception => e
-      elog("RPC Exception: #{e.class} #{e} #{e.backtrace} #{cli.inspect} #{req.inspect}")
+      elog('RPC Exception', error: e)
       res.body = process_exception(e).to_msgpack
       res.code = e.code
     end
@@ -155,7 +155,7 @@ class Service
       ::Timeout.timeout(self.dispatcher_timeout) { self.handlers[group].send(mname, *msg) }
 
     rescue ::Exception => e
-      elog("RPC Exception: #{e.class} #{e.to_s} #{e.backtrace} #{msg.inspect} #{req.inspect}")
+      elog('RPC Exception', error: e)
       process_exception(e)
     end
   end

--- a/lib/msf/core/session_manager.rb
+++ b/lib/msf/core/session_manager.rb
@@ -138,8 +138,7 @@ class SessionManager < Hash
       #
       rescue ::Exception => e
         respawn_cnt += 1
-        elog("Exception #{respawn_cnt}/#{respawn_max} in monitor thread #{e.class} #{e}")
-        elog("Call stack: \n#{e.backtrace.join("\n")}")
+        elog("Exception #{respawn_cnt}/#{respawn_max} in monitor thread", error: e)
         if respawn_cnt < respawn_max
           ::IO.select(nil, nil, nil, 10.0)
           retry

--- a/lib/msf/core/thread_manager.rb
+++ b/lib/msf/core/thread_manager.rb
@@ -84,7 +84,7 @@ class ThreadManager < Array
       end
 
       rescue ::Exception => e
-        elog("thread monitor: #{e} #{e.backtrace} source:#{self[:tm_call].inspect}")
+        elog("Thread Monitor Exception | Source: #{self[:tm_call].inspect}", error: e)
       end
     end
   end
@@ -106,12 +106,11 @@ class ThreadManager < Array
           argv.shift.call(*argv)
         rescue ::Exception => e
           elog(
-              "thread exception: #{::Thread.current[:tm_name]}  critical=#{::Thread.current[:tm_crit]}  " \
-              "error: #{e.class} #{e}\n" \
+              "Thread Exception: #{::Thread.current[:tm_name]}  critical=#{::Thread.current[:tm_crit]}  " \
               "  source:\n" \
-              "    #{::Thread.current[:tm_call].join "\n    "}"
+              "    #{::Thread.current[:tm_call].join "\n    "}",
+              error: e
           )
-          elog("Call Stack\n#{e.backtrace.join("\n")}")
           raise e
         ensure
           if framework.db && framework.db.active && framework.db.is_local?

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -779,7 +779,7 @@ class Core
         print_status("Successfully loaded plugin: #{inst.name}")
       end
     rescue ::Exception => e
-      elog("Error loading plugin #{path}: #{e}\n\n#{e.backtrace.join("\n")}", 'core', 0)
+      elog("Error loading plugin #{path}", error: e)
       print_error("Failed to load plugin from #{path}: #{e}")
     end
   end
@@ -1005,7 +1005,7 @@ class Core
         cmd_route_help
       end
     rescue => error
-      elog("#{error}\n\n#{error.backtrace.join("\n")}")
+      elog(error)
       print_error(error.message)
     end
   end
@@ -1632,7 +1632,7 @@ class Core
       end
     rescue OptionValidateError => e
       print_error(e.message)
-      elog(e.message)
+      elog('Exception encountered in cmd_set', error: e)
     end
 
     # Set PAYLOAD from TARGET

--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -1500,15 +1500,15 @@ class Db
           print_error("Please note that there were #{warnings} warnings") if warnings > 1
           print_error("Please note that there was one warning") if warnings == 1
 
-        rescue Msf::DBImportError
+        rescue Msf::DBImportError => e
           print_error("Failed to import #{filename}: #{$!}")
-          elog("Failed to import #{filename}: #{$!.class}: #{$!}")
+          elog("Failed to import #{filename}", error: e)
           dlog("Call stack: #{$@.join("\n")}", LEV_3)
           next
         rescue REXML::ParseException => e
           print_error("Failed to import #{filename} due to malformed XML:")
           print_error("#{e.class}: #{e}")
-          elog("Failed to import #{filename}: #{e.class}: #{e}")
+          elog("Failed to import #{filename}", error: e)
           dlog("Call stack: #{$@.join("\n")}", LEV_3)
           next
         end

--- a/lib/msf/ui/console/command_dispatcher/evasion.rb
+++ b/lib/msf/ui/console/command_dispatcher/evasion.rb
@@ -36,7 +36,7 @@ class Evasion
       print_error('Evasion interrupted by the console user')
     rescue ::Exception => e
       print_error("Evasion failed: #{e.class} #{e}")
-      elog("#{e.class} #{e.message}\n#{e.backtrace * "\n"}")
+      elog('Evasion Failed', error: e)
     end
   end
 

--- a/lib/msf/ui/console/module_command_dispatcher.rb
+++ b/lib/msf/ui/console/module_command_dispatcher.rb
@@ -105,7 +105,7 @@ module ModuleCommandDispatcher
         if exception.kind_of?(::Interrupt)
           raise exception
         else
-          elog("#{exception} #{exception.class}:\n#{exception.backtrace.join("\n")}")
+          elog('Error encountered with first Thread', error: exception)
         end
       end
 
@@ -252,20 +252,20 @@ module ModuleCommandDispatcher
     rescue ::Rex::ConnectionError, ::Rex::ConnectionProxyError, ::Errno::ECONNRESET, ::Errno::EINTR, ::Rex::TimeoutError, ::Timeout::Error => e
       # Connection issues while running check should be handled by the module
       print_error("Check failed: #{e.class} #{e}")
-      elog("#{e.message}\n#{e.backtrace.join("\n")}")
+      elog('Check Failed', error: e)
     rescue ::Msf::Exploit::Failed => e
       # Handle fail_with and other designated exploit failures
       print_error("Check failed: #{e.class} #{e}")
-      elog("#{e.message}\n#{e.backtrace.join("\n")}")
+      elog('Check Failed', error: e)
     rescue ::RuntimeError => e
       # Some modules raise RuntimeError but we don't necessarily care about those when we run check()
-      elog("#{e.message}\n#{e.backtrace.join("\n")}")
+      elog('Check Failed', error: e)
     rescue ::NotImplementedError => e
       print_error(e.message)
-      elog("#{e.message}\n#{e.backtrace.join("\n")}")
+      elog('Check Failed', error: e)
     rescue ::Exception => e
       print_error("Check failed: #{e.class} #{e}")
-      elog("#{e.message}\n#{e.backtrace.join("\n")}")
+      elog('Check Failed', error: e)
     end
   end
 

--- a/lib/rex/json_hash_file.rb
+++ b/lib/rex/json_hash_file.rb
@@ -85,7 +85,7 @@ private
     begin
       JSON.parse(data)
     rescue JSON::ParserError => e
-      # elog("JSONHashFile @ #{path} was corrupt: #{e.class} #{e}"
+      elog("JSONHashFile at #{path} was corrupt", error: e)
       {}
     end
   end

--- a/lib/rex/logging/log_dispatcher.rb
+++ b/lib/rex/logging/log_dispatcher.rb
@@ -108,7 +108,7 @@ class LogDispatcher
   # This method returns the log level threshold of a given source.
   #
   def get_level(src)
-    log_levels[src]
+    log_levels.fetch(src, DEFAULT_LOG_LEVEL)
   end
 
   attr_accessor :log_sinks, :log_sinks_lock # :nodoc:
@@ -118,8 +118,6 @@ end
 end
 end
 
-###
-#
 # An instance of the log dispatcher exists in the global namespace, along
 # with stubs for many of the common logging methods.  Various sources can
 # register themselves as a log sink such that logs can be directed at
@@ -130,12 +128,47 @@ end
 ###
 ExceptionCallStack = "__EXCEPTCALLSTACK__"
 
+BACKTRACE_LOG_LEVEL = 3 # Equal to LEV_3
+DEFAULT_LOG_LEVEL = 0 # Equal to LEV_3
+
 def dlog(msg, src = 'core', level = 0)
   $dispatcher.log(LOG_DEBUG, src, level, msg)
 end
 
-def elog(msg, src = 'core', level = 0)
-  $dispatcher.log(LOG_ERROR, src, level, msg)
+# Logs errors in a standard format for each Log Level.
+#
+# @param msg [String] Contains message from the developer explaining why an error was encountered.
+# Can also be an +Exception+, in which case a log is built from the +Exception+ with no accompanying message.
+#
+# @param src [String] Used to indicate where the error is originating from. Most commonly set to 'core'.
+#
+# @param log_level [Integer] Indicates the level of logging the message should be recorded at. If log_level is greater than
+# the global log level set for +src+, then the log is not recorded.
+#
+# @param error [Exception] Exception of an error that needs to be logged. For all log messages, the class and message of
+# an exception is added to a log message. If the global log level set for +src+ is greater than +BACKTRACE_LOG_LEVEL+,
+# then the stack trace for an error is also added to the log message.
+#
+# (Eg Loop Iterations, Variables, Function Calls).
+#
+# @return [NilClass].
+def elog(msg, src = 'core', log_level = 0, error: nil)
+  error = msg.is_a?(Exception) ? msg : error
+
+  if error.nil? || !error.is_a?(Exception)
+    $dispatcher.log(LOG_ERROR, src, log_level, msg)
+  else
+    error_details = "#{error.class} #{error.message}"
+    if get_log_level(src) >= BACKTRACE_LOG_LEVEL
+      error_details << "\nCall stack:\n#{error.backtrace.join("\n")}"
+    end
+
+    if msg.is_a?(Exception)
+      $dispatcher.log(LOG_ERROR, src, log_level,"#{error_details}")
+    else
+      $dispatcher.log(LOG_ERROR, src, log_level,"#{msg} - #{error_details}")
+    end
+  end
 end
 
 def wlog(msg, src = 'core', level = 0)

--- a/lib/rex/post/hwbridge/ui/console/command_dispatcher.rb
+++ b/lib/rex/post/hwbridge/ui/console/command_dispatcher.rb
@@ -73,9 +73,7 @@ module Console::CommandDispatcher
   def log_error(msg)
     print_error(msg)
 
-    elog(msg, 'hwbridge')
-
-    dlog("Call stack:\n#{$@.join("\n")}", 'hwbridge')
+    elog(msg, 'hwbridge', error: $!)
   end
 
 end

--- a/lib/rex/post/hwbridge/ui/console/command_dispatcher/automotive.rb
+++ b/lib/rex/post/hwbridge/ui/console/command_dispatcher/automotive.rb
@@ -310,10 +310,9 @@ class Console::CommandDispatcher::Automotive
             client.automotive.cansend(bus, id, "023E00")
             sleep(2)
           end
-        rescue ::Exception
-          print_error("Error in TesterPResent: #{$!.class} #{$!}")
-          elog("Error in TesterPreset: #{$!.class} #{$!}")
-          dlog("Callstack: #{$@.join("\n")}")
+        rescue ::Exception => e
+          print_error('Error in TesterPresent')
+          elog('Error in TesterPreset', error: e)
         end
         self.tpjobs[myjid] = nil
         print_status("TesterPreset #{myjid} has stopped (#{::Thread.current[:args].inspect})")

--- a/lib/rex/post/hwbridge/ui/console/command_dispatcher/core.rb
+++ b/lib/rex/post/hwbridge/ui/console/command_dispatcher/core.rb
@@ -402,10 +402,9 @@ class Console::CommandDispatcher::Core
         # the rest of the arguments get passed in through the binding
         client.execute_script(script_name, args)
       end
-    rescue
-      print_error("Error in script: #{$!.class} #{$!}")
-      elog("Error in script: #{$!.class} #{$!}")
-      dlog("Callstack: #{$@.join("\n")}")
+    rescue => e
+      print_error("Error in script: #{script_name}")
+      elog("Error in script: #{script_name}", error: e)
     end
   end
 
@@ -451,11 +450,11 @@ class Console::CommandDispatcher::Core
       ::Thread.current[:args] = xargs.dup
       begin
         # the rest of the arguments get passed in through the binding
-        client.execute_script(args.shift, args)
-      rescue ::Exception
-        print_error("Error in script: #{$!.class} #{$!}")
-        elog("Error in script: #{$!.class} #{$!}")
-        dlog("Callstack: #{$@.join("\n")}")
+        script_name = args.shift
+        client.execute_script(script_name, args)
+      rescue ::Exception => e
+        print_error("Error in script: #{script_name}")
+        elog("Error in script #{script_name}", error: e)
       end
       self.bgjobs[myjid] = nil
       print_status("Background script with Job ID #{myjid} has completed (#{::Thread.current[:args].inspect})")

--- a/lib/rex/post/meterpreter/extensions/stdapi/webcam/webcam.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/webcam/webcam.rb
@@ -157,7 +157,7 @@ class Webcam
       write_file("#{tmp_dir}\\interface.html", interface)
       write_file("#{tmp_dir}\\api.js", api)
     rescue RuntimeError => e
-      elog("webcam_chat failed. #{e.class} #{e}")
+      elog('webcam_chat failed', error: e)
       raise "Unable to initialize the interface on the target machine"
     end
 
@@ -175,7 +175,7 @@ class Webcam
       begin
         write_file(profile_path, setting)
       rescue RuntimeError => e
-        elog("webcam_chat failed: #{e.class} #{e}")
+        elog('webcam_chat failed', error: e)
         raise "Unable to write the necessary setting for Firefox."
       end
       args = "-p #{profile_name}"
@@ -186,7 +186,7 @@ class Webcam
     begin
       session.sys.process.execute(remote_browser_path, "#{args} #{tmp_dir}\\interface.html", exec_opts)
     rescue RuntimeError => e
-      elog("webcam_chat failed. #{e.class} #{e}")
+      elog('webcam_chat failed', error: e)
       raise "Unable to start the remote browser: #{e.message}"
     end
   end

--- a/lib/rex/post/meterpreter/packet_dispatcher.rb
+++ b/lib/rex/post/meterpreter/packet_dispatcher.rb
@@ -96,7 +96,7 @@ module PacketDispatcher
       cli.send_response(resp)
     rescue => e
       send_queue.unshift(resp) if resp
-      elog("Exception sending a reply to the reader request: #{cli.inspect} #{e.class} #{e} #{e.backtrace}")
+      elog("Exception sending a reply to the reader request #{cli.inspect}", error: e)
     end
   end
 
@@ -416,7 +416,7 @@ module PacketDispatcher
         # If we have any packets that weren't handled, they go back
         # on the incomplete queue so that they're prioritised over
         # new packets that are coming in off the wire.
-        dlog("Requeuing #{incomplete.length} packet(s)", 'meterpreter', LEV_1) if incomplete.length > 0 
+        dlog("Requeuing #{incomplete.length} packet(s)", 'meterpreter', LEV_1) if incomplete.length > 0
         while incomplete.length > 0
           @incomplete_queue << incomplete.shift
         end
@@ -663,7 +663,7 @@ module HttpPacketDispatcher
         cli.send_response(resp)
       rescue ::Exception => e
         send_queue.unshift(rpkt) if rpkt
-        elog("Exception sending a reply to the reader request: #{cli.inspect} #{e.class} #{e} #{e.backtrace}")
+        elog("Exception sending a reply to the reader request #{cli.inspect}", error: e)
       end
     else
       resp.body = ""
@@ -678,7 +678,7 @@ module HttpPacketDispatcher
     end
 
     rescue ::Exception => e
-      elog("Exception handling request: #{cli.inspect} #{req.inspect} #{e.class} #{e} #{e.backtrace}")
+      elog("Exception handling request: #{cli.inspect} #{req.inspect}", error: e)
     end
   end
 

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
@@ -1177,9 +1177,9 @@ class Console::CommandDispatcher::Core
     begin
       server = client.sys.process.open
     rescue TimeoutError => e
-      elog(e.to_s)
+      elog('Server Timeout', error: e)
     rescue RequestError => e
-      elog(e.to_s)
+      elog('Request Error', error: e)
     end
 
     service = client.pfservice
@@ -1445,10 +1445,9 @@ class Console::CommandDispatcher::Core
         # the rest of the arguments get passed in through the binding
         client.execute_script(script_name, args)
       end
-    rescue
-      print_error("Error in script: #{$!.class} #{$!}")
-      elog("Error in script: #{$!.class} #{$!}")
-      dlog("Callstack: #{$@.join("\n")}")
+    rescue => e
+      print_error("Error in script: #{script_name}")
+      elog("Error in script: #{script_name}", error: e)
     end
   end
 
@@ -1499,11 +1498,11 @@ class Console::CommandDispatcher::Core
       ::Thread.current[:args] = xargs.dup
       begin
         # the rest of the arguments get passed in through the binding
-        client.execute_script(args.shift, args)
-      rescue ::Exception
-        print_error("Error in script: #{$!.class} #{$!}")
-        elog("Error in script: #{$!.class} #{$!}")
-        dlog("Callstack: #{$@.join("\n")}")
+        script_name = args.shift
+        client.execute_script(script_name, args)
+      rescue ::Exception => e
+        print_error("Error in script: #{script_name}")
+        elog("Error in script: #{script_name}", error: e)
       end
       self.bgjobs[myjid] = nil
       print_status("Background script with Job ID #{myjid} has completed (#{::Thread.current[:args].inspect})")
@@ -1849,4 +1848,3 @@ end
 end
 end
 end
-

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/priv/elevate.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/priv/elevate.rb
@@ -106,7 +106,7 @@ class Console::CommandDispatcher::Priv::Elevate
       translate_technique_index(technique).each do |desc|
         print_error(desc)
       end
-      elog("#{e.class} #{e.message} (Technique: #{technique})\n#{e.backtrace * "\n"}")
+      elog("Technique: #{technique})", error: e)
       return
     end
 

--- a/lib/rex/proto/dcerpc/svcctl/packet.rb
+++ b/lib/rex/proto/dcerpc/svcctl/packet.rb
@@ -56,7 +56,7 @@ class Client
         end
       end
     rescue Rex::Proto::DCERPC::Exceptions::Fault => e
-      elog("Error getting scm handle: #{e}")
+      elog('Error getting scm handle', error: e)
     end
 
     [scm_handle, scm_status]
@@ -120,7 +120,7 @@ class Client
     begin
       response = dcerpc_client.call(CREATE_SERVICE_W, stubdata)
     rescue Rex::Proto::DCERPC::Exceptions::Fault => e
-      elog("Error creating service: #{e}")
+      elog('Error creating service', error: e)
     end
 
     if response
@@ -152,7 +152,7 @@ class Client
       response = dcerpc_client.call(CHANGE_SERVICE_CONFIG2_W, stubdata) # ChangeServiceConfig2
       svc_status = error_code(response)
     rescue Rex::Proto::DCERPC::Exceptions::Fault => e
-      elog("Error changing service description : #{e}")
+      elog('Error changing service description', error: e)
     end
 
     svc_status
@@ -172,7 +172,7 @@ class Client
         svc_status = error_code(response)
       end
     rescue Rex::Proto::DCERPC::Exceptions::Fault => e
-      elog("Error closing service handle: #{e}")
+      elog('Error closing service handle', error: e)
     end
 
     svc_status
@@ -198,7 +198,7 @@ class Client
         end
       end
     rescue Rex::Proto::DCERPC::Exceptions::Fault => e
-      elog("Error opening service handle: #{e}")
+      elog('Error opening service handle', error: e)
     end
 
     svc_handle
@@ -250,7 +250,7 @@ class Client
         svc_status = error_code(response)
       end
     rescue Rex::Proto::DCERPC::Exceptions::Fault => e
-      elog("Error starting service: #{e}")
+      elog('Error starting service', error: e)
     end
 
     svc_status
@@ -280,7 +280,7 @@ class Client
        svc_status =  error_code(response[28,4])
       end
     rescue Rex::Proto::DCERPC::Exceptions::Fault => e
-      elog("Error controlling service: #{e}")
+      elog('Error controlling service', error: e)
     end
 
     svc_status
@@ -299,7 +299,7 @@ class Client
         svc_status = error_code(response)
       end
     rescue Rex::Proto::DCERPC::Exceptions::Fault => e
-      elog("Error deleting service: #{e}")
+      elog('Error deleting service', error: e)
     end
 
     svc_status
@@ -323,7 +323,7 @@ class Client
         ret = 2
       end
     rescue Rex::Proto::DCERPC::Exceptions::Fault => e
-      elog("Error deleting service: #{e}")
+      elog('Error deleting service', error: e)
     end
 
     ret

--- a/lib/rex/proto/http/handler/erb.rb
+++ b/lib/rex/proto/http/handler/erb.rb
@@ -77,8 +77,8 @@ class Handler::Erb < Handler
       end
     rescue Errno::ENOENT
       server.send_e404(cli, req)
-    rescue
-      elog("Erb::on_request: #{$!}\n#{$@.join("\n")}", LogSource)
+    rescue => e
+      elog('Erb::on_request', LogSource, error: e)
 
       resp.code    = 500
       resp.message = "Internal Server Error"

--- a/lib/rex/proto/http/handler/proc.rb
+++ b/lib/rex/proto/http/handler/proc.rb
@@ -36,10 +36,10 @@ class Handler::Proc < Handler
   def on_request(cli, req)
     begin
       procedure.call(cli, req)
-    rescue Errno::EPIPE, ::Errno::ECONNRESET, ::Errno::ENOTCONN, ::Errno::ECONNABORTED
-      elog("Proc::on_request: Client closed connection prematurely", LogSource)
-    rescue
-      elog("Proc::on_request: #{$!.class}: #{$!}\n\n#{$@.join("\n")}", LogSource)
+    rescue Errno::EPIPE, ::Errno::ECONNRESET, ::Errno::ENOTCONN, ::Errno::ECONNABORTED => e
+      elog('Proc::on_request: Client closed connection prematurely', LogSource, error: e)
+    rescue => e
+      elog('Proc::on_request', LogSource, error: e)
       if self.server and self.server.context
         exploit = self.server.context['MsfExploit']
         if exploit

--- a/lib/rex/proto/http/response.rb
+++ b/lib/rex/proto/http/response.rb
@@ -126,7 +126,7 @@ class Response < Packet
     begin
       json = JSON.parse(self.body)
     rescue JSON::ParserError => e
-      elog("#{e.class} #{e.message}\n#{e.backtrace * "\n"}")
+      elog(e)
     end
 
     json

--- a/lib/rex/proto/http/server.rb
+++ b/lib/rex/proto/http/server.rb
@@ -368,8 +368,7 @@ protected
         handler.on_request(cli, request)
       end
     else
-      elog("Failed to find handler for resource: #{request.resource}",
-        LogSource)
+      elog("Failed to find handler for resource: #{request.resource}", LogSource)
 
       send_e404(cli, request)
     end

--- a/lib/rex/services/local_relay.rb
+++ b/lib/rex/services/local_relay.rb
@@ -183,8 +183,8 @@ class LocalRelay
       self.relay_thread = Rex::ThreadFactory.spawn("LocalRelay", false) {
         begin
           monitor_relays
-        rescue ::Exception
-          elog("Error in #{self} monitor_relays: #{$!}", 'rex')
+        rescue ::Exception => e
+          elog("Error in #{self} monitor_relays", 'rex', error: e)
         end
       }
     end
@@ -494,8 +494,8 @@ protected
         dlog("monitor_relays: closed stream #{e.stream}", 'rex', LEV_3)
 
         next
-      rescue
-        elog("Error in #{self} monitor_relays select: #{$!.class} #{$!}", 'rex')
+      rescue => e
+        elog("Error in #{self} monitor_relays select:", 'rex', error: e)
         return
       end
 
@@ -516,8 +516,8 @@ protected
             data = rfd.sysread(65536)
             rfd.other_stream.on_other_data(data)
           # If we catch an error, close the connection
-          rescue ::Exception
-            elog("Error in #{self} monitor_relays read: #{$!}", 'rex')
+          rescue ::Exception => e
+            elog("Error in #{self} monitor_relays read", 'rex', error: e)
             close_relay_conn(rfd)
           end
         end

--- a/modules/auxiliary/admin/scada/phoenix_command.rb
+++ b/modules/auxiliary/admin/scada/phoenix_command.rb
@@ -59,7 +59,7 @@ class MetasploitModule < Msf::Auxiliary
       sock.put(data)
       buf = sock.get_once || ''
     rescue Rex::AddressInUse, ::Errno::ETIMEDOUT, Rex::HostUnreachable, Rex::ConnectionTimeout, Rex::ConnectionRefused, ::Timeout::Error, ::EOFError => e
-      elog("#{e.class} #{e.message}\n#{e.backtrace * "\n"}")
+      elog(e)
     end
 
     bin_to_hex(buf)

--- a/modules/auxiliary/admin/smb/delete_file.rb
+++ b/modules/auxiliary/admin/smb/delete_file.rb
@@ -53,7 +53,7 @@ class MetasploitModule < Msf::Auxiliary
         # If there's no exception raised at this point, we assume the file has been removed.
         print_good("Deleted: #{remote_path}")
       rescue Rex::Proto::SMB::Exceptions::ErrorCode => e
-        elog("#{e.class} #{e.message}\n#{e.backtrace * "\n"}")
+        elog("Cannot delete #{remote_path}:", error: e)
         print_error("Cannot delete #{remote_path}: #{e.message}")
       end
     end
@@ -63,7 +63,7 @@ class MetasploitModule < Msf::Auxiliary
     begin
       smb_delete_files
     rescue Rex::Proto::SMB::Exceptions::LoginError => e
-      elog("#{e.class} #{e.message}\n#{e.backtrace * "\n"}")
+      elog('Unable to login', error: e)
       print_error("Unable to login: #{e.message}")
     end
   end

--- a/modules/auxiliary/admin/smb/download_file.rb
+++ b/modules/auxiliary/admin/smb/download_file.rb
@@ -56,7 +56,7 @@ class MetasploitModule < Msf::Auxiliary
         path = store_loot("smb.shares.file", "application/octet-stream", rhost, data, fname)
         print_good("#{remote_path} saved as: #{path}")
       rescue Rex::Proto::SMB::Exceptions::ErrorCode => e
-        elog("#{e.class} #{e.message}\n#{e.backtrace * "\n"}")
+        elog("Unable to download #{remote_path}:", error: e)
         print_error("Unable to download #{remote_path}: #{e.message}")
       end
     end
@@ -66,7 +66,7 @@ class MetasploitModule < Msf::Auxiliary
     begin
       smb_download
     rescue Rex::Proto::SMB::Exceptions::LoginError => e
-      elog("#{e.class} #{e.message}\n#{e.backtrace * "\n"}")
+      elog("Unable to login: #{e.message}", error: e)
       print_error("Unable to login: #{e.message}")
     end
   end

--- a/modules/auxiliary/admin/smb/upload_file.rb
+++ b/modules/auxiliary/admin/smb/upload_file.rb
@@ -64,12 +64,12 @@ class MetasploitModule < Msf::Auxiliary
 
           print_good("#{local_path} uploaded to #{remote_path}")
         rescue Rex::Proto::SMB::Exceptions::ErrorCode => e
-          elog("#{e.class} #{e.message}\n#{e.backtrace * "\n"}")
+          elog("Unable to upload #{local_path} to #{remote_path}", error: e)
           print_error("Unable to upload #{local_path} to #{remote_path} : #{e.message}")
         end
       end
     rescue Rex::Proto::SMB::Exceptions::LoginError => e
-      elog("#{e.class} #{e.message}\n#{e.backtrace * "\n"}")
+      elog("Unable to login:", error: e)
       print_error("Unable to login: #{e.message}")
     end
   end

--- a/modules/auxiliary/dos/misc/ibm_tsm_dos.rb
+++ b/modules/auxiliary/dos/misc/ibm_tsm_dos.rb
@@ -72,7 +72,7 @@ class MetasploitModule < Msf::Auxiliary
     print_status("Packet sent!")
   rescue Rex::AddressInUse, ::Errno::ETIMEDOUT, Rex::HostUnreachable, Rex::ConnectionTimeout, Rex::ConnectionRefused, ::Timeout::Error, ::EOFError => ex
     print_error("Exploit failed: #{ex.class} #{ex.message}")
-    elog("#{ex.class} #{ex.message}\n#{ex.backtrace * "\n"}")
+    elog(ex)
   ensure
     disconnect
   end

--- a/modules/auxiliary/dos/scada/allen_bradley_pccc.rb
+++ b/modules/auxiliary/dos/scada/allen_bradley_pccc.rb
@@ -168,7 +168,7 @@ class MetasploitModule < Msf::Auxiliary
     end
 
   rescue Rex::AddressInUse, ::Errno::ETIMEDOUT, Rex::HostUnreachable, Rex::ConnectionTimeout, Rex::ConnectionRefused, ::Timeout::Error, ::EOFError => e
-    elog("#{e.class} #{e.message}\n#{e.backtrace * "\n"}")
+    elog(e)
   ensure
     disconnect
   end
@@ -202,7 +202,7 @@ class MetasploitModule < Msf::Auxiliary
     sock.put(pccc_dos_pkt(enip_session_id, cip_connection_id))
 
   rescue Rex::AddressInUse, ::Errno::ETIMEDOUT, Rex::HostUnreachable, Rex::ConnectionTimeout, Rex::ConnectionRefused, ::Timeout::Error, ::EOFError => e
-    elog("#{e.class} #{e.message}\n#{e.backtrace * "\n"}")
+    elog(e)
   ensure
     disconnect
   end

--- a/modules/auxiliary/scanner/ftp/bison_ftp_traversal.rb
+++ b/modules/auxiliary/scanner/ftp/bison_ftp_traversal.rb
@@ -103,10 +103,10 @@ class MetasploitModule < Msf::Auxiliary
 
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout => e
       vprint_error(e.message)
-      elog("#{e.class} #{e.message} #{e.backtrace * "\n"}")
+      elog(e)
     rescue ::Timeout::Error, ::Errno::EPIPE => e
       vprint_error(e.message)
-      elog("#{e.class} #{e.message} #{e.backtrace * "\n"}")
+      elog(e)
     ensure
       data_disconnect
       disconnect

--- a/modules/auxiliary/scanner/ftp/colorado_ftp_traversal.rb
+++ b/modules/auxiliary/scanner/ftp/colorado_ftp_traversal.rb
@@ -87,10 +87,10 @@ class MetasploitModule < Msf::Auxiliary
 
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout => e
       vprint_error(e.message)
-      elog("#{e.class} #{e.message} #{e.backtrace * "\n"}")
+      elog(e)
     rescue ::Timeout::Error, ::Errno::EPIPE => e
       vprint_error(e.message)
-      elog("#{e.class} #{e.message} #{e.backtrace * "\n"}")
+      elog(e)
     ensure
       data_disconnect
       disconnect

--- a/modules/auxiliary/scanner/ftp/easy_file_sharing_ftp.rb
+++ b/modules/auxiliary/scanner/ftp/easy_file_sharing_ftp.rb
@@ -97,10 +97,10 @@ class MetasploitModule < Msf::Auxiliary
 
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout => e
       vprint_error(e.message)
-      elog("#{e.class} #{e.message} #{e.backtrace * "\n"}")
+      elog(e)
     rescue ::Timeout::Error, ::Errno::EPIPE => e
       vprint_error(e.message)
-      elog("#{e.class} #{e.message} #{e.backtrace * "\n"}")
+      elog(e)
     ensure
       data_disconnect
       disconnect

--- a/modules/auxiliary/scanner/ftp/konica_ftp_traversal.rb
+++ b/modules/auxiliary/scanner/ftp/konica_ftp_traversal.rb
@@ -102,10 +102,10 @@ class MetasploitModule < Msf::Auxiliary
 
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout => e
       vprint_error(e.message)
-      elog("#{e.class} #{e.message} #{e.backtrace * "\n"}")
+      elog(e)
     rescue ::Timeout::Error, ::Errno::EPIPE => e
       vprint_error(e.message)
-      elog("#{e.class} #{e.message} #{e.backtrace * "\n"}")
+      elog(e)
     ensure
       data_disconnect
       disconnect

--- a/modules/auxiliary/scanner/ftp/pcman_ftp_traversal.rb
+++ b/modules/auxiliary/scanner/ftp/pcman_ftp_traversal.rb
@@ -100,10 +100,10 @@ class MetasploitModule < Msf::Auxiliary
 
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout => e
       vprint_error(e.message)
-      elog("#{e.class} #{e.message} #{e.backtrace * "\n"}")
+      elog(e)
     rescue ::Timeout::Error, ::Errno::EPIPE => e
       vprint_error(e.message)
-      elog("#{e.class} #{e.message} #{e.backtrace * "\n"}")
+      elog(e)
     ensure
       data_disconnect
       disconnect

--- a/modules/auxiliary/scanner/http/drupal_views_user_enum.rb
+++ b/modules/auxiliary/scanner/http/drupal_views_user_enum.rb
@@ -109,7 +109,7 @@ class MetasploitModule < Msf::Auxiliary
         begin
           user_list = JSON.parse(res.body)
         rescue JSON::ParserError => e
-          elog("#{e.class} #{e.message}\n#{e.backtrace * "\n"}")
+          elog('Exception encountered parsing JSON response', error: e)
           return []
         end
         if user_list.empty?

--- a/modules/auxiliary/scanner/http/elasticsearch_traversal.rb
+++ b/modules/auxiliary/scanner/http/elasticsearch_traversal.rb
@@ -106,7 +106,7 @@ class MetasploitModule < Msf::Auxiliary
     begin
       data_hash = JSON.parse(contents)
     rescue JSON::ParserError => e
-      elog("#{e.class} #{e.message}\n#{e.backtrace * "\n"}")
+      elog(e)
       return
     end
 

--- a/modules/auxiliary/scanner/http/wp_nextgen_galley_file_read.rb
+++ b/modules/auxiliary/scanner/http/wp_nextgen_galley_file_read.rb
@@ -80,7 +80,7 @@ class MetasploitModule < Msf::Auxiliary
     begin
       j = JSON.parse(res.body)
     rescue JSON::ParserError => e
-      elog("#{e.class} #{e.message}\n#{e.backtrace * "\n"}")
+      elog(e)
       return []
     end
 

--- a/modules/auxiliary/scanner/rdp/cve_2019_0708_bluekeep.rb
+++ b/modules/auxiliary/scanner/rdp/cve_2019_0708_bluekeep.rb
@@ -100,7 +100,7 @@ class MetasploitModule < Msf::Auxiliary
       bt = e.backtrace.join("\n")
       vprint_error("Unexpected error: #{e.message}")
       vprint_line(bt)
-      elog("#{e.message}\n#{bt}")
+      elog(e)
     rescue RdpCommunicationError
       vprint_error('Error communicating RDP protocol.')
       status = Exploit::CheckCode::Unknown
@@ -110,7 +110,7 @@ class MetasploitModule < Msf::Auxiliary
       bt = e.backtrace.join("\n")
       vprint_error("Unexpected error: #{e.message}")
       vprint_line(bt)
-      elog("#{e.message}\n#{bt}")
+      elog(e)
     ensure
       rdp_disconnect
     end

--- a/modules/auxiliary/scanner/rdp/ms12_020_check.rb
+++ b/modules/auxiliary/scanner/rdp/ms12_020_check.rb
@@ -176,7 +176,7 @@ class MetasploitModule < Msf::Auxiliary
       bt = e.backtrace.join("\n")
       vprint_error("Unexpected error: #{e.message}")
       vprint_line(bt)
-      elog("#{e.message}\n#{bt}")
+      elog(e)
     ensure
       disconnect
     end

--- a/modules/auxiliary/scanner/smb/smb_uninit_cred.rb
+++ b/modules/auxiliary/scanner/smb/smb_uninit_cred.rb
@@ -79,7 +79,7 @@ class MetasploitModule < Msf::Auxiliary
       dcerpc_bind(handle)
     rescue ::Rex::Proto::SMB::Exceptions::LoginError,
       ::Rex::Proto::SMB::Exceptions::ErrorCode => e
-      elog("#{e.message}\n#{e.backtrace * "\n"}")
+      elog(e)
       return false
     rescue Errno::ECONNRESET,
         ::Rex::Proto::SMB::Exceptions::InvalidType,
@@ -87,10 +87,10 @@ class MetasploitModule < Msf::Auxiliary
         ::Rex::Proto::SMB::Exceptions::InvalidCommand,
         ::Rex::Proto::SMB::Exceptions::InvalidWordCount,
         ::Rex::Proto::SMB::Exceptions::NoReply => e
-      elog("#{e.message}\n#{e.backtrace * "\n"}")
+      elog(e)
       return false
     rescue ::Exception => e
-      elog("#{e.message}\n#{e.backtrace * "\n"}")
+      elog(e)
       return false
     end
 
@@ -117,14 +117,14 @@ class MetasploitModule < Msf::Auxiliary
     begin
       dcerpc.call(0x06, stub)
     rescue ::Rex::Proto::SMB::Exceptions::ErrorCode => e
-      elog("#{e.message}\n#{e.backtrace * "\n"}")
+      elog(e)
     rescue Errno::ECONNRESET,
         ::Rex::Proto::SMB::Exceptions::InvalidType,
         ::Rex::Proto::SMB::Exceptions::ReadPacket,
         ::Rex::Proto::SMB::Exceptions::InvalidCommand,
         ::Rex::Proto::SMB::Exceptions::InvalidWordCount,
         ::Rex::Proto::SMB::Exceptions::NoReply => e
-      elog("#{e.message}\n#{e.backtrace * "\n"}")
+      elog(e)
     rescue ::Exception => e
       if e.to_s =~ /execution expired/i
         # So what happens here is that when you trigger the buggy code path, you hit this:

--- a/modules/auxiliary/scanner/snmp/cnpilot_r_snmp_loot.rb
+++ b/modules/auxiliary/scanner/snmp/cnpilot_r_snmp_loot.rb
@@ -135,8 +135,7 @@ class MetasploitModule < Msf::Auxiliary
       raise $!
     rescue ::Exception => e
       print_error("Unknown error: #{e.class} #{e}")
-      elog("Unknown error: #{e.class} #{e}")
-      elog("Call stack:\n#{e.backtrace.join "\n"}")
+      elog(e)
     ensure
       disconnect_snmp
     end

--- a/modules/auxiliary/scanner/snmp/epmp1000_snmp_loot.rb
+++ b/modules/auxiliary/scanner/snmp/epmp1000_snmp_loot.rb
@@ -159,8 +159,7 @@ class MetasploitModule < Msf::Auxiliary
       raise $!
     rescue ::Exception => e
       print_error("Unknown error: #{e.class} #{e}")
-      elog("Unknown error: #{e.class} #{e}")
-      elog("Call stack:\n#{e.backtrace.join "\n"}")
+      elog(e)
     ensure
       disconnect_snmp
     end

--- a/modules/auxiliary/scanner/snmp/sbg6580_enum.rb
+++ b/modules/auxiliary/scanner/snmp/sbg6580_enum.rb
@@ -217,8 +217,7 @@ class MetasploitModule < Msf::Auxiliary
       raise $!
     rescue ::Exception => e
       print_error("Unknown error: #{e.class} #{e}")
-      elog("Unknown error: #{e.class} #{e}")
-      elog("Call stack:\n#{e.backtrace.join "\n"}")
+      elog(e)
     ensure
       disconnect_snmp
     end

--- a/modules/auxiliary/scanner/snmp/snmp_enum.rb
+++ b/modules/auxiliary/scanner/snmp/snmp_enum.rb
@@ -869,8 +869,7 @@ class MetasploitModule < Msf::Auxiliary
       raise $!
     rescue ::Exception => e
       print_error("Unknown error: #{e.class} #{e}")
-      elog("Unknown error: #{e.class} #{e}")
-      elog("Call stack:\n#{e.backtrace.join "\n"}")
+      elog(e)
     ensure
       disconnect_snmp
     end

--- a/modules/auxiliary/scanner/telnet/telnet_encrypt_overflow.rb
+++ b/modules/auxiliary/scanner/telnet/telnet_encrypt_overflow.rb
@@ -126,13 +126,13 @@ class MetasploitModule < Msf::Auxiliary
       end
     rescue ::Rex::ConnectionError, ::Errno::ECONNRESET => e
       print_error("A network issue has occurred: #{e.message}")
-      elog("#{e.class} #{e.message}\n#{e.backtrace * "\n"}")
+      elog('A network issue has occurred', error: e)
     rescue Timeout::Error => e
       print_error("#{target_host}:#{rport} Timed out after #{to} seconds")
-      elog("#{e.class} #{e.message}\n#{e.backtrace * "\n"}")
+      elog("#{target_host}:#{rport} Timed out after #{to} seconds", error: e)
     rescue ::Exception => e
       print_error("#{target_host}:#{rport} Error: #{e} #{e.backtrace}")
-      elog("#{e.class} #{e.message}\n#{e.backtrace * "\n"}")
+      elog("#{target_host}:#{rport} Error: #{e} #{e.backtrace}", error: e)
     ensure
       disconnect
     end

--- a/modules/auxiliary/scanner/telnet/telnet_version.rb
+++ b/modules/auxiliary/scanner/telnet/telnet_version.rb
@@ -38,13 +38,13 @@ class MetasploitModule < Msf::Auxiliary
       end
     rescue ::Rex::ConnectionError, ::Errno::ECONNRESET => e
       print_error("A network issue has occurred: #{e.message}")
-      elog("#{e.class} #{e.message}\n#{e.backtrace * "\n"}")
+      elog("A network issue has occurred", error: e)
     rescue Timeout::Error => e
       print_error("#{target_host}:#{rport}, Server timed out after #{to} seconds. Skipping.")
-      elog("#{e.class} #{e.message}\n#{e.backtrace * "\n"}")
+      elog("#{target_host}:#{rport}, Server timed out after #{to} seconds. Skipping.", error: e)
     rescue ::Exception => e
       print_error("#{e} #{e.backtrace}")
-      elog("#{e.class} #{e.message}\n#{e.backtrace * "\n"}")
+      elog(e)
     end
   end
 end

--- a/modules/auxiliary/server/browser_autopwn.rb
+++ b/modules/auxiliary/server/browser_autopwn.rb
@@ -984,7 +984,7 @@ class MetasploitModule < Msf::Auxiliary
           rescue ::Interrupt
             raise $!
           rescue ::Exception => e
-            elog("Reporting failed: #{e.class} : #{e.message} #{e.backtrace}")
+            elog('Reporting failed', error: e)
           end
         end
       end

--- a/modules/exploits/linux/local/glibc_origin_expansion_priv_esc.rb
+++ b/modules/exploits/linux/local/glibc_origin_expansion_priv_esc.rb
@@ -205,10 +205,9 @@ class MetasploitModule < Msf::Exploit::Local
 
     begin
       so = Metasm::ELF.compile_c(cpu, so_stub).encode_string(:lib)
-    rescue
+    rescue => e
       print_error "Metasm encoding failed: #{$ERROR_INFO}"
-      elog "Metasm encoding failed: #{$ERROR_INFO.class} : #{$ERROR_INFO}"
-      elog "Call stack:\n#{$ERROR_INFO.backtrace.join "\n"}"
+      elog('Metasm encoding failed', error: e)
       fail_with Failure::Unknown, 'Metasm encoding failed'
     end
 

--- a/modules/exploits/linux/local/pkexec.rb
+++ b/modules/exploits/linux/local/pkexec.rb
@@ -358,10 +358,9 @@ int main(int argc,char *argv[], char ** envp)
 
     begin
       elf = Metasm::ELF.compile_c(cpu, main).encode_string
-    rescue
+    rescue => e
       print_error "Metasm Encoding failed: #{$ERROR_INFO}"
-      elog "Metasm Encoding failed: #{$ERROR_INFO.class} : #{$ERROR_INFO}"
-      elog "Call stack:\n#{$ERROR_INFO.backtrace.join("\n")}"
+      elog('Metasm Encoding failed', error: e)
       return
     end
 

--- a/modules/exploits/linux/local/udev_netlink.rb
+++ b/modules/exploits/linux/local/udev_netlink.rb
@@ -216,10 +216,9 @@ int main() {
 
     begin
       elf = sc.encode_string
-    rescue
-      print_error "Metasm Encoding failed: #{$!}"
-      elog "Metasm Encoding failed: #{$!.class} : #{$!}"
-      elog "Call stack:\n#{$!.backtrace.join("\n")}"
+    rescue => e
+      print_error 'Metasm Encoding failed'
+      elog('Metasm Encoding failed', error: e)
       return
     end
 

--- a/modules/exploits/linux/ssh/mercurial_ssh_exec.rb
+++ b/modules/exploits/linux/ssh/mercurial_ssh_exec.rb
@@ -126,7 +126,7 @@ class MetasploitModule < Msf::Exploit::Remote
       begin
         ssh.loop unless session_created?
       rescue Errno::EBADF => e
-        elog(e.message)
+        elog(e)
       end
     end
   end

--- a/modules/exploits/linux/ssh/solarwinds_lem_exec.rb
+++ b/modules/exploits/linux/ssh/solarwinds_lem_exec.rb
@@ -162,7 +162,7 @@ class MetasploitModule < Msf::Exploit::Remote
       begin
         ssh.loop unless session_created?
       rescue Errno::EBADF => e
-        elog(e.message)
+        elog(e)
       end
     end
   end

--- a/modules/exploits/multi/misc/legend_bot_exec.rb
+++ b/modules/exploits/multi/misc/legend_bot_exec.rb
@@ -101,7 +101,7 @@ class MetasploitModule < Msf::Exploit::Remote
         read_data = sock.get_once(-1, 1)
       end
     rescue ::EOFError, ::Timeout::Error, ::Errno::ETIMEDOUT => e
-      elog("#{e.class} #{e.message}\n#{e.backtrace * "\n"}")
+      elog(e)
     end
 
     data

--- a/modules/exploits/multi/misc/w3tw0rk_exec.rb
+++ b/modules/exploits/multi/misc/w3tw0rk_exec.rb
@@ -91,7 +91,7 @@ class MetasploitModule < Msf::Exploit::Remote
         read_data = sock.get_once(-1, 1)
       end
     rescue ::EOFError, ::Timeout::Error, ::Errno::ETIMEDOUT => e
-      elog("#{e.class} #{e.message}\n#{e.backtrace * "\n"}")
+      elog(e)
     end
 
     data

--- a/modules/exploits/multi/misc/xdh_x_exec.rb
+++ b/modules/exploits/multi/misc/xdh_x_exec.rb
@@ -103,7 +103,7 @@ class MetasploitModule < Msf::Exploit::Remote
         read_data = sock.get_once(-1, 1)
       end
     rescue ::EOFError, ::Timeout::Error, ::Errno::ETIMEDOUT => e
-      elog("#{e.class} #{e.message}\n#{e.backtrace * "\n"}")
+      elog(e)
     end
 
     data

--- a/modules/exploits/windows/fileformat/adobe_pdf_embedded_exe.rb
+++ b/modules/exploits/windows/fileformat/adobe_pdf_embedded_exe.rb
@@ -88,15 +88,17 @@ class MetasploitModule < Msf::Exploit::Remote
       # Lazy fix:
       # Similar to the problem with NoMethod -- something we need is missing in the PDF.
       # But really what happens is the module trusts the PDF too much.
-      print_error("Sorry, I'm picky. Incompatible PDF structure: #{e.message}. Please try a different PDF template.")
-      elog("Call stack:\n#{$!.backtrace.join("\n")}")
+
+      # Don't be sorry, you're a beautiful human we all appreciate greatly
+      print_error("Sorry, I'm picky. Incompatible PDF structure. Please try a different PDF template.")
+      elog('Sorry, I\'m picky. Incompatible PDF structure', error: e)
     rescue NoMethodError => e
       # Lazy fix:
       # When a NoMethod error is hit, that means that something in the PDF is actually missing,
       # so we can't parse it. If we can't parse it properly, then we can't garantee the exploit
       # will work, either.  So we might as well just reject it.
       print_error("Sorry, I'm picky. Incompatible PDF structure, please try a different PDF template.")
-      elog("Call stack:\n#{$!.backtrace.join("\n")}")
+      elog('Sorry, I\'m picky. Incompatible PDF structure', error: e)
     end
   end
 

--- a/modules/exploits/windows/http/geutebrueck_gcore_x64_rce_bo.rb
+++ b/modules/exploits/windows/http/geutebrueck_gcore_x64_rce_bo.rb
@@ -251,7 +251,7 @@ class MetasploitModule < Msf::Exploit::Remote
         print_status('Exploit sent!')
         buf = sock.get_once || ''
       rescue Rex::AddressInUse, ::Errno::ETIMEDOUT, Rex::HostUnreachable, Rex::ConnectionTimeout, Rex::ConnectionRefused, ::Timeout::Error, ::EOFError => e
-        elog("#{e.class} #{e.message}\n#{e.backtrace * "\n"}\n#{e.fail_with}")
+        elog('Exception encountered in \'exploit\'', error: e)
       ensure
         print_status('Closing socket.')
         disconnect

--- a/modules/exploits/windows/local/alpc_taskscheduler.rb
+++ b/modules/exploits/windows/local/alpc_taskscheduler.rb
@@ -105,7 +105,7 @@ class MetasploitModule < Msf::Exploit::Local
     sysinfo['Computer']
     true
   rescue Rex::Post::Meterpreter::RequestError, Rex::TimeoutError => e
-    elog("#{e.class} #{e.message}\n#{e.backtrace * "\n"}")
+    elog(e)
     false
   end
 
@@ -142,7 +142,7 @@ class MetasploitModule < Msf::Exploit::Local
     inject_magic(process, payload_dll)
     print_good('Exploit finished, wait for (hopefully privileged) payload execution to complete.')
   rescue Rex::Post::Meterpreter::RequestError => e
-    elog("#{e.class} #{e.message}\n#{e.backtrace * "\n"}")
+    elog(e)
     print_error(e.message)
   end
 end

--- a/modules/exploits/windows/local/comahawk.rb
+++ b/modules/exploits/windows/local/comahawk.rb
@@ -107,7 +107,7 @@ class MetasploitModule < Msf::Exploit::Local
     begin
       cmd_exec('cmd.exe', "/c #{exploit_path} #{payload_path}", 60)
     rescue Rex::TimeoutError => e
-      elog("#{e.class} #{e.message}\n#{e.backtrace * "\n"}")
+      elog('Caught timeout.  Exploit may be taking longer or it may have failed.', error: e)
       print_error("Caught timeout.  Exploit may be taking longer or it may have failed.")
     end
     vprint_status("Cleaning up #{exploit_path}")
@@ -118,7 +118,7 @@ class MetasploitModule < Msf::Exploit::Local
     begin
       print_status("Attempting to PrivEsc on #{sysinfo['Computer']} via session ID: #{datastore['SESSION']}")
     rescue Rex::Post::Meterpreter::RequestError => e
-      elog("#{e.class} #{e.message}\n#{e.backtrace * "\n"}")
+      elog('Could not connect to session', error: e)
       raise Msf::Exploit::Failed, 'Could not connect to session'
     end
   end
@@ -142,7 +142,7 @@ class MetasploitModule < Msf::Exploit::Local
       file_rm(path)
       print_status("Deleted #{path}")
     rescue Rex::Post::Meterpreter::RequestError => e
-      elog("#{e.class} #{e.message}\n#{e.backtrace * "\n"}")
+      elog(e)
       print_error("Unable to delete #{path}")
     end
   end

--- a/modules/exploits/windows/local/cve_2018_8453_win32k_priv_esc.rb
+++ b/modules/exploits/windows/local/cve_2018_8453_win32k_priv_esc.rb
@@ -76,7 +76,7 @@ class MetasploitModule < Msf::Exploit::Local
     vprint_good("#{fname} written")
     file_loc
   rescue Rex::Post::Meterpreter::RequestError => e
-    elog("#{e.class} #{e.message}\n#{e.backtrace * "\n"}")
+    elog('Unable to write file to target', error: e)
     fail_with(Failure::Unknown, "Writing #{fname} to disk was unsuccessful")
   end
 

--- a/modules/exploits/windows/local/cve_2020_0668_service_tracing.rb
+++ b/modules/exploits/windows/local/cve_2020_0668_service_tracing.rb
@@ -196,7 +196,7 @@ class MetasploitModule < Msf::Exploit::Local
       inject_magic(process)
       print_good('Exploit finished, wait for (hopefully privileged) payload execution to complete.')
     rescue Rex::Post::Meterpreter::RequestError => e
-      elog("#{e.class} #{e.message}\n#{e.backtrace * "\n"}")
+      elog(e)
       print_error(e.message)
     end
   end
@@ -312,7 +312,7 @@ class MetasploitModule < Msf::Exploit::Local
     begin
       print_status("Attempting to PrivEsc on #{sysinfo['Computer']} via session ID: #{datastore['SESSION']}")
     rescue Rex::Post::Meterpreter::RequestError => e
-      elog("#{e.class} #{e.message}\n#{e.backtrace * "\n"}")
+      elog(e)
       raise Msf::Exploit::Failed, 'Could not connect to session'
     end
   end
@@ -362,7 +362,7 @@ class MetasploitModule < Msf::Exploit::Local
       file_rm(path)
       print_status("Deleted #{path}")
     rescue Rex::Post::Meterpreter::RequestError => e
-      elog("#{e.class} #{e.message}\n#{e.backtrace * "\n"}")
+      elog(e)
       print_error("Unable to delete #{path}")
     end
   end

--- a/modules/exploits/windows/local/mov_ss.rb
+++ b/modules/exploits/windows/local/mov_ss.rb
@@ -124,7 +124,7 @@ class MetasploitModule < Msf::Exploit::Local
     begin
       print_status("Attempting to PrivEsc on #{sysinfo['Computer']} via session ID: #{datastore['SESSION']}")
     rescue Rex::Post::Meterpreter::RequestError => e
-      elog("#{e.class} #{e.message}\n#{e.backtrace * "\n"}")
+      elog(e)
       raise Msf::Exploit::Failed, 'Could not connect to session'
     end
   end
@@ -151,7 +151,7 @@ class MetasploitModule < Msf::Exploit::Local
         file_rm(path)
         print_status("Deleted #{path}")
       rescue Rex::Post::Meterpreter::RequestError => e
-        elog("#{e.class} #{e.message}\n#{e.backtrace * "\n"}")
+        elog(e)
         print_error("Unable to delete #{path}")
       end
     end
@@ -193,7 +193,7 @@ class MetasploitModule < Msf::Exploit::Local
       inject_magic(process)
       print_good('Exploit finished, wait for (hopefully privileged) payload execution to complete.')
     rescue Rex::Post::Meterpreter::RequestError => e
-      elog("#{e.class} #{e.message}\n#{e.backtrace * "\n"}")
+      elog(e)
       print_error(e.message)
     end
   end
@@ -208,7 +208,7 @@ class MetasploitModule < Msf::Exploit::Local
       execute_exploit
       print_good('Exploit finished, wait for (hopefully privileged) payload execution to complete.')
     rescue Rex::Post::Meterpreter::RequestError => e
-      elog("#{e.class} #{e.message}\n#{e.backtrace * "\n"}")
+      elog(e)
       print_error(e.message)
       ensure_clean_exploit_destination
       ensure_clean_payload_destination

--- a/modules/exploits/windows/local/ms18_8120_win32k_privesc.rb
+++ b/modules/exploits/windows/local/ms18_8120_win32k_privesc.rb
@@ -88,7 +88,7 @@ class MetasploitModule < Msf::Exploit::Local
     vprint_good("#{fname} written")
     file_loc
   rescue Rex::Post::Meterpreter::RequestError => e
-    elog("#{e.class} #{e.message}\n#{e.backtrace * "\n"}")
+    elog(e)
     fail_with(Failure::Unknown, "Writing #{fname} to disk was unsuccessful")
   end
 

--- a/modules/exploits/windows/local/ntapphelpcachecontrol.rb
+++ b/modules/exploits/windows/local/ntapphelpcachecontrol.rb
@@ -113,7 +113,7 @@ class MetasploitModule < Msf::Exploit::Local
     rescue Rex::Post::Meterpreter::RequestError
       process = client.sys.process.open
     rescue ::Exception => e
-      elog("#{e.message}\nCall stack:\n#{e.backtrace.join("\n")}")
+      elog(e)
     end
     process
   end

--- a/modules/exploits/windows/local/persistence_image_exec_options.rb
+++ b/modules/exploits/windows/local/persistence_image_exec_options.rb
@@ -69,7 +69,7 @@ class MetasploitModule < Msf::Exploit::Local
     begin
       print_status("Attempting Persistence on #{sysinfo['Computer']} via session ID: #{datastore['SESSION']}")
     rescue Rex::Post::Meterpreter::RequestError => e
-      elog("#{e.class} #{e.message}\n#{e.backtrace * "\n"}")
+      elog(e)
       raise Msf::Exploit::Failed, 'Could not connect to session'
     end
   end

--- a/modules/exploits/windows/local/ps_wmi_exec.rb
+++ b/modules/exploits/windows/local/ps_wmi_exec.rb
@@ -133,7 +133,7 @@ class MetasploitModule < Msf::Exploit::Local
       psh_output = datastore["RHOSTS"] ? psh_exec(script) : psh_exec(script,true,false)
       print_good(psh_output)
     rescue Rex::TimeoutError => e
-      elog("#{e.class} #{e.message}\n#{e.backtrace * "\n"}")
+      elog(e)
     end
 
     vprint_good('PSH WMI exec is complete.')

--- a/modules/exploits/windows/misc/hp_dataprotector_encrypted_comms.rb
+++ b/modules/exploits/windows/misc/hp_dataprotector_encrypted_comms.rb
@@ -114,7 +114,7 @@ class MetasploitModule < Msf::Exploit::Remote
     begin
       buf = sock.get_once
     rescue ::EOFError => e
-      elog("#{e.class} #{e.message}\n#{e.backtrace * "\n"}")
+      elog(e)
     end
 
     print_status("Establishing encrypted channel")

--- a/modules/post/multi/manage/zip.rb
+++ b/modules/post/multi/manage/zip.rb
@@ -70,7 +70,7 @@ class MetasploitModule < Msf::Post
     rescue Rex::Post::Meterpreter::RequestError => e
       # It could raise an exception even when the token is successfully stolen,
       # so we will just log the exception and move on.
-      elog("#{e.class} #{e.message}\n#{e.backtrace * "\n"}")
+      elog(e)
     end
 
     @token_stolen = true

--- a/modules/post/multi/recon/local_exploit_suggester.rb
+++ b/modules/post/multi/recon/local_exploit_suggester.rb
@@ -54,7 +54,7 @@ class MetasploitModule < Msf::Post
     module_platforms.include? platform_obj
   rescue ArgumentError => e
     # When not found, find_platform raises an ArgumentError
-    elog "#{e.class} #{e.message}\n#{e.backtrace * "\n"}"
+    elog('Could not find a platform', error: e)
     return false
   end
 
@@ -144,7 +144,7 @@ class MetasploitModule < Msf::Post
         end
       rescue Rex::Post::Meterpreter::RequestError => e
         # Creates a log record in framework.log
-        elog "#{e.class} #{e.message}\n#{e.backtrace * "\n"}"
+        elog("#{m.shortname} failed to run", error: e)
         vprint_error "#{e.class} #{m.shortname} failed to run: #{e.message}"
       end
     end

--- a/modules/post/windows/escalate/unmarshal_cmd_exec.rb
+++ b/modules/post/windows/escalate/unmarshal_cmd_exec.rb
@@ -76,7 +76,7 @@ class MetasploitModule < Msf::Post
     begin
       print_status("Attempting to Run on #{sysinfo['Computer']} via session ID: #{datastore['SESSION']}")
     rescue Rex::Post::Meterpreter::RequestError => e
-      elog("#{e.class} #{e.message}\n#{e.backtrace * "\n"}")
+      elog(e)
       raise Msf::Exploit::Failed, 'Could not connect to session'
     end
   end
@@ -103,7 +103,7 @@ class MetasploitModule < Msf::Post
         file_rm(path)
         print_status("Deleted #{path}")
       rescue Rex::Post::Meterpreter::RequestError => e
-        elog("#{e.class} #{e.message}\n#{e.backtrace * "\n"}")
+        elog(e)
         print_error("Unable to delete #{path}")
       end
     end
@@ -157,7 +157,7 @@ class MetasploitModule < Msf::Post
       ensure_clean_destination(exploit_path)
       ensure_clean_destination(script_path)
     rescue Rex::Post::Meterpreter::RequestError => e
-      elog("#{e.class} #{e.message}\n#{e.backtrace * "\n"}")
+      elog('Command failed, cleaning up', error: e)
       print_good('Command failed, cleaning up')
       print_error(e.message)
       ensure_clean_destination(exploit_path)

--- a/modules/post/windows/gather/credentials/heidisql.rb
+++ b/modules/post/windows/gather/credentials/heidisql.rb
@@ -153,7 +153,7 @@ class MetasploitModule < Msf::Post
           end
         end
       rescue ::Rex::Post::Meterpreter::RequestError => e
-        elog("#{e.class} #{e.message}\n#{e.backtrace * "\n"}")
+        elog(e)
         print_error("Cannot Access User SID: #{hive['HKU']} : #{e.message}")
       end
     end

--- a/modules/post/windows/gather/credentials/smartermail.rb
+++ b/modules/post/windows/gather/credentials/smartermail.rb
@@ -55,7 +55,7 @@ class MetasploitModule < Msf::Post
     begin
       port = JSON.parse(data)['BoundPort']
     rescue JSON::ParserError => e
-      elog("#{e.class} - Unable to parse BoundPort (#{e.message}) #{e.backtrace * "\n"}")
+      elog('Unable to parse BoundPort', error: e)
       return nil
     end
 

--- a/plugins/msfd.rb
+++ b/plugins/msfd.rb
@@ -128,8 +128,8 @@ class Plugin::Msfd < Msf::Plugin
             'LocalOutput' => Rex::Ui::Text::Output::Socket.new(cli),
             'AllowCommandPassthru' => false,
             'DisableBanner' => opts['DisableBanner'] ? true : false).run
-        rescue
-          elog("Msfd: Client error: #{$!}\n\n#{$@.join("\n")}", 'core')
+        rescue => e
+          elog('Msfd client error', error: e)
         ensure
           msg = "Msfd: Closing client connection with #{cli.peerhost}"
           ilog(msg, 'core')
@@ -162,4 +162,3 @@ protected
 end
 
 end
-

--- a/tools/exploit/egghunter.rb
+++ b/tools/exploit/egghunter.rb
@@ -154,7 +154,7 @@ if __FILE__ == $PROGRAM_NAME
   begin
     driver.run
   rescue ::Exception => e
-    elog("#{e.class}: #{e.message}\n#{e.backtrace * "\n"}")
+    elog(e)
     $stderr.puts "[x] #{e.class}: #{e.message}"
     $stderr.puts "[*] If necessary, please refer to framework.log for more details."
   end

--- a/tools/payloads/ysoserial/dot_net.rb
+++ b/tools/payloads/ysoserial/dot_net.rb
@@ -125,7 +125,7 @@ if __FILE__ == $PROGRAM_NAME
   begin
     driver.run
   rescue ::Exception => e
-    elog("#{e.class}: #{e.message}\n#{e.backtrace * "\n"}")
+    elog(e)
     $stderr.puts "[x] #{e.class}: #{e.message}"
     $stderr.puts "[*] If necessary, please refer to framework.log for more details."
   end


### PR DESCRIPTION
**Important changes are in `logging/log_dispatcher.rb`, everything else is just cleanup.**

This PR attempts to standardise `elog` usage by restricting it's API to three variables; a message, a source, and an `Exception`.

- `msg` is simple string. If this is the only variable passed to `elog`, no additional parsing is performed.
- `src` dictates the LogSource. This is most commonly `core` but can also be `hdwbridge` and `Meterpreter`
- `error` is the exception that caused the error, if any. The `.class` & `.message` values of an exception are always extracted and added to the log message. If the global log level is >= 1, the the Exception `.backtrace` is also added.


Standardizing error logging will allow us to send error logs to `framework.log` and improve functionality of the `debug` command https://github.com/rapid7/metasploit-framework/pull/13430.

Happy Friday! One of the files I cleaned up has an Easter Egg in it, first one to find it gets a prize.


![method_vars_simp](https://user-images.githubusercontent.com/54621924/84527523-fe23ec00-acd5-11ea-98c2-734ffd4f99f0.gif)
![method_vars_blind_simp](https://user-images.githubusercontent.com/54621924/84527535-02500980-acd6-11ea-95d1-88f45cf79cb6.gif)
