### PR TITLE
Fix session verification by checking TLV negotiation

### DIFF
--- a/lib/msf/base/sessions/meterpreter.rb
+++ b/lib/msf/base/sessions/meterpreter.rb
@@ -128,16 +128,20 @@ class Meterpreter < Rex::Post::Meterpreter::Client
 
       session.init_ui(self.user_input, self.user_output)
 
-      session.tlv_enc_key = session.core.negotiate_tlv_encryption
+      verification_timeout = datastore['AutoVerifySessionTimeout']&.to_i || session.comm_timeout
+      begin
+        session.tlv_enc_key = session.core.negotiate_tlv_encryption(timeout: verification_timeout)
+      rescue Rex::TimeoutError
+      end
 
-      unless datastore['AutoVerifySession'] == false
-        unless session.is_valid_session?(datastore['AutoVerifySessionTimeout'].to_i)
-          print_error("Meterpreter session #{session.sid} is not valid and will be closed")
-          # Terminate the session without cleanup if it did not validate
-          session.skip_cleanup = true
-          session.kill
-          return nil
-        end
+      if session.tlv_enc_key.nil?
+        # Fail-closed if TLV encryption can't be negotiated (close the session as invalid)
+        dlog("Session #{session.sid} failed to negotiate TLV encryption")
+        print_error("Meterpreter session #{session.sid} is not valid and will be closed")
+        # Terminate the session without cleanup if it did not validate
+        session.skip_cleanup = true
+        session.kill
+        return nil
       end
 
       # always make sure that the new session has a new guid if it's not already known
@@ -407,25 +411,6 @@ class Meterpreter < Rex::Post::Meterpreter::Client
     console.disable_output = true
     console.run_single('load priv')
     console.disable_output = original
-  end
-
-  #
-  # Validate session information by checking for a machine_id response
-  #
-  def is_valid_session?(timeout=10)
-    return true if self.machine_id
-
-    begin
-      self.machine_id = self.core.machine_id(timeout)
-
-      return true
-    rescue ::Rex::Post::Meterpreter::RequestError
-      # This meterpreter doesn't support core_machine_id
-      return true
-    rescue ::Exception => e
-      dlog("Session #{self.sid} did not respond to validation request #{e.class}: #{e}")
-    end
-    false
   end
 
   def update_session_info

--- a/lib/msf/base/sessions/meterpreter_options.rb
+++ b/lib/msf/base/sessions/meterpreter_options.rb
@@ -23,10 +23,6 @@ module Msf
               'AutoLoadStdapi',
               [true, "Automatically load the Stdapi extension", true]
             ),
