### PR TITLE
Fix issue in length detection in Time Based MySQL injections, and enhance string hex encoding

### DIFF
--- a/lib/msf/core/exploit/sqli/mysqli/common.rb
+++ b/lib/msf/core/exploit/sqli/mysqli/common.rb
@@ -260,7 +260,7 @@ module Msf::Exploit::SQLi::MySQLi
         output_bit = blind_request("#{if_function}length(cast((#{query}) as binary))&#{1 << i}<>0#{sleep_part}")
         output_length |= (1 << i) if output_bit
         i += 1
-        stop = blind_request("#{if_function}length(cast((#{query}) as binary))/#{1 << i}=0#{sleep_part}")
+        stop = blind_request("#{if_function}floor(length(cast((#{query}) as binary))/#{1 << i})=0#{sleep_part}")
         break if stop
       end
       output_length

--- a/lib/msf/core/exploit/sqli/mysqli/common.rb
+++ b/lib/msf/core/exploit/sqli/mysqli/common.rb
@@ -305,10 +305,12 @@ module Msf::Exploit::SQLi::MySQLi
     #  Encodes strings in the query string as hexadecimal numbers
     #
     def hex_encode_strings(query)
-      # empty strings are not encoded, they can be avoided anyway
       # for more encoding capabilities, run code at the beginning of your block
       query.gsub(/'[^']+?'|"[^"]+?"/) do |match|
         '0x' + Rex::Text.to_hex(match[1..-2], '')
+      end
+           .gsub(/''|""/) do
+        "repeat(0x#{rand(0..255).to_s(16)},0)"
       end
     end
   end

--- a/lib/msf/core/exploit/sqli/mysqli/common.rb
+++ b/lib/msf/core/exploit/sqli/mysqli/common.rb
@@ -306,12 +306,13 @@ module Msf::Exploit::SQLi::MySQLi
     #
     def hex_encode_strings(query)
       # for more encoding capabilities, run code at the beginning of your block
-      query.gsub(/'[^']+?'|"[^"]+?"/) do |match|
-        '0x' + Rex::Text.to_hex(match[1..-2], '')
-      end
-           .gsub(/''|""/) do
+      query.gsub(/''|""/) do
         "repeat(0x#{rand(0..255).to_s(16)},0)"
       end
+      .gsub(/'[^']+?'|"[^"]+?"/) do |match|
+        '0x' + Rex::Text.to_hex(match[1..-2], '')
+      end
+           
     end
   end
 end


### PR DESCRIPTION
# First fix

This PR fixes an issue in the `blind_detect_length` method used to find the length of the output in time-based MySQL injections, for checking that no more non-zero bits were left in the length, I figured out that `length(cast((#{query}) as binary))/#{1 << i}` returns a float instead of an integer (yes, in MySQL, `select 5/2` returns `2.5`), for this reason, I added a call to floor, this bug wasn't breaking the functionnality, because even if it does not stop and keeps incrementing i, it will get to the point where the float number is just too close to 0, and where the comparison would succeed.

The effect of this is greatly improved performance of time-based SQL injections when the DBMS in-use is MySQL.

Thanks to @h00die for helping me find this issue (found it while testing an SQLi for a module he developed).

# Second fix

Seeing the work done on #14576 , where the SQLi doesn't work if `''` is present in the payload, I added support for empty strings in `hex_encode_strings`, just setting it to true on initialization of the SQLi object should now take care of empty strings.

The reason I didn't add it at first is that strings in MySQL can be encoded as hex numbers, but empty strings are an exception, I encode them as `repeat(0x#{rand(0..255).to_s(16)},0)`, which repeats a random byte 0 times, always returning `''`.
 
## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use exploit/linux/http/eyesofnetwork_autodiscovery_rce`
- [x] set the args, set `VERBOSE` to true
- [x] **Verify** that the exploit still works (for Fix 1)
- [x] edit the module code, in `sqli_to_admin_session`, add `opts: { hex_encode_strings: true }` in the instantiation of the sqli object.
- [x] reload
- [x] run `irb`, then run `exploit`, and CTRL+C before it finishes, just to get `@sqli` to be instantiated
- [x] run the following: `@sqli.run_sql('select concat("","a","","b")')`, should show the quote-free payload (because of `VERBOSE`), and return `"ab"`.

