### PR TITLE
Fix search command highlighting for single characters

### DIFF
--- a/lib/msf/ui/console/table_print/highlight_substring_styler.rb
+++ b/lib/msf/ui/console/table_print/highlight_substring_styler.rb
@@ -5,25 +5,18 @@ module Msf
     module Console
       module TablePrint
         class HighlightSubstringStyler
-          COLOR = '%bgmag'
+          HIGHLIGHT_COLOR = '%bgmag'
+          RESET_COLOR = '%clr'
 
           def initialize(substrings)
             @substrings = substrings
           end
 
           def style(value)
-            value_cp = value.clone
+            search_terms = @substrings.map { |substring| Regexp.escape(substring) }
+            search_pattern = /#{search_terms.join('|')}/i
 
-            @substrings.each do |s|
-              # Regex used to pull out matches and preserve case sensitivity
-              matches = value_cp.scan(%r{#{Regexp.escape(s)}}i)
-
-              matches.each do |m|
-                value_cp.gsub!(m, COLOR + m + '%clr')
-              end
-            end
-
-            value_cp
+            value.gsub(search_pattern) { |match| "#{HIGHLIGHT_COLOR}#{match}#{RESET_COLOR}" }
           end
         end
       end

--- a/spec/lib/msf/ui/console/table_print/highlight_substring_styler_spec.rb
+++ b/spec/lib/msf/ui/console/table_print/highlight_substring_styler_spec.rb
@@ -23,5 +23,12 @@ RSpec.describe Msf::Ui::Console::TablePrint::HighlightSubstringStyler do
 
       expect(styler.style(str)).to eql "AAAAA%bgmagBBB%clrAAAAA%bgmagCCC%clr"
     end
+
+    it 'should highlight single characters' do
+      str = 'ABCABC'
+      styler = described_class.new(%w(a b c))
+
+      expect(styler.style(str)).to eql "%bgmagA%clr%bgmagB%clr%bgmagC%clr%bgmagA%clr%bgmagB%clr%bgmagC%clr"
+    end
   end
 end


### PR DESCRIPTION
closes https://github.com/rapid7/metasploit-framework/issues/14922

Thanks to @pingport80 for raising the issue and pointing to where the code was having issues over a quick slack chat

### Before

<img width="1249" alt="image" src="https://user-images.githubusercontent.com/60357436/168253462-6cecdbdb-977a-48f6-a55b-65ea5c4ff753.png">

### After

![image](https://user-images.githubusercontent.com/60357436/112043360-7ca09a80-8b40-11eb-9e69-a2e3a0a429a7.png)

## Verification

List the steps needed to make sure this thing works

- Open msfconsole
- `search a eternal`
- Verify that the results are highlighted as expected
