### PR TITLE
Add tab completion for run command

### DIFF
--- a/lib/msf/ui/console/command_dispatcher.rb
+++ b/lib/msf/ui/console/command_dispatcher.rb
@@ -135,5 +135,5 @@ end
 end end end
 
 require 'msf/ui/console/module_command_dispatcher'
+require 'msf/ui/console/module_option_tab_completion'
 require 'msf/ui/console/command_dispatcher/core'
-

--- a/lib/msf/ui/console/command_dispatcher/auxiliary.rb
+++ b/lib/msf/ui/console/command_dispatcher/auxiliary.rb
@@ -12,6 +12,7 @@ module CommandDispatcher
 class Auxiliary
 
   include Msf::Ui::Console::ModuleCommandDispatcher
+  include Msf::Ui::Console::ModuleOptionTabCompletion
 
   @@auxiliary_action_opts = Rex::Parser::Arguments.new(
     '-h' => [ false, 'Help banner.'                                                        ],
@@ -89,8 +90,9 @@ class Auxiliary
   # Tab completion for the run command
   #
   def cmd_run_tabs(str, words)
-    return [] if words.length > 1
-    @@auxiliary_opts.fmt.keys
+    flags = @@auxiliary_opts.fmt.keys
+    options = tab_complete_option(str, words)
+    flags + options
   end
 
   #

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1842,7 +1842,6 @@ class Core
   # @param words [Array<String>] the previously completed words on the command line.  words is always
   # at least 1 when tab completion has reached this stage since the command itself has been completed
   def cmd_set_tabs(str, words)
-
     # A value has already been specified
     return [] if words.length > 2
 
@@ -1850,8 +1849,7 @@ class Core
     if words.length == 2
       return tab_complete_option_values(str, words, opt: words[1])
     end
-    Readline.completion_append_character = " "
-    return tab_complete_option_names(str, words)
+    tab_complete_option_names(str, words)
   end
 
   def cmd_setg_help

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -42,6 +42,7 @@ class Core
 
   include Msf::Ui::Console::CommandDispatcher
   include Msf::Ui::Console::CommandDispatcher::Common
+  include Msf::Ui::Console::ModuleOptionTabCompletion
 
   # Session command options
   @@sessions_opts = Rex::Parser::Arguments.new(
@@ -1847,79 +1848,10 @@ class Core
 
     # A value needs to be specified
     if words.length == 2
-      return tab_complete_option(str, words)
+      return tab_complete_option_values(str, words, opt: words[1])
     end
-
-    res = cmd_unset_tabs(str, words) || [ ]
-    # There needs to be a better way to register global options, but for
-    # now all we have is an ad-hoc list of opts that the shell treats
-    # specially.
-    res += %w{
-      ConsoleLogging
-      LogLevel
-      MinimumRank
-      SessionLogging
-      TimestampOutput
-      Prompt
-      PromptChar
-      PromptTimeFormat
-      MeterpreterPrompt
-    }
-    mod = active_module
-
-    if (not mod)
-      return res
-    end
-
-    mod.options.sorted.each { |e|
-      name, _opt = e
-      next unless Msf::OptCondition.show_option(mod, _opt)
-      res << name
-    }
-
-    # Exploits provide these three default options
-    if (mod.exploit?)
-      res << 'PAYLOAD'
-      res << 'NOP'
-      res << 'TARGET'
-      res << 'ENCODER'
-    elsif (mod.evasion?)
-      res << 'PAYLOAD'
-      res << 'TARGET'
-      res << 'ENCODER'
-    elsif (mod.payload?)
-      res << 'ENCODER'
-    end
-
-    if mod.kind_of?(Msf::Module::HasActions)
-      res << "ACTION"
-    end
-
-    if ((mod.exploit? or mod.evasion?) and mod.datastore['PAYLOAD'])
-      p = framework.payloads.create(mod.datastore['PAYLOAD'])
-      if (p)
-        p.options.sorted.each { |e|
-          name, _opt = e
-          next unless Msf::OptCondition.show_option(mod, _opt)
-          res << name
-        }
-      end
-    end
-
-    unless str.blank?
-      res = res.select { |term| term.upcase.start_with?(str.upcase) }
-      res = res.map { |term|
-        if str == str.upcase
-          str + term[str.length..-1].upcase
-        elsif str == str.downcase
-          str + term[str.length..-1].downcase
-        else
-          str + term[str.length..-1]
-        end
-      }
-    end
-
-    return res
+    Readline.completion_append_character = " "
+    return tab_complete_option_names(str, words)
   end
 
   def cmd_setg_help
@@ -1927,6 +1859,17 @@ class Core
     print_line
     print_line "Exactly like set -g, set a value in the global datastore."
     print_line
+  end
+
+  #
+  # Tab completion for the unset command
+  #
+  # @param str [String] the string currently being typed before tab was hit
+  # @param words [Array<String>] the previously completed words on the command
+  #   line. `words` is always at least 1 when tab completion has reached this
+  #   stage since the command itself has been completed.
+  def cmd_unset_tabs(str, words)
+    tab_complete_datastore_names(str, words)
   end
 
   #
@@ -2128,26 +2071,6 @@ class Core
 
       datastore.delete(val)
     end
-  end
-
-  #
-  # Tab completion for the unset command
-  #
-  # @param str [String] the string currently being typed before tab was hit
-  # @param words [Array<String>] the previously completed words on the command
-  #   line. `words` is always at least 1 when tab completion has reached this
-  #   stage since the command itself has been completed.
-  def cmd_unset_tabs(str, words)
-    datastore = active_module ? active_module.datastore : self.framework.datastore
-    keys = datastore.keys
-
-    mod = active_module
-    if mod
-      keys = keys.delete_if do |name|
-        !(mod_opt = mod.options[name]).nil? && !Msf::OptCondition.show_option(mod, mod_opt)
-      end
-    end
-    keys
   end
 
   def cmd_unsetg_help
@@ -2393,262 +2316,6 @@ class Core
     # replace with new code that permits "nested" tab completion
     # tabs = driver.get_all_commands if (str and str =~ /\w/)
     tabs
-  end
-
-  #
-  # Provide tab completion for option values
-  #
-  def tab_complete_option(str, words)
-    opt = words[1]
-    res = []
-    mod = active_module
-
-    # With no active module, we have nothing to compare
-    if (not mod)
-      return res
-    end
-
-    # Well-known option names specific to exploits
-    if (mod.exploit?)
-      return option_values_payloads() if opt.upcase == 'PAYLOAD'
-      return option_values_targets()  if opt.upcase == 'TARGET'
-      return option_values_nops()     if opt.upcase == 'NOPS'
-      return option_values_encoders() if opt.upcase == 'STAGEENCODER'
-    elsif (mod.evasion?)
-      return option_values_payloads() if opt.upcase == 'PAYLOAD'
-      return option_values_targets()  if opt.upcase == 'TARGET'
-    end
-
-    # Well-known option names specific to modules with actions
-    if mod.kind_of?(Msf::Module::HasActions)
-      return option_values_actions() if opt.upcase == 'ACTION'
-    end
-
-    # The ENCODER option works for evasions, payloads and exploits
-    if ((mod.evasion? or mod.exploit? or mod.payload?) and opt.upcase == 'ENCODER')
-      return option_values_encoders()
-    end
-
-    # Well-known option names specific to post-exploitation
-    if (mod.post? or mod.exploit?)
-      return option_values_sessions() if opt.upcase == 'SESSION'
-    end
-
-    # Is this option used by the active module?
-    mod.options.each_key do |key|
-      res.concat(option_values_dispatch(mod.options[key], str, words)) if key.downcase == opt.downcase
-    end
-
-    # How about the selected payload?
-    if ((mod.evasion? or mod.exploit?) and mod.datastore['PAYLOAD'])
-      if p = framework.payloads.create(mod.datastore['PAYLOAD'])
-        p.options.each_key do |key|
-          res.concat(option_values_dispatch(p.options[key], str, words)) if key.downcase == opt.downcase
-        end
-      end
-    end
-
-    return res
-  end
-
-  # XXX: We repurpose OptAddressLocal#interfaces, so we can't put this in Rex
-  def tab_complete_source_interface(o)
-    return [] unless o.is_a?(Msf::OptAddressLocal)
-    o.interfaces
-  end
-
-  #
-  # Provide possible option values based on type
-  #
-  def option_values_dispatch(o, str, words)
-
-    res = []
-    res << o.default.to_s if o.default
-
-    case o
-    when Msf::OptAddress
-      case o.name.upcase
-      when 'RHOST'
-        option_values_target_addrs().each do |addr|
-          res << addr
-        end
-      when 'LHOST', 'SRVHOST', 'REVERSELISTENERBINDADDRESS'
-        rh = self.active_module.datastore['RHOST'] || framework.datastore['RHOST']
-        if rh and not rh.empty?
-          res << Rex::Socket.source_address(rh)
-        else
-          res += tab_complete_source_address
-          res += tab_complete_source_interface(o)
-        end
-      end
-
-    when Msf::OptAddressRange
-      case str
-      when /^file:(.*)/
-        files = tab_complete_filenames($1, words)
-        res += files.map { |f| "file:" + f } if files
-      when /\/$/
-        res << str+'32'
-        res << str+'24'
-        res << str+'16'
-      when /\-$/
-        res << str+str[0, str.length - 1]
-      else
-        option_values_target_addrs().each do |addr|
-          res << addr
-        end
-      end
-
-    when Msf::OptPort
-      case o.name.upcase
-      when 'RPORT'
-        option_values_target_ports().each do |port|
-          res << port
-        end
-      end
-
-      if (res.empty?)
-        res << (rand(65534)+1).to_s
-      end
-
-    when Msf::OptEnum
-      o.enums.each do |val|
-        res << val
-      end
-
-    when Msf::OptPath
-      files = tab_complete_filenames(str, words)
-      res += files if files
-
-    when Msf::OptBool
-      res << 'true'
-      res << 'false'
-
-    when Msf::OptString
-      if (str =~ /^file:(.*)/)
-        files = tab_complete_filenames($1, words)
-        res += files.map { |f| "file:" + f } if files
-      end
-    end
-
-    return res
-  end
-
-  #
-  # Provide valid payload options for the current exploit
-  #
-  def option_values_payloads
-    if @cache_payloads && active_module == @previous_module && active_module.target == @previous_target
-      return @cache_payloads
-    end
-
-    @previous_module = active_module
-    @previous_target = active_module.target
-
-    @cache_payloads = active_module.compatible_payloads.map do |refname, payload|
-      refname
-    end
-
-    @cache_payloads
-  end
-
-  #
-  # Provide valid session options for the current post-exploit module
-  #
-  def option_values_sessions
-    if active_module.respond_to?(:compatible_sessions)
-      active_module.compatible_sessions.map { |sid| sid.to_s }
-    end
-  end
-
-  #
-  # Provide valid target options for the current exploit
-  #
-  def option_values_targets
-    res = []
-    if (active_module.targets)
-      1.upto(active_module.targets.length) { |i| res << (i-1).to_s }
-      res += active_module.targets.map(&:name)
-    end
-    return res
-  end
-
-
-  #
-  # Provide valid action options for the current module
-  #
-  def option_values_actions
-    res = []
-    if (active_module.actions)
-      active_module.actions.each { |i| res << i.name }
-    end
-    return res
-  end
-
-  #
-  # Provide valid nops options for the current exploit
-  #
-  def option_values_nops
-    framework.nops.map { |refname, mod| refname }
-  end
-
-  #
-  # Provide valid encoders options for the current exploit or payload
-  #
-  def option_values_encoders
-    framework.encoders.map { |refname, mod| refname }
-  end
-
-  #
-  # Provide the target addresses
-  #
-  def option_values_target_addrs
-    res = [ ]
-    res << Rex::Socket.source_address()
-    return res if not framework.db.active
-
-    # List only those hosts with matching open ports?
-    mport = self.active_module.datastore['RPORT']
-    if mport
-      mport = mport.to_i
-      hosts = {}
-      framework.db.services.each do |service|
-        if service.port == mport
-          hosts[ service.host.address ] = true
-        end
-      end
-
-      hosts.keys.each do |host|
-        res << host
-      end
-
-    # List all hosts in the database
-    else
-      framework.db.hosts.each do |host|
-        res << host.address
-      end
-    end
-
-    return res
-  end
-
-  #
-  # Provide the target ports
-  #
-  def option_values_target_ports
-    res = [ ]
-    return res if not framework.db.active
-    return res if not self.active_module.datastore['RHOST']
-    host = framework.db.has_host?(framework.db.workspace, self.active_module.datastore['RHOST'])
-    return res if not host
-
-    framework.db.services.each do |service|
-      if service.host_id == host.id
-        res << service.port.to_s
-      end
-    end
-
-    return res
   end
 
   protected

--- a/lib/msf/ui/console/command_dispatcher/evasion.rb
+++ b/lib/msf/ui/console/command_dispatcher/evasion.rb
@@ -5,6 +5,7 @@ module CommandDispatcher
 class Evasion
 
   include Msf::Ui::Console::ModuleCommandDispatcher
+  include Msf::Ui::Console::ModuleOptionTabCompletion
 
   def commands
     super.update({
@@ -50,21 +51,31 @@ class Evasion
 
   alias cmd_rexploit cmd_rerun
 
-  def cmd_exploit_tabs(str, words)
+  #
+  # Tab completion for the run command
+  #
+  def cmd_run_tabs(str, words)
     fmt = {
-      '-e' => [ framework.encoders.map { |refname, mod| refname } ],
-      '-f' => [ nil                                               ],
-      '-h' => [ nil                                               ],
-      '-j' => [ nil                                               ],
-      '-J' => [ nil                                               ],
-      '-n' => [ framework.nops.map { |refname, mod| refname }     ],
-      '-o' => [ true                                              ],
-      '-p' => [ framework.payloads.map { |refname, mod| refname } ],
-      '-t' => [ true                                              ],
-      '-z' => [ nil                                               ]
+        '-e' => [ framework.encoders.map { |refname, mod| refname } ],
+        '-f' => [ nil                                               ],
+        '-h' => [ nil                                               ],
+        '-j' => [ nil                                               ],
+        '-J' => [ nil                                               ],
+        '-n' => [ framework.nops.map { |refname, mod| refname }     ],
+        '-o' => [ true                                              ],
+        '-p' => [ framework.payloads.map { |refname, mod| refname } ],
+        '-t' => [ true                                              ],
+        '-z' => [ nil                                               ]
     }
-    tab_complete_generic(fmt, str, words)
+    flags = tab_complete_generic(fmt, str, words)
+    options = tab_complete_option(str, words)
+    flags + options
   end
+
+  #
+  # Tab completion for the exploit command
+  #
+  alias cmd_exploit_tabs cmd_run_tabs
 
   def cmd_to_handler(*_args)
     handler = framework.modules.create('exploit/multi/handler')

--- a/lib/msf/ui/console/command_dispatcher/exploit.rb
+++ b/lib/msf/ui/console/command_dispatcher/exploit.rb
@@ -12,6 +12,7 @@ module CommandDispatcher
 class Exploit
 
   include Msf::Ui::Console::ModuleCommandDispatcher
+  include Msf::Ui::Console::ModuleOptionTabCompletion
 
   @@exploit_opts = Rex::Parser::Arguments.new(
     "-e" => [ true,  "The payload encoder to use.  If none is specified, ENCODER is used." ],
@@ -69,21 +70,31 @@ class Exploit
     return session
   end
 
-  def cmd_exploit_tabs(str, words)
+  #
+  # Tab completion for the run command
+  #
+  def cmd_run_tabs(str, words)
     fmt = {
-      '-e' => [ framework.encoders.map { |refname, mod| refname } ],
-      '-f' => [ nil                                               ],
-      '-h' => [ nil                                               ],
-      '-j' => [ nil                                               ],
-      '-J' => [ nil                                               ],
-      '-n' => [ framework.nops.map { |refname, mod| refname }     ],
-      '-o' => [ true                                              ],
-      '-p' => [ framework.payloads.map { |refname, mod| refname } ],
-      '-t' => [ true                                              ],
-      '-z' => [ nil                                               ]
+        '-e' => [ framework.encoders.map { |refname, mod| refname } ],
+        '-f' => [ nil                                               ],
+        '-h' => [ nil                                               ],
+        '-j' => [ nil                                               ],
+        '-J' => [ nil                                               ],
+        '-n' => [ framework.nops.map { |refname, mod| refname }     ],
+        '-o' => [ true                                              ],
+        '-p' => [ framework.payloads.map { |refname, mod| refname } ],
+        '-t' => [ true                                              ],
+        '-z' => [ nil                                               ]
     }
-    tab_complete_generic(fmt, str, words)
+    flags = tab_complete_generic(fmt, str, words)
+    options = tab_complete_option(str, words)
+    flags + options
   end
+
+  #
+  # Tab completion for the exploit command
+  #
+  alias cmd_exploit_tabs cmd_run_tabs
 
   #
   # Launches exploitation attempts.

--- a/lib/msf/ui/console/command_dispatcher/payload.rb
+++ b/lib/msf/ui/console/command_dispatcher/payload.rb
@@ -11,6 +11,7 @@ module Msf
         ###
         class Payload
           include Msf::Ui::Console::ModuleCommandDispatcher
+          include Msf::Ui::Console::ModuleOptionTabCompletion
 
           # Load supported formats
           @@supported_formats = \
@@ -187,6 +188,9 @@ module Msf
             true
           end
 
+          #
+          # Tab completion for the generate command
+          #
           def cmd_generate_tabs(str, words)
             fmt = {
               '-b' => [ true                                              ],
@@ -204,7 +208,9 @@ module Msf
               '-i' => [ true                                              ],
               '-v' => [ nil                                               ]
             }
-            tab_complete_generic(fmt, str, words)
+            flags = tab_complete_generic(fmt, str, words)
+            options = tab_complete_option(str, words)
+            flags + options
           end
         end
       end

--- a/lib/msf/ui/console/command_dispatcher/post.rb
+++ b/lib/msf/ui/console/command_dispatcher/post.rb
@@ -12,6 +12,7 @@ module CommandDispatcher
 class Post
 
   include Msf::Ui::Console::ModuleCommandDispatcher
+  include Msf::Ui::Console::ModuleOptionTabCompletion
 
 
   @@post_opts = Rex::Parser::Arguments.new(
@@ -160,8 +161,9 @@ class Post
   # at least 1 when tab completion has reached this stage since the command itself has been completed
   #
   def cmd_run_tabs(str, words)
-    return [] if words.length > 1
-    @@post_opts.fmt.keys
+    flags = @@post_opts.fmt.keys
+    options = tab_complete_option(str, words)
+    flags + options
   end
 
   alias cmd_exploit_tabs cmd_run_tabs

--- a/lib/msf/ui/console/module_option_tab_completion.rb
+++ b/lib/msf/ui/console/module_option_tab_completion.rb
@@ -1,0 +1,359 @@
+module Msf
+  module Ui
+    module Console
+      ###
+      #
+      # Module-specific tab completion helper.
+      #
+      ###
+      module ModuleOptionTabCompletion
+        #
+        # Tab completion for datastore names
+        #
+        # @param str [String] the string currently being typed before tab was hit
+        # @param words [Array<String>] the previously completed words on the command
+        #   line. `words` is always at least 1 when tab completion has reached this
+        #   stage since the command itself has been completed.
+        def tab_complete_datastore_names(_str, _words)
+          datastore = active_module ? active_module.datastore : framework.datastore
+          keys = datastore.keys
+
+          mod = active_module
+          if mod
+            keys = keys.delete_if do |name|
+              !(mod_opt = mod.options[name]).nil? && !Msf::OptCondition.show_option(mod, mod_opt)
+            end
+          end
+          keys
+        end
+
+        #
+        # Tab completion options values
+        #
+        def tab_complete_option(str, words)
+          if str.end_with?('=')
+            option_name = str.chop
+            ::Readline.completion_append_character = ' '
+            return tab_complete_option_values(option_name, words, opt: option_name).map { |value| "#{str}#{value}" }
+          else
+            if str.include?('=')
+              str_split = str.split('=')
+              option_value = str_split[1].strip
+              option_name = str_split[0].strip
+              ::Readline.completion_append_character = ' '
+              return tab_complete_option_values(option_value, words, opt: option_name).map { |value| "#{option_name}=#{value}" }
+            end
+          end
+          ::Readline.completion_append_character = ' '
+          return tab_complete_option_names(str, words).map { |name| "#{name}=" }
+        end
+
+        #
+        # Provide tab completion for name values
+        #
+        def tab_complete_option_names(str, words)
+          res = tab_complete_datastore_names(str, words) || [ ]
+          # There needs to be a better way to register global options, but for
+          # now all we have is an ad-hoc list of opts that the shell treats
+          # specially.
+          res += %w[
+            ConsoleLogging
+            LogLevel
+            MinimumRank
+            SessionLogging
+            TimestampOutput
+            Prompt
+            PromptChar
+            PromptTimeFormat
+            MeterpreterPrompt
+          ]
+          mod = active_module
+          if !mod
+            return res
+          end
+
+          mod.options.sorted.each do |e|
+            name, _opt = e
+            next unless Msf::OptCondition.show_option(mod, _opt)
+
+            res << name
+          end
+          # Exploits provide these three default options
+          if mod.exploit?
+            res << 'PAYLOAD'
+            res << 'NOP'
+            res << 'TARGET'
+            res << 'ENCODER'
+          elsif mod.evasion?
+            res << 'PAYLOAD'
+            res << 'TARGET'
+            res << 'ENCODER'
+          elsif mod.payload?
+            res << 'ENCODER'
+          end
+          if mod.is_a?(Msf::Module::HasActions)
+            res << 'ACTION'
+          end
+          if ((mod.exploit? || mod.evasion?) && mod.datastore['PAYLOAD'])
+            p = framework.payloads.create(mod.datastore['PAYLOAD'])
+            if p
+              p.options.sorted.each do |e|
+                name, _opt = e
+                res << name
+              end
+            end
+          end
+          unless str.blank?
+            res = res.select { |term| term.upcase.start_with?(str.upcase) }
+            res = res.map do |term|
+              if str == str.upcase
+                str + term[str.length..-1].upcase
+              elsif str == str.downcase
+                str + term[str.length..-1].downcase
+              else
+                str + term[str.length..-1]
+              end
+            end
+          end
+          return res
+        end
+
+        #
+        # Provide tab completion for option values
+        #
+        def tab_complete_option_values(str, words, opt:)
+          res = []
+          mod = active_module
+          # With no active module, we have nothing to compare
+          if !mod
+            return res
+          end
+
+          # Well-known option names specific to exploits
+          if mod.exploit?
+            return option_values_payloads if opt.upcase == 'PAYLOAD'
+            return option_values_targets if opt.upcase == 'TARGET'
+            return option_values_nops if opt.upcase == 'NOPS'
+            return option_values_encoders if opt.upcase == 'STAGEENCODER'
+          elsif mod.evasion?
+            return option_values_payloads if opt.upcase == 'PAYLOAD'
+            return option_values_targets if opt.upcase == 'TARGET'
+          end
+          # Well-known option names specific to modules with actions
+          if mod.is_a?(Msf::Module::HasActions)
+            return option_values_actions if opt.upcase == 'ACTION'
+          end
+          # The ENCODER option works for evasions, payloads and exploits
+          if ((mod.evasion? || mod.exploit? || mod.payload?) && (opt.upcase == 'ENCODER'))
+            return option_values_encoders
+          end
+
+          # Well-known option names specific to post-exploitation
+          if (mod.post? || mod.exploit?)
+            return option_values_sessions if opt.upcase == 'SESSION'
+          end
+          # Is this option used by the active module?
+          mod.options.each_key do |key|
+            if key.downcase == opt.downcase
+              res.concat(option_values_dispatch(mod.options[key], str, words))
+            end
+          end
+          # How about the selected payload?
+          if ((mod.evasion? || mod.exploit?) && mod.datastore['PAYLOAD'])
+            if p = framework.payloads.create(mod.datastore['PAYLOAD'])
+              p.options.each_key do |key|
+                res.concat(option_values_dispatch(p.options[key], str, words)) if key.downcase == opt.downcase
+              end
+            end
+          end
+          return res
+        end
+
+        #
+        # Provide possible option values based on type
+        #
+        def option_values_dispatch(o, str, words)
+          res = []
+          res << o.default.to_s if o.default
+          case o
+          when Msf::OptAddress
+            case o.name.upcase
+            when 'RHOST'
+              option_values_target_addrs.each do |addr|
+                res << addr
+              end
+            when 'LHOST', 'SRVHOST', 'REVERSELISTENERBINDADDRESS'
+              rh = active_module.datastore['RHOST'] || framework.datastore['RHOST']
+              if rh && !rh.empty?
+                res << Rex::Socket.source_address(rh)
+              else
+                res += tab_complete_source_address
+                res += tab_complete_source_interface(o)
+              end
+            end
+          when Msf::OptAddressRange
+            case str
+            when /^file:(.*)/
+              files = tab_complete_filenames(Regexp.last_match(1), words)
+              res += files.map { |f| 'file:' + f } if files
+            when %r{/$}
+              res << str + '32'
+              res << str + '24'
+              res << str + '16'
+            when /\-$/
+              res << str + str[0, str.length - 1]
+            else
+              option_values_target_addrs.each do |addr|
+                res << addr
+              end
+            end
+          when Msf::OptPort
+            case o.name.upcase
+            when 'RPORT'
+              option_values_target_ports.each do |port|
+                res << port
+              end
+            end
+            if res.empty?
+              res << rand(1..65534).to_s
+            end
+          when Msf::OptEnum
+            o.enums.each do |val|
+              res << val
+            end
+          when Msf::OptPath
+            files = tab_complete_filenames(str, words)
+            res += files if files
+          when Msf::OptBool
+            res << 'true'
+            res << 'false'
+          when Msf::OptString
+            if (str =~ /^file:(.*)/)
+              files = tab_complete_filenames(Regexp.last_match(1), words)
+              res += files.map { |f| 'file:' + f } if files
+            end
+          end
+          return res
+        end
+
+        # XXX: We repurpose OptAddressLocal#interfaces, so we can't put this in Rex
+        def tab_complete_source_interface(o)
+          return [] unless o.is_a?(Msf::OptAddressLocal)
+
+          o.interfaces
+        end
+
+        #
+        # Provide valid payload options for the current exploit
+        #
+        def option_values_payloads
+          if @cache_payloads && active_module == @previous_module && active_module.target == @previous_target
+            return @cache_payloads
+          end
+
+          @previous_module = active_module
+          @previous_target = active_module.target
+          @cache_payloads = active_module.compatible_payloads.map do |refname, _payload|
+            refname
+          end
+          @cache_payloads
+        end
+
+        #
+        # Provide valid session options for the current post-exploit module
+        #
+        def option_values_sessions
+          if active_module.respond_to?(:compatible_sessions)
+            active_module.compatible_sessions.map { |sid| sid.to_s }
+          end
+        end
+
+        #
+        # Provide valid target options for the current exploit
+        #
+        def option_values_targets
+          res = []
+          if active_module.targets
+            1.upto(active_module.targets.length) { |i| res << (i - 1).to_s }
+            res += active_module.targets.map(&:name)
+          end
+          return res
+        end
+
+        #
+        # Provide valid action options for the current module
+        #
+        def option_values_actions
+          res = []
+          if active_module.actions
+            active_module.actions.each { |i| res << i.name }
+          end
+          return res
+        end
+
+        #
+        # Provide valid nops options for the current exploit
+        #
+        def option_values_nops
+          framework.nops.map { |refname, _mod| refname }
+        end
+
+        #
+        # Provide valid encoders options for the current exploit or payload
+        #
+        def option_values_encoders
+          framework.encoders.map { |refname, _mod| refname }
+        end
+
+        #
+        # Provide the target addresses
+        #
+        def option_values_target_addrs
+          res = [ ]
+          res << Rex::Socket.source_address
+          return res if !framework.db.active
+
+          # List only those hosts with matching open ports?
+          mport = active_module.datastore['RPORT']
+          if mport
+            mport = mport.to_i
+            hosts = {}
+            framework.db.services.each do |service|
+              if service.port == mport
+                hosts[service.host.address] = true
+              end
+            end
+            hosts.keys.each do |host|
+              res << host
+            end
+            # List all hosts in the database
+          else
+            framework.db.hosts.each do |host|
+              res << host.address
+            end
+          end
+          return res
+        end
+
+        #
+        # Provide the target ports
+        #
+        def option_values_target_ports
+          res = [ ]
+          return res if !framework.db.active
+          return res if !active_module.datastore['RHOST']
+
+          host = framework.db.has_host?(framework.db.workspace, active_module.datastore['RHOST'])
+          return res if !host
+
+          framework.db.services.each do |service|
+            if service.host_id == host.id
+              res << service.port.to_s
+            end
+          end
+          return res
+        end
+      end
+    end
+  end
+end

--- a/lib/msf/ui/console/module_option_tab_completion.rb
+++ b/lib/msf/ui/console/module_option_tab_completion.rb
@@ -33,19 +33,21 @@ module Msf
         def tab_complete_option(str, words)
           if str.end_with?('=')
             option_name = str.chop
+            option_value = ''
+
             ::Readline.completion_append_character = ' '
-            return tab_complete_option_values(option_name, words, opt: option_name).map { |value| "#{str}#{value}" }
-          else
-            if str.include?('=')
-              str_split = str.split('=')
-              option_value = str_split[1].strip
-              option_name = str_split[0].strip
-              ::Readline.completion_append_character = ' '
-              return tab_complete_option_values(option_value, words, opt: option_name).map { |value| "#{option_name}=#{value}" }
-            end
+            return tab_complete_option_values(option_value, words, opt: option_name).map { |value| "#{str}#{value}" }
+          elsif str.include?('=')
+            str_split = str.split('=')
+            option_name = str_split[0].strip
+            option_value = str_split[1].strip
+
+            ::Readline.completion_append_character = ' '
+            return tab_complete_option_values(option_value, words, opt: option_name).map { |value| "#{option_name}=#{value}" }
           end
-          ::Readline.completion_append_character = ' '
-          return tab_complete_option_names(str, words).map { |name| "#{name}=" }
+
+          ::Readline.completion_append_character = ''
+          tab_complete_option_names(str, words).map { |name| "#{name}=" }
         end
 
         #

--- a/lib/rex/ui/text/dispatcher_shell.rb
+++ b/lib/rex/ui/text/dispatcher_shell.rb
@@ -358,6 +358,8 @@ module DispatcherShell
   # Readline.basic_word_break_characters variable being set to \x00
   #
   def tab_complete(str)
+    ::Readline.completion_append_character = ' '
+
     # Check trailing whitespace so we can tell 'x' from 'x '
     str_match = str.match(/[^\\]([\\]{2})*\s+$/)
     str_trail = (str_match.nil?) ? '' : str_match[0]


### PR DESCRIPTION
Re-opening https://github.com/rapid7/metasploit-framework/pull/14150

### Before
Tab completion was not compatible with the run command.

### After
Tab completion now works with relevant modules:
- Auxiliary
- Evasion
- Exploit
- Payload
- Post

![add_tab_completion_pr](https://user-images.githubusercontent.com/69522014/93469786-df428080-f8e8-11ea-8388-23dc1e0c2458.gif)


## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/windows/wins/ms04_045_wins` - just an example, possibly test different module types
- [ ] type `run` followed by a space then hit `tab`
- [ ] **Verify** that a list of possible tab completions displays
- [ ] **Verify** that tab completion works for both flags and options in multiple different scenarios 


### Additional testing scenarios

#### Completing keys:

```
use smb_version
run rhos<tab>
```

Expected result: `run rhosts=`

#### Completing values:

```
use smb_version
run rhosts=<tab>
```

Expected result: `run rhosts=x.x.x.x `

### Completing keys, and unrelated commands

```
use smb_version
run rhosts<tab>
db_statu<tab>
```

Expected result: _with a space_: `db_status `.