### PR TITLE
Add checks to msftidy_docs and update the template for them

### DIFF
--- a/data/markdown_doc/default_template.erb
+++ b/data/markdown_doc/default_template.erb
@@ -15,8 +15,8 @@
 <% end %>
 
 ## Module Ranking
-
 <%# https://github.com/rapid7/metasploit-framework/wiki/Exploit-Ranking %>
+
 **<%= items[:mod_rank_name] %>**
 
 <% if items[:mod_rank_name] == "Excellent" %>
@@ -47,6 +47,7 @@
 <% end %>
 
 ## Module Traits
+<%# https://github.com/rapid7/metasploit-framework/wiki/Definition-of-Module-Reliability,-Side-Effects,-and-Stability %>
 
 <% unless items[:mod_side_effects].empty? %>
 ### Side Effects
@@ -68,7 +69,7 @@
 <% description = "Module may produce physical effects (Examples: the device makes movement or flashes LEDs)." %>
 <% end %>
 
-* **<%= side_effect %>** &mdash; <%= description %>
+* **<%= side_effect %>:** <%= description %>
 <% end %>
 <% end %>
 
@@ -84,7 +85,7 @@
 <% description = "The module isn't expected to get a shell reliably (such as only once)." %>
 <% end %>
 
-* **<%= reliability %>** &mdash; <%= description %>
+* **<%= reliability %>:** <%= description %>
 <% end %>
 <% end %>
 
@@ -108,7 +109,7 @@
 <% description = "Modules may cause a resource (such as a file) to be unavailable for the OS." %>
 <% end %>
 
-* **<%= stability %>** &mdash; <%= description %>
+* **<%= stability %>:** <%= description %>
 <% end %>
 <% end %>
 
@@ -136,7 +137,7 @@ No options are required.
 <% else %>
 <% items[:mod_options].each_pair do |name, props| %>
 <% if props.required && props.default.nil? %>
-* **<%= name %>** &mdash; <%= props.desc %>
+* **<%= name %>:** <%= props.desc %>
 <% end %>
 <% end %>
 <% end %>

--- a/data/markdown_doc/default_template.erb
+++ b/data/markdown_doc/default_template.erb
@@ -16,7 +16,13 @@
 
 ## Module Ranking
 
-<%= normalize_rank(items[:mod_rank]) %>
+**<%= items[:mod_rank_name] %>**
+
+<% if items[:mod_rank_name] == "Excellent" %>
+> The exploit will never crash the service. This is the case for SQL Injection, CMD execution, RFI, LFI, etc. No typical
+> memory corruption exploits should be given this ranking unless there are extraordinary circumstances
+> ([WMF Escape()](https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/windows/browser/ms06_001_wmf_setabortproc.rb)).
+<% end %>
 
 ## Side Effects
 

--- a/data/markdown_doc/default_template.erb
+++ b/data/markdown_doc/default_template.erb
@@ -16,25 +16,101 @@
 
 ## Module Ranking
 
+<%# https://github.com/rapid7/metasploit-framework/wiki/Exploit-Ranking %>
 **<%= items[:mod_rank_name] %>**
 
 <% if items[:mod_rank_name] == "Excellent" %>
 > The exploit will never crash the service. This is the case for SQL Injection, CMD execution, RFI, LFI, etc. No typical
-> memory corruption exploits should be given this ranking unless there are extraordinary circumstances
-> ([WMF Escape()](https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/windows/browser/ms06_001_wmf_setabortproc.rb)).
+> memory corruption exploits should be given this ranking unless there are extraordinary circumstances.
+
+<% elsif items[:mod_rank_name] == "Great" %>
+> The exploit has a default target AND either auto-detects the appropriate target or uses an application-specific return
+> address AFTER a version check.
+
+<% elsif items[:mod_rank_name] == "Good" %>
+> The exploit has a default target and it is the "common case" for this type of software (English, Windows 7 for a
+> desktop app, 2012 for server, etc).
+
+<% elsif items[:mod_rank_name] == "Normal" %>
+> The exploit is otherwise reliable, but depends on a specific version and can't (or doesn't) reliably autodetect.
+
+<% elsif items[:mod_rank_name] == "Average" %>
+> The exploit is generally unreliable or difficult to exploit.
+
+<% elsif items[:mod_rank_name] == "Low" %>
+> The exploit is nearly impossible to exploit (or under 50% success rate) for common platforms.
+
+<% elsif items[:mod_rank_name] == "Manual" %>
+> The exploit is unstable or difficult to exploit and is basically a DoS. This ranking is also used when the module has
+> no use unless specifically configured by the user (e.g.: [exploit/windows/smb/psexec][1]).
+
 <% end %>
 
