### PR TITLE
Update metasploit-payloads gem to 2.0.37

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,7 +29,7 @@ PATH
       metasploit-concern
       metasploit-credential
       metasploit-model
-      metasploit-payloads (= 2.0.34)
+      metasploit-payloads (= 2.0.37)
       metasploit_data_models
       metasploit_payloads-mettle (= 1.0.6)
       mqtt
@@ -224,7 +224,7 @@ GEM
       activemodel (~> 5.2.2)
       activesupport (~> 5.2.2)
       railties (~> 5.2.2)
-    metasploit-payloads (2.0.34)
+    metasploit-payloads (2.0.37)
     metasploit_data_models (4.1.2)
       activerecord (~> 5.2.2)
       activesupport (~> 5.2.2)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -70,7 +70,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '2.0.34'
+  spec.add_runtime_dependency 'metasploit-payloads', '2.0.37'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '1.0.6'
   # Needed by msfgui and other rpc components


### PR DESCRIPTION
This PR bumps framework to use Metasploit payloads gem 2.0.37 (previously 2.0.34), pulling in the following payloads PR changes:

* Java linter issues
    * rapid7/metasploit-payloads#457 
    * rapid7/metasploit-payloads#460
    * rapid7/metasploit-payloads#463
    * rapid7/metasploit-payloads#464
    * rapid7/metasploit-payloads#465
* rapid7/metasploit-payloads#476
* rapid7/metasploit-payloads#475

## Verification
List the steps needed to make sure this thing works

- [x] Retest manually
- [x] Let automated tests pass