### PR TITLE
Update LICENSE to use https field values

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Source: http://www.metasploit.com/
 
 Files: *

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Source: http://www.metasploit.com/
+Source: https://www.metasploit.com/
 
 Files: *
 Copyright: 2006-2020, Rapid7, Inc.


### PR DESCRIPTION
Updates `LICENSE` file to use https version of the URL for the `Format` and `Source` fields. See [Machine-readable debian/copyright file: 6.1. Format](https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/#format-field)

## Verification
- [x] **Verify** `Format` and `Source` now use the https version of the URL
