### PR TITLE
Add history avoidance for commands and remove leading spaces from readline input

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -715,6 +715,7 @@ class Core
     print_line
     print_line "If -n is not set, only the last #{@history_limit} commands will be shown."
     print_line 'If -c is specified, the command history and history file will be cleared.'
+    print_line 'Start commands with a space to avoid saving them to history.'
     print @@history_opts.usage
   end
 

--- a/lib/msf/ui/tip.rb
+++ b/lib/msf/ui/tip.rb
@@ -35,6 +35,7 @@ module Msf
         "Adapter names can be used for IP params #{highlight('set LHOST eth0')}",
         "Use #{highlight('sessions -1')} to interact with the last opened session",
         "View missing module options with #{highlight('show missing')}",
+        "Start commands with a space to avoid saving them to history",
       ].freeze
       private_constant :COMMON_TIPS
 

--- a/lib/rex/ui/text/input/readline.rb
+++ b/lib/rex/ui/text/input/readline.rb
@@ -158,7 +158,7 @@ begin
         RbReadline.rl_outstream = output
 
         begin
-          line = RbReadline.readline(reset_sequence + prompt).to_s.strip
+          line = RbReadline.readline(reset_sequence + prompt)
         rescue ::Exception => exception
           RbReadline.rl_cleanup_after_signal()
           RbReadline.rl_deprep_terminal()
@@ -166,10 +166,10 @@ begin
           raise exception
         end
 
-        if add_history && line != ""
+        if add_history && line && !line.start_with?(' ')
           # Don't add duplicate lines to history
-          if ::Readline::HISTORY.empty? || line != ::Readline::HISTORY[-1]
-            RbReadline.add_history(line)
+          if ::Readline::HISTORY.empty? || line.strip != ::Readline::HISTORY[-1]
+            RbReadline.add_history(line.strip)
           end
         end
 

--- a/lib/rex/ui/text/input/readline.rb
+++ b/lib/rex/ui/text/input/readline.rb
@@ -158,7 +158,7 @@ begin
         RbReadline.rl_outstream = output
 
         begin
-          line = RbReadline.readline(reset_sequence + prompt)
+          line = RbReadline.readline(reset_sequence + prompt).to_s.strip
         rescue ::Exception => exception
           RbReadline.rl_cleanup_after_signal()
           RbReadline.rl_deprep_terminal()
@@ -166,7 +166,7 @@ begin
           raise exception
         end
 
-        if add_history && line
+        if add_history && line != ""
           # Don't add duplicate lines to history
           if ::Readline::HISTORY.empty? || line != ::Readline::HISTORY[-1]
             RbReadline.add_history(line)

--- a/lib/rex/ui/text/shell.rb
+++ b/lib/rex/ui/text/shell.rb
@@ -157,8 +157,8 @@ module Shell
           ret = run_single(line)
           # don't bother saving lines that couldn't be found as a
           # command, create the file if it doesn't exist, don't save dupes
-          if ret && self.histfile && line != @last_line
-            File.open(self.histfile, "a+") { |f| f.puts(line) }
+          if ret && self.histfile && line && line.strip != @last_line&.strip
+            File.open(self.histfile, "a+") { |f| f.puts(line.strip) unless line.starts_with?(" ") }
             @last_line = line
           end
           self.stop_count = 0


### PR DESCRIPTION
## Summary
This PR fixes a small bug in `lib/rex/ui/text/input/readline.rb` library.
In particular, Readline will remove consecutive duplicate lines from history file but currently it doesn't remove leading and trailing spaces. For example `jobs` and `jobs ` will be considered different commands and saved twice to history file.

This fix has also been ported over into the `lib/rex/ui/text/shell.rb` library to ensure that commands written to the `~/.msf4/history` history file are properly stripped of leading and trailing whitespace prior to being written. 

Additionally both libraries have been updated so that if a command starts with a leading space, it will not be logged into either the history file or the output of `history`. This incorporates a suggestion from @smcintyre-r7 to incorporate an option for users to hide certain commands from the history by prepending them with a space character, which is useful for hiding commands that may contain passwords or other sensitive information.

## Verification Steps
- [x] Load `msfconsole`
- [x] Run `   history`
- [x] Run `history`. Verify that the output only shows one command, aka `history`, with no leading or trailing spaces.
- [x] Run `*spaces here ignore me* set PASSWORD sensitivePassword`
- [x] Run `set USERNAME test`
- [x] Run `set USERNAME test  *multiple spaces here*`
- [x] Check the contents of `~/.msf4/history`. You should see only one entry for the `history` command, no entries containing `sensitivePassword`, and one entry containing `set USERNAME test`.
 - [x] Run `history`. Verify that the output shows one instance of `history`, followed by `set USERNAME test`, followed by `history`.