### PR TITLE
guard ssh connection reset

### DIFF
--- a/lib/metasploit/framework/login_scanner/ssh.rb
+++ b/lib/metasploit/framework/login_scanner/ssh.rb
@@ -85,7 +85,7 @@ module Metasploit
                 opt_hash
               )
             end
-          rescue OpenSSL::Cipher::CipherError, ::EOFError, Net::SSH::Disconnect, Rex::ConnectionError, ::Timeout::Error => e
+          rescue OpenSSL::Cipher::CipherError, ::EOFError, Net::SSH::Disconnect, Rex::ConnectionError, ::Timeout::Error, Errno::ECONNRESET => e
             result_options.merge!(status: Metasploit::Model::Login::Status::UNABLE_TO_CONNECT, proof: e)
           rescue Net::SSH::Exception
             result_options.merge!(status: Metasploit::Model::Login::Status::INCORRECT, proof: e)


### PR DESCRIPTION
When attempting a login a remote reset should not error the scanner.

In some scenarios the ssh gem allow an exception if a connection reset is received during a login attempt.
```
Auxiliary failed: Errno::ECONNRESET Connection reset by peer
Call stack:
    vendor/bundle/ruby/2.7.0/gems/net-ssh-6.1.0/lib/net/ssh/transport/server_version.rb:54:in `readpartial'
    vendor/bundle/ruby/2.7.0/gems/net-ssh-6.1.0/lib/net/ssh/transport/server_version.rb:54:in `block (2 levels) in negotiate!'
    vendor/bundle/ruby/2.7.0/gems/net-ssh-6.1.0/lib/net/ssh/transport/server_version.rb:52:in `loop'
    vendor/bundle/ruby/2.7.0/gems/net-ssh-6.1.0/lib/net/ssh/transport/server_version.rb:52:in `block in negotiate!'
    vendor/bundle/ruby/2.7.0/gems/net-ssh-6.1.0/lib/net/ssh/transport/server_version.rb:50:in `loop'
    vendor/bundle/ruby/2.7.0/gems/net-ssh-6.1.0/lib/net/ssh/transport/server_version.rb:50:in `negotiate!'
    vendor/bundle/ruby/2.7.0/gems/net-ssh-6.1.0/lib/net/ssh/transport/server_version.rb:34:in `initialize'
    vendor/bundle/ruby/2.7.0/gems/net-ssh-6.1.0/lib/net/ssh/transport/session.rb:86:in `new'
    vendor/bundle/ruby/2.7.0/gems/net-ssh-6.1.0/lib/net/ssh/transport/session.rb:86:in `initialize'
    vendor/bundle/ruby/2.7.0/gems/net-ssh-6.1.0/lib/net/ssh.rb:251:in `new'
    vendor/bundle/ruby/2.7.0/gems/net-ssh-6.1.0/lib/net/ssh.rb:251:in `start'
    lib/metasploit/framework/login_scanner/ssh.rb:82:in `block in attempt_login'
```

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [ ] `use auxiliary/scanner/ssh/ssh_login`
- [ ] **Verify** when connection is reset during a login attempt the module continues.
