### PR TITLE
Update AutoCheck to use prepend instead of include, add ForceExploit option

### DIFF
--- a/lib/msf/core/exploit/auto_check.rb
+++ b/lib/msf/core/exploit/auto_check.rb
@@ -21,7 +21,7 @@ module Exploit::Remote::AutoCheck
     print_status('Executing automatic check (disable AutoCheck to override)')
 
     warning_msg = 'ForceExploit is enabled, proceeding with exploitation.'
-    error_msg = 'Enable ForceExploit to override.'
+    error_msg = 'Enable ForceExploit to override check result.'
 
     case (checkcode = check)
     when Exploit::CheckCode::Vulnerable, Exploit::CheckCode::Appears

--- a/lib/msf/core/exploit/auto_check.rb
+++ b/lib/msf/core/exploit/auto_check.rb
@@ -1,8 +1,5 @@
 # -*- coding: binary -*-
 
-require 'msf/core/exploit'
-require 'msf/core/module/failure'
-
 module Msf
 module Exploit::Remote::AutoCheck
 
@@ -17,35 +14,44 @@ module Exploit::Remote::AutoCheck
 
   def exploit
     unless datastore['AutoCheck']
-      print_warning('AutoCheck is disabled. Proceeding with exploitation.')
+      print_warning('AutoCheck is disabled, proceeding with exploitation')
       return super
     end
 
     print_status('Executing automatic check (disable AutoCheck to override)')
 
-    # This isn't even my final form!
+    warning_msg = 'ForceExploit is enabled, proceeding with exploitation.'
+    error_msg = 'Enable ForceExploit to override.'
+
     case (checkcode = check)
     when Exploit::CheckCode::Vulnerable, Exploit::CheckCode::Appears
       print_good(checkcode.message)
-      return super
+      super
     when Exploit::CheckCode::Detected
       print_warning(checkcode.message)
-      return super
+      super
     when Exploit::CheckCode::Safe
-      print_warning(checkcode.message)
-      return super if datastore['ForceExploit']
+      if datastore['ForceExploit']
+        print_warning("#{checkcode.message} #{warning_msg}")
+        return super
+      end
+
       fail_with(Module::Failure::NotVulnerable,
-                "#{checkcode.message} Disable ForceExploit to override.")
+                "#{checkcode.message} #{error_msg}")
     when Exploit::CheckCode::Unsupported
-      print_warning(checkcode.message)
-      return super if datastore['ForceExploit']
-      fail_with(Module::Failure::BadConfig,
-                "#{checkcode.message} Disable ForceExploit to override.")
+      if datastore['ForceExploit']
+        print_warning("#{checkcode.message} #{warning_msg}")
+        return super
+      end
+
+      fail_with(Module::Failure::BadConfig, "#{checkcode.message} #{error_msg}")
     else
-      print_warning(checkcode.message)
-      return super if datastore['ForceExploit']
-      fail_with(Module::Failure::Unknown,
-                "#{checkcode.message} Disable ForceExploit to override.")
+      if datastore['ForceExploit']
+        print_warning("#{checkcode.message} #{warning_msg}")
+        return super
+      end
+
+      fail_with(Module::Failure::Unknown, "#{checkcode.message} #{error_msg}")
     end
   end
 

--- a/lib/msf/core/exploit/auto_check.rb
+++ b/lib/msf/core/exploit/auto_check.rb
@@ -1,8 +1,7 @@
 # -*- coding: binary -*-
 
-#
-# XXX: This is a VERY ROUGH mixin for automatic check (formerly ForceExploit)
-#
+require 'msf/core/exploit'
+require 'msf/core/module/failure'
 
 module Msf
 module Exploit::Remote::AutoCheck
@@ -11,14 +10,15 @@ module Exploit::Remote::AutoCheck
     super
 
     register_advanced_options([
-      OptBool.new('AutoCheck', [false, 'Run check before exploitation', true])
+      OptBool.new('AutoCheck', [false, 'Run check before exploitation', true]),
+      OptBool.new('ForceExploit', [false, 'Override check result', false])
     ])
   end
 
   def exploit
     unless datastore['AutoCheck']
       print_warning('AutoCheck is disabled. Proceeding with exploitation.')
