### PR TITLE
[GSOC] Tab-completion improved for module OPTIONS not available

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -23,6 +23,8 @@ require 'msf/ui/console/command_dispatcher/modules'
 require 'msf/ui/console/command_dispatcher/developer'
 require 'msf/util/document_generator'
 
+require 'msf/core/opt_condition'
+
 require 'optparse'
 
 module Msf
@@ -1871,6 +1873,7 @@ class Core
 
     mod.options.sorted.each { |e|
       name, _opt = e
+      next unless Msf::OptCondition.show_option(mod, mod_opt)
       res << name
     }
 
@@ -1897,6 +1900,7 @@ class Core
       if (p)
         p.options.sorted.each { |e|
           name, _opt = e
+          next unless Msf::OptCondition.show_option(mod, _opt)
           res << name
         }
       end
@@ -2135,7 +2139,15 @@ class Core
   #   stage since the command itself has been completed.
   def cmd_unset_tabs(str, words)
     datastore = active_module ? active_module.datastore : self.framework.datastore
-    datastore.keys
+    keys = datastore.keys
+
+    mod = active_module
+    mod.options.each do |name, mod_opt|
+      next if Msf::OptCondition.show_option(mod, mod_opt)
+      i = keys.index(name)
+      keys.delete_at i if i
+    end
+    keys
   end
 
   def cmd_unsetg_help

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -2143,10 +2143,8 @@ class Core
 
     mod = active_module
     if mod
-      mod.options.each do |name, mod_opt|
-        next if Msf::OptCondition.show_option(mod, mod_opt)
-        i = keys.index(name)
-        keys.delete_at i if i
+      keys = keys.delete_if do |name|
+        !(mod_opt = mod.options[name]).nil? && !Msf::OptCondition.show_option(mod, mod_opt)
       end
     end
     keys

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1873,7 +1873,7 @@ class Core
 
     mod.options.sorted.each { |e|
       name, _opt = e
-      next unless Msf::OptCondition.show_option(mod, mod_opt)
+      next unless Msf::OptCondition.show_option(mod, _opt)
       res << name
     }
 

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -2142,10 +2142,12 @@ class Core
     keys = datastore.keys
 
     mod = active_module
-    mod.options.each do |name, mod_opt|
-      next if Msf::OptCondition.show_option(mod, mod_opt)
-      i = keys.index(name)
-      keys.delete_at i if i
+    if mod
+      mod.options.each do |name, mod_opt|
+        next if Msf::OptCondition.show_option(mod, mod_opt)
+        i = keys.index(name)
+        keys.delete_at i if i
+      end
     end
     keys
   end


### PR DESCRIPTION
With a recent code improvement, module OPTIONS not necessary will not be shown when _show options_. However, tab-completion still works for the module OPTIONS which are not shown (as long as the exist).
Now I made tab-completion for module OPTIONS only working for the available module OPTIONS shown with _show options_.

## Verification

We will use the [cmdstager](https://github.com/mariabelenTC/metasploit-framework/blob/GSOC1/lib/msf/core/exploit/cmdstager.rb), where we added the following OPTIONS:


    server_conditions = ['CMDSTAGER::FLAVOR', 'in', %w{certutil tftp wget curl fetch lwprequest psh_invokewebrequest}]
    register_options(
      [
        OptAddressLocal.new('SRVHOST', [true, 'The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.', '0.0.0.0' ], conditions: server_conditions),
        OptPort.new('SRVPORT', [true, "The local port to listen on.", 8080], conditions: server_conditions)
      ])

In this case, the OPTIONS `SRVHOST` and `SRVPORT` should be only displayed when the value of the OPTION CMDSTAGER::FLAVOR is any of the following: `certutil` `tftp` `wget` `curl` `fetch` `lwprequest` `psh_invokewebrequest`, as the condition says.

These are the steps needed to make sure the new code improvement for tab-completion works:

- [ ] Start `msfconsole`
- [ ] `use exploit/multi/ssh/sshexec`
- [ ] `show options`
- [ ] Verify that the options `SRVHOST` and `SRVPORT` are not displayed.
- [ ] Write `set SRVHO` and press tab for automatic tab-completion.
- [ ] Verify tab-completion does not work.
- [ ] `set CMDSTAGER::FLAVOR bourne`
- [ ] Verify that the options `SRVHOST` and `SRVPORT` are still not displayed.
- [ ] Write `set SRVHO` and press tab for automatic tab-completion.
- [ ] Verify tab-completion does not work.
- [ ] `set CMDSTAGER::FLAVOR wget`
- [ ] Verify that the options `SRVHOST` and `SRVPORT` are now displayed.
- [ ] Write `set SRVHO` and press tab for automatic tab-completion.
- [ ] Verify tab-completion now does work.

The same applies to the `set` and `unset` commands.