### PR TITLE
Update vbulletin module with correct CVE

### DIFF
--- a/modules/exploits/multi/http/vbulletin_widget_template_rce.rb
+++ b/modules/exploits/multi/http/vbulletin_widget_template_rce.rb
@@ -30,7 +30,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'References' => [
           ['URL', 'https://blog.exploitee.rs/2020/exploiting-vbulletin-a-tale-of-patch-fail/'],
-          ['CVE', '2020-7373']
+          ['CVE', '2020-17496']
         ],
         'DisclosureDate' => '2020-08-09',
         'License' => MSF_LICENSE,


### PR DESCRIPTION
Apparently someone snarfed the CVE for this out from under me. Since they were faster
to publish, we should use that number instead of the one out of our block.

## Verification

Check the the `info` for this module is actually `CVE-2020-17496` and not any other CVE. (I'm reluctant to say exactly what the number is replacing now because I worry about automatic scrapers. It's kind of like saying "Candyman" too many times.)