-## Side Effects
+## Module Traits
 
-<%= normalize_side_effects(items[:mod_side_effects]) %>
+<% unless items[:mod_side_effects].empty? %>
+### Side Effects
 
-## Reliability
+<% items[:mod_side_effects].each do |side_effect| %>
+<% if side_effect == "artifacts-on-disk" %>
+<% description = "Modules leaves a payload or a dropper on the target machine." %>
+<% elsif side_effect == "config-changes" %>
+<% description = "Module modifies some configuration setting on the target machine." %>
+<% elsif side_effect == "ioc-in-logs" %>
+<% description = "Module leaves signs of a compromise in a log file (Example: SQL injection data found in HTTP log)." %>
+<% elsif side_effect == "account-lockouts" %>
+<% description = "Module may cause account lockouts (likely due to brute-forcing)." %>
+<% elsif side_effect == "screen-effects" %>
+<% description = "Module may show something on the screen (Example: a window pops up)." %>
+<% elsif side_effect == "audio-effects" %>
+<% description = "Module may cause a noise (Examples: audio output from the speakers or hardware beeps)." %>
+<% elsif side_effect == "physical-effects" %>
+<% description = "Module may produce physical effects (Examples: the device makes movement or flashes LEDs)." %>
+<% end %>
 
-<%= normalize_reliability(items[:mod_reliability]) %>
+* **<%= side_effect %>** &mdash; <%= description %>
+<% end %>
+<% end %>
 
-## Stability
+<% unless items[:mod_reliability].empty? %>
+### Reliability
 
-<%= normalize_stability(items[:mod_stability]) %>
+<% items[:mod_reliability].each do |reliability| %>
+<% if reliability == "first-attempt-fail" %>
+<% description = "The module tends to fail to get a session on the first attempt." %>
+<% elsif reliability == "repeatable-session" %>
+<% description = "The module is expected to get a shell every time it runs." %>
+<% elsif reliability == "unreliable-session" %>
+<% description = "The module isn't expected to get a shell reliably (such as only once)." %>
+<% end %>
+
+* **<%= reliability %>** &mdash; <%= description %>
+<% end %>
+<% end %>
+
+<% unless items[:mod_stability].empty? %>
+### Stability
+
+<% items[:mod_stability].each do |stability| %>
+<% if stability == "crash-safe" %>
+<% description = "Module should not crash the service." %>
+<% elsif stability == "crash-service-restarts" %>
+<% description = "Module may crash the service, but the service restarts." %>
+<% elsif stability == "crash-service-down" %>
+<% description = "Module may crash the service, and the service remains down." %>
+<% elsif stability == "crash-os-restarts" %>
+<% description = "Module may crash the OS, but the OS restarts." %>
+<% elsif stability == "crash-os-down" %>
+<% description = "Module may crash the OS, and the OS remains down." %>
+<% elsif stability == "service-resource-loss" %>
+<% description = "Module may cause a resource (such as a file or data in a database) to be unavailable for the service." %>
+<% elsif stability == "os-resource-loss" %>
+<% description = "Modules may cause a resource (such as a file) to be unavailable for the OS." %>
+<% end %>
+
+* **<%= stability %>** &mdash; <%= description %>
+<% end %>
+<% end %>
 
 ## Related Pull Requests
 
@@ -55,12 +131,18 @@
 
 ## Required Options
 
-<% if normalize_options(items[:mod_options]).empty? %>
-No options required.
+<% if items[:mod_options].empty? %>
+No options are required.
 <% else %>
-<%= normalize_options(items[:mod_options]) %>
+<% items[:mod_options].each_pair do |name, props| %>
+<% if props.required && props.default.nil? %>
+* **<%= name %>** &mdash; <%= props.desc %>
+<% end %>
+<% end %>
 <% end %>
 
 ## Basic Usage
 
 <%= normalize_demo_output(items[:mod_demo]) %>
+
+[1]: https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/windows/smb/psexec.rb

--- a/documentation/modules/module_doc_template.md
+++ b/documentation/modules/module_doc_template.md
@@ -9,13 +9,13 @@ files, as well as instructions on installing/configuring the environment if it i
 standard install. Much of this will come from the PR, and can be copy/pasted.
 
 ## Verification Steps
-  Example steps in this format (is also in the PR):
+Example steps in this format (is also in the PR):
 
-  1. Install the application
-  2. Start msfconsole
-  3. Do: ```use [module path]```
-  4. Do: ```run```
-  5. You should get a shell.
+1. Install the application
+1. Start msfconsole
+1. Do: `use [module path]`
+1. Do: `run`
+1. You should get a shell.
 
 ## Options
 List each option and how to use it.
