### PR TITLE
more flexible time parse

### DIFF
--- a/lib/rex/parser/acunetix_document.rb
+++ b/lib/rex/parser/acunetix_document.rb
@@ -76,7 +76,7 @@ module Rex
         end
       when "StartTime"
         @state[:has_text] = false
-        @state[:timestamp] = @text.to_s.tr!(',','').tr!('/','-')
+        @state[:timestamp] = @text.to_time
         @text = nil
       when "Text"
         @state[:has_text] = false


### PR DESCRIPTION
Acunetix reports may serialize time in multiple patterns
Previously
```
<StartTime><![CDATA[8/5/2016, 23:45:12]]></StartTime>
```
Recently
```
<StartTime><![CDATA[2021-03-29T01:23:45.112233+01:00]]></StartTime>
```

`irb` shows parsing examples
```
>> '8/5/2016, 23:45:12'.to_time
=> 2016-05-08 23:45:12 -0500
>> '2021-03-29T01:23:45.112233+01:00'.to_time
=> 2021-03-28 19:23:45.112233 -0500
```
## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `db_import Old_Acunetix.xml`
- [x] **Verify** successful import
- [x] `db_import Current_Acunetix.xml`
- [x] **Verify** successful import
