### PR TITLE
Add note about using a module after searching

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -473,8 +473,14 @@ module Msf
             else
               print_line(tbl.to_s)
               print_status("Using #{used_module}") if used_module
-            end
 
+              if @module_search_results.length > 1
+                index_usage = "use #{@module_search_results.length - 1}"
+                name_usage = "use #{@module_search_results.last.fullname}"
+
+                print("Interact with a module by name or index, for example %grn#{index_usage}%clr or %grn#{name_usage}%clr\n\n")
+              end
+            end
             true
           end
 


### PR DESCRIPTION
Adds additional affordance to the search command, directing users to either the `use id` or `use name` syntax:

![image](https://user-images.githubusercontent.com/60357436/86278516-6a588800-bbd0-11ea-8d58-c6c564a7175a.png)

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] Search for a module and ensure the `usage` command affordance is now present