### PR TITLE
Bump msgpack dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -239,7 +239,7 @@ GEM
     mini_portile2 (2.5.0)
     minitest (5.14.3)
     mqtt (0.5.0)
-    msgpack (1.4.1)
+    msgpack (1.4.2)
     multipart-post (2.1.1)
     mustermann (1.1.1)
       ruby2_keywords (~> 0.0.1)


### PR DESCRIPTION
Currently we're seeing the following error in our automated tests:

```
Fetching gem metadata from https://rubygems.org/.........
Your bundle is locked to msgpack (1.4.1), but that version could not be found in
any of the sources listed in your Gemfile. If you haven't changed sources, that
means the author of msgpack (1.4.1) has removed it. You'll need to update your
bundle to a version other than msgpack (1.4.1) that hasn't been removed in order
to install.
```

Verified locally:

```
➜  metasploit-framework: gemset delete metasploit-framework
Are you SURE you wish to remove the entire gemset directory 'metasploit-framework' (/Users/user/.rvm/gems/ruby-2.7.2@metasploit-framework)?
(anything other than 'yes' will cancel) > yes
Removing gemset metasploit-framework...
....
➜  metasploit-framework: bundle
Fetching gem metadata from https://rubygems.org/.........
Your bundle is locked to msgpack (1.4.1), but that version could not be found in any of the sources listed in your
Gemfile. If you haven't changed sources, that means the author of msgpack (1.4.1) has removed it. You'll need to update
your bundle to a version other than msgpack (1.4.1) that hasn't been removed in order to install.
```

It looks like this version was yanked, then a new 1.4.2 version was released shortly after:

> I'm very sorry for the case that Gemfile.lock already specifies 1.4.1 (or 1.4.0), but yanking those versions is the only solution for this problem. Please update it again to 1.4.2.
Thank you for trying those versions very early, and reporting your situation.

https://github.com/msgpack/msgpack-ruby/issues/205

## Verification

Ensure that tests pass successfully