### PR TITLE
Better Handling For Incompatible Meterpreter Extensions and Commands

### DIFF
--- a/lib/msf/base/sessions/meterpreter.rb
+++ b/lib/msf/base/sessions/meterpreter.rb
@@ -151,6 +151,8 @@ class Meterpreter < Rex::Post::Meterpreter::Client
         # TODO: This session was either staged or previously known, and so we should do some accounting here!
       end
 
+      session.commands.concat(session.core.get_loaded_extension_commands('core'))
+
       # Unhook the process prior to loading stdapi to reduce logging/inspection by any AV/PSP
       if datastore['AutoUnhookProcess'] == true
         console.run_single('load unhook')

--- a/lib/rex/post/meterpreter/client.rb
+++ b/lib/rex/post/meterpreter/client.rb
@@ -316,7 +316,6 @@ class Client
   # registered extension that can be reached through client.ext.[extension].
   #
   def add_extension(name, commands=[])
-    self.commands |= []
     self.commands.concat(commands)
 
     # Check to see if this extension has already been loaded.

--- a/lib/rex/post/meterpreter/client_core.rb
+++ b/lib/rex/post/meterpreter/client_core.rb
@@ -364,16 +364,20 @@ class ClientCore < Extension
       end
 
       if path.nil? and image.nil?
-        raise RuntimeError, "No module of the name #{modnameprovided} found", caller
+        if Rex::Post::Meterpreter::ExtensionMapper.get_extension_names.include?(mod.downcase)
+          raise RuntimeError, "The \"#{mod.downcase}\" extension is not supported by this Meterpreter type (#{client.session_type})", caller
+        else
+          raise RuntimeError, "No module of the name #{modnameprovided} found", caller
+        end
       end
 
       # Load the extension DLL
       commands = load_library(
-          'LibraryFilePath' => path,
+          'LibraryFilePath'  => path,
           'LibraryFileImage' => image,
-          'UploadLibrary'   => true,
-          'Extension'       => true,
-          'SaveToDisk'      => opts['LoadFromDisk'])
+          'UploadLibrary'    => true,
+          'Extension'        => true,
+          'SaveToDisk'       => opts['LoadFromDisk'])
     end
 
     # wire the commands into the client

--- a/lib/rex/post/meterpreter/client_core.rb
+++ b/lib/rex/post/meterpreter/client_core.rb
@@ -104,6 +104,7 @@ class ClientCore < Extension
   def get_loaded_extension_commands(extension)
     request = Packet.create_request(COMMAND_ID_CORE_ENUMEXTCMD)
 
+    # handle 'core' as a special case since it's not a typical extension
     extension = EXTENSION_ID_CORE if extension == 'core'
     extension = Rex::Post::Meterpreter::ExtensionMapper.get_extension_id(extension) unless extension.is_a? Integer
     request.add_tlv(TLV_TYPE_UINT,   extension)

--- a/lib/rex/post/meterpreter/client_core.rb
+++ b/lib/rex/post/meterpreter/client_core.rb
@@ -98,11 +98,15 @@ class ClientCore < Extension
   #
   # Get a list of loaded commands for the given extension.
   #
-  def get_loaded_extension_commands(extension_name)
+  # @param [String, Integer] extension Either the extension name or the extension ID to load the commands for.
+  #
+  # @return [Array<Integer>] An array of command IDs that are supported by the specified extension.
+  def get_loaded_extension_commands(extension)
     request = Packet.create_request(COMMAND_ID_CORE_ENUMEXTCMD)
 
-    start = Rex::Post::Meterpreter::ExtensionMapper.get_extension_id(extension_name)
-    request.add_tlv(TLV_TYPE_UINT, start)
+    extension = EXTENSION_ID_CORE if extension == 'core'
+    extension = Rex::Post::Meterpreter::ExtensionMapper.get_extension_id(extension) unless extension.is_a? Integer
+    request.add_tlv(TLV_TYPE_UINT,   extension)
     request.add_tlv(TLV_TYPE_LENGTH, COMMAND_ID_RANGE)
 
     begin