@@ -27,19 +27,18 @@ Talk about what it does, and how to use it appropriately. If the default value i
 ## Scenarios
 Specific demo of using the module that might be useful in a real world scenario.
 
-
 ### Version and OS
 
-  ```
-  code or console output
-  ```
+```
+code or console output
+```
 
-  For example:
+For example:
 
-  To do this specific thing, here's how you do it:
+To do this specific thing, here's how you do it:
 
-  ```
-  msf > use module_name
-  msf auxiliary(module_name) > set POWERLEVEL >9000
-  msf auxiliary(module_name) > exploit
-  ```
+```
+msf > use module_name
+msf auxiliary(module_name) > set POWERLEVEL >9000
+msf auxiliary(module_name) > exploit
+```

--- a/lib/msf/core/constants.rb
+++ b/lib/msf/core/constants.rb
@@ -55,7 +55,7 @@ RankingName         =
 # Stability traits
 #
 
-# Module should not crash the service
+# Module should not crash the service.
 CRASH_SAFE             = 'crash-safe'
 # Module may crash the service, but the service restarts.
 CRASH_SERVICE_RESTARTS = 'crash-service-restarts'
@@ -65,7 +65,7 @@ CRASH_SERVICE_DOWN     = 'crash-service-down'
 CRASH_OS_RESTARTS      = 'crash-os-restarts'
 # Module may crash the OS, and the OS remains down.
 CRASH_OS_DOWN          = 'crash-os-down'
-# Module may cause a resource (such as a file or data in database) to be unavailable for the service.
+# Module may cause a resource (such as a file or data in a database) to be unavailable for the service.
 SERVICE_RESOURCE_LOSS  = 'service-resource-loss'
 # Modules may cause a resource (such as a file) to be unavailable for the OS.
 OS_RESOURCE_LOSS       = 'os-resource-loss'
@@ -74,30 +74,30 @@ OS_RESOURCE_LOSS       = 'os-resource-loss'
 # Side-effect traits
 #
 
-# Modules leaves payload or a dropper on the target machine
+# Modules leaves a payload or a dropper on the target machine.
 ARTIFACTS_ON_DISK = 'artifacts-on-disk'
-# Module modifies some config file on the target machine
+# Module modifies some configuration setting on the target machine.
 CONFIG_CHANGES    = 'config-changes'
-# Module leaves signs of a compromise in a log file (Example: SQL injection data found in HTTP log)
+# Module leaves signs of a compromise in a log file (Example: SQL injection data found in HTTP log).
 IOC_IN_LOGS       = 'ioc-in-logs'
-# Module may cause account lockouts (likely due to brute-forcing)
+# Module may cause account lockouts (likely due to brute-forcing).
 ACCOUNT_LOCKOUTS  = 'account-lockouts'
-# Module may show something on the screen (Example: a window pops up)
+# Module may show something on the screen (Example: a window pops up).
 SCREEN_EFFECTS    = 'screen-effects'
-# Module may cause a noise (Examples: audio output from the speakers or hardware beeps)
+# Module may cause a noise (Examples: audio output from the speakers or hardware beeps).
 AUDIO_EFFECTS     = 'audio-effects'
-# Module may produce physical effects (Examples: the device makes movement or flashes LEDs)
+# Module may produce physical effects (Examples: the device makes movement or flashes LEDs).
 PHYSICAL_EFFECTS  = 'physical-effects'
 
 #
 # Reliability
 #
 
-# The module tends to fail to get a session at first attempt
+# The module tends to fail to get a session on the first attempt.
 FIRST_ATTEMPT_FAIL = 'first-attempt-fail'
-# The module is expected to get a shell every time it fires
+# The module is expected to get a shell every time it runs.
 REPEATABLE_SESSION = 'repeatable-session'
-# The module isn't expected to get a shell reliably (such as only once)
+# The module isn't expected to get a shell reliably (such as only once).
 UNRELIABLE_SESSION = 'unreliable-session'
 
 module HttpClients

--- a/lib/msf/util/document_generator.rb
+++ b/lib/msf/util/document_generator.rb
@@ -61,6 +61,7 @@ module Msf
             mod_pull_requests: pr,
             mod_refs:          mod.references,
             mod_rank:          mod.rank,
+            mod_rank_name:     Msf::RankingName[mod.rank].capitalize,
             mod_platforms:     mod.send(:module_info)['Platform'],
             mod_options:       mod.options,
             mod_side_effects:  mod.side_effects,

