### PR TITLE
use ensure for cleanup

### DIFF
--- a/lib/msf/core/exploit_driver.rb
+++ b/lib/msf/core/exploit_driver.rb
@@ -166,12 +166,13 @@ class ExploitDriver
 
       begin
         job_run_proc(ctx)
-        # For multi exploit targets.
-        # Keep the payload handler until last target or interrupt
-        job_cleanup_proc(ctx) unless keep_handler
       rescue ::Interrupt
         job_cleanup_proc(ctx)
         raise $!
+      ensure
+        # For multi exploit targets.
+        # Keep the payload handler until last target or interrupt
+        job_cleanup_proc(ctx) unless keep_handler
       end
     end
 


### PR DESCRIPTION
There exists a possibility that cleanup can be missed when an exploit raises
an exception other than `Interrupt` when run, by shifting the cleanup into
`ensure` for all exceptions when `keep_handler` is not set handlers and
other cleanup tasks from a module will be called for more possible error
states.

## Verification

List the steps needed to make sure this thing works

- [x] Pro reproduction documentation can be provided.
