### PR TITLE
Add a module to enumerate all the installed software and their given versions

### DIFF
--- a/documentation/modules/post/multi/gather/enum_software_versions.md
+++ b/documentation/modules/post/multi/gather/enum_software_versions.md
@@ -3,7 +3,10 @@
   This module uses an existing session on any Windows, Linux, BSD, Solaris, OSX or Android machine
   to gather information about all software installed on the target machine and their versions.
 
-  This module therefore targets any machine running Windows, Linux, BSD, Solaris, OSX, or Android.
+  This module therefore targets any machine running Windows, Linux, BSD, Solaris, OSX, or Android. Note
+  that for Linux systems, software enumeration is done via package managers. As a result the results may
+  not reflect all of the available software on the system simply because users may have installed additional
+  software from alternative sources such as source code that these package managers are not aware of.
 
 ## Verification Steps
 

--- a/documentation/modules/post/multi/gather/enum_software_versions.md
+++ b/documentation/modules/post/multi/gather/enum_software_versions.md
@@ -1,0 +1,48 @@
+## Vulnerable Application
+
+  This module uses an existing session on any Windows, Linux, BSD, Solaris, OSX or Android machine
+  to gather information about all software installed on the target machine and their versions.
+
+  This module therefore targets any machine running Windows, Linux, BSD, Solaris, OSX, or Android.
+
+## Verification Steps
+
+  1. Get session
+  2. Do `use post/multi/gather/enum_software_versions`
+  3. Do `set SESSION <session id>`
+  4. Do `run`
+  5. See loot.
+
+## Options
+
+This module does not use any special options beyond the standard `SESSION` option which 
+is set to the value of the session the user wishes to run this module on.
+
+## Scenarios
+
+### Windows Server 2019 Standard Edition x64 Running as a Low Privileged User
+```
+msf6 exploit(multi/handler) > use post/multi/gather/enum_software_versions 
+msf6 post(multi/gather/enum_software_versions) > show options
+
+Module options (post/multi/gather/enum_software_versions):
+
+   Name     Current Setting  Required  Description
+   ----     ---------------  --------  -----------
+   SESSION                   yes       The session to run this module on.
+
+msf6 post(multi/gather/enum_software_versions) > set SESSION 1 
+SESSION => 1
+msf6 post(multi/gather/enum_software_versions) > run
+
+[+] Stored information about the installed products to the loot file at /home/gwillcox/.msf4/loot/20200915173649_default_172.27.37.216_host.windows.sof_930739.txt
+[*] Post module execution completed
+msf6 post(multi/gather/enum_software_versions) > cat /home/gwillcox/.msf4/loot/20200915173649_default_172.27.37.216_host.windows.sof_930739.txt
+[*] exec: cat /home/gwillcox/.msf4/loot/20200915173649_default_172.27.37.216_host.windows.sof_930739.txt
+
+Description                     InstallDate  Name                            Version      
+Pragma TelnetServer             20200911     Pragma TelnetServer             7.0.10.1990  
+Google Update Helper            20200910     Google Update Helper            1.3.35.451   
+VanDyke Software SecureCRT 8.7  20200911     VanDyke Software SecureCRT 8.7  8.7.3        
+msf6 post(multi/gather/enum_software_versions) > 
+```

--- a/modules/post/multi/gather/enum_software_versions.rb
+++ b/modules/post/multi/gather/enum_software_versions.rb
@@ -5,22 +5,27 @@
 
 class MetasploitModule < Msf::Post
 
-  def initialize(info={})
-    super( update_info( info,
-        'Name'          => 'Multiplatform Installed Software Version',
-        'Description'   => %q{ This module, when run against a compromised machine, will gather details on all installed software, 
-        including their versions and if available, when they were installed, and will save it into a loot file for later use. 
-        Users can then use this loot file to determine what additional vulnerabilites may affect the target machine. },
-        'License'       => MSF_LICENSE,
-        'Author'        => [ 'gwillcox-r7' ],
-        'Platform'      => %w{ win linux osx bsd solaris android },
-        #'Platform'      => %w{ android osx win linux bsd solaris },
-        'SessionTypes'  => [ 'meterpreter', 'shell' ],
-      ))
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Multiplatform Installed Software Version',
+        'Description' => %q{
+          This module, when run against a compromised machine, will gather details on all installed software,
+          including their versions and if available, when they were installed, and will save it into a loot file for later use.
+          Users can then use this loot file to determine what additional vulnerabilites may affect the target machine.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [ 'gwillcox-r7' ],
+        'Platform' => %w[win linux osx bsd solaris android],
+        # 'Platform'      => %w{ android osx win linux bsd solaris },
+        'SessionTypes' => [ 'meterpreter', 'shell' ]
+      )
+    )
   end
 
   def store_linux_loot(listing)
-    file = store_loot("host.linux.software.versions", "text/plain", session, listing, "installed_software.txt", "Installed Software and Versions")
+    file = store_loot('host.linux.software.versions', 'text/plain', session, listing, 'installed_software.txt', 'Installed Software and Versions')
     print_good("Stored information about the installed products to the loot file at #{file}")
   end
 
@@ -28,105 +33,107 @@ class MetasploitModule < Msf::Post
   def run
     case session.platform
     when 'windows'
-        listing = cmd_exec('wmic product get Name, Description, Version, InstallDate', nil, 6000)
-        unless listing =~ /Description/
-            print_error("Was unable to get a listing of installed products...")
-            return nil
-        end
-        file = store_loot("host.windows.software.versions", "text/plain", session, listing, "installed_software.txt", "Installed Software and Versions")
-        print_good("Stored information about the installed products to the loot file at #{file}")
+      listing = cmd_exec('wmic product get Name, Description, Version, InstallDate', nil, 6000)
+      unless listing =~ /Description/
+        print_error('Was unable to get a listing of installed products...')
+        return nil
+      end
+      file = store_loot('host.windows.software.versions', 'text/plain', session, listing, 'installed_software.txt', 'Installed Software and Versions')
+      print_good("Stored information about the installed products to the loot file at #{file}")
     when 'linux'
