### PR TITLE
Fixes the generate commands tab completion crash, caused when no result are returned.

### DIFF
--- a/lib/rex/ui/text/dispatcher_shell.rb
+++ b/lib/rex/ui/text/dispatcher_shell.rb
@@ -312,7 +312,7 @@ module DispatcherShell
       elsif arg.kind_of?(Array)
         tabs = arg.map {|a| a.to_s}
       end
-      tabs
+      tabs.nil? ? [] : tabs
     end
 
     #

--- a/lib/rex/ui/text/dispatcher_shell.rb
+++ b/lib/rex/ui/text/dispatcher_shell.rb
@@ -268,7 +268,7 @@ module DispatcherShell
         dir += File::SEPARATOR if dir[-1,1] != File::SEPARATOR
         matches = ::Readline::FILENAME_COMPLETION_PROC.call(dir)
       end
-      matches
+      matches.nil? ? [] : matches
     end
 
     #
@@ -312,7 +312,7 @@ module DispatcherShell
       elsif arg.kind_of?(Array)
         tabs = arg.map {|a| a.to_s}
       end
-      tabs.nil? ? [] : tabs
+      tabs
     end
 
     #


### PR DESCRIPTION
This PR Resolves #14358.

The crash was previously caused when the user tried tab completing with the generate command when no results would be returned, this resulted in a crash and would kill the msfconsole.  

An example command that would have caused the crash:
```
generate -f rawTrac<tab>
```
Example of crash:
![fix_generate_command_pr](https://user-images.githubusercontent.com/69522014/98542065-409f2400-2288-11eb-8bcb-3a31aec63632.gif)




This fix will now catch any commands that would have returned no results previously, to now return a blank array. 

![fix_generate_command_fix_pr](https://user-images.githubusercontent.com/69522014/98542284-91168180-2288-11eb-86ed-8ef257016a8f.gif)


## Verification

Testing steps:

- [ ] Start `msfconsole`
- [ ] `use payload/python/meterpreter/reverse_tcp`
- [ ] Try a command that would have previously returned no results
- [ ] E.g. `generate -f rawTrac<tab>`
- [ ] **Verify** that these commands no longer kill `msfconsole`
