### PR TITLE
Fix autoloading when using the rpc client

### DIFF
--- a/lib/msf/core/rpc/v10/client.rb
+++ b/lib/msf/core/rpc/v10/client.rb
@@ -3,7 +3,7 @@ require 'xmlrpc/client'
 require 'msgpack'
 
 require 'rex'
-
+require 'msf'
 
 
 module Msf


### PR DESCRIPTION
Enable autoloading when using the rpc client as an entrypoint into framework

This not working has affected pros update script so this PR aims to resolve that issue

# Verification
- [ ] Build pro against this branch of framework
- [ ] Deploy pro
- [ ] Attempt to use the `engine/update.rb` script
- [ ] It should work