### PR TITLE
Add websocket notification real time terminal

### DIFF
--- a/lib/msf/core/framework.rb
+++ b/lib/msf/core/framework.rb
@@ -62,6 +62,7 @@ class Framework
   require 'msf/core/event_dispatcher'
   require 'rex/json_hash_file'
   require 'msf/core/cert_provider'
+  require 'msf/core/ws_manager'
 
   #
   # Creates an instance of the framework context.
@@ -219,6 +220,16 @@ class Framework
   def sessions
     synchronize {
       @sessions ||= Msf::SessionManager.new(self)
+    }
+  end
+
+  # Websocket manager that tracks websocket associated with this framework
+  # instance over the course of their lifetime.
+  #
+  # @return [Msf::WebSocketManager]
+  def websocket
+    synchronize {
+      @websocket ||= Msf::WebSocketManager.new(self)
     }
   end
 

--- a/lib/msf/core/rpc/ws/ws_event_notify.rb
+++ b/lib/msf/core/rpc/ws/ws_event_notify.rb
@@ -1,0 +1,57 @@
+module Msf
+  module WS
+    class EventNotify
+      class Subscriber
+        include Framework::Offspring
+        def initialize(framework)
+          self.framework = framework
+        end
+
+        def respond_to?(_name, *_args)
+          # Why yes, I can do that.
+          true
+        end
+
+        def on_session_open(session)
+          res = {
+            'type' => session.type.to_s,
+            'tunnel_to_s' => session.tunnel_to_s,
+            'via_exploit' => session.via_exploit.to_s,
+            'via_payload' => session.via_payload.to_s
+          }
+          if (session.type.to_s == 'meterpreter')
+            res['platform'] = session.platform.to_s
+          end
+          data = framework.websocket.wrap_websocket_data(:notify, __method__, res)
+          framework.websocket.notify(:notify, data)
+        end
+
+        def on_session_close(session, reason = '')
+          res = {
+            'type' => session.type.to_s,
+            'reason' => reason.to_s,
+            'tunnel_to_s' => session.tunnel_to_s,
+            'via_exploit' => session.via_exploit.to_s,
+            'via_payload' => session.via_payload.to_s
+          }
+          if (session.type.to_s == 'meterpreter')
+            res['platform'] = session.platform.to_s
+          end
+          data = framework.websocket.wrap_websocket_data(:notify, __method__, res)
+          framework.websocket.notify(:notify, data)
+        end
+
+        def method_missing(_method_name, *_args)
+        end
+
+      end
+      def initialize(framework, _opts)
+        @subscriber = Subscriber.new(framework)
+        subscribers = framework.events.instance_variable_get(:@session_event_subscribers).collect(&:class)
+        if !subscribers.include?(@subscriber.class)
+          framework.events.add_session_subscriber(@subscriber)
+        end
+      end
+    end
+  end
+end

--- a/lib/msf/core/web_services/json_rpc_app.rb
+++ b/lib/msf/core/web_services/json_rpc_app.rb
@@ -8,6 +8,7 @@ require 'msf/core/web_services/framework_extension'
 require 'msf/core/web_services/servlet_helper'
 require 'msf/core/web_services/servlet/auth_servlet'
 require 'msf/core/web_services/servlet/json_rpc_servlet'
+require 'msf/core/web_services/servlet/web_socket_servlet'
 require 'msf/core/web_services/json_rpc_exception_handling'
 
 module Msf::WebServices
@@ -22,6 +23,7 @@ module Msf::WebServices
     # Servlet registration
     register AuthServlet
     register JsonRpcServlet
+    register WebsocketServlet
 
     # Custom error handling
     register JsonRpcExceptionHandling::SinatraExtension

