### PR TITLE
Fix update mode in DBManager::Note#report_note

### DIFF
--- a/lib/msf/core/db_manager/note.rb
+++ b/lib/msf/core/db_manager/note.rb
@@ -147,7 +147,7 @@ module Msf::DBManager::Note
     conditions[:service_id] = service[:id] if service
     conditions[:vuln_id] = opts[:vuln_id]
 
-    case mode
+    case mode.to_sym
     when :unique
       note      = wspace.notes.where(conditions).first_or_initialize
       note.data = data


### PR DESCRIPTION
This fixes an issue when setting the update mode in `DBManager::Note#report_note` with web services.

The update mode is retrieved from the option hash, which contains strings when the web service proxy is enabled. Then, it is compared to symbols values (`:unique`, `:unique_data`) and fails. As a result, the update mode will always be `:insert` for whatever option set.

The fix ensure the `mode` value is a symbol before comparing it.
