### PR TITLE
Fix errors in auxiliary/gather/saltstack_salt_root_key and exploit/linux/http/axis_srv_parhand_rce

### DIFF
--- a/modules/auxiliary/gather/saltstack_salt_root_key.rb
+++ b/modules/auxiliary/gather/saltstack_salt_root_key.rb
@@ -91,6 +91,7 @@ class MetasploitModule < Msf::Auxiliary
     Exploit::CheckCode::Vulnerable(root_key) # And the root key as the reason!
   rescue EOFError, Rex::ConnectionError => e
     print_error("#{e.class}: #{e.message}")
+    Exploit::CheckCode::Unknown
   ensure
     # This is from Msf::Exploit::Remote::ZeroMQ
     zmq_disconnect

--- a/modules/exploits/linux/http/axis_srv_parhand_rce.rb
+++ b/modules/exploits/linux/http/axis_srv_parhand_rce.rb
@@ -12,7 +12,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'                => 'Axis Network Camera .srv to parhand RCE',
+      'Name'                => 'Axis Network Camera .srv-to-parhand RCE',
       'Description'         => %q{
         This module exploits an auth bypass in .srv functionality and a
         command injection in parhand to execute code as the root user.


### PR DESCRIPTION
```
msf6 exploit(linux/misc/saltstack_salt_unauth_rce) > check

[*] 192.168.123.135:4506 - Using auxiliary/gather/saltstack_salt_root_key as check
[*] 192.168.123.135:4506 - Connecting to ZeroMQ service at 192.168.123.135:4506
[-] 192.168.123.135:4506 - Rex::ConnectionRefused: The connection was refused by the remote host (192.168.123.135:4506).
[*] 192.168.123.135:4506 - Disconnecting from 192.168.123.135:4506
[*] 192.168.123.135:4506 - This module does not support check. auxiliary/gather/saltstack_salt_root_key does not return a CheckCode.
msf6 exploit(linux/misc/saltstack_salt_unauth_rce) > use auxiliary/gather/saltstack_salt_root_key
msf6 auxiliary(gather/saltstack_salt_root_key) > edit
[*] Launching vim -i NONE /Users/wvu/rapid7/metasploit-framework/modules/auxiliary/gather/saltstack_salt_root_key.rb
msf6 auxiliary(gather/saltstack_salt_root_key) > git diff
[*] exec: git diff

diff --git a/modules/auxiliary/gather/saltstack_salt_root_key.rb b/modules/auxiliary/gather/saltstack_salt_root_key.rb
index 335c4d3282..bbc48da707 100644
--- a/modules/auxiliary/gather/saltstack_salt_root_key.rb
+++ b/modules/auxiliary/gather/saltstack_salt_root_key.rb
@@ -91,6 +91,7 @@ class MetasploitModule < Msf::Auxiliary
     Exploit::CheckCode::Vulnerable(root_key) # And the root key as the reason!
   rescue EOFError, Rex::ConnectionError => e
     print_error("#{e.class}: #{e.message}")
+    Exploit::CheckCode::Unknown
   ensure
     # This is from Msf::Exploit::Remote::ZeroMQ
     zmq_disconnect
msf6 auxiliary(gather/saltstack_salt_root_key) > reload
[*] Reloading module...
msf6 auxiliary(gather/saltstack_salt_root_key) > previous
[*] Using configured payload python/meterpreter/reverse_https
msf6 exploit(linux/misc/saltstack_salt_unauth_rce) > check

[*] 192.168.123.135:4506 - Using auxiliary/gather/saltstack_salt_root_key as check
[*] 192.168.123.135:4506 - Connecting to ZeroMQ service at 192.168.123.135:4506
[-] 192.168.123.135:4506 - Rex::ConnectionRefused: The connection was refused by the remote host (192.168.123.135:4506).
[*] 192.168.123.135:4506 - Disconnecting from 192.168.123.135:4506
[*] 192.168.123.135:4506 - Cannot reliably check exploitability.
msf6 exploit(linux/misc/saltstack_salt_unauth_rce) >
```

Fixes #10300 and #13401.