### PR TITLE
Re add color to search command

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -353,7 +353,7 @@ GEM
       rex-socket
       rex-text
     rex-struct2 (0.1.3)
-    rex-text (0.2.31)
+    rex-text (0.2.33)
     rex-zip (0.1.4)
       rex-text
     rexml (3.2.4)

--- a/lib/msf/ui/console/command_dispatcher/creds.rb
+++ b/lib/msf/ui/console/command_dispatcher/creds.rb
@@ -434,7 +434,7 @@ class Creds
       'Header'  => "Credentials",
       # For now, don't perform any word wrapping on the cred table as it breaks the workflow of
       # copying credentials and pasting them into applications
-      'Width' => ::BigDecimal::INFINITY,
+      'WordWrap' => false,
       'Columns' => cred_table_columns,
       'SearchTerm' => search_term
     }

--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -1303,7 +1303,7 @@ module Msf
                 'SearchTerm' => row_filter,
                 # For now, don't perform any word wrapping on the search table as it breaks the workflow of
                 # copying module names in conjunction with the `use <paste-buffer>` command
-                'Width' => ::BigDecimal::INFINITY,
+                'WordWrap' => false,
                 'Columns' => [
                   '#',
                   'Name',

--- a/spec/lib/msf/ui/console/command_dispatcher/creds_spec.rb
+++ b/spec/lib/msf/ui/console/command_dispatcher/creds_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Creds do
               '',
               'host  origin  service  public    private   realm  private_type  JtR Format',
               '----  ------  -------  ------    -------   -----  ------------  ----------',
-              '                       thisuser  thispass         Password'
+              '                       thisuser  thispass         Password      '
             ])
           end
 
@@ -85,7 +85,7 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Creds do
               '',
               'host  origin  service  public    private   realm  private_type  JtR Format',
               '----  ------  -------  ------    -------   -----  ------------  ----------',
-              '                       thisuser  thispass         Password'
+              '                       thisuser  thispass         Password      '
             ])
           end
 
@@ -98,7 +98,7 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Creds do
                 '',
                 'host  origin  service  public  private        realm  private_type  JtR Format',
                 '----  ------  -------  ------  -------        -----  ------------  ----------',
-                '                               nonblank_pass         Password'
+                '                               nonblank_pass         Password      '
               ])
             end
           end
@@ -111,7 +111,7 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Creds do
                 '',
                 'host  origin  service  public         private  realm  private_type  JtR Format',
                 '----  ------  -------  ------         -------  -----  ------------  ----------',
-                '                       nonblank_user                  Password'
+                '                       nonblank_user                  Password      '
               ])
             end
           end
@@ -208,7 +208,7 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Creds do
                 '',
                 'host  origin  service  public    private   realm  private_type  JtR Format',
                 '----  ------  -------  ------    -------   -----  ------------  ----------',
-                '                       thisuser  thispass         Password'
+                '                       thisuser  thispass         Password      '
               ])
             end
           end


### PR DESCRIPTION
Rex-text now supports an explicit option for per-table word wrapping, instead of manually setting the width to be infinitely wide

Normally should be no user facing changes, but in this case it coincidentally reintroduces the colorized search support. A future ticket will enhance rex-text's word wrapped tables to which contain color codes.

## Verification

- Open msfconsole
- Confirm that the search table is now colorized, and doesn't word wrap
- Confirm that the credentials table doesn't word wrap
- Confirm that option tables wrap as expected, for instance with the `options` command
- `features set wrapped_tables false` opts out of word wrapping entirely