### PR TITLE
[GSoC] Ev2 - Easier actions interaction system for modules implemented

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/auxiliary.rb
+++ b/lib/msf/ui/console/command_dispatcher/auxiliary.rb
@@ -22,6 +22,13 @@ class Auxiliary
     "-q" => [ false, "Run the module in quiet mode with no output"                         ]
   )
 
+  @@auxiliary_actions_opts = Rex::Parser::Arguments.new(
+    "-h" => [ false, "Help banner."                                                        ],
+    "-j" => [ false, "Run in the context of a job."                                        ],
+    "-o" => [ true,  "A comma separated list of options in VAR=VAL format."                ],
+    "-q" => [ false, "Run the module in quiet mode with no output"                         ]
+  )
+
   #
   # Returns the hash of commands specific to auxiliary modules.
   #
@@ -73,7 +80,7 @@ class Auxiliary
     raise Msf::MissingActionError.new(meth) if action.nil?
     mod.datastore['ACTION'] = action.name
 
-    cmd_run(*args)
+    cmd_run(*args, cmd: action.name)
   end
 
   #
@@ -95,9 +102,9 @@ class Auxiliary
   #
   # Executes an auxiliary module
   #
-  def cmd_run(*args)
+  def cmd_run(*args, cmd: "run")
     opts    = []
-    action  = mod.datastore['ACTION']
+    action  ||= mod.datastore['ACTION']
     jobify  = false
     quiet   = false
 
@@ -112,7 +119,11 @@ class Auxiliary
       when '-q'
         quiet  = true
       when '-h'
-        cmd_run_help
+        if cmd == "run"
+          cmd_run_help
+        else
+          cmd_action_help(action)
+        end
         return false
       else
         if val[0] != '-' && val.match?('=')
@@ -202,6 +213,13 @@ class Auxiliary
     print_line
     print_line "Launches an auxiliary module."
     print @@auxiliary_opts.usage
+  end
+
+  def cmd_action_help(action)
+    print_line "Usage: #{action} [options]"
+    print_line
+    print_line "Launches an auxiliary module."
+    print @@auxiliary_actions_opts.usage
   end
 
   alias cmd_exploit_help cmd_run_help

--- a/lib/msf/ui/console/command_dispatcher/auxiliary.rb
+++ b/lib/msf/ui/console/command_dispatcher/auxiliary.rb
@@ -216,7 +216,7 @@ class Auxiliary
   end
 
   def cmd_action_help(action)
-    print_line "Usage: #{action} [options]"
+    print_line "Usage: " + action.downcase + " [options]"
     print_line
     print_line "Launches an auxiliary module."
     print @@auxiliary_actions_opts.usage

--- a/lib/msf/ui/console/command_dispatcher/auxiliary.rb
+++ b/lib/msf/ui/console/command_dispatcher/auxiliary.rb
@@ -13,21 +13,16 @@ class Auxiliary
 
   include Msf::Ui::Console::ModuleCommandDispatcher
 