-        # All of the following options were taken from https://distrowatch.com/dwres.php?resource=package-management
-        operating_system = cmd_exec('hostnamectl')
-        if operating_system =~ /not found/
-            print_error("Can't determine the host's OS, as the 'hostnamectl' command was not found")
-            return nil
-        elsif operating_system =~ /ubuntu/i || operating_system =~ /debian/i || operating_system =~ /elementary/i || operating_system =~ /mint/i || operating_system =~ /MX/ || operating_system =~ /zorin/i || operating_system =~ /kali/i
-            listing = cmd_exec('apt list --installed')
-            if listing =~ /not found/
-                print_error("The command 'apt' does not exist on the host")
-                return nil
-            end
-            unless listing =~ /listing\.\./i
-                print_error("Was unable to dump the versions of software installed!")
-                return nil
-            end
-            store_linux_loot(listing)
-        elsif operating_system =~ / [aA]rch / || operating_system =~ /manjaro/i
-            listing = cmd_exec('pacman -Q')
-            if listing =~ /not found/
-                print_error("The command 'pacman' does not exist on the host")
-                return nil
-            end
-            store_linux_loot(listing)
-        elsif operating_system =~ /opensuse/i
-            listing = cmd_exec('zypper search -is')
-            if listing =~ /not found/
-                print_error("The command 'zypper' does not exist on the host")
-                return nil
-            end
-            store_linux_loot(listing)
-        elsif operating_system =~ /fedora/i || operating_system =~ /centos/i
-            listing = cmd_exec('rpm -qa')
-            if listing =~ /not found/
-                print_error("The command 'rpm' does not exist on the host")
-                return nil
-            end
-            store_linux_loot(listing)
-        elsif operating_system =~ /alpine/i
-            listing = cmd_exec('apk info')
-            if listing =~ /not found/
-                print_error("The command 'apk' does not exist on the host")
-                return nil
-            end
-            store_linux_loot(listing)
-        elsif operating_system =~ /gentoo/i
-            listing = cmd_exec('qlist -i')
-            if listing =~ /not found/
-                print_error("The command 'qlist' does not exist on the host")
-                return nil
-            end
-            store_linux_loot(listing)
-        elsif operating_system =~ /freebsd/i
-            listing = cmd_exec('pkg info')
-            if listing =~ /not found/
-                print_error("The command 'pkg' does not exist on the host")
-                return nil
-            end
-            store_linux_loot(listing)
-        else
-            print_error("The target's operating system is not supported at this time.")
-            return nil
-        end
-    when 'bsd'
-        listing = cmd_exec('pkg info')
+      # All of the following options were taken from https://distrowatch.com/dwres.php?resource=package-management
+      operating_system = cmd_exec('hostnamectl')
+      if operating_system =~ /not found/
+        print_error("Can't determine the host's OS, as the 'hostnamectl' command was not found")
+        return nil
+      elsif operating_system =~ /ubuntu/i || operating_system =~ /debian/i || operating_system =~ /elementary/i || operating_system =~ /mint/i || operating_system =~ /MX/ || operating_system =~ /zorin/i || operating_system =~ /kali/i
+        listing = cmd_exec('apt list --installed')
         if listing =~ /not found/
-            print_error("The command 'pkg' does not exist on the host")
-            return nil
+          print_error("The command 'apt' does not exist on the host")
+          return nil
+        end
+        unless listing =~ /listing\.\./i
+          print_error('Was unable to dump the versions of software installed!')
+          return nil
         end
         store_linux_loot(listing)
-    when 'osx'
-        listing = cmd_exec('system_profiler SPApplicationsDataType')
+      elsif operating_system =~ / [aA]rch / || operating_system =~ /manjaro/i
+        listing = cmd_exec('pacman -Q')
         if listing =~ /not found/
-            print_error("The command 'system_profiler' does not exist on the host")
-            return nil
+          print_error("The command 'pacman' does not exist on the host")
+          return nil
         end
-        file = store_loot("host.osx.software.versions", "text/plain", session, listing, "installed_software.txt", "Installed Software and Versions")
-        print_good("Stored information about the installed products to the loot file at #{file}")
-    when 'solaris'
+        store_linux_loot(listing)
+      elsif operating_system =~ /opensuse/i
+        listing = cmd_exec('zypper search -is')
+        if listing =~ /not found/
+          print_error("The command 'zypper' does not exist on the host")
+          return nil
+        end
+        store_linux_loot(listing)
+      elsif operating_system =~ /fedora/i || operating_system =~ /centos/i
+        listing = cmd_exec('rpm -qa')
+        if listing =~ /not found/
+          print_error("The command 'rpm' does not exist on the host")
+          return nil
+        end
+        store_linux_loot(listing)
+      elsif operating_system =~ /alpine/i
+        listing = cmd_exec('apk info')
+        if listing =~ /not found/
+          print_error("The command 'apk' does not exist on the host")
+          return nil
+        end
+        store_linux_loot(listing)
+      elsif operating_system =~ /gentoo/i
+        listing = cmd_exec('qlist -i')
+        if listing =~ /not found/
+          print_error("The command 'qlist' does not exist on the host")
+          return nil
+        end
+        store_linux_loot(listing)
+      elsif operating_system =~ /freebsd/i
         listing = cmd_exec('pkg info')
         if listing =~ /not found/
-            print_error("The command 'pkg' does not exist on the host")
-            return nil
+          print_error("The command 'pkg' does not exist on the host")
+          return nil
         end
