### PR TITLE
Remove bit struct

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,6 @@ PATH
       aws-sdk-s3
       bcrypt
       bcrypt_pbkdf
-      bit-struct
       bson
       concurrent-ruby (= 1.0.5)
       dnsruby
@@ -147,7 +146,6 @@ GEM
     bcrypt (3.1.16)
     bcrypt_pbkdf (1.1.0)
     bindata (2.4.8)
-    bit-struct (0.16)
     bson (4.12.0)
     builder (3.2.4)
     byebug (11.1.3)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -111,8 +111,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'tzinfo-data'
   # Gem for dealing with SSHKeys
   spec.add_runtime_dependency 'sshkey'
-  # BitStruct Library used for handling certain Protocol Header/Packet construction
-  spec.add_runtime_dependency 'bit-struct'
   # Library for interpreting Windows error codes and strings
   spec.add_runtime_dependency 'windows_error'
   # This used to be depended on by nokogiri, depended on by wmap


### PR DESCRIPTION
It looks like this was added to dns fuzzer modules back in the day:
https://github.com/rapid7/metasploit-framework/pull/7034

The dependencies were then later removed and replaced with BinData in this pull request:
https://github.com/rapid7/metasploit-framework/pull/8186

with the context:
> Because bit-struct is not Ruby 2.4+ compatible and appears to be unmaintained now, this converts our DNS fuzzers to use bindata instead.

I imagine this is good to delete now

## Verification

List the steps needed to make sure this thing works

- [ ] Ensure CI passes
- [ ] Manually ensure Framework and Pro don't have any references to BitStruct