### PR TITLE
Add Linux Container Enumeration Module

### DIFF
--- a/documentation/modules/post/linux/gather/enum_containers.md
+++ b/documentation/modules/post/linux/gather/enum_containers.md
@@ -27,7 +27,7 @@
 
 ## Scenarios
 
-Scenario 1: Docker is installed and there  are 4 running containers
+Scenario 1: Docker is installed with 4 running containers
 ```
 msf5 post(linux/gather/enum_containers) > set session 4
 session => 4
@@ -43,7 +43,7 @@ CONTAINER ID        IMAGE               COMMAND             CREATED             
 [*] Post module execution completed
 ```
 
-Scenario 2: Docker, LXC and RKT are installed
+Scenario 2: Docker, LXC and RKT are installed, and each of them are running their own containers
 ```
 msf5 post(linux/gather/enum_containers) > set session 5
 session => 5
@@ -105,4 +105,26 @@ HOME=/root
 HOSTNAME=1a339ef0d38e
 HOME=/root
 [*] Post module execution completed
+```
+
+Scenario 5: Docker, LXC, and RKT are all installed on the target but the user cannot enumerate all containers due to a lack of permissions
+```
+msf5 post(linux/gather/enum_containers) > exploit
+
+[+] docker was found on the system!
+[-] Was unable to enumerate the number of docker containers due to a lack of permissions!
+[-] No active or inactive containers were found for docker
+
+[+] lxc was found on the system!
+[+] lxc: 1 Running Containers / 1 Total
+NAME    STATE   IPV4                 IPV6                                         TYPE      SNAPSHOTS
+one-fox RUNNING 10.166.198.97 (eth0) fd42:a29:a47e:79c6:216:3eff:fe1f:1dca (eth0) CONTAINER 0
+[+] Results stored in: /home/gwillcox/.msf4/loot/20200805175357_default_172.27.129.4_host.lxc_contain_675096.txt
+
+[+] rkt was found on the system!
+[-] Was unable to enumerate the number of rkt containers due to a lack of permissions!
+[-] No active or inactive containers were found for rkt
+
+[*] Post module execution completed
+msf5 post(linux/gather/enum_containers) >
 ```

--- a/documentation/modules/post/linux/gather/enum_containers.md
+++ b/documentation/modules/post/linux/gather/enum_containers.md
@@ -1,0 +1,70 @@
+## Container Platforms
+
+  This module looks for container platforms running on the target and then lists any currently running containers for each platform found. The currently supported container platforms are:
+  
+  1. Docker
+  2. LXC
+  3. RKT
+
+## Verification Steps
+
+  1. Start msfconsole
+  2. Get a session via exploit of your choice
+  3. Load and run the module `run post/linux/gather/enum_containers`
+  4. You should get feedback if any container platforms are runnable by the current user and if there are any active containers running on them
+
+## Options
+
+  **SESSION**
+
+  Which session to use, which can be viewed with `sessions -l`
+
+## Scenarios
+
+Scenario 1: Docker is installed and there  are 4 running containers
+```
+msf5 post(linux/gather/enum_containers) > set session 4
+session => 4
+msf5 post(linux/gather/enum_containers) > run
+
+[+] docker: 4 Active Containers
+CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
+6e406d13fde7        ubuntu              "/bin/bash"         5 days ago          Up 45 hours                             test4
+3d137beafb08        ubuntu              "/bin/bash"         5 days ago          Up 45 hours                             test3
+8cb7e2aff68a        ubuntu              "/bin/bash"         5 days ago          Up 45 hours                             test2
+1a339ef0d38e        ubuntu              "/bin/bash"         5 days ago          Up 45 hours                             test1
+[*] Post module execution completed
+```
+
+Scenario 2: Docker, LXC and RKT are installed
+```
+msf5 post(linux/gather/enum_containers) > set session 5
+session => 5
+msf5 post(linux/gather/enum_containers) > run
+
+[+] docker: 4 Active Containers
+CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
+6e406d13fde7        ubuntu              "/bin/bash"         5 days ago          Up 45 hours                             test4
+3d137beafb08        ubuntu              "/bin/bash"         5 days ago          Up 45 hours                             test3
+8cb7e2aff68a        ubuntu              "/bin/bash"         5 days ago          Up 45 hours                             test2
+1a339ef0d38e        ubuntu              "/bin/bash"         5 days ago          Up 45 hours                             test1
+[+] lxc: 2 Active Containers
++---------------+---------+-----------------------+-----------------------------------------------+-----------+-----------+
+|     NAME      |  STATE  |         IPV4          |                     IPV6                      |   TYPE    | SNAPSHOTS |
++---------------+---------+-----------------------+-----------------------------------------------+-----------+-----------+
+| t4testingName | RUNNING | 10.132.199.244 (eth0) | fd42:53d9:b4c9:609e:216:3eff:fece:f6df (eth0) | CONTAINER | 0         |
++---------------+---------+-----------------------+-----------------------------------------------+-----------+-----------+
+| ubuntu        | RUNNING | 10.132.199.192 (eth0) | fd42:53d9:b4c9:609e:216:3eff:fe9a:fa5f (eth0) | CONTAINER | 0         |
++---------------+---------+-----------------------+-----------------------------------------------+-----------+-----------+
+[+] rkt: 0 Active Containers
+[*] Post module execution completed
+```
+
+Scenario 3: No container software is runnable
+```
+msf5 post(linux/gather/enum_containers) > set session 6
+session => 6
+msf5 post(linux/gather/enum_containers) > run
+[-] No container software appears to be installed
+[*] Post module execution completed
+```

