### PR TITLE
Update metasploit-payloads gem to 2.0.44

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,7 +28,7 @@ PATH
       metasploit-concern (~> 3.0.0)
       metasploit-credential (~> 4.0.0)
       metasploit-model (~> 3.1.0)
-      metasploit-payloads (= 2.0.43)
+      metasploit-payloads (= 2.0.44)
       metasploit_data_models (~> 4.1.0)
       metasploit_payloads-mettle (= 1.0.9)
       mqtt
@@ -226,7 +226,7 @@ GEM
       activemodel (~> 5.2.2)
       activesupport (~> 5.2.2)
       railties (~> 5.2.2)
-    metasploit-payloads (2.0.43)
+    metasploit-payloads (2.0.44)
     metasploit_data_models (4.1.3)
       activerecord (~> 5.2.2)
       activesupport (~> 5.2.2)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -70,7 +70,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model', '~> 3.1.0'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '2.0.43'
+  spec.add_runtime_dependency 'metasploit-payloads', '2.0.44'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '1.0.9'
   # Needed by msfgui and other rpc components


### PR DESCRIPTION
Update the metasploit-payloads gem to v2.0.44 (previously 2.0.43). This adds the changes made in rapid7/metasploit-payloads#484 which adds a feature to the Java Meterpreter.

## Verification

- [x] Retest manually
- [x] Let automated tests pass
