### PR TITLE
Allow local exploits for RPC compatible_sessions

### DIFF
--- a/lib/msf/core/rpc/v10/rpc_module.rb
+++ b/lib/msf/core/rpc/v10/rpc_module.rb
@@ -348,7 +348,16 @@ class RPC_Module < RPC_Base
   # @example Here's how you would use this from the client:
   #  rpc.call('module.compatible_sessions', 'windows/wlan/wlan_profile')
   def rpc_compatible_sessions(mname)
-    m   = _find_module('post',mname)
+    if mname.start_with? 'exploit/'
+      m = _find_module('exploit',mname)
+    else
+      m = _find_module('post',mname)
+    end
+
+    unless m.respond_to? :compatible_sessions
+      error(500, "Cannot determine compatible sessions for non-local module: #{mname}")
+    end
+
     res = {}
     res['sessions'] = m.compatible_sessions
 


### PR DESCRIPTION
This allows programmatically determining which current sessions are available for which module. Formerly, when passed a local exploit module the RPC method would barf since it was hard-coded to look for `post`-type modules.

Verification
=========
- [x] Start and connect to the RPC interface
- [x] Query the compatible sessions endpoint with a local exploit, like `exploit/windows/local/cve_2020_0796_smbghost`
- [x] Verify an empty result set is sent back instead of an error