### PR TITLE
cve-2020-29583 - zyxel hardcoded creds

### DIFF
--- a/data/wordlists/unix_passwords.txt
+++ b/data/wordlists/unix_passwords.txt
@@ -1008,4 +1008,3 @@ MargaretThatcheris110%SEXY
 karaf
 vagrant
 PrOw!aN_fXp
-

--- a/data/wordlists/unix_passwords.txt
+++ b/data/wordlists/unix_passwords.txt
@@ -1007,3 +1007,5 @@ arcsight
 MargaretThatcheris110%SEXY
 karaf
 vagrant
+PrOw!aN_fXp
+

--- a/data/wordlists/unix_users.txt
+++ b/data/wordlists/unix_users.txt
@@ -167,4 +167,3 @@ xpdb
 xpopr
 zabbix
 zyfwp
-

--- a/data/wordlists/unix_users.txt
+++ b/data/wordlists/unix_users.txt
@@ -166,3 +166,5 @@ www-data
 xpdb
 xpopr
 zabbix
+zyfwp
+


### PR DESCRIPTION
This PR adds the hardcoded creds found in Zyxel devices which is captured as cve-2020-29583 to the unix creds files.  Nice and easy PR.