### PR TITLE
Rubocop: Layout/ExtraSpacing: Enable AllowBeforeTrailingComments

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -192,7 +192,7 @@ Layout/ExtraSpacing:
   # When true, allows things like 'obj.meth(arg)  # comment',
   # rather than insisting on 'obj.meth(arg) # comment'.
   # If done for alignment, either this OR AllowForAlignment will allow it.
-  AllowBeforeTrailingComments: false
+  AllowBeforeTrailingComments: true
   # When true, forces the alignment of `=` in assignments on consecutive lines.
   ForceEqualSignAlignment: false
 


### PR DESCRIPTION
Allowing spaces before trailing inline comments for alignment purposes makes sense.

This code pattern appears frequently and is often useful for commenting large blocks of data (especially binary data) such as manually crafted packets and ROP gadgets.

For example:

https://github.com/rapid7/metasploit-framework/blob/5dafb5292266343f5d565722ed7cf1f1b4764b3f/modules/exploits/windows/browser/ms12_004_midi.rb#L552-L586

It makes no sense to enforce a single space before the comment and makes the code worse to read. There is no harm in allowing spaces before comments beyond potentially affecting readability; whereas `rubocop -a` modifications are objectively harder to read. Preventing multiple spaces has more cons than pros.

This change also cuts the number of Rubocop violations in half for some modules.
