### PR TITLE
replace ::Rex::Socket.gethostbyname with Socket.getaddrinfo

### DIFF
--- a/lib/rex/proto/proxy/socks4a.rb
+++ b/lib/rex/proto/proxy/socks4a.rb
@@ -131,7 +131,7 @@ class Socks4a
       def resolve( hostname )
         if( not hostname.empty? )
           begin
-            return Rex::Socket.addr_itoa( Rex::Socket.gethostbyname( hostname )[3].unpack( 'N' ).first )
+            return Rex::Socket.getaddress(hostname, false)
           rescue ::SocketError
             return nil
           end

--- a/modules/auxiliary/admin/backupexec/dump.rb
+++ b/modules/auxiliary/admin/backupexec/dump.rb
@@ -129,7 +129,7 @@ class MetasploitModule < Msf::Auxiliary
       0,
       0,
       1,
-      Rex::Socket.gethostbyname(local_addr)[3],
+      Rex::Socket.resolv_nbo(local_addr, false),
       local_port
     ].pack('NNNNNNNA4N')
 

--- a/modules/auxiliary/dos/windows/smb/ms11_019_electbowser.rb
+++ b/modules/auxiliary/dos/windows/smb/ms11_019_electbowser.rb
@@ -56,7 +56,7 @@ class MetasploitModule < Msf::Auxiliary
     @client = Rex::Proto::SMB::Client.new(udp_sock)
 
     ip = Rex::Socket.source_address(datastore['RHOST'])
-    ip_src = Rex::Socket.gethostbyname(ip)[3]
+    ip_src = Rex::Socket.resolv_nbo(ip, false)
 
     svc_src = "\x41\x41\x00"   # pre-encoded?
     name_src = Rex::Text.rand_text_alphanumeric(15) # 4+rand(10))


### PR DESCRIPTION
Part of the Ruby 3 upgrade ticket rapid7/metasploit-framework#14666

This PR replaces a rex-socket method that will be deprecated with Ruby 3.0. `::Rex::Socket.gethostbyname` was previously being called like so: 
```Ruby
Rex::Socket.gethostbyname(local_addr)[3]
```
This would return an IPV4 address. This was the sole use of this method within framework. We're replacing this to now use another rex-socket method:
```Ruby
::Rex::Socket.resolv_nbo("example.com", false)
```
This will maintain the same functionality and and will return a IPV4 address.
```Ruby
2.7.2 :007 > ::Rex::Socket.gethostbyname("example.com")[3]
 => "]\xB8\xD8\""
2.7.2 :008 > ::Rex::Socket.resolv_nbo("example.com")
 => "]\xB8\xD8\""
```
For clarity on why `Rex::Socket.resolve_nbo(local_addr, false)` is taking two args, is because this [method](https://github.com/rapid7/rex-socket/blob/9c9f5519e6e84afd30ffb68270bfeb2429d9302c/lib/rex/socket.rb#L262-L264) will be updated with the following changes in a PR from the rex-socket repo:
```Ruby
  def self.resolv_nbo(host, accepts_ipv6 = true)
    ip_address = Rex::Socket.getaddress(host, accepts_ipv6)
    IPAddr.new(ip_address).hton
  end
```
More information can be found in the existing [PR](https://github.com/rapid7/rex-socket/pull/27#discussion_r581897774) within the rex-socket repo.


## Verification

List the steps needed to make sure this thing works

### Testing 
Steps I took to test the `::Rex::Socket.resolv_nbo("example.com", false)` method
- [ ] use `auxiliary/dos/windows/smb/ms11_019_electbowser`
- [ ] run `set rhosts 127.0.0.1` (you don't need a valid target here)
- [ ] run `set domain localhost` 
- [ ] run the module
- [ ] `ensure` the module runs as expected

Expected output:
![image](https://user-images.githubusercontent.com/69522014/109331532-dae5a080-7854-11eb-88fb-7a1f00a15beb.png)


Steps I took to test the `Rex::Socket.getaddress(hostname, false)` method
- [ ] use `auxiliary/server/socks_proxy`
- [ ] run `set version 4a`
- [ ] run `curl --socks4a 127.0.0.1:1080 https://google.com/`
- [ ] **Verify** you get the expected output

Expected output:
![image](https://user-images.githubusercontent.com/69522014/109331945-5fd0ba00-7855-11eb-9af2-ceab08288fc0.png)
