### PR TITLE
Ensure msftidy runs on ci

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -67,6 +67,10 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@v2
+        # Required to checkout HEAD^ for the msftidy script
+        # https://github.com/actions/checkout/tree/5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f#checkout-head
+        with:
+          fetch-depth: 2
 
       - uses: actions/setup-ruby@v1
         with:
@@ -90,7 +94,7 @@ jobs:
         env:
           BUNDLER_WITHOUT: coverage development pcap
 
-      - name: Setup mstidy
+      - name: Setup msftidy
         run: |
           ln -sf ../../tools/dev/pre-commit-hook.rb ./.git/hooks/post-merge
           ls -la ./.git/hooks

--- a/tools/dev/pre-commit-hook.rb
+++ b/tools/dev/pre-commit-hook.rb
@@ -1,5 +1,7 @@
 #!/usr/bin/env ruby
 
+require "open3"
+
 #
 # Check that modules actually pass msftidy checks before committing
 # or after merging.
@@ -17,6 +19,16 @@
 # (rarely). If you'd prefer to copy it directly, that's okay, too (mark
 # it +x and don't name it filename.rb, just filename).
 #
+
+def run(command, exception: true)
+  puts command
+  stdout, status = ::Open3.capture2(command)
+  if !status.success? && exception
+    raise "Command failed with status (#{status.exitstatus}): #{command}"
+  end
+
+  stdout
+end
 
 def merge_error_message
   msg = []
@@ -45,9 +57,9 @@ else
 end
 
 if base_caller == :post_merge
-  changed_files = %x[git diff --name-only HEAD^ HEAD]
+  changed_files = run('git diff --name-only HEAD^ HEAD')
 else
-  changed_files = %x[git diff --cached --name-only]
+  changed_files = run('git diff --cached --name-only')
 end
 
 changed_files.each_line do |fname|


### PR DESCRIPTION
The migration to Github Actions accidentally dropped support for verifying the results of msftidy https://github.com/rapid7/metasploit-framework/pull/14495

This pull request fixes that

### Before

The msftidy.rb script was silently breaking

```
[*] Running msftidy.rb in ./.git/hooks/post-merge mode
git diff --name-only HEAD^ HEAD | cat
fatal: ambiguous argument 'HEAD^': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
--- No Metasploit modules to check ---
```

### After

The msftidy script has been updated to raise an error if the required git commands failed:

```
[*] Running msftidy.rb in ./.git/hooks/post-merge mode
git diff --name-only HEAD^ HEAD
fatal: ambiguous argument 'HEAD^': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
./.git/hooks/post-merge:26:in `run': Command failed with status (128): git diff --name-only HEAD^ HEAD (RuntimeError)
	from ./.git/hooks/post-merge:59:in `<main>'
Error: Process completed with exit code 1.
```

Testing against a previously broken module now works as expected:

```
[*] Running msftidy.rb in ./.git/hooks/post-merge mode
git diff --name-only HEAD^ HEAD
--- Checking new and changed module syntax with tools/dev/msftidy.rb ---
modules/exploits/multi/fileformat/archive_tar_arb_file_write.rb - [ERROR] '<' is a bad character in module title.
------------------------------------------------------------------------
------------------------------------------------------------------------
[*] This merge contains modules failing msftidy.rb
[*] Please fix this if you intend to publish these
[*] modules to a popular metasploit-framework repo
------------------------------------------------------------------------
```


## Verification

I verified that CI now correctly validates a module's quality, testing against a previously broken module now works as expected:

```
[*] Running msftidy.rb in ./.git/hooks/post-merge mode
git diff --name-only HEAD^ HEAD
--- Checking new and changed module syntax with tools/dev/msftidy.rb ---
modules/exploits/multi/fileformat/archive_tar_arb_file_write.rb - [ERROR] '<' is a bad character in module title.
------------------------------------------------------------------------
------------------------------------------------------------------------
[*] This merge contains modules failing msftidy.rb
[*] Please fix this if you intend to publish these
[*] modules to a popular metasploit-framework repo
------------------------------------------------------------------------
```