### PR TITLE
Enable word wrapped rex tables by default

### DIFF
--- a/lib/msf/core/feature_manager.rb
+++ b/lib/msf/core/feature_manager.rb
@@ -16,9 +16,9 @@ module Msf
     WRAPPED_TABLES = 'wrapped_tables'
     DEFAULTS = [
       {
-        name: 'wrapped_tables',
+        name: WRAPPED_TABLES,
         description: 'When enabled Metasploit will wordwrap all tables to fit into the available terminal width',
-        default_value: false
+        default_value: true
       }.freeze,
       {
         name: 'RHOST_HTTP_URL',
@@ -32,6 +32,14 @@ module Msf
     #
     def initialize
       @flag_lookup = DEFAULTS.each_with_object({}) do |feature, acc|
+        if feature[:name] == WRAPPED_TABLES
+          if feature[:default_value] == true
+            Rex::Text::Table.wrap_tables!
+          else
+            Rex::Text::Table.unwrap_tables!
+          end
+        end
+
         key = feature[:name]
         acc[key] = feature.dup
       end

--- a/lib/msf/ui/console/command_dispatcher/creds.rb
+++ b/lib/msf/ui/console/command_dispatcher/creds.rb
@@ -432,6 +432,9 @@ class Creds
     svcs.flatten!
     tbl_opts = {
       'Header'  => "Credentials",
+      # For now, don't perform any word wrapping on the cred table as it breaks the workflow of
+      # copying credentials and pasting them into applications
+      'Width' => ::BigDecimal::INFINITY,
       'Columns' => cred_table_columns,
       'SearchTerm' => search_term
     }
@@ -483,7 +486,7 @@ class Creds
           "", # host
           origin, # origin
           "", # service
-          public_val, 
+          public_val,
           private_val,
           realm_val,
           human_val, #private type

--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -1301,6 +1301,9 @@ module Msf
                 'Prefix'     => "\n",
                 'Postfix'    => "\n",
                 'SearchTerm' => row_filter,
+                # For now, don't perform any word wrapping on the search table as it breaks the workflow of
+                # copying module names in conjunction with the `use <paste-buffer>` command
+                'Width' => ::BigDecimal::INFINITY,
                 'Columns' => [
                   '#',
                   'Name',

--- a/spec/lib/msf/ui/console/command_dispatcher/creds_spec.rb
+++ b/spec/lib/msf/ui/console/command_dispatcher/creds_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Creds do
         let(:nonblank_password)   { 'nonblank_pass' }
 
         let!(:origin) { FactoryBot.create(:metasploit_credential_origin_import) }
-        
+
         let!(:priv) { FactoryBot.create(:metasploit_credential_password, data: password) }
         let!(:pub) { FactoryBot.create(:metasploit_credential_username, username: username) }
         let!(:blank_pub) { blank_pub = FactoryBot.create(:metasploit_credential_blank_username) }
@@ -48,14 +48,14 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Creds do
             public: pub,
             realm: nil,
             workspace: framework.db.workspace)
-          
+
           FactoryBot.create(:metasploit_credential_core,
             origin: origin,
             private: nonblank_priv,
             public: blank_pub,
             realm: nil,
             workspace: framework.db.workspace)
-            
+
           FactoryBot.create(:metasploit_credential_core,
             origin: origin,
             private: blank_priv,
@@ -73,7 +73,7 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Creds do
               '',
               'host  origin  service  public    private   realm  private_type  JtR Format',
               '----  ------  -------  ------    -------   -----  ------------  ----------',
-              '                       thisuser  thispass         Password      '
+              '                       thisuser  thispass         Password'
             ])
           end
 
@@ -85,7 +85,7 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Creds do
               '',
               'host  origin  service  public    private   realm  private_type  JtR Format',
               '----  ------  -------  ------    -------   -----  ------------  ----------',
-              '                       thisuser  thispass         Password      '
+              '                       thisuser  thispass         Password'
             ])
           end
 
@@ -98,7 +98,7 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Creds do
                 '',
                 'host  origin  service  public  private        realm  private_type  JtR Format',
                 '----  ------  -------  ------  -------        -----  ------------  ----------',
-                '                               nonblank_pass         Password      '
+                '                               nonblank_pass         Password'
               ])
             end
           end
@@ -111,7 +111,7 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Creds do
                 '',
                 'host  origin  service  public         private  realm  private_type  JtR Format',
                 '----  ------  -------  ------         -------  -----  ------------  ----------',
-                '                       nonblank_user                  Password      '
+                '                       nonblank_user                  Password'
               ])
             end
           end
@@ -208,7 +208,7 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Creds do
                 '',
                 'host  origin  service  public    private   realm  private_type  JtR Format',
                 '----  ------  -------  ------    -------   -----  ------------  ----------',
-                '                       thisuser  thispass         Password      '
+                '                       thisuser  thispass         Password'
               ])
             end
           end

--- a/spec/lib/msf/ui/console/command_dispatcher/db_spec.rb
+++ b/spec/lib/msf/ui/console/command_dispatcher/db_spec.rb
@@ -234,8 +234,8 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Db do
           "",
           "host         port  proto  name      state  info",
           "----         ----  -----  ----      -----  ----",
-          "192.168.0.1  1024  udp    service1  open   ",
-          "192.168.0.1  1025  tcp    service2  open   "
+          "192.168.0.1  1024  udp    service1  open",
+          "192.168.0.1  1025  tcp    service2  open"
         ]
       end
     end
@@ -267,8 +267,8 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Db do
             "",
             "host         port  proto  name  state  info",
             "----         ----  -----  ----  -----  ----",
-            "192.168.0.2  1025  snmp         open   ",
-            "192.168.0.2  1026  snmp         open   "
+            "192.168.0.2  1025  snmp         open",
+            "192.168.0.2  1026  snmp         open"
           ]
         }
       end


### PR DESCRIPTION
Enables word wrapped rex tables by default, apart from the following potentially workflow breaking areas:

- Search command - as it breaks the workflow of copying module names in conjunction with the `use <paste-buffer>` command
- Creds command - as it breaks the workflow of copying credentials and pasting them into applications

In a future PR these other above areas will be enabled too, once it's confirmed that this PR doesn't break other use cases/tooling.

## Before

![image](https://user-images.githubusercontent.com/60357436/106124824-6b946800-6153-11eb-815b-a577bfe84789.png)

## After

![image](https://user-images.githubusercontent.com/60357436/106124737-5586a780-6153-11eb-8d98-1d775a127538.png)

## Verification

- Ensure that search + creds commands don't wordwrap
- Ensure that other tables wrap, such as options/info/etc
- Ensure `features set wrapped_tables false` disables functionality 