### PR TITLE
Change CVE reference from CVE Details to NVD

### DIFF
--- a/documentation/modules/exploit/linux/http/rconfig_ajaxarchivefiles_rce.md
+++ b/documentation/modules/exploit/linux/http/rconfig_ajaxarchivefiles_rce.md
@@ -69,8 +69,8 @@ id
 uid=48(apache) gid=48(apache) groups=48(apache)
 ```
 ## References
-1. <https://cvedetails.com/cve/CVE-2019-19509/>
-2. <https://cvedetails.com/cve/CVE-2020-10220/>
+1. <https://nvd.nist.gov/vuln/detail/CVE-2019-19509>
+2. <https://nvd.nist.gov/vuln/detail/CVE-2020-10220>
 3. <https://www.exploit-db.com/exploits/47982>
 4. <https://www.exploit-db.com/exploits/48208>
 5. <https://github.com/v1k1ngfr/exploits-rconfig/blob/master/rconfig_CVE-2019-19509.py>

--- a/documentation/modules/exploit/windows/misc/crosschex_device_bof.md
+++ b/documentation/modules/exploit/windows/misc/crosschex_device_bof.md
@@ -66,6 +66,6 @@ Listing: C:\Program Files\Anviz\CrossChex Standard
 
 ## References
 
-1. <https://cvedetails.com/cve/CVE-2019-12518>
+1. <https://nvd.nist.gov/vuln/detail/CVE-2019-12518>
 2. <https://www.0x90.zone/multiple/reverse/2019/11/28/Anviz-pwn.html>
 3. <https://www.exploit-db.com/exploits/47734>

--- a/lib/msf/core/module/reference.rb
+++ b/lib/msf/core/module/reference.rb
@@ -114,8 +114,6 @@ class Msf::Module::SiteReference < Msf::Module::Reference
       self.site = "https://wpscan.com/vulnerability/#{in_ctx_val}"
     elsif in_ctx_id == 'PACKETSTORM'
       self.site = "https://packetstormsecurity.com/files/#{in_ctx_val}"
-    elsif in_ctx_id == 'AKB'
-      self.site = "https://attackerkb.com/assessments/#{in_ctx_val}"
     elsif in_ctx_id == 'URL'
       self.site = in_ctx_val.to_s
     elsif in_ctx_id == 'LOGO'

--- a/lib/msf/core/module/reference.rb
+++ b/lib/msf/core/module/reference.rb
@@ -95,7 +95,7 @@ class Msf::Module::SiteReference < Msf::Module::Reference
     self.ctx_val = in_ctx_val
 
     if in_ctx_id == 'CVE'
-      self.site = "https://cvedetails.com/cve/CVE-#{in_ctx_val}/"
+      self.site = "https://nvd.nist.gov/vuln/detail/CVE-#{in_ctx_val}"
     elsif in_ctx_id == 'CWE'
       self.site = "https://cwe.mitre.org/data/definitions/#{in_ctx_val}.html"
     elsif in_ctx_id == 'BID'
@@ -114,6 +114,8 @@ class Msf::Module::SiteReference < Msf::Module::Reference
       self.site = "https://wpscan.com/vulnerability/#{in_ctx_val}"
     elsif in_ctx_id == 'PACKETSTORM'
       self.site = "https://packetstormsecurity.com/files/#{in_ctx_val}"
+    elsif in_ctx_id == 'AKB'
+      self.site = "https://attackerkb.com/assessments/#{in_ctx_val}"
     elsif in_ctx_id == 'URL'
       self.site = in_ctx_val.to_s
     elsif in_ctx_id == 'LOGO'

--- a/modules/exploits/linux/http/f5_icontrol_rest_ssrf_rce.rb
+++ b/modules/exploits/linux/http/f5_icontrol_rest_ssrf_rce.rb
@@ -44,8 +44,8 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'References' => [
           ['CVE', '2021-22986'],
+          ['AKB', 'f6b19d24-b24e-4abd-98cf-2988d7424311'],
           ['URL', 'https://support.f5.com/csp/article/K03009991'],
-          ['URL', 'https://attackerkb.com/assessments/f6b19d24-b24e-4abd-98cf-2988d7424311'],
           ['URL', 'https://research.nccgroup.com/2021/03/18/rift-detection-capabilities-for-recent-f5-big-ip-big-iq-icontrol-rest-api-vulnerabilities-cve-2021-22986/']
           # https://clouddocs.f5.com/products/big-iq/mgmt-api/v7.0.0/ApiReferences/bigiq_public_api_ref/r_auth_login.html
         ],

--- a/modules/exploits/linux/http/f5_icontrol_rest_ssrf_rce.rb
+++ b/modules/exploits/linux/http/f5_icontrol_rest_ssrf_rce.rb
@@ -44,8 +44,8 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'References' => [
           ['CVE', '2021-22986'],
-          ['AKB', 'f6b19d24-b24e-4abd-98cf-2988d7424311'],
           ['URL', 'https://support.f5.com/csp/article/K03009991'],
+          ['URL', 'https://attackerkb.com/assessments/f6b19d24-b24e-4abd-98cf-2988d7424311'],
           ['URL', 'https://research.nccgroup.com/2021/03/18/rift-detection-capabilities-for-recent-f5-big-ip-big-iq-icontrol-rest-api-vulnerabilities-cve-2021-22986/']
           # https://clouddocs.f5.com/products/big-iq/mgmt-api/v7.0.0/ApiReferences/bigiq_public_api_ref/r_auth_login.html
         ],

--- a/modules/exploits/windows/browser/ms05_054_onload.rb
+++ b/modules/exploits/windows/browser/ms05_054_onload.rb
@@ -35,8 +35,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ['MSB', 'MS05-054'],
           ['CVE', '2005-1790'],
           ['OSVDB', '17094'],
-          ['BID', '13799'],
-          ['URL', 'http://www.cvedetails.com/cve/CVE-2005-1790'],
+          ['BID', '13799']
         ],
       'DefaultOptions' =>
         {

--- a/tools/modules/module_reference.rb
+++ b/tools/modules/module_reference.rb
@@ -37,7 +37,6 @@ def types
     'ZDI'         => 'http://www.zerodayinitiative.com/advisories/ZDI-#{in_ctx_val}',
     'WPVDB'       => 'https://wpscan.com/vulnerability/#{in_ctx_val}',
     'PACKETSTORM' => 'https://packetstormsecurity.com/files/#{in_ctx_val}',
-    'AKB'         => 'https://attackerkb.com/assessments/#{in_ctx_val}',
     'URL'         => '#{in_ctx_val}'
   }
 end

--- a/tools/modules/module_reference.rb
+++ b/tools/modules/module_reference.rb
@@ -28,7 +28,7 @@ require 'uri'
 def types
   {
     'ALL'         => '',
-    'CVE'         => 'http://cvedetails.com/cve/#{in_ctx_val}/',
+    'CVE'         => 'https://nvd.nist.gov/vuln/detail/CVE-#{in_ctx_val}',
     'CWE'         => 'http://cwe.mitre.org/data/definitions/#{in_ctx_val}.html',
     'BID'         => 'http://www.securityfocus.com/bid/#{in_ctx_val}',
     'MSB'         => 'http://technet.microsoft.com/en-us/security/bulletin/#{in_ctx_val}',
@@ -37,6 +37,7 @@ def types
     'ZDI'         => 'http://www.zerodayinitiative.com/advisories/ZDI-#{in_ctx_val}',
     'WPVDB'       => 'https://wpscan.com/vulnerability/#{in_ctx_val}',
     'PACKETSTORM' => 'https://packetstormsecurity.com/files/#{in_ctx_val}',
+    'AKB'         => 'https://attackerkb.com/assessments/#{in_ctx_val}',
     'URL'         => '#{in_ctx_val}'
   }
 end


### PR DESCRIPTION
Changing the `CVE` reference to [NVD](https://nvd.nist.gov/) has been a long time coming, since [CVE Details](https://www.cvedetails.com/) is antiquated and no longer tracks Metasploit modules. Please check for any Pro side effects.

**ETA: It's worse than I thought: CVE Details appears to be defunct. [It hasn't tracked CVEs since 2019.](https://www.cvedetails.com/vulnerability-list/)**

```
msf6 exploit(linux/http/f5_icontrol_rest_ssrf_rce) > grep -A 4 ^References: info
References:
  https://nvd.nist.gov/vuln/detail/CVE-2021-22986
  https://support.f5.com/csp/article/K03009991
  https://attackerkb.com/assessments/f6b19d24-b24e-4abd-98cf-2988d7424311
  https://research.nccgroup.com/2021/03/18/rift-detection-capabilities-for-recent-f5-big-ip-big-iq-icontrol-rest-api-vulnerabilities-cve-2021-22986/
msf6 exploit(linux/http/f5_icontrol_rest_ssrf_rce) >
```

~The new `AKB` reference is limited to assessments at this time, but you can trick it into referencing a [Rapid7 analysis](https://attackerkb.com/assessments/ff98621a-00e4-4ffc-8c5b-058fcdf21143#rapid7-analysis) by appending the URI fragment.~ I removed the new `AKB` reference. I'm not sure it adds enough value due to the URL format.