### PR TITLE
Add shell support for win checkvm module and `get_processes` method in `post/common.rb`

### DIFF
--- a/lib/msf/core/post/common.rb
+++ b/lib/msf/core/post/common.rb
@@ -35,21 +35,7 @@ module Msf::Post::Common
   #
   def has_pid?(pid)
     pid_list = []
-    case client.type
-    when /meterpreter/
-      pid_list = client.sys.process.processes.collect {|e| e['pid']}
-    when /shell/
-      if client.platform == 'windows'
-        o = cmd_exec('tasklist /FO LIST')
-        pid_list = o.scan(/^PID:\s+(\d+)/).flatten
-      else
-        o = cmd_exec('ps ax')
-        pid_list = o.scan(/^\s*(\d+)/).flatten
-      end
-
-      pid_list = pid_list.collect {|e| e.to_i}
-    end
-
+    pid_list = get_processes.collect {|e| e['pid']}
     pid_list.include?(pid)
   end
 

--- a/lib/msf/core/post/common.rb
+++ b/lib/msf/core/post/common.rb
@@ -272,7 +272,6 @@ module Msf::Post::Common
         process = {}
         process['name'] = properties[10].to_s.gsub(/\[|\]/,"")
         process['pid'] = properties[1].to_s
-        process['user'] = properties[0].to_s
         processes.push(process)
       end
     end

--- a/lib/msf/core/post/common.rb
+++ b/lib/msf/core/post/common.rb
@@ -265,10 +265,18 @@ module Msf::Post::Common
         process['pid'] = properties[1].to_s
         processes.push(process)
       end
-      return processes
     else
-      #ps aux
+      ps_aux = cmd_exec('ps aux').split("\n")
+      ps_aux.each do |p|
+        properties = p.split
+        process = {}
+        process['name'] = properties[10].to_s.gsub(/\[|\]/,"")
+        process['pid'] = properties[1].to_s
+        process['user'] = properties[0].to_s
+        processes.push(process)
+      end
     end
+    return processes
   end
 
 end

--- a/lib/msf/core/post/common.rb
+++ b/lib/msf/core/post/common.rb
@@ -34,8 +34,7 @@ module Msf::Post::Common
   # Checks if the remote system has a process with ID +pid+
   #
   def has_pid?(pid)
-    pid_list = []
-    pid_list = get_processes.collect {|e| e['pid']}
+    pid_list = get_processes.collect { |e| e['pid'] }
     pid_list.include?(pid)
   end
 
@@ -244,6 +243,7 @@ module Msf::Post::Common
     processes = []
     if session.platform == 'windows'
       tasklist = cmd_exec('tasklist').split("\n")
+      4.times { tasklist.delete_at(0) }
       tasklist.each do |p|
         properties = p.split
         process = {}
@@ -251,11 +251,11 @@ module Msf::Post::Common
         process['pid'] = properties[1].to_i
         processes.push(process)
       end
-      4.times {processes.delete_at(0)}
-      # adding manually because this is common for all windows I think and spliting for this was causing problem for other processes.
-      processes.push({'name' => 'System Idle Process', 'pid' => 0})
+      # adding manually because this is common for all windows I think and splitting for this was causing problem for other processes.
+      processes.prepend({ 'name' => '[System Process]', 'pid' => 0 })
     else
       ps_aux = cmd_exec('ps aux').split("\n")
+      ps_aux.delete_at(0)
       ps_aux.each do |p|
         properties = p.split
         process = {}
@@ -263,7 +263,6 @@ module Msf::Post::Common
         process['pid'] = properties[1].to_i
         processes.push(process)
       end
-      processes.delete_at(0)
     end
     return processes
   end

--- a/lib/msf/core/post/common.rb
+++ b/lib/msf/core/post/common.rb
@@ -251,4 +251,24 @@ module Msf::Post::Common
     raise "Unable to check if command `#{cmd}' exists"
   end
 
+  def get_processes
+    if session.type == 'meterpreter'
+      return session.sys.process.get_processes
+    end
+    processes = []
+    if session.platform == 'windows'
+      tasklist = cmd_exec('tasklist').split("\n")
+      tasklist.each do |p|
+        properties = p.split
+        process = {}
+        process['name'] = properties[0].to_s
+        process['pid'] = properties[1].to_s
+        processes.push(process)
+      end
+      return processes
+    else
+      #ps aux
+    end
+  end
+
 end

--- a/modules/post/windows/gather/checkvm.rb
+++ b/modules/post/windows/gather/checkvm.rb
@@ -3,7 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-
 class MetasploitModule < Msf::Post
   include Msf::Post::Windows::Registry
   include Msf::Auxiliary::Report
@@ -25,7 +24,7 @@ class MetasploitModule < Msf::Post
           'Aaron Soto <aaron_soto[at]rapid7.com>'
         ],
         'Platform' => [ 'win' ],
-        'SessionTypes' => [ 'meterpreter' ]
+        'SessionTypes' => [ 'meterpreter', 'shell' ]
       )
     )
   end
@@ -75,7 +74,7 @@ class MetasploitModule < Msf::Post
 
     key_path = 'HKLM\HARDWARE\DESCRIPTION\System'
     system_bios_version = registry_getvaldata(key_path, 'SystemBiosVersion')
-    return true if system_bios_version && system_bios_version.unpack('s<*').reduce('', :<<).include?('Hyper-V')
+    return true if system_bios_version && system_bios_version.include?('Hyper-V')
 
     key_path = 'HKLM\HARDWARE\DEVICEMAP\Scsi\Scsi Port 0\Scsi Bus 0\Target Id 0\Logical Unit Id 0'
     return true if registry_getvaldata(key_path, 'Identifier') =~ /Msft    Virtual Disk    1.0/i
