### PR TITLE
Use and semantics when searching for text

### DIFF
--- a/lib/msf/core/modules/metadata/search.rb
+++ b/lib/msf/core/modules/metadata/search.rb
@@ -1,3 +1,5 @@
+# -*- coding: binary -*-
+
 require 'msf/core/modules/metadata'
 
 #
@@ -15,6 +17,11 @@ module Msf::Modules::Metadata::Search
   MODULE_TYPE_SHORTHANDS = {
     "aux" => Msf::MODULE_AUX
   }
+
+  module SearchMode
+    INCLUDE = 0
+    EXCLUDE = 1
+  end
 
   #
   # Parses command line search string into a hash. A param prefixed with '-' indicates "not", and will omit results
@@ -52,9 +59,9 @@ module Msf::Modules::Metadata::Search
       res[keyword] ||=[   [],    []   ]
       if search_term[0,1] == "-"
         next if search_term.length == 1
-        res[keyword][1] << search_term[1,search_term.length-1]
+        res[keyword][SearchMode::EXCLUDE] << search_term[1,search_term.length-1]
       else
-        res[keyword][0] << search_term
+        res[keyword][SearchMode::INCLUDE] << search_term
       end
     end
     res
@@ -87,22 +94,41 @@ module Msf::Modules::Metadata::Search
 
     param_hash = params
 
-    [0,1].each do |mode|
+    [SearchMode::INCLUDE, SearchMode::EXCLUDE].each do |mode|
       match = false
       param_hash.keys.each do |keyword|
         next if param_hash[keyword][mode].length == 0
 
+        # free form text search will honor 'and' semantics, i.e. 'metasploit pro' will only match modules that contain both
+        # words, and will return false when only one word is matched
+        if keyword == 'text'
+          text_segments = [module_metadata.name, module_metadata.fullname, module_metadata.description] + module_metadata.references + module_metadata.author + (module_metadata.notes['AKA'] || [])
+
+          if module_metadata.targets
+            text_segments = text_segments + module_metadata.targets
+          end
+
+          param_hash[keyword][mode].each do |search_term|
+            has_match = text_segments.any? { |text_segment| text_segment =~ as_regex(search_term) }
+            match = [keyword, search_term] if has_match
+            if mode == SearchMode::INCLUDE && !has_match
+              return false
+            end
+            if mode == SearchMode::EXCLUDE && has_match
+              return false
+            end
+          end
+
+          next
+        end
+
+        # The remaining keywords honor 'or' semantics, i.e. the following param_hash will match either osx, or linux
+        # {"platform"=>[["osx", "linux"], []]}
         param_hash[keyword][mode].each do |search_term|
           # Reset the match flag for each keyword for inclusive search
-          match = false if mode == 0
+          match = false if mode == SearchMode::INCLUDE
 
-          # Convert into a case-insensitive regex
-          utf8_buf = search_term.dup.force_encoding('UTF-8')
-          if utf8_buf.valid_encoding?
-            regex = Regexp.new(Regexp.escape(utf8_buf), true)
-          else
-            return false
-          end
+          regex = as_regex(search_term)
           case keyword
             when 'aka'
               match = [keyword, search_term] if (module_metadata.notes['AKA'] || []).any? { |aka| aka =~ regex }
@@ -176,13 +202,6 @@ module Msf::Modules::Metadata::Search
               match = [keyword, search_term] if module_metadata.references.any? { |ref| ref =~ regex }
             when 'target', 'targets'
               match = [keyword, search_term] if module_metadata.targets.any? { |target| target =~ regex }
-            when 'text'
-              terms = [module_metadata.name, module_metadata.fullname, module_metadata.description] + module_metadata.references + module_metadata.author + (module_metadata.notes['AKA'] || [])
-
-              if module_metadata.targets
-                terms = terms + module_metadata.targets
-              end
-              match = [keyword, search_term] if terms.any? { |term| term =~ regex }
             when 'type'
               match = [keyword, search_term] if Msf::MODULE_TYPES.any? { |module_type| search_term == module_type and module_metadata.type == module_type }
           else
@@ -192,17 +211,28 @@ module Msf::Modules::Metadata::Search
           break if match
         end
         # Filter this module if no matches for a given keyword type
-        if mode == 0 and not match
+        if mode == SearchMode::INCLUDE and not match
           return false
         end
       end
       # Filter this module if we matched an exclusion keyword (-value)
-      if mode == 1 and match
+      if mode == SearchMode::EXCLUDE and match
         return false
       end
     end
 
     true
+  end
+
+  def as_regex(search_term)
+    # Convert into a case-insensitive regex
+    utf8_buf = search_term.dup.force_encoding('UTF-8')
+    if utf8_buf.valid_encoding?
+       Regexp.new(Regexp.escape(utf8_buf), Regexp::IGNORECASE)
+    else
+      # If the encoding is invalid, default to a regex that matches anything
+      //
+    end
   end
 
   def get_fields(module_metadata, fields)

--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -669,7 +669,7 @@ module Msf
                   # Avoid trying to use the search result if it exactly matches
                   # the module we were trying to load. The module cannot be
                   # loaded and searching isn't going to change that.
