### PR TITLE
Add stdout logging functionality to json rpc

### DIFF
--- a/lib/msf/base/logging.rb
+++ b/lib/msf/base/logging.rb
@@ -16,12 +16,13 @@ class Logging
 
   # Initialize logging.
   #
+  # @param log_sink [Rex::Logging::LogSink] Log sink.
   # @return [void]
-  def self.init
+  def self.init(log_sink = nil)
     if (! @@initialized)
       @@initialized = true
 
-      f = Rex::Logging::Sinks::Flatfile.new(
+      log_sink ||= Rex::Logging::Sinks::Flatfile.new(
         Msf::Config.log_directory + File::SEPARATOR + "framework.log")
 
       # Register each known log source
@@ -30,7 +31,7 @@ class Logging
         Msf::LogSource,
         'base',
       ].each { |src|
-        register_log_source(src, f)
+        register_log_source(src, log_sink)
       }
     end
   end
@@ -80,7 +81,7 @@ class Logging
   # @return [void]
   def self.start_session_log(session)
     if (log_source_registered?(session.log_source) == false)
-      f = Rex::Logging::Sinks::TimestampFlatfile.new(
+      f = Rex::Logging::Sinks::FlatfileWithoutColors.new(
       Msf::Config.session_log_directory + File::SEPARATOR + "#{session.log_file_name}.log")
 
       register_log_source(session.log_source, f)

--- a/lib/rex/logging/log_sink.rb
+++ b/lib/rex/logging/log_sink.rb
@@ -38,6 +38,8 @@ end
 end
 end
 
+require 'rex/logging/sinks/stream'
 require 'rex/logging/sinks/flatfile'
+require 'rex/logging/sinks/flatfile_without_colors'
 require 'rex/logging/sinks/stderr'
-require 'rex/logging/sinks/timestamp_flatfile'
+require 'rex/logging/sinks/stdout'

--- a/lib/rex/logging/sinks/flatfile.rb
+++ b/lib/rex/logging/sinks/flatfile.rb
@@ -9,47 +9,15 @@ module Sinks
 # file on disk.
 #
 ###
-class Flatfile
-
-  include Rex::Logging::LogSink
+class Flatfile < Rex::Logging::Sinks::Stream
 
   #
   # Creates a flatfile log sink instance that will be configured to log to
   # the supplied file path.
   #
   def initialize(file)
-    self.fd = File.new(file, "a")
+    super(File.new(file, 'a'))
   end
-
-  def cleanup # :nodoc:
-    fd.close
-  end
-
-  def log(sev, src, level, msg) # :nodoc:
-    if (sev == LOG_RAW)
-      fd.write(msg)
-    else
-      code = 'i'
-
-      case sev
-        when LOG_DEBUG
-          code = 'd'
-        when LOG_ERROR
-          code = 'e'
-        when LOG_INFO
-          code = 'i'
-        when LOG_WARN
-          code = 'w'
-      end
-      fd.write("[#{get_current_timestamp}] [#{code}(#{level})] #{src}: #{msg}\n")
-    end
-
-    fd.flush
-  end
-
-protected
-
-  attr_accessor :fd # :nodoc:
 
 end
 

--- a/lib/rex/logging/sinks/flatfile_without_colors.rb
+++ b/lib/rex/logging/sinks/flatfile_without_colors.rb
@@ -6,16 +6,17 @@ module Sinks
 ###
 #
 # This class implements the LogSink interface and backs it against a
-# file on disk with a Timestamp.
+# file on disk. The logged messages will have their colors and trailing
+# whitespace removed
 #
 ###
-class TimestampFlatfile < Flatfile
+class FlatfileWithoutColors < Flatfile
 
   def log(sev, src, level, msg) # :nodoc:
     return unless msg.present?
     msg = msg.gsub(/\x1b\[[0-9;]*[mG]/,'').gsub(/[\x01-\x02]/, ' ').gsub(/\s+$/,'')
-    fd.write("[#{get_current_timestamp}] #{msg}\n")
-    fd.flush
+    stream.write("[#{get_current_timestamp}] #{msg}\n")
+    stream.flush
   end
 end
 

--- a/lib/rex/logging/sinks/stderr.rb
+++ b/lib/rex/logging/sinks/stderr.rb
@@ -7,37 +7,14 @@ module Sinks
 #
 # This class implements the LogSink interface and backs it against stderr
 ###
-class Stderr
-
-  include Rex::Logging::LogSink
+class Stderr < Rex::Logging::Sinks::Stream
 
   #
-  # Writes log data to stderr
+  # Creates a log sink instance that will be configured to log to stderr
   #
-
-  def log(sev, src, level, msg) # :nodoc:
-    if (sev == LOG_RAW)
-      $stderr.write(msg)
-    else
-      code = 'i'
-
-      case sev
-        when LOG_DEBUG
-          code = 'd'
-        when LOG_ERROR
-          code = 'e'
-        when LOG_INFO
-          code = 'i'
-        when LOG_WARN
-          code = 'w'
-      end
-      $stderr.write("[#{get_current_timestamp}] [#{code}(#{level})] #{src}: #{msg}\n")
-    end
-
-    $stderr.flush
+  def initialize
+    super($stderr)
   end
-
-protected
 
 end
 

--- a/lib/rex/logging/sinks/stdout.rb
+++ b/lib/rex/logging/sinks/stdout.rb
@@ -1,0 +1,21 @@
+# -*- coding: binary -*-
+module Rex
+module Logging
+module Sinks
+
+###
+#
+# This class implements the LogSink interface and backs it against stdout
+###
+class Stdout < Rex::Logging::Sinks::Stream
+
+  #
+  # Creates a log sink instance that will be configured to log to stdout
+  #
+  def initialize
+    super($stdout)
+  end
+
+end
+
+end end end

--- a/lib/rex/logging/sinks/stream.rb
+++ b/lib/rex/logging/sinks/stream.rb
@@ -1,0 +1,49 @@
+# -*- coding: binary -*-
+module Rex
+module Logging
+module Sinks
+
+###
+#
+# This class implements the LogSink interface and backs it against a stream
+###
+class Stream
+
+  include Rex::Logging::LogSink
+
+  def initialize(stream)
+    @stream = stream
+  end
+
+  #
+  # Writes log data to a stream
+  #
+  def log(sev, src, level, msg) # :nodoc:
+    if (sev == LOG_RAW)
+      stream.write(msg)
+    else
+      code = 'i'
+
+      case sev
+        when LOG_DEBUG
+          code = 'd'
+        when LOG_ERROR
+          code = 'e'
+        when LOG_INFO
+          code = 'i'
+        when LOG_WARN
+          code = 'w'
+      end
+      stream.write("[#{get_current_timestamp}] [#{code}(#{level})] #{src}: #{msg}\n")
+    end
+
+    stream.flush
+  end
+
+protected
+
+  attr_accessor :stream # :nodoc:
+
+end
+
+end end end


### PR DESCRIPTION
Updates the json rpc to allow logging to stderr via an environment variable `MSF_WS_DATA_SERVICE_LOG_TO_STDOUT`. Now the framework logs will appear in the console when ran directly:

```
$ MSF_WS_DATA_SERVICE_LOG_TO_STDOUT=true bundle exec thin --rackup msf-json-rpc.ru --address localhost --port 8081 --environment production --tag msf-json-rpc start
Thin web server (v1.7.2 codename Bachmanity)
Maximum connections set to 1024
Listening on localhost:8081, CTRL+C to stop
[11/10/2020 19:09:40] [e(0)] core: Auxiliary failed - Rex::ConnectionRefused The connection was refused by the remote host (127.0.0.1:443).
[11/10/2020 19:09:41] [e(0)] core: Auxiliary failed - Rex::ConnectionRefused The connection was refused by the remote host (127.0.0.1:443).
```

This allows for the rpc service's log output to be collected by alternative log routers, such as logplex/fluentd, or in this specific case - a parent process can consume the logs of the running json rpc service process directly and stream the logs to its own logging infrastructure, without the logs hitting the host machine's disk.

Additional context: https://12factor.net/logs

## Verification

List the steps needed to make sure this thing works

- [ ] Ensure that framework logs now appear within the console:
> MSF_WS_DATA_SERVICE_LOG_TO_STDOUT=true bundle exec thin --rackup msf-json-rpc.ru --address localhost --port 8081 --environment production --tag msf-json-rpc start