### PR TITLE
Adding impacket dependency to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ ENV METASPLOIT_GROUP=metasploit
 # used for the copy command
 RUN addgroup -S $METASPLOIT_GROUP
 
-RUN apk add --no-cache bash sqlite-libs nmap nmap-scripts nmap-nselibs postgresql-libs python python3 ncurses libcap su-exec
+RUN apk add --no-cache bash sqlite-libs nmap nmap-scripts nmap-nselibs postgresql-libs python python3 ncurses libcap su-exec alpine-sdk python2-dev openssl-dev py-pip
 
 RUN /usr/sbin/setcap cap_net_raw,cap_net_bind_service=+eip $(which ruby)
 RUN /usr/sbin/setcap cap_net_raw,cap_net_bind_service=+eip $(which nmap)
@@ -57,6 +57,7 @@ COPY . $APP_HOME/
 RUN chown -R root:metasploit $APP_HOME/
 RUN chmod 664 $APP_HOME/Gemfile.lock
 RUN cp -f $APP_HOME/docker/database.yml $APP_HOME/config/database.yml
+RUN pip install impacket
 
 WORKDIR $APP_HOME
 


### PR DESCRIPTION
This PR adds the impacket dependency to the Dockerfile and addresses issue https://github.com/rapid7/metasploit-framework/issues/13366

## Verification

List the steps needed to make sure this thing works

- [x] `docker build --no-cache`
- [x] Verify that the build succeeds
- [x] `docker run -it <resulting image id from docker build>`
- [x] msf should run suceessfully
- [ ] 
```
use scanner/smb/impacket/wmiexec
set SMBUser example
set SMBPass example
set RHOSTS x.x.x.x
set COMMAND whoami
exploit
```
- [x] Verify that you receive successful output (e.g. `domain/username`) and that you do NOT see `Module dependencies (impacket) missing, cannot continue`


