### PR TITLE
Update to payload caching

### DIFF
--- a/modules/payloads/singles/bsd/x64/exec.rb
+++ b/modules/payloads/singles/bsd/x64/exec.rb
@@ -13,7 +13,7 @@
 ###
 module MetasploitModule
 
-  CachedSize = 31
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Payload::Bsd

--- a/modules/payloads/singles/bsd/x64/shell_bind_tcp.rb
+++ b/modules/payloads/singles/bsd/x64/shell_bind_tcp.rb
@@ -7,7 +7,7 @@ require 'msf/core/handler/bind_tcp'
 
 module MetasploitModule
 
-  CachedSize = 136
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Payload::Bsd

--- a/modules/payloads/singles/bsd/x64/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/bsd/x64/shell_reverse_tcp.rb
@@ -7,7 +7,7 @@ require 'msf/core/handler/reverse_tcp'
 
 module MetasploitModule
 
-  CachedSize = 98
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Payload::Bsd

--- a/modules/payloads/singles/bsd/x86/exec.rb
+++ b/modules/payloads/singles/bsd/x86/exec.rb
@@ -13,7 +13,7 @@
 ###
 module MetasploitModule
 
-  CachedSize = 24
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Payload::Bsd

--- a/modules/payloads/singles/cmd/unix/bind_awk.rb
+++ b/modules/payloads/singles/cmd/unix/bind_awk.rb
@@ -9,7 +9,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 136
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/cmd/unix/bind_busybox_telnetd.rb
+++ b/modules/payloads/singles/cmd/unix/bind_busybox_telnetd.rb
@@ -9,7 +9,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 26
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/cmd/unix/bind_inetd.rb
+++ b/modules/payloads/singles/cmd/unix/bind_inetd.rb
@@ -9,7 +9,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 487
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/cmd/unix/bind_lua.rb
+++ b/modules/payloads/singles/cmd/unix/bind_lua.rb
@@ -9,7 +9,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 218
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/cmd/unix/bind_netcat_gaping.rb
+++ b/modules/payloads/singles/cmd/unix/bind_netcat_gaping.rb
@@ -9,7 +9,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 24
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/cmd/unix/bind_netcat_gaping_ipv6.rb
+++ b/modules/payloads/singles/cmd/unix/bind_netcat_gaping_ipv6.rb
@@ -9,7 +9,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 25
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/cmd/unix/bind_nodejs.rb
+++ b/modules/payloads/singles/cmd/unix/bind_nodejs.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 2239
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Payload::NodeJS

--- a/modules/payloads/singles/cmd/unix/bind_perl.rb
+++ b/modules/payloads/singles/cmd/unix/bind_perl.rb
@@ -9,7 +9,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 240
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/cmd/unix/bind_perl_ipv6.rb
+++ b/modules/payloads/singles/cmd/unix/bind_perl_ipv6.rb
@@ -9,7 +9,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 152
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/cmd/unix/bind_r.rb
+++ b/modules/payloads/singles/cmd/unix/bind_r.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 132
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Payload::R

--- a/modules/payloads/singles/cmd/unix/bind_ruby.rb
+++ b/modules/payloads/singles/cmd/unix/bind_ruby.rb
@@ -9,7 +9,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 137
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/cmd/unix/bind_ruby_ipv6.rb
+++ b/modules/payloads/singles/cmd/unix/bind_ruby_ipv6.rb
@@ -9,7 +9,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 142
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/cmd/unix/bind_socat_udp.rb
+++ b/modules/payloads/singles/cmd/unix/bind_socat_udp.rb
@@ -9,7 +9,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 70
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/cmd/unix/bind_zsh.rb
+++ b/modules/payloads/singles/cmd/unix/bind_zsh.rb
@@ -9,7 +9,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 99
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/cmd/unix/pingback_bind.rb
+++ b/modules/payloads/singles/cmd/unix/pingback_bind.rb
@@ -9,7 +9,7 @@ require 'msf/base/sessions/pingback'
 
 module MetasploitModule
 
-  CachedSize = 103
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Payload::Pingback

--- a/modules/payloads/singles/cmd/unix/pingback_reverse.rb
+++ b/modules/payloads/singles/cmd/unix/pingback_reverse.rb
@@ -9,7 +9,7 @@ require 'msf/base/sessions/pingback'
 
 module MetasploitModule
 
-  CachedSize = 99
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Payload::Pingback

--- a/modules/payloads/singles/cmd/unix/reverse.rb
+++ b/modules/payloads/singles/cmd/unix/reverse.rb
@@ -9,7 +9,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 130
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/cmd/unix/reverse_awk.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_awk.rb
@@ -9,7 +9,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 150
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/cmd/unix/reverse_jjs.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_jjs.rb
@@ -9,7 +9,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 863
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/cmd/unix/reverse_ksh.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_ksh.rb
@@ -9,7 +9,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 52
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/cmd/unix/reverse_lua.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_lua.rb
@@ -9,7 +9,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 224
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/cmd/unix/reverse_ncat_ssl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_ncat_ssl.rb
@@ -9,7 +9,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 42
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/cmd/unix/reverse_netcat_gaping.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_netcat_gaping.rb
@@ -9,7 +9,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 34
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/cmd/unix/reverse_nodejs.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_nodejs.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 3231
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Payload::NodeJS

--- a/modules/payloads/singles/cmd/unix/reverse_openssl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_openssl.rb
@@ -9,7 +9,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 182
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/cmd/unix/reverse_perl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_perl.rb
@@ -9,7 +9,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 234
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/cmd/unix/reverse_perl_ssl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_perl_ssl.rb
@@ -9,7 +9,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 173
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/cmd/unix/reverse_php_ssl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_php_ssl.rb
@@ -9,7 +9,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 279
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/cmd/unix/reverse_python_ssl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_python_ssl.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 629
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Payload::Python

--- a/modules/payloads/singles/cmd/unix/reverse_r.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_r.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 157
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Payload::R

--- a/modules/payloads/singles/cmd/unix/reverse_ruby.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_ruby.rb
@@ -9,7 +9,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 133
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/cmd/unix/reverse_ruby_ssl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_ruby_ssl.rb
@@ -9,7 +9,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 185
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/cmd/unix/reverse_socat_udp.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_socat_udp.rb
@@ -9,7 +9,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 87
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/cmd/unix/reverse_ssl_double_telnet.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_ssl_double_telnet.rb
@@ -9,7 +9,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 136
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/cmd/unix/reverse_tclsh.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_tclsh.rb
@@ -9,7 +9,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 184
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/cmd/unix/reverse_zsh.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_zsh.rb
@@ -9,7 +9,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 94
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/cmd/windows/bind_lua.rb
+++ b/modules/payloads/singles/cmd/windows/bind_lua.rb
@@ -9,7 +9,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 218
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/cmd/windows/bind_perl.rb
+++ b/modules/payloads/singles/cmd/windows/bind_perl.rb
@@ -9,7 +9,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 139
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/cmd/windows/bind_perl_ipv6.rb
+++ b/modules/payloads/singles/cmd/windows/bind_perl_ipv6.rb
@@ -9,7 +9,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 140
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/cmd/windows/bind_ruby.rb
+++ b/modules/payloads/singles/cmd/windows/bind_ruby.rb
@@ -9,7 +9,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 128
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/cmd/windows/reverse_lua.rb
+++ b/modules/payloads/singles/cmd/windows/reverse_lua.rb
@@ -9,7 +9,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 224
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/cmd/windows/reverse_perl.rb
+++ b/modules/payloads/singles/cmd/windows/reverse_perl.rb
@@ -9,7 +9,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 148
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/cmd/windows/reverse_powershell.rb
+++ b/modules/payloads/singles/cmd/windows/reverse_powershell.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 1588
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/cmd/windows/reverse_ruby.rb
+++ b/modules/payloads/singles/cmd/windows/reverse_ruby.rb
@@ -9,7 +9,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 126
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/firefox/exec.rb
+++ b/modules/payloads/singles/firefox/exec.rb
@@ -5,7 +5,7 @@
 
 module MetasploitModule
 
-  CachedSize = 1019
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Payload::Firefox

--- a/modules/payloads/singles/java/jsp_shell_bind_tcp.rb
+++ b/modules/payloads/singles/java/jsp_shell_bind_tcp.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 1593
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Payload::JSP

--- a/modules/payloads/singles/java/jsp_shell_reverse_tcp.rb
+++ b/modules/payloads/singles/java/jsp_shell_reverse_tcp.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 1501
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Payload::JSP

--- a/modules/payloads/singles/linux/armbe/shell_bind_tcp.rb
+++ b/modules/payloads/singles/linux/armbe/shell_bind_tcp.rb
@@ -9,7 +9,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 118
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Payload::Linux

--- a/modules/payloads/singles/linux/armle/exec.rb
+++ b/modules/payloads/singles/linux/armle/exec.rb
@@ -13,7 +13,7 @@
 ###
 module MetasploitModule
 
-  CachedSize = 29
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Payload::Linux

--- a/modules/payloads/singles/linux/mipsbe/exec.rb
+++ b/modules/payloads/singles/linux/mipsbe/exec.rb
@@ -5,7 +5,7 @@
 
 module MetasploitModule
 
-  CachedSize = 52
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Payload::Linux

--- a/modules/payloads/singles/linux/mipsle/exec.rb
+++ b/modules/payloads/singles/linux/mipsle/exec.rb
@@ -5,7 +5,7 @@
 
 module MetasploitModule
 
-  CachedSize = 52
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Payload::Linux

--- a/modules/payloads/singles/linux/x64/exec.rb
+++ b/modules/payloads/singles/linux/x64/exec.rb
@@ -5,7 +5,7 @@
 
 module MetasploitModule
 
-  CachedSize = 47
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Payload::Linux

--- a/modules/payloads/singles/linux/x86/exec.rb
+++ b/modules/payloads/singles/linux/x86/exec.rb
@@ -13,7 +13,7 @@
 ###
 module MetasploitModule
 
-  CachedSize = 43
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Payload::Linux

--- a/modules/payloads/singles/linux/x86/read_file.rb
+++ b/modules/payloads/singles/linux/x86/read_file.rb
@@ -5,7 +5,7 @@
 
 module MetasploitModule
 
-  CachedSize = 63
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Payload::Linux

--- a/modules/payloads/singles/linux/x86/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/x86/shell_reverse_tcp.rb
@@ -9,7 +9,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 68
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Payload::Linux

--- a/modules/payloads/singles/nodejs/shell_bind_tcp.rb
+++ b/modules/payloads/singles/nodejs/shell_bind_tcp.rb
@@ -13,7 +13,7 @@ require 'msf/base/sessions/command_shell'
 
 module MetasploitModule
 
-  CachedSize = 555
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Payload::NodeJS

--- a/modules/payloads/singles/nodejs/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/nodejs/shell_reverse_tcp.rb
@@ -13,7 +13,7 @@ require 'msf/base/sessions/command_shell'
 
 module MetasploitModule
 
-  CachedSize = 803
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Payload::NodeJS

--- a/modules/payloads/singles/nodejs/shell_reverse_tcp_ssl.rb
+++ b/modules/payloads/singles/nodejs/shell_reverse_tcp_ssl.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 831
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Payload::NodeJS

--- a/modules/payloads/singles/osx/x64/exec.rb
+++ b/modules/payloads/singles/osx/x64/exec.rb
@@ -5,7 +5,7 @@
 
 module MetasploitModule
 
-  CachedSize = 31
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
 

--- a/modules/payloads/singles/osx/x64/shell_bind_tcp.rb
+++ b/modules/payloads/singles/osx/x64/shell_bind_tcp.rb
@@ -7,7 +7,7 @@ require 'msf/core/handler/bind_tcp'
 
 module MetasploitModule
 
-  CachedSize = 136
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Payload::Osx

--- a/modules/payloads/singles/osx/x64/shell_find_tag.rb
+++ b/modules/payloads/singles/osx/x64/shell_find_tag.rb
@@ -9,7 +9,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 107
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Payload::Osx

--- a/modules/payloads/singles/osx/x64/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/osx/x64/shell_reverse_tcp.rb
@@ -7,7 +7,7 @@ require 'msf/core/handler/reverse_tcp'
 
 module MetasploitModule
 
-  CachedSize = 108
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Payload::Osx

--- a/modules/payloads/singles/osx/x86/exec.rb
+++ b/modules/payloads/singles/osx/x86/exec.rb
@@ -13,7 +13,7 @@
 ###
 module MetasploitModule
 
-  CachedSize = 24
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Payload::Bsd::X86

