### PR TITLE
telpho10_credential_dump: Prevent traversal in untar

### DIFF
--- a/modules/auxiliary/admin/http/telpho10_credential_dump.rb
+++ b/modules/auxiliary/admin/http/telpho10_credential_dump.rb
@@ -37,7 +37,7 @@ class MetasploitModule < Msf::Auxiliary
     File.open(tarfile, 'rb') do |file|
       Rex::Tar::Reader.new(file) do |tar|
         tar.each do |entry|
-          dest = File.join destination, entry.full_name
+          dest = File.join(destination, File.basename(entry.full_name))
           if entry.file?
             File.open(dest, 'wb') do |f|
               f.write(entry.read)


### PR DESCRIPTION
Use `File.basename` for tar file contents to prevent relative path traversal in `untar` method in `telpho10_credential_dump`.

```ruby
irb(main):001:0> File.basename("../../../../../../../payload.bin")
=> "payload.bin"
irb(main):002:0> 
```

Potentially resolves #14015

I have no idea if this is suitable as I'm uncertain as to the expected structure of the tar file contents. However, the module appears to expect the contents to exist within the root of the tar file.

Nonetheless, this patch prevents the path traversal.

```
msf6 > use multi/fileformat/zip_slip
[*] No payload configured, defaulting to linux/x86/meterpreter/reverse_tcp
msf6 exploit(multi/fileformat/zip_slip) > set TARGETPAYLOADPATH ../../../../../../../payload.bin
TARGETPAYLOADPATH => ../../../../../../../payload.bin
msf6 exploit(multi/fileformat/zip_slip) > run

[+] msf.tar stored at /root/.msf4/local/msf.tar
[*] When extracted, the payload is expected to extract to:
[*] ../../../../../../../payload.bin
msf6 exploit(multi/fileformat/zip_slip) > mkdir /var/www/html/telpho/
[*] exec: mkdir /var/www/html/telpho/

msf6 exploit(multi/fileformat/zip_slip) > mkdir /var/www/html/telpho/system
[*] exec: mkdir /var/www/html/telpho/system

msf6 exploit(multi/fileformat/zip_slip) > mkdir /var/www/html/telpho/temp
[*] exec: mkdir /var/www/html/telpho/temp

msf6 exploit(multi/fileformat/zip_slip) > touch /var/www/html/telpho/system/backup.php
[*] exec: touch /var/www/html/telpho/system/backup.php

msf6 exploit(multi/fileformat/zip_slip) > mv /root/.msf4/local/msf.tar /var/www/html/telpho/temp/telpho10.epb
[*] exec: mv /root/.msf4/local/msf.tar /var/www/html/telpho/temp/telpho10.epb

msf6 exploit(multi/fileformat/zip_slip) > ls -la /payload.bin
[*] exec: ls -la /payload.bin

ls: cannot access '/payload.bin': No such file or directory
msf6 exploit(multi/fileformat/zip_slip) > use auxiliary/admin/http/telpho10_credential_dump
msf6 auxiliary(admin/http/telpho10_credential_dump) > set rhosts 127.0.0.1
rhosts => 127.0.0.1
msf6 auxiliary(admin/http/telpho10_credential_dump) > run
[*] Running module against 127.0.0.1

[*] Generating backup
[*] Downloading backup
[+] File saved in: /root/.msf4/loot/20200821112619_default_127.0.0.1_telpho10.backup_860433.tar
[-] Could not unpack files.
[*] Auxiliary module execution completed
msf6 auxiliary(admin/http/telpho10_credential_dump) > ls -la /payload.bin
[*] exec: ls -la /payload.bin

-rwxrwxrwx 1 root root 207 Aug 21 11:26 /payload.bin
msf6 auxiliary(admin/http/telpho10_credential_dump) > rm /payload.bin
[*] exec: rm /payload.bin

msf6 auxiliary(admin/http/telpho10_credential_dump) > reload
[*] Reloading module...
msf6 auxiliary(admin/http/telpho10_credential_dump) > git diff modules/auxiliary/admin/http/telpho10_credential_dump.rb
[*] exec: git diff modules/auxiliary/admin/http/telpho10_credential_dump.rb

diff --git a/modules/auxiliary/admin/http/telpho10_credential_dump.rb b/modules/auxiliary/admin/http/telpho10_credential_dump.rb
index 5c62f9e280..f1f9901a67 100644
--- a/modules/auxiliary/admin/http/telpho10_credential_dump.rb
+++ b/modules/auxiliary/admin/http/telpho10_credential_dump.rb
@@ -37,7 +37,7 @@ class MetasploitModule < Msf::Auxiliary
     File.open(tarfile, 'rb') do |file|
       Rex::Tar::Reader.new(file) do |tar|
         tar.each do |entry|
-          dest = File.join destination, entry.full_name
+          dest = File.join(destination, File.basename(entry.full_name))
           if entry.file?
             File.open(dest, 'wb') do |f|
               f.write(entry.read)
rmsf6 auxiliary(admin/http/telpho10_credential_dump) > run
[*] Running module against 127.0.0.1

[*] Generating backup
[*] Downloading backup
[+] File saved in: /root/.msf4/loot/20200821112811_default_127.0.0.1_telpho10.backup_948148.tar
[-] Could not unpack files.
[*] Auxiliary module execution completed
msf6 auxiliary(admin/http/telpho10_credential_dump) > ls -la /payload.bin
[*] exec: ls -la /payload.bin

ls: cannot access '/payload.bin': No such file or directory
msf6 auxiliary(admin/http/telpho10_credential_dump) > ls -la /root/.msf4/loot/20200821112811_default_127.0.0.1_telpho10.backup_948148
[*] exec: ls -la /root/.msf4/loot/20200821112811_default_127.0.0.1_telpho10.backup_948148

total 48
drwxr-xr-x 3 root root  4096 Aug 21 11:28 .
drwxr-xr-x 6 root root 32768 Aug 21 11:28 ..
drwxr-xr-x 2 root root  4096 Aug 21 11:28 mysql
-rwxrwxrwx 1 root root   207 Aug 21 11:28 payload.bin
msf6 auxiliary(admin/http/telpho10_credential_dump) > 
```

There may still be some issues with symlinks, especially as the tar file contents are decompressed then immediately modified with `File.chmod(entry.header.mode, dest)`.
