### PR TITLE
Add WrappedTable support with feature flag integration

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -341,7 +341,7 @@ GEM
       rex-socket
       rex-text
     rex-struct2 (0.1.2)
-    rex-text (0.2.27)
+    rex-text (0.2.28)
     rex-zip (0.1.3)
       rex-text
     rexml (3.2.4)

--- a/lib/msf/core.rb
+++ b/lib/msf/core.rb
@@ -41,6 +41,7 @@ require 'msf/events'
 
 # Framework context and core classes
 require 'msf/core/framework'
+require 'msf/core/feature_manager'
 require 'msf/core/db_manager'
 require 'msf/core/event_dispatcher'
 require 'msf/core/module_manager'

--- a/lib/msf/core/feature_manager.rb
+++ b/lib/msf/core/feature_manager.rb
@@ -1,0 +1,68 @@
+# -*- coding: binary -*-
+# frozen_string_literal: true
+
+require 'msf/core/plugin'
+
+module Msf
+  ###
+  #
+  # The feature manager is responsible for managing feature flags that can change characteristics of framework.
+  #
+  ###
+  class FeatureManager
+
+    include Framework::Offspring
+
+    WRAPPED_TABLES = 'wrapped_tables'
+    DEFAULTS = [
+      {
+        name: 'wrapped_tables',
+        description: 'When enabled Metasploit will wordwrap all tables to fit into the available terminal width',
+        enabled: false
+      }.freeze
+    ].freeze
+
+    #
+    # Initializes the feature manager.
+    #
+    def initialize(framework)
+      @framework = framework
+      @flag_lookup = DEFAULTS.each_with_object({}) do |feature, acc|
+        key = feature[:name]
+        acc[key] = feature.dup
+      end
+    end
+
+    def all
+      @flag_lookup.values
+    end
+
+    def enabled?(name)
+      return false unless @flag_lookup[name]
+
+      @flag_lookup[name][:enabled] == true
+    end
+
+    def exists?(name)
+      @flag_lookup.key?(name)
+    end
+
+    def names
+      all.map { |feature| feature[:name] }
+    end
+
+    def set(name, value)
+      return false unless @flag_lookup[name]
+
+      @flag_lookup[name][:enabled] = value
+
+      if name == WRAPPED_TABLES
+        if value
+          Rex::Text::Table.wrap_tables!
+        else
+          Rex::Text::Table.unwrap_tables!
+        end
+      end
+    end
+  end
+end

--- a/lib/msf/core/feature_manager.rb
+++ b/lib/msf/core/feature_manager.rb
@@ -7,26 +7,26 @@ module Msf
   ###
   #
   # The feature manager is responsible for managing feature flags that can change characteristics of framework.
-  #
+  # Each feature will have a default value. The user can choose to override this default value if they wish.
   ###
   class FeatureManager
 
-    include Framework::Offspring
+    include Singleton
 
+    CONFIG_KEY = 'framework/features'
     WRAPPED_TABLES = 'wrapped_tables'
     DEFAULTS = [
       {
         name: 'wrapped_tables',
         description: 'When enabled Metasploit will wordwrap all tables to fit into the available terminal width',
-        enabled: false
+        default_value: false
       }.freeze
     ].freeze
 
     #
     # Initializes the feature manager.
     #
-    def initialize(framework)
-      @framework = framework
+    def initialize
       @flag_lookup = DEFAULTS.each_with_object({}) do |feature, acc|
         key = feature[:name]
         acc[key] = feature.dup
@@ -34,13 +34,16 @@ module Msf
     end
 
     def all
-      @flag_lookup.values
+      @flag_lookup.values.map do |feature|
+        feature.slice(:name, :description).merge(enabled: enabled?(feature[:name]))
+      end
     end
 
     def enabled?(name)
       return false unless @flag_lookup[name]
 
-      @flag_lookup[name][:enabled] == true
+      feature = @flag_lookup[name]
+      feature.key?(:user_preference) ? feature[:user_preference] : feature[:default_value]
     end
 
     def exists?(name)