--- a/documentation/modules/post/linux/gather/enum_containers.md
+++ b/documentation/modules/post/linux/gather/enum_containers.md
@@ -10,8 +10,10 @@
 
   1. Start msfconsole
   2. Get a session via exploit of your choice
-  3. Load and run the module `run post/linux/gather/enum_containers`
-  4. You should get feedback if any container platforms are runnable by the current user and if there are any active containers running on them
+  3. Load the module `use post/linux/gather/enum_containers`
+  4. Set the session `set session 1`
+  5. run the module `run`
+  6. You should get feedback if any container platforms are runnable by the current user and if there are any active containers running on them
 
 ## Options
 

--- a/documentation/modules/post/linux/gather/enum_containers.md
+++ b/documentation/modules/post/linux/gather/enum_containers.md
@@ -20,6 +20,10 @@
   **SESSION**
 
   Which session to use, which can be viewed with `sessions -l`
+ 
+  **CMD**
+
+  Optional shell command to run on each running container
 
 ## Scenarios
 
@@ -29,12 +33,13 @@ msf5 post(linux/gather/enum_containers) > set session 4
 session => 4
 msf5 post(linux/gather/enum_containers) > run
 
-[+] docker: 4 Active Containers
+[+] docker: 4 Running Containers / 4 Total
+[+] 
 CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
-6e406d13fde7        ubuntu              "/bin/bash"         5 days ago          Up 45 hours                             test4
-3d137beafb08        ubuntu              "/bin/bash"         5 days ago          Up 45 hours                             test3
-8cb7e2aff68a        ubuntu              "/bin/bash"         5 days ago          Up 45 hours                             test2
-1a339ef0d38e        ubuntu              "/bin/bash"         5 days ago          Up 45 hours                             test1
+6e406d13fde7        ubuntu              "/bin/bash"         10 days ago         Up 3 hours                              test4
+3d137beafb08        ubuntu              "/bin/bash"         10 days ago         Up 3 hours                              test3
+8cb7e2aff68a        ubuntu              "/bin/bash"         10 days ago         Up 3 hours                              test2
+1a339ef0d38e        ubuntu              "/bin/bash"         10 days ago         Up 3 hours                              test1
 [*] Post module execution completed
 ```
 
@@ -50,15 +55,19 @@ CONTAINER ID        IMAGE               COMMAND             CREATED             
 3d137beafb08        ubuntu              "/bin/bash"         5 days ago          Up 45 hours                             test3
 8cb7e2aff68a        ubuntu              "/bin/bash"         5 days ago          Up 45 hours                             test2
 1a339ef0d38e        ubuntu              "/bin/bash"         5 days ago          Up 45 hours                             test1
-[+] lxc: 2 Active Containers
+[+] lxc: 2 Running Containers / 3 Total
+[+] 
 +---------------+---------+-----------------------+-----------------------------------------------+-----------+-----------+
 |     NAME      |  STATE  |         IPV4          |                     IPV6                      |   TYPE    | SNAPSHOTS |
++---------------+---------+-----------------------+-----------------------------------------------+-----------+-----------+
+| privesc       | STOPPED |                       |                                               | CONTAINER | 0         |
 +---------------+---------+-----------------------+-----------------------------------------------+-----------+-----------+
 | t4testingName | RUNNING | 10.132.199.244 (eth0) | fd42:53d9:b4c9:609e:216:3eff:fece:f6df (eth0) | CONTAINER | 0         |
 +---------------+---------+-----------------------+-----------------------------------------------+-----------+-----------+
 | ubuntu        | RUNNING | 10.132.199.192 (eth0) | fd42:53d9:b4c9:609e:216:3eff:fe9a:fa5f (eth0) | CONTAINER | 0         |
 +---------------+---------+-----------------------+-----------------------------------------------+-----------+-----------+
-[+] rkt: 0 Active Containers
+
+[+] rkt: 0 Active Containers / 0 Total
 [*] Post module execution completed
 ```
 
@@ -68,5 +77,32 @@ msf5 post(linux/gather/enum_containers) > set session 6
 session => 6
 msf5 post(linux/gather/enum_containers) > run
 [-] No container software appears to be installed
