### PR TITLE
Fix payloads not being encoded in exploits when BadChars contains whitespace

### DIFF
--- a/lib/msf/core/encoded_payload.rb
+++ b/lib/msf/core/encoded_payload.rb
@@ -275,7 +275,8 @@ class EncodedPayload
     # If there are no bad characters, then the raw is the same as the
     # encoded
     else
-      unless reqs['BadChars'].blank?
+      # NOTE: BadChars can contain whitespace, so don't use String#blank?
+      unless reqs['BadChars'].nil? || reqs['BadChars'].empty?
         ilog("#{pinst.refname}: payload contains no badchars, skipping automatic encoding", 'core', LEV_0)
       end
 
@@ -516,7 +517,10 @@ protected
   attr_accessor :reqs
 
   def has_chars?(chars)
-    return false if chars.blank? || self.raw.blank?
+    # NOTE: BadChars can contain whitespace, so don't use String#blank?
+    if chars.nil? || self.raw.nil? || chars.empty? || self.raw.empty?
+      return false
+    end
 
     chars.each_byte do |bad|
       return true if self.raw.index(bad.chr(Encoding::ASCII_8BIT))


### PR DESCRIPTION
`msfvenom` is not affected by this regression due to its [separate pre-flight checks](https://github.com/rapid7/metasploit-framework/pull/13415/files#diff-76010ce8586ff92ecebb06ebd319a074R488).

```
wvu@kharak:~/rapid7/metasploit-framework:master$ ./msfvenom -p cmd/unix/generic -b " " CMD="uname -a"
[-] No platform was selected, choosing Msf::Module::Platform::Unix from the payload
[-] No arch selected, selecting arch: cmd from the payload
Found 5 compatible encoders
Attempting to encode payload with 1 iterations of cmd/echo
cmd/echo succeeded with size 61 (iteration=0)
cmd/echo chosen with final size 61
Payload size: 61 bytes
/bin/echo${IFS}-ne${IFS}'\x75\x6e\x61\x6d\x65\x20\x2d\x61'|sh
wvu@kharak:~/rapid7/metasploit-framework:master$
```

## Verification

See #13415. Test with whitespace.

## Testing

```
msf6 exploit(multi/misc/ibm_tm1_unauth_rce) > git diff
[*] exec: git diff

diff --git a/modules/exploits/multi/misc/ibm_tm1_unauth_rce.rb b/modules/exploits/multi/misc/ibm_tm1_unauth_rce.rb
index ba475e14d9..5a1fa69989 100644
--- a/modules/exploits/multi/misc/ibm_tm1_unauth_rce.rb
+++ b/modules/exploits/multi/misc/ibm_tm1_unauth_rce.rb
@@ -76,8 +76,8 @@ class MetasploitModule < Msf::Exploit::Remote
               'Arch'      => [ARCH_CMD],
               'Payload'   =>
               {
-                # only one bad char in Linux, baby! (that we know of...)
-                'BadChars'  => "\x27",
+                # lol
+                'BadChars'  => "\x20",
               }
             }
           ],
@@ -390,6 +390,8 @@ class MetasploitModule < Msf::Exploit::Remote
   end

   def exploit
+    return p payload.encoded
+
     # first let's check if SRVHOST is valid
     if datastore['SRVHOST'] == "0.0.0.0"
       fail_with(Failure::Unknown, "Please enter a valid IP address for SRVHOST")
msf6 exploit(multi/misc/ibm_tm1_unauth_rce) >
```

### `master`

```
msf6 exploit(multi/misc/ibm_tm1_unauth_rce) > rerun
[*] Reloading module...

[+] uname -a
"uname -a"
[*] Exploit completed, but no session was created.
msf6 exploit(multi/misc/ibm_tm1_unauth_rce) >
```

### Patch

```
msf6 exploit(multi/misc/ibm_tm1_unauth_rce) > rerun
[*] Reloading module...

[+] uname -a
"/bin/echo${IFS}-ne${IFS}'\\x75\\x6e\\x61\\x6d\\x65\\x20\\x2d\\x61'|sh"
[*] Exploit completed, but no session was created.
msf6 exploit(multi/misc/ibm_tm1_unauth_rce) >
```

Fixes #13415. Needed in #14000.