### PR TITLE
Roll back Travis testing to 2.7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ language: ruby
 rvm:
   - '2.5.8'
   - '2.6.6'
-  - '2.7.2'
+  - '2.7.1'
 
 env:
   - CMD='bundle exec rake rspec-rerun:spec SPEC_OPTS="--tag content"'


### PR DESCRIPTION
2.7.2 is not available yet in RVM.

Verification
=========
- [ ] Travis runs complete without failure
