### PR TITLE
Fix linux checkvm bug

### DIFF
--- a/documentation/modules/post/linux/gather/checkvm.md
+++ b/documentation/modules/post/linux/gather/checkvm.md
@@ -7,9 +7,8 @@ There are many locations that are checked for having evidence of being a virtual
 3. `/proc/scsi/scsi`
 4. `cat /proc/ide/hd*/model`
 5. `lspci`
-6. `ls -1 /sys/bus`
-7. `lscpu`
-8. `dmesg`
+6. `dmesg`
+7. `/sys/class/dmi/id/product_name`
 
 ## Verification Steps
 

--- a/modules/post/linux/gather/checkvm.rb
+++ b/modules/post/linux/gather/checkvm.rb
@@ -8,144 +8,147 @@ class MetasploitModule < Msf::Post
   include Msf::Post::Linux::Priv
   include Msf::Post::Linux::System
 
-
-  def initialize(info={})
-    super( update_info( info,
-        'Name'          => 'Linux Gather Virtual Environment Detection',
-        'Description'   => %q{
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Linux Gather Virtual Environment Detection',
+        'Description' => %q{
           This module attempts to determine whether the system is running
           inside of a virtual environment and if so, which one. This
           module supports detection of Hyper-V, VMWare, VirtualBox, Xen,
-          and QEMU/KVM.},
-        'License'       => MSF_LICENSE,
-        'Author'        => [ 'Carlos Perez <carlos_perez[at]darkoperator.com>'],
-        'Platform'      => [ 'linux' ],
-        'SessionTypes'  => [ 'shell', 'meterpreter' ]
-      ))
+          and QEMU/KVM.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [ 'Carlos Perez <carlos_perez[at]darkoperator.com>'],
+        'Platform' => [ 'linux' ],
+        'SessionTypes' => [ 'shell', 'meterpreter' ]
+      )
+    )
   end
 
   # Run Method for when run command is issued
   def run
-    print_status("Gathering System info ....")
+    print_status('Gathering System info ....')
     vm = nil
     dmi_info = nil
     ls_pci_data = nil
 
     if is_root?
-      dmi_info = cmd_exec("/usr/sbin/dmidecode")
+      dmi_info = cmd_exec('/usr/sbin/dmidecode')
     end
 
     # Check DMi Info
     if dmi_info
       case dmi_info
       when /microsoft corporation/i
-        vm = "MS Hyper-V"
+        vm = 'MS Hyper-V'
       when /vmware/i
-        vm = "VMware"
+        vm = 'VMware'
       when /virtualbox/i
-        vm = "VirtualBox"
+        vm = 'VirtualBox'
       when /qemu/i
-        vm = "Qemu/KVM"
+        vm = 'Qemu/KVM'
       when /domu/i
-        vm = "Xen"
+        vm = 'Xen'
       end
     end
 
     # Check Modules
-    if not vm
-      loaded_modules = cmd_exec("/sbin/lsmod")
-      case loaded_modules.to_s.gsub("\n", " ")
+    if !vm
+      loaded_modules = cmd_exec('/sbin/lsmod')
+      case loaded_modules.to_s.gsub("\n", ' ')
       when /vboxsf|vboxguest/i
-        vm = "VirtualBox"
+        vm = 'VirtualBox'
       when /vmw_ballon|vmxnet|vmw/i
-        vm = "VMware"
+        vm = 'VMware'
       when /xen-vbd|xen-vnif/
-        vm = "Xen"
+        vm = 'Xen'
       when /virtio_pci|virtio_net/
-        vm = "Qemu/KVM"
+        vm = 'Qemu/KVM'
       when /hv_vmbus|hv_blkvsc|hv_netvsc|hv_utils|hv_storvsc/
-        vm = "MS Hyper-V"
+        vm = 'MS Hyper-V'
       end
     end
 
     # Check SCSI Driver
-    if not vm
-      proc_scsi = read_file("/proc/scsi/scsi")
+    if !vm
+      proc_scsi = read_file('/proc/scsi/scsi')
       if proc_scsi
-        case proc_scsi.gsub("\n", " ")
+        case proc_scsi.gsub("\n", ' ')
         when /vmware/i
-          vm = "VMware"
+          vm = 'VMware'
         when /vbox/i
-          vm = "VirtualBox"
+          vm = 'VirtualBox'
         end
       end
     end
 
     # Check IDE Devices
