### PR TITLE
Fixed shell script creation with passwords with special characters

### DIFF
--- a/modules/post/multi/manage/sudo.rb
+++ b/modules/post/multi/manage/sudo.rb
@@ -98,8 +98,7 @@ class MetasploitModule < Msf::Post
         # Need to timeout in case there's a blocking prompt after all
         ::Timeout.timeout(120) do
           vprint_status "Writing the SUDO_ASKPASS script: #{askpass_sh}"
-          cmd_exec("echo \\#\\!/bin/sh > #{askpass_sh}") # Cursed csh
-          write_file(askpass_sh, "#!/bin/sh\necho '#{password}'\n")q
+          write_file(askpass_sh, "#!/bin/sh\necho '#{password}'\n")
           vprint_status "Setting executable bit."
           cmd_exec("chmod +x #{askpass_sh}")
           vprint_status "Setting environment variable."

--- a/modules/post/multi/manage/sudo.rb
+++ b/modules/post/multi/manage/sudo.rb
@@ -99,7 +99,7 @@ class MetasploitModule < Msf::Post
         ::Timeout.timeout(120) do
           vprint_status "Writing the SUDO_ASKPASS script: #{askpass_sh}"
           cmd_exec("echo \\#\\!/bin/sh > #{askpass_sh}") # Cursed csh
-          cmd_exec("echo echo #{password} >> #{askpass_sh}")
+          cmd_exec("echo 'echo '\"'\"'#{password}'\"'\"'' >> #{askpass_sh}")
           vprint_status "Setting executable bit."
           cmd_exec("chmod +x #{askpass_sh}")
           vprint_status "Setting environment variable."

--- a/modules/post/multi/manage/sudo.rb
+++ b/modules/post/multi/manage/sudo.rb
@@ -99,7 +99,7 @@ class MetasploitModule < Msf::Post
         ::Timeout.timeout(120) do
           vprint_status "Writing the SUDO_ASKPASS script: #{askpass_sh}"
           cmd_exec("echo \\#\\!/bin/sh > #{askpass_sh}") # Cursed csh
-          cmd_exec("echo 'echo '\"'\"'#{password}'\"'\"'' >> #{askpass_sh}")
+          write_file(askpass_sh, "#!/bin/sh\necho '#{password}'\n")q
           vprint_status "Setting executable bit."
           cmd_exec("chmod +x #{askpass_sh}")
           vprint_status "Setting environment variable."


### PR DESCRIPTION
With the _post/multi/manage/sudo_ module I encountered that passwords with the _$_ character causes this module to fail. This is due to that lack of quoting when generating the script for _sudo -s -A_. The lack of quoting causes the script to attempt to expand the _$_ as a variable. For example the password _"the$sign"_ creates the script:

`#!/bin/sh`
`echo the`

In sudo.rb on line 102, I changed the line:

`cmd_exec("echo echo #{password} >> #{askpass_sh}")`
 to
`cmd_exec("echo 'echo '\"'\"'#{password}'\"'\"'' >> #{askpass_sh}")`

This adds quoting to the script generation and to the script itself. Now the password _"the$sign"_ creates the script:

` #!/bin/sh`
` echo 'the$sign'`

Special characters in passwords shouldn't cause failures with the exception of the ' character. Thanks to @bwatters-r7 for reviewing the initial change.