### PR TITLE
Fix a target version discrepancy in the CVE-2020-17132 docs

### DIFF
--- a/documentation/modules/exploit/windows/http/exchange_ecp_dlp_policy.md
+++ b/documentation/modules/exploit/windows/http/exchange_ecp_dlp_policy.md
@@ -36,7 +36,7 @@ Follow [Setup](#setup) and [Scenarios](#scenarios).
 
 ### 0
 
-`Exchange Server <= 2016 CU19 and 2019 CU6`
+`Exchange Server <= 2016 CU19 and 2019 CU8`
 
 ## Options
 


### PR DESCRIPTION
This fixes a simple target version discrepancy for the CVE-2020-17132 exploit that [@wvu-r7](https://github.com/rapid7/metasploit-framework/pull/14607/files#r574862912) pointed out in the module docs.

I'll land it myself once the unit tests pass.