### PR TITLE
Switch to using mod parameter for tab completion

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1832,9 +1832,9 @@ class Core
 
     # A value needs to be specified
     if words.length == 2
-      return tab_complete_option_values(str, words, opt: words[1])
+      return tab_complete_option_values(active_module, str, words, opt: words[1])
     end
-    tab_complete_option_names(str, words)
+    tab_complete_option_names(active_module, str, words)
   end
 
   def cmd_setg_help
@@ -1852,7 +1852,7 @@ class Core
   #   line. `words` is always at least 1 when tab completion has reached this
   #   stage since the command itself has been completed.
   def cmd_unset_tabs(str, words)
-    tab_complete_datastore_names(str, words)
+    tab_complete_datastore_names(active_module, str, words)
   end
 
   #

--- a/lib/msf/ui/console/command_dispatcher/evasion.rb
+++ b/lib/msf/ui/console/command_dispatcher/evasion.rb
@@ -68,7 +68,7 @@ class Evasion
         '-z' => [ nil                                               ]
     }
     flags = tab_complete_generic(fmt, str, words)
-    options = tab_complete_option(str, words)
+    options = tab_complete_option(active_module, str, words)
     flags + options
   end
 

--- a/lib/msf/ui/console/command_dispatcher/exploit.rb
+++ b/lib/msf/ui/console/command_dispatcher/exploit.rb
@@ -87,7 +87,7 @@ class Exploit
         '-z' => [ nil                                               ]
     }
     flags = tab_complete_generic(fmt, str, words)
-    options = tab_complete_option(str, words)
+    options = tab_complete_option(active_module, str, words)
     flags + options
   end
 

--- a/lib/msf/ui/console/command_dispatcher/payload.rb
+++ b/lib/msf/ui/console/command_dispatcher/payload.rb
@@ -210,7 +210,7 @@ module Msf
               '-v' => [ nil                                               ]
             }
             flags = tab_complete_generic(fmt, str, words)
-            options = tab_complete_option(str, words)
+            options = tab_complete_option(active_module, str, words)
             flags + options
           end
         end

--- a/lib/msf/ui/console/module_action_commands.rb
+++ b/lib/msf/ui/console/module_action_commands.rb
@@ -118,8 +118,8 @@ module ModuleActionCommands
   # at least 1 when tab completion has reached this stage since the command itself has been completed
   #
   def cmd_run_tabs(str, words)
-    flags = @@run_action_opts.fmt.keys
-    options = tab_complete_option(str, words)
+    flags = @@module_opts.fmt.keys
+    options = tab_complete_option(active_module, str, words)
     flags + options
   end
 


### PR DESCRIPTION
This is a pre-requisite PR for future work. These functions will be used with an arbitrary module - not just the `active_module` that the implementation currently assumes. There should be no semantic changes for the end user as part of this PR.

## Verification

- [x]  Start msfconsole
- [x]  use exploit/windows/wins/ms04_045_wins - just an example, possibly test different module types
- [x]  type run followed by a space then hit tab
- [x]  Verify that a list of possible tab completions displays
- [x]  Verify that tab completion works for both flags and options in multiple different scenarios

These are the same verification steps as https://github.com/rapid7/metasploit-framework/pull/14240