### PR TITLE
add redis_Unauthorized.rb

### DIFF
--- a/modules/auxiliary/scanner/redis/redis_unauthorized.rb
+++ b/modules/auxiliary/scanner/redis/redis_unauthorized.rb
@@ -1,0 +1,53 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::Tcp
+  include Msf::Auxiliary::Redis
+  include Msf::Auxiliary::Report
+  include Msf::Auxiliary::Scanner
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'         => 'Redis Unauthorized Scanner',
+      'Description'  => %q(
+        This module finds Redis Unauthorized vulnerability.
+      ),
+      'Author'       => [ 'weaponmaster3070@gmail.com', 'whale3070' ],
+      'License'      => MSF_LICENSE))
+
+    register_options(
+      [
+        Opt::RPORT(6379),
+        OptString.new('COMMAND', [ true, 'The Redis command to run', 'INFO' ])
+      ]
+    )
+  end
+
+  def command
+    datastore['COMMAND']
+  end
+
+  def run_host(_ip)
+    vprint_status("Contacting redis")
+    begin
+      connect  #Establishes a TCP connection to the specified RHOST/RPORT
+      return unless (data = redis_command(command))
+      #puts data
+      if data["redis_version"]
+          report_service(host: rhost, port: rport, name: "redis server", info: "#{command} response: #{data}") #store in the msf database
+          print_good("Found redis with #{command} command: #{Rex::Text.to_hex_ascii(data)}")
+      else
+          vprint_error('Not found redis_Unauthorized')
+      end
+
+    rescue Rex::AddressInUse, Rex::HostUnreachable, Rex::ConnectionTimeout,
+           Rex::ConnectionRefused, ::Timeout::Error, ::EOFError, ::Errno::ETIMEDOUT => e
+      vprint_error("Error while communicating: #{e}")
+    ensure
+      disconnect
+    end
+  end
+end


### PR DESCRIPTION
Tell us what this change does. If you're fixing a bug, please mention
the github issue number.