+[*] Post module execution completed
+```
+
+Scenario 4: List all containers and execute the `env` command on all running containers
+```
+msf5 post(linux/gather/enum_containers) > set session 6
+session => 6
+msf5 post(linux/gather/enum_containers) > set cmd env
+cmd => env
+msf5 post(linux/gather/enum_containers) > run
+
+[+] docker: 2 Running Containers / 2 Total
+[+] 
+CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
+8cb7e2aff68a        ubuntu              "/bin/bash"         10 days ago         Up 3 hours                              test2
+1a339ef0d38e        ubuntu              "/bin/bash"         10 days ago         Up 3 hours                              test1
+
+[*] Executing command on docker container test2
+[*] Running docker exec 'test2' env
+[+] PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+HOSTNAME=8cb7e2aff68a
+HOME=/root
+[*] Executing command on docker container test1
+[*] Running docker exec 'test1' env
+[+] PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+HOSTNAME=1a339ef0d38e
+HOME=/root
 [*] Post module execution completed
 ```

--- a/documentation/modules/post/linux/gather/enum_containers.md
+++ b/documentation/modules/post/linux/gather/enum_containers.md
@@ -1,6 +1,6 @@
 ## Container Platforms
 
-  This module looks for container platforms running on the target and then lists any currently running containers for each platform found. The currently supported container platforms are:
+This module looks for container platforms running on the target and then lists any currently running containers for each platform found. The currently supported container platforms are:
   
   1. Docker
   2. LXC
@@ -33,50 +33,56 @@ msf5 post(linux/gather/enum_containers) > set session 4
 session => 4
 msf5 post(linux/gather/enum_containers) > run
 
-[+] docker: 4 Running Containers / 4 Total
-[+] 
-CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
-6e406d13fde7        ubuntu              "/bin/bash"         10 days ago         Up 3 hours                              test4
-3d137beafb08        ubuntu              "/bin/bash"         10 days ago         Up 3 hours                              test3
-8cb7e2aff68a        ubuntu              "/bin/bash"         10 days ago         Up 3 hours                              test2
-1a339ef0d38e        ubuntu              "/bin/bash"         10 days ago         Up 3 hours                              test1
+[+] docker was found on the system!
+[+] docker: 1 Running Containers / 5 Total
+CONTAINER ID        IMAGE               COMMAND                  CREATED             STATUS                         PORTS               NAMES
+853913ae1e17        nginx               "/docker-entrypoint.…"   About an hour ago   Up About an hour               80/tcp              lucid_tu
+0422ad0a1d6e        nginx               "/docker-entrypoint.…"   About an hour ago   Exited (0) About an hour ago                       gifted_thompson
+35930fd284e1        nginx               "/docker-entrypoint.…"   2 days ago          Exited (0) 5 hours ago                             unruffled_gates
+a7149a9a858e        nginx               "/docker-entrypoint.…"   2 days ago          Exited (127) 2 days ago                            pedantic_tesla
+cfa40ec4d85c        nginx               "/docker-entrypoint.…"   2 days ago          Exited (0) 2 days ago                              fervent_gates
+[+] Results stored in: /home/gwillcox/.msf4/loot/20200805143522_default_172.27.129.4_host.docker_cont_134332.txt
 [*] Post module execution completed
 ```
 
 Scenario 2: Docker, LXC and RKT are installed, and each of them are running their own containers
 ```
-msf5 post(linux/gather/enum_containers) > set session 5
-session => 5
-msf5 post(linux/gather/enum_containers) > run
+msf5 post(linux/gather/enum_containers) > set session 2
+session => 2
+msf5 post(linux/gather/enum_containers) > exploit
 
-[+] docker: 4 Active Containers
-CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
-6e406d13fde7        ubuntu              "/bin/bash"         5 days ago          Up 45 hours                             test4
-3d137beafb08        ubuntu              "/bin/bash"         5 days ago          Up 45 hours                             test3
-8cb7e2aff68a        ubuntu              "/bin/bash"         5 days ago          Up 45 hours                             test2
-1a339ef0d38e        ubuntu              "/bin/bash"         5 days ago          Up 45 hours                             test1
-[+] lxc: 2 Running Containers / 3 Total
-[+] 
-+---------------+---------+-----------------------+-----------------------------------------------+-----------+-----------+
-|     NAME      |  STATE  |         IPV4          |                     IPV6                      |   TYPE    | SNAPSHOTS |
-+---------------+---------+-----------------------+-----------------------------------------------+-----------+-----------+
-| privesc       | STOPPED |                       |                                               | CONTAINER | 0         |
-+---------------+---------+-----------------------+-----------------------------------------------+-----------+-----------+
-| t4testingName | RUNNING | 10.132.199.244 (eth0) | fd42:53d9:b4c9:609e:216:3eff:fece:f6df (eth0) | CONTAINER | 0         |
-+---------------+---------+-----------------------+-----------------------------------------------+-----------+-----------+
-| ubuntu        | RUNNING | 10.132.199.192 (eth0) | fd42:53d9:b4c9:609e:216:3eff:fe9a:fa5f (eth0) | CONTAINER | 0         |
-+---------------+---------+-----------------------+-----------------------------------------------+-----------+-----------+
+[+] docker was found on the system!
+[+] docker: 1 Running Containers / 5 Total
+CONTAINER ID        IMAGE               COMMAND                  CREATED             STATUS                         PORTS               NAMES
+853913ae1e17        nginx               "/docker-entrypoint.…"   About an hour ago   Up About an hour               80/tcp              lucid_tu
+0422ad0a1d6e        nginx               "/docker-entrypoint.…"   About an hour ago   Exited (0) About an hour ago                       gifted_thompson
+35930fd284e1        nginx               "/docker-entrypoint.…"   2 days ago          Exited (0) 5 hours ago                             unruffled_gates
+a7149a9a858e        nginx               "/docker-entrypoint.…"   2 days ago          Exited (127) 2 days ago                            pedantic_tesla
+cfa40ec4d85c        nginx               "/docker-entrypoint.…"   2 days ago          Exited (0) 2 days ago                              fervent_gates
+[+] Results stored in: /home/gwillcox/.msf4/loot/20200805193841_default_172.27.129.4_host.docker_cont_169517.txt
 
-[+] rkt: 0 Active Containers / 0 Total
+[+] lxc was found on the system!
+[+] lxc: 1 Running Containers / 1 Total
+NAME    STATE   IPV4                 IPV6                                         TYPE      SNAPSHOTS
+one-fox RUNNING 10.166.198.97 (eth0) fd42:a29:a47e:79c6:216:3eff:fe1f:1dca (eth0) CONTAINER 0
+[+] Results stored in: /home/gwillcox/.msf4/loot/20200805193842_default_172.27.129.4_host.lxc_contain_448673.txt
+
+[+] rkt was found on the system!
+[+] rkt: 2 Running Containers / 1 Total
+UUID            APP     IMAGE NAME              STATE           CREATED         STARTED         NETWORKS
+1f5f73a2        etcd    coreos.com/etcd:v3.1.7  running         32 minutes ago  32 minutes ago  default:ip4=172.16.28.3
+384c8a25        etcd    coreos.com/etcd:v3.1.7  exited garbage  4 hours ago     4 hours ago     default:ip4=172.16.28.2
+[+] Results stored in: /home/gwillcox/.msf4/loot/20200805193842_default_172.27.129.4_host.rkt_contain_801968.txt
+
 [*] Post module execution completed
-```
+msf5 post(linux/gather/enum_containers) >
 
 Scenario 3: No container software is runnable
 ```
 msf5 post(linux/gather/enum_containers) > set session 6
 session => 6
 msf5 post(linux/gather/enum_containers) > run
-[-] No container software appears to be installed
+[-] No container software appears to be installed or runnable by the current user
 [*] Post module execution completed
 ```
 