--- a/lib/rex/post/meterpreter/extension_mapper.rb
+++ b/lib/rex/post/meterpreter/extension_mapper.rb
@@ -16,18 +16,24 @@ class ExtensionMapper
   end
 
   def self.get_extension_id(name)
-    k = self.get_extension_klass(name)
+    begin
+      k = self.get_extension_klass(name)
+    rescue RuntimeError
+      return nil
+    end
+
     k.extension_id
   end
 
   def self.get_extension_name(id)
-    self.get_extension_names.each do |name|
+    self.get_extension_names.find do |name|
       begin
         klass = self.get_extension_klass(name)
       rescue RuntimeError
         next
       end
-      return name if klass.extension_id == id
+
+      klass.extension_id == id
     end
   end
 

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher.rb
@@ -64,7 +64,7 @@ module Console::CommandDispatcher
   def unknown_command(cmd, line)
     if @filtered_commands.include?(cmd)
       print_error("The \"#{cmd}\" command is not supported by this Meterpreter type (#{client.session_type})")
-      return true
+      return :handled
     end
 
     super

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher.rb
@@ -53,7 +53,7 @@ module Console::CommandDispatcher
   #
   def filter_commands(all, reqs)
     all.delete_if do |cmd, _desc|
-      reqs[cmd].any? { |req| !client.commands.include?(req) }
+      reqs[cmd]&.any? { |req| !client.commands.include?(req) }
     end
   end
 

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher.rb
@@ -38,6 +38,7 @@ module Console::CommandDispatcher
 
   def initialize(shell)
     @msf_loaded = nil
+    @filtered_commands = []
     super
   end
 
@@ -53,8 +54,20 @@ module Console::CommandDispatcher
   #
   def filter_commands(all, reqs)
     all.delete_if do |cmd, _desc|
-      reqs[cmd]&.any? { |req| !client.commands.include?(req) }
+      if reqs[cmd]&.any? { |req| !client.commands.include?(req) }
+        @filtered_commands << cmd
+        true
+      end
     end
+  end
+
+  def unknown_command(cmd, line)
+    if @filtered_commands.include?(cmd)
+      print_error("The '#{cmd}' command is not supported by this Meterpreter type (#{client.session_type})")
+      return true
+    end
+
+    super
   end
 
   #

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher.rb
@@ -63,7 +63,7 @@ module Console::CommandDispatcher
 
   def unknown_command(cmd, line)
     if @filtered_commands.include?(cmd)
-      print_error("The '#{cmd}' command is not supported by this Meterpreter type (#{client.session_type})")
+      print_error("The \"#{cmd}\" command is not supported by this Meterpreter type (#{client.session_type})")
       return true
     end
 

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
@@ -47,7 +47,7 @@ class Console::CommandDispatcher::Core
   # List of supported commands.
   #
   def commands
