### PR TITLE
Make `swagger-blocks` a default dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,6 @@ group :development, :test do
   gem 'rspec-rails'
   gem 'rspec-rerun'
   gem 'rubocop'
-  gem 'swagger-blocks'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,7 @@ PATH
       sinatra
       sqlite3
       sshkey
+      swagger-blocks
       thin
       tzinfo
       tzinfo-data
@@ -478,7 +479,6 @@ DEPENDENCIES
   rubocop
   ruby-prof (= 1.4.2)
   simplecov (= 0.18.2)
-  swagger-blocks
   timecop
   yard
 

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -105,6 +105,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'thin'
   spec.add_runtime_dependency 'sinatra'
   spec.add_runtime_dependency 'warden'
+  spec.add_runtime_dependency 'swagger-blocks'
   # Required for JSON-RPC client
   spec.add_runtime_dependency 'em-http-request'
   # TimeZone info


### PR DESCRIPTION
`swagger-blocks` is a necessary gem for running the metasploit web service, currently if you install without the `development` and `test` groups you don't get `swagger-block` installed and so the web service fails to start

Adding `BUNDLE_WITHOUT: "development:test"` to your bundle config should allow you to replicate the issue

Example stacktrace from before:
```
/usr/share/metasploit-framework/vendor/bundle/ruby/2.7.0/gems/zeitwerk-2.4.2/lib/zeitwerk/kernel.rb:34:in `require': cannot load such file -- swagger/blocks (LoadError)
        from /usr/share/metasploit-framework/vendor/bundle/ruby/2.7.0/gems/zeitwerk-2.4.2/lib/zeitwerk/kernel.rb:34:in `require'
        from /usr/share/metasploit-framework/vendor/bundle/ruby/2.7.0/gems/activesupport-5.2.5/lib/active_support/dependencies.rb:291:in `block in require'
        from /usr/share/metasploit-framework/vendor/bundle/ruby/2.7.0/gems/activesupport-5.2.5/lib/active_support/dependencies.rb:257:in `load_dependency'
        from /usr/share/metasploit-framework/vendor/bundle/ruby/2.7.0/gems/activesupport-5.2.5/lib/active_support/dependencies.rb:291:in `require'
        from /usr/share/metasploit-framework/lib/msf/core/web_services/metasploit_api_app.rb:3:in `<top (required)>'
        from /usr/share/metasploit-framework/vendor/bundle/ruby/2.7.0/gems/zeitwerk-2.4.2/lib/zeitwerk/kernel.rb:26:in `require'
        from /usr/share/metasploit-framework/vendor/bundle/ruby/2.7.0/gems/zeitwerk-2.4.2/lib/zeitwerk/kernel.rb:26:in `require'
        from /usr/share/metasploit-framework/vendor/bundle/ruby/2.7.0/gems/activesupport-5.2.5/lib/active_support/dependencies.rb:291:in `block in require'
        from /usr/share/metasploit-framework/vendor/bundle/ruby/2.7.0/gems/activesupport-5.2.5/lib/active_support/dependencies.rb:257:in `load_dependency'
        from /usr/share/metasploit-framework/vendor/bundle/ruby/2.7.0/gems/activesupport-5.2.5/lib/active_support/dependencies.rb:291:in `require'
        from /usr/share/metasploit-framework/msf-ws.ru:16:in `block in <main>'
        from /usr/share/metasploit-framework/vendor/bundle/ruby/2.7.0/gems/rack-2.2.3/lib/rack/builder.rb:125:in `instance_eval'
        from /usr/share/metasploit-framework/vendor/bundle/ruby/2.7.0/gems/rack-2.2.3/lib/rack/builder.rb:125:in `initialize'
        from /usr/share/metasploit-framework/msf-ws.ru:1:in `new'
        from /usr/share/metasploit-framework/msf-ws.ru:1:in `<main>'
        from /usr/share/metasploit-framework/vendor/bundle/ruby/2.7.0/gems/thin-1.8.0/lib/rack/adapter/loader.rb:33:in `eval'
        from /usr/share/metasploit-framework/vendor/bundle/ruby/2.7.0/gems/thin-1.8.0/lib/rack/adapter/loader.rb:33:in `load'
        from /usr/share/metasploit-framework/vendor/bundle/ruby/2.7.0/gems/thin-1.8.0/lib/thin/controllers/controller.rb:182:in `load_rackup_config'
        from /usr/share/metasploit-framework/vendor/bundle/ruby/2.7.0/gems/thin-1.8.0/lib/thin/controllers/controller.rb:72:in `start'
        from /usr/share/metasploit-framework/vendor/bundle/ruby/2.7.0/gems/thin-1.8.0/lib/thin/runner.rb:203:in `run_command'
        from /usr/share/metasploit-framework/vendor/bundle/ruby/2.7.0/gems/thin-1.8.0/lib/thin/runner.rb:159:in `run!'
        from /usr/share/metasploit-framework/vendor/bundle/ruby/2.7.0/gems/thin-1.8.0/bin/thin:6:in `<top (required)>'
        from /usr/share/metasploit-framework/vendor/bundle/ruby/2.7.0/bin/thin:23:in `load'
        from /usr/share/metasploit-framework/vendor/bundle/ruby/2.7.0/bin/thin:23:in `<main>'

```

# Verification
- [ ] `bundle install` without the development and test groups
- [ ] Verify that webservice can start up via msfdb