### PR TITLE
Add Modbus banner grabbing module

### DIFF
--- a/documentation/modules/auxiliary/scanner/scada/modbus_banner_grabbing.md
+++ b/documentation/modules/auxiliary/scanner/scada/modbus_banner_grabbing.md
@@ -7,22 +7,10 @@ For more technical information, you can refer to this link: https://en.wikipedia
 By default the service is running on port 502, so any device with this port open could be a potential target.
 
 ## Verification Steps
-<<<<<<< HEAD
-  1. Do: ```use auxiliary/scanner/scada/modbus_banner_grabbing```
-<<<<<<< HEAD
-  2. Do: ```set RHOST <IP>```
-  3. Do: ```set UNIT_ID <ID>```
-=======
-  2. Do: ```set RHOST <IP>``` where IP is the IP address of the target.
-  3. Do: ```set UNIT_ID <ID>``` where ID is a number between 1 and 254. This is optional, default Unite Identifier is set to ```0```.
->>>>>>> Update documentation/modules/auxiliary/scanner/scada/modbus_banner_grabbing.md
-  4. Do: ```run```
-=======
   1. Do: `use auxiliary/scanner/scada/modbus_banner_grabbing`
-  2. Do: `set RHOST <IP>`
-  3. Do: `set UNIT_ID <ID>`
+  2. Do: `set RHOST <IP>` where IP is the IP address of the target.
+  3. Do: `set UNIT_ID <ID>` where ID is a number from 0 to 254 inclusive. This is optional, the default Unit Identifier on most devices is `0`.
   4. Do: `run`
->>>>>>> Update documentation to fix spelling mistakes and grammar
 
 The response from the target device may contain several objects. Some of these objects can be seen below:
 
@@ -47,17 +35,19 @@ Notes
 ```
 
 ## Options
-  1. `UNIT_ID` is the Unit Identifier and must be a number between 1 and 254. By default this value is set to `0`.
+  1. `UNIT_ID` is the Unit Identifier and must be a number from 0 to 254 inclusive. By default this value is set to `0`.
   2. `RHOST` is the IP address of the target.
 
 ## Scenarios
 The following scenarios describe some of the responses you may receive from the target:
 
-### Execution Successful
-The target responded with some object information such as `Vendor Name`, `Product Code` and `Revision`.
+### Schneider Electric BMX NOE 0100 - Successful Response
 
 ```
-msf5 auxiliary(scanner/scada/modbus_banner_grabbing) > run
+msf6 > use auxiliary/scanner/scada/modbus_banner_grabbing
+msf6 auxiliary(scanner/scada/modbus_banner_grabbing) > set RHOSTS 192.168.1.1
+RHOSTS => 192.168.1.1
+msf6 auxiliary(scanner/scada/modbus_banner_grabbing) > run
 
 [*] 192.168.1.1:502    - Number of Objects: 3
 [+] 192.168.1.1:502    - VendorName: Schneider Electric
@@ -67,31 +57,41 @@ msf5 auxiliary(scanner/scada/modbus_banner_grabbing) > run
 [*] Auxiliary module execution completed
 ```
 
-### No Reply
+### Schneider Electric BMX NOE 0100 - No Reply
 The target never replied to the attacker's request.
 
 ```
-msf5 auxiliary(scanner/scada/modbus_banner_grabbing) > run
+msf6 > use auxiliary/scanner/scada/modbus_banner_grabbing
+msf6 auxiliary(scanner/scada/modbus_banner_grabbing) > set RHOSTS 192.168.1.2
+RHOSTS => 192.168.1.2
+msf6 auxiliary(scanner/scada/modbus_banner_grabbing) > run
 
 [-] 192.168.1.2:502      - MODBUS - No reply
 [*] 192.168.1.2:502      - Scanned 1 of 1 hosts (100% complete)
 [*] Auxiliary module execution completed
 ```
 
-### Network Error
+### Schneider Electric BMX NOE 0100 - Network Error
 Some network error occurred, such as a connection error, a network timeout, or the connection was refused. Alternatively, the host may be unreachable.
 
-```msf5 auxiliary(scanner/scada/modbus_banner_grabbing) > run
+```
+msf6 > use auxiliary/scanner/scada/modbus_banner_grabbing
+msf6 auxiliary(scanner/scada/modbus_banner_grabbing) > set RHOSTS 192.168.1.3
+RHOSTS => 192.168.1.3
+msf6 auxiliary(scanner/scada/modbus_banner_grabbing) > run
 
 [-] 192.168.1.3:502     - MODBUS - Network error during payload: The connection timed out (217.71.253.52:502).
 [*] 192.168.1.3:502     - Scanned 1 of 1 hosts (100% complete)
 [*] Auxiliary module execution completed
 ```
 
