### PR TITLE
Ignore Rubocop ExtraSpacing rules for BinData objects

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,6 +15,7 @@ AllCops:
 require:
   - ./lib/rubocop/cop/layout/module_hash_on_new_line.rb
   - ./lib/rubocop/cop/layout/module_description_indentation.rb
+  - ./lib/rubocop/cop/layout/extra_spacing_with_bindata_ignored.rb
   - ./lib/rubocop/cop/lint/module_disclosure_date_format.rb
   - ./lib/rubocop/cop/lint/module_disclosure_date_present.rb
 
@@ -277,7 +278,7 @@ Layout/EmptyLinesAroundMethodBody:
   Enabled: false
   Description: 'these are used to increase readability'
 
-Layout/ExtraSpacing:
+Layout/ExtraSpacingWithBinDataIgnored:
   Description: 'Do not use unnecessary spacing.'
   Enabled: true
   # When true, allows most uses of extra spacing if the intent is to align

--- a/lib/rubocop/cop/layout/extra_spacing_with_bindata_ignored.rb
+++ b/lib/rubocop/cop/layout/extra_spacing_with_bindata_ignored.rb
@@ -1,0 +1,30 @@
+module RuboCop
+  module Cop
+    module Layout
+      class ExtraSpacingWithBinDataIgnored < ExtraSpacing
+
+        def_node_matcher :bindata?, <<~PATTERN
+          (class _ (const (const _ :BinData) _) _)
+        PATTERN
+
+        # Returns an array of ranges that should not be reported.
+        #
+        # Note that BinData classes are skipped in their entirety, as
+        # these frequently have custom whitespace alignment to improve
+        # readability.
+        def ignored_ranges(ast)
+          return [] unless ast
+          return @ignored_ranges if @ignored_ranges
+
+          ignored_bindata_ranges = on_node(:class, ast).map do |clazz|
+            next unless bindata?(clazz)
+
+            clazz.source_range.begin_pos..clazz.source_range.end_pos
+          end.compact
+
+          @ignored_ranges = super + ignored_bindata_ranges
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/layout/extra_spacing_with_bindata_ignored_spec.rb
+++ b/spec/rubocop/cop/layout/extra_spacing_with_bindata_ignored_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'rubocop/cop/layout/extra_spacing_with_bindata_ignored'
+
+RSpec.describe RuboCop::Cop::Layout::ExtraSpacingWithBinDataIgnored do
+  subject(:cop) { described_class.new(config) }
+  let(:config) do
+    RuboCop::Config.new(
+      'Layout/ExtraSpacingWithBinDataIgnored' => {
+        'AllowForAlignment' => false,
+        'AllowBeforeTrailingComments' => true,
+        'ForceEqualSignAlignment' => false
+      }
+    )
+  end
+
+  it 'registers an offense and corrects alignment' do
+    expect_offense(<<~RUBY)
+      uint8    :foo
+           ^^^ Unnecessary spacing detected.
+      uint16   :bar
+            ^^ Unnecessary spacing detected.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      uint8 :foo
+      uint16 :bar
+    RUBY
+  end
+
+  it 'ignores offenses within BinData objects' do
+    expect_no_offenses(<<~RUBY)
+      class Foo < BinData::Record
+        uint8    :foo
+        uint16   :bar
+      end
+
+      class Bar < BinData::Array
+        BAR_SUCCESS           = 0x0001
+        BAR_SOME_FLAG         = 0x0010
+
+        choice                   :member_value, selection: -> { selection_routine(index) } do
+          record                  Types::Record
+          boolean                 Enums::PrimitiveTypeEnum[:Boolean]
+          uint8                   Enums::PrimitiveTypeEnum[:Byte]
+          #???                    Enums::PrimitiveTypeEnum[:Char] # todo: implement this primitive type
+          length_prefixed_string  Enums::PrimitiveTypeEnum[:Decimal]
+          double                  Enums::PrimitiveTypeEnum[:Double]
+          int16                   Enums::PrimitiveTypeEnum[:Int16]
+          int32                   Enums::PrimitiveTypeEnum[:Int32]
+          int64                   Enums::PrimitiveTypeEnum[:Int64]
+          int8                    Enums::PrimitiveTypeEnum[:SByte]
+          float                   Enums::PrimitiveTypeEnum[:Single]
+          int64                   Enums::PrimitiveTypeEnum[:TimeSpan]
+          date_time               Enums::PrimitiveTypeEnum[:DateTime]
+          uint16                  Enums::PrimitiveTypeEnum[:UInt16]
+          uint32                  Enums::PrimitiveTypeEnum[:UInt32]
+          uint64                  Enums::PrimitiveTypeEnum[:UInt64]
+          null                    Enums::PrimitiveTypeEnum[:Null]
+          length_prefixed_string  Enums::PrimitiveTypeEnum[:String]
+        end
+      end
+    RUBY
+  end
+end


