### PR TITLE
Add time command

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/developer.rb
+++ b/lib/msf/ui/console/command_dispatcher/developer.rb
@@ -23,7 +23,8 @@ class Msf::Ui::Console::CommandDispatcher::Developer
       'pry'        => 'Open the Pry debugger on the current module or Framework',
       'edit'       => 'Edit the current module or a file with the preferred editor',
       'reload_lib' => 'Reload Ruby library files from specified paths',
-      'log'        => 'Display framework.log paged to the end if possible'
+      'log'        => 'Display framework.log paged to the end if possible',
+      'time'       => 'Time how long it takes to run a particular command'
     }
   end
 
@@ -307,4 +308,29 @@ class Msf::Ui::Console::CommandDispatcher::Developer
     end
   end
 
+  #
+  # Time how long in seconds a command takes to execute
+  #
+  def cmd_time(*args)
+    start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    command = args.join(' ')
+    driver.run_single(command)
+  ensure
+    end_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    elapsed_time = end_time - start_time
+    print_good("Command #{command.inspect} completed in #{elapsed_time} seconds")
+  end
+
+  def cmd_time_help
+    print_line 'Usage: time [command]'
+    print_line
+    print_line 'Time how long a command takes to execute in seconds'
+    print_line
+    print_line '   Usage:'
+    print_line '      * time db_import ./db_import.html'
+    print_line '      * time show exploits'
+    print_line '      * time reload_all'
+    print_line '      * time missing_command'
+    print_line
+  end
 end


### PR DESCRIPTION
### Overview

Adds a new time command which will identify performance pain points for our users

![image](https://user-images.githubusercontent.com/60357436/112164044-7ca6a600-8be5-11eb-9f30-ca39014cd956.png)

This requirement has come up a few times in the past, and would have been useful in a few scenarios such as these issues/pull requests:
- https://github.com/rapid7/metasploit-framework/pull/14937 - Improves performance of show command 
- https://github.com/rapid7/metasploit-framework/pull/13041 - Cut unknown command handling time in half
- https://github.com/rapid7/metasploit-framework/issues/14763 - Why is db_import so slow?
- https://github.com/rapid7/metasploit-framework/pull/13998 - Always use module cache for searching

### Example

With this change in place, it's now immediately clear the time difference of handling missing commands for end-users before the scoundrels hacked it down lower. Example before:

![image](https://user-images.githubusercontent.com/60357436/112164361-bb3c6080-8be5-11eb-89d4-d14eb10c6457.png)

Example after:

![image](https://user-images.githubusercontent.com/60357436/112177922-4111d900-8bf1-11eb-81d6-ba0c33691e36.png)

it's now a lot more clear the time differences and benefit of these performance improvements to our users 😄 

## Verification

My verification steps included:

- [x] Start `msfconsole`
- [x] Verify some of the examples work `time show exploits`, `time missing_command` etc. I think there's potentially edge cases here, but I couldn't find any when testing
- [x] I also verified that `Process.clock_gettime(Process::CLOCK_MONOTONIC)` was available on mac + windows

The only concern is potential shadowing of the normal shell reserved `time` being unavailable as being inconvenient in some scenarios