### PR TITLE
Migrate old uses of manual autocheck to use the new prepend autocheck

### DIFF
--- a/modules/exploits/android/local/futex_requeue.rb
+++ b/modules/exploits/android/local/futex_requeue.rb
@@ -8,6 +8,7 @@ class MetasploitModule < Msf::Exploit::Local
 
   include Msf::Post::File
   include Msf::Post::Common
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info={})
     super( update_info( info, {
@@ -86,9 +87,6 @@ class MetasploitModule < Msf::Exploit::Local
         ],
       }
     ))
-    register_advanced_options [
-      OptBool.new('ForceExploit', [false, 'Override check result', false]),
-    ]
   end
 
   def check
@@ -103,13 +101,6 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    unless [CheckCode::Detected, CheckCode::Appears].include? check
-      unless datastore['ForceExploit']
-        fail_with Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.'
-      end
-      print_warning 'Target does not appear to be vulnerable'
-    end
-
     if target['auto']
       product = cmd_exec("getprop ro.build.product")
       fingerprint = cmd_exec("getprop ro.build.fingerprint")

--- a/modules/exploits/android/local/janus.rb
+++ b/modules/exploits/android/local/janus.rb
@@ -10,6 +10,7 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::File
   include Msf::Post::Android::Priv
   include Msf::Payload::Android
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info={})
     super( update_info( info, {
@@ -53,9 +54,6 @@ class MetasploitModule < Msf::Exploit::Local
     register_options([
       OptString.new('PACKAGE', [true, 'The package to target, or ALL to attempt all', 'com.phonegap.camerasample']),
     ])
-    register_advanced_options [
-      OptBool.new('ForceExploit', [false, 'Override check result', false]),
-    ]
   end
 
   def check
@@ -131,13 +129,6 @@ class MetasploitModule < Msf::Exploit::Local
         print_error e.to_s
         false
       end
-    end
-
-    unless [CheckCode::Detected, CheckCode::Appears].include? check
-      unless datastore['ForceExploit']
-        fail_with Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.'
-      end
-      print_warning 'Target does not appear to be vulnerable'
     end
 
     if datastore["PACKAGE"] == 'ALL'

--- a/modules/exploits/bsd/finger/morris_fingerd_bof.rb
+++ b/modules/exploits/bsd/finger/morris_fingerd_bof.rb
@@ -11,6 +11,7 @@ class MetasploitModule < Msf::Exploit::Remote
   ARCH_VAX = 'vax'
 
   include Msf::Exploit::Remote::Tcp
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(update_info(info,
@@ -58,10 +59,6 @@ class MetasploitModule < Msf::Exploit::Remote
     ))
 
     register_options([Opt::RPORT(79)])
-
-    register_advanced_options([
-      OptBool.new('ForceExploit', [false, 'Override check result', false])
-    ])
   end
 
   def check
@@ -86,12 +83,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    unless datastore['ForceExploit']
-      unless check == CheckCode::Detected
-        fail_with(Failure::NotVulnerable, 'Set ForceExploit to override')
-      end
-    end
-
     # Start by generating our custom VAX shellcode
     shellcode = payload.encoded
 

--- a/modules/exploits/example_linux_priv_esc.rb
+++ b/modules/exploits/example_linux_priv_esc.rb
@@ -27,6 +27,7 @@ class MetasploitModule < Msf::Exploit::Local
   # includes: COMPILE option, live_compile?, upload_and_compile
   # strip_comments
   include Msf::Post::Linux::Compile
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(
@@ -81,7 +82,6 @@ class MetasploitModule < Msf::Exploit::Local
     )
     # force exploit is used to bypass the check command results
     register_advanced_options [
-      OptBool.new('ForceExploit', [ false, 'Override check result', false ]),
       OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ])
     ]
 
@@ -116,14 +116,6 @@ class MetasploitModule < Msf::Exploit::Local
   # or just runs the exploit on the system.
   #
   def exploit
-    # First check the system is vulnerable, or the user wants to run regardless
-    unless check == CheckCode::Appears
-      unless datastore['ForceExploit']
-        fail_with Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.'
-      end
-      print_warning 'Target does not appear to be vulnerable'
-    end
-
     # Check if we're already root
     if is_root?
       unless datastore['ForceExploit']

--- a/modules/exploits/linux/http/citrix_dir_traversal_rce.rb
+++ b/modules/exploits/linux/http/citrix_dir_traversal_rce.rb
@@ -10,6 +10,7 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::Remote::CheckModule
   include Msf::Exploit::FileDropper
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(update_info(info,
@@ -73,10 +74,6 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options([
       OptString.new('TARGETURI', [true, 'Base path', '/'])
     ])
-
-    register_advanced_options([
-      OptBool.new('ForceExploit', [false, 'Override check result', false])
-    ])
   end
 
   def cmd_unix_generic?
@@ -84,17 +81,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    unless datastore['ForceExploit']
-      case check
-      when CheckCode::Vulnerable
-        print_good('The target appears to be vulnerable')
-      when CheckCode::Safe
-        fail_with(Failure::NotVulnerable, 'The target does not appear to be vulnerable')
-      else
-        fail_with(Failure::Unknown, 'The target vulnerability state is unknown')
-      end
-    end
-
     print_status("Yeeting #{datastore['PAYLOAD']} payload at #{peer}")
     vprint_status("Generated payload: #{payload.encoded}")
 

--- a/modules/exploits/linux/http/eyesofnetwork_autodiscovery_rce.rb
+++ b/modules/exploits/linux/http/eyesofnetwork_autodiscovery_rce.rb
@@ -8,6 +8,7 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::CmdStager
   include Msf::Exploit::SQLi
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(update_info(info,
@@ -87,9 +88,6 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options [
       OptString.new('TARGETURI', [true, 'Base path to EyesOfNetwork', '/']),
       OptString.new('SERVER_ADDR', [true, 'EyesOfNetwork server IP address (if different from RHOST)', '']),
-    ]
-    register_advanced_options [
-      OptBool.new('ForceExploit',  [false, 'Override check result', false])
     ]
   end
 
@@ -404,13 +402,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    unless [CheckCode::Detected, CheckCode::Appears].include? check
-      unless datastore['ForceExploit']
-        fail_with Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.'
-      end
-      print_warning 'Target does not appear to be vulnerable'
-    end
-
     if @version != '5.3'
       print_status "Target is EyesOfNetwork version #{@version}. Attempting exploitation using CVE-2020-9465."
       sqli_to_admin_session

--- a/modules/exploits/linux/http/hp_van_sdn_cmd_inject.rb
+++ b/modules/exploits/linux/http/hp_van_sdn_cmd_inject.rb
@@ -13,6 +13,7 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::EXE
   include Msf::Exploit::FileDropper
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(update_info(info,
@@ -68,8 +69,7 @@ class MetasploitModule < Msf::Exploit::Remote
     ])
 
     register_advanced_options([
-      OptString.new('PayloadName', [false, 'Payload name (random if unset)']),
-      OptBool.new('ForceExploit',  [false, 'Override check result', false])
+      OptString.new('PayloadName', [false, 'Payload name (random if unset)'])
     ])
   end
 
@@ -104,12 +104,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    if datastore['ForceExploit']
-      print_warning('ForceExploit set! Exploiting anyway!')
-    elsif [CheckCode::Safe, CheckCode::Unknown].include?(check)
-      fail_with(Failure::NotVulnerable, 'Set ForceExploit to override')
-    end
-
     if target['Type'] == :unix_memory
       print_status('Executing command payload')
       execute_command(payload.encoded)

--- a/modules/exploits/linux/http/imperva_securesphere_exec.rb
+++ b/modules/exploits/linux/http/imperva_securesphere_exec.rb
@@ -8,6 +8,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::CmdStager
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(
@@ -56,9 +57,6 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('TARGETURI', [false, 'The URI path to impcli', '/pws/impcli']),
         OptInt.new('TIMEOUT', [false, 'HTTP connection timeout', 15])
       ])
-    register_advanced_options [
-      OptBool.new('ForceExploit',  [false, 'Override check result', false])
-    ]
   end
 
   def check
@@ -77,13 +75,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    unless CheckCode::Vulnerable == check
-      unless datastore['ForceExploit']
-        fail_with(Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.')
-      end
-      print_warning 'Target does not appear to be vulnerable'
-    end
-
     print_status("Sending payload #{datastore['PAYLOAD']}")
     execute_cmdstager
   end

--- a/modules/exploits/linux/http/linuxki_rce.rb
+++ b/modules/exploits/linux/http/linuxki_rce.rb
@@ -10,6 +10,7 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::PhpEXE
   include Msf::Exploit::FileDropper
   include Msf::Exploit::CmdStager
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(
@@ -77,7 +78,6 @@ class MetasploitModule < Msf::Exploit::Remote
       OptString.new('TARGETURI', [true, 'The path to the web application', '/']),
     ])
     register_advanced_options([
-      OptBool.new('ForceExploit', [false, 'Override check result', false]),
       OptString.new('WritableDir', [true, 'Writable dir for droppers', '/tmp'])
     ])
   end
@@ -110,12 +110,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    unless datastore['ForceExploit']
-      if check == CheckCode::Safe
-        fail_with(Failure::NotVulnerable, 'Set ForceExploit to override')
-      end
-    end
-
     print_status("Executing #{target.name} target")
 
     print_status('Sending payload...')

--- a/modules/exploits/linux/http/nagios_xi_authenticated_rce.rb
+++ b/modules/exploits/linux/http/nagios_xi_authenticated_rce.rb
@@ -7,6 +7,7 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::CmdStager
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(update_info(info,
@@ -265,13 +266,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    unless [CheckCode::Detected, CheckCode::Appears].include? check
-      unless datastore['ForceExploit']
-        fail_with Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.'
-      end
-      print_warning 'Target does not appear to be vulnerable'
-    end
-
     if @version
       print_status("Found Nagios XI application with version #{@version}.")
     end

--- a/modules/exploits/linux/http/qnap_qcenter_change_passwd_exec.rb
+++ b/modules/exploits/linux/http/qnap_qcenter_change_passwd_exec.rb
@@ -8,6 +8,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::CmdStager
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(update_info(info,
@@ -56,9 +57,6 @@ class MetasploitModule < Msf::Exploit::Remote
       OptString.new('TARGETURI', [true, "Base path to Q'Center", '/qcenter/']),
       OptString.new('USERNAME', [true, 'Username for the application', 'admin']),
       OptString.new('PASSWORD', [true, 'Password for the application', 'admin'])
-    ]
-    register_advanced_options [
-      OptBool.new('ForceExploit',  [false, 'Override check result', false])
     ]
   end
 
@@ -176,13 +174,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    unless [CheckCode::Detected, CheckCode::Appears].include? check
-      unless datastore['ForceExploit']
-        fail_with Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.'
-      end
-      print_warning 'Target does not appear to be vulnerable'
-    end
-
     login datastore['USERNAME'], datastore['PASSWORD']
 
     if datastore['USERNAME'].eql? 'admin'

--- a/modules/exploits/linux/http/synology_dsm_smart_exec_auth.rb
+++ b/modules/exploits/linux/http/synology_dsm_smart_exec_auth.rb
@@ -9,6 +9,7 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::Remote::HttpServer
   include Msf::Exploit::FileDropper
+  prepend Msf::Exploit::Remote::AutoCheck
 
   DEVICE_INFO_PATTERN = /major=(?<major>\d+)&minor=(?<minor>\d+)&build=(?<build>\d+)
                         &junior=\d+&unique=synology_\w+_(?<model>[^&]+)/x.freeze
@@ -68,10 +69,6 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('PASSWORD', [true, 'The Password for Synology', ''])
       ]
     )
-
-    register_advanced_options [
-      OptBool.new('ForceExploit', [false, 'Override check result', false])
-    ]
   end
 
   def check
@@ -162,13 +159,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    unless check == CheckCode::Appears
-      unless datastore['ForceExploit']
-        fail_with Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.'
-      end
-      print_warning 'Target does not appear to be vulnerable'
-    end
-
     if datastore['SRVHOST'] == '0.0.0.0'
       fail_with(Failure::BadConfig, 'SRVHOST must be set to an IP address (0.0.0.0 is invalid) for exploitation to be successful')
     end

--- a/modules/exploits/linux/http/webmin_backdoor.rb
+++ b/modules/exploits/linux/http/webmin_backdoor.rb
@@ -10,6 +10,7 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::CmdStager
   include Msf::Module::Deprecated
+  prepend Msf::Exploit::Remote::AutoCheck
 
   moved_from 'exploit/unix/webapp/webmin_backdoor'
 
@@ -76,10 +77,6 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options([
       Opt::RPORT(10000),
       OptString.new('TARGETURI', [true, 'Base path to Webmin', '/'])
-    ])
-
-    register_advanced_options([
-      OptBool.new('ForceExploit', [false, 'Override check result', false])
     ])
   end
 
@@ -149,12 +146,6 @@ class MetasploitModule < Msf::Exploit::Remote
       CheckCode::Appears,
       CheckCode::Vulnerable
     ]
-
-    unless datastore['ForceExploit']
-      unless checkcodes.include?(check)
-        fail_with(Failure::NotVulnerable, 'Set ForceExploit to override')
-      end
-    end
 
     print_status("Configuring #{target.name} target")
 

--- a/modules/exploits/linux/local/abrt_sosreport_priv_esc.rb
+++ b/modules/exploits/linux/local/abrt_sosreport_priv_esc.rb
@@ -12,6 +12,7 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::Linux::Kernel
   include Msf::Exploit::EXE
   include Msf::Exploit::FileDropper
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(update_info(info,
@@ -68,7 +69,6 @@ class MetasploitModule < Msf::Exploit::Local
       OptInt.new('TIMEOUT', [true, 'Timeout for sosreport (seconds)', '600'])
     ]
     register_advanced_options [
-      OptBool.new('ForceExploit',  [false, 'Override check result', false]),
       OptString.new('WritableDir', [true, 'A directory where we can write files', '/tmp'])
     ]
   end
@@ -126,13 +126,6 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    unless check == CheckCode::Appears
-      unless datastore['ForceExploit']
-        fail_with Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.'
-      end
-      print_warning 'Target does not appear to be vulnerable'
-    end
-
     if is_root?
       unless datastore['ForceExploit']
         fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'

--- a/modules/exploits/linux/local/af_packet_chocobo_root_priv_esc.rb
+++ b/modules/exploits/linux/local/af_packet_chocobo_root_priv_esc.rb
@@ -13,6 +13,7 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::Linux::Kernel
   include Msf::Exploit::EXE
   include Msf::Exploit::FileDropper
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(update_info(info,
@@ -78,7 +79,6 @@ class MetasploitModule < Msf::Exploit::Local
       OptInt.new('TIMEOUT', [ true, 'Race timeout (seconds)', '600' ]),
     ]
     register_advanced_options [
-      OptBool.new('ForceExploit',  [ false, 'Override check result', false ]),
       OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ])
     ]
   end
@@ -148,13 +148,6 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    unless check == CheckCode::Appears
-      unless datastore['ForceExploit']
-        fail_with Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.'
-      end
-      print_warning 'Target does not appear to be vulnerable'
-    end
-
     if is_root?
       unless datastore['ForceExploit']
         fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'

--- a/modules/exploits/linux/local/af_packet_packet_set_ring_priv_esc.rb
+++ b/modules/exploits/linux/local/af_packet_packet_set_ring_priv_esc.rb
@@ -12,6 +12,7 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::Linux::Kernel
   include Msf::Exploit::EXE
   include Msf::Exploit::FileDropper
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(update_info(info,
@@ -76,7 +77,6 @@ class MetasploitModule < Msf::Exploit::Local
       OptEnum.new('COMPILE', [ true, 'Compile on target', 'Auto', %w(Auto True False) ])
     ]
     register_advanced_options [
-      OptBool.new('ForceExploit',  [ false, 'Override check result', false ]),
       OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ])
     ]
   end
@@ -188,13 +188,6 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    unless check == CheckCode::Appears
-      unless datastore['ForceExploit']
-        fail_with Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.'
-      end
-      print_warning 'Target does not appear to be vulnerable'
-    end
-
     if is_root?
       unless datastore['ForceExploit']
         fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'

--- a/modules/exploits/linux/local/asan_suid_executable_priv_esc.rb
+++ b/modules/exploits/linux/local/asan_suid_executable_priv_esc.rb
@@ -11,6 +11,7 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::Linux::System
   include Msf::Exploit::EXE
   include Msf::Exploit::FileDropper
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(update_info(info,
@@ -74,7 +75,6 @@ class MetasploitModule < Msf::Exploit::Local
       OptInt.new('SPRAY_SIZE', [true, 'Number of PID symlinks to create', 50])
     ]
     register_advanced_options [
-      OptBool.new('ForceExploit',  [false, 'Override check result', false]),
       OptString.new('WritableDir', [true, 'A directory where we can write files', '/tmp'])
     ]
 
@@ -162,13 +162,6 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    unless check == CheckCode::Appears
-      unless datastore['ForceExploit']
-        fail_with Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.'
-      end
-      print_warning 'Target does not appear to be vulnerable'
-    end
-
     if is_root?
       unless datastore['ForceExploit']
         fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'

--- a/modules/exploits/linux/local/blueman_set_dhcp_handler_dbus_priv_esc.rb
+++ b/modules/exploits/linux/local/blueman_set_dhcp_handler_dbus_priv_esc.rb
@@ -11,6 +11,7 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::Linux::System
   include Msf::Exploit::EXE
   include Msf::Exploit::FileDropper
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(update_info(info,
@@ -59,7 +60,6 @@ class MetasploitModule < Msf::Exploit::Local
       'Targets'        => [['Auto', {}]],
       'DefaultTarget'  => 0))
     register_advanced_options [
-      OptBool.new('ForceExploit', [false, 'Override check result', false]),
       OptString.new('WritableDir', [true, 'A directory where we can write files', '/tmp'])
     ]
   end
@@ -125,13 +125,6 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    unless check == CheckCode::Vulnerable
-      unless datastore['ForceExploit']
-        fail_with Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.'
-      end
-      print_warning 'Target does not appear to be vulnerable'
-    end
-
     if is_root?
       unless datastore['ForceExploit']
         fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'

--- a/modules/exploits/linux/local/bpf_priv_esc.rb
+++ b/modules/exploits/linux/local/bpf_priv_esc.rb
@@ -12,6 +12,7 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::Linux::Kernel
   include Msf::Exploit::EXE
   include Msf::Exploit::FileDropper
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super( update_info( info,
@@ -79,7 +80,6 @@ class MetasploitModule < Msf::Exploit::Local
       OptInt.new('MAXWAIT', [true, 'Max time to wait for decrementation in seconds', 120])
     ]
     register_advanced_options [
-      OptBool.new('ForceExploit',  [false, 'Override check result', false]),
       OptString.new('WritableDir', [true, 'A directory where we can write files', '/tmp']),
     ]
   end
@@ -228,13 +228,6 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    unless check == CheckCode::Appears
-      unless datastore['ForceExploit']
-        fail_with Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.'
-      end
-      print_warning 'Target does not appear to be vulnerable'
-    end
-
     if is_root?
       unless datastore['ForceExploit']
         fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'

--- a/modules/exploits/linux/local/diamorphine_rootkit_signal_priv_esc.rb
+++ b/modules/exploits/linux/local/diamorphine_rootkit_signal_priv_esc.rb
@@ -11,6 +11,7 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::Linux::System
   include Msf::Exploit::EXE
   include Msf::Exploit::FileDropper
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(update_info(info,
@@ -47,7 +48,6 @@ class MetasploitModule < Msf::Exploit::Local
       OptInt.new('SIGNAL', [true, 'Diamorphine elevate signal', 64])
     ]
     register_advanced_options [
-      OptBool.new('ForceExploit', [false, 'Override check result', false]),
       OptString.new('WritableDir', [true, 'A directory where we can write files', '/tmp'])
     ]
   end

--- a/modules/exploits/linux/local/docker_daemon_privilege_escalation.rb
+++ b/modules/exploits/linux/local/docker_daemon_privilege_escalation.rb
@@ -11,6 +11,7 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::Linux::System
   include Msf::Exploit::EXE
   include Msf::Exploit::FileDropper
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info={})
     super(update_info(info, {
@@ -31,7 +32,6 @@ class MetasploitModule < Msf::Exploit::Local
       }
     ))
     register_advanced_options([
-      OptBool.new('ForceExploit',  [false, 'Override check result', false]),
       OptString.new("WritableDir", [true, "A directory where we can write files", "/tmp"])
     ])
   end
@@ -51,13 +51,6 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    unless check == CheckCode::Vulnerable
-      unless datastore['ForceExploit']
-        fail_with Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.'
-      end
-      print_warning 'Target does not appear to be vulnerable'
-    end
-
     if is_root?
       unless datastore['ForceExploit']
         fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'

--- a/modules/exploits/linux/local/docker_privileged_container_escape.rb
+++ b/modules/exploits/linux/local/docker_privileged_container_escape.rb
@@ -43,7 +43,6 @@ class MetasploitModule < Msf::Exploit::Local
     )
     register_advanced_options(
       [
-        OptBool.new('ForceExploit', [false, 'Override check result', false]),
         OptBool.new('ForcePayloadSearch', [false, 'Search for payload on the file system rather than copying it from container', false]),
         OptString.new('WritableContainerDir', [true, 'A directory where we can write files in the container', '/tmp']),
         OptString.new('WritableHostDir', [true, 'A directory where we can write files inside on the host', '/tmp']),

--- a/modules/exploits/linux/local/exim4_deliver_message_priv_esc.rb
+++ b/modules/exploits/linux/local/exim4_deliver_message_priv_esc.rb
@@ -10,6 +10,7 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::File
   include Msf::Post::Linux::Priv
   include Msf::Post::Linux::System
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(
@@ -64,7 +65,6 @@ class MetasploitModule < Msf::Exploit::Local
 
     register_advanced_options(
       [
-        OptBool.new('ForceExploit', [ false, 'Force exploit even if the current session is root', false ]),
         OptFloat.new('ExpectTimeout', [ true, 'Timeout for Expect when communicating with exim', 3.5 ]),
         OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ])
       ]

--- a/modules/exploits/linux/local/glibc_realpath_priv_esc.rb
+++ b/modules/exploits/linux/local/glibc_realpath_priv_esc.rb
@@ -12,6 +12,7 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::Linux::Kernel
   include Msf::Exploit::EXE
   include Msf::Exploit::FileDropper
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(update_info(info,
@@ -64,7 +65,6 @@ class MetasploitModule < Msf::Exploit::Local
       OptEnum.new('COMPILE', [ true, 'Compile on target', 'Auto', %w(Auto True False) ])
     ]
     register_advanced_options [
-      OptBool.new('ForceExploit',  [ false, 'Override check result', false ]),
       OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ])
     ]
   end
@@ -174,13 +174,6 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    unless check == CheckCode::Appears
-      unless datastore['ForceExploit']
-        fail_with Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.'
-      end
-      print_warning 'Target does not appear to be vulnerable'
-    end
-
     if is_root?
       unless datastore['ForceExploit']
         fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'

--- a/modules/exploits/linux/local/hp_xglance_priv_esc.rb
+++ b/modules/exploits/linux/local/hp_xglance_priv_esc.rb
@@ -12,6 +12,7 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::File
   include Msf::Exploit::EXE
   include Msf::Exploit::FileDropper
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(
@@ -62,7 +63,6 @@ class MetasploitModule < Msf::Exploit::Local
       OptString.new('GLANCE_PATH', [ true, 'Path to xglance-bin', '/opt/perf/bin/xglance-bin' ])
     ]
     register_advanced_options [
-      OptBool.new('ForceExploit', [ false, 'Override check result', false ]),
       OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ])
     ]
 
@@ -109,13 +109,6 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    unless check == CheckCode::Appears
-      unless datastore['ForceExploit']
-        fail_with Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.'
-      end
-      print_warning 'Target does not appear to be vulnerable'
-    end
-
     if is_root?
       unless datastore['ForceExploit']
         fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override'

--- a/modules/exploits/linux/local/ktsuss_suid_priv_esc.rb
+++ b/modules/exploits/linux/local/ktsuss_suid_priv_esc.rb
@@ -11,6 +11,7 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::Linux::System
   include Msf::Exploit::EXE
   include Msf::Exploit::FileDropper
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(update_info(info,
@@ -74,7 +75,6 @@ class MetasploitModule < Msf::Exploit::Local
       OptString.new('KTSUSS_PATH', [true, 'Path to staprun executable', '/usr/bin/ktsuss'])
     ]
     register_advanced_options [
-      OptBool.new('ForceExploit', [false, 'Override check result', false]),
       OptString.new('WritableDir', [true, 'A directory where we can write files', '/tmp'])
     ]
   end
@@ -118,13 +118,6 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    unless check == CheckCode::Vulnerable
-      unless datastore['ForceExploit']
-        fail_with Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.'
-      end
-      print_warning 'Target does not appear to be vulnerable'
-    end
-
     if is_root?
       unless datastore['ForceExploit']
         fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'

--- a/modules/exploits/linux/local/lastore_daemon_dbus_priv_esc.rb
+++ b/modules/exploits/linux/local/lastore_daemon_dbus_priv_esc.rb
@@ -10,6 +10,7 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::Linux::Priv
   include Msf::Exploit::EXE
   include Msf::Exploit::FileDropper
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(update_info(info,
@@ -45,7 +46,6 @@ class MetasploitModule < Msf::Exploit::Local
       'Targets'        => [[ 'Auto', {} ]],
       'DefaultTarget'  => 0))
     register_advanced_options [
-      OptBool.new('ForceExploit',  [ false, 'Override check result', false ]),
       OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ])
     ]
   end
@@ -120,13 +120,6 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    unless check == CheckCode::Appears
-      unless datastore['ForceExploit']
-        fail_with Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.'
-      end
-      print_warning 'Target does not appear to be vulnerable'
-    end
-
     if is_root?
       unless datastore['ForceExploit']
         fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'

--- a/modules/exploits/linux/local/libuser_roothelper_priv_esc.rb
+++ b/modules/exploits/linux/local/libuser_roothelper_priv_esc.rb
@@ -11,6 +11,7 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::Linux::System
   include Msf::Exploit::EXE
   include Msf::Exploit::FileDropper
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(update_info(info,
@@ -78,7 +79,6 @@ class MetasploitModule < Msf::Exploit::Local
       OptString.new('PASSWORD', [ true, 'Password for the current user', '' ])
     ]
     register_advanced_options [
-      OptBool.new('ForceExploit',  [ false, 'Override check result', false ]),
       OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ])
     ]
   end
@@ -158,13 +158,6 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    if check == CheckCode::Safe
-      unless datastore['ForceExploit']
-        fail_with Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.'
-      end
-      print_warning 'Target does not appear to be vulnerable'
-    end
-
     if is_root?
       unless datastore['ForceExploit']
         fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'

--- a/modules/exploits/linux/local/nested_namespace_idmap_limit_priv_esc.rb
+++ b/modules/exploits/linux/local/nested_namespace_idmap_limit_priv_esc.rb
@@ -12,6 +12,7 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::File
   include Msf::Exploit::EXE
   include Msf::Exploit::FileDropper
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(update_info(info,
@@ -81,7 +82,6 @@ class MetasploitModule < Msf::Exploit::Local
       OptEnum.new('COMPILE', [true, 'Compile on target', 'Auto', %w[Auto True False]])
     ]
     register_advanced_options [
-      OptBool.new('ForceExploit',  [false, 'Override check result', false]),
       OptString.new('WritableDir', [true, 'A directory where we can write files', '/tmp'])
     ]
   end
@@ -194,13 +194,6 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    unless check == CheckCode::Appears
-      unless datastore['ForceExploit']
-        fail_with Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.'
-      end
-      print_warning 'Target does not appear to be vulnerable'
-    end
-
     if is_root?
       unless datastore['ForceExploit']
         fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'

--- a/modules/exploits/linux/local/network_manager_vpnc_username_priv_esc.rb
+++ b/modules/exploits/linux/local/network_manager_vpnc_username_priv_esc.rb
@@ -11,6 +11,7 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::Linux::System
   include Msf::Exploit::EXE
   include Msf::Exploit::FileDropper
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(update_info(info,
@@ -64,7 +65,6 @@ class MetasploitModule < Msf::Exploit::Local
         },
       'DefaultTarget'  => 0))
     register_advanced_options [
-      OptBool.new('ForceExploit',  [ false, 'Override check result', false ]),
       OptString.new('WritableDir', [true, 'A directory where we can write files', '/tmp'])
     ]
   end
@@ -96,13 +96,6 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    unless check == CheckCode::Detected
-      unless datastore['ForceExploit']
-        fail_with Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.'
-      end
-      print_warning 'Target does not appear to be vulnerable'
-    end
-
     if is_root?
       unless datastore['ForceExploit']
         fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'

--- a/modules/exploits/linux/local/omniresolve_suid_priv_esc.rb
+++ b/modules/exploits/linux/local/omniresolve_suid_priv_esc.rb
@@ -11,6 +11,7 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::Linux::System
   include Msf::Exploit::EXE
   include Msf::Exploit::FileDropper
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(update_info(info,
@@ -72,7 +73,6 @@ class MetasploitModule < Msf::Exploit::Local
 
     register_advanced_options(
       [
-        OptBool.new('ForceExploit', [ false, 'Override check result', false ]),
         OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ])
       ])
   end
@@ -110,13 +110,6 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    if check == CheckCode::Safe
-      unless datastore['ForceExploit']
-        fail_with(Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.')
-      end
-      print_warning 'Target does not appear to be vulnerable'
-    end
-
     if is_root?
       unless datastore['ForceExploit']
         fail_with(Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.')

--- a/modules/exploits/linux/local/ptrace_sudo_token_priv_esc.rb
+++ b/modules/exploits/linux/local/ptrace_sudo_token_priv_esc.rb
@@ -12,6 +12,7 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::Linux::System
   include Msf::Exploit::EXE
   include Msf::Exploit::FileDropper
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(update_info(info,
@@ -72,7 +73,6 @@ class MetasploitModule < Msf::Exploit::Local
       OptInt.new('TIMEOUT', [true, 'Process injection timeout (seconds)', '30'])
     ]
     register_advanced_options [
-      OptBool.new('ForceExploit', [false, 'Override check result', false]),
       OptString.new('WritableDir', [true, 'A directory where we can write files', '/tmp'])
     ]
   end
@@ -123,13 +123,6 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    unless check == CheckCode::Detected
-      unless datastore['ForceExploit']
-        fail_with Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.'
-      end
-      print_warning 'Target does not appear to be vulnerable'
-    end
-
     if is_root?
       unless datastore['ForceExploit']
         fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'

--- a/modules/exploits/linux/local/ptrace_traceme_pkexec_helper.rb
+++ b/modules/exploits/linux/local/ptrace_traceme_pkexec_helper.rb
@@ -13,6 +13,7 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::Linux::Compile
   include Msf::Exploit::EXE
   include Msf::Exploit::FileDropper
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(update_info(info,
@@ -61,7 +62,6 @@ class MetasploitModule < Msf::Exploit::Local
         },
       'DisclosureDate' => '2019-07-04'))
     register_advanced_options [
-      OptBool.new('ForceExploit', [false, 'Override check result', false]),
       OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ])
     ]
   end
@@ -103,13 +103,6 @@ class MetasploitModule < Msf::Exploit::Local
   def exploit
     if is_root? && !datastore['ForceExploit']
       fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'
-    end
-
-    unless check == CheckCode::Appears
-      unless datastore['ForceExploit']
-        fail_with Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.'
-      end
-      print_warning 'Target does not appear to be vulnerable'
     end
 
     unless writable? datastore['WritableDir']

--- a/modules/exploits/linux/local/rds_atomic_free_op_null_pointer_deref_priv_esc.rb
+++ b/modules/exploits/linux/local/rds_atomic_free_op_null_pointer_deref_priv_esc.rb
@@ -13,6 +13,7 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::Linux::Kernel
   include Msf::Exploit::EXE
   include Msf::Exploit::FileDropper
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(update_info(info,
@@ -75,7 +76,6 @@ class MetasploitModule < Msf::Exploit::Local
         },
       'DefaultTarget'  => 0))
     register_advanced_options [
-      OptBool.new('ForceExploit',  [ false, 'Override check result', false ]),
       OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ])
     ]
   end
