### PR TITLE
Updates for PsExec documentation

### DIFF
--- a/documentation/modules/exploit/windows/smb/psexec.md
+++ b/documentation/modules/exploit/windows/smb/psexec.md
@@ -1,16 +1,17 @@
-PSexec is one of the most popular exploits against Microsoft Windows. It is a great way to test password security and demonstrate how a
+PsExec is one of the most popular exploits against Microsoft Windows. It is a great way to test password security and demonstrate how a
 stolen password could lead to a complete compromise of an entire corporate network.
 
 ## Vulnerable Application
 
-To be able to use exploit/windows/smb/psexec:
+To be able to use `exploit/windows/smb/psexec`:
 
-1. You must have a valid username/password.
-2. The firewall must allow SMB traffic.
-3. The target must use SMBv1.
-4. The remote Windows machine's network security policy must allow it. If you see
-  [one of these errors](https://github.com/rapid7/metasploit-framework/wiki/What-does-my-Rex%3A%3AProto%3A%3ASMB-Error-mean%3F), then the
-  Windows machine does not allow it.
+1. A valid username and password must be set.
+1. The firewall must allow SMB traffic.
+1. The remote Windows machine's network security policy must allow it.
+    * If the specified account is a local Administrator and the target is Windows Vista or newer, then "Remote UAC" must be disabled (the
+      `DWORD` value `HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System\LocalAccountTokenFilterPolicy` must be 1).
+      See [Pass-the-Hash Is Dead: Long Live LocalAccountTokenFilterPolicy][1] for more information. Without this setting, the server will
+      respond with `STATUS_ACCESS_DENIED` and PsExec will fail.
 
 ## Verification Steps
 
@@ -135,3 +136,5 @@ The command target causes the psexec operation to execute an operating system co
 by Metasploit, or the user can specify their own by using the `cmd/windows/generic` payload and setting `CMD`. The output of the command
 will be written to a file and then retrieved so that it is accessible. If the command does not immediately return, then reading the output
 will fail.
+
+[1]: https://www.harmj0y.net/blog/redteaming/pass-the-hash-is-dead-long-live-localaccounttokenfilterpolicy/


### PR DESCRIPTION
This updates the documentation for the `exploit/windows/smb/psexec` module to make the following changes:

* Remove the use of "The target must use SMBv1" -- This is no longer accurate, the module supports v1 - v3.1.1
* Mention that on modern systems "Remove UAC" needs to be disabled to allow a local Administrator account to be used
* Removed the dead line to Rex-based error messages

## Testing

- [ ] Start msfconsole
- [ ] Run: `use exploit/windows/smb/psexec` to use the module
- [ ] Run: `info -d` to generate the documentation
- [ ] See the docs, and ensure that they make sense and provide more value now than before

**Don't merge this into master until #13935 is merged in.** Marked as delayed to indicate this is blocked, however it is ready for review.