### PR TITLE
Dyn dns update fix

### DIFF
--- a/modules/auxiliary/admin/dns/dyn_dns_update.rb
+++ b/modules/auxiliary/admin/dns/dyn_dns_update.rb
@@ -67,8 +67,11 @@ class MetasploitModule < Msf::Auxiliary
       when action == :resolve
         begin
           answer = resolver.query(fqdn, type)
-          print_good "Found existing #{type} record for #{fqdn}"
-          return true
+          if (answer.answer.count > 0) then
+            print_good "Found existing #{type} record for #{fqdn}"
+            return true
+          end
+          return false
         rescue Dnsruby::ResolvError, IOError => e
           print_good "Did not find an existing #{type} record for #{fqdn}"
           vprint_error "Query failed: #{e.message}"

--- a/modules/auxiliary/admin/dns/dyn_dns_update.rb
+++ b/modules/auxiliary/admin/dns/dyn_dns_update.rb
@@ -36,7 +36,6 @@ class MetasploitModule < Msf::Auxiliary
     register_options([
       OptString.new('DOMAIN', [true, 'The domain name']),
       OptAddress.new('RHOST', [true, 'The vulnerable DNS server IP address']),
-      OptPort.new('RPORT', [true, "DNS server port", 53]),
       OptString.new('HOSTNAME', [true, 'The name record you want to add']),
       OptAddress.new('IP', [false, 'The IP you want to assign to the record']),
       OptString.new('VALUE', [false, 'The string to be added with TXT or CNAME record']),
@@ -59,7 +58,6 @@ class MetasploitModule < Msf::Auxiliary
         opts[:src_address6] = datastore['CHOST']
       end
     end
-    opts[:port] = datastore['RPORT']
     resolver = Dnsruby::Resolver.new(opts)
     update   = Dnsruby::Update.new(domain)
     updated  = false

--- a/modules/auxiliary/admin/dns/dyn_dns_update.rb
+++ b/modules/auxiliary/admin/dns/dyn_dns_update.rb
@@ -36,6 +36,7 @@ class MetasploitModule < Msf::Auxiliary
     register_options([
       OptString.new('DOMAIN', [true, 'The domain name']),
       OptAddress.new('RHOST', [true, 'The vulnerable DNS server IP address']),
+      OptPort.new('RPORT', [true, "DNS server port", 53]),
       OptString.new('HOSTNAME', [true, 'The name record you want to add']),
       OptAddress.new('IP', [false, 'The IP you want to assign to the record']),
       OptString.new('VALUE', [false, 'The string to be added with TXT or CNAME record']),
@@ -58,6 +59,7 @@ class MetasploitModule < Msf::Auxiliary
         opts[:src_address6] = datastore['CHOST']
       end
     end
+    opts[:port] = datastore['RPORT']
     resolver = Dnsruby::Resolver.new(opts)
     update   = Dnsruby::Update.new(domain)
     updated  = false


### PR DESCRIPTION
The resolve function used to always return true, regardless whether the record it was asked to resolve existed or not, this broke some onward calls when they tried to update things that didn't really exist.

## Verification

List the steps needed to make sure this thing works

- Try to update a record that doesn't exist:

```
msf6 auxiliary(admin/dns/dyn_dns_update) > set ACTION UPDATE
ACTION => UPDATE
msf6 auxiliary(admin/dns/dyn_dns_update) > set HOSTNAME new2
HOSTNAME => new2
msf6 auxiliary(admin/dns/dyn_dns_update) > run

[+] Did not find an existing TXT record for new2.digi.int
[*] Sending dynamic DNS add message...
[+] The record 'new2.digi.int => aa' has been added!
[*] Auxiliary module execution completed
```
It gets added

- Now run it again and it will get updated

```
msf6 auxiliary(admin/dns/dyn_dns_update) > run

[+] Found existing TXT record for new2.digi.int
[*] Sending dynamic DNS delete message...
[+] The record 'new2.digi.int => aa' has been deleted!
[*] Sending dynamic DNS add message...
[+] The record 'new2.digi.int => aa' has been added!
[*] Auxiliary module execution completed
msf6 auxiliary(admin/dns/dyn_dns_update) > 
```


