### PR TITLE
Linguistic fixes of 'does not exists'

### DIFF
--- a/lib/msf/base/sessions/command_shell.rb
+++ b/lib/msf/base/sessions/command_shell.rb
@@ -370,7 +370,7 @@ class CommandShell
 
     # Check if src exists
     if !file_exists(src)
-      print_error("The target file does not exists")
+      print_error("The target file does not exist")
       return
     end
 

--- a/lib/net/dns/header.rb
+++ b/lib/net/dns/header.rb
@@ -150,7 +150,7 @@ module Net # :nodoc:
         RCodeErrorString = ["No errors",
           "The name server was unable to interpret the query",
           "The name server was unable to process this query due to problem with the name server",
-          "Domain name referenced in the query does not exists",
+          "Domain name referenced in the query does not exist",
           "The name server does not support the requested kind of query",
           "The name server refuses to perform the specified operation for policy reasons",
           "",

--- a/lib/rex/proto/smb/constants.rb
+++ b/lib/rex/proto/smb/constants.rb
@@ -172,7 +172,7 @@ class Constants
   CAP_UNIX_EXTENSIONS  = 0x800000
 
   # Open Modes
-  OPEN_MODE_CREAT = 0x10   # Create the file if file does not exists. Otherwise, operation fails.
+  OPEN_MODE_CREAT = 0x10   # Create the file if file does not exist. Otherwise, operation fails.
   OPEN_MODE_EXCL  = 0x00   # When used with SMB_O_CREAT, operation fails if file exists. Cannot be used with SMB_O_OPEN.
   OPEN_MODE_OPEN  = 0x01   # Open the file if the file exists
   OPEN_MODE_TRUNC = 0x02   # Truncate the file if the file exists

--- a/modules/exploits/windows/local/persistence.rb
+++ b/modules/exploits/windows/local/persistence.rb
@@ -163,7 +163,7 @@ class MetasploitModule < Msf::Exploit::Local
     filepath = temppath + "\\" + filename
 
     unless directory?(temppath)
-      print_error("#{temppath} does not exists on the target")
+      print_error("#{temppath} does not exist on the target")
       return nil
     end
 

--- a/modules/exploits/windows/misc/ahsay_backup_fileupload.rb
+++ b/modules/exploits/windows/misc/ahsay_backup_fileupload.rb
@@ -133,7 +133,7 @@ class MetasploitModule < Msf::Exploit::Remote
       if username == "" or password == ""
         fail_with(Failure::NoAccess, 'Please set a username and password')
       else
-        #check if account does not exists?
+        #check if account does not exist?
         if !check_account?
           # Create account and check if it is valid
           if create_account?

--- a/modules/post/multi/gather/multi_command.rb
+++ b/modules/post/multi/gather/multi_command.rb
@@ -26,7 +26,7 @@ class MetasploitModule < Msf::Post
   def run
     print_status("Running module against #{sysinfo['Computer']}")
     if not ::File.exist?(datastore['RESOURCE'])
-      raise "Resource File does not exists!"
+      raise "Resource File does not exist!"
     else
       ::File.open(datastore['RESOURCE'], "rb").each_line do |cmd|
         next if cmd.strip.length < 1

--- a/modules/post/multi/gather/run_console_rc_file.rb
+++ b/modules/post/multi/gather/run_console_rc_file.rb
@@ -30,7 +30,7 @@ class MetasploitModule < Msf::Post
   def run
     print_status("Running module against #{sysinfo['Computer']}")
     if not ::File.exist?(datastore['RESOURCE'])
-      raise "Resource File does not exists!"
+      raise "Resource File does not exist!"
     else
       ::File.open(datastore['RESOURCE'], "rb").each_line do |cmd|
         next if cmd.strip.length < 1

--- a/modules/post/multi/manage/multi_post.rb
+++ b/modules/post/multi/manage/multi_post.rb
@@ -34,7 +34,7 @@ class MetasploitModule < Msf::Post
     macro = datastore['MACRO']
     entries = []
     if not ::File.exist?(macro)
-      print_error "Resource File does not exists!"
+      print_error "Resource File does not exist!"
       return
     else
       ::File.open(datastore['MACRO'], "rb").each_line do |line|

--- a/modules/post/windows/gather/wmic_command.rb
+++ b/modules/post/windows/gather/wmic_command.rb
@@ -42,7 +42,7 @@ class MetasploitModule < Msf::Post
           store_wmic_loot(result, cmd)
         end
       else
-        raise "Resource File does not exists!"
+        raise "Resource File does not exist!"
       end
 
     elsif datastore['COMMAND']

--- a/scripts/meterpreter/hostsedit.rb
+++ b/scripts/meterpreter/hostsedit.rb
@@ -85,7 +85,7 @@ if client.platform == 'windows'
     when "-l"
       checkuac(session)
       if not ::File.exist?(val)
-        raise "File #{val} does not exists!"
+        raise "File #{val} does not exist!"
       else
         backuphosts(session,hosts)
         ::File.open(val, "r").each_line do |line|

--- a/scripts/meterpreter/multi_console_command.rb
+++ b/scripts/meterpreter/multi_console_command.rb
@@ -41,7 +41,7 @@ end
   when "-r"
     script = val
     if not ::File.exist?(script)
-      raise "Command List File does not exists!"
+      raise "Command List File does not exist!"
     else
       commands = []
       ::File.open(script, "r").each_line do |line|

--- a/scripts/meterpreter/multicommand.rb
+++ b/scripts/meterpreter/multicommand.rb
@@ -82,7 +82,7 @@ end
   when "-r"
     script = val
     if not ::File.exist?(script)
-      raise "Command List File does not exists!"
+      raise "Command List File does not exist!"
     else
       ::File.open(script, "r").each_line do |line|
         commands << line.chomp

--- a/scripts/meterpreter/multiscript.rb
+++ b/scripts/meterpreter/multiscript.rb
@@ -58,7 +58,7 @@ end
   when "-r"
     script = val
     if not ::File.exist?(script)
-      raise "Script List File does not exists!"
+      raise "Script List File does not exist!"
     else
       ::File.open(script, "rb").each_line do |line|
         commands << line

--- a/scripts/meterpreter/process_memdump.rb
+++ b/scripts/meterpreter/process_memdump.rb
@@ -53,7 +53,7 @@ end
     list = val
     resource = ""
     if not ::File.exist?(list)
-      raise "Command List File does not exists!"
+      raise "Command List File does not exist!"
     else
       ::File.open(list, "r").each_line do |line|
         resource << line

--- a/scripts/meterpreter/schtasksabuse.rb
+++ b/scripts/meterpreter/schtasksabuse.rb
@@ -132,7 +132,7 @@ end
   when "-s"
     script = val
     if not ::File.exist?(script)
-      raise "Command List File does not exists!"
+      raise "Command List File does not exist!"
     else
       ::File.open(script, "r").each_line do |line|
         commands << line.chomp
@@ -141,7 +141,7 @@ end
   when "-l"
     list = val
     if not ::File.exist?(list)
-      raise "Command List File does not exists!"
+      raise "Command List File does not exist!"
     else
       ::File.open(list, "r").each_line do |line|
         targets << line.chomp

--- a/scripts/meterpreter/uploadexec.rb
+++ b/scripts/meterpreter/uploadexec.rb
@@ -26,7 +26,7 @@ end
 
 def upload(session,file,trgloc = "")
   if not ::File.exist?(file)
-    raise "File to Upload does not exists!"
+    raise "File to Upload does not exist!"
   else
     if trgloc == ""
     location = session.sys.config.getenv('TEMP')

--- a/scripts/meterpreter/virusscan_bypass.rb
+++ b/scripts/meterpreter/virusscan_bypass.rb
@@ -37,7 +37,7 @@ end
 
 def upload(session,file,trgloc)
   if not ::File.exist?(file)
-    raise "File to Upload does not exists!"
+    raise "File to Upload does not exist!"
   else
     @location = session.sys.config.getenv('TEMP')
     begin

--- a/scripts/meterpreter/winbf.rb
+++ b/scripts/meterpreter/winbf.rb
@@ -78,7 +78,7 @@ def passbf(session,passlist,target,user,opt,logfile)
   i = 0
   if opt == 1
     if not ::File.exist?(user)
-      raise "Usernames List File does not exists!"
+      raise "Usernames List File does not exist!"
     else
       user = ::File.open(user, "r")
     end
@@ -171,7 +171,7 @@ unsupported if client.platform != 'windows'
 
     passlist = val
     if not ::File.exist?(passlist)
-      raise "Password File does not exists!"
+      raise "Password File does not exist!"
     end
   when "-t"
     target = val

--- a/scripts/meterpreter/wmic.rb
+++ b/scripts/meterpreter/wmic.rb
@@ -104,7 +104,7 @@ end
 
     script = val
     if not ::File.exist?(script)
-      raise "Command List File does not exists!"
+      raise "Command List File does not exist!"
     else
       ::File.open(script, "r").each_line do |line|
         next if line.strip.length < 1


### PR DESCRIPTION
Fixes #14020.
Replaces "does not exists" with "does not exist" across the framework, in the hope of correcting PR #14024