### PR TITLE
post/windows/gather/checkvm: cleanup, increase efficiency, fix style

### DIFF
--- a/modules/post/windows/gather/checkvm.rb
+++ b/modules/post/windows/gather/checkvm.rb
@@ -9,349 +9,215 @@ class MetasploitModule < Msf::Post
   include Msf::Post::Windows::Registry
   include Msf::Auxiliary::Report
 
-  def initialize(info={})
-    super( update_info( info,
-      'Name'          => 'Windows Gather Virtual Environment Detection',
-      'Description'   => %q{
-        This module attempts to determine whether the system is running
-        inside of a virtual environment and if so, which one. This
-        module supports detection of Hyper-V, VMWare, Virtual PC,
-        VirtualBox, Xen, and QEMU.
-      },
-      'License'       => MSF_LICENSE,
-      'Author'        => [
-        'Carlos Perez <carlos_perez[at]darkoperator.com>',
-        'Aaron Soto <aaron_soto[at]rapid7.com>'
-      ],
-      'Platform'      => [ 'win' ],
-      'SessionTypes'  => [ 'meterpreter' ]
-    ))
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Windows Gather Virtual Environment Detection',
+        'Description' => %q{
+          This module attempts to determine whether the system is running
+          inside of a virtual environment and if so, which one. This
+          module supports detection of Hyper-V, VMWare, Virtual PC,
+          VirtualBox, Xen, and QEMU.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Carlos Perez <carlos_perez[at]darkoperator.com>',
+          'Aaron Soto <aaron_soto[at]rapid7.com>'
+        ],
+        'Platform' => [ 'win' ],
+        'SessionTypes' => [ 'meterpreter' ]
+      )
+    )
   end
 
-  # Method for detecting if it is a Hyper-V VM
-  def hypervchk(session)
-    vm = false
-
-    physicalHost = registry_getvaldata('HKLM\SOFTWARE\Microsoft\Virtual Machine\Guest\Parameters','PhysicalHostNameFullyQualified')
-    if physicalHost
-      vm=true
+  def hyperv?
+    physical_host = registry_getvaldata('HKLM\SOFTWARE\Microsoft\Virtual Machine\Guest\Parameters', 'PhysicalHostNameFullyQualified')
+    if physical_host
       report_note(
-        :host   => session,
-        :type   => 'host.physicalHost',
-        :data   => { :physicalHost => physicalHost },
-        :update => :unique_data
-        )
+        host: session,
+        type: 'host.physicalHost',
+        data: { physicalHost: physical_host },
+        update: :unique_data
+      )
+      print_good("This is a Hyper-V Virtual Machine running on physical host #{physical_host}")
+      return true
     end
 
-    if not vm
-      sfmsvals = registry_enumkeys('HKLM\SOFTWARE\Microsoft')
-      if sfmsvals and sfmsvals.include?("Hyper-V")
-        vm = true
-      elsif sfmsvals and sfmsvals.include?("VirtualMachine")
-        vm = true
-      elsif registry_getvaldata('HKLM\HARDWARE\DESCRIPTION\System','SystemBiosVersion') =~ /vrtual/i
-        vm = true
-      end
+    sfmsvals = registry_enumkeys('HKLM\SOFTWARE\Microsoft')
+    if sfmsvals
+      return true if sfmsvals.include?('Hyper-V')
+      return true if sfmsvals.include?('VirtualMachine')
     end
 
-    if not vm
-      srvvals = registry_enumkeys('HKLM\HARDWARE\ACPI\FADT')
-      if srvvals and srvvals.include?("VRTUAL")
-        vm = true
-      else
-        srvvals = registry_enumkeys('HKLM\HARDWARE\ACPI\RSDT')
-        if srvvals and srvvals.include?("VRTUAL")
-          vm = true
-        end
-      end
-    end
+    return true if registry_getvaldata('HKLM\HARDWARE\DESCRIPTION\System', 'SystemBiosVersion') =~ /vrtual/i
 