@@ -84,47 +90,62 @@ Scenario 4: List all containers and execute the `env` command on all running con
 ```
 msf5 post(linux/gather/enum_containers) > set session 6
 session => 6
-msf5 post(linux/gather/enum_containers) > set cmd env
-cmd => env
+msf5 post(linux/gather/enum_containers) > set CMD "env"
+CMD => env
 msf5 post(linux/gather/enum_containers) > run
 
-[+] docker: 2 Running Containers / 2 Total
-[+] 
-CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
-8cb7e2aff68a        ubuntu              "/bin/bash"         10 days ago         Up 3 hours                              test2
-1a339ef0d38e        ubuntu              "/bin/bash"         10 days ago         Up 3 hours                              test1
-
-[*] Executing command on docker container test2
-[*] Running docker exec 'test2' env
-[+] PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-HOSTNAME=8cb7e2aff68a
-HOME=/root
-[*] Executing command on docker container test1
-[*] Running docker exec 'test1' env
-[+] PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-HOSTNAME=1a339ef0d38e
-HOME=/root
-[*] Post module execution completed
-```
-
-Scenario 5: Docker, LXC, and RKT are all installed on the target but the user cannot enumerate all containers due to a lack of permissions
-```
-msf5 post(linux/gather/enum_containers) > exploit
-
 [+] docker was found on the system!
-[-] Was unable to enumerate the number of docker containers due to a lack of permissions!
-[-] No active or inactive containers were found for docker
+[+] docker: 1 Running Containers / 5 Total
+CONTAINER ID        IMAGE               COMMAND                  CREATED             STATUS                    PORTS               NAMES
+853913ae1e17        nginx               "/docker-entrypoint.…"   2 hours ago         Up 2 hours                80/tcp              lucid_tu
+0422ad0a1d6e        nginx               "/docker-entrypoint.…"   2 hours ago         Exited (0) 2 hours ago                        gifted_thompson
+35930fd284e1        nginx               "/docker-entrypoint.…"   2 days ago          Exited (0) 6 hours ago                        unruffled_gates
+a7149a9a858e        nginx               "/docker-entrypoint.…"   2 days ago          Exited (127) 2 days ago                       pedantic_tesla
+cfa40ec4d85c        nginx               "/docker-entrypoint.…"   2 days ago          Exited (0) 2 days ago                         fervent_gates
+[+] Results stored in: /home/gwillcox/.msf4/loot/20200805202620_default_172.27.129.4_host.docker_cont_406553.txt
 
+[*] Executing command on docker container lucid_tu
+[+] PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+HOSTNAME=853913ae1e17
+NGINX_VERSION=1.19.1
+NJS_VERSION=0.4.2
+PKG_RELEASE=1~buster
+HOME=/root
 [+] lxc was found on the system!
 [+] lxc: 1 Running Containers / 1 Total
 NAME    STATE   IPV4                 IPV6                                         TYPE      SNAPSHOTS
 one-fox RUNNING 10.166.198.97 (eth0) fd42:a29:a47e:79c6:216:3eff:fe1f:1dca (eth0) CONTAINER 0
-[+] Results stored in: /home/gwillcox/.msf4/loot/20200805175357_default_172.27.129.4_host.lxc_contain_675096.txt
+[+] Results stored in: /home/gwillcox/.msf4/loot/20200805202623_default_172.27.129.4_host.lxc_contain_977736.txt
 
+[*] Executing command on lxc container one-fox
+[+] PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
+container=lxc
+HOME=/root
+USER=root
+LANG=C.UTF-8
 [+] rkt was found on the system!
-[-] Was unable to enumerate the number of rkt containers due to a lack of permissions!
-[-] No active or inactive containers were found for rkt
+[+] rkt: 2 Running Containers / 1 Total
+UUID            APP     IMAGE NAME              STATE           CREATED         STARTED         NETWORKS
+1f5f73a2        etcd    coreos.com/etcd:v3.1.7  running         1 hour ago      1 hour ago      default:ip4=172.16.28.3
+384c8a25        etcd    coreos.com/etcd:v3.1.7  exited garbage  5 hours ago     5 hours ago     default:ip4=172.16.28.2
+[+] Results stored in: /home/gwillcox/.msf4/loot/20200805202625_default_172.27.129.4_host.rkt_contain_522670.txt
 
+[*] Executing command on rkt container 1f5f73a2
+[-] RKT containers do not support command execution
+Use rkt enter '1f5f73a2' to manually enumerate this container
+[+] USER=root
+HOME=/root
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/system/bin:/system/sbin:/system/xbin
+LANG=C
+PWD=/home/gwillcox/git/metasploit-framework
+[*] Executing command on rkt container 384c8a25
+[-] RKT containers do not support command execution
+Use rkt enter '384c8a25' to manually enumerate this container
+[+] USER=root
+HOME=/root
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/system/bin:/system/sbin:/system/xbin
+LANG=C
+PWD=/home/gwillcox/git/metasploit-framework
 [*] Post module execution completed
 msf5 post(linux/gather/enum_containers) >
 ```