@@ -54,7 +57,7 @@ module Msf
     def set(name, value)
       return false unless @flag_lookup[name]
 
-      @flag_lookup[name][:enabled] = value
+      @flag_lookup[name][:user_preference] = value
 
       if name == WRAPPED_TABLES
         if value
@@ -63,6 +66,26 @@ module Msf
           Rex::Text::Table.unwrap_tables!
         end
       end
+    end
+
+    def load_config
+      conf = Msf::Config.load
+      conf.fetch(CONFIG_KEY, {}).each do |name, value|
+        set(name, value == 'true')
+      end
+    end
+
+    def save_config
+      # Note, we intentionally omit features that have not explicitly been set by the user.
+      config = Msf::Config.load
+      old_config = config.fetch(CONFIG_KEY, {})
+      new_config = @flag_lookup.values.each_with_object(old_config) do |feature, config|
+        next unless feature.key?(:user_preference)
+
+        config.merge!(feature[:name] => feature[:user_preference].to_s)
+      end
+
+      Msf::Config.save(CONFIG_KEY => new_config)
     end
   end
 end

--- a/lib/msf/core/framework.rb
+++ b/lib/msf/core/framework.rb
@@ -81,7 +81,7 @@ class Framework
     self.analyze   = Analyze.new(self)
     self.plugins   = PluginManager.new(self)
     self.browser_profiles = Hash.new
-    self.features = FeatureManager.new(self)
+    self.features = FeatureManager.instance
 
     # Configure the thread factory
     Rex::ThreadFactory.provider = Metasploit::Framework::ThreadFactoryProvider.new(framework: self)

--- a/lib/msf/core/framework.rb
+++ b/lib/msf/core/framework.rb
@@ -81,6 +81,7 @@ class Framework
     self.analyze   = Analyze.new(self)
     self.plugins   = PluginManager.new(self)
     self.browser_profiles = Hash.new
+    self.features = FeatureManager.new(self)
 
     # Configure the thread factory
     Rex::ThreadFactory.provider = Metasploit::Framework::ThreadFactoryProvider.new(framework: self)
@@ -195,6 +196,11 @@ class Framework
   # framework objects to offer related objects/actions available.
   #
   attr_reader   :analyze
+  #
+  # The framework instance's feature manager. The feature manager is responsible
+  # for configuring feature flags that can change characteristics of framework.
+  #
+  attr_reader   :features
 
   #
   # The framework instance's dependency
@@ -277,6 +283,7 @@ protected
   attr_writer   :db # :nodoc:
   attr_writer   :browser_profiles # :nodoc:
   attr_writer   :analyze # :nodoc:
+  attr_writer   :features # :nodoc:
 
   private
 

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -113,6 +113,7 @@ class Core
       "color"      => "Toggle color",
       "debug"      => "Display information useful for debugging",
       "exit"       => "Exit the console",
+      "features"   => "Display the list of not yet released features that can be opted in to",
       "get"        => "Gets the value of a context-specific variable",
       "getg"       => "Gets the value of a global variable",
       "grep"       => "Grep the output of another command",
@@ -562,6 +563,120 @@ class Core
   end
 
   alias cmd_quit cmd_exit
