### PR TITLE
Modified zabbix login to work with newer versions of zabbix

### DIFF
--- a/documentation/modules/auxiliary/scanner/http/zabbix_login.md
+++ b/documentation/modules/auxiliary/scanner/http/zabbix_login.md
@@ -1,48 +1,133 @@
 ## Vulnerable Application
 
-This module attempts to login to zabbix server, by default module will use default credentials and also supports user defined login credentials
+This module attempts to guess valid logins to a specified Zabbix server.
+Login details can be retrieved either from an external file, from the database,
+or they can be specified one by one via the `USERNAME` and `PASSWORD` options.
+
+This module will also check to see if the default login of `Admin:zabbix` works
+and if the target Zabbix host has guest access enabled.
+
 ### Environment
 
-Zabbix team provides virtual images of multiple versions of Zabbix server.
-In this example versions 3, 4 and 5(latest) were tested.
+Zabbix team provides virtual images of multiple versions of Zabbix
+as Zabbix Appliance downloads at https://www.zabbix.com/download_appliance.
+This module has been confirmed to work against version 3, 4 and 5, as well as
+version 2.4 and 2.2.
 
 ## Verification Steps
 
-  1. Install zabbix 
+  1. Download and install one of the Zabbix Appliance virtual images.
   2. Start msfconsole
-  3. Do: ```use auxiliary/scanner/http/zabbix_login```
-  4. Do: ```set rhosts [ip]```
-  5. Do: ```run```
-  6. If no credentials supplied, module will try zabbix default credentails and if successful the following line is 
-     displayed:
-        [+] 192.168.0.151 - Success: 'Admin:zabbix'
+  3. Do: `use auxiliary/scanner/http/zabbix_login`
+  4. Do: `set rhosts [ip]`
+  5. Do: `run`
+  6. Verify: That the module tries all credentials provided and returns any credentials that it successfully finds.
+  7. Verify: That the module also tries the default administrative password of `Admin:zabbix` and also checks if guest access is enabled.
+  8. Verify: That running the `creds` command will show that any enumerated passwords have been saved into the database (if one is connected).
 
 ## Options
 
-  **TARGETURI**
+  ### TARGETURI
 
-  Folder where login page is located.  Versions 3 and 4 by default use /zabbix/.
-  This module sets **TARGETURI** to /zabbix/ by default.
-
-  Note that version 5 of zabbix, location of login page has moved to /.  If module is used against zabbix version 5, 
-  **TARGETURI** needs to be changed to /.  To do that run following in metasploit
-  ````set TARGETURI / ````
+  Folder where login page is located.  Versions 3 and 4 by default use `/zabbix/`,
+  however version 5 uses `/` as its default. Because of this, the module sets
+  `TARGETURI` to `/zabbix/` by default, however users can run `set TARGETURI /`
+  to change the `TARGETURI` value if needed.
 
 ## Scenarios
 
