### PR TITLE
make default prompt always display running major #

### DIFF
--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -26,7 +26,7 @@ class Driver < Msf::Ui::Driver
   ConfigGroup = "framework/ui/console"
   DbConfigGroup = "framework/database"
 
-  DefaultPrompt     = "%undmsf5%clr"
+  DefaultPrompt     = "%undmsf#{Metasploit::Framework::Version::MAJOR}%clr"
   DefaultPromptChar = "%clr>"
 
   #


### PR DESCRIPTION
make default prompt always display running major #

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] **Verify** prompt default is `msf5`
- [x] for local testing modify `lib/metasploit/framework/version.rb` to a 4.x version.
- [x] **Verify** prompt default is `msf4`
