### PR TITLE
Add ruby 3.0.0 issue bot response

### DIFF
--- a/.github/label-actions.yml
+++ b/.github/label-actions.yml
@@ -123,3 +123,11 @@ issues:
         When creating an issue, please ensure that the default issue template has been updated with the required details.
 
         Closing this issue. If you believe this issue has been closed in error, please provide any relevant output and logs which may be useful in diagnosing the issue.
+
+    ruby-3.0.0:
+      close: true
+      comment: |
+        This issue appears to be related to Ruby 3.0.0. At this time Metasploit does not support Ruby 3.0.0.
+        Please try using Ruby 2.7.x with Metasploit.
+
+        Closing this issue as a duplicate of #14666 - which aims to track this feature request.


### PR DESCRIPTION
Adds a bot response for the Ruby 3.0.0 upgrade.

Note that I'm pre-empting the need for this bot's response. So far there has only been one raised Ruby 3.0.0 issue - https://github.com/rapid7/metasploit-framework/issues/14660