--- a/modules/payloads/singles/php/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/php/meterpreter_reverse_tcp.rb
@@ -11,7 +11,7 @@ require 'msf/base/sessions/meterpreter_options'
 
 module MetasploitModule
 
-  CachedSize = 34264
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Payload::Php::ReverseTcp

--- a/modules/payloads/singles/python/meterpreter_bind_tcp.rb
+++ b/modules/payloads/singles/python/meterpreter_bind_tcp.rb
@@ -11,7 +11,7 @@ require 'msf/base/sessions/meterpreter_python'
 
 module MetasploitModule
 
-  CachedSize = 112793
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Payload::Python

--- a/modules/payloads/singles/python/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/python/meterpreter_reverse_http.rb
@@ -11,7 +11,7 @@ require 'msf/base/sessions/meterpreter_python'
 
 module MetasploitModule
 
-  CachedSize = 112761
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Payload::Python

--- a/modules/payloads/singles/python/pingback_bind_tcp.rb
+++ b/modules/payloads/singles/python/pingback_bind_tcp.rb
@@ -6,7 +6,7 @@ require 'msf/core/payload/pingback'
 
 module MetasploitModule
 
-  CachedSize = 262
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Payload::Pingback

--- a/modules/payloads/singles/python/pingback_reverse_tcp.rb
+++ b/modules/payloads/singles/python/pingback_reverse_tcp.rb
@@ -6,7 +6,7 @@ require 'msf/core/payload/pingback'
 
 module MetasploitModule
 
-  CachedSize = 193
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Payload::Pingback

--- a/modules/payloads/singles/python/shell_bind_tcp.rb
+++ b/modules/payloads/singles/python/shell_bind_tcp.rb
@@ -5,7 +5,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 381
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/python/shell_reverse_tcp_ssl.rb
+++ b/modules/payloads/singles/python/shell_reverse_tcp_ssl.rb
@@ -9,7 +9,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 561
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/python/shell_reverse_udp.rb
+++ b/modules/payloads/singles/python/shell_reverse_udp.rb
@@ -9,7 +9,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 397
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/r/shell_bind_tcp.rb
+++ b/modules/payloads/singles/r/shell_bind_tcp.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 125
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Payload::R

--- a/modules/payloads/singles/r/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/r/shell_reverse_tcp.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 150
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Payload::R

--- a/modules/payloads/singles/ruby/pingback_bind_tcp.rb
+++ b/modules/payloads/singles/ruby/pingback_bind_tcp.rb
@@ -6,7 +6,7 @@ require 'msf/core/payload/pingback'
 
 module MetasploitModule
 
-  CachedSize = 103
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Payload::Ruby

--- a/modules/payloads/singles/ruby/pingback_reverse_tcp.rb
+++ b/modules/payloads/singles/ruby/pingback_reverse_tcp.rb
@@ -6,7 +6,7 @@ require 'msf/core/payload/pingback'
 
 module MetasploitModule
 
-  CachedSize = 100
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Payload::Ruby

--- a/modules/payloads/singles/ruby/shell_bind_tcp.rb
+++ b/modules/payloads/singles/ruby/shell_bind_tcp.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 516
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Payload::Ruby

--- a/modules/payloads/singles/ruby/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/ruby/shell_reverse_tcp.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 516
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Msf::Payload::Ruby

--- a/modules/payloads/singles/windows/dns_txt_query_exec.rb
+++ b/modules/payloads/singles/windows/dns_txt_query_exec.rb
@@ -5,7 +5,7 @@
 
 module MetasploitModule
 
-  CachedSize = 285
+  CachedSize = :dynamic
 
   include Msf::Payload::Windows
   include Msf::Payload::Single

--- a/modules/payloads/singles/windows/download_exec.rb
+++ b/modules/payloads/singles/windows/download_exec.rb
@@ -5,7 +5,7 @@
 
 module MetasploitModule
 
-  CachedSize = 423
+  CachedSize = :dynamic
 
   include Msf::Payload::Windows
   include Msf::Payload::Single

--- a/modules/payloads/singles/windows/exec.rb
+++ b/modules/payloads/singles/windows/exec.rb
@@ -12,7 +12,7 @@ require 'msf/core/payload/windows/exec'
 ###
 module MetasploitModule
 
-  CachedSize = 192
+  CachedSize = :dynamic
 
   include Msf::Payload::Windows::Exec
 

--- a/modules/payloads/singles/windows/loadlibrary.rb
+++ b/modules/payloads/singles/windows/loadlibrary.rb
@@ -12,7 +12,7 @@ require 'msf/core/payload/windows/loadlibrary'
 ###
 module MetasploitModule
 
-  CachedSize = 230
+  CachedSize = 202
 
   include Msf::Payload::Windows::LoadLibrary
 

--- a/modules/payloads/singles/windows/x64/exec.rb
+++ b/modules/payloads/singles/windows/x64/exec.rb
@@ -5,7 +5,7 @@
 
 module MetasploitModule
 
-  CachedSize = 275
+  CachedSize = :dynamic
 
   include Msf::Payload::Windows
   include Msf::Payload::Single

--- a/modules/payloads/singles/windows/x64/loadlibrary.rb
+++ b/modules/payloads/singles/windows/x64/loadlibrary.rb
@@ -5,7 +5,7 @@
 
 module MetasploitModule
 
-  CachedSize = 313
+  CachedSize = 285
 
   include Msf::Payload::Windows
   include Msf::Payload::Single

--- a/modules/payloads/stagers/php/bind_tcp.rb
+++ b/modules/payloads/stagers/php/bind_tcp.rb
@@ -8,7 +8,7 @@ require 'msf/core/payload/php/bind_tcp'
 
 module MetasploitModule
 
-  CachedSize = 1338
+  CachedSize = :dynamic
 
   include Msf::Payload::Stager
   include Msf::Payload::Php::BindTcp

--- a/modules/payloads/stagers/php/bind_tcp_ipv6.rb
+++ b/modules/payloads/stagers/php/bind_tcp_ipv6.rb
@@ -8,7 +8,7 @@ require 'msf/core/payload/php/bind_tcp'
 
 module MetasploitModule
 
-  CachedSize = 1337
+  CachedSize = :dynamic
 
   include Msf::Payload::Stager
   include Msf::Payload::Php::BindTcp

--- a/modules/payloads/stagers/php/bind_tcp_ipv6_uuid.rb
+++ b/modules/payloads/stagers/php/bind_tcp_ipv6_uuid.rb
@@ -8,7 +8,7 @@ require 'msf/core/payload/php/bind_tcp'
 
 module MetasploitModule
 
-  CachedSize = 1511
+  CachedSize = :dynamic
 
   include Msf::Payload::Stager
   include Msf::Payload::Php::BindTcp

--- a/modules/payloads/stagers/php/bind_tcp_uuid.rb
+++ b/modules/payloads/stagers/php/bind_tcp_uuid.rb
@@ -8,7 +8,7 @@ require 'msf/core/payload/php/bind_tcp'
 
 module MetasploitModule
 
-  CachedSize = 1512
+  CachedSize = :dynamic
 
   include Msf::Payload::Stager
   include Msf::Payload::Php::BindTcp

--- a/modules/payloads/stagers/php/reverse_tcp.rb
+++ b/modules/payloads/stagers/php/reverse_tcp.rb
@@ -8,7 +8,7 @@ require 'msf/core/payload/php/reverse_tcp'
 
 module MetasploitModule
 
-  CachedSize = 1116
+  CachedSize = :dynamic
 
   include Msf::Payload::Stager
   include Msf::Payload::Php::ReverseTcp

--- a/modules/payloads/stagers/php/reverse_tcp_uuid.rb
+++ b/modules/payloads/stagers/php/reverse_tcp_uuid.rb
@@ -8,7 +8,7 @@ require 'msf/core/payload/php/reverse_tcp'
 
 module MetasploitModule
 
-  CachedSize = 1290
+  CachedSize = :dynamic
 
   include Msf::Payload::Stager
   include Msf::Payload::Php::ReverseTcp

--- a/modules/payloads/stagers/python/bind_tcp.rb
+++ b/modules/payloads/stagers/python/bind_tcp.rb
@@ -11,7 +11,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 429
+  CachedSize = :dynamic
 
   include Msf::Payload::Stager
   include Msf::Payload::Python

--- a/modules/payloads/stagers/python/reverse_http.rb
+++ b/modules/payloads/stagers/python/reverse_http.rb
@@ -9,7 +9,7 @@ require 'msf/core/payload/python/reverse_http'
 
 module MetasploitModule
 
-  CachedSize = 569
+  CachedSize = :dynamic
 
   include Msf::Payload::Stager
   include Msf::Payload::Python

--- a/modules/payloads/stagers/python/reverse_tcp_uuid.rb
+++ b/modules/payloads/stagers/python/reverse_tcp_uuid.rb
@@ -10,7 +10,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 601
+  CachedSize = :dynamic
 
   include Msf::Payload::Stager
   include Msf::Payload::Python

--- a/modules/payloads/stagers/windows/reverse_winhttp.rb
+++ b/modules/payloads/stagers/windows/reverse_winhttp.rb
@@ -8,7 +8,7 @@ require 'msf/core/payload/windows/reverse_winhttp'
 
 module MetasploitModule
 
-  CachedSize = 533
+  CachedSize = :dynamic
 
   include Msf::Payload::Stager
   include Msf::Payload::Windows

--- a/modules/payloads/stagers/windows/reverse_winhttps.rb
+++ b/modules/payloads/stagers/windows/reverse_winhttps.rb
@@ -8,7 +8,7 @@ require 'msf/core/payload/windows/reverse_winhttps'
 
 module MetasploitModule
 
-  CachedSize = 555
+  CachedSize = :dynamic
 
   include Msf::Payload::Stager
   include Msf::Payload::Windows

--- a/modules/payloads/stagers/windows/x64/reverse_winhttp.rb
+++ b/modules/payloads/stagers/windows/x64/reverse_winhttp.rb
@@ -8,7 +8,7 @@ require 'msf/core/payload/windows/x64/reverse_winhttp'
 
 module MetasploitModule
 
-  CachedSize = 745
+  CachedSize = :dynamic
 
   include Msf::Payload::Stager
   include Msf::Payload::Windows

--- a/modules/payloads/stagers/windows/x64/reverse_winhttps.rb
+++ b/modules/payloads/stagers/windows/x64/reverse_winhttps.rb
@@ -8,7 +8,7 @@ require 'msf/core/payload/windows/x64/reverse_winhttps'
 
 module MetasploitModule
 
-  CachedSize = 781
+  CachedSize = :dynamic
 
   include Msf::Payload::Stager
   include Msf::Payload::Windows

--- a/spec/modules/payloads_spec.rb
+++ b/spec/modules/payloads_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/aix/ppc/shell_bind_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'aix/ppc/shell_bind_tcp'
   end
@@ -20,7 +19,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/aix/ppc/shell_find_port'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'aix/ppc/shell_find_port'
   end
@@ -30,7 +28,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/aix/ppc/shell_interact'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'aix/ppc/shell_interact'
   end
@@ -40,7 +37,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/aix/ppc/shell_reverse_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'aix/ppc/shell_reverse_tcp'
   end
@@ -50,7 +46,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/apple_ios/aarch64/meterpreter_reverse_http'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'apple_ios/aarch64/meterpreter_reverse_http'
   end
@@ -60,7 +55,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/apple_ios/aarch64/meterpreter_reverse_https'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'apple_ios/aarch64/meterpreter_reverse_https'
   end
@@ -70,7 +64,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/apple_ios/aarch64/meterpreter_reverse_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'apple_ios/aarch64/meterpreter_reverse_tcp'
   end
@@ -80,7 +73,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/apple_ios/aarch64/shell_reverse_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'apple_ios/aarch64/shell_reverse_tcp'
   end
@@ -90,7 +82,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/apple_ios/armle/meterpreter_reverse_http'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'apple_ios/armle/meterpreter_reverse_http'
   end
@@ -100,7 +91,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/apple_ios/armle/meterpreter_reverse_https'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'apple_ios/armle/meterpreter_reverse_https'
   end
@@ -110,7 +100,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/apple_ios/armle/meterpreter_reverse_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'apple_ios/armle/meterpreter_reverse_tcp'
   end
@@ -120,7 +109,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                             'singles/android/meterpreter_reverse_https'
                           ],
-                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'android/meterpreter_reverse_https'
   end
@@ -130,7 +118,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                             'singles/android/meterpreter_reverse_http'
                           ],
-                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'android/meterpreter_reverse_http'
   end
@@ -140,7 +127,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                             'singles/android/meterpreter_reverse_tcp'
                           ],
