### PR TITLE
UCMDB: remove warning from docs and change Linux target to reverse_python

### DIFF
--- a/documentation/modules/exploit/multi/http/microfocus_ucmdb_unauth_deser.md
+++ b/documentation/modules/exploit/multi/http/microfocus_ucmdb_unauth_deser.md
@@ -19,10 +19,6 @@ Vulnerable versions of the software can be downloaded from Micro Focus website b
 
 Both Linux and Windows installations are affected.
 
-NOTE: At the time of writing this (24/01/2021), Metasploit ysoserial Linux payloads (except cmd/unix/generic) are
-broken! Remove this comment once this all works, and change the default payload from `cmd/unix/generic` to
-`cmd/unix/reverse_python` in the module code.
-
 All details about these vulnerabilities can be obtained from the advisory:
 
 * https://github.com/pedrib/PoC/blob/master/advisories/Micro_Focus/Micro_Focus_OBM.md

--- a/modules/exploits/multi/http/microfocus_ucmdb_unauth_deser.rb
+++ b/modules/exploits/multi/http/microfocus_ucmdb_unauth_deser.rb
@@ -63,7 +63,7 @@ class MetasploitModule < Msf::Exploit::Remote
                 'Platform' => 'unix',
                 'Arch' => [ARCH_CMD],
                 'DefaultOptions' =>
-                { 'PAYLOAD' => 'cmd/unix/generic' }
+                { 'PAYLOAD' => 'cmd/unix/reverse_python' }
               },
             ]
           ],


### PR DESCRIPTION
This commit removes the warning about msf's ysoserial payload from the Micro Focus UCMDB deser module, and changes the default Linux payload to cmd/unix/reverse_python.

It is made possible after the changes done in PR #14732 

Tested on both Linux and Windows targets, works like a charm.