### PR TITLE
Ensure adobe sandbox collab sync session types is an array

### DIFF
--- a/modules/exploits/windows/local/adobe_sandbox_adobecollabsync.rb
+++ b/modules/exploits/windows/local/adobe_sandbox_adobecollabsync.rb
@@ -35,7 +35,7 @@ class MetasploitModule < Msf::Exploit::Local
         ],
       'Arch'          => ARCH_X86,
       'Platform'      => 'win',
-      'SessionTypes'  => 'meterpreter',
+      'SessionTypes'  => ['meterpreter'],
       'Payload'        =>
         {
           'Space'       => 12288,


### PR DESCRIPTION
Ensures adobe sandbox collab sync session types is an array

Noticed that this module was out of alignment with others when doing some data mining:
```ruby
[5] pry(main)> pp data.map { |m| m['session_types'] }.tally
{nil=>3690,
 []=>22,
 ["shell"]=>50,
 ["meterpreter"]=>298,
 ["meterpreter", "shell"]=>57,
 ["shell", "meterpreter"]=>121,
 "meterpreter"=>1,
 ["hwbridge"]=>10,
 ["powershell"]=>1}
```

There's only one non-array value found for all modules