### PR TITLE
Remove rspec test focus, and ensure all tests run

### DIFF
--- a/spec/lib/msf/core/modules/loader/base_spec.rb
+++ b/spec/lib/msf/core/modules/loader/base_spec.rb
@@ -357,7 +357,7 @@ RSpec.describe Msf::Modules::Loader::Base do
           allow(module_manager).to receive(:on_module_load)
 
           # if the module eval error includes the module_path then the module_path was passed along correctly
-          expect(subject).to receive(:elog).with(/#{Regexp.escape(module_path)}/)
+          expect(subject).to receive(:elog).with(/#{Regexp.escape(module_path)}/, error: an_instance_of(NoMethodError))
           expect(subject.load_module(parent_path, type, module_reference_name, :reload => true)).to be_falsey
         end
 

--- a/spec/rubocop/cop/layout/module_description_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/module_description_indentation_spec.rb
@@ -267,7 +267,7 @@ RSpec.describe RuboCop::Cop::Layout::ModuleDescriptionIndentation do
     RUBY
   end
 
-  it 'registers an offense when there is additional whitespace', focus: true do
+  it 'registers an offense when there is additional whitespace' do
     expect_offense(<<~RUBY)
       class DummyModule
         def initialize(info = {})

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -51,8 +51,12 @@ RSpec.configure do |config|
   # to individual examples or groups you care about by tagging them with
   # `:focus` metadata. When nothing is tagged with `:focus`, all examples
   # get run.
-  config.filter_run :focus
-  config.run_all_when_everything_filtered = true
+  if ENV['CI']
+    config.before(:example, :focus) { raise "Should not commit focused specs" }
+  else
+    config.filter_run focus: true
+    config.run_all_when_everything_filtered = true
+  end
 
   # allow more verbose output when running an individual spec file.
   if config.files_to_run.one?

--- a/spec/support/shared/examples/msf/db_manager/migration.rb
+++ b/spec/support/shared/examples/msf/db_manager/migration.rb
@@ -52,35 +52,28 @@ RSpec.shared_examples_for 'Msf::DBManager::Migration' do
     end
 
     context 'with StandardError from ActiveRecord::Migration.migrate' do
-      let(:error) do
+      let(:standard_error) do
         StandardError.new(message)
       end
 
       let(:message) do
-        "Error during migration"
+        "DB.migrate threw an exception"
       end
 
       before(:example) do
-        expect(ActiveRecord::Migrator).to receive(:migrate).and_raise(error)
+        expect(ActiveRecord::Migrator).to receive(:migrate).and_raise(standard_error)
       end
 
       it 'should set Msf::DBManager#error' do
         migrate
 
-        expect(db_manager.error).to eq error
+        expect(db_manager.error).to eq standard_error
       end
 
       it 'should log error message at error level' do
-        expect(db_manager).to receive(:elog) do |error_message|
-          expect(error_message).to include(error.to_s)
-        end
-
-        migrate
-      end
-
-      it 'should log error backtrace at debug level' do
-        expect(db_manager).to receive(:dlog) do |debug_message|
-          expect(debug_message).to include('Call stack')
+        expect(db_manager).to receive(:elog) do |error_message, error:|
+          expect(error_message).to include(standard_error.to_s)
+          expect(error).to eql(standard_error)
         end
 
         migrate


### PR DESCRIPTION
Only one test is currently being run within the test suite due to an unintentional commit of `focus: true` on the rspec test suite.

~~There will be a separate pull request created to ensure that this mistake can't happen in the future~~

Adding the fail safe to this pull request