--- a/lib/msf/util/document_generator/normalizer.rb
+++ b/lib/msf/util/document_generator/normalizer.rb
@@ -248,15 +248,6 @@ module Msf
         end
 
 
-        # Returns the markdown format for module rank.
-        #
-        # @param rank [String] Module rank.
-        # @return [String]
-        def normalize_rank(rank)
-          "[#{Msf::RankingName[rank].capitalize}](https://github.com/rapid7/metasploit-framework/wiki/Exploit-Ranking)"
-        end
-
-
         # Returns the markdown format for module side effects.
         #
         # @param side_effects [Array<String>] Module effects.

--- a/lib/msf/util/document_generator/normalizer.rb
+++ b/lib/msf/util/document_generator/normalizer.rb
@@ -155,23 +155,6 @@ module Msf
         end
 
 
-        # Returns the markdown format for module datastore options.
-        #
-        # @param mod_options [Hash] Datastore options
-        # @return [String]
-        def normalize_options(mod_options)
-          required_options = []
-
-          mod_options.each_pair do |name, props|
-            if props.required && props.default.nil?
-              required_options << "* #{name} - #{props.desc}"
-            end
-          end
-
-          required_options * "\n"
-        end
-
-
         # Returns the markdown format for module description.
         #
         # @param description [String] Module description.
@@ -245,32 +228,6 @@ module Msf
           else
             platforms
           end
-        end
-
-
-        # Returns the markdown format for module side effects.
-        #
-        # @param side_effects [Array<String>] Module effects.
-        # @return [String]
-        def normalize_side_effects(side_effects)
-          md_side_effects = side_effects.collect { |s| "* #{s}\n" }.join
-          md_side_effects.empty? ? 'N/A' : md_side_effects
-        end
-
-
-        # Returns the markdown format for module reliability.
-        #
-        # @param reliability [Array<String>] Module reliability.
-        # @return [String]
-        def normalize_reliability(reliability)
-          md_reliability = reliability.collect { |r| "* #{r}\n" }.join
-          md_reliability.empty? ? 'N/A' : md_reliability
-        end
-
-
-        def normalize_stability(stability)
-          md_stability = stability.collect { |s| "* #{s}\n" }.join
-          md_stability.empty? ? 'N/A' : md_stability
         end
 
 

--- a/spec/lib/msf/util/document_generator/normalizer_spec.rb
+++ b/spec/lib/msf/util/document_generator/normalizer_spec.rb
@@ -130,14 +130,6 @@ RSpec.describe Msf::Util::DocumentGenerator::DocumentNormalizer do
     end
   end
 
-  describe 'normalize_options' do
-    context 'when datastore options are given' do
-      it 'returns a list of options in HTML' do
-        expect(subject.send(:normalize_options, msf_mod.options)).to include('* RHOST - The target address')
-      end
-    end
-  end
-
   describe 'normalize_description' do
     context 'when a description is a long one-liner' do
       it 'returns the wrapped the description' do
@@ -185,19 +177,6 @@ RSpec.describe Msf::Util::DocumentGenerator::DocumentNormalizer do
     context 'when a platform as a string is given' do
       it 'returns the platform' do
         expect(subject.send(:normalize_platforms, msf_mod.platforms)).to eq(mod_platforms)
-      end
-    end
-  end
-
-  describe 'normalize_rank' do
-    context 'when a rank is given' do
-      it 'returns the rank' do
-        expect(subject.send(:normalize_rank, msf_mod.rank)).to include('Normal')
-      end
-
-      it 'includes a wiki about exploit ranks' do
-        wiki = 'https://github.com/rapid7/metasploit-framework/wiki/Exploit-Ranking'
-        expect(subject.send(:normalize_rank, msf_mod.rank)).to include(wiki)
       end
     end
   end

--- a/tools/dev/msftidy_docs.rb
+++ b/tools/dev/msftidy_docs.rb
@@ -116,7 +116,7 @@ class MsftidyDoc
   def check_start_with_vuln_app
     unless @lines.first =~ /^## Vulnerable Application$/
       warn('Docs should start with ## Vulnerable Application')
-    end 
+    end
   end
 
   def has_h2_headings
@@ -215,8 +215,17 @@ class MsftidyDoc
     @lines.each do |ln|
       idx += 1
 
-      if ln.scan(/```/).length.odd?
-        in_codeblock = !in_codeblock
+      tback = ln.scan(/```/)
+      if tback.length > 0
+        if tback.length.even?
+          warn("Should use single backquotes (`) for single line literals instead of triple backquotes (```)", idx)
+        else
+          in_codeblock = !in_codeblock
+        end
+
+        if ln =~ /^\s+```/
+          warn("Code blocks using triple backquotes (```) should not be indented", idx)
+        end
       end
 
       if ln =~ /## Options/