-    if not vm
-      case cmd_exec("cat /proc/ide/hd*/model")
+    if !vm
+      case cmd_exec('cat /proc/ide/hd*/model')
       when /vbox/i
-        vm = "VirtualBox"
+        vm = 'VirtualBox'
       when /vmware/i
-        vm = "VMware"
+        vm = 'VMware'
       when /qemu/i
-        vm = "Qemu/KVM"
+        vm = 'Qemu/KVM'
       when /virtual [vc]d/i
-        vm = "Hyper-V/Virtual PC"
+        vm = 'Hyper-V/Virtual PC'
       end
     end
 
     # Check using lspci
-    if not vm
+    if !vm
       case get_sysinfo[:distro]
       when /oracle|centos|suse|redhat|mandrake|slackware|fedora/i
-        lspci_data = cmd_exec("/sbin/lspci")
+        lspci_data = cmd_exec('/sbin/lspci')
       when /debian|ubuntu/
-        lspci_data = cmd_exec("/usr/bin/lspci")
+        lspci_data = cmd_exec('/usr/bin/lspci')
       else
-        lspci_data = cmd_exec("lspci")
+        lspci_data = cmd_exec('lspci')
       end
 
-      case lspci_data.to_s.gsub("\n", " ")
+      case lspci_data.to_s.gsub("\n", ' ')
       when /vmware/i
-        vm = "VMware"
+        vm = 'VMware'
       when /virtualbox/i
-        vm = "VirtualBox"
+        vm = 'VirtualBox'
       end
     end
 
-    if not vm
+    if !vm
       product_name = read_file('/sys/class/dmi/id/product_name')
       if product_name
-        case product_name.gsub("\n", " ")
+        case product_name.gsub("\n", ' ')
         when /vmware/i
-          vm = "VMware"
+          vm = 'VMware'
         when /virtualbox/i
-          vm = "VirtualBox"
+          vm = 'VirtualBox'
         when /xen/i
-          vm = "Xen"
+          vm = 'Xen'
         when /KVM/i
-          vm = "KVM"
+          vm = 'KVM'
         when /oracle/i
-          vm = "Oracle Corporation"
+          vm = 'Oracle Corporation'
         end
       end
     end
 
     # Check dmesg Output
-    if not vm
-      dmesg = cmd_exec("dmesg")
+    if !vm
+      dmesg = cmd_exec('dmesg')
       case dmesg
       when /vboxbios|vboxcput|vboxfacp|vboxxsdt|vbox cd-rom|vbox harddisk/i
-        vm = "VirtualBox"
+        vm = 'VirtualBox'
       when /vmware virtual ide|vmware pvscsi|vmware virtual platform/i
-        vm = "VMware"
+        vm = 'VMware'
       when /xen_mem|xen-vbd/i
-        vm =  "Xen"
+        vm = 'Xen'
       when /qemu virtual cpu version/i
-        vm = "Qemu/KVM"
-      when /\/dev\/vmnet/
-        vm = "VMware"
+        vm = 'Qemu/KVM'
+      when %r{/dev/vmnet}
+        vm = 'VMware'
       end
     end
 
@@ -153,7 +156,7 @@ class MetasploitModule < Msf::Post
       print_good("This appears to be a '#{vm}' virtual machine")
       report_virtualization(vm)
     else
-      print_status("This does not appear to be a virtual machine")
+      print_status('This does not appear to be a virtual machine')
     end
 
   end

--- a/modules/post/linux/gather/checkvm.rb
+++ b/modules/post/linux/gather/checkvm.rb
@@ -132,18 +132,6 @@ class MetasploitModule < Msf::Post
       end
     end
 
-    # Check using lscpu
-    if not vm
-      case cmd_exec("lscpu")
-      when /Xen/i
-        vm = "Xen"
-      when /KVM/i
-        vm = "KVM"
-      when /Microsoft/i
-        vm = "MS Hyper-V"
-      end
-    end
-
     # Check dmesg Output
     if not vm
       dmesg = cmd_exec("dmesg")

--- a/modules/post/linux/gather/checkvm.rb
+++ b/modules/post/linux/gather/checkvm.rb
@@ -32,7 +32,6 @@ class MetasploitModule < Msf::Post
     print_status('Gathering System info ....')
     vm = nil
     dmi_info = nil
