### PR TITLE
Add optional baseline for http response time in scanner/http/owa_login

### DIFF
--- a/modules/auxiliary/scanner/http/owa_login.rb
+++ b/modules/auxiliary/scanner/http/owa_login.rb
@@ -97,7 +97,7 @@ class MetasploitModule < Msf::Auxiliary
     register_advanced_options(
       [
         OptString.new('AD_DOMAIN', [ false, "Optional AD domain to prepend to usernames", '']),
-        OptFloat.new('BASELINE_AUTH_TIME', [ false, "Baseline HTTP authentication response time for invalid users", 1.0])
+        OptFloat.new('BaselineAuthTime', [ false, "Baseline HTTP authentication response time for invalid users", 1.0])
       ])
 
     deregister_options('BLANK_PASSWORDS', 'RHOSTS')
@@ -185,7 +185,7 @@ class MetasploitModule < Msf::Auxiliary
       if datastore['AUTH_TIME']
         start_time = Time.now
       end
-      baseline = datastore['BASELINE_AUTH_TIME'] || 1.0
+      baseline = datastore['BaselineAuthTime'] || 1.0
 
       res = send_request_cgi({
         'encode'   => true,

--- a/modules/auxiliary/scanner/http/owa_login.rb
+++ b/modules/auxiliary/scanner/http/owa_login.rb
@@ -96,7 +96,8 @@ class MetasploitModule < Msf::Auxiliary
 
     register_advanced_options(
       [
-        OptString.new('AD_DOMAIN', [ false, "Optional AD domain to prepend to usernames", ''])
+        OptString.new('AD_DOMAIN', [ false, "Optional AD domain to prepend to usernames", '']),
+        OptFloat.new('BASELINE_AUTH_TIME', [ false, "Baseline HTTP authentication response time for invalid users", 1.0])
       ])
 
     deregister_options('BLANK_PASSWORDS', 'RHOSTS')
@@ -184,6 +185,7 @@ class MetasploitModule < Msf::Auxiliary
       if datastore['AUTH_TIME']
         start_time = Time.now
       end
+      baseline = datastore['BASELINE_AUTH_TIME'] || 1.0
 
       res = send_request_cgi({
         'encode'   => true,
@@ -253,7 +255,7 @@ class MetasploitModule < Msf::Auxiliary
         headers['Cookie'] = 'PBack=0;' << res.get_cookies
       else
         # Login didn't work. no point in going on, however, check if valid domain account by response time.
-        if elapsed_time && elapsed_time <= 1
+        if elapsed_time && elapsed_time <= baseline
           unless user =~ /@\w+\.\w+/
             report_cred(
               ip: res.peerinfo['addr'],
@@ -301,7 +303,7 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     if res.redirect?
-      if elapsed_time && elapsed_time <= 1
+      if elapsed_time && elapsed_time <= baseline
         unless user =~ /@\w+\.\w+/
           report_cred(
             ip: res.peerinfo['addr'],
@@ -329,7 +331,7 @@ class MetasploitModule < Msf::Auxiliary
       )
       return :next_user
     else
-      if elapsed_time && elapsed_time <= 1
+      if elapsed_time && elapsed_time <= baseline
         unless user =~ /@\w+\.\w+/
           report_cred(
             ip: res.peerinfo['addr'],


### PR DESCRIPTION
A new advanced option ~~BASELINE_AUTH_TIME~~ `BaselineAuthTime` allows to specify a baseline
for http authentication response times to discriminate valid/invalid
OWA users.

This advanced option for the auxiliary module `scanner/http/owa_login`
makes it possible to tweak the timing settings used to enumerate users on
Outlook Web Access (OWA). 

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use auxiliary/scanner/http/owa_login`
- [ ] Set required options `RHOST`, `USERNAME`, `PASSWORD`
- [ ] `set BaseLineAuthTime 0.5`
- [ ] **Verify** that a valid user is added to creds when the http response time falls under the baseline
- [ ] **Verify** the an invalid user is ignored when the http response time is over the baseline

## Scenarios
### Setup
```
msf5 > use auxiliary/scanner/http/owa_login
msf5 auxiliary(scanner/http/owa_login) > set RHOST 127.0.0.1
RHOST => 127.0.0.1
msf5 auxiliary(scanner/http/owa_login) > set PASSWORD invalid
PASSWORD => invalid
msf5 auxiliary(scanner/http/owa_login) > set DOMAIN EVILCORP
DOMAIN => EVILCORP
msf5 auxiliary(scanner/http/owa_login) > set BASELINE_AUTH_TIME 0.5
BASELINE_AUTH_TIME => 0.5
```

### Invalid user (not saved)
```
msf5 auxiliary(scanner/http/owa_login) > set USERNAME nobody
USERNAME => nobody
msf5 auxiliary(scanner/http/owa_login) > run

[*] 127.0.0.1:443 OWA - Testing version OWA_2013
[+] Found target domain: EVILCORP
[*] 127.0.0.1:443 OWA - Trying nobody : invalid
[+] server type: MX01
[-] 127.0.0.1:443 OWA - FAILED LOGIN. 0.8797193 'EVILCORP\nobody' : 'invalid' (HTTP redirect with reason 2)
[*] Auxiliary module execution completed
```

### Valid user (saved to creds)
```
msf5 auxiliary(scanner/http/owa_login) > set USERNAME administrator
USERNAME => administrator
msf5 auxiliary(scanner/http/owa_login) > run

[*] 127.0.0.1:443 OWA - Testing version OWA_2013
[+] Found target domain: EVILCORP
[*] 127.0.0.1:443 OWA - Trying administrator : invalid
[+] server type: MX01
[!] No active DB -- Credential data will not be saved!
[*] 127.0.0.1:443 OWA - FAILED LOGIN, BUT USERNAME IS VALID. 0.124869 'EVILCORP\administrator' : 'invalid': SAVING TO CREDS
[*] Auxiliary module execution completed
```