### PR TITLE
check if a module has a check method first

### DIFF
--- a/lib/msf/base/simple/auxiliary.rb
+++ b/lib/msf/base/simple/auxiliary.rb
@@ -118,7 +118,7 @@ module Auxiliary
 
     unless mod.has_check?
       # Bail out early if the module doesn't have check
-      raise Msf::ValidationError, Msf::Exploit::CheckCode::Unsupported.message
+      raise ::NoMethodError.new(Msf::Exploit::CheckCode::Unsupported.message, 'check')
     end
 
     # Validate the option container state so that options will

--- a/lib/msf/base/simple/auxiliary.rb
+++ b/lib/msf/base/simple/auxiliary.rb
@@ -116,10 +116,11 @@ module Auxiliary
       mod.init_ui(opts['LocalInput'], opts['LocalOutput'])
     end
 
+    return Msf::Exploit::CheckCode::Unsupported unless mod.has_check?
+
     # Validate the option container state so that options will
     # be normalized
     mod.validate
-
 
     run_uuid = Rex::Text.rand_text_alphanumeric(24)
     job_listener.waiting run_uuid
@@ -131,7 +132,7 @@ module Auxiliary
         ctx,
         Proc.new do |ctx_|
           self.job_run_proc(ctx_) do |m|
-            m.has_check? ? m.check : Msf::Exploit::CheckCode::Unsupported
+            m.check
           end
         end,
         Proc.new { |ctx_| self.job_cleanup_proc(ctx_) }
@@ -141,7 +142,7 @@ module Auxiliary
     else
       # Run check if it exists
       result = self.job_run_proc(ctx) do |m|
-        m.has_check? ? m.check : Msf::Exploit::CheckCode::Unsupported
+        m.check
       end
       self.job_cleanup_proc(ctx)
 

--- a/lib/msf/base/simple/auxiliary.rb
+++ b/lib/msf/base/simple/auxiliary.rb
@@ -116,7 +116,10 @@ module Auxiliary
       mod.init_ui(opts['LocalInput'], opts['LocalOutput'])
     end
 
-    return Msf::Exploit::CheckCode::Unsupported unless mod.has_check?
+    unless mod.has_check?
+      # Bail out early if the module doesn't have check
+      raise Msf::ValidationError, Msf::Exploit::CheckCode::Unsupported.message
+    end
 
     # Validate the option container state so that options will
     # be normalized

--- a/lib/msf/base/simple/exploit.rb
+++ b/lib/msf/base/simple/exploit.rb
@@ -184,7 +184,10 @@ module Exploit
       mod.init_ui(opts['LocalInput'], opts['LocalOutput'])
     end
 
-    return Msf::Exploit::CheckCode::Unsupported unless mod.has_check?
+    unless mod.has_check?
+      # Bail out early if the module doesn't have check
+      raise Msf::ValidationError, Msf::Exploit::CheckCode::Unsupported.message
+    end
 
     # Validate the option container state so that options will
     # be normalized

--- a/lib/msf/base/simple/exploit.rb
+++ b/lib/msf/base/simple/exploit.rb
@@ -186,7 +186,7 @@ module Exploit
 
     unless mod.has_check?
       # Bail out early if the module doesn't have check
-      raise Msf::ValidationError, Msf::Exploit::CheckCode::Unsupported.message
+      raise ::NoMethodError.new(Msf::Exploit::CheckCode::Unsupported.message, 'check')
     end
 
     # Validate the option container state so that options will

--- a/lib/msf/base/simple/exploit.rb
+++ b/lib/msf/base/simple/exploit.rb
@@ -184,6 +184,8 @@ module Exploit
       mod.init_ui(opts['LocalInput'], opts['LocalOutput'])
     end
 
+    return Msf::Exploit::CheckCode::Unsupported unless mod.has_check?
+
     # Validate the option container state so that options will
     # be normalized
     mod.validate
@@ -221,7 +223,7 @@ module Exploit
     begin
       job_listener.start run_uuid
       mod.setup
-      result = mod.has_check? ? mod.check : Msf::Exploit::CheckCode::Unsupported
+      result = mod.check
       job_listener.completed(run_uuid, result, mod)
     rescue => e
       job_listener.failed(run_uuid, e, mod)

--- a/lib/msf/core/rpc/json/dispatcher.rb
+++ b/lib/msf/core/rpc/json/dispatcher.rb
@@ -111,6 +111,10 @@ module Msf::RPC::JSON
         end
 
         response
+      rescue Msf::OptionValidateError => e
+        raise InvalidParams.new(data: { options: e.options, message: e.message })
+      rescue ::NoMethodError => e
+        raise MethodNotFound.new(e.name, data: { method: e.name, message: e.message })
       rescue ArgumentError
         raise InvalidParams.new
       rescue Msf::RPC::Exception => e


### PR DESCRIPTION
Currently, if you run 'check' on a module that does not have a check method, it will first complain that you have not set the `RHOSTS` option, whether it's an exploit module or a scanner. Then, once you set RHOSTS (or whatever else it needs), it will then say 'Psych! I didn't have a method in the first place!'.

This switches that logic around so that it first alerts you that the module doesn't have support in the first place. It also similarizes more logic between aux and exploit for some future convergence possibility.

## Verification

- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/http/http_put`
- [x] **Verify** the output looks something like this:
```
msf5 > use auxiliary/scanner/http/http_put
msf5 auxiliary(scanner/http/http_put) > run
[-] Auxiliary failed: Msf::OptionValidateError One or more options failed to validate: RHOSTS.
msf5 auxiliary(scanner/http/http_put) > check
[*] :80 - This module does not support check.
```
