### PR TITLE
Fix port parsing error when importing openvas

### DIFF
--- a/lib/rex/parser/openvas_nokogiri.rb
+++ b/lib/rex/parser/openvas_nokogiri.rb
@@ -112,8 +112,8 @@ module Parser
             @state[:proto] = @text.split('(')[1].split('/')[1].split(')')[0]
             record_service unless @state[:name].nil?
           elsif @text.index('/')
-            @state[:port] = @text.split('/')[0]
-            @state[:proto] = @text.split('/')[1]
+            @state[:port] = @text.split('/')[0].strip
+            @state[:proto] = @text.split('/')[1].strip
             record_service unless @state[:port] == 'general'
           end
         end


### PR DESCRIPTION
Fix port parsing error when importing to import a openvas file.

closes https://github.com/rapid7/metasploit-framework/issues/14174

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] Ensure you are connected to a local database:
```
msf6 exploit(multi/handler) > db_status
[*] Connected to msf. Connection type: postgresql.
```
- [x] Ensure that the example import is extracted [import.xml.zip](https://github.com/rapid7/metasploit-framework/files/5304200/import.xml.zip)
- [x] `db_import import.xml`
- [x] **Verify** that services and hosts are correctly imported:
```
msf6 > hosts

Hosts
=====

address   mac  name  os_name  os_flavor  os_sp  purpose  info  comments
-------   ---  ----  -------  ---------  -----  -------  ----  --------
10.0.2.4             Unknown                    device

msf6 > services
Services
========

host      port  proto  name  state  info
----      ----  -----  ----  -----  ----
10.0.2.4  8787  tcp          open
10.0.2.4  22    tcp          open
10.0.2.4  80    tcp          open
10.0.2.4  445   tcp          open
10.0.2.4  1524  tcp          open
10.0.2.4  3632  tcp          open
10.0.2.4  5432  tcp          open
10.0.2.4  5900  tcp          open
10.0.2.4  6200  tcp          open
10.0.2.4  6667  tcp          open
10.0.2.4  8009  tcp          open
10.0.2.4  21    tcp          open
```

There should be import messages too, but they're not appearing.