### PR TITLE
Adding an option to specify a target URL

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,8 @@ source 'https://rubygems.org'
 gemspec name: 'metasploit-framework'
 
 gem 'sqlite3', '~>1.3.0'
+# gem 'rex-text', path: '../rex-text'
+gem 'rex-text', git: 'https://github.com/adfoster-r7/rex-text', branch: 'add-word-wrapping-to-rex-tables'
 
 # separate from test as simplecov is not run on travis-ci
 group :coverage do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,10 @@
+GIT
+  remote: https://github.com/adfoster-r7/rex-text
+  revision: f7990ab39b8a347b0a16d2db9c52ea227b332457
+  branch: add-word-wrapping-to-rex-tables
+  specs:
+    rex-text (0.2.27)
+
 PATH
   remote: .
   specs:
@@ -347,7 +354,6 @@ GEM
       rex-socket
       rex-text
     rex-struct2 (0.1.2)
-    rex-text (0.2.26)
     rex-zip (0.1.3)
       rex-text
     rexml (3.2.4)
@@ -448,6 +454,7 @@ DEPENDENCIES
   pry-byebug
   rake
   redcarpet
+  rex-text!
   rspec-rails
   rspec-rerun
   rubocop (= 0.86.0)

--- a/lib/msf/core.rb
+++ b/lib/msf/core.rb
@@ -41,6 +41,7 @@ require 'msf/events'
 
 # Framework context and core classes
 require 'msf/core/framework'
+require 'msf/core/feature_manager'
 require 'msf/core/db_manager'
 require 'msf/core/event_dispatcher'
 require 'msf/core/module_manager'

--- a/lib/msf/core/data_store.rb
+++ b/lib/msf/core/data_store.rb
@@ -43,14 +43,23 @@ class DataStore < Hash
       end
     end
 
-    super(k,v)
+    if v.is_a? Hash
+      v.each { |key, value| self[key] = value }
+    else
+      super(k,v)
+    end
   end
 
   #
   # Case-insensitive wrapper around hash lookup
   #
   def [](k)
-    super(find_key_case(k))
+    k = find_key_case(k)
+    if options[k].respond_to? :calculate_value
+      options[k].calculate_value(self)
+    else
+      super(k)
+    end
   end
 
   #

--- a/lib/msf/core/exploit/http/client.rb
+++ b/lib/msf/core/exploit/http/client.rb
@@ -22,7 +22,6 @@ module Exploit::Remote::HttpClient
 
     register_options(
       [
-        Opt::RHOST_URL,
         Opt::RHOST,
         Opt::RPORT(80),
         OptString.new('VHOST', [ false, "HTTP server virtual host" ]),
@@ -30,6 +29,10 @@ module Exploit::Remote::HttpClient
         Opt::Proxies
       ], self.class
     )
+
+    # if framework.features.enabled?("RHOST_HTTP_URL")
+    #   register_options([OPT::RHOST_HTTP_URL])
+    # end
 
     register_advanced_options(
       [

--- a/lib/msf/core/exploit/http/client.rb
+++ b/lib/msf/core/exploit/http/client.rb
@@ -30,9 +30,9 @@ module Exploit::Remote::HttpClient
       ], self.class
     )
 
