### PR TITLE
Note that Meterpreter now requires Windows XP SP2 or newer

### DIFF
--- a/modules/payloads/singles/windows/meterpreter_bind_named_pipe.rb
+++ b/modules/payloads/singles/windows/meterpreter_bind_named_pipe.rb
@@ -21,7 +21,7 @@ module MetasploitModule
 
     super(merge_info(info,
       'Name'        => 'Windows Meterpreter Shell, Bind Named Pipe Inline',
-      'Description' => 'Connect to victim and spawn a Meterpreter shell',
+      'Description' => 'Connect to victim and spawn a Meterpreter shell. Requires Windows XP SP2 or newer.',
       'Author'      => [ 'UserExistsError' ],
       'License'     => MSF_LICENSE,
       'Platform'    => 'win',

--- a/modules/payloads/singles/windows/meterpreter_bind_tcp.rb
+++ b/modules/payloads/singles/windows/meterpreter_bind_tcp.rb
@@ -21,7 +21,7 @@ module MetasploitModule
 
     super(merge_info(info,
       'Name'        => 'Windows Meterpreter Shell, Bind TCP Inline',
-      'Description' => 'Connect to victim and spawn a Meterpreter shell',
+      'Description' => 'Connect to victim and spawn a Meterpreter shell. Requires Windows XP SP2 or newer.',
       'Author'      => [ 'OJ Reeves' ],
       'License'     => MSF_LICENSE,
       'Platform'    => 'win',

--- a/modules/payloads/singles/windows/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/windows/meterpreter_reverse_http.rb
@@ -21,7 +21,7 @@ module MetasploitModule
 
     super(merge_info(info,
       'Name'        => 'Windows Meterpreter Shell, Reverse HTTP Inline',
-      'Description' => 'Connect back to attacker and spawn a Meterpreter shell',
+      'Description' => 'Connect back to attacker and spawn a Meterpreter shell. Requires Windows XP SP2 or newer.',
       'Author'      => [ 'OJ Reeves' ],
       'License'     => MSF_LICENSE,
       'Platform'    => 'win',

--- a/modules/payloads/singles/windows/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/windows/meterpreter_reverse_https.rb
@@ -21,7 +21,7 @@ module MetasploitModule
 
     super(merge_info(info,
       'Name'        => 'Windows Meterpreter Shell, Reverse HTTPS Inline',
-      'Description' => 'Connect back to attacker and spawn a Meterpreter shell',
+      'Description' => 'Connect back to attacker and spawn a Meterpreter shell. Requires Windows XP SP2 or newer.',
       'Author'      => [ 'OJ Reeves' ],
       'License'     => MSF_LICENSE,
       'Platform'    => 'win',

--- a/modules/payloads/singles/windows/meterpreter_reverse_ipv6_tcp.rb
+++ b/modules/payloads/singles/windows/meterpreter_reverse_ipv6_tcp.rb
@@ -21,7 +21,7 @@ module MetasploitModule
 
     super(merge_info(info,
       'Name'        => 'Windows Meterpreter Shell, Reverse TCP Inline (IPv6)',
-      'Description' => 'Connect back to attacker and spawn a Meterpreter shell',
+      'Description' => 'Connect back to attacker and spawn a Meterpreter shell. Requires Windows XP SP2 or newer.',
       'Author'      => [ 'OJ Reeves' ],
       'License'     => MSF_LICENSE,
       'Platform'    => 'win',

--- a/modules/payloads/singles/windows/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/meterpreter_reverse_tcp.rb
@@ -21,7 +21,7 @@ module MetasploitModule
 
     super(merge_info(info,
       'Name'        => 'Windows Meterpreter Shell, Reverse TCP Inline',
-      'Description' => 'Connect back to attacker and spawn a Meterpreter shell',
+      'Description' => 'Connect back to attacker and spawn a Meterpreter shell. Requires Windows XP SP2 or newer.',
       'Author'      => [ 'OJ Reeves' ],
       'License'     => MSF_LICENSE,
       'Platform'    => 'win',

--- a/modules/payloads/singles/windows/x64/meterpreter_bind_named_pipe.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_bind_named_pipe.rb
@@ -21,7 +21,7 @@ module MetasploitModule
 
     super(merge_info(info,
       'Name'        => 'Windows Meterpreter Shell, Bind Named Pipe Inline (x64)',
-      'Description' => 'Connect to victim and spawn a Meterpreter shell',
+      'Description' => 'Connect to victim and spawn a Meterpreter shell. Requires Windows XP SP2 or newer.',
       'Author'      => [ 'UserExistsError' ],
       'License'     => MSF_LICENSE,
       'Platform'    => 'win',

--- a/modules/payloads/singles/windows/x64/meterpreter_bind_tcp.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_bind_tcp.rb
@@ -21,7 +21,7 @@ module MetasploitModule
 
     super(merge_info(info,
       'Name'        => 'Windows Meterpreter Shell, Bind TCP Inline (x64)',
-      'Description' => 'Connect to victim and spawn a Meterpreter shell',
+      'Description' => 'Connect to victim and spawn a Meterpreter shell. Requires Windows XP SP2 or newer.',
       'Author'      => [ 'OJ Reeves' ],
       'License'     => MSF_LICENSE,
       'Platform'    => 'win',

--- a/modules/payloads/singles/windows/x64/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_reverse_http.rb
@@ -21,7 +21,7 @@ module MetasploitModule
 
     super(merge_info(info,
       'Name'        => 'Windows Meterpreter Shell, Reverse HTTP Inline (x64)',
-      'Description' => 'Connect back to attacker and spawn a Meterpreter shell',
+      'Description' => 'Connect back to attacker and spawn a Meterpreter shell. Requires Windows XP SP2 or newer.',
       'Author'      => [ 'OJ Reeves' ],
       'License'     => MSF_LICENSE,
       'Platform'    => 'win',

--- a/modules/payloads/singles/windows/x64/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_reverse_https.rb
@@ -21,7 +21,7 @@ module MetasploitModule
 
     super(merge_info(info,
       'Name'        => 'Windows Meterpreter Shell, Reverse HTTPS Inline (x64)',
-      'Description' => 'Connect back to attacker and spawn a Meterpreter shell',
+      'Description' => 'Connect back to attacker and spawn a Meterpreter shell. Requires Windows XP SP2 or newer.',
       'Author'      => [ 'OJ Reeves' ],
       'License'     => MSF_LICENSE,
       'Platform'    => 'win',

--- a/modules/payloads/singles/windows/x64/meterpreter_reverse_ipv6_tcp.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_reverse_ipv6_tcp.rb
@@ -21,7 +21,7 @@ module MetasploitModule
 
     super(merge_info(info,
       'Name'        => 'Windows Meterpreter Shell, Reverse TCP Inline (IPv6) (x64)',
-      'Description' => 'Connect back to attacker and spawn a Meterpreter shell',
+      'Description' => 'Connect back to attacker and spawn a Meterpreter shell. Requires Windows XP SP2 or newer.',
       'Author'      => [ 'OJ Reeves' ],
       'License'     => MSF_LICENSE,
       'Platform'    => 'win',

--- a/modules/payloads/singles/windows/x64/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_reverse_tcp.rb
@@ -21,7 +21,7 @@ module MetasploitModule
 
     super(merge_info(info,
       'Name'        => 'Windows Meterpreter Shell, Reverse TCP Inline x64',
-      'Description' => 'Connect back to attacker and spawn a Meterpreter shell',
+      'Description' => 'Connect back to attacker and spawn a Meterpreter shell. Requires Windows XP SP2 or newer.',
       'Author'      => [ 'OJ Reeves' ],
       'License'     => MSF_LICENSE,
       'Platform'    => 'win',

--- a/modules/payloads/stages/windows/meterpreter.rb
+++ b/modules/payloads/stages/windows/meterpreter.rb
@@ -21,7 +21,7 @@ module MetasploitModule
   def initialize(info = {})
     super(update_info(info,
       'Name'          => 'Windows Meterpreter (Reflective Injection)',
-      'Description'   => 'Inject the meterpreter server DLL via the Reflective Dll Injection payload (staged)',
+      'Description'   => 'Inject the Meterpreter server DLL via the Reflective Dll Injection payload (staged). Requires Windows XP SP2 or newer',
       'Author'        => ['skape', 'sf', 'OJ Reeves'],
       'PayloadCompat' => { 'Convention' => 'sockedi handleedi http https'},
       'License'       => MSF_LICENSE,

--- a/modules/payloads/stages/windows/x64/meterpreter.rb
+++ b/modules/payloads/stages/windows/x64/meterpreter.rb
@@ -21,7 +21,7 @@ module MetasploitModule
   def initialize(info = {})
     super(update_info(info,
       'Name'          => 'Windows Meterpreter (Reflective Injection x64)',
-      'Description'   => 'Inject the meterpreter server DLL via the Reflective Dll Injection payload (staged x64)',
+      'Description'   => 'Inject the meterpreter server DLL via the Reflective Dll Injection payload (staged). Requires Windows XP SP2 or newer',
       'Author'        => ['skape', 'sf', 'OJ Reeves'],
       'PayloadCompat' => { 'Convention' => 'sockrdi handlerdi http https'},
       'License'       => MSF_LICENSE,


### PR DESCRIPTION
This simply informs users that the Windows Meterpreter no longer supports versions older than Windows XP SP2. On Windows XP SP1 the session will fail to load and crash. At this time we don't have compatibility checks for exploit/payload combos based on the target OS version, but that might be something we should look into in the future.

For Windows XP SP2, I checked that all of the loaded plugins load and ran some commands to spot check them for bugs. What I found was:

* The `python` extension will crash the Meterpreter session when it's loaded. This isn't great, but we don't have away to check an extension is compatible. If it's implemented for the Meterpreter platform (ie Windows x86 by providing the `ext_server_python.x86.dll` file) it is simply expected to work. We could add a runtime check, but we'd need to pull the Windows version and that would require the `stdapi` extension leading to a chicken-and-the-egg problem when it comes to implementing it in a generic fashion. Maybe `stdapi` should be a special case? I noted this in discussion #14493.
* The powershell payload loads but when issuing a simple command it fails which seems reasonable because AFAIK Powershell isn't on XP SP2.

    ```
    meterpreter > powershell_shell 
    PS > Write-Host 'Hello World!'
    [-] 8: Operation failed: The handle is invalid.
    meterpreter > 
    ```
* All of the tests in `post/test/meterpreter` and `post/test/railgun` pass 🎉 

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] Run `info` on a Windows Meterpreter payload
- [ ] See a note regarding compatibility

(Sort of) Fixes #14473 by informing the user or at least documenting it somewhere that XP SP0 and SP1 are not intended to work and we have no intention of backporting and maintaining compatibility.