### PR TITLE
Exclude more labels from stale bot

### DIFF
--- a/.github/workflows/schedule-stale.yml
+++ b/.github/workflows/schedule-stale.yml
@@ -32,5 +32,5 @@ jobs:
 
             As a friendly reminder: the best way to see this issue, or any other, fixed is to open a Pull Request.
           exempt-issue-labels: |
-            not-stale,confirmed,easy,newbie-friendly
+            not-stale,confirmed,easy,newbie-friendly,suggestion,suggestion-module,suggestion-feature,suggestion-docs
           debug-only: false


### PR DESCRIPTION
Adds more labels for stale bot to exclude from marking as stale/closing

## Verification

When the stale bot runs make sure it doesn't mark the added labels on any issues as `stale`
