### PR TITLE
Fixes nexpose_connect login failure when user or password contains an @ symbol

### DIFF
--- a/plugins/nexpose.rb
+++ b/plugins/nexpose.rb
@@ -117,7 +117,7 @@ class Plugin::Nexpose < Msf::Plugin
 
       case args.length
       when 1,2
-        cred,targ = args[0].split('@', 2)
+        cred,_split,targ = args[0].rpartition('@')
         @user,@pass = cred.split(':', 2)
         targ ||= '127.0.0.1:3780'
         @host,@port = targ.split(':', 2)


### PR DESCRIPTION
This PR resolves #14865.

Previously if a user had an `@` symbol present in their username or password, it would fail to login. This was down to the previous code calling `.split` on the string and this resulted in the string being split at the `@` within the username/password.

### Using `.split` method:
```Ruby
[9] pry(#<Msf::Plugin::Nexpose::NexposeCommandDispatcher>)> args
=> ["admin:p@ssword@localhost:8000", "ok"]
[10] pry(#<Msf::Plugin::Nexpose::NexposeCommandDispatcher>)> cred,targ = args[0].split('@', 2)
=> ["admin:p", "ssword@localhost:8000"]
[11] pry(#<Msf::Plugin::Nexpose::NexposeCommandDispatcher>)> targ
=> "ssword@localhost:8000"
[12] pry(#<Msf::Plugin::Nexpose::NexposeCommandDispatcher>)> @user
=> "admin"
[13] pry(#<Msf::Plugin::Nexpose::NexposeCommandDispatcher>)> @pass
=> "p"
[14] pry(#<Msf::Plugin::Nexpose::NexposeCommandDispatcher>)> @host
=> "ssword@localhost"
[15] pry(#<Msf::Plugin::Nexpose::NexposeCommandDispatcher>)> @port
=> "8000"
```

This fixes now uses `rpartition` instead of split. This results in the right most `@` symbol being where the string is split. The right most `@` symbol should always be the last occurrence in our string, just before the target IP address.

`rpartition` [docs](https://apidock.com/ruby/String/rpartition).

### Using `.rpartition` method:
Added a small code change. Added an additional variable called `_split`, that will be used to just take the `@` symbol out of the equation. 

Code change:
```Ruby
cred,_split,targ = args[0].rpartition('@')
```
Output:
```Ruby
[3] pry(#<Msf::Plugin::Nexpose::NexposeCommandDispatcher>)> args
=> ["admin:p@ssword@localhost:8000", "ok"]
[4] pry(#<Msf::Plugin::Nexpose::NexposeCommandDispatcher>)> cred,_split,targ = args[0].rpartition('@')
=> ["admin:p@ssword", "@", "localhost:8000"]
[5] pry(#<Msf::Plugin::Nexpose::NexposeCommandDispatcher>)> cred
=> "admin:p@ssword"
[6] pry(#<Msf::Plugin::Nexpose::NexposeCommandDispatcher>)> _split
=> "@"
[7] pry(#<Msf::Plugin::Nexpose::NexposeCommandDispatcher>)> targ
=> "localhost:8000"
[8] pry(#<Msf::Plugin::Nexpose::NexposeCommandDispatcher>)> @user
=> "admin"
[9] pry(#<Msf::Plugin::Nexpose::NexposeCommandDispatcher>)> @pass
=> "p@ssword"
[10] pry(#<Msf::Plugin::Nexpose::NexposeCommandDispatcher>)> @host
=> "localhost"
[11] pry(#<Msf::Plugin::Nexpose::NexposeCommandDispatcher>)> @port
=> "8000"
```

# Note 
This has yet to be tested on a Nexpose server, hence why it is in draft. This fix has been tested by replicating @adfoster-r7's [comment](https://github.com/rapid7/metasploit-framework/pull/14962#issuecomment-809312516) below.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] Get a listener up and running in a separate tab `ncat -lvnp 8000 --ssl`
- [ ] Run `load nexpose`
- [ ] **Verify** the ncat response is returning the correct values 
e.g. output:
```Bash
<LoginRequest password='p@ssword123' sync-id='0' user-id='admin'></LoginRequest>
```