### PR TITLE
Update sqlite3 version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,6 @@ source 'https://rubygems.org'
 #   spec.add_runtime_dependency '<name>', [<version requirements>]
 gemspec name: 'metasploit-framework'
 
-gem 'sqlite3', '~>1.3.0'
-
 # separate from test as simplecov is not run on travis-ci
 group :coverage do
   # code coverage for tests

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -417,7 +417,7 @@ GEM
       rack (~> 2.2)
       rack-protection (= 2.1.0)
       tilt (~> 2.0)
-    sqlite3 (1.3.13)
+    sqlite3 (1.4.2)
     sshkey (2.0.0)
     swagger-blocks (3.0.0)
     thin (1.8.0)
@@ -467,7 +467,6 @@ DEPENDENCIES
   rubocop
   ruby-prof
   simplecov (= 0.18.2)
-  sqlite3 (~> 1.3.0)
   swagger-blocks
   timecop
   yard


### PR DESCRIPTION
Fixes SQLite3 deprecation warning:
> /usr/share/metasploit-framework/modules/post/windows/gather/enum_chrome.rb:144: warning: rb_check_safe_obj will be removed in Ruby 3.0

https://github.com/rapid7/metasploit-framework/issues/14666

## Verification

- Ensure that CI tests pass
- Ensure that metasploit-omnibus works
- Ensure that the `rb_check_safe_obj` warnings no longer appear