Please ensure you are submitting **from a unique branch** in your [repository](https://github.com/rapid7/metasploit-framework/pull/11086#issuecomment-445506416) to master in Rapid7's.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] Do: `use /auxiliary/scanner/redis/redis_Unauthorized.rb`
- [x] Do: `set RHOSTS 3.238.76.130`
- [x] Do: `run`
- [x] If the system has redis version keyword, they will be printed out.

## Scenarios

```
msf6 auxiliary(scanner/redis/redis_Unauthorized) > run

[+] 3.238.76.130:6379     - Found redis with INFO command: $3739\x0d\x0a# Server\x0d\x0aredis_version:6.0.8\x0d\x0aredis_git_sha1:00000000\x0d\x0aredis_git_dirty:0\x0d\x0aredis_build_id:b5497f16f69092d4\x0d\x0aredis_mode:standalone\x0d\x0aos:Linux 5.3.0-1035-aws x86_64\x0d\x0aarch_bits:64\x0d\x0amultiplexing_api:epoll\x0d\x0aatomicvar_api:atomic-builtin\x0d\x0agcc_version:8.3.0\x0d\x0aprocess_id:1\x0d\x0arun_id:0c0ff32bf840785afeb0d5daed5904fb6b379de2\x0d\x0atcp_port:6379\x0d\x0auptime_in_seconds:10102386\x0d\x0auptime_in_days:116\x0d\x0ahz:10\x0d\x0aconfigured_hz:10\x0d\x0alru_clock:2869036\x0d\x0aexecutable:/data/redis-server\x0d\x0aconfig_file:\x0d\x0aio_threads_active:0\x0d\x0a\x0d\x0a# Clients\x0d\x0aconnected_clients:3\x0d\x0aclient_recent_max_input_buffer:2\x0d\x0aclient_recent_max_output_buffer:0\x0d\x0ablocked_clients:0\x0d\x0atracking_clients:0\x0d\x0aclients_in_timeout_table:0\x0d\x0a\x0d\x0a# Memory\x0d\x0aused_memory:922072\x0d\x0aused_memory_human:900.46K\x0d\x0aused_memory_rss:8261632\x0d\x0aused_memory_rss_human:7.88M\x0d\x0aused_memory_peak:2091832\x0d\x0aused_memory_peak_human:1.99M\x0d\x0aused_memory_peak_perc:44.08%\x0d\x0aused_memory_overhead:837468\x0d\x0aused_memory_startup:802984\x0d\x0aused_memory_dataset:84604\x0d\x0aused_memory_dataset_perc:71.04%\x0d\x0aallocator_allocated:1004568\x0d\x0aallocator_active:1351680\x0d\x0aallocator_resident:3756032\x0d\x0atotal_system_memory:8346411008\x0d\x0atotal_system_memory_human:7.77G\x0d\x0aused_memory_lua:37888\x0d\x0aused_memory_lua_human:37.00K\x0d\x0aused_memory_scripts:0\x0d\x0aused_memory_scripts_human:0B\x0d\x0anumber_of_cached_scripts:0\x0d\x0amaxmemory:0\x0d\x0amaxmemory_human:0B\x0d\x0amaxmemory_policy:noeviction\x0d\x0aallocator_frag_ratio:1.35\x0d\x0aallocator_frag_bytes:347112\x0d\x0aallocator_rss_ratio:2.78\x0d\x0aallocator_rss_bytes:2404352\x0d\x0arss_overhead_ratio:2.20\x0d\x0arss_overhead_bytes:4505600\x0d\x0amem_fragmentation_ratio:9.62\x0d\x0amem_fragmentation_bytes:7403056\x0d\x0amem_not_counted_for_evict:0\x0d\x0amem_replication_backlog:0\x0d\x0amem_clients_slaves:0\x0d\x0amem_clients_normal:33972\x0d\x0amem_aof_buffer:0\x0d\x0amem_allocator:jemalloc-5.1.0\x0d\x0aactive_defrag_running:0\x0d\x0alazyfree_pending_objects:0\x0d\x0a\x0d\x0a# Persistence\x0d\x0aloading:0\x0d\x0ardb_changes_since_last_save:483\x0d\x0ardb_bgsave_in_progress:0\x0d\x0ardb_last_save_time:1613362771\x0d\x0ardb_last_bgsave_status:err\x0d\x0ardb_last_bgsave_time_sec:0\x0d\x0ardb_current_bgsave_time_sec:-1\x0d\x0ardb_last_cow_size:466944\x0d\x0aaof_enabled:0\x0d\x0aaof_rewrite_in_progress:0\x0d\x0aaof_rewrite_scheduled:0\x0d\x0aaof_last_rewrite_time_sec:-1\x0d\x0aaof_current_rewrite_time_sec:-1\x0d\x0aaof_last_bgrewrite_status:ok\x0d\x0aaof_last_write_status:ok\x0d\x0aaof_last_cow_size:0\x0d\x0amodule_fork_in_progress:0\x0d\x0amodule_fork_last_cow_size:0\x0d\x0a\x0d\x0a# Stats\x0d\x0atotal_connections_received:11895\x0d\x0atotal_commands_processed:122882\x0d\x0ainstantaneous_ops_per_sec:0\x0d\x0atotal_net_input_bytes:336294453\x0d\x0atotal_net_output_bytes:124766153\x0d\x0ainstantaneous_input_kbps:0.00\x0d\x0ainstantaneous_output_kbps:0.00\x0d\x0arejected_connections:0\x0d\x0async_full:0\x0d\x0async_partial_ok:0\x0d\x0async_partial_err:0\x0d\x0aexpired_keys:20\x0d\x0aexpired_stale_perc:0.00\x0d\x0aexpired_time_cap_reached_count:0\x0d\x0aexpire_cycle_cpu_milliseconds:337740\x0d\x0aevicted_keys:0\x0d\x0akeyspace_hits:26\x0d\x0akeyspace_misses:1\x0d\x0apubsub_channels:0\x0d\x0apubsub_patterns:0\x0d\x0alatest_fork_usec:342\x0d\x0amigrate_cached_sockets:0\x0d\x0aslave_expires_tracked_keys:0\x0d\x0aactive_defrag_hits:0\x0d\x0aactive_defrag_misses:0\x0d\x0aactive_defrag_key_hits:0\x0d\x0aactive_defrag_key_misses:0\x0d\x0atracking_total_keys:0\x0d\x0atracking_total_items:0\x0d\x0atracking_total_prefixes:0\x0d\x0aunexpected_error_replies:0\x0d\x0atotal_reads_processed:138507\x0d\x0atotal_writes_processed:127016\x0d\x0aio_threaded_reads_processed:0\x0d\x0aio_threaded_writes_processed:0\x0d\x0a\x0d\x0a# Replication\x0d\x0arole:master\x0d\x0aconnected_slaves:0\x0d\x0amaster_replid:2e3d5f4c37c9708e2ef70dea66bdc51cc4e8156b\x0d\x0amaster_replid2:3d323daea87a966b5b0d3f79f94540afd19f4c0d\x0d\x0amaster_repl_offset:0\x0d\x0asecond_repl_offset:1\x0d\x0arepl_backlog_active:0\x0d\x0arepl_backlog_size:1048576\x0d\x0arepl_backlog_first_byte_offset:0\x0d\x0arepl_backlog_histlen:0\x0d\x0a\x0d\x0a# CPU\x0d\x0aused_cpu_sys:7543.945538\x0d\x0aused_cpu_user:8284.842661\x0d\x0aused_cpu_sys_children:37.045444\x0d\x0aused_cpu_user_children:390.341854\x0d\x0a\x0d\x0a# Modules\x0d\x0a\x0d\x0a# Cluster\x0d\x0acluster_enabled:0\x0d\x0a\x0d\x0a# Keyspace\x0d\x0adb0:keys=8,expires=0,avg_ttl=0\x0d\x0adb1:keys=1,expires=1,avg_ttl=5833100
[*] 3.238.76.130:6379     - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

If you are opening a PR for a new module that exploits a **specific** piece of hardware or requires a **complex or hard-to-find** testing environment, we recommend that you send us a demo of your module executing correctly. Seeing your module in action will help us review your PR faster!

Specific Hardware Examples:
* Switches
* Routers
* IP Cameras
* IoT devices

Complex Software Examples:
* Expensive proprietary software
* Software with an extensive installation process
* Software that requires exploit testing across multiple significantly different versions
* Software without an English language UI

We will also accept demonstrations of successful module execution even if your module doesn't meet the above conditions. It's not a necessity, but it may help us land your module faster!

Demonstration of successful module execution can take the form of a packet capture (pcap) or a screen recording. You can send pcaps and recordings to [msfdev@metaspolit.com](mailto:msfdev@metaspolit.com). Please include a CVE number in the subject header (if applicable), and a link to your PR in the email body.