-                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'android/meterpreter_reverse_tcp'
   end
@@ -151,7 +137,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/android/reverse_http',
                               'stages/android/meterpreter'
                           ],
-                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'android/meterpreter/reverse_http'
   end
@@ -162,7 +147,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/android/reverse_https',
                               'stages/android/meterpreter'
                           ],
-                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'android/meterpreter/reverse_https'
   end
@@ -173,7 +157,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/android/reverse_tcp',
                               'stages/android/meterpreter'
                           ],
-                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'android/meterpreter/reverse_tcp'
   end
@@ -184,7 +167,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/android/reverse_http',
                               'stages/android/shell'
                           ],
-                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'android/shell/reverse_http'
   end
@@ -195,7 +177,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/android/reverse_https',
                               'stages/android/shell'
                           ],
-                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'android/shell/reverse_https'
   end
@@ -206,7 +187,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/android/reverse_tcp',
                               'stages/android/shell'
                           ],
-                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'android/shell/reverse_tcp'
   end
@@ -216,7 +196,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/bsd/sparc/shell_bind_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'bsd/sparc/shell_bind_tcp'
   end
@@ -226,7 +205,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/bsd/sparc/shell_reverse_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'bsd/sparc/shell_reverse_tcp'
   end
@@ -236,7 +214,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/bsd/vax/shell_reverse_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'bsd/vax/shell_reverse_tcp'
   end
@@ -246,7 +223,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/bsd/x64/exec'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'bsd/x64/exec'
   end
@@ -256,7 +232,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/bsd/x64/shell_bind_ipv6_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'bsd/x64/shell_bind_ipv6_tcp'
   end
@@ -266,7 +241,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/bsd/x64/shell_bind_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'bsd/x64/shell_bind_tcp'
   end
@@ -276,7 +250,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/bsd/x64/shell_bind_tcp_small'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'bsd/x64/shell_bind_tcp_small'
   end
@@ -286,7 +259,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/bsd/x64/shell_reverse_ipv6_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'bsd/x64/shell_reverse_ipv6_tcp'
   end
@@ -296,7 +268,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/bsd/x64/shell_reverse_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'bsd/x64/shell_reverse_tcp'
   end
@@ -306,7 +277,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/bsd/x64/shell_reverse_tcp_small'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'bsd/x64/shell_reverse_tcp_small'
   end
@@ -316,7 +286,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/bsd/x86/exec'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'bsd/x86/exec'
   end
@@ -326,7 +295,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/bsd/x86/metsvc_bind_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'bsd/x86/metsvc_bind_tcp'
   end
@@ -336,7 +304,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/bsd/x86/metsvc_reverse_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'bsd/x86/metsvc_reverse_tcp'
   end
@@ -347,7 +314,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/bsd/x86/bind_ipv6_tcp',
                               'stages/bsd/x86/shell'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'bsd/x86/shell/bind_ipv6_tcp'
   end
@@ -358,7 +324,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/bsd/x86/bind_tcp',
                               'stages/bsd/x86/shell'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'bsd/x86/shell/bind_tcp'
   end
@@ -369,7 +334,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/bsd/x86/find_tag',
                               'stages/bsd/x86/shell'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'bsd/x86/shell/find_tag'
   end
@@ -380,7 +344,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/bsd/x86/reverse_ipv6_tcp',
                               'stages/bsd/x86/shell'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'bsd/x86/shell/reverse_ipv6_tcp'
   end
@@ -391,7 +354,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/bsd/x86/reverse_tcp',
                               'stages/bsd/x86/shell'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'bsd/x86/shell/reverse_tcp'
   end
@@ -401,7 +363,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/bsd/x86/shell_bind_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'bsd/x86/shell_bind_tcp'
   end
@@ -411,7 +372,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/bsd/x86/shell_bind_tcp_ipv6'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'bsd/x86/shell_bind_tcp_ipv6'
   end
@@ -421,7 +381,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/bsd/x86/shell_find_port'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'bsd/x86/shell_find_port'
   end
@@ -431,7 +390,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/bsd/x86/shell_find_tag'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'bsd/x86/shell_find_tag'
   end
@@ -441,7 +399,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/bsd/x86/shell_reverse_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'bsd/x86/shell_reverse_tcp'
   end
@@ -451,7 +408,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/bsd/x86/shell_reverse_tcp_ipv6'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'bsd/x86/shell_reverse_tcp_ipv6'
   end
@@ -462,7 +418,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/bsdi/x86/bind_tcp',
                               'stages/bsdi/x86/shell'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'bsdi/x86/shell/bind_tcp'
   end
@@ -473,7 +428,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/bsdi/x86/reverse_tcp',
                               'stages/bsdi/x86/shell'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'bsdi/x86/shell/reverse_tcp'
   end
@@ -483,7 +437,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/bsdi/x86/shell_bind_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'bsdi/x86/shell_bind_tcp'
   end
@@ -493,7 +446,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/bsdi/x86/shell_find_port'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'bsdi/x86/shell_find_port'
   end
@@ -503,7 +455,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/bsdi/x86/shell_reverse_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'bsdi/x86/shell_reverse_tcp'
   end
@@ -513,7 +464,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/cmd/mainframe/generic_jcl'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/mainframe/generic_jcl'
   end
@@ -523,7 +473,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/cmd/mainframe/bind_shell_jcl'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/mainframe/bind_shell_jcl'
   end
@@ -533,7 +482,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/cmd/mainframe/reverse_shell_jcl'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/mainframe/reverse_shell_jcl'
   end
@@ -543,7 +491,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/cmd/mainframe/apf_privesc_jcl'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/mainframe/apf_privesc_jcl'
   end
@@ -553,7 +500,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/cmd/unix/bind_awk'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/bind_awk'
   end
@@ -563,7 +509,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/cmd/unix/bind_busybox_telnetd'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/bind_busybox_telnetd'
   end
@@ -573,7 +518,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/cmd/unix/bind_inetd'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/bind_inetd'
   end
@@ -583,7 +527,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/cmd/unix/bind_lua'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/bind_lua'
   end
@@ -593,7 +536,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/cmd/unix/bind_jjs'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/bind_jjs'
   end
@@ -603,7 +545,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/cmd/unix/bind_netcat'
                           ],
-                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/bind_netcat'
   end
@@ -613,7 +554,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/cmd/unix/bind_netcat_gaping'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/bind_netcat_gaping'
   end
@@ -623,7 +563,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/cmd/unix/bind_netcat_gaping_ipv6'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/bind_netcat_gaping_ipv6'
   end
@@ -633,7 +572,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/cmd/unix/bind_nodejs'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/bind_nodejs'
   end
@@ -643,7 +581,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/cmd/unix/bind_socat_udp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/bind_socat_udp'
   end
@@ -653,7 +590,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/cmd/unix/bind_perl'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/bind_perl'
   end
@@ -663,7 +599,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/cmd/unix/bind_perl_ipv6'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/bind_perl_ipv6'
   end
@@ -673,7 +608,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                             'singles/cmd/unix/bind_r'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/bind_r'
   end
@@ -683,7 +617,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/cmd/unix/bind_ruby'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/bind_ruby'
   end
@@ -693,7 +626,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/cmd/unix/bind_ruby_ipv6'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/bind_ruby_ipv6'
   end
@@ -703,7 +635,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/cmd/unix/bind_stub'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/bind_stub'
   end
@@ -713,7 +644,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/cmd/unix/bind_zsh'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/bind_zsh'
   end
@@ -723,7 +653,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/cmd/unix/generic'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/generic'
   end
@@ -733,7 +662,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/cmd/unix/interact'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/interact'
   end
@@ -743,7 +671,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/cmd/unix/pingback_bind'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/pingback_bind'
   end
@@ -753,7 +680,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/cmd/unix/pingback_reverse'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/pingback_reverse'
   end
@@ -763,7 +689,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/cmd/unix/reverse'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/reverse'
   end
@@ -773,7 +698,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/cmd/unix/reverse_awk'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/reverse_awk'
   end
@@ -783,7 +707,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/cmd/unix/reverse_bash'
                           ],
-                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/reverse_bash'
   end
@@ -793,7 +716,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                             'singles/cmd/unix/reverse_bash_udp'
                           ],
-                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/reverse_bash_udp'
   end
@@ -803,7 +725,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/cmd/unix/reverse_bash_telnet_ssl'
                           ],
-                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/reverse_bash_telnet_ssl'
   end
@@ -813,7 +734,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/cmd/unix/reverse_ksh'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/reverse_ksh'
   end
@@ -823,7 +743,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/cmd/unix/reverse_jjs'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/reverse_jjs'
   end
@@ -833,7 +752,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/cmd/unix/reverse_lua'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/reverse_lua'
   end
@@ -843,7 +761,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                             'singles/cmd/unix/reverse_ncat_ssl'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/reverse_ncat_ssl'
   end
@@ -853,7 +770,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/cmd/unix/reverse_netcat'
                           ],
-                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/reverse_netcat'
   end
@@ -863,7 +779,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/cmd/unix/reverse_netcat_gaping'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/reverse_netcat_gaping'
   end
@@ -873,7 +788,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/cmd/unix/reverse_nodejs'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/reverse_nodejs'
   end
@@ -883,7 +797,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/cmd/unix/reverse_openssl'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/reverse_openssl'
   end
@@ -893,7 +806,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/cmd/unix/reverse_socat_udp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/reverse_socat_udp'
   end
@@ -903,7 +815,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/cmd/unix/reverse_ssh'
                           ],
-                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/reverse_ssh'
   end
@@ -913,7 +824,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/cmd/unix/reverse_perl'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/reverse_perl'
   end
@@ -923,7 +833,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/cmd/unix/reverse_perl_ssl'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/reverse_perl_ssl'
   end
@@ -933,7 +842,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/cmd/unix/reverse_php_ssl'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/reverse_php_ssl'
   end
@@ -943,7 +851,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/cmd/unix/reverse_python'
                           ],
-                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/reverse_python'
   end
@@ -953,7 +860,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/cmd/unix/reverse_python_ssl'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/reverse_python_ssl'
   end
@@ -963,7 +869,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                             'singles/cmd/unix/reverse_r'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/reverse_r'
   end
@@ -973,7 +878,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/cmd/unix/reverse_ruby'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/reverse_ruby'
   end
@@ -983,7 +887,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/cmd/unix/reverse_ruby_ssl'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/reverse_ruby_ssl'
   end
@@ -993,7 +896,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/cmd/unix/reverse_ssl_double_telnet'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/reverse_ssl_double_telnet'
   end
@@ -1003,7 +905,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/cmd/unix/reverse_stub'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/reverse_stub'
   end
@@ -1013,7 +914,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/cmd/unix/reverse_tclsh'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/reverse_tclsh'
   end
@@ -1023,7 +923,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/cmd/unix/reverse_zsh'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/unix/reverse_zsh'
   end
@@ -1033,7 +932,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/cmd/windows/adduser'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/windows/adduser'
   end
@@ -1043,7 +941,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/cmd/windows/bind_lua'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/windows/bind_lua'
   end
@@ -1053,7 +950,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/cmd/windows/bind_perl'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/windows/bind_perl'
   end
@@ -1063,7 +959,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/cmd/windows/bind_perl_ipv6'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/windows/bind_perl_ipv6'
   end
@@ -1073,7 +968,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/cmd/windows/bind_ruby'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/windows/bind_ruby'
   end
@@ -1083,7 +977,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/cmd/windows/download_eval_vbs'
                           ],
-                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/windows/download_eval_vbs'
   end
@@ -1093,7 +986,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/cmd/windows/download_exec_vbs'
                           ],
-                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/windows/download_exec_vbs'
   end
@@ -1103,7 +995,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/cmd/windows/generic'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/windows/generic'
   end
@@ -1113,7 +1004,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/cmd/windows/powershell_bind_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/windows/powershell_bind_tcp'
   end
@@ -1123,7 +1013,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/cmd/windows/powershell_reverse_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/windows/powershell_reverse_tcp'
   end
@@ -1133,7 +1022,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/cmd/windows/reverse_lua'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/windows/reverse_lua'
   end
@@ -1143,7 +1031,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/cmd/windows/reverse_perl'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/windows/reverse_perl'
   end
@@ -1153,7 +1040,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/cmd/windows/reverse_powershell'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/windows/reverse_powershell'
   end
@@ -1163,7 +1049,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/cmd/windows/reverse_ruby'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/windows/reverse_ruby'
   end
@@ -1173,7 +1058,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/firefox/exec'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'firefox/exec'
   end
@@ -1183,7 +1067,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/firefox/shell_bind_tcp'
                           ],
