### PR TITLE
Networking Scripts w/o DB (#13962)

### DIFF
--- a/documentation/modules/auxiliary/admin/networking/brocade_config.md
+++ b/documentation/modules/auxiliary/admin/networking/brocade_config.md
@@ -6,8 +6,127 @@ This module imports a Brocade configuration file into the database.
 This is similar to `post/networking/gather/enum_brocade` only access isn't required,
 and assumes you already have the file.
 
+### Example Config
+
 Example files for import can be found on git, like
 [this](https://raw.githubusercontent.com/h00die/MSF-Testing-Scripts/master/brocade_08.0.30hT311_ic_icx6430.conf).
+
+```
+!
+Startup-config data location is flash memory
+!
+Startup configuration:
+!
+ver 08.0.20T311
+!
+stack unit 1
+  module 1 icx6430-24-port-management-module
+  module 2 icx6430-sfp-4port-4g-module
+!
+!
+!
+!
+!
+!
+!
+!
+aaa authentication web-server default local
+aaa authentication login default local
+enable password-display
+enable super-user-password 8 $1$QP3H93Wm$uxYAs2HmAK0lQiP3ig5tm.
+ip address 2.2.2.2 255.255.255.0 dynamic
+ip dns server-address 1.1.1.1
+ip default-gateway 1.1.1.1
+!
+username brocade password 8 $1$f/uxhovU$dST5lNskZCPQe/5QijULi0
+username test password 8 $1$qKOcZizM$ySW1EyiUpKSHw9MT4PZ11.
+snmp-server community 2 $MlVzZCFAbg== ro
+snmp-server community 2 $U2kyXj1k rw
+!
+!
+interface ethernet 1/1/1
+ speed-duplex 1000-full-master
+!
+interface ethernet 1/1/2
+ speed-duplex 1000-full-master
+!
+interface ethernet 1/1/3
+ speed-duplex 1000-full-master
+!
+interface ethernet 1/1/4
+ speed-duplex 1000-full-master
+!
+interface ethernet 1/1/5
+ speed-duplex 1000-full-master
+!
+interface ethernet 1/1/6
+ speed-duplex 1000-full-master
+!
+interface ethernet 1/1/7
+ speed-duplex 1000-full-master
+!
+interface ethernet 1/1/8
+ speed-duplex 1000-full-master
+!
+interface ethernet 1/1/9
+ speed-duplex 1000-full-master
+!
+interface ethernet 1/1/10
+ speed-duplex 1000-full-master
+!
+interface ethernet 1/1/11
+ speed-duplex 1000-full-master
+!
+interface ethernet 1/1/12
+ speed-duplex 1000-full-master
+!
+interface ethernet 1/1/13
+ speed-duplex 1000-full-master
+!
+interface ethernet 1/1/14
+ speed-duplex 1000-full-master
+!
+interface ethernet 1/1/15
+ speed-duplex 1000-full-master
+!
+interface ethernet 1/1/16
+ speed-duplex 1000-full-master
+!
+interface ethernet 1/1/17
+ speed-duplex 1000-full-master
+!
+interface ethernet 1/1/18
+ speed-duplex 1000-full-master
+!
+interface ethernet 1/1/19
+ speed-duplex 1000-full-master
+!
+interface ethernet 1/1/20
+ speed-duplex 1000-full-master
+!
+interface ethernet 1/1/21
+ speed-duplex 1000-full-master
+!
+interface ethernet 1/1/22
+ speed-duplex 1000-full-master
+!
+interface ethernet 1/1/23
+ speed-duplex 1000-full-master
+ no spanning-tree
+!
+interface ethernet 1/1/24
+ speed-duplex 1000-full-master
+ no spanning-tree
+!
+!
+!
+!
+!
+!
+!
+!
+end
+```
 
 ## Verification Steps
 

--- a/documentation/modules/auxiliary/admin/networking/juniper_config.md
+++ b/documentation/modules/auxiliary/admin/networking/juniper_config.md
@@ -6,10 +6,1003 @@ This module imports a Juniper configuration file into the database.
 This is similar to `post/networking/gather/enum_juniper` only access isn't required,
 and assumes you already have the file.
 
-Example files for import can be found on git, like
-[this (junos)](https://raw.githubusercontent.com/h00die/MSF-Testing-Scripts/master/juniper_ex2200.config)
-or
-[this (screenos)](https://raw.githubusercontent.com/h00die/MSF-Testing-Scripts/master/juniper_ssg5_screenos.conf).
+### Example Configs
+
+#### JunOS
+
+[JunOS](https://raw.githubusercontent.com/h00die/MSF-Testing-Scripts/master/juniper_ex2200.config)
+
+```
+## Last commit: 2016-08-15 13:35:48 UTC by root
+version 12.3R7.7;
+system {
+    host-name h00dieJuniperEx2200;
+    root-authentication {
+        encrypted-password "$1$pz9b1.fq$foo5r85Ql8mXdoRUe0C1E."; ## SECRET-DATA
+    }
+    login {
+        user newuser {
+            uid 2000;
+            class super-user;
+            authentication {
+                encrypted-password "$1$rm8FaMFY$k4LFxqsVAiGO5tKqyO9jJ/"; ## SECRET-DATA
+            }
+        }
+        user newuser2 {
+            uid 2002;
+            class operator;
+            authentication {
+                encrypted-password "$1$aDZi44AP$bQGGjqPJ.F.Cm5QvX2yaa0"; ## SECRET-DATA
+            }
+        }
+        user newuser3 {
+            uid 2003;
+            class read-only;
+            authentication {
+                encrypted-password "$1$1.YvKzUY$dcAj99KngGhFZTpxGjA93."; ## SECRET-DATA
+            }
+        }
+        user newuser4 {
+            uid 2004;
+            class unauthorized;
+            authentication {
+                encrypted-password "$1$bdWYaqOE$z6oTSJS3p1R8CoNaos9Ce/"; ## SECRET-DATA
+            }
+        }
+    }
+    services {
+        ssh {
+            root-login allow;
+        }
+        web-management {
+            http;
+        }
+        dhcp {
+            traceoptions {
+                file dhcp_logfile;
+                level all;
+                flag all;
+            }
+            pool 192.168.10.0/24 {
+                address-range low 192.168.10.2 high 192.168.10.254;
+            }
+        }
+    }
+    syslog {
+        user * {
+            any emergency;
+        }
+        file messages {
+            any notice;
+            authorization info;
+        }
+        file interactive-commands {
+            interactive-commands any;
+        }
+    }
+}
+chassis {
+    alarm {
+        management-ethernet {
+            link-down ignore;
+        }
+    }
+    auto-image-upgrade;
+}
+interfaces {
+    ge-0/0/0 {
+        unit 0 {
+            family inet {
+                address 192.168.1.3/32;
+            }
+        }
+    }
+    ge-0/0/1 {
+        unit 0 {
+            family inet {
+                address 192.168.1.4/32;
+            }
+        }
+    }
+    ge-0/0/2 {
+        unit 0 {
+            family inet {
+                address 192.168.1.5/24;
+            }
+        }
+    }
+    ge-0/0/3 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/4 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/5 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/6 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/7 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/8 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/9 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/10 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/11 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/12 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/13 {
+        unit 0 {
+ ## Last commit: 2016-08-15 13:35:48 UTC by root
+version 12.3R7.7;
+system {
+    host-name h00dieJuniperEx2200;
+    root-authentication {
+        encrypted-password "$1$pz9b1.fq$foo5r85Ql8mXdoRUe0C1E."; ## SECRET-DATA
+    }
+    login {
+        user newuser {
+            uid 2000;
+            class super-user;
+            authentication {
+                encrypted-password "$1$rm8FaMFY$k4LFxqsVAiGO5tKqyO9jJ/"; ## SECRET-DATA
+            }
+        }
+        user newuser2 {
+            uid 2002;
+            class operator;
+            authentication {
+                encrypted-password "$1$aDZi44AP$bQGGjqPJ.F.Cm5QvX2yaa0"; ## SECRET-DATA
+            }
+        }
+        user newuser3 {
+            uid 2003;
+            class read-only;
+            authentication {
+                encrypted-password "$1$1.YvKzUY$dcAj99KngGhFZTpxGjA93."; ## SECRET-DATA
+            }
+        }
+        user newuser4 {
+            uid 2004;
+            class unauthorized;
+            authentication {
+                encrypted-password "$1$bdWYaqOE$z6oTSJS3p1R8CoNaos9Ce/"; ## SECRET-DATA
+            }
+        }
+    }
+    services {
+        ssh {
+            root-login allow;
+        }
+        web-management {
+            http;
+        }
+        dhcp {
+            traceoptions {
+                file dhcp_logfile;
+                level all;
+                flag all;
+            }
+            pool 192.168.10.0/24 {
+                address-range low 192.168.10.2 high 192.168.10.254;
+            }
+        }
+    }
+    syslog {
+        user * {
+            any emergency;
+        }
+        file messages {
+            any notice;
+            authorization info;
+        }
+        file interactive-commands {
+            interactive-commands any;
+        }
+    }
+}
+chassis {
+    alarm {
+        management-ethernet {
+            link-down ignore;
+        }
+    }
+    auto-image-upgrade;
+}
+interfaces {
+    ge-0/0/0 {
+        unit 0 {
+            family inet {
+                address 192.168.1.3/32;
+            }
+        }
+    }
+    ge-0/0/1 {
+        unit 0 {
+            family inet {
+                address 192.168.1.4/32;
+            }
+        }
+    }
+    ge-0/0/2 {
+        unit 0 {
+            family inet {
+                address 192.168.1.5/24;
+            }
+        }
+    }
+    ge-0/0/3 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/4 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/5 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/6 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/7 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/8 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/9 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/10 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/11 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/12 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/13 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/14 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/15 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/16 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/17 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/18 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/19 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/20 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/21 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/22 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/23 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/24 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/25 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/26 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/27 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/28 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/29 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/30 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/31 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/32 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/33 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/34 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/35 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/36 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/37 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/38 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/39 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/40 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/41 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/42 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/43 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/44 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/45 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/46 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/47 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/1/0 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/1/1 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/1/2 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/1/3 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    me0 {
+        unit 0 {
+            family inet {
+                address 192.168.1.1/24;
+            }
+        }
+    }
+    pp0 {
+        unit 0 {
+            ppp-options {
+                pap {
+                    local-name "'pap_username'";
+                    local-password "$9$he4revM87-dsevm5TQCAp0BErvLxd4JDNdkPfT/9BIR"; ## SECRET-DATA
+                }
+            }
+        }
+    }
+    st0 {
+        unit 1;
+    }
+    vlan {
+        unit 0 {
+            family inet {
+                dhcp {
+                    vendor-id Juniper-ex2200-48t-4g;
+                }
+            }
+        }
+    }
+}
+snmp {
+    name "snmp name";
+    description "snmp description";
+    location basement;
+    contact admin;
+    view jweb-view-all {
+        oid .1 include;
+    }
+    community read {
+        authorization read-only;
+    }
+    community write {
+        view jweb-view-all;
+        authorization read-write;
+    }
+    community public {
+        authorization read-only;
+    }
+    community private {
+        authorization read-write;
+    }
+    community secretsauce {
+        authorization read-write;
+    }
+    community "hello there" {
+        authorization read-write;
+    }
+}
+routing-options {
+    static {
+        route 0.0.0.0/0 next-hop 192.168.1.254;
+    }
+}
+protocols {
+    igmp-snooping {
+        vlan all;
+    }
+    rstp;
+    lldp {
+        interface all;
+    }
+    lldp-med {
+        interface all;
+    }
+}
+access {
+    radius-server {
+        1.1.1.1 secret "$9$Y-4GikqfF39JGCu1Ileq.PQ6AB1hrlMBIyKvWdV"; ## SECRET-DATA
+    }
+}
+ethernet-switching-options {
+    storm-control {
+        interface all;
+    }
+}
+vlans {
+    default {
+        l3-interface vlan.0;
+    }
+}           family ethernet-switching;
+        }
+    }
+    ge-0/0/14 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/15 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/16 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/17 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/18 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/19 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/20 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/21 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/22 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/23 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/24 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/25 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/26 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/27 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/28 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/29 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/30 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/31 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/32 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/33 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/34 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/35 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/36 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/37 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/38 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/39 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/40 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/41 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/42 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/43 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/44 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/45 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/46 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/0/47 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/1/0 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/1/1 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/1/2 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    ge-0/1/3 {
+        unit 0 {
+            family ethernet-switching;
+        }
+    }
+    me0 {
+        unit 0 {
+            family inet {
+                address 192.168.1.1/24;
+            }
+        }
+    }
+    pp0 {
+        unit 0 {
+            ppp-options {
+                pap {
+                    local-name "'pap_username'";
+                    local-password "$9$he4revM87-dsevm5TQCAp0BErvLxd4JDNdkPfT/9BIR"; ## SECRET-DATA
+                }
+            }
+        }
+    }
+    st0 {
+        unit 1;
+    }
+    vlan {
+        unit 0 {
+            family inet {
+                dhcp {
+                    vendor-id Juniper-ex2200-48t-4g;
+                }
+            }
+        }
+    }
+}
+snmp {
+    name "snmp name";
+    description "snmp description";
+    location basement;
+    contact admin;
+    view jweb-view-all {
+        oid .1 include;
+    }
+    community read {
+        authorization read-only;
+    }
+    community write {
+        view jweb-view-all;
+        authorization read-write;
+    }
+    community public {
+        authorization read-only;
+    }
+    community private {
+        authorization read-write;
+    }
+    community secretsauce {
+        authorization read-write;
+    }
+    community "hello there" {
+        authorization read-write;
+    }
+}
+routing-options {
+    static {
+        route 0.0.0.0/0 next-hop 192.168.1.254;
+    }
+}
+protocols {
+    igmp-snooping {
+        vlan all;
+    }
+    rstp;
+    lldp {
+        interface all;
+    }
+    lldp-med {
+        interface all;
+    }
+}
+access {
+    radius-server {
+        1.1.1.1 secret "$9$Y-4GikqfF39JGCu1Ileq.PQ6AB1hrlMBIyKvWdV"; ## SECRET-DATA
+    }
+}
+ethernet-switching-options {
+    storm-control {
+        interface all;
+    }
+}
+vlans {
+    default {
+        l3-interface vlan.0;
+    }
+}
+```
+
+#### ScreenOS
+
+[screenos](https://raw.githubusercontent.com/h00die/MSF-Testing-Scripts/master/juniper_ssg5_screenos.conf)
+
+```
+unset key protection enable
+set clock timezone 0
+set vrouter trust-vr sharable
+set vrouter "untrust-vr"
+exit
+set vrouter "trust-vr"
+unset auto-route-export
+exit
+set alg appleichat enable
+unset alg appleichat re-assembly enable
+set alg sctp enable
+set auth-server "Local" id 0
+set auth-server "Local" server-name "Local"
+set auth default auth server "Local"
+set auth radius accounting port 1646
+set admin name "netscreen"
+set admin password "nKVUM2rwMUzPcrkG5sWIHdCtqkAibn"
+set admin auth web timeout 10
+set admin auth dial-in timeout 3
+set admin auth server "Local"
+set admin format dos
+set zone "Trust" vrouter "trust-vr"
+set zone "Untrust" vrouter "trust-vr"
+set zone "DMZ" vrouter "trust-vr"
+set zone "VLAN" vrouter "trust-vr"
+set zone "Untrust-Tun" vrouter "trust-vr"
+set zone "Trust" tcp-rst 
+set zone "Untrust" block 
+unset zone "Untrust" tcp-rst 
+set zone "MGT" block 
+unset zone "V1-Trust" tcp-rst 
+unset zone "V1-Untrust" tcp-rst 
+set zone "DMZ" tcp-rst 
+unset zone "V1-DMZ" tcp-rst 
+unset zone "VLAN" tcp-rst 
+set zone "Untrust" screen tear-drop
+set zone "Untrust" screen syn-flood
+set zone "Untrust" screen ping-death
+set zone "Untrust" screen ip-filter-src
+set zone "Untrust" screen land
+set zone "V1-Untrust" screen tear-drop
+set zone "V1-Untrust" screen syn-flood
+set zone "V1-Untrust" screen ping-death
+set zone "V1-Untrust" screen ip-filter-src
+set zone "V1-Untrust" screen land
+set interface "ethernet0/0" zone "Untrust"
+set interface "ethernet0/1" zone "DMZ"
+set interface "bgroup0" zone "Trust"
+set interface bgroup0 port ethernet0/2
+set interface bgroup0 port ethernet0/3
+set interface bgroup0 port ethernet0/4
+set interface bgroup0 port ethernet0/5
+set interface bgroup0 port ethernet0/6
+unset interface vlan1 ip
+set interface bgroup0 ip 192.168.1.1/24
+set interface bgroup0 nat
+unset interface vlan1 bypass-others-ipsec
+unset interface vlan1 bypass-non-ip
+set interface bgroup0 ip manageable
+set interface ethernet0/0 dhcp client enable
+set interface ethernet0/0 dhcp client settings autoconfig
+set interface "serial0/0" modem settings "USR" init "AT&F"
+set interface "serial0/0" modem settings "USR" active
+set interface "serial0/0" modem speed 115200
+set interface "serial0/0" modem retry 3
+set interface "serial0/0" modem interval 10
+set interface "serial0/0" modem idle-time 10
+set ip tftp retry 30
+set ip tftp timeout 30
+set flow tcp-mss
+unset flow no-tcp-seq-check
+set flow tcp-syn-check
+unset flow tcp-syn-bit-check
+set flow reverse-route clear-text prefer
+set flow reverse-route tunnel always
+set pki authority default scep mode "auto"
+set pki x509 default cert-path partial
+set user "testuser" uid 1
+set user "testuser" type auth
+set user "testuser" hash-password "02b0jt2gZGipCiIEgl4eainqZIKzjSNQYLIwE="
+set user "testuser" enable
+set crypto-policy
+exit
+set ike respond-bad-spi 1
+set ike ikev2 ike-sa-soft-lifetime 60
+unset ike ikeid-enumeration
+unset ike dos-protection
+unset ipsec access-session enable
+set ipsec access-session maximum 5000
+set ipsec access-session upper-threshold 0
+set ipsec access-session lower-threshold 0
+set ipsec access-session dead-p2-sa-timeout 0
+unset ipsec access-session log-error
+unset ipsec access-session info-exch-connected
+unset ipsec access-session use-error-log
+set url protocol websense
+exit
+set policy id 1 from "Trust" to "Untrust"  "Any" "Any" "ANY" permit 
+set policy id 1
+exit
+set nsmgmt bulkcli reboot-timeout 60
+set ssh version v2
+set config lock timeout 5
+unset license-key auto-update
+set telnet client enable
+set snmp port listen 161
+set snmp port trap 162
+set snmpv3 local-engine id "0162122013002408"
+set vrouter "untrust-vr"
+exit
+set vrouter "trust-vr"
+unset add-default-route
+exit
+set vrouter "untrust-vr"
+exit
+set vrouter "trust-vr"
+exit
+```
 
 ## Verification Steps
 

--- a/lib/msf/core/auxiliary/brocade.rb
+++ b/lib/msf/core/auxiliary/brocade.rb
@@ -1,116 +1,124 @@
 # -*- coding: binary -*-
+
 module Msf
+  ###
+  #
+  # This module provides methods for working with Brocade equipment
+  #
+  ###
+  module Auxiliary::Brocade
+    include Msf::Auxiliary::Report
 
-###
-#
-# This module provides methods for working with Brocade equipment
-#
-###
-module Auxiliary::Brocade
-  include Msf::Auxiliary::Report
+    def create_credential_and_login(opts = {})
+      return nil unless active_db?
 
-  def create_credential_and_login(opts={})
-    return nil unless active_db?
-
-    if self.respond_to?(:[]) and self[:task]
-      opts[:task_id] ||= self[:task].record.id
-    end
-
-    core               = opts.fetch(:core, create_credential(opts))
-    access_level       = opts.fetch(:access_level, nil)
-    last_attempted_at  = opts.fetch(:last_attempted_at, nil)
-    status             = opts.fetch(:status, Metasploit::Model::Login::Status::UNTRIED)
-
-    login_object = nil
-    retry_transaction do
-      service_object = create_credential_service(opts)
-      login_object = Metasploit::Credential::Login.where(core_id: core.id, service_id: service_object.id).first_or_initialize
-
-      if opts[:task_id]
-        login_object.tasks << Mdm::Task.find(opts[:task_id])
+      if respond_to?(:[]) && self[:task]
+        opts[:task_id] ||= self[:task].record.id
       end
 
-      login_object.access_level      = access_level if access_level
-      login_object.last_attempted_at = last_attempted_at if last_attempted_at
-      if status == Metasploit::Model::Login::Status::UNTRIED
-        if login_object.last_attempted_at.nil?
+      core = opts.fetch(:core, create_credential(opts))
+      access_level = opts.fetch(:access_level, nil)
+      last_attempted_at = opts.fetch(:last_attempted_at, nil)
+      status = opts.fetch(:status, Metasploit::Model::Login::Status::UNTRIED)
+
+      login_object = nil
+      retry_transaction do
+        service_object = create_credential_service(opts)
+        login_object = Metasploit::Credential::Login.where(core_id: core.id, service_id: service_object.id).first_or_initialize
+
+        if opts[:task_id]
+          login_object.tasks << Mdm::Task.find(opts[:task_id])
+        end
+
+        login_object.access_level = access_level if access_level
+        login_object.last_attempted_at = last_attempted_at if last_attempted_at
+        if status == Metasploit::Model::Login::Status::UNTRIED
+          if login_object.last_attempted_at.nil?
+            login_object.status = status
+          end
+        else
           login_object.status = status
         end
-      else
-        login_object.status = status
+        login_object.save!
       end
-      login_object.save!
+
+      login_object
     end
 
-    login_object
-  end
+    def brocade_config_eater(thost, tport, config)
+      # this is for brocade type devices.
+      # It is similar to cisco
+      # Docs: enable password-display -> http://wwwaem.brocade.com/content/html/en/command-reference-guide/fastiron-08040-commandref/GUID-169889CD-1A74-4A23-AC78-38796692374F.html
 
+      if framework.db.active
+        credential_data = {
+          address: thost,
+          port: tport,
+          protocol: 'tcp',
+          workspace_id: myworkspace.id,
+          origin_type: :service,
+          private_type: :nonreplayable_hash,
+          service_name: '',
+          module_fullname: fullname,
+          status: Metasploit::Model::Login::Status::UNTRIED
+        }
+      end
 
-  def brocade_config_eater(thost, tport, config)
-    # this is for brocade type devices.
-    # It is similar to cisco
-    # Docs: enable password-display -> http://wwwaem.brocade.com/content/html/en/command-reference-guide/fastiron-08040-commandref/GUID-169889CD-1A74-4A23-AC78-38796692374F.html
+      store_loot('brocade.config', 'text/plain', thost, config.strip, 'config.txt', 'Brocade Configuration')
 
-    credential_data = {
-      address: thost,
-      port: tport,
-      protocol: 'tcp',
-      workspace_id: myworkspace.id,
-      origin_type: :service,
-      private_type: :nonreplayable_hash,
-      service_name: '',
-      module_fullname: self.fullname,
-      status: Metasploit::Model::Login::Status::UNTRIED
-    }
+      # Brocade has this one configuration called "password display". With it, we get hashes. With out it, just ...
+      if config =~ /enable password-display/
+        print_good('password-display is enabled, hashes will be displayed in config')
+      else
+        print_bad('password-display is disabled, no password hashes displayed in config')
+      end
 
-    store_loot('brocade.config', 'text/plain', thost, config.strip, 'config.txt', 'Brocade Configuration')
+      # enable password
+      # Example lines:
+      # enable super-user-password 8 $1$QP3H93Wm$uxYAs2HmAK01QiP3ig5tm.
+      config.scan(/enable super-user-password 8 (?<admin_password_hash>.+)/i).each do |result|
+        admin_hash = result[0].strip
+        next if admin_hash == '.....'
 
-    # Brocade has this one configuration called "password display". With it, we get hashes. With out it, just ...
-    if config =~ /enable password-display/
-      print_good('password-display is enabled, hashes will be displayed in config')
-    else
-      print_bad('password-display is disabled, no password hashes displayed in config')
-    end
-
-    # enable password
-    # Example lines:
-    # enable super-user-password 8 $1$QP3H93Wm$uxYAs2HmAK01QiP3ig5tm.
-    config.scan(/enable super-user-password 8 (?<admin_password_hash>.+)/i).each do |result|
-      admin_hash = result[0].strip
-      unless admin_hash == '.....'
         print_good("enable password hash #{admin_hash}")
+        next unless framework.db.active
+
         cred = credential_data.dup
         cred[:username] = 'enable'
         cred[:private_data] = admin_hash
         create_credential_and_login(cred)
       end
-    end
 
-    # user account
-    # Example lines:
-    # username brocade password 8 $1$YBaHUWpr$PzeUrP0XmVOyVNM5rYy99/
-    config.scan(/username "?(?<user_name>[a-z0-9]+)"? password (?<user_type>\w+) (?<user_hash>[0-9a-z=\$\/]{34})/i).each do |result|
-      user_name = result[0].strip
-      user_type  = result[1].strip
-      user_hash = result[2].strip
-      unless user_hash == '.....'
+      # user account
+      # Example lines:
+      # username brocade password 8 $1$YBaHUWpr$PzeUrP0XmVOyVNM5rYy99/
+      config.scan(%r{username "?(?<user_name>[a-z0-9]+)"? password (?<user_type>\w+) (?<user_hash>[0-9a-z=\$/]{34})}i).each do |result|
+        user_name = result[0].strip
+        user_type = result[1].strip
+        user_hash = result[2].strip
+        next if user_hash == '.....'
+
         print_good("User #{user_name} of type #{user_type} found with password hash #{user_hash}.")
+        next unless framework.db.active
+
         cred = credential_data.dup
         cred[:username] = user_name
         cred[:private_data] = user_hash
         create_credential_and_login(cred)
       end
-    end
 
-    # snmp
-    # Example lines:
-    # snmp-server community 1 $Si2^=d rw
-    # these at times look base64 encoded, which they may be, but are also encrypted
-    config.scan(/snmp-server community (?<snmp_id>[\d]+) (?<snmp_community>.+) (?<snmp_permissions>rw|ro)/i).each do |result|
-      snmp_community = result[1].strip
-      snmp_permissions = result[2].strip
-      unless snmp_community == '.....'
+      # snmp
+      # Example lines:
+      # snmp-server community 1 $Si2^=d rw
+      # these at times look base64 encoded, which they may be, but are also encrypted
+      config.scan(/snmp-server community (?<snmp_id>[\d]+) (?<snmp_community>.+) (?<snmp_permissions>rw|ro)/i).each do |result|
+        snmp_community = result[1].strip
+        snmp_permissions = result[2].strip
+        next if snmp_community == '.....'
+
         print_good("#{'ENCRYPTED ' if snmp_community.start_with?('$')}SNMP community #{snmp_community} with permissions #{snmp_permissions}")
+        next unless framework.db.active
+
         cred = credential_data.dup
         cred[:protocol] = 'udp'
         cred[:port] = 161
@@ -118,9 +126,7 @@ module Auxiliary::Brocade
         cred[:private_data] = snmp_community
         create_credential_and_login(cred)
       end
-    end
 
+    end
   end
 end
-end
-

--- a/lib/msf/core/auxiliary/cisco.rb
+++ b/lib/msf/core/auxiliary/cisco.rb
@@ -1,87 +1,167 @@
 # -*- coding: binary -*-
+
 module Msf
+  ###
+  #
+  # This module provides methods for working with Cisco equipment
+  #
+  ###
+  module Auxiliary::Cisco
+    include Msf::Auxiliary::Report
 
-###
-#
-# This module provides methods for working with Cisco equipment
-#
-###
-module Auxiliary::Cisco
-  include Msf::Auxiliary::Report
+    def cisco_ios_decrypt7(inp)
+      xlat = [
+        0x64, 0x73, 0x66, 0x64, 0x3b, 0x6b, 0x66, 0x6f,
+        0x41, 0x2c, 0x2e, 0x69, 0x79, 0x65, 0x77, 0x72,
+        0x6b, 0x6c, 0x64, 0x4a, 0x4b, 0x44, 0x48, 0x53,
+        0x55, 0x42
+      ]
 
-  def cisco_ios_decrypt7(inp)
-    xlat = [
-      0x64, 0x73, 0x66, 0x64, 0x3b, 0x6b, 0x66, 0x6f,
-      0x41, 0x2c, 0x2e, 0x69, 0x79, 0x65, 0x77, 0x72,
-      0x6b, 0x6c, 0x64, 0x4a, 0x4b, 0x44, 0x48, 0x53,
-      0x55, 0x42
-    ]
+      return nil if !(inp[0, 2] =~ /\d\d/)
 
-    return nil if not inp[0,2] =~ /\d\d/
-
-    seed  = nil
-    clear = ""
-    inp.scan(/../).each do |byte|
-      if not seed
-        seed = byte.to_i
-        next
+      seed = nil
+      clear = ''
+      inp.scan(/../).each do |byte|
+        if !seed
+          seed = byte.to_i
+          next
+        end
+        byte = byte.to_i(16)
+        clear << [ byte ^ xlat[seed]].pack('C')
+        seed += 1
       end
-      byte = byte.to_i(16)
-      clear << [ byte ^ xlat[ seed ]].pack("C")
-      seed += 1
-    end
-    clear
-  end
-
-  def cisco_ios_config_eater(thost, tport, config)
-
-    credential_data = {
-      address: thost,
-      port: tport,
-      protocol: 'tcp',
-      workspace_id: myworkspace.id,
-      origin_type: :service,
-      private_type: :password,
-      service_name: '',
-      module_fullname: self.fullname,
-      status: Metasploit::Model::Login::Status::UNTRIED
-    }
-
-    # Default SNMP to UDP
-    if tport == 161
-      credential_data[:protocol] = 'udp'
+      clear
     end
 
-    store_loot("cisco.ios.config", "text/plain", thost, config.strip, "config.txt", "Cisco IOS Configuration")
+    def cisco_ios_config_eater(thost, tport, config)
 
-    tuniface = nil
+      if framework.db.active
+        credential_data = {
+          address: thost,
+          port: tport,
+          protocol: 'tcp',
+          workspace_id: myworkspace.id,
+          origin_type: :service,
+          private_type: :password,
+          service_name: '',
+          module_fullname: fullname,
+          status: Metasploit::Model::Login::Status::UNTRIED
+        }
+      end
 
-    host_info = {
-      :host => thost,
-      :os_name => 'Cisco IOS',
-    }
-    report_host(host_info)
+      # Default SNMP to UDP
+      if tport == 161
+        credential_data[:protocol] = 'udp'
+      end
 
-    config.each_line do |line|
-      case line
-#
-# Cover host details
-#
+      store_loot('cisco.ios.config', 'text/plain', thost, config.strip, 'config.txt', 'Cisco IOS Configuration')
+
+      tuniface = nil
+
+      host_info = {
+        host: thost,
+        os_name: 'Cisco IOS'
+      }
+      report_host(host_info)
+
+      config.each_line do |line|
+        case line
+          #
+          # Cover host details
+          #
         when /^version (\d\d\.\d)/i
-          host_info[:os_flavor] = $1.to_s
+          host_info[:os_flavor] = Regexp.last_match(1).to_s
           report_host(host_info)
         when /^hostname (\S+)/i
-          host_info[:name] = $1.to_s
+          host_info[:name] = Regexp.last_match(1).to_s
           report_host(host_info)
-#
-# Enable passwords
-#
+          #
+          # Enable passwords
+          #
         when /^\s*enable (password|secret) (\d+) (.*)/i
-          stype = $2.to_i
-          shash = $3.strip
+          stype = Regexp.last_match(2).to_i
+          shash = Regexp.last_match(3).strip
 
-          if stype == 5
+          if framework.db.active
+            cred = credential_data.dup
+            cred[:private_data] = shash
+          else
+            cred = {} # throw away
+          end
+
+          case stype
+          when 5
             print_good("#{thost}:#{tport} MD5 Encrypted Enable Password: #{shash}")
+            cred[:jtr_format] = 'md5'
+            cred[:private_type] = :nonreplayable_hash
+            create_credential_and_login(cred) if framework.db.active
+          when 0 # unencrypted
+            print_good("#{thost}:#{tport} Enable Password: #{shash}")
+            create_credential_and_login(cred) if framework.db.active
+          when 7
+            shash = begin
+                    cisco_ios_decrypt7(shash)
+                    rescue StandardError
+                      shash
+                  end
+            print_good("#{thost}:#{tport} Decrypted Enable Password: #{shash}")
+            cred[:private_data] = shash
+            create_credential_and_login(cred) if framework.db.active
+          end
+
+        when /^\s*enable password (.*)/i
+          spass = Regexp.last_match(1).strip
+          print_good("#{thost}:#{tport} Unencrypted Enable Password: #{spass}")
+
+          if framework.db.active
+            cred = credential_data.dup
+            cred[:private_data] = spass
+            create_credential_and_login(cred)
+          end
+
+          #
+          # SNMP
+          #
+        when /^\s*snmp-server community ([^\s]+) (RO|RW)/i
+          stype = Regexp.last_match(2).strip
+          scomm = Regexp.last_match(1).strip
+          print_good("#{thost}:#{tport} SNMP Community (#{stype}): #{scomm}")
+
+          if framework.db.active
+            cred = credential_data.dup
+            if stype.downcase == 'ro'
+              cred[:access_level] = 'RO'
+            else
+              cred[:access_level] = 'RW'
+            end
+            cred[:protocol] = 'udp'
+            cred[:port] = 161
+            cred[:private_data] = scomm
+            create_credential_and_login(cred)
+          end
+          #
+          # VTY Passwords
+          #
+        when /^\s*password 7 ([^\s]+)/i
+          spass = Regexp.last_match(1).strip
+          spass = begin
+                  cisco_ios_decrypt7(spass)
+                  rescue StandardError
+                    spass
+                end
+
+          print_good("#{thost}:#{tport} Decrypted VTY Password: #{spass}")
+
+          if framework.db.active
+            cred = credential_data.dup
+            cred[:private_data] = spass
+            create_credential_and_login(cred)
+          end
+
+        when /^\s*(password|secret) 5 (.*)/i
+          shash = Regexp.last_match(2).strip
+          print_good("#{thost}:#{tport} MD5 Encrypted VTY Password: #{shash}")
+          if framework.db.active
             cred = credential_data.dup
             cred[:jtr_format] = 'md5'
             cred[:private_data] = shash
@@ -89,320 +169,274 @@ module Auxiliary::Cisco
             create_credential_and_login(cred)
           end
 
-          if stype == 0 #unencrypted
-            print_good("#{thost}:#{tport} Enable Password: #{shash}")
-            cred = credential_data.dup
-            cred[:private_data] = shash
-            create_credential_and_login(cred)
-          end
-
-          if stype == 7
-            shash = cisco_ios_decrypt7(shash) rescue shash
-            print_good("#{thost}:#{tport} Decrypted Enable Password: #{shash}")
-            cred = credential_data.dup
-            cred[:private_data] = shash
-            create_credential_and_login(cred)
-          end
-
-        when /^\s*enable password (.*)/i
-          spass = $1.strip
-          print_good("#{thost}:#{tport} Unencrypted Enable Password: #{spass}")
-
-          cred = credential_data.dup
-          cred[:private_data] = spass
-          create_credential_and_login(cred)
-
-#
-# SNMP
-#
-        when /^\s*snmp-server community ([^\s]+) (RO|RW)/i
-          stype = $2.strip
-          scomm = $1.strip
-          print_good("#{thost}:#{tport} SNMP Community (#{stype}): #{scomm}")
-
-          cred = credential_data.dup
-          if stype.downcase == "ro"
-            cred[:access_level] = "RO"
-          else
-            cred[:access_level] = "RW"
-          end
-          cred[:protocol] = "udp"
-          cred[:port] = 161
-          cred[:private_data] = scomm
-          create_credential_and_login(cred)
-#
-# VTY Passwords
-#
-        when /^\s*password 7 ([^\s]+)/i
-          spass = $1.strip
-          spass = cisco_ios_decrypt7(spass) rescue spass
-
-          print_good("#{thost}:#{tport} Decrypted VTY Password: #{spass}")
-
-          cred = credential_data.dup
-          cred[:private_data] = spass
-          create_credential_and_login(cred)
-
-
-        when /^\s*(password|secret) 5 (.*)/i
-          shash = $2.strip
-          print_good("#{thost}:#{tport} MD5 Encrypted VTY Password: #{shash}")
-          cred = credential_data.dup
-          cred[:jtr_format] = 'md5'
-          cred[:private_data] = shash
-          cred[:private_type] = :nonreplayable_hash
-          create_credential_and_login(cred)
-
         when /^\s*password (0 |)([^\s]+)/i
-          spass = $2.strip
+          spass = Regexp.last_match(2).strip
           print_good("#{thost}:#{tport} Unencrypted VTY Password: #{spass}")
 
-          cred = credential_data.dup
-          cred[:private_data] = spass
-          create_credential_and_login(cred)
+          if framework.db.active
+            cred = credential_data.dup
+            cred[:private_data] = spass
+            create_credential_and_login(cred)
+          end
 
-#
-# WiFi Passwords
-#
+          #
+          # WiFi Passwords
+          #
         when /^\s*encryption key \d+ size \d+bit (\d+) ([^\s]+)/
-          spass = $2.strip
+          spass = Regexp.last_match(2).strip
           print_good("#{thost}:#{tport} Wireless WEP Key: #{spass}")
 
         when /^\s*wpa-psk (ascii|hex) (\d+) ([^\s]+)/i
 
-          stype = $2.to_i
-          spass = $3.strip
+          stype = Regexp.last_match(2).to_i
+          spass = Regexp.last_match(3).strip
 
-          if stype == 5
-            print_good("#{thost}:#{tport} Wireless WPA-PSK MD5 Password Hash: #{spass}")
+          if framework.db.active
             cred = credential_data.dup
+            cred[:private_data] = spass
+          else
+            cred = {} # throw away
+          end
+
+          case stype
+          when 5
+            print_good("#{thost}:#{tport} Wireless WPA-PSK MD5 Password Hash: #{spass}")
             cred[:jtr_format] = 'md5'
+            cred[:private_type] = :nonreplayable_hash
+            create_credential_and_login(cred) if framework.db.active
+          when 0
+            print_good("#{thost}:#{tport} Wireless WPA-PSK Password: #{spass}")
+            create_credential_and_login(cred) if framework.db.active
+          when 7
+            spass = begin
+                    cisco_ios_decrypt7(spass)
+                    rescue StandardError
+                      spass
+                  end
+            print_good("#{thost}:#{tport} Wireless WPA-PSK Decrypted Password: #{spass}")
+            cred[:private_data] = spass
+            create_credential_and_login(cred) if framework.db.active
+          end
+
+          #
+          # VPN Passwords
+          #
+        when /^\s*crypto isakmp key ([^\s]+) address ([^\s]+)/i
+          spass = Regexp.last_match(1)
+          shost = Regexp.last_match(2)
+
+          print_good("#{thost}:#{tport} VPN IPSEC ISAKMP Key '#{spass}' Host '#{shost}'")
+          if framework.db.active
+            cred = credential_data.dup
             cred[:private_data] = spass
             cred[:private_type] = :nonreplayable_hash
             create_credential_and_login(cred)
           end
 
-          if stype == 0
-            print_good("#{thost}:#{tport} Wireless WPA-PSK Password: #{spass}")
-            cred = credential_data.dup
-            cred[:private_data] = spass
-            create_credential_and_login(cred)
-          end
-
-          if stype == 7
-            spass = cisco_ios_decrypt7(spass) rescue spass
-            print_good("#{thost}:#{tport} Wireless WPA-PSK Decrypted Password: #{spass}")
-            cred = credential_data.dup
-            cred[:private_data] = spass
-            create_credential_and_login(cred)
-          end
-
-#
-# VPN Passwords
-#
-        when /^\s*crypto isakmp key ([^\s]+) address ([^\s]+)/i
-          spass  = $1
-          shost  = $2
-
-          print_good("#{thost}:#{tport} VPN IPSEC ISAKMP Key '#{spass}' Host '#{shost}'")
-          cred = credential_data.dup
-          cred[:private_data] = spass
-          cred[:private_type] = :nonreplayable_hash
-          create_credential_and_login(cred)
-
         when /^\s*interface tunnel(\d+)/i
-          tuniface = $1
+          tuniface = Regexp.last_match(1)
 
         when /^\s*tunnel key ([^\s]+)/i
-          spass = $1
+          spass = Regexp.last_match(1)
           siface = tuniface
 
           print_good("#{thost}:#{tport} GRE Tunnel Key #{spass} for Interface Tunnel #{siface}")
-          cred = credential_data.dup
-          cred[:private_data] = spass
-          cred[:private_type] = :nonreplayable_hash
-          create_credential_and_login(cred)
+          if framework.db.active
+            cred = credential_data.dup
+            cred[:private_data] = spass
+            cred[:private_type] = :nonreplayable_hash
+            create_credential_and_login(cred)
+          end
 
         when /^\s*ip nhrp authentication ([^\s]+)/i
-          spass = $1
+          spass = Regexp.last_match(1)
           siface = tuniface
 
           print_good("#{thost}:#{tport} NHRP Authentication Key #{spass} for Interface Tunnel #{siface}")
-          cred = credential_data.dup
-          cred[:private_data] = spass
-          cred[:private_type] = :nonreplayable_hash
-          create_credential_and_login(cred)
-
-
-#
-# Various authentication secrets
-#
-        when /^\s*username ([^\s]+) privilege (\d+) (secret|password) (\d+) ([^\s]+)/i
-          user  = $1
-          priv  = $2
-          stype = $4.to_i
-          spass = $5
-
-          if stype == 5
-            print_good("#{thost}:#{tport} Username '#{user}' with MD5 Encrypted Password: #{spass}")
+          if framework.db.active
             cred = credential_data.dup
-            cred[:jtr_format] = 'md5'
-            cred[:username] = user.to_s
             cred[:private_data] = spass
             cred[:private_type] = :nonreplayable_hash
             create_credential_and_login(cred)
           end
 
-          if stype == 0
+          #
+          # Various authentication secrets
+          #
+        when /^\s*username ([^\s]+) privilege (\d+) (secret|password) (\d+) ([^\s]+)/i
+          user = Regexp.last_match(1)
+          priv = Regexp.last_match(2)
+          stype = Regexp.last_match(4).to_i
+          spass = Regexp.last_match(5)
+
+          if framework.db.active
+            cred = credential_data.dup
+            cred[:username] = user.to_s
+            cred[:private_data] = spass
+          else
+            cred = {} # throw away
+          end
+
+          case stype
+          when 5
+            print_good("#{thost}:#{tport} Username '#{user}' with MD5 Encrypted Password: #{spass}")
+            cred[:jtr_format] = 'md5'
+            cred[:private_type] = :nonreplayable_hash
+            create_credential_and_login(cred) if framework.db.active
+          when 0
             print_good("#{thost}:#{tport} Username '#{user}' with Password: #{spass}")
-            cred = credential_data.dup
-            cred[:username] = user.to_s
-            cred[:private_data] = spass
-            create_credential_and_login(cred)
-          end
-
-          if stype == 7
-            spass = cisco_ios_decrypt7(spass) rescue spass
+            create_credential_and_login(cred) if framework.db.active
+          when 7
+            spass = begin
+                    cisco_ios_decrypt7(spass)
+                    rescue StandardError
+                      spass
+                  end
             print_good("#{thost}:#{tport} Username '#{user}' with Decrypted Password: #{spass}")
+            cred[:private_data] = spass
+            create_credential_and_login(cred) if framework.db.active
+          end
+
+          # This regex captures ephones from Cisco Unified Communications Manager Express (CUE) which come in forms like:
+          # username "phonefour" password 444444
+          # username test password test
+          # This is used for the voicemail system
+        when /^\s*username "?([\da-z]+)"? password ([^\s]+)/i
+          user = Regexp.last_match(1)
+          spass = Regexp.last_match(2)
+          print_good("#{thost}:#{tport} ePhone Username '#{user}' with Password: #{spass}")
+          if framework.db.active
             cred = credential_data.dup
             cred[:username] = user.to_s
             cred[:private_data] = spass
             create_credential_and_login(cred)
           end
-
-        # This regex captures ephones from Cisco Unified Communications Manager Express (CUE) which come in forms like:
-        # username "phonefour" password 444444
-        # username test password test
-        # This is used for the voicemail system
-        when /^\s*username "?([\da-z]+)"? password ([^\s]+)/i
-          user  = $1
-          spass = $2
-          print_good("#{thost}:#{tport} ePhone Username '#{user}' with Password: #{spass}")
-          cred = credential_data.dup
-          cred[:username] = user.to_s
-          cred[:private_data] = spass
-          create_credential_and_login(cred)
 
         when /^\s*username ([^\s]+) (secret|password) (\d+) ([^\s]+)/i
-          user  = $1
-          stype = $3.to_i
-          spass = $4
+          user = Regexp.last_match(1)
+          stype = Regexp.last_match(3).to_i
+          spass = Regexp.last_match(4)
 
-          if stype == 5
+          if framework.db.active
+            cred = credential_data.dup
+            cred[:username] = user.to_s
+            cred[:private_data] = spass
+          else
+            cred = {}
+          end
+
+          case stype
+          when 5
             print_good("#{thost}:#{tport} Username '#{user}' with MD5 Encrypted Password: #{spass}")
-            cred = credential_data.dup
             cred[:jtr_format] = 'md5'
-            cred[:username] = user.to_s
-            cred[:private_data] = spass
             cred[:private_type] = :nonreplayable_hash
-            create_credential_and_login(cred)
-          end
-
-          if stype == 0
+            create_credential_and_login(cred) if framework.db.active
+          when 0
             print_good("#{thost}:#{tport} Username '#{user}' with Password: #{spass}")
-            cred = credential_data.dup
-            cred[:username] = user.to_s
-            cred[:private_data] = spass
-            create_credential_and_login(cred)
-          end
-
-          if stype == 7
-            spass = cisco_ios_decrypt7(spass) rescue spass
+            create_credential_and_login(cred) if framework.db.active
+          when 7
+            spass = begin
+                    cisco_ios_decrypt7(spass)
+                    rescue StandardError
+                      spass
+                  end
             print_good("#{thost}:#{tport} Username '#{user}' with Decrypted Password: #{spass}")
-            cred = credential_data.dup
-            cred[:username] = user.to_s
             cred[:private_data] = spass
-            create_credential_and_login(cred)
+            create_credential_and_login(cred) if framework.db.active
           end
 
-        # https://www.cisco.com/c/en/us/td/docs/voice_ip_comm/cucme/command/reference/cme_cr/cme_cr_chapter_010101.html#wp3722577363
+          # https://www.cisco.com/c/en/us/td/docs/voice_ip_comm/cucme/command/reference/cme_cr/cme_cr_chapter_010101.html#wp3722577363
         when /^\s*web admin (customer|system) name ([^\s]+) (secret [0|5]|password) ([^\s]+)/i
-          login = $1
-          suser = $2
-          stype = $3
-          spass = $4
-          if stype == 'secret 5'
-            print_good("#{thost}:#{tport} Web Admin Username: #{suser} Type: #{login} MD5 Encrypted Password: #{spass}")
+          login = Regexp.last_match(1)
+          suser = Regexp.last_match(2)
+          stype = Regexp.last_match(3)
+          spass = Regexp.last_match(4)
+
+          if framework.db.active
             cred = credential_data.dup
-            cred[:jtr_format] = 'md5'
             cred[:username] = suser.to_s
             cred[:private_data] = spass
-            cred[:private_type] = :nonreplayable_hash
-            create_credential_and_login(cred)
+          else
+            cred = {}
           end
 
-          if stype == 'secret 0' || stype == 'password'
+          case stype
+          when 'secret 5'
+            print_good("#{thost}:#{tport} Web Admin Username: #{suser} Type: #{login} MD5 Encrypted Password: #{spass}")
+            cred[:jtr_format] = 'md5'
+            cred[:private_type] = :nonreplayable_hash
+            create_credential_and_login(cred) if framework.db.active
+          when 'secret 0', 'password'
             print_good("#{thost}:#{tport} Web Username: #{suser} Type: #{login} Password: #{spass}")
-            cred = credential_data.dup
-            cred[:username] = suser.to_s
-            cred[:private_data] = spass
-            create_credential_and_login(cred)
+            create_credential_and_login(cred) if framework.db.active
           end
 
         when /^\s*ppp.*username ([^\s]+) (secret|password) (\d+) ([^\s]+)/i
 
-          suser = $1
-          stype = $3.to_i
-          spass = $4
+          suser = Regexp.last_match(1)
+          stype = Regexp.last_match(3).to_i
+          spass = Regexp.last_match(4)
 
-          if stype == 5
+          if framework.db.active
+            cred = credential_data.dup
+            cred[:username] = suser.to_s
+            cred[:private_data] = spass
+          else
+            cred = {}
+          end
+
+          case stype
+          when 5
             print_good("#{thost}:#{tport} PPP Username #{suser} MD5 Encrypted Password: #{spass}")
-            cred = credential_data.dup
             cred[:jtr_format] = 'md5'
-            cred[:username] = suser.to_s
-            cred[:private_data] = spass
             cred[:private_type] = :nonreplayable_hash
-            create_credential_and_login(cred)
-          end
-
-          if stype == 0
+            create_credential_and_login(cred) if framework.db.active
+          when 0
             print_good("#{thost}:#{tport} PPP Username: #{suser} Password: #{spass}")
-            cred = credential_data.dup
-            cred[:username] = suser.to_s
-            cred[:private_data] = spass
-            create_credential_and_login(cred)
-          end
-
-          if stype == 7
-            spass = cisco_ios_decrypt7(spass) rescue spass
+            create_credential_and_login(cred) if framework.db.active
+          when 7
+            spass = begin
+                    cisco_ios_decrypt7(spass)
+                    rescue StandardError
+                      spass
+                  end
             print_good("#{thost}:#{tport} PPP Username: #{suser} Decrypted Password: #{spass}")
-            cred = credential_data.dup
-            cred[:username] = suser.to_s
             cred[:private_data] = spass
-            create_credential_and_login(cred)
+            create_credential_and_login(cred) if framework.db.active
           end
 
         when /^\s*ppp chap (secret|password) (\d+) ([^\s]+)/i
-          stype = $2.to_i
-          spass = $3
+          stype = Regexp.last_match(2).to_i
+          spass = Regexp.last_match(3)
 
-          if stype == 5
+          if framework.db.active
+            cred = credential_data.dup
+            cred[:private_data] = spass
+          else
+            cred = {}
+          end
+
+          case stype
+          when 5
             print_good("#{thost}:#{tport} PPP CHAP MD5 Encrypted Password: #{spass}")
-            cred = credential_data.dup
             cred[:jtr_format] = 'md5'
-            cred[:private_data] = spass
             cred[:private_type] = :nonreplayable_hash
-            create_credential_and_login(cred)
-          end
-
-          if stype == 0
+            create_credential_and_login(cred) if framework.db.active
+          when 0
             print_good("#{thost}:#{tport} Password: #{spass}")
-            cred = credential_data.dup
-            cred[:private_data] = spass
-            create_credential_and_login(cred)
-          end
-
-          if stype == 7
-            spass = cisco_ios_decrypt7(spass) rescue spass
+            create_credential_and_login(cred) if framework.db.active
+          when 7
+            spass = begin
+                    cisco_ios_decrypt7(spass)
+                    rescue StandardError
+                      spass
+                  end
             print_good("#{thost}:#{tport} PPP Decrypted Password: #{spass}")
-            cred = credential_data.dup
             cred[:private_data] = spass
-            create_credential_and_login(cred)
+            create_credential_and_login(cred) if framework.db.active
           end
+        end
       end
     end
   end
-
 end
-end
-

--- a/lib/msf/core/auxiliary/juniper.rb
+++ b/lib/msf/core/auxiliary/juniper.rb
@@ -26,17 +26,19 @@ module Auxiliary::Juniper
       :os_name => 'Juniper ScreenOS'
     })
 
-    credential_data = {
-      address: thost,
-      port: tport,
-      protocol: 'tcp',
-      workspace_id: myworkspace.id,
-      origin_type: :service,
-      service_name: '',
-      private_type: :nonreplayable_hash,
-      module_fullname: self.fullname,
-      status: Metasploit::Model::Login::Status::UNTRIED
-    }
+    if framework.db.active
+      credential_data = {
+        address: thost,
+        port: tport,
+        protocol: 'tcp',
+        workspace_id: myworkspace.id,
+        origin_type: :service,
+        service_name: '',
+        private_type: :nonreplayable_hash,
+        module_fullname: self.fullname,
+        status: Metasploit::Model::Login::Status::UNTRIED
+      }
+    end
 
     store_loot('juniper.netscreen.config', 'text/plain', thost, config.strip, 'config.txt', 'Juniper Netscreen Configuration')
 
@@ -48,6 +50,7 @@ module Auxiliary::Juniper
       admin_name = result[0].strip
       admin_hash = result[1].strip
       print_good("Admin user #{admin_name} found with password hash #{admin_hash}")
+      next unless framework.db.active
       cred = credential_data.dup
       cred[:username] = admin_name
       cred[:private_data] = admin_hash
@@ -66,6 +69,7 @@ module Auxiliary::Juniper
       user_enable = result[4].strip
       user_hash = result[3].strip
       print_good("User #{user_uid} named #{user_name} found with password hash #{user_hash}. Enable permission: #{user_enable}")
+      next unless framework.db.active
       cred = credential_data.dup
       cred[:username] = user_name
       cred[:jtr_format] = 'sha1'
@@ -80,6 +84,7 @@ module Auxiliary::Juniper
       snmp_community = result[0].strip
       snmp_permissions = result[1].strip
       print_good("SNMP community #{snmp_community} with permissions #{snmp_permissions}")
+      next unless framework.db.active
       cred = credential_data.dup
       if snmp_permissions.downcase == 'read-write'
         cred[:access_level] = 'RW'
@@ -105,6 +110,7 @@ module Auxiliary::Juniper
       ppp_hash = result[3].strip
       ppp_authtype = result[1].strip
       print_good("PPTP Profile #{ppp_name} with username #{ppp_username} hash #{ppp_hash} via #{ppp_authtype}")
+      next unless framework.db.active
       cred = credential_data.dup
       cred[:username] = ppp_username
       cred[:private_data] = ppp_hash
@@ -122,6 +128,7 @@ module Auxiliary::Juniper
       ike_password = result[2].strip
       ike_method = result[3].strip
       print_good("IKE Profile #{ike_name} to #{ike_address} with password #{ike_password} via #{ike_method}")
+      next unless framework.db.active
       cred = credential_data.dup
       cred[:private_data] = ike_password
       cred[:private_type] = :password
@@ -143,17 +150,19 @@ module Auxiliary::Juniper
     })
 
 
-    credential_data = {
-      address: thost,
-      port: tport,
-      protocol: 'tcp',
-      workspace_id: myworkspace.id,
-      origin_type: :service,
-      private_type: :nonreplayable_hash,
-      service_name: '',
-      module_fullname: self.fullname,
-      status: Metasploit::Model::Login::Status::UNTRIED
-    }
+    if framework.db.active
+      credential_data = {
+        address: thost,
+        port: tport,
+        protocol: 'tcp',
+        workspace_id: myworkspace.id,
+        origin_type: :service,
+        private_type: :nonreplayable_hash,
+        service_name: '',
+        module_fullname: self.fullname,
+        status: Metasploit::Model::Login::Status::UNTRIED
+      }
+    end
 
     store_loot('juniper.junos.config', 'text/plain', thost, config.strip, 'config.txt', 'Juniper JunOS Configuration')
 
@@ -171,11 +180,13 @@ module Auxiliary::Juniper
       jtr_format = identify_hash root_hash
 
       print_good("root password hash: #{root_hash}")
-      cred = credential_data.dup
-      cred[:username] = 'root'
-      cred[:jtr_format] = jtr_format
-      cred[:private_data] = root_hash
-      create_credential_and_login(cred)
+      if framework.db.active
+        cred = credential_data.dup
+        cred[:username] = 'root'
+        cred[:jtr_format] = jtr_format
+        cred[:private_data] = root_hash
+        create_credential_and_login(cred)
+      end
     end
 
     # access privileges https://kb.juniper.net/InfoCenter/index?page=content&id=KB10902
@@ -187,6 +198,7 @@ module Auxiliary::Juniper
       jtr_format = identify_hash user_hash
 
       print_good("User #{user_uid} named #{user_name} in group #{user_permission} found with password hash #{user_hash}.")
+      next unless framework.db.active
       cred = credential_data.dup
       cred[:username] = user_name
       cred[:jtr_format] = jtr_format
@@ -199,6 +211,7 @@ module Auxiliary::Juniper
       snmp_community = result[0].strip
       snmp_permissions = result[1].strip
       print_good("SNMP community #{snmp_community} with permissions read-#{snmp_permissions}")
+      next unless framework.db.active
       cred = credential_data.dup
       if snmp_permissions.downcase == 'write'
         cred[:access_level] = 'RW'
@@ -217,6 +230,7 @@ module Auxiliary::Juniper
       radius_hash = result[1].strip
       radius_server = result[0].strip
       print_good("radius server #{radius_server} password hash: #{radius_hash}")
+      next unless framework.db.active
       cred = credential_data.dup
       cred[:address] = radius_server
       cred[:port] = 1812
@@ -230,6 +244,7 @@ module Auxiliary::Juniper
       ppp_username = result[0].strip
       ppp_hash = result[1].strip
       print_good("PPTP username #{ppp_username} hash #{ppp_hash} via PAP")
+      next unless framework.db.active
       cred = credential_data.dup
       cred[:username] = ppp_username
       cred[:private_data] = ppp_hash

--- a/lib/msf/core/auxiliary/mikrotik.rb
+++ b/lib/msf/core/auxiliary/mikrotik.rb
@@ -78,17 +78,19 @@ module Msf
     end
 
     def mikrotik_swos_config_eater(thost, tport, config)
-      credential_data = {
-        address: thost,
-        port: tport,
-        protocol: 'tcp',
-        workspace_id: myworkspace.id,
-        origin_type: :service,
-        private_type: :password,
-        service_name: '',
-        module_fullname: fullname,
-        status: Metasploit::Model::Login::Status::UNTRIED
-      }
+      if framework.db.active
+        credential_data = {
+          address: thost,
+          port: tport,
+          protocol: 'tcp',
+          workspace_id: myworkspace.id,
+          origin_type: :service,
+          private_type: :password,
+          service_name: '',
+          module_fullname: fullname,
+          status: Metasploit::Model::Login::Status::UNTRIED
+        }
+      end
 
       # Default SNMP to UDP
       if tport == 161
@@ -128,13 +130,15 @@ module Msf
       if /,\.pwd\.b:{pwd:'(?<password>[a-f\d]*)'}/ =~ config
         password = Array(password).pack('H*')
         print_good("#{thost}:#{tport} Admin login password: #{password}")
-        cred = credential_data.dup
-        cred[:port] = 80
-        cred[:protocol] = 'tcp'
-        cred[:service_name] = 'www'
-        cred[:username] = 'admin' # hardcoded
-        cred[:private_data] = password.to_s
-        create_credential_and_login(cred)
+        if framework.db.active
+          cred = credential_data.dup
+          cred[:port] = 80
+          cred[:protocol] = 'tcp'
+          cred[:service_name] = 'www'
+          cred[:username] = 'admin' # hardcoded
+          cred[:private_data] = password.to_s
+          create_credential_and_login(cred)
+        end
       end
 
       # ,snmp.b:{en:0x01,com:'7075626c6963',ci:'636f6e74616374696e666f',loc:'6c6f636174696f6e'}
@@ -144,12 +148,14 @@ module Msf
         contact = Array(contact).pack('H*')
         location = Array(location).pack('H*')
         print_good("#{thost}:#{tport} SNMP Community: #{community}, contact: #{contact}, location: #{location}")
-        cred = credential_data.dup
-        cred[:port] = 161
-        cred[:protocol] = 'udp'
-        cred[:service_name] = 'snmp'
-        cred[:private_data] = community.to_s
-        create_credential_and_login(cred)
+        if framework.db.active
+          cred = credential_data.dup
+          cred[:port] = 161
+          cred[:protocol] = 'udp'
+          cred[:service_name] = 'snmp'
+          cred[:private_data] = community.to_s
+          create_credential_and_login(cred)
+        end
       end
 
       # ,nm:['506f727431','506f727432','506f727433','506f727434','506f727435','506f727436','506f727437','506f727438','506f727439','506f72743130','506f72743131','506f72743132','506f72743133','506f72743134','506f72743135','506f72743136','506f72743137','506f72743138','506f72743139','506f72743230','506f72743231','506f72743232','506f72743233','75706c696e6b','53465031','53465032']}
@@ -167,17 +173,19 @@ module Msf
     end
 
     def mikrotik_routeros_config_eater(thost, tport, config)
-      credential_data = {
-        address: thost,
-        port: tport,
-        protocol: 'tcp',
-        workspace_id: myworkspace.id,
-        origin_type: :service,
-        private_type: :password,
-        service_name: '',
-        module_fullname: fullname,
-        status: Metasploit::Model::Login::Status::UNTRIED
-      }
+      if framework.db.active
+        credential_data = {
+          address: thost,
+          port: tport,
+          protocol: 'tcp',
+          workspace_id: myworkspace.id,
+          origin_type: :service,
+          private_type: :password,
+          service_name: '',
+          module_fullname: fullname,
+          status: Metasploit::Model::Login::Status::UNTRIED
+        }
+      end
 
       # Default SNMP to UDP
       if tport == 161
@@ -222,6 +230,8 @@ module Msf
 
             value = values_to_hash(value)
             print_good("#{thost}:#{tport} #{value['disabled'] ? 'disabled' : ''} Open VPN Client to #{value['connect-to']} on mac #{value['mac-address']} named #{value['name']} with username #{value['user']} and password #{value['password']}")
+            next unless framework.db.active
+
             cred = credential_data.dup
             cred[:port] = 1194
             cred[:service_name] = 'openvpn'
@@ -241,6 +251,8 @@ module Msf
 
             value = values_to_hash(value)
             print_good("#{thost}:#{tport} #{value['disabled'] ? '' : 'disabled'} PPPoE Client on #{value['interface']} named #{value['name']} and service name #{value['service-name']} with username #{value['user']} and password #{value['password']}")
+            next unless framework.db.active
+
             cred = credential_data.dup
             cred[:username] = value['user']
             cred[:service_name] = 'pppoe'
@@ -259,6 +271,8 @@ module Msf
 
             value = values_to_hash(value)
             print_good("#{thost}:#{tport} #{value['disabled'] ? '' : 'disabled'} L2TP Client to #{value['connect-to']} named #{value['name']} with username #{value['user']} and password #{value['password']}")
+            next unless framework.db.active
+
             cred = credential_data.dup
             cred[:port] = 1701
             cred[:service_name] = 'l2tp'
@@ -277,6 +291,8 @@ module Msf
 
             value = values_to_hash(value)
             print_good("#{thost}:#{tport} #{value['disabled'] ? '' : 'disabled'} PPTP Client to #{value['connect-to']} named #{value['name']} with username #{value['user']} and password #{value['password']}")
+            next unless framework.db.active
+
             cred = credential_data.dup
             cred[:service_name] = 'pptp'
             cred[:port] = 1723
@@ -299,6 +315,8 @@ module Msf
             else
               print_good("#{thost}:#{tport} SNMP community #{value['name']} with password #{value['authentication-password']} and #{value['write-access'] ? 'write access' : 'read only'}")
             end
+
+            next unless framework.db.active
 
             cred = credential_data.dup
             if value['write-access'] == 'yes'
@@ -323,6 +341,8 @@ module Msf
 
             value = values_to_hash(value)
             print_good("#{thost}:#{tport} #{value['disabled'] ? 'disabled' : ''} PPP tunnel bridging named #{value['name']} with profile name #{value['profile']} and password #{value['password']}")
+            next unless framework.db.active
+
             cred = credential_data.dup
             cred[:username] = ''
             cred[:private_data] = value['password']
@@ -340,6 +360,8 @@ module Msf
 
             value = values_to_hash(value)
             print_good("#{thost}:#{tport} #{value['disabled'] == 'yes' ? 'disabled' : ''} SMB Username #{value['name']} and password #{value['password']}#{' with RO only access' if value['read-only'] == 'yes' || !value['read-only']}")
+            next unless framework.db.active
+
             cred = credential_data.dup
             if value['read-only'] == 'yes' || !value['read-only']
               cred[:access_level] = 'RO'
@@ -360,6 +382,8 @@ module Msf
 
             value = values_to_hash(value)
             print_good("#{thost}:#{tport} SMTP Username #{value['user']} and password #{value['password']} for #{value['address']}:#{value['port'] || '25'}")
+            next unless framework.db.active
+
             cred = credential_data.dup
             cred[:service_name] = 'smtp'
             cred[:port] = value['port'] ? value['port'].to_i : 25
@@ -391,7 +415,11 @@ module Msf
               next
             end
 
-            cred = credential_data.dup
+            if framework.db.active
+              cred = credential_data.dup
+            else
+              cred = {}
+            end
 
             # The following section is a little complicated due to the way mikrotik exports values
             # in compact/terse/default mode, it will skip printing default values, so we have to check
@@ -399,25 +427,33 @@ module Msf
             # In verbose mode, they will print but be empty
             if value['wpa-pre-shared-key'] && !value['wpa-pre-shared-key'].empty?
               output << " with WPA password #{value['wpa-pre-shared-key']}"
-              cred[:private_data] = value['wpa-pre-shared-key']
-              create_credential_and_login(cred)
+              if framework.db.active
+                cred[:private_data] = value['wpa-pre-shared-key']
+                create_credential_and_login(cred)
+              end
             elsif value['wpa2-pre-shared-key'] && !value['wpa2-pre-shared-key'].empty?
               output << " with WPA2 password #{value['wpa2-pre-shared-key']}"
-              cred[:private_data] = value['wpa2-pre-shared-key']
-              create_credential_and_login(cred)
+              if framework.db.active
+                cred[:private_data] = value['wpa2-pre-shared-key']
+                create_credential_and_login(cred)
+              end
             elsif value['authentication-types'] == 'wpa2-eap'
               output << " with WPA2-EAP username #{value['mschapv2-username']} password #{value['mschapv2-password']}"
-              cred[:username] = value['mschapv2-username']
-              cred[:private_data] = value['mschapv2-password']
-              create_credential_and_login(cred)
+              if framework.db.active
+                cred[:username] = value['mschapv2-username']
+                cred[:private_data] = value['mschapv2-password']
+                create_credential_and_login(cred)
+              end
             elsif value['static-key-0'] || value['static-key-1'] || value['static-key-2'] || value['static-key-3']
               (0..3).each do |i|
                 key = "static-key-#{i}"
                 next unless value[key]
 
                 output << " with WEP password #{value[key]}"
-                cred[:private_data] = value[key]
-                create_credential_and_login(cred) # run for each key we find
+                if framework.db.active
+                  cred[:private_data] = value[key]
+                  create_credential_and_login(cred) # run for each key we find
+                end
               end
             end
 

--- a/lib/msf/core/auxiliary/ubiquiti.rb
+++ b/lib/msf/core/auxiliary/ubiquiti.rb
@@ -5,43 +5,43 @@ require 'bson'
 require 'zip'
 
 module Msf
+  ###
+  #
+  # This module provides methods for working with Ubiquiti equipment
+  #
+  ###
+  module Auxiliary::Ubiquiti
+    include Msf::Auxiliary::Report
 
-###
-#
-# This module provides methods for working with Ubiquiti equipment
-#
-###
-module Auxiliary::Ubiquiti
-  include Msf::Auxiliary::Report
-
-  def decrypt_unf(contents)
-    aes = OpenSSL::Cipher.new('aes-128-cbc')
-    aes.key = 'bcyangkmluohmars' # https://github.com/zhangyoufu/unifi-backup-decrypt/blob/master/E>
-    aes.padding = 0
-    aes.decrypt
-    aes.iv = 'ubntenterpriseap'
-    aes.update(contents)
-  end
-
-  def repair_zip(fname)
-    zip_exe = Msf::Util::Helper.which('zip')
-    if zip_exe.nil?
-      print_error('Zip utility not found.')
-      return nil
+    def decrypt_unf(contents)
+      aes = OpenSSL::Cipher.new('aes-128-cbc')
+      aes.key = 'bcyangkmluohmars' # https://github.com/zhangyoufu/unifi-backup-decrypt/blob/master/E>
+      aes.padding = 0
+      aes.decrypt
+      aes.iv = 'ubntenterpriseap'
+      aes.update(contents)
     end
-    print_status('Attempting to repair zip file (this is normal and takes some time)')
-    temp_file = Rex::Quickfile.new("fixed_zip")
-    system("yes | #{zip_exe} -FF #{fname} --out #{temp_file.path}.zip > /dev/null")
-    return File.read("#{temp_file.path}.zip")
-  end
 
-  def extract_and_process_db(db_path)
-    f = nil
-    Zip::File.open(db_path) do |zip_file|
-      # Handle entries one by one
-      zip_file.each do |entry|
-        # Extract to file
-        if entry.name == 'db.gz'
+    def repair_zip(fname)
+      zip_exe = Msf::Util::Helper.which('zip')
+      if zip_exe.nil?
+        print_error('Zip utility not found.')
+        return nil
+      end
+      print_status('Attempting to repair zip file (this is normal and takes some time)')
+      temp_file = Rex::Quickfile.new('fixed_zip')
+      system("yes | #{zip_exe} -FF #{fname} --out #{temp_file.path}.zip > /dev/null")
+      return File.read("#{temp_file.path}.zip")
+    end
+
+    def extract_and_process_db(db_path)
+      f = nil
+      Zip::File.open(db_path) do |zip_file|
+        # Handle entries one by one
+        zip_file.each do |entry|
+          # Extract to file
+          next unless entry.name == 'db.gz'
+
           print_status('extracting db.gz')
           gz = Zlib::GzipReader.new(entry.get_input_stream)
           f = gz.read
@@ -49,129 +49,135 @@ module Auxiliary::Ubiquiti
           break
         end
       end
+      f
     end
-    f
-  end
 
-  def bson_to_json(byte_buffer)
-    # This function takes a byte buffer (db file from Unifi read in), which is a bson string
-    # it then converts it to JSON, where it uses the 'select collection' documents
-    # as keys.  For instance a bson that contained the follow (displayed in json
-    # for ease):
-    # {"__cmd"=>"select", "collection"=>"heatmap"}
-    # {'example'=>'example'}
-    # {'example2'=>'example2'}
-    # would become:
-    # {'heatmap'=>[{'example'=>'example'}, {'example2'=>'example2'}]}
-    # this is mainly done to ease the grouping of items for easy navigation later.
+    def bson_to_json(byte_buffer)
+      # This function takes a byte buffer (db file from Unifi read in), which is a bson string
+      # it then converts it to JSON, where it uses the 'select collection' documents
+      # as keys.  For instance a bson that contained the follow (displayed in json
+      # for ease):
+      # {"__cmd"=>"select", "collection"=>"heatmap"}
+      # {'example'=>'example'}
+      # {'example2'=>'example2'}
+      # would become:
+      # {'heatmap'=>[{'example'=>'example'}, {'example2'=>'example2'}]}
+      # this is mainly done to ease the grouping of items for easy navigation later.
 
-    buf = BSON::ByteBuffer.new(byte_buffer)
-    output = {}
-    key = ''
+      buf = BSON::ByteBuffer.new(byte_buffer)
+      output = {}
+      key = ''
 
-    while buf
-      begin
-        # read the document from the buffer
-        bson = BSON::Document.from_bson(buf)
-        if bson.has_key?('__cmd')
-          key = bson['collection']
-          output[key] = []
-          next
+      while buf
+        begin
+          # read the document from the buffer
+          bson = BSON::Document.from_bson(buf)
+          if bson.has_key?('__cmd')
+            key = bson['collection']
+            output[key] = []
+            next
+          end
+          output[key] << bson
+        rescue RangeError
+          break
         end
-        output[key] << bson
-      rescue RangeError
-        break
       end
+      output
     end
-    output
-  end
 
-  def unifi_config_eater(thost, tport, config)
-    # This is for the Ubiquiti Unifi files.  These are typically in the backup download zip file
-    # then in the db.gz file as db.  It is a MongoDB BSON file, which can be difficult to read.
-    # https://stackoverflow.com/questions/51242412/undefined-method-read-bson-document-for-bsonmodule
-    # The BSON file is a bunch of BSON Documents chained together.  There doesn't seem to be a good
-    # way to read these files directly, so looping through loading the content seems to work with
-    # minimal repercussions.
+    def unifi_config_eater(thost, tport, config)
+      # This is for the Ubiquiti Unifi files.  These are typically in the backup download zip file
+      # then in the db.gz file as db.  It is a MongoDB BSON file, which can be difficult to read.
+      # https://stackoverflow.com/questions/51242412/undefined-method-read-bson-document-for-bsonmodule
+      # The BSON file is a bunch of BSON Documents chained together.  There doesn't seem to be a good
+      # way to read these files directly, so looping through loading the content seems to work with
+      # minimal repercussions.
 
-    # The file format is broken into sections by __cmd select documents as such:
-    # {"__cmd"=>"select", "collection"=>"heatmap"}
-    # we can pull the relevant section name via the collection value.
+      # The file format is broken into sections by __cmd select documents as such:
+      # {"__cmd"=>"select", "collection"=>"heatmap"}
+      # we can pull the relevant section name via the collection value.
 
-    creds_template = {
-      address: thost,
-      port: tport,
-      protocol: 'tcp',
-      workspace_id: myworkspace.id,
-      origin_type: :service,
-      private_type: :password,
-      service_name: '',
-      module_fullname: self.fullname,
-      status: Metasploit::Model::Login::Status::UNTRIED
-    }
-
-    report_host({
-      :host => thost,
-      :info => 'Ubiquiti Unifi Controller'
-    })
-
-    store_loot('unifi.json', 'application/json', thost, config.to_s.strip, 'unifi.json', 'Ubiquiti Unifi Configuration')
-
-    # Example BSON lines
-    # {"__cmd"=>"select", "collection"=>"admin"}
-    # {"_id"=>BSON::ObjectId('5c7f23af3825ce2067a1d9ce'), "name"=>"adminuser", "email"=>"admin@admin.com", "x_shadow"=>"$6$R4qnAaaF$AAAlL2t.fXu0aaa9z3uvcIm3ujbtJLhIO.lN1xZqHZPQoUAXs2BUTmI5UbuBo2/8t3epzbVLib17Ls7GCVx7V.", "time_created"=>1551825823, "last_site_name"=>"default", "ubic_name"=>"admin@admin.com", "ubic_uuid"=>"c23da064-3f4d-282f-1dc9-7e25f9c6812c", "ui_settings"=>{"dashboardConfig"=>{"lastActiveDashboardId"=>"2c7f2d213813ce2487d1ac38", "dashboards"=>{"3c7f678a3815ce2021d1d9c7"=>{"order"=>1}, "5b4f2d269115ce2087d1abb9"=>{}}}}}
-    def process_admin(lines, credential_data)
-      lines.each do |line|
-        admin_name = line['name']
-        admin_email = line['email']
-        admin_password_hash = line['x_shadow']
-        print_good("Admin user #{admin_name} with email #{admin_email} found with password hash #{admin_password_hash}")
-        cred = credential_data.dup
-        cred[:username] = admin_name
-        cred[:private_data] = admin_password_hash
-        cred[:private_type] = :nonreplayable_hash
-        create_credential_and_login(cred)
+      if framework.db.active
+        creds_template = {
+          address: thost,
+          port: tport,
+          protocol: 'tcp',
+          workspace_id: myworkspace.id,
+          origin_type: :service,
+          private_type: :password,
+          service_name: '',
+          module_fullname: fullname,
+          status: Metasploit::Model::Login::Status::UNTRIED
+        }
       end
-    end
 
-    # Example BSON lines
-    # {"__cmd"=>"select", "collection"=>"firewallrule"}
-    # {"_id"=>BSON::ObjectId('5c7f23af3825ce2067a1d9ce'), "ruleset" => "WAN_OUT", "rule_index" => "2000", "name" => "Block Example", "enabled" => true, "action" => "reject", "protocol_match_excepted" => false, "logging" => false, "state_new" => false, "state_established" => false, "state_invalid" => false, "state_related" => false, "ipsec" => "", "src_firewallgroup_ids" => ["1a1c15a11111ce14b1f1111a"], "src_mac_address" => "", "dst_firewallgroup_ids" => [], "dst_address" => "", "src_address" => "", "protocol" => "all", "icmp_typename" => "", "src_networkconf_id" => "", "src_networkconf_type" => "NETv4", "dst_networkconf_id" => "", "dst_networkconf_type" => "NETv4", "site_id" => "1c1f208b3815ce1111a1a1a1"}
-    def process_firewallrule(lines, _)
-      lines.each do |line|
-        rule = "#{line['action']}"
-        unless line['dst_address'].empty?
-          rule << " dst addresses: #{line['dst_address']}"
-        end
-        unless line['dst_firewallgroup_ids'].empty?
-          rule << " dst group: #{line['dst_firewallgroup_ids'].join(', ')}"
-        end
-        unless line['src_address'].empty?
-          rule << " src addresses: #{line['src_address']}"
-        end
-        unless line['src_firewallgroup_ids'].empty?
-          rule << " src group: #{line['src_firewallgroup_ids'].join(', ')}"
-        end
-        rule << " protocol: #{line['protocol']}"
+      report_host({
+        host: thost,
+        info: 'Ubiquiti Unifi Controller'
+      })
 
-        print_status("#{line['enabled'] ? 'Enabled' : 'Disabled'} Firewall Rule '#{line['name']}': #{rule}")
+      store_loot('unifi.json', 'application/json', thost, config.to_s.strip, 'unifi.json', 'Ubiquiti Unifi Configuration')
+
+      # Example BSON lines
+      # {"__cmd"=>"select", "collection"=>"admin"}
+      # {"_id"=>BSON::ObjectId('5c7f23af3825ce2067a1d9ce'), "name"=>"adminuser", "email"=>"admin@admin.com", "x_shadow"=>"$6$R4qnAaaF$AAAlL2t.fXu0aaa9z3uvcIm3ujbtJLhIO.lN1xZqHZPQoUAXs2BUTmI5UbuBo2/8t3epzbVLib17Ls7GCVx7V.", "time_created"=>1551825823, "last_site_name"=>"default", "ubic_name"=>"admin@admin.com", "ubic_uuid"=>"c23da064-3f4d-282f-1dc9-7e25f9c6812c", "ui_settings"=>{"dashboardConfig"=>{"lastActiveDashboardId"=>"2c7f2d213813ce2487d1ac38", "dashboards"=>{"3c7f678a3815ce2021d1d9c7"=>{"order"=>1}, "5b4f2d269115ce2087d1abb9"=>{}}}}}
+      def process_admin(lines, credential_data)
+        lines.each do |line|
+          admin_name = line['name']
+          admin_email = line['email']
+          admin_password_hash = line['x_shadow']
+          print_good("Admin user #{admin_name} with email #{admin_email} found with password hash #{admin_password_hash}")
+          next unless framework.db.active
+
+          cred = credential_data.dup
+          cred[:username] = admin_name
+          cred[:private_data] = admin_password_hash
+          cred[:private_type] = :nonreplayable_hash
+          create_credential_and_login(cred)
+        end
       end
-    end
 
-    # Example BSON lines
-    # {"__cmd"=>"select", "collection"=>"radiusprofile"}
-    # {"_id"=>BSON::ObjectId('2c7a318c38c5ce2f86d179cb'), "attr_no_delete"=>true, "attr_hidden_id"=>"Default", "name"=>"Default", "site_id"=>"3c7f226b2315be2087a1d5b2", "use_usg_auth_server"=>true, "auth_servers"=>[{"ip"=>"192.168.0.1", "port"=>1812, "x_secret"=>""}], "acct_servers"=>[]}
-    def process_radiusprofile(lines, credential_data)
-      lines.each do |line|
-        line['auth_servers'].each do |server|
-          report_service(
-            host: server['ip'],
-            port: server['port'],
-            name: 'radius',
-            proto: 'udp'
-          )
-          if server['x_secret'] # no need to output if the secret is blank, therefore its not configured
+      # Example BSON lines
+      # {"__cmd"=>"select", "collection"=>"firewallrule"}
+      # {"_id"=>BSON::ObjectId('5c7f23af3825ce2067a1d9ce'), "ruleset" => "WAN_OUT", "rule_index" => "2000", "name" => "Block Example", "enabled" => true, "action" => "reject", "protocol_match_excepted" => false, "logging" => false, "state_new" => false, "state_established" => false, "state_invalid" => false, "state_related" => false, "ipsec" => "", "src_firewallgroup_ids" => ["1a1c15a11111ce14b1f1111a"], "src_mac_address" => "", "dst_firewallgroup_ids" => [], "dst_address" => "", "src_address" => "", "protocol" => "all", "icmp_typename" => "", "src_networkconf_id" => "", "src_networkconf_type" => "NETv4", "dst_networkconf_id" => "", "dst_networkconf_type" => "NETv4", "site_id" => "1c1f208b3815ce1111a1a1a1"}
+      def process_firewallrule(lines, _)
+        lines.each do |line|
+          rule = (line['action']).to_s
+          unless line['dst_address'].empty?
+            rule << " dst addresses: #{line['dst_address']}"
+          end
+          unless line['dst_firewallgroup_ids'].empty?
+            rule << " dst group: #{line['dst_firewallgroup_ids'].join(', ')}"
+          end
+          unless line['src_address'].empty?
+            rule << " src addresses: #{line['src_address']}"
+          end
+          unless line['src_firewallgroup_ids'].empty?
+            rule << " src group: #{line['src_firewallgroup_ids'].join(', ')}"
+          end
+          rule << " protocol: #{line['protocol']}"
+
+          print_status("#{line['enabled'] ? 'Enabled' : 'Disabled'} Firewall Rule '#{line['name']}': #{rule}")
+        end
+      end
+
+      # Example BSON lines
+      # {"__cmd"=>"select", "collection"=>"radiusprofile"}
+      # {"_id"=>BSON::ObjectId('2c7a318c38c5ce2f86d179cb'), "attr_no_delete"=>true, "attr_hidden_id"=>"Default", "name"=>"Default", "site_id"=>"3c7f226b2315be2087a1d5b2", "use_usg_auth_server"=>true, "auth_servers"=>[{"ip"=>"192.168.0.1", "port"=>1812, "x_secret"=>""}], "acct_servers"=>[]}
+      def process_radiusprofile(lines, credential_data)
+        lines.each do |line|
+          line['auth_servers'].each do |server|
+            report_service(
+              host: server['ip'],
+              port: server['port'],
+              name: 'radius',
+              proto: 'udp'
+            )
+            next unless server['x_secret'] # no need to output if the secret is blank, therefore its not configured
+
             print_good("Radius server: #{server['ip']}:#{server['port']} with secret '#{server['x_secret']}'")
+            next unless framework.db.active
+
             cred = credential_data.dup
             cred[:username] = ''
             cred[:private_data] = server['x_secret']
@@ -181,47 +187,53 @@ module Auxiliary::Ubiquiti
           end
         end
       end
-    end
 
-    # settings has multiple items we care about:
-    #   x_mesh_essid/x_mesh_psk -> should contain the mesh network wifi name and password
-    #   ntp -> ntp servers
-    #   x_ssh_username/x_ssh_password/x_ssh_keys/x_ssh_sha512passwd
+      # settings has multiple items we care about:
+      #   x_mesh_essid/x_mesh_psk -> should contain the mesh network wifi name and password
+      #   ntp -> ntp servers
+      #   x_ssh_username/x_ssh_password/x_ssh_keys/x_ssh_sha512passwd
 
-    # Example lines
-    # {"__cmd"=>"select", "collection"=>"setting"}
-    # {"_id"=>BSON::ObjectId('3c3e21ac3715ce20a721d9ba'), "site_id"=>"3c2f215b3825ca2087c1dfb6", "key"=>"ntp", "ntp_server_1"=>"0.ubnt.pool.ntp.org", "ntp_server_2"=>"1.ubnt.pool.ntp.org", "ntp_server_3"=>"2.ubnt.pool.ntp.org", "ntp_server_4"=>"3.ubnt.pool.ntp.org"}
-    # {"_id"=>BSON::ObjectId('3c3e21ac3715ce20a721d9bb'), "site_id"=>"3c2f215b3825ca2087c1dfb6", "key"=>"mgmt", "advanced_feature_enabled"=>false, "x_ssh_enabled"=>true, "x_ssh_bind_wildcard"=>false, "x_ssh_auth_password_enabled"=>true, "unifi_idp_enabled"=>true, "x_mgmt_key"=>"ba6cbe170f8276cd86b24ac79ab29afc", "x_ssh_username"=>"admin", "x_ssh_password"=>"16xoB6F2UyAcU6fP", "x_ssh_keys"=>[], "x_ssh_sha512passwd"=>"$6$R4qnAaaF$AAAlL2t.fXu0aaa9z3uvcIm3ujbtJLhIO.lN1xZqHZPQoUAXs2BUTmI5UbuBo2/8t3epzbVLib17Ls7GCVx7V."}
-    # {"_id"=>BSON::ObjectId('3c3e21ac3715ce20a721d9bc'), "site_id"=>"3c2f215b3825ca2087c1dfb6", "key"=>"connectivity", "enabled"=>true, "uplink_type"=>"gateway", "x_mesh_essid"=>"vwire-851237d214c8c6ba", "x_mesh_psk"=>"523a9b872b4624c7894f96c3ae22cdfa"}
-    # {"_id"=>BSON::ObjectId('3c3e21ac3715ce20a721d9bd'), "site_id"=>"3c2f215b3825ca2087c1dfb6", "key"=>"snmp", "community": "public", "enabled": true, "enabledV3": true, "username": "usernamesnmpv3", "x_password": "passwordsnmpv3"}
-    def process_setting(lines, credential_data)
-      lines.each do |line|
-        case line['key']
-        when 'snmp'
-          cred = credential_data.dup
-          cred[:protocol] = 'udp'
-          cred[:port] = 161
-          cred[:service_name] = 'snmp'
-          unless line['community'].blank?
-            cred[:private_data] = line['community']
+      # Example lines
+      # {"__cmd"=>"select", "collection"=>"setting"}
+      # {"_id"=>BSON::ObjectId('3c3e21ac3715ce20a721d9ba'), "site_id"=>"3c2f215b3825ca2087c1dfb6", "key"=>"ntp", "ntp_server_1"=>"0.ubnt.pool.ntp.org", "ntp_server_2"=>"1.ubnt.pool.ntp.org", "ntp_server_3"=>"2.ubnt.pool.ntp.org", "ntp_server_4"=>"3.ubnt.pool.ntp.org"}
+      # {"_id"=>BSON::ObjectId('3c3e21ac3715ce20a721d9bb'), "site_id"=>"3c2f215b3825ca2087c1dfb6", "key"=>"mgmt", "advanced_feature_enabled"=>false, "x_ssh_enabled"=>true, "x_ssh_bind_wildcard"=>false, "x_ssh_auth_password_enabled"=>true, "unifi_idp_enabled"=>true, "x_mgmt_key"=>"ba6cbe170f8276cd86b24ac79ab29afc", "x_ssh_username"=>"admin", "x_ssh_password"=>"16xoB6F2UyAcU6fP", "x_ssh_keys"=>[], "x_ssh_sha512passwd"=>"$6$R4qnAaaF$AAAlL2t.fXu0aaa9z3uvcIm3ujbtJLhIO.lN1xZqHZPQoUAXs2BUTmI5UbuBo2/8t3epzbVLib17Ls7GCVx7V."}
+      # {"_id"=>BSON::ObjectId('3c3e21ac3715ce20a721d9bc'), "site_id"=>"3c2f215b3825ca2087c1dfb6", "key"=>"connectivity", "enabled"=>true, "uplink_type"=>"gateway", "x_mesh_essid"=>"vwire-851237d214c8c6ba", "x_mesh_psk"=>"523a9b872b4624c7894f96c3ae22cdfa"}
+      # {"_id"=>BSON::ObjectId('3c3e21ac3715ce20a721d9bd'), "site_id"=>"3c2f215b3825ca2087c1dfb6", "key"=>"snmp", "community": "public", "enabled": true, "enabledV3": true, "username": "usernamesnmpv3", "x_password": "passwordsnmpv3"}
+      def process_setting(lines, credential_data)
+        lines.each do |line|
+          case line['key']
+          when 'snmp'
+            if framework.db.active
+              cred = credential_data.dup
+              cred[:protocol] = 'udp'
+              cred[:port] = 161
+              cred[:service_name] = 'snmp'
+            else
+              cred = {} # throw away
+            end
+            unless line['community'].blank?
+              print_good("SNMP v2 #{line['enabled'] ? 'enabled' : 'disabled'} with password #{line['community']}")
+              cred[:private_data] = line['community']
+              create_credential_and_login(cred) if framework.db.active
+            end
+            unless line['x_password'].blank? || line['username'].blank?
+              print_good("SNMP v3 #{line['enabledV3'] ? 'enabled' : 'disabled'} with username #{line['username']} password #{line['x_password']}")
+              cred[:username] = line['username']
+              cred[:private_data] = line['x_password']
+              create_credential_and_login(cred) if framework.db.active
+            end
+          when 'connectivity'
+            print_good("Mesh Wifi Network #{line['x_mesh_essid']} password #{line['x_mesh_psk']}")
+            next unless framework.db.active
+
+            cred = credential_data.dup
+            cred[:username] = line['x_mesh_essid']
+            cred[:private_data] = line['x_mesh_psk']
             create_credential_and_login(cred)
-            print_good("SNMP v2 #{line['enabled'] ? 'enabled' : 'disabled'} with password #{line['community']}")
-          end
-          unless line['x_password'].blank? || line['username'].blank?
-            cred[:username] = line['username']
-            cred[:private_data] = line['x_password']
-            create_credential_and_login(cred)
-            print_good("SNMP v3 #{line['enabledV3'] ? 'enabled' : 'disabled'} with username #{line['username']} password #{line['x_password']}")
-          end
-        when 'connectivity'
-          cred = credential_data.dup
-          cred[:username] = line['x_mesh_essid']
-          cred[:private_data] = line['x_mesh_psk']
-          create_credential_and_login(cred)
-          print_good("Mesh Wifi Network #{line['x_mesh_essid']} password #{line['x_mesh_psk']}")
-        when 'ntp'
-          ['ntp_server_1', 'ntp_server_2', 'ntp_server_3', 'ntp_server_4'].each do |ntp|
-            unless line[ntp].empty? || line[ntp].ends_with?('ubnt.pool.ntp.org')
+          when 'ntp'
+            ['ntp_server_1', 'ntp_server_2', 'ntp_server_3', 'ntp_server_4'].each do |ntp|
+              next if line[ntp].empty? || line[ntp].ends_with?('ubnt.pool.ntp.org')
+
               report_service(
                 host: line[ntp],
                 port: '123',
@@ -230,96 +242,100 @@ module Auxiliary::Ubiquiti
               )
               print_good("NTP Server: #{line[ntp]}")
             end
+          when 'mgmt'
+            admin_name = line['x_ssh_username']
+            admin_password_hash = line['x_ssh_sha512passwd']
+            admin_password = line['x_ssh_password']
+            print_good("SSH user #{admin_name} found with password #{admin_password} and hash #{admin_password_hash}")
+            line['x_ssh_keys'].each do |key|
+              print_good("SSH user #{admin_name} found with SSH key: #{key}")
+            end
+            next unless framework.db.active
+
+            cred = credential_data.dup
+            cred[:username] = admin_name
+            cred[:private_data] = admin_password_hash
+            cred[:private_type] = :nonreplayable_hash
+            login = create_credential_and_login(cred)
+            if login.present? && admin_password.present?
+              create_cracked_credential(username: admin_name, password: admin_password, core_id: login.core.id)
+            end
           end
-        when 'mgmt'
-          admin_name = line['x_ssh_username']
-          admin_password_hash = line['x_ssh_sha512passwd']
-          admin_password = line['x_ssh_password']
-          print_good("SSH user #{admin_name} found with password #{admin_password} and hash #{admin_password_hash}")
+        end
+      end
+
+      # Example lines
+      # {"__cmd"=>"select", "collection"=>"wlanconf"}
+      # {"_id"=>BSON::ObjectId('3c3e21ac3715ce20a721d9ba'), "enabled" => true, "security" => "wpapsk", "wep_idx" => 1, "wpa_mode" => "wpa2", "wpa_enc" => "ccmp", "usergroup_id" => "5a7f111a3815ce1111a1d1c3", "dtim_mode" => "default", "dtim_ng" => 1, "dtim_na" => 1, "minrate_ng_enabled" => false, "minrate_ng_advertising_rates" => false, "minrate_ng_data_rate_kbps" => 1000, "minrate_ng_cck_rates_enabled" => true, "minrate_na_enabled" => false, "minrate_na_advertising_rates" => false, "minrate_na_data_rate_kbps" => 6000, "mac_filter_enabled" => false, "mac_filter_policy" => "allow", "mac_filter_list" => [], "bc_filter_enabled" => false, "bc_filter_list" => [], "group_rekey" => 3600, "name" => "ssid_name", "x_passphrase" => "supersecret", "wlangroup_id" => "5c7f208c3815ce2087d1d9c4", "schedule" => [], "minrate_ng_mgmt_rate_kbps" => 1000, "minrate_na_mgmt_rate_kbps" => 6000, "minrate_ng_beacon_rate_kbps" => 1000, "minrate_na_beacon_rate_kbps" => 6000, "site_id" => "5c7f208b3815ce2087d1d9b6", "x_iapp_key" => "d11a1c86df1111be86aaa69e8aa1c57f", "no2ghz_oui" => true}
+      def process_wlanconf(lines, credential_data)
+        lines.each do |line|
+          ssid = line['name']
+          mode = line['security']
+          password = line['x_passphrase']
+          print_good("#{line['enabled'] ? 'Enabled' : 'Disabled'} wifi #{ssid} on #{mode}(#{line['wpa_mode']},#{line['wpa_enc']}) has password #{password}")
+          next unless framework.db.active
+
           cred = credential_data.dup
-          cred[:username] = admin_name
-          cred[:private_data] = admin_password_hash
-          cred[:private_type] = :nonreplayable_hash
-          login = create_credential_and_login(cred)
-          if login.present? && admin_password.present?
-            create_cracked_credential(username: admin_name, password: admin_password, core_id: login.core.id)
+          cred[:username] = ssid
+          cred[:private_data] = password
+          create_credential_and_login(cred)
+        end
+      end
+
+      # Example lines
+      # {"__cmd"=>"select", "collection"=>"firewallgroup"}
+      # {"_id"=>BSON::ObjectId('3c3e21ac3715ce20a721d9ba'), "name" => "Cameras", "group_type" => "address-group", "group_members" => ["1.1.1.1"], "site_id" => "5c7f111b3815ce208aaa111a"}
+      def process_firewallgroup(lines, _)
+        lines.each do |line|
+          print_status("Firewall Group: #{line['name']}, group type: #{line['group_type']}, members: #{line['group_members'].join(', ')}")
+        end
+      end
+
+      # Example lines
+      # {"__cmd"=>"select", "collection"=>"device"}
+      # {"_id"=>BSON::ObjectId('3c3e21ac3715ce20a721d9ba'), "ip" => "5.5.5.5", "mac" => "cc:cc:cc:cc:cc:cc", "model" => "UGW3", "type" => "ugw", "version" => "4.4.44.5213844", "adopted" => true, "site_id" => "5aaaaaabaaaaae1117d1d1b6", "x_authkey" => "eaaaaaaa63e59ab89c111e11d6e11aa1", "cfgversion" => "aaa4b11b1df1a111", "config_network" => {"type" => "dhcp", "ip" => "1.1.1.1"}, "license_state" => "registered", "two_phase_adopt" => false, "unsupported" => false, "unsupported_reason" => 0, "x_fingerprint" => "aa:aa:11:aa:11:11:11:11:11:11:11:11:11:11:11:11", "x_ssh_hostkey" => "MIIBIjANBgkAhkiG9w0AAQEFAAOCAQ8AMIIBCgKCAQEAAU4S/7r548xvtGuHlgAAAKzkrL+t97ZWAZru8wQFbltEB4111HiIAkzt041td8V+P7c1bQtn3YQdViAuH2h2sgt8feAvMWo56OskAoDvHwAEv5AWqmPKy/xmKbdfgA5wTzvSztPGFA4QuOuA1YxQICf1MgpoOtplAAA31JxAYF/t7n8qgvJlm1JRv2AAAZHHtSiz1IaxzOO9LAAAqCfHvHugPcZYk2yAAAP7JrnnR1fAVj9F4aaYaA0eSjvDTAglykXHCbh1EWAAAecqHZ/SWn9cjmuAAArZxxG6m6Eu/aj9we82/PmtKzQGN0RWUsgrxajQowtNpVsNTnaOglUsfQIDAAAA", "x_ssh_hostkey_fingerprint" => "11:11:11:11:11:11:11:11:11:11:11:11:11:11:11:11", "inform_url" => "http://1.1.2.2:8080/inform", "inform_ip" => "1.1.1.1", "serial" => "AAAAAAAAAAAA", "required_version" => "4.0.0", "ethernet_table" => [{ "mac" => "b4:fb:e4:cc:cc:cc", "num_port" => 1, "name" => "eth0"}, {"mac" => "b4:fb:e4:bb:bb:bb", "num_port" => 1, "name" => "eth1"}, {"mac" => "b4:fb:e4:aa:aa:aa", "num_port" => 1, "name" => "eth2"}], "fw_caps" => 184323, "hw_caps" => 0, "usg_caps" => 786431, "board_rev" => 16, "x_aes_gcm" => true, "ethernet_overrides" => [{"ifname" => "eth1", "networkgroup" => "LAN"}, {"ifname" => "eth0", "networkgroup" => "WAN"}], "led_override" => "default", "led_override_color" => "#0000ff", "led_override_color_brightness" => 100, "outdoor_mode_override" => "default", "name" => "USG", "map_id" => "1a111c2e1111ce2087d1e199", "x" => -22.11111198630405, "y" => -41.1111113859866, "heightInMeters" => 2.4}
+      def process_device(lines, _)
+        lines.each do |line|
+          report_host({
+            host: line['ip'],
+            name: line['name'],
+            mac: line['mac'],
+            os_name: 'Ubiquiti Unifi'
+          })
+          print_good("Unifi Device #{line['name']} of model #{line['model']} on #{line['ip']}")
+        end
+      end
+
+      # Example lines
+      # {"__cmd"=>"select", "collection"=>"user"}
+      # {"_id"=>BSON::ObjectId('3c3e21ac3715ce20a721d9ba'), "mac" => "00:0c:29:11:aa:11", "site_id" => "5c7f111b1111aa2087d11111", "oui" => "Vmware", "is_guest" => false, "first_seen" => 1551111161, "last_seen" => 1561621747, "is_wired" => true, "hostname" => "android", "usergroup_id" => "", "name" => "example device", "noted" => true, "use_fixedip" =>  true, "network_id" => "1c7f111a1115aa2087aaa9aa", "fixed_ip" => "7.7.7.7"}
+      def process_user(lines, _)
+        lines.each do |line|
+          host_hash = {
+            name: line['hostname'],
+            mac: line['mac']
+          }
+          desc = "#{line['hostname']} (#{line['mac']})"
+          if line['fixed_ip']
+            host_hash[:host] = line['fixed_ip']
+            desc << " on IP #{line['fixed_ip']}"
           end
-          line['x_ssh_keys'].each do |key|
-            print_good("SSH user #{admin_name} found with SSH key: #{key}")
+          if line['name']
+            host_hash[:info] = line['name']
+            desc << " with name #{line['name']}"
           end
+          report_host(host_hash)
+          print_good("Network Device #{desc} found")
         end
       end
-    end
 
-    # Example lines
-    # {"__cmd"=>"select", "collection"=>"wlanconf"}
-    # {"_id"=>BSON::ObjectId('3c3e21ac3715ce20a721d9ba'), "enabled" => true, "security" => "wpapsk", "wep_idx" => 1, "wpa_mode" => "wpa2", "wpa_enc" => "ccmp", "usergroup_id" => "5a7f111a3815ce1111a1d1c3", "dtim_mode" => "default", "dtim_ng" => 1, "dtim_na" => 1, "minrate_ng_enabled" => false, "minrate_ng_advertising_rates" => false, "minrate_ng_data_rate_kbps" => 1000, "minrate_ng_cck_rates_enabled" => true, "minrate_na_enabled" => false, "minrate_na_advertising_rates" => false, "minrate_na_data_rate_kbps" => 6000, "mac_filter_enabled" => false, "mac_filter_policy" => "allow", "mac_filter_list" => [], "bc_filter_enabled" => false, "bc_filter_list" => [], "group_rekey" => 3600, "name" => "ssid_name", "x_passphrase" => "supersecret", "wlangroup_id" => "5c7f208c3815ce2087d1d9c4", "schedule" => [], "minrate_ng_mgmt_rate_kbps" => 1000, "minrate_na_mgmt_rate_kbps" => 6000, "minrate_ng_beacon_rate_kbps" => 1000, "minrate_na_beacon_rate_kbps" => 6000, "site_id" => "5c7f208b3815ce2087d1d9b6", "x_iapp_key" => "d11a1c86df1111be86aaa69e8aa1c57f", "no2ghz_oui" => true}
-    def process_wlanconf(lines, credential_data)
-      lines.each do |line|
-        ssid = line['name']
-        mode = line['security']
-        password = line['x_passphrase']
-        cred = credential_data.dup
-        cred[:username] = ssid
-        cred[:private_data] = password
-        create_credential_and_login(cred)
-        print_good("#{line['enabled'] ? 'Enabled' : 'Disabled'} wifi #{ssid} on #{mode}(#{line['wpa_mode']},#{line['wpa_enc']}) has password #{password}")
+      # here is where we actually process the file
+      config.each do |key, value|
+        next unless respond_to?("process_#{key}")
+
+        credential_data = creds_template.dup
+        send("process_#{key}", value, credential_data)
       end
-    end
-
-    # Example lines
-    # {"__cmd"=>"select", "collection"=>"firewallgroup"}
-    # {"_id"=>BSON::ObjectId('3c3e21ac3715ce20a721d9ba'), "name" => "Cameras", "group_type" => "address-group", "group_members" => ["1.1.1.1"], "site_id" => "5c7f111b3815ce208aaa111a"}
-    def process_firewallgroup(lines, _)
-      lines.each do |line|
-        print_status("Firewall Group: #{line['name']}, group type: #{line['group_type']}, members: #{line['group_members'].join(', ')}")
-      end
-    end
-
-    # Example lines
-    # {"__cmd"=>"select", "collection"=>"device"}
-    # {"_id"=>BSON::ObjectId('3c3e21ac3715ce20a721d9ba'), "ip" => "5.5.5.5", "mac" => "cc:cc:cc:cc:cc:cc", "model" => "UGW3", "type" => "ugw", "version" => "4.4.44.5213844", "adopted" => true, "site_id" => "5aaaaaabaaaaae1117d1d1b6", "x_authkey" => "eaaaaaaa63e59ab89c111e11d6e11aa1", "cfgversion" => "aaa4b11b1df1a111", "config_network" => {"type" => "dhcp", "ip" => "1.1.1.1"}, "license_state" => "registered", "two_phase_adopt" => false, "unsupported" => false, "unsupported_reason" => 0, "x_fingerprint" => "aa:aa:11:aa:11:11:11:11:11:11:11:11:11:11:11:11", "x_ssh_hostkey" => "MIIBIjANBgkAhkiG9w0AAQEFAAOCAQ8AMIIBCgKCAQEAAU4S/7r548xvtGuHlgAAAKzkrL+t97ZWAZru8wQFbltEB4111HiIAkzt041td8V+P7c1bQtn3YQdViAuH2h2sgt8feAvMWo56OskAoDvHwAEv5AWqmPKy/xmKbdfgA5wTzvSztPGFA4QuOuA1YxQICf1MgpoOtplAAA31JxAYF/t7n8qgvJlm1JRv2AAAZHHtSiz1IaxzOO9LAAAqCfHvHugPcZYk2yAAAP7JrnnR1fAVj9F4aaYaA0eSjvDTAglykXHCbh1EWAAAecqHZ/SWn9cjmuAAArZxxG6m6Eu/aj9we82/PmtKzQGN0RWUsgrxajQowtNpVsNTnaOglUsfQIDAAAA", "x_ssh_hostkey_fingerprint" => "11:11:11:11:11:11:11:11:11:11:11:11:11:11:11:11", "inform_url" => "http://1.1.2.2:8080/inform", "inform_ip" => "1.1.1.1", "serial" => "AAAAAAAAAAAA", "required_version" => "4.0.0", "ethernet_table" => [{ "mac" => "b4:fb:e4:cc:cc:cc", "num_port" => 1, "name" => "eth0"}, {"mac" => "b4:fb:e4:bb:bb:bb", "num_port" => 1, "name" => "eth1"}, {"mac" => "b4:fb:e4:aa:aa:aa", "num_port" => 1, "name" => "eth2"}], "fw_caps" => 184323, "hw_caps" => 0, "usg_caps" => 786431, "board_rev" => 16, "x_aes_gcm" => true, "ethernet_overrides" => [{"ifname" => "eth1", "networkgroup" => "LAN"}, {"ifname" => "eth0", "networkgroup" => "WAN"}], "led_override" => "default", "led_override_color" => "#0000ff", "led_override_color_brightness" => 100, "outdoor_mode_override" => "default", "name" => "USG", "map_id" => "1a111c2e1111ce2087d1e199", "x" => -22.11111198630405, "y" => -41.1111113859866, "heightInMeters" => 2.4}
-    def process_device(lines, _)
-      lines.each do |line|
-        report_host({
-         :host => line['ip'],
-         :name => line['name'],
-         :mac => line['mac'],
-         :os_name => 'Ubiquiti Unifi'
-        })
-        print_good("Unifi Device #{line['name']} of model #{line['model']} on #{line['ip']}")
-      end
-    end
-
-    # Example lines
-    # {"__cmd"=>"select", "collection"=>"user"}
-    # {"_id"=>BSON::ObjectId('3c3e21ac3715ce20a721d9ba'), "mac" => "00:0c:29:11:aa:11", "site_id" => "5c7f111b1111aa2087d11111", "oui" => "Vmware", "is_guest" => false, "first_seen" => 1551111161, "last_seen" => 1561621747, "is_wired" => true, "hostname" => "android", "usergroup_id" => "", "name" => "example device", "noted" => true, "use_fixedip" =>  true, "network_id" => "1c7f111a1115aa2087aaa9aa", "fixed_ip" => "7.7.7.7"}
-    def process_user(lines, _)
-      lines.each do |line|
-        host_hash = {
-         :name => line['hostname'],
-         :mac => line['mac']
-        }
-        desc = "#{line['hostname']} (#{line['mac']})"
-        if line['fixed_ip'] 
-          host_hash[:host] = line['fixed_ip']
-          desc << " on IP #{line['fixed_ip']}"
-        end
-        if line['name'] 
-          host_hash[:info] = line['name']
-          desc << " with name #{line['name']}"
-        end
-        report_host(host_hash)
-        print_good("Network Device #{desc} found")
-      end
-    end
-
-    # here is where we actually process the file
-    config.each do |key,value|
-      next unless self.respond_to?("process_#{key}")
-      credential_data = creds_template.dup
-      self.send("process_#{key}", value, credential_data)
     end
   end
-end
 end


### PR DESCRIPTION
Fixes #13962

The libraries for networking/* all contained a bug where if a DB is NOT connected, they would throw an error.  The libraries have been updated to avoid this error and simply print the output w/o using DB stuff.  This was done with `framework.db.status` similar to the ping payloads per @bwatters-r7 suggestion.

I ran `rubocop -a` to correct a bunch of things as well.

I embedded config files when applicable in the docs to make it slightly easier to grab them.

## Verification

- [x] rspec still works
- [x] `use auxiliary/admin/networking/*`
- [x] `info -d` and save a config to a local file (Ubiquiti you'll have to get your own)
- [x] `db_disconnect`
- [x] `set rhost`, `set config`
- [x] `run`
- [x] ensure you dont get a stack trace

