### PR TITLE
Add Msf::Post::Unix.is_root? method

### DIFF
--- a/lib/msf/core/post/unix.rb
+++ b/lib/msf/core/post/unix.rb
@@ -4,6 +4,12 @@ require 'msf/core/post/linux/system'
 
 module Msf::Post::Unix
 
+  #
+  # @return [Boolean] true if session is running as uid=0
+  #
+  def is_root?
+    (cmd_exec('id -u').to_s.gsub(/[^\d]/, '') == '0')
+  end
 
   #
   # Returns an array of hashes each representing a user

--- a/modules/exploits/freebsd/local/intel_sysret_priv_esc.rb
+++ b/modules/exploits/freebsd/local/intel_sysret_priv_esc.rb
@@ -7,6 +7,7 @@ class MetasploitModule < Msf::Exploit::Local
   Rank = GreatRanking
 
   include Msf::Post::File
+  include Msf::Post::Unix
   include Msf::Exploit::EXE
   include Msf::Exploit::FileDropper
 
@@ -104,10 +105,6 @@ class MetasploitModule < Msf::Exploit::Local
 
   def exploit_data(file)
     ::File.binread ::File.join(Msf::Config.data_directory, 'exploits', 'cve-2012-0217', file)
-  end
-
-  def is_root?
-    (cmd_exec('id -u').to_s.gsub(/[^\d]/, '') == '0')
   end
 
   def strip_comments(c_code)

--- a/modules/exploits/freebsd/local/rtld_execl_priv_esc.rb
+++ b/modules/exploits/freebsd/local/rtld_execl_priv_esc.rb
@@ -7,6 +7,7 @@ class MetasploitModule < Msf::Exploit::Local
   Rank = ExcellentRanking
 
   include Msf::Post::File
+  include Msf::Post::Unix
   include Msf::Exploit::EXE
   include Msf::Exploit::FileDropper
 
@@ -92,10 +93,6 @@ class MetasploitModule < Msf::Exploit::Local
     rm_f path
     write_file path, data
     register_file_for_cleanup path
-  end
-
-  def is_root?
-    (cmd_exec('id -u').to_s.gsub(/[^\d]/, '') == '0')
   end
 
   def check

--- a/modules/exploits/openbsd/local/dynamic_loader_chpass_privesc.rb
+++ b/modules/exploits/openbsd/local/dynamic_loader_chpass_privesc.rb
@@ -7,6 +7,7 @@ class MetasploitModule < Msf::Exploit::Local
   Rank = ExcellentRanking
 
   include Msf::Post::File
+  include Msf::Post::Unix
   include Msf::Exploit::EXE
   include Msf::Exploit::FileDropper
 
@@ -78,10 +79,6 @@ class MetasploitModule < Msf::Exploit::Local
     rm_f path
     write_file path, data
     register_file_for_cleanup path
-  end
-
-  def is_root?
-    (cmd_exec('id -u').to_s.gsub(/[^\d]/, '') == '0')
   end
 
   def libutil_name


### PR DESCRIPTION
Add `Msf::Post::Unix.is_root?` and update FreeBSD and OpenBSD local exploit modules to use `Msf::Post::Unix.is_root?`.
