### PR TITLE
Add url reference to peplink_bauth_sqli

### DIFF
--- a/modules/auxiliary/gather/peplink_bauth_sqli.rb
+++ b/modules/auxiliary/gather/peplink_bauth_sqli.rb
@@ -26,6 +26,7 @@ class MetasploitModule < Msf::Auxiliary
           [
             [ 'EDB', '42130' ],
             [ 'CVE', '2017-8835' ],
+            [ 'URL', 'https://gist.github.com/red0xff/c4511d2f427efcb8b018534704e9607a' ]
           ],
         'Targets' => [['Wildcard Target', {}]],
         'DefaultTarget' => 0


### PR DESCRIPTION
This PR adds [an URL reference](https://gist.github.com/red0xff/c4511d2f427efcb8b018534704e9607a) to the module `auxiliary/gather/peplink_bauth_sqli`, the reference is a writeup on using the SQL injection library to implement the module.