### PR TITLE
Add a login scanner for Jupyter Notebooks

### DIFF
--- a/documentation/modules/auxiliary/scanner/http/jupyter_login.md
+++ b/documentation/modules/auxiliary/scanner/http/jupyter_login.md
@@ -1,0 +1,52 @@
+## Vulnerable Application
+
+This module checks if authentication is required on a Jupyter Lab or Notebook server. If it is, this module will
+bruteforce the password. Jupyter only requires a password to authenticate, usernames are not used. This module is
+compatible with versions 4.3.0 (released 2016-12-08) and newer. [Version 4.3.0][1] is the first version in which
+authentication is required by default.
+
+A note on names, "Jupyter Lab" is the next-generation interface for "Jupyter Notebooks" which was the successor of the
+original IPython Notebook system. This module is compatible with both standard Jupyter Notebook and Jupyter Lab servers.
+
+### Installation
+
+1. Install the latest version of Jupyter from PyPi using pip: `pip install notebook`. The "notebook" package is the core
+  application and is the one whose version number is referenced.
+1. Start Jupyter using `jupyter notebook`, new installs will randomly generate an authentication token and open the
+  browser with it
+1. As of [version 5.3][2], the user will be prompted to set a password the first time they open the UI
+1. With the password set, the module can be tested
+
+## Verification Steps
+
+1. Install the application
+1. Start msfconsole
+1. Do: `use auxiliary/scanner/http/jupyter_login`
+1. Set the `RHOSTS` option
+    * With no other options set, this will only check if authentication is required
+1. Do: `run`
+1. You should see login attempts
+
+## Options
+
+## Scenarios
+
+### Jupyte Notebook 4.3.0
+
+```
+msf5 > use auxiliary/scanner/http/jupyter_login 
+msf5 auxiliary(scanner/http/jupyter_login) > set RHOSTS 192.168.159.128
+RHOSTS => 192.168.159.128
+msf5 auxiliary(scanner/http/jupyter_login) > set PASS_FILE /tmp/passwords.txt
+PASS_FILE => /tmp/passwords.txt
+msf5 auxiliary(scanner/http/jupyter_login) > run
+
+[*] 192.168.159.128:8888 - The server responded that it is running Jupyter version: 4.3.0
+[+] 192.168.159.128:8888 - No password is required.
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+msf5 auxiliary(scanner/http/jupyter_login) >
+```
+
+[1]: https://jupyter-notebook.readthedocs.io/en/stable/changelog.html#release-4-3
+[2]: https://jupyter-notebook.readthedocs.io/en/stable/public_server.html#automatic-password-setup

--- a/documentation/modules/auxiliary/scanner/http/jupyter_login.md
+++ b/documentation/modules/auxiliary/scanner/http/jupyter_login.md
@@ -54,6 +54,8 @@ msf5 auxiliary(scanner/http/jupyter_login) >
 
 ```
 msf5 > use auxiliary/scanner/http/jupyter_login 
+msf5 auxiliary(scanner/http/jupyter_login) > set RHOSTS 192.168.159.128
+RHOSTS => 192.168.159.128
 msf5 auxiliary(scanner/http/jupyter_login) > set PASS_FILE /tmp/passwords.txt
 PASS_FILE => /tmp/passwords.txt
 msf5 auxiliary(scanner/http/jupyter_login) > run

--- a/documentation/modules/auxiliary/scanner/http/jupyter_login.md
+++ b/documentation/modules/auxiliary/scanner/http/jupyter_login.md
@@ -11,10 +11,10 @@ original IPython Notebook system. This module is compatible with both standard J
 ### Installation
 
 1. Install the latest version of Jupyter from PyPi using pip: `pip install notebook`. The "notebook" package is the core
-  application and is the one whose version number is referenced.
-1. Start Jupyter using `jupyter notebook`, new installs will randomly generate an authentication token and open the
-  browser with it
-1. As of [version 5.3][2], the user will be prompted to set a password the first time they open the UI
+  application and is the one whose version number is used as the Jupyter version number referred to in this document.
+1. Start Jupyter using `jupyter notebook`
+    * New installs will randomly generate an authentication token and open the browser with it
+    * As of [version 5.3][2], the user will be prompted to set a password the first time they open the UI
 1. With the password set, the module can be tested
 
 ## Verification Steps
@@ -25,13 +25,15 @@ original IPython Notebook system. This module is compatible with both standard J
 1. Set the `RHOSTS` option
     * With no other options set, this will only check if authentication is required
 1. Do: `run`
-1. You should see login attempts
+1. You should the server version
+1. If password options (such as `PASS_FILE`) where specified, and the server requires authentication then you should see
+   login attempts
 
 ## Options
 
 ## Scenarios
 
-### Jupyte Notebook 4.3.0
+### Jupyter Notebook 4.3.0 With No Authentication Requirement
 
 ```
 msf5 > use auxiliary/scanner/http/jupyter_login 
