### PR TITLE
Always show module actions within the info command

### DIFF
--- a/lib/msf/base/serializer/readable_text.rb
+++ b/lib/msf/base/serializer/readable_text.rb
@@ -320,7 +320,7 @@ class ReadableText
     output << dump_traits(mod)
 
     # Actions
-    if mod.action
+    if mod.actions.any?
       output << "Available actions:\n"
       output << dump_module_actions(mod, indent)
     end
@@ -385,7 +385,7 @@ class ReadableText
     end
 
     # Actions
-    if mod.action
+    if mod.actions.any?
       output << "Available actions:\n"
       output << dump_module_actions(mod, indent)
     end


### PR DESCRIPTION
Always show module actions within the info command.

### Before

Actions are not always shown to the user

![image](https://user-images.githubusercontent.com/60357436/95393041-c62e5d80-08f1-11eb-9b6a-357b6a2273fd.png)

### After

Actions are now shown

![image](https://user-images.githubusercontent.com/60357436/95392944-8d8e8400-08f1-11eb-9887-f8beff543100.png)

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use admin/serverprotect/file`
- [x] `info`
- [x] **Verify** the available actions show as expected

- [x] Start `msfconsole`
- [x] use a module that doesn't have any options
- [x] `info`
- [x] **Verify** no actions show