### PR TITLE
Reduce msfvenom run time by only loading relevant module sets

### DIFF
--- a/msfvenom
+++ b/msfvenom
@@ -49,10 +49,10 @@ def init_framework(create_opts={})
   ]
 
   create_opts[:module_types].map! do |type|
-    type = Msf.const_get("MODULE_#{type.upcase}")
+    Msf.const_get("MODULE_#{type.upcase}")
   end
 
-  @framework = ::Msf::Simple::Framework.create
+  @framework = ::Msf::Simple::Framework.create(create_opts)
 end
 
 # Cached framework object


### PR DESCRIPTION
This PR reduces msfvenom run time by only loading relevant module sets

So turns out the work was already all done! we just weren't using it, the options were never being passed in

Before:
![image](https://user-images.githubusercontent.com/19910435/91552409-aa638f00-e923-11ea-9001-7d7c22b676fc.png)

After:
![image](https://user-images.githubusercontent.com/19910435/91552447-bcddc880-e923-11ea-828b-8e011d8c014b.png)

