### PR TITLE
Use correct namespace for calls to `Rex::Proto::NTP::Modes.ntp_private`

### DIFF
--- a/lib/rex/proto/ntp.rb
+++ b/lib/rex/proto/ntp.rb
@@ -3,4 +3,5 @@
 module Rex::Proto::NTP
   include Rex::Proto::NTP::Constants
   include Rex::Proto::NTP::Modes
+  extend Rex::Proto::NTP::Modes
 end

--- a/lib/rex/proto/ntp/modes.rb
+++ b/lib/rex/proto/ntp/modes.rb
@@ -117,7 +117,7 @@ module NTP::Modes
     rest   :payload
   end
 
-  def self.ntp_control(version, operation, payload = nil)
+  def ntp_control(version, operation, payload = nil)
     n = NTPControl.new
     n.version = version
     n.operation = operation
@@ -129,7 +129,7 @@ module NTP::Modes
     n
   end
 
-  def self.ntp_private(version, implementation, request_code, payload = nil)
+  def ntp_private(version, implementation, request_code, payload = nil)
     n = NTPPrivate.new
     n.version = version
     n.implementation = implementation
@@ -138,7 +138,7 @@ module NTP::Modes
     n
   end
 
-  def self.ntp_generic(version, mode)
+  def ntp_generic(version, mode)
     n = NTPGeneric.new
     n.version = version
     n.mode = mode
@@ -146,7 +146,7 @@ module NTP::Modes
   end
 
   # Parses the given message and provides a description about the NTP message inside
-  def self.describe(message)
+  def describe(message)
     ntp = NTPGeneric.new.read(message)
     "#{message.size}-byte version #{ntp.version} mode #{ntp.mode} reply"
   end

--- a/modules/auxiliary/fuzzers/ntp/ntp_protocol_fuzzer.rb
+++ b/modules/auxiliary/fuzzers/ntp/ntp_protocol_fuzzer.rb
@@ -97,7 +97,7 @@ class MetasploitModule < Msf::Auxiliary
     @versions.each do |version|
       print_status("#{host}:#{rport} fuzzing version #{version} control messages (mode 6)")
       @mode_6_operations.each do |op|
-        request = Rex::Proto::NTP::Modes.ntp_control(version, op).to_binary_s
+        request = Rex::Proto::NTP.ntp_control(version, op).to_binary_s
         what = "#{request.size}-byte version #{version} mode 6 op #{op} message"
         vprint_status("#{host}:#{rport} probing with #{request.size}-byte #{what}")
         responses = probe(host, datastore['RPORT'].to_i, request)
@@ -113,7 +113,7 @@ class MetasploitModule < Msf::Auxiliary
       print_status("#{host}:#{rport} fuzzing version #{version} private messages (mode 7)")
       @mode_7_implementations.each do |implementation|
         @mode_7_request_codes.each do |request_code|
-          request = Rex::Proto::NTP::Modes.ntp_private(version, implementation, request_code, "\0" * 188).to_binary_s
+          request = Rex::Proto::NTP.ntp_private(version, implementation, request_code, "\0" * 188).to_binary_s
           what = "#{request.size}-byte version #{version} mode 7 imp #{implementation} req #{request_code} message"
           vprint_status("#{host}:#{rport} probing with #{request.size}-byte #{what}")
           responses = probe(host, datastore['RPORT'].to_i, request)
@@ -198,7 +198,7 @@ class MetasploitModule < Msf::Auxiliary
     return if responses.empty?
     responses.each do |response|
       data = response[0]
-      descriptions << Rex::Proto::NTP::Modes.describe(data)
+      descriptions << Rex::Proto::NTP.describe(data)
       problems << 'large response' if request.size < data.size
       ntp_req = Rex::Proto::NTP::NTPGeneric.new.read(request)
       ntp_resp = Rex::Proto::NTP::NTPGeneric.new.read(data)


### PR DESCRIPTION
Continuation of #14991 

#14696 changed the namespacing of some things and this was lost in the shuffle

# Verification
- [ ] Start msfconsole
- [ ] `use auxiliary/scanner/ntp/ntp_monlist`
- [ ] set options and run (you don't need anything setup to test the module doesn't break)
- [ ] `use auxiliary/scanner/ntp/ntp_protocol_fuzzer`
- [ ] set options and run (you don't need anything setup to test the module doesn't break)
