### PR TITLE
Update SMB Version Scanning

### DIFF
--- a/documentation/modules/auxiliary/scanner/smb/smb_version.md
+++ b/documentation/modules/auxiliary/scanner/smb/smb_version.md
@@ -1,167 +1,67 @@
-The `smb_version` module is used to determine what version of the Operating System is installed.
-This module also attempts to determine the following information on the system if possible:
+The `smb_version` module is used to determine information about a remote SMB server. It will fingerprint protocol
+version and capability information. If the target server supports SMB version 1, then the module will also attempt to
+identify the information about the host operating system.
+
+### Protocol Information
+
+1. Protocol Versions: The list of SMB protocol versions that the server supports.
+1. Preferred Dialect: The preferred dialect for the newest protocol version that the server supports.
+1. Signature Requirements: Whether or not the server requires security signatures.
+1. Uptime: How long the server has been up, as calculated by subtracting the current time from the system time. This 
+   calculation requires that both fields be provided by the server. If one or both fields are unset, this value will be
+   omitted.
+    * Requires versions: 2+
+1. Server GUID: The unique identifier of the server. This value can be used to identify systems with multiple network 
+   interfaces.
+    * Requires versions: 2+
+1. Capabilities: The supported encryption and compression algorithms that the server supports.
+    * Requires versions: 3+
+
+### Host Operating System Information
+
+*This information is only available if the target SMB server supports SMB version 1.*
 
 1. OS (product and version)
-2. lanman version
-3. OS build number
-4. Service pack
-5. OS language
-
-## Vulnerable Application
-
-To use `smb_version`, make sure you are able to connect to a SMB service that supports SMBv1.
+1. LAN Manager version
+1. OS build number
+1. Service pack
+1. OS language
 
 ## Verification Steps
 
