### PR TITLE
update metasploit-payloads gem to v2.0.43

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,7 +28,7 @@ PATH
       metasploit-concern (~> 3.0.0)
       metasploit-credential (~> 4.0.0)
       metasploit-model (~> 3.1.0)
-      metasploit-payloads (= 2.0.41)
+      metasploit-payloads (= 2.0.43)
       metasploit_data_models (~> 4.1.0)
       metasploit_payloads-mettle (= 1.0.9)
       mqtt
@@ -222,7 +222,7 @@ GEM
       activemodel (~> 5.2.2)
       activesupport (~> 5.2.2)
       railties (~> 5.2.2)
-    metasploit-payloads (2.0.41)
+    metasploit-payloads (2.0.43)
     metasploit_data_models (4.1.3)
       activerecord (~> 5.2.2)
       activesupport (~> 5.2.2)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -70,7 +70,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model', '~> 3.1.0'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '2.0.41'
+  spec.add_runtime_dependency 'metasploit-payloads', '2.0.43'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '1.0.9'
   # Needed by msfgui and other rpc components


### PR DESCRIPTION
This pulls in two PHP changes from metasploit-payloads:
 - https://github.com/rapid7/metasploit-payloads/pull/482
 - https://github.com/rapid7/metasploit-payloads/pull/483

## Verification

- [x] Ensure tests pass
- [x] Check PHP meterpreter now has a `resolve` command