### PR TITLE
Pin metasploit gems in preparation for rails 6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,11 +25,11 @@ PATH
       jsobfu
       json
       metasm
-      metasploit-concern
-      metasploit-credential
-      metasploit-model
+      metasploit-concern (~> 3.0.0)
+      metasploit-credential (~> 4.0.0)
+      metasploit-model (~> 3.1.0)
       metasploit-payloads (= 2.0.41)
-      metasploit_data_models
+      metasploit_data_models (~> 4.1.0)
       metasploit_payloads-mettle (= 1.0.8)
       mqtt
       msgpack

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -61,14 +61,14 @@ Gem::Specification.new do |spec|
   # Metasm compiler/decompiler/assembler
   spec.add_runtime_dependency 'metasm'
   # Metasploit::Concern hooks
-  spec.add_runtime_dependency 'metasploit-concern'
+  spec.add_runtime_dependency 'metasploit-concern', '~> 3.0.0'
   # Metasploit::Credential database models
-  spec.add_runtime_dependency 'metasploit-credential'
+  spec.add_runtime_dependency 'metasploit-credential', '~> 4.0.0'
   # Database models shared between framework and Pro.
-  spec.add_runtime_dependency 'metasploit_data_models'
+  spec.add_runtime_dependency 'metasploit_data_models', '~> 4.1.0'
   # Things that would normally be part of the database model, but which
   # are needed when there's no database
-  spec.add_runtime_dependency 'metasploit-model'
+  spec.add_runtime_dependency 'metasploit-model', '~> 3.1.0'
   # Needed for Meterpreter
   spec.add_runtime_dependency 'metasploit-payloads', '2.0.41'
   # Needed for the next-generation POSIX Meterpreter


### PR DESCRIPTION
In preparation for the Rails 6 upgrade - required for Ruby 3 https://github.com/rapid7/metasploit-framework/issues/14666 - Let's restrict these Gem versions in a similar pattern to the approach taken by the rails 5 upgrade - https://github.com/rapid7/metasploit-framework/pull/12836

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] **Verify** Basic functionality works as expected