--- a/modules/post/linux/gather/enum_containers.rb
+++ b/modules/post/linux/gather/enum_containers.rb
@@ -1,0 +1,94 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Post
+  include Msf::Post::File
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name' => 'Linux Container Enumeration',
+      'Description' => %q{
+        This module attempts to enumerate containers running on the target machine.
+        Supports Docker, LXC and RKT.
+      },
+      'License' => MSF_LICENSE,
+      'Author' => ['Mat Rollings'],
+      'Platform' => ['linux'],
+      'SessionTypes' => ['shell', 'meterpreter']
+    ))
+  end
+
+  # Check if a container program is installed and usable by current user
+  def runnable(container_type)
+    case container_type
+    when 'docker'
+      result = cmd_exec('docker ps >/dev/null 2>&1 && echo true')
+    when 'lxc'
+      result = cmd_exec('lxc list >/dev/null 2>&1 && echo true')
+    when 'rkt'
+      result = cmd_exec('rkt list >/dev/null 2>&1 && echo true')
+    else
+      print_error("Invalid container type #{container_type}")
+      return false
+    end
+    result =~ /true$/
+  end
+
+  # Count the number of currently running containers
+  def count_containers(container_type)
+    case container_type
+    when 'docker'
+      result = cmd_exec('docker ps --format "{{.Names}}" 2>/dev/null | wc -l')
+    when 'lxc'
+      result = cmd_exec('lxc list -c n --format csv 2>/dev/null | wc -l')
+    when 'rkt'
+      result = cmd_exec('rkt list 2>/dev/null | tail -n +2  | wc -l')
+    else
+      print_error("Invalid container type '#{container_type}'")
+      return 0
+    end
+    result.to_i
+  end
+
+  # List the currently running containers
+  def list_containers(container_type)
+    case container_type
+    when 'docker'
+      result = cmd_exec('docker ps')
+    when 'lxc'
+      result = cmd_exec('lxc list')
+    when 'rkt'
+      result = cmd_exec('rkt list')
+    else
+      print_error("Invalid container type '#{container_type}'")
+      return false
+    end
+    result
+  end
+
+  # Run Method for when run command is issued
+  def run
+    platforms = %w[docker lxc rkt]
+    platforms_found = false
+
+    platforms.each do |platform|
+      if runnable(platform)
+        platforms_found = true
+        no_active = count_containers(platform)
+        print_good("#{platform}: #{no_active} Active Containers")
+        if noActive > 0
+          containers = list_containers(platform)
+          print("#{containers}\n")
+        end
+      else
+        vprint_status("#{platform} is either not installed or not runnable by current user")
+      end
+    end
+
+    unless platforms_found
+      print_error('No container software appears to be installed')
+    end
+  end
+end

