### PR TITLE
Improve handling of external modules when missing runtime dependencies

### DIFF
--- a/lib/msf/core/module_manager.rb
+++ b/lib/msf/core/module_manager.rb
@@ -27,12 +27,6 @@ module Msf
 
     include Enumerable
 
-    #
-    # CONSTANTS
-    #
-
-    # Maps module type directory to its module type.
-    TYPE_BY_DIRECTORY = Msf::Modules::Loader::Base::DIRECTORY_BY_TYPE.invert
 
     def [](key)
       names = key.split("/")
@@ -64,7 +58,7 @@ module Msf
       potential_type_or_directory = names.first
 
       # if first name is a type
-      if Msf::Modules::Loader::Base::DIRECTORY_BY_TYPE.has_key? potential_type_or_directory
+      if DIRECTORY_BY_TYPE.has_key? potential_type_or_directory
         type = potential_type_or_directory
       # if first name is a type directory
       else

--- a/lib/msf/core/module_manager/cache.rb
+++ b/lib/msf/core/module_manager/cache.rb
@@ -83,7 +83,7 @@ module Msf::ModuleManager::Cache
 
       # XXX borked
       loaders.each do |loader|
-        if loader.loadable?(parent_path)
+        if loader.loadable_module?(parent_path, type, reference_name)
           type = module_info[:type]
           reference_name = module_info[:reference_name]
 

--- a/lib/msf/core/module_manager/loading.rb
+++ b/lib/msf/core/module_manager/loading.rb
@@ -21,6 +21,10 @@ module Msf::ModuleManager::Loading
       Msf::Modules::Loader::Executable # TODO: XXX: When this is the first loader we can load normal exploits, but not payloads
   ]
 
+  # Maps module type directory to its module type.
+  DIRECTORY_BY_TYPE = Msf::Modules::Loader::Base::DIRECTORY_BY_TYPE
+  TYPE_BY_DIRECTORY = Msf::Modules::Loader::Base::TYPE_BY_DIRECTORY
+
   def file_changed?(path)
     changed = false
 
@@ -47,6 +51,40 @@ module Msf::ModuleManager::Loading
     end
 
     changed
+  end
+
+  # Return errors associated with the supplied reference name.
+  #
+  # @param name [String] e.g. 'auxiliary/scanner/msmail/host_id'
+  #   It may optionally be prefixed with a "<type>/", in which case we
+  #   will pass it to `get_module_error(module_reference_name, type)`.
+  #   Otherwise, we step through all sets until we find one that
+  #   matches.
+  # @return (error) which will return either an error or nil.
+  def load_error_by_name(name)
+    return load_error_by_name(self.aliases[name]) if self.aliases[name]
+    names = name.split("/")
+    potential_type_or_directory = names.first
+
+    if DIRECTORY_BY_TYPE.has_key? potential_type_or_directory
+      type = potential_type_or_directory
+      # if first name is a type directory
+    else
+      type = TYPE_BY_DIRECTORY[potential_type_or_directory]
+    end
+
+    error = nil
+    if type
+      module_reference_name = names[1 .. -1].join("/")
+      error = get_module_error(module_reference_name, type)
+    else
+      module_set_by_type.each do |type, _set|
+        module_reference_name = "#{type}/#{name}"
+        error = load_error_by_name(module_reference_name)
+        break if error
+      end
+    end
+    error
   end
 
   attr_accessor :module_load_error_by_path, :module_load_warnings
@@ -136,5 +174,21 @@ module Msf::ModuleManager::Loading
     end
 
     count_by_type
+  end
+
+  # Get a specific modules errors from the supplied module_reference_name and type
+  #
+  # @param module_reference_name [String] e.g. 'scanner/msmail/host_id'
+  # @param type [String] this will be the type of module e.g. 'auxiliary'
+  #
+  # These @params will the be used to loop through `module_info_by_path` [Hash] to check for
+  # any matching modules paths. This path becomes the key and returns the associated error.
+  def get_module_error(module_reference_name, type)
+    module_info_by_path.each do |mod_path, module_value|
+      if module_value[:reference_name] == module_reference_name && module_value[:type] == type
+        return module_load_error_by_path[mod_path]
+      end
+    end
+    nil
   end
 end

--- a/lib/msf/core/modules/external/bridge.rb
+++ b/lib/msf/core/modules/external/bridge.rb
@@ -72,6 +72,12 @@ module Msf::Modules
         else
           raise "Error running module #{self.path}"
         end
+      rescue => e
+        raise handle_exception(e)
+      end
+
+      def handle_exception(e)
+        e
       end
 
       def write_message(fd, json)