@@ -43,6 +45,22 @@ msf5 auxiliary(scanner/http/jupyter_login) > run
 
 [*] 192.168.159.128:8888 - The server responded that it is running Jupyter version: 4.3.0
 [+] 192.168.159.128:8888 - No password is required.
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+msf5 auxiliary(scanner/http/jupyter_login) >
+```
+
+### Jupyter Notebook 6.0.2 With A Password Set
+
+```
+msf5 > use auxiliary/scanner/http/jupyter_login 
+msf5 auxiliary(scanner/http/jupyter_login) > set PASS_FILE /tmp/passwords.txt
+PASS_FILE => /tmp/passwords.txt
+msf5 auxiliary(scanner/http/jupyter_login) > run
+
+[*] 192.168.159.128:8888 - The server responded that it is running Jupyter version: 6.0.2
+[-] 192.168.159.128:8888 - LOGIN FAILED: :Password (Incorrect)
+[+] 192.168.159.128:8888 - Login Successful: :Password1
 [*] Scanned 1 of 1 hosts (100% complete)
 [*] Auxiliary module execution completed
 msf5 auxiliary(scanner/http/jupyter_login) >

--- a/lib/metasploit/framework/community_string_collection.rb
+++ b/lib/metasploit/framework/community_string_collection.rb
@@ -6,7 +6,7 @@ module Metasploit
     # This class is responsible for taking datastore options from the snmp_login module
     # and yielding appropriate {Metasploit::Framework::Credential}s to the {Metasploit::Framework::LoginScanner::SNMP}.
     # This one has to be different from credentialCollection as it will only have a {Metasploit::Framework::Credential#public}
-    # It may be slightly confusing that the attribues are called password and pass_file, because this is what the legacy
+    # It may be slightly confusing that the attributes are called password and pass_file, because this is what the legacy
     # module used. However, community Strings are now considered more to be public credentials than private ones.
     class CommunityStringCollection
       # @!attribute pass_file

--- a/lib/metasploit/framework/credential_collection.rb
+++ b/lib/metasploit/framework/credential_collection.rb
@@ -1,233 +1,292 @@
 require 'metasploit/framework/credential'
 
-class Metasploit::Framework::CredentialCollection
+module Metasploit::Framework
 
-  # @!attribute additional_privates
-  #   Additional privates to be combined
-  #
-  #   @return [Array<String>]
-  attr_accessor :additional_privates
+    class PrivateCredentialCollection
+      # @!attribute additional_privates
+      #   Additional privates to be combined
+      #
+      #   @return [Array<String>]
+      attr_accessor :additional_privates
 
-  # @!attribute additional_publics
-  #   Additional public to be combined
-  #
-  #   @return [Array<String>]
-  attr_accessor :additional_publics
+      # @!attribute blank_passwords
+      #   Whether each username should be tried with a blank password
+      #   @return [Boolean]
+      attr_accessor :blank_passwords
 
-  # @!attribute blank_passwords
-  #   Whether each username should be tried with a blank password
-  #   @return [Boolean]
-  attr_accessor :blank_passwords
+      # @!attribute pass_file
+      #   Path to a file containing passwords, one per line
+      #   @return [String]
+      attr_accessor :pass_file
 
-  # @!attribute pass_file
-  #   Path to a file containing passwords, one per line
-  #   @return [String]
-  attr_accessor :pass_file
+      # @!attribute password
+      #   @return [String]
+      attr_accessor :password
 
-  # @!attribute password
-  #   @return [String]
-  attr_accessor :password
+      # @!attribute prepended_creds
+      #   List of credentials to be tried before any others
+      #
+      #   @see #prepend_cred
+      #   @return [Array<Credential>]
+      attr_accessor :prepended_creds
 
-  # @!attribute prepended_creds
-  #   List of credentials to be tried before any others
-  #
-  #   @see #prepend_cred
-  #   @return [Array<Credential>]
-  attr_accessor :prepended_creds
+      # @!attribute realm
+      #   @return [String]
+      attr_accessor :realm
 
