### PR TITLE
Fix issue with web service when storing a file to the loot

### DIFF
--- a/lib/metasploit/framework/data_service/proxy/loot_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/loot_data_proxy.rb
@@ -4,7 +4,10 @@ module LootDataProxy
     begin
       self.data_service_operation do |data_service|
         if !data_service.is_a?(Msf::DBManager)
-          opts[:data] = Base64.urlsafe_encode64(opts[:data].empty? ? "" : opts[:data].join('')) if opts[:data] and opts[:data].kind_of?(Array) else opts[:data]
+          unless opts[:data].nil?
+            opts[:data] = opts[:data].join if opts[:data].kind_of?(Array)
+            opts[:data] = Base64.urlsafe_encode64(opts[:data]) unless opts[:data].empty?
+          end
         end
         add_opts_workspace(opts)
         data_service.report_loot(opts)


### PR DESCRIPTION
When adding data to the loot with `store_loot` method, a file is created and the metadata about this file is stored in the database. In `LootDataProxy#report_loot`, the data is base64-encoded before being sent to the web service endpoint safely. However, this is done only if the data is an `Array`. Since it is always base64-decoded on the other side, this causes an error avoiding the entry to be stored in the database.

This fixes this issue by making sure the data is always base64-encoded wether it is an array or a string.

## Verification
This behavior can be reproduced by using the `loot` command with an existing text file:

- [x] Create a text file with some content
- [x] Start the database and the MSF web service if they are not already started (`msfdb start`)
- [x] Start `msfconsole`
- [x] `loot -f <text file path> -i "my info" -a 1.2.3.4 -t text`
- [x] **Verify** no error is returned
- [x] `loot`
- [x] **Verify** the metadata about the file is correctly displayed
