### PR TITLE
fix #14428, fix execute files with unicode characters in stdapi sys.process.execute

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,7 +29,7 @@ PATH
       metasploit-concern
       metasploit-credential
       metasploit-model
-      metasploit-payloads (= 2.0.23)
+      metasploit-payloads (= 2.0.24)
       metasploit_data_models
       metasploit_payloads-mettle (= 1.0.2)
       mqtt
@@ -220,7 +220,7 @@ GEM
       activemodel (~> 5.2.2)
       activesupport (~> 5.2.2)
       railties (~> 5.2.2)
-    metasploit-payloads (2.0.23)
+    metasploit-payloads (2.0.24)
     metasploit_data_models (4.1.1)
       activerecord (~> 5.2.2)
       activesupport (~> 5.2.2)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -70,7 +70,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '2.0.23'
+  spec.add_runtime_dependency 'metasploit-payloads', '2.0.24'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '1.0.2'
   # Needed by msfgui and other rpc components


### PR DESCRIPTION
This PR bumps framework to use Metasploit payloads gem 2.0.24 (previously 2.0.23), pulling in the following payloads PR changes:

* https://github.com/rapid7/metasploit-payloads/pull/446

## Verification
List the steps needed to make sure this thing works

- [x] Retest manually
- [x] Let automated tests pass