### PR TITLE
Add rubocop rule to correct `Gem::Version` to `Rex::Version`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,6 +19,7 @@ require:
   - ./lib/rubocop/cop/layout/extra_spacing_with_bindata_ignored.rb
   - ./lib/rubocop/cop/lint/module_disclosure_date_format.rb
   - ./lib/rubocop/cop/lint/module_disclosure_date_present.rb
+  - ./lib/rubocop/cop/lint/deprecated_gem_version.rb
 
 Layout/SpaceBeforeBrackets:
   Description: >-
@@ -156,6 +157,13 @@ Lint/ModuleDisclosureDatePresent:
   Include:
     # Only exploits require disclosure dates, but they can be present in auxiliary modules etc.
     - 'modules/exploits/**/*'
+
+Lint/DeprecatedGemVersion:
+  Enabled: true
+  Exclude:
+    - 'metasploit-framework.gemspec'
+    - 'spec/**/*'
+    - 'lib/rex/version.rb'
 
 Metrics/ClassLength:
   Description: 'Most Metasploit modules are quite large. This is ok.'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -162,8 +162,6 @@ Lint/DeprecatedGemVersion:
   Enabled: true
   Exclude:
     - 'metasploit-framework.gemspec'
-    - 'spec/**/*'
-    - 'lib/rex/version.rb'
 
 Metrics/ClassLength:
   Description: 'Most Metasploit modules are quite large. This is ok.'

--- a/lib/rex/version.rb
+++ b/lib/rex/version.rb
@@ -1,3 +1,4 @@
+# rubocop:disable Lint/DeprecatedGemVersion
 class Rex::Version < Gem::Version
 
   def initialize(version)
@@ -9,3 +10,4 @@ class Rex::Version < Gem::Version
     super version
   end
 end
+# rubocop:enable Lint/DeprecatedGemVersion

--- a/lib/rubocop/cop/lint/deprecated_gem_version.rb
+++ b/lib/rubocop/cop/lint/deprecated_gem_version.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Lint
+
+      class DeprecatedGemVersion < Base
+        include RangeHelp
+        extend AutoCorrector
+
+        MSG = 'Use `Rex::Version` instead of `Gem::Version`.'
+
+        # @!method gem_version_const(node)
+        def_node_matcher :gem_version_const, <<~PATTERN
+             (const
+              $(const {nil? cbase} :Gem) {:Version})
+        PATTERN
+
+        # @!method gem_version_const_cbase(node)
+        def_node_matcher :gem_version_const_cbase, <<~PATTERN
+             (const
+              $(const {cbase} :Gem) {:Version})
+        PATTERN
+
+        def on_const(node)
+          return unless gem_version_const(node)
+
+          add_offense(node, message: MSG) do |corrector|
+            autocorrect(corrector, node)
+          end
+        end
+
+        private
+
+        def autocorrect(corrector, node)
+          if gem_version_const_cbase(node)
+            corrector.replace(gem_version_const_cbase(node), '::Rex')
+          else
+            corrector.replace(gem_version_const(node), 'Rex')
+          end
+        end
+
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/lint/deprecated_gem_version.rb
+++ b/lib/rubocop/cop/lint/deprecated_gem_version.rb
@@ -3,7 +3,6 @@
 module RuboCop
   module Cop
     module Lint
-
       class DeprecatedGemVersion < Base
         include RangeHelp
         extend AutoCorrector
@@ -12,14 +11,14 @@ module RuboCop
 
         # @!method gem_version_const(node)
         def_node_matcher :gem_version_const, <<~PATTERN
-             (const
-              $(const {nil? cbase} :Gem) {:Version})
+          (const
+           $(const {nil? cbase} :Gem) {:Version})
         PATTERN
 
         # @!method gem_version_const_cbase(node)
         def_node_matcher :gem_version_const_cbase, <<~PATTERN
-             (const
-              $(const {cbase} :Gem) {:Version})
+          (const
+           $(const {cbase} :Gem) {:Version})
         PATTERN
 
         def on_const(node)

--- a/modules/auxiliary/scanner/http/apache_flink_jobmanager_traversal.rb
+++ b/modules/auxiliary/scanner/http/apache_flink_jobmanager_traversal.rb
@@ -69,7 +69,7 @@ class MetasploitModule < Msf::Auxiliary
       return Exploit::CheckCode::Detected('Could not determine Apache Flink software version.')
     end
 
