### PR TITLE
Fix exploit/solaris/ssh/pam_username_bof module doc

### DIFF
--- a/documentation/modules/exploit/solaris/ssh/pam_username_bof.md
+++ b/documentation/modules/exploit/solaris/ssh/pam_username_bof.md
@@ -14,8 +14,10 @@ may vary.
 
 Download and install [Solaris 10u11 1/13
 (x86)](https://www.oracle.com/solaris/solaris10/downloads/solaris10-get-jsp-downloads.html)
-in VMware or VirtualBox. SunSSH should already be installed and running
-when you start the system.
+in VMware or VirtualBox. You will need an Oracle account.
+
+SunSSH should already be installed and running when you start the
+system.
 
 ### Adding new targets
 

--- a/documentation/modules/exploit/solaris/ssh/pam_username_bof.md
+++ b/documentation/modules/exploit/solaris/ssh/pam_username_bof.md
@@ -47,7 +47,7 @@ Follow [Setup](#setup) and [Scenarios](#scenarios).
 
 ## Scenarios
 
-### `SunSSH 1.1.5 / Solaris 10u11 1/13 (x86) / VMware`
+### `SunSSH 1.1.5 / Solaris 10u11 1/13 (x86) / VirtualBox`
 
 ```
 msf6 > use exploit/solaris/ssh/pam_username_bof


### PR DESCRIPTION
I retested in VirtualBox and updated the output but not the header. Added a note about needing an Oracle account, too.

![image](https://user-images.githubusercontent.com/4551878/102679706-45080800-4177-11eb-99bc-05d186fe34a2.png)

Fixes #14446.