### PR TITLE
Remove CmdStagerFlavor from a couple modules

### DIFF
--- a/modules/exploits/windows/http/plesk_mylittleadmin_viewstate.rb
+++ b/modules/exploits/windows/http/plesk_mylittleadmin_viewstate.rb
@@ -80,7 +80,6 @@ class MetasploitModule < Msf::Exploit::Remote
             {
               'Arch' => [ARCH_X86, ARCH_X64],
               'Type' => :win_dropper,
-              'CmdStagerFlavor' => %i[psh_invokewebrequest certutil vbs],
               'DefaultOptions' => {
                 'CMDSTAGER::FLAVOR' => :psh_invokewebrequest,
                 'PAYLOAD' => 'windows/x64/meterpreter/reverse_tcp'

--- a/modules/exploits/windows/http/sharepoint_ssi_viewstate.rb
+++ b/modules/exploits/windows/http/sharepoint_ssi_viewstate.rb
@@ -63,7 +63,6 @@ class MetasploitModule < Msf::Exploit::Remote
             {
               'Arch' => [ARCH_X86, ARCH_X64],
               'Type' => :win_dropper,
-              'CmdStagerFlavor' => %i[psh_invokewebrequest certutil vbs],
               'DefaultOptions' => {
                 'CMDSTAGER::FLAVOR' => :psh_invokewebrequest,
                 'PAYLOAD' => 'windows/x64/meterpreter_reverse_https'


### PR DESCRIPTION
Not strictly necessary. We need a better way to limit by platform.

```
msf6 exploit(windows/http/plesk_mylittleadmin_viewstate) > set target Windows\ Dropper
target => Windows Dropper
msf6 exploit(windows/http/plesk_mylittleadmin_viewstate) > set cmdstager::flavor
set cmdstager::flavor auto                  set cmdstager::flavor debug_asm             set cmdstager::flavor lwprequest            set cmdstager::flavor vbs
set cmdstager::flavor bourne                set cmdstager::flavor debug_write           set cmdstager::flavor printf                set cmdstager::flavor vbs_adodb
set cmdstager::flavor certutil              set cmdstager::flavor echo                  set cmdstager::flavor psh_invokewebrequest  set cmdstager::flavor wget
set cmdstager::flavor curl                  set cmdstager::flavor fetch                 set cmdstager::flavor tftp
msf6 exploit(windows/http/plesk_mylittleadmin_viewstate) > set cmdstager::flavor
cmdstager::flavor => psh_invokewebrequest
msf6 exploit(windows/http/plesk_mylittleadmin_viewstate) >
```

```
msf6 exploit(windows/http/sharepoint_ssi_viewstate) > set target Windows\ Dropper
target => Windows Dropper
msf6 exploit(windows/http/sharepoint_ssi_viewstate) > set cmdstager::flavor
set cmdstager::flavor auto                  set cmdstager::flavor debug_asm             set cmdstager::flavor lwprequest            set cmdstager::flavor vbs
set cmdstager::flavor bourne                set cmdstager::flavor debug_write           set cmdstager::flavor printf                set cmdstager::flavor vbs_adodb
set cmdstager::flavor certutil              set cmdstager::flavor echo                  set cmdstager::flavor psh_invokewebrequest  set cmdstager::flavor wget
set cmdstager::flavor curl                  set cmdstager::flavor fetch                 set cmdstager::flavor tftp
msf6 exploit(windows/http/sharepoint_ssi_viewstate) > set cmdstager::flavor
cmdstager::flavor => psh_invokewebrequest
msf6 exploit(windows/http/sharepoint_ssi_viewstate) >
```

Related to https://github.com/rapid7/metasploit-framework/pull/14971#discussion_r604486785, sort of. That was a badchars thing.

Fixes #13494 and #14265.