-### Modbus Exception Codes (i.e. Memory Parity Error)
+### Schneider Electric BMX NOE 0100 - Modbus Exception Code (i.e. Memory Parity Error)
 
 ```
-msf5 auxiliary(scanner/scada/modbus_banner_grabbing) > run
+msf6 > use auxiliary/scanner/scada/modbus_banner_grabbing
+msf6 auxiliary(scanner/scada/modbus_banner_grabbing) > set RHOSTS 192.168.1.4
+RHOSTS => 192.168.1.4
+msf6 auxiliary(scanner/scada/modbus_banner_grabbing) > run
 
 [-] 192.168.1.4:502      - Memory Parity Error: Slave detected a parity error in memory.
 [*] 192.168.1.4:502      - Scanned 1 of 1 hosts (100% complete)

--- a/documentation/modules/auxiliary/scanner/scada/modbus_banner_grabbing.md
+++ b/documentation/modules/auxiliary/scanner/scada/modbus_banner_grabbing.md
@@ -1,0 +1,68 @@
+## Vulnerable Application
+
+  Banner grabbing for Modbus using Function Code 43 (Read Device Identification). Modbus is a data communications protocol originally published by Modicon (now Schneider Electric) in 1979 for use with its programmable logic controllers (PLCs).
+  
+  https://en.wikipedia.org/wiki/Modbus#Available_function/command_codes
+
+## Verification Steps
+
+  1. Do: ```use auxiliary/scanner/scada/modbus_banner_grabbing```
+  2. Do: ```set RHOST=IP``` where IP is the IP address of the target.
+  2. Do: ```set UNIT_ID=ID``` where ID is a number between 1 and 254. This is optional, default Unite Identifier is set to ```0```.
+  3. Do: ```run```
+
+## Options
+
+```
+msf5 auxiliary(scanner/scada/modbus_banner_grabbing) > notes 
+
+Notes
+=====
+
+ Time                     Host            Service  Port  Protocol  Type                Data
+ ----                     ----            -------  ----  --------  ----                ----
+ 2020-07-06 13:25:50 UTC  192.168.1.1     modbus   502   tcp       modbus.vendorname   "Schneider Electric"
+ 2020-07-06 13:25:50 UTC  192.168.1.1     modbus   502   tcp       modbus.productcode  "BMX NOE 0100"
+ 2020-07-06 13:25:50 UTC  192.168.1.1     modbus   502   tcp       modbus.revision     "V3.10"
+ ```
+
+## Scenarios
+
+Execution successfull
+  ```
+msf5 auxiliary(scanner/scada/modbus_banner_grabbing) > run
+
+[*] 192.168.1.1:502    - Number of Objects: 3
+[+] 192.168.1.1:502    - VendorName: Schneider Electric
+[+] 192.168.1.1:502    - ProductCode: BMX NOE 0100
+[+] 192.168.1.1:502    - Revision: V3.10
+[*] 192.168.1.1:502    - Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```
+
+Not reply
+```
+msf5 auxiliary(scanner/scada/modbus_banner_grabbing) > run
+
+[-] 192.168.1.2:502      - MODBUS - No reply
+[*] 192.168.1.2:502      - Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```
+
+Network error
+```
+msf5 auxiliary(scanner/scada/modbus_banner_grabbing) > run
+
+[-] 192.168.1.3:502     - MODBUS - Network error during payload: The connection timed out (217.71.253.52:502).
+[*] 192.168.1.3:502     - Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```
+
+Modbuss exception codes (I.e. Memory Parity Error)
+```
+msf5 auxiliary(scanner/scada/modbus_banner_grabbing) > run
+
+[-] 192.168.1.4:502      - Memory Parity Error: Slave detected a parity error in memory.
+[*] 192.168.1.4:502      - Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```

--- a/documentation/modules/auxiliary/scanner/scada/modbus_banner_grabbing.md
+++ b/documentation/modules/auxiliary/scanner/scada/modbus_banner_grabbing.md
@@ -82,7 +82,7 @@ Connection errors, network timeout, host unreachable or connection refused.
 [*] Auxiliary module execution completed
 ```
 
-Modbuss exception codes (I.e. Memory Parity Error)
+### Modbuss exception codes (I.e. Memory Parity Error)
 
 ```msf5 auxiliary(scanner/scada/modbus_banner_grabbing) > run
 

--- a/documentation/modules/auxiliary/scanner/scada/modbus_banner_grabbing.md
+++ b/documentation/modules/auxiliary/scanner/scada/modbus_banner_grabbing.md
@@ -1,20 +1,34 @@
 ## Vulnerable Application
 
-  Banner grabbing for Modbus using Function Code 43 (Read Device Identification). Modbus is a data communications protocol originally published by Modicon (now Schneider Electric) in 1979 for use with its programmable logic controllers (PLCs).
-  
-  https://en.wikipedia.org/wiki/Modbus#Available_function/command_codes
+This module will perform Banner grabbing in devices that uses the Modbus protocol.
+The module will send a payload with the function code 43 which is used to read device identification.
+For more technical information, you can refer to this link: https://en.wikipedia.org/wiki/Modbus#Available_function/command_codes.
+
+Any device with the 502 port exposed could be a potential target.
+A search in Shodan with the Dork `port:502` it's an easier way to find targets.
+Also you can filter the results by 'product'.
 
 ## Verification Steps
-
   1. Do: ```use auxiliary/scanner/scada/modbus_banner_grabbing```
-  2. Do: ```set RHOST=IP``` where IP is the IP address of the target.
-  2. Do: ```set UNIT_ID=ID``` where ID is a number between 1 and 254. This is optional, default Unite Identifier is set to ```0```.
-  3. Do: ```run```
+<<<<<<< HEAD
+  2. Do: ```set RHOST <IP>```
+  3. Do: ```set UNIT_ID <ID>```
+=======
+  2. Do: ```set RHOST <IP>``` where IP is the IP address of the target.
+  3. Do: ```set UNIT_ID <ID>``` where ID is a number between 1 and 254. This is optional, default Unite Identifier is set to ```0```.
+>>>>>>> Update documentation/modules/auxiliary/scanner/scada/modbus_banner_grabbing.md
+  4. Do: ```run```
 
-## Options
+You can expect receive as response which may contain some of the following objects:
 
-```
-msf5 auxiliary(scanner/scada/modbus_banner_grabbing) > notes 
+```vendor name, product code, min. max. revision, vendor url, product name, model name, etc.```
+
+If the ```UNIT_ID``` value is not the correct one or the response contains an error you will receive one Modbus exception code message.
+
+Successful results from the scan will be stored as a ```note``` in the project. You can access just typing ```note``` in the console.
+
+```msf5 
+auxiliary(scanner/scada/modbus_banner_grabbing) > notes
 
 Notes
 =====
@@ -23,46 +37,51 @@ Notes
  ----                     ----            -------  ----  --------  ----                ----
  2020-07-06 13:25:50 UTC  192.168.1.1     modbus   502   tcp       modbus.vendorname   "Schneider Electric"
  2020-07-06 13:25:50 UTC  192.168.1.1     modbus   502   tcp       modbus.productcode  "BMX NOE 0100"
- 2020-07-06 13:25:50 UTC  192.168.1.1     modbus   502   tcp       modbus.revision     "V3.10"
- ```
+ 2020-07-06 13:25:50 UTC  192.168.1.1     modbus   502   tcp       modbus.revision     "V3.10"```
+
+## Options
+  1. ```UNIT_ID``` is the Unite Identifier and must be a number between 1 and 254. By default is set to ```0```.
+  2. ```RHOST``` is the IP address of the target.
 
 ## Scenarios
+Here are some of the possible responses that you may receive from the target.
 
-Execution successfull
-  ```
-msf5 auxiliary(scanner/scada/modbus_banner_grabbing) > run
+### Execution Successfull
+
+Target responds with some object information like ```Vendor Name```, ```Product Code``` and ```Revision```.
+
+```msf5 auxiliary(scanner/scada/modbus_banner_grabbing) > run
 
 [*] 192.168.1.1:502    - Number of Objects: 3
 [+] 192.168.1.1:502    - VendorName: Schneider Electric
 [+] 192.168.1.1:502    - ProductCode: BMX NOE 0100
 [+] 192.168.1.1:502    - Revision: V3.10
 [*] 192.168.1.1:502    - Scanned 1 of 1 hosts (100% complete)
-[*] Auxiliary module execution completed
-```
+[*] Auxiliary module execution completed```
 
-Not reply
-```
-msf5 auxiliary(scanner/scada/modbus_banner_grabbing) > run
+### Not Reply
+The target never reply the request.
+
+```msf5 auxiliary(scanner/scada/modbus_banner_grabbing) > run
 
 [-] 192.168.1.2:502      - MODBUS - No reply
 [*] 192.168.1.2:502      - Scanned 1 of 1 hosts (100% complete)
-[*] Auxiliary module execution completed
-```
+[*] Auxiliary module execution completed```
 
-Network error
-```
-msf5 auxiliary(scanner/scada/modbus_banner_grabbing) > run
+### Network Error
+
+Connection errors, network timeout, host unreachable or connection refused.
+
+```msf5 auxiliary(scanner/scada/modbus_banner_grabbing) > run
 
 [-] 192.168.1.3:502     - MODBUS - Network error during payload: The connection timed out (217.71.253.52:502).
 [*] 192.168.1.3:502     - Scanned 1 of 1 hosts (100% complete)
-[*] Auxiliary module execution completed
-```
+[*] Auxiliary module execution completed```
 
 Modbuss exception codes (I.e. Memory Parity Error)
-```
-msf5 auxiliary(scanner/scada/modbus_banner_grabbing) > run
+
+```msf5 auxiliary(scanner/scada/modbus_banner_grabbing) > run
 
 [-] 192.168.1.4:502      - Memory Parity Error: Slave detected a parity error in memory.
 [*] 192.168.1.4:502      - Scanned 1 of 1 hosts (100% complete)
-[*] Auxiliary module execution completed
-```
+[*] Auxiliary module execution completed```

--- a/documentation/modules/auxiliary/scanner/scada/modbus_banner_grabbing.md
+++ b/documentation/modules/auxiliary/scanner/scada/modbus_banner_grabbing.md
@@ -13,7 +13,7 @@ By default the service is running on port 502, so any device with this port open
 
 The response from the target device may contain several objects. Some of these objects can be seen below:
 
-`vendor name, product code, min. max. revision, vendor url, product name, model name`
+`vendor name, product code, revision number (in *major version*.*minor version* format), vendor url, product name, model name`
 
 If the target was unable to process the Modbus message, a Modbus exception message will be returned from the target,
  which will then be output to the screen.
@@ -34,7 +34,7 @@ Notes
 ```
 
 ## Options
