### PR TITLE
Store loot from a file

### DIFF
--- a/lib/msf/core/auxiliary/report.rb
+++ b/lib/msf/core/auxiliary/report.rb
@@ -420,6 +420,8 @@ module Auxiliary::Report
     full_path = ::File.expand_path(path)
     if data.nil? && data_file.is_a?(String)
       FileUtils.cp(data_file, full_path)
+    elsif data.nil?
+      raise ArgumentError.new("One of arguments data or data_file must be provided.")
     else
       File.open(full_path, "wb") do |fd|
         fd.write(data)

--- a/lib/msf/core/auxiliary/report.rb
+++ b/lib/msf/core/auxiliary/report.rb
@@ -386,7 +386,8 @@ module Auxiliary::Report
   # ignored if there is no database
   #
   # +data_file+ in case the stolen data does not fit into memory, you may store them
-  # into a temporary file. Leave +data+=nil and provide the temp file path via +data_file+
+  # into a temporary file. Leave +data+=nil and provide the temp file path via +data_file+.
+  # The provided file must by synced to disk with IO#close or IO#fsync prior calling store_loot
   #
   def store_loot(ltype, ctype, host, data=nil, filename=nil, info=nil, service=nil, data_file=nil)
     if ! ::File.directory?(Msf::Config.loot_directory)

--- a/lib/msf/core/auxiliary/report.rb
+++ b/lib/msf/core/auxiliary/report.rb
@@ -385,7 +385,10 @@ module Auxiliary::Report
   # +filename+ and +info+ are only stored as metadata, and therefore both are
   # ignored if there is no database
   #
-  def store_loot(ltype, ctype, host, data, filename=nil, info=nil, service=nil)
+  # +data_file+ in case the stolen data does not fit into memory, you may store them
+  # into a temporary file. Leave +data+=nil and provide the temp file path via +data_file+
+  #
+  def store_loot(ltype, ctype, host, data=nil, filename=nil, info=nil, service=nil, data_file=nil)
     if ! ::File.directory?(Msf::Config.loot_directory)
       FileUtils.mkdir_p(Msf::Config.loot_directory)
     end
@@ -415,8 +418,12 @@ module Auxiliary::Report
 
     path = File.join(Msf::Config.loot_directory, name)
     full_path = ::File.expand_path(path)
-    File.open(full_path, "wb") do |fd|
-      fd.write(data)
+    if data.nil? && data_file.is_a?(String)
+      FileUtils.cp(data_file, full_path)
+    else
+      File.open(full_path, "wb") do |fd|
+        fd.write(data)
+      end
     end
 
     if (db)


### PR DESCRIPTION
This PR adds a possibility to store_loot via a file name. In case of low memory, multiple threads and/or very large loots, the data in string might exhaust the available memory (or cause heavy swapping).
With this PR modules can store the loot in a temporary file and instead of +data+ argument, provide a file path via +data_file+.

Sort of:

```
Tempfile.create do |f|
  while there_is_a_loot do
    f.write("... large loot chunk ...")
  end
  f.close # Important! to sync the data to disk
  store_loot(
    name, # ltype
    'text/plain', # ctype
    @rhost, # host
    nil, # data
    nil, # filename
    "Info", # info
    nil, # service
    f.path # data_file
  )
end

``` 