### PR TITLE
Preference target values when registering options

### DIFF
--- a/lib/msf/core/module/data_store.rb
+++ b/lib/msf/core/module/data_store.rb
@@ -23,13 +23,16 @@ module Msf::Module::DataStore
     if (module_info['DefaultOptions'])
       self.datastore.import_options_from_hash(module_info['DefaultOptions'], true, 'self')
     end
+
+    # Preference the defaults for the currently set target
+    import_target_defaults
   end
 
   #
   # Import the target's DefaultOptions hash into the datastore.
   #
   def import_target_defaults
-    return unless target && target.default_options
+    return unless defined?(targets) && targets && target && target.default_options
 
     datastore.import_options_from_hash(target.default_options, true, 'self')
   end

--- a/lib/msf/core/module/options.rb
+++ b/lib/msf/core/module/options.rb
@@ -45,7 +45,6 @@ module Msf::Module::Options
   #
   def register_advanced_options(options, owner = self.class)
     self.options.add_advanced_options(options, owner)
-    self.datastore.import_options(self.options, 'self', true)
     import_defaults(false)
   end
 
@@ -54,7 +53,6 @@ module Msf::Module::Options
   #
   def register_evasion_options(options, owner = self.class)
     self.options.add_evasion_options(options, owner)
-    self.datastore.import_options(self.options, 'self', true)
     import_defaults(false)
   end
 
@@ -63,7 +61,6 @@ module Msf::Module::Options
   #
   def register_options(options, owner = self.class)
     self.options.add_options(options, owner)
-    self.datastore.import_options(self.options, 'self', true)
     import_defaults(false)
   end
 end

--- a/modules/exploits/linux/http/apache_ofbiz_deserialiation.rb
+++ b/modules/exploits/linux/http/apache_ofbiz_deserialiation.rb
@@ -77,9 +77,6 @@ class MetasploitModule < Msf::Exploit::Remote
       Opt::RPORT(8443),
       OptString.new('TARGETURI', [true, 'Base path', '/'])
     ])
-
-    # XXX: https://github.com/rapid7/metasploit-framework/issues/12963
-    import_target_defaults
   end
 
   def check

--- a/modules/exploits/linux/http/cisco_ucs_cloupia_script_rce.rb
+++ b/modules/exploits/linux/http/cisco_ucs_cloupia_script_rce.rb
@@ -97,9 +97,6 @@ class MetasploitModule < Msf::Exploit::Remote
         ]
       )
     ])
-
-    # XXX: https://github.com/rapid7/metasploit-framework/issues/12963
-    import_target_defaults
   end
 
   def check

--- a/modules/exploits/linux/http/f5_bigip_tmui_rce.rb
+++ b/modules/exploits/linux/http/f5_bigip_tmui_rce.rb
@@ -88,9 +88,6 @@ class MetasploitModule < Msf::Exploit::Remote
     register_advanced_options([
       OptString.new('WritableDir', [true, 'Writable directory', '/tmp'])
     ])
-
-    # XXX: https://github.com/rapid7/metasploit-framework/issues/12963
-    import_target_defaults
   end
 
   def check

--- a/modules/exploits/linux/http/nagios_xi_authenticated_rce.rb
+++ b/modules/exploits/linux/http/nagios_xi_authenticated_rce.rb
@@ -86,7 +86,6 @@ class MetasploitModule < Msf::Exploit::Remote
     register_advanced_options [
       OptBool.new('ForceExploit',  [false, 'Override check result', false])
     ]
-    import_target_defaults
   end
 
   def check

--- a/modules/exploits/linux/misc/saltstack_salt_unauth_rce.rb
+++ b/modules/exploits/linux/misc/saltstack_salt_unauth_rce.rb
@@ -106,9 +106,6 @@ class MetasploitModule < Msf::Exploit::Remote
     register_advanced_options([
       OptInt.new('WfsDelay', [true, 'Seconds to wait for *all* sessions', 10])
     ])
-
-    # XXX: https://github.com/rapid7/metasploit-framework/issues/12963
-    import_target_defaults
   end
 
   # NOTE: check is provided by auxiliary/gather/saltstack_salt_root_key

--- a/modules/exploits/linux/smtp/apache_james_exec.rb
+++ b/modules/exploits/linux/smtp/apache_james_exec.rb
@@ -72,7 +72,6 @@ class MetasploitModule < Msf::Exploit::Remote
           OptString.new('POP3PORT', [false, 'Port for POP3 Apache James Service', '110' ]),
           Opt::RPORT(25)
         ])
-    import_target_defaults
   end
 
   def check

--- a/modules/exploits/unix/webapp/thinkphp_rce.rb
+++ b/modules/exploits/unix/webapp/thinkphp_rce.rb
@@ -82,9 +82,6 @@ class MetasploitModule < Msf::Exploit::Remote
       OptFloat.new('CmdOutputTimeout',
                    [true, 'Timeout for cmd/unix/generic output', 3.5])
     ])
-
-    # XXX: https://github.com/rapid7/metasploit-framework/issues/12963
-    import_target_defaults
   end
 
   # PoC version check using the first <span> from the ThinkPHP copyright:

--- a/modules/exploits/windows/http/plesk_mylittleadmin_viewstate.rb
+++ b/modules/exploits/windows/http/plesk_mylittleadmin_viewstate.rb
@@ -109,9 +109,6 @@ class MetasploitModule < Msf::Exploit::Remote
       Opt::RPORT(8401, true, 'The myLittleAdmin port (default for Plesk!)'),
       OptString.new('TARGETURI', [true, 'Base path', '/'])
     ])
-
-    # XXX: https://github.com/rapid7/metasploit-framework/issues/12963
-    import_target_defaults
   end
 
   def check


### PR DESCRIPTION
Fixes https://github.com/rapid7/metasploit-framework/issues/12963

## Verification

List the steps needed to make sure this thing works

- [x] Run through the original issue's steps and ensure that `DisablePayloadHandler` is now set to true
- [x] Verify some the other modules have the same options / advanced options
- [x] Verify that there's no other impacted code paths, I'm thinking that `share_datastore` _could_ be impacted - but will need to confirm.