### PR TITLE
use more explicit date set in Timecop

### DIFF
--- a/spec/rubocop/cop/lint/module_disclosure_date_format_spec.rb
+++ b/spec/rubocop/cop/lint/module_disclosure_date_format_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe RuboCop::Cop::Lint::ModuleDisclosureDateFormat do
   let(:config) { RuboCop::Config.new }
 
   before(:each) do
-    Timecop.freeze('2020-10-02')
+    Timecop.freeze(2020, 10, 02, 12)
   end
 
   after(:example) do


### PR DESCRIPTION
Update usage of Timecop to a more explicit parameter set as 12:00 to account for timezone shifts.

Fixes the below error seen when executing specs in common testing some timezones.
```
20:03:41 RuboCop::Cop::Lint::ModuleDisclosureDateFormat .F.F
20:03:41 
20:03:41   1) RuboCop::Cop::Lint::ModuleDisclosureDateFormat provides an autocorrection when the DisclosureDate can safely be converted to the required format
20:03:41      Failure/Error:
20:03:41        expect_offense(<<~RUBY)
20:03:41          class DummyModule
20:03:41            def initialize(info = {})
20:03:41              super(
20:03:41                update_info(
20:03:41                  info,
20:03:41                  'Name' => 'Simple module name',
20:03:41                  'Description' => 'Lorem ipsum dolor sit amet',
20:03:41                  'Author' => [ 'example1', 'example2' ],
20:03:41                  'License' => MSF_LICENSE,
20:03:41 
20:03:41        Diff:
20:03:41        @@ -10,7 +10,7 @@
20:03:41                 'Platform' => 'win',
20:03:41                 'Arch' => ARCH_X86,
20:03:41                 'DisclosureDate' => 'Dec 7 2007'
20:03:41        -                            ^^^^^^^^^^^^ Modules should specify a DisclosureDate with the required format '%Y-%m-%d', for example '2020-10-02'
20:03:41        +                            ^^^^^^^^^^^^ Modules should specify a DisclosureDate with the required format '%Y-%m-%d', for example '2020-10-01'
20:03:41               )
20:03:41             )
20:03:41           end
20:03:41      # /home/jenkins/.rvm/gems/ruby-2.6.3@metasploit-framework1/gems/rubocop-1.2.0/lib/rubocop/rspec/expect_offense.rb:140:in `expect_offense'
20:03:41      # ./spec/rubocop/cop/lint/module_disclosure_date_format_spec.rb:84:in `block (2 levels) in <top (required)>'
20:03:41 
20:03:41   2) RuboCop::Cop::Lint::ModuleDisclosureDateFormat rejects invalid DisclosureDate values
20:03:41      Failure/Error:
20:03:41        expect_offense(<<~RUBY)
20:03:41          class DummyModule
20:03:41            def initialize(info = {})
20:03:41              super(
20:03:41                update_info(
20:03:41                  info,
20:03:41                  'Name' => 'Simple module name',
20:03:41                  'Description' => 'Lorem ipsum dolor sit amet',
20:03:41                  'Author' => [ 'example1', 'example2' ],
20:03:41                  'License' => MSF_LICENSE,
20:03:41 
20:03:41        Diff:
20:03:41        @@ -10,7 +10,7 @@
20:03:41                 'Platform' => 'win',
20:03:41                 'Arch' => ARCH_X86,
20:03:41                 'DisclosureDate' => 'January 5'
20:03:41        -                            ^^^^^^^^^^^ Modules should specify a DisclosureDate with the required format '%Y-%m-%d', for example '2020-10-02'
20:03:41        +                            ^^^^^^^^^^^ Modules should specify a DisclosureDate with the required format '%Y-%m-%d', for example '2020-10-01'
20:03:41         
20:03:41               )
20:03:41             )
20:03:41      # /home/jenkins/.rvm/gems/ruby-2.6.3@metasploit-framework1/gems/rubocop-1.2.0/lib/rubocop/rspec/expect_offense.rb:140:in `expect_offense'
20:03:41      # ./spec/rubocop/cop/lint/module_disclosure_date_format_spec.rb:60:in `block (2 levels) in <top (required)>'
```

## Verification

List the steps needed to make sure this thing works

- [ ] Rspec passes regardless of timezone.

