### PR TITLE
Make smb_version scanner compatible with ruby <= 2.5

### DIFF
--- a/modules/auxiliary/scanner/smb/smb_version.rb
+++ b/modules/auxiliary/scanner/smb/smb_version.rb
@@ -88,7 +88,7 @@ class MetasploitModule < Msf::Auxiliary
 
       break if protocol.nil?
       version = { 'SMB2' => 2, 'SMB3' => 3 }.fetch(protocol, 1)
-      versions.filter! { |v| v < version }
+      versions.select! { |v| v < version }
 
       dialect = simple.client.dialect
       if simple.client.is_a? RubySMB::Client


### PR DESCRIPTION
This pull request closes #14088 , which prevented `auxiliary/scanner/smb/smb_version` to run on on systems with Ruby < 2.6 such as Ubuntu versions < 20.04. It also makes Metasploit meet its own system requirements stated on https://www.rapid7.com/products/metasploit/system-requirements/ again.

The only change is replaceing `versions.filter!` with `versions.select!`. The former was introduced in Ruby 2.6 as an alias for the latter (see https://apidock.com/ruby/Array/filter), so nothing really changes under the hood.

## Verification

#### Ruby < 2.6
```
$ ruby -v
ruby 2.5.5p157 (2019-03-15 revision 67260) [x86_64-linux-gnu]
$ irb
irb(main):001:0> versions = [1, 2, 3]
=> [1, 2, 3]
irb(main):002:0> version = 3
=> 3
irb(main):003:0> versions.filter! { |v| v < version }
Traceback (most recent call last):
        2: from /usr/bin/irb:11:in `<main>'
        1: from (irb):3
NoMethodError (undefined method `filter!' for [1, 2, 3]:Array)
irb(main):004:0> versions.select! { |v| v < version }
=> [1, 2]
```
#### Ruby >= 2.6
```
$ ruby -v               
ruby 2.7.1p83 (2020-03-31 revision a0c7c23c9c) [x86_64-linux]
$ irb
irb(main):001:0> versions = [1, 2, 3]
irb(main):002:0> version = 3
irb(main):003:0> versions.filter! { |v| v < version }
=> [1, 2]
irb(main):004:0> versions = [1, 2, 3]
irb(main):005:0> version = 3
irb(main):006:0> versions.select! { |v| v < version }
```
#### In Metasploit
1. Run `msfconsole`
2. `use auxiliary/scanner/smb/smb_version`
3. `set RHOSTS ...`
4. `run`