-    c = {
+    cmds = {
       '?'                        => 'Help menu',
       'background'               => 'Backgrounds the current session',
       'bg'                       => 'Alias for background',
@@ -69,55 +69,58 @@ class Console::CommandDispatcher::Core
       'run'                      => 'Executes a meterpreter script or Post module',
       'bgrun'                    => 'Executes a meterpreter script as a background thread',
       'bgkill'                   => 'Kills a background meterpreter script',
-      'get_timeouts'             => 'Get the current session timeout values',
-      'set_timeouts'             => 'Set the current session timeout values',
       'sessions'                 => 'Quickly switch to another session',
       'bglist'                   => 'Lists running background scripts',
       'write'                    => 'Writes data to a channel',
       'enable_unicode_encoding'  => 'Enables encoding of unicode strings',
-      'disable_unicode_encoding' => 'Disables encoding of unicode strings'
+      'disable_unicode_encoding' => 'Disables encoding of unicode strings',
+      'migrate'                  => 'Migrate the server to another process',
+      'pivot'                    => 'Manage pivot listeners',
+      # transport related commands
+      'sleep'                    => 'Force Meterpreter to go quiet, then re-establish session',
+      'transport'                => 'Manage the transport mechanisms',
+      'get_timeouts'             => 'Get the current session timeout values',
+      'set_timeouts'             => 'Set the current session timeout values',
     }
 
     if client.passive_service
-      c['detach'] = 'Detach the meterpreter session (for http/https)'
+      cmds['detach'] = 'Detach the meterpreter session (for http/https)'
     end
 
-    # Currently we have some windows-specific core commands`
-    if client.platform == 'windows'
-      # only support the SSL switching for HTTPS
-      if client.passive_service && client.sock.type? == 'tcp-ssl'
-        c['ssl_verify'] = 'Modify the SSL certificate verification setting'
-      end
-
-      c['pivot'] = 'Manage pivot listeners'
-    end
-
-    if client.platform == 'windows' || client.platform == 'linux'
-      # Migration only supported on windows and linux
-      c['migrate'] = 'Migrate the server to another process'
-    end
-
-    # TODO: This code currently checks both platform and architecture for the python
-    # and java types because technically the platform should be updated to indicate
-    # the OS platform rather than the meterpreter arch. When we've properly implemented
-    # the platform update feature we can remove some of these conditions
-    if client.platform == 'windows' || client.platform == 'linux' ||
-        client.platform == 'python' || client.arch == ARCH_PYTHON ||
-        client.platform == 'java' || client.arch == ARCH_JAVA ||
-        client.platform == 'android' || client.arch == ARCH_DALVIK
-      # Yet to implement transport hopping for other meterpreters.
-      c['transport'] = 'Change the current transport mechanism'
-
-      # sleep functionality relies on the transport features, so only
-      # wire that in with the transport stuff.
-      c['sleep'] = 'Force Meterpreter to go quiet, then re-establish session.'
+    if client.passive_service && client.sock.type? == 'tcp-ssl'
+      cmds['ssl_verify'] = 'Modify the SSL certificate verification setting'
     end
 
     if msf_loaded?
-      c['info'] = 'Displays information about a Post module'
+      cmds['info'] = 'Displays information about a Post module'
     end
 
-    c
+    reqs = {
+      'load'         => [COMMAND_ID_CORE_LOADLIB],
+      'machine_id'   => [COMMAND_ID_CORE_MACHINE_ID],
+      'migrate'      => [COMMAND_ID_CORE_MIGRATE],
+      'pivot'        => [COMMAND_ID_CORE_PIVOT_ADD, COMMAND_ID_CORE_PIVOT_REMOVE],
+      'secure'       => [COMMAND_ID_CORE_NEGOTIATE_TLV_ENCRYPTION],
+      # channel related commands
+      'read'         => [COMMAND_ID_CORE_CHANNEL_READ],
+      'write'        => [COMMAND_ID_CORE_CHANNEL_WRITE],
+      'close'        => [COMMAND_ID_CORE_CHANNEL_CLOSE],
+      # transport related commands
+      'sleep'        => [COMMAND_ID_CORE_TRANSPORT_SLEEP],
+      'ssl_verify'   => [COMMAND_ID_CORE_TRANSPORT_GETCERTHASH, COMMAND_ID_CORE_TRANSPORT_SETCERTHASH],
+      'transport'    => [
+        COMMAND_ID_CORE_TRANSPORT_ADD,
+        COMMAND_ID_CORE_TRANSPORT_CHANGE,
+        COMMAND_ID_CORE_TRANSPORT_LIST,
+        COMMAND_ID_CORE_TRANSPORT_NEXT,
+        COMMAND_ID_CORE_TRANSPORT_PREV,
+        COMMAND_ID_CORE_TRANSPORT_REMOVE
+      ],
+      'get_timeouts' => [COMMAND_ID_CORE_TRANSPORT_SET_TIMEOUTS],
+      'set_timeouts' => [COMMAND_ID_CORE_TRANSPORT_SET_TIMEOUTS],
+    }
+
+    filter_commands(cmds, reqs)
   end
 
   #

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
@@ -120,6 +120,11 @@ class Console::CommandDispatcher::Core
       'set_timeouts' => [COMMAND_ID_CORE_TRANSPORT_SET_TIMEOUTS],
     }
 
