### PR TITLE
Hide negative results behind vprint_error within `auxiliary/scanner/ssh/ssh_enumusers`

### DIFF
--- a/modules/auxiliary/scanner/ssh/ssh_enumusers.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_enumusers.rb
@@ -227,9 +227,9 @@ class MetasploitModule < Msf::Auxiliary
       print_good("#{peer(ip)} User '#{user}' found")
       do_report(ip, user, rport)
     when :connection_error
-      print_error("#{peer(ip)} User '#{user}' on could not connect")
+      vprint_error("#{peer(ip)} User '#{user}' on could not connect")
     when :fail
-      print_error("#{peer(ip)} User '#{user}' not found")
+      vprint_error("#{peer(ip)} User '#{user}' not found")
     end
   end
 


### PR DESCRIPTION
If you use the `auxiliary/scanner/ssh/ssh_enumusers` module and test a lot of users, the output gets polluted with many misses (e.g `User 'xxx' not found`).
Other auxiliary-moules hide those negative results per default and show them only if you specify verbose output.

My changes change the prints so that they also only show positive results per default. You can still get the full output if verbose is true.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use uxiliary/scanner/ssh/ssh_enumusers`
- [ ] `set rhosts <IP>`
- [ ] `set user_file /opt/metasploit-framework/embedded/framework/data/wordlists/unix_users.txt`
- [ ] `run`
- [ ] **Verify** that users who are not found are not displayed in the output by default
- [ ] `set verbose true`
- [ ] `run`
- [ ] **Verify** that now all results are displayed