+
+  def cmd_features_help
+    print_line <<~CMD_FEATURE_HELP
+      Enable or disable unreleased features that Metasploit supports
+
+      Usage:
+        features set feature_name [true/false]
+        features print
+
+      Subcommands:
+        set - Enable or disable a given feature
+        print - show all available features and their current configuration
+
+      Examples:
+        View available features:
+          features print
+
+        Enable a feature:
+          features set new_feature true
+
+        Disable a feature:
+          features set new_feature false
+    CMD_FEATURE_HELP
+  end
+
+  #
+  # This method handles the features command which allows a user to opt into enabling
+  # features that are not yet released to everyone by default.
+  #
+  def cmd_features(*args)
+    args << 'print' if args.empty?
+
+    action, *rest = args
+    case action
+    when 'set'
+      feature_name, value = rest
+
+      unless framework.features.exists?(feature_name)
+        print_warning("Feature name '#{feature_name}' is not available. Either it has been removed, integrated by default, or does not exist.")
+        print_warning("Currently supported features: #{framework.features.names.join(', ')}") if framework.features.all.any?
+        print_warning('There are currently no features to toggle.') if framework.features.all.empty?
+        return
+      end
+
+      unless %w[true false].include?(value)
+        print_warning('Please specify true or false to configure this feature.')
+        return
+      end
+
+      framework.features.set(feature_name, value == 'true')
+      print_line("#{feature_name} => #{value}")
+    when 'print'
+      if framework.features.all.empty?
+        print_line 'There are no features to enable at this time. Either the features have been removed, or integrated by default.'
+        return
+      end
+
+      features_table = Table.new(
+        Table::Style::Default,
+        'Header' => 'Features table',
+        'Prefix' => "\n",
+        'Postfix' => "\n",
+        'Columns' => [
+          '#',
+          'Name',
+          'Enabled',
+          'Description',
+        ]
+      )
+
+      framework.features.all.each.with_index do |feature, index|
+        features_table << [
+          index,
+          feature[:name],
+          feature[:enabled].to_s,
+          feature[:description]
+        ]
+      end
+
+      print_line features_table.to_s
+    else
+      cmd_help
+    end
+  rescue StandardError => e
+    elog(e)
+    print_error(e.message)
+  end
+
+  #
+  # Tab completion for the features command
+  #
+  # @param str [String] the string currently being typed before tab was hit
+  # @param words [Array<String>] the previously completed words on the command line.  words is always
+  # at least 1 when tab completion has reached this stage since the command itself has been completed
+  def cmd_features_tabs(_str, words)
+    if words.length == 1
+      return %w[set print]
+    end
+
+    _command_name, action, *rest = words
+    ret = []
+    case action
+    when 'set'
+      feature_name, _value = rest
+
+      if framework.features.exists?(feature_name)
+        ret += %w[true false]
+      else
+        ret += framework.features.names
+      end
+    end
+
+    ret
+  end
 
   def cmd_history(*args)
     length = Readline::HISTORY.length

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -601,7 +601,7 @@ class Core
       feature_name, value = rest
 
       unless framework.features.exists?(feature_name)
-        print_warning("Feature name '#{feature_name}' is not available. Either it has been removed, integrated by default, or does not exist.")
+        print_warning("Feature name '#{feature_name}' is not available. Either it has been removed, integrated by default, or does not exist in this version of Metasploit.")
         print_warning("Currently supported features: #{framework.features.names.join(', ')}") if framework.features.all.any?
         print_warning('There are currently no features to toggle.') if framework.features.all.empty?
         return
@@ -1241,6 +1241,12 @@ class Core
   def cmd_save(*args)
     # Save the console config
     driver.save_config
+
+    begin
+      FeatureManager.instance.save_config
+    rescue StandardException => e
+      elog(e)
+    end
 
     # Save the framework's datastore
     begin

--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -132,6 +132,12 @@ class Driver < Msf::Ui::Driver
 
     load_db_config(opts['Config'])
 
+    begin
+      FeatureManager.instance.load_config
+    rescue StandardException => e
+      elog(e)
+    end
+
     if !framework.db || !framework.db.active
       if framework.db.error == "disabled"
         print_warning("Database support has been disabled")

--- a/lib/msf/ui/console/table.rb
+++ b/lib/msf/ui/console/table.rb
@@ -18,13 +18,10 @@ class Table < Rex::Text::Table
     Default = 0
   end
 
-  #
-  # Initializes a wrappered table with the supplied style and options.
-  #
-  def initialize(style, opts = {})
-    self.style = style
+  def self.new(*args, &block)
+    style, opts = args
 
-    if (self.style == Style::Default)
+    if style == Style::Default
       opts['Indent']  = 3
       if (!opts['Prefix'])
         opts['Prefix']  = "\n"
@@ -32,28 +29,26 @@ class Table < Rex::Text::Table
       if (!opts['Postfix'])
         opts['Postfix'] = "\n"
       end
