### PR TITLE
Show correct rank for show exploits command

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -1277,7 +1277,7 @@ module Msf
                       count += 1,
                       refname,
                       o.disclosure_date.nil? ? "" : o.disclosure_date.strftime("%Y-%m-%d"),
-                      o.rank_to_s,
+                      o.rank,
                       o.has_check? ? 'Yes' : 'No',
                       o.name
                     ]


### PR DESCRIPTION
closes #14168

## Before

All modules show up with 'manual' rank:
![image](https://user-images.githubusercontent.com/60357436/94001906-15707c00-fd91-11ea-9181-cb709bff2801.png)

## After

The correct rank is shown for each module:
![image](https://user-images.githubusercontent.com/60357436/94001783-ec4feb80-fd90-11ea-9e8d-29753269ec20.png)

## Verification

- open msfconsole
- verify `show exploits` shows the correct rank for modules
- verify `show auxiliary` shows the correct rank for modules