### PR TITLE
Handle nil versions in preparation for rubygems 4

### DIFF
--- a/lib/metasploit/framework/api/version.rb
+++ b/lib/metasploit/framework/api/version.rb
@@ -10,7 +10,7 @@ module Metasploit
       end
 
       VERSION = "#{Version::MAJOR}.#{Version::MINOR}.#{Version::PATCH}"
-      GEM_VERSION = Gem::Version.new(VERSION)
+      GEM_VERSION = Rex::Version.new(VERSION)
     end
   end
 end

--- a/lib/metasploit/framework/core/version.rb
+++ b/lib/metasploit/framework/core/version.rb
@@ -13,7 +13,7 @@ module Metasploit
       end
 
       VERSION = Metasploit::Framework::VERSION
-      GEM_VERSION = Gem::Version.new(Metasploit::Framework::GEM_VERSION)
+      GEM_VERSION = Rex::Version.new(Metasploit::Framework::GEM_VERSION)
     end
   end
 end

--- a/lib/metasploit/framework/login_scanner/phpmyadmin.rb
+++ b/lib/metasploit/framework/login_scanner/phpmyadmin.rb
@@ -14,7 +14,7 @@ module Metasploit
 
           if res && res.body.include?('phpMyAdmin')
             if res.body =~ /PMA_VERSION:"(\d+\.\d+\.\d+)"/
-              version = Gem::Version.new($1)
+              version = Rex::Version.new($1)
             end
             return version.to_s
           end

--- a/lib/msf/core/exploit/remote/http/drupal.rb
+++ b/lib/msf/core/exploit/remote/http/drupal.rb
@@ -23,7 +23,7 @@ module Exploit::Remote::HTTP::Drupal
 
   # Determine Drupal version
   #
-  # @return [Gem::Version] Version as Gem::Version
+  # @return [Rex::Version] Version as Rex::Version
   def drupal_version
     res = send_request_cgi(
       'method' => 'GET',
@@ -49,12 +49,12 @@ module Exploit::Remote::HTTP::Drupal
 
   # Return CHANGELOG.txt
   #
-  # @param version [Gem::Version] Gem::Version or version string
+  # @param version [Rex::Version] Rex::Version or version string
   # @return [String] CHANGELOG.txt as a string
   def drupal_changelog(version)
-    return unless version && Gem::Version.correct?(version)
+    return unless version && Rex::Version.correct?(version)
 
-    uri = Gem::Version.new(version) < Gem::Version.new('8') ?
+    uri = Rex::Version.new(version) < Rex::Version.new('8') ?
           normalize_uri(target_uri.path, 'CHANGELOG.txt') :
           normalize_uri(target_uri.path, 'core/CHANGELOG.txt')
 
@@ -89,16 +89,16 @@ module Exploit::Remote::HTTP::Drupal
   # Match a Drupal version
   #
   # @param string [String] String to match against
-  # @return [Gem::Version] Version as Gem::Version
+  # @return [Rex::Version] Version as Rex::Version
   def version_match(string)
     return unless string
 
     # Perl devs love me; Ruby devs hate me
     string =~ /^Drupal ([\d.]+)/
 
-    return unless $1 && Gem::Version.correct?($1)
+    return unless $1 && Rex::Version.correct?($1)
 
-    Gem::Version.new($1)
+    Rex::Version.new($1)
   end
 
 end

--- a/lib/msf/core/exploit/remote/http/wordpress/version.rb
+++ b/lib/msf/core/exploit/remote/http/wordpress/version.rb
@@ -189,7 +189,7 @@ module Msf::Exploit::Remote::HTTP::Wordpress::Version
       if vuln_introduced_version.nil?
         # All versions are vulnerable
         return Msf::Exploit::CheckCode::Appears(details:{version: version})
-      elsif Gem::Version.new(version) >= Gem::Version.new(vuln_introduced_version)
+      elsif Rex::Version.new(version) >= Rex::Version.new(vuln_introduced_version)
         # Newer or equal to the version it was introduced
         return Msf::Exploit::CheckCode::Appears(details:{version: version})
       else
@@ -197,12 +197,12 @@ module Msf::Exploit::Remote::HTTP::Wordpress::Version
       end
     else
       # Version older than fixed version
-      if Gem::Version.new(version) < Gem::Version.new(fixed_version)
+      if Rex::Version.new(version) < Rex::Version.new(fixed_version)
         if vuln_introduced_version.nil?
           # Older than fixed version, no vuln introduction date, flag as vuln
           return Msf::Exploit::CheckCode::Appears(details:{version: version})
         # vuln_introduced_version provided, check if version is newer
-        elsif Gem::Version.new(version) >= Gem::Version.new(vuln_introduced_version)
+        elsif Rex::Version.new(version) >= Rex::Version.new(vuln_introduced_version)
           return Msf::Exploit::CheckCode::Appears(details:{version: version})
         else
           # Not in range, nut vulnerable

--- a/lib/msf/core/payload/apk.rb
+++ b/lib/msf/core/payload/apk.rb
@@ -150,8 +150,8 @@ class Msf::Payload::Apk
       raise RuntimeError, "apktool not found. If it's not in your PATH, please add it."
     end
 
-    apk_v = Gem::Version.new(apktool)
-    unless apk_v >= Gem::Version.new('2.0.1')
+    apk_v = Rex::Version.new(apktool)
+    unless apk_v >= Rex::Version.new('2.0.1')
       raise RuntimeError, "apktool version #{apk_v} not supported, please download at least version 2.0.1."
     end
 

--- a/lib/rex.rb
+++ b/lib/rex.rb
@@ -94,6 +94,9 @@ require 'rex/compat'
 require 'rex/sslscan/scanner'
 require 'rex/sslscan/result'
 
+# Versions
+require 'rex/version'
+
 # Overload the Kernel.sleep() function to be thread-safe
 Kernel.class_eval("
   def sleep(seconds=nil)

--- a/lib/rex/post/hwbridge/extensions/automotive/automotive.rb
+++ b/lib/rex/post/hwbridge/extensions/automotive/automotive.rb
@@ -120,7 +120,7 @@ class Automotive < Extension
     data = [ data ] if data.is_a? Integer
     if data.size < 8
       # Padding is handled differently after 0.0.3
-      if Gem::Version.new(client.api_version) < Gem::Version.new('0.0.4')
+      if Rex::Version.new(client.api_version) < Rex::Version.new('0.0.4')
         data = padd_packet(data, opt['PADDING']) if opt.key? 'PADDING'
       end
       data = array2hex(data).join

--- a/lib/rex/version.rb
+++ b/lib/rex/version.rb
@@ -1,8 +1,7 @@
-
 class Rex::Version < Gem::Version
 
   def initialize(version)
-    if version == nil
+    if version.nil?
       # Rubygems 4 is deprecating `nil` as a valid version number
       # Currently it is the equivalent of a `0` so we set that here to keep the same functionality
       version = 0

--- a/lib/rex/version.rb
+++ b/lib/rex/version.rb
@@ -1,0 +1,12 @@
+
+class Rex::Version < Gem::Version
+
+  def initialize(version)
+    if version == nil
+      # Rubygems 4 is deprecating `nil` as a valid version number
+      # Currently it is the equivalent of a `0` so we set that here to keep the same functionality
+      version = 0
+    end
+    super version
+  end
+end

--- a/modules/auxiliary/admin/http/allegro_rompager_auth_bypass.rb
+++ b/modules/auxiliary/admin/http/allegro_rompager_auth_bypass.rb
@@ -210,7 +210,7 @@ class MetasploitModule < Msf::Auxiliary
     # ensure the fingerprint at least appears vulnerable
     if /RomPager\/(?<version>[\d\.]+)/ =~ fp
       vprint_status("#{peer} is RomPager #{version}")
-      if Gem::Version.new(version) < Gem::Version.new('4.34')
+      if Rex::Version.new(version) < Rex::Version.new('4.34')
         if /realm="(?<model>.+)"/ =~ fp
           return model
         end

--- a/modules/auxiliary/admin/http/joomla_registration_privesc.rb
+++ b/modules/auxiliary/admin/http/joomla_registration_privesc.rb
@@ -54,7 +54,7 @@ class MetasploitModule < Msf::Auxiliary
       return Exploit::CheckCode::Safe
     end
 
-    version = Gem::Version.new(joomla_version)
+    version = Rex::Version.new(joomla_version)
 
     unless version
       vprint_error('Unable to detect Joomla version')
@@ -63,7 +63,7 @@ class MetasploitModule < Msf::Auxiliary
 
     vprint_status("Detected Joomla version #{version}")
 
-    if version.between?(Gem::Version.new('3.4.4'), Gem::Version.new('3.6.3'))
+    if version.between?(Rex::Version.new('3.4.4'), Rex::Version.new('3.6.3'))
       return Exploit::CheckCode::Appears
     end
 

--- a/modules/auxiliary/admin/http/netgear_r6700_pass_reset.rb
+++ b/modules/auxiliary/admin/http/netgear_r6700_pass_reset.rb
@@ -100,13 +100,13 @@ class MetasploitModule < Msf::Auxiliary
       fail_with(Failure::UnexpectedReply, 'Failed to obtain device version: no version number found in response') # Taken from https://stackoverflow.com/questions/4115115/extract-a-substring-from-a-string-in-ruby-using-a-regular-expression
     end
     raw_version_number = version[0].gsub('V', '') # If we got a result, then take the first result from the returned array, and remove the leading 'V'.
-    Gem::Version.new(raw_version_number) # Finally lets turn it into a Gem::Version object for later use in other parts of the code.
+    Rex::Version.new(raw_version_number) # Finally lets turn it into a Rex::Version object for later use in other parts of the code.
   end
 
   def check
     target_version = retrieve_version
     print_status("Target is running firmware version #{target_version}")
-    if (target_version < Gem::Version.new('1.0.4.94')) && (target_version >= Gem::Version.new('1.0.2.62'))
+    if (target_version < Rex::Version.new('1.0.4.94')) && (target_version >= Rex::Version.new('1.0.2.62'))
       return Exploit::CheckCode::Appears
     else
       return Exploit::Checkcode::Safe
@@ -115,12 +115,12 @@ class MetasploitModule < Msf::Auxiliary
 
   def find_offset
     target_version = retrieve_version
-    if target_version == Gem::Version.new('1.0.4.84')
+    if target_version == Rex::Version.new('1.0.4.84')
       print_status("#{peer} - Identified Netgear R6700v3 (firmware V1.0.0.4.84_10.0.58) as the target.")
       # this offset is where execution will jump to
       # a part in the middle of the binary that resets the admin password
       return "\x58\x9a\x03"
-    elsif target_version == Gem::Version.new('1.0.4.82')
+    elsif target_version == Rex::Version.new('1.0.4.82')
       print_status("#{peer} - Identified Netgear R6700v3 (firmware V1.0.0.4.82_10.0.57) as the target.")
       return "\x48\x9a\x03"
     end

--- a/modules/auxiliary/admin/http/pfadmin_set_protected_alias.rb
+++ b/modules/auxiliary/admin/http/pfadmin_set_protected_alias.rb
@@ -66,9 +66,9 @@ class MetasploitModule < Msf::Auxiliary
     if res.body =~ /<div id="footer".*Postfix Admin/m
       version = res.body.match(/<div id="footer"[^<]*<a[^<]*Postfix\s*Admin\s*([^<]*)<\//mi)
       return Exploit::CheckCode::Detected unless version
-      if Gem::Version.new("2.91") > Gem::Version.new(version[1])
+      if Rex::Version.new("2.91") > Rex::Version.new(version[1])
         return Exploit::CheckCode::Detected
-      elsif Gem::Version.new("3.0.1") < Gem::Version.new(version[1])
+      elsif Rex::Version.new("3.0.1") < Rex::Version.new(version[1])
         return Exploit::CheckCode::Detected
       end
       return Exploit::CheckCode::Appears

--- a/modules/auxiliary/gather/memcached_extractor.rb
+++ b/modules/auxiliary/gather/memcached_extractor.rb
@@ -128,7 +128,7 @@ class MetasploitModule < Msf::Auxiliary
       connect
       if (version = determine_version)
         vprint_good("Connected to memcached version #{version}")
-        if (Gem::Version.new(version) >= Gem::Version.new('1.5.4'))
+        if (Rex::Version.new(version) >= Rex::Version.new('1.5.4'))
           command_string = "lru_crawler"
         else
           command_string = 'cachedump'

--- a/modules/auxiliary/gather/qnap_backtrace_admin_hash.rb
+++ b/modules/auxiliary/gather/qnap_backtrace_admin_hash.rb
@@ -64,7 +64,7 @@ class MetasploitModule < Msf::Auxiliary
       @target = (xml.at('//platform').text == 'TS-NASX86' ? 'x86' : 'ARM')
       vprint_status("QNAP #{info[0]} #{info[1..-1].join('-')} detected")
 
-      if Gem::Version.new(info[1]) < Gem::Version.new('4.2.3')
+      if Rex::Version.new(info[1]) < Rex::Version.new('4.2.3')
         Exploit::CheckCode::Appears
       else
         Exploit::CheckCode::Detected

--- a/modules/auxiliary/scanner/couchdb/couchdb_enum.rb
+++ b/modules/auxiliary/scanner/couchdb/couchdb_enum.rb
@@ -88,11 +88,11 @@ class MetasploitModule < Msf::Auxiliary
 
   def check
     return Exploit::CheckCode::Unknown unless get_version
-    version = Gem::Version.new(@version)
+    version = Rex::Version.new(@version)
     return Exploit::CheckCode::Unknown if version.version.empty?
     vprint_good("#{peer} - Found CouchDB version #{version}")
 
-    return Exploit::CheckCode::Appears if version < Gem::Version.new('1.7.0') || version.between?(Gem::Version.new('2.0.0'), Gem::Version.new('2.1.0'))
+    return Exploit::CheckCode::Appears if version < Rex::Version.new('1.7.0') || version.between?(Rex::Version.new('2.0.0'), Rex::Version.new('2.1.0'))
 
     Exploit::CheckCode::Safe
   end
@@ -216,9 +216,9 @@ class MetasploitModule < Msf::Auxiliary
 
     if datastore['CREATEUSER']
       fail_with(Failure::Unknown, 'get_version failed in run') unless get_version
-      version = Gem::Version.new(@version)
+      version = Rex::Version.new(@version)
       print_good("#{peer} - Found CouchDB version #{version}")
-      create_user if version < Gem::Version.new('1.7.0') || version.between?(Gem::Version.new('2.0.0'), Gem::Version.new('2.1.0'))
+      create_user if version < Rex::Version.new('1.7.0') || version.between?(Rex::Version.new('2.0.0'), Rex::Version.new('2.1.0'))
     end
     auth = basic_auth(username, password) if username && password
     get_server_info(auth) if datastore['SERVERINFO']

--- a/modules/auxiliary/scanner/http/allegro_rompager_misfortune_cookie.rb
+++ b/modules/auxiliary/scanner/http/allegro_rompager_misfortune_cookie.rb
@@ -78,7 +78,7 @@ class MetasploitModule < Msf::Auxiliary
     fp = http_fingerprint(response: res)
     if /RomPager\/(?<version>[\d\.]+)/ =~ fp
       vprint_status("#{peer} is RomPager #{version}")
-      if Gem::Version.new(version) < Gem::Version.new('4.34')
+      if Rex::Version.new(version) < Rex::Version.new('4.34')
         return Exploit::CheckCode::Appears
       end
     end

--- a/modules/auxiliary/scanner/http/bmc_trackit_passwd_reset.rb
+++ b/modules/auxiliary/scanner/http/bmc_trackit_passwd_reset.rb
@@ -66,7 +66,7 @@ class MetasploitModule < Msf::Auxiliary
       version = res.body.scan(/\bBuild=([\d\.]+)/).flatten.first
       if version
         fix_version = '11.4'
-        if Gem::Version.new(version) < Gem::Version.new(fix_version)
+        if Rex::Version.new(version) < Rex::Version.new(fix_version)
           report_vuln(
             host: ip,
             port: rport,

--- a/modules/auxiliary/scanner/http/hp_sys_mgmt_login.rb
+++ b/modules/auxiliary/scanner/http/hp_sys_mgmt_login.rb
@@ -50,7 +50,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def is_version_tested?(version)
     # As of Sep 4 2014, version 7.4 is the latest and that's the last one we've tested
-    if Gem::Version.new(version) < Gem::Version.new('7.5')
+    if Rex::Version.new(version) < Rex::Version.new('7.5')
       return true
     end
 

--- a/modules/auxiliary/scanner/http/limesurvey_zip_traversals.rb
+++ b/modules/auxiliary/scanner/http/limesurvey_zip_traversals.rb
@@ -174,7 +174,7 @@ class MetasploitModule < Msf::Auxiliary
     /Version\s+(?<version>\d\.\d{1,2}\.\d{1,2})/ =~ res.body
     return nil unless version
 
-    Gem::Version.new(version)
+    Rex::Version.new(version)
   end
 
   def run_host(ip)
@@ -188,14 +188,14 @@ class MetasploitModule < Msf::Auxiliary
       cve_2019_9960_pre3_15_9 cookie, ip
     end
     vprint_status "Version Detected: #{version.version}"
-    if version.between?(Gem::Version.new('4.0'), Gem::Version.new('4.1.11'))
+    if version.between?(Rex::Version.new('4.0'), Rex::Version.new('4.1.11'))
       cve_2020_11455 cookie, ip
-    elsif version.between?(Gem::Version.new('2.50.0'), Gem::Version.new('3.15.9'))
+    elsif version.between?(Rex::Version.new('2.50.0'), Rex::Version.new('3.15.9'))
       cve_2019_9960_version_3 cookie, ip
     # 2.50 is when LimeSurvey started doing almost daily releases.  This version was
     # picked arbitrarily as I can't seem to find a lower bounds on when this other
     # method may be needed.
-    elsif version < Gem::Version.new('2.50.0')
+    elsif version < Rex::Version.new('2.50.0')
       cve_2019_9960_pre25 cookie, ip
     else
       print_bad "No exploit for version #{version.version}"

--- a/modules/auxiliary/scanner/http/wordpress_content_injection.rb
+++ b/modules/auxiliary/scanner/http/wordpress_content_injection.rb
@@ -50,14 +50,14 @@ class MetasploitModule < Msf::Auxiliary
 
   def check_host(_ip)
     if (version = wordpress_version)
-      version = Gem::Version.new(version)
+      version = Rex::Version.new(version)
     else
       return Exploit::CheckCode::Safe
     end
 
     vprint_status("WordPress #{version}: #{full_uri}")
 
-    if version.between?(Gem::Version.new('4.7'), Gem::Version.new('4.7.1'))
+    if version.between?(Rex::Version.new('4.7'), Rex::Version.new('4.7.1'))
       Exploit::CheckCode::Appears
     else
       Exploit::CheckCode::Detected

--- a/modules/auxiliary/scanner/http/wordpress_multicall_creds.rb
+++ b/modules/auxiliary/scanner/http/wordpress_multicall_creds.rb
@@ -76,7 +76,7 @@ class MetasploitModule < Msf::Auxiliary
     elsif !wordpress_xmlrpc_enabled?
       print_error("#{peer}:#{rport}#{wordpress_url_xmlrpc} does not enable XMLRPC")
       false
-    elsif Gem::Version.new(version) >= Gem::Version.new('4.4.1')
+    elsif Rex::Version.new(version) >= Rex::Version.new('4.4.1')
       print_error("#{peer}#{wordpress_url_xmlrpc} Target's version (#{version}) is not vulnerable to this attack.")
       vprint_status("Dropping CHUNKSIZE from #{datastore['CHUNKSIZE']} to 1")
       datastore['CHUNKSIZE'] = 1

--- a/modules/auxiliary/scanner/http/wp_loginizer_log_sqli.rb
+++ b/modules/auxiliary/scanner/http/wp_loginizer_log_sqli.rb
@@ -57,7 +57,7 @@ class MetasploitModule < Msf::Auxiliary
       return
     end
 
-    if Gem::Version.new(wp_ver) < Gem::Version.new('5.4')
+    if Rex::Version.new(wp_ver) < Rex::Version.new('5.4')
       vprint_error("Wordpress (core) #{wp_ver} is unexploitable.  Version 5.4+ required.")
       return
     end

--- a/modules/auxiliary/scanner/smb/smb_uninit_cred.rb
+++ b/modules/auxiliary/scanner/smb/smb_uninit_cred.rb
@@ -178,7 +178,7 @@ class MetasploitModule < Msf::Auxiliary
 
   # Converts a version string into an object so we can eval it
   def version(v)
-    Gem::Version.new(v)
+    Rex::Version.new(v)
   end
 
 

--- a/modules/auxiliary/scanner/ssh/libssh_auth_bypass.rb
+++ b/modules/auxiliary/scanner/ssh/libssh_auth_bypass.rb
@@ -58,7 +58,7 @@ class MetasploitModule < Msf::Auxiliary
 
   # Vulnerable since 0.6.0 and patched in 0.7.6 and 0.8.4
   def check_banner(ip, version)
-    version =~ /libssh[_-]?([\d.]*)$/ && $1 && (v = Gem::Version.new($1))
+    version =~ /libssh[_-]?([\d.]*)$/ && $1 && (v = Rex::Version.new($1))
 
     if v.nil?
       vprint_error("#{ip}:#{rport} - #{version} does not appear to be libssh")
@@ -66,8 +66,8 @@ class MetasploitModule < Msf::Auxiliary
     elsif v.to_s.empty?
       vprint_warning("#{ip}:#{rport} - libssh version not reported")
       Exploit::CheckCode::Detected
-    elsif v.between?(Gem::Version.new('0.6.0'), Gem::Version.new('0.7.5')) ||
-          v.between?(Gem::Version.new('0.8.0'), Gem::Version.new('0.8.3'))
+    elsif v.between?(Rex::Version.new('0.6.0'), Rex::Version.new('0.7.5')) ||
+          v.between?(Rex::Version.new('0.8.0'), Rex::Version.new('0.8.3'))
       vprint_good("#{ip}:#{rport} - #{version} appears to be unpatched")
       Exploit::CheckCode::Appears
     else

--- a/modules/auxiliary/sqli/openemr/openemr_sqli_dump.rb
+++ b/modules/auxiliary/sqli/openemr/openemr_sqli_dump.rb
@@ -68,7 +68,7 @@ class MetasploitModule < Msf::Auxiliary
     version.sub! ')', ''
     version.strip!
 
-    return Exploit::CheckCode::Safe unless Gem::Version.new(version) < Gem::Version.new('5.0.1.7')
+    return Exploit::CheckCode::Safe unless Rex::Version.new(version) < Rex::Version.new('5.0.1.7')
 
     Exploit::CheckCode::Appears
   end

--- a/modules/exploits/aix/local/xorg_x11_server.rb
+++ b/modules/exploits/aix/local/xorg_x11_server.rb
@@ -177,7 +177,7 @@ class MetasploitModule < Msf::Exploit::Local
   def xorg_vulnerable?
     version = cmd_exec('lslpp -L | grep -i X11.base.rte | awk \'{ print $2 }\'')
     print_status("Xorg version is #{version}")
-    semantic_version = Gem::Version.new(version)
+    semantic_version = Rex::Version.new(version)
 
     vulnerable_versions = [
       ['6.1.9.0', '6.1.9.100'],
@@ -190,8 +190,8 @@ class MetasploitModule < Msf::Exploit::Local
     ]
 
     vulnerable_versions.each do |version_pair|
-      if semantic_version >= Gem::Version.new(version_pair[0]) &&
-         semantic_version <= Gem::Version.new(version_pair[1])
+      if semantic_version >= Rex::Version.new(version_pair[0]) &&
+         semantic_version <= Rex::Version.new(version_pair[1])
         return true
       end
     end

--- a/modules/exploits/android/local/futex_requeue.rb
+++ b/modules/exploits/android/local/futex_requeue.rb
@@ -91,7 +91,7 @@ class MetasploitModule < Msf::Exploit::Local
 
   def check
     os = cmd_exec("getprop ro.build.version.release")
-    unless Gem::Version.new(os) < Gem::Version.new('4.5.0')
+    unless Rex::Version.new(os) < Rex::Version.new('4.5.0')
       vprint_error "Android version #{os} does not appear to be vulnerable"
       return CheckCode::Safe
     end

--- a/modules/exploits/android/local/janus.rb
+++ b/modules/exploits/android/local/janus.rb
@@ -58,7 +58,7 @@ class MetasploitModule < Msf::Exploit::Local
 
   def check
     os = cmd_exec("getprop ro.build.version.release")
-    unless Gem::Version.new(os).between?(Gem::Version.new('5.1.1'), Gem::Version.new('8.0.0'))
+    unless Rex::Version.new(os).between?(Rex::Version.new('5.1.1'), Rex::Version.new('8.0.0'))
       vprint_error "Android version #{os} is not vulnerable."
       return CheckCode::Safe
     end

--- a/modules/exploits/apple_ios/browser/webkit_createthis.rb
+++ b/modules/exploits/apple_ios/browser/webkit_createthis.rb
@@ -68,7 +68,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def get_version(user_agent)
     if user_agent =~ /OS (.*?) like Mac OS X\)/
-      ios_version = Gem::Version.new($1.gsub("_", "."))
+      ios_version = Rex::Version.new($1.gsub("_", "."))
       return ios_version
     end
     fail_with Failure::NotVulnerable, 'Target is not vulnerable'
@@ -94,7 +94,7 @@ class MetasploitModule < Msf::Exploit::Remote
     user_agent = request['User-Agent']
     print_status("Requesting #{request.uri} from #{user_agent}")
     version = get_version(user_agent)
-    ios_11 = (version >= Gem::Version.new('11.0.0'))
+    ios_11 = (version >= Rex::Version.new('11.0.0'))
     if request.uri =~ %r{/exploit$}
       loader_data = exploit_data('CVE-2017-13861', 'exploit')
       srvhost = Rex::Socket.resolv_nbo_i(srvhost_addr)
@@ -299,7 +299,7 @@ function get_mem_rw(stage1) {
 }
 ^
 
-    get_mem_rw = (version >= Gem::Version.new('11.2.2')) ? get_mem_rw_ios_11 : get_mem_rw_ios_10
+    get_mem_rw = (version >= Rex::Version.new('11.2.2')) ? get_mem_rw_ios_11 : get_mem_rw_ios_10
     utils = exploit_data "javascript_utils", "utils.js"
     int64 = exploit_data "javascript_utils", "int64.js"
     dump_offsets = ''

--- a/modules/exploits/example_linux_priv_esc.rb
+++ b/modules/exploits/example_linux_priv_esc.rb
@@ -95,8 +95,8 @@ class MetasploitModule < Msf::Exploit::Local
   def check
     # Check the kernel version to see if its in a vulnerable range
     release = kernel_release
-    if Gem::Version.new(release.split('-').first) > Gem::Version.new('4.14.11') ||
-       Gem::Version.new(release.split('-').first) < Gem::Version.new('4.0')
+    if Rex::Version.new(release.split('-').first) > Rex::Version.new('4.14.11') ||
+       Rex::Version.new(release.split('-').first) < Rex::Version.new('4.0')
       vprint_error "Kernel version #{release} is not vulnerable"
       return CheckCode::Safe
     end

--- a/modules/exploits/example_webapp.rb
+++ b/modules/exploits/example_webapp.rb
@@ -102,7 +102,7 @@ class MetasploitModule < Msf::Exploit::Remote
       # Version 1.2
       /Version: (?<version>[\d]{1,2}\.[\d]{1,2})<\/td>/ =~ res.body
 
-      if version && Gem::Version.new(version) <= Gem::Version.new('1.3')
+      if version && Rex::Version.new(version) <= Rex::Version.new('1.3')
         vprint_good("Version Detected: #{version}")
         Exploit::CheckCode::Appears
       end

--- a/modules/exploits/linux/http/apache_couchdb_cmd_exec.rb
+++ b/modules/exploits/linux/http/apache_couchdb_cmd_exec.rb
@@ -73,11 +73,11 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     get_version
-    version = Gem::Version.new(@version)
+    version = Rex::Version.new(@version)
     return CheckCode::Unknown if version.version.empty?
     vprint_status "Found CouchDB version #{version}"
 
-    return CheckCode::Appears if version < Gem::Version.new('1.7.0') || version.between?(Gem::Version.new('2.0.0'), Gem::Version.new('2.1.0'))
+    return CheckCode::Appears if version < Rex::Version.new('1.7.0') || version.between?(Rex::Version.new('2.0.0'), Rex::Version.new('2.1.0'))
 
     CheckCode::Safe
   end
@@ -177,7 +177,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def send_payload(version)
     vprint_status("#{peer} - CouchDB version is #{version}") if version
 
-    version = Gem::Version.new(@version)
+    version = Rex::Version.new(@version)
     if version.version.empty?
       vprint_warning("#{peer} - Cannot retrieve the version of CouchDB.")
       # if target set Automatic, exploit failed.
@@ -188,11 +188,11 @@ class MetasploitModule < Msf::Exploit::Remote
       elsif target == targets[2]
         payload2
       end
-    elsif version < Gem::Version.new('1.7.0')
+    elsif version < Rex::Version.new('1.7.0')
       payload1
-    elsif version.between?(Gem::Version.new('2.0.0'), Gem::Version.new('2.1.0'))
+    elsif version.between?(Rex::Version.new('2.0.0'), Rex::Version.new('2.1.0'))
       payload2
-    elsif version >= Gem::Version.new('1.7.0') || Gem::Version.new('2.1.0')
+    elsif version >= Rex::Version.new('1.7.0') || Rex::Version.new('2.1.0')
       fail_with(Failure::NotVulnerable, "#{peer} - The target is not vulnerable.")
     end
   end

--- a/modules/exploits/linux/http/centreon_useralias_exec.rb
+++ b/modules/exploits/linux/http/centreon_useralias_exec.rb
@@ -56,7 +56,7 @@ class MetasploitModule < Msf::Exploit::Remote
       )
       /LoginInvitVersion"><br \/>[\s]+(?<version>[\d]{1,2}\.[\d]{1,2}\.[\d]{1,2})[\s]+<\/td>/ =~ res.body
 
-      if version && Gem::Version.new(version) <= Gem::Version.new('2.5.3')
+      if version && Rex::Version.new(version) <= Rex::Version.new('2.5.3')
         vprint_good("Version Detected: #{version}")
         Exploit::CheckCode::Appears
       else

--- a/modules/exploits/linux/http/eyesofnetwork_autodiscovery_rce.rb
+++ b/modules/exploits/linux/http/eyesofnetwork_autodiscovery_rce.rb
@@ -143,9 +143,9 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Detected('Could not determine EyesOfNetwork version.')
     end
 
-    api_version = Gem::Version.new api_version
+    api_version = Rex::Version.new api_version
 
-    unless api_version <= Gem::Version.new('2.4.2')
+    unless api_version <= Rex::Version.new('2.4.2')
       return CheckCode::Safe("Target is EyesOfNetwork with API version #{api_version}.")
     end
 

--- a/modules/exploits/linux/http/geutebruck_testaction_exec.rb
+++ b/modules/exploits/linux/http/geutebruck_testaction_exec.rb
@@ -79,9 +79,9 @@ class MetasploitModule < Msf::Exploit::Remote
     result = firmware
     return result unless result == true
 
-    version = Gem::Version.new(@version)
+    version = Rex::Version.new(@version)
     vprint_status "Found Geutebruck version #{version}"
-    if version < Gem::Version.new('1.12.0.25') || version == Gem::Version.new('1.12.13.2') || version == Gem::Version.new('1.12.14.5')
+    if version < Rex::Version.new('1.12.0.25') || version == Rex::Version.new('1.12.13.2') || version == Rex::Version.new('1.12.14.5')
       return CheckCode::Appears
     end
 

--- a/modules/exploits/linux/http/ipfire_oinkcode_exec.rb
+++ b/modules/exploits/linux/http/ipfire_oinkcode_exec.rb
@@ -71,10 +71,10 @@ class MetasploitModule < Msf::Exploit::Remote
       if res && res.code == 200
         /\<strong\>IPFire (?<version>[\d.]{4}) \([\w]+\) - Core Update (?<update>[\d]+)/ =~ res.body
       end
-      if version.nil? || update.nil? || !Gem::Version.correct?(version)
+      if version.nil? || update.nil? || !Rex::Version.correct?(version)
         vprint_error('No Recognizable Version Found')
         CheckCode::Safe
-      elsif Gem::Version.new(version) <= Gem::Version.new('2.19') && update.to_i <= 110
+      elsif Rex::Version.new(version) <= Rex::Version.new('2.19') && update.to_i <= 110
         CheckCode::Appears
       else
         vprint_error('Version and/or Update Not Supported')

--- a/modules/exploits/linux/http/jenkins_cli_deserialization.rb
+++ b/modules/exploits/linux/http/jenkins_cli_deserialization.rb
@@ -84,8 +84,8 @@ class MetasploitModule < Msf::Exploit::Remote
     /Jenkins\s+ver\.\s+(?<version>\d+(?:\.\d+)*)/ =~ login_res.body
     return Exploit::CheckCode::Safe('Version of Jenkins cannot be found.') unless version
 
-    vers_no = Gem::Version.new(version)
-    return Exploit::CheckCode::Appears("Jenkins version #{version} detected") if vers_no < Gem::Version.new('2.54')
+    vers_no = Rex::Version.new(version)
+    return Exploit::CheckCode::Appears("Jenkins version #{version} detected") if vers_no < Rex::Version.new('2.54')
 
     Exploit::CheckCode::Detected
   end

--- a/modules/exploits/linux/http/librenms_collectd_cmd_inject.rb
+++ b/modules/exploits/linux/http/librenms_collectd_cmd_inject.rb
@@ -70,9 +70,9 @@ class MetasploitModule < Msf::Exploit::Remote
     version = about_res.body.match(/version\s+to\s+(\d+\.\d+\.?\d*)/)
     return Exploit::CheckCode::Detected unless version && version.length > 1
     vprint_status("LibreNMS version #{version[1]} detected")
-    version = Gem::Version.new(version[1])
+    version = Rex::Version.new(version[1])
 
-    return Exploit::CheckCode::Appears if version <= Gem::Version.new('1.50')
+    return Exploit::CheckCode::Appears if version <= Rex::Version.new('1.50')
   end
 
   def login
@@ -125,7 +125,7 @@ class MetasploitModule < Msf::Exploit::Remote
     version = get_version
     print_status("LibreNMS version: #{version}")
 
-    if version && Gem::Version.new(version) < Gem::Version.new('1.50')
+    if version && Rex::Version.new(version) < Rex::Version.new('1.50')
       dev_uri = normalize_uri(target_uri.path, 'ajax_table.php')
       format = '+list_detail'
     else

--- a/modules/exploits/linux/http/nagios_xi_authenticated_rce.rb
+++ b/modules/exploits/linux/http/nagios_xi_authenticated_rce.rb
@@ -178,9 +178,9 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Detected('Could not determine Nagios XI version.')
     end
 
-    @version = Gem::Version.new @version
+    @version = Rex::Version.new @version
 
-    unless @version <= Gem::Version.new('5.6.5')
+    unless @version <= Rex::Version.new('5.6.5')
       return CheckCode::Safe("Target is Nagios XI with version #{@version}.")
     end
 

--- a/modules/exploits/linux/http/nagios_xi_chained_rce.rb
+++ b/modules/exploits/linux/http/nagios_xi_chained_rce.rb
@@ -29,7 +29,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Arch'           => ARCH_CMD,
       'Privileged'     => true,
       'Targets'        => [
-        ['Nagios XI <= 5.2.7', version: Gem::Version.new('5.2.7')]
+        ['Nagios XI <= 5.2.7', version: Rex::Version.new('5.2.7')]
       ],
       'DefaultTarget'  => 0
     ))
