### PR TITLE
Add sort by category and reverse search results flags to the search command

### DIFF
--- a/lib/msf/core/modules/metadata/search.rb
+++ b/lib/msf/core/modules/metadata/search.rb
@@ -81,12 +81,34 @@ module Msf::Modules::Metadata::Search
         search_results << module_metadata
       end
     }
+    if params['sort']
+      cat = params['sort'][0][0].to_s
+      search_results=sorting(search_results, cat)
+    end
     return search_results
   end
 
   #######
   private
   #######
+
+  def sorting(search_results, cat)
+    case cat
+      when "date"
+        search_results.sort_by! {|meta| meta.disclosure_date}
+      when "name"
+        search_results.sort_by! {|meta| meta.name}
+      when "author"
+        search_results.sort_by! {|meta| meta.author}
+      when "rank"
+        search_results.sort_by! {|meta| meta.rank}
+      when "type"
+        search_results.sort_by! {|meta| meta.type}
+      else
+        search_results
+    end
+    search_results
+  end
 
   def is_match(params, module_metadata)
     return true if params.empty?

--- a/lib/msf/core/modules/metadata/search.rb
+++ b/lib/msf/core/modules/metadata/search.rb
@@ -81,34 +81,12 @@ module Msf::Modules::Metadata::Search
         search_results << module_metadata
       end
     }
-    if params['sort']
-      cat = params['sort'][0][0].to_s
-      search_results=sorting(search_results, cat)
-    end
     return search_results
   end
 
   #######
   private
   #######
-
-  def sorting(search_results, cat)
-    case cat
-      when "date"
-        search_results.sort_by! {|meta| meta.disclosure_date}
-      when "name"
-        search_results.sort_by! {|meta| meta.name}
-      when "author"
-        search_results.sort_by! {|meta| meta.author}
-      when "rank"
-        search_results.sort_by! {|meta| meta.rank}
-      when "type"
-        search_results.sort_by! {|meta| meta.type}
-      else
-        search_results
-    end
-    search_results
-  end
 
   def is_match(params, module_metadata)
     return true if params.empty?

--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -396,7 +396,9 @@ module Msf
             use          = false
             count        = -1
             search_terms = []
-
+            sort         = 'name'
+            sort_options = ['rank','disclosure_date','name','date','type']
+            desc         = false
             ignore_use_exact_match = false
 
             @@search_opts.parse(args) do |opt, idx, val|

--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -442,11 +442,13 @@ module Msf
                     sort='disclosure_date'
                   end
                   eval("@module_search_results.sort_by! {|meta| meta.#{sort}}")
+                end
 
                   if desc
                     @module_search_results.reverse!
                   end
-              end
+                
+                end
 
               if @module_search_results.empty?
                 print_error('No results from search')


### PR DESCRIPTION
This PR adds sort utility to search command after which the user can sort the search results based on different categories:

- Rank
- Disclosure date
- Module name
- Module Type
- If it supports a check method or not

This is implemented via the new command line flag `-s` which takes one argument, the column to sort by, and orders the results in ascending order. If users wish to view the results in descending order, they can use the newly added `-r` flag.

