### PR TITLE
Adds error handling for `mssql_idf` when module returns no matching results

### DIFF
--- a/modules/auxiliary/admin/mssql/mssql_idf.rb
+++ b/modules/auxiliary/admin/mssql/mssql_idf.rb
@@ -22,9 +22,7 @@ class MetasploitModule < Msf::Auxiliary
         This module will search the specified MSSQL server for
         'interesting' columns and data.
 
-        The module has been tested against SQL Server 2005 but it should also work on
-        SQL Server 2008. The module will not work against SQL Server 2000 at this time,
-        if you are interested in supporting this platform, please contact the author.
+        This module has been tested against the latest SQL Server 2019 docker container image (22/04/2021).
       },
       'Author'         => [ 'Robin Wood <robin[at]digininja.org>' ],
       'License'        => MSF_LICENSE,
@@ -90,7 +88,6 @@ class MetasploitModule < Msf::Auxiliary
     begin
       if mssql_login_datastore
         result = mssql_query(sql, false)
-        column_data = result[:rows]
       else
         print_error('Login failed')
         return
@@ -103,6 +100,11 @@ class MetasploitModule < Msf::Auxiliary
     column_data = result[:rows]
     widths = [0, 0, 0, 0, 0, 9]
     total_width = 0
+
+    if column_data.nil?
+      print_error("No columns matched the pattern #{datastore['NAMES'].inspect}. Set the NAMES option to change this search pattern.")
+      return
+    end
 
     (column_data|headings).each { |row|
       0.upto(4) { |col|


### PR DESCRIPTION
Resolves #15059

This PR adds error handling for the scenario when a user attempts to run the `mssql_idf` module against a database that has no columns matching the pattern set within the `NAME` options within module options. 

Module options example:
 
![image](https://user-images.githubusercontent.com/69522014/115696827-ee941b80-a35a-11eb-8e94-50be80d7bf65.png)

This would cause the following error:
```
Auxiliary failed: NoMethodError undefined method `each' for true:TrueClass
```

This was due to `column_data` being equal to `nil`, as `result[:rows]` would only be generated if the module found results matching the `NAME` options search pattern. 

![image](https://user-images.githubusercontent.com/69522014/115697148-331fb700-a35b-11eb-9c9b-17c912d4288e.png)

## Before 
![image](https://user-images.githubusercontent.com/69522014/115697495-8560d800-a35b-11eb-9856-c1c2b4e350d5.png)

## After 
![image](https://user-images.githubusercontent.com/69522014/115697675-a7f2f100-a35b-11eb-903a-9dec662c4020.png)

## After with results being found
![image](https://user-images.githubusercontent.com/69522014/115697787-cc4ecd80-a35b-11eb-9226-058f26c97d13.png)


## Verification

- [ ] Start `msfconsole`
- [ ] `use admin/mssql/mssql_idf`
- [ ] `set` module options, my module options can be found above
- [ ] **Verify** the error is now caught and handled gracefully
- [ ] **Verify** the module no longer returns `Auxiliary failed: NoMethodError undefined method `each' for true:TrueClass`

## Database 
If wanting to set up the database to test that is all working as expected after the changes, I followed this [guide](https://docs.microsoft.com/en-us/sql/linux/quickstart-install-connect-docker?view=sql-server-ver15&pivots=cs1-bash).

Commands used to create the table: 
```SQL
CREATE TABLE CreditCard (id INT, CardNumber NVARCHAR(50))
INSERT INTO CreditCard VALUES (1, 1234567891011121);
INSERT INTO CreditCard VALUES (2, 1234567891011122);
INSERT INTO CreditCard VALUES (3, 1234567891011123);

# To verify all data was added use 
SELECT * FROM CreditCard
```