### PR TITLE
Remove unused payload compatibility code

### DIFF
--- a/lib/msf/core/payload.rb
+++ b/lib/msf/core/payload.rb
@@ -282,29 +282,6 @@ class Payload < Msf::Module
   end
 
   #
-  # Checks to see if the supplied convention is compatible with this
-  # payload's convention.
-  #
-  def compatible_convention?(conv)
-    # If we don't have a convention or our convention is equal to
-    # the one supplied, then we know we are compatible.
-    if ((self.convention == nil) or
-        (self.convention == conv))
-      true
-    # On the flip side, if we are a stager and the supplied convention is
-    # nil, then we know it's compatible.
-    elsif ((payload_type == Type::Stager) and
-           (conv == nil))
-      true
-    # Otherwise, the conventions don't match in some way or another, and as
-    # such we deem ourself as not being compatible with the supplied
-    # convention.
-    else
-      false
-    end
-  end
-
-  #
   # Return the connection associated with this payload, or none if there
   # isn't one.
   #


### PR DESCRIPTION
This original version of the convention checker has not been used in
quite some time, now all of that is covered in
https://github.com/rapid7/metasploit-framework/blob/f910d64f4d727ea213359fff8238cc0675b33478/lib/msf/core/module/compatibility.rb#L13

Verification
=========
- [ ] Verify `git grep compatible_convention?` is empty
- [ ] Verify things still work