### PR TITLE
Cygwin SSH Windows Identification

### DIFF
--- a/lib/metasploit/framework/login_scanner/ssh.rb
+++ b/lib/metasploit/framework/login_scanner/ssh.rb
@@ -158,7 +158,7 @@ module Metasploit
                   proof = proof.map {|item| item.strip}
                   proof = proof.join(", ").to_s
                 # Windows
-                elsif proof =~ /is not recognized as an internal or external command/
+                elsif proof =~ /command not found|is not recognized as an internal or external command/
                   proof = ssh_socket.exec!("systeminfo\n").to_s
                   /OS Name:\s+(?<os_name>.+)$/ =~ proof
                   /OS Version:\s+(?<os_num>.+)$/ =~ proof
@@ -208,7 +208,7 @@ module Metasploit
             'hpux'
           when /AIX/
             'aix'
-          when /Win32|Windows|Microsoft/
+          when /cygwin|Win32|Windows|Microsoft/
             'windows'
           when /Unknown command or computer name|Line has invalid autocommand/
             'cisco-ios'


### PR DESCRIPTION
## Description
- Updated result proof to identify Windows systems from Cygwin shells

## Verification
- [x] Start `msfconsole`
- [x] Scan [Metasploitable3](https://github.com/rapid7/metasploitable3)
- [x] Use the `auxiliary/scanner/ssh/ssh_login` Module
- [x] Add `Vagrant`:`Vagrant` as the credential pair and set RHOST to the address of Metasploitable3
- [x] **Verify** the proof properly identifies the machine as Windows (On the same line as `Success: 'vagrant':'vagrant'`)