### PR TITLE
Allow scanner modules to skip hosts on fail_with

### DIFF
--- a/lib/msf/core/auxiliary.rb
+++ b/lib/msf/core/auxiliary.rb
@@ -13,13 +13,13 @@ module Msf
 ###
 class Auxiliary < Msf::Module
 
-  require 'msf/core/auxiliary/mixins'
-
   class Complete < RuntimeError
   end
 
   class Failed < RuntimeError
   end
+
+  require 'msf/core/auxiliary/mixins'
 
   include HasActions
 

--- a/lib/msf/core/auxiliary/scanner.rb
+++ b/lib/msf/core/auxiliary/scanner.rb
@@ -1,4 +1,5 @@
 # -*- coding: binary -*-
+
 module Msf
 
 ###
@@ -9,6 +10,8 @@ module Msf
 
 module Auxiliary::Scanner
 
+class AttemptFailed < Msf::Auxiliary::Failed
+end
 
 #
 # Initializes an instance of a recon auxiliary module
@@ -119,7 +122,7 @@ def run
             if datastore['CHOST']
               @scan_errors << "The source IP (CHOST) value of #{datastore['CHOST']} was not usable"
             end
-          rescue Msf::Auxiliary::Failed => e
+          rescue Msf::Auxiliary::Scanner::AttemptFailed => e
             nmod.vprint_error("#{e}")
           rescue ::Rex::ConnectionError, ::Rex::ConnectionProxyError, ::Errno::ECONNRESET, ::Errno::EINTR, ::Rex::TimeoutError, ::Timeout::Error, ::EOFError
           rescue ::Interrupt,::NoMethodError, ::RuntimeError, ::ArgumentError, ::NameError
@@ -204,7 +207,7 @@ def run
               if datastore['CHOST']
                 @scan_errors << "The source IP (CHOST) value of #{datastore['CHOST']} was not usable"
               end
-            rescue Msf::Auxiliary::Failed => e
+            rescue Msf::Auxiliary::Scanner::AttemptFailed => e
               print_error("#{e}")
             rescue ::Rex::ConnectionError, ::Rex::ConnectionProxyError, ::Errno::ECONNRESET, ::Errno::EINTR, ::Rex::TimeoutError, ::Timeout::Error
             rescue ::Interrupt,::NoMethodError, ::RuntimeError, ::ArgumentError, ::NameError
@@ -332,6 +335,16 @@ def add_delay_jitter(_delay, _jitter)
     final_delay = delay_value.to_f / 1000.0
     vprint_status("Delaying for #{final_delay} second(s) (#{original_value}ms +/- #{jitter_value}ms)")
     sleep final_delay
+  end
+end
+
+def fail_with(reason, msg = nil, abort: false)
+  if abort
+    # raising Failed will case the run to be aborted
+    raise Msf::Auxiliary::Failed, "#{reason.to_s}: #{msg}"
+  else
+    # raising AttemptFailed will cause the run_host / run_batch to be aborted
+    raise Msf::Auxiliary::Scanner::AttemptFailed, "#{reason.to_s}: #{msg}"
   end
 end
 

--- a/lib/msf/core/auxiliary/scanner.rb
+++ b/lib/msf/core/auxiliary/scanner.rb
@@ -119,6 +119,8 @@ def run
             if datastore['CHOST']
               @scan_errors << "The source IP (CHOST) value of #{datastore['CHOST']} was not usable"
             end
+          rescue Msf::Auxiliary::Failed => e
+            print_error("#{nmod.respond_to?(:peer) ? nmod.peer : tip} - #{e}")
           rescue ::Rex::ConnectionError, ::Rex::ConnectionProxyError, ::Errno::ECONNRESET, ::Errno::EINTR, ::Rex::TimeoutError, ::Timeout::Error, ::EOFError
           rescue ::Interrupt,::NoMethodError, ::RuntimeError, ::ArgumentError, ::NameError
             raise $!
@@ -198,10 +200,12 @@ def run
             mybatch = bat.dup
             begin
               nmod.run_batch(mybatch)
