### PR TITLE
Update PR Template to request Demos for difficult to test Modules 

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,9 +15,8 @@ List the steps needed to make sure this thing works
 - [ ] **Verify** the thing does not do what it should not
 - [ ] **Document** the thing and how it works ([Example](https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/post/multi/gather/aws_keys.md))
 
-If you are opening a PR for a new Module that exploits a **specific** piece of hardware, or requires a **very** complex testing environment, we will need a demonstration of your module executing correctly in order to land your Module in a reasonable time. 
+If you are opening a PR for a new Module that exploits a **specific** piece of hardware or requires a **very** complex testing environment, we will need a demonstration of your Module executing correctly in order to land your Module in a reasonable time. 
 
 We will also accept demonstrations of successful Module execution if it doesn't match any of the above conditions and you think it will still help land your Module, but it is not a neccessity. 
 
 Demonstration of successful Module execution can take the form of a Packet Capture, a Screen Recording, or a Video Conference with a member of the Metasploit team via your conferencing tool of choice. PCAPs, Screen Recordings, or times you are available for a Video Conference should be sent to [msfdev@metaspolit.com](mailto:msfdev@metaspolit.com).
-

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,3 @@
-
 Tell us what this change does. If you're fixing a bug, please mention
 the github issue number.
 
@@ -15,19 +14,20 @@ List the steps needed to make sure this thing works
 - [ ] **Verify** the thing does not do what it should not
 - [ ] **Document** the thing and how it works ([Example](https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/post/multi/gather/aws_keys.md))
 
-If you are opening a PR for a new module that exploits a **specific** piece of hardware or requires a **complex or hard-to-find** testing environment, we recommend that you send us a demo of your module executing correctly. Seeing your module in action will help us review your use case faster!
-
+If you are opening a PR for a new module that exploits a **specific** piece of hardware or requires a **complex or hard-to-find** testing environment, we recommend that you send us a demo of your module executing correctly. Seeing your module in action will help us review your PR faster!
 
 Specific Hardware Examples:
-* Enterprise Switches (PR 13303)
-* IP Cameras (PR 13170)
+* Switches
+* Routers
+* IP Cameras
+* IoT devices
 
+Complex Software Examples:
+* Expensive proprietary software
+* Software with an extensive installation process
+* Software that requires exploit testing across multiple significantly different versions
+* Software without an English language UI
 
-Complex Testing Enviroment Examples:
-* Multiple testing scenarios (PR 12096)
+We will also accept demonstrations of successful module execution even if your module doesn't meet the above conditions. It's not a necessity, but it may help us land your module faster!
 
-
-We will also accept demonstrations of successful module execution even if your module doesn't meet the above conditions. It's not a necessity, but it may help us land your module faster! 
-
-Demonstration of successful module execution can take the form of a packet capture (pcap) or a screen recording. You can send pcaps and recordings to [msfdev@metaspolit.com](mailto:msfdev@metaspolit.com). Please include a CVE number in the subject header (if applicable), and a link to your PR in the email body. 
-
+Demonstration of successful module execution can take the form of a packet capture (pcap) or a screen recording. You can send pcaps and recordings to [msfdev@metaspolit.com](mailto:msfdev@metaspolit.com). Please include a CVE number in the subject header (if applicable), and a link to your PR in the email body.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,3 +15,9 @@ List the steps needed to make sure this thing works
 - [ ] **Verify** the thing does not do what it should not
 - [ ] **Document** the thing and how it works ([Example](https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/post/multi/gather/aws_keys.md))
 
+If you are opening a PR for a new Module that exploits a **specific** piece of hardware, or requires a **very** complex testing environment, we will need a demonstration of your module executing correctly in order to land your Module in a reasonable time. 
+
+We will also accept demonstrations of successful Module execution if it doesn't match any of the above conditions and you think it will still help land your Module, but it is not a neccessity. 
+
+Demonstration of successful Module execution can take the form of a Packet Capture, a Screen Recording, or a Video Conference with a member of the Metasploit team via your conferencing tool of choice. PCAPs, Screen Recordings, or times you are available for a Video Conference should be sent to [msfdev@metaspolit.com](mailto:msfdev@metaspolit.com).
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -29,5 +29,5 @@ Complex Testing Enviroment Examples:
 
 We will also accept demonstrations of successful module execution even if your module doesn't meet the above conditions. It's not a necessity, but it may help us land your module faster! 
 
-Demonstration of successful module execution can take the form of a packet capture (pcap) or a screen recording. You can send pcaps and recordings to [msfdev@metaspolit.com](mailto:msfdev@metaspolit.com).
+Demonstration of successful module execution can take the form of a packet capture (pcap) or a screen recording. You can send pcaps and recordings to [msfdev@metaspolit.com](mailto:msfdev@metaspolit.com). Please include a CVE number in the subject header (if apllicable), and a link to your PR in the email body. 
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,9 +15,18 @@ List the steps needed to make sure this thing works
 - [ ] **Verify** the thing does not do what it should not
 - [ ] **Document** the thing and how it works ([Example](https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/post/multi/gather/aws_keys.md))
 
-If you are opening a PR for a new Module that exploits a **specific** piece of hardware, or requires a **very** complex testing environment, we will need a demonstration of your module executing correctly in order to land your Module in a reasonable time. 
+If you are opening a PR for a new Module that exploits a **specific** piece of hardware, or requires a **very** complex testing environment, we will need a demonstration of your module executing correctly in order to land your Module in a reasonable time.
 
