### PR TITLE
Adds fix for msfdb issues on Ubuntu

### DIFF
--- a/msfdb
+++ b/msfdb
@@ -47,6 +47,8 @@ require 'msfenv'
 @components = %w(database webservice)
 @environments = %w(production development)
 
+ENV['PATH'] = "/usr/lib/postgresql/12/bin:#{ENV['PATH']}"
+
 @options = {
     component: :all,
     debug: false,


### PR DESCRIPTION
This PR resolves #12098. 

`ENV['PATH'] = "/usr/lib/postgresql/12/bin:#{ENV['PATH']}"` has been added into the `msfdb` script, this sets postgresql to be included within `$PATH`. Prior to this change, this was something Ubuntu users had required to do manually as a fix.

The user will also have to run `sudo adduser {your-user-name} postgres` to add themselves as a user for the postgres group. So I plan to make some changes to the [wiki](https://github.com/rapid7/metasploit-framework/wiki/Setting-Up-a-Metasploit-Development-Environment#optional-set-up-the-rest-api-and-postgresql-database) to step users through setting that up. I have added a mock for the wiki below.

### Before 
![image](https://user-images.githubusercontent.com/69522014/107961690-28812400-6f9e-11eb-90ed-092c393608ab.png)


### After
![image](https://user-images.githubusercontent.com/69522014/107961593-04bdde00-6f9e-11eb-861d-1f5a195aaa2e.png)


## Mock wiki update
I think adding the following in as a third step makes sense.

![image](https://user-images.githubusercontent.com/69522014/107959983-fa024980-6f9b-11eb-8337-ba0449c1d96a.png)


## Environment
For testing I used a fresh Ubuntu VM and installed Metasploit via Git clone. **_Do not use the omnibus installer_**, as this bug is not present in that installation method as postgres comes embedded. 
Once I had Metasploit cloned I just followed the [wiki](https://github.com/rapid7/metasploit-framework/wiki/Setting-Up-a-Metasploit-Development-Environment#optional-set-up-the-rest-api-and-postgresql-database) to get everything set-up. Once you have verified you're getting the original error. 
Then add my change via `vim` and ensure the error is gone and `./msfdb init` runs successfully. 
There may be smarter ways to test this, but thought I'd mention my method. 

Add the following code:
```ruby
ENV['PATH'] = "/usr/lib/postgresql/12/bin:#{ENV['PATH']}"
```
into the following file, at `line 50`: 
```bash
metasploit-framework/msfdb
```

## Verification

List the steps needed to make sure this thing works

- [ ] Git clone Metasploit onto a Ubuntu VM
- [ ] Follow the [wiki](https://github.com/rapid7/metasploit-framework/wiki/Setting-Up-a-Metasploit-Development-Environment#optional-set-up-the-rest-api-and-postgresql-database) to get everything set-up
- [ ] Verify your getting the original error
- [ ] Add in the fix describe above in `Environment` section
- [ ] Verify you can run `./msfdb init` without receiving any errors.
