### PR TITLE
Unify the socks modules using a VERSION option

### DIFF
--- a/documentation/modules/auxiliary/server/socks_proxy.md
+++ b/documentation/modules/auxiliary/server/socks_proxy.md
@@ -1,0 +1,68 @@
+## Verification Steps
+
+1. Start `msfconsole`
+2. Do: `use auxiliary/server/socks_proxy`
+3. Do: `run`
+4. Do: `curl --proxy socks5://localhost:1080 https://github.com`
+5. You should see the source for the GitHub homepage
+
+## Options
+
+**SRVHOST**
+
+The local IP address to bind the proxy server to. The default value of `0.0.0.0` will expose the proxy to everything on
+the attacker's network.
+
+**SRVPORT**
+
+The local port to bind the proxy to. The default value is `1080`, the standard port for a SOCKS proxy.
+
+## Scenarios
+
+This module is great when pivoting across a network. Suppose we have two machines:
+
+1. Attacker's machine, on the `192.168.1.0/24` subnet.
+2. Victim machine with two network interfaces, one attached to the `192.168.1.0/24` subnet and the other attached to the
+   non-routable `10.0.0.0/24` subnet.
+
+We'll begin by starting the SOCKS proxy:
+```
+msf > use auxiliary/server/socks_proxy
+msf auxiliary(socks_proxy) > run
+[*] Auxiliary module execution completed
+[*] Starting the SOCKS proxy server
+msf auxiliary(socks_proxy) >
+```
+
+Preparing to pivot across a network requires us to first establish a Meterpreter session on the victim machine. From
+there, we can use the `autoroute` script to enable access to the non-routable subnet:
+
+```
+meterpreter > run autoroute -s 10.0.0.0/24
+```
+
+The `autoroute` module will enable our local SOCKS proxy to direct all traffic to the `10.0.0.0/24` subnet through our
+Meterpreter session, causing it to emerge from the victim's machine and thus giving us access to the non-routable
+subnet. We can now use `curl` to connect to a machine on the non-routable subnet via the SOCKS proxy:
+
+```
+curl --proxy socks5://localhost:1080 http://10.0.0.15:8080/robots.txt
+```
+
+We can take this a step further and use proxychains to enable other tools that don't have built-in support for proxies
+to access the non-routable subnet. The short-and-sweet guide to installing and configuring proxychains looks something
+like this:
+
+```
+# apt-get install proxychains
+# cp /etc/proxychains.conf /etc/proxychains.conf.backup
+# echo "socks5 127.0.0.1 8080" > /etc/proxychains.conf
+```
+
+From there, we can use our other tools by simply prefixing them with `proxychains`:
+
+```
+# proxychains curl http://10.0.0.15:8080/robots.txt
+# proxychains nmap -sT -Pn -n -p 22 10.0.0.15
+# proxychains firefox
+```

--- a/lib/msf/core/opt_string.rb
+++ b/lib/msf/core/opt_string.rb
@@ -10,8 +10,7 @@ module Msf
 class OptString < OptBase
 
   # This adds a length parameter to check for the maximum length of strings.
-  def initialize(in_name, attrs = [],
-               required: false, desc: nil, default: nil, enums: [], regex: nil, aliases: [], max_length: nil)
+  def initialize(in_name, attrs = [], **kwargs)
     super
   end
 

--- a/modules/auxiliary/server/socks4a.rb
+++ b/modules/auxiliary/server/socks4a.rb
@@ -9,6 +9,9 @@ require 'rex/proto/proxy/socks4a'
 class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Report
 
