### PR TITLE
Reload module after toggling features

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -614,6 +614,8 @@ class Core
 
       framework.features.set(feature_name, value == 'true')
       print_line("#{feature_name} => #{value}")
+      # Reload the current module, as feature flags may impact the available module options etc
+      driver.run_single("reload") if driver.active_module
     when 'print'
       if framework.features.all.empty?
         print_line 'There are no features to enable at this time. Either the features have been removed, or integrated by default.'


### PR DESCRIPTION
Setting `features set RHOST_HTTP_URL false` when inside a module doesn't cause the option to appear. This PR now reloads the current module to ensure the `RHOST_HTTP_URL` appears as an option.

## Verification

Open metasploit console, and run:

```
use auxiliary/scanner/http/squid_pivot_scanning
features set RHOST_HTTP_URL true
options
```

Verify that `RHOST_HTTP_URL` is now valid option.

### Before

The new RHOST_HTTP_URL option does not appear:

```
msf6 auxiliary(scanner/http/squid_pivot_scanning) > features set RHOST_HTTP_URL true
RHOST_HTTP_URL => true
msf6 auxiliary(scanner/http/squid_pivot_scanning) > options

Module options (auxiliary/scanner/http/squid_pivot_scanning):

   Name          Current Setting                               Required  Description
   ----          ---------------                               --------  -----------
   CANARY_IP     1.2.3.4                                       yes       The IP to check if the proxy always answers positively; the IP should not respond
                                                                         .
   MANUAL_CHECK  true                                          yes       Stop the scan if server seems to answer positively to every request
   PORTS         21,80,139,443,445,1433,1521,1723,3389,8080,9  yes       Ports to scan; must be TCP
                 100
   Proxies                                                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RANGE         172.31.179.0                                  yes       IPs to scan through Squid proxy
   RHOSTS        10.10.10.200                                  yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>
                                                                         '
   RPORT         3128                                          yes       The target port (TCP)
   SSL           false                                         no        Negotiate SSL/TLS for outgoing connections
   THREADS       1                                             yes       The number of concurrent threads (max one per host)
   VHOST                                                       no        HTTP server virtual host


```

### After

The new RHOST_HTTP_URL option appears:

```
msf6 auxiliary(scanner/http/squid_pivot_scanning) > features set RHOST_HTTP_URL true
RHOST_HTTP_URL => true
[*] Reloading module...  < -- new
msf6 auxiliary(scanner/http/squid_pivot_scanning) > options

Module options (auxiliary/scanner/http/squid_pivot_scanning):

   Name            Current Setting                              Required  Description
   ----            ---------------                              --------  -----------
   CANARY_IP       1.2.3.4                                      yes       The IP to check if the proxy always answers positively; the IP should not respon
                                                                          d.
   MANUAL_CHECK    true                                         yes       Stop the scan if server seems to answer positively to every request
   PORTS           21,80,139,443,445,1433,1521,1723,3389,8080,  yes       Ports to scan; must be TCP
                   9100
   Proxies                                                      no        A proxy chain of format type:host:port[,type:host:port][...]
   RANGE           172.31.179.0                                 yes       IPs to scan through Squid proxy
   RHOSTS          10.10.10.200                                 yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path
                                                                          >'
   RHOST_HTTP_URL  http://10.10.10.200:3128/                    no        The target URL, only applicable if there is a single URL
   ^ Option now appears
   RPORT           3128                                         yes       The target port (TCP)
   SSL             false                                        no        Negotiate SSL/TLS for outgoing connections
   THREADS         1                                            yes       The number of concurrent threads (max one per host)
   VHOST                                                        no        HTTP server virtual host
```