### PR TITLE
Automatically verify shell sessions

### DIFF
--- a/lib/msf/base/sessions/command_shell.rb
+++ b/lib/msf/base/sessions/command_shell.rb
@@ -91,13 +91,15 @@ class CommandShell
   def bootstrap(datastore = {}, handler = nil)
     session = self
 
-    token = Rex::Text.rand_text_alphanumeric(16)
-    response = shell_command("echo #{token}")
-    unless response&.include?(token)
-      dlog("Session #{session.sid} failed to respond to an echo command")
-      print_error("Command shell session #{session.sid} is not valid and will be closed")
-      session.kill
-      return nil
+    if datastore['AutoVerifySession']
+      token = Rex::Text.rand_text_alphanumeric(8..24)
+      response = shell_command("echo #{token}")
+      unless response&.include?(token)
+        dlog("Session #{session.sid} failed to respond to an echo command")
+        print_error("Command shell session #{session.sid} is not valid and will be closed")
+        session.kill
+        return nil
+      end
     end
   end
 

--- a/lib/msf/base/sessions/command_shell.rb
+++ b/lib/msf/base/sessions/command_shell.rb
@@ -88,6 +88,26 @@ class CommandShell
     return true
   end
 
+  def bootstrap(datastore = {}, handler = nil)
+    session = self
+
+    token = Rex::Text.rand_text_alphanumeric(16)
+    response = shell_command("echo #{token}")
+    unless response&.include?(token)
+      dlog("Session #{session.sid} failed to respond to an echo command")
+      print_error("Command shell session #{session.sid} is not valid and will be closed")
+      session.kill
+      return nil
+    end
+
+    # Process the auto-run scripts for this session
+    if self.respond_to?(:process_autoruns)
+      self.process_autoruns(datastore)
+    end
+
+    handler.on_session(self) if handler
+  end
+
   #
   # Return the subdir of the `documentation/` directory that should be used
   # to find usage documentation

--- a/lib/msf/base/sessions/command_shell.rb
+++ b/lib/msf/base/sessions/command_shell.rb
@@ -93,7 +93,7 @@ class CommandShell
 
     if datastore['AutoVerifySession']
       token = Rex::Text.rand_text_alphanumeric(8..24)
-      response = shell_command("echo #{token}")
+      response = shell_command("echo #{token}", 3)
       unless response&.include?(token)
         dlog("Session #{session.sid} failed to respond to an echo command")
         print_error("Command shell session #{session.sid} is not valid and will be closed")
@@ -617,20 +617,19 @@ class CommandShell
   #
   # Explicitly run a single command, return the output.
   #
-  def shell_command(cmd)
+  def shell_command(cmd, timeout=5)
     # Send the command to the session's stdin.
     shell_write(cmd + "\n")
 
-    timeo = 5
-    etime = ::Time.now.to_f + timeo
+    etime = ::Time.now.to_f + timeout
     buff = ""
 
     # Keep reading data until no more data is available or the timeout is
     # reached.
-    while (::Time.now.to_f < etime and (self.respond_to?(:ring) or ::IO.select([rstream], nil, nil, timeo)))
+    while (::Time.now.to_f < etime and (self.respond_to?(:ring) or ::IO.select([rstream], nil, nil, timeout)))
       res = shell_read(-1, 0.01)
       buff << res if res
-      timeo = etime - ::Time.now.to_f
+      timeout = etime - ::Time.now.to_f
     end
 
     buff

--- a/lib/msf/base/sessions/command_shell.rb
+++ b/lib/msf/base/sessions/command_shell.rb
@@ -99,13 +99,6 @@ class CommandShell
       session.kill
       return nil
     end
-
-    # Process the auto-run scripts for this session
-    if self.respond_to?(:process_autoruns)
-      self.process_autoruns(datastore)
-    end
-
-    handler.on_session(self) if handler
   end
 
   #

--- a/lib/msf/base/sessions/command_shell_options.rb
+++ b/lib/msf/base/sessions/command_shell_options.rb
@@ -20,7 +20,8 @@ module CommandShellOptions
         OptBool.new('CreateSession', [false, 'Create a new session for every successful login', true]),
         OptString.new('InitialAutoRunScript', "An initial script to run on session creation (before AutoRunScript)"),
         OptString.new('AutoRunScript', "A script to run automatically on session creation."),
-        OptString.new('CommandShellCleanupCommand', "A command to run before the session is closed")
+        OptString.new('CommandShellCleanupCommand', "A command to run before the session is closed"),
+        OptBool.new('AutoVerifySession', [true, 'Automatically verify and drop invalid sessions', true])
       ]
     )
   end

