### PR TITLE
Extract `PseudoShell` into it's own file for zeitwerk

### DIFF
--- a/lib/rex/ui/text/pseudo_shell.rb
+++ b/lib/rex/ui/text/pseudo_shell.rb
@@ -1,0 +1,15 @@
+
+module Rex
+  module Ui
+    module Text
+      ###
+      #
+      # Pseudo-shell interface that simply includes the Shell mixin.
+      #
+      ###
+      class PseudoShell
+        include Shell
+      end
+    end
+  end
+end

--- a/lib/rex/ui/text/shell.rb
+++ b/lib/rex/ui/text/shell.rb
@@ -494,15 +494,5 @@ private
 
 end
 
-###
-#
-# Pseudo-shell interface that simply includes the Shell mixin.
-#
-###
-class PseudoShell
-  include Shell
-end
-
-
 end end end
 


### PR DESCRIPTION
Resolves #14841 

PseudoShell has been moved to it's own appropriately named file so zeitwerk can pick it up properly now

# Verification
- [ ] `./tools/exploit/metasm_shell.rb`
- [ ] It doesn't fail! (previously got this error ```/usr/share/metasploit-framework/tools/exploit/metasm_shell.rb:162:in `<main>': uninitialized constant Rex::Ui::Text::PseudoShell (NameError)```