### PR TITLE
Allow adding details to CheckCodes

### DIFF
--- a/lib/msf/core/db_manager/host.rb
+++ b/lib/msf/core/db_manager/host.rb
@@ -229,18 +229,6 @@ module Msf::DBManager::Host
         opts[:name] = opts[:name][0,255]
       end
 
-      if opts[:os_name]
-        os_name, os_flavor = split_windows_os_name(opts[:os_name])
-        opts[:os_name] = os_name if os_name.present?
-        if opts[:os_flavor].present?
-          if os_flavor.present? # only prepend if there is a value that needs it
-            opts[:os_flavor] = os_flavor + opts[:os_flavor]
-          end
-        else
-          opts[:os_flavor] = os_flavor
-        end
-      end
-
       opts.each do |k,v|
         if host.attribute_names.include?(k.to_s)
           unless host.attribute_locked?(k.to_s)
@@ -300,12 +288,5 @@ module Msf::DBManager::Host
       host.update!(opts)
       return host
     }
-  end
-
-  def split_windows_os_name(os_name)
-    return [] if os_name.nil?
-    flavor_match = os_name.match(/Windows\s+(.*)/)
-    return [] if flavor_match.nil?
-    ["Windows", flavor_match.captures.first]
   end
 end

--- a/lib/msf/core/exploit.rb
+++ b/lib/msf/core/exploit.rb
@@ -81,28 +81,28 @@ class Exploit < Msf::Module
     # of the codebase.
 
     class << self
-      def Unknown(reason = nil, **kwargs)
-        self.new('unknown', reason, **kwargs)
+      def Unknown(reason = nil, details: {})
+        self.new('unknown', reason, details: details)
       end
 
-      def Safe(reason = nil, **kwargs)
-        self.new('safe', reason, **kwargs)
+      def Safe(reason = nil, details: {})
+        self.new('safe', reason, details: details)
       end
 
-      def Detected(reason = nil, **kwargs)
-        self.new('detected', reason, **kwargs)
+      def Detected(reason = nil, details: {})
+        self.new('detected', reason, details: details)
       end
 
-      def Appears(reason = nil, **kwargs)
-        self.new('appears', reason, **kwargs)
+      def Appears(reason = nil, details: {})
+        self.new('appears', reason, details: details)
       end
 
-      def Vulnerable(reason = nil, **kwargs)
-        self.new('vulnerable', reason, **kwargs)
+      def Vulnerable(reason = nil, details: {})
+        self.new('vulnerable', reason, details: details)
       end
 
-      def Unsupported(reason = nil, **kwargs)
-        self.new('unsupported', reason, **kwargs)
+      def Unsupported(reason = nil, details: {})
+        self.new('unsupported', reason, details: details)
       end
     end
 

--- a/lib/msf/core/exploit.rb
+++ b/lib/msf/core/exploit.rb
@@ -69,7 +69,7 @@ class Exploit < Msf::Module
   # https://github.com/rapid7/metasploit-framework/wiki/How-to-write-a-check()-method
   #
   ##
-  class CheckCode < Struct.new(:code, :message, :reason)
+  class CheckCode < Struct.new(:code, :message, :reason, :details)
     # Do customization here because we need class constants and special
     # optional values and the block mode of Struct.new does not support that.
     #
@@ -131,10 +131,7 @@ class Exploit < Msf::Module
         else
           ''
       end
-      super(code, "#{msg} #{reason}".strip, reason)
-
-      # details is intentionally omitted from the struct fields
-      @details = details
+      super(code, "#{msg} #{reason}".strip, reason, details)
     end
 
     #
@@ -173,8 +170,6 @@ class Exploit < Msf::Module
     # The module does not support the check method.
     #
     Unsupported = self.Unsupported()
-
-    attr_reader :details
   end
 
   #

--- a/lib/msf/core/exploit.rb
+++ b/lib/msf/core/exploit.rb
@@ -69,7 +69,7 @@ class Exploit < Msf::Module
   # https://github.com/rapid7/metasploit-framework/wiki/How-to-write-a-check()-method
   #
   ##