-        file = store_loot("host.solaris.software.versions", "text/plain", session, listing, "installed_software.txt", "Installed Software and Versions")
-        print_good("Stored information about the installed products to the loot file at #{file}")
+        store_linux_loot(listing)
+      else
+        print_error("The target's operating system is not supported at this time.")
+        return nil
+      end
+    when 'bsd'
+      listing = cmd_exec('pkg info')
+      if listing =~ /not found/
+        print_error("The command 'pkg' does not exist on the host")
+        return nil
+      end
+      store_linux_loot(listing)
+    when 'osx'
+      listing = cmd_exec('system_profiler SPApplicationsDataType')
+      if listing =~ /not found/
+        print_error("The command 'system_profiler' does not exist on the host")
+        return nil
+      end
+      file = store_loot('host.osx.software.versions', 'text/plain', session, listing, 'installed_software.txt', 'Installed Software and Versions')
+      print_good("Stored information about the installed products to the loot file at #{file}")
+    when 'solaris'
+      listing = cmd_exec('pkg info')
+      if listing =~ /not found/
+        print_error("The command 'pkg' does not exist on the host")
+        return nil
+      end
+      file = store_loot('host.solaris.software.versions', 'text/plain', session, listing, 'installed_software.txt', 'Installed Software and Versions')
+      print_good("Stored information about the installed products to the loot file at #{file}")
     when 'android'
-        listing = cmd_exec('pm list packages -f')
+      listing = cmd_exec('pm list packages -f')
+      if listing =~ /not found/
+        print_error("The command 'pkg' does not exist on the host")
+        return nil
+      end
+      file = store_loot('host.android.software.versions', 'text/plain', session, listing, 'installed_software.txt', 'Installed Software and Versions')
+      print_good("Stored information about the installed products to the loot file at #{file}")
     end
-
-  rescue Rex::TimeoutError, Rex::Post::Meterpreter::RequestError
-  rescue ::Exception => e
-    print_status("The following error was encountered: #{e.class} #{e}")
   end
 end

--- a/modules/post/multi/gather/enum_software_versions.rb
+++ b/modules/post/multi/gather/enum_software_versions.rb
@@ -45,31 +45,25 @@ class MetasploitModule < Msf::Post
       print_good("Stored information about the installed products to the loot file at #{file}")
     when 'linux'
       # All of the following options were taken from https://distrowatch.com/dwres.php?resource=package-management
-      cmd = %w[hostnamectl]
-      if command_exists?('hostnamectl') == false
-        print_error("The 'hostnamectl' command doesn't exist on the host, so we can't enumerate what OS this Linux host is running!")
-        return
-      end
-      operating_system = cmd_exec(cmd[0]).to_s
-      if operating_system.empty?
-        print_error('No results were returned when trying to determine the OS. An error likely occured.')
-        return
-      end
-      case operating_system
-      when /(?:[uU]buntu|[dD]ebian|[eE]lementary|[mM]int|MX|[zZ]orin|[kK]ali)/
+      # and further verified against VMs that were set up in testing labs.
+      if command_exists?('apt') # Debian, Ubuntu, and Debian derived distros.
         cmd = %w[apt list --installed]
-      when /(?: [aA]rch |[mM]anjaro)/
+      elsif command_exists?('pacman') # Arch and Manjaro are two popular examples
         cmd = %w[pacman -Q]
-      when /opensuse/i
+      elsif command_exists?('zypper')  # OpenSuse is a popular example
         cmd = %w[zypper search -is]
-      when /(?:fedora|centos|red hat enterprise linux)/i
+      elsif command_exists?('rpm') # Fedora, Centos, RHEL
         cmd = %w[rpm -qa]
-      when /alpine/i
+      elsif command_exists?('apk') # Apline
         cmd = %w[apk info -v]
-      when /gentoo/i
+      elsif command_exists?('qlist') # Gentoo
         cmd = %w[qlist -Iv]
-      when /freebsd/i
+      elsif command_exists?('pkg') # FreeBSD
         cmd = %w[pkg info]
+      else
+        print_error("The target system either doesn't have a package manager system, or does not use a known package manager system!")
+        print_error('Unable to enumerate the softwaare on the target system. Exiting...')
+        return nil
       end
 
       if command_exists?((cmd[0]).to_s) == false

--- a/modules/post/multi/gather/enum_software_versions.rb
+++ b/modules/post/multi/gather/enum_software_versions.rb
@@ -32,6 +32,10 @@ class MetasploitModule < Msf::Post
   def run
     case session.platform
     when 'windows'
+      if command_exists?('wmic') == false
+        print_error("The 'wmic' command doesn't exist on this host!") # wmic is technically marked as depreciated so this command could very well be removed in future releases.
+        return nil
+      end
       listing = cmd_exec('wmic product get Name, Description, Version, InstallDate', nil, 6000)
       unless listing.include?('Description')
         print_error('Was unable to get a listing of installed products...')
@@ -42,6 +46,10 @@ class MetasploitModule < Msf::Post
     when 'linux'
       # All of the following options were taken from https://distrowatch.com/dwres.php?resource=package-management
       cmd = %w{ 'hostnamectl' }
+      if command_exists?('hostnamectl') == false
+        print_error("The 'hostnamectl' command doesn't exist on the host, so we can't enumerate what OS this Linux host is running!")
+        return nil
+      end
       operating_system = cmd_exec("#{cmd[0]}")
       case operating_system
       when /(?:[uU]buntu|[dD]ebian|[eE]lementary|[mM]int|MX|[zZ]orin|[kK]ali)/
@@ -60,42 +68,35 @@ class MetasploitModule < Msf::Post
         cmd = %w{ 'pkg info' }
       end
 
-      if (listing = cmd_exec(cmd)) =~ /not found/
+      if (command_exists?("#{cmd[0]}")) == false
         print_error("The command #{cmd[0]} was not found on the target.")
         return nil
       else
