### PR TITLE
Update metasploit-payloads gem to 2.0.34

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,7 +29,7 @@ PATH
       metasploit-concern
       metasploit-credential
       metasploit-model
-      metasploit-payloads (= 2.0.28)
+      metasploit-payloads (= 2.0.34)
       metasploit_data_models
       metasploit_payloads-mettle (= 1.0.6)
       mqtt
@@ -224,7 +224,7 @@ GEM
       activemodel (~> 5.2.2)
       activesupport (~> 5.2.2)
       railties (~> 5.2.2)
-    metasploit-payloads (2.0.28)
+    metasploit-payloads (2.0.34)
     metasploit_data_models (4.1.2)
       activerecord (~> 5.2.2)
       activesupport (~> 5.2.2)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -70,7 +70,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '2.0.28'
+  spec.add_runtime_dependency 'metasploit-payloads', '2.0.34'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '1.0.6'
   # Needed by msfgui and other rpc components

--- a/modules/payloads/singles/python/meterpreter_bind_tcp.rb
+++ b/modules/payloads/singles/python/meterpreter_bind_tcp.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 112793
+  CachedSize = 112869
 
   include Msf::Payload::Single
   include Msf::Payload::Python

--- a/modules/payloads/singles/python/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/python/meterpreter_reverse_http.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 112761
+  CachedSize = 112837
 
   include Msf::Payload::Single
   include Msf::Payload::Python

--- a/modules/payloads/singles/python/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/python/meterpreter_reverse_https.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 112765
+  CachedSize = 112837
 
   include Msf::Payload::Single
   include Msf::Payload::Python

--- a/modules/payloads/singles/python/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/python/meterpreter_reverse_tcp.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 112693
+  CachedSize = 112769
 
   include Msf::Payload::Single
   include Msf::Payload::Python


### PR DESCRIPTION
This PR bumps framework to use Metasploit payloads gem 2.0.34 (previously 2.0.28), pulling in the following payloads PR changes:

* rapid7/metasploit-payloads#451
* rapid7/metasploit-payloads#473
* Java linter issues
    * rapid7/metasploit-payloads#453
    * rapid7/metasploit-payloads#454
    * rapid7/metasploit-payloads#455
    * rapid7/metasploit-payloads#456
    * rapid7/metasploit-payloads#459
    * rapid7/metasploit-payloads#460
    * rapid7/metasploit-payloads#461
    * rapid7/metasploit-payloads#462
    * rapid7/metasploit-payloads#466
    * rapid7/metasploit-payloads#468
    * rapid7/metasploit-payloads#469

## Verification
List the steps needed to make sure this thing works

- [x] Retest manually
- [x] Let automated tests pass