### PR TITLE
hashcat logic fixes for crackers

### DIFF
--- a/lib/msf/core/auxiliary/password_cracker.rb
+++ b/lib/msf/core/auxiliary/password_cracker.rb
@@ -90,10 +90,12 @@ module Auxiliary::PasswordCracker
     rescue Metasploit::Framework::PasswordCracker::PasswordCrackerNotFoundError => e
       fail_with(Msf::Module::Failure::BadConfig, e.message)
     end
-    if cracker.cracker == 'john' && (cracker.cracker_version.nil? || !cracker.cracker_version.include?('jumbo'))
+    # throw this to a local variable since it causes a shell out to pull the version
+    cracker_version = cracker.cracker_version
+    if cracker.cracker == 'john' && (cracker_version.nil? || !cracker_version.include?('jumbo'))
       fail_with(Msf::Module::Failure::BadConfig, 'John the Ripper JUMBO patch version required.  See https://github.com/magnumripper/JohnTheRipper')
     end
-    print_good("#{cracker.cracker} Version Detected: #{cracker.cracker_version}")
+    print_good("#{cracker.cracker} Version Detected: #{cracker_version}")
     cracker
   end
 

--- a/lib/msf/core/auxiliary/password_cracker.rb
+++ b/lib/msf/core/auxiliary/password_cracker.rb
@@ -90,11 +90,10 @@ module Auxiliary::PasswordCracker
     rescue Metasploit::Framework::PasswordCracker::PasswordCrackerNotFoundError => e
       fail_with(Msf::Module::Failure::BadConfig, e.message)
     end
-    cracker_version = cracker.cracker_version
-    if cracking_application == 'john' && cracker_version.nil? || !cracker_version.include?('jumbo')
+    if cracker.cracker == 'john' && (cracker.cracker_version.nil? || !cracker.cracker_version.include?('jumbo'))
       fail_with(Msf::Module::Failure::BadConfig, 'John the Ripper JUMBO patch version required.  See https://github.com/magnumripper/JohnTheRipper')
     end
-    print_good("#{cracking_application} Version Detected: #{cracker_version}")
+    print_good("#{cracker.cracker} Version Detected: #{cracker.cracker_version}")
     cracker
   end
 


### PR DESCRIPTION
This fixes a logic bug in the cracker libraries where hashcat wasn't able to be run.  It was throwing an error that the JTR jumbo patch wasn't installed, even though JTR wasn't the selected cracker.  It also cleans up a variable to use the object instead.

## pre

```
msf6 auxiliary(analyze/crack_windows) > set action hashcat
action => hashcat
msf6 auxiliary(analyze/crack_windows) > run

[-] Auxiliary aborted due to failure: bad-config: John the Ripper JUMBO patch version required.  See https://github.com/magnumripper/JohnTheRipper
[*] Auxiliary module execution completed
```

## post

```
msf6 auxiliary(analyze/crack_windows) > set action hashcat
action => hashcat
msf6 auxiliary(analyze/crack_windows) > run

[+] hashcat Version Detected: v6.1.1
[*] Hashes Written out to /tmp/hashes_tmp20210403-150192-15nkdvt
[*] Wordlist file written out to /tmp/jtrtmp20210403-150192-2ymh0

```