-    # if framework.features.enabled?("RHOST_HTTP_URL")
-    #   register_options([OPT::RHOST_HTTP_URL])
-    # end
+    if framework.features.enabled?("RHOST_HTTP_URL")
+      register_options([Opt::RHOST_HTTP_URL])
+    end
 
     register_advanced_options(
       [

--- a/lib/msf/core/exploit/http/client.rb
+++ b/lib/msf/core/exploit/http/client.rb
@@ -22,6 +22,7 @@ module Exploit::Remote::HttpClient
 
     register_options(
       [
+        Opt::RHOST_URL,
         Opt::RHOST,
         Opt::RPORT(80),
         OptString.new('VHOST', [ false, "HTTP server virtual host" ]),

--- a/lib/msf/core/feature_manager.rb
+++ b/lib/msf/core/feature_manager.rb
@@ -1,0 +1,68 @@
+# -*- coding: binary -*-
+# frozen_string_literal: true
+
+require 'msf/core/plugin'
+
+module Msf
+  ###
+  #
+  # The feature manager is responsible for managing feature flags that can change characteristics of framework.
+  #
+  ###
+  class FeatureManager
+
+    include Framework::Offspring
+
+    WRAPPED_TABLES = 'wrapped_tables'
+    DEFAULTS = [
+      {
+        name: 'wrapped_tables',
+        description: 'When enabled Metasploit will wordwrap all tables to fit into the available terminal width',
+        enabled: false
+      }.freeze
+    ].freeze
+
+    #
+    # Initializes the feature manager.
+    #
+    def initialize(framework)
+      @framework = framework
+      @flag_lookup = DEFAULTS.each_with_object({}) do |feature, acc|
+        key = feature[:name]
+        acc[key] = feature.dup
+      end
+    end
+
+    def all
+      @flag_lookup.values
+    end
+
+    def enabled?(name)
+      return false unless @flag_lookup[name]
+
+      @flag_lookup[name][:enabled] == true
+    end
+
+    def exists?(name)
+      @flag_lookup.key?(name)
+    end
+
+    def names
+      all.map { |feature| feature[:name] }
+    end
+
+    def set(name, value)
+      return false unless @flag_lookup[name]
+
+      @flag_lookup[name][:enabled] = value
+
+      if name == WRAPPED_TABLES
+        if value
+          Rex::Text::Table.wrap_tables!
+        else
+          Rex::Text::Table.unwrap_tables!
+        end
+      end
+    end
+  end
+end

--- a/lib/msf/core/feature_manager.rb
+++ b/lib/msf/core/feature_manager.rb
@@ -7,26 +7,26 @@ module Msf
   ###
   #
   # The feature manager is responsible for managing feature flags that can change characteristics of framework.
-  #
+  # Each feature will have a default value. The user can choose to override this default value if they wish.
   ###
   class FeatureManager
 
-    include Framework::Offspring
+    include Singleton
 
+    CONFIG_KEY = 'framework/features'
     WRAPPED_TABLES = 'wrapped_tables'
     DEFAULTS = [
       {
         name: 'wrapped_tables',
         description: 'When enabled Metasploit will wordwrap all tables to fit into the available terminal width',
-        enabled: false
+        default_value: false
       }.freeze
     ].freeze
 
     #
     # Initializes the feature manager.
     #
-    def initialize(framework)
-      @framework = framework
+    def initialize
       @flag_lookup = DEFAULTS.each_with_object({}) do |feature, acc|
         key = feature[:name]
         acc[key] = feature.dup
@@ -34,13 +34,16 @@ module Msf
     end
 
     def all
-      @flag_lookup.values
+      @flag_lookup.values.map do |feature|
+        feature.slice(:name, :description).merge(enabled: enabled?(feature[:name]))
+      end
     end
 
     def enabled?(name)
       return false unless @flag_lookup[name]
 
-      @flag_lookup[name][:enabled] == true
+      feature = @flag_lookup[name]
+      feature.key?(:user_preference) ? feature[:user_preference] : feature[:default_value]
     end
 
     def exists?(name)
@@ -54,7 +57,7 @@ module Msf
     def set(name, value)
       return false unless @flag_lookup[name]
 
-      @flag_lookup[name][:enabled] = value
+      @flag_lookup[name][:user_preference] = value
 
       if name == WRAPPED_TABLES
         if value
@@ -63,6 +66,26 @@ module Msf
           Rex::Text::Table.unwrap_tables!
         end
       end
+    end
+
+    def load_config
+      conf = Msf::Config.load
+      conf.fetch(CONFIG_KEY, {}).each do |name, value|
+        set(name, value == 'true')
+      end
+    end
+
+    def save_config
+      # Note, we intentionally omit features that have not explicitly been set by the user.
+      config = Msf::Config.load
+      old_config = config.fetch(CONFIG_KEY, {})
+      new_config = @flag_lookup.values.each_with_object(old_config) do |feature, config|
+        next unless feature.key?(:user_preference)
+
+        config.merge!(feature[:name] => feature[:user_preference].to_s)
+      end
+
+      Msf::Config.save(CONFIG_KEY => new_config)
     end
   end
 end

--- a/lib/msf/core/feature_manager.rb
+++ b/lib/msf/core/feature_manager.rb
@@ -20,6 +20,11 @@ module Msf
         name: 'wrapped_tables',
         description: 'When enabled Metasploit will wordwrap all tables to fit into the available terminal width',
         default_value: false
+      }.freeze,
+      {
+        name: 'RHOST_HTTP_URL',
+        description: 'When enabled in supported modules you can specify a URL as a target',
+        default_value: false
       }.freeze
     ].freeze
 

--- a/lib/msf/core/framework.rb
+++ b/lib/msf/core/framework.rb
@@ -81,7 +81,7 @@ class Framework
     self.analyze   = Analyze.new(self)
     self.plugins   = PluginManager.new(self)
     self.browser_profiles = Hash.new
-    self.features = FeatureManager.new(self)
+    self.features = FeatureManager.instance
 
     # Configure the thread factory
     Rex::ThreadFactory.provider = Metasploit::Framework::ThreadFactoryProvider.new(framework: self)

--- a/lib/msf/core/framework.rb
+++ b/lib/msf/core/framework.rb
@@ -81,6 +81,7 @@ class Framework
     self.analyze   = Analyze.new(self)
     self.plugins   = PluginManager.new(self)
     self.browser_profiles = Hash.new
+    self.features = FeatureManager.new(self)
 
     # Configure the thread factory
     Rex::ThreadFactory.provider = Metasploit::Framework::ThreadFactoryProvider.new(framework: self)
@@ -195,6 +196,11 @@ class Framework
   # framework objects to offer related objects/actions available.
   #
   attr_reader   :analyze
+  #
+  # The framework instance's feature manager. The feature manager is responsible
+  # for configuring feature flags that can change characteristics of framework.
+  #
+  attr_reader   :features
 
   #
   # The framework instance's dependency
@@ -277,6 +283,7 @@ protected
   attr_writer   :db # :nodoc:
   attr_writer   :browser_profiles # :nodoc:
   attr_writer   :analyze # :nodoc:
+  attr_writer   :features # :nodoc:
 
   private
 

--- a/lib/msf/core/opt.rb
+++ b/lib/msf/core/opt.rb
@@ -63,7 +63,7 @@ module Msf
     end
 
     def self.RHOST_URL(default=nil, required=false, desc="The target URL, only applicable if there is a single URL")
-      Msf::OptRhostURL.new(__method__.to_s, [required, desc, default ])
+      Msf::OptHTTPRhostURL.new(__method__.to_s, [required, desc, default ])
     end
 
     def self.stager_retry_options

--- a/lib/msf/core/opt.rb
+++ b/lib/msf/core/opt.rb
@@ -62,6 +62,10 @@ module Msf
       )
     end
 
+    def self.RHOST_URL(default=nil, required=false, desc="The target URL, only applicable if there is a single URL")
+      Msf::OptRhostUrl.new(__method__.to_s, [ required, desc, default ])
+    end
+
     def self.stager_retry_options
       [
         OptInt.new('StagerRetryCount',
@@ -114,6 +118,7 @@ module Msf
     Proxies = Proxies()
     RHOST = RHOST()
     RHOSTS = RHOSTS()
+    RHOST_URL = RHOST_URL()
     RPORT = RPORT()
     SSLVersion = SSLVersion()
   end

--- a/lib/msf/core/opt.rb
+++ b/lib/msf/core/opt.rb
@@ -63,7 +63,7 @@ module Msf
     end
 
     def self.RHOST_URL(default=nil, required=false, desc="The target URL, only applicable if there is a single URL")
-      Msf::OptRhostUrl.new(__method__.to_s, [ required, desc, default ])
+      Msf::OptRhostURL.new(__method__.to_s, [required, desc, default ])
     end
 
     def self.stager_retry_options

--- a/lib/msf/core/opt.rb
+++ b/lib/msf/core/opt.rb
@@ -14,92 +14,83 @@ module Msf
   #   register_advanced_options([Opt::Proxies])
   #
   module Opt
-
     # @return [OptAddress]
-    def self.CHOST(default=nil, required=false, desc="The local client address")
+    def self.CHOST(default = nil, required = false, desc = 'The local client address')
       Msf::OptAddress.new(__method__.to_s, [ required, desc, default ])
     end
 
     # @return [OptPort]
-    def self.CPORT(default=nil, required=false, desc="The local client port")
+    def self.CPORT(default = nil, required = false, desc = 'The local client port')
       Msf::OptPort.new(__method__.to_s, [ required, desc, default ])
     end
 
     # @return [OptAddressLocal]
-    def self.LHOST(default=nil, required=true, desc="The listen address (an interface may be specified)")
+    def self.LHOST(default = nil, required = true, desc = 'The listen address (an interface may be specified)')
       Msf::OptAddressLocal.new(__method__.to_s, [ required, desc, default ])
     end
 
     # @return [OptPort]
-    def self.LPORT(default=nil, required=true, desc="The listen port")
+    def self.LPORT(default = nil, required = true, desc = 'The listen port')
       Msf::OptPort.new(__method__.to_s, [ required, desc, default ])
     end
 
     # @return [OptString]
-    def self.Proxies(default=nil, required=false, desc="A proxy chain of format type:host:port[,type:host:port][...]")
+    def self.Proxies(default = nil, required = false, desc = 'A proxy chain of format type:host:port[,type:host:port][...]')
       Msf::OptString.new(__method__.to_s, [ required, desc, default ])
     end
 
     # @return [OptAddressRange]
-    def self.RHOSTS(default=nil, required=true, desc="The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'")
+    def self.RHOSTS(default = nil, required = true, desc = "The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'")
       Msf::OptAddressRange.new('RHOSTS', [ required, desc, default ])
     end
 
-    def self.RHOST(default=nil, required=true, desc="The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'")
+    def self.RHOST(default = nil, required = true, desc = "The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'")
       Msf::OptAddressRange.new('RHOSTS', [ required, desc, default ], aliases: [ 'RHOST' ])
     end
 
     # @return [OptPort]
-    def self.RPORT(default=nil, required=true, desc="The target port")
+    def self.RPORT(default = nil, required = true, desc = 'The target port')
       Msf::OptPort.new(__method__.to_s, [ required, desc, default ])
     end
 
     # @return [OptEnum]
     def self.SSLVersion
       Msf::OptEnum.new('SSLVersion',
-        'Specify the version of SSL/TLS to be used (Auto, TLS and SSL23 are auto-negotiate)',
-        enums: Rex::Socket::SslTcp.supported_ssl_methods
-      )
+                       'Specify the version of SSL/TLS to be used (Auto, TLS and SSL23 are auto-negotiate)',
+                       enums: Rex::Socket::SslTcp.supported_ssl_methods)
     end
 
-    def self.RHOST_URL(default=nil, required=false, desc="The target URL, only applicable if there is a single URL")
+    def self.RHOST_HTTP_URL(default = nil, required = false, desc = 'The target URL, only applicable if there is a single URL')
       Msf::OptHTTPRhostURL.new(__method__.to_s, [required, desc, default ])
     end
 
     def self.stager_retry_options
       [
         OptInt.new('StagerRetryCount',
-          'The number of times the stager should retry if the first connect fails',
-          default: 10,
-          aliases: ['ReverseConnectRetries']
-        ),
+                   'The number of times the stager should retry if the first connect fails',
+                   default: 10,
+                   aliases: ['ReverseConnectRetries']),
         OptInt.new('StagerRetryWait',
-          'Number of seconds to wait for the stager between reconnect attempts',
-          default: 5
-        )
+                   'Number of seconds to wait for the stager between reconnect attempts',
+                   default: 5)
       ]
     end
 
     def self.http_proxy_options
       [
         OptString.new('HttpProxyHost', 'An optional proxy server IP address or hostname',
-          aliases: ['PayloadProxyHost']
-        ),
+                      aliases: ['PayloadProxyHost']),
         OptPort.new('HttpProxyPort', 'An optional proxy server port',
-          aliases: ['PayloadProxyPort']
-        ),
+                    aliases: ['PayloadProxyPort']),
         OptString.new('HttpProxyUser', 'An optional proxy server username',
-          aliases: ['PayloadProxyUser'],
-          max_length: Rex::Payloads::Meterpreter::Config::PROXY_USER_SIZE - 1
-        ),
+                      aliases: ['PayloadProxyUser'],
+                      max_length: Rex::Payloads::Meterpreter::Config::PROXY_USER_SIZE - 1),
         OptString.new('HttpProxyPass', 'An optional proxy server password',
-          aliases: ['PayloadProxyPass'],
-          max_length: Rex::Payloads::Meterpreter::Config::PROXY_PASS_SIZE - 1
-        ),
+                      aliases: ['PayloadProxyPass'],
+                      max_length: Rex::Payloads::Meterpreter::Config::PROXY_PASS_SIZE - 1),
         OptEnum.new('HttpProxyType', 'The type of HTTP proxy',
-          enums: ['HTTP', 'SOCKS'],
-          aliases: ['PayloadProxyType']
-        )
+                    enums: ['HTTP', 'SOCKS'],
+                    aliases: ['PayloadProxyType'])
       ]
     end
 
