### PR TITLE
Cdata backdoor wordlist

### DIFF
--- a/data/wordlists/telnet_cdata_ftth_backdoor_userpass.txt
+++ b/data/wordlists/telnet_cdata_ftth_backdoor_userpass.txt
@@ -1,0 +1,4 @@
+suma123 panger123
+debug debug124
+root root126
+guest

--- a/data/wordlists/telnet_cdata_ftth_backdoor_userpass.txt
+++ b/data/wordlists/telnet_cdata_ftth_backdoor_userpass.txt
@@ -1,4 +1,4 @@
 suma123 panger123
 debug debug124
 root root126
-guest
+guest 


### PR DESCRIPTION
Addresses issue #13843 

Further information:
 - https://www.zdnet.com/article/backdoor-accounts-discovered-in-29-ftth-devices-from-chinese-vendor-c-data/
 - https://pierrekim.github.io/blog/2020-07-07-cdata-olt-0day-vulnerabilities.html
