### PR TITLE
Fix typo in modules/exploits/windows/local/bypassuac module

### DIFF
--- a/modules/exploits/windows/local/bypassuac_comhijack.rb
+++ b/modules/exploits/windows/local/bypassuac_comhijack.rb
@@ -113,7 +113,7 @@ class MetasploitModule < Msf::Exploit::Local
       args << " #{hijack[:cmd_args]}" if hijack[:cmd_args]
 
       # Launch the application from cmd.exe instead of directly so that we can
-      # avoid the dreaded 740 error (elevation requried)
+      # avoid the dreaded 740 error (elevation required)
       client.sys.process.execute(commspec, args, {'Hidden' => true})
 
       # Wait a copule of seconds to give the payload a chance to fire before cleaning up

--- a/modules/exploits/windows/local/bypassuac_comhijack.rb
+++ b/modules/exploits/windows/local/bypassuac_comhijack.rb
@@ -122,7 +122,7 @@ class MetasploitModule < Msf::Exploit::Local
       handler(client)
 
     ensure
-      print_status("Cleaining up registry ...")
+      print_status("Cleaning up registry ...")
       registry_deletekey(hijack[:root_key], registry_view)
     end
   end


### PR DESCRIPTION
Correct small typo of the module exploits/windows/local/bypassuac_comhijack in the output to the msfconsole.