### PR TITLE
Use the constants for the object comparison of NTStatus codes

### DIFF
--- a/lib/metasploit/framework/login_scanner/smb.rb
+++ b/lib/metasploit/framework/login_scanner/smb.rb
@@ -37,15 +37,15 @@ module Metasploit
 
         module StatusCodes
           CORRECT_CREDENTIAL_STATUS_CODES = [
-            "STATUS_ACCOUNT_DISABLED",
-            "STATUS_ACCOUNT_EXPIRED",
-            "STATUS_ACCOUNT_RESTRICTION",
-            "STATUS_INVALID_LOGON_HOURS",
-            "STATUS_INVALID_WORKSTATION",
-            "STATUS_LOGON_TYPE_NOT_GRANTED",
-            "STATUS_PASSWORD_EXPIRED",
-            "STATUS_PASSWORD_MUST_CHANGE",
-          ].freeze.map(&:freeze)
+            WindowsError::NTStatus::STATUS_ACCOUNT_DISABLED,
+            WindowsError::NTStatus::STATUS_ACCOUNT_EXPIRED,
+            WindowsError::NTStatus::STATUS_ACCOUNT_RESTRICTION,
+            WindowsError::NTStatus::STATUS_INVALID_LOGON_HOURS,
+            WindowsError::NTStatus::STATUS_INVALID_WORKSTATION,
+            WindowsError::NTStatus::STATUS_LOGON_TYPE_NOT_GRANTED,
+            WindowsError::NTStatus::STATUS_PASSWORD_EXPIRED,
+            WindowsError::NTStatus::STATUS_PASSWORD_MUST_CHANGE,
+          ].freeze
         end
 
         # @!attribute dispatcher
@@ -116,12 +116,12 @@ module Metasploit
               end
             end
 
-            case status_code.name
-              when 'STATUS_SUCCESS', 'STATUS_PASSWORD_MUST_CHANGE', 'STATUS_PASSWORD_EXPIRED'
+            case status_code
+              when WindowsError::NTStatus::STATUS_SUCCESS, WindowsError::NTStatus::STATUS_PASSWORD_MUST_CHANGE, WindowsError::NTStatus::STATUS_PASSWORD_EXPIRED
                 status = Metasploit::Model::Login::Status::SUCCESSFUL
-              when 'STATUS_ACCOUNT_LOCKED_OUT'
+              when WindowsError::NTStatus::STATUS_ACCOUNT_LOCKED_OUT
                 status = Metasploit::Model::Login::Status::LOCKED_OUT
-              when 'STATUS_LOGON_FAILURE', 'STATUS_ACCESS_DENIED'
+              when WindowsError::NTStatus::STATUS_LOGON_FAILURE, WindowsError::NTStatus::STATUS_ACCESS_DENIED
                 status = Metasploit::Model::Login::Status::INCORRECT
               when *StatusCodes::CORRECT_CREDENTIAL_STATUS_CODES
                 status = Metasploit::Model::Login::Status::DENIED_ACCESS


### PR DESCRIPTION
This fixes #14354. There's apparently a difference in the order of constants defined in ruby when `bundle exec` is used vs when it's not. This case was causing the `auxiliary/scanner/smb/smb_login` module to fail because RubySMB was returning status code 0 with a name of `STATUS_WAIT_0`. This name however was not handled as a successful login case as it should be within Metasploit's logon scanner.

