### PR TITLE
Add consistent error logging for module loading and handle nil backtraces

### DIFF
--- a/lib/msf/core/modules/loader/base.rb
+++ b/lib/msf/core/modules/loader/base.rb
@@ -414,17 +414,7 @@ class Msf::Modules::Loader::Base
     # backtraces should not appear.
     module_manager.module_load_error_by_path[module_path] = "#{error.class} #{error}"
 
-    log_lines = []
-    log_lines << "#{module_path} failed to load due to the following error:"
-    log_lines << error.class.to_s
-    log_lines << error.to_s
-    if error.backtrace
-      log_lines << "Call stack:"
-      log_lines += error.backtrace
-    end
-
-    log_message = log_lines.join(' ')
-    elog(log_message)
+    elog("#{module_path} failed to load", error: error)
   end
 
   # Records the load warning to {Msf::ModuleManager::Loading#module_load_warnings} and the log.

--- a/lib/rex/logging/log_dispatcher.rb
+++ b/lib/rex/logging/log_dispatcher.rb
@@ -160,7 +160,11 @@ def elog(msg, src = 'core', log_level = 0, error: nil)
   else
     error_details = "#{error.class} #{error.message}"
     if get_log_level(src) >= BACKTRACE_LOG_LEVEL
-      error_details << "\nCall stack:\n#{error.backtrace.join("\n")}"
+      if error.backtrace
+        error_details << "\nCall stack:\n#{error.backtrace.join("\n")}"
+      else
+        error_details << "\nCall stack:\nNone"
+      end
     end
 
     if msg.is_a?(Exception)


### PR DESCRIPTION
Dependent on https://github.com/rapid7/metasploit-framework/pull/13430

Updating the new error logging API to correctly handle the backtrace array being `nil`, which occurs when custom exception objects are created and passed to `elog`:

https://github.com/rapid7/metasploit-framework/blob/6d6f539d049d3483a52e3512fe34eee0bfea30bc/lib/msf/core/modules/loader/executable.rb#L84

Example:

```
2.6.6 :001 > Exception.new("Hello world").backtrace
 => nil 
```

## Verification

List the steps needed to make sure this thing works

- [ ] Force a syntax error on a module file for instance on `exploit/windows/smb/ms08_067_netapi`
- [ ] Start `msfconsole`
- [ ] `use exploit/windows/smb/ms08_067_netapi`
- [ ] **Verify** the module doesn't load
- [ ] **Verify** the framework log is populated with the correct error information
- [ ] `set LogLevel 3`
- [ ] `use exploit/windows/smb/ms08_067_netapi`
- [ ] **Verify** the framework log now has additional backtrace information