### PR TITLE
Edit baldr_upload_exec.rb and Its Documentation For Compliance and To Remove Typos

### DIFF
--- a/documentation/modules/exploit/multi/http/baldr_upload_exec.md
+++ b/documentation/modules/exploit/multi/http/baldr_upload_exec.md
@@ -3,8 +3,8 @@
 ### Description
 
 This module exploits an arbitrary file upload vulnerability within the Baldr
-stealer malware control panel when uploading victim log files (which are uploaded 
-as ZIP files). Attackers can turn this vulnerability into an RCE by first 
+stealer malware control panel when uploading victim log files (which are uploaded
+as ZIP files). Attackers can turn this vulnerability into an RCE by first
 registering a new bot to the panel and then uploading a ZIP file containing
 malicious PHP, which will then uploaded to a publicly accessible
 directory underneath the /logs web directory.
@@ -20,25 +20,14 @@ uploading the malicious ZIP file.
   2. Start msfconsole
   3. Do: `use exploit/multi/http/baldr_upload_exec`
   4. Do `set rhost 192.168.1.27`
-  4. Do: `check`
-```
-[*] Baldr Version: <= v2.0
-[+] 192.168.1.27:80 - The target is vulnerable.
-```
+  5. Do: `run`
+  6. Verify that you get a shell on the target system
 
-## Targets
 
-```
-Exploit targets:
+## Options
 
-   Id  Name
-   --  ----
-   0   Auto
-   1   <= v2.0
-   2   v2.2
-   3   v3.0 & v3.1
-```
-
+### TARGETURI
+The URI where the Baldr panel/gateway is located on the target web server.
 
 ## Scenarios
 ```

--- a/documentation/modules/exploit/multi/http/baldr_upload_exec.md
+++ b/documentation/modules/exploit/multi/http/baldr_upload_exec.md
@@ -2,9 +2,17 @@
 
 ### Description
 
-This module exploits a arbitrary file upload vulnerability within the Baldr stealer malware control panel. Attackers can turn this
-vulnerability into an RCE by adding a malicious PHP code inside the victim logs ZIP file and registering a new bot to the panel by uploading the ZIP file under logs directory. On versions 3.0 and 3.1 victim logs are ciphered by a random 4 byte XOR key. 
-This exploit module retrieves the IP spesific XOR key from panel gate and registers a new victim to the panel with adding the selected payload inside the victim logs. 
+This module exploits an arbitrary file upload vulnerability within the Baldr
+stealer malware control panel when uploading victim log files (which are uploaded 
+as ZIP files). Attackers can turn this vulnerability into an RCE by first 
+registering a new bot to the panel and then uploading a ZIP file containing
+malicious PHP, which will then uploaded to a publicly accessible
+directory underneath the /logs web directory.
+
+Note that on versions 3.0 and 3.1 the ZIP files containing the victim log files
+are encoded by XORing them with a random 4 byte key. This exploit module gets around
+this restriction by retrieving the IP specific XOR key from panel gate before
+uploading the malicious ZIP file.
 
 ## Verification Steps
 
@@ -14,7 +22,7 @@ This exploit module retrieves the IP spesific XOR key from panel gate and regist
   4. Do `set rhost 192.168.1.27`
   4. Do: `check`
 ```
