### PR TITLE
Winrm login workaround

### DIFF
--- a/lib/metasploit/framework/login_scanner/winrm.rb
+++ b/lib/metasploit/framework/login_scanner/winrm.rb
@@ -41,11 +41,19 @@ module Metasploit
 
         # send an HTTP request that WinRM would consider as valid  (SOAP XML in the message matching the XML schema definition)
         def send_request(opts)
+          opts['preferred_auth'] = self.framework_module.datastore['PREFERRED_AUTH']
+
+          # Straight up hack since if Basic auth is used winrm complains about the content size being 0
+          # The error message actually complains about the Content-Size header not being set even though it is
+          # but it doesn't like it being 0 and other auth methods fail with the supplied data to get around it
+          # So only if "Basic" is selected as the preferred option do we add this extra stuff as a workaround
+          if opts['preferred_auth'] == 'Basic'
             opts['headers'] ||= { }
             opts['ctype'] = 'application/soap+xml;charset=UTF-8'
             opts['data'] = wsman_identity_request
             opts['headers']['Content-Length'] = opts['data'].length
-            super
+          end
+          super
         end
 
         # The method *must* be "POST", so don't let the user change it

--- a/lib/metasploit/framework/login_scanner/winrm.rb
+++ b/lib/metasploit/framework/login_scanner/winrm.rb
@@ -42,11 +42,13 @@ module Metasploit
         # send an HTTP request that WinRM would consider as valid  (SOAP XML in the message matching the XML schema definition)
         def send_request(opts)
           opts['preferred_auth'] = self.framework_module.datastore['PREFERRED_AUTH']
-
           # Straight up hack since if Basic auth is used winrm complains about the content size being 0
           # The error message actually complains about the Content-Size header not being set even though it is
           # but it doesn't like it being 0 and other auth methods fail with the supplied data to get around it
           # So only if "Basic" is selected as the preferred option do we add this extra stuff as a workaround
+          #
+          # NOTE: if 'Basic' is selected as a preferred option then is not available these extra options are still set
+          # Since we don't know what auth method the client will finally use at this point it's difficult to get around
           if opts['preferred_auth'] == 'Basic'
             opts['headers'] ||= { }
             opts['ctype'] = 'application/soap+xml;charset=UTF-8'

--- a/lib/rex/proto/http/client.rb
+++ b/lib/rex/proto/http/client.rb
@@ -272,6 +272,14 @@ class Client
 
     # if several providers are available, the client may want one in particular
     preferred_auth = opts['preferred_auth']
+    if supported_auths.include?(preferred_auth)
+      # Really would like to give some feedback to the user here
+      # But I can't figure out how we're supposed to get `print_status` or similar in here
+      puts("#{preferred_auth} is supported")
+    elsif preferred_auth != nil
+      puts("#{preferred_auth} is not supported, falling back to one of #{supported_auths}")
+      preferred_auth = nil
+    end
 
     if supported_auths.include?('Basic') && (preferred_auth.nil? || preferred_auth == 'Basic')
       opts['headers'] ||= {}

--- a/modules/auxiliary/scanner/winrm/winrm_login.rb
+++ b/modules/auxiliary/scanner/winrm/winrm_login.rb
@@ -33,7 +33,7 @@ class MetasploitModule < Msf::Auxiliary
       'License'        => MSF_LICENSE
     )
 
-    register_options([Msf::OptEnum.new('PREFERRED_AUTH', 'Preferred authentication method', enums: ['Negotiate', 'Kerberos', 'Basic'], default: 'Negotiate')])
+    register_options([Msf::OptEnum.new('PREFERRED_AUTH', 'Preferred authentication method', enums: %w[Negotiate Basic], default: 'Negotiate')])
     deregister_options('PASSWORD_SPRAY')
   end
 

--- a/modules/auxiliary/scanner/winrm/winrm_login.rb
+++ b/modules/auxiliary/scanner/winrm/winrm_login.rb
@@ -33,6 +33,7 @@ class MetasploitModule < Msf::Auxiliary
       'License'        => MSF_LICENSE
     )
 
+    register_options([Msf::OptEnum.new('PREFERRED_AUTH', 'Preferred authentication method', enums: ['Negotiate', 'Kerberos', 'Basic'], default: 'Negotiate')])
     deregister_options('PASSWORD_SPRAY')
   end
 


### PR DESCRIPTION
This PR fixes an issue where the winrm login scanner was failing to authenticate with serves that did not accept 'Basic' authentication.

The issues arose from a recent PR which made an attempt to fix logging into winrm servers with 'Basic' authentication here #13442 
The data this PR added to the request caused logging into winrm with anything other than 'Basic' authentication to fail

This PR addresses this issue in a couple ways
- Only when the preferred auth method is set to 'Basic' will the extra data be sent in the request
- The auth method is defaulted to 'Negotiate' whereas previously it was 'Basic'