+        listing = cmd_exec(cmd.join(' '))
         store_linux_loot(listing)
       end
-    when 'bsd'
-      listing = cmd_exec('pkg info')
-      if listing =~ /not found/
+    when 'bsd','solaris'
+      if command_exists?('pkg') == false
         print_error("The command 'pkg' does not exist on the host")
         return nil
       end
-      file = store_loot('host.bsd.software.versions', 'text/plain', session, listing, 'installed_software.txt', 'Installed Software and Versions')
+      listing = cmd_exec('pkg info')
+      file = store_loot('host.bsd.solaris.software.versions', 'text/plain', session, listing, 'installed_software.txt', 'Installed Software and Versions')
       print_good("Stored information about the installed products to the loot file at #{file}")
     when 'osx'
-      listing = cmd_exec('system_profiler SPApplicationsDataType')
-      if listing =~ /not found/
+      if command_exists?('system_profiler') == false
         print_error("The command 'system_profiler' does not exist on the host")
         return nil
       end
+      listing = cmd_exec('system_profiler SPApplicationsDataType')
       file = store_loot('host.osx.software.versions', 'text/plain', session, listing, 'installed_software.txt', 'Installed Software and Versions')
       print_good("Stored information about the installed products to the loot file at #{file}")
-    when 'solaris'
-      listing = cmd_exec('pkg info')
-      if listing =~ /not found/
-        print_error("The command 'pkg' does not exist on the host")
-        return nil
-      end
-      file = store_loot('host.solaris.software.versions', 'text/plain', session, listing, 'installed_software.txt', 'Installed Software and Versions')
-      print_good("Stored information about the installed products to the loot file at #{file}")
     when 'android'
-      listing = cmd_exec('pm list packages -f')
-      if listing =~ /not found/
+      if command_exists?('pm') == false
         print_error("The command 'pm' does not exist on the host")
         return nil
       end
+      listing = cmd_exec('pm list packages -f')
       file = store_loot('host.android.software.versions', 'text/plain', session, listing, 'installed_software.txt', 'Installed Software and Versions')
       print_good("Stored information about the installed products to the loot file at #{file}")
     end

