### PR TITLE
Update metasploit payloads to 1.4.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,7 +29,7 @@ PATH
       metasploit-concern (~> 2.0.0)
       metasploit-credential (~> 3.0.0)
       metasploit-model (~> 2.0.4)
-      metasploit-payloads (= 1.4.2)
+      metasploit-payloads (= 1.4.4)
       metasploit_data_models (~> 3.0.10)
       metasploit_payloads-mettle (= 0.5.21)
       mqtt
@@ -220,7 +220,7 @@ GEM
       activemodel (~> 4.2.6)
       activesupport (~> 4.2.6)
       railties (~> 4.2.6)
-    metasploit-payloads (1.4.2)
+    metasploit-payloads (1.4.4)
     metasploit_data_models (3.0.10)
       activerecord (~> 4.2.6)
       activesupport (~> 4.2.6)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -70,7 +70,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model', '~> 2.0.4'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '1.4.2'
+  spec.add_runtime_dependency 'metasploit-payloads', '1.4.4'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '0.5.21'
   # Needed by msfgui and other rpc components


### PR DESCRIPTION
This bumps metapsloit payloads to 1.4.4, pulling in the changes from:
https://github.com/rapid7/metasploit-payloads/pull/403
https://github.com/rapid7/metasploit-payloads/pull/393

## Verification

List the steps needed to make sure this thing works

- [x] Allow automated tests and checks to complete to make sure I did not miss anything simple.
- [x] Perform automated tests and verify cmd_exec tests pass without any stderr errors.


