### PR TITLE
msftidy: Fix exploit module checks for author and stack buffer overflow

### DIFF
--- a/modules/exploits/linux/http/netgear_wnr2000_rce.rb
+++ b/modules/exploits/linux/http/netgear_wnr2000_rce.rb
@@ -13,9 +13,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'NETGEAR WNR2000v5 (Un)authenticated hidden_lang_avi Stack Overflow',
+      'Name'           => 'NETGEAR WNR2000v5 (Un)authenticated hidden_lang_avi Stack Buffer Overflow',
       'Description'    => %q{
-        The NETGEAR WNR2000 router has a buffer overflow vulnerability in the hidden_lang_avi
+        The NETGEAR WNR2000 router has a stack buffer overflow vulnerability in the hidden_lang_avi
         parameter.
         In order to exploit it, it is necessary to guess the value of a certain timestamp which
         is in the configuration of the router. An authenticated attacker can simply fetch this

--- a/modules/exploits/osx/local/nfs_mount_root.rb
+++ b/modules/exploits/osx/local/nfs_mount_root.rb
@@ -15,7 +15,7 @@ class MetasploitModule < Msf::Exploit::Local
     super(update_info(info,
       'Name'          => 'Mac OS X NFS Mount Privilege Escalation Exploit',
       'Description'   => %q{
-        This exploit leverages a stack overflow vulnerability to escalate privileges.
+        This exploit leverages a stack buffer overflow vulnerability to escalate privileges.
         The vulnerable function nfs_convert_old_nfs_args does not verify the size
         of a user-provided argument before copying it to the stack. As a result, by
         passing a large size as an argument, a local user can overwrite the stack with arbitrary

--- a/modules/exploits/windows/fileformat/ms_visual_basic_vbp.rb
+++ b/modules/exploits/windows/fileformat/ms_visual_basic_vbp.rb
@@ -12,7 +12,7 @@ class MetasploitModule < Msf::Exploit::Remote
     super(update_info(info,
       'Name'           => 'Microsoft Visual Basic VBP Buffer Overflow',
       'Description'    => %q{
-          This module exploits a stack overflow in Microsoft Visual
+        This module exploits a stack buffer overflow in Microsoft Visual
         Basic 6.0. When a specially crafted vbp file containing a long
         reference line, an attacker may be able to execute arbitrary
         code.

--- a/modules/exploits/windows/misc/plugx.rb
+++ b/modules/exploits/windows/misc/plugx.rb
@@ -11,9 +11,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'PlugX Controller Stack Overflow',
+      'Name'           => 'PlugX Controller Stack Buffer Overflow',
       'Description'    => %q{
-          This module exploits a Stack buffer overflow in the PlugX Controller (C2 server)
+        This module exploits a stack buffer overflow in the PlugX Controller (C2 server).
       },
       'Author'         => 'Professor Plum',
       'License'        => MSF_LICENSE,

--- a/tools/dev/msftidy.rb
+++ b/tools/dev/msftidy.rb
@@ -484,7 +484,7 @@ class Msftidy
   def check_bad_terms
     # "Stack overflow" vs "Stack buffer overflow" - See explanation:
     # http://blogs.technet.com/b/srd/archive/2009/01/28/stack-overflow-stack-exhaustion-not-the-same-as-stack-buffer-overflow.aspx
-    if @module_type == 'exploit' && @source.gsub("\n", "") =~ /stack[[:space:]]+overflow/i
+    if @module_type == 'exploits' && @source.gsub("\n", "") =~ /stack[[:space:]]+overflow/i
       warn('Contains "stack overflow" You mean "stack buffer overflow"?')
     elsif @module_type == 'auxiliary' && @source.gsub("\n", "") =~ /stack[[:space:]]+overflow/i
       warn('Contains "stack overflow" You mean "stack exhaustion"?')
@@ -725,7 +725,7 @@ class Msftidy
   #
   def check_author
     # Only the three common module types have a consistently defined info hash
-    return unless %w[exploit auxiliary post].include?(@module_type)
+    return unless %w[exploits auxiliary post].include?(@module_type)
 
     unless @source =~ /["']Author["'][[:space:]]*=>/
       error('Missing "Author" info, please add')


### PR DESCRIPTION
The `module_type` for exploit modules is `exploits` (not `exploit`). This was causing some checks to be missed.

This PR fixes the checks and resolves the warnings subsequently raised by these checks.

```
$ ./tools/dev/msftidy.rb modules/exploits/ | grep Author
$ ./tools/dev/msftidy.rb modules/exploits/ | grep overflow
modules/exploits/linux/http/netgear_wnr2000_rce.rb - [WARNING] Contains "stack overflow" You mean "stack buffer overflow"?
modules/exploits/osx/local/nfs_mount_root.rb - [WARNING] Contains "stack overflow" You mean "stack buffer overflow"?
modules/exploits/windows/fileformat/ms_visual_basic_vbp.rb - [WARNING] Contains "stack overflow" You mean "stack buffer overflow"?
modules/exploits/windows/fileformat/nuance_pdf_launch_overflow.rb - [INFO] No CVE references found. Please check before you land!
modules/exploits/windows/misc/plugx.rb - [WARNING] Contains "stack overflow" You mean "stack buffer overflow"?
```