-  1. `RHOST` is the IP address of the target.
+There are no non-default options for this module.
 
 ## Scenarios
 The following scenarios describe some of the responses you may receive from the target:

--- a/documentation/modules/auxiliary/scanner/scada/modbus_banner_grabbing.md
+++ b/documentation/modules/auxiliary/scanner/scada/modbus_banner_grabbing.md
@@ -1,14 +1,13 @@
 ## Vulnerable Application
 
-This module will perform Banner grabbing in devices that uses the Modbus protocol.
-The module will send a payload with the function code 43 which is used to read device identification.
+This module will perform banner grabbing on devices that use the Modbus protocol by sending 
+a payload with the function code 43 to read the target device's identification information.
 For more technical information, you can refer to this link: https://en.wikipedia.org/wiki/Modbus#Available_function/command_codes.
 
-Any device with the 502 port exposed could be a potential target.
-A search in Shodan with the Dork `port:502` it's an easier way to find targets.
-Also you can filter the results by 'product'.
+By default the service is running on port 502, so any device with this port open could be a potential target.
 
 ## Verification Steps
+<<<<<<< HEAD
   1. Do: ```use auxiliary/scanner/scada/modbus_banner_grabbing```
 <<<<<<< HEAD
   2. Do: ```set RHOST <IP>```
@@ -18,17 +17,24 @@ Also you can filter the results by 'product'.
   3. Do: ```set UNIT_ID <ID>``` where ID is a number between 1 and 254. This is optional, default Unite Identifier is set to ```0```.
 >>>>>>> Update documentation/modules/auxiliary/scanner/scada/modbus_banner_grabbing.md
   4. Do: ```run```
+=======
+  1. Do: `use auxiliary/scanner/scada/modbus_banner_grabbing`
+  2. Do: `set RHOST <IP>`
+  3. Do: `set UNIT_ID <ID>`
+  4. Do: `run`
+>>>>>>> Update documentation to fix spelling mistakes and grammar
 
-You can expect receive as response which may contain some of the following objects:
+The response from the target device may contain several objects. Some of these objects can be seen below:
 
-```vendor name, product code, min. max. revision, vendor url, product name, model name, etc.```
+`vendor name, product code, min. max. revision, vendor url, product name, model name`
 
-If the ```UNIT_ID``` value is not the correct one or the response contains an error you will receive one Modbus exception code message.
+If the `UNIT_ID` value set by the attacker is incorrect, or if the target was unable to process the Modbus message,
+a Modbus exception message will be returned from the target, which will then be output to the screen.
 
-Successful results from the scan will be stored as a ```note``` in the project. You can access by typing ```note``` in the console.
+Successful results from the scan will be stored as a `note` in the framework. You can access these notes by typing `note` in the console.
 
-```msf5 
-auxiliary(scanner/scada/modbus_banner_grabbing) > notes
+```
+msf5 auxiliary(scanner/scada/modbus_banner_grabbing) > notes
 
 Notes
 =====
@@ -38,20 +44,20 @@ Notes
  2020-07-06 13:25:50 UTC  192.168.1.1     modbus   502   tcp       modbus.vendorname   "Schneider Electric"
  2020-07-06 13:25:50 UTC  192.168.1.1     modbus   502   tcp       modbus.productcode  "BMX NOE 0100"
  2020-07-06 13:25:50 UTC  192.168.1.1     modbus   502   tcp       modbus.revision     "V3.10"
- ```
+```
 
 ## Options
-  1. ```UNIT_ID``` is the Unite Identifier and must be a number between 1 and 254. By default is set to ```0```.
-  2. ```RHOST``` is the IP address of the target.
+  1. `UNIT_ID` is the Unit Identifier and must be a number between 1 and 254. By default this value is set to `0`.
+  2. `RHOST` is the IP address of the target.
 
 ## Scenarios
-Here are some of the possible responses that you may receive from the target.
+The following scenarios describe some of the responses you may receive from the target:
 
-### Execution Successfull
+### Execution Successful
+The target responded with some object information such as `Vendor Name`, `Product Code` and `Revision`.
 
