### PR TITLE
guard host search on rhost set

### DIFF
--- a/lib/msf/core/exploit/auto_target.rb
+++ b/lib/msf/core/exploit/auto_target.rb
@@ -49,7 +49,7 @@ module Msf
     # @return [Mdm:Host] the Host record if one exists
     # @return [nil] if no Host record is present, or the DB is not active
     def auto_target_host
-      return nil unless self.respond_to?(:rhost)
+      return nil unless self.respond_to?(:rhost) && rhost
       return nil unless framework.db.active
       host = framework.db.get_host({workspace:  self.workspace, address: rhost})
       return host


### PR DESCRIPTION
During module instantiation auto_target process is expected to account
for existing hosts if `rhost` is set, however just testing if the module
responds to `rhost` is not sufficent to guard the query, a value must also
have been set.

## Verification

List the steps needed to make sure this thing works

- [ ] Automation tests pass
