### PR TITLE
Always display `SRVHOST` and `SRVPORT` options when `CMDSTAGER::FLAVOR` is set to `auto`

### DIFF
--- a/lib/msf/core/exploit/cmdstager.rb
+++ b/lib/msf/core/exploit/cmdstager.rb
@@ -55,7 +55,7 @@ module Exploit::CmdStager
     flavors = STAGERS.keys if flavors.empty?
     flavors.unshift('auto')
 
-    server_conditions = ['CMDSTAGER::FLAVOR', 'in', %w{certutil tftp wget curl fetch lwprequest psh_invokewebrequest}]
+    server_conditions = ['CMDSTAGER::FLAVOR', 'in', %w{auto certutil tftp wget curl fetch lwprequest psh_invokewebrequest}]
     register_options(
       [
         OptAddressLocal.new('SRVHOST', [true, 'The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.', '0.0.0.0' ], conditions: server_conditions),


### PR DESCRIPTION
When `auto` is selected in `CMDSTAGER::FLAVOR`, `show options` command doesn't display SRVHOST and SRVPORT options. The `auto` flavor makes `CmdStager` select the actual flavor when the exploit is launched. If the selected flavor involves starting a server (FTP, HTTP, etc.), these two options are used, but not displayed.

This PR adds `auto` to the list of conditions used to display SRVHOST and SRVPORT options and make sure they will be always displayed. I understand this might be confusing to see server-related options when the `CMDSTAGER::FLAVOR` only contains non-server-related flavors, but I couldn't find an easy way to evaluate `auto` before the exploit is executed to get the correct flavor. I prefer to have these options displayed in this scenario, but this is open to discussion if you think otherwise.

## Verification
- [ ] Start `msfconsole`
- [ ] `use linux/misc/qnap_transcode_server`
- [ ] `show advanced`
- [ ] **Verify** the `CMDSTAGER::FLAVOR` is set to `auto` and the accepted options are `auto`, `wget` and `curl`
- [ ] `show options`
- [ ] **Verify** `SRVHOST` and `SRVPORT` options are displayed
