### PR TITLE
refactor test for ruby 2.7 deprecations

### DIFF
--- a/spec/support/shared/examples/msf/db_manager/import/metasploit_framework/xml.rb
+++ b/spec/support/shared/examples/msf/db_manager/import/metasploit_framework/xml.rb
@@ -95,7 +95,7 @@ RSpec.shared_examples_for 'Msf::DBManager::Import::MetasploitFramework::XML' do
 
   context 'CONSTANTS' do
     it 'should define MSF_WEB_PAGE_TEXT_ELEMENT_NAMES in any order' do
-      described_class::MSF_WEB_PAGE_TEXT_ELEMENT_NAMES =~ [
+      expected_keys = [
           'auth',
           'body',
           'code',
@@ -104,14 +104,15 @@ RSpec.shared_examples_for 'Msf::DBManager::Import::MetasploitFramework::XML' do
           'location',
           'mtime'
       ]
+      expect(described_class::MSF_WEB_PAGE_TEXT_ELEMENT_NAMES).to match_array(expected_keys)
     end
 
     it 'should define MSF_WEB_TEXT_ELEMENT_NAMES in any order' do
-      described_class::MSF_WEB_TEXT_ELEMENT_NAMES =~ msf_web_text_element_names
+      expect(described_class::MSF_WEB_TEXT_ELEMENT_NAMES).to match_array(msf_web_text_element_names)
     end
 
     it 'should define MSF_WEB_VULN_TEXT_ELEMENT_NAMES in any order' do
-      described_class::MSF_WEB_VULN_TEXT_ELEMENT_NAMES =~ [
+      expected_keys = [
           'blame',
           'category',
           'confidence',
@@ -122,6 +123,7 @@ RSpec.shared_examples_for 'Msf::DBManager::Import::MetasploitFramework::XML' do
           'proof',
           'risk'
       ]
+      expect(described_class::MSF_WEB_VULN_TEXT_ELEMENT_NAMES).to match_array(expected_keys)
     end
   end
 


### PR DESCRIPTION
addresses `warning: deprecated Object#=~ is called on Array; it always returns nil`

Simply use rspec comparisons in place of `=~` for array check. 

## Verification

List the steps needed to make sure this thing works

- [ ] Travis tests pass for all supported Ruby versions