### PR TITLE
fix rails 5 bug for password cracker custom_wordlists

### DIFF
--- a/lib/metasploit/framework/password_crackers/wordlist.rb
+++ b/lib/metasploit/framework/password_crackers/wordlist.rb
@@ -64,7 +64,7 @@ module Metasploit
         #   @return [Mdm::Workspace] the workspace this cracker is for.
         attr_accessor :workspace
 
-        validates :custom_wordlist, :'Metasploit::Framework::File_path' => true, if: -> { 'custom_wordlist.present?' }
+        validates :custom_wordlist, :'Metasploit::Framework::File_path' => true, if: -> { custom_wordlist.present? }
 
         validates :mutate,
                   inclusion: { in: [true, false], message: "must be true or false"  }


### PR DESCRIPTION
fixes #14964 

This fixes a bug in the validation of `custom_wordlist` for password crackers according to @jmartin-r7 that was introduced in rails 5 upgrade.

## Current Behavior

If you don't include a `custom_wordlist` you get an icky crash.

```
msf6 auxiliary(analyze/crack_windows) > run

[+] john Version Detected: 1.9.0-jumbo-1 OMP
[*] Hashes Written out to /tmp/hashes_tmp20210401-69143-gz83yi
[-] Auxiliary failed: Metasploit::Framework::PasswordCracker::InvalidWordlist Custom wordlist is not a valid path to a regular file, Custom wordlist is not a valid path to a regular file, Custom wordlist is not a valid path to a regular file, Custom wordlist is not a valid path to a regular file, Custom wordlist is not a valid path to a regular file, Custom wordlist is not a valid path to a regular file, Custom wordlist is not a valid path to a regular file, Custom wordlist is not a valid path to a regular file, Custom wordlist is not a valid path to a regular file
[-] Call stack:
[-]   /metasploit-framework/lib/metasploit/framework/password_crackers/wordlist.rb:390:in `valid!'
[-]   /metasploit-framework/lib/metasploit/framework/password_crackers/wordlist.rb:376:in `to_file'
[-]   /metasploit-framework/lib/msf/core/auxiliary/password_cracker.rb:119:in `wordlist_file'
[-]   /metasploit-framework/modules/auxiliary/analyze/crack_windows.rb:202:in `run'
[*] Auxiliary module execution completed
```

## Post

it works.

```
[+] john Version Detected: 1.9.0-jumbo-1 OMP
[*] Hashes Written out to /tmp/hashes_tmp20210401-118520-1y8pz5f
[*] Wordlist file written out to /tmp/jtrtmp20210401-118520-68iyrt
[*] Checking lm hashes already cracked...
[*] Cracking lm hashes in single mode...
```