### PR TITLE
Railgun datatype updates

### DIFF
--- a/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/windows/def_advapi32.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/windows/def_advapi32.rb
@@ -414,33 +414,33 @@ class Def_windows_advapi32
     dll.add_function('RegConnectRegistryA', 'DWORD',[
       ["PCHAR","lpMachineName","in"],
       ["DWORD","hKey","in"],
-      ["PDWORD","phkResult","out"],
+      ["PHANDLE","phkResult","out"],
       ])
 
     dll.add_function('RegConnectRegistryExA', 'DWORD',[
       ["PCHAR","lpMachineName","in"],
       ["DWORD","hKey","in"],
       ["DWORD","Flags","in"],
-      ["PDWORD","phkResult","out"],
+      ["PHANDLE","phkResult","out"],
       ])
 
     dll.add_function('RegConnectRegistryExW', 'DWORD',[
       ["PWCHAR","lpMachineName","in"],
       ["DWORD","hKey","in"],
       ["DWORD","Flags","in"],
-      ["PDWORD","phkResult","out"],
+      ["PHANDLE","phkResult","out"],
       ])
 
     dll.add_function('RegConnectRegistryW', 'DWORD',[
       ["PWCHAR","lpMachineName","in"],
       ["DWORD","hKey","in"],
-      ["PDWORD","phkResult","out"],
+      ["PHANDLE","phkResult","out"],
       ])
 
     dll.add_function('RegCreateKeyA', 'DWORD',[
       ["DWORD","hKey","in"],
       ["PCHAR","lpSubKey","in"],
-      ["PDWORD","phkResult","out"],
+      ["PHANDLE","phkResult","out"],
       ])
 
     dll.add_function('RegCreateKeyExA', 'DWORD',[
@@ -451,7 +451,7 @@ class Def_windows_advapi32
       ["DWORD","dwOptions","in"],
       ["DWORD","samDesired","in"],
       ["PBLOB","lpSecurityAttributes","in"],
-      ["PDWORD","phkResult","out"],
+      ["PHANDLE","phkResult","out"],
       ["PDWORD","lpdwDisposition","out"],
       ])
 
@@ -463,14 +463,14 @@ class Def_windows_advapi32
       ["DWORD","dwOptions","in"],
       ["DWORD","samDesired","in"],
       ["PBLOB","lpSecurityAttributes","in"],