@@ -118,7 +109,7 @@ module Msf
     Proxies = Proxies()
     RHOST = RHOST()
     RHOSTS = RHOSTS()
-    RHOST_URL = RHOST_URL()
+    RHOST_HTTP_URL = RHOST_HTTP_URL()
     RPORT = RPORT()
     SSLVersion = SSLVersion()
   end

--- a/lib/msf/core/opt_http_rhost_url.rb
+++ b/lib/msf/core/opt_http_rhost_url.rb
@@ -6,7 +6,7 @@ module Msf
   # RHOST URL option.
   #
   ###
-  class OptRhostURL < OptBase
+  class OptHTTPRhostURL < OptBase
     def type
       'rhost url'
     end
@@ -15,6 +15,8 @@ module Msf
       return unless value
 
       uri = get_uri(value)
+      return unless uri
+
       option_hash = {}
       # Blank this out since we don't know if this new value will have a `VHOST` to ensure we remove the old value
       option_hash['VHOST'] = nil
@@ -53,7 +55,8 @@ module Msf
           uri.path = (datastore['TARGETURI'] || datastore['URI'] || '/')
           uri.user = datastore['HttpUsername']
           uri.password = datastore['HttpPassword'] if uri.user
-          uri.to_s.delete_prefix('//')
+          uri.scheme = datastore['SSL'] ? "https" : "http"
+          uri
         rescue URI::InvalidComponentError
           nil
         end
@@ -63,10 +66,10 @@ module Msf
     protected
 
     def get_uri(value)