-    if not vm
-      srvvals = registry_enumkeys('HKLM\SYSTEM\ControlSet001\Services')
-      if srvvals and srvvals.include?("vmicexchange")
-        vm = true
-      else
-        key_path = 'HKLM\HARDWARE\DESCRIPTION\System'
-        systemBiosVersion = registry_getvaldata(key_path,'SystemBiosVersion')
-        if systemBiosVersion.unpack("s<*").reduce('', :<<).include? "Hyper-V"
-          vm = true
-        end
-      end
-    end
+    srvvals = registry_enumkeys('HKLM\HARDWARE\ACPI\FADT')
+    return true if srvvals && srvvals.include?('VRTUAL')
 
-    if not vm
-      key_path = 'HKLM\HARDWARE\DEVICEMAP\Scsi\Scsi Port 0\Scsi Bus 0\Target Id 0\Logical Unit Id 0'
-      if registry_getvaldata(key_path,'Identifier') =~ /Msft    Virtual Disk    1.0/i
-        vm = true
-      end
-    end
+    srvvals = registry_enumkeys('HKLM\HARDWARE\ACPI\RSDT')
+    return true if srvvals && srvvals.include?('VRTUAL')
 
-    if vm
-      report_note(
-        :host   => session,
-        :type   => 'host.hypervisor',
-        :data   => { :hypervisor => "MS Hyper-V" },
-        :update => :unique_data
-        )
-      if physicalHost
-        print_good("This is a Hyper-V Virtual Machine running on physical host #{physicalHost}")
-      else
-        print_good("This is a Hyper-V Virtual Machine")
-      end
-      return "MS Hyper-V"
-    end
+    return true if @services && @services.include?('vmicexchange')
+
+    key_path = 'HKLM\HARDWARE\DESCRIPTION\System'
+    system_bios_version = registry_getvaldata(key_path, 'SystemBiosVersion')
+    return true if system_bios_version && system_bios_version.unpack('s<*').reduce('', :<<).include?('Hyper-V')
+
+    key_path = 'HKLM\HARDWARE\DEVICEMAP\Scsi\Scsi Port 0\Scsi Bus 0\Target Id 0\Logical Unit Id 0'
+    return true if registry_getvaldata(key_path, 'Identifier') =~ /Msft    Virtual Disk    1.0/i
+
+    false
   end
 
-  # Method for checking if it is a VMware VM
-  def vmwarechk(session)
-    vm = false
-    srvvals = registry_enumkeys('HKLM\SYSTEM\ControlSet001\Services')
-    if srvvals and  srvvals.include?("vmdebug")
-      vm = true
-    elsif srvvals and srvvals.include?("vmmouse")
-      vm = true
-    elsif srvvals and srvvals.include?("VMTools")
-      vm = true
-    elsif srvvals and srvvals.include?("VMMEMCTL")
-      vm = true
+  def vmware?
+    if @services
+      return true if @services.include?('vmdebug')
+      return true if @services.include?('vmmouse')
+      return true if @services.include?('VMTools')
+      return true if @services.include?('VMMEMCTL')
     end
-    if not vm
-      if registry_getvaldata('HKLM\HARDWARE\DESCRIPTION\System\BIOS','SystemManufacturer') =~ /vmware/i
-        vm = true
-      end
-    end
-    if not vm
-      key_path = 'HKLM\HARDWARE\DEVICEMAP\Scsi\Scsi Port 0\Scsi Bus 0\Target Id 0\Logical Unit Id 0'
-      if registry_getvaldata(key_path,'Identifier') =~ /vmware/i
-        vm = true
-      end
-    end
-    if not vm
-      vmwareprocs = [
-        "vmwareuser.exe",
-        "vmwaretray.exe"
-      ]
-      session.sys.process.get_processes().each do |x|
-        vmwareprocs.each do |p|
-          if p == (x['name'].downcase)
-            vm = true
-          end
-        end
+
+    return true if registry_getvaldata('HKLM\HARDWARE\DESCRIPTION\System\BIOS', 'SystemManufacturer') =~ /vmware/i
+    return true if registry_getvaldata('HKLM\HARDWARE\DEVICEMAP\Scsi\Scsi Port 0\Scsi Bus 0\Target Id 0\Logical Unit Id 0', 'Identifier') =~ /vmware/i
+
+    vmwareprocs = [
+      'vmwareuser.exe',
+      'vmwaretray.exe'
+    ]
+    @processes.each do |x|
+      vmwareprocs.each do |p|
+        return true if p == x['name'].downcase
       end
     end
 