-
-      super(opts)
     end
+
+    instance = super(opts, &block)
+    if style == Style::Default
+      instance.extend(DefaultStyle)
+    end
+    instance
   end
 
-  #
-  # Print nothing if there are no rows if the style is default.
-  #
-  def to_s
-    if (style == Style::Default)
+  module DefaultStyle
+    #
+    # Print nothing if there are no rows if the style is default.
+    #
+    def to_s
       return '' if (rows.length == 0)
+
+      super
     end
-
-    super
   end
-
-protected
-
-  attr_accessor :style # :nodoc:
-
 end
-
 end
 end
 end

--- a/lib/msf/ui/debug.rb
+++ b/lib/msf/ui/debug.rb
@@ -48,7 +48,7 @@ module Msf
 
         # Delete all groups from the config ini that potentially have more up to date information
         ini.keys.each do |key|
-          unless key =~ %r{^framework/database}
+          unless key.start_with?("framework/database") || key.start_with?("framework/features")
             ini.delete(key)
           end
         end

--- a/spec/lib/msf/core/feature_manager_spec.rb
+++ b/spec/lib/msf/core/feature_manager_spec.rb
@@ -1,0 +1,79 @@
+# -*- coding:binary -*-
+
+require 'spec_helper'
+require 'msf/core/feature_manager'
+
+RSpec.describe Msf::FeatureManager do
+  let(:mock_features) do
+    [
+      {
+        name: 'filtered_options',
+        description: 'Add option filtering functionality to Metasploit',
+        enabled: false
+      },
+      {
+        name: 'new_search_capabilities',
+        description: 'Add new search capabilities to Metasploit',
+        enabled: true
+      }
+    ]
+  end
+  let(:mock_framework) { instance_double(Msf::Framework) }
+  let(:subject) { described_class.new(mock_framework) }
+
+  before(:each) do
+    stub_const('Msf::FeatureManager::DEFAULTS', mock_features)
+  end
+
+  describe '#all' do
+    it { expect(subject.all).to eql mock_features }
+  end
+
+  describe '#enabled?' do
+    it { expect(subject.enabled?('missing_option')).to be false }
+    it { expect(subject.enabled?('filtered_options')).to be false }
+    it { expect(subject.enabled?('new_search_capabilities')).to be true }
+  end
+
+  describe '#exists?' do
+    it { expect(subject.exists?('missing_option')).to be false }
+    it { expect(subject.exists?('filtered_options')).to be true }
+    it { expect(subject.exists?('new_search_capabilities')).to be true }
+  end
+
+  describe 'names' do
+    it { expect(subject.names).to eq ['filtered_options', 'new_search_capabilities'] }
+  end
+
+  describe '#set' do
+    context 'when a flag is enabled' do
+      before(:each) do
+        subject.set('filtered_options', true)
+      end
+
+      it { expect(subject.enabled?('missing_option')).to be false }
+      it { expect(subject.enabled?('filtered_options')).to be true }
+      it { expect(subject.enabled?('new_search_capabilities')).to be true }
+    end
+
+    context 'when a flag is disabled' do
+      before(:each) do
+        subject.set('new_search_capabilities', false)
+      end
+
+      it { expect(subject.enabled?('missing_option')).to be false }
+      it { expect(subject.enabled?('filtered_options')).to be false }
+      it { expect(subject.enabled?('new_search_capabilities')).to be false }
+    end
+
+    context 'when the flag does not exist' do
+      before(:each) do
+        subject.set('missing_option', false)
+      end
+
+      it { expect(subject.enabled?('missing_option')).to be false }
+      it { expect(subject.enabled?('filtered_options')).to be false }
+      it { expect(subject.enabled?('new_search_capabilities')).to be true }
+    end
+  end
+end