@@ -125,13 +125,6 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    unless [CheckCode::Detected, CheckCode::Appears].include? check
-      unless datastore['ForceExploit']
-        fail_with Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.'
-      end
-      print_warning 'Target does not appear to be vulnerable'
-    end
-
     if is_root?
       unless datastore['ForceExploit']
         fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'

--- a/modules/exploits/linux/local/rds_rds_page_copy_user_priv_esc.rb
+++ b/modules/exploits/linux/local/rds_rds_page_copy_user_priv_esc.rb
@@ -14,6 +14,7 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Exploit::EXE
   include Msf::Exploit::FileDropper
   include Msf::Module::Deprecated
+  prepend Msf::Exploit::Remote::AutoCheck
 
   moved_from 'exploit/linux/local/rds_priv_esc'
 
@@ -68,7 +69,6 @@ class MetasploitModule < Msf::Exploit::Local
         },
       'DefaultTarget'  => 0))
     register_advanced_options [
-      OptBool.new('ForceExploit',  [ false, 'Override check result', false ]),
       OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ])
     ]
   end
@@ -113,13 +113,6 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    unless check == CheckCode::Appears
-      unless datastore['ForceExploit']
-        fail_with Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.'
-      end
-      print_warning 'Target does not appear to be vulnerable'
-    end
-
     if is_root?
       unless datastore['ForceExploit']
         fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'

