### PR TITLE
Remove fail_with from check method

### DIFF
--- a/modules/exploits/linux/local/exim4_deliver_message_priv_esc.rb
+++ b/modules/exploits/linux/local/exim4_deliver_message_priv_esc.rb
@@ -173,12 +173,6 @@ class MetasploitModule < Msf::Exploit::Local
     Rex.sleep(5)
   end
 
-  def check_for_bash
-    unless command_exists?('/bin/bash')
-      fail_with(Failure::NotFound, 'bash not found')
-    end
-  end
-
   def on_new_session(session)
     super
 
@@ -201,7 +195,9 @@ class MetasploitModule < Msf::Exploit::Local
       socket.close
       socket_subsystem.shutdown
     else
-      check_for_bash
+      unless command_exists?('/bin/bash')
+        return CheckCode::Safe('bash not found')
+      end
       res = cmd_exec("/bin/bash -c 'exec 3</dev/tcp/localhost/#{datastore['EXIMPORT']} && "\
                      "(read -u 3 && echo $REPLY) || echo false'")
       if res == 'false'
@@ -244,8 +240,10 @@ class MetasploitModule < Msf::Exploit::Local
                                     'to get root privileges.')
     end
 
-    if session.type == 'shell'
-      check_for_bash
+    unless session.type == 'meterpreter'
+      unless command_exists?('/bin/bash')
+        fail_with(Failure::NotFound, 'bash not found')
+      end
     end
 
     @payload_path = File.join(base_dir, Rex::Text.rand_text_alpha(10))


### PR DESCRIPTION
Remove `fail_with` call from `check` method in `exim4_deliver_message_priv_esc` module as this was crashing the local exploit suggester module. Resolves #13850.

Also slightly improves the module logic. The module falsely believed that the only two session types are `shell` or `meterpreter`. This ignores `ssh` and is not future-proof. This PR modifies the logic to check for `session.type != 'meterpreter'` instead of `session.type == 'shell'`.