--- a/modules/post/linux/gather/enum_containers.rb
+++ b/modules/post/linux/gather/enum_containers.rb
@@ -7,21 +7,25 @@ class MetasploitModule < Msf::Post
   include Msf::Post::File
 
   def initialize(info = {})
-    super(update_info(info,
-                      'Name' => 'Linux Container Enumeration',
-                      'Description' => %q{
-        This module attempts to enumeratec containers on the target machine and optionally run a command on each active container found..
-        Supports Docker, LXC and RKT.
-      },
-                      'License' => MSF_LICENSE,
-                      'Author' => ['stealthcopter'],
-                      'Platform' => ['linux'],
-                      'SessionTypes' => ['shell', 'meterpreter']
-          ))
+    super(
+      update_info(
+        info,
+        'Name' => 'Linux Container Enumeration',
+        'Description' => %q{
+          This module attempts to enumeratec containers on the target machine and optionally run a command on each active container found..
+          Supports Docker, LXC and RKT.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => ['stealthcopter'],
+        'Platform' => ['linux'],
+        'SessionTypes' => ['shell', 'meterpreter']
+      )
+    )
     register_options(
-        [
-            OptString.new('CMD', [false, 'Optional command to run on each running container', ''])
-        ])
+      [
+        OptString.new('CMD', [false, 'Optional command to run on each running container', ''])
+      ]
+    )
   end
 
   def cmd
@@ -133,7 +137,12 @@ class MetasploitModule < Msf::Post
     platforms.each do |platform|
       num_containers = count_containers(platform)
       num_running_containers = count_containers(platform, false)
-      print_good("#{platform}: #{num_running_containers} Running Containers / #{num_containers} Total")
+
+      if num_containers == 0
+        print_good("#{platform} found but no active or inactive containers were found")
+      else
+        print_good("#{platform}: #{num_running_containers} Running Containers / #{num_containers} Total")
+      end
 
       next unless num_containers
 

--- a/modules/post/linux/gather/enum_containers.rb
+++ b/modules/post/linux/gather/enum_containers.rb
@@ -14,7 +14,7 @@ class MetasploitModule < Msf::Post
         Supports Docker, LXC and RKT.
       },
       'License' => MSF_LICENSE,
-      'Author' => ['Mat Rollings'],
+      'Author' => ['Mat Rollings [stealthcopter]'],
       'Platform' => ['linux'],
       'SessionTypes' => ['shell', 'meterpreter']
     ))

--- a/modules/post/linux/gather/enum_containers.rb
+++ b/modules/post/linux/gather/enum_containers.rb
@@ -125,7 +125,7 @@ class MetasploitModule < Msf::Post
   end
 
   # Execute a command on a container
-  def container_execute(container_type, container_identifier, command = 'env')
+  def container_execute(container_type, container_identifier, command)
     case container_type
     when 'docker'
       command = "docker exec '#{container_identifier}' #{command}"

--- a/modules/post/linux/gather/enum_containers.rb
+++ b/modules/post/linux/gather/enum_containers.rb
@@ -40,9 +40,9 @@ class MetasploitModule < Msf::Post
     when 'lxc'
       command = 'lxc >/dev/null 2>&1 && echo true'
     when 'rkt'
-      command = 'rkt help >/dev/null 2>&1 && echo true' # Apparently rkt doesn't play nice with 2>&1 in most cases so just a heads up. 
-                                                        # `rkt help` does seem to not raise errors though so thats why we use it 
-                                                        # here over just `rkt`
+      command = 'rkt help >/dev/null 2>&1 && echo true' # Apparently rkt doesn't play nice with 2>&1 in most cases so just a heads up.
+    # `rkt help` does seem to not raise errors though so thats why we use it
+    # here over just `rkt`
     else
       print_error("Invalid container type #{container_type}")
       return false
@@ -165,7 +165,7 @@ class MetasploitModule < Msf::Post
 
       containers = list_containers(platform)
       # Using print so not to mess up table formatting
-      print_line("#{containers}")
+      print_line(containers.to_s)
 
       p = store_loot("host.#{platform}_containers", 'text/plain', session, containers, "#{platform}_containers.txt", "#{platform} Containers")
       print_good("Results stored in: #{p}\n")