@@ -95,9 +94,11 @@ class MetasploitModule < Msf::Post
       'vmwareuser.exe',
       'vmwaretray.exe'
     ]
-    get_processes.each do |x|
-      vmwareprocs.each do |p|
-        return true if p == x['name'].downcase
+    if session.type == 'meterpreter'
+      get_processes.each do |x|
+        vmwareprocs.each do |p|
+          return true if p == x['name'].downcase
+        end
       end
     end
 
@@ -113,9 +114,11 @@ class MetasploitModule < Msf::Post
       'vmusrvc.exe',
       'vmsrvc.exe'
     ]
-    get_processes.each do |x|
-      vpcprocs.each do |p|
-        return true if p == x['name'].downcase
+    if session.type == 'meterpreter'
+      get_processes.each do |x|
+        vpcprocs.each do |p|
+          return true if p == x['name'].downcase
+        end
       end
     end
 
@@ -127,9 +130,11 @@ class MetasploitModule < Msf::Post
       'vboxservice.exe',
       'vboxtray.exe'
     ]
-    get_processes.each do |x|
-      vboxprocs.each do |p|
-        return true if p == x['name'].downcase
+    if session.type == 'meterpreter'
+      get_processes.each do |x|
+        vboxprocs.each do |p|
+          return true if p == x['name'].downcase
+        end
       end
     end
 
@@ -158,9 +163,11 @@ class MetasploitModule < Msf::Post
     xenprocs = [
       'xenservice.exe'
     ]
-    get_processes.each do |x|
-      xenprocs.each do |p|
-        return true if p == x['name'].downcase
+    if session.type == 'meterpreter'
+      get_processes.each do |x|
+        xenprocs.each do |p|
+          return true if p == x['name'].downcase
+        end
       end
     end
 
@@ -202,7 +209,7 @@ class MetasploitModule < Msf::Post
   end
 
   def run
-    print_status("Checking if #{sysinfo['Computer']} is a Virtual Machine ...")
+    print_status('Checking if the target is a Virtual Machine ...')
 
     if hyperv?
       report_vm('Hyper-V')
@@ -217,7 +224,7 @@ class MetasploitModule < Msf::Post
     elsif qemu?
       report_vm('Qemu')
     else
-      print_status("#{sysinfo['Computer']} appears to be a Physical Machine")
+      print_status('The target appears to be a Physical Machine')
     end
   end
 end

--- a/modules/post/windows/gather/checkvm.rb
+++ b/modules/post/windows/gather/checkvm.rb
@@ -34,11 +34,6 @@ class MetasploitModule < Msf::Post
     @services
   end
 
-  def get_processes
-    @processes ||= session.sys.process.get_processes
-    @processes
-  end
-
   def service_exists?(service)
     get_services && get_services.include?(service)
   end
@@ -94,11 +89,9 @@ class MetasploitModule < Msf::Post
       'vmwareuser.exe',
       'vmwaretray.exe'
     ]
-    if session.type == 'meterpreter'
-      get_processes.each do |x|
-        vmwareprocs.each do |p|
-          return true if p == x['name'].downcase
-        end
+    get_processes.each do |x|
+      vmwareprocs.each do |p|
+        return true if p == x['name'].downcase
       end
     end
 
@@ -114,11 +107,9 @@ class MetasploitModule < Msf::Post
       'vmusrvc.exe',
       'vmsrvc.exe'
     ]
-    if session.type == 'meterpreter'
-      get_processes.each do |x|
-        vpcprocs.each do |p|
-          return true if p == x['name'].downcase
-        end
+    get_processes.each do |x|
+      vpcprocs.each do |p|
+        return true if p == x['name'].downcase
       end
     end
 
@@ -130,11 +121,9 @@ class MetasploitModule < Msf::Post
       'vboxservice.exe',
       'vboxtray.exe'
     ]
-    if session.type == 'meterpreter'
-      get_processes.each do |x|
-        vboxprocs.each do |p|
-          return true if p == x['name'].downcase
-        end
+    get_processes.each do |x|
+      vboxprocs.each do |p|
+        return true if p == x['name'].downcase
       end
     end
 
@@ -163,11 +152,9 @@ class MetasploitModule < Msf::Post
     xenprocs = [
       'xenservice.exe'
     ]
-    if session.type == 'meterpreter'
-      get_processes.each do |x|
-        xenprocs.each do |p|
-          return true if p == x['name'].downcase
-        end
+    get_processes.each do |x|
+      xenprocs.each do |p|
+        return true if p == x['name'].downcase
       end
     end
 


### PR DESCRIPTION
## Summary
This PR adds shell session support to `windows_checkvm` module. However there is one limitation for shell sessions over meterpreter. Shell sessions don't have `get_processes` method to check for specific processes to identify if it's a vm. But most checks are based on registry keys which work on both.

## Verification Steps
```
msf6 > handler -H 192.168.29.232 -P 4444 -p windows/x64/shell_reverse_tcp
[*] Payload handler running as background job 7.

[*] Started reverse TCP handler on 192.168.29.232:4444 
msf6 > [*] Command shell session 1 opened (192.168.29.232:4444 -> 192.168.29.232:44208)

msf6 > use post/windows/gather/checkvm 
msf6 post(windows/gather/checkvm) > set session 1 
session => 1
msf6 post(windows/gather/checkvm) > run

[*] Checking if the target is a Virtual Machine ...
[+] This is a VirtualBox Virtual Machine
[*] Post module execution completed
msf6 post(windows/gather/checkvm) > 
```