-1. Do: ```use auxiliary/scanner/smb/smb_version``` 
-2. Do: ```set rhosts [IP]```
-3. Do: ```run```
+1. Do: `use auxiliary/scanner/smb/smb_version`
+2. Do: `set rhosts [IP]`
+3. Do: `run`
 
 ## Scenarios
 
 This is an example run of a network with several different version of Windows, metasploit 1 and 2, and a NAS device running SAMBA.
 
 ```
-msf > use auxiliary/scanner/smb/smb_version 
-msf auxiliary(smb_version) > set rhosts 10.9.7.1-254
-rhosts => 10.9.7.1-254
-msf auxiliary(smb_version) > set threads 5
-threads => 5
-msf auxiliary(smb_version) > run
+msf5 auxiliary(scanner/smb/smb_version) > show options 
 
-[*] 10.9.7.7:445       - Host is running Windows 2008 R2 Standard (build:7600) (name:WIN-O712LQK2K69) (workgroup:WORKGROUP )
-[*] Scanned  26 of 254 hosts (10% complete)
-[*] 10.9.7.35:445      - Host could not be identified: Unix (Samba 3.0.20-Debian)
-[*] 10.9.7.46:445      - Host could not be identified: Unix (Samba 3.0.20-Debian)
-[*] Scanned  52 of 254 hosts (20% complete)
-[*] Scanned  77 of 254 hosts (30% complete)
-[*] 10.9.7.91:445      - Host is running Windows 8.1 Enterprise Evaluation (build:9600) (name:IE11WIN8_1) (workgroup:WORKGROUP )
-[*] Scanned 105 of 254 hosts (41% complete)
-[*] 10.9.7.108:445     - Host is running Windows XP SP3 (language:English) (name:WINXP) (workgroup:WORKGROUP )
-[*] 10.9.7.119:445     - Host could not be identified: Windows 6.1 (Samba 4.4.9)
-[*] 10.9.7.127:445     - Host is running Windows 2000 SP4 with ms05-010+ (language:English) (name:WIN2K) (workgroup:WORKGROUP )
-[*] Scanned 127 of 254 hosts (50% complete)
-[*] Scanned 154 of 254 hosts (60% complete)
-[*] 10.9.7.164:445     - Host is running Windows 2012 Standard (build:9200) (name:WIN-OBKF2JFCDKL)
-[*] 10.9.7.175:445     - Host is running Windows 10 Pro (build:14393) (name:WORKDESK)
-[*] Scanned 178 of 254 hosts (70% complete)
-[*] Scanned 204 of 254 hosts (80% complete)
-[*] Scanned 231 of 254 hosts (90% complete)
-[*] 10.9.7.232:445     - Host is running Windows 7 Enterprise SP1 (build:7601) (name:IE11WIN7) (workgroup:WORKGROUP )
-[*] Scanned 254 of 254 hosts (100% complete)
+Module options (auxiliary/scanner/smb/smb_version):
+
+   Name       Current Setting           Required  Description
+   ----       ---------------           --------  -----------
+   RHOSTS     file:smb_servers.txt      yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
+   SMBDomain  .                         no        The Windows domain to use for authentication
+   SMBPass                              no        The password for the specified username
+   SMBUser                              no        The username to authenticate as
+   THREADS    5                         yes       The number of concurrent threads (max one per host)
+
+msf5 auxiliary(scanner/smb/smb_version) > run
+
+[*] 192.168.0.94:445      - SMB Detected (versions:2, 3) (preferred dialect:SMB 3.1.1) (compression capabilities:LZNT1) (encryption capabilities:AES-128-CCM) (signatures:optional) (guid:{a13d40f9-c789-44f6-b5b0-14d4bd633284})
+[*] 192.168.0.212:445     - SMB Detected (versions:1, 2, 3) (preferred dialect:SMB 3.0.2) (signatures:optional) (uptime:7w 6d 11h 52m) (guid:{9874f7e3-5178-4db9-af57-113adf0b67b9})
+[+] 192.168.0.212:445     -   Host is running Windows 2012 R2 Standard (build:9600) (name:WIN-R1FK95KGVJ5)
+[*] 192.168.0.107:445     - SMB Detected (versions:1, 2, 3) (preferred dialect:SMB 3.1.1) (compression capabilities:LZNT1) (encryption capabilities:AES-128-CCM) (signatures:optional) (uptime:7w 6d 11h 52m) (guid:{515c49bb-24c3-4092-825a-62afd6e1bd45})
+[+] 192.168.0.107:445     -   Host is running Windows 2016 Datacenter (build:14393) (name:EC2AMAZ-IO7R6NR)
+[*] Scanned 2 of 4 hosts (50% complete)
+[*] Scanned 3 of 4 hosts (75% complete)
+[*] 192.168.0.100:445     - SMB Detected (versions:1, 2) (preferred dialect:SMB 2.1) (signatures:optional) (uptime:7w 6d 12h 31m) (guid:{c21f4e2f-1e0a-4dd1-96a4-5dad6465a2ab})
+[+] 192.168.0.100:445     -   Host is running Windows 2008 R2 Datacenter SP1 (build:7601) (name:WIN-RHDA4UK6PF6) (workgroup:WORKGROUP)
+[*] Scanned 4 of 4 hosts (100% complete)
 [*] Auxiliary module execution completed
-```
-
-## Confirmation with nmap
-
-There are several scripts that attempt to validate OS information through SMB.  The most equivalent is [smb-os-discovery](https://nmap.org/nsedoc/scripts/smb-os-discovery.html).
-
-```
-nmap --script smb-os-discovery.nse -p445 10.9.7.7,35,91,108,119,127,164,175,232
-
-Starting Nmap 7.40 ( https://nmap.org ) at 2017-05-19 14:12 EDT
-Nmap scan report for WIN-O712LQK2K69 (10.9.7.7)
-Host is up (0.0025s latency).
-PORT    STATE SERVICE
-445/tcp open  microsoft-ds
-MAC Address: 00:0C:29:28:DD:A0 (VMware)
-
-Host script results:
-| smb-os-discovery: 
-|   OS: Windows Server 2008 R2 Standard 7600 (Windows Server 2008 R2 Standard 6.1)
-|   OS CPE: cpe:/o:microsoft:windows_server_2008::-
-|   Computer name: WIN-O712LQK2K69
-|   NetBIOS computer name: WIN-O712LQK2K69\x00
-|   Workgroup: WORKGROUP\x00
-|_  System time: 2017-05-19T11:12:15-07:00
-
-Nmap scan report for 10.9.7.35
-Host is up (0.0018s latency).
-PORT    STATE SERVICE
-445/tcp open  microsoft-ds
-MAC Address: 00:0C:29:59:D4:F7 (VMware)
-
-Host script results:
-| smb-os-discovery: 
-|   OS: Unix (Samba 3.0.20-Debian)
-|   NetBIOS computer name: 
-|   Workgroup: WORKGROUP\x00
-|_  System time: 2017-05-19T14:33:31-04:00
-
-Nmap scan report for IE11Win8_1 (10.9.7.91)
-Host is up (0.0020s latency).
-PORT    STATE SERVICE
-445/tcp open  microsoft-ds
-MAC Address: 00:0C:29:E0:CF:FB (VMware)
-
-Host script results:
-| smb-os-discovery: 
-|   OS: Windows 8.1 Enterprise Evaluation 9600 (Windows 8.1 Enterprise Evaluation 6.3)
-|   OS CPE: cpe:/o:microsoft:windows_8.1::-
-|   NetBIOS computer name: IE11WIN8_1\x00
-|   Workgroup: WORKGROUP\x00
-|_  System time: 2017-05-19T11:04:48-07:00
-
-Nmap scan report for winxp (10.9.7.108)
-Host is up (0.0018s latency).
-PORT    STATE SERVICE
-445/tcp open  microsoft-ds
-MAC Address: 00:0C:29:D6:24:67 (VMware)
-
-Host script results:
-| smb-os-discovery: 
-|   OS: Windows XP (Windows 2000 LAN Manager)
-|   OS CPE: cpe:/o:microsoft:windows_xp::-
-|   Computer name: winxp
-|   NetBIOS computer name: WINXP\x00
-|   Workgroup: RAGEGROUP\x00
-|_  System time: 2017-05-19T14:12:29-04:00
-
-Nmap scan report for workNAS (10.9.7.119)
-Host is up (0.0024s latency).
-PORT    STATE SERVICE
-445/tcp open  microsoft-ds
-MAC Address: 00:11:32:10:FE:C4 (Synology Incorporated)
-
-Host script results:
-| smb-os-discovery: 
-|   OS: Windows 6.1 (Samba 4.4.9)
-|   Computer name: worknas
-|   NetBIOS computer name: WORKNAS\x00
-|   Domain name: \x00
-|   FQDN: worknas
-|_  System time: 2017-05-19T14:12:41-04:00
-
-Nmap scan report for win2k (10.9.7.127)
-Host is up (0.0025s latency).
-PORT    STATE SERVICE
-445/tcp open  microsoft-ds
-MAC Address: 00:0C:29:C8:97:2D (VMware)
-
-Host script results:
-| smb-os-discovery: 
-|   OS: Windows 2000 (Windows 2000 LAN Manager)
-|   OS CPE: cpe:/o:microsoft:windows_2000::-
-|   Computer name: win2k
-|   NetBIOS computer name: WIN2K\x00
-|   Workgroup: WORKGROUP\x00
-|_  System time: 2017-05-19T14:04:37-04:00
-
-Nmap scan report for IE11Win7 (10.9.7.232)
-Host is up (0.0019s latency).
-PORT    STATE SERVICE
-445/tcp open  microsoft-ds
-MAC Address: 00:0C:29:7D:29:4C (VMware)
-
-Host script results:
-| smb-os-discovery: 
-|   OS: Windows 7 Enterprise 7601 Service Pack 1 (Windows 7 Enterprise 6.1)
-|   OS CPE: cpe:/o:microsoft:windows_7::sp1
-|   Computer name: IE11Win7
-|   NetBIOS computer name: IE11WIN7\x00
-|   Workgroup: WORKGROUP\x00
-|_  System time: 2017-05-19T11:04:46-07:00
-
-Nmap done: 8 IP addresses (7 hosts up) scanned in 4.67 seconds
-
+msf5 auxiliary(scanner/smb/smb_version) > 
 ```

--- a/documentation/modules/auxiliary/scanner/smb/smb_version.md
+++ b/documentation/modules/auxiliary/scanner/smb/smb_version.md
@@ -39,30 +39,40 @@ identify the information about the host operating system.
 This is an example run of a network with several different version of Windows, metasploit 1 and 2, and a NAS device running SAMBA.
 
 ```
+msf5 auxiliary(scanner/smb/smb_version) > set RHOSTS 192.168.159.0/24
+RHOSTS => 192.168.159.0/24
 msf5 auxiliary(scanner/smb/smb_version) > show options 
 
 Module options (auxiliary/scanner/smb/smb_version):
 
-   Name       Current Setting           Required  Description
-   ----       ---------------           --------  -----------
-   RHOSTS     file:smb_servers.txt      yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
-   SMBDomain  .                         no        The Windows domain to use for authentication
-   SMBPass                              no        The password for the specified username
-   SMBUser                              no        The username to authenticate as
-   THREADS    5                         yes       The number of concurrent threads (max one per host)
+   Name     Current Setting   Required  Description
+   ----     ---------------   --------  -----------
+   RHOSTS   192.168.159.0/24  yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
+   THREADS  15                yes       The number of concurrent threads (max one per host)
 
 msf5 auxiliary(scanner/smb/smb_version) > run
 
-[*] 192.168.0.94:445      - SMB Detected (versions:2, 3) (preferred dialect:SMB 3.1.1) (compression capabilities:LZNT1) (encryption capabilities:AES-128-CCM) (signatures:optional) (guid:{a13d40f9-c789-44f6-b5b0-14d4bd633284})
-[*] 192.168.0.212:445     - SMB Detected (versions:1, 2, 3) (preferred dialect:SMB 3.0.2) (signatures:optional) (uptime:7w 6d 11h 52m) (guid:{9874f7e3-5178-4db9-af57-113adf0b67b9})
-[+] 192.168.0.212:445     -   Host is running Windows 2012 R2 Standard (build:9600) (name:WIN-R1FK95KGVJ5)
-[*] 192.168.0.107:445     - SMB Detected (versions:1, 2, 3) (preferred dialect:SMB 3.1.1) (compression capabilities:LZNT1) (encryption capabilities:AES-128-CCM) (signatures:optional) (uptime:7w 6d 11h 52m) (guid:{515c49bb-24c3-4092-825a-62afd6e1bd45})
-[+] 192.168.0.107:445     -   Host is running Windows 2016 Datacenter (build:14393) (name:EC2AMAZ-IO7R6NR)
-[*] Scanned 2 of 4 hosts (50% complete)
-[*] Scanned 3 of 4 hosts (75% complete)
-[*] 192.168.0.100:445     - SMB Detected (versions:1, 2) (preferred dialect:SMB 2.1) (signatures:optional) (uptime:7w 6d 12h 31m) (guid:{c21f4e2f-1e0a-4dd1-96a4-5dad6465a2ab})
-[+] 192.168.0.100:445     -   Host is running Windows 2008 R2 Datacenter SP1 (build:7601) (name:WIN-RHDA4UK6PF6) (workgroup:WORKGROUP)
-[*] Scanned 4 of 4 hosts (100% complete)
+[*] 192.168.159.10:445    - SMB Detected (versions:1, 2, 3) (preferred dialect:SMB 3.1.1) (compression capabilities:LZNT1) (encryption capabilities:AES-128-CCM) (signatures:required) (guid:{faf5534c-d125-4081-aa2a-cf3256415908}) (authentication domain:MSFLAB)
+[*] 192.168.159.10:445    -   Host could not be identified: Windows Server 2019 Standard 17763 (Windows Server 2019 Standard 6.3)
+[*] 192.168.159.30:445    - SMB Detected (versions:2, 3) (preferred dialect:SMB 3.1.1) (compression capabilities:LZNT1) (encryption capabilities:AES-128-CCM) (signatures:optional) (guid:{8f1ce8b7-e198-404e-89d6-a27297b1c3f2}) (authentication domain:DESKTOP-RTCRBEV)
+[*] 192.168.159.0/24:     - Scanned  30 of 256 hosts (11% complete)
+[*] 192.168.159.38:445    - SMB Detected (versions:2, 3) (preferred dialect:SMB 3.0.2) (signatures:optional) (uptime:4d 17h 33m 34s) (guid:{cd5d41db-0bb8-4954-9421-0cdd14b7c6f7}) (authentication domain:WIN-46IL3RC2FHI)
+[*] 192.168.159.31:445    - SMB Detected (versions:1, 2) (preferred dialect:SMB 2.1) (signatures:optional) (uptime:3m 6s) (guid:{caaee1a3-8f74-4dd0-b0eb-436d7abc8979}) (authentication domain:WIN-9NSI4A6AIHJ)
+[+] 192.168.159.31:445    -   Host is running Windows 7 Professional SP1 (build:7601) (name:WIN-9NSI4A6AIHJ) (workgroup:WORKGROUP)
+[*] 192.168.159.48:445    - SMB Detected (versions:1) (preferred dialect:) (signatures:optional)
+[+] 192.168.159.48:445    -   Host is running Windows XP SP2 (language:English) (name:SMCINTYR-81CC7C) (workgroup:WORKGROUP)
+[*] 192.168.159.0/24:     - Scanned  57 of 256 hosts (22% complete)
+[*] 192.168.159.0/24:     - Scanned  87 of 256 hosts (33% complete)
+[*] 192.168.159.0/24:     - Scanned 104 of 256 hosts (40% complete)
+[*] 192.168.159.128:445   - SMB Detected (versions:2, 3) (preferred dialect:SMB 3.1.1) (compression capabilities:LZ77) (encryption capabilities:AES-128-GCM) (signatures:optional) (guid:{61636f6c-686c-736f-7400-000000000000}) (authentication domain:LOCALHOST)
+[*] 192.168.159.129:445   - SMB Detected (versions:1, 2, 3) (preferred dialect:SMB 3.1.1) (compression capabilities:LZNT1) (encryption capabilities:AES-128-CCM) (signatures:optional) (guid:{19147a6c-08c1-4e9c-b6c5-1119e2c57e6a}) (authentication domain:DESKTOP-R9TM84E)
+[+] 192.168.159.129:445   -   Host is running Windows 10 Enterprise (build:17763) (name:DESKTOP-R9TM84E) (workgroup:WORKGROUP)
+[*] 192.168.159.0/24:     - Scanned 137 of 256 hosts (53% complete)
+[*] 192.168.159.0/24:     - Scanned 163 of 256 hosts (63% complete)
+[*] 192.168.159.0/24:     - Scanned 180 of 256 hosts (70% complete)
+[*] 192.168.159.0/24:     - Scanned 205 of 256 hosts (80% complete)
+[*] 192.168.159.0/24:     - Scanned 234 of 256 hosts (91% complete)
+[*] 192.168.159.0/24:     - Scanned 256 of 256 hosts (100% complete)
 [*] Auxiliary module execution completed
 msf5 auxiliary(scanner/smb/smb_version) > 
 ```

--- a/documentation/modules/auxiliary/scanner/smb/smb_version.md
+++ b/documentation/modules/auxiliary/scanner/smb/smb_version.md
@@ -16,6 +16,7 @@ identify the information about the host operating system.
     * Requires versions: 2+
 1. Capabilities: The supported encryption and compression algorithms that the server supports.
     * Requires versions: 3+
+1. Authentication Domain: The domain that the server prompts the user to authenticate to when attempting to login.
 
 ### Host Operating System Information
 

--- a/lib/msf/core/module/deprecated.rb
+++ b/lib/msf/core/module/deprecated.rb
@@ -6,21 +6,29 @@ module Msf::Module::Deprecated
   module ClassMethods
     attr_accessor :deprecation_date
     attr_accessor :deprecated_names
+    attr_accessor :deprecation_reason
 
     # Mark this module as deprecated
     #
     # Any time this module is run it will print warnings to that effect.
     #
-    # @param deprecation_date [Date,#to_s] The date on which this module will
+    # @param date [Date,#to_s] The date on which this module will
     #   be removed
+    # @param reason [String] A description reason for this module being deprecated
     # @return [void]
-    def deprecated(date)
+    def deprecated(date, reason = nil)
       self.deprecation_date = date
+      self.deprecation_reason = reason
 
       # NOTE: fullname isn't set until a module has been added to a set, which is after it is evaluated
       add_warning do
-        [ "*%red" + "The module #{fullname} is deprecated!".center(88) + "%clr*",
-          "*" + "This module will be removed on or about #{self.class.deprecation_date}".center(88) + "*" ]
+        details = [
+          "*%red" + "The module #{fullname} is deprecated!".center(88) + "%clr*",
+          "*" + "This module will be removed on or about #{date}".center(88) + "*"
+        ]
+        details << "*#{reason.center(88)}*" if reason.present?
+
+        details
       end
     end
 

--- a/modules/auxiliary/scanner/smb/smb1.rb
+++ b/modules/auxiliary/scanner/smb/smb1.rb
@@ -11,6 +11,9 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Scanner
   include Msf::Auxiliary::Report
 
+  include Msf::Module::Deprecated
+  deprecated(Date.new(2020, 10, 6))
+
   # Aliases for common classes
   SIMPLE = Rex::Proto::SMB::SimpleClient
   XCEPT  = Rex::Proto::SMB::Exceptions

--- a/modules/auxiliary/scanner/smb/smb1.rb
+++ b/modules/auxiliary/scanner/smb/smb1.rb
@@ -12,7 +12,10 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Report
 
   include Msf::Module::Deprecated
-  deprecated(Date.new(2020, 10, 6))
+  deprecated(
+    Date.new(2020, 10, 6),
+    reason = 'Use auxiliary/scanner/smb/smb_version for SMB version detection'
+  )
 
   # Aliases for common classes
   SIMPLE = Rex::Proto::SMB::SimpleClient

--- a/modules/auxiliary/scanner/smb/smb2.rb
+++ b/modules/auxiliary/scanner/smb/smb2.rb
@@ -13,7 +13,10 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Report
 
   include Msf::Module::Deprecated
-  deprecated(Date.new(2020, 10, 6))
+  deprecated(
+    Date.new(2020, 10, 6),
+    reason = 'Use auxiliary/scanner/smb/smb_version for SMB version detection'
+  )
 
   # Aliases for common classes
   SIMPLE = Rex::Proto::SMB::SimpleClient

--- a/modules/auxiliary/scanner/smb/smb2.rb
+++ b/modules/auxiliary/scanner/smb/smb2.rb
@@ -12,6 +12,9 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Scanner
   include Msf::Auxiliary::Report
 
+  include Msf::Module::Deprecated
+  deprecated(Date.new(2020, 10, 6))
+
   # Aliases for common classes
   SIMPLE = Rex::Proto::SMB::SimpleClient
   XCEPT  = Rex::Proto::SMB::Exceptions

--- a/modules/auxiliary/scanner/smb/smb_version.rb
+++ b/modules/auxiliary/scanner/smb/smb_version.rb
@@ -79,7 +79,7 @@ class MetasploitModule < Msf::Auxiliary
         protocol = simple.client.negotiate
       rescue Rex::Proto::SMB::Exceptions::Error, RubySMB::Error::RubySMBError
         break
-      rescue
+      rescue Errno::ECONNRESET
         break
       rescue ::Exception => e # rubocop:disable Lint/RescueException
         vprint_error("#{rhost}: #{e.class} #{e}")

--- a/modules/auxiliary/scanner/smb/smb_version.rb
+++ b/modules/auxiliary/scanner/smb/smb_version.rb
@@ -105,9 +105,14 @@ class MetasploitModule < Msf::Auxiliary
         end
         info[:server_guid] = simple.client.server_guid
 
-        if info[:auth_domain].nil?
-          simple.client.authenticate
-          info[:auth_domain] = simple.client.default_domain
+        unless info.key? :auth_domain
+          begin
+            simple.client.authenticate
+          rescue RubySMB::RubySMBError
+            info[:auth_domain] = nil
+          else
+            info[:auth_domain] = simple.client.default_domain
+          end
         end
       end
 

--- a/modules/auxiliary/scanner/smb/smb_version.rb
+++ b/modules/auxiliary/scanner/smb/smb_version.rb
@@ -104,6 +104,11 @@ class MetasploitModule < Msf::Auxiliary
           info[:uptime] = seconds_to_timespan(uptime)
         end
         info[:server_guid] = simple.client.server_guid
+
+        if info[:auth_domain].nil?
+          simple.client.authenticate
+          info[:auth_domain] = simple.client.default_domain
+        end
       end
 
       info[:preferred_dialect] = preferred_dialect
@@ -193,6 +198,7 @@ class MetasploitModule < Msf::Auxiliary
         end
         desc << " (uptime:#{info[:uptime]})" if info[:uptime]
         desc << " (guid:#{Rex::Text.to_guid(info[:server_guid])})" if info[:server_guid]
+        desc << " (authentication domain:#{info[:auth_domain]})" if info[:auth_domain]
         lines << { type: :status, message: desc }
 
         #

--- a/modules/auxiliary/scanner/smb/smb_version.rb
+++ b/modules/auxiliary/scanner/smb/smb_version.rb
@@ -7,7 +7,6 @@ require 'recog'
 
 class MetasploitModule < Msf::Auxiliary
 
-
   # Exploit mixins should be called first
   include Msf::Exploit::Remote::DCERPC
   include Msf::Exploit::Remote::SMB::Client
@@ -17,11 +16,20 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Scanner
   include Msf::Auxiliary::Report
 
+  SMB2_DIALECT_STRINGS = {
+    '0x0202' => 'SMB 2.0.2',
+    '0x0210' => 'SMB 2.1',
+    '0x0300' => 'SMB 3.0',
+    '0x0302' => 'SMB 3.0.2',
+    '0x0311' => 'SMB 3.1.1',
+    '0x02ff' => 'SMB 2.???'
+  }
+
   def initialize
     super(
       'Name'        => 'SMB Version Detection',
       'Description' => 'Display version information about each system',
-      'Author'      => 'hdm',
+      'Author'      => ['hdm', 'Spencer McIntyre'],
       'License'     => MSF_LICENSE
     )
 
@@ -39,6 +47,80 @@ class MetasploitModule < Msf::Auxiliary
     (@smb_port == 445)
   end
 
+  def smb_versions
+    preferred_dialect = nil
+    supported = []
+    (1..3).each do |version|
+      begin
+        simple = connect(false, versions: [version])
+        protocol = simple.client.negotiate
+      rescue Rex::Proto::SMB::Exceptions::Error, RubySMB::Error::RubySMBError
+        next
+      rescue Errno::ECONNRESET
+        next
+      rescue ::Exception => e
+        vprint_error("#{rhost}: #{e.class} #{e}")
+        next
+      end
+
+      preferred_dialect = simple.client.dialect
+      if simple.client.is_a? RubySMB::Client
+        preferred_dialect = SMB2_DIALECT_STRINGS[preferred_dialect]
+      end
+
+      supported << version unless protocol.nil?
+    end
+
+    # assume that if the server supports multiple versions, the preferred
+    # dialect will correspond to the latest version
+    {versions: supported, preferred_dialect: preferred_dialect}
+  end
+
+  def smb_description(res, nd_smb_fingerprint)
+    #
+    # Create the note hash for fingerprint.match
+    #
+    nd_fingerprint_match = { }
+
+    #
+    # Create a descriptive string for service.info
+    #
+    desc = res['os'].dup
+
+    if res['edition'].to_s.length > 0
+      desc << " #{res['edition']}"
+      nd_smb_fingerprint[:os_edition] = res['edition']
+      nd_fingerprint_match['os.edition'] = res['edition']
+    end
+
+    if res['sp'].to_s.length > 0
+      desc << " #{res['sp'].downcase.gsub('service pack ', 'SP')}"
+      nd_smb_fingerprint[:os_sp] = res['sp']
+      nd_fingerprint_match['os.version'] = res['sp']
+    end
+
+    if res['build'].to_s.length > 0
+      desc << " (build:#{res['build']})"
+      nd_smb_fingerprint[:os_build] = res['build']
+      nd_fingerprint_match['os.build'] = res['build']
+    end
+
+    if res['lang'].to_s.length > 0 and res['lang'] != 'Unknown'
+      desc << " (language:#{res['lang']})"
+      nd_smb_fingerprint[:os_lang] = res['lang']
+      nd_fingerprint_match['os.language'] = nd_smb_fingerprint[:os_lang]
+    end
+
+    if simple.client.default_name
+      desc << " (name:#{simple.client.default_name})"
+      nd_smb_fingerprint[:SMBName] = simple.client.default_name
+      nd_fingerprint_match['host.name'] = nd_smb_fingerprint[:SMBName]
+    end
+
+    {text: desc, fingerprint_match: nd_fingerprint_match, smb_fingerprint: nd_smb_fingerprint}
+  end
+
+  #
   # Fingerprint a single host
   #
   def run_host(ip)
@@ -47,109 +129,17 @@ class MetasploitModule < Msf::Auxiliary
       @smb_port = pnum
       self.simple = nil
 
-    begin
-      res = smb_fingerprint()
+      begin
+        res = smb_fingerprint()
 
-      #
-      # Create the note hash for smb.fingerprint
-      #
-      conf = {
-         :native_os => res['native_os'],
-         :native_lm => res['native_lm']
-      }
-
-      if res['os'] and res['os'] != 'Unknown'
-
-        #
-        # Create the note hash for fingerprint.match
-        #
-        match_conf = { }
-
-        #
-        # Create a descriptive string for service.info
-        #
-        desc = res['os'].dup
-
-        if res['edition'].to_s.length > 0
-          desc << " #{res['edition']}"
-          conf[:os_edition] = res['edition']
-          match_conf['os.edition'] = res['edition']
-        end
-
-        if res['sp'].to_s.length > 0
-          desc << " #{res['sp'].downcase.gsub('service pack ', 'SP')}"
-          conf[:os_sp] = res['sp']
-          match_conf['os.version'] = res['sp']
-        end
-
-        if res['build'].to_s.length > 0
-          desc << " (build:#{res['build']})"
-          conf[:os_build] = res['build']
-          match_conf['os.build'] = res['build']
-        end
-
-        if res['lang'].to_s.length > 0 and res['lang'] != 'Unknown'
-          desc << " (language:#{res['lang']})"
-          conf[:os_lang] = res['lang']
-          match_conf['os.language'] = conf[:os_lang]
-        end
-
-        if simple.client.default_name
-          desc << " (name:#{simple.client.default_name})"
-          conf[:SMBName] = simple.client.default_name
-          match_conf['host.name'] = conf[:SMBName]
-        end
-
-        if simple.client.default_domain
-          if simple.client.default_domain.encoding.name == "UTF-8"
-            desc << " (domain:#{simple.client.default_domain})"
-          else
-            # Workgroup names are in ANSI, but may contain invalid characters
-            # Go through each char and convert/check
-            temp_workgroup = simple.client.default_domain.dup
-            desc << " (workgroup:"
-            temp_workgroup.each_char do |i|
-              begin
-                desc << i.encode("UTF-8")
-              rescue Encoding::UndefinedConversionError => e
-                desc << '?'
-                print_error("Found incompatible (non-ANSI) character in Workgroup name. Replaced with '?'")
-              end
-            end
-            desc << " )"
-          end
-          conf[:SMBDomain] = simple.client.default_domain
-          match_conf['host.domain'] = conf[:SMBDomain]
-        end
+        version_info = smb_versions
+        #next unless versions.length
+        desc = "SMB Detected (versions:#{version_info[:versions].join(', ')}) (preferred dialect:#{version_info[:preferred_dialect]})"
 
         if simple.client.peer_require_signing
           desc << " (signatures:required)"
         else
           desc << " (signatures:optional)"
-        end
-
-        print_good("Host is running #{desc}")
-
-        # Report the service with a friendly banner
-        report_service(
-          :host  => ip,
-          :port  => rport,
-          :proto => 'tcp',
-          :name  => 'smb',
-          :info  => desc
-        )
-
-        # Report a fingerprint.match hash for name, domain, and language
-        # Ignore OS fields, as those are handled via smb.fingerprint
-        report_note(
-          :host  => ip,
-          :port  => rport,
-          :proto => 'tcp',
-          :ntype => 'fingerprint.match',
-          :data  => match_conf
-        )
-
-        unless simple.client.require_signing
           report_vuln({
             :host  => ip,
             :port  => rport,
@@ -161,45 +151,104 @@ class MetasploitModule < Msf::Auxiliary
             ]
           })
         end
