### PR TITLE
Fix heading order check in msftidy_docs

### DIFF
--- a/tools/dev/msftidy_docs.rb
+++ b/tools/dev/msftidy_docs.rb
@@ -200,7 +200,7 @@ class MsftidyDoc
     end
   end
 
-  # This checks that the H2 headings are in the right order.
+  # This checks that the H2 headings are in the right order. Options are optional.
   def h2_order
     unless @source =~ /^## Vulnerable Application$.+^## Verification Steps$.+(?:^## Options$.+)?^## Scenarios$/m
       warn('H2 headings in incorrect order.  Should be: Vulnerable Application, Verification Steps, Options, Scenarios')

--- a/tools/dev/msftidy_docs.rb
+++ b/tools/dev/msftidy_docs.rb
@@ -12,6 +12,8 @@ require 'fileutils'
 require 'find'
 require 'time'
 
+SUPPRESS_INFO_MESSAGES = !!ENV['MSF_SUPPRESS_INFO_MESSAGES']
+
 class String
   def red
     "\e[1;31;40m#{self}\e[0m"

--- a/tools/dev/msftidy_docs.rb
+++ b/tools/dev/msftidy_docs.rb
@@ -200,9 +200,9 @@ class MsftidyDoc
     end
   end
 
-  # This checks that the H2 headings are in teh right order.
+  # This checks that the H2 headings are in the right order.
   def h2_order
-    unless @source =~ /^## Vulnerable Application$.+^## Verification Steps$.+^## Options$.+^## Scenarios$/m
+    unless @source =~ /^## Vulnerable Application$.+^## Verification Steps$.+(?:^## Options$.+)?^## Scenarios$/m
       warn('H2 headings in incorrect order.  Should be: Vulnerable Application, Verification Steps, Options, Scenarios')
     end
   end

--- a/tools/dev/msftidy_docs.rb
+++ b/tools/dev/msftidy_docs.rb
@@ -178,7 +178,8 @@ class MsftidyDoc
     end
 
     unless has_options
-      warn('Missing Section: ## Options')
+      # INFO because there may be no documentation-worthy options
+      info('Missing Section: ## Options')
     end
 
     if has_bad_description


### PR DESCRIPTION
Options are optional and already reported if missing.

```
wvu@kharak:~/rapid7/metasploit-framework:master$ tools/dev/msftidy_docs.rb documentation/modules/exploit/linux/http/vmware_vrops_mgr_ssrf_rce.md
documentation/modules/exploit/linux/http/vmware_vrops_mgr_ssrf_rce.md - [WARNING] Missing Section: ## Options
documentation/modules/exploit/linux/http/vmware_vrops_mgr_ssrf_rce.md - [WARNING] H2 headings in incorrect order. Should be: Vulnerable Application, Verification Steps, Options, Scenarios
wvu@kharak:~/rapid7/metasploit-framework:master$
```

After the fixes in this PR:

```
wvu@kharak:~/rapid7/metasploit-framework:bug/msftidy_docs$ tools/dev/msftidy_docs.rb documentation/modules/exploit/linux/http/vmware_vrops_mgr_ssrf_rce.md
documentation/modules/exploit/linux/http/vmware_vrops_mgr_ssrf_rce.md - [INFO] Missing Section: ## Options
wvu@kharak:~/rapid7/metasploit-framework:bug/msftidy_docs$
```

Fixes https://github.com/rapid7/metasploit-framework/pull/12878#discussion_r369854800.