### PR TITLE
Fix missing constant error when accessing the api web service

### DIFF
--- a/lib/msf/core/web_services/views/auth/account.erb
+++ b/lib/msf/core/web_services/views/auth/account.erb
@@ -9,7 +9,7 @@
 
 <script type="text/javascript">
     function getNewApiToken() {
-        loadDoc("POST", "<%= AuthServlet.api_generate_token_path %>", function(xhr) {
+        loadDoc("POST", "<%= Msf::WebServices::AuthServlet.api_generate_token_path %>", function(xhr) {
             var response = JSON.parse(xhr.responseText);
             document.getElementById("api-token").innerHTML = response.data.token;
         }, errorHandler);
@@ -44,13 +44,13 @@
       <a href="javascript:void(0)" class="dropdown-btn"><%= warden.user(:user).username %></a>
       <div class="dropdown-content">
         <a href="#" onclick="getNewApiToken();">Generate New API Token</a>
-        <a href="<%= AuthServlet.api_logout_path %>">Log Out</a>
+        <a href="<%= Msf::WebServices::AuthServlet.api_logout_path %>">Log Out</a>
       </div>
     </li>
   <% else %>
-    <li><a href="<%= AuthServlet.api_login_path %>">Log In</a></li>
+    <li><a href="<%= Msf::WebServices::AuthServlet.api_login_path %>">Log In</a></li>
   <% end %>
-  <li><a href="<%= ApiDocsServlet.html_path %>">API Documentation</a></li>
+  <li><a href="<%= Msf::WebServices::ApiDocsServlet.html_path %>">API Documentation</a></li>
 </ul>
 
 <div style="padding:20px;">
@@ -62,7 +62,7 @@
       <%= !warden.user(:user).nil? && !warden.user(:user).persistence_token.nil? ? warden.user(:user).persistence_token : 'none' %>
     </div>
   <% else %>
-    <div id="not-logged-in-label">You are not currently logged in. Please click <a href="<%= AuthServlet.api_login_path %>">here</a> to be taken to the login page.</div>
+    <div id="not-logged-in-label">You are not currently logged in. Please click <a href="<%= Msf::WebServices::AuthServlet.api_login_path %>">here</a> to be taken to the login page.</div>
   <% end %>
 </div>
 

--- a/lib/msf/core/web_services/views/auth/login.erb
+++ b/lib/msf/core/web_services/views/auth/login.erb
@@ -26,7 +26,7 @@
     $(document).ready(function(){
         $("#submit").on('click', function(){
             $.ajax({
-                url: '<%= AuthServlet.api_login_path %>',
+                url: '<%= Msf::WebServices::AuthServlet.api_login_path %>',
                 type : "POST",
                 data : ConvertFormToJSON($("#login_form")),
                 contentType: "application/json; charset=utf-8",
@@ -37,7 +37,7 @@
                     // is not easily handled by Javascript AJAX requests. When the /login endpoint
                     // is more fully fleshed out we should add proper handling for valid and
                     // invalid login attempts.
-                    window.location.replace('<%= AuthServlet.api_account_path %>');
+                    window.location.replace('<%= Msf::WebServices::AuthServlet.api_account_path %>');
                 },
                 error: function(xhr, resp, text) {
                     console.log(xhr, resp, text);


### PR DESCRIPTION
resolves #14662 

Missed some constants in a couple of `.erb` files during the zeitwerk upgrade, this PR resolves the issue by using the full constant name

# Verification steps
- [ ] Checkout this PR
- [ ] (Re)start your webservice (`./msfdb restart --ssl-disable-verify `)
- [ ] Navigate to `https://localhost:5443/api/v1/auth/login`
- [ ] Login with your username and password that you definitely still remember
- [ ] Nothing breaks!