### PR TITLE
guard and notify for missing encoders

### DIFF
--- a/lib/msf/core/payload_generator.rb
+++ b/lib/msf/core/payload_generator.rb
@@ -252,6 +252,10 @@ module Msf
         @iterations = 1 if iterations < 1
 
         encoder_mod = framework.encoders.create(encoder_opt[0])
+        unless encoder_mod
+          cli_print "#{encoder_opt[0]} not found continuing..."
+          next
+        end
         encoder_mod.datastore.import_options_from_hash(datastore)
         shellcode = run_encoder(encoder_mod, shellcode)
       end


### PR DESCRIPTION
Fix #13435

When an encoder module is incorrectly entered or does not exist
continue the encoding process and log the invalid entry to console.

Tell us what this change does. If you're fixing a bug, please mention
the github issue number.

## Verification

List the steps needed to make sure this thing works

- [ ] See issue #13435 for reproduction steps
