### PR TITLE
Improves performance of show command 

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -1536,7 +1536,7 @@ module Msf
           #
           # Handles the filtering of modules that will be generated into a table
           def show_module_metadata(table_name, module_filter)
-            count = 0
+            count = -1
             tbl = generate_module_table(table_name)
 
             if module_filter.is_a?(Array) || module_filter.is_a?(Hash)

--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -1329,45 +1329,50 @@ module Msf
           # Module list enumeration
           #
 
-          def show_encoders(regex = nil, minrank = nil, opts = nil) # :nodoc:
+          def show_encoders # :nodoc:
             # If an active module has been selected and it's an exploit, get the
             # list of compatible encoders and display them
             if (active_module and active_module.exploit? == true)
-              show_module_set("Compatible Encoders", active_module.compatible_encoders, regex, minrank, opts)
+              show_module_metadata('Compatible Encoders', active_module.compatible_encoders)
             else
-              show_module_set("Encoders", framework.encoders, regex, minrank, opts)
+              show_module_metadata('Encoders', 'encoder')
             end
           end
 
-          def show_nops(regex = nil, minrank = nil, opts = nil) # :nodoc:
-            show_module_set("NOP Generators", framework.nops, regex, minrank, opts)
+          def show_nops # :nodoc:
+            show_module_metadata('NOP Generators', 'nop')
           end
 
-          def show_exploits(regex = nil, minrank = nil, opts = nil) # :nodoc:
-            show_module_set("Exploits", framework.exploits, regex, minrank, opts)
+          def show_exploits # :nodoc:
+            show_module_metadata('Exploits', 'exploit')
           end
 
-          def show_payloads(regex = nil, minrank = nil, opts = nil) # :nodoc:
+          def show_payloads # :nodoc:
             # If an active module has been selected and it's an exploit, get the
             # list of compatible payloads and display them
             if active_module && (active_module.exploit? || active_module.evasion?)
               @@payload_show_results = active_module.compatible_payloads
 
-              show_module_set('Compatible Payloads', @@payload_show_results, regex, minrank, opts)
+              show_module_metadata('Compatible Payloads', @@payload_show_results)
             else
-              show_module_set('Payloads', framework.payloads, regex, minrank, opts)
+              # show_module_set(‘Payloads’, framework.payloads, regex, minrank, opts)
+              show_module_metadata('Payloads', 'payload')
             end
           end
 
-          def show_auxiliary(regex = nil, minrank = nil, opts = nil) # :nodoc:
-            show_module_set("Auxiliary", framework.auxiliary, regex, minrank, opts)
+          def show_auxiliary # :nodoc:
+            show_module_metadata('Auxiliary','auxiliary')
           end
 
-          def show_post(regex = nil, minrank = nil, opts = nil) # :nodoc:
-            show_module_set("Post", framework.post, regex, minrank, opts)
+          def show_post # :nodoc:
+            show_module_metadata('Post','post')
           end
 
-          def show_favorites(regex = nil, minrank = nil, opts = nil) # :nodoc:
+          def show_evasion # :nodoc:
+            show_module_metadata('Evasion','evasion')
+          end
+
+          def show_favorites # :nodoc:
             favs_file = Msf::Config.fav_modules_file
 
             unless File.exists?(favs_file)
@@ -1392,7 +1397,7 @@ module Msf
               module_name = mod.strip
               fav_modules[module_name] = framework.modules[module_name]
             end
-            show_module_set("Favorites", fav_modules, regex, minrank, opts)
+            show_module_metadata('Favorites', fav_modules)
           end
 
           def show_missing(mod) # :nodoc:
@@ -1416,10 +1421,6 @@ module Msf
                 print("\nPayload options (#{mod.datastore['PAYLOAD']}):\n\n#{p_opt}\n") if (p_opt and p_opt.length > 0)
               end
             end
-          end
-
-          def show_evasion(regex = nil, minrank = nil, opts = nil) # :nodoc:
-            show_module_set('evasion', framework.evasion, regex, minrank, opts)
           end
 
           def show_global_options
@@ -1527,55 +1528,64 @@ module Msf
             print(tbl.to_s)
           end
 
-          def show_module_set(type, module_set, regex = nil, minrank = nil, opts = nil) # :nodoc:
-            count = -1
+          # @param [table_name] used to name table
+          # @param [module_filter] this will either be a modules fullname, or it will be an Array(show payloads/encoders)
+          # or a Hash(show favorites) containing fullname
+          # @param [compatible_mod] handles logic for if there is an active module when the
+          # `show` command is run
+          #
+          # Handles the filtering of modules that will be generated into a table
+          def show_module_metadata(table_name, module_filter)
+            count = 0
+            tbl = generate_module_table(table_name)
 
