### PR TITLE
Expand wordpress_scanner to look for themes & plugins

### DIFF
--- a/documentation/modules/auxiliary/scanner/http/wordpress_scanner.md
+++ b/documentation/modules/auxiliary/scanner/http/wordpress_scanner.md
@@ -1,11 +1,10 @@
-## Description
-
-Detects Wordpress installations and their version number.
-
-
 ## Vulnerable Application
 
+Detects Wordpress installations and their version number.
+Also, optionally, detects themes and plugins.
+
 ### Setup using Docksal
+
 Install [Docksal](https://docksal.io/)
 
 Create a new WordPress installation using `fin project create`
@@ -75,10 +74,34 @@ Admin panel: http://msf-wp.docksal/wp-admin. User/password: admin/admin
 
 ## Verification Steps
 
-1. Do: ```use auxiliary/scanner/http/wordpress_sanner```
-2. Do: ```set RHOSTS [IP]```
-3. Do: ```set VHOST [HOSTNAME]```
-4. Do: ```run```
+1. Do: `use auxiliary/scanner/http/wordpress_sanner`
+2. Do: `set RHOSTS [IP]`
+3. Do: `set VHOST [HOSTNAME]`
+4. Do: `run`
+
+## Options
+
+### PLUGINS
+
+If plugins should be scanned. Defaults to `true`
+
+### PLUGINS_FILE
+
+Which plugins list to use. Default is `data/wordlists/wp-plugins.txt`
+
+### THEMES
+
+If themes should be scanned. Defaults to `true`
+
+### THEMES_FILE
+
+Which themes list to use. Default is `data/wordlists/wp-themes.txt`
+
+### Progress
+
+How often to print a prorgress bar while scanning for themes/plugins.  Defaults to `1000`
+
+## Scenarios
 
 ### Wordpress 5.2 running in Docksal
 
@@ -98,4 +121,129 @@ msf5 auxiliary(scanner/http/wordpress_scanner) > run
 [*] Auxiliary module execution completed
 msf5 auxiliary(scanner/http/wordpress_scanner) > 
 
+```
+
+### Wordpress 5.4.2 with Pluin and Theme Enumeration
+
+```
+msf6 > use auxiliary/scanner/http/wordpress_scanner 
+msf6 auxiliary(scanner/http/wordpress_scanner) > set rhosts 192.168.2.144
+rhosts => 192.168.2.144
+msf6 auxiliary(scanner/http/wordpress_scanner) > run
+
+[*] Trying 192.168.2.144
+[+] 192.168.2.144 running Wordpress 5.4.2
+[*] Enumerating Themes
+[*] Progress 0/19226 (0.0%)
+[*] Progress 1000/19226 (5.2%)
+[*] Progress 2000/19226 (10.4%)
+[*] Progress 3000/19226 (15.6%)
+[*] Progress 4000/19226 (20.8%)
+[*] Progress 5000/19226 (26.0%)
+[*] Progress 6000/19226 (31.2%)
+[*] Progress 7000/19226 (36.4%)
+[*] Progress 8000/19226 (41.61%)
+[*] Progress 9000/19226 (46.81%)
+[*] Progress 10000/19226 (52.01%)
+[*] Progress 11000/19226 (57.21%)
+[*] Progress 12000/19226 (62.41%)
+[*] Progress 13000/19226 (67.61%)
+[*] Progress 14000/19226 (72.81%)
+[*] Progress 15000/19226 (78.01%)
+[*] Progress 16000/19226 (83.22%)
+[*] Progress 17000/19226 (88.42%)
+[+] Detected Theme: twentynineteen version 1.5 
+[+] Detected Theme: twentyseventeen version 2.3 
+[*] Progress 18000/19226 (93.62%)
+[*] Progress 19000/19226 (98.82%)
+[*] Enumerating Plugins
+[*] Progress 0/80624 (0.0%)
+[*] Progress 1000/80624 (1.24%)
+[*] Progress 2000/80624 (2.48%)
+[+] Detected Plugin: akismet version 4.1.5 
+[*] Progress 3000/80624 (3.72%)
+[*] Progress 4000/80624 (4.96%)
+[*] Progress 5000/80624 (6.2%)
+[*] Progress 6000/80624 (7.44%)
+[*] Progress 7000/80624 (8.68%)
+[*] Progress 8000/80624 (9.92%)
+[*] Progress 9000/80624 (11.16%)
+[*] Progress 10000/80624 (12.4%)
+[*] Progress 11000/80624 (13.64%)
+[*] Progress 12000/80624 (14.88%)
+[*] Progress 13000/80624 (16.12%)
+[+] Detected Plugin: contact-form-7 version 5.1.9 
+[*] Progress 14000/80624 (17.36%)
+[*] Progress 15000/80624 (18.6%)
+[*] Progress 16000/80624 (19.84%)
+[*] Progress 17000/80624 (21.08%)
+[*] Progress 18000/80624 (22.32%)
+[+] Detected Plugin: drag-and-drop-multiple-file-upload-contact-form-7 version 1.3.3.2 
+[*] Progress 19000/80624 (23.56%)
+[*] Progress 20000/80624 (24.8%)
+[+] Detected Plugin: email-subscribers version 4.2.2 
+[*] Progress 21000/80624 (26.04%)
+[*] Progress 22000/80624 (27.28%)
+[*] Progress 23000/80624 (28.52%)
+[*] Progress 24000/80624 (29.76%)
+[*] Progress 25000/80624 (31.0%)
+[*] Progress 26000/80624 (32.24%)
+[*] Progress 27000/80624 (33.48%)
+[*] Progress 28000/80624 (34.72%)
+[*] Progress 29000/80624 (35.96%)
+[*] Progress 30000/80624 (37.2%)
+[*] Progress 31000/80624 (38.45%)
+[*] Progress 32000/80624 (39.69%)
+[*] Progress 33000/80624 (40.93%)
+[*] Progress 34000/80624 (42.17%)
+[*] Progress 35000/80624 (43.41%)
+[+] Detected Plugin: loginizer version 1.6.3 
+[*] Progress 36000/80624 (44.65%)
+[*] Progress 37000/80624 (45.89%)
+[*] Progress 38000/80624 (47.13%)
+[*] Progress 39000/80624 (48.37%)
+[*] Progress 40000/80624 (49.61%)
+[*] Progress 41000/80624 (50.85%)
+[*] Progress 42000/80624 (52.09%)
+[*] Progress 43000/80624 (53.33%)
+[*] Progress 44000/80624 (54.57%)
+[*] Progress 45000/80624 (55.81%)
+[*] Progress 46000/80624 (57.05%)
+[*] Progress 47000/80624 (58.29%)
+[*] Progress 48000/80624 (59.53%)
+[*] Progress 49000/80624 (60.77%)
+[*] Progress 50000/80624 (62.01%)
+[*] Progress 51000/80624 (63.25%)
+[*] Progress 52000/80624 (64.49%)
+[*] Progress 53000/80624 (65.73%)
+[*] Progress 54000/80624 (66.97%)
+[*] Progress 55000/80624 (68.21%)
+[+] Detected Plugin: simple-file-list version 4.2.2 
+[*] Progress 56000/80624 (69.45%)
+[*] Progress 57000/80624 (70.69%)
+[*] Progress 58000/80624 (71.93%)
+[*] Progress 59000/80624 (73.17%)
+[*] Progress 60000/80624 (74.41%)
+[*] Progress 61000/80624 (75.65%)
+[*] Progress 62000/80624 (76.9%)
+[*] Progress 63000/80624 (78.14%)
+[*] Progress 64000/80624 (79.38%)
+[*] Progress 65000/80624 (80.62%)
+[*] Progress 66000/80624 (81.86%)
+[*] Progress 67000/80624 (83.1%)
+[*] Progress 68000/80624 (84.34%)
+[*] Progress 69000/80624 (85.58%)
+[*] Progress 70000/80624 (86.82%)
+[*] Progress 71000/80624 (88.06%)
+[*] Progress 72000/80624 (89.3%)
+[*] Progress 73000/80624 (90.54%)
+[*] Progress 74000/80624 (91.78%)
+[*] Progress 75000/80624 (93.02%)
+[*] Progress 76000/80624 (94.26%)
+[*] Progress 77000/80624 (95.5%)
+[*] Progress 78000/80624 (96.74%)
+[*] Progress 79000/80624 (97.98%)
+[*] Progress 80000/80624 (99.22%)
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
 ```

--- a/documentation/modules/auxiliary/scanner/http/wordpress_scanner.md
+++ b/documentation/modules/auxiliary/scanner/http/wordpress_scanner.md
@@ -123,127 +123,147 @@ msf5 auxiliary(scanner/http/wordpress_scanner) >
 
 ```
 
-### Wordpress 5.4.2 with Pluin and Theme Enumeration
+### Wordpress 5.4.2 with Plugin and Theme Enumeration
 
 ```
-msf6 > use auxiliary/scanner/http/wordpress_scanner 
-msf6 auxiliary(scanner/http/wordpress_scanner) > set rhosts 192.168.2.144
-rhosts => 192.168.2.144
+msf6 > use auxiliary/scanner/http/wordpress_scanner
+[*] Using auxiliary/scanner/http/wordpress_scanner
+msf6 auxiliary(scanner/http/wordpress_scanner) > set rhosts 1.1.1.1
+rhosts => 1.1.1.1
 msf6 auxiliary(scanner/http/wordpress_scanner) > run
 
-[*] Trying 192.168.2.144
-[+] 192.168.2.144 running Wordpress 5.4.2
-[*] Enumerating Themes
-[*] Progress 0/19226 (0.0%)
-[*] Progress 1000/19226 (5.2%)
-[*] Progress 2000/19226 (10.4%)
-[*] Progress 3000/19226 (15.6%)
-[*] Progress 4000/19226 (20.8%)
-[*] Progress 5000/19226 (26.0%)
-[*] Progress 6000/19226 (31.2%)
-[*] Progress 7000/19226 (36.4%)
-[*] Progress 8000/19226 (41.61%)
-[*] Progress 9000/19226 (46.81%)
-[*] Progress 10000/19226 (52.01%)
-[*] Progress 11000/19226 (57.21%)
-[*] Progress 12000/19226 (62.41%)
-[*] Progress 13000/19226 (67.61%)
-[*] Progress 14000/19226 (72.81%)
-[*] Progress 15000/19226 (78.01%)
-[*] Progress 16000/19226 (83.22%)
-[*] Progress 17000/19226 (88.42%)
-[+] Detected Theme: twentynineteen version 1.5 
-[+] Detected Theme: twentyseventeen version 2.3 
-[*] Progress 18000/19226 (93.62%)
-[*] Progress 19000/19226 (98.82%)
-[*] Enumerating Plugins
-[*] Progress 0/80624 (0.0%)
-[*] Progress 1000/80624 (1.24%)
-[*] Progress 2000/80624 (2.48%)
-[+] Detected Plugin: akismet version 4.1.5 
-[*] Progress 3000/80624 (3.72%)
-[*] Progress 4000/80624 (4.96%)
-[*] Progress 5000/80624 (6.2%)
-[*] Progress 6000/80624 (7.44%)
-[*] Progress 7000/80624 (8.68%)
-[*] Progress 8000/80624 (9.92%)
-[*] Progress 9000/80624 (11.16%)
-[*] Progress 10000/80624 (12.4%)
-[*] Progress 11000/80624 (13.64%)
-[*] Progress 12000/80624 (14.88%)
-[*] Progress 13000/80624 (16.12%)
-[+] Detected Plugin: contact-form-7 version 5.1.9 
-[*] Progress 14000/80624 (17.36%)
-[*] Progress 15000/80624 (18.6%)
-[*] Progress 16000/80624 (19.84%)
-[*] Progress 17000/80624 (21.08%)
-[*] Progress 18000/80624 (22.32%)
-[+] Detected Plugin: drag-and-drop-multiple-file-upload-contact-form-7 version 1.3.3.2 
-[*] Progress 19000/80624 (23.56%)
-[*] Progress 20000/80624 (24.8%)
-[+] Detected Plugin: email-subscribers version 4.2.2 
-[*] Progress 21000/80624 (26.04%)
-[*] Progress 22000/80624 (27.28%)
-[*] Progress 23000/80624 (28.52%)
-[*] Progress 24000/80624 (29.76%)
-[*] Progress 25000/80624 (31.0%)
-[*] Progress 26000/80624 (32.24%)
-[*] Progress 27000/80624 (33.48%)
-[*] Progress 28000/80624 (34.72%)
-[*] Progress 29000/80624 (35.96%)
-[*] Progress 30000/80624 (37.2%)
-[*] Progress 31000/80624 (38.45%)
-[*] Progress 32000/80624 (39.69%)
-[*] Progress 33000/80624 (40.93%)
-[*] Progress 34000/80624 (42.17%)
-[*] Progress 35000/80624 (43.41%)
-[+] Detected Plugin: loginizer version 1.6.3 
-[*] Progress 36000/80624 (44.65%)
-[*] Progress 37000/80624 (45.89%)
-[*] Progress 38000/80624 (47.13%)
-[*] Progress 39000/80624 (48.37%)
-[*] Progress 40000/80624 (49.61%)
-[*] Progress 41000/80624 (50.85%)
-[*] Progress 42000/80624 (52.09%)
-[*] Progress 43000/80624 (53.33%)
-[*] Progress 44000/80624 (54.57%)
-[*] Progress 45000/80624 (55.81%)
-[*] Progress 46000/80624 (57.05%)
-[*] Progress 47000/80624 (58.29%)
-[*] Progress 48000/80624 (59.53%)
-[*] Progress 49000/80624 (60.77%)
-[*] Progress 50000/80624 (62.01%)
-[*] Progress 51000/80624 (63.25%)
-[*] Progress 52000/80624 (64.49%)
-[*] Progress 53000/80624 (65.73%)
-[*] Progress 54000/80624 (66.97%)
-[*] Progress 55000/80624 (68.21%)
-[+] Detected Plugin: simple-file-list version 4.2.2 
-[*] Progress 56000/80624 (69.45%)
-[*] Progress 57000/80624 (70.69%)
-[*] Progress 58000/80624 (71.93%)
-[*] Progress 59000/80624 (73.17%)
-[*] Progress 60000/80624 (74.41%)
-[*] Progress 61000/80624 (75.65%)
-[*] Progress 62000/80624 (76.9%)
-[*] Progress 63000/80624 (78.14%)
-[*] Progress 64000/80624 (79.38%)
-[*] Progress 65000/80624 (80.62%)
-[*] Progress 66000/80624 (81.86%)
-[*] Progress 67000/80624 (83.1%)
-[*] Progress 68000/80624 (84.34%)
-[*] Progress 69000/80624 (85.58%)
-[*] Progress 70000/80624 (86.82%)
-[*] Progress 71000/80624 (88.06%)
-[*] Progress 72000/80624 (89.3%)
-[*] Progress 73000/80624 (90.54%)
-[*] Progress 74000/80624 (91.78%)
-[*] Progress 75000/80624 (93.02%)
-[*] Progress 76000/80624 (94.26%)
-[*] Progress 77000/80624 (95.5%)
-[*] Progress 78000/80624 (96.74%)
-[*] Progress 79000/80624 (97.98%)
-[*] Progress 80000/80624 (99.22%)
+[*] Trying 1.1.1.1
+[+] 1.1.1.1 - Detected Wordpress 5.4.2
+[*] 1.1.1.1 - Enumerating Themes
+[*] 1.1.1.1 - Progress      0/19226 (0.0%)
+[*] 1.1.1.1 - Progress   1000/19226 (5.2%)
+[*] 1.1.1.1 - Progress   2000/19226 (10.4%)
+[*] 1.1.1.1 - Progress   3000/19226 (15.6%)
+[*] 1.1.1.1 - Progress   4000/19226 (20.8%)
+[*] 1.1.1.1 - Progress   5000/19226 (26.0%)
+[*] 1.1.1.1 - Progress   6000/19226 (31.2%)
+[*] 1.1.1.1 - Progress   7000/19226 (36.4%)
+[*] 1.1.1.1 - Progress   8000/19226 (41.61%)
+[*] 1.1.1.1 - Progress   9000/19226 (46.81%)
+[*] 1.1.1.1 - Progress  10000/19226 (52.01%)
+[*] 1.1.1.1 - Progress  11000/19226 (57.21%)
+[*] 1.1.1.1 - Progress  12000/19226 (62.41%)
+[*] 1.1.1.1 - Progress  13000/19226 (67.61%)
+[*] 1.1.1.1 - Progress  14000/19226 (72.81%)
+[*] 1.1.1.1 - Progress  15000/19226 (78.01%)
+[*] 1.1.1.1 - Progress  16000/19226 (83.22%)
+[*] 1.1.1.1 - Progress  17000/19226 (88.42%)
+[+] 1.1.1.1 - Detected theme: twentynineteen version 1.5
+[+] 1.1.1.1 - Detected theme: twentyseventeen version 2.3
+[*] 1.1.1.1 - Progress  18000/19226 (93.62%)
+[*] 1.1.1.1 - Progress  19000/19226 (98.82%)
+[*] 1.1.1.1 - Finished scanning themes
+[*] 1.1.1.1 - Enumerating plugins
+[*] 1.1.1.1 - Progress      0/80624 (0.0%)
+[*] 1.1.1.1 - Progress   1000/80624 (1.24%)
+[*] 1.1.1.1 - Progress   2000/80624 (2.48%)
+[+] 1.1.1.1 - Detected plugin: akismet version 4.1.5
+[*] 1.1.1.1 - Progress   3000/80624 (3.72%)
+[*] 1.1.1.1 - Progress   4000/80624 (4.96%)
+[*] 1.1.1.1 - Progress   5000/80624 (6.2%)
+[*] 1.1.1.1 - Progress   6000/80624 (7.44%)
+[*] 1.1.1.1 - Progress   7000/80624 (8.68%)
+[*] 1.1.1.1 - Progress   8000/80624 (9.92%)
+[*] 1.1.1.1 - Progress   9000/80624 (11.16%)
+[*] 1.1.1.1 - Progress  10000/80624 (12.4%)
+[*] 1.1.1.1 - Progress  11000/80624 (13.64%)
+[*] 1.1.1.1 - Progress  12000/80624 (14.88%)
+[*] 1.1.1.1 - Progress  13000/80624 (16.12%)
+[+] 1.1.1.1 - Detected plugin: contact-form-7 version 5.1.9
+[*] 1.1.1.1 - Progress  14000/80624 (17.36%)
+[*] 1.1.1.1 - Progress  15000/80624 (18.6%)
+[*] 1.1.1.1 - Progress  16000/80624 (19.84%)
+[*] 1.1.1.1 - Progress  17000/80624 (21.08%)
+[*] 1.1.1.1 - Progress  18000/80624 (22.32%)
+[+] 1.1.1.1 - Detected plugin: drag-and-drop-multiple-file-upload-contact-form-7 version 1.3.3.2
+[*] 1.1.1.1 - Progress  19000/80624 (23.56%)
+[*] 1.1.1.1 - Progress  20000/80624 (24.8%)
+[+] 1.1.1.1 - Detected plugin: email-subscribers version 4.2.2
+[*] 1.1.1.1 - Progress  21000/80624 (26.04%)
+[*] 1.1.1.1 - Progress  22000/80624 (27.28%)
+[*] 1.1.1.1 - Progress  23000/80624 (28.52%)
+[*] 1.1.1.1 - Progress  24000/80624 (29.76%)
+[*] 1.1.1.1 - Progress  25000/80624 (31.0%)
+[*] 1.1.1.1 - Progress  26000/80624 (32.24%)
+[*] 1.1.1.1 - Progress  27000/80624 (33.48%)
+[*] 1.1.1.1 - Progress  28000/80624 (34.72%)
+[*] 1.1.1.1 - Progress  29000/80624 (35.96%)
+[*] 1.1.1.1 - Progress  30000/80624 (37.2%)
+[*] 1.1.1.1 - Progress  31000/80624 (38.45%)
+[*] 1.1.1.1 - Progress  32000/80624 (39.69%)
+[*] 1.1.1.1 - Progress  33000/80624 (40.93%)
+[*] 1.1.1.1 - Progress  34000/80624 (42.17%)
+[*] 1.1.1.1 - Progress  35000/80624 (43.41%)
+[+] 1.1.1.1 - Detected plugin: loginizer version 1.6.3
+[*] 1.1.1.1 - Progress  36000/80624 (44.65%)
+[*] 1.1.1.1 - Progress  37000/80624 (45.89%)
+[*] 1.1.1.1 - Progress  38000/80624 (47.13%)
+[*] 1.1.1.1 - Progress  39000/80624 (48.37%)
+[*] 1.1.1.1 - Progress  40000/80624 (49.61%)
+[*] 1.1.1.1 - Progress  41000/80624 (50.85%)
+[*] 1.1.1.1 - Progress  42000/80624 (52.09%)
+[*] 1.1.1.1 - Progress  43000/80624 (53.33%)
+[*] 1.1.1.1 - Progress  44000/80624 (54.57%)
+[*] 1.1.1.1 - Progress  45000/80624 (55.81%)
+[*] 1.1.1.1 - Progress  46000/80624 (57.05%)
+[*] 1.1.1.1 - Progress  47000/80624 (58.29%)
+[*] 1.1.1.1 - Progress  48000/80624 (59.53%)
+[*] 1.1.1.1 - Progress  49000/80624 (60.77%)
+[*] 1.1.1.1 - Progress  50000/80624 (62.01%)
+[*] 1.1.1.1 - Progress  51000/80624 (63.25%)
+[*] 1.1.1.1 - Progress  52000/80624 (64.49%)
+[*] 1.1.1.1 - Progress  53000/80624 (65.73%)
+[*] 1.1.1.1 - Progress  54000/80624 (66.97%)
+[*] 1.1.1.1 - Progress  55000/80624 (68.21%)
+[+] 1.1.1.1 - Detected plugin: simple-file-list version 4.2.2
+[*] 1.1.1.1 - Progress  56000/80624 (69.45%)
+[*] 1.1.1.1 - Progress  57000/80624 (70.69%)
+[*] 1.1.1.1 - Progress  58000/80624 (71.93%)
+[*] 1.1.1.1 - Progress  59000/80624 (73.17%)
+[*] 1.1.1.1 - Progress  60000/80624 (74.41%)
+[*] 1.1.1.1 - Progress  61000/80624 (75.65%)
+[*] 1.1.1.1 - Progress  62000/80624 (76.9%)
+[*] 1.1.1.1 - Progress  63000/80624 (78.14%)
+[*] 1.1.1.1 - Progress  64000/80624 (79.38%)
+[*] 1.1.1.1 - Progress  65000/80624 (80.62%)
+[*] 1.1.1.1 - Progress  66000/80624 (81.86%)
+[*] 1.1.1.1 - Progress  67000/80624 (83.1%)
+[*] 1.1.1.1 - Progress  68000/80624 (84.34%)
+[*] 1.1.1.1 - Progress  69000/80624 (85.58%)
+[*] 1.1.1.1 - Progress  70000/80624 (86.82%)
+[*] 1.1.1.1 - Progress  71000/80624 (88.06%)
+[*] 1.1.1.1 - Progress  72000/80624 (89.3%)
+[*] 1.1.1.1 - Progress  73000/80624 (90.54%)
+[*] 1.1.1.1 - Progress  74000/80624 (91.78%)
+[*] 1.1.1.1 - Progress  75000/80624 (93.02%)
+[*] 1.1.1.1 - Progress  76000/80624 (94.26%)
+[*] 1.1.1.1 - Progress  77000/80624 (95.5%)
+[*] 1.1.1.1 - Progress  78000/80624 (96.74%)
+[*] 1.1.1.1 - Progress  79000/80624 (97.98%)
+[*] 1.1.1.1 - Progress  80000/80624 (99.22%)
+[*] 1.1.1.1 - Finished scanning plugins
+[*] 1.1.1.1 - Finished all scans
 [*] Scanned 1 of 1 hosts (100% complete)
 [*] Auxiliary module execution completed
+msf6 auxiliary(scanner/http/wordpress_scanner) > notes
+
+Notes
+=====
+
+ Time                     Host     Service  Port  Protocol  Type                                                                                 Data
+ ----                     ----     -------  ----  --------  ----                                                                                 ----
+ 2020-12-04 19:01:18 UTC  1.1.1.1  http     80    tcp       Wordpress 5.4.2                                                                      "/"
+ 2020-12-05 02:16:03 UTC  1.1.1.1  http     80    tcp       Wordpress Theme: twentynineteen version 1.5                                          {}
+ 2020-12-05 02:16:03 UTC  1.1.1.1  http     80    tcp       Wordpress Theme: twentyseventeen version 2.3                                         {}
+ 2020-12-05 02:16:58 UTC  1.1.1.1  http     80    tcp       Wordpress Plugin: akismet version 4.1.5                                              {}
+ 2020-12-05 02:18:44 UTC  1.1.1.1  http     80    tcp       Wordpress Plugin: contact-form-7 version 5.1.9                                       {}
+ 2020-12-05 02:19:35 UTC  1.1.1.1  http     80    tcp       Wordpress Plugin: drag-and-drop-multiple-file-upload-contact-form-7 version 1.3.3.2  {}
+ 2020-12-05 02:19:58 UTC  1.1.1.1  http     80    tcp       Wordpress Plugin: email-subscribers version 4.2.2                                    {}
+ 2020-12-05 02:22:41 UTC  1.1.1.1  http     80    tcp       Wordpress Plugin: loginizer version 1.6.3                                            {}
+ 2020-12-05 02:26:05 UTC  1.1.1.1  http     80    tcp       Wordpress Plugin: simple-file-list version 4.2.2                                     {}
 ```

--- a/lib/msf/core/exploit/http/wordpress/version.rb
+++ b/lib/msf/core/exploit/http/wordpress/version.rb
@@ -188,29 +188,29 @@ module Msf::Exploit::Remote::HTTP::Wordpress::Version
     if fixed_version.nil?
       if vuln_introduced_version.nil?
         # All versions are vulnerable
-        return Msf::Exploit::CheckCode::Appears(details:version)
+        return Msf::Exploit::CheckCode::Appears(details:{version: version})
       elsif Gem::Version.new(version) >= Gem::Version.new(vuln_introduced_version)
         # Newer or equal to the version it was introduced
-        return Msf::Exploit::CheckCode::Appears(details:version)
+        return Msf::Exploit::CheckCode::Appears(details:{version: version})
       else
-        return Msf::Exploit::CheckCode::Safe(details:version)
+        return Msf::Exploit::CheckCode::Safe(details:{version: version})
       end
     else
       # Version older than fixed version
       if Gem::Version.new(version) < Gem::Version.new(fixed_version)
         if vuln_introduced_version.nil?
           # Older than fixed version, no vuln introduction date, flag as vuln
-          return Msf::Exploit::CheckCode::Appears(details:version)
+          return Msf::Exploit::CheckCode::Appears(details:{version: version})
         # vuln_introduced_version provided, check if version is newer
         elsif Gem::Version.new(version) >= Gem::Version.new(vuln_introduced_version)
-          return Msf::Exploit::CheckCode::Appears(details:version)
+          return Msf::Exploit::CheckCode::Appears(details:{version: version})
         else
           # Not in range, nut vulnerable
-          return Msf::Exploit::CheckCode::Safe(details:version)
+          return Msf::Exploit::CheckCode::Safe(details:{version: version})
         end
       # version newer than fixed version
       else
-        return Msf::Exploit::CheckCode::Safe(details:version)
+        return Msf::Exploit::CheckCode::Safe(details:{version: version})
       end
     end
   rescue ArgumentError => e

--- a/lib/msf/core/exploit/http/wordpress/version.rb
+++ b/lib/msf/core/exploit/http/wordpress/version.rb
@@ -188,29 +188,29 @@ module Msf::Exploit::Remote::HTTP::Wordpress::Version
     if fixed_version.nil?
       if vuln_introduced_version.nil?
         # All versions are vulnerable
-        return Msf::Exploit::CheckCode::Appears
+        return Msf::Exploit::CheckCode::Appears(details:version)
       elsif Gem::Version.new(version) >= Gem::Version.new(vuln_introduced_version)
         # Newer or equal to the version it was introduced
-        return Msf::Exploit::CheckCode::Appears
+        return Msf::Exploit::CheckCode::Appears(details:version)
       else
-        return Msf::Exploit::CheckCode::Safe
+        return Msf::Exploit::CheckCode::Safe(details:version)
       end
     else
       # Version older than fixed version
       if Gem::Version.new(version) < Gem::Version.new(fixed_version)
         if vuln_introduced_version.nil?
           # Older than fixed version, no vuln introduction date, flag as vuln
-          return Msf::Exploit::CheckCode::Appears
+          return Msf::Exploit::CheckCode::Appears(details:version)
         # vuln_introduced_version provided, check if version is newer
         elsif Gem::Version.new(version) >= Gem::Version.new(vuln_introduced_version)
-          return Msf::Exploit::CheckCode::Appears
+          return Msf::Exploit::CheckCode::Appears(details:version)
         else
           # Not in range, nut vulnerable
-          return Msf::Exploit::CheckCode::Safe
+          return Msf::Exploit::CheckCode::Safe(details:version)
         end
       # version newer than fixed version
       else
-        return Msf::Exploit::CheckCode::Safe
+        return Msf::Exploit::CheckCode::Safe(details:version)
       end
     end
   rescue ArgumentError => e

--- a/modules/auxiliary/scanner/http/wordpress_scanner.rb
+++ b/modules/auxiliary/scanner/http/wordpress_scanner.rb
@@ -21,18 +21,20 @@ class MetasploitModule < Msf::Auxiliary
     register_options [
       OptBool.new('THEMES', [false, 'Detect themes', true]),
       OptBool.new('PLUGINS', [false, 'Detect plugins', true]),
-      OptPath.new('THEMES_FILE', [true, 'File containing themes to enumerate',
+      OptPath.new('THEMES_FILE', [
+        true, 'File containing themes to enumerate',
         File.join(Msf::Config.data_directory, 'wordlists', 'wp-themes.txt')
       ]),
-      OptPath.new('PLUGINS_FILE', [true, 'File containing plugins to enumerate',
+      OptPath.new('PLUGINS_FILE', [
+        true, 'File containing plugins to enumerate',
         File.join(Msf::Config.data_directory, 'wordlists', 'wp-plugins.txt')
       ]),
       OptInt.new('PROGRESS', [true, 'how often to print progress', 1000])
     ]
   end
 
-  def print_progress(i,total)
-    print_status("Progress #{i}/#{total} (#{((i.to_f/total) * 100).truncate(2)}%)")
+  def print_progress(i, total)
+    print_status("Progress #{i}/#{total} (#{((i.to_f / total) * 100).truncate(2)}%)")
   end
 
   def run_host(target_host)
@@ -53,7 +55,7 @@ class MetasploitModule < Msf::Auxiliary
       )
       if datastore['THEMES']
         print_status('Enumerating Themes')
-    
+
         f = File.open(datastore['THEMES_FILE'], 'rb')
         total = f.lines.count
         f.rewind
@@ -64,6 +66,7 @@ class MetasploitModule < Msf::Auxiliary
           vprint_status("Checking theme: #{theme}")
           version = check_theme_version_from_readme(theme)
           next if version == Msf::Exploit::CheckCode::Unknown # aka not found
+
           print_good("Detected Theme: #{theme} version #{version.details} ")
         end
       end
@@ -80,6 +83,7 @@ class MetasploitModule < Msf::Auxiliary
           vprint_status("Checking plugin: #{plugin}")
           version = check_plugin_version_from_readme(plugin)
           next if version == Msf::Exploit::CheckCode::Unknown # aka not found
+
           print_good("Detected Plugin: #{plugin} version #{version.details} ")
         end
       end

--- a/modules/auxiliary/scanner/http/wordpress_scanner.rb
+++ b/modules/auxiliary/scanner/http/wordpress_scanner.rb
@@ -10,28 +10,79 @@ class MetasploitModule < Msf::Auxiliary
 
   def initialize
     super(
-      'Name'        => 'Wordpress Scanner',
-      'Description' => 'Detects Wordpress installations and their version number',
-      'Author'      => [ 'Christian Mehlmauer' ],
-      'License'     => MSF_LICENSE
+      'Name' => 'Wordpress Scanner',
+      'Description' => 'Detects Wordpress Versions, Themes, and Plugins',
+      'Author' => [
+        'Christian Mehlmauer', # original module
+        'h00die' # plugins and themes
+      ],
+      'License' => MSF_LICENSE
     )
+    register_options [
+      OptBool.new('THEMES', [false, 'Detect themes', true]),
+      OptBool.new('PLUGINS', [false, 'Detect plugins', true]),
+      OptPath.new('THEMES_FILE', [true, 'File containing themes to enumerate',
+        File.join(Msf::Config.data_directory, 'wordlists', 'wp-themes.txt')
+      ]),
+      OptPath.new('PLUGINS_FILE', [true, 'File containing plugins to enumerate',
+        File.join(Msf::Config.data_directory, 'wordlists', 'wp-plugins.txt')
+      ]),
+      OptInt.new('PROGRESS', [true, 'how often to print progress', 1000])
+    ]
+  end
+
+  def print_progress(i,total)
+    print_status("Progress #{i}/#{total} (#{((i.to_f/total) * 100).truncate(2)}%)")
   end
 
   def run_host(target_host)
     print_status("Trying #{target_host}")
     if wordpress_and_online?
       version = wordpress_version
-      version_string = version ? version : '(no version detected)'
+      version_string = version || '(no version detected)'
       print_good("#{target_host} running Wordpress #{version_string}")
       report_note(
-          {
-              :host   => target_host,
-              :proto  => 'tcp',
-              :sname => (ssl ? 'https' : 'http'),
-              :port   => rport,
-              :type   => "Wordpress #{version_string}",
-              :data   => target_uri
-          })
+        {
+          host: target_host,
+          proto: 'tcp',
+          sname: (ssl ? 'https' : 'http'),
+          port: rport,
+          type: "Wordpress #{version_string}",
+          data: target_uri
+        }
+      )
+      if datastore['THEMES']
+        print_status('Enumerating Themes')
+    
+        f = File.open(datastore['THEMES_FILE'], 'rb')
+        total = f.lines.count
+        f.rewind
+        f = f.lines
+        f.each_with_index do |theme, i|
+          theme = theme.strip
+          print_progress(i, total) if i % datastore['PROGRESS'] == 0
+          vprint_status("Checking theme: #{theme}")
+          version = check_theme_version_from_readme(theme)
+          next if version == Msf::Exploit::CheckCode::Unknown # aka not found
+          print_good("Detected Theme: #{theme} version #{version.details} ")
+        end
+      end
+      if datastore['PLUGINS']
+        print_status('Enumerating Plugins')
+
+        f = File.open(datastore['PLUGINS_FILE'], 'rb')
+        total = f.lines.count
+        f.rewind
+        f = f.lines
+        f.each_with_index do |plugin, i|
+          plugin = plugin.strip
+          print_progress(i, total) if i % datastore['PROGRESS'] == 0
+          vprint_status("Checking plugin: #{plugin}")
+          version = check_plugin_version_from_readme(plugin)
+          next if version == Msf::Exploit::CheckCode::Unknown # aka not found
+          print_good("Detected Plugin: #{plugin} version #{version.details} ")
+        end
+      end
     end
   end
 end

--- a/spec/lib/msf/core/exploit/http/wordpress/version_spec.rb
+++ b/spec/lib/msf/core/exploit/http/wordpress/version_spec.rb
@@ -119,23 +119,23 @@ RSpec.describe Msf::Exploit::Remote::HTTP::Wordpress::Version do
       let(:wp_code) { 200 }
       let(:wp_fixed_version) { '1.0.1' }
       let(:wp_body) { 'stable tag:  1.0.0' }
-      it { expect(subject.send(:check_version_from_readme, :plugin, 'name', wp_fixed_version)).to eq(Msf::Exploit::CheckCode::Appears(details: '1.0.0')) }
+      it { expect(subject.send(:check_version_from_readme, :plugin, 'name', wp_fixed_version)).to eq(Msf::Exploit::CheckCode::Appears) }
       let(:wp_body) { 'stable tag:1.0.0' }
-      it { expect(subject.send(:check_version_from_readme, :plugin, 'name', wp_fixed_version)).to eq(Msf::Exploit::CheckCode::Appears(details: '1.0.0')) }
+      it { expect(subject.send(:check_version_from_readme, :plugin, 'name', wp_fixed_version)).to eq(Msf::Exploit::CheckCode::Appears) }
     end
 
     context 'when installed version is vulnerable' do
       let(:wp_code) { 200 }
       let(:wp_fixed_version) { '1.0.1' }
       let(:wp_body) { 'stable tag: 1.0.0' }
-      it { expect(subject.send(:check_version_from_readme, :plugin, 'name', wp_fixed_version)).to eq(Msf::Exploit::CheckCode::Appears(details: '1.0.0')) }
+      it { expect(subject.send(:check_version_from_readme, :plugin, 'name', wp_fixed_version)).to eq(Msf::Exploit::CheckCode::Appears) }
     end
 
     context 'when installed version is not vulnerable' do
       let(:wp_code) { 200 }
       let(:wp_fixed_version) { '1.0.1' }
       let(:wp_body) { 'stable tag: 1.0.2' }
-      it { expect(subject.send(:check_version_from_readme, :plugin, 'name', wp_fixed_version)).to eq(Msf::Exploit::CheckCode::Safe(details: '1.0.2')) }
+      it { expect(subject.send(:check_version_from_readme, :plugin, 'name', wp_fixed_version)).to eq(Msf::Exploit::CheckCode::Safe) }
     end
 
     context 'when installed version is vulnerable (version range)' do
@@ -143,7 +143,7 @@ RSpec.describe Msf::Exploit::Remote::HTTP::Wordpress::Version do
       let(:wp_fixed_version) { '1.0.2' }
       let(:wp_introd_version) { '1.0.0' }
       let(:wp_body) { 'stable tag: 1.0.1' }
-      it { expect(subject.send(:check_version_from_readme, :plugin, 'name', wp_fixed_version, wp_introd_version)).to eq(Msf::Exploit::CheckCode::Appears(details: '1.0.1')) }
+      it { expect(subject.send(:check_version_from_readme, :plugin, 'name', wp_fixed_version, wp_introd_version)).to eq(Msf::Exploit::CheckCode::Appears) }
     end
 
     context 'when installed version is older (version range)' do
@@ -151,7 +151,7 @@ RSpec.describe Msf::Exploit::Remote::HTTP::Wordpress::Version do
       let(:wp_fixed_version) { '1.0.1' }
       let(:wp_introd_version) { '1.0.0' }
       let(:wp_body) { 'stable tag: 0.0.9' }
-      it { expect(subject.send(:check_version_from_readme, :plugin, 'name', wp_fixed_version, wp_introd_version)).to eq(Msf::Exploit::CheckCode::Safe(details: '0.0.9')) }
+      it { expect(subject.send(:check_version_from_readme, :plugin, 'name', wp_fixed_version, wp_introd_version)).to eq(Msf::Exploit::CheckCode::Safe) }
     end
 
     context 'when installed version is newer (version range)' do
@@ -159,20 +159,20 @@ RSpec.describe Msf::Exploit::Remote::HTTP::Wordpress::Version do
       let(:wp_fixed_version) { '1.0.1' }
       let(:wp_introd_version) { '1.0.0' }
       let(:wp_body) { 'stable tag: 1.0.2' }
-      it { expect(subject.send(:check_version_from_readme, :plugin, 'name', wp_fixed_version, wp_introd_version)).to eq(Msf::Exploit::CheckCode::Safe(details: '1.0.2')) }
+      it { expect(subject.send(:check_version_from_readme, :plugin, 'name', wp_fixed_version, wp_introd_version)).to eq(Msf::Exploit::CheckCode::Safe) }
     end
 
     context 'when installed version is newer (text in version number)' do
       let(:wp_code) { 200 }
       let(:wp_fixed_version) { '1.5.3' }
       let(:wp_body) { 'Stable tag: 2.0.0-beta1' }
-      it { expect(subject.send(:check_version_from_readme, :plugin, 'name', wp_fixed_version)).to eq(Msf::Exploit::CheckCode::Safe(details: '2.0.0-beta1')) }
+      it { expect(subject.send(:check_version_from_readme, :plugin, 'name', wp_fixed_version)).to eq(Msf::Exploit::CheckCode::Safe) }
     end
 
     context 'when all versions are vulnerable' do
       let(:wp_code) { 200 }
       let(:wp_body) { 'Stable tag: 1.0.0' }
-      it { expect(subject.send(:check_version_from_readme, :plugin, 'name')).to eq(Msf::Exploit::CheckCode::Appears(details: '1.0.0')) }
+      it { expect(subject.send(:check_version_from_readme, :plugin, 'name')).to eq(Msf::Exploit::CheckCode::Appears) }
     end
 
     context 'when an error occurs when parsing the version' do
@@ -228,23 +228,23 @@ RSpec.describe Msf::Exploit::Remote::HTTP::Wordpress::Version do
       let(:wp_code) { 200 }
       let(:wp_fixed_version) { '1.0.1' }
       let(:wp_body) { 'Version:  1.0.0' }
-      it { expect(subject.send(:check_theme_version_from_style, 'name', wp_fixed_version)).to eq(Msf::Exploit::CheckCode::Appears(details: '1.0.0')) }
+      it { expect(subject.send(:check_theme_version_from_style, 'name', wp_fixed_version)).to eq(Msf::Exploit::CheckCode::Appears) }
       let(:wp_body) { 'Version:1.0.0' }
-      it { expect(subject.send(:check_theme_version_from_style, 'name', wp_fixed_version)).to eq(Msf::Exploit::CheckCode::Appears(details: '1.0.0')) }
+      it { expect(subject.send(:check_theme_version_from_style, 'name', wp_fixed_version)).to eq(Msf::Exploit::CheckCode::Appears) }
     end
 
     context 'when installed version is vulnerable' do
       let(:wp_code) { 200 }
       let(:wp_fixed_version) { '1.0.1' }
       let(:wp_body) { 'Version: 1.0.0' }
-      it { expect(subject.send(:check_theme_version_from_style, 'name', wp_fixed_version)).to eq(Msf::Exploit::CheckCode::Appears(details: '1.0.0')) }
+      it { expect(subject.send(:check_theme_version_from_style, 'name', wp_fixed_version)).to eq(Msf::Exploit::CheckCode::Appears) }
     end
 
     context 'when installed version is not vulnerable' do
       let(:wp_code) { 200 }
       let(:wp_fixed_version) { '1.0.1' }
       let(:wp_body) { 'Version: 1.0.2' }
-      it { expect(subject.send(:check_theme_version_from_style, 'name', wp_fixed_version)).to eq(Msf::Exploit::CheckCode::Safe(details: '1.0.2')) }
+      it { expect(subject.send(:check_theme_version_from_style, 'name', wp_fixed_version)).to eq(Msf::Exploit::CheckCode::Safe) }
     end
 
     context 'when installed version is vulnerable (version range)' do
@@ -252,7 +252,7 @@ RSpec.describe Msf::Exploit::Remote::HTTP::Wordpress::Version do
       let(:wp_fixed_version) { '1.0.2' }
       let(:wp_introd_version) { '1.0.0' }
       let(:wp_body) { 'Version: 1.0.1' }
-      it { expect(subject.send(:check_theme_version_from_style, 'name', wp_fixed_version, wp_introd_version)).to eq(Msf::Exploit::CheckCode::Appears(details: '1.0.1')) }
+      it { expect(subject.send(:check_theme_version_from_style, 'name', wp_fixed_version, wp_introd_version)).to eq(Msf::Exploit::CheckCode::Appears) }
     end
 
     context 'when installed version is older (version range)' do
@@ -260,7 +260,7 @@ RSpec.describe Msf::Exploit::Remote::HTTP::Wordpress::Version do
       let(:wp_fixed_version) { '1.0.1' }
       let(:wp_introd_version) { '1.0.0' }
       let(:wp_body) { 'Version: 0.0.9' }
-      it { expect(subject.send(:check_theme_version_from_style, 'name', wp_fixed_version, wp_introd_version)).to eq(Msf::Exploit::CheckCode::Safe(details: '0.0.9')) }
+      it { expect(subject.send(:check_theme_version_from_style, 'name', wp_fixed_version, wp_introd_version)).to eq(Msf::Exploit::CheckCode::Safe) }
     end
 
     context 'when installed version is newer (version range)' do
@@ -268,20 +268,20 @@ RSpec.describe Msf::Exploit::Remote::HTTP::Wordpress::Version do
       let(:wp_fixed_version) { '1.0.1' }
       let(:wp_introd_version) { '1.0.0' }
       let(:wp_body) { 'Version: 1.0.2' }
-      it { expect(subject.send(:check_theme_version_from_style, 'name', wp_fixed_version, wp_introd_version)).to eq(Msf::Exploit::CheckCode::Safe(details: '1.0.2')) }
+      it { expect(subject.send(:check_theme_version_from_style, 'name', wp_fixed_version, wp_introd_version)).to eq(Msf::Exploit::CheckCode::Safe) }
     end
 
     context 'when installed version is newer (text in version number)' do
       let(:wp_code) { 200 }
       let(:wp_fixed_version) { '1.5.3' }
       let(:wp_body) { 'Version: 2.0.0-beta1' }
-      it { expect(subject.send(:check_theme_version_from_style, 'name', wp_fixed_version)).to eq(Msf::Exploit::CheckCode::Safe(details: '2.0.0-beta1')) }
+      it { expect(subject.send(:check_theme_version_from_style, 'name', wp_fixed_version)).to eq(Msf::Exploit::CheckCode::Safe) }
     end
 
     context 'when all versions are vulnerable' do
       let(:wp_code) { 200 }
       let(:wp_body) { 'Version: 1.0.0' }
-      it { expect(subject.send(:check_theme_version_from_style, 'name')).to eq(Msf::Exploit::CheckCode::Appears(details: '1.0.0')) }
+      it { expect(subject.send(:check_theme_version_from_style, 'name')).to eq(Msf::Exploit::CheckCode::Appears) }
     end
 
     context 'when an error occurs when parsing the version' do
@@ -339,23 +339,23 @@ RSpec.describe Msf::Exploit::Remote::HTTP::Wordpress::Version do
       let(:wp_code) { 200 }
       let(:wp_fixed_version) { '1.0.1' }
       let(:wp_body) { 'Version:  1.0.0' }
-      it { expect(subject.send(:check_version_from_custom_file, wp_path, wp_regex, wp_fixed_version)).to eq(Msf::Exploit::CheckCode::Appears(details: '1.0.0')) }
+      it { expect(subject.send(:check_version_from_custom_file, wp_path, wp_regex, wp_fixed_version)).to eq(Msf::Exploit::CheckCode::Appears) }
       let(:wp_body) { 'Version:1.0.0' }
-      it { expect(subject.send(:check_version_from_custom_file, wp_path, wp_regex, wp_fixed_version)).to eq(Msf::Exploit::CheckCode::Appears(details: '1.0.0')) }
+      it { expect(subject.send(:check_version_from_custom_file, wp_path, wp_regex, wp_fixed_version)).to eq(Msf::Exploit::CheckCode::Appears) }
     end
 
     context 'when installed version is vulnerable' do
       let(:wp_code) { 200 }
       let(:wp_fixed_version) { '1.0.1' }
       let(:wp_body) { 'Version: 1.0.0' }
-      it { expect(subject.send(:check_version_from_custom_file, wp_path, wp_regex, wp_fixed_version)).to eq(Msf::Exploit::CheckCode::Appears(details: '1.0.0')) }
+      it { expect(subject.send(:check_version_from_custom_file, wp_path, wp_regex, wp_fixed_version)).to eq(Msf::Exploit::CheckCode::Appears) }
     end
 
     context 'when installed version is not vulnerable' do
       let(:wp_code) { 200 }
       let(:wp_fixed_version) { '1.0.1' }
       let(:wp_body) { 'Version: 1.0.2' }
-      it { expect(subject.send(:check_version_from_custom_file, wp_path, wp_regex, wp_fixed_version)).to eq(Msf::Exploit::CheckCode::Safe(details: '1.0.2')) }
+      it { expect(subject.send(:check_version_from_custom_file, wp_path, wp_regex, wp_fixed_version)).to eq(Msf::Exploit::CheckCode::Safe) }
     end
 
     context 'when installed version is vulnerable (version range)' do
@@ -363,7 +363,7 @@ RSpec.describe Msf::Exploit::Remote::HTTP::Wordpress::Version do
       let(:wp_fixed_version) { '1.0.2' }
       let(:wp_introd_version) { '1.0.0' }
       let(:wp_body) { 'Version: 1.0.1' }
-      it { expect(subject.send(:check_version_from_custom_file, wp_path, wp_regex, wp_fixed_version, wp_introd_version)).to eq(Msf::Exploit::CheckCode::Appears(details: '1.0.1')) }
+      it { expect(subject.send(:check_version_from_custom_file, wp_path, wp_regex, wp_fixed_version, wp_introd_version)).to eq(Msf::Exploit::CheckCode::Appears) }
     end
 
     context 'when installed version is older (version range)' do
@@ -371,7 +371,7 @@ RSpec.describe Msf::Exploit::Remote::HTTP::Wordpress::Version do
       let(:wp_fixed_version) { '1.0.1' }
       let(:wp_introd_version) { '1.0.0' }
       let(:wp_body) { 'Version: 0.0.9' }
-      it { expect(subject.send(:check_version_from_custom_file, wp_path, wp_regex, wp_fixed_version, wp_introd_version)).to eq(Msf::Exploit::CheckCode::Safe(details: '0.0.9')) }
+      it { expect(subject.send(:check_version_from_custom_file, wp_path, wp_regex, wp_fixed_version, wp_introd_version)).to eq(Msf::Exploit::CheckCode::Safe) }
     end
 
     context 'when installed version is newer (version range)' do
@@ -379,20 +379,20 @@ RSpec.describe Msf::Exploit::Remote::HTTP::Wordpress::Version do
       let(:wp_fixed_version) { '1.0.1' }
       let(:wp_introd_version) { '1.0.0' }
       let(:wp_body) { 'Version: 1.0.2' }
-      it { expect(subject.send(:check_version_from_custom_file, wp_path, wp_regex, wp_fixed_version, wp_introd_version)).to eq(Msf::Exploit::CheckCode::Safe(details: '1.0.2')) }
+      it { expect(subject.send(:check_version_from_custom_file, wp_path, wp_regex, wp_fixed_version, wp_introd_version)).to eq(Msf::Exploit::CheckCode::Safe) }
     end
 
     context 'when installed version is newer (text in version number)' do
       let(:wp_code) { 200 }
       let(:wp_fixed_version) { '1.5.3' }
       let(:wp_body) { 'Version: 2.0.0-beta1' }
-      it { expect(subject.send(:check_version_from_custom_file, wp_path, wp_regex, wp_fixed_version)).to eq(Msf::Exploit::CheckCode::Safe(details: '2.0.0-beta1')) }
+      it { expect(subject.send(:check_version_from_custom_file, wp_path, wp_regex, wp_fixed_version)).to eq(Msf::Exploit::CheckCode::Safe) }
     end
 
     context 'when all versions are vulnerable' do
       let(:wp_code) { 200 }
       let(:wp_body) { 'Version: 1.0.0' }
-      it { expect(subject.send(:check_version_from_custom_file, wp_path, wp_regex)).to eq(Msf::Exploit::CheckCode::Appears(details: '1.0.0')) }
+      it { expect(subject.send(:check_version_from_custom_file, wp_path, wp_regex)).to eq(Msf::Exploit::CheckCode::Appears) }
     end
 
     context 'when an error occurs when parsing the version' do

--- a/spec/lib/msf/core/exploit/http/wordpress/version_spec.rb
+++ b/spec/lib/msf/core/exploit/http/wordpress/version_spec.rb
@@ -119,23 +119,23 @@ RSpec.describe Msf::Exploit::Remote::HTTP::Wordpress::Version do
       let(:wp_code) { 200 }
       let(:wp_fixed_version) { '1.0.1' }
       let(:wp_body) { 'stable tag:  1.0.0' }
-      it { expect(subject.send(:check_version_from_readme, :plugin, 'name', wp_fixed_version)).to be(Msf::Exploit::CheckCode::Appears(details: '1.0.0')) }
+      it { expect(subject.send(:check_version_from_readme, :plugin, 'name', wp_fixed_version)).to eq(Msf::Exploit::CheckCode::Appears(details: '1.0.0')) }
       let(:wp_body) { 'stable tag:1.0.0' }
-      it { expect(subject.send(:check_version_from_readme, :plugin, 'name', wp_fixed_version)).to be(Msf::Exploit::CheckCode::Appears(details: '1.0.0')) }
+      it { expect(subject.send(:check_version_from_readme, :plugin, 'name', wp_fixed_version)).to eq(Msf::Exploit::CheckCode::Appears(details: '1.0.0')) }
     end
 
     context 'when installed version is vulnerable' do
       let(:wp_code) { 200 }
       let(:wp_fixed_version) { '1.0.1' }
       let(:wp_body) { 'stable tag: 1.0.0' }
-      it { expect(subject.send(:check_version_from_readme, :plugin, 'name', wp_fixed_version)).to be(Msf::Exploit::CheckCode::Appears(details: '1.0.0')) }
+      it { expect(subject.send(:check_version_from_readme, :plugin, 'name', wp_fixed_version)).to eq(Msf::Exploit::CheckCode::Appears(details: '1.0.0')) }
     end
 
     context 'when installed version is not vulnerable' do
       let(:wp_code) { 200 }
       let(:wp_fixed_version) { '1.0.1' }
       let(:wp_body) { 'stable tag: 1.0.2' }
-      it { expect(subject.send(:check_version_from_readme, :plugin, 'name', wp_fixed_version)).to be(Msf::Exploit::CheckCode::Safe(details: '1.0.2')) }
+      it { expect(subject.send(:check_version_from_readme, :plugin, 'name', wp_fixed_version)).to eq(Msf::Exploit::CheckCode::Safe(details: '1.0.2')) }
     end
 
     context 'when installed version is vulnerable (version range)' do
@@ -143,7 +143,7 @@ RSpec.describe Msf::Exploit::Remote::HTTP::Wordpress::Version do
       let(:wp_fixed_version) { '1.0.2' }
       let(:wp_introd_version) { '1.0.0' }
       let(:wp_body) { 'stable tag: 1.0.1' }
-      it { expect(subject.send(:check_version_from_readme, :plugin, 'name', wp_fixed_version, wp_introd_version)).to be(Msf::Exploit::CheckCode::Appears(details: '1.0.1')) }
+      it { expect(subject.send(:check_version_from_readme, :plugin, 'name', wp_fixed_version, wp_introd_version)).to eq(Msf::Exploit::CheckCode::Appears(details: '1.0.1')) }
     end
 
     context 'when installed version is older (version range)' do
@@ -151,7 +151,7 @@ RSpec.describe Msf::Exploit::Remote::HTTP::Wordpress::Version do
       let(:wp_fixed_version) { '1.0.1' }
       let(:wp_introd_version) { '1.0.0' }
       let(:wp_body) { 'stable tag: 0.0.9' }
-      it { expect(subject.send(:check_version_from_readme, :plugin, 'name', wp_fixed_version, wp_introd_version)).to be(Msf::Exploit::CheckCode::Safe(details: '0.0.9')) }
+      it { expect(subject.send(:check_version_from_readme, :plugin, 'name', wp_fixed_version, wp_introd_version)).to eq(Msf::Exploit::CheckCode::Safe(details: '0.0.9')) }
     end
 
     context 'when installed version is newer (version range)' do
@@ -159,20 +159,20 @@ RSpec.describe Msf::Exploit::Remote::HTTP::Wordpress::Version do
       let(:wp_fixed_version) { '1.0.1' }
       let(:wp_introd_version) { '1.0.0' }
       let(:wp_body) { 'stable tag: 1.0.2' }
-      it { expect(subject.send(:check_version_from_readme, :plugin, 'name', wp_fixed_version, wp_introd_version)).to be(Msf::Exploit::CheckCode::Safe(details: '1.0.2')) }
+      it { expect(subject.send(:check_version_from_readme, :plugin, 'name', wp_fixed_version, wp_introd_version)).to eq(Msf::Exploit::CheckCode::Safe(details: '1.0.2')) }
     end
 
     context 'when installed version is newer (text in version number)' do
       let(:wp_code) { 200 }
       let(:wp_fixed_version) { '1.5.3' }
       let(:wp_body) { 'Stable tag: 2.0.0-beta1' }
-      it { expect(subject.send(:check_version_from_readme, :plugin, 'name', wp_fixed_version)).to be(Msf::Exploit::CheckCode::Safe(details: '2.0.0-beta1')) }
+      it { expect(subject.send(:check_version_from_readme, :plugin, 'name', wp_fixed_version)).to eq(Msf::Exploit::CheckCode::Safe(details: '2.0.0-beta1')) }
     end
 
     context 'when all versions are vulnerable' do
       let(:wp_code) { 200 }
       let(:wp_body) { 'Stable tag: 1.0.0' }
-      it { expect(subject.send(:check_version_from_readme, :plugin, 'name')).to be(Msf::Exploit::CheckCode::Appears(details: '1.0.0')) }
+      it { expect(subject.send(:check_version_from_readme, :plugin, 'name')).to eq(Msf::Exploit::CheckCode::Appears(details: '1.0.0')) }
     end
 
     context 'when an error occurs when parsing the version' do
@@ -228,23 +228,23 @@ RSpec.describe Msf::Exploit::Remote::HTTP::Wordpress::Version do
       let(:wp_code) { 200 }
       let(:wp_fixed_version) { '1.0.1' }
       let(:wp_body) { 'Version:  1.0.0' }
-      it { expect(subject.send(:check_theme_version_from_style, 'name', wp_fixed_version)).to be(Msf::Exploit::CheckCode::Appears(details: '1.0.0')) }
+      it { expect(subject.send(:check_theme_version_from_style, 'name', wp_fixed_version)).to eq(Msf::Exploit::CheckCode::Appears(details: '1.0.0')) }
       let(:wp_body) { 'Version:1.0.0' }
-      it { expect(subject.send(:check_theme_version_from_style, 'name', wp_fixed_version)).to be(Msf::Exploit::CheckCode::Appears(details: '1.0.0')) }
+      it { expect(subject.send(:check_theme_version_from_style, 'name', wp_fixed_version)).to eq(Msf::Exploit::CheckCode::Appears(details: '1.0.0')) }
     end
 
     context 'when installed version is vulnerable' do
       let(:wp_code) { 200 }
       let(:wp_fixed_version) { '1.0.1' }
       let(:wp_body) { 'Version: 1.0.0' }
-      it { expect(subject.send(:check_theme_version_from_style, 'name', wp_fixed_version)).to be(Msf::Exploit::CheckCode::Appears(details: '1.0.0')) }
+      it { expect(subject.send(:check_theme_version_from_style, 'name', wp_fixed_version)).to eq(Msf::Exploit::CheckCode::Appears(details: '1.0.0')) }
     end
 
     context 'when installed version is not vulnerable' do
       let(:wp_code) { 200 }
       let(:wp_fixed_version) { '1.0.1' }
       let(:wp_body) { 'Version: 1.0.2' }
-      it { expect(subject.send(:check_theme_version_from_style, 'name', wp_fixed_version)).to be(Msf::Exploit::CheckCode::Safe(details: '1.0.2')) }
+      it { expect(subject.send(:check_theme_version_from_style, 'name', wp_fixed_version)).to eq(Msf::Exploit::CheckCode::Safe(details: '1.0.2')) }
     end
 
     context 'when installed version is vulnerable (version range)' do
@@ -252,7 +252,7 @@ RSpec.describe Msf::Exploit::Remote::HTTP::Wordpress::Version do
       let(:wp_fixed_version) { '1.0.2' }
       let(:wp_introd_version) { '1.0.0' }
       let(:wp_body) { 'Version: 1.0.1' }
-      it { expect(subject.send(:check_theme_version_from_style, 'name', wp_fixed_version, wp_introd_version)).to be(Msf::Exploit::CheckCode::Appears(details: '1.0.1')) }
+      it { expect(subject.send(:check_theme_version_from_style, 'name', wp_fixed_version, wp_introd_version)).to eq(Msf::Exploit::CheckCode::Appears(details: '1.0.1')) }
     end
 
     context 'when installed version is older (version range)' do
@@ -260,7 +260,7 @@ RSpec.describe Msf::Exploit::Remote::HTTP::Wordpress::Version do
       let(:wp_fixed_version) { '1.0.1' }
       let(:wp_introd_version) { '1.0.0' }
       let(:wp_body) { 'Version: 0.0.9' }
-      it { expect(subject.send(:check_theme_version_from_style, 'name', wp_fixed_version, wp_introd_version)).to be(Msf::Exploit::CheckCode::Safe(details: '0.0.9')) }
+      it { expect(subject.send(:check_theme_version_from_style, 'name', wp_fixed_version, wp_introd_version)).to eq(Msf::Exploit::CheckCode::Safe(details: '0.0.9')) }
     end
 
     context 'when installed version is newer (version range)' do
@@ -268,20 +268,20 @@ RSpec.describe Msf::Exploit::Remote::HTTP::Wordpress::Version do
       let(:wp_fixed_version) { '1.0.1' }
       let(:wp_introd_version) { '1.0.0' }
       let(:wp_body) { 'Version: 1.0.2' }
-      it { expect(subject.send(:check_theme_version_from_style, 'name', wp_fixed_version, wp_introd_version)).to be(Msf::Exploit::CheckCode::Safe(details: '1.0.2')) }
+      it { expect(subject.send(:check_theme_version_from_style, 'name', wp_fixed_version, wp_introd_version)).to eq(Msf::Exploit::CheckCode::Safe(details: '1.0.2')) }
     end
 
     context 'when installed version is newer (text in version number)' do
       let(:wp_code) { 200 }
       let(:wp_fixed_version) { '1.5.3' }
       let(:wp_body) { 'Version: 2.0.0-beta1' }
-      it { expect(subject.send(:check_theme_version_from_style, 'name', wp_fixed_version)).to be(Msf::Exploit::CheckCode::Safe(details: '2.0.0-beta1')) }
+      it { expect(subject.send(:check_theme_version_from_style, 'name', wp_fixed_version)).to eq(Msf::Exploit::CheckCode::Safe(details: '2.0.0-beta1')) }
     end
 
     context 'when all versions are vulnerable' do
       let(:wp_code) { 200 }
       let(:wp_body) { 'Version: 1.0.0' }
-      it { expect(subject.send(:check_theme_version_from_style, 'name')).to be(Msf::Exploit::CheckCode::Appears(details: '1.0.0')) }
+      it { expect(subject.send(:check_theme_version_from_style, 'name')).to eq(Msf::Exploit::CheckCode::Appears(details: '1.0.0')) }
     end
 
     context 'when an error occurs when parsing the version' do
@@ -339,23 +339,23 @@ RSpec.describe Msf::Exploit::Remote::HTTP::Wordpress::Version do
       let(:wp_code) { 200 }
       let(:wp_fixed_version) { '1.0.1' }
       let(:wp_body) { 'Version:  1.0.0' }
-      it { expect(subject.send(:check_version_from_custom_file, wp_path, wp_regex, wp_fixed_version)).to be(Msf::Exploit::CheckCode::Appears(details: '1.0.0')) }
+      it { expect(subject.send(:check_version_from_custom_file, wp_path, wp_regex, wp_fixed_version)).to eq(Msf::Exploit::CheckCode::Appears(details: '1.0.0')) }
       let(:wp_body) { 'Version:1.0.0' }
-      it { expect(subject.send(:check_version_from_custom_file, wp_path, wp_regex, wp_fixed_version)).to be(Msf::Exploit::CheckCode::Appears(details: '1.0.0')) }
+      it { expect(subject.send(:check_version_from_custom_file, wp_path, wp_regex, wp_fixed_version)).to eq(Msf::Exploit::CheckCode::Appears(details: '1.0.0')) }
     end
 
     context 'when installed version is vulnerable' do
       let(:wp_code) { 200 }
       let(:wp_fixed_version) { '1.0.1' }
       let(:wp_body) { 'Version: 1.0.0' }
-      it { expect(subject.send(:check_version_from_custom_file, wp_path, wp_regex, wp_fixed_version)).to be(Msf::Exploit::CheckCode::Appears(details: '1.0.0')) }
+      it { expect(subject.send(:check_version_from_custom_file, wp_path, wp_regex, wp_fixed_version)).to eq(Msf::Exploit::CheckCode::Appears(details: '1.0.0')) }
     end
 
     context 'when installed version is not vulnerable' do
       let(:wp_code) { 200 }
       let(:wp_fixed_version) { '1.0.1' }
       let(:wp_body) { 'Version: 1.0.2' }
-      it { expect(subject.send(:check_version_from_custom_file, wp_path, wp_regex, wp_fixed_version)).to be(Msf::Exploit::CheckCode::Safe(details: '1.0.2')) }
+      it { expect(subject.send(:check_version_from_custom_file, wp_path, wp_regex, wp_fixed_version)).to eq(Msf::Exploit::CheckCode::Safe(details: '1.0.2')) }
     end
 
     context 'when installed version is vulnerable (version range)' do
@@ -363,7 +363,7 @@ RSpec.describe Msf::Exploit::Remote::HTTP::Wordpress::Version do
       let(:wp_fixed_version) { '1.0.2' }
       let(:wp_introd_version) { '1.0.0' }
       let(:wp_body) { 'Version: 1.0.1' }
-      it { expect(subject.send(:check_version_from_custom_file, wp_path, wp_regex, wp_fixed_version, wp_introd_version)).to be(Msf::Exploit::CheckCode::Appears(details: '1.0.1')) }
+      it { expect(subject.send(:check_version_from_custom_file, wp_path, wp_regex, wp_fixed_version, wp_introd_version)).to eq(Msf::Exploit::CheckCode::Appears(details: '1.0.1')) }
     end
 
     context 'when installed version is older (version range)' do
@@ -371,7 +371,7 @@ RSpec.describe Msf::Exploit::Remote::HTTP::Wordpress::Version do
       let(:wp_fixed_version) { '1.0.1' }
       let(:wp_introd_version) { '1.0.0' }
       let(:wp_body) { 'Version: 0.0.9' }
-      it { expect(subject.send(:check_version_from_custom_file, wp_path, wp_regex, wp_fixed_version, wp_introd_version)).to be(Msf::Exploit::CheckCode::Safe(details: '0.0.9')) }
+      it { expect(subject.send(:check_version_from_custom_file, wp_path, wp_regex, wp_fixed_version, wp_introd_version)).to eq(Msf::Exploit::CheckCode::Safe(details: '0.0.9')) }
     end
 
     context 'when installed version is newer (version range)' do
@@ -379,20 +379,20 @@ RSpec.describe Msf::Exploit::Remote::HTTP::Wordpress::Version do
       let(:wp_fixed_version) { '1.0.1' }
       let(:wp_introd_version) { '1.0.0' }
       let(:wp_body) { 'Version: 1.0.2' }
-      it { expect(subject.send(:check_version_from_custom_file, wp_path, wp_regex, wp_fixed_version, wp_introd_version)).to be(Msf::Exploit::CheckCode::Safe(details: '1.0.2')) }
+      it { expect(subject.send(:check_version_from_custom_file, wp_path, wp_regex, wp_fixed_version, wp_introd_version)).to eq(Msf::Exploit::CheckCode::Safe(details: '1.0.2')) }
     end
 
     context 'when installed version is newer (text in version number)' do
       let(:wp_code) { 200 }
       let(:wp_fixed_version) { '1.5.3' }
       let(:wp_body) { 'Version: 2.0.0-beta1' }
-      it { expect(subject.send(:check_version_from_custom_file, wp_path, wp_regex, wp_fixed_version)).to be(Msf::Exploit::CheckCode::Safe(details: '2.0.0-beta1')) }
+      it { expect(subject.send(:check_version_from_custom_file, wp_path, wp_regex, wp_fixed_version)).to eq(Msf::Exploit::CheckCode::Safe(details: '2.0.0-beta1')) }
     end
 
     context 'when all versions are vulnerable' do
       let(:wp_code) { 200 }
       let(:wp_body) { 'Version: 1.0.0' }
-      it { expect(subject.send(:check_version_from_custom_file, wp_path, wp_regex)).to be(Msf::Exploit::CheckCode::Appears(details: '1.0.0')) }
+      it { expect(subject.send(:check_version_from_custom_file, wp_path, wp_regex)).to eq(Msf::Exploit::CheckCode::Appears(details: '1.0.0')) }
     end
 
     context 'when an error occurs when parsing the version' do

--- a/spec/lib/msf/core/exploit/http/wordpress/version_spec.rb
+++ b/spec/lib/msf/core/exploit/http/wordpress/version_spec.rb
@@ -119,23 +119,23 @@ RSpec.describe Msf::Exploit::Remote::HTTP::Wordpress::Version do
       let(:wp_code) { 200 }
       let(:wp_fixed_version) { '1.0.1' }
       let(:wp_body) { 'stable tag:  1.0.0' }
-      it { expect(subject.send(:check_version_from_readme, :plugin, 'name', wp_fixed_version)).to be(Msf::Exploit::CheckCode::Appears) }
+      it { expect(subject.send(:check_version_from_readme, :plugin, 'name', wp_fixed_version)).to be(Msf::Exploit::CheckCode::Appears(details: '1.0.0')) }
       let(:wp_body) { 'stable tag:1.0.0' }
-      it { expect(subject.send(:check_version_from_readme, :plugin, 'name', wp_fixed_version)).to be(Msf::Exploit::CheckCode::Appears) }
+      it { expect(subject.send(:check_version_from_readme, :plugin, 'name', wp_fixed_version)).to be(Msf::Exploit::CheckCode::Appears(details: '1.0.0')) }
     end
 
     context 'when installed version is vulnerable' do
       let(:wp_code) { 200 }
       let(:wp_fixed_version) { '1.0.1' }
       let(:wp_body) { 'stable tag: 1.0.0' }
-      it { expect(subject.send(:check_version_from_readme, :plugin, 'name', wp_fixed_version)).to be(Msf::Exploit::CheckCode::Appears) }
+      it { expect(subject.send(:check_version_from_readme, :plugin, 'name', wp_fixed_version)).to be(Msf::Exploit::CheckCode::Appears(details: '1.0.0')) }
     end
 
     context 'when installed version is not vulnerable' do
       let(:wp_code) { 200 }
       let(:wp_fixed_version) { '1.0.1' }
       let(:wp_body) { 'stable tag: 1.0.2' }
-      it { expect(subject.send(:check_version_from_readme, :plugin, 'name', wp_fixed_version)).to be(Msf::Exploit::CheckCode::Safe) }
+      it { expect(subject.send(:check_version_from_readme, :plugin, 'name', wp_fixed_version)).to be(Msf::Exploit::CheckCode::Safe(details: '1.0.2')) }
     end
 
     context 'when installed version is vulnerable (version range)' do
@@ -143,7 +143,7 @@ RSpec.describe Msf::Exploit::Remote::HTTP::Wordpress::Version do
       let(:wp_fixed_version) { '1.0.2' }
       let(:wp_introd_version) { '1.0.0' }
       let(:wp_body) { 'stable tag: 1.0.1' }
-      it { expect(subject.send(:check_version_from_readme, :plugin, 'name', wp_fixed_version, wp_introd_version)).to be(Msf::Exploit::CheckCode::Appears) }
+      it { expect(subject.send(:check_version_from_readme, :plugin, 'name', wp_fixed_version, wp_introd_version)).to be(Msf::Exploit::CheckCode::Appears(details: '1.0.1')) }
     end
 
     context 'when installed version is older (version range)' do
@@ -151,7 +151,7 @@ RSpec.describe Msf::Exploit::Remote::HTTP::Wordpress::Version do
       let(:wp_fixed_version) { '1.0.1' }
       let(:wp_introd_version) { '1.0.0' }
       let(:wp_body) { 'stable tag: 0.0.9' }
-      it { expect(subject.send(:check_version_from_readme, :plugin, 'name', wp_fixed_version, wp_introd_version)).to be(Msf::Exploit::CheckCode::Safe) }
+      it { expect(subject.send(:check_version_from_readme, :plugin, 'name', wp_fixed_version, wp_introd_version)).to be(Msf::Exploit::CheckCode::Safe(details: '0.0.9')) }
     end
 
     context 'when installed version is newer (version range)' do
@@ -159,20 +159,20 @@ RSpec.describe Msf::Exploit::Remote::HTTP::Wordpress::Version do
       let(:wp_fixed_version) { '1.0.1' }
       let(:wp_introd_version) { '1.0.0' }
       let(:wp_body) { 'stable tag: 1.0.2' }
-      it { expect(subject.send(:check_version_from_readme, :plugin, 'name', wp_fixed_version, wp_introd_version)).to be(Msf::Exploit::CheckCode::Safe) }
+      it { expect(subject.send(:check_version_from_readme, :plugin, 'name', wp_fixed_version, wp_introd_version)).to be(Msf::Exploit::CheckCode::Safe(details: '1.0.2')) }
     end
 
     context 'when installed version is newer (text in version number)' do
       let(:wp_code) { 200 }
       let(:wp_fixed_version) { '1.5.3' }
       let(:wp_body) { 'Stable tag: 2.0.0-beta1' }
-      it { expect(subject.send(:check_version_from_readme, :plugin, 'name', wp_fixed_version)).to be(Msf::Exploit::CheckCode::Safe) }
+      it { expect(subject.send(:check_version_from_readme, :plugin, 'name', wp_fixed_version)).to be(Msf::Exploit::CheckCode::Safe(details: '2.0.0-beta1')) }
     end
 
     context 'when all versions are vulnerable' do
       let(:wp_code) { 200 }
       let(:wp_body) { 'Stable tag: 1.0.0' }
-      it { expect(subject.send(:check_version_from_readme, :plugin, 'name')).to be(Msf::Exploit::CheckCode::Appears) }
+      it { expect(subject.send(:check_version_from_readme, :plugin, 'name')).to be(Msf::Exploit::CheckCode::Appears(details: '1.0.0')) }
     end
 
     context 'when an error occurs when parsing the version' do
@@ -228,23 +228,23 @@ RSpec.describe Msf::Exploit::Remote::HTTP::Wordpress::Version do
       let(:wp_code) { 200 }
       let(:wp_fixed_version) { '1.0.1' }
       let(:wp_body) { 'Version:  1.0.0' }
-      it { expect(subject.send(:check_theme_version_from_style, 'name', wp_fixed_version)).to be(Msf::Exploit::CheckCode::Appears) }
+      it { expect(subject.send(:check_theme_version_from_style, 'name', wp_fixed_version)).to be(Msf::Exploit::CheckCode::Appears(details: '1.0.0')) }
       let(:wp_body) { 'Version:1.0.0' }
-      it { expect(subject.send(:check_theme_version_from_style, 'name', wp_fixed_version)).to be(Msf::Exploit::CheckCode::Appears) }
+      it { expect(subject.send(:check_theme_version_from_style, 'name', wp_fixed_version)).to be(Msf::Exploit::CheckCode::Appears(details: '1.0.0')) }
     end
 
     context 'when installed version is vulnerable' do
       let(:wp_code) { 200 }
       let(:wp_fixed_version) { '1.0.1' }
       let(:wp_body) { 'Version: 1.0.0' }
-      it { expect(subject.send(:check_theme_version_from_style, 'name', wp_fixed_version)).to be(Msf::Exploit::CheckCode::Appears) }
+      it { expect(subject.send(:check_theme_version_from_style, 'name', wp_fixed_version)).to be(Msf::Exploit::CheckCode::Appears(details: '1.0.0')) }
     end
 
     context 'when installed version is not vulnerable' do
       let(:wp_code) { 200 }
       let(:wp_fixed_version) { '1.0.1' }
       let(:wp_body) { 'Version: 1.0.2' }
-      it { expect(subject.send(:check_theme_version_from_style, 'name', wp_fixed_version)).to be(Msf::Exploit::CheckCode::Safe) }
+      it { expect(subject.send(:check_theme_version_from_style, 'name', wp_fixed_version)).to be(Msf::Exploit::CheckCode::Safe(details: '1.0.2')) }
     end
 
     context 'when installed version is vulnerable (version range)' do
@@ -252,7 +252,7 @@ RSpec.describe Msf::Exploit::Remote::HTTP::Wordpress::Version do
       let(:wp_fixed_version) { '1.0.2' }
       let(:wp_introd_version) { '1.0.0' }
       let(:wp_body) { 'Version: 1.0.1' }
-      it { expect(subject.send(:check_theme_version_from_style, 'name', wp_fixed_version, wp_introd_version)).to be(Msf::Exploit::CheckCode::Appears) }
+      it { expect(subject.send(:check_theme_version_from_style, 'name', wp_fixed_version, wp_introd_version)).to be(Msf::Exploit::CheckCode::Appears(details: '1.0.1')) }
     end
 
     context 'when installed version is older (version range)' do
@@ -260,7 +260,7 @@ RSpec.describe Msf::Exploit::Remote::HTTP::Wordpress::Version do
       let(:wp_fixed_version) { '1.0.1' }
       let(:wp_introd_version) { '1.0.0' }
       let(:wp_body) { 'Version: 0.0.9' }
-      it { expect(subject.send(:check_theme_version_from_style, 'name', wp_fixed_version, wp_introd_version)).to be(Msf::Exploit::CheckCode::Safe) }
+      it { expect(subject.send(:check_theme_version_from_style, 'name', wp_fixed_version, wp_introd_version)).to be(Msf::Exploit::CheckCode::Safe(details: '0.0.9')) }
     end
 
     context 'when installed version is newer (version range)' do
@@ -268,20 +268,20 @@ RSpec.describe Msf::Exploit::Remote::HTTP::Wordpress::Version do
       let(:wp_fixed_version) { '1.0.1' }
       let(:wp_introd_version) { '1.0.0' }
       let(:wp_body) { 'Version: 1.0.2' }
-      it { expect(subject.send(:check_theme_version_from_style, 'name', wp_fixed_version, wp_introd_version)).to be(Msf::Exploit::CheckCode::Safe) }
+      it { expect(subject.send(:check_theme_version_from_style, 'name', wp_fixed_version, wp_introd_version)).to be(Msf::Exploit::CheckCode::Safe(details: '1.0.2')) }
     end
 
     context 'when installed version is newer (text in version number)' do
       let(:wp_code) { 200 }
       let(:wp_fixed_version) { '1.5.3' }
       let(:wp_body) { 'Version: 2.0.0-beta1' }
-      it { expect(subject.send(:check_theme_version_from_style, 'name', wp_fixed_version)).to be(Msf::Exploit::CheckCode::Safe) }
+      it { expect(subject.send(:check_theme_version_from_style, 'name', wp_fixed_version)).to be(Msf::Exploit::CheckCode::Safe(details: '2.0.0-beta1')) }
     end
 
     context 'when all versions are vulnerable' do
       let(:wp_code) { 200 }
       let(:wp_body) { 'Version: 1.0.0' }
-      it { expect(subject.send(:check_theme_version_from_style, 'name')).to be(Msf::Exploit::CheckCode::Appears) }
+      it { expect(subject.send(:check_theme_version_from_style, 'name')).to be(Msf::Exploit::CheckCode::Appears(details: '1.0.0')) }
     end
 
     context 'when an error occurs when parsing the version' do
@@ -339,23 +339,23 @@ RSpec.describe Msf::Exploit::Remote::HTTP::Wordpress::Version do
       let(:wp_code) { 200 }
       let(:wp_fixed_version) { '1.0.1' }
       let(:wp_body) { 'Version:  1.0.0' }
-      it { expect(subject.send(:check_version_from_custom_file, wp_path, wp_regex, wp_fixed_version)).to be(Msf::Exploit::CheckCode::Appears) }
+      it { expect(subject.send(:check_version_from_custom_file, wp_path, wp_regex, wp_fixed_version)).to be(Msf::Exploit::CheckCode::Appears(details: '1.0.0')) }
       let(:wp_body) { 'Version:1.0.0' }
-      it { expect(subject.send(:check_version_from_custom_file, wp_path, wp_regex, wp_fixed_version)).to be(Msf::Exploit::CheckCode::Appears) }
+      it { expect(subject.send(:check_version_from_custom_file, wp_path, wp_regex, wp_fixed_version)).to be(Msf::Exploit::CheckCode::Appears(details: '1.0.0')) }
     end
 
     context 'when installed version is vulnerable' do
       let(:wp_code) { 200 }
       let(:wp_fixed_version) { '1.0.1' }
       let(:wp_body) { 'Version: 1.0.0' }
-      it { expect(subject.send(:check_version_from_custom_file, wp_path, wp_regex, wp_fixed_version)).to be(Msf::Exploit::CheckCode::Appears) }
+      it { expect(subject.send(:check_version_from_custom_file, wp_path, wp_regex, wp_fixed_version)).to be(Msf::Exploit::CheckCode::Appears(details: '1.0.0')) }
     end
 
     context 'when installed version is not vulnerable' do
       let(:wp_code) { 200 }
       let(:wp_fixed_version) { '1.0.1' }
       let(:wp_body) { 'Version: 1.0.2' }
-      it { expect(subject.send(:check_version_from_custom_file, wp_path, wp_regex, wp_fixed_version)).to be(Msf::Exploit::CheckCode::Safe) }
+      it { expect(subject.send(:check_version_from_custom_file, wp_path, wp_regex, wp_fixed_version)).to be(Msf::Exploit::CheckCode::Safe(details: '1.0.2')) }
     end
 
     context 'when installed version is vulnerable (version range)' do
@@ -363,7 +363,7 @@ RSpec.describe Msf::Exploit::Remote::HTTP::Wordpress::Version do
       let(:wp_fixed_version) { '1.0.2' }
       let(:wp_introd_version) { '1.0.0' }
       let(:wp_body) { 'Version: 1.0.1' }
-      it { expect(subject.send(:check_version_from_custom_file, wp_path, wp_regex, wp_fixed_version, wp_introd_version)).to be(Msf::Exploit::CheckCode::Appears) }
+      it { expect(subject.send(:check_version_from_custom_file, wp_path, wp_regex, wp_fixed_version, wp_introd_version)).to be(Msf::Exploit::CheckCode::Appears(details: '1.0.1')) }
     end
 
     context 'when installed version is older (version range)' do
@@ -371,7 +371,7 @@ RSpec.describe Msf::Exploit::Remote::HTTP::Wordpress::Version do
       let(:wp_fixed_version) { '1.0.1' }
       let(:wp_introd_version) { '1.0.0' }
       let(:wp_body) { 'Version: 0.0.9' }
-      it { expect(subject.send(:check_version_from_custom_file, wp_path, wp_regex, wp_fixed_version, wp_introd_version)).to be(Msf::Exploit::CheckCode::Safe) }
+      it { expect(subject.send(:check_version_from_custom_file, wp_path, wp_regex, wp_fixed_version, wp_introd_version)).to be(Msf::Exploit::CheckCode::Safe(details: '0.0.9')) }
     end
 
     context 'when installed version is newer (version range)' do
@@ -379,20 +379,20 @@ RSpec.describe Msf::Exploit::Remote::HTTP::Wordpress::Version do
       let(:wp_fixed_version) { '1.0.1' }
       let(:wp_introd_version) { '1.0.0' }
       let(:wp_body) { 'Version: 1.0.2' }
-      it { expect(subject.send(:check_version_from_custom_file, wp_path, wp_regex, wp_fixed_version, wp_introd_version)).to be(Msf::Exploit::CheckCode::Safe) }
+      it { expect(subject.send(:check_version_from_custom_file, wp_path, wp_regex, wp_fixed_version, wp_introd_version)).to be(Msf::Exploit::CheckCode::Safe(details: '1.0.2')) }
     end
 
     context 'when installed version is newer (text in version number)' do
       let(:wp_code) { 200 }
       let(:wp_fixed_version) { '1.5.3' }
       let(:wp_body) { 'Version: 2.0.0-beta1' }
-      it { expect(subject.send(:check_version_from_custom_file, wp_path, wp_regex, wp_fixed_version)).to be(Msf::Exploit::CheckCode::Safe) }
+      it { expect(subject.send(:check_version_from_custom_file, wp_path, wp_regex, wp_fixed_version)).to be(Msf::Exploit::CheckCode::Safe(details: '2.0.0-beta1')) }
     end
 
     context 'when all versions are vulnerable' do
       let(:wp_code) { 200 }
       let(:wp_body) { 'Version: 1.0.0' }
-      it { expect(subject.send(:check_version_from_custom_file, wp_path, wp_regex)).to be(Msf::Exploit::CheckCode::Appears) }
+      it { expect(subject.send(:check_version_from_custom_file, wp_path, wp_regex)).to be(Msf::Exploit::CheckCode::Appears(details: '1.0.0')) }
     end
 
     context 'when an error occurs when parsing the version' do


### PR DESCRIPTION
Remember that time in #14419 where we added updates to `wp-plugins.txt` and `wp-themes.txt`?  Yea, well:

```
me@kali:/metasploit-framework/modules$ grep -R 'wp-themes.txt' *
me@kali:/metasploit-framework/modules$ grep -R 'wp-plugins.txt' *
```
We have these files, which are huge, and aren't used.  Instead of removing them, lets use them!

This PR updates `wordpress_scanner` to also enumerate themes and plugins.  It also modifies the theme/plugin version wordpress lib to return the version in the details thanks to #14294 .  Also a rubocop, and msftidy_docs.

## Verification

- [x] Install wordpress, add a theme or plugin if you wish
- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/http/wordpress_version`
- [x] `set rhosts [ip]`
- [x] `run`
- [x] **Verify** it still works to find the version
- [x] **Verify** it now also finds plugins and themes


Is it worth adding a note? The version part does that, I was 50/50 if it was worth the effort, not sure many people actually use notes.  I'll take input.