### PR TITLE
Fix switching between pry and irb

### DIFF
--- a/lib/rex/ui/text/irb_shell.rb
+++ b/lib/rex/ui/text/irb_shell.rb
@@ -24,7 +24,7 @@ class IrbShell
     # Initialize IRB by setting up its internal configuration hash and
     # stuff.
     if (@@IrbInitialized == false)
-      load('irb.rb')
+      require 'irb'
 
       IRB.setup(nil)
       IRB.conf[:PROMPT_MODE]  = :SIMPLE


### PR DESCRIPTION
Closes https://github.com/rapid7/metasploit-framework/issues/14948

## Verification

Open up msfconsole, and swap between both tools. Ensure there are no exceptions:
```
msfconsole
irb
exit
pry
exit
```