-    if Gem::Version.new(version).between?(Gem::Version.new('1.11.0'), Gem::Version.new('1.11.2'))
+    if Rex::Version.new(version).between?(Rex::Version.new('1.11.0'), Rex::Version.new('1.11.2'))
       return Exploit::CheckCode::Appears("Apache Flink version #{version} appears vulnerable.")
     end
 

--- a/modules/auxiliary/scanner/http/wp_chopslider_id_sqli.rb
+++ b/modules/auxiliary/scanner/http/wp_chopslider_id_sqli.rb
@@ -54,9 +54,9 @@ class MetasploitModule < Msf::Auxiliary
     })
     fail_with Failure::Unreachable, 'Connection failed' unless res
     if res && res.body =~ /idangerous.chopslider-(\d\.\d).css-css/
-      v = Gem::Version.new(Regexp.last_match(1))
+      v = Rex::Version.new(Regexp.last_match(1))
       print_status "Version detected: #{v}"
-      if v <= Gem::Version.new('3.4')
+      if v <= Rex::Version.new('3.4')
         return Msf::Exploit::CheckCode::Appears
       end
     end

--- a/spec/lib/rex/version_spec.rb
+++ b/spec/lib/rex/version_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 require 'rex/version'
 
+# rubocop:disable Lint/DeprecatedGemVersion
 RSpec.describe Rex::Version do
-
   context 'when version is nil' do
     let(:version) { nil }
     subject { Rex::Version.new(version) }
@@ -12,11 +12,11 @@ RSpec.describe Rex::Version do
     end
 
     it 'should be equivalent to a version of "0"' do
-      expect(subject).to eq Gem::Version.new("0")
+      expect(subject).to eq Gem::Version.new('0')
     end
 
     it 'should be equivalent to a version of empty string' do
-      expect(subject).to eq Gem::Version.new("")
+      expect(subject).to eq Gem::Version.new('')
     end
 
     it 'should not be less than a version of 0' do
@@ -28,12 +28,12 @@ RSpec.describe Rex::Version do
     end
 
     it 'should be less than a version of "0.0.1"' do
-      expect(subject).to be < Gem::Version.new("0.0.1")
+      expect(subject).to be < Gem::Version.new('0.0.1')
     end
 
     it 'should not be greater than a version of "0.0.1"' do
-      expect(subject).not_to be > Gem::Version.new("0.0.1")
+      expect(subject).not_to be > Gem::Version.new('0.0.1')
     end
-
   end
 end
+# rubocop:enable Lint/DeprecatedGemVersion

--- a/spec/rubocop/cop/lint/deprecated_gem_version_spec.rb
+++ b/spec/rubocop/cop/lint/deprecated_gem_version_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 require 'rubocop/cop/lint/deprecated_gem_version'
 
-
 RSpec.describe RuboCop::Cop::Lint::DeprecatedGemVersion do
   subject(:cop) { described_class.new(config) }
   let(:config) { RuboCop::Config.new }

--- a/spec/rubocop/cop/lint/deprecated_gem_version_spec.rb
+++ b/spec/rubocop/cop/lint/deprecated_gem_version_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+require 'rubocop/cop/lint/deprecated_gem_version'
+
+
+RSpec.describe RuboCop::Cop::Lint::DeprecatedGemVersion do
+  subject(:cop) { described_class.new(config) }
+  let(:config) { RuboCop::Config.new }
+
+  it 'corrects `Gem::Version`' do
+    expect_offense(<<~RUBY)
+      Gem::Version
+      ^^^^^^^^^^^^ Use `Rex::Version` instead of `Gem::Version`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      Rex::Version
+    RUBY
+  end
+
+  it 'corrects `Gem::Version.new`' do
+    expect_offense(<<~RUBY)
+      Gem::Version.new("1.0.0")
+      ^^^^^^^^^^^^ Use `Rex::Version` instead of `Gem::Version`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      Rex::Version.new("1.0.0")
+    RUBY
+  end
+
+  it 'corrects `::Gem::Version`' do
+    expect_offense(<<~RUBY)
+      ::Gem::Version
+      ^^^^^^^^^^^^^^ Use `Rex::Version` instead of `Gem::Version`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      ::Rex::Version
+    RUBY
+  end
+
+  it 'does not correct `Abc::Gem::Version`' do
+    expect_no_offenses(<<~RUBY)
+      Abc::Gem::Version
+    RUBY
+  end
+end


### PR DESCRIPTION
Adds a rubocop rule to enforce the use of `Rex::Version` over `Gem::Version` carried on from this PR #14769
