### PR TITLE
Update sap_service_discovery.rb to support discovering SAP IGS servers

### DIFF
--- a/modules/auxiliary/scanner/sap/sap_service_discovery.rb
+++ b/modules/auxiliary/scanner/sap/sap_service_discovery.rb
@@ -55,7 +55,7 @@ class MetasploitModule < Msf::Auxiliary
       '8210', '8220', '8230', '4363', '4444', '4445', '9999', '20003', '20004',
       '20005', '20006', '20007', '31596', '31597', '31602', '31601', '31604',
       '2000', '2001', '2002', '8355', '8357', '8351' ,'8352', '8353', '8366',
-      '1090', '1095', '20201', '1099', '1089'
+      '1090', '1095', '20201', '1099', '1089', '40080'
     ]
 
     ports = []
@@ -185,6 +185,8 @@ class MetasploitModule < Msf::Auxiliary
                 service = "ITS AGate sapavw00_<INST>"
               when /^4[0-9][0-9]00/
                 service = "IGS Multiplexer"
+              when /^40080$/
+                service = "SAP Internet Graphics Server [HTTP]"
               when /^8200$/
                 service = "XI JMS/JDBC/File Adapter"
               when /^8210$/


### PR DESCRIPTION
Add new port 40080 - SAP Internet Graphics Server [HTTP] to `sap_service_discovery.rb` to allow the SAP service discovery scanner to identify servers running SAP IGS.

The **Internet Graphics Service (IGS)** where it provides a way infrastructure to enable developers to display graphics in an internet browser with minimal effort. It has been integrated in several different SAP UI technologies where it provides a way for data from another SAP system or data source to be utilized to generate dynamic graphical or non-graphical output.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] Do: `use auxiliary/scanner/sap/sap_service_discovery`
- [x] Do: `set RHOSTS [IP]`
- [x] Do: `run`

New output of this script:
```
msf6 > use auxiliary/scanner/sap/sap_service_discovery
msf6 auxiliary(scanner/sap/sap_service_discovery) > set rhosts 172.16.30.29
rhosts => 172.16.30.29
msf6 auxiliary(scanner/sap/sap_service_discovery) > run

[*] 172.16.30.29:         - [SAP] Beginning service Discovery '172.16.30.29'

[+] 172.16.30.29:         - 172.16.30.29:50001	 - SAP JAVA EE Dispatcher [HTTPS] OPEN
[+] 172.16.30.29:         - 172.16.30.29:50000	 - SAP JAVA EE Dispatcher [HTTP] OPEN
[+] 172.16.30.29:         - 172.16.30.29:50004	 - SAP JAVA EE Dispatcher [P4] OPEN
[+] 172.16.30.29:         - 172.16.30.29:50007	 - SAP JAVA EE Dispatcher [IIOP] OPEN
[+] 172.16.30.29:         - 172.16.30.29:50013	 - SAP StartService [SOAP] sapctrl00 OPEN
[+] 172.16.30.29:         - 172.16.30.29:40000	 - IGS Multiplexer OPEN
[+] 172.16.30.29:         - 172.16.30.29:3201	 - SAP Dispatcher sapdp01 OPEN
[+] 172.16.30.29:         - 172.16.30.29:3301	 - SAP Gateway sapgw01 OPEN
[+] 172.16.30.29:         - 172.16.30.29:8101	 - SAP Message Server [HTTP] OPEN
[+] 172.16.30.29:         - 172.16.30.29:50113	 - SAP StartService [SOAP] sapctrl01 OPEN
[+] 172.16.30.29:         - 172.16.30.29:3901	 - ITS AGate sapavw00_<INST> OPEN
[+] 172.16.30.29:         - 172.16.30.29:40080	 - SAP Internet Graphics Server [HTTP] OPEN
[*] 172.16.30.29:         - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```