### PR TITLE
Update uses of open ssl

### DIFF
--- a/lib/metasploit/framework/aws/client.rb
+++ b/lib/metasploit/framework/aws/client.rb
@@ -17,7 +17,7 @@ module Metasploit
             print_error "Unexpected value format"
             return nil
           end
-          digest = OpenSSL::Digest::SHA256.new
+          digest = OpenSSL::Digest.new('SHA256')
           if value.respond_to?(:read)
             chunk = nil
             chunk_size = 1024 * 1024 # 1 megabyte

--- a/lib/msf/core/auxiliary/ubiquiti.rb
+++ b/lib/msf/core/auxiliary/ubiquiti.rb
@@ -15,9 +15,9 @@ module Msf
 
     def decrypt_unf(contents)
       aes = OpenSSL::Cipher.new('aes-128-cbc')
+      aes.decrypt
       aes.key = 'bcyangkmluohmars' # https://github.com/zhangyoufu/unifi-backup-decrypt/blob/master/E>
       aes.padding = 0
-      aes.decrypt
       aes.iv = 'ubntenterpriseap'
       aes.update(contents)
     end

--- a/lib/msf/core/cert_provider.rb
+++ b/lib/msf/core/cert_provider.rb
@@ -90,7 +90,7 @@ module Ssl
         cert.extensions << ef.create_extension("extendedKeyUsage", ekuse)
       end
 
-      cert.sign(key, OpenSSL::Digest::SHA256.new)
+      cert.sign(key, OpenSSL::Digest.new('SHA256'))
 
       [key, cert, nil]
     end

--- a/lib/msf/core/payload/android.rb
+++ b/lib/msf/core/payload/android.rb
@@ -103,7 +103,7 @@ module Msf::Payload::Android
     cert.not_after = Time.at(0x78045d81 + rand(0x7fffffff - 0x78045d81))
 
     # If this line is left out, signature verification fails on OSX.
-    cert.sign(key, OpenSSL::Digest::SHA1.new)
+    cert.sign(key, OpenSSL::Digest.new('SHA1'))
 
     jar.sign(key, cert, [cert])
   end

--- a/lib/msf/core/post/windows/priv.rb
+++ b/lib/msf/core/post/windows/priv.rb
@@ -306,6 +306,7 @@ module Msf::Post::Windows::Priv
       end
 
       rc4 = OpenSSL::Cipher.new("rc4")
+      rc4.decrypt
       rc4.key = md5x.digest
       lsa_key  = rc4.update(pol[12,48])
       lsa_key << rc4.final
@@ -356,6 +357,7 @@ module Msf::Post::Windows::Priv
     end
 
     aes = OpenSSL::Cipher.new("aes-256-cbc")
+    aes.decrypt
     aes.key = sha256x.digest
 
     vprint_status("digest #{sha256x.digest.unpack("H*")[0]}")
@@ -363,7 +365,7 @@ module Msf::Post::Windows::Priv
     decrypted_data = ''
 
     (60...policy_secret.length).step(16) do |i|
-      aes.decrypt
+      aes.reset
       aes.padding = 0
       decrypted_data << aes.update(policy_secret[i,16])
     end
@@ -389,7 +391,7 @@ module Msf::Post::Windows::Priv
       block_key = key[j..j+6]
       des_key = convert_des_56_to_64(block_key)
       d1 = OpenSSL::Cipher.new('des-ecb')
-
+      d1.decrypt
       d1.padding = 0
       d1.key = des_key
       d1o = d1.update(enc_block)

--- a/lib/rex/crypto/aes256.rb
+++ b/lib/rex/crypto/aes256.rb
@@ -9,7 +9,7 @@ module Rex
       # @param key [String] Secret key.
       # @return [String] The encrypted string.
       def self.encrypt_aes256(iv, key, value)
-        aes = OpenSSL::Cipher::AES256.new(:CBC)
+        aes = OpenSSL::Cipher.new('aes-256-cbc')
         aes.encrypt
         aes.iv = iv
         aes.key = key