+    # XXX: Remove this line once the payloads gem has had another major version bump from 2.x to 3.x and
+    # rapid7/metasploit-payloads#451 has been landed to correct the `enumextcmd` behavior on Windows. Until then, skip
+    # filtering for Windows which supports all the filtered commands anyways.
+    reqs.clear if client.base_platform == 'windows'
+
     filter_commands(cmds, reqs)
   end
 

--- a/lib/rex/ui/text/dispatcher_shell.rb
+++ b/lib/rex/ui/text/dispatcher_shell.rb
@@ -328,6 +328,15 @@ module DispatcherShell
       end
       addresses
     end
+
+    #
+    # A callback that can be used to handle unknown commands. This can for example, allow a dispatcher to mark a command
+    # as being disabled.
+    #
+    # @return [Boolean] Returns true when the dispatcher has handled the command.
+    def unknown_command(method, line)
+      false
+    end
   end
 
   #
@@ -473,6 +482,8 @@ module DispatcherShell
           if (dispatcher.commands.has_key?(method) or dispatcher.deprecated_commands.include?(method))
             self.on_command_proc.call(line.strip) if self.on_command_proc
             run_command(dispatcher, method, arguments)
+            found = true
+          elsif dispatcher.unknown_command(method, line)
             found = true
           end
         rescue ::Interrupt

--- a/lib/rex/ui/text/dispatcher_shell.rb
+++ b/lib/rex/ui/text/dispatcher_shell.rb
@@ -333,9 +333,11 @@ module DispatcherShell
     # A callback that can be used to handle unknown commands. This can for example, allow a dispatcher to mark a command
     # as being disabled.
     #
-    # @return [Boolean] Returns true when the dispatcher has handled the command.
+    # @return [Symbol, nil] Returns a symbol specifying the action that was taken by the handler or `nil` if no action
+    #   was taken. The only supported action at this time is `:handled`, signifying that the unknown command was handled
+    #   by this dispatcher and no additional dispatchers should receive it.
     def unknown_command(method, line)
-      false
+      nil
     end
   end
 
@@ -463,11 +465,16 @@ module DispatcherShell
   #
   # Run a single command line.
   #
+  # @param [String] line The command string that should be executed.
+  # @param [Boolean] propagate_errors Whether or not to raise exceptions that are caught while executing the command.
+  #
+  # @return [Boolean] A boolean value signifying whether or not the command was handled. Value is `true` when the
+  #   command line was handled.
   def run_single(line, propagate_errors: false)
-    arguments = parse_line(line)
-    method    = arguments.shift
-    found     = false
-    error     = false
+    arguments  = parse_line(line)
+    method     = arguments.shift
+    cmd_status = nil  # currently either nil or :handled, more statuses can be added in the future
+    error      = false
 
     # If output is disabled output will be nil
     output.reset_color if (output)
@@ -482,12 +489,12 @@ module DispatcherShell
           if (dispatcher.commands.has_key?(method) or dispatcher.deprecated_commands.include?(method))
             self.on_command_proc.call(line.strip) if self.on_command_proc
             run_command(dispatcher, method, arguments)
-            found = true
-          elsif dispatcher.unknown_command(method, line)
-            found = true
+            cmd_status = :handled
+          elsif cmd_status.nil?
+            cmd_status = dispatcher.unknown_command(method, line)
           end
         rescue ::Interrupt
-          found = true
+          cmd_status = :handled
           print_error("#{method}: Interrupted")
           raise if propagate_errors
         rescue OptionParser::ParseError => e
@@ -515,12 +522,12 @@ module DispatcherShell
         break if (dispatcher_stack.length != entries)
       }
 
-      if (found == false and error == false)
+      if (cmd_status.nil? && error == false)
         unknown_command(method, line)
       end
     end
 
-    return found
+    return cmd_status == :handled
   end
 
   #