@@ -250,7 +259,7 @@ class MsftidyDoc
       end
 
       l = 140
-      if ln.length > l && !in_codeblock
+      if ln.rstrip.length > l && !in_codeblock
         warn("Line too long (#{ln.length}).  Consider a newline (which resolves to a space in markdown) to break it up around #{l} characters.", idx)
       end
 


### PR DESCRIPTION
This adds a few additional checks to the `msftidy_docs` utility and updates the docs template to be compliant with them. This also adds more information to the automatically generated module docs to explain the exploit ranking and module traits. This allows the user to understand the meaning of the values without having to look them up on GitHub (in the case of the ranking) or the source code (in the case of the traits.

Changes include:
1. Prefer single backquotes for one line literals instead of triple backquotes
1. Dedent triple backquote blocks, because indenting them causes their content to also be indented in the rendered output
1. Use markdowns automatic numbering for numeric lists, this makes updating the template easier
1. Remove trailing whitespace when checking the line length.
    * If the user wrote exactly 140 characters followed by a new line, that should be permitted as 140 characters. This basically allows them to use a guide line that alot of editors support like RubyMine, Geany and Atom.
1. Additional information in the generated module docs under the "Overview" tab.

### Overview Information
One thing I wanted to call out about the new "Overview" tab is that there's some duplication of information. For the rankings, it's duplicated with the [wiki](https://github.com/rapid7/metasploit-framework/wiki/Exploit-Ranking) while for the traits it's duplicated from comments in the code of `constants.rb`. It's not particularly ideal to have this info duplicated within the code base, but I wasn't sure that the solution would be to update the constants or have a bunch of string descriptions defined within `constants.rb`.

These updates also migrate towards more heavily relying on the existing Ruby ERB template as opposed to using a bunch of Ruby functions in `normalizer.rb` to generate markdown. I removed the ones that are no longer necessary.

## Verification

- [ ] Run msftidy on the docs template, see only errors for content that needs to be changed
- [ ] Make a new doc from the docs template, using the automatic numbering, and single back quotes for single line literals
- [ ] Load metasploit and generate the docs using `info -d` and see that they render cleanly
    - [ ] See explanations for the significance of the values in the "Overview" tab 

## Examples 

### Tidy Examples

Tidy On Old Template:
```
documentation/modules/module_doc_template.md - [ERROR] Doc missing module. Check file name and path(s) are correct. Doc: documentation/modules/module_doc_template.md
documentation/modules/module_doc_template.md - [WARNING] Docs should start with ## Vulnerable Application
documentation/modules/module_doc_template.md - [WARNING] Scenario sub-sections should include the vulnerable application version and OS tested on in an H3, not just ### Version and OS
documentation/modules/module_doc_template.md:12 - [WARNING] Instructional text not removed
documentation/modules/module_doc_template.md:16 - [WARNING] Should use single backquotes (`) for single line literals instead of triple backquotes (```)
documentation/modules/module_doc_template.md:17 - [WARNING] Should use single backquotes (`) for single line literals instead of triple backquotes (```)
documentation/modules/module_doc_template.md:33 - [WARNING] Code blocks using triple backquotes (```) should not be indented
documentation/modules/module_doc_template.md:35 - [WARNING] Code blocks using triple backquotes (```) should not be indented
documentation/modules/module_doc_template.md:41 - [WARNING] Code blocks using triple backquotes (```) should not be indented
documentation/modules/module_doc_template.md:45 - [WARNING] Code blocks using triple backquotes (```) should not be indented
```

Tidy On New Template:
```
documentation/modules/module_doc_template.md - [ERROR] Doc missing module. Check file name and path(s) are correct. Doc: documentation/modules/module_doc_template.md
documentation/modules/module_doc_template.md - [WARNING] Docs should start with ## Vulnerable Application
documentation/modules/module_doc_template.md - [WARNING] Scenario sub-sections should include the vulnerable application version and OS tested on in an H3, not just ### Version and OS
documentation/modules/module_doc_template.md:12 - [WARNING] Instructional text not removed
```

*The remaining warnings are for sections that need to be filled in.*

### Overview Comparison

Old "Overview" section for exploit/windows/http/exchange_ecp_viewstate:
![old-docs](https://user-images.githubusercontent.com/2058303/88485394-64419700-cf43-11ea-8bdd-835716bc9cad.png)

New "Overview" section for exploit/windows/http/exchange_ecp_viewstate
![new-docs](https://user-images.githubusercontent.com/2058303/88485406-74f20d00-cf43-11ea-9efc-c297eb348ebb.png)
