### PR TITLE
Skip CNAME records in DNS SRV parsing - Fix #13952

### DIFF
--- a/lib/msf/core/exploit/dns/enumeration.rb
+++ b/lib/msf/core/exploit/dns/enumeration.rb
@@ -216,7 +216,7 @@ module Enumeration
         next if resp.blank? || resp.answer.blank?
         srv_record_data = []
         resp.answer.each do |r|
-          next if r.type == Dnsruby::RR::IN::CNAME
+          next if r.class == Dnsruby::RR::IN::CNAME
           data = {
             host: r.name.to_s,
             port: r.port,


### PR DESCRIPTION
No idea if this is the correct patch for #13952 but it resolves the issue.