### PR TITLE
postgres_payload: fix deadlink

### DIFF
--- a/modules/exploits/windows/postgres/postgres_payload.rb
+++ b/modules/exploits/windows/postgres/postgres_payload.rb
@@ -35,7 +35,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'License'        => MSF_LICENSE,
       'References'     =>
         [
-          [ 'URL', 'http://lab.lonerunners.net/blog/sqli-writing-files-to-disk-under-postgresql' ], # A litte more specific to PostgreSQL
+          [ 'URL', 'https://web.archive.org/web/20100803002909/http://lab.lonerunners.net/blog/sqli-writing-files-to-disk-under-postgresql' ], # A litte more specific to PostgreSQL
         ],
       'Platform'       => 'win',
       'Targets'        =>


### PR DESCRIPTION
Replace the original link (dead) by the cached version in web archive.