@@ -22,7 +22,7 @@ module Rex
       # @param key [String] Secret key.
       # @return [String] The decrypted string.
       def self.decrypt_aes256(iv, key, value)
-        aes = OpenSSL::Cipher::AES256.new(:CBC)
+        aes = OpenSSL::Cipher.new('aes-256-cbc')
         aes.decrypt
         aes.iv = iv
         aes.key = key

--- a/lib/rex/parser/net_sarang.rb
+++ b/lib/rex/parser/net_sarang.rb
@@ -24,8 +24,8 @@ module Rex
           self.username = username
           self.sid = sid
           self.master_password = master_password
-          md5 = OpenSSL::Digest::MD5.new
-          sha256 = OpenSSL::Digest::SHA256.new
+          md5 = OpenSSL::Digest.new('MD5')
+          sha256 = OpenSSL::Digest.new('SHA256')
           if (self.version > 0) && (self.version < 5.1)
             self.key = (type == 'Xshell') ? md5.digest('!X@s#h$e%l^l&') : md5.digest('!X@s#c$e%l^l&')
           elsif (self.version >= 5.1) && (self.version <= 5.2)
@@ -50,7 +50,7 @@ module Rex
           if (version < 5.1)
             return Rex::Text.encode_base64(cipher)
           else
-            sha256 = OpenSSL::Digest::SHA256.new
+            sha256 = OpenSSL::Digest.new('SHA256')
             checksum = sha256.digest(string)
             ciphertext = cipher
             return Rex::Text.encode_base64(ciphertext + checksum)

--- a/lib/rex/proto/ntlm/crypt.rb
+++ b/lib/rex/proto/ntlm/crypt.rb
@@ -82,10 +82,11 @@ BASE = Rex::Proto::NTLM::Base
 
   def self.apply_des(plain, keys)
     raise RuntimeError, "No OpenSSL support" if not @@loaded_openssl
-    dec = OpenSSL::Cipher::DES.new
+    dec = OpenSSL::Cipher.new('DES')
     keys.map do |k|
+      dec.decrypt
       dec.key = k
-      dec.encrypt.update(plain)
+      dec.update(plain)
     end
   end
 
@@ -118,7 +119,7 @@ BASE = Rex::Proto::NTLM::Base
     unless opt[:unicode]
       userdomain = Rex::Text.to_unicode(userdomain)
     end
-    OpenSSL::HMAC.digest(OpenSSL::Digest::MD5.new, ntlmhash, userdomain)
+    OpenSSL::HMAC.digest(OpenSSL::Digest.new('MD5'), ntlmhash, userdomain)
   end
 
   # Create the LANMAN response
@@ -198,7 +199,7 @@ BASE = Rex::Proto::NTLM::Base
       bb = blob.serialize
     end
 
-    OpenSSL::HMAC.digest(OpenSSL::Digest::MD5.new, key, chal + bb) + bb
+    OpenSSL::HMAC.digest(OpenSSL::Digest.new('MD5'), key, chal + bb) + bb
   end
 
   def self.lmv2_response(arg, opt = {})
@@ -210,7 +211,7 @@ BASE = Rex::Proto::NTLM::Base
     cc   = opt[:client_challenge] || rand(CONST::MAX64)
     cc   = BASE::pack_int64le(cc) if cc.is_a?(::Integer)
 
-    OpenSSL::HMAC.digest(OpenSSL::Digest::MD5.new, key, chal + cc) + cc
+    OpenSSL::HMAC.digest(OpenSSL::Digest.new('MD5'), key, chal + cc) + cc
   end
 
   def self.ntlm2_session(arg, opt = {})
@@ -338,7 +339,7 @@ BASE = Rex::Proto::NTLM::Base
 
     ntlm_key = self.ntlmv1_user_session_key(pass, opt )
     session_chal = srv_chall + cli_chall
