### PR TITLE
address final `get_service` call conversion

### DIFF
--- a/lib/rex/parser/acunetix_nokogiri.rb
+++ b/lib/rex/parser/acunetix_nokogiri.rb
@@ -509,7 +509,7 @@ module Rex
       address = resolve_address(host)
       return unless address
       # If we didn't create the service, we don't care about the site
-      service_object = db.get_service @args[:workspace], address, "tcp", port
+      service_object = db.services(:workspace => @args[:workspace], :hosts => {address: address}, :proto => "tcp", :port => port).first
       return unless service_object
       web_site_info = {
         :workspace => @args[:workspace],


### PR DESCRIPTION
A missed conversion from #14143 breaks `acunetix` imports.
Convert the call to `get_service` to use the `services`.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `db_import test.xml` a valid acunetix import with a web page is needed
- [ ] **Verify** the import completes and reports correct details