-    if vm
-      report_note(
-        :host   => session,
-        :type   => 'host.hypervisor',
-        :data   => { :hypervisor => "VMware" },
-        :update => :unique_data
-        )
-      print_good("This is a VMware Virtual Machine")
-      return "VMWare"
-    end
+    false
   end
 
-  # Method for checking if it is a Virtual PC VM
-  def checkvrtlpc(session)
-    vm = false
+  def virtualpc?
+    if @services
+      return true if @services.include?('vpc-s3')
+      return true if @services.include?('vpcuhub')
+      return true if @services.include?('msvmmouf')
+    end
+
     vpcprocs = [
-      "vmusrvc.exe",
-      "vmsrvc.exe"
+      'vmusrvc.exe',
+      'vmsrvc.exe'
     ]
-    session.sys.process.get_processes().each do |x|
+    @processes.each do |x|
       vpcprocs.each do |p|
-        if p == (x['name'].downcase)
-          vm = true
-        end
+        return true if p == x['name'].downcase
       end
     end
-    if not vm
-      srvvals = registry_enumkeys('HKLM\SYSTEM\ControlSet001\Services')
-      if srvvals and srvvals.include?("vpc-s3")
-        vm = true
-      elsif srvvals and srvvals.include?("vpcuhub")
-        vm = true
-      elsif srvvals and srvvals.include?("msvmmouf")
-        vm = true
-      end
-    end
-    if vm
-      report_note(
-        :host   => session,
-        :type   => 'host.hypervisor',
-        :data   => { :hypervisor => "VirtualPC" },
-        :update => :unique_data
-        )
-      print_good("This is a VirtualPC Virtual Machine")
-      return "VirtualPC"
-    end
+
+    false
   end
 
-  # Method for checking if it is a VirtualBox VM
-  def vboxchk(session)
-    vm = false
+  def virtualbox?
     vboxprocs = [
-      "vboxservice.exe",
-      "vboxtray.exe"
+      'vboxservice.exe',
+      'vboxtray.exe'
     ]
-    session.sys.process.get_processes().each do |x|
+    @processes.each do |x|
       vboxprocs.each do |p|
-        if p == (x['name'].downcase)
-          vm = true
-        end
+        return true if p == x['name'].downcase
       end
     end
-    if not vm
-      srvvals = registry_enumkeys('HKLM\HARDWARE\ACPI\DSDT')
-      if srvvals and srvvals.include?("VBOX__")
-        vm = true
-      end
+
+    srvvals = registry_enumkeys('HKLM\HARDWARE\ACPI\DSDT')
+    return true if srvvals && srvvals.include?('VBOX__')
+
+    srvvals = registry_enumkeys('HKLM\HARDWARE\ACPI\FADT')
+    return true if srvvals && srvvals.include?('VBOX__')
+
+    srvvals = registry_enumkeys('HKLM\HARDWARE\ACPI\RSDT')
+    return true if srvvals && srvvals.include?('VBOX__')
+
+    key_path = 'HKLM\HARDWARE\DEVICEMAP\Scsi\Scsi Port 0\Scsi Bus 0\Target Id 0\Logical Unit Id 0'
+    return true if registry_getvaldata(key_path, 'Identifier') =~ /vbox/i
+
+    return true if registry_getvaldata('HKLM\HARDWARE\DESCRIPTION\System', 'SystemBiosVersion') =~ /vbox/i
+
+    if @services
+      return true if @services.include?('VBoxMouse')
+      return true if @services.include?('VBoxGuest')
+      return true if @services.include?('VBoxService')
+      return true if @services.include?('VBoxSF')
     end
