### PR TITLE
Fix features help command

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -644,7 +644,7 @@ class Core
 
       print_line features_table.to_s
     else
-      cmd_help
+      cmd_features_help
     end
   rescue StandardError => e
     elog(e)


### PR DESCRIPTION
Fixes the features command to correctly show the help information available.

## Verification

- [ ] Start `msfconsole`
- [ ] **Verify** that the feature's help works as expected:
- `features --help`
- `features missing_command`
- `help features`