### PR TITLE
Fix broken association handling for remote msfdb services command

### DIFF
--- a/lib/metasploit/framework/data_service/remote/http/response_data_helper.rb
+++ b/lib/metasploit/framework/data_service/remote/http/response_data_helper.rb
@@ -115,7 +115,7 @@ module ResponseDataHelper
 
       case association.macro
         when :belongs_to
-          data.delete("#{k}_id")
+          data.delete(:"#{k}_id")
           # Polymorphic associations do not auto-create the 'build_model' method
           next if association.options[:polymorphic]
           to_ar(association.klass, v, obj.send("build_#{k}"))

--- a/spec/lib/metasploit/framework/data_service/response_data_helper_spec.rb
+++ b/spec/lib/metasploit/framework/data_service/response_data_helper_spec.rb
@@ -1,0 +1,134 @@
+require 'spec_helper'
+require 'json'
+require 'metasploit/framework/data_service/remote/http/core'
+
+RSpec.describe ResponseDataHelper do
+  subject do
+    described_mixin = described_class
+    klass = Class.new do
+      include described_mixin
+    end
+    klass.new
+  end
+
+  let(:host_hash) do
+    {
+      id: 1,
+      created_at: '2021-04-12T15:36:51.130Z',
+      address: '127.0.0.1',
+      mac: nil,
+      comm: '',
+      name: 'localhost',
+      state: 'alive',
+      os_name: 'Unknown',
+      os_flavor: nil,
+      os_sp: nil,
+      os_lang: nil,
+      arch: nil,
+      workspace_id: 1,
+      updated_at: '2021-04-12T15:36:51.155Z',
+      purpose: 'device',
+      info: nil,
+      comments: nil,
+      scope: nil,
+      virtual_host: nil,
+      note_count: 0,
+      vuln_count: 0,
+      service_count: 5,
+      host_detail_count: 0,
+      exploit_attempt_count: 0,
+      cred_count: 0,
+      detected_arch: nil,
+      os_family: nil
+    }
+  end
+  let(:service_hash) do
+    {
+      id: 1,
+      host_id: 1,
+      created_at: '2021-04-12T15:36:51.146Z',
+      port: 53,
+      proto: 'tcp',
+      state: 'open',
+      name: 'domain',
+      updated_at: '2021-04-12T15:36:51.146Z',
+      info: '',
+      host: host_hash
+    }
+  end
+
+  describe '#json_to_mdm_object' do
+    context 'when the json is a service object' do
+      let(:response_body_json) do
+        JSON.pretty_generate({ data: [service_hash] })
+      end
+
+      let(:response_wrapper) do
+        instance_double(
+          Metasploit::Framework::DataService::RemoteHTTPDataService::SuccessResponse,
+          response_body: response_body_json
+        )
+      end
+
+      before(:each) do
+        allow(response_wrapper).to receive(:is_a?).with(Metasploit::Framework::DataService::RemoteHTTPDataService::SuccessResponse).and_return(true)
+      end
+
+      it 'converts the service object successfully' do
+        expected_service_attributes = {
+          id: 1,
+          host_id: 1,
+          created_at: Time.zone.parse('2021-04-12T15:36:51.146Z'),
+          port: 53,
+          proto: 'tcp',
+          state: 'open',
+          name: 'domain',
+          updated_at: Time.zone.parse('2021-04-12T15:36:51.146Z'),
+          info: ''
+        }
+
+        result = subject.json_to_mdm_object(response_wrapper, 'Mdm::Service')
+        expect(result.size).to be(1)
+        expect(result.first.class).to eq Mdm::Service
+        expect(result.first).to have_attributes(expected_service_attributes)
+      end
+
+      it 'converts the service relation host object successfully' do
+        expected_host_attributes = {
+          id: 1,
+          created_at: Time.zone.parse('2021-04-12T15:36:51.130Z'),
+          address: '127.0.0.1',
+          mac: nil,
+          comm: '',
+          name: 'localhost',
+          state: 'alive',
+          os_name: 'Unknown',
+          os_flavor: nil,
+          os_sp: nil,
+          os_lang: nil,
+          arch: nil,
+          workspace_id: 1,
+          updated_at: Time.zone.parse('2021-04-12T15:36:51.155Z'),
+          purpose: 'device',
+          info: nil,
+          comments: nil,
+          scope: nil,
+          virtual_host: nil,
+          note_count: 0,
+          vuln_count: 0,
+          service_count: 5,
+          host_detail_count: 0,
+          exploit_attempt_count: 0,
+          cred_count: 0,
+          detected_arch: nil,
+          os_family: nil
+        }
+
+        service = subject.json_to_mdm_object(response_wrapper, 'Mdm::Service').first
+        host = service.host
+        expect(host.class).to eql(Mdm::Host)
+        expect(host).to have_attributes(expected_host_attributes)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Noticed this when testing the RPC functionality