-      else
-        desc = "#{res['native_os']} (#{res['native_lm']})"
-        report_service(:host => ip, :port => rport, :name => 'smb', :info => desc)
-        print_status("Host could not be identified: #{desc}")
-      end
+        print_status(desc)
 
-      # Report a smb.fingerprint hash of attributes for OS fingerprinting
-      report_note(
-        :host  => ip,
-        :port  => rport,
-        :proto => 'tcp',
-        :ntype => 'smb.fingerprint',
-        :data  => conf
-      )
+        #
+        # Create the note hash for smb.fingerprint
+        #
+        nd_smb_fingerprint = {
+           :native_os => res['native_os'],
+           :native_lm => res['native_lm']
+        }
 
-      disconnect
+        if res['os'] && res['os'] != 'Unknown'
+          description = smb_description(res, nd_smb_fingerprint)
+          desc = description[:text]
+          nd_fingerprint_match = description[:fingerprint_match]
+          nd_smb_fingerprint = description[:smb_fingerprint]
 
-      break
+          if simple.client.default_domain
+            if simple.client.default_domain.encoding.name == "UTF-8"
+              desc << " (domain:#{simple.client.default_domain})"
+            else
+              # Workgroup names are in ANSI, but may contain invalid characters
+              # Go through each char and convert/check
+              temp_workgroup = simple.client.default_domain.dup
+              desc << " (workgroup:"
+              temp_workgroup.each_char do |i|
+                begin
+                  desc << i.encode("UTF-8")
+                rescue Encoding::UndefinedConversionError => e
+                  desc << '?'
+                  vprint_error("Found incompatible (non-ANSI) character in Workgroup name. Replaced with '?'")
+                end
+              end
+              desc << ")"
+            end
+            nd_smb_fingerprint[:SMBDomain] = simple.client.default_domain
+            nd_fingerprint_match['host.domain'] = nd_smb_fingerprint[:SMBDomain]
+          end
 
