### PR TITLE
Add missing payload tests

### DIFF
--- a/spec/modules/payloads_spec.rb
+++ b/spec/modules/payloads_spec.rb
@@ -3768,6 +3768,215 @@ RSpec.describe 'modules/payloads', :content do
                           reference_name: 'windows/patchupmeterpreter/reverse_tcp_rc4_dns'
   end
 
+  context 'windows/peinject/bind_hidden_ipknock_tcp' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                              'stagers/windows/bind_hidden_ipknock_tcp',
+                              'stages/windows/peinject'
+                          ],
+                          dynamic_size: true,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'windows/peinject/bind_hidden_ipknock_tcp'
+  end
+
+  context 'windows/peinject/bind_hidden_tcp' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                              'stagers/windows/bind_hidden_tcp',
+                              'stages/windows/peinject'
+                          ],
+                          dynamic_size: true,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'windows/peinject/bind_hidden_tcp'
+  end
+
+  context 'windows/peinject/bind_ipv6_tcp' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                              'stagers/windows/bind_ipv6_tcp',
+                              'stages/windows/peinject'
+                          ],
+                          dynamic_size: true,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'windows/peinject/bind_ipv6_tcp'
+  end
+
+  context 'windows/peinject/bind_ipv6_tcp_uuid' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                              'stagers/windows/bind_ipv6_tcp_uuid',
+                              'stages/windows/peinject'
+                          ],
+                          dynamic_size: true,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'windows/peinject/bind_ipv6_tcp_uuid'
+  end
+
+  context 'windows/peinject/bind_named_pipe' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                              'stagers/windows/bind_named_pipe',
+                              'stages/windows/peinject'
+                          ],
+                          dynamic_size: true,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'windows/peinject/bind_named_pipe'
+  end
+
+  context 'windows/peinject/bind_nonx_tcp' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                              'stagers/windows/bind_nonx_tcp',
+                              'stages/windows/peinject'
+                          ],
+                          dynamic_size: true,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'windows/peinject/bind_nonx_tcp'
+  end
+
+  context 'windows/peinject/bind_tcp' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                              'stagers/windows/bind_tcp',
+                              'stages/windows/peinject'
+                          ],
+                          dynamic_size: true,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'windows/peinject/bind_tcp'
+  end
+
+  context 'windows/peinject/bind_tcp_rc4' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                              'stagers/windows/bind_tcp_rc4',
+                              'stages/windows/peinject'
+                          ],
+                          dynamic_size: true,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'windows/peinject/bind_tcp_rc4'
+  end
+
+  context 'windows/peinject/bind_tcp_uuid' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                              'stagers/windows/bind_tcp_uuid',
+                              'stages/windows/peinject'
+                          ],
+                          dynamic_size: true,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'windows/peinject/bind_tcp_uuid'
+  end
+
+  context 'windows/peinject/find_tag' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                              'stagers/windows/findtag_ord',
+                              'stages/windows/peinject'
+                          ],
+                          dynamic_size: true,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'windows/peinject/find_tag'
+  end
+
+  context 'windows/peinject/reverse_ipv6_tcp' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                              'stagers/windows/reverse_ipv6_tcp',
+                              'stages/windows/peinject'
+                          ],
+                          dynamic_size: true,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'windows/peinject/reverse_ipv6_tcp'
+  end
+
+  context 'windows/peinject/reverse_nonx_tcp' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                              'stagers/windows/reverse_nonx_tcp',
+                              'stages/windows/peinject'
+                          ],
+                          dynamic_size: true,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'windows/peinject/reverse_nonx_tcp'
+  end
+
+  context 'windows/peinject/reverse_ord_tcp' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                              'stagers/windows/reverse_ord_tcp',
+                              'stages/windows/peinject'
+                          ],
+                          dynamic_size: true,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'windows/peinject/reverse_ord_tcp'
+  end
+
+  context 'windows/peinject/reverse_tcp' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                              'stagers/windows/reverse_tcp',
+                              'stages/windows/peinject'
+                          ],
+                          dynamic_size: true,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'windows/peinject/reverse_tcp'
+  end
+
+  context 'windows/peinject/reverse_tcp_allports' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                              'stagers/windows/reverse_tcp_allports',
+                              'stages/windows/peinject'
+                          ],
+                          dynamic_size: true,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'windows/peinject/reverse_tcp_allports'
+  end
+
+  context 'windows/peinject/reverse_tcp_dns' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                              'stagers/windows/reverse_tcp_dns',
+                              'stages/windows/peinject'
+                          ],
+                          dynamic_size: true,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'windows/peinject/reverse_tcp_dns'
+  end
+
+  context 'windows/peinject/reverse_tcp_rc4' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                              'stagers/windows/reverse_tcp_rc4',
+                              'stages/windows/peinject'
+                          ],
+                          dynamic_size: true,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'windows/peinject/reverse_tcp_rc4'
+  end
+
+  context 'windows/peinject/reverse_tcp_rc4_dns' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                              'stagers/windows/reverse_tcp_rc4_dns',
+                              'stages/windows/peinject'
+                          ],
+                          dynamic_size: true,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'windows/peinject/reverse_tcp_rc4_dns'
+  end
+
+  context 'windows/peinject/reverse_tcp_uuid' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                              'stagers/windows/reverse_tcp_uuid',
+                              'stages/windows/peinject'
+                          ],
+                          dynamic_size: true,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'windows/peinject/reverse_tcp_uuid'
+  end
+
   context 'windows/pingback_bind_tcp' do
     it_should_behave_like 'payload cached size is consistent',
                           ancestor_reference_names: [
@@ -4581,6 +4790,116 @@ RSpec.describe 'modules/payloads', :content do
                           dynamic_size: false,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/x64/meterpreter_reverse_tcp'
+  end
+
+  context 'windows/x64/peinject/bind_ipv6_tcp' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                              'stagers/windows/x64/bind_ipv6_tcp',
+                              'stages/windows/x64/peinject'
+                          ],
+                          dynamic_size: true,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'windows/x64/peinject/bind_ipv6_tcp'
+  end
+
+  context 'windows/x64/peinject/bind_ipv6_tcp_uuid' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                              'stagers/windows/x64/bind_ipv6_tcp_uuid',
+                              'stages/windows/x64/peinject'
+                          ],
+                          dynamic_size: true,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'windows/x64/peinject/bind_ipv6_tcp_uuid'
+  end
+
+  context 'windows/x64/peinject/bind_named_pipe' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                              'stagers/windows/x64/bind_named_pipe',
+                              'stages/windows/x64/peinject'
+                          ],
+                          dynamic_size: true,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'windows/x64/peinject/bind_named_pipe'
+  end
+
+  context 'windows/x64/peinject/bind_tcp' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                              'stagers/windows/x64/bind_tcp',
+                              'stages/windows/x64/peinject'
+                          ],
+                          dynamic_size: true,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'windows/x64/peinject/bind_tcp'
+  end
+
+  context 'windows/x64/peinject/bind_tcp_rc4' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                              'stagers/windows/x64/bind_tcp_rc4',
+                              'stages/windows/x64/peinject'
+                          ],
+                          dynamic_size: true,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'windows/x64/peinject/bind_tcp_rc4'
+  end
+
+  context 'windows/x64/peinject/bind_tcp_uuid' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                              'stagers/windows/x64/bind_tcp_uuid',
+                              'stages/windows/x64/peinject'
+                          ],
+                          dynamic_size: true,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'windows/x64/peinject/bind_tcp_uuid'
+  end
+
+  context 'windows/x64/peinject/reverse_named_pipe' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                              'stagers/windows/x64/reverse_named_pipe',
+                              'stages/windows/x64/peinject'
+                          ],
+                          dynamic_size: true,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'windows/x64/peinject/reverse_named_pipe'
+  end
+
+  context 'windows/x64/peinject/reverse_tcp' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                              'stagers/windows/x64/reverse_tcp',
+                              'stages/windows/x64/peinject'
+                          ],
+                          dynamic_size: true,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'windows/x64/peinject/reverse_tcp'
+  end
+
+  context 'windows/x64/peinject/reverse_tcp_rc4' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                              'stagers/windows/x64/reverse_tcp_rc4',
+                              'stages/windows/x64/peinject'
+                          ],
+                          dynamic_size: true,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'windows/x64/peinject/reverse_tcp_rc4'
+  end
+
+  context 'windows/x64/peinject/reverse_tcp_uuid' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                              'stagers/windows/x64/reverse_tcp_uuid',
+                              'stages/windows/x64/peinject'
+                          ],
+                          dynamic_size: true,
+                          modules_pathname: modules_pathname,
+                          reference_name: 'windows/x64/peinject/reverse_tcp_uuid'
   end
 
   context 'windows/x64/powershell_bind_tcp' do

--- a/spec/support/shared/examples/payload_cached_size_is_consistent.rb
+++ b/spec/support/shared/examples/payload_cached_size_is_consistent.rb
@@ -157,7 +157,7 @@ RSpec.shared_examples_for 'payload cached size is consistent' do |options|
       )
     end
 
-    next if reference_name =~ /generic/
+    next if reference_name =~ /generic|peinject/
 
     if dynamic_size
       it 'is dynamic_size?' do


### PR DESCRIPTION
Add payload tests for missing `peinject` stage.

## Verification

List the steps needed to make sure this thing works

- [ ] rake spec does not report missing payload tests.
```
Untested payload detected.  Running `tools/modules/missing_payload_tests.rb` to see contexts to add to `spec/modules/payloads_spec.rb` to test those payload ancestor reference names.
```