@@ -52,7 +52,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if (version = html.at('//input[@name = "version"]/@value'))
       vprint_status("Nagios XI version: #{version}")
-      if Gem::Version.new(version) <= target[:version]
+      if Rex::Version.new(version) <= target[:version]
         return CheckCode::Appears
       end
     end

--- a/modules/exploits/linux/http/nagios_xi_chained_rce_2_electric_boogaloo.rb
+++ b/modules/exploits/linux/http/nagios_xi_chained_rce_2_electric_boogaloo.rb
@@ -37,8 +37,8 @@ class MetasploitModule < Msf::Exploit::Remote
         [
           [
             'Nagios XI 5.2.6 <= 5.4.12',
-            upper_version: Gem::Version.new('5.4.12'),
-            lower_version: Gem::Version.new('5.2.6')
+            upper_version: Rex::Version.new('5.4.12'),
+            lower_version: Rex::Version.new('5.2.6')
           ]
         ],
       'References'     =>
@@ -75,7 +75,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     if (@version = res.get_html_document.at('//input[@name = "version"]/@value').text)
-      @version = Gem::Version.new(@version)
+      @version = Rex::Version.new(@version)
       vprint_good("STEP 0: Found Nagios XI version: #{@version.to_s}")
       if @version < target[:lower_version]
         vprint_bad('Try nagios_xi_chained for this version.')
@@ -121,7 +121,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def get_api_keys
     vprint_status 'STEP 2: Exploiting SQLi to extract user API keys.'
 
