### PR TITLE
Add `favorite` module feature and `show favorites` command for msfconsole

### DIFF
--- a/lib/msf/base/config.rb
+++ b/lib/msf/base/config.rb
@@ -202,6 +202,13 @@ class Config < Hash
     self.new.history_file
   end
 
+  # Returns the full path to the fav_modules file.
+  #
+  # @return [String] path the fav_modules file.
+  def self.fav_modules_file
+    self.new.fav_modules_file
+  end
+
   # Returns the full path to the handler file.
   #
   # @return [String] path the handler file.
@@ -291,6 +298,13 @@ class Config < Hash
   # @return [String] path the history file.
   def history_file
     config_directory + FileSep + "history"
+  end
+
+  # Returns the full path to the fav_modules file.
+  #
+  # @return [String] path the fav_modules file.
+  def fav_modules_file
+    config_directory + FileSep + "fav_modules"
   end
 
   # Returns the full path to the handler file.

--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -979,11 +979,12 @@ module Msf
           def cmd_favorite_help
             print_line 'Usage: favorite [mod1 mod2 ...]'
             print_line
-            print_line 'Add current module to the list of favorite modules'
+            print_line 'Add one or multiple modules to the list of favorite modules stored in the fav_modules file'
+            print_line 'If no module name is specified, the command will add the active module if there is one'
             print_line
-            print_line "OPTIONS:"
-            print_line "  -d                Delete the provided module(s) from the fav_modules file"
-            print_line "  -D                Delete the fav_modules file"
+            print_line 'OPTIONS:'
+            print_line '  -d                Delete the provided module(s) or the active module from the fav_modules file'
+            print_line '  -D                Delete the fav_modules file'
           end
 
           #

--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -1006,7 +1006,7 @@ module Msf
                 end
 
                 # remove module from contents (deletion happens below)
-                contents = contents.split("\n")
+                contents = contents.split
                 contents.delete(mod.fullname)
 
               else


### PR DESCRIPTION
## About 
This change adds a new feature to `msfconsole` that allows users to create, view, edit and delete a list of favorite modules. The list is by default stored in the `.msf4` folder in a file called `fav_modules`. The feature adds two new module commands:

- A command called `favorite`, which can be used to add modules to `fav_modules`, to delete modules from it, and to delete the `fav_modules` file altogether.
- A specific `show` command called `show favorites`, which can be used to view all favorited modules in the same output format as other `show` commands.

## Demo
I've made a short demo video of the feature in action. Check it out [here](https://www.youtube.com/watch?v=A_kcwFw4HrI)

## The `favorite` module command
```
Usage: favorite [mod1 mod2 ...]

Add one or multiple modules to the list of favorite modules stored in the fav_modules file
If no module name is specified, the command will add the active module if there is one

OPTIONS:
  -d               Delete the provided module(s) from the fav_modules file
  -D               Delete the fav_modules file
```
### Adding modules
- To add one or multiple modules to fav_modules, run `favorite` followed by the module name(s). It is not always necessary to add the module type at the beginning, eg:
```
msf6 > favorite multi/handler post/multi/manage/autoroute
[*] Added exploit/multi/handler to /root/.msf4/fav_modules
[*] Added post/multi/manage/autoroute to /root/.msf4/fav_modules
```
- To add the active module, just run `favorite` without arguments, eg:
```
msf6 exploit(windows/smb/ms17_010_eternalblue) > favorite 
[*] Added exploit/windows/smb/ms17_010_eternalblue to /root/.msf4/fav_modules
```
### Deleting modules
- To delete one or multiple modules, run `favorite` with the `-d` flag, eg:
```
msf6 exploit(windows/smb/ms17_010_eternalblue) > favorite -d
[*] Removed exploit/windows/smb/ms17_010_eternalblue from /root/.msf4/fav_modules
```
```
msf6 > favorite -d multi/handler post/multi/manage/autoroute
[*] Removed exploit/multi/handler from /root/.msf4/fav_modules
[*] Removed post/multi/manage/autoroute from /root/.msf4/fav_modules
```

- To delete the `fav_modules` file altogether, run `favorite` with the `-D` flag, eg:
```
msf6 > favorite -D
[*] Removing /root/.msf4/fav_modules if it exists
```
### Errors and warnings

- If `favorite` is run without arguments but there is not active module, an error message is printed
```
msf6 > favorite 
[-] No module active
```
- If a user provides an invalid module to add or delete, an error message is printed
```
msf6 > favorite this/is/not/a/module
[-] Invalid module: this/is/not/a/module
```
```
msf6 > favorite -d this/is/not/a/module/either
[-] Invalid module: this/is/not/a/module/either

```
- If a user tries to add a module that is already present in `fav_modules`, the module will not be added and a warning will be printed
```
msf6 > favorite multi/handler
[!] Module exploit/multi/handler has already been favorited and will not be added to /root/.msf4/fav_modules
```
- If a user tries to delete a module that is not present in `fav_modules`, or if `fav_modules` does not exist, `favorite` will do nothing
```
msf6 > favorite -d post/multi/manage/autoroute
msf6 > 
```
- If a user tries to delete `fav_modules` even though it doesn't exist, `favorite` will do nothing
```
msf6 > favorite -D
[*] Removing /root/.msf4/fav_modules if it exists
```
- If the `-D` and `-d` flags are used together, or if the `-D` flag is used together with a module name,`favorite` will delete the `fav_modules` file and return
```
msf6 > favorite -D multi/handler
[*] Removing /root/.msf4/fav_modules if it exists
```
```
msf6 > favorite -D -d
[*] Removing /root/.msf4/fav_modules if it exists
```
```
msf6 > favorite -D -d multi/handler
[*] Removing /root/.msf4/fav_modules if it exists
```
## The `show favorites` command
- `show favorites` can be used to view the list of favorited modules stored in the `fav_modules` file, eg:
```
msf6 > show favorites 

Favorites
=========

   #  Name                                 Disclosure Date  Rank    Check  Description
   -  ----                                 ---------------  ----    -----  -----------
   0  auxiliary/scanner/smb/smb_login                       manual  No     SMB Login Check Scanner
   1  exploit/multi/handler                                 manual  No     Generic Payload Handler
   2  exploit/windows/http/zentao_pro_rce  2020-06-01       manual  Yes    ZenTao Pro 8.8.2 Remote Code Execution
   3  post/multi/manage/autoroute                           manual  No     Multi Manage Network Route via Meterpreter Session
```
- If the `fav_modules` file is empty or does not exist, `show favorites` will print an error message
```
msf6 > show favorites 
[-] /root/.msf4/fav_modules does not exist or is empty
```
## Potential future addition: access via `use <index>`
While msfconsole allows users to access modules listed in search results via the index number, eg `use 5`, this feature is not available for the results of any of the `show` commands. However, if this feature is ever added, it will be immediately available for `show favorites` as well, since this command supports the same output format as other `show` commands like `show post`