### PR TITLE
Allow search to start from root path

### DIFF
--- a/lib/rex/post/meterpreter/extensions/stdapi/fs/file.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/fs/file.rb
@@ -82,7 +82,7 @@ class File < Rex::Post::Meterpreter::Extensions::Stdapi::Fs::IO
     request = Packet.create_request( COMMAND_ID_STDAPI_FS_SEARCH )
 
     root = client.unicode_filter_decode(root) if root
-    root = root.chomp( self.separator ) if root
+    root = root.chomp( self.separator ) if root && !root.eql?('/')
 
     request.add_tlv( TLV_TYPE_SEARCH_ROOT, root )
     request.add_tlv( TLV_TYPE_SEARCH_GLOB, glob )

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
@@ -148,7 +148,7 @@ class Console::CommandDispatcher::Stdapi::Fs
       "-h" => [ false, "Help Banner" ],
       "-d" => [ true,  "The directory/drive to begin searching from. Leave empty to search all drives. (Default: #{root})" ],
       "-f" => [ true,  "A file pattern glob to search for. (e.g. *secret*.doc?)" ],
-      "-r" => [ true,  "Recursivly search sub directories. (Default: #{recurse})" ]
+      "-r" => [ true,  "Recursively search sub directories. (Default: #{recurse})" ]
     )
 
     opts.parse(args) { | opt, idx, val |


### PR DESCRIPTION
If a user is running a meterpreter session on a non-Windows OS, the search functionality cannot start a
search from the root directory because msf strips the file separator from the input used to create a
search request. Because of this, meterpreter will default to the current working directory and produce
less results than expected or none at all.

This change just makes sure that the search root is not `/` before chomping the file separator. This also
fixes a typo in the search `help` output.

### Before change

```
meterpreter > search -f *.lib -d /
No files matching your search were found.
```

### After change

```
meterpreter > search -f *.lib -d /
Found 6 results...
    /usr/src/linux-headers-4.18.0-15/scripts/Makefile.lib (14968 bytes)
    /usr/src/linux-hwe-5.4-headers-5.4.0-62/scripts/Makefile.lib (15026 bytes)
    /usr/src/linux-headers-5.4.0-65-generic/scripts/Makefile.lib (15026 bytes)
    /usr/src/linux-hwe-5.4-headers-5.4.0-65/scripts/Makefile.lib (15026 bytes)
    /usr/src/linux-headers-4.18.0-15-generic/scripts/Makefile.lib (14968 bytes)
    /usr/src/linux-headers-5.4.0-62-generic/scripts/Makefile.lib (15026 bytes)
```

## Verification

- [x] Start `msfconsole`
- [x] Get a python meterpreter session on a Linux box
- [x] Start a search from the root directory, ex: `search -f *.lib -d /`
- [x] **Verify** that the search actually starts from the root directory instead of the cwd of the session

