### PR TITLE
do not test iface in macOS for IPv6 inconsistency

### DIFF
--- a/spec/lib/msf/core/opt_address_local_spec.rb
+++ b/spec/lib/msf/core/opt_address_local_spec.rb
@@ -19,8 +19,11 @@ RSpec.describe Msf::OptAddressLocal do
     { :value => "127.0.0.1",    :normalized => "127.0.0.1" },
     { :value => "2001:db8::",   :normalized => "2001:db8::" },
     { :value => "::1",          :normalized => "::1" },
-    { :value => iface[:name],   :normalized => iface[:addr]}
   ]
+
+  unless RUBY_PLATFORM.match('darwin')
+    valid_values << { :value => iface[:name],   :normalized => iface[:addr]}
+  end
   
   invalid_values = [
     # Too many dots


### PR DESCRIPTION
Suppress an issue in tab completion testing on macOS due to IPv6 vs IPv4 result precedence.

## Verification

List the steps needed to make sure this thing works

- [ ] rspec automation passes
- [ ] `rake spec` on a macOS dev install passes