+  include Msf::Module::Deprecated
+  deprecated(Date.new(2020, 12, 29), reason="Use auxiliary/server/socks_proxy and set VERSION to 4a")
+
   def initialize
     super(
       'Name'        => 'Socks4a Proxy Server',

--- a/modules/auxiliary/server/socks_proxy.rb
+++ b/modules/auxiliary/server/socks_proxy.rb
@@ -3,7 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-require 'thread'
 require 'rex/proto/proxy/socks4a'
 require 'rex/proto/proxy/socks5'
 
@@ -12,13 +11,13 @@ class MetasploitModule < Msf::Auxiliary
 
   def initialize
     super(
-      'Name'           => 'SOCKS Proxy Server',
-      'Description'    => %q{
+      'Name' => 'SOCKS Proxy Server',
+      'Description' => %q{
         This module provides a SOCKS proxy server that uses the builtin Metasploit routing to relay connections.
       },
-      'Author'         => [ 'sf', 'Spencer McIntyre', 'surefire' ],
-      'License'        => MSF_LICENSE,
-      'Actions'        =>
+      'Author' => [ 'sf', 'Spencer McIntyre', 'surefire' ],
+      'License' => MSF_LICENSE,
+      'Actions' =>
         [
           [ 'Proxy', 'Description' => 'Run a SOCKS proxy server' ]
         ],
@@ -26,15 +25,15 @@ class MetasploitModule < Msf::Auxiliary
         [
           'Proxy'
         ],
-      'DefaultAction'  => 'Proxy'
+      'DefaultAction' => 'Proxy'
     )
 
     register_options([
-      OptString.new('SRVHOST',  [true,  'The address to listen on', '0.0.0.0']),
-      OptPort.new('SRVPORT',    [true,  'The port to listen on', 1080]),
-      OptEnum.new('VERSION',    [ true, 'The SOCKS version to use', '5', %w( 4a 5 ) ]),
-      OptString.new('USERNAME', [false, 'Proxy username for SOCKS5 listener'], conditions: %w( VERSION == 5 )),
-      OptString.new('PASSWORD', [false, 'Proxy password for SOCKS5 listener'], conditions: %w( VERSION == 5 )),
+      OptString.new('SRVHOST', [true, 'The address to listen on', '0.0.0.0']),
+      OptPort.new('SRVPORT', [true, 'The port to listen on', 1080]),
+      OptEnum.new('VERSION', [ true, 'The SOCKS version to use', '5', %w[4a 5] ]),
+      OptString.new('USERNAME', [false, 'Proxy username for SOCKS5 listener'], conditions: %w[VERSION == 5]),
+      OptString.new('PASSWORD', [false, 'Proxy password for SOCKS5 listener'], conditions: %w[VERSION == 5]),
     ])
   end
 
@@ -57,9 +56,9 @@ class MetasploitModule < Msf::Auxiliary
 
   def run
     opts = {
-      'ServerHost'     => datastore['SRVHOST'],
-      'ServerPort'     => datastore['SRVPORT'],
-      'Context'        => {'Msf' => framework, 'MsfExploit' => self}
+      'ServerHost' => datastore['SRVHOST'],
+      'ServerPort' => datastore['SRVPORT'],
+      'Context' => { 'Msf' => framework, 'MsfExploit' => self }
     }
 
     if datastore['VERSION'] == '5'


### PR DESCRIPTION
This consolidates the SOCKS modules under a single new module `socks_proxy` using a `VERSION` datastore option. I deprecated the original two 4a and 5 modules in a week plus 3 months from now and migrated the 4a documentation over to the new module.

No functionality should be lost, the user can just select the version they'd like to use. I default to the newer version (5) which is a lot more stable since I fixed a bunch of reported bugs earlier this year, but again users can easily downgrade by setting the `VERSION` datastore option.

## Verification

- [x] Start `msfconsole`
- [x] `use auxiliary/server/socks_proxy`
- [x] Test version 4a
    - [x] `set VERSION 4a`
    - [x] `set SRVPORT 1084`
    - [x] Run the module and then use curl to validate that it's working: `curl --proxy socks4a://localhost:1084 https://github.com`
- [x] Test version 5
    - [x] `set VERSION 5`
    - [x] `set SRVPORT 1085`
    - [x] Run the module and then use curl to validate that it's working: `curl --proxy socks5://localhost:1085 https://github.com`
