### PR TITLE
Add check for nmap requiring sudo permissions

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -2131,7 +2131,8 @@ class Db
           next if nmap_err.strip.empty?
           print_status("Nmap: '#{nmap_err.strip}'")
           # Check if the stderr text includes 'root', this only happens if the scan requires root privileges
-          if nmap_err.include? 'root'
+          if nmap_err =~ /requires? raw socket access/ or
+            nmap_err.include? 'only works if you are root' or nmap_err =~ /requires? raw socket access/
             return run_nmap(nmap, arguments, use_sudo: true) unless use_sudo
           end
         end

--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -2131,7 +2131,7 @@ class Db
           next if nmap_err.strip.empty?
           print_status("Nmap: '#{nmap_err.strip}'")
           # Check if the stderr text includes 'root', this only happens if the scan requires root privileges
-          if nmap_err =~ /requires? raw socket access/ or
+          if nmap_err =~ /requires? root privileges/ or
             nmap_err.include? 'only works if you are root' or nmap_err =~ /requires? raw socket access/
             return run_nmap(nmap, arguments, use_sudo: true) unless use_sudo
           end


### PR DESCRIPTION
Resolves #12035

This PR adds in the ability for framework to detect when a given nmap scan requires sudo privileges and re-runs nmap with `sudo` prompting the user in the typical way

User being prompted for their sudo password
![image](https://user-images.githubusercontent.com/19910435/103642550-324d4b80-4f4b-11eb-8925-363f40cca53d.png)

User being informed sudo permissions are needed and not being prompted as you'd expect having recently used `sudo`
![image](https://user-images.githubusercontent.com/19910435/103642630-57da5500-4f4b-11eb-94c7-3c5b641d0803.png)

- [x] Run nmap scan which requires root privileges (`db_nmap -sS -p 80 127.0.0.1`)
- [x] A prompt should appear informing the user that root privileges are required (and typically also ask for their password)
- [x] Once submitted the scan should go off as normal
- [x] If connected check the scanned host was added to the DB (`hosts`)
- [x] Run another nmap scan which doesn't require root privileges (`db_nmap  -p 80 127.0.0.1`)
- [x] There should be no prompt and it should run as normal
- [x] If connected check the scanned host was added to the DB (`hosts`)