-            tbl = generate_module_table(type)
+            if module_filter.is_a?(Array) || module_filter.is_a?(Hash)
+              module_filter.sort.each do |_mod_fullname, mod_obj|
+                mod = nil
 
-            module_set.sort.each { |refname, mod|
-              o = nil
-
-              begin
-                o = mod.new
-              rescue ::Exception
-              end
-              next if not o
-
-              # handle a search string, search deep
-              if (
-              not regex or
-                o.name.match(regex) or
-                o.description.match(regex) or
-                o.refname.match(regex) or
-                o.references.map{|x| [x.ctx_id + '-' + x.ctx_val, x.to_s]}.join(' ').match(regex) or
-                o.author.to_s.match(regex)
-              )
-                if (not minrank or minrank <= o.rank)
-                  show = true
-                  if opts
-                    mod_opt_keys = o.options.keys.map { |x| x.downcase }
-
-                    opts.each do |opt,val|
-                      if !mod_opt_keys.include?(opt.downcase) || (val != nil && o.datastore[opt] != val)
-                        show = false
-                      end
-                    end
-                  end
-                  if (opts == nil or show == true)
-                    tbl << [
-                      count += 1,
-                      refname,
-                      o.disclosure_date.nil? ? "" : o.disclosure_date.strftime("%Y-%m-%d"),
-                      o.rank,
-                      o.has_check? ? 'Yes' : 'No',
-                      o.name
-                    ]
-                  end
+                begin
+                  mod = mod_obj.new
+                rescue ::Exception
                 end
-              end
-            }
+                next unless mod
 
+                count += 1
+                tbl << add_record(mod, count, true)
+              end
+            else
+              results = Msf::Modules::Metadata::Cache.instance.find(
+                'type' => [[module_filter], []]
+              )
+              # Loop over each module and gather data
+              results.each do |mod, _value|
+                count += 1
+                tbl << add_record(mod, count, false)
+              end
+            end
             print(tbl.to_s)
+          end
+
+          # @param [mod] current module being passed in
+          # @param [count] passes the count for each record
+          # @param [compatible_mod] handles logic for if there is an active module when the
+          # `show` command is run
+          #
+          # Adds a record for a table, also handle logic for whether the module is currently
+          # handling compatible payloads/encoders
+          def add_record(mod, count, compatible_mod)
+            if compatible_mod
+              check = mod.has_check? ? 'Yes' : 'No'
+            else
+              check = mod.check ? 'Yes' : 'No'
+            end
+            [
+              count,
+              mod.fullname,
+              mod.disclosure_date.nil? ? '' : mod.disclosure_date.strftime('%Y-%m-%d'),
+              mod.rank,
+              check,
+              mod.name
+            ]
           end
 
           def generate_module_table(type, search_terms = [], row_filter = nil) # :nodoc:


### PR DESCRIPTION
This PR addresses the slow load times on the `show` command within msfconsole.

The changes I have added will now allow the `show` command to make use of the metasploit cache. 

Previously the `show` command was slow when returning bigger lists of results e.g. `show exploits` was taking ~13 seconds, whereas now it's under a second.

This change was applied to the following commands:
- `show encoders`
- `show nops`
- `show exploits`
- `show payloads`
- `show auxiliary`
- `show post`
- `show evasion`
- `show favorites`

## Performance stats
Time in seconds for each command to finish, using the new `time` command:
| Command |  Old method  |  New method  | 
|:-:|:-:|:-:|
|  `show encoders` with active module |  0.03 |  0.06 |   
|  `show payloads` with active module |  2.7 |  2.9 |
| `show encoders` |  0.02 |  0.04 |  
|  `show payloads` |  1.0 |  0.3 |   
|  `show exploits` |  13.8 |  0.9 |
|  `show auxiliary` |  3.2 |  0.4 |
|  `show post` |  1.9 |  0.14 |
|  `show evasion` |  0.05 |  0.03 |
|  `show favorites` |  0.02 |  0.03 |

## Before
![show_exploit_performance_master](https://user-images.githubusercontent.com/69522014/112139406-a1d9eb00-8bca-11eb-9a24-73f25b7f2e39.gif)
## After 
![show_exploit_performance](https://user-images.githubusercontent.com/69522014/112138834-e31dcb00-8bc9-11eb-97d9-7754101adc79.gif)

### Side note
My IDE kept removing two lines where there was a line with indentation but no code, couldn't seem to get it to not edit those lines ¯\\\_(ツ)_/¯

## Verification

- [ ] Start `msfconsole`
- [ ] ` use exploit/windows/smb/ms17_010_eternalblue`
- [ ] Go through the list of commands above and test performance and functionality
- [ ] **Verify** the output content is the same as what was being returned on `master`
- [ ] **Verify** the performance of the commands output is now faster.