--- a/lib/msf/core/web_services/servlet/web_socket_servlet.rb
+++ b/lib/msf/core/web_services/servlet/web_socket_servlet.rb
@@ -1,0 +1,94 @@
+require 'msf/core/rpc'
+require 'faye/websocket'
+
+module Msf::WebServices
+  module WebsocketServlet
+    Faye::WebSocket.load_adapter('thin')
+    def self.api_path
+      '/api/v1/websocket'
+    end
+
+    def self.api_path_for_notify
+      "#{WebsocketServlet.api_path}/notify"
+    end
+
+    def self.api_path_for_console
+      "#{WebsocketServlet.api_path}/console"
+    end
+
+    def self.registered(app)
+      app.get WebsocketServlet.api_path_for_notify, &notify
+      app.get WebsocketServlet.api_path_for_console, &console
+    end
+
+    def self.notify
+      lambda {
+        warden.authenticate!
+        if Faye::WebSocket.websocket?(env)
+          ws = Faye::WebSocket.new(env, nil, { ping: 15 })
+          username = ws.env['warden'].authenticate ? ws.env['warden'].authenticate.username : nil
+          ws.on :open do |_event|
+            framework.websocket.register(:notify, ws)
+            data = framework.websocket.wrap_websocket_data(:notify, 'login', { username: username })
+            framework.websocket.notify(:notify, data)
+          end
+
+          ws.on :close do |_event|
+            framework.websocket.deregister(:notify, ws)
+            data = framework.websocket.wrap_websocket_data(:notify, 'logout', { username: username })
+            framework.websocket.notify(:notify, data)
+            ws = nil
+          end
+
+          ws.on :message do |event|
+            begin
+              ws_data = JSON.parse(event.data)
+              framework.websocket.notify(:notify, ws_data.to_json)
+            rescue JSON::ParserError => e
+              data = framework.websocket.wrap_websocket_data(:notify, 'error', { error: e.to_s })
+              ws.send(data)
+            end
+          end
+          ws.rack_response
+        else
+          [200, { 'Content-Type' => 'application/json' }, ['Error']]
+        end
+      }
+    end
+
+    def self.console
+      lambda {
+        warden.authenticate!
+        if Faye::WebSocket.websocket?(env)
+          ws = Faye::WebSocket.new(env, nil, { ping: 15 })
+          ws.on :open do |_event|
+            framework.websocket.register(:console, ws)
+            @console_driver = Msf::Ui::Web::Driver.new(framework: framework)
+            @cid = @console_driver.create_console({})
+            @console_driver.consoles[@cid].pipe.create_subscriber_proc(
+              'ws', &proc { |output|
+                       data = { cid: @cid, prompt: @console_driver.consoles[@cid].prompt, output: output }
+                       ws.send(data.to_json)
+                     }
+            )
+          end
+
+          ws.on :close do |_event|
+            framework.websocket.deregister(:console, ws)
+            @console_driver.consoles[@cid].shutdown
+            @console_driver.consoles.delete(@cid)
+            ws = nil
+          end
+
+          ws.on :message do |event|
+            input = event.data
+            @console_driver.consoles[@cid].pipe.write_input(input)
+          end
+          ws.rack_response
+        else
+          [200, { 'Content-Type' => 'application/json' }, ['Error']]
+        end
+      }
+    end
+  end
+end

--- a/lib/msf/core/ws_manager.rb
+++ b/lib/msf/core/ws_manager.rb
@@ -1,0 +1,45 @@
+# -*- coding: binary -*-
+require 'msf/core/rpc/ws/ws_event_notify'
+
+module Msf
+  # Ws
+  class WebSocketManager
+    include Framework::Offspring
+
+    attr_accessor :handlers
+    def initialize(framework)
+      self.framework = framework
+      self.clients = { notify: [] }
+      self.handlers = {}
+
+      add_handler(:notify, Msf::WS::EventNotify.new(framework, {}))
+    end
+
+    def register(type, ws)
+      clients[type] = [] if !clients.key?(type)
+      clients[type] << ws if !clients[type].include?(ws)
+    end
+
+    def deregister(type, ws)
+      clients[type] = [] if !clients.key?(type)
+      clients[type].delete(ws) if clients[type].include?(ws)
+    end
+
+    def wrap_websocket_data(type, action, data)
+      res = { type: type, action: action, data: data }
+      res.to_json
+    end
+
+    def notify(type, message)
+      clients[type].each { |client| client.send(message) }
+    end
+
+    def add_handler(group, handler)
+      handlers[group] = handler
+    end
+
+    attr_accessor :websocket # :nodoc:
+    attr_accessor :clients # :nodoc:
+
+  end
+end


### PR DESCRIPTION
This branch adds websocket notification and real-time terminal to API. 
I am developing a front-end project for Metasploit, which requires the server to actively notify messages. 
When a session is opened, I do not need to refresh the browser to get the notification. 
The idea of real-time terminal came to me temporarily. I think it makes good use of the real-time property of websocket.

This makes it possible for multiple users to operate a target at the same time, Like **Cobalt Strike**

- Start RPC service
```
bundle exec thin --rackup msf-json-rpc.ru --address rpc.kali-team.cn --port 8081 --ssl --ssl-key-file /home/kali-team/.msf4/msf-ws-key.pem --ssl-cert-file /home/kali-team/.msf4/msf-ws-cert.pem --ssl-disable-verify --environment development --log /home/kali-team/.msf4/logs/msf-ws.log --pid /home/kali-team/.msf4/msf-ws.pid --tag msf-json-rpc --debug start --threaded
```
## notification

Because browser‘s console can't add headers to websocket requests, I'll test them with client code.
Or comment out the authentication function before testing. **warden.authenticate!**