-    if not vm
-      srvvals = registry_enumkeys('HKLM\HARDWARE\ACPI\FADT')
-      if srvvals and srvvals.include?("VBOX__")
-        vm = true
-      end
-    end
-    if not vm
-      srvvals = registry_enumkeys('HKLM\HARDWARE\ACPI\RSDT')
-      if srvvals and srvvals.include?("VBOX__")
-        vm = true
-      end
-    end
-    if not vm
-      key_path = 'HKLM\HARDWARE\DEVICEMAP\Scsi\Scsi Port 0\Scsi Bus 0\Target Id 0\Logical Unit Id 0'
-      if registry_getvaldata(key_path,'Identifier') =~ /vbox/i
-        vm = true
-      end
-    end
-    if not vm
-      if registry_getvaldata('HKLM\HARDWARE\DESCRIPTION\System','SystemBiosVersion') =~ /vbox/i
-        vm = true
-      end
-    end
-    if not vm
-      srvvals = registry_enumkeys('HKLM\SYSTEM\ControlSet001\Services')
-      if srvvals and srvvals.include?("VBoxMouse")
-        vm = true
-      elsif srvvals and srvvals.include?("VBoxGuest")
-        vm = true
-      elsif srvvals and srvvals.include?("VBoxService")
-        vm = true
-      elsif srvvals and srvvals.include?("VBoxSF")
-        vm = true
-      end
-    end
-    if vm
-      report_note(
-        :host   => session,
-        :type   => 'host.hypervisor',
-        :data   => { :hypervisor => "VirtualBox" },
-        :update => :unique_data
-        )
-      print_good("This is a Sun VirtualBox Virtual Machine")
-      return "VirtualBox"
-    end
+
+    false
   end
 
-  # Method for checking if it is a Xen VM
-  def xenchk(session)
-    vm = false
+  def xen?
     xenprocs = [
-      "xenservice.exe"
+      'xenservice.exe'
     ]
-    session.sys.process.get_processes().each do |x|
+    @processes.each do |x|
       xenprocs.each do |p|
-        if p == (x['name'].downcase)
-          vm = true
-        end
+        return true if p == x['name'].downcase
       end
     end
-    if not vm
-      srvvals = registry_enumkeys('HKLM\HARDWARE\ACPI\DSDT')
-      if srvvals and srvvals.include?("Xen")
-        vm = true
-      end
+
+    srvvals = registry_enumkeys('HKLM\HARDWARE\ACPI\DSDT')
+    return true if srvvals && srvvals.include?('Xen')
+
+    srvvals = registry_enumkeys('HKLM\HARDWARE\ACPI\FADT')
+    return true if srvvals && srvvals.include?('Xen')
+
+    srvvals = registry_enumkeys('HKLM\HARDWARE\ACPI\RSDT')
+    return true if srvvals && srvvals.include?('Xen')
+
+    if @services
+      return true if @services.include?('xenevtchn')
+      return true if @services.include?('xennet')
+      return true if @services.include?('xennet6')
+      return true if @services.include?('xensvc')
+      return true if @services.include?('xenvdb')
     end
-    if not vm
-      srvvals = registry_enumkeys('HKLM\HARDWARE\ACPI\FADT')
-      if srvvals and srvvals.include?("Xen")
-        vm = true
-      end
-    end
-    if not vm
-      srvvals = registry_enumkeys('HKLM\HARDWARE\ACPI\RSDT')
-      if srvvals and srvvals.include?("Xen")
-        vm = true
-      end
-    end
-    if not vm
-      srvvals = registry_enumkeys('HKLM\SYSTEM\ControlSet001\Services')
-      if srvvals and srvvals.include?("xenevtchn")
-        vm = true
-      elsif srvvals and srvvals.include?("xennet")
-        vm = true
-      elsif srvvals and srvvals.include?("xennet6")
-        vm = true
-      elsif srvvals and srvvals.include?("xensvc")
-        vm = true
-      elsif srvvals and srvvals.include?("xenvdb")
-        vm = true
-      end
-    end
-    if vm
-      report_note(
-        :host   => session,
-        :type   => 'host.hypervisor',
-        :data   => { :hypervisor => "Xen" },
-        :update => :unique_data
-        )
-      print_good("This is a Xen Virtual Machine")
-      return "Xen"
-    end
+
+    false
   end
 