-    OpenSSL::HMAC.digest(OpenSSL::Digest::MD5.new, ntlm_key, session_chal)
+    OpenSSL::HMAC.digest(OpenSSL::Digest.new('MD5'), ntlm_key, session_chal)
   end
 
   # Used when the LMv2 response is sent
@@ -346,8 +347,8 @@ BASE = Rex::Proto::NTLM::Base
     raise RuntimeError, "No OpenSSL support" if not @@loaded_openssl
 
     ntlmv2_key = self.ntlmv2_hash(user, pass, domain, opt)
-    hash1 = OpenSSL::HMAC.digest(OpenSSL::Digest::MD5.new, ntlmv2_key, srv_chall + cli_chall)
-    OpenSSL::HMAC.digest(OpenSSL::Digest::MD5.new, ntlmv2_key, hash1)
+    hash1 = OpenSSL::HMAC.digest(OpenSSL::Digest.new('MD5'), ntlmv2_key, srv_chall + cli_chall)
+    OpenSSL::HMAC.digest(OpenSSL::Digest.new('MD5'), ntlmv2_key, hash1)
   end
 
   # Used when the NTLMv2 response is sent

--- a/lib/rex/proto/rfb/cipher.rb
+++ b/lib/rex/proto/rfb/cipher.rb
@@ -92,7 +92,7 @@ class Cipher
 
     shared_key = dh.compute_key(dh_peer.pub_key)
 
-    md5 = OpenSSL::Digest::MD5.new
+    md5 = OpenSSL::Digest.new('MD5')
     key_digest = md5.digest(shared_key)
 
     cipher = OpenSSL::Cipher.new("aes-128-ecb")

--- a/modules/auxiliary/server/openssl_altchainsforgery_mitm_proxy.rb
+++ b/modules/auxiliary/server/openssl_altchainsforgery_mitm_proxy.rb
@@ -99,7 +99,7 @@ class MetasploitModule < Msf::Auxiliary
     root_ca_cert.add_extension(extension_factory.create_extension('basicConstraints', 'CA:TRUE', true))
     root_ca_cert.add_extension(extension_factory.create_extension('keyUsage', 'keyCertSign,cRLSign', true))
     root_ca_cert.add_extension(extension_factory.create_extension('subjectKeyIdentifier', 'hash'))
-    root_ca_cert.sign(root_ca_key, OpenSSL::Digest::SHA1.new)
+    root_ca_cert.sign(root_ca_key, OpenSSL::Digest.new('SHA1'))
 
     inter_ca_name = OpenSSL::X509::Name.parse('/C=US/O=Intermediate Inc./CN=Intermediate CA')
     inter_ca_key = OpenSSL::PKey::RSA.new(2048)
@@ -115,11 +115,11 @@ class MetasploitModule < Msf::Auxiliary
     inter_ca_cert.add_extension(extension_factory.create_extension('basicConstraints', 'CA:TRUE', true))
     inter_ca_cert.add_extension(extension_factory.create_extension('keyUsage', 'keyCertSign,cRLSign', true))
     inter_ca_cert.add_extension(extension_factory.create_extension('subjectKeyIdentifier', 'hash'))
-    inter_ca_cert.sign(root_ca_key, OpenSSL::Digest::SHA1.new)
+    inter_ca_cert.sign(root_ca_key, OpenSSL::Digest.new('SHA1'))
 
     subinter_ca_cert = OpenSSL::X509::Certificate.new(File.read(datastore['CACERT']))
     subinter_ca_cert.issuer = inter_ca_name
-    subinter_ca_cert.sign(inter_ca_key, OpenSSL::Digest::SHA1.new)
+    subinter_ca_cert.sign(inter_ca_key, OpenSSL::Digest.new('SHA1'))
     leaf_key = OpenSSL::PKey::RSA.new(File.read(datastore['KEY']), datastore['PASSPHRASE'])
     leaf_cert = OpenSSL::X509::Certificate.new(File.read(datastore['CERT']))
 
