### PR TITLE
Bump rex-exploitation gem from 0.1.25 to 0.1.26

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -320,7 +320,7 @@ GEM
       metasm
       rex-arch
       rex-text
-    rex-exploitation (0.1.25)
+    rex-exploitation (0.1.26)
       jsobfu
       metasm
       rex-arch


### PR DESCRIPTION
Bumping rex-exploitation version to pick up a small change to how rex-arch constants are referenced
