### PR TITLE
Fix merge mistake with PR 14222

### DIFF
--- a/modules/exploits/multi/http/php_fpm_rce.rb
+++ b/modules/exploits/multi/http/php_fpm_rce.rb
@@ -126,8 +126,8 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def send_crafted_request(path:, qsl: datastore['MinQSL'], customh_length: 1, cmd: '', allow_retry: true)
-    uri = CGI.escape(normalize_uri(target_uri.path, path)).gsub(/([?&])/, {'?'=>'%3F', '&'=>'%26'})
-    qsl_delta = uri.length - path.length - CGI.escape(target_uri.path).length
+    uri = Rex::Text.uri_encode(normalize_uri(target_uri.path, path)).gsub(/([?&])/, {'?'=>'%3F', '&'=>'%26'})
+    qsl_delta = uri.length - path.length - Rex::Text.uri_encode(target_uri.path).length
     if qsl_delta.odd?
       fail_with Failure::Unknown, "Got odd qslDelta, that means the URL encoding gone wrong: path=#{path}, qsl_delta=#{qsl_delta}"
     end


### PR DESCRIPTION
You can safely ignore most of this PR but if you must know I made a mistake merging #14222 and forgot to change `CGI.escape()` to `Rex::Text.uri_encode()` before merging it in, as `CGI.escape()` was causing the module to fail. This fixes that issue. 