@@ -137,7 +137,7 @@ class MetasploitModule < Msf::Auxiliary
     fake_cert.add_extension(extension_factory.create_extension('basicConstraints', 'CA:FALSE', true))
     fake_cert.add_extension(extension_factory.create_extension('keyUsage', 'digitalSignature,nonRepudiation,keyEncipherment'))
     fake_cert.add_extension(extension_factory.create_extension('subjectKeyIdentifier', 'hash'))
-    fake_cert.sign(leaf_key, OpenSSL::Digest::SHA1.new)
+    fake_cert.sign(leaf_key, OpenSSL::Digest.new('SHA1'))
 
     context = OpenSSL::SSL::SSLContext.new
     context.cert = fake_cert

--- a/modules/auxiliary/server/openssl_heartbeat_client_memory.rb
+++ b/modules/auxiliary/server/openssl_heartbeat_client_memory.rb
@@ -395,7 +395,7 @@ class MetasploitModule < Msf::Auxiliary
     ]
     ef.issuer_certificate = cert
     cert.add_extension ef.create_extension("authorityKeyIdentifier", "keyid:always,issuer:always")
-    cert.sign(key, OpenSSL::Digest::SHA1.new)
+    cert.sign(key, OpenSSL::Digest.new('SHA1'))
     cert
   end
 
@@ -448,15 +448,15 @@ class MetasploitModule < Msf::Auxiliary
     })
 
     client_cipher = OpenSSL::Cipher.new('aes-128-cbc')
+    client_cipher.decrypt
     client_cipher.key = @state[c][:client_write_key]
     client_cipher.iv  = @state[c][:client_iv]
-    client_cipher.decrypt
     client_mac = OpenSSL::HMAC.new(@state[c][:client_write_mac_key], OpenSSL::Digest.new('sha1'))
 
     server_cipher = OpenSSL::Cipher.new('aes-128-cbc')
+    server_cipher.encrypt
     server_cipher.key = @state[c][:server_write_key]
     server_cipher.iv  = @state[c][:server_iv]
-    server_cipher.encrypt
     server_mac = OpenSSL::HMAC.new(@state[c][:server_write_mac_key], OpenSSL::Digest.new('sha1'))
 
     @state[c].update({

--- a/modules/exploits/linux/http/empire_skywalker.rb
+++ b/modules/exploits/linux/http/empire_skywalker.rb
@@ -70,7 +70,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def aes_encrypt(key, data, include_mac=false)
-    cipher = OpenSSL::Cipher::AES256.new(:CBC)
+    cipher = OpenSSL::Cipher.new('aes-256-cbc')
     cipher.encrypt
     iv = cipher.random_iv
     cipher.key = key

--- a/modules/exploits/linux/http/github_enterprise_secret.rb
+++ b/modules/exploits/linux/http/github_enterprise_secret.rb
@@ -85,7 +85,7 @@ class MetasploitModule < Msf::Exploit::Remote
     hmac = gh_manage_value.split('--').last.split(';', 2).first
     vprint_status("Data: #{data.gsub(/\n/, '')}")
     vprint_status("Extracted HMAC: #{hmac}")
-    expected_hmac = OpenSSL::HMAC.hexdigest(OpenSSL::Digest::SHA1.new, secret, data)
+    expected_hmac = OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('SHA1'), secret, data)
     vprint_status("Expected HMAC: #{expected_hmac}")
 
     if expected_hmac == hmac
@@ -137,7 +137,7 @@ class MetasploitModule < Msf::Exploit::Remote
     serialized_output = `ruby -e "#{ruby_code}"`
 
     serialized_object = [serialized_output].pack('m')
-    hmac = OpenSSL::HMAC.hexdigest(OpenSSL::Digest::SHA1.new, secret, serialized_object)
+    hmac = OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('SHA1'), secret, serialized_object)
 
     return serialized_object, hmac
   end

