### PR TITLE
Fixes meterpreter tab completion issues

### DIFF
--- a/spec/lib/msf/ui/text/dispatcher_shell_spec.rb
+++ b/spec/lib/msf/ui/text/dispatcher_shell_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+RSpec.describe Rex::Ui::Text::DispatcherShell do
+  let(:prompt) { "%undmsf6%clr" }
+  let(:prompt_char) { "%clr>" }
+  let(:subject) do
+    dummy_class = Class.new
+    dummy_class.include described_class
+    dummy_class.new(prompt, prompt_char)
+  end
+
+  # Tests added to verify regex correctly returns correct values in various situations
+  describe '#shellsplitex' do
+    [
+      { input: "dir", expected: { quote: nil, words: ["dir"] } },
+      { input: "dir \"/\"", expected: {:quote=>nil, :words=>["dir", "/"]} },
+      { input: "dir \"/", expected: {:quote=>"\"", :words=>["dir", "/"]} },
+      { input: "dir \"/Program", expected: {:quote=>"\"", :words=>["dir", "/Program"]} },
+      { input: "dir \"/Program/", expected: {:quote=>"\"", :words=>["dir", "/Program/"]} },
+      { input: "dir C:\\Pro", expected: {:quote=>nil, :words=>["dir", "C:\\Pro"]} },
+      { input: "dir \"C:\\Pro\"", expected: {:quote=>nil, :words=>["dir", "C:\\Pro"]} },
+      { input: "dir 'C:\\Pro'", expected: {:quote=>nil, :words=>["dir", "C:\\Pro"]} },
+      { input: "dir 'C:\\ProgramData\\jim\\bob.rb'", expected: {:quote=>nil, :words=>["dir", "C:\\ProgramData\\jim\\bob.rb"]} },
+      { input: "dir 'C:\\ProgramData\\jim\\'", expected: {:quote=>nil, :words=>["dir", "C:\\ProgramData\\jim\\"]} },
+      { input: "dir \"C:\\Pro", expected: { quote: "\"", words: ["dir", "C:\\Pro"] } },
+      { input: "dir \"C: \\Pro", expected: { quote: "\"", words: ["dir", "C: \\Pro"] } },
+      { input: "dir \"C:\\Program F", expected: { quote: "\"", words: ["dir", "C:\\Program F"] } }
+    ].each do |test|
+      it { expect(subject.shellsplitex(test[:input])).to eql(test[:expected]) }
+    end
+  end
+end


### PR DESCRIPTION
This PR resolves  #14502.

Previously when attempting to tab complete within meterpreter, a stack trace with a nil exception would be returned if the user didn't add end quotes to the string they were attempting to tab complete.
### Examples:
This would have returned a a stack trace with a nil exception.
```Bash
dir "C:\Pro<tab>
```
Whereas, this wouldn't have caused a crash, but didn't tab complete either.
```Bash
dir "C:\Pro<tab>"
```

With this fix, users should now be able to tab complete with meterpreter. 
![meterpreter_autocomplete_fix](https://user-images.githubusercontent.com/69522014/114860783-5808ad00-9de4-11eb-876c-c35466231c2a.gif)

### Tests
This PR also adds tests  verify the regex within `shellsplitex` correctly returns correct values in various situations.

## Side note
The only issue I have encountered and may need to be fixed before merging this PR or maybe create a new ticket for, is when you tab complete it will add the end quote and add a whitespace to the command line (this can be seen in the gif above). This leaves your cursor two spaces away from the string if you wanted to continue tab completing that existing string.
I believe I encountered something similar in a previous tab completion ticket I worked on, so I plan to look into that and see if I can come up with anything.

## Verification

### Payload and handler setup
![image](https://user-images.githubusercontent.com/69522014/114861482-3a881300-9de5-11eb-88e3-edd67437b13e.png)


- [ ] Gain a meterpreter session
- [ ] Try tab completing e.g. `dir "C:\Pro<tab>`
- [ ] **Verify** it no longer returns a stack trace with a nil exception
- [ ] **Verify** it will now tab complete 