### PR TITLE
Fix remote db imports

### DIFF
--- a/lib/msf_autoload.rb
+++ b/lib/msf_autoload.rb
@@ -285,3 +285,4 @@ loader.setup # ready!
 # global autoload of common gems
 autoload :Faker, 'faker'
 autoload :BinData, 'bindata'
+autoload :REXML, 'rexml/document'


### PR DESCRIPTION
Resolves #14520 

Was getting a constant missing error when trying to do `db_import` whilst connected to the remote data service, seems during the zeitwerk work `REXML` was no longer being loaded when booting the webservice via `msfdb`

# Verification
- [ ] Check out this PR
- [ ] Restart your webservice `msfdb restart`
- [ ] import an nmap scan `db_import nmap_scan.xml` (example nmap scan `nmap 127.0.0.1 -oA nmap_scan`
- [ ] run `hosts`
- [ ] you should see the host you scanned with nmap displayed