### PR TITLE
Move `on_session_open` event to after the session has been bootstrapped

### DIFF
--- a/lib/msf/base/sessions/meterpreter.rb
+++ b/lib/msf/base/sessions/meterpreter.rb
@@ -122,87 +122,82 @@ class Meterpreter < Rex::Post::Meterpreter::Client
   def bootstrap(datastore = {}, handler = nil)
     session = self
 
-    init_session = Proc.new do
-      # Configure unicode encoding before loading stdapi
-      session.encode_unicode = datastore['EnableUnicodeEncoding']
+    # Configure unicode encoding before loading stdapi
+    session.encode_unicode = datastore['EnableUnicodeEncoding']
 
-      session.init_ui(self.user_input, self.user_output)
+    session.init_ui(self.user_input, self.user_output)
 
-      verification_timeout = datastore['AutoVerifySessionTimeout']&.to_i || session.comm_timeout
-      begin
-        session.tlv_enc_key = session.core.negotiate_tlv_encryption(timeout: verification_timeout)
-      rescue Rex::TimeoutError
-      end
-
-      if session.tlv_enc_key.nil?
-        # Fail-closed if TLV encryption can't be negotiated (close the session as invalid)
-        dlog("Session #{session.sid} failed to negotiate TLV encryption")
-        print_error("Meterpreter session #{session.sid} is not valid and will be closed")
-        # Terminate the session without cleanup if it did not validate
-        session.skip_cleanup = true
-        session.kill
-        return nil
-      end
-
-      # always make sure that the new session has a new guid if it's not already known
-      guid = session.session_guid
-      if guid == "\x00" * 16
-        guid = [SecureRandom.uuid.gsub(/-/, '')].pack('H*')
-        session.core.set_session_guid(guid)
-        session.session_guid = guid
-        # TODO: New stageless session, do some account in the DB so we can track it later.
-      else
-        # TODO: This session was either staged or previously known, and so we should do some accounting here!
-      end
-
-      session.commands.concat(session.core.get_loaded_extension_commands('core'))
-
-      # Unhook the process prior to loading stdapi to reduce logging/inspection by any AV/PSP
-      if datastore['AutoUnhookProcess'] == true
-        console.run_single('load unhook')
-        console.run_single('unhook_pe')
-      end
-
-      unless datastore['AutoLoadStdapi'] == false
-
-        session.load_stdapi
-
-        unless datastore['AutoSystemInfo'] == false
-          session.load_session_info
-        end
-
-        # only load priv on native windows
-        # TODO: abstract this too, to remove windows stuff
-        if session.platform == 'windows' && [ARCH_X86, ARCH_X64].include?(session.arch)
-          session.load_priv rescue nil
-        end
-      end
-
-      # TODO: abstract this a little, perhaps a "post load" function that removes
-      # platform-specific stuff?
-      if session.platform == 'android'
-        session.load_android
-      end
-
-      ['InitialAutoRunScript', 'AutoRunScript'].each do |key|
-        unless datastore[key].nil? || datastore[key].empty?
-          args = Shellwords.shellwords(datastore[key])
-          print_status("Session ID #{session.sid} (#{session.tunnel_to_s}) processing #{key} '#{datastore[key]}'")
-          session.execute_script(args.shift, *args)
-        end
-      end
-
-      # Process the auto-run scripts for this session
-      if self.respond_to?(:process_autoruns)
-        self.process_autoruns(datastore)
-      end
-
-      # Tell the handler that we have a session
-      handler.on_session(self) if handler
+    verification_timeout = datastore['AutoVerifySessionTimeout']&.to_i || session.comm_timeout
+    begin
+      session.tlv_enc_key = session.core.negotiate_tlv_encryption(timeout: verification_timeout)
+    rescue Rex::TimeoutError
     end
 
