### PR TITLE
Improve msfdb UX

### DIFF
--- a/msfdb
+++ b/msfdb
@@ -187,7 +187,8 @@ end
 
 def start_db
   if !Dir.exist?(@db)
-    puts "No database found at #{@db}, not starting"
+    print_error "No database found at #{@db}."
+    print_error "Has the database been initialized with \"msfdb init\" or \"msfdb init --component database\"?"
     return
   end
 
@@ -517,6 +518,14 @@ def start_web_service(expect_auth: true)
 
   # daemonize MSF web service
   print 'Attempting to start MSF web service...'
+
+  unless File.file?(@ws_ssl_key_default)
+    puts "#{'failed'.red.bold}"
+    print_error "The SSL Key needed for the webservice to connect to the database could not be found at #{@ws_ssl_key_default}."
+    print_error 'Has the webservice been initialized with "msfdb init"  or "msfdb init --component webservice"?'
+    return false
+  end
+
   if run_cmd("#{thin_cmd} start") == 0
     # wait until web service is online
     retry_count = 0
@@ -533,18 +542,19 @@ def start_web_service(expect_auth: true)
     end
 
       if response_data[:state] == :online
-      puts "#{'success'.green.bold}"
-      puts 'MSF web service started and online'
-      return true
+        puts "#{'success'.green.bold}"
+        puts 'MSF web service started and online'
+        return true
       elsif response_data[:state] == :error
-      puts "#{'failed'.red.bold}"
-      print_error 'MSF web service appears to be started, but may not operate as expected.'
-      puts "#{response_data[:message]}"
-      else
-      puts "#{'failed'.red.bold}"
-      print_error 'MSF web service does not appear to be started.'
-    end
-    puts "Please see #{@ws_log} for additional details."
+        puts "#{'failed'.red.bold}"
+        print_error 'MSF web service failed and returned the following message:'
+        puts "#{response_data[:message].nil? || response_data[:message].empty? ? "No message returned." : response_data[:message]}"
+      elsif response_data[:state] == :offline
+        puts "#{'failed'.red.bold}"
+        print_error 'A connection with the web service was refused.'
+      end
+
+    puts "Please see #{@ws_log} for additional webservice details."
     return false
   else
     puts "#{'failed'.red.bold}"
@@ -1082,9 +1092,14 @@ if $PROGRAM_NAME == __FILE__
   prompt_for_deletion(command)
   if @options[:component] == :all
     @components.each { |component|
+      puts '===================================================================='
+      puts "Running the '#{command}' command for the #{component}:"
       invoke_command(commands, component.to_sym, command)
+      puts '===================================================================='
+      puts
     }
   else
+    puts "Running the '#{command}' command for the #{@options[:component].to_s}:"
     invoke_command(commands, @options[:component], command)
   end
 end


### PR DESCRIPTION
If you run `msfdb delete` followed by `msfdb start`, you get this message on the command line:

```
15:02 $ bundle exec msfdb start
No database found at /Users/agalway/.msf4/db, not starting
Attempting to start MSF web service...failed
[!] MSF web service appears to be started, but may not operate as expected.

Please see /Users/agalway/.msf4/logs/msf-ws.log for additional details.
```

The above output is misleading, as the `[!]` draws your eye away from the important "No DB found" line. Also, it says that the web service has failed to start, and then on the next line it says it "appears to be started". This is due to bad logging, and both components running the `start` command without any clear separation between the webservice logs and the database logs, making them blur together.

This PR makes the following changes:

- Improves readability for the messages produced by `msfdb start` when either the webservice or the database haven't been created with `msfdb init`
- Makes it clear to users that when `msfdb <command>` is run,` <command>` is sent to all components attached to `msfdb` (currently the webservice & the database).
  - These changes also separate the `stdout` of both components, improving readability

## Verification
- [x] `msfdb delete`
- [x] `msfdb start`
- [x] Output will look like this:
![image](https://user-images.githubusercontent.com/54621924/98266389-28768e80-1f82-11eb-8f82-6bb96ea87100.png)

- [x] Running any other command with `msfdb` will separate the outputs for the database and the webservice into separate components Eg:
![image](https://user-images.githubusercontent.com/54621924/98266510-522fb580-1f82-11eb-9606-ed81f0d143b5.png)