### PR TITLE
Correct DNS PTR record crash

### DIFF
--- a/lib/msf/core/exploit/remote/dns/enumeration.rb
+++ b/lib/msf/core/exploit/remote/dns/enumeration.rb
@@ -189,8 +189,8 @@ module Enumeration
     records = []
     resp.answer.each do |r|
       next unless r.class == Dnsruby::RR::IN::PTR
-      records << r.ptr.to_s
-      print_good("#{ip}: PTR: #{r.ptr} ")
+      records << r.rdata.to_s
+      print_good("#{ip}: PTR: #{r.rdata} ")
     end
     return if records.blank?
     dns_note(ip, 'DNS PTR records', records) if datastore['DnsNote']


### PR DESCRIPTION
When using `auxiliary/gather/enum_dns` and setting `NS` to an internal system, the following crash occurs (which is fixed with this PR):
```
[-] Auxiliary failed: NoMethodError undefined method `ptr' for #<Dnsruby::RR::IN::PTR:0x00007f8b9e9cb450>
```

**Before**:

![image](https://user-images.githubusercontent.com/13158109/114723144-6c777780-9d08-11eb-97aa-91d9e82cf54c.png)

**After**:
![image](https://user-images.githubusercontent.com/13158109/114723200-7b5e2a00-9d08-11eb-8138-f7fbfc9c09e1.png)
