### PR TITLE
Require rubocop for new modules

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,61 @@
+name: Lint
+
+on:
+  push:
+    branches-ignore:
+      - gh-pages
+      - metakitty
+  pull_request:
+    branches:
+      - '*'
+
+jobs:
+  msftidy:
+    runs-on: ubuntu-16.04
+    timeout-minutes: 40
+
+    strategy:
+      fail-fast: true
+      matrix:
+        ruby:
+          - 2.5
+
+    name: Lint msftidy
+    steps:
+      - name: Install system dependencies
+        run: sudo apt-get install libpcap-dev graphviz
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+        # Required to checkout HEAD^ and 3a046f01dae340c124dd3895e670983aef5fe0c5 for the msftidy script
+        # https://github.com/actions/checkout/tree/5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f#checkout-head
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+
+      - name: Setup bundler
+        run: |
+          gem install bundler
+
+      - uses: actions/cache@v2
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
+
+      - name: Bundle install
+        run: |
+          bundle config path vendor/bundle
+          bundle install --jobs 4 --retry 3
+        env:
+          BUNDLER_WITHOUT: coverage development pcap
+
+      - name: Run msftidy
+        run: |
+          ln -sf ../../tools/dev/pre-commit-hook.rb ./.git/hooks/post-merge
+          ls -la ./.git/hooks
+          ./.git/hooks/post-merge

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -67,10 +67,6 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@v2
-        # Required to checkout HEAD^ for the msftidy script
-        # https://github.com/actions/checkout/tree/5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f#checkout-head
-        with:
-          fetch-depth: 2
 
       - uses: actions/setup-ruby@v1
         with:
@@ -93,12 +89,6 @@ jobs:
           bundle install --jobs 4 --retry 3
         env:
           BUNDLER_WITHOUT: coverage development pcap
-
-      - name: Setup msftidy
-        run: |
-          ln -sf ../../tools/dev/pre-commit-hook.rb ./.git/hooks/post-merge
-          ls -la ./.git/hooks
-          ./.git/hooks/post-merge
 
       - name: Create database
         run: |

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,13 +4,14 @@
 # new modules.
 #
 # Updates to this file should include a 'Description' parameter for any
-# explaination needed.
+# explanation needed.
 
 # inherit_from: .rubocop_todo.yml
 
 AllCops:
   TargetRubyVersion: 2.5
   SuggestExtensions: false
+  NewCops: disable
 
 require:
   - ./lib/rubocop/cop/layout/module_hash_on_new_line.rb
@@ -196,6 +197,7 @@ Style/Documentation:
   Description: 'Most Metasploit modules do not have class documentation.'
   Exclude:
     - 'modules/**/*'
+    - 'spec/file_fixtures/modules/**/*'
 
 Layout/FirstArgumentIndentation:
   Enabled: true

--- a/spec/file_fixtures/modules/auxiliary/auxiliary_rubocopped.rb
+++ b/spec/file_fixtures/modules/auxiliary/auxiliary_rubocopped.rb
@@ -1,0 +1,21 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Rubocopped Auxiliary Module for RSpec',
+        'Description' => 'Test!',
+        'Author' => 'Unknown',
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['EDB', '48308']
+        ]
+      )
+    )
+  end
+end

--- a/spec/tools/dev/msftidy_runner_spec.rb
+++ b/spec/tools/dev/msftidy_runner_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+
+require Metasploit::Framework.root.join('tools/dev/msftidy.rb').to_path
+
+RSpec.describe MsftidyRunner do
+  context 'with a tidy auxiliary module' do
+    let(:auxiliary_tidy) { File.expand_path('modules/auxiliary/auxiliary_tidy.rb', FILE_FIXTURES_PATH) }
+    let(:msftidy) { described_class.new(auxiliary_tidy) }
+
+    before(:each) do
+      get_stdout do
+        msftidy.run_checks
+        @msftidy_status = msftidy.status
+      end
+    end
+
+    it 'returns zero (no warnings or errors)' do
+      expect(@msftidy_status).to be_zero
+    end
+  end
+
+  context 'with an untidy auxiliary module' do
+    let(:auxiliary_untidy) { File.expand_path('modules/auxiliary/auxiliary_untidy.rb', FILE_FIXTURES_PATH) }
+    let(:msftidy) { described_class.new(auxiliary_untidy) }
+
+    before(:each) do
+      @msftidy_stdout = get_stdout { msftidy.run_checks }
+    end
+
+    it 'ERRORs when invalid superclass' do
+      expect(@msftidy_stdout).to match(/ERROR.+Invalid super class for auxiliary module/)
+    end
+
+    it 'WARNINGs when specifying Rank' do
+      expect(@msftidy_stdout).to match(/WARNING.+Rank/)
+    end
+  end
+
+  context 'with a tidy payload module' do
+    let(:payload_tidy) { File.expand_path('modules/payloads/payload_tidy.rb', FILE_FIXTURES_PATH) }
+    let(:msftidy) { described_class.new(payload_tidy) }
+
+    before(:each) do
+      get_stdout do
+        msftidy.run_checks
+        @msftidy_status = msftidy.status
+      end
+    end
+
+    it 'returns zero (no warnings or errors)' do
+      expect(@msftidy_status).to be_zero
+    end
+  end
+end