@@ -176,6 +182,15 @@ class Msf::Modules::External::PyBridge < Msf::Modules::External::Bridge
     pythonpath = ENV['PYTHONPATH'] || ''
     self.env = self.env.merge({ 'PYTHONPATH' => File.expand_path('../python', __FILE__) + File::PATH_SEPARATOR + pythonpath})
   end
+
+  def handle_exception(error)
+    case error
+    when Errno::ENOENT
+      LoadError.new('Failed to execute external Python module. Please ensure you have Python installed on your environment.')
+    else
+      super
+    end
+  end
 end
 
 class Msf::Modules::External::RbBridge < Msf::Modules::External::Bridge
@@ -211,6 +226,15 @@ class Msf::Modules::External::GoBridge < Msf::Modules::External::Bridge
 
     self.env = self.env.merge({'GOPATH' => go_path})
     self.cmd = ['go', 'run', self.path]
+  end
+
+  def handle_exception(error)
+    case error
+    when Errno::ENOENT
+      LoadError.new('Failed to execute external Go module. Please ensure you have Go installed on your environment.')
+    else
+      super
+    end
   end
 end
 

--- a/lib/msf/core/modules/loader/directory.rb
+++ b/lib/msf/core/modules/loader/directory.rb
@@ -1,6 +1,6 @@
 # -*- coding: binary -*-
 
-# Concerns loading module from a directory
+# Concerns loading Ruby modules from a directory
 class Msf::Modules::Loader::Directory < Msf::Modules::Loader::Base
   # Returns true if the path is a directory
   #
@@ -9,6 +9,11 @@ class Msf::Modules::Loader::Directory < Msf::Modules::Loader::Base
   # @return [false] otherwise
   def loadable?(path)
     File.directory?(path)
+  end
+
+  def loadable_module?(parent_path, type, module_reference_name)
+    full_path = module_path(parent_path, type, module_reference_name)
+    module_path?(full_path)
   end
 
   protected
@@ -35,7 +40,7 @@ class Msf::Modules::Loader::Directory < Msf::Modules::Loader::Base
 
       # Try to load modules from all the files in the supplied path
       Rex::Find.find(full_entry_path) do |entry_descendant_path|
-        if module_path?(entry_descendant_path) && !script_path?(entry_descendant_path)
+        if module_path?(entry_descendant_path)
           entry_descendant_pathname = Pathname.new(entry_descendant_path)
           relative_entry_descendant_pathname = entry_descendant_pathname.relative_path_from(full_entry_pathname)
           relative_entry_descendant_path = relative_entry_descendant_pathname.to_s

--- a/lib/msf/core/modules/loader/executable.rb
+++ b/lib/msf/core/modules/loader/executable.rb
@@ -11,6 +11,11 @@ class Msf::Modules::Loader::Executable < Msf::Modules::Loader::Base
     File.directory?(path)
   end
 
+  def loadable_module?(parent_path, type, module_reference_name)
+    full_path = module_path(parent_path, type, module_reference_name)
+    script_path?(full_path)
+  end
+
   protected
 
   # Yields the module_reference_name for each module file found under the directory path.
@@ -88,6 +93,9 @@ class Msf::Modules::Loader::Executable < Msf::Modules::Loader::Base
         elog "Unable to load module #{full_path}, unknown module type"
         return ''
       end
+    rescue LoadError => e
+      load_error(full_path, e)
+      return ''
     rescue ::Exception => e
       elog("Unable to load module #{full_path}", error: e)
       # XXX migrate this to a full load_error when we can tell the user why the

--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -672,7 +672,17 @@ module Msf
               mod = framework.modules.create(mod_name)
 
               unless mod
+                # Checks to see if we have any load_errors for the current module.
+                # and if so, returns them to the user.
+                load_error = framework.modules.load_error_by_name(mod_name)
+                if load_error
+                  print_error("Failed to load module: #{load_error}")
+                  return false
+                end
                 unless mod_resolved
+                  elog("Module #{mod_name} not found, and no loading errors found. If you're using a custom module" \
+                    ' refer to our wiki: https://github.com/rapid7/metasploit-framework/wiki/Running-Private-Modules')
+
                   # Avoid trying to use the search result if it exactly matches
                   # the module we were trying to load. The module cannot be
                   # loaded and searching isn't going to change that.

--- a/spec/lib/msf/core/modules/loader/base_spec.rb
+++ b/spec/lib/msf/core/modules/loader/base_spec.rb
@@ -687,8 +687,15 @@ RSpec.describe Msf::Modules::Loader::Base do
     end
 
     context '#module_path?' do