-  # @!attribute realm
-  #   @return [String]
-  attr_accessor :realm
-
-  # @!attribute user_as_pass
-  #   Whether each username should be tried as a password for that user
-  #   @return [Boolean]
-  attr_accessor :user_as_pass
-
-  # @!attribute user_file
-  #   Path to a file containing usernames, one per line
-  #   @return [String]
-  attr_accessor :user_file
-
-  # @!attribute username
-  #   @return [String]
-  attr_accessor :username
-
-  # @!attribute userpass_file
-  #   Path to a file containing usernames and passwords separated by a space,
-  #   one pair per line
-  #   @return [String]
-  attr_accessor :userpass_file
-
-  # @option opts [Boolean] :blank_passwords See {#blank_passwords}
-  # @option opts [String] :pass_file See {#pass_file}
-  # @option opts [String] :password See {#password}
-  # @option opts [Array<Credential>] :prepended_creds ([]) See {#prepended_creds}
-  # @option opts [Boolean] :user_as_pass See {#user_as_pass}
-  # @option opts [String] :user_file See {#user_file}
-  # @option opts [String] :username See {#username}
-  # @option opts [String] :userpass_file See {#userpass_file}
-  def initialize(opts = {})
-    opts.each do |attribute, value|
-      public_send("#{attribute}=", value)
-    end
-    self.prepended_creds     ||= []
-    self.additional_privates ||= []
-    self.additional_publics  ||= []
-  end
-
-  # Adds a string as an addition private credential
-  # to be combined in the collection.
-  #
-  # @param [String] private_str the string to use as a private
-  # @return [void]
-  def add_private(private_str='')
-    additional_privates << private_str
-  end
-
-  # Adds a string as an addition public credential
-  # to be combined in the collection.
-  #
-  # @param [String] public_str the string to use as a public
-  # @return [void]
-  def add_public(public_str='')
-    additional_publics << public_str
-  end
-
-  # Add {Credential credentials} that will be yielded by {#each}
-  #
-  # @see prepended_creds
-  # @param cred [Credential]
-  # @return [self]
-  def prepend_cred(cred)
-    prepended_creds.unshift cred
-    self
-  end
-
-  # Combines all the provided credential sources into a stream of {Credential}
-  # objects, yielding them one at a time
-  #
-  # @yieldparam credential [Metasploit::Framework::Credential]
-  # @return [void]
-  def each
-    if pass_file.present?
-      pass_fd = File.open(pass_file, 'r:binary')
-    end
-
-    prepended_creds.each { |c| yield c }
-
-    if username.present?
-      if password.present?
-        yield Metasploit::Framework::Credential.new(public: username, private: password, realm: realm, private_type: private_type(password))
-      end
-      if user_as_pass
-        yield Metasploit::Framework::Credential.new(public: username, private: username, realm: realm, private_type: :password)
-      end
-      if blank_passwords
-        yield Metasploit::Framework::Credential.new(public: username, private: "", realm: realm, private_type: :password)
-      end
-      if pass_fd
-        pass_fd.each_line do |pass_from_file|
-          pass_from_file.chomp!
-          yield Metasploit::Framework::Credential.new(public: username, private: pass_from_file, realm: realm, private_type: private_type(pass_from_file))
+      # @option opts [Boolean] :blank_passwords See {#blank_passwords}
+      # @option opts [String] :pass_file See {#pass_file}
+      # @option opts [String] :password See {#password}
+      # @option opts [Array<Credential>] :prepended_creds ([]) See {#prepended_creds}
+      # @option opts [Boolean] :user_as_pass See {#user_as_pass}
+      # @option opts [String] :user_file See {#user_file}
+      # @option opts [String] :username See {#username}
+      # @option opts [String] :userpass_file See {#userpass_file}
+      def initialize(opts = {})
+        opts.each do |attribute, value|
+          public_send("#{attribute}=", value)
         end
-        pass_fd.seek(0)
+        self.prepended_creds     ||= []
+        self.additional_privates ||= []
       end
-      additional_privates.each do |add_private|
-        yield Metasploit::Framework::Credential.new(public: username, private: add_private, realm: realm, private_type: private_type(add_private))
+
+      # Adds a string as an addition private credential
+      # to be combined in the collection.
+      #
+      # @param [String] private_str the string to use as a private
+      # @return [void]
+      def add_private(private_str='')
+        additional_privates << private_str
+      end
+
+      # Add {Credential credentials} that will be yielded by {#each}
+      #
+      # @see prepended_creds
+      # @param cred [Credential]
+      # @return [self]
+      def prepend_cred(cred)
+        prepended_creds.unshift cred
+        self
+      end
+
+      # Combines all the provided credential sources into a stream of {Credential}
+      # objects, yielding them one at a time
+      #
+      # @yieldparam credential [Metasploit::Framework::Credential]
+      # @return [void]
+      def each
+        if pass_file.present?
+          pass_fd = File.open(pass_file, 'r:binary')
+        end
+
+        prepended_creds.each { |c| yield c }
+
+        if password.present?
+          yield Metasploit::Framework::Credential.new(private: password, realm: realm, private_type: private_type(password))
+        end
+        if blank_passwords
+          yield Metasploit::Framework::Credential.new(private: "", realm: realm, private_type: :password)
+        end
+        if pass_fd
+          pass_fd.each_line do |pass_from_file|
+            pass_from_file.chomp!
+            yield Metasploit::Framework::Credential.new(private: pass_from_file, realm: realm, private_type: private_type(pass_from_file))
+          end
+          pass_fd.seek(0)
+        end
+        additional_privates.each do |add_private|
+          yield Metasploit::Framework::Credential.new(private: add_private, realm: realm, private_type: private_type(add_private))
+        end
+
+      ensure
+        pass_fd.close if pass_fd && !pass_fd.closed?
+      end
+
+      # Returns true when #each will have no results to iterate
+      def empty?
+        prepended_creds.empty? && !has_privates?
+      end
+
+      def has_privates?
+        password.present? || pass_file.present? || !additional_privates.empty? || blank_passwords
+      end
+
+      protected
+
+      def private_type(private)
+        if private =~ /[0-9a-f]{32}:[0-9a-f]{32}/
+          :ntlm_hash
+        elsif private =~ /^md5([a-f0-9]{32})$/
+          :postgres_md5
+        else
+          :password
+        end
       end
     end
 
