### PR TITLE
Fix dangling reference issue in cve_2020_0688_service_tracing.rb and filesystem.rb

### DIFF
--- a/lib/msf/core/post/windows/filesystem.rb
+++ b/lib/msf/core/post/windows/filesystem.rb
@@ -185,7 +185,10 @@ module Msf
 
           unless result['return']
             print_error("Error deleting the reparse point. Windows Error Code: #{result['GetLastError']} - #{result['ErrorMessage']}")
+            return -1
           end
+           
+          session.railgun.kernel32.CloseHandle(handle)          
           result['return']
         end
 
@@ -209,15 +212,9 @@ module Msf
           handle
         end
 
-        def delete_mount_point(path)
-          buffer = ReparseGuidDataBuffer.new
-          buffer.reparse_tag = IO_REPARSE_TAG_MOUNT_POINT
-
-          handle = open_reparse_point(path, true)
+        def delete_mount_point(path, handle)
           return nil unless handle
-
-          delete_reparse_point(handle, buffer.to_binary_s)
-          session.fs.dir.rmdir(path)
+          session.fs.dir.rmdir(path) # Might need some more logic here.
           session.railgun.kernel32.CloseHandle(handle)
         end
 
@@ -329,7 +326,7 @@ module Msf
           return nil unless handle
 
           set_reparse_point(handle, reparse_data.to_binary_s)
-          return handle
+          handle
         end
       end # FileSystem
     end # Windows

--- a/lib/msf/core/post/windows/filesystem.rb
+++ b/lib/msf/core/post/windows/filesystem.rb
@@ -217,6 +217,7 @@ module Msf
           return nil unless handle
 
           delete_reparse_point(handle, buffer.to_binary_s)
+          session.fs.dir.rmdir(path)
           session.railgun.kernel32.CloseHandle(handle)
         end
 

--- a/lib/msf/core/post/windows/filesystem.rb
+++ b/lib/msf/core/post/windows/filesystem.rb
@@ -217,6 +217,7 @@ module Msf
           return nil unless handle
 
           delete_reparse_point(handle, buffer.to_binary_s)
+          session.railgun.kernel32.CloseHandle(handle)
         end
 
         def write_to_memory(process, str)
@@ -327,6 +328,7 @@ module Msf
           return nil unless handle
 
           set_reparse_point(handle, reparse_data.to_binary_s)
+          return handle
         end
       end # FileSystem
     end # Windows

--- a/modules/exploits/windows/local/cve_2020_0668_service_tracing.rb
+++ b/modules/exploits/windows/local/cve_2020_0668_service_tracing.rb
@@ -80,7 +80,6 @@ class MetasploitModule < Msf::Exploit::Local
       OptString.new('PHONEBOOK_UPLOAD_NAME',
                     [false, 'The name of the phonebook file to trigger RASDIAL (%RAND% by default).', nil])
     ])
-    # stores open handles to cleanup properly
   end
 
   def write_reg_value(registry_hash)
@@ -148,16 +147,6 @@ class MetasploitModule < Msf::Exploit::Local
     end
   end
 
-  def cleanup_mountpoint(dir)
-    print_status("Delete mountpoint #{dir}")
-    begin
-      session.fs.dir.rmdir(dir)
-      session.railgun.kernel32.CloseHandle(mount_point_handle)
-    rescue Rex::Post::Meterpreter::RequestError
-      print_error("Error when deleting \"#{dir}\".")
-    end
-  end
-
   def setup_process
     begin
       print_status('Launching notepad to host the exploit...')
@@ -200,7 +189,7 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def rastapi_privileged_filecopy(file_contents, exploit_dir, upload_payload_pathname, target_payload_pathname)
-    handles = []
+    handles = [] # stores open handles to cleanup properly
     reg_hash = create_reg_hash(file_contents.length - 1, exploit_dir)
     vprint_status("Registry hash = #{reg_hash}")
 
@@ -269,7 +258,7 @@ class MetasploitModule < Msf::Exploit::Local
       vprint_status("Closing symlink handle #{handle}: #{result['ErrorMessage']}")
     end
     print_status('Removing Mountpoint')
-    session.fs.dir.rmdir(exploit_dir)
+    delete_mount_point(exploit_dir, mount_point_handle)
     print_status('Removing directories')
     unless moved_md5 == upload_md5
       fail_with(Failure::Unknown, 'Payload hashes do not match; filecopy failed.')