+      def mock_module(module_path, content: nil, executable: false)
+        allow(File).to receive(:file?).with(module_path).and_return(true)
+        allow(File).to receive(:read).with(module_path, 2).and_return(content)
+        allow(File).to receive(:executable?).with(module_path).and_return(executable)
+      end
+
       it 'should return false if path is hidden' do
         hidden_path = '.hidden/path/file.rb'
+        mock_module(hidden_path)
 
         expect(subject.send(:module_path?, hidden_path)).to be_falsey
       end
@@ -696,6 +703,7 @@ RSpec.describe Msf::Modules::Loader::Base do
       it 'should return false if the file extension is not MODULE_EXTENSION' do
         non_module_extension = '.c'
         path = "path/with/wrong/extension#{non_module_extension}"
+        mock_module(path)
 
         expect(non_module_extension).not_to eq described_class::MODULE_EXTENSION
         expect(subject.send(:module_path?, path)).to be_falsey
@@ -704,6 +712,7 @@ RSpec.describe Msf::Modules::Loader::Base do
       it 'should return false if the file is a unit test' do
         unit_test_extension = '.rb.ut.rb'
         path = "path/to/unit_test#{unit_test_extension}"
+        mock_module(path)
 
         expect(subject.send(:module_path?, path)).to be_falsey
       end
@@ -711,12 +720,23 @@ RSpec.describe Msf::Modules::Loader::Base do
       it 'should return false if the file is a test suite' do
         test_suite_extension = '.rb.ts.rb'
         path = "path/to/test_suite#{test_suite_extension}"
+        mock_module(path)
 
         expect(subject.send(:module_path?, path)).to be_falsey
       end
 
       it 'should return true otherwise' do
+        mock_module(module_path)
         expect(subject.send(:module_path?, module_path)).to be_truthy
+      end
+
+      it 'should not load executable modules' do
+        mock_module(
+            module_path,
+            content: "#!",
+            executable: true
+        )
+        expect(subject.send(:module_path?, module_path)).to be_falsey
       end
     end
 

--- a/spec/support/shared/examples/msf/module_manager/cache.rb
+++ b/spec/support/shared/examples/msf/module_manager/cache.rb
@@ -177,8 +177,13 @@ RSpec.shared_examples_for 'Msf::ModuleManager::Cache' do
 
       it 'should enumerate loaders until if it find the one where loadable?(parent_path) is true' do
         # Only the first one gets it since it finds the module
-        loader = module_manager.send(:loaders).first
-        expect(loader).to receive(:loadable?).with(parent_path).and_call_original
+        first_loader = module_manager.send(:loaders).first
+        expect(first_loader).to receive(:loadable_module?).with(parent_path, type, reference_name).and_return(false)
+        expect(first_loader).not_to receive(:load_module)
+
+        second_loader = module_manager.send(:loaders).second
+        expect(second_loader).to receive(:loadable_module?).with(parent_path, type, reference_name).and_return(true)
+        expect(second_loader).to receive(:load_module).with(parent_path, type, reference_name, force: true).and_call_original
 
         load_cached_module
       end

--- a/spec/support/shared/examples/msf/module_manager/loading.rb
+++ b/spec/support/shared/examples/msf/module_manager/loading.rb
@@ -1,4 +1,92 @@
 RSpec.shared_examples_for 'Msf::ModuleManager::Loading' do