-    # Defer the session initialization to the Session Manager scheduler
-    framework.sessions.schedule init_session
+    if session.tlv_enc_key.nil?
+      # Fail-closed if TLV encryption can't be negotiated (close the session as invalid)
+      dlog("Session #{session.sid} failed to negotiate TLV encryption")
+      print_error("Meterpreter session #{session.sid} is not valid and will be closed")
+      # Terminate the session without cleanup if it did not validate
+      session.skip_cleanup = true
+      session.kill
+      return nil
+    end
+
+    # always make sure that the new session has a new guid if it's not already known
+    guid = session.session_guid
+    if guid == "\x00" * 16
+      guid = [SecureRandom.uuid.gsub(/-/, '')].pack('H*')
+      session.core.set_session_guid(guid)
+      session.session_guid = guid
+      # TODO: New stageless session, do some account in the DB so we can track it later.
+    else
+      # TODO: This session was either staged or previously known, and so we should do some accounting here!
+    end
+
+    session.commands.concat(session.core.get_loaded_extension_commands('core'))
+
+    # Unhook the process prior to loading stdapi to reduce logging/inspection by any AV/PSP
+    if datastore['AutoUnhookProcess'] == true
+      console.run_single('load unhook')
+      console.run_single('unhook_pe')
+    end
+
+    unless datastore['AutoLoadStdapi'] == false
+
+      session.load_stdapi
+
+      unless datastore['AutoSystemInfo'] == false
+        session.load_session_info
+      end
+
+      # only load priv on native windows
+      # TODO: abstract this too, to remove windows stuff
+      if session.platform == 'windows' && [ARCH_X86, ARCH_X64].include?(session.arch)
+        session.load_priv rescue nil
+      end
+    end
+
+    # TODO: abstract this a little, perhaps a "post load" function that removes
+    # platform-specific stuff?
+    if session.platform == 'android'
+      session.load_android
+    end
+
+    ['InitialAutoRunScript', 'AutoRunScript'].each do |key|
+      unless datastore[key].nil? || datastore[key].empty?
+        args = Shellwords.shellwords(datastore[key])
+        print_status("Session ID #{session.sid} (#{session.tunnel_to_s}) processing #{key} '#{datastore[key]}'")
+        session.execute_script(args.shift, *args)
+      end
+    end
+
+    # Process the auto-run scripts for this session
+    if self.respond_to?(:process_autoruns)
+      self.process_autoruns(datastore)
+    end
+
+    # Tell the handler that we have a session
+    handler.on_session(self) if handler
   end
 
   ##

--- a/lib/msf/core/session_manager.rb
+++ b/lib/msf/core/session_manager.rb
@@ -217,15 +217,6 @@ class SessionManager < Hash
       # Insert the session into the session hash table
       self[next_sid.to_i] = session
 
-      # Notify the framework that we have a new session opening up...
-      # Don't let errant event handlers kill our session
-      begin
-        framework.events.on_session_open(session)
-      rescue ::Exception => e
-        wlog("Exception in on_session_open event handler: #{e.class}: #{e}")
-        wlog("Call Stack\n#{e.backtrace.join("\n")}")
-      end
-
       if session.respond_to?("console")
         session.console.on_command_proc = Proc.new { |command, error| framework.events.on_session_command(session, command) }
         session.console.on_print_proc = Proc.new { |output| framework.events.on_session_output(session, output) }

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
@@ -1304,7 +1304,7 @@ class Console::CommandDispatcher::Core
       end
 
       if (extensions.include?(md))
-        print_error("The \"#{md}\" extension has already been loaded.")
+        print_warning("The \"#{md}\" extension has already been loaded.")
         next
       end
 


### PR DESCRIPTION
Resolves #14594 

The `on_session_open` event was being triggered _before_ the session was being properly initialised so I moved things around a bit to trigger it only after the session finished it's bootstrap process. The reason this was a problem was that the `auto_add_route` extension needs the `stdapi` loaded in meterpreter but trying to load that before bootstrapping does not work.

# Verification
- [x] Load up msfconsole `./msfconsole`
- [x] `load auto_add_route`
- [x] Use your favourite method to get a meterpreter session
- [x] When the session pops you should now see somethign like:
```
[*] Meterpreter session 1 opened (192.168.1.10:8080 -> 127.0.0.1) at 2021-03-02 15:38:49 +0000
[*] AutoAddRoute: Routing new subnet 10.0.2.0/255.255.255.0 through session 1
```
- [ ] The `route` command should show a table just created entry
- [ ] Interact with the session `sessions -1`
- [ ] Commands such as `ls` and `pwd` should work

 