### PR TITLE
Add puma to gemspec

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,6 +48,7 @@ PATH
       pcaprub
       pdf-reader
       pg
+      puma
       railties
       rb-readline
       recog
@@ -122,7 +123,7 @@ GEM
     ast (2.4.1)
     aws-eventstream (1.1.0)
     aws-partitions (1.402.0)
-    aws-sdk-core (3.109.3)
+    aws-sdk-core (3.110.0)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)
       aws-sigv4 (~> 1.1)
@@ -244,6 +245,7 @@ GEM
     net-ssh (6.1.0)
     network_interface (0.0.2)
     nexpose (7.2.1)
+    nio4r (2.5.4)
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
     octokit (4.19.0)
@@ -273,6 +275,8 @@ GEM
       byebug (~> 11.0)
       pry (~> 0.13.0)
     public_suffix (4.0.6)
+    puma (5.1.0)
+      nio4r (~> 2.0)
     rack (2.2.3)
     rack-protection (2.1.0)
       rack

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -101,6 +101,7 @@ Gem::Specification.new do |spec|
   # Needed for Microsoft patch finding tool (msu_finder)
   spec.add_runtime_dependency 'patch_finder'
   # Required for Metasploit Web Services
+  spec.add_runtime_dependency 'puma'
   spec.add_runtime_dependency 'thin'
   spec.add_runtime_dependency 'sinatra'
   spec.add_runtime_dependency 'warden'


### PR DESCRIPTION
Placeholder pull request to see the impact of adding Puma to the gemspec.

## Verification

Verifying that Puma works:
```
$ bundle exec puma --port 8081 --environment production --tag msf-json-rpc ./msf-json-rpc.ru 
Puma starting in single mode...
* Puma version: 5.1.0 (ruby 2.7.2-p137) ("At Your Service")
*  Min threads: 0
*  Max threads: 5
*  Environment: production
*          PID: 17121
* Listening on http://0.0.0.0:8081
Use Ctrl-C to stop
```

Basic curl example:
```
$ curl --request POST --url http://localhost:8081/api/v1/json-rpc --header 'content-type: application/json' --data '{ "jsonrpc": "2.0", "method": "core.version", "id": 1, "params": [] }'
{"jsonrpc":"2.0","result":{"version":"6.0.19-dev-1a01581a6e","ruby":"2.7.2 x86_64-darwin19 2020-10-01","api":"1.0"},"id":1}% 
```