### PR TITLE
ensure selected cracker is available and viable

### DIFF
--- a/lib/msf/core/auxiliary/password_cracker.rb
+++ b/lib/msf/core/auxiliary/password_cracker.rb
@@ -76,7 +76,7 @@ module Auxiliary::PasswordCracker
   # @return [nilClass] if there is no active framework db connection
   # @return [Metasploit::Framework::PasswordCracker::Cracker] if it successfully creates a Password Cracker object
   def new_password_cracker(cracking_application)
-    fail_with(Msf::Module::Failure::BadConfig, "Password cracking is not available without an active data database connection.") unless framework.db.active
+    fail_with(Msf::Module::Failure::BadConfig, "Password cracking is not available without an active database connection.") unless framework.db.active
     cracker = Metasploit::Framework::PasswordCracker::Cracker.new(
         config: datastore['CONFIG'],
         cracker_path: datastore['CRACKER_PATH'],

--- a/lib/msf/core/auxiliary/password_cracker.rb
+++ b/lib/msf/core/auxiliary/password_cracker.rb
@@ -75,9 +75,9 @@ module Auxiliary::PasswordCracker
   #
   # @return [nilClass] if there is no active framework db connection
   # @return [Metasploit::Framework::PasswordCracker::Cracker] if it successfully creates a Password Cracker object
-  def new_password_cracker
-    return nil unless framework.db.active
-    Metasploit::Framework::PasswordCracker::Cracker.new(
+  def new_password_cracker(cracking_application)
+    fail_with(Msf::Module::Failure::BadConfig, "Password cracking is not available without an active data database connection.") unless framework.db.active
+    cracker = Metasploit::Framework::PasswordCracker::Cracker.new(
         config: datastore['CONFIG'],
         cracker_path: datastore['CRACKER_PATH'],
         max_runtime: datastore['ITERATION_TIMEOUT'],
@@ -85,6 +85,18 @@ module Auxiliary::PasswordCracker
         optimize: datastore['OptimizeKernel'],
         wordlist: datastore['CUSTOM_WORDLIST']
     )
+    cracker.cracker = cracking_application
+    begin
+      cracker.binary_path
+    rescue Metasploit::Framework::PasswordCracker::PasswordCrackerNotFoundError => e
+      fail_with(Msf::Module::Failure::BadConfig, e.message)
+    end
+    cracker_version = cracker.cracker_version
+    if cracking_application == 'john' && cracker_version.nil? || !cracker_version.include?('jumbo')
+      fail_with(Msf::Module::Failure::BadConfig, 'John the Ripper JUMBO patch version required.  See https://github.com/magnumripper/JohnTheRipper')
+    end
+    print_good("#{cracking_application} Version Detected: #{cracker_version}")
+    cracker
   end
 
   # This method instantiates a {Metasploit::Framework::JtR::Wordlist}, writes the data

--- a/modules/auxiliary/analyze/apply_pot.rb
+++ b/modules/auxiliary/analyze/apply_pot.rb
@@ -61,13 +61,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
-    cracker = new_password_cracker
-    cracker.cracker = action.name
-    cracker_version = cracker.cracker_version
-    if action.name == 'john' and !cracker_version.include? 'jumbo'
-      fail_with(Failure::BadConfig, 'John the Ripper JUMBO patch version required.  See https://github.com/magnumripper/JohnTheRipper')
-    end
-    print_good("#{action.name} Version Detected: #{cracker_version}")
+    cracker = new_password_cracker(action.name)
 
     lookups = []
 

--- a/modules/auxiliary/analyze/crack_aix.rb
+++ b/modules/auxiliary/analyze/crack_aix.rb
@@ -116,14 +116,7 @@ class MetasploitModule < Msf::Auxiliary
     # Inner array format: db_id, hash_type, username, password, method_of_crack
     results = []
 
-    cracker = new_password_cracker
-    cracker.cracker = action.name
-
-    cracker_version = cracker.cracker_version
-    if action.name == 'john' and not cracker_version.include?'jumbo'
-      fail_with(Failure::BadConfig, 'John the Ripper JUMBO patch version required.  See https://github.com/magnumripper/JohnTheRipper')
-    end
-    print_good("#{action.name} Version Detected: #{cracker_version}")
+    cracker = new_password_cracker(action.name)
 
     # create the hash file first, so if there aren't any hashes we can quit early
     # hashes is a reference list used by hashcat only

--- a/modules/auxiliary/analyze/crack_databases.rb
+++ b/modules/auxiliary/analyze/crack_databases.rb
@@ -209,7 +209,6 @@ class MetasploitModule < Msf::Auxiliary
     results = []
 
     cracker = new_password_cracker(action.name)
-    cracker.cracker = action.name
 
     # create the hash file first, so if there aren't any hashes we can quit early
     # hashes is a reference list used by hashcat only

--- a/modules/auxiliary/analyze/crack_databases.rb
+++ b/modules/auxiliary/analyze/crack_databases.rb
@@ -208,14 +208,8 @@ class MetasploitModule < Msf::Auxiliary
     # Inner array format: db_id, hash_type, username, password, method_of_crack
     results = []
 
-    cracker = new_password_cracker
+    cracker = new_password_cracker(action.name)
     cracker.cracker = action.name
-
-    cracker_version = cracker.cracker_version
-    if action.name == 'john' and not cracker_version.include?'jumbo'
-      fail_with(Failure::BadConfig, 'John the Ripper JUMBO patch version required.  See https://github.com/magnumripper/JohnTheRipper')
-    end
-    print_good("#{action.name} Version Detected: #{cracker_version}")
 
     # create the hash file first, so if there aren't any hashes we can quit early
     # hashes is a reference list used by hashcat only

--- a/modules/auxiliary/analyze/crack_linux.rb
+++ b/modules/auxiliary/analyze/crack_linux.rb
@@ -134,14 +134,7 @@ class MetasploitModule < Msf::Auxiliary
     # Inner array format: db_id, hash_type, username, password, method_of_crack
     results = []
 
-    cracker = new_password_cracker
-    cracker.cracker = action.name
-
-    cracker_version = cracker.cracker_version
-    if action.name == 'john' and not cracker_version.include?'jumbo'
-      fail_with(Failure::BadConfig, 'John the Ripper JUMBO patch version required.  See https://github.com/magnumripper/JohnTheRipper')
-    end
-    print_good("#{action.name} Version Detected: #{cracker_version}")
+    cracker = new_password_cracker(action.name)
 
     # create the hash file first, so if there aren't any hashes we can quit early
     # hashes is a reference list used by hashcat only

--- a/modules/auxiliary/analyze/crack_mobile.rb
+++ b/modules/auxiliary/analyze/crack_mobile.rb
@@ -117,14 +117,7 @@ class MetasploitModule < Msf::Auxiliary
     # Inner array format: db_id, hash_type, username, password, method_of_crack
     results = []
 
-    cracker = new_password_cracker
-    cracker.cracker = action.name
-
-    cracker_version = cracker.cracker_version
-    if action.name == 'john' and not cracker_version.include?'jumbo'
-      fail_with(Failure::BadConfig, 'John the Ripper JUMBO patch version required.  See https://github.com/magnumripper/JohnTheRipper')
-    end
-    print_good("#{action.name} Version Detected: #{cracker_version}")
+    cracker = new_password_cracker(action.name)
 
     # create the hash file first, so if there aren't any hashes we can quit early
     # hashes is a reference list used by hashcat only

--- a/modules/auxiliary/analyze/crack_osx.rb
+++ b/modules/auxiliary/analyze/crack_osx.rb
@@ -118,14 +118,7 @@ class MetasploitModule < Msf::Auxiliary
     # Inner array format: db_id, hash_type, username, password, method_of_crack
     results = []
 
-    cracker = new_password_cracker
-    cracker.cracker = action.name
-
-    cracker_version = cracker.cracker_version
-    if action.name == 'john' and not cracker_version.include?'jumbo'
-      fail_with(Failure::BadConfig, 'John the Ripper JUMBO patch version required.  See https://github.com/magnumripper/JohnTheRipper')
-    end
-    print_good("#{action.name} Version Detected: #{cracker_version}")
+    cracker = new_password_cracker(action.name)
 
     # create the hash file first, so if there aren't any hashes we can quit early
     # hashes is a reference list used by hashcat only

--- a/modules/auxiliary/analyze/crack_webapps.rb
+++ b/modules/auxiliary/analyze/crack_webapps.rb
@@ -119,14 +119,7 @@ class MetasploitModule < Msf::Auxiliary
     # Inner array format: db_id, hash_type, username, password, method_of_crack
     results = []
 
-    cracker = new_password_cracker
-    cracker.cracker = action.name
-
-    cracker_version = cracker.cracker_version
-    if action.name == 'john' and not cracker_version.include?'jumbo'
-      fail_with(Failure::BadConfig, 'John the Ripper JUMBO patch version required.  See https://github.com/magnumripper/JohnTheRipper')
-    end
-    print_good("#{action.name} Version Detected: #{cracker_version}")
+    cracker = new_password_cracker(action.name)
 
     # create the hash file first, so if there aren't any hashes we can quit early
     # hashes is a reference list used by hashcat only

--- a/modules/auxiliary/analyze/crack_windows.rb
+++ b/modules/auxiliary/analyze/crack_windows.rb
@@ -192,14 +192,7 @@ class MetasploitModule < Msf::Auxiliary
     # Inner array format: db_id, hash_type, username, password, method_of_crack
     results = []
 
-    cracker = new_password_cracker
-    cracker.cracker = action.name
-
-    cracker_version = cracker.cracker_version
-    if action.name == 'john' and not cracker_version.include?'jumbo'
-      fail_with(Failure::BadConfig, 'John the Ripper JUMBO patch version required.  See https://github.com/magnumripper/JohnTheRipper')
-    end
-    print_good("#{action.name} Version Detected: #{cracker_version}")
+    cracker = new_password_cracker(action.name)
 
     # create the hash file first, so if there aren't any hashes we can quit early
     # hashes is a reference list used by hashcat only


### PR DESCRIPTION
When no password cracker is installed `cracker_version` returns `nil`.
Guard against `nil` in the version check and consolidate detection of
a viable environment and application as a responsibility of the factory
that provides the instance.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole` on a system without `john` or `hashcat` installed and a empty database available
- [ ] `db_disconnect`
- [ ] `use crack_linux` (or any other `auxiliary/analyze/crack_*` module)
- [ ] `run`
- [ ] **Verify** Failure is reported with database requirement noted.
- [ ] Start `msfconsole` on a system without `john` or `hashcat` installed
- [ ] `db_connect`
- [ ] `use crack_linux`
- [ ] `run`
- [ ] **Verify** Failure is reported noting no binary found.
- [ ] install `john` without `jumbo` patch
- [ ] `use crack_linux`
- [ ] `run`
- [ ] **Verify** Failure is reported noting `jumbo` patch is required.
- [ ] install `john` with `jumbo` patch
- [ ] `use crack_linux`
- [ ] `run`
- [ ] **Verify** Result reports no credentials cracked since none exist in the database.
- [ ] `use crack_linux`
- [ ] `set action hashcat`
- [ ] `run`
- [ ] **Verify** Failure is reported noting no binary found.
- [ ] install `hashcat`
- [ ] `use crack_linux`
- [ ] `set action hashcat`
- [ ] `run`
- [ ] **Verify** Result reports no credentials cracked since none exist in the database.
