### PR TITLE
fix railgun file_version and add test

### DIFF
--- a/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/windows/def_version.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/windows/def_version.rb
@@ -29,7 +29,8 @@ class Def_windows_version
     dll.add_function('VerQueryValueA', 'BOOL',[
       ["LPVOID","pBlock","in"],
       ["PCHAR","lpSubBlock","in"],
-      ["LPVOID","lplpBuffer","out"],
+      # On MSDN this is LPVOID, but must be PHANDLE
+      ["PHANDLE","lplpBuffer","out"],
       ["PDWORD","puLen","out"]
     ])
 

--- a/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/windows/def_version.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/windows/def_version.rb
@@ -29,8 +29,7 @@ class Def_windows_version
     dll.add_function('VerQueryValueA', 'BOOL',[
       ["LPVOID","pBlock","in"],
       ["PCHAR","lpSubBlock","in"],
-      # On MSDN this is LPVOID, but must be PHANDLE
-      ["PHANDLE","lplpBuffer","out"],
+      ["PULONG_PTR","lplpBuffer","out"],
       ["PDWORD","puLen","out"]
     ])
 

--- a/test/modules/post/test/railgun.rb
+++ b/test/modules/post/test/railgun.rb
@@ -6,6 +6,8 @@ require 'module_test'
 class MetasploitModule < Msf::Post
 
   include Msf::ModuleTest::PostTest
+  include Msf::Post::File
+  include Msf::Post::Windows::FileInfo
   include Msf::Post::Windows::Railgun
 
   def initialize(info={})
@@ -84,6 +86,15 @@ class MetasploitModule < Msf::Post
     end
 
     session.railgun.libc.free(buffer)
+  end
+
+  def test_api_function_file_info_windows
+    return unless session.platform == 'windows'
+    it "Should retrieve the win32k file version" do
+      path = expand_path('%WINDIR%\\system32\\win32k.sys')
+      major, minor, build, revision, brand = file_version(path)
+      true
+    end
   end
 
   def test_api_function_calls_windows


### PR DESCRIPTION
This fixes the file_version function which is currently crashing after:
https://github.com/rapid7/metasploit-framework/pull/14448/files

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] Get a x64 meterpreter session on Windows
- [x] `loadpath test/modules`
- [x] `use post/test/railgun`
- [x] `set SESSION -1`
- [x] `run`
- [ ] ...
- [x] **Verify** the tests pass

