### PR TITLE
Add explicit require for open3 depenency

### DIFF
--- a/lib/metasploit/framework/data_service/remote/managed_remote_data_service.rb
+++ b/lib/metasploit/framework/data_service/remote/managed_remote_data_service.rb
@@ -1,5 +1,6 @@
 require 'singleton'
 require 'metasploit/framework/data_service/remote/http/core'
+require 'open3'
 
 module Metasploit
 module Framework


### PR DESCRIPTION
Fixes a missing dependency `open3` within the ManagedRemoteDataService class. This caused an unrelated pull request to fail on a test due to the missing `Open3` constant.

## Verification

- [ ] Verify that the automated tests passed