### PR TITLE
impersonate_ssl: added an SNI option for the ssl certificate request

### DIFF
--- a/modules/auxiliary/gather/impersonate_ssl.rb
+++ b/modules/auxiliary/gather/impersonate_ssl.rb
@@ -7,56 +7,61 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::Tcp
   include Msf::Auxiliary::Report
 
-  def initialize(info={})
-    super(update_info(info,
-      'Name'        => 'HTTP SSL Certificate Impersonation',
-      'Author'      => ' Chris John Riley',
-      'References'  =>
-          [
-            ['URL', 'http://www.slideshare.net/ChrisJohnRiley/ssl-certificate-impersonation-for-shits-andgiggles']
-          ],
-      'License'     => MSF_LICENSE,
-      'Description' => %q{
-        This module request a copy of the remote SSL certificate and creates a local
-        (self.signed) version using the information from the remote version. The module
-        then Outputs (PEM|DER) format private key / certificate and a combined version
-        for use in Apache or other Metasploit modules requiring SSLCert Inputs for private
-        key / CA cert have been provided for those with DigiNotar certs hanging about!
-      }
-    ))
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'HTTP SSL Certificate Impersonation',
+        'Author' => ' Chris John Riley',
+        'References' =>
+            [
+              ['URL', 'http://www.slideshare.net/ChrisJohnRiley/ssl-certificate-impersonation-for-shits-andgiggles']
+            ],
+        'License' => MSF_LICENSE,
+        'Description' => %q{
+          This module request a copy of the remote SSL certificate and creates a local
+          (self.signed) version using the information from the remote version. The module
+          then Outputs (PEM|DER) format private key / certificate and a combined version
+          for use in Apache or other Metasploit modules requiring SSLCert Inputs for private
+          key / CA cert have been provided for those with DigiNotar certs hanging about!
+        }
+      )
+    )
 
     register_options(
       [
         Opt::RPORT(443),
-        OptString.new('SNI',              [false, "Server Name Indicator", nil]),
-        OptEnum.new('OUT_FORMAT',         [true,  "Output format", 'PEM', ['DER','PEM']]),
-        OptString.new('EXPIRATION',       [false, "Date the new cert should expire (e.g. 06 May 2012, YESTERDAY or NOW)", nil]),
-        OptPath.new('PRIVKEY',            [false, "Sign the cert with your own CA private key", nil]),
-        OptString.new('PRIVKEY_PASSWORD', [false, "Password for private key specified in PRIV_KEY (if applicable)", nil]),
-        OptPath.new('CA_CERT',            [false, "CA Public certificate", nil]),
-        OptString.new('ADD_CN',           [false, "Add CN to match spoofed site name (e.g. *.example.com)", nil])
-      ])
+        OptString.new('SNI', [false, 'Server Name Indicator', nil]),
+        OptEnum.new('OUT_FORMAT', [true, 'Output format', 'PEM', ['DER', 'PEM']]),
+        OptString.new('EXPIRATION', [false, 'Date the new cert should expire (e.g. 06 May 2012, YESTERDAY or NOW)', nil]),
+        OptPath.new('PRIVKEY', [false, 'Sign the cert with your own CA private key', nil]),
+        OptString.new('PRIVKEY_PASSWORD', [false, 'Password for private key specified in PRIV_KEY (if applicable)', nil]),
+        OptPath.new('CA_CERT', [false, 'CA Public certificate', nil]),
+        OptString.new('ADD_CN', [false, 'Add CN to match spoofed site name (e.g. *.example.com)', nil])
+      ]
+    )
 
     register_advanced_options(
       [
-        OptBool.new('AlterSerial',        [false, "Alter the serial number slightly to avoid FireFox serial matching", true])
-      ])
+        OptBool.new('AlterSerial', [false, 'Alter the serial number slightly to avoid FireFox serial matching', true])
+      ]
+    )
   end
 
