### PR TITLE
Fix #14261 Prompt timestamp escape display error

### DIFF
--- a/lib/rex/ui/text/shell.rb
+++ b/lib/rex/ui/text/shell.rb
@@ -2,8 +2,6 @@
 require 'rex/text/color'
 require 'rex/ui'
 
-gem 'pry-byebug'
-
 module Rex
 module Ui
 module Text

--- a/lib/rex/ui/text/shell.rb
+++ b/lib/rex/ui/text/shell.rb
@@ -2,6 +2,8 @@
 require 'rex/text/color'
 require 'rex/ui'
 
+gem 'pry-byebug'
+
 module Rex
 module Ui
 module Text
@@ -414,8 +416,11 @@ module Shell
 
       skip_next = true
       if spec == 'T'
-        # This %T is the strftime shorthand for %H:%M:%S
-        strftime_format = framework.datastore['PromptTimeFormat'] || '%T'
+        if framework.datastore['PromptTimeFormat']
+          strftime_format = framework.datastore['PromptTimeFormat']
+        else
+          strftime_format = Time::DATE_FORMATS[:db].to_s
+        end
         formatted << Time.now.strftime(strftime_format).to_s
       elsif spec == 'W' && framework.db.active
         formatted << framework.db.workspace.name


### PR DESCRIPTION
This PR fixes issue #14261. 

Forgot I had this laying around, and was able to get to it after the holidays and chaos of the start of 2021. This gets the timestamp to show up in the prompt when setting the prompt to `%T`. Without being too familiar of files under rex, I think this should do the trick. Let me know if it should be cleaned up or if I logically didn't get something right. 

Sorry for the delay!

## Verification

- [ ] Start `msfconsole`
- [ ] `show options` to verify the value of `PromptTimeFormat`
- [ ] `set Prompt %T` to set the prompt to display the correct date and time
- [ ] **Verify** that the accurate date and time is shown 

```
./msfconsole -q -r prompt_test.rc
[*] Processing prompt_test.rc for ERB directives.
resource (prompt_test.rc)> show options

Global Options:
===============

   Option             Current Setting      Description
   ------             ---------------      -----------
   ConsoleLogging     false                Log all console input and output
   LogLevel           0                    Verbosity of logs (default 0, max 3)
   MeterpreterPrompt  meterpreter  The meterpreter prompt string
   MinimumRank        0                    The minimum rank of exploits that will run without explicit confirmation
   Prompt             msf6                 The prompt string
   PromptChar         >                    The prompt character
   PromptTimeFormat   %Y-%m-%d %H:%M:%S    Format for timestamp escapes in prompts
   SessionLogging     false                Log all input and output for sessions
   TimestampOutput    false                Prefix all console output with a timestamp

resource (prompt_test.rc)> set Prompt %T
Prompt => %T
2021-01-19 17:59:56 > set Prompt msf6
Prompt => msf6
msf6 > set Prompt %T
Prompt => %T
2021-01-19 18:00:16 > 
```
