### PR TITLE
Fix jupyter-login when scanning non-Jupyter hosts

### DIFF
--- a/modules/auxiliary/scanner/http/jupyter_login.rb
+++ b/modules/auxiliary/scanner/http/jupyter_login.rb
@@ -56,9 +56,9 @@ class MetasploitModule < Msf::Auxiliary
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, 'api')
     })
-    version = res.get_json_document.dig('version')
+    version = res&.get_json_document&.dig('version')
     if version.nil?
-      print_error "#{peer} - The server does not appear to be running Jupyter (failed to fetch the API version)"
+      vprint_error "#{peer} - The server does not appear to be running Jupyter (failed to fetch the API version)"
       return
     end
     vprint_status "#{peer} - The server responded that it is running Jupyter version: #{version}"


### PR DESCRIPTION
This fixes a simple bug in the Jupyter Login module that would cause a stack trace and a failure to scan other systems when given a range. This was due to me not checking the response when fingerprinting the version. This change uses safe navigation operator to retrieve the version and updates the failure message from a `print_error` to a `vprint_error` (to no overburden the user when scanning a Class-C).

## Testing

- [ ] Start `msfconsole`
- [ ] `use auxiliary/scanner/http/jupyter_login`
- [ ] Set the RHOST and RPORT to anything **but** a legit Jupyter instance
- [ ] `set VERBOSE true`
- [ ] Run the module and **do not** see a stack trace, but instead see an error message that the remote system is not a Jupyter instance

## Example Output
Before this bug fix:

```
msf6 auxiliary(scanner/http/jupyter_login) > set RHOSTS 192.168.159.0/24
RHOSTS => 192.168.159.0/24
msf6 auxiliary(scanner/http/jupyter_login) > run

[-] The host (192.168.159.0:8888) was unreachable.
[-] Auxiliary failed: NoMethodError undefined method `get_json_document' for nil:NilClass
[-] Call stack:
[-]   /home/smcintyre/Repositories/metasploit-framework/modules/auxiliary/scanner/http/jupyter_login.rb:59:in `run_host'
[-]   /home/smcintyre/Repositories/metasploit-framework/lib/msf/core/auxiliary/scanner.rb:117:in `block (2 levels) in run'
[-]   /home/smcintyre/Repositories/metasploit-framework/lib/msf/core/thread_manager.rb:106:in `block in spawn'
[*] Auxiliary module execution completed
msf6 auxiliary(scanner/http/jupyter_login) >
```

After this bug fix:

```
msf6 exploit(multi/handler) > use auxiliary/scanner/http/jupyter_login 
msf6 auxiliary(scanner/http/jupyter_login) > show options 

Module options (auxiliary/scanner/http/jupyter_login):

   Name              Current Setting     Required  Description
   ----              ---------------     --------  -----------
   BLANK_PASSWORDS   false               no        Try blank passwords for all users
   BRUTEFORCE_SPEED  5                   yes       How fast to bruteforce, from 0 to 5
   DB_ALL_PASS       false               no        Add all passwords in the current database to the list
   PASSWORD                              no        A specific password to authenticate with
   PASS_FILE         /tmp/passwords.txt  no        File containing passwords, one per line
   Proxies                               no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS            192.168.159.128     yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
   RPORT             8888                yes       The target port (TCP)
   SSL               false               no        Negotiate SSL/TLS for outgoing connections
   TARGETURI         /                   yes       The path to the Jupyter application
   THREADS           1                   yes       The number of concurrent threads (max one per host)
   VERBOSE           true                yes       Whether to print output for all attempts
   VHOST                                 no        HTTP server virtual host

msf6 auxiliary(scanner/http/jupyter_login) > set RHOSTS 192.168.159.0/24
RHOSTS => 192.168.159.0/24
msf6 auxiliary(scanner/http/jupyter_login) > run

[-] The host (192.168.159.0:8888) was unreachable.
[-] 192.168.159.0:8888 - The server does not appear to be running Jupyter (failed to fetch the API version)
...
```