-                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'firefox/shell_bind_tcp'
   end
@@ -1193,7 +1076,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/firefox/shell_reverse_tcp'
                           ],
-                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'firefox/shell_reverse_tcp'
   end
@@ -1203,7 +1085,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/generic/custom'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'generic/custom'
   end
@@ -1213,7 +1094,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/generic/debug_trap'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'generic/debug_trap'
   end
@@ -1223,7 +1103,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/generic/shell_bind_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'generic/shell_bind_tcp'
   end
@@ -1233,7 +1112,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/generic/shell_reverse_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'generic/shell_reverse_tcp'
   end
@@ -1243,7 +1121,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/generic/tight_loop'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'generic/tight_loop'
   end
@@ -1253,7 +1130,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/java/jsp_shell_bind_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'java/jsp_shell_bind_tcp'
   end
@@ -1263,7 +1139,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/java/jsp_shell_reverse_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'java/jsp_shell_reverse_tcp'
   end
@@ -1274,7 +1149,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/java/bind_tcp',
                               'stages/java/meterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'java/meterpreter/bind_tcp'
   end
@@ -1285,7 +1159,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/java/reverse_http',
                               'stages/java/meterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'java/meterpreter/reverse_http'
   end
@@ -1296,7 +1169,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/java/reverse_https',
                               'stages/java/meterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'java/meterpreter/reverse_https'
   end
@@ -1307,7 +1179,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/java/reverse_tcp',
                               'stages/java/meterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'java/meterpreter/reverse_tcp'
   end
@@ -1318,7 +1189,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/java/bind_tcp',
                               'stages/java/shell'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'java/shell/bind_tcp'
   end
@@ -1329,7 +1199,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/java/reverse_tcp',
                               'stages/java/shell'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'java/shell/reverse_tcp'
   end
@@ -1339,7 +1208,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/java/shell_reverse_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'java/shell_reverse_tcp'
   end
@@ -1349,7 +1217,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                             'singles/linux/aarch64/shell_reverse_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/aarch64/shell_reverse_tcp'
   end
@@ -1359,7 +1226,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                             'singles/linux/aarch64/meterpreter_reverse_http'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/aarch64/meterpreter_reverse_http'
   end
@@ -1369,7 +1235,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                             'singles/linux/aarch64/meterpreter_reverse_https'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/aarch64/meterpreter_reverse_https'
   end
@@ -1380,7 +1245,6 @@ RSpec.describe 'modules/payloads', :content do
                             'stagers/linux/aarch64/reverse_tcp',
                             'stages/linux/aarch64/shell'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/aarch64/shell/reverse_tcp'
   end
@@ -1391,7 +1255,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/linux/armbe/shell_bind_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/armbe/shell_bind_tcp'
   end
@@ -1401,7 +1264,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/linux/armle/adduser'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/armle/adduser'
   end
@@ -1411,7 +1273,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/linux/armle/exec'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/armle/exec'
   end
@@ -1422,7 +1283,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/linux/armle/bind_tcp',
                               'stages/linux/armle/shell'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/armle/shell/bind_tcp'
   end
@@ -1433,7 +1293,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/linux/armle/reverse_tcp',
                               'stages/linux/armle/shell'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/armle/shell/reverse_tcp'
   end
@@ -1443,7 +1302,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/linux/armle/shell_bind_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/armle/shell_bind_tcp'
   end
@@ -1453,7 +1311,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/linux/armle/shell_reverse_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/armle/shell_reverse_tcp'
   end
@@ -1463,7 +1320,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/linux/mipsbe/exec'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/mipsbe/exec'
   end
@@ -1473,7 +1329,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/linux/mipsbe/reboot'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/mipsbe/reboot'
   end
@@ -1484,7 +1339,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/linux/mipsbe/reverse_tcp',
                               'stages/linux/mipsbe/shell'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/mipsbe/shell/reverse_tcp'
   end
@@ -1494,7 +1348,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/linux/mipsbe/shell_bind_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/mipsbe/shell_bind_tcp'
   end
@@ -1504,7 +1357,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/linux/mipsbe/shell_reverse_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/mipsbe/shell_reverse_tcp'
   end
@@ -1514,7 +1366,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/linux/mipsle/exec'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/mipsle/exec'
   end
@@ -1524,7 +1375,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/linux/mipsle/reboot'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/mipsle/reboot'
   end
@@ -1535,7 +1385,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/linux/mipsle/reverse_tcp',
                               'stages/linux/mipsle/shell'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/mipsle/shell/reverse_tcp'
   end
@@ -1545,7 +1394,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/linux/mipsle/shell_bind_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/mipsle/shell_bind_tcp'
   end
@@ -1555,7 +1403,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/linux/mipsle/shell_reverse_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/mipsle/shell_reverse_tcp'
   end
@@ -1565,7 +1412,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/linux/ppc/shell_bind_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/ppc/shell_bind_tcp'
   end
@@ -1575,7 +1421,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/linux/ppc/shell_find_port'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/ppc/shell_find_port'
   end
@@ -1585,7 +1430,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/linux/ppc/shell_reverse_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/ppc/shell_reverse_tcp'
   end
@@ -1595,7 +1439,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/linux/ppc64/shell_bind_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/ppc64/shell_bind_tcp'
   end
@@ -1605,7 +1448,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/linux/ppc64/shell_find_port'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/ppc64/shell_find_port'
   end
@@ -1615,7 +1457,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/linux/ppc64/shell_reverse_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/ppc64/shell_reverse_tcp'
   end
@@ -1625,7 +1466,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/linux/x64/exec'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x64/exec'
   end
@@ -1635,7 +1475,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/linux/x64/pingback_bind_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x64/pingback_bind_tcp'
   end
@@ -1645,7 +1484,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/linux/x64/pingback_reverse_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x64/pingback_reverse_tcp'
   end
@@ -1656,7 +1494,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/linux/x64/bind_tcp',
                               'stages/linux/x64/shell'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x64/shell/bind_tcp'
   end
@@ -1667,7 +1504,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/linux/x64/reverse_tcp',
                               'stages/linux/x64/shell'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x64/shell/reverse_tcp'
   end
@@ -1677,7 +1513,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/linux/x64/shell_bind_ipv6_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x64/shell_bind_ipv6_tcp'
   end
@@ -1687,7 +1522,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/linux/x64/shell_bind_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x64/shell_bind_tcp'
   end
@@ -1697,7 +1531,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/linux/x64/shell_bind_tcp_random_port'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x64/shell_bind_tcp_random_port'
   end
@@ -1707,7 +1540,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/linux/x64/shell_find_port'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x64/shell_find_port'
   end
@@ -1717,7 +1549,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/linux/x64/shell_reverse_ipv6_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x64/shell_reverse_ipv6_tcp'
   end
@@ -1727,7 +1558,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/linux/x64/shell_reverse_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x64/shell_reverse_tcp'
   end
@@ -1737,7 +1567,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/linux/x86/adduser'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x86/adduser'
   end
@@ -1747,7 +1576,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/linux/x86/chmod'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x86/chmod'
   end
@@ -1757,7 +1585,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/linux/x86/exec'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x86/exec'
   end
@@ -1767,7 +1594,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/linux/x86/read_file'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x86/read_file'
   end
@@ -1778,7 +1604,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/linux/x86/bind_ipv6_tcp',
                               'stages/linux/x86/shell'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x86/shell/bind_ipv6_tcp'
   end
@@ -1789,7 +1614,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/linux/x86/bind_nonx_tcp',
                               'stages/linux/x86/shell'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x86/shell/bind_nonx_tcp'
   end
@@ -1800,7 +1624,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/linux/x86/bind_tcp',
                               'stages/linux/x86/shell'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x86/shell/bind_tcp'
   end
@@ -1811,7 +1634,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/linux/x86/find_tag',
                               'stages/linux/x86/shell'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x86/shell/find_tag'
   end
@@ -1822,7 +1644,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/linux/x86/reverse_ipv6_tcp',
                               'stages/linux/x86/shell'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x86/shell/reverse_ipv6_tcp'
   end
@@ -1833,7 +1654,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/linux/x86/reverse_nonx_tcp',
                               'stages/linux/x86/shell'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x86/shell/reverse_nonx_tcp'
   end
@@ -1844,7 +1664,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/linux/x86/reverse_tcp',
                               'stages/linux/x86/shell'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x86/shell/reverse_tcp'
   end
@@ -1854,7 +1673,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/linux/x86/shell_bind_ipv6_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x86/shell_bind_ipv6_tcp'
   end
@@ -1864,7 +1682,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/linux/x86/shell_bind_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x86/shell_bind_tcp'
   end
@@ -1874,7 +1691,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/linux/x86/shell_bind_tcp_random_port'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x86/shell_bind_tcp_random_port'
   end
@@ -1884,7 +1700,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/linux/x86/shell_find_port'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x86/shell_find_port'
   end
@@ -1894,7 +1709,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/linux/x86/shell_find_tag'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x86/shell_find_tag'
   end
@@ -1904,7 +1718,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/linux/x86/shell_reverse_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x86/shell_reverse_tcp'
   end
@@ -1914,7 +1727,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/linux/x86/shell_reverse_tcp_ipv6'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x86/shell_reverse_tcp_ipv6'
   end
@@ -1924,7 +1736,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                             'singles/mainframe/shell_reverse_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'mainframe/shell_reverse_tcp'
   end
@@ -1935,7 +1746,6 @@ RSpec.describe 'modules/payloads', :content do
                             'stagers/multi/reverse_http',
                             'stages/multi/meterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'multi/meterpreter/reverse_http'
   end
@@ -1946,7 +1756,6 @@ RSpec.describe 'modules/payloads', :content do
                             'stagers/multi/reverse_https',
                             'stages/multi/meterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'multi/meterpreter/reverse_https'
   end
@@ -1957,7 +1766,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/netware/reverse_tcp',
                               'stages/netware/shell'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'netware/shell/reverse_tcp'
   end
@@ -1967,7 +1775,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/nodejs/shell_bind_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'nodejs/shell_bind_tcp'
   end
@@ -1977,7 +1784,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/nodejs/shell_reverse_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'nodejs/shell_reverse_tcp'
   end
@@ -1987,7 +1793,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/nodejs/shell_reverse_tcp_ssl'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'nodejs/shell_reverse_tcp_ssl'
   end
@@ -1998,7 +1803,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/osx/armle/bind_tcp',
                               'stages/osx/armle/execute'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'osx/armle/execute/bind_tcp'
   end
@@ -2009,7 +1813,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/osx/armle/reverse_tcp',
                               'stages/osx/armle/execute'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'osx/armle/execute/reverse_tcp'
   end
@@ -2020,7 +1823,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/osx/armle/bind_tcp',
                               'stages/osx/armle/shell'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'osx/armle/shell/bind_tcp'
   end
@@ -2031,7 +1833,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/osx/armle/reverse_tcp',
                               'stages/osx/armle/shell'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'osx/armle/shell/reverse_tcp'
   end
@@ -2041,7 +1842,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/osx/armle/shell_bind_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'osx/armle/shell_bind_tcp'
   end
@@ -2051,7 +1851,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/osx/armle/shell_reverse_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'osx/armle/shell_reverse_tcp'
   end
@@ -2061,7 +1860,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/osx/armle/vibrate'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'osx/armle/vibrate'
   end
@@ -2072,7 +1870,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/osx/ppc/bind_tcp',
                               'stages/osx/ppc/shell'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'osx/ppc/shell/bind_tcp'
   end
@@ -2083,7 +1880,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/osx/ppc/find_tag',
                               'stages/osx/ppc/shell'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'osx/ppc/shell/find_tag'
   end
@@ -2094,7 +1890,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/osx/ppc/reverse_tcp',
                               'stages/osx/ppc/shell'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'osx/ppc/shell/reverse_tcp'
   end
@@ -2104,7 +1899,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/osx/ppc/shell_bind_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'osx/ppc/shell_bind_tcp'
   end
@@ -2114,7 +1908,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/osx/ppc/shell_reverse_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'osx/ppc/shell_reverse_tcp'
   end
@@ -2125,7 +1918,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/osx/x64/bind_tcp',
                               'stages/osx/x64/dupandexecve'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'osx/x64/dupandexecve/bind_tcp'
   end
@@ -2136,7 +1928,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/osx/x64/reverse_tcp',
                               'stages/osx/x64/dupandexecve'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'osx/x64/dupandexecve/reverse_tcp'
   end
@@ -2146,7 +1937,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/osx/x64/exec'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'osx/x64/exec'
   end
