### PR TITLE
Update metasploit-payloads gem to 2.0.22

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,7 +29,7 @@ PATH
       metasploit-concern
       metasploit-credential
       metasploit-model
-      metasploit-payloads (= 2.0.16)
+      metasploit-payloads (= 2.0.22)
       metasploit_data_models
       metasploit_payloads-mettle (= 1.0.2)
       mqtt

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -70,7 +70,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '2.0.16'
+  spec.add_runtime_dependency 'metasploit-payloads', '2.0.22'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '1.0.2'
   # Needed by msfgui and other rpc components


### PR DESCRIPTION
This PR bumps framework to use Metasploit payloads gem 2.0.22 (previously 2.0.16), pulling in the following payloads PR changes:

* rapid7/metasploit-payloads#435
* rapid7/metasploit-payloads#439
* rapid7/metasploit-payloads#441
    * rapid7/metasploit-payloads#442 (related to 441)
    * rapid7/metasploit-payloads#443 (related to 441)
* rapid7/metasploit-payloads#444

## Verification
List the steps needed to make sure this thing works

- [ ] Retest manually
- [ ] Let automated tests pass