--- a/modules/post/linux/gather/enum_containers.rb
+++ b/modules/post/linux/gather/enum_containers.rb
@@ -179,7 +179,7 @@ class MetasploitModule < Msf::Post
       running_container_ids.each do |container_id|
         print_status("Executing command on #{platform} container #{container_id}")
         command_result = container_execute(platform, container_id, cmd)
-        print_good(command_result) if !container.nil?
+        print_good(command_result) if !command_result.nil?
       end
     end
   end

--- a/modules/post/linux/gather/enum_containers.rb
+++ b/modules/post/linux/gather/enum_containers.rb
@@ -177,14 +177,15 @@ class MetasploitModule < Msf::Post
 
       running_container_ids = list_running_containers_id(platform)
       next if running_container_ids.nil?
+
       running_container_ids.each do |container_id|
         print_status("Executing command on #{platform} container #{container_id}")
         command_result = container_execute(platform, container_id, cmd)
-        if !command_result.nil?
-          print_good(command_result)
-          p = store_loot("host.#{platform}_command_results", 'text/plain', session, command_result, "#{platform}_containers_command_results.txt", "#{platform} Containers Command Results")
-          print_good("Command execution results stored in: #{p}\n")
-        end
+        next if command_result.nil?
+
+        print_good(command_result)
+        p = store_loot("host.#{platform}_command_results", 'text/plain', session, command_result, "#{platform}_containers_command_results.txt", "#{platform} Containers Command Results")
+        print_good("Command execution results stored in: #{p}\n")
       end
     end
   end

--- a/modules/post/linux/gather/enum_containers.rb
+++ b/modules/post/linux/gather/enum_containers.rb
@@ -132,7 +132,8 @@ class MetasploitModule < Msf::Post
     when 'lxc'
       command = "lxc exec '#{container_identifier}' -- #{command}"
     when 'rkt'
-      print_error("RKT containers do not support command execution\nUse rkt enter '#{container_identifier}' to manually enumerate this container")
+      print_error("RKT containers do not support command execution\nUse the command \"rkt enter '#{container_identifier}'\" to manually enumerate this container")
+      return nil
     else
       print_error("Invalid container type '#{container_type}'")
       return nil
@@ -179,7 +180,11 @@ class MetasploitModule < Msf::Post
       running_container_ids.each do |container_id|
         print_status("Executing command on #{platform} container #{container_id}")
         command_result = container_execute(platform, container_id, cmd)
-        print_good(command_result) if !command_result.nil?
+        if !command_result.nil?
+          print_good(command_result) 
+          p = store_loot("host.#{platform}_command_results", 'text/plain', session, command_result, "#{platform}_containers_command_results.txt", "#{platform} Containers Command Results")
+          print_good("Command execution results stored in: #{p}\n")
+        end
       end
     end
   end

--- a/modules/post/linux/gather/enum_containers.rb
+++ b/modules/post/linux/gather/enum_containers.rb
@@ -36,11 +36,13 @@ class MetasploitModule < Msf::Post
   def runnable(container_type)
     case container_type
     when 'docker'
-      command = 'docker container ls -a >/dev/null 2>&1 && echo true'
+      command = 'docker >/dev/null 2>&1 && echo true'
     when 'lxc'
-      command = 'lxc list >/dev/null 2>&1 && echo true'
+      command = 'lxc >/dev/null 2>&1 && echo true'
     when 'rkt'
-      command = 'rkt list >/dev/null 2>&1 && echo true'
+      command = 'rkt help >/dev/null 2>&1 && echo true' # Apparently rkt doesn't play nice with 2>&1 in most cases so just a heads up. 
+                                                        # `rkt help` does seem to not raise errors though so thats why we use it 
+                                                        # here over just `rkt`
     else
       print_error("Invalid container type #{container_type}")
       return false

--- a/modules/post/linux/gather/enum_containers.rb
+++ b/modules/post/linux/gather/enum_containers.rb
@@ -12,8 +12,8 @@ class MetasploitModule < Msf::Post
         info,
         'Name' => 'Linux Container Enumeration',
         'Description' => %q{
-          This module attempts to enumeratec containers on the target machine and optionally run a command on each active container found..
-          Supports Docker, LXC and RKT.
+          This module attempts to enumerate containers on the target machine and optionally run a command on each active container found.
+          Currently it supports Docker, LXC and RKT.
         },
         'License' => MSF_LICENSE,
         'Author' => ['stealthcopter'],
@@ -40,9 +40,9 @@ class MetasploitModule < Msf::Post
     when 'lxc'
       command = 'lxc >/dev/null 2>&1 && echo true'
     when 'rkt'
-      command = 'rkt help >/dev/null 2>&1 && echo true' # Apparently rkt doesn't play nice with 2>&1 in most cases so just a heads up.
-    # `rkt help` does seem to not raise errors though so thats why we use it
-    # here over just `rkt`
+      # Apparently rkt doesn't play nice with 2>&1 for most commands, though `rkt help` 
+      # seems to be fine so this is why its used here vs just 'rkt'
+      command = 'rkt help >/dev/null 2>&1 && echo true'
     else
       print_error("Invalid container type #{container_type}")
       return false
