### PR TITLE
Fix fail_with usage in exploit/windows/http/advantech_iview_unauth_rce

### DIFF
--- a/modules/exploits/windows/http/advantech_iview_unauth_rce.rb
+++ b/modules/exploits/windows/http/advantech_iview_unauth_rce.rb
@@ -240,7 +240,8 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     unless res && res.code == 200 && (config = res.get_json_document.first)
-      fail_with(Failure::NotFound, 'Failed to retrieve restored config')
+      print_error('Failed to retrieve restored config')
+      return
     end
 
     if config['EXPORTPATH'] == 'webapps\\iView3\\'

--- a/modules/exploits/windows/http/advantech_iview_unauth_rce.rb
+++ b/modules/exploits/windows/http/advantech_iview_unauth_rce.rb
@@ -244,7 +244,8 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     if config['EXPORTPATH'] == 'webapps\\iView3\\'
-      fail_with(Failure::UnexpectedReply, 'Failed to restore config')
+      print_warning('Failed to restore config')
+      return
     end
 
     print_good('Successfully restored config')

--- a/modules/exploits/windows/http/sharepoint_ssi_viewstate.rb
+++ b/modules/exploits/windows/http/sharepoint_ssi_viewstate.rb
@@ -254,7 +254,8 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     unless res
-      fail_with(Failure::Unreachable, "Target did not respond to #{__method__}")
+      print_error("Target did not respond to #{__method__}")
+      return
     end
 
     unless res.code == 204


### PR DESCRIPTION
Brain fart. Should be `print_warning` so as not to fail the session.

https://github.com/rapid7/metasploit-framework/blob/75e8fef7de24e38c20e81be584c0f939aa712e9d/modules/exploits/windows/http/sharepoint_ssi_viewstate.rb#L242-L243

https://github.com/rapid7/metasploit-framework/blob/75e8fef7de24e38c20e81be584c0f939aa712e9d/modules/exploits/windows/http/sharepoint_ssi_viewstate.rb#L260-L263

Fixes #14920. And #14265.