### PR TITLE
hwbridge: fix syntax error introduced in aeed81de291260c12934d3afe1425a3852875a01

### DIFF
--- a/lib/rex/post/hwbridge/ui/console/command_dispatcher/custom_methods.rb
+++ b/lib/rex/post/hwbridge/ui/console/command_dispatcher/custom_methods.rb
@@ -57,15 +57,14 @@ class Console::CommandDispatcher::CustomMethods
   def cmd_generic_handler_help(cmd)
     @custom_methods.each do |meth|
       next unless meth["method_name"] =~ /#{cmd}$/
-        args = ""
-        args = "<args>" if meth["args"].size > 0
-        print_line("Usage: #{cmd} #{args}")
-        print_line
-        meth["args"].each do |arg|
-          req = ""
-          req = "  *required*" if arg.key? "required" and arg["required"] == true
-          print_line("  #{arg["arg_name"]}=<#{arg["arg_type"]}> #{req}")
-        end
+      args = ""
+      args = "<args>" if meth["args"].size > 0
+      print_line("Usage: #{cmd} #{args}")
+      print_line
+      meth["args"].each do |arg|
+        req = ""
+        req = "  *required*" if arg.key? "required" and arg["required"] == true
+        print_line("  #{arg["arg_name"]}=<#{arg["arg_type"]}> #{req}")
       end
     end
   end


### PR DESCRIPTION
hwbridge: fix syntax error introduced in aeed81de291260c12934d3afe1425a3852875a01

Untested.

The refactoring in aeed81de291260c12934d3afe1425a3852875a01 was clearly incorrect:

![refactoring](https://user-images.githubusercontent.com/434827/88193720-55c45880-cc81-11ea-8a6c-663a2578d6bd.png)
