### PR TITLE
added regex based gsub to remove trailing ':'

### DIFF
--- a/lib/msf/core/modules/metadata/search.rb
+++ b/lib/msf/core/modules/metadata/search.rb
@@ -33,7 +33,9 @@ module Msf::Modules::Metadata::Search
   def self.parse_search_string(search_string)
     search_string ||= ''
     search_string += ' '
-
+    
+    search_string = search_string.gsub(/((\s*?\:+)+$)|((\:*\s)+$)/,'')
+      
     # Split search terms by space, but allow quoted strings
     terms = search_string.split(/\"/).collect{|term| term.strip==term ? term : term.split(' ')}.flatten
     terms.delete('')

--- a/lib/msf/core/modules/metadata/search.rb
+++ b/lib/msf/core/modules/metadata/search.rb
@@ -34,7 +34,7 @@ module Msf::Modules::Metadata::Search
     search_string ||= ''
     search_string += ' '
     
-    search_string = search_string.gsub(/((\s*?\:+)+$)|((\:*\s)+$)/,'')
+    search_string = search_string.gsub(/((\:+\s*)\z|(\\s*:+)\z|(\:\s*:+ *)\z)/,'')
       
     # Split search terms by space, but allow quoted strings
     terms = search_string.split(/\"/).collect{|term| term.strip==term ? term : term.split(' ')}.flatten


### PR DESCRIPTION
Fixes #14768 by removing trailing : along side spaces before and after.