### PR TITLE
Bump msf-payloads Gem from 2.0.27 to 2.0.28

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,7 +29,7 @@ PATH
       metasploit-concern
       metasploit-credential
       metasploit-model
-      metasploit-payloads (= 2.0.27)
+      metasploit-payloads (= 2.0.28)
       metasploit_data_models
       metasploit_payloads-mettle (= 1.0.5)
       mqtt
@@ -224,7 +224,7 @@ GEM
       activemodel (~> 5.2.2)
       activesupport (~> 5.2.2)
       railties (~> 5.2.2)
-    metasploit-payloads (2.0.27)
+    metasploit-payloads (2.0.28)
     metasploit_data_models (4.1.1)
       activerecord (~> 5.2.2)
       activesupport (~> 5.2.2)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -70,7 +70,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '2.0.27'
+  spec.add_runtime_dependency 'metasploit-payloads', '2.0.28'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '1.0.5'
   # Needed by msfgui and other rpc components


### PR DESCRIPTION
This PR bumps framework to use Metasploit payloads gem 2.0.28 (previously 2.0.27), pulling in the following payloads PR changes:

* https://github.com/rapid7/metasploit-payloads/pull/451

## Verification

List the steps needed to make sure this thing works

- [x] Retest manually
- [x] Let automated tests pass