-  def get_cert(rhost,rport,sni)
-      ctx = OpenSSL::SSL::SSLContext.new
-      sock = TCPSocket.new(rhost, rport)
-      ssl = OpenSSL::SSL::SSLSocket.new(sock, ctx)
-      if sni
-        ssl.hostname = sni
-      end
-      ssl.connect
-      cert = ssl.peer_cert
-      return cert
+  def get_cert(rhost, rport, sni)
+    ctx = OpenSSL::SSL::SSLContext.new
+    sock = TCPSocket.new(rhost, rport)
+    ssl = OpenSSL::SSL::SSLSocket.new(sock, ctx)
+    if sni
+      ssl.hostname = sni
+    end
+    ssl.connect
+    cert = ssl.peer_cert
+    return cert
   end
 
   def run
-    if not datastore['SNI'].nil?
+    if !datastore['SNI'].nil?
       sni = datastore['SNI']
       print_status("Connecting to #{rhost}:#{rport} SNI:#{sni}")
     else
@@ -64,45 +69,45 @@ class MetasploitModule < Msf::Auxiliary
       print_status("Connecting to #{rhost}:#{rport}")
     end
 
-    if not datastore['PRIVKEY'].nil? and not datastore['CA_CERT'].nil?
-      print_status("Signing generated certificate with provided PRIVATE KEY and CA Certificate")
-      if not datastore['PRIVKEY_PASSWORD'].nil? and not datastore['PRIVKEY_PASSWORD'].empty?
+    if !datastore['PRIVKEY'].nil? && !datastore['CA_CERT'].nil?
+      print_status('Signing generated certificate with provided PRIVATE KEY and CA Certificate')
+      if !datastore['PRIVKEY_PASSWORD'].nil? && !datastore['PRIVKEY_PASSWORD'].empty?
         ca_key = OpenSSL::PKey::RSA.new(File.read(datastore['PRIVKEY']), datastore['PRIVKEY_PASSWORD'])
       else
         ca_key = OpenSSL::PKey::RSA.new(File.read(datastore['PRIVKEY']))
       end
       ca = OpenSSL::X509::Certificate.new(File.read(datastore['CA_CERT']))
-    elsif not datastore['PRIVKEY'].nil? or not datastore['CA_CERT'].nil?
+    elsif !datastore['PRIVKEY'].nil? || !datastore['CA_CERT'].nil?
       # error if both PRIVKEY and CA_CERT are not BOTH provided
-      print_error("CA Certificate AND Private Key must be provided!")
+      print_error('CA Certificate AND Private Key must be provided!')
       return
     end
 
     begin
       cert = get_cert(rhost, rport, sni)
       disconnect
-    rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout => e
+    rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
     rescue ::Timeout::Error, ::Errno::EPIPE => e
       print_error(e.message)
     end
 
-    if not cert
+    if !cert
       print_error("#{rhost}:#{rport} No certificate subject or CN found")
       return
     end
 
