### PR TITLE
Fix Search Command's Substring Highlighter

### DIFF
--- a/lib/msf/ui/console/table_print/highlight_substring_styler.rb
+++ b/lib/msf/ui/console/table_print/highlight_substring_styler.rb
@@ -17,7 +17,7 @@ module Msf
             @substrings.each do |s|
               # Regex used to pull out matches and preserve case sensitivity
               matches = value_cp.scan(%r{#{Regexp.escape(s)}}i)
-
+              matches.uniq!
               matches.each do |m|
                 value_cp.gsub!(m, COLOR + m + '%clr')
               end


### PR DESCRIPTION
This PR fixes #14922 .

Substring Highlighter had a issue which made it recursively highlighting the matched strings resulting in highlighting multiple times or throwing the code on the results. Some combination of searches also make it highlight infinitely making it never ending. eg. `search eternal g`.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] Ensure `search eternal a` results in clean results without `%bgmag` or `%clr` in search results.
- [ ]  Ensure `search eternal g` gives the result in expected time.