-    if user_file.present?
-      File.open(user_file, 'r:binary') do |user_fd|
-        user_fd.each_line do |user_from_file|
-          user_from_file.chomp!
-          if password.present?
-            yield Metasploit::Framework::Credential.new(public: user_from_file, private: password, realm: realm, private_type: private_type(password) )
+  class CredentialCollection < PrivateCredentialCollection
+
+    # @!attribute additional_publics
+    #   Additional public to be combined
+    #
+    #   @return [Array<String>]
+    attr_accessor :additional_publics
+
+    # @!attribute user_as_pass
+    #   Whether each username should be tried as a password for that user
+    #   @return [Boolean]
+    attr_accessor :user_as_pass
+
+    # @!attribute user_file
+    #   Path to a file containing usernames, one per line
+    #   @return [String]
+    attr_accessor :user_file
+
+    # @!attribute username
+    #   @return [String]
+    attr_accessor :username
+
+    # @!attribute userpass_file
+    #   Path to a file containing usernames and passwords separated by a space,
+    #   one pair per line
+    #   @return [String]
+    attr_accessor :userpass_file
+
+    # @option opts [Boolean] :blank_passwords See {#blank_passwords}
+    # @option opts [String] :pass_file See {#pass_file}
+    # @option opts [String] :password See {#password}
+    # @option opts [Array<Credential>] :prepended_creds ([]) See {#prepended_creds}
+    # @option opts [Boolean] :user_as_pass See {#user_as_pass}
+    # @option opts [String] :user_file See {#user_file}
+    # @option opts [String] :username See {#username}
+    # @option opts [String] :userpass_file See {#userpass_file}
+    def initialize(opts = {})
+      super
+      self.additional_publics  ||= []
+    end
+
+    # Adds a string as an addition public credential
+    # to be combined in the collection.
+    #
+    # @param [String] public_str the string to use as a public
+    # @return [void]
+    def add_public(public_str='')
+      additional_publics << public_str
+    end
+
+    # Combines all the provided credential sources into a stream of {Credential}
+    # objects, yielding them one at a time
+    #
+    # @yieldparam credential [Metasploit::Framework::Credential]
+    # @return [void]
+    def each
+      if pass_file.present?
+        pass_fd = File.open(pass_file, 'r:binary')
+      end
+
+      prepended_creds.each { |c| yield c }
+
+      if username.present?
+        if password.present?
+          yield Metasploit::Framework::Credential.new(public: username, private: password, realm: realm, private_type: private_type(password))
+        end
+        if user_as_pass
+          yield Metasploit::Framework::Credential.new(public: username, private: username, realm: realm, private_type: :password)
+        end
+        if blank_passwords
+          yield Metasploit::Framework::Credential.new(public: username, private: "", realm: realm, private_type: :password)
+        end
+        if pass_fd
+          pass_fd.each_line do |pass_from_file|
+            pass_from_file.chomp!
+            yield Metasploit::Framework::Credential.new(public: username, private: pass_from_file, realm: realm, private_type: private_type(pass_from_file))
           end
-          if user_as_pass
-            yield Metasploit::Framework::Credential.new(public: user_from_file, private: user_from_file, realm: realm, private_type: :password)
-          end
-          if blank_passwords
-            yield Metasploit::Framework::Credential.new(public: user_from_file, private: "", realm: realm, private_type: :password)
-          end
-          if pass_fd
-            pass_fd.each_line do |pass_from_file|
-              pass_from_file.chomp!
-              yield Metasploit::Framework::Credential.new(public: user_from_file, private: pass_from_file, realm: realm, private_type: private_type(pass_from_file))
+          pass_fd.seek(0)
+        end
+        additional_privates.each do |add_private|
+          yield Metasploit::Framework::Credential.new(public: username, private: add_private, realm: realm, private_type: private_type(add_private))
+        end
+      end
+
+      if user_file.present?
+        File.open(user_file, 'r:binary') do |user_fd|
+          user_fd.each_line do |user_from_file|
+            user_from_file.chomp!
+            if password.present?
+              yield Metasploit::Framework::Credential.new(public: user_from_file, private: password, realm: realm, private_type: private_type(password) )
             end
-            pass_fd.seek(0)
-          end
-          additional_privates.each do |add_private|
-            yield Metasploit::Framework::Credential.new(public: user_from_file, private: add_private, realm: realm, private_type: private_type(add_private))
+            if user_as_pass
+              yield Metasploit::Framework::Credential.new(public: user_from_file, private: user_from_file, realm: realm, private_type: :password)
+            end
+            if blank_passwords
+              yield Metasploit::Framework::Credential.new(public: user_from_file, private: "", realm: realm, private_type: :password)
+            end
+            if pass_fd
+              pass_fd.each_line do |pass_from_file|
+                pass_from_file.chomp!
+                yield Metasploit::Framework::Credential.new(public: user_from_file, private: pass_from_file, realm: realm, private_type: private_type(pass_from_file))
+              end
+              pass_fd.seek(0)
+            end
+            additional_privates.each do |add_private|
+              yield Metasploit::Framework::Credential.new(public: user_from_file, private: add_private, realm: realm, private_type: private_type(add_private))
+            end
           end
         end
       end
-    end
 
-    if userpass_file.present?
-      File.open(userpass_file, 'r:binary') do |userpass_fd|
-        userpass_fd.each_line do |line|
-          user, pass = line.split(" ", 2)
-          if pass.blank?
-            pass = ''
-          else
-            pass.chomp!
+      if userpass_file.present?
+        File.open(userpass_file, 'r:binary') do |userpass_fd|
+          userpass_fd.each_line do |line|
+            user, pass = line.split(" ", 2)
+            if pass.blank?
+              pass = ''
+            else
+              pass.chomp!
+            end
+            yield Metasploit::Framework::Credential.new(public: user, private: pass, realm: realm)
           end
