### PR TITLE
Remove debug print from lib/msf/core/session/interactive.rb

### DIFF
--- a/lib/msf/core/session/interactive.rb
+++ b/lib/msf/core/session/interactive.rb
@@ -127,7 +127,6 @@ protected
     rescue Interrupt
       # The user hit ctrl-c while we were handling a ctrl-c. Ignore
     end
-    p ""
   end
 
   def _usr1

--- a/lib/msf/core/session/interactive.rb
+++ b/lib/msf/core/session/interactive.rb
@@ -127,6 +127,7 @@ protected
     rescue Interrupt
       # The user hit ctrl-c while we were handling a ctrl-c. Ignore
     end
+    true
   end
 
   def _usr1


### PR DESCRIPTION
This has been bugging me for nearly two years, so I tracked it down to b6e2c34b11a877d733a38a7ea029b3cca083610c in #10448.

```
[*] Command shell session 1 opened (172.28.128.1:4444 -> 172.28.128.5:42066) at 2020-06-28 23:00:28 -0500

^C
Abort session 1? [y/N]  y
""
```