@@ -2157,7 +1947,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/osx/x64/bind_tcp',
                               'stages/osx/x64/meterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'osx/x64/meterpreter/bind_tcp'
   end
@@ -2168,7 +1957,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/osx/x64/reverse_tcp',
                               'stages/osx/x64/meterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'osx/x64/meterpreter/reverse_tcp'
   end
@@ -2179,7 +1967,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/osx/x64/reverse_tcp_uuid',
                               'stages/osx/x64/meterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'osx/x64/meterpreter/reverse_tcp_uuid'
   end
@@ -2189,7 +1976,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                             'singles/osx/x64/meterpreter_reverse_http'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'osx/x64/meterpreter_reverse_http'
   end
@@ -2199,7 +1985,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                             'singles/osx/x64/meterpreter_reverse_https'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'osx/x64/meterpreter_reverse_https'
   end
@@ -2209,7 +1994,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                             'singles/osx/x64/meterpreter_reverse_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'osx/x64/meterpreter_reverse_tcp'
   end
@@ -2219,7 +2003,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/osx/x64/say'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'osx/x64/say'
   end
@@ -2229,7 +2012,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/osx/x64/shell_bind_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'osx/x64/shell_bind_tcp'
   end
@@ -2239,7 +2021,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/osx/x64/shell_find_tag'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'osx/x64/shell_find_tag'
   end
@@ -2249,7 +2030,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/osx/x64/shell_reverse_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'osx/x64/shell_reverse_tcp'
   end
@@ -2260,7 +2040,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/osx/x86/bind_tcp',
                               'stages/osx/x86/bundleinject'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'osx/x86/bundleinject/bind_tcp'
   end
@@ -2271,7 +2050,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/osx/x86/reverse_tcp',
                               'stages/osx/x86/bundleinject',
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'osx/x86/bundleinject/reverse_tcp'
   end
@@ -2281,7 +2059,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/osx/x86/exec'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'osx/x86/exec'
   end
@@ -2292,7 +2069,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/osx/x86/bind_tcp',
                               'stages/osx/x86/isight'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'osx/x86/isight/bind_tcp'
   end
@@ -2303,7 +2079,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/osx/x86/reverse_tcp',
                               'stages/osx/x86/isight'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'osx/x86/isight/reverse_tcp'
   end
@@ -2313,7 +2088,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/osx/x86/shell_bind_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'osx/x86/shell_bind_tcp'
   end
@@ -2323,7 +2097,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/osx/x86/shell_find_port'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'osx/x86/shell_find_port'
   end
@@ -2333,7 +2106,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/osx/x86/shell_reverse_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'osx/x86/shell_reverse_tcp'
   end
@@ -2344,7 +2116,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/osx/x86/bind_tcp',
                               'stages/osx/x86/vforkshell'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'osx/x86/vforkshell/bind_tcp'
   end
@@ -2355,7 +2126,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/osx/x86/reverse_tcp',
                               'stages/osx/x86/vforkshell'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'osx/x86/vforkshell/reverse_tcp'
   end
@@ -2365,7 +2135,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/osx/x86/vforkshell_bind_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'osx/x86/vforkshell_bind_tcp'
   end
@@ -2375,7 +2144,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/osx/x86/vforkshell_reverse_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'osx/x86/vforkshell_reverse_tcp'
   end
@@ -2385,7 +2153,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/php/bind_perl'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'php/bind_perl'
   end
@@ -2395,7 +2162,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/php/bind_perl_ipv6'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'php/bind_perl_ipv6'
   end
@@ -2405,7 +2171,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/php/bind_php'
                           ],
-                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'php/bind_php'
   end
@@ -2415,7 +2180,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/php/bind_php_ipv6'
                           ],
-                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'php/bind_php_ipv6'
   end
@@ -2425,7 +2189,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/php/download_exec'
                           ],
-                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'php/download_exec'
   end
@@ -2435,7 +2198,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/php/exec'
                           ],
-                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'php/exec'
   end
@@ -2446,7 +2208,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/php/bind_tcp',
                               'stages/php/meterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'php/meterpreter/bind_tcp'
   end
@@ -2457,7 +2218,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/php/bind_tcp_uuid',
                               'stages/php/meterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'php/meterpreter/bind_tcp_uuid'
   end
@@ -2468,7 +2228,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/php/bind_tcp_ipv6',
                               'stages/php/meterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'php/meterpreter/bind_tcp_ipv6'
   end
@@ -2479,7 +2238,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/php/bind_tcp_ipv6_uuid',
                               'stages/php/meterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'php/meterpreter/bind_tcp_ipv6_uuid'
   end
@@ -2490,7 +2248,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/php/reverse_tcp',
                               'stages/php/meterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'php/meterpreter/reverse_tcp'
   end
@@ -2501,7 +2258,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/php/reverse_tcp_uuid',
                               'stages/php/meterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'php/meterpreter/reverse_tcp_uuid'
   end
@@ -2511,7 +2267,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/php/meterpreter_reverse_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'php/meterpreter_reverse_tcp'
   end
@@ -2521,7 +2276,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/php/reverse_perl'
                           ],
-                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'php/reverse_perl'
   end
@@ -2531,7 +2285,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/php/reverse_php'
                           ],
-                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'php/reverse_php'
   end
@@ -2541,7 +2294,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/php/shell_findsock'
                           ],
-                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'php/shell_findsock'
   end
@@ -2552,7 +2304,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/python/bind_tcp',
                               'stages/python/meterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'python/meterpreter/bind_tcp'
   end
@@ -2563,7 +2314,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/python/bind_tcp_uuid',
                               'stages/python/meterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'python/meterpreter/bind_tcp_uuid'
   end
@@ -2574,7 +2324,6 @@ RSpec.describe 'modules/payloads', :content do
                             'stagers/python/reverse_http',
                             'stages/python/meterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'python/meterpreter/reverse_http'
   end
@@ -2585,7 +2334,6 @@ RSpec.describe 'modules/payloads', :content do
                             'stagers/python/reverse_https',
                             'stages/python/meterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'python/meterpreter/reverse_https'
   end
@@ -2596,7 +2344,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/python/reverse_tcp',
                               'stages/python/meterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'python/meterpreter/reverse_tcp'
   end
@@ -2607,7 +2354,6 @@ RSpec.describe 'modules/payloads', :content do
                             'stagers/python/reverse_tcp_ssl',
                             'stages/python/meterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'python/meterpreter/reverse_tcp_ssl'
   end
@@ -2618,7 +2364,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/python/reverse_tcp_uuid',
                               'stages/python/meterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'python/meterpreter/reverse_tcp_uuid'
   end
@@ -2628,7 +2373,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/python/meterpreter_bind_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'python/meterpreter_bind_tcp'
   end
@@ -2638,7 +2382,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/python/meterpreter_reverse_http'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'python/meterpreter_reverse_http'
   end
@@ -2648,7 +2391,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/python/meterpreter_reverse_https'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'python/meterpreter_reverse_https'
   end
@@ -2658,7 +2400,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/python/meterpreter_reverse_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'python/meterpreter_reverse_tcp'
   end
@@ -2668,7 +2409,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/python/pingback_bind_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'python/pingback_bind_tcp'
   end
@@ -2678,7 +2418,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/python/pingback_reverse_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'python/pingback_reverse_tcp'
   end
@@ -2688,7 +2427,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/python/shell_bind_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'python/shell_bind_tcp'
   end
@@ -2698,7 +2436,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/python/shell_reverse_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'python/shell_reverse_tcp'
   end
@@ -2708,7 +2445,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/python/shell_reverse_tcp_ssl'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'python/shell_reverse_tcp_ssl'
   end
@@ -2718,7 +2454,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/python/shell_reverse_udp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'python/shell_reverse_udp'
   end
@@ -2728,7 +2463,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/ruby/pingback_bind_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'ruby/pingback_bind_tcp'
   end
@@ -2738,7 +2472,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/ruby/pingback_reverse_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'ruby/pingback_reverse_tcp'
   end
@@ -2748,7 +2481,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/ruby/shell_bind_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'ruby/shell_bind_tcp'
   end
@@ -2758,7 +2490,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/ruby/shell_bind_tcp_ipv6'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'ruby/shell_bind_tcp_ipv6'
   end
@@ -2768,7 +2499,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/ruby/shell_reverse_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'ruby/shell_reverse_tcp'
   end
@@ -2778,7 +2508,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/ruby/shell_reverse_tcp_ssl'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'ruby/shell_reverse_tcp_ssl'
   end
@@ -2788,7 +2517,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/solaris/sparc/shell_bind_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'solaris/sparc/shell_bind_tcp'
   end
@@ -2798,7 +2526,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/solaris/sparc/shell_find_port'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'solaris/sparc/shell_find_port'
   end
@@ -2808,7 +2535,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/solaris/sparc/shell_reverse_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'solaris/sparc/shell_reverse_tcp'
   end
@@ -2818,7 +2544,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/solaris/x86/shell_bind_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'solaris/x86/shell_bind_tcp'
   end
@@ -2828,7 +2553,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/solaris/x86/shell_find_port'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'solaris/x86/shell_find_port'
   end
@@ -2838,7 +2562,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/solaris/x86/shell_reverse_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'solaris/x86/shell_reverse_tcp'
   end
@@ -2848,7 +2571,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/tty/unix/interact'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'tty/unix/interact'
   end
@@ -2858,7 +2580,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/windows/adduser'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/adduser'
   end
@@ -2869,7 +2590,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/bind_ipv6_tcp',
                               'stages/windows/dllinject'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/dllinject/bind_ipv6_tcp'
   end
@@ -2880,7 +2600,6 @@ RSpec.describe 'modules/payloads', :content do
                             'stagers/windows/bind_named_pipe',
                             'stages/windows/dllinject'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/dllinject/bind_named_pipe'
   end
@@ -2891,7 +2610,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/bind_nonx_tcp',
                               'stages/windows/dllinject'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/dllinject/bind_nonx_tcp'
   end
@@ -2902,7 +2620,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/bind_tcp',
                               'stages/windows/dllinject'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/dllinject/bind_tcp'
   end
@@ -2913,7 +2630,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/bind_tcp_rc4',
                               'stages/windows/dllinject'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/dllinject/bind_tcp_rc4'
   end
@@ -2924,7 +2640,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/findtag_ord',
                               'stages/windows/dllinject'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/dllinject/find_tag'
   end
@@ -2935,7 +2650,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/reverse_hop_http',
                               'stages/windows/dllinject'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/dllinject/reverse_hop_http'
   end
@@ -2946,7 +2660,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/reverse_http',
                               'stages/windows/dllinject'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/dllinject/reverse_http'
   end
@@ -2957,7 +2670,6 @@ RSpec.describe 'modules/payloads', :content do
                             'stagers/windows/reverse_http_proxy_pstore',
                             'stages/windows/dllinject'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/dllinject/reverse_http_proxy_pstore'
   end
@@ -2968,7 +2680,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/reverse_ipv6_tcp',
                               'stages/windows/dllinject'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/dllinject/reverse_ipv6_tcp'
   end
@@ -2979,7 +2690,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/reverse_nonx_tcp',
                               'stages/windows/dllinject'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/dllinject/reverse_nonx_tcp'
   end
@@ -2990,7 +2700,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/reverse_ord_tcp',
                               'stages/windows/dllinject'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/dllinject/reverse_ord_tcp'
   end
@@ -3001,7 +2710,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/reverse_tcp',
                               'stages/windows/dllinject'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/dllinject/reverse_tcp'
   end
@@ -3012,7 +2720,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/reverse_tcp_allports',
                               'stages/windows/dllinject'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/dllinject/reverse_tcp_allports'
   end
@@ -3023,7 +2730,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/reverse_tcp_dns',
                               'stages/windows/dllinject'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/dllinject/reverse_tcp_dns'
   end
@@ -3034,7 +2740,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/reverse_tcp_rc4',
                               'stages/windows/dllinject'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/dllinject/reverse_tcp_rc4'
   end
@@ -3045,7 +2750,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/reverse_tcp_rc4_dns',
                               'stages/windows/dllinject'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/dllinject/reverse_tcp_rc4_dns'
   end
@@ -3055,7 +2759,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/windows/dns_txt_query_exec'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/dns_txt_query_exec'
   end
@@ -3065,7 +2768,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/windows/download_exec'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/download_exec'
   end
@@ -3092,7 +2794,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/windows/exec'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/exec'
   end
@@ -3102,7 +2803,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/windows/format_all_drives'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/format_all_drives'
   end
@@ -3112,7 +2812,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/windows/loadlibrary'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/loadlibrary'
   end
