### PR TITLE
Raise more descriptive meterpreter related error messages

### DIFF
--- a/lib/msf/core/post_mixin.rb
+++ b/lib/msf/core/post_mixin.rb
@@ -59,7 +59,10 @@ module Msf::PostMixin
       select(nil,nil,nil,back_off_period)
     end
     session_ready = !!session.sys
-    raise "Could not get a hold of the session." unless session_ready
+    unless session_ready
+      raise "The stdapi extension has not been loaded yet." unless session.tlv_enc_key.nil?
+      raise "Could not get a hold of the session."
+    end
     return session_ready
   end
 

--- a/lib/rex/post/meterpreter/extension_mapper.rb
+++ b/lib/rex/post/meterpreter/extension_mapper.rb
@@ -26,6 +26,8 @@ class ExtensionMapper
   end
 
   def self.get_extension_name(id)
+    id = id - (id % COMMAND_ID_RANGE)
+
     self.get_extension_names.find do |name|
       begin
         klass = self.get_extension_klass(name)


### PR DESCRIPTION
This updates a few error conditions to raise exceptions with more specific messages that will hopefully help users and developers to more quickly and easily identify the cause of the issue. These changes are in the same vein as #14617, but instead of being for Meterpreter UI commands, now Metasploit will provide similar information through direct API use (as is the case with modules). The aforementioned PR started to place *all* commands into the command array, and these changes build on that by first checking a request packet's API command ID (in `#method`) before issuing the request. This allows Metasploit to proactively identify when a command will fail due to it not being supported by the remote end. 

Eventually, Metasploit should probably be proactively validating a session's compatibility prior to running a post module (see discussion #14493). Once that's the case, a descriptive error message should still be used incase an incompatible command is somehow issued.

## Verification

The Java Meterpreter does not support the `stdapi_net_resolve_hosts` command at this time, meaning that the `post/multi/gather/resolve_hosts` module can't use it. In the steps below, we use this as an example to show the more descriptive error message.

- [x] Generate a Java Meterpreter
- [x] Start a handler for the Java Meterpreter, set `AutoLoadStdapi` to false (needed for one of the error conditions)
- [x] Execute the payload to establish a session
- [x] `use post/multi/gather/resolve_hosts`
- [x] Set the `SESSION` parameter and run the module
- [x] See a stack trace that says it failed because the stdapi extension wasn't loaded yet (instead of the old "Could not get a hold of the session." message)
- [x] Load the stdapi extension in the meterpreter session and run the module again
- [x] See a stack trace, but note that the error message is descriptive and correctly states that the command isn't supported instead of a generic message

### Demo (New)

```
msf6 post(multi/gather/resolve_hosts) > run

[!] SESSION may not be compatible with this module.
[-] Post failed: RuntimeError The stdapi extension has not been loaded yet.
[-] Call stack:
[-]   /home/smcintyre/Repositories/metasploit-framework/lib/msf/core/post_mixin.rb:63:in `check_for_session_readiness'
[-]   /home/smcintyre/Repositories/metasploit-framework/lib/msf/core/post_mixin.rb:44:in `setup'
[-]   /home/smcintyre/Repositories/metasploit-framework/lib/msf/core/post.rb:28:in `setup'
[*] Post module execution completed
msf6 post(multi/gather/resolve_hosts) > sessions -i -1
[*] Starting interaction with 1...

meterpreter > load stdapi
Loading extension stdapi...Success.
meterpreter > background 
[*] Backgrounding session 1...
msf6 post(multi/gather/resolve_hosts) > run

[!] SESSION may not be compatible with this module.
[*] Attempting to resolve 'google.com' on localhost.localdomain
[-] Post failed: Rex::Post::Meterpreter::RequestError stdapi_net_resolve_hosts: Operation failed: The command is not supported by this Meterpreter type (java/java)
[-] Call stack:
[-]   /home/smcintyre/Repositories/metasploit-framework/lib/rex/post/meterpreter/packet_dispatcher.rb:218:in `send_packet_wait_response'
[-]   /home/smcintyre/Repositories/metasploit-framework/lib/rex/post/meterpreter/packet_dispatcher.rb:186:in `send_request'
[-]   /home/smcintyre/Repositories/metasploit-framework/lib/rex/post/meterpreter/extensions/stdapi/net/resolve.rb:55:in `resolve_hosts'
[-]   /home/smcintyre/Repositories/metasploit-framework/modules/post/multi/gather/resolve_hosts.rb:60:in `run'
[*] Post module execution completed
msf6 post(multi/gather/resolve_hosts) >
```

### Demo (Old)

```
msf6 payload(java/meterpreter/reverse_tcp) > set AutoLoadStdapi false
AutoLoadStdapi => false
msf6 payload(java/meterpreter/reverse_tcp) > to_handler 
[*] Payload Handler Started as Job 0
msf6 payload(java/meterpreter/reverse_tcp) > 
[*] Started reverse TCP handler on 192.168.159.128:4444 

msf6 payload(java/meterpreter/reverse_tcp) > 
[*] Sending stage (58055 bytes) to 192.168.159.128
[*] Meterpreter session 1 opened (192.168.159.128:4444 -> 192.168.159.128:52418) at 2021-04-14 12:57:20 -0400

msf6 payload(java/meterpreter/reverse_tcp) > use post/multi/gather/resolve_hosts 
msf6 post(multi/gather/resolve_hosts) > run

[!] SESSION may not be compatible with this module.
[-] Post failed: RuntimeError Could not get a hold of the session.
[-] Call stack:
[-]   /home/smcintyre/Repositories/metasploit-framework/lib/msf/core/post_mixin.rb:62:in `check_for_session_readiness'
[-]   /home/smcintyre/Repositories/metasploit-framework/lib/msf/core/post_mixin.rb:44:in `setup'
[-]   /home/smcintyre/Repositories/metasploit-framework/lib/msf/core/post.rb:28:in `setup'
[*] Post module execution completed
msf6 post(multi/gather/resolve_hosts) > sessions -i -1
[*] Starting interaction with 1...

meterpreter > load stdapi
Loading extension stdapi...Success.
meterpreter > background 
[*] Backgrounding session 1...
msf6 post(multi/gather/resolve_hosts) > run

[!] SESSION may not be compatible with this module.
[*] Attempting to resolve 'google.com' on localhost.localdomain
[-] Post failed: Rex::Post::Meterpreter::RequestError stdapi_net_resolve_hosts: Operation failed: 1
[-] Call stack:
[-]   /home/smcintyre/Repositories/metasploit-framework/lib/rex/post/meterpreter/extensions/stfdapi/net/resolve.rb:55:in `resolve_hosts'
[-]   /home/smcintyre/Repositories/metasploit-framework/modules/post/multi/gather/resolve_hosts.rb:60:in `run'
[*] Post module execution completed
msf6 post(multi/gather/resolve_hosts) > 
```