### PR TITLE
update WPVDB link type

### DIFF
--- a/documentation/modules/auxiliary/admin/http/wp_gdpr_compliance_privesc.md
+++ b/documentation/modules/auxiliary/admin/http/wp_gdpr_compliance_privesc.md
@@ -1,6 +1,6 @@
 ## Description
 
-This module exploits the [Wordpress GDPR compliance plugin](https://wordpress.org/plugins/wp-gdpr-compliance/) lack of validation ([WPVDB 9144](https://wpvulndb.com/vulnerabilities/9144)), which affects versions 1.4.2 and lower.
+This module exploits the [Wordpress GDPR compliance plugin](https://wordpress.org/plugins/wp-gdpr-compliance/) lack of validation ([WPVDB 9144](https://wpscan.com/vulnerability/9144)), which affects versions 1.4.2 and lower.
 
 When a user triggers GDPR-related actions, Wordpress's `admin-ajax.php` is called but fails to do validation and capacity checks regarding the asked actions. This leads to any unauthenticated user being able to modify any arbitrary settings on the targeted server.
 

--- a/lib/msf/core/module/reference.rb
+++ b/lib/msf/core/module/reference.rb
@@ -111,7 +111,7 @@ class Msf::Module::SiteReference < Msf::Module::Reference
     elsif in_ctx_id == 'ZDI'
       self.site = "http://www.zerodayinitiative.com/advisories/ZDI-#{in_ctx_val}"
     elsif in_ctx_id == 'WPVDB'
-      self.site = "https://wpvulndb.com/vulnerabilities/#{in_ctx_val}"
+      self.site = "https://wpscan.com/vulnerability/#{in_ctx_val}"
     elsif in_ctx_id == 'PACKETSTORM'
       self.site = "https://packetstormsecurity.com/files/#{in_ctx_val}"
     elsif in_ctx_id == 'URL'

--- a/tools/dev/msftidy.rb
+++ b/tools/dev/msftidy.rb
@@ -180,7 +180,7 @@ class Msftidy
         when 'ZDI'
           warn("Invalid ZDI reference") if value !~ /^\d{2}-\d{3,4}$/
         when 'WPVDB'
-          warn("Invalid WPVDB reference") if value !~ /^\d+$/
+          warn("Invalid WPVDB reference") if value !~ /^\d+$/ and value !~ /^[0-9a-fA-F]{8}-(?:[0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}?$/
         when 'PACKETSTORM'
           warn("Invalid PACKETSTORM reference") if value !~ /^\d+$/
         when 'URL'
@@ -195,6 +195,8 @@ class Msftidy
           elsif value =~ /^https?:\/\/www\.kb\.cert\.org\/vuls\/id\//
             warn("Please use 'US-CERT-VU' for '#{value}'")
           elsif value =~ /^https?:\/\/wpvulndb\.com\/vulnerabilities\//
+            warn("Please use 'WPVDB' for '#{value}'")
+          elsif value =~ /^https?:\/\/wpscan\.com\/vulnerability\//
             warn("Please use 'WPVDB' for '#{value}'")
           elsif value =~ /^https?:\/\/(?:[^\.]+\.)?packetstormsecurity\.(?:com|net|org)\//
             warn("Please use 'PACKETSTORM' for '#{value}'")

--- a/tools/modules/module_reference.rb
+++ b/tools/modules/module_reference.rb
@@ -35,7 +35,7 @@ def types
     'EDB'         => 'http://www.exploit-db.com/exploits/#{in_ctx_val}',
     'US-CERT-VU'  => 'http://www.kb.cert.org/vuls/id/#{in_ctx_val}',
     'ZDI'         => 'http://www.zerodayinitiative.com/advisories/ZDI-#{in_ctx_val}',
-    'WPVDB'       => 'https://wpvulndb.com/vulnerabilities/#{in_ctx_val}',
+    'WPVDB'       => 'https://wpscan.com/vulnerability/#{in_ctx_val}',
     'PACKETSTORM' => 'https://packetstormsecurity.com/files/#{in_ctx_val}',
     'URL'         => '#{in_ctx_val}'
   }


### PR DESCRIPTION
This PR updates the `WPVDB` link type.

We recently switched the main domain from `wpvulndb.com` to `wpscan.com`. Also vulnerability IDs are now also in GUID format for new vulns.

This PR changes the links to the new `wpscan.com` domain and also allows GUIDs in IDs in msftidy