-Target responds with some object information like ```Vendor Name```, ```Product Code``` and ```Revision```.
-
-```msf5 auxiliary(scanner/scada/modbus_banner_grabbing) > run
+```
+msf5 auxiliary(scanner/scada/modbus_banner_grabbing) > run
 
 [*] 192.168.1.1:502    - Number of Objects: 3
 [+] 192.168.1.1:502    - VendorName: Schneider Electric
@@ -61,10 +67,11 @@ Target responds with some object information like ```Vendor Name```, ```Product 
 [*] Auxiliary module execution completed
 ```
 
-### Not Reply
-The target never reply the request.
+### No Reply
+The target never replied to the attacker's request.
 
-```msf5 auxiliary(scanner/scada/modbus_banner_grabbing) > run
+```
+msf5 auxiliary(scanner/scada/modbus_banner_grabbing) > run
 
 [-] 192.168.1.2:502      - MODBUS - No reply
 [*] 192.168.1.2:502      - Scanned 1 of 1 hosts (100% complete)
@@ -72,8 +79,7 @@ The target never reply the request.
 ```
 
 ### Network Error
-
-Connection errors, network timeout, host unreachable or connection refused.
+Some network error occurred, such as a connection error, a network timeout, or the connection was refused. Alternatively, the host may be unreachable.
 
 ```msf5 auxiliary(scanner/scada/modbus_banner_grabbing) > run
 
@@ -82,9 +88,10 @@ Connection errors, network timeout, host unreachable or connection refused.
 [*] Auxiliary module execution completed
 ```
 
-### Modbuss exception codes (I.e. Memory Parity Error)
+### Modbus Exception Codes (i.e. Memory Parity Error)
 
-```msf5 auxiliary(scanner/scada/modbus_banner_grabbing) > run
+```
+msf5 auxiliary(scanner/scada/modbus_banner_grabbing) > run
 
 [-] 192.168.1.4:502      - Memory Parity Error: Slave detected a parity error in memory.
 [*] 192.168.1.4:502      - Scanned 1 of 1 hosts (100% complete)

--- a/documentation/modules/auxiliary/scanner/scada/modbus_banner_grabbing.md
+++ b/documentation/modules/auxiliary/scanner/scada/modbus_banner_grabbing.md
@@ -1,6 +1,6 @@
 ## Vulnerable Application
 
-This module will perform banner grabbing on devices that use the Modbus protocol by sending 
+This module will perform banner grabbing on devices that use the Modbus protocol by sending
 a payload with the function code 43 to read the target device's identification information.
 For more technical information, you can refer to this link: https://en.wikipedia.org/wiki/Modbus#Available_function/command_codes.
 
@@ -9,15 +9,14 @@ By default the service is running on port 502, so any device with this port open
 ## Verification Steps
   1. Do: `use auxiliary/scanner/scada/modbus_banner_grabbing`
   2. Do: `set RHOST <IP>` where IP is the IP address of the target.
-  3. Do: `set UNIT_ID <ID>` where ID is a number from 0 to 254 inclusive. This is optional, the default Unit Identifier on most devices is `0`.
-  4. Do: `run`
+  3. Do: `run`
 
 The response from the target device may contain several objects. Some of these objects can be seen below:
 
 `vendor name, product code, min. max. revision, vendor url, product name, model name`
 
-If the `UNIT_ID` value set by the attacker is incorrect, or if the target was unable to process the Modbus message,
-a Modbus exception message will be returned from the target, which will then be output to the screen.
+If the target was unable to process the Modbus message, a Modbus exception message will be returned from the target,
+ which will then be output to the screen.
 
 Successful results from the scan will be stored as a `note` in the framework. You can access these notes by typing `note` in the console.
 
@@ -35,8 +34,7 @@ Notes
 ```
 
 ## Options
-  1. `UNIT_ID` is the Unit Identifier and must be a number from 0 to 254 inclusive. By default this value is set to `0`.
-  2. `RHOST` is the IP address of the target.
+  1. `RHOST` is the IP address of the target.
 
 ## Scenarios
 The following scenarios describe some of the responses you may receive from the target:
@@ -72,7 +70,8 @@ msf6 auxiliary(scanner/scada/modbus_banner_grabbing) > run
 ```
 
 ### Schneider Electric BMX NOE 0100 - Network Error
-Some network error occurred, such as a connection error, a network timeout, or the connection was refused. Alternatively, the host may be unreachable.
+Some network error occurred, such as a connection error, a network timeout, or the connection was refused.
+Alternatively, the host may be unreachable.
 
 ```
 msf6 > use auxiliary/scanner/scada/modbus_banner_grabbing

--- a/documentation/modules/auxiliary/scanner/scada/modbus_banner_grabbing.md
+++ b/documentation/modules/auxiliary/scanner/scada/modbus_banner_grabbing.md
@@ -25,7 +25,7 @@ You can expect receive as response which may contain some of the following objec
 
 If the ```UNIT_ID``` value is not the correct one or the response contains an error you will receive one Modbus exception code message.
 
-Successful results from the scan will be stored as a ```note``` in the project. You can access just typing ```note``` in the console.
+Successful results from the scan will be stored as a ```note``` in the project. You can access by typing ```note``` in the console.
 
 ```msf5 
 auxiliary(scanner/scada/modbus_banner_grabbing) > notes
@@ -37,7 +37,8 @@ Notes
  ----                     ----            -------  ----  --------  ----                ----
  2020-07-06 13:25:50 UTC  192.168.1.1     modbus   502   tcp       modbus.vendorname   "Schneider Electric"
  2020-07-06 13:25:50 UTC  192.168.1.1     modbus   502   tcp       modbus.productcode  "BMX NOE 0100"
- 2020-07-06 13:25:50 UTC  192.168.1.1     modbus   502   tcp       modbus.revision     "V3.10"```
+ 2020-07-06 13:25:50 UTC  192.168.1.1     modbus   502   tcp       modbus.revision     "V3.10"
+ ```
 
 ## Options
   1. ```UNIT_ID``` is the Unite Identifier and must be a number between 1 and 254. By default is set to ```0```.
@@ -57,7 +58,8 @@ Target responds with some object information like ```Vendor Name```, ```Product 
 [+] 192.168.1.1:502    - ProductCode: BMX NOE 0100
 [+] 192.168.1.1:502    - Revision: V3.10
 [*] 192.168.1.1:502    - Scanned 1 of 1 hosts (100% complete)
