### PR TITLE
Update bot label comments

### DIFF
--- a/.github/label-actions.yml
+++ b/.github/label-actions.yml
@@ -99,7 +99,10 @@ pulls:
 
 issues:
   actions:
+    # Termux issues are usually user error. However they may describe issues within modules/framework itself,
+    # and for this reason they are not closed automatically.
     termux:
+      close: false
       comment: |
         Termux is not officially supported. https://github.com/rapid7/metasploit-framework/issues/11023
 
@@ -110,17 +113,40 @@ issues:
         * https://wiki.termux.com/wiki/Metasploit_Framework
         * termux/termux-packages/issues/715
 
+    # Used for issues that have had low effort applied, haven't followed the issue template, and there's not enough
+    # information to warrant staying open
     needs-issue-template:
       close: true
       comment: |
-        When creating an issue, please ensure that the default issue template has been updated with the required details.
+        When creating an issue, please ensure that the default issue template has been updated with the required details:
+        https://github.com/rapid7/metasploit-framework/issues/new/choose
 
         Closing this issue. If you believe this issue has been closed in error, please provide any relevant output and logs which may be useful in diagnosing the issue.
 
+    # Used for issues that have attempted to provide some details, but more information is required. This can be
+    # useful for older issues, or issues that have been raised without following the issue template fully and have
+    # useful comments present that stop it from being closed outright.
+    needs-more-information:
+      close: false
+      comment: |
+        It looks like there's not enough information to replicate this issue. Please provide any relevant output and logs which may be useful in diagnosing the issue.
+
+        This includes:
+
+        - All of the item points within this [tempate](https://github.com/rapid7/metasploit-framework/blob/master/.github/ISSUE_TEMPLATE/bug_report.md)
+        - The result of the `debug` command in your Metasploit console
+        - Screenshots showing the issues you're having
+        - Exact replication steps
+
+        The easier it is for us to replicate and debug an issue means there's a higher chance of this issue being resolved.
+
+    # Used for issues that have zero effort applied, potentially bot related
+    # https://github.com/rapid7/metasploit-framework/pull/13280#issuecomment-616842090
     potato:
       close: true
       comment: |
-        When creating an issue, please ensure that the default issue template has been updated with the required details.
+        When creating an issue, please ensure that the default issue template has been updated with the required details:
+        https://github.com/rapid7/metasploit-framework/issues/new/choose
 
         Closing this issue. If you believe this issue has been closed in error, please provide any relevant output and logs which may be useful in diagnosing the issue.
 


### PR DESCRIPTION
This PR Improves the bot label's comments based on triaging sessions from the past few weeks.

At a high level it:
- Adds an additional `needs-more-information` label
- Updates `needs-issue-template`/`potato` with links to the issues selector page
- Adds comments clarifying some of the labels with their expected usage.