-    sqli_parm = @version < Gem::Version.new('5.3.0') ? 'backend_ticket' : 'api_key'
+    sqli_parm = @version < Rex::Version.new('5.3.0') ? 'backend_ticket' : 'api_key'
     sqli_val = rand_text_alpha(rand(5) + 5)
     res = send_request_cgi({
       'uri' => '/nagiosql/admin/helpedit.php',

--- a/modules/exploits/linux/http/nagios_xi_magpie_debug.rb
+++ b/modules/exploits/linux/http/nagios_xi_magpie_debug.rb
@@ -39,7 +39,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Arch'           => [ARCH_X86, ARCH_X64],
       'Targets'        =>
         [
-          ['Nagios XI 5.5.6', version: Gem::Version.new('5.5.6')]
+          ['Nagios XI 5.5.6', version: Rex::Version.new('5.5.6')]
         ],
       'DefaultOptions' =>
         {

--- a/modules/exploits/linux/http/netsweeper_webadmin_unixlogin.rb
+++ b/modules/exploits/linux/http/netsweeper_webadmin_unixlogin.rb
@@ -95,7 +95,7 @@ class MetasploitModule < Msf::Exploit::Remote
       )
     end
 
-    if Gem::Version.new(version) <= Gem::Version.new('6.4.4')
+    if Rex::Version.new(version) <= Rex::Version.new('6.4.4')
       return CheckCode::Appears(
         "Netsweeper #{version} is a vulnerable version."
       )

--- a/modules/exploits/linux/http/nexus_repo_manager_el_injection.rb
+++ b/modules/exploits/linux/http/nexus_repo_manager_el_injection.rb
@@ -94,7 +94,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Unknown('Target did not respond with Nexus version.')
     end
 
-    if Gem::Version.new(version) <= Gem::Version.new('3.21.1')
+    if Rex::Version.new(version) <= Rex::Version.new('3.21.1')
       return CheckCode::Appears("Nexus #{version} is a vulnerable version.")
     end
 

--- a/modules/exploits/linux/http/op5_config_exec.rb
+++ b/modules/exploits/linux/http/op5_config_exec.rb
@@ -61,7 +61,7 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::UnexpectedReply, "#{peer} - Could not connect to web service - no response") if res.nil?
       /Version: (?<version>[\d]{1,2}\.[\d]{1,2}\.[\d]{1,2})[\s]+\|/ =~ res.body
 
-      if version && Gem::Version.new(version) <= Gem::Version.new('7.1.9')
+      if version && Rex::Version.new(version) <= Rex::Version.new('7.1.9')
         vprint_good("Version Detected: #{version}")
         Exploit::CheckCode::Appears
       else

--- a/modules/exploits/linux/http/pandora_fms_events_exec.rb
+++ b/modules/exploits/linux/http/pandora_fms_events_exec.rb
@@ -118,9 +118,9 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Detected('Could not determine the Pandora FMS version.')
     end
 
-    version = Gem::Version.new version
+    version = Rex::Version.new version
 
-    unless version <= Gem::Version.new('7.0.744')
+    unless version <= Rex::Version.new('7.0.744')
       return CheckCode::Safe("Target is Pandora FMS version #{full_version}.")
     end
 

--- a/modules/exploits/linux/http/pandora_fms_sqli.rb
+++ b/modules/exploits/linux/http/pandora_fms_sqli.rb
@@ -87,7 +87,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     unless version.nil?
       vprint_status("Pandora FMS #{version} found")
-      if Gem::Version.new(version) <= Gem::Version.new('5.0SP2')
+      if Rex::Version.new(version) <= Rex::Version.new('5.0SP2')
         return Exploit::CheckCode::Appears
       end
     end

--- a/modules/exploits/linux/http/pandora_ping_cmd_exec.rb
+++ b/modules/exploits/linux/http/pandora_ping_cmd_exec.rb
@@ -63,11 +63,11 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     pandora_version = res.body.scan(%r{<div id="ver_num">v(.*?)</div>}).flatten.first
-    version = Gem::Version.new(pandora_version)
+    version = Rex::Version.new(pandora_version)
 
     print_status("Pandora FMS version #{version}") if version
 
-    if Gem::Version.new(version) <= Gem::Version.new('7.0NG')
+    if Rex::Version.new(version) <= Rex::Version.new('7.0NG')
       return Exploit::CheckCode::Appears
     end
 

--- a/modules/exploits/linux/http/php_imap_open_rce.rb
+++ b/modules/exploits/linux/http/php_imap_open_rce.rb
@@ -103,7 +103,7 @@ class MetasploitModule < Msf::Exploit::Remote
       major, minor = res.body.scan(/PHP Major Version: (?<major>5\.[1-6]{1})<\/li>\s+<li>PHP Minor Version: (?<minor>[\d]?\d)/).flatten
       phpversion = "#{major}.#{minor}"
       if res.code == 200 && res.body =~ /PHP Mail Server Support Test/ && phpversion != '.'
-        if Gem::Version.new(phpversion) < Gem::Version.new('5.6.39')
+        if Rex::Version.new(phpversion) < Rex::Version.new('5.6.39')
           vprint_good("PHP Version #{phpversion} is vulnerable")
           return CheckCode::Appears
         else

--- a/modules/exploits/linux/http/qnap_qcenter_change_passwd_exec.rb
+++ b/modules/exploits/linux/http/qnap_qcenter_change_passwd_exec.rb
@@ -79,10 +79,10 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Detected
     end
 
-    version = Gem::Version.new version
+    version = Rex::Version.new version
     vprint_status "Target is QNAP Q'Center appliance version #{version}"
 
-    if version >= Gem::Version.new('1.7.1083')
+    if version >= Rex::Version.new('1.7.1083')
       return CheckCode::Safe
     end
 

--- a/modules/exploits/linux/http/supervisor_xmlrpc_exec.rb
+++ b/modules/exploits/linux/http/supervisor_xmlrpc_exec.rb
@@ -64,7 +64,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check_version(version)
-    if version <= Gem::Version.new('3.3.2') and version >= Gem::Version.new('3.0a1')
+    if version <= Rex::Version.new('3.3.2') and version >= Rex::Version.new('3.0a1')
       return true
     else
       return false
@@ -89,7 +89,7 @@ class MetasploitModule < Msf::Exploit::Remote
       if res.code == 200
         match = res.body.match(/<span>(\d+\.[\dab]\.\d+)<\/span>/)
         if match
-          version = Gem::Version.new(match[1])
+          version = Rex::Version.new(match[1])
           if check_version(version)
             print_good("Vulnerable version found: #{version}")
             return Exploit::CheckCode::Appears

--- a/modules/exploits/linux/http/unraid_auth_bypass_exec.rb
+++ b/modules/exploits/linux/http/unraid_auth_bypass_exec.rb
@@ -66,7 +66,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     /\sVersion:\s(?<version>\d{1,2}\.\d{1,2}\.\d{1,2})&nbsp;/ =~ res.body
 
-    if version && Gem::Version.new(version) == Gem::Version.new('6.8.0')
+    if version && Rex::Version.new(version) == Rex::Version.new('6.8.0')
       return CheckCode::Appears("Unraid version #{version} appears to be vulnerable")
     end
 

--- a/modules/exploits/linux/http/webmin_backdoor.rb
+++ b/modules/exploits/linux/http/webmin_backdoor.rb
@@ -51,7 +51,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'Platform'       => 'unix',
           'Arch'           => ARCH_CMD,
           'Version'        => [
-            Gem::Version.new('1.890'), Gem::Version.new('1.920')
+            Rex::Version.new('1.890'), Rex::Version.new('1.920')
           ],
           'Type'           => :unix_memory,
           'DefaultOptions' => {'PAYLOAD' => 'cmd/unix/reverse_perl'}
@@ -60,7 +60,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'Platform'       => 'linux',
           'Arch'           => [ARCH_X86, ARCH_X64],
           'Version'        => [
-            Gem::Version.new('1.890'), Gem::Version.new('1.920')
+            Rex::Version.new('1.890'), Rex::Version.new('1.920')
           ],
           'Type'           => :linux_dropper,
           'DefaultOptions' => {'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp'}
@@ -104,7 +104,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Unknown
     end
 
-    version = Gem::Version.new(version)
+    version = Rex::Version.new(version)
 
     vprint_status("Webmin #{version} detected")
     checkcode = CheckCode::Detected

--- a/modules/exploits/linux/local/abrt_sosreport_priv_esc.rb
+++ b/modules/exploits/linux/local/abrt_sosreport_priv_esc.rb
@@ -102,7 +102,7 @@ class MetasploitModule < Msf::Exploit::Local
       vprint_status 'Could not retrieve ABRT package version'
       return CheckCode::Safe
     end
-    unless Gem::Version.new(abrt_version) < Gem::Version.new('2.1.11-35.el7')
+    unless Rex::Version.new(abrt_version) < Rex::Version.new('2.1.11-35.el7')
       vprint_status "ABRT package version #{abrt_version} is not vulnerable"
       return CheckCode::Safe
     end

--- a/modules/exploits/linux/local/apport_abrt_chroot_priv_esc.rb
+++ b/modules/exploits/linux/local/apport_abrt_chroot_priv_esc.rb
@@ -84,9 +84,9 @@ class MetasploitModule < Msf::Exploit::Local
     end
     vprint_good 'Unprivileged user namespaces are permitted'
 
-    kernel_version = Gem::Version.new kernel_release.split('-').first
+    kernel_version = Rex::Version.new kernel_release.split('-').first
 
-    if kernel_version < Gem::Version.new('3.12')
+    if kernel_version < Rex::Version.new('3.12')
       vprint_error "Linux kernel version #{kernel_version} is not vulnerable"
       return CheckCode::Safe
     end
@@ -115,10 +115,10 @@ class MetasploitModule < Msf::Exploit::Local
         return CheckCode::Safe
       end
 
-      apport_version = Gem::Version.new(res.split('-').first)
+      apport_version = Rex::Version.new(res.split('-').first)
 
       # apport 2.13 < 2.17.1
-      if apport_version.between?(Gem::Version.new('2.13'), Gem::Version.new('2.17'))
+      if apport_version.between?(Rex::Version.new('2.13'), Rex::Version.new('2.17'))
         vprint_good "Apport version #{apport_version} is vulnerable"
         return CheckCode::Appears
       end

--- a/modules/exploits/linux/local/bpf_priv_esc.rb
+++ b/modules/exploits/linux/local/bpf_priv_esc.rb
@@ -177,8 +177,8 @@ class MetasploitModule < Msf::Exploit::Local
     release = kernel_release
     version = kernel_version
 
-    if Gem::Version.new(release.split('-').first) < Gem::Version.new('4.4') ||
-       Gem::Version.new(release.split('-').first) > Gem::Version.new('4.5.5')
+    if Rex::Version.new(release.split('-').first) < Rex::Version.new('4.4') ||
+       Rex::Version.new(release.split('-').first) > Rex::Version.new('4.5.5')
       vprint_error "Kernel version #{release} #{version} is not vulnerable"
       return CheckCode::Safe
     end

--- a/modules/exploits/linux/local/bpf_sign_extension_priv_esc.rb
+++ b/modules/exploits/linux/local/bpf_sign_extension_priv_esc.rb
@@ -114,8 +114,8 @@ class MetasploitModule < Msf::Exploit::Local
     vprint_good("System architecture #{arch} is supported")
 
     release = kernel_release
-    if Gem::Version.new(release.split('-').first) > Gem::Version.new('4.14.11') ||
-       Gem::Version.new(release.split('-').first) < Gem::Version.new('4.0')
+    if Rex::Version.new(release.split('-').first) > Rex::Version.new('4.14.11') ||
+       Rex::Version.new(release.split('-').first) < Rex::Version.new('4.0')
       return CheckCode::Safe("Kernel version #{release} is not vulnerable")
     end
 

--- a/modules/exploits/linux/local/exim4_deliver_message_priv_esc.rb
+++ b/modules/exploits/linux/local/exim4_deliver_message_priv_esc.rb
@@ -39,8 +39,8 @@ class MetasploitModule < Msf::Exploit::Local
           [
             [
               'Exim 4.87 - 4.91',
-              lower_version: Gem::Version.new('4.87'),
-              upper_version: Gem::Version.new('4.91')
+              lower_version: Rex::Version.new('4.87'),
+              upper_version: Rex::Version.new('4.91')
             ]
           ],
         'DefaultOptions' =>
@@ -208,7 +208,7 @@ class MetasploitModule < Msf::Exploit::Local
     end
 
     if res =~ /Exim ([0-9\.]+)/i
-      version = Gem::Version.new(Regexp.last_match(1))
+      version = Rex::Version.new(Regexp.last_match(1))
       vprint_status("Found exim version: #{version}")
       if version >= target[:lower_version] && version <= target[:upper_version]
         return CheckCode::Appears

--- a/modules/exploits/linux/local/glibc_ld_audit_dso_load_priv_esc.rb
+++ b/modules/exploits/linux/local/glibc_ld_audit_dso_load_priv_esc.rb
@@ -93,12 +93,12 @@ class MetasploitModule < Msf::Exploit::Local
 
   def check
     glibc_banner = cmd_exec 'ldd --version'
-    glibc_version = Gem::Version.new glibc_banner.scan(/^ldd\s+\(.*\)\s+([\d\.]+)/).flatten.first
+    glibc_version = Rex::Version.new glibc_banner.scan(/^ldd\s+\(.*\)\s+([\d\.]+)/).flatten.first
     if glibc_version.to_s.eql? ''
       vprint_error 'Could not determine the GNU C library version'
       return CheckCode::Safe
-    elsif glibc_version >= Gem::Version.new('2.12.2') ||
-          (glibc_version >= Gem::Version.new('2.11.3') && glibc_version < Gem::Version.new('2.12'))
+    elsif glibc_version >= Rex::Version.new('2.12.2') ||
+          (glibc_version >= Rex::Version.new('2.11.3') && glibc_version < Rex::Version.new('2.12'))
       vprint_error "GNU C Library version #{glibc_version} is not vulnerable"
       return CheckCode::Safe
     end

--- a/modules/exploits/linux/local/glibc_origin_expansion_priv_esc.rb
+++ b/modules/exploits/linux/local/glibc_origin_expansion_priv_esc.rb
@@ -88,14 +88,14 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    v = Gem::Version.new glibc_version
+    v = Rex::Version.new glibc_version
     if v.eql? ''
       vprint_error 'Could not determine the GNU C library version'
       return CheckCode::Safe
     end
 
-    if v >= Gem::Version.new('2.12.2') ||
-       (v >= Gem::Version.new('2.11.3') && v < Gem::Version.new('2.12'))
+    if v >= Rex::Version.new('2.12.2') ||
+       (v >= Rex::Version.new('2.11.3') && v < Rex::Version.new('2.12'))
       vprint_error "GNU C Library version #{v} is not vulnerable"
       return CheckCode::Safe
     end

--- a/modules/exploits/linux/local/glibc_realpath_priv_esc.rb
+++ b/modules/exploits/linux/local/glibc_realpath_priv_esc.rb
@@ -125,7 +125,7 @@ class MetasploitModule < Msf::Exploit::Local
 
   def check
     version = kernel_release
-    if Gem::Version.new(version.split('-').first) < Gem::Version.new('2.6.36')
+    if Rex::Version.new(version.split('-').first) < Rex::Version.new('2.6.36')
       vprint_error "Linux kernel version #{version} is not vulnerable"
       return CheckCode::Safe
     end
@@ -139,7 +139,7 @@ class MetasploitModule < Msf::Exploit::Local
     vprint_good "System architecture #{arch} is supported"
 
     version = glibc_version
-    if Gem::Version.new(version.split('-').first) > Gem::Version.new('2.26')
+    if Rex::Version.new(version.split('-').first) > Rex::Version.new('2.26')
       vprint_error "GNU C Library version #{version} is not vulnerable"
       return CheckCode::Safe
     end

--- a/modules/exploits/linux/local/libuser_roothelper_priv_esc.rb
+++ b/modules/exploits/linux/local/libuser_roothelper_priv_esc.rb
@@ -141,14 +141,14 @@ class MetasploitModule < Msf::Exploit::Local
     vprint_good 'File /etc/passwd is not immutable'
 
     glibc_banner = cmd_exec 'ldd --version'
-    glibc_version = Gem::Version.new glibc_banner.scan(/^ldd\s+\(.*\)\s+([\d\.]+)/).flatten.first
+    glibc_version = Rex::Version.new glibc_banner.scan(/^ldd\s+\(.*\)\s+([\d\.]+)/).flatten.first
     if glibc_version.to_s.eql? ''
       vprint_error 'Could not determine the GNU C library version'
       return CheckCode::Detected
     end
 
     # roothelper.c requires functions only available since glibc 2.6+
-    if glibc_version < Gem::Version.new('2.6')
+    if glibc_version < Rex::Version.new('2.6')
       vprint_error "GNU C Library version #{glibc_version} is not supported"
       return CheckCode::Safe
     end

--- a/modules/exploits/linux/local/nested_namespace_idmap_limit_priv_esc.rb
+++ b/modules/exploits/linux/local/nested_namespace_idmap_limit_priv_esc.rb
@@ -152,10 +152,10 @@ class MetasploitModule < Msf::Exploit::Local
 
     # Patched in 4.18.19 and 4.19.2
     release = kernel_release
-    v = Gem::Version.new release.split('-').first
-    if v < Gem::Version.new('4.15') ||
-       v >= Gem::Version.new('4.19.2') ||
-       (v >= Gem::Version.new('4.18.19') && v < Gem::Version.new('4.19'))
+    v = Rex::Version.new release.split('-').first
+    if v < Rex::Version.new('4.15') ||
+       v >= Rex::Version.new('4.19.2') ||
+       (v >= Rex::Version.new('4.18.19') && v < Rex::Version.new('4.19'))
       vprint_error "Kernel version #{release} is not vulnerable"
       return CheckCode::Safe
     end

--- a/modules/exploits/linux/local/omniresolve_suid_priv_esc.rb
+++ b/modules/exploits/linux/local/omniresolve_suid_priv_esc.rb
@@ -45,7 +45,7 @@ class MetasploitModule < Msf::Exploit::Local
         [
           [
             'Micro Focus (HPE) Data Protector <= 10.40 build 118',
-            upper_version: Gem::Version.new('10.40')
+            upper_version: Rex::Version.new('10.40')
           ]
         ],
       'DefaultOptions' =>
@@ -97,8 +97,8 @@ class MetasploitModule < Msf::Exploit::Local
       build = $3.to_i
       vprint_status("omniresolve version #{version} build #{build}")
 
-      unless Gem::Version.new(version) < target[:upper_version] ||
-             (Gem::Version.new(version) == target[:upper_version] && build <= 118)
+      unless Rex::Version.new(version) < target[:upper_version] ||
+             (Rex::Version.new(version) == target[:upper_version] && build <= 118)
         return CheckCode::Safe
       end
 

--- a/modules/exploits/linux/local/overlayfs_priv_esc.rb
+++ b/modules/exploits/linux/local/overlayfs_priv_esc.rb
@@ -89,10 +89,10 @@ class MetasploitModule < Msf::Exploit::Local
       os_id = cmd_exec('grep ^ID= /etc/os-release')
       case os_id
       when 'ID=ubuntu'
-        kernel = Gem::Version.new(cmd_exec('/bin/uname -r'))
+        kernel = Rex::Version.new(cmd_exec('/bin/uname -r'))
         case kernel.release.to_s
         when '3.13.0'
-          if kernel.between?(Gem::Version.new('3.13.0-24-generic'),Gem::Version.new('3.13.0-54-generic'))
+          if kernel.between?(Rex::Version.new('3.13.0-24-generic'),Rex::Version.new('3.13.0-54-generic'))
             vprint_good("Kernel #{kernel} is vulnerable to CVE-2015-1328")
             return true
           else
@@ -100,7 +100,7 @@ class MetasploitModule < Msf::Exploit::Local
             return false
           end
         when '3.16.0'
-          if kernel.between?(Gem::Version.new('3.16.0-25-generic'),Gem::Version.new('3.16.0-40-generic'))
+          if kernel.between?(Rex::Version.new('3.16.0-25-generic'),Rex::Version.new('3.16.0-40-generic'))
             vprint_good("Kernel #{kernel} is vulnerable to CVE-2015-1328")
             return true
           else
@@ -108,10 +108,10 @@ class MetasploitModule < Msf::Exploit::Local
             return false
           end
         when '3.19.0'
-          if kernel.between?(Gem::Version.new('3.19.0-18-generic'),Gem::Version.new('3.19.0-20-generic'))
+          if kernel.between?(Rex::Version.new('3.19.0-18-generic'),Rex::Version.new('3.19.0-20-generic'))
             vprint_good("Kernel #{kernel} is vulnerable to CVE-2015-1328")
             return true
-          elsif kernel.between?(Gem::Version.new('3.19.0-18-generic'),Gem::Version.new('3.19.0-42-generic'))
+          elsif kernel.between?(Rex::Version.new('3.19.0-18-generic'),Rex::Version.new('3.19.0-42-generic'))
             vprint_good("Kernel #{kernel} is vulnerable to CVE-2015-8660")
             return true
           else
@@ -119,7 +119,7 @@ class MetasploitModule < Msf::Exploit::Local
             return false
           end
         when '4.2.0'
-          if kernel.between?(Gem::Version.new('4.2.0-18-generic'),Gem::Version.new('4.2.0-22-generic'))
+          if kernel.between?(Rex::Version.new('4.2.0-18-generic'),Rex::Version.new('4.2.0-22-generic'))
             vprint_good("Kernel #{kernel} is vulnerable to CVE-2015-8660")
             return true
           else
@@ -131,10 +131,10 @@ class MetasploitModule < Msf::Exploit::Local
           return false
         end
       when 'ID=fedora'
-        kernel = Gem::Version.new(cmd_exec('/usr/bin/uname -r').sub(/\.fc.*/, '')) # we need to remove the trailer after .fc
+        kernel = Rex::Version.new(cmd_exec('/usr/bin/uname -r').sub(/\.fc.*/, '')) # we need to remove the trailer after .fc
         # irb(main):008:0> '4.0.4-301.fc22.x86_64'.sub(/\.fc.*/, '')
         # => "4.0.4-301"
-        if kernel.release < Gem::Version.new('4.2.8')
+        if kernel.release < Rex::Version.new('4.2.8')
           vprint_good("Kernel #{kernel} is vulnerable to CVE-2015-8660.  Exploitation UNTESTED")
           return true
         else

--- a/modules/exploits/linux/local/pkexec.rb
+++ b/modules/exploits/linux/local/pkexec.rb
@@ -72,12 +72,12 @@ class MetasploitModule < Msf::Exploit::Local
     version = cmd_exec('pkexec --version').split.last
 
     # version can be a string, so we check it
-    if version.nil? || !Gem::Version.correct?(version)
+    if version.nil? || !Rex::Version.correct?(version)
       vprint_error('pkexec not found or version incorrect')
       return CheckCode::Unknown
     end
 
-    if Gem::Version.new(version) <= Gem::Version.new('0.101')
+    if Rex::Version.new(version) <= Rex::Version.new('0.101')
       vprint_good("pkexec #{version} found")
       return CheckCode::Appears
     end

--- a/modules/exploits/linux/local/ptrace_traceme_pkexec_helper.rb
+++ b/modules/exploits/linux/local/ptrace_traceme_pkexec_helper.rb
@@ -70,9 +70,9 @@ class MetasploitModule < Msf::Exploit::Local
     # Introduced in 4.10, but also backported
     # Patched in 4.4.185, 4.9.185, 4.14.133, 4.19.58, 5.1.17
     release = kernel_release
-    v = Gem::Version.new release.split('-').first
+    v = Rex::Version.new release.split('-').first
 
-    if v >= Gem::Version.new('5.1.17') || v < Gem::Version.new('3')
+    if v >= Rex::Version.new('5.1.17') || v < Rex::Version.new('3')
       vprint_error "Kernel version #{release} is not vulnerable"
       return CheckCode::Safe
     end

--- a/modules/exploits/linux/local/rds_rds_page_copy_user_priv_esc.rb
+++ b/modules/exploits/linux/local/rds_rds_page_copy_user_priv_esc.rb
@@ -91,8 +91,8 @@ class MetasploitModule < Msf::Exploit::Local
 
   def check
     version = kernel_release
-    unless Gem::Version.new(version.split('-').first) >= Gem::Version.new('2.6.30') &&
-           Gem::Version.new(version.split('-').first) < Gem::Version.new('2.6.37')
+    unless Rex::Version.new(version.split('-').first) >= Rex::Version.new('2.6.30') &&
+           Rex::Version.new(version.split('-').first) < Rex::Version.new('2.6.37')
       return CheckCode::Safe("Linux kernel version #{version} is not vulnerable")
     end
     vprint_good "Linux kernel version #{version} appears to be vulnerable"

--- a/modules/exploits/linux/local/sock_sendpage.rb
+++ b/modules/exploits/linux/local/sock_sendpage.rb
@@ -87,15 +87,15 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    version = Gem::Version.new kernel_release.split('-').first
+    version = Rex::Version.new kernel_release.split('-').first
 
     if version.to_s.eql? ''
       vprint_error 'Could not determine the kernel version'
       return CheckCode::Unknown
     end
 
-    if version.between?(Gem::Version.new('2.4.4'), Gem::Version.new('2.4.37.4')) ||
-       version.between?(Gem::Version.new('2.6.0'), Gem::Version.new('2.6.30.4'))
+    if version.between?(Rex::Version.new('2.4.4'), Rex::Version.new('2.4.37.4')) ||
+       version.between?(Rex::Version.new('2.6.0'), Rex::Version.new('2.6.30.4'))
       vprint_good "Kernel version #{version} appears to be vulnerable"
     else
       vprint_error "Kernel version #{version} is not vulnerable"

--- a/modules/exploits/linux/local/su_login.rb
+++ b/modules/exploits/linux/local/su_login.rb
@@ -112,7 +112,7 @@ class MetasploitModule < Msf::Exploit::Local
       end
 
       # Check that util-linux in of a compatible version.
-      unless version >= Gem::Version.new('2.25')
+      unless version >= Rex::Version.new('2.25')
         vprint_error("The package 'util-linux' must be version 2.25 or higher")
         return CheckCode::Safe
       end
@@ -187,6 +187,6 @@ class MetasploitModule < Msf::Exploit::Local
 
     return false unless match
 
-    return Gem::Version.new(match[:version])
+    return Rex::Version.new(match[:version])
   end
 end

--- a/modules/exploits/linux/local/sudo_baron_samedit.rb
+++ b/modules/exploits/linux/local/sudo_baron_samedit.rb
@@ -91,12 +91,12 @@ class MetasploitModule < Msf::Exploit::Local
     sudo_version = get_versions[:sudo]
     return CheckCode::Unknown('Could not identify the version of sudo.') if sudo_version.nil?
 
-    # fixup the p number used by sudo to be compatible with Gem::Version
+    # fixup the p number used by sudo to be compatible with Rex::Version
     sudo_version.gsub!(/p/, '.')
 
     vuln_builds = [
-      [Gem::Version.new('1.8.2'), Gem::Version.new('1.8.31.2')],
-      [Gem::Version.new('1.9.0'), Gem::Version.new('1.9.5.1')],
+      [Rex::Version.new('1.8.2'), Rex::Version.new('1.8.31.2')],
+      [Rex::Version.new('1.9.0'), Rex::Version.new('1.9.5.1')],
     ]
 
     if sudo_version == '1.8.31'
@@ -104,7 +104,7 @@ class MetasploitModule < Msf::Exploit::Local
       return CheckCode::Detected("sudo #{sudo_version} maybe a vulnerable build.")
     end
 
-    if vuln_builds.any? { |build_range| Gem::Version.new(sudo_version).between?(*build_range) }
+    if vuln_builds.any? { |build_range| Rex::Version.new(sudo_version).between?(*build_range) }
       return CheckCode::Appears("sudo #{sudo_version} is a vulnerable build.")
     end
 

--- a/modules/exploits/linux/local/vmware_alsa_config.rb
+++ b/modules/exploits/linux/local/vmware_alsa_config.rb
@@ -135,14 +135,14 @@ class MetasploitModule < Msf::Exploit::Local
 
     config = read_file('/etc/vmware/config') rescue ''
     if config =~ /player\.product\.version\s*=\s*"([\d\.]+)"/
-      version = Gem::Version.new $1.gsub(/\.$/, '')
+      version = Rex::Version.new $1.gsub(/\.$/, '')
       vprint_status "VMware is version #{version}"
     else
       vprint_error 'Could not determine VMware version.'
       return CheckCode::Detected
     end
 
-    if version >= Gem::Version.new('12.5.6')
+    if version >= Rex::Version.new('12.5.6')
       vprint_error 'Target version is not vulnerable'
       return CheckCode::Safe
     end

--- a/modules/exploits/linux/misc/aerospike_database_udf_cmd_exec.rb
+++ b/modules/exploits/linux/misc/aerospike_database_udf_cmd_exec.rb
@@ -188,7 +188,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     vprint_status("Aerospike Database version #{version}")
 
-    if Gem::Version.new(version) >= Gem::Version.new('5.1.0.3')
+    if Rex::Version.new(version) >= Rex::Version.new('5.1.0.3')
       return CheckCode::Safe('Version is not vulnerable')
     end
 

--- a/modules/exploits/linux/misc/hid_discoveryd_command_blink_on_unauth_rce.rb
+++ b/modules/exploits/linux/misc/hid_discoveryd_command_blink_on_unauth_rce.rb
@@ -89,24 +89,24 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # Vulnerable version mappings from VertXploit
     vuln = false
-    version = Gem::Version.new(hid_res[:version].to_s)
+    version = Rex::Version.new(hid_res[:version].to_s)
     case hid_res[:model]
     when 'E400'     # EDGEPlus
-      vuln = true if version <= Gem::Version.new('3.5.1.1483')
+      vuln = true if version <= Rex::Version.new('3.5.1.1483')
     when 'EH400'    # EDGE EVO
-      vuln = true if version <= Gem::Version.new('3.5.1.1483')
+      vuln = true if version <= Rex::Version.new('3.5.1.1483')
     when 'EHS400'   # EDGE EVO Solo
-      vuln = true if version <= Gem::Version.new('3.5.1.1483')
+      vuln = true if version <= Rex::Version.new('3.5.1.1483')
     when 'ES400'    # EDGEPlus Solo
-      vuln = true if version <= Gem::Version.new('3.5.1.1483')
+      vuln = true if version <= Rex::Version.new('3.5.1.1483')
     when 'V2-V1000' # VertX EVO
-      vuln = true if version <= Gem::Version.new('3.5.1.1483')
+      vuln = true if version <= Rex::Version.new('3.5.1.1483')
     when 'V2-V2000' # VertX EVO
-      vuln = true if version <= Gem::Version.new('3.5.1.1483')
+      vuln = true if version <= Rex::Version.new('3.5.1.1483')
     when 'V1000'    # VertX Legacy
-      vuln = true if version <= Gem::Version.new('2.2.7.568')
+      vuln = true if version <= Rex::Version.new('2.2.7.568')
     when 'V2000'    # VertX Legacy
-      vuln = true if version <= Gem::Version.new('2.2.7.568')
+      vuln = true if version <= Rex::Version.new('2.2.7.568')
     else
       vprint_error "#{rhost}:#{rport} - Device model was not recognized"
       return CheckCode::Detected

--- a/modules/exploits/linux/redis/redis_replication_cmd_exec.rb
+++ b/modules/exploits/linux/redis/redis_replication_cmd_exec.rb
@@ -88,8 +88,8 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     # Only vulnerable to version 4.x or 5.x
-    version = Gem::Version.new(redis_version)
-    if version >= Gem::Version.new('4.0.0')
+    version = Rex::Version.new(redis_version)
+    if version >= Rex::Version.new('4.0.0')
       vprint_status("Redis version is #{redis_version}")
       return Exploit::CheckCode::Vulnerable
     end

--- a/modules/exploits/linux/samba/is_known_pipename.rb
+++ b/modules/exploits/linux/samba/is_known_pipename.rb
@@ -448,29 +448,29 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Safe
     end
 
-    samba_version = Gem::Version.new($1.gsub(/\.$/, ''))
+    samba_version = Rex::Version.new($1.gsub(/\.$/, ''))
 
     vprint_status("Samba version identified as #{samba_version.to_s}")
 
-    if samba_version < Gem::Version.new('3.5.0')
+    if samba_version < Rex::Version.new('3.5.0')
       return CheckCode::Safe
     end
 
     # Patched in 4.4.14
-    if samba_version < Gem::Version.new('4.5.0') &&
-       samba_version >= Gem::Version.new('4.4.14')
+    if samba_version < Rex::Version.new('4.5.0') &&
+       samba_version >= Rex::Version.new('4.4.14')
       return CheckCode::Safe
     end
 
     # Patched in 4.5.10
-    if samba_version > Gem::Version.new('4.5.0') &&
-       samba_version < Gem::Version.new('4.6.0') &&
-       samba_version >= Gem::Version.new('4.5.10')
+    if samba_version > Rex::Version.new('4.5.0') &&
+       samba_version < Rex::Version.new('4.6.0') &&
+       samba_version >= Rex::Version.new('4.5.10')
       return CheckCode::Safe
     end
 
     # Patched in 4.6.4
-    if samba_version >= Gem::Version.new('4.6.4')
+    if samba_version >= Rex::Version.new('4.6.4')
       return CheckCode::Safe
     end
 

--- a/modules/exploits/linux/smtp/apache_james_exec.rb
+++ b/modules/exploits/linux/smtp/apache_james_exec.rb
@@ -98,8 +98,8 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Detected("Could not determine JAMES Remote Administration Tool version")
     end
     # Create version objects
-    target_version = Gem::Version.new(version)
-    vulnerable_version = Gem::Version.new("2.3.2")
+    target_version = Rex::Version.new(version)
+    vulnerable_version = Rex::Version.new("2.3.2")
 
     # Check version number
     if target_version > vulnerable_version

--- a/modules/exploits/linux/upnp/belkin_wemo_upnp_exec.rb
+++ b/modules/exploits/linux/upnp/belkin_wemo_upnp_exec.rb
@@ -93,7 +93,7 @@ class MetasploitModule < Msf::Exploit::Remote
     checkcode = CheckCode::Detected
 
     version = (v = res.get_xml_document.at('firmwareVersion')&.text) &&
-              v =~ /WeMo_WW_(\d+(?:\.\d+)+)/ && $1 && Gem::Version.new($1)
+              v =~ /WeMo_WW_(\d+(?:\.\d+)+)/ && $1 && Rex::Version.new($1)
 
     unless version
       vprint_error('Could not determine firmware version')
@@ -103,7 +103,7 @@ class MetasploitModule < Msf::Exploit::Remote
     vprint_status("Found firmware version: #{version}")
 
     # https://www.tripwire.com/state-of-security/featured/my-sector-story-root-shell-on-the-belkin-wemo-switch/
-    if version < Gem::Version.new('2.00.8643')
+    if version < Rex::Version.new('2.00.8643')
       vprint_good("Firmware version #{version} < 2.00.8643")
       checkcode = CheckCode::Appears
     else

--- a/modules/exploits/multi/browser/adobe_flash_hacking_team_uaf.rb
+++ b/modules/exploits/multi/browser/adobe_flash_hacking_team_uaf.rb
@@ -67,9 +67,9 @@ class MetasploitModule < Msf::Exploit::Remote
           :flash   => lambda do |ver|
             case target.name
             when 'Windows'
-              return true if Gem::Version.new(ver) <= Gem::Version.new('18.0.0.194')
+              return true if Rex::Version.new(ver) <= Rex::Version.new('18.0.0.194')
             when 'Linux'
-              return true if ver =~ /^11\./ && Gem::Version.new(ver) <= Gem::Version.new('11.2.202.468')
+              return true if ver =~ /^11\./ && Rex::Version.new(ver) <= Rex::Version.new('11.2.202.468')
             end
 
             false

--- a/modules/exploits/multi/browser/adobe_flash_nellymoser_bof.rb
+++ b/modules/exploits/multi/browser/adobe_flash_nellymoser_bof.rb
@@ -70,10 +70,10 @@ class MetasploitModule < Msf::Exploit::Remote
           :flash   => lambda do |ver|
             case target.name
             when 'Windows'
-              return true if ver =~ /^18\./ && Gem::Version.new(ver) <= Gem::Version.new('18.0.0.161')
-              return true if ver =~ /^17\./ && Gem::Version.new(ver) != Gem::Version.new('17.0.0.169')
+              return true if ver =~ /^18\./ && Rex::Version.new(ver) <= Rex::Version.new('18.0.0.161')
+              return true if ver =~ /^17\./ && Rex::Version.new(ver) != Rex::Version.new('17.0.0.169')
             when 'Linux'
-              return true if ver =~ /^11\./ && Gem::Version.new(ver) <= Gem::Version.new('11.2.202.466') && Gem::Version.new(ver) != Gem::Version.new('11.2.202.457')
+              return true if ver =~ /^11\./ && Rex::Version.new(ver) <= Rex::Version.new('11.2.202.466') && Rex::Version.new(ver) != Rex::Version.new('11.2.202.457')
             end
 
             false

--- a/modules/exploits/multi/browser/adobe_flash_net_connection_confusion.rb
+++ b/modules/exploits/multi/browser/adobe_flash_net_connection_confusion.rb
@@ -67,9 +67,9 @@ class MetasploitModule < Msf::Exploit::Remote
           :flash   => lambda do |ver|
             case target.name
             when 'Windows'
-              return true if ver =~ /^16\./ && Gem::Version.new(ver) <= Gem::Version.new('16.0.0.305')
+              return true if ver =~ /^16\./ && Rex::Version.new(ver) <= Rex::Version.new('16.0.0.305')
             when 'Linux'
-              return true if ver =~ /^11\./ && Gem::Version.new(ver) <= Gem::Version.new('11.2.202.442')
+              return true if ver =~ /^11\./ && Rex::Version.new(ver) <= Rex::Version.new('11.2.202.442')
             end
 
             false

--- a/modules/exploits/multi/browser/adobe_flash_opaque_background_uaf.rb
+++ b/modules/exploits/multi/browser/adobe_flash_opaque_background_uaf.rb
@@ -75,7 +75,7 @@ class MetasploitModule < Msf::Exploit::Remote
           :flash   => lambda do |ver|
             case target.name
             when 'Windows'
-              return true if ver =~ /^18\./ && Gem::Version.new(ver) <= Gem::Version.new('18.0.0.203')
+              return true if ver =~ /^18\./ && Rex::Version.new(ver) <= Rex::Version.new('18.0.0.203')
             end
 
             false

--- a/modules/exploits/multi/browser/adobe_flash_pixel_bender_bof.rb
+++ b/modules/exploits/multi/browser/adobe_flash_pixel_bender_bof.rb
@@ -64,11 +64,11 @@ class MetasploitModule < Msf::Exploit::Remote
           :flash   => lambda do |ver|
             case target.name
             when 'Windows'
-              return true if ver =~ /^11\./ && Gem::Version.new(ver) <= Gem::Version.new('11.7.700.275')
+              return true if ver =~ /^11\./ && Rex::Version.new(ver) <= Rex::Version.new('11.7.700.275')
               return true if ver =~ /^12\./
-              return true if ver =~ /^13\./ && Gem::Version.new(ver) <= Gem::Version.new('13.0.0.182')
+              return true if ver =~ /^13\./ && Rex::Version.new(ver) <= Rex::Version.new('13.0.0.182')
             when 'Linux'
-              return true if ver =~ /^11\./ && Gem::Version.new(ver) <= Gem::Version.new('11.2.202.350')
+              return true if ver =~ /^11\./ && Rex::Version.new(ver) <= Rex::Version.new('11.2.202.350')
             end
 
             false

--- a/modules/exploits/multi/browser/adobe_flash_shader_drawing_fill.rb
+++ b/modules/exploits/multi/browser/adobe_flash_shader_drawing_fill.rb
@@ -63,9 +63,9 @@ class MetasploitModule < Msf::Exploit::Remote
           :flash   => lambda do |ver|
             case target.name
             when 'Windows'
-              return true if ver =~ /^17\./ && Gem::Version.new(ver) <= Gem::Version.new('17.0.0.188')
+              return true if ver =~ /^17\./ && Rex::Version.new(ver) <= Rex::Version.new('17.0.0.188')
             when 'Linux'
-              return true if ver =~ /^11\./ && Gem::Version.new(ver) <= Gem::Version.new('11.2.202.460')
+              return true if ver =~ /^11\./ && Rex::Version.new(ver) <= Rex::Version.new('11.2.202.460')
             end
 
             false

--- a/modules/exploits/multi/browser/adobe_flash_shader_job_overflow.rb
+++ b/modules/exploits/multi/browser/adobe_flash_shader_job_overflow.rb
@@ -67,9 +67,9 @@ class MetasploitModule < Msf::Exploit::Remote
           :flash   => lambda do |ver|
             case target.name
             when 'Windows'
-              return true if ver =~ /^17\./ && Gem::Version.new(ver) <= Gem::Version.new('17.0.0.169')
+              return true if ver =~ /^17\./ && Rex::Version.new(ver) <= Rex::Version.new('17.0.0.169')
             when 'Linux'
-              return true if ver =~ /^11\./ && Gem::Version.new(ver) <= Gem::Version.new('11.2.202.457')
+              return true if ver =~ /^11\./ && Rex::Version.new(ver) <= Rex::Version.new('11.2.202.457')
             end
 
             false

--- a/modules/exploits/multi/browser/adobe_flash_uncompress_zlib_uaf.rb
+++ b/modules/exploits/multi/browser/adobe_flash_uncompress_zlib_uaf.rb
@@ -63,9 +63,9 @@ class MetasploitModule < Msf::Exploit::Remote
           :flash   => lambda do |ver|
             case target.name
             when 'Windows'
-              return true if ver =~ /^16\./ && Gem::Version.new(ver) <= Gem::Version.new('16.0.0.287')
+              return true if ver =~ /^16\./ && Rex::Version.new(ver) <= Rex::Version.new('16.0.0.287')
             when 'Linux'
-              return true if ver =~ /^11\./ && Gem::Version.new(ver) <= Gem::Version.new('11.2.202.438')
+              return true if ver =~ /^11\./ && Rex::Version.new(ver) <= Rex::Version.new('11.2.202.438')
             end
 
             false

--- a/modules/exploits/multi/http/atutor_upload_traversal.rb
+++ b/modules/exploits/multi/http/atutor_upload_traversal.rb
@@ -154,8 +154,8 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Detected('Unable to obtain ATutor version. However, the project is no longer maintained, so the target is likely vulnerable.')
     end
 
-    @version = Gem::Version.new(@version)
-    unless @version <= Gem::Version.new('2.4')
+    @version = Rex::Version.new(@version)
+    unless @version <= Rex::Version.new('2.4')
       return CheckCode::Unknown("Target is ATutor with version #{@version}.")
     end
 

--- a/modules/exploits/multi/http/cmsms_object_injection_rce.rb
+++ b/modules/exploits/multi/http/cmsms_object_injection_rce.rb
@@ -84,10 +84,10 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Safe
     end
 
-    version = Gem::Version.new(res.body.scan(/CMS Made Simple<\/a> version (\d+\.\d+\.\d+)/).flatten.first)
+    version = Rex::Version.new(res.body.scan(/CMS Made Simple<\/a> version (\d+\.\d+\.\d+)/).flatten.first)
     vprint_status("#{peer} - CMS Made Simple Version: #{version}")
 
-    if version <= Gem::Version.new('2.2.9.1')
+    if version <= Rex::Version.new('2.2.9.1')
       return CheckCode::Appears
     end
 

--- a/modules/exploits/multi/http/cmsms_showtime2_rce.rb
+++ b/modules/exploits/multi/http/cmsms_showtime2_rce.rb
@@ -120,8 +120,8 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     if res.code == 200
-      module_version = Gem::Version.new(res.body.scan(/^version = "?(\d\.\d\.\d)"?/).flatten.first)
-      if module_version < Gem::Version.new('3.6.3')
+      module_version = Rex::Version.new(res.body.scan(/^version = "?(\d\.\d\.\d)"?/).flatten.first)
+      if module_version < Rex::Version.new('3.6.3')
         # Showtime2 module is uploaded and present on "Module Manager" section but it could be NOT installed.
         vprint_status("Showtime2 version: #{module_version}")
         return Exploit::CheckCode::Appears

--- a/modules/exploits/multi/http/cmsms_upload_rename_rce.rb
+++ b/modules/exploits/multi/http/cmsms_upload_rename_rce.rb
@@ -68,10 +68,10 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     if res.body =~ %r{CMS Made Simple</a> version (\d+\.\d+\.\d+)}i
-      version = Gem::Version.new($1)
+      version = Rex::Version.new($1)
       vprint_status("#{peer} - CMS Made Simple Version: #{version}")
 
-      if version == Gem::Version.new('2.2.5')
+      if version == Rex::Version.new('2.2.5')
         return CheckCode::Appears
       end
     end

--- a/modules/exploits/multi/http/gitlab_file_read_rce.rb
+++ b/modules/exploits/multi/http/gitlab_file_read_rce.rb
@@ -468,14 +468,14 @@ class MetasploitModule < Msf::Exploit::Remote
 
     git_lab_client = GitLabClient.new(self)
     git_lab_client.sign_in(datastore['USERNAME'], datastore['PASSWORD'])
-    version = Gem::Version.new(git_lab_client.version['version'][/(\d+.\d+.\d+)/, 1])
+    version = Rex::Version.new(git_lab_client.version['version'][/(\d+.\d+.\d+)/, 1])
 
     # Arbitrary file reads are present from 8.5 and fixed in 12.9.1, 12.8.8, and 12.7.8
     # However, RCE is only available from 12.4 and fixed in 12.9.1, 12.8.8, and 12.7.8
     has_rce_present = (
-      version.between?(Gem::Version.new('12.4.0'), Gem::Version.new('12.7.7')) ||
-        version.between?(Gem::Version.new('12.8.0'), Gem::Version.new('12.8.7')) ||
-        version == Gem::Version.new('12.9.0')
+      version.between?(Rex::Version.new('12.4.0'), Rex::Version.new('12.7.7')) ||
+        version.between?(Rex::Version.new('12.8.0'), Rex::Version.new('12.8.7')) ||
+        version == Rex::Version.new('12.9.0')
     )
     if has_rce_present
       return Exploit::CheckCode::Appears("GitLab #{version} is a vulnerable version.")

--- a/modules/exploits/multi/http/jenkins_metaprogramming.rb
+++ b/modules/exploits/multi/http/jenkins_metaprogramming.rb
@@ -63,14 +63,14 @@ class MetasploitModule < Msf::Exploit::Remote
         ['Unix In-Memory',
           'Platform'       => 'unix',
           'Arch'           => ARCH_CMD,
-          'Version'        => Gem::Version.new('2.137'),
+          'Version'        => Rex::Version.new('2.137'),
           'Type'           => :unix_memory,
           'DefaultOptions' => {'PAYLOAD' => 'cmd/unix/reverse_netcat'}
         ],
         ['Java Dropper',
           'Platform'       => 'java',
           'Arch'           => ARCH_JAVA,
-          'Version'        => Gem::Version.new('2.137'),
+          'Version'        => Rex::Version.new('2.137'),
           'Type'           => :java_dropper,
           'DefaultOptions' => {'PAYLOAD' => 'java/meterpreter/reverse_https'}
         ]
@@ -111,7 +111,7 @@ class MetasploitModule < Msf::Exploit::Remote
     vprint_status("Jenkins #{version} detected")
     checkcode = CheckCode::Detected
 
-    if Gem::Version.new(version) > target['Version']
+    if Rex::Version.new(version) > target['Version']
       vprint_error("Jenkins #{version} is not a supported target")
       return CheckCode::Safe
     end

--- a/modules/exploits/multi/http/joomla_http_header_rce.rb
+++ b/modules/exploits/multi/http/joomla_http_header_rce.rb
@@ -78,7 +78,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     php_version, rest = res.headers['X-Powered-By'].scan(/PHP\/([\d\.]+)(?:-(.+))?/i).flatten || ''
-    version = Gem::Version.new(php_version)
+    version = Rex::Version.new(php_version)
     vulnerable = false
 
     # check for ubuntu and debian specific versions. Was fixed in
@@ -93,11 +93,11 @@ class MetasploitModule < Msf::Exploit::Remote
       sub_version = rest.scan(/^\dubuntu([\d\.]+)/i).flatten.first || ''
       vprint_status("Found Ubuntu PHP version #{res.headers['X-Powered-By']}")
 
-      if version > Gem::Version.new('5.5.9')
+      if version > Rex::Version.new('5.5.9')
         vulnerable = false
-      elsif version == Gem::Version.new('5.5.9') && Gem::Version.new(sub_version) >= Gem::Version.new('4.13')
+      elsif version == Rex::Version.new('5.5.9') && Rex::Version.new(sub_version) >= Rex::Version.new('4.13')
         vulnerable = false
-      elsif version == Gem::Version.new('5.3.10') && Gem::Version.new(sub_version) >= Gem::Version.new('3.20')
+      elsif version == Rex::Version.new('5.3.10') && Rex::Version.new(sub_version) >= Rex::Version.new('3.20')
         vulnerable = false
       else
         vulnerable = true
@@ -106,18 +106,18 @@ class MetasploitModule < Msf::Exploit::Remote
       sub_version = rest.scan(/^\d+\+deb([\du]+)/i).flatten.first || ''
       vprint_status("Found Debian PHP version #{res.headers['X-Powered-By']}")
 
-      if version > Gem::Version.new('5.4.45')
+      if version > Rex::Version.new('5.4.45')
         vulnerable = false
-      elsif version == Gem::Version.new('5.4.45') && sub_version != '7u1'
+      elsif version == Rex::Version.new('5.4.45') && sub_version != '7u1'
         vulnerable = false
       else
         vulnerable = true
       end
     else
       vprint_status("Found PHP version #{res.headers['X-Powered-By']}")
-      vulnerable = true if version <= Gem::Version.new('5.4.44')
-      vulnerable = true if version.between?(Gem::Version.new('5.5.0'), Gem::Version.new('5.5.28'))
-      vulnerable = true if version.between?(Gem::Version.new('5.6.0'), Gem::Version.new('5.6.12'))
+      vulnerable = true if version <= Rex::Version.new('5.4.44')
+      vulnerable = true if version.between?(Rex::Version.new('5.5.0'), Rex::Version.new('5.5.28'))
+      vulnerable = true if version.between?(Rex::Version.new('5.6.0'), Rex::Version.new('5.6.12'))
     end
 
     unless vulnerable
@@ -128,7 +128,7 @@ class MetasploitModule < Msf::Exploit::Remote
     j_version = joomla_version
     unless j_version.nil?
       vprint_status("Detected Joomla version #{j_version}")
-      return Exploit::CheckCode::Appears if Gem::Version.new(j_version) < Gem::Version.new('3.4.6')
+      return Exploit::CheckCode::Appears if Rex::Version.new(j_version) < Rex::Version.new('3.4.6')
     end
 
     return Exploit::CheckCode::Detected if online

--- a/modules/exploits/multi/http/manage_engine_dc_pmp_sqli.rb
+++ b/modules/exploits/multi/http/manage_engine_dc_pmp_sqli.rb
@@ -614,18 +614,18 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def ver_lt(a, b)
-    Gem::Version.new(a) < Gem::Version.new(b)
+    Rex::Version.new(a) < Rex::Version.new(b)
   end
 
   def ver_lt_eq(a, b)
-    Gem::Version.new(a) <= Gem::Version.new(b)
+    Rex::Version.new(a) <= Rex::Version.new(b)
   end
 
   def ver_gt_eq(a, b)
-    Gem::Version.new(a) >= Gem::Version.new(b)
+    Rex::Version.new(a) >= Rex::Version.new(b)
   end
 
   def ver_gt(a, b)
-    Gem::Version.new(a) > Gem::Version.new(b)
+    Rex::Version.new(a) > Rex::Version.new(b)
   end
 end

--- a/modules/exploits/multi/http/mantisbt_manage_proj_page_rce.rb
+++ b/modules/exploits/multi/http/mantisbt_manage_proj_page_rce.rb
@@ -60,11 +60,11 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Unknown
     end
 
-    version = Gem::Version.new(Regexp.last_match[1])
+    version = Rex::Version.new(Regexp.last_match[1])
 
     vprint_status("Mantis version #{version} detected")
 
-    if res.code == 200 && version <= Gem::Version.new('1.1.3')
+    if res.code == 200 && version <= Rex::Version.new('1.1.3')
       return CheckCode::Appears
     end
 

--- a/modules/exploits/multi/http/mantisbt_php_exec.rb
+++ b/modules/exploits/multi/http/mantisbt_php_exec.rb
@@ -89,9 +89,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
     return Exploit::CheckCode::Unknown if version.nil?
 
-    gem_version = Gem::Version.new(version)
-    gem_version_introduced = Gem::Version.new('1.2.0a3')
-    gem_version_fixed = Gem::Version.new('1.2.18')
+    gem_version = Rex::Version.new(version)
+    gem_version_introduced = Rex::Version.new('1.2.0a3')
+    gem_version_fixed = Rex::Version.new('1.2.18')
 
     if gem_version < gem_version_fixed && gem_version >= gem_version_introduced
       return Msf::Exploit::CheckCode::Appears

--- a/modules/exploits/multi/http/maracms_upload_exec.rb
+++ b/modules/exploits/multi/http/maracms_upload_exec.rb
@@ -119,9 +119,9 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Detected('Could not determine MaraCMS version.')
     end
 
-    version = Gem::Version.new version
+    version = Rex::Version.new version
 
-    unless version <= Gem::Version.new('7.2') # 7.2 is the version listed on the about page for MaraCMS 7.5
+    unless version <= Rex::Version.new('7.2') # 7.2 is the version listed on the about page for MaraCMS 7.5
       # MaraCMS no longer seems to be maintained, but the check below is added in case they every update it
       return CheckCode::Safe('Target is likely MaraCMS with a version higher than 7.5 and may not be vulnerable.')
     end

--- a/modules/exploits/multi/http/monstra_fileupload_exec.rb
+++ b/modules/exploits/multi/http/monstra_fileupload_exec.rb
@@ -69,8 +69,8 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     if res.body =~ /<\/a>.*?Version (\d+\.\d+\.\d+)/i
-      version = Gem::Version.new($1)
-      vulnVersion = Gem::Version.new('3.0.4')
+      version = Rex::Version.new($1)
+      vulnVersion = Rex::Version.new('3.0.4')
       vprint_status("Monstra CMS: #{version}")
 
       if version > vulnVersion

--- a/modules/exploits/multi/http/nostromo_code_exec.rb
+++ b/modules/exploits/multi/http/nostromo_code_exec.rb
@@ -75,7 +75,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if res.code == 200 and res.headers['Server'] =~ /nostromo [\d.]{5}/
       /nostromo (?<version>[\d.]{5})/ =~ res.headers['Server']
-      if Gem::Version.new(version) <= Gem::Version.new('1.9.6')
+      if Rex::Version.new(version) <= Rex::Version.new('1.9.6')
         return CheckCode::Appears
       end
     end

--- a/modules/exploits/multi/http/openmrs_deserialization.rb
+++ b/modules/exploits/multi/http/openmrs_deserialization.rb
@@ -79,9 +79,9 @@ class MetasploitModule < Msf::Exploit::Remote
     version_no = version_no.match(/\d+\.\d+\.\d*/)
     return CheckCode::Detected('Successfully identified OpenMRS, but cannot detect version') unless version_no
 
-    version_no = Gem::Version.new(version_no)
+    version_no = Rex::Version.new(version_no)
 
-    if (version_no < Gem::Version.new('1.11.8') || version_no.between?(Gem::Version.new('2'), Gem::Version.new('2.1.3')))
+    if (version_no < Rex::Version.new('1.11.8') || version_no.between?(Rex::Version.new('2'), Rex::Version.new('2.1.3')))
       return CheckCode::Appears("OpenMRS platform version: #{version_no}")
     end
 

--- a/modules/exploits/multi/http/phpmyadmin_lfi_rce.rb
+++ b/modules/exploits/multi/http/phpmyadmin_lfi_rce.rb
@@ -67,10 +67,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # v4.8.0 || 4.8.1 phpMyAdmin
     if res.body =~ /PMA_VERSION:"(\d+\.\d+\.\d+)"/
-      version = Gem::Version.new($1)
+      version = Rex::Version.new($1)
       vprint_status("#{peer} - phpMyAdmin version: #{version}")
 
-      if version == Gem::Version.new('4.8.0') || version == Gem::Version.new('4.8.1')
+      if version == Rex::Version.new('4.8.0') || version == Rex::Version.new('4.8.1')
         return Exploit::CheckCode::Appears
       end
       return Exploit::CheckCode::Safe

--- a/modules/exploits/multi/http/phpmyadmin_null_termination_exec.rb
+++ b/modules/exploits/multi/http/phpmyadmin_null_termination_exec.rb
@@ -76,9 +76,9 @@ class MetasploitModule < Msf::Exploit::Remote
       vprint_status("#{peer} - PHP version: #{php_version}")
 
       if php_version =~ /PHP\/(\d+\.\d+\.\d+)/
-        version = Gem::Version.new($1)
+        version = Rex::Version.new($1)
         vprint_status("#{peer} - PHP version: #{version.to_s}")
-        if version > Gem::Version.new('5.4.6')
+        if version > Rex::Version.new('5.4.6')
           return Exploit::CheckCode::Safe
         end
       end
@@ -88,12 +88,12 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # 4.3.0 - 4.6.2 authorized user RCE exploit
     if res.body =~ /pmaversion = '(\d+\.\d+\.\d+)';/
-      version = Gem::Version.new($1)
+      version = Rex::Version.new($1)
       vprint_status("#{peer} - phpMyAdmin version: #{version.to_s}")
 
-      if version >= Gem::Version.new('4.3.0') and version <= Gem::Version.new('4.6.2')
+      if version >= Rex::Version.new('4.3.0') and version <= Rex::Version.new('4.6.2')
         return Exploit::CheckCode::Appears
-      elsif version < Gem::Version.new('4.3.0')
+      elsif version < Rex::Version.new('4.3.0')
         return Exploit::CheckCode::Detected
       end
       return Exploit::CheckCode::Safe

--- a/modules/exploits/multi/http/pimcore_unserialize_rce.rb
+++ b/modules/exploits/multi/http/pimcore_unserialize_rce.rb
@@ -143,10 +143,10 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def assign_target(version)
-    if Gem::Version.new(version) >= Gem::Version.new('5.0.0') && Gem::Version.new(version) <= Gem::Version.new('5.6.6')
+    if Rex::Version.new(version) >= Rex::Version.new('5.0.0') && Rex::Version.new(version) <= Rex::Version.new('5.6.6')
       print_good("The target is vulnerable!")
       return targets[0]
-    elsif Gem::Version.new(version) >= Gem::Version.new('4.0.0') && Gem::Version.new(version) <= Gem::Version.new('4.6.5')
+    elsif Rex::Version.new(version) >= Rex::Version.new('4.0.0') && Rex::Version.new(version) <= Rex::Version.new('4.6.5')
       print_good("The target is vulnerable!")
       return targets[1]
     else

--- a/modules/exploits/multi/http/solr_velocity_rce.rb
+++ b/modules/exploits/multi/http/solr_velocity_rce.rb
@@ -197,7 +197,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # convert to JSON
     ver_json = ver.get_json_document
     # get Solr version
-    solr_version = Gem::Version.new(ver_json['lucene']['solr-spec-version'])
+    solr_version = Rex::Version.new(ver_json['lucene']['solr-spec-version'])
     print_status("Found Apache Solr #{solr_version}")
     # get OS version details
     @target_platform = ver_json['system']['name']
@@ -211,7 +211,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     # the vulnerability is only present in Solr versions <= 8.3.0
-    unless solr_version <= Gem::Version.new('8.3.0')
+    unless solr_version <= Rex::Version.new('8.3.0')
       return CheckCode::Safe('Running version of Solr is not vulnerable!')
     end
 

--- a/modules/exploits/multi/http/totaljs_cms_widget_exec.rb
+++ b/modules/exploits/multi/http/totaljs_cms_widget_exec.rb
@@ -116,9 +116,9 @@ class MetasploitModule < Msf::Exploit::Remote
     return code unless element.respond_to?(:text)
     title = element.text.scan(/CMS v([\d\.]+)/).flatten.first
     return code unless title
-    version = Gem::Version.new(title)
+    version = Rex::Version.new(title)
 
-    if version <= Gem::Version.new('12')
+    if version <= Rex::Version.new('12')
       # If we are able to check the version, we could try the default cred and attempt
       # to execute malicious code and see how the application responds. However, this
       # seems to a bit too aggressive so I'll leave that to the exploit part.

--- a/modules/exploits/multi/http/vbulletin_getindexablecontent.rb
+++ b/modules/exploits/multi/http/vbulletin_getindexablecontent.rb
@@ -478,9 +478,9 @@ class MetasploitModule < Msf::Exploit::Remote
     return CheckCode::Safe if res.body.to_s =~ /vBulletin 5\.6\.1 Patch Level 1/
 
     if res.body.to_s =~ /vBulletin ([.0-9]+)/
-      if Gem::Version.new(Regexp.last_match(1)) > Gem::Version.new('5.6.1')
+      if Rex::Version.new(Regexp.last_match(1)) > Rex::Version.new('5.6.1')
         return CheckCode::Safe
-      elsif Gem::Version.new(Regexp.last_match(1)) > Gem::Version.new('5.0.0')
+      elsif Rex::Version.new(Regexp.last_match(1)) > Rex::Version.new('5.0.0')
         return CheckCode::Appears
       end
 

--- a/modules/exploits/multi/http/wp_db_backup_rce.rb
+++ b/modules/exploits/multi/http/wp_db_backup_rce.rb
@@ -83,7 +83,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Detected unless version && version.length > 1
 
       vprint_status("Version of wp-database-backup detected: #{version[1]}")
-      return CheckCode::Appears if Gem::Version.new(version[1]) < Gem::Version.new('5.2')
+      return CheckCode::Appears if Rex::Version.new(version[1]) < Rex::Version.new('5.2')
     end
     CheckCode::Safe
   end

--- a/modules/exploits/multi/http/wp_responsive_thumbnail_slider_upload.rb
+++ b/modules/exploits/multi/http/wp_responsive_thumbnail_slider_upload.rb
@@ -64,8 +64,8 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     if res && res.body && res.body =~ /Version:([\d\.]+)/
-      version = Gem::Version.new($1)
-      if version <= Gem::Version.new('1.0')
+      version = Rex::Version.new($1)
+      if version <= Rex::Version.new('1.0')
         vprint_status("Plugin version found: #{version}")
         return CheckCode::Appears
       end

--- a/modules/exploits/multi/local/magnicomp_sysinfo_mcsiwrapper_priv_esc.rb
+++ b/modules/exploits/multi/local/magnicomp_sysinfo_mcsiwrapper_priv_esc.rb
@@ -95,7 +95,7 @@ class MetasploitModule < Msf::Exploit::Local
       vprint_error 'Could not determine the SysInfo version'
       return CheckCode::Detected
     end
-    if Gem::Version.new(version.sub('-H', '.')) >= Gem::Version.new('10.64')
+    if Rex::Version.new(version.sub('-H', '.')) >= Rex::Version.new('10.64')
       vprint_error "SysInfo version #{version} is not vulnerable"
       return CheckCode::Safe
     end

--- a/modules/exploits/multi/local/xorg_x11_suid_server.rb
+++ b/modules/exploits/multi/local/xorg_x11_suid_server.rb
@@ -130,8 +130,8 @@ class MetasploitModule < Msf::Exploit::Local
     # version check
     x_version = cmd_exec "Xorg -version"
     if x_version.include?("Release Date")
-      v = Gem::Version.new(x_version.scan(/\d\.\d+\.\d+/).first)
-      unless v.between?(Gem::Version.new('1.19.0'), Gem::Version.new('1.20.2'))
+      v = Rex::Version.new(x_version.scan(/\d\.\d+\.\d+/).first)
+      unless v.between?(Rex::Version.new('1.19.0'), Rex::Version.new('1.20.2'))
         vprint_error "Xorg version #{v} not supported"
         return CheckCode::Safe
       end

--- a/modules/exploits/multi/local/xorg_x11_suid_server_modulepath.rb
+++ b/modules/exploits/multi/local/xorg_x11_suid_server_modulepath.rb
@@ -109,8 +109,8 @@ class MetasploitModule < Msf::Exploit::Local
 
     x_version = cmd_exec "Xorg -version"
     if x_version.include?("Release Date")
-      v = Gem::Version.new(x_version.scan(/\d\.\d+\.\d+/).first)
-      unless v.between?(Gem::Version.new('1.19.0'), Gem::Version.new('1.20.2'))
+      v = Rex::Version.new(x_version.scan(/\d\.\d+\.\d+/).first)
+      unless v.between?(Rex::Version.new('1.19.0'), Rex::Version.new('1.20.2'))
         vprint_error "Xorg version #{v} not supported"
         return CheckCode::Safe
       end

--- a/modules/exploits/multi/misc/arkeia_agent_exec.rb
+++ b/modules/exploits/multi/misc/arkeia_agent_exec.rb
@@ -298,7 +298,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if data =~ /VERSION.*WD Arkeia ([0-9]+\.[0-9]+\.[0-9]+)/
       version = $1
       vprint_status("#{rhost}:#{rport} - Arkeia version detected: #{version}")
-      if Gem::Version.new(version) <= Gem::Version.new('11.0.12')
+      if Rex::Version.new(version) <= Rex::Version.new('11.0.12')
         return Exploit::CheckCode::Appears
       else
         return Exploit::CheckCode::Safe

--- a/modules/exploits/multi/misc/hp_data_protector_exec_integutil.rb
+++ b/modules/exploits/multi/misc/hp_data_protector_exec_integutil.rb
@@ -95,7 +95,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return Exploit::CheckCode::Safe
     end
 
-    if Gem::Version.new(version) <= Gem::Version.new('9')
+    if Rex::Version.new(version) <= Rex::Version.new('9')
       return Exploit::CheckCode::Appears
     end
 

--- a/modules/exploits/multi/misc/weblogic_deserialize.rb
+++ b/modules/exploits/multi/misc/weblogic_deserialize.rb
@@ -69,16 +69,16 @@ class MetasploitModule < Msf::Exploit::Remote
 
     /WebLogic Server Version: (?<version>\d+\.\d+\.\d+\.*\d*)/ =~ res
     if version
-      version = Gem::Version.new(version)
+      version = Rex::Version.new(version)
       vprint_good("Detected Oracle WebLogic Server Version: #{version.to_s}")
 
       case
       when version.to_s.start_with?('10.3')
-        return CheckCode::Appears unless version > Gem::Version.new('10.3.6.0')
+        return CheckCode::Appears unless version > Rex::Version.new('10.3.6.0')
       when version.to_s.start_with?('12.1')
-        return CheckCode::Appears unless version > Gem::Version.new('12.1.3.0')
+        return CheckCode::Appears unless version > Rex::Version.new('12.1.3.0')
       when version.to_s.start_with?('12.2')
-        return CheckCode::Appears unless version > Gem::Version.new('12.2.1.3')
+        return CheckCode::Appears unless version > Rex::Version.new('12.2.1.3')
       end
     end
 

--- a/modules/exploits/multi/misc/weblogic_deserialize_badattr_extcomp.rb
+++ b/modules/exploits/multi/misc/weblogic_deserialize_badattr_extcomp.rb
@@ -80,8 +80,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
     versions =
       [
-        Gem::Version.new('12.1.3.0.0'), Gem::Version.new('12.2.1.3.0'),
-        Gem::Version.new('12.2.1.4.0')
+        Rex::Version.new('12.1.3.0.0'), Rex::Version.new('12.2.1.3.0'),
+        Rex::Version.new('12.2.1.4.0')
       ]
 
     return CheckCode::Unknown('Failed to obtain response from service') unless res
@@ -89,7 +89,7 @@ class MetasploitModule < Msf::Exploit::Remote
     /WebLogic\s+Server\s+Version:\s+(?<version>\d+\.\d+\.\d+\.*\d*\.*\d*)/ =~ res
     return CheckCode::Unknown('Failed to detect WebLogic') unless version
 
-    @version_no = Gem::Version.new(version)
+    @version_no = Rex::Version.new(version)
     print_status("WebLogic version detected: #{@version_no}")
 
     return CheckCode::Appears if versions.include?(@version_no)
@@ -277,9 +277,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def extractor_comp_uid
     case @version_no
-    when Gem::Version.new('12.1.3.0.0')
+    when Rex::Version.new('12.1.3.0.0')
       'c7ad6d3a676f3c18'
-    when Gem::Version.new('12.2.1.3.0')
+    when Rex::Version.new('12.2.1.3.0')
       'fb4ac83df1d72edc'
     else
       'f9b3bc58cc52cd21'
@@ -287,14 +287,14 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def change_handle?
-    @version_no == Gem::Version.new('12.2.1.3.0')
+    @version_no == Rex::Version.new('12.2.1.3.0')
   end
 
   def chained_extractor_uid
     case @version_no
-    when Gem::Version.new('12.1.3.0.0')
+    when Rex::Version.new('12.1.3.0.0')
       '889f81b0945d5b7f'
-    when Gem::Version.new('12.2.1.3.0')
+    when Rex::Version.new('12.2.1.3.0')
       '06ee10433a4cc4b4'
     else
       '435b250b72f63db5'
@@ -303,9 +303,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def abstract_extractor_uid
     case @version_no
-    when Gem::Version.new('12.1.3.0.0')
+    when Rex::Version.new('12.1.3.0.0')
       '658195303e723821'
-    when Gem::Version.new('12.2.1.3.0')
+    when Rex::Version.new('12.2.1.3.0')
       '752289ad4d460138'
     else
       '9b1be18ed70100e5'
@@ -314,9 +314,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def reflection_extractor_uid
     case @version_no
-    when Gem::Version.new('12.1.3.0.0')
+    when Rex::Version.new('12.1.3.0.0')
       'ee7ae995c02fb4a2'
-    when Gem::Version.new('12.2.1.3.0')
+    when Rex::Version.new('12.2.1.3.0')
       '87973791b26429dd'
     else
       '1f62f564b951b614'
@@ -325,7 +325,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def reflect_extract_count
     case @version_no
-    when Gem::Version.new('12.2.1.3.0')
+    when Rex::Version.new('12.2.1.3.0')
       '3'
     else
       '2'
@@ -335,7 +335,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def add_sect
     sect = ''
 
-    if @version_no == Gem::Version.new('12.2.1.3.0')
+    if @version_no == Rex::Version.new('12.2.1.3.0')
       sect << '4c0011' # Object, length: 17
       sect << '6d5f657874726163746f' # m_extractorCached
       sect << '72436163686564'
@@ -348,7 +348,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def add_tc_null
-    return '70' if @version_no == Gem::Version.new('12.2.1.3.0')
+    return '70' if @version_no == Rex::Version.new('12.2.1.3.0')
 
     ''
   end

--- a/modules/exploits/multi/misc/weblogic_deserialize_badattrval.rb
+++ b/modules/exploits/multi/misc/weblogic_deserialize_badattrval.rb
@@ -76,14 +76,14 @@ class MetasploitModule < Msf::Exploit::Remote
     sleep(2)
     res = sock.get_once
 
-    versions = [ Gem::Version.new('12.1.3.0.0'), Gem::Version.new('12.2.1.3.0'), Gem::Version.new('12.2.1.4.0') ]
+    versions = [ Rex::Version.new('12.1.3.0.0'), Rex::Version.new('12.2.1.3.0'), Rex::Version.new('12.2.1.4.0') ]
 
     return CheckCode::Unknown('Failed to obtain response from service') unless res
 
     /WebLogic\s+Server\s+Version:\s+(?<version>\d+\.\d+\.\d+\.*\d*\.*\d*)/ =~ res
     return CheckCode::Unknown('Failed to detect WebLogic') unless version
 
-    @version_no = Gem::Version.new(version)
+    @version_no = Rex::Version.new(version)
     print_status("WebLogic version detected: #{@version_no}")
 
     return CheckCode::Appears if versions.include?(@version_no)
@@ -300,7 +300,7 @@ class MetasploitModule < Msf::Exploit::Remote
     payload_obj << '71' # TC_REFERENCE
     payload_obj << '007e0001' # handle
 
-    unless @version_no == Gem::Version.new('12.1.3.0.0')
+    unless @version_no == Rex::Version.new('12.1.3.0.0')
       payload_obj << add_class_desc
     end
 
@@ -459,14 +459,14 @@ class MetasploitModule < Msf::Exploit::Remote
   # rubocop:enable Metrics/MethodLength
 
   def change_handle?
-    @version_no == Gem::Version.new('12.1.3.0.0')
+    @version_no == Rex::Version.new('12.1.3.0.0')
   end
 
   def limit_filter_uid
     case @version_no
-    when Gem::Version.new('12.1.3.0.0')
+    when Rex::Version.new('12.1.3.0.0')
       '99022596d7b45953'
-    when Gem::Version.new('12.2.1.3.0')
+    when Rex::Version.new('12.2.1.3.0')
       'ab2901b976c4e271'
     else
       '954e4590be89865f'
@@ -475,9 +475,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def chained_extractor_uid
     case @version_no
-    when Gem::Version.new('12.1.3.0.0')
+    when Rex::Version.new('12.1.3.0.0')
       '889f81b0945d5b7f'
-    when Gem::Version.new('12.2.1.3.0')
+    when Rex::Version.new('12.2.1.3.0')
       '06ee10433a4cc4b4'
     else
       '435b250b72f63db5'
@@ -486,9 +486,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def abstract_extractor_uid
     case @version_no
-    when Gem::Version.new('12.1.3.0.0')
+    when Rex::Version.new('12.1.3.0.0')
       '658195303e723821'
-    when Gem::Version.new('12.2.1.3.0')
+    when Rex::Version.new('12.2.1.3.0')
       '752289ad4d460138'
     else
       '9b1be18ed70100e5'
@@ -497,9 +497,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def reflection_extractor_uid
     case @version_no
-    when Gem::Version.new('12.1.3.0.0')
+    when Rex::Version.new('12.1.3.0.0')
       'ee7ae995c02fb4a2'
-    when Gem::Version.new('12.2.1.3.0')
+    when Rex::Version.new('12.2.1.3.0')
       '87973791b26429dd'
     else
       '1f62f564b951b614'
@@ -508,7 +508,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def reflect_extract_count
     case @version_no
-    when Gem::Version.new('12.2.1.3.0')
+    when Rex::Version.new('12.2.1.3.0')
       '3'
     else
       '2'
@@ -518,7 +518,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def add_sect
     sect = ''
 
-    if @version_no == Gem::Version.new('12.2.1.3.0')
+    if @version_no == Rex::Version.new('12.2.1.3.0')
       sect << '4c0011' # Object, length: 17
       sect << '6d5f657874726163746f' # m_extractorCached
       sect << '72436163686564'
@@ -544,7 +544,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def add_tc_null
-    return '70' if @version_no == Gem::Version.new('12.2.1.3.0')
+    return '70' if @version_no == Rex::Version.new('12.2.1.3.0')
 
     ''
   end

--- a/modules/exploits/multi/misc/weblogic_deserialize_marshalledobject.rb
+++ b/modules/exploits/multi/misc/weblogic_deserialize_marshalledobject.rb
@@ -91,15 +91,15 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Unknown
     end
 
-    version = Gem::Version.new(version)
+    version = Rex::Version.new(version)
     vprint_good("Detected Oracle WebLogic Server Version: #{version}")
     case
     when version.to_s.start_with?('10.3')
-      return CheckCode::Appears unless version > Gem::Version.new('10.3.6.0')
+      return CheckCode::Appears unless version > Rex::Version.new('10.3.6.0')
     when version.to_s.start_with?('12.1.3')
-      return CheckCode::Appears unless version > Gem::Version.new('12.1.3.0')
+      return CheckCode::Appears unless version > Rex::Version.new('12.1.3.0')
     when version.to_s.start_with?('12.2')
-      return CheckCode::Appears unless version > Gem::Version.new('12.2.1.0')
+      return CheckCode::Appears unless version > Rex::Version.new('12.2.1.0')
     end
 
     return CheckCode::Safe

--- a/modules/exploits/multi/misc/weblogic_deserialize_rawobject.rb
+++ b/modules/exploits/multi/misc/weblogic_deserialize_rawobject.rb
@@ -90,17 +90,17 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Unknown
     end
 
-    version = Gem::Version.new(version)
+    version = Rex::Version.new(version)
     vprint_good("Detected Oracle WebLogic Server Version: #{version}")
     case
     when version.to_s.start_with?('10.3')
-      return CheckCode::Appears unless version > Gem::Version.new('10.3.6.0')
+      return CheckCode::Appears unless version > Rex::Version.new('10.3.6.0')
     when version.to_s.start_with?('12.1.2')
-      return CheckCode::Appears unless version > Gem::Version.new('12.1.2.0')
+      return CheckCode::Appears unless version > Rex::Version.new('12.1.2.0')
     when version.to_s.start_with?('12.1.3')
-      return CheckCode::Appears unless version > Gem::Version.new('12.1.3.0')
+      return CheckCode::Appears unless version > Rex::Version.new('12.1.3.0')
     when version.to_s.start_with?('12.2')
-      return CheckCode::Appears unless version > Gem::Version.new('12.2.1.0')
+      return CheckCode::Appears unless version > Rex::Version.new('12.2.1.0')
     end
 
     return CheckCode::Safe

--- a/modules/exploits/multi/misc/weblogic_deserialize_unicastref.rb
+++ b/modules/exploits/multi/misc/weblogic_deserialize_unicastref.rb
@@ -95,15 +95,15 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Unknown
     end
 
-    version = Gem::Version.new(version)
+    version = Rex::Version.new(version)
     vprint_good("Detected Oracle WebLogic Server Version: #{version}")
     case
     when version.to_s.start_with?('10.3')
-      return CheckCode::Appears unless version > Gem::Version.new('10.3.6.0')
+      return CheckCode::Appears unless version > Rex::Version.new('10.3.6.0')
     when version.to_s.start_with?('12.1.3')
-      return CheckCode::Appears unless version > Gem::Version.new('12.1.3.0')
+      return CheckCode::Appears unless version > Rex::Version.new('12.1.3.0')
     when version.to_s.start_with?('12.2')
-      return CheckCode::Appears unless version > Gem::Version.new('12.2.1.1')
+      return CheckCode::Appears unless version > Rex::Version.new('12.2.1.1')
     end
 
     return CheckCode::Safe

--- a/modules/exploits/multi/php/wp_duplicator_code_inject.rb
+++ b/modules/exploits/multi/php/wp_duplicator_code_inject.rb
@@ -68,7 +68,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     version = response.body.to_s.scan( /version: ([^<]*)</).last.first
-    if Gem::Version.new(version) <= Gem::Version.new("1.2.40")
+    if Rex::Version.new(version) <= Rex::Version.new("1.2.40")
       return CheckCode::Vulnerable
     else
       return CheckCode::Detected

--- a/modules/exploits/multi/postgres/postgres_copy_from_program_cmd_exec.rb
+++ b/modules/exploits/multi/postgres/postgres_copy_from_program_cmd_exec.rb
@@ -99,7 +99,7 @@ class MetasploitModule < Msf::Exploit::Remote
     return false unless version[:auth]
     vprint_status version[:auth].to_s
     version_full = version[:auth].to_s.scan(/^PostgreSQL ([\d\.]+)/).flatten.first
-    if Gem::Version.new(version_full) >= Gem::Version.new('9.3')
+    if Rex::Version.new(version_full) >= Rex::Version.new('9.3')
       return true
     else
       return false

--- a/modules/exploits/multi/postgres/postgres_createlang.rb
+++ b/modules/exploits/multi/postgres/postgres_createlang.rb
@@ -69,7 +69,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     version_full = version[:auth].to_s.scan(/^PostgreSQL ([\d\.]+)/i).flatten.first
 
-    if Gem::Version.new(version_full) >= Gem::Version.new('8.0')
+    if Rex::Version.new(version_full) >= Rex::Version.new('8.0')
       return true
     else
       return false

--- a/modules/exploits/multi/scada/inductive_ignition_rce.rb
+++ b/modules/exploits/multi/scada/inductive_ignition_rce.rb
@@ -127,12 +127,12 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    version = Gem::Version.new(version_get)
+    version = Rex::Version.new(version_get)
     if version.segments.length < 3
       fail_with(Failure::Unknown, 'Failed to obtain target version')
     end
     print_status("#{peer} - Detected version #{version}")
-    if version >= Gem::Version.new('8.0.0') && version <= Gem::Version.new('8.0.7')
+    if version >= Rex::Version.new('8.0.0') && version <= Rex::Version.new('8.0.7')
       return Exploit::CheckCode::Appears
     else
       return Exploit::CheckCode::Safe
@@ -174,7 +174,7 @@ class MetasploitModule < Msf::Exploit::Remote
       cmd = payload.encoded
     end
 
-    version = Gem::Version.new(version_get)
+    version = Rex::Version.new(version_get)
 
     if version
       print_status("#{peer} - Detected version #{version}")
@@ -187,7 +187,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # An alternative to this would be GET /system/launchmf/D which will helpfully return
     # a list of all the jars in the system, letting us pick the right gadget chain.
     # However only 8.0.0 differs, so let's just have a special case for that.
-    if version == Gem::Version.new('8.0.0')
+    if version == Rex::Version.new('8.0.0')
       lib = 'CommonsCollections6'
     else
       lib = 'CommonsBeanutils1'

--- a/modules/exploits/osx/browser/adobe_flash_delete_range_tl_op.rb
+++ b/modules/exploits/osx/browser/adobe_flash_delete_range_tl_op.rb
@@ -57,7 +57,7 @@ class MetasploitModule < Msf::Exploit::Remote
           flash: lambda do |ver|
             case target.name
             when 'Mac OS X'
-              return true if Gem::Version.new(ver) <= Gem::Version.new('21.0.0.182')
+              return true if Rex::Version.new(ver) <= Rex::Version.new('21.0.0.182')
             end
 
             false

--- a/modules/exploits/osx/browser/safari_in_operator_side_effect.rb
+++ b/modules/exploits/osx/browser/safari_in_operator_side_effect.rb
@@ -441,17 +441,17 @@ class MetasploitModule < Msf::Exploit::Remote
     if user_agent =~ /Intel Mac OS X (.*?)\)/
       osx_version = Regexp.last_match(1).gsub('_', '.')
       if user_agent =~ %r{Version/(.*?) }
