### PR TITLE
More descript error logging for external modules

### DIFF
--- a/lib/msf/core/modules/external/shim.rb
+++ b/lib/msf/core/modules/external/shim.rb
@@ -4,7 +4,11 @@ require 'msf/core/modules/external'
 class Msf::Modules::External::Shim
   def self.generate(module_path, framework)
     mod = Msf::Modules::External.new(module_path, framework: framework)
-    return nil unless mod.meta
+    # first check if meta exists and raise an issue if not, #14281
+    # raise instead of returning nil to avoid confusion
+    unless mod.meta
+      raise LoadError, " Try running file manually to check for errors or dependency issues."
+    end
     case mod.meta['type']
     when 'remote_exploit'
       remote_exploit(mod)

--- a/lib/msf/core/modules/loader/base.rb
+++ b/lib/msf/core/modules/loader/base.rb
@@ -468,18 +468,15 @@ class Msf::Modules::Loader::Base
   def script_path?(path)
     # warn users if their external modules aren't marked executable
     # per #14281
-    unless !File.directory?(path) &&
-        ['#!', '//'].include?(File.read(path, 2))
-        return false
-    end
-    if File.executable?(path)
-      return true
-    end
-    unless File.extname(path) == '.rb'
+    if File.directory?(path) || !['#!', '//'].include?(File.read(path, 2))
+      false
+    elsif File.executable?(path)
+      true
+    else
       # prefer elog since load_error clutters the UI on potential false positives
       elog("Unable to load module #{path} - LoadError Possible non-executable external module.")
+      false
     end
-    false
   end
 
   # Changes a file name path to a canonical module reference name.

--- a/lib/msf/core/modules/loader/base.rb
+++ b/lib/msf/core/modules/loader/base.rb
@@ -466,9 +466,20 @@ class Msf::Modules::Loader::Base
 
   # Tries to determine if a file might be executable,
   def script_path?(path)
-    File.executable?(path) &&
-      !File.directory?(path) &&
-      ['#!', '//'].include?(File.read(path, 2))
+    # warn users if their external modules aren't marked executable
+    # per #14281
+    unless !File.directory?(path) &&
+        ['#!', '//'].include?(File.read(path, 2))
+        return false
+    end
+    if File.executable?(path)
+      return true
+    end
+    unless File.extname(path) == '.rb'
+      # prefer elog since load_error clutters the UI on potential false positives
+      elog("Unable to load module #{path} - LoadError Possible non-executable external module")
+    end
+    false
   end
 
   # Changes a file name path to a canonical module reference name.

--- a/lib/msf/core/modules/loader/base.rb
+++ b/lib/msf/core/modules/loader/base.rb
@@ -477,7 +477,7 @@ class Msf::Modules::Loader::Base
     end
     unless File.extname(path) == '.rb'
       # prefer elog since load_error clutters the UI on potential false positives
-      elog("Unable to load module #{path} - LoadError Possible non-executable external module")
+      elog("Unable to load module #{path} - LoadError Possible non-executable external module.")
     end
     false
   end


### PR DESCRIPTION
Fixes #14281

This PR gives better, more accurate, error logging for external modules.

## Issue 1

Any compile error or dependency error for a module will give 'unknown module type' error in logs, which is obviously not the true error.

Previously:
```
core: Unable to load module /vagrant/modules/auxiliary/gather/office365userenum.py, unknown module type
```

now:
```
core: Unable to load module /vagrant/metasploit-framework/modules/auxiliary/gather/office365userenum.py - LoadError  Try running file manually to check for errors or dependency issues.
```

I thought about doing an `exec` on the file to pull the actual error, but thought that may be dangerous to execute an arbitrary file, whereas the error just suggests you do it and the user takes responsibility.

## Issue 2

When developing an external module, it needs to be marked executable as per the wiki documentation.  That isn't always the most obvious thing however, and the logs silently skip over the file.  Now logs tell the user:

```
[10/21/2020 16:55:56] [e(0)] core: Unable to load module /vagrant/metasploit-framework/modules/auxiliary/gather/mikrotik_winbox_fileread.py - LoadError Possible non-executable external module
```