### PR TITLE
Very rough+small start, demoed a few weeks ago with VoiceOver.

### DIFF
--- a/lib/metasploit/framework/command/console.rb
+++ b/lib/metasploit/framework/command/console.rb
@@ -44,7 +44,7 @@ class Metasploit::Framework::Command::Console < Metasploit::Framework::Command::
     when :version
       $stderr.puts "Framework Version: #{Metasploit::Framework::VERSION}"
     else
-      spinner unless parsed_options.options.console.quiet
+      spinner unless parsed_options.options.console.quiet || parsed_options.options.console.screen_reader
       driver.run
     end
   end
@@ -80,6 +80,7 @@ class Metasploit::Framework::Command::Console < Metasploit::Framework::Command::
       driver_options['DatabaseMigrationPaths'] = options.database.migrations_paths
       driver_options['DatabaseYAML'] = options.database.config
       driver_options['DeferModuleLoads'] = options.modules.defer_loads
+      driver_options['ScreenReader'] = options.console.screen_reader
       driver_options['DisableBanner'] = options.console.quiet
       driver_options['DisableDatabase'] = options.database.disable
       driver_options['HistFile'] = options.console.histfile

--- a/lib/metasploit/framework/parsed_options/console.rb
+++ b/lib/metasploit/framework/parsed_options/console.rb
@@ -13,6 +13,7 @@ class Metasploit::Framework::ParsedOptions::Console < Metasploit::Framework::Par
         options.console.histfile = nil
         options.console.local_output = nil
         options.console.plugins = []
+        options.console.screen_reader = false
         options.console.quiet = false
         options.console.real_readline = false
         options.console.resources = []
@@ -53,6 +54,10 @@ class Metasploit::Framework::ParsedOptions::Console < Metasploit::Framework::Par
 
         option_parser.on('-p', '--plugin PLUGIN', 'Load a plugin on startup') do |plugin|
           options.console.plugins << plugin
+        end
+
+        option_parser.on('-s', '--screen-reader', 'Enable better screen reader compatibility') do
+          options.console.screen_reader = true
         end
 
         option_parser.on('-q', '--quiet', 'Do not print the banner on startup') do

--- a/lib/msf/base/serializer/readable_text.rb
+++ b/lib/msf/base/serializer/readable_text.rb
@@ -591,16 +591,21 @@ class ReadableText
       'Indent'  => indent.length,
       'Columns' =>
         [
-          'Name',
-          'Current Setting',
-          'Required',
-          'Description'
+          'Name,',
+          'Current Setting,',
+          'Required,',
+          'Description,.'
         ])
 
     mod.options.sorted.each do |name, opt|
       next unless opt.advanced?
       val = mod.datastore[name].nil? ? opt.default : mod.datastore[name]
-      tbl << [ name, opt.display_value(val), opt.required? ? "yes" : "no", opt.desc ]
+      if opt.display_value(val) and !opt.display_value(val).empty?
+        dval = "#{opt.display_value(val)},"
+      else
+        dval = "NIL,"
+      end
+      tbl << [ "#{name},", dval, opt.required? ? "yes," : "no,", "#{opt.desc},." ]
     end
 
     return tbl.to_s

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -215,40 +215,52 @@ class Core
   # Display one of the fabulous banners.
   #
   def cmd_banner(*args)
-    banner  = "%cya" + Banner.to_s + "%clr\n\n"
+    stats       = framework.stats
+    version     = "%yelmetasploit v#{Metasploit::Framework::VERSION}%clr",
+    padding     = 48
 
