### PR TITLE
Fixing zip import errors

### DIFF
--- a/lib/msf/core/db_manager/import/metasploit_framework/zip.rb
+++ b/lib/msf/core/db_manager/import/metasploit_framework/zip.rb
@@ -3,9 +3,9 @@ module Msf::DBManager::Import::MetasploitFramework::Zip
   # XXX: This function is stupidly long. It needs to be refactored.
   def import_msf_collateral(args={}, &block)
     data = ::File.open(args[:filename], "rb") {|f| f.read(f.stat.size)}
-    wspace = Msf::Util::DBManager.process_opts_workspace(args, framework).name
+    wspace = Msf::Util::DBManager.process_opts_workspace(args, framework)
     args = args.clone()
-    args.detele(:workspace)
+    args.delete(:workspace)
     bl = validate_ips(args[:blacklist]) ? args[:blacklist].split : []
     basedir = args[:basedir] || args['basedir'] || ::File.join(Msf::Config.data_directory, "msf")
 
@@ -59,7 +59,7 @@ module Msf::DBManager::Import::MetasploitFramework::Zip
     return 0 if bl.include? host_info[loot.at("host-id").text.to_s.strip]
     loot_info              = {}
     loot_info[:host]       = host_info[loot.at("host-id").text.to_s.strip]
-    loot_info[:workspace]  = args[:workspace]
+    loot_info[:workspace]  = wspace
     loot_info[:ctype]      = nils_for_nulls(loot.at("content-type").text.to_s.strip)
     loot_info[:info]       = nils_for_nulls(unserialize_object(loot.at("info"), allow_yaml))
     loot_info[:ltype]      = nils_for_nulls(loot.at("ltype").text.to_s.strip)
@@ -104,7 +104,7 @@ module Msf::DBManager::Import::MetasploitFramework::Zip
   # Parses task Nokogiri::XML::Element
   def parse_zip_task(task, wspace, bl, allow_yaml, btag, args, basedir, host_info, &block)
     task_info = {}
-    task_info[:workspace] = args[:workspace]
+    task_info[:workspace] = wspace
     # Should user be imported (original) or declared (the importing user)?
     task_info[:user] = nils_for_nulls(task.at("created-by").text.to_s.strip)
     task_info[:desc] = nils_for_nulls(task.at("description").text.to_s.strip)
@@ -165,7 +165,7 @@ module Msf::DBManager::Import::MetasploitFramework::Zip
   # XXX: Refactor so it's not quite as sanity-blasting.
   def import_msf_zip(args={}, &block)
     data = args[:data]
-    wspace = Msf::Util::DBManager.process_opts_workspace(args, framework).name
+    wspace = Msf::Util::DBManager.process_opts_workspace(args, framework)
     bl = validate_ips(args[:blacklist]) ? args[:blacklist].split : []
 
     new_tmp = ::File.join(Dir::tmpdir,"msf","imp_#{Rex::Text::rand_text_alphanumeric(4)}",@import_filedata[:zip_basename])


### PR DESCRIPTION
In particular:
* passed workspace as an object instead of calling `.name`
* loot and task processing now consumes `wspace` parameter
* fixed typo in `.delete` method

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] Run `db_import fix_import.zip`
- [x] **Verify** the import completes without error
- [x] **Verify** hosts command reports one host
- [x] **Verify** creds imported correctly
- [x] **Verify** loots import correctly
~[fix_import.zip](https://github.com/rapid7/metasploit-framework/files/5126707/fix_import.zip)~
[fix_import.zip](https://github.com/rapid7/metasploit-framework/files/5151124/fix_import.zip)