@@ -3122,7 +2821,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/windows/messagebox'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/messagebox'
   end
@@ -3132,7 +2830,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/windows/meterpreter_bind_named_pipe'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/meterpreter_bind_named_pipe'
   end
@@ -3142,7 +2839,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                             'singles/windows/meterpreter_bind_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/meterpreter_bind_tcp'
   end
@@ -3152,7 +2848,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                             'singles/windows/meterpreter_reverse_http'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/meterpreter_reverse_http'
   end
@@ -3162,7 +2857,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                             'singles/windows/meterpreter_reverse_https'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/meterpreter_reverse_https'
   end
@@ -3172,7 +2866,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                             'singles/windows/meterpreter_reverse_ipv6_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/meterpreter_reverse_ipv6_tcp'
   end
@@ -3182,7 +2875,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                             'singles/windows/meterpreter_reverse_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/meterpreter_reverse_tcp'
   end
@@ -3193,7 +2885,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/bind_ipv6_tcp',
                               'stages/windows/meterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/meterpreter/bind_ipv6_tcp'
   end
@@ -3204,7 +2895,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/bind_ipv6_tcp_uuid',
                               'stages/windows/meterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/meterpreter/bind_ipv6_tcp_uuid'
   end
@@ -3215,7 +2905,6 @@ RSpec.describe 'modules/payloads', :content do
                             'stagers/windows/bind_named_pipe',
                             'stages/windows/meterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/meterpreter/bind_named_pipe'
   end
@@ -3226,7 +2915,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/bind_nonx_tcp',
                               'stages/windows/meterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/meterpreter/bind_nonx_tcp'
   end
@@ -3237,7 +2925,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/bind_tcp',
                               'stages/windows/meterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/meterpreter/bind_tcp'
   end
@@ -3248,7 +2935,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/bind_tcp_rc4',
                               'stages/windows/meterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/meterpreter/bind_tcp_rc4'
   end
@@ -3259,7 +2945,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/bind_tcp_uuid',
                               'stages/windows/meterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/meterpreter/bind_tcp_uuid'
   end
@@ -3270,7 +2955,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/findtag_ord',
                               'stages/windows/meterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/meterpreter/find_tag'
   end
@@ -3281,7 +2965,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/reverse_hop_http',
                               'stages/windows/meterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/meterpreter/reverse_hop_http'
   end
@@ -3292,7 +2975,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/reverse_http',
                               'stages/windows/meterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/meterpreter/reverse_http'
   end
@@ -3303,7 +2985,6 @@ RSpec.describe 'modules/payloads', :content do
                             'stagers/windows/reverse_http_proxy_pstore',
                             'stages/windows/meterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/meterpreter/reverse_http_proxy_pstore'
   end
@@ -3314,7 +2995,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/reverse_https',
                               'stages/windows/meterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/meterpreter/reverse_https'
   end
@@ -3325,7 +3005,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/reverse_https_proxy',
                               'stages/windows/meterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/meterpreter/reverse_https_proxy'
   end
@@ -3336,7 +3015,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/reverse_ipv6_tcp',
                               'stages/windows/meterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/meterpreter/reverse_ipv6_tcp'
   end
@@ -3347,7 +3025,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/reverse_named_pipe',
                               'stages/windows/meterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/meterpreter/reverse_named_pipe'
   end
@@ -3358,7 +3035,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/reverse_nonx_tcp',
                               'stages/windows/meterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/meterpreter/reverse_nonx_tcp'
   end
@@ -3369,7 +3045,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/reverse_ord_tcp',
                               'stages/windows/meterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/meterpreter/reverse_ord_tcp'
   end
@@ -3380,7 +3055,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/reverse_tcp',
                               'stages/windows/meterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/meterpreter/reverse_tcp'
   end
@@ -3391,7 +3065,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/reverse_tcp_allports',
                               'stages/windows/meterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/meterpreter/reverse_tcp_allports'
   end
@@ -3402,7 +3075,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/reverse_tcp_dns',
                               'stages/windows/meterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/meterpreter/reverse_tcp_dns'
   end
@@ -3413,7 +3085,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/reverse_tcp_rc4',
                               'stages/windows/meterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/meterpreter/reverse_tcp_rc4'
   end
@@ -3424,7 +3095,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/reverse_tcp_rc4_dns',
                               'stages/windows/meterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/meterpreter/reverse_tcp_rc4_dns'
   end
@@ -3435,7 +3105,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/reverse_tcp_uuid',
                               'stages/windows/meterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/meterpreter/reverse_tcp_uuid'
   end
@@ -3445,7 +3114,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/windows/metsvc_bind_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/metsvc_bind_tcp'
   end
@@ -3455,7 +3123,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/windows/metsvc_reverse_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/metsvc_reverse_tcp'
   end
@@ -3466,7 +3133,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/bind_ipv6_tcp',
                               'stages/windows/patchupdllinject'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/patchupdllinject/bind_ipv6_tcp'
   end
@@ -3477,7 +3143,6 @@ RSpec.describe 'modules/payloads', :content do
                             'stagers/windows/bind_named_pipe',
                             'stages/windows/patchupdllinject'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/patchupdllinject/bind_named_pipe'
   end
@@ -3488,7 +3153,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/bind_nonx_tcp',
                               'stages/windows/patchupdllinject'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/patchupdllinject/bind_nonx_tcp'
   end
@@ -3499,7 +3163,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/bind_tcp',
                               'stages/windows/patchupdllinject'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/patchupdllinject/bind_tcp'
   end
@@ -3510,7 +3173,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/bind_tcp_rc4',
                               'stages/windows/patchupdllinject'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/patchupdllinject/bind_tcp_rc4'
   end
@@ -3521,7 +3183,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/findtag_ord',
                               'stages/windows/patchupdllinject'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/patchupdllinject/find_tag'
   end
@@ -3532,7 +3193,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/reverse_ipv6_tcp',
                               'stages/windows/patchupdllinject'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/patchupdllinject/reverse_ipv6_tcp'
   end
@@ -3543,7 +3203,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/reverse_nonx_tcp',
                               'stages/windows/patchupdllinject'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/patchupdllinject/reverse_nonx_tcp'
   end
@@ -3554,7 +3213,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/reverse_ord_tcp',
                               'stages/windows/patchupdllinject'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/patchupdllinject/reverse_ord_tcp'
   end
@@ -3565,7 +3223,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/reverse_tcp',
                               'stages/windows/patchupdllinject'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/patchupdllinject/reverse_tcp'
   end
@@ -3576,7 +3233,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/reverse_tcp_allports',
                               'stages/windows/patchupdllinject'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/patchupdllinject/reverse_tcp_allports'
   end
@@ -3587,7 +3243,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/reverse_tcp_dns',
                               'stages/windows/patchupdllinject'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/patchupdllinject/reverse_tcp_dns'
   end
@@ -3598,7 +3253,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/reverse_tcp_rc4',
                               'stages/windows/patchupdllinject'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/patchupdllinject/reverse_tcp_rc4'
   end
@@ -3609,7 +3263,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/reverse_tcp_rc4_dns',
                               'stages/windows/patchupdllinject'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/patchupdllinject/reverse_tcp_rc4_dns'
   end
@@ -3620,7 +3273,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/bind_ipv6_tcp',
                               'stages/windows/patchupmeterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/patchupmeterpreter/bind_ipv6_tcp'
   end
@@ -3631,7 +3283,6 @@ RSpec.describe 'modules/payloads', :content do
                             'stagers/windows/bind_named_pipe',
                             'stages/windows/patchupmeterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/patchupmeterpreter/bind_named_pipe'
   end
@@ -3642,7 +3293,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/bind_nonx_tcp',
                               'stages/windows/patchupmeterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/patchupmeterpreter/bind_nonx_tcp'
   end
@@ -3653,7 +3303,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/bind_tcp',
                               'stages/windows/patchupmeterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/patchupmeterpreter/bind_tcp'
   end
@@ -3664,7 +3313,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/bind_tcp_rc4',
                               'stages/windows/patchupmeterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/patchupmeterpreter/bind_tcp_rc4'
   end
@@ -3675,7 +3323,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/findtag_ord',
                               'stages/windows/patchupmeterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/patchupmeterpreter/find_tag'
   end
@@ -3686,7 +3333,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/reverse_ipv6_tcp',
                               'stages/windows/patchupmeterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/patchupmeterpreter/reverse_ipv6_tcp'
   end
@@ -3697,7 +3343,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/reverse_nonx_tcp',
                               'stages/windows/patchupmeterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/patchupmeterpreter/reverse_nonx_tcp'
   end
@@ -3708,7 +3353,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/reverse_ord_tcp',
                               'stages/windows/patchupmeterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/patchupmeterpreter/reverse_ord_tcp'
   end
@@ -3719,7 +3363,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/reverse_tcp',
                               'stages/windows/patchupmeterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/patchupmeterpreter/reverse_tcp'
   end
@@ -3730,7 +3373,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/reverse_tcp_allports',
                               'stages/windows/patchupmeterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/patchupmeterpreter/reverse_tcp_allports'
   end
@@ -3741,7 +3383,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/reverse_tcp_dns',
                               'stages/windows/patchupmeterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/patchupmeterpreter/reverse_tcp_dns'
   end
@@ -3752,7 +3393,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/reverse_tcp_rc4',
                               'stages/windows/patchupmeterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/patchupmeterpreter/reverse_tcp_rc4'
   end
@@ -3763,7 +3403,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/reverse_tcp_rc4_dns',
                               'stages/windows/patchupmeterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/patchupmeterpreter/reverse_tcp_rc4_dns'
   end
@@ -3773,7 +3412,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/windows/pingback_bind_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/pingback_bind_tcp'
   end
@@ -3783,7 +3421,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/windows/pingback_reverse_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/pingback_reverse_tcp'
   end
@@ -3794,7 +3431,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/bind_ipv6_tcp',
                               'stages/windows/shell'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/shell/bind_ipv6_tcp'
   end
@@ -3805,7 +3441,6 @@ RSpec.describe 'modules/payloads', :content do
                             'stagers/windows/bind_named_pipe',
                             'stages/windows/shell'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/shell/bind_named_pipe'
   end
@@ -3816,7 +3451,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/bind_nonx_tcp',
                               'stages/windows/shell'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/shell/bind_nonx_tcp'
   end
@@ -3827,7 +3461,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/bind_tcp',
                               'stages/windows/shell'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/shell/bind_tcp'
   end
@@ -3838,7 +3471,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/bind_tcp_rc4',
                               'stages/windows/shell'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/shell/bind_tcp_rc4'
   end
@@ -3849,7 +3481,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/findtag_ord',
                               'stages/windows/shell'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/shell/find_tag'
   end
@@ -3860,7 +3491,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/reverse_ipv6_tcp',
                               'stages/windows/shell'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/shell/reverse_ipv6_tcp'
   end
@@ -3871,7 +3501,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/reverse_nonx_tcp',
                               'stages/windows/shell'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/shell/reverse_nonx_tcp'
   end
@@ -3882,7 +3511,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/reverse_ord_tcp',
                               'stages/windows/shell'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/shell/reverse_ord_tcp'
   end
@@ -3893,7 +3521,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/reverse_tcp',
                               'stages/windows/shell'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/shell/reverse_tcp'
   end
@@ -3904,7 +3531,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/reverse_tcp_allports',
                               'stages/windows/shell'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/shell/reverse_tcp_allports'
   end
@@ -3915,7 +3541,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/reverse_tcp_dns',
                               'stages/windows/shell'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/shell/reverse_tcp_dns'
   end
@@ -3926,7 +3551,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/reverse_tcp_rc4',
                               'stages/windows/shell'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/shell/reverse_tcp_rc4'
   end
@@ -3937,7 +3561,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/reverse_tcp_rc4_dns',
                               'stages/windows/shell'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/shell/reverse_tcp_rc4_dns'
   end
@@ -3948,7 +3571,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/reverse_udp',
                               'stages/windows/shell'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/shell/reverse_udp'
   end
@@ -3958,7 +3580,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/windows/shell_bind_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/shell_bind_tcp'
   end
@@ -3968,7 +3589,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/windows/shell_bind_tcp_xpfw'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/shell_bind_tcp_xpfw'
   end
@@ -3978,7 +3598,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/windows/shell_hidden_bind_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/shell_hidden_bind_tcp'
   end
@@ -3988,7 +3607,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/windows/shell_reverse_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/shell_reverse_tcp'
   end
@@ -3998,7 +3616,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/windows/speak_pwned'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/speak_pwned'
   end
