### PR TITLE
Fix method check for linux/ftp/proftp_telnet_iac module

### DIFF
--- a/modules/exploits/freebsd/ftp/proftp_telnet_iac.rb
+++ b/modules/exploits/freebsd/ftp/proftp_telnet_iac.rb
@@ -90,33 +90,35 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     # NOTE: We don't care if the login failed here...
     ret = connect
+    banner = sock.get_once || ''
 
     # We just want the banner to check against our targets..
-    print_status("FTP Banner: #{banner.strip}")
+    vprint_status("FTP Banner: #{banner.strip}")
 
     status = CheckCode::Safe
-    if banner =~ /ProFTPD (1\.3\.[23][^ ])/i
-      ver = $1
-      maj,min,rel = ver.split('.')
-      relv = rel.slice!(0,1)
-      case relv
-      when '2'
-        if rel.length > 0
-          if rel[0,2] == 'rc'
-            if rel[2,rel.length].to_i >= 3
+    banner_array = banner.split('.')
+
+    if banner_array.count() > 0 && !banner_array[3].nil?
+      # gets 1 char on the third part of version number.
+      relnum = banner_array[2][0..0]
+      tmp = banner_array[2].split(' ')
+      # gets extra string info of version number.
+      # example: 1.2.3rc ('rc' string)
+      extra = tmp[0][1..(tmp[0].length - 1)]
+      if relnum == '2'
+        if extra.length > 0
+          if extra[0..1] == 'rc'
+            v = extra[2..extra.length].to_i
+            if v && v > 2
               status = CheckCode::Appears
             end
           else
             status = CheckCode::Appears
           end
         end
-      when '3'
-        # 1.3.3+ defaults to vulnerable (until >= 1.3.3c)
-        status = CheckCode::Appears
-        if rel.length > 0
-          if rel[0,2] != 'rc' and rel[0,1] > 'b'
-            status = CheckCode::Safe
-          end
+      elsif relnum == '3'
+        if [ '', 'a', 'b', 'c' ].include?(extra)
+          status = CheckCode::Appears
         end
       end
     end

--- a/modules/exploits/freebsd/ftp/proftp_telnet_iac.rb
+++ b/modules/exploits/freebsd/ftp/proftp_telnet_iac.rb
@@ -117,7 +117,7 @@ class MetasploitModule < Msf::Exploit::Remote
           end
         end
       elsif relnum == '3'
-        if [ '', 'a', 'b', 'c' ].include?(extra)
+        if [ '', 'a', 'b' ].include?(extra)
           status = CheckCode::Appears
         end
       end

--- a/modules/exploits/freebsd/ftp/proftp_telnet_iac.rb
+++ b/modules/exploits/freebsd/ftp/proftp_telnet_iac.rb
@@ -96,29 +96,31 @@ class MetasploitModule < Msf::Exploit::Remote
     vprint_status("FTP Banner: #{banner.strip}")
 
     status = CheckCode::Safe
-    banner_array = banner.split('.')
+    if banner =~ /ProFTPD (1\.3\.[23])/i
+      banner_array = banner.split('.')
 
-    if banner_array.count() > 0 && !banner_array[3].nil?
-      # gets 1 char on the third part of version number.
-      relnum = banner_array[2][0..0]
-      tmp = banner_array[2].split(' ')
-      # gets extra string info of version number.
-      # example: 1.2.3rc ('rc' string)
-      extra = tmp[0][1..(tmp[0].length - 1)]
-      if relnum == '2'
-        if extra.length > 0
-          if extra[0..1] == 'rc'
-            v = extra[2..extra.length].to_i
-            if v && v > 2
+      if banner_array.count() > 0 && !banner_array[3].nil?
+        # gets 1 char on the third part of version number.
+        relnum = banner_array[2][0..0]
+        tmp = banner_array[2].split(' ')
+        # gets extra string info of version number.
+        # example: 1.2.3rc ('rc' string)
+        extra = tmp[0][1..(tmp[0].length - 1)]
+        if relnum == '2'
+          if extra.length > 0
+            if extra[0..1] == 'rc'
+              v = extra[2..extra.length].to_i
+              if v && v > 2
+                status = CheckCode::Appears
+              end
+            else
               status = CheckCode::Appears
             end
-          else
+          end
+        elsif relnum == '3'
+          if [ '', 'a', 'b', ].include?(extra)
             status = CheckCode::Appears
           end
-        end
-      elsif relnum == '3'
-        if [ '', 'a', 'b' ].include?(extra)
-          status = CheckCode::Appears
         end
       end
     end

--- a/modules/exploits/linux/ftp/proftp_telnet_iac.rb
+++ b/modules/exploits/linux/ftp/proftp_telnet_iac.rb
@@ -277,29 +277,29 @@ class MetasploitModule < Msf::Exploit::Remote
     status = CheckCode::Safe
     bannerArray = banner.split('.')
 
