### PR TITLE
fix typos and documentation in chrome_simplifiedlowering_overflow

### DIFF
--- a/documentation/modules/exploit/multi/browser/chrome_simplifiedlowering_overflow.md
+++ b/documentation/modules/exploit/multi/browser/chrome_simplifiedlowering_overflow.md
@@ -1,28 +1,40 @@
-This module exploits an issue in Google Chrome versions before 87.0.4280.88 (64 bit). The exploit makes use of a integer overflow in the SimplifiedLowering phase in turbofan. It is used along with a typer hardening bypass using ArrayPrototypeShift to create a JSArray with a length of -1. This is abused to gain arbitrary read/write into the isolate region. Then an ArrayBuffer can be used to achieve absolute arbitrary read/write.
-The exploit then uses WebAssembly in order to allocate a region of RWX memory, which is then replaced with the payload shellcode.
-
-**The payload is executed within the sandboxed renderer process, so the browser must be run with the --no-sandbox option for the payload to work correctly.**
-
 ## Vulnerable Application
 
-The module is compatible with any 64bit Google Chrome (versions before 87.0.4280.88) on multiple platforms. However, the code that writes the shellcode into the rwx region (wasm_rwx_addr) may need to be modified.
+This module exploits an issue in Google Chrome versions before 87.0.4280.88 (64 bit).
+The exploit makes use of an integer overflow in the SimplifiedLowering phase in turbofan.
+It is used along with a typer hardening bypass using ArrayPrototypeShift to create a JSArray with a length of -1.
+This is abused to gain arbitrary read/write into the isolate region.
+Then an ArrayBuffer can be used to achieve absolute arbitrary read/write.
+The exploit then uses WebAssembly in order to allocate a region of RWX memory, which is then replaced with the payload shellcode.
+
+**The payload is executed within the sandboxed renderer process,
+so the browser must be run with the --no-sandbox option for the payload to work correctly.**
+
+The module is compatible with any 64bit Google Chrome (versions before 87.0.4280.88) on multiple platforms.
+However, the code that writes the shellcode into the rwx region (wasm_rwx_addr) may need to be modified.
 
 **Vulnerable Application Installation Steps**
 
 You can download a vulnerable Chrome version from this location:
 [https://chromium.cypress.io/win64/stable/87.0.4280.66](https://chromium.cypress.io/win64/stable/87.0.4280.66)
 
-1. Do: ```use exploit/multi/browser/chrome_simplifiedlowering_overflow```
-2. Do: ```set URIPATH / [PATH]```
-3. Do: ```set LHOST [IP]```
-4. Do: ```set SRVHOST [IP]```
-5. Do: ```exploit```
+## Verification Steps
+
+1. Do: `use exploit/multi/browser/chrome_simplifiedlowering_overflow`
+2. Do: `set URIPATH / [PATH]`
+3. Do: `set LHOST [IP]`
+4. Do: `set SRVHOST [IP]`
+5. Do: `exploit`
+
+## Options
+None
 
 ## Scenarios
 
 ### Windows 10 and Google Chrome 87.0.4280.66 with --no-sandbox
-Start Google Chrome without a sandbox:
-```➜  ~ google-chrome-stable --no-sandbox```
+
+Start Google Chrome without a sandbox, e.g:
+`"C:\Program Files (x86)\Google\Chrome\Application\chrome.exe" --no-sandbox`
 
 ```
 msf5 > use exploit/multi/browser/chrome_simplifiedlowering_overflow

--- a/modules/exploits/multi/browser/chrome_simplifiedlowering_overflow.rb
+++ b/modules/exploits/multi/browser/chrome_simplifiedlowering_overflow.rb
@@ -17,7 +17,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Description' => %q{
           This module exploits an issue in Google Chrome versions before 87.0.4280.88 (64 bit).
           The exploit makes use of an integer overflow in the SimplifiedLowering phase in turbofan.
-          It is used along with a typer hardening bypass using ArrayPrototypeShift to create a JSArray with a length of -1.
+          It is used along with a type hardening bypass using ArrayPrototypeShift to create a JSArray with a length of -1.
           This is abused to gain arbitrary read/write into the isolate region.
           Then an ArrayBuffer can be used to achieve absolute arbitrary read/write.
           The exploit then uses WebAssembly in order to allocate a region of RWX memory, which is then replaced with the payload shellcode.

--- a/modules/exploits/multi/browser/chrome_simplifiedlowering_overflow.rb
+++ b/modules/exploits/multi/browser/chrome_simplifiedlowering_overflow.rb
@@ -16,7 +16,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Name' => 'Google Chrome versions before 87.0.4280.88 integer overflow during SimplfiedLowering phase',
         'Description' => %q{
           This module exploits an issue in Google Chrome versions before 87.0.4280.88 (64 bit).
-          The exploit makes use of a integer overflow in the SimplifiedLowering phase in turbofan.
+          The exploit makes use of an integer overflow in the SimplifiedLowering phase in turbofan.
           It is used along with a typer hardening bypass using ArrayPrototypeShift to create a JSArray with a length of -1.
           This is abused to gain arbitrary read/write into the isolate region.
           Then an ArrayBuffer can be used to achieve absolute arbitrary read/write.
@@ -36,6 +36,10 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'Arch' => [ ARCH_X64 ],
         'DefaultTarget' => 0,
+        'Payload' =>
+        {
+          'Space' => 4096
+        },
         'Targets' =>
           [
             ['Linux - Google Chrome 87.0.4280.66 (64 bit)', { 'Platform' => 'linux' }],

--- a/modules/exploits/multi/browser/chrome_simplifiedlowering_overflow.rb
+++ b/modules/exploits/multi/browser/chrome_simplifiedlowering_overflow.rb
@@ -40,6 +40,11 @@ class MetasploitModule < Msf::Exploit::Remote
         {
           'Space' => 4096
         },
+        'Notes' =>
+        {
+          'Reliability' => [ REPEATABLE_SESSION ],
+          'SideEffects' => [ IOC_IN_LOGS ]
+        },
         'Targets' =>
           [
             ['Linux - Google Chrome 87.0.4280.66 (64 bit)', { 'Platform' => 'linux' }],


### PR DESCRIPTION
This change fixes some typos and runs msftidy_docs on the chrome_simplifiedlowering_overflow documentation.

## Verification

List the steps needed to make sure this thing works

- [x] **Verify** the module description looks ok
- [x] **Verify** the documentation looks ok
