### PR TITLE
Update exploit/linux/http/vmware_vrops_mgr_ssrf_rce documentation

### DIFF
--- a/documentation/modules/exploit/linux/http/vmware_vrops_mgr_ssrf_rce.md
+++ b/documentation/modules/exploit/linux/http/vmware_vrops_mgr_ssrf_rce.md
@@ -20,7 +20,8 @@ The following vRealize Operations Manager versions are vulnerable:
 * 8.3.0
 
 Version 8.3.0 is not exploitable for creds and is therefore not
-supported by this module. Tested against 8.0.1.
+supported by this module. Tested successfully against 8.0.1, 8.1.0,
+8.1.1, and 8.2.0.
 
 [CVE-2021-21975]: https://nvd.nist.gov/vuln/detail/CVE-2021-21975
 [CVE-2021-21983]: https://nvd.nist.gov/vuln/detail/CVE-2021-21983

--- a/modules/exploits/linux/http/vmware_vrops_mgr_ssrf_rce.rb
+++ b/modules/exploits/linux/http/vmware_vrops_mgr_ssrf_rce.rb
@@ -36,7 +36,8 @@ class MetasploitModule < Msf::Exploit::Remote
           * 8.3.0
 
           Version 8.3.0 is not exploitable for creds and is therefore not
-          supported by this module. Tested against 8.0.1.
+          supported by this module. Tested successfully against 8.0.1, 8.1.0,
+          8.1.1, and 8.2.0.
         },
         'Author' => [
           'Egor Dimitrenko', # Discovery


### PR DESCRIPTION
I tested a few more versions _successfully_, in order to determine the upper bound of exploitability.

* 8.1.0
* 8.1.1
* 8.2.0

Updates #15005.