### PR TITLE
Add example of `info 3` to the search results

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -477,9 +477,10 @@ module Msf
 
               if @module_search_results.length > 1
                 index_usage = "use #{@module_search_results.length - 1}"
+                index_info = "info #{@module_search_results.length - 1}"
                 name_usage = "use #{@module_search_results.last.fullname}"
 
-                print("Interact with a module by name or index, for example %grn#{index_usage}%clr or %grn#{name_usage}%clr\n\n")
+                print("Interact with a module by name or index, for example %grn#{index_info}%clr, %grn#{index_usage}%clr or %grn#{name_usage}%clr\n\n")
               end
             end
 


### PR DESCRIPTION
### Before
Before the search command gave instructions on how to show the user how to `use` modules:
![image](https://user-images.githubusercontent.com/69522014/92227164-c88a3b80-ee9d-11ea-8bcc-04e82ca36ef0.png)


### After
Now the search command will give instructions on how to utilise both `use` and `info` on modules:
![image](https://user-images.githubusercontent.com/69522014/92227212-dcce3880-ee9d-11ea-897b-970b9a05bd96.png)


## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `search winrm`
- [ ] **Verify** the module instructions have now updated with `info` example

