### PR TITLE
unlock bcrypt

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ PATH
       aws-sdk-ec2
       aws-sdk-iam
       aws-sdk-s3
-      bcrypt (= 3.1.12)
+      bcrypt
       bcrypt_pbkdf
       bit-struct
       bson
@@ -143,7 +143,7 @@ GEM
       aws-sigv4 (~> 1.1)
     aws-sigv4 (1.2.1)
       aws-eventstream (~> 1, >= 1.0.2)
-    bcrypt (3.1.12)
+    bcrypt (3.1.15)
     bcrypt_pbkdf (1.0.1)
     bindata (2.4.8)
     bit-struct (0.16)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -53,7 +53,7 @@ Gem::Specification.new do |spec|
   # Needed for config.action_view for view plugin compatibility for Pro
   spec.add_runtime_dependency 'actionpack', *Metasploit::Framework::RailsVersionConstraint::RAILS_VERSION
   # Needed for some admin modules (cfme_manageiq_evm_pass_reset.rb)
-  spec.add_runtime_dependency 'bcrypt', '3.1.12'
+  spec.add_runtime_dependency 'bcrypt'
   # Needed for Javascript obfuscation
   spec.add_runtime_dependency 'jsobfu'
   # Needed for some admin modules (scrutinizer_add_user.rb)


### PR DESCRIPTION
The latest released bcrypt gem now compiles on arm 32-bit.

~#12664~ 

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] **Verify** verify specs and PR tests pass
- [x] `bundle install` on raspbian

