### PR TITLE
Fix #13798, Fix #14128, fix utf8 encoding issues on meterpreter

### DIFF
--- a/lib/rex/post/meterpreter/extensions/stdapi/fs/dir.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/fs/dir.rb
@@ -280,6 +280,7 @@ class Dir < Rex::Post::Dir
     end
 
     dir_files.each { |src_sub|
+      src_sub.force_encoding('UTF-8')
       dst_sub = src_sub.dup
       dst_sub.gsub!(::File::SEPARATOR, '_')                                   # '/' on all systems
       dst_sub.gsub!(::File::ALT_SEPARATOR, '_') if ::File::ALT_SEPARATOR      # nil on Linux, '\' on Windows

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
@@ -619,7 +619,7 @@ class Console::CommandDispatcher::Stdapi::Fs
     end
 
     tbl = Rex::Text::Table.new(
-      'Header'  => "Listing: #{path}",
+      'Header'  => "Listing: #{path}".force_encoding('UTF-8'),
       'SortIndex' => columns.index(sort),
       'SortOrder' => order,
       'Columns' => columns,
@@ -639,7 +639,7 @@ class Console::CommandDispatcher::Stdapi::Fs
           ffstat ? ffstat.size       : '',
           ffstat ? ffstat.ftype[0,3] : '',
           ffstat ? ffstat.mtime      : '',
-          fname
+          fname.force_encoding('UTF-8')
         ]
       row.insert(4, p['FileShortName'] || '') if short
 


### PR DESCRIPTION
This change fixes #13798 and #14128 which are caused by unicode file/directory names.
It seems the directory listing returned from the meterpreter TLV here: https://github.com/rapid7/metasploit-framework/blob/master/lib/rex/post/meterpreter/extensions/stdapi/fs/dir.rb#L65
is ASCII-8BIT.
This change ensure it's encoded as UTF-8 before passing it to the database, or to Rex::Table (for ls).

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] Get any meterpreter session (I was able to reproduce on both Android and linux/x64 (mettle))
- [x] Ensure you have a database connected (required for #14128)
- [x] **Verify** the following:
```
meterpreter > mkdir testunicode
Creating directory: testunicode
meterpreter > cd testunicode
meterpreter > mkdir 🔥
Creating directory: 🔥
meterpreter > cd 🔥
meterpreter > edit 💩
meterpreter > ls
Listing: /metasploit-framework/testunicode/🔥
==============================================================

Mode              Size  Type  Last modified              Name
----              ----  ----  -------------              ----
100664/rw-rw-r--  0     fil   2021-03-13 11:13:19 +0000  💩

meterpreter > cd ..
meterpreter > download *
[*] mirroring  : ./🔥 -> /metasploit-framework/🔥
[*] downloading: ./🔥/💩 -> /metasploit-framework/🔥/💩
[*] download   : ./🔥/💩 -> /metasploit-framework/🔥/💩
[*] mirrored   : ./🔥 -> /metasploit-framework/🔥
meterpreter > exit
```

## Before the fix:
```
meterpreter > mkdir testunicode
Creating directory: testunicode
meterpreter > cd testunicode
meterpreter > mkdir 🔥
Creating directory: 🔥
meterpreter > cd 🔥
meterpreter > edit 💩
meterpreter > ls
[-] Error running command ls: Encoding::CompatibilityError incompatible character encodings: ASCII-8BIT and UTF-8
meterpreter > cd ..
meterpreter > download *
[*] mirroring  : ./🔥 -> /metasploit-framework/🔥
[-] Error running command download: Encoding::CompatibilityError incompatible character encodings: UTF-8 and ASCII-8BIT
```
