### PR TITLE
Randomly generate hashes for hashlib and networking specs

### DIFF
--- a/lib/msf/core/auxiliary/brocade.rb
+++ b/lib/msf/core/auxiliary/brocade.rb
@@ -92,7 +92,7 @@ module Msf
       # user account
       # Example lines:
       # username brocade password 8 $1$YBaHUWpr$PzeUrP0XmVOyVNM5rYy99/
-      config.scan(%r{username "?(?<user_name>[a-z0-9]+)"? password (?<user_type>\w+) (?<user_hash>[0-9a-z=\$/]{34})}i).each do |result|
+      config.scan(%r{username "?(?<user_name>[a-z0-9]+)"? password (?<user_type>\w+) (?<user_hash>[0-9a-z=\$/\.]{34})}i).each do |result|
         user_name = result[0].strip
         user_type = result[1].strip
         user_hash = result[2].strip


### PR DESCRIPTION
https://github.com/rapid7/metasploit-framework/pull/14031#discussion_r474726358

The hashlib spec, and networking specs now randomly generate md5 and sha256 password hashes to test against.
Also fixed a bug in the Brocade hash checks where `.` wasn't a valid character.