### PR TITLE
Add cookie management to HttpClient and improve standards compliance (Content-Type and PRG pattern)

### DIFF
--- a/lib/msf/core/exploit/http/client.rb
+++ b/lib/msf/core/exploit/http/client.rb
@@ -2,6 +2,7 @@
 
 require 'uri'
 require 'digest'
+
 module Msf
 
 ###
@@ -11,6 +12,7 @@ module Msf
 #
 ###
 module Exploit::Remote::HttpClient
+
   include Msf::Auxiliary::Report
 
   #
@@ -48,6 +50,7 @@ module Exploit::Remote::HttpClient
         OptString.new('DOMAIN', [ true, 'The domain to use for Windows authentication', 'WORKSTATION']),
         OptFloat.new('HttpClientTimeout', [false, 'HTTP connection and receive timeout']),
         OptBool.new('HttpPartialResponses', [false, 'Return partial HTTP responses despite timeouts', false]),
+        OptBool.new('HttpKeepCookies', [false, 'Keep cookies from HTTP responses for reuse in HTTP requests', false]),
         OptBool.new('HttpTrace', [false, 'Show the raw HTTP requests and responses', false]),
         OptBool.new('HttpTraceHeadersOnly', [false, 'Show HTTP headers only in HttpTrace', false]),
         OptString.new('HttpTraceColors', [false, 'HTTP request and response colors for HttpTrace (unset to disable)', 'red/blu'])
@@ -88,6 +91,9 @@ module Exploit::Remote::HttpClient
     )
     register_autofilter_ports([ 80, 8080, 443, 8000, 8888, 8880, 8008, 3000, 8443 ])
     register_autofilter_services(%W{ http https })
+
+    # Initialize an empty cookie jar to keep cookies
+    self.cookie_jar = Set.new
   end
 
   def deregister_http_client_options
@@ -314,69 +320,81 @@ module Exploit::Remote::HttpClient
   #
   # Passes +opts+ through directly to Rex::Proto::Http::Client#request_raw.
   #
-  def send_request_raw(opts={}, timeout = 20, disconnect = false)
+  def send_request_raw(opts = {}, timeout = 20, disconnect = false)
     if datastore['HttpClientTimeout'] && datastore['HttpClientTimeout'] > 0
       actual_timeout = datastore['HttpClientTimeout']
     else
-      actual_timeout =  opts[:timeout] || timeout
+      actual_timeout = opts[:timeout] || timeout
     end
 
-    begin
-      c = connect(opts)
-      r = opts[:cgi] ? c.request_cgi(opts) : c.request_raw(opts)
+    c = connect(opts)
+    r = opts[:cgi] ? c.request_cgi(opts) : c.request_raw(opts)
 
-      if datastore['HttpTrace']
-        request_color, response_color =
-          (datastore['HttpTraceColors'] || '').split('/').map { |color| "%bld%#{color}" }
+    if datastore['HttpTrace']
+      request_color, response_color =
+        (datastore['HttpTraceColors'] || '').split('/').map { |color| "%bld%#{color}" }
 
-        request = r.to_s(headers_only: datastore['HttpTraceHeaders'])
+      request = r.to_s(headers_only: datastore['HttpTraceHeaders'])
 
-        print_line('#' * 20)
-        print_line('# Request:')
-        print_line('#' * 20)
-        print_line("%clr#{request_color}#{request}%clr")
-      end
-
-      res = c.send_recv(r, actual_timeout)
-
-      if datastore['HttpTrace']
-        print_line('#' * 20)
-        print_line('# Response:')
-        print_line('#' * 20)
-
-        if res
-          response = res.to_terminal_output(headers_only: datastore['HttpTraceHeadersOnly'])
-
-          print_line("%clr#{response_color}#{response}%clr")
-        else
-          print_line('No response received')
-        end
-      end
-
-      disconnect(c) if disconnect
-
-      res
-    rescue ::Errno::EPIPE, ::Timeout::Error => e
-      print_line(e.message) if datastore['HttpTrace']
-      nil
-    rescue Rex::ConnectionError => e
-      vprint_error(e.to_s)
-      nil
-    rescue ::Exception => e
-      print_line(e.message) if datastore['HttpTrace']
-      raise e
+      print_line('#' * 20)
+      print_line('# Request:')
+      print_line('#' * 20)
+      print_line("%clr#{request_color}#{request}%clr")
     end
+
+    res = c.send_recv(r, actual_timeout)
+
+    if datastore['HttpTrace']
+      print_line('#' * 20)
+      print_line('# Response:')
+      print_line('#' * 20)
+
+      if res
+        response = res.to_terminal_output(headers_only: datastore['HttpTraceHeadersOnly'])
+
+        print_line("%clr#{response_color}#{response}%clr")
+      else
+        print_line('No response received')
+      end
+    end
+
+    disconnect(c) if disconnect
+
+    res
+  rescue ::Errno::EPIPE, ::Timeout::Error => e
+    print_line(e.message) if datastore['HttpTrace']
+    nil
+  rescue Rex::ConnectionError => e
+    vprint_error(e.to_s)
+    nil
+  rescue ::Exception => e
+    print_line(e.message) if datastore['HttpTrace']
+    raise e
   end
