### PR TITLE
FortiMail Login Bypass Scanner

### DIFF
--- a/documentation/modules/auxiliary/scanner/http/fortimail_login_bypass_detection.md
+++ b/documentation/modules/auxiliary/scanner/http/fortimail_login_bypass_detection.md
@@ -1,3 +1,5 @@
+## Vulnerable Application
+
 This module detects vulnerable versions of FortiMail exploitable with an unauthenticated login bypass vulnerability.
 
 Tested against the following versions of FortiMail:

--- a/documentation/modules/auxiliary/scanner/http/fortimail_login_bypass_detection.md
+++ b/documentation/modules/auxiliary/scanner/http/fortimail_login_bypass_detection.md
@@ -1,0 +1,36 @@
+This module detects vulnerable versions of FortiMail exploitable with an unauthenticated login bypass vulnerability.
+
+Tested against the following versions of FortiMail:
+- 5.4.9, 5.4.10, 5.4.11
+- 6.0.5, 6.0.6, 6.0.7, 6.0.8, 6.0.9
+- 6.2.1, 6.2.2, 6.2.3
+- 6.4.0
+
+## Verification Steps
+
+- [ ] Start `msfconsole`
+- [ ] `use auxiliary/scanner/http/fortimail_login_bypass_detection`
+- [ ] `set RHOSTS <RHOSTS>`
+- [ ] `set VERBOSE true`
+- [ ] `run`
+- [ ] **Verify** that systems are detected accordingly
+
+## Scenarios
+
+```
+msf5 auxiliary(scanner/http/fortimail_login_bypass_detection) > run
+
+[*] Checking vulnerability at 172.16.144.198
+[+] 172.16.144.198 - Vulnerable version of FortiMail detected
+[*] Scanned 1 of 4 hosts (25% complete)
+[*] Checking vulnerability at 172.16.144.199
+[+] 172.16.144.199 - Vulnerable version of FortiMail detected
+[*] Scanned 2 of 4 hosts (50% complete)
+[*] Checking vulnerability at 172.16.144.200
+[+] 172.16.144.200 - Vulnerable version of FortiMail detected
+[*] Scanned 3 of 4 hosts (75% complete)
+[*] Checking vulnerability at 172.16.144.201
+[-] 172.16.144.201 - Not vulnerable version of FortiMail detected
+[*] Scanned 4 of 4 hosts (100% complete)
+[*] Auxiliary module execution completed
+```

--- a/modules/auxiliary/scanner/http/fortimail_login_bypass_detection.rb
+++ b/modules/auxiliary/scanner/http/fortimail_login_bypass_detection.rb
@@ -61,6 +61,14 @@ class MetasploitModule < Msf::Auxiliary
         version = res.body[/fml-admin-login-(\d+).js/, 1].to_i
         if (res.body.include? "newpassword" and (version.between?(140, 160) or version.between?(730, 745) or version.between?(250, 263)))
           print_good("#{ip} - Vulnerable version of FortiMail detected")
+
+          report_vuln(
+            :host => rhost,
+            :port => rport,
+            :name => 'FortiMail Login Bypass',
+            :refs => references
+          )
+
         else
           print_bad("#{ip} - No vulnerable version of FortiMail detected")
           return :abort

--- a/modules/auxiliary/scanner/http/fortimail_login_bypass_detection.rb
+++ b/modules/auxiliary/scanner/http/fortimail_login_bypass_detection.rb
@@ -22,7 +22,7 @@ class MetasploitModule < Msf::Auxiliary
       ],
       'References' =>
         [
-          ['URL',   'https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-9294'],
+          ['CVE',   '2020-9294'],
           ['URL',   'https://fortiguard.com/psirt/FG-IR-20-045'],
           ['URL',   'https://www.redguard.ch/blog/2020/07/02/fortimail-unauthenticated-login-bypass/']
         ],

