### PR TITLE
move config_changes on plex module

### DIFF
--- a/modules/exploits/windows/http/plex_unpickle_dict_rce.rb
+++ b/modules/exploits/windows/http/plex_unpickle_dict_rce.rb
@@ -46,8 +46,8 @@ class MetasploitModule < Msf::Exploit::Remote
         },
         'Notes' => {
           'Stability' => [CRASH_SERVICE_RESTARTS], # we reboot the server twice
-          'Reliability' => [REPEATABLE_SESSION, CONFIG_CHANGES], # we attempt to revert config changes
-          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK, CONFIG_CHANGES] # we attempt to revert config changes
         },
         'Targets' =>
           [


### PR DESCRIPTION
This moves `CONFIG_CHANGES` to the side effects meta block from the (incorrect) reliability block as discussed with @smcintyre-r7 