### PR TITLE
force active record object load

### DIFF
--- a/lib/msf/core/db_manager/vuln.rb
+++ b/lib/msf/core/db_manager/vuln.rb
@@ -31,7 +31,7 @@ module Msf::DBManager::Vuln
     vuln = nil
 
     if service
-      other_vulns = service.vulns.includes(:vuln_details).where(crit)
+      other_vulns = service.vulns.includes(:vuln_details).where(crit).to_a
       vuln = other_vulns.empty? ? nil : other_vulns.first
     end
 
@@ -40,7 +40,7 @@ module Msf::DBManager::Vuln
 
     # Prevent matches against other services
     crit["vulns.service_id"] = nil if service
-    other_vulns = host.vulns.includes(:vuln_details).where(crit)
+    other_vulns = host.vulns.includes(:vuln_details).where(crit).to_a
     other_vulns.empty? ? nil : other_vulns.first
   end
 


### PR DESCRIPTION
In some cases when `empty?` returns true `first` will fail to get db connection

Stack trace when fails:
```
[*] Importing 'NeXpose XML Report' data
[*] Import: Parsing with 'Nokogiri v1.10.10'
[-] Error while running command db_import: No connection pool with 'primary' found.

Call stack:
/Users/jmartin/.rvm/gems/ruby-2.7.2@metasploit-framework/gems/activerecord-5.2.4.4/lib/active_record/connection_adapters/abstract/connection_pool.rb:1032:in `retrieve_connection'
/Users/jmartin/.rvm/gems/ruby-2.7.2@metasploit-framework/gems/activerecord-5.2.4.4/lib/active_record/connection_handling.rb:118:in `retrieve_connection'
/Users/jmartin/.rvm/gems/ruby-2.7.2@metasploit-framework/gems/activerecord-5.2.4.4/lib/active_record/connection_handling.rb:90:in `connection'
/Users/jmartin/.rvm/gems/ruby-2.7.2@metasploit-framework/gems/arel-9.0.0/lib/arel/nodes/node.rb:49:in `to_sql'
/Users/jmartin/.rvm/gems/ruby-2.7.2@metasploit-framework/gems/activerecord-5.2.4.4/lib/active_record/connection_adapters/postgresql/schema_statements.rb:580:in `block in columns_for_distinct'
/Users/jmartin/.rvm/gems/ruby-2.7.2@metasploit-framework/gems/activerecord-5.2.4.4/lib/active_record/connection_adapters/postgresql/schema_statements.rb:578:in `map'
/Users/jmartin/.rvm/gems/ruby-2.7.2@metasploit-framework/gems/activerecord-5.2.4.4/lib/active_record/connection_adapters/postgresql/schema_statements.rb:578:in `columns_for_distinct'
/Users/jmartin/.rvm/gems/ruby-2.7.2@metasploit-framework/gems/activerecord-5.2.4.4/lib/active_record/relation/finder_methods.rb:405:in `limited_ids_for'
/Users/jmartin/.rvm/gems/ruby-2.7.2@metasploit-framework/gems/activerecord-5.2.4.4/lib/active_record/relation/finder_methods.rb:391:in `apply_join_dependency'
/Users/jmartin/.rvm/gems/ruby-2.7.2@metasploit-framework/gems/activerecord-5.2.4.4/lib/active_record/relation.rb:550:in `block in exec_queries'
/Users/jmartin/.rvm/gems/ruby-2.7.2@metasploit-framework/gems/activerecord-5.2.4.4/lib/active_record/relation.rb:584:in `skip_query_cache_if_necessary'
/Users/jmartin/.rvm/gems/ruby-2.7.2@metasploit-framework/gems/activerecord-5.2.4.4/lib/active_record/relation.rb:547:in `exec_queries'
/Users/jmartin/.rvm/gems/ruby-2.7.2@metasploit-framework/gems/activerecord-5.2.4.4/lib/active_record/association_relation.rb:34:in `exec_queries'
/Users/jmartin/.rvm/gems/ruby-2.7.2@metasploit-framework/gems/activerecord-5.2.4.4/lib/active_record/relation.rb:422:in `load'
/Users/jmartin/.rvm/gems/ruby-2.7.2@metasploit-framework/gems/activerecord-5.2.4.4/lib/active_record/relation.rb:200:in `records'
/Users/jmartin/.rvm/gems/ruby-2.7.2@metasploit-framework/gems/activerecord-5.2.4.4/lib/active_record/relation.rb:195:in `to_ary'
/Users/jmartin/.rvm/gems/ruby-2.7.2@metasploit-framework/gems/activerecord-5.2.4.4/lib/active_record/relation/finder_methods.rb:532:in `find_nth_with_limit'
/Users/jmartin/.rvm/gems/ruby-2.7.2@metasploit-framework/gems/activerecord-5.2.4.4/lib/active_record/relation/finder_methods.rb:517:in `find_nth'
/Users/jmartin/.rvm/gems/ruby-2.7.2@metasploit-framework/gems/activerecord-5.2.4.4/lib/active_record/relation/finder_methods.rb:125:in `first'
/Users/jmartin/rapid7/src/r7-source/metasploit/metasploit-framework/lib/msf/core/db_manager/vuln.rb:44:in `find_vuln_by_details'
/Users/jmartin/rapid7/src/r7-source/metasploit/metasploit-framework/lib/msf/core/db_manager/vuln.rb:184:in `block in report_vuln'
/Users/jmartin/.rvm/gems/ruby-2.7.2@metasploit-framework/gems/activerecord-5.2.4.4/lib/active_record/connection_adapters/abstract/connection_pool.rb:416:in `with_connection'
/Users/jmartin/rapid7/src/r7-source/metasploit/metasploit-framework/lib/msf/core/db_manager/vuln.rb:96:in `report_vuln'
/Users/jmartin/rapid7/src/r7-source/metasploit/metasploit-framework/lib/metasploit/framework/data_service/proxy/vuln_data_proxy.rb:33:in `block in report_vuln'
/Users/jmartin/rapid7/src/r7-source/metasploit/metasploit-framework/lib/metasploit/framework/data_service/proxy/core.rb:166:in `data_service_operation'
/Users/jmartin/rapid7/src/r7-source/metasploit/metasploit-framework/lib/metasploit/framework/data_service/proxy/vuln_data_proxy.rb:31:in `report_vuln'
/Users/jmartin/rapid7/src/r7-source/metasploit/metasploit-framework/lib/rex/parser/nexpose_raw_nokogiri.rb:432:in `block in report_test'
/Users/jmartin/.rvm/gems/ruby-2.7.2@metasploit-framework/gems/activerecord-5.2.4.4/lib/active_record/connection_adapters/abstract/connection_pool.rb:416:in `with_connection'
/Users/jmartin/rapid7/src/r7-source/metasploit/metasploit-framework/lib/rex/parser/nexpose_raw_nokogiri.rb:429:in `report_test'
/Users/jmartin/rapid7/src/r7-source/metasploit/metasploit-framework/lib/rex/parser/nexpose_raw_nokogiri.rb:100:in `end_element'
/Users/jmartin/.rvm/gems/ruby-2.7.2@metasploit-framework/gems/nokogiri-1.10.10/lib/nokogiri/xml/sax/document.rb:127:in `end_element_namespace'
/Users/jmartin/.rvm/gems/ruby-2.7.2@metasploit-framework/gems/nokogiri-1.10.10/lib/nokogiri/xml/sax/parser.rb:110:in `parse_with'
/Users/jmartin/.rvm/gems/ruby-2.7.2@metasploit-framework/gems/nokogiri-1.10.10/lib/nokogiri/xml/sax/parser.rb:110:in `parse_memory'
/Users/jmartin/.rvm/gems/ruby-2.7.2@metasploit-framework/gems/nokogiri-1.10.10/lib/nokogiri/xml/sax/parser.rb:83:in `parse'
/Users/jmartin/rapid7/src/r7-source/metasploit/metasploit-framework/lib/msf/core/db_manager/import/nexpose/raw.rb:12:in `import_nexpose_raw_noko_stream'
/Users/jmartin/rapid7/src/r7-source/metasploit/metasploit-framework/lib/msf/core/db_manager/import/nexpose/raw.rb:25:in `import_nexpose_rawxml'
/Users/jmartin/rapid7/src/r7-source/metasploit/metasploit-framework/lib/msf/core/db_manager/import.rb:100:in `import'
/Users/jmartin/rapid7/src/r7-source/metasploit/metasploit-framework/lib/msf/core/db_manager/import.rb:219:in `import_file'
/Users/jmartin/rapid7/src/r7-source/metasploit/metasploit-framework/lib/metasploit/framework/data_service/proxy/db_import_data_proxy.rb:17:in `block in import_file'
/Users/jmartin/rapid7/src/r7-source/metasploit/metasploit-framework/lib/metasploit/framework/data_service/proxy/core.rb:166:in `data_service_operation'
/Users/jmartin/rapid7/src/r7-source/metasploit/metasploit-framework/lib/metasploit/framework/data_service/proxy/db_import_data_proxy.rb:15:in `import_file'
/Users/jmartin/rapid7/src/r7-source/metasploit/metasploit-framework/lib/msf/ui/console/command_dispatcher/db.rb:1463:in `block (3 levels) in cmd_db_import'
/Users/jmartin/rapid7/src/r7-source/metasploit/metasploit-framework/lib/msf/ui/console/command_dispatcher/db.rb:1456:in `each'
/Users/jmartin/rapid7/src/r7-source/metasploit/metasploit-framework/lib/msf/ui/console/command_dispatcher/db.rb:1456:in `block (2 levels) in cmd_db_import'
/Users/jmartin/rapid7/src/r7-source/metasploit/metasploit-framework/lib/msf/ui/console/command_dispatcher/db.rb:1450:in `each'
/Users/jmartin/rapid7/src/r7-source/metasploit/metasploit-framework/lib/msf/ui/console/command_dispatcher/db.rb:1450:in `block in cmd_db_import'
/Users/jmartin/.rvm/gems/ruby-2.7.2@metasploit-framework/gems/activerecord-5.2.4.4/lib/active_record/connection_adapters/abstract/connection_pool.rb:416:in `with_connection'
/Users/jmartin/rapid7/src/r7-source/metasploit/metasploit-framework/lib/msf/ui/console/command_dispatcher/db.rb:1445:in `cmd_db_import'
/Users/jmartin/rapid7/src/r7-source/metasploit/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:525:in `run_command'
/Users/jmartin/rapid7/src/r7-source/metasploit/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:476:in `block in run_single'
/Users/jmartin/rapid7/src/r7-source/metasploit/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:470:in `each'
/Users/jmartin/rapid7/src/r7-source/metasploit/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:470:in `run_single'
/Users/jmartin/rapid7/src/r7-source/metasploit/metasploit-framework/lib/rex/ui/text/shell.rb:158:in `run'
/Users/jmartin/rapid7/src/r7-source/metasploit/metasploit-framework/lib/metasploit/framework/command/console.rb:48:in `start'
/Users/jmartin/rapid7/src/r7-source/metasploit/metasploit-framework/lib/metasploit/framework/command/base.rb:82:in `start'
./msfconsole:23:in `<main>'
```
## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `workspace -a importTest`
- [x] `db_import import-sample.xml`
- [x] **Verify** hosts, services & vulns import.


[import-sample.xml.gz](https://github.com/rapid7/metasploit-framework/files/5668987/import-sample.xml.gz)
