### PR TITLE
Fix Scanner stall for modules of non equal per host duration 

### DIFF
--- a/lib/msf/core/auxiliary/scanner.rb
+++ b/lib/msf/core/auxiliary/scanner.rb
@@ -144,13 +144,11 @@ def run
         break
       end
 
-      # Assume that the oldest thread will be one of the
-      # first to finish and wait for it.  After that's
-      # done, remove any finished threads from the list
-      # and continue on.  This will open up at least one
-      # spot for a new thread
+      # Attempt to wait for the oldest thread for a second,
+      # remove any finished threads from the list
+      # and continue on.
       tla = @tl.length
-      @tl.first.join
+      @tl.first.join(1)
       @tl.delete_if { |t| not t.alive? }
       tlb = @tl.length
 
@@ -231,14 +229,12 @@ def run
         break
       end
 
-      # Assume that the oldest thread will be one of the
-      # first to finish and wait for it.  After that's
-      # done, remove any finished threads from the list
-      # and continue on.  This will open up at least one
-      # spot for a new thread
+      # Attempt to wait for the oldest thread for a second,
+      # remove any finished threads from the list
+      # and continue on.
       tla = 0
       @tl.map {|t| tla += t[:batch_size] }
-      @tl.first.join
+      @tl.first.join(1)
       @tl.delete_if { |t| not t.alive? }
       tlb = 0
       @tl.map {|t| tlb += t[:batch_size] }

--- a/lib/msf/core/auxiliary/scanner.rb
+++ b/lib/msf/core/auxiliary/scanner.rb
@@ -144,13 +144,11 @@ def run
         break
       end
 
-      # Assume that the oldest thread will be one of the
-      # first to finish and wait for it.  After that's
-      # done, remove any finished threads from the list
-      # and continue on.  This will open up at least one
-      # spot for a new thread
+      # Attempt to wait for the oldest thread for a second,
+      # remove any finished threads from the list
+      # and continue on. 
       tla = @tl.length
-      @tl.first.join
+      @tl.first.join(1)
       @tl.delete_if { |t| not t.alive? }
       tlb = @tl.length
 
@@ -231,14 +229,12 @@ def run
         break
       end
 
-      # Assume that the oldest thread will be one of the
-      # first to finish and wait for it.  After that's
-      # done, remove any finished threads from the list
-      # and continue on.  This will open up at least one
-      # spot for a new thread
+      # Attempt to wait for the oldest thread for a second,
+      # remove any finished threads from the list
+      # and continue on. 
       tla = 0
       @tl.map {|t| tla += t[:batch_size] }
-      @tl.first.join
+      @tl.first.join(1)
       @tl.delete_if { |t| not t.alive? }
       tlb = 0
       @tl.map {|t| tlb += t[:batch_size] }


### PR DESCRIPTION
This PR attempts to fix a  stall that happens when scanner module has non equal duration per different hosts. 
Imagine situation:
```
set THREADS 10  
```

Let's assume we scan 100 hosts. For all hosts the run_host() finishes within 10 seconds, except for a host number 4, where the run_host() from whatever reason takes 15 minutes.

1. 10 threads are spawned and filled with first ten hosts
2. 1st thread is joined after 10 seconds and rest of the threads is deleted except the thread number 4. 
3. The `@tl` now contains just one thread (the originally 4th one) and the thread becomes the oldest one (first to join)
4. New 9 threads are created, all 9 finish in 10 seconds
5. loop now waits in join for 15 minutes for the 4th host. **No new threads are created until the longest one finishes.**

I got the stall very often while testing the PR #13906, i.e. ldap server responses' duration vary between seconds and minutes or hours for different servers. 
With this fix I’ve been able to improve performance in my use case more than 30 times and been able to utilize both CPU and network bandwidth at maximum.