### PR TITLE
Allow OpenVAS import to import vulns without references.

### DIFF
--- a/lib/rex/parser/openvas_nokogiri.rb
+++ b/lib/rex/parser/openvas_nokogiri.rb
@@ -138,34 +138,27 @@ module Parser
       return
     end
 
+    references = []
     if @state[:cves] and @state[:cves] != "NOCVE" and !@state[:cves].empty?
       @state[:cves].split(',').each do |cve|
-        vuln_info = {}
-        vuln_info[:host] = @state[:host]
-        vuln_info[:refs] = normalize_references([{ :source => "CVE", :value => cve}])
-        vuln_info[:name] = @state[:vuln_name]
-        vuln_info[:info] = @state[:vuln_desc]
-        vuln_info[:port] = @state[:port]
-        vuln_info[:proto] = @state[:proto]
-        vuln_info[:workspace] = @args[:workspace]
-
-        db_report(:vuln, vuln_info)
+        references.append({ :source => "CVE", :value => cve})
       end
     end
     if @state[:bid] and @state[:bid] != "NOBID" and !@state[:bid].empty?
       @state[:bid].split(',').each do |bid|
-        vuln_info = {}
-        vuln_info[:host] = @state[:host]
-        vuln_info[:refs] = normalize_references([{ :source => "BID", :value => bid}])
-        vuln_info[:name] = @state[:vuln_name]
-        vuln_info[:info] = @state[:vuln_desc]
-        vuln_info[:port] = @state[:port]
-        vuln_info[:proto] = @state[:proto]
-        vuln_info[:workspace] = @args[:workspace]
-
-        db_report(:vuln, vuln_info)
+        references.append({ :source => "BID", :value => bid})
       end
     end
+
+    vuln_info = {}
+    vuln_info[:host] = @state[:host]
+    vuln_info[:refs] = normalize_references(references)
+    vuln_info[:name] = @state[:vuln_name]
+    vuln_info[:info] = @state[:vuln_desc]
+    vuln_info[:port] = @state[:port]
+    vuln_info[:proto] = @state[:proto]
+    vuln_info[:workspace] = @args[:workspace]
+    db_report(:vuln, vuln_info)
   end
 
   def record_service


### PR DESCRIPTION
Local scanning didn't show any results that had CVEs or BIDs, which the default OpenVAS import logic skips. This modifies the importer to allow for importing vulns even if they do not have references.

## Verification

- [x] Export an XML report from OpenVAS or Greenbone security scanner that contains non-CVE/BID vulns
- [x] Start `msfconsole` and db_import the file
- [x] Verify that 'vulns' shows some vulns.

Before:
```
msf5 > vulns 

Vulnerabilities
===============

Timestamp  Host  Name  References
---------  ----  ----  ----------

msf5 
```

After:
```
msf5 > vulns 

Vulnerabilities
===============

Timestamp                Host            Name                                        References
---------                ----            ----                                        ----------
2020-07-25 08:12:34 UTC  192.168.56.109  source_name                                 
2020-07-25 08:12:34 UTC  192.168.56.109  SSL/TLS: Untrusted Certificate Authorities  
2020-07-25 08:12:34 UTC  192.168.56.1    TCP timestamps                              

msf5 >
```

Easy fix observed while looking at #12848