### PR TITLE
Fix up the DNS enumeration library so that AXFR records aren't displayed with stray [ and ] characters

### DIFF
--- a/lib/msf/core/exploit/dns/enumeration.rb
+++ b/lib/msf/core/exploit/dns/enumeration.rb
@@ -51,7 +51,7 @@ module Enumeration
         dns.nameservers -= dns.nameservers
         dns.nameservers = ns_a_records
         zone = dns.axfr(domain)
-      
+
       # Original set of exceptions which were deliberately caught but were missing some
       # situations. Leaving these in as they may want to be treated differently
       # to other, maybe more generic, exceptions.
@@ -62,7 +62,7 @@ module Enumeration
       end
       next if zone.blank?
       records << zone
-      print_good("#{domain} Zone Transfer: #{zone}")
+      print_good("#{domain} Zone Transfer: #{zone.to_s[1...-1]}") # Use [1...-1] to remove the stray [ and ] characters from the output.
     end
     return if records.blank?
     records

--- a/lib/msf/core/exploit/dns/enumeration.rb
+++ b/lib/msf/core/exploit/dns/enumeration.rb
@@ -61,8 +61,8 @@ module Enumeration
         print_error("Query #{domain} DNS AXFR - unknown exception: #{e}")
       end
       next if zone.blank?
-      records << zone
-      print_good("#{domain} Zone Transfer: #{zone.to_s[1...-1]}") # Use [1...-1] to remove the stray [ and ] characters from the output.
+      records += zone
+      print_good("#{domain} Zone Transfer: #{zone.map(&:inspect).join}")
     end
     return if records.blank?
     records

--- a/lib/msf/core/exploit/dns/enumeration.rb
+++ b/lib/msf/core/exploit/dns/enumeration.rb
@@ -62,7 +62,8 @@ module Enumeration
       end
       next if zone.blank?
       records += zone
-      print_good("#{domain} Zone Transfer: #{zone.map(&:inspect).join}")
+      print_good("#{domain} Zone Transfer: ")
+      print_line(zone.map(&:inspect).join)
     end
     return if records.blank?
     records


### PR DESCRIPTION
Fixes #14237

This resolves an issue whereby AXFR records were being printed out by the enumeration library with stray `[` and `]` characters because the library failed to take into account that one of its arguments was an array and was trying to print it out as a string, without first removing the stray `[` and `]` characters that will be included when Ruby converts the array to a string.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use auxiliary/gather/enum_dns`
- [x] `set DOMAIN zonetransfer.me`
- [x] `set ENUM_A false`
- [x] `set ENUM_CNAME false`
- [x] `set ENUM_MX false`
- [x] `set ENUM_NS false`
- [x] `set ENUM_SRV false`
- [x] `set ENUM_TXT false`
- [x] `set ENUM_AXFR true` <- This is the only ENUM_ setting that should be set to `true`.
- [x] **Verify** that the DNS zone transfer works successfully and that you don't see a line like `[+] zonetransfer.me Zone Transfer: [;; Answer received from 34.225.33.2:53 (2039 bytes)` and instead see a line like `[+] zonetransfer.me Zone Transfer: ;; Answer received from 81.4.108.41:53 (1983 bytes)` (notice the lack of `[`).
- [x] **Verify** that no `]` characters are shown at the end of the output.