--- a/modules/post/multi/gather/enum_software_versions.rb
+++ b/modules/post/multi/gather/enum_software_versions.rb
@@ -9,7 +9,7 @@ class MetasploitModule < Msf::Post
     super(
       update_info(
         info,
-        'Name' => 'Multiplatform Installed Software Version',
+        'Name' => 'Multiplatform Installed Software Version Enumerator',
         'Description' => %q{
           This module, when run against a compromised machine, will gather details on all installed software,
           including their versions and if available, when they were installed, and will save it into a loot file for later use.
@@ -18,7 +18,6 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => [ 'gwillcox-r7' ],
         'Platform' => %w[win linux osx bsd solaris android],
-        # 'Platform'      => %w{ android osx win linux bsd solaris },
         'SessionTypes' => [ 'meterpreter', 'shell' ]
       )
     )
@@ -34,7 +33,7 @@ class MetasploitModule < Msf::Post
     case session.platform
     when 'windows'
       listing = cmd_exec('wmic product get Name, Description, Version, InstallDate', nil, 6000)
-      unless listing =~ /Description/
+      unless listing.include?('Description')
         print_error('Was unable to get a listing of installed products...')
         return nil
       end
@@ -42,66 +41,29 @@ class MetasploitModule < Msf::Post
       print_good("Stored information about the installed products to the loot file at #{file}")
     when 'linux'
       # All of the following options were taken from https://distrowatch.com/dwres.php?resource=package-management
-      operating_system = cmd_exec('hostnamectl')
-      if operating_system =~ /not found/
-        print_error("Can't determine the host's OS, as the 'hostnamectl' command was not found")
-        return nil
-      elsif operating_system =~ /ubuntu/i || operating_system =~ /debian/i || operating_system =~ /elementary/i || operating_system =~ /mint/i || operating_system =~ /MX/ || operating_system =~ /zorin/i || operating_system =~ /kali/i
-        listing = cmd_exec('apt list --installed')
-        if listing =~ /not found/
-          print_error("The command 'apt' does not exist on the host")
-          return nil
-        end
-        unless listing =~ /listing\.\./i
-          print_error('Was unable to dump the versions of software installed!')
-          return nil
-        end
-        store_linux_loot(listing)
-      elsif operating_system =~ / [aA]rch / || operating_system =~ /manjaro/i
-        listing = cmd_exec('pacman -Q')
-        if listing =~ /not found/
-          print_error("The command 'pacman' does not exist on the host")
-          return nil
-        end
-        store_linux_loot(listing)
+      cmd = %w{ 'hostnamectl' }
+      operating_system = cmd_exec("#{cmd[0]}")
+      if operating_system =~ /(?:[uU]buntu|[dD]ebian|[eE]lementary|[mM]int|MX|[zZ]orin|[kK]ali)/
+        cmd = %w{ 'apt list --installed' }
+      elsif operating_system =~ /(?: [aA]rch |[mM]anjaro)/
+        cmd = %w{ 'pacman -Q' }
       elsif operating_system =~ /opensuse/i
-        listing = cmd_exec('zypper search -is')
-        if listing =~ /not found/
-          print_error("The command 'zypper' does not exist on the host")
-          return nil
-        end
-        store_linux_loot(listing)
-      elsif operating_system =~ /fedora/i || operating_system =~ /centos/i
-        listing = cmd_exec('rpm -qa')
-        if listing =~ /not found/
-          print_error("The command 'rpm' does not exist on the host")
-          return nil
-        end
-        store_linux_loot(listing)
+        cmd = %w{ 'zypper search -is' }
+      elsif operating_system =~ /(?:fedora|centos|red hat enterprise linux)/i
+        cmd = %w{ 'rpm -qa' }
       elsif operating_system =~ /alpine/i
-        listing = cmd_exec('apk info')
-        if listing =~ /not found/
-          print_error("The command 'apk' does not exist on the host")
-          return nil
-        end
-        store_linux_loot(listing)
+        cmd = %w{ 'apk info' }
       elsif operating_system =~ /gentoo/i
-        listing = cmd_exec('qlist -i')
-        if listing =~ /not found/
-          print_error("The command 'qlist' does not exist on the host")
-          return nil
-        end
-        store_linux_loot(listing)
+        cmd = %w{ 'qlist -i' }
       elsif operating_system =~ /freebsd/i
-        listing = cmd_exec('pkg info')
-        if listing =~ /not found/
-          print_error("The command 'pkg' does not exist on the host")
-          return nil
-        end
-        store_linux_loot(listing)
-      else
-        print_error("The target's operating system is not supported at this time.")
+        cmd = %w{ 'pkg info' }
+      end
+      
+      if (listing = cmd_exec(cmd)) =~ /not found/
+        print_error("The command #{cmd[0]} was not found on the target.")
         return nil
+      else
+        store_linux_loot(listing)
       end
     when 'bsd'
       listing = cmd_exec('pkg info')
@@ -109,7 +71,8 @@ class MetasploitModule < Msf::Post
         print_error("The command 'pkg' does not exist on the host")
         return nil
       end
-      store_linux_loot(listing)
+      file = store_loot('host.bsd.software.versions', 'text/plain', session, listing, 'installed_software.txt', 'Installed Software and Versions')
+      print_good("Stored information about the installed products to the loot file at #{file}")
     when 'osx'
       listing = cmd_exec('system_profiler SPApplicationsDataType')
       if listing =~ /not found/
@@ -129,7 +92,7 @@ class MetasploitModule < Msf::Post
     when 'android'
       listing = cmd_exec('pm list packages -f')
       if listing =~ /not found/
-        print_error("The command 'pkg' does not exist on the host")
+        print_error("The command 'pm' does not exist on the host")
         return nil
       end
       file = store_loot('host.android.software.versions', 'text/plain', session, listing, 'installed_software.txt', 'Installed Software and Versions')

--- a/modules/post/multi/gather/enum_software_versions.rb
+++ b/modules/post/multi/gather/enum_software_versions.rb
@@ -48,9 +48,11 @@ class MetasploitModule < Msf::Post
       # and further verified against VMs that were set up in testing labs.
       if command_exists?('apt') # Debian, Ubuntu, and Debian derived distros.
         cmd = %w[apt list --installed]
+      elsif command_exists?('dpkg') # Alternative for Debian based systems
+        cmd = %w[dpkg -l]
       elsif command_exists?('pacman') # Arch and Manjaro are two popular examples
         cmd = %w[pacman -Q]
-      elsif command_exists?('zypper')  # OpenSuse is a popular example
+      elsif command_exists?('zypper') # OpenSUSE is a popular example
         cmd = %w[zypper search -is]
       elsif command_exists?('rpm') # Fedora, Centos, RHEL
         cmd = %w[rpm -qa]
@@ -60,6 +62,10 @@ class MetasploitModule < Msf::Post
         cmd = %w[qlist -Iv]
       elsif command_exists?('pkg') # FreeBSD
         cmd = %w[pkg info]
+      elsif command_exists?('equo') # Sabayon
+        cmd = %w[equo q list installed -v]
+      elsif command_exists?('nix-env')
+        cmd = %w[nix-env -q]
       else
         print_error("The target system either doesn't have a package manager system, or does not use a known package manager system!")
         print_error('Unable to enumerate the softwaare on the target system. Exiting...')

--- a/modules/post/multi/gather/enum_software_versions.rb
+++ b/modules/post/multi/gather/enum_software_versions.rb
@@ -3,8 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-require 'rex/google/geolocation'
-
 class MetasploitModule < Msf::Post
 
   def initialize(info={})
@@ -123,6 +121,8 @@ class MetasploitModule < Msf::Post
         end
         file = store_loot("host.solaris.software.versions", "text/plain", session, listing, "installed_software.txt", "Installed Software and Versions")
         print_good("Stored information about the installed products to the loot file at #{file}")
+    when 'android'
+        listing = cmd_exec('pm list packages -f')
     end
 
   rescue Rex::TimeoutError, Rex::Post::Meterpreter::RequestError

--- a/modules/post/multi/gather/enum_software_versions.rb
+++ b/modules/post/multi/gather/enum_software_versions.rb
@@ -1,0 +1,132 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'rex/google/geolocation'
+
+class MetasploitModule < Msf::Post
+
+  def initialize(info={})
+    super( update_info( info,
+        'Name'          => 'Multiplatform Installed Software Version',
+        'Description'   => %q{ This module, when run against a compromised machine, will gather details on all installed software, 
+        including their versions and if available, when they were installed, and will save it into a loot file for later use. 
+        Users can then use this loot file to determine what additional vulnerabilites may affect the target machine. },
+        'License'       => MSF_LICENSE,
+        'Author'        => [ 'gwillcox-r7' ],
+        'Platform'      => %w{ win linux osx bsd solaris android },
+        #'Platform'      => %w{ android osx win linux bsd solaris },
+        'SessionTypes'  => [ 'meterpreter', 'shell' ],
+      ))
+  end
+
+  def store_linux_loot(listing)
+    file = store_loot("host.linux.software.versions", "text/plain", session, listing, "installed_software.txt", "Installed Software and Versions")
+    print_good("Stored information about the installed products to the loot file at #{file}")
+  end
+
+  # Run Method for when run command is issued
+  def run
+    case session.platform
+    when 'windows'
+        listing = cmd_exec('wmic product get Name, Description, Version, InstallDate', nil, 6000)
+        unless listing =~ /Description/
+            print_error("Was unable to get a listing of installed products...")
+            return nil
+        end
+        file = store_loot("host.windows.software.versions", "text/plain", session, listing, "installed_software.txt", "Installed Software and Versions")
+        print_good("Stored information about the installed products to the loot file at #{file}")
+    when 'linux'
+        # All of the following options were taken from https://distrowatch.com/dwres.php?resource=package-management
+        operating_system = cmd_exec('hostnamectl')
+        if operating_system =~ /not found/
+            print_error("Can't determine the host's OS, as the 'hostnamectl' command was not found")
+            return nil
+        elsif operating_system =~ /ubuntu/i || operating_system =~ /debian/i || operating_system =~ /elementary/i || operating_system =~ /mint/i || operating_system =~ /MX/ || operating_system =~ /zorin/i || operating_system =~ /kali/i
+            listing = cmd_exec('apt list --installed')
+            if listing =~ /not found/
+                print_error("The command 'apt' does not exist on the host")
+                return nil
+            end
+            unless listing =~ /listing\.\./i
+                print_error("Was unable to dump the versions of software installed!")
+                return nil
+            end
+            store_linux_loot(listing)
+        elsif operating_system =~ / [aA]rch / || operating_system =~ /manjaro/i
+            listing = cmd_exec('pacman -Q')
+            if listing =~ /not found/
+                print_error("The command 'pacman' does not exist on the host")
+                return nil
+            end
+            store_linux_loot(listing)
+        elsif operating_system =~ /opensuse/i
+            listing = cmd_exec('zypper search -is')
+            if listing =~ /not found/
+                print_error("The command 'zypper' does not exist on the host")
+                return nil
+            end
+            store_linux_loot(listing)
+        elsif operating_system =~ /fedora/i || operating_system =~ /centos/i
+            listing = cmd_exec('rpm -qa')
+            if listing =~ /not found/
+                print_error("The command 'rpm' does not exist on the host")
+                return nil
+            end
+            store_linux_loot(listing)
+        elsif operating_system =~ /alpine/i
+            listing = cmd_exec('apk info')
+            if listing =~ /not found/
+                print_error("The command 'apk' does not exist on the host")
+                return nil
+            end
+            store_linux_loot(listing)
+        elsif operating_system =~ /gentoo/i
+            listing = cmd_exec('qlist -i')
+            if listing =~ /not found/
+                print_error("The command 'qlist' does not exist on the host")
+                return nil
+            end
+            store_linux_loot(listing)
+        elsif operating_system =~ /freebsd/i
+            listing = cmd_exec('pkg info')
+            if listing =~ /not found/
+                print_error("The command 'pkg' does not exist on the host")
+                return nil
+            end
+            store_linux_loot(listing)
+        else
+            print_error("The target's operating system is not supported at this time.")
+            return nil
+        end
+    when 'bsd'
+        listing = cmd_exec('pkg info')
+        if listing =~ /not found/
+            print_error("The command 'pkg' does not exist on the host")
+            return nil
+        end
+        store_linux_loot(listing)
+    when 'osx'
+        listing = cmd_exec('system_profiler SPApplicationsDataType')
+        if listing =~ /not found/
+            print_error("The command 'system_profiler' does not exist on the host")
+            return nil
+        end
+        file = store_loot("host.osx.software.versions", "text/plain", session, listing, "installed_software.txt", "Installed Software and Versions")
+        print_good("Stored information about the installed products to the loot file at #{file}")
+    when 'solaris'
+        listing = cmd_exec('pkg info')
+        if listing =~ /not found/
+            print_error("The command 'pkg' does not exist on the host")
+            return nil
+        end
+        file = store_loot("host.solaris.software.versions", "text/plain", session, listing, "installed_software.txt", "Installed Software and Versions")
+        print_good("Stored information about the installed products to the loot file at #{file}")
+    end
+
+  rescue Rex::TimeoutError, Rex::Post::Meterpreter::RequestError
+  rescue ::Exception => e
+    print_status("The following error was encountered: #{e.class} #{e}")
+  end
+end

--- a/modules/post/multi/gather/enum_software_versions.rb
+++ b/modules/post/multi/gather/enum_software_versions.rb
@@ -34,12 +34,12 @@ class MetasploitModule < Msf::Post
     when 'windows'
       if command_exists?('wmic') == false
         print_error("The 'wmic' command doesn't exist on this host!") # wmic is technically marked as depreciated so this command could very well be removed in future releases.
-        return nil
+        return
       end
-      listing = cmd_exec('wmic product get Name, Description, Version, InstallDate', nil, 6000)
+      listing = cmd_exec('wmic product get Name, Description, Version, InstallDate',, 6000).to_s
       unless listing.include?('Description')
         print_error('Was unable to get a listing of installed products...')
-        return nil
+        return
       end
       file = store_loot('host.windows.software.versions', 'text/plain', session, listing, 'installed_software.txt', 'Installed Software and Versions')
       print_good("Stored information about the installed products to the loot file at #{file}")
@@ -48,9 +48,13 @@ class MetasploitModule < Msf::Post
       cmd = %w{ 'hostnamectl' }
       if command_exists?('hostnamectl') == false
         print_error("The 'hostnamectl' command doesn't exist on the host, so we can't enumerate what OS this Linux host is running!")
-        return nil
+        return
       end
-      operating_system = cmd_exec("#{cmd[0]}")
+      operating_system = cmd_exec("#{cmd[0]}").to_s
+      if operating_system.empty?
+        print_error("No results were returned when trying to determine the OS. An error likely occured.")
+        return
+      end
       case operating_system
       when /(?:[uU]buntu|[dD]ebian|[eE]lementary|[mM]int|MX|[zZ]orin|[kK]ali)/
         cmd = %w{ 'apt list --installed' }
@@ -70,33 +74,49 @@ class MetasploitModule < Msf::Post
 
       if (command_exists?("#{cmd[0]}")) == false
         print_error("The command #{cmd[0]} was not found on the target.")
-        return nil
+        return
       else
-        listing = cmd_exec(cmd.join(' '))
+        listing = cmd_exec(cmd.join(' ')).to_s
+        if listing.empty?
+            print_error("No results were returned when trying to get software installed on the Linux host. An error likely occured.")
+            return
+        end
         store_linux_loot(listing)
       end
     when 'bsd','solaris'
       if command_exists?('pkg') == false
         print_error("The command 'pkg' does not exist on the host")
-        return nil
+        return
       end
-      listing = cmd_exec('pkg info')
+      listing = cmd_exec('pkg info').to_s
+      if listing.empty?
+        print_error("No results were returned when trying to get software installed on the BSD/Solaris host. An error likely occured.")
+        return
+      end
       file = store_loot('host.bsd.solaris.software.versions', 'text/plain', session, listing, 'installed_software.txt', 'Installed Software and Versions')
       print_good("Stored information about the installed products to the loot file at #{file}")
     when 'osx'
       if command_exists?('system_profiler') == false
         print_error("The command 'system_profiler' does not exist on the host")
-        return nil
+        return
       end
-      listing = cmd_exec('system_profiler SPApplicationsDataType')
+      listing = cmd_exec('system_profiler SPApplicationsDataType').to_s
+      if listing.empty?
+        print_error("No results were returned when trying to get software installed on the OSX host. An error likely occured.")
+        return
+      end
       file = store_loot('host.osx.software.versions', 'text/plain', session, listing, 'installed_software.txt', 'Installed Software and Versions')
       print_good("Stored information about the installed products to the loot file at #{file}")
     when 'android'
       if command_exists?('pm') == false
         print_error("The command 'pm' does not exist on the host")
-        return nil
+        return
       end
-      listing = cmd_exec('pm list packages -f')
+      listing = cmd_exec('pm list packages -f').to_s
+      if listing.empty?
+        print_error("No results were returned when trying to get software installed on the Linux host. An error likely occured.")
+        return
+      end
       file = store_loot('host.android.software.versions', 'text/plain', session, listing, 'installed_software.txt', 'Installed Software and Versions')
       print_good("Stored information about the installed products to the loot file at #{file}")
     end

--- a/modules/post/multi/gather/enum_software_versions.rb
+++ b/modules/post/multi/gather/enum_software_versions.rb
@@ -43,19 +43,20 @@ class MetasploitModule < Msf::Post
       # All of the following options were taken from https://distrowatch.com/dwres.php?resource=package-management
       cmd = %w{ 'hostnamectl' }
       operating_system = cmd_exec("#{cmd[0]}")
-      if operating_system =~ /(?:[uU]buntu|[dD]ebian|[eE]lementary|[mM]int|MX|[zZ]orin|[kK]ali)/
+      case operating_system
+      when /(?:[uU]buntu|[dD]ebian|[eE]lementary|[mM]int|MX|[zZ]orin|[kK]ali)/
         cmd = %w{ 'apt list --installed' }
-      elsif operating_system =~ /(?: [aA]rch |[mM]anjaro)/
+      when /(?: [aA]rch |[mM]anjaro)/
         cmd = %w{ 'pacman -Q' }
-      elsif operating_system =~ /opensuse/i
+      when /opensuse/i
         cmd = %w{ 'zypper search -is' }
-      elsif operating_system =~ /(?:fedora|centos|red hat enterprise linux)/i
+      when /(?:fedora|centos|red hat enterprise linux)/i
         cmd = %w{ 'rpm -qa' }
-      elsif operating_system =~ /alpine/i
+      when /alpine/i
         cmd = %w{ 'apk info' }
-      elsif operating_system =~ /gentoo/i
+      when /gentoo/i
         cmd = %w{ 'qlist -i' }
-      elsif operating_system =~ /freebsd/i
+      when /freebsd/i
         cmd = %w{ 'pkg info' }
       end
 

--- a/modules/post/multi/gather/enum_software_versions.rb
+++ b/modules/post/multi/gather/enum_software_versions.rb
@@ -58,7 +58,7 @@ class MetasploitModule < Msf::Post
       elsif operating_system =~ /freebsd/i
         cmd = %w{ 'pkg info' }
       end
-      
+
       if (listing = cmd_exec(cmd)) =~ /not found/
         print_error("The command #{cmd[0]} was not found on the target.")
         return nil

--- a/modules/post/multi/gather/enum_software_versions.rb
+++ b/modules/post/multi/gather/enum_software_versions.rb
@@ -36,7 +36,7 @@ class MetasploitModule < Msf::Post
         print_error("The 'wmic' command doesn't exist on this host!") # wmic is technically marked as depreciated so this command could very well be removed in future releases.
         return
       end
-      listing = cmd_exec('wmic product get Name, Description, Version, InstallDate',, 6000).to_s
+      listing = cmd_exec('wmic product get Name, Description, Version, InstallDate', nil, 6000).to_s
       unless listing.include?('Description')
         print_error('Was unable to get a listing of installed products...')
         return
@@ -45,52 +45,52 @@ class MetasploitModule < Msf::Post
       print_good("Stored information about the installed products to the loot file at #{file}")
     when 'linux'
       # All of the following options were taken from https://distrowatch.com/dwres.php?resource=package-management
-      cmd = %w{ 'hostnamectl' }
+      cmd = %w[hostnamectl]
       if command_exists?('hostnamectl') == false
         print_error("The 'hostnamectl' command doesn't exist on the host, so we can't enumerate what OS this Linux host is running!")
         return
       end
-      operating_system = cmd_exec("#{cmd[0]}").to_s
+      operating_system = cmd_exec(cmd[0]).to_s
       if operating_system.empty?
-        print_error("No results were returned when trying to determine the OS. An error likely occured.")
+        print_error('No results were returned when trying to determine the OS. An error likely occured.')
         return
       end
       case operating_system
       when /(?:[uU]buntu|[dD]ebian|[eE]lementary|[mM]int|MX|[zZ]orin|[kK]ali)/
-        cmd = %w{ 'apt list --installed' }
+        cmd = %w[apt list --installed]
       when /(?: [aA]rch |[mM]anjaro)/
-        cmd = %w{ 'pacman -Q' }
+        cmd = %w[pacman -Q]
       when /opensuse/i
-        cmd = %w{ 'zypper search -is' }
+        cmd = %w[zypper search -is]
       when /(?:fedora|centos|red hat enterprise linux)/i
-        cmd = %w{ 'rpm -qa' }
+        cmd = %w[rpm -qa]
       when /alpine/i
-        cmd = %w{ 'apk info' }
+        cmd = %w[apk info]
       when /gentoo/i
-        cmd = %w{ 'qlist -i' }
+        cmd = %w[qlist -i]
       when /freebsd/i
-        cmd = %w{ 'pkg info' }
+        cmd = %w[pkg info]
       end
 
-      if (command_exists?("#{cmd[0]}")) == false
+      if command_exists?((cmd[0]).to_s) == false
         print_error("The command #{cmd[0]} was not found on the target.")
         return
       else
         listing = cmd_exec(cmd.join(' ')).to_s
         if listing.empty?
-            print_error("No results were returned when trying to get software installed on the Linux host. An error likely occured.")
-            return
+          print_error('No results were returned when trying to get software installed on the Linux host. An error likely occured.')
+          return
         end
         store_linux_loot(listing)
       end
-    when 'bsd','solaris'
+    when 'bsd', 'solaris'
       if command_exists?('pkg') == false
         print_error("The command 'pkg' does not exist on the host")
         return
       end
       listing = cmd_exec('pkg info').to_s
       if listing.empty?
-        print_error("No results were returned when trying to get software installed on the BSD/Solaris host. An error likely occured.")
+        print_error('No results were returned when trying to get software installed on the BSD/Solaris host. An error likely occured.')
         return
       end
       file = store_loot('host.bsd.solaris.software.versions', 'text/plain', session, listing, 'installed_software.txt', 'Installed Software and Versions')
@@ -102,7 +102,7 @@ class MetasploitModule < Msf::Post
       end
       listing = cmd_exec('system_profiler SPApplicationsDataType').to_s
       if listing.empty?
-        print_error("No results were returned when trying to get software installed on the OSX host. An error likely occured.")
+        print_error('No results were returned when trying to get software installed on the OSX host. An error likely occured.')
         return
       end
       file = store_loot('host.osx.software.versions', 'text/plain', session, listing, 'installed_software.txt', 'Installed Software and Versions')
@@ -114,7 +114,7 @@ class MetasploitModule < Msf::Post
       end
       listing = cmd_exec('pm list packages -f').to_s
       if listing.empty?
-        print_error("No results were returned when trying to get software installed on the Linux host. An error likely occured.")
+        print_error('No results were returned when trying to get software installed on the Linux host. An error likely occured.')
         return
       end
       file = store_loot('host.android.software.versions', 'text/plain', session, listing, 'installed_software.txt', 'Installed Software and Versions')

--- a/modules/post/multi/gather/enum_software_versions.rb
+++ b/modules/post/multi/gather/enum_software_versions.rb
@@ -14,6 +14,10 @@ class MetasploitModule < Msf::Post
           This module, when run against a compromised machine, will gather details on all installed software,
           including their versions and if available, when they were installed, and will save it into a loot file for later use.
           Users can then use this loot file to determine what additional vulnerabilites may affect the target machine.
+
+          Note that for Linux systems, software enumeration is done via package managers. As a result the results may
+          not reflect all of the available software on the system simply because users may have installed additional
+          software from alternative sources such as source code that these package managers are not aware of.
         },
         'License' => MSF_LICENSE,
         'Author' => [ 'gwillcox-r7' ],

