### PR TITLE
Added string PKey support for ssh module

### DIFF
--- a/documentation/modules/auxiliary/scanner/ssh/ssh_login_pubkey.md
+++ b/documentation/modules/auxiliary/scanner/ssh/ssh_login_pubkey.md
@@ -17,9 +17,11 @@
   4. Do: ` use auxiliary/scanner/ssh/ssh_login_pubkey`
   5. Do: `set rhosts`
   6. Do: set usernames with one of the available options
-  7. Do: `set KEY_PATH ` to either a file or path
-  7. Do: `run`
-  8. You will hopefully see something similar to the following:
+  7. Do: set private keys with one or both of the available options
+     1. Do: `set KEY_PATH ` to either a file or path
+     2. Do: `set PRIVATE_KEY ` to `file:PRIVATE_KEY_PATH`
+  8. Do: `run`
+  9. You will hopefully see something similar to the following:
 
   ```
   [+] SSH - Success: 'ubuntu:-----BEGIN RSA PRIVATE KEY-----
@@ -31,6 +33,10 @@
 
   A string to the private key to attempt, or a folder containing private keys to attempt.  Any file name starting with a period (`.`) or ending in `.pub` will be ignored.
   An SSH key is typically kept in a user's home directory under `.ssh/id_rsa`.  The file contents, when not encrypted with a password will start with `-----BEGIN RSA PRIVATE KEY-----`
+
+  **PRIVATE_KEY**
+
+  A string of the private key to attempt. For MSFConsole users the option should be set to `file:PRIVATE_KEY_PATH` and it will read in the string value of the private key. Currently OpenSSH, RSA, DSA, and EC private keys are supported. 
   
   **RHOSTS**
   
@@ -56,6 +62,8 @@
 
 It is important to note that usernames can be entered in multiple combinations.  For instance, a username could be set in `USERNAME`, and be part of `USER_FILE`.
 This module makes a combination of all of the above when attempting logins.  So if a username is set in `USERNAME`, and a `USER_FILE` is listed, usernames will be generated from BOTH of these.
+
+Similar to `USERNAME` and `USER_FILE`, both `KEY_PATH` and `PRIVATE_KEY` can be set simultaneously and all unique combinations of these will be tested.
 
 ## Scenarios
 
@@ -106,6 +114,81 @@ AaZna5YokhaNvfGGbO5N8YoYShIpGdvWI+dIT8xYvPkJmYdnTz7/dmBUcwLtNVx/
 
 '
 [!] No active DB -- Credential data will not be saved!
+[+] SSH - Success: 'ubuntu:-----BEGIN RSA PRIVATE KEY-----
+MIIEpQIBAAKCAQEAtwJrqowPyjWONHUCMqU/Fh3yRn42+X9hahtTv/6plYpb4WrA
+NxDaYIrBGAO//u2SkGcIhnAdzYVmovWahKEwcxZ2XJo/nj4gjh1CbI1xVCFeE/oX
+oWpIN+4q8JQ0Iq1dm+c+WPQIEzlVpMRaKeuMxdGPNMTYWxolSEIMPPYmyWXG6gz8
+fYYZDo8+w8G78w7oUV6hSIwCDzw09A5yGyt51ZETeSZiZ24bHlBQSyk7yFq/eo58
+xhlc79jpZrSdX8kx8HrCZKND7O6E4YSktfSHOvd81QUCSyoi5Y+9RXsLjUEba0+Y
+0Az8mZPLdxbRu75eeD/mZTv5gALewXeb65IkPQIDAQABAoIBACvi5LbNR6wSE7v4
+o0JJ5ksDe2n0MnK6XT34t6i/BSPbPhVcaCPMYtHr9Eox/ATCK/d8/cpfcIYsi2Rg
+yWEs1lWC+XdTdhYYh+4MjjVB5f9q0QixXKFUv2TKNHnk0GvQbzZHyefC/Xy+rw8I
+FyceWW/GxTS+T7PpHS+qxwyHat24ph7Xz/cE/0UyrVu+NAzFXaHq60M2/RRh3uXE
+1vqiZVlapczO/DxsnPwQrE2EOm0lzrQVmZbX5BYK1yiCd5eTgLhOb+ms2p/8pb2I
+jrK5FzLnUZu0H0ZHtihOVkx4l8NZqB36jinaRs0wWN7It4/C5+NkyoMvuceIn1Wx
+tstYD3ECgYEA7sOb0CdGxXw0IVrJF+3C8m1UG3CfQfzms+rJb9w3OJVl2BTlYdPr
+JgXI/YoV9FQPvXmTWrRP9e6x0kuSVHO1ejMpyLHGmMcJDZhpVKMROOosIWfROxwk
+bkPU2jdUXIrHgu8NnmnyytjUnJgeerQZLhCtjKmBKCZisS4WPBdun3MCgYEAxDh1
+fjFJttWhgeg6pcvvmDUWO1W0lJ9ZjjQll1UmbPmKDGwwsjPZEkZfLkvI77st81AT
+eW/p7tMKE3fCkXkn2KWMQ6ZGN5yflwvjJOMAVZz8ir8Cu1npa6f6HIrxpHSKethY
+dG4ssCpQctfoRfN4wg6fOHBOpGd3BH1GdOwR4Y8CgYEAq3h7e//ZCZbrcVDbvn2Y
+VbZCgvpcxW002d0yEU2bst1IKOjI23rwE3xwHfV/UtrT+wVG2AtKqZpkxlxTmKcI
+m9wGlAVoVOwMCmF8s7XwdmlmjA8c6lCJsU6xnI3D3jokklnP9AauwRL7jgKJUSHq
+O3TqzmwlP4phslEg0sMZRRUCgYEAwkS3prG7rqYBmjFG52FqnIJquWIYQFEoBE+C
+rDqkqZ3B3Jy89aG5l4tOrvJfRWJHky7DqSZxMH+G6VFXtFmEZs04er3DpUmPA6fE
+Qn/wk9KygdetJ7pUDL8pNFsn9M9hT1Ck+tkdq2ipb5ptn9v2wgJiBynB4qmBP1Oc
+jyQua+cCgYEAl77hJQK97tdJ5TuOXSsdpW8IMvbiaWTgvZtKVJev31lWgJ+knpCf
+AaZna5YokhaNvfGGbO5N8YoYShIpGdvWI+dIT8xYvPkJmYdnTz7/dmBUcwLtNVx/
+7PI/l5XrFMRsnu/CYuBPuWB+RCTLjIr1D1RluNbIb7xr+kDHuzgInvA=
+-----END RSA PRIVATE KEY-----
+
+' 'uid=1000(ubuntu) gid=1000(ubuntu) groups=1000(ubuntu),4(adm),24(cdrom),27(sudo),30(dip),46(plugdev),110(lpadmin),111(sambashare) Linux Ubuntu14 4.2.0-27-generic #32~14.04.1-Ubuntu SMP Fri Jan 22 15:32:26 UTC 2016 x86_64 x86_64 x86_64 GNU/Linux '
+[*] Command shell session 1 opened (192.168.2.117:44179 -> 192.168.2.156:22) at 2017-02-22 22:08:11 -0500
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```
+
+
+
+  Similar example but run with a KEY FILE set for `PRIVATE_KEY`:
+  ```
+msf > use auxiliary/scanner/ssh/ssh_login_pubkey 
+msf auxiliary(ssh_login_pubkey) > set rhosts 192.168.2.156
+rhosts => 192.168.2.156
+msf auxiliary(ssh_login_pubkey) > set username ubuntu
+username => ubuntu
+msf auxiliary(ssh_login_pubkey) > set private_key file:/root/sshkeys/id_rsa
+private_key => -----BEGIN RSA PRIVATE KEY-----
+MIIEpQIBAAKCAQEAtwJrqowPyjWONHUCMqU/Fh3yRn42+X9hahtTv/6plYpb4WrA
+NxDaYIrBGAO//u2SkGcIhnAdzYVmovWahKEwcxZ2XJo/nj4gjh1CbI1xVCFeE/oX
+oWpIN+4q8JQ0Iq1dm+c+WPQIEzlVpMRaKeuMxdGPNMTYWxolSEIMPPYmyWXG6gz8
+fYYZDo8+w8G78w7oUV6hSIwCDzw09A5yGyt51ZETeSZiZ24bHlBQSyk7yFq/eo58
+xhlc79jpZrSdX8kx8HrCZKND7O6E4YSktfSHOvd81QUCSyoi5Y+9RXsLjUEba0+Y
+0Az8mZPLdxbRu75eeD/mZTv5gALewXeb65IkPQIDAQABAoIBACvi5LbNR6wSE7v4
+o0JJ5ksDe2n0MnK6XT34t6i/BSPbPhVcaCPMYtHr9Eox/ATCK/d8/cpfcIYsi2Rg
+yWEs1lWC+XdTdhYYh+4MjjVB5f9q0QixXKFUv2TKNHnk0GvQbzZHyefC/Xy+rw8I
+FyceWW/GxTS+T7PpHS+qxwyHat24ph7Xz/cE/0UyrVu+NAzFXaHq60M2/RRh3uXE
+1vqiZVlapczO/DxsnPwQrE2EOm0lzrQVmZbX5BYK1yiCd5eTgLhOb+ms2p/8pb2I
+jrK5FzLnUZu0H0ZHtihOVkx4l8NZqB36jinaRs0wWN7It4/C5+NkyoMvuceIn1Wx
+tstYD3ECgYEA7sOb0CdGxXw0IVrJF+3C8m1UG3CfQfzms+rJb9w3OJVl2BTlYdPr
+JgXI/YoV9FQPvXmTWrRP9e6x0kuSVHO1ejMpyLHGmMcJDZhpVKMROOosIWfROxwk
+bkPU2jdUXIrHgu8NnmnyytjUnJgeerQZLhCtjKmBKCZisS4WPBdun3MCgYEAxDh1
+fjFJttWhgeg6pcvvmDUWO1W0lJ9ZjjQll1UmbPmKDGwwsjPZEkZfLkvI77st81AT
+eW/p7tMKE3fCkXkn2KWMQ6ZGN5yflwvjJOMAVZz8ir8Cu1npa6f6HIrxpHSKethY
+dG4ssCpQctfoRfN4wg6fOHBOpGd3BH1GdOwR4Y8CgYEAq3h7e//ZCZbrcVDbvn2Y
+VbZCgvpcxW002d0yEU2bst1IKOjI23rwE3xwHfV/UtrT+wVG2AtKqZpkxlxTmKcI
+m9wGlAVoVOwMCmF8s7XwdmlmjA8c6lCJsU6xnI3D3jokklnP9AauwRL7jgKJUSHq
+O3TqzmwlP4phslEg0sMZRRUCgYEAwkS3prG7rqYBmjFG52FqnIJquWIYQFEoBE+C
+rDqkqZ3B3Jy89aG5l4tOrvJfRWJHky7DqSZxMH+G6VFXtFmEZs04er3DpUmPA6fE
+Qn/wk9KygdetJ7pUDL8pNFsn9M9hT1Ck+tkdq2ipb5ptn9v2wgJiBynB4qmBP1Oc
+jyQua+cCgYEAl77hJQK97tdJ5TuOXSsdpW8IMvbiaWTgvZtKVJev31lWgJ+knpCf
+AaZna5YokhaNvfGGbO5N8YoYShIpGdvWI+dIT8xYvPkJmYdnTz7/dmBUcwLtNVx/
+7PI/l5XrFMRsnu/CYuBPuWB+RCTLjIr1D1RluNbIb7xr+kDHuzgInvA=
+-----END RSA PRIVATE KEY-----
+msf auxiliary(ssh_login_pubkey) > run
+
+[*] 192.168.2.156:22 SSH - Testing Cleartext Keys
+[*] SSH - Testing 1 keys from
 [+] SSH - Success: 'ubuntu:-----BEGIN RSA PRIVATE KEY-----
 MIIEpQIBAAKCAQEAtwJrqowPyjWONHUCMqU/Fh3yRn42+X9hahtTv/6plYpb4WrA
 NxDaYIrBGAO//u2SkGcIhnAdzYVmovWahKEwcxZ2XJo/nj4gjh1CbI1xVCFeE/oX

--- a/documentation/modules/auxiliary/scanner/ssh/ssh_login_pubkey.md
+++ b/documentation/modules/auxiliary/scanner/ssh/ssh_login_pubkey.md
@@ -36,7 +36,7 @@
 
   **PRIVATE_KEY**
 
-  A string of the private key to attempt. For MSFConsole users the option should be set to `file:PRIVATE_KEY_PATH` and it will read in the string value of the private key. Currently OpenSSH, RSA, DSA, and EC private keys are supported. 
+  A string of the private key to attempt. For MSFConsole users the option should be set to `file:PRIVATE_KEY_PATH` and it will read in the string value of the private key. Currently OpenSSH, RSA, DSA, and ECDSA private keys are supported. 
   
   **RHOSTS**
   

--- a/lib/msf/core/auxiliary/command_shell.rb
+++ b/lib/msf/core/auxiliary/command_shell.rb
@@ -51,6 +51,15 @@ module Auxiliary::CommandShell
     framework.sessions.register(sess)
     sess.process_autoruns(datastore)
 
+    # Notify the framework that we have a new session opening up...
+    # Don't let errant event handlers kill our session
+    begin
+      framework.events.on_session_open(sess)
+    rescue ::Exception => e
+      wlog("Exception in on_session_open event handler: #{e.class}: #{e}")
+      wlog("Call Stack\n#{e.backtrace.join("\n")}")
+    end
+
     sess
   end
 

--- a/modules/auxiliary/scanner/ssh/ssh_login.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_login.rb
@@ -58,6 +58,8 @@ class MetasploitModule < Msf::Auxiliary
   def session_setup(result, scanner)
     return unless scanner.ssh_socket
 
+    platform = scanner.get_platform(result.proof)
+
     # Create a new session
     conn = Net::SSH::CommandStream.new(scanner.ssh_socket)
 
@@ -73,7 +75,7 @@ class MetasploitModule < Msf::Auxiliary
     self.sockets.delete(scanner.ssh_socket.transport.socket)
 
     # Set the session platform
-    s.platform = scanner.get_platform(result.proof)
+    s.platform = platform
 
     # Create database host information
     host_info = {host: scanner.host}
@@ -90,6 +92,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def run_host(ip)
     @ip = ip
+    print_brute :ip => ip, :msg => "Starting bruteforce"
 
     cred_collection = Metasploit::Framework::CredentialCollection.new(
       blank_passwords: datastore['BLANK_PASSWORDS'],

--- a/modules/auxiliary/scanner/ssh/ssh_login_pubkey.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_login_pubkey.rb
@@ -239,7 +239,7 @@ class MetasploitModule < Msf::Auxiliary
       end
 
       if @private_key.present?
-        data = Net::SSH::KeyFactory.load_data_private_key(@private_key).to_s
+        data = Net::SSH::KeyFactory.load_data_private_key(@private_key, @password, false).to_s
         if valid_key?(data)
           @key_data << data
         else

--- a/modules/auxiliary/scanner/ssh/ssh_login_pubkey.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_login_pubkey.rb
@@ -41,7 +41,7 @@ class MetasploitModule < Msf::Auxiliary
         Opt::RPORT(22),
         OptPath.new('KEY_PATH', [false, 'Filename or directory of cleartext private keys. Filenames beginning with a dot, or ending in ".pub" will be skipped. Duplicate private keys will be ignored.']),
         OptString.new('KEY_PASS', [false, 'Passphrase for SSH private key(s)']),
-        OptString.new('PRIVATE_KEY', [false, 'The string value of the private key that will be used. If you are using MSFConsole, this value should be set as file:PRIVATE_KEY_PATH. OpenSSH, RSA, DSA, and EC private keys are supported.'])
+        OptString.new('PRIVATE_KEY', [false, 'The string value of the private key that will be used. If you are using MSFConsole, this value should be set as file:PRIVATE_KEY_PATH. OpenSSH, RSA, DSA, and ECDSA private keys are supported.'])
       ], self.class
     )
 
@@ -134,7 +134,18 @@ class MetasploitModule < Msf::Auxiliary
 
     keys = prepend_db_keys(keys)
 
-    print_brute :level => :vstatus, :ip => ip, :msg => "Testing #{keys.key_data.count} keys from #{datastore['KEY_PATH']}"
+    key_count = keys.key_data.count
+    key_sources = []
+    unless datastore['KEY_PATH'].blank?
+      key_sources.append(datastore['KEY_PATH'])
+    end
+
+    unless datastore['PRIVATE_KEY'].blank?
+      key_sources.append('PRIVATE_KEY')
+    end
+
+
+    print_brute :level => :vstatus, :ip => ip, :msg => "Testing #{key_count} #{'key'.pluralize(key_count)} from #{key_sources.join(' and ')}"
     scanner = Metasploit::Framework::LoginScanner::SSH.new(
       host: ip,
       port: rport,

--- a/modules/auxiliary/scanner/ssh/ssh_login_pubkey.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_login_pubkey.rb
@@ -39,8 +39,9 @@ class MetasploitModule < Msf::Auxiliary
     register_options(
       [
         Opt::RPORT(22),
-        OptPath.new('KEY_PATH', [true, 'Filename or directory of cleartext private keys. Filenames beginning with a dot, or ending in ".pub" will be skipped. Duplicate private keys will be ignored.']),
+        OptPath.new('KEY_PATH', [false, 'Filename or directory of cleartext private keys. Filenames beginning with a dot, or ending in ".pub" will be skipped. Duplicate private keys will be ignored.']),
         OptString.new('KEY_PASS', [false, 'Passphrase for SSH private key(s)']),
+        OptString.new('PRIVATE_KEY', [false, 'The string value of the private key that will be used. If you are using MSFConsole, this value should be set as file:PRIVATE_KEY_PATH. OpenSSH, RSA, DSA, and EC private keys are supported.'])
       ], self.class
     )
 
@@ -69,7 +70,7 @@ class MetasploitModule < Msf::Auxiliary
     datastore['RHOST']
   end
 
-  def session_setup(result, scanner, fingerprint)
+  def session_setup(result, scanner, fingerprint, cred_core_private_id)
     return unless scanner.ssh_socket
 
     # Create a new session from the socket
@@ -78,12 +79,13 @@ class MetasploitModule < Msf::Auxiliary
     # Clean up the stored data - need to stash the keyfile into
     # a datastore for later reuse.
     merge_me = {
-      'USERPASS_FILE'  => nil,
-      'USER_FILE'      => nil,
-      'PASS_FILE'      => nil,
-      'USERNAME'       => result.credential.public,
-      'SSH_KEYFILE_B64' => [result.credential.private].pack("m*").gsub("\n",""),
-      'KEY_PATH'        => nil
+      'USERPASS_FILE'        => nil,
+      'USER_FILE'            => nil,
+      'PASS_FILE'            => nil,
+      'USERNAME'             => result.credential.public,
+      'CRED_CORE_PRIVATE_ID' => cred_core_private_id,
+      'SSH_KEYFILE_B64'      => [result.credential.private].pack("m*").gsub("\n",""),
+      'KEY_PATH'             => nil
     }
 
     info = "SSH #{result.credential.public}:#{fingerprint} (#{ip}:#{rport})"
@@ -120,6 +122,7 @@ class MetasploitModule < Msf::Auxiliary
       password: datastore['KEY_PASS'],
       user_file: datastore['USER_FILE'],
       username: datastore['USERNAME'],
+      private_key: datastore['PRIVATE_KEY']
     )
 
     unless keys.valid?
@@ -161,7 +164,7 @@ class MetasploitModule < Msf::Auxiliary
           create_credential_login(credential_data)
           tmp_key = result.credential.private
           ssh_key = SSHKey.new tmp_key
-          session_setup(result, scanner, ssh_key.fingerprint) if datastore['CreateSession']
+          session_setup(result, scanner, ssh_key.fingerprint, credential_core.private_id) if datastore['CreateSession']
           if datastore['GatherProof'] && scanner.get_platform(result.proof) == 'unknown'
             msg = "While a session may have opened, it may be bugged.  If you experience issues with it, re-run this module with"
             msg << " 'set gatherproof false'.  Also consider submitting an issue at github.com/rapid7/metasploit-framework with"
@@ -187,12 +190,12 @@ class MetasploitModule < Msf::Auxiliary
           scanner.ssh_socket.close if scanner.ssh_socket && !scanner.ssh_socket.closed?
       end
     end
-
   end
 
   class KeyCollection < Metasploit::Framework::CredentialCollection
     attr_accessor :key_data
     attr_accessor :key_path
+    attr_accessor :private_key
     attr_accessor :error_list
 
     # Override CredentialCollection#has_privates?
@@ -207,26 +210,43 @@ class MetasploitModule < Msf::Auxiliary
     def valid?
       @error_list = []
       @key_data = Set.new
-      if File.directory?(@key_path)
-        @key_files ||= Dir.entries(@key_path).reject { |f| f =~ /^\x2e|\x2epub$/ }
-        @key_files.each do |f|
+
+      unless @private_key.present? || @key_path.present?
+        raise RuntimeError, "No key path or key provided"
+      end
+
+      if @key_path.present?
+        if File.directory?(@key_path)
+          @key_files ||= Dir.entries(@key_path).reject { |f| f =~ /^\x2e|\x2epub$/ }
+          @key_files.each do |f|
+            begin
+              data = read_key(File.join(@key_path, f))
+              @key_data << data if valid_key?(data)
+            rescue StandardError => e
+              @error_list << "#{File.join(@key_path, f)}: #{e}"
+            end
+          end
+        elsif File.file?(@key_path)
           begin
-            data = read_key(File.join(@key_path, f))
+            data = read_key(@key_path)
             @key_data << data if valid_key?(data)
           rescue StandardError => e
-            @error_list << "#{File.join(@key_path, f)}: #{e}"
+            @error_list << "#{@key_path} could not be read, #{e}"
           end
+        else
+          raise RuntimeError, "Invalid key path"
         end
-      elsif File.file?(@key_path)
-        begin
-          data = read_key(@key_path)
-          @key_data << data if valid_key?(data)
-        rescue StandardError => e
-          @error_list << "#{@key_path} could not be read, #{e}"
-        end
-      else
-        raise RuntimeError, "No key path"
       end
+
+      if @private_key.present?
+        data = Net::SSH::KeyFactory.load_data_private_key(@private_key).to_s
+        if valid_key?(data)
+          @key_data << data
+        else
+          raise RuntimeError, "Invalid private key"
+        end
+      end
+
       !@key_data.empty?
     end
 


### PR DESCRIPTION
## Description

This is adding a private key option so that the string value of a key can be passed into the ssh_login_pubkey module as well, this is to add functionality to the module as well as refactor this module into the Pro codebase.

## Verification

- [ ] Install SSH and start it
- [ ] Create an SSH keypair and copy the public key over to a VM for verification
- [ ] Start `msfconsole`
- [ ] `use auxiliary/scanner/ssh/ssh_login_pubkey`
- [ ] set `rhosts` to the IP of the VM
- [ ] set `username` or `user_file`
- [ ] set `private_key` to `file:PRIVATE_KEY_FILE`
- [ ] Confirm that private_key now has your private key stored in it
- [ ] `run`
- [ ] Verify that you now have a successful login

Documentation has been updated within this PR but if you feel the need to add more you can do so [here](https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/auxiliary/scanner/ssh/ssh_login_pubkey.md)

