### PR TITLE
Fixes rhost_http_url crashes when running the check method

### DIFF
--- a/lib/msf/core/opt_http_rhost_url.rb
+++ b/lib/msf/core/opt_http_rhost_url.rb
@@ -67,6 +67,7 @@ module Msf
 
     def get_uri(value)
       return unless value
+      value = calculate_value(value) if value.is_a? Hash
       return unless single_rhost?(value)
 
       value = 'http://' + value unless value.start_with?(%r{https?://})

--- a/spec/lib/msf/core/opt_http_rhost_url_spec.rb
+++ b/spec/lib/msf/core/opt_http_rhost_url_spec.rb
@@ -35,4 +35,24 @@ RSpec.describe Msf::OptHTTPRhostURL do
       end
     end
   end
+
+  describe '#valid?' do
+    [
+      { expected: true, value: { 'VHOST' => nil, 'RHOSTS' => '127.0.0.1', 'RPORT' => 80, 'SSL' => false, 'TARGETURI' => '/', 'URI' => '/', 'HttpUsername' => '', 'HttpPassword' => '' } },
+      { expected: true, value: 'google.com' },
+      { expected: true, value: 'https://google.com' },
+      { expected: true, value: '127.0.0.1' },
+      { expected: true, value: 'http://127.0.0.1/' },
+      { expected: true, value: nil }, # RHOST_HTTP_URL does not have to be set, so nil should return true.
+      { expected: false, value: { 'VHOST' => nil, 'RHOSTS' => '', 'RPORT' => 80, 'SSL' => false, 'TARGETURI' => '/', 'URI' => '/', 'HttpUsername' => '', 'HttpPassword' => '' } },
+      { expected: false, value: {} },
+      { expected: false, value: '' }
+    ].each do |test|
+      context test[:value].to_s do
+        it "should return #{test[:expected]}" do
+          expect(subject.valid?(test[:value])).to eq(test[:expected])
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR Resolves #14308.

The crash was previously caused when the user enabled `features set RHOST_HTTP_URL true`, then when the check method is ran, it would crash and return this error message. 
```
[-] Check failed: NoMethodError undefined method `split' for #<Hash:0x00005592b18970d0>
```

Example of crash:
![fix_rhost_crash_check_command_issue](https://user-images.githubusercontent.com/69522014/98807090-0f525f80-2412-11eb-8530-3b2b0e16c19b.gif)


This was caused due to a hash being passed in as `value` in `single_rhost?(value)`. The fix now checks if value is a hash in `get_uri` and sets it appropriately before it gets passed to `single_rhost?(value)`.


## Options used to recreated issue:
![image](https://user-images.githubusercontent.com/69522014/98806305-e41b4080-2410-11eb-8876-376667355865.png)


## Verification

Set-up for testing:
I edited my `/etc/hosts` to contain 
```
127.0.0.1       wordpress.jeff.thm
```
![image](https://user-images.githubusercontent.com/69522014/98808328-d5825880-2413-11eb-9d4d-86434498bde7.png)

Test steps:

- [ ] Start `msfconsole`
- [ ] run `features set RHOST_HTTP_URL true`
- [ ] run `use exploit/unix/webapp/wp_admin_shell_upload`
- [ ] Set options - see above for options used 
- [ ] **Verify** the check method does not cause a crash