-          yield Metasploit::Framework::Credential.new(public: user, private: pass, realm: realm)
         end
       end
-    end
 
-    additional_publics.each do |add_public|
-      if password.present?
-        yield Metasploit::Framework::Credential.new(public: add_public, private: password, realm: realm, private_type: private_type(password) )
-      end
-      if user_as_pass
-        yield Metasploit::Framework::Credential.new(public: add_public, private: user_from_file, realm: realm, private_type: :password)
-      end
-      if blank_passwords
-        yield Metasploit::Framework::Credential.new(public: add_public, private: "", realm: realm, private_type: :password)
-      end
-      if pass_fd
-        pass_fd.each_line do |pass_from_file|
-          pass_from_file.chomp!
-          yield Metasploit::Framework::Credential.new(public: add_public, private: pass_from_file, realm: realm, private_type: private_type(pass_from_file))
+      additional_publics.each do |add_public|
+        if password.present?
+          yield Metasploit::Framework::Credential.new(public: add_public, private: password, realm: realm, private_type: private_type(password) )
         end
-        pass_fd.seek(0)
+        if user_as_pass
+          yield Metasploit::Framework::Credential.new(public: add_public, private: user_from_file, realm: realm, private_type: :password)
+        end
+        if blank_passwords
+          yield Metasploit::Framework::Credential.new(public: add_public, private: "", realm: realm, private_type: :password)
+        end
+        if pass_fd
+          pass_fd.each_line do |pass_from_file|
+            pass_from_file.chomp!
+            yield Metasploit::Framework::Credential.new(public: add_public, private: pass_from_file, realm: realm, private_type: private_type(pass_from_file))
+          end
+          pass_fd.seek(0)
+        end
+        additional_privates.each do |add_private|
+          yield Metasploit::Framework::Credential.new(public: add_public, private: add_private, realm: realm, private_type: private_type(add_private))
+        end
       end
-      additional_privates.each do |add_private|
-        yield Metasploit::Framework::Credential.new(public: add_public, private: add_private, realm: realm, private_type: private_type(add_private))
-      end
+
+    ensure
+      pass_fd.close if pass_fd && !pass_fd.closed?
     end
 
-  ensure
-    pass_fd.close if pass_fd && !pass_fd.closed?
-  end
-
-  # Returns true when #each will have no results to iterate
-  def empty?
-    prepended_creds.empty? && !has_users? || (has_users? && !has_privates?)
-  end
-
-  def has_users?
-    username.present? || user_file.present? || userpass_file.present? || !additional_publics.empty?
-  end
-
-  def has_privates?
-    password.present? || pass_file.present? || userpass_file.present? || !additional_privates.empty? || blank_passwords || user_as_pass
-  end
-
-  private
-
-  def private_type(private)
-    if private =~ /[0-9a-f]{32}:[0-9a-f]{32}/
-      :ntlm_hash
-    elsif private =~ /^md5([a-f0-9]{32})$/
-      :postgres_md5
-    else
-      :password
+    # Returns true when #each will have no results to iterate
+    def empty?
+      prepended_creds.empty? && !has_users? || (has_users? && !has_privates?)
     end
-  end
 
+    def has_users?
+      username.present? || user_file.present? || userpass_file.present? || !additional_publics.empty?
+    end
+
+    def has_privates?
+      super || userpass_file.present? || user_as_pass
+    end
+
+  end
 end

--- a/lib/metasploit/framework/credential_collection.rb
+++ b/lib/metasploit/framework/credential_collection.rb
@@ -2,127 +2,127 @@ require 'metasploit/framework/credential'
 
 module Metasploit::Framework
 
-    class PrivateCredentialCollection
-      # @!attribute additional_privates
-      #   Additional privates to be combined
-      #
-      #   @return [Array<String>]
-      attr_accessor :additional_privates
+  class PrivateCredentialCollection
+    # @!attribute additional_privates
+    #   Additional privates to be combined
+    #
+    #   @return [Array<String>]
+    attr_accessor :additional_privates
 
-      # @!attribute blank_passwords
-      #   Whether each username should be tried with a blank password
-      #   @return [Boolean]
-      attr_accessor :blank_passwords
+    # @!attribute blank_passwords
+    #   Whether each username should be tried with a blank password
+    #   @return [Boolean]
+    attr_accessor :blank_passwords
 
-      # @!attribute pass_file
-      #   Path to a file containing passwords, one per line
-      #   @return [String]
-      attr_accessor :pass_file
+    # @!attribute pass_file
+    #   Path to a file containing passwords, one per line
+    #   @return [String]
+    attr_accessor :pass_file
 
-      # @!attribute password
-      #   @return [String]
-      attr_accessor :password
+    # @!attribute password
+    #   @return [String]
+    attr_accessor :password
 
-      # @!attribute prepended_creds
-      #   List of credentials to be tried before any others
-      #
-      #   @see #prepend_cred
-      #   @return [Array<Credential>]
-      attr_accessor :prepended_creds
+    # @!attribute prepended_creds
+    #   List of credentials to be tried before any others
+    #
+    #   @see #prepend_cred
+    #   @return [Array<Credential>]
+    attr_accessor :prepended_creds
 