-### Example run against zabbix version 3
+### Zabbix Version 5.0.5
 
 ```
-msf5 > use auxiliary/scanner/http/zabbix_login
-msf5 auxiliary(scanner/http/zabbix_login) > set RHOSTS 192.168.0.151
-RHOSTS => 192.168.0.151
-msf5 auxiliary(scanner/http/zabbix_login) > run
+msf6 > use auxiliary/scanner/http/zabbix_login
+msf6 auxiliary(scanner/http/zabbix_login) > info
 
-[*] 192.168.0.151:80 - Found Zabbix version
-[*] 192.168.0.151:80 - Zabbix has disabled Guest mode
-[+] 192.168.0.151:80 - Success: 'Admin:zabbix'
+       Name: Zabbix Server Brute Force Utility
+     Module: auxiliary/scanner/http/zabbix_login
+    License: Metasploit Framework License (BSD)
+       Rank: Normal
+
+Provided by:
+  hdm <x@hdm.io>
+
+Check supported:
+  No
+
+Basic options:
+  Name              Current Setting  Required  Description
+  ----              ---------------  --------  -----------
+  BLANK_PASSWORDS   false            no        Try blank passwords for all users
+  BRUTEFORCE_SPEED  5                yes       How fast to bruteforce, from 0 to 5
+  DB_ALL_CREDS      false            no        Try each user/password couple stored in the current database
+  DB_ALL_PASS       false            no        Add all passwords in the current database to the list
+  DB_ALL_USERS      false            no        Add all users in the current database to the list
+  PASSWORD                           no        A specific password to authenticate with
+  PASS_FILE                          no        File containing passwords, one per line
+  Proxies                            no        A proxy chain of format type:host:port[,type:host:port][...]
+  RHOSTS                             yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
+  RPORT             80               yes       The target port (TCP)
+  SSL               false            no        Negotiate SSL/TLS for outgoing connections
+  STOP_ON_SUCCESS   false            yes       Stop guessing when a credential works for a host
+  TARGETURI         /zabbix/         yes       The path to the Zabbix server application
+  THREADS           1                yes       The number of concurrent threads (max one per host)
+  USERNAME                           no        A specific username to authenticate as
+  USERPASS_FILE                      no        File containing users and passwords separated by space, one pair per line
+  USER_AS_PASS      false            no        Try the username as the password for all users
+  USER_FILE                          no        File containing usernames, one per line
+  VERBOSE           true             yes       Whether to print output for all attempts
+  VHOST                              no        HTTP server virtual host
+
+Description:
+  This module attempts to login to Zabbix server instance using
+  username and password combinations indicated by the USER_FILE,
+  PASS_FILE, and USERPASS_FILE options. It will also test for the
+  Zabbix default login (Admin:zabbix) and guest access.
+
+msf6 auxiliary(scanner/http/zabbix_login) > set TARGETURI /
+TARGETURI => /
+msf6 auxiliary(scanner/http/zabbix_login) > set RHOSTS 172.29.121.85
+RHOSTS => 172.29.121.85
+msf6 auxiliary(scanner/http/zabbix_login) > show options
+
+Module options (auxiliary/scanner/http/zabbix_login):
+
+   Name              Current Setting  Required  Description
+   ----              ---------------  --------  -----------
+   BLANK_PASSWORDS   false            no        Try blank passwords for all users
+   BRUTEFORCE_SPEED  5                yes       How fast to bruteforce, from 0 to 5
+   DB_ALL_CREDS      false            no        Try each user/password couple stored in the current database
+   DB_ALL_PASS       false            no        Add all passwords in the current database to the list
+   DB_ALL_USERS      false            no        Add all users in the current database to the list
+   PASSWORD                           no        A specific password to authenticate with
+   PASS_FILE                          no        File containing passwords, one per line
+   Proxies                            no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS            172.29.121.85    yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
+   RPORT             80               yes       The target port (TCP)
+   SSL               false            no        Negotiate SSL/TLS for outgoing connections
+   STOP_ON_SUCCESS   false            yes       Stop guessing when a credential works for a host
+   TARGETURI         /                yes       The path to the Zabbix server application
+   THREADS           1                yes       The number of concurrent threads (max one per host)
+   USERNAME                           no        A specific username to authenticate as
+   USERPASS_FILE                      no        File containing users and passwords separated by space, one pair per line
+   USER_AS_PASS      false            no        Try the username as the password for all users
+   USER_FILE                          no        File containing usernames, one per line
+   VERBOSE           true             yes       Whether to print output for all attempts
+   VHOST                              no        HTTP server virtual host
+
+msf6 auxiliary(scanner/http/zabbix_login) > run
+
+[*] 172.29.121.85:80 - Found Zabbix version 5.0
+[*] 172.29.121.85:80 - This Zabbix instance has disabled Guest mode
+[+] 172.29.121.85:80 - Success: 'Admin:zabbix'
 [*] Scanned 1 of 1 hosts (100% complete)
 [*] Auxiliary module execution completed
-msf5 auxiliary(scanner/http/zabbix_login) > 
+msf6 auxiliary(scanner/http/zabbix_login) > creds
+Credentials
+===========
 
+host           origin         service          public                private                                                            realm  private_type    JtR Format
+----           ------         -------          ------                -------                                                            -----  ------------    ----------
+172.29.121.85  172.29.121.85  80/tcp (http)    Admin                 zabbix                                                                    Password
+
+msf6 auxiliary(scanner/http/zabbix_login) >
 ```

