### PR TITLE
Move exploit/linux/http/citrix_dir_traversal_rce to exploit/freebsd

### DIFF
--- a/documentation/modules/exploit/freebsd/http/citrix_dir_traversal_rce.md
+++ b/documentation/modules/exploit/freebsd/http/citrix_dir_traversal_rce.md
@@ -9,7 +9,7 @@ This `/vpns/` directory is interesting because it contains Perl code. The script
 A malicious attacker can execute arbitrary commands remotely by creating a corrupted XML file that uses the Perl Template Toolkit in part of payload.
 
 ```
-msf5 exploit(linux/http/citrix_dir_traversal_rce) > run
+msf5 exploit(freebsd/http/citrix_dir_traversal_rce) > run
 
 [*] Using auxiliary/scanner/http/citrix_dir_traversal as check
 [+] http://127.0.0.1:8080/vpn/../vpns/cfg/smb.conf - The target is vulnerable to CVE-2019-19781.
@@ -23,9 +23,9 @@ uid=65534(nobody) gid=65534(nobody) groups=65534(nobody)
 [!] This exploit may require manual cleanup of '/netscaler/portal/templates/mdjLHiHtIYmh.xml' on the target
 [!] This exploit may require manual cleanup of '/var/tmp/netscaler/portal/templates/mdjLHiHtIYmh.xml.ttc2' on the target
 [*] Exploit completed, but no session was created.
-msf5 exploit(linux/http/citrix_dir_traversal_rce) > set payload cmd/unix/bind_perl
+msf5 exploit(freebsd/http/citrix_dir_traversal_rce) > set payload cmd/unix/bind_perl
 payload => cmd/unix/bind_perl
-msf5 exploit(linux/http/citrix_dir_traversal_rce) > run
+msf5 exploit(freebsd/http/citrix_dir_traversal_rce) > run
 
 [*] Using auxiliary/scanner/http/citrix_dir_traversal as check
 [+] http://127.0.0.1:8080/vpn/../vpns/cfg/smb.conf - The target is vulnerable to CVE-2019-19781.
@@ -48,7 +48,7 @@ uid=65534(nobody) gid=65534(nobody) groups=65534(nobody)
 
 1. Install the module as usual
 2. Start msfconsole
-3. Do: `use exploit/linux/http/citrix_dir_traversal_rce`
+3. Do: `use exploit/freebsd/http/citrix_dir_traversal_rce`
 4. Do: `set RHOSTS [IP]`
 5. Do: `set LHOST [IP]`
 6. Do: `set VERBOSE true`

--- a/modules/exploits/freebsd/http/citrix_dir_traversal_rce.rb
+++ b/modules/exploits/freebsd/http/citrix_dir_traversal_rce.rb
@@ -7,10 +7,13 @@ class MetasploitModule < Msf::Exploit::Remote
 
   Rank = ExcellentRanking
 
+  prepend Msf::Exploit::Remote::AutoCheck
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::Remote::CheckModule
   include Msf::Exploit::FileDropper
-  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Module::Deprecated
+
+  moved_from 'exploit/linux/http/citrix_dir_traversal_rce'
 
   def initialize(info = {})
     super(update_info(info,


### PR DESCRIPTION
It's actually FreeBSD. It was my mistake in https://github.com/rapid7/metasploit-framework/pull/12816/commits/a45821b70671ad1c00cb3f31a9c10bcc9cd74c27, since I didn't ~have a target~ pay close enough attention.

```
root@ns# uname -a
FreeBSD ns 8.4-NETSCALER-13.0 FreeBSD 8.4-NETSCALER-13.0 #0 ab6af7edac92(heads/mana_79_64)-dirty: Mon Apr  5 08:13:06 PDT 2021     root@sjc-bld-bsd84-105:/usr/obj/usr/home/build/adc/usr.src/sys/NS64  amd64
root@ns#
```

```
msf6 > use exploit/linux/http/citrix_dir_traversal_rce
[*] Using configured payload python/meterpreter/reverse_tcp

[!] *         The module exploit/linux/http/citrix_dir_traversal_rce has been moved!         *
[!] *              You are using exploit/freebsd/http/citrix_dir_traversal_rce               *
msf6 exploit(linux/http/citrix_dir_traversal_rce) > use exploit/freebsd/http/citrix_dir_traversal_rce
[*] Using configured payload python/meterpreter/reverse_tcp
msf6 exploit(freebsd/http/citrix_dir_traversal_rce) >
```

Fixes #12816.