### PR TITLE
remove cwe-74 from cmsms_object_injection_rce, and cwe-20 from chkrootkit

### DIFF
--- a/modules/exploits/multi/http/cmsms_object_injection_rce.rb
+++ b/modules/exploits/multi/http/cmsms_object_injection_rce.rb
@@ -28,7 +28,6 @@ class MetasploitModule < Msf::Exploit::Remote
       'License' => MSF_LICENSE,
       'References' => [
         ['CVE', '2019-9055'],
-        ['CWE', '74'],
         ['URL', 'https://newsletter.cmsmadesimple.org/w/89247Qog4jCRCuRinvhsofwg'],
         ['URL', 'https://www.cmsmadesimple.org/2019/03/Announcing-CMS-Made-Simple-v2.2.10-Spuzzum']
       ],

--- a/modules/exploits/unix/local/chkrootkit.rb
+++ b/modules/exploits/unix/local/chkrootkit.rb
@@ -31,7 +31,6 @@ class MetasploitModule < Msf::Exploit::Local
         ['OSVDB', '107710'],
         ['EDB', '33899'],
         ['BID', '67813'],
-        ['CWE', '20'],
         ['URL', 'https://seclists.org/oss-sec/2014/q2/430']
       ],
       'DisclosureDate' => '2014-06-04',


### PR DESCRIPTION
CWEs tend to be generic issues.  [CWE-74](https://cwe.mitre.org/data/definitions/74.html) is Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection'), and [CWE-20](https://cwe.mitre.org/data/definitions/20.html) is Improper Input Validation.

Nessus marks [Web Application Cookies Not Marked HttpOnly](https://www.tenable.com/plugins/nessus/85601) as having CWE-74 and CWE-20.  When a finding with this is imported into Pro, `modules/exploits/multi/http/cmsms_object_injection_rce.rb` and `modules/exploits/unix/local/chkrootkit.rb` are incorrectly marked as applicable modules.  I think Nessus saying that plugin should have those references is a bit of a stretch, however, I think it's too generic a reference to include, and thus to avoid false positives, removing it form the modules will help.

Steps to reproduce:
1. Scan an HTTP website that uses cookies with Nessus.
1. Import it to msf (I used pro)
1. See CMS Made Simple Authenticated RCE via object injection and chkrootkit listed as a applicable modules even though they are far from the truth.