-  class CheckCode < Struct.new(:code, :message, :reason, :details)
+  class CheckCode < Struct.new(:code, :message, :reason)
     # Do customization here because we need class constants and special
     # optional values and the block mode of Struct.new does not support that.
     #
@@ -81,28 +81,28 @@ class Exploit < Msf::Module
     # of the codebase.
 
     class << self
-      def Unknown(reason = nil, details: {})
-        self.new('unknown', reason, details)
+      def Unknown(reason = nil, **kwargs)
+        self.new('unknown', reason, **kwargs)
       end
 
-      def Safe(reason = nil, details: {})
-        self.new('safe', reason, details)
+      def Safe(reason = nil, **kwargs)
+        self.new('safe', reason, **kwargs)
       end
 
-      def Detected(reason = nil, details: {})
-        self.new('detected', reason, details)
+      def Detected(reason = nil, **kwargs)
+        self.new('detected', reason, **kwargs)
       end
 
-      def Appears(reason = nil, details: {})
-        self.new('appears', reason, details)
+      def Appears(reason = nil, **kwargs)
+        self.new('appears', reason, **kwargs)
       end
 
-      def Vulnerable(reason = nil, details: {})
-        self.new('vulnerable', reason, details)
+      def Vulnerable(reason = nil, **kwargs)
+        self.new('vulnerable', reason, **kwargs)
       end
 
-      def Unsupported(reason = nil, details: {})
-        self.new('unsupported', reason, details)
+      def Unsupported(reason = nil, **kwargs)
+        self.new('unsupported', reason, **kwargs)
       end
     end
 
@@ -120,7 +120,7 @@ class Exploit < Msf::Module
       other.is_a?(self.class) && self.code == other.code
     end
 
-    def initialize(code, reason, details = {})
+    def initialize(code, reason, details: {})
       msg = case code
         when 'unknown';     'Cannot reliably check exploitability.'
         when 'safe';        'The target is not exploitable.'
@@ -131,7 +131,10 @@ class Exploit < Msf::Module
         else
           ''
       end
-      super(code, "#{msg} #{reason}".strip, reason, details)
+      super(code, "#{msg} #{reason}".strip, reason)
+
+      # details is intentionally omitted from the struct fields
+      @details = details
     end
 
     #
@@ -170,6 +173,8 @@ class Exploit < Msf::Module
     # The module does not support the check method.
     #
     Unsupported = self.Unsupported()
+
+    attr_reader :details
   end
 
   #

--- a/lib/msf/core/exploit.rb
+++ b/lib/msf/core/exploit.rb
@@ -69,7 +69,7 @@ class Exploit < Msf::Module
   # https://github.com/rapid7/metasploit-framework/wiki/How-to-write-a-check()-method
   #
   ##
-  class CheckCode < Struct.new(:code, :message, :reason)
+  class CheckCode < Struct.new(:code, :message, :reason, :details)
     # Do customization here because we need class constants and special
     # optional values and the block mode of Struct.new does not support that.
     #
@@ -81,28 +81,28 @@ class Exploit < Msf::Module
     # of the codebase.
 
     class << self
-      def Unknown(reason = nil)
-        self.new('unknown', reason)
+      def Unknown(reason = nil, details: {})
+        self.new('unknown', reason, details)
       end
 
-      def Safe(reason = nil)
-        self.new('safe', reason)
+      def Safe(reason = nil, details: {})
+        self.new('safe', reason, details)
       end
 
-      def Detected(reason = nil)
-        self.new('detected', reason)
+      def Detected(reason = nil, details: {})
+        self.new('detected', reason, details)
       end
 
-      def Appears(reason = nil)
-        self.new('appears', reason)
+      def Appears(reason = nil, details: {})
+        self.new('appears', reason, details)
       end
 
