### PR TITLE
Enhance analyze command API to understand modules' needs

### DIFF
--- a/lib/msf/core/analyze.rb
+++ b/lib/msf/core/analyze.rb
@@ -21,80 +21,13 @@ class Msf::Analyze
     # finds all modules that have references matching those found on host vulns with service data
     found_modules = mrefs.values_at(*vuln_refs).compact.reduce(:+)
     found_modules&.each do |fnd_mod|
-      # next if exploit_filter_by_service(fnd_mod, vuln.service)
-      if exploit_matches_host_os(fnd_mod, eval_host)
-        if fnd_mod.session_types
-          if eval_host.sessions.alive.none? { |sess| exploit_matches_session(fnd_mod, sess) }
-            suggested_modules << [fnd_mod, :session_required]
-          else
-            suggested_modules << [fnd_mod, :ready_for_test]
-          end
-        else
-          suggested_modules << [fnd_mod, :ready_for_test]
-        end
+      creds = @framework.db.creds(port: fnd_mod.rport) if fnd_mod.rport
+      r = Result.new(mod: fnd_mod, host: eval_host, available_creds: creds)
+      if r.match?
+        suggested_modules << r
       end
     end
 
-    {modules: suggested_modules}
-  end
-
-
-  private
-
-  # Tests for various service conditions by comparing the module's fullname (which
-  # is basically a pathname) to the intended target service record. The service.info
-  # column is tested against a regex in most/all cases and "false" is returned in the
-  # event of a match between an incompatible module and service fingerprint.
-  def exploit_filter_by_service(mod, serv)
-
-    # Filter out Unix vs Windows exploits for SMB services
-    return true if (mod.fullname =~ /\/samba/ and serv.info.to_s =~ /windows/i)
-    return true if (mod.fullname =~ /\/windows/ and serv.info.to_s =~ /samba|unix|vxworks|qnx|netware/i)
-    return true if (mod.fullname =~ /\/netware/ and serv.info.to_s =~ /samba|unix|vxworks|qnx/i)
-
-    # Filter out IIS exploits for non-Microsoft services
-    return true if (mod.fullname =~ /\/iis\/|\/isapi\// and (serv.info.to_s !~ /microsoft|asp/i))
-
-    # Filter out Apache exploits for non-Apache services
-    return true if (mod.fullname =~ /\/apache/ and serv.info.to_s !~ /apache|ibm/i)
-
-    false
-  end
-
-  # Determines if an exploit (mod, an instantiated module) is suitable for the host (host)
-  # defined operating system. Returns true if the host.os isn't defined, if the module's target
-  # OS isn't defined, if the module's OS is "unix" and the host's OS is not "windows," or
-  # if the module's target is "php." Or, of course, in the event the host.os actually matches.
-  # This is a fail-open gate; if there's a doubt, assume the module will work on this target.
-  def exploit_matches_host_os(mod, host)
-    hos = host.os_name
-    return true if hos.nil? || hos.empty?
-
-    set = mod.platform.split(',').map{ |x| x.downcase }
-    return true if set.empty?
-
-    # Special cases
-    return true if set.include?("unix") and hos !~ /windows/i
-
-    if set.include?("unix")
-      # Skip archaic old HPUX bugs if we have a solid match against another OS
-      return false if set.include?("hpux") and mod.refname.index("hpux") and hos =~ /linux|irix|solaris|aix|bsd/i
-      # Skip AIX bugs if we have a solid match against another OS
-      return false if set.include?("aix") and mod.refname.index("aix") and hos =~ /linux|irix|solaris|hpux|bsd/i
-      # Skip IRIX bugs if we have a solid match against another OS
-      return false if set.include?("irix") and mod.refname.index("irix") and hos =~ /linux|solaris|hpux|aix|bsd/i
-    end
-
-    return true if set.include?("php")
-
-    set.each do |mos|
-      return true if hos.downcase.index(mos)
-    end
-
-    false
-  end
-
-  def exploit_matches_session(mod, session)
-    mod.session_types&.include? session.type
+    {results: suggested_modules}
   end
 end

--- a/lib/msf/core/analyze.rb
+++ b/lib/msf/core/analyze.rb
@@ -56,7 +56,8 @@ class Msf::Analyze
     end
 
     vuln_families = grouped_vulns.values
-    vuln_families.uniq! || vuln_families
+    vuln_families.uniq!
+    vuln_families
   end
 
   def suggest_modules_for_vulns(eval_host, vuln_families)

--- a/lib/msf/core/analyze.rb
+++ b/lib/msf/core/analyze.rb
@@ -77,9 +77,9 @@ class Msf::Analyze
             next if evaluated_module_targets.include?([fnd_mod, port])
 
             creds = @framework.db.creds(svcs: [svc.name])
-            r = Result.new(mod: fnd_mod, host: eval_host, datastore: {'rport': port}, available_creds: creds)
+            r = Result.new(mod: fnd_mod, host: eval_host, datastore: {'rport': port}, available_creds: creds, framework: @framework)
             if r.match?
-              suggested_modules << r
+              suggested_modules << r.evaluate
             end
             evaluated_module_targets << [fnd_mod, port]
           end
@@ -97,10 +97,10 @@ class Msf::Analyze
       next if evaluated_module_targets.include?([fnd_mod, port])
 
       creds = @framework.db.creds(port: port) if port
-      r = Result.new(mod: fnd_mod, host: eval_host, datastore: {'rport': port}, available_creds: creds)
+      r = Result.new(mod: fnd_mod, host: eval_host, datastore: {'rport': port}, available_creds: creds, framework: @framework)
 
       if r.match?
-        suggested_modules << r
+        suggested_modules << r.evaluate
       end
       evaluated_module_targets << [fnd_mod, port]
     end

--- a/lib/msf/core/analyze.rb
+++ b/lib/msf/core/analyze.rb
@@ -13,19 +13,70 @@ class Msf::Analyze
       return {}
     end
 
-    vuln_refs = []
-    eval_host.vulns.each do |vuln|
-      vuln_refs.push(*vuln.refs.map {|r| r.name.upcase})
+    # Group related vulns
+    vulns = eval_host.vulns.map do |vuln|
+      [vuln, Set.new(vuln.refs.map {|r| r.name.upcase})]
+    end
+    grouped_vulns = Hash.new
+
+    vulns.each_index do |ii|
+      vuln, refs = vulns[ii]
+      grouped_vulns[vuln] ||= [Array.new, Set.new]
+      grouped_vulns[vuln][0] << vuln
+      grouped_vulns[vuln][1].merge(refs)
+
+      vulns[(ii+1)..-1].each do |candidate_match, candidate_refs|
+        # TODO: measure if sorting the refs ahead of time and doing a O(n + m)
+        # walk here is faster
+        if candidate_refs.intersect? refs
+          grouped_vulns[candidate_match] = grouped_vulns[vuln]
+        end
+      end
     end
 
+    vuln_families = grouped_vulns.values
+    vuln_families = vuln_families.uniq! || vuln_families
     # finds all modules that have references matching those found on host vulns with service data
-    found_modules = mrefs.values_at(*vuln_refs).compact.reduce(:+)
-    found_modules&.each do |fnd_mod|
-      creds = @framework.db.creds(port: fnd_mod.rport) if fnd_mod.rport
-      r = Result.new(mod: fnd_mod, host: eval_host, available_creds: creds)
+    evaluated_module_targets = Set.new
+    to_evaluate_with_defaults = Array.new
+    vuln_families&.each do |vulns, refs|
+      found_modules = mrefs.values_at(*refs).compact.reduce(:+)
+      next unless found_modules
+
+      services = vulns.map(&:service).compact
+      found_modules.each do |fnd_mod|
+        if services.any?
+          services.each do |svc|
+            port = svc.port
+            next if evaluated_module_targets.include?([fnd_mod, port])
+
+            creds = @framework.db.creds(svcs: [svc.name])
+            r = Result.new(mod: fnd_mod, host: eval_host, datastore: {'rport': port}, available_creds: creds)
+            if r.match?
+              suggested_modules << r
+            end
+            evaluated_module_targets << [fnd_mod, port]
+          end
+        else
+          # Only have the default port to go off of, at least for this vuln,
+          # prefer using the service data if available on a different vuln
+          # entry
+          port = fnd_mod.rport
+          to_evaluate_with_defaults << [fnd_mod, port]
+        end
+      end
+    end
+
+    to_evaluate_with_defaults.each do |fnd_mod, port|
+      next if evaluated_module_targets.include?([fnd_mod, port])
+
+      creds = @framework.db.creds(port: port) if port
+      r = Result.new(mod: fnd_mod, host: eval_host, datastore: {'rport': port}, available_creds: creds)
+
       if r.match?
         suggested_modules << r
       end
+      evaluated_module_targets << [fnd_mod, port]
     end
 
     {results: suggested_modules}

--- a/lib/msf/core/analyze.rb
+++ b/lib/msf/core/analyze.rb
@@ -5,23 +5,32 @@ class Msf::Analyze
   end
 
   def host(eval_host)
-    suggested_modules = []
-
-    mrefs, _mports, _mservs = Msf::Modules::Metadata::Cache.instance.all_exploit_maps
-
     unless eval_host.vulns
       return {}
     end
 
     # Group related vulns
-    vulns = eval_host.vulns.map do |vuln|
+    vuln_families = group_vulns(eval_host.vulns)
+
+    # finds all modules that have references matching those found on host vulns with service data
+    suggested_modules = suggest_modules_for_vulns(eval_host, vuln_families)
+
+    {results: suggested_modules}
+  end
+
+  private
+
+  def group_vulns(vulns)
+    return [] if vulns.empty?
+
+    vulns = vulns.map do |vuln|
       [vuln, Set.new(vuln.refs.map {|r| r.name.upcase})]
     end
     grouped_vulns = Hash.new
 
     vulns.each_index do |ii|
       vuln, refs = vulns[ii]
-      grouped_vulns[vuln] ||= [Array.new, Set.new]
+      grouped_vulns[vuln] ||= [Set.new, Set.new]
       grouped_vulns[vuln][0] << vuln
       grouped_vulns[vuln][1].merge(refs)
 
@@ -29,17 +38,34 @@ class Msf::Analyze
         # TODO: measure if sorting the refs ahead of time and doing a O(n + m)
         # walk here is faster
         if candidate_refs.intersect? refs
-          grouped_vulns[candidate_match] = grouped_vulns[vuln]
+          if grouped_vulns[candidate_match]
+            # For merging two different transitive sets that overlap, we need
+            # to merge the individual grouping elements and then use those
+            # cells inside both the grouping arrays so that all the
+            # already-visited vulns are rolled into the big new set
+            grouped_vulns[candidate_match][0] = grouped_vulns[candidate_match][0].merge(grouped_vulns[vuln][0])
+            grouped_vulns[candidate_match][1] = grouped_vulns[candidate_match][1].merge(grouped_vulns[vuln][1])
+            grouped_vulns[vuln][0] = grouped_vulns[candidate_match][0]
+            grouped_vulns[vuln][1] = grouped_vulns[candidate_match][1]
+          else
+            # Whoever was initialized first has the canonical set
+            grouped_vulns[candidate_match] = grouped_vulns[vuln]
+          end
         end
       end
     end
 
     vuln_families = grouped_vulns.values
-    vuln_families = vuln_families.uniq! || vuln_families
-    # finds all modules that have references matching those found on host vulns with service data
+    vuln_families.uniq! || vuln_families
+  end
+
+  def suggest_modules_for_vulns(eval_host, vuln_families)
+    mrefs, _mports, _mservs = Msf::Modules::Metadata::Cache.instance.all_exploit_maps
+    suggested_modules = []
+
     evaluated_module_targets = Set.new
     to_evaluate_with_defaults = Array.new
-    vuln_families&.each do |vulns, refs|
+    vuln_families.each do |vulns, refs|
       found_modules = mrefs.values_at(*refs).compact.reduce(:+)
       next unless found_modules
 
@@ -79,6 +105,6 @@ class Msf::Analyze
       evaluated_module_targets << [fnd_mod, port]
     end
 
-    {results: suggested_modules}
+    suggested_modules
   end
 end

--- a/lib/msf/core/analyze/result.rb
+++ b/lib/msf/core/analyze/result.rb
@@ -77,7 +77,7 @@ class Msf::Analyze::Result
   end
 
   def have_service_cred?
-    @available_creds.any?
+    @available_creds&.any?
   end
 
   def have_datastore_cred?

--- a/lib/msf/core/analyze/result.rb
+++ b/lib/msf/core/analyze/result.rb
@@ -67,11 +67,11 @@ class Msf::Analyze::Result
   end
 
   def matches_session?(session)
-    !!@mod.session_types&.include?(session.type)
+    session.stype == 'meterpreter' || !!@mod.session_types&.include?(session.type)
   end
 
   def required_sessions_list
-    return "" unless @mod.session_types
+    return "meterpreter" unless @mod.session_types&.any?
 
     @mod.session_types.join(' or ')
   end

--- a/lib/msf/core/analyze/result.rb
+++ b/lib/msf/core/analyze/result.rb
@@ -1,0 +1,145 @@
+class Msf::Analyze::Result
+
+  attr_reader :datastore
+  attr_reader :host
+  attr_reader :missing
+  attr_reader :mod
+  attr_reader :required
+
+  def initialize(host:, mod:, available_creds: nil, datastore: nil)
+    @host = host
+    @mod = mod
+    @required = []
+    @missing = []
+    @datastore = datastore&.transform_keys(&:downcase) || Hash.new
+    @available_creds = available_creds
+
+    determine_likely_compatibility
+  end
+
+  def to_s
+    if ready_for_test?
+      "ready for testing"
+    else
+      missing.map do |m|
+        case m
+        when :os_match
+          "operating system does not match"
+        when :session
+          "open #{required_sessions_list} session required"
+        when :credential
+          "credentials are required"
+        end
+      end.join(', ')
+    end
+  end
+
+  def match?
+    !missing.include? :os_match
+  end
+
+  def ready_for_test?
+    missing.empty?
+  end
+
+  private
+
+  def determine_likely_compatibility
+    if matches_host_os?
+      @datastore['rhost'] = @host.address
+    else
+      @missing << :os_match
+    end
+
+    if @mod.session_types
+      @required << :session
+
+      if @host.sessions.alive.none? { |sess| matches_session?(sess) }
+        @missing << :session
+      end
+    end
+
+    if @mod.post_auth?
+      unless @mod.default_cred? || have_service_cred? || have_datastore_cred?
+        missing << :credential
+      end
+    end
+  end
+
+  def matches_session?(session)
+    !!@mod.session_types&.include?(session.type)
+  end
+
+  def required_sessions_list
+    return "" unless @mod.session_types
+
+    @mod.session_types.join(' or ')
+  end
+
+  def have_service_cred?
+    @available_creds.any?
+  end
+
+  def have_datastore_cred?
+    !!(@datastore['username'] && @datastore['password'])
+  end
+
+  # Determines if an exploit (mod, an instantiated module) is suitable for the host (host)
+  # defined operating system. Returns true if the host.os isn't defined, if the module's target
+  # OS isn't defined, if the module's OS is "unix" and the host's OS is not "windows," or if
+  # the module's target is "php", "python", or "java." Or, of course, in the event the host.os
+  # actually matches. This is a fail-open gate; if there's a doubt, assume the module will work
+  # on this target.
+  def matches_host_os?
+    hos = @host.os_name&.downcase
+    return true if hos.nil? || hos.empty?
+
+    set = @mod.platform.split(',').map{ |x| x.downcase }
+    return true if set.empty?
+
+    # Special cases
+    if set.include?('unix')
+      # Skip archaic old HPUX bugs if we have a solid match against another OS
+      return false if set.include?("hpux") && mod.refname.include?("hpux") && !hos.inlcude?("hpux")
+      # Skip AIX bugs if we have a solid match against another OS
+      return false if set.include?("aix") && mod.refname.include?("aix") && !hos.include?("aix")
+      # Skip IRIX bugs if we have a solid match against another OS
+      return false if set.include?("irix") && mod.refname.include?("irix") && !hos.include?("irix")
+
+      return true if !hos.include?('windows')
+    end
+
+    return true if set.include?("php")
+    return true if set.include?("python")
+    return true if set.include?("java")
+
+    set.each do |mos|
+      return true if hos.include?(mos)
+    end
+
+    false
+  end
+
+=begin
+  # Tests for various service conditions by comparing the module's fullname (which
+  # is basically a pathname) to the intended target service record. The service.info
+  # column is tested against a regex in most/all cases and "false" is returned in the
+  # event of a match between an incompatible module and service fingerprint.
+  # TODO: fix and integrate
+  def exploit_filter_by_service(mod, serv)
+
+    # Filter out Unix vs Windows exploits for SMB services
+    return true if (mod.fullname =~ /\/samba/ and serv.info.to_s =~ /windows/i)
+    return true if (mod.fullname =~ /\/windows/ and serv.info.to_s =~ /samba|unix|vxworks|qnx|netware/i)
+    return true if (mod.fullname =~ /\/netware/ and serv.info.to_s =~ /samba|unix|vxworks|qnx/i)
+
+    # Filter out IIS exploits for non-Microsoft services
+    return true if (mod.fullname =~ /\/iis\/|\/isapi\// and (serv.info.to_s !~ /microsoft|asp/i))
+
+    # Filter out Apache exploits for non-Apache services
+    return true if (mod.fullname =~ /\/apache/ and serv.info.to_s !~ /apache|ibm/i)
+
+    false
+  end
+=end
+end

--- a/lib/msf/core/analyze/result.rb
+++ b/lib/msf/core/analyze/result.rb
@@ -60,7 +60,7 @@ class Msf::Analyze::Result
     end
 
     if @mod.post_auth?
-      unless @mod.default_cred? || have_service_cred? || have_datastore_cred?
+      unless @mod.default_cred? || has_service_cred? || has_datastore_cred?
         @missing << :credential
       end
     end
@@ -116,11 +116,11 @@ class Msf::Analyze::Result
     @mod.session_types.join(' or ')
   end
 
-  def have_service_cred?
+  def has_service_cred?
     @available_creds&.any?
   end
 
-  def have_datastore_cred?
+  def has_datastore_cred?
     !!(@datastore['username'] && @datastore['password'])
   end
 

--- a/lib/msf/core/analyze/result.rb
+++ b/lib/msf/core/analyze/result.rb
@@ -30,22 +30,15 @@ class Msf::Analyze::Result
   def to_s
     if ready_for_test?
       "ready for testing"
-    elsif @missing.empty?
+    elsif @missing.empty? && @invalid.empty?
       # TODO? confirm vuln match in this class
       "has matching reference"
     else
-      missing.map do |m|
-        case m
-        when :os_match
-          "operating system does not match"
-        when :session, "SESSION"
-          "open #{required_sessions_list} session required"
-        when :credential
-          "credentials are required"
-        when String
-          "option #{m.inspect} needs to be set"
-        end
-      end.uniq.join(', ')
+      if missing_message.empty? || invalid_message.empty?
+        missing_message + invalid_message
+      else
+        [missing_message, invalid_message].join(', ')
+      end
     end
   end
 
@@ -54,7 +47,7 @@ class Msf::Analyze::Result
   end
 
   def ready_for_test?
-    @prerequisites_evaluated && missing.empty?
+    @prerequisites_evaluated && @missing.empty? && @invalid.empty?
   end
 
   private
@@ -165,6 +158,30 @@ class Msf::Analyze::Result
     end
 
     false
+  end
+
+  def missing_message
+    @missing.map do |m|
+      case m
+      when :os_match
+        "operating system does not match"
+      when :session, "SESSION"
+        "open #{required_sessions_list} session required"
+      when :credential
+        "credentials are required"
+      when String
+        "option #{m.inspect} needs to be set"
+      end
+    end.uniq.join(', ')
+  end
+
+  def invalid_message
+    @invalid.map do |o|
+      case o
+      when String
+        "option #{o.inspect} is currently invalid"
+      end
+    end.join(', ')
   end
 
 =begin

--- a/lib/msf/core/db_manager/import.rb
+++ b/lib/msf/core/db_manager/import.rb
@@ -145,7 +145,7 @@ module Msf::DBManager::Import
         if serv.nil? && !second_pass_services.empty?
           second_pass_services.each do |service|
             next unless mports[service.port]
-            if (match_vulns - mports[service.port]).size < matched_vulns.size
+            if (matched_vulns - mports[service.port]).size < matched_vulns.size
               serv = service
               break
             end

--- a/lib/msf/core/db_manager/import.rb
+++ b/lib/msf/core/db_manager/import.rb
@@ -99,7 +99,7 @@ module Msf::DBManager::Import
     opts.delete(:workspace)
     self.send "import_#{ftype}".to_sym, opts.merge(workspace: wspace.name), &block
     # post process the import here for missing default port maps
-    mrefs, mports, _mservs = Msf::Modules::Metadata::Cache.instance.all_remote_exploit_maps
+    mrefs, mports, _mservs = Msf::Modules::Metadata::Cache.instance.all_exploit_maps
     # the map build above is a little expensive, another option is to do
     # a host by ref search for each vuln ref and then check port reported for each module
     # IMHO this front loaded cost here is worth it with only a small number of modules
@@ -124,9 +124,8 @@ module Msf::DBManager::Import
         serv = nil
 
         # Module names that match this vulnerability
-        matched = mrefs.values_at(*(vuln.refs.map { |x| x.name.upcase } & mrefs.keys)).map { |x| x.values }.flatten.uniq
-        next if matched.empty?
-        match_names = matched.map { |mod| mod.fullname }
+        matched_vulns = Set.new(mrefs.values_at(*vuln.refs.map { |x| x.name.upcase }).compact.flatten(1))
+        next if matched_vulns.empty?
 
         second_pass_services = []
 
@@ -136,7 +135,7 @@ module Msf::DBManager::Import
             next
           end
           next unless mports[service.port]
-          if (match_names - mports[service.port].keys).count < match_names.count
+          if (match_vulns - mports[service.port]).size < matched_vulns.size
             serv = service
             break
           end
@@ -146,7 +145,7 @@ module Msf::DBManager::Import
         if serv.nil? && !second_pass_services.empty?
           second_pass_services.each do |service|
             next unless mports[service.port]
-            if (match_names - mports[service.port].keys).count < match_names.count
+            if (match_vulns - mports[service.port]).size < matched_vulns.size
               serv = service
               break
             end

--- a/lib/msf/core/db_manager/import.rb
+++ b/lib/msf/core/db_manager/import.rb
@@ -135,7 +135,7 @@ module Msf::DBManager::Import
             next
           end
           next unless mports[service.port]
-          if (match_vulns - mports[service.port]).size < matched_vulns.size
+          if (matched_vulns - mports[service.port]).size < matched_vulns.size
             serv = service
             break
           end

--- a/lib/msf/core/module.rb
+++ b/lib/msf/core/module.rb
@@ -343,12 +343,17 @@ module Msf
     def default_cred?
       return false unless post_auth?
 
-      cred_opts_with_default = required_cred_options.select { |name, opt|
-        case opt.type
-        when 'string'
-          return true unless opt.default.blank?
+      required_cred_options.all? do |name, opt|
+        if opt.type == 'string'
+          if !opt.default.blank?
+            true
+          else
+            false
+          end
+        else
+          true
         end
-      }
+      end
 
       false
     end

--- a/lib/msf/core/modules/metadata/maps.rb
+++ b/lib/msf/core/modules/metadata/maps.rb
@@ -9,7 +9,7 @@ module Msf::Modules::Metadata::Maps
   @mservs = {}
 
 
-  def all_remote_exploit_maps
+  def all_exploit_maps
 
     return @mrefs, @mports, @mservs if @mrefs && !@mrefs.empty?
 
@@ -20,33 +20,32 @@ module Msf::Modules::Metadata::Maps
     get_metadata.each do |exploit|
       # expand this in future to be more specific about remote exploits.
       next unless exploit.type == "exploit"
-      fullname = exploit.fullname
       exploit.references.each do |reference|
         next if reference =~ /^URL/
         ref = reference
         ref.upcase!
 
-        mrefs[ref]           ||= {}
-        mrefs[ref][fullname] = exploit
+        mrefs[ref] ||= Set.new
+        mrefs[ref] << exploit
       end
 
       if exploit.rport
         rport                        = exploit.rport
-        mports[rport.to_i]           ||= {}
-        mports[rport.to_i][fullname] = exploit
+        mports[rport.to_i]           ||= []
+        mports[rport.to_i] << exploit
       end
 
       unless exploit.autofilter_ports.nil? || exploit.autofilter_ports.empty?
         exploit.autofilter_ports.each do |rport|
-          mports[rport.to_i]           ||= {}
-          mports[rport.to_i][fullname] = exploit
+          mports[rport.to_i] ||= Set.new
+          mports[rport.to_i] << exploit
         end
       end
 
       unless exploit.autofilter_services.nil? || exploit.autofilter_services.empty?
         exploit.autofilter_services.each do |serv|
-          mservs[serv]           ||= {}
-          mservs[serv][fullname] = exploit
+          mservs[serv] ||= Set.new
+          mservs[serv] << exploit
         end
       end
 

--- a/lib/msf/core/modules/metadata/obj.rb
+++ b/lib/msf/core/modules/metadata/obj.rb
@@ -48,8 +48,10 @@ class Obj
   attr_reader :check
   # @return [Boolean]
   attr_reader :post_auth
+  alias :post_auth? :post_auth # Mirror the Module class
   # @return [Boolean]
   attr_reader :default_credential
+  alias :default_cred? :default_credential # Mirror the Module class
   # @return [Hash]
   attr_reader :notes
   # @return [Array<String>]

--- a/lib/msf/core/modules/metadata/obj.rb
+++ b/lib/msf/core/modules/metadata/obj.rb
@@ -52,6 +52,8 @@ class Obj
   attr_reader :default_credential
   # @return [Hash]
   attr_reader :notes
+  # @return [Array<String>]
+  attr_reader :session_types
 
   def initialize(module_instance, obj_hash = nil)
     unless obj_hash.nil?
@@ -104,6 +106,8 @@ class Obj
 
     @notes = module_instance.notes
 
+    @session_types = module_instance.respond_to?(:session_types) && module_instance.session_types
+
     # Due to potentially non-standard ASCII we force UTF-8 to ensure no problem with JSON serialization
     force_encoding(::Encoding::UTF_8)
   end
@@ -136,6 +140,7 @@ class Obj
       'post_auth'          => @post_auth,
       'default_credential' => @default_credential,
       'notes'              => @notes,
+      'session_types'      => @session_types,
       'needs_cleanup'      => @needs_cleanup
     }.to_json(*args)
   end
@@ -186,6 +191,7 @@ class Obj
     @default_credential = obj_hash['default_credential']
     @notes              = obj_hash['notes'].nil? ? {} : obj_hash['notes']
     @needs_cleanup      = obj_hash['needs_cleanup']
+    @session_types      = obj_hash['session_types']
 
   end
 

--- a/lib/msf/ui/console/command_dispatcher/db/analyze.rb
+++ b/lib/msf/ui/console/command_dispatcher/db/analyze.rb
@@ -52,9 +52,9 @@ module Msf::Ui::Console::CommandDispatcher::Analyze
 
         reported_module = false
         host_result = framework.analyze.host(eval_host)
-        found_modules = host_result[:modules]
-        found_modules.each do |fnd_mod, status|
-          print_status(fnd_mod.fullname + " - " + status.to_s.gsub('_', ' '))
+        found_modules = host_result[:results]
+        found_modules.each do |res|
+          print_status(res.mod.fullname + " - " + res.to_s)
           reported_module = true
         end
 

--- a/lib/msf/ui/console/command_dispatcher/db/analyze.rb
+++ b/lib/msf/ui/console/command_dispatcher/db/analyze.rb
@@ -53,8 +53,8 @@ module Msf::Ui::Console::CommandDispatcher::Analyze
         reported_module = false
         host_result = framework.analyze.host(eval_host)
         found_modules = host_result[:modules]
-        found_modules.each do |fnd_mod|
-          print_status(fnd_mod.fullname)
+        found_modules.each do |fnd_mod, status|
+          print_status(fnd_mod.fullname + " - " + status.to_s.gsub('_', ' '))
           reported_module = true
         end
 

--- a/lib/msf/ui/console/command_dispatcher/db/analyze.rb
+++ b/lib/msf/ui/console/command_dispatcher/db/analyze.rb
@@ -14,6 +14,9 @@ module Msf::Ui::Console::CommandDispatcher::Analyze
     host_ranges = []
     print_empty = false
 
+    found_vulns = false
+    reported_module = false
+
     while (arg = args.shift)
       case arg
         when '-h','help'
@@ -51,10 +54,12 @@ module Msf::Ui::Console::CommandDispatcher::Analyze
           print_status("No suggestions for #{eval_host.address}.") if  print_empty
           next
         end
+        found_vulns = true
 
         host_result = framework.analyze.host(eval_host)
         found_modules = host_result[:results]
         if found_modules.any?
+          reported_module = true
           print_status("Analysis for #{eval_host.address} ->")
           found_modules.each do |res|
             print_status("  " + res.mod.fullname + " - " + res.to_s)
@@ -65,7 +70,20 @@ module Msf::Ui::Console::CommandDispatcher::Analyze
           print_status("No suggestions for #{eval_host.address}.")
         end
       end
+
+      if !print_empty
+        if !found_vulns
+          if host_ranges.any?
+            print_status("No vulnerabilities found for given hosts.")
+          else
+            print_status("No vulnerabilities found for hosts in this workspace.")
+          end
+        elsif !reported_module
+          print_status("No matching modules found.")
+        end
+      end
     end
+
     suggested_modules
   end
 

--- a/lib/msf/ui/console/command_dispatcher/db/analyze.rb
+++ b/lib/msf/ui/console/command_dispatcher/db/analyze.rb
@@ -1,7 +1,7 @@
 module Msf::Ui::Console::CommandDispatcher::Analyze
 
   def cmd_analyze_help
-    print_line "Usage: analyze [addr1 addr2 ...]"
+    print_line "Usage: analyze [OPTIONS] [addr1 addr2 ...]"
     print_line
   end
 
@@ -12,12 +12,15 @@ module Msf::Ui::Console::CommandDispatcher::Analyze
     end
 
     host_ranges = []
+    print_empty = false
 
     while (arg = args.shift)
       case arg
         when '-h','help'
           cmd_analyze_help
           return
+        when '-a', '-v'
+          print_empty = true
         else
           (arg_host_range(arg, host_ranges))
       end
@@ -44,23 +47,23 @@ module Msf::Ui::Console::CommandDispatcher::Analyze
       host_ids.each do |id|
         eval_host = framework.db.hosts(id: id).first
         next unless eval_host
-        print_status("Analyzing #{eval_host.address}...")
         unless eval_host.vulns
-          print_status("No suggestions for #{eval_host.address}.")
+          print_status("No suggestions for #{eval_host.address}.") if  print_empty
           next
         end
 
-        reported_module = false
         host_result = framework.analyze.host(eval_host)
         found_modules = host_result[:results]
-        found_modules.each do |res|
-          print_status(res.mod.fullname + " - " + res.to_s)
-          reported_module = true
+        if found_modules.any?
+          print_status("Analysis for #{eval_host.address} ->")
+          found_modules.each do |res|
+            print_status("  " + res.mod.fullname + " - " + res.to_s)
+          end
+
+          suggested_modules[eval_host.address] = found_modules
+        elsif print_empty
+          print_status("No suggestions for #{eval_host.address}.")
         end
-
-        suggested_modules[eval_host.address] = found_modules
-
-        print_status("No suggestions for #{eval_host.address}.") unless reported_module
       end
     end
     suggested_modules

--- a/modules/auxiliary/gather/apache_rave_creds.rb
+++ b/modules/auxiliary/gather/apache_rave_creds.rb
@@ -46,10 +46,6 @@ class MetasploitModule < Msf::Auxiliary
     true
   end
 
-  def default_cred?
-    true
-  end
-
   def login(username, password)
     uri = normalize_uri(target_uri.to_s, "j_spring_security_check")
 

--- a/modules/auxiliary/gather/zabbix_toggleids_sqli.rb
+++ b/modules/auxiliary/gather/zabbix_toggleids_sqli.rb
@@ -38,10 +38,6 @@ class MetasploitModule < Msf::Auxiliary
       ])
   end
 
