### PR TITLE
updates Vagrantfile to support vmware_desktop

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,17 +6,18 @@ display_name = "metasploit-framework"
 Vagrant.configure(2) do |config|
   config.ssh.forward_x11 = true
   config.vm.box = "hashicorp/bionic64" # https://app.vagrantup.com/hashicorp/boxes/bionic64
-  #config.gui = true # uncomment to show VM in your hypervisor's GUI
   config.vm.network :forwarded_port, guest: 4444, host: 4444
   config.vm.provider "vmware_desktop" do |v|
 	  v.memory = 2048
 	  v.cpus = 2
     v.vmx['displayname'] = display_name
+    #v.gui = true # uncomment to show VM in your hypervisor's GUI
   end
   config.vm.provider "virtualbox" do |v|
     v.name = display_name
 	  v.memory = 2048
 	  v.cpus = 2
+    #v.gui = true # uncomment to show VM in your hypervisor's GUI
   end
   %w(.vimrc .gitconfig).each do |f|
     local = File.expand_path "~/#{f}"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,15 +1,20 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+display_name = "metasploit-framework"
+
 Vagrant.configure(2) do |config|
   config.ssh.forward_x11 = true
-  config.vm.box = "ubuntu/bionic64"
+  config.vm.box = "hashicorp/bionic64" # https://app.vagrantup.com/hashicorp/boxes/bionic64
+  #config.gui = true # uncomment to show VM in your hypervisor's GUI
   config.vm.network :forwarded_port, guest: 4444, host: 4444
-  config.vm.provider "vmware" do |v|
+  config.vm.provider "vmware_desktop" do |v|
 	  v.memory = 2048
 	  v.cpus = 2
+    v.vmx['displayname'] = display_name
   end
   config.vm.provider "virtualbox" do |v|
+    v.name = display_name
 	  v.memory = 2048
 	  v.cpus = 2
   end
@@ -28,11 +33,16 @@ Vagrant.configure(2) do |config|
     config.vm.provision "shell", inline: step
   end
 
-  [ "gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB",
-    "curl -L https://get.rvm.io | bash -s stable",
-    "source ~/.rvm/scripts/rvm && cd /vagrant && rvm install `cat .ruby-version`",
-    "source ~/.rvm/scripts/rvm && cd /vagrant && bundle",
-    "mkdir -p ~/.msf4",
+  [ # use the rvm install method used in omnibus install
+    # only show stderr when gpg really fails. avoids superfluous stderr from gpg
+    'out=`curl -sSL https://rvm.io/mpapis.asc | gpg --import - 2>&1` && echo "imported mpapis.asc" || echo $out 1>&2',
+    'out=`curl -sSL https://rvm.io/pkuczynski.asc | gpg --import - 2>&1` && echo "imported pkuczynski.asc" || echo $out 1>&2',
+    'out=`curl -L -sSL https://get.rvm.io | bash -s stable 2>&1` && echo "rvm installed" || echo $out 1>&2',
+    # only install Ruby if the right version isn't already present
+    "echo 'Installing Ruby if necessary'",
+    'cd /vagrant && rv=`cat .ruby-version` && source ~/.rvm/scripts/rvm && rvm list strings | grep -q $rv || rvm install $rv',
+    'source ~/.rvm/scripts/rvm && cd /vagrant && gem install --quiet bundler && bundle',
+    'mkdir -p ~/.msf4',
   ].each do |step|
     config.vm.provision "shell", privileged: false, inline: step
   end


### PR DESCRIPTION
Coordinated with @jmartin-r7 

- changes box from ubuntu/bionic64 to hashicorp/bionic64 as Canonical doesn't have a vmware box
- makes it obvious how to allow the VM to show up in the hypervisor GUI
- updates vmware provider to be the official vmware_desktop provider
- Adds a VM display name option
- Changes gpg key imports and rvm install to match what's in omnibus
- handles stderr better to avoid some extra warnings unless there's a real failure
- Installs Ruby only if it's not installed already (nicer if have to reprovision the box)
- switches back to gem install bundler due to upstream bundler/ruby changes
- adds --quiet to gem install bundler to avoid progress bar junk

## Verification

List the steps needed to make sure this thing works

- [x] `vagrant up --provider=vmware_desktop` || `vagrant up` to build both vbox and vmware
- [ ] longer version: `vagrant box add "hashicorp/bionic64" --provider=vmware_desktop` and `vagrant provision`
- [x] run a second `vagrant provision` to check that you don't get any extra red warnings than you get normally
- [x] `vagrant ssh` etc
- [x] **Verify** `vagrant up --provider=virtualbox` doesn't fail 
