### PR TITLE
check shodan API key

### DIFF
--- a/modules/auxiliary/gather/shodan_honeyscore.rb
+++ b/modules/auxiliary/gather/shodan_honeyscore.rb
@@ -42,6 +42,11 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
+    # check our API key is somewhat sane
+    unless /^[a-z\d]{32}$/i.match?(datastore['SHODAN_APIKEY'])
+      fail_with(Failure::BadConfig, 'Shodan API key should be 32 characters a-z,A-Z,0-9.')
+    end
+
     key = datastore['SHODAN_APIKEY']
 
     # Check the length of the key (should be 32 chars)

--- a/modules/auxiliary/gather/shodan_search.rb
+++ b/modules/auxiliary/gather/shodan_search.rb
@@ -87,6 +87,11 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
+    # check our API key is somewhat sane
+    unless /^[a-z\d]{32}$/i.match?(datastore['SHODAN_APIKEY'])
+      fail_with(Failure::BadConfig, 'Shodan API key should be 32 characters a-z,A-Z,0-9.')
+    end
+
     # check to ensure api.shodan.io is resolvable
     unless shodan_resolvable?
       print_error("Unable to resolve api.shodan.io")


### PR DESCRIPTION
Related to https://github.com/rapid7/metasploit-framework/issues/13598#issuecomment-643646040

Ping @adfoster-r7  since you were also involved in that issue

This PR adds a simple check to ensure the Shodan API key passes a basic sanity check (32 character `/a-z,0-9/i`.  I don't think it will resolve #13598 however it will at least weed out the easy problems.

# After Patch
good key (sanitized)
```
msf5 auxiliary(gather/shodan_search) > set SHODAN_APIKEY aAA1jN111IxghvAA02AAtataLLbIvAa0
SHODAN_APIKEY => aAA1jN111IxghvAA02AAtataLLbIvAa0
msf5 auxiliary(gather/shodan_search) > set verbose true
verbose => true
msf5 auxiliary(gather/shodan_search) > run

[*] Total: 28 on 1 pages. Showing: 1 page(s)
[*] Collecting data, please wait...

```
bad key
```
msf5 auxiliary(gather/shodan_search) > set SHODAN_APIKEY aAA1jN111IxghvAA02AAtata
SHODAN_APIKEY => aAA1jN111IxghvAA02AAtata
msf5 auxiliary(gather/shodan_search) > run

[-] Auxiliary aborted due to failure: bad-config: Shodan API key should be 32 characters a-z,A-Z,0-9.
[*] Auxiliary module execution completed

```