### PR TITLE
Fix bug where vhost wasn't being set correctly when using rhost http url

### DIFF
--- a/lib/msf/core/exploit/remote/http_client.rb
+++ b/lib/msf/core/exploit/remote/http_client.rb
@@ -170,7 +170,7 @@ module Exploit::Remote::HttpClient
 
     # Configure the HTTP client with the supplied parameter
     nclient.set_config(
-      'vhost' => opts['vhost'] || opts['rhost'] || self.vhost(),
+      'vhost' => opts['vhost'] || self.vhost(),
       'agent' => datastore['UserAgent'],
       'partial' => opts['partial'],
       'uri_encode_mode'        => datastore['HTTP::uri_encode_mode'],
@@ -443,7 +443,7 @@ module Exploit::Remote::HttpClient
       end
 
       opts['rhost'] = datastore['RHOST']
-      opts['vhost'] = opts['vhost'] || opts['rhost'] || self.vhost()
+      opts['vhost'] = opts['vhost'] || self.vhost()
       opts['rport'] = datastore['RPORT']
 
       opts['SSL'] = ssl

--- a/lib/msf/core/opt_http_rhost_url.rb
+++ b/lib/msf/core/opt_http_rhost_url.rb
@@ -51,7 +51,7 @@ module Msf
       return unless datastore['RHOSTS']
       begin
         uri_type = datastore['SSL'] ? URI::HTTPS : URI::HTTP
-        uri = uri_type.build(host: datastore['RHOSTS'])
+        uri = uri_type.build(host: datastore['VHOST'] || datastore['RHOSTS'])
         uri.port = datastore['RPORT']
         # The datastore uses both `TARGETURI` and `URI` to denote the path of a URL, we try both here and fall back to `/`
         uri.path = (datastore['TARGETURI'] || datastore['URI'] || '/')

--- a/spec/lib/msf/core/opt_http_rhost_url_spec.rb
+++ b/spec/lib/msf/core/opt_http_rhost_url_spec.rb
@@ -25,7 +25,8 @@ RSpec.describe Msf::OptHTTPRhostURL do
       { expected_url: 'http://example.com', datastore: { 'RHOSTS' => 'example.com', 'RPORT' => 80, 'SSL' => false, 'TARGETURI' => '', 'URI' => '', 'VHOST' => 'example.com', 'HttpUsername' => '', 'HttpPassword' => '' } },
       { expected_url: 'https://example.com', datastore: { 'RHOSTS' => 'example.com', 'RPORT' => 443, 'SSL' => true, 'TARGETURI' => '', 'URI' => '', 'VHOST' => 'example.com', 'HttpUsername' => '', 'HttpPassword' => '' } },
       { expected_url: 'http://user:pass@example.com:1234/somePath', datastore: { 'RHOSTS' => 'example.com', 'RPORT' => 1234, 'SSL' => false, 'TARGETURI' => '/somePath', 'URI' => '/somePath', 'VHOST' => 'example.com', 'HttpUsername' => 'user', 'HttpPassword' => 'pass' } },
-      { expected_url: 'http://127.0.0.1', datastore: { 'RHOSTS' => '127.0.0.1', 'RPORT' => 80, 'SSL' => false, 'TARGETURI' => '', 'URI' => '', 'VHOST' => nil, 'HttpUsername' => '', 'HttpPassword' => '' } }
+      { expected_url: 'http://127.0.0.1', datastore: { 'RHOSTS' => '127.0.0.1', 'RPORT' => 80, 'SSL' => false, 'TARGETURI' => '', 'URI' => '', 'VHOST' => nil, 'HttpUsername' => '', 'HttpPassword' => '' } },
+      { expected_url: 'http://example.com', datastore: { 'RHOSTS' => '127.0.0.1', 'RPORT' => 80, 'SSL' => false, 'TARGETURI' => '', 'URI' => '', 'VHOST' => 'example.com', 'HttpUsername' => '', 'HttpPassword' => '' } }
     ].each do |test|
       context test[:datastore].to_s do
         it "should return #{test[:expected_url]}" do


### PR DESCRIPTION
@adfoster-r7 noticed a bug where the `VHOST` datastore option was not being set correctly when using the `RHOST_HTTP_URL` option, this PR is to fix that particular issue

# Verification steps

- [ ] Start up msfconsole
- [ ] `set HTTPTRACE true`
- [ ] `features set RHOST_HTTP_URL true`
- [ ] `use exploit/multi/http/gitlab_file_read_rce`
- [ ] `set RHOST_HTTP_URL <http://example.com>` 
      - Targeting hackthebox laboratory box 10.10.10.216
      - Add `git.laboratory.htb` to your /etc/hosts:



- [ ] `set username foo`
- [ ] `set password foo`
- [ ] `run` the module
- [ ] With this fix you should see the `Host` header properly filled in with the domain name (on master this is not populated correctly)