--- a/spec/lib/msf/core/feature_manager_spec.rb
+++ b/spec/lib/msf/core/feature_manager_spec.rb
@@ -9,24 +9,37 @@ RSpec.describe Msf::FeatureManager do
       {
         name: 'filtered_options',
         description: 'Add option filtering functionality to Metasploit',
-        enabled: false
+        default_value: false
       },
       {
         name: 'new_search_capabilities',
         description: 'Add new search capabilities to Metasploit',
-        enabled: true
+        default_value: true
       }
     ]
   end
-  let(:mock_framework) { instance_double(Msf::Framework) }
-  let(:subject) { described_class.new(mock_framework) }
+  let(:subject) { described_class.send(:new) }
 
   before(:each) do
     stub_const('Msf::FeatureManager::DEFAULTS', mock_features)
   end
 
   describe '#all' do
-    it { expect(subject.all).to eql mock_features }
+    let(:expected_features) do
+      [
+        {
+          name: 'filtered_options',
+          description: 'Add option filtering functionality to Metasploit',
+          enabled: false
+        },
+        {
+          name: 'new_search_capabilities',
+          description: 'Add new search capabilities to Metasploit',
+          enabled: true
+        }
+      ]
+    end
+    it { expect(subject.all).to eql expected_features }
   end
 
   describe '#enabled?' do
@@ -74,6 +87,136 @@ RSpec.describe Msf::FeatureManager do
       it { expect(subject.enabled?('missing_option')).to be false }
       it { expect(subject.enabled?('filtered_options')).to be false }
       it { expect(subject.enabled?('new_search_capabilities')).to be true }
+    end
+  end
+
+  describe "#load_config" do
+    before(:each) do
+      allow(Msf::Config).to receive(:load).and_return(Rex::Parser::Ini.from_s(config))
+      subject.load_config
+    end
+
+    context 'when the config file is empty' do
+      let(:config) do
+        <<~CONFIG
+
+        CONFIG
+      end
+
+      let(:expected_features) do
+        [
+          {
+            name: 'filtered_options',
+            description: 'Add option filtering functionality to Metasploit',
+            enabled: false
+          },
+          {
+            name: 'new_search_capabilities',
+            description: 'Add new search capabilities to Metasploit',
+            enabled: true
+          }
+        ]
+      end
+
+      it { expect(subject.all).to eql expected_features }
+    end
+
+    context 'when there are valid and invalid flags' do
+      let(:config) do
+        <<~CONFIG
+          [framework/features]
+          new_search_capabilities=false
+          missing_feature=true
+        CONFIG
+      end
+
+      let(:expected_features) do
+        [
+          {
+            name: 'filtered_options',
+            description: 'Add option filtering functionality to Metasploit',
+            enabled: false
+          },
+          {
+            name: 'new_search_capabilities',
+            description: 'Add new search capabilities to Metasploit',
+            enabled: false
+          }
+        ]
+      end
+
+      it { expect(subject.all).to eql expected_features }
+    end
+  end
+
+  describe '#save_config' do
+    before(:each) do
+      allow(Msf::Config).to receive(:load).and_return(Rex::Parser::Ini.from_s(config))
+      allow(Msf::Config).to receive(:save)
+    end
+
+    context 'when there is no existing configuration' do
+      before(:each) do
+        subject.save_config
+      end
+
+      let(:config) do
+        <<~CONFIG
+          [framework/features]
+        CONFIG
+      end
+
+      let(:expected_config) do
+        {
+          "framework/features" => {}
+        }
+      end
+
+      it { expect(Msf::Config).to have_received(:save).with(expected_config) }
+    end
+
+    context 'when there is only a missing feature' do
+      before(:each) do
+        subject.save_config
+      end
+
+      let(:config) do
+        <<~CONFIG
+          [framework/features]
+          missing_feature=true
+        CONFIG
+      end
+
+      let(:expected_config) do
+        {
+          "framework/features" => { "missing_feature" => "true" }
+        }
+      end
+
+      it { expect(Msf::Config).to have_received(:save).with(expected_config) }
+    end
+
+    context 'when there are user preferences set' do
+      before(:each) do
+        subject.set('new_search_capabilities', true)
+        subject.save_config
+      end
+
+      let(:config) do
+        <<~CONFIG
+          [framework/features]
+          new_search_capabilities=false
+          missing_feature=true
+        CONFIG
+      end
+
+      let(:expected_config) do
+        {
+          "framework/features" => { "missing_feature" => "true", "new_search_capabilities"=>"true" }
+        }
+      end
+
+      it { expect(Msf::Config).to have_received(:save).with(expected_config) }
     end
   end
 end


