### PR TITLE
Replace `rexml` autoload with an explicit require to prevent circular dependencies

### DIFF
--- a/lib/msf_autoload.rb
+++ b/lib/msf_autoload.rb
@@ -285,4 +285,4 @@ loader.setup # ready!
 # global autoload of common gems
 autoload :Faker, 'faker'
 autoload :BinData, 'bindata'
-autoload :REXML, 'rexml/document'
+require 'rexml/document'


### PR DESCRIPTION
#14863 introduced an `autoload` for `:REXML` since it wasn't being loaded in all cases but recently pro ran into an issue where this had caused a circular dependency. This can be mitigated by explicitly requiring the dependency rather than autoloading it