--- a/modules/auxiliary/scanner/http/fortimail_login_bypass_detection.rb
+++ b/modules/auxiliary/scanner/http/fortimail_login_bypass_detection.rb
@@ -1,0 +1,75 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Auxiliary::Report
+  include Msf::Auxiliary::Scanner
+
+  def initialize
+    super(
+      'Name' => 'FortiMail Unauthenticated Login Bypass Scanner',
+      'Description' => %q{
+        This module attempts to detect instances of FortiMail vulnerable
+        against an unauthenicated login bypass (CVE-2020-9294).
+      },
+      'Author'         => [
+        'Mike Connor', # Initial Vulnerability discovery
+        'Juerg Schweingruber <juerg.schweingruber@redguard.ch>', # Vulnerability Re-Discovery
+        'Patrick Schmid <patrick.schmid@redguard.ch>' # Exploit Development & MSF module
+      ],
+      'References' =>
+        [
+          ['URL',   'https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-9294'],
+          ['URL',   'https://fortiguard.com/psirt/FG-IR-20-045']
+        ],
+      'License' => MSF_LICENSE
+    )
+
+    register_options([
+      OptString.new('TARGETURI', [true, 'Path to the FortiMail admin page', '/admin/AdminLogin.html']),
+      OptInt.new('RPORT', [true, "Default remote port", 443])
+    ])
+
+    register_advanced_options([
+      OptBool.new('SSL', [true, "Negotiate SSL connection", true])
+    ])
+  end
+
+  def target_url
+    proto = "http"
+    if rport == 443 or ssl
+      proto = "https"
+    end
+    uri = normalize_uri(datastore['URI'])
+    "#{proto}://#{vhost}:#{rport}#{uri}"
+  end
+
+  def run_host(ip)
+    print_status("Checking vulnerability at #{ip}")
+    uri = normalize_uri(target_uri.path)
+    begin
+      res = send_request_raw({
+        'method' => 'GET',
+        'uri' => uri
+        })
+
+      if (res and res.code == 200 and res.body.include? "newpassword" and res.body.include? "fml-admin-login-0160.js")
+        print_good("#{ip} - Vulnerable version of FortiMail found")
+      elsif (res and res.code == 301)
+        print_error("#{target_url} - Page redirect to #{res.headers['Location']}")
+        return :abort
+      else
+        print_bad("#{ip} - Not vulnerable version of FortiMail found")
+        return :abort
+      end
+
+    rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
+    rescue ::Timeout::Error, ::Errno::EPIPE
+    rescue ::OpenSSL::SSL::SSLError => e
+      return if(e.to_s.match(/^SSL_connect /) ) # strange errors / exception if SSL connection aborted
+    end
+  end
+end

--- a/modules/auxiliary/scanner/http/fortimail_login_bypass_detection.rb
+++ b/modules/auxiliary/scanner/http/fortimail_login_bypass_detection.rb
@@ -62,17 +62,15 @@ class MetasploitModule < Msf::Auxiliary
         if (res.body.include? "newpassword" and (version.between?(140, 160) or version.between?(730, 745) or version.between?(250, 263)))
           print_good("#{ip} - Vulnerable version of FortiMail detected")
         else
-          print_bad("#{ip} - Not vulnerable version of FortiMail detected")
+          print_bad("#{ip} - No vulnerable version of FortiMail detected")
           return :abort
         end
       elsif (res and res.code == 301)
         print_error("#{target_url} - Page redirect to #{res.headers['Location']}")
         return :abort
       else
-        if (datastore['VERBOSE'])
-          print_bad("#{ip} - No version of FortiMail detected")
-          return :abort
-        end
+        vprint_bad("#{ip} - No version of FortiMail detected")
+        return :abort
       end
 
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout

