### PR TITLE
Add Packet::Header#include? to check for the presence of headers in a case-insensitive manner

### DIFF
--- a/lib/rex/proto/http/packet/header.rb
+++ b/lib/rex/proto/http/packet/header.rb
@@ -96,6 +96,14 @@ class Packet::Header < Hash
   end
 
   #
+  # More advanced include? that does downcase comparison
+  #
+  def include?(key)
+    self.each_key.any? { |k|
+      k.casecmp?(key)
+    }
+  end
+  #
   # Converts the header to a string.
   #
   def to_s(prefix = '')


### PR DESCRIPTION
This PR makes the `#include?` method of Packet::Header check for the presence of headers in a case-insensitive manner.
As pointed out by @jmartin-r7 , header fields are case-insensitive (RFC links : [1](https://tools.ietf.org/html/rfc7230#section-3.2) and [2](https://tools.ietf.org/html/rfc7540#section-8.1.2))

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] in `irb`, Create an HTTP Response with given headers
- [ ] Try checking if the `#include?` method returns what it should if the case of the characters is different
