### PR TITLE
allow dns server on different port

### DIFF
--- a/modules/auxiliary/admin/dns/dyn_dns_update.rb
+++ b/modules/auxiliary/admin/dns/dyn_dns_update.rb
@@ -44,7 +44,6 @@ class MetasploitModule < Msf::Auxiliary
       OptAddress.new('CHOST', [false, 'The source address to use for queries and updates'])
     ])
 
-    deregister_options('RPORT')
   end
 
   def record_action(type, type_enum, value, action)

--- a/modules/auxiliary/admin/dns/dyn_dns_update.rb
+++ b/modules/auxiliary/admin/dns/dyn_dns_update.rb
@@ -36,6 +36,7 @@ class MetasploitModule < Msf::Auxiliary
     register_options([
       OptString.new('DOMAIN', [true, 'The domain name']),
       OptAddress.new('RHOST', [true, 'The vulnerable DNS server IP address']),
+      OptPort.new('RPORT', [true, "DNS server port", 53]),
       OptString.new('HOSTNAME', [true, 'The name record you want to add']),
       OptAddress.new('IP', [false, 'The IP you want to assign to the record']),
       OptString.new('VALUE', [false, 'The string to be added with TXT or CNAME record']),
@@ -58,6 +59,7 @@ class MetasploitModule < Msf::Auxiliary
         opts[:src_address6] = datastore['CHOST']
       end
     end
+    opts[:port] = datastore['RPORT']
     resolver = Dnsruby::Resolver.new(opts)
     update   = Dnsruby::Update.new(domain)
     updated  = false


### PR DESCRIPTION
Tell us what this change does. If you're fixing a bug, please mention
the github issue number.

Please ensure you are submitting **from a unique branch** in your [repository](https://github.com/rapid7/metasploit-framework/pull/11086#issuecomment-445506416) to master in Rapid7's.

## Verification

List the steps needed to make sure this thing works

Start a DNS server on a non-standard port - I'm on 5353

- [x] Start `msfconsole`
- [x] `use auxiliary/admin/dns/dyn_dns_update`
- [x] `set RPORT 5353`
- [x] set all the other options
- [x] monitor the DNS logs for update requests
- [x] Run the module
- [x] See the entry in the logs
- [x] Check the update has happened with dig
- [x] Just setting the RPORT so nothing unusual, does it need documenting?

The one thing I can't get it to do is to show the RPORT in the list of options. I've copied code that works from other modules but it won't show up.
