### PR TITLE
Use WritableDir in execute_cmdstager for exploit/linux/http/f5_bigip_tmui_rce

### DIFF
--- a/modules/exploits/linux/http/f5_bigip_tmui_rce.rb
+++ b/modules/exploits/linux/http/f5_bigip_tmui_rce.rb
@@ -123,7 +123,7 @@ class MetasploitModule < Msf::Exploit::Remote
     when :unix_cmd
       execute_command(payload.encoded)
     when :linux_dropper
-      execute_cmdstager
+      execute_cmdstager(temp: datastore['WritableDir'])
     end
   ensure
     delete_alias if @created_alias


### PR DESCRIPTION
Since we're using `WritableDir` in `script_path` for `upload_script`, we can also use it in `:temp` for `execute_cmdstager`.

```
msf6 exploit(linux/http/f5_bigip_tmui_rce) > grep WritableDir advanced
   WritableDir             /tmp                                                yes       Writable directory
msf6 exploit(linux/http/f5_bigip_tmui_rce) >
```

https://github.com/rapid7/rex-exploitation/blob/9c19df14e66d381e318996478e5d55018a6061c6/lib/rex/exploitation/cmdstager/base.rb#L26-L31

Fixes #13807. Bughancement.