-      ["PDWORD","phkResult","out"],
+      ["PHANDLE","phkResult","out"],
       ["PDWORD","lpdwDisposition","out"],
       ])
 
     dll.add_function('RegCreateKeyW', 'DWORD',[
       ["DWORD","hKey","in"],
       ["PWCHAR","lpSubKey","in"],
-      ["PDWORD","phkResult","out"],
+      ["PHANDLE","phkResult","out"],
       ])
 
     dll.add_function('RegDeleteKeyA', 'DWORD',[
@@ -629,13 +629,13 @@ class Def_windows_advapi32
 
     dll.add_function('RegOpenCurrentUser', 'DWORD',[
       ["DWORD","samDesired","in"],
-      ["PDWORD","phkResult","out"],
+      ["PHANDLE","phkResult","out"],
       ])
 
     dll.add_function('RegOpenKeyA', 'DWORD',[
       ["DWORD","hKey","in"],
       ["PCHAR","lpSubKey","in"],
-      ["PDWORD","phkResult","out"],
+      ["PHANDLE","phkResult","out"],
       ])
 
     dll.add_function('RegOpenKeyExA', 'DWORD',[
@@ -643,7 +643,7 @@ class Def_windows_advapi32
       ["PCHAR","lpSubKey","in"],
       ["DWORD","ulOptions","inout"],
       ["DWORD","samDesired","in"],
-      ["PDWORD","phkResult","out"],
+      ["PHANDLE","phkResult","out"],
       ])
 
     dll.add_function('RegOpenKeyExW', 'DWORD',[
@@ -651,20 +651,20 @@ class Def_windows_advapi32
       ["PWCHAR","lpSubKey","in"],
       ["DWORD","ulOptions","inout"],
       ["DWORD","samDesired","in"],
-      ["PDWORD","phkResult","out"],
+      ["PHANDLE","phkResult","out"],
       ])
 
     dll.add_function('RegOpenKeyW', 'DWORD',[
       ["DWORD","hKey","in"],
       ["PWCHAR","lpSubKey","in"],
-      ["PDWORD","phkResult","out"],
+      ["PHANDLE","phkResult","out"],
       ])
 
     dll.add_function('RegOpenUserClassesRoot', 'DWORD',[
       ["DWORD","hToken","in"],
       ["DWORD","dwOptions","inout"],
       ["DWORD","samDesired","in"],
-      ["PDWORD","phkResult","out"],
+      ["PHANDLE","phkResult","out"],
       ])
 
     dll.add_function('RegOverridePredefKey', 'DWORD',[
@@ -1335,7 +1335,7 @@ class Def_windows_advapi32
       ["PBLOB","PrivilegesToDelete","in"],
       ["DWORD","RestrictedSidCount","in"],
       ["PBLOB","SidsToRestrict","in"],
-      ["PDWORD","NewTokenHandle","out"],
+      ["PHANDLE","NewTokenHandle","out"],
       ])
 
     dll.add_function('CreateWellKnownSid', 'BOOL',[
@@ -1371,7 +1371,7 @@ class Def_windows_advapi32
     dll.add_function('DuplicateToken', 'BOOL',[
       ["DWORD","ExistingTokenHandle","in"],
       ["DWORD","ImpersonationLevel","in"],
-      ["PDWORD","DuplicateTokenHandle","out"],
+      ["PHANDLE","DuplicateTokenHandle","out"],
       ])
 
     dll.add_function('DuplicateTokenEx', 'BOOL',[
@@ -1380,7 +1380,7 @@ class Def_windows_advapi32
       ["PBLOB","lpTokenAttributes","in"],
       ["DWORD","ImpersonationLevel","in"],
       ["DWORD","TokenType","in"],
-      ["PDWORD","phNewToken","out"],
+      ["PHANDLE","phNewToken","out"],
       ])
 
     dll.add_function('EncryptFileA', 'BOOL',[
@@ -1639,7 +1639,7 @@ class Def_windows_advapi32
       ["PCHAR","lpszPassword","in"],
       ["DWORD","dwLogonType","in"],
       ["DWORD","dwLogonProvider","in"],
-      ["PDWORD","phToken","out"],
+      ["PHANDLE","phToken","out"],
       ])
 
     dll.add_function('LogonUserExA', 'BOOL',[
@@ -1648,7 +1648,7 @@ class Def_windows_advapi32
       ["PCHAR","lpszPassword","in"],
       ["DWORD","dwLogonType","in"],
       ["DWORD","dwLogonProvider","in"],
-      ["PDWORD","phToken","out"],
+      ["PHANDLE","phToken","out"],
       ["PDWORD","ppLogonSid","out"],
       ["PBLOB","ppProfileBuffer","out"],
       ["PDWORD","pdwProfileLength","out"],
@@ -1661,7 +1661,7 @@ class Def_windows_advapi32
       ["PWCHAR","lpszPassword","in"],
       ["DWORD","dwLogonType","in"],
       ["DWORD","dwLogonProvider","in"],
-      ["PDWORD","phToken","out"],
+      ["PHANDLE","phToken","out"],
       ["PDWORD","ppLogonSid","out"],
       ["PBLOB","ppProfileBuffer","out"],
       ["PDWORD","pdwProfileLength","out"],
@@ -1674,7 +1674,7 @@ class Def_windows_advapi32
       ["PWCHAR","lpszPassword","in"],
       ["DWORD","dwLogonType","in"],
       ["DWORD","dwLogonProvider","in"],
-      ["PDWORD","phToken","out"],
+      ["PHANDLE","phToken","out"],
       ])
 
     dll.add_function('LookupAccountNameA', 'BOOL',[
@@ -1901,14 +1901,14 @@ class Def_windows_advapi32
     dll.add_function('OpenProcessToken', 'BOOL',[
       ["DWORD","ProcessHandle","in"],
       ["DWORD","DesiredAccess","in"],
-      ["PDWORD","TokenHandle","out"],
+      ["PHANDLE","TokenHandle","out"],
       ])
 
     dll.add_function('OpenThreadToken', 'BOOL',[
       ["DWORD","ThreadHandle","in"],
       ["DWORD","DesiredAccess","in"],
       ["BOOL","OpenAsSelf","in"],
-      ["PDWORD","TokenHandle","out"],
+      ["PHANDLE","TokenHandle","out"],
       ])
 
     dll.add_function('PrivilegeCheck', 'BOOL',[
@@ -2076,7 +2076,7 @@ class Def_windows_advapi32
       ])
 
     dll.add_function('SetThreadToken', 'BOOL',[
-      ["PDWORD","Thread","in"],
+      ["PHANDLE","Thread","in"],
       ["DWORD","Token","in"],
       ])
 

--- a/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/windows/def_crypt32.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/windows/def_crypt32.rb
@@ -16,7 +16,7 @@ class Def_windows_crypt32
         ['PBLOB','pDataIn', 'in'],
         ['PWCHAR', 'szDataDescr', 'out'],
         ['PBLOB', 'pOptionalEntropy', 'in'],
-        ['PVOID', 'pvReserved', 'in'],
+        ['LPVOID', 'pvReserved', 'in'],
         ['PBLOB', 'pPromptStruct', 'in'],
         ['DWORD', 'dwFlags', 'in'],
         ['PBLOB', 'pDataOut', 'out']

--- a/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/windows/def_crypt32.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/windows/def_crypt32.rb
@@ -16,7 +16,7 @@ class Def_windows_crypt32
         ['PBLOB','pDataIn', 'in'],
         ['PWCHAR', 'szDataDescr', 'out'],
         ['PBLOB', 'pOptionalEntropy', 'in'],
-        ['PDWORD', 'pvReserved', 'in'],
+        ['PVOID', 'pvReserved', 'in'],
         ['PBLOB', 'pPromptStruct', 'in'],
         ['DWORD', 'dwFlags', 'in'],
         ['PBLOB', 'pDataOut', 'out']

--- a/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/windows/def_iphlpapi.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/windows/def_iphlpapi.rb
@@ -67,12 +67,12 @@ class Def_windows_iphlpapi
       ])
 
     dll.add_function('NotifyAddrChange', 'DWORD',[
-      ["PDWORD","Handle","inout"],
+      ["PHANDLE","Handle","inout"],
       ["PBLOB","overlapped","in"],
       ])
 
     dll.add_function('NotifyRouteChange', 'DWORD',[
-      ["PDWORD","Handle","inout"],
+      ["PHANDLE","Handle","inout"],
       ["PBLOB","overlapped","in"],
       ])
 

--- a/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/windows/def_kernel32.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/windows/def_kernel32.rb
@@ -3756,7 +3756,7 @@ class Def_windows_kernel32
       ["PBLOB","lpBaseAddress","inout"],
       ["PBLOB","lpBuffer","inout"],
       ["DWORD","cbRead","in"],
-      ["PDWORD","lpNumberOfBytesRead","in"],
+      ["PSIZE_T","lpNumberOfBytesRead","in"],
       ])
 
     dll.add_function('CreateToolhelp32Snapshot', 'DWORD',[
@@ -3839,7 +3839,7 @@ class Def_windows_kernel32
       ["PBLOB","lpBaseAddress","inout"],
       ["PBLOB","lpBuffer","inout"],
       ["DWORD","cbRead","in"],
-      ["PDWORD","lpNumberOfBytesRead","in"],
+      ["PSIZE_T","lpNumberOfBytesRead","in"],
       ])
 
     return dll

--- a/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/windows/def_ntdll.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/windows/def_ntdll.rb
@@ -26,7 +26,7 @@ class Def_windows_ntdll
       ])
 
     dll.add_function('NtCreateFile', 'DWORD',[
-      ["PDWORD","FileHandle","inout"],
+      ["PHANDLE","FileHandle","inout"],
       ["DWORD","DesiredAccess","in"],
       ["PBLOB","ObjectAttributes","in"],
       ["PBLOB","IoStatusBlock","inout"],
@@ -53,7 +53,7 @@ class Def_windows_ntdll
       ])
 
     dll.add_function('NtOpenFile', 'DWORD',[
-      ["PDWORD","FileHandle","inout"],
+      ["PHANDLE","FileHandle","inout"],
       ["DWORD","DesiredAccess","in"],
       ["PBLOB","ObjectAttributes","in"],
       ["PBLOB","IoStatusBlock","inout"],

--- a/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/windows/def_user32.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/windows/def_user32.rb
@@ -160,7 +160,7 @@ class Def_windows_user32
       ["DWORD","wHow","in"],
       ["PBLOB","lpRect","in"],
       ["DWORD","cKids","in"],
-      ["PDWORD","lpKids","in"],
+      ["PHANDLE","lpKids","in"],
       ])
 
     dll.add_function('ChangeClipboardChain', 'BOOL',[
@@ -2163,7 +2163,7 @@ class Def_windows_user32
 
     dll.add_function('MsgWaitForMultipleObjects', 'DWORD',[
       ["DWORD","nCount","in"],
-      ["PDWORD","pHandles","in"],
+      ["PHANDLE","pHandles","in"],
       ["BOOL","fWaitAll","in"],
       ["DWORD","dwMilliseconds","in"],
       ["DWORD","dwWakeMask","in"],
@@ -2171,7 +2171,7 @@ class Def_windows_user32
 
     dll.add_function('MsgWaitForMultipleObjectsEx', 'DWORD',[
       ["DWORD","nCount","in"],
-      ["PDWORD","pHandles","in"],
+      ["PHANDLE","pHandles","in"],
       ["DWORD","dwMilliseconds","in"],
       ["DWORD","dwWakeMask","in"],
       ["DWORD","dwFlags","in"],
@@ -2319,7 +2319,7 @@ class Def_windows_user32
       ["DWORD","nIconIndex","in"],
       ["DWORD","cxIcon","in"],
       ["DWORD","cyIcon","in"],
-      ["PDWORD","phicon","out"],
+      ["PHANDLE","phicon","out"],
       ["PDWORD","piconid","out"],
       ["DWORD","nIcons","in"],
       ["DWORD","flags","in"],
@@ -2330,7 +2330,7 @@ class Def_windows_user32
       ["DWORD","nIconIndex","in"],
       ["DWORD","cxIcon","in"],
       ["DWORD","cyIcon","in"],
-      ["PDWORD","phicon","out"],
+      ["PHANDLE","phicon","out"],
       ["PDWORD","piconid","out"],
       ["DWORD","nIcons","in"],
       ["DWORD","flags","in"],
@@ -2982,7 +2982,7 @@ class Def_windows_user32
       ["DWORD","wHow","in"],
       ["PBLOB","lpRect","in"],
       ["DWORD","cKids","in"],
-      ["PDWORD","lpKids","in"],
+      ["PHANDLE","lpKids","in"],
       ])
 
     dll.add_function('ToAscii', 'DWORD',[

--- a/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/windows/def_version.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/windows/def_version.rb
@@ -29,7 +29,7 @@ class Def_windows_version
     dll.add_function('VerQueryValueA', 'BOOL',[
       ["LPVOID","pBlock","in"],
       ["PCHAR","lpSubBlock","in"],
-      ["PVOID","lplpBuffer","out"],
+      ["LPVOID","lplpBuffer","out"],
       ["PDWORD","puLen","out"]
     ])
 

--- a/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/windows/def_version.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/windows/def_version.rb
@@ -29,7 +29,7 @@ class Def_windows_version
     dll.add_function('VerQueryValueA', 'BOOL',[
       ["LPVOID","pBlock","in"],
       ["PCHAR","lpSubBlock","in"],
-      ["PDWORD","lplpBuffer","out"],
+      ["PVOID","lplpBuffer","out"],
       ["PDWORD","puLen","out"]
     ])
 

--- a/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/windows/def_ws2_32.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/windows/def_ws2_32.rb
@@ -273,13 +273,13 @@ class Def_windows_ws2_32
     dll.add_function('WSALookupServiceBeginA', 'DWORD',[
       ["PBLOB","lpqsRestrictions","in"],
       ["DWORD","dwControlFlags","in"],
-      ["PDWORD","lphLookup","inout"],
+      ["PHANDLE","lphLookup","inout"],
       ])
 
     dll.add_function('WSALookupServiceBeginW', 'DWORD',[
       ["PBLOB","lpqsRestrictions","in"],
       ["DWORD","dwControlFlags","in"],
-      ["PDWORD","lphLookup","inout"],
+      ["PHANDLE","lphLookup","inout"],
       ])
 
     dll.add_function('WSALookupServiceEnd', 'DWORD',[
@@ -324,7 +324,7 @@ class Def_windows_ws2_32
       ])
 
     dll.add_function('WSAProviderConfigChange', 'DWORD',[
-      ["PDWORD","lpNotificationHandle","inout"],
+      ["PHANDLE","lpNotificationHandle","inout"],
       ["PBLOB","lpOverlapped","in"],
       ["PBLOB","lpCompletionRoutine","in"],
       ])
@@ -455,7 +455,7 @@ class Def_windows_ws2_32
 
     dll.add_function('WSAWaitForMultipleEvents', 'DWORD',[
       ["DWORD","cEvents","in"],
-      ["PDWORD","lphEvents","in"],
+      ["PHANDLE","lphEvents","in"],
       ["BOOL","fWaitAll","in"],
       ["DWORD","dwTimeout","in"],
       ["BOOL","fAlertable","in"],

--- a/lib/rex/post/meterpreter/extensions/stdapi/railgun/library.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/railgun/library.rb
@@ -119,7 +119,8 @@ class Library
   # return value and all inout params.  See #call_function.
   #
   def add_function(name, return_type, params, remote_name=nil, calling_conv='stdcall')
-    params = reduce_params(params)
+    return_type = reduce_type(return_type)
+    params = reduce_parameter_types(params)
     if remote_name == nil
       remote_name = name
     end
@@ -375,18 +376,21 @@ class Library
   end
 
   # perform type conversions as necessary to reduce the datatypes to their primitives
-  def reduce_params(params)
+  def reduce_parameter_types(params)
     params.each_with_index do |param, idx|
       type, name, direction = param
-
-      while @@datatype_map.key?(type)
-        type = @@datatype_map[type]
-      end
-
-      params[idx] = [type, name, direction]
+      params[idx] = [reduce_type(type), name, direction]
     end
 
     params
+  end
+
+  def reduce_type(datatype)
+    while @@datatype_map.key?(datatype)
+      datatype = @@datatype_map[datatype]
+    end
+
+    datatype
   end
 end
 

--- a/lib/rex/post/meterpreter/extensions/stdapi/railgun/library_function.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/railgun/library_function.rb
@@ -34,13 +34,6 @@ module Railgun
 # represents one function, e.g. MessageBoxW
 #
 class LibraryFunction
-  @@datatype_map = {
-    'HANDLE'  => 'LPVOID',
-    'PHANDLE' => 'PULONG_PTR', # really should be PVOID* but LPVOID is handled specially with the 'L' prefix to *not* treat it as a pointer
-    'SIZE_T'  => 'ULONG_PTR',
-    'PSIZE_T' => 'PULONG_PTR',
-  }.freeze
-
   @@allowed_datatypes = {
     'VOID'       => ['return'],
     'BOOL'       => ['in', 'return'],
@@ -64,7 +57,6 @@ class LibraryFunction
 
   def initialize(return_type, params, remote_name, calling_conv='stdcall')
     check_return_type(return_type) # we do error checking as early as possible so the library is easier to use
-    params = reduce_params(params)
     check_params(params)
     check_calling_conv(calling_conv)
     @return_type = return_type
@@ -112,18 +104,6 @@ class LibraryFunction
       if direction == "return"
         raise "direction 'return' is only for the return value of the function."
       end
-    end
-  end
-
-  def reduce_params(params)
-    params.each_with_index do |param, idx|
-      type, name, direction = param
-
-      while @@datatype_map.key?(type)
-        type = @@datatype_map[type]
-      end
-
-      params[idx] = [type, name, direction]
     end
   end
 end

--- a/lib/rex/post/meterpreter/extensions/stdapi/railgun/library_helper.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/railgun/library_helper.rb
@@ -91,7 +91,7 @@ module LibraryHelper
   end
 
   # assembles the buffers "in" and "inout"
-  def assemble_buffer(direction, function, args)
+  def assemble_buffer(direction, function, args, arch)
     layout = {} # paramName => BufferItem
     blob = ""
     #puts " building buffer: #{direction}"
@@ -110,28 +110,31 @@ module LibraryHelper
         end
 
         case param_desc[0] # required argument type
-          when "PDWORD"
-            dw = param_to_number(args[param_idx])
-            buffer = [dw].pack('V')
-          when "PWCHAR"
-            raise "param #{param_desc[1]}: string expected" unless args[param_idx].class == String
-            buffer = str_to_uni_z(args[param_idx])
-          when "PCHAR"
-            raise "param #{param_desc[1]}: string expected" unless args[param_idx].class == String
-            buffer = str_to_ascii_z(args[param_idx])
-          when "PBLOB"
-            raise "param #{param_desc[1]}: please supply your BLOB as string!" unless args[param_idx].class == String
-            buffer = args[param_idx]
+        when 'PULONG_PTR'
+          val = param_to_number(args[param_idx])
+          buffer = [val].pack(arch == ARCH_X64 ? 'Q<' : 'V')
+        when "PDWORD"
+          val = param_to_number(args[param_idx])
+          buffer = [val].pack('V')
+        when "PWCHAR"
+          raise "param #{param_desc[1]}: string expected" unless args[param_idx].class == String
+          buffer = str_to_uni_z(args[param_idx])
+        when "PCHAR"
+          raise "param #{param_desc[1]}: string expected" unless args[param_idx].class == String
+          buffer = str_to_ascii_z(args[param_idx])
+        when "PBLOB"
+          raise "param #{param_desc[1]}: please supply your BLOB as string!" unless args[param_idx].class == String
+          buffer = args[param_idx]
           # other types (non-pointers) don't reference buffers
           # and don't need any treatment here
         end
 
-        if buffer != nil
+        unless buffer.nil?
           #puts "   adding #{buffer.length} bytes to heap blob"
           layout[param_desc[1]] = BufferItem.new(param_idx, blob.length, buffer.length, param_desc[0])
           blob += buffer
           # sf: force 8 byte alignment to satisfy x64, wont matter on x86.
-          while( blob.length % 8 != 0 )
+          while blob.length % 8 != 0
             blob += "\x00"
           end
           #puts "   heap blob size now #{blob.length}"

--- a/lib/rex/post/meterpreter/extensions/stdapi/railgun/library_helper.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/railgun/library_helper.rb
@@ -142,6 +142,8 @@ module LibraryHelper
     return [layout, blob]
   end
 
+
+
 end
 
 end; end; end; end; end; end;

--- a/lib/rex/post/meterpreter/extensions/stdapi/railgun/multicall.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/railgun/multicall.rb
@@ -47,12 +47,6 @@ class MultiCaller
 
     # needed by LibraryHelper
     @consts_mgr = consts_mgr
-
-    if @client.native_arch == ARCH_X64
-      @native = 'Q<'
-    else
-      @native = 'V'
-    end
   end
 
   def call(functions)
@@ -80,7 +74,7 @@ class MultiCaller
         Rex::Post::Meterpreter::GroupTlv.new(TLV_TYPE_RAILGUN_MULTI_GROUP),
         function,
         args,
-        client.native_arch
+        @client.native_arch
       )
       request.tlvs << group
       call_layouts << layouts
@@ -96,7 +90,7 @@ class MultiCaller
       lib_name, function, args = f
       library = @parent.get_library(lib_name)
       function = library.functions[function] unless function.instance_of? LibraryFunction
-      function_results << library.build_response(call_results.shift, function, call_layouts.shift, client.native_arch)
+      function_results << library.build_response(call_results.shift, function, call_layouts.shift, @client.native_arch)
     end
 
     function_results

--- a/lib/rex/post/meterpreter/extensions/stdapi/railgun/multicall.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/railgun/multicall.rb
@@ -39,291 +39,69 @@ module Railgun
 # A easier way to call multiple functions in a single request
 class MultiCaller
 
-    include LibraryHelper
+  include LibraryHelper
 
-    def initialize(client, parent, consts_mgr)
-      @parent = parent
-      @client = client
+  def initialize(client, parent, consts_mgr)
+    @parent = parent
+    @client = client
 
-      # needed by LibraryHelper
-      @consts_mgr = consts_mgr
+    # needed by LibraryHelper
+    @consts_mgr = consts_mgr
 
-      if @client.native_arch == ARCH_X64
-        @native = 'Q<'
-      else
-        @native = 'V'
+    if @client.native_arch == ARCH_X64
+      @native = 'Q<'
+    else
+      @native = 'V'
+    end
+  end
+
+  def call(functions)
+    request = Packet.create_request(COMMAND_ID_STDAPI_RAILGUN_API_MULTI)
+    function_results = []
+    call_layouts          = []
+    functions.each do |f|
+      lib_name, function, args = f
+      library = @parent.get_library(lib_name)
+
+      unless library
+        raise "Library #{lib_name} has not been loaded"
       end
+
+      unless function.instance_of? LibraryFunction
+        function = library.functions[function]
+        unless function
+          raise "Library #{lib_name} function #{function} has not been defined"
+        end
+      end
+
+      raise "#{function.params.length} arguments expected. #{args.length} arguments provided." unless args.length == function.params.length
+
+      group, layouts = library.build_packet_and_layouts(
+        Rex::Post::Meterpreter::GroupTlv.new(TLV_TYPE_RAILGUN_MULTI_GROUP),
+        function,
+        args,
+        client.native_arch
+      )
+      request.tlvs << group
+      call_layouts << layouts
     end
 
-    def call(functions)
-      request = Packet.create_request(COMMAND_ID_STDAPI_RAILGUN_API_MULTI)
-      function_results = []
-      layouts          = []
-      functions.each do |f|
-        lib_name, function, args = f
-        lib_host = @parent.get_library(lib_name)
-
-        if not lib_host
-          raise "Library #{lib_name} has not been loaded"
-        end
-
-        unless function.instance_of? LibraryFunction
-          function = lib_host.functions[function]
-          if not function
-            raise "Library #{lib_name} function #{function} has not been defined"
-          end
-        end
-
-        raise "#{function.params.length} arguments expected. #{args.length} arguments provided." unless args.length == function.params.length
-
-        # We transmit the immediate stack and three heap-buffers:
-        # in, inout and out. The reason behind the separation is bandwidth.
-        # We don't want to transmit uninitialized data in or no-longer-needed data out.
-
-        # out-only-buffers that are ONLY transmitted on the way BACK
-        out_only_layout = {} # paramName => BufferItem
-        out_only_size_bytes = 0
-        #puts " assembling out-only buffer"
-        function.params.each_with_index do |param_desc, param_idx|
-          #puts " processing #{param_desc[1]}"
-
-          # Special case:
-          # The user can choose to supply a Null pointer instead of a buffer
-          # in this case we don't need space in any heap buffer
-          if param_desc[0][0,1] == 'P' # type is a pointer (except LPVOID where the L negates this)
-            if args[param_idx] == nil
-              next
-            end
-          end
-
-          # we care only about out-only buffers
-          if param_desc[2] == 'out'
-            if !args[param_idx].kind_of? Integer
-              raise "error in param #{param_desc[1]}: Out-only buffers must be described by a number indicating their size in bytes"
-            end
-            buffer_size = args[param_idx]
-            if param_desc[0] == 'PULONG_PTR'
-              # bump up the size for an x64 pointer
-              if @native == 'Q<' && buffer_size == 4
-                args[param_idx] = 8
-                buffer_size = args[param_idx]
-              end
-
-              if @native == 'Q<'
-                if buffer_size != 8
-                  raise "Please pass 8 for 'out' PULONG_PTR, since they require a buffer of size 8"
-                end
-              elsif @native == 'V'
-                if buffer_size != 4
-                  raise "Please pass 4 for 'out' PULONG_PTR, since they require a buffer of size 4"
-                end
-              end
-            end
-
-            out_only_layout[param_desc[1]] = BufferItem.new(param_idx, out_only_size_bytes, buffer_size, param_desc[0])
-            out_only_size_bytes += buffer_size
-          end
-        end
-
-        tmp = assemble_buffer('in', function, args)
-        in_only_layout = tmp[0]
-        in_only_buffer = tmp[1]
-
-        tmp = assemble_buffer('inout', function, args)
-        inout_layout = tmp[0]
-        inout_buffer = tmp[1]
-
-
-        # now we build the stack
-        # every stack dword will be described by two dwords:
-        # first dword describes second dword:
-        #	0 - literal,
-        #	1 = relative to in-only buffer
-        #	2 = relative to out-only buffer
-        #	3 = relative to inout buffer
-
-        # (literal numbers and pointers to buffers we have created)
-        literal_pairs_blob = ""
-        #puts " assembling literal stack"
-        function.params.each_with_index do |param_desc, param_idx|
-          #puts "  processing (#{param_desc[0]}, #{param_desc[1]}, #{param_desc[2]})"
-          buffer = nil
-          # is it a pointer to a buffer on our stack
-          if ['PULONG_PTR', 'PDWORD', 'PWCHAR', 'PCHAR', 'PBLOB'].include? param_desc[0]
-            #puts '   pointer'
-            if args[param_idx] == nil # null pointer?
-              buffer = [0].pack(@native) # type: DWORD  (so the library does not rebase it)
-              buffer += [0].pack(@native) # value: 0
-            elsif param_desc[2] == 'in'
-              buffer = [1].pack(@native)
-              buffer += [in_only_layout[param_desc[1]].addr].pack(@native)
-            elsif param_desc[2] == 'out'
-              buffer = [2].pack(@native)
-              buffer += [out_only_layout[param_desc[1]].addr].pack(@native)
-            elsif param_desc[2] == 'inout'
-              buffer = [3].pack(@native)
-              buffer += [inout_layout[param_desc[1]].addr].pack(@native)
-            else
-              raise 'unexpected direction'
-            end
-          else
-            #puts '   not a pointer'
-            # it's not a pointer
-            buffer = [0].pack(@native)
-            case param_desc[0]
-              when 'LPVOID', 'ULONG_PTR'
-                num     = param_to_number(args[param_idx])
-                buffer += [num].pack(@native)
-              when 'DWORD'
-                num     = param_to_number(args[param_idx])
-                buffer += [num & 0xffffffff].pack(@native)
-              when 'WORD'
-                num     = param_to_number(args[param_idx])
-                buffer += [num & 0xffff].pack(@native)
-              when 'BYTE'
-                num     = param_to_number(args[param_idx])
-                buffer += [num & 0xff].pack(@native)
-              when 'BOOL'
-                case args[param_idx]
-                  when true
-                    buffer += [1].pack(@native)
-                  when false
-                    buffer += [0].pack(@native)
-                  else
-                    raise "param #{param_desc[1]}: true or false expected"
-                end
-              else
-                raise "unexpected type for param #{param_desc[1]}"
-            end
-          end
-
-          #puts "   adding pair to blob"
-          literal_pairs_blob += buffer
-          #puts "   buffer size %X" % buffer.length
-          #puts "   blob size so far: %X" % literal_pairs_blob.length
-        end
-
-        #puts "\n\nsending Stuff to meterpreter"
-
-        group = Rex::Post::Meterpreter::GroupTlv.new(TLV_TYPE_RAILGUN_MULTI_GROUP)
-        group.add_tlv(TLV_TYPE_RAILGUN_SIZE_OUT, out_only_size_bytes)
-        group.add_tlv(TLV_TYPE_RAILGUN_STACKBLOB, literal_pairs_blob)
-        group.add_tlv(TLV_TYPE_RAILGUN_BUFFERBLOB_IN, in_only_buffer)
-        group.add_tlv(TLV_TYPE_RAILGUN_BUFFERBLOB_INOUT, inout_buffer)
-        group.add_tlv(TLV_TYPE_RAILGUN_LIBNAME, lib_host.library_path)
-        group.add_tlv(TLV_TYPE_RAILGUN_FUNCNAME, function.remote_name)
-        request.tlvs << group
-
-        layouts << [inout_layout, out_only_layout]
-      end
-
-      call_results = []
-      res = @client.send_request(request)
-      res.each(TLV_TYPE_RAILGUN_MULTI_GROUP) do |val|
-        call_results << val
-      end
-
-      functions.each do |f|
-        lib_name, function, args = f
-        lib_host = @parent.get_library(lib_name)
-        function = lib_host.functions[function] unless function.instance_of? LibraryFunction
-        response = call_results.shift
-        inout_layout, out_only_layout = layouts.shift
-
-        rec_inout_buffers = response.get_tlv_value(TLV_TYPE_RAILGUN_BACK_BUFFERBLOB_INOUT)
-        rec_out_only_buffers = response.get_tlv_value(TLV_TYPE_RAILGUN_BACK_BUFFERBLOB_OUT)
-        rec_return_value = response.get_tlv_value(TLV_TYPE_RAILGUN_BACK_RET)
-        rec_last_error = response.get_tlv_value(TLV_TYPE_RAILGUN_BACK_ERR)
-        rec_err_msg = response.get_tlv_value(TLV_TYPE_RAILGUN_BACK_MSG)
-
-        # Error messages come back with trailing CRLF, so strip it out
-        # if we do get a message.
-        rec_err_msg.strip! if not rec_err_msg.nil?
-
-        # The hash the function returns
-        return_hash = {
-          'GetLastError' => rec_last_error,
-          'ErrorMessage' => rec_err_msg
-        }
-
-        #process return value
-        case function.return_type
-          when 'LPVOID', 'ULONG_PTR'
-            if( @native == 'Q<' )
-              return_hash['return'] = rec_return_value
-            else
-              return_hash['return'] = rec_return_value % 4294967296
-            end
-          when 'DWORD'
-            return_hash['return'] = rec_return_value % 4294967296
-          when 'WORD'
-            return_hash['return'] = rec_return_value % 65536
-          when 'BYTE'
-            return_hash['return'] = rec_return_value % 256
-          when 'BOOL'
-            return_hash['return'] = (rec_return_value != 0)
-          when 'VOID'
-            return_hash['return'] = nil
-          else
-            raise "unexpected return type: #{function.return_type}"
-        end
-        #puts return_hash
-        #puts "out_only_layout:"
-        #puts out_only_layout
-
-
-        # process out-only buffers
-        #puts "processing out-only buffers:"
-        out_only_layout.each_pair do |param_name, buffer_item|
-          #puts "   #{param_name}"
-          buffer = rec_out_only_buffers[buffer_item.addr, buffer_item.length_in_bytes]
-          case buffer_item.datatype
-            when 'PULONG_PTR'
-              return_hash[param_name] = buffer.unpack(@native).first
-            when 'PDWORD'
-              return_hash[param_name] = buffer.unpack('V').first
-            when 'PCHAR'
-              return_hash[param_name] = asciiz_to_str(buffer)
-            when 'PWCHAR'
-              return_hash[param_name] = uniz_to_str(buffer)
-            when 'PBLOB'
-              return_hash[param_name] = buffer
-            else
-              raise "unexpected type in out-only buffer of #{param_name}: #{buffer_item.datatype}"
-          end
-        end
-        #puts return_hash
-
-        # process in-out buffers
-        #puts "processing in-out buffers:"
-        inout_layout.each_pair do |param_name, buffer_item|
-          #puts '   #{param_name}'
-          buffer = rec_inout_buffers[buffer_item.addr, buffer_item.length_in_bytes]
-          case buffer_item.datatype
-            when 'PULONG_PTR'
-              return_hash[param_name] = buffer.unpack(native).first
-            when 'PDWORD'
-              return_hash[param_name] = buffer.unpack('V').first
-            when 'PCHAR'
-              return_hash[param_name] = asciiz_to_str(buffer)
-            when 'PWCHAR'
-              return_hash[param_name] = uniz_to_str(buffer)
-            when 'PBLOB'
-              return_hash[param_name] = buffer
-            else
-              raise "unexpected type in in-out-buffer of #{param_name}: #{buffer_item.datatype}"
-          end
-        end
-        #puts return_hash
-        #puts "finished"
-
-        function_results << return_hash
-      end
-      function_results
+    call_results = []
+    res = @client.send_request(request)
+    res.each(TLV_TYPE_RAILGUN_MULTI_GROUP) do |val|
+      call_results << val
     end
-    # process_multi_function_call
 
-  protected
+    functions.each do |f|
+      lib_name, function, args = f
+      library = @parent.get_library(lib_name)
+      function = library.functions[function] unless function.instance_of? LibraryFunction
+      function_results << library.build_response(call_results.shift, function, call_layouts.shift, client.native_arch)
+    end
+
+    function_results
+  end
+  # process_multi_function_call
 
 end # MultiCall
 


### PR DESCRIPTION
This updates a whole bunch of Railgun stuff. The intention is to correct the `PDWORD` data type to *always* be handled as a pointer to an unsigned 32-bit integer, regardless of the host architecture. This fixes #14400. In doing this, a number of definitions needed to be updated from `PDWORD` to `PHANDLE` or `PSIZE_T` where `PDWORD` was being used previously. In these cases, the functions were reliant on Railgun's misinformed interpretation of the `PDWORD` datatype. Functions which *actually* needed a legit `PDWORD` were broken on 64-bit systems as they'd be treated incorrectly as having a 64-bit width.

Now the `PHANDLE` and `PSIZE_T` datatypes are new, and they're both<sup>1</sup> actually `PULONG_PTR` (that is to say PHANDLE == PSIZE_T == PULONG_PTR) which is also a new data type. The new `PULONG_PTR` data type replaces Railgun's PDWORD and acts as it did when it was broken. You can see in the [documentation](https://docs.microsoft.com/en-us/windows/win32/winprog/windows-data-types#ulong_ptr) that it's width is dependant on the host architecture. The `PHANDLE` and `PSIZE_T` types use a new type map which allows us to have a closer mapping to the original function definitions/documentation on MSDN. Eventually, I think we should move towards even more explicit definitions such as defining `DWORD` as `uint32_t` for example. This would help prevent us from having to update the definitions in the future which would ideally only need to be done when they are inconsistent with what Microsoft has published.

I also consolidated the Meterpreter packet building code for both the single and multi dispatch routines. This reduces code reuse and will make refactoring easier in the future since there are fewer places that need to be updated to add, remove, and change data types.

Verification

- [ ] `post/test/railgun` should work, all tests should pass
- [ ] `post/test/railgun_reverse_lookups` should also work with all tests passing
- [ ] The steps to reproduce #14400 should show that the issue has been fixed, `check_dir_perms` now functions correctly
    * You'll need to use a 64-bit meterpreter session and grant privileges to everyone on a service executable for a true test case showing it works

<sup>1</sup> https://docs.microsoft.com/en-us/windows/win32/winprog/windows-data-types#size_t
