### PR TITLE
Fix bug in tools/modules/module_author.rb

### DIFF
--- a/tools/modules/module_author.rb
+++ b/tools/modules/module_author.rb
@@ -17,6 +17,7 @@ end
 
 $:.unshift(File.expand_path(File.join(File.dirname(msfbase), '..', '..', 'lib')))
 
+require 'msfenv'
 require 'rex'
 require 'json'
 


### PR DESCRIPTION
The module_author.rb script is currently broken:
```
metasploit-framework > tools/modules/module_author.rb
Traceback (most recent call last):
tools/modules/module_author.rb:31:in `<main>': uninitialized constant Rex::Parser (NameError)
```

This commit fixes it by adding `require 'msfdev'` to the includes:
```
metasploit-framework > tools/modules/module_author.rb
(...)
    96     wvu <wvu@metasploit.com>
    105    Unknown
    121    OJ Reeves
    131    bcoles <bcoles@gmail.com>
    172    jduck <jduck@metasploit.com>
    195    skape <mmiller@hick.org>
    228    sf <stephen_fewer@harmonysecurity.com>
    264    MC <mc@metasploit.com>
    274    sinn3r <sinn3r@metasploit.com>
    371    juan vazquez <juan.vazquez@metasploit.com>
    470    hdm <x@hdm.io>
```