-    if bannerArray.count() > 0 and !bannerArray[3].nil?
-     # gets 1 char on the third part of version number.
-     relnum = bannerArray[2][0..0]
-     tmp = bannerArray[2].split(' ')
-     # gets extra string info of version number.
-     # example: 1.2.3rc ('rc' string)
-     extra = tmp[0][1..(tmp[0].length - 1)]
-     if relnum == '2'
-      if extra.length > 0
-       if extra[0..1] == 'rc'
-        v = extra[2..extra.length].to_i
-        if v and v > 2
-         status = CheckCode::Appears
+    if bannerArray.count() > 0 && !bannerArray[3].nil?
+      # gets 1 char on the third part of version number.
+      relnum = bannerArray[2][0..0]
+      tmp = bannerArray[2].split(' ')
+      # gets extra string info of version number.
+      # example: 1.2.3rc ('rc' string)
+      extra = tmp[0][1..(tmp[0].length - 1)]
+      if relnum == '2'
+        if extra.length > 0
+          if extra[0..1] == 'rc'
+            v = extra[2..extra.length].to_i
+            if v && v > 2
+              status = CheckCode::Appears
+            end
+          else
+            status = CheckCode::Appears
+          end
         end
-       else
-        status = CheckCode::Appears
-       end
+      elsif relnum == '3'
+        if [ '', 'a', 'b', 'c' ].include?(extra)
+          status = CheckCode::Appears
+        end
       end
-     elsif relnum == '3'
-      if extra.length == 0 or extra =~ /[abrc]/i
-       status = CheckCode::Appears
-      end
-     end
     end
 
     disconnect

--- a/modules/exploits/linux/ftp/proftp_telnet_iac.rb
+++ b/modules/exploits/linux/ftp/proftp_telnet_iac.rb
@@ -275,30 +275,31 @@ class MetasploitModule < Msf::Exploit::Remote
     vprint_status("FTP Banner: #{banner.strip}")
 
     status = CheckCode::Safe
-    if banner =~ /ProFTPD (1\.3\.[23][^ ])/i
-      ver = $1
-      maj,min,rel = ver.split('.')
-      relv = rel.slice!(0,1)
-      case relv
-      when '2'
-        if rel.length > 0
-          if rel[0,2] == 'rc'
-            if rel[2,rel.length].to_i >= 3
-              status = CheckCode::Appears
-            end
-          else
-            status = CheckCode::Appears
-          end
+    bannerArray = banner.split('.')
+
+    if bannerArray.count() > 0 and !bannerArray[3].nil?
+     # gets 1 char on the third part of version number.
+     relnum = bannerArray[2][0..0]
+     tmp = bannerArray[2].split(' ')
+     # gets extra string info of version number.
+     # example: 1.2.3rc ('rc' string)
+     extra = tmp[0][1..(tmp[0].length - 1)]
+     if relnum == '2'
+      if extra.length > 0
+       if extra[0..1] == 'rc'
+        v = extra[2..extra.length].to_i
+        if v and v > 2
+         status = CheckCode::Appears
         end
-      when '3'
-        # 1.3.3+ defaults to vulnerable (until >= 1.3.3c)
+       else
         status = CheckCode::Appears
-        if rel.length > 0
-          if rel[0,2] != 'rc' and rel[0,1] > 'b'
-            status = CheckCode::Safe
-          end
-        end
+       end
       end
+     elsif relnum == '3'
+      if extra.length == 0 or extra =~ /[abrc]/i
+       status = CheckCode::Appears
+      end
+     end
     end
 
     disconnect

--- a/modules/exploits/linux/ftp/proftp_telnet_iac.rb
+++ b/modules/exploits/linux/ftp/proftp_telnet_iac.rb
@@ -275,29 +275,31 @@ class MetasploitModule < Msf::Exploit::Remote
     vprint_status("FTP Banner: #{banner.strip}")
 
     status = CheckCode::Safe
-    banner_array = banner.split('.')
+    if banner =~ /ProFTPD (1\.3\.[23])/i
+      banner_array = banner.split('.')
 
-    if banner_array.count() > 0 && !banner_array[3].nil?
-      # gets 1 char on the third part of version number.
-      relnum = banner_array[2][0..0]
-      tmp = banner_array[2].split(' ')
-      # gets extra string info of version number.
-      # example: 1.2.3rc ('rc' string)
-      extra = tmp[0][1..(tmp[0].length - 1)]
-      if relnum == '2'
-        if extra.length > 0
-          if extra[0..1] == 'rc'
-            v = extra[2..extra.length].to_i
-            if v && v > 2
+      if banner_array.count() > 0 && !banner_array[3].nil?
+        # gets 1 char on the third part of version number.
+        relnum = banner_array[2][0..0]
+        tmp = banner_array[2].split(' ')
+        # gets extra string info of version number.
+        # example: 1.2.3rc ('rc' string)
+        extra = tmp[0][1..(tmp[0].length - 1)]
+        if relnum == '2'
+          if extra.length > 0
+            if extra[0..1] == 'rc'
+              v = extra[2..extra.length].to_i
+              if v && v > 2
+                status = CheckCode::Appears
+              end
+            else
               status = CheckCode::Appears
             end
-          else
+          end
+        elsif relnum == '3'
+          if [ '', 'a', 'b', ].include?(extra)
             status = CheckCode::Appears
           end