--- a/modules/exploits/linux/local/recvmmsg_priv_esc.rb
+++ b/modules/exploits/linux/local/recvmmsg_priv_esc.rb
@@ -12,6 +12,7 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::Linux::Kernel
   include Msf::Exploit::EXE
   include Msf::Exploit::FileDropper
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(update_info(info,
@@ -54,7 +55,6 @@ class MetasploitModule < Msf::Exploit::Local
       OptEnum.new('COMPILE', [ true, 'Compile on target', 'Auto', %w(Auto True False) ])
     ]
     register_advanced_options [
-      OptBool.new('ForceExploit',  [ false, 'Override check result', false ]),
       OptString.new('WritableDir', [ true, 'A directory where we can write files (must not be mounted noexec)', '/tmp' ])
     ]
   end
@@ -142,13 +142,6 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    unless check == CheckCode::Appears
-      unless datastore['ForceExploit']
-        fail_with Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.'
-      end
-      print_warning 'Target does not appear to be vulnerable'
-    end
-
     if is_root?
       unless datastore['ForceExploit']
         fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'

--- a/modules/exploits/linux/local/reptile_rootkit_reptile_cmd_priv_esc.rb
+++ b/modules/exploits/linux/local/reptile_rootkit_reptile_cmd_priv_esc.rb
@@ -11,6 +11,7 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::Linux::System
   include Msf::Exploit::EXE
   include Msf::Exploit::FileDropper
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(update_info(info,
@@ -48,7 +49,6 @@ class MetasploitModule < Msf::Exploit::Local
       OptString.new('REPTILE_CMD_PATH', [true, 'Path to reptile_cmd executable', '/reptile/reptile_cmd'])
     ]
     register_advanced_options [
-      OptBool.new('ForceExploit', [false, 'Override check result', false]),
       OptString.new('WritableDir', [true, 'A directory where we can write files', '/tmp'])
     ]
   end
@@ -98,13 +98,6 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    unless check == CheckCode::Vulnerable
-      unless datastore['ForceExploit']
-        fail_with Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.'
-      end
-      print_warning 'Target does not appear to be vulnerable'
-    end
-
     if is_root?
       unless datastore['ForceExploit']
         fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'

--- a/modules/exploits/linux/local/servu_ftp_server_prepareinstallation_priv_esc.rb
+++ b/modules/exploits/linux/local/servu_ftp_server_prepareinstallation_priv_esc.rb
@@ -12,6 +12,7 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::Linux::System
   include Msf::Exploit::EXE
   include Msf::Exploit::FileDropper
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(update_info(info,
@@ -76,7 +77,6 @@ class MetasploitModule < Msf::Exploit::Local
       OptString.new('SERVU_PATH', [true, 'Path to Serv-U executable', '/usr/local/Serv-U/Serv-U'])
     ]
     register_advanced_options [
-      OptBool.new('ForceExploit', [false, 'Override check result', false]),
       OptString.new('WritableDir', [true, 'A directory where we can write files', '/tmp'])
     ]
   end
@@ -124,13 +124,6 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    unless check == CheckCode::Detected
-      unless datastore['ForceExploit']
-        fail_with Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.'
-      end
-      print_warning 'Target does not appear to be vulnerable'
-    end
-
     if is_root?
       unless datastore['ForceExploit']
         fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'

--- a/modules/exploits/linux/local/sock_sendpage.rb
+++ b/modules/exploits/linux/local/sock_sendpage.rb
@@ -13,6 +13,7 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Exploit::FileDropper
   include Msf::Exploit::Local::LinuxKernel
   include Msf::Exploit::Local::Linux
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(update_info(info,
@@ -70,7 +71,6 @@ class MetasploitModule < Msf::Exploit::Local
       OptBool.new('DEBUG_EXPLOIT', [ true, "Make the exploit executable be verbose about what it's doing", false ])
     ]
     register_advanced_options [
-      OptBool.new('ForceExploit',  [ false, 'Override check result', false ]),
       OptString.new('WritableDir', [ true, 'A directory where we can write files (must not be mounted noexec)', '/tmp' ])
     ]
   end
@@ -134,13 +134,6 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    if check == CheckCode::Safe
-      unless datastore['ForceExploit']
-        fail_with Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.'
-      end
-      print_warning 'Target does not appear to be vulnerable'
-    end
-
     if is_root?
       unless datastore['ForceExploit']
         fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'

--- a/modules/exploits/linux/local/systemtap_modprobe_options_priv_esc.rb
+++ b/modules/exploits/linux/local/systemtap_modprobe_options_priv_esc.rb
@@ -11,6 +11,7 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::Linux::System
   include Msf::Exploit::EXE
   include Msf::Exploit::FileDropper
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(update_info(info,
@@ -72,7 +73,6 @@ class MetasploitModule < Msf::Exploit::Local
       OptString.new('STAPRUN_PATH', [true, 'Path to staprun executable', '/usr/bin/staprun'])
     ]
     register_advanced_options [
-      OptBool.new('ForceExploit', [false, 'Override check result', false]),
       OptString.new('WritableDir', [true, 'A directory where we can write files', '/tmp'])
     ]
   end
@@ -116,13 +116,6 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    unless check == CheckCode::Detected
-      unless datastore['ForceExploit']
-        fail_with Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.'
-      end
-      print_warning 'Target does not appear to be vulnerable'
-    end
-
     if is_root?
       unless datastore['ForceExploit']
         fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'

--- a/modules/exploits/linux/local/ufo_privilege_escalation.rb
+++ b/modules/exploits/linux/local/ufo_privilege_escalation.rb
@@ -12,6 +12,7 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::Linux::Kernel
   include Msf::Exploit::EXE
   include Msf::Exploit::FileDropper
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(update_info(info,
@@ -75,7 +76,6 @@ class MetasploitModule < Msf::Exploit::Local
       OptEnum.new('COMPILE', [ true, 'Compile on target', 'Auto', %w[Auto True False] ])
     ]
     register_advanced_options [
-      OptBool.new('ForceExploit',  [ false, 'Override check result', false ]),
       OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ])
     ]
   end
@@ -185,13 +185,6 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    unless check == CheckCode::Appears
-      unless datastore['ForceExploit']
-        fail_with Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.'
-      end
-      print_warning 'Target does not appear to be vulnerable'
-    end
-
     if is_root?
       unless datastore['ForceExploit']
         fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'

--- a/modules/exploits/linux/local/vmware_alsa_config.rb
+++ b/modules/exploits/linux/local/vmware_alsa_config.rb
@@ -12,6 +12,7 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::File
   include Msf::Exploit::EXE
   include Msf::Exploit::FileDropper
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(update_info(info,
@@ -65,7 +66,6 @@ class MetasploitModule < Msf::Exploit::Local
         },
       'DefaultTarget'  => 1))
     register_advanced_options [
-      OptBool.new('ForceExploit', [false, 'Override check result', false]),
       OptString.new('WritableDir', [true, 'A directory where we can write files', '/tmp']),
       OptString.new('Xdisplay', [true, 'Display exploit will attempt to use', ':0'])
     ]
@@ -151,13 +151,6 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    unless [CheckCode::Detected, CheckCode::Appears].include? check
-      unless datastore['ForceExploit']
-        fail_with Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.'
-      end
-      print_warning 'Target does not appear to be vulnerable'
-    end
-
     if is_root?
       unless datastore['ForceExploit']
         fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'

--- a/modules/exploits/linux/upnp/belkin_wemo_upnp_exec.rb
+++ b/modules/exploits/linux/upnp/belkin_wemo_upnp_exec.rb
@@ -9,6 +9,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::CmdStager
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(update_info(info,
@@ -71,7 +72,6 @@ class MetasploitModule < Msf::Exploit::Remote
     ])
 
     register_advanced_options([
-      OptBool.new('ForceExploit',  [true, 'Override check result', false]),
       OptString.new('WritableDir', [true, 'Writable directory', '/tmp'])
     ])
   end
@@ -115,14 +115,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    checkcode = check
-
-    unless datastore['ForceExploit']
-      unless checkcode == CheckCode::Appears
-        fail_with(Failure::NotVulnerable, 'Set ForceExploit to override')
-      end
-    end
-
     case target['Type']
     when :unix_memory
       execute_command(payload.encoded)

--- a/modules/exploits/multi/http/cmsms_object_injection_rce.rb
+++ b/modules/exploits/multi/http/cmsms_object_injection_rce.rb
@@ -7,6 +7,7 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = NormalRanking
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::FileDropper
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(update_info(info,
@@ -44,9 +45,6 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('PASSWORD', [true, 'Password to authenticate with', ''])
       ]
     )
-    register_advanced_options([
-      OptBool.new('ForceExploit', [false, 'Override check result', false])
-    ])
   end
 
   def multipart_form_data(uri, data, message)
@@ -153,12 +151,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    unless [CheckCode::Detected, CheckCode::Appears].include?(check)
-      unless datastore['ForceExploit']
-        fail_with Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.'
-      end
-      print_warning 'Target does not appear to be vulnerable'
-    end
     login
     send_injection
   end

--- a/modules/exploits/multi/http/cmsms_upload_rename_rce.rb
+++ b/modules/exploits/multi/http/cmsms_upload_rename_rce.rb
@@ -8,6 +8,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::FileDropper
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(update_info(info,
@@ -49,10 +50,6 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('USERNAME', [ true, "Username to authenticate with", '']),
         OptString.new('PASSWORD', [ true, "Password to authenticate with", ''])
       ])
-
-    register_advanced_options ([
-      OptBool.new('ForceExploit',  [false, 'Override check result', false])
-    ])
   end
 
   def check
@@ -83,13 +80,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    unless [CheckCode::Detected, CheckCode::Appears].include?(check)
-      unless datastore['ForceExploit']
-        fail_with Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.'
-      end
-      print_warning 'Target does not appear to be vulnerable'
-    end
-
     res = send_request_cgi({
       'uri' => normalize_uri(target_uri.path, 'admin', 'login.php'),
       'method' => 'POST',

--- a/modules/exploits/multi/http/jenkins_metaprogramming.rb
+++ b/modules/exploits/multi/http/jenkins_metaprogramming.rb
@@ -10,6 +10,7 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::Remote::HttpServer
   include Msf::Exploit::FileDropper
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(update_info(info,
@@ -87,11 +88,6 @@ class MetasploitModule < Msf::Exploit::Remote
       Opt::RPORT(8080),
       OptString.new('TARGETURI', [true, 'Base path to Jenkins', '/'])
     ])
-
-    register_advanced_options([
-      OptBool.new('ForceExploit', [false, 'Override check result', false])
-    ])
-
     deregister_options('URIPATH')
   end
 
@@ -135,12 +131,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    unless datastore['ForceExploit']
-      unless check == CheckCode::Vulnerable
-        fail_with(Failure::NotVulnerable, 'Set ForceExploit to override')
-      end
-    end
-
     print_status("Configuring #{target.name} target")
 
     vars_get = {'value' => go_go_gadget2}

--- a/modules/exploits/multi/http/nostromo_code_exec.rb
+++ b/modules/exploits/multi/http/nostromo_code_exec.rb
@@ -8,6 +8,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::CmdStager
   include Msf::Exploit::Remote::HttpClient
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(update_info(info,
@@ -58,10 +59,6 @@ class MetasploitModule < Msf::Exploit::Remote
         'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
       }
     ))
-
-    register_advanced_options([
-      OptBool.new('ForceExploit', [false, 'Override check result', false])
-    ])
   end
 
   def check
@@ -102,10 +99,6 @@ class MetasploitModule < Msf::Exploit::Remote
       CheckCode::Appears,
       CheckCode::Vulnerable
     ]
-
-    unless checkcodes.include?(check) || datastore['ForceExploit']
-      fail_with(Failure::NotVulnerable, 'Set ForceExploit to override')
-    end
 
     print_status("Configuring #{target.name} target")
 

--- a/modules/exploits/multi/http/openmrs_deserialization.rb
+++ b/modules/exploits/multi/http/openmrs_deserialization.rb
@@ -8,6 +8,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::CmdStager
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(update_info(info,
@@ -63,8 +64,6 @@ class MetasploitModule < Msf::Exploit::Remote
       Opt::RPORT(8081),
       OptString.new('TARGETURI', [ true, 'Base URI for OpenMRS', '/' ])
     ])
-
-    register_advanced_options([ OptBool.new('ForceExploit', [ false, 'Override check result', false ]) ])
   end
 
   def check
@@ -120,12 +119,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    chk_status = check
-    print_status('Target is running OpenMRS') if chk_status == CheckCode::Appears
-    unless ((chk_status == CheckCode::Appears || chk_status == CheckCode::Detected) || datastore['ForceExploit'] )
-      fail_with(Failure::NoTarget, 'Target is not vulnerable')
-    end
-
     cmds = generate_cmdstager(:concat_operator => '&&')
     print_status('Sending payload...')
     cmds.first.split('&&').map { |cmd| execute_command(cmd) }

--- a/modules/exploits/multi/http/vbulletin_widgetconfig_rce.rb
+++ b/modules/exploits/multi/http/vbulletin_widgetconfig_rce.rb
@@ -7,6 +7,7 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::HttpClient
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(update_info(info,
@@ -73,10 +74,6 @@ class MetasploitModule < Msf::Exploit::Remote
       OptString.new('TARGETURI', [true, 'The URI of the vBulletin base path', '/']),
       OptEnum.new('PHP_CMD', [true, 'Specify the PHP function in which you want to execute the payload.', 'shell_exec', ['shell_exec', 'exec']])
     ])
-
-    register_advanced_options([
-      OptBool.new('ForceExploit', [false, 'Override check result', false])
-    ])
   end
 
   def cmd_payload(command)
@@ -111,11 +108,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    unless check.eql? Exploit::CheckCode::Vulnerable
-      unless datastore['ForceExploit']
-        fail_with(Failure::NotVulnerable, 'The target is not exploitable.')
-      end
-    end
     vprint_good("The target appears to be vulnerable.")
 
     print_status("Sending #{datastore['PAYLOAD']} command payload")

--- a/modules/exploits/openbsd/local/dynamic_loader_chpass_privesc.rb
+++ b/modules/exploits/openbsd/local/dynamic_loader_chpass_privesc.rb
@@ -10,6 +10,7 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::Unix
   include Msf::Exploit::EXE
   include Msf::Exploit::FileDropper
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(update_info(info,
@@ -61,7 +62,6 @@ class MetasploitModule < Msf::Exploit::Local
       OptString.new('CHPASS_PATH', [true, 'Path to chpass', '/usr/bin/chpass'])
     ]
     register_advanced_options [
-      OptBool.new('ForceExploit', [false, 'Override check result', false]),
       OptString.new('WritableDir', [true, 'A directory where we can write files', '/tmp'])
     ]
   end
@@ -105,13 +105,6 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    unless check == CheckCode::Detected
-      unless datastore['ForceExploit']
-        fail_with Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.'
-      end
-      print_warning 'Target does not appear to be vulnerable'
-    end
-
     if is_root?
       unless datastore['ForceExploit']
         fail_with Failure::BadConfig, 'Session already has root privileges. Set ForceExploit to override.'

--- a/modules/exploits/osx/local/vmware_fusion_lpe.rb
+++ b/modules/exploits/osx/local/vmware_fusion_lpe.rb
@@ -10,6 +10,7 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::File
   include Msf::Exploit::EXE
   include Msf::Exploit::FileDropper
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(
@@ -59,10 +60,6 @@ class MetasploitModule < Msf::Exploit::Local
 
     register_options [
       OptInt.new('MAXATTEMPTS', [true, 'Maximum attempts to win race for 11.5.3', 75])
-    ]
-
-    register_advanced_options [
-      OptBool.new('ForceExploit', [false, 'Override check result', false])
     ]
   end
 
@@ -201,14 +198,6 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    # First check the system is vulnerable, or the user wants to run regardless
-    unless check == CheckCode::Appears
-      unless datastore['ForceExploit']
-        fail_with Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.'
-      end
-      print_warning 'Target does not appear to be vulnerable'
-    end
-
     # Check if we're already root
     if is_root?
       unless datastore['ForceExploit']

--- a/modules/exploits/solaris/local/extremeparr_dtappgather_priv_esc.rb
+++ b/modules/exploits/solaris/local/extremeparr_dtappgather_priv_esc.rb
@@ -12,6 +12,7 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::Solaris::Kernel
   include Msf::Exploit::EXE
   include Msf::Exploit::FileDropper
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(update_info(info,
@@ -82,7 +83,6 @@ class MetasploitModule < Msf::Exploit::Local
       OptString.new('DTAPPGATHER_PATH', [true, 'Path to dtappgather executable', '/usr/dt/bin/dtappgather'])
     ]
     register_advanced_options [
-      OptBool.new('ForceExploit',  [false, 'Override check result', false]),
       OptString.new('WritableDir', [true, 'A directory where we can write files', '/tmp'])
     ]
   end
@@ -160,13 +160,6 @@ class MetasploitModule < Msf::Exploit::Local
   def exploit
     if is_root?
       fail_with Failure::BadConfig, 'Session already has root privileges'
-    end
-
-    unless [CheckCode::Detected, CheckCode::Appears].include? check
-      unless datastore['ForceExploit']
-        fail_with Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.'
-      end
-      print_warning 'Target does not appear to be vulnerable'
     end
 
     unless writable? datastore['WritableDir']

--- a/modules/exploits/solaris/local/libnspr_nspr_log_file_priv_esc.rb
+++ b/modules/exploits/solaris/local/libnspr_nspr_log_file_priv_esc.rb
@@ -12,6 +12,7 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::Solaris::Kernel
   include Msf::Exploit::EXE
   include Msf::Exploit::FileDropper
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(update_info(info,
@@ -78,7 +79,6 @@ class MetasploitModule < Msf::Exploit::Local
       OptString.new('SUID_PATH', [true, 'Path to suid executable (must be linked to a vulnerable version of libnspr4.so)', '/usr/bin/cancel'])
     ]
     register_advanced_options [
-      OptBool.new('ForceExploit',  [false, 'Override check result', false]),
       OptString.new('WritableDir', [true, 'A directory where we can write files', '/tmp'])
     ]
   end
@@ -186,13 +186,6 @@ class MetasploitModule < Msf::Exploit::Local
   def exploit
     if is_root?
       fail_with Failure::BadConfig, 'Session already has root privileges'
-    end
-
-    unless [CheckCode::Detected, CheckCode::Appears].include? check
-      unless datastore['ForceExploit']
-        fail_with Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.'
-      end
-      print_warning 'Target does not appear to be vulnerable'
     end
 
     unless is_writable? datastore['WritableDir']

--- a/modules/exploits/solaris/local/rsh_stack_clash_priv_esc.rb
+++ b/modules/exploits/solaris/local/rsh_stack_clash_priv_esc.rb
@@ -12,6 +12,7 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::Solaris::Kernel
   include Msf::Exploit::EXE
   include Msf::Exploit::FileDropper
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(update_info(info,
@@ -82,7 +83,6 @@ class MetasploitModule < Msf::Exploit::Local
       OptString.new('RSH_PATH', [true, 'Path to rsh executable', '/usr/bin/rsh'])
     ]
     register_advanced_options [
-      OptBool.new('ForceExploit',  [false, 'Override check result', false]),
       OptString.new('WritableDir', [true, 'A directory where we can write files', '/tmp'])
     ]
   end
@@ -154,13 +154,6 @@ class MetasploitModule < Msf::Exploit::Local
   def exploit
     if is_root?
       fail_with Failure::BadConfig, 'Session already has root privileges'
-    end
-
-    unless check == CheckCode::Detected
-      unless datastore['ForceExploit']
-        fail_with Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.'
-      end
-      print_warning 'Target does not appear to be vulnerable'
     end
 
     unless writable? datastore['WritableDir']

--- a/modules/exploits/solaris/local/xscreensaver_log_priv_esc.rb
+++ b/modules/exploits/solaris/local/xscreensaver_log_priv_esc.rb
@@ -12,6 +12,7 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::Solaris::Kernel
   include Msf::Exploit::EXE
   include Msf::Exploit::FileDropper
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(update_info(info,
@@ -69,7 +70,6 @@ class MetasploitModule < Msf::Exploit::Local
     ]
     register_advanced_options [
       OptString.new('Xdisplay', [true, 'Display to use if starting a new Xorg session', ':1']),
-      OptBool.new('ForceExploit', [false, 'Override check result', false]),
       OptString.new('WritableDir', [true, 'A directory where we can write files', '/tmp'])
     ]
   end
@@ -139,13 +139,6 @@ class MetasploitModule < Msf::Exploit::Local
   def exploit
     if is_root?
       fail_with Failure::BadConfig, 'Session already has root privileges'
-    end
-
-    unless [CheckCode::Detected, CheckCode::Appears].include? check
-      unless datastore['ForceExploit']
-        fail_with Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.'
-      end
-      print_warning 'Target does not appear to be vulnerable'
     end
 
     unless writable? datastore['WritableDir']

--- a/modules/exploits/unix/local/emacs_movemail.rb
+++ b/modules/exploits/unix/local/emacs_movemail.rb
@@ -8,6 +8,7 @@ class MetasploitModule < Msf::Exploit::Local
   Rank = ExcellentRanking
 
   include Msf::Post::File
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(
@@ -51,10 +52,6 @@ class MetasploitModule < Msf::Exploit::Local
 
     register_options([
       OptString.new('MOVEMAIL', [true, 'Path to movemail', '/etc/movemail'])
-    ])
-
-    register_advanced_options([
-      OptBool.new('ForceExploit', [false, 'Override check result', false])
     ])
   end
 

--- a/modules/exploits/unix/smtp/morris_sendmail_debug.rb
+++ b/modules/exploits/unix/smtp/morris_sendmail_debug.rb
@@ -10,6 +10,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::Tcp
   include Msf::Exploit::Remote::Expect
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(update_info(info,
@@ -51,7 +52,6 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options([Opt::RPORT(25)])
 
     register_advanced_options([
-      OptBool.new('ForceExploit',   [false, 'Override check result', false]),
       OptFloat.new('ExpectTimeout', [true, 'Timeout for Expect', 3.5])
     ])
   end
@@ -86,12 +86,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    unless datastore['ForceExploit']
-      unless check == CheckCode::Appears
-        fail_with(Failure::NotVulnerable, 'Set ForceExploit to override')
-      end
-    end
-
     # We don't care who the user is, so randomize it
     from = rand_text_alphanumeric(8..42)
 

--- a/modules/exploits/unix/smtp/opensmtpd_mail_from_rce.rb
+++ b/modules/exploits/unix/smtp/opensmtpd_mail_from_rce.rb
@@ -10,6 +10,7 @@ class MetasploitModule < Msf::Exploit::Remote
   prepend Msf::Exploit::Remote::AutoCheck
   include Msf::Exploit::Remote::Tcp
   include Msf::Exploit::Remote::Expect
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(
@@ -61,7 +62,6 @@ class MetasploitModule < Msf::Exploit::Remote
     ])
 
     register_advanced_options([
-      OptBool.new('ForceExploit', [false, 'Override check result', false]),
       OptFloat.new('ExpectTimeout', [true, 'Timeout for Expect', 3.5])
     ])
   end

--- a/modules/exploits/unix/webapp/drupal_drupalgeddon2.rb
+++ b/modules/exploits/unix/webapp/drupal_drupalgeddon2.rb
@@ -11,6 +11,7 @@ class MetasploitModule < Msf::Exploit::Remote
   # XXX: CmdStager can't handle badchars
   include Msf::Exploit::PhpEXE
   include Msf::Exploit::FileDropper
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(update_info(info,
@@ -132,7 +133,6 @@ class MetasploitModule < Msf::Exploit::Remote
     ])
 
     register_advanced_options([
-      OptBool.new('ForceExploit',  [false, 'Override check result', false]),
       OptString.new('WritableDir', [true, 'Writable dir for droppers', '/tmp'])
     ])
   end
@@ -183,12 +183,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    unless datastore['ForceExploit']
-      if check == CheckCode::Safe
-        fail_with(Failure::NotVulnerable, 'Set ForceExploit to override')
-      end
-    end
-
     unless @version
       print_warning('Targeting Drupal 7.x as a fallback')
       @version = Gem::Version.new('7')

--- a/modules/exploits/unix/webapp/drupal_restws_unserialize.rb
+++ b/modules/exploits/unix/webapp/drupal_restws_unserialize.rb
@@ -9,6 +9,7 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = NormalRanking
 
   include Msf::Exploit::Remote::HTTP::Drupal
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(update_info(info,
@@ -80,10 +81,6 @@ class MetasploitModule < Msf::Exploit::Remote
       OptInt.new('NODE',         [false, 'Node ID to target with GET method', 1]),
       OptBool.new('DUMP_OUTPUT', [false, 'Dump payload command output', false])
     ])
-
-    register_advanced_options([
-      OptBool.new('ForceExploit', [false, 'Override check result', false])
-    ])
   end
 
   def check
@@ -140,12 +137,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    if datastore['ForceExploit']
-      print_warning('ForceExploit set! Exploiting anyway!')
-    elsif [CheckCode::Safe, CheckCode::Unknown].include?(check)
-      fail_with(Failure::NotVulnerable, 'Set ForceExploit to override')
-    end
-
     if datastore['PAYLOAD'] == 'cmd/unix/generic'
       print_warning('Enabling DUMP_OUTPUT for cmd/unix/generic')
       # XXX: Naughty datastore modification

--- a/modules/exploits/unix/webapp/wp_plainview_activity_monitor_rce.rb
+++ b/modules/exploits/unix/webapp/wp_plainview_activity_monitor_rce.rb
@@ -6,6 +6,7 @@
 class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::HTTP::Wordpress
   include Msf::Exploit::Remote::HttpClient
+  prepend Msf::Exploit::Remote::AutoCheck
 
   Rank = ExcellentRanking
 
@@ -49,11 +50,6 @@ class MetasploitModule < Msf::Exploit::Remote
           OptString.new('USERNAME', [ true,  "The user to authenticate as"]),
           OptString.new('PASSWORD', [ true,  "The password to authenticate with" ])
         ])
-
-      register_advanced_options(
-        [
-          OptBool.new('ForceExploit',  [ false, 'Override check result', false ]),
-        ])
   end
 
   def check
@@ -65,14 +61,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    check_code = check
-    unless check_code == CheckCode::Detected || check_code == CheckCode::Appears
-      unless datastore['ForceExploit']
-        fail_with Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override.'
-      end
-      print_warning 'Target does not appear to be vulnerable'
-    end
-
     user = datastore['USERNAME']
     password = datastore['PASSWORD']
 

--- a/modules/exploits/windows/http/apache_tika_jp2_jscript.rb
+++ b/modules/exploits/windows/http/apache_tika_jp2_jscript.rb
@@ -9,6 +9,7 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::CmdStager
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::Powershell
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(update_info(info,
@@ -57,11 +58,6 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         Opt::RPORT(9998),
         OptString.new('TARGETURI', [true, 'The base path to the web application', '/'])
-      ])
-
-    register_advanced_options(
-      [
-        OptBool.new('ForceExploit', [true, 'Override check result', false])
       ])
   end
 
@@ -112,12 +108,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    checkcode = check
-    unless checkcode == CheckCode::Vulnerable || datastore['ForceExploit']
-      print_error("#{checkcode[1]}. Set ForceExploit to override.")
-      return
-    end
-
     execute_cmdstager(linemax: 8000)
   end
 end

--- a/modules/exploits/windows/local/anyconnect_lpe.rb
+++ b/modules/exploits/windows/local/anyconnect_lpe.rb
@@ -11,6 +11,7 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::File
   include Msf::Exploit::EXE
   include Msf::Exploit::FileDropper
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(
@@ -86,10 +87,6 @@ class MetasploitModule < Msf::Exploit::Local
           ' should be found). It will be automatically detected if not set.'
       ]),
       OptEnum.new('CVE', [ true, 'Vulnerability to use', 'CVE-2020-3433', ['CVE-2020-3433', 'CVE-2020-3153']])
-    ]
-
-    register_advanced_options [
-      OptBool.new('ForceExploit', [false, 'Override check result', false])
     ]
   end
 
@@ -202,10 +199,6 @@ class MetasploitModule < Msf::Exploit::Local
       unless @installation_path
         fail_with(Failure::NoTarget, 'Installation path not found (try to set INSTALL_PATH if automatic detection failed)')
       end
-      unless datastore['ForceExploit']
-        fail_with(Failure::NotVulnerable, 'Target is not vulnerable (set ForceExploit to override)')
-      end
-      print_warning('Override check result and attempt exploitation anyway')
     end
 
     cac_cmd = '"CAC-nc-install'

--- a/modules/exploits/windows/local/ricoh_driver_privesc.rb
+++ b/modules/exploits/windows/local/ricoh_driver_privesc.rb
@@ -11,6 +11,7 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Exploit::EXE
   include Msf::Post::Windows::Priv
   include Msf::Exploit::FileDropper
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(update_info(info,
@@ -67,13 +68,10 @@ class MetasploitModule < Msf::Exploit::Local
     ))
 
     self.needs_cleanup = true
-
-    register_advanced_options([
-      OptBool.new('ForceExploit', [ false, 'Override check result', false ])
-    ])
   end
 
   def check
+    @driver_path = ''
     dir_name = "C:\\ProgramData\\RICOH_DRV"
 
     return CheckCode::Safe('No Ricoh driver directory found') unless directory?(dir_name)
@@ -138,11 +136,6 @@ class MetasploitModule < Msf::Exploit::Local
 
     if sysinfo['Architecture'] != payload.arch.first
       fail_with(Failure::BadConfig, 'The payload should use the same architecture as the target driver')
-    end
-
-    @driver_path = ''
-    unless check == CheckCode::Appears || datastore['ForceExploit']
-      fail_with(Failure::NotVulnerable, 'Target is not vulnerable. Set ForceExploit to override')
     end
 
     @printer_name = Rex::Text.rand_text_alpha(5..9)

--- a/modules/exploits/windows/rdp/cve_2019_0708_bluekeep_rce.rb
+++ b/modules/exploits/windows/rdp/cve_2019_0708_bluekeep_rce.rb
@@ -46,6 +46,7 @@
 #    MS_T120 on XP... should be same process as the RDPSND
 
 class MetasploitModule < Msf::Exploit::Remote
+  prepend Msf::Exploit::Remote::AutoCheck
 
   Rank = ManualRanking
 
@@ -204,7 +205,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_advanced_options(
       [
-        OptBool.new('ForceExploit', [false, 'Override check result', false]),
         OptInt.new('GROOMSIZE', [true, 'Size of the groom in MB', 250]),
         OptEnum.new('GROOMCHANNEL', [true, 'Channel to use for grooming', 'RDPSND', ['RDPSND', 'MS_T120']]),
         OptInt.new('GROOMCHANNELCOUNT', [true, 'Number of channels to groom', 1]),
@@ -214,10 +214,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    unless check == CheckCode::Vulnerable || datastore['ForceExploit']
-      fail_with(Failure::NotVulnerable, 'Set ForceExploit to override')
-    end
-
     if target['FingerprintOnly']
       fail_with(Msf::Module::Failure::BadConfig, 'Set the most appropriate target manually. If you are targeting 2008, make sure fDisableCam=0 !')
     end

--- a/modules/exploits/windows/smb/ms17_010_eternalblue.rb
+++ b/modules/exploits/windows/smb/ms17_010_eternalblue.rb
@@ -12,6 +12,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::DCERPC
   include Msf::Exploit::Remote::CheckModule
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(
@@ -109,7 +110,6 @@ class MetasploitModule < Msf::Exploit::Remote
     )
     register_advanced_options(
       [
-        OptBool.new('ForceExploit', [false, 'Override check result', false]),
         OptString.new('ProcessName', [true, 'Process to inject payload into.', 'spoolsv.exe']),
         OptInt.new('MaxExploitAttempts', [true, 'The number of times to retry the exploit.', 3]),
         OptInt.new('GroomAllocations', [true, 'Initial number of times to groom the kernel pool.', 12]),


### PR DESCRIPTION
These changes have been made in reference to https://github.com/rapid7/metasploit-framework/pull/13787.

I have migrated the old uses of manual check calls to use the new prepend autocheck approach.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] Test some of the changed modules e.g. `use exploit/android/local/futex_requeue`
- [ ] **Verify** that changed modules operate correctly