-
 
   # Connects to the server, creates a request, sends the request,
   # reads the response
   #
   # Passes `opts` through directly to {Rex::Proto::Http::Client#request_cgi}.
+  # Set `opts['keep_cookies']` to keep cookies from responses for reuse in requests.
   #
   # @return (see Rex::Proto::Http::Client#send_recv))
-  def send_request_cgi(opts={}, timeout = 20, disconnect = true)
-    send_request_raw(opts.merge(cgi: true), timeout, disconnect)
+  def send_request_cgi(opts = {}, timeout = 20, disconnect = true)
+    if cookie_jar.any?
+      opts = { 'cookie' => cookie_jar.to_a.join(' ') }.merge(opts)
+    end
+
+    res = send_request_raw(opts.merge(cgi: true), timeout, disconnect)
+
+    return unless res
+    return res unless res.headers['Set-Cookie'].present?
+
+    if opts['keep_cookies'] || datastore['HttpKeepCookies']
+      # XXX: CGI::Cookie (get_cookies_parsed) is hella broken
+      cookie_jar.merge(res.get_cookies.split(' '))
+    end
+
+    res
   end
 
   # Connects to the server, creates a request, sends the request, reads the
@@ -871,10 +889,10 @@ module Exploit::Remote::HttpClient
     }
   end
 
-protected
+  protected
 
   attr_accessor :client
+  attr_accessor :cookie_jar
 
 end
-
 end

--- a/lib/msf/core/exploit/http/client.rb
+++ b/lib/msf/core/exploit/http/client.rb
@@ -387,23 +387,17 @@ module Exploit::Remote::HttpClient
   #   `opts['redirect_uri']` will contain the full URI.
   #
   # @return (see #send_request_cgi)
-  def send_request_cgi!(opts={}, timeout = 20, redirect_depth = 1)
-    if datastore['HttpClientTimeout'] && datastore['HttpClientTimeout'] > 0
-      actual_timeout = datastore['HttpClientTimeout']
-    else
-      actual_timeout =  opts[:timeout] || timeout
-    end
+  def send_request_cgi!(opts = {}, timeout = 20, redirect_depth = 1)
+    res = send_request_cgi(opts, timeout)
 
-    res = send_request_cgi(opts, actual_timeout)
-    return res unless res && res.redirect? && redirect_depth > 0
+    return unless res
+    return res unless res.redirect? && res.redirection && redirect_depth > 0
 
     redirect_depth -= 1
-    return res if res.redirection.nil?
 
     reconfig_redirect_opts!(res, opts)
-    send_request_cgi!(opts, actual_timeout, redirect_depth)
+    send_request_cgi!(opts, timeout, redirect_depth)
   end
-
 
   # Modifies the HTTP request options for a redirection.
   #
@@ -411,6 +405,13 @@ module Exploit::Remote::HttpClient
   # @param opts [Hash] The HTTP request options to modify.
   # @return [void]
   def reconfig_redirect_opts!(res, opts)
+    # XXX: https://github.com/rapid7/metasploit-framework/issues/12281
+    if opts['method'] == 'POST'
+      opts['method'] = 'GET'
+      opts['data'] = nil
+      opts['vars_post'] = {}
+    end
+
     location = res.redirection
 
     if location.relative?
@@ -425,7 +426,7 @@ module Exploit::Remote::HttpClient
         opts['redirect_uri'] = new_redirect_uri
         opts['uri'] = new_redirect_uri
       end
-      
+
       opts['rhost'] = datastore['RHOST']
       opts['vhost'] = opts['vhost'] || opts['rhost'] || self.vhost()
       opts['rport'] = datastore['RPORT']
@@ -446,6 +447,9 @@ module Exploit::Remote::HttpClient
         opts['SSL'] = false
       end
     end
+
+    # Don't forget any GET parameters
+    opts['query'] ||= location.query if location.query
   end
 
   #

--- a/lib/msf/core/exploit/http/client.rb
+++ b/lib/msf/core/exploit/http/client.rb
@@ -49,8 +49,6 @@ module Exploit::Remote::HttpClient
         OptBool.new('FingerprintCheck', [ false, 'Conduct a pre-exploit fingerprint verification', true]),
         OptString.new('DOMAIN', [ true, 'The domain to use for Windows authentication', 'WORKSTATION']),
         OptFloat.new('HttpClientTimeout', [false, 'HTTP connection and receive timeout']),
-        OptBool.new('HttpPartialResponses', [false, 'Return partial HTTP responses despite timeouts', false]),
-        OptBool.new('HttpKeepCookies', [false, 'Keep cookies from HTTP responses for reuse in HTTP requests', false]),
         OptBool.new('HttpTrace', [false, 'Show the raw HTTP requests and responses', false]),
         OptBool.new('HttpTraceHeadersOnly', [false, 'Show HTTP headers only in HttpTrace', false]),
         OptString.new('HttpTraceColors', [false, 'HTTP request and response colors for HttpTrace (unset to disable)', 'red/blu'])
