### PR TITLE
Point to paylodas v2.0.8

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,7 +29,7 @@ PATH
       metasploit-concern (~> 2.0.0)
       metasploit-credential (~> 3.0.0)
       metasploit-model (~> 2.0.4)
-      metasploit-payloads (= 2.0.6)
+      metasploit-payloads (= 2.0.8)
       metasploit_data_models (~> 3.0.10)
       metasploit_payloads-mettle (= 1.0.1)
       mqtt
@@ -220,7 +220,7 @@ GEM
       activemodel (~> 4.2.6)
       activesupport (~> 4.2.6)
       railties (~> 4.2.6)
-    metasploit-payloads (2.0.6)
+    metasploit-payloads (2.0.8)
     metasploit_data_models (3.0.10)
       activerecord (~> 4.2.6)
       activesupport (~> 4.2.6)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -70,7 +70,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model', '~> 2.0.4'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '2.0.6'
+  spec.add_runtime_dependency 'metasploit-payloads', '2.0.8'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '1.0.1'
   # Needed by msfgui and other rpc components


### PR DESCRIPTION
This bumps the payloads version up to 2.0.8, which includes valid working binaries for 6.x

Thanks @bcook-r7, @jmartin-r7 and @smcintyre-r7  for helping with this!