### PR TITLE
Make feature, enhancement, library label exemptions

### DIFF
--- a/.github/workflows/schedule-stale.yml
+++ b/.github/workflows/schedule-stale.yml
@@ -32,5 +32,5 @@ jobs:
 
             As a friendly reminder: the best way to see this issue, or any other, fixed is to open a Pull Request.
           exempt-issue-labels: |
-            not-stale,confirmed,easy,newbie-friendly,suggestion,suggestion-module,suggestion-feature,suggestion-docs,ascii-utf8-issues,database
+            not-stale,confirmed,easy,newbie-friendly,suggestion,suggestion-module,suggestion-feature,suggestion-docs,ascii-utf8-issues,database,feature,enhancement,library
           debug-only: false


### PR DESCRIPTION
More exempt labels, these aren't really used for issues with the new suggestion-* labels but there are some older issues with these labels that shouldn't be auto-closed