+  let(:parent_path) do
+    Metasploit::Framework.root.join('modules')
+  end
+
+  let(:module_basename) do
+    [basename_prefix, '.rb']
+  end
+
+  context '#load_error_by_name' do
+    it 'should return errors associated with that module' do
+      Tempfile.open(module_basename) do |tempfile|
+        module_path = tempfile.path
+        modification_time = File.mtime(module_path).to_i
+        name = 'auxiliary/mock_dir/mock_dir/mock_file'
+
+        subject.send(:module_info_by_path)[module_path] = {
+            reference_name: 'mock_dir/mock_dir/mock_file',
+            type: 'auxiliary',
+            parent_path: parent_path,
+            modification_time: modification_time
+        }
+        subject.send(:module_load_error_by_path)[module_path] = 'mock error'
+
+        subject.load_error_by_name(name)
+        expect(subject.load_error_by_name(name)).to(eql 'mock error')
+      end
+    end
+
+    it 'should return errors associated with that module, even without a prefixed module type' do
+      Tempfile.open(module_basename) do |tempfile|
+        module_path = tempfile.path
+        modification_time = File.mtime(module_path).to_i
+        name = 'mock_dir/mock_dir/mock_file'
+
+        subject.send(:module_info_by_path)[module_path] = {
+            reference_name: 'mock_dir/mock_dir/mock_file',
+            type: 'auxiliary',
+            parent_path: parent_path,
+            modification_time: modification_time
+        }
+        subject.send(:module_load_error_by_path)[module_path] = 'mock error'
+
+        subject.load_error_by_name(name)
+        expect(subject.load_error_by_name(name)).to(eql 'mock error')
+      end
+    end
+
+    it 'should recognise we are passing a module alias and return errors associated with that aliased module' do
+      Tempfile.open(module_basename) do |tempfile|
+        module_path = tempfile.path
+        modification_time = File.mtime(module_path).to_i
+        name = 'auxiliary/mock_dir/mock_dir/mock_file'
+
+        subject.send(:module_info_by_path)[module_path] = {
+            reference_name: 'mock_dir/mock_dir/mock_file',
+            type: 'auxiliary',
+            parent_path: parent_path,
+            modification_time: modification_time
+        }
+
+        subject.send(:module_load_error_by_path)[module_path] = 'mock error'
+        subject.send(:aliases)['auxiliary/mock_dir/mock_dir/mock_file_alias'] = 'auxiliary/mock_dir/mock_dir/mock_file'
+        subject.send(:inv_aliases)['auxiliary/mock_dir/mock_dir/mock_file'] = 'auxiliary/mock_dir/mock_dir/mock_file_alias'
+
+        subject.load_error_by_name(name)
+        expect(subject.load_error_by_name(name)).to(eql 'mock error')
+      end
+    end
+
+    it 'should return nil as this module will have no associated errors' do
+      Tempfile.open(module_basename) do |tempfile|
+        module_path = tempfile.path
+        modification_time = File.mtime(module_path).to_i
+        name = 'auxiliary/mock_dir/mock_dir/mock_file'
+
+        subject.send(:module_info_by_path)[module_path] = {
+            reference_name: 'mock_dir/mock_dir/mock_file',
+            type: 'auxiliary',
+            parent_path: parent_path,
+            modification_time: modification_time
+        }
+
+        subject.load_error_by_name(name)
+        expect(subject.load_error_by_name(name)).to(eql nil)
+      end
+    end
+  end
+
   context '#file_changed?' do
     let(:module_basename) do
       [basename_prefix, '.rb']
@@ -104,10 +192,6 @@ RSpec.shared_examples_for 'Msf::ModuleManager::Loading' do
           ],
           'type' => type
       }
-    end
-
-    let(:parent_path) do
-      Metasploit::Framework.root.join('modules')
     end
 
     let(:path) do


### PR DESCRIPTION
This PR improves the handling of external modules when they're missing runtime dependencies.

Previously if the user was missing a runtime language for an external module they were trying to run, they got back a generic error that just stated that the selected module failed to load.
 
This PR aims to give the user a more useful error. It will now return which runtime language the user is missing on their environment (this has been implemented for both Python and Go).

## Before
![image](https://user-images.githubusercontent.com/69522014/106272145-7d940a80-6228-11eb-9555-7440f3cd1bbb.png)

## After
![image](https://user-images.githubusercontent.com/69522014/106272665-4f62fa80-6229-11eb-8754-ce26a29f1754.png)

## Note
This also propagates ruby syntax errors about modules to the users now:
![image](https://user-images.githubusercontent.com/69522014/106148012-74476700-6170-11eb-81bf-127134df4d2f.png)

## Aliases
Aliased modules are also supported. 
![image](https://user-images.githubusercontent.com/69522014/106302277-a7f9be00-6250-11eb-964d-087743ff475b.png)



## Verification
### To test this PR you will need an environment that doesn't have either Python or Go installed.

- [ ] Start `msfconsole`
- [ ] use a Python or Go external module e.g. `use auxiliary/scanner/msmail/host_id`
- [ ] **Verify** the output now informs the user they are missing the required runtime language
- [ ] **Verify** these changes have not altered regular module functionality

To test aliases being handled correctly, I added the line below into `module_manager.rb` [to the begiining of the `create` method](https://github.com/rapid7/metasploit-framework/blob/1619f8333d9822ccdb80b0782cb6af912a00188f/lib/msf/core/module_manager.rb#L58). 
```
self.aliases["auxiliary/mock_scanner/mock_mail/mock_host_id"] = "auxiliary/scanner/msmail/host_id"
``` 

- [ ] Start `msfconsole`
- [ ] use `auxiliary/mock_scanner/mock_mail/mock_host_id` (if you have copied my method above)
- [ ] **Verify** the output still informs the user they are missing the required runtime language
- [ ] **Verify** these changes have not altered regular module functionality
