### PR TITLE
Apply fixes for invalid sysinfo['Architecture'] checks, aka #14599, to affected modules

### DIFF
--- a/modules/exploits/windows/local/capcom_sys_exec.rb
+++ b/modules/exploits/windows/local/capcom_sys_exec.rb
@@ -52,7 +52,7 @@ class MetasploitModule < Msf::Exploit::Local
       return Exploit::CheckCode::Unknown
     end
 
-    if sysinfo['Architecture'] !~ /(wow|x)64/i
+    if sysinfo['Architecture'] != ARCH_X64
       return Exploit::CheckCode::Safe
     end
 

--- a/modules/exploits/windows/local/cve_2017_8464_lnk_lpe.rb
+++ b/modules/exploits/windows/local/cve_2017_8464_lnk_lpe.rb
@@ -117,7 +117,9 @@ class MetasploitModule < Msf::Exploit::Local
       fail_with(Failure::NotVulnerable, 'Exploit not available on this system.')
     end
 
-    if sysinfo['Architecture'] == ARCH_X64 && target.arch.first == ARCH_X86
+    if sysinfo['Architecture'] == ARCH_X64 && session.arch == ARCH_X86
+      fail_with(Failure::NoTarget, 'Running against WOW64 is not supported, please get an x64 session')
+    elsif sysinfo['Architecture'] == ARCH_X64 && target.arch.first == ARCH_X86
       fail_with(Failure::NoTarget, 'Session host is x64, but the target is specified as x86')
     elsif sysinfo['Architecture'] == ARCH_X86 && target.arch.first == ARCH_X64
       fail_with(Failure::NoTarget, 'Session host is x86, but the target is specified as x64')

--- a/modules/exploits/windows/local/cve_2020_0796_smbghost.rb
+++ b/modules/exploits/windows/local/cve_2020_0796_smbghost.rb
@@ -94,7 +94,7 @@ class MetasploitModule < Msf::Exploit::Local
       fail_with(Failure::None, 'Session is already elevated')
     end
 
-    if sysinfo['Architecture'] =~ /wow64/i
+    if sysinfo['Architecture'] == ARCH_X64 && session.arch == ARCH_X86
       fail_with(Failure::NoTarget, 'Running against WOW64 is not supported')
     elsif sysinfo['Architecture'] == ARCH_X64 && target.arch.first == ARCH_X86
       fail_with(Failure::NoTarget, 'Session host is x64, but the target is specified as x86')

--- a/modules/exploits/windows/local/cve_2020_1313_system_orchestrator.rb
+++ b/modules/exploits/windows/local/cve_2020_1313_system_orchestrator.rb
@@ -133,7 +133,7 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def validate_target
-    if sysinfo['Architecture'] == ARCH_X86
+    if sysinfo['Architecture'] != ARCH_X64
       fail_with(Failure::NoTarget, 'Exploit code is 64-bit only')
     end
   end

--- a/modules/exploits/windows/local/cve_2020_17136.rb
+++ b/modules/exploits/windows/local/cve_2020_17136.rb
@@ -136,10 +136,10 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    if sysinfo['Architecture'] != 'x64'
+    if sysinfo['Architecture'] != ARCH_X64
       fail_with(Failure::NoTarget, 'This module currently only supports targeting x64 systems!')
-    elsif session.arch != 'x64'
-      fail_with(Failure::NoTarget, 'Sorry, WoW64 is not supported at this time!')
+    elsif session.arch != ARCH_X64
+      fail_with(Failure::NoTarget, 'Sorry, WOW64 is not supported at this time!')
     end
     dir_junct_path = 'C:\\Windows\\Temp'
     intermediate_dir = rand_text_alpha(10).to_s

--- a/modules/exploits/windows/local/mov_ss.rb
+++ b/modules/exploits/windows/local/mov_ss.rb
@@ -130,7 +130,7 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def validate_target
-    if sysinfo['Architecture'] == ARCH_X86
+    if sysinfo['Architecture'] != ARCH_X64
       fail_with(Failure::NoTarget, 'Exploit code is 64-bit only')
     end
     if sysinfo['OS'] =~ /XP/

--- a/modules/exploits/windows/local/ms14_058_track_popup_menu.rb
+++ b/modules/exploits/windows/local/ms14_058_track_popup_menu.rb
@@ -82,7 +82,7 @@ class MetasploitModule < Msf::Exploit::Local
       return Exploit::CheckCode::Safe
     end
 
-    if sysinfo["Architecture"] =~ /(wow|x)64/i
+    if sysinfo["Architecture"] == ARCH_X64
       arch = ARCH_X64
     elsif sysinfo["Architecture"] == ARCH_X86
       arch = ARCH_X86
@@ -110,7 +110,7 @@ class MetasploitModule < Msf::Exploit::Local
       fail_with(Failure::NotVulnerable, "Exploit not available on this system.")
     end
 
-    if sysinfo["Architecture"] =~ /wow64/i
+    if sysinfo["Architecture"] == ARCH_X64 && session.arch == ARCH_X86
       fail_with(Failure::NoTarget, 'Running against WOW64 is not supported')
     elsif sysinfo["Architecture"] == ARCH_X64 && target.arch.first == ARCH_X86
       fail_with(Failure::NoTarget, 'Session host is x64, but the target is specified as x86')

