### PR TITLE
Replace self with the explicit Module name In AuthServlet lambdas

### DIFF
--- a/lib/msf/core/web_services/servlet/auth_servlet.rb
+++ b/lib/msf/core/web_services/servlet/auth_servlet.rb
@@ -58,8 +58,8 @@ module Msf::WebServices::AuthServlet
     lambda {
       warden.authenticate!(scope: :user)
 
-      if session[:return_to].nil? || session[:return_to] == self.api_login_path
-        redirect self.api_account_path
+      if session[:return_to].nil? || session[:return_to] == Msf::WebServices::AuthServlet.api_login_path
+        redirect Msf::WebServices::AuthServlet.api_account_path
       else
         redirect session[:return_to]
       end
@@ -70,7 +70,7 @@ module Msf::WebServices::AuthServlet
   def self.get_logout
     lambda {
       warden.logout
-      redirect self.api_account_path
+      redirect Msf::WebServices::AuthServlet.api_account_path
     }
   end
 
@@ -79,7 +79,7 @@ module Msf::WebServices::AuthServlet
     lambda {
       # change action to drop the scope param since this is used
       # by XMLHttpRequest (XHR) and we don't want a redirect
-      warden.authenticate!(scope: :user, action: self.api_unauthenticated_path)
+      warden.authenticate!(scope: :user, action: Msf::WebServices::AuthServlet.api_unauthenticated_path)
       token = get_db.create_new_user_token(id: warden.user(:user).id, token_length: 40)
       set_json_data_response(response: {message: "Generated new API token.", token: token})
     }
@@ -90,7 +90,7 @@ module Msf::WebServices::AuthServlet
     lambda {
       if !params['scope'].nil? && params['scope'] == 'user'
         session[:return_to] = warden_options[:attempted_path] if session[:return_to].nil?
-        redirect self.api_login_path
+        redirect Msf::WebServices::AuthServlet.api_login_path
       end
 
       msg = warden_options[:message]


### PR DESCRIPTION
Resolves #14496 

This file was partially refactored incorrectly as part of #14202
Totally my fault I had no idea that when you're running code in a lambda like this is changes the meaning of `self`, basically I thought I made a safe change but I didn't


I also did a quick check and didn't spot any other cases where this could be a problem but if you spot any give me a shout

# Verification

- [ ] run `./msfdb reinit`

That's all the steps, it breaks on master and works with this PR

Output on Master:
```
~/dev/metasploit-framework on  upstream-master! ⌚ 10:36:27
$ ./msfdb reinit                                                                                                                                                           ‹ruby-2.7.2@metasploit-framework›
[?] Would you like to delete your existing data and configurations?: 
Please answer yes or no.
[?] Would you like to delete your existing data and configurations?: y
====================================================================
Running the 'reinit' command for the database:
Stopping database at /home/dwelch/.msf4/db
Deleting all data at /home/dwelch/.msf4/db
Creating database at /home/dwelch/.msf4/db
Starting database at /home/dwelch/.msf4/db...success
Creating database users
Writing client authentication configuration file /home/dwelch/.msf4/db/pg_hba.conf
Stopping database at /home/dwelch/.msf4/db
Starting database at /home/dwelch/.msf4/db...success
Creating initial database schema
====================================================================

====================================================================
Running the 'reinit' command for the webservice:
MSF web service is no longer running
[?] Initial MSF web service account username? [dwelch]: 
[?] Initial MSF web service account password? (Leave blank for random password): 
Generating SSL key and certificate for MSF web service
Attempting to start MSF web service...success
MSF web service started and online
Creating MSF web service user dwelch

    ############################################################
    ##              MSF Web Service Credentials               ##
    ##                                                        ##
    ##        Please store these credentials securely.        ##
    ##    You will need them to connect to the webservice.    ##
    ############################################################

MSF web service username: ****************
MSF web service password: ********************************************
[!] Error creating MSF web service user API token
Failed to complete MSF web service configuration, please reinitialize.
Stopping MSF web service PID 72426
====================================================================

```

And with this PR

```
~/dev/metasploit-framework on  upstream-master! ⌚ 11:14:36
$ ./msfdb reinit                                                                                                                                                           ‹ruby-2.7.2@metasploit-framework›
[?] Would you like to delete your existing data and configurations?: 
Please answer yes or no.
[?] Would you like to delete your existing data and configurations?: y
====================================================================
Running the 'reinit' command for the database:
Stopping database at /home/dwelch/.msf4/db
Deleting all data at /home/dwelch/.msf4/db
Creating database at /home/dwelch/.msf4/db
Starting database at /home/dwelch/.msf4/db...success
Creating database users
Writing client authentication configuration file /home/dwelch/.msf4/db/pg_hba.conf
Stopping database at /home/dwelch/.msf4/db
Starting database at /home/dwelch/.msf4/db...success
Creating initial database schema
====================================================================

====================================================================
Running the 'reinit' command for the webservice:
Stopping MSF web service PID 77301
[?] Initial MSF web service account username? [dwelch]: 
[?] Initial MSF web service account password? (Leave blank for random password): 
Generating SSL key and certificate for MSF web service
Attempting to start MSF web service...success
MSF web service started and online
Creating MSF web service user dwelch

    ############################################################
    ##              MSF Web Service Credentials               ##
    ##                                                        ##
    ##        Please store these credentials securely.        ##
    ##    You will need them to connect to the webservice.    ##
    ############################################################

MSF web service username: ******
MSF web service password: ************************************************
MSF web service user API token: ************************************************************************************************************


MSF web service configuration complete
The web service has been configured as your default data service in msfconsole with the name "local-https-data-service"

If needed, manually reconnect to the data service in msfconsole using the command:
db_connect --token ************************************************************************************************************ --cert /home/dwelch/.msf4/msf-ws-cert.pem --skip-verify https://localhost:5443

The username and password are credentials for the API account:
https://localhost:5443/api/v1/auth/account

====================================================================
```