### PR TITLE
Add action description to module.info rpc calls

### DIFF
--- a/lib/msf/core/rpc/v10/rpc_module.rb
+++ b/lib/msf/core/rpc/v10/rpc_module.rb
@@ -247,7 +247,7 @@ class RPC_Module < RPC_Base
     if m.type == 'auxiliary' || m.type == 'post'
       res['actions'] = {}
       m.actions.each_index do |i|
-        res['actions'][i] = m.actions[i].name
+        res['actions'][m.actions[i].name] = m.actions[i].description
       end
 
       if m.default_action

--- a/msfrpc
+++ b/msfrpc
@@ -72,7 +72,6 @@ end
 $0 = "msfrpc"
 
 require 'msf/core/rpc/v10/client'
-require 'rex/ui'
 
 rpc = Msf::RPC::Client.new(
   :host => opts['ServerHost'],


### PR DESCRIPTION
Fixes https://github.com/rapid7/metasploit-framework/issues/14456

As per the feature suggestion detailed [here](https://github.com/rapid7/metasploit-framework/issues/14456), we were returning an unused index as the key for `Auxiliary` & `Post` module actions:

```
>> rpc.call('module.info', 'auxiliary', 'scanner/ssl/openssl_heartbleed')
...
"actions"=>{0=>"SCAN", 1=>"DUMP", 2=>"KEYS"}}
```

When we could be using the action names as the key & add a description as the value:
```
>> rpc.call('module.info', 'auxiliary', 'scanner/ssl/openssl_heartbleed')
...
"actions"=>{"SCAN"=>"Check hosts for vulnerability", "DUMP"=>"Dump memory contents to loot", "KEYS"=>"Recover private keys from memory"},
```

This may break some user scripts and frustrate some muscle memory, but it's worth it for some added info IMO. 

- [x] `./msfrpcd -P LetMeIn`
- [x] `./msfrpc -P LetMeIn -a 127.0.0.1`
- [x] `>> rpc.call('module.info', 'auxiliary', 'scanner/ssl/openssl_heartbleed')`
- [x] Observe nice new action descriptions
- [x] Don't observe any bugs 🤞 