### PR TITLE
Fix zabbix login module to work with newer versions of zabbix

### DIFF
--- a/documentation/modules/auxiliary/scanner/http/zabbix_login.md
+++ b/documentation/modules/auxiliary/scanner/http/zabbix_login.md
@@ -1,0 +1,48 @@
+## Vulnerable Application
+
+This module attempts to login to zabbix server, by default module will use default credentials and also supports user defined login credentials
+### Environment
+
+Zabbix team provides virtual images of multiple versions of Zabbix server.
+In this example versions 3, 4 and 5(latest) were tested.
+
+## Verification Steps
+
+  1. Install zabbix 
+  2. Start msfconsole
+  3. Do: ```use auxiliary/scanner/http/zabbix_login```
+  4. Do: ```set rhosts [ip]```
+  5. Do: ```run```
+  6. If no credentials supplied, module will try zabbix default credentails and if successful the following line is 
+     displayed:
+        [+] 192.168.0.151 - Success: 'Admin:zabbix'
+
+## Options
+
+  **TARGETURI**
+
+  Folder where login page is located.  Versions 3 and 4 by default use /zabbix/.
+  This module sets **TARGETURI** to /zabbix/ by default.
+
+  Note that version 5 of zabbix, location of login page has moved to /.  If module is used against zabbix version 5, 
+  **TARGETURI** needs to be changed to /.  To do that run following in metasploit
+  ````set TARGETURI / ````
+
+## Scenarios
+
+### Example run against zabbix version 3
+
+```
+msf5 > use auxiliary/scanner/http/zabbix_login
+msf5 auxiliary(scanner/http/zabbix_login) > set RHOSTS 192.168.0.151
+RHOSTS => 192.168.0.151
+msf5 auxiliary(scanner/http/zabbix_login) > run
+
+[*] 192.168.0.151:80 - Found Zabbix version
+[*] 192.168.0.151:80 - Zabbix has disabled Guest mode
+[+] 192.168.0.151:80 - Success: 'Admin:zabbix'
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+msf5 auxiliary(scanner/http/zabbix_login) > 
+
+```

--- a/lib/metasploit/framework/login_scanner/zabbix.rb
+++ b/lib/metasploit/framework/login_scanner/zabbix.rb
@@ -48,7 +48,7 @@ module Metasploit
               return "Unexpected HTTP response code #{res.code} (is this really Zabbix?)"
             end
 
-            if res.body.to_s !~ /Zabbix ([^\s]+) Copyright .* by Zabbix/m
+            if res.body.to_s !~ /Zabbix/
               return "Unexpected HTTP body (is this really Zabbix?)"
             end
 
@@ -115,14 +115,15 @@ module Metasploit
           res = try_credential(credential)
           if res && res.code == 302
             opts = {
-              'uri'     => normalize_uri('profile.php'),
+              #'uri'     => normalize_uri('profile.php'), --> works for versions 3 and 4 but not 5
+              'uri'     => normalize_uri('discoveryconf.php'),
               'method'  => 'GET',
               'headers' => {
                 'Cookie'  => "zbx_sessionid=#{self.zsession}"
               }
             }
             res = send_request(opts)
-            if (res && res.code == 200 && res.body.to_s =~ /<title>Zabbix .*: User profile<\/title>/)
+            if (res && res.code == 200 && res.body.to_s =~ /Zabbix/)
               return {:status => Metasploit::Model::Login::Status::SUCCESSFUL, :proof => res.body}
             end
           end


### PR DESCRIPTION
Login module does not recognize successful login with newer versions (3,4, and 5-latest).  See issue 14195.
Also added documentation for zabbix login module

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use auxiliary/scanner/http/zabbix_login`
- [ ] set RHOSTS <IP ADDRESS>
- [ ] run
- [ ] <IP ADDRESS> - Success: 'Admin:zabbix'

Above was tested using Zabbix Virtual images running in Virtualbox 6.1
Images used were Zabbix Server versions 3, 4 and 5.
_Note that on Zabbix server version 5, the target uri moved and requires an additional variable set in msfconsole
set TARGETURI /_



