### PR TITLE
Add banner celebrating the awesome teams who joined us in the 2020 ctf

### DIFF
--- a/data/logos/ctf2020.txt
+++ b/data/logos/ctf2020.txt
@@ -1,0 +1,60 @@
+%clr
+*Neutrino_Cannon*PrettyBeefy*PostalTime*binbash*deadastronauts*EvilBunnyWrote*L1T*Mail.ru*() { :;}; echo vulnerable*
+*Team sorceror*ADACTF*BisonSquad*socialdistancing*LeukeTeamNaam*OWASP Moncton*Alegori*exit*Vampire Bunnies*APT593*
+*QuePasaZombiesAndFriends*NetSecBG*coincoin*ShroomZ*Slow Coders*Scavenger Security*Bruh*NoTeamName*Terminal Cult*
+*edspiner*BFG*MagentaHats*0x01DA*Kaczuszki*AlphaPwners*FILAHA*Raffaela*HackSurYvette*outout*HackSouth*Corax*yeeb0iz*
+*SKUA*Cyber COBRA*flaghunters*0xCD*AI Generated*CSEC*p3nnm3d*IFS*CTF_Circle*InnotecLabs*baadf00d*BitSwitchers*0xnoobs*
+*ItPwns - Intergalactic Team of PWNers*PCCsquared*fr334aks*runCMD*0x194*Kapital Krakens*ReadyPlayer1337*Team 443*
+*H4CKSN0W*InfOUsec*CTF Community*DCZia*NiceWay*0xBlueSky*ME3*Tipi'Hack*Porg Pwn Platoon*Hackerty*hackstreetboys*
+*ideaengine007*eggcellent*H4x*cw167*localhorst*Original Cyan Lonkero*Sad_Pandas*FalseFlag*OurHeartBleedsOrange*SBWASP*
+*Cult of the Dead Turkey*doesthismatter*crayontheft*Cyber Mausoleum*scripterz*VetSec*norbot*Delta Squad Zero*Mukesh*
+*x00-x00*BlackCat*ARESx*cxp*vaporsec*purplehax*RedTeam@MTU*UsalamaTeam*vitamink*RISC*forkbomb444*hownowbrowncow*
+*etherknot*cheesebaguette*downgrade*FR!3ND5*badfirmware*Cut3Dr4g0n*dc615*nora*Polaris One*team*hail hydra*Takoyaki*
+*Sudo Society*incognito-flash*TheScientists*Tea Party*Reapers of Pwnage*OldBoys*M0ul3Fr1t1B13r3*bearswithsaws*DC540*
+*iMosuke*Infosec_zitro*CrackTheFlag*TheConquerors*Asur*4fun*Rogue-CTF*Cyber*TMHC*The_Pirhacks*btwIuseArch*MadDawgs*
+*HInc*The Pighty Mangolins*CCSF_RamSec*x4n0n*x0rc3r3rs*emehacr*Ph4n70m_R34p3r*humziq*Preeminence*UMGC*ByteBrigade*
+*TeamFastMark*Towson-Cyberkatz*meow*xrzhev*PA Hackers*Kuolema*Nakateam*L0g!c B0mb*NOVA-InfoSec*teamstyle*Panic*
+*B0NG0R3*                                                                                    *Les Cadets Rouges*buf*
+*Les Tontons Fl4gueurs*                                                                      *404 : Flag Not Found*
+*' UNION SELECT 'password*  %bld%red    _________                __                         %clr         *OCD247*Sparkle Pony* 
+*burner_herz0g*             %bld%red    \_   ___ \_____  _______/  |_ __ _________   ____   %clr         *Kill$hot*ConEmu*
+*here_there_be_trolls*      %bld%red    /    \  \/\__  \ \____ \   __\  |  \_  __ \_/ __ \  %clr         *;echo"hacked"*
+*r4t5_*6rung4nd4*NYUSEC*    %bld%red    \     \____/ __ \|  |_> >  | |  |  /|  | \/\  ___/  %clr         *karamel4e*
+*IkastenIO*TWC*balkansec*   %bld%red     \______  (____  /   __/|__| |____/ |__|    \___  > %clr         *cybersecurity.li*
+*TofuEelRoll*Trash Pandas*  %bld%red            \/     \/|__|                           \/  %clr         *OneManArmy*cyb3r_w1z4rd5*
+*Astra*Got Schwartz?*tmux*  %bld%red                ___________.__                          %clr         *AreYouStuck*Mr.Robot.0*
+*\nls*Juicy white peach*    %bld%red                \__    ___/|  |__   ____                %clr         *EPITA Rennes*
+*HackerKnights*             %bld%red                  |    |   |  |  \_/ __ \               %clr         *guildOfGengar*Titans*
+*Pentest Rangers*           %bld%red                  |    |   |   Y  \  ___/               %clr         *The Libbyrators*
+*placeholder name*bitup*    %bld%red                  |____|   |___|  /\___  >              %clr         *JeffTadashi*Mikeal*
+*UCASers*onotch*            %bld%red                                \/     \/               %clr         *ky_dong_day_song*
+*NeNiNuMmOk*                %bld%red              ___________.__                            %clr         *JustForFun!*
+*Maux de tête*LalaNG*       %bld%red              \_   _____/|  | _____     ____            %clr         *g3tsh3Lls0on*
+*crr0tz*z3r0p0rn*clueless*  %bld%red               |    __)  |  | \__  \   / ___\           %clr         *Phở Đặc Biệt*Paradox*
+*HackWara*                  %bld%red               |     \   |  |__/ __ \_/ /_/  >          %clr         *KaRIPux*inf0sec*
+*Kugelschreibertester*      %bld%red               \___  /   |____(____  /\___  /           %clr         *bluehens*Antoine77*
+*icemasters*                %bld%red                   \/              \//_____/            %clr         *genxy*TRADE_NAMES*
+*Spartan's Ravens*          %bld%red             _______________   _______________          %clr         *BadByte*fontwang_tw*
+*g0ldd1gg3rs*pappo*         %bld%red            \_____  \   _  \  \_____  \   _  \          %clr         *ghoti*
+*Les CRACKS*c0dingRabbits*  %bld%red             /  ____/  /_\  \  /  ____/  /_\  \         %clr         *LinuxRiders*   
+*2Cr4Sh*RecycleBin*         %bld%red            /       \  \_/   \/       \  \_/   \        %clr         *Jalan Durian*
+*ExploitStudio*             %bld%red            \_______ \_____  /\_______ \_____  /        %clr         *WPICSC*logaritm*
+*Car RamRod*0x41414141*     %bld%red                    \/     \/         \/     \/         %clr         *Orv1ll3*team-fm4dd*
+*Björkson*FlyingCircus*                                                                      *PwnHub*H4X0R*Yanee*
+*Securifera*hot cocoa*                                                                       *Et3rnal*PelarianCP*
+*n00bytes*DNC&G*guildzero*dorko*tv*42*{EHF}*CarpeDien*Flamin-Go*BarryWhite*XUcyber*FernetInjection*DCcurity*
+*Mars Explorer*ozen_cfw*Fat Boys*Simpatico*nzdjb*Isec-U.O*The Pomorians*T35H*H@wk33*JetJ*OrangeStar*Team Corgi*
+*D0g3*0itch*OffRes*LegionOfRinf*UniWA*wgucoo*Pr0ph3t*L0ner*_n00bz*OSINT Punchers*Tinfoil Hats*Hava*Team Neu*
+*Cyb3rDoctor*Techlock Inc*kinakomochi*DubbelDopper*bubbasnmp*w*Gh0st$*tyl3rsec*LUCKY_CLOVERS*ev4d3rx10-team*ir4n6*
+*PEQUI_ctf*HKLBGD*L3o*5 bits short of a byte*UCM*ByteForc3*Death_Geass*Stryk3r*WooT*Raise The Black*CTErr0r*
+*Individual*mikejam*Flag Predator*klandes*_no_Skids*SQ.*CyberOWL*Ironhearts*Kizzle*gauti*
+*San Antonio College Cyber Rangers*sam.ninja*Akerbeltz*cheeseroyale*Ephyra*sard city*OrderingChaos*Pickle_Ricks*
+*Hex2Text*defiant*hefter*Flaggermeister*Oxford Brookes University*OD1E*noob_noob*Ferris Wheel*Ficus*ONO*jameless*
+*Log1c_b0mb*dr4k0t4*0th3rs*dcua*cccchhhh6819*Manzara's Magpies*pwn4lyfe*Droogy*Shrubhound Gang*ssociety*HackJWU*
+*asdfghjkl*n00bi3*i-cube warriors*WhateverThrone*Salvat0re*Chadsec*0x1337deadbeef*StarchThingIDK*Tieto_alaviiva_turva*
+*InspiV*RPCA Cyber Club*kurage0verfl0w*lammm*pelicans_for_freedom*switchteam*tim*departedcomputerchairs*cool_runnings*
+*chads*SecureShell*EetIetsHekken*CyberSquad*P&K*Trident*RedSeer*SOMA*EVM*BUckys_Angels*OrangeJuice*DemDirtyUserz*
+*OpenToAll*Born2Hack*Bigglesworth*NIS*10Monkeys1Keyboard*TNGCrew*Cla55N0tF0und*exploits33kr*root_rulzz*InfosecIITG*
+*superusers*H@rdT0R3m3b3r*operators*NULL*stuxCTF*mHackresciallo*Eclipse*Gingabeast*Hamad*Immortals*arasan*MouseTrap*
+*damn_sadboi*tadaaa*null2root*HowestCSP*fezfezf*LordVader*Fl@g_Hunt3rs*bluenet*P@Ge2mE*
+


### PR DESCRIPTION
This is a banner celebrating the teams that scored at least 100 points in the Metasploit 2020 CTF. 

 ## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `banner` until the new banner comes up
- [x] **Verify** banner appears eventually
- [x] **Verify** nothing is offensive
- [ ] **Verify** all teams are there

![image](https://user-images.githubusercontent.com/17987018/104215570-944ffa00-53fe-11eb-9bf9-b20b3dc54e7f.png)
