### PR TITLE
Fixes ssh_login gather proof issue when user has low privileges

### DIFF
--- a/lib/metasploit/framework/login_scanner/ssh.rb
+++ b/lib/metasploit/framework/login_scanner/ssh.rb
@@ -115,7 +115,7 @@ module Metasploit
         def gather_proof
           proof = ''
           begin
-            Timeout.timeout(5) do
+            Timeout.timeout(10) do
               proof = ssh_socket.exec!("id\n").to_s
               if (proof =~ /id=/)
                 proof << ssh_socket.exec!("uname -a\n").to_s
@@ -162,6 +162,9 @@ module Metasploit
                   proof = ssh_socket.exec!("systeminfo\n").to_s
                   /OS Name:\s+(?<os_name>.+)$/ =~ proof
                   /OS Version:\s+(?<os_num>.+)$/ =~ proof
+                  if os_num.nil? || os_name.nil?
+                    proof = ssh_socket.exec!("ver\n").to_s
+                  end
                   if os_name && os_num
                     proof = "#{os_name.chomp} #{os_num.chomp}"
                   end

--- a/lib/metasploit/framework/login_scanner/ssh.rb
+++ b/lib/metasploit/framework/login_scanner/ssh.rb
@@ -162,11 +162,10 @@ module Metasploit
                   proof = ssh_socket.exec!("systeminfo\n").to_s
                   /OS Name:\s+(?<os_name>.+)$/ =~ proof
                   /OS Version:\s+(?<os_num>.+)$/ =~ proof
-                  if os_num.nil? || os_name.nil?
-                    proof = ssh_socket.exec!("ver\n").to_s.strip
-                  end
-                  if os_name && os_num
-                    proof = "#{os_name.chomp} #{os_num.chomp}"
+                  if os_num.present? && os_name.present?
+                    proof = "#{os_name.strip} #{os_num.strip}"
+                  else
+                    proof = ssh_socket.exec!("ver\n").strip
                   end
                 # mikrotik
                 elsif proof =~ /bad command name id \(line 1 column 1\)/

--- a/lib/metasploit/framework/login_scanner/ssh.rb
+++ b/lib/metasploit/framework/login_scanner/ssh.rb
@@ -163,7 +163,7 @@ module Metasploit
                   /OS Name:\s+(?<os_name>.+)$/ =~ proof
                   /OS Version:\s+(?<os_num>.+)$/ =~ proof
                   if os_num.nil? || os_name.nil?
-                    proof = ssh_socket.exec!("ver\n").to_s
+                    proof = ssh_socket.exec!("ver\n").to_s.strip
                   end
                   if os_name && os_num
                     proof = "#{os_name.chomp} #{os_num.chomp}"

--- a/lib/metasploit/framework/login_scanner/ssh.rb
+++ b/lib/metasploit/framework/login_scanner/ssh.rb
@@ -165,7 +165,7 @@ module Metasploit
                   if os_num.present? && os_name.present?
                     proof = "#{os_name.strip} #{os_num.strip}"
                   else
-                    proof = ssh_socket.exec!("ver\n").strip
+                    proof = ssh_socket.exec!("ver\n").to_s.strip
                   end
                 # mikrotik
                 elsif proof =~ /bad command name id \(line 1 column 1\)/


### PR DESCRIPTION
This PR Resolves #14351.

Previously when a user attempted to `ssh_login` when their user privileges were below admin they would get this error:

![image](https://user-images.githubusercontent.com/69522014/99806208-96e84e80-2b35-11eb-8668-6ae974ae8991.png)

This was due to the user not having permissions to use the `systeminfo` command. 

This fix adds a fallback, that will resort to using the `ver` command if the user have permissions for `systeminfo`
Now when the same user from the error above tries to ssh in, they can now gain access. 

![image](https://user-images.githubusercontent.com/69522014/99804830-833be880-2b33-11eb-9719-1bc5a02b723c.png)

I also changed the value of `Timeout.timeout(5)` to a 10 second duration as I was encountering some issues with it being 5 seconds during testing.

## Verification

Setting up environment - steps I took, just incase they're off use: 

- [x] Get a windows environment running for your target 
- [x] Ensure you have a user with standard privileges that has a password set - as you can't ssh in without having a password set
- [x] May also need to install OpenSSH on your target machine

Test steps:

- [x] Start `msfconsole`
- [x] run `use auxiliary/scanner/ssh/ssh_login`
- [x] run `run RHOSTS=xxx.xxx.xxx.xxx username=xxx password=xxxxxxxx`
- [x] **Verify** that you gain access successfully and no longer receive the error above when using the low privilege user
- [x] Repeat steps above for admin user to ensure previous functionality remains