### PR TITLE
Fix #14888, fix downloading a utf-8 directory directly

### DIFF
--- a/lib/rex/post/meterpreter/extensions/stdapi/fs/dir.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/fs/dir.rb
@@ -258,6 +258,8 @@ class Dir < Rex::Post::Dir
   # local directory, optionally in a recursive fashion.
   #
   def Dir.download(dst, src, opts = {}, force = true, glob = nil, &stat)
+    src.force_encoding('UTF-8')
+    dst.force_encoding('UTF-8')
     tries_cnt = 0
 
     continue =  opts["continue"]

--- a/lib/rex/post/meterpreter/extensions/stdapi/fs/file.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/fs/file.rb
@@ -325,6 +325,7 @@ class File < Rex::Post::Meterpreter::Extensions::Stdapi::Fs::IO
   def File.download(dest, src_files, opts = {}, &stat)
     timestamp = opts["timestamp"]
     [*src_files].each { |src|
+      src.force_encoding('UTF-8')
       if (::File.basename(dest) != File.basename(src))
         # The destination when downloading is a local file so use this
         # system's separator


### PR DESCRIPTION
This change fixes a similar bug to #14888 , but this time you need to specify the directory directly
This change ensure the directory source and destination are UTF-8 encoded.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] Get any meterpreter session (I was able to reproduce on both Android and linux/x64 (mettle))
- [x] Ensure you have a database connected
- [x] **Verify** the following:
```
meterpreter > mkdir testunicode
Creating directory: testunicode
meterpreter > cd testunicode
meterpreter > mkdir 🔥
Creating directory: 🔥
meterpreter > cd 🔥
meterpreter > edit ⚡
meterpreter > ls
Listing: /metasploit-framework/testunicode/🔥
==============================================================

Mode              Size  Type  Last modified              Name
----              ----  ----  -------------              ----
100664/rw-rw-r--  0     fil   2021-03-13 11:13:19 +0000  ⚡

meterpreter > cd ..
meterpreter > download 🔥
[*] mirroring  : ./🔥 -> /metasploit-framework/🔥
[*] downloading: ./🔥/⚡ -> /metasploit-framework/🔥/⚡
[*] download   : ./🔥/⚡ -> /metasploit-framework/🔥/⚡
[*] mirrored   : ./🔥 -> /metasploit-framework/🔥
meterpreter > exit
```

## Before the fix:
```
meterpreter > mkdir testunicode
Creating directory: testunicode
meterpreter > cd testunicode
meterpreter > mkdir 🔥
Creating directory: 🔥
meterpreter > cd 🔥
meterpreter > edit ⚡
meterpreter > cd ..
meterpreter > download 🔥
[-] Error running command download: Encoding::CompatibilityError incompatible character encodings: ASCII-8BIT and UTF-8
```