-        end
-      elsif relnum == '3'
-        if [ '', 'a', 'b', ].include?(extra)
-          status = CheckCode::Appears
         end
       end
     end

--- a/modules/exploits/linux/ftp/proftp_telnet_iac.rb
+++ b/modules/exploits/linux/ftp/proftp_telnet_iac.rb
@@ -275,12 +275,12 @@ class MetasploitModule < Msf::Exploit::Remote
     vprint_status("FTP Banner: #{banner.strip}")
 
     status = CheckCode::Safe
-    bannerArray = banner.split('.')
+    banner_array = banner.split('.')
 
-    if bannerArray.count() > 0 && !bannerArray[3].nil?
+    if banner_array.count() > 0 && !banner_array[3].nil?
       # gets 1 char on the third part of version number.
-      relnum = bannerArray[2][0..0]
-      tmp = bannerArray[2].split(' ')
+      relnum = banner_array[2][0..0]
+      tmp = banner_array[2].split(' ')
       # gets extra string info of version number.
       # example: 1.2.3rc ('rc' string)
       extra = tmp[0][1..(tmp[0].length - 1)]

--- a/modules/exploits/linux/ftp/proftp_telnet_iac.rb
+++ b/modules/exploits/linux/ftp/proftp_telnet_iac.rb
@@ -296,7 +296,7 @@ class MetasploitModule < Msf::Exploit::Remote
           end
         end
       elsif relnum == '3'
-        if [ '', 'a', 'b', 'c' ].include?(extra)
+        if [ '', 'a', 'b', ].include?(extra)
           status = CheckCode::Appears
         end
       end


### PR DESCRIPTION
Fixes https://github.com/rapid7/metasploit-framework/issues/14848

Please ensure you are submitting **from a unique branch** in your [repository](https://github.com/rapid7/metasploit-framework/pull/11086#issuecomment-445506416) to master in Rapid7's.

## Verification

List the steps needed to make sure this thing works

- [x] Make a target (ProFTPD 1.3.3) in your local (see https://github.com/rapid7/metasploit-framework/issues/14848)
- [x] Start `msfconsole`
- [x] `use exploit/linux/ftp/proftp_telnet_iac`
- [x] `set RHOSTS localhost`
- [x] `set RPORT 2021`
- [x] run `check`
- [x] Verify that the target is **vulnerable**

## Scenarios

Target (ProFTPD 1.3.3)

```
$ sudo docker run -p 2021:2021 proftpd_vuln:latest
 - using TCP receive buffer size of 131072 bytes
 - using TCP send buffer size of 16384 bytes
 - <IfModule>: using 'mod_ident.c' section at line 32
 - <Directory />: adding section for resolved path '/'
172.17.0.12 - 
172.17.0.12 - Config for ProFTPD TEST Installation:
172.17.0.12 - /
172.17.0.12 -  AllowOverwrite
172.17.0.12 -  TransferLog
172.17.0.12 -  RequireValidShell
172.17.0.12 -  UseFtpUsers
172.17.0.12 -  WtmpLog
172.17.0.12 -  Umask
172.17.0.12 - DefaultServer
172.17.0.12 - UserID
172.17.0.12 - UserName
172.17.0.12 - GroupID
172.17.0.12 - GroupName
172.17.0.12 - AuthUserFile
172.17.0.12 - AuthGroupFile
172.17.0.12 - PidFile
172.17.0.12 - TransferLog
172.17.0.12 - RequireValidShell
172.17.0.12 - UseFtpUsers
172.17.0.12 - WtmpLog
172.17.0.12 - IdentLookups
172.17.0.12 - Umask
172.17.0.12 - ProFTPD 1.3.3 (stable) (built Tue Mar 2 2021 06:47:05 UTC) standalone mode STARTUP
172.17.0.12 (::ffff:172.17.0.1[::ffff:172.17.0.1]) - session requested from client in unknown class
172.17.0.12 (::ffff:172.17.0.1[::ffff:172.17.0.1]) - connected - local  : ::ffff:172.17.0.12:2021
172.17.0.12 (::ffff:172.17.0.1[::ffff:172.17.0.1]) - connected - remote : ::ffff:172.17.0.1:45910
172.17.0.12 (::ffff:172.17.0.1[::ffff:172.17.0.1]) - FTP session opened.
172.17.0.12 (::ffff:172.17.0.1[::ffff:172.17.0.1]) - FTP session closed.
```

Metasploit console

```
msf6 > use exploit/linux/ftp/proftp_telnet_iac
[*] No payload configured, defaulting to linux/x86/meterpreter/reverse_tcp
msf6 exploit(linux/ftp/proftp_telnet_iac) > set RHOSTS localhost
RHOSTS => localhost
msf6 exploit(linux/ftp/proftp_telnet_iac) > set RPORT 2021
RPORT => 2021
msf6 exploit(linux/ftp/proftp_telnet_iac) > check
[*] 127.0.0.1:2021 - The target appears to be vulnerable.
msf6 exploit(linux/ftp/proftp_telnet_iac) > 
```