@@ -4009,7 +3626,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/bind_ipv6_tcp',
                               'stages/windows/upexec'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/upexec/bind_ipv6_tcp'
   end
@@ -4020,7 +3636,6 @@ RSpec.describe 'modules/payloads', :content do
                             'stagers/windows/bind_named_pipe',
                             'stages/windows/upexec'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/upexec/bind_named_pipe'
   end
@@ -4031,7 +3646,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/bind_nonx_tcp',
                               'stages/windows/upexec'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/upexec/bind_nonx_tcp'
   end
@@ -4042,7 +3656,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/bind_tcp',
                               'stages/windows/upexec'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/upexec/bind_tcp'
   end
@@ -4053,7 +3666,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/bind_tcp_rc4',
                               'stages/windows/upexec'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/upexec/bind_tcp_rc4'
   end
@@ -4064,7 +3676,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/findtag_ord',
                               'stages/windows/upexec'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/upexec/find_tag'
   end
@@ -4075,7 +3686,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/reverse_ipv6_tcp',
                               'stages/windows/upexec'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/upexec/reverse_ipv6_tcp'
   end
@@ -4086,7 +3696,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/reverse_nonx_tcp',
                               'stages/windows/upexec'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/upexec/reverse_nonx_tcp'
   end
@@ -4097,7 +3706,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/reverse_ord_tcp',
                               'stages/windows/upexec'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/upexec/reverse_ord_tcp'
   end
@@ -4108,7 +3716,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/reverse_tcp',
                               'stages/windows/upexec'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/upexec/reverse_tcp'
   end
@@ -4119,7 +3726,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/reverse_tcp_allports',
                               'stages/windows/upexec'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/upexec/reverse_tcp_allports'
   end
@@ -4130,7 +3736,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/reverse_tcp_dns',
                               'stages/windows/upexec'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/upexec/reverse_tcp_dns'
   end
@@ -4141,7 +3746,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/reverse_tcp_rc4',
                               'stages/windows/upexec'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/upexec/reverse_tcp_rc4'
   end
@@ -4152,7 +3756,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/reverse_tcp_rc4_dns',
                               'stages/windows/upexec'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/upexec/reverse_tcp_rc4_dns'
   end
@@ -4163,7 +3766,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/reverse_udp',
                               'stages/windows/upexec'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/upexec/reverse_udp'
   end
@@ -4174,7 +3776,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/bind_ipv6_tcp',
                               'stages/windows/vncinject'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/vncinject/bind_ipv6_tcp'
   end
@@ -4185,7 +3786,6 @@ RSpec.describe 'modules/payloads', :content do
                             'stagers/windows/bind_named_pipe',
                             'stages/windows/vncinject'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/vncinject/bind_named_pipe'
   end
@@ -4196,7 +3796,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/bind_nonx_tcp',
                               'stages/windows/vncinject'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/vncinject/bind_nonx_tcp'
   end
@@ -4207,7 +3806,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/bind_tcp',
                               'stages/windows/vncinject'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/vncinject/bind_tcp'
   end
@@ -4218,7 +3816,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/bind_tcp_rc4',
                               'stages/windows/vncinject'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/vncinject/bind_tcp_rc4'
   end
@@ -4229,7 +3826,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/findtag_ord',
                               'stages/windows/vncinject'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/vncinject/find_tag'
   end
@@ -4240,7 +3836,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/reverse_ipv6_tcp',
                               'stages/windows/vncinject'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/vncinject/reverse_ipv6_tcp'
   end
@@ -4251,7 +3846,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/reverse_nonx_tcp',
                               'stages/windows/vncinject'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/vncinject/reverse_nonx_tcp'
   end
@@ -4262,7 +3856,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/reverse_ord_tcp',
                               'stages/windows/vncinject'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/vncinject/reverse_ord_tcp'
   end
@@ -4273,7 +3866,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/reverse_tcp',
                               'stages/windows/vncinject'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/vncinject/reverse_tcp'
   end
@@ -4284,7 +3876,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/reverse_tcp_allports',
                               'stages/windows/vncinject'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/vncinject/reverse_tcp_allports'
   end
@@ -4295,7 +3886,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/reverse_tcp_dns',
                               'stages/windows/vncinject'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/vncinject/reverse_tcp_dns'
   end
@@ -4306,7 +3896,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/reverse_tcp_rc4',
                               'stages/windows/vncinject'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/vncinject/reverse_tcp_rc4'
   end
@@ -4317,7 +3906,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/reverse_tcp_rc4_dns',
                               'stages/windows/vncinject'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/vncinject/reverse_tcp_rc4_dns'
   end
@@ -4344,7 +3932,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/windows/x64/exec'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/x64/exec'
   end
@@ -4354,7 +3941,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/windows/x64/loadlibrary'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/x64/loadlibrary'
   end
@@ -4364,7 +3950,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/windows/x64/messagebox'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/x64/messagebox'
   end
@@ -4375,7 +3960,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/x64/bind_ipv6_tcp',
                               'stages/windows/x64/meterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/x64/meterpreter/bind_ipv6_tcp'
   end
@@ -4386,7 +3970,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/x64/bind_ipv6_tcp_uuid',
                               'stages/windows/x64/meterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/x64/meterpreter/bind_ipv6_tcp_uuid'
   end
@@ -4397,7 +3980,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/x64/bind_named_pipe',
                               'stages/windows/x64/meterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/x64/meterpreter/bind_named_pipe'
   end
@@ -4408,7 +3990,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/x64/bind_tcp',
                               'stages/windows/x64/meterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/x64/meterpreter/bind_tcp'
   end
@@ -4419,7 +4000,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/x64/bind_tcp_rc4',
                               'stages/windows/x64/meterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/x64/meterpreter/bind_tcp_rc4'
   end
@@ -4430,7 +4010,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/x64/bind_tcp_uuid',
                               'stages/windows/x64/meterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/x64/meterpreter/bind_tcp_uuid'
   end
@@ -4441,7 +4020,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/x64/reverse_http',
                               'stages/windows/x64/meterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/x64/meterpreter/reverse_http'
   end
@@ -4452,7 +4030,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/x64/reverse_https',
                               'stages/windows/x64/meterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/x64/meterpreter/reverse_https'
   end
@@ -4463,7 +4040,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/x64/reverse_named_pipe',
                               'stages/windows/x64/meterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/x64/meterpreter/reverse_named_pipe'
   end
@@ -4474,7 +4050,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/x64/reverse_tcp',
                               'stages/windows/x64/meterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/x64/meterpreter/reverse_tcp'
   end
@@ -4485,7 +4060,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/x64/reverse_tcp_rc4',
                               'stages/windows/x64/meterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/x64/meterpreter/reverse_tcp_rc4'
   end
@@ -4496,7 +4070,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/x64/reverse_tcp_uuid',
                               'stages/windows/x64/meterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/x64/meterpreter/reverse_tcp_uuid'
   end
@@ -4507,7 +4080,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/x64/reverse_winhttp',
                               'stages/windows/x64/meterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/x64/meterpreter/reverse_winhttp'
   end
@@ -4518,7 +4090,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/x64/reverse_winhttps',
                               'stages/windows/x64/meterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/x64/meterpreter/reverse_winhttps'
   end
@@ -4528,7 +4099,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/windows/x64/meterpreter_bind_named_pipe'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/x64/meterpreter_bind_named_pipe'
   end
@@ -4538,7 +4108,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/windows/x64/meterpreter_bind_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/x64/meterpreter_bind_tcp'
   end
@@ -4548,7 +4117,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/windows/x64/meterpreter_reverse_http'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/x64/meterpreter_reverse_http'
   end
@@ -4558,7 +4126,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/windows/x64/meterpreter_reverse_https'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/x64/meterpreter_reverse_https'
   end
@@ -4568,7 +4135,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/windows/x64/meterpreter_reverse_ipv6_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/x64/meterpreter_reverse_ipv6_tcp'
   end
@@ -4578,7 +4144,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/windows/x64/meterpreter_reverse_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/x64/meterpreter_reverse_tcp'
   end
@@ -4588,7 +4153,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                             'singles/windows/x64/powershell_bind_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/x64/powershell_bind_tcp'
   end
@@ -4598,7 +4162,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                             'singles/windows/x64/powershell_reverse_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/x64/powershell_reverse_tcp'
   end
@@ -4608,7 +4171,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/windows/x64/pingback_reverse_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/x64/pingback_reverse_tcp'
   end
@@ -4619,7 +4181,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/x64/bind_named_pipe',
                               'stages/windows/x64/shell'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/x64/shell/bind_named_pipe'
   end
@@ -4630,7 +4191,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/x64/bind_tcp',
                               'stages/windows/x64/shell'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/x64/shell/bind_tcp'
   end
@@ -4641,7 +4201,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/x64/bind_tcp_rc4',
                               'stages/windows/x64/shell'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/x64/shell/bind_tcp_rc4'
   end
@@ -4652,7 +4211,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/x64/reverse_tcp',
                               'stages/windows/x64/shell'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/x64/shell/reverse_tcp'
   end
@@ -4663,7 +4221,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/x64/reverse_tcp_rc4',
                               'stages/windows/x64/shell'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/x64/shell/reverse_tcp_rc4'
   end
@@ -4673,7 +4230,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/windows/x64/shell_bind_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/x64/shell_bind_tcp'
   end
@@ -4683,7 +4239,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/windows/x64/shell_reverse_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/x64/shell_reverse_tcp'
   end
@@ -4694,7 +4249,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/x64/bind_named_pipe',
                               'stages/windows/x64/vncinject'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/x64/vncinject/bind_named_pipe'
   end
@@ -4705,7 +4259,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/x64/bind_tcp',
                               'stages/windows/x64/vncinject'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/x64/vncinject/bind_tcp'
   end
@@ -4716,7 +4269,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/x64/bind_tcp_rc4',
                               'stages/windows/x64/vncinject'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/x64/vncinject/bind_tcp_rc4'
   end
@@ -4727,7 +4279,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/x64/reverse_tcp',
                               'stages/windows/x64/vncinject'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/x64/vncinject/reverse_tcp'
   end
@@ -4738,7 +4289,6 @@ RSpec.describe 'modules/payloads', :content do
                               'stagers/windows/x64/reverse_tcp_rc4',
                               'stages/windows/x64/vncinject'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/x64/vncinject/reverse_tcp_rc4'
   end
@@ -4749,7 +4299,6 @@ RSpec.describe 'modules/payloads', :content do
                             'stagers/windows/bind_hidden_tcp',
                             'stages/windows/dllinject'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/dllinject/bind_hidden_tcp'
   end
@@ -4760,7 +4309,6 @@ RSpec.describe 'modules/payloads', :content do
                             'stagers/windows/bind_hidden_tcp',
                             'stages/windows/meterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/meterpreter/bind_hidden_tcp'
   end
@@ -4771,7 +4319,6 @@ RSpec.describe 'modules/payloads', :content do
                             'stagers/windows/bind_hidden_tcp',
                             'stages/windows/patchupdllinject'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/patchupdllinject/bind_hidden_tcp'
   end
@@ -4782,7 +4329,6 @@ RSpec.describe 'modules/payloads', :content do
                             'stagers/windows/bind_hidden_tcp',
                             'stages/windows/patchupmeterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/patchupmeterpreter/bind_hidden_tcp'
   end
@@ -4793,7 +4339,6 @@ RSpec.describe 'modules/payloads', :content do
                             'stagers/windows/bind_hidden_tcp',
                             'stages/windows/shell'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/shell/bind_hidden_tcp'
   end
@@ -4804,7 +4349,6 @@ RSpec.describe 'modules/payloads', :content do
                             'stagers/windows/bind_hidden_tcp',
                             'stages/windows/upexec'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/upexec/bind_hidden_tcp'
   end
@@ -4815,7 +4359,6 @@ RSpec.describe 'modules/payloads', :content do
                             'stagers/windows/bind_hidden_tcp',
                             'stages/windows/vncinject'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/vncinject/bind_hidden_tcp'
   end
@@ -4826,7 +4369,6 @@ RSpec.describe 'modules/payloads', :content do
                             'stagers/windows/bind_hidden_ipknock_tcp',
                             'stages/windows/dllinject'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/dllinject/bind_hidden_ipknock_tcp'
   end
@@ -4837,7 +4379,6 @@ RSpec.describe 'modules/payloads', :content do
                             'stagers/windows/bind_hidden_ipknock_tcp',
                             'stages/windows/meterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/meterpreter/bind_hidden_ipknock_tcp'
   end
@@ -4848,7 +4389,6 @@ RSpec.describe 'modules/payloads', :content do
                             'stagers/windows/bind_hidden_ipknock_tcp',
                             'stages/windows/patchupdllinject'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/patchupdllinject/bind_hidden_ipknock_tcp'
   end
