### PR TITLE
Refine exploit/linux/http/vmware_vrops_mgr_ssrf_rce module doc again

### DIFF
--- a/documentation/modules/exploit/linux/http/vmware_vrops_mgr_ssrf_rce.md
+++ b/documentation/modules/exploit/linux/http/vmware_vrops_mgr_ssrf_rce.md
@@ -28,11 +28,11 @@ supported by this module. Tested against 8.0.1.
 ### Setup
 
 Import an exploitable vRealize Operations Manager OVA, such as
-[vRealize-Operations-Manager-Appliance-8.0.1.15331180_OVF10.ova], into
+[`vRealize-Operations-Manager-Appliance-8.0.1.15331180_OVF10.ova`], into
 your desired hypervisor. Boot the virtual appliance, and it should be
 exploitable out of the box once it's up.
 
-[vRealize-Operations-Manager-Appliance-8.0.1.15331180_OVF10.ova]:
+[`vRealize-Operations-Manager-Appliance-8.0.1.15331180_OVF10.ova`]:
 https://my.vmware.com/web/vmware/downloads/details?downloadGroup=VROPS-801&productId=940&rPId=40733
 
 ## Verification Steps


### PR DESCRIPTION
I've used this Markdown trick before, but I wasn't sure it'd work here. _Narrator: It does._ And it looks awesome.

![image](https://user-images.githubusercontent.com/4551878/116836520-6d275f00-ab8c-11eb-99af-b32579f7189a.png)

Fixes #15139. The added benefit here is that the filename is in a clearly readable, monospaced font.