### PR TITLE
Implement better load_error handling mechanism

### DIFF
--- a/lib/msf/core/modules/loader/base.rb
+++ b/lib/msf/core/modules/loader/base.rb
@@ -126,7 +126,7 @@ class Msf::Modules::Loader::Base
 
     begin
       # read_module_content() will raise exceptions when fails
-      module_content = read_module_content(parent_path, type, module_reference_name)
+      module_content = read_module_content(parent_path, type, module_reference_name, throw_exception)
     rescue ::Exception => error
       # raise exception when required
       raise Msf::Modules::Error.new(
@@ -605,8 +605,9 @@ class Msf::Modules::Loader::Base
   # @param parent_path (see #load_module)
   # @param type (see #load_module)
   # @param module_reference_name (see #load_module)
+  # @param throw_exception (see #load_module)
   # @return [String] module content that can be module_evaled into the {#create_namespace_module}
-  def read_module_content(parent_path, type, module_reference_name)
+  def read_module_content(parent_path, type, module_reference_name, throw_exception = false)
     raise ::NotImplementedError
   end
 

--- a/lib/msf/core/modules/loader/base.rb
+++ b/lib/msf/core/modules/loader/base.rb
@@ -135,7 +135,7 @@ class Msf::Modules::Loader::Base
       ) if throw_exception
       # otherwise, do the legacy error reporting
       load_error(module_path, error)
-      module_content = ""
+      module_content = ''
     end
 
     if module_content.empty?
@@ -155,7 +155,12 @@ class Msf::Modules::Loader::Base
         raise
       rescue ::Exception => error
         # raise exception when required
-        raise Msf::ModuleLoadError.new(module_path) if throw_exception
+        if throw_exception
+          raise Msf::Modules::Error.new(
+            module_path:           module_path,
+            module_reference_name: module_reference_name
+          )
+        end
         # otherwise, do the legacy error reporting
         load_error(module_path, error)
         return false
@@ -171,11 +176,13 @@ class Msf::Modules::Loader::Base
         klass = namespace_module.const_get('MetasploitModule', false)
       else
         # raise exception when required
