### PR TITLE
Lazy load `HrrRbSsh` to stop `pty` from being required on windows

### DIFF
--- a/lib/rex/proto/ssh/server.rb
+++ b/lib/rex/proto/ssh/server.rb
@@ -1,9 +1,11 @@
 # -*- coding: binary -*-
-require 'rex/proto/ssh/connection'
 
 module Rex
 module Proto
 module Ssh
+
+  autoload :Connection, 'rex/proto/ssh/connection'
+
 ###
 #
 # Runtime extension of the SSH clients that connect to the server.


### PR DESCRIPTION
Resolves #14512 

Presumably broken by _something_ in #14202 

More work to be done to be nicer to the user, catching the actual problem of `pty` not being available on windows and logging out the reason

# Verification
Steps for reproducing the issue are mentioned in the issue

- [ ] Install latest framework on windows
- [ ] Verify that running msfconsole breaks
- [ ] Switch over to this PR
- [ ] msfconsole should now start up