--- a/modules/exploits/windows/backupexec/ssl_uaf.rb
+++ b/modules/exploits/windows/backupexec/ssl_uaf.rb
@@ -574,7 +574,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # Have to do this after creating subjectKeyIdentifier extension
     ca_cert.add_extension(extn_factory.create_extension('authorityKeyIdentifier', 'keyid:always,issuer'))
 
-    ca_cert.sign(ca_key, OpenSSL::Digest::SHA256.new)
+    ca_cert.sign(ca_key, OpenSSL::Digest.new('SHA256'))
 
     [ca_cert, ca_key]
   end
@@ -605,7 +605,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # Have to do this after creating subjectKeyIdentifier extension
     agent_cert.add_extension(extn_factory.create_extension('authorityKeyIdentifier', 'keyid:always,issuer'))
 
-    agent_cert.sign(ca_key, OpenSSL::Digest::SHA256.new)
+    agent_cert.sign(ca_key, OpenSSL::Digest.new('SHA256'))
 
     req = SSLRequest.new_for_opcode(SSLRequest::Opcode.give_signed_cert)
     req.ca_cert = ca_cert.to_s

--- a/modules/post/multi/gather/remmina_creds.rb
+++ b/modules/post/multi/gather/remmina_creds.rb
@@ -47,6 +47,7 @@ class MetasploitModule < Msf::Post
 
   def decrypt(secret, data)
     c = OpenSSL::Cipher.new('des3')
+    c.decrypt
     key_data = Base64.decode64(secret)
     # the key is the first 24 bytes of the secret
     c.key = key_data[0, 24]
@@ -54,7 +55,6 @@ class MetasploitModule < Msf::Post
     c.iv = key_data[24, 8]
     # passwords less than 16 characters are padded with nulls
     c.padding = 0
-    c.decrypt
     p = c.update(Base64.decode64(data))
     p << c.final
     # trim null-padded, < 16 character passwords

--- a/modules/post/windows/gather/cachedump.rb
+++ b/modules/post/windows/gather/cachedump.rb
@@ -264,9 +264,9 @@ class MetasploitModule < Msf::Post
 
   def decrypt_hash_vista(edata, nlkm, ch)
     aes = OpenSSL::Cipher.new('aes-128-cbc')
+    aes.decrypt
     aes.key = nlkm[16...32]
     aes.padding = 0
-    aes.decrypt
     aes.iv = ch
 
     decrypted = ""

--- a/modules/post/windows/gather/credentials/coreftp.rb
+++ b/modules/post/windows/gather/credentials/coreftp.rb
@@ -89,8 +89,8 @@ class MetasploitModule < Msf::Post
   def decrypt(encoded)
     cipher = [encoded].pack("H*")
     aes = OpenSSL::Cipher.new("AES-128-ECB")
-    aes.padding = 0
     aes.decrypt
+    aes.padding = 0
     aes.key = "hdfzpysvpzimorhk"
     password = (aes.update(cipher) + aes.final).gsub(/\x00/,'')
     return password

--- a/modules/post/windows/gather/credentials/epo_sql.rb
+++ b/modules/post/windows/gather/credentials/epo_sql.rb
@@ -156,8 +156,8 @@ class MetasploitModule < Msf::Post
   def decrypt46(encoded)
     encrypted_data = Rex::Text.decode_base64(encoded)
     aes = OpenSSL::Cipher.new('AES-128-ECB')
-    aes.padding = 0
     aes.decrypt
+    aes.padding = 0
     # Private key extracted from ePO 4.6.0 Build 1029
     # If other keys are required for other versions of 4.6 - will have to add version
     # identification routines in to the main part of the module

--- a/modules/post/windows/gather/credentials/securecrt.rb
+++ b/modules/post/windows/gather/credentials/securecrt.rb
@@ -134,9 +134,9 @@ class MetasploitModule < Msf::Post
     config_passphrase = datastore['PASSPHRASE'] || nil
     key = OpenSSL::Digest::SHA256.new(config_passphrase).digest
     aes = OpenSSL::Cipher.new('AES-256-CBC')