-    print_status("Copying certificate from #{rhost}:#{rport}\n#{cert.subject.to_s} ")
+    print_status("Copying certificate from #{rhost}:#{rport}\n#{cert.subject} ")
     vprint_status("Original Certifcate Details\n\n#{cert.to_text}")
 
     begin
       keylength = /Key: \((\d+)/i.match(cert.signature_algorithm)[1] # Grab keylength from target cert
-    rescue
+    rescue StandardError
       keylength = 1024
     end
 
     begin
       hashtype = /Algorithm: (\w+)With/i.match(cert.to_text)[1] # Grab hashtype from target cert
-    rescue
+    rescue StandardError
       hashtype = 'sha1'
     end
 
@@ -110,19 +115,19 @@ class MetasploitModule < Msf::Auxiliary
     ef = OpenSSL::X509::ExtensionFactory.new
 
     # Duplicate information from the remote certificate
-    entries = ['version','serial', 'subject', 'not_before','not_after']
-    entries.each do | ent |
-      eval("new_cert.#{ent} = cert.#{ent}")
+    entries = ['version', 'serial', 'subject', 'not_before', 'not_after']
+    entries.each do |ent|
+      new_cert.send("#{ent}=", cert.send(ent))
     end
 
     # add additional Common Name to the new cert
-    if not datastore['ADD_CN'].nil?  and not datastore['ADD_CN'].empty?
-      new_cert.subject = OpenSSL::X509::Name.new(new_cert.subject.to_a << ["CN", "#{datastore['ADD_CN']}"])
+    if !datastore['ADD_CN'].nil? && !datastore['ADD_CN'].empty?
+      new_cert.subject = OpenSSL::X509::Name.new(new_cert.subject.to_a << ['CN', datastore['ADD_CN'].to_s])
       print_status("Adding #{datastore['ADD_CN']} to the end of the certificate subject")
       vprint_status("Certificate Subject: #{new_cert.subject}")
     end
 
-    if not datastore['EXPIRATION'].nil? and not datastore['EXPIRATION'].empty?
+    if !datastore['EXPIRATION'].nil? && !datastore['EXPIRATION'].empty?
       # alter the not_after and not_before dates
       print_status("Altering certificate expiry information to #{datastore['EXPIRATION']}")
 
@@ -130,16 +135,14 @@ class MetasploitModule < Msf::Auxiliary
       when 'yesterday'
         new_cert.not_after = 24.hours.ago
         new_cert.not_before = 1.year.ago - 24.hours # set start date (1 year cert)
-        vprint_status("Certificate expiry date set to #{new_cert.not_after}")
       when 'now'
         new_cert.not_after = Time.now
         new_cert.not_before = 1.year.ago # set start date (1 year cert)
-        vprint_status("Certificate expiry date set to #{new_cert.not_after}")
       else
         new_cert.not_after = Time.parse(datastore['EXPIRATION'])
         new_cert.not_before = Time.parse(datastore['EXPIRATION']) - 1.year # set start date (1 year cert)
-        vprint_status("Certificate expiry date set to #{new_cert.not_after}")
       end
+      vprint_status("Certificate expiry date set to #{new_cert.not_after}")
     end
 
     # Alter serial to avoid duplicate issuer/serial detection
@@ -149,7 +152,7 @@ class MetasploitModule < Msf::Auxiliary
         new_cert.serial = (cert.serial.to_s[0..-2] + rand(0xFF).to_s).to_i
       else
         # serial is too small, create random serial
-        vprint_error("The serial number of the original cert is too short. Creating new random serial")
+        vprint_error('The serial number of the original cert is too short. Creating new random serial')
         new_cert.serial = rand(0xFFFF)
       end
     else
@@ -157,7 +160,7 @@ class MetasploitModule < Msf::Auxiliary
       new_cert.serial = cert.serial.to_s
     end
 
-    if not datastore['PRIVKEY'].nil? and not datastore['PRIVKEY'].empty?
+    if !datastore['PRIVKEY'].nil? && !datastore['PRIVKEY'].empty?
       new_cert.public_key = ca_key.public_key
       ef.subject_certificate = ca
       ef.issuer_certificate = ca
@@ -168,7 +171,7 @@ class MetasploitModule < Msf::Auxiliary
       new_cert.public_key = new_key.public_key
       ef.subject_certificate = new_cert
       ef.issuer_certificate = new_cert
-      if not datastore['ADD_CN'].nil? and not datastore['ADD_CN'].empty?
+      if !datastore['ADD_CN'].nil? && !datastore['ADD_CN'].empty?
         new_cert.issuer = new_cert.subject
       else
         new_cert.issuer = cert.subject
@@ -176,35 +179,35 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     new_cert.extensions = [
-      ef.create_extension("basicConstraints","CA:FALSE", true),
-      ef.create_extension("subjectKeyIdentifier","hash"),
+      ef.create_extension('basicConstraints', 'CA:FALSE', true),
+      ef.create_extension('subjectKeyIdentifier', 'hash'),
     ]
 
-    if not datastore['PRIVKEY'].nil? and not datastore['PRIVKEY'].empty?
-      new_cert.sign(ca_key, eval("OpenSSL::Digest::#{hashtype.upcase}.new"))
+    if !datastore['PRIVKEY'].nil? && !datastore['PRIVKEY'].empty?
+      new_cert.sign(ca_key, OpenSSL::Digest.new(hashtype))
       new_key = ca_key # Set for file output
     else
-      new_cert.sign(new_key, eval("OpenSSL::Digest::#{hashtype.upcase}.new"))
+      new_cert.sign(new_key, OpenSSL::Digest.new(hashtype))
     end
 
     vprint_status("Duplicate Certificate Details\n\n#{new_cert.to_text}")
-    print_status("Beginning export of certificate files")
+    print_status('Beginning export of certificate files')
 
-    priv_key = new_key.send(eval("\"to_#{datastore['OUT_FORMAT'].downcase}\""))
-    cert_crt = new_cert.send(eval("\"to_#{datastore['OUT_FORMAT'].downcase}\""))
-    combined = new_key.send("to_pem") + new_cert.send("to_pem")
+    priv_key = new_key.send("to_#{datastore['OUT_FORMAT'].downcase}")
+    cert_crt = new_cert.send("to_#{datastore['OUT_FORMAT'].downcase}")
+    combined = new_key.send('to_pem') + new_cert.send('to_pem')
 
     addr = Rex::Socket.getaddress(rhost) # Convert rhost to ip for DB
 
     print_status("Creating looted key/crt/pem files for #{rhost}:#{rport}")
 
-    p = store_loot("#{datastore['RHOST'].downcase}_key", datastore['OUT_FORMAT'].downcase, addr, priv_key, "imp_ssl.key", "Impersonate_SSL")
+    p = store_loot("#{datastore['RHOST'].downcase}_key", datastore['OUT_FORMAT'].downcase, addr, priv_key, 'imp_ssl.key', 'Impersonate_SSL')
     print_good("key: #{p}")
 
-    p = store_loot("#{datastore['RHOST'].downcase}_cert", datastore['OUT_FORMAT'].downcase, addr, cert_crt, "imp_ssl.crt", "Impersonate_SSL")
+    p = store_loot("#{datastore['RHOST'].downcase}_cert", datastore['OUT_FORMAT'].downcase, addr, cert_crt, 'imp_ssl.crt', 'Impersonate_SSL')
     print_good("crt: #{p}")
 
-    p = store_loot("#{datastore['RHOST'].downcase}_pem", "pem", addr, combined, "imp_ssl.pem", "Impersonate_SSL")
+    p = store_loot("#{datastore['RHOST'].downcase}_pem", 'pem', addr, combined, 'imp_ssl.pem', 'Impersonate_SSL')
     print_good("pem: #{p}")
 
   end

--- a/modules/auxiliary/gather/impersonate_ssl.rb
+++ b/modules/auxiliary/gather/impersonate_ssl.rb
@@ -43,7 +43,7 @@ class MetasploitModule < Msf::Auxiliary
       ])
   end
 
-  def getCert(rhost,rport,sni)
+  def get_cert(rhost,rport,sni)
       ctx = OpenSSL::SSL::SSLContext.new
       sock = TCPSocket.new(rhost, rport)
       ssl = OpenSSL::SSL::SSLSocket.new(sock, ctx)
@@ -79,7 +79,7 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     begin
-      cert = getCert(rhost, rport, sni)
+      cert = get_cert(rhost, rport, sni)
       disconnect
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout => e
     rescue ::Timeout::Error, ::Errno::EPIPE => e


### PR DESCRIPTION
This fix allows to set the server name indication for requesting the certificate
see:
https://github.com/rapid7/metasploit-framework/issues/14653#issuecomment-798945324
```
use auxiliary/gather/impersonate_ssl
set SNI www.google.com
set RHOSTS www.google.com
run
```