### PR TITLE
rescue SSLError in HTTP scanner check_setup

### DIFF
--- a/lib/metasploit/framework/login_scanner/chef_webui.rb
+++ b/lib/metasploit/framework/login_scanner/chef_webui.rb
@@ -57,7 +57,7 @@ module Metasploit
               return "Unexpected HTTP body (is this really Chef WebUI?)"
             end
 
-          rescue ::EOFError, Errno::ETIMEDOUT, Rex::ConnectionError, ::Timeout::Error
+          rescue ::EOFError, Errno::ETIMEDOUT, OpenSSL::SSL::SSLError, Rex::ConnectionError, ::Timeout::Error
             return "Unable to connect to target"
           end
 

--- a/lib/metasploit/framework/login_scanner/glassfish.rb
+++ b/lib/metasploit/framework/login_scanner/glassfish.rb
@@ -56,7 +56,7 @@ module Metasploit
             if @version.nil? || @version !~ /^[2349]/
               return "Unsupported version ('#{@version}')"
             end
-          rescue ::EOFError, Errno::ETIMEDOUT, Rex::ConnectionError, ::Timeout::Error
+          rescue ::EOFError, Errno::ETIMEDOUT, OpenSSL::SSL::SSLError, Rex::ConnectionError, ::Timeout::Error
             return "Unable to connect to target"
           end
 

--- a/lib/metasploit/framework/login_scanner/http.rb
+++ b/lib/metasploit/framework/login_scanner/http.rb
@@ -190,8 +190,8 @@ module Metasploit
             # Use _send_recv instead of send_recv to skip automatic
             # authentication
             response = http_client._send_recv(request)
-          rescue ::EOFError, Errno::ETIMEDOUT, Rex::ConnectionError, ::Timeout::Error
-            error_message = "Unable to connect to target"
+          rescue ::EOFError, Errno::ETIMEDOUT, OpenSSL::SSL::SSLError, Rex::ConnectionError, ::Timeout::Error
+            return "Unable to connect to target"
           end
 
           if !(response && response.code == 401 && response.headers['WWW-Authenticate'])

--- a/lib/metasploit/framework/login_scanner/zabbix.rb
+++ b/lib/metasploit/framework/login_scanner/zabbix.rb
@@ -54,7 +54,7 @@ module Metasploit
 
             self.version = $1
 
-          rescue ::EOFError, Errno::ETIMEDOUT, Rex::ConnectionError, ::Timeout::Error
+          rescue ::EOFError, Errno::ETIMEDOUT, OpenSSL::SSL::SSLError, Rex::ConnectionError, ::Timeout::Error
             return "Unable to connect to target"
           end
 


### PR DESCRIPTION
By capturing possible connection errors when SSL cannot be
negotiated, this update prevents early exit due to failure of a
single IP when scanning a range of IPs

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use` an https based login_scanner to scan a host with the service unable to offer SSL support
- [ ] **Verify** module completes
- [ ] **Verify** no exception occurs

Note: there are at least 10 other known overrides of `check_setup` that do not rescue any errors.  Due to inconsistent behaviors for these methods, scope has been limited to get a start on improvements.