### PR TITLE
Ensure cookie jars are correctly duped

### DIFF
--- a/lib/msf/core/exploit/remote/http/http_cookie_jar.rb
+++ b/lib/msf/core/exploit/remote/http/http_cookie_jar.rb
@@ -59,6 +59,13 @@ module Msf
             parsed_cookies.each { |c| add(Msf::Exploit::Remote::HTTP::HttpCookie.new(c)) }
             parsed_cookies
           end
+
+          # Modules are replicated before running. This method ensures that the cookie jar from
+          # one run, will not impact subsequent runs.
+          def initialize_copy(other)
+            super
+            @cookie_jar = other.instance_variable_get(:@cookie_jar).clone
+          end
         end
 
         class HashStoreWithoutAutomaticExpiration < ::HTTP::CookieJar::HashStore

--- a/spec/lib/msf/core/exploit/remote/remote/http/http_cookie_jar_spec.rb
+++ b/spec/lib/msf/core/exploit/remote/remote/http/http_cookie_jar_spec.rb
@@ -244,4 +244,17 @@ RSpec.describe Msf::Exploit::Remote::HTTP::HttpCookieJar do
       expect(cookie_jar.cookies).to match_array(cookies)
     end
   end
+
+  describe '#dup' do
+    it 'ensures the cookie jar is additionally duped' do
+      original = cookie_jar
+      dup = cookie_jar.dup
+
+      5.times { original.add(random_cookie) }
+      2.times { dup.add(random_cookie) }
+
+      expect(original.cookies.length).to be 5
+      expect(dup.cookies.length).to be 2
+    end
+  end
 end


### PR DESCRIPTION
Continuation of https://github.com/rapid7/metasploit-framework/pull/14831

Ensures that cookie jars are correctly duped as part of metasploit's replicant logic:

https://github.com/rapid7/metasploit-framework/blob/ee3a9e9e14b3f5047addfcdce165eea51a7670eb/lib/msf/core/module.rb#L147-L165

### Before

Running a module, then checking its `cookie_jar` shows cookies are being shared unintentionally:
```
msf6 exploit(unix/http/cacti_filter_sqli_rce) > run

[*] Started reverse TCP handler on 172.17.0.1:4444 
[*] Grabbing CSRF
[+] CSRF: sid:04cab0b1e235e02964ec1bb038b961189fd4ebec,1620156733
[*] Attempting login
[*] Dumping creds
[+] Username: admin, Password Hash: $2y$10$zBxQnqS7zVj1ChNIZy9zpe5x0CCUu.3unpOTl9zOl0LO2.JRAotE6
[+] Username: guest, Password Hash: 43e9a4ab75570f5b
[*] Backing-up path_php_binary value
[+] path_php_binary: /tmp/xgrho
[*] Uploading payload
[*] Triggering payload
[*] Command shell session 2 opened (172.17.0.1:4444 -> 172.22.0.4:34902) at 2021-05-04 15:32:17 -0400
[*] Cleaning up environment
[*] Grabbing CSRF
[+] CSRF: sid:dbb86ddfb70ef0336f1a9581dd1af28eb68173e4,1620156754
[*] Attempting login
[*] Resetting DB Value
exit
[*] 127.0.0.1 - Command shell session 2 closed.
msf6 exploit(unix/http/cacti_filter_sqli_rce) > irb
[*] Starting IRB shell...
[*] You are in exploit/unix/http/cacti_filter_sqli_rce

>> cookie_jar.cookies.length
=> 2 <-- **Here** Original cookie_jar mutated across runs
>> 

```

### After

After running a module, there's no trace in the original `cookie_jar`:

```
msf6 exploit(unix/http/cacti_filter_sqli_rce) > run -j
[*] Exploit running as background job 2.
msf6 exploit(unix/http/cacti_filter_sqli_rce) > 
[*] Started reverse TCP handler on 172.17.0.1:4444 
[*] Grabbing CSRF
[+] CSRF: sid:053e337a4c050e96eae72a997d01ebb166fbdada,1620156928
[*] Attempting login
[*] Dumping creds
[+] Username: admin, Password Hash: $2y$10$zBxQnqS7zVj1ChNIZy9zpe5x0CCUu.3unpOTl9zOl0LO2.JRAotE6
[+] Username: guest, Password Hash: 43e9a4ab75570f5b
[*] Backing-up path_php_binary value
[+] path_php_binary: /tmp/ikzp
[*] Uploading payload
[*] Triggering payload
[*] Command shell session 2 opened (172.17.0.1:4444 -> 172.22.0.4:35048) at 2021-05-04 15:35:32 -0400
[*] Cleaning up environment
[*] Grabbing CSRF
[+] CSRF: sid:de4e7f8c24c3688b5035dcc04fa8e71cd027422e,1620156949
[*] Attempting login
[*] Resetting DB Value

msf6 exploit(unix/http/cacti_filter_sqli_rce) > irb
[*] Starting IRB shell...
[*] You are in exploit/unix/http/cacti_filter_sqli_rce

>> cookie_jar.cookies.length
=> 0 <-- **Here** Original cookie_jar no longer mutated across runs
>> 
```

## Verification

Ensure CI passes with the newly added unit tests for this scenario
Ensure that running a module doesn't leave its cookies around in subsequent runs.

Shout out to @cdelafuente-r7 for spotting this edge case 🏆 