### PR TITLE
Autoload faker to avoid potential missing constant errors

### DIFF
--- a/lib/msf/core/cert_provider.rb
+++ b/lib/msf/core/cert_provider.rb
@@ -3,7 +3,6 @@ require 'rex/socket/ssl'
 module Msf
 module Ssl
   module CertProvider
-    autoload :Faker, 'faker'
 
     def self.rand_vars(opts = {})
       opts ||= {}

--- a/lib/msf_autoload.rb
+++ b/lib/msf_autoload.rb
@@ -281,3 +281,6 @@ loader.inflector.inflect(
   )
 
 loader.setup # ready!
+
+# global autoload of common gems
+autoload :Faker, 'faker'

--- a/modules/exploits/windows/http/exchange_ecp_dlp_policy.rb
+++ b/modules/exploits/windows/http/exchange_ecp_dlp_policy.rb
@@ -3,8 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-require 'faker'
-
 class MetasploitModule < Msf::Exploit::Remote
 
   Rank = ExcellentRanking


### PR DESCRIPTION
These modules used to just hope faker got loaded, and it did, until zeitwerk happened so I'm adding a couple explicit requires

# Verification
- [x] `use osx/manage/sonic_pi`
- [x] `irb`
- [x] `agent`
- [x] No exception about a missing constant :) 