-  def qemuchk(session)
-    vm = false
-    if not vm
-      key_path = 'HKLM\HARDWARE\DEVICEMAP\Scsi\Scsi Port 0\Scsi Bus 0\Target Id 0\Logical Unit Id 0'
-      if registry_getvaldata(key_path,'Identifier') =~ /qemu/i
-        print_status("This is a QEMU/KVM Virtual Machine")
-        vm = true
-      end
-    end
-    if not vm
-      key_path = 'HKLM\HARDWARE\DESCRIPTION\System\CentralProcessor\0'
-      if registry_getvaldata(key_path,'ProcessorNameString') =~ /qemu/i
-        print_status("This is a QEMU/KVM Virtual Machine")
-        vm = true
-      end
-    end
+  def qemu?
+    key_path = 'HKLM\HARDWARE\DEVICEMAP\Scsi\Scsi Port 0\Scsi Bus 0\Target Id 0\Logical Unit Id 0'
+    return true if registry_getvaldata(key_path, 'Identifier') =~ /qemu/i
 
-    if vm
-      report_note(
-        :host   => session,
-        :type   => 'host.hypervisor',
-        :data   => { :hypervisor => "Qemu/KVM" },
-        :update => :unique_data
-        )
-      print_good("This is a Qemu/KVM Virtual Machine")
-      return "Qemu/KVM"
-    end
+    key_path = 'HKLM\HARDWARE\DESCRIPTION\System\CentralProcessor\0'
+    return true if registry_getvaldata(key_path, 'ProcessorNameString') =~ /qemu/i
+
+    false
   end
 
-  # run Method
+  def report_vm(hypervisor)
+    print_good("This is a #{hypervisor} Virtual Machine")
+    report_note(
+      host: session,
+      type: 'host.hypervisor',
+      data: { hypervisor: hypervisor },
+      update: :unique_data
+    )
+    report_virtualization(hypervisor)
+  end
+
   def run
-    print_status("Checking if #{sysinfo['Computer']} is a Virtual Machine .....")
-    found = hypervchk(session)
-    found ||= vmwarechk(session)
-    found ||= checkvrtlpc(session)
-    found ||= vboxchk(session)
-    found ||= xenchk(session)
-    found ||= qemuchk(session)
-    if found
-      report_virtualization(found)
+    print_status("Checking if #{sysinfo['Computer']} is a Virtual Machine ...")
+
+    @services = registry_enumkeys('HKLM\SYSTEM\ControlSet001\Services')
+    @processes = session.sys.process.get_processes
+
+    if hyperv?
+      report_vm('Hyper-V')
+    elsif vmware?
+      report_vm('VMware')
+    elsif virtualpc?
+      report_vm('VirtualPC')
+    elsif virtualbox?
+      report_vm('VirtualBox')
+    elsif xen?
+      report_vm('Xen')
+    elsif qemu?
+      report_vm('Qemu')
     else
       print_status("#{sysinfo['Computer']} appears to be a Physical Machine")
     end

--- a/modules/post/windows/gather/checkvm.rb
+++ b/modules/post/windows/gather/checkvm.rb
@@ -41,6 +41,10 @@ class MetasploitModule < Msf::Post
     @processes
   end
 
+  def service_exists?(service)
+    get_services && get_services.include?(service)
+  end
+
   def hyperv?
     physical_host = registry_getvaldata('HKLM\SOFTWARE\Microsoft\Virtual Machine\Guest\Parameters', 'PhysicalHostNameFullyQualified')
     if physical_host
@@ -68,7 +72,7 @@ class MetasploitModule < Msf::Post
     srvvals = registry_enumkeys('HKLM\HARDWARE\ACPI\RSDT')
     return true if srvvals && srvvals.include?('VRTUAL')
 
-    return true if get_services && get_services.include?('vmicexchange')
+    return true if service_exists?('vmicexchange')
 
     key_path = 'HKLM\HARDWARE\DESCRIPTION\System'
     system_bios_version = registry_getvaldata(key_path, 'SystemBiosVersion')
