### PR TITLE
report `CheckCode` for `check` failure

### DIFF
--- a/modules/auxiliary/gather/peplink_bauth_sqli.rb
+++ b/modules/auxiliary/gather/peplink_bauth_sqli.rb
@@ -196,7 +196,7 @@ class MetasploitModule < Msf::Auxiliary
         'method' => 'GET',
         'cookie' => "bauth=' or #{payload}--"
       })
-      fail_with 'Unable to connect to target' unless res
+      fail_with 'Unable to connect to target' , "#{target_uri.path}" unless res
       res.get_cookies.empty? # no Set-Cookie header means the session cookie is valid
     end
     if @sqli.test_vulnerable

--- a/modules/auxiliary/gather/peplink_bauth_sqli.rb
+++ b/modules/auxiliary/gather/peplink_bauth_sqli.rb
@@ -196,7 +196,7 @@ class MetasploitModule < Msf::Auxiliary
         'method' => 'GET',
         'cookie' => "bauth=' or #{payload}--"
       })
-      fail_with 'Unable to connect to target' , "#{target_uri.path}" unless res
+      return Exploit::CheckCode::Unknown("Unable to connect to #{target_uri.path}") unless res
       res.get_cookies.empty? # no Set-Cookie header means the session cookie is valid
     end
     if @sqli.test_vulnerable


### PR DESCRIPTION
`fail_with` should not be used in `check` method, convert to return the `Unknown` status when the endpoint required cannot be reached.

## Verification

List the steps needed to make sure this thing works

- [ ] See https://github.com/rapid7/metasploit-framework/pull/13847#issuecomment-661964193
- [ ] Provide an invalid target
- [ ] ***Verify*** failure is reported properly
