### PR TITLE
Fix Rex::Socket::SSHFactory NameError in exploit/linux/ssh/f5_bigip_known_privkey

### DIFF
--- a/modules/exploits/linux/ssh/f5_bigip_known_privkey.rb
+++ b/modules/exploits/linux/ssh/f5_bigip_known_privkey.rb
@@ -5,6 +5,7 @@
 
 require 'net/ssh'
 require 'net/ssh/command_stream'
+require 'rex/socket/ssh_factory'
 
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking


### PR DESCRIPTION
This could probably be refactored to use `Msf::Exploit::Remote::SSH`, but this is just a quick fix.

```
msf6 exploit(linux/ssh/f5_bigip_known_privkey) > run

[-] Exploit failed: NameError uninitialized constant Rex::Socket::SSHFactory
[*] Exploit completed, but no session was created.
msf6 exploit(linux/ssh/f5_bigip_known_privkey) > edit
[*] Launching vim -i NONE /Users/wvu/rapid7/metasploit-framework/modules/exploits/linux/ssh/f5_bigip_known_privkey.rb
msf6 exploit(linux/ssh/f5_bigip_known_privkey) > git diff
[*] exec: git diff

diff --git a/modules/exploits/linux/ssh/f5_bigip_known_privkey.rb b/modules/exploits/linux/ssh/f5_bigip_known_privkey.rb
index 6dcda59b5e..2e6e8b8645 100644
--- a/modules/exploits/linux/ssh/f5_bigip_known_privkey.rb
+++ b/modules/exploits/linux/ssh/f5_bigip_known_privkey.rb
@@ -5,6 +5,7 @@

 require 'net/ssh'
 require 'net/ssh/command_stream'
+require 'rex/socket/ssh_factory'

 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
msf6 exploit(linux/ssh/f5_bigip_known_privkey) > rerun
[*] Reloading module...

[+] Successful login
[*] Found shell.
[*] Command shell session 1 opened (127.0.0.1:53182 -> 127.0.0.1:22) at 2021-04-19 17:03:18 -0500
```

Not sure if this is a Zeitwerk regression or what.