### PR TITLE
Remove < character from Archive_Tar exploit module

### DIFF
--- a/modules/exploits/multi/fileformat/archive_tar_arb_file_write.rb
+++ b/modules/exploits/multi/fileformat/archive_tar_arb_file_write.rb
@@ -14,9 +14,9 @@ class MetasploitModule < Msf::Exploit::Remote
     super(
       update_info(
         info,
-        'Name' => 'PEAR Archive_Tar < 1.4.11 Arbitrary File Write',
+        'Name' => 'PEAR Archive_Tar 1.4.10 Arbitrary File Write',
         'Description' => %q{
-          This module takes advantages of Archive_Tar < 1.4.11's lack of validation of file stream wrappers contained
+          This module takes advantages of Archive_Tar <= 1.4.10's lack of validation of file stream wrappers contained
           within filenames to write an arbitrary file containing user controlled content to an arbitrary file
           on disk. Note that the file will be written to disk with the permissions of the user that PHP is
           running as, so it may not be possible to overwrite some files if the PHP user is not appropriately
@@ -43,7 +43,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Arch' => ARCH_PHP,
         'Targets' =>
           [
-            ['Archive_Tar < 1.4.11', {}]
+            ['Archive_Tar <= 1.4.10', {}]
           ],
         'Privileged' => false,
         'DisclosureDate' => '2020-11-17'


### PR DESCRIPTION
Fixes the reported error with msftidy, removing the `<` character from Archive_Tar exploit module

## Verification

Verify that this module now passes msftidy:

```
$ bundle exec ruby ./tools/dev/msftidy.rb modules/exploits/multi/fileformat/archive_tar_arb_file_write.rb
modules/exploits/multi/fileformat/archive_tar_arb_file_write.rb - [ERROR] '<' is a bad character in module title.
```