### PR TITLE
Update metasploit_payloads-mettle gem to 1.0.8

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,7 +30,7 @@ PATH
       metasploit-model
       metasploit-payloads (= 2.0.39)
       metasploit_data_models
-      metasploit_payloads-mettle (= 1.0.7)
+      metasploit_payloads-mettle (= 1.0.8)
       mqtt
       msgpack
       nessus_rest
@@ -233,7 +233,7 @@ GEM
       railties (~> 5.2.2)
       recog (~> 2.0)
       webrick
-    metasploit_payloads-mettle (1.0.7)
+    metasploit_payloads-mettle (1.0.8)
     method_source (1.0.0)
     mini_portile2 (2.5.0)
     minitest (5.14.4)

--- a/LICENSE_GEMS
+++ b/LICENSE_GEMS
@@ -64,7 +64,7 @@ metasploit-framework, 6.0.38, "New BSD"
 metasploit-model, 3.1.3, "New BSD"
 metasploit-payloads, 2.0.39, "3-clause (or ""modified"") BSD"
 metasploit_data_models, 4.1.2, "New BSD"
-metasploit_payloads-mettle, 1.0.7, "3-clause (or ""modified"") BSD"
+metasploit_payloads-mettle, 1.0.8, "3-clause (or ""modified"") BSD"
 method_source, 1.0.0, MIT
 mini_portile2, 2.5.0, MIT
 minitest, 5.14.4, MIT

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -72,7 +72,7 @@ Gem::Specification.new do |spec|
   # Needed for Meterpreter
   spec.add_runtime_dependency 'metasploit-payloads', '2.0.39'
   # Needed for the next-generation POSIX Meterpreter
-  spec.add_runtime_dependency 'metasploit_payloads-mettle', '1.0.7'
+  spec.add_runtime_dependency 'metasploit_payloads-mettle', '1.0.8'
   # Needed by msfgui and other rpc components
   spec.add_runtime_dependency 'msgpack'
   # get list of network interfaces, like eth* from OS.

--- a/modules/payloads/singles/apple_ios/aarch64/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/apple_ios/aarch64/meterpreter_reverse_http.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 777632
+  CachedSize = 777780
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/apple_ios/aarch64/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/apple_ios/aarch64/meterpreter_reverse_https.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 777632
+  CachedSize = 777780
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/apple_ios/aarch64/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/apple_ios/aarch64/meterpreter_reverse_tcp.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 777632
+  CachedSize = 777780
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/apple_ios/armle/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/apple_ios/armle/meterpreter_reverse_http.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 624704
+  CachedSize = 641296
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/apple_ios/armle/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/apple_ios/armle/meterpreter_reverse_https.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 624704
+  CachedSize = 641296
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/apple_ios/armle/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/apple_ios/armle/meterpreter_reverse_tcp.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 624704
+  CachedSize = 641296
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/aarch64/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/aarch64/meterpreter_reverse_http.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 1092000
+  CachedSize = 1093208
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/aarch64/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/aarch64/meterpreter_reverse_https.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 1092000
+  CachedSize = 1093208
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/aarch64/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/aarch64/meterpreter_reverse_tcp.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 1092000
+  CachedSize = 1093208
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/armbe/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/armbe/meterpreter_reverse_http.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 1023324
+  CachedSize = 1025040
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/armbe/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/armbe/meterpreter_reverse_https.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 1023324
+  CachedSize = 1025040
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/armbe/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/armbe/meterpreter_reverse_tcp.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 1023324
+  CachedSize = 1025040
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/armle/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/armle/meterpreter_reverse_http.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 1023324
+  CachedSize = 1025044
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/armle/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/armle/meterpreter_reverse_https.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 1023324
+  CachedSize = 1025044
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/armle/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/armle/meterpreter_reverse_tcp.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 1023324
+  CachedSize = 1025044
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/mips64/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/mips64/meterpreter_reverse_http.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 1569464
+  CachedSize = 1572984
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/mips64/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/mips64/meterpreter_reverse_https.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 1569464
+  CachedSize = 1572984
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/mips64/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/mips64/meterpreter_reverse_tcp.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 1569464
+  CachedSize = 1572984
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/mipsbe/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/mipsbe/meterpreter_reverse_http.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 1461420
+  CachedSize = 1463956
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/mipsbe/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/mipsbe/meterpreter_reverse_https.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 1461420
+  CachedSize = 1463956
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/mipsbe/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/mipsbe/meterpreter_reverse_tcp.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 1461420
+  CachedSize = 1463956
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/mipsle/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/mipsle/meterpreter_reverse_http.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 1464324
+  CachedSize = 1466444
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/mipsle/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/mipsle/meterpreter_reverse_https.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 1464324
+  CachedSize = 1466444
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/mipsle/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/mipsle/meterpreter_reverse_tcp.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 1464324
+  CachedSize = 1466444
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/ppc/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/ppc/meterpreter_reverse_http.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 1210840
+  CachedSize = 1210956
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/ppc/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/ppc/meterpreter_reverse_https.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 1210840
+  CachedSize = 1210956
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/ppc/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/ppc/meterpreter_reverse_tcp.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 1210840
+  CachedSize = 1210956
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/ppc64le/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/ppc64le/meterpreter_reverse_http.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 1169208
+  CachedSize = 1169352
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/ppc64le/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/ppc64le/meterpreter_reverse_https.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 1169208
+  CachedSize = 1169352
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/ppc64le/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/ppc64le/meterpreter_reverse_tcp.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 1169208
+  CachedSize = 1169352
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/ppce500v2/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/ppce500v2/meterpreter_reverse_http.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 1163520
+  CachedSize = 1163636
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/ppce500v2/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/ppce500v2/meterpreter_reverse_https.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 1163520
+  CachedSize = 1163636
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/ppce500v2/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/ppce500v2/meterpreter_reverse_tcp.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 1163520
+  CachedSize = 1163636
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/x64/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/x64/meterpreter_reverse_http.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 1032344
+  CachedSize = 1036592
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/x64/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/x64/meterpreter_reverse_https.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 1032344
+  CachedSize = 1036592
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/x64/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/x64/meterpreter_reverse_tcp.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 1032344
+  CachedSize = 1036592
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/x86/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/x86/meterpreter_reverse_http.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 1101336
+  CachedSize = 1101452
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/x86/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/x86/meterpreter_reverse_https.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 1101336
+  CachedSize = 1101452
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/x86/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/x86/meterpreter_reverse_tcp.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 1101336
+  CachedSize = 1101452
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/zarch/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/zarch/meterpreter_reverse_http.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 1226520
+  CachedSize = 1226672
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/zarch/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/zarch/meterpreter_reverse_https.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 1226520
+  CachedSize = 1226672
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/linux/zarch/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/zarch/meterpreter_reverse_tcp.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 1226520
+  CachedSize = 1226672
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/osx/x64/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/osx/x64/meterpreter_reverse_http.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 799908
+  CachedSize = 804156
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/osx/x64/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/osx/x64/meterpreter_reverse_https.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 799908
+  CachedSize = 804156
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions

--- a/modules/payloads/singles/osx/x64/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/osx/x64/meterpreter_reverse_tcp.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 799908
+  CachedSize = 804156
 
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions


### PR DESCRIPTION
This PR bumps framework to use mettle payloads gem 1.0.8 (previously 1.0.7), pulling in the following changes:

* https://github.com/rapid7/mettle/pull/211

## Verification

List the steps needed to make sure this thing works

- [x] Let automated tests pass
- [x] Manual sanity check (`meterpreter > search -f *.wav`)
