### PR TITLE
post/android/capture/screen: Use Msf::Post::Common mixin

### DIFF
--- a/modules/post/android/capture/screen.rb
+++ b/modules/post/android/capture/screen.rb
@@ -4,6 +4,7 @@
 ##
 
 class MetasploitModule < Msf::Post
+  include Msf::Post::Common
   include Msf::Post::File
 
   def initialize(info={})


### PR DESCRIPTION
I have no idea when this stopped working and why. [Somewhere along the line](https://github.com/rapid7/metasploit-framework/commits/master/modules/post/android/capture/screen.rb) the `require 'msf/core'` line was removed which might be the root cause.

Before:

```
msf6 post(android/capture/screen) > run

[!] SESSION may not be compatible with this module.
[-] Post failed: NoMethodError undefined method `cmd_exec' for #<Msf::Modules::Post__Android__Capture__Screen::MetasploitModule:0x0000555ae032b8e8>
[-] Call stack:
[-]   /root/Desktop/metasploit-framework/modules/post/android/capture/screen.rb:29:in `run'
[*] Post module execution completed
```

After:

```
msf6 post(android/capture/screen) > rexploit 
[*] Reloading module...

[!] SESSION may not be compatible with this module.
[+] Downloading screenshot...
[+] Screenshot saved at /root/.msf4/loot/20201220061323_default_10.1.1.105_screen_capture.s_653869.png
[*] Post module execution completed
msf6 post(android/capture/screen) > file /root/.msf4/loot/20201220061323_default_10.1.1.105_screen_capture.s_653869.png
[*] exec: file /root/.msf4/loot/20201220061323_default_10.1.1.105_screen_capture.s_653869.png

/root/.msf4/loot/20201220061323_default_10.1.1.105_screen_capture.s_653869.png: PNG image data, 1280 x 720, 8-bit/color RGBA, non-interlaced

```
