### PR TITLE
Adds a fix for frozen string crash when using `reload_all`

### DIFF
--- a/lib/msf/core/modules/metadata/obj.rb
+++ b/lib/msf/core/modules/metadata/obj.rb
@@ -203,11 +203,11 @@ class Obj
   end
 
   def force_encoding(encoding)
-    @name.force_encoding(encoding)
-    @fullname.force_encoding(encoding)
-    @description.force_encoding(encoding)
-    @author.each {|a| a.force_encoding(encoding)}
-    @references.each {|r| r.force_encoding(encoding)}
+    @name = @name.dup.force_encoding(encoding)
+    @fullname = @fullname.dup.force_encoding(encoding)
+    @description = @description.dup.force_encoding(encoding)
+    @author = @author.each {|a| a.dup.force_encoding(encoding)}
+    @references = @references.each {|r| r.dup.force_encoding(encoding)}
   end
 
 end

--- a/lib/msf/core/modules/metadata/obj.rb
+++ b/lib/msf/core/modules/metadata/obj.rb
@@ -206,8 +206,8 @@ class Obj
     @name = @name.dup.force_encoding(encoding)
     @fullname = @fullname.dup.force_encoding(encoding)
     @description = @description.dup.force_encoding(encoding)
-    @author = @author.each {|a| a.dup.force_encoding(encoding)}
-    @references = @references.each {|r| r.dup.force_encoding(encoding)}
+    @author = @author.map {|a| a.dup.force_encoding(encoding)}
+    @references = @references.map {|r| r.dup.force_encoding(encoding)}
   end
 
 end


### PR DESCRIPTION
This issue was brought to light after landing https://github.com/rapid7/metasploit-framework/pull/14264 and just wanted to reference it here for future travellers.
 
When landing/testing this PR several days ago I didn't come across this bug, @dwelch-r7 found it when using the `reload_all` command.

When running the `reload_all` command. The following error was returned:
```
[*] Reloading modules from all module paths...
[-] Error while running command reload_all: can't modify frozen String: "Kong Gateway Admin API Remote Code Execution"
```

This was due to the ```force_encoding(encoding)``` method trying to encode strings in a module that had ```# frozen_string_literal: true``` present. 

The fix adds `.dup` to the ```force_encoding(encoding)``` method call to bypass the restrictions put in place by ```# frozen_string_literal: true``` as `.dup` allows the encoding to be performed on the duplicate code before being reassigned to themselves.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] run `reload_all`
- [ ] **Verify** that the error above is no longer present and everything works as expected
