### PR TITLE
Reserve space for the encoder when generating payloads

### DIFF
--- a/lib/msf/core/encoded_payload.rb
+++ b/lib/msf/core/encoded_payload.rb
@@ -65,6 +65,8 @@ class EncodedPayload
 
       # Tell the payload how much space is available
       pinst.available_space = self.space
+      # Reserve 10% of the available space if encoding is required
+      pinst.available_space -= (self.space * 0.1).ceil if needs_encoding
 
       # Generate the raw version of the payload first
       generate_raw() if self.raw.nil?
@@ -125,9 +127,9 @@ class EncodedPayload
   # encoded attribute.
   #
   def encode
-    # If the exploit has bad characters, we need to run the list of encoders
-    # in ranked precedence and try to encode without them.
-    if reqs['Encoder'] || reqs['ForceEncode'] || has_chars?(reqs['BadChars'])
+    # If the exploit needs the payload to be encoded, we need to run the list of
+    # encoders in ranked precedence and try to encode with them.
+    if needs_encoding
       encoders = pinst.compatible_encoders
 
       # Make sure the encoder name from the user has the same String#encoding
@@ -516,11 +518,20 @@ protected
   #
   attr_accessor :reqs
 
+  def needs_encoding
+    reqs['Encoder'] || reqs['ForceEncode'] || has_chars?(reqs['BadChars'])
+  end
+
   def has_chars?(chars)
     # NOTE: BadChars can contain whitespace, so don't use String#blank?
-    if chars.nil? || self.raw.nil? || chars.empty? || self.raw.empty?
+    if chars.nil? || chars.empty?
       return false
     end
+
+    # payload hasn't been set yet but we have bad characters so assume they'll need to be encoded
+    return true if self.raw.nil?
+
+    return false if self.raw.empty?
 
     chars.each_byte do |bad|
       return true if self.raw.index(bad.chr(Encoding::ASCII_8BIT))

--- a/lib/msf/core/encoded_payload.rb
+++ b/lib/msf/core/encoded_payload.rb
@@ -63,10 +63,13 @@ class EncodedPayload
       # First, validate
       pinst.validate()
 
-      # Tell the payload how much space is available
-      pinst.available_space = self.space
-      # Reserve 10% of the available space if encoding is required
-      pinst.available_space -= (self.space * 0.1).ceil if needs_encoding
+      # Propagate space information when set
+      unless self.space.nil?
+        # Tell the payload how much space is available
+        pinst.available_space = self.space
+        # Reserve 10% of the available space if encoding is required
+        pinst.available_space -= (self.space * 0.1).ceil if needs_encoding
+      end
 
       # Generate the raw version of the payload first
       generate_raw() if self.raw.nil?


### PR DESCRIPTION
This PR changes the behavior of the encoded payload to artificially decrease the `available_space` when it is anticipated that the payload will need to be encoded. The reason for this is that many payloads have a stub like the following which will check if there is space that is available to add the exit function and reliability. This causes a problem for exploits with a small amount of space such as `windows/smb/ms08_067_netapi` (where only 408 bytes available). In this case, the payload notices it has enough space and consumes it putting just under the threshold of available space, causing all encoders which also require room to then fail. The 10% that is reserved for encoders was a number artificially chosen by me but was sufficient for the `x86/jmp_call_additive` encoder to do it's job. This issue originally came from the changes I made to the Block API which increased the size of each payload just slightly causing this particular exploit to begin to fail due to the threshold having been reached.

```ruby
    if self.available_space.nil? || required_space <= self.available_space
      conf[:exitfunk] = ds['EXITFUNC']
      conf[:reliable] = true
    end
```

The need to encode is determined by the new `needs_encoding` function which uses the previously inlined logic but has been altered to assume encoding will be required if the exploit explicitly specifies an encoder or bad characters are defined and the payload has not yet been generated. This presents a bit of a chicken and the egg problem, so we just assume that if there are bad characters then we need to encode the payload.

## Verification

- [x] Start `msfconsole`
- [x] `use exploit/windows/smb/ms08_067_netapi`
- [x] Set the options as appropriate, run the exploit and get a shell
- [ ] Test other exploits with payloads that were updated

Fixes #14141
