### PR TITLE
Add service stub encoder validation

### DIFF
--- a/modules/exploits/windows/smb/ms17_010_psexec.rb
+++ b/modules/exploits/windows/smb/ms17_010_psexec.rb
@@ -104,7 +104,19 @@ class MetasploitModule < Msf::Exploit::Remote
     deregister_options('SMB::ProtocolVersion')
   end
 
+  def validate_service_stub_encoder!
+    service_encoder = datastore['SERVICE_STUB_ENCODER']
+    return if service_encoder.nil? || service_encoder.empty?
+
+    encoder = framework.encoders[service_encoder]
+    if encoder.nil?
+      raise Msf::OptionValidateError.new(["SERVICE_STUB_ENCODER - Failed to find encoder #{service_encoder.inspect}"])
+    end
+  end
+
   def exploit
+    validate_service_stub_encoder!
+
     begin
       if datastore['SMBUser'].present?
         print_status("Authenticating to #{datastore['RHOST']} as user '#{splitname(datastore['SMBUser'])}'...")

--- a/modules/exploits/windows/smb/psexec.rb
+++ b/modules/exploits/windows/smb/psexec.rb
@@ -121,7 +121,19 @@ class MetasploitModule < Msf::Exploit::Remote
     native_upload(smbshare, service_filename, service_encoder)
   end
 
+  def validate_service_stub_encoder!
+    service_encoder = datastore['SERVICE_STUB_ENCODER']
+    return if service_encoder.nil? || service_encoder.empty?
+
+    encoder = framework.encoders[service_encoder]
+    if encoder.nil?
+      raise Msf::OptionValidateError.new(["SERVICE_STUB_ENCODER - Failed to find encoder #{service_encoder.inspect}"])
+    end
+  end
+
   def exploit
+    validate_service_stub_encoder!
+
     # automatically select an SMB share unless one is explicitly specified
     if datastore['SHARE'] && !datastore['SHARE'].blank?
       smbshare = datastore['SHARE']


### PR DESCRIPTION
Fixes https://github.com/rapid7/metasploit-framework/issues/13435

Just a quick solution to improve the user experience of the `m17_010_psexec` and `psexec` modules to ensure that `SERVICE_STUB_ENCODER` is validated before running the module.

A long term solution might be adding a new opt for encoder validation, but it seems like there's not many use cases for this in the code base.

### Before

The invalid encoder is quietly ignored

### After

The invalid encoder is validated:

```
msf6 exploit(windows/smb/ms17_010_psexec) > set rhosts 127.0.0.1
rhosts => 127.0.0.1
msf6 exploit(windows/smb/ms17_010_psexec) > set service_stub_encoder missing
service_stub_encoder => missing
msf6 exploit(windows/smb/ms17_010_psexec) > run

[*] Started reverse TCP handler on 192.168.1.223:4444 
[-] 127.0.0.1:445 - Exploit failed: Msf::OptionValidateError The following options failed to validate: SERVICE_STUB_ENCODER - Failed to find encoder "notfound".
[*] Exploit completed, but no session was created.
```

## Verification

List the steps needed to make sure this thing works

- [x] Attempt to run the modules with an invalid service stub encoder
```
use exploit/windows/smb/psexec
set target 2
set rhost 127.0.0.1
set SERVICE_STUB_ENCODER notfound
run
```
- [x] **Verify** the the invalid stub encoder is validated