### PR TITLE
nimcontroller_bof: return CheckCode::Unknown if response is empty

### DIFF
--- a/modules/exploits/windows/nimsoft/nimcontroller_bof.rb
+++ b/modules/exploits/windows/nimsoft/nimcontroller_bof.rb
@@ -84,6 +84,10 @@ class MetasploitModule < Msf::Exploit::Remote
     sock.put(generate_probe('get_info', ['interfaces=0']))
     response = sock.get_once(4096)
 
+    unless response
+      return CheckCode::Unknown('No response')
+    end
+
     list_check = -1
 
     begin


### PR DESCRIPTION
Patch implemented based on source code review. Untested but apparently this patch works. #14462