--- a/test/modules/post/test/meterpreter.rb
+++ b/test/modules/post/test/meterpreter.rb
@@ -47,6 +47,19 @@ class MetasploitModule < Msf::Post
     super
   end
 
+  def test_core_command_id_enumeration
+    commands = []
+
+    it "should enumerate supported core commands" do
+      commands.concat(session.core.get_loaded_extension_commands('core'))
+      !commands.empty?
+    end
+
+    # 3 is arbitrary, but it's probably a good bare minimum to include enumextcmd, machine_id, and loadlib
+    it "should support 3 or more core commands" do
+      commands.length >= 3
+    end
+  end
 
   def test_sys_process
     vprint_status("Starting process tests")


### PR DESCRIPTION
This requires rapid7/metasploit-payloads#451 to be landed first and the gem to be bumped.

This makes a number of changes to offer better handling for Meterpreter extensions and commands that are incompatible with a particular session. This for example will handle when the user attempts to `migrate` using a Python Meterpreter, or load the `kiwi` extension on the PHP Meterpreter. Currently in both of these cases, the user will get an error basically implying that Metasploit has no idea what that command or extension is. This could easily confuse someone less familiar with Metasploit that may not realize that `migrate` isn't supported on all Meterpreters, or that not all Meterpreters have the same extensions. With these changes in place, the user will get a more descriptive error message stating that the command<sup>1</sup> or extension is incompatible with the current session type (which is printed in the output to make our jobs easier when troubleshooting issues opened by users).

One of the major changes made to facilitate this is to enumerate the command IDs that are supported by the Meterpreter core since not all of them support all of the same core commands. With this in place, Metasploit is able to rely on Meterpreter informing it of which core commands it can handle and use that information to filter commands. This is a much better solution than the platform fingerprinting that is in place now. It is also how commands for extensions like `stdapi` are currently filtered. There's a good amount of code that was refactored in this PR to rely on the enumerated core commands instead of fingerprinting the platform which isn't super consistent.

This PR also updates the `post/test/meterpreter` module to incorporate a new test that ensures that the core command IDs can be enumerated as the extension ones can be.

<sup>1</sup> For a Meterpreter command to be reported as incompatible, the extension that provides it must have been loaded. For example, if a user attempts to run `creds_all` without loading `kiwi`, they'll still get an error that the command is unknown.

## Testing
- [x] Start `msfconsole` and run `loadpath test/modules` to load the test modules
- [x] Use `exploit/windows/smb/psexec` and set the options to target a Windows system
- [x] Use the `AutoRunScript` option to automatically run `post/test/meterpreter`
- [x] Run it for both the 32-bit and 64-bit payloads, see no error messages
- [x] Open a Python / Java / PHP Meterperter
- [x] See that Windows-specific commands and extensions are not available (commands: `migrate`, `ssl_verify`, etc.) (extensions: `python`, `kiwi`, `powershell`, etc.)
- [ ] See that commands that are not supported do not appear in the `help` output and are not suggested for tab completion

## Demo

In this example, the Python Meterpreter is used which lacks support for the `migrate` command and does not have the `kiwi` extension.

```
msf6 payload(python/meterpreter/reverse_tcp) > sessions -i -1
[*] Starting interaction with 1...

meterpreter > sysinfo
Computer        : localhost.localdomain
OS              : Linux 5.9.16-100.fc32.x86_64 #1 SMP Mon Dec 21 14:10:00 UTC 2020
Architecture    : x64
System Language : en_US
Meterpreter     : python/linux
meterpreter > migrate 1234
[-] The "migrate" command is not supported by this Meterpreter type (python/linux)
meterpreter > thisCommandDoesNotExist
[-] Unknown command: thisCommandDoesNotExist.
meterpreter > load kiwi
Loading extension kiwi...
[-] Failed to load extension: The "kiwi" extension is not supported by this Meterpreter type (python/linux)
meterpreter > load thisExtensionDoesNotExist
Loading extension thisextensiondoesnotexist...
[-] Failed to load extension: No module of the name thisextensiondoesnotexist found
meterpreter > 
```

Fixes #14610