-        if Gem::Version.new(Regexp.last_match(1)) > Gem::Version.new('13.1')
+        if Rex::Version.new(Regexp.last_match(1)) > Rex::Version.new('13.1')
           print_warning "Safari version #{Regexp.last_match(1)} is not vulnerable"
           return false
         else
           print_good "Safari version #{Regexp.last_match(1)} appears to be vulnerable"
         end
       end
-      mac_osx_version = Gem::Version.new(osx_version)
-      if mac_osx_version >= Gem::Version.new('10.15.5')
+      mac_osx_version = Rex::Version.new(osx_version)
+      if mac_osx_version >= Rex::Version.new('10.15.5')
         print_warning "macOS version #{mac_osx_version} is not vulnerable"
-      elsif mac_osx_version < Gem::Version.new('10.14')
+      elsif mac_osx_version < Rex::Version.new('10.14')
         print_warning "macOS version #{mac_osx_version} is not supported"
       elsif offset_table.key?(osx_version)
         return offset_table[osx_version]

--- a/modules/exploits/osx/browser/safari_proxy_object_type_confusion.rb
+++ b/modules/exploits/osx/browser/safari_proxy_object_type_confusion.rb
@@ -112,17 +112,17 @@ class MetasploitModule < Msf::Exploit::Remote
     if user_agent =~ /Intel Mac OS X (.*?)\)/
       osx_version = $1.gsub("_", ".")
       if user_agent =~ /Version\/(.*?) /