-      return
+      return super
     end
 
     print_status('Executing automatic check (disable AutoCheck to override)')
@@ -27,17 +27,25 @@ module Exploit::Remote::AutoCheck
     case (checkcode = check)
     when Exploit::CheckCode::Vulnerable, Exploit::CheckCode::Appears
       print_good(checkcode.message)
+      return super
     when Exploit::CheckCode::Detected
       print_warning(checkcode.message)
+      return super
     when Exploit::CheckCode::Safe
+      print_warning(checkcode.message)
+      return super if datastore['ForceExploit']
       fail_with(Module::Failure::NotVulnerable,
-                "#{checkcode.message} Disable AutoCheck to override.")
+                "#{checkcode.message} Disable ForceExploit to override.")
     when Exploit::CheckCode::Unsupported
+      print_warning(checkcode.message)
+      return super if datastore['ForceExploit']
       fail_with(Module::Failure::BadConfig,
-                "#{checkcode.message} Disable AutoCheck to override.")
+                "#{checkcode.message} Disable ForceExploit to override.")
     else
+      print_warning(checkcode.message)
+      return super if datastore['ForceExploit']
       fail_with(Module::Failure::Unknown,
-                "#{checkcode.message} Disable AutoCheck to override.")
+                "#{checkcode.message} Disable ForceExploit to override.")
     end
   end
 

--- a/modules/exploits/linux/http/cisco_ucs_cloupia_script_rce.rb
+++ b/modules/exploits/linux/http/cisco_ucs_cloupia_script_rce.rb
@@ -91,7 +91,9 @@ class MetasploitModule < Msf::Exploit::Remote
         [
           true,
           'Leak API key from this file (absolute path)',
-          '/opt/infra/idaccessmgr/logfile.txt'
+          '/opt/infra/idaccessmgr/logfile.txt',
+          nil, # enums
+          %r{^/.+$} # LEAK_FILE must be an absolute path
         ]
       )
     ])