-[*] Auxiliary module execution completed```
+[*] Auxiliary module execution completed
+```
 
 ### Not Reply
 The target never reply the request.
@@ -66,7 +68,8 @@ The target never reply the request.
 
 [-] 192.168.1.2:502      - MODBUS - No reply
 [*] 192.168.1.2:502      - Scanned 1 of 1 hosts (100% complete)
-[*] Auxiliary module execution completed```
+[*] Auxiliary module execution completed
+```
 
 ### Network Error
 
@@ -76,7 +79,8 @@ Connection errors, network timeout, host unreachable or connection refused.
 
 [-] 192.168.1.3:502     - MODBUS - Network error during payload: The connection timed out (217.71.253.52:502).
 [*] 192.168.1.3:502     - Scanned 1 of 1 hosts (100% complete)
-[*] Auxiliary module execution completed```
+[*] Auxiliary module execution completed
+```
 
 Modbuss exception codes (I.e. Memory Parity Error)
 
@@ -84,4 +88,5 @@ Modbuss exception codes (I.e. Memory Parity Error)
 
 [-] 192.168.1.4:502      - Memory Parity Error: Slave detected a parity error in memory.
 [*] 192.168.1.4:502      - Scanned 1 of 1 hosts (100% complete)
-[*] Auxiliary module execution completed```
+[*] Auxiliary module execution completed
+```

--- a/modules/auxiliary/scanner/scada/modbus_banner_grabbing.rb
+++ b/modules/auxiliary/scanner/scada/modbus_banner_grabbing.rb
@@ -1,0 +1,169 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::Tcp
+  include Msf::Auxiliary::Report
+  include Msf::Auxiliary::Scanner
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'        => 'Modbus Banner Grabbing',
+      'Description' => %q{
+        Banner grabbing for Modbus using Function Code 43 (Read Device
+        Identification). Modbus is a data communications protocol originally
+        published by Modicon (now Schneider Electric) in 1979 for use with its
+        programmable logic controllers (PLCs).
+      },
+      'Author'      =>
+      [
+        'Juan Escobar <juan[at]]null-life.com>', # @itsecurityco
+        'Ezequiel Fernandez' # @capitan_alfa
+      ],
+      'References'  =>
+      [
+        [ 'URL', 'https://en.wikipedia.org/wiki/Modbus#Modbus_TCP_frame_format_(primarily_used_on_Ethernet_networks)' ],
+        [ 'URL', 'https://github.com/industrialarmy/Hello_Proto' ],
+      ],
+      'License'     => MSF_LICENSE
+    ))
+
+    register_options(
+      [
+        Opt::RPORT(502),
+        OptInt.new('UNIT_ID', [true, "Tells the Slave Address of the device behind the gateway [1..254]", 0]),
+        OptInt.new('TIMEOUT', [true, 'Timeout for the network probe', 2])
+      ])
+  end
+
+  # Main Modbus exception codes
+  def handle_exception_codes(code)
+    case code
+      when "\xab\x01"
+        print_error("Illegal Function: Function code received in the query is not recognized or allowed by slave.")
+      when "\xab\x02"
+        print_error("Illegal Data Address: Data address of some or all the required entities are not allowed or do not exist in slave.")
+      when "\xab\x03"
+        print_error("Illegal Data Value: Value is not accepted by slave.")
+      when "\xab\x04"
+        print_error("Slave Device Failure: Unrecoverable error occurred while slave was attempting to perform requested action.")
+      when "\xab\x05"
+        print_error("Acknowledge: Slave has accepted request and is processing it, but a long duration of time is required.")
+      when "\xab\x06"
+        print_error("Slave Device Busy: Slave is engaged in processing a long-duration command.")
+      when "\xab\x07"
+        print_error("Negative Acknowledge: Slave cannot perform the programming functions.")
+      when "\xab\x08"
+        print_error("Memory Parity Error: Slave detected a parity error in memory.")
+      when "\xab\x0a"
+        print_error(" Gateway Path Unavailable: Specialized for Modbus gateways. Indicates a misconfigured gateway.")
+      when "\xab\x0b"
+        print_error("Gateway Target Device Failed to Respond: Specialized for Modbus gateways.")
+      else
+        print_error("MODBUS - received incorrect data.")
+    end
+  end
+
+  def run_host(ip)
+    object_name = {
+      0   => "VendorName",
+      1   => "ProductCode",
+      2   => "Revision",
+      3   => "VendorUrl",
+      4   => "ProductName",
+      5   => "ModelName",
+      6   => "UserAppName",
+      7   => "Reserved",
+      8   => "Reserved",
+      9   => "Reserved",
+      10  => "Reserved",
+      128 => "PrivateObjects",
+      255 => "PrivateObjects"
+    }
+
+    # Modbus/TCP Response Bytes
+    mbtcp = {
+        'trans_id' =>         { 'start' =>  0, 'bytes' => 2 },
+        'prot_id' =>          { 'start' =>  2, 'bytes' => 2 },
+        'len' =>              { 'start' =>  4, 'bytes' => 2 },
+        'unit_id' =>          { 'start' =>  6, 'bytes' => 1 },
+        'func_code' =>        { 'start' =>  7, 'bytes' => 1 },
+        'mei' =>              { 'start' =>  8, 'bytes' => 1 },
+        'read_device_id' =>   { 'start' =>  9, 'bytes' => 1 },
+        'conformity_level' => { 'start' => 10, 'bytes' => 1 },
+        'more_follows' =>     { 'start' => 11, 'bytes' => 1 },
+        'next_object_id' =>   { 'start' => 12, 'bytes' => 1 },
+        'num_objects' =>      { 'start' => 13, 'bytes' => 1 },
+        'object_id' =>        { 'start' => 14, 'bytes' => 1 },
+        'objects_len' =>      { 'start' => 15, 'bytes' => 1 },
+        'object_str_value' => { 'start' => 16, 'bytes' => nil }
+    }
+
+    begin
+      connect()
+
+      packet  = "\x44\x62" # Transaction Identifier
+      packet << "\x00\x00" # Protocol Identifier
+      packet << "\x00\x05" # Length
+      packet << [datastore['UNIT_ID']].pack("C") # Unit Identifier
+      packet << "\x2b"     # .010 1011 = Function Code: Encapsulated Interface Transport (43)
+      packet << "\x0e"     # MEI type: Read Device Identification (14)
+      packet << "\x03"     # Read Device ID: Extended Device Identification (3)
+      packet << "\x00"     # Object ID: VendorName (0)
+
+      sock.put(packet)
+      data = sock.get_once(-1, datastore['TIMEOUT'])
+
+      if data
+        # Read Device Identification (43)
+        if data[mbtcp['func_code']['start'], 2] == "\x2b\x0e"
+          num_objects = data[mbtcp['num_objects']['start'], mbtcp['num_objects']['bytes']].unpack("C")[0]
+          print_status("Number of Objects: #{ num_objects }")
+          object_start = mbtcp['object_id']['start']
+
+          for i in 1..num_objects.to_i
+            object = Hash.new
+            object['id']        = data[object_start, mbtcp['object_id']['bytes']].unpack("C")[0]
+            object['len']       = data[object_start + mbtcp['object_id']['bytes'], mbtcp['objects_len']['bytes']].unpack("C")[0]
+            object["str_value"] = data[object_start + mbtcp['object_id']['bytes'] + mbtcp['objects_len']['bytes'], object['len']].unpack("a*")[0]
+            begin
+              object['name'] = object_name[object['id']]
+            rescue
+              object['name'] = "Name X"
+            end
+
+            print_good("#{ object['name'] }: #{ object['str_value'] }")
+            object_start = object_start + mbtcp['object_id']['bytes'] + mbtcp['objects_len']['bytes'] + object['len']
+
+            report_note(
+              :host => ip,
+              :proto => 'tcp',
+              :port => rport,
+              :sname => 'modbus',
+              :type => "modbus.#{ object['name'].downcase }",
+              :data => object['str_value']
+            )
+          end
+        else
+          handle_exception_codes(data[mbtcp['func_code']['start'], 2])
+        end
+      else
+        raise ::Rex::ConnectionTimeout
+      end
+    rescue ::Interrupt
+      print_error("MODBUS - Interrupt during payload")
+      raise $!
+    rescue ::Rex::HostUnreachable, ::Rex::ConnectionError, ::Rex::ConnectionTimeout, ::Rex::ConnectionRefused => e
+      print_error("MODBUS - Network error during payload: #{e}")
+      return nil
+    rescue ::EOFError
+      print_error("MODBUS - No reply")
+    end
+
+    def cleanup
+      disconnect() rescue nil
+    end
+  end
+end

