### PR TITLE
Update Gemfile.local.example to Showcase the Path Option

### DIFF
--- a/Gemfile.local.example
+++ b/Gemfile.local.example
@@ -31,5 +31,5 @@ group :local do
   gem 'lab', '~> 0.2.7'
   # And this is another way that references local directories to find and compile the gem file as needed.
   # This is the optimal method for testing Gem PRs such as those in rex-text or rex-powershell.
-  gem 'rex-powershell', path: '/home/gwillcox-r7/git/rex-powershell'
+  gem 'rex-powershell', path: '../rex-powershell'
 end

--- a/Gemfile.local.example
+++ b/Gemfile.local.example
@@ -27,6 +27,9 @@ end
 
 # Create a custom group
 group :local do
-  # Add the lab gem so that the 'lab' plugin will work again
+  # This is the first way to add a non-standard gem file dependency in.
   gem 'lab', '~> 0.2.7'
+  # And this is another way that references local directories to find and compile the gem file as needed.
+  # This is the optimal method for testing Gem PRs such as those in rex-text or rex-powershell.
+  gem 'rex-powershell', path: '/home/gwillcox-r7/git/rex-powershell'
 end


### PR DESCRIPTION
This PR is a simple update to the Gemfile.local.example file which should show users how to use the `path:` option, which in combination with the wiki page I made at https://github.com/rapid7/metasploit-framework/wiki/Testing-Rex-and-other-Gem-File-Updates-With-Gemfile.local-and-Gemfile.local.example, should allow users to more readily find documentation on how to perform testing of changes in Gem repositories such as `rex-powershell` and `rex-text`. This area has been sorely missing documentation so this is my initial attempt at it based off of what I learned doing it myself. If others have ideas I'm open to hearing them. 

## Verification

- [ ] Make sure that the update to `Gemfile.local.example` makes sense.
- [ ] Confirm that the instructions at https://github.com/rapid7/metasploit-framework/wiki/Testing-Rex-and-other-Gem-File-Updates-With-Gemfile.local-and-Gemfile.local.example make sense and that none of the information there needs to be relocated to this file.
- [ ] Leave a comment below with any changes you think are necessary.
- [ ] Congrats, that's all there is to this PR. Go grab a :beer:
