### PR TITLE
Add Nagios XI mixin and auxiliary scanner module and docs

### DIFF
--- a/documentation/modules/auxiliary/scanner/http/nagios_xi_scanner.md
+++ b/documentation/modules/auxiliary/scanner/http/nagios_xi_scanner.md
@@ -1,16 +1,17 @@
 ## Vulnerable Application
 
-The module detects the version of Nagios XI applications and suggests matching exploit modules based on the version number.
+The module detects the version of Nagios XI running on a target and suggests matching exploit modules based on the version number.
 
 The module takes advantage of the `Msf::Exploit::Remote::HTTP::NagiosXi` mixin in order to
 authenticate to the target and obtain the version number, which is only revealed to authenticated users.
 
 When used to target a specific host, the module requires valid credentials for a Nagios XI account.
 These can be provided via `USERNAME` and `PASSWORD` options.
+
 Alternatively, it is possible to provide a specific Nagios XI version number via the `VERSION` option.
 In that case, the module simply suggests matching exploit modules and does not probe the target(s).
 
-The module currently supports the following exploit modules:
+The module is able to recommend the following modules based on the target's Nagios XI version:
 - exploit/linux/http/nagios_xi_plugins_check_plugin_authenticated_rce (CVE-2019-15949)
 - exploit/linux/http/nagios_xi_plugins_filename_authenticated_rce (CVE-2020-35578)
 - exploit/linux/http/nagios_xi_mibs_authenticated_rce (CVE-2020-5791)
@@ -48,6 +49,11 @@ the module will not probe the target, so it is not necessary to provide credenti
 ## Scenarios
 ### Nagios XI 5.6.5 running on CentOS 7
 ```
+msf6 > use auxiliary/scanner/http/nagios_xi_scanner 
+msf6 auxiliary(scanner/http/nagios_xi_scanner) > set rhosts 192.168.1.14
+rhosts => 192.168.1.14
+msf6 auxiliary(scanner/http/nagios_xi_scanner) > set password nagiosadmin
+password => nagiosadmin
 msf6 auxiliary(scanner/http/nagios_xi_scanner) > show options 
 
 Module options (auxiliary/scanner/http/nagios_xi_scanner):
@@ -85,6 +91,11 @@ msf6 auxiliary(scanner/http/nagios_xi_scanner) > run
 ```
 ### Nagios XI 5.7.9 version provided via VERSION
 ```
+msf6 > use auxiliary/scanner/http/nagios_xi_scanner 
+msf6 auxiliary(scanner/http/nagios_xi_scanner) > set rhosts 192.168.1.14
+rhosts => 192.168.1.14
+msf6 auxiliary(scanner/http/nagios_xi_scanner) > set version 5.7.9
+version => 5.7.9
 msf6 auxiliary(scanner/http/nagios_xi_scanner) > show options 
 
 Module options (auxiliary/scanner/http/nagios_xi_scanner):
@@ -95,7 +106,7 @@ Module options (auxiliary/scanner/http/nagios_xi_scanner):
                                               . This includes signing the license agreement.
    PASSWORD        nagiosadmin      no        Password to authenticate with
    Proxies                          no        A proxy chain of format type:host:port[,type:host:port][...]
-   RHOSTS          192.168.1.140    yes       The target host(s), range CIDR identifier, or hosts file with synt
+   RHOSTS          192.168.1.14     yes       The target host(s), range CIDR identifier, or hosts file with synt
                                               ax 'file:<path>'
    RPORT           80               yes       The target port (TCP)
    SSL             false            no        Negotiate SSL/TLS for outgoing connections
@@ -116,6 +127,13 @@ msf6 auxiliary(scanner/http/nagios_xi_scanner) > run
 ```
 ### Nagios XI 5.7.5 - incomplete installation, FINISH_INSTALL set to true
 ```
+msf6 > use auxiliary/scanner/http/nagios_xi_scanner 
+msf6 auxiliary(scanner/http/nagios_xi_scanner) > set rhosts 192.168.1.16
+rhosts => 192.168.1.16
+msf6 auxiliary(scanner/http/nagios_xi_scanner) > set password nagiosadmin
+password => nagiosadmin
+msf6 auxiliary(scanner/http/nagios_xi_scanner) > set finish_install true
+finish_install => true
 msf6 auxiliary(scanner/http/nagios_xi_scanner) > show options 
 
 Module options (auxiliary/scanner/http/nagios_xi_scanner):

--- a/documentation/modules/auxiliary/scanner/http/nagios_xi_scanner.md
+++ b/documentation/modules/auxiliary/scanner/http/nagios_xi_scanner.md
@@ -68,7 +68,7 @@ Module options (auxiliary/scanner/http/nagios_xi_scanner):
                                               ax 'file:<path>'
    RPORT           80               yes       The target port (TCP)
    SSL             false            no        Negotiate SSL/TLS for outgoing connections
-   TARGETURI       /nagiosxi/       yes       The base path to the NagiosXi application
+   TARGETURI       /nagiosxi/       yes       The base path to the Nagios XI application
    THREADS         1                yes       The number of concurrent threads (max one per host)
    USERNAME        nagiosadmin      no        Username to authenticate with
    VERSION                          no        Nagios XI version to check against existing exploit modules
@@ -104,13 +104,13 @@ Module options (auxiliary/scanner/http/nagios_xi_scanner):
    ----            ---------------  --------  -----------
    FINISH_INSTALL  false            no        If the Nagios XI installation has not been completed, try to do so
                                               . This includes signing the license agreement.
-   PASSWORD        nagiosadmin      no        Password to authenticate with
+   PASSWORD                         no        Password to authenticate with
    Proxies                          no        A proxy chain of format type:host:port[,type:host:port][...]
    RHOSTS          192.168.1.14     yes       The target host(s), range CIDR identifier, or hosts file with synt
                                               ax 'file:<path>'
    RPORT           80               yes       The target port (TCP)
    SSL             false            no        Negotiate SSL/TLS for outgoing connections
-   TARGETURI       /nagiosxi/       yes       The base path to the NagiosXi application
+   TARGETURI       /nagiosxi/       yes       The base path to the Nagios XI application
    THREADS         1                yes       The number of concurrent threads (max one per host)
    USERNAME        nagiosadmin      no        Username to authenticate with
    VERSION         5.7.9            no        Nagios XI version to check against existing exploit modules
@@ -148,7 +148,7 @@ Module options (auxiliary/scanner/http/nagios_xi_scanner):
                                               ax 'file:<path>'
    RPORT           80               yes       The target port (TCP)
    SSL             false            no        Negotiate SSL/TLS for outgoing connections
-   TARGETURI       /nagiosxi/       yes       The base path to the NagiosXi application
+   TARGETURI       /nagiosxi/       yes       The base path to the Nagios XI application
    THREADS         1                yes       The number of concurrent threads (max one per host)
    USERNAME        nagiosadmin      no        Username to authenticate with
    VERSION                          no        Nagios XI version to check against existing exploit modules

--- a/documentation/modules/auxiliary/scanner/http/nagios_xi_scanner.md
+++ b/documentation/modules/auxiliary/scanner/http/nagios_xi_scanner.md
@@ -1,0 +1,105 @@
+## Vulnerable Application
+
+The module detects the version of Nagios XI applications and suggests matching exploit modules based on the version number.
+
+The module takes advantage of the `Msf::Exploit::Remote::HTTP::NagiosXi` mixin in order to
+authenticate to the target and obtain the version number, which is only revealed to authenticated users.
+
+When used to target a specific host, the module requires valid credentials for a Nagios XI account.
+These can be provided via `USERNAME` and `PASSWORD` options.
+Alternatively, it is possible to provide a specific Nagios XI version number via the `VERSION` option.
+In that case, the module simply suggests matching exploit modules and does not probe the target(s).
+
+The module currently supports the following exploit modules:
+- exploit/linux/http/nagios_xi_plugins_check_ping_authenticated_rce (CVE-2019-15949)
+- exploit/linux/http/nagios_xi_plugins_filename_authenticated_rce (CVE-2020-35578)
+- exploit/linux/http/nagios_xi_mibs_authenticated_rce (CVE-2020-5791)
+- exploit/linux/http/nagios_xi_snmptrap_authenticated_rce (CVE-2020-5792)
+
+### Setting up Nagios XI for testing
+
+Vulnerable Nagios XI versions are available [here](https://assets.nagios.com/downloads/nagiosxi/versions.php).
+Detailed installation instructions are available
+[here](https://assets.nagios.com/downloads/nagiosxi/docs/Installing-Nagios-XI-Manually-on-Linux.pdf)
+and an official video tutorial is available [here](https://www.youtube.com/watch?v=fBWA6t6dJ4I).
+
+## Verification Steps
+1. Start msfconsole
+2. Do: `use auxiliary/scanner/http/nagios_xi_scanner`
+3. Do: `set RHOSTS [IP]`
+4. Do: `set USERNAME [username for a valid Nagios XI account]`
+5. Do: `set PASSWORD [password for a valid Nagios XI account]`
+6. Do: `run`
+
+## Options
+### PASSWORD
+The password for the Nagios XI account to authenticate with.
+### TARGETURI
+The base path to Nagios XI. The default value is `/nagiosxi/`.
+### USERNAME
+The username for the Nagios XI account to authenticate with. The default value is `nagiosadmin`.
+### VERSION
+The Nagios XI version to check against existing exploit modules. If this option is selected,
+the module will not probe the target, so it is not necessary to provide credentials.
+
+## Scenarios
+### Nagios XI 5.7.3 running on CentOS 7
+```
+msf6 auxiliary(scanner/http/nagios_xi_scanner) > show options 
+
+Module options (auxiliary/scanner/http/nagios_xi_scanner):
+
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   PASSWORD   nagiosadmin      no        Password to authenticate with
+   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS     192.168.1.14     yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
+   RPORT      80               yes       The target port (TCP)
+   SSL        false            no        Negotiate SSL/TLS for outgoing connections
+   TARGETURI  /nagiosxi/       yes       The base path to the NagiosXi application
+   THREADS    1                yes       The number of concurrent threads (max one per host)
+   USERNAME   nagiosadmin      no        Username to authenticate with
+   VERSION                     no        Nagios XI version to check against existing exploit modules
+   VHOST                       no        HTTP server virtual host
+
+msf6 auxiliary(scanner/http/nagios_xi_scanner) > run
+
+[+] Successfully authenticated to Nagios XI
+[*] Target is Nagios XI with version 5.7.3
+[+] The target appears to be vulnerable to the following 3 exploit(s):
+[*] 
+[*]     CVE-2020-35578  exploit/linux/http/nagios_xi_plugins_filename_authenticated_rce
+[*]     CVE-2020-5791   exploit/linux/http/nagios_xi_mibs_authenticated_rce
+[*]     CVE-2020-5792   exploit/linux/http/nagios_xi_snmptrap_authenticated_rce
+[*] 
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```
+### Nagios XI 5.7.9 version provided via VERSION
+```
+msf6 auxiliary(scanner/http/nagios_xi_scanner) > show options 
+
+Module options (auxiliary/scanner/http/nagios_xi_scanner):
+
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   PASSWORD                    no        Password to authenticate with
+   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS     192.168.91.140   yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
+   RPORT      80               yes       The target port (TCP)
+   SSL        false            no        Negotiate SSL/TLS for outgoing connections
+   TARGETURI  /nagiosxi/       yes       The base path to the NagiosXi application
+   THREADS    1                yes       The number of concurrent threads (max one per host)
+   USERNAME   nagiosadmin      no        Username to authenticate with
+   VERSION    5.7.9            no        Nagios XI version to check against existing exploit modules
+   VHOST                       no        HTTP server virtual host
+
+msf6 auxiliary(scanner/http/nagios_xi_scanner) > run
+
+[+] Version 5.7.9 matches the following 1 exploit(s):
+[*] 
+[*]     CVE-2020-35578  exploit/linux/http/nagios_xi_plugins_filename_authenticated_rce
+[*] 
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```

--- a/documentation/modules/auxiliary/scanner/http/nagios_xi_scanner.md
+++ b/documentation/modules/auxiliary/scanner/http/nagios_xi_scanner.md
@@ -11,7 +11,7 @@ Alternatively, it is possible to provide a specific Nagios XI version number via
 In that case, the module simply suggests matching exploit modules and does not probe the target(s).
 
 The module currently supports the following exploit modules:
-- exploit/linux/http/nagios_xi_plugins_check_ping_authenticated_rce (CVE-2019-15949)
+- exploit/linux/http/nagios_xi_plugins_check_plugin_authenticated_rce (CVE-2019-15949)
 - exploit/linux/http/nagios_xi_plugins_filename_authenticated_rce (CVE-2020-35578)
 - exploit/linux/http/nagios_xi_mibs_authenticated_rce (CVE-2020-5791)
 - exploit/linux/http/nagios_xi_snmptrap_authenticated_rce (CVE-2020-5792)
@@ -32,6 +32,9 @@ and an official video tutorial is available [here](https://www.youtube.com/watch
 6. Do: `run`
 
 ## Options
+### FINISH_INSTALL
+If this is set to `true`, the module will try to finish installing Nagios XI on targets where the installation has not been completed.
+This includes signing the license agreement. The default value is `false`.
 ### PASSWORD
 The password for the Nagios XI account to authenticate with.
 ### TARGETURI
@@ -43,37 +46,42 @@ The Nagios XI version to check against existing exploit modules. If this option 
 the module will not probe the target, so it is not necessary to provide credentials.
 
 ## Scenarios
-### Nagios XI 5.7.3 running on CentOS 7
+### Nagios XI 5.6.5 running on CentOS 7
 ```
 msf6 auxiliary(scanner/http/nagios_xi_scanner) > show options 
 
 Module options (auxiliary/scanner/http/nagios_xi_scanner):
 
-   Name       Current Setting  Required  Description
-   ----       ---------------  --------  -----------
-   PASSWORD   nagiosadmin      no        Password to authenticate with
-   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
-   RHOSTS     192.168.1.14     yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
-   RPORT      80               yes       The target port (TCP)
-   SSL        false            no        Negotiate SSL/TLS for outgoing connections
-   TARGETURI  /nagiosxi/       yes       The base path to the NagiosXi application
-   THREADS    1                yes       The number of concurrent threads (max one per host)
-   USERNAME   nagiosadmin      no        Username to authenticate with
-   VERSION                     no        Nagios XI version to check against existing exploit modules
-   VHOST                       no        HTTP server virtual host
+   Name            Current Setting  Required  Description
+   ----            ---------------  --------  -----------
+   FINISH_INSTALL  false            no        If the Nagios XI installation has not been completed, try to do so
+                                              . This includes signing the license agreement.
+   PASSWORD        nagiosadmin      no        Password to authenticate with
+   Proxies                          no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS          192.168.1.14     yes       The target host(s), range CIDR identifier, or hosts file with synt
+                                              ax 'file:<path>'
+   RPORT           80               yes       The target port (TCP)
+   SSL             false            no        Negotiate SSL/TLS for outgoing connections
+   TARGETURI       /nagiosxi/       yes       The base path to the NagiosXi application
+   THREADS         1                yes       The number of concurrent threads (max one per host)
+   USERNAME        nagiosadmin      no        Username to authenticate with
+   VERSION                          no        Nagios XI version to check against existing exploit modules
+   VHOST                            no        HTTP server virtual host
 
 msf6 auxiliary(scanner/http/nagios_xi_scanner) > run
 
 [+] Successfully authenticated to Nagios XI
-[*] Target is Nagios XI with version 5.7.3
-[+] The target appears to be vulnerable to the following 3 exploit(s):
+[*] Target is Nagios XI with version 5.6.5
+[+] The target appears to be vulnerable to the following 4 exploit(s):
 [*] 
+[*]     CVE-2019-15949  exploit/linux/http/nagios_xi_plugins_check_plugin_authenticated_rce.rb
 [*]     CVE-2020-35578  exploit/linux/http/nagios_xi_plugins_filename_authenticated_rce
-[*]     CVE-2020-5791   exploit/linux/http/nagios_xi_mibs_authenticated_rce
 [*]     CVE-2020-5792   exploit/linux/http/nagios_xi_snmptrap_authenticated_rce
+[*]     CVE-2020-5791   exploit/linux/http/nagios_xi_mibs_authenticated_rce
 [*] 
 [*] Scanned 1 of 1 hosts (100% complete)
 [*] Auxiliary module execution completed
+
 ```
 ### Nagios XI 5.7.9 version provided via VERSION
 ```
@@ -81,22 +89,64 @@ msf6 auxiliary(scanner/http/nagios_xi_scanner) > show options
 
 Module options (auxiliary/scanner/http/nagios_xi_scanner):
 
-   Name       Current Setting  Required  Description
-   ----       ---------------  --------  -----------
-   PASSWORD                    no        Password to authenticate with
-   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
-   RHOSTS     192.168.91.140   yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
-   RPORT      80               yes       The target port (TCP)
-   SSL        false            no        Negotiate SSL/TLS for outgoing connections
-   TARGETURI  /nagiosxi/       yes       The base path to the NagiosXi application
-   THREADS    1                yes       The number of concurrent threads (max one per host)
-   USERNAME   nagiosadmin      no        Username to authenticate with
-   VERSION    5.7.9            no        Nagios XI version to check against existing exploit modules
-   VHOST                       no        HTTP server virtual host
+   Name            Current Setting  Required  Description
+   ----            ---------------  --------  -----------
+   FINISH_INSTALL  false            no        If the Nagios XI installation has not been completed, try to do so
+                                              . This includes signing the license agreement.
+   PASSWORD        nagiosadmin      no        Password to authenticate with
+   Proxies                          no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS          192.168.1.140    yes       The target host(s), range CIDR identifier, or hosts file with synt
+                                              ax 'file:<path>'
+   RPORT           80               yes       The target port (TCP)
+   SSL             false            no        Negotiate SSL/TLS for outgoing connections
+   TARGETURI       /nagiosxi/       yes       The base path to the NagiosXi application
+   THREADS         1                yes       The number of concurrent threads (max one per host)
+   USERNAME        nagiosadmin      no        Username to authenticate with
+   VERSION         5.7.9            no        Nagios XI version to check against existing exploit modules
+   VHOST                            no        HTTP server virtual host
 
 msf6 auxiliary(scanner/http/nagios_xi_scanner) > run
 
 [+] Version 5.7.9 matches the following 1 exploit(s):
+[*] 
+[*]     CVE-2020-35578  exploit/linux/http/nagios_xi_plugins_filename_authenticated_rce
+[*] 
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```
+### Nagios XI 5.7.5 - incomplete installation, FINISH_INSTALL set to true
+```
+msf6 auxiliary(scanner/http/nagios_xi_scanner) > show options 
+
+Module options (auxiliary/scanner/http/nagios_xi_scanner):
+
+   Name            Current Setting  Required  Description
+   ----            ---------------  --------  -----------
+   FINISH_INSTALL  true             no        If the Nagios XI installation has not been completed, try to do so
+                                              . This includes signing the license agreement.
+   PASSWORD        nagiosadmin      no        Password to authenticate with
+   Proxies                          no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS          192.168.1.16     yes       The target host(s), range CIDR identifier, or hosts file with synt
+                                              ax 'file:<path>'
+   RPORT           80               yes       The target port (TCP)
+   SSL             false            no        Negotiate SSL/TLS for outgoing connections
+   TARGETURI       /nagiosxi/       yes       The base path to the NagiosXi application
+   THREADS         1                yes       The number of concurrent threads (max one per host)
+   USERNAME        nagiosadmin      no        Username to authenticate with
+   VERSION                          no        Nagios XI version to check against existing exploit modules
+   VHOST                            no        HTTP server virtual host
+
+msf6 auxiliary(scanner/http/nagios_xi_scanner) > run 
+[*] Attempting to authenticate to Nagios XI...   
+[!] The target seems to be a Nagios XI application that has not been fully installed yet.
+[*] Attempting to finish the Nagios XI installation on the target using the provided password. The username will be `nagiosadmin`.
+[*] Attempting to authenticate to Nagios XI...
+[!] The Nagios XI license agreement has not yet been signed on the target.
+[*] Attempting to sign the Nagios XI license agreement... 
+[*] Attempting to authenticate to Nagios XI...
+[+] Successfully authenticated to Nagios XI
+[*] Target is Nagios XI with version 5.7.5
+[+] The target appears to be vulnerable to the following 1 exploit(s):
 [*] 
 [*]     CVE-2020-35578  exploit/linux/http/nagios_xi_plugins_filename_authenticated_rce
 [*] 

--- a/lib/msf/core/exploit/remote/http/nagios_xi.rb
+++ b/lib/msf/core/exploit/remote/http/nagios_xi.rb
@@ -1,0 +1,30 @@
+# -*- coding: binary -*-
+
+module Msf
+  class Exploit
+    class Remote
+      module HTTP
+        # This module provides a way of interacting with NagiosXI installations
+        module NagiosXi
+          include Msf::Exploit::Remote::HttpClient
+          include Msf::Exploit::Remote::HTTP::NagiosXi::Login
+          include Msf::Exploit::Remote::HTTP::NagiosXi::RceCheck
+          include Msf::Exploit::Remote::HTTP::NagiosXi::URIs
+          include Msf::Exploit::Remote::HTTP::NagiosXi::Version
+          
+          def initialize(info = {})
+            super
+
+            register_options(
+              [
+                Msf::OptString.new('TARGETURI', [true, 'The base path to the NagiosXi application', '/nagiosxi/']),
+                Msf::OptString.new('USERNAME', [false, 'Username to authenticate with', 'nagiosadmin']),
+                Msf::OptString.new('PASSWORD', [false, 'Password to authenticate with', nil])
+              ], Msf::Exploit::Remote::HTTP::NagiosXi
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/msf/core/exploit/remote/http/nagios_xi.rb
+++ b/lib/msf/core/exploit/remote/http/nagios_xi.rb
@@ -4,7 +4,7 @@ module Msf
   class Exploit
     class Remote
       module HTTP
-        # This module provides a way of interacting with NagiosXI installations
+        # This module provides a way of interacting with Nagios XI installations
         module NagiosXi
           include Msf::Exploit::Remote::HttpClient
           include Msf::Exploit::Remote::HTTP::NagiosXi::Install
@@ -12,7 +12,7 @@ module Msf
           include Msf::Exploit::Remote::HTTP::NagiosXi::RceCheck
           include Msf::Exploit::Remote::HTTP::NagiosXi::URIs
           include Msf::Exploit::Remote::HTTP::NagiosXi::Version
-          
+
           def initialize(info = {})
             super
 

--- a/lib/msf/core/exploit/remote/http/nagios_xi.rb
+++ b/lib/msf/core/exploit/remote/http/nagios_xi.rb
@@ -7,6 +7,7 @@ module Msf
         # This module provides a way of interacting with NagiosXI installations
         module NagiosXi
           include Msf::Exploit::Remote::HttpClient
+          include Msf::Exploit::Remote::HTTP::NagiosXi::Install
           include Msf::Exploit::Remote::HTTP::NagiosXi::Login
           include Msf::Exploit::Remote::HTTP::NagiosXi::RceCheck
           include Msf::Exploit::Remote::HTTP::NagiosXi::URIs
@@ -19,7 +20,9 @@ module Msf
               [
                 Msf::OptString.new('TARGETURI', [true, 'The base path to the NagiosXi application', '/nagiosxi/']),
                 Msf::OptString.new('USERNAME', [false, 'Username to authenticate with', 'nagiosadmin']),
-                Msf::OptString.new('PASSWORD', [false, 'Password to authenticate with', nil])
+                Msf::OptString.new('PASSWORD', [false, 'Password to authenticate with', nil]),
+                Msf::OptBool.new('FINISH_INSTALL', [false, 'If the Nagios XI installation has not been completed, try to do so. This includes signing the license agreement.', false])
+
               ], Msf::Exploit::Remote::HTTP::NagiosXi
             )
           end

--- a/lib/msf/core/exploit/remote/http/nagios_xi.rb
+++ b/lib/msf/core/exploit/remote/http/nagios_xi.rb
@@ -18,7 +18,7 @@ module Msf
 
             register_options(
               [
-                Msf::OptString.new('TARGETURI', [true, 'The base path to the NagiosXi application', '/nagiosxi/']),
+                Msf::OptString.new('TARGETURI', [true, 'The base path to the Nagios XI application', '/nagiosxi/']),
                 Msf::OptString.new('USERNAME', [false, 'Username to authenticate with', 'nagiosadmin']),
                 Msf::OptString.new('PASSWORD', [false, 'Password to authenticate with', nil]),
                 Msf::OptBool.new('FINISH_INSTALL', [false, 'If the Nagios XI installation has not been completed, try to do so. This includes signing the license agreement.', false])

--- a/lib/msf/core/exploit/remote/http/nagios_xi/install.rb
+++ b/lib/msf/core/exploit/remote/http/nagios_xi/install.rb
@@ -3,14 +3,14 @@
 module Msf::Exploit::Remote::HTTP::NagiosXi::Install
   include Msf::Exploit::Remote::HTTP::NagiosXi::URIs
   include Msf::Exploit::Remote::HTTP::NagiosXi::Login
-  # attempts to complete the Nagios XI web installation
+  # Attempts to complete the Nagios XI web installation
   #
   # @param pass [String] Password
   # @return [nil, Array] nil if the installation seems successful, otherwise Array containing an error code and an error message
   def install_nagios_xi(pass)
     print_status('Attempting to finish the Nagios XI installation on the target using the provided password. The username will be `nagiosadmin`.')
 
-    # visit the install page to obtain the cookies and nsp token required for installing the app
+    # Visit the install page to obtain the cookies and nsp token required for installing the app
      res_install_page = send_request_cgi({
       'method' => 'GET',
       'uri' => nagios_xi_install_url
@@ -36,7 +36,7 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::Install
       return [2, 'Unable to obtain the nsp token required to install Nagios XI']
     end
 
-    # install the app, using the provided password (the username cannot be set here, it is `nagiosadmin` by default)
+    # Install the app, using the provided password (the username cannot be set here, it is `nagiosadmin` by default)
     res_start_install = send_request_cgi({
       'method' => 'POST',
       'uri' => nagios_xi_install_url,
@@ -60,8 +60,8 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::Install
       return [2, 'Received unexpected reply while trying to install Nagios XI on the target.']
     end
 
-    # if installation succeeded, we don't need to return anything here
-    # it is better to start a new session to authenticate now, otherwise the session may timeout
+    # If installation succeeded, we don't need to return anything here.
+    # It is better to start a new session to authenticate now, otherwise the session may timeout
     return
   end
 
@@ -102,8 +102,8 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::Install
       return [2, 'Received unexpected reply while trying to accept the Nagios XI license agreement.']
     end
 
-    # if signing the license agreement succeeded, we don't need to return anything here
-    # it is better to start a new session to authenticate now, otherwise the session may timeout
+    # If signing the license agreement succeeded, we don't need to return anything here
+    # It is better to start a new session to authenticate now, otherwise the session may timeout
     return
   end
 

--- a/lib/msf/core/exploit/remote/http/nagios_xi/install.rb
+++ b/lib/msf/core/exploit/remote/http/nagios_xi/install.rb
@@ -1,6 +1,8 @@
 # -*- coding: binary -*-
 
 module Msf::Exploit::Remote::HTTP::NagiosXi::Install
+  include Msf::Exploit::Remote::HTTP::NagiosXi::URIs
+  include Msf::Exploit::Remote::HTTP::NagiosXi::Login
   # attempts to complete the Nagios XI web installation
   #
   # @param pass [String] Password
@@ -69,6 +71,14 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::Install
   # @param nsp [String] nsp token required to visit the license agreement page
   # @return [nil, Array] nil if signing the the license agreement succeeds, otherwise Array containing an error code and an error message
   def sign_license_agreement(cookies, nsp)
+    if cookies.blank?
+      return [2, 'Cannot sign the license agreement. The provided cookies are empty or nil.']
+    end
+
+    if nsp.blank?
+      return [2, 'Cannot sign the license agreement. The provided `nsp_str` value is empty or nil.']
+    end
+
     print_status('Attempting to sign the Nagios XI license agreement...')
 
     res_sign_license = send_request_cgi({

--- a/lib/msf/core/exploit/remote/http/nagios_xi/install.rb
+++ b/lib/msf/core/exploit/remote/http/nagios_xi/install.rb
@@ -1,0 +1,100 @@
+# -*- coding: binary -*-
+
+module Msf::Exploit::Remote::HTTP::NagiosXi::Install
+  # attempts to complete the Nagios XI web installation
+  #
+  # @param pass [String] Password
+  # @return [nil, Msf::Exploit::CheckCode] nil if the installation seems successful, Msf::Exploit::CheckCode otherwise
+  def install_nagios_xi(pass)
+    print_status('Attempting to finish the Nagios XI installation on the target using the provided password. The username will be `nagiosadmin`.')
+
+    # visit the install page to obtain the cookies and nsp token required for installing the app
+     res_install_page = send_request_cgi({
+      'method' => 'GET',
+      'uri' => nagios_xi_install_url
+    })
+
+    unless res_install_page
+      return Msf::Exploit::CheckCode::Unknown('Connection failed')
+    end
+
+    unless res_install_page.code == 200 && res_install_page.body.include?('Nagios XI') && res_install_page.body.include?('install')
+      return Msf::Exploit::CheckCode::Detected('Received unexpected reply while trying to access the Nagios XI Installer.')
+    end
+
+    install_cookies = res_install_page.get_cookies
+
+    if install_cookies.blank?
+      return Msf::Exploit::CheckCode::Detected('Unable to obtain the cookies required to install Nagios XI')
+    end
+
+    install_nsp = get_nsp(res_install_page)
+
+    if install_nsp.blank?
+      return Msf::Exploit::CheckCode::Detected('Unable to obtain the nsp token required to install Nagios XI')
+    end
+
+    # install the app, using the provided password (the username cannot be set here, it is `nagiosadmin` by default)
+    res_start_install = send_request_cgi({
+      'method' => 'POST',
+      'uri' => nagios_xi_install_url,
+      'cookie' => install_cookies,
+      'vars_post' => {
+        'install' => 1,
+        'nsp' => install_nsp,
+        'url' => "#{full_uri(target_uri.path)}",
+        'admin_name' => 'Nagios Administrator',
+        'admin_email' => 'root@localhost',
+        'admin_password' => password,
+        'timezone' => 'UTC'
+      }
+    })
+
+    unless res_start_install
+      return Msf::Exploit::CheckCode::Unknown('Connection failed')
+    end
+
+    unless res_start_install.code == 200 && res_start_install.body.include?('>Nagios XI<') && res_start_install.body.include?('login') # you may now login
+      return Msf::Exploit::CheckCode::Detected('Received unexpected reply while trying to install Nagios XI on the target.')
+    end
+
+    # if installation succeeded, we don't need to return anything here
+    # it is better to start a new session to authenticate now, otherwise the session may timeout
+    return
+  end
+
+  # Signs the Nagios XI license agreement
+  #
+  # @param cookies [String] cookies required to visit the license agreement page
+  # @param nsp [String] nsp token required to visit the license agreement page
+  # @return [nil, Msf::Exploit::CheckCode] nil if signing the the license agreement succeeds, Msf::Exploit::CheckCode otherwise
+  def sign_license_agreement(cookies, nsp)
+    print_status('Attempting to sign the Nagios XI license agreement...')
+
+    res_sign_license = send_request_cgi({
+      'method' => 'POST',
+      'uri' => nagios_xi_login_url,
+      'cookie' => cookies,
+      'vars_get' => { 'showlicense' => ''},
+      'vars_post' => {
+        'page' => nagios_xi_login_url,
+        'pageopt' => 'agreelicense',
+        'nsp' => nsp,
+        'agree_license' => 'on'
+      }
+    })
+
+    unless res_sign_license
+      return Msf::Exploit::CheckCode::Unknown('Connection failed')
+    end
+
+    unless res_sign_license.code == 302 && res_sign_license.headers['Location'].end_with?('index.php')
+      return Msf::Exploit::CheckCode::Detected('Received unexpected reply while trying to accept the Nagios XI license agreement.')
+    end
+
+    # if signing the license agreement succeeded, we don't need to return anything here
+    # it is better to start a new session to authenticate now, otherwise the session may timeout
+    return
+  end
+
+end

--- a/lib/msf/core/exploit/remote/http/nagios_xi/install.rb
+++ b/lib/msf/core/exploit/remote/http/nagios_xi/install.rb
@@ -4,7 +4,7 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::Install
   # attempts to complete the Nagios XI web installation
   #
   # @param pass [String] Password
-  # @return [nil, Msf::Exploit::CheckCode] nil if the installation seems successful, Msf::Exploit::CheckCode otherwise
+  # @return [nil, Array] nil if the installation seems successful, otherwise Array containing an error code and an error message
   def install_nagios_xi(pass)
     print_status('Attempting to finish the Nagios XI installation on the target using the provided password. The username will be `nagiosadmin`.')
 
@@ -15,23 +15,23 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::Install
     })
 
     unless res_install_page
-      return Msf::Exploit::CheckCode::Unknown('Connection failed')
+      return [1, 'Connection failed']
     end
 
     unless res_install_page.code == 200 && res_install_page.body.include?('Nagios XI') && res_install_page.body.include?('install')
-      return Msf::Exploit::CheckCode::Detected('Received unexpected reply while trying to access the Nagios XI Installer.')
+      return [2, 'Received unexpected reply while trying to access the Nagios XI Installer.']
     end
 
     install_cookies = res_install_page.get_cookies
 
     if install_cookies.blank?
-      return Msf::Exploit::CheckCode::Detected('Unable to obtain the cookies required to install Nagios XI')
+      return [2, 'Unable to obtain the cookies required to install Nagios XI']
     end
 
     install_nsp = get_nsp(res_install_page)
 
     if install_nsp.blank?
-      return Msf::Exploit::CheckCode::Detected('Unable to obtain the nsp token required to install Nagios XI')
+      return [2, 'Unable to obtain the nsp token required to install Nagios XI']
     end
 
     # install the app, using the provided password (the username cannot be set here, it is `nagiosadmin` by default)
@@ -51,11 +51,11 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::Install
     })
 
     unless res_start_install
-      return Msf::Exploit::CheckCode::Unknown('Connection failed')
+      return [1, 'Connection failed']
     end
 
     unless res_start_install.code == 200 && res_start_install.body.include?('>Nagios XI<') && res_start_install.body.include?('login') # you may now login
-      return Msf::Exploit::CheckCode::Detected('Received unexpected reply while trying to install Nagios XI on the target.')
+      return [2, 'Received unexpected reply while trying to install Nagios XI on the target.']
     end
 
     # if installation succeeded, we don't need to return anything here
@@ -67,7 +67,7 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::Install
   #
   # @param cookies [String] cookies required to visit the license agreement page
   # @param nsp [String] nsp token required to visit the license agreement page
-  # @return [nil, Msf::Exploit::CheckCode] nil if signing the the license agreement succeeds, Msf::Exploit::CheckCode otherwise
+  # @return [nil, Array] nil if signing the the license agreement succeeds, otherwise Array containing an error code and an error message
   def sign_license_agreement(cookies, nsp)
     print_status('Attempting to sign the Nagios XI license agreement...')
 
@@ -85,11 +85,11 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::Install
     })
 
     unless res_sign_license
-      return Msf::Exploit::CheckCode::Unknown('Connection failed')
+      return [1, 'Connection failed']
     end
 
     unless res_sign_license.code == 302 && res_sign_license.headers['Location'].end_with?('index.php')
-      return Msf::Exploit::CheckCode::Detected('Received unexpected reply while trying to accept the Nagios XI license agreement.')
+      return [2, 'Received unexpected reply while trying to accept the Nagios XI license agreement.']
     end
 
     # if signing the license agreement succeeded, we don't need to return anything here

--- a/lib/msf/core/exploit/remote/http/nagios_xi/login.rb
+++ b/lib/msf/core/exploit/remote/http/nagios_xi/login.rb
@@ -1,0 +1,89 @@
+# -*- coding: binary -*-
+
+module Msf::Exploit::Remote::HTTP::NagiosXi::Login
+  # performs a Naxios XI login
+  #
+  # @param user [String] Username
+  # @param pass [String] Password
+  # @return [String, Msf::Exploit::CheckCode] String containing the session cookies on successful login, Msf::Exploit::CheckCode otherwise
+  def nagios_xi_login(user, pass)
+    # empty the cookie jar, otherwise the module will start failing if it is run multiple times in a short timespan
+    self.cookie_jar = [].to_set
+
+    # visit the login page in order to obtain the cookies and the `nsp_str` token required for authentication
+    res_pre_login = send_request_cgi({
+      'method' => 'GET',
+      'uri' => nagios_xi_login_url,
+      'keep_cookies' => true,
+    })
+
+    unless res_pre_login
+      return Msf::Exploit::CheckCode::Unknown('Connection failed')
+    end
+
+    unless res_pre_login.code == 200 && res_pre_login.body.include?('<b>Nagios XI</b>')
+      return Msf::Exploit::CheckCode::Safe('Target is not a Nagios XI application')
+    end
+
+    nsp = get_nsp(res_pre_login)
+
+    if nsp.blank?
+      return Msf::Exploit::CheckCode::Unknown('Unable to obtain the value of the `nsp_str` token required for authentication')
+    end
+
+    # authenticate
+    res_login = send_request_cgi({
+      'method' => 'POST',
+      'uri' => nagios_xi_login_url,
+      'keep_cookies' => true,
+      'vars_post' => {
+        'nsp' => nsp,
+        'pageopt' => 'login',
+        'username' => user,
+        'password' => pass
+      }
+    })
+
+    unless res_login
+      return Msf::Exploit::CheckCode::Unknown('Connection failed')
+    end
+
+    unless res_login.code == 302 && res_login.headers['Location'] == 'index.php'
+      return Msf::Exploit::CheckCode::Detected('Received unexpected reply while trying to authenticate')
+    end
+
+    # keep only the most recent cookie, otherwise the session will time out
+    auth_cookies = cookie_jar.to_a[1]
+    self.cookie_jar = auth_cookies.split.to_set
+
+    # visit the index page to verify we successfully authenticated
+    res_index = send_request_cgi({
+      'method' => 'GET',
+      'uri' => nagios_xi_backend_url,
+    })
+
+    unless res_index
+      return Msf::Exploit::CheckCode::Unknown('Connection failed')
+    end
+
+    unless res_index.code == 200 && res_index.body.include?("id='lid-menu-home-homedashboard'>Home Dashboard</a>")
+      return Msf::Exploit::CheckCode::Detected('Received unexpected reply while trying to acess the NagiosXI home dashboard after authenticating.')
+    end
+
+    nsp = get_nsp(res_index)
+
+    if nsp.blank?
+      return Msf::Exploit::CheckCode::Unknown('Unable to obtain the value of the `nsp_str` token required for authentication')
+    end
+    
+    auth_cookies
+  end
+
+  # Grabs the nsp_str value from an HTTP response using regex
+  #
+  # @param res [Rex::Proto::Http::Response] HTTP response
+  # @return [String] nsp_str value
+  def get_nsp(res)
+    nsp = res.body.scan(/nsp_str = "([a-z0-9]+)/).flatten.first rescue ''
+  end
+end

--- a/lib/msf/core/exploit/remote/http/nagios_xi/login.rb
+++ b/lib/msf/core/exploit/remote/http/nagios_xi/login.rb
@@ -37,7 +37,7 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::Login
 
     # Grab the necessary tokens required for authentication
     nsp = get_nsp(res_pre_login)
-    if nsp.blank?
+    if nsp.nil?
       return [2, ['Unable to obtain the value of the `nsp_str` token required for authentication']]
     end
 
@@ -145,8 +145,7 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::Login
       end
 
       nsp = get_nsp(res_index)
-
-      if nsp.blank?
+      if nsp.nil?
         return [2, ['Failed to obtain the nsp token required for signing the license agreement.']]
       end
 
@@ -163,9 +162,9 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::Login
   # Grabs the nsp_str value from an HTTP response using regex
   #
   # @param res [Rex::Proto::Http::Response] HTTP response
-  # @return [String] nsp_str value
+  # @return [String, nil] nsp_str value, nil if not found
   def get_nsp(res)
-    nsp = res.body.scan(/nsp_str = "([a-z0-9]+)/).flatten.first rescue ''
+    nsp = res.body.scan(/nsp_str = "([a-z0-9]+)/)&.flatten&.first
   end
 
   # Performs an authentication attempt. If the server does not return a response,

--- a/lib/msf/core/exploit/remote/http/nagios_xi/login.rb
+++ b/lib/msf/core/exploit/remote/http/nagios_xi/login.rb
@@ -6,7 +6,7 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::Login
   # @param user [String] Username
   # @param pass [String] Password
   # @param finish_install [Boolean] Boolean indicating if the module should finish installing Nagios XI on target hosts if the isntallation hasn't been completed or the license agreement is not signed
-  # @return [Array, String, Array, Msf::Exploit::CheckCode] Array containing the HTTP response body and session cookies if the Nagios XI backend was accessed successfully, String 'install_required' if Nagios Xi is not fully installed, Array containing 'sign_license' and the cookies and nsp token if the license agreement is not signed, Msf::Exploit::CheckCode otherwise
+  # @return [Array,Integer] Array containing the HTTP response body and session cookies if the Nagios XI backend was accessed successfully, Integer if Nagios XI hasn't been fully installed, otherwise Array containing an error code and an error message
   def nagios_xi_login(user, pass, finish_intall)
     print_status('Attempting to authenticate to Nagios XI...')
 
@@ -17,32 +17,32 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::Login
     })
 
     unless res_pre_login
-      return Msf::Exploit::CheckCode::Unknown('Connection failed')
+      return [1, 'Connection failed']
     end
 
     unless res_pre_login.code == 200 && res_pre_login.body.include?('>Nagios XI<')
       # check if we are perhaps dealing with a Nagios XI app that hasn't been fully installed yet 
       unless res_pre_login.code == 302 && res_pre_login.body.include?('>Nagios XI<') && res_pre_login.headers['Location'].end_with?('/install.php')
-        return Msf::Exploit::CheckCode::Safe('Target is not a Nagios XI application')
+        return [3, 'Target is not a Nagios XI application']
       end
 
       print_warning('The target seems to be a Nagios XI application that has not been fully installed yet.')
       unless finish_intall
-        return Msf::Exploit::CheckCode::Detected('You can let the module complete the installation by setting `FINISH_INSTALL` to true.')
+        return [2, 'You can let the module complete the installation by setting `FINISH_INSTALL` to true.']          
       end
 
-      return 'install_required'
+      return 4
     end
     
     # grab the necessary tokens required for authentication
     nsp = get_nsp(res_pre_login)
     if nsp.blank?
-      return Msf::Exploit::CheckCode::Unknown('Unable to obtain the value of the `nsp_str` token required for authentication')
+      return [2, 'Unable to obtain the value of the `nsp_str` token required for authentication']
     end
 
     pre_auth_cookies = res_pre_login.get_cookies
     if pre_auth_cookies.blank?
-      return Msf::Exploit::CheckCode::Unknown('Unable to obtain the cookies required for authentication')
+      return [2, 'Unable to obtain the cookies required for authentication']
     end
 
     # authenticate
@@ -59,18 +59,18 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::Login
     })
 
     unless res_login
-      return Msf::Exploit::CheckCode::Unknown('Connection failed')
+      return [1, 'Connection failed']
     end
 
     unless res_login.code == 302 && res_login.headers['Location'] == 'index.php'
-      return Msf::Exploit::CheckCode::Detected('Received unexpected reply while trying to authenticate')
+      return [2, 'Received unexpected reply while trying to authenticate']
     end
 
     # grab the cookies
     auth_cookies = res_login.get_cookies
 
     if auth_cookies.blank?
-      return Msf::Exploit::CheckCode::Unknown('Unable to obtain the cookies required for authentication')
+      return [2, 'Unable to obtain the cookies required for authentication']
     end
 
     # make sure we only use the cookies we need, otherwise we may encounter a session timeout
@@ -123,7 +123,7 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::Login
   #
   # @param auth_cookies [String] Cookies required for authentication
   # @param finish_install [Boolean] Boolean indicating if the module should finish installing Nagios XI on target hosts if the isntallation hasn't been completed or the license agreement is not signed
-  # @return [String, Array, Msf::Exploit::CheckCode] HTTP response body if the Nagios XI backend was accessed successfully, Array containing 'sign_license' and the cookies and nsp token if the license agreement is not signed yet, Msf::Exploit::CheckCode otherwise
+  # @return [String, Array] HTTP response body if the Nagios XI backend was accessed successfully, otherwise Array containing an error code and either an error message or (if the license agreement is not signed) an Array with authentication tokens
   def visit_nagios_dashboard(auth_cookies, finish_intall)
     # visit the index page to verify we successfully authenticated
     res_index = send_request_cgi({
@@ -133,27 +133,27 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::Login
     })
 
     unless res_index
-      return Msf::Exploit::CheckCode::Unknown('Connection failed')
+      return [1, 'Connection failed']
     end
 
     unless res_index.code == 200 && res_index.body.include?('>Home Dashboard<')
       # check if we need to sign the license agreement
       unless res_index.code == 302 && res_index.headers['Location'].end_with?('login.php?showlicense')
-        return Msf::Exploit::CheckCode::Detected('Received unexpected reply while trying to acess the NagiosXI home dashboard after authenticating.')
+        return [2, 'Received unexpected reply while trying to acess the NagiosXI home dashboard after authenticating.']
       end
 
       print_warning('The Nagios XI license agreement has not yet been signed on the target.')
       unless finish_intall
-        return Msf::Exploit::CheckCode::Detected('You can let the module sign the Nagios XI license agreement by setting `FINISH_INSTALL` to true.')
+        return [2, 'You can let the module sign the Nagios XI license agreement by setting `FINISH_INSTALL` to true.']
       end
 
       nsp = get_nsp(res_index)
 
       if nsp.blank?
-        return Msf::Exploit::CheckCode::Detected('Failed to obtain the nsp token required for signing the license agreement.')
+        return [2, 'Failed to obtain the nsp token required for signing the license agreement.']
       end
 
-      return ['sign_license', auth_cookies, nsp]
+      return [5, [auth_cookies, nsp]]
     end
 
     res_index
@@ -173,16 +173,16 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::Login
   # @param username [String] Username required for authentication
   # @param password [String] Password required for authentication
   # @param finish_install [Boolean] Boolean indicating if the module should finish installing Nagios XI on target hosts if the isntallation hasn't been completed or the license agreement is not signed
-  # @return [Array, String, Array, Msf::Exploit::CheckCode] Array containing the HTTP response body and session cookies if the Nagios XI backend was accessed successfully, String 'install_required' if Nagios Xi is not fully installed, Array containing 'sign_license' and the cookies and nsp token if the license agreement is not signed, Msf::Exploit::CheckCode otherwise
+  # @return [Array] Array containing the HTTP response body and session cookies if the Nagios XI backend was accessed successfully, otherwise Array containing an error code and an error message
   def login_after_install_or_license(username, password, finish_install)
     # after installing Nagios XI or signing the license agreement, we sometimes don't receive a server response
     # this loop ensures that at least 2 login attempts are performed if this happens, as the second one usually works
     second_attempt = false
     while true
-      login_result = nagios_xi_login(username, password, finish_install)
+      login_result,error_message = nagios_xi_login(username, password, finish_install)
 
-      break unless login_result.instance_of? Msf::Exploit::CheckCode
-      break unless login_result.message.include?('Connection failed')
+      break unless error_message
+      break unless error_message == 'Connection failed'
 
       if second_attempt
         print_warning('The server is still not responding. If you wait a few seconds and rerun the module, it might still work.')
@@ -195,7 +195,7 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::Login
       end
     end
 
-    return login_result
+    return [login_result, error_message]
 
   end
 end

--- a/lib/msf/core/exploit/remote/http/nagios_xi/login.rb
+++ b/lib/msf/core/exploit/remote/http/nagios_xi/login.rb
@@ -7,7 +7,7 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::Login
   # @param user [String] Username
   # @param pass [String] Password
   # @param finish_install [Boolean] Boolean indicating if the module should finish installing Nagios XI on target hosts if the installation hasn't been completed or the license agreement is not signed
-  # @return [Array] Array containing the HTTP response body and session cookies if the Nagios XI backend was accessed successfully, Array containing an error code and nil if Nagios XI hasn't been fully installed, otherwise Array containing an error code and an error message
+  # @return [Array] Array containing a response code and an Array containing one of four possibilities: the HTTP response body and session cookies if the Nagios XI backend was accessed successfully; nil if Nagios XI hasn't been fully installed; cookies and the nsp token if the license agreement is not signed; otherwise an error message
   def nagios_xi_login(user, pass, finish_install)
     print_status('Attempting to authenticate to Nagios XI...')
 
@@ -18,32 +18,32 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::Login
     })
 
     unless res_pre_login
-      return [1, 'Connection failed']
+      return [1, ['Connection failed']]
     end
 
     unless res_pre_login.code == 200 && res_pre_login.body.include?('>Nagios XI<')
       # check if we are perhaps dealing with a Nagios XI app that hasn't been fully installed yet 
       unless res_pre_login.code == 302 && res_pre_login.body.include?('>Nagios XI<') && res_pre_login.headers['Location'].end_with?('/install.php')
-        return [3, 'Target is not a Nagios XI application']
+        return [3, ['Target is not a Nagios XI application']]
       end
 
       print_warning('The target seems to be a Nagios XI application that has not been fully installed yet.')
       unless finish_install
-        return [2, 'You can let the module complete the installation by setting `FINISH_INSTALL` to true.']          
+        return [2, ['You can let the module complete the installation by setting `FINISH_INSTALL` to true.']]
       end
 
-      return [4, nil]
+      return [4, [nil]]
     end
     
     # grab the necessary tokens required for authentication
     nsp = get_nsp(res_pre_login)
     if nsp.blank?
-      return [2, 'Unable to obtain the value of the `nsp_str` token required for authentication']
+      return [2, ['Unable to obtain the value of the `nsp_str` token required for authentication']]
     end
 
     pre_auth_cookies = res_pre_login.get_cookies
     if pre_auth_cookies.blank?
-      return [2, 'Unable to obtain the cookies required for authentication']
+      return [2, ['Unable to obtain the cookies required for authentication']]
     end
 
     # authenticate
@@ -60,18 +60,18 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::Login
     })
 
     unless res_login
-      return [1, 'Connection failed']
+      return [1, ['Connection failed']]
     end
 
     unless res_login.code == 302 && res_login.headers['Location'] == 'index.php'
-      return [2, 'Received unexpected reply while trying to authenticate']
+      return [2, ['Received unexpected reply while trying to authenticate. Please check your credentials.']]
     end
 
     # grab the cookies
     auth_cookies = res_login.get_cookies
 
     if auth_cookies.blank?
-      return [2, 'Unable to obtain the cookies required for authentication']
+      return [2, ['Unable to obtain the cookies required for authentication']]
     end
 
     # make sure we only use the cookies we need, otherwise we may encounter a session timeout
@@ -117,7 +117,7 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::Login
   #
   # @param auth_cookies [String] Cookies required for authentication
   # @param finish_install [Boolean] Boolean indicating if the module should finish installing Nagios XI on target hosts if the installation hasn't been completed or the license agreement is not signed
-  # @return [Array] Array containing an HTTP response body and the authentication cookies if the Nagios XI backend was accessed successfully, otherwise Array containing an error code and either an error message or (if the license agreement is not signed) an Array with authentication tokens
+  # @return [Array] Array containing a result code and an Array containing one of three possibilities: an HTTP response body and cookies if the Nagios XI backend was accessed successfully; cookies and the nsp token if the license agreement is not signed; otherwise an error message
   def visit_nagios_dashboard(auth_cookies, finish_install)
     # visit the index page to verify we successfully authenticated
     res_index = send_request_cgi({
@@ -127,24 +127,24 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::Login
     })
 
     unless res_index
-      return [1, 'Connection failed']
+      return [1, ['Connection failed']]
     end
 
     unless res_index.code == 200 && res_index.body.include?('>Home Dashboard<')
       # check if we need to sign the license agreement
       unless res_index.code == 302 && res_index.headers['Location'].end_with?('login.php?showlicense')
-        return [2, 'Received unexpected reply while trying to acess the NagiosXI home dashboard after authenticating.']
+        return [2, ['Received unexpected reply while trying to acess the NagiosXI home dashboard after authenticating.']]
       end
 
       print_warning('The Nagios XI license agreement has not yet been signed on the target.')
       unless finish_install
-        return [2, 'You can let the module sign the Nagios XI license agreement by setting `FINISH_INSTALL` to true.']
+        return [2, ['You can let the module sign the Nagios XI license agreement by setting `FINISH_INSTALL` to true.']]
       end
 
       nsp = get_nsp(res_index)
 
       if nsp.blank?
-        return [2, 'Failed to obtain the nsp token required for signing the license agreement.']
+        return [2, ['Failed to obtain the nsp token required for signing the license agreement.']]
       end
 
       return [5, [auth_cookies, nsp]]
@@ -153,7 +153,7 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::Login
     # return the HTTP resonse body and the authentication cookies
     ## the response body can be used to obtain the version number
     ## the cookies can be used by exploit modules to send authenticated requests
-    [res_index.body, auth_cookies]
+    [0, [res_index.body, auth_cookies]]
 
   end
 
@@ -178,8 +178,7 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::Login
     while true
       login_result, error_message = nagios_xi_login(username, password, finish_install)
 
-      break unless error_message
-      break unless error_message == 'Connection failed'
+      break unless error_message == ['Connection failed']
 
       if second_attempt
         print_warning('The server is still not responding. If you wait a few seconds and rerun the module, it might still work.')

--- a/lib/msf/core/exploit/remote/http/nagios_xi/login.rb
+++ b/lib/msf/core/exploit/remote/http/nagios_xi/login.rb
@@ -1,13 +1,14 @@
 # -*- coding: binary -*-
 
 module Msf::Exploit::Remote::HTTP::NagiosXi::Login
+  include Msf::Exploit::Remote::HTTP::NagiosXi::URIs
   # performs a Naxios XI login
   #
   # @param user [String] Username
   # @param pass [String] Password
-  # @param finish_install [Boolean] Boolean indicating if the module should finish installing Nagios XI on target hosts if the isntallation hasn't been completed or the license agreement is not signed
-  # @return [Array,Integer] Array containing the HTTP response body and session cookies if the Nagios XI backend was accessed successfully, Integer if Nagios XI hasn't been fully installed, otherwise Array containing an error code and an error message
-  def nagios_xi_login(user, pass, finish_intall)
+  # @param finish_install [Boolean] Boolean indicating if the module should finish installing Nagios XI on target hosts if the installation hasn't been completed or the license agreement is not signed
+  # @return [Array] Array containing the HTTP response body and session cookies if the Nagios XI backend was accessed successfully, Array containing an error code and nil if Nagios XI hasn't been fully installed, otherwise Array containing an error code and an error message
+  def nagios_xi_login(user, pass, finish_install)
     print_status('Attempting to authenticate to Nagios XI...')
 
     # visit the login page in order to obtain the cookies and the `nsp_str` token required for authentication
@@ -27,11 +28,11 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::Login
       end
 
       print_warning('The target seems to be a Nagios XI application that has not been fully installed yet.')
-      unless finish_intall
+      unless finish_install
         return [2, 'You can let the module complete the installation by setting `FINISH_INSTALL` to true.']          
       end
 
-      return 4
+      return [4, nil]
     end
     
     # grab the necessary tokens required for authentication
@@ -77,25 +78,18 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::Login
     auth_cookies = clean_cookies(pre_auth_cookies, auth_cookies)
 
     # try to visit the dasboard
-    dashboard_response = visit_nagios_dashboard(auth_cookies, finish_intall)
-
-    # if we visited the dashboard, return the response body and the cookies
-    ## the response body can be used to obtain the version number
-    ## the cookies can be used by exploit modules to send authenticated requests
-    if dashboard_response.instance_of? Rex::Proto::Http::Response
-      return [dashboard_response.body, auth_cookies]
-    end
-
-    dashboard_response
-
+    visit_nagios_dashboard(auth_cookies, finish_install)
   end
 
   # compares cookies obtained before and after authentication and modifies the latter to remove cookies that may cause session timeouts
   #
   # @param pre_auth_cookies [String] Cookies obtained before authenticating to Nagios XI
   # @param auth_cookies [String] Cookies obtained while authenticating to Nagios XI
-  # @return [String] String containing the cookies required for authentication, stripped off unnecessary/unwanted cookies
+  # @return [String, nil] String containing the cookies required for authentication, stripped off unnecessary/unwanted cookies, nil if one or both of the parameters passed to this method are nil
   def clean_cookies(pre_auth_cookies, auth_cookies)
+    if pre_auth_cookies.nil? || auth_cookies.nil?
+      return nil
+    end
     # Nagios XI may sometimes send the cookie `nagiosxi=deleted;` as part of the cookies after authentication
     # This was observed when trying to access Nagios XI 5.3.0 when the license agreement had not been accepted yet.
     # The `nagiosxi=deleted;` cookie should be filtered out, since it may break authentication
@@ -109,7 +103,7 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::Login
     auth_cookies = auth_cookies_array.join(' ')
 
     # for newer Nagios XI versions, we need to remove the pre_auth cookies from the auth_cookies string, otherwise the session will timeout
-    # however, older Nagios XI versions only use one and the same cookie before and after authentication
+    # however, older Nagios XI versions use only cookie which has the same name both before and after authentication
     unless pre_auth_cookies == auth_cookies
       if auth_cookies.include?(pre_auth_cookies)
         auth_cookies = auth_cookies.gsub(pre_auth_cookies, '').strip
@@ -122,9 +116,9 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::Login
   # performs an HTTP GET request to the Nagios XI backend to verify if authentication succeeded
   #
   # @param auth_cookies [String] Cookies required for authentication
