### PR TITLE
remove `which` command in binary_exists? method

### DIFF
--- a/lib/msf/base/sessions/command_shell.rb
+++ b/lib/msf/base/sessions/command_shell.rb
@@ -312,18 +312,17 @@ class CommandShell
   end
 
   #
-  # Check if there is a binary in PATH env
+  # Returns path of a binary in PATH env.
   #
   def binary_exists(binary)
     print_status("Trying to find binary(#{binary}) on target machine")
-    binary_path = shell_command_token("command -v \"#{binary}\" || echo 'false'")
-    if binary_path.eql?("false")
+    binary_path = shell_command_token("command -v '#{binary}' || echo 'false'")
+    if binary_path.to_s.include?('false')
       print_error("#{binary} not found")
       return nil
-    else
+    end
       print_status("Found #{binary} at #{binary_path}")
       return binary_path
-    end
   end
 
   #

--- a/lib/msf/base/sessions/command_shell.rb
+++ b/lib/msf/base/sessions/command_shell.rb
@@ -321,7 +321,7 @@ class CommandShell
       print_error("#{binary} not found")
       return nil
     end
-    binary_path=binary_path.split[0].chomp
+    binary_path=binary_path.split("\n")[0].chomp
     print_status("Found #{binary} at #{binary_path}")
     return binary_path
   end

--- a/lib/msf/base/sessions/command_shell.rb
+++ b/lib/msf/base/sessions/command_shell.rb
@@ -316,9 +316,9 @@ class CommandShell
   #
   def binary_exists(binary)
     print_status("Trying to find binary(#{binary}) on target machine")
-    binary_path = shell_command_token("which #{binary}").to_s.strip
-    if binary_path.eql?("#{binary} not found") || binary_path == ""
-      print_error(binary_path)
+    binary_path = shell_command_token("command -v \"#{binary}\" || echo 'false'")
+    if binary_path.eql?("false")
+      print_error("#{binary} not found")
       return nil
     else
       print_status("Found #{binary} at #{binary_path}")

--- a/lib/msf/base/sessions/command_shell.rb
+++ b/lib/msf/base/sessions/command_shell.rb
@@ -316,11 +316,12 @@ class CommandShell
   #
   def binary_exists(binary)
     print_status("Trying to find binary(#{binary}) on target machine")
-    binary_path = shell_command_token("command -v '#{binary}' || echo 'false'")
-    if binary_path.to_s.include?('false')
+    binary_path = shell_command_token("command -v '#{binary}' && echo true")
+    if binary_path.eql?("")
       print_error("#{binary} not found")
       return nil
     end
+    binary_path=binary_path.split[0].chomp
     print_status("Found #{binary} at #{binary_path}")
     return binary_path
   end

--- a/lib/msf/base/sessions/command_shell.rb
+++ b/lib/msf/base/sessions/command_shell.rb
@@ -316,12 +316,14 @@ class CommandShell
   #
   def binary_exists(binary)
     print_status("Trying to find binary(#{binary}) on target machine")
-    binary_path = shell_command_token("command -v '#{binary}' && echo true")
-    if binary_path.to_s.eql?("")
-      print_error("#{binary} not found")
-      return nil
+    binary_path = shell_command_token("command -v '#{binary}'").to_s.strip
+    if binary_path.eql?("")
+      binary_path = shell_command_token("which #{binary}").to_s.strip
+      if binary_path.eql?("#{binary} not found") || binary_path == ""
+        print_error("#{binary} not found")
+        return nil
+      end
     end
-    binary_path = binary_path.split("\n")[0].chomp
     print_status("Found #{binary} at #{binary_path}")
     return binary_path
   end

--- a/lib/msf/base/sessions/command_shell.rb
+++ b/lib/msf/base/sessions/command_shell.rb
@@ -316,18 +316,18 @@ class CommandShell
   #
   def binary_exists(binary)
     print_status("Trying to find binary(#{binary}) on target machine")
-  if shell_command_token('command -v command').to_s.strip == 'command'
-    binary_path = shell_command_token("command -v '#{binary}' && echo true").to_s.strip
-  else
-    binary_path = shell_command_token("which '#{binary}' && echo true").to_s.strip
-  end
-  unless binary_path.include?("true")
-    print_error("#{binary} not found")
-    return nil
-  end
-  binary_path = binary_path.split("\n")[0].strip  #removes 'true' from stdout
-  print_status("Found #{binary} at #{binary_path}")
-  return binary_path
+    if shell_command_token('command -v command').to_s.strip == 'command'
+      binary_path = shell_command_token("command -v '#{binary}' && echo true").to_s.strip
+    else
+      binary_path = shell_command_token("which '#{binary}' && echo true").to_s.strip
+    end
+    unless binary_path.include?("true")
+      print_error("#{binary} not found")
+      return nil
+    end
+    binary_path = binary_path.split("\n")[0].strip  #removes 'true' from stdout
+    print_status("Found #{binary} at #{binary_path}")
+    return binary_path
   end
 
   #

--- a/lib/msf/base/sessions/command_shell.rb
+++ b/lib/msf/base/sessions/command_shell.rb
@@ -316,13 +316,15 @@ class CommandShell
   #
   def binary_exists(binary)
     print_status("Trying to find binary(#{binary}) on target machine")
-    binary_path = shell_command_token("command -v '#{binary}'").to_s.strip
-    if binary_path.eql?("")
+    if shell_command_token('command -v command').to_s.strip == 'command'
+      binary_path = shell_command_token("command -v '#{binary}'").to_s.strip
+    else
       binary_path = shell_command_token("which #{binary}").to_s.strip
