### PR TITLE
guard persist on handler existence

### DIFF
--- a/lib/msf/base/serializer/readable_text.rb
+++ b/lib/msf/base/serializer/readable_text.rb
@@ -1018,8 +1018,9 @@ class ReadableText
         end
 
         persist_list.each do |e|
-          if framework.jobs[job_id.to_s].ctx[1]
-             row[7] = 'true' if e['mod_options']['Options'] == framework.jobs[job_id.to_s].ctx[1].datastore
+          handler_ctx = framework.jobs[job_id.to_s].ctx[1]
+          if handler_ctx && handler_ctx.respond_to?(:datastore)
+             row[7] = 'true' if e['mod_options']['Options'] == handler_ctx.datastore
           end
         end
 

--- a/lib/msf/ui/console/command_dispatcher/jobs.rb
+++ b/lib/msf/ui/console/command_dispatcher/jobs.rb
@@ -242,7 +242,8 @@ module Msf
 
           def add_persist_job(job_id)
             if job_id && framework.jobs.has_key?(job_id.to_s)
-              unless framework.jobs[job_id.to_s].ctx[1]
+              handler_ctx = framework.jobs[job_id.to_s].ctx[1]
+              unless handler_ctx and handler_ctx.respond_to?(:replicant)
                 print_error("Add persistent job failed: job #{job_id} is not payload handler.")
                 return
               end


### PR DESCRIPTION
Short term fix to only persist jobs with handlers. More work should
be done to improve job persistence to allow more jobs types to persist.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/multi/handler`
- [ ] `set LHOST <IP_ADDRESS>`
- [ ] `set payload windows/meterpreter/reverse_tcp`
- [ ] `run -j`
- [ ] `jobs -P`
- [ ] `use socks_proxy`
- [ ] `set LHOST <IP_ADDRESS>
- [ ] `run`
- [ ] `jobs -v`
- [ ] `jobs -P`
- [ ] **Verify** all command complete successfully (second `jobs -P` will report `socks_proxy` job is not a handler)