-      # @!attribute realm
-      #   @return [String]
-      attr_accessor :realm
+    # @!attribute realm
+    #   @return [String]
+    attr_accessor :realm
 
-      # @option opts [Boolean] :blank_passwords See {#blank_passwords}
-      # @option opts [String] :pass_file See {#pass_file}
-      # @option opts [String] :password See {#password}
-      # @option opts [Array<Credential>] :prepended_creds ([]) See {#prepended_creds}
-      # @option opts [Boolean] :user_as_pass See {#user_as_pass}
-      # @option opts [String] :user_file See {#user_file}
-      # @option opts [String] :username See {#username}
-      # @option opts [String] :userpass_file See {#userpass_file}
-      def initialize(opts = {})
-        opts.each do |attribute, value|
-          public_send("#{attribute}=", value)
-        end
-        self.prepended_creds     ||= []
-        self.additional_privates ||= []
+    # @option opts [Boolean] :blank_passwords See {#blank_passwords}
+    # @option opts [String] :pass_file See {#pass_file}
+    # @option opts [String] :password See {#password}
+    # @option opts [Array<Credential>] :prepended_creds ([]) See {#prepended_creds}
+    # @option opts [Boolean] :user_as_pass See {#user_as_pass}
+    # @option opts [String] :user_file See {#user_file}
+    # @option opts [String] :username See {#username}
+    # @option opts [String] :userpass_file See {#userpass_file}
+    def initialize(opts = {})
+      opts.each do |attribute, value|
+        public_send("#{attribute}=", value)
+      end
+      self.prepended_creds     ||= []
+      self.additional_privates ||= []
+    end
+
+    # Adds a string as an addition private credential
+    # to be combined in the collection.
+    #
+    # @param [String] private_str the string to use as a private
+    # @return [void]
+    def add_private(private_str='')
+      additional_privates << private_str
+    end
+
+    # Add {Credential credentials} that will be yielded by {#each}
+    #
+    # @see prepended_creds
+    # @param cred [Credential]
+    # @return [self]
+    def prepend_cred(cred)
+      prepended_creds.unshift cred
+      self
+    end
+
+    # Combines all the provided credential sources into a stream of {Credential}
+    # objects, yielding them one at a time
+    #
+    # @yieldparam credential [Metasploit::Framework::Credential]
+    # @return [void]
+    def each
+      if pass_file.present?
+        pass_fd = File.open(pass_file, 'r:binary')
       end
 
-      # Adds a string as an addition private credential
-      # to be combined in the collection.
-      #
-      # @param [String] private_str the string to use as a private
-      # @return [void]
-      def add_private(private_str='')
-        additional_privates << private_str
+      prepended_creds.each { |c| yield c }
+
+      if password.present?
+        yield Metasploit::Framework::Credential.new(private: password, realm: realm, private_type: private_type(password))
+      end
+      if blank_passwords
+        yield Metasploit::Framework::Credential.new(private: "", realm: realm, private_type: :password)
+      end
+      if pass_fd
+        pass_fd.each_line do |pass_from_file|
+          pass_from_file.chomp!
+          yield Metasploit::Framework::Credential.new(private: pass_from_file, realm: realm, private_type: private_type(pass_from_file))
+        end
+        pass_fd.seek(0)
+      end
+      additional_privates.each do |add_private|
+        yield Metasploit::Framework::Credential.new(private: add_private, realm: realm, private_type: private_type(add_private))
       end
 
-      # Add {Credential credentials} that will be yielded by {#each}
-      #
-      # @see prepended_creds
-      # @param cred [Credential]
-      # @return [self]
-      def prepend_cred(cred)
-        prepended_creds.unshift cred
-        self
-      end
+    ensure
+      pass_fd.close if pass_fd && !pass_fd.closed?
+    end
 
-      # Combines all the provided credential sources into a stream of {Credential}
-      # objects, yielding them one at a time
-      #
-      # @yieldparam credential [Metasploit::Framework::Credential]
-      # @return [void]
-      def each
-        if pass_file.present?
-          pass_fd = File.open(pass_file, 'r:binary')
-        end
+    # Returns true when #each will have no results to iterate
+    def empty?
+      prepended_creds.empty? && !has_privates?
+    end
 
-        prepended_creds.each { |c| yield c }
+    def has_privates?
+      password.present? || pass_file.present? || !additional_privates.empty? || blank_passwords
+    end
 
-        if password.present?
-          yield Metasploit::Framework::Credential.new(private: password, realm: realm, private_type: private_type(password))
-        end
-        if blank_passwords
-          yield Metasploit::Framework::Credential.new(private: "", realm: realm, private_type: :password)
-        end
-        if pass_fd
-          pass_fd.each_line do |pass_from_file|
-            pass_from_file.chomp!
-            yield Metasploit::Framework::Credential.new(private: pass_from_file, realm: realm, private_type: private_type(pass_from_file))
-          end
-          pass_fd.seek(0)
-        end
-        additional_privates.each do |add_private|
-          yield Metasploit::Framework::Credential.new(private: add_private, realm: realm, private_type: private_type(add_private))
-        end
+    protected
 