-  # @param finish_install [Boolean] Boolean indicating if the module should finish installing Nagios XI on target hosts if the isntallation hasn't been completed or the license agreement is not signed
-  # @return [String, Array] HTTP response body if the Nagios XI backend was accessed successfully, otherwise Array containing an error code and either an error message or (if the license agreement is not signed) an Array with authentication tokens
-  def visit_nagios_dashboard(auth_cookies, finish_intall)
+  # @param finish_install [Boolean] Boolean indicating if the module should finish installing Nagios XI on target hosts if the installation hasn't been completed or the license agreement is not signed
+  # @return [Array] Array containing an HTTP response body and the authentication cookies if the Nagios XI backend was accessed successfully, otherwise Array containing an error code and either an error message or (if the license agreement is not signed) an Array with authentication tokens
+  def visit_nagios_dashboard(auth_cookies, finish_install)
     # visit the index page to verify we successfully authenticated
     res_index = send_request_cgi({
       'method' => 'GET',
@@ -143,7 +137,7 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::Login
       end
 
       print_warning('The Nagios XI license agreement has not yet been signed on the target.')
-      unless finish_intall
+      unless finish_install
         return [2, 'You can let the module sign the Nagios XI license agreement by setting `FINISH_INSTALL` to true.']
       end
 
@@ -156,7 +150,10 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::Login
       return [5, [auth_cookies, nsp]]
     end
 
-    res_index
+    # return the HTTP resonse body and the authentication cookies
+    ## the response body can be used to obtain the version number
+    ## the cookies can be used by exploit modules to send authenticated requests
+    [res_index.body, auth_cookies]
 
   end
 
@@ -172,14 +169,14 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::Login
   #
   # @param username [String] Username required for authentication
   # @param password [String] Password required for authentication
-  # @param finish_install [Boolean] Boolean indicating if the module should finish installing Nagios XI on target hosts if the isntallation hasn't been completed or the license agreement is not signed
+  # @param finish_install [Boolean] Boolean indicating if the module should finish installing Nagios XI on target hosts if the installation hasn't been completed or the license agreement is not signed
   # @return [Array] Array containing the HTTP response body and session cookies if the Nagios XI backend was accessed successfully, otherwise Array containing an error code and an error message
   def login_after_install_or_license(username, password, finish_install)
     # after installing Nagios XI or signing the license agreement, we sometimes don't receive a server response
     # this loop ensures that at least 2 login attempts are performed if this happens, as the second one usually works
     second_attempt = false
     while true
-      login_result,error_message = nagios_xi_login(username, password, finish_install)
+      login_result, error_message = nagios_xi_login(username, password, finish_install)
 
       break unless error_message
       break unless error_message == 'Connection failed'

--- a/lib/msf/core/exploit/remote/http/nagios_xi/login.rb
+++ b/lib/msf/core/exploit/remote/http/nagios_xi/login.rb
@@ -6,7 +6,7 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::Login
   # @param user [String] Username
   # @param pass [String] Password
   # @param finish_install [Boolean] Boolean indicating if the module should finish installing Nagios XI on target hosts if the isntallation hasn't been completed or the license agreement is not signed
-  # @return [String, String, Array, Msf::Exploit::CheckCode] HTTP response body if the Nagios XI backend was accessed successfully, String 'install_required' if Nagios Xi is not fully installed, Array containing 'sign_license' and the cookies and nsp token if the license agreement is not signed, Msf::Exploit::CheckCode otherwise
+  # @return [Array, String, Array, Msf::Exploit::CheckCode] Array containing the HTTP response body and session cookies if the Nagios XI backend was accessed successfully, String 'install_required' if Nagios Xi is not fully installed, Array containing 'sign_license' and the cookies and nsp token if the license agreement is not signed, Msf::Exploit::CheckCode otherwise
   def nagios_xi_login(user, pass, finish_intall)
     print_status('Attempting to authenticate to Nagios XI...')
 
@@ -77,7 +77,16 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::Login
     auth_cookies = clean_cookies(pre_auth_cookies, auth_cookies)
 
     # try to visit the dasboard
-    dashboard_cookies = visit_nagios_dashboard(auth_cookies, finish_intall)
+    dashboard_response = visit_nagios_dashboard(auth_cookies, finish_intall)
+
+    # if we visited the dashboard, return the response body and the cookies
+    ## the response body can be used to obtain the version number
+    ## the cookies can be used by exploit modules to send authenticated requests
+    if dashboard_response.instance_of? Rex::Proto::Http::Response
+      return [dashboard_response.body, auth_cookies]
+    end
+
+    dashboard_response
 
   end
 
@@ -147,7 +156,7 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::Login
       return ['sign_license', auth_cookies, nsp]
     end
 
-    res_index.body
+    res_index
 
   end
 

--- a/lib/msf/core/exploit/remote/http/nagios_xi/login.rb
+++ b/lib/msf/core/exploit/remote/http/nagios_xi/login.rb
@@ -5,8 +5,11 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::Login
   #
   # @param user [String] Username
   # @param pass [String] Password
-  # @return [String, Msf::Exploit::CheckCode] String containing the session cookies on successful login, Msf::Exploit::CheckCode otherwise
-  def nagios_xi_login(user, pass)
+  # @param finish_install [Boolean] Boolean indicating if the module should finish installing Nagios XI on target hosts if the isntallation hasn't been completed or the license agreement is not signed
+  # @return [String, String, Array, Msf::Exploit::CheckCode] HTTP response body if the Nagios XI backend was accessed successfully, String 'install_required' if Nagios Xi is not fully installed, Array containing 'sign_license' and the cookies and nsp token if the license agreement is not signed, Msf::Exploit::CheckCode otherwise
+  def nagios_xi_login(user, pass, finish_intall)
+    print_status('Attempting to authenticate to Nagios XI...')
+
     # visit the login page in order to obtain the cookies and the `nsp_str` token required for authentication
     res_pre_login = send_request_cgi({
       'method' => 'GET',
@@ -18,11 +21,21 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::Login
     end
 
     unless res_pre_login.code == 200 && res_pre_login.body.include?('>Nagios XI<')
-      return Msf::Exploit::CheckCode::Safe('Target is not a Nagios XI application')
+      # check if we are perhaps dealing with a Nagios XI app that hasn't been fully installed yet 
+      unless res_pre_login.code == 302 && res_pre_login.body.include?('>Nagios XI<') && res_pre_login.headers['Location'].end_with?('/install.php')
+        return Msf::Exploit::CheckCode::Safe('Target is not a Nagios XI application')
+      end
+
+      print_warning('The target seems to be a Nagios XI application that has not been fully installed yet.')
+      unless finish_intall
+        return Msf::Exploit::CheckCode::Detected('You can let the module complete the installation by setting `FINISH_INSTALL` to true.')
+      end
+
+      return 'install_required'
     end
-
+    
+    # grab the necessary tokens required for authentication
     nsp = get_nsp(res_pre_login)
-
     if nsp.blank?
       return Msf::Exploit::CheckCode::Unknown('Unable to obtain the value of the `nsp_str` token required for authentication')
     end
@@ -60,15 +73,49 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::Login
       return Msf::Exploit::CheckCode::Unknown('Unable to obtain the cookies required for authentication')
     end
 
+    # make sure we only use the cookies we need, otherwise we may encounter a session timeout
+    auth_cookies = clean_cookies(pre_auth_cookies, auth_cookies)
+
+    # try to visit the dasboard
+    dashboard_cookies = visit_nagios_dashboard(auth_cookies, finish_intall)
+
+  end
+
+  # compares cookies obtained before and after authentication and modifies the latter to remove cookies that may cause session timeouts
+  #
+  # @param pre_auth_cookies [String] Cookies obtained before authenticating to Nagios XI
+  # @param auth_cookies [String] Cookies obtained while authenticating to Nagios XI
+  # @return [String] String containing the cookies required for authentication, stripped off unnecessary/unwanted cookies
+  def clean_cookies(pre_auth_cookies, auth_cookies)
+    # Nagios XI may sometimes send the cookie `nagiosxi=deleted;` as part of the cookies after authentication
+    # This was observed when trying to access Nagios XI 5.3.0 when the license agreement had not been accepted yet.
+    # The `nagiosxi=deleted;` cookie should be filtered out, since it may break authentication
+    if auth_cookies.include?('nagiosxi=deleted;')
+      auth_cookies = auth_cookies.gsub('nagiosxi=deleted;', '').strip
+    end
+
+    # remove duplicate cookies, necessary to make the next check work in case multiple identical cookies were set (as observed on older Nagios versions)
+    auth_cookies_array = auth_cookies.split(' ')
+    auth_cookies_array.uniq!
+    auth_cookies = auth_cookies_array.join(' ')
+
     # for newer Nagios XI versions, we need to remove the pre_auth cookies from the auth_cookies string, otherwise the session will timeout
     # however, older Nagios XI versions only use one and the same cookie before and after authentication
     unless pre_auth_cookies == auth_cookies
-
       if auth_cookies.include?(pre_auth_cookies)
         auth_cookies = auth_cookies.gsub(pre_auth_cookies, '').strip
       end
     end
 
+    auth_cookies
+  end
+
+  # performs an HTTP GET request to the Nagios XI backend to verify if authentication succeeded
+  #
+  # @param auth_cookies [String] Cookies required for authentication
+  # @param finish_install [Boolean] Boolean indicating if the module should finish installing Nagios XI on target hosts if the isntallation hasn't been completed or the license agreement is not signed
+  # @return [String, Array, Msf::Exploit::CheckCode] HTTP response body if the Nagios XI backend was accessed successfully, Array containing 'sign_license' and the cookies and nsp token if the license agreement is not signed yet, Msf::Exploit::CheckCode otherwise
+  def visit_nagios_dashboard(auth_cookies, finish_intall)
     # visit the index page to verify we successfully authenticated
     res_index = send_request_cgi({
       'method' => 'GET',
@@ -81,10 +128,27 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::Login
     end
 
     unless res_index.code == 200 && res_index.body.include?('>Home Dashboard<')
-      return Msf::Exploit::CheckCode::Detected('Received unexpected reply while trying to acess the NagiosXI home dashboard after authenticating.')
+      # check if we need to sign the license agreement
+      unless res_index.code == 302 && res_index.headers['Location'].end_with?('login.php?showlicense')
+        return Msf::Exploit::CheckCode::Detected('Received unexpected reply while trying to acess the NagiosXI home dashboard after authenticating.')
+      end
+
+      print_warning('The Nagios XI license agreement has not yet been signed on the target.')
+      unless finish_intall
+        return Msf::Exploit::CheckCode::Detected('You can let the module sign the Nagios XI license agreement by setting `FINISH_INSTALL` to true.')
+      end
+
+      nsp = get_nsp(res_index)
+
+      if nsp.blank?
+        return Msf::Exploit::CheckCode::Detected('Failed to obtain the nsp token required for signing the license agreement.')
+      end
+
+      return ['sign_license', auth_cookies, nsp]
     end
 
-    auth_cookies
+    res_index.body
+
   end
 
   # Grabs the nsp_str value from an HTTP response using regex

--- a/lib/msf/core/exploit/remote/http/nagios_xi/login.rb
+++ b/lib/msf/core/exploit/remote/http/nagios_xi/login.rb
@@ -2,7 +2,7 @@
 
 module Msf::Exploit::Remote::HTTP::NagiosXi::Login
   include Msf::Exploit::Remote::HTTP::NagiosXi::URIs
-  # performs a Naxios XI login
+  # performs a Nagios XI login
   #
   # @param user [String] Username
   # @param pass [String] Password
@@ -11,7 +11,7 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::Login
   def nagios_xi_login(user, pass, finish_install)
     print_status('Attempting to authenticate to Nagios XI...')
 
-    # visit the login page in order to obtain the cookies and the `nsp_str` token required for authentication
+    # Visit the login page in order to obtain the cookies and the `nsp_str` token required for authentication
     res_pre_login = send_request_cgi({
       'method' => 'GET',
       'uri' => nagios_xi_login_url,
@@ -22,7 +22,7 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::Login
     end
 
     unless res_pre_login.code == 200 && res_pre_login.body.include?('>Nagios XI<')
-      # check if we are perhaps dealing with a Nagios XI app that hasn't been fully installed yet 
+      # Check if we are perhaps dealing with a Nagios XI app that hasn't been fully installed yet
       unless res_pre_login.code == 302 && res_pre_login.body.include?('>Nagios XI<') && res_pre_login.headers['Location'].end_with?('/install.php')
         return [3, ['Target is not a Nagios XI application']]
       end
@@ -34,8 +34,8 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::Login
 
       return [4, [nil]]
     end
-    
-    # grab the necessary tokens required for authentication
+
+    # Grab the necessary tokens required for authentication
     nsp = get_nsp(res_pre_login)
     if nsp.blank?
       return [2, ['Unable to obtain the value of the `nsp_str` token required for authentication']]
@@ -67,21 +67,22 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::Login
       return [2, ['Received unexpected reply while trying to authenticate. Please check your credentials.']]
     end
 
-    # grab the cookies
+    # Grab the cookies
     auth_cookies = res_login.get_cookies
 
     if auth_cookies.blank?
       return [2, ['Unable to obtain the cookies required for authentication']]
     end
 
-    # make sure we only use the cookies we need, otherwise we may encounter a session timeout
+    # Make sure we only use the cookies we need, otherwise we may encounter a session timeout
     auth_cookies = clean_cookies(pre_auth_cookies, auth_cookies)
 
-    # try to visit the dasboard
+    # Try to visit the dasboard
     visit_nagios_dashboard(auth_cookies, finish_install)
   end
 
-  # compares cookies obtained before and after authentication and modifies the latter to remove cookies that may cause session timeouts
+  # Compares cookies obtained before and after authentication and modifies the
+  # latter to remove cookies that may cause session timeouts
   #
   # @param pre_auth_cookies [String] Cookies obtained before authenticating to Nagios XI
   # @param auth_cookies [String] Cookies obtained while authenticating to Nagios XI
@@ -90,20 +91,22 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::Login
     if pre_auth_cookies.nil? || auth_cookies.nil?
       return nil
     end
-    # Nagios XI may sometimes send the cookie `nagiosxi=deleted;` as part of the cookies after authentication
+    # Nagios XI may sometimes send the cookie `nagiosxi=deleted;` as part of the cookies after authentication.
     # This was observed when trying to access Nagios XI 5.3.0 when the license agreement had not been accepted yet.
-    # The `nagiosxi=deleted;` cookie should be filtered out, since it may break authentication
+    # The `nagiosxi=deleted;` cookie should be filtered out, since it may break authentication.
     if auth_cookies.include?('nagiosxi=deleted;')
       auth_cookies = auth_cookies.gsub('nagiosxi=deleted;', '').strip
     end
 
-    # remove duplicate cookies, necessary to make the next check work in case multiple identical cookies were set (as observed on older Nagios versions)
+    # Remove duplicate cookies, necessary to make the next check work in case multiple
+    # identical cookies were set (as observed on older Nagios versions)
     auth_cookies_array = auth_cookies.split(' ')
     auth_cookies_array.uniq!
     auth_cookies = auth_cookies_array.join(' ')
 
-    # for newer Nagios XI versions, we need to remove the pre_auth cookies from the auth_cookies string, otherwise the session will timeout
-    # however, older Nagios XI versions use only cookie which has the same name both before and after authentication
+    # For newer Nagios XI versions, we need to remove the pre_auth cookies from the auth_cookies
+    # string, otherwise the session will timeout. However, older Nagios XI versions use a single cookie
+    # which has the same name both before and after authentication.
     unless pre_auth_cookies == auth_cookies
       if auth_cookies.include?(pre_auth_cookies)
         auth_cookies = auth_cookies.gsub(pre_auth_cookies, '').strip
@@ -113,13 +116,13 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::Login
     auth_cookies
   end
 
-  # performs an HTTP GET request to the Nagios XI backend to verify if authentication succeeded
+  # Performs an HTTP GET request to the Nagios XI backend to verify if authentication succeeded
   #
   # @param auth_cookies [String] Cookies required for authentication
   # @param finish_install [Boolean] Boolean indicating if the module should finish installing Nagios XI on target hosts if the installation hasn't been completed or the license agreement is not signed
   # @return [Array] Array containing a result code and an Array containing one of three possibilities: an HTTP response body and cookies if the Nagios XI backend was accessed successfully; cookies and the nsp token if the license agreement is not signed; otherwise an error message
   def visit_nagios_dashboard(auth_cookies, finish_install)
-    # visit the index page to verify we successfully authenticated
+    # Visit the index page to verify we successfully authenticated
     res_index = send_request_cgi({
       'method' => 'GET',
       'uri' => nagios_xi_backend_url,
@@ -131,7 +134,7 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::Login
     end
 
     unless res_index.code == 200 && res_index.body.include?('>Home Dashboard<')
-      # check if we need to sign the license agreement
+      # Check if we need to sign the license agreement
       unless res_index.code == 302 && res_index.headers['Location'].end_with?('login.php?showlicense')
         return [2, ['Received unexpected reply while trying to acess the NagiosXI home dashboard after authenticating.']]
       end
@@ -150,9 +153,9 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::Login
       return [5, [auth_cookies, nsp]]
     end
 
-    # return the HTTP resonse body and the authentication cookies
-    ## the response body can be used to obtain the version number
-    ## the cookies can be used by exploit modules to send authenticated requests
+    # Return the HTTP resonse body and the authentication cookies.
+    # The response body can be used to obtain the version number.
+    # The cookies can be used by exploit modules to send authenticated requests.
     [0, [res_index.body, auth_cookies]]
 
   end
@@ -165,15 +168,16 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::Login
     nsp = res.body.scan(/nsp_str = "([a-z0-9]+)/).flatten.first rescue ''
   end
 
-  # performs an authentication attempt. If the server does not return a response, a second attempt is made after a delay of 5 seconds
+  # Performs an authentication attempt. If the server does not return a response,
+  # a second attempt is made after a delay of 5 seconds
   #
   # @param username [String] Username required for authentication
   # @param password [String] Password required for authentication
   # @param finish_install [Boolean] Boolean indicating if the module should finish installing Nagios XI on target hosts if the installation hasn't been completed or the license agreement is not signed
   # @return [Array] Array containing the HTTP response body and session cookies if the Nagios XI backend was accessed successfully, otherwise Array containing an error code and an error message
   def login_after_install_or_license(username, password, finish_install)
-    # after installing Nagios XI or signing the license agreement, we sometimes don't receive a server response
-    # this loop ensures that at least 2 login attempts are performed if this happens, as the second one usually works
+    # After installing Nagios XI or signing the license agreement, we sometimes don't receive a server response.
+    # This loop ensures that at least 2 login attempts are performed if this happens, as the second one usually works.
     second_attempt = false
     while true
       login_result, error_message = nagios_xi_login(username, password, finish_install)

--- a/lib/msf/core/exploit/remote/http/nagios_xi/login.rb
+++ b/lib/msf/core/exploit/remote/http/nagios_xi/login.rb
@@ -167,4 +167,35 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::Login
   def get_nsp(res)
     nsp = res.body.scan(/nsp_str = "([a-z0-9]+)/).flatten.first rescue ''
   end
+
+  # performs an authentication attempt. If the server does not return a response, a second attempt is made after a delay of 5 seconds
+  #
+  # @param username [String] Username required for authentication
+  # @param password [String] Password required for authentication
+  # @param finish_install [Boolean] Boolean indicating if the module should finish installing Nagios XI on target hosts if the isntallation hasn't been completed or the license agreement is not signed
+  # @return [Array, String, Array, Msf::Exploit::CheckCode] Array containing the HTTP response body and session cookies if the Nagios XI backend was accessed successfully, String 'install_required' if Nagios Xi is not fully installed, Array containing 'sign_license' and the cookies and nsp token if the license agreement is not signed, Msf::Exploit::CheckCode otherwise
+  def login_after_install_or_license(username, password, finish_install)
+    # after installing Nagios XI or signing the license agreement, we sometimes don't receive a server response
+    # this loop ensures that at least 2 login attempts are performed if this happens, as the second one usually works
+    second_attempt = false
+    while true
+      login_result = nagios_xi_login(username, password, finish_install)
+
+      break unless login_result.instance_of? Msf::Exploit::CheckCode
+      break unless login_result.message.include?('Connection failed')
+
+      if second_attempt
+        print_warning('The server is still not responding. If you wait a few seconds and rerun the module, it might still work.')
+        break
+      else
+        print_warning('No response received from the server. This can happen after installing Nagios XI or signing the license agreement')
+        print_status('The module will wait for 5 seconds and retry.')
+        second_attempt = true
+        sleep 5
+      end
+    end
+
+    return login_result
+
+  end
 end

--- a/lib/msf/core/exploit/remote/http/nagios_xi/login.rb
+++ b/lib/msf/core/exploit/remote/http/nagios_xi/login.rb
@@ -7,21 +7,17 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::Login
   # @param pass [String] Password
   # @return [String, Msf::Exploit::CheckCode] String containing the session cookies on successful login, Msf::Exploit::CheckCode otherwise
   def nagios_xi_login(user, pass)
-    # empty the cookie jar, otherwise the module will start failing if it is run multiple times in a short timespan
-    self.cookie_jar = [].to_set
-
     # visit the login page in order to obtain the cookies and the `nsp_str` token required for authentication
     res_pre_login = send_request_cgi({
       'method' => 'GET',
       'uri' => nagios_xi_login_url,
-      'keep_cookies' => true,
     })
 
     unless res_pre_login
       return Msf::Exploit::CheckCode::Unknown('Connection failed')
     end
 
-    unless res_pre_login.code == 200 && res_pre_login.body.include?('<b>Nagios XI</b>')
+    unless res_pre_login.code == 200 && res_pre_login.body.include?('>Nagios XI<')
       return Msf::Exploit::CheckCode::Safe('Target is not a Nagios XI application')
     end
 
@@ -31,11 +27,16 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::Login
       return Msf::Exploit::CheckCode::Unknown('Unable to obtain the value of the `nsp_str` token required for authentication')
     end
 
+    pre_auth_cookies = res_pre_login.get_cookies
+    if pre_auth_cookies.blank?
+      return Msf::Exploit::CheckCode::Unknown('Unable to obtain the cookies required for authentication')
+    end
+
     # authenticate
     res_login = send_request_cgi({
       'method' => 'POST',
       'uri' => nagios_xi_login_url,
-      'keep_cookies' => true,
+      'cookie' => pre_auth_cookies,
       'vars_post' => {
         'nsp' => nsp,
         'pageopt' => 'login',
@@ -52,30 +53,37 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::Login
       return Msf::Exploit::CheckCode::Detected('Received unexpected reply while trying to authenticate')
     end
 
-    # keep only the most recent cookie, otherwise the session will time out
-    auth_cookies = cookie_jar.to_a[1]
-    self.cookie_jar = auth_cookies.split.to_set
+    # grab the cookies
+    auth_cookies = res_login.get_cookies
+
+    if auth_cookies.blank?
+      return Msf::Exploit::CheckCode::Unknown('Unable to obtain the cookies required for authentication')
+    end
+
+    # for newer Nagios XI versions, we need to remove the pre_auth cookies from the auth_cookies string, otherwise the session will timeout
+    # however, older Nagios XI versions only use one and the same cookie before and after authentication
+    unless pre_auth_cookies == auth_cookies
+
+      if auth_cookies.include?(pre_auth_cookies)
+        auth_cookies = auth_cookies.gsub(pre_auth_cookies, '').strip
+      end
+    end
 
     # visit the index page to verify we successfully authenticated
     res_index = send_request_cgi({
       'method' => 'GET',
       'uri' => nagios_xi_backend_url,
+      'cookie' => auth_cookies
     })
 
     unless res_index
       return Msf::Exploit::CheckCode::Unknown('Connection failed')
     end
 
-    unless res_index.code == 200 && res_index.body.include?("id='lid-menu-home-homedashboard'>Home Dashboard</a>")
+    unless res_index.code == 200 && res_index.body.include?('>Home Dashboard<')
       return Msf::Exploit::CheckCode::Detected('Received unexpected reply while trying to acess the NagiosXI home dashboard after authenticating.')
     end
 
-    nsp = get_nsp(res_index)
-
-    if nsp.blank?
-      return Msf::Exploit::CheckCode::Unknown('Unable to obtain the value of the `nsp_str` token required for authentication')
-    end
-    
     auth_cookies
   end
 

--- a/lib/msf/core/exploit/remote/http/nagios_xi/rce_check.rb
+++ b/lib/msf/core/exploit/remote/http/nagios_xi/rce_check.rb
@@ -10,8 +10,12 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::RceCheck
     
     # known exploits that affect versions prior to the one in the hash key
     nagios_rce_version_prior = {
-      '5.6.6' => [['CVE-2019-15949', 'nagios_xi_plugins_check_ping_authenticated_rce']],
-      '5.8.0' => [['CVE-2020-35578', 'nagios_xi_plugins_filename_authenticated_rce']]
+      '5.6.6' => [
+        ['CVE-2019-15949', 'nagios_xi_plugins_check_ping_authenticated_rce']
+      ],
+      '5.8.0' => [
+        ['CVE-2020-35578', 'nagios_xi_plugins_filename_authenticated_rce']
+      ]
     }
 
     nagios_rce_version_prior.each do |fixed_version, info|
@@ -22,7 +26,10 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::RceCheck
 
     # known exploits that affect only the version in the hash key
     nagios_rce_version_equals = {
-      '5.7.3' => [['CVE-2020-5791', 'nagios_xi_mibs_authenticated_rce'],['CVE-2020-5792', 'nagios_xi_snmptrap_authenticated_rce']]
+      '5.7.3' => [
+        ['CVE-2020-5791', 'nagios_xi_mibs_authenticated_rce'],
+        ['CVE-2020-5792', 'nagios_xi_snmptrap_authenticated_rce']
+      ]
     }
 
     nagios_rce_version_equals.each do |fixed_version, info|

--- a/lib/msf/core/exploit/remote/http/nagios_xi/rce_check.rb
+++ b/lib/msf/core/exploit/remote/http/nagios_xi/rce_check.rb
@@ -5,18 +5,11 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::RceCheck
   #
   # @param version [Gem::Version] Nagios XI version
   # @return [Hash, Msf::Exploit::CheckCode], Hash mapping CVE numbers to exploit module names if the target is vulnerable, Msf::Exploit::CheckCode otherwise
-  def nagios_xi_rce_check(version)
+   def nagios_xi_rce_check(version)
     matching_exploits = {}
     
     # known exploits that affect versions prior to the one in the hash key
-    nagios_rce_version_prior = {
-      '5.6.6' => [
-        ['CVE-2019-15949', 'nagios_xi_plugins_check_ping_authenticated_rce']
-      ],
-      '5.8.0' => [
-        ['CVE-2020-35578', 'nagios_xi_plugins_filename_authenticated_rce']
-      ]
-    }
+    nagios_rce_version_prior = {}
 
     nagios_rce_version_prior.each do |fixed_version, info|
       if version < Gem::Version.new(fixed_version)
@@ -25,12 +18,7 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::RceCheck
     end
 
     # known exploits that affect only the version in the hash key
-    nagios_rce_version_equals = {
-      '5.7.3' => [
-        ['CVE-2020-5791', 'nagios_xi_mibs_authenticated_rce'],
-        ['CVE-2020-5792', 'nagios_xi_snmptrap_authenticated_rce']
-      ]
-    }
+    nagios_rce_version_equals = {}
 
     nagios_rce_version_equals.each do |fixed_version, info|
       if version == Gem::Version.new(fixed_version)
@@ -38,15 +26,28 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::RceCheck
       end
     end
 
-    # the below hash can be populated with exploits that affect version ranges
-    # each hash key should be two versions separated by a hyphen, eg `5.8.0-5.8.5`
-    nagios_rce_version_range = {} 
+    # known exploits that affect version ranges (inclusive)
+    # each hash key should be two versions separated by a hyphen, eg `5.6.0-5.8.5`
+    nagios_rce_version_range = {
+      '5.3.0-5.6.5' => [
+        ['CVE-2019-15949', 'nagios_xi_plugins_check_plugin_authenticated_rce.rb']
+      ],
+      '5.3.0-5.7.9' => [
+        ['CVE-2020-35578', 'nagios_xi_plugins_filename_authenticated_rce']
+      ],
+      '5.5.0-5.7.3' => [
+        ['CVE-2020-5792', 'nagios_xi_snmptrap_authenticated_rce']
+      ],
+      '5.6.0-5.7.3' => [
+        ['CVE-2020-5791', 'nagios_xi_mibs_authenticated_rce']
+      ],
+    }
 
     nagios_rce_version_range.each do |fixed_version, info|
-      safe_lower, safe_higher = fixed_version.split("-")
-      safe_lower = Gem::Version.new(safe_lower)
-      safe_higher = Gem::Version.new(safe_higher)
-      if safe_lower < version < safe_higher
+      lower, higher = fixed_version.split("-")
+      lower = Gem::Version.new(lower)
+      higher = Gem::Version.new(higher)
+      if version >= lower && version <= higher
         matching_exploits = add_cve_module_to_hash(matching_exploits,info)
       end
     end

--- a/lib/msf/core/exploit/remote/http/nagios_xi/rce_check.rb
+++ b/lib/msf/core/exploit/remote/http/nagios_xi/rce_check.rb
@@ -29,7 +29,7 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::RceCheck
     # known exploits that affect version ranges (inclusive)
     # each hash key should be two versions separated by a hyphen, eg `5.6.0-5.8.5`
     nagios_rce_version_range = {
-      '5.3.0-5.6.5' => [
+      '5.2.0-5.6.5' => [
         ['CVE-2019-15949', 'nagios_xi_plugins_check_plugin_authenticated_rce.rb']
       ],
       '5.3.0-5.7.9' => [

--- a/lib/msf/core/exploit/remote/http/nagios_xi/rce_check.rb
+++ b/lib/msf/core/exploit/remote/http/nagios_xi/rce_check.rb
@@ -3,34 +3,38 @@
 module Msf::Exploit::Remote::HTTP::NagiosXi::RceCheck
   # Uses the Nagios XI version to check which CVEs and related exploit modules the target is vulnerable to, if any
   #
-  # @param version [Gem::Version] Nagios XI version
+  # @param version [Rex::Version] Nagios XI version
   # @return [Hash], Hash mapping CVE numbers to exploit module names if the target is vulnerable, empty hash otherwise
    def nagios_xi_rce_check(version)
     matching_exploits = {}
     
-    # known exploits that affect versions prior to the one in the hash key
+    # Storage area for known exploits that affect versions prior to the one in the hash key
     nagios_rce_version_prior = {}
 
-    nagios_rce_version_prior.each do |fixed_version, info|
-      if version < Gem::Version.new(fixed_version)
-        matching_exploits = add_cve_module_to_hash(matching_exploits,info)
+    unless nagios_rce_version_prior.empty?
+      nagios_rce_version_prior.each do |fixed_version, info|
+        if version < Rex::Version.new(fixed_version)
+          matching_exploits = add_cve_module_to_hash(matching_exploits, info)
+        end
       end
     end
 
-    # known exploits that affect only the version in the hash key
+    # Storage area for known exploits that affect only the version in the hash key
     nagios_rce_version_equals = {}
 
-    nagios_rce_version_equals.each do |fixed_version, info|
-      if version == Gem::Version.new(fixed_version)
-        matching_exploits = add_cve_module_to_hash(matching_exploits,info)
+    unless nagios_rce_version_equals.empty?
+      nagios_rce_version_equals.each do |fixed_version, info|
+        if version == Rex::Version.new(fixed_version)
+          matching_exploits = add_cve_module_to_hash(matching_exploits, info)
+        end
       end
     end
 
-    # known exploits that affect version ranges (inclusive)
+    # Storage area for known exploits that affect version ranges (inclusive)
     # each hash key should be two versions separated by a hyphen, eg `5.6.0-5.8.5`
     nagios_rce_version_range = {
       '5.2.0-5.6.5' => [
-        ['CVE-2019-15949', 'nagios_xi_plugins_check_plugin_authenticated_rce.rb']
+        ['CVE-2019-15949', 'nagios_xi_plugins_check_plugin_authenticated_rce']
       ],
       '5.3.0-5.7.9' => [
         ['CVE-2020-35578', 'nagios_xi_plugins_filename_authenticated_rce']
@@ -45,21 +49,22 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::RceCheck
 
     nagios_rce_version_range.each do |fixed_version, info|
       lower, higher = fixed_version.split("-")
-      lower = Gem::Version.new(lower)
-      higher = Gem::Version.new(higher)
+      lower = Rex::Version.new(lower)
+      higher = Rex::Version.new(higher)
       if version >= lower && version <= higher
-        matching_exploits = add_cve_module_to_hash(matching_exploits,info)
+        matching_exploits = add_cve_module_to_hash(matching_exploits, info)
       end
     end
 
     matching_exploits
   end
 
-  # Helper function that populates the matching_exploits hash with the contents of cve_module_array by setting index 0 of each array as the key and index 1 as the value
+  # Helper function that populates the matching_exploits hash with the contents of cve_module_array by
+  # setting index 0 of each array as the key and index 1 as the value
   #
   # @param matching_exploits [Hash] maps CVE numbers to exploit module names
   # @param cve_module_array [Array] contains arrays with a CVE number at index 0 and a matching exploit at index 1
-  # @return [Hash] matching exploits, maps CVE numbers to exploit module names
+  # @return [Hash] matching exploits, updated list of matching exploits, mapping CVE numbers to exploit module names
   def add_cve_module_to_hash(matching_exploits, cve_module_array)
     # account for version numbers for which we have multiple exploits
     if cve_module_array.length > 1

--- a/lib/msf/core/exploit/remote/http/nagios_xi/rce_check.rb
+++ b/lib/msf/core/exploit/remote/http/nagios_xi/rce_check.rb
@@ -9,7 +9,11 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::RceCheck
     matching_exploits = {}
     
     # Storage area for known exploits that affect versions prior to the one in the hash key
-    nagios_rce_version_prior = {}
+    nagios_rce_version_prior = {
+      '5.2.8' => [
+        ['NO CVE AVAILABLE', 'nagios_xi_chained_rce']
+      ],
+    }
 
     unless nagios_rce_version_prior.empty?
       nagios_rce_version_prior.each do |fixed_version, info|
@@ -33,8 +37,14 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::RceCheck
     # Storage area for known exploits that affect version ranges (inclusive)
     # each hash key should be two versions separated by a hyphen, eg `5.6.0-5.8.5`
     nagios_rce_version_range = {
+      '5.2.0-5.5.6' => [
+        ['CVE-2018-15708,15710', 'nagios_xi_magpie_debug']
+      ],
       '5.2.0-5.6.5' => [
         ['CVE-2019-15949', 'nagios_xi_plugins_check_plugin_authenticated_rce']
+      ],
+      '5.2.6-5.4.12' => [
+        ['CVE-2018-8733,8734,8735,8736', 'nagios_xi_chained_rce_2_electric_boogaloo']
       ],
       '5.3.0-5.7.9' => [
         ['CVE-2020-35578', 'nagios_xi_plugins_filename_authenticated_rce']

--- a/lib/msf/core/exploit/remote/http/nagios_xi/rce_check.rb
+++ b/lib/msf/core/exploit/remote/http/nagios_xi/rce_check.rb
@@ -72,7 +72,7 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::RceCheck
   #
   # @param matching_exploits [Hash] maps CVE numbers to exploit module names
   # @param cve_module_array [Array] contains arrays with a CVE number at index 0 and a matching exploit at index 1
-  # @return [Hash] matching exploits, updated list of matching exploits, mapping CVE numbers to exploit module names
+  # @return [Hash] updated list of matching exploits, mapping CVE numbers to exploit module names
   def add_cve_module_to_hash(matching_exploits, cve_module_array)
     # Account for version numbers for which we have multiple exploits
     if cve_module_array.length > 1

--- a/lib/msf/core/exploit/remote/http/nagios_xi/rce_check.rb
+++ b/lib/msf/core/exploit/remote/http/nagios_xi/rce_check.rb
@@ -4,7 +4,7 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::RceCheck
   # Uses the Nagios XI version to check which CVEs and related exploit modules the target is vulnerable to, if any
   #
   # @param version [Gem::Version] Nagios XI version
-  # @return [Hash, Msf::Exploit::CheckCode], Hash mapping CVE numbers to exploit module names if the target is vulnerable, Msf::Exploit::CheckCode otherwise
+  # @return [Hash], Hash mapping CVE numbers to exploit module names if the target is vulnerable, empty hash otherwise
    def nagios_xi_rce_check(version)
     matching_exploits = {}
     
@@ -50,10 +50,6 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::RceCheck
       if version >= lower && version <= higher
         matching_exploits = add_cve_module_to_hash(matching_exploits,info)
       end
-    end
-
-    if matching_exploits.empty?
-      return Msf::Exploit::CheckCode::Safe("Nagios XI version #{version} doesn't match any exploit modules.")
     end
 
     matching_exploits

--- a/lib/msf/core/exploit/remote/http/nagios_xi/rce_check.rb
+++ b/lib/msf/core/exploit/remote/http/nagios_xi/rce_check.rb
@@ -15,11 +15,9 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::RceCheck
       ],
     }
 
-    unless nagios_rce_version_prior.empty?
-      nagios_rce_version_prior.each do |fixed_version, info|
-        if version < Rex::Version.new(fixed_version)
-          matching_exploits = add_cve_module_to_hash(matching_exploits, info)
-        end
+    nagios_rce_version_prior.each do |fixed_version, info|
+      if version < Rex::Version.new(fixed_version)
+        matching_exploits = add_cve_module_to_hash(matching_exploits, info)
       end
     end
 

--- a/lib/msf/core/exploit/remote/http/nagios_xi/rce_check.rb
+++ b/lib/msf/core/exploit/remote/http/nagios_xi/rce_check.rb
@@ -7,7 +7,7 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::RceCheck
   # @return [Hash], Hash mapping CVE numbers to exploit module names if the target is vulnerable, empty hash otherwise
    def nagios_xi_rce_check(version)
     matching_exploits = {}
-    
+
     # Storage area for known exploits that affect versions prior to the one in the hash key
     nagios_rce_version_prior = {
       '5.2.8' => [
@@ -32,17 +32,17 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::RceCheck
       end
     end
 
-    # Storage area for known exploits that affect version ranges (inclusive)
-    # each hash key should be two versions separated by a hyphen, eg `5.6.0-5.8.5`
+    # Storage area for known exploits that affect version ranges (inclusive).
+    # Each hash key should be two versions separated by a hyphen, eg `5.6.0-5.8.5`
     nagios_rce_version_range = {
       '5.2.0-5.5.6' => [
-        ['CVE-2018-15708,15710', 'nagios_xi_magpie_debug']
+        ['CVE-2018-15708, CVE-2018-15710', 'nagios_xi_magpie_debug']
       ],
       '5.2.0-5.6.5' => [
         ['CVE-2019-15949', 'nagios_xi_plugins_check_plugin_authenticated_rce']
       ],
       '5.2.6-5.4.12' => [
-        ['CVE-2018-8733,8734,8735,8736', 'nagios_xi_chained_rce_2_electric_boogaloo']
+        ['CVE-2018-8733, CVE-2018-8734, CVE-2018-8735, CVE-2018-8736', 'nagios_xi_chained_rce_2_electric_boogaloo']
       ],
       '5.3.0-5.7.9' => [
         ['CVE-2020-35578', 'nagios_xi_plugins_filename_authenticated_rce']
@@ -67,14 +67,14 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::RceCheck
     matching_exploits
   end
 
-  # Helper function that populates the matching_exploits hash with the contents of cve_module_array by
-  # setting index 0 of each array as the key and index 1 as the value
+  # Helper function that populates the matching_exploits hash with the contents
+  # of cve_module_array by setting index 0 of each array as the key and index 1 as the value.
   #
   # @param matching_exploits [Hash] maps CVE numbers to exploit module names
   # @param cve_module_array [Array] contains arrays with a CVE number at index 0 and a matching exploit at index 1
   # @return [Hash] matching exploits, updated list of matching exploits, mapping CVE numbers to exploit module names
   def add_cve_module_to_hash(matching_exploits, cve_module_array)
-    # account for version numbers for which we have multiple exploits
+    # Account for version numbers for which we have multiple exploits
     if cve_module_array.length > 1
       cve_module_array.each do |cma|
         cve, msf_module = cma

--- a/lib/msf/core/exploit/remote/http/nagios_xi/rce_check.rb
+++ b/lib/msf/core/exploit/remote/http/nagios_xi/rce_check.rb
@@ -1,0 +1,72 @@
+# -*- coding: binary -*-
+
+module Msf::Exploit::Remote::HTTP::NagiosXi::RceCheck
+  # Uses the Nagios XI version to check which CVEs and related exploit modules the target is vulnerable to, if any
+  #
+  # @param version [Gem::Version] Nagios XI version
+  # @return [Hash, Msf::Exploit::CheckCode], Hash mapping CVE numbers to exploit module names if the target is vulnerable, Msf::Exploit::CheckCode otherwise
+  def nagios_xi_rce_check(version)
+    matching_exploits = {}
+    
+    # known exploits that affect versions prior to the one in the hash key
+    nagios_rce_version_prior = {
+      '5.6.6' => [['CVE-2019-15949', 'nagios_xi_plugins_check_ping_authenticated_rce']],
+      '5.8.0' => [['CVE-2020-35578', 'nagios_xi_plugins_filename_authenticated_rce']]
+    }
+
+    nagios_rce_version_prior.each do |fixed_version, info|
+      if version < Gem::Version.new(fixed_version)
+        matching_exploits = add_cve_module_to_hash(matching_exploits,info)
+      end
+    end
+
+    # known exploits that affect only the version in the hash key
+    nagios_rce_version_equals = {
+      '5.7.3' => [['CVE-2020-5791', 'nagios_xi_mibs_authenticated_rce'],['CVE-2020-5792', 'nagios_xi_snmptrap_authenticated_rce']]
+    }
+
+    nagios_rce_version_equals.each do |fixed_version, info|
+      if version == Gem::Version.new(fixed_version)
+        matching_exploits = add_cve_module_to_hash(matching_exploits,info)
+      end
+    end
+
+    # the below hash can be populated with exploits that affect version ranges
+    # each hash key should be two versions separated by a hyphen, eg `5.8.0-5.8.5`
+    nagios_rce_version_range = {} 
+
+    nagios_rce_version_range.each do |fixed_version, info|
+      safe_lower, safe_higher = fixed_version.split("-")
+      safe_lower = Gem::Version.new(safe_lower)
+      safe_higher = Gem::Version.new(safe_higher)
+      if safe_lower < version < safe_higher
+        matching_exploits = add_cve_module_to_hash(matching_exploits,info)
+      end
+    end
+
+    if matching_exploits.empty?
+      return Msf::Exploit::CheckCode::Safe("Nagios XI version #{version} doesn't match any exploit modules.")
+    end
+
+    matching_exploits
+  end
+
+  # Helper function that populates the matching_exploits hash with the contents of cve_module_array by setting index 0 of each array as the key and index 1 as the value
+  #
+  # @param matching_exploits [Hash] maps CVE numbers to exploit module names
+  # @param cve_module_array [Array] contains arrays with a CVE number at index 0 and a matching exploit at index 1
+  # @return [Hash] matching exploits, maps CVE numbers to exploit module names
+  def add_cve_module_to_hash(matching_exploits, cve_module_array)
+    # account for version numbers for which we have multiple exploits
+    if cve_module_array.length > 1
+      cve_module_array.each do |cma|
+        cve, msf_module = cma
+        matching_exploits[cve] = msf_module
+      end
+    else
+      cve, msf_module = cve_module_array.flatten
+      matching_exploits[cve] = msf_module
+    end
+    matching_exploits
+  end
+end

--- a/lib/msf/core/exploit/remote/http/nagios_xi/uris.rb
+++ b/lib/msf/core/exploit/remote/http/nagios_xi/uris.rb
@@ -1,0 +1,18 @@
+# -*- coding: binary -*-
+module Msf::Exploit::Remote::HTTP::NagiosXi::URIs
+
+  # Returns the Nagios XI Login URL
+  #
+  # @return [String] Nagios XI Login URL
+  def nagios_xi_login_url
+    normalize_uri(target_uri.path, 'login.php')
+  end
+
+  # Returns the Nagios XI Backend URL
+  #
+  # @return [String] Nagios XI Backend URL
+  def nagios_xi_backend_url
+    normalize_uri(target_uri.path, 'index.php')
+  end
+
+end

--- a/lib/msf/core/exploit/remote/http/nagios_xi/uris.rb
+++ b/lib/msf/core/exploit/remote/http/nagios_xi/uris.rb
@@ -15,4 +15,11 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::URIs
     normalize_uri(target_uri.path, 'index.php')
   end
 
+  # Returns the Nagios XI Installation URL
+  #
+  # @return [String] Nagios XI Install URL
+  def nagios_xi_install_url
+    normalize_uri(target_uri.path, 'install.php')
+  end
+
 end

--- a/lib/msf/core/exploit/remote/http/nagios_xi/version.rb
+++ b/lib/msf/core/exploit/remote/http/nagios_xi/version.rb
@@ -1,26 +1,12 @@
 # -*- coding: binary -*-
 
 module Msf::Exploit::Remote::HTTP::NagiosXi::Version
-  # Extracts the Nagios XI version information from index.php
+  # Extracts the Nagios XI version information from an HTTP response
   #
-  # @param cookies [String] cookies obtained from an HTTP response
+  # @param res_backend [String] HTTP response
   # @return [String, Msf::Exploit::CheckCode], String containing the Nagios XI version if successful, otherwise Msf::Exploit::CheckCode
-  def nagios_xi_version_index(cookies)
-    res_backend = send_request_cgi({
-      'method' => 'GET',
-      'uri' => nagios_xi_backend_url,
-      'cookie' => cookies
-    })
-
-    unless res_backend
-      return Msf::Exploit::CheckCode::Unknown('Connection failed')
-    end
-
-    unless res_backend.code == 200 && res_backend.body.include?('>Home Dashboard<')
-      return Msf::Exploit::CheckCode::Unknown('Received unexpected response while trying to visit the Nagios XI dashboard') # it is unlcear why this would happen
-    end
-
-    version = res_backend.body.scan(/product=nagiosxi&version=(\d+\.\d+\.\d+)&/).flatten.first rescue ''
+  def nagios_xi_version(res_backend)
+    version = res_backend.scan(/product=nagiosxi&version=(\d+\.\d+\.\d+)&/).flatten.first rescue ''
     if version.blank?
       return Msf::Exploit::CheckCode::Detected('Unable to obtain the Nagios XI version from the dashboard')
     end
@@ -28,3 +14,4 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::Version
     version
   end
 end
+

--- a/lib/msf/core/exploit/remote/http/nagios_xi/version.rb
+++ b/lib/msf/core/exploit/remote/http/nagios_xi/version.rb
@@ -9,7 +9,7 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::Version
   # @param res_backend [String] HTTP response body
   # @return [String, nil], String containing the Nagios XI version if successful, nil otherwise
   def nagios_xi_version(res_backend)
-    version = res_backend.scan(/product=nagiosxi&version=(.*?)&/)&.flatten&.first
+    version = res_backend.scan(/product=nagiosxi&version=(.*+)&/)&.flatten&.first
   end
 
   # Tries to obtain the Nagios XI version from the login.php page. This will not work for older Nagios XI versions.

--- a/lib/msf/core/exploit/remote/http/nagios_xi/version.rb
+++ b/lib/msf/core/exploit/remote/http/nagios_xi/version.rb
@@ -9,7 +9,7 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::Version
   # @param res_backend [String] HTTP response body
   # @return [String, nil], String containing the Nagios XI version if successful, nil otherwise
   def nagios_xi_version(res_backend)
-    version = res_backend.scan(/product=nagiosxi&version=(.*+)&/)&.flatten&.first
+    version = res_backend.scan(/product=nagiosxi&version=(.+?)&/)&.flatten&.first
   end
 
   # Tries to obtain the Nagios XI version from the login.php page. This will not work for older Nagios XI versions.

--- a/lib/msf/core/exploit/remote/http/nagios_xi/version.rb
+++ b/lib/msf/core/exploit/remote/http/nagios_xi/version.rb
@@ -3,7 +3,8 @@
 module Msf::Exploit::Remote::HTTP::NagiosXi::Version
   include Msf::Exploit::Remote::HTTP::NagiosXi::URIs
 
-  # Extracts the Nagios XI version information from an HTTP response body obtained after authentication. Works for index.php and perhaps other backend pages.
+  # Extracts the Nagios XI version information from an HTTP response body obtained after authentication.
+  # Works for index.php and perhaps other backend pages.
   #
   # @param res_backend [String] HTTP response body
   # @return [String, nil], String containing the Nagios XI version if successful, nil otherwise
@@ -29,7 +30,7 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::Version
     end
 
     nagios_version = res.body.scan(/name="version" value="(\d+\.\d+\.\d+)">/)&.flatten&.first
-    
+
     if nagios_version.nil?
       return [2, 'Unable to obtain Nagios XI version from the login page.']
     end

--- a/lib/msf/core/exploit/remote/http/nagios_xi/version.rb
+++ b/lib/msf/core/exploit/remote/http/nagios_xi/version.rb
@@ -16,7 +16,7 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::Version
       return Msf::Exploit::CheckCode::Unknown('Connection failed')
     end
 
-    unless res_backend.code == 200 && res_backend.body.include?("id='lid-menu-home-homedashboard'>Home Dashboard</a>")
+    unless res_backend.code == 200 && res_backend.body.include?('>Home Dashboard<')
       return Msf::Exploit::CheckCode::Unknown('Received unexpected response while trying to visit the Nagios XI dashboard') # it is unlcear why this would happen
     end
 

--- a/lib/msf/core/exploit/remote/http/nagios_xi/version.rb
+++ b/lib/msf/core/exploit/remote/http/nagios_xi/version.rb
@@ -1,0 +1,30 @@
+# -*- coding: binary -*-
+
+module Msf::Exploit::Remote::HTTP::NagiosXi::Version
+  # Extracts the Nagios XI version information from index.php
+  #
+  # @param cookies [String] cookies obtained from an HTTP response
+  # @return [String, Msf::Exploit::CheckCode], String containing the Nagios XI version if successful, otherwise Msf::Exploit::CheckCode
+  def nagios_xi_version_index(cookies)
+    res_backend = send_request_cgi({
+      'method' => 'GET',
+      'uri' => nagios_xi_backend_url,
+      'cookie' => cookies
+    })
+
+    unless res_backend
+      return Msf::Exploit::CheckCode::Unknown('Connection failed')
+    end
+
+    unless res_backend.code == 200 && res_backend.body.include?("id='lid-menu-home-homedashboard'>Home Dashboard</a>")
+      return Msf::Exploit::CheckCode::Unknown('Received unexpected response while trying to visit the Nagios XI dashboard') # it is unlcear why this would happen
+    end
+
+    version = res_backend.body.scan(/product=nagiosxi&version=(\d+\.\d+\.\d+)&/).flatten.first rescue ''
+    if version.blank?
+      return Msf::Exploit::CheckCode::Detected('Unable to obtain the Nagios XI version from the dashboard')
+    end
+
+    version
+  end
+end

--- a/lib/msf/core/exploit/remote/http/nagios_xi/version.rb
+++ b/lib/msf/core/exploit/remote/http/nagios_xi/version.rb
@@ -1,17 +1,19 @@
 # -*- coding: binary -*-
 
 module Msf::Exploit::Remote::HTTP::NagiosXi::Version
-  # Extracts the Nagios XI version information from an HTTP response
+  include Msf::Exploit::Remote::HTTP::NagiosXi::URIs
+
+  # Extracts the Nagios XI version information from an HTTP response body obtained after authentication. Works for index.php and perhaps other backend pages.
   #
-  # @param res_backend [String] HTTP response
+  # @param res_backend [String] HTTP response body
   # @return [String, nil], String containing the Nagios XI version if successful, nil otherwise
   def nagios_xi_version(res_backend)
-    version = res_backend.scan(/product=nagiosxi&version=(\d+\.\d+\.\d+)&/)&.flatten&.first
+    version = res_backend.scan(/product=nagiosxi&version=(.*?)&/)&.flatten&.first
   end
 
   # Tries to obtain the Nagios XI version from the login.php page. This will not work for older Nagios XI versions.
   #
-  # @return [String, Array], String containing the Nagios XI version if successful, otherwise Array containing an error code and an error message
+  # @return [Array], Array containing the Nagios XI version and nil if successful, otherwise Array containing an error code and an error message
   def nagios_xi_version_no_auth
     res = send_request_cgi({
       'method' => 'GET',
@@ -32,7 +34,7 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::Version
       return [2, 'Unable to obtain Nagios XI version from the login page.']
     end
 
-    nagios_version
+    [nagios_version, nil]
   end
 
 end

--- a/lib/msf/core/exploit/remote/http/nagios_xi/version.rb
+++ b/lib/msf/core/exploit/remote/http/nagios_xi/version.rb
@@ -4,19 +4,14 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::Version
   # Extracts the Nagios XI version information from an HTTP response
   #
   # @param res_backend [String] HTTP response
-  # @return [String, Msf::Exploit::CheckCode], String containing the Nagios XI version if successful, otherwise Msf::Exploit::CheckCode
+  # @return [String, nil], String containing the Nagios XI version if successful, nil otherwise
   def nagios_xi_version(res_backend)
-    version = res_backend.scan(/product=nagiosxi&version=(\d+\.\d+\.\d+)&/).flatten.first rescue ''
-    if version.blank?
-      return Msf::Exploit::CheckCode::Detected('Unable to obtain the Nagios XI version from the dashboard')
-    end
-
-    version
+    version = res_backend.scan(/product=nagiosxi&version=(\d+\.\d+\.\d+)&/)&.flatten&.first
   end
 
   # Tries to obtain the Nagios XI version from the login.php page. This will not work for older Nagios XI versions.
   #
-  # @return [String, Msf::Exploit::CheckCode], String containing the Nagios XI version if successful, otherwise Msf::Exploit::CheckCode
+  # @return [String, Array], String containing the Nagios XI version if successful, otherwise Array containing an error code and an error message
   def nagios_xi_version_no_auth
     res = send_request_cgi({
       'method' => 'GET',
@@ -24,17 +19,17 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::Version
     })
 
     unless res
-      return Msf::Exploit::CheckCode::Unknown('Connection failed')
+      return [1, 'Connection failed']
     end
 
     unless [200,302].include?(res.code) && res.body.include?('>Nagios XI<')
-      return Msf::Exploit::CheckCode::Safe('Target is not a Nagios XI application')
+      return [3, 'Target is not a Nagios XI application']
     end
 
-    nagios_version = res.body.scan(/name="version" value="(\d+\.\d+\.\d+)">/).flatten.first
+    nagios_version = res.body.scan(/name="version" value="(\d+\.\d+\.\d+)">/)&.flatten&.first
     
-    if nagios_version.blank?
-      return Msf::Exploit::CheckCode::Unknown('Unable to obtain Nagios XI version from the login page.')
+    if nagios_version.nil?
+      return [2, 'Unable to obtain Nagios XI version from the login page.']
     end
 
     nagios_version

--- a/lib/msf/core/exploit/remote/http/nagios_xi/version.rb
+++ b/lib/msf/core/exploit/remote/http/nagios_xi/version.rb
@@ -13,5 +13,32 @@ module Msf::Exploit::Remote::HTTP::NagiosXi::Version
 
     version
   end
+
+  # Tries to obtain the Nagios XI version from the login.php page. This will not work for older Nagios XI versions.
+  #
+  # @return [String, Msf::Exploit::CheckCode], String containing the Nagios XI version if successful, otherwise Msf::Exploit::CheckCode
+  def nagios_xi_version_no_auth
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => nagios_xi_login_url,
+    })
+
+    unless res
+      return Msf::Exploit::CheckCode::Unknown('Connection failed')
+    end
+
+    unless [200,302].include?(res.code) && res.body.include?('>Nagios XI<')
+      return Msf::Exploit::CheckCode::Safe('Target is not a Nagios XI application')
+    end
+
+    nagios_version = res.body.scan(/name="version" value="(\d+\.\d+\.\d+)">/).flatten.first
+    
+    if nagios_version.blank?
+      return Msf::Exploit::CheckCode::Unknown('Unable to obtain Nagios XI version from the login page.')
+    end
+
+    nagios_version
+  end
+
 end
 

--- a/modules/auxiliary/scanner/http/nagios_xi_scanner.rb
+++ b/modules/auxiliary/scanner/http/nagios_xi_scanner.rb
@@ -1,0 +1,123 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::HTTP::NagiosXi
+  include Msf::Auxiliary::Scanner
+  include Msf::Auxiliary::Report
+
+  def initialize
+    super(
+      'Name' => 'Nagios XI Scanner',
+      'Description' => %q{
+        The module detects the version of Nagios XI applications and
+        suggests matching exploit modules based on the version number.
+        Since Nagios XI applications only reveal the version to authenticated
+        users, valid credentials for a Nagios XI account are required.
+        Alternatively, it is possible to provide a specific Nagios XI version
+        number via the `VERSION` option. In that case, the module simply
+        suggests matching exploit modules and does not probe the target(s).
+
+      },
+      'Author' => [ 'Erik Wynter' ], # @wyntererik
+      'License' => MSF_LICENSE,
+      'References' =>
+        [
+          ['CVE', '2019-15949'],
+          ['CVE', '2020-5791'],
+          ['CVE', '2020-5792'],
+          ['CVE', '2020-35578']
+        ]
+    )
+    register_options [
+      OptString.new('VERSION', [false, 'Nagios XI version to check against existing exploit modules', nil])
+    ]
+  end
+
+  def username
+    datastore['USERNAME']
+  end
+
+  def password
+    datastore['PASSWORD']
+  end
+
+  def version
+    datastore['VERSION']
+  end
+
+  def rce_check(version, real_target = nil)
+    begin
+      gem_version = Gem::Version.new(version)
+    rescue ArgumentError
+      print_error("Invalid version format: `#{version}`. Please provide an existing Nagios XI version or use `unset VERSION` to cancel")
+      return Msf::Exploit::CheckCode::Unknown
+    end
+
+    cve_rce_hash = nagios_xi_rce_check(gem_version)
+
+    if cve_rce_hash.instance_of? Msf::Exploit::CheckCode
+      if real_target
+        print_error(cve_rce_hash.message)
+      else
+        print_error("Nagios XI version #{version} doesn't match any exploit modules.")
+      end
+      return cve_rce_hash
+    end
+
+    # adjust the output based on whether a version was provided, or we obtained a version from a target
+    if real_target
+      print_good("The target appears to be vulnerable to the following #{cve_rce_hash.length} exploit(s):")
+    else
+      print_good("Version #{version} matches the following #{cve_rce_hash.length} exploit(s):")
+    end
+
+    print_status('')
+    cve_rce_hash.each do |cve, exploit_module|
+      print_status("\t#{cve}\texploit/linux/http/#{exploit_module}")
+    end
+    print_status('')
+    return Msf::Exploit::CheckCode::Appears
+  end
+
+  # the first undercore in _target_Host was appended to stop RobuCop from flagging this line
+  def run_host(_target_host)
+    # check if we have a valid version to test
+    if version
+      if version.empty?
+        print_error('VERSION cannot be empty. Please provide an existing Nagios XI VERSION or use `unset VERSION` to cancel')
+        return Msf::Exploit::CheckCode::Unknown
+      end
+
+      return rce_check(version)
+    end
+
+    # check if we have credentials
+    if username.blank? || password.blank?
+      print_error('Please provide a valid Nagios XI USERNAME and PASSWORD, or a specific VERSION to check')
+      return Msf::Exploit::CheckCode::Unknown
+    end
+
+    # obtain cookies required for authentication
+    cookies = nagios_xi_login(username, password)
+    if cookies.instance_of? Msf::Exploit::CheckCode
+      print_error(cookies.message)
+      return cookies
+    end
+
+    # authenticate and obtain the Nagios XI version
+    print_good('Successfully authenticated to Nagios XI')
+    version = nagios_xi_version_index(cookies)
+    if version.instance_of? Msf::Exploit::CheckCode
+      print_error(version.message)
+      return version
+    end
+
+    print_status("Target is Nagios XI with version #{version}")
+
+    # check if the Nagios XI version matches any exploit modules
+    return rce_check(version, true)
+  end
+end

--- a/modules/auxiliary/scanner/http/nagios_xi_scanner.rb
+++ b/modules/auxiliary/scanner/http/nagios_xi_scanner.rb
@@ -93,7 +93,7 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     begin
-      gem_version = Gem::Version.new(clean_version)
+      gem_version = Rex::Version.new(clean_version)
     rescue ArgumentError
       print_error("Invalid version format: `#{version}`. Please provide an existing Nagios XI version or use `unset VERSION` to cancel")
       return

--- a/modules/auxiliary/scanner/http/nagios_xi_scanner.rb
+++ b/modules/auxiliary/scanner/http/nagios_xi_scanner.rb
@@ -114,8 +114,13 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     print_status('')
+    # get the length of the longest key, this is used to align the output when printing
+    max_key_length = 0
+    cve_rce_hash.each_key { |k| max_key_length = k.length if k.length > max_key_length }
+    # iterate over the hash, and print out the keys and values while using max_key_length to calculate the padding
     cve_rce_hash.each do |cve, exploit_module|
-      print_status("\t#{cve}\texploit/linux/http/#{exploit_module}")
+      padding = (max_key_length + 4) - cve.length
+      print_status("\t#{cve}#{' ' * padding}exploit/linux/http/#{exploit_module}")
     end
     print_status('')
     return

--- a/modules/auxiliary/scanner/http/nagios_xi_scanner.rb
+++ b/modules/auxiliary/scanner/http/nagios_xi_scanner.rb
@@ -129,8 +129,9 @@ class MetasploitModule < Msf::Auxiliary
       return Msf::Exploit::CheckCode::Unknown
     end
 
-    # obtain cookies required for authentication
-    login_result = nagios_xi_login(username, password, finish_install)
+    # use nagios_xi_login to try and authenticate
+    # if authentication succeeds, nagios_xi_login returns an array containing the http response body of a get request to index.php and the session cookies
+    login_result, _auth_cookies = nagios_xi_login(username, password, finish_install)
     if login_result.instance_of? Msf::Exploit::CheckCode
       print_error(login_result.message)
       return login_result
@@ -143,7 +144,7 @@ class MetasploitModule < Msf::Auxiliary
         return install_result
       end
 
-      login_result = login_after_install_or_license
+      login_result, _auth_cookies = login_after_install_or_license
       if login_result.instance_of? Msf::Exploit::CheckCode
         print_error(login_result.message)
         return login_result
@@ -164,7 +165,7 @@ class MetasploitModule < Msf::Auxiliary
         return sign_license_result
       end
 
-      login_result = login_after_install_or_license
+      login_result, _auth_cookies = login_after_install_or_license
       if login_result.instance_of? Msf::Exploit::CheckCode
         print_error(login_result.message)
         return login_result

--- a/modules/auxiliary/scanner/http/nagios_xi_scanner.rb
+++ b/modules/auxiliary/scanner/http/nagios_xi_scanner.rb
@@ -147,7 +147,7 @@ class MetasploitModule < Msf::Auxiliary
       print_status("Target is Nagios XI with version #{nagios_version_result}")
 
       # check if the Nagios XI version matches any exploit modules
-      return rce_check(nagios_version_result, true)
+      return rce_check(nagios_version_result, real_target: true)
     end
 
     # use nagios_xi_login to try and authenticate

--- a/modules/auxiliary/scanner/http/nagios_xi_scanner.rb
+++ b/modules/auxiliary/scanner/http/nagios_xi_scanner.rb
@@ -80,7 +80,7 @@ class MetasploitModule < Msf::Auxiliary
 
   end
 
-  def rce_check(version, real_target = nil)
+  def rce_check(version, real_target: false)
     version_type, clean_version = parse_version(version)
     if version_type == 'unsupported'
       print_error("Invalid version format: `#{version}`. Please provide an existing Nagios XI version or use `unset VERSION` to cancel")
@@ -121,7 +121,7 @@ class MetasploitModule < Msf::Auxiliary
     return
   end
 
-  # the first undercore in _target_Host was appended to stop RobuCop from flagging this line
+  # the first undercore in _target_host is used since this parameter is passed in by default but our code never uses it
   def run_host(_target_host)
     # check if we have a valid version to test
     if version
@@ -148,7 +148,6 @@ class MetasploitModule < Msf::Auxiliary
 
       # check if the Nagios XI version matches any exploit modules
       return rce_check(nagios_version_result, true)
-
     end
 
     # use nagios_xi_login to try and authenticate
@@ -209,6 +208,6 @@ class MetasploitModule < Msf::Auxiliary
     print_status("Target is Nagios XI with version #{nagios_version}")
 
     # check if the Nagios XI version matches any exploit modules
-    return rce_check(nagios_version, true)
+    rce_check(nagios_version, real_target: true)
   end
 end


### PR DESCRIPTION
## About
This change adds a new mixin for Nagios XI web applications to  `lib/msf/core/exploit/remote/http/nagios_xi`. It also adds an `auxiliary/scanner/http` module (and docs) that takes advantage of this mixin. The module detects the version of Nagios XI applications and suggests matching exploit modules based on the version number. It supports the following exploit modules.
- exploit/linux/http/nagios_xi_plugins_check_ping_authenticated_rce (CVE-2019-15949) #14701
- exploit/linux/http/nagios_xi_plugins_filename_authenticated_rce (CVE-2020-35578) #14700
- exploit/linux/http/nagios_xi_mibs_authenticated_rce (CVE-2020-5791) #14698
- exploit/linux/http/nagios_xi_snmptrap_authenticated_rce (CVE-2020-5792) #14699

## Vulnerable system
This depends on the specific exploit module, but probably most if not all Nagios XI versions between 5.4.0 and 5.8.0 are vulnerable to at least one exploit, and perhaps this goes for older versions as well.

## Verification Steps
- [x] Start msfconsole
- [x] Do: `use auxiliary/scanner/http/nagios_xi_scanner`
- [x] Do: `set RHOSTS [IP]`
- [x] Do: `set USERNAME [username for a valid Nagios XI account]`
- [x] Do: `set PASSWORD [password for a valid Nagios XI account]`
- [x] Do: `run`

## Options
### PASSWORD
The password for the Nagios XI account to authenticate with.
### TARGETURI
The base path to Nagios XI. The default value is `/nagiosxi/`.
### USERNAME
The username for the Nagios XI account to authenticate with. The default value is `nagiosadmin`.
### VERSION
The Nagios XI version to check against existing exploit modules. If this option is selected, the module will not probe the target, so it is not necessary to provide credentials.

## Scenarios
### Nagios XI 5.7.3 running on CentOS 7
```
msf6 auxiliary(scanner/http/nagios_xi_scanner) > show options 

Module options (auxiliary/scanner/http/nagios_xi_scanner):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   PASSWORD   nagiosadmin      no        Password to authenticate with
   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS     192.168.1.14     yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
   RPORT      80               yes       The target port (TCP)
   SSL        false            no        Negotiate SSL/TLS for outgoing connections
   TARGETURI  /nagiosxi/       yes       The base path to the NagiosXi application
   THREADS    1                yes       The number of concurrent threads (max one per host)
   USERNAME   nagiosadmin      no        Username to authenticate with
   VERSION                     no        Nagios XI version to check against existing exploit modules
   VHOST                       no        HTTP server virtual host

msf6 auxiliary(scanner/http/nagios_xi_scanner) > run

[+] Successfully authenticated to Nagios XI
[*] Target is Nagios XI with version 5.7.3
[+] The target appears to be vulnerable to the following 3 exploit(s):
[*] 
[*]     CVE-2020-35578  exploit/linux/http/nagios_xi_plugins_filename_authenticated_rce
[*]     CVE-2020-5791   exploit/linux/http/nagios_xi_mibs_authenticated_rce
[*]     CVE-2020-5792   exploit/linux/http/nagios_xi_snmptrap_authenticated_rce
[*] 
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```
### Nagios XI 5.7.9 version provided via VERSION
```
msf6 auxiliary(scanner/http/nagios_xi_scanner) > show options 

Module options (auxiliary/scanner/http/nagios_xi_scanner):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   PASSWORD                    no        Password to authenticate with
   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS     192.168.91.140   yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
   RPORT      80               yes       The target port (TCP)
   SSL        false            no        Negotiate SSL/TLS for outgoing connections
   TARGETURI  /nagiosxi/       yes       The base path to the NagiosXi application
   THREADS    1                yes       The number of concurrent threads (max one per host)
   USERNAME   nagiosadmin      no        Username to authenticate with
   VERSION    5.7.9            no        Nagios XI version to check against existing exploit modules
   VHOST                       no        HTTP server virtual host

msf6 auxiliary(scanner/http/nagios_xi_scanner) > run

[+] Version 5.7.9 matches the following 1 exploit(s):
[*] 
[*]     CVE-2020-35578  exploit/linux/http/nagios_xi_plugins_filename_authenticated_rce
[*] 
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```