### PR TITLE
Add fix to nagios_xi_plugins_check_ping_authenticated_rce.rb to Ensure Old Versions Can Still Be Detected As Being Vulnerable

### DIFF
--- a/modules/exploits/linux/http/nagios_xi_plugins_check_plugin_authenticated_rce.rb
+++ b/modules/exploits/linux/http/nagios_xi_plugins_check_plugin_authenticated_rce.rb
@@ -166,6 +166,11 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     print_status("Target is Nagios XI with version #{nagios_version}")
+
+    if /^\d{4}R\d\.\d/.match(nagios_version) || /^\d{4}RC\d/.match(nagios_version) || /^\d{4}R\d.\d[A-Ha-h]/.match(nagios_version) || nagios_version == '5R1.0'
+      nagios_version = '1.0.0' # Set to really old version as a placeholder. Basically we don't want to exploit these versions.
+    end
+
     # check if the target is actually vulnerable
     @version = Rex::Version.new(nagios_version)
     if @version < Rex::Version.new('5.6.6')


### PR DESCRIPTION
Some old versions of Nagios XI had unusual version numbering such as `5r1.0`. Unfortunately whilst testing this PR I forgot to add the regex that is in the other modules to this, which is basically the following line:

```
if /^\d{4}R\d\.\d/.match(nagios_version) || /^\d{4}RC\d/.match(nagios_version) || /^\d{4}R\d.\d[A-Ha-h]/.match(nagios_version) || nagios_version == '5R1.0'
      nagios_version = '1.0.0' # Set to really old version as a placeholder. Basically we don't want to exploit these versions.
    end
```

The reason this line is necessary before calling `Rex::Version::new(nagios_version)` is that `Rex::Version` does not handle cases where the version number contains letters within its contents. Therefore we must set the value of `nagios_version` to some number. However as we don't really care about versions older than `5.6.6` in this exploit, as they are all vulnerable anyway, we just set it to `1.0.0` as a placeholder to just indicate that this version of NagiosXI is vulnerable.

Note that this fix is applied after the line `print_status("Target is Nagios XI with version #{nagios_version}")` so we will still print out the correct version of NagiosXI that is installed on the target, and this fix only affects the logic of determining if the target is vulnerable or not.

## Verification

List the steps needed to make sure this thing works

- [ ] Grab a copy of CentOS 7.
- [ ] Install a really old version of Nagios XI on it such as 5.2.8 or 5.2.7 that has odd naming in its version number (aka the version number has some characters or similar in it).
- [ ] **Verify** that running the `check` method now returns the vulnerable version that is installed on the target and that the module now identifies the target as being vulnerable without crashing the module.
