### PR TITLE
Ignore tests when reloading files

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/developer.rb
+++ b/lib/msf/ui/console/command_dispatcher/developer.rb
@@ -76,8 +76,9 @@ class Msf::Ui::Console::CommandDispatcher::Developer
     files = output.split("\n")
 
     files.each do |file|
+      next if file.end_with?('_spec.rb')
       f = File.join(Msf::Config.install_root, file)
-      reload_file(file, print_errors: false)
+      reload_file(f, print_errors: false)
     end
   end
 


### PR DESCRIPTION
## Before

When spec files are changed, this causes issues with the reload_lib command:

```
msf6 exploit(windows/smb/psexec) > echo ' ' >> spec/lib/msf/core/author_spec.rb
[*] exec: echo ' ' >> spec/lib/msf/core/author_spec.rb

msf6 exploit(windows/smb/psexec) > reload_lib -a
[*] Reloading /Users/adfoster/Documents/code/metasploit-framework/spec/lib/msf/core/author_spec.rb
[-] Error while running command reload_lib: cannot load such file -- spec_helper
```

## After

The reload_lib command works, ignoring spec file changes:

```
msf6 exploit(windows/smb/psexec) > echo ' ' >> spec/lib/msf/core/author_spec.rb
[*] exec: echo ' ' >> spec/lib/msf/core/author_spec.rb

msf6 exploit(windows/smb/psexec) > reload_lib -a
msf6 exploit(windows/smb/psexec) >
```

## Verification

List the steps needed to make sure this thing works

- [x] Modify an arbitrary spec file: `echo ' ' >> spec/lib/msf/core/author_spec.rb`
- [x] Start `msfconsole`
- [x] `reload_lib -a`
- [x] **Verify** there is no crash