### PR TITLE
Updates search command to always show additional usage details

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -155,7 +155,7 @@ module Msf
               cmd_info_help
               return false
             end
-            
+
             args.each do |arg|
               mod_name = arg
 
@@ -473,15 +473,13 @@ module Msf
               }
             else
               print_line(tbl.to_s)
+              index_usage = "use #{@module_search_results.length - 1}"
+              index_info = "info #{@module_search_results.length - 1}"
+              name_usage = "use #{@module_search_results.last.fullname}"
+
+              print("Interact with a module by name or index. For example %grn#{index_info}%clr, %grn#{index_usage}%clr or %grn#{name_usage}%clr\n\n")
+
               print_status("Using #{used_module}") if used_module
-
-              if @module_search_results.length > 1
-                index_usage = "use #{@module_search_results.length - 1}"
-                index_info = "info #{@module_search_results.length - 1}"
-                name_usage = "use #{@module_search_results.last.fullname}"
-
-                print("Interact with a module by name or index, for example %grn#{index_info}%clr, %grn#{index_usage}%clr or %grn#{name_usage}%clr\n\n")
-              end
             end
 
             true


### PR DESCRIPTION
## Before 

The additional usage details for the search command was 'smart' and was hidden when when only one module was successfully found:

![image](https://user-images.githubusercontent.com/60357436/92477144-fb9f3880-f1d7-11ea-853a-fe4ad32a115c.png)

## After

Updates the search command to always show additional usage details:

![image](https://user-images.githubusercontent.com/60357436/92477283-402ad400-f1d8-11ea-94be-724a74e71778.png)

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `search postgres login`
- [ ] `use postgres login`
- [ ] **Verify** the the search details appear
