### PR TITLE
Fix run command tab completions by using the correct value

### DIFF
--- a/lib/msf/ui/console/module_action_commands.rb
+++ b/lib/msf/ui/console/module_action_commands.rb
@@ -118,7 +118,7 @@ module ModuleActionCommands
   # at least 1 when tab completion has reached this stage since the command itself has been completed
   #
   def cmd_run_tabs(str, words)
-    flags = @@run_action_opts.fmt.keys
+    flags = @@module_opts.fmt.keys
     options = tab_complete_option(str, words)
     flags + options
   end


### PR DESCRIPTION
This fixes a simple bug introduced in #14582 where a non-existent value is used to populate the tab completion array for the `run` command of modules that support actions as commands. See [here](https://github.com/rapid7/metasploit-framework/pull/14564#pullrequestreview-573808988) for the original bug report.

To reproduce the issue, use an auxiliary or exploit module, type in `run `, and hit the tab key. Without this fix, the framework will crash while with this fix the tab completion should work correctly.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use auxiliary/gather/jenkins_cred_recovery`
- [x] Type in `run ` (note the space at the end)
- [x] Double tap the tab key and see that metasploit suggestions options for completion instead of crashing