@@ -118,10 +120,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    unless datastore['LEAK_FILE'].start_with?('/')
-      fail_with(Failure::BadConfig, 'LEAK_FILE is not an absolute path')
-    end
-
     # Randomly named file is never written to the exports directory
     create_exports_dir(
       '/opt/infra/web_cloudmgr/apache-tomcat/webapps/app/cloudmgr/exports',

--- a/modules/exploits/linux/http/cisco_ucs_cloupia_script_rce.rb
+++ b/modules/exploits/linux/http/cisco_ucs_cloupia_script_rce.rb
@@ -8,7 +8,7 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::HttpClient
-  include Msf::Exploit::Remote::AutoCheck
+  prepend Msf::Exploit::Remote::AutoCheck
   include Msf::Exploit::CmdStager
 
   def initialize(info = {})
@@ -121,9 +121,6 @@ class MetasploitModule < Msf::Exploit::Remote
     unless datastore['LEAK_FILE'].start_with?('/')
       fail_with(Failure::BadConfig, 'LEAK_FILE is not an absolute path')
     end
-
-    # NOTE: Automatic check is implemented by the AutoCheck mixin
-    super
 
     # Randomly named file is never written to the exports directory
     create_exports_dir(

--- a/modules/exploits/linux/http/netsweeper_webadmin_unixlogin.rb
+++ b/modules/exploits/linux/http/netsweeper_webadmin_unixlogin.rb
@@ -8,7 +8,7 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::HttpClient
-  include Msf::Exploit::Remote::AutoCheck
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(
@@ -105,9 +105,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    # NOTE: Automatic check is implemented by the AutoCheck mixin
-    super
-
     referer = rand_referer(:exploit)
     vprint_status("Selecting random whitelisted Referer header: #{referer}")
     vprint_status("Injecting Python code into password field: #{fake_password}")

--- a/modules/exploits/linux/http/nexus_repo_manager_el_injection.rb
+++ b/modules/exploits/linux/http/nexus_repo_manager_el_injection.rb
@@ -8,7 +8,7 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::HttpClient
-  include Msf::Exploit::Remote::AutoCheck
+  prepend Msf::Exploit::Remote::AutoCheck
   include Msf::Exploit::CmdStager
 
   def initialize(info = {})
@@ -70,6 +70,7 @@ class MetasploitModule < Msf::Exploit::Remote
     true
   end
 
+
   # Send a GET / request to the server, check the response for a Server header
   # containing the Nexus version, and then check if it's a vulnerable version
   def check
@@ -102,9 +103,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    # NOTE: Automatic check is implemented by the AutoCheck mixin
-    super
-
     print_status("Executing command stager for #{datastore['PAYLOAD']}")
 
     # This will drop a binary payload to disk and execute it!

--- a/modules/exploits/linux/http/nexus_repo_manager_el_injection.rb
+++ b/modules/exploits/linux/http/nexus_repo_manager_el_injection.rb
@@ -70,7 +70,6 @@ class MetasploitModule < Msf::Exploit::Remote
     true
   end
 
-
   # Send a GET / request to the server, check the response for a Server header
   # containing the Nexus version, and then check if it's a vulnerable version
   def check

--- a/modules/exploits/linux/local/diamorphine_rootkit_signal_priv_esc.rb
+++ b/modules/exploits/linux/local/diamorphine_rootkit_signal_priv_esc.rb
@@ -88,13 +88,6 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    unless check == CheckCode::Vulnerable
-      unless datastore['ForceExploit']
-        fail_with Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.'
-      end
-      print_warning 'Target does not appear to be vulnerable'
-    end
-
     if is_root?
       unless datastore['ForceExploit']
         fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'

--- a/modules/exploits/multi/http/agent_tesla_panel_rce.rb
+++ b/modules/exploits/multi/http/agent_tesla_panel_rce.rb
@@ -8,7 +8,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::FileDropper
-  include Msf::Exploit::Remote::AutoCheck
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(
@@ -180,9 +180,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    # NOTE: Automatic check is implemented by the AutoCheck mixin
-    super
-
     os = os_get_name
     unless os
       print_bad('Could not determine the targeted operating system.')

--- a/modules/exploits/multi/http/atutor_upload_traversal.rb
+++ b/modules/exploits/multi/http/atutor_upload_traversal.rb
@@ -8,7 +8,7 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::CmdStager
   include Msf::Exploit::FileDropper
-  include Msf::Exploit::Remote::AutoCheck
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(
@@ -317,9 +317,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    # NOTE: Automatic check is implemented by the AutoCheck mixin
-    super
-
     res = login
     if target.name == 'Auto'
       select_target(res)

--- a/modules/exploits/multi/http/liferay_java_unmarshalling.rb
+++ b/modules/exploits/multi/http/liferay_java_unmarshalling.rb
@@ -9,7 +9,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::Remote::Java::HTTP::ClassLoader
-  include Msf::Exploit::Remote::AutoCheck
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(
@@ -107,9 +107,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    # NOTE: Automatic check is implemented by the AutoCheck mixin
-    super
-
     # Start our HTTP server to provide remote classloading
     @classloader_uri = start_service
 

--- a/modules/exploits/multi/http/vbulletin_getindexablecontent.rb
+++ b/modules/exploits/multi/http/vbulletin_getindexablecontent.rb
@@ -7,7 +7,7 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = ManualRanking
 
   include Msf::Exploit::Remote::HttpClient
-  include Msf::Exploit::Remote::AutoCheck
+  prepend Msf::Exploit::Remote::AutoCheck
 
   HttpFingerprint = { method: 'GET', uri: '/', pattern: [/vBulletin.version = '5.+'/] }
 
@@ -492,8 +492,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
   # Performs all exploit functionality
   def exploit
-    super
-
     # Get node_id for requests
     node_id = get_node
     fail_with(Failure::Unknown, 'Could not get a valid node id for the vBulletin install.') unless node_id

--- a/modules/exploits/multi/misc/weblogic_deserialize_badattr_extcomp.rb
+++ b/modules/exploits/multi/misc/weblogic_deserialize_badattr_extcomp.rb
@@ -9,7 +9,7 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::Tcp
   include Msf::Exploit::CmdStager
   include Msf::Exploit::Powershell
-  include Msf::Exploit::Remote::AutoCheck
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(
@@ -100,8 +100,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    super
-
     connect
     print_status('Sending handshake...')
     t3_handshake

--- a/modules/exploits/multi/misc/weblogic_deserialize_badattrval.rb
+++ b/modules/exploits/multi/misc/weblogic_deserialize_badattrval.rb
@@ -9,7 +9,7 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::Tcp
   include Msf::Exploit::CmdStager
   include Msf::Exploit::Powershell
-  include Msf::Exploit::Remote::AutoCheck
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(
@@ -94,8 +94,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    super
-
     connect
     print_status('Sending handshake...')
     t3_handshake

--- a/modules/exploits/unix/local/opensmtpd_oob_read_lpe.rb
+++ b/modules/exploits/unix/local/opensmtpd_oob_read_lpe.rb
@@ -10,7 +10,7 @@ class MetasploitModule < Msf::Exploit::Local
 
   include Msf::Exploit::Remote::TcpServer
   include Msf::Exploit::Remote::Expect
-  include Msf::Exploit::Remote::AutoCheck
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(update_info(info,
@@ -103,9 +103,6 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    # NOTE: Automatic check is implemented by the AutoCheck mixin
-    super
-
     start_service
 
     sendmail = "/usr/sbin/sendmail '#{rcpt_to}' < /dev/null && echo true"

--- a/modules/exploits/unix/smtp/opensmtpd_mail_from_rce.rb
+++ b/modules/exploits/unix/smtp/opensmtpd_mail_from_rce.rb
@@ -9,7 +9,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::Tcp
   include Msf::Exploit::Remote::Expect
-  include Msf::Exploit::Remote::AutoCheck
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(
@@ -79,9 +79,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    # NOTE: Automatic check is implemented by the AutoCheck mixin
-    super
-
     # We don't care who we are, so randomize it
     me = rand_text_alphanumeric(8..42)
 

--- a/modules/exploits/unix/webapp/bolt_authenticated_rce.rb
+++ b/modules/exploits/unix/webapp/bolt_authenticated_rce.rb
@@ -9,7 +9,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::CmdStager
-  include Msf::Exploit::Remote::AutoCheck
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(
@@ -202,9 +202,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    # NOTE: Automatic check is implemented by the AutoCheck mixin
-    super
-
     csrf
     unless @csrf_token && !@csrf_token.empty?
       fail_with Failure::NoAccess, 'Failed to obtain CSRF token'

--- a/modules/exploits/unix/webapp/thinkphp_rce.rb
+++ b/modules/exploits/unix/webapp/thinkphp_rce.rb
@@ -8,7 +8,7 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::HttpClient
-  include Msf::Exploit::Remote::AutoCheck
+  prepend Msf::Exploit::Remote::AutoCheck
   include Msf::Exploit::CmdStager
 
   def initialize(info = {})
@@ -148,9 +148,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    # NOTE: Automatic check is implemented by the AutoCheck mixin
-    super
-
     # This is just extra insurance in case I screwed up the check method
     unless @version
       fail_with(Failure::NoTarget, 'Could not detect ThinkPHP version')

--- a/modules/exploits/unix/webapp/wp_infinitewp_auth_bypass.rb
+++ b/modules/exploits/unix/webapp/wp_infinitewp_auth_bypass.rb
@@ -8,7 +8,7 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = ManualRanking
 
   include Msf::Exploit::Remote::HTTP::Wordpress
-  include Msf::Exploit::Remote::AutoCheck
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(update_info(info,
@@ -121,9 +121,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    # NOTE: Automatic check is implemented by the AutoCheck mixin
-    super
-
     print_status("Bypassing auth for #{username} at #{full_uri}")
     unless (@cookie = auth_bypass).include?('wordpress_logged_in')
       fail_with(Failure::NoAccess, "Could not log in as #{username}")

--- a/modules/exploits/windows/http/desktopcentral_deserialization.rb
+++ b/modules/exploits/windows/http/desktopcentral_deserialization.rb
@@ -8,7 +8,7 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::HttpClient
-  include Msf::Exploit::Remote::AutoCheck
+  prepend Msf::Exploit::Remote::AutoCheck
   include Msf::Exploit::CmdStager
   include Msf::Exploit::Powershell
   include Msf::Exploit::FileDropper
@@ -125,9 +125,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    # NOTE: Automatic check is implemented by the AutoCheck mixin
-    super
-
     print_status("Executing #{target.name} for #{datastore['PAYLOAD']}")
 
     case target['Type']

--- a/modules/exploits/windows/http/plesk_mylittleadmin_viewstate.rb
+++ b/modules/exploits/windows/http/plesk_mylittleadmin_viewstate.rb
@@ -21,7 +21,7 @@ class MetasploitModule < Msf::Exploit::Remote
     "\x77\xe0\x62\x8b\x17\xaa\x92\x80\x39\xbf".freeze
 
   include Msf::Exploit::Remote::HttpClient
-  include Msf::Exploit::Remote::AutoCheck
+  prepend Msf::Exploit::Remote::AutoCheck
   include Msf::Exploit::ViewState
   include Msf::Exploit::CmdStager
   include Msf::Exploit::Powershell
@@ -164,9 +164,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    # NOTE: Automatic check is implemented by the AutoCheck mixin
-    super
-
     print_status("Executing #{target.name} for #{datastore['PAYLOAD']}")
 
     case target['Type']

--- a/modules/exploits/windows/http/sharepoint_workflows_xoml.rb
+++ b/modules/exploits/windows/http/sharepoint_workflows_xoml.rb
@@ -8,7 +8,7 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::CmdStager
   include Msf::Exploit::Powershell
-  include Msf::Exploit::Remote::AutoCheck
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(update_info(info,
@@ -84,9 +84,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    # NOTE: Automatic check is implemented by the AutoCheck mixin
-    super
-
     case target['Type']
     when :windows_command
       execute_command(payload.encoded)

--- a/modules/exploits/windows/http/tomcat_cgi_cmdlineargs.rb
+++ b/modules/exploits/windows/http/tomcat_cgi_cmdlineargs.rb
@@ -8,6 +8,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::CmdStager
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info={})
     super(update_info(info,
@@ -54,11 +55,6 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         OptString.new('TARGETURI', [true, 'The URI path to CGI script', '/'])
-      ])
-
-    register_advanced_options(
-      [
-        OptBool.new('ForceExploit', [false, 'Override check result', false])
       ])
 
     deregister_options('SRVHOST', 'SRVPORT', 'URIPATH')
@@ -118,16 +114,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    print_status("Checking if #{rhost} is vulnerable")
-    unless check == CheckCode::Vulnerable
-      unless datastore['ForceExploit']
-        fail_with(Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.')
-      end
-
-      print_warning('Target does not appear to be vulnerable.')
-    end
-
-    print_status("#{rhost} seems vulnerable, what a good day.")
     execute_cmdstager(flavor: :vbs, temp: '.', linemax: 7000)
   end
 end

--- a/modules/exploits/windows/local/cve_2020_0787_bits_arbitrary_file_move.rb
+++ b/modules/exploits/windows/local/cve_2020_0787_bits_arbitrary_file_move.rb
@@ -12,7 +12,7 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::Windows::ReflectiveDLLInjection
   include Msf::Exploit::FileDropper
   include Msf::Post::File
-  include Msf::Exploit::Remote::AutoCheck
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(
@@ -216,9 +216,6 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    # NOTE: Automatic check is implemented by the AutoCheck mixin
-    super
-
     # Step 1: Check target environment is correct.
     print_status('Step #1: Checking target environment...')
     if is_system?

--- a/modules/exploits/windows/local/cve_2020_0796_smbghost.rb
+++ b/modules/exploits/windows/local/cve_2020_0796_smbghost.rb
@@ -10,7 +10,7 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::Windows::Priv
   include Msf::Post::Windows::Process
   include Msf::Post::Windows::ReflectiveDLLInjection
-  include Msf::Exploit::Remote::AutoCheck
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(
@@ -90,9 +90,6 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    # NOTE: Automatic check is implemented by the AutoCheck mixin
-    super
-
     if is_system?
       fail_with(Failure::None, 'Session is already elevated')
     end

--- a/modules/exploits/windows/local/ntusermndragover.rb
+++ b/modules/exploits/windows/local/ntusermndragover.rb
@@ -15,7 +15,7 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::Windows::Priv
   include Msf::Post::Windows::FileInfo
   include Msf::Post::Windows::ReflectiveDLLInjection
-  include Msf::Exploit::Remote::AutoCheck
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(
@@ -106,8 +106,6 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    super
-
     if is_system?
       fail_with(Failure::None, 'Session is already elevated')
     end

--- a/spec/lib/msf/core/exploit/remote/auto_check.rb
+++ b/spec/lib/msf/core/exploit/remote/auto_check.rb
@@ -119,15 +119,15 @@ RSpec.describe Msf::Exploit::Remote::AutoCheck do
 
       it_behaves_like "An AutoCheck module which can be overridden",
                       check_code: ::Msf::Exploit::CheckCode::Safe,
-                      expected_error: "The target is not exploitable. Disable ForceExploit to override."
+                      expected_error: "The target is not exploitable. Enable ForceExploit to override."
 
       it_behaves_like "An AutoCheck module which can be overridden",
                       check_code: ::Msf::Exploit::CheckCode::Unsupported,
-                      expected_error: "This module does not support check. Disable ForceExploit to override."
+                      expected_error: "This module does not support check. Enable ForceExploit to override."
 
       it_behaves_like "An AutoCheck module which can be overridden",
                       check_code: ::Msf::Exploit::CheckCode::Unknown,
-                      expected_error: "Cannot reliably check exploitability. Disable ForceExploit to override."
+                      expected_error: "Cannot reliably check exploitability. Enable ForceExploit to override."
     end
   end
 end

--- a/spec/lib/msf/core/exploit/remote/auto_check.rb
+++ b/spec/lib/msf/core/exploit/remote/auto_check.rb
@@ -119,15 +119,15 @@ RSpec.describe Msf::Exploit::Remote::AutoCheck do
 
       it_behaves_like "An AutoCheck module which can be overridden",
                       check_code: ::Msf::Exploit::CheckCode::Safe,
-                      expected_error: "The target is not exploitable. Enable ForceExploit to override."
+                      expected_error: "The target is not exploitable. Enable ForceExploit to override check result."
 
       it_behaves_like "An AutoCheck module which can be overridden",
                       check_code: ::Msf::Exploit::CheckCode::Unsupported,
-                      expected_error: "This module does not support check. Enable ForceExploit to override."
+                      expected_error: "This module does not support check. Enable ForceExploit to override check result."
 
       it_behaves_like "An AutoCheck module which can be overridden",
                       check_code: ::Msf::Exploit::CheckCode::Unknown,
-                      expected_error: "Cannot reliably check exploitability. Enable ForceExploit to override."
+                      expected_error: "Cannot reliably check exploitability. Enable ForceExploit to override check result."
     end
   end
 end

--- a/spec/lib/msf/core/exploit/remote/auto_check.rb
+++ b/spec/lib/msf/core/exploit/remote/auto_check.rb
@@ -1,0 +1,133 @@
+require 'spec_helper'
+require 'msf/core/exploit'
+
+RSpec.shared_examples "An AutoCheck module which can be overridden" do |opts|
+  context "When the check method returns #{opts[:check_code]}", focus: opts[:focus] do
+    let(:check_result) { opts[:check_code] }
+
+    context "when the check method returns #{opts[:check_code]}" do
+      context "when ForceExploit is enabled" do
+        before(:each) do
+          subject.datastore['ForceExploit'] = true
+          subject.exploit
+        end
+
+        it "calls the check method" do
+          expect(subject).to have_received(:check)
+        end
+
+        it 'calls the original exploit' do
+          expect(subject).to have_received(:original_exploit_call)
+        end
+      end
+    end
+
+    context "when ForceExploit is disabled" do
+      before(:each) do
+        subject.datastore['ForceExploit'] = false
+      end
+
+      it "it doesn't call the original exploit" do
+        expect { subject.exploit }.to raise_error(opts[:expected_error]) do
+          expect(subject).to_not have_received(:original_exploit_call)
+        end
+      end
+    end
+  end
+end
+
+RSpec.describe Msf::Exploit::Remote::AutoCheck do
+  let(:mock_module) do
+    context_described_class = described_class
+    Class.new(::Msf::Exploit) do
+      prepend context_described_class
+
+      def check
+        # mocked
+      end
+
+      def exploit
+        original_exploit_call
+      end
+
+      def original_exploit_call
+        # Helper for verifying the original exploit function was called
+      end
+    end
+  end
+  subject { mock_module.new }
+
+  before(:each) do
+    allow(subject).to receive(:check).and_return(check_result)
+    allow(subject).to receive(:original_exploit_call).and_call_original
+  end
+
+  describe '#exploit' do
+    context 'when AutoCheck is disabled' do
+      let(:check_result) { ::Msf::Exploit::CheckCode::Vulnerable }
+
+      before(:each) do
+        subject.datastore['AutoCheck'] = false
+        subject.exploit
+      end
+
+      it "doesn't call the check method" do
+        expect(subject).to_not have_received(:check)
+      end
+
+      it "correctly calls the exploit method" do
+        expect(subject).to have_received(:original_exploit_call)
+      end
+    end
+
+    context 'when AutoCheck is enabled' do
+      before(:each) do
+        subject.datastore['AutoCheck'] = true
+      end
+
+      context 'when the check method returns vulnerable' do
+        let(:check_result) { ::Msf::Exploit::CheckCode::Vulnerable }
+
+        before(:each) do
+          subject.exploit
+        end
+
+        it "calls the check method" do
+          expect(subject).to have_received(:check)
+        end
+
+        it 'calls the original exploit' do
+          expect(subject).to have_received(:original_exploit_call)
+        end
+      end
+
+      context 'when the check method returns appears' do
+        let(:check_result) { ::Msf::Exploit::CheckCode::Appears }
+
+        before(:each) do
+          subject.exploit
+        end
+
+        it "calls the check method" do
+          expect(subject).to have_received(:check)
+        end
+
+        it 'calls the original exploit' do
+          expect(subject).to have_received(:original_exploit_call)
+        end
+      end
+
+      it_behaves_like "An AutoCheck module which can be overridden",
+                      check_code: ::Msf::Exploit::CheckCode::Safe,
+                      expected_error: "The target is not exploitable. Disable ForceExploit to override."
+
+      it_behaves_like "An AutoCheck module which can be overridden",
+                      check_code: ::Msf::Exploit::CheckCode::Unsupported,
+                      expected_error: "This module does not support check. Disable ForceExploit to override."
+
+      it_behaves_like "An AutoCheck module which can be overridden",
+                      check_code: ::Msf::Exploit::CheckCode::Unknown,
+                      expected_error: "Cannot reliably check exploitability. Disable ForceExploit to override."
+    end
+  end
+end


### PR DESCRIPTION
This PR updates the AutoCheck mixin from being included to being prepended:

> Module#prepend which is similar to Module#include, however a method in the prepended module overrides the corresponding method in the prepending module.

[Ruby Docs](https://ruby-doc.org/core-2.6.1/Module.html#method-i-prepend_features)

This means that the AutoCheck mixin now acts as a decorator which can conditionally decide when to call the original exploit module, rather than the previous approach which required the exploit module to call AutoCheck mixin.

## Verification

List the steps needed to make sure this thing works

- [x]  Automated tests work and align with assumptions
- [x] Run a module which fails its check
- [x]  **Verify** that `set AutoCheck true/false` works
- [x]  **Verify** that `set ForceExploit true/false` works
