### PR TITLE
Update debug command connection name logging

### DIFF
--- a/lib/msf/ui/debug.rb
+++ b/lib/msf/ui/debug.rb
@@ -321,8 +321,6 @@ module Msf
             output = "Connected to #{cdb}. Connection type: #{framework.db.driver}."
           end
 
-          output += " Connection name: #{framework.db.get_data_service}." if framework.db.get_data_service
-
           output
         end
 

--- a/spec/lib/msf/debug_spec.rb
+++ b/spec/lib/msf/debug_spec.rb
@@ -1297,8 +1297,7 @@ RSpec.describe Msf::Ui::Debug do
       'Metasploit::Framework::DataService::DataProxy',
       name: 'db_name',
       driver: 'http',
-      connection_established?: true,
-      get_data_service: 'db_data_service'
+      connection_established?: true
     )
 
     framework = instance_double(
@@ -1320,7 +1319,7 @@ RSpec.describe Msf::Ui::Debug do
       Framework: VERSION
       Ruby: #{RUBY_DESCRIPTION}
       Install Root: bad/path
-      Session Type: Connected to db_name. Connection type: http. Connection name: db_data_service.
+      Session Type: Connected to db_name. Connection type: http.
       Install Method: Other - Please specify
       ```
 
@@ -1336,8 +1335,7 @@ RSpec.describe Msf::Ui::Debug do
     db = double(
       'Metasploit::Framework::DataService::DataProxy',
       connection_established?: true,
-      driver: 'local',
-      get_data_service: 'db_data_service'
+      driver: 'local'
     )
 
     framework = instance_double(
@@ -1368,7 +1366,7 @@ RSpec.describe Msf::Ui::Debug do
       Framework: VERSION
       Ruby: #{RUBY_DESCRIPTION}
       Install Root: bad/path
-      Session Type: Connected to current_db_connection. Connection type: local. Connection name: db_data_service.
+      Session Type: Connected to current_db_connection. Connection type: local.
       Install Method: Other - Please specify
       ```
 


### PR DESCRIPTION
### Before

The debug command has an extra connection name logged which outputs ruby object details unintentionally:

```
Framework: 6.0.14-dev-d3e3291bd1
Ruby: ruby 2.7.2p137 (2020-10-01 revision 5445e04352) [x86_64-darwin19]
Install Root: /Users/user/Documents/code/metasploit-framework
Session Type: Connected to remote_data_service: (https://localhost:5443). Connection type: http. Connection name: #<Metasploit::Framework::DataService::RemoteHTTPDataService:0x00007fe615297bf8>.
Install Method: Git Clone
```

### After

The ruby object details are removed, as the existing message has enough information at present:

```
Framework: 6.0.14-dev-d3e3291bd1
Ruby: ruby 2.7.2p137 (2020-10-01 revision 5445e04352) [x86_64-darwin19]
Install Root: /Users/user/Documents/code/metasploit-framework
Session Type: Connected to remote_data_service: (https://localhost:5443). Connection type: http.
Install Method: Git Clone
```

### Difference

```diff
 Framework: 6.0.14-dev-d3e3291bd1
 Ruby: ruby 2.7.2p137 (2020-10-01 revision 5445e04352) [x86_64-darwin19]
 Install Root: /Users/user/Documents/code/metasploit-framework
- Session Type: Connected to remote_data_service: (https://localhost:5443). Connection type: http. Connection name: #<Metasploit::Framework::DataService::RemoteHTTPDataService:0x00007fe615297bf8>.
+ Session Type: Connected to remote_data_service: (https://localhost:5443). Connection type: http.
 Install Method: Git Clone
```

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ]  **Verify** the debug command is updated