-    ls_pci_data = nil
 
     if is_root?
       dmi_info = cmd_exec('/usr/sbin/dmidecode')

--- a/modules/post/linux/gather/checkvm.rb
+++ b/modules/post/linux/gather/checkvm.rb
@@ -118,17 +118,17 @@ class MetasploitModule < Msf::Post
       product_name = read_file('/sys/class/dmi/id/product_name')
       if product_name
         case product_name.gsub("\n", " ")
-      	when /vmware/i
-      	  vm = "VMware"
-      	when /virtualbox/i
-      	  vm = "VirtualBox"
-      	when /xen/i
-      	  vm = "Xen"
-      	when /KVM/i
-      	  vm = "KVM"
-      	when /oracle/i
-      	  vm = "Oracle Corporation"
-      	end
+        when /vmware/i
+          vm = "VMware"
+        when /virtualbox/i
+          vm = "VirtualBox"
+        when /xen/i
+          vm = "Xen"
+        when /KVM/i
+          vm = "KVM"
+        when /oracle/i
+          vm = "Oracle Corporation"
+        end
       end
     end
 

--- a/modules/post/linux/gather/checkvm.rb
+++ b/modules/post/linux/gather/checkvm.rb
@@ -114,10 +114,21 @@ class MetasploitModule < Msf::Post
       end
     end
 
-    # Xen bus check
     if not vm
-      if cmd_exec("ls -1 /sys/bus").to_s.split("\n").include?("xen")
-        vm = "Xen"
+      product_name = read_file('/sys/class/dmi/id/product_name')
+      if product_name
+        case product_name.gsub("\n", " ")
+      	when /vmware/i
+      	  vm = "VMware"
+      	when /virtualbox/i
+      	  vm = "VirtualBox"
+      	when /xen/i
+      	  vm = "Xen"
+      	when /KVM/i
+      	  vm = "KVM"
+      	when /oracle/i
+      	  vm = "Oracle Corporation"
+      	end
       end
     end
 

--- a/modules/post/linux/gather/checkvm.rb
+++ b/modules/post/linux/gather/checkvm.rb
@@ -70,12 +70,14 @@ class MetasploitModule < Msf::Post
 
     # Check SCSI Driver
     if not vm
-      proc_scsi = read_file("/proc/scsi/scsi") rescue ""
-      case proc_scsi.gsub("\n", " ")
-      when /vmware/i
-        vm = "VMware"
-      when /vbox/i
-        vm = "VirtualBox"
+      if readable? ("/proc/scsi/scsi")
+        proc_scsi = read_file("/proc/scsi/scsi")
+        case proc_scsi.gsub("\n", " ")
+        when /vmware/i
+          vm = "VMware"
+        when /vbox/i
+          vm = "VirtualBox"
+        end
       end
     end
 

--- a/modules/post/linux/gather/checkvm.rb
+++ b/modules/post/linux/gather/checkvm.rb
@@ -70,8 +70,8 @@ class MetasploitModule < Msf::Post
 
     # Check SCSI Driver
     if not vm
-      if readable? ("/proc/scsi/scsi")
-        proc_scsi = read_file("/proc/scsi/scsi")
+      proc_scsi = read_file("/proc/scsi/scsi")
+      if proc_scsi
         case proc_scsi.gsub("\n", " ")
         when /vmware/i
           vm = "VMware"


### PR DESCRIPTION
### Summary
This PR fixes a bug in module `/post/linux/gather/checkvm` which is used to check whether a system in running inside a virtual environment or not.

### Part of code with Bug
```ruby
proc_scsi = read_file("/proc/scsi/scsi") rescue ""
case proc_scsi.gsub("\n", " ")
```
`read_file` API will return nil if the file is not present or not readable and doing a `gsub` on nil will throw an error.

```
msf6 post(linux/gather/checkvm) > run

[*] Gathering System info ....
[-] Post failed: NoMethodError undefined method `gsub' for nil:NilClass
[-] Call stack:
[-]   /tmp/metasploit-framework/modules/post/linux/gather/checkvm.rb:74:in `run'
[*] Post module execution completed
```
### Verification Steps
```
msf6 post(linux/gather/checkvm) > run 
[*] Reloading module...

[*] Gathering System info ....
[+] This appears to be a 'VirtualBox' virtual machine
[*] Post module execution completed
```