### PR TITLE
Propagate errors for the run simple api

### DIFF
--- a/lib/msf/base/simple/auxiliary.rb
+++ b/lib/msf/base/simple/auxiliary.rb
@@ -84,6 +84,8 @@ module Auxiliary
     else
       result = self.job_run_proc(ctx, &:run)
       self.job_cleanup_proc(ctx)
+      # the original mod was cloned, additionally copy any potential errors on to the original instance
+      omod.error = mod.error
 
       return result
     end

--- a/lib/msf/base/simple/exploit.rb
+++ b/lib/msf/base/simple/exploit.rb
@@ -148,11 +148,15 @@ module Exploit
 
       # Propagate this back to the caller for console mgmt
       oexploit.job_id = exploit.job_id
+      oexploit.fail_reason = exploit.fail_reason
+      oexploit.fail_detail = exploit.fail_detail
     rescue ::Interrupt
       exploit.error = $!
+      oexploit.error = exploit.error
       raise $!
     rescue ::Exception => e
       exploit.error = e
+      oexploit.error = exploit.error
       exploit.print_error("Exploit failed: #{e}")
       elog("Exploit failed (#{exploit.refname})", error: e)
     end


### PR DESCRIPTION
Any exceptions raised by the run simple api are attached to a replicant module, which is never propagated back to the caller.

## Verification

#### Exploits
Update a module to raise an exception
```diff
diff --git a/modules/exploits/windows/misc/crosschex_device_bof.rb b/modules/exploits/windows/misc/crosschex_device_bof.rb
index f253c0743c..351f19a385 100644
--- a/modules/exploits/windows/misc/crosschex_device_bof.rb
+++ b/modules/exploits/windows/misc/crosschex_device_bof.rb
@@ -67,6 +67,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
+    raise 'Unexpected explosion'
     connect_udp
 
     res, host, port = udp_sock.recvfrom(PACKET_LEN, datastore['TIMEOUT'].to_i > 0 ? datastore['TIMEOUT'].to_i : nil)
```

Open `irb` and verify the semantics have changed:
```ruby
irb
mod = framework.modules.create("exploit/windows/misc/crosschex_device_bof")
Msf::Simple::Exploit.exploit_simple(mod, { 'Payload' => 'windows/shell/reverse_tcp', 'Options' => { 'RHOST' => '127.0.0.1', 'LHOST' => '127.0.0.1' } })
mod.fail_reason # unreachable
mod.fail_detail  # The destination is invalid: (127.0.0.1:0).
```

```ruby
irb
mod = framework.modules.create("exploit/windows/misc/crosschex_device_bof")
Msf::Simple::Exploit.exploit_simple(mod, { 'Payload' => 'windows/shell/reverse_tcp', 'Options' => { } })
mod.error # #<Msf::OptionValidateError: One or more options failed to validate: LHOST.>
```

```ruby
irb
mod = framework.modules.create("exploit/windows/misc/crosschex_device_bof")
Msf::Simple::Exploit.exploit_simple(mod, { 'Payload' => 'windows/shell/reverse_tcp', 'Options' => { 'CHOST' => '127.0.0.1', 'CPORT' => '9000', 'LHOST' => '127.0.0.1' } })
mod.fail_reason # unreachable
mod.fail_detail  # Unexpected explosion
```

#### Auxiliary scanner

```diff
--- a/modules/auxiliary/scanner/http/title.rb
+++ b/modules/auxiliary/scanner/http/title.rb
@@ -38,6 +38,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run_host(target_host)
+    raise 'Unexpected explosion'
     begin
       # Send a normal GET request
       res = send_request_cgi(
```

```ruby
irb
mod = framework.modules.create("auxiliary/scanner/http/title")
Msf::Simple::Auxiliary.run_simple(mod, { 'Options' => { 'RHOSTS' => 'example.com' } })
mod.error # => unexpected explosion
```