+        value = 'http://' + value unless value.start_with?(/https?:\/\//)
         URI(value)
       rescue URI::InvalidURIError
-        URI('//' + value)
+        nil
     end
-
   end
 end

--- a/lib/msf/core/opt_http_rhost_url.rb
+++ b/lib/msf/core/opt_http_rhost_url.rb
@@ -8,7 +8,7 @@ module Msf
   ###
   class OptHTTPRhostURL < OptBase
     def type
-      'rhost url'
+      'rhost http url'
     end
 
     def normalize(value)
@@ -49,13 +49,13 @@ module Msf
     def calculate_value(datastore)
       if datastore['RHOSTS']
         begin
-          uri = URI::Generic.build(host: datastore['RHOSTS'])
+          uri_type = datastore['SSL'] ? URI::HTTPS : URI::HTTP
+          uri = uri_type.build(host: datastore['RHOSTS'])
           uri.port = datastore['RPORT']
           # The datastore uses both `TARGETURI` and `URI` to denote the path of a URL, we try both here and fall back to `/`
           uri.path = (datastore['TARGETURI'] || datastore['URI'] || '/')
           uri.user = datastore['HttpUsername']
           uri.password = datastore['HttpPassword'] if uri.user
-          uri.scheme = datastore['SSL'] ? "https" : "http"
           uri
         rescue URI::InvalidComponentError
           nil
@@ -66,10 +66,10 @@ module Msf
     protected
 
     def get_uri(value)
-        value = 'http://' + value unless value.start_with?(/https?:\/\//)
-        URI(value)
-      rescue URI::InvalidURIError
-        nil
+      value = 'http://' + value unless value.start_with?(%r{https?://})
+      URI(value)
+    rescue URI::InvalidURIError
+      nil
     end
   end
 end

--- a/lib/msf/core/opt_http_rhost_url.rb
+++ b/lib/msf/core/opt_http_rhost_url.rb
@@ -48,19 +48,18 @@ module Msf
     end
 
     def calculate_value(datastore)
-      if datastore['RHOSTS']
-        begin
-          uri_type = datastore['SSL'] ? URI::HTTPS : URI::HTTP
-          uri = uri_type.build(host: datastore['RHOSTS'])
-          uri.port = datastore['RPORT']
-          # The datastore uses both `TARGETURI` and `URI` to denote the path of a URL, we try both here and fall back to `/`
-          uri.path = (datastore['TARGETURI'] || datastore['URI'] || '/')
-          uri.user = datastore['HttpUsername']
-          uri.password = datastore['HttpPassword'] if uri.user
-          uri
-        rescue URI::InvalidComponentError
-          nil
-        end
+      return unless datastore['RHOSTS']
+      begin
+        uri_type = datastore['SSL'] ? URI::HTTPS : URI::HTTP
+        uri = uri_type.build(host: datastore['RHOSTS'])
+        uri.port = datastore['RPORT']
+        # The datastore uses both `TARGETURI` and `URI` to denote the path of a URL, we try both here and fall back to `/`
+        uri.path = (datastore['TARGETURI'] || datastore['URI'] || '/')
+        uri.user = datastore['HttpUsername']
+        uri.password = datastore['HttpPassword'] if uri.user
+        uri
+      rescue URI::InvalidComponentError
+        nil
       end
     end
 

--- a/lib/msf/core/opt_raw.rb
+++ b/lib/msf/core/opt_raw.rb
@@ -28,7 +28,7 @@ class OptRaw < OptBase
     value
   end
 
-  def valid?(value=self.value)
+  def valid?(value=self.value, check_empty: true)
     value = normalize(value)
     return false if empty_required_value?(value)
     return super

--- a/lib/msf/core/opt_rhost_url.rb
+++ b/lib/msf/core/opt_rhost_url.rb
@@ -42,16 +42,18 @@ module Msf
     end
 
     def calculate_value(datastore)
-      begin
-        uri = URI::Generic.build(host: datastore['RHOSTS'])
-        uri.port=datastore['RPORT']
-        # The datastore uses both `TARGETURI` and `URI` to denote the path of a URL, we try both here and fall back to `/`
-        uri.path=(datastore['TARGETURI'] || datastore['URI'] || '/')
-        uri.user=datastore['HttpUsername']
-        uri.password=datastore['HttpPassword'] if uri.user
-        uri
-      rescue URI::InvalidComponentError
-        return nil
+      if datastore['RHOSTS']
+        begin
+          uri = URI::Generic.build(host: datastore['RHOSTS'])
+          uri.port=datastore['RPORT']
+          # The datastore uses both `TARGETURI` and `URI` to denote the path of a URL, we try both here and fall back to `/`
+          uri.path=(datastore['TARGETURI'] || datastore['URI'] || '/')
+          uri.user=datastore['HttpUsername']
+          uri.password=datastore['HttpPassword'] if uri.user
+          uri
+        rescue URI::InvalidComponentError
+          nil
+        end
       end
     end
 

--- a/lib/msf/core/opt_rhost_url.rb
+++ b/lib/msf/core/opt_rhost_url.rb
@@ -63,12 +63,9 @@ module Msf
     protected
 
     def get_uri(value)
-      begin
-        uri = URI(value)
+        URI(value)
       rescue URI::InvalidURIError
-        uri = URI('//' + value)
-      end
-      uri
+        URI('//' + value)
     end
 
   end

--- a/lib/msf/core/opt_rhost_url.rb
+++ b/lib/msf/core/opt_rhost_url.rb
@@ -23,8 +23,8 @@ module Msf
       option_hash['SSL'] = %w{ssl https}.include?(uri.scheme)
 
       # Both `TARGETURI` and `URI` are used as datastore options to denote the path on a uri
-      option_hash['TARGETURI'] = uri.path
-      option_hash['URI'] = uri.path
+      option_hash['TARGETURI'] = uri.path || '/'
+      option_hash['URI'] = uri.path || '/'
 
       if uri.scheme and %{http https}.include?(uri.scheme)
         option_hash['VHOST'] = uri.hostname unless Rex::Socket.is_ip_addr?(uri.hostname)
@@ -35,7 +35,8 @@ module Msf
       option_hash
     end
 
-    def valid?(value, check_empty: true)
+    def valid?(value, check_empty: false)
+      return true unless value
       uri = URI(value)
       return false unless uri.host != nil and uri.port != nil
       super
@@ -50,7 +51,7 @@ module Msf
           uri.path=(datastore['TARGETURI'] || datastore['URI'] || '/')
           uri.user=datastore['HttpUsername']
           uri.password=datastore['HttpPassword'] if uri.user
-          uri.to_s.delete_prefix('//')
+          uri
         rescue URI::InvalidComponentError
           nil
         end

--- a/lib/msf/core/opt_rhost_url.rb
+++ b/lib/msf/core/opt_rhost_url.rb
@@ -50,7 +50,7 @@ module Msf
           uri.path=(datastore['TARGETURI'] || datastore['URI'] || '/')
           uri.user=datastore['HttpUsername']
           uri.password=datastore['HttpPassword'] if uri.user
-          uri
+          uri.to_s.delete_prefix('//')
         rescue URI::InvalidComponentError
           nil
         end

--- a/lib/msf/core/opt_rhost_url.rb
+++ b/lib/msf/core/opt_rhost_url.rb
@@ -1,0 +1,59 @@
+# -*- coding: binary -*-
+
+module Msf
+  ###
+  #
+  # RHOST URL option.
+  #
+  ###
+  class OptRhostUrl < OptBase
+    def type
+      'rhost url'
+    end
+
+
+    def normalize(value)
+      uri = URI(value)
+      option_hash = {}
+      # Blank this out since we don't know if this new value will have a `VHOST` to ensure we remove the old value
+      option_hash['VHOST'] = nil
+
+      option_hash['RHOSTS'] = uri.hostname
+      option_hash['RPORT'] = uri.port
+      option_hash['SSL'] = %w{ssl https}.include?(uri.scheme)
+
+      # Both `TARGETURI` and `URI` are used as datastore options to denote the path on a uri
+      option_hash['TARGETURI'] = uri.path
+      option_hash['URI'] = uri.path
+
+      if uri.scheme and %{http https}.include?(uri.scheme)
+        option_hash['VHOST'] = uri.hostname unless Rex::Socket.is_ip_addr?(uri.hostname)
+        option_hash['HttpUsername'] = uri.user.to_s
+        option_hash['HttpPassword'] = uri.password.to_s
+      end
+
+      option_hash
+    end
+
+    def valid?(value, check_empty: true)
+      uri = URI(value)
+      return false unless uri.host != nil and uri.port != nil
+      super
+    end
+
+    def calculate_value(datastore)
+      begin
+        uri = URI::Generic.build(host: datastore['RHOSTS'])
+        uri.port=datastore['RPORT']
+        # The datastore uses both `TARGETURI` and `URI` to denote the path of a URL, we try both here and fall back to `/`
+        uri.path=(datastore['TARGETURI'] || datastore['URI'] || '/')
+        uri.user=datastore['HttpUsername']
+        uri.password=datastore['HttpPassword'] if uri.user
+        uri
+      rescue URI::InvalidComponentError
+        return nil
+      end
+    end
+
+  end
+end

--- a/lib/msf/core/opt_rhost_url.rb
+++ b/lib/msf/core/opt_rhost_url.rb
@@ -13,7 +13,9 @@ module Msf
 
 
     def normalize(value)
-      uri = URI(value)
+      return unless value
+
+      uri = get_uri(value)
       option_hash = {}
       # Blank this out since we don't know if this new value will have a `VHOST` to ensure we remove the old value
       option_hash['VHOST'] = nil
@@ -37,8 +39,8 @@ module Msf
 
     def valid?(value, check_empty: false)
       return true unless value
-      uri = URI(value)
-      return false unless uri.host != nil and uri.port != nil
+      uri = get_uri(value)
+      false unless uri.host != nil and uri.port != nil
       super
     end
 
@@ -51,11 +53,22 @@ module Msf
           uri.path=(datastore['TARGETURI'] || datastore['URI'] || '/')
           uri.user=datastore['HttpUsername']
           uri.password=datastore['HttpPassword'] if uri.user
-          uri
+          uri.to_s.delete_prefix('//')
         rescue URI::InvalidComponentError
           nil
         end
       end
+    end
+
+    protected
+
+    def get_uri(value)
+      begin
+        uri = URI(value)
+      rescue URI::InvalidURIError
+        uri = URI('//' + value)
+      end
+      uri
     end
 
   end

--- a/lib/msf/core/opt_rhost_url.rb
+++ b/lib/msf/core/opt_rhost_url.rb
@@ -6,11 +6,10 @@ module Msf
   # RHOST URL option.
   #
   ###
-  class OptRhostUrl < OptBase
+  class OptRhostURL < OptBase
     def type
       'rhost url'
     end
-
 
     def normalize(value)
       return unless value
@@ -22,13 +21,13 @@ module Msf
 
       option_hash['RHOSTS'] = uri.hostname
       option_hash['RPORT'] = uri.port
-      option_hash['SSL'] = %w{ssl https}.include?(uri.scheme)
+      option_hash['SSL'] = %w[ssl https].include?(uri.scheme)
 
       # Both `TARGETURI` and `URI` are used as datastore options to denote the path on a uri
       option_hash['TARGETURI'] = uri.path || '/'
       option_hash['URI'] = uri.path || '/'
 
-      if uri.scheme and %{http https}.include?(uri.scheme)
+      if uri.scheme && %(http https).include?(uri.scheme)
         option_hash['VHOST'] = uri.hostname unless Rex::Socket.is_ip_addr?(uri.hostname)
         option_hash['HttpUsername'] = uri.user.to_s
         option_hash['HttpPassword'] = uri.password.to_s
@@ -39,8 +38,9 @@ module Msf
 
     def valid?(value, check_empty: false)
       return true unless value
+
       uri = get_uri(value)
-      false unless uri.host != nil and uri.port != nil
+      false unless !uri.host.nil? && !uri.port.nil?
       super
     end
 
@@ -48,11 +48,11 @@ module Msf
       if datastore['RHOSTS']
         begin
           uri = URI::Generic.build(host: datastore['RHOSTS'])
-          uri.port=datastore['RPORT']
+          uri.port = datastore['RPORT']
           # The datastore uses both `TARGETURI` and `URI` to denote the path of a URL, we try both here and fall back to `/`
-          uri.path=(datastore['TARGETURI'] || datastore['URI'] || '/')
-          uri.user=datastore['HttpUsername']
-          uri.password=datastore['HttpPassword'] if uri.user
+          uri.path = (datastore['TARGETURI'] || datastore['URI'] || '/')
+          uri.user = datastore['HttpUsername']
+          uri.password = datastore['HttpPassword'] if uri.user
           uri.to_s.delete_prefix('//')
         rescue URI::InvalidComponentError
           nil

--- a/lib/msf/core/option_container.rb
+++ b/lib/msf/core/option_container.rb
@@ -18,6 +18,7 @@ module Msf
   autoload :OptRaw, 'msf/core/opt_raw'
   autoload :OptRegexp, 'msf/core/opt_regexp'
   autoload :OptString, 'msf/core/opt_string'
+  autoload :OptRhostUrl, 'msf/core/opt_rhost_url'
 
   #
   # The options purpose in life is to associate named options with arbitrary

--- a/lib/msf/core/option_container.rb
+++ b/lib/msf/core/option_container.rb
@@ -18,7 +18,7 @@ module Msf
   autoload :OptRaw, 'msf/core/opt_raw'
   autoload :OptRegexp, 'msf/core/opt_regexp'
   autoload :OptString, 'msf/core/opt_string'
-  autoload :OptRhostURL, 'msf/core/opt_rhost_url'
+  autoload :OptHTTPRhostURL, 'msf/core/opt_http_rhost_url'
 
   #
   # The options purpose in life is to associate named options with arbitrary

--- a/lib/msf/core/option_container.rb
+++ b/lib/msf/core/option_container.rb
@@ -18,7 +18,7 @@ module Msf
   autoload :OptRaw, 'msf/core/opt_raw'
   autoload :OptRegexp, 'msf/core/opt_regexp'
   autoload :OptString, 'msf/core/opt_string'
-  autoload :OptRhostUrl, 'msf/core/opt_rhost_url'
+  autoload :OptRhostURL, 'msf/core/opt_rhost_url'
 
   #
   # The options purpose in life is to associate named options with arbitrary

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -113,6 +113,7 @@ class Core
       "color"      => "Toggle color",
       "debug"      => "Display information useful for debugging",
       "exit"       => "Exit the console",
+      "features"   => "Display the list of not yet released features that can be opted in to",
       "get"        => "Gets the value of a context-specific variable",
       "getg"       => "Gets the value of a global variable",
       "grep"       => "Grep the output of another command",
@@ -562,6 +563,120 @@ class Core
   end
 
   alias cmd_quit cmd_exit
+
+  def cmd_features_help
+    print_line <<~CMD_FEATURE_HELP
+      Enable or disable unreleased features that Metasploit supports
+
+      Usage:
+        features set feature_name [true/false]
+        features print
+
+      Subcommands:
+        set - Enable or disable a given feature
+        print - show all available features and their current configuration
+
+      Examples:
+        View available features:
+          features print
+
+        Enable a feature:
+          features set new_feature true
+
+        Disable a feature:
+          features set new_feature false
+    CMD_FEATURE_HELP
+  end
+
+  #
+  # This method handles the features command which allows a user to opt into enabling
+  # features that are not yet released to everyone by default.
+  #
+  def cmd_features(*args)
+    args << 'print' if args.empty?
+
+    action, *rest = args
+    case action
+    when 'set'
+      feature_name, value = rest
+
+      unless framework.features.exists?(feature_name)
+        print_warning("Feature name '#{feature_name}' is not available. Either it has been removed, integrated by default, or does not exist.")
+        print_warning("Currently supported features: #{framework.features.names.join(', ')}") if framework.features.all.any?
+        print_warning('There are currently no features to toggle.') if framework.features.all.empty?
+        return
+      end
+
+      unless %w[true false].include?(value)
+        print_warning('Please specify true or false to configure this feature.')
+        return
+      end
+
+      framework.features.set(feature_name, value == 'true')
+      print_line("#{feature_name} => #{value}")
+    when 'print'
+      if framework.features.all.empty?
+        print_line 'There are no features to enable at this time. Either the features have been removed, or integrated by default.'
+        return
+      end
+
+      features_table = Table.new(
+        Table::Style::Default,
+        'Header' => 'Features table',
+        'Prefix' => "\n",
+        'Postfix' => "\n",
+        'Columns' => [
+          '#',
+          'Name',
+          'Enabled',
+          'Description',
+        ]
+      )
+
+      framework.features.all.each.with_index do |feature, index|
+        features_table << [
+          index,
+          feature[:name],
+          feature[:enabled].to_s,
+          feature[:description]
+        ]
+      end
+
+      print_line features_table.to_s
+    else
+      cmd_help
+    end
+  rescue StandardError => e
+    elog(e)
+    print_error(e.message)
+  end
+
+  #
+  # Tab completion for the features command
+  #
+  # @param str [String] the string currently being typed before tab was hit
+  # @param words [Array<String>] the previously completed words on the command line.  words is always
+  # at least 1 when tab completion has reached this stage since the command itself has been completed
+  def cmd_features_tabs(_str, words)
+    if words.length == 1
+      return %w[set print]
+    end
+
+    _command_name, action, *rest = words
+    ret = []
+    case action
+    when 'set'
+      feature_name, _value = rest
+
+      if framework.features.exists?(feature_name)
+        ret += %w[true false]
+      else
+        ret += framework.features.names
+      end
+    end
+
+    ret
+  end
 
   def cmd_history(*args)
     length = Readline::HISTORY.length

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -134,10 +134,7 @@ class Core
       "unset"      => "Unsets one or more context-specific variables",
       "unsetg"     => "Unsets one or more global variables",
       "version"    => "Show the framework and console library version numbers",
-      "spool"      => "Write console output into a file as well the screen",
-      "set_macro"  => "sets multiple options yay",
-      "setg_macro"  => "sets multiple options yay"
-
+      "spool"      => "Write console output into a file as well the screen"
     }
   end
 
@@ -1722,33 +1719,6 @@ class Core
     print_line "If setting a PAYLOAD, this command can take an index from `show payloads'."
     print_line
   end
-
-  def cmd_setg_macro(key, value)
-    cmd_set_macro(key, value, global: true)
-  end
-
-  def cmd_set_macro(key, value, global: false)
-    case key.upcase
-    when "RHOST_URL"
-      set_rhost_url(value, global: global)
-    else
-      # type code here
-    end
-  end
-
-  def set_rhost_url(value, global: false)
-    rhost_url = URI(value)
-    set_option('RHOSTS', rhost_url.hostname, global: global)
-    set_option('RPORT', rhost_url.port, global: global)
-    set_option('SSL', %w{ssl https}.include?(rhost_url.scheme), global: global)
-    set_option('TARGETURI', rhost_url.path, global: global)
-    if %{http https}.include?(rhost_url.scheme)
-      set_option('VHOST', rhost_url.hostname, global: global) unless Rex::Socket.is_ip_addr?(rhost_url.hostname)
-      set_option('HttpUsername', rhost_url.user.to_s, global: global)
-      set_option('HttpPassword', rhost_url.password.to_s, global: global)
-    end
-  end
-
 
   def cmd_set(*args)
     # Figure out if these are global variables

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -601,7 +601,7 @@ class Core
       feature_name, value = rest
 
       unless framework.features.exists?(feature_name)
-        print_warning("Feature name '#{feature_name}' is not available. Either it has been removed, integrated by default, or does not exist.")
+        print_warning("Feature name '#{feature_name}' is not available. Either it has been removed, integrated by default, or does not exist in this version of Metasploit.")
         print_warning("Currently supported features: #{framework.features.names.join(', ')}") if framework.features.all.any?
         print_warning('There are currently no features to toggle.') if framework.features.all.empty?
         return
@@ -1241,6 +1241,12 @@ class Core
   def cmd_save(*args)
     # Save the console config
     driver.save_config
+
+    begin
+      FeatureManager.instance.save_config
+    rescue StandardException => e
+      elog(e)
+    end
 
     # Save the framework's datastore
     begin

--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -132,6 +132,12 @@ class Driver < Msf::Ui::Driver
 
     load_db_config(opts['Config'])
 
+    begin
+      FeatureManager.instance.load_config
+    rescue StandardException => e
+      elog(e)
+    end
+
     if !framework.db || !framework.db.active
       if framework.db.error == "disabled"
         print_warning("Database support has been disabled")

--- a/lib/msf/ui/console/table.rb
+++ b/lib/msf/ui/console/table.rb
@@ -18,13 +18,10 @@ class Table < Rex::Text::Table
     Default = 0
   end
 
-  #
-  # Initializes a wrappered table with the supplied style and options.
-  #
-  def initialize(style, opts = {})
-    self.style = style
+  def self.new(*args, &block)
+    style, opts = args
 
-    if (self.style == Style::Default)
+    if style == Style::Default
       opts['Indent']  = 3
       if (!opts['Prefix'])
         opts['Prefix']  = "\n"
@@ -32,28 +29,26 @@ class Table < Rex::Text::Table
       if (!opts['Postfix'])
         opts['Postfix'] = "\n"
       end
-
-      super(opts)
     end
+
+    instance = super(opts, &block)
+    if style == Style::Default
+      instance.extend(DefaultStyle)
+    end
+    instance
   end
 
-  #
-  # Print nothing if there are no rows if the style is default.
-  #
-  def to_s
-    if (style == Style::Default)
+  module DefaultStyle
+    #
+    # Print nothing if there are no rows if the style is default.
+    #
+    def to_s
       return '' if (rows.length == 0)
+
+      super
     end
-
-    super
   end
-
-protected
-
-  attr_accessor :style # :nodoc:
-
 end
-
 end
 end
 end

--- a/lib/msf/ui/debug.rb
+++ b/lib/msf/ui/debug.rb
@@ -48,7 +48,7 @@ module Msf
 
         # Delete all groups from the config ini that potentially have more up to date information
         ini.keys.each do |key|
-          unless key =~ %r{^framework/database}
+          unless key.start_with?("framework/database") || key.start_with?("framework/features")
             ini.delete(key)
           end
         end

--- a/spec/lib/metasploit/framework/aws/client_spec.rb
+++ b/spec/lib/metasploit/framework/aws/client_spec.rb
@@ -4,9 +4,12 @@ require 'metasploit/framework/aws/client'
 RSpec.describe Metasploit::Framework::Aws::Client do
 
   subject do
-    s = Class.new(Msf::Auxiliary) do
+    mod_klass = Class.new(Msf::Auxiliary) do
       include Metasploit::Framework::Aws::Client
-    end.new
+    end
+    features = instance_double(Msf::FeatureManager, enabled?: false)
+    mod_klass.framework = instance_double(Msf::Framework, features: features, datastore: {})
+    s = mod_klass.new
     s.datastore['Region'] = 'us-east-1'
     s.datastore['RHOST'] = '127.0.0.1'
     s

--- a/spec/lib/msf/core/exploit/http/jboss/base_spec.rb
+++ b/spec/lib/msf/core/exploit/http/jboss/base_spec.rb
@@ -6,10 +6,12 @@ require 'msf/core/exploit/http/jboss'
 
 RSpec.describe Msf::Exploit::Remote::HTTP::JBoss::Base do
   subject do
-    mod = ::Msf::Exploit.new
-    mod.extend Msf::Exploit::Remote::HTTP::JBoss
-    mod.send(:initialize)
-    mod
+    mod_klass = Class.new(::Msf::Exploit) do
+      include Msf::Exploit::Remote::HTTP::JBoss
+    end
+    features = instance_double(Msf::FeatureManager, enabled?: false)
+    mod_klass.framework = instance_double(Msf::Framework, features: features, datastore: {})
+    mod_klass.new
   end
 
   describe "#deploy" do

--- a/spec/lib/msf/core/exploit/http/jboss/bean_shell_scripts_spec.rb
+++ b/spec/lib/msf/core/exploit/http/jboss/bean_shell_scripts_spec.rb
@@ -6,10 +6,12 @@ require 'msf/core/exploit/http/jboss'
 
 RSpec.describe Msf::Exploit::Remote::HTTP::JBoss::BeanShellScripts do
   subject do
-    mod = ::Msf::Exploit.new
-    mod.extend Msf::Exploit::Remote::HTTP::JBoss
-    mod.send(:initialize)
-    mod
+    mod_klass = Class.new(::Msf::Exploit) do
+      include Msf::Exploit::Remote::HTTP::JBoss
+    end
+    features = instance_double(Msf::FeatureManager, enabled?: false)
+    mod_klass.framework = instance_double(Msf::Framework, features: features, datastore: {})
+    mod_klass.new
   end
 
   describe "#generate_bsh" do

--- a/spec/lib/msf/core/exploit/http/jboss/bean_shell_spec.rb
+++ b/spec/lib/msf/core/exploit/http/jboss/bean_shell_spec.rb
@@ -7,10 +7,12 @@ require 'msf/core/exploit/http/jboss'
 RSpec.describe Msf::Exploit::Remote::HTTP::JBoss::BeanShell do
 
   subject do
-    mod = ::Msf::Exploit.new
-    mod.extend Msf::Exploit::Remote::HTTP::JBoss
-    mod.send(:initialize)
-    mod
+    mod_klass = Class.new(::Msf::Exploit) do
+      include Msf::Exploit::Remote::HTTP::JBoss
+    end
+    features = instance_double(Msf::FeatureManager, enabled?: false)
+    mod_klass.framework = instance_double(Msf::Framework, features: features, datastore: {})
+    mod_klass.new
   end
 
   before :example do

--- a/spec/lib/msf/core/exploit/http/jboss/deployment_file_repository_scripts_spec.rb
+++ b/spec/lib/msf/core/exploit/http/jboss/deployment_file_repository_scripts_spec.rb
@@ -6,10 +6,12 @@ require 'msf/core/exploit/http/jboss'
 
 RSpec.describe Msf::Exploit::Remote::HTTP::JBoss::DeploymentFileRepositoryScripts do
   subject do
-    mod = ::Msf::Exploit.new
-    mod.extend Msf::Exploit::Remote::HTTP::JBoss
-    mod.send(:initialize)
-    mod
+    mod_klass = Class.new(::Msf::Exploit) do
+      include Msf::Exploit::Remote::HTTP::JBoss
+    end
+    features = instance_double(Msf::FeatureManager, enabled?: false)
+    mod_klass.framework = instance_double(Msf::Framework, features: features, datastore: {})
+    mod_klass.new
   end
 
   describe "#stager_jsp_with_payload" do

--- a/spec/lib/msf/core/exploit/http/jboss/deployment_file_repository_spec.rb
+++ b/spec/lib/msf/core/exploit/http/jboss/deployment_file_repository_spec.rb
@@ -6,10 +6,12 @@ require 'msf/core/exploit/http/jboss'
 
 RSpec.describe Msf::Exploit::Remote::HTTP::JBoss::DeploymentFileRepository do
   subject do
-    mod = ::Msf::Exploit.new
-    mod.extend Msf::Exploit::Remote::HTTP::JBoss
-    mod.send(:initialize)
-    mod
+    mod_klass = Class.new(::Msf::Exploit) do
+      include Msf::Exploit::Remote::HTTP::JBoss
+    end
+    features = instance_double(Msf::FeatureManager, enabled?: false)
+    mod_klass.framework = instance_double(Msf::Framework, features: features, datastore: {})
+    mod_klass.new
   end
 
   let (:base_name) do

--- a/spec/lib/msf/core/exploit/http/joomla/base_spec.rb
+++ b/spec/lib/msf/core/exploit/http/joomla/base_spec.rb
@@ -6,10 +6,12 @@ require 'msf/core/exploit/http/joomla'
 RSpec.describe Msf::Exploit::Remote::HTTP::Joomla::Base do
 
   subject do
-    mod = ::Msf::Exploit.new
-    mod.extend ::Msf::Exploit::Remote::HTTP::Joomla
-    mod.send(:initialize)
-    mod
+    mod_klass = Class.new(::Msf::Exploit) do
+      include ::Msf::Exploit::Remote::HTTP::Joomla
+    end
+    features = instance_double(Msf::FeatureManager, enabled?: false)
+    mod_klass.framework = instance_double(Msf::Framework, features: features, datastore: {})
+    mod_klass.new
   end
 
   let(:joomla_body) do

--- a/spec/lib/msf/core/exploit/http/joomla/version_spec.rb
+++ b/spec/lib/msf/core/exploit/http/joomla/version_spec.rb
@@ -5,10 +5,12 @@ require 'msf/core/exploit/http/joomla'
 
 RSpec.describe Msf::Exploit::Remote::HTTP::Joomla::Version do
   subject do
-    mod = ::Msf::Exploit.new
-    mod.extend ::Msf::Exploit::Remote::HTTP::Joomla
-    mod.send(:initialize)
-    mod
+    mod_klass = Class.new(::Msf::Exploit) do
+      include ::Msf::Exploit::Remote::HTTP::Joomla
+    end
+    features = instance_double(Msf::FeatureManager, enabled?: false)
+    mod_klass.framework = instance_double(Msf::Framework, features: features, datastore: {})
+    mod_klass.new
   end
 
   # From /joomla/language/en-GB/en-GB.xml

--- a/spec/lib/msf/core/exploit/http/wordpress/base_spec.rb
+++ b/spec/lib/msf/core/exploit/http/wordpress/base_spec.rb
@@ -8,10 +8,12 @@ require 'msf/core/exploit/http/wordpress'
 
 RSpec.describe Msf::Exploit::Remote::HTTP::Wordpress::Base do
   subject do
-    mod = ::Msf::Exploit.new
-    mod.extend ::Msf::Exploit::Remote::HTTP::Wordpress
-    mod.send(:initialize)
-    mod
+    mod_klass = Class.new(::Msf::Exploit) do
+      include ::Msf::Exploit::Remote::HTTP::Wordpress
+    end
+    features = instance_double(Msf::FeatureManager, enabled?: false)
+    mod_klass.framework = instance_double(Msf::Framework, features: features, datastore: {})
+    mod_klass.new
   end
 
   describe '#wordpress_and_online?' do

--- a/spec/lib/msf/core/exploit/http/wordpress/login_spec.rb
+++ b/spec/lib/msf/core/exploit/http/wordpress/login_spec.rb
@@ -8,10 +8,12 @@ require 'msf/core/exploit/http/wordpress'
 
 RSpec.describe Msf::Exploit::Remote::HTTP::Wordpress::Login do
   subject do
-    mod = ::Msf::Exploit.new
-    mod.extend ::Msf::Exploit::Remote::HTTP::Wordpress
-    mod.send(:initialize)
-    mod
+    mod_klass = Class.new(::Msf::Exploit) do
+      include ::Msf::Exploit::Remote::HTTP::Wordpress
+    end
+    features = instance_double(Msf::FeatureManager, enabled?: false)
+    mod_klass.framework = instance_double(Msf::Framework, features: features, datastore: {})
+    mod_klass.new
   end
 
   describe '#wordpress_login' do

--- a/spec/lib/msf/core/exploit/http/wordpress/version_spec.rb
+++ b/spec/lib/msf/core/exploit/http/wordpress/version_spec.rb
@@ -8,10 +8,12 @@ require 'msf/core/exploit/http/wordpress'
 
 RSpec.describe Msf::Exploit::Remote::HTTP::Wordpress::Version do
   subject do
-    mod = ::Msf::Exploit.new
-    mod.extend ::Msf::Exploit::Remote::HTTP::Wordpress
-    mod.send(:initialize)
-    mod
+    mod_klass = Class.new(::Msf::Exploit) do
+      include ::Msf::Exploit::Remote::HTTP::Wordpress
+    end
+    features = instance_double(Msf::FeatureManager, enabled?: false)
+    mod_klass.framework = instance_double(Msf::Framework, features: features, datastore: {})
+    mod_klass.new
   end
 
   describe '#wordpress_version' do

--- a/spec/lib/msf/core/feature_manager_spec.rb
+++ b/spec/lib/msf/core/feature_manager_spec.rb
@@ -1,0 +1,79 @@
+# -*- coding:binary -*-
+
+require 'spec_helper'
+require 'msf/core/feature_manager'
+
+RSpec.describe Msf::FeatureManager do
+  let(:mock_features) do
+    [
+      {
+        name: 'filtered_options',
+        description: 'Add option filtering functionality to Metasploit',
+        enabled: false
+      },
+      {
+        name: 'new_search_capabilities',
+        description: 'Add new search capabilities to Metasploit',
+        enabled: true
+      }
+    ]
+  end
+  let(:mock_framework) { instance_double(Msf::Framework) }
+  let(:subject) { described_class.new(mock_framework) }
+
+  before(:each) do
+    stub_const('Msf::FeatureManager::DEFAULTS', mock_features)
+  end
+
+  describe '#all' do
+    it { expect(subject.all).to eql mock_features }
+  end
+
+  describe '#enabled?' do
+    it { expect(subject.enabled?('missing_option')).to be false }
+    it { expect(subject.enabled?('filtered_options')).to be false }
+    it { expect(subject.enabled?('new_search_capabilities')).to be true }
+  end
+
+  describe '#exists?' do
+    it { expect(subject.exists?('missing_option')).to be false }
+    it { expect(subject.exists?('filtered_options')).to be true }
+    it { expect(subject.exists?('new_search_capabilities')).to be true }
+  end
+
+  describe 'names' do
+    it { expect(subject.names).to eq ['filtered_options', 'new_search_capabilities'] }
+  end
+
+  describe '#set' do
+    context 'when a flag is enabled' do
+      before(:each) do
+        subject.set('filtered_options', true)
+      end
+
+      it { expect(subject.enabled?('missing_option')).to be false }
+      it { expect(subject.enabled?('filtered_options')).to be true }
+      it { expect(subject.enabled?('new_search_capabilities')).to be true }
+    end
+
+    context 'when a flag is disabled' do
+      before(:each) do
+        subject.set('new_search_capabilities', false)
+      end
+
+      it { expect(subject.enabled?('missing_option')).to be false }
+      it { expect(subject.enabled?('filtered_options')).to be false }
+      it { expect(subject.enabled?('new_search_capabilities')).to be false }
+    end
+
+    context 'when the flag does not exist' do
+      before(:each) do
+        subject.set('missing_option', false)
+      end
+
+      it { expect(subject.enabled?('missing_option')).to be false }
+      it { expect(subject.enabled?('filtered_options')).to be false }
+      it { expect(subject.enabled?('new_search_capabilities')).to be true }
+    end
+  end
+end

--- a/spec/lib/msf/core/feature_manager_spec.rb
+++ b/spec/lib/msf/core/feature_manager_spec.rb
@@ -9,24 +9,37 @@ RSpec.describe Msf::FeatureManager do
       {
         name: 'filtered_options',
         description: 'Add option filtering functionality to Metasploit',
-        enabled: false
+        default_value: false
       },
       {
         name: 'new_search_capabilities',
         description: 'Add new search capabilities to Metasploit',
-        enabled: true
+        default_value: true
       }
     ]
   end
-  let(:mock_framework) { instance_double(Msf::Framework) }
-  let(:subject) { described_class.new(mock_framework) }
+  let(:subject) { described_class.send(:new) }
 
   before(:each) do
     stub_const('Msf::FeatureManager::DEFAULTS', mock_features)
   end
 
   describe '#all' do
-    it { expect(subject.all).to eql mock_features }
+    let(:expected_features) do
+      [
+        {
+          name: 'filtered_options',
+          description: 'Add option filtering functionality to Metasploit',
+          enabled: false
+        },
+        {
+          name: 'new_search_capabilities',
+          description: 'Add new search capabilities to Metasploit',
+          enabled: true
+        }
+      ]
+    end
+    it { expect(subject.all).to eql expected_features }
   end
 
   describe '#enabled?' do
@@ -74,6 +87,136 @@ RSpec.describe Msf::FeatureManager do
       it { expect(subject.enabled?('missing_option')).to be false }
       it { expect(subject.enabled?('filtered_options')).to be false }
       it { expect(subject.enabled?('new_search_capabilities')).to be true }
+    end
+  end
+
+  describe "#load_config" do
+    before(:each) do
+      allow(Msf::Config).to receive(:load).and_return(Rex::Parser::Ini.from_s(config))
+      subject.load_config
+    end
+
+    context 'when the config file is empty' do
+      let(:config) do
+        <<~CONFIG
+
+        CONFIG
+      end
+
+      let(:expected_features) do
+        [
+          {
+            name: 'filtered_options',
+            description: 'Add option filtering functionality to Metasploit',
+            enabled: false
+          },
+          {
+            name: 'new_search_capabilities',
+            description: 'Add new search capabilities to Metasploit',
+            enabled: true
+          }
+        ]
+      end
+
+      it { expect(subject.all).to eql expected_features }
+    end
+
+    context 'when there are valid and invalid flags' do
+      let(:config) do
+        <<~CONFIG
+          [framework/features]
+          new_search_capabilities=false
+          missing_feature=true
+        CONFIG
+      end
+
+      let(:expected_features) do
+        [
+          {
+            name: 'filtered_options',
+            description: 'Add option filtering functionality to Metasploit',
+            enabled: false
+          },
+          {
+            name: 'new_search_capabilities',
+            description: 'Add new search capabilities to Metasploit',
+            enabled: false
+          }
+        ]
+      end
+
+      it { expect(subject.all).to eql expected_features }
+    end
+  end
+
+  describe '#save_config' do
+    before(:each) do
+      allow(Msf::Config).to receive(:load).and_return(Rex::Parser::Ini.from_s(config))
+      allow(Msf::Config).to receive(:save)
+    end
+
+    context 'when there is no existing configuration' do
+      before(:each) do
+        subject.save_config
+      end
+
+      let(:config) do
+        <<~CONFIG
+          [framework/features]
+        CONFIG
+      end
+
+      let(:expected_config) do
+        {
+          "framework/features" => {}
+        }
+      end
+
+      it { expect(Msf::Config).to have_received(:save).with(expected_config) }
+    end
+
+    context 'when there is only a missing feature' do
+      before(:each) do
+        subject.save_config
+      end
+
+      let(:config) do
+        <<~CONFIG
+          [framework/features]
+          missing_feature=true
+        CONFIG
+      end
+
+      let(:expected_config) do
+        {
+          "framework/features" => { "missing_feature" => "true" }
+        }
+      end
+
+      it { expect(Msf::Config).to have_received(:save).with(expected_config) }
+    end
+
+    context 'when there are user preferences set' do
+      before(:each) do
+        subject.set('new_search_capabilities', true)
+        subject.save_config
+      end
+
+      let(:config) do
+        <<~CONFIG
+          [framework/features]
+          new_search_capabilities=false
+          missing_feature=true
+        CONFIG
+      end
+
+      let(:expected_config) do
+        {
+          "framework/features" => { "missing_feature" => "true", "new_search_capabilities"=>"true" }
+        }
+      end
+
+      it { expect(Msf::Config).to have_received(:save).with(expected_config) }
     end
   end
 end

--- a/spec/lib/msf/core/opt_http_rhost_url_spec.rb
+++ b/spec/lib/msf/core/opt_http_rhost_url_spec.rb
@@ -1,7 +1,7 @@
 require 'msf/core/opt_http_rhost_url'
 
 RSpec.describe Msf::OptHTTPRhostURL do
-  subject(:opt) { described_class }
+  subject(:opt) { described_class.new('RHOST_HTTP_URL') }
 
   valid_values = [
     { value: 'http://example.com', normalized: { 'RHOSTS' => 'example.com', 'RPORT' => 80, 'SSL' => false, 'TARGETURI' => '', 'URI' => '', 'VHOST' => 'example.com', 'HttpUsername' => '', 'HttpPassword' => '' } },
@@ -20,4 +20,42 @@ RSpec.describe Msf::OptHTTPRhostURL do
   ]
 
   it_behaves_like 'an option', valid_values, invalid_values, 'rhost http url'
+
+
+  calculate_values = [
+      { value: 'http://example.com', normalized: { 'RHOSTS' => 'example.com', 'RPORT' => 80, 'SSL' => false, 'TARGETURI' => '', 'URI' => '', 'VHOST' => 'example.com', 'HttpUsername' => '', 'HttpPassword' => '' } },
+      { value: 'https://example.com', normalized: { 'RHOSTS' => 'example.com', 'RPORT' => 443, 'SSL' => true, 'TARGETURI' => '', 'URI' => '', 'VHOST' => 'example.com', 'HttpUsername' => '', 'HttpPassword' => '' } },
+      { value: 'http://user:pass@example.com:1234/somePath', normalized: { 'RHOSTS' => 'example.com', 'RPORT' => 1234, 'SSL' => false, 'TARGETURI' => '/somePath', 'URI' => '/somePath', 'VHOST' => 'example.com', 'HttpUsername' => 'user', 'HttpPassword' => 'pass' } },
+      { value: 'http://127.0.0.1', normalized: { 'RHOSTS' => '127.0.0.1', 'RPORT' => 80, 'SSL' => false, 'TARGETURI' => '', 'URI' => '', 'VHOST' => nil, 'HttpUsername' => '', 'HttpPassword' => '' } }
+  ]
+
+  calculate_values_no_schema = [
+      { value: 'example.com', normalized: { 'RHOSTS' => 'example.com', 'RPORT' => 80, 'SSL' => false, 'TARGETURI' => '', 'URI' => '', 'VHOST' => 'example.com', 'HttpUsername' => '', 'HttpPassword' => '' } },
+      { value: 'example.com:443', normalized: { 'RHOSTS' => 'example.com', 'RPORT' => 443, 'SSL' => false, 'TARGETURI' => '', 'URI' => '', 'VHOST' => 'example.com', 'HttpUsername' => '', 'HttpPassword' => '' } },
+      { value: 'user:pass@example.com:1234/somePath', normalized: { 'RHOSTS' => 'example.com', 'RPORT' => 1234, 'SSL' => false, 'TARGETURI' => '/somePath', 'URI' => '/somePath', 'VHOST' => 'example.com', 'HttpUsername' => 'user', 'HttpPassword' => 'pass' } },
+      { value: '127.0.0.1', normalized: { 'RHOSTS' => '127.0.0.1', 'RPORT' => 80, 'SSL' => false, 'TARGETURI' => '', 'URI' => '', 'VHOST' => nil, 'HttpUsername' => '', 'HttpPassword' => '' } }
+  ]
+
+  describe '#calculate_value' do
+    calculate_values.each do | url |
+
+      context url[:normalized].to_s do
+        it "should return #{url[:value]}" do
+          expect(subject.calculate_value(url[:normalized])).to eq(URI(url[:value]))
+        end
+      end
+    end
+  end
+
+  describe '#calculate_value missing scheme' do
+    calculate_values_no_schema.each do | url |
+
+      context url[:normalized].to_s do
+        it "should return #{url[:value]}" do
+          expect(subject.calculate_value(url[:normalized])).to eq(URI('http://' + url[:value]))
+        end
+      end
+    end
+  end
+
 end

--- a/spec/lib/msf/core/opt_http_rhost_url_spec.rb
+++ b/spec/lib/msf/core/opt_http_rhost_url_spec.rb
@@ -1,0 +1,23 @@
+require 'msf/core/opt_http_rhost_url'
+
+RSpec.describe Msf::OptHTTPRhostURL do
+  subject(:opt) { described_class }
+
+  valid_values = [
+    { value: 'http://example.com', normalized: { 'RHOSTS' => 'example.com', 'RPORT' => 80, 'SSL' => false, 'TARGETURI' => '', 'URI' => '', 'VHOST' => 'example.com', 'HttpUsername' => '', 'HttpPassword' => '' } },
+    { value: 'https://example.com', normalized: { 'RHOSTS' => 'example.com', 'RPORT' => 443, 'SSL' => true, 'TARGETURI' => '', 'URI' => '', 'VHOST' => 'example.com', 'HttpUsername' => '', 'HttpPassword' => '' } },
+    { value: 'example.com', normalized: { 'RHOSTS' => 'example.com', 'RPORT' => 80, 'SSL' => false, 'TARGETURI' => '', 'URI' => '', 'VHOST' => 'example.com', 'HttpUsername' => '', 'HttpPassword' => '' } },
+    { value: 'http://user:pass@example.com:1234/somePath', normalized: { 'RHOSTS' => 'example.com', 'RPORT' => 1234, 'SSL' => false, 'TARGETURI' => '/somePath', 'URI' => '/somePath', 'VHOST' => 'example.com', 'HttpUsername' => 'user', 'HttpPassword' => 'pass' } },
+    { value: 'http://127.0.0.1', normalized: { 'RHOSTS' => '127.0.0.1', 'RPORT' => 80, 'SSL' => false, 'TARGETURI' => '', 'URI' => '', 'VHOST' => nil, 'HttpUsername' => '', 'HttpPassword' => '' } }
+  ]
+
+  invalid_values = [
+    { value: '192.0.2.0/24' },
+    { value: '192.0.2.0-255' },
+    { value: '192.0.2.0,1-255' },
+    { value: '192.0.2.*' },
+    { value: '192.0.2.0-192.0.2.255' }
+  ]
+
+  it_behaves_like 'an option', valid_values, invalid_values, 'rhost http url'
+end

--- a/spec/tools/md5_lookup_spec.rb
+++ b/spec/tools/md5_lookup_spec.rb
@@ -55,7 +55,10 @@ RSpec.describe Md5LookupUtility do
   end
 
   subject do
-    Md5LookupUtility::Md5Lookup.new
+    mod_klass = Md5LookupUtility::Md5Lookup
+    features = instance_double(Msf::FeatureManager, enabled?: false)
+    mod_klass.framework = instance_double(Msf::Framework, features: features, datastore: {})
+    mod_klass.new
   end
 
   def set_expected_response(body)
@@ -253,7 +256,11 @@ RSpec.describe Md5LookupUtility do
     describe '#get_hash_results' do
       context 'when a hash is found' do
         it 'yields a result' do
-          search_engine = Md5LookupUtility::Md5Lookup.new
+          mod_klass = Md5LookupUtility::Md5Lookup
+          features = instance_double(Msf::FeatureManager, enabled?: false)
+          mod_klass.framework = instance_double(Msf::Framework, features: features, datastore: {})
+          search_engine = mod_klass.new
+
           allow(search_engine).to receive(:lookup).and_return(good_result)
           allow(Md5LookupUtility::Md5Lookup).to receive(:new).and_return(search_engine)
 

--- a/spec/tools/virustotal_spec.rb
+++ b/spec/tools/virustotal_spec.rb
@@ -87,7 +87,11 @@ RSpec.describe VirusTotalUtility do
         let(:vt) do
           file = double(File, read: malware_data)
           allow(File).to receive(:open).with(filename, 'rb') {|&block| block.yield file}
-          VirusTotalUtility::VirusTotal.new({'api_key'=>api_key, 'sample'=>filename})
+
+          mod_klass = VirusTotalUtility::VirusTotal
+          features = instance_double(Msf::FeatureManager, enabled?: false)
+          mod_klass.framework = instance_double(Msf::Framework, features: features, datastore: {})
+          mod_klass.new({'api_key'=>api_key, 'sample'=>filename})
         end
 
         context ".Initializer" do


### PR DESCRIPTION
This PR is for an additional option that allows users to specify a URL (i.e. `set RHOST_URL https://example.com/path`) rather than setting each individual option that is the current workflow (i.e. `set RHOSTS example.com`, `set RPORT 443`, `set SSL true` ... etc)

For full details on the various approaches to adding URL Support to Metasploit:
https://github.com/rapid7/metasploit-framework/wiki/RFC---Metasploit-URL-support

I currently only have the new option added to `Exploit::Remote::HttpClient` but I'm sure there are a few other places it also belongs, more than happy to add it in anywhere that makes sense

Here is an example of the setting in action:
![image](https://user-images.githubusercontent.com/19910435/85633272-d8e99300-b670-11ea-9a6a-b87bf93f8cf4.png)

The reverse is also true, i.e. you can set multiple individual values and the RHOST_URL will be displayed for you:
![image](https://user-images.githubusercontent.com/19910435/85633561-5e6d4300-b671-11ea-8657-0c95edfa1117.png)

Http username and password is also supported:
![image](https://user-images.githubusercontent.com/19910435/85634107-96c15100-b672-11ea-9d64-d98a86ecac0d.png)



Some things to note with the current implementation:
- Only single URLs may be specified (In other words you are not able specify an address range in the new option), attempting this will blank out the RHOST_URL option, but any previous options that were set will remain.
![image](https://user-images.githubusercontent.com/19910435/85634296-fddf0580-b672-11ea-9f3c-67e141a84cee.png)

- URLs of the format `example.com` notably missing the scheme are not supported, you must do `//example.com:<port>` or even better `https://example.com`
![image](https://user-images.githubusercontent.com/19910435/85633839-008d2b00-b672-11ea-981f-46f0fe65ed6b.png)


To sum up, if this feature is to be added users would be able to simply input `set RHOST_URL` and paste in their target rather than having to set anywhere up to 6 different options depending on what that particular module cared about.