--- a/modules/auxiliary/scanner/scada/modbus_banner_grabbing.rb
+++ b/modules/auxiliary/scanner/scada/modbus_banner_grabbing.rb
@@ -25,6 +25,7 @@ class MetasploitModule < Msf::Auxiliary
       ],
       'References'  =>
       [
+        [ 'URL', 'https://modbus.org/docs/Modbus_Messaging_Implementation_Guide_V1_0b.pdf' ],
         [ 'URL', 'https://en.wikipedia.org/wiki/Modbus#Modbus_TCP_frame_format_(primarily_used_on_Ethernet_networks)' ],
         [ 'URL', 'https://github.com/industrialarmy/Hello_Proto' ],
       ],
@@ -34,7 +35,6 @@ class MetasploitModule < Msf::Auxiliary
     register_options(
       [
         Opt::RPORT(502),
-        OptInt.new('UNIT_ID', [true, "A number from 0 to 254 inclusive indicating the Slave Address of the device behind the gateway", 0]),
         OptInt.new('TIMEOUT', [true, 'Timeout for the network probe', 2])
       ])
   end
@@ -103,17 +103,12 @@ class MetasploitModule < Msf::Auxiliary
     }
 
     begin
-      if (datastore['UNIT_ID'] > 254 || datastore['UNIT_ID'] < 0)
-        print_error('The value of UNIT_ID must be between 0 and 254 inclusive. Please supply a valid value.')
-        return
-      end
-
       connect
 
       packet  = "\x44\x62" # Transaction Identifier
       packet << "\x00\x00" # Protocol Identifier
       packet << "\x00\x05" # Length
-      packet << [datastore['UNIT_ID']].pack("C") # Unit Identifier
+      packet << "\xFF"     # Unit Identifier
       packet << "\x2b"     # .010 1011 = Function Code: Encapsulated Interface Transport (43)
       packet << "\x0e"     # MEI type: Read Device Identification (14)
       packet << "\x03"     # Read Device ID: Extended Device Identification (3)

--- a/modules/auxiliary/scanner/scada/modbus_banner_grabbing.rb
+++ b/modules/auxiliary/scanner/scada/modbus_banner_grabbing.rb
@@ -9,110 +9,114 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Scanner
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'        => 'Modbus Banner Grabbing',
-      'Description' => %q{
-        This module grabs the banner of any device running the Modbus protocol
-        by sending a request with Modbus Function Code 43 (Read Device
-        Identification). Modbus is a data communications protocol originally
-        published by Modicon (now Schneider Electric) in 1979 for use with its
-        programmable logic controllers (PLCs).
-      },
-      'Author'      =>
-      [
-        'Juan Escobar <juan[at]null-life.com>', # @itsecurityco
-        'Ezequiel Fernandez' # @capitan_alfa
-      ],
-      'References'  =>
-      [
-        [ 'URL', 'https://modbus.org/docs/Modbus_Messaging_Implementation_Guide_V1_0b.pdf' ],
-        [ 'URL', 'https://en.wikipedia.org/wiki/Modbus#Modbus_TCP_frame_format_(primarily_used_on_Ethernet_networks)' ],
-        [ 'URL', 'https://github.com/industrialarmy/Hello_Proto' ],
-      ],
-      'License'     => MSF_LICENSE
-    ))
+    super(
+      update_info(
+        info,
+        'Name' => 'Modbus Banner Grabbing',
+        'Description' => %q{
+          This module grabs the banner of any device running the Modbus protocol
+          by sending a request with Modbus Function Code 43 (Read Device
+          Identification). Modbus is a data communications protocol originally
+          published by Modicon (now Schneider Electric) in 1979 for use with its
+          programmable logic controllers (PLCs).
+        },
+        'Author' =>
+        [
+          'Juan Escobar <juan[at]null-life.com>', # @itsecurityco
+          'Ezequiel Fernandez' # @capitan_alfa
+        ],
+        'References' =>
+        [
+          [ 'URL', 'https://modbus.org/docs/Modbus_Messaging_Implementation_Guide_V1_0b.pdf' ],
+          [ 'URL', 'https://en.wikipedia.org/wiki/Modbus#Modbus_TCP_frame_format_(primarily_used_on_Ethernet_networks)' ],
+          [ 'URL', 'https://github.com/industrialarmy/Hello_Proto' ],
+        ],
+        'License' => MSF_LICENSE
+      )
+    )
 
     register_options(
       [
         Opt::RPORT(502),
         OptInt.new('TIMEOUT', [true, 'Timeout for the network probe', 2])
-      ])
+      ]
+    )
   end
 
   # Main Modbus exception codes
   def handle_exception_codes(code)
     case code
