### PR TITLE
Fix up lib/postgres/postgre-pr/message.rb's self.read function to Avoid nil Errors After Calling stream.read_exactly_n_bytes

### DIFF
--- a/lib/postgres/postgres-pr/message.rb
+++ b/lib/postgres/postgres-pr/message.rb
@@ -46,7 +46,7 @@ class Message
     type = stream.read_exactly_n_bytes(1) unless startup
     length = stream.read_exactly_n_bytes(4).to_s.unpack('N').first  # FIXME: length should be signed, not unsigned
 
-    raise ParseError unless length >= 4
+    raise ParseError unless (!length.nil? && length >= 4)
 
     # initialize buffer
     buffer = Buffer.of_size(startup ? length : 1+length)

--- a/lib/postgres/postgres-pr/message.rb
+++ b/lib/postgres/postgres-pr/message.rb
@@ -48,6 +48,13 @@ class Message
 
     raise ParseError unless (!length.nil? && length >= 4)
 
+    # If we didn't read any bytes and startup was not set, then type will be nil, so don't continue.
+    unless startup
+      if type.nil?
+        return ParseError
+      end
+    end
+
     # initialize buffer
     buffer = Buffer.of_size(startup ? length : 1+length)
     buffer.write(type) unless startup

--- a/lib/postgres/postgres-pr/message.rb
+++ b/lib/postgres/postgres-pr/message.rb
@@ -46,7 +46,7 @@ class Message
     type = stream.read_exactly_n_bytes(1) unless startup
     length = stream.read_exactly_n_bytes(4).to_s.unpack('N').first  # FIXME: length should be signed, not unsigned
 
-    raise ParseError if (!length.nil? || length >= 4)
+    raise ParseError if (length.nil? || length < 4)
 
     # If we didn't read any bytes and startup was not set, then type will be nil, so don't continue.
     unless startup

--- a/lib/postgres/postgres-pr/message.rb
+++ b/lib/postgres/postgres-pr/message.rb
@@ -46,7 +46,7 @@ class Message
     type = stream.read_exactly_n_bytes(1) unless startup
     length = stream.read_exactly_n_bytes(4).to_s.unpack('N').first  # FIXME: length should be signed, not unsigned
 
-    raise ParseError unless (!length.nil? && length >= 4)
+    raise ParseError if (!length.nil? || length >= 4)
 
     # If we didn't read any bytes and startup was not set, then type will be nil, so don't continue.
     unless startup


### PR DESCRIPTION
Closes #13217

This PR fixes an issue first reported via #13217 where its possible for `lib/postgres/postgres-pr/message.rb` to try and read bytes from a stream, but that stream doesn't return any bytes. There are two variables this could affect: `type`, and `length`. The issue that was reported was when `length` was set to `nil`, but in theory the `type` variable could also be set to `nil` if the call to `stream.read_exactly_n_bytes(1)` didn't return any data and `startup` is set to `false` or `nil`.

This PR fixes this issue in two ways:

1. Adds a check to ensure that `length` is not `nil`, and ensure that this check takes place before checking that `length` is not greater than or equal to 4 to avoid stack traces.
2. Adds an additional check on the `type` value if `startup` was `false` or `nil` to ensure that `type` is not `nil` before we proceed to use it as an offset into an array.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/postgres/postgres_login`
- [x] Set the `RHOST` option and verify the module runs normally.
- [x] **Verify** that these code changes do not break anything.
- [x] Happy dance 👍 
