### PR TITLE
Add autoload for bindata

### DIFF
--- a/lib/msf_autoload.rb
+++ b/lib/msf_autoload.rb
@@ -284,3 +284,4 @@ loader.setup # ready!
 
 # global autoload of common gems
 autoload :Faker, 'faker'
+autoload :BinData, 'bindata'


### PR DESCRIPTION
With the zeitwerk shuffle the `bindata` gem was no longer guaranteed to be loaded where it was being used so let's make sure it's available everywhere

- [ ] Create this .rc file
```cat > waitForStore.rc << EOF
<ruby>
require "msf/core/modules/metadata/store"
UserMetaDataFile = Msf::Modules::Metadata::Store::UserMetaDataFile
store_dir = File.join(Msf::Config.config_directory, "store")
cache_file = File.join(store_dir, UserMetaDataFile)
framework.modules.refresh_cache_from_module_files
while true do
	break if File.exist?(cache_file)
	sleep(5)
end
</ruby>
exit
EOF
```
- [ ] `rm db/modules_metadata_base.json`
- [ ] `rm ~/.msf4/store/modules_metadata.json`
- [ ] `./msfconsole -qr waitForStore.rc`
- [ ] The error should no longer be visible in `framework.log`