-We will also accept demonstrations of successful Module execution if it doesn't match any of the above conditions and you think it will still help land your Module, but it is not a neccessity. 
+Specific Hardware Examples:
+* https://github.com/rapid7/metasploit-framework/pull/13303
+* https://github.com/rapid7/metasploit-framework/pull/13170
+
+
+Complex Testing Enviroment Examples:
+* https://github.com/rapid7/metasploit-framework/pull/12096
+
+
+We will also accept demonstrations of successful Module execution if your Module doesn't match any of the above conditions and you think it will still help land your Module, but it is not a neccessity. 
 
 Demonstration of successful Module execution can take the form of a Packet Capture, a Screen Recording, or a Video Conference with a member of the Metasploit team via your conferencing tool of choice. PCAPs, Screen Recordings, or times you are available for a Video Conference should be sent to [msfdev@metaspolit.com](mailto:msfdev@metaspolit.com).
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,7 +15,8 @@ List the steps needed to make sure this thing works
 - [ ] **Verify** the thing does not do what it should not
 - [ ] **Document** the thing and how it works ([Example](https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/post/multi/gather/aws_keys.md))
 
-If you are opening a PR for a new Module that exploits a **specific** piece of hardware, or requires a **very** complex testing environment, we will need a demonstration of your module executing correctly in order to land your Module in a reasonable time.
+If you are opening a PR for a new module that exploits a **specific** piece of hardware or requires a **complex or hard-to-find** testing environment, we recommend that you send us a demo of your module executing correctly. Seeing your module in action will help us review your use case faster!
+
 
 Specific Hardware Examples:
 * https://github.com/rapid7/metasploit-framework/pull/13303
@@ -26,7 +27,7 @@ Complex Testing Enviroment Examples:
 * https://github.com/rapid7/metasploit-framework/pull/12096
 
 
-We will also accept demonstrations of successful Module execution if your Module doesn't match any of the above conditions and you think it will still help land your Module, but it is not a neccessity. 
+We will also accept demonstrations of successful module execution even if your module doesn't meet the above conditions. It's not a necessity, but it may help us land your module faster! 
 
-Demonstration of successful Module execution can take the form of a Packet Capture, a Screen Recording, or a Video Conference with a member of the Metasploit team via your conferencing tool of choice. PCAPs, Screen Recordings, or times you are available for a Video Conference should be sent to [msfdev@metaspolit.com](mailto:msfdev@metaspolit.com).
+Demonstration of successful module execution can take the form of a packet capture (pcap) or a screen recording. You can send pcaps and recordings to [msfdev@metaspolit.com](mailto:msfdev@metaspolit.com).
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,6 +17,6 @@ List the steps needed to make sure this thing works
 
 If you are opening a PR for a new Module that exploits a **specific** piece of hardware or requires a **very** complex testing environment, we will need a demonstration of your Module executing correctly in order to land your Module in a reasonable time. 
 
-We will also accept demonstrations of successful Module execution if it doesn't match any of the above conditions and you think it will still help land your Module, but it is not a neccessity. 
+We will also accept demonstrations of successful Module execution if it doesn't match any of the above conditions and you think it will still help land your Module, but it is not a necessity. 
 
 Demonstration of successful Module execution can take the form of a Packet Capture, a Screen Recording, or a Video Conference with a member of the Metasploit team via your conferencing tool of choice. PCAPs, Screen Recordings, or times you are available for a Video Conference should be sent to [msfdev@metaspolit.com](mailto:msfdev@metaspolit.com).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,15 +19,15 @@ If you are opening a PR for a new module that exploits a **specific** piece of h
 
 
 Specific Hardware Examples:
-* https://github.com/rapid7/metasploit-framework/pull/13303
-* https://github.com/rapid7/metasploit-framework/pull/13170
+* Enterprise Switches (PR 13303)
+* IP Cameras (PR 13170)
 
 
 Complex Testing Enviroment Examples:
-* https://github.com/rapid7/metasploit-framework/pull/12096
+* Multiple testing scenarios (PR 12096)
 
 
 We will also accept demonstrations of successful module execution even if your module doesn't meet the above conditions. It's not a necessity, but it may help us land your module faster! 
 
-Demonstration of successful module execution can take the form of a packet capture (pcap) or a screen recording. You can send pcaps and recordings to [msfdev@metaspolit.com](mailto:msfdev@metaspolit.com). Please include a CVE number in the subject header (if apllicable), and a link to your PR in the email body. 
+Demonstration of successful module execution can take the form of a packet capture (pcap) or a screen recording. You can send pcaps and recordings to [msfdev@metaspolit.com](mailto:msfdev@metaspolit.com). Please include a CVE number in the subject header (if applicable), and a link to your PR in the email body. 
 


### PR DESCRIPTION
Adds three paragraphs to the PR template that detail: 

1. Under what situations we would want a module demo
2. That we'll take a module demo even if an Author's module doesn't match the criteria
3. Instructions on what type of demo we accept and where authors can send them

I've had this conversation a few times already with Authors so I figured I might as well put it in the template and save everyone some time.

RFC on paragraph 2 in particular.