--- a/modules/exploits/windows/local/ms14_058_track_popup_menu.rb
+++ b/modules/exploits/windows/local/ms14_058_track_popup_menu.rb
@@ -82,12 +82,6 @@ class MetasploitModule < Msf::Exploit::Local
       return Exploit::CheckCode::Safe
     end
 
-    if sysinfo["Architecture"] == ARCH_X64
-      arch = ARCH_X64
-    elsif sysinfo["Architecture"] == ARCH_X86
-      arch = ARCH_X86
-    end
-
     file_path = expand_path("%windir%") << "\\system32\\win32k.sys"
     major, minor, build, revision, branch = file_version(file_path)
     vprint_status("win32k.sys file version: #{major}.#{minor}.#{build}.#{revision} branch: #{branch}")

--- a/modules/exploits/windows/local/ms15_051_client_copy_image.rb
+++ b/modules/exploits/windows/local/ms15_051_client_copy_image.rb
@@ -73,11 +73,7 @@ class MetasploitModule < Msf::Exploit::Local
       return Exploit::CheckCode::Unknown
     end
 
-    if sysinfo['Architecture'] =~ /(wow|x)64/i
-      arch = ARCH_X64
-    elsif sysinfo['Architecture'] =~ /x86/i
-      arch = ARCH_X86
-    end
+    arch = sysinfo['Architecture']
 
     file_path = expand_path('%windir%') << '\\system32\\win32k.sys'
     major, minor, build, revision, branch = file_version(file_path)

--- a/modules/exploits/windows/local/ms15_051_client_copy_image.rb
+++ b/modules/exploits/windows/local/ms15_051_client_copy_image.rb
@@ -73,8 +73,6 @@ class MetasploitModule < Msf::Exploit::Local
       return Exploit::CheckCode::Unknown
     end
 
-    arch = sysinfo['Architecture']
-
     file_path = expand_path('%windir%') << '\\system32\\win32k.sys'
     major, minor, build, revision, branch = file_version(file_path)
     vprint_status("win32k.sys file version: #{major}.#{minor}.#{build}.#{revision} branch: #{branch}")

--- a/modules/exploits/windows/local/ms15_078_atmfd_bof.rb
+++ b/modules/exploits/windows/local/ms15_078_atmfd_bof.rb
@@ -297,7 +297,7 @@ class MetasploitModule < Msf::Exploit::Local
     end
 
     # We have tested only 64 bits
-    if sysinfo['Architecture'] !~ /(wow|x)64/i
+    if sysinfo['Architecture'] != ARCH_X64
       return Exploit::CheckCode::Unknown
     end
 

--- a/modules/post/windows/gather/cachedump.rb
+++ b/modules/post/windows/gather/cachedump.rb
@@ -306,7 +306,7 @@ class MetasploitModule < Msf::Post
       client.railgun.netapi32()
       join_status = client.railgun.netapi32.NetGetJoinInformation(nil,4,4)["BufferType"]
 
-      if sysinfo['Architecture'] =~ /x64/
+      if sysinfo['Architecture'] == ARCH_X64
         join_status = join_status & 0x00000000ffffffff
       end
 

--- a/modules/post/windows/gather/enum_emet.rb
+++ b/modules/post/windows/gather/enum_emet.rb
@@ -28,7 +28,7 @@ class MetasploitModule < Msf::Post
   end
 
   def run
-    reg_view = sysinfo['Architecture'] =~ /x64/ ? REGISTRY_VIEW_64_BIT : REGISTRY_VIEW_32_BIT
+    reg_view = sysinfo['Architecture'] == ARCH_X64 ? REGISTRY_VIEW_64_BIT : REGISTRY_VIEW_32_BIT
     reg_vals = registry_enumvals('HKLM\\SOFTWARE\\Microsoft\\EMET\\AppSettings', reg_view)
     if reg_vals.nil?
       print_error('Failed to enumerate EMET Protected.')


### PR DESCRIPTION
Fixes #14599

Applies fixes to ensure that `sysinfo['Architecture']` is checked to see if it is `ARCH_X64` and that `session.arch` is `x86` before determining the target is a WOW64 target for several modules that were only checking to see if `sysinfo['Architecture']` contained `WOW64`. As per the discussion in #14599 this was incorrect as `sysinfo['Architecture']` will only return `ARCH_X64` or `ARCH_X86` aka the strings `x64` and `x86` respectively, and will no longer return the `wow64` string as per the change in https://github.com/rapid7/metasploit-framework/pull/7507, which notes:

`the Architecture value in sysinfo no longer shows (Current process is WOW64) when running a WOW64 process. Instead, architecture is always set to x86 or x64`

I also went ahead and tided up a few modules that were using regex checks where they could have just used a check to see if the value was `ARCH_X64` along the way to help make the code a bit neater and faster to run.

The bug tag was applied only cause this is a bug for the code at https://github.com/rapid7/metasploit-framework/blob/c0b42ff7a2a1b677aaba6acd7ebeefddcffdf38e/modules/exploits/windows/local/cve_2020_0796_smbghost.rb#L97. All other files I believe are mostly just improvements for the sake of making them in line with the change; they shouldn't really affect how the exploit performs when running against a WOW64 target compared to the code that it is currently running.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] Make sure all the modules load and there are no errors.
- [x] **Verify** that the changes look correct.
- [x] **Verify** the modules still return an error code (if applicable) if the target is a WOW64 target and that module is supposed to throw an error upon realizing the target is WOW64.
- [x] **Document** any errors encountered or questions, etc you have.