### PR TITLE
guard when spawn is used with TcpServer mixin

### DIFF
--- a/lib/msf/core/exploit/remote/socket_server.rb
+++ b/lib/msf/core/exploit/remote/socket_server.rb
@@ -89,7 +89,8 @@ module Exploit::Remote::SocketServer
         end
 
         self.service = nil
-      rescue ::Exception
+      rescue ::Exception => e
+        print_error(e.message)
       end
     end
   end

--- a/modules/exploits/windows/ftp/freefloatftp_wbem.rb
+++ b/modules/exploits/windows/ftp/freefloatftp_wbem.rb
@@ -139,12 +139,17 @@ class MetasploitModule < Msf::Exploit::Remote
 
     begin
       t = framework.threads.spawn("reqs", false) {
-        # Upload our malicious executable
-        u = upload(exe_name)
-        # Upload the mof file
-        upload(mof_name) if u
-        register_file_for_cleanup("#{::File.basename(exe_name)}")
-        register_file_for_cleanup("wbem\\mof\\good\\#{::File.basename(mof_name)}")
+        begin
+          # Upload our malicious executable
+          u = upload(exe_name)
+          # Upload the mof file
+          upload(mof_name) if u
+          register_file_for_cleanup("#{::File.basename(exe_name)}")
+          register_file_for_cleanup("wbem\\mof\\good\\#{::File.basename(mof_name)}")
+        rescue ::Exception => e
+          print_error "Upload Failed: #{e.message}"
+          cleanup
+        end
       }
       super
     ensure

--- a/modules/exploits/windows/ftp/open_ftpd_wbem.rb
+++ b/modules/exploits/windows/ftp/open_ftpd_wbem.rb
@@ -134,12 +134,17 @@ class MetasploitModule < Msf::Exploit::Remote
 
     begin
       t = framework.threads.spawn("reqs", false) {
-        # Upload our malicious executable
-        u = upload(exe_name)
-        # Upload the mof file
-        upload(mof_name) if u
-        register_file_for_cleanup("#{::File.basename(exe_name)}")
-        register_file_for_cleanup("wbem\\mof\\good\\#{::File.basename(mof_name)}")
+        begin
+          # Upload our malicious executable
+          u = upload(exe_name)
+          # Upload the mof file
+          upload(mof_name) if u
+          register_file_for_cleanup("#{::File.basename(exe_name)}")
+          register_file_for_cleanup("wbem\\mof\\good\\#{::File.basename(mof_name)}")
+        rescue ::Errno::ECONNRESET => e
+          print_error "Upload Failed: #{e.message}"
+          cleanup
+        end
       }
 
       super

--- a/modules/exploits/windows/ftp/open_ftpd_wbem.rb
+++ b/modules/exploits/windows/ftp/open_ftpd_wbem.rb
@@ -141,7 +141,7 @@ class MetasploitModule < Msf::Exploit::Remote
           upload(mof_name) if u
           register_file_for_cleanup("#{::File.basename(exe_name)}")
           register_file_for_cleanup("wbem\\mof\\good\\#{::File.basename(mof_name)}")
-        rescue ::Errno::ECONNRESET => e
+        rescue ::Exception => e
           print_error "Upload Failed: #{e.message}"
           cleanup
         end

--- a/modules/exploits/windows/ftp/quickshare_traversal_write.rb
+++ b/modules/exploits/windows/ftp/quickshare_traversal_write.rb
@@ -48,6 +48,7 @@ class MetasploitModule < Msf::Exploit::Remote
         [
           ['QuickShare File Server 1.2.1', {}]
         ],
+      'Stance' => Msf::Exploit::Stance::Aggressive,
       'Privileged'     => false,
       'DisclosureDate' => '2011-02-03',
       'DefaultTarget'  => 0))
@@ -104,14 +105,12 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_user(datastore['FTPUSER'], conn)
 
     if res !~ /^(331|2)/
-      vprint_error("The server rejected our username: #{res.to_s}")
-      return false
+      fail_with(Failure::BadConfig, "The server rejected our username: #{res.to_s}")
     end
 
     res = send_pass(datastore['FTPPASS'], conn)
     if res !~ /^(2|503)/
-      vprint_error("The server rejected our password: #{res.to_s}")
-      return false
+      fail_with(Failure::BadConfig, "The server rejected our password: #{res.to_s}")
     end
 
     # Switch to binary mode
@@ -147,11 +146,16 @@ class MetasploitModule < Msf::Exploit::Remote
 
     begin
       t = framework.threads.spawn("reqs", false) {
-        # Upload our malicious executable
-        u = upload(exe_name)
+        begin
+          # Upload our malicious executable
+          u = upload(exe_name)
 
-        # Upload the mof file
-        upload(mof_name) if u
+          # Upload the mof file
+          upload(mof_name) if u
+        rescue ::Exception => e
+          print_error e.message
+          cleanup
+        end
       }
       super
     ensure

--- a/modules/exploits/windows/http/solarwinds_storage_manager_sql.rb
+++ b/modules/exploits/windows/http/solarwinds_storage_manager_sql.rb
@@ -219,6 +219,9 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     handler
+  rescue ::Exception => e
+    print_error("Failure attempting to inject exe: #{e.message}")
+    cleanup
   end
 
 


### PR DESCRIPTION
When attempting to utilize `exploit/windows/ftp/open_ftpd_wbem` the file upload preformed in a separate thread can fail commonly with a `connection reset`.  When this occurs, the service started by the `Msf::Exploit::Remote::TcpServer` mixin never receives a request to serve the `on_client_connect` method.  This results in the module waiting indefinetly for the the service connection and failing to complete.

```
msf6 > use Open-FTPD
[*] No payload configured, defaulting to windows/meterpreter/reverse_tcp

Matching Modules
================

   #  Name                                Disclosure Date  Rank       Check  Description
   -  ----                                ---------------  ----       -----  -----------
   0  exploit/windows/ftp/open_ftpd_wbem  2012-06-18       excellent  Yes    Open-FTPD 1.2 Arbitrary File Upload


Interact with a module by name or index. For example info 0, use 0 or use exploit/windows/ftp/open_ftpd_wbem

[*] Using exploit/windows/ftp/open_ftpd_wbem
msf6 exploit(windows/ftp/open_ftpd_wbem) > set RHOST 192.168.1.20
RHOST => 192.168.1.20
msf6 exploit(windows/ftp/open_ftpd_wbem) > run

[*] Started reverse TCP handler on 192.168.1.2:4444
[*] 192.168.1.20:21 - Started service listener on 0.0.0.0:8080
[*] 192.168.1.20:21 - Server started.
[*] 192.168.1.20:21 - Trying to upload rLtiRVGs.exe
[*] 192.168.1.20:21 - Set binary mode
[*] 192.168.1.20:21 - Set active mode "192,168,1,2,31,144"
```
Resulting in 
```
ruby      53855   15u  IPv4 0x2ebce6469311ce33      0t0  TCP 192.168.1.2:4444 (LISTEN)
ruby      53855   16u  IPv4 0x2ebce64693607093      0t0  TCP *:8080 (LISTEN)
ruby      53855   17u  IPv4 0x2ebce646975506b3      0t0  TCP 192.168.1.2:58429->192.168.1.20:21 (CLOSED)
```

These hung listeners will remain until the module execution is manually cancelled.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use use Open-FTPD`
- [ ] `set RHOST <valid ftp server not vulnerable to this module>`
- [ ] `run`
- [ ] **Verify** module reports `Upload Failed: Connection reset by peer`
- [ ] **Verify** the module completes and closes both the hander and service listener