-      when "\xab\x01"
-        print_error("Illegal Function: Function code received in the query is not recognized or allowed by slave.")
-      when "\xab\x02"
-        print_error("Illegal Data Address: Data address of some or all the required entities are not allowed or do not exist in slave.")
-      when "\xab\x03"
-        print_error("Illegal Data Value: Value is not accepted by slave.")
-      when "\xab\x04"
-        print_error("Slave Device Failure: Unrecoverable error occurred while slave was attempting to perform requested action.")
-      when "\xab\x05"
-        print_error("Acknowledge: Slave has accepted request and is processing it, but a long duration of time is required.")
-      when "\xab\x06"
-        print_error("Slave Device Busy: Slave is engaged in processing a long-duration command.")
-      when "\xab\x07"
-        print_error("Negative Acknowledge: Slave cannot perform the programming functions.")
-      when "\xab\x08"
-        print_error("Memory Parity Error: Slave detected a parity error in memory.")
-      when "\xab\x0a"
-        print_error("Gateway Path Unavailable: Specialized for Modbus gateways. Indicates a misconfigured gateway.")
-      when "\xab\x0b"
-        print_error("Gateway Target Device Failed to Respond: Specialized for Modbus gateways.")
-      else
-        print_error("MODBUS - received incorrect data.")
+    when "\xab\x01"
+      print_error('Illegal Function: The function code received in the query is not recognized or allowed by the slave.')
+    when "\xab\x02"
+      print_error('Illegal Data Address: Data address of some or all the required entities are not allowed or do not exist in slave.')
+    when "\xab\x03"
+      print_error('Illegal Data Value: Value is not accepted by slave.')
+    when "\xab\x04"
+      print_error('Slave Device Failure: Unrecoverable error occurred while slave was attempting to perform requested action.')
+    when "\xab\x05"
+      print_error('Acknowledge: Slave has accepted the request and is processing it, but requires a long period of time to process it.')
+    when "\xab\x06"
+      print_error('Slave Device Busy: Slave is engaged in processing a long-duration program command.')
+    when "\xab\x07"
+      print_error('Negative Acknowledge: Slave cannot perform the programming function recieved in the query.')
+    when "\xab\x08"
+      print_error('Memory Parity Error: Slave detected a parity error in memory.')
+    when "\xab\x0a"
+      print_error('Gateway Path Unavailable: The gateway was likely misconfigured or is overloaded as it was unable to internally connect the input and output channels.')
+    when "\xab\x0b"
+      print_error("Gateway Target Device Failed to Respond: Gateway could not find the target device on the network or the target device didn't respond.")
+    else
+      print_error('MODBUS - received incorrect data.')
     end
   end
 
   def run_host(ip)
     object_name = {
-      0   => "VendorName",
-      1   => "ProductCode",
-      2   => "Revision",
-      3   => "VendorUrl",
-      4   => "ProductName",
-      5   => "ModelName",
-      6   => "UserAppName",
-      7   => "Reserved",
-      8   => "Reserved",
-      9   => "Reserved",
-      10  => "Reserved",
-      128 => "PrivateObjects",
-      255 => "PrivateObjects"
+      0 => 'VendorName',
+      1 => 'ProductCode',
+      2 => 'Revision',
+      3 => 'VendorUrl',
+      4 => 'ProductName',
+      5 => 'ModelName',
+      6 => 'UserAppName',
+      7 => 'Reserved',
+      8 => 'Reserved',
+      9 => 'Reserved',
+      10 => 'Reserved',
+      128 => 'PrivateObjects',
+      255 => 'PrivateObjects'
     }
 
     # Modbus/TCP Response Bytes
     mbtcp = {
-        'trans_id' =>         { 'start' =>  0, 'bytes' => 2 },
-        'prot_id' =>          { 'start' =>  2, 'bytes' => 2 },
-        'len' =>              { 'start' =>  4, 'bytes' => 2 },
-        'unit_id' =>          { 'start' =>  6, 'bytes' => 1 },
-        'func_code' =>        { 'start' =>  7, 'bytes' => 1 },
-        'mei' =>              { 'start' =>  8, 'bytes' => 1 },
-        'read_device_id' =>   { 'start' =>  9, 'bytes' => 1 },
-        'conformity_level' => { 'start' => 10, 'bytes' => 1 },
-        'more_follows' =>     { 'start' => 11, 'bytes' => 1 },
-        'next_object_id' =>   { 'start' => 12, 'bytes' => 1 },
-        'num_objects' =>      { 'start' => 13, 'bytes' => 1 },
-        'object_id' =>        { 'start' => 14, 'bytes' => 1 },
-        'objects_len' =>      { 'start' => 15, 'bytes' => 1 },
-        'object_str_value' => { 'start' => 16, 'bytes' => nil }
+      'trans_id' => { 'start' => 0, 'bytes' => 2 },
+      'prot_id' => { 'start' => 2, 'bytes' => 2 },
+      'len' => { 'start' => 4, 'bytes' => 2 },
+      'unit_id' => { 'start' => 6, 'bytes' => 1 },
+      'func_code' => { 'start' => 7, 'bytes' => 1 },
+      'mei' => { 'start' => 8, 'bytes' => 1 },
+      'read_device_id' => { 'start' => 9, 'bytes' => 1 },
+      'conformity_level' => { 'start' => 10, 'bytes' => 1 },
+      'more_follows' => { 'start' => 11, 'bytes' => 1 },
+      'next_object_id' => { 'start' => 12, 'bytes' => 1 },
+      'num_objects' => { 'start' => 13, 'bytes' => 1 },
+      'object_id' => { 'start' => 14, 'bytes' => 1 },
+      'objects_len' => { 'start' => 15, 'bytes' => 1 },
+      'object_str_value' => { 'start' => 16, 'bytes' => nil }
     }
 
     begin
       connect
 
-      packet  = "\x44\x62" # Transaction Identifier
+      packet = "\x44\x62" # Transaction Identifier
       packet << "\x00\x00" # Protocol Identifier
       packet << "\x00\x05" # Length