-      ensure
-        pass_fd.close if pass_fd && !pass_fd.closed?
-      end
-
-      # Returns true when #each will have no results to iterate
-      def empty?
-        prepended_creds.empty? && !has_privates?
-      end
-
-      def has_privates?
-        password.present? || pass_file.present? || !additional_privates.empty? || blank_passwords
-      end
-
-      protected
-
-      def private_type(private)
-        if private =~ /[0-9a-f]{32}:[0-9a-f]{32}/
-          :ntlm_hash
-        elsif private =~ /^md5([a-f0-9]{32})$/
-          :postgres_md5
-        else
-          :password
-        end
+    def private_type(private)
+      if private =~ /[0-9a-f]{32}:[0-9a-f]{32}/
+        :ntlm_hash
+      elsif private =~ /^md5([a-f0-9]{32})$/
+        :postgres_md5
+      else
+        :password
       end
     end
+  end
 
   class CredentialCollection < PrivateCredentialCollection
 

--- a/lib/metasploit/framework/login_scanner/jupyter.rb
+++ b/lib/metasploit/framework/login_scanner/jupyter.rb
@@ -1,0 +1,60 @@
+require 'metasploit/framework/login_scanner/http'
+
+module Metasploit
+  module Framework
+    module LoginScanner
+
+      # Jupyter login scanner
+      class Jupyter < HTTP
+
+        # Inherit LIKELY_PORTS,LIKELY_SERVICE_NAMES, and REALM_KEY from HTTP
+        CAN_GET_SESSION = true
+        DEFAULT_PORT    = 8888
+        PRIVATE_TYPES   = [ :password ]
+
+        # (see Base#set_sane_defaults)
+        def set_sane_defaults
+          self.uri = '/login' if self.uri.nil?
+          self.method = 'POST' if self.method.nil?
+
+          super
+        end
+
+        def attempt_login(credential)
+          result_opts = {
+            credential: credential,
+            host: host,
+            port: port,
+            protocol: 'tcp',
+            service_name: ssl ? 'https' : 'http'
+          }
+
+          begin
+            res = send_request({'method'=> 'GET', 'uri' => uri})
+            vars_post = {'password' => credential.private }
+            unless (node = res.get_html_document.xpath('//form//input[@name="_xsrf"]')).empty?
+              # versions < 4.3.1 do not use this field
+              vars_post['_xsrf'] = node.first['value']
+            end
+
+            res = send_request({
+              'method' => 'POST',
+              'uri' => uri,
+              'cookie' => res.get_cookies,
+              'vars_post' => vars_post
+            })
+
+            if res&.code == 302 && res.headers['Location']
+              result_opts.merge!(status: Metasploit::Model::Login::Status::SUCCESSFUL, proof: res.headers)
+            else
+              result_opts.merge!(status: Metasploit::Model::Login::Status::INCORRECT, proof: res)
+            end
+          rescue ::EOFError, Errno::ETIMEDOUT ,Errno::ECONNRESET, Rex::ConnectionError, OpenSSL::SSL::SSLError, ::Timeout::Error => e
+            result_opts.merge!(status: Metasploit::Model::Login::Status::UNABLE_TO_CONNECT, proof: e)
+          end
+          Result.new(result_opts)
+        end
+      end
+    end
+  end
+end

--- a/lib/metasploit/framework/login_scanner/jupyter.rb
+++ b/lib/metasploit/framework/login_scanner/jupyter.rb
@@ -32,8 +32,9 @@ module Metasploit
           begin
             res = send_request({'method'=> 'GET', 'uri' => uri})
             vars_post = {'password' => credential.private }
+
+            # versions < 4.3.1 do not use this field
             unless (node = res.get_html_document.xpath('//form//input[@name="_xsrf"]')).empty?
-              # versions < 4.3.1 do not use this field
               vars_post['_xsrf'] = node.first['value']
             end
 
@@ -49,7 +50,7 @@ module Metasploit
             else
               result_opts.merge!(status: Metasploit::Model::Login::Status::INCORRECT, proof: res)
             end
-          rescue ::EOFError, Errno::ETIMEDOUT ,Errno::ECONNRESET, Rex::ConnectionError, OpenSSL::SSL::SSLError, ::Timeout::Error => e
+          rescue ::EOFError, Errno::ETIMEDOUT, Errno::ECONNRESET, Rex::ConnectionError, OpenSSL::SSL::SSLError, ::Timeout::Error => e
             result_opts.merge!(status: Metasploit::Model::Login::Status::UNABLE_TO_CONNECT, proof: e)
           end
           Result.new(result_opts)

