### PR TITLE
[GSoC] Add a method for SQL injections where query output is not needed, and read_from_file support for MySQLi

### DIFF
--- a/lib/msf/core/exploit/sqli/common.rb
+++ b/lib/msf/core/exploit/sqli/common.rb
@@ -39,18 +39,31 @@ module Msf::Exploit::SQLi
     end
 
     #
-    #   Queries the bloc with the given SQL query, and returns the result (this method is used in regular
-    #   SQL injection exploits, where the query results are returned in the response to the user)
+    #   Queries the bloc with the given SQL query, without necessarly returning a result (needed for
+    #   example when uploading a file using a time-based SQL injection, as it's not necessary to
+    #   run multiple queries for that purpose), not to be overriden, it is guaranteed that the query
+    #   will run only once.
     #   @param query [String] The SQL query to execute
-    #   @return [String] The query results
+    #   @return [String] The query results if any, ignore it if you don't expect output
     #
-    def run_sql(query)
+    def raw_run_sql(query)
       vprint_status "{SQLi} Executing (#{query})"
       if @hex_encode_strings
         query = hex_encode_strings(query)
         vprint_status "{SQLi} Encoded to (#{query})"
       end
       @query_proc.call(query)
+    end
+
+    #
+    #   Queries the bloc with the given SQL query, and returns the result, this method is overriden in
+    #   blind SQL injection classes, implementing the logic of leaking one bit at a time, and working 
+    #   exactly the same as this method.
+    #   @param query [String] The SQL query to execute
+    #   @return [String] The query results
+    #
+    def run_sql(query)
+      raw_run_sql(query)
     end
 
     attr_reader :datastore, :framework

--- a/lib/msf/core/exploit/sqli/mysqli/common.rb
+++ b/lib/msf/core/exploit/sqli/mysqli/common.rb
@@ -200,7 +200,14 @@ module Msf::Exploit::SQLi::MySQLi
     # Attempt writing data to the file at the given path
     #
     def write_to_file(fpath, data)
-      run_sql("select '#{data}' into dumpfile '#{fpath}'")
+      raw_run_sql("select '#{data}' into dumpfile '#{fpath}'")
+    end
+
+    #
+    # Attempt reading from a file on the filesystem
+    #
+    def read_from_file(fpath)
+      run_sql("select load_file('#{fpath}')")
     end
 
     private


### PR DESCRIPTION
This adds the method `raw_run_sql`, which will run the query one time, even if the injection type is time or boolean-based blind, this method willl be used in methods that write to files, execute system commands and so on (wouldn't make sense to use `run_sql` in these cases, as its implementation for blind queries checks the length of the output, then keeps leaking it bit by bit, it is necessary to run the query only once in these cases).

This also adds a method `read_from_file` for MySQLi, which would read from a file from the filesystem, if the `FILE` privilege is granted to the current user.

## Verification

Not a lot of changes, and mostly additions.

- `raw_run_sql` is the same as `run_sql` for non-blind injections, as it runs the query only once, and returns a result if any.
- For blind injection classes, `raw_run_sql` is not overriden, and still runs the query only once.

For testing `read_from_file`, the only method 'added', it just uses the `load_file` function available in MySQL.