### PR TITLE
Add requires for python payloads

### DIFF
--- a/modules/payloads/singles/python/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/python/shell_reverse_tcp.rb
@@ -6,6 +6,7 @@
 require 'msf/core/handler/reverse_tcp'
 require 'msf/base/sessions/command_shell'
 require 'msf/base/sessions/command_shell_options'
+require 'msf/core/payload/python'
 
 module MetasploitModule
 

--- a/modules/payloads/singles/python/shell_reverse_tcp_ssl.rb
+++ b/modules/payloads/singles/python/shell_reverse_tcp_ssl.rb
@@ -6,6 +6,7 @@
 require 'msf/core/handler/reverse_tcp_ssl'
 require 'msf/base/sessions/command_shell'
 require 'msf/base/sessions/command_shell_options'
+require 'msf/core/payload/python'
 
 module MetasploitModule
 

--- a/modules/payloads/singles/python/shell_reverse_udp.rb
+++ b/modules/payloads/singles/python/shell_reverse_udp.rb
@@ -6,6 +6,7 @@
 require 'msf/core/handler/reverse_udp'
 require 'msf/base/sessions/command_shell'
 require 'msf/base/sessions/command_shell_options'
+require 'msf/core/payload/python'
 
 module MetasploitModule
 


### PR DESCRIPTION
PR #14325 added in some `includes` without the appropriate requires which caused some tests to fail intermittently (depending on whether or not that constant happened to be loaded by a previous test or not)

Example of tests failing on master:
https://travis-ci.org/github/rapid7/metasploit-framework/jobs/746146572