### PR TITLE
Exclude multi payloads from automatic PAYLOAD selection

### DIFF
--- a/lib/msf/core/evasion.rb
+++ b/lib/msf/core/evasion.rb
@@ -118,15 +118,16 @@ module Msf
 
     # Returns a list of compatible payloads based on platform, architecture,
     # and size requirements.
-    def compatible_payloads
+    def compatible_payloads(excluded_platforms: [], excluded_archs: [])
       payloads = []
 
       c_platform, c_arch = normalize_platform_arch
 
+      # The "All" platform name represents generic payloads
       results = Msf::Modules::Metadata::Cache.instance.find(
         'type'     => [['payload'], []],
-        'platform' => [[*c_platform.names, 'All'], []], # "All" for generic
-        'arch'     => [c_arch, []]
+        'platform' => [[*c_platform.names, 'All'], excluded_platforms],
+        'arch'     => [c_arch, excluded_archs]
       )
 
       results.each do |res|

--- a/lib/msf/core/exploit.rb
+++ b/lib/msf/core/exploit.rb
@@ -814,19 +814,18 @@ class Exploit < Msf::Module
     return true
   end
 
-  #
   # Returns a list of compatible payloads based on platform, architecture,
   # and size requirements.
-  #
-  def compatible_payloads
+  def compatible_payloads(excluded_platforms: [], excluded_archs: [])
     payloads = []
 
     c_platform, c_arch = normalize_platform_arch
 
+    # The "All" platform name represents generic payloads
     results = Msf::Modules::Metadata::Cache.instance.find(
       'type'     => [['payload'], []],
-      'platform' => [[*c_platform.names, 'All'], []], # "All" for generic
-      'arch'     => [c_arch, []]
+      'platform' => [[*c_platform.names, 'All'], excluded_platforms],
+      'arch'     => [c_arch, excluded_archs]
     )
 
     results.each do |res|

--- a/lib/msf/ui/console/command_dispatcher/exploit.rb
+++ b/lib/msf/ui/console/command_dispatcher/exploit.rb
@@ -294,8 +294,24 @@ class Exploit
       excluded_platforms: ['Multi'] # We don't want to select a multi payload
     ).map(&:first)
 
+    # XXX: Determine LHOST based on RHOST or an arbitrary internet address
+    lhost = Rex::Socket.source_address(mod.datastore['RHOST'] || '50.50.50.50')
+
+    configure_payload = lambda do |payload|
+      mod.datastore['PAYLOAD'] = payload
+
+      # Set LHOST if this is a reverse payload
+      if payload.index('reverse')
+        mod.datastore['LHOST'] = lhost
+      end
+
+      payload
+    end
+
     # If there is only one compatible payload, return it immediately
-    return compatible_payloads.first if compatible_payloads.length == 1
+    if compatible_payloads.length == 1
+      return configure_payload.call(compatible_payloads.first)
+    end
 
     # XXX: This approach is subpar, and payloads should really be ranked!
     preferred_payloads = [
@@ -309,23 +325,13 @@ class Exploit
       'generic/shell_bind_tcp'
     ]
 
-    # XXX: Determine LHOST based on RHOST or an arbitrary internet address
-    lhost = Rex::Socket.source_address(mod.datastore['RHOST'] || '50.50.50.50')
-
     # XXX: This is not efficient in the slightest
     preferred_payloads.each do |type|
       payload = compatible_payloads.find { |name| name.end_with?(type) }
 
       next unless payload
 
-      mod.datastore['PAYLOAD'] = payload
-
-      # Set LHOST if this is a reverse payload
-      if payload.index('reverse')
-        mod.datastore['LHOST'] = lhost
-      end
-
-      return payload
+      return configure_payload.call(payload)
     end
 
     nil

--- a/lib/msf/ui/console/command_dispatcher/exploit.rb
+++ b/lib/msf/ui/console/command_dispatcher/exploit.rb
@@ -290,17 +290,23 @@ class Exploit
   # Select a reasonable default payload and minimally configure it
   # TODO: Move this somewhere better or make it more dynamic?
   def self.choose_payload(mod)
-    compatible_payloads = mod.compatible_payloads.map(&:first)
+    compatible_payloads = mod.compatible_payloads(
+      excluded_platforms: ['Multi'] # We don't want to select a multi payload
+    ).map(&:first)
 