--- a/modules/exploits/windows/local/cve_2020_0668_service_tracing.rb
+++ b/modules/exploits/windows/local/cve_2020_0668_service_tracing.rb
@@ -150,11 +150,8 @@ class MetasploitModule < Msf::Exploit::Local
 
   def cleanup_mountpoint(dir)
     print_status("Delete mountpoint #{dir}")
-    unless delete_mount_point(dir)
-      print_error('Error when deleting the mount point.')
-    end
     begin
-      session.fs.dir.rmdir(dir)
+      session.railgun.kernel32.CloseHandle(mount_point_handle)
     rescue Rex::Post::Meterpreter::RequestError
       print_error("Error when deleting \"#{dir}\".")
     end
@@ -215,7 +212,8 @@ class MetasploitModule < Msf::Exploit::Local
 
     # Create mountpoint
     print_status('Creating mountpoint')
-    unless create_mount_point(exploit_dir, mount_dir)
+    mount_point_handle = create_mount_point(exploit_dir, mount_dir)
+    unless (mount_point_handle)
       fail_with(Failure::Unknown, 'Error when creating the mount point... aborting.')
     end
 

--- a/modules/exploits/windows/local/cve_2020_0668_service_tracing.rb
+++ b/modules/exploits/windows/local/cve_2020_0668_service_tracing.rb
@@ -213,7 +213,7 @@ class MetasploitModule < Msf::Exploit::Local
     # Create mountpoint
     print_status('Creating mountpoint')
     mount_point_handle = create_mount_point(exploit_dir, mount_dir)
-    unless (mount_point_handle)
+    unless mount_point_handle
       fail_with(Failure::Unknown, 'Error when creating the mount point... aborting.')
     end
 

--- a/modules/exploits/windows/local/cve_2020_0668_service_tracing.rb
+++ b/modules/exploits/windows/local/cve_2020_0668_service_tracing.rb
@@ -151,6 +151,7 @@ class MetasploitModule < Msf::Exploit::Local
   def cleanup_mountpoint(dir)
     print_status("Delete mountpoint #{dir}")
     begin
+      session.fs.dir.rmdir(dir)
       session.railgun.kernel32.CloseHandle(mount_point_handle)
     rescue Rex::Post::Meterpreter::RequestError
       print_error("Error when deleting \"#{dir}\".")


### PR DESCRIPTION
Whilst creating my exploit for CVE-2020_0668 I was porting some of my code over to use the `create_mount_point` code, however I noticed something rather odd: the current code for `create_mount_point` in `lib/msf/core/post/windows/filesystem.rb` calls `open_reparse_point` which in turn opens up a handle to a file. This is saved into a variable named `handle`. Weirdly though, this handle is never passed back to the caller and is never closed, which leads to a dangling handle situation. 

So whats bad about this? Well technically not that much if you never need to delete that junction after you create it, as once the process associated with the calling Meterpreter session closes, there will be no more handles to that mount point/directory junction, and therefore Windows will delete it automatically.

But what if your exploiting a process that doesn't terminate after you exit Meterpreter? Or what if you need to delete and then recreate that directory junction? Well tough luck. Now that you don't have the handle anymore there is no way to close that file unless you terminate the process associated with your Meterpreter session. Now not only have you lost your session, but you've also potentially terminated a sensitive process on the target. Not good :sad:

This PR fixes this by ensuring that `create_mount_point` returns the handle that is created from `open_reparse_point`,  and also updates `delete_mount_point` within `lib/msf/core/post/windows/filesystem.rb`  to remove a similar danging handle issue.

Finally I went back and updated the code for `exploit/windows/local/cve_2020_0668_service_tracing.rb`, the only module that used these functions, so that it called them correctly. Unfortunately this also meant that `delete_mount_point` is now code that is no longer called by any function. I have left it in the library as I still think there could be use cases for it, such as deleting an existing junction that an exploit has not created, but I did want to bring this point up in case someone queries why its still there.

## Verification

List the steps needed to make sure this thing works

- [x] Review the code and make sure that nothing looks odd/needs code improvements.
- [x] Check that cve_2020_0668_service_tracing.rb now properly deletes the junctions that it creates. (@bwatters-r7 is probably the best person to test this)
- [x] Celebrate 🥳 
