### PR TITLE
Fix filezilla_client_cred.rb to only base64 decode strings inside tags marked as being base64 encoded

### DIFF
--- a/modules/post/multi/gather/filezilla_client_cred.rb
+++ b/modules/post/multi/gather/filezilla_client_cred.rb
@@ -129,15 +129,6 @@ class MetasploitModule < Msf::Post
     create_credential_login(login_data)
   end
 
-  def is_base64?(str)
-    str.match(/^([A-Za-z0-9+\/]{4})*([A-Za-z0-9+\/]{4}|[A-Za-z0-9+\/]{3}=|[A-Za-z0-9+\/]{2}==)$/) ? true : false
-  end
-
-
-  def try_decode_password(str)
-    is_base64?(str) ? Rex::Text.decode_base64(str) : str
-  end
-
 
   def get_filezilla_creds(paths)
 
@@ -197,7 +188,7 @@ class MetasploitModule < Msf::Post
             port: loot['port'],
             service_name: 'ftp',
             username: loot['user'],
-            password: try_decode_password(loot['password'])
+            password: loot['password']
           )
         end
       end
@@ -221,7 +212,11 @@ class MetasploitModule < Msf::Post
         account['logontype'] = "Anonymous"
       when /1|4/
         account['user'] = sub.elements['User'].text rescue "<unknown>"
-        account['password'] = sub.elements['Pass'].text rescue "<unknown>"
+        if sub.elements['Pass'].attributes['encoding'] == 'base64'
+          account['password'] = Rex::Text.decode_base64(sub.elements['Pass'].text) rescue "<unknown>"
+        else
+          account['password'] = sub.elements['Pass'].text rescue "<unknown>"
+        end
       when /2|3/
         account['user'] = sub.elements['User'].text rescue "<unknown>"
         account['password'] = "<blank>"
@@ -250,7 +245,7 @@ class MetasploitModule < Msf::Post
       print_status("    Server: %s:%s" % [account['host'], account['port']])
       print_status("    Protocol: %s" % account['protocol'])
       print_status("    Username: %s" % account['user'])
-      print_status("    Password: %s" % try_decode_password(account['password']))
+      print_status("    Password: %s" % account['password'])
       print_line("")
     end
     return creds


### PR DESCRIPTION
Fixes not base64 encoded passwords detected as base64 encoded. Base64 encoding is set iff encoding attribute is set to base64 and not when it "could be due to length and alphabet of the password"

What did not work:
```run post/multi/gather/filezilla_client_cred```
with a `sitemanager.xml` containing
```<Pass>AAAABBBBCCCC</Pass>```
as this was detected as `base64`.
The correct way to detect `base64` is to look for the attribute `encoding='base64'`
like:
```<Pass encoding="base64">QUFBQUJCQkJDQ0ND</Pass>```

