### PR TITLE
Include KB installation date in enum_patches

### DIFF
--- a/modules/post/windows/gather/enum_patches.rb
+++ b/modules/post/windows/gather/enum_patches.rb
@@ -34,32 +34,33 @@ class MetasploitModule < Msf::Post
 
   def run
     unless load_extapi
-      print_error 'ExtAPI failed to load'
+      print_error("ExtAPI failed to load")
       return
     end
 
     begin
-      objects = session.extapi.wmi.query("SELECT HotFixID FROM Win32_QuickFixEngineering")
+      objects = session.extapi.wmi.query("SELECT HotFixID, InstalledOn FROM Win32_QuickFixEngineering")
     rescue RuntimeError
-      print_error "Known bug in WMI query, try migrating to another process"
+      print_error("Known bug in WMI query, try migrating to another process")
       return
     end
 
     if objects[:values].nil?
       kb_ids = []
     else
-      kb_ids = objects[:values].reject(&:nil?).map { |kb| kb[0] }
+      kb_ids = objects[:values].reject(&:nil?).map { |kb| kb }
     end
 
     if kb_ids.empty?
-      print_status 'Found no patches installed'
+      print_status("Found no patches installed")
       return
     end
 
     l = store_loot('enum_patches', 'text/plain', session, kb_ids.join("\n"))
     print_status("Patch list saved to #{l}")
+
     kb_ids.each do |kb|
-      print_status("#{kb} applied")
+      print_good("#{kb[0]} installed on #{kb[1]}")
     end
   end
 end


### PR DESCRIPTION
This change improves the module by also having it output when a given patch package was installed (this information can also be retrieved from the WMI query); this will provide insight into how regularly and reliably a PC (and by extension, environment) patches - for example, are they late in installing patches by months, when did they last patch etc.

Currently, the output of this module only lists the KB packages installed on a Windows PC. 

## Verification

- [ ] Start `msfconsole`
- [ ] Spawn a Meterpreter session against a Windows target
- [ ] With the session sent to background, search for `enum_patches`
- [ ] Set the `SESSION` parameter to match the session of interest
- [ ] `RUN` the module
- [ ] The post-exploitation module runs with the following output

## msfconsole Output
### Output with proposed changes (from a Win 7 SP1 VM)
```
[+] KB2534111 installed on 8/31/2020
[+] KB2999226 installed on 8/31/2020
[+] KB976902 installed on 11/21/2010
```
### Output without proposed changes
```
[*] KB2534111 applied
[*] KB2999226 applied
[*] KB976902 applied
```