### PR TITLE
Update rubocop version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,7 @@ group :development, :test do
   # environment is development
   gem 'rspec-rails'
   gem 'rspec-rerun'
-  gem 'rubocop', "0.86.0"
+  gem 'rubocop'
   gem 'swagger-blocks'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -375,13 +375,13 @@ GEM
     rspec-rerun (1.1.0)
       rspec (~> 3.0)
     rspec-support (3.9.3)
-    rubocop (0.86.0)
+    rubocop (0.87.0)
       parallel (~> 1.10)
-      parser (>= 2.7.0.1)
+      parser (>= 2.7.1.1)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.7)
       rexml
-      rubocop-ast (>= 0.0.3, < 1.0)
+      rubocop-ast (>= 0.1.0, < 1.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 2.0)
     rubocop-ast (0.1.0)
@@ -450,7 +450,7 @@ DEPENDENCIES
   redcarpet
   rspec-rails
   rspec-rerun
-  rubocop (= 0.86.0)
+  rubocop
   ruby-prof
   simplecov (= 0.18.2)
   sqlite3 (~> 1.3.0)

--- a/lib/rubocop/cop/layout/module_description_indentation.rb
+++ b/lib/rubocop/cop/layout/module_description_indentation.rb
@@ -1,7 +1,8 @@
 module RuboCop
   module Cop
     module Layout
-      class ModuleDescriptionIndentation < Cop
+      class ModuleDescriptionIndentation < Base
+        extend AutoCorrector
         include Alignment
 
         MSG = "Module descriptions should be properly aligned to the 'Description' key, and within %q{ ... }"
@@ -22,13 +23,15 @@ module RuboCop
           hash.each_pair do |key, value|
             if key.value == "Description"
               if requires_correction?(key, value)
-                add_offense(value, location: :end)
+                add_offense(value.location.end, &autocorrector(value))
               end
             end
           end
         end
 
-        def autocorrect(description_value)
+        private
+
+        def autocorrector(description_value)
           lambda do |corrector|
             description_key = description_value.parent.key
             new_content = indent_description_value_correctly(description_key, description_value)
@@ -36,8 +39,6 @@ module RuboCop
             corrector.replace(description_value.source_range, new_content)
           end
         end
-
-        private
 
         def requires_correction?(description_key, description_value)
           return false if description_value.single_line?

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,7 @@ require File.expand_path('../../config/rails_bigdecimal_fix', __FILE__)
 #
 # Must be explicit as activerecord is optional dependency
 require 'active_record/railtie'
+require 'rubocop'
 require 'rubocop/rspec/support'
 require 'metasploit/framework/database'
 # check if database.yml is present


### PR DESCRIPTION
Rubocop is changing their API in preparation for a major 1.0 release. This pull request aligns with the latest API as documented in their [upgrade guide](https://github.com/rubocop-hq/rubocop/blob/698a17f46b554fad89ef51076bdd0207b71f1856/docs/modules/ROOT/pages/v1_upgrade_notes.adoc#cop-upgrade-guide).