-        raise Msf::Modules::Error.new(
-          module_path: module_path,
-          module_reference_name: module_reference_name,
-          causal_message: 'invalid module class name (must be MetasploitModule)'
-        ) if throw_exception
+        if throw_exception
+          raise Msf::Modules::Error.new(
+            module_path:           module_path,
+            module_reference_name: module_reference_name,
+            causal_message:        'invalid module class name (must be MetasploitModule)'
+          )
+        end
         # otherwise, use the old error handler load_error
         load_error(module_path, Msf::Modules::Error.new(
           module_path:           module_path,
@@ -201,11 +208,13 @@ class Msf::Modules::Loader::Base
       return false unless loaded
     rescue NameError
       # raise exception when required
-      raise Msf::Modules::Error.new(
-        module_path: module_path,
-        module_reference_name: module_reference_name,
-        causal_message: 'invalid module class name (must be MetasploitModule)'
-      ) if throw_exception
+      if throw_exception
+        raise Msf::Modules::Error.new(
+          module_path:           module_path,
+          module_reference_name: module_reference_name,
+          causal_message:        'invalid module filename (must be lowercase alphanumeric snake case)'
+        )
+      end
       # otherwise, use the old error handler load_error
       load_error(module_path, Msf::Modules::Error.new(
         module_path:           module_path,
@@ -471,7 +480,7 @@ class Msf::Modules::Loader::Base
   #
   # @abstract Override to return the path to the module on the file system so that errors can be reported correctly.
   #
-  # @param path (see #load_module)
+  # @param parent_path (see #load_module)
   # @param type (see #load_module)
   # @param module_reference_name (see #load_module)
   # @return [String] The path to module.

--- a/lib/msf/core/modules/loader/directory.rb
+++ b/lib/msf/core/modules/loader/directory.rb
@@ -78,8 +78,8 @@ class Msf::Modules::Loader::Directory < Msf::Modules::Loader::Base
         # @see https://github.com/ruby/ruby/blob/ruby_1_9_3/io.c#L2038
         module_content = f.read(f.stat.size)
       end
-    rescue Errno::ENOENT => error
-      load_error(full_path, error)
+    rescue Errno::ENOENT
+      raise
     end
 
     module_content

--- a/lib/msf/core/modules/loader/directory.rb
+++ b/lib/msf/core/modules/loader/directory.rb
@@ -40,6 +40,7 @@ class Msf::Modules::Loader::Directory < Msf::Modules::Loader::Base
           relative_entry_descendant_pathname = entry_descendant_pathname.relative_path_from(full_entry_pathname)
           relative_entry_descendant_path = relative_entry_descendant_pathname.to_s
           next if File::basename(relative_entry_descendant_path).start_with?('example')
+
           # The module_reference_name doesn't have a file extension
           module_reference_name = module_reference_name_from_path(relative_entry_descendant_path)
 
@@ -80,6 +81,7 @@ class Msf::Modules::Loader::Directory < Msf::Modules::Loader::Base
       end
     rescue Errno::ENOENT => error
       raise if throw_exception
+
       load_error(full_path, error)
     end
 

--- a/lib/msf/core/modules/loader/directory.rb
+++ b/lib/msf/core/modules/loader/directory.rb
@@ -64,7 +64,7 @@ class Msf::Modules::Loader::Directory < Msf::Modules::Loader::Base
   #
   # @param (see Msf::Modules::Loader::Base#read_module_content)
   # @return (see Msf::Modules::Loader::Base#read_module_content)
-  def read_module_content(parent_path, type, module_reference_name)
+  def read_module_content(parent_path, type, module_reference_name, throw_exception = false)
     full_path = module_path(parent_path, type, module_reference_name)
 
     module_content = ''
@@ -78,8 +78,9 @@ class Msf::Modules::Loader::Directory < Msf::Modules::Loader::Base
         # @see https://github.com/ruby/ruby/blob/ruby_1_9_3/io.c#L2038
         module_content = f.read(f.stat.size)
       end
-    rescue Errno::ENOENT
-      raise
+    rescue Errno::ENOENT => error
+      raise if throw_exception
+      load_error(full_path, error)
     end
 
     module_content

--- a/lib/msf/core/modules/loader/executable.rb
+++ b/lib/msf/core/modules/loader/executable.rb
@@ -74,7 +74,7 @@ class Msf::Modules::Loader::Executable < Msf::Modules::Loader::Base
   #
   # @param (see Msf::Modules::Loader::Base#read_module_content)
   # @return (see Msf::Modules::Loader::Base#read_module_content)
-  def read_module_content(parent_path, type, module_reference_name)
+  def read_module_content(parent_path, type, module_reference_name, throw_exception = false)
     full_path = module_path(parent_path, type, module_reference_name)
     unless File.executable?(full_path)
       load_error(full_path, Errno::ENOENT.new)
@@ -89,10 +89,18 @@ class Msf::Modules::Loader::Executable < Msf::Modules::Loader::Base
           module_path: full_path,
           module_reference_name: module_reference_name,
           causal_message: 'unknown module type'
-        )
+        ) if throw_exception
+        load_error(full_path, Msf::Modules::Error.new(
+          module_path: full_path,
+          module_reference_name: module_reference_name,
+          causal_message: 'unknown module type'
+        ))
+        return ''
       end
-    rescue ::Exception
-      raise
+    rescue ::Exception => error
+      raise if throw_exception
+      load_error(full_path, error)
+      return ''
     end
   end
 end

--- a/lib/msf/core/modules/loader/executable.rb
+++ b/lib/msf/core/modules/loader/executable.rb
@@ -100,7 +100,7 @@ class Msf::Modules::Loader::Executable < Msf::Modules::Loader::Base
     rescue ::Exception => error
       raise if throw_exception
       load_error(full_path, error)
-      return ''
+      ''
     end
   end
 end

--- a/lib/msf/core/modules/loader/executable.rb
+++ b/lib/msf/core/modules/loader/executable.rb
@@ -85,15 +85,14 @@ class Msf::Modules::Loader::Executable < Msf::Modules::Loader::Base
       if content
         return content
       else
-        elog "Unable to load module #{full_path}, unknown module type"
-        return ''
+        raise Msf::Modules::Error.new(
+          module_path: full_path,
+          module_reference_name: module_reference_name,
+          causal_message: 'unknown module type'
+        )
       end
-    rescue ::Exception => e
-      elog("Unable to load module #{full_path}", error: e)
-      # XXX migrate this to a full load_error when we can tell the user why the
-      # module did not load and/or how to resolve it.
-      # load_error(full_path, e)
-      ''
+    rescue ::Exception
+      raise
     end
   end
 end

--- a/spec/lib/msf/core/modules/loader/base_spec.rb
+++ b/spec/lib/msf/core/modules/loader/base_spec.rb
@@ -43,6 +43,10 @@ RSpec.describe Msf::Modules::Loader::Base do
     Msf::MODULE_AUX
   end
 
+  let(:throw_exception) do
+    false
+  end
+
   context 'CONSTANTS' do
 
     context 'DIRECTORY_BY_TYPE' do
@@ -346,7 +350,7 @@ RSpec.describe Msf::Modules::Loader::Base do
         it 'should call #read_module_content to get the module content so that #read_module_content can be overridden to change loading behavior' do
           allow(module_manager).to receive(:on_module_load)
 
-          expect(subject).to receive(:read_module_content).with(parent_path, type, module_reference_name).and_return(module_content)
+          expect(subject).to receive(:read_module_content).with(parent_path, type, module_reference_name, throw_exception).and_return(module_content)
 
           expect(subject.load_module(parent_path, type, module_reference_name)).to be_truthy
         end
@@ -362,7 +366,7 @@ RSpec.describe Msf::Modules::Loader::Base do
 
         context 'with empty module content' do
           before(:example) do
-            allow(subject).to receive(:read_module_content).with(parent_path, type, module_reference_name).and_return('')
+            allow(subject).to receive(:read_module_content).with(parent_path, type, module_reference_name, throw_exception).and_return('')
           end
 
           it 'should return false' do
@@ -449,7 +453,7 @@ RSpec.describe Msf::Modules::Loader::Base do
 
             allow(subject).to receive(:namespace_module_transaction).and_yield(@namespace_module)
 
-            allow(subject).to receive(:read_module_content).with(parent_path, type, module_reference_name).and_return(module_content)
+            allow(subject).to receive(:read_module_content).with(parent_path, type, module_reference_name, throw_exception).and_return(module_content)
 
             @module_load_error_by_path = {}
             allow(module_manager).to receive(:module_load_error_by_path).and_return(@module_load_error_by_path)
@@ -1003,7 +1007,7 @@ RSpec.describe Msf::Modules::Loader::Base do
         type = Msf::MODULE_AUX
 
         expect {
-          subject.send(:read_module_content, parent_pathname.to_s, type, module_reference_name)
+          subject.send(:read_module_content, parent_pathname.to_s, type, module_reference_name, throw_exception)
         }.to raise_error(NotImplementedError)
       end
     end

--- a/spec/support/shared/examples/msf/module_manager/cache.rb
+++ b/spec/support/shared/examples/msf/module_manager/cache.rb
@@ -190,7 +190,8 @@ RSpec.shared_examples_for 'Msf::ModuleManager::Cache' do
             parent_path,
             type,
             reference_name,
-            :force => true
+            :force => true,
+            :throw_exception => true
         ).and_call_original
 
         load_cached_module


### PR DESCRIPTION
Resolves #12943

This PR implements a better way to handle loading errors in `Msf::Modules::Loader::Base`. The previous loading mechanism fails in dealing with non-Ruby modules because loaders do not interact with each other, which means that a Ruby module loader has no idea of what other loaders can do. This could lead to false warnings of not loaded modules as described in #12943.

* [ ] Start `msfconsole` and `use exploit/windows/smb/ms17_010_eternalblue_win8`
* [ ] Run `save`
* [ ] Exit the console
* [ ] Restart `msfconsole` and no warnings regarding `ms17_010_eternalblue_win8.rb` (which does not exists because `exploit/windows/smb/ms17_010_eternalblue_win8` is a Python module) should appear