### PR TITLE
Add the ability to use numerics with info command

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -110,6 +110,22 @@ module Msf
             print_line
           end
 
+          def print_module_info(mod, dump_json: false, show_doc: false)
+            if dump_json
+              print(Serializer::Json.dump_module(mod) + "\n")
+            elsif show_doc
+              f = Tempfile.new(["#{mod.shortname}_doc", '.html'])
+              begin
+                print_status("Generating documentation for #{mod.shortname}, then opening #{f.path} in a browser...")
+                Msf::Util::DocumentGenerator.spawn_module_document(mod, f)
+              ensure
+                f.close if f
+              end
+            else
+              print(Serializer::ReadableText.dump_module(mod))
+            end
+          end
+
           #
           # Displays information about one or more module.
           #
@@ -128,49 +144,41 @@ module Msf
             end
 
             if (args.length == 0)
-              if (active_module)
-                if dump_json
-                  print(Serializer::Json.dump_module(active_module) + "\n")
-                elsif show_doc
-                  f = Tempfile.new(["#{active_module.shortname}_doc", '.html'])
-                  begin
-                    print_status("Generating documentation for #{active_module.shortname}, then opening #{f.path} in a browser...")
-                    Msf::Util::DocumentGenerator.spawn_module_document(active_module, f)
-                  ensure
-                    f.close if f
-                  end
-                else
-                  print(Serializer::ReadableText.dump_module(active_module))
-                end
+              if active_module
+                print_module_info(active_module, dump_json: dump_json, show_doc: show_doc)
                 return true
               else
                 cmd_info_help
                 return false
               end
-            elsif args.include? "-h"
+            elsif args.include? '-h'
               cmd_info_help
               return false
             end
+            
+            args.each do |arg|
+              mod_name = arg
 
-            args.each { |name|
+              # Use a module by search index
+              index_from_list(@module_search_results, mod_name) do |mod|
+                next unless mod && mod.respond_to?(:fullname)
+
+                # Module cache object from @module_search_results
+                mod_name = mod.fullname
+              end
+
+              # Ensure we have a reference name and not a path
+              name = trim_path(mod_name, 'modules')
+
+              # Creates an instance of the module
               mod = framework.modules.create(name)
 
-              if (mod == nil)
+              if mod.nil?
                 print_error("Invalid module: #{name}")
-              elsif dump_json
-                print(Serializer::Json.dump_module(mod) + "\n")
-              elsif show_doc
-                f = Tempfile.new(["#{mod.shortname}_doc", '.html'])
-                begin
-                  print_status("Generating documentation for #{mod.shortname}, then opening #{f.path} in a browser...")
-                  Msf::Util::DocumentGenerator.spawn_module_document(mod, f)
-                ensure
-                  f.close if f
-                end
               else
-                print(Serializer::ReadableText.dump_module(mod))
+                print_module_info(mod, dump_json: dump_json, show_doc: show_doc)
               end
-            }
+            end
           end
 
           def cmd_options_help
@@ -649,7 +657,10 @@ module Msf
 
             # Use a module by search index
             index_from_list(@module_search_results, mod_name) do |mod|
-              return false unless mod && mod.respond_to?(:fullname)
+              unless mod && mod.respond_to?(:fullname)
+                print_error("Invalid module index: #{mod_name}")
+                return false
+              end
 
               # Module cache object from @module_search_results
               mod_name = mod.fullname


### PR DESCRIPTION
### Before 
Before you were not able to use numerics with the info command
![image](https://user-images.githubusercontent.com/69522014/91311725-52098180-e7ab-11ea-98ed-678b05cedda9.png)

### After 
Now if you use a numeric with the info command it will display the corresponding modules info
![image](https://user-images.githubusercontent.com/69522014/91312013-a4e33900-e7ab-11ea-9c92-34d0bbe95f2f.png)


## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `search winrm`
- [ ] `info 0`
- [ ] **Verify** the info command displays the corresponding modules information
- [ ] **Verify** `info 9999999` returns `[-] Invalid module: 9999999`
