### PR TITLE
abb_wserver_exec - add CVE reference

### DIFF
--- a/modules/exploits/windows/scada/abb_wserver_exec.rb
+++ b/modules/exploits/windows/scada/abb_wserver_exec.rb
@@ -29,6 +29,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'References'     =>
         [
+          [ 'CVE', '2019-5620' ],
           [ 'OSVDB', '100324'],
           [ 'ZDI', '13-270' ],
           [ 'URL', 'https://library.e.abb.com/public/41ccfa8ccd0431e6c1257c1200395574/ABB_SoftwareVulnerabilityHandlingAdvisory_ABB-VU-PSAC-1MRS235805.pdf']


### PR DESCRIPTION
add the cve for this

https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-5620
https://nvd.nist.gov/vuln/detail/CVE-2019-5620

cve was assigned years after public exploit code