### PR TITLE
Make cmd/unix target types consistent to :unix_cmd

### DIFF
--- a/modules/exploits/linux/http/cisco_ucs_cloupia_script_rce.rb
+++ b/modules/exploits/linux/http/cisco_ucs_cloupia_script_rce.rb
@@ -54,7 +54,7 @@ class MetasploitModule < Msf::Exploit::Remote
             'Unix Command',
             'Platform' => 'unix',
             'Arch' => ARCH_CMD,
-            'Type' => :unix_command,
+            'Type' => :unix_cmd,
             'DefaultOptions' => {
               'PAYLOAD' => 'cmd/unix/reverse_bash'
             }
@@ -135,7 +135,7 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("Executing #{target.name} for #{datastore['PAYLOAD']}")
 
     case target['Type']
-    when :unix_command
+    when :unix_cmd
       execute_command(payload.encoded)
     when :linux_dropper
       execute_cmdstager

--- a/modules/exploits/linux/http/citrix_dir_traversal_rce.rb
+++ b/modules/exploits/linux/http/citrix_dir_traversal_rce.rb
@@ -51,7 +51,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ['Unix Command',
           'Platform'        => 'unix',
           'Arch'            => ARCH_CMD,
-          'Type'            => :unix_command,
+          'Type'            => :unix_cmd,
           'DefaultOptions'  => {'PAYLOAD' => 'cmd/unix/reverse_perl'}
         ]
       ],
@@ -99,7 +99,7 @@ class MetasploitModule < Msf::Exploit::Remote
     case target['Type']
     when :python
       execute_command(%(/var/python/bin/python2 -c "#{payload.encoded}"))
-    when :unix_command
+    when :unix_cmd
       if (res = execute_command(payload.encoded)) && cmd_unix_generic?
         print_line(res.get_html_document.text.gsub(/undef error - Attempt to bless.*/m, ''))
       end

--- a/modules/exploits/linux/misc/saltstack_salt_unauth_rce.rb
+++ b/modules/exploits/linux/misc/saltstack_salt_unauth_rce.rb
@@ -62,7 +62,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [
             'Master (Unix command)',
             'Description' => 'Executing Unix command on the master',
-            'Type' => :unix_command,
+            'Type' => :unix_cmd,
             'DefaultOptions' => {
               'PAYLOAD' => 'cmd/unix/reverse_python_ssl'
             }
@@ -78,7 +78,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [
             'Minions (Unix command)',
             'Description' => 'Executing Unix command on the minions',
-            'Type' => :unix_command,
+            'Type' => :unix_cmd,
             'DefaultOptions' => {
               # cmd/unix/reverse_python_ssl crashes in this target
               'PAYLOAD' => 'cmd/unix/reverse_python'
@@ -178,7 +178,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'lang' => payload.arch.first,
         'code' => payload.encoded
       )
-    when :unix_command
+    when :unix_cmd
       # HTTPS doesn't appear to be supported by the server :(
       print_status("Serving intermediate stager over HTTP: #{start_service}")
 
@@ -236,7 +236,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'fun' => 'cmd.exec_code',
         'arg' => [payload.arch.first, payload.encoded]
       )
-    when :unix_command
+    when :unix_cmd
       vprint_status("Executing Unix command: #{payload.encoded}")
 
       # https://docs.saltstack.com/en/master/ref/modules/all/salt.modules.cmdmod.html#salt.modules.cmdmod.run


### PR DESCRIPTION
There were some using `:unix_command`, and it was just an oversight.