### PR TITLE
switch to lazy loading faker

### DIFF
--- a/lib/msf/core/cert_provider.rb
+++ b/lib/msf/core/cert_provider.rb
@@ -1,9 +1,9 @@
 require 'rex/socket/ssl'
-require 'faker'
 
 module Msf
 module Ssl
   module CertProvider
+    autoload :Faker, 'faker'
 
     def self.rand_vars(opts = {})
       opts ||= {}


### PR DESCRIPTION
Lazy load faker, it's not needed during boot up and even then only in specific cases so it makes sense

To verify time:
```time ./msfconsole -qx "exit"```
or
```multitime -n 10 ./msfconsole -qx "exit"```
which gives you an average