### PR TITLE
Fix up ExploitError Module Inside exceptions.rb to Properly Propagate Errors to Users

### DIFF
--- a/lib/msf/core/exceptions.rb
+++ b/lib/msf/core/exceptions.rb
@@ -152,8 +152,8 @@ end
 module ExploitError
   include Exception
 
-  def to_s
-    "An exploitation error occurred."
+  def initialize(msg="An exploitation error occurred.")
+    super(msg)
   end
 end
 


### PR DESCRIPTION
As reported by Raphael Oliveira via the msfdev mailing list, there appears to be an issue when running a module without specifying a payload. Take a look at the following output, which shows that running the Unreal IRC backdoor exploit without a payload results in a generic error message of `Exploit failed: An exploitation error occurred`:

```
msf5 > use exploit/unix/irc/unreal_ircd_3281_backdoor
msf5 exploit(unix/irc/unreal_ircd_3281_backdoor) > show options

Module options (exploit/unix/irc/unreal_ircd_3281_backdoor):

   Name    Current Setting  Required  Description
   ----    ---------------  --------  -----------
   RHOSTS                   yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
   RPORT   6667             yes       The target port (TCP)


Exploit target:

   Id  Name
   --  ----
   0   Automatic Target


msf5 exploit(unix/irc/unreal_ircd_3281_backdoor) > set RHOSTS 127.0.0.1
RHOSTS => 127.0.0.1
msf5 exploit(unix/irc/unreal_ircd_3281_backdoor) > show options

Module options (exploit/unix/irc/unreal_ircd_3281_backdoor):

   Name    Current Setting  Required  Description
   ----    ---------------  --------  -----------
   RHOSTS  127.0.0.1        yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
   RPORT   6667             yes       The target port (TCP)


Exploit target:

   Id  Name
   --  ----
   0   Automatic Target


msf5 exploit(unix/irc/unreal_ircd_3281_backdoor) > exploit

[-] 127.0.0.1:6667 - Exploit failed: An exploitation error occurred.
[*] Exploit completed, but no session was created.
msf5 exploit(unix/irc/unreal_ircd_3281_backdoor) >
```

As you can probably already tell, this error message is not very helpful and does not actually tell the user what the root issue is. 
After digging into this further with the team, it was discovered that this is an edge case which slipped by the checks when we did https://github.com/rapid7/metasploit-framework/pull/13367, where we didn't appropriately apply the same updates to propagate errors to the end user to errors of type `ExploitError`.

This PR fixes this by ensuring that `ExploitErrors` have a `initialize` definition that appropriately propagates any errors that are thrown to their callers instead of replacing the error text with the generic message `Exploit failed: An exploitation error occurred`.

Here is what the new output should now look like:

```
msf5 > use exploit/unix/irc/unreal_ircd_3281_backdoor
msf5 exploit(unix/irc/unreal_ircd_3281_backdoor) > show options

Module options (exploit/unix/irc/unreal_ircd_3281_backdoor):

   Name    Current Setting  Required  Description
   ----    ---------------  --------  -----------
   RHOSTS                   yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
   RPORT   6667             yes       The target port (TCP)


Exploit target:

   Id  Name
   --  ----
   0   Automatic Target


msf5 exploit(unix/irc/unreal_ircd_3281_backdoor) > set RHOSTS 127.0.0.1
RHOSTS => 127.0.0.1
msf5 exploit(unix/irc/unreal_ircd_3281_backdoor) > exploit

[-] 127.0.0.1:6667 - Exploit failed: A payload has not been selected.
[*] Exploit completed, but no session was created.
msf5 exploit(unix/irc/unreal_ircd_3281_backdoor) >
```

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/unix/irc/unreal_ircd_3281_backdoor`
- [ ] `set RHOST 127.0.0.1`
- [ ] `exploit`
- [ ] **Verify** that the error message is `Exploit failed: A payload has not been selected.`