### PR TITLE
Make the EICAR canary useful again

### DIFF
--- a/lib/msf/core/framework.rb
+++ b/lib/msf/core/framework.rb
@@ -39,9 +39,6 @@ class Framework
 
   Revision = "$Revision$"
 
-  # EICAR canary
-  EICARCorrupted      = ::Msf::Util::EXE.is_eicar_corrupted?
-
   #
   # Mixin meant to be included into all classes that can have instances that
   # should be tied to the framework, such as modules.
@@ -247,6 +244,25 @@ class Framework
   def search(search_string)
     search_params = Msf::Modules::Metadata::Search.parse_search_string(search_string)
     Msf::Modules::Metadata::Cache.instance.find(search_params)
+  end
+
+  #
+  # EICAR Canary
+  # @return [Boolean] Should return true if the EICAR file has been corrupted
+  def eicar_corrupted?
+    path = ::File.expand_path(::File.join(
+      ::File.dirname(__FILE__),"..", "..", "..", "data", "eicar.com")
+    )
+    return true unless ::File.exist?(path)
+
+    data = ::File.read(path)
+    return true unless Digest::SHA1.hexdigest(data) == "3395856ce81f2b7382dee72602f798b642f14140"
+
+    false
+
+    # If anything goes wrong assume AV got us
+    rescue ::Exception
+      true
   end
 
 protected

--- a/lib/msf/core/framework.rb
+++ b/lib/msf/core/framework.rb
@@ -260,9 +260,9 @@ class Framework
 
     false
 
-    # If anything goes wrong assume AV got us
-    rescue ::Exception
-      true
+  # If anything goes wrong assume AV got us
+  rescue ::Exception
+    true
   end
 
 protected

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -238,8 +238,6 @@ class Core
   def cmd_banner(*args)
     banner  = "%cya" + Banner.to_s + "%clr\n\n"
 
-    avdwarn = nil
-
     stats       = framework.stats
     version     = "%yelmetasploit v#{Metasploit::Framework::VERSION}%clr",
     exp_aux_pos = "#{stats.num_exploits} exploits - #{stats.num_auxiliary} auxiliary - #{stats.num_post} post",
@@ -255,21 +253,8 @@ class Core
     banner << "\n"
     banner << Msf::Serializer::ReadableText.word_wrap("Metasploit tip: #{Tip.sample}\n", indent = 0, cols = 60)
 
-    if ::Msf::Framework::EICARCorrupted
-      avdwarn = []
-      avdwarn << "Warning: This copy of the Metasploit Framework has been corrupted by an installed anti-virus program."
-      avdwarn << "         We recommend that you disable your anti-virus or exclude your Metasploit installation path,"
-      avdwarn << "         then restore the removed files from quarantine or reinstall the framework. For more info: "
-      avdwarn << "             https://community.rapid7.com/docs/DOC-1273"
-      avdwarn << ""
-    end
-
     # Display the banner
     print_line(banner)
-
-    if(avdwarn)
-      avdwarn.map{|line| print_error(line) }
-    end
 
   end
 

--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -416,14 +416,13 @@ class Driver < Msf::Ui::Driver
   end
 
   def av_warning_message
-      avdwarn = []
-      avdwarn << "Warning: This copy of the Metasploit Framework has been corrupted by an installed anti-virus program."
-      avdwarn << "         We recommend that you disable your anti-virus or exclude your Metasploit installation path,"
-      avdwarn << "         then restore the removed files from quarantine or reinstall the framework. For more info: "
-      avdwarn << "             https://community.rapid7.com/docs/DOC-1273"
-      avdwarn << ""
+      avdwarn = "\e[31m"\
+                "Warning: This copy of the Metasploit Framework has been corrupted by an installed anti-virus program."\
+                " We recommend that you disable your anti-virus or exclude your Metasploit installation path, "\
+                "then restore the removed files from quarantine or reinstall the framework.\e[0m"\
+                "\n\nFor more info: https://community.rapid7.com/docs/DOC-1273\n\n"
 
-      avdwarn.map{|line| print_error(line) }
+      $stderr.puts(Msf::Serializer::ReadableText.word_wrap(avdwarn, 0, 80))
   end
 
   #

--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -393,7 +393,7 @@ class Driver < Msf::Ui::Driver
       print_warning(log_msg)
     end
 
-    if framework.db && framework.db.active
+    if framework.db&.active
       framework.db.workspace = framework.db.default_workspace unless framework.db.workspace
     end
 
@@ -406,11 +406,24 @@ class Driver < Msf::Ui::Driver
 
     run_single("banner") unless opts['DisableBanner']
 
+    av_warning_message if framework.eicar_corrupted?
+
     opts["Plugins"].each do |plug|
       run_single("load '#{plug}'")
     end if opts["Plugins"]
 
     self.on_command_proc = Proc.new { |command| framework.events.on_ui_command(command) }
+  end
+
+  def av_warning_message
+      avdwarn = []
+      avdwarn << "Warning: This copy of the Metasploit Framework has been corrupted by an installed anti-virus program."
+      avdwarn << "         We recommend that you disable your anti-virus or exclude your Metasploit installation path,"
+      avdwarn << "         then restore the removed files from quarantine or reinstall the framework. For more info: "
+      avdwarn << "             https://community.rapid7.com/docs/DOC-1273"
+      avdwarn << ""
+
+      avdwarn.map{|line| print_error(line) }
   end
 
   #

--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -420,7 +420,7 @@ class Driver < Msf::Ui::Driver
                 "Warning: This copy of the Metasploit Framework has been corrupted by an installed anti-virus program."\
                 " We recommend that you disable your anti-virus or exclude your Metasploit installation path, "\
                 "then restore the removed files from quarantine or reinstall the framework.\e[0m"\
-                "\n\nFor more info: https://community.rapid7.com/docs/DOC-1273\n\n"
+                "\n\n"
 
       $stderr.puts(Msf::Serializer::ReadableText.word_wrap(avdwarn, 0, 80))
   end

--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -2173,28 +2173,6 @@ require 'digest/sha1'
     ]
   end
 
-  #
-  # EICAR Canary
-  # @return [Boolean] Should return true
-  def self.is_eicar_corrupted?
-    path = ::File.expand_path(::File.join(
-      ::File.dirname(__FILE__),"..", "..", "..", "data", "eicar.com")
-    )
-    return true unless ::File.exist?(path)
-    ret = false
-    if ::File.exist?(path)
-      begin
-        data = ::File.read(path)
-        unless Digest::SHA1.hexdigest(data) == "3395856ce81f2b7382dee72602f798b642f14140"
-          ret = true
-        end
-      rescue ::Exception
-        ret = true
-      end
-    end
-    ret
-  end
-
   # self.get_file_contents
   #
   # @param perms  [String]


### PR DESCRIPTION
Resolves #14415 

Refactor of where and when the EICAR canary is checked

# Verification
- [x] Delete the `data/eicar.com` file
- [x] Startup framework (with and without the quiet flag `-q`)
- [x] Observe the EICAR warning

You may also delete the `/gems/metasploit-payloads-2.0.24/data/android/apk/classes.dex` file which was mentioned in the issue and framework should no longer break due to the load order differences meaning the AV warning will always be displayed first