### PR TITLE
Remove redundant rubocop disables

### DIFF
--- a/modules/exploits/multi/scada/inductive_ignition_rce.rb
+++ b/modules/exploits/multi/scada/inductive_ignition_rce.rb
@@ -115,7 +115,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def create_java_str(payload)
-    # rubocop:disable Style/StringConcatenation
     (
       "\xac\xed" +                  # STREAM_MAGIC
       "\x00\x05" +                  # STREAM_VERSION
@@ -123,7 +122,6 @@ class MetasploitModule < Msf::Exploit::Remote
       [payload.length].pack('n') +  # length
       payload
     ).force_encoding('ascii')       # is this needed in msf?
-    # rubocop:enable Style/StringConcatenation
   end
 
   def check

--- a/modules/post/linux/gather/enum_containers.rb
+++ b/modules/post/linux/gather/enum_containers.rb
@@ -93,13 +93,11 @@ class MetasploitModule < Msf::Post
     when 'lxc'
       # LXC does some awful table formatting, lets try and fix it to be more uniform
       result = cmd_exec('lxc list').each_line.reject { |st| st =~ /^\+--/ }.map.with_index.map do |s, i|
-        # rubocop:disable Style/StringConcatenation
         if i == 0
           s.split('| ').map { |t| t.strip.ljust(t.size, ' ').gsub(/\|/, '') }.join + "\n"
         else
           s.gsub(/\| /, '').gsub(/\|/, '')
         end
-        # rubocop:enable Style/StringConcatenation
       end.join.strip
     when 'rkt'
       result = cmd_exec('rkt list')


### PR DESCRIPTION
This rule was disabled here: https://github.com/rapid7/metasploit-framework/pull/14814

Therefore these disable comments are redundant now

## Verification

- Tests pass 
- `bundle exec ruby ./tools/dev/msftidy.rb -a modules` passes locally