### PR TITLE
Fix Auxiliary::AuthBrute when using DB_ALL_USERS and DB_ALL_PASS options

### DIFF
--- a/lib/msf/core/auxiliary/auth_brute.rb
+++ b/lib/msf/core/auxiliary/auth_brute.rb
@@ -333,12 +333,12 @@ module Auxiliary::AuthBrute
         end
       end
       if datastore['DB_ALL_USERS']
-        framework.db.creds(workspace: myworkspace.name).creds.each do |o|
+        framework.db.creds(workspace: myworkspace.name).each do |o|
           users << o.public.username if o.public
         end
       end
       if datastore['DB_ALL_PASS']
-        framework.db.creds(workspace: myworkspace.name).creds.each do |o|
+        framework.db.creds(workspace: myworkspace.name).each do |o|
           passwords << o.private.data if o.private && o.private.type =~ /password/i
         end
       end


### PR DESCRIPTION
The `Auxiliary::AuthBrute` module breaks when calling `build_credentials_array` with the either `DB_ALL_USERS` or `DB_ALL_PASS` options set. These options tell the scanner to also use usernames or passwords already present in the database.

This can be triggered by using the `scanner/http/wordpress_login_enum` auxiliary module with a username already set in the database:

### Before this fix:

```
msf6 auxiliary(scanner/http/wordpress_login_enum) > creds
Credentials
===========

host       origin     service          public  private  realm  private_type  JtR Format
----       ------     -------          ------  -------  -----  ------------  ----------
127.0.0.1  127.0.0.1  8080/tcp (http)  test1
msf6 auxiliary(scanner/http/wordpress_login_enum) > options

Module options (auxiliary/scanner/http/wordpress_login_enum):

   Name                 Current Setting  Required  Description
   ----                 ---------------  --------  -----------
   BLANK_PASSWORDS      false            no        Try blank passwords for all users
   BRUTEFORCE           true             yes       Perform brute force authentication
   BRUTEFORCE_SPEED     5                yes       How fast to bruteforce, from 0 to 5
   DB_ALL_CREDS         false            no        Try each user/password couple stored in the current database
   DB_ALL_PASS          false            no        Add all passwords in the current database to the list
   DB_ALL_USERS         true             no        Add all users in the current database to the list
   ENUMERATE_USERNAMES  true             yes       Enumerate usernames
   PASSWORD                              no        A specific password to authenticate with
   PASS_FILE                             no        File containing passwords, one per line
   Proxies                               no        A proxy chain of format type:host:port[,type:host:port][...]
   RANGE_END            10               no        Last user id to enumerate
   RANGE_START          1                no        First user id to enumerate
   RHOSTS               127.0.0.1        yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
   RPORT                8000             yes       The target port (TCP)
   SSL                  false            no        Negotiate SSL/TLS for outgoing connections
   STOP_ON_SUCCESS      false            yes       Stop guessing when a credential works for a host
   TARGETURI            /                yes       The base path to the wordpress application
   THREADS              1                yes       The number of concurrent threads (max one per host)
   USERNAME                              no        A specific username to authenticate as
   USERPASS_FILE                         no        File containing users and passwords separated by space, one pair per line
   USER_AS_PASS         false            no        Try the username as the password for all users
   USER_FILE                             no        File containing usernames, one per line
   VALIDATE_USERS       true             yes       Validate usernames
   VERBOSE              true             yes       Whether to print output for all attempts
   VHOST                                 no        HTTP server virtual host

msf6 auxiliary(scanner/http/wordpress_login_enum) > run

[*] / - WordPress Version 4.2.4 detected
[*] 127.0.0.1:8000 - / - WordPress User-Enumeration - Running User Enumeration
[*] 127.0.0.1:8000 - / - WordPress User-Validation - Running User Validation
[-] Auxiliary failed: NoMethodError undefined method `creds' for #<Array:0x00007f9fe12a38b0>
[-] Call stack:
[-]   /Users/cdelafuente/dev/src/metasploit-framework/lib/msf/core/auxiliary/auth_brute.rb:336:in `build_credentials_array'
[-]   /Users/cdelafuente/dev/src/metasploit-framework/lib/msf/core/auxiliary/auth_brute.rb:198:in `each_user_pass'
[-]   /Users/cdelafuente/dev/src/metasploit-framework/modules/auxiliary/scanner/http/wordpress_login_enum.rb:63:in `run_host'
[-]   /Users/cdelafuente/dev/src/metasploit-framework/lib/msf/core/auxiliary/scanner.rb:120:in `block (2 levels) in run'
[-]   /Users/cdelafuente/dev/src/metasploit-framework/lib/msf/core/thread_manager.rb:105:in `block in spawn'
[*] Auxiliary module execution completed
```