--- a/modules/auxiliary/scanner/http/jupyter_login.rb
+++ b/modules/auxiliary/scanner/http/jupyter_login.rb
@@ -1,0 +1,112 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'metasploit/framework/credential_collection'
+require 'metasploit/framework/login_scanner/jupyter'
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Auxiliary::Scanner
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Auxiliary::Report
+  include Msf::Auxiliary::AuthBrute
+
+  def initialize
+    super(
+      'Name'           => 'Jupyter Login Utility',
+      'Description'    => %q{
+        This module checks if authentication is required on a Jupyter Lab or Notebook server. If it is, this module will
+        bruteforce the password. Jupyter only requires a password to authenticate, usernames are not used. This module
+        is compatible with versions 4.3.0 (released 2016-12-08) and newer.
+      },
+      'Author'         => [ 'Spencer McIntyre' ],
+      'License'        => MSF_LICENSE
+    )
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [ true,  'The path to the Jupyter application', '/' ]),
+        Opt::RPORT(8888)
+      ])
+
+    deregister_options('PASSWORD_SPRAY')
+    deregister_options('DB_ALL_CREDS', 'DB_ALL_USERS', 'HttpUsername', 'STOP_ON_SUCCESS', 'USERNAME', 'USERPASS_FILE', 'USER_AS_PASS', 'USER_FILE')
+
+    register_autofilter_ports([ 80, 443, 8888 ])
+  end
+
+  def requires_password?(ip)
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'tree')
+    })
+
+    return false if res&.code == 200
+    destination = res.headers['Location'].split('?', 2)[0]
+    return true if destination.ends_with?(normalize_uri(target_uri.path, 'login'))
+    fail_with(Failure::UnexpectedReply, "#{peer} - The server responded with a redirect that did not match a known fingerprint")
+  end
+
+  def run_host(ip)
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'api')
+    })
+    version = res.get_json_document.dig('version')
+    if version.nil?
+      print_error "#{peer} - The server does not appear to be running Jupyter (failed to fetch the API version)"
+      return
+    end
+    vprint_status "#{peer} - The server responded that it is running Jupyter version: #{version}"
+
+    unless requires_password?(ip)
+      print_good "#{peer} - No password is required."
+      report_vuln(
+        :host        => ip,
+        :port        => rport,
+        :proto       => 'tcp',
+        :sname       => (ssl ? 'https' : 'http'),
+        :name        => "Unauthenticated Jupyter Access",
+        :info        => "Module #{self.fullname} confirmed access to the Jupyter application with no authentication"
+      )
+      return
+    end
+
+    cred_collection = Metasploit::Framework::PrivateCredentialCollection.new(
+      blank_passwords: datastore['BLANK_PASSWORDS'],
+      pass_file: datastore['PASS_FILE'],
+      password: datastore['PASSWORD']
+    )
+
+    scanner = Metasploit::Framework::LoginScanner::Jupyter.new(
+      configure_http_login_scanner(
+        uri: normalize_uri(target_uri.path, 'login'),
+        cred_details: cred_collection,
+        bruteforce_speed: datastore['BRUTEFORCE_SPEED'],
+        connection_timeout: 10,
+        http_password: datastore['HttpPassword'],
+        # there is only one password and no username, so don't bother continuing
+        stop_on_success: true
+      )
+    )
+
+    scanner.scan! do |result|
+      credential_data = result.to_h
+      credential_data.merge!(
+          module_fullname: fullname,
+          workspace_id: myworkspace_id
+      )
+      if result.success?
+        credential_core = create_credential(credential_data)
+        credential_data[:core] = credential_core
+        create_credential_login(credential_data)
+
+        print_good "#{peer} - Login Successful: #{result.credential}"
+      else
+        invalidate_login(credential_data)
+        vprint_error "#{peer} - LOGIN FAILED: #{result.credential} (#{result.status})"
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a Jupyter login scanner that will:

* Check if authentication is required (just set `RHOST` and `RPORT`) and if it is not, log a vulnerability
* If password options are specified, it will attempt to brute force the password

I also refactored the `CredentialCollection` class into `PrivateCredentialCollection` and `CredentialCollection` where `PrivateCredentialCollection` is suitable for use in scenarios where there is no "public" information ie a username. This is the case with Jupyter, where authentication only uses a password.

This supports Jupyter since version 4.3.0 (released over 3 years ago on 2016-12-08). Main reason that it doesn't support older versions is that the `api` endpoint doesn't return the version, so it's a bit harder to fingerprint that the remote endpoint is in fact Jupyter.

## Verification

List the steps needed to make sure this thing works

- [x] Install Jupyter (latest version is 6.x)
    - [ ] Start Jupyter, you should be prompted to set a password the first time, keep it running for the "Authenticated test"
- [x] Start `msfconsole`
- [x] Use `auxiliary/scanner/http/jupyter_login`
* Authenticated test
    - [x] Start Jupyter with: `jupyter notebook`
    - [x] Run the module with a short password list and see it login (assuming the password you set is in the short list)
* Unauthenticated test
    - [x] Start Jupyter with: `jupyter notebook --ip='*' --NotebookApp.token='' --NotebookApp.password=''` to disable authentication
    - [x] Run the module and see it report that authentication is not required

## Example

```
msf5 > use auxiliary/scanner/http/jupyter_login 
msf5 auxiliary(scanner/http/jupyter_login) > set RHOSTS 192.168.159.128
RHOSTS => 192.168.159.128
msf5 auxiliary(scanner/http/jupyter_login) > set PASS_FILE /tmp/passwords.txt
PASS_FILE => /tmp/passwords.txt
msf5 auxiliary(scanner/http/jupyter_login) > run
[*] 192.168.159.128:8888 - The server responded that it is running Jupyter version: 4.3.0
[+] 192.168.159.128:8888 - No password is required.
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf5 auxiliary(scanner/http/jupyter_login) >
```