### PR TITLE
Nmap vulners script import

### DIFF
--- a/lib/msf/core/db_manager/vuln.rb
+++ b/lib/msf/core/db_manager/vuln.rb
@@ -110,6 +110,8 @@ module Msf::DBManager::Vuln
           str = "#{r.ctx_id}-#{r.ctx_val}"
         elsif (r.is_a?(Hash) and r[:ctx_id] and r[:ctx_val])
           str = "#{r[:ctx_id]}-#{r[:ctx_val]}"
+        elsif r.is_a?(String)
+          str = r
         end
         rids << find_or_create_ref(:name => str) unless str.nil?
       end

--- a/lib/rex/parser/nmap_nokogiri.rb
+++ b/lib/rex/parser/nmap_nokogiri.rb
@@ -413,13 +413,10 @@ module Rex
       if @state[:vulners]
         vuln_info = {
             :workspace => @args[:workspace],
-            #:task => args[:task],
             :host => @state[:addresses]["ipv4"],
             :port => @state[:port]["portid"],
             :proto => @state[:port]["protocol"],
             :name => @state[:vulners][:cpe],
-            #:info => 'Vulnerability in Windows DNS RPC Interface Could Allow Remote Code Execution',
-            # Add more refs based on nessus/nexpose .. results
             :refs => @state[:vulners][:refs]
         }
         db_report(:vuln, vuln_info)


### PR DESCRIPTION
This PR adds the ability for framework to import vulns found with the nmap vulners script into it's database.

- [x] Run an nmap scan and save the output `nmap <target-ip> --script=vulners -oA nmap_output_filename`
- [x] Run `db_import nmap_output_filename.xml` from within the console
- [x] The `hosts` command should show you the host that you scanned
- [x] The `vulns` command should show you any vulnerabilities identified by nmap and the services associated with them
- [x] The `analyze` command can also be used to check which vulnerabilities metasploit also has coverage for
- [x] Should work in the same way running `db_nmap` rather than running nmap separately and importing