### PR TITLE
fixed module html references for info -d command

### DIFF
--- a/lib/msf/util/document_generator/normalizer.rb
+++ b/lib/msf/util/document_generator/normalizer.rb
@@ -203,11 +203,15 @@ module Msf
               normalized << "* [#{ref.ctx_val}](#{ref.site})"
             when 'URL'
               normalized << "* [#{ref.site}](#{ref.site})"
+            when 'OSVDB'
+              normalized << "* #{ref.site.to_s}"
             when 'US-CERT-VU'
               normalized << "* [VU##{ref.ctx_val}](#{ref.site})"
             when 'CVE', 'cve'
               if !cve_collection.empty? && ref.ctx_val.blank?
                 normalized << "* #{NO_CVE_MESSAGE}"
+              else
+                normalized << "* [#{ref.ctx_id}-#{ref.ctx_val}](#{ref.site})"
               end
             else
               normalized << "* [#{ref.ctx_id}-#{ref.ctx_val}](#{ref.site})"


### PR DESCRIPTION
### Before 
Before when you clicked the OSVDB link, it brought you to a dead link. 
![image](https://user-images.githubusercontent.com/69522014/91549911-9e75ce00-e91f-11ea-86f8-24c84baed43a.png)

The CVE link was also not being displayed even though `exploit/windows/http/rejetto_hfs_exec` has a CVE reference.
![image](https://user-images.githubusercontent.com/69522014/91549665-2effde80-e91f-11ea-883c-d5af503daa6a.png)

### After
Now the OSVDB article will no longer display a dead link and will display as a string, as OSVDB is no longer being supported https://www.securityweek.com/osvdb-shut-down-permanently, also the CVE link will now appear.
![image](https://user-images.githubusercontent.com/69522014/91549433-d892a000-e91e-11ea-9dcd-f877a07c592b.png)

Also, if the module does not contain a CVE reference it will return
![image](https://user-images.githubusercontent.com/69522014/91552332-8b64fd00-e923-11ea-9ac5-f1d7cfe078b1.png)
which will direct the user to this link: https://github.com/rapid7/metasploit-framework/wiki/Why-CVE-is-not-available

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/windows/http/rejetto_hfs_exec`
- [ ] `info -d`
- [ ] **Verify** the OSVDB no longer displays a dead link
- [ ] **Verify** the CVE link is present