### PR TITLE
Handle modules failing to be created when checking compatibility

### DIFF
--- a/lib/msf/core/exploit.rb
+++ b/lib/msf/core/exploit.rb
@@ -710,7 +710,12 @@ class Exploit < Msf::Module
     # Skip over payloads that are too big
     return false if payload_space && p.cached_size && p.cached_size > payload_space
 
-    pi = p.new
+    begin
+      pi = p.new
+    rescue ::Exception, ::LoadError => e
+      wlog("Module #{name} failed to initialize: #{e}", 'core', LEV_0)
+      return false
+    end
 
     # Are we compatible in terms of conventions and connections and
     # what not?

--- a/msfvenom
+++ b/msfvenom
@@ -346,7 +346,13 @@ def dump_payloads(platform = nil, arch = nil)
   framework.payloads.each_module(
     'Platform' => platform ? Msf::Module::PlatformList.transform(platform.split(',')) : nil,
     'Arch'     => arch ? arch.split(',') : nil) do |name, mod|
-      tbl << [ name, mod.new.description.split.join(' ') ]
+      begin
+        mod_info = mod.new.description.split.join(' ')
+      rescue ::Exception, ::LoadError => e
+        wlog("Module #{name} failed to initialize: #{e}", 'core', LEV_0)
+        next
+      end
+      tbl << [ name, mod_info ]
   end
 
   "\n" + tbl.to_s + "\n"


### PR DESCRIPTION
Resolves #14866 

On windows the `pty` gem is not available so when an attempt is made to initialize certain payloads for example when running `show payloads` it errors out
If the module fails to be created then I think it makes sense that it just shouldn't be returned as a compatible module for the exploit

# Verification

- [ ] Load up metasploit on windows
- [ ] `use exploit/multi/handler`
- [ ] show payloads
- [ ] Also check msfvenom `./msfvenom -l payloads `