-[*] Verison: Baldr <= v2.0
+[*] Baldr Version: <= v2.0
 [+] 192.168.1.27:80 - The target is vulnerable.
 ```
 
@@ -39,7 +47,7 @@ msf5 exploit(exploit/multi/http/baldr_upload_exec) > set rhost 192.168.1.27
 rhost => 192.168.1.27
 msf5 exploit(multi/http/baldr_upload_exec) > run
 
-[*] Baldr Verison: <= v2.0
+[*] Baldr Version: <= v2.0
 [+] Payload uploaded to /logs/FJETBHLL/.vatw.php
 [+] Payload successfully triggered !
 [*] Started bind TCP handler against 192.168.1.27:9090

--- a/modules/exploits/multi/http/baldr_upload_exec.rb
+++ b/modules/exploits/multi/http/baldr_upload_exec.rb
@@ -16,15 +16,16 @@ class MetasploitModule < Msf::Exploit::Remote
         'Name' => 'Baldr Botnet Panel Shell Upload Exploit',
         'Description' => %q{
           This module exploits an arbitrary file upload vulnerability within the Baldr
-          stealer malware control panel. Attackers can turn this vulnerability into
-          an RCE by adding a malicious PHP code inside the victim logs ZIP file and
-          registering a new bot to the panel by uploading the ZIP file under the logs
-          directory. On versions 3.0 and 3.1 victim logs are ciphered by a random 4
-          byte XOR key.
-
-          This exploit module retrieves the IP specific XOR key from panel gate
-          and registers a new victim to the panel with adding the selected payload
-          inside the victim logs.
+          stealer malware control panel when uploading victim log files (which are uploaded 
+          as ZIP files). Attackers can turn this vulnerability into an RCE by first 
+          registering a new bot to the panel and then uploading a ZIP file containing
+          malicious PHP, which will then uploaded to a publicly accessible
+          directory underneath the /logs web directory.
+          
+          Note that on versions 3.0 and 3.1 the ZIP files containing the victim log files
+          are encoded by XORing them with a random 4 byte key. This exploit module gets around
+          this restriction by retrieving the IP specific XOR key from panel gate before
+          uploading the malicious ZIP file.
         },
         'License' => MSF_LICENSE,
         'Author' =>

--- a/modules/exploits/multi/http/baldr_upload_exec.rb
+++ b/modules/exploits/multi/http/baldr_upload_exec.rb
@@ -15,14 +15,14 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'Baldr Botnet Panel Shell Upload Exploit',
         'Description' => %q{
-          This module exploits a arbitrary file upload vulnerability within the Baldr
+          This module exploits an arbitrary file upload vulnerability within the Baldr
           stealer malware control panel. Attackers can turn this vulnerability into
           an RCE by adding a malicious PHP code inside the victim logs ZIP file and
-          registering a new bot to the panel by uploading the ZIP file under logs
+          registering a new bot to the panel by uploading the ZIP file under the logs
           directory. On versions 3.0 and 3.1 victim logs are ciphered by a random 4
           byte XOR key.
 
-          This exploit module retrieves the IP spesific XOR key from panel gate
+          This exploit module retrieves the IP specific XOR key from panel gate
           and registers a new victim to the panel with adding the selected payload
           inside the victim logs.
         },

--- a/modules/exploits/multi/http/baldr_upload_exec.rb
+++ b/modules/exploits/multi/http/baldr_upload_exec.rb
@@ -16,12 +16,12 @@ class MetasploitModule < Msf::Exploit::Remote
         'Name' => 'Baldr Botnet Panel Shell Upload Exploit',
         'Description' => %q{
           This module exploits an arbitrary file upload vulnerability within the Baldr
-          stealer malware control panel when uploading victim log files (which are uploaded 
-          as ZIP files). Attackers can turn this vulnerability into an RCE by first 
+          stealer malware control panel when uploading victim log files (which are uploaded
+          as ZIP files). Attackers can turn this vulnerability into an RCE by first
           registering a new bot to the panel and then uploading a ZIP file containing
           malicious PHP, which will then uploaded to a publicly accessible
           directory underneath the /logs web directory.
-          
+
           Note that on versions 3.0 and 3.1 the ZIP files containing the victim log files
           are encoded by XORing them with a random 4 byte key. This exploit module gets around
           this restriction by retrieving the IP specific XOR key from panel gate before


### PR DESCRIPTION
This PR fixes a confusing description field for the `modules/exploits/multi/http/baldr_upload_exec.rb` module as well as its associated documentation at `documentation/modules/exploit/multi/http/baldr_upload_exec.md`. It also adds in a missing `Options` section within the documentation that wasn't included for some reason slipped past our checks when we originally landed this PR.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use exploits/multi/http/baldr_upload_exec.rb`
- [x] **Verify** that the new info from the `info` command shows the description without typos.
- [x] **Document** if there are any other locations within the module or its documentation that need typo fixes.