-    # These messages should /not/ show up when you're on a git checkout;
-    # you're a developer, so you already know all this.
-    if (is_apt || binary_install)
-      content = [
-        "Trouble managing data? List, sort, group, tag and search your pentest data\nin Metasploit Pro -- learn more on http://rapid7.com/metasploit",
-        "Frustrated with proxy pivoting? Upgrade to layer-2 VPN pivoting with\nMetasploit Pro -- learn more on http://rapid7.com/metasploit",
-        "Payload caught by AV? Fly under the radar with Dynamic Payloads in\nMetasploit Pro -- learn more on http://rapid7.com/metasploit",
-        "Easy phishing: Set up email templates, landing pages and listeners\nin Metasploit Pro -- learn more on http://rapid7.com/metasploit",
-        "Taking notes in notepad? Have Metasploit Pro track & report\nyour progress and findings -- learn more on http://rapid7.com/metasploit",
-        "Tired of typing 'set RHOSTS'? Click & pwn with Metasploit Pro\nLearn more on http://rapid7.com/metasploit",
-        "Love leveraging credentials? Check out bruteforcing\nin Metasploit Pro -- learn more on http://rapid7.com/metasploit",
-        "Save 45% of your time on large engagements with Metasploit Pro\nLearn more on http://rapid7.com/metasploit",
-        "Validate lots of vulnerabilities to demonstrate exposure\nwith Metasploit Pro -- Learn more on http://rapid7.com/metasploit"
-      ]
-      banner << content.sample # Ruby 1.9-ism!
-      banner << "\n\n"
+    if (args.length == 0)
+      banner  = "%cya" + Banner.to_s + "%clr\n\n"
+
+      # These messages should /not/ show up when you're on a git checkout;
+      # you're a developer, so you already know all this.
+      if (is_apt || binary_install)
+        content = [
+          "Trouble managing data? List, sort, group, tag and search your pentest data\nin Metasploit Pro -- learn more on http://rapid7.com/metasploit",
+          "Frustrated with proxy pivoting? Upgrade to layer-2 VPN pivoting with\nMetasploit Pro -- learn more on http://rapid7.com/metasploit",
+          "Payload caught by AV? Fly under the radar with Dynamic Payloads in\nMetasploit Pro -- learn more on http://rapid7.com/metasploit",
+          "Easy phishing: Set up email templates, landing pages and listeners\nin Metasploit Pro -- learn more on http://rapid7.com/metasploit",
+          "Taking notes in notepad? Have Metasploit Pro track & report\nyour progress and findings -- learn more on http://rapid7.com/metasploit",
+          "Tired of typing 'set RHOSTS'? Click & pwn with Metasploit Pro\nLearn more on http://rapid7.com/metasploit",
+          "Love leveraging credentials? Check out bruteforcing\nin Metasploit Pro -- learn more on http://rapid7.com/metasploit",
+          "Save 45% of your time on large engagements with Metasploit Pro\nLearn more on http://rapid7.com/metasploit",
+          "Validate lots of vulnerabilities to demonstrate exposure\nwith Metasploit Pro -- Learn more on http://rapid7.com/metasploit"
+        ]
+        banner << content.sample # Ruby 1.9-ism!
+        banner << "\n\n"
+      end
+
+      exp_aux_pos = "#{stats.num_exploits} exploits - #{stats.num_auxiliary} auxiliary - #{stats.num_post} post",
+      pay_enc_nop = "#{stats.num_payloads} payloads - #{stats.num_encoders} encoders - #{stats.num_nops} nops",
+      eva         = "#{stats.num_evasion} evasion",
+
+      banner << ("       =[ %-#{padding+8}s]\n" % version)
+      banner << ("+ -- --=[ %-#{padding}s]\n" % exp_aux_pos)
+      banner << ("+ -- --=[ %-#{padding}s]\n" % pay_enc_nop)
+      banner << ("+ -- --=[ %-#{padding}s]\n" % eva)
+    elsif (args[0] == "-s")
+      exp_aux_pos = "#{stats.num_exploits.to_s.chars.to_a.reverse.each_slice(3).map(&:join).join(",").reverse} exploits, #{stats.num_auxiliary.to_s.chars.to_a.reverse.each_slice(3).map(&:join).join(",").reverse} auxiliary, #{stats.num_post.to_s.chars.to_a.reverse.each_slice(3).map(&:join).join(",").reverse} post",
+      pay_enc_nop = "#{stats.num_payloads} payloads, #{stats.num_encoders.to_s.chars.to_a.reverse.each_slice(3).map(&:join).join(",").reverse} encoders, #{stats.num_nops.to_s.chars.to_a.reverse.each_slice(3).map(&:join).join(",").reverse} nops",
+      eva         = "#{stats.num_evasion.to_s.chars.to_a.reverse.each_slice(3).map(&:join).join(",").reverse} evasion",
+
+      banner = ""
+      banner << ("%s,.\n" % version)
+      banner << ("%s,.\n" % exp_aux_pos)
+      banner << ("%s,.\n" % pay_enc_nop)
+      banner << ("%s,.\n" % eva)
     end
 
     avdwarn = nil