-            OptBool.new(
-              'AutoVerifySession',
-              [true, "Automatically verify and drop invalid sessions", true]
-            ),
             OptInt.new(
               'AutoVerifySessionTimeout',
               [false, "Timeout period to wait for session validation to occur, in seconds", 30]

--- a/lib/rex/post/meterpreter/client_core.rb
+++ b/lib/rex/post/meterpreter/client_core.rb
@@ -742,7 +742,7 @@ class ClientCore < Extension
   #
   # Negotiates the use of encryption at the TLV level
   #
-  def negotiate_tlv_encryption
+  def negotiate_tlv_encryption(timeout: client.comm_timeout)
     sym_key = nil
     rsa_key = OpenSSL::PKey::RSA.new(2048)
     rsa_pub_key = rsa_key.public_key
@@ -751,7 +751,7 @@ class ClientCore < Extension
     request.add_tlv(TLV_TYPE_RSA_PUB_KEY, rsa_pub_key.to_der)
 
     begin
-      response = client.send_request(request)
+      response = client.send_request(request, timeout)
       key_enc = response.get_tlv_value(TLV_TYPE_ENC_SYM_KEY)
       key_type = response.get_tlv_value(TLV_TYPE_SYM_KEY_TYPE)
 


### PR DESCRIPTION
The `AutoVerifySession` feature that we have does not appear to work since 6.x added full TLV encryption. This is due to the fact that the TLV negotiation takes place [before](https://github.com/rapid7/metasploit-framework/blob/e0dfd5cf9a536202fc4397b38ea6d2c41da55897/lib/msf/base/sessions/meterpreter.rb#L131-L141) session verification. The session verification itself just issues a TLV to fetch the remote machine ID to ensure that the session is responsive. If the TLV negotiation times out, a `Rex::TimeoutError` is raised and the session is closed. In this case the timeout takes the default value of 300 seconds and closes the session without any error message describing why.

The solution to address this proposed within this PR is to require successful TLV encryption negotiation in order for a session to be considered valid. Since v6 all Meterpreters support TLV encryption and since v5 Meterpreter sessions are incompatible anyway, we should never have a session established by a Meterpreter instance regardless of the implementation and platform that does not support TLV encryption. Metasploit should (and does) fail closed when TLV encryption can not be established, so there's no point in trying to issue the command to obtain the machine ID if it fails.

This also removes the `AutoVerifySession` datastore option (which previously defaulted to `true`) and instead always performs the verification, because again all valid Meterpreter instances should negotiate TLV encryption.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] Start a reverse TCP Meterpreter instance, any platform will do
    * `handler -p python/meterpreter/reverse_tcp -P 4444 -H 192.168.159.128`
    - [x] Connect to the listener with netcat `nc localhost 4444` and just let it sit
    - [x] After 30 seconds, see that the session is invalid and that it is closed
- [x] Start a reverse HTTP Meterpreter instance, (Python is eaiest for this step to base64-decode the URL)
    * `use payload/python/meterpreter/reverse_http`, `to_handler`
    - [x] Generate the stage and decode the Base64 blob to recover the URL (I like using [CyberChef](https://gchq.github.io/CyberChef/#recipe=From_Base64('A-Za-z0-9%2B/%3D',true)) for this step)
    - [x] Make an HTTP GET request to the recovered URL
    - [x] See that a Meterpreter session is opened
    - [x] After 30 seconds, see that the session is invalid and that it is closed

## Output After This Patch
In this case an invalid session is opened by making an HTTP GET request to the URL. After 30 seconds (instead of 5 minutes) the session is identified as invalid and closed.
```
msf6 payload(python/meterpreter/reverse_http) > to_handler 
[*] Payload Handler Started as Job 1
msf6 payload(python/meterpreter/reverse_http) > 
[*] Started HTTP reverse handler on http://192.168.159.128:8080
[*] http://192.168.159.128:8080 handling request from 192.168.159.128; (UUID: mfjvr5pv) Staging python payload (39572 bytes) ...
[*] Meterpreter session 1 opened (192.168.159.128:8080 -> 192.168.159.128:33612) at 2021-02-22 11:25:22 -0500
[-] Meterpreter session 1 is not valid and will be closed
[*] 192.168.159.128 - Meterpreter session 1 closed.
```

## Output Before This Patch
Here you see that the session is opened and then it does with no explanation. There was a period of a few minutes that elapsed between the session being opened and the message stating that it died.
```
msf6 payload(python/meterpreter/reverse_tcp) > to_handler 
[*] Payload Handler Started as Job 0
msf6 payload(python/meterpreter/reverse_tcp) > 
[*] Started reverse TCP handler on 192.168.159.128:4444 
[*] Sending stage (39348 bytes) to 192.168.159.128
[*] Meterpreter session 1 opened (192.168.159.128:4444 -> 192.168.159.128:46070) at 2021-02-22 09:14:00 -0500
[*] 192.168.159.128 - Meterpreter session 1 closed.  Reason: Died

msf6 payload(python/meterpreter/reverse_tcp) > 
```

In this example, the user immediately interacts with the session and attempts to load the stdapi extension. Because the session is unresponsive, Metasploit incorrectly identifies that the Meterpreter doesn't support the load command.
```
msf6 payload(python/meterpreter/reverse_tcp) > 
[*] Sending stage (39344 bytes) to 192.168.159.128
[*] Meterpreter session 2 opened (192.168.159.128:4444 -> 192.168.159.128:46136) at 2021-02-22 09:17:22 -0500

msf6 payload(python/meterpreter/reverse_tcp) > sessions -i 2
[*] Starting interaction with 2...

meterpreter > load stdapi
[-] The "load" command is not supported by this Meterpreter type (python/python)
meterpreter >
```