### PR TITLE
Add remote data service support for autoroute

### DIFF
--- a/lib/metasploit/framework/data_service/proxy/route_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/route_data_proxy.rb
@@ -1,0 +1,24 @@
+module RouteDataProxy
+  def report_session_route(opts)
+    begin
+      self.data_service_operation do |data_service|
+        add_opts_workspace(opts)
+        data_service.report_session_route(opts)
+      end
+    rescue => e
+      self.log_error(e, "Problem reporting route")
+    end
+  end
+
+  def report_session_route_remove(opts)
+    begin
+      self.data_service_operation do |data_service|
+        add_opts_workspace(opts)
+        data_service.report_session_route_remove(opts)
+      end
+    rescue => e
+      self.log_error(e, "Problem removing route")
+    end
+  end
+
+end

--- a/lib/metasploit/framework/data_service/remote/http/core.rb
+++ b/lib/metasploit/framework/data_service/remote/http/core.rb
@@ -314,11 +314,11 @@ class RemoteHTTPDataService
     if !data_hash.nil? && !data_hash.empty?
       data_hash.each do |k,v|
         if v.is_a?(Msf::Session)
-          dlog('Dropping Msf::Session object before converting to JSON.')
+          dlog('Replacing Msf::Session object with session sid before converting to JSON.')
           dlog("data_hash is #{data_hash}")
           dlog('Callstack:')
           caller.each { |line| dlog("#{line}\n")}
-          data_hash.delete(k)
+          data_hash[k] = v.sid
         end
       end
       json_body = data_hash.to_json

--- a/lib/metasploit/framework/data_service/remote/http/core.rb
+++ b/lib/metasploit/framework/data_service/remote/http/core.rb
@@ -314,11 +314,11 @@ class RemoteHTTPDataService
     if !data_hash.nil? && !data_hash.empty?
       data_hash.each do |k,v|
         if v.is_a?(Msf::Session)
-          dlog('Replacing Msf::Session object with session sid before converting to JSON.')
+          dlog('Dropping Msf::Session object before converting to JSON.')
           dlog("data_hash is #{data_hash}")
           dlog('Callstack:')
           caller.each { |line| dlog("#{line}\n")}
-          data_hash[k] = v.sid
+          data_hash.delete(k)
         end
       end
       json_body = data_hash.to_json

--- a/lib/metasploit/framework/data_service/remote/http/data_service_auto_loader.rb
+++ b/lib/metasploit/framework/data_service/remote/http/data_service_auto_loader.rb
@@ -21,6 +21,7 @@ module DataServiceAutoLoader
   autoload :RemoteMsfDataService, 'metasploit/framework/data_service/remote/http/remote_msf_data_service'
   autoload :RemoteDbImportDataService, 'metasploit/framework/data_service/remote/http/remote_db_import_data_service.rb'
   autoload :RemotePayloadDataService, 'metasploit/framework/data_service/remote/http/remote_payload_data_service'
+  autoload :RemoteRouteDataService, 'metasploit/framework/data_service/remote/http/remote_route_data_service'
 
   include RemoteHostDataService
   include RemoteEventDataService
@@ -41,4 +42,5 @@ module DataServiceAutoLoader
   include RemoteMsfDataService
   include RemoteDbImportDataService
   include RemotePayloadDataService
+  include RemoteRouteDataService
 end

--- a/lib/metasploit/framework/data_service/remote/http/remote_route_data_service.rb
+++ b/lib/metasploit/framework/data_service/remote/http/remote_route_data_service.rb
@@ -7,10 +7,12 @@ module RemoteRouteDataService
   ROUTE_MDM_CLASS = 'Mdm::Route'
 
   def report_session_route(opts)
+    opts[:session] = opts[:session].db_record
     json_to_mdm_object(self.post_data(ROUTE_API_PATH, opts), ROUTE_MDM_CLASS).first
   end
 
   def report_session_route_remove(opts)
+    opts[:session] = opts[:session].db_record
     path = get_path_select(opts, ROUTE_API_PATH) + '/remove'
     json_to_mdm_object(self.post_data(path, opts), ROUTE_MDM_CLASS).first
   end

--- a/lib/metasploit/framework/data_service/remote/http/remote_route_data_service.rb
+++ b/lib/metasploit/framework/data_service/remote/http/remote_route_data_service.rb
@@ -1,0 +1,18 @@
+require 'metasploit/framework/data_service/remote/http/response_data_helper'
+
+module RemoteRouteDataService
+  include ResponseDataHelper
+
+  ROUTE_API_PATH = '/api/v1/routes'
+  ROUTE_MDM_CLASS = 'Mdm::Route'
+
+  def report_session_route(opts)
+    json_to_mdm_object(self.post_data(ROUTE_API_PATH, opts), ROUTE_MDM_CLASS).first
+  end
+
+  def report_session_route_remove(opts)
+    path = get_path_select(opts, ROUTE_API_PATH) + '/remove'
+    json_to_mdm_object(self.post_data(path, opts), ROUTE_MDM_CLASS).first
+  end
+
+end

--- a/lib/metasploit/framework/data_service/stubs/route_data_service.rb
+++ b/lib/metasploit/framework/data_service/stubs/route_data_service.rb
@@ -1,0 +1,11 @@
+module RouteDataService
+  def report_session_route(opts)
+    raise 'RouteDataService#report_session_route is not implemented'
+
+  end
+
+  def report_session_route_remove(opts)
+    raise 'RouteDataService#report_session_route_remove is not implemented'
+  end
+
+end

--- a/lib/msf/core/db_manager/route.rb
+++ b/lib/msf/core/db_manager/route.rb
@@ -1,8 +1,14 @@
+require 'msf/core/db_manager/session'
+
 module Msf::DBManager::Route