--- a/documentation/modules/auxiliary/scanner/http/zabbix_login.md
+++ b/documentation/modules/auxiliary/scanner/http/zabbix_login.md
@@ -1,0 +1,48 @@
+## Vulnerable Application
+
+This module attempts to login to zabbix server, by default module will use default credentials and also supports user defined login credentials
+### Environment
+
+Zabbix team provides virtual images of multiple versions of Zabbix server.
+In this example versions 3, 4 and 5(latest) were tested.
+
+## Verification Steps
+
+  1. Install zabbix 
+  2. Start msfconsole
+  3. Do: ```use auxiliary/scanner/http/zabbix_login```
+  4. Do: ```set rhosts [ip]```
+  5. Do: ```run```
+  6. If no credentials supplied, module will try zabbix default credentails and if successful the following line is 
+     displayed:
+        [+] 192.168.0.151 - Success: 'Admin:zabbix'
+
+## Options
+
+  **TARGETURI**
+
+  Folder where login page is located.  Versions 3 and 4 by default use /zabbix/.
+  This module sets **TARGETURI** to /zabbix/ by default.
+
+  Note that version 5 of zabbix, location of login page has moved to /.  If module is used against zabbix version 5, 
+  **TARGETURI** needs to be changed to /.  To do that run following in metasploit
+  ````set TARGETURI / ````
+
+## Scenarios
+
+### Example run against zabbix version 3
+
+```
+msf5 > use auxiliary/scanner/http/zabbix_login
+msf5 auxiliary(scanner/http/zabbix_login) > set RHOSTS 192.168.0.151
+RHOSTS => 192.168.0.151
+msf5 auxiliary(scanner/http/zabbix_login) > run
+
+[*] 192.168.0.151:80 - Found Zabbix version
+[*] 192.168.0.151:80 - Zabbix has disabled Guest mode
+[+] 192.168.0.151:80 - Success: 'Admin:zabbix'
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+msf5 auxiliary(scanner/http/zabbix_login) > 
+
+```

--- a/documentation/modules/auxiliary/scanner/http/zabbix_login.md
+++ b/documentation/modules/auxiliary/scanner/http/zabbix_login.md
@@ -83,42 +83,20 @@ Description:
   PASS_FILE, and USERPASS_FILE options. It will also test for the
   Zabbix default login (Admin:zabbix) and guest access.
 
-msf6 auxiliary(scanner/http/zabbix_login) > set TARGETURI /
-TARGETURI => /
 msf6 auxiliary(scanner/http/zabbix_login) > set RHOSTS 172.29.121.85
 RHOSTS => 172.29.121.85
-msf6 auxiliary(scanner/http/zabbix_login) > show options
-
-Module options (auxiliary/scanner/http/zabbix_login):
-
-   Name              Current Setting  Required  Description
-   ----              ---------------  --------  -----------
-   BLANK_PASSWORDS   false            no        Try blank passwords for all users
-   BRUTEFORCE_SPEED  5                yes       How fast to bruteforce, from 0 to 5
-   DB_ALL_CREDS      false            no        Try each user/password couple stored in the current database
-   DB_ALL_PASS       false            no        Add all passwords in the current database to the list
-   DB_ALL_USERS      false            no        Add all users in the current database to the list
-   PASSWORD                           no        A specific password to authenticate with
-   PASS_FILE                          no        File containing passwords, one per line
-   Proxies                            no        A proxy chain of format type:host:port[,type:host:port][...]
-   RHOSTS            172.29.121.85    yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
-   RPORT             80               yes       The target port (TCP)
-   SSL               false            no        Negotiate SSL/TLS for outgoing connections
-   STOP_ON_SUCCESS   false            yes       Stop guessing when a credential works for a host
-   TARGETURI         /                yes       The path to the Zabbix server application
-   THREADS           1                yes       The number of concurrent threads (max one per host)
-   USERNAME                           no        A specific username to authenticate as
-   USERPASS_FILE                      no        File containing users and passwords separated by space, one pair per line
-   USER_AS_PASS      false            no        Try the username as the password for all users
-   USER_FILE                          no        File containing usernames, one per line
-   VERBOSE           true             yes       Whether to print output for all attempts
-   VHOST                              no        HTTP server virtual host
-
+msf6 auxiliary(scanner/http/zabbix_login) > set TARGETURI /
+TARGETURI => /
+msf6 auxiliary(scanner/http/zabbix_login) > set USERNAME Admin
+USERNAME => Admin
+msf6 auxiliary(scanner/http/zabbix_login) > set PASSWORD zabbix2
+PASSWORD => zabbix2
 msf6 auxiliary(scanner/http/zabbix_login) > run
 
 [*] 172.29.121.85:80 - Found Zabbix version 5.0
 [*] 172.29.121.85:80 - This Zabbix instance has disabled Guest mode
-[+] 172.29.121.85:80 - Success: 'Admin:zabbix'
+[-] 172.29.121.85:80 - Failed: 'Admin:zabbix'
+[+] 172.29.121.85:80 - Success: 'Admin:zabbix2'
 [*] Scanned 1 of 1 hosts (100% complete)
 [*] Auxiliary module execution completed
 msf6 auxiliary(scanner/http/zabbix_login) > creds
@@ -127,7 +105,7 @@ Credentials
 
 host           origin         service          public                private                                                            realm  private_type    JtR Format
 ----           ------         -------          ------                -------                                                            -----  ------------    ----------