@@ -4859,7 +4399,6 @@ RSpec.describe 'modules/payloads', :content do
                             'stagers/windows/bind_hidden_ipknock_tcp',
                             'stages/windows/patchupmeterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/patchupmeterpreter/bind_hidden_ipknock_tcp'
   end
@@ -4869,7 +4408,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                             'singles/windows/powershell_bind_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/powershell_bind_tcp'
   end
@@ -4879,7 +4417,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                             'singles/windows/powershell_reverse_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/powershell_reverse_tcp'
   end
@@ -4890,7 +4427,6 @@ RSpec.describe 'modules/payloads', :content do
                             'stagers/windows/bind_hidden_ipknock_tcp',
                             'stages/windows/shell'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/shell/bind_hidden_ipknock_tcp'
   end
@@ -4901,7 +4437,6 @@ RSpec.describe 'modules/payloads', :content do
                             'stagers/windows/bind_hidden_ipknock_tcp',
                             'stages/windows/upexec'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/upexec/bind_hidden_ipknock_tcp'
   end
@@ -4912,7 +4447,6 @@ RSpec.describe 'modules/payloads', :content do
                             'stagers/windows/bind_hidden_ipknock_tcp',
                             'stages/windows/vncinject'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/vncinject/bind_hidden_ipknock_tcp'
   end
@@ -4923,7 +4457,6 @@ RSpec.describe 'modules/payloads', :content do
                             'stagers/windows/reverse_winhttp',
                             'stages/windows/meterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/meterpreter/reverse_winhttp'
   end
@@ -4934,7 +4467,6 @@ RSpec.describe 'modules/payloads', :content do
                             'stagers/windows/reverse_winhttps',
                             'stages/windows/meterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/meterpreter/reverse_winhttps'
   end
@@ -4944,7 +4476,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                             'singles/linux/mips64/meterpreter_reverse_http'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/mips64/meterpreter_reverse_http'
   end
@@ -4954,7 +4485,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                             'singles/linux/mips64/meterpreter_reverse_https'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/mips64/meterpreter_reverse_https'
   end
@@ -4964,7 +4494,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                             'singles/linux/mipsbe/meterpreter_reverse_http'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/mipsbe/meterpreter_reverse_http'
   end
@@ -4974,7 +4503,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                             'singles/linux/mipsbe/meterpreter_reverse_https'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/mipsbe/meterpreter_reverse_https'
   end
@@ -4984,7 +4512,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                             'singles/linux/mipsle/meterpreter_reverse_http'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/mipsle/meterpreter_reverse_http'
   end
@@ -4994,7 +4521,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                             'singles/linux/mipsle/meterpreter_reverse_https'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/mipsle/meterpreter_reverse_https'
   end
@@ -5004,7 +4530,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                             'singles/linux/ppc/meterpreter_reverse_http'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/ppc/meterpreter_reverse_http'
   end
@@ -5014,7 +4539,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                             'singles/linux/ppc/meterpreter_reverse_https'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/ppc/meterpreter_reverse_https'
   end
@@ -5024,7 +4548,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/linux/ppce500v2/meterpreter_reverse_http'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/ppce500v2/meterpreter_reverse_http'
   end
@@ -5034,7 +4557,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/linux/ppce500v2/meterpreter_reverse_https'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/ppce500v2/meterpreter_reverse_https'
   end
@@ -5044,7 +4566,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/linux/ppce500v2/meterpreter_reverse_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/ppce500v2/meterpreter_reverse_tcp'
   end
@@ -5054,7 +4575,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                             'singles/linux/ppc64le/meterpreter_reverse_http'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/ppc64le/meterpreter_reverse_http'
   end
@@ -5064,7 +4584,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                             'singles/linux/ppc64le/meterpreter_reverse_https'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/ppc64le/meterpreter_reverse_https'
   end
@@ -5074,7 +4593,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                             'singles/linux/x64/meterpreter_reverse_http'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x64/meterpreter_reverse_http'
   end
@@ -5084,7 +4602,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                             'singles/linux/x64/meterpreter_reverse_https'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x64/meterpreter_reverse_https'
   end
@@ -5094,7 +4611,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                             'singles/linux/x86/meterpreter_reverse_http'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x86/meterpreter_reverse_http'
   end
@@ -5104,7 +4620,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                             'singles/linux/x86/meterpreter_reverse_https'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x86/meterpreter_reverse_https'
   end
@@ -5114,7 +4629,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                             'singles/linux/x86/metsvc_bind_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x86/metsvc_bind_tcp'
   end
@@ -5124,7 +4638,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                             'singles/linux/x86/metsvc_reverse_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x86/metsvc_reverse_tcp'
   end
@@ -5134,7 +4647,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                             'singles/linux/zarch/meterpreter_reverse_http'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/zarch/meterpreter_reverse_http'
   end
@@ -5144,7 +4656,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                             'singles/linux/zarch/meterpreter_reverse_https'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/zarch/meterpreter_reverse_https'
   end
@@ -5155,7 +4666,6 @@ RSpec.describe 'modules/payloads', :content do
                             'stagers/linux/aarch64/reverse_tcp',
                             'stages/linux/aarch64/meterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/aarch64/meterpreter/reverse_tcp'
   end
@@ -5165,7 +4675,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                             'singles/linux/aarch64/meterpreter_reverse_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/aarch64/meterpreter_reverse_tcp'
   end
@@ -5175,7 +4684,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                             'singles/linux/armbe/meterpreter_reverse_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/armbe/meterpreter_reverse_tcp'
   end
@@ -5185,7 +4693,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                             'singles/linux/armbe/meterpreter_reverse_http'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/armbe/meterpreter_reverse_http'
   end
@@ -5195,7 +4702,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                             'singles/linux/armbe/meterpreter_reverse_https'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/armbe/meterpreter_reverse_https'
   end
@@ -5205,7 +4711,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                             'singles/linux/armle/meterpreter_reverse_http'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/armle/meterpreter_reverse_http'
   end
@@ -5215,7 +4720,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                             'singles/linux/armle/meterpreter_reverse_https'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/armle/meterpreter_reverse_https'
   end
@@ -5226,7 +4730,6 @@ RSpec.describe 'modules/payloads', :content do
                             'stagers/linux/armle/bind_tcp',
                             'stages/linux/armle/meterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/armle/meterpreter/bind_tcp'
   end
@@ -5237,7 +4740,6 @@ RSpec.describe 'modules/payloads', :content do
                             'stagers/linux/armle/reverse_tcp',
                             'stages/linux/armle/meterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/armle/meterpreter/reverse_tcp'
   end
@@ -5247,7 +4749,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                             'singles/linux/armle/meterpreter_reverse_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/armle/meterpreter_reverse_tcp'
   end
@@ -5257,7 +4758,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                             'singles/linux/mips64/meterpreter_reverse_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/mips64/meterpreter_reverse_tcp'
   end
@@ -5268,7 +4768,6 @@ RSpec.describe 'modules/payloads', :content do
                             'stagers/linux/mipsbe/reverse_tcp',
                             'stages/linux/mipsbe/meterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/mipsbe/meterpreter/reverse_tcp'
   end
@@ -5278,7 +4777,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                             'singles/linux/mipsbe/meterpreter_reverse_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/mipsbe/meterpreter_reverse_tcp'
   end
@@ -5289,7 +4787,6 @@ RSpec.describe 'modules/payloads', :content do
                             'stagers/linux/mipsle/reverse_tcp',
                             'stages/linux/mipsle/meterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/mipsle/meterpreter/reverse_tcp'
   end
@@ -5299,7 +4796,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                             'singles/linux/mipsle/meterpreter_reverse_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/mipsle/meterpreter_reverse_tcp'
   end
@@ -5309,7 +4805,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                             'singles/linux/ppc/meterpreter_reverse_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/ppc/meterpreter_reverse_tcp'
   end
@@ -5319,7 +4814,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                             'singles/linux/ppc64le/meterpreter_reverse_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/ppc64le/meterpreter_reverse_tcp'
   end
@@ -5330,7 +4824,6 @@ RSpec.describe 'modules/payloads', :content do
                             'stagers/linux/x64/bind_tcp',
                             'stages/linux/x64/meterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x64/meterpreter/bind_tcp'
   end
@@ -5341,7 +4834,6 @@ RSpec.describe 'modules/payloads', :content do
                             'stagers/linux/x64/reverse_tcp',
                             'stages/linux/x64/meterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x64/meterpreter/reverse_tcp'
   end
@@ -5351,7 +4843,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                             'singles/linux/x64/meterpreter_reverse_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x64/meterpreter_reverse_tcp'
   end
@@ -5362,7 +4853,6 @@ RSpec.describe 'modules/payloads', :content do
                             'stagers/linux/x86/bind_ipv6_tcp',
                             'stages/linux/x86/meterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x86/meterpreter/bind_ipv6_tcp'
   end
@@ -5373,7 +4863,6 @@ RSpec.describe 'modules/payloads', :content do
                             'stagers/linux/x86/bind_ipv6_tcp_uuid',
                             'stages/linux/x86/meterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x86/meterpreter/bind_ipv6_tcp_uuid'
   end
@@ -5384,7 +4873,6 @@ RSpec.describe 'modules/payloads', :content do
                             'stagers/linux/x86/bind_nonx_tcp',
                             'stages/linux/x86/meterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x86/meterpreter/bind_nonx_tcp'
   end
@@ -5395,7 +4883,6 @@ RSpec.describe 'modules/payloads', :content do
                             'stagers/linux/x86/bind_tcp',
                             'stages/linux/x86/meterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x86/meterpreter/bind_tcp'
   end
@@ -5406,7 +4893,6 @@ RSpec.describe 'modules/payloads', :content do
                             'stagers/linux/x86/bind_tcp_uuid',
                             'stages/linux/x86/meterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x86/meterpreter/bind_tcp_uuid'
   end
@@ -5417,7 +4903,6 @@ RSpec.describe 'modules/payloads', :content do
                             'stagers/linux/x86/find_tag',
                             'stages/linux/x86/meterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x86/meterpreter/find_tag'
   end
@@ -5428,7 +4913,6 @@ RSpec.describe 'modules/payloads', :content do
                             'stagers/linux/x86/reverse_ipv6_tcp',
                             'stages/linux/x86/meterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x86/meterpreter/reverse_ipv6_tcp'
   end
@@ -5439,7 +4923,6 @@ RSpec.describe 'modules/payloads', :content do
                             'stagers/linux/x86/reverse_nonx_tcp',
                             'stages/linux/x86/meterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x86/meterpreter/reverse_nonx_tcp'
   end
@@ -5450,7 +4933,6 @@ RSpec.describe 'modules/payloads', :content do
                             'stagers/linux/x86/reverse_tcp',
                             'stages/linux/x86/meterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x86/meterpreter/reverse_tcp'
   end
@@ -5461,7 +4943,6 @@ RSpec.describe 'modules/payloads', :content do
                             'stagers/linux/x86/reverse_tcp_uuid',
                             'stages/linux/x86/meterpreter'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x86/meterpreter/reverse_tcp_uuid'
   end
@@ -5471,7 +4952,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                             'singles/linux/x86/meterpreter_reverse_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/x86/meterpreter_reverse_tcp'
   end
@@ -5481,7 +4961,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                             'singles/linux/zarch/meterpreter_reverse_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'linux/zarch/meterpreter_reverse_tcp'
   end
@@ -5491,7 +4970,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                             'singles/r/shell_bind_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'r/shell_bind_tcp'
   end
@@ -5501,7 +4979,6 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                             'singles/r/shell_reverse_tcp'
                           ],
-                          dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'r/shell_reverse_tcp'
   end


### PR DESCRIPTION
Updates payload caching to use dynamic sizes when different payload options generate different payload sizes

This is achieved by creating a second set of payload opts in `payload_cached_size.rb` with the same keys as the original opts, but with larger values. This set of larger opts is then used to determine if a payload is dynamic by comparing the size of the payload instance created with the existing set of opts, and the larger opts.

Also updated the `payload_cached_size_is_consistent.rb` test to use a method of generating modules that's more consistent with `payload_cached_size.rb`, to aid parity. `payload_cached_size_is_consistent.rb` also now determines if a payload is of size `dynamic` programmatically, meaning the `paylaods_spec.rb` file no longer has to set this value.

Setting an additional **100** payloads to `dynamic` size doesn't affect startup time to a noticeable degree. (Tested with this  branch and `upstream-master` running `time ./msfconsole -x exit`). 