- ruby client
``` ruby
require 'faye/websocket'
require 'eventmachine'
require 'pry'
EM.run{

  ws = Faye::WebSocket::Client.new('wss://rpc.kali-team.cn:8081/api/v1/websocket/notify', [], {
    :headers => { 'Authorization' => 'Bearer 15f96b3959677f6e45c2efaa1b42ae46cdcac96a2c0e41d3e2033d001af534d10842f40fe58ee081' }
  })
  ws.on :open do |e|
    p [:open]
  end

  ws.on :message do |e|
    p [:message, e.data]
  end

  ws.on :close do |e|
    p [:close, e.code, e.reason]
    ws = nil
  end
 }

```
- run client
``` shell
✗ ruby ../client.rb
[:open]
[:message, "{\"type\":\"notify\",\"action\":\"login\",\"data\":{\"username\":\"rpc\"}}"]
[:message, "{\"type\":\"notify\",\"action\":\"on_session_open\",\"data\":{\"type\":\"meterpreter\",\"tunnel_to_s\":\"192.168.76.1:7788 -\\u003e 192.168.76.128:1090\",\"via_exploit\":\"exploit/multi/handler\",\"via_payload\":\"payload/windows/meterpreter/reverse_tcp\",\"platform\":\"windows\"}}"]
[:message, "{\"type\":\"notify\",\"action\":\"on_session_close\",\"data\":{\"type\":\"meterpreter\",\"reason\":\"Died\",\"tunnel_to_s\":\"192.168.76.1:7788 -\\u003e 192.168.76.128:1090\",\"via_exploit\":\"exploit/multi/handler\",\"via_payload\":\"payload/windows/meterpreter/reverse_tcp\",\"platform\":\"windows\"}}"]
[:close, 1006, ""]

```
- You can see on_ session_ open and on_ session_ close keyword.
- It can also be a user's chat room

## Real time terminal
- Chrome Console
```
ws = new WebSocket("wss://rpc.kali-team.cn:8081/api/v1/websocket/console");
WebSocket {url: "wss://rpc.kali-team.cn:8081/api/v1/websocket/console", readyState: 0, bufferedAmount: 0, onopen: null, onerror: null, …}
ws.onmessage = function(evt){console.log(JSON.parse(evt.data)['output']);};
ƒ (evt){console.log(JSON.parse(evt.data)['output']);}
[*] Meterpreter session 1 opened (192.168.76.1:7788 -> 192.168.76.128:1025) at 2020-07-05 23:50:07 +0800

ws.send("sessions\r\n")

Active sessions
===============

  Id  Name  Type                     Information                                      Connection
  --  ----  ----                     -----------                                      ----------
  1         meterpreter x86/windows  KT-7445BC822526\Administrator @ KT-7445BC822526  192.168.76.1:7788 -> 192.168.76.128:1025 (192.168.76.128)

ws.send("sessions 1\r\n")
[*] Starting interaction with 1...


ws.send("sysinfo\r\n")

Computer        : KT-7445BC822526
OS              : Windows XP (5.1 Build 2600, Service Pack 3).
Architecture    : x86
System Language : zh_CN
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x86/windows
```
- ruby client

``` ruby
require 'faye/websocket'
require 'eventmachine'
require 'pry'
EM.run{

  ws = Faye::WebSocket::Client.new('wss://rpc.kali-team.cn:8081/api/v1/websocket/console', [], {
    :headers => { 'Authorization' => 'Bearer 15f96b3959677f6e45c2efaa1b42ae46cdcac96a2c0e41d3e2033d001af534d10842f40fe58ee081' }
  })
  ws.on :open do |e|
    ws.send("show options\r\n")
    p [:open]
  end

  ws.on :message do |e|
    # binding.pry
    p [:message, e.data]
  end

  ws.on :close do |e|
    p [:close, e.code, e.reason]
    ws = nil
  end
 }
```
- run client
``` shell
✗ ruby ../client.rb
[:open]
[:message, "{\"cid\":\"0\",\"prompt\":\"\\u0001\\u0002msf5\\u0001\\u0002 \\u0001\\u0002\\u003e \",\"output\":\"\\nGlobal Options:\\n===============\\n\\n   Option             Current Setting      Description\\n   ------             ---------------      -----------\\n   ConsoleLogging     false                Log all console input and output\\n   LogLevel           0                    Verbosity of logs (default 0, max 3)\\n   MeterpreterPrompt  %undmeterpreter%clr  The meterpreter prompt string\\n   MinimumRank        0                    The minimum rank of exploits that will run without explicit confirmation\\n   Prompt             msf5                 The prompt string\\n   PromptChar         \\u003e                    The prompt character\\n   PromptTimeFormat   %Y-%m-%d %H:%M:%S    Format for timestamp escapes in prompts\\n   SessionLogging     false                Log all input and output for sessions\\n   TimestampOutput    false                Prefix all console output with a timestamp\\n\\n\"}"]
```