-
-    stats       = framework.stats
-    version     = "%yelmetasploit v#{Metasploit::Framework::VERSION}%clr",
-    exp_aux_pos = "#{stats.num_exploits} exploits - #{stats.num_auxiliary} auxiliary - #{stats.num_post} post",
-    pay_enc_nop = "#{stats.num_payloads} payloads - #{stats.num_encoders} encoders - #{stats.num_nops} nops",
-    eva         = "#{stats.num_evasion} evasion",
-    padding     = 48
-
-    banner << ("       =[ %-#{padding+8}s]\n" % version)
-    banner << ("+ -- --=[ %-#{padding}s]\n" % exp_aux_pos)
-    banner << ("+ -- --=[ %-#{padding}s]\n" % pay_enc_nop)
-    banner << ("+ -- --=[ %-#{padding}s]\n" % eva)
-
     if ::Msf::Framework::EICARCorrupted
       avdwarn = []
       avdwarn << "Warning: This copy of the Metasploit Framework has been corrupted by an installed anti-virus program."

--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -502,11 +502,15 @@ class Db
     col_names.map do |col|
       cp_hsh[col] = { 'MaxChar' => 52 }
     end
+    col_names_modified = []
+    col_names.each do |n|
+      col_names_modified << "#{n},"
+    end
     # If we got here, we're searching.  Delete implies search
+    # 'Header'  => "Hosts",
     tbl = Rex::Text::Table.new(
       {
-        'Header'  => "Hosts",
-        'Columns' => col_names,
+        'Columns' => col_names_modified,
         'ColProps' => cp_hsh,
         'SortIndex' => order_by
       })
@@ -561,7 +565,11 @@ class Db
             end
           # Otherwise, it's just an attribute
           else
-            host[n] || ""
+            if host[n]
+              "#{host[n].to_s},"
+            else
+              "NIL,"
+            end
           end
         end
 

--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -387,7 +387,11 @@ class Driver < Msf::Ui::Driver
       $stderr.print "\r" + (" " * 50) + "\n"
     end
 
-    run_single("banner") unless opts['DisableBanner']
+    if opts['ScreenReader']
+      run_single("banner -s")
+    else
+      run_single("banner") unless opts['DisableBanner']
+    end
 
     opts["Plugins"].each do |plug|
       run_single("load '#{plug}'")


### PR DESCRIPTION
EDIT: this is in reference to this [Metasploit Framework discussion](https://github.com/rapid7/metasploit-framework/discussions/14367#discussioncomment-592279).

This was a hackathon project I did in early 2020 (also explains why this fork+branch is WAY behind current Framework) where I used the built-in macOS screen reader.  With limited time (hackathon!), I  looked at improving three problems I noticed right away:

1. Reading useless stuff
2. Reading without appropriate pause
3. No indication of missing data

I put my work behind a new `msfconsole` commandline option: `-s`.  Then I made some improvements (hopefully), such as adding commas/punctuation to create pauses and `NIL` to convey that a field was empty.  Then I juxstaposed some common commands with "before" and "after" video clips, where "before" would be how VoiceOver currently (or in early 2020, anyway) would read `msfconsole` output, and "after" would be running the same command but in a session of `msfconsole -s` where I had tried to make it better.  Here's some of those clips (MAKE SURE TO UNMUTE EACH CLIP!  :P  ):

### starting the console up (wanted to still read the data around module counts, but skip the ASCII banner stuff)

BEFORE

https://user-images.githubusercontent.com/19912177/114250968-0c2db200-9965-11eb-9f66-bae7b6b66e45.mp4

AFTER

https://user-images.githubusercontent.com/19912177/114250973-12bc2980-9965-11eb-8b4a-836f872cd5c1.mp4

### `hosts` command 

BEFORE

https://user-images.githubusercontent.com/19912177/114251051-54e56b00-9965-11eb-9151-b5fdd9f2fb60.mp4

AFTER

https://user-images.githubusercontent.com/19912177/114251202-cf15ef80-9965-11eb-8e1e-14a603f759d6.mp4

### listing a handler's advanced options

BEFORE

https://user-images.githubusercontent.com/19912177/114251125-878f6380-9965-11eb-9089-3c5b9b04d853.mp4

AFTER

https://user-images.githubusercontent.com/19912177/114251123-83634600-9965-11eb-9da4-3deaf85c128e.mp4