-
-  @@auxiliary_opts = Rex::Parser::Arguments.new(
-    "-h" => [ false, "Help banner."                                                        ],
-    "-j" => [ false, "Run in the context of a job."                                       ],
-    "-o" => [ true,  "A comma separated list of options in VAR=VAL format."                ],
-    "-a" => [ true,  "The action to use.  If none is specified, ACTION is used."           ],
-    "-q" => [ false, "Run the module in quiet mode with no output"                         ]
+  @@auxiliary_action_opts = Rex::Parser::Arguments.new(
+    '-h' => [ false, 'Help banner.'                                                        ],
+    '-j' => [ false, 'Run in the context of a job.'                                        ],
+    '-o' => [ true,  'A comma separated list of options in VAR=VAL format.'                ],
+    '-q' => [ false, 'Run the module in quiet mode with no output'                         ]
   )
 
-  @@auxiliary_actions_opts = Rex::Parser::Arguments.new(
-    "-h" => [ false, "Help banner."                                                        ],
-    "-j" => [ false, "Run in the context of a job."                                        ],
-    "-o" => [ true,  "A comma separated list of options in VAR=VAL format."                ],
-    "-q" => [ false, "Run the module in quiet mode with no output"                         ]
-  )
+  @@auxiliary_opts = Rex::Parser::Arguments.new(@@auxiliary_action_opts.fmt.merge(
+    '-a' =>  [ true,  'The action to use.  If none is specified, ACTION is used.'],
+  ))
 
   #
   # Returns the hash of commands specific to auxiliary modules.
@@ -102,7 +97,7 @@ class Auxiliary
   #
   # Executes an auxiliary module
   #
-  def cmd_run(*args, cmd: "run")
+  def cmd_run(*args, cmd: 'run')
     opts    = []
     action  ||= mod.datastore['ACTION']
     jobify  = false
@@ -119,7 +114,7 @@ class Auxiliary
       when '-q'
         quiet  = true
       when '-h'
-        if cmd == "run"
+        if cmd == 'run'
           cmd_run_help
         else
           cmd_action_help(action)
@@ -219,7 +214,7 @@ class Auxiliary
     print_line "Usage: " + action.downcase + " [options]"
     print_line
     print_line "Launches an auxiliary module."
-    print @@auxiliary_actions_opts.usage
+    print @@auxiliary_action_opts.usage
   end
 
   alias cmd_exploit_help cmd_run_help

--- a/lib/msf/ui/console/command_dispatcher/auxiliary.rb
+++ b/lib/msf/ui/console/command_dispatcher/auxiliary.rb
@@ -1,4 +1,4 @@
-# -*- coding: binary -*-
+<# -*- coding: binary -*-
 module Msf
 module Ui
 module Console
@@ -57,8 +57,8 @@ class Auxiliary
     end
 
     action = meth.to_s.delete_prefix('cmd_')
-    if mod && mod.kind_of?(Msf::Module::HasActions) && mod.actions.map(&:name).map(&:downcase).include?(action)
-       do_action(action, *args)
+    if mod && mod.kind_of?(Msf::Module::HasActions) && mod.actions.map(&:name).any? { |a| a.casecmp?(action) }
+       return do_action(action, *args)
     end
 
     return
@@ -69,8 +69,8 @@ class Auxiliary
   # Execute the module with a set action
   #
   def do_action(meth, *args)
-    action = mod.actions.select { |action| action.name.downcase == meth.downcase }.first
-    raise Exception('no action') if action.nil?
+    action = mod.actions.find { |action| action.name.casecmp?(meth) }
+    raise Msf::MissingActionError.new(meth) if action.nil?
     mod.datastore['ACTION'] = action.name
 
     cmd_run(*args)

--- a/lib/msf/ui/console/command_dispatcher/auxiliary.rb
+++ b/lib/msf/ui/console/command_dispatcher/auxiliary.rb
@@ -1,4 +1,4 @@
-<# -*- coding: binary -*-
+# -*- coding: binary -*-
 module Msf
 module Ui
 module Console

--- a/lib/msf/ui/console/command_dispatcher/auxiliary.rb
+++ b/lib/msf/ui/console/command_dispatcher/auxiliary.rb
@@ -73,9 +73,8 @@ class Auxiliary
   def do_action(meth, *args)
     action = mod.actions.find { |action| action.name.casecmp?(meth) }
     raise Msf::MissingActionError.new(meth) if action.nil?
-    mod.datastore['ACTION'] = action.name
 
-    cmd_run(*args, cmd: action.name)
+    cmd_run(*args, action: action.name)
   end
 
   #
@@ -97,7 +96,7 @@ class Auxiliary
   #
   # Executes an auxiliary module
   #
-  def cmd_run(*args, cmd: 'run')
+  def cmd_run(*args, action: nil)
     opts    = []
     action  ||= mod.datastore['ACTION']
     jobify  = false
@@ -114,7 +113,7 @@ class Auxiliary
       when '-q'
         quiet  = true
       when '-h'
-        if cmd == 'run'
+        if action.nil?
           cmd_run_help
         else
           cmd_action_help(action)

--- a/lib/msf/ui/console/command_dispatcher/auxiliary.rb
+++ b/lib/msf/ui/console/command_dispatcher/auxiliary.rb
@@ -26,7 +26,7 @@ class Auxiliary
   # Returns the hash of commands specific to auxiliary modules.
   #
   def action_commands
-      mod.actions.map { |action| [action.name, action.description] }.to_h
+      mod.actions.map { |action| [action.name.downcase, action.description] }.to_h
   end
 
   #
@@ -57,8 +57,7 @@ class Auxiliary
     end
 
     action = meth.to_s.delete_prefix('cmd_')
-    mod_actions = mod.actions.map(&:name)
-    if mod && mod.kind_of?(Msf::Module::HasActions) && mod_actions.include?(action)
+    if mod && mod.kind_of?(Msf::Module::HasActions) && mod.actions.map(&:name).map(&:downcase).include?(action)
        do_action(action, *args)
     end
 
@@ -70,7 +69,10 @@ class Auxiliary
   # Execute the module with a set action
   #
   def do_action(meth, *args)
-    mod.datastore['ACTION'] = meth
+    action = mod.actions.select { |action| action.name.downcase == meth.downcase }.first
+    raise Exception('no action') if action.nil?
+    mod.datastore['ACTION'] = action.name
+
     cmd_run(*args)
   end
 

--- a/lib/msf/ui/console/command_dispatcher/auxiliary.rb
+++ b/lib/msf/ui/console/command_dispatcher/auxiliary.rb
@@ -56,10 +56,10 @@ class Auxiliary
       return mod.send(meth.to_s, *args)
     end
 
-    method = meth.to_s.split(/_/)
-    mod_actions = Serializer::ReadableText.dump_module_actions(mod, '   ')
-    if mod && mod.kind_of?(Msf::Module::HasActions) && mod_actions.include?(method[1])
-       do_action(method[1], *args)
+    action = meth.to_s.delete_prefix('cmd_')
+    mod_actions = mod.actions.map(&:name)
+    if mod && mod.kind_of?(Msf::Module::HasActions) && mod_actions.include?(action)
+       do_action(action, *args)
     end
 
     return


### PR DESCRIPTION
I have implemented a **system to make modules actions interaction easier** and smoother for users.
These are the steps needed to make sure this thing works:

- [x] Start `msfconsole`
- [x] We select a module with ACTIONS available, for example: `msf5 > use auxiliary/admin/dns/dyn_dns_update`
- [x] We can check the actions available:  `show actions`
- [x] Now, instead of: `set action UPDATE` or `set action DELETE` and the `run`, we can make `UPDATE` or `DELETE`, which will automatically execute the module with the action set.

*Note that if you write `UPD` and press `tab` it will autocomplete `UPDATE`.

