### PR TITLE
Update metasploit-payloads gem to 2.0.39

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,7 +28,7 @@ PATH
       metasploit-concern
       metasploit-credential
       metasploit-model
-      metasploit-payloads (= 2.0.37)
+      metasploit-payloads (= 2.0.39)
       metasploit_data_models
       metasploit_payloads-mettle (= 1.0.6)
       mqtt
@@ -222,7 +222,7 @@ GEM
       activemodel (~> 5.2.2)
       activesupport (~> 5.2.2)
       railties (~> 5.2.2)
-    metasploit-payloads (2.0.37)
+    metasploit-payloads (2.0.39)
     metasploit_data_models (4.1.2)
       activerecord (~> 5.2.2)
       activesupport (~> 5.2.2)

--- a/LICENSE_GEMS
+++ b/LICENSE_GEMS
@@ -62,7 +62,7 @@ metasploit-concern, 3.0.1, "New BSD"
 metasploit-credential, 4.0.3, "New BSD"
 metasploit-framework, 6.0.37, "New BSD"
 metasploit-model, 3.1.3, "New BSD"
-metasploit-payloads, 2.0.37, "3-clause (or ""modified"") BSD"
+metasploit-payloads, 2.0.39, "3-clause (or ""modified"") BSD"
 metasploit_data_models, 4.1.2, "New BSD"
 metasploit_payloads-mettle, 1.0.6, "3-clause (or ""modified"") BSD"
 method_source, 1.0.0, MIT

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -70,7 +70,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '2.0.37'
+  spec.add_runtime_dependency 'metasploit-payloads', '2.0.39'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '1.0.6'
   # Needed by msfgui and other rpc components

--- a/modules/payloads/singles/java/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/java/shell_reverse_tcp.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 7544
+  CachedSize = 7503
 
   include Msf::Payload::Single
   include Msf::Payload::Java

--- a/modules/payloads/singles/python/meterpreter_bind_tcp.rb
+++ b/modules/payloads/singles/python/meterpreter_bind_tcp.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 112869
+  CachedSize = 112877
 
   include Msf::Payload::Single
   include Msf::Payload::Python

--- a/modules/payloads/singles/python/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/python/meterpreter_reverse_http.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 112837
+  CachedSize = 112845
 
   include Msf::Payload::Single
   include Msf::Payload::Python

--- a/modules/payloads/singles/python/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/python/meterpreter_reverse_https.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 112837
+  CachedSize = 112845
 
   include Msf::Payload::Single
   include Msf::Payload::Python

--- a/modules/payloads/singles/python/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/python/meterpreter_reverse_tcp.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 112769
+  CachedSize = 112773
 
   include Msf::Payload::Single
   include Msf::Payload::Python

--- a/modules/payloads/stagers/java/bind_tcp.rb
+++ b/modules/payloads/stagers/java/bind_tcp.rb
@@ -5,7 +5,7 @@
 
 module MetasploitModule
 
-  CachedSize = 5303
+  CachedSize = 5262
 
   include Msf::Payload::Stager
   include Msf::Payload::Java

--- a/modules/payloads/stagers/java/reverse_http.rb
+++ b/modules/payloads/stagers/java/reverse_http.rb
@@ -5,7 +5,7 @@
 
 module MetasploitModule
 
-  CachedSize = 5386
+  CachedSize = 5345
 
   include Msf::Payload::Stager
   include Msf::Payload::Java

--- a/modules/payloads/stagers/java/reverse_https.rb
+++ b/modules/payloads/stagers/java/reverse_https.rb
@@ -5,7 +5,7 @@
 
 module MetasploitModule
 
-  CachedSize = 6195
+  CachedSize = 6154
 
   include Msf::Payload::Stager
   include Msf::Payload::Java

--- a/modules/payloads/stagers/java/reverse_tcp.rb
+++ b/modules/payloads/stagers/java/reverse_tcp.rb
@@ -5,7 +5,7 @@
 
 module MetasploitModule
 
-  CachedSize = 5303
+  CachedSize = 5262
 
   include Msf::Payload::Stager
   include Msf::Payload::Java


### PR DESCRIPTION
This PR bumps framework to use Metasploit payloads gem 2.0.39 (previously 2.0.37), pulling in the following payloads PR changes:

* https://github.com/rapid7/metasploit-payloads/pull/467 (no testing required)
* https://github.com/rapid7/metasploit-payloads/pull/477

