### PR TITLE
Update php_fpm_rce.rb

### DIFF
--- a/modules/exploits/multi/http/php_fpm_rce.rb
+++ b/modules/exploits/multi/http/php_fpm_rce.rb
@@ -126,8 +126,8 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def send_crafted_request(path:, qsl: datastore['MinQSL'], customh_length: 1, cmd: '', allow_retry: true)
-    uri = URI.encode(normalize_uri(target_uri.path, path)).gsub(/([?&])/, {'?'=>'%3F', '&'=>'%26'})
-    qsl_delta = uri.length - path.length - URI.encode(target_uri.path).length
+    uri = CGI.escape(normalize_uri(target_uri.path, path)).gsub(/([?&])/, {'?'=>'%3F', '&'=>'%26'})
+    qsl_delta = uri.length - path.length - CGI.escape(target_uri.path).length
     if qsl_delta.odd?
       fail_with Failure::Unknown, "Got odd qslDelta, that means the URL encoding gone wrong: path=#{path}, qsl_delta=#{qsl_delta}"
     end


### PR DESCRIPTION
URI.encode/URI.escape is obsolete and will raise depreciation warnings every time it is called, which can result in a lot of extra output that can clutter users screens. This PR replaces this call within `php_fpm_rce.rb` with calls to CGI.escape to appropriately resolve these depreciation errors.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/multi/http/php_fpm_rce`
- [ ] Configure Options
- [ ] 'exploit"


Original Code:
![image](https://user-images.githubusercontent.com/37945660/95103302-763d7400-0702-11eb-8873-f462c4e5f627.png)

Updated Code:
![image](https://user-images.githubusercontent.com/37945660/95103287-70e02980-0702-11eb-9239-7ce2f4edba2c.png)