-    rescue ::Rex::Proto::SMB::Exceptions::NoReply => e
-      next
-    rescue ::Rex::Proto::SMB::Exceptions::ErrorCode  => e
-      next
-    rescue ::Rex::Proto::SMB::Exceptions::LoginError => e
-      # Vista has 139 open but doesnt like *SMBSERVER
-      if(e.to_s =~ /server refused our NetBIOS/)
+          print_good("  Host is running #{desc}")
+
+          # Report the service with a friendly banner
+          report_service(
+            :host  => ip,
+            :port  => rport,
+            :proto => 'tcp',
+            :name  => 'smb',
+            :info  => desc
+          )
+
+          # Report a fingerprint.match hash for name, domain, and language
+          # Ignore OS fields, as those are handled via smb.fingerprint
+          report_note(
+            :host  => ip,
+            :port  => rport,
+            :proto => 'tcp',
+            :ntype => 'fingerprint.match',
+            :data  => nd_fingerprint_match
+          )
+        else
+          desc = ''
+          if res['native_os'] || res['native_lm']
+            desc = "#{res['native_os']} (#{res['native_lm']})"
+            report_service(:host => ip, :port => rport, :name => 'smb', :info => desc)
+            desc = ': ' + desc
+          end
+          print_status("  Host could not be identified#{desc}")
+        end
+
+        # Report a smb.fingerprint hash of attributes for OS fingerprinting
+        report_note(
+          :host  => ip,
+          :port  => rport,
+          :proto => 'tcp',
+          :ntype => 'smb.fingerprint',
+          :data  => nd_smb_fingerprint
+        )
+
+        disconnect
+
+        break
+
+      rescue ::Rex::Proto::SMB::Exceptions::NoReply => e
         next
