### PR TITLE
RangeWalker Updates For Better Hostname Handling

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -344,7 +344,7 @@ GEM
       metasm
       rex-core
       rex-text
-    rex-socket (0.1.28)
+    rex-socket (0.1.29)
       rex-core
     rex-sslscan (0.1.6)
       rex-core

--- a/lib/msf/base/logging.rb
+++ b/lib/msf/base/logging.rb
@@ -28,6 +28,7 @@ class Logging
       # Register each known log source
       [
         Rex::LogSource,
+        Rex::Socket::LogSource,
         Msf::LogSource,
         'base',
       ].each { |src|

--- a/lib/msf/core/auxiliary/scanner.rb
+++ b/lib/msf/core/auxiliary/scanner.rb
@@ -111,7 +111,7 @@ def run
         host = ar.next_host
         break if not host
 
-        @tl << framework.threads.spawn("ScannerHost(#{self.refname})-#{host}", false, host.dup) do |thr_host|
+        @tl << framework.threads.spawn("ScannerHost(#{self.refname})-#{host[:address]}", false, host.dup) do |thr_host|
           targ = thr_host[:address]
           nmod = self.replicant
           nmod.datastore['RHOST'] = thr_host[:address]

--- a/lib/msf/core/auxiliary/scanner.rb
+++ b/lib/msf/core/auxiliary/scanner.rb
@@ -108,16 +108,17 @@ def run
         # Stop scanning if we hit a fatal error
         break if has_fatal_errors?
 
-        ip = ar.next_ip
-        break if not ip
+        host = ar.next_host
+        break if not host
 
-        @tl << framework.threads.spawn("ScannerHost(#{self.refname})-#{ip}", false, ip.dup) do |tip|
-          targ = tip
+        @tl << framework.threads.spawn("ScannerHost(#{self.refname})-#{host}", false, host.dup) do |thr_host|
+          targ = thr_host[:address]
           nmod = self.replicant
-          nmod.datastore['RHOST'] = targ
+          nmod.datastore['RHOST'] = thr_host[:address]
+          nmod.datastore['VHOST'] = thr_host[:hostname] if nmod.options.include?('VHOST') && nmod.datastore['VHOST'].blank?
 
           begin
-            res << {tip => nmod.run_host(targ)}
+            res << {thr_host[:address] => nmod.run_host(targ)}
           rescue ::Rex::BindFailed
             if datastore['CHOST']
               @scan_errors << "The source IP (CHOST) value of #{datastore['CHOST']} was not usable"

--- a/lib/msf/ui/console/command_dispatcher/auxiliary.rb
+++ b/lib/msf/ui/console/command_dispatcher/auxiliary.rb
@@ -72,11 +72,11 @@ class Auxiliary
         end
 
         rhosts_range = Rex::Socket::RangeWalker.new(rhosts_opt.normalize(rhosts))
-        rhosts_range.each do |rhost|
+        rhosts_range.each_host do |rhost|
           nmod = mod.replicant
-          nmod.datastore['RHOST'] = rhost
-          nmod.datastore['VHOST'] = rhosts if (!Rex::Socket.is_ip_addr?(rhosts) && nmod.is_a?(Msf::Exploit::Remote::HttpClient) && nmod.datastore['VHOST'].nil?)
-          print_status("Running module against #{rhost}")
+          nmod.datastore['RHOST'] = rhost[:address]
+          nmod.datastore['VHOST'] = rhost[:hostname] if nmod.options.include?('VHOST') && nmod.datastore['VHOST'].blank?
+          print_status("Running module against #{rhost[:address]}")
           nmod.run_simple(
             'Action'         => args[:action],
             'OptionStr'      => args[:datastore_options].map { |k,v| "#{k}=#{v}" }.join(','),

--- a/lib/msf/ui/console/command_dispatcher/creds.rb
+++ b/lib/msf/ui/console/command_dispatcher/creds.rb
@@ -56,35 +56,6 @@ class Creds
   # Miscellaneous option helpers
   #
 
-  # Parse +arg+ into a {Rex::Socket::RangeWalker} and append the result into +host_ranges+
-  #
-  # @note This modifies +host_ranges+ in place
-  #
-  # @param arg [String] The thing to turn into a RangeWalker
-  # @param host_ranges [Array] The array of ranges to append
-  # @param required [Boolean] Whether an empty +arg+ should be an error
-  # @return [Boolean] true if parsing was successful or false otherwise
-  def arg_host_range(arg, host_ranges, required=false)
-    if (!arg and required)
-      print_error("Missing required host argument")
-      return false
-    end
-    begin
-      rw = Rex::Socket::RangeWalker.new(arg)
-    rescue
-      print_error("Invalid host parameter, #{arg}.")
-      return false
-    end
-
-    if rw.valid?
-      host_ranges << rw
-    else
-      print_error("Invalid host parameter, #{arg}.")
-      return false
-    end
-    return true
-  end
-
   #
   # Can return return active or all, on a certain host or range, on a
   # certain port or range, and/or on a service name.

--- a/lib/msf/ui/console/command_dispatcher/exploit.rb
+++ b/lib/msf/ui/console/command_dispatcher/exploit.rb
@@ -179,18 +179,18 @@ class Exploit
     # For multiple targets exploit attempts.
     if rhosts_range && rhosts_range.length.to_i > 1
       opts[:multi] = true
-      rhosts_range.each do |rhost|
+      rhosts_range.each_host do |rhost|
         nmod = mod.replicant
-        nmod.datastore['RHOST'] = rhost
-        nmod.datastore['VHOST'] = rhosts if (!Rex::Socket.is_ip_addr?(rhosts) && nmod.is_a?(Msf::Exploit::Remote::HttpClient) && nmod.datastore['VHOST'].nil?)
+        nmod.datastore['RHOST'] = rhost[:address]
+        nmod.datastore['VHOST'] = rhost[:hostname] if nmod.options.include?('VHOST') && nmod.datastore['VHOST'].blank?
         # If rhost is the last target, let exploit handler stop.
-        opts["multi"] = false if rhost == (Rex::Socket.addr_itoa(rhosts_range.ranges.first.stop))
+        opts["multi"] = false if rhost[:address] == (Rex::Socket.addr_itoa(rhosts_range.ranges.first.stop))
         # Catch the interrupt exception to stop the whole module during exploit
         begin
           print_status("Exploiting target #{rhost}")
           session = exploit_single(nmod, opts)
         rescue ::Interrupt
-          print_status("Stopping exploiting current target #{rhost}...")
+          print_status("Stopping exploiting current target #{rhost[:address]}...")
           print_status("Control-C again to force quit exploiting all targets.")
           begin
             Rex.sleep(1)

--- a/lib/msf/ui/console/module_command_dispatcher.rb
+++ b/lib/msf/ui/console/module_command_dispatcher.rb
@@ -81,7 +81,7 @@ module ModuleCommandDispatcher
         host = hosts.next_host
         break unless host
 
-        @tl << framework.threads.spawn("CheckHost-#{ip}", false, host.dup) { |thr_host|
+        @tl << framework.threads.spawn("CheckHost-#{host[:address]}", false, host.dup) { |thr_host|
           # Make sure this is thread-safe when assigning an IP to the RHOST
           # datastore option
           nmod = mod.replicant

--- a/lib/msf/ui/console/module_command_dispatcher.rb
+++ b/lib/msf/ui/console/module_command_dispatcher.rb
@@ -78,16 +78,17 @@ module ModuleCommandDispatcher
 
     loop do
       while (@tl.length < threads_max)
-        ip = hosts.next_ip
-        break unless ip
+        host = hosts.next_host
+        break unless host
 
-        @tl << framework.threads.spawn("CheckHost-#{ip}", false, ip.dup) { |tip|
+        @tl << framework.threads.spawn("CheckHost-#{ip}", false, host.dup) { |thr_host|
           # Make sure this is thread-safe when assigning an IP to the RHOST
           # datastore option
-          instance = mod.replicant
-          instance.datastore['RHOST'] = tip.dup
-          Msf::Simple::Framework.simplify_module(instance, false)
-          check_simple(instance)
+          nmod = mod.replicant
+          nmod.datastore['RHOST'] = thr_host[:address].dup
+          nmod.datastore['VHOST'] = thr_host[:hostname].dup if nmod.options.include?('VHOST') && nmod.datastore['VHOST'].blank?
+          Msf::Simple::Framework.simplify_module(nmod, false)
+          check_simple(nmod)
         }
       end
 

--- a/modules/auxiliary/scanner/http/title.rb
+++ b/modules/auxiliary/scanner/http/title.rb
@@ -27,8 +27,6 @@ class MetasploitModule < Msf::Auxiliary
         OptBool.new('SHOW_TITLES', [ true, 'Show the titles on the console as they are grabbed', true ]),
         OptString.new('TARGETURI', [true, 'The base path', '/'])
       ])
-
-    deregister_options('VHOST')
   end
 
   def run
@@ -41,61 +39,61 @@ class MetasploitModule < Msf::Auxiliary
 
   def run_host(target_host)
     begin
-        # Send a normal GET request
-        res = send_request_cgi(
-          'uri' => normalize_uri(target_uri.path)
-        )
+      # Send a normal GET request
+      res = send_request_cgi(
+        'uri' => normalize_uri(target_uri.path)
+      )
 
-        # If no response, quit now
-        if res.nil?
-          vprint_error("[#{target_host}:#{rport}] No response")
-          return
-        end
-
-        # Retrieve the headers to capture the Location and Server header
-        # Note that they are case-insensitive but stored in a hash
-        server_header = nil
-        location_header = nil
-        if !res.headers.nil?
-          res.headers.each do |key, val|
-            location_header = val if key.downcase == 'location'
-            server_header  = val if key.downcase == 'server'
-          end
-        else
-          vprint_error("[#{target_host}:#{rport}] No HTTP headers")
-        end
-
-        # If the body is blank, just stop now as there is no chance of a title
-        if res.body.nil?
-          vprint_error("[#{target_host}:#{rport}] No webpage body")
-          return
-        end
-
-        # Very basic, just match the first title tag we come to. If the match fails,
-        # there is no chance that we will have a title
-        rx = %r{<title>[\n\t\s]*(?<title>.+?)[\s\n\t]*</title>}im.match(res.body.to_s)
-        unless rx
-          vprint_error("[#{target_host}:#{rport}] No webpage title")
-          return
-        end
-
-        # Last bit of logic to capture the title
-        rx[:title].strip!
-        if rx[:title] != ''
-          rx_title = Rex::Text.html_decode(rx[:title])
-          if datastore['SHOW_TITLES']
-            print_good("[#{target_host}:#{rport}] [C:#{res.code}] [R:#{location_header}] [S:#{server_header}] #{rx_title}")
-          end
-          if datastore['STORE_NOTES']
-            notedata = { code: res.code, port: rport, server: server_header, title: rx_title, redirect: location_header, uri: datastore['TARGETURI'] }
-            report_note(host: target_host, port: rport, type: "http.title", data: notedata, update: :unique_data)
-          end
-        else
-          vprint_error("[#{target_host}:#{rport}] No webpage title")
-        end
+      # If no response, quit now
+      if res.nil?
+        vprint_error("[#{target_host}:#{rport}] No response")
+        return
       end
 
-      rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
-      rescue ::Timeout::Error, ::Errno::EPIPE
+      # Retrieve the headers to capture the Location and Server header
+      # Note that they are case-insensitive but stored in a hash
+      server_header = nil
+      location_header = nil
+      if !res.headers.nil?
+        res.headers.each do |key, val|
+          location_header = val if key.downcase == 'location'
+          server_header  = val if key.downcase == 'server'
+        end
+      else
+        vprint_error("[#{target_host}:#{rport}] No HTTP headers")
+      end
+
+      # If the body is blank, just stop now as there is no chance of a title
+      if res.body.nil?
+        vprint_error("[#{target_host}:#{rport}] No webpage body")
+        return
+      end
+
+      # Very basic, just match the first title tag we come to. If the match fails,
+      # there is no chance that we will have a title
+      rx = %r{<title>[\n\t\s]*(?<title>.+?)[\s\n\t]*</title>}im.match(res.body.to_s)
+      unless rx
+        vprint_error("[#{target_host}:#{rport}] No webpage title")
+        return
+      end
+
+      # Last bit of logic to capture the title
+      rx[:title].strip!
+      if rx[:title] != ''
+        rx_title = Rex::Text.html_decode(rx[:title])
+        if datastore['SHOW_TITLES']
+          print_good("[#{target_host}:#{rport}] [C:#{res.code}] [R:#{location_header}] [S:#{server_header}] #{rx_title}")
+        end
+        if datastore['STORE_NOTES']
+          notedata = { code: res.code, port: rport, server: server_header, title: rx_title, redirect: location_header, uri: datastore['TARGETURI'] }
+          report_note(host: target_host, port: rport, type: "http.title", data: notedata, update: :unique_data)
+        end
+      else
+        vprint_error("[#{target_host}:#{rport}] No webpage title")
+      end
+    end
+
+    rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
+    rescue ::Timeout::Error, ::Errno::EPIPE
   end
 end


### PR DESCRIPTION
This expands on the work I previously submitted in PR #14605 and addresses the primary limitation that it had whereby if multiple hostnames were used it would fail to correctly set the `VHOST` datastore option. This requires the changes I made to the `RangeWalker` class, submitted in rapid7/rex-socket#28. That changeset adds the host-hash concept which correctly maintains the correlation between hostnames and IP address when DNS resolution takes place. This primarily benefits modules that are capable of targeting multiple hosts and require knowledge of the DNS hostname (think HTTP scanners).

In the future the host hash from the `RangeWalker` can be extended. For example, we could easily add a MAC address field if necessary.

All the applicable uses of `RangeWalker` through out the framework were updated to use the new host-hash. This allows setting the `VHOST` datastore option, but it's only set when it is both a registered datastore option for the module and blank. This prevents it from being modified should the user explicitly set a value for it. This is changed from checking if the module is an instance of the HttpClient which is another approach that could have been used but this is likely more flexible and just relies on the consistent convention of the VHOST option.

One of the note-worthy usages that was **not** updated were the modules that took batches of IP addresses to scan. In this case, those modules were left as is since switching it to the host hash would require updating each one individually. Scanners that take a single target however were updated as can be seen in the demonstration.

## Demonstration
The `auxiliary/scanner/http/title` module is a good test case for this. When targeting GitHub user sites, (`username.github.io`), the VHOST must be specified in order to fetch the correct page since GitHub hosts all the users on the same servers. If the user tries to target two separate users, the module will fail to identify the titles of their respective pages because the VHOST datastore option is not set in the HTTP request. It should be noted that I also removed the de-registering code for the VHOST datastore option in this module, because as can be seen through this test case, it is necessary in certain cases.

In the following example, the behavior exhibited from the master branch at this time shows that the site title isn't found or returns a "301 Moved Permanently" response.
```
msf6 auxiliary(scanner/http/title) > show options 

Module options (auxiliary/scanner/http/title):

   Name         Current Setting                            Required  Description
   ----         ---------------                            --------  -----------
   Proxies                                                 no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS       zerosteiner.github.io benichmt1.github.io  yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
   RPORT        443                                        yes       The target port (TCP)
   SHOW_TITLES  true                                       yes       Show the titles on the console as they are grabbed
   SSL          true                                       no        Negotiate SSL/TLS for outgoing connections
   STORE_NOTES  true                                       yes       Store the captured information in notes. Use "notes -t http.title" to view
   TARGETURI    /                                          yes       The base path
   THREADS      1                                          yes       The number of concurrent threads (max one per host)

msf6 auxiliary(scanner/http/title) > run

[+] [185.199.111.153:443] [C:404] [R:] [S:GitHub.com] Site not found &middot; GitHub Pages
[*] Scanned 1 of 8 hosts (12% complete)
[+] [185.199.108.153:443] [C:301] [R:https://www.185.199.108.153/] [S:GitHub.com] 301 Moved Permanently
[*] Scanned 2 of 8 hosts (25% complete)
[+] [185.199.109.153:443] [C:404] [R:] [S:GitHub.com] Site not found &middot; GitHub Pages
[*] Scanned 3 of 8 hosts (37% complete)
[+] [185.199.110.153:443] [C:404] [R:] [S:GitHub.com] Site not found &middot; GitHub Pages
[*] Scanned 4 of 8 hosts (50% complete)
[+] [185.199.108.153:443] [C:301] [R:https://www.185.199.108.153/] [S:GitHub.com] 301 Moved Permanently
[*] Scanned 5 of 8 hosts (62% complete)
[+] [185.199.110.153:443] [C:404] [R:] [S:GitHub.com] Site not found &middot; GitHub Pages
[*] Scanned 6 of 8 hosts (75% complete)
[+] [185.199.109.153:443] [C:404] [R:] [S:GitHub.com] Site not found &middot; GitHub Pages
[*] Scanned 7 of 8 hosts (87% complete)
[+] [185.199.111.153:443] [C:404] [R:] [S:GitHub.com] Site not found &middot; GitHub Pages
[*] Scanned 8 of 8 hosts (100% complete)
[*] Auxiliary module execution completed
msf6 auxiliary(scanner/http/title) > 
```

With these changes, the same options correctly return the page titles.

```
msf6 auxiliary(scanner/http/title) > show options 

Module options (auxiliary/scanner/http/title):

   Name         Current Setting                            Required  Description
   ----         ---------------                            --------  -----------
   Proxies                                                 no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS       zerosteiner.github.io benichmt1.github.io  yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
   RPORT        443                                        yes       The target port (TCP)
   SHOW_TITLES  true                                       yes       Show the titles on the console as they are grabbed
   SSL          true                                       no        Negotiate SSL/TLS for outgoing connections
   STORE_NOTES  true                                       yes       Store the captured information in notes. Use "notes -t http.title" to view
   TARGETURI    /                                          yes       The base path
   THREADS      1                                          yes       The number of concurrent threads (max one per host)
   VHOST                                                   no        HTTP server virtual host

msf6 auxiliary(scanner/http/title) > run

[+] [185.199.109.153:443] [C:200] [R:] [S:GitHub.com] zeroSteiner
[*] Scanned 1 of 8 hosts (12% complete)
[+] [185.199.111.153:443] [C:200] [R:] [S:GitHub.com] zeroSteiner
[*] Scanned 2 of 8 hosts (25% complete)
[+] [185.199.108.153:443] [C:200] [R:] [S:GitHub.com] zeroSteiner
[*] Scanned 3 of 8 hosts (37% complete)
[+] [185.199.110.153:443] [C:200] [R:] [S:GitHub.com] zeroSteiner
[*] Scanned 4 of 8 hosts (50% complete)
[+] [185.199.111.153:443] [C:200] [R:] [S:GitHub.com] Michael Benich | Professional Portfolio
[*] Scanned 5 of 8 hosts (62% complete)
[+] [185.199.108.153:443] [C:200] [R:] [S:GitHub.com] Michael Benich | Professional Portfolio
[*] Scanned 6 of 8 hosts (75% complete)
[+] [185.199.109.153:443] [C:200] [R:] [S:GitHub.com] Michael Benich | Professional Portfolio
[*] Scanned 7 of 8 hosts (87% complete)
[+] [185.199.110.153:443] [C:200] [R:] [S:GitHub.com] Michael Benich | Professional Portfolio
[*] Scanned 8 of 8 hosts (100% complete)
[*] Auxiliary module execution completed
msf6 auxiliary(scanner/http/title) > 
```

## Verification

List the steps needed to make sure this thing works

- [ ] Follow along with the demonstration
    - [ ] Start `msfconsole`
    - [ ] `use auxiliary/scanner/http/title`
    - [ ] `set RHOSTS zerosteiner.github.io benichmt1.github.io`
        * These are just two users that use the GitHub pages feature and whose page has the necessary HTML `<title>` element to be identified by the module
    - [ ] `set RPORT 443` and `set SSL true`
    - [ ] Run the module and verify that the titles are the expected values
        * Following the same steps on the master branch can demonstrate the original issue
- [ ] Try using loading an HTTP exploit module
- [ ] set the RHOSTS data store option to hostname and a range (localhost will work)
- [ ] Run the module and ensure that the exploit continues to work correctly
- [ ] Use the `check` command to check a hostname and range of hosts as well
- [ ] Enabling `HttpTrace` here can help since you can see the host header