--- a/modules/auxiliary/scanner/http/fortimail_login_bypass_detection.rb
+++ b/modules/auxiliary/scanner/http/fortimail_login_bypass_detection.rb
@@ -13,12 +13,12 @@ class MetasploitModule < Msf::Auxiliary
       'Name' => 'FortiMail Unauthenticated Login Bypass Scanner',
       'Description' => %q{
         This module attempts to detect instances of FortiMail vulnerable
-        against an unauthenicated login bypass (CVE-2020-9294).
+        against an unauthenticated login bypass (CVE-2020-9294).
       },
       'Author'         => [
         'Mike Connor', # Initial Vulnerability discovery
-        'Juerg Schweingruber <juerg.schweingruber@redguard.ch>', # Vulnerability Re-Discovery
-        'Patrick Schmid <patrick.schmid@redguard.ch>' # Exploit Development & MSF module
+        'Juerg Schweingruber <juerg.schweingruber[at]redguard.ch>', # Vulnerability Re-Discovery
+        'Patrick Schmid <patrick.schmid[at]redguard.ch>' # Exploit Development & MSF module
       ],
       'References' =>
         [
@@ -31,7 +31,7 @@ class MetasploitModule < Msf::Auxiliary
 
     register_options([
       OptString.new('TARGETURI', [true, 'Path to the FortiMail admin page', '/admin/AdminLogin.html']),
-      OptInt.new('RPORT', [true, "Default remote port", 443])
+      Opt::RPORT(443)
     ])
 
     register_advanced_options([
@@ -49,9 +49,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run_host(ip)
-    if (datastore['VERBOSE'])
-      print_status("Checking vulnerability at #{ip}")
-    end
+    vprint_status("Checking vulnerability at #{ip}")
     uri = normalize_uri(target_uri.path)
     begin
       res = send_request_raw({

--- a/modules/auxiliary/scanner/http/fortimail_login_bypass_detection.rb
+++ b/modules/auxiliary/scanner/http/fortimail_login_bypass_detection.rb
@@ -23,7 +23,8 @@ class MetasploitModule < Msf::Auxiliary
       'References' =>
         [
           ['URL',   'https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-9294'],
-          ['URL',   'https://fortiguard.com/psirt/FG-IR-20-045']
+          ['URL',   'https://fortiguard.com/psirt/FG-IR-20-045'],
+          ['URL',   'https://www.redguard.ch/blog/2020/07/02/fortimail-unauthenticated-login-bypass/']
         ],
       'License' => MSF_LICENSE
     )

--- a/modules/auxiliary/scanner/http/fortimail_login_bypass_detection.rb
+++ b/modules/auxiliary/scanner/http/fortimail_login_bypass_detection.rb
@@ -71,7 +71,7 @@ class MetasploitModule < Msf::Auxiliary
             :name => 'FortiMail Login Bypass',
            :refs => references
           )
-          
+
         else
           print_bad("#{ip} - Not vulnerable version of FortiMail detected")
           return :abort

--- a/modules/auxiliary/scanner/http/fortimail_login_bypass_detection.rb
+++ b/modules/auxiliary/scanner/http/fortimail_login_bypass_detection.rb
@@ -69,13 +69,14 @@ class MetasploitModule < Msf::Auxiliary
       return :abort
     end
 
-    version = res.body[/fml-admin-login-(\d+).js/, 1].to_i
+    version_raw = res.body[/fml-admin-login-(\d+).js/, 1]
+    version = version_raw.to_i
     unless (res.body.include?("newpassword") && (version.between?(140, 160) || version.between?(730, 745) || version.between?(250, 263)))
-      print_bad("#{ip} - Not vulnerable version of FortiMail detected")
+      print_bad("#{ip} - Not vulnerable version (Build: #{version_raw}) of FortiMail detected")
       return :abort
     end
 
-    print_good("#{ip} - Vulnerable version of FortiMail detected")
+    print_good("#{ip} - Vulnerable version (Build: #{version_raw}) of FortiMail detected")
 
     report_vuln(
       :host => rhost,


### PR DESCRIPTION
This module detects vulnerable versions of FortiMail exploitable with an unauthenticated login bypass vulnerability as disclosed in CVE-2020-9294.

Tested against the following versions of FortiMail:
- 5.4.9, 5.4.10, 5.4.11
- 6.0.5, 6.0.6, 6.0.7, 6.0.8, 6.0.9
- 6.2.1, 6.2.2, 6.2.3
- 6.4.0

## Verification Steps

- [ ] Start `msfconsole`
- [ ] `use auxiliary/scanner/http/fortimail_login_bypass_detection`
- [ ] `set RHOSTS <RHOSTS>`
- [ ] `set VERBOSE true`
- [ ] `run`
- [ ] **Verify** that systems are detected accordingly

## Output
```
msf5 auxiliary(scanner/http/fortimail_login_bypass_detection) > run

[*] Checking vulnerability at 172.16.144.198
[+] 172.16.144.198 - Vulnerable version of FortiMail detected
[*] Scanned 1 of 4 hosts (25% complete)
[*] Checking vulnerability at 172.16.144.199
[+] 172.16.144.199 - Vulnerable version of FortiMail detected
[*] Scanned 2 of 4 hosts (50% complete)
[*] Checking vulnerability at 172.16.144.200
[+] 172.16.144.200 - Vulnerable version of FortiMail detected
[*] Scanned 3 of 4 hosts (75% complete)
[*] Checking vulnerability at 172.16.144.201
[-] 172.16.144.201 - Not vulnerable version of FortiMail detected
[*] Scanned 4 of 4 hosts (100% complete)
[*] Auxiliary module execution completed
```