-172.29.121.85  172.29.121.85  80/tcp (http)    Admin                 zabbix                                                                    Password
+172.29.121.85  172.29.121.85  80/tcp (http)    Admin                 zabbix2                                                                   Password
 
 msf6 auxiliary(scanner/http/zabbix_login) >
 ```

--- a/lib/metasploit/framework/login_scanner/zabbix.rb
+++ b/lib/metasploit/framework/login_scanner/zabbix.rb
@@ -76,8 +76,8 @@ module Metasploit
           res = cli.send_recv(req)
 
           # Found a cookie? Set it. We're going to need it.
-          if res && res.get_cookies =~ /(?:zbx_session(?:id)?)=([a-zA-Z0-9]*)((?:%3D){0,2});/i
-            self.zsession = $1 + $2
+          if res && res.get_cookies =~ /(zbx_session(?:id)?=\w+(?:%3D){0,2};)/i
+            self.zsession = $1
           end
 
           res
@@ -113,7 +113,7 @@ module Metasploit
             'uri'     => normalize_uri(url),
             'method'  => 'GET',
             'headers' => {
-              'Cookie'  => "zbx_sessionid=#{self.zsession}; zbx_session=#{self.zsession}"
+              'Cookie'  => "#{self.zsession}"
             }
           }
           send_request(opts)

--- a/lib/metasploit/framework/login_scanner/zabbix.rb
+++ b/lib/metasploit/framework/login_scanner/zabbix.rb
@@ -110,7 +110,6 @@ module Metasploit
 
         def perform_login_attempt(url)
           opts = {
-            # profile.php exists in Zabbix versions up to Zabbix 5.x
             'uri'     => normalize_uri(url),
             'method'  => 'GET',
             'headers' => {
@@ -130,7 +129,7 @@ module Metasploit
           res = try_credential(credential)
 
           if res && res.code == 302
-            res = perform_login_attempt('profile.php')
+            res = perform_login_attempt('profile.php') # profile.php exists in Zabbix versions up to Zabbix 5.x
             if (res && res.code == 200 && res.body.to_s =~ /<title>.*: User profile<\/title>/)
               return {:status => Metasploit::Model::Login::Status::SUCCESSFUL, :proof => res.body}
             else

--- a/lib/metasploit/framework/login_scanner/zabbix.rb
+++ b/lib/metasploit/framework/login_scanner/zabbix.rb
@@ -76,8 +76,8 @@ module Metasploit
           res = cli.send_recv(req)
 
           # Found a cookie? Set it. We're going to need it.
-          if res && res.get_cookies =~ /zbx_sessionid=(\w*);/i
-            self.zsession = $1
+          if res && res.get_cookies =~ /(?:zbx_session(?:id)?)=([a-zA-Z0-9]*)((?:%3D){0,2});/i
+            self.zsession = $1 + $2
           end
 
           res
@@ -113,7 +113,7 @@ module Metasploit
             'uri'     => normalize_uri(url),
             'method'  => 'GET',
             'headers' => {
-              'Cookie'  => "zbx_sessionid=#{self.zsession}"
+              'Cookie'  => "zbx_sessionid=#{self.zsession}; zbx_session=#{self.zsession}"
             }
           }
           send_request(opts)

--- a/lib/metasploit/framework/login_scanner/zabbix.rb
+++ b/lib/metasploit/framework/login_scanner/zabbix.rb
@@ -48,7 +48,7 @@ module Metasploit
               return "Unexpected HTTP response code #{res.code} (is this really Zabbix?)"
             end
 
-            if res.body.to_s !~ /Zabbix ([^\s]+) Copyright .* by Zabbix/m
+            if res.body.to_s !~ /Zabbix/
               return "Unexpected HTTP body (is this really Zabbix?)"
             end
 
@@ -115,14 +115,15 @@ module Metasploit
           res = try_credential(credential)
           if res && res.code == 302
             opts = {
-              'uri'     => normalize_uri('profile.php'),
+              #'uri'     => normalize_uri('profile.php'), --> works for versions 3 and 4 but not 5
+              'uri'     => normalize_uri('discoveryconf.php'),
               'method'  => 'GET',
               'headers' => {
                 'Cookie'  => "zbx_sessionid=#{self.zsession}"
               }
             }
             res = send_request(opts)
-            if (res && res.code == 200 && res.body.to_s =~ /<title>Zabbix .*: User profile<\/title>/)
+            if (res && res.code == 200 && res.body.to_s =~ /Zabbix/)
               return {:status => Metasploit::Model::Login::Status::SUCCESSFUL, :proof => res.body}
             end
           end

--- a/modules/auxiliary/scanner/http/zabbix_login.rb
+++ b/modules/auxiliary/scanner/http/zabbix_login.rb
@@ -170,6 +170,19 @@ class MetasploitModule < Msf::Auxiliary
   def is_guest_mode_enabled?
     dashboard_uri = normalize_uri(datastore['TARGETURI'] + '/' + 'dashboard.php')
     res = send_request_cgi({'uri'=>dashboard_uri})
-    !! (res && res.code == 200 && res.body.to_s =~ /<title>Zabbix .*: Dashboard<\/title>/)
+    if (res && res.code == 200 && res.body.to_s =~ /<title>.*: Dashboard<\/title>/)
+      return true
+    else # Otherwise target is most likely a newer version of Zabbix, so lets try the updated URL.
+      dashboard_uri = normalize_uri(datastore['TARGETURI'] + '/' + 'zabbix.php')
+      res = send_request_cgi({
+        'uri' => dashboard_uri,
+        'vars_get' => { 'action' => 'dashboard.view' }
+      })
+      if (res && res.code == 200 && res.body.to_s =~ /<title>.*: Dashboard<\/title>/)
+        return true
+      else
+        return false
+      end
+    end
   end
 end

--- a/modules/auxiliary/scanner/http/zabbix_login.rb
+++ b/modules/auxiliary/scanner/http/zabbix_login.rb
@@ -52,7 +52,7 @@ class MetasploitModule < Msf::Auxiliary
     if is_guest_mode_enabled?
       print_brute :level => :good, :ip => ip, :msg => "Note: This Zabbix instance has Guest mode enabled"
     else
-      print_brute :level=>:status, :ip=>rhost, :msg=>("Zabbix has disabled Guest mode")
+      print_brute :level=>:status, :ip=>rhost, :msg=>("This Zabbix instance has disabled Guest mode")
     end
 
     bruteforce(ip)

--- a/spec/lib/metasploit/framework/login_scanner/zabbix_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/zabbix_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe Metasploit::Framework::LoginScanner::Zabbix do
       allow_any_instance_of(Rex::Proto::Http::Client).to receive(:send_recv).and_return(Rex::Proto::Http::Response.new(res_code))
       allow_any_instance_of(Rex::Proto::Http::Response).to receive(:get_cookies).and_return("zbx_sessionid=ZBXSESSIONID_MAGIC_VALUE;")
       http_scanner.send_request(req_opts)
-      expect(http_scanner.zsession).to eq("ZBXSESSIONID_MAGIC_VALUE")
+      expect(http_scanner.zsession).to match(/zbx_session(?:id)?=ZBXSESSIONID_MAGIC_VALUE/)
     end
   end
 


### PR DESCRIPTION
Added documentation for zabbix login

Github issue number is 14195

Please ensure you are submitting **from a unique branch** in your [repository](https://github.com/rapid7/metasploit-framework/pull/11086#issuecomment-445506416) to master in Rapid7's.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] use auxiliary/scanner/http/zabbix_login
- [ ] set RHOSTS
- [ ] run

    - Success: 'Admin:zabbix'

Above was tested using Zabbix Virtual images running in Virtualbox 6.1
Images used were Zabbix Server versions 3, 4 and 5.
_Note that on Zabbix server version 5, the target uri moved and requires an additional variable set in msfconsole
set TARGETURI /_

Testing done using virtual appliances for Zabbix, available at https://www.zabbix.com/download_appliance.
Used appliance versions 3, 4 and 5 (5 is latest release)
Virtuals running within Virtualbox 6.1
Screenshot of test against zabbix 5 running on IP 192.168.0.125
![test-zabbix5](https://user-images.githubusercontent.com/4121754/96807375-5c7b7c80-13e4-11eb-8852-3d29d7a844dd.png)

### Reasons for change
Original plan was to provide markdown documentation for auxiliary/scanner/http/zabbix_login.  A test environment was created to build documentation, but discovered that the auxiliary/scanner/http/zabbix_login module would fail.  All testing is done using default admin credentials for zabbix.  Error message follows:
![zabbix_login_fail](https://user-images.githubusercontent.com/4121754/96938547-a9208f80-1498-11eb-9933-5b4c9b59fbac.png)

Further investigation showed that module is using the regex to confirm the string exists in the html after successful login.  I believe this module was written for a version prior to version 3 ( the oldest version I was able to test with).  The older versions of Zabbix must have contained a slightly different string within the html.  The credentials did successfully log in but this error does not register as success, it also does not populate metasploit backend database with credential information.  
From this testing, decided to modify the library so that the scanner worked as expected on the newer versions of zabbix.