-      if binary_path.eql?("#{binary} not found") || binary_path == ""
-        print_error("#{binary} not found")
-        return nil
-      end
+    end
+    if binary_path.end_with?("#{binary} not found") || binary_path.include?("no #{binary} in") || binary_path == ""
+      print_error("#{binary} not found")
+      return nil
+    end
     end
     print_status("Found #{binary} at #{binary_path}")
     return binary_path

--- a/lib/msf/base/sessions/command_shell.rb
+++ b/lib/msf/base/sessions/command_shell.rb
@@ -321,7 +321,7 @@ class CommandShell
       print_error("#{binary} not found")
       return nil
     end
-    binary_path=binary_path.split("\n")[0].chomp
+    binary_path = binary_path.split("\n")[0].chomp
     print_status("Found #{binary} at #{binary_path}")
     return binary_path
   end

--- a/lib/msf/base/sessions/command_shell.rb
+++ b/lib/msf/base/sessions/command_shell.rb
@@ -321,8 +321,8 @@ class CommandShell
       print_error("#{binary} not found")
       return nil
     end
-      print_status("Found #{binary} at #{binary_path}")
-      return binary_path
+    print_status("Found #{binary} at #{binary_path}")
+    return binary_path
   end
 
   #

--- a/lib/msf/base/sessions/command_shell.rb
+++ b/lib/msf/base/sessions/command_shell.rb
@@ -317,7 +317,7 @@ class CommandShell
   def binary_exists(binary)
     print_status("Trying to find binary(#{binary}) on target machine")
     binary_path = shell_command_token("command -v '#{binary}' && echo true")
-    if binary_path.eql?("")
+    if binary_path.to_s.eql?("")
       print_error("#{binary} not found")
       return nil
     end

--- a/lib/msf/base/sessions/command_shell.rb
+++ b/lib/msf/base/sessions/command_shell.rb
@@ -316,18 +316,18 @@ class CommandShell
   #
   def binary_exists(binary)
     print_status("Trying to find binary(#{binary}) on target machine")
-    if shell_command_token('command -v command').to_s.strip == 'command'
-      binary_path = shell_command_token("command -v '#{binary}'").to_s.strip
-    else
-      binary_path = shell_command_token("which #{binary}").to_s.strip
-    end
-    if binary_path.end_with?("#{binary} not found") || binary_path.include?("no #{binary} in") || binary_path == ""
-      print_error("#{binary} not found")
-      return nil
-    end
-    end
-    print_status("Found #{binary} at #{binary_path}")
-    return binary_path
+  if shell_command_token('command -v command').to_s.strip == 'command'
+    binary_path = shell_command_token("command -v '#{binary}' && echo true").to_s.strip
+  else
+    binary_path = shell_command_token("which '#{binary}' && echo true").to_s.strip
+  end
+  unless binary_path.include?("true")
+    print_error("#{binary} not found")
+    return nil
+  end
+  binary_path = binary_path.split("\n")[0].strip  #removes 'true' from stdout
+  print_status("Found #{binary} at #{binary_path}")
+  return binary_path
   end
 
   #


### PR DESCRIPTION
### PR/Issue 15000! :tada:
## Summary

This PR fixes #14077.

The `binary_exists?` method in `Msf::Sessions::CommandShell` was using `which` for checking whether a binary exists on a remote system or not. `command` is preferred over `which` command. Also the indicator to check whether binary exists depended on the standard error which may vary with locale.

This PR uses `command -v` method to check the existence of binary and returns its path if it does and doesn't depend of the standard error as an indicator. Thanks to @bcoles for finding this issue and suggesting the solution in the comments.

## Verification Steps
The `binary_exists` method is used only by the `shell` command which is used to get an interactive shell by searching for executables like `python`, `socat`, `script` etc. So this PR can be verified by using the shell command in an interactive session to get and `interactive shell`.
```
msf6 > handler -H 127.0.0.1 -P 4446 -p linux/x64/shell_reverse_tcp
[*] Payload handler running as background job 1.

[!] You are binding to a loopback address by setting LHOST to 127.0.0.1. Did you want ReverseListenerBindAddress?
[*] Started reverse TCP handler on 127.0.0.1:4446
[*] Command shell session 3 opened (127.0.0.1:4446 -> 127.0.0.1:38528) at 2021-04-04 17:35:04 +0530

msf6 > sessions -i 3 
[*] Starting interaction with 3...

shell

[*] Trying to find binary(python) on target machine
[*] Found python at /usr/bin/python
[*] Using `python` to pop up an interactive shell
[*] Trying to find binary(bash) on target machine
[*] Found bash at /usr/bin/bash
pwd
pwd
/home/pingport80/rapid7/metasploit-framework/lib/msf/base/sessions
pingport80@kali:~/rapid7/metasploit-framework/lib/msf/base/sessions$

pingport80@kali:~/rapid7/metasploit-framework/lib/msf/base/sessions$ whatis which
whatis which
which (1)            - locate a command
pingport80@kali:~/rapid7/metasploit-framework/lib/msf/base/sessions$
pingport80@kali:~/rapid7/metasploit-framework/lib/msf/base/sessions$ ^C
Abort session 4? [y/N]  y

[*] 127.0.0.1 - Command shell session 3 closed.  Reason: User exit
 ```
