### PR TITLE
Msf::Post::File.file_local_write: Use Rex::FileUtils.clean_path(local_file_name)

### DIFF
--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -264,10 +264,11 @@ module Msf::Post::File
   # @param data [String]
   # @return [void]
   def file_local_write(local_file_name, data)
-    unless ::File.exist?(local_file_name)
-      ::FileUtils.touch(local_file_name)
+    fname = Rex::FileUtils.clean_path(local_file_name)
+    unless ::File.exist?(fname)
+      ::FileUtils.touch(fname)
     end
-    output = ::File.open(local_file_name, "a")
+    output = ::File.open(fname, "a")
     data.each_line do |d|
       output.puts(d)
     end


### PR DESCRIPTION
Update `Msf::Post::File.file_local_write` to use `Rex::FileUtils.clean_path(local_file_name)`.

This might break stuff. I don't care.