-  def report_session_route(session, route)
+  def report_session_route(opts)
     return if not active
+    session = opts[:session]
+    route = opts[:route]
     if session.respond_to? :db_record
       s = session.db_record
+    elsif session.is_a? Integer
+      s = Mdm::Session.find(session)
     else
       s = session
     end
@@ -17,10 +23,14 @@ module Msf::DBManager::Route
   }
   end
 
-  def report_session_route_remove(session, route)
+  def report_session_route_remove(opts)
     return if not active
+    session = opts[:session]
+    route = opts[:route]
     if session.respond_to? :db_record
       s = session.db_record
+    elsif session.is_a? Integer
+      s = Mdm::Session.find(session)
     else
       s = session
     end

--- a/lib/msf/core/db_manager/route.rb
+++ b/lib/msf/core/db_manager/route.rb
@@ -7,8 +7,8 @@ module Msf::DBManager::Route
     route = opts[:route]
     if session.respond_to? :db_record
       s = session.db_record
-    elsif session.is_a? Integer
-      s = Mdm::Session.find(session)
+    elsif session.is_a?(Hash) && session.key?(:id)
+      s = Mdm::Session.find(session[:id])
     else
       s = session
     end
@@ -29,8 +29,8 @@ module Msf::DBManager::Route
     route = opts[:route]
     if session.respond_to? :db_record
       s = session.db_record
-    elsif session.is_a? Integer
-      s = Mdm::Session.find(session)
+    elsif session.is_a?(Hash) && session.key?(:id)
+      s = Mdm::Session.find(session[:id])
     else
       s = session
     end

--- a/lib/msf/core/framework.rb
+++ b/lib/msf/core/framework.rb
@@ -492,13 +492,13 @@ class FrameworkEventSubscriber
   ##
   # :category: ::Msf::SessionEvent implementors
   def on_session_route(session, route)
-    framework.db.report_session_route(session, route)
+    framework.db.report_session_route({session: session, route: route})
   end
 
   ##
   # :category: ::Msf::SessionEvent implementors
   def on_session_route_remove(session, route)
-    framework.db.report_session_route_remove(session, route)
+    framework.db.report_session_route_remove({session: session, route: route})
   end
 
   ##

--- a/lib/msf/core/web_services/metasploit_api_app.rb
+++ b/lib/msf/core/web_services/metasploit_api_app.rb
@@ -30,6 +30,8 @@ class Msf::WebServices::MetasploitApiApp < Sinatra::Base
   register Msf::WebServices::PayloadServlet
   register Msf::WebServices::ModuleSearchServlet
   register Msf::WebServices::DbImportServlet
+  register Msf::WebServices::RouteServlet
+
   configure do
     set :sessions, {key: 'msf-ws.session', expire_after: 300}
     set :session_secret, ENV.fetch('MSF_WS_SESSION_SECRET') { SecureRandom.hex(16) }

--- a/lib/msf/core/web_services/servlet/route_servlet.rb
+++ b/lib/msf/core/web_services/servlet/route_servlet.rb
@@ -1,0 +1,49 @@
+module RouteServlet
+
+  def self.api_path
+    '/api/v1/routes'
+  end
+
+  def self.api_path_remove
+    "#{RouteServlet.api_path}/remove"
+  end
+
+  def self.registered(app)
+    app.post RouteServlet.api_path, &report_session_route
+    app.post RouteServlet.api_path_remove, &report_session_route_remove
+  end
+
+  #######
+  private
+  #######
+
+  def self.report_session_route
+    lambda {
+      warden.authenticate!
+      begin
+        job = lambda { |opts|
+          print_warning(opts)
+          get_db.report_session_route(opts)
+        }
+        exec_report_job(request, &job)
+      rescue => e
+        print_error_and_create_response(error: e, message: 'There was an error creating the route:', code: 500)
+      end
+    }
+  end
+
+  def self.report_session_route_remove
+    lambda {
+      warden.authenticate!
+      begin
+        opts = parse_json_request(request, false)
+        data = get_db.report_session_route_remove(opts)
+        set_json_data_response(response: data)
+      rescue => e
+        print_error_and_create_response(error: e, message: 'There was an error deleting route:', code: 500)
+      end
+    }
+  end
+
+
+end

--- a/lib/msf/core/web_services/servlet/route_servlet.rb
+++ b/lib/msf/core/web_services/servlet/route_servlet.rb
@@ -1,16 +1,16 @@
-module RouteServlet
+module Msf::WebServices::RouteServlet
 
   def self.api_path
     '/api/v1/routes'
   end
 
   def self.api_path_remove
-    "#{RouteServlet.api_path}/remove"
+    "#{self.api_path}/remove"
   end
 
   def self.registered(app)
-    app.post RouteServlet.api_path, &report_session_route
-    app.post RouteServlet.api_path_remove, &report_session_route_remove
+    app.post self.api_path, &report_session_route
+    app.post self.api_path_remove, &report_session_route_remove
   end
 
   #######


### PR DESCRIPTION
Resolves #12805 and Resolves #11491

This PR adds in a couple of missing methods from the remote data services for adding/deleting routes

# Verification
- [x] Boot up the remote data service
- [x] Boot up msfconsole with a remote data service connection
- [x] Gain a session
- [x] `use post/multi/manage/autoroute`
- [x] Set the session and run the module
- [x] Observe no errors
- [x] Observe that the `routes` table in the db will now have an entry
- [x] `set CMD delete` and run the module again
- [x] Observe no errors
- [x] Observe that the `routes` table in the db will now have no entries


