### PR TITLE
Eagerly load hrr_rb_ssh within reverse_ssh module

### DIFF
--- a/modules/payloads/singles/cmd/unix/reverse_ssh.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_ssh.rb
@@ -3,6 +3,7 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
+require 'msf/core/handler/reverse_ssh'
 require 'msf/base/sessions/command_shell'
 require 'msf/base/sessions/command_shell_options'
 


### PR DESCRIPTION
Context: The current `reverse_ssh` module depends on `hrr_rb_ssh`. This gem does not work on windows as it eventually loads the `pty` ruby module, which isn't compiled/supported on Windows.

When zeitwerk introduced lazy loading of the core folder, it changed when hrr_rb_sh gets loaded. It turns out that If the load to hr_rb_ssh is deferred, it will throw an error during a later stage of the payload set calculation steps - rather than during the initial module loading stage. The payload calculation doesn't have any error handling, which causes the LoadError of `pty` to bubble up and kill the running process instead.

To keep things simple, this PR fixes the initial crash by PR forcing the synchronous/eager loading of hrr_rb_sh to occur during the module loading stage, rather than during the later payload calculation stage. We'll have to think about which other modules lazy loading will impact.

---

Fixes #14512
Replaces the need for https://github.com/rapid7/metasploit-framework/pull/14514
Regression introduced by https://github.com/rapid7/metasploit-framework/pull/14202

## Verification

Verify that this version works on windows and linux:

- [ ] `msfconsole.bat`
- [ ] `msfvenom.bat -l payload`
- [ ] `./msfvenom -p linux/x64/meterpreter_reverse_https -f elf  -o linux-x64-meterpreter_reverse_https-192x168x16x137-30004.elf LHOST=192.168.15.71 LPORT=30004`