### PR TITLE
update apply_pot to the hashcat generation

### DIFF
--- a/modules/auxiliary/analyze/apply_pot.rb
+++ b/modules/auxiliary/analyze/apply_pot.rb
@@ -17,7 +17,13 @@ class MetasploitModule < Msf::Auxiliary
         help combine all the passwords into an easy to use format.
       },
       'Author'          => ['h00die'],
-      'License'         => MSF_LICENSE
+      'License'         => MSF_LICENSE,
+      'Actions'         =>
+        [
+          ['john', 'Description' => 'Use John the Ripper'],
+          # ['hashcat', 'Description' => 'Use Hashcat'], # removed for simplicity
+        ],
+      'DefaultAction' => 'john',
     )
     deregister_options('ITERATION_TIMEOUT')
     deregister_options('CUSTOM_WORDLIST')
@@ -49,8 +55,20 @@ class MetasploitModule < Msf::Auxiliary
     end
   end
 
+  def show_run_command(cracker_instance)
+    return unless datastore['ShowCommand']
+    cmd = cracker_instance.show_command
+    print_status("   Cracking Command: #{cmd.join(' ')}")
+  end
+
   def run
-    cracker = new_john_cracker
+    cracker = new_password_cracker
+    cracker.cracker = action.name
+    cracker_version = cracker.cracker_version
+    if action.name == 'john' and not cracker_version.include?'jumbo'
+      fail_with(Failure::BadConfig, 'John the Ripper JUMBO patch version required.  See https://github.com/magnumripper/JohnTheRipper')
+    end
+    print_good("#{action.name} Version Detected: #{cracker_version}")
 
     lookups = []
 
@@ -79,7 +97,8 @@ class MetasploitModule < Msf::Auxiliary
 
       print_status("Checking #{format} hashes against pot file")
       cracker.format = format
-      cracker.each_cracked_password do |password_line|
+      show_run_command(cracker)
+      cracker.each_cracked_password.each do |password_line|
         password_line.chomp!
         next if password_line.blank? || password_line.nil?
         fields = password_line.split(":")


### PR DESCRIPTION
Fixes #14380 .

When the cracker modules got updated to include hashcat functionality, the libs changed.  Looks like I forgot to update `apply_pot`.  This updates the module to make it work again.

## Verification

- [x] Load in some hashes: https://github.com/rapid7/metasploit-framework/wiki/Hashes-and-Password-Cracking#example-hashes
- [x] Crack some of them with the appropriate modules, or create your own pot file (passwords are on the wiki page)
- [x] `creds -d`
- [x] reload the hashes so theyre not already cracked
- [x] use the `apply_pot` module
- [x] **Verify** the module doesn't crash
- [x] **Verify** the module cracks some of the passwords
