### PR TITLE
add console output for Interrupt details.

### DIFF
--- a/msfconsole
+++ b/msfconsole
@@ -21,7 +21,8 @@ begin
 
   Metasploit::Framework::Profiler.start
   Metasploit::Framework::Command::Console.start
-rescue Interrupt
-  puts "\nAborting..."
+rescue Interrupt => e
+  puts "\nAborting... because:"
+  puts e
   exit(1)
 end


### PR DESCRIPTION
Or, is there a reason not to print such messages?