-      packet << "\xFF"     # Unit Identifier
-      packet << "\x2b"     # .010 1011 = Function Code: Encapsulated Interface Transport (43)
-      packet << "\x0e"     # MEI type: Read Device Identification (14)
-      packet << "\x03"     # Read Device ID: Extended Device Identification (3)
-      packet << "\x00"     # Object ID: VendorName (0)
+      packet << "\xFF" # Unit Identifier
+      packet << "\x2b" # 0010 1011 = Function Code: Encapsulated Interface Transport (43)
+      packet << "\x0e" # MEI type: Read Device Identification (14)
+      packet << "\x03" # Read Device ID: Extended Device Identification (3)
+      packet << "\x00" # Object ID: VendorName (0)
 
       sock.put(packet)
       data = sock.get_once(-1, datastore['TIMEOUT'])
@@ -130,45 +134,45 @@ class MetasploitModule < Msf::Auxiliary
       num_objects = data[mbtcp['num_objects']['start'], mbtcp['num_objects']['bytes']]
 
       if num_objects.nil?
-        print_error("MODBUS - No data was received, try changing the UNIT_ID value.")
+        print_error('MODBUS - No data was received from the target machine, its possible it may be offline or not responding.')
         return
       end
 
-      num_objects = num_objects.unpack("C")[0]
-      print_status("Number of Objects: #{ num_objects }")
+      num_objects = num_objects.unpack1('C')
+      print_status("Number of Objects: #{num_objects}")
       object_start = mbtcp['object_id']['start']
 
-      for i in 1..num_objects.to_i
+      for _i in 1..num_objects.to_i
         object = Hash.new
-        object['id']        = data[object_start, mbtcp['object_id']['bytes']].unpack("C")[0]
-        object['len']       = data[object_start + mbtcp['object_id']['bytes'], mbtcp['objects_len']['bytes']].unpack("C")[0]
-        object["str_value"] = data[object_start + mbtcp['object_id']['bytes'] + mbtcp['objects_len']['bytes'], object['len']].unpack("a*")[0]
-        begin
+        object['id'] = data[object_start, mbtcp['object_id']['bytes']].unpack1('C')
+        object['len'] = data[object_start + mbtcp['object_id']['bytes'], mbtcp['objects_len']['bytes']].unpack1('C')
+        object['str_value'] = data[object_start + mbtcp['object_id']['bytes'] + mbtcp['objects_len']['bytes'], object['len']].unpack1('a*')
+        if object_name.key?(object['id'])
           object['name'] = object_name[object['id']]
-        rescue
+        else
           object['name'] = 'Missing_Name'
         end
 
-        print_good("#{ object['name'] }: #{ object['str_value'] }")
+        print_good("#{object['name']}: #{object['str_value']}")
         object_start = object_start + mbtcp['object_id']['bytes'] + mbtcp['objects_len']['bytes'] + object['len']
 
         report_note(
-          :host => ip,
-          :proto => 'tcp',
-          :port => rport,
-          :sname => 'modbus',
-          :type => "modbus.#{ object['name'].downcase }",
-          :data => object['str_value']
+          host: ip,
+          proto: 'tcp',
+          port: rport,
+          sname: 'modbus',
+          type: "modbus.#{object['name'].downcase}",
+          data: object['str_value']
         )
       end
     rescue ::Interrupt
-      print_error("MODBUS - Interrupt during payload")
+      print_error('MODBUS - Interrupt during payload')
       raise $!
     rescue ::Rex::HostUnreachable, ::Rex::ConnectionError, ::Rex::ConnectionTimeout, ::Rex::ConnectionRefused => e
       print_error("MODBUS - Network error during payload: #{e}")
       return
     rescue ::EOFError
-      print_error("MODBUS - No reply")
+      print_error('MODBUS - No reply')
       return
     end
 

--- a/modules/auxiliary/scanner/scada/modbus_banner_grabbing.rb
+++ b/modules/auxiliary/scanner/scada/modbus_banner_grabbing.rb
@@ -58,7 +58,7 @@ class MetasploitModule < Msf::Auxiliary
       when "\xab\x08"
         print_error("Memory Parity Error: Slave detected a parity error in memory.")
       when "\xab\x0a"
-        print_error(" Gateway Path Unavailable: Specialized for Modbus gateways. Indicates a misconfigured gateway.")
+        print_error("Gateway Path Unavailable: Specialized for Modbus gateways. Indicates a misconfigured gateway.")
       when "\xab\x0b"
         print_error("Gateway Target Device Failed to Respond: Specialized for Modbus gateways.")
       else
@@ -119,7 +119,14 @@ class MetasploitModule < Msf::Auxiliary
       if data
         # Read Device Identification (43)
         if data[mbtcp['func_code']['start'], 2] == "\x2b\x0e"
-          num_objects = data[mbtcp['num_objects']['start'], mbtcp['num_objects']['bytes']].unpack("C")[0]
+          num_objects = data[mbtcp['num_objects']['start'], mbtcp['num_objects']['bytes']]
+
+          unless num_objects != nil
+            print_error("MODBUS - received incorrect data.")
+            return
+          end
+
+          num_objects = num_objects.unpack("C")[0]
           print_status("Number of Objects: #{ num_objects }")
           object_start = mbtcp['object_id']['start']
 

--- a/modules/auxiliary/scanner/scada/modbus_banner_grabbing.rb
+++ b/modules/auxiliary/scanner/scada/modbus_banner_grabbing.rb
@@ -129,7 +129,7 @@ class MetasploitModule < Msf::Auxiliary
       num_objects = data[mbtcp['num_objects']['start'], mbtcp['num_objects']['bytes']]
 
       if num_objects.nil?
-        print_error("MODBUS - received incorrect data.")
+        print_error("MODBUS - No data was received, try changing the UNID_ID value.")
         return
       end
 


### PR DESCRIPTION
Banner grabbing for Modbus using Function Code 43 (Read Device Identification). Modbus is a data communications protocol originally published by Modicon (now Schneider Electric) in 1979 for use with its programmable logic controllers (PLCs).
  
  https://en.wikipedia.org/wiki/Modbus#Available_function/command_codes

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] Do `use auxiliary/scanner/scada/modbus_banner_grabbing`
- [x] Do `set RHOST IP`
- [x] Do  `run`
- [x] **Document** the thing and how it works ([Modbus Banner Grabbing](https://github.com/itsecurityco/metasploit-framework/blob/modbus-banner/documentation/modules/auxiliary/scanner/scada/modbus_banner_grabbing.md))

## Shodan dork
- Search: `port:502` It's easier find targets if you filter by  products

## Screenshot

![tempsnip](https://user-images.githubusercontent.com/1725054/86605759-1b667600-bf75-11ea-86fd-f9356954f556.png)
