### PR TITLE
Add warning for screen effect to tccbypass

### DIFF
--- a/modules/post/osx/escalate/tccbypass.rb
+++ b/modules/post/osx/escalate/tccbypass.rb
@@ -31,6 +31,10 @@ class MetasploitModule < Msf::Post
           ['URL', 'https://medium.com/@mattshockl/cve-2020-9934-bypassing-the-os-x-transparency-consent-and-control-tcc-framework-for-4e14806f1de8'],
           ['URL', 'https://github.com/mattshockl/CVE-2020-9934'],
         ],
+        'Notes' =>
+          {
+            'SideEffects' => [ ARTIFACTS_ON_DISK, SCREEN_EFFECTS ]
+          },
         'Platform' => [ 'osx' ],
         'SessionTypes' => [ 'shell', 'meterpreter' ]
       )


### PR DESCRIPTION
Just after I landed https://github.com/rapid7/metasploit-framework/pull/13942, I looked over at my test machine to see a popup happened warning
```
A keychain cannot be found to store "com.apple.scopedbookmarksagent.xpc"
```
My guess is that this is related to the escalate module.  As such, I've added 'screen_effects' to the SideEffects entry.  (Also Artifacts on disk, because that's likely inevitable, too)

@timwr I trust this assumption is right?

## Verification

Follow the steps for testing https://github.com/rapid7/metasploit-framework/pull/13942, and verify (1) that the module still works and (2) you get the warning message a few minutes after using it.