### PR TITLE
Update the VHOST datastore option for modules

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/auxiliary.rb
+++ b/lib/msf/ui/console/command_dispatcher/auxiliary.rb
@@ -75,6 +75,7 @@ class Auxiliary
         rhosts_range.each do |rhost|
           nmod = mod.replicant
           nmod.datastore['RHOST'] = rhost
+          nmod.datastore['VHOST'] = rhosts if (!Rex::Socket.is_ip_addr?(rhosts) && nmod.is_a?(Msf::Exploit::Remote::HttpClient) && nmod.datastore['VHOST'].nil?)
           print_status("Running module against #{rhost}")
           nmod.run_simple(
             'Action'         => args[:action],

--- a/lib/msf/ui/console/command_dispatcher/exploit.rb
+++ b/lib/msf/ui/console/command_dispatcher/exploit.rb
@@ -182,6 +182,7 @@ class Exploit
       rhosts_range.each do |rhost|
         nmod = mod.replicant
         nmod.datastore['RHOST'] = rhost
+        nmod.datastore['VHOST'] = rhosts if (!Rex::Socket.is_ip_addr?(rhosts) && nmod.is_a?(Msf::Exploit::Remote::HttpClient) && nmod.datastore['VHOST'].nil?)
         # If rhost is the last target, let exploit handler stop.
         opts["multi"] = false if rhost == (Rex::Socket.addr_itoa(rhosts_range.ranges.first.stop))
         # Catch the interrupt exception to stop the whole module during exploit


### PR DESCRIPTION
While working on #14597, @dwelch-r7 correctly pointed out to me that the VHOST option should be set automatically. However it looks like since the addition of handling RHOSTS for all modules, it stopped working. This was due to the new RHOSTS handling resolving the hostname into the IP address and then setting the module's `RHOST` datastore option which was originally used as the default VHOST value. This caused the `VHOST` header to be an IP address instead of the hostname which is not ideal and in the case of the `auxiliary/gather/external_ip` module, was breaking the HTTP request.

This change updates the command handler for auxiliary and exploit modules which include the logic to handle RHOSTS. The update checks to see if the module uses the HTTP client mixin and if it does will set the VHOST datastore option as appropriate.

## Verification

This can be used as an alternative fix for #14597, whose root cause is likely affecting additional modules.

- [ ] Start `msfconsole`
- [ ] `use auxiliary/gather/external_ip`
- [ ] Run it and see your IP address
    * Without this patch or the changes from #14597, the module would not return the users public IP address. Using the `HttpTrace` option would show that the server was returning a 404 error. 

<details>
<summary>With the patch</summary>

```
msf6 auxiliary(gather/external_ip) > show options 

Module options (auxiliary/gather/external_ip):

   Name         Current Setting  Required  Description
   ----         ---------------  --------  -----------
   Proxies                       no        A proxy chain of format type:host:port[,type:host:port][...]
   REPORT_HOST  false            no        Add the found IP to the database
   RHOSTS       ifconfig.me      yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
   RPORT        80               yes       The target port (TCP)
   SSL          false            no        Negotiate SSL/TLS for outgoing connections
   VHOST                         no        HTTP server virtual host

msf6 auxiliary(gather/external_ip) > set HttpTrace true
HttpTrace => true
msf6 auxiliary(gather/external_ip) > run
[*] Running module against 216.239.32.21

####################
# Request:
####################
GET /ip HTTP/1.1
Host: ifconfig.me
User-Agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)


####################
# Response:
####################
HTTP/1.1 200 OK
Date: Mon, 11 Jan 2021 15:42:54 GMT
Content-Type: text/plain; charset=utf-8
Content-Length: 12
Access-Control-Allow-Origin: *
Via: 1.1 google

###.###.220.23
[+] Source ip to 216.239.32.21 is ###.###.220.23
[*] Running module against 216.239.38.21
####################
# Request:
####################
GET /ip HTTP/1.1
Host: ifconfig.me
User-Agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)


####################
# Response:
####################
HTTP/1.1 200 OK
Date: Mon, 11 Jan 2021 15:42:54 GMT
Content-Type: text/plain; charset=utf-8
Content-Length: 12
Access-Control-Allow-Origin: *
Via: 1.1 google

###.###.220.23
[+] Source ip to 216.239.38.21 is ###.###.220.23
[*] Running module against 216.239.34.21
####################
# Request:
####################
GET /ip HTTP/1.1
Host: ifconfig.me
User-Agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)


####################
# Response:
####################
HTTP/1.1 200 OK
Date: Mon, 11 Jan 2021 15:42:55 GMT
Content-Type: text/plain; charset=utf-8
Content-Length: 12
Access-Control-Allow-Origin: *
Via: 1.1 google

###.###.220.23
[+] Source ip to 216.239.34.21 is ###.###.220.23
[*] Running module against 216.239.36.21
####################
# Request:
####################
GET /ip HTTP/1.1
Host: ifconfig.me
User-Agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)


####################
# Response:
####################
HTTP/1.1 200 OK
Date: Mon, 11 Jan 2021 15:42:55 GMT
Content-Type: text/plain; charset=utf-8
Content-Length: 12
Access-Control-Allow-Origin: *
Via: 1.1 google

###.###.220.23
[+] Source ip to 216.239.36.21 is ###.###.220.23
[*] Auxiliary module execution completed
msf6 auxiliary(gather/external_ip) > 

```
</details>

<details>
<summary>Without the patch</summary>

```
msf6 auxiliary(gather/external_ip) > show options 

Module options (auxiliary/gather/external_ip):

   Name         Current Setting  Required  Description
   ----         ---------------  --------  -----------
   Proxies                       no        A proxy chain of format type:host:port[,type:host:port][...]
   REPORT_HOST  false            no        Add the found IP to the database
   RHOSTS       ifconfig.me      yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
   RPORT        80               yes       The target port (TCP)
   SSL          false            no        Negotiate SSL/TLS for outgoing connections
   VHOST                         no        HTTP server virtual host

msf6 auxiliary(gather/external_ip) > set HttpTrace true
HttpTrace => true
msf6 auxiliary(gather/external_ip) > run
[*] Running module against 216.239.32.21

####################
# Request:
####################
GET /ip HTTP/1.1
Host: 216.239.32.21
User-Agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)


####################
# Response:
####################
HTTP/1.1 404 Not Found
Date: Mon, 11 Jan 2021 15:44:00 GMT
Content-Type: text/html; charset=UTF-8
Server: ghs
Content-Length: 1563
X-XSS-Protection: 0
X-Frame-Options: SAMEORIGIN

<!DOCTYPE html>
<html lang=en>
  <meta charset=utf-8>
  <meta name=viewport content="initial-scale=1, minimum-scale=1, width=device-width">
  <title>Error 404 (Not Found)!!1</title>
  <style>
    *{margin:0;padding:0}html,code{font:15px/22px arial,sans-serif}html{background:#fff;color:#222;padding:15px}body{margin:7% auto 0;max-width:390px;min-height:180px;padding:30px 0 15px}* > body{background:url(//www.google.com/images/errors/robot.png) 100% 5px no-repeat;padding-right:205px}p{margin:11px 0 22px;overflow:hidden}ins{color:#777;text-decoration:none}a img{border:0}@media screen and (max-width:772px){body{background:none;margin-top:0;max-width:none;padding-right:0}}#logo{background:url(//www.google.com/images/branding/googlelogo/1x/googlelogo_color_150x54dp.png) no-repeat;margin-left:-5px}@media only screen and (min-resolution:192dpi){#logo{background:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) no-repeat 0% 0%/100% 100%;-moz-border-image:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) 0}}@media only screen and (-webkit-min-device-pixel-ratio:2){#logo{background:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) no-repeat;-webkit-background-size:100% 100%}}#logo{display:inline-block;height:54px;width:150px}
  </style>
  <a href=//www.google.com/><span id=logo aria-label=Google></span></a>
  <p><b>404.</b> <ins>That’s an error.</ins>
  <p>The requested URL <code>/ip</code> was not found on this server.  <ins>That’s all we know.</ins>

[*] Running module against 216.239.36.21
####################
# Request:
####################
GET /ip HTTP/1.1
Host: 216.239.36.21
User-Agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)


####################
# Response:
####################
HTTP/1.1 404 Not Found
Date: Mon, 11 Jan 2021 15:44:00 GMT
Content-Type: text/html; charset=UTF-8
Server: ghs
Content-Length: 1563
X-XSS-Protection: 0
X-Frame-Options: SAMEORIGIN

<!DOCTYPE html>
<html lang=en>
  <meta charset=utf-8>
  <meta name=viewport content="initial-scale=1, minimum-scale=1, width=device-width">
  <title>Error 404 (Not Found)!!1</title>
  <style>
    *{margin:0;padding:0}html,code{font:15px/22px arial,sans-serif}html{background:#fff;color:#222;padding:15px}body{margin:7% auto 0;max-width:390px;min-height:180px;padding:30px 0 15px}* > body{background:url(//www.google.com/images/errors/robot.png) 100% 5px no-repeat;padding-right:205px}p{margin:11px 0 22px;overflow:hidden}ins{color:#777;text-decoration:none}a img{border:0}@media screen and (max-width:772px){body{background:none;margin-top:0;max-width:none;padding-right:0}}#logo{background:url(//www.google.com/images/branding/googlelogo/1x/googlelogo_color_150x54dp.png) no-repeat;margin-left:-5px}@media only screen and (min-resolution:192dpi){#logo{background:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) no-repeat 0% 0%/100% 100%;-moz-border-image:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) 0}}@media only screen and (-webkit-min-device-pixel-ratio:2){#logo{background:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) no-repeat;-webkit-background-size:100% 100%}}#logo{display:inline-block;height:54px;width:150px}
  </style>
  <a href=//www.google.com/><span id=logo aria-label=Google></span></a>
  <p><b>404.</b> <ins>That’s an error.</ins>
  <p>The requested URL <code>/ip</code> was not found on this server.  <ins>That’s all we know.</ins>

[*] Running module against 216.239.38.21
####################
# Request:
####################
GET /ip HTTP/1.1
Host: 216.239.38.21
User-Agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)


####################
# Response:
####################
HTTP/1.1 404 Not Found
Date: Mon, 11 Jan 2021 15:44:00 GMT
Content-Type: text/html; charset=UTF-8
Server: ghs
Content-Length: 1563
X-XSS-Protection: 0
X-Frame-Options: SAMEORIGIN

<!DOCTYPE html>
<html lang=en>
  <meta charset=utf-8>
  <meta name=viewport content="initial-scale=1, minimum-scale=1, width=device-width">
  <title>Error 404 (Not Found)!!1</title>
  <style>
    *{margin:0;padding:0}html,code{font:15px/22px arial,sans-serif}html{background:#fff;color:#222;padding:15px}body{margin:7% auto 0;max-width:390px;min-height:180px;padding:30px 0 15px}* > body{background:url(//www.google.com/images/errors/robot.png) 100% 5px no-repeat;padding-right:205px}p{margin:11px 0 22px;overflow:hidden}ins{color:#777;text-decoration:none}a img{border:0}@media screen and (max-width:772px){body{background:none;margin-top:0;max-width:none;padding-right:0}}#logo{background:url(//www.google.com/images/branding/googlelogo/1x/googlelogo_color_150x54dp.png) no-repeat;margin-left:-5px}@media only screen and (min-resolution:192dpi){#logo{background:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) no-repeat 0% 0%/100% 100%;-moz-border-image:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) 0}}@media only screen and (-webkit-min-device-pixel-ratio:2){#logo{background:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) no-repeat;-webkit-background-size:100% 100%}}#logo{display:inline-block;height:54px;width:150px}
  </style>
  <a href=//www.google.com/><span id=logo aria-label=Google></span></a>
  <p><b>404.</b> <ins>That’s an error.</ins>
  <p>The requested URL <code>/ip</code> was not found on this server.  <ins>That’s all we know.</ins>

[*] Running module against 216.239.34.21
####################
# Request:
####################
GET /ip HTTP/1.1
Host: 216.239.34.21
User-Agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)


####################
# Response:
####################
HTTP/1.1 404 Not Found
Date: Mon, 11 Jan 2021 15:44:00 GMT
Content-Type: text/html; charset=UTF-8
Server: ghs
Content-Length: 1563
X-XSS-Protection: 0
X-Frame-Options: SAMEORIGIN

<!DOCTYPE html>
<html lang=en>
  <meta charset=utf-8>
  <meta name=viewport content="initial-scale=1, minimum-scale=1, width=device-width">
  <title>Error 404 (Not Found)!!1</title>
  <style>
    *{margin:0;padding:0}html,code{font:15px/22px arial,sans-serif}html{background:#fff;color:#222;padding:15px}body{margin:7% auto 0;max-width:390px;min-height:180px;padding:30px 0 15px}* > body{background:url(//www.google.com/images/errors/robot.png) 100% 5px no-repeat;padding-right:205px}p{margin:11px 0 22px;overflow:hidden}ins{color:#777;text-decoration:none}a img{border:0}@media screen and (max-width:772px){body{background:none;margin-top:0;max-width:none;padding-right:0}}#logo{background:url(//www.google.com/images/branding/googlelogo/1x/googlelogo_color_150x54dp.png) no-repeat;margin-left:-5px}@media only screen and (min-resolution:192dpi){#logo{background:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) no-repeat 0% 0%/100% 100%;-moz-border-image:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) 0}}@media only screen and (-webkit-min-device-pixel-ratio:2){#logo{background:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) no-repeat;-webkit-background-size:100% 100%}}#logo{display:inline-block;height:54px;width:150px}
  </style>
  <a href=//www.google.com/><span id=logo aria-label=Google></span></a>
  <p><b>404.</b> <ins>That’s an error.</ins>
  <p>The requested URL <code>/ip</code> was not found on this server.  <ins>That’s all we know.</ins>

[*] Auxiliary module execution completed
msf6 auxiliary(gather/external_ip) > 

```
</details>