-                  mods_found = cmd_search('-I', '-u', mod_name)
+                  mods_found = cmd_search('-I', '-u', *args)
                 end
 
                 unless mods_found

--- a/spec/lib/msf/core/modules/metadata/search_spec.rb
+++ b/spec/lib/msf/core/modules/metadata/search_spec.rb
@@ -1,3 +1,5 @@
+# -*- coding: binary -*-
+
 require 'spec_helper'
 
 RSpec.describe Msf::Modules::Metadata::Search do
@@ -201,6 +203,49 @@ RSpec.describe Msf::Modules::Metadata::Search do
 
     context 'on nil and empty input' do
       it_should_behave_like 'search_filter', :accept => [nil, '', '  '], :test_inverse => false
+    end
+
+    context 'on a module with a #description of "metasploit pro console"' do
+      let(:opts) { ({ 'description' => 'metasploit pro console' }) }
+      it_should_behave_like(
+        'search_filter',
+        :accept => ["metasploit", "metasploit pro", "metasploit pro console", "console pro"],
+        :reject => ["metasploit framework", "pro framework", "pro console php"],
+        :test_inverse => false
+      )
+    end
+
+    context 'when invalid encodings are used, all results are returned' do
+      context 'and the search term is present' do
+        let(:opts) { ({ 'author' => ['István'.force_encoding("UTF-8")] }) }
+        it_should_behave_like(
+          'search_filter',
+          accept: [
+            "author:István",
+            "author:Istv\xE1n ",
+            "author:Istv\u00E1n ",
+          ],
+          :reject => [
+            'different_author'
+          ],
+          :test_inverse => false
+        )
+      end
+      context 'and the search term is not present' do
+        let(:opts) { ({ 'author' => ['different_author'] }) }
+        it_should_behave_like(
+          'search_filter',
+          accept: [
+            'different_author',
+            "author:Istv\xE1n",
+          ],
+          :reject => [
+            "author:István",
+            "author:Istv\u00E1n ",
+          ],
+          :test_inverse => false
+        )
+      end
     end
 
     context 'when filtering by module #type' do


### PR DESCRIPTION
When searching for multiple text terms, the search will now require for all words to be matched

### Before

When searching for `search postgresql login` - all modules matching either `postgresql` or `login` will be returned:
 
```
msf6 exploit(windows/smb/psexec) >  search postgresql login

Matching Modules
================

   #    Name                                           Disclosure Date  Rank       Check  Description
   -    ----                                           ---------------  ----       -----  -----------
   0    auxiliary/admin/appletv/appletv_display_image                   normal     No     Apple TV Image Remote Control
   1    auxiliary/admin/appletv/appletv_display_video                   normal     No     Apple TV Video Remote Control
 
    ...  many modules later ...

   248  post/windows/manage/sticky_keys                                 normal     No     Sticky Keys Persistance Module
   249  post/windows/manage/wdigest_caching                             normal     No     Windows Post Manage WDigest Credential Caching


Interact with a module by name or index, for example use 249 or use post/windows/manage/wdigest_caching
```

### After

When searching for `search postgresql login` - only modules matching both `postgresql` and `login` will be returned:

```
msf6 exploit(windows/tftp/distinct_tftp_traversal) > search postgresql login
Matching Modules
================
   #  Name                                       Disclosure Date  Rank    Check  Description
   -  ----                                       ---------------  ----    -----  -----------
   0  auxiliary/scanner/postgres/postgres_login                   normal  No     PostgreSQL Login Utility
```

## Verification

### 1 - Console search

Open the console, and ensure that normal search functionality works as expected:

```
search postgres
search login
search postgres login
search author:egypt arch:x64
search psexec author:egypt arch:x64
```

### 2 - rpcd

Create an instance of msfrpcd in one tab:

```
bundle exec ruby ./msfrpcd -P foo -f
```

In another create the client:
```
bundle exec ./ruby msfrpc -P foo -a 127.0.0.1
```

Ensure search works as expected, and aligns with the existing msfconsole search functionality:
```
rpc.call("module.search", "postgres")
rpc.call("module.search", "login")
rpc.call("module.search", "postgres login")
rpc.call("module.search", "author:egypt arch:x64")
rpc.call("module.search", "psexec author:egypt arch:x64")
```

### 3 - json web service

The existing webservice should not be impacted by this code change, but for a sanity check - run the service with:

```
bundle exec thin --rackup msf-json-rpc.ru --address localhost --port 8081 --environment production --tag msf-json-rpc start
```

Run some search queries:

```
curl --request POST --url http://localhost:8081/api/v1/json-rpc --header 'content-type: application/json' --data '{ "jsonrpc": "2.0", "method": "module.search", "id": 1, "params": ["postgres login"] }'
curl --request POST --url http://localhost:8081/api/v1/json-rpc --header 'content-type: application/json' --data '{ "jsonrpc": "2.0", "method": "module.search", "id": 1, "params": ["author:egypt arch:x64"] }'
curl --request POST --url http://localhost:8081/api/v1/json-rpc --header 'content-type: application/json' --data '{ "jsonrpc": "2.0", "method": "module.search", "id": 1, "params": ["psexec author:egypt arch:x64"] }'

```