### PR TITLE
Fix store_loot bug within several cn-kali-team modules

### DIFF
--- a/modules/post/windows/gather/credentials/securecrt.rb
+++ b/modules/post/windows/gather/credentials/securecrt.rb
@@ -211,7 +211,7 @@ class MetasploitModule < Msf::Post
       end
       print_line(tbl.to_s)
       if tbl.rows.count
-        path = store_loot('host.securecrt_sessions', 'text/plain', session, tbl, 'securecrt_sessions.txt', 'SecureCRT Sessions')
+        path = store_loot('host.securecrt_sessions', 'text/plain', session, tbl.to_s, 'securecrt_sessions.txt', 'SecureCRT Sessions')
         print_good("Session info stored in: #{path}")
       end
     end

--- a/modules/post/windows/gather/credentials/xshell_xftp_password.rb
+++ b/modules/post/windows/gather/credentials/xshell_xftp_password.rb
@@ -184,7 +184,7 @@ class MetasploitModule < Msf::Post
     print_line(tbl.to_s)
     # Only save data to disk when there's something in the table
     if tbl.rows.count
-      path = store_loot('host.xshell_xftp_password', 'text/plain', session, tbl, 'xshell_xftp_password.txt', 'Xshell Xftp Passwords')
+      path = store_loot('host.xshell_xftp_password', 'text/plain', session, tbl.to_s, 'xshell_xftp_password.txt', 'Xshell Xftp Passwords')
       print_good("Passwords stored in: #{path}")
     end
   end


### PR DESCRIPTION
This PR fixes a bug that was overlooked when reviewing https://github.com/rapid7/metasploit-framework/pull/14199, whereby the SecureCRT module will fail to complete without giving a stack trace as a call to `store_loot` is made with the contents of a `Rex::Text:Table`. Unfortunately the `store_loot` method is expecting a string and will try to call `.empty?` on the `Rex::Text::Table` object, which does not have a `.empty?` method, resulting in a stack trace.

This PR updates the code so that the contents of the `Rex::Text::Table` are first converted into a string prior to being passed to the `store_loot` call.

EDIT: This PR also fixes the same issue within `post/windows/gather/credentials/xshell_xftp_password.rb` as pointed out by @cn-kali-team.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] Gain a Meterpreter shell on a Windows target with SecureCRT installed and which has several sessions, some of which have blank username and password fields.
- [ ] Ensure that `post/windows/gather/credentials/securecrt.rb` runs without generating a stack trace.
- [ ] Report any errors encountered.
- [ ] Gain a Meterpreter shell on a Windows target with XShell XFTP installed and which is configured to save XShell sessions with username and password info included.
- [ ] Ensure that `post/windows/gather/credentials/xshell_xftp_password.rb` runs without generating a stack trace.
- [ ] Report any errors encountered.