### PR TITLE
updates Dockerfile for bundler 2 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,7 @@ RUN chown -R root:metasploit /usr/local/bundle
 COPY . $APP_HOME/
 RUN chown -R root:metasploit $APP_HOME/
 RUN chmod 664 $APP_HOME/Gemfile.lock
+RUN gem update --system
 RUN cp -f $APP_HOME/docker/database.yml $APP_HOME/config/database.yml
 RUN pip install impacket
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ruby:2.6.6-alpine3.10 AS builder
 LABEL maintainer="Rapid7"
 
-ARG BUNDLER_ARGS="--jobs=8 --without development test coverage"
+ARG BUNDLER_CONFIG_ARGS="set clean 'true' set no-cache 'true' set system 'true' set without 'development test coverage'"
 ENV APP_HOME=/usr/src/metasploit-framework
 ENV BUNDLE_IGNORE_MESSAGES="true"
 WORKDIR $APP_HOME
@@ -28,8 +28,9 @@ RUN apk add --no-cache \
       ncurses-dev \
       git \
     && echo "gem: --no-document" > /etc/gemrc \
-    && gem update --system 3.0.6 \
-    && bundle install --force --clean --no-cache --system $BUNDLER_ARGS \
+    && gem update --system \
+    && bundle config $BUNDLER_ARGS \
+    && bundle install --redownload --jobs=8 \
     # temp fix for https://github.com/bundler/bundler/issues/6680
     && rm -rf /usr/local/bundle/cache \
     # needed so non root users can read content of the bundle

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN apk add --no-cache \
     && chmod -R a+r /usr/local/bundle
 
 
-FROM ruby:2.6.5-alpine3.10
+FROM ruby:2.6.6-alpine3.10
 LABEL maintainer="Rapid7"
 
 ENV APP_HOME=/usr/src/metasploit-framework


### PR DESCRIPTION
Updates in Gemfile.lock now require bundler 2.x support and use new config syntax requirements.

Unlock rubygems version to bring in the latest compatible rubygems and `vendor` version of bundler.  

## Verification

List the steps needed to make sure this thing works

- [ ] `docker build -t msf .`
- [ ] **Verify** container builds properly