-        if Gem::Version.new($1) >= Gem::Version.new('11.1.1')
+        if Rex::Version.new($1) >= Rex::Version.new('11.1.1')
           print_warning "Safari version #{$1} is not vulnerable"
           return false
         else
           print_good "Safari version #{$1} appears to be vulnerable"
         end
       end
-      mac_osx_version = Gem::Version.new(osx_version)
-      if mac_osx_version >= Gem::Version.new('10.13.4')
+      mac_osx_version = Rex::Version.new(osx_version)
+      if mac_osx_version >= Rex::Version.new('10.13.4')
         print_warning "macOS version #{mac_osx_version} is not vulnerable"
-      elsif mac_osx_version < Gem::Version.new('10.12')
+      elsif mac_osx_version < Rex::Version.new('10.12')
         print_warning "macOS version #{mac_osx_version} is not vulnerable"
       elsif offset_table.key?(osx_version)
         offset = offset_table[osx_version]

--- a/modules/exploits/osx/local/cfprefsd_race_condition.rb
+++ b/modules/exploits/osx/local/cfprefsd_race_condition.rb
@@ -82,10 +82,10 @@ session    optional       pam_permit.so
   # rubocop:enable Style/ClassVars
 
   def check
-    version = Gem::Version.new(get_system_version)
-    if version > Gem::Version.new('10.15.4')
+    version = Rex::Version.new(get_system_version)
+    if version > Rex::Version.new('10.15.4')
       CheckCode::Safe