-      def Vulnerable(reason = nil)
-        self.new('vulnerable', reason)
+      def Vulnerable(reason = nil, details: {})
+        self.new('vulnerable', reason, details)
       end
 
-      def Unsupported(reason = nil)
-        self.new('unsupported', reason)
+      def Unsupported(reason = nil, details: {})
+        self.new('unsupported', reason, details)
       end
     end
 
@@ -120,7 +120,7 @@ class Exploit < Msf::Module
       other.is_a?(self.class) && self.code == other.code
     end
 
-    def initialize(code, reason)
+    def initialize(code, reason, details = {})
       msg = case code
         when 'unknown';     'Cannot reliably check exploitability.'
         when 'safe';        'The target is not exploitable.'
@@ -131,7 +131,7 @@ class Exploit < Msf::Module
         else
           ''
       end
-      super(code, "#{msg} #{reason}".strip, reason)
+      super(code, "#{msg} #{reason}".strip, reason, details)
     end
 
     #

--- a/modules/auxiliary/scanner/smb/smb_ms17_010.rb
+++ b/modules/auxiliary/scanner/smb/smb_ms17_010.rb
@@ -76,6 +76,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def run_host(ip)
     checkcode = Exploit::CheckCode::Unknown
+    details = {}
 
     begin
       ipc_share = "\\\\#{ip}\\IPC$"
@@ -93,14 +94,16 @@ class MetasploitModule < Msf::Auxiliary
           case dcerpc_getarch
           when ARCH_X86
             os << ' x86 (32-bit)'
+            details[:arch] = ARCH_X86
           when ARCH_X64
             os << ' x64 (64-bit)'
+            details[:arch] = ARCH_X64
           end
         end
 
         print_good("Host is likely VULNERABLE to MS17-010! - #{os}")
 
