### PR TITLE
Fix #14940, Fix #14338, fix dir C:\ with nil ftype

### DIFF
--- a/lib/rex/post/file_stat.rb
+++ b/lib/rex/post/file_stat.rb
@@ -132,7 +132,7 @@ class FileStat
   end
 
   def ftype
-    return @@ftypes[(mode & 0170000) >> 13].dup
+    return @@ftypes[(mode & 0170000) >> 13].dup || ''
   end
 
   #

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
@@ -637,7 +637,7 @@ class Console::CommandDispatcher::Stdapi::Fs
       row = [
           ffstat ? ffstat.prettymode : '',
           ffstat ? ffstat.size       : '',
-          ffstat ? ffstat.ftype[0,3] : '',
+          ffstat && ffstat.ftype ? ffstat.ftype[0,3] : '',
           ffstat ? ffstat.mtime      : '',
           fname.force_encoding('UTF-8')
         ]

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
@@ -637,7 +637,7 @@ class Console::CommandDispatcher::Stdapi::Fs
       row = [
           ffstat ? ffstat.prettymode : '',
           ffstat ? ffstat.size       : '',
-          ffstat && ffstat.ftype ? ffstat.ftype[0,3] : '',
+          ffstat ? ffstat.ftype[0,3] : '',
           ffstat ? ffstat.mtime      : '',
           fname.force_encoding('UTF-8')
         ]


### PR DESCRIPTION
This is a speculative fix for https://github.com/rapid7/metasploit-framework/issues/14940 and https://github.com/rapid7/metasploit-framework/issues/14338

I was unable to reproduce the issue, but given the stack trace it seems the ftype was nil, causing the crash.
@friedrico then confirmed it did indeed fix the issue.

## Verification

List the steps needed to make sure this thing works

- [ ] Look at https://github.com/rapid7/metasploit-framework/issues/14940 and https://github.com/rapid7/metasploit-framework/issues/14338
- [ ] **Verify** this change would fix that issue
- [ ] ¯\\\_(ツ)\_/¯
- [ ] Profit