### After this fix:

```
msf6 auxiliary(scanner/http/wordpress_login_enum) > creds
Credentials
===========

host       origin     service          public  private  realm  private_type  JtR Format
----       ------     -------          ------  -------  -----  ------------  ----------
127.0.0.1  127.0.0.1  8080/tcp (http)  test1
msf6 auxiliary(scanner/http/wordpress_login_enum) > options

Module options (auxiliary/scanner/http/wordpress_login_enum):

   Name                 Current Setting  Required  Description
   ----                 ---------------  --------  -----------
   BLANK_PASSWORDS      false            no        Try blank passwords for all users
   BRUTEFORCE           true             yes       Perform brute force authentication
   BRUTEFORCE_SPEED     5                yes       How fast to bruteforce, from 0 to 5
   DB_ALL_CREDS         false            no        Try each user/password couple stored in the current database
   DB_ALL_PASS          false            no        Add all passwords in the current database to the list
   DB_ALL_USERS         true             no        Add all users in the current database to the list
   ENUMERATE_USERNAMES  true             yes       Enumerate usernames
   PASSWORD                              no        A specific password to authenticate with
   PASS_FILE                             no        File containing passwords, one per line
   Proxies                               no        A proxy chain of format type:host:port[,type:host:port][...]
   RANGE_END            10               no        Last user id to enumerate
   RANGE_START          1                no        First user id to enumerate
   RHOSTS               127.0.0.1        yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
   RPORT                8000             yes       The target port (TCP)
   SSL                  false            no        Negotiate SSL/TLS for outgoing connections
   STOP_ON_SUCCESS      false            yes       Stop guessing when a credential works for a host
   TARGETURI            /                yes       The base path to the wordpress application
   THREADS              1                yes       The number of concurrent threads (max one per host)
   USERNAME                              no        A specific username to authenticate as
   USERPASS_FILE                         no        File containing users and passwords separated by space, one pair per line
   USER_AS_PASS         false            no        Try the username as the password for all users
   USER_FILE                             no        File containing usernames, one per line
   VALIDATE_USERS       true             yes       Validate usernames
   VERBOSE              true             yes       Whether to print output for all attempts
   VHOST                                 no        HTTP server virtual host

msf6 auxiliary(scanner/http/wordpress_login_enum) > run

[*] / - WordPress Version 4.2.4 detected
[*] 127.0.0.1:8000 - / - WordPress User-Enumeration - Running User Enumeration
[*] 127.0.0.1:8000 - / - WordPress User-Validation - Running User Validation
[*] / - WordPress User-Validation - Checking Username:'test1'
[-] 127.0.0.1:8000 - [1/1] - / - WordPress User-Validation - Invalid Username: 'test1'
[*] 127.0.0.1:8000 - [2/1] - / - WordPress Brute Force - Running Bruteforce
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use modules/auxiliary/scanner/http/wordpress_login_enum.rb`
- [ ] **Verify** there is at least one username in the database with the `creds` command
- [ ] `set DB_ALL_USERS true`
- [ ] `set RHOSTS <IP>`
- [ ] `set RPORT <port>`
- [ ] `run`
- [ ] **Verify** it breaks on master
- [ ] **Verify** it doesn't break with this fix