--- a/lib/msf/base/sessions/meterpreter.rb
+++ b/lib/msf/base/sessions/meterpreter.rb
@@ -190,14 +190,6 @@ class Meterpreter < Rex::Post::Meterpreter::Client
         session.execute_script(args.shift, *args)
       end
     end
-
-    # Process the auto-run scripts for this session
-    if self.respond_to?(:process_autoruns)
-      self.process_autoruns(datastore)
-    end
-
-    # Tell the handler that we have a session
-    handler.on_session(self) if handler
   end
 
   ##

--- a/lib/msf/core/exploit.rb
+++ b/lib/msf/core/exploit.rb
@@ -298,7 +298,7 @@ class Exploit < Msf::Module
     if aggressive?
       register_advanced_options(
         [
-          OptInt.new('WfsDelay', [ false, "Additional delay when waiting for a session", 0 ])
+          OptInt.new('WfsDelay', [ false, "Additional delay in seconds to wait for a session", 2 ])
         ], Msf::Exploit)
     end
 
@@ -1256,10 +1256,12 @@ class Exploit < Msf::Module
   end
 
   #
-  # The default "wait for session" delay is zero for all exploits.
+  # The minimum "wait for session" delay is 3 seconds for all exploits, the
+  # WfsDelay configuration option is added on top of this. The delay allows time
+  # for the session handler to perform any session verification.
   #
   def wfs_delay
-    (datastore['WfsDelay'] || 0).to_i
+    (datastore['WfsDelay'] || 0).to_i + 3
   end
 
   #

--- a/lib/msf/core/handler.rb
+++ b/lib/msf/core/handler.rb
@@ -269,15 +269,17 @@ protected
     # Call the handler's on_session() method
     if session.respond_to?(:bootstrap)
       session.bootstrap(datastore, self)
-    else
-      # Process the auto-run scripts for this session
-      if session.respond_to?(:process_autoruns)
-        session.process_autoruns(datastore)
-      end
-      on_session(session)
+
+      return unless session.alive
     end
 
-    return unless session.alive
+    # Process the auto-run scripts for this session
+    if session.respond_to?(:process_autoruns)
+      session.process_autoruns(datastore)
+    end
+
+    # Tell the handler that we have a session
+    on_session(session)
 
     # Notify the framework that we have a new session opening up...
     # Don't let errant event handlers kill our session

--- a/lib/msf/core/handler.rb
+++ b/lib/msf/core/handler.rb
@@ -277,6 +277,8 @@ protected
       on_session(session)
     end
 
+    return unless session.alive
+
     # Notify the framework that we have a new session opening up...
     # Don't let errant event handlers kill our session
     begin


### PR DESCRIPTION
This updates the CommandShell session type to automatically validate that the session is established and responsive. This is similar to what the Meterpreter session type does already, as well as the [bind_udp](https://github.com/rapid7/metasploit-framework/blob/1a2bf98222cd7d1a51da459fbd86b65e5fe3d500/lib/msf/core/handler/bind_udp.rb#L147-L152). The intention is to help users by automatically determining which are valid sessions before they can be used and thus avoid failed module runs.

The echo command is used to validate that the session is responsive. This works in posix shells as well as Windows' command shell and powershell, all three of which have been tested with these changes.

Previously on the Meterpreter session type was using the `#bootstrap` method. This is where it's validation takes place, so this uses the same pattern for the command shell. A check to ensure the session is still alive is performed after the `#bootstrap` call to account for the session having been killed. Additionally, processing autoruns was consistently moved into the handler, regardless of whether or not there was a `#bootstrap` callback since the original Meterpreter one ran autoruns as one of the last steps anyways.

## Verification

- [ ] Start `msfconsole`
- [ ] Select a command shell payload with a reverse listener
    - [ ] `handler -p python/shell_reverse_tcp -P 4444 -H 0.0.0.0`
- [ ] Connect to it with netcat, just connect without a shell to test an invalid connection
    - [ ] `ncat localhost 4444`
- [ ] After a few seconds, see that the shell session is invalid and that it is closed
- [ ] Generate a legitimate payload and run it, see that a valid session is established and responsive
- [ ] Try the same steps above with a bind shell, using netcat as the listener (use the `-l` option)

## Demo

```
msf6 > handler -p python/shell_reverse_tcp -P 4444 -H 0.0.0.0
[*] Payload handler running as background job 0.

msf6 > [*] Started reverse TCP handler on 0.0.0.0:4444 
[-] Command shell session 3 is not valid and will be closed
[*] 127.0.0.1 - Command shell session 3 closed.
```