### PR TITLE
move cve-2020-29583 to a better file

### DIFF
--- a/data/wordlists/routers_userpass.txt
+++ b/data/wordlists/routers_userpass.txt
@@ -505,3 +505,4 @@ wradmin trancell
 write private
 xd xd
 xxx cascade
+zyfwp PrOw!aN_fXp

--- a/data/wordlists/unix_passwords.txt
+++ b/data/wordlists/unix_passwords.txt
@@ -1007,4 +1007,3 @@ arcsight
 MargaretThatcheris110%SEXY
 karaf
 vagrant
-PrOw!aN_fXp

--- a/data/wordlists/unix_users.txt
+++ b/data/wordlists/unix_users.txt
@@ -166,4 +166,3 @@ www-data
 xpdb
 xpopr
 zabbix
-zyfwp


### PR DESCRIPTION
https://github.com/rapid7/metasploit-framework/pull/14630#issuecomment-763025772

This PR moves the creds to the router userpass file where it is a MUCH better fit.