### PR TITLE
Credit Mikhail Klyuchnikov for CVE-2019-19781

### DIFF
--- a/modules/auxiliary/scanner/http/citrix_dir_traversal.rb
+++ b/modules/auxiliary/scanner/http/citrix_dir_traversal.rb
@@ -25,7 +25,8 @@ class MetasploitModule < Msf::Auxiliary
       ],
       'References'     => [
         ['CVE', '2019-19781'],
-        ['URL', 'https://support.citrix.com/article/CTX267027/']
+        ['URL', 'https://support.citrix.com/article/CTX267027/'],
+        ['URL', 'https://swarm.ptsecurity.com/remote-code-execution-in-citrix-adc/']
       ],
       'DisclosureDate' => '2019-12-17',
       'License'        => MSF_LICENSE,

--- a/modules/auxiliary/scanner/http/citrix_dir_traversal.rb
+++ b/modules/auxiliary/scanner/http/citrix_dir_traversal.rb
@@ -19,8 +19,9 @@ class MetasploitModule < Msf::Auxiliary
         a "[global]" directive in smb.conf, which this file should always contain.
       },
       'Author'         => [
-        'Erik Wynter', # Module (@wyntererik)
-        'altonjx'      # Module (@altonjx)
+        'Mikhail Klyuchnikov', # Discovery
+        'Erik Wynter',         # Module (@wyntererik)
+        'altonjx'              # Module (@altonjx)
       ],
       'References'     => [
         ['CVE', '2019-19781'],

--- a/modules/exploits/linux/http/citrix_dir_traversal_rce.rb
+++ b/modules/exploits/linux/http/citrix_dir_traversal_rce.rb
@@ -35,7 +35,8 @@ class MetasploitModule < Msf::Exploit::Remote
         ['EDB', '47901'],
         ['EDB', '47902'],
         ['URL', 'https://support.citrix.com/article/CTX267027/'],
-        ['URL', 'https://www.mdsec.co.uk/2020/01/deep-dive-to-citrix-adc-remote-code-execution-cve-2019-19781/']
+        ['URL', 'https://www.mdsec.co.uk/2020/01/deep-dive-to-citrix-adc-remote-code-execution-cve-2019-19781/'],
+        ['URL', 'https://swarm.ptsecurity.com/remote-code-execution-in-citrix-adc/']
       ],
       'DisclosureDate'      => '2019-12-17',
       'License'             => MSF_LICENSE,

--- a/modules/exploits/linux/http/citrix_dir_traversal_rce.rb
+++ b/modules/exploits/linux/http/citrix_dir_traversal_rce.rb
@@ -19,6 +19,7 @@ class MetasploitModule < Msf::Exploit::Remote
         NetScaler, and Gateway 10.5, 11.1, 12.0, 12.1, and 13.0, to execute an arbitrary command payload.
       },
       'Author'              => [
+        'Mikhail Klyuchnikov',          # Discovery
         'Project Zero India',           # PoC used by this module
         'TrustedSec',                   # PoC used by this module
         'James Brytan',                 # PoC contributed independently


### PR DESCRIPTION
This should not have been missed.

```
wvu@kharak-STABLE:/rapid7/metasploit-framework:bug/author$ git grep "Mikhail Klyuchnikov"
db/modules_metadata_base.json:      "Mikhail Klyuchnikov",
modules/auxiliary/scanner/http/citrix_dir_traversal.rb:        'Mikhail Klyuchnikov', # Discovery
modules/exploits/linux/http/citrix_dir_traversal_rce.rb:        'Mikhail Klyuchnikov',          # Discovery
modules/exploits/linux/http/f5_bigip_tmui_rce.rb:          'Mikhail Klyuchnikov', # Discovery
wvu@kharak-STABLE:/rapid7/metasploit-framework:bug/author$
```

Fixes #12813 and #12816.