### PR TITLE
add version details to drupal_views_user_enum.rb 

### DIFF
--- a/modules/auxiliary/scanner/http/drupal_views_user_enum.rb
+++ b/modules/auxiliary/scanner/http/drupal_views_user_enum.rb
@@ -14,7 +14,9 @@ class MetasploitModule < Msf::Auxiliary
       'Name'           => 'Drupal Views Module Users Enumeration',
       'Description'    => %q{
         This module exploits an information disclosure vulnerability in the 'Views'
-        module of Drupal, brute-forcing the first 10 usernames from 'a' to 'z'
+        module of Drupal, brute-forcing the first 10 usernames from 'a' to 'z'.
+        Drupal 6 with 'Views' module <= 6.x-2.11 are vulnerable.  Drupal does not
+        consider disclosure of usernames as a weakness.
       },
       'Author'         =>
         [
@@ -26,6 +28,7 @@ class MetasploitModule < Msf::Auxiliary
       'References'     =>
         [
           ['URL', 'http://www.madirish.net/node/465'],
+          ['URL', 'https://www.drupal.org/node/1004778'],
         ],
       'DisclosureDate' => '2010-07-02'
     ))


### PR DESCRIPTION
`drupal_views_user_enum.rb` contains no information on what version is vulnerable in the description.  While it is 10yrs old, it would be nice to have this information since it was in madirish's original writeup.  Added that and a reference that shows drupal doesn't consider username enumeration a vulnerability (and thus no CVE).

To test this commit, load the module, check `info` to see the new link and description are included.