### PR TITLE
creds need web service to support request by `:id`

### DIFF
--- a/lib/metasploit/framework/data_service/remote/http/remote_service_data_service.rb
+++ b/lib/metasploit/framework/data_service/remote/http/remote_service_data_service.rb
@@ -3,7 +3,8 @@ module RemoteServiceDataService
   SERVICE_MDM_CLASS = 'Mdm::Service'
 
   def services(opts)
-    json_to_mdm_object(self.get_data(SERVICE_API_PATH, nil, opts), SERVICE_MDM_CLASS)
+    path = get_path_select(opts, SERVICE_API_PATH)
+    json_to_mdm_object(self.get_data(path, nil, opts), SERVICE_MDM_CLASS)
   end
 
   def report_service(opts)

--- a/lib/msf/core/web_services/servlet/service_servlet.rb
+++ b/lib/msf/core/web_services/servlet/service_servlet.rb
@@ -10,6 +10,7 @@ module ServiceServlet
 
   def self.registered(app)
     app.get  ServiceServlet.api_path, &get_services
+    app.get  ServiceServlet.api_path_with_id, &get_services
     app.post ServiceServlet.api_path, &report_service
     app.put ServiceServlet.api_path_with_id, &update_service
     app.delete ServiceServlet.api_path, &delete_service


### PR DESCRIPTION
When using a `remote data service` the `services` endpoint needs to support request for a single known `:id` service.

## Verification

List the steps needed to make sure this thing works

- [ ] setup a `metasploitable3` target
- [ ] Start `msfconsole` with `web service` based db access
- [ ] `use gather/windows_secrets_dump`
- [ ] `set LHOST <metasploitable3 IP>`
- [ ] `set SMBUser vagrant`
- [ ] `set SMBPass vagrant`
- [ ] `creds`
- [ ] **Verify** creds display properly

