### PR TITLE
Fix a typo in Eclipse Equinox product name

### DIFF
--- a/documentation/modules/exploit/multi/misc/osgi_console_exec.md
+++ b/documentation/modules/exploit/multi/misc/osgi_console_exec.md
@@ -31,7 +31,7 @@ Follow these steps to run the vulnerable application on a Linux host:
 
 Follow these steps to run the vulnerable application on a Windows host:
 
-1. Download the Eclipse Equinoxe SDK from https://www.eclipse.org/downloads/download.php?file=/equinox/drops/R-Oxygen.2-201711300510/equinox-SDK-Oxygen.2.zip&r=1
+1. Download the Eclipse Equinox SDK from https://www.eclipse.org/downloads/download.php?file=/equinox/drops/R-Oxygen.2-201711300510/equinox-SDK-Oxygen.2.zip&r=1
 2. Create a test directory. Let's name it `osgi_test` for clarity.
 3. Create a directory named `configuration` in `osgi_test`
 4. Create a file named `config.ini` in your `configuration` directory. The file should contain the following lines only:

--- a/modules/exploits/multi/misc/osgi_console_exec.rb
+++ b/modules/exploits/multi/misc/osgi_console_exec.rb
@@ -15,10 +15,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Eclipse Equinoxe OSGi Console Command Execution',
+      'Name'           => 'Eclipse Equinox OSGi Console Command Execution',
       'Description'    => %q{
-        Exploit Eclipse Equinoxe OSGi (Open Service Gateway initiative) console
-        'fork' command to execute arbitrary commands on the remote system..
+        Exploit Eclipse Equinox OSGi (Open Service Gateway initiative) console
+        'fork' command to execute arbitrary commands on the remote system.
       },
       'Author'         =>
         [


### PR DESCRIPTION
The module docs had an extra character for the product name that makes
copy-paste search less straight forward.

## Verification
- [ ] Read the fixed module docs
- [ ] The module metadata generation should catch this typo fix

Fixes #9554.