@@ -81,11 +85,8 @@ class MetasploitModule < Msf::Post
   end
 
   def vmware?
-    if get_services
-      return true if get_services.include?('vmdebug')
-      return true if get_services.include?('vmmouse')
-      return true if get_services.include?('VMTools')
-      return true if get_services.include?('VMMEMCTL')
+    %w[vmdebug vmmouse VMTools VMMEMCTL].each do |service|
+      return true if service_exists?(service)
     end
 
     return true if registry_getvaldata('HKLM\HARDWARE\DESCRIPTION\System\BIOS', 'SystemManufacturer') =~ /vmware/i
@@ -105,10 +106,8 @@ class MetasploitModule < Msf::Post
   end
 
   def virtualpc?
-    if get_services
-      return true if get_services.include?('vpc-s3')
-      return true if get_services.include?('vpcuhub')
-      return true if get_services.include?('msvmmouf')
+    %w[vpc-s3 vpcuhub msvmmouf].each do |service|
+      return true if service_exists?(service)
     end
 
     vpcprocs = [
@@ -149,11 +148,8 @@ class MetasploitModule < Msf::Post
 
     return true if registry_getvaldata('HKLM\HARDWARE\DESCRIPTION\System', 'SystemBiosVersion') =~ /vbox/i
 
-    if get_services
-      return true if get_services.include?('VBoxMouse')
-      return true if get_services.include?('VBoxGuest')
-      return true if get_services.include?('VBoxService')
-      return true if get_services.include?('VBoxSF')
+    %w[VBoxMouse VBoxGuest VBoxService VBoxSF].each do |service|
+      return true if service_exists?(service)
     end
 
     false
@@ -178,12 +174,8 @@ class MetasploitModule < Msf::Post
     srvvals = registry_enumkeys('HKLM\HARDWARE\ACPI\RSDT')
     return true if srvvals && srvvals.include?('Xen')
 
-    if get_services
-      return true if get_services.include?('xenevtchn')
-      return true if get_services.include?('xennet')
-      return true if get_services.include?('xennet6')
-      return true if get_services.include?('xensvc')
-      return true if get_services.include?('xenvdb')
+    %w[xenevtchn xennet xennet6 xensvc xenvdb].each do |service|
+      return true if service_exists?(service)
     end
 
     false


### PR DESCRIPTION
Fixes #13624

* Increase execution speed by ensuring `registry_enumkeys('HKLM\SYSTEM\ControlSet001\Services')` and `session.sys.process.get_processes` are called only once.
* Decrease code duplication. Decrease lines of code by ~33%.
* Update style in line with Rubocop rules.

The module logic should remain the same (unless I've made a mistake). That is, if one hypervisor is identified, all other checks are skipped.

```
msf5 exploit(multi/handler) > [*] Sending stage (201283 bytes) to 172.16.191.130
[*] Meterpreter session 1 opened (172.16.191.165:1337 -> 172.16.191.130:50336) at 2020-06-13 18:12:36 -0400

msf5 exploit(multi/handler) > use post/windows/gather/checkvm 
msf5 post(windows/gather/checkvm) > set session 1
session => 1
msf5 post(windows/gather/checkvm) > run

[*] Checking if TEST is a Virtual Machine ...
[+] This is a VMware Virtual Machine
[*] Post module execution completed
msf5 post(windows/gather/checkvm) > notes

Notes
=====

 Time                     Host            Service  Port  Protocol  Type             Data
 ----                     ----            -------  ----  --------  ----             ----
 2020-06-13 22:23:46 UTC  172.16.191.130                           host.hypervisor  {:hypervisor=>"VMware"}
```

Commented out the `vmware?` checks to ensure the module still works, and correctly reports that the system is not a virtual machine:

```
msf5 post(windows/gather/checkvm) > rexploit 
[*] Reloading module...

[*] Checking if TEST is a Virtual Machine ...
[*] TEST appears to be a Physical Machine
[*] Post module execution completed
msf5 post(windows/gather/checkvm) > 

```