### PR TITLE
Add a SECURITY.md file

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,13 +23,13 @@ security@rapid7.com. If you like, you can use our [PGP key][pgp] to
 encrypt your messages, but we certainly don't mind cleartext reports
 over email.
 
-## Via GitHub Issues
+## NOT via GitHub Issues
 
-Actually, please don't! Disclosing security vulnerabilities to public
-bug trackers is kind of mean, even when it's well-intentioned, since
-you end up dropping 0-day on pretty much everyone right out of the gate.
-We'd prefer you didn't!
+Please don't! Disclosing security vulnerabilities to public bug trackers
+is kind of mean, even when it's well-intentioned, since you end up
+dropping 0-day on pretty much everyone right out of the gate. We'd prefer
+you didn't!
 
-[r7vulns]:https://www.rapid7.com/security/disclosure/
+[r7-vulns]:https://www.rapid7.com/security/disclosure/
 [pgp]:https://keybase.io/rapid7/pgp_keys.asc?fingerprint=9a90aea0576cbcafa39c502ba5e16807959d3eda
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,35 @@
+# Reporting security issues
+
+Thanks for your interest in making Metasploit more secure! If you feel
+that you have found a security issue involving Metasploit, Meterpreter,
+Recog, or any other Rapid7 open source project, you are welcome to let
+us know in the way that's most comfortable for you.
+
+## Via ZenDesk
+
+You can click on the big blue button at [Rapid7's Vulnerability
+Disclosure][r7-vulns] page, which will get you to our general
+vulnerability reporting system. While this does require a (free) ZenDesk
+account to use, you'll get regular updates on your issue as our software
+support teams work through it. As it happens [that page][r7-vulns] also
+will tell you what to expect when it comes to reporting vulns, how fast
+we'll fix and respond, and all the rest, so it's a pretty good read
+regardless.
+
+## Via email
+
+If you're more of a traditionalist, you can email your finding to
+security@rapid7.com. If you like, you can use our [PGP key][pgp] to
+encrypt your messages, but we certainly don't mind cleartext reports
+over email.
+
+## Via GitHub Issues
+
+Actually, please don't! Disclosing security vulnerabilities to public
+bug trackers is kind of mean, even when it's well-intentioned, since
+you end up dropping 0-day on pretty much everyone right out of the gate.
+We'd prefer you didn't!
+
+[r7vulns]:https://www.rapid7.com/security/disclosure/
+[pgp]:https://keybase.io/rapid7/pgp_keys.asc?fingerprint=9a90aea0576cbcafa39c502ba5e16807959d3eda
+


### PR DESCRIPTION
Git has this cool shield button on the ribbon on every project now that indicates the vulnerability reporting policy for that project. We should totally populate this so people don't accidentally dox our bugs on Issues.

## Verification

It's docs, so just read it.

- [ ] Once landed, the link on the shield button up top should point to this doc.