## Verification
List the steps needed to make sure this thing works

- [ ] Retest manually
- [ ] Let automated tests pass

### Before
```
msfconsole -q
msf6 > use exploit/multi/handler
[*] Using configured payload generic/shell_reverse_tcp
msf6 exploit(multi/handler) > set payload python/meterpreter/reverse_tcp
payload => python/meterpreter/reverse_tcp
msf6 exploit(multi/handler) > set LHOST 192.168.13.37
LHOST => 192.168.13.37
msf6 exploit(multi/handler) > set LPORT 4444
LPORT => 4444
msf6 exploit(multi/handler) > run -j
[*] Exploit running as background job 0.
[*] Exploit completed, but no session was created.
msf6 exploit(multi/handler) >
[*] Started reverse TCP handler on 192.168.13.37:4444
msf6 exploit(multi/handler) > [*] Sending stage (39344 bytes) to 192.168.13.37
[*] Meterpreter session 1 opened (192.168.13.37:4444 -> 192.168.13.37:55420) at 2021-03-19 20:38:45 +0000

msf6 exploit(multi/handler) > loadpath test/modules
Loaded 37 modules:
    10 post modules
    13 exploit modules
    14 auxiliary modules
msf6 exploit(multi/handler) > use post/test/meterpreter
msf6 post(test/meterpreter) > set SESSION -1
SESSION => -1
msf6 post(test/meterpreter) > run

[*] Running against session -1
[*] Session type is meterpreter and platform is linux
[+] should enumerate supported core commands
[+] should support 3 or more core commands
[+] should return its own process id
[+] should return a list of processes
[+] should return a user id
[+] should return a sysinfo Hash
[+] should return network interfaces
[+] should have an interface that matches session_host
[-] FAILED: should return network routes
[-] Exception: Rex::Post::Meterpreter::RequestError : stdapi_net_config_get_routes: Operation failed: Unknown error
[+] should return the proper directory separator
[+] should return the current working directory
[+] should list files in the current directory
[+] should stat a directory
[+] should create and remove a dir
[+] should change directories
[+] should create and remove files
[+] should upload a file
[+] should move files
[+] should copy files
[+] should do md5 and sha1 of files
[*] Passed: 20; Failed: 0
[*] Post module execution completed
msf6 post(test/meterpreter) > 


```

### After
```

msfconsole -q
msf6 > use exploit/multi/handler
[*] Using configured payload generic/shell_reverse_tcp
msf6 exploit(multi/handler) > set payload python/meterpreter/reverse_tcp
payload => python/meterpreter/reverse_tcp
msf6 exploit(multi/handler) > set LHOST 192.168.13.37
LHOST => 192.168.13.37
msf6 exploit(multi/handler) > set LPORT 4444
LPORT => 4444
msf6 exploit(multi/handler) > run -j
[*] Exploit running as background job 0.
[*] Exploit completed, but no session was created.
msf6 exploit(multi/handler) >
[*] Started reverse TCP handler on 192.168.13.37:4444
msf6 exploit(multi/handler) > [*] Sending stage (39344 bytes) to 192.168.13.37
[*] Meterpreter session 1 opened (192.168.13.37:4444 -> 192.168.13.37:55420) at 2021-03-19 20:38:45 +0000

msf6 exploit(multi/handler) > loadpath test/modules
Loaded 37 modules:
    10 post modules
    13 exploit modules
    14 auxiliary modules
msf6 exploit(multi/handler) > use post/test/meterpreter
msf6 post(test/meterpreter) > set SESSION -1
SESSION => -1
msf6 post(test/meterpreter) > run

[*] Running against session -1
[*] Session type is meterpreter and platform is linux
[+] should enumerate supported core commands
[+] should support 3 or more core commands
[+] should return its own process id
[+] should return a list of processes
[+] should return a user id
[+] should return a sysinfo Hash
[+] should return network interfaces
[+] should have an interface that matches session_host
[+] should return network routes
[+] should return the proper directory separator
[+] should return the current working directory
[+] should list files in the current directory
[+] should stat a directory
[+] should create and remove a dir
[+] should change directories
[+] should create and remove files
[+] should upload a file
[+] should move files
[+] should copy files
[+] should do md5 and sha1 of files
[*] Passed: 20; Failed: 0
[*] Post module execution completed

```