### PR TITLE
bump Gemfile.lock and metasploit-framework.gemspec to use mettle 1.0.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,7 +31,7 @@ PATH
       metasploit-model
       metasploit-payloads (= 2.0.28)
       metasploit_data_models
-      metasploit_payloads-mettle (= 1.0.5)
+      metasploit_payloads-mettle (= 1.0.6)
       mqtt
       msgpack
       nessus_rest
@@ -234,7 +234,7 @@ GEM
       pg
       railties (~> 5.2.2)
       recog (~> 2.0)
-    metasploit_payloads-mettle (1.0.5)
+    metasploit_payloads-mettle (1.0.6)
     method_source (1.0.0)
     mini_portile2 (2.5.0)
     minitest (5.14.3)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -72,7 +72,7 @@ Gem::Specification.new do |spec|
   # Needed for Meterpreter
   spec.add_runtime_dependency 'metasploit-payloads', '2.0.28'
   # Needed for the next-generation POSIX Meterpreter
-  spec.add_runtime_dependency 'metasploit_payloads-mettle', '1.0.5'
+  spec.add_runtime_dependency 'metasploit_payloads-mettle', '1.0.6'
   # Needed by msfgui and other rpc components
   spec.add_runtime_dependency 'msgpack'
   # get list of network interfaces, like eth* from OS.

--- a/modules/payloads/singles/linux/armbe/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/armbe/meterpreter_reverse_http.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 1023220
+  CachedSize = 1023340
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/armbe/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/armbe/meterpreter_reverse_https.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 1023220
+  CachedSize = 1023340
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/armbe/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/armbe/meterpreter_reverse_tcp.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 1023220
+  CachedSize = 1023340
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/armle/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/armle/meterpreter_reverse_http.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 1023220
+  CachedSize = 1023340
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/armle/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/armle/meterpreter_reverse_https.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 1023220
+  CachedSize = 1023340
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/armle/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/armle/meterpreter_reverse_tcp.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 1023220
+  CachedSize = 1023340
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/mips64/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/mips64/meterpreter_reverse_http.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 1569384
+  CachedSize = 1569496
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/mips64/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/mips64/meterpreter_reverse_https.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 1569384
+  CachedSize = 1569496
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/mips64/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/mips64/meterpreter_reverse_tcp.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 1569384
+  CachedSize = 1569496
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/mipsbe/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/mipsbe/meterpreter_reverse_http.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 1461340
+  CachedSize = 1461452
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/mipsbe/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/mipsbe/meterpreter_reverse_https.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 1461340
+  CachedSize = 1461452
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/mipsbe/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/mipsbe/meterpreter_reverse_tcp.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 1461340
+  CachedSize = 1461452
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/x86/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/x86/meterpreter_reverse_http.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 1097244
+  CachedSize = 1101336
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/x86/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/x86/meterpreter_reverse_https.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 1097244
+  CachedSize = 1101336
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/x86/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/x86/meterpreter_reverse_tcp.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 1097244
+  CachedSize = 1101336
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions


### PR DESCRIPTION
This PR bumps framework to use mettle payloads gem 1.0.6, pulling in the following changes:

* https://github.com/rapid7/mettle/pull/207

## Verification

List the steps needed to make sure this thing works

- [ ] Manual sanity check
- [ ] Let automated tests pass
