### PR TITLE
Remove sizes hash and calculation of payload sizes on boot

### DIFF
--- a/lib/msf/core/payload_set.rb
+++ b/lib/msf/core/payload_set.rb
@@ -47,9 +47,6 @@ class PayloadSet < ModuleSet
     self.stages  = {}
     self.singles = {}
 
-    # Hash that caches the sizes of payloads
-    self.sizes   = {}
-
     # Single instance cache of modules for use with doing quick referencing
     # of attributes that would require an instance.
     self._instances = {}
@@ -94,15 +91,6 @@ class PayloadSet < ModuleSet
       # Add it to the set
       add_single(p, name, op[5])
       new_keys.push name
-
-      # Cache the payload's size
-      begin
-        sizes[name] = p.cached_size || p.new.size
-      # Don't cache generic payload sizes.
-      rescue NoCompatiblePayloadError
-      rescue StandardError => e
-        elog("Unable to build payload #{name} due to #{e}.")
-      end
     }
 
     # Recalculate staged payloads
@@ -181,9 +169,6 @@ class PayloadSet < ModuleSet
           'paths' => op[5]['paths'] + ip[5]['paths'],
           'type'  => op[5]['type']})
         new_keys.push combined
-
-        # Cache the payload's size
-        sizes[combined] = p.cached_size || p.new.size
       }
     }
 
@@ -404,10 +389,6 @@ class PayloadSet < ModuleSet
   # The list of singles that have been loaded.
   #
   attr_reader :singles
-  #
-  # The sizes of all the built payloads thus far.
-  #
-  attr_reader :sizes
 
 protected
 
@@ -450,7 +431,7 @@ protected
   end
 
   attr_accessor :payload_type_modules # :nodoc:
-  attr_writer   :stages, :singles, :sizes # :nodoc:
+  attr_writer   :stages, :singles # :nodoc:
   attr_accessor :_instances # :nodoc:
 
 end


### PR DESCRIPTION
Removing the sizes hash and all payload size calculations that were done to populate it
The hash was never being used and this does not affect the filtering of available payloads which is done elsewhere


https://github.com/rapid7/metasploit-framework/commit/f1691c5470fee105a17e558b9e2e2e2950d1fe5a#diff-779cad5a3d687ab18499e0fe3fd20ee4R153-R179
this function was the only thing that used it, and it was (partially) removed in the very next commit

https://github.com/rapid7/metasploit-framework/blob/618fbf075a28bcd763e7f38d7826d379166ce298/lib/msf/core/exploit.rb#L717-L724
Used it more recently and was replaced by:
https://github.com/rapid7/metasploit-framework/blob/9a5f393e0b1a34b24a2f9eb715c89d4d99816d0c/lib/msf/core/exploit.rb#L824-L838

we do still seem to be filtering out payloads based on size properly aswell, easy test on windows/smb/ms17_010_eternalblue it has all the staged meterpreters but none of the full fat ones, and then for shells again all the staged oens but only two of the full fat onescompared to say windows/tftp/distinct_tftp_traversal which has both the staged and non-staged versions available since it doesn't have a size limit
 
https://github.com/rapid7/metasploit-framework/blob/b28d9517bc1572d4c75e862a4c5a308d8ba627c6/lib/msf/core/exploit.rb#L832
basically calls into that function to get all compatible payloads then that highlighted lines filters out based on cached_size and other miscellaneous things like privileged

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/windows/smb/ms17_010_eternalblue`
- [ ] `show payloads`
- [ ] Observe that payloads that are too large (e.g. non-staged meterpreters) are still not available for use due to the size restriction