One solution could have been to simply add the string "STATUS_WAIT_0" to the list of successful results. I instead opted to leverage the 
 custom object comparison implemented by the [`ErrorCode`](https://github.com/rapid7/windows_error/blob/master/lib/windows_error/error_code.rb#L37) object.


## Verification

List the steps needed to make sure this thing works

- [ ] Start using `bundle exec ./msfconsole`
- [ ] Use the `auxiliary/scanner/smb/smb_login` module
- [ ] Set the options as appropriate
- [ ] Run the module and see a positive test case

*To validate the original issue, simply follow the same steps without this patch.*

## Example Output
<details>
<summary>Before the patch</summary>

```
bundle exec ./msfconsole 
                                                  
%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
%%     %%%         %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
%%  %%  %%%%%%%%   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
%%  %  %%%%%%%%   %%%%%%%%%%% https://metasploit.com %%%%%%%%%%%%%%%%%%%%%%%%
%%  %%  %%%%%%   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
%%  %%%%%%%%%   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
%%%%%  %%%  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
%%%%    %%   %%%%%%%%%%%  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%  %%%  %%%%%
%%%%  %%  %%  %      %%      %%    %%%%%      %    %%%%  %%   %%%%%%       %%
%%%%  %%  %%  %  %%% %%%%  %%%%  %%  %%%%  %%%%  %% %%  %% %%% %%  %%%  %%%%%
%%%%  %%%%%%  %%   %%%%%%   %%%%  %%%  %%%%  %%    %%  %%% %%% %%   %%  %%%%%
%%%%%%%%%%%% %%%%     %%%%%    %%  %%   %    %%  %%%%  %%%%   %%%   %%%     %
%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%  %%%%%%% %%%%%%%%%%%%%%
%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%          %%%%%%%%%%%%%%
%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


       =[ metasploit v6.0.16-dev-598475b147               ]
+ -- --=[ 2072 exploits - 1124 auxiliary - 352 post       ]
+ -- --=[ 596 payloads - 45 encoders - 10 nops            ]
+ -- --=[ 7 evasion                                       ]

Metasploit tip: Enable verbose logging with set VERBOSE true

[*] Processing /home/smcintyre/.msf4/msfconsole.rc for ERB directives.
resource (/home/smcintyre/.msf4/msfconsole.rc)> setg SESSION -1
SESSION => -1
resource (/home/smcintyre/.msf4/msfconsole.rc)> load request
[*] Successfully loaded plugin: Request
resource (/home/smcintyre/.msf4/msfconsole.rc)> loadpath test/modules
Loaded 35 modules:
    13 auxiliary modules
    9 post modules
    13 exploit modules
msf6 auxiliary(scanner/smb/smb_login) > show options 

Module options (auxiliary/scanner/smb/smb_login):

   Name               Current Setting  Required  Description
   ----               ---------------  --------  -----------
   ABORT_ON_LOCKOUT   false            yes       Abort the run when an account lockout is detected
   BLANK_PASSWORDS    false            no        Try blank passwords for all users
   BRUTEFORCE_SPEED   5                yes       How fast to bruteforce, from 0 to 5
   DB_ALL_CREDS       false            no        Try each user/password couple stored in the current database
   DB_ALL_PASS        false            no        Add all passwords in the current database to the list
   DB_ALL_USERS       false            no        Add all users in the current database to the list
   DETECT_ANY_AUTH    false            no        Enable detection of systems accepting any authentication
   DETECT_ANY_DOMAIN  false            no        Detect if domain is required for the specified user
   PASS_FILE                           no        File containing passwords, one per line
   PRESERVE_DOMAINS   true             no        Respect a username that contains a domain name.
   Proxies                             no        A proxy chain of format type:host:port[,type:host:port][...]
   RECORD_GUEST       false            no        Record guest-privileged random logins to the database
   RHOSTS             192.168.159.129  yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
   RPORT              445              yes       The SMB service port (TCP)
   SMBDomain          .                no        The Windows domain to use for authentication
   SMBPass            Password1        no        The password for the specified username
   SMBUser            smcintyre        no        The username to authenticate as
   STOP_ON_SUCCESS    false            yes       Stop guessing when a credential works for a host
   THREADS            1                yes       The number of concurrent threads (max one per host)
   USERPASS_FILE                       no        File containing users and passwords separated by space, one pair per line
   USER_AS_PASS       false            no        Try the username as the password for all users
   USER_FILE                           no        File containing usernames, one per line
   VERBOSE            true             yes       Whether to print output for all attempts

msf6 auxiliary(scanner/smb/smb_login) > run

[*] 192.168.159.129:445   - 192.168.159.129:445 - Starting SMB login bruteforce
[-] 192.168.159.129:445   - 192.168.159.129:445 - Failed: '.\smcintyre:Password1',
[*] 192.168.159.129:445   - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf6 auxiliary(scanner/smb/smb_login) > 
```
</details>

<details>
<summary>After the patch</summary>

```
bundle exec ./msfconsole    
                                                  
 _                                                    _
/ \    /\         __                         _   __  /_/ __
| |\  / | _____   \ \           ___   _____ | | /  \ _   \ \
| | \/| | | ___\ |- -|   /\    / __\ | -__/ | || | || | |- -|
|_|   | | | _|__  | |_  / -\ __\ \   | |    | | \__/| |  | |_
      |/  |____/  \___\/ /\ \\___/   \/     \__|    |_\  \___\


       =[ metasploit v6.0.16-dev-06b16106b4               ]
+ -- --=[ 2072 exploits - 1124 auxiliary - 352 post       ]
+ -- --=[ 596 payloads - 45 encoders - 10 nops            ]
+ -- --=[ 7 evasion                                       ]

Metasploit tip: View all productivity tips with the tips command

[*] Processing /home/smcintyre/.msf4/msfconsole.rc for ERB directives.
resource (/home/smcintyre/.msf4/msfconsole.rc)> setg SESSION -1
SESSION => -1
resource (/home/smcintyre/.msf4/msfconsole.rc)> load request
[*] Successfully loaded plugin: Request
resource (/home/smcintyre/.msf4/msfconsole.rc)> loadpath test/modules
Loaded 35 modules:
    13 auxiliary modules
    9 post modules
    13 exploit modules
msf6 auxiliary(scanner/smb/smb_login) > show options 

Module options (auxiliary/scanner/smb/smb_login):

   Name               Current Setting  Required  Description
   ----               ---------------  --------  -----------
   ABORT_ON_LOCKOUT   false            yes       Abort the run when an account lockout is detected
   BLANK_PASSWORDS    false            no        Try blank passwords for all users
   BRUTEFORCE_SPEED   5                yes       How fast to bruteforce, from 0 to 5
   DB_ALL_CREDS       false            no        Try each user/password couple stored in the current database
   DB_ALL_PASS        false            no        Add all passwords in the current database to the list
   DB_ALL_USERS       false            no        Add all users in the current database to the list
   DETECT_ANY_AUTH    false            no        Enable detection of systems accepting any authentication
   DETECT_ANY_DOMAIN  false            no        Detect if domain is required for the specified user
   PASS_FILE                           no        File containing passwords, one per line
   PRESERVE_DOMAINS   true             no        Respect a username that contains a domain name.
   Proxies                             no        A proxy chain of format type:host:port[,type:host:port][...]
   RECORD_GUEST       false            no        Record guest-privileged random logins to the database
   RHOSTS             192.168.159.129  yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
   RPORT              445              yes       The SMB service port (TCP)
   SMBDomain          .                no        The Windows domain to use for authentication
   SMBPass            Password1        no        The password for the specified username
   SMBUser            smcintyre        no        The username to authenticate as
   STOP_ON_SUCCESS    false            yes       Stop guessing when a credential works for a host
   THREADS            1                yes       The number of concurrent threads (max one per host)
   USERPASS_FILE                       no        File containing users and passwords separated by space, one pair per line
   USER_AS_PASS       false            no        Try the username as the password for all users
   USER_FILE                           no        File containing usernames, one per line
   VERBOSE            true             yes       Whether to print output for all attempts

msf6 auxiliary(scanner/smb/smb_login) > run

[*] 192.168.159.129:445   - 192.168.159.129:445 - Starting SMB login bruteforce
[+] 192.168.159.129:445   - 192.168.159.129:445 - Success: '.\smcintyre:Password1' Administrator
[*] 192.168.159.129:445   - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf6 auxiliary(scanner/smb/smb_login) > 
```
</details>

You can also demonstrate the issue by using `irb` to check the difference of `WindowsError::NTStatus.find_by_retval(0)`. The array will be in a different order depending on how msfconsole was run (either with or without `bundle exec`). This was causing an issue due to RubySMB using the first array member as the status: `WindowsError::NTStatus.find_by_retval(value).first`.
