### PR TITLE
Add missing requires for socks proxy

### DIFF
--- a/lib/rex/proto/proxy/socks5/server_client.rb
+++ b/lib/rex/proto/proxy/socks5/server_client.rb
@@ -2,6 +2,7 @@
 
 require 'bindata'
 require 'rex/socket'
+require 'rex/proto/proxy/socks5/packet'
 
 module Rex
 module Proto


### PR DESCRIPTION
Resolves #14793

Adds a missing requires for `rex/proto/proxy/socks5/packet` in `server_client.rb` 
zeitwerk didn't work in this case since there were multiple classes in that file and zeitwerk is only aware of the one matching the file name (ServerClient in this case)

# Verification 
- [x] `use auxiliary/server/socks_proxy`
- [x] `run`
- [ ] Configure proxychains
- [ ] `proxychains curl http://google.com`
- [ ] Nothing should break anymore