--- a/modules/post/multi/gather/enum_software_versions.rb
+++ b/modules/post/multi/gather/enum_software_versions.rb
@@ -65,9 +65,9 @@ class MetasploitModule < Msf::Post
       when /(?:fedora|centos|red hat enterprise linux)/i
         cmd = %w[rpm -qa]
       when /alpine/i
-        cmd = %w[apk info]
+        cmd = %w[apk info -v]
       when /gentoo/i
-        cmd = %w[qlist -i]
+        cmd = %w[qlist -Iv]
       when /freebsd/i
         cmd = %w[pkg info]
       end


### PR DESCRIPTION
This PR adds a new module, `enum_software_versions.rb`, whose sole purpose is to gather a list of all the software that has been installed on a compromised computer and output this as a `loot` note for later examination. This can allow users to conduct additional enumeration that may assist them in determining ways to gain additional privileges on the machine, or to determine other outdated software that should be updated on the target, which could be written up in a pentesting report.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] Gain a shell on any supported platform (Windows, OSX, Android, Solaris, BSD, Linux)
- [ ] `use post/multi/gather/enum_software_versions`
- [ ] `set SESSION <SESSION ID>`
- [ ] **Verify** that you are able to grab the list of installed software and their versions, and that this information is successfully saved to a loot file on disk.
- [ ] **Document** anything that does not work as expected.

Note that this PR will likely need several machines to test it fully and properly. I based most of the work off of the info on https://distrowatch.com/dwres.php?resource=package-management and used the options for `List installed packages`, along with some additional research where needed, but I'd appreciate it if anyone knows of any better ways to do some of the steps that I am doing here or if there are ways to gather this info that may work across more versions of the target OS.