### PR TITLE
Fix user path on newer Windows

### DIFF
--- a/modules/post/windows/gather/enum_powershell_env.rb
+++ b/modules/post/windows/gather/enum_powershell_env.rb
@@ -27,12 +27,12 @@ class MetasploitModule < Msf::Post
     env_vars = session.sys.config.getenvs('SystemDrive', 'USERNAME')
     sysdrv = env_vars['SystemDrive']
 
-    if os =~ /Windows 7|Vista|2008/
-      path4users = sysdrv + "\\Users\\"
-      profilepath = "\\Documents\\WindowsPowerShell\\"
-    else
+    if os =~ /XP|2003/
       path4users = sysdrv + "\\Documents and Settings\\"
       profilepath = "\\My Documents\\WindowsPowerShell\\"
+    else
+      path4users = sysdrv + "\\Users\\"
+      profilepath = "\\Documents\\WindowsPowerShell\\"
     end
 
     if is_system?


### PR DESCRIPTION

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] get a meterp session on Windows 10 or any server version newer than 2008
- [x] `use post/windows/gather/enum_powershell_env`
- [x] `set session -1`
- [x] `run`
- [x] **Verify** it checks the correct path: "C:\Users\" 
