### PR TITLE
Fix store_loot bug 

### DIFF
--- a/lib/metasploit/framework/data_service/proxy/loot_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/loot_data_proxy.rb
@@ -3,11 +3,8 @@ module LootDataProxy
   def report_loot(opts)
     begin
       self.data_service_operation do |data_service|
-        if !data_service.is_a?(Msf::DBManager)
-          unless opts[:data].nil?
-            opts[:data] = opts[:data].join if opts[:data].kind_of?(Array)
-            opts[:data] = Base64.urlsafe_encode64(opts[:data]) unless opts[:data].empty?
-          end
+        unless data_service.is_a?(Msf::DBManager)
+          opts[:data] = Base64.urlsafe_encode64(opts[:data].to_s) unless opts[:data].nil?
         end
         add_opts_workspace(opts)
         data_service.report_loot(opts)

--- a/lib/msf/core/auxiliary/report.rb
+++ b/lib/msf/core/auxiliary/report.rb
@@ -430,7 +430,7 @@ module Auxiliary::Report
       conf[:workspace] = myworkspace
       conf[:name] = filename if filename
       conf[:info] = info if info
-      conf[:data] = data if data
+      conf[:data] = data unless data.nil?
 
       if service and service.kind_of?(::Mdm::Service)
         conf[:service] = service if service


### PR DESCRIPTION
This pull request ensures that any datatypes can now be persisted as loot, and additionally fixes an edge-case were arrays weren't being stored in the remote database service in the same way that they were being stored to local loot files.

A bug that was originally introduced through https://github.com/rapid7/metasploit-framework/pull/12931, there have been subsequent PR's since then to fix a regression introduced at this point. 

These PR's being:
- https://github.com/rapid7/metasploit-framework/pull/14145
- https://github.com/rapid7/metasploit-framework/pull/14223

This pull request will replace the need for #14223

This should be how the loot should be stored in the database. I believe `msfconsole` doesn't have a way to display the loot that's stored in the database, but it's directly accessible via `irb`. This can be verified by querying the database from the `irb` console:

```
msf6 post(windows/gather/credentials/securecrt) > irb
[*] Starting IRB shell...
[*] You are in post/windows/gather/credentials/securecrt

>> store_loot("password", "text/plain", "127.0.0.1", [1,2,3])
=> "/home/gwillcox/.msf4/loot/20201102113117_default_127.0.0.1_password_733008.txt"
>> pp Mdm::Loot.last.data
"[1, 2, 3]"
=> "[1, 2, 3]"
>> 
```


## Verification
- [x] Start the MSF database with `./msfdb start`
- [x] Start `msfconsole`
- [x] Gain a Meterpreter shell on a Windows target with SecureCRT installed and which has several sessions, some of which have blank username and password fields.
- [ ] Ensure that `post/windows/gather/credentials/securecrt.rb` runs without generating a stack trace.
- [x] Report any errors encountered.
- [x] Gain a Meterpreter shell on a Windows target with XShell XFTP installed and which is configured to save XShell sessions with username and password info included.
- [x] Ensure that `post/windows/gather/credentials/xshell_xftp_password.rb` runs without generating a stack trace.
- [x] Report any errors encountered.