### PR DESCRIPTION
Add initial wrapped tables support to Metasploit. The functionality is hidden behind an opt-in feature flag for now. This allows for the functionality to be released and tested without breaking existing user's workflow.

Rex Text pull request, which details some of the edge cases that are not yet supported: https://github.com/rapid7/rex-text/pull/32

### Feature support

A new `features` command has been added to the console. This allows users to opt in to new Metasploit features that aren't ready for everyone to use just yet. 

```
msf5 > features

Features table
==============

   #  Name            Enabled  Description
   -  ----            -------  -----------
   0  wrapped_tables  true     When enabled Metasploit will wordwrap all tables to fit into the available terminal width
```

The features can be enabled/disabled:

```
msf5 > features set wrapped_tables true 
wrapped_tables => true
```

The expected workflow to have features enabled and saved within the `~/.msf4/config` file:

```
$ cat ~/.msf4/config

...

[framework/features]
wrapped_tables=true
foo_bar_baz=true

...

```

Which will enable the required feature flag at startup.

Example usage:

![image](https://user-images.githubusercontent.com/60357436/87031925-b496c600-c1db-11ea-9313-6a7f252d2498.png)

If `~/.msf4/config` uses the `features` configuration, swapping to an older branch won't have any impact on a user.

In the future a particular feature flag may be removed, as the feature has been enabled for everyone - or it was removed entirely. This scenario will be handled gracefully:

![image](https://user-images.githubusercontent.com/60357436/87032950-4b17b700-c1dd-11ea-8e6f-440ee00144c8.png)

### Console

Before

![image](https://user-images.githubusercontent.com/60357436/86923816-72f81380-c126-11ea-90a5-1a4de77c74f9.png)

After

![image](https://user-images.githubusercontent.com/60357436/86923843-7b504e80-c126-11ea-8225-1bddd7573df5.png)

### Plain text

Before

```
msf5 > info post/windows/gather/phish_windows_credentials 

...

Provided by:
  Wesley Neelen <security@forsec.nl>
  Matt Nelson

Compatible session types:
  Meterpreter

Basic options:
  Name         Current Setting                                                                Required  Description
  ----         ---------------                                                                --------  -----------
  DESCRIPTION  {PROCESS_NAME} needs your permissions to start. Please enter user credentials  yes       Message shown in the loginprompt
  PROCESS                                                                                     no        Prompt if a specific process is started by the target. (e.g. calc.exe or specify * for all processes)
  SESSION                                                                                     yes       The session to run this module on.
```

After

```
msf5 > info post/windows/gather/phish_windows_credentials 

...

Basic options:
  Name         Current Setting      Required  Description
  ----         ---------------      --------  -----------
  DESCRIPTION  {PROCESS_NAME} need  yes       Message shown in the loginprompt
               s your permissions
               to start. Please en
               ter user credential
               s
  PROCESS                           no        Prompt if a specific process is
                                              started by the target. (e.g. cal
                                              c.exe or specify * for all proce
                                              sses)
  SESSION                           yes       The session to run this module o
                                              n.

...
```

### Console notes

before

![image](https://user-images.githubusercontent.com/60357436/87426170-b9da8300-c5d6-11ea-86cf-13de5f098bd7.png)

after

![image](https://user-images.githubusercontent.com/60357436/87426115-aaf3d080-c5d6-11ea-9985-c3bed60593c5.png)

### Termux

Before

![image](https://user-images.githubusercontent.com/60357436/87031141-8fee1e80-c1da-11ea-8c5a-c4a66d9ba216.png)

After

![image](https://user-images.githubusercontent.com/60357436/87031106-7b118b00-c1da-11ea-83e8-4f7758b49aa6.png)