-    elsif version < Gem::Version.new('10.15')
+    elsif version < Rex::Version.new('10.15')
       CheckCode::Safe
     else
       CheckCode::Appears

--- a/modules/exploits/osx/local/dyld_print_to_file_root.rb
+++ b/modules/exploits/osx/local/dyld_print_to_file_root.rb
@@ -78,8 +78,8 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def ver?
-    Gem::Version.new(get_sysinfo['ProductVersion']).between?(
-      Gem::Version.new('10.10.0'), Gem::Version.new('10.10.4')
+    Rex::Version.new(get_sysinfo['ProductVersion']).between?(
+      Rex::Version.new('10.10.0'), Rex::Version.new('10.10.4')
     )
   end
 

--- a/modules/exploits/osx/local/feedback_assistant_root.rb
+++ b/modules/exploits/osx/local/feedback_assistant_root.rb
@@ -54,8 +54,8 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    version = Gem::Version.new(get_system_version)
-    if version >= Gem::Version.new('10.14.4')
+    version = Rex::Version.new(get_system_version)
+    if version >= Rex::Version.new('10.14.4')
       CheckCode::Safe
     else
       CheckCode::Appears

--- a/modules/exploits/osx/local/iokit_keyboard_root.rb
+++ b/modules/exploits/osx/local/iokit_keyboard_root.rb
@@ -91,6 +91,6 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def ver_lt(a, b)
-    Gem::Version.new(a) < Gem::Version.new(b)
+    Rex::Version.new(a) < Rex::Version.new(b)
   end
 end

--- a/modules/exploits/osx/local/libxpc_mitm_ssudo.rb
+++ b/modules/exploits/osx/local/libxpc_mitm_ssudo.rb
@@ -54,8 +54,8 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    version = Gem::Version.new(get_system_version)
-    if version >= Gem::Version.new('10.13.4')
+    version = Rex::Version.new(get_system_version)
+    if version >= Rex::Version.new('10.13.4')
       CheckCode::Safe
     else
       CheckCode::Appears

--- a/modules/exploits/osx/local/nfs_mount_root.rb
+++ b/modules/exploits/osx/local/nfs_mount_root.rb
@@ -93,6 +93,6 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def ver_lt(a, b)
-    Gem::Version.new(a.gsub(/~.*?$/,'')) < Gem::Version.new(b.gsub(/~.*?$/,''))
+    Rex::Version.new(a.gsub(/~.*?$/,'')) < Rex::Version.new(b.gsub(/~.*?$/,''))
   end
 end

--- a/modules/exploits/osx/local/rootpipe.rb
+++ b/modules/exploits/osx/local/rootpipe.rb
@@ -100,8 +100,8 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def ver?
-    Gem::Version.new(get_sysinfo['ProductVersion']).between?(
-      Gem::Version.new('10.9'), Gem::Version.new('10.10.2')
+    Rex::Version.new(get_sysinfo['ProductVersion']).between?(
+      Rex::Version.new('10.9'), Rex::Version.new('10.10.2')
     )
   end
 

--- a/modules/exploits/osx/local/rootpipe_entitlements.rb
+++ b/modules/exploits/osx/local/rootpipe_entitlements.rb
@@ -104,8 +104,8 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def ver?
-    Gem::Version.new(get_sysinfo['ProductVersion']).between?(
-      Gem::Version.new('10.9'), Gem::Version.new('10.10.3')
+    Rex::Version.new(get_sysinfo['ProductVersion']).between?(
+      Rex::Version.new('10.9'), Rex::Version.new('10.10.3')
     )
   end
 

--- a/modules/exploits/osx/local/timemachine_cmd_injection.rb
+++ b/modules/exploits/osx/local/timemachine_cmd_injection.rb
@@ -57,8 +57,8 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    version = Gem::Version.new(get_system_version)
-    if version >= Gem::Version.new('10.14.4')
+    version = Rex::Version.new(get_system_version)
+    if version >= Rex::Version.new('10.14.4')
       CheckCode::Safe
     else
       CheckCode::Appears

--- a/modules/exploits/osx/local/tpwn.rb
+++ b/modules/exploits/osx/local/tpwn.rb
@@ -81,8 +81,8 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def ver?
-    Gem::Version.new(get_sysinfo['ProductVersion']).between?(
-      Gem::Version.new('10.10.4'), Gem::Version.new('10.10.5')
+    Rex::Version.new(get_sysinfo['ProductVersion']).between?(
+      Rex::Version.new('10.10.4'), Rex::Version.new('10.10.5')
     )
   end
 

--- a/modules/exploits/osx/local/vmware_fusion_lpe.rb
+++ b/modules/exploits/osx/local/vmware_fusion_lpe.rb
@@ -99,7 +99,7 @@ class MetasploitModule < Msf::Exploit::Local
     if version_raw.blank?
       fail_with Failure::BadConfig, 'Unable to determine VMware Fusion version.  Set ForceExploit to override.'
     end
-    Gem::Version.new(version)
+    Rex::Version.new(version)
   end
 
   def pre_11_5_3
@@ -188,7 +188,7 @@ class MetasploitModule < Msf::Exploit::Local
       return CheckCode::Safe
     end
     version = get_version
-    if version.between?(Gem::Version.new('10.1.3'), Gem::Version.new('11.5.3'))
+    if version.between?(Rex::Version.new('10.1.3'), Rex::Version.new('11.5.3'))
       vprint_good "Vmware Fusion #{version} is exploitable"
     else
       print_bad "VMware Fusion #{version} is NOT exploitable"
@@ -215,10 +215,10 @@ class MetasploitModule < Msf::Exploit::Local
     end
 
     version = get_version
-    if version == Gem::Version.new('11.5.3')
+    if version == Rex::Version.new('11.5.3')
       vprint_status 'Using 11.5.3 exploit'
       exactly_11_5_3
-    elsif version.between?(Gem::Version.new('10.1.3'), Gem::Version.new('11.5.2'))
+    elsif version.between?(Rex::Version.new('10.1.3'), Rex::Version.new('11.5.2'))
       vprint_status 'Using pre-11.5.3 exploit'
       pre_11_5_3
     end

--- a/modules/exploits/solaris/local/extremeparr_dtappgather_priv_esc.rb
+++ b/modules/exploits/solaris/local/extremeparr_dtappgather_priv_esc.rb
@@ -148,7 +148,7 @@ class MetasploitModule < Msf::Exploit::Local
       return CheckCode::Detected
     end
 
-    unless Gem::Version.new(version).between? Gem::Version.new('5.7'), Gem::Version.new('5.10')
+    unless Rex::Version.new(version).between? Rex::Version.new('5.7'), Rex::Version.new('5.10')
       vprint_error "Solaris version #{version} is not vulnerable"
       return CheckCode::Safe
     end

--- a/modules/exploits/solaris/local/libnspr_nspr_log_file_priv_esc.rb
+++ b/modules/exploits/solaris/local/libnspr_nspr_log_file_priv_esc.rb
@@ -138,7 +138,7 @@ class MetasploitModule < Msf::Exploit::Local
       return CheckCode::Unknown
     end
 
-    if Gem::Version.new(libnspr_pkg_version) >= Gem::Version.new('4.6.3')
+    if Rex::Version.new(libnspr_pkg_version) >= Rex::Version.new('4.6.3')
       vprint_error "libnspr version #{libnspr_pkg_version} is not vulnerable"
       return CheckCode::Safe
     end
@@ -153,7 +153,7 @@ class MetasploitModule < Msf::Exploit::Local
       return CheckCode::Detected
     end
 
-    unless Gem::Version.new(version) <= Gem::Version.new('5.10')
+    unless Rex::Version.new(version) <= Rex::Version.new('5.10')
       vprint_error "Solaris version #{version} is not vulnerable"
       return CheckCode::Safe
     end

--- a/modules/exploits/solaris/local/xscreensaver_log_priv_esc.rb
+++ b/modules/exploits/solaris/local/xscreensaver_log_priv_esc.rb
@@ -127,7 +127,7 @@ class MetasploitModule < Msf::Exploit::Local
     end
 
     # Bug introduced in version 5.06. Patched in version <~ 5.42.
-    unless Gem::Version.new(xscreensaver_version).between?(Gem::Version.new('5.06'), Gem::Version.new('5.41'))
+    unless Rex::Version.new(xscreensaver_version).between?(Rex::Version.new('5.06'), Rex::Version.new('5.41'))
       vprint_error "xscreensaver version #{xscreensaver_version} is not vulnerable"
       return CheckCode::Safe
     end

--- a/modules/exploits/unix/http/pfsense_graph_injection_exec.rb
+++ b/modules/exploits/unix/http/pfsense_graph_injection_exec.rb
@@ -113,12 +113,12 @@ class MetasploitModule < Msf::Exploit::Remote
     /Version.+<strong>(?<version>[0-9\.\-RELEASE]+)[\n]?<\/strong>/m =~ res.body
     if version
       print_status("Detected pfSense #{version}, uploading intial payload")
-      return Gem::Version.new(version)
+      return Rex::Version.new(version)
     end
     # If the device isn't fully setup, you get stuck at redirects to wizard.php
     # however, this does NOT stop exploitation strangely
     print_error('pfSense version not detected or wizard still enabled.')
-    Gem::Version.new('0.0')
+    Rex::Version.new('0.0')
   end
 
   def exploit

--- a/modules/exploits/unix/http/pfsense_group_member_exec.rb
+++ b/modules/exploits/unix/http/pfsense_group_member_exec.rb
@@ -110,12 +110,12 @@ class MetasploitModule < Msf::Exploit::Remote
     /Version.+<strong>(?<version>[0-9\.\-RELEASE]+)[\n]?<\/strong>/m =~ res.body
     if version
       print_status("pfSense Version Detected: #{version}")
-      return Gem::Version.new(version)
+      return Rex::Version.new(version)
     end
     # If the device isn't fully setup, you get stuck at redirects to wizard.php
     # however, this does NOT stop exploitation strangely
     print_error("pfSens Version Not Detected or wizard still enabled.")
-    Gem::Version.new('0.0')
+    Rex::Version.new('0.0')
   end
 
   def check
@@ -163,9 +163,9 @@ class MetasploitModule < Msf::Exploit::Remote
         'groupid' => '',
         'save' => 'Save'
       }
-      if version >= Gem::Version.new('2.3')
+      if version >= Rex::Version.new('2.3')
         post_vars = post_vars.merge('gtype' => 'local')
-      elsif version <= Gem::Version.new('2.3') # catch for 2.2.6. left this elsif for easy expansion to other versions as needed
+      elsif version <= Rex::Version.new('2.3') # catch for 2.2.6. left this elsif for easy expansion to other versions as needed
         post_vars = post_vars.merge(
           'act' => '',
           'gtype' => '',

--- a/modules/exploits/unix/http/pihole_blocklist_exec.rb
+++ b/modules/exploits/unix/http/pihole_blocklist_exec.rb
@@ -105,7 +105,7 @@ class MetasploitModule < Msf::Exploit::Remote
       # <b>Pi-hole Version </b> v4.3.2 <a class="alert-link lookatme" href="https://github.com/pi-hole/pi-hole/releases" target="_blank">(Update available!)</a>            <b>
       %r{<b>Pi-hole Version\s*</b>\s*v?(?<version>[\d.]+).*<b>} =~ res.body
 
-      if version && Gem::Version.new(version) <= Gem::Version.new('4.4')
+      if version && Rex::Version.new(version) <= Rex::Version.new('4.4')
         vprint_good("Version Detected: #{version}")
         return CheckCode::Appears
       else

--- a/modules/exploits/unix/http/pihole_dhcp_mac_exec.rb
+++ b/modules/exploits/unix/http/pihole_dhcp_mac_exec.rb
@@ -74,7 +74,7 @@ class MetasploitModule < Msf::Exploit::Remote
       %r{<b>Web Interface Version\s*</b>\s*(vDev \(HEAD, )?v?(?<version>[\d.]+)\)?.*<b>}m =~ res.body
       # rubocop:enable Lint/MixedRegexpCaptureTypes
 
-      if version && Gem::Version.new(version) <= Gem::Version.new('4.3.2')
+      if version && Rex::Version.new(version) <= Rex::Version.new('4.3.2')
         vprint_good("Version Detected: #{version}")
         return CheckCode::Appears
       else

--- a/modules/exploits/unix/http/pihole_whitelist_exec.rb
+++ b/modules/exploits/unix/http/pihole_whitelist_exec.rb
@@ -133,7 +133,7 @@ class MetasploitModule < Msf::Exploit::Remote
       %r{<b>Web Interface Version\s*</b>\s*(vDev \(HEAD, )?v?(?<version>[\d.]+)\)?.*<b>}m =~ res.body
       # rubocop:enable Lint/MixedRegexpCaptureTypes
 
-      if version && Gem::Version.new(version) < Gem::Version.new('3.3')
+      if version && Rex::Version.new(version) < Rex::Version.new('3.3')
         vprint_good("Version Detected: #{version}")
         return CheckCode::Appears
       else

--- a/modules/exploits/unix/http/quest_kace_systems_management_rce.rb
+++ b/modules/exploits/unix/http/quest_kace_systems_management_rce.rb
@@ -83,16 +83,16 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Detected
     end
 
-    version = Gem::Version.new res.headers['X-KACE-Version'].to_s
+    version = Rex::Version.new res.headers['X-KACE-Version'].to_s
     vprint_status "Found KACE appliance version #{version}"
 
     # Patched versions : https://support.quest.com/product-notification/noti-00000134
-    if version < Gem::Version.new('7.0') ||
-       (version >= Gem::Version.new('7.0') && version < Gem::Version.new('7.0.121307')) ||
-       (version >= Gem::Version.new('7.1') && version < Gem::Version.new('7.1.150')) ||
-       (version >= Gem::Version.new('7.2') && version < Gem::Version.new('7.2.103')) ||
-       (version >= Gem::Version.new('8.0') && version < Gem::Version.new('8.0.320')) ||
-       (version >= Gem::Version.new('8.1') && version < Gem::Version.new('8.1.108'))
+    if version < Rex::Version.new('7.0') ||
+       (version >= Rex::Version.new('7.0') && version < Rex::Version.new('7.0.121307')) ||
+       (version >= Rex::Version.new('7.1') && version < Rex::Version.new('7.1.150')) ||
+       (version >= Rex::Version.new('7.2') && version < Rex::Version.new('7.2.103')) ||
+       (version >= Rex::Version.new('8.0') && version < Rex::Version.new('8.0.320')) ||
+       (version >= Rex::Version.new('8.1') && version < Rex::Version.new('8.1.108'))
       return CheckCode::Appears
     end
 

--- a/modules/exploits/unix/local/opensmtpd_oob_read_lpe.rb
+++ b/modules/exploits/unix/local/opensmtpd_oob_read_lpe.rb
@@ -41,8 +41,8 @@ class MetasploitModule < Msf::Exploit::Local
           [
             'OpenSMTPD < 6.6.4 (automatic grammar selection)',
             {
-              patched_version: Gem::Version.new('6.6.4'),
-              new_grammar_version: Gem::Version.new('6.4.0')
+              patched_version: Rex::Version.new('6.6.4'),
+              new_grammar_version: Rex::Version.new('6.4.0')
             }
           ]
         ],
@@ -89,7 +89,7 @@ class MetasploitModule < Msf::Exploit::Local
       return CheckCode::Unknown('OpenSMTPD version could not be found.')
     end
 
-    version = Gem::Version.new(version)
+    version = Rex::Version.new(version)
 
     if version < target[:patched_version]
       if version >= target[:new_grammar_version]

--- a/modules/exploits/unix/sonicwall/sonicwall_xmlrpc_rce.rb
+++ b/modules/exploits/unix/sonicwall/sonicwall_xmlrpc_rce.rb
@@ -76,9 +76,9 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Safe
     end
 
-    version = Gem::Version.new $1.to_s
+    version = Rex::Version.new $1.to_s
 
-    unless version <= Gem::Version.new('8.1')
+    unless version <= Rex::Version.new('8.1')
       return CheckCode::Safe
     end
 

--- a/modules/exploits/unix/webapp/actualanalyzer_ant_cookie_exec.rb
+++ b/modules/exploits/unix/webapp/actualanalyzer_ant_cookie_exec.rb
@@ -80,7 +80,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return Exploit::CheckCode::Unknown
     elsif res.code == 200 && /title="ActualAnalyzer Lite \(free\) (?<version>[\d\.]+)"/ =~ res.body
       vprint_status("Found version: #{version}")
-      if Gem::Version.new(version) <= Gem::Version.new('2.81')
+      if Rex::Version.new(version) <= Rex::Version.new('2.81')
         report_vuln(
           host: rhost,
           name: self.name,

--- a/modules/exploits/unix/webapp/drupal_drupalgeddon2.rb
+++ b/modules/exploits/unix/webapp/drupal_drupalgeddon2.rb
@@ -73,25 +73,25 @@ class MetasploitModule < Msf::Exploit::Remote
         ['Drupal 7.x (PHP In-Memory)',
           'Platform'   => 'php',
           'Arch'       => ARCH_PHP,
-          'Version'    => Gem::Version.new('7'),
+          'Version'    => Rex::Version.new('7'),
           'Type'       => :php_memory
         ],
         ['Drupal 7.x (PHP Dropper)',
           'Platform'   => 'php',
           'Arch'       => ARCH_PHP,
-          'Version'    => Gem::Version.new('7'),
+          'Version'    => Rex::Version.new('7'),
           'Type'       => :php_dropper
         ],
         ['Drupal 7.x (Unix In-Memory)',
           'Platform'   => 'unix',
           'Arch'       => ARCH_CMD,
-          'Version'    => Gem::Version.new('7'),
+          'Version'    => Rex::Version.new('7'),
           'Type'       => :unix_memory
         ],
         ['Drupal 7.x (Linux Dropper)',
           'Platform'   => 'linux',
           'Arch'       => [ARCH_X86, ARCH_X64],
-          'Version'    => Gem::Version.new('7'),
+          'Version'    => Rex::Version.new('7'),
           'Type'       => :linux_dropper
         ],
         #
@@ -100,25 +100,25 @@ class MetasploitModule < Msf::Exploit::Remote
         ['Drupal 8.x (PHP In-Memory)',
           'Platform'   => 'php',
           'Arch'       => ARCH_PHP,
-          'Version'    => Gem::Version.new('8'),
+          'Version'    => Rex::Version.new('8'),
           'Type'       => :php_memory
         ],
         ['Drupal 8.x (PHP Dropper)',
           'Platform'   => 'php',
           'Arch'       => ARCH_PHP,
-          'Version'    => Gem::Version.new('8'),
+          'Version'    => Rex::Version.new('8'),
           'Type'       => :php_dropper
         ],
         ['Drupal 8.x (Unix In-Memory)',
           'Platform'   => 'unix',
           'Arch'       => ARCH_CMD,
-          'Version'    => Gem::Version.new('8'),
+          'Version'    => Rex::Version.new('8'),
           'Type'       => :unix_memory
         ],
         ['Drupal 8.x (Linux Dropper)',
           'Platform'   => 'linux',
           'Arch'       => [ARCH_X86, ARCH_X64],
-          'Version'    => Gem::Version.new('8'),
+          'Version'    => Rex::Version.new('8'),
           'Type'       => :linux_dropper
         ]
       ],
@@ -185,7 +185,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     unless @version
       print_warning('Targeting Drupal 7.x as a fallback')
-      @version = Gem::Version.new('7')
+      @version = Rex::Version.new('7')
     end
 
     if datastore['PAYLOAD'] == 'cmd/unix/generic'

--- a/modules/exploits/unix/webapp/get_simple_cms_upload_exec.rb
+++ b/modules/exploits/unix/webapp/get_simple_cms_upload_exec.rb
@@ -93,7 +93,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     print_status("Version #{version} found")
 
-    if Gem::Version.new(version) <= Gem::Version.new('3.1.2')
+    if Rex::Version.new(version) <= Rex::Version.new('3.1.2')
       return Exploit::CheckCode::Appears
     end
 

--- a/modules/exploits/unix/webapp/jquery_file_upload.rb
+++ b/modules/exploits/unix/webapp/jquery_file_upload.rb
@@ -90,9 +90,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
       unless a
         res.headers['Server'] =~ /Apache\/([\d.]+)/ &&
-          $1 && (a = Gem::Version.new($1))
+          $1 && (a = Rex::Version.new($1))
 
-        if a && a >= Gem::Version.new('2.3.9')
+        if a && a >= Rex::Version.new('2.3.9')
           vprint_good("Found Apache #{a} (AllowOverride None may be set)")
         elsif a
           vprint_warning("Found Apache #{a} (AllowOverride All may be set)")
@@ -100,9 +100,9 @@ class MetasploitModule < Msf::Exploit::Remote
       end
 
       next unless res.code == 200 && (j = res.get_json_document) &&
-                  j['version'] && (v = Gem::Version.new(j['version']))
+                  j['version'] && (v = Rex::Version.new(j['version']))
 
-      if v <= Gem::Version.new('9.22.0')
+      if v <= Rex::Version.new('9.22.0')
         vprint_good("Found unpatched jQuery File Upload #{v}")
         return CheckCode::Appears
       else

--- a/modules/exploits/unix/webapp/openmediavault_rpc_rce.rb
+++ b/modules/exploits/unix/webapp/openmediavault_rpc_rce.rb
@@ -120,12 +120,12 @@ class MetasploitModule < Msf::Exploit::Remote
     end
     print_good("#{peer} - Identified OpenMediaVault version #{version}.")
 
-    version_gemmed = Gem::Version.new(version)
-    if version_gemmed < Gem::Version.new('3.0.1')
+    version_gemmed = Rex::Version.new(version)
+    if version_gemmed < Rex::Version.new('3.0.1')
       return version
-    elsif version_gemmed >= Gem::Version.new('4.0.0') && version_gemmed < Gem::Version.new('4.1.36')
+    elsif version_gemmed >= Rex::Version.new('4.0.0') && version_gemmed < Rex::Version.new('4.1.36')
       return version
-    elsif version_gemmed >= Gem::Version.new('5.0.0') && version_gemmed < Gem::Version.new('5.5.12')
+    elsif version_gemmed >= Rex::Version.new('5.0.0') && version_gemmed < Rex::Version.new('5.5.12')
       return version
     else
       return nil

--- a/modules/exploits/unix/webapp/opennetadmin_ping_cmd_injection.rb
+++ b/modules/exploits/unix/webapp/opennetadmin_ping_cmd_injection.rb
@@ -69,13 +69,13 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     opennetadmin_version = res.body.scan(/OpenNetAdmin - v([\d\.]+)/).flatten.first
-    version = Gem::Version.new(opennetadmin_version)
+    version = Rex::Version.new(opennetadmin_version)
 
     if version
       vprint_status "OpenNetAdmin version #{version}"
     end
 
-    if version.between?(Gem::Version.new('8.5.14'), Gem::Version.new('18.1.1'))
+    if version.between?(Rex::Version.new('8.5.14'), Rex::Version.new('18.1.1'))
       return CheckCode::Appears
     end
 

--- a/modules/exploits/unix/webapp/phpcollab_upload_exec.rb
+++ b/modules/exploits/unix/webapp/phpcollab_upload_exec.rb
@@ -61,7 +61,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Unknown
     end
 
-    if Gem::Version.new(version) >= Gem::Version.new('0')
+    if Rex::Version.new(version) >= Rex::Version.new('0')
       return CheckCode::Appears
     end
 

--- a/modules/exploits/unix/webapp/piwik_superuser_plugin_upload.rb
+++ b/modules/exploits/unix/webapp/piwik_superuser_plugin_upload.rb
@@ -226,7 +226,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     # Only versions after 3 have a seperate Marketplace plugin
-    if piwik_version && Gem::Version.new(piwik_version) >= Gem::Version.new('3')
+    if piwik_version && Rex::Version.new(piwik_version) >= Rex::Version.new('3')
       marketplace_available = true
     else
       marketplace_available = false

--- a/modules/exploits/unix/webapp/thinkphp_rce.rb
+++ b/modules/exploits/unix/webapp/thinkphp_rce.rb
@@ -139,9 +139,9 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     # Make the parsed version a comparable ivar for automatic exploitation
-    @version = Gem::Version.new(version)
+    @version = Rex::Version.new(version)
 
-    if @version <= Gem::Version.new('5.0.23')
+    if @version <= Rex::Version.new('5.0.23')
       return CheckCode::Appears("ThinkPHP #{@version} is a vulnerable version.")
     end
 
@@ -170,9 +170,9 @@ class MetasploitModule < Msf::Exploit::Remote
   def execute_command(cmd, _opts = {})
     vprint_status("Executing command: #{cmd}")
 
-    if @version < Gem::Version.new('5.0.23')
+    if @version < Rex::Version.new('5.0.23')
       exploit_less_than_5_0_23(cmd)
-    elsif @version == Gem::Version.new('5.0.23')
+    elsif @version == Rex::Version.new('5.0.23')
       exploit_5_0_23(cmd)
     else # This is just extra insurance in case I screwed up the exploit method
       fail_with(Failure::NoTarget, "Could not target ThinkPHP #{@version}")

--- a/modules/exploits/unix/webapp/trixbox_ce_endpoint_devicemap_rce.rb
+++ b/modules/exploits/unix/webapp/trixbox_ce_endpoint_devicemap_rce.rb
@@ -86,11 +86,11 @@ class MetasploitModule < Msf::Exploit::Remote
       end
     end
     print_good("#{peer} - Trixbox CE v#{version} identified.")
-    if Gem::Version.new(version).between?(Gem::Version.new('2.6.0.0'), Gem::Version.new('2.8.0.4'))
+    if Rex::Version.new(version).between?(Rex::Version.new('2.6.0.0'), Rex::Version.new('2.8.0.4'))
       @uri = normalize_uri(target_uri.path, '/maint/modules/endpointcfg/endpoint_devicemap.php')
-    elsif Gem::Version.new(version).between?(Gem::Version.new('2.0.0.0'), Gem::Version.new('2.4.9.9'))
+    elsif Rex::Version.new(version).between?(Rex::Version.new('2.0.0.0'), Rex::Version.new('2.4.9.9'))
       @uri = normalize_uri(target_uri.path, '/maint/modules/11_endpointcfg/endpoint_devicemap.php')
-    elsif Gem::Version.new(version).between?(Gem::Version.new('1.2.0.0'), Gem::Version.new('1.9.9.9'))
+    elsif Rex::Version.new(version).between?(Rex::Version.new('1.2.0.0'), Rex::Version.new('1.9.9.9'))
       @uri = normalize_uri(target_uri.path, '/maint/endpoint_devicemap.php')
     else
       return nil

--- a/modules/exploits/unix/webapp/wp_infinitewp_auth_bypass.rb
+++ b/modules/exploits/unix/webapp/wp_infinitewp_auth_bypass.rb
@@ -84,7 +84,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Unknown('Could not detect WordPress version.')
     end
 
-    if Gem::Version.new(version) >= Gem::Version.new('4.9')
+    if Rex::Version.new(version) >= Rex::Version.new('4.9')
       return CheckCode::Safe("WordPress #{version} is an unsupported target.")
     end
 

--- a/modules/exploits/unix/webapp/wp_phpmailer_host_header.rb
+++ b/modules/exploits/unix/webapp/wp_phpmailer_host_header.rb
@@ -64,14 +64,14 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     if (version = wordpress_version)
-      version = Gem::Version.new(version)
+      version = Rex::Version.new(version)
     else
       return CheckCode::Safe
     end
 
     vprint_status("WordPress #{version} installed at #{full_uri}")
 
-    if version <= Gem::Version.new('4.6')
+    if version <= Rex::Version.new('4.6')
       CheckCode::Appears
     else
       CheckCode::Detected

--- a/modules/exploits/unix/webapp/xymon_useradm_cmd_exec.rb
+++ b/modules/exploits/unix/webapp/xymon_useradm_cmd_exec.rb
@@ -136,7 +136,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     vprint_status "#{peer} - Xymon version #{version}"
 
-    if Gem::Version.new(version) >= Gem::Version.new('4.3.25')
+    if Rex::Version.new(version) >= Rex::Version.new('4.3.25')
       return CheckCode::Safe
     end
 

--- a/modules/exploits/windows/browser/adobe_flash_casi32_int_overflow.rb
+++ b/modules/exploits/windows/browser/adobe_flash_casi32_int_overflow.rb
@@ -45,7 +45,7 @@ class MetasploitModule < Msf::Exploit::Remote
               os =~ OperatingSystems::Match::WINDOWS_81
           end,
           :ua_name => lambda { |ua| [Msf::HttpClients::IE, Msf::HttpClients::FF].include?(ua) },
-          :flash   => lambda { |ver| ver =~ /^15\./ && Gem::Version.new(ver) <=  Gem::Version.new('15.0.0.167') },
+          :flash   => lambda { |ver| ver =~ /^15\./ && Rex::Version.new(ver) <=  Rex::Version.new('15.0.0.167') },
           :arch    => ARCH_X86
         },
       'Targets'             =>

--- a/modules/exploits/windows/browser/adobe_flash_copy_pixels_to_byte_array.rb
+++ b/modules/exploits/windows/browser/adobe_flash_copy_pixels_to_byte_array.rb
@@ -51,7 +51,7 @@ class MetasploitModule < Msf::Exploit::Remote
               os =~ OperatingSystems::Match::WINDOWS_81
           end,
           :ua_name => lambda { |ua| [Msf::HttpClients::IE, Msf::HttpClients::FF].include?(ua) },
-          :flash   => lambda { |ver| ver =~ /^14\./ && Gem::Version.new(ver) <=  Gem::Version.new('14.0.0.179') },
+          :flash   => lambda { |ver| ver =~ /^14\./ && Rex::Version.new(ver) <=  Rex::Version.new('14.0.0.179') },
           :arch    => ARCH_X86
         },
       'Targets'             =>

--- a/modules/exploits/windows/browser/adobe_flash_domain_memory_uaf.rb
+++ b/modules/exploits/windows/browser/adobe_flash_domain_memory_uaf.rb
@@ -50,7 +50,7 @@ class MetasploitModule < Msf::Exploit::Remote
               os =~ OperatingSystems::Match::WINDOWS_81
           end,
           :ua_name => lambda { |ua| [Msf::HttpClients::IE, Msf::HttpClients::FF].include?(ua) },
-          :flash   => lambda { |ver| ver =~ /^17\./ && Gem::Version.new(ver) <= Gem::Version.new('17.0.0.134') },
+          :flash   => lambda { |ver| ver =~ /^17\./ && Rex::Version.new(ver) <= Rex::Version.new('17.0.0.134') },
           :arch    => ARCH_X86
         },
       'Targets'             =>

