### PR TITLE
Map Meterpreter command IDs to their names when raising a RequestError

### DIFF
--- a/lib/rex/post/meterpreter/extension_mapper.rb
+++ b/lib/rex/post/meterpreter/extension_mapper.rb
@@ -24,7 +24,7 @@ class ExtensionMapper
     self.get_extension_names.each do |name|
       begin
         klass = self.get_extension_klass(name)
-      rescue LoadError
+      rescue RuntimeError
         next
       end
       return name if klass.extension_id == id

--- a/lib/rex/post/meterpreter/extension_mapper.rb
+++ b/lib/rex/post/meterpreter/extension_mapper.rb
@@ -8,36 +8,55 @@ class ExtensionMapper
 
   @@klasses = {}
 
+  def self.get_extension_names
+    base = ::File.join(File.dirname(__dir__), 'meterpreter/extensions')
+    ::Dir.entries(base).select do |e|
+      ::File.directory?(::File.join(base, e)) && !['.', '..'].include?(e)
+    end
+  end
+
   def self.get_extension_id(name)
     k = self.get_extension_klass(name)
     k.extension_id
+  end
+
+  def self.get_extension_name(id)
+    self.get_extension_names.each do |name|
+      begin
+        klass = self.get_extension_klass(name)
+      rescue LoadError
+        next
+      end
+      return name if klass.extension_id == id
+    end
+  end
+
+  def self.get_extension_module(name)
+    name.downcase!
+
+    begin
+      require("rex/post/meterpreter/extensions/#{name}/#{name}")
+    rescue LoadError
+      # the extension doesn't exist on disk
+      raise RuntimeError, "Unable to load extension '#{name}' - module does not exist."
+    end
+    s = Rex::Post::Meterpreter::Extensions.constants.find { |c| name == c.to_s.downcase }
+    Rex::Post::Meterpreter::Extensions.const_get(s)
   end
 
   def self.get_extension_klass(name)
     name.downcase!
 
     unless @@klasses[name]
-      begin
-        require("rex/post/meterpreter/extensions/#{name}/#{name}")
-      rescue LoadError
-        # the extension doesn't exist on disk
-        raise RuntimeError, "Unable to load extension '#{name}' - module does not exist."
-      end
-      s = Rex::Post::Meterpreter::Extensions.constants.select { |c|
-        name == c.to_s.downcase
-      }[0]
-      @@klasses[name] =  Rex::Post::Meterpreter::Extensions.const_get(s).const_get(s)
+      mod = self.get_extension_module(name)
+      @@klasses[name] = mod.const_get(mod.name.split('::').last)
     end
 
     @@klasses[name]
   end
 
   def self.dump_extensions
-    base = ::File.join(File.dirname(__dir__), 'meterpreter/extensions')
-    names = ::Dir.entries(base).select { |e|
-      ::File.directory?(::File.join(base, e)) && !['.', '..'].include?(e)
-    }
-    names.each { |n|
+    self.get_extension_names.each { |n|
       STDERR.puts("EXTENSION_ID_#{n.upcase} = #{self.get_extension_id(n)}\n")
     }
   end


### PR DESCRIPTION
Back when we release version 6, we changed Meterpreter commands to use numeric IDs instead of string values. Since then, when a `RequestError` is raised for whatever reason we get the numeric command ID instead of the name which means the user needs to look it up themselves to get some context as to what command failed.

This PR updates the `RequestError` to map the numeric command ID back to its string representation by looking up the extension module, then enumerating the `COMMAND_ID_*` constants to find the correct value. The result is nicer error messages that can help the user quickly identify the problem.

## Examples
The following two cases show the before and after. In this case, an error is raised while running the `post/linux/gather/gnome_keyring_dump` module because the target system doesn't have the necessary `libgnome-keyring.so.0` library. This causes the `stdapi_railgun_api` command (ID: 1028) to fail. Notice the number in the first example, and the string in the second.

### Before

```
msf6 post(linux/gather/gnome_keyring_dump) > run

[-] Post failed: Rex::Post::Meterpreter::RequestError 1028: Operation failed: Python exception: OSError
[-] Call stack:
[-]   /home/smcintyre/Repositories/metasploit-framework/lib/rex/post/meterpreter/extensions/stdapi/railgun/library.rb:373:in `process_function_call'
[-]   /home/smcintyre/Repositories/metasploit-framework/lib/rex/post/meterpreter/extensions/stdapi/railgun/library.rb:95:in `call_function'
[-]   /home/smcintyre/Repositories/metasploit-framework/lib/rex/post/meterpreter/extensions/stdapi/railgun/library_wrapper.rb:25:in `method_missing'
[-]   /home/smcintyre/Repositories/metasploit-framework/modules/post/linux/gather/gnome_keyring_dump.rb:195:in `run'
[*] Post module execution completed
msf6 post(linux/gather/gnome_keyring_dump) > 
```

### After

```
msf6 post(linux/gather/gnome_keyring_dump) > run

[-] Post failed: Rex::Post::Meterpreter::RequestError stdapi_railgun_api: Operation failed: Python exception: OSError
[-] Call stack:
[-]   /home/smcintyre/Repositories/metasploit-framework/lib/rex/post/meterpreter/extensions/stdapi/railgun/library.rb:373:in `process_function_call'
[-]   /home/smcintyre/Repositories/metasploit-framework/lib/rex/post/meterpreter/extensions/stdapi/railgun/library.rb:95:in `call_function'
[-]   /home/smcintyre/Repositories/metasploit-framework/lib/rex/post/meterpreter/extensions/stdapi/railgun/library_wrapper.rb:25:in `method_missing'
[-]   /home/smcintyre/Repositories/metasploit-framework/modules/post/linux/gather/gnome_keyring_dump.rb:195:in `run'
[*] Post module execution completed
msf6 post(linux/gather/gnome_keyring_dump) >
```

## Verification

You'll need to trigger some kind of an exception to see the new details.

- [x] Start `msfconsole`
- [x] Get a Python Meterpreter session on a system without `libgnome-keyring.so.0`
- [x] Run the `post/linux/gather/gnome_keyring_dump` module and see the error message without the command ID

