### PR TITLE
Update enum_putty_saved_sessions.rb

### DIFF
--- a/modules/post/windows/gather/enum_putty_saved_sessions.rb
+++ b/modules/post/windows/gather/enum_putty_saved_sessions.rb
@@ -13,7 +13,7 @@ class MetasploitModule < Msf::Post
   include Msf::Post::File
   include Msf::Post::Windows::Registry
 
-  INTERESTING_KEYS = ['HostName', 'UserName', 'PublicKeyFile', 'PortNumber', 'PortForwardings']
+  INTERESTING_KEYS = ['HostName', 'UserName', 'PublicKeyFile', 'PortNumber', 'PortForwardings','ProxyUsername','ProxyPassword']
   PAGEANT_REGISTRY_KEY = "HKCU\\Software\\SimonTatham\\PuTTY"
   PUTTY_PRIVATE_KEY_ANALYSIS = ['Name', 'HostName', 'UserName', 'PublicKeyFile', 'Type', 'Cipher', 'Comment']
 


### PR DESCRIPTION
PuTTY.exe Insecure Password Storage: Enum_PuTTY_Saved_Sessions.rb Improvement
Authors: **Brian Saunders, Aaron Hobdy, Matt Kiely (HuskyHacks)**

This pull request improves the post/windows/gather/enum_putty_saved_sessions.rb module by adding two registry keys that were omitted previously, ProxyUsername and ProxyPassword. Please see screenshots below:

In PuTTY, the user has the ability to save sessions. The module was already finding credentials and exploiting this fact by querying the registry for values.

![image](https://user-images.githubusercontent.com/57866415/96509121-97858080-1229-11eb-9743-d404c75f95e3.png)

BUT... it was not querying for two additional fields that can set a username and plain text password in the registry: ProxyUsername and ProxyPassword. 

![image](https://user-images.githubusercontent.com/57866415/96509137-9b190780-1229-11eb-8d99-f700da5a26b5.png)

If the user adds a username and password in these fields and saves their session, the values are added to the registry in the following locations:

HKCU\Software\SimonTatham\PuTTY\Sessions\\[Username]\ProxyUsername
HKCU\Software\SimonTatham\PuTTY\Sessions\\[Username]\ProxyPassword

![image](https://user-images.githubusercontent.com/57866415/96509142-9ce2cb00-1229-11eb-9a60-887595f2cb8e.png)

The picture below was taken before the simple script revision, showing that the old module does not check for these credential values.

![image](https://user-images.githubusercontent.com/57866415/96509146-9eac8e80-1229-11eb-81de-aea1feea9a8f.png)

But, after our script revision, these values are queried for and displayed.

![image](https://user-images.githubusercontent.com/57866415/96510731-f815bd00-122b-11eb-9230-708d6ae663cc.png)

## Verification

Tested with latest PuTTY client (0.74 32-bit) on Windows 7 test VM.

- [x] Download and install PuTTY 32 or 64 bit on a Windows test VM.
- [x] In the Session window, input an IP address to connect to.
- [x] Add a username to the Saved Sessions field.
- [x] Under the Connections section, in Proxy, add a username and password to the Username and Password fields
- [x] Back in the Session section, click "Save" to save the user's session information (including the proxy username and password)
- [x] Gain a Meterpreter shell on the target
- [x] Enter: run post/windows/gather/enum_putty_saved_sessions


Reference:
- http://hyp3rlinx.altervista.org/advisories/PUTTY.EXE-INSECURE-PASSWORD-STORAGE.txt