### PR TITLE
Fix usage of `Failure::` constant

### DIFF
--- a/lib/msf/core/auxiliary/mqtt.rb
+++ b/lib/msf/core/auxiliary/mqtt.rb
@@ -24,11 +24,11 @@ module Msf
       end
 
       def setup
-        fail_with(Failure::BadConfig, 'READ_TIMEOUT must be > 0') if read_timeout <= 0
+        fail_with(Msf::Exploit::Failure::BadConfig, 'READ_TIMEOUT must be > 0') if read_timeout <= 0
 
         client_id_arg = datastore['CLIENT_ID']
         if client_id_arg && client_id_arg.blank?
-          fail_with(Failure::BadConfig, 'CLIENT_ID must be a non-empty string')
+          fail_with(Msf::Exploit::Failure::BadConfig, 'CLIENT_ID must be a non-empty string')
         end
       end
 

--- a/lib/msf/core/exploit.rb
+++ b/lib/msf/core/exploit.rb
@@ -284,7 +284,7 @@ class Exploit < Msf::Module
     self.successful = false
     self.session_count = 0
     self.active_timeout = 120
-    self.fail_reason = Failure::None
+    self.fail_reason = Msf::Exploit::Failure::None
 
     if (info['Payload'] and info['Payload']['ActiveTimeout'])
       self.active_timeout = info['Payload']['ActiveTimeout'].to_i

--- a/lib/msf/core/exploit/remote/zeromq.rb
+++ b/lib/msf/core/exploit/remote/zeromq.rb
@@ -38,11 +38,11 @@ module Msf::Exploit::Remote::ZeroMQ
     print_status('Negotiating signature')
 
     unless (res = sock.get_once)
-      fail_with(Failure::Unknown, 'Did not receive signature')
+      fail_with(Msf::Exploit::Failure::Unknown, 'Did not receive signature')
     end
 
     unless res == ZEROMQ_SIGNATURE
-      fail_with(Failure::UnexpectedReply,
+      fail_with(Msf::Exploit::Failure::UnexpectedReply,
                 "Received invalid signature: #{res.inspect}")
     end
 
@@ -56,11 +56,11 @@ module Msf::Exploit::Remote::ZeroMQ
     print_status('Negotiating version')
 
     unless (res = sock.get_once)
-      fail_with(Failure::Unknown, 'Did not receive version')
+      fail_with(Msf::Exploit::Failure::Unknown, 'Did not receive version')
     end
 
     unless res == ZEROMQ_VERSION
-      fail_with(Failure::UnexpectedReply,
+      fail_with(Msf::Exploit::Failure::UnexpectedReply,
                 "Received incompatible version: #{res.inspect}")
     end
 
@@ -74,12 +74,12 @@ module Msf::Exploit::Remote::ZeroMQ
     print_status("Negotiating #{mechanism} security mechanism")
 
     unless (res = sock.get_once)
-      fail_with(Failure::Unknown, 'Did not receive security mechanism')
+      fail_with(Msf::Exploit::Failure::Unknown, 'Did not receive security mechanism')
     end
 
     unless res.include?(mechanism)
       fail_with(
-        Failure::UnexpectedReply,
+        Msf::Exploit::Failure::UnexpectedReply,
         "Did not receive #{mechanism} security mechanism: #{res.inspect}"
       )
     end
@@ -104,12 +104,12 @@ module Msf::Exploit::Remote::ZeroMQ
     )
 
     unless (res = sock.get_once)
-      fail_with(Failure::Unknown, 'Did not receive READY reply')
+      fail_with(Msf::Exploit::Failure::Unknown, 'Did not receive READY reply')
     end
 
     unless res.match(/READY.+Socket-Type.+#{server}.+Identity/m)
       fail_with(
-        Failure::UnexpectedReply,
+        Msf::Exploit::Failure::UnexpectedReply,
         "Did not receive READY reply of type #{server}: #{res.inspect}"
       )
     end

--- a/lib/msf/core/exploit/sqli/sqlitei/time_based_blind.rb
+++ b/lib/msf/core/exploit/sqli/sqlitei/time_based_blind.rb
@@ -49,7 +49,7 @@ class Msf::Exploit::SQLi::SQLitei::TimeBasedBlind < Msf::Exploit::SQLi::SQLitei:
       @heavyquery_parameter *= 2
       max_tries -= 1
       if max_tries == 0
-        fail_with Failure::Unknown, 'Could not detect the heavyquery parameter after 100 tries'
+        fail_with Msf::Exploit::Failure::Unknown, 'Could not detect the heavyquery parameter after 100 tries'
       end
     end
     @heavyquery_parameter = @heavyquery_parameter * 3 / 2 # for safety


### PR DESCRIPTION
Resolves #14724 

Replaces all usages of `Failure::` outside of the modules with the full constant name since it doesn't resolve correctly unless you do this

Previously:
```
[!] [2021.02.12-14:40:57] You are binding to a loopback address by setting LHOST to 127.0.0.1. Did you want ReverseListenerBindAddress?
[*] [2021.02.12-14:40:58] Started HTTPS reverse handler on https://127.0.0.1:8443
[*] [2021.02.12-14:40:58] 216.58.210.46:443 - Using auxiliary/gather/saltstack_salt_root_key as check
[*] [2021.02.12-14:40:58] 216.58.210.46:443 - Connecting to ZeroMQ service at 216.58.210.46:443
[*] [2021.02.12-14:40:58] 216.58.210.46:443 - Negotiating signature
[-] [2021.02.12-14:41:08] 216.58.210.46:443 - Auxiliary failed: NameError uninitialized constant Msf::Exploit::Remote::ZeroMQ::Failure
[-] [2021.02.12-14:41:09] 216.58.210.46:443 - Call stack:
[-] [2021.02.12-14:41:09] 216.58.210.46:443 -   /home/dwelch/dev/metasploit-framework/lib/msf/core/exploit/remote/zeromq.rb:41:in `zmq_negotiate_signature'
[-] [2021.02.12-14:41:09] 216.58.210.46:443 -   /home/dwelch/dev/metasploit-framework/lib/msf/core/exploit/remote/zeromq.rb:31:in `zmq_negotiate'
[-] [2021.02.12-14:41:09] 216.58.210.46:443 -   /home/dwelch/dev/metasploit-framework/modules/auxiliary/gather/saltstack_salt_root_key.rb:65:in `run'
[*] [2021.02.12-14:41:09] 216.58.210.46:443 - Connecting to ZeroMQ service at 216.58.210.46:443
```

Now:
```
[!] [2021.02.12-14:40:09] You are binding to a loopback address by setting LHOST to 127.0.0.1. Did you want ReverseListenerBindAddress?
[*] [2021.02.12-14:40:09] Started HTTPS reverse handler on https://127.0.0.1:8443
[*] [2021.02.12-14:40:09] 216.58.210.46:443 - Using auxiliary/gather/saltstack_salt_root_key as check
[*] [2021.02.12-14:40:09] 216.58.210.46:443 - Connecting to ZeroMQ service at 216.58.210.46:443
[*] [2021.02.12-14:40:09] 216.58.210.46:443 - Negotiating signature
[-] [2021.02.12-14:40:19] 216.58.210.46:443 - Auxiliary aborted due to failure: unknown: Did not receive signature
[*] [2021.02.12-14:40:19] 216.58.210.46:443 - Connecting to ZeroMQ service at 216.58.210.46:443
```

# Verification steps
- [ ] `use exploit/linux/misc/saltstack_salt_unauth_rce`
- [ ] `set LHOST 127.0.0.1`
- [ ] `set RHOST google.com`
- [ ] `run`