### PR TITLE
Fix #14974, fix uninitialized constant in cve_2020_1054_drawiconex_lpe

### DIFF
--- a/modules/exploits/windows/local/cve_2020_1054_drawiconex_lpe.rb
+++ b/modules/exploits/windows/local/cve_2020_1054_drawiconex_lpe.rb
@@ -109,7 +109,7 @@ class MetasploitModule < Msf::Exploit::Local
       @oob_offset = 0x240
       return CheckCode::Appears
     else
-      return CheckCode::NotSupported
+      return CheckCode::Safe("No target for win32k.sys version #{build_num_gemversion}")
     end
   end
 


### PR DESCRIPTION
Fix for https://github.com/rapid7/metasploit-framework/issues/14974, reported by @DarkRed777
Thanks @bcoles!

## Verification

List the steps needed to make sure this thing works

- [ ] Get a `windows/x64/meterpreter/reverse_tcp` session on Windows 10
- [ ] `use exploit/windows/local/cve_2020_1054_drawiconex_lpe`
- [ ] `set SESSION -1`
- [ ] `run`
- [ ] **Verify** you don't get an exception

### Before
```
msf6 exploit(windows/local/cve_2020_1054_drawiconex_lpe) > run

[*] Started reverse TCP handler on 192.168.0.18:4444
[*] Executing automatic check (disable AutoCheck to override)
[-] Exploit failed: NameError uninitialized constant Msf::Exploit::CheckCode::NotSupported
[*] Exploit completed, but no session was created.
```

### After
```
msf6 exploit(windows/local/cve_2020_1054_drawiconex_lpe) > run

[*] Started reverse TCP handler on 192.168.0.18:4444
[*] Executing automatic check (disable AutoCheck to override)
[-] Exploit aborted due to failure: not-vulnerable: The target is not exploitable. No target for win32k.sys version 6.2.18362.1198 Enable ForceExploit to override check result.
[*] Exploit completed, but no session was created.
```
