### PR TITLE
Update metasploit-payloads gem to 2.0.16

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,7 +29,7 @@ PATH
       metasploit-concern
       metasploit-credential
       metasploit-model
-      metasploit-payloads (= 2.0.14)
+      metasploit-payloads (= 2.0.16)
       metasploit_data_models
       metasploit_payloads-mettle (= 1.0.2)
       mqtt

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -70,7 +70,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '2.0.14'
+  spec.add_runtime_dependency 'metasploit-payloads', '2.0.16'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '1.0.2'
   # Needed by msfgui and other rpc components


### PR DESCRIPTION
This PR bumps framework to use Metasploit payloads gem 2.0.16, pulling in the following payloads PR changes:
https://github.com/rapid7/metasploit-payloads/pull/437
https://github.com/rapid7/metasploit-payloads/pull/438

## Verification

List the steps needed to make sure this thing works

- [ ] Retest manually 
- [ ] Let automated tests pass