+    aes.decrypt
     aes.key = key
     aes.padding = 0
-    aes.decrypt
     aes.iv = iv
     padded_plain_bytes = aes.update([ciphertext].pack('H*'))
     plain_bytes_length = padded_plain_bytes[0, 4].unpack1('l') # bytes to int little-endian format.

--- a/modules/post/windows/gather/credentials/smartermail.rb
+++ b/modules/post/windows/gather/credentials/smartermail.rb
@@ -40,7 +40,7 @@ class MetasploitModule < Msf::Post
   #
   def decrypt_des(encrypted)
     return nil if encrypted.nil?
-    decipher = OpenSSL::Cipher::DES.new
+    decipher = OpenSSL::Cipher.new('DES')
     decipher.decrypt
     decipher.key = "\xb9\x9a\x52\xd4\x58\x77\xe9\x18"
     decipher.iv  = "\x52\xe9\xc3\x9f\x13\xb4\x1d\x0f"

--- a/modules/post/windows/gather/hashdump.rb
+++ b/modules/post/windows/gather/hashdump.rb
@@ -145,15 +145,16 @@ class MetasploitModule < Msf::Post
         hash.update(vf[0x70, 16] + @sam_qwerty + bootkey + @sam_numeric)
 
         rc4 = OpenSSL::Cipher.new("rc4")
+        rc4.decrypt
         rc4.key = hash.digest
         hbootkey  = rc4.update(vf[0x80, 32])
         hbootkey << rc4.final
         hbootkey
       when 2
         aes = OpenSSL::Cipher.new('aes-128-cbc')
+        aes.decrypt
         aes.key = bootkey
         aes.padding = 0
-        aes.decrypt
         aes.iv = vf[0x78, 16]
         aes.update(vf[0x88, 16]) # we need only 16 bytes
       else
@@ -261,6 +262,7 @@ class MetasploitModule < Msf::Post
         md5.update(hbootkey[0,16] + [rid].pack("V") + pass)
 
         rc4 = OpenSSL::Cipher.new('rc4')
+        rc4.decrypt
         rc4.key = md5.digest
         okey = rc4.update(enchash[4, 16])
       when 2
@@ -269,9 +271,9 @@ class MetasploitModule < Msf::Post
         end
 
         aes = OpenSSL::Cipher.new('aes-128-cbc')
+        aes.decrypt
         aes.key = hbootkey[0, 16]
         aes.padding = 0
-        aes.decrypt
         aes.iv = enchash[8, 16]
         okey = aes.update(enchash[24, 16]) # we need only 16 bytes
       else
@@ -282,17 +284,19 @@ class MetasploitModule < Msf::Post
     des_k1, des_k2 = rid_to_key(rid)
 
     d1 = OpenSSL::Cipher.new('des-ecb')
+    d1.decrypt
     d1.padding = 0
     d1.key = des_k1
 
     d2 = OpenSSL::Cipher.new('des-ecb')
+    d2.decrypt
     d2.padding = 0
     d2.key = des_k2
 
-    d1o  = d1.decrypt.update(okey[0,8])
+    d1o  = d1.update(okey[0,8])
     d1o << d1.final
 
-    d2o  = d2.decrypt.update(okey[8,8])
+    d2o  = d2.update(okey[8,8])
     d1o << d2.final
     d1o + d2o
   end

--- a/modules/post/windows/gather/smart_hashdump.rb
+++ b/modules/post/windows/gather/smart_hashdump.rb
@@ -71,6 +71,7 @@ class MetasploitModule < Msf::Post
     hash.update(vf[0x70, 16] + @sam_qwerty + bootkey + @sam_numeric)
 
     rc4 = OpenSSL::Cipher.new('rc4')
+    rc4.decrypt
     rc4.key = hash.digest
     hbootkey = rc4.update(vf[0x80, 32])
     hbootkey << rc4.final
@@ -190,10 +191,12 @@ class MetasploitModule < Msf::Post
     des_k1, des_k2 = rid_to_key(rid)
 
     d1 = OpenSSL::Cipher.new('des-ecb')
