### PR TITLE
Lock ruby-prof until nightly builds can use c11

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ group :development do
   # memory profiling
   gem 'memory_profiler'
   # cpu profiling
-  gem 'ruby-prof'
+  gem 'ruby-prof', '1.4.2'
   # Metasploit::Aggregator external session proxy
   # disabled during 2.5 transition until aggregator is available
   #gem 'metasploit-aggregator'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -393,7 +393,7 @@ GEM
     rubocop-ast (1.4.1)
       parser (>= 2.7.1.5)
     ruby-macho (2.5.0)
-    ruby-prof (1.4.3)
+    ruby-prof (1.4.2)
     ruby-progressbar (1.11.0)
     ruby-rc4 (0.1.5)
     ruby2_keywords (0.0.4)
@@ -469,7 +469,7 @@ DEPENDENCIES
   rspec-rails
   rspec-rerun
   rubocop
-  ruby-prof
+  ruby-prof (= 1.4.2)
   simplecov (= 0.18.2)
   swagger-blocks
   timecop


### PR DESCRIPTION
Due to https://github.com/ruby-prof/ruby-prof/commit/659faf3bc2b3f2fe715fb836a17571ff04910924 ruby-prof cannot be compiled on the centos6 currently used for nightly packaging by https://github.com/rapid7/metasploit-omnibus.  Lock to 1.4.2 until adjustments are made.

## Verification

List the steps needed to make sure this thing works

- [ ] Verify `bundle install` in `rapid7/msf-centos6-x64-omnibus:2020_03` docker image.