-  def default_cred?
-    true
-  end
-
   def check
 
     sid, cookies = authenticate

--- a/modules/auxiliary/scanner/ipmi/ipmi_dumphashes.rb
+++ b/modules/auxiliary/scanner/ipmi/ipmi_dumphashes.rb
@@ -50,10 +50,6 @@ class MetasploitModule < Msf::Auxiliary
     true
   end
 
-  def default_cred?
-    true
-  end
-
   def ipmi_status(msg)
     vprint_status("#{rhost}:#{rport} - IPMI - #{msg}")
   end

--- a/modules/exploits/linux/http/apache_couchdb_cmd_exec.rb
+++ b/modules/exploits/linux/http/apache_couchdb_cmd_exec.rb
@@ -67,10 +67,6 @@ class MetasploitModule < Msf::Exploit::Remote
     true
   end
 
-  def default_cred?
-    true
-  end
-
   def check
     get_version
     version = Rex::Version.new(@version)

--- a/modules/exploits/multi/http/visual_mining_netcharts_upload.rb
+++ b/modules/exploits/multi/http/visual_mining_netcharts_upload.rb
@@ -60,10 +60,6 @@ class MetasploitModule < Msf::Exploit::Remote
     true
   end
 
-  def default_cred?
-    true
-  end
-
   def check
     res = send_request_cgi({
       'method'   => 'GET',

--- a/modules/exploits/unix/webapp/foswiki_maketext.rb
+++ b/modules/exploits/unix/webapp/foswiki_maketext.rb
@@ -66,10 +66,6 @@ class MetasploitModule < Msf::Exploit::Remote
     true
   end
 
-  def default_cred?
-    true
-  end
-
   def do_login(username, password)
     res = send_request_cgi({
       'method'   => 'POST',

--- a/modules/exploits/unix/webapp/moinmoin_twikidraw.rb
+++ b/modules/exploits/unix/webapp/moinmoin_twikidraw.rb
@@ -70,10 +70,6 @@ class MetasploitModule < Msf::Exploit::Remote
     true
   end
 
-  def default_cred?
-    true
-  end
-
   def moinmoin_template(path)
     template =[]
     template << "# -*- coding: iso-8859-1 -*-"

--- a/modules/exploits/windows/iis/msadc.rb
+++ b/modules/exploits/windows/iis/msadc.rb
@@ -71,10 +71,6 @@ class MetasploitModule < Msf::Exploit::Remote
     true
   end
 
-  def default_cred?
-    true
-  end
-
   def check
     res = send_request_raw({
         'uri'          =>  normalize_uri(datastore['PATH']),

--- a/spec/lib/msf/core/analyze_spec.rb
+++ b/spec/lib/msf/core/analyze_spec.rb
@@ -9,19 +9,19 @@ RSpec.describe Msf::Analyze do
     let(:ref_4) { FactoryBot.create(:mdm_ref) }
 
     let(:vuln_a) { FactoryBot.create(:mdm_vuln) }
-    let(:vuln_ap1) { FactoryBot.create(:mdm_vuln) }
+    let(:vuln_a_dup_1) { FactoryBot.create(:mdm_vuln) }
     let(:vuln_b) { FactoryBot.create(:mdm_vuln) }
     let(:vuln_c) { FactoryBot.create(:mdm_vuln) }
-    let(:vuln_cta) { FactoryBot.create(:mdm_vuln) }
+    let(:vuln_c_transitive_to_a) { FactoryBot.create(:mdm_vuln) }
     let(:vuln_d) { FactoryBot.create(:mdm_vuln) }
-    let(:vuln_dtc) { FactoryBot.create(:mdm_vuln) }
+    let(:vuln_d_transitive_to_c) { FactoryBot.create(:mdm_vuln) }
 
     let!(:vuln_a_refnames) do
       refs = [
         ref_1
       ]
       allow(vuln_a).to receive(:refs).and_return(refs)
-      allow(vuln_ap1).to receive(:refs).and_return(refs)
+      allow(vuln_a_dup_1).to receive(:refs).and_return(refs)
 
       refs.map { |r| r.name.upcase }
     end
@@ -44,12 +44,12 @@ RSpec.describe Msf::Analyze do
       refs.map { |r| r.name.upcase }
     end
 
-    let!(:vuln_cta_refnames) do
+    let!(:vuln_c_transitive_to_a_refnames) do
       refs = [
         ref_1,
         ref_3
       ]
-      allow(vuln_cta).to receive(:refs).and_return(refs)
+      allow(vuln_c_transitive_to_a).to receive(:refs).and_return(refs)
 
       refs.map { |r| r.name.upcase }
     end
@@ -63,12 +63,12 @@ RSpec.describe Msf::Analyze do
       refs.map { |r| r.name.upcase }
     end
 
-    let!(:vuln_dtc_refnames) do
+    let!(:vuln_d_transitive_to_c_refnames) do
       refs = [
         ref_4,
         ref_3
       ]
-      allow(vuln_dtc).to receive(:refs).and_return(refs)
+      allow(vuln_d_transitive_to_c).to receive(:refs).and_return(refs)
 
       refs.map { |r| r.name.upcase }
     end
@@ -119,7 +119,7 @@ RSpec.describe Msf::Analyze do
     end
 
     context 'with overlapping vulns' do
-      subject(:group_vulns) { msf_analyze.send(:group_vulns, [vuln_a, vuln_ap1]) }
+      subject(:group_vulns) { msf_analyze.send(:group_vulns, [vuln_a, vuln_a_dup_1]) }
 
       it 'should return two Sets per vuln family' do
         expect(subject.size).to be(1)
@@ -130,7 +130,7 @@ RSpec.describe Msf::Analyze do
       end
 
       it 'should return the vulns together' do
-        expect(subject[0][0]).to eql(Set.new([vuln_a, vuln_ap1]))
+        expect(subject[0][0]).to eql(Set.new([vuln_a, vuln_a_dup_1]))
       end
 
       it 'should return the upcased names of the refs in a set' do
@@ -139,7 +139,7 @@ RSpec.describe Msf::Analyze do
     end
 
     context 'with overlapping and disjoint vulns' do
-      subject(:group_vulns) { msf_analyze.send(:group_vulns, [vuln_a, vuln_b, vuln_ap1]) }
+      subject(:group_vulns) { msf_analyze.send(:group_vulns, [vuln_a, vuln_b, vuln_a_dup_1]) }
 
       it 'should return two Sets per vuln family' do
         expect(subject.size).to be(2)
@@ -150,7 +150,7 @@ RSpec.describe Msf::Analyze do
       end
 
       it 'should return the vulns with the same references together' do
-        expect(subject[0][0]).to eql(Set.new([vuln_a, vuln_ap1]))
+        expect(subject[0][0]).to eql(Set.new([vuln_a, vuln_a_dup_1]))
         expect(subject[1][0]).to eql(Set.new([vuln_b]))
       end
 
@@ -161,7 +161,7 @@ RSpec.describe Msf::Analyze do
     end
 
     context 'with transitive vulns' do
-      %w(vuln_a vuln_c vuln_cta).permutation do |perm|
+      %w(vuln_a vuln_c vuln_c_transitive_to_a).permutation do |perm|
         context "in permutation #{perm.inspect}" do
           # One the one hand, we need to test all these permutations, on the
           # other I'm sorry.
@@ -188,7 +188,7 @@ RSpec.describe Msf::Analyze do
     end
 
     context 'with double-transitive vulns' do
-      %w(vuln_a vuln_c vuln_cta vuln_d vuln_dtc).permutation do |perm|
+      %w(vuln_a vuln_c vuln_c_transitive_to_a vuln_d vuln_d_transitive_to_c).permutation do |perm|
         context "in permutation #{perm.inspect}" do
           # One the one hand, we need to test all these permutations, on the
           # other I'm sorry.

--- a/spec/lib/msf/core/analyze_spec.rb
+++ b/spec/lib/msf/core/analyze_spec.rb
@@ -1,0 +1,217 @@
+require 'spec_helper'
+
+RSpec.describe Msf::Analyze do
+  context '#group_vulns' do
+    subject(:msf_analyze) { Msf::Analyze.new(nil) }
+    let(:ref_1) { FactoryBot.create(:mdm_ref) }
+    let(:ref_2) { FactoryBot.create(:mdm_ref) }
+    let(:ref_3) { FactoryBot.create(:mdm_ref) }
+    let(:ref_4) { FactoryBot.create(:mdm_ref) }
+
+    let(:vuln_a) { FactoryBot.create(:mdm_vuln) }
+    let(:vuln_ap1) { FactoryBot.create(:mdm_vuln) }
+    let(:vuln_b) { FactoryBot.create(:mdm_vuln) }
+    let(:vuln_c) { FactoryBot.create(:mdm_vuln) }
+    let(:vuln_cta) { FactoryBot.create(:mdm_vuln) }
+    let(:vuln_d) { FactoryBot.create(:mdm_vuln) }
+    let(:vuln_dtc) { FactoryBot.create(:mdm_vuln) }
+
+    let!(:vuln_a_refnames) do
+      refs = [
+        ref_1
+      ]
+      allow(vuln_a).to receive(:refs).and_return(refs)
+      allow(vuln_ap1).to receive(:refs).and_return(refs)
+
+      refs.map { |r| r.name.upcase }
+    end
+
+    let!(:vuln_b_refnames) do
+      refs = [
+        ref_2
+      ]
+      allow(vuln_b).to receive(:refs).and_return(refs)
+
+      refs.map { |r| r.name.upcase }
+    end
+
+    let!(:vuln_c_refnames) do
+      refs = [
+        ref_3
+      ]
+      allow(vuln_c).to receive(:refs).and_return(refs)
+
+      refs.map { |r| r.name.upcase }
+    end
+
+    let!(:vuln_cta_refnames) do
+      refs = [
+        ref_1,
+        ref_3
+      ]
+      allow(vuln_cta).to receive(:refs).and_return(refs)
+
+      refs.map { |r| r.name.upcase }
+    end
+
+    let!(:vuln_d_refnames) do
+      refs = [
+        ref_4
+      ]
+      allow(vuln_d).to receive(:refs).and_return(refs)
+
+      refs.map { |r| r.name.upcase }
+    end
+
+    let!(:vuln_dtc_refnames) do
+      refs = [
+        ref_4,
+        ref_3
+      ]
+      allow(vuln_dtc).to receive(:refs).and_return(refs)
+
+      refs.map { |r| r.name.upcase }
+    end
+
+    it 'should return an Array' do
+      ret = subject.send(:group_vulns, [])
+      expect(ret).to be_an(Array)
+    end
+
+    context 'with one vuln' do
+      subject(:group_vulns) { msf_analyze.send(:group_vulns, [vuln_a]) }
+
+      it 'should return two Sets per vuln family' do
+        expect(subject.size).to be(1)
+        expect(subject.first[0]).to be_a(Set)
+        expect(subject.first[1]).to be_a(Set)
+      end
+
+      it 'should return the vuln' do
+        expect(subject.first[0]).to eql(Set.new([vuln_a]))
+      end
+
+      it 'should return the upcased names of the refs in a set' do
+        expect(subject.first[1]).to eql(Set.new(vuln_a_refnames))
+      end
+    end
+
+    context 'with disjoint vulns' do
+      subject(:group_vulns) { msf_analyze.send(:group_vulns, [vuln_a, vuln_b]) }
+
+      it 'should return two Sets per vuln family' do
+        expect(subject.size).to be(2)
+        subject.each do |family|
+          expect(family[0]).to be_a(Set)
+          expect(family[1]).to be_a(Set)
+        end
+      end
+
+      it 'should return the vulns separately' do
+        expect(subject[0][0]).to eql(Set.new([vuln_a]))
+        expect(subject[1][0]).to eql(Set.new([vuln_b]))
+      end
+
+      it 'should return the upcased names of the refs in separate sets' do
+        expect(subject[0][1]).to eql(Set.new(vuln_a_refnames))
+        expect(subject[1][1]).to eql(Set.new(vuln_b_refnames))
+      end
+    end
+
+    context 'with overlapping vulns' do
+      subject(:group_vulns) { msf_analyze.send(:group_vulns, [vuln_a, vuln_ap1]) }
+
+      it 'should return two Sets per vuln family' do
+        expect(subject.size).to be(1)
+        subject.each do |family|
+          expect(family[0]).to be_a(Set)
+          expect(family[1]).to be_a(Set)
+        end
+      end
+
+      it 'should return the vulns together' do
+        expect(subject[0][0]).to eql(Set.new([vuln_a, vuln_ap1]))
+      end
+
+      it 'should return the upcased names of the refs in a set' do
+        expect(subject[0][1]).to eql(Set.new(vuln_a_refnames))
+      end
+    end
+
+    context 'with overlapping and disjoint vulns' do
+      subject(:group_vulns) { msf_analyze.send(:group_vulns, [vuln_a, vuln_b, vuln_ap1]) }
+
+      it 'should return two Sets per vuln family' do
+        expect(subject.size).to be(2)
+        subject.each do |family|
+          expect(family[0]).to be_a(Set)
+          expect(family[1]).to be_a(Set)
+        end
+      end
+
+      it 'should return the vulns with the same references together' do
+        expect(subject[0][0]).to eql(Set.new([vuln_a, vuln_ap1]))
+        expect(subject[1][0]).to eql(Set.new([vuln_b]))
+      end
+
+      it 'should return the upcased names of the refs separate sets' do
+        expect(subject[0][1]).to eql(Set.new(vuln_a_refnames))
+        expect(subject[1][1]).to eql(Set.new(vuln_b_refnames))
+      end
+    end
+
+    context 'with transitive vulns' do
+      %w(vuln_a vuln_c vuln_cta).permutation do |perm|
+        context "in permutation #{perm.inspect}" do
+          # One the one hand, we need to test all these permutations, on the
+          # other I'm sorry.
+          let(:vuln_permutation) { eval("[#{perm.join(',')}]") }
+          subject(:group_vulns) { msf_analyze.send(:group_vulns, vuln_permutation) }
+
+          it 'should return two Sets per vuln family' do
+            expect(subject.size).to be(1)
+            subject.each do |family|
+              expect(family[0]).to be_a(Set)
+              expect(family[1]).to be_a(Set)
+            end
+          end
+
+          it 'should return the vulns together' do
+            expect(subject[0][0]).to eql(Set.new(vuln_permutation))
+          end
+
+          it 'should return the upcased names of the refs a set' do
+            expect(subject[0][1]).to eql(Set.new(vuln_a_refnames.concat(vuln_c_refnames)))
+          end
+        end
+      end
+    end
+
+    context 'with double-transitive vulns' do
+      %w(vuln_a vuln_c vuln_cta vuln_d vuln_dtc).permutation do |perm|
+        context "in permutation #{perm.inspect}" do
+          # One the one hand, we need to test all these permutations, on the
+          # other I'm sorry.
+          let(:vuln_permutation) { eval("[#{perm.join(',')}]") }
+          subject(:group_vulns) { msf_analyze.send(:group_vulns, vuln_permutation) }
+
+          it 'should return two Sets per vuln family' do
+            expect(subject.size).to be(1)
+            subject.each do |family|
+              expect(family[0]).to be_a(Set)
+              expect(family[1]).to be_a(Set)
+            end
+          end
+
+          it 'should return the vulns together' do
+            expect(subject[0][0]).to eql(Set.new(vuln_permutation))
+          end
+
+          it 'should return the upcased names of the refs a set' do
+            expect(subject[0][1]).to eql(Set.new(vuln_a_refnames.concat(vuln_c_refnames, vuln_d_refnames)))
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/msf/core/analyze_spec.rb
+++ b/spec/lib/msf/core/analyze_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe Msf::Analyze do
     context 'with transitive vulns' do
       %w(vuln_a vuln_c vuln_c_transitive_to_a).permutation do |perm|
         context "in permutation #{perm.inspect}" do
-          # One the one hand, we need to test all these permutations, on the
+          # On the one hand, we need to test all these permutations, on the
           # other I'm sorry.
           let(:vuln_permutation) { eval("[#{perm.join(',')}]") }
           subject(:group_vulns) { msf_analyze.send(:group_vulns, vuln_permutation) }
@@ -190,7 +190,7 @@ RSpec.describe Msf::Analyze do
     context 'with double-transitive vulns' do
       %w(vuln_a vuln_c vuln_c_transitive_to_a vuln_d vuln_d_transitive_to_c).permutation do |perm|
         context "in permutation #{perm.inspect}" do
-          # One the one hand, we need to test all these permutations, on the
+          # On the one hand, we need to test all these permutations, on the
           # other I'm sorry.
           let(:vuln_permutation) { eval("[#{perm.join(',')}]") }
           subject(:group_vulns) { msf_analyze.send(:group_vulns, vuln_permutation) }


### PR DESCRIPTION
Beginning steps to enhance the `analyze` command to be able to understand what potentially testable modules will need in order to run. Currently re-working vuln/service matching to lose less information. Putting more module option information in the module cache and/or having a step that instantiates good matches will likely be needed soon to provide better targeting.