### PR TITLE
Fix report_note ActiveRecord::StatementInvalid PG::InvalidTextRepresentation exception

### DIFF
--- a/lib/msf/core/db_manager/note.rb
+++ b/lib/msf/core/db_manager/note.rb
@@ -135,7 +135,7 @@ module Msf::DBManager::Note
     if host and (opts[:port] and proto)
       # only one result can be returned, as the +port+ field restricts potential results to a single service
       service = services(:workspace => wspace,
-                         :hosts => {address: host},
+                         :hosts => {address: host.address},
                          :proto => proto,
                          :port => opts[:port]).first
     elsif opts[:service] and opts[:service].kind_of? ::Mdm::Service


### PR DESCRIPTION
When a port is being specified while reporting a note using `report_note` there is an ActiveRecord exception that is being raised due to the `address` used in the SQL query. This change uses the `#address` attribute of the host, instead of the host object itself in this field allowing the services lookup to succeed.

This bug affects a couple of modules including:
* `auxiliary/gather/windows_secrets_dump`
* `auxiliary/scanner/http/robots_txt`

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/http/robots_txt`
- [ ] Set it to a host that has a robots.txt file so a note gets reported, you can use https://zerosteiner.com/robots.txt
    - [x] `set RHOSTS zerosteiner.com`
    - [x] `set SSL true`
    - [x] `set RPORT 443`
- [x] Run the module and **do not** see an exception, check the output of `notes -t ROBOTS_TXT` and see the expected entry

<details>
<summary>Original Unpatched Exception</summary>

```
msf6 auxiliary(scanner/http/robots_txt) > run

[*] [192.168.249.2] /robots.txt found
[+] Contents of Robots.txt:
User-agent: *
Disallow: 

[*] Error: 192.168.249.2: ActiveRecord::StatementInvalid PG::InvalidTextRepresentation: ERROR:  invalid input syntax for type inet: "2"
: SELECT  "services".* FROM "services" INNER JOIN "hosts" ON "services"."host_id" = "hosts"."id" WHERE "hosts"."workspace_id" = $1 AND "hosts"."address" = $2 AND "services"."proto" = $3 AND "services"."port" = $4 ORDER BY services.port, services.proto, "hosts"."address", "services"."port" ASC LIMIT $5
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf6 auxiliary(scanner/http/robots_txt) >
msf6 auxiliary(scanner/http/robots_txt) > use auxiliary/gather/windows_secrets_dump 
msf6 auxiliary(gather/windows_secrets_dump) > show options 

Module options (auxiliary/gather/windows_secrets_dump):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   RHOSTS                      yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
   RPORT      445              yes       The target port (TCP)
   SMBDomain  .                no        The Windows domain to use for authentication
   SMBPass                     no        The password for the specified username
   SMBUser                     no        The username to authenticate as

msf6 auxiliary(gather/windows_secrets_dump) > set RHOSTS 192.168.159.10 
RHOSTS => 192.168.159.10
msf6 auxiliary(gather/windows_secrets_dump) > set SMBUser smcintyre
SMBUser => smcintyre
msf6 auxiliary(gather/windows_secrets_dump) > set SMBPass Password1
SMBPass => Password1
msf6 auxiliary(gather/windows_secrets_dump) > run
[*] Running module against 192.168.159.10

