### PR TITLE
Disable Style/StringConcatenation Rubocop rule

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -288,6 +288,19 @@ Style/ParenthesesAroundCondition:
   Enabled: false
   Description: 'This is used in too many places to discount, especially in ported code. Has little effect'
 
+Style/StringConcatenation:
+  Enabled: false
+  Description: >-
+    Disabled for now as it changes escape sequences when auto corrected:
+      https://github.com/rubocop/rubocop/issues/9543
+
+    Additionally seems to break with multiline string concatenation with trailing comments, example:
+      payload = "\x12" + # Size
+                "\x34" + # eip
+                "\x56"   # etc
+    With `rubocop -A` this will become:
+      payload = "\u00124V"    # etc
+
 Style/TrailingCommaInArrayLiteral:
   Enabled: false
   Description: 'This is often a useful pattern, and is actually required by other languages. It does not hurt.'


### PR DESCRIPTION
Disabling Style/StringConcatenation Rubocop rule as it changes escape sequences and drops trailing comments, example input:

```ruby
payload = "\x12" + # size
          "\x34" + # eip
          "\x56    # etc
```

Becomes:

```ruby
payload = "\u00124V"    # etc
```

Cross-referenced RuboCop issue: https://github.com/rubocop/rubocop/issues/9543

## Verification

- CI passes