--- a/spec/tools/dev/rubocop_runner_spec.rb
+++ b/spec/tools/dev/rubocop_runner_spec.rb
@@ -1,0 +1,79 @@
+require 'spec_helper'
+
+require Metasploit::Framework.root.join('tools/dev/msftidy.rb').to_path
+
+RSpec.describe RuboCopRunner do
+  # Metasploit globally sets `::Encoding.default_internal`, which
+  # breaks reading Rubocop's ability to load its default config file
+  # as UTF-8.
+  #
+  # Note that this is a test only issue, as msftidy runs in its own
+  # Ruby process and doesn't load Metasploit which causes this issue
+  def patch_io_read_encoding
+    original_read = IO.method(:read)
+    allow(IO).to receive(:read) do |absolute_path, **kwargs|
+      original_read.call(absolute_path, **kwargs.merge(encoding: ::Encoding.default_internal))
+    end
+  end
+
+  before(:each) do
+    patch_io_read_encoding
+  end
+
+  context 'with a tidy module' do
+    let(:file) { File.expand_path('modules/auxiliary/auxiliary_rubocopped.rb', FILE_FIXTURES_PATH) }
+
+    before(:each) do
+      allow(subject).to receive(:requires_rubocop?).and_return(true)
+      @stdout = get_stdout do
+        @status = subject.run(file)
+      end
+    end
+
+    it 'returns zero (no warnings or errors)' do
+      expect(@status).to be_zero
+    end
+
+    it 'contains no warnings' do
+      expect(@stdout).to match 'no offenses detected'
+    end
+  end
+
+  context 'with an untidy tidy module' do
+    let(:file) { File.expand_path('modules/exploits/existing_auto_target.rb', FILE_FIXTURES_PATH) }
+
+    before(:each) do
+      allow(subject).to receive(:requires_rubocop?).and_return(true)
+      @stdout = get_stdout do
+        @status = subject.run(file)
+      end
+    end
+
+    it 'returns zero (no warnings or errors)' do
+      expect(@status).to_not be_zero
+    end
+
+    it 'contains no warnings' do
+      expect(@stdout).to match 'Rubocop failed'
+    end
+  end
+
+  context 'with an untidy module that is marked as too old for requiring linting' do
+    let(:file) { File.expand_path('modules/exploits/existing_auto_target.rb', FILE_FIXTURES_PATH) }
+
+    before(:each) do
+      allow(subject).to receive(:requires_rubocop?).and_return(false)
+      @stdout = get_stdout do
+        @status = subject.run(file)
+      end
+    end
+
+    it 'returns zero (no warnings or errors)' do
+      expect(@status).to be_zero
+    end
+
+    it 'contains no warnings' do
+      expect(@stdout).to be_empty
+    end
+  end
+end

--- a/tools/dev/pre-commit-hook.rb
+++ b/tools/dev/pre-commit-hook.rb
@@ -75,11 +75,11 @@ if files_to_check.empty?
 else
   puts "--- Checking new and changed module syntax with tools/dev/msftidy.rb ---"
   files_to_check.each do |fname|
-    cmd = "ruby ./tools/dev/msftidy.rb  #{fname}"
-    msftidy_output= %x[ #{cmd} ]
+    command = "bundle exec ruby ./tools/dev/msftidy.rb #{fname}"
+    msftidy_output, status = ::Open3.capture2(command)
+    valid = false unless status.success?
     puts "#{fname} - msftidy check passed" if msftidy_output.empty?
     msftidy_output.each_line do |line|
-      valid = false unless line['INFO']
       puts line
     end
   end


### PR DESCRIPTION
Note that the rubocop file change is from https://github.com/rapid7/metasploit-framework/pull/14733 - once that is landed, this will be rebased and the commit will no longer appear in this PR

This PR require Rubocop to pass for new modules as part of our CI setup

**Note** - Once merged PR is merged it may cause issues for old pull requests that get landed after the fact. It could make sense to merge this when there are less pull requests in flight, or force all inflight pull requests to rebase.

## Verification

I am testing these scenarios:

- Ensure that a very old module doesn't require being rubocopped - to avoid noisey pull requests for bug fixes. In an ideal world contributors could put up a pre-requisite PR for purely running rubocop, then a separate PR for any bug fixes - or two commits. It's unlikely this would happen though.
- Ensure that a newly created module requires being rubocop
- Ensure that modifying a recently created module requires rubocop to pass
- Ensure that the previous msftidy semantics are enforced and honored

Example of the Github Actions screen:

![image](https://user-images.githubusercontent.com/60357436/107513715-87126080-6ba0-11eb-8232-6f73d50f48aa.png)

![image](https://user-images.githubusercontent.com/60357436/107512221-6f39dd00-6b9e-11eb-92f0-038686c688d7.png)

