### PR TITLE
Add signal rescue to tools/exploit/* Ruby scripts to avoid long call traces

### DIFF
--- a/tools/exploit/egghunter.rb
+++ b/tools/exploit/egghunter.rb
@@ -4,7 +4,7 @@
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
-
+begin
 msfbase = __FILE__
 while File.symlink?(msfbase)
   msfbase = File.expand_path(File.readlink(msfbase), File.dirname(msfbase))
@@ -157,4 +157,7 @@ if __FILE__ == $PROGRAM_NAME
     $stderr.puts "[x] #{e.class}: #{e.message}"
     $stderr.puts "[*] If necessary, please refer to framework.log for more details."
   end
+end
+rescue SignalException => e
+  puts("Aborted! #{e}")
 end

--- a/tools/exploit/exe2vba.rb
+++ b/tools/exploit/exe2vba.rb
@@ -9,7 +9,7 @@
 # This script converts an EXE to a VBA script for Word/Excel
 # Credit to PriestMaster for the original C code
 #
-
+begin
 msfbase = __FILE__
 while File.symlink?(msfbase)
   msfbase = File.expand_path(File.readlink(msfbase), File.dirname(msfbase))
@@ -47,3 +47,6 @@ out.close
 inp.close
 
 $stderr.puts "[*] Converted #{dat.length} bytes of EXE into a VBA script"
+rescue SignalException => e
+  puts("Aborted! #{e}")
+end

--- a/tools/exploit/exe2vbs.rb
+++ b/tools/exploit/exe2vbs.rb
@@ -8,7 +8,7 @@
 #
 # This script converts an EXE to a vbs script
 #
-
+begin
 msfbase = __FILE__
 while File.symlink?(msfbase)
   msfbase = File.expand_path(File.readlink(msfbase), File.dirname(msfbase))
@@ -46,3 +46,6 @@ out.close
 inp.close
 
 $stderr.puts "[*] Converted #{dat.length} bytes of EXE into a vbs script"
+rescue SignalException => e
+  puts("Aborted! #{e}")
+end

--- a/tools/exploit/find_badchars.rb
+++ b/tools/exploit/find_badchars.rb
@@ -9,7 +9,7 @@
 # This script is intended to assist an exploit developer in deducing what
 # "bad characters" exist for a given input path to a program.
 #
-
+begin
 msfbase = __FILE__
 while File.symlink?(msfbase)
   msfbase = File.expand_path(File.readlink(msfbase), File.dirname(msfbase))
@@ -163,4 +163,7 @@ if new_badchars.length < 1
   $stderr.puts(OutStatus + "All characters matched, no new bad characters discovered.")
 else
   $stderr.puts(OutStatus + "Proposed BadChars: \"" + Rex::Text.to_hex(new_badchars) + "\"")
+end
+rescue SignalException => e
+  puts("Aborted! #{e}")
 end

--- a/tools/exploit/java_deserializer.rb
+++ b/tools/exploit/java_deserializer.rb
@@ -4,7 +4,7 @@
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
-
+begin
 msf_base = __FILE__
 while File.symlink?(msf_base)
   msf_base = File.expand_path(File.readlink(msf_base), File.dirname(msf_base))
@@ -165,4 +165,7 @@ if __FILE__ == $PROGRAM_NAME
 
   deserializer = JavaDeserializer.new(ARGV[0])
   deserializer.run(options)
+end
+rescue SignalException => e
+  puts("Aborted! #{e}")
 end

--- a/tools/exploit/jsobfu.rb
+++ b/tools/exploit/jsobfu.rb
@@ -4,7 +4,7 @@
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
-
+begin
 msfbase = __FILE__
 while File.symlink?(msfbase)
   msfbase = File.expand_path(File.readlink(msfbase), File.dirname(msfbase))
@@ -114,4 +114,7 @@ end
 if __FILE__ == $PROGRAM_NAME
   driver = Jsobfu::Driver.new
   driver.run
+end
+rescue SignalException => e
+  puts("Aborted! #{e}")
 end

--- a/tools/exploit/metasm_shell.rb
+++ b/tools/exploit/metasm_shell.rb
@@ -17,7 +17,7 @@
 #
 #    Licence is LGPL, see LICENCE in the top-level directory
 #
-
+begin
 msfbase = __FILE__
 while File.symlink?(msfbase)
   msfbase = File.expand_path(File.readlink(msfbase), File.dirname(msfbase))
@@ -187,3 +187,6 @@ shell.run { |l|
     puts "Error: #{e.class} #{e.message}"
   end
 }
+rescue SignalException => e
+  puts("Aborted! #{e}")
+end

--- a/tools/exploit/msf_irb_shell.rb
+++ b/tools/exploit/msf_irb_shell.rb
@@ -4,7 +4,7 @@
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
-
+begin
 msfbase = __FILE__
 while File.symlink?(msfbase)
   msfbase = File.expand_path(File.readlink(msfbase), File.dirname(msfbase))
@@ -20,3 +20,7 @@ require 'rex'
 framework = Msf::Simple::Framework.create
 
 Rex::Ui::Text::IrbShell.new(binding).run
+
+rescue SignalException => e
+  puts("Aborted! #{e}")
+end

--- a/tools/exploit/msu_finder.rb
+++ b/tools/exploit/msu_finder.rb
@@ -4,7 +4,7 @@
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
-
+begin
 require 'patch_finder/core/helper'
 require 'patch_finder/msu'
 require 'optparse'
@@ -110,4 +110,7 @@ end
 if __FILE__ == $PROGRAM_NAME
   bin = PatchFinderBin.new
   bin.main
+end
+rescue SignalException => e
+  puts("Aborted! #{e}")
 end

--- a/tools/exploit/nasm_shell.rb
+++ b/tools/exploit/nasm_shell.rb
@@ -10,7 +10,7 @@
 # certain x86 instructions by making use of nasm if it is installed and
 # reachable through the PATH environment variable.
 #
-
+begin
 msfbase = __FILE__
 while File.symlink?(msfbase)
   msfbase = File.expand_path(File.readlink(msfbase), File.dirname(msfbase))
@@ -54,3 +54,6 @@ shell.run { |line|
     puts "Error: #{$!}"
   end
 }
+rescue SignalException => e
+  puts("Aborted! #{e}")
+end

--- a/tools/exploit/pattern_create.rb
+++ b/tools/exploit/pattern_create.rb
@@ -4,7 +4,7 @@
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
-
+begin
 msfbase = __FILE__
 while File.symlink?(msfbase)
   msfbase = File.expand_path(File.readlink(msfbase), File.dirname(msfbase))
@@ -79,4 +79,7 @@ if __FILE__ == $PROGRAM_NAME
     $stderr.puts "[x] #{e.class}: #{e.message}"
     $stderr.puts "[*] If necessary, please refer to framework.log for more details."
   end
+end
+rescue SignalException => e
+  puts("Aborted! #{e}")
 end

--- a/tools/exploit/pattern_offset.rb
+++ b/tools/exploit/pattern_offset.rb
@@ -4,7 +4,7 @@
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
-
+begin
 msfbase = __FILE__
 while File.symlink?(msfbase)
   msfbase = File.expand_path(File.readlink(msfbase), File.dirname(msfbase))
@@ -148,4 +148,7 @@ if __FILE__ == $PROGRAM_NAME
     $stderr.puts "[*] If necessary, please refer to framework.log for more details."
 
   end
+end
+rescue SignalException => e
+  puts("Aborted!")
 end

--- a/tools/exploit/pdf2xdp.rb
+++ b/tools/exploit/pdf2xdp.rb
@@ -8,7 +8,7 @@
 # Alexander 'alech' Klink, 2011
 # public domain / CC-0
 #
-
+begin
 require 'base64'
 
 pdf = ARGV.shift
@@ -36,3 +36,6 @@ end
 xdp_out.print '<?xml version="1.0"?><?xfa ?><xdp:xdp xmlns:xdp="http://ns.adobe.com/xdp/"><pdf xmlns="http://ns.adobe.com/xdp/pdf/"><document><chunk>'
 xdp_out.print Base64.encode64(pdf_content)
 xdp_out.print '</chunk></document></pdf></xdp:xdp>'
+rescue SignalException => e
+  puts("Aborted! #{e}")
+end

--- a/tools/exploit/psexec.rb
+++ b/tools/exploit/psexec.rb
@@ -8,7 +8,7 @@
 #
 # This is rough and dirty standalone (Rex only) psexec implementation
 #
-
+begin
 msfbase = __FILE__
 while File.symlink?(msfbase)
   msfbase = File.expand_path(File.readlink(msfbase), File.dirname(msfbase))
@@ -278,4 +278,7 @@ rescue ::Interrupt
   raise $!
 rescue ::Exception
   #raise $!
+end
+rescue SignalException => e
+  puts("Aborted! #{e}")
 end

--- a/tools/exploit/random_compile_c.rb
+++ b/tools/exploit/random_compile_c.rb
@@ -10,7 +10,7 @@ def help
 end
 
 help if ARGV.empty? || ARGV.include?('-h')
-
+begin
 msfbase = __FILE__
 while File.symlink?(msfbase)
   msfbase = File.expand_path(File.readlink(msfbase), File.dirname(msfbase))
@@ -35,4 +35,7 @@ source_code = File.read(source_code_path)
 Metasploit::Framework::Compiler::Windows.compile_random_c_to_file(out_path, source_code, weight: weight.to_i)
 if File.exists?(out_path)
   puts "File saved as #{out_path}"
+end
+rescue SignalException => e
+  puts("Aborted! #{e}")
 end

--- a/tools/exploit/reg.rb
+++ b/tools/exploit/reg.rb
@@ -9,7 +9,7 @@
 # This script acts as a small registry reader.
 # You may easily automate a lot of registry forensics with a proper method.
 #
-
+begin
 msfbase = __FILE__
 while File.symlink?(msfbase)
   msfbase = File.expand_path(File.readlink(msfbase), File.dirname(msfbase))
@@ -539,4 +539,7 @@ when "get_user_application_information"
 
 else
   puts "Sorry invalid command, try with \"help\""
+end
+rescue SignalException => e
+  puts("Aborted! #{e}")
 end

--- a/tools/exploit/virustotal.rb
+++ b/tools/exploit/virustotal.rb
@@ -26,7 +26,7 @@
 # Author:
 # sinn3r <sinn3r[at]metasploit.com>
 #
-
+begin
 msfbase = __FILE__
 while File.symlink?(msfbase)
   msfbase = File.expand_path(File.readlink(msfbase), File.dirname(msfbase))
@@ -562,4 +562,7 @@ if __FILE__ == $PROGRAM_NAME
     $stdout.puts
     $stdout.puts "Good bye"
   end
+end
+rescue SignalException => e
+  puts("Aborted! #{e}")
 end


### PR DESCRIPTION
## Summary

This PR was fixes #6170.

Many msf ruby scripts take their time to do their job and meanwhile if user closes this with `SIGINT`, the user is presented with long dirty call traces. 
This PR fixes that and presents users an aborted message.

All the scripts that are changed can be located under `tools/exploit/*`

## Verification Steps
Ensure that when you try to stop any script while it is executing it should give a `Aborted!` message instead of long backtrace.

```
$ ./pattern_create.rb -l 5000000
^CAborted! 
$
$./egghunter.rb
^CAborted!
$
$ ./virustotal.rb
^CAborted! 
```
