### PR TITLE
Remove extra `require` in msfrpc client

### DIFF
--- a/msfrpc
+++ b/msfrpc
@@ -72,7 +72,6 @@ end
 $0 = "msfrpc"
 
 require 'msf/core/rpc/v10/client'
-require 'rex/ui'
 
 rpc = Msf::RPC::Client.new(
   :host => opts['ServerHost'],


### PR DESCRIPTION
msfrpc client had a `require rex/ui` but  `lib/rex/ui.rb` was removed . I thought I got them all but my search was limited to files ending in `.rb` which this one doesn't :upside_down_face: 

# Verification
- [ ] Start up the msfrpcd service `/msfrpcd -P password `
- [ ] Connect with the client `./msfrpc -a 127.0.0.1 -P password`
- [ ] No more errors
