### PR TITLE
Revendor openvas omp, fix ruby deprecations when using the openvas plugin

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,7 +42,6 @@ PATH
       nokogiri
       octokit
       openssl-ccm
-      openvas-omp
       packetfu
       patch_finder
       pcaprub
@@ -250,7 +249,6 @@ GEM
       sawyer (~> 0.8.0, >= 0.5.3)
     openssl-ccm (1.2.2)
     openssl-cmac (2.0.1)
-    openvas-omp (0.0.4)
     packetfu (1.1.13)
       pcaprub
     parallel (1.19.2)

--- a/lib/metasploit/framework/data_service/remote/http/remote_db_import_data_service.rb
+++ b/lib/metasploit/framework/data_service/remote/http/remote_db_import_data_service.rb
@@ -5,6 +5,10 @@ module RemoteDbImportDataService
 
   DB_IMPORT_API_PATH = '/api/v1/db-import'
 
+  def import(opts, &block)
+    self.post_data_async(DB_IMPORT_API_PATH, opts)
+  end
+
   def import_file(opts)
     filename = opts[:filename]
     data = ""

--- a/lib/msf/core/db_manager/import.rb
+++ b/lib/msf/core/db_manager/import.rb
@@ -342,7 +342,7 @@ module Msf::DBManager::Import
     elsif (firstline.index(/<get_reports_response status=['"]200['"] status_text=['"]OK['"]>/))
       @import_filedata[:type] = "OpenVAS XML"
       return :openvas_new_xml
-    elsif (firstline.index(/<report id=['"]/))
+    elsif (firstline.match?('<report') && firstline.match?(' id=') && firstline.match?(' format_id='))
       @import_filedata[:type] = "OpenVAS XML"
       return :openvas_new_xml
     elsif (firstline.index("<NessusClientData>"))

--- a/lib/openvas/openvas-omp.rb
+++ b/lib/openvas/openvas-omp.rb
@@ -1,0 +1,640 @@
+#!/usr/bin/env ruby
+#
+# This plugin provides integration with OpenVAS. Written by kost and
+# averagesecurityguy.
+#
+# Distributed under MIT license: 
+# http://www.opensource.org/licenses/mit-license.php
+#
+
+require 'socket' 
+require 'timeout'
+require 'openssl'
+require 'rexml/document'
+require 'rexml/text'
+require 'base64'
+
+# OpenVASOMP module
+# 
+# Usage: require 'openvas-omp'
+
+module OpenVASOMP
+
+#------------------------------
+# Error Classes
+#------------------------------
+  class OMPError < :: RuntimeError
+    attr_accessor :reason
+    def initialize(reason = '')
+      self.reason = reason
+    end
+    def to_s
+      "OpenVAS OMP: #{self.reason}"
+    end
+  end
+
+  class OMPConnectionError < OMPError
+    def initialize
+      self.reason = "Could not connect to server"
+    end
+  end
+
+  class OMPResponseError < OMPError
+    def initialize
+      self.reason = "Error in OMP request/response"
+    end
+  end
+
+  class OMPAuthError < OMPError
+    def initialize
+      self.reason = "Authentication failed"
+    end
+  end
+
+  class XMLParsingError < OMPError
+    def initialize
+      self.reason = "XML parsing failed"
+    end
+  end
+
+
+#------------------------------
+# Connection Class
+#------------------------------
+  class OpenVASConnection
+    attr_accessor :socket, :bufsize, :debug
+
+    def initialize(host="127.0.0.1", port=9390, debug=false)
+      @host = host
+      @port = port
+      @socket = nil
+      @bufsize = 16384
+      @debug = debug
+    end
+
+    def connect
+      if @debug then puts "Connecting to server #{@host} on port #{@port}" end
+      plain_socket = TCPSocket.open(@host, @port)
+      ssl_context = OpenSSL::SSL::SSLContext.new()
+      @socket = OpenSSL::SSL::SSLSocket.new(plain_socket, ssl_context)
+      @socket.sync_close = true
+      @socket.connect
+    end
+      
+    def disconnect
+      if @debug then
+        puts "Closing connection to server #{@host} on port #{@port}" end
+      if @socket then @socket.close end
+    end
+
+    def sendrecv(data)
+      # Send the data
+      if @debug then puts "Preparing to send data" end
+      if not @socket then connect end
+      if @debug then puts "SENDING: " + data end
+      @socket.puts(data)
+
+      # Receive the response
+      resp = ''
+      size = 0
+      begin	
+        begin
+          timeout(@read_timeout) {
+              a = @socket.sysread(@bufsize)
+              size = a.length
+              resp << a
+          }
+        rescue Timeout::Error
+          size = 0
+        rescue EOFError
+          raise OMPResponseError
+        end
+      end while size >= @bufsize
+      
+      if @debug then puts "RECEIVED: " + resp end
+      return resp
+    end
+  end
+    
+
+#------------------------------
+# OpenVASOMP class
+#------------------------------
+  class OpenVASOMP
+    # initialize object: try to connect to OpenVAS using URL, user and password
+    attr_reader :targets, :tasks, :configs, :formats, :reports
+
+    def initialize(user="openvas", pass="openvas", host="localhost", port=9392, debug=false)
+      @debug = debug
+      @token = ''
+      @server = OpenVASConnection.new(host, port, debug)
+      @server.connect
+      login(user, pass)
+      @configs = nil
+      @tasks = nil
+      @targets = nil
+      @formats = nil
+      @reports = nil
+      config_get_all
+      task_get_all
+      target_get_all
+      format_get_all
+      report_get_all
+    end
+
+  #--------------------------
+  # Low level commands. Only
+  # used by OpenVASOMP class.
+  #--------------------------
+    # Nests a string inside an XML tag specified by root
+    def xml_str(root, str)
+      return "<#{root}>#{str}</#{root}>"
+    end
+
+    # Creates an XML root with child elements specified by a hash
+    def xml_elems(root, elems)
+      xml = REXML::Element.new(root)
+      elems.each do |key, val|
+        e = xml.add_element(key)
+        e.text = val
+      end
+      return xml.to_s
+    end
+
+    # Creates and XML element with attributes specified by a hash
+    def xml_attrs(elem, attribs)
+      xml = REXML::Element.new(elem)
+      attribs.each do |key, val|
+        xml.attributes[key] = val
+      end
+      return xml.to_s
+    end
+
+    # Send authentication string and return an XML object (authentication token)
+    def auth_request_xml(request)
+      if @debug
+        puts "Sending Request: #{request}"
+      end
+      resp = @server.sendrecv(request)
+      begin
+        docxml = REXML::Document.new(resp)
+        status = docxml.root.attributes['status'].to_i
+        status_text = docxml.root.attributes['status_text']
+        if @debug
+          puts "Status: #{status}"
+          puts "Status Text: #{status_text}"
+        end
+      rescue
+        raise XMLParsingError
+      end
+
+      return status, status_text
+    end
+
+    # Send string request wrapped with authentication XML and return 
+    # an XML object
+    def omp_request_xml(request)
+      if @debug
+        puts "Sending Request: #{request}"
+      end
+      resp = @server.sendrecv(@token + request)
+      begin
+        # Wrap the response in XML tags to use next_element properly.
+        docxml = REXML::Document.new("<response>" + resp + "</response>")
+        resp = docxml.root.elements['authenticate_response'].next_element
+        status = resp.attributes['status'].to_i
+        status_text = resp.attributes['status_text']	
+        if @debug
+          puts "Status: #{status}"
+          puts "Status Text: #{status_text}"
+        end
+      rescue
+        raise XMLParsingError
+      end
+
+      return status, status_text, resp
+    end
+
+  #--------------------------
+  # Class API methods.
+  #--------------------------
+    # Sets debug level
+    def debug(value)
+      if value == 0
+        @debug = false
+        @server.debug = false
+        return "Debug is deactivated."
+      else
+        @debug = true
+        @server.debug = true
+        return "Debug is activated."
+      end
+    end
+
+    # get OMP version (you don't need to be authenticated)
+    def get_version
+      status, status_text, resp = omp_request_xml("<get_version/>")
+      begin
+        version = resp.elements['version'].text
+        return version
+      rescue
+        raise XMLParsingError 
+      end
+    end
+
+    # login to OpenVAS server. 
+    # if successful returns authentication XML for further usage
+    # if unsuccessful returns empty string
+    def login(user, pass)
+      creds = xml_elems("credentials", {"username"=> user, "password" => pass})
+      req = xml_str("authenticate", creds)
+      status, status_text = auth_request_xml(req)
+
+      if status == 200
+        @token = req
+      else
+        raise OMPAuthError	
+      end
+    end
+
+    # Logout by disconnecting from the server and deleting the
+    # authentication string. There are no sessions in OMP, must
+    # send the credentials every time.
+    def logout
+      @server.disconnect()
+      @token = ''
+    end
+
+#------------------------------
+# Target Functions
+#------------------------------
+
+    # OMP - Get all targets for scanning and returns array of hashes
+    # with following keys: id,name,comment,hosts,max_hosts,in_use
+    #
+    # Usage:
+    # array_of_hashes = target_get_all()
+    # 
+    def target_get_all()
+      begin
+        status, status_text, resp = omp_request_xml("<get_targets/>")
+
+        list = Array.new
+        resp.elements.each('//get_targets_response/target') do |target|
+          td = Hash.new
+          td["id"] = target.attributes["id"]
+          td["name"] = target.elements["name"].text
+          td["comment"] = target.elements["comment"].text
+          td["hosts"] = target.elements["hosts"].text
+          td["max_hosts"] = target.elements["max_hosts"].text
+          td["in_use"] = target.elements["in_use"].text
+          list.push td
+        end
+        @targets = list
+        return list
+      rescue 
+        raise OMPResponseError
+      end
+    end
+
+    # OMP - Create target for scanning
+    #
+    # Usage:
+    #
+    # target_id = ov.target_create("name"=>"localhost",
+    # 	"hosts"=>"127.0.0.1","comment"=>"yes")
+    # 
+    def target_create(name, hosts, comment)
+      req = xml_elems("create_target", {"name"=>name, "hosts"=>hosts, "comment"=>comment})
+
+      begin
+        status, status_text, resp = omp_request_xml(req)
+        target_get_all
+        return "#{status_text}: #{resp.attributes['id']}"
+      rescue 
+        raise OMPResponseError
+      end
+    end
+
+    # OMP - Delete target 
+    #
+    # Usage:
+    #
+    # ov.target_delete(target_id)
+    # 
+    def target_delete(id) 
+      target = @targets[id.to_i]
+      if not target
+        raise OMPError.new("Invalid target id.")
+      end
+      req = xml_attrs("delete_target",{"target_id" => target["id"]})
+      begin
+        status, status_text, resp = omp_request_xml(req)
+        target_get_all
+        return status_text
+      rescue 
+        raise OMPResponseError
+      end
+    end
+
+  #--------------------------
+  # Task Functions
+  #--------------------------
+    # In short: Create a task.
+    #
+    # The client uses the create_task command to create a new task. 
+    # 
+    def task_create(name, comment, config_id, target_id)
+      config = @configs[config_id.to_i]
+      target = @targets[target_id.to_i]
+      config = xml_attrs("config", {"id"=>config["id"]})
+      target = xml_attrs("target", {"id"=>target["id"]})
+      namestr = xml_str("name", name)
+      commstr = xml_str("comment", comment)
+      
+      req = xml_str("create_task", namestr + commstr + config + target)
+
+      begin
+        status, status_text, resp = omp_request_xml(req)
+        task_get_all
+        return "#{status_text}: #{resp.attributes['id']}"
+      rescue 
+        raise OMPResponseError
+      end
+    end
+
+    # In short: Delete a task.
+    #
+    # The client uses the delete_task command to delete an existing task,
+    # including all reports associated with the task. 
+    # 
+    def task_delete(task_id) 
+      task = @tasks[task_id.to_i]
+      if not task
+        raise OMPError.new("Invalid task id.")
+      end
+      req = xml_attrs("delete_task",{"task_id" => task["id"]})
+      begin
+        status, status_text, resp = omp_request_xml(req)
+        task_get_all
+        return status_text
+      rescue 
+        raise OMPResponseError
+      end
+    end
+
+    # In short: Get all tasks.
+    #
+    # The client uses the get_tasks command to get task information. 
+    # 
+    def task_get_all()
+      begin
+        status, status_text, resp = omp_request_xml("<get_tasks/>")
+        
+        list = Array.new
+        resp.elements.each('//get_tasks_response/task') do |task|
+          td = Hash.new
+          td["id"] = task.attributes["id"]
+          td["name"] = task.elements["name"].text
+          td["comment"] = task.elements["comment"].text
+          td["status"] = task.elements["status"].text
+          td["progress"] = task.elements["progress"].text
+          list.push td	
+        end
+        @tasks = list
+        return list
+      rescue
+        raise OMPResponseError
+      end
+    end
+
+    # In short: Manually start an existing task.
+    #
+    # The client uses the start_task command to manually start an existing
+    # task.
+    #
+    def task_start(task_id)
+      task = @tasks[task_id.to_i]
+      if not task
+        raise OMPError.new("Invalid task id.")
+      end
+      req = xml_attrs("start_task",{"task_id" => task["id"]})
+      begin
+        status, status_text, resp = omp_request_xml(req)
+        return status_text
+      rescue 
+        raise OMPResponseError
+      end
+    end
+
+    # In short: Stop a running task.
+    #
+    # The client uses the stop_task command to manually stop a running
+    # task.
+    #
+    def task_stop(task_id) 
+      task = @tasks[task_id.to_i]
+      if not task
+        raise OMPError.new("Invalid task id.")
+      end
+      req = xml_attrs("stop_task",{"task_id" => task["id"]})
+      begin
+        status, status_text, resp = omp_request_xml(req)
+        return status_text
+      rescue 
+        raise OMPResponseError
+      end
+    end 
+
+    # In short: Pause a running task.
+    #
+    # The client uses the pause_task command to manually pause a running
+    # task.
+    #
+    def task_pause(task_id) 
+      task = @tasks[task_id.to_i]
+      if not task
+        raise OMPError.new("Invalid task id.")
+      end
+      req = xml_attrs("pause_task",{"task_id" => task["id"]})
+      begin
+        status, status_text, resp = omp_request_xml(req)
+        return status_text
+      rescue 
+        raise OMPResponseError
+      end
+    end
+
+    # In short: Resume task if stopped, else start task.
+    #
+    # The client uses the resume_or_start_task command to manually start
+    # an existing task, ensuring that the task will resume from its
+    # previous position if the task is in the Stopped state.
+    # 
+    def task_resume_or_start(task_id) 
+      task = @tasks[task_id.to_i]
+      if not task
+        raise OMPError.new("Invalid task id.")
+      end
+      req = xml_attrs("resume_or_start_task",{"task_id" => task["id"]})
+      begin
+        status, status_text, resp = omp_request_xml(req)
+        return status_text
+      rescue 
+        raise OMPResponseError
+      end
+    end
+
+    # In short: Resume a puased task
+    #
+    # The client uses the resume_paused_task command to manually resume
+    # a paused task.
+    # 
+    def task_resume_paused(task_id) 
+      task = @tasks[task_id.to_i]
+      if not task
+        raise OMPError.new("Invalid task id.")
+      end
+      req = xml_attrs("resume_paused_task",{"task_id" => task["id"]})
+      begin
+        status, status_text, resp = omp_request_xml(req)
+        return status_text
+      rescue 
+        raise OMPResponseError
+      end
+    end
+
+  #--------------------------
+  # Config Functions
+  #--------------------------
+    # OMP - get configs and returns hash as response
+    # hash[config_id]=config_name
+    #
+    # Usage:
+    #
+    # array_of_hashes=ov.config_get_all()
+    # 
+    def config_get_all()
+      begin
+        status, status_text, resp = omp_request_xml("<get_configs/>")
+
+        list = Array.new
+        resp.elements.each('//get_configs_response/config') do |config|
+          c = Hash.new
+          c["id"] = config.attributes["id"]
+          c["name"] = config.elements["name"].text
+          list.push c
+        end
+        @configs = list
+        return list
+      rescue 
+        raise OMPResponseError
+      end
+    end	
+
+
+  #--------------------------
+  # Format Functions
+  #--------------------------
+    # Get a list of report formats
+    def format_get_all()
+      begin
+        status, status_text, resp = omp_request_xml("<get_report_formats/>")
+        if @debug then print resp end
+        
+        list = Array.new
+        resp.elements.each('//get_report_formats_response/report_format') do |report|
+          td = Hash.new
+          td["id"] = report.attributes["id"]
+          td["name"] = report.elements["name"].text
+          td["extension"] = report.elements["extension"].text
+          td["summary"] = report.elements["summary"].text
+          list.push td	
+        end
+        @formats = list
+        return list
+      rescue
+        raise OMPResponseError
+      end
+    end
+
+
+  #--------------------------
+  # Report Functions
+  #--------------------------
+    # Get a list of reports
+    def report_get_all()
+      begin
+        status, status_text, resp = omp_request_xml("<get_reports/>")
+        
+        list = Array.new
+        resp.elements.each('//get_reports_response/report') do |report|
+          td = Hash.new
+          td["id"] = report.attributes["id"]
+          td["task"] = report.elements["report/task/name"].text
+          td["start_time"] = report.elements["report/scan_start"].text
+          td["stop_time"] = report.elements["report/scan_end"].text
+          list.push td	
+        end
+        @reports = list
+        return list
+      rescue
+        raise OMPResponseError
+      end
+    end
+
+    def report_delete(report_id) 
+      report = @reports[report_id.to_i]
+      if not report
+        raise OMPError.new("Invalid report id.")
+      end
+      req = xml_attrs("delete_report",{"report_id" => report["id"]})
+      begin
+        status, status_text, resp = omp_request_xml(req)
+        report_get_all
+        return status_text
+      rescue 
+        raise OMPResponseError
+      end
+    end
+
+    # Get a report by id. Must also specify the format_id
+    def report_get_by_id(report_id, format_id)
+      report = @reports[report_id.to_i]
+      if not report
+        raise OMPError.new("Invalid report id.")
+      end
+
+      format = @formats[format_id.to_i]
+      if not format
+        raise OMPError.new("Invalid format id.")
+      end
+
+      req = xml_attrs("get_reports", {"report_id"=>report["id"], "format_id"=>format["id"]})
+      begin
+        status, status_text, resp = omp_request_xml(req)
+      rescue
+        raise OMPResponseError
+      end
+
+      if status == "404"
+        raise OMPError.new(status_text)
+      end
+
+      content_type = resp.elements["report"].attributes["content_type"]
+      report = resp.elements["report"].to_s
+
+      if report == nil
+        raise OMPError.new("The report is empty.")
+      end
+
+      # XML reports are in XML format, everything else is base64 encoded.
+      if content_type == "text/xml"
+        return report
+      else
+        return Base64.decode64(report)
+      end
+    end
+
+    end
+end

--- a/lib/rex/parser/openvas_nokogiri.rb
+++ b/lib/rex/parser/openvas_nokogiri.rb
@@ -81,11 +81,11 @@ module Parser
         if @text
           if /^(?<p_num>\d{1,5})\/(?<p_proto>.+)\s\((?<p_name>.+)\)/ =~ @text
             @state[:name] = p_name.gsub(/iana: /i, '')
-            @state[:port] = p_num
+            @state[:port] = p_num.strip
             @state[:proto] = p_proto
           elsif @text.index('(')
             @state[:proto] = @text.split('(')[1].split('/')[1].gsub(/\)/, '')
-            @state[:port] = @text.split('(')[1].split('/')[0].gsub(/\)/, '')
+            @state[:port] = @text.split('(')[1].split('/')[0].gsub(/\)/, '').strip
           elsif @text.index('/')
             @state[:proto] = @text.split('/')[1].strip
             @state[:port] = @text.split('/')[0].strip
@@ -103,16 +103,16 @@ module Parser
         if @text
           if /^(?<p_num>\d{1,5})\/(?<p_proto>.+)\s\((?<p_name>.+)\)/ =~ @text
             @state[:name] = p_name.gsub(/iana: /i, '')
-            @state[:port] = p_num
+            @state[:port] = p_num.strip
             @state[:proto] = p_proto
             record_service if p_num
           elsif @text.index('(')
             @state[:name] = @text.split(' ')[0]
-            @state[:port] = @text.split('(')[1].split('/')[0]
+            @state[:port] = @text.split('(')[1].split('/')[0].strip
             @state[:proto] = @text.split('(')[1].split('/')[1].split(')')[0]
             record_service unless @state[:name].nil?
           elsif @text.index('/')
-            @state[:port] = @text.split('/')[0]
+            @state[:port] = @text.split('/')[0].strip
             @state[:proto] = @text.split('/')[1]
             record_service unless @state[:port] == 'general'
           end

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -189,8 +189,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'tzinfo'
   # Needed so that disk size output isn't horrible
   spec.add_runtime_dependency 'filesize'
-  # Needed for openvas plugin
-  spec.add_runtime_dependency 'openvas-omp'
   # Needed by metasploit nessus bridge
   spec.add_runtime_dependency 'nessus_rest'
   # Nexpose Gem

--- a/plugins/openvas.rb
+++ b/plugins/openvas.rb
@@ -460,12 +460,7 @@ class Plugin::OpenVAS < Msf::Plugin
               'Columns' => ["ID", "Task Name", "Start Time", "Stop Time"])
 
         @ov.report_get_all.each do |report|
-          report_id = report.elements["report"].attributes["id"]
-          report_task = report.elements["task/name"].get_text
-          report_start_time = report.elements["creation_time"].get_text
-          report_stop_time = report.elements["modification_time"].get_text
-
-          tbl << [ report_id, report_task, report_start_time, report_stop_time ]
+          tbl << [ report["id"], report["task"], report["start_time"], report["stop_time"] ]
         end
         print_good("OpenVAS list of reports")
         print_line

--- a/plugins/openvas.rb
+++ b/plugins/openvas.rb
@@ -513,6 +513,9 @@ class Plugin::OpenVAS < Msf::Plugin
       if args?(args, 2)
         begin
           report = @ov.report_get_by_id(args[0], args[1])
+          # OpenVAS sends the report with an invalid attribute in the middle of
+          # the XML document. Remove that before passing to the XML parser.
+          report.sub!('<?xml version="1.0" encoding="UTF-8"?>', '')
           print_status("Importing report to database.")
           framework.db.import({:data => report})
         rescue OpenVASOMP::OMPError => e


### PR DESCRIPTION
PR #7223 had good intentions that we'd see better support from the upstream vendor gem for openvas-omp, but unfortunately it hasn't been maintained in a while (see https://github.com/rapid7/metasploit-framework/issues/13797#issuecomment-663836093 https://github.com/kost/openvas-omp-ruby/pull/4, etc.). So this PR undoes #7223 and fixes the long-standing bug in using the deprecated `timeout` function.

Fixes #13797 #12715 #12848

## Verification

- [ ] Start `msfconsole` and use the openvas plugin, verify functionality

```
$ ./msfconsole -qx 'load openvas; openvas_connect admin password localhost 9390'
[*] Welcome to OpenVAS integration by kost and averagesecurityguy.
[*] 
[*] OpenVAS integration requires a database connection. Once the 
[*] database is ready, connect to the OpenVAS server using openvas_connect.
[*] For additional commands use openvas_help.
[*] 
[*] Successfully loaded plugin: OpenVAS
[*] Connecting to OpenVAS instance at localhost:9390 with username admin...
[+] OpenVAS connection successful
msf5 > openvas_
openvas_config_list           openvas_report_delete         openvas_target_list           openvas_task_resume_or_start
openvas_connect               openvas_report_download       openvas_task_create           openvas_task_start
openvas_debug                 openvas_report_import         openvas_task_delete           openvas_task_stop
openvas_disconnect            openvas_report_list           openvas_task_list             openvas_version
openvas_format_list           openvas_target_create         openvas_task_pause            
openvas_help                  openvas_target_delete         openvas_task_resume           
msf5 > openvas_config_list 
[+] OpenVAS list of configs

ID                                    Name
--                                    ----
085569ce-73ed-11df-83c3-002264764cea  empty
2d3f051c-55ba-11e3-bf43-406186ea4fc5  Host Discovery
698f691e-7489-11df-9d8c-002264764cea  Full and fast ultimate
708f25c4-7489-11df-8094-002264764cea  Full and very deep
74db13d6-7489-11df-91b9-002264764cea  Full and very deep ultimate
8715c877-47a0-438d-98a3-27c7a6ab2196  Discovery
bbca7412-a950-11e3-9109-406186ea4fc5  System Discovery
daba56c8-73ec-11df-a475-002264764cea  Full and fast

msf5 > openvas_report_list 
[+] OpenVAS list of reports

ID  Task Name  Start Time  Stop Time
--  ---------  ----------  ---------

```

I'm relying on OpenVas users like @bcoles, @guarisma, and @KittyTechnoProgrammer to validate that this works as expected in their scenarios. Thanks in advance!