--- a/modules/exploits/windows/browser/adobe_flash_uncompress_zlib_uninitialized.rb
+++ b/modules/exploits/windows/browser/adobe_flash_uncompress_zlib_uninitialized.rb
@@ -46,7 +46,7 @@ class MetasploitModule < Msf::Exploit::Remote
               os =~ OperatingSystems::Match::WINDOWS_81
           end,
           :ua_name => lambda { |ua| [Msf::HttpClients::IE, Msf::HttpClients::FF].include?(ua) },
-          :flash   => lambda { |ver| ver =~ /^15\./ && Gem::Version.new(ver) <=  Gem::Version.new('15.0.0.189') },
+          :flash   => lambda { |ver| ver =~ /^15\./ && Rex::Version.new(ver) <=  Rex::Version.new('15.0.0.189') },
           :arch    => ARCH_X86
         },
       'Targets'             =>

--- a/modules/exploits/windows/browser/adobe_flash_worker_byte_array_uaf.rb
+++ b/modules/exploits/windows/browser/adobe_flash_worker_byte_array_uaf.rb
@@ -45,7 +45,7 @@ class MetasploitModule < Msf::Exploit::Remote
               os =~ OperatingSystems::Match::WINDOWS_81
           end,
           :ua_name => lambda { |ua| [Msf::HttpClients::IE, Msf::HttpClients::FF].include?(ua) },
-          :flash   => lambda { |ver| ver =~ /^16\./ && Gem::Version.new(ver) <= Gem::Version.new('16.0.0.296') },
+          :flash   => lambda { |ver| ver =~ /^16\./ && Rex::Version.new(ver) <= Rex::Version.new('16.0.0.296') },
           :arch    => ARCH_X86
         },
       'Targets'             =>

--- a/modules/exploits/windows/browser/advantech_webaccess_dvs_getcolor.rb
+++ b/modules/exploits/windows/browser/advantech_webaccess_dvs_getcolor.rb
@@ -40,7 +40,7 @@ class MetasploitModule < Msf::Exploit::Remote
           :source  => /script|headers/i,
           :os_name => OperatingSystems::Match::WINDOWS,
           :ua_name => /MSIE/i,