-        checkcode = Exploit::CheckCode::Vulnerable
+        checkcode = Exploit::CheckCode::Vulnerable(details: details)
 
         report_vuln(
           host: ip,

--- a/modules/auxiliary/scanner/smb/smb_ms17_010.rb
+++ b/modules/auxiliary/scanner/smb/smb_ms17_010.rb
@@ -154,10 +154,10 @@ class MetasploitModule < Msf::Auxiliary
       unless (fp_match = Recog::Nizer.match('smb.native_os', simple.client.peer_native_os)).nil?
         report_host(
           host: rhost,
-          name: simple.client.default_name,
           arch: details[:arch],
           os_family: 'Windows',
-          os_flavor: fp_match['os.edition']
+          os_flavor: fp_match['os.edition'],
+          os_name: fp_match['os.product']
         )
       end
 

--- a/modules/exploits/windows/smb/ms17_010_eternalblue.rb
+++ b/modules/exploits/windows/smb/ms17_010_eternalblue.rb
@@ -129,7 +129,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     unless (check_code.details[:arch] || dcerpc_getarch) == ARCH_X64
-      fail_with(Failure::NoTarget, 'This exploit module only support x64 (64-bit) targets')
+      fail_with(Failure::NoTarget, 'This exploit module only supports x64 (64-bit) targets')
     end
 
     begin

--- a/modules/exploits/windows/smb/ms17_010_eternalblue.rb
+++ b/modules/exploits/windows/smb/ms17_010_eternalblue.rb
@@ -123,8 +123,13 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    unless check == CheckCode::Vulnerable || datastore['ForceExploit']
+    check_code = check
+    unless check_code == CheckCode::Vulnerable || datastore['ForceExploit']
       fail_with(Failure::NotVulnerable, 'Set ForceExploit to override')
+    end
+
+    unless (check_code.details[:arch] || dcerpc_getarch) == ARCH_X64
+      fail_with(Failure::NoTarget, 'This exploit module only support x64 (64-bit) targets')
     end
 
     begin

--- a/spec/api/json_rpc_spec.rb
+++ b/spec/api/json_rpc_spec.rb
@@ -124,6 +124,7 @@ RSpec.describe "Metasploit's json-rpc" do
             'status' => 'completed',
             'result' => {
               'code' => 'safe',
+              'details' => {},
               'message' => 'The target is not exploitable.',
               'reason' => nil
             }


### PR DESCRIPTION
It would be super nice if we could allow check methods (and modules used as check-modules) to return arbitrary information that's relevant for exploitation.

One particular use case where this would be really nice is for MS17-010. In this case, Metasploit has a scanner module that can identify vulnerable systems regardless of the architecture. The exploit module however only supports exploiting x64 targets. In practice, this means that targets are identified as being vulnerable (which they technically are affected by the vulnerability) and then targeted for exploitation regardless of whether or not the exploit will work based on the target architecture. This can easily lead to [confusion](https://github.com/rapid7/metasploit-framework/issues/14092#issuecomment-694129127).

You may be wondering, "well why not just check the arch again in the MS17-010 exploit?" and you'd be right, that could be another option. This scenario however isn't the [only one](https://github.com/rapid7/metasploit-framework/blob/master/modules/auxiliary/gather/saltstack_salt_root_key.rb#L91) where getting information out of the check module would be useful. There are also instances where exploits define their own check methods that need to propagate information for exploitation, like HTTP sessions IDs. In this case the most common solution is to use instance attributes on the module itself which is fine, but would limit us from moving these check methods into dedicated auxiliary check-modules.

Marked as delayed because this requires #14290 to be landed first (for MS17-010 exploit fixes).

## Implementation Notes
The new `#details` attribute is intentionally left out of the struct. It's the newest field so it doesn't need to maintain the array-interface for backwards compatibility. Additionally, defining it as an attribute maintains compatibility with the RPC interface (I think, at least the unit tests don't show a difference like they do if it's defined in the struct). Leaving it out of the RPC interface is intentional since it removes the need for the data to be serializable, and it's likely only going to be consumed by exploit modules in the local instance of Metasploit anyways.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/windows/smb/ms17_010_eternalblue`
- [ ] Target a vulnerable Windows 7 x86 system
- [ ] Run the `check` method and see that the target is vulnerable
- [ ] Run the `exploit` method and see that the exploit fails with the "no-target" code since x86 isn't supported by the module

## Example Output

```
msf6 auxiliary(scanner/smb/smb_ms17_010) > run
[+] 10.4.23.29:445        - Host is likely VULNERABLE to MS17-010! - Windows 7 Enterprise 7600 x86 (32-bit)
[*] 10.4.23.29:445        - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf6 auxiliary(scanner/smb/smb_ms17_010) > use exploit/windows/smb/ms17_010_eternalblue
[*] Using configured payload windows/x64/meterpreter/reverse_tcp
msf6 exploit(windows/smb/ms17_010_eternalblue) > set RHOSTS 10.4.23.29
RHOSTS => 10.4.23.29
msf6 exploit(windows/smb/ms17_010_eternalblue) > check
[*] 10.4.23.29:445 - Using auxiliary/scanner/smb/smb_ms17_010 as check
[+] 10.4.23.29:445        - Host is likely VULNERABLE to MS17-010! - Windows 7 Enterprise 7600 x86 (32-bit)
[*] 10.4.23.29:445        - Scanned 1 of 1 hosts (100% complete)
[+] 10.4.23.29:445 - The target is vulnerable.
msf6 exploit(windows/smb/ms17_010_eternalblue) > exploit
[*] Started reverse TCP handler on 192.168.159.128:4444 
[*] 10.4.23.29:445 - Using auxiliary/scanner/smb/smb_ms17_010 as check
[+] 10.4.23.29:445        - Host is likely VULNERABLE to MS17-010! - Windows 7 Enterprise 7600 x86 (32-bit)
[*] 10.4.23.29:445        - Scanned 1 of 1 hosts (100% complete)
[-] 10.4.23.29:445 - Exploit aborted due to failure: no-target: This exploit module only support x64 (64-bit) targets
[*] Exploit completed, but no session was created.
```