### PR TITLE
Delete pry history appended to msf history

### DIFF
--- a/lib/rex/ui/text/shell.rb
+++ b/lib/rex/ui/text/shell.rb
@@ -154,7 +154,12 @@ module Shell
         # Otherwise, call what should be an overriden instance method to
         # process the line.
         else
+          hist_length = Readline::HISTORY.length
           ret = run_single(line)
+          if line.start_with?("pry")
+            hist_diff = Readline::HISTORY.length - hist_length
+            hist_diff.times { Readline::HISTORY.pop() }
+          end
           # don't bother saving lines that couldn't be found as a
           # command, create the file if it doesn't exist, don't save dupes
           if ret && self.histfile && line != @last_line


### PR DESCRIPTION
Delete unwanted (out of context) history appended to to Readline::HISTORY after executing pry.
fixes #10149 

before: 
```
msf6 > history
...
...
245  show
246  show -h
247  show all
248  history
msf6 > pry
#<Pry::Config:0x000055f7fca09a20>
[*] Starting Pry shell...
[*] You are in the "framework" object

[1] pry(#<Msf::Framework>)> exit
245  show
246  show -h
247  show all
248  history
...
...
314  Readline::HISTORY.length
315  Readline::HISTORY.pop()
316  exit
317  ls Readline::HISTORY
318  exit
319  msf6 > pry
320  #<Pry::Config:0x000055f7fca09a20>
321  [*] Starting Pry shell...
322  [*] You are in the "framework" object
323  [1] pry(#<Msf::Framework>)>
324  exit
325  history
msf6 >
```

after

```
msf6 > history
...
...
240  pry
241  history
242  history
msf6 > pry
#<Pry::Config:0x00007f59d0021d78>
[*] Starting Pry shell...
[*] You are in the "framework" object

[1] pry(#<Msf::Framework>)> exit
msf6 > history
...
...
240  pry
241  history
242  history
243  pry
244  history
msf6 > 
```

PS: Ik the fix is very crude, but I don't see any other way around xD