### PR TITLE
download version of get-pip supporting python2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,7 @@ RUN chown -R root:metasploit $APP_HOME/
 RUN chmod 664 $APP_HOME/Gemfile.lock
 RUN gem update --system
 RUN cp -f $APP_HOME/docker/database.yml $APP_HOME/config/database.yml
-RUN curl -O https://bootstrap.pypa.io/get-pip.py && python get-pip.py && rm get-pip.py
+RUN curl -L -O https://github.com/pypa/get-pip/raw/3843bff3a0a61da5b63ea0b7d34794c5c51a2f11/get-pip.py && python get-pip.py && rm get-pip.py
 RUN pip install impacket
 
 WORKDIR $APP_HOME


### PR DESCRIPTION
As of Jan 30, the latest version of get-pip provides
pip 21.0+ and no longer supports python2 syntax.  By
pulling down the locked version directly from github
instead of latest from pypi the requirement to only
support python3 is deferred.

## Verification

List the steps needed to make sure this thing works

- [ ] `docker build -t metasploitframework/metasploit-framework:test-build .`
