### PR TITLE
Fix invalid disclosure date formats

### DIFF
--- a/modules/auxiliary/gather/pimcore_creds_sqli.rb
+++ b/modules/auxiliary/gather/pimcore_creds_sqli.rb
@@ -35,7 +35,7 @@ class MetasploitModule < Msf::Auxiliary
         {
           'SideEffects' => [ IOC_IN_LOGS ]
         },
-      'DisclosureDate' => 'Aug 13, 2018'
+      'DisclosureDate' => 'Aug 13 2018'
     ))
 
     register_options(

--- a/modules/auxiliary/scanner/memcached/memcached_amp.rb
+++ b/modules/auxiliary/scanner/memcached/memcached_amp.rb
@@ -24,7 +24,7 @@ class MetasploitModule < Msf::Auxiliary
           'Jon Hart <jon_hart@rapid7.com>', # Metasploit scanner module
         ],
       'License'     => MSF_LICENSE,
-      'DisclosureDate' => 'Feb 27, 2018',
+      'DisclosureDate' => 'Feb 27 2018',
       'References'  =>
           [
             ['URL', 'https://blog.cloudflare.com/memcrashed-major-amplification-attacks-from-port-11211/'],

--- a/modules/auxiliary/scanner/memcached/memcached_udp_version.rb
+++ b/modules/auxiliary/scanner/memcached/memcached_udp_version.rb
@@ -21,7 +21,7 @@ class MetasploitModule < Msf::Auxiliary
           'Jon Hart <jon_hart@rapid7.com>' # Metasploit scanner module
         ],
       'License'     => MSF_LICENSE,
-      'DisclosureDate' => 'Jul 23, 2003',
+      'DisclosureDate' => 'Jul 23 2003',
       'References' =>
           [
             ['URL', 'https://github.com/memcached/memcached/blob/master/doc/protocol.txt']

--- a/modules/auxiliary/scanner/telnet/satel_cmd_exec.rb
+++ b/modules/auxiliary/scanner/telnet/satel_cmd_exec.rb
@@ -25,7 +25,7 @@ class MetasploitModule < Msf::Auxiliary
         [
           'Karn Ganeshen <KarnGaneshen[at]gmail.com>'
         ],
-      'DisclosureDate' => 'Apr 07, 2017',
+      'DisclosureDate' => 'Apr 07 2017',
       'License' => MSF_LICENSE,
       'DefaultOptions' => { 'VERBOSE' => true })
       )

--- a/modules/exploits/linux/http/dcos_marathon.rb
+++ b/modules/exploits/linux/http/dcos_marathon.rb
@@ -44,7 +44,7 @@ class MetasploitModule < Msf::Exploit::Remote
       ],
       'DefaultOptions' => { 'WfsDelay' => 75 },
       'DefaultTarget'  => 0,
-      'DisclosureDate' => 'Mar 03, 2017'))
+      'DisclosureDate' => 'Mar 03 2017'))
 
     register_options(
       [

--- a/modules/exploits/linux/http/docker_daemon_tcp.rb
+++ b/modules/exploits/linux/http/docker_daemon_tcp.rb
@@ -31,7 +31,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ['URL', 'https://docs.docker.com/engine/security/security/#docker-daemon-attack-surface'],
         ['URL', 'https://docs.docker.com/engine/reference/commandline/dockerd/#bind-docker-to-another-hostport-or-a-unix-socket']
       ],
-      'DisclosureDate'   => 'Jul 25, 2017',
+      'DisclosureDate'   => 'Jul 25 2017',
       'Targets'          => [
         [ 'Linux x64', {
           'Arch'         => ARCH_X64,

--- a/modules/exploits/linux/http/nagios_xi_chained_rce_2_electric_boogaloo.rb
+++ b/modules/exploits/linux/http/nagios_xi_chained_rce_2_electric_boogaloo.rb
@@ -54,7 +54,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'DefaultOptions' => {
          'WfsDelay' => 30
       },
-      'DisclosureDate'  => 'Apr 17, 2018',
+      'DisclosureDate'  => 'Apr 17 2018',
       'DefaultTarget'   => 0))
     register_options(
       [

--- a/modules/exploits/linux/http/rancher_server.rb
+++ b/modules/exploits/linux/http/rancher_server.rb
@@ -38,7 +38,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Targets'          => [[ 'Linux', {} ]],
       'DefaultOptions'   => { 'WfsDelay' => 75, 'Payload' => 'linux/x64/meterpreter/reverse_tcp' },
       'DefaultTarget'    => 0,
-      'DisclosureDate'   => 'Jul 27, 2017'))
+      'DisclosureDate'   => 'Jul 27 2017'))
 
     register_options(
       [

--- a/modules/exploits/multi/http/mantisbt_manage_proj_page_rce.rb
+++ b/modules/exploits/multi/http/mantisbt_manage_proj_page_rce.rb
@@ -33,7 +33,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [
             [ 'Mantis <= 1.1.3', { } ],
           ],
-      'DisclosureDate' => 'Oct 16, 2008',
+      'DisclosureDate' => 'Oct 16 2008',
       'DefaultTarget' => 0))
      register_options(
       [

--- a/modules/exploits/multi/misc/erlang_cookie_rce.rb
+++ b/modules/exploits/multi/misc/erlang_cookie_rce.rb
@@ -57,7 +57,7 @@ class MetasploitModule < Msf::Exploit::Remote
             ]
           ],
         'DefaultTarget'  => 0,
-        'DisclosureDate' => 'Nov 20, 2009', # https://github.com/erlang/otp/blob/master/lib/kernel/src/os.erl (history)
+        'DisclosureDate' => 'Nov 20 2009', # https://github.com/erlang/otp/blob/master/lib/kernel/src/os.erl (history)
       )
     )
 

--- a/modules/exploits/unix/http/pfsense_graph_injection_exec.rb
+++ b/modules/exploits/unix/http/pfsense_graph_injection_exec.rb
@@ -54,7 +54,7 @@ class MetasploitModule < Msf::Exploit::Remote
           },
         'Targets'        => [[ 'Automatic Target', {} ]],
         'DefaultTarget'  => 0,
-        'DisclosureDate' => 'Apr 18, 2016',
+        'DisclosureDate' => 'Apr 18 2016',
       )
     )
 


### PR DESCRIPTION
Fixing some disclosure dates that were incorrectly formatted.

## Verification

Verified that the modules still load as expected and that the `info`/`search` command works as expected.

- [x] Start `msfconsole`
- [x] `use pimcore_creds_sqli`
- [x] `info`
- [x] **Verify** the date is formatted as expected - `2018-08-13`