### PR TITLE
Bugfix: Better handling of Squid HTTP response codes.

### DIFF
--- a/documentation/modules/auxiliary/scanner/http/squid_pivot_scanning.md
+++ b/documentation/modules/auxiliary/scanner/http/squid_pivot_scanning.md
@@ -67,9 +67,9 @@ To test this module, you can try the following:
     1. `set RHOSTS squid.internal`
     1. `set RPORT 3128`
 1. Set the `RANGE` parameter to be the destination host addresses you wish to port scan.
-1.1. `set RANGE 192.168.0.1-192.168.0.2`
+    1. `set RANGE 192.168.0.1-192.168.0.2`
 1. (Optional) Set the specific `PORTS` parameter to any ports you wish to port scan on the hosts in `RANGE`.
-1.1. `set PORTS 21-23,80,443`
+    1. `set PORTS 21-23,80,443`
 1. Do: `run`
 1. You should see the module attempt to connect to the proxy, and then first port of the first host in `RANGE`. Ports will be tested sequentially until the end of `PORTS` is reached, at which point it will start from the first port on the next host in `RANGE`.
 

--- a/documentation/modules/auxiliary/scanner/http/squid_pivot_scanning.md
+++ b/documentation/modules/auxiliary/scanner/http/squid_pivot_scanning.md
@@ -1,0 +1,283 @@
+## Description
+
+A exposed Squid proxy will usually allow an attacker to make requests on their behalf. If misconfigured, this may give the attacker information about devices that they cannot normally reach. For example, an attacker may be able to make requests for internal IP addresses against an open Squid proxy exposed to the Internet, therefore performing a port scan against the internal network.
+
+The `auxiliary/scanner/http/open_proxy` module can be used to test for open proxies, though a Squid proxy does not have to be on the open Internet in order to allow for pivoting (e.g. an Intranet Squid proxy which allows the attack to pivot to another part of the internal network).
+
+This module will not be able to scan network ranges or ports denied by Squid ACLs. Fortunately it is possible to detect whether a host was up and the port was closed, or if the request was blocked by an ACL, based on the response Squid gives. This feedback is provided to the user in meterpreter `VERBOSE` output, otherwise only open and permitted ports are printed.
+
+
+### Vulnerable Application Setup
+
+The [official Squid configuration documentation](https://wiki.squid-cache.org/SquidFaq/ConfiguringSquid) covers the significant flexibility of the Squid proxy. For this module, the most relevant core Squid configuration lines usually looks like this (default for version 3.5):
+
+```
+http_port 3128
+
+acl localnet src 10.0.0.0/8     # RFC1918 possible internal network
+acl localnet src 172.16.0.0/12  # RFC1918 possible internal network
+acl localnet src 192.168.0.0/16 # RFC1918 possible internal network
+acl localnet src fc00::/7       # RFC 4193 local private network range
+acl localnet src fe80::/10      # RFC 4291 link-local (directly plugged) machines
+
+acl SSL_ports port 443
+
+acl Safe_ports port 80          # http
+acl Safe_ports port 21          # ftp
+acl Safe_ports port 443         # https
+acl Safe_ports port 70          # gopher
+acl Safe_ports port 210         # wais
+acl Safe_ports port 280         # http-mgmt
+acl Safe_ports port 488         # gss-http
+acl Safe_ports port 591         # filemaker
+acl Safe_ports port 777         # multiling http
+acl Safe_ports port 1025-65535  # unregistered ports
+
+acl CONNECT method CONNECT
+
+http_access deny !Safe_ports
+http_access deny CONNECT !SSL_ports
+http_access allow localhost manager
+http_access deny manager
+
+#
+# INSERT YOUR OWN RULE(S) HERE TO ALLOW ACCESS FROM YOUR CLIENTS
+#
+
+http_access allow localnet
+http_access allow localhost
+http_access deny all
+```
+
+In short, this opens port 3128 for proxying from `localhost` or a `localnet` ranges to any port in `Safe_ports`, and allows SSL CONNECT requests to be made to `SSL_ports` (just 443 in this example).
+
+The references to "manager" are referring to a component of Squid which provides management controls and reports displaying statistics about the squid process as it runs, and can show useful information like file descriptors or internal hostnames and IP addresses if the ACL permits access. [See the official docs](https://wiki.squid-cache.org/Features/CacheManager) for more information on the Cache Manager.
+
+As such, you should be able to install Squid with default configuration, and reach through it from an internal network source range to anythin the Squid proxy has a route to. If you wish to test against other ports or network ranges, modify the configuration to suit prior to testing.
+
+
+## Verification Steps
+To test this module, you can try the following:
+
+1. Install Squid
+1. Start the Squid service
+1. Start msfconsole
+1. Do: `use auxiliary/scanner/http/squid_pivot_scanning`
+1. Set the `RHOSTS` and `RPORT` to be that of Squid's host address and port:
+    1. `set RHOSTS squid.internal`
+    1. `set RPORT 3128`
+1. Set the `RANGE` parameter to be the destination host addresses you wish to port scan.
+1.1. `set RANGE 192.168.0.1-192.168.0.2`
+1. (Optional) Set the specific `PORTS` parameter to any ports you wish to port scan on the hosts in `RANGE`.
+1.1. `set PORTS 21-23,80,443`
+1. Do: `run`
+1. You should see the module attempt to connect to the proxy, and then first port of the first host in `RANGE`. Ports will be tested sequentially until the end of `PORTS` is reached, at which point it will start from the first port on the next host in `RANGE`.
+
+
+## Options
+Here is a quick overview of each option within the module.
+
+### CANARY_IP
+
+The IP to check if the proxy always answers positively - this IP address should not normally respond.
+
+Default value: `1.2.3.4`
+
+### MANUAL_CHECK
+
+Invoke the canary check, and stop the scan if the Squid proxy server appears to answer positively to every request.
+
+Default value: `true`
+
+### PORTS
+
+The destination TCP ports to scan through the proxy. Ports will be scanned in ascending order.
+
+Note: these must be TCP, this scanner cannot scan other protocols.
+
+### Proxies
+
+This option should not be confused with the Squid proxy you are trying to scan - this is one of the default Meterpreter paramets in which you can specify a proxy chain to use that you require to reach the Squid proxy.
+
+### RANGE
+
+This is the IP range you wish to sca through the Squid proxy. `PORTS` on these hosts will be scanned. Hosts are scanned in ascending order.
+
+### RPORT
+
+This is the port that the Squid proxy is listening on. Squid defaults to 3128.
+
+Default value: `3128`
+
+### SSL
+
+Whether you need to connect to Squid with SSL. This is not normally the case.
+
+Default value: `false`
+
+### THREADS
+
+The number of concurrent threads (max one per Squid host).
+
+Default value: `1`
+
+### VHOST
+
+HTTP server virtual host header to send on requests.
+
+
+## Scenarios and Examples
+The following is a brief demo of a port scan against two hosts (`192.168.0.1` and `192.168.0.2`) through a Squid proxy responding at `10.10.10.100:3128`. You could assume that the Squid host has a public or otherwise reachable IP address, where the `192.168.0.0` network range is not normally reachable to you.
+
+```
+msf6 > use auxiliary/scanner/http/squid_pivot_scanning
+msf6 auxiliary(scanner/http/squid_pivot_scanning) > set RHOSTS 10.10.10.100
+RHOSTS => 10.10.10.100
+msf6 auxiliary(scanner/http/squid_pivot_scanning) > set RPORT 3128
+RPORT => 3128
+msf6 auxiliary(scanner/http/squid_pivot_scanning) > set PORTS 21-25,79-81,139,443,445,1433,1521,1723,3389,8080,9100
+PORTS => 21-25,79-81,139,443,445,1433,1521,1723,3389,8080,9100
+msf6 auxiliary(scanner/http/squid_pivot_scanning) > set RANGE 192.168.0.1-192.168.0.2
+RANGE => 192.168.0.1-192.168.0.2
+msf6 auxiliary(scanner/http/squid_pivot_scanning) > run
+
+[+] [10.10.10.100] 192.168.0.1 is alive.
+[+] [10.10.10.100] 192.168.0.1:80 seems open (HTTP 200, server header: 'nginx/1.14.0 (Ubuntu)').
+[+] [10.10.10.100] 192.168.0.2 is alive.
+[+] [10.10.10.100] 192.168.0.2:80 seems open (HTTP 302 redirect to: 'index.php', server header: 'nginx/1.14.0 (Ubuntu)')
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```
+
+Setting the `VERBOSE` option will show each port tested and explain the reason for unreachable ports, if known. This can be helpful, as a port might very well be open and responding on a host, however if it is denied by the Squid ACL you will be unable to reach it regardless.
+
+```
+msf6 auxiliary(scanner/http/squid_pivot_scanning) > set VERBOSE true
+VERBOSE => true
+msf6 auxiliary(scanner/http/squid_pivot_scanning) > run
+
+[*] [10.10.10.100] Verifying manual testing is not required...
+[*] [10.10.10.100] Requesting 192.168.0.1:21
+[+] [10.10.10.100] 192.168.0.1 is alive.
+[*] [10.10.10.100] 192.168.0.1 is alive but 21 is closed.
+[*] [10.10.10.100] Requesting 192.168.0.1:22
+[*] [10.10.10.100] 192.168.0.1:22 likely blocked by ACL.
+[*] [10.10.10.100] Requesting 192.168.0.1:23
+[*] [10.10.10.100] 192.168.0.1:23 likely blocked by ACL.
+[*] [10.10.10.100] Requesting 192.168.0.1:24
+[*] [10.10.10.100] 192.168.0.1:24 likely blocked by ACL.
+[*] [10.10.10.100] Requesting 192.168.0.1:25
+[*] [10.10.10.100] 192.168.0.1:25 likely blocked by ACL.
+[*] [10.10.10.100] Requesting 192.168.0.1:79
+[*] [10.10.10.100] 192.168.0.1:79 likely blocked by ACL.
+[*] [10.10.10.100] Requesting 192.168.0.1:80
+[+] [10.10.10.100] 192.168.0.1:80 seems open (HTTP 200, server header: 'nginx/1.14.0 (Ubuntu)').
+[*] [10.10.10.100] Requesting 192.168.0.1:81
+[*] [10.10.10.100] 192.168.0.1:81 likely blocked by ACL.
+[*] [10.10.10.100] Requesting 192.168.0.1:139
+[*] [10.10.10.100] 192.168.0.1:139 likely blocked by ACL.
+[*] [10.10.10.100] Requesting 192.168.0.1:443
+[*] [10.10.10.100] 192.168.0.1 is alive but 443 is closed.
+[*] [10.10.10.100] Requesting 192.168.0.1:445
+[*] [10.10.10.100] 192.168.0.1:445 likely blocked by ACL.
+[*] [10.10.10.100] Requesting 192.168.0.1:1433
+[*] [10.10.10.100] 192.168.0.1 is alive but 1433 is closed.
+[*] [10.10.10.100] Requesting 192.168.0.1:1521
+[*] [10.10.10.100] 192.168.0.1 is alive but 1521 is closed.
+[*] [10.10.10.100] Requesting 192.168.0.1:1723
+[*] [10.10.10.100] 192.168.0.1 is alive but 1723 is closed.
+[*] [10.10.10.100] Requesting 192.168.0.1:3389
+[*] [10.10.10.100] 192.168.0.1 is alive but 3389 is closed.
+[*] [10.10.10.100] Requesting 192.168.0.1:8080
+[*] [10.10.10.100] 192.168.0.1 is alive but 8080 is closed.
+[*] [10.10.10.100] Requesting 192.168.0.1:9100
+[*] [10.10.10.100] 192.168.0.1 is alive but 9100 is closed.
+[*] [10.10.10.100] Requesting 192.168.0.2:21
+[+] [10.10.10.100] 192.168.0.2 is alive.
+[*] [10.10.10.100] 192.168.0.2 is alive but 21 is closed.
+[*] [10.10.10.100] Requesting 192.168.0.2:22
+[*] [10.10.10.100] 192.168.0.2:22 likely blocked by ACL.
+[*] [10.10.10.100] Requesting 192.168.0.2:23
+[*] [10.10.10.100] 192.168.0.2:23 likely blocked by ACL.
+[*] [10.10.10.100] Requesting 192.168.0.2:24
+[*] [10.10.10.100] 192.168.0.2:24 likely blocked by ACL.
+[*] [10.10.10.100] Requesting 192.168.0.2:25
+[*] [10.10.10.100] 192.168.0.2:25 likely blocked by ACL.
+[*] [10.10.10.100] Requesting 192.168.0.2:79
+[*] [10.10.10.100] 192.168.0.2:79 likely blocked by ACL.
+[*] [10.10.10.100] Requesting 192.168.0.2:80
+[+] [10.10.10.100] 192.168.0.2:80 seems open (HTTP 302 redirect to: 'index.php', server header: 'nginx/1.14.0 (Ubuntu)')
+[*] [10.10.10.100] Requesting 192.168.0.2:81
+[*] [10.10.10.100] 192.168.0.2:81 likely blocked by ACL.
+[*] [10.10.10.100] Requesting 192.168.0.2:139
+[*] [10.10.10.100] 192.168.0.2:139 likely blocked by ACL.
+[*] [10.10.10.100] Requesting 192.168.0.2:443
+[*] [10.10.10.100] 192.168.0.2 is alive but 443 is closed.
+[*] [10.10.10.100] Requesting 192.168.0.2:445
+[*] [10.10.10.100] 192.168.0.2:445 likely blocked by ACL.
+[*] [10.10.10.100] Requesting 192.168.0.2:1433
+[*] [10.10.10.100] 192.168.0.2 is alive but 1433 is closed.
+[*] [10.10.10.100] Requesting 192.168.0.2:1521
+[*] [10.10.10.100] 192.168.0.2 is alive but 1521 is closed.
+[*] [10.10.10.100] Requesting 192.168.0.2:1723
+[*] [10.10.10.100] 192.168.0.2 is alive but 1723 is closed.
+[*] [10.10.10.100] Requesting 192.168.0.2:3389
+[*] [10.10.10.100] 192.168.0.2 is alive but 3389 is closed.
+[*] [10.10.10.100] Requesting 192.168.0.2:8080
+[*] [10.10.10.100] 192.168.0.2 is alive but 8080 is closed.
+[*] [10.10.10.100] Requesting 192.168.0.2:9100
+[*] [10.10.10.100] 192.168.0.2 is alive but 9100 is closed.
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```
+
+If the Squid administrator has made the error of having an ACL be too permissive, you might even see more interesting ports. A contrived example is below, note SSH has been added to `Safe_ports`.
+
+```
+acl Safe_ports port 80          # http
+acl Safe_ports port 443         # https
+acl Safe_ports port 21          # ftp
+acl Safe_ports port 22          # ssh
+
+http_access deny !Safe_ports
+http_access allow localhost
+http_access allow localnet
+http_access deny all
+```
+
+```
+msf6 auxiliary(scanner/http/squid_pivot_scanning) > set TARGETS 127.0.0.1
+TARGETS => 127.0.0.1
+msf6 auxiliary(scanner/http/squid_pivot_scanning) > set RANGE 127.0.0.1
+RANGE => 127.0.0.1
+msf6 auxiliary(scanner/http/squid_pivot_scanning) > set PORTS 21-23
+PORTS => 21-23
+msf6 auxiliary(scanner/http/squid_pivot_scanning) > run
+
+[*] [10.10.10.100] Verifying manual testing is not required...
+[*] [10.10.10.100] Requesting 127.0.0.1:21
+[+] [10.10.10.100] 127.0.0.1 is alive.
+[*] [10.10.10.100] 127.0.0.1 is alive but 21 is closed.
+[*] [10.10.10.100] Requesting 127.0.0.1:22
+[+] [10.10.10.100] 127.0.0.1:22 seems open (HTTP 200, server header: 'unknown').
+[*] [10.10.10.100] Requesting 127.0.0.1:23
+[*] [10.10.10.100] 127.0.0.1:23 likely blocked by ACL.
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```
+
+
+Finally, it is worth knowing that all open discovered ports are saved as services for later viewing:
+
+```
+msf6 auxiliary(scanner/http/squid_pivot_scanning) > services
+Services
+========
+
+host          port  proto  name                   state  info
+----          ----  -----  ----                   -----  ----
+127.0.0.1     22    tcp    unknown                open   SSH-2.0-OpenSSH_7.9p1 Debian-10+deb10u2
+Protocol mismatch.
+192.168.0.1  80    tcp    nginx/1.14.0 (ubuntu)  open   <html><head>...
+192.168.0.2  80    tcp    nginx/1.14.0 (ubuntu)  open   Redirect to: index.php
+```

--- a/modules/auxiliary/scanner/http/squid_pivot_scanning.rb
+++ b/modules/auxiliary/scanner/http/squid_pivot_scanning.rb
@@ -60,7 +60,7 @@ class MetasploitModule < Msf::Auxiliary
 
   end
 
-  def run_host
+  def run_host(target_host)
     begin
       iplist = Rex::Socket::RangeWalker.new(datastore['RANGE'])
       portlist = Rex::Socket.portspec_crack(datastore['PORTS'])

--- a/modules/auxiliary/scanner/http/squid_pivot_scanning.rb
+++ b/modules/auxiliary/scanner/http/squid_pivot_scanning.rb
@@ -37,7 +37,6 @@ class MetasploitModule < Msf::Auxiliary
         meterpreter `VERBOSE` output, otherwise only open and permitted ports
         are printed.
       },
-      'Author'	       => [''],
       'Author' =>
         [
           'willis',     # Original meterpreter module
@@ -151,7 +150,7 @@ class MetasploitModule < Msf::Auxiliary
               # By this stage, we've likely got a good connection. Parsing the body might no longer be reasonable if the
               # destination port is not serving HTTP (eg: SSH), but we can derive information from the headers Squid
               # returns.
-              if res.code == 301 or res.code == 302
+              if res.code.between?(300, 399)
                 # We can be more verbose if we have a known redirect.
                 print_good("[#{rhost}] #{target}:#{port} seems open (HTTP #{res.code} redirect to: '#{res.headers['Location']}', server header: '#{res.headers['Server']}')")
                 report_service(:host => target, :port => port, :name => res.headers['Server'], :info => "Redirect to: " + res.headers['Location'] )

--- a/modules/auxiliary/scanner/http/squid_pivot_scanning.rb
+++ b/modules/auxiliary/scanner/http/squid_pivot_scanning.rb
@@ -17,19 +17,32 @@ class MetasploitModule < Msf::Auxiliary
     super(
       'Name'          => 'Squid Proxy Port Scanner',
       'Description'   => %q{
-        A misconfigured Squid proxy can allow an attacker to make requests on his behalf.
-          This may give the attacker information about devices that he cannot reach but the
-          Squid proxy can. For example, an attacker can make requests for internal IP addresses
-          against a misconfigured open Squid proxy exposed to the Internet, therefore performing
-          an internal port scan. The error messages returned by the proxy are used to determine
-          if the port is open or not.
+        A exposed Squid proxy will usually allow an attacker to make requests on
+        their behalf. If misconfigured, this may give the attacker information
+        about devices that they cannot normally reach. For example, an attacker
+        may be able to make requests for internal IP addresses against an open
+        Squid proxy exposed to the Internet, therefore performing a port scan
+        against the internal network.
 
-          Many Squid proxies use custom error codes so your mileage may vary. The open_proxy
-          module can be used to test for open proxies, though a Squid proxy does not have to be
-          open in order to allow for pivoting (e.g. an Intranet Squid proxy which allows
-          the attack to pivot to another part of the network).
+        The `auxiliary/scanner/http/open_proxy` module can be used to test for
+        open proxies, though a Squid proxy does not have to be on the open
+        Internet in order to allow for pivoting (e.g. an Intranet Squid proxy
+        which allows the attack to pivot to another part of the internal
+        network).
+
+        This module will not be able to scan network ranges or ports denied by
+        Squid ACLs. Fortunately it is possible to detect whether a host was up
+        and the port was closed, or if the request was blocked by an ACL, based
+        on the response Squid gives. This feedback is provided to the user in
+        meterpreter `VERBOSE` output, otherwise only open and permitted ports
+        are printed.
       },
-      'Author'	       => ['willis'],
+      'Author'	       => [''],
+      'Author' =>
+        [
+          'willis',     # Original meterpreter module
+          '0x44434241'  # Detection updates and documentation
+        ],
       'References'	 =>
         [
               'URL','http://wiki.squid-cache.org/SquidFaq/SecurityPitfalls'

--- a/modules/auxiliary/scanner/http/squid_pivot_scanning.rb
+++ b/modules/auxiliary/scanner/http/squid_pivot_scanning.rb
@@ -15,8 +15,8 @@ class MetasploitModule < Msf::Auxiliary
 
   def initialize
     super(
-      'Name'          => 'Squid Proxy Port Scanner',
-      'Description'   => %q{
+      'Name'        => 'Squid Proxy Port Scanner',
+      'Description' => %q{
         A exposed Squid proxy will usually allow an attacker to make requests on
         their behalf. If misconfigured, this may give the attacker information
         about devices that they cannot normally reach. For example, an attacker
@@ -36,139 +36,137 @@ class MetasploitModule < Msf::Auxiliary
         on the response Squid gives. This feedback is provided to the user in
         meterpreter `VERBOSE` output, otherwise only open and permitted ports
         are printed.
-      },
-      'Author' =>
+        },
+      'Author'      =>
         [
           'willis',     # Original meterpreter module
           '0x44434241'  # Detection updates and documentation
         ],
-      'References'	 =>
+      'References'	=>
         [
-              'URL','http://wiki.squid-cache.org/SquidFaq/SecurityPitfalls'
+          'URL', 'http://wiki.squid-cache.org/SquidFaq/SecurityPitfalls'
         ],
-
-      'License'	=> MSF_LICENSE
+      'License'	    => MSF_LICENSE
     )
 
     register_options(
       [
-        OptString.new('RANGE', [true, "IPs to scan through Squid proxy", '']),
-        OptString.new('PORTS', [true, "Ports to scan; must be TCP", "21,80,139,443,445,1433,1521,1723,3389,8080,9100"]),
-        OptBool.new('MANUAL_CHECK',[true,"Stop the scan if server seems to answer positively to every request",true]),
-        OptString.new('CANARY_IP',[true,"The IP to check if the proxy always answers positively; the IP should not respond.","1.2.3.4"])
-      ])
+        OptString.new('RANGE', [true, 'IPs to scan through Squid proxy', '']),
+        OptString.new('PORTS', [true, 'Ports to scan; must be TCP', '21,80,139,443,445,1433,1521,1723,3389,8080,9100']),
+        OptBool.new('MANUAL_CHECK', [true, 'Stop the scan if server seems to answer positively to every request', true]),
+        OptString.new('CANARY_IP', [true, 'The IP to check if the proxy always answers positively; the IP should not respond.', '1.2.3.4'])
+      ]
+    )
 
   end
 
-  def run_host(target_host)
-
+  def run_host
     begin
-        iplist = Rex::Socket::RangeWalker.new(datastore['RANGE'])
-        dead = false
-        portlist = Rex::Socket.portspec_crack(datastore['PORTS'])
+      iplist = Rex::Socket::RangeWalker.new(datastore['RANGE'])
+      portlist = Rex::Socket.portspec_crack(datastore['PORTS'])
+      dead = false
 
-        if portlist.empty?
-          raise Msf::OptionValidateError.new(['PORTS'])
-        end
+      if portlist.empty?
+        raise Msf::OptionValidateError.new(['PORTS'])
+      end
 
-        vprint_status("[#{rhost}] Verifying manual testing is not required...")
+      vprint_status("[#{rhost}] Verifying manual testing is not required...")
 
-        manual = false
-        # request a non-existent page first to make sure the server doesn't respond with a 200 to everything.
-        res_test = send_request_cgi({
-          'uri'          => "http://#{datastore['CANARY_IP']}:80",
-          'method'       => 'GET',
-          'data'  =>      '',
-          'version' => '1.0',
-          'vhost' => ''
-        }, 10)
+      manual = false
+      # request a non-existent page first to make sure the server doesn't respond with a 200 to everything.
+      res_test = send_request_cgi({
+        'uri'     => "http://#{datastore['CANARY_IP']}:80",
+        'method'  => 'GET',
+        'data'    => '',
+        'version' => '1.0',
+        'vhost'   => ''
+      }, 10)
 
-        if res_test and res_test.body and (res_test.code == 200)
-          print_error("#{rhost} likely answers positively to every request, check it manually.")
-          print_error("\t\t Proceeding with the scan may increase false positives.")
-          manual = true
-        end
+      if res_test && res_test.body && (res_test.code == 200)
+        print_error("#{rhost} likely answers positively to every request, check it manually.")
+        print_error("\t\t Proceeding with the scan may increase false positives.")
+        manual = true
+      end
 
+      iplist.each do |target|
+        next if manual && datastore['MANUAL_CHECK']
 
-        iplist.each do |target|
-          next if manual and datastore['MANUAL_CHECK']
-          alive = nil
+        alive = nil
 
-          portlist.each do |port|
-            next if dead
+        portlist.each do |port|
+          next if dead
 
-            vprint_status("[#{rhost}] Requesting #{target}:#{port}")
-            if port==443
-              res = send_request_cgi({
-                'uri'          => "https://#{target}:#{port}",
-                'method'       => 'GET',
-                'data'  =>      '',
-                'version' => '1.0',
-                'vhost' => ''
-                }, 10)
-            else
-              res = send_request_cgi({
-                'uri'          => "http://#{target}:#{port}",
-                'method'       => 'GET',
-                'data'  =>      '',
-                'version' => '1.0',
-                'vhost' => ''
-              }, 10)
-            end
-
-            if res and res.body
-              # Look at the HTTP headers back from Squid first, for some easy error detection.
-              if res.headers.key?('X-Squid-Error')
-                case res.headers['X-Squid-Error']
-                when /ERR_CONNECT_FAIL/
-                  # Usually a HTTP 503, page body can give some more information. Example:
-                  # <p id="sysmsg">The system returned: <i>(111) Connection refused</i></p>
-                  if res.body =~ /id="sysmsg".*Connection refused/
-                    if alive.nil?
-                      print_good("[#{rhost}] #{target} is alive.")
-                      alive = true
-                    end
-                    vprint_status("[#{rhost}] #{target} is alive but #{port} is closed.")
-                  elsif res.body =~ /id="sysmsg".*No route to host/
-                    dead = true
-                    print_error("[#{rhost}] No route to #{target}")
-                  end
-                when /ERR_ACCESS_DENIED/
-                  # Indicates that the Squid ACLs do not allow connecting to this port.
-                  # See: https://wiki.squid-cache.org/SquidFaq/SquidAcl
-                  vprint_status("[#{rhost}] #{target}:#{port} likely blocked by ACL.")
-                when /ERR_DNS_FAIL/
-                  # Squid could not resolve the destination hostname.
-                  dead = true
-                  print_error("[#{rhost}] Squid could not resolve '#{target}', try putting the IP in the RANGE parameter if known.")
-                else
-                  print_error("[#{rhost}] #{target}:#{port} unknown Squid proxy error: '#{res.headers['X-Squid-Error']}' (HTTP #{res.code})")
-                end
-                next # Skip to next port if the host is not marked as dead
-              end
-
-              # By this stage, we've likely got a good connection. Parsing the body might no longer be reasonable if the
-              # destination port is not serving HTTP (eg: SSH), but we can derive information from the headers Squid
-              # returns.
-              if res.code.between?(300, 399)
-                # We can be more verbose if we have a known redirect.
-                print_good("[#{rhost}] #{target}:#{port} seems open (HTTP #{res.code} redirect to: '#{res.headers['Location']}', server header: '#{res.headers['Server']}')")
-                report_service(:host => target, :port => port, :name => res.headers['Server'], :info => "Redirect to: " + res.headers['Location'] )
-              else
-                # 200 OK, 404 Not Found etc - still indicates the port was open and responding.
-                server = res.headers['Server'] || "unknown"
-                print_good("[#{rhost}] #{target}:#{port} seems open (HTTP #{res.code}, server header: '#{server}').")
-                report_service(:host => target, :port => port, :name => server, :info => res.body )
-              end
-
-            end
+          vprint_status("[#{rhost}] Requesting #{target}:#{port}")
+          if port == 443
+            res = send_request_cgi({
+              'uri'     => "https://#{target}:#{port}",
+              'method'  => 'GET',
+              'data'    => '',
+              'version' => '1.0',
+              'vhost'   => ''
+            }, 10)
+          else
+            res = send_request_cgi({
+              'uri'     => "http://#{target}:#{port}",
+              'method'  => 'GET',
+              'data'    => '',
+              'version' => '1.0',
+              'vhost'   => ''
+            }, 10)
           end
-          dead = false
+
+          if res && res.body
+            # Look at the HTTP headers back from Squid first, for some easy error detection.
+            if res.headers.key?('X-Squid-Error')
+              case res.headers['X-Squid-Error']
+              when /ERR_CONNECT_FAIL/
+                # Usually a HTTP 503, page body can give some more information. Example:
+                # <p id="sysmsg">The system returned: <i>(111) Connection refused</i></p>
+                if res.body =~ /id="sysmsg".*Connection refused/
+                  if alive.nil?
+                    print_good("[#{rhost}] #{target} is alive.")
+                    alive = true
+                  end
+                  vprint_status("[#{rhost}] #{target} is alive but #{port} is closed.")
+                elsif res.body =~ /id="sysmsg".*No route to host/
+                  dead = true
+                  print_error("[#{rhost}] No route to #{target}")
+                end
+              when /ERR_ACCESS_DENIED/
+                # Indicates that the Squid ACLs do not allow connecting to this port.
+                # See: https://wiki.squid-cache.org/SquidFaq/SquidAcl
+                vprint_status("[#{rhost}] #{target}:#{port} likely blocked by ACL.")
+              when /ERR_DNS_FAIL/
+                # Squid could not resolve the destination hostname.
+                dead = true
+                print_error("[#{rhost}] Squid could not resolve '#{target}', try putting the IP in the RANGE parameter if known.")
+              else
+                print_error("[#{rhost}] #{target}:#{port} unknown Squid proxy error: '#{res.headers['X-Squid-Error']}' (HTTP #{res.code})")
+              end
+              next # Skip to next port if the host is not marked as dead
+            end
+
+            # By this stage, we've likely got a good connection. Parsing the body might no longer be reasonable if the
+            # destination port is not serving HTTP (eg: SSH), but we can derive information from the headers Squid
+            # returns.
+            if res.code.between?(300, 399)
+              # We can be more verbose if we have a known redirect.
+              print_good("[#{rhost}] #{target}:#{port} seems open (HTTP #{res.code} redirect to: '#{res.headers['Location']}', server header: '#{res.headers['Server']}')")
+              report_service(host: target, port: port, name: res.headers['Server'], info: 'Redirect to: ' + res.headers['Location'])
+            else
+              # 200 OK, 404 Not Found etc - still indicates the port was open and responding.
+              server = res.headers['Server'] || 'unknown'
+              print_good("[#{rhost}] #{target}:#{port} seems open (HTTP #{res.code}, server header: '#{server}').")
+              report_service(host: target, port: port, name: server, info: res.body)
+            end
+
+          end
         end
+        dead = false
+      end
 
-        rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
-        rescue ::Timeout::Error, ::Errno::EPIPE
-
+      rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
+      rescue ::Timeout::Error, ::Errno::EPIPE
     end
   end
 end


### PR DESCRIPTION
So I was playing an online CTF last night, and noticed something interesting while port-scanning through a Squid proxy (addresses altered to prevent Google from correlating a live challenge to a PR, but otherwise verbatim):

```
...
[*] [192.168.0.100] 192.168.0.2:77 blocked by ACL
[*] [192.168.0.100] 192.168.0.2:78 blocked by ACL
[*] [192.168.0.100] 192.168.0.2:79 blocked by ACL
[*] [192.168.0.100] 192.168.0.2:81 blocked by ACL
[*] [192.168.0.100] 192.168.0.2:82 blocked by ACL
[*] [192.168.0.100] 192.168.0.2:83 blocked by ACL
...
```

As you can see... port 80 was not printed, but it _was_ open. Turns out, the remote server gave a HTTP 302, which was not handled by the code and fell out of the loop without printing. If you set VERBOSE to true, it does indicate that the port is tried, but you still get no nicely visible green **[+]**, which is very helpful when scanning lots of ports. Now, this could be fixed like this:

```
diff --git a/modules/auxiliary/scanner/http/squid_pivot_scanning.rb b/modules/auxiliary/scanner/http/squid_pivot_scanning.rb
index be547ebc00..c93b18d961 100644
--- a/modules/auxiliary/scanner/http/squid_pivot_scanning.rb
+++ b/modules/auxiliary/scanner/http/squid_pivot_scanning.rb
@@ -105,7 +105,7 @@ class MetasploitModule < Msf::Auxiliary
 
             if res and res.body
 
-              if res.code == 200 or res.body =~ /Zero/ or res.code == 404 or res.code == 401
+              if res.code == 200 or res.body =~ /Zero/ or res.code == 404 or res.code == 401 or res.code == 302
                 print_good("[#{rhost}] #{target}:#{port} seems OPEN")
                 report_service(:host => target, :port => port, :name => "unknown", :info => res.body )
               end

```

But that's not really an improvement. So here is my proposed change, to look for the `X-Squid-Error` response header for error handling first, and response body second (if parse-able). The errors that can be returned [are documented here](http://www.squid-cache.org/Doc/code/err__type_8h.html), and with a little parsing we can determine useful error information for the user. If the client receives an error from Squid that is not handled, the error type will now also be printed for the user (eg: ERR_READ_TIMEOUT). 

(Side note - I have no idea why this is trying to match for `/Zero/` - any ideas? It's not found in the body of any Squid pages I saw, and the most relevant changes from git blame are 9+ years ago.)

After looking at the documentation I don't believe these Squid headers can be disabled either (but some Squid headers can be disabled to make it less obvious that traffic is proxied). At any rate, the following commonly recommended by Google results Squid configuration does not disable the `X-Squid-Error` header which might break this method of fingerprinting:

```
via off
forwarded_for off
request_header_access From deny all
request_header_access Server deny all
request_header_access WWW-Authenticate deny all
request_header_access Link deny all
request_header_access Cache-Control deny all
request_header_access Proxy-Connection deny all
request_header_access X-Cache deny all
request_header_access X-Cache-Lookup deny all
request_header_access Via deny all
request_header_access X-Forwarded-For deny all
request_header_access Pragma deny all
request_header_access Keep-Alive deny all
```

...and the configuration option `request_header_access X-Squid-Error deny all` does not appear to have any effect in Squid 4.6, at any rate. So I think this method is safe and reliable.

Previously, the module would also output every IP:PORT pair (well, _almost_ every pair...), even when they are closed or forbidden by Squid ACL. I've set closed or forbidden ports to be verbose only, so that the default non-verbose port-scanning output prints a significantly shorter list for human consumption.

As HTTP 3xx redirects were not previously displayed to users, the redirect location is now also printed in the output. The server header is printed for all open ports where available, and stored in the database.

As usual, more than happy for constructive feedback or suggestions for improvement - I'm a Ruby newbie. I searched for any related issues and couldn't find any, so rather than create an issue I figured I'd just submit a PR to fix it and save everyone some time.

# Verification

## Previous behavior

Again, note port 80 is missing from output on host 192.168.0.**2**, as this host gives a HTTP 302.
```
msf5 > use auxiliary/scanner/http/squid_pivot_scanning 
msf5 auxiliary(scanner/http/squid_pivot_scanning) > set RHOSTS 192.168.0.100
RHOSTS => 192.168.0.100
msf5 auxiliary(scanner/http/squid_pivot_scanning) > set RPORT 3128
RPORT => 3128
msf5 auxiliary(scanner/http/squid_pivot_scanning) > set PORTS 21-25,79-81,139,443,445,1433,1521,1723,3389,8080,9100
PORTS => 21-25,79-81,139,443,445,1433,1521,1723,3389,8080,9100
msf5 auxiliary(scanner/http/squid_pivot_scanning) > set RANGE 192.168.0.1-192.168.0.2
RANGE => 192.168.0.1-192.168.0.2
msf5 auxiliary(scanner/http/squid_pivot_scanning) > run 

[+] [192.168.0.100] 192.168.0.1 is alive but 21 is CLOSED
[+] [192.168.0.100] 192.168.0.1 is alive but 22 is CLOSED
[*] [192.168.0.100] 192.168.0.1:23 blocked by ACL
[*] [192.168.0.100] 192.168.0.1:24 blocked by ACL
[*] [192.168.0.100] 192.168.0.1:25 blocked by ACL
[*] [192.168.0.100] 192.168.0.1:79 blocked by ACL
[+] [192.168.0.100] 192.168.0.1:80 seems OPEN
[*] [192.168.0.100] 192.168.0.1:81 blocked by ACL
[*] [192.168.0.100] 192.168.0.1:139 blocked by ACL
[+] [192.168.0.100] 192.168.0.1 is alive but 443 is CLOSED
[*] [192.168.0.100] 192.168.0.1:445 blocked by ACL
[+] [192.168.0.100] 192.168.0.1 is alive but 1433 is CLOSED
[+] [192.168.0.100] 192.168.0.1 is alive but 1521 is CLOSED
[+] [192.168.0.100] 192.168.0.1 is alive but 1723 is CLOSED
[+] [192.168.0.100] 192.168.0.1 is alive but 3389 is CLOSED
[+] [192.168.0.100] 192.168.0.1 is alive but 8080 is CLOSED
[+] [192.168.0.100] 192.168.0.1 is alive but 9100 is CLOSED
[+] [192.168.0.100] 192.168.0.2 is alive but 21 is CLOSED
[+] [192.168.0.100] 192.168.0.2 is alive but 22 is CLOSED
[*] [192.168.0.100] 192.168.0.2:23 blocked by ACL
[*] [192.168.0.100] 192.168.0.2:24 blocked by ACL
[*] [192.168.0.100] 192.168.0.2:25 blocked by ACL
[*] [192.168.0.100] 192.168.0.2:79 blocked by ACL
[*] [192.168.0.100] 192.168.0.2:81 blocked by ACL
[*] [192.168.0.100] 192.168.0.2:139 blocked by ACL
[+] [192.168.0.100] 192.168.0.2 is alive but 443 is CLOSED
[*] [192.168.0.100] 192.168.0.2:445 blocked by ACL
[+] [192.168.0.100] 192.168.0.2 is alive but 1433 is CLOSED
[+] [192.168.0.100] 192.168.0.2 is alive but 1521 is CLOSED
[+] [192.168.0.100] 192.168.0.2 is alive but 1723 is CLOSED
[+] [192.168.0.100] 192.168.0.2 is alive but 3389 is CLOSED
[+] [192.168.0.100] 192.168.0.2 is alive but 8080 is CLOSED
[+] [192.168.0.100] 192.168.0.2 is alive but 9100 is CLOSED
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed

msf5 auxiliary(scanner/http/squid_pivot_scanning) > services
Services
========

host          port  proto  name     state  info
----          ----  -----  ----     -----  ----
192.168.0.1  80    tcp    unknown  open   [REDACTED]
```

## New behavior
```
msf6 auxiliary(scanner/http/squid_pivot_scanning) > set PORTS 21-25,79-81,139,443,445,1433,1521,1723,3389,8080,9100
PORTS => 21-25,79-81,139,443,445,1433,1521,1723,3389,8080,9100
msf6 auxiliary(scanner/http/squid_pivot_scanning) > run

[+] [192.168.0.100] 192.168.0.1 is alive.
[+] [192.168.0.100] 192.168.0.1:80 seems open (HTTP 200, server header: 'nginx/1.14.0 (Ubuntu)').
[+] [192.168.0.100] 192.168.0.2 is alive.
[+] [192.168.0.100] 192.168.0.2:80 seems open (HTTP 302 redirect to: 'redacted.php', server header: 'nginx/1.14.0 (Ubuntu)')
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed

msf6 auxiliary(scanner/http/squid_pivot_scanning) > services
Services
========

host          port  proto  name                   state  info
----          ----  -----  ----                   -----  ----
192.168.0.1  80    tcp    nginx/1.14.0 (ubuntu)  open   [REDACTED]
192.168.0.2  80    tcp    nginx/1.14.0 (ubuntu)  open   Redirect to: redacted.php

```

Verbose output:
```
msf6 auxiliary(scanner/http/squid_pivot_scanning) > set VERBOSE true
VERBOSE => true
msf6 auxiliary(scanner/http/squid_pivot_scanning) > run

[*] [192.168.0.100] Verifying manual testing is not required...
[*] [192.168.0.100] Requesting 192.168.0.1:21
[+] [192.168.0.100] 192.168.0.1 is alive.
[*] [192.168.0.100] 192.168.0.1 is alive but 21 is closed.
[*] [192.168.0.100] Requesting 192.168.0.1:22
[*] [192.168.0.100] 192.168.0.1:22 likely blocked by ACL.
[*] [192.168.0.100] Requesting 192.168.0.1:23
[*] [192.168.0.100] 192.168.0.1:23 likely blocked by ACL.
[*] [192.168.0.100] Requesting 192.168.0.1:24
[*] [192.168.0.100] 192.168.0.1:24 likely blocked by ACL.
[*] [192.168.0.100] Requesting 192.168.0.1:25
[*] [192.168.0.100] 192.168.0.1:25 likely blocked by ACL.
[*] [192.168.0.100] Requesting 192.168.0.1:79
[*] [192.168.0.100] 192.168.0.1:79 likely blocked by ACL.
[*] [192.168.0.100] Requesting 192.168.0.1:80
[+] [192.168.0.100] 192.168.0.1:80 seems open (HTTP 200, server header: 'nginx/1.14.0 (Ubuntu)').
[*] [192.168.0.100] Requesting 192.168.0.1:81
[*] [192.168.0.100] 192.168.0.1:81 likely blocked by ACL.
[*] [192.168.0.100] Requesting 192.168.0.1:139
[*] [192.168.0.100] 192.168.0.1:139 likely blocked by ACL.
[*] [192.168.0.100] Requesting 192.168.0.1:443
[*] [192.168.0.100] 192.168.0.1 is alive but 443 is closed.
[*] [192.168.0.100] Requesting 192.168.0.1:445
[*] [192.168.0.100] 192.168.0.1:445 likely blocked by ACL.
[*] [192.168.0.100] Requesting 192.168.0.1:1433
[*] [192.168.0.100] 192.168.0.1 is alive but 1433 is closed.
[*] [192.168.0.100] Requesting 192.168.0.1:1521
[*] [192.168.0.100] 192.168.0.1 is alive but 1521 is closed.
[*] [192.168.0.100] Requesting 192.168.0.1:1723
[*] [192.168.0.100] 192.168.0.1 is alive but 1723 is closed.
[*] [192.168.0.100] Requesting 192.168.0.1:3389
[*] [192.168.0.100] 192.168.0.1 is alive but 3389 is closed.
[*] [192.168.0.100] Requesting 192.168.0.1:8080
[*] [192.168.0.100] 192.168.0.1 is alive but 8080 is closed.
[*] [192.168.0.100] Requesting 192.168.0.1:9100
[*] [192.168.0.100] 192.168.0.1 is alive but 9100 is closed.
[*] [192.168.0.100] Requesting 192.168.0.2:21
[+] [192.168.0.100] 192.168.0.2 is alive.
[*] [192.168.0.100] 192.168.0.2 is alive but 21 is closed.
[*] [192.168.0.100] Requesting 192.168.0.2:22
[*] [192.168.0.100] 192.168.0.2:22 likely blocked by ACL.
[*] [192.168.0.100] Requesting 192.168.0.2:23
[*] [192.168.0.100] 192.168.0.2:23 likely blocked by ACL.
[*] [192.168.0.100] Requesting 192.168.0.2:24
[*] [192.168.0.100] 192.168.0.2:24 likely blocked by ACL.
[*] [192.168.0.100] Requesting 192.168.0.2:25
[*] [192.168.0.100] 192.168.0.2:25 likely blocked by ACL.
[*] [192.168.0.100] Requesting 192.168.0.2:79
[*] [192.168.0.100] 192.168.0.2:79 likely blocked by ACL.
[*] [192.168.0.100] Requesting 192.168.0.2:80
[+] [192.168.0.100] 192.168.0.2:80 seems open (HTTP 302 redirect to: 'redacted.php', server header: 'nginx/1.14.0 (Ubuntu)')
[*] [192.168.0.100] Requesting 192.168.0.2:81
[*] [192.168.0.100] 192.168.0.2:81 likely blocked by ACL.
[*] [192.168.0.100] Requesting 192.168.0.2:139
[*] [192.168.0.100] 192.168.0.2:139 likely blocked by ACL.
[*] [192.168.0.100] Requesting 192.168.0.2:443
[*] [192.168.0.100] 192.168.0.2 is alive but 443 is closed.
[*] [192.168.0.100] Requesting 192.168.0.2:445
[*] [192.168.0.100] 192.168.0.2:445 likely blocked by ACL.
[*] [192.168.0.100] Requesting 192.168.0.2:1433
[*] [192.168.0.100] 192.168.0.2 is alive but 1433 is closed.
[*] [192.168.0.100] Requesting 192.168.0.2:1521
[*] [192.168.0.100] 192.168.0.2 is alive but 1521 is closed.
[*] [192.168.0.100] Requesting 192.168.0.2:1723
[*] [192.168.0.100] 192.168.0.2 is alive but 1723 is closed.
[*] [192.168.0.100] Requesting 192.168.0.2:3389
[*] [192.168.0.100] 192.168.0.2 is alive but 3389 is closed.
[*] [192.168.0.100] Requesting 192.168.0.2:8080
[*] [192.168.0.100] 192.168.0.2 is alive but 8080 is closed.
[*] [192.168.0.100] Requesting 192.168.0.2:9100
[*] [192.168.0.100] 192.168.0.2 is alive but 9100 is closed.
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

I've also tested this with non-HTTP services to ensure it still works - for example, SSH (note for reviewers: Squid config needs to be adjusted to allow port 22, as it is not normally permitted. Adding `acl Safe_ports port 22` to a default configuration should be enough for testing):
```
msf6 auxiliary(scanner/http/squid_pivot_scanning) > set TARGETS 127.0.0.1
TARGETS => 127.0.0.1
msf6 auxiliary(scanner/http/squid_pivot_scanning) > set RANGE 127.0.0.1
RANGE => 127.0.0.1
msf6 auxiliary(scanner/http/squid_pivot_scanning) > set PORTS 21-23
PORTS => 21-23
msf6 auxiliary(scanner/http/squid_pivot_scanning) > run

[*] [192.168.0.100] Verifying manual testing is not required...
[*] [192.168.0.100] Requesting 127.0.0.1:21
[+] [192.168.0.100] 127.0.0.1 is alive.
[*] [192.168.0.100] 127.0.0.1 is alive but 21 is closed.
[*] [192.168.0.100] Requesting 127.0.0.1:22
[+] [192.168.0.100] 127.0.0.1:22 seems open (HTTP 200, server header: 'unknown').
[*] [192.168.0.100] Requesting 127.0.0.1:23
[*] [192.168.0.100] 127.0.0.1:23 likely blocked by ACL.
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf6 auxiliary(scanner/http/squid_pivot_scanning) > services
Services
========

host          port  proto  name                   state  info
----          ----  -----  ----                   -----  ----
127.0.0.1     22    tcp    unknown                open   SSH-2.0-OpenSSH_7.9p1 Debian-10+deb10u2
Protocol mismatch.
```
