### PR TITLE
Investigate lazy enumerators for auth brute mixin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# TODO: Will remove as part of final review
+rockyou*
+users*
 .bundle
 Gemfile.local
 Gemfile.local.lock

--- a/lib/msf/core/exploit/remote/http/wordpress/users.rb
+++ b/lib/msf/core/exploit/remote/http/wordpress/users.rb
@@ -15,7 +15,7 @@ module Msf::Exploit::Remote::HTTP::Wordpress::Users
     return true if res and res.code == 200 and
         (res.body.to_s =~ /Incorrect password/ or
             res.body.to_s =~ /document\.getElementById\('user_pass'\)/ or
-            res.body.to_s =~/<strong>#{user}<\/strong> is incorrect/)
+            res.body.to_s =~/<strong>#{Regexp.escape(user)}<\/strong> is incorrect/)
 
     return false
   end

--- a/spec/msf/core/auxiliary/auth_brute_spec.rb
+++ b/spec/msf/core/auxiliary/auth_brute_spec.rb
@@ -116,6 +116,7 @@ RSpec.describe Msf::Auxiliary::AuthBrute do
         )
       ]
     )
+
   end
 
   # Convenience method which defers the creation of a temporary file until its needed as
@@ -291,7 +292,7 @@ RSpec.describe Msf::Auxiliary::AuthBrute do
             ['user2', 'pass1'],
             ['user2', 'pass2']
           ],
-          expected_size: 6
+          expected_size: 8
         )
 
         it_behaves_like(
@@ -311,7 +312,7 @@ RSpec.describe Msf::Auxiliary::AuthBrute do
             ['user2', 'pass1'],
             ['user3', 'pass1']
           ],
-          expected_size: 6
+          expected_size: 9
         )
 
         it_behaves_like(
@@ -332,7 +333,7 @@ RSpec.describe Msf::Auxiliary::AuthBrute do
             ['user1', 'pass1'],
             ['user2', 'pass1']
           ],
-          expected_size: 6
+          expected_size: 12
         )
 
         it_behaves_like(
@@ -386,7 +387,7 @@ RSpec.describe Msf::Auxiliary::AuthBrute do
             ['user3', 'pass2'],
             ['user3', 'pass3']
           ],
-          expected_size: 9
+          expected_size: 81
         )
       end
 
@@ -421,7 +422,7 @@ RSpec.describe Msf::Auxiliary::AuthBrute do
             ['user1', 'foo bar'],
             ['user3', 'foo']
           ],
-          expected_size: 6
+          expected_size: 8
         )
 
         it_behaves_like(
@@ -454,7 +455,7 @@ RSpec.describe Msf::Auxiliary::AuthBrute do
             ['user1', 'foo'],
             ['user3', 'foo']
           ],
-          expected_size: 5
+          expected_size: 8
         )
       end
 
@@ -524,7 +525,7 @@ RSpec.describe Msf::Auxiliary::AuthBrute do
             ['db_nonblank_user', 'db_pass'],
             ['db_nonblank_user', 'db_nonblank_pass']
           ],
-          expected_size: 9
+          expected_size: 12
         )
       end
 
@@ -578,7 +579,7 @@ RSpec.describe Msf::Auxiliary::AuthBrute do
             ['db_nonblank_user', 'pass3'],
             ['db_nonblank_user', 'db_pass']
           ],
-          expected_size: 31
+          expected_size: 47
         )
       end
     end


### PR DESCRIPTION
This PR asks the question as to whether or not we can use lazy enumerators for the auth brute mixin

### Before

The current auth brute mixin attempts to create huge arrays in memory before attempting the brute force. This means for large word lists such as `rockyou.txt`, you'll be waiting a while - or run out of memory - https://github.com/rapid7/metasploit-framework/issues/14471

![image](https://user-images.githubusercontent.com/60357436/116560444-4d2c3d00-a8f9-11eb-8be8-792e25f9a3ca.png)

### After

The wordlists are no longer created up front in memory, and are instead lazily defined, and evaluated on demand. This means by default the wordpress module will start now start brute forcing credentials in a much short period of time of only a second or two, followed by pretty rapid enumeration:

![image](https://user-images.githubusercontent.com/60357436/116562701-4e5e6980-a8fb-11eb-85d6-346fa852238d.png)

## Verification

This has only been tested with wordpress_login_enum so far. Opening a PR for comments now, as I imagine there's other dragons to consider.

```
use scanner/http/wordpress_login_enum
set USER_FILE users.txt
set PASS_FILE rockyou.txt
run
```