### PR TITLE
Force smb_relay module to use the Rex SMB client over ruby_smb

### DIFF
--- a/modules/exploits/windows/smb/smb_relay.rb
+++ b/modules/exploits/windows/smb/smb_relay.rb
@@ -453,7 +453,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return
     end
 
-    rclient = Rex::Proto::SMB::SimpleClient.new(rsock, rport == 445 ? true : false)
+    rclient = Rex::Proto::SMB::SimpleClient.new(rsock, rport == 445 ? true : false, backend: :rex)
 
     begin
       rclient.login_split_start_ntlm1(smb[:nbsrc])
@@ -505,7 +505,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return
     end
 
-    rclient = Rex::Proto::SMB::SimpleClient.new(rsock, true)
+    rclient = Rex::Proto::SMB::SimpleClient.new(rsock, true, backend: :rex)
 
     rclient.client.negotiate(true) # extended security true
 


### PR DESCRIPTION
Resolves #14903

This module was attempting to use `Rex::Proto::SMB::Client` features but at some point was inadvertantly switched over to using `ruby_smb`. This PR just forces the use of the Rex client for this module

# Verification
- [x] Run the module (make sure to set the `SMBHOST` option)
- [x] Use impackets `smbclient.py` to connect 
- [x] Should see the module relaying requests to the server
