### PR TITLE
Fix smb version error handling

### DIFF
--- a/modules/auxiliary/scanner/smb/smb_version.rb
+++ b/modules/auxiliary/scanner/smb/smb_version.rb
@@ -113,7 +113,7 @@ class MetasploitModule < Msf::Auxiliary
         unless info.key? :auth_domain
           begin
             simple.client.authenticate
-          rescue RubySMB::RubySMBError
+          rescue RubySMB::Error::RubySMBError
             info[:auth_domain] = nil
           else
             info[:auth_domain] = simple.client.default_domain


### PR DESCRIPTION
### Before

Running smb_version against a valid smb target doesn't complete successfully, and outputs an uninitialized constant error:

```
msf6 auxiliary(scanner/smb/smb_version) > run

[-] x.x.x.x:445       - x.x.x.x: NameError uninitialized constant RubySMB::RubySMBError
[*] x.x.x.x:139       - SMB Detected (versions:) (preferred dialect:) (signatures:optional)
[*] x.x.x.x: - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

### After

The target is correctly versioned:

```
msf6 auxiliary(scanner/smb/smb_version) > run

[*] x.x.x.x:445       - SMB Detected (versions:1, 2) (preferred dialect:SMB 2.0.2) (signatures:optional) (uptime:95w 2d 20h 56m 37s) (guid:{69f9e0fe-a610-4529-8f5f-9d8d953f1576})
[+] x.x.x.x:445       -   Host is running Windows 2008 Enterprise SP1 (build:6001) (name:xyz) (workgroup:WORKGROUP)
[*] x.x.x.x: - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

Verified statically within irb:

```
>> RubySMB::RubySMBError
Traceback (most recent call last):
       16: from /Users/adfoster/.rvm/gems/ruby-2.6.6@metasploit-framework/gems/bundler-2.1.4/lib/bundler/cli/exec.rb:28:in `run'
       15: from /Users/adfoster/.rvm/gems/ruby-2.6.6@metasploit-framework/gems/bundler-2.1.4/lib/bundler/cli/exec.rb:63:in `kernel_load'
       14: from /Users/adfoster/.rvm/gems/ruby-2.6.6@metasploit-framework/gems/bundler-2.1.4/lib/bundler/cli/exec.rb:63:in `load'
       13: from /Users/adfoster/Documents/code/metasploit-framework/msfconsole:23:in `<top (required)>'
       12: from /Users/adfoster/Documents/code/metasploit-framework/lib/metasploit/framework/command/base.rb:82:in `start'
       11: from /Users/adfoster/Documents/code/metasploit-framework/lib/metasploit/framework/command/console.rb:48:in `start'
       10: from /Users/adfoster/Documents/code/metasploit-framework/lib/rex/ui/text/shell.rb:158:in `run'
        9: from /Users/adfoster/Documents/code/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:470:in `run_single'
        8: from /Users/adfoster/Documents/code/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:470:in `each'
        7: from /Users/adfoster/Documents/code/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:476:in `block in run_single'
        6: from /Users/adfoster/Documents/code/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:525:in `run_command'
        5: from /Users/adfoster/Documents/code/metasploit-framework/lib/msf/ui/console/command_dispatcher/developer.rb:115:in `cmd_irb'
        4: from /Users/adfoster/Documents/code/metasploit-framework/lib/rex/ui/text/irb_shell.rb:52:in `run'
        3: from /Users/adfoster/Documents/code/metasploit-framework/lib/rex/ui/text/irb_shell.rb:52:in `catch'
        2: from /Users/adfoster/Documents/code/metasploit-framework/lib/rex/ui/text/irb_shell.rb:53:in `block in run'
        1: from (irb):1
NameError (uninitialized constant RubySMB::RubySMBError)
```

A quick look at the codebase showed that this might be the right constant:
```
>> RubySMB::Error::RubySMBError
=> RubySMB::Error::RubySMBError
```