### PR TITLE
Hadoop "vuln" not a vuln

### DIFF
--- a/documentation/modules/exploit/linux/http/hadoop_unauth_exec.md
+++ b/documentation/modules/exploit/linux/http/hadoop_unauth_exec.md
@@ -1,6 +1,7 @@
 ## Description
 
-This module exploits an unauthenticated command execution vulnerability in Apache Hadoop through ResourceManager REST API.
+This module uses built-in functionality to execute arbitrary commands on an unsecured Hadoop server which is
+not configured for strong authentication, via Hadoop's standard ResourceManager REST API.
 
 ## Vulnerable Application
 
@@ -13,7 +14,6 @@ https://github.com/vulhub/vulhub/tree/master/hadoop/unauthorized-yarn
 ### Vulnerable Application Installation Setup.
 
 Change dictory to `vulhub/hadoop/unauthorized-yarn`, and run `docker-compose up -d`
-
 
 ## Verification Steps
 

--- a/modules/exploits/linux/http/hadoop_unauth_exec.rb
+++ b/modules/exploits/linux/http/hadoop_unauth_exec.rb
@@ -14,7 +14,8 @@ class MetasploitModule < Msf::Exploit::Remote
     super(update_info(info,
       'Name'           => 'Hadoop YARN ResourceManager Unauthenticated Command Execution',
       'Description'    => %q{
-          This module exploits an unauthenticated command execution vulnerability in Apache Hadoop through ResourceManager REST API.
+          This module uses built-in functionality to execute arbitrary commands on an unsecured Hadoop server which is not configured for strong
+          authentication, via Hadoop's standard ResourceManager REST API.
       },
       'License'        => MSF_LICENSE,
       'Author'         =>
@@ -26,6 +27,7 @@ class MetasploitModule < Msf::Exploit::Remote
         [
           ['URL', 'http://archive.hack.lu/2016/Wavestone%20-%20Hack.lu%202016%20-%20Hadoop%20safari%20-%20Hunting%20for%20vulnerabilities%20-%20v1.0.pdf'],
           ['URL', 'https://github.com/vulhub/vulhub/tree/master/hadoop/unauthorized-yarn']
+          # Note, there will never be a CVE for this issue, unless something radical changes in the CVE inclusion rules.
         ],
       'Platform'       => 'linux',
       'Arch'           => [ARCH_X86, ARCH_X64],
@@ -34,7 +36,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ['Automatic', {}]
         ],
       'Privileged'     => false,
-      'DisclosureDate' => 'Oct 19 2016',
+      'DisclosureDate' => '2016-10-19',
       'DefaultTarget'  => 0
     ))
 


### PR DESCRIPTION
Updates the Hadoop exploit description, and adds a comment about the lack of a CVE.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `info exploit/linux/http/hadoop_unauth_exec`
- [x] **Verify** the new description is free of grammar other errors.

Fixes #10027.