-          rescue ::Rex::BindFailed
-            if datastore['CHOST']
-              @scan_errors << "The source IP (CHOST) value of #{datastore['CHOST']} was not usable"
-            end
+            rescue ::Rex::BindFailed
+              if datastore['CHOST']
+                @scan_errors << "The source IP (CHOST) value of #{datastore['CHOST']} was not usable"
+              end
+            rescue Msf::Auxiliary::Failed => e
+              print_error("#{e}")
             rescue ::Rex::ConnectionError, ::Rex::ConnectionProxyError, ::Errno::ECONNRESET, ::Errno::EINTR, ::Rex::TimeoutError, ::Timeout::Error
             rescue ::Interrupt,::NoMethodError, ::RuntimeError, ::ArgumentError, ::NameError
               raise $!

--- a/lib/msf/core/auxiliary/scanner.rb
+++ b/lib/msf/core/auxiliary/scanner.rb
@@ -120,7 +120,7 @@ def run
               @scan_errors << "The source IP (CHOST) value of #{datastore['CHOST']} was not usable"
             end
           rescue Msf::Auxiliary::Failed => e
-            print_error("#{nmod.respond_to?(:peer) ? nmod.peer : tip} - #{e}")
+            nmod.vprint_error("#{e}")
           rescue ::Rex::ConnectionError, ::Rex::ConnectionProxyError, ::Errno::ECONNRESET, ::Errno::EINTR, ::Rex::TimeoutError, ::Timeout::Error, ::EOFError
           rescue ::Interrupt,::NoMethodError, ::RuntimeError, ::ArgumentError, ::NameError
             raise $!

--- a/modules/auxiliary/scanner/http/jupyter_login.rb
+++ b/modules/auxiliary/scanner/http/jupyter_login.rb
@@ -48,7 +48,7 @@ class MetasploitModule < Msf::Auxiliary
     destination = res.headers['Location'].split('?', 2)[0]
     return true if destination.end_with?(normalize_uri(target_uri.path, 'login'))
 
-    fail_with(Failure::UnexpectedReply, "#{peer} - The server responded with a redirect that did not match a known fingerprint")
+    fail_with(Failure::UnexpectedReply, "The server responded with a redirect that did not match a known fingerprint")
   end
 
   def run_host(ip)
@@ -56,11 +56,11 @@ class MetasploitModule < Msf::Auxiliary
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, 'api')
     })
+    fail_with(Failure::Unreachable, 'Failed to fetch the Jupyter API version') if res.nil?
+
     version = res&.get_json_document&.dig('version')
-    if version.nil?
-      vprint_error "#{peer} - The server does not appear to be running Jupyter (failed to fetch the API version)"
-      return
-    end
+    fail_with(Failure::UnexpectedReply, 'Failed to fetch the Jupyter API version') if version.nil?
+
     vprint_status "#{peer} - The server responded that it is running Jupyter version: #{version}"
 
     unless requires_password?(ip)


### PR DESCRIPTION
I'm not sure if this is a bug or simply a feature gap, but either way scanner modules who have a `run_host` method defined can not utilize the `fail_with` pattern of exiting out. This is because `fail_with` raises a `Msf::Auxiliary::Failed` exception which isn't ignored on a per-host basis. I would think that within `run_host` we'd want failures to simply cause the processing of that one host to be aborted and not the entire range that the user specified. This would also allow scanner modules to invoke mixin methods that use `fail_with` without breaking.

I would assume that `fail_with` instances that **should** cause the entire module to be aborted (like `Failure::BadConfig`) would be placed in the top level `run` method before calling `super` to invoke the scan logic. I can't seem to find an instance of any scanners doing this though.

I updated the Jupyter Login module as a contrived example to show that if it fails to identify the remote server, it'll `fail_with` an appropriate reason and the scanner will move on. This behavior came up while working with the contributor on #13906 (see [their comment](https://github.com/rapid7/metasploit-framework/pull/13906#issuecomment-678641960)).

## Verification

- [ ] Start `msfconsole`
- [ ] `use auxiliary/scanner/http/jupyter_login`
- [ ] `set RHOSTS` to some Class-C
- [ ] Run the module and see multiple failure methods showing that the entire module was not aborted
