### PR TITLE
Ensure external python modules have formatted logging

### DIFF
--- a/lib/msf/core/modules/external/python/metasploit/module.py
+++ b/lib/msf/core/modules/external/python/metasploit/module.py
@@ -14,7 +14,7 @@ class LogFormatter(logging.Formatter):
         self.prefix = prefix
 
     def format(self, record):
-        return self.prefix + record.msg
+        return self.prefix + super().format(record)
 
 
 class LogHandler(logging.Handler):


### PR DESCRIPTION
### Before

Python's log messages are not correctly formatted:

```
$ PYTHONPATH=./lib/msf/core/modules/external/python:$PYTHONPATH /usr/local/opt/python@3.9/bin/python3.9 modules/auxiliary/example.py --rhost www.google.com run
[*] www.google.com - Starting new HTTPS connection (%d): %s:%s
/usr/local/lib/python3.9/site-packages/urllib3/connectionpool.py:1013: InsecureRequestWarning: Unverified HTTPS request is being made to host 'www.google.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  warnings.warn(
[*] www.google.com - %s://%s:%s "%s %s %s" %s %s
[*] www.google.com - <!doctype html><html itemscope="" itemtype="http:/...
```

### After

Python's log messages are correctly formatted:

```
$ PYTHONPATH=./lib/msf/core/modules/external/python:$PYTHONPATH /usr/local/opt/python@3.9/bin/python3.9 modules/auxiliary/example.py --rhost www.google.com run
[*] www.google.com - Starting new HTTPS connection (1): www.google.com:443
/usr/local/lib/python3.9/site-packages/urllib3/connectionpool.py:1013: InsecureRequestWarning: Unverified HTTPS request is being made to host 'www.google.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  warnings.warn(
[*] www.google.com - https://www.google.com:443 "GET // HTTP/1.1" 200 None
[*] www.google.com - <!doctype html><html itemscope="" itemtype="http:/...
```

## Verification

- Verify that python external modules work as expected within the console
- Verify that python external modules work as expected directly:
```
PYTHONPATH=./lib/msf/core/modules/external/python:$PYTHONPATH python3 modules/auxiliary/example.py --rhost www.google.com run
```
