### PR TITLE
Use CheckModule auxiliary/scanner/misc/java_rmi_server in exploit/multi/misc/java_rmi_server

### DIFF
--- a/modules/auxiliary/scanner/misc/java_rmi_server.rb
+++ b/modules/auxiliary/scanner/misc/java_rmi_server.rb
@@ -33,9 +33,13 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run_host(target_host)
-    vprint_status("Sending RMI Header...")
-    connect
+    begin
+      connect
+    rescue Rex::ConnectionError
+      return Exploit::CheckCode::Unknown
+    end
 
+    vprint_status("Sending RMI Header...")
     send_header
     ack = recv_protocol_ack
     if ack.nil?

--- a/modules/auxiliary/scanner/misc/java_rmi_server.rb
+++ b/modules/auxiliary/scanner/misc/java_rmi_server.rb
@@ -41,7 +41,7 @@ class MetasploitModule < Msf::Auxiliary
     if ack.nil?
       print_error("Failed to negotiate RMI protocol")
       disconnect
-      return
+      return Exploit::CheckCode::Unknown
     end
 
     # Determine if the instance allows remote class loading
@@ -81,7 +81,7 @@ class MetasploitModule < Msf::Auxiliary
     if return_value.nil?
       print_good("Failed to send RMI Call, anyway JAVA RMI Endpoint detected")
       report_service(:host => rhost, :port => rport, :name => "java-rmi", :info => "")
-      return
+      return Exploit::CheckCode::Detected
     end
 
     if return_value.is_exception? && loader_enabled?(return_value.value)
@@ -94,9 +94,11 @@ class MetasploitModule < Msf::Auxiliary
         :info         => "Module #{self.fullname} confirmed remote code execution via this RMI service",
         :refs         => self.references
       )
+      Exploit::CheckCode::Vulnerable
     else
       print_status("#{rhost}:#{rport} Java RMI Endpoint Detected: Class Loader Disabled")
       report_service(:host => rhost, :port => rport, :name => "java-rmi", :info => "Class Loader: Disabled")
+      Exploit::CheckCode::Safe
     end
   end
 

--- a/modules/exploits/multi/misc/java_rmi_server.rb
+++ b/modules/exploits/multi/misc/java_rmi_server.rb
@@ -8,6 +8,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::Java::Rmi::Client
   include Msf::Exploit::Remote::HttpServer
+  include Msf::Exploit::Remote::CheckModule
 
   def initialize(info = {})
     super(update_info(info,
@@ -41,6 +42,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Stance'         => Msf::Exploit::Stance::Aggressive,
       'DefaultOptions' =>
         {
+          'CheckModule' => 'auxiliary/scanner/misc/java_rmi_server',
           'WfsDelay' => 10
         },
       'Targets'        =>


### PR DESCRIPTION
```
msf6 exploit(multi/misc/java_rmi_server) > check

[*] 127.0.0.1:1099 - Using auxiliary/scanner/misc/java_rmi_server as check
[*] 127.0.0.1:1099        - Sending RMI Header...
[*] 127.0.0.1:1099        - Sending RMI Call...
[+] 127.0.0.1:1099        - 127.0.0.1:1099 Java RMI Endpoint Detected: Class Loader Enabled
[*] 127.0.0.1:1099        - Scanned 1 of 1 hosts (100% complete)
[+] 127.0.0.1:1099 - The target is vulnerable.
msf6 exploit(multi/misc/java_rmi_server) >
```

https://github.com/vulhub/vulhub/tree/master/java/rmi-codebase