### PR DESCRIPTION
This PR adds support for ignoring Rubocop's ExtraSpacing rules for BinData objects. I think this will be the easiest approach to minimalize the impact of introducing Rubocop.

Note, I have also created the issue https://github.com/rubocop-hq/rubocop/issues/9518 as a feature request.

## Verification

### Master

Rubocop enforces the removal of the additional whitespace within BinData classes:

```
$ rubocop --only Layout/ExtraSpacing modules/auxiliary/gather/windows_secrets_dump.rb  
For /Users/adfoster/Documents/code/metasploit-framework: configuration from /Users/adfoster/Documents/code/metasploit-framework/.rubocop.yml
Default configuration from /Users/adfoster/.rvm/gems/ruby-2.7.2@metasploit-framework/gems/rubocop-1.9.1/config/default.yml
Inspecting 1 file
Scanning /Users/adfoster/Documents/code/metasploit-framework/modules/auxiliary/gather/windows_secrets_dump.rb
C

Offenses:

modules/auxiliary/gather/windows_secrets_dump.rb:71:11: C: [Correctable] Layout/ExtraSpacing: Unnecessary spacing detected.
    string   :enc_hash, length: 16
          ^^
modules/auxiliary/gather/windows_secrets_dump.rb:72:11: C: [Correctable] Layout/ExtraSpacing: Unnecessary spacing detected.
    string   :unknown, length: 56
          ^^
modules/auxiliary/gather/windows_secrets_dump.rb:74:11: C: [Correctable] Layout/ExtraSpacing: Unnecessary spacing detected.
    string   :pad1, length: -> { pad_length(self.username) }
          ^^
modules/auxiliary/gather/windows_secrets_dump.rb:76:11: C: [Correctable] Layout/ExtraSpacing: Unnecessary spacing detected.
    string   :pad2, length: -> { pad_length(self.domain_name) }
          ^^
modules/auxiliary/gather/windows_secrets_dump.rb:78:11: C: [Correctable] Layout/ExtraSpacing: Unnecessary spacing detected.
    string   :pad3, length: -> { pad_length(self.dns_domain_name) }
          ^^
modules/auxiliary/gather/windows_secrets_dump.rb:80:11: C: [Correctable] Layout/ExtraSpacing: Unnecessary spacing detected.
    string   :pad4, length: -> { pad_length(self.upn) }
```

### This branch

Any offenses within BinData are now ignored:

```
rubocop --only Layout/ExtraSpacingWithBinDataIgnored modules/auxiliary/gather/windows_secrets_dump.rb
Inspecting 1 file
C

Offenses:

modules/auxiliary/gather/windows_secrets_dump.rb:265:16: C: [Correctable] Layout/ExtraSpacingWithBinDataIgnored: Unnecessary spacing detected.
      hboot_key  = rc4.update(value_data[0x80, 32])
               ^
modules/auxiliary/gather/windows_secrets_dump.rb:330:15: C: [Correctable] Layout/ExtraSpacingWithBinDataIgnored: Unnecessary spacing detected.
    sam_lmpass   = "LMPASSWORD\x00"

```