[*] 192.168.159.10:445 - Service RemoteRegistry is already running
[*] 192.168.159.10:445 - Retrieving target system bootKey
[+] 192.168.159.10:445 - bootKey: 0x42c7cf7f8d076635db445a8c5c75588e
[*] 192.168.159.10:445 - Cleaning up...
[-] 192.168.159.10:445 - Auxiliary failed: ActiveRecord::StatementInvalid PG::InvalidTextRepresentation: ERROR:  invalid input syntax for type inet: "1"
: SELECT  "services".* FROM "services" INNER JOIN "hosts" ON "services"."host_id" = "hosts"."id" WHERE "hosts"."workspace_id" = $1 AND "hosts"."address" = $2 AND "services"."proto" = $3 AND "services"."port" = $4 ORDER BY services.port, services.proto, "hosts"."address", "services"."port" ASC LIMIT $5
[-] 192.168.159.10:445 - Call stack:
[-] 192.168.159.10:445 -   /home/smcintyre/.rvm/gems/ruby-2.6.6@metasploit-framework/gems/activerecord-5.2.4.4/lib/active_record/connection_adapters/postgresql_adapter.rb:611:in `exec_params'
[-] 192.168.159.10:445 -   /home/smcintyre/.rvm/gems/ruby-2.6.6@metasploit-framework/gems/activerecord-5.2.4.4/lib/active_record/connection_adapters/postgresql_adapter.rb:611:in `block (2 levels) in exec_no_cache'
[-] 192.168.159.10:445 -   /home/smcintyre/.rvm/gems/ruby-2.6.6@metasploit-framework/gems/activesupport-5.2.4.4/lib/active_support/dependencies/interlock.rb:48:in `block in permit_concurrent_loads'
[-] 192.168.159.10:445 -   /home/smcintyre/.rvm/gems/ruby-2.6.6@metasploit-framework/gems/activesupport-5.2.4.4/lib/active_support/concurrency/share_lock.rb:187:in `yield_shares'
[-] 192.168.159.10:445 -   /home/smcintyre/.rvm/gems/ruby-2.6.6@metasploit-framework/gems/activesupport-5.2.4.4/lib/active_support/dependencies/interlock.rb:47:in `permit_concurrent_loads'
[-] 192.168.159.10:445 -   /home/smcintyre/.rvm/gems/ruby-2.6.6@metasploit-framework/gems/activerecord-5.2.4.4/lib/active_record/connection_adapters/postgresql_adapter.rb:610:in `block in exec_no_cache'
[-] 192.168.159.10:445 -   /home/smcintyre/.rvm/gems/ruby-2.6.6@metasploit-framework/gems/activerecord-5.2.4.4/lib/active_record/connection_adapters/abstract_adapter.rb:581:in `block (2 levels) in log'
[-] 192.168.159.10:445 -   /home/smcintyre/.rvm/rubies/ruby-2.6.6/lib/ruby/2.6.0/monitor.rb:235:in `mon_synchronize'
[-] 192.168.159.10:445 -   /home/smcintyre/.rvm/gems/ruby-2.6.6@metasploit-framework/gems/activerecord-5.2.4.4/lib/active_record/connection_adapters/abstract_adapter.rb:580:in `block in log'
[-] 192.168.159.10:445 -   /home/smcintyre/.rvm/gems/ruby-2.6.6@metasploit-framework/gems/activesupport-5.2.4.4/lib/active_support/notifications/instrumenter.rb:23:in `instrument'
[-] 192.168.159.10:445 -   /home/smcintyre/.rvm/gems/ruby-2.6.6@metasploit-framework/gems/activerecord-5.2.4.4/lib/active_record/connection_adapters/abstract_adapter.rb:571:in `log'
[-] 192.168.159.10:445 -   /home/smcintyre/.rvm/gems/ruby-2.6.6@metasploit-framework/gems/activerecord-5.2.4.4/lib/active_record/connection_adapters/postgresql_adapter.rb:609:in `exec_no_cache'
[-] 192.168.159.10:445 -   /home/smcintyre/.rvm/gems/ruby-2.6.6@metasploit-framework/gems/activerecord-5.2.4.4/lib/active_record/connection_adapters/postgresql_adapter.rb:598:in `execute_and_clear'
[-] 192.168.159.10:445 -   /home/smcintyre/.rvm/gems/ruby-2.6.6@metasploit-framework/gems/activerecord-5.2.4.4/lib/active_record/connection_adapters/postgresql/database_statements.rb:81:in `exec_query'
[-] 192.168.159.10:445 -   /home/smcintyre/.rvm/gems/ruby-2.6.6@metasploit-framework/gems/activerecord-5.2.4.4/lib/active_record/connection_adapters/abstract/database_statements.rb:478:in `select'
[-] 192.168.159.10:445 -   /home/smcintyre/.rvm/gems/ruby-2.6.6@metasploit-framework/gems/activerecord-5.2.4.4/lib/active_record/connection_adapters/abstract/database_statements.rb:70:in `select_all'
[-] 192.168.159.10:445 -   /home/smcintyre/.rvm/gems/ruby-2.6.6@metasploit-framework/gems/activerecord-5.2.4.4/lib/active_record/connection_adapters/abstract/query_cache.rb:106:in `select_all'
[-] 192.168.159.10:445 -   /home/smcintyre/.rvm/gems/ruby-2.6.6@metasploit-framework/gems/activerecord-5.2.4.4/lib/active_record/querying.rb:41:in `find_by_sql'
[-] 192.168.159.10:445 -   /home/smcintyre/.rvm/gems/ruby-2.6.6@metasploit-framework/gems/activerecord-5.2.4.4/lib/active_record/relation.rb:560:in `block in exec_queries'
[-] 192.168.159.10:445 -   /home/smcintyre/.rvm/gems/ruby-2.6.6@metasploit-framework/gems/activerecord-5.2.4.4/lib/active_record/relation.rb:584:in `skip_query_cache_if_necessary'
[-] 192.168.159.10:445 -   /home/smcintyre/.rvm/gems/ruby-2.6.6@metasploit-framework/gems/activerecord-5.2.4.4/lib/active_record/relation.rb:547:in `exec_queries'
[-] 192.168.159.10:445 -   /home/smcintyre/.rvm/gems/ruby-2.6.6@metasploit-framework/gems/activerecord-5.2.4.4/lib/active_record/association_relation.rb:34:in `exec_queries'
[-] 192.168.159.10:445 -   /home/smcintyre/.rvm/gems/ruby-2.6.6@metasploit-framework/gems/activerecord-5.2.4.4/lib/active_record/relation.rb:422:in `load'
[-] 192.168.159.10:445 -   /home/smcintyre/.rvm/gems/ruby-2.6.6@metasploit-framework/gems/activerecord-5.2.4.4/lib/active_record/relation.rb:200:in `records'
[-] 192.168.159.10:445 -   /home/smcintyre/.rvm/gems/ruby-2.6.6@metasploit-framework/gems/activerecord-5.2.4.4/lib/active_record/relation.rb:195:in `to_ary'
[-] 192.168.159.10:445 -   /home/smcintyre/.rvm/gems/ruby-2.6.6@metasploit-framework/gems/activerecord-5.2.4.4/lib/active_record/relation/finder_methods.rb:532:in `find_nth_with_limit'
[-] 192.168.159.10:445 -   /home/smcintyre/.rvm/gems/ruby-2.6.6@metasploit-framework/gems/activerecord-5.2.4.4/lib/active_record/relation/finder_methods.rb:517:in `find_nth'
[-] 192.168.159.10:445 -   /home/smcintyre/.rvm/gems/ruby-2.6.6@metasploit-framework/gems/activerecord-5.2.4.4/lib/active_record/relation/finder_methods.rb:125:in `first'
[-] 192.168.159.10:445 -   /home/smcintyre/Repositories/metasploit-framework/lib/msf/core/db_manager/note.rb:140:in `block in report_note'
[-] 192.168.159.10:445 -   /home/smcintyre/.rvm/gems/ruby-2.6.6@metasploit-framework/gems/activerecord-5.2.4.4/lib/active_record/connection_adapters/abstract/connection_pool.rb:416:in `with_connection'
[-] 192.168.159.10:445 -   /home/smcintyre/Repositories/metasploit-framework/lib/msf/core/db_manager/note.rb:81:in `report_note'
[-] 192.168.159.10:445 -   /home/smcintyre/Repositories/metasploit-framework/lib/metasploit/framework/data_service/proxy/note_data_proxy.rb:40:in `block in report_note'
[-] 192.168.159.10:445 -   /home/smcintyre/Repositories/metasploit-framework/lib/metasploit/framework/data_service/proxy/core.rb:166:in `data_service_operation'
[-] 192.168.159.10:445 -   /home/smcintyre/Repositories/metasploit-framework/lib/metasploit/framework/data_service/proxy/note_data_proxy.rb:38:in `report_note'
[-] 192.168.159.10:445 -   /home/smcintyre/Repositories/metasploit-framework/lib/msf/core/auxiliary/report.rb:177:in `report_note'
[-] 192.168.159.10:445 -   /home/smcintyre/Repositories/metasploit-framework/modules/auxiliary/gather/windows_secrets_dump.rb:457:in `report_info'
[-] 192.168.159.10:445 -   /home/smcintyre/Repositories/metasploit-framework/modules/auxiliary/gather/windows_secrets_dump.rb:1054:in `run'
[*] Auxiliary module execution completed
msf6 auxiliary(gather/windows_secrets_dump) >
```
</details>

<details>
<summary>Newly Patched, No Exception</summary>

```
msf6 auxiliary(scanner/http/robots_txt) > show options 

Module options (auxiliary/scanner/http/robots_txt):

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   PATH     /                yes       The test path to find robots.txt file
   Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS   zerosteiner.com  yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
   RPORT    443              yes       The target port (TCP)
   SSL      true             no        Negotiate SSL/TLS for outgoing connections
   THREADS  1                yes       The number of concurrent threads (max one per host)
   VHOST                     no        HTTP server virtual host

msf6 auxiliary(scanner/http/robots_txt) > run

[*] [192.168.249.2] /robots.txt found
[+] Contents of Robots.txt:
User-agent: *
Disallow: 

[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf6 auxiliary(scanner/http/robots_txt) > notes -t ROBOTS_TXT

Notes
=====

 Time                     Host           Service  Port  Protocol  Type        Data
 ----                     ----           -------  ----  --------  ----        ----
 2020-09-30 18:00:04 UTC  192.168.249.2  https    443   tcp       ROBOTS_TXT  ""

msf6 auxiliary(scanner/http/robots_txt) >
```
</details>