### PR TITLE
sync Gemfile.lock for version missed in #14267

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -219,7 +219,7 @@ GEM
       activemodel (~> 5.2.2)
       activesupport (~> 5.2.2)
       railties (~> 5.2.2)
-    metasploit-payloads (2.0.16)
+    metasploit-payloads (2.0.22)
     metasploit_data_models (4.1.0)
       activerecord (~> 5.2.2)
       activesupport (~> 5.2.2)


### PR DESCRIPTION
Updates the lock file for consistent `metasploit-payloads` gem versions.  This was identified as missed during `omnibus` builds for windows.

```
05:36:04 Error:
05:36:04 
05:36:04     Bundler could not find compatible versions for gem "metasploit-payloads":
05:36:04   In snapshot (Gemfile.lock):
05:36:04     metasploit-payloads (= 2.0.16)
05:36:04 
05:36:04   In Gemfile:
05:36:04     metasploit-framework was resolved to 6.0.12, which depends on
05:36:04       metasploit-payloads (= 2.0.22)
```