### PR TITLE
Fix missing vhost in rhost http url feature

### DIFF
--- a/lib/msf/core/opt_http_rhost_url.rb
+++ b/lib/msf/core/opt_http_rhost_url.rb
@@ -51,7 +51,7 @@ module Msf
       return unless datastore['RHOSTS']
       begin
         uri_type = datastore['SSL'] ? URI::HTTPS : URI::HTTP
-        uri = uri_type.build(host: datastore['RHOSTS'])
+        uri = uri_type.build(host: datastore['VHOST'] || datastore['RHOSTS'])
         uri.port = datastore['RPORT']
         # The datastore uses both `TARGETURI` and `URI` to denote the path of a URL, we try both here and fall back to `/`
         uri.path = (datastore['TARGETURI'] || datastore['URI'] || '/')

--- a/spec/lib/msf/core/opt_http_rhost_url_spec.rb
+++ b/spec/lib/msf/core/opt_http_rhost_url_spec.rb
@@ -25,8 +25,8 @@ RSpec.describe Msf::OptHTTPRhostURL do
       { expected_url: 'http://example.com', datastore: { 'RHOSTS' => 'example.com', 'RPORT' => 80, 'SSL' => false, 'TARGETURI' => '', 'URI' => '', 'VHOST' => 'example.com', 'HttpUsername' => '', 'HttpPassword' => '' } },
       { expected_url: 'https://example.com', datastore: { 'RHOSTS' => 'example.com', 'RPORT' => 443, 'SSL' => true, 'TARGETURI' => '', 'URI' => '', 'VHOST' => 'example.com', 'HttpUsername' => '', 'HttpPassword' => '' } },
       { expected_url: 'http://user:pass@example.com:1234/somePath', datastore: { 'RHOSTS' => 'example.com', 'RPORT' => 1234, 'SSL' => false, 'TARGETURI' => '/somePath', 'URI' => '/somePath', 'VHOST' => 'example.com', 'HttpUsername' => 'user', 'HttpPassword' => 'pass' } },
-      { expected_url: 'http://127.0.0.1', datastore: { 'RHOSTS' => '127.0.0.1', 'RPORT' => 80, 'SSL' => false, 'TARGETURI' => '', 'URI' => '', 'VHOST' => nil, 'HttpUsername' => '', 'HttpPassword' => '' } }
-    ].each do |test|
+      { expected_url: 'http://127.0.0.1', datastore: { 'RHOSTS' => '127.0.0.1', 'RPORT' => 80, 'SSL' => false, 'TARGETURI' => '', 'URI' => '', 'VHOST' => nil, 'HttpUsername' => '', 'HttpPassword' => '' } },
+      { expected_url: 'http://example.com', datastore: { 'RHOSTS' => '127.0.0.1', 'RPORT' => 80, 'SSL' => false, 'TARGETURI' => '', 'URI' => '', 'VHOST' => 'example.com', 'HttpUsername' => '', 'HttpPassword' => '' } }    ].each do |test|
       context test[:datastore].to_s do
         it "should return #{test[:expected_url]}" do
           expect(subject.calculate_value(test[:datastore])).to eq(test[:expected_url])


### PR DESCRIPTION
If this looks familiar it's because it's https://github.com/rapid7/metasploit-framework/pull/14609 but without the stuff that broke things! Apparently I was wrong when I said this: https://github.com/rapid7/metasploit-framework/pull/14609/files#r556578099
I definitely observed it being an IP address and apparently it can _sometimes_ be a domain name so let's leave it there for now

@adfoster-r7 noticed a bug where the `VHOST` datastore option was not being set correctly when using the `RHOST_HTTP_URL` option, this PR is to fix that particular issue

# Verification steps

- [ ] Start up msfconsole
- [ ] `set HTTPTRACE true`
- [ ] `features set RHOST_HTTP_URL true`
- [ ] `use exploit/multi/http/gitlab_file_read_rce`
- [ ] `set RHOST_HTTP_URL <http://example.com>` 
      - Targeting hackthebox laboratory box 10.10.10.216
      - Add `git.laboratory.htb` to your /etc/hosts:
- [ ] `set username foo`
- [ ] `set password foo`
- [ ] `run` the module
- [ ] With this fix you should see the `Host` header properly filled in with the domain name (on master this is not populated correctly)

Also verify that the `Host` header is still present when _not_ using the `RHOST_HTTP_URL` option https://github.com/rapid7/metasploit-framework/issues/14673

- [ ] `set HTTPTRACE true`
- [ ] `use auxiliary/gather/shodan_search`
- [ ] `set shodan_apikey 000000000000(example)`
- [ ] `set query ABCD`
- [ ] run
- [ ] `Host` header should be set