### PR TITLE
Wrap kiwi cmd arguments in quotes

### DIFF
--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/kiwi.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/kiwi.rb
@@ -80,7 +80,10 @@ class Console::CommandDispatcher::Kiwi
   end
 
   def cmd_kiwi_cmd(*args)
-    output = client.kiwi.exec_cmd(args.join(' '))
+    # Kiwi expects instructions with arguments to be quoted so quote everything to be sure
+    # "You can pass instructions on mimikatz command line, those with arguments/spaces must be quoted."
+    # Quote from: https://github.com/gentilkiwi/mimikatz/wiki
+    output = client.kiwi.exec_cmd(args.map { |s| '"' + s + '"'}.join(' '))
     print_line(output)
   end
 


### PR DESCRIPTION
Resolves #14136 

Kiwi expects commands with an argument to be wrapped in quotes but we weren't doing that even when the user would wrap it in quotes one the meterpreter prompt. This PR resolves that by wrapping each command in quotes so kiwi can parse it correctly

# Verification
- [x] Get a native meterpreter shell on windows (i.e. using `windows/x64/meterpreter_reverse_http`)
- [x] Interact with the session `sessions -1`
- [x] Run `getsystem` (some kiwi commands require a privileged account)
- [x] Run `load kiwi`
- [x] Run `kiwi_cmd "sekurlsa::logonPasswords full"`
- [x] You should see a line like this `mimikatz(powershell) # sekurlsa::logonPasswords full` previously the `full` would be run as a separate command which does not work