### PR TITLE
Add a stale bot for dealing with stale issues

### DIFF
--- a/.github/workflows/schedule-stale.yml
+++ b/.github/workflows/schedule-stale.yml
@@ -1,0 +1,35 @@
+on:
+  schedule:
+    - cron: "0 16 * * *"
+name: Stale Bot workflow
+jobs:
+  build:
+    name: stale
+    runs-on: ubuntu-latest
+    steps:
+      - name: stale
+        id: stale
+        uses: actions/stale@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-stale: 30
+          days-before-close: 30
+          operations-per-run: 10
+          stale-issue-message: |
+            Hi!
+
+            This issue has been left open with no activity for a while now.
+
+            We get a lot of issues, so we currently close issues after 60 days of inactivity. It’s been at least 30 days since the last update here.
+            If we missed this issue or if you want to keep it open, please reply here. You can also add the label "not stale" to keep this issue open!
+
+            As a friendly reminder: the best way to see this issue, or any other, fixed is to open a Pull Request.
+          close-issue-message: |
+            Hi again!
+
+            It’s been 60 days since anything happened on this issue, so we are going to close it.
+            Please keep in mind that I’m only a robot, so if I’ve closed this issue in error please feel free to reopen this issue or create a new one if you need anything else.
+
+            As a friendly reminder: the best way to see this issue, or any other, fixed is to open a Pull Request.
+          exempt-issue-labels: |
+            not stale

--- a/.github/workflows/schedule-stale.yml
+++ b/.github/workflows/schedule-stale.yml
@@ -33,3 +33,4 @@ jobs:
             As a friendly reminder: the best way to see this issue, or any other, fixed is to open a Pull Request.
           exempt-issue-labels: |
             not stale
+          debug-only: true


### PR DESCRIPTION
This PR is an initial skeleton for how we might want a new stalebot implementation to be set up

This uses github actions and is heavily influenced by the stalebot used here: https://github.com/gatsbyjs/gatsby/blob/80e8f8b4bd86e48c8b3c814a31c5134e623fa14f/.github/workflows/schedule-stale.yml

Currently it's set to run everyday at 4PM GMT, it will mark issues older than 30 days as stale and 30 days after that it will close them if there is still no activity or the `not stale` label has been applied. These values can be tuned later but I figured it's better to start high and work our way down if we feel the need.
To stop everyone from being overwhelmed with emails when we first start it up it's set to only perform 10 actions per day, which also gives someone (likely me) time to go through and make sure any issues that shouldn't be closed are appropriately labeled `not stale` 
The order it will look at the issues is `descending` which I believe means from oldest to newest which I think is what we would want.

Wording could be a lot better, I just wanted to get the ball rolling, happy to take any and all suggestions

https://github.com/actions/stale/blob/main/action.yml
You can find other available fields we can use here, for example we could also do something similar for PRs but I figured let's keep it simple to begin with.