The date feature was described in issue [#13101](https://github.com/rapid7/metasploit-framework/issues/13101)

## Verification

- [x] Start `msfconsole`
- [x] `search shellshock`
- [x] `search shellshock -s rank`
- [x] Ensure `search shellshock -s rank -r` returns the same results as above but in descending order.
- [x] `search shellshock -s disclosure_date`
- [x] `search shellshock -s date`
- [ ] `search shellshock -s name`
- [ ] `search shellshock -s type`
- [ ] `search shellshock -s check`
- [ ] Ensure `search shellshock -s fake` returns an error message about having an invalid value for the `-s` switch.


The examples below show different sorting categories:

```
msf6 > search shellshock

Matching Modules
================

   #   Name                                               Disclosure Date  Rank       Check  Description
   -   ----                                               ---------------  ----       -----  -----------
   0   auxiliary/scanner/http/apache_mod_cgi_bash_env     2014-09-24       normal     Yes    Apache mod_cgi Bash Environment Variable Injection (Shellshock) Scanner
   1   auxiliary/server/dhclient_bash_env                 2014-09-24       normal     No     DHCP Client Bash Environment Variable Code Injection (Shellshock)
   2   exploit/linux/http/advantech_switch_bash_env_exec  2015-12-01       excellent  Yes    Advantech Switch Bash Environment Variable Code Injection (Shellshock)
   3   exploit/linux/http/ipfire_bashbug_exec             2014-09-29       excellent  Yes    IPFire Bash Environment Variable Injection (Shellshock)
   4   exploit/multi/ftp/pureftpd_bash_env_exec           2014-09-24       excellent  Yes    Pure-FTPd External Authentication Bash Environment Variable Code Injection (Shellshock)
   5   exploit/multi/http/apache_mod_cgi_bash_env_exec    2014-09-24       excellent  Yes    Apache mod_cgi Bash Environment Variable Code Injection (Shellshock)
   6   exploit/multi/http/cups_bash_env_exec              2014-09-24       excellent  Yes    CUPS Filter Bash Environment Variable Code Injection (Shellshock)
   7   exploit/multi/misc/legend_bot_exec                 2015-04-27       excellent  Yes    Legend Perl IRC Bot Remote Code Execution
   8   exploit/multi/misc/xdh_x_exec                      2015-12-04       excellent  Yes    Xdh / LinuxNet Perlbot / fBot IRC Bot Remote Code Execution
   9   exploit/osx/local/vmware_bash_function_root        2014-09-24       normal     Yes    OS X VMWare Fusion Privilege Escalation via Bash Environment Code Injection (Shellshock)
   10  exploit/unix/dhcp/bash_environment                 2014-09-24       excellent  No     Dhclient Bash Environment Variable Injection (Shellshock)
   11  exploit/unix/smtp/qmail_bash_env_exec              2014-09-24       normal     No     Qmail SMTP Bash Environment Variable Injection (Shellshock)



msf6 > search shellshock sort:date

Matching Modules
================

   #   Name                                               Disclosure Date  Rank       Check  Description
   -   ----                                               ---------------  ----       -----  -----------
   0   auxiliary/scanner/http/apache_mod_cgi_bash_env     2014-09-24       normal     Yes    Apache mod_cgi Bash Environment Variable Injection (Shellshock) Scanner
   1   auxiliary/server/dhclient_bash_env                 2014-09-24       normal     No     DHCP Client Bash Environment Variable Code Injection (Shellshock)
   2   exploit/multi/ftp/pureftpd_bash_env_exec           2014-09-24       excellent  Yes    Pure-FTPd External Authentication Bash Environment Variable Code Injection (Shellshock)
   3   exploit/multi/http/apache_mod_cgi_bash_env_exec    2014-09-24       excellent  Yes    Apache mod_cgi Bash Environment Variable Code Injection (Shellshock)
   4   exploit/multi/http/cups_bash_env_exec              2014-09-24       excellent  Yes    CUPS Filter Bash Environment Variable Code Injection (Shellshock)
   5   exploit/osx/local/vmware_bash_function_root        2014-09-24       normal     Yes    OS X VMWare Fusion Privilege Escalation via Bash Environment Code Injection (Shellshock)
   6   exploit/unix/dhcp/bash_environment                 2014-09-24       excellent  No     Dhclient Bash Environment Variable Injection (Shellshock)
   7   exploit/unix/smtp/qmail_bash_env_exec              2014-09-24       normal     No     Qmail SMTP Bash Environment Variable Injection (Shellshock)
   8   exploit/linux/http/ipfire_bashbug_exec             2014-09-29       excellent  Yes    IPFire Bash Environment Variable Injection (Shellshock)
   9   exploit/multi/misc/legend_bot_exec                 2015-04-27       excellent  Yes    Legend Perl IRC Bot Remote Code Execution
   10  exploit/linux/http/advantech_switch_bash_env_exec  2015-12-01       excellent  Yes    Advantech Switch Bash Environment Variable Code Injection (Shellshock)
   11  exploit/multi/misc/xdh_x_exec                      2015-12-04       excellent  Yes    Xdh / LinuxNet Perlbot / fBot IRC Bot Remote Code Execution


msf6 > search shellshock sort:rank

Matching Modules
================

   #   Name                                               Disclosure Date  Rank       Check  Description
   -   ----                                               ---------------  ----       -----  -----------
   0   auxiliary/scanner/http/apache_mod_cgi_bash_env     2014-09-24       normal     Yes    Apache mod_cgi Bash Environment Variable Injection (Shellshock) Scanner
   1   auxiliary/server/dhclient_bash_env                 2014-09-24       normal     No     DHCP Client Bash Environment Variable Code Injection (Shellshock)
   2   exploit/osx/local/vmware_bash_function_root        2014-09-24       normal     Yes    OS X VMWare Fusion Privilege Escalation via Bash Environment Code Injection (Shellshock)
   3   exploit/unix/smtp/qmail_bash_env_exec              2014-09-24       normal     No     Qmail SMTP Bash Environment Variable Injection (Shellshock)
   4   exploit/linux/http/advantech_switch_bash_env_exec  2015-12-01       excellent  Yes    Advantech Switch Bash Environment Variable Code Injection (Shellshock)
   5   exploit/linux/http/ipfire_bashbug_exec             2014-09-29       excellent  Yes    IPFire Bash Environment Variable Injection (Shellshock)
   6   exploit/multi/ftp/pureftpd_bash_env_exec           2014-09-24       excellent  Yes    Pure-FTPd External Authentication Bash Environment Variable Code Injection (Shellshock)
   7   exploit/multi/http/apache_mod_cgi_bash_env_exec    2014-09-24       excellent  Yes    Apache mod_cgi Bash Environment Variable Code Injection (Shellshock)
   8   exploit/multi/http/cups_bash_env_exec              2014-09-24       excellent  Yes    CUPS Filter Bash Environment Variable Code Injection (Shellshock)
   9   exploit/multi/misc/legend_bot_exec                 2015-04-27       excellent  Yes    Legend Perl IRC Bot Remote Code Execution
   10  exploit/multi/misc/xdh_x_exec                      2015-12-04       excellent  Yes    Xdh / LinuxNet Perlbot / fBot IRC Bot Remote Code Execution
   11  exploit/unix/dhcp/bash_environment                 2014-09-24       excellent  No     Dhclient Bash Environment Variable Injection (Shellshock)
```

