### PR TITLE
clear crypto spec warning

### DIFF
--- a/spec/lib/rex/crypto/aes256_spec.rb
+++ b/spec/lib/rex/crypto/aes256_spec.rb
@@ -21,14 +21,14 @@ RSpec.describe Rex::Crypto do
       iv = SecureRandom.random_bytes(1)
       # Because it could raise either a OpenSSL::Cipher::CipherError or an ArgumentError
       # dependong on the environment, we will just expect it to raise an exception
-      expect { Rex::Crypto.encrypt_aes256(iv, key, value) }.to raise_exception
+      expect { Rex::Crypto.encrypt_aes256(iv, key, value) }.to raise_exception ArgumentError
     end
 
     it 'raises an exception due to a short key' do
       key = SecureRandom.random_bytes(1)
       # Because it could raise either a OpenSSL::Cipher::CipherError or an ArgumentError
       # dependong on the environment, we will just expect it to raise an exception
-      expect { Rex::Crypto.encrypt_aes256(iv, key, value) }.to raise_exception
+      expect { Rex::Crypto.encrypt_aes256(iv, key, value) }.to raise_exception ArgumentError
     end
 
     it 'encrypts the string Hello World' do
@@ -42,14 +42,14 @@ RSpec.describe Rex::Crypto do
       iv = SecureRandom.random_bytes(1)
       # Because it could raise either a OpenSSL::Cipher::CipherError or an ArgumentError
       # dependong on the environment, we will just expect it to raise an exception
-      expect { Rex::Crypto.decrypt_aes256(iv, key, value) }.to raise_exception
+      expect { Rex::Crypto.decrypt_aes256(iv, key, value) }.to raise_exception ArgumentError
     end
 
     it 'raises an exception due to a short key' do
       key = SecureRandom.random_bytes(1)
       # Because it could raise either a OpenSSL::Cipher::CipherError or an ArgumentError
       # dependong on the environment, we will just expect it to raise an exception
-      expect { Rex::Crypto.decrypt_aes256(iv, key, value) }.to raise_exception
+      expect { Rex::Crypto.decrypt_aes256(iv, key, value) }.to raise_exception ArgumentError
     end
 
     it 'decrypts the value to Hello World' do


### PR DESCRIPTION
add specific error class to remove warning

## Verification

List the steps needed to make sure this thing works

- [ ] Check Travis results no longer report:
```
WARNING: Using the `raise_error` matcher without providing a specific error or message risks false positives, since `raise_error` will match when Ruby raises a `NoMethodError`, `NameError` or `ArgumentError`, potentially allowing the expectation to pass without even executing the method you are intending to call. Actual error raised was...
```