-          :ua_ver  => lambda { |ver| Gem::Version.new(ver) <  Gem::Version.new('10') },
+          :ua_ver  => lambda { |ver| Rex::Version.new(ver) <  Rex::Version.new('10') },
           :activex => [
             {
               clsid: "{5CE92A27-9F6A-11D2-9D3D-000001155641}",

--- a/modules/exploits/windows/browser/malwarebytes_update_exec.rb
+++ b/modules/exploits/windows/browser/malwarebytes_update_exec.rb
@@ -83,7 +83,7 @@ class MetasploitModule < Msf::Exploit::Remote
     this_version = $1
     next_version = NEXT_VERSION[:mbam]
     if
-      Gem::Version.new(next_version) >= Gem::Version.new(this_version)
+      Rex::Version.new(next_version) >= Rex::Version.new(this_version)
       return true
     else
       print_error "Version #{this_version} of Anti-Malware isn't vulnerable, not attempting update."

--- a/modules/exploits/windows/ftp/wing_ftp_admin_exec.rb
+++ b/modules/exploits/windows/ftp/wing_ftp_admin_exec.rb
@@ -82,11 +82,11 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Safe
     end
 
-    @version = Gem::Version.new(ver.body.scan(/Wing FTP Server ([\d\.]+)/).flatten.first)
+    @version = Rex::Version.new(ver.body.scan(/Wing FTP Server ([\d\.]+)/).flatten.first)
     print_status("Found Wing FTP Server #{@version}")
 
     # Lua capabilities and administrator console were added in version 3.0.0, so everything above that is (probably) vulnerable
-    unless @version >= Gem::Version.new('3.0.0')
+    unless @version >= Rex::Version.new('3.0.0')
       @vuln_check = false
       return CheckCode::Safe
     end
@@ -125,7 +125,7 @@ class MetasploitModule < Msf::Exploit::Remote
       psh_command = cmd_psh_payload(payload.encoded, payload_instance.arch.first, encode_final_payload: true)
       execute_command(psh_command)
     else
-      if @version > Gem::Version.new('4.3.8')
+      if @version > Rex::Version.new('4.3.8')
         fail_with(Failure::NoTarget, "Version #{@version} detected and PowerShell not found, aborting exploit attempt!")
       end
       print_warning("PowerShell not found, will revert to CmdStager for payload delivery!")

--- a/modules/exploits/windows/http/apache_tika_jp2_jscript.rb
+++ b/modules/exploits/windows/http/apache_tika_jp2_jscript.rb
@@ -74,9 +74,9 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     if res.body =~ /Apache Tika (\d.[\d]+)/
-      version = Gem::Version.new($1)
+      version = Rex::Version.new($1)
       vprint_status("Apache Tika Version Detected: #{version}")
-      if version.between?(Gem::Version.new('1.15'), Gem::Version.new('1.17'))
+      if version.between?(Rex::Version.new('1.15'), Rex::Version.new('1.17'))
         return CheckCode::Vulnerable
       end
     end

--- a/modules/exploits/windows/http/cayin_xpost_sql_rce.rb
+++ b/modules/exploits/windows/http/cayin_xpost_sql_rce.rb
@@ -82,7 +82,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     %r{// xPost v(?<version>[\d.]+) } =~ res.body
 
-    if version && Gem::Version.new(version) <= Gem::Version.new('2.5')
+    if version && Rex::Version.new(version) <= Rex::Version.new('2.5')
       print_good("Version Detected: #{version}")
       return CheckCode::Appears
     end

--- a/modules/exploits/windows/http/desktopcentral_file_upload.rb
+++ b/modules/exploits/windows/http/desktopcentral_file_upload.rb
@@ -96,7 +96,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
       if build.nil?
         return Exploit::CheckCode::Unknown
-      elsif Gem::Version.new(build) < Gem::Version.new("80293")
+      elsif Rex::Version.new(build) < Rex::Version.new("80293")
         return Exploit::CheckCode::Appears
       else
         return Exploit::CheckCode::Safe

--- a/modules/exploits/windows/http/desktopcentral_statusupdate_upload.rb
+++ b/modules/exploits/windows/http/desktopcentral_statusupdate_upload.rb
@@ -75,7 +75,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
       if build.nil?
         return Exploit::CheckCode::Unknown
-      elsif Gem::Version.new(build) < Gem::Version.new("90055")
+      elsif Rex::Version.new(build) < Rex::Version.new("90055")
         return Exploit::CheckCode::Appears
       else
         return Exploit::CheckCode::Safe

--- a/modules/exploits/windows/http/exchange_ecp_dlp_policy.rb
+++ b/modules/exploits/windows/http/exchange_ecp_dlp_policy.rb
@@ -109,8 +109,8 @@ class MetasploitModule < Msf::Exploit::Remote
   def vuln_builds
     # https://docs.microsoft.com/en-us/exchange/new-features/build-numbers-and-release-dates?view=exchserver-2019
     [
-      [Gem::Version.new('15.1.225'), Gem::Version.new('15.1.2176')], # Exchange Server 2016
-      [Gem::Version.new('15.2.196'), Gem::Version.new('15.2.792')] # Exchange Server 2019
+      [Rex::Version.new('15.1.225'), Rex::Version.new('15.1.2176')], # Exchange Server 2016
+      [Rex::Version.new('15.2.196'), Rex::Version.new('15.2.792')] # Exchange Server 2019
     ]
   end
 
@@ -131,7 +131,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Unknown('Target does not appear to be running Exchange Server.')
     end
 
-    if vuln_builds.any? { |build_range| Gem::Version.new(build).between?(*build_range) }
+    if vuln_builds.any? { |build_range| Rex::Version.new(build).between?(*build_range) }
       return CheckCode::Appears("Exchange Server #{build} is a vulnerable build.")
     end
 

--- a/modules/exploits/windows/http/lexmark_markvision_gfd_upload.rb
+++ b/modules/exploits/windows/http/lexmark_markvision_gfd_upload.rb
@@ -59,7 +59,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return Exploit::CheckCode::Unknown
     end
 
-    if Gem::Version.new(version) <= Gem::Version.new('2.0.0')
+    if Rex::Version.new(version) <= Rex::Version.new('2.0.0')
       return Exploit::CheckCode::Appears
     end
 

--- a/modules/exploits/windows/http/manage_engine_opmanager_rce.rb
+++ b/modules/exploits/windows/http/manage_engine_opmanager_rce.rb
@@ -64,7 +64,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if res.body =~ /OpManager.*v\.([0-9]+\.[0-9]+)<\/span>/
       version = $1
-      if Gem::Version.new(version) <= Gem::Version.new('11.6')
+      if Rex::Version.new(version) <= Rex::Version.new('11.6')
         return Exploit::CheckCode::Appears
       else
         # Patch unknown

--- a/modules/exploits/windows/http/plex_unpickle_dict_rce.rb
+++ b/modules/exploits/windows/http/plex_unpickle_dict_rce.rb
@@ -230,8 +230,8 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Safe('Only Windows OS is exploitable')
     end
     print_good("Server OS: #{server['MediaContainer']['platform']} (#{server['MediaContainer']['platformVersion']})")
-    v = Gem::Version.new(server['MediaContainer']['version'])
-    if v >= Gem::Version.new('1.19.3')
+    v = Rex::Version.new(server['MediaContainer']['version'])
+    if v >= Rex::Version.new('1.19.3')
       print_bad("Server Version: #{v}")
       return CheckCode::Safe('Only < 1.19.3 is exploitable')
     end

--- a/modules/exploits/windows/http/prtg_authenticated_rce.rb
+++ b/modules/exploits/windows/http/prtg_authenticated_rce.rb
@@ -256,7 +256,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
       if prtg_version
         vprint_status("Identified PRTG Network Monitor Version #{prtg_version}")
-        if Gem::Version.new(prtg_version) < Gem::Version.new('18.2.39')
+        if Rex::Version.new(prtg_version) < Rex::Version.new('18.2.39')
           return CheckCode::Appears
         else
           return CheckCode::Safe

--- a/modules/exploits/windows/http/rejetto_hfs_exec.rb
+++ b/modules/exploits/windows/http/rejetto_hfs_exec.rb
@@ -59,7 +59,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if res &&  res.headers['Server'] && res.headers['Server'] =~ /HFS ([\d.]+)/
       version = $1
-      if Gem::Version.new(version) <= Gem::Version.new("2.3")
+      if Rex::Version.new(version) <= Rex::Version.new("2.3")
         return Exploit::CheckCode::Detected
       else
         return Exploit::CheckCode::Safe

--- a/modules/exploits/windows/http/sharepoint_ssi_viewstate.rb
+++ b/modules/exploits/windows/http/sharepoint_ssi_viewstate.rb
@@ -123,9 +123,9 @@ class MetasploitModule < Msf::Exploit::Remote
     # https://docs.microsoft.com/en-us/officeupdates/sharepoint-updates
     # https://buildnumbers.wordpress.com/sharepoint/
     [
-      [Gem::Version.new('15.0.0.4571'), Gem::Version.new('15.0.0.5275')], # SharePoint 2013
-      [Gem::Version.new('16.0.0.4351'), Gem::Version.new('16.0.0.5056')], # SharePoint 2016
-      [Gem::Version.new('16.0.0.10337'), Gem::Version.new('16.0.0.10366')] # SharePoint 2019
+      [Rex::Version.new('15.0.0.4571'), Rex::Version.new('15.0.0.5275')], # SharePoint 2013
+      [Rex::Version.new('16.0.0.4351'), Rex::Version.new('16.0.0.5056')], # SharePoint 2016
+      [Rex::Version.new('16.0.0.10337'), Rex::Version.new('16.0.0.10366')] # SharePoint 2019
     ]
   end
 
@@ -147,7 +147,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Unknown('Target does not appear to be running SharePoint.')
     end
 
-    if vuln_builds.any? { |build_range| Gem::Version.new(build).between?(*build_range) }
+    if vuln_builds.any? { |build_range| Rex::Version.new(build).between?(*build_range) }
       return CheckCode::Appears("SharePoint #{build} is a vulnerable build.")
     end
 

--- a/modules/exploits/windows/http/zentao_pro_rce.rb
+++ b/modules/exploits/windows/http/zentao_pro_rce.rb
@@ -138,9 +138,9 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Detected('Unable to obtain ZenTao version.')
     end
 
-    @version = Gem::Version.new(version)
+    @version = Rex::Version.new(version)
 
-    unless @version <= Gem::Version.new('8.8.2')
+    unless @version <= Rex::Version.new('8.8.2')
       return CheckCode::Detected("Target is ZenTao version #{@version}.")
     end
 

--- a/modules/exploits/windows/local/anyconnect_lpe.rb
+++ b/modules/exploits/windows/local/anyconnect_lpe.rb
@@ -173,9 +173,9 @@ class MetasploitModule < Msf::Exploit::Local
 
     cve_2020_3153 = (datastore['CVE'] == 'CVE-2020-3153')
 
-    patched_version_cve_2020_3153 = Gem::Version.new('4.8.02042')
-    patched_version_cve_2020_3433 = Gem::Version.new('4.9.00086')
-    @ac_version = Gem::Version.new(version.join('.'))
+    patched_version_cve_2020_3153 = Rex::Version.new('4.8.02042')
+    patched_version_cve_2020_3433 = Rex::Version.new('4.9.00086')
+    @ac_version = Rex::Version.new(version.join('.'))
     if @ac_version < patched_version_cve_2020_3153
       return CheckCode.Appears("Cisco AnyConnect version #{@ac_version} < #{patched_version_cve_2020_3153} (CVE-2020-3153 & CVE-2020-3433).")
     elsif (@ac_version < patched_version_cve_2020_3433) && !cve_2020_3153
@@ -200,7 +200,7 @@ class MetasploitModule < Msf::Exploit::Local
     end
 
     cac_cmd = '"CAC-nc-install'
-    if @ac_version && @ac_version >= Gem::Version.new('4.7')
+    if @ac_version && @ac_version >= Rex::Version.new('4.7')
       vprint_status('"-ipc" argument needed')
       cac_cmd << "\t-ipc=#{rand_text_numeric(5)}"
     else

--- a/modules/exploits/windows/local/cve_2019_1458_wizardopium.rb
+++ b/modules/exploits/windows/local/cve_2019_1458_wizardopium.rb
@@ -95,22 +95,22 @@ class MetasploitModule < Msf::Exploit::Local
     major, minor, build, revision, branch = file_version(file_path)
     vprint_status("win32k.sys file version: #{major}.#{minor}.#{build}.#{revision} branch: #{branch}")
 
-    build_num_gemversion = Gem::Version.new("#{major}.#{minor}.#{build}.#{revision}")
+    build_num_gemversion = Rex::Version.new("#{major}.#{minor}.#{build}.#{revision}")
 
     # Build numbers taken from https://www.qualys.com/research/security-alerts/2019-12-10/microsoft/
-    if (build_num_gemversion >= Gem::Version.new('6.0.6000.0')) && (build_num_gemversion < Gem::Version.new('6.0.6003.20692')) # Windows Vista and Windows Server 2008
+    if (build_num_gemversion >= Rex::Version.new('6.0.6000.0')) && (build_num_gemversion < Rex::Version.new('6.0.6003.20692')) # Windows Vista and Windows Server 2008
       return CheckCode::Appears
-    elsif (build_num_gemversion >= Gem::Version.new('6.1.7600.0')) && (build_num_gemversion < Gem::Version.new('6.1.7601.24540')) # Windows 7 and Windows Server 2008 R2
+    elsif (build_num_gemversion >= Rex::Version.new('6.1.7600.0')) && (build_num_gemversion < Rex::Version.new('6.1.7601.24540')) # Windows 7 and Windows Server 2008 R2
       return CheckCode::Appears
-    elsif (build_num_gemversion >= Gem::Version.new('6.2.9200.0')) && (build_num_gemversion < Gem::Version.new('6.2.9200.22932')) # Windows 8 and Windows Server 2012
+    elsif (build_num_gemversion >= Rex::Version.new('6.2.9200.0')) && (build_num_gemversion < Rex::Version.new('6.2.9200.22932')) # Windows 8 and Windows Server 2012
       return CheckCode::Appears
-    elsif (build_num_gemversion >= Gem::Version.new('6.3.9600.0')) && (build_num_gemversion < Gem::Version.new('6.3.9600.19574')) # Windows 8.1 and Windows Server 2012 R2
+    elsif (build_num_gemversion >= Rex::Version.new('6.3.9600.0')) && (build_num_gemversion < Rex::Version.new('6.3.9600.19574')) # Windows 8.1 and Windows Server 2012 R2
       return CheckCode::Appears
-    elsif (build_num_gemversion >= Gem::Version.new('10.0.10240.0')) && (build_num_gemversion < Gem::Version.new('10.0.10240.18427')) # Windows 10 v1507
+    elsif (build_num_gemversion >= Rex::Version.new('10.0.10240.0')) && (build_num_gemversion < Rex::Version.new('10.0.10240.18427')) # Windows 10 v1507
       return CheckCode::Appears
-    elsif (build_num_gemversion >= Gem::Version.new('10.0.10586.0')) && (build_num_gemversion < Gem::Version.new('10.0.10586.99999')) # Windows 10 v1511
+    elsif (build_num_gemversion >= Rex::Version.new('10.0.10586.0')) && (build_num_gemversion < Rex::Version.new('10.0.10586.99999')) # Windows 10 v1511
       return CheckCode::Appears
-    elsif (build_num_gemversion >= Gem::Version.new('10.0.14393.0')) && (build_num_gemversion < Gem::Version.new('10.0.14393.3383')) # Windows 10 v1607
+    elsif (build_num_gemversion >= Rex::Version.new('10.0.14393.0')) && (build_num_gemversion < Rex::Version.new('10.0.14393.3383')) # Windows 10 v1607
       return CheckCode::Appears
     else
       return CheckCode::Safe

--- a/modules/exploits/windows/local/cve_2020_0787_bits_arbitrary_file_move.rb
+++ b/modules/exploits/windows/local/cve_2020_0787_bits_arbitrary_file_move.rb
@@ -107,37 +107,37 @@ class MetasploitModule < Msf::Exploit::Local
       return CheckCode::Safe('Target is not running a vulnerable version of Windows!')
     end
 
-    build_num_gemversion = Gem::Version.new(build_num)
+    build_num_gemversion = Rex::Version.new(build_num)
 
     # Build numbers taken from https://www.qualys.com/research/security-alerts/2020-03-10/microsoft/
-    if (build_num_gemversion >= Gem::Version.new('10.0.18363.0')) && (build_num_gemversion < Gem::Version.new('10.0.18363.719')) # Windows 10 v1909
+    if (build_num_gemversion >= Rex::Version.new('10.0.18363.0')) && (build_num_gemversion < Rex::Version.new('10.0.18363.719')) # Windows 10 v1909
       return CheckCode::Appears('Vulnerable Windows 10 v1909 build detected!')
-    elsif (build_num_gemversion >= Gem::Version.new('10.0.18362.0')) && (build_num_gemversion < Gem::Version.new('10.0.18362.719')) # Windows 10 v1903
+    elsif (build_num_gemversion >= Rex::Version.new('10.0.18362.0')) && (build_num_gemversion < Rex::Version.new('10.0.18362.719')) # Windows 10 v1903
       return CheckCode::Appears('Vulnerable Windows 10 v1903 build detected!')
-    elsif (build_num_gemversion >= Gem::Version.new('10.0.17763.0')) && (build_num_gemversion < Gem::Version.new('10.0.17763.1098')) # Windows 10 v1809
+    elsif (build_num_gemversion >= Rex::Version.new('10.0.17763.0')) && (build_num_gemversion < Rex::Version.new('10.0.17763.1098')) # Windows 10 v1809
       return CheckCode::Appears('Vulnerable Windows 10 v1809 build detected!')
-    elsif (build_num_gemversion >= Gem::Version.new('10.0.17134.0')) && (build_num_gemversion < Gem::Version.new('10.0.17134.1365')) # Windows 10 v1803
+    elsif (build_num_gemversion >= Rex::Version.new('10.0.17134.0')) && (build_num_gemversion < Rex::Version.new('10.0.17134.1365')) # Windows 10 v1803
       return CheckCode::Appears('Vulnerable Windows 10 v1803 build detected!')
-    elsif (build_num_gemversion >= Gem::Version.new('10.0.16299.0')) && (build_num_gemversion < Gem::Version.new('10.0.16299.1747')) # Windows 10 v1709
+    elsif (build_num_gemversion >= Rex::Version.new('10.0.16299.0')) && (build_num_gemversion < Rex::Version.new('10.0.16299.1747')) # Windows 10 v1709
       return CheckCode::Appears('Vulnerable Windows 10 v1709 build detected!')
-    elsif (build_num_gemversion >= Gem::Version.new('10.0.15063.0')) && (build_num_gemversion < Gem::Version.new('10.0.15063.2313')) # Windows 10 v1703
+    elsif (build_num_gemversion >= Rex::Version.new('10.0.15063.0')) && (build_num_gemversion < Rex::Version.new('10.0.15063.2313')) # Windows 10 v1703
       return CheckCode::Appears('Vulnerable Windows 10 v1703 build detected!')
-    elsif (build_num_gemversion >= Gem::Version.new('10.0.14393.0')) && (build_num_gemversion < Gem::Version.new('10.0.14393.3564')) # Windows 10 v1607
+    elsif (build_num_gemversion >= Rex::Version.new('10.0.14393.0')) && (build_num_gemversion < Rex::Version.new('10.0.14393.3564')) # Windows 10 v1607
       return CheckCode::Appears('Vulnerable Windows 10 v1607 build detected!')
-    elsif (build_num_gemversion >= Gem::Version.new('10.0.10586.0')) && (build_num_gemversion < Gem::Version.new('10.0.10586.9999999')) # Windows 10 v1511
+    elsif (build_num_gemversion >= Rex::Version.new('10.0.10586.0')) && (build_num_gemversion < Rex::Version.new('10.0.10586.9999999')) # Windows 10 v1511
       return CheckCode::Appears('Vulnerable Windows 10 v1511 build detected!')
-    elsif (build_num_gemversion >= Gem::Version.new('10.0.10240.0')) && (build_num_gemversion < Gem::Version.new('10.0.10240.18519')) # Windows 10 v1507
+    elsif (build_num_gemversion >= Rex::Version.new('10.0.10240.0')) && (build_num_gemversion < Rex::Version.new('10.0.10240.18519')) # Windows 10 v1507
       return CheckCode::Appears('Vulnerable Windows 10 v1507 build detected!')
-    elsif (build_num_gemversion >= Gem::Version.new('6.3.9600.0')) && (build_num_gemversion < Gem::Version.new('6.3.9600.19665')) # Windows 8.1/Windows Server 2012 R2
+    elsif (build_num_gemversion >= Rex::Version.new('6.3.9600.0')) && (build_num_gemversion < Rex::Version.new('6.3.9600.19665')) # Windows 8.1/Windows Server 2012 R2
       target_not_presently_supported
       return CheckCode::Appears('Vulnerable Windows 8.1/Windows Server 2012 R2 build detected!')
-    elsif (build_num_gemversion >= Gem::Version.new('6.2.9200.0')) && (build_num_gemversion < Gem::Version.new('6.2.9200.23009')) # Windows 8/Windows Server 2012
+    elsif (build_num_gemversion >= Rex::Version.new('6.2.9200.0')) && (build_num_gemversion < Rex::Version.new('6.2.9200.23009')) # Windows 8/Windows Server 2012
       target_not_presently_supported
       return CheckCode::AppearsAppears('Vulnerable Windows 8/Windows Server 2012 build detected!')
-    elsif (build_num_gemversion >= Gem::Version.new('6.1.7600.0')) && (build_num_gemversion < Gem::Version.new('6.1.7601.24549')) # Windows 7/Windows Server 2008 R2
+    elsif (build_num_gemversion >= Rex::Version.new('6.1.7600.0')) && (build_num_gemversion < Rex::Version.new('6.1.7601.24549')) # Windows 7/Windows Server 2008 R2
       target_not_presently_supported
       return CheckCode::Appears('Vulnerable Windows 7/Windows Server 2008 R2 build detected!')
-    elsif (build_num_gemversion >= Gem::Version.new('6.0.6001.0')) && (build_num_gemversion < Gem::Version.new('6.0.6003.20749')) # Windows Server 2008/Windows Server 2008 SP2
+    elsif (build_num_gemversion >= Rex::Version.new('6.0.6001.0')) && (build_num_gemversion < Rex::Version.new('6.0.6003.20749')) # Windows Server 2008/Windows Server 2008 SP2
       target_not_presently_supported
       return CheckCode::Appears('Windows Server 2008/Windows Server 2008 SP2 build detected!')
     else

--- a/modules/exploits/windows/local/cve_2020_1054_drawiconex_lpe.rb
+++ b/modules/exploits/windows/local/cve_2020_1054_drawiconex_lpe.rb
@@ -99,12 +99,12 @@ class MetasploitModule < Msf::Exploit::Local
     major, minor, build, revision, branch = file_version(file_path)
     vprint_status("win32k.sys file version: #{major}.#{minor}.#{build}.#{revision} branch: #{branch}")
 
-    build_num_gemversion = Gem::Version.new("#{major}.#{minor}.#{build}.#{revision}")
-    if (build_num_gemversion >= Gem::Version.new('6.1.7600.0')) && (build_num_gemversion < Gem::Version.new('6.1.7601.24542')) # Windows 7 SP1
+    build_num_gemversion = Rex::Version.new("#{major}.#{minor}.#{build}.#{revision}")
+    if (build_num_gemversion >= Rex::Version.new('6.1.7600.0')) && (build_num_gemversion < Rex::Version.new('6.1.7601.24542')) # Windows 7 SP1
       @xleft_offset = 0x900
       @oob_offset = 0x238
       return CheckCode::Appears
-    elsif (build_num_gemversion >= Gem::Version.new('6.1.7600.0')) && (build_num_gemversion < Gem::Version.new('6.1.7601.24553')) # Windows 7 SP1 with patches
+    elsif (build_num_gemversion >= Rex::Version.new('6.1.7600.0')) && (build_num_gemversion < Rex::Version.new('6.1.7601.24553')) # Windows 7 SP1 with patches
       @xleft_offset = 0x8c0
       @oob_offset = 0x240
       return CheckCode::Appears

--- a/modules/exploits/windows/local/cve_2020_17136.rb
+++ b/modules/exploits/windows/local/cve_2020_17136.rb
@@ -116,19 +116,19 @@ class MetasploitModule < Msf::Exploit::Local
       vprint_status("Target's build number: #{build_num}")
     end
 
-    build_num_gemversion = Gem::Version.new(build_num)
+    build_num_gemversion = Rex::Version.new(build_num)
     # Build numbers taken from https://www.qualys.com/research/security-alerts/2020-03-10/microsoft/
-    if (build_num_gemversion >= Gem::Version.new('10.0.19042.0')) && (build_num_gemversion < Gem::Version.new('10.0.19042.685')) # Windows 10 20H2
+    if (build_num_gemversion >= Rex::Version.new('10.0.19042.0')) && (build_num_gemversion < Rex::Version.new('10.0.19042.685')) # Windows 10 20H2
       return CheckCode::Appears('A vulnerable Windows 10 20H2 build was detected!')
-    elsif (build_num_gemversion >= Gem::Version.new('10.0.19041.0')) && (build_num_gemversion < Gem::Version.new('10.0.19041.685')) # Windows 10 v2004 aka 20H1
+    elsif (build_num_gemversion >= Rex::Version.new('10.0.19041.0')) && (build_num_gemversion < Rex::Version.new('10.0.19041.685')) # Windows 10 v2004 aka 20H1
       return CheckCode::Appears('A vulnerable Windows 10 20H1 build was detected!')
-    elsif (build_num_gemversion >= Gem::Version.new('10.0.18363.0')) && (build_num_gemversion < Gem::Version.new('10.0.18363.1256')) # Windows 10 v1909
+    elsif (build_num_gemversion >= Rex::Version.new('10.0.18363.0')) && (build_num_gemversion < Rex::Version.new('10.0.18363.1256')) # Windows 10 v1909
       return CheckCode::Appears('A vulnerable Windows 10 v1909 build was detected!')
-    elsif (build_num_gemversion >= Gem::Version.new('10.0.18362.0')) && (build_num_gemversion < Gem::Version.new('10.0.18362.1256')) # Windows 10 v1903
+    elsif (build_num_gemversion >= Rex::Version.new('10.0.18362.0')) && (build_num_gemversion < Rex::Version.new('10.0.18362.1256')) # Windows 10 v1903
       return CheckCode::Appears('A vulnerable Windows 10 v1903 build was detected!')
-    elsif (build_num_gemversion >= Gem::Version.new('10.0.17763.0')) && (build_num_gemversion < Gem::Version.new('10.0.17763.1637')) # Windows 10 v1809
+    elsif (build_num_gemversion >= Rex::Version.new('10.0.17763.0')) && (build_num_gemversion < Rex::Version.new('10.0.17763.1637')) # Windows 10 v1809
       return CheckCode::Appears('A vulnerable Windows 10 v1809 build was detected!')
-    elsif (build_num_gemversion >= Gem::Version.new('10.0.17134.0')) && (build_num_gemversion < Gem::Version.new('10.0.17134.1902')) # Windows 10 v1803
+    elsif (build_num_gemversion >= Rex::Version.new('10.0.17134.0')) && (build_num_gemversion < Rex::Version.new('10.0.17134.1902')) # Windows 10 v1803
       return CheckCode::Appears('A vulnerable Windows 10 v1809 build was detected!')
     else
       return CheckCode::Safe('The build number of the target machine does not appear to be a vulnerable version!')

--- a/modules/exploits/windows/local/dnsadmin_serverlevelplugindll.rb
+++ b/modules/exploits/windows/local/dnsadmin_serverlevelplugindll.rb
@@ -230,13 +230,13 @@ class MetasploitModule < Msf::Exploit::Local
         vprint_status("Target's build number: #{build_num}")
       end
 
-      build_num_gemversion = Gem::Version.new(build_num)
+      build_num_gemversion = Rex::Version.new(build_num)
 
       # If the target is running Windows 10 or Windows Server versions with a
       # build number of 16299 or later, aka v1709 or later, then we need to check
       # if "Enable insecure guest logons" is enabled on the target system as per
       # https://support.microsoft.com/en-us/help/4046019/guest-access-in-smb2-disabled-by-default-in-windows-10-and-windows-ser
-      if (build_num_gemversion >= Gem::Version.new('10.0.16299.0'))
+      if (build_num_gemversion >= Rex::Version.new('10.0.16299.0'))
         # check if "Enable insecure guest logons" is enabled on the target system
         allow_insecure_guest_auth = registry_getvaldata('HKLM\\SYSTEM\\CurrentControlSet\\Services\\LanmanWorkstation\\Parameters', 'AllowInsecureGuestAuth')
         unless allow_insecure_guest_auth == 1

--- a/modules/exploits/windows/local/docker_credential_wincred.rb
+++ b/modules/exploits/windows/local/docker_credential_wincred.rb
@@ -54,11 +54,11 @@ class MetasploitModule < Msf::Exploit::Local
     output = cmd_exec('cmd.exe', '/c docker -v')
     vprint_status(output)
     version_string = output.match(/(\d+\.)(\d+\.)(\d)/)[0]
-    Gem::Version.new(version_string.split('.').map(&:to_i).join('.'))
+    Rex::Version.new(version_string.split('.').map(&:to_i).join('.'))
   end
 
   def check
-    if docker_version <= Gem::Version.new('18.09.0')
+    if docker_version <= Rex::Version.new('18.09.0')
       return CheckCode::Appears
     end
 

--- a/modules/exploits/windows/local/gog_galaxyclientservice_privesc.rb
+++ b/modules/exploits/windows/local/gog_galaxyclientservice_privesc.rb
@@ -81,9 +81,9 @@ class MetasploitModule < Msf::Exploit::Local
 
     return CheckCode::Detected('Galaxy Client version not found') unless ver_no
 
-    version = Gem::Version.new(ver_no)
+    version = Rex::Version.new(ver_no)
 
-    return CheckCode::Appears("Vulnerable version found: #{ver_no}") if version < Gem::Version.new('2.0.13')
+    return CheckCode::Appears("Vulnerable version found: #{ver_no}") if version < Rex::Version.new('2.0.13')
 
     CheckCode::Detected("Galaxy Client version #{ver_no} not vulnerable")
   end

--- a/modules/exploits/windows/local/ms14_009_ie_dfsvc.rb
+++ b/modules/exploits/windows/local/ms14_009_ie_dfsvc.rb
@@ -76,7 +76,7 @@ class MetasploitModule < Msf::Exploit::Local
 
     mscorlib_version = get_mscorlib_version
 
-    if Gem::Version.new(mscorlib_version) >= Gem::Version.new(NET_VERSIONS[net_version]["mscorlib"])
+    if Rex::Version.new(mscorlib_version) >= Rex::Version.new(NET_VERSIONS[net_version]["mscorlib"])
       return Exploit::CheckCode::Safe
     end
 
@@ -137,7 +137,7 @@ class MetasploitModule < Msf::Exploit::Local
 
     mscorlib_version = get_mscorlib_version
 
-    if Gem::Version.new(mscorlib_version) >= Gem::Version.new(NET_VERSIONS[net_version]["mscorlib"])
+    if Rex::Version.new(mscorlib_version) >= Rex::Version.new(NET_VERSIONS[net_version]["mscorlib"])
       fail_with(Failure::NotVulnerable, ".NET Installation not vulnerable")
     end
 

--- a/modules/exploits/windows/local/ms15_078_atmfd_bof.rb
+++ b/modules/exploits/windows/local/ms15_078_atmfd_bof.rb
@@ -303,7 +303,7 @@ class MetasploitModule < Msf::Exploit::Local
 
     atmfd = atmfd_version
     # atmfd 5.1.2.238 => Works
-    unless atmfd && Gem::Version.new(atmfd) <= Gem::Version.new('5.1.2.243')
+    unless atmfd && Rex::Version.new(atmfd) <= Rex::Version.new('5.1.2.243')
       return Exploit::CheckCode::Safe
     end
 

--- a/modules/post/android/manage/remove_lock.rb
+++ b/modules/post/android/manage/remove_lock.rb
@@ -47,8 +47,8 @@ class MetasploitModule < Msf::Post
       fail_with(Failure::Unknown, 'Failed to retrieve build.prop, you might need to try again.')
     end
 
-    android_version = Gem::Version.new(build_prop['ro.build.version.release'])
-    if android_version <= Gem::Version.new('4.3') && android_version >= Gem::Version.new('4.0')
+    android_version = Rex::Version.new(build_prop['ro.build.version.release'])
+    if android_version <= Rex::Version.new('4.3') && android_version >= Rex::Version.new('4.0')
       return true
     end
 

--- a/modules/post/osx/escalate/tccbypass.rb
+++ b/modules/post/osx/escalate/tccbypass.rb
@@ -50,10 +50,10 @@ class MetasploitModule < Msf::Post
       return Exploit::CheckCode::Unknown
     end
 
-    version = Gem::Version.new(system_version)
-    if version >= Gem::Version.new('10.15.6')
+    version = Rex::Version.new(system_version)
+    if version >= Rex::Version.new('10.15.6')
       return Exploit::CheckCode::Safe
-    elsif version < Gem::Version.new('10.15.0')
+    elsif version < Rex::Version.new('10.15.0')
       return Exploit::CheckCode::Unknown
     else
       return Exploit::CheckCode::Appears

--- a/modules/post/solaris/escalate/srsexec_readline.rb
+++ b/modules/post/solaris/escalate/srsexec_readline.rb
@@ -54,8 +54,8 @@ class MetasploitModule < Msf::Post
       return false
     end
 
-    version = Gem::Version.new($1.split(".").map(&:to_i).join('.'))
-    unless version.between?(Gem::Version.new('3.2.3'), Gem::Version.new('3.2.4'))
+    version = Rex::Version.new($1.split(".").map(&:to_i).join('.'))
+    unless version.between?(Rex::Version.new('3.2.3'), Rex::Version.new('3.2.4'))
       print_error "#{version} is not vulnerable"
       return false
     end

--- a/modules/post/windows/gather/credentials/mcafee_vse_hashdump.rb
+++ b/modules/post/windows/gather/credentials/mcafee_vse_hashdump.rb
@@ -8,10 +8,10 @@ class MetasploitModule < Msf::Post
   include Msf::Auxiliary::Report
   include Msf::Post::Windows::UserProfiles
 
-  VERSION_5 = Gem::Version.new('5.0')
-  VERSION_6 = Gem::Version.new('6.0')
-  VERSION_8 = Gem::Version.new('8.0')
-  VERSION_9 = Gem::Version.new('9.0')
+  VERSION_5 = Rex::Version.new('5.0')
+  VERSION_6 = Rex::Version.new('6.0')
+  VERSION_8 = Rex::Version.new('8.0')
+  VERSION_9 = Rex::Version.new('9.0')
 
   def initialize(info = {})
     super(update_info(
@@ -82,7 +82,7 @@ class MetasploitModule < Msf::Post
         vprint_error("No McAfee VSE version key found in #{key}")
         next
       end
-      hash_map[hash] = Gem::Version.new(version)
+      hash_map[hash] = Rex::Version.new(version)
     end
     hash_map
   end

--- a/modules/post/windows/gather/credentials/pulse_secure.rb
+++ b/modules/post/windows/gather/credentials/pulse_secure.rb
@@ -337,8 +337,8 @@ class MetasploitModule < Msf::Post
   # Array of vulnerable builds branches.
   def vuln_builds
     [
-      [Gem::Version.new('0.0.0'), Gem::Version.new('9.0.5')],
-      [Gem::Version.new('9.1.0'), Gem::Version.new('9.1.4')],
+      [Rex::Version.new('0.0.0'), Rex::Version.new('9.0.5')],
+      [Rex::Version.new('9.1.0'), Rex::Version.new('9.1.4')],
     ]
   end
 
@@ -366,9 +366,9 @@ class MetasploitModule < Msf::Post
       version_data = version_file.read.to_s
       version_file.close
       matches = version_data.scan(/DisplayVersion=([0-9.]+)/m)
-      build = Gem::Version.new(matches[0][0])
+      build = Rex::Version.new(matches[0][0])
       print_status("Target is running Pulse Secure Connect build #{build}.")
-      if vuln_builds.any? { |build_range| Gem::Version.new(build).between?(*build_range) }
+      if vuln_builds.any? { |build_range| Rex::Version.new(build).between?(*build_range) }
         print_good('This version is considered vulnerable.')
         return Msf::Exploit::CheckCode::Vulnerable
       end

--- a/spec/lib/rex/version_spec.rb
+++ b/spec/lib/rex/version_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+require 'rex/version'
+
+RSpec.describe Rex::Version do
+
+  context 'when version is nil' do
+    let(:version) { nil }
+    subject { Rex::Version.new(version) }
+
+    it 'should be equivalent to a version of 0' do
+      expect(subject).to eq Gem::Version.new(0)
+    end
+
+    it 'should be equivalent to a version of "0"' do
+      expect(subject).to eq Gem::Version.new("0")
+    end
+
+    it 'should be equivalent to a version of empty string' do
+      expect(subject).to eq Gem::Version.new("")
+    end
+
+    it 'should not be less than a version of 0' do
+      expect(subject).not_to be < Gem::Version.new(0)
+    end
+
+    it 'should not be greater than a version of 0' do
+      expect(subject).not_to be > Gem::Version.new(0)
+    end
+
+    it 'should be less than a version of "0.0.1"' do
+      expect(subject).to be < Gem::Version.new("0.0.1")
+    end
+
+    it 'should not be greater than a version of "0.0.1"' do
+      expect(subject).not_to be > Gem::Version.new("0.0.1")
+    end
+
+  end
+end


### PR DESCRIPTION
Resolves #11744 

Some information about nil being deprecated in an upcoming Rubygems version here: https://github.com/rubygems/rubygems/issues/2359

This PR wraps the `Gem::Version` from Rubygems and handles a `nil` version being passed in in such a way as to keep the current functionality (treats it equal to the version being 0)

Vast majority of changes are just changing references from `Gem::Version` to `Rex::Version`, important files are here 
`lib/rex/version.rb` and the tests here `spec/lib/rex/version_spec.rb`

# Verification
- [x] Tests pass
