### PR TITLE
Support command actions for post modules and consolidate VSS modules

### DIFF
--- a/documentation/modules/post/windows/manage/vss.md
+++ b/documentation/modules/post/windows/manage/vss.md
@@ -1,0 +1,178 @@
+## Overview
+This module will perform management actions for Volume Shadow Copies on the system. This is based on the VSSOwn Script
+originally posted by Tim Tomes and Mark Baggett. The session must be running with Administrative privileges and outside
+of UAC.
+
+## Options
+
+### DEVICE
+
+*Only applicable with the VSS_MOUNT action.*
+
+DeviceObject of the shadow copy to mount. This should begin with `\\?\GLOBALROOT\Device` and **must end with a slash (`\`)**.
+
+### PATH
+
+*Only applicable with the VSS_MOUNT and VSS_UNMOUNT actions.*
+
+Path to use for mounting the shadow copy.
+
+### SIZE
+
+*Only applicable with the VSS_SET_MAX_STORAGE_SIZE action.*
+
+Size in bytes to set for max storage.
+
+### VOLUME
+
+*Only applicable with the VSS_CREATE action.*
+
+Volume to make a copy of.
+
+## Scenarios
+
+### Create And Access A Shadow Copy
+
+First, ensure the session is running with elevated privileges and that UAC is not restricting it.
+
+```
+msf6 post(windows/manage/vss) > 
+[*] Sending stage (200262 bytes) to 192.168.159.30
+[*] Meterpreter session 2 opened (192.168.159.128:4444 -> 192.168.159.30:62600) at 2021-01-04 12:09:59 -0500
+
+msf6 post(windows/manage/vss) > sessions -i -1
+[*] Starting interaction with 2...
+
+meterpreter > getuid
+Server username: DESKTOP-RTCRBEV\Spencer McIntyre
+meterpreter > sysinfo 
+Computer        : DESKTOP-RTCRBEV
+OS              : Windows 10 (10.0 Build 18363).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 2
+Meterpreter     : x64/windows
+meterpreter > getsystem 
+...got system via technique 1 (Named Pipe Impersonation (In Memory/Admin)).
+meterpreter > background 
+[*] Backgrounding session 2...
+```
+
+Next, use the VSS module to the the storage information and then create a shadow copy of the `C:` drive (the default
+value).
+
+```
+msf6 post(windows/manage/vss) > vss_get_info 
+
+[*] Volume Shadow Copy service is running.
+[*] Software Shadow Copy service not running. Starting it now...
+[+] Software Shadow Copy started successfully.
+[+] Shadow Copy Storage Data
+========================
+
+  Field           Value
+  -----           -----
+  AllocatedSpace  
+  MaxSpace        
+  UsedSpace       
+
+[*] Post module execution completed
+msf6 post(windows/manage/vss) > set ACTION VSS_CREATE 
+ACTION => VSS_CREATE
+msf6 post(windows/manage/vss) > run
+
+[*] Volume Shadow Copy service is running.
+[*] Software Shadow Copy service is running.
+[*] ShadowCopy created successfully
+[+] Shadow Copy "{A38B3122-4D7A-4B93-B31B-D1454C2FED4D}" created!
+[*] Post module execution completed
+msf6 post(windows/manage/vss) >
+```
+
+After creating the shadow copy, list the copies to get the `DeviceObject` path and mount it.
+
+```
+msf6 post(windows/manage/vss) > vss_list_copies 
+
+[*] Volume Shadow Copy service is running.
+[*] Software Shadow Copy service is running.
+[*] Getting data for Shadow Copy {A38B3122-4D7A-4B93-B31B-D1454C2FED4D} (This may take a minute)
+[+] Shadow Copy Data
+================
+
+  Field                Value
+  -----                -----
+  ClientAccessible     TRUE
+  Count                1
+  DeviceObject         \\?\GLOBALROOT\Device\HarddiskVolumeShadowCopy1
+  Differential         TRUE
+  ExposedLocally       FALSE
+  ExposedName          
+  ExposedRemotely      FALSE
+  HardwareAssisted     FALSE
+  ID                   "{A38B3122-4D7A-4B93-B31B-D1454C2FED4D}"
+  Imported             FALSE
+  NoAutoRelease        TRUE
+  NoWriters            TRUE
+  NotSurfaced          NotSurfacedFALSE
+  OriginiatingMachine  DESKTOP-RTCRBEV
+  Persistent           TRUE
+  Plex                 FALSE
+  ProviderID           {B5946137-7B9F-4925-AF80-51ABD60B20D5}
+  ServiceMachine       DESKTOP-RTCRBEV
+  SetID                {F608494B-C0DB-4462-81B0-12D06A2DD3EB}
+  State                12
+  Transportable        FALSE
+  VolumeName           \\?\Volume{a5e97ffa-0120-4d03-ad47-18a94e9bfb2b}\
+
+[*] Post module execution completed
+msf6 post(windows/manage/vss) > set ACTION VSS_MOUNT 
+ACTION => VSS_MOUNT
+msf6 post(windows/manage/vss) > set DEVICE \\\\?\\GLOBALROOT\\Device\\HarddiskVolumeShadowCopy1\\
+DEVICE => \\?\GLOBALROOT\Device\HarddiskVolumeShadowCopy1\
+msf6 post(windows/manage/vss) > run
+
+[*] Volume Shadow Copy service is running.
+[*] Software Shadow Copy service is running.
+[*] Creating the symlink...
+[+] Mounted successfully
+[*] Post module execution completed
+msf6 post(windows/manage/vss) >
+```
+
+Finally, interact with the session to access the mounted directory before unmounting it.
+
+```
+msf6 post(windows/manage/vss) > sessions -i -1
+[*] Starting interaction with 2...
+
+meterpreter > dir ShadowCopy 
+Listing: ShadowCopy
+===================
+
+Mode              Size        Type  Last modified              Name
+----              ----        ----  -------------              ----
+40777/rwxrwxrwx   0           dir   2019-03-19 00:52:43 -0400  $Recycle.Bin
+40777/rwxrwxrwx   0           dir   2020-03-31 17:40:05 -0400  Documents and Settings
+40777/rwxrwxrwx   0           dir   2019-03-19 00:52:43 -0400  PerfLogs
+40555/r-xr-xr-x   4096        dir   2019-03-19 00:52:43 -0400  Program Files
+40555/r-xr-xr-x   4096        dir   2019-03-19 00:52:44 -0400  Program Files (x86)
+40777/rwxrwxrwx   0           dir   2019-03-19 00:52:44 -0400  ProgramData
+40777/rwxrwxrwx   0           dir   2020-03-31 20:39:26 -0400  Recovery
+40777/rwxrwxrwx   4096        dir   2020-03-31 20:38:24 -0400  System Volume Information
+40555/r-xr-xr-x   4096        dir   2019-03-19 00:37:22 -0400  Users
+40777/rwxrwxrwx   16384       dir   2019-03-19 00:37:22 -0400  Windows
+100666/rw-rw-rw-  1476395008  fil   2020-03-31 20:38:25 -0400  pagefile.sys
+100666/rw-rw-rw-  16777216    fil   2020-03-31 20:38:25 -0400  swapfile.sys
+
+meterpreter > background 
+[*] Backgrounding session 2...
+msf6 post(windows/manage/vss) > vss_unmount 
+
+[*] Volume Shadow Copy service is running.
+[*] Software Shadow Copy service is running.
+[*] Deleting the symlink...
+[*] Post module execution completed
+msf6 post(windows/manage/vss) >
+```

--- a/lib/msf/base/simple/post.rb
+++ b/lib/msf/base/simple/post.rb
@@ -47,6 +47,13 @@ module Post
     # Import options from the OptionStr or Option hash.
     mod._import_extra_options(opts)
 
+    mod.datastore['ACTION'] = opts['Action'] if opts['Action']
+
+    # Verify the ACTION
+    if (mod.actions.length > 0 and not mod.action)
+      raise MissingActionError, "Please use: #{mod.actions.collect {|e| e.name} * ", "}"
+    end
+
     # Verify the options
     mod.options.validate(mod.datastore)
 

--- a/lib/msf/core/opt_condition.rb
+++ b/lib/msf/core/opt_condition.rb
@@ -25,7 +25,7 @@ module Msf
       operator = opt.conditions[1]
       right_value = opt.conditions[2]
       if left_source == 'ACTION'
-        left_value = mod.action.name.to_s
+        left_value = mod.action ? mod.action.name.to_s : nil
       elsif left_source == 'TARGET'
         left_value = mod.target.name.to_s
       else

--- a/lib/msf/core/post/windows/shadow_copy.rb
+++ b/lib/msf/core/post/windows/shadow_copy.rb
@@ -129,6 +129,11 @@ module ShadowCopy
     result = wmic_query("shadowcopy call create \"ClientAccessible\", \"#{volume}\"")
 
     retval = result.match(/ReturnValue = (\d)/)
+    if retval.nil?
+      print_error('Shadow copy creation failed')
+      return
+    end
+
     case retval[1].to_i
     when 0
       print_status("ShadowCopy created successfully")
@@ -161,7 +166,7 @@ module ShadowCopy
     else
       print_error("Unknown error")
     end
-    return nil
+    return
   end
 
   #
@@ -176,7 +181,7 @@ module ShadowCopy
       if service_restart("VSS", START_TYPE_MANUAL)
         print_good("Volume Shadow Copy started successfully.")
       else
-        print_error("Insufficient Privs to start service!")
+        print_error("Insufficient privileges to start the service!")
         return false
       end
     end
@@ -195,7 +200,7 @@ module ShadowCopy
       if service_restart("swprv", START_TYPE_MANUAL)
         print_good("Software Shadow Copy started successfully.")
       else
-        print_error("Insufficient Privs to start service!")
+        print_error("Insufficient privileges to start the service!")
         return false
       end
     end

--- a/lib/msf/ui/console/command_dispatcher.rb
+++ b/lib/msf/ui/console/command_dispatcher.rb
@@ -134,6 +134,7 @@ module CommandDispatcher
 end
 end end end
 
+require 'msf/ui/console/module_action_commands'
 require 'msf/ui/console/module_command_dispatcher'
 require 'msf/ui/console/module_option_tab_completion'
 require 'msf/ui/console/command_dispatcher/core'

--- a/lib/msf/ui/console/command_dispatcher/auxiliary.rb
+++ b/lib/msf/ui/console/command_dispatcher/auxiliary.rb
@@ -19,7 +19,7 @@ class Auxiliary
   # Returns the hash of commands specific to auxiliary modules.
   #
   def commands
-    super.update({
+    super.merge({
       "run"      => "Launches the auxiliary module",
       "rcheck"   => "Reloads the module and checks if the target is vulnerable",
       "rerun"    => "Reloads and launches the auxiliary module",

--- a/lib/msf/ui/console/command_dispatcher/post.rb
+++ b/lib/msf/ui/console/command_dispatcher/post.rb
@@ -12,6 +12,7 @@ module CommandDispatcher
 class Post
 
   include Msf::Ui::Console::ModuleCommandDispatcher
+  include Msf::Ui::Console::ModuleActionCommands
   include Msf::Ui::Console::ModuleOptionTabCompletion
 
 
@@ -32,20 +33,6 @@ class Post
       "exploit"  => "This is an alias for the run command",
       "rexploit" => "This is an alias for the rerun command",
     }).merge( (mod ? mod.post_commands : {}) )
-  end
-
-  #
-  # Allow modules to define their own commands
-  #
-  def method_missing(meth, *args)
-    if (mod and mod.respond_to?(meth.to_s))
-
-      # Initialize user interaction
-      mod.init_ui(driver.input, driver.output)
-
-      return mod.send(meth.to_s, *args)
-    end
-    return
   end
 
   #
@@ -85,34 +72,9 @@ class Post
   #
   # Executes a post module
   #
-  def cmd_run(*args)
-    opt_str = nil
-    jobify  = false
-    quiet   = false
-
-    @@post_opts.parse(args) do |opt, idx, val|
-      case opt
-      when '-j'
-        jobify = true
-      when '-o'
-        opt_str = val
-      when '-a'
-        action = val
-      when '-q'
-        quiet  = true
-      when '-h'
-        cmd_run_help
-        return false
-      else
-        (key, val) = val.split('=')
-        if key && val
-          mod.datastore[key] = val
-        else
-          cmd_run_help
-          return false
-        end
-      end
-    end
+  def cmd_run(*args, action: nil)
+    return false unless (args = parse_run_opts(args, action: action))
+    jobify = args[:jobify]
 
     # Always run passive modules in the background
     if (mod.passive)
@@ -121,11 +83,12 @@ class Post
 
     begin
       mod.run_simple(
-        'OptionStr'      => opt_str,
+        'Action'         => args[:action],
+        'OptionStr'      => args[:datastore_options].map { |k,v| "#{k}=#{v}" }.join(','),
         'LocalInput'     => driver.input,
         'LocalOutput'    => driver.output,
         'RunAsJob'       => jobify,
-        'Quiet'          => quiet
+        'Quiet'          => args[:quiet]
       )
     rescue ::Timeout::Error
       print_error("Post triggered a timeout exception")
@@ -153,26 +116,13 @@ class Post
 
   alias cmd_exploit cmd_run
 
-  #
-  # Tab completion for the run command
-  #
-  # @param str [String] the string currently being typed before tab was hit
-  # @param words [Array<String>] the previously completed words on the command line.  words is always
-  # at least 1 when tab completion has reached this stage since the command itself has been completed
-  #
-  def cmd_run_tabs(str, words)
-    flags = @@post_opts.fmt.keys
-    options = tab_complete_option(str, words)
-    flags + options
-  end
-
   alias cmd_exploit_tabs cmd_run_tabs
 
   def cmd_run_help
     print_line "Usage: run [options]"
     print_line
     print_line "Launches a post module."
-    print @@post_opts.usage
+    print @@module_opts.usage
   end
 
   alias cmd_exploit_help cmd_run_help

--- a/lib/msf/ui/console/command_dispatcher/post.rb
+++ b/lib/msf/ui/console/command_dispatcher/post.rb
@@ -27,7 +27,7 @@ class Post
   # Returns the hash of commands specific to post modules.
   #
   def commands
-    super.update({
+    super.merge({
       "run"   => "Launches the post exploitation module",
       "rerun" => "Reloads and launches the module",
       "exploit"  => "This is an alias for the run command",

--- a/lib/msf/ui/console/module_action_commands.rb
+++ b/lib/msf/ui/console/module_action_commands.rb
@@ -30,7 +30,7 @@ module ModuleActionCommands
   end
 
   def commands
-    super.merge(action_commands)
+    super.merge(action_commands) { |k, old_val, new_val| old_val}
   end
 
   #
@@ -81,8 +81,8 @@ module ModuleActionCommands
         end
         return
       else
-        if val[0] != '-' && val.match?('=')
-          ds_opts.push(val)
+        if val[0] != '-' && val.include?('=')
+          ds_opts.store(*val.split('=', 2))
         else
           cmd_run_help
           return

--- a/lib/msf/ui/console/module_action_commands.rb
+++ b/lib/msf/ui/console/module_action_commands.rb
@@ -50,7 +50,7 @@ module ModuleActionCommands
       return do_action(action, *args)
     end
 
-    return
+    super
   end
 
   #

--- a/lib/msf/ui/console/module_action_commands.rb
+++ b/lib/msf/ui/console/module_action_commands.rb
@@ -1,0 +1,89 @@
+# -*- coding: binary -*-
+require 'msf/ui/console/command_dispatcher'
+
+module Msf
+module Ui
+module Console
+
+###
+#
+# A mixin to enable the ModuleCommandDispatcher to leverage module ACTIONs as commands.
+#
+###
+module ModuleActionCommands
+  @@module_action_opts = Rex::Parser::Arguments.new(
+    '-h' => [ false, 'Help banner.'                                          ],
+    '-j' => [ false, 'Run in the context of a job.'                          ],
+    '-o' => [ true,  'A comma separated list of options in VAR=VAL format.'  ],
+    '-q' => [ false, 'Run the module in quiet mode with no output'           ]
+  )
+
+  @@module_opts = Rex::Parser::Arguments.new(@@module_action_opts.fmt.merge(
+    '-a' => [ true, 'The action to use. If none is specified, ACTION is used.']
+  ))
+
+  #
+  # Returns the hash of commands specific to auxiliary modules.
+  #
+  def action_commands
+    mod.actions.map { |action| [action.name.downcase, action.description] }.to_h
+  end
+
+  def commands
+    super.merge(action_commands)
+  end
+
+  #
+  # Allow modules to define their own commands
+  #
+  def method_missing(meth, *args)
+    if (mod and mod.respond_to?(meth.to_s, true) )
+
+      # Initialize user interaction
+      mod.init_ui(driver.input, driver.output)
+
+      return mod.send(meth.to_s, *args)
+    end
+
+    action = meth.to_s.delete_prefix('cmd_')
+    if mod && mod.kind_of?(Msf::Module::HasActions) && mod.actions.map(&:name).any? { |a| a.casecmp?(action) }
+       return do_action(action, *args)
+    end
+
+    return
+  end
+
+  #
+  # Execute the module with a set action
+  #
+  def do_action(meth, *args)
+    action = mod.actions.find { |action| action.name.casecmp?(meth) }
+    raise Msf::MissingActionError.new(meth) if action.nil?
+
+    cmd_run(*args, action: action.name)
+  end
+
+  def cmd_action_help(action)
+    print_line "Usage: " + action.downcase + " [options]"
+    print_line
+    print_line "Launches a specfic module action."
+    print @@module_action_opts.usage
+  end
+
+  #
+  # Tab completion for the run command
+  #
+  # @param str [String] the string currently being typed before tab was hit
+  # @param words [Array<String>] the previously completed words on the command line.  words is always
+  # at least 1 when tab completion has reached this stage since the command itself has been completed
+  #
+  def cmd_run_tabs(str, words)
+    flags = @@run_action_opts.fmt.keys
+    options = tab_complete_option(str, words)
+    flags + options
+  end
+
+end
+end
+end
+end

--- a/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/windows/def_kernel32.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/windows/def_kernel32.rb
@@ -516,6 +516,18 @@ class Def_windows_kernel32
       ["PWCHAR","lpName","in"],
       ])
 
+    dll.add_function( 'CreateSymbolicLinkA', 'BOOL',[
+      ["PCHAR","lpSymlinkFileName","in"],
+      ["PCHAR","lpTargetFileName","in"],
+      ["DWORD","dwFlags","in"]
+      ])
+
+    dll.add_function( 'CreateSymbolicLinkW', 'BOOL',[
+      ["PWCHAR","lpSymlinkFileName","in"],
+      ["PWCHAR","lpTargetFileName","in"],
+      ["DWORD","dwFlags","in"]
+      ])
+
     dll.add_function( 'CreateTapePartition', 'DWORD',[
       ["HANDLE","hDevice","in"],
       ["DWORD","dwPartitionMethod","in"],

--- a/modules/post/windows/manage/vss.rb
+++ b/modules/post/windows/manage/vss.rb
@@ -1,0 +1,112 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Post
+  include Msf::Post::Windows::FileSystem
+  include Msf::Post::Windows::Priv
+  include Msf::Post::Windows::ShadowCopy
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'                 => "Windows Manage Volume Shadow Copies",
+      'Description'          => %q{
+        This module will perform management actions for Volume Shadow Copies on the system. This is based on the VSSOwn
+        Script originally posted by Tim Tomes and Mark Baggett.
+
+        Works on win2k3 and later.
+        },
+      'License'              => MSF_LICENSE,
+      'Platform'             => ['win'],
+      'SessionTypes'         => ['meterpreter'],
+      'Author'               => ['theLightCosine'],
+      'References'    => [
+        [ 'URL', 'http://pauldotcom.com/2011/11/safely-dumping-hashes-from-liv.html' ]
+      ],
+      'Actions' => [
+        [ 'VSS_CREATE', { 'Description' => 'Create a new VSS copy'} ],
+        [ 'VSS_LIST_COPIES', { 'Description' => 'List VSS copies' } ],
+        [ 'VSS_MOUNT', { 'Description' => 'Mount a VSS copy' } ],
+        [ 'VSS_GET_INFO', { 'Description' => 'Get VSS information' } ],
+        [ 'VSS_SET_MAX_STORAGE_SIZE', { 'Description' => 'Set the VSS maximum storage size' } ]
+      ],
+      'DefaultAction' => 'VSS_GET_INFO',
+    ))
+
+    register_options(
+      [
+        OptInt.new('SIZE', [ false, 'Size in bytes to set for max storage'], conditions: %w{ ACTION == VSS_SET_MAX_STORAGE_SIZE }),
+        OptString.new('VOLUME', [ false, 'Volume to make a copy of.', 'C:\\'], conditions: %w{ ACTION == VSS_CREATE }),
+        OptString.new('DEVICE', [ false, 'DeviceObject of shadow copy to mount.' ], conditions: %w{ ACTION == VSS_MOUNT }),
+        OptString.new('PATH', [ false, 'Path to mount the shadow copy to.' ], conditions: %w{ ACTION == VSS_MOUNT })
+      ])
+  end
+
+
+  def run
+    # all conditional options are required when active, make sure none of them are blank
+    options.each_pair do |name, option|
+      next if option.conditions.empty?
+      next unless Msf::OptCondition.show_option(self, option)
+      fail_with(Failure::BadConfig, "The #{name} option is required by the #{action.name} action.") if datastore[name].blank?
+    end
+
+    fail_with(Failure::NoAccess, 'This module requires administrative privileges to run') unless is_admin?
+    fail_with(Failure::NoAccess, 'This module requires UAC to be bypassed first') if is_uac_enabled?
+    fail_with(Failure::Unknown, 'Failed to start the necessary VSS services') unless start_vss
+
+    send("action_#{action.name.downcase}")
+  end
+
+  def action_vss_create
+    if (id = create_shadowcopy(datastore['VOLUME']))
+      print_good "Shadow Copy #{id} created!"
+    end
+  end
+
+  def action_vss_get_info
+    return unless (storage_data = vss_get_storage)
+
+    tbl = Rex::Text::Table.new(
+      'Header'  => 'Shadow Copy Storage Data',
+      'Indent'  => 2,
+      'Columns' => ['Field', 'Value']
+    )
+    storage_data.each_pair{|k,v| tbl << [k,v]}
+    print_good(tbl.to_s)
+    store_loot('host.shadowstorage', 'text/plain', session, tbl.to_s, 'shadowstorage.txt', 'Shadow Copy Storage Info')
+  end
+
+  def action_vss_mount
+    print_status('Creating the symlink...')
+    # todo: check if this can be replaced with create_symlink create_symlink(nil, datastore['PATH'], datastore['DEVICE'])
+    session.sys.process.execute("cmd.exe /C mklink /D #{datastore['PATH']} #{datastore['DEVICE']}", nil, {'Hidden' => true})
+  end
+
+  def action_vss_list_copies
+    shadow_copies = vss_list
+    return if shadow_copies.empty?
+
+    list = ''
+    shadow_copies.each do |copy|
+      tbl = Rex::Text::Table.new(
+        'Header'  => 'Shadow Copy Data',
+        'Indent'  => 2,
+        'Columns' => ['Field', 'Value']
+      )
+      copy.each_pair{|k,v| tbl << [k,v]}
+      list << " #{tbl.to_s} \n\n"
+      print_good tbl.to_s
+    end
+    store_loot('host.shadowcopies', 'text/plain', session, list, 'shadowcopies.txt', 'Shadow Copy Info')
+  end
+
+  def action_vss_set_max_storage_size
+    if vss_set_storage(datastore['SIZE'])
+      print_good('Size updated successfully')
+    else
+      print_error('There was a problem updating the storage size')
+    end
+  end
+end

--- a/modules/post/windows/manage/vss.rb
+++ b/modules/post/windows/manage/vss.rb
@@ -86,7 +86,11 @@ class MetasploitModule < Msf::Post
   def action_vss_mount
     print_status('Creating the symlink...')
     device = datastore['DEVICE']
-    device << '/' unless device.end_with?('/') # the DEVICE parameter needs to end with / or the link will be created successfully but will not work
+    unless device =~ /^([\/\\])\1\?\1GLOBALROOT\1Device\1([\w\- ]+)\1?$/
+      fail_with(Failure::BadConfig, 'The DEVICE parameter is incorrect, it should begin with \\\\?\\GLOBALROOT\\Device\\')
+    end
+    device << $1 unless device.end_with?($1) # the DEVICE parameter needs to end with / or the link will be created successfully but will not work
+
     result = session.railgun.kernel32.CreateSymbolicLinkA(datastore['PATH'], device, 'SYMBOLIC_LINK_FLAG_DIRECTORY')
     if result['return']
       print_good('Mounted successfully')

--- a/modules/post/windows/manage/vss.rb
+++ b/modules/post/windows/manage/vss.rb
@@ -37,10 +37,10 @@ class MetasploitModule < Msf::Post
 
     register_options(
       [
-        OptInt.new('SIZE', [ false, 'Size in bytes to set for max storage' ], conditions: %w{ ACTION == VSS_SET_MAX_STORAGE_SIZE }),
+        OptInt.new('SIZE', [ false, 'Size in bytes to set for max storage.' ], conditions: %w{ ACTION == VSS_SET_MAX_STORAGE_SIZE }),
         OptString.new('VOLUME', [ false, 'Volume to make a copy of.', 'C:\\' ], conditions: %w{ ACTION == VSS_CREATE }),
-        OptString.new('DEVICE', [ false, 'DeviceObject of shadow copy to mount.' ], conditions: ['ACTION', 'in', %w{ VSS_MOUNT VSS_UNMOUNT } ]),
-        OptString.new('PATH', [ false, 'Path to use for mounting the shadow copy.' 'ShadowCopy' ], conditions: %w{ ACTION == VSS_MOUNT })
+        OptString.new('DEVICE', [ false, 'DeviceObject of the shadow copy to mount.' ], conditions: %w{ ACTION == VSS_MOUNT }),
+        OptString.new('PATH', [ false, 'Path to use for mounting the shadow copy.' 'ShadowCopy' ], conditions: ['ACTION', 'in', %w{ VSS_MOUNT VSS_UNMOUNT } ])
       ])
   end
 
@@ -80,7 +80,9 @@ class MetasploitModule < Msf::Post
 
   def action_vss_mount
     print_status('Creating the symlink...')
-    result = session.railgun.kernel32.CreateSymbolicLinkA(datastore['PATH'], datastore['DEVICE'], 'SYMBOLIC_LINK_FLAG_DIRECTORY')
+    device = datastore['DEVICE']
+    device << '/' unless device.end_with?('/')  # the DEVICE parameter needs to end with / or the link will be created successfully but will not work
+    result = session.railgun.kernel32.CreateSymbolicLinkA(datastore['PATH'], device, 'SYMBOLIC_LINK_FLAG_DIRECTORY')
     if result['return']
       print_good('Mounted successfully')
     else

--- a/modules/post/windows/manage/vss_create.rb
+++ b/modules/post/windows/manage/vss_create.rb
@@ -7,6 +7,9 @@ class MetasploitModule < Msf::Post
   include Msf::Post::Windows::Priv
   include Msf::Post::Windows::ShadowCopy
 
+  include Msf::Module::Deprecated
+  deprecated(Date.new(2021, 4, 11), reason="Use post/windows/manage/vss and the VSS_CREATE action")
+
   def initialize(info={})
     super(update_info(info,
       'Name'                 => "Windows Manage Create Shadow Copy",

--- a/modules/post/windows/manage/vss_list.rb
+++ b/modules/post/windows/manage/vss_list.rb
@@ -7,6 +7,9 @@ class MetasploitModule < Msf::Post
   include Msf::Post::Windows::Priv
   include Msf::Post::Windows::ShadowCopy
 
+  include Msf::Module::Deprecated
+  deprecated(Date.new(2021, 4, 11), reason="Use post/windows/manage/vss and the VSS_LIST_COPIES action")
+
   def initialize(info={})
     super(update_info(info,
       'Name'                 => "Windows Manage List Shadow Copies",

--- a/modules/post/windows/manage/vss_mount.rb
+++ b/modules/post/windows/manage/vss_mount.rb
@@ -7,6 +7,9 @@ class MetasploitModule < Msf::Post
   include Msf::Post::Windows::Priv
   include Msf::Post::Windows::ShadowCopy
 
+  include Msf::Module::Deprecated
+  deprecated(Date.new(2021, 4, 11), reason="Use post/windows/manage/vss and the VSS_MOUNT action")
+
   def initialize(info={})
     super(update_info(info,
       'Name'                 => "Windows Manage Mount Shadow Copy",

--- a/modules/post/windows/manage/vss_set_storage.rb
+++ b/modules/post/windows/manage/vss_set_storage.rb
@@ -47,7 +47,7 @@ class MetasploitModule < Msf::Post
       return
     end
     if vss_set_storage(datastore['SIZE'])
-      print_good("Size upated successfully")
+      print_good("Size updated successfully")
     else
       print_error("There was a problem updating the storage size")
     end

--- a/modules/post/windows/manage/vss_set_storage.rb
+++ b/modules/post/windows/manage/vss_set_storage.rb
@@ -7,6 +7,9 @@ class MetasploitModule < Msf::Post
   include Msf::Post::Windows::Priv
   include Msf::Post::Windows::ShadowCopy
 
+  include Msf::Module::Deprecated
+  deprecated(Date.new(2021, 4, 11), reason="Use post/windows/manage/vss and the VSS_SET_MAX_STORAGE_SIZE action")
+
   def initialize(info={})
     super(update_info(info,
       'Name'                 => "Windows Manage Set Shadow Copy Storage Space",

--- a/modules/post/windows/manage/vss_storage.rb
+++ b/modules/post/windows/manage/vss_storage.rb
@@ -7,6 +7,9 @@ class MetasploitModule < Msf::Post
   include Msf::Post::Windows::Priv
   include Msf::Post::Windows::ShadowCopy
 
+  include Msf::Module::Deprecated
+  deprecated(Date.new(2021, 4, 11), reason="Use post/windows/manage/vss and the VSS_GET_INFO action")
+
   def initialize(info={})
     super(update_info(info,
       'Name'                 => "Windows Manage Get Shadow Copy Storage Info",


### PR DESCRIPTION
This PR makes two main changes which I'll describe in-depth below.

### Post Module Action Commands

The first major change is to allow post module actions to be run as commands like auxiliary modules can be. This expands on the changes originally introduced in the GSOC Summer 2020 project submitted in PR #13919. In order to add this functionality to the post module command dispatcher while not duplicating a bunch of code, I implemented the new `Msf::Ui::Console::ModuleActionCommands` mixin. We can use the mixin to add action commands for the dispatchers of other modules as well. Exploit modules probably make the most sense to target next. I also had to update `Msf::Simple::Post.run_simple` to take an explicit `'Action'` key from the options just its auxiliary counterpart.

### VSS Module Consolidation

The next major change leverages the new action commands to consolidate the 5 existing VSS management modules into a single unit. This makes interaction easier by sharing datastore options, and context setup. As a bonus I added the `VSS_UNMOUNT` action, added module documentation, and switched an external command to its API counterpart via railgun. Finally, I deprecated the 5 original modules since they're replaced with the new one.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] Get a meterpreter session running as SYSTEM (or Admin without UAC) on a recent Windows system (server 2003 or newer, I tested using Windows 10 v1909)
- [ ] Use the new vss module (run `use post/windows/manage/vss`)
- [ ] Generate the documentation (run `info -d`)
- [ ] Read the documentation, and follow the steps to see VSS info, create a shadow copy, mount it and unmount it
    - [ ] See VSS info (run `vss_get_info `), there probably won't be much here
    - [ ] Create a shadow copy (run `vss_create`), the default will create one for the `C:\` drive
    - [ ] List the shadow copies and see at least one in there (run `vss_list_copies`), this takes a minute
    - [ ] Copy the `DeviceObject and use it to mount the copy (run `vss_mount DEVICE=$DeviceObject`), the default mounts to "ShadowCopy" in the current directory
    - [ ] See that it was mounted successfully (there should be contents in that file identical to the root of the drive
    - [ ] Unmount the shadow copy (run `vss_unmount`)

Example output is available in the new module docs