-    # XXX: This approach is subpar, but at least this list has been reevaluated
-    preferred_payloads = %w[
-      meterpreter/reverse_https
-      meterpreter/reverse_http
-      meterpreter/reverse_tcp
-      shell_reverse_tcp
-      shell/reverse_tcp
-      generic/shell_reverse_tcp
-      generic/shell_bind_tcp
+    # If there is only one compatible payload, return it immediately
+    return compatible_payloads.first if compatible_payloads.length == 1
+
+    # XXX: This approach is subpar, and payloads should really be ranked!
+    preferred_payloads = [
+      # These payloads are generally reliable and common enough in practice
+      '/meterpreter/reverse_tcp',
+      '/shell/reverse_tcp',
+      'cmd/unix/reverse_netcat',
+      'cmd/windows/powershell_reverse_tcp',
+      # Fall back on a generic payload to autoselect a specific payload
+      'generic/shell_reverse_tcp',
+      'generic/shell_bind_tcp'
     ]
 
     # XXX: Determine LHOST based on RHOST or an arbitrary internet address

--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -769,13 +769,11 @@ module Msf
             end
 
             # Choose a default payload when the module is used, not run
-            if mod.datastore['PAYLOAD'].nil? && dispatcher.respond_to?(:choose_payload)
+            if mod.datastore['PAYLOAD']
+              print_status("Using configured payload #{mod.datastore['PAYLOAD']}")
+            elsif dispatcher.respond_to?(:choose_payload)
               chosen_payload = dispatcher.choose_payload(mod)
-
-              # XXX: No vprint_status in this context
-              if framework.datastore['VERBOSE'].to_s == 'true' && chosen_payload
-                print_status("No payload configured, defaulting to #{chosen_payload}")
-              end
+              print_status("No payload configured, defaulting to #{chosen_payload}") if chosen_payload
             end
 
             mod.init_ui(driver.input, driver.output)

--- a/modules/exploits/multi/handler.rb
+++ b/modules/exploits/multi/handler.rb
@@ -34,6 +34,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Arch'           => ARCH_ALL,
         'Targets'        => [ [ 'Wildcard Target', {} ] ],
         'DefaultTarget'  => 0,
+        'DefaultOptions' => { 'PAYLOAD' => 'generic/shell_reverse_tcp' }
       )
     )
 


### PR DESCRIPTION
`multi` payloads were being automatically selected in some cases. These payloads are not usable in a normal context. Modules should have platform-specific payloads selected for them.

The intended behavior is as follows:

```
msf5 > use exploit/multi/http/ibm_openadmin_tool_soap_welcomeserver_exec
[*] No payload configured, defaulting to php/meterpreter/reverse_tcp
msf5 exploit(multi/http/ibm_openadmin_tool_soap_welcomeserver_exec) > set payload
payload => php/meterpreter/reverse_tcp
msf5 exploit(multi/http/ibm_openadmin_tool_soap_welcomeserver_exec) >
```

```
msf5 exploit(multi/http/ibm_openadmin_tool_soap_welcomeserver_exec) > use exploit/unix/webapp/drupal_drupalgeddon2
[*] No payload configured, defaulting to php/meterpreter/reverse_tcp
msf5 exploit(unix/webapp/drupal_drupalgeddon2) > set payload
payload => php/meterpreter/reverse_tcp
msf5 exploit(unix/webapp/drupal_drupalgeddon2) >
```

```
msf5 exploit(unix/webapp/drupal_drupalgeddon2) > use exploit/linux/samba/is_known_pipename
[*] No payload configured, defaulting to cmd/unix/interact
msf5 exploit(linux/samba/is_known_pipename) > set payload
payload => cmd/unix/interact
msf5 exploit(linux/samba/is_known_pipename) >
```

```
msf5 exploit(linux/samba/is_known_pipename) > use exploit/windows/smb/ms17_010_eternalblue
[*] No payload configured, defaulting to windows/x64/meterpreter/reverse_tcp
msf5 exploit(windows/smb/ms17_010_eternalblue) > set payload
payload => windows/x64/meterpreter/reverse_tcp
msf5 exploit(windows/smb/ms17_010_eternalblue) >
```

`exploit/multi/handler` requires a special case, so we default it to a `generic` reverse shell handler:

```
msf5 exploit(windows/smb/ms17_010_eternalblue) > use exploit/multi/handler
[*] Using configured payload generic/shell_reverse_tcp
msf5 exploit(multi/handler) > set payload
payload => generic/shell_reverse_tcp
msf5 exploit(multi/handler) >
```

And this is how a module should respond if it has a saved `PAYLOAD` config:

```
msf5 > use exploit/multi/handler
[*] Using configured payload windows/x64/meterpreter_reverse_tcp
msf5 exploit(multi/handler) >
```

Fixes #13566 and resolves #13752 and #13754.