### Before

Using the services command whilst connected to an external database was previously attempting to read the host information from the local database, rather than the remote database:
```
msf6 > services

[-] Error while running command services: undefined method `address' for nil:NilClass

Call stack:
/mnt/hgfs/metasploit-framework/lib/msf/ui/console/command_dispatcher/db.rb:791:in `block (2 levels) in cmd_services'
/mnt/hgfs/metasploit-framework/lib/msf/ui/console/command_dispatcher/db.rb:775:in `each'
/mnt/hgfs/metasploit-framework/lib/msf/ui/console/command_dispatcher/db.rb:775:in `block in cmd_services'
/mnt/hgfs/metasploit-framework/lib/msf/ui/console/command_dispatcher/db.rb:2007:in `block in each_host_range_chunk'
/mnt/hgfs/metasploit-framework/lib/msf/ui/console/command_dispatcher/db.rb:1988:in `each'
/mnt/hgfs/metasploit-framework/lib/msf/ui/console/command_dispatcher/db.rb:1988:in `each_host_range_chunk'
/mnt/hgfs/metasploit-framework/lib/msf/ui/console/command_dispatcher/db.rb:770:in `cmd_services'
/mnt/hgfs/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:542:in `run_command'
/mnt/hgfs/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:491:in `block in run_single'
/mnt/hgfs/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:485:in `each'
/mnt/hgfs/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:485:in `run_single'
/mnt/hgfs/metasploit-framework/lib/rex/ui/text/shell.rb:157:in `run'
/mnt/hgfs/metasploit-framework/lib/metasploit/framework/command/console.rb:48:in `start'
/mnt/hgfs/metasploit-framework/lib/metasploit/framework/command/base.rb:82:in `start'
./msfconsole:23:in `<main>'
```

I tracked this problem down to the change of hash map keys being strings to symbols, and it looks like this line was missed: https://github.com/rapid7/metasploit-framework/commit/bcfe434d1ec880ef727b5406b44c3470cd3523b6

### After

The services command works as expected:
```
msf6 > services
Services
========

host       port  proto  name        state  info
----       ----  -----  ----        -----  ----
127.0.0.1  53    tcp    domain      open
127.0.0.1  631   tcp    ipp         open
127.0.0.1  5432  tcp    postgresql  open
127.0.0.1  8009  tcp    ajp13       open
127.0.0.1  8080  tcp    http-proxy  open
```

## Verification

- Create a new remote msfdb on machine A
- From machine B, connect to machine A's database:
> db_connect --name test-remote-service --token 0bf5d341cd35a333f8562c83d16c4f3efb071a41a7ec17575b9c13b1700d631189b4282e591595c3 --skip-verify https://192.168.222.1:5443
- Run `db_nmap 127.0.0.1` with running services
- Run the `services` command and ensure that the console doesn't break, and that information appears as expected

Note that machine B's database should be empty for this to work best when verifying the stack trace, otherwise it will work - but just show data from the local database rather than remote database