### PR TITLE
Fix fail_with check

### DIFF
--- a/tools/dev/msftidy.rb
+++ b/tools/dev/msftidy.rb
@@ -614,7 +614,7 @@ class Msftidy
       end
 
       if ln =~ /^\s*fail_with\(/
-        unless ln =~ /^\s*fail_with\(.*Failure\:\:(?:None|Unknown|Unreachable|BadConfig|Disconnected|NotFound|UnexpectedReply|TimeoutExpired|UserInterrupt|NoAccess|NoTarget|NotVulnerable|PayloadFailed),/
+        unless ln + @lines[idx] =~ /^\s*fail_with\(\s*Failure\:\:(?:None|Unknown|Unreachable|BadConfig|Disconnected|NotFound|UnexpectedReply|TimeoutExpired|UserInterrupt|NoAccess|NoTarget|NotVulnerable|PayloadFailed),/
           error("fail_with requires a valid Failure:: reason as first parameter: #{ln}", idx)
         end
       end


### PR DESCRIPTION
If the first argument was on a new line, it would fail the check even though the first argument was in the accepted list. This fix concatenates the following line before doing the regex. Also, a `.*` has been changed to `\s` in order to match the new line without having to use the `m` flag. An additional benefit of this is that (while invalid syntax) `fail_with("Failure::None,` will now also be caught.

This will still still cause an error to be reported if there is a blank line between the opening bracket and the first argument, but that seems unlikely to happen in the real world.