+    d1.decrypt
     d1.padding = 0
     d1.key = des_k1
 
     d2 = OpenSSL::Cipher.new('des-ecb')
+    d2.decrypt
     d2.padding = 0
     d2.key = des_k2
 
@@ -201,13 +204,14 @@ class MetasploitModule < Msf::Post
     md5.update(hbootkey[0, 16] + [rid].pack('V') + pass)
 
     rc4 = OpenSSL::Cipher.new('rc4')
+    rc4.decrypt
     rc4.key = md5.digest
     okey = rc4.update(enchash)
 
-    d1o = d1.decrypt.update(okey[0, 8])
+    d1o = d1.update(okey[0, 8])
     d1o << d1.final
 
-    d2o = d2.decrypt.update(okey[8, 8])
+    d2o = d2.update(okey[8, 8])
     d1o << d2.final
     d1o + d2o
   end


### PR DESCRIPTION
This PR:
- Updates uses of openssl objects to assign the key _after_ calling `.decrypt` / `.encrypt` method calls
- Runs `Lint/DeprecatedOpenSSLConstant` Rubocop rule

```
rubocop --only Lint/DeprecatedOpenSSLConstant -a modules lib
```

## Context

Ruby 3.0 ships with openssl 2.2.0 - which adds now throws an error if the key is set before calling decrypt/encrypt methods.
This PR fixes calls to OpenSSL to ensure methods are called in the right order.

For my machine:
```
2.6.5 :005 > OpenSSL::OPENSSL_LIBRARY_VERSION
 => "OpenSSL 1.1.1i  8 Dec 2020" 
2.6.5 :006 > OpenSSL::VERSION
 => "2.2.0" 
```

### Before

Running with Ruby 2.7 / OpenSSL 2.1.0:

```
docker run -it --rm -v $(pwd):$(pwd) -w $(pwd) ruby:2.7 /bin/bash
```

The following code works:

```ruby
$ irb

require 'openssl'
cipher = OpenSSL::Cipher.new("aes-128-cbc")
cipher.key = "A" * 16
cipher.encrypt
cipher.update("hello world") + cipher.final

=> "\\\x1D\xDF{\xCD+;\xBC\xCB\xDE+\x1E\xA7\xC9g\xF3"
```

### After

With Ruby 3.0 / OpenSSL 2.2.0:

```
docker run -it --rm -v $(pwd):$(pwd) -w $(pwd) ruby:3.0 /bin/bash
```

The following code now raises an exception:

```
Traceback (most recent call last):
        5: from /usr/local/bin/irb:23:in `<main>'
        4: from /usr/local/bin/irb:23:in `load'
        3: from /usr/local/lib/ruby/gems/3.0.0/gems/irb-1.3.0/exe/irb:11:in `<top (required)>'
        2: from (irb):68:in `<main>'
        1: from (irb):68:in `update'
OpenSSL::Cipher::CipherError (key not set)
```

### Solution

The code needs updated to ensure the key is set _after_ the encrypt/decrypt call:

```ruby
require 'openssl'
cipher = OpenSSL::Cipher.new("aes-128-cbc")
cipher.encrypt
cipher.key = "A" * 16
cipher.update("hello world") + cipher.final
```

openssl 2.2.0 test example:
https://github.com/ruby/ruby/blame/42a16e5974c3919755013eeee0debb16ffb69ff5/test/openssl/test_cipher.rb#L308-L321

## Verification

I verified changes statically after updating the Gemfile to open ssl 2.2.0 and rerunning bundle:
```
gem 'openssl', '2.2.0'
```

I created small test snippets as sanity checks, which I've added as comments were appropriate

Remaining testing effort:
- [x] Test secrets_dump module. Passed, but noticed https://github.com/rapid7/metasploit-framework/issues/14832
- [x] Test meterpreter `hashdump`
- [x] `modules/post/windows/gather/smart_hashdump.rb`

