### PR TITLE
Increase operations per run

### DIFF
--- a/.github/workflows/schedule-stale.yml
+++ b/.github/workflows/schedule-stale.yml
@@ -14,7 +14,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-stale: 30
           days-before-close: 30
-          operations-per-run: 10
+          operations-per-run: 25
           stale-issue-message: |
             Hi!
 


### PR DESCRIPTION
Bumps the operations per run of the stale bot from 10 to 25, it's currently only looking at the same issues over and over and we need it to get further down the list