@@ -152,12 +152,12 @@ class MetasploitModule < Msf::Post
 
     platforms.each do |platform|
       print_good("#{platform} was found on the system!")
-      num_containers = count_containers(platform)
+      num_containers = count_containers(platform, false)
 
       if num_containers == 0
         print_error("No active or inactive containers were found for #{platform}\n")
       else
-        num_running_containers = count_containers(platform, false)
+        num_running_containers = count_containers(platform, true)
         print_good("#{platform}: #{num_running_containers} Running Containers / #{num_containers} Total")
       end
 

--- a/modules/post/linux/gather/enum_containers.rb
+++ b/modules/post/linux/gather/enum_containers.rb
@@ -40,7 +40,7 @@ class MetasploitModule < Msf::Post
     when 'lxc'
       command = 'lxc >/dev/null 2>&1 && echo true'
     when 'rkt'
-      # Apparently rkt doesn't play nice with 2>&1 for most commands, though `rkt help` 
+      # Apparently rkt doesn't play nice with 2>&1 for most commands, though `rkt help`
       # seems to be fine so this is why its used here vs just 'rkt'
       command = 'rkt help >/dev/null 2>&1 && echo true'
     else
@@ -181,7 +181,7 @@ class MetasploitModule < Msf::Post
         print_status("Executing command on #{platform} container #{container_id}")
         command_result = container_execute(platform, container_id, cmd)
         if !command_result.nil?
-          print_good(command_result) 
+          print_good(command_result)
           p = store_loot("host.#{platform}_command_results", 'text/plain', session, command_result, "#{platform}_containers_command_results.txt", "#{platform} Containers Command Results")
           print_good("Command execution results stored in: #{p}\n")
         end


### PR DESCRIPTION
Adds a new module `post/linux/gather/enum_containers` that will detect if there are any container platforms (runnable by the current user) on the target machine and list any actively running containers on any it finds. Currently supports Docker, LXC and RKT

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] Get a session via exploit of your choice, on a target that has containers running
- [x] `use post/linux/gather/enum_containers`
- [x] `set session 1`
- [x] `run`
- [x] **Verify** that the module lists any active containers 

## Scenarios

Scenario 1: Docker is installed and there  are 4 running containers
```
msf5 post(linux/gather/enum_containers) > set session 4
session => 4
msf5 post(linux/gather/enum_containers) > run

[+] docker: 4 Active Containers
CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
6e406d13fde7        ubuntu              "/bin/bash"         5 days ago          Up 45 hours                             test4
3d137beafb08        ubuntu              "/bin/bash"         5 days ago          Up 45 hours                             test3
8cb7e2aff68a        ubuntu              "/bin/bash"         5 days ago          Up 45 hours                             test2
1a339ef0d38e        ubuntu              "/bin/bash"         5 days ago          Up 45 hours                             test1
[*] Post module execution completed
```

Scenario 2: Docker, LXC and RKT are installed
```
msf5 post(linux/gather/enum_containers) > set session 5
session => 5
msf5 post(linux/gather/enum_containers) > run

[+] docker: 4 Active Containers
CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
6e406d13fde7        ubuntu              "/bin/bash"         5 days ago          Up 45 hours                             test4
3d137beafb08        ubuntu              "/bin/bash"         5 days ago          Up 45 hours                             test3
8cb7e2aff68a        ubuntu              "/bin/bash"         5 days ago          Up 45 hours                             test2
1a339ef0d38e        ubuntu              "/bin/bash"         5 days ago          Up 45 hours                             test1
[+] lxc: 2 Active Containers
+---------------+---------+-----------------------+-----------------------------------------------+-----------+-----------+
|     NAME      |  STATE  |         IPV4          |                     IPV6                      |   TYPE    | SNAPSHOTS |
+---------------+---------+-----------------------+-----------------------------------------------+-----------+-----------+
| t4testingName | RUNNING | 10.132.199.244 (eth0) | fd42:53d9:b4c9:609e:216:3eff:fece:f6df (eth0) | CONTAINER | 0         |
+---------------+---------+-----------------------+-----------------------------------------------+-----------+-----------+
| ubuntu        | RUNNING | 10.132.199.192 (eth0) | fd42:53d9:b4c9:609e:216:3eff:fe9a:fa5f (eth0) | CONTAINER | 0         |
+---------------+---------+-----------------------+-----------------------------------------------+-----------+-----------+
[+] rkt: 0 Active Containers
[*] Post module execution completed
```

Scenario 3: No container software is runnable
```
msf5 post(linux/gather/enum_containers) > set session 6
session => 6
msf5 post(linux/gather/enum_containers) > run
[-] No container software appears to be installed
[*] Post module execution completed
```

