### PR TITLE
Fix issue in Redis modules when run against authenticated instances

### DIFF
--- a/lib/msf/core/auxiliary/redis.rb
+++ b/lib/msf/core/auxiliary/redis.rb
@@ -52,7 +52,8 @@ module Msf
         vprint_error("No response to '#{command_string}'")
         return
       end
-      if REDIS_UNAUTHORIZED_RESPONSE =~ command_response
+      if match = command_response.match(REDIS_UNAUTHORIZED_RESPONSE)
+        auth_response = match[:auth_response]
         fail_with(::Msf::Module::Failure::BadConfig, "#{peer} requires authentication but Password unset") unless datastore['Password']
         vprint_status("Requires authentication (#{printable_redis_response(auth_response, false)})")
         if (auth_response = send_redis_command('AUTH', datastore['PASSWORD']))


### PR DESCRIPTION
Redis modules that use the `redis_command` method fail when authentication is present on the Redis instance. By adding in extra error logging, we can see the cause:

```
msf6 auxiliary(scanner/redis/file_upload) > run                                                                   
                                                                                                                  
[-] 127.0.0.1:6379        - Auxiliary failed: NameError undefined local variable or method `auth_response' for #<Msf::Modules::Auxiliary__Scanner__Redis__File_upload::MetasploitModule:0x000055b2fe31c638>
Did you mean?  author_to_s                       [-] 127.0.0.1:6379        - Call stack:                                                                           
[-] 127.0.0.1:6379        -   /home/smash/git/metasploit-framework/lib/msf/core/auxiliary/redis.rb:57:in `redis_command'
[-] 127.0.0.1:6379        -   /home/smash/git/metasploit-framework/modules/auxiliary/scanner/redis/file_upload.rb:122:in `check'
[-] 127.0.0.1:6379        -   /home/smash/git/metasploit-framework/modules/auxiliary/scanner/redis/file_upload.rb:158:in `run_host'
[-] 127.0.0.1:6379        -   /home/smash/git/metasploit-framework/lib/msf/core/auxiliary/scanner.rb:121:in `block (2 levels) in run'
[-] 127.0.0.1:6379        -   /home/smash/git/metasploit-framework/lib/msf/core/thread_manager.rb:105:in `block in spawn'
[*] Auxiliary module execution completed
```

This was a result of moving the regex into a constant, which broke named captures:

https://github.com/rapid7/metasploit-framework/commit/20f4050e5b0cc430f1cec333792a469863a7f282#diff-93e4bb8f08966b468043dde216d65c0afa081c6e530193b2e6578b96e8aa8103