+      rescue ::Rex::Proto::SMB::Exceptions::ErrorCode  => e
+        next
+      rescue ::Rex::Proto::SMB::Exceptions::LoginError => e
+        # Vista has 139 open but doesnt like *SMBSERVER
+        next if e.to_s =~ /server refused our NetBIOS/
+        return
+      rescue ::Timeout::Error
+      rescue ::Rex::ConnectionError
+        next
+
+      rescue ::Exception => e
+        print_error("#{rhost}: #{e.class} #{e}")
+      ensure
+        disconnect
       end
-
-      return
-    rescue ::Timeout::Error
-    rescue ::Rex::ConnectionError
-      next
-
-    rescue ::Exception => e
-      print_error("#{rhost}: #{e.class} #{e}")
-    ensure
-      disconnect
-    end
     end
   end
 end

--- a/modules/exploits/windows/smb/psexec_psh.rb
+++ b/modules/exploits/windows/smb/psexec_psh.rb
@@ -14,6 +14,12 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::SMB::Client::Psexec
   include Msf::Exploit::Powershell
 
+  include Msf::Module::Deprecated
+  deprecated(
+    Date.new(2020, 9, 16),
+    reason = "Use exploit/windows/smb/psexec and the 'PowerShell' target"
+  )
+
   def initialize(info = {})
     super(update_info(info,
       'Name'             => 'Microsoft Windows Authenticated Powershell Command Execution',


### PR DESCRIPTION
This modules updates the `auxiliary/scanner/smb/smb_version` module with a few new features. Prior to this, it would identify host OS information when the remote host supported SMBv1. These changes will continue to identify host OS information when that's the case, but will also fingerprint SMB qualities including:

* All supported SMB versions
* The preferred dialect of SMB
* SMB 3.1.1 encryption and compression capabilities
* The server's GUID value
* How long the server has been online
    * This keeps the functionality around from the old smb2 module.

Since we can now detect all versions of SMB, the smb1 and smb2 modules are deprecated. These modules were used to identify SMB servers of their respective versions. The smb2 module would also print how long the server had been online.

## Verification

List the steps needed to make sure this thing works

- [ ] Agree that October 6th, 2020, is a sufficient date for deprecating the smb1 and smb2 modules
- [ ] Start `msfconsole`
- [ ] `use auxiliary/scanner/smb/smb_version`
- [ ] Read the docs with `info -d` and ensure they make sense
- [ ] Run the module on a variety of SMB servers, see useful results
- [ ] See that results are still added to the database

## Demonstration

```
msf5 auxiliary(scanner/smb/smb_version) > show options 

Module options (auxiliary/scanner/smb/smb_version):

   Name     Current Setting                    Required  Description
   ----     ---------------                    --------  -----------
   RHOSTS   192.168.159.0/24 192.168.250.0/26  yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
   THREADS  15                                 yes       The number of concurrent threads (max one per host)

msf5 auxiliary(scanner/smb/smb_version) > run

[*] 192.168.159.10:445    - SMB Detected (versions:2, 3) (preferred dialect:SMB 3.1.1) (compression capabilities:LZNT1) (encryption capabilities:AES-128-CCM) (signatures:optional) (guid:{93525f47-f2fb-4299-874d-f764ed353fac})
[*] 192.168.159.38:445    - SMB Detected (versions:1, 2, 3) (preferred dialect:SMB 3.0.2) (signatures:optional) (uptime:1d 20h 34m) (guid:{a5133e68-c2d5-440c-a30c-462857fe5435})
[+] 192.168.159.38:445    -   Host is running Windows 8.1 (build:9600) (name:WIN-46IL3RC2FHI) (workgroup:WORKGROUP)
[*] 192.168.159.31:445    - SMB Detected (versions:1, 2) (preferred dialect:SMB 2.1) (signatures:optional) (uptime:1d 6h 53m) (guid:{8be70c30-f4ce-4f04-84a5-b9a3c539e54c})
[+] 192.168.159.31:445    -   Host is running Windows 7 Professional SP1 (build:7601) (name:WIN-9NSI4A6AIHJ) (workgroup:WORKGROUP)
[*] Scanned  32 of 320 hosts (10% complete)
[*] 192.168.159.48:445    - SMB Detected (versions:1) (preferred dialect:NT LM 0.12) (signatures:optional)
[+] 192.168.159.48:445    -   Host is running Windows XP SP2 (language:English) (name:SMCINTYR-81CC7C) (workgroup:WORKGROUP)
[*] Scanned  67 of 320 hosts (20% complete)
[*] Scanned  97 of 320 hosts (30% complete)
[*] 192.168.159.128:445   - SMB Detected (versions:2, 3) (preferred dialect:SMB 3.1.1) (compression capabilities:LZ77) (encryption capabilities:AES-128-GCM) (signatures:optional) (guid:{61636f6c-686c-736f-7400-000000000000})
[*] 192.168.159.129:445   - SMB Detected (versions:1, 2, 3) (preferred dialect:SMB 3.1.1) (compression capabilities:LZNT1) (encryption capabilities:AES-128-CCM) (signatures:optional) (guid:{d966a509-b40b-4729-b037-58446f417061})
[+] 192.168.159.129:445   -   Host is running Windows 10 Enterprise (build:17763) (name:DESKTOP-R9TM84E) (workgroup:WORKGROUP)
[*] Scanned 135 of 320 hosts (42% complete)
[*] Scanned 160 of 320 hosts (50% complete)
[*] Scanned 194 of 320 hosts (60% complete)
[*] Scanned 225 of 320 hosts (70% complete)
[*] Scanned 261 of 320 hosts (81% complete)
[*] 192.168.250.5:445     - SMB Detected (versions:2, 3) (preferred dialect:SMB 3.1.1) (compression capabilities:LZNT1) (encryption capabilities:AES-128-CCM) (signatures:optional) (guid:{0073616e-0000-0000-0000-000000000000})
[*] Scanned 289 of 320 hosts (90% complete)
[*] Scanned 320 of 320 hosts (100% complete)
[*] Auxiliary module execution completed
```