@@ -174,7 +172,7 @@ module Exploit::Remote::HttpClient
     nclient.set_config(
       'vhost' => opts['vhost'] || opts['rhost'] || self.vhost(),
       'agent' => datastore['UserAgent'],
-      'partial' => opts['partial'] || datastore['HttpPartialResponses'],
+      'partial' => opts['partial'],
       'uri_encode_mode'        => datastore['HTTP::uri_encode_mode'],
       'uri_full_url'           => datastore['HTTP::uri_full_url'],
       'pad_method_uri_count'   => datastore['HTTP::pad_method_uri_count'],
@@ -387,9 +385,8 @@ module Exploit::Remote::HttpClient
     res = send_request_raw(opts.merge(cgi: true), timeout, disconnect)
 
     return unless res
-    return res unless res.headers['Set-Cookie'].present?
 
-    if opts['keep_cookies'] || datastore['HttpKeepCookies']
+    if opts['keep_cookies'] && res.headers['Set-Cookie'].present?
       # XXX: CGI::Cookie (get_cookies_parsed) is hella broken
       cookie_jar.merge(res.get_cookies.split(' '))
     end

--- a/lib/rex/proto/http/client.rb
+++ b/lib/rex/proto/http/client.rb
@@ -123,38 +123,36 @@ class Client
   # @option opts 'vhost'         [String] Host header value
   #
   # @return [ClientRequest]
-  def request_raw(opts={})
+  def request_raw(opts = {})
     opts = self.config.merge(opts)
 
-    opts['ssl']         = self.ssl
-    opts['cgi']         = false
-    opts['port']        = self.port
+    opts['cgi'] = false
+    opts['port'] = self.port
+    opts['ssl'] = self.ssl
 
-    req = ClientRequest.new(opts)
+    ClientRequest.new(opts)
   end
-
 
   #
   # Create a CGI compatible request
   #
   # @param (see #request_raw)
   # @option opts (see #request_raw)
-  # @option opts 'ctype'         [String] Content-Type header value, default: +application/x-www-form-urlencoded+
+  # @option opts 'ctype'         [String] Content-Type header value, default for POST requests: +application/x-www-form-urlencoded+
   # @option opts 'encode_params' [Bool]   URI encode the GET or POST variables (names and values), default: true
   # @option opts 'vars_get'      [Hash]   GET variables as a hash to be translated into a query string
   # @option opts 'vars_post'     [Hash]   POST variables as a hash to be translated into POST data
   #
   # @return [ClientRequest]
-  def request_cgi(opts={})
+  def request_cgi(opts = {})
     opts = self.config.merge(opts)
 
-    opts['ctype']       ||= 'application/x-www-form-urlencoded'
-    opts['ssl']         = self.ssl
-    opts['cgi']         = true
-    opts['port']        = self.port
+    opts['cgi'] = true
+    opts['port'] = self.port
+    opts['ssl'] = self.ssl
+    opts['ctype'] ||= 'application/x-www-form-urlencoded' if opts['method'] == 'POST'
 
-    req = ClientRequest.new(opts)
-    req
+    ClientRequest.new(opts)
   end
 
   #

--- a/lib/rex/proto/http/response.rb
+++ b/lib/rex/proto/http/response.rb
@@ -219,11 +219,9 @@ class Response < Packet
   # @return [URI] the uri of the redirection location.
   # @return [nil] if the response hasn't a Location header or it isn't a valid uri.
   def redirection
-    begin
-      URI(headers['Location'])
-    rescue ::URI::InvalidURIError
-      nil
-    end
+    URI(headers['Location'])
+  rescue ArgumentError, ::URI::InvalidURIError
+    nil
   end
 
   #


### PR DESCRIPTION
# Superseded by #14831

## Synopsis

Set `opts['keep_cookies']` in `send_request_cgi(!)` to keep cookies from HTTP responses for reuse in HTTP requests.

## Usage

This is an example from #14126:

```ruby
res = send_request_cgi!({
  'method' => 'POST',
  'uri' => normalize_uri(target_uri.path, '/owa/auth.owa'),
  'vars_post' => {
    'username' => username,
    'password' => password,
    'flags' => '',
    'destination' => full_uri('/owa/', vhost_uri: true)
  },
  'keep_cookies' => true
}, datastore['HttpClientTimeout'], 2) # timeout and redirect_depth
```

Subsequent `send_request_cgi(!)` calls will use the cookies in the "cookie jar."

## Reviewing

The [abridged diff](https://github.com/rapid7/metasploit-framework/pull/14139/files?diff=unified&w=1) might be useful.

## Testing

You may test against #14126.

## References

Required by #14126. Fixes #12281, #12510, and #12916. See also: #13092.