### PR TITLE
Fix broken ntlm message constants

### DIFF
--- a/lib/msf/core.rb
+++ b/lib/msf/core.rb
@@ -14,7 +14,14 @@
 require 'rex'
 require 'rex/ui'
 require 'rex/arch'
+
 include Rex::Arch
+
+NTLM_CONST   ||= ::Rex::Proto::NTLM::Constants
+NTLM_CRYPT   ||= ::Rex::Proto::NTLM::Crypt
+NTLM_UTILS   ||= ::Rex::Proto::NTLM::Utils
+NTLM_BASE    ||= ::Rex::Proto::NTLM::Base
+NTLM_MESSAGE ||= ::Rex::Proto::NTLM::Message
 
 module Msf
   autoload :Author, 'msf/core/author'

--- a/lib/msf/core/exploit/ntlm.rb
+++ b/lib/msf/core/exploit/ntlm.rb
@@ -1,15 +1,4 @@
 # -*- coding: binary -*-
-require 'rex/proto/ntlm/constants'
-require 'rex/proto/ntlm/crypt'
-require 'rex/proto/ntlm/base'
-require 'rex/proto/ntlm/message'
-require 'rex/proto/ntlm/utils'
-
-NTLM_CONST   ||= ::Rex::Proto::NTLM::Constants
-NTLM_CRYPT   ||= ::Rex::Proto::NTLM::Crypt
-NTLM_UTILS   ||= ::Rex::Proto::NTLM::Utils
-NTLM_BASE    ||= ::Rex::Proto::NTLM::Base
-NTLM_MESSAGE ||= ::Rex::Proto::NTLM::Message
 
 module Msf
 


### PR DESCRIPTION
Fix broken ntlm message constants

Closes https://github.com/rapid7/metasploit-framework/issues/14611

### Before

An error is shown to the user:

```
[-] <IP>:3389     - Unexpected error: uninitialized constant Msf::Exploit::Remote::RDP::NTLM_MESSAGE
/usr/share/metasploit-framework/lib/msf/core/exploit/remote/rdp.rb:205:in `rdp_fingerprint'
/usr/share/metasploit-framework/modules/auxiliary/scanner/rdp/cve_2019_0708_bluekeep.rb:206:in `check_rdp_vuln'
/usr/share/metasploit-framework/modules/auxiliary/scanner/rdp/cve_2019_0708_bluekeep.rb:98:in `check_host'
/usr/share/metasploit-framework/modules/auxiliary/scanner/rdp/cve_2019_0708_bluekeep.rb:65:in `run_host'
/usr/share/metasploit-framework/lib/msf/core/auxiliary/scanner.rb:120:in `block (2 levels) in run'
/usr/share/metasploit-framework/lib/msf/core/thread_manager.rb:105:in `block in spawn'
```

### After

The module works as expected:

```
msf6 auxiliary(scanner/rdp/cve_2019_0708_bluekeep) > run

[+] 10.10.39.203:3389     - The target is vulnerable. The target attempted cleanup of the incorrectly-bound MS_T120 channel.
[*] 10.10.39.203:3389     - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

## Verification

Target a windows machine which is vulnerable to bluekeep

```
use scanner/rdp/cve_2019_0708_bluekeep
set rhost 10.10.39.203
run
```