### PR TITLE
Fix up disclosure date for zentao_pro_rce

### DIFF
--- a/modules/exploits/windows/http/zentao_pro_rce.rb
+++ b/modules/exploits/windows/http/zentao_pro_rce.rb
@@ -65,7 +65,7 @@ class MetasploitModule < Msf::Exploit::Remote
             ]
           ],
         'DefaultTarget' => 0,
-        'DisclosureDate' => '0020-06-20'
+        'DisclosureDate' => '2020-06-20'
       )
     )
 


### PR DESCRIPTION
Fixes #14239 by correctly adjusting the date of the `zentao_pro_rce` module so that it has the correct disclosure date of '2020-06-20'.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use modules/exploits/windows/http/zentao_pro_rce.rb`
- [ ] `info`
- [ ] **Verify** the disclosure date is in the right format of YYYY-MM-DD and that it has the right date.
