### PR TITLE
simple typo fix in comment (in the YARD)

### DIFF
--- a/lib/msf/core/rpc/v10/rpc_session.rb
+++ b/lib/msf/core/rpc/v10/rpc_session.rb
@@ -129,7 +129,7 @@ class RPC_Session < RPC_Base
   # @param [Integer] sid Session ID.
   # @param [String] lhost Local host.
   # @param [Integer] lport Local port.
-  # @return [Hash] A hash indicating the actioin was successful. It contains the following key:
+  # @return [Hash] A hash indicating the action was successful. It contains the following key:
   #  * 'result' [String] A message that says 'success'
   # @example Here's how you would use this from the client:
   #  rpc.call('session.shell_upgrade', 2, payload_lhost, payload_lport)


### PR DESCRIPTION
fixes typo: changes "actioin" to "action"

## Verification

List the steps needed to make sure this thing works

- [ ] Read it :)