### PR TITLE
Bump RubySMB to version 2.0.7

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -386,7 +386,7 @@ GEM
     ruby-progressbar (1.10.1)
     ruby-rc4 (0.1.5)
     ruby2_keywords (0.0.2)
-    ruby_smb (2.0.6)
+    ruby_smb (2.0.7)
       bindata
       openssl-ccm
       openssl-cmac


### PR DESCRIPTION
This bumps RubySMB to version to 2.0.7, which includes a fix related to `netlogon` RPC. This fixes an issue with the [Zerologon module](https://github.com/rapid7/metasploit-framework/blob/master/modules/auxiliary/admin/dcerpc/cve_2020_1472_zerologon.rb) when targeting systems with specific NetBIOS names. Please refers to the RubySMB original [PR](https://github.com/rapid7/ruby_smb/pull/166) for details.