### PR TITLE
msfdb default to database only

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -1827,17 +1827,20 @@ class Db
   end
 
   def cmd_db_disconnect_help
-    print_line "Usage: db_disconnect"
-    print_line
-    print_line "Disconnect from the data service."
+    print_line "Usage:"
+    print_line "    db_disconnect              Temporarily disconnects from the currently configured dataservice."
+    print_line "    db_disconnect --clear      Clears the default dataservice that msfconsole will use when opened."
     print_line
   end
 
   def cmd_db_disconnect(*args)
     return if not db_check_driver
 
-    if(args[0] and (args[0] == "-h" || args[0] == "--help"))
+    if args[0] == '-h' || args[0] == '--help'
       cmd_db_disconnect_help
+      return
+    elsif args[0] == '-c' || args[0] == '--clear'
+      clear_default_db
       return
     end
 
@@ -1890,27 +1893,6 @@ class Db
       print_error e.message
     end
   end
-
-  def cmd_db_clear_default_help(*args)
-    print_line "Usage: db_clear_default"
-    print_line
-    print_line "Clears the default data service connection used on startup."
-    print_line
-  end
-
-
-  def cmd_db_clear_default(*args)
-    while (arg = args.shift)
-      case arg
-      when '-h', '--help'
-        cmd_db_clear_default_help
-        return
-      end
-    end
-
-    clear_default_db
-  end
-
 
   def save_db_to_config(database, database_name)
     if database_name =~ /\/|\[|\]/

--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -36,8 +36,7 @@ class Db
       "db_disconnect"    => "Disconnect from the current data service",
       "db_status"        => "Show the current data service status",
       "db_save"          => "Save the current data service connection as the default to reconnect on startup",
-      "db_remove"        => "Remove the saved data service entry",
-      "db_clear_default" => "Clears the default data service connection used on startup"
+      "db_remove"        => "Remove the saved data service entry"
     }
 
     more = {

--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -32,11 +32,12 @@ class Db
   #
   def commands
     base = {
-      "db_connect"    => "Connect to an existing data service",
-      "db_disconnect" => "Disconnect from the current data service",
-      "db_status"     => "Show the current data service status",
-      "db_save"       => "Save the current data service connection as the default to reconnect on startup",
-      "db_remove"     => "Remove the saved data service entry"
+      "db_connect"       => "Connect to an existing data service",
+      "db_disconnect"    => "Disconnect from the current data service",
+      "db_status"        => "Show the current data service status",
+      "db_save"          => "Save the current data service connection as the default to reconnect on startup",
+      "db_remove"        => "Remove the saved data service entry",
+      "db_clear_default" => "Clears the default data service connection used on startup"
     }
 
     more = {
@@ -1889,6 +1890,27 @@ class Db
       print_error e.message
     end
   end
+
+  def cmd_db_clear_default_help(*args)
+    print_line "Usage: db_clear_default"
+    print_line
+    print_line "Clears the default data service connection used on startup."
+    print_line
+  end
+
+
+  def cmd_db_clear_default(*args)
+    while (arg = args.shift)
+      case arg
+      when '-h', '--help'
+        cmd_db_clear_default_help
+        return
+      end
+    end
+
+    clear_default_db
+  end
+
 
   def save_db_to_config(database, database_name)
     if database_name =~ /\/|\[|\]/

--- a/msfdb
+++ b/msfdb
@@ -57,7 +57,9 @@ require 'msfenv'
 @component_provided = false
 
 @options = {
-    component: :database,
+    # When the component vlaue is nil, the user has not yet specified a specific component
+    # It will later be defaulted to a more sane value
+    component: nil,
     debug: false,
     msf_db_name: 'msf',
     msf_db_user: 'msf',
@@ -254,28 +256,12 @@ def update_db_port
   end
 end
 
-def ask_yn_default(question, default_value)
-  return default_value if @options[:use_defaults]
-
-  print "#{'[?]'.blue.bold} #{question} [#{default_value}]: "
-  yn = STDIN.gets.strip
-  case yn
-  when /^[Yy]/
-    return true
-  when /^[Nn]/
-    return false
-  when nil, ''
-    return default_value
-  else
-    puts 'Please answer yes or no.'
-  end
-end
-
-def ask_yn_loop(question)
+def ask_yn(question, default: nil)
   loop do
-    print "#{'[?]'.blue.bold} #{question}: "
-    yn = STDIN.gets
-    case yn
+    print "#{'[?]'.blue.bold} #{question} [#{default}]: "
+    input = STDIN.gets.strip
+    input = input.empty? ? default : input
+    case input
     when /^[Yy]/
       return true
     when /^[Nn]/
@@ -286,13 +272,13 @@ def ask_yn_loop(question)
   end
 end
 
-def ask_value(question, default_value)
-  return default_value if @options[:use_defaults]
+def ask_value(question, default)
+  return default if @options[:use_defaults]
 
-  print "#{'[?]'.blue.bold} #{question} [#{default_value}]: "
+  print "#{'[?]'.blue.bold} #{question} [#{default}]: "
   input = STDIN.gets.strip
   if input.nil? || input.empty?
-    return default_value
+    return default
   else
     return input
   end
@@ -629,26 +615,29 @@ def output_web_service_information
   end
 end
 
-def persist_data_service
-  # execute msfconsole commands to add and persist the data service connection
-  cmd = "./msfconsole -qx \"#{get_db_connect_command}; db_save; exit\""
+def run_msfconsole_command(cmd)
+  # Attempts to run a the metasploit command first with the default env settings, and once again with the path set
+  # to the current directory. This ensures that it works in an environment such as bundler
   if @db_driver.run_cmd(cmd) != 0
     # attempt to execute msfconsole in the current working directory
     if @db_driver.run_cmd(cmd, env: {'PATH' => ".:#{ENV["PATH"]}"}) != 0
-      puts 'Failed to run msfconsole and persist the data service connection'
+      puts 'Failed to run msfconsole'
     end
   end
 end
 
-def clear_default_data_service
+def persist_data_service
+  puts 'Persisting data service credentials in msfconsole'
   # execute msfconsole commands to add and persist the data service connection
-  cmd = "./msfconsole -qx db_clear_default; exit\""
-  if @db_driver.run_cmd(cmd) != 0
-    # attempt to execute msfconsole in the current working directory
-    if @db_driver.run_cmd(cmd, env: {'PATH' => ".:#{ENV["PATH"]}"}) != 0
-      puts 'Failed to run msfconsole and clear the default data service connection'
-    end
-  end
+  cmd = "./msfconsole -qx '#{get_db_connect_command}; db_save; exit'"
+  run_msfconsole_command(cmd)
+end
+
+def clear_default_data_service
+  puts 'Clearing data service credentials in msfconsole'
+  # execute msfconsole commands to clear the default data service connection
+  cmd = "./msfconsole -qx 'db_disconnect --clear; exit'"
+  run_msfconsole_command(cmd)
 end
 
 def get_db_connect_command
@@ -946,10 +935,22 @@ def has_requirements(postgresql_cmds)
   ret_val
 end
 
-
 def should_generate_web_service_ssl
   @options[:ssl] && ((!File.file?(@options[:ssl_key]) || !File.file?(@options[:ssl_cert])) ||
       (@options[:ssl_key] == @ws_ssl_key_default && @options[:ssl_cert] == @ws_ssl_cert_default))
+end
+
+def prompt_for_component(command)
+  if command == :status || command == :delete
+    return :all
+  end
+
+  enable_webservice = ask_yn("Would you like to #{command} the webservice? (Not Required)", default: 'no')
+  if enable_webservice
+    :all
+  else
+    :database
+  end
 end
 
 def prompt_for_deletion(command)
@@ -973,12 +974,10 @@ def prompt_for_deletion(command)
   end
 end
 
-
 def should_delete
   return true if @options[:use_defaults]
-  ask_yn_loop("Would you like to delete your existing data and configurations?")
+  ask_yn("Would you like to delete your existing data and configurations?")
 end
-
 
 if $PROGRAM_NAME == __FILE__
   # Bomb out if we're root
@@ -1010,17 +1009,6 @@ if $PROGRAM_NAME == __FILE__
   }
 
   parse_args(ARGV)
-
-  unless @component_provided
-    if ask_yn_default('Would you also like this operation to affect the webservice?', false)
-      @options[:component] = :all
-    end
-  end
-
-  if @options[:database]
-    clear_default_data_service
-  end
-
   update_db_port
 
   if @connection_string
@@ -1035,7 +1023,14 @@ if $PROGRAM_NAME == __FILE__
   end
 
   command = ARGV[0].to_sym
+  if @options[:component].nil?
+    @options[:component] = prompt_for_component(command)
+  end
   prompt_for_deletion(command)
+  # Disable the locally configured webservice component
+  if command != :status && @options[:component] == :database
+    clear_default_data_service
+  end
   if @options[:component] == :all
     @components.each { |component|
       puts '===================================================================='

--- a/msfdb
+++ b/msfdb
@@ -56,7 +56,7 @@ require 'msfenv'
 @environments = %w(production development)
 
 @options = {
-    component: :all,
+    component: :database,
     debug: false,
     msf_db_name: 'msf',
     msf_db_user: 'msf',
@@ -758,7 +758,7 @@ def parse_args(args)
     opts.separator('Manage a Metasploit Framework database and web service')
     opts.separator('')
     opts.separator('General Options:')
-    opts.on('--component COMPONENT', @components + ['all'], 'Component used with provided command (default: all)',
+    opts.on('--component COMPONENT', @components + ['all'], 'Component used with provided command (default: database)',
             "  (#{@components.join(', ')})") { |component|
       @options[:component] = component.to_sym
     }
@@ -1003,7 +1003,7 @@ if $PROGRAM_NAME == __FILE__
       puts
     }
   else
-    puts "Running the '#{command}' command for the #{@options[:component].to_s}:"
+    puts "Running the '#{command}' command for the #{@options[:component]}:"
     invoke_command(commands, @options[:component], command)
   end
 end

--- a/msfdb
+++ b/msfdb
@@ -640,6 +640,17 @@ def persist_data_service
   end
 end
 
+def clear_default_data_service
+  # execute msfconsole commands to add and persist the data service connection
+  cmd = "./msfconsole -qx db_clear_default; exit\""
+  if @db_driver.run_cmd(cmd) != 0
+    # attempt to execute msfconsole in the current working directory
+    if @db_driver.run_cmd(cmd, env: {'PATH' => ".:#{ENV["PATH"]}"}) != 0
+      puts 'Failed to run msfconsole and clear the default data service connection'
+    end
+  end
+end
+
 def get_db_connect_command
   data_service_name = "local-#{@options[:ssl] ? 'https' : 'http'}-data-service"
   if !@options[:data_service_name].nil?
@@ -1001,9 +1012,13 @@ if $PROGRAM_NAME == __FILE__
   parse_args(ARGV)
 
   unless @component_provided
-    if ask_yn_default('Would you also like to start up the webservice?', false)
+    if ask_yn_default('Would you also like this operation to affect the webservice?', false)
       @options[:component] = :all
     end
+  end
+
+  if @options[:database]
+    clear_default_data_service
   end
 
   update_db_port

--- a/msfdb
+++ b/msfdb
@@ -54,10 +54,9 @@ require 'msfenv'
 
 @components = %w(database webservice)
 @environments = %w(production development)
-@component_provided = false
 
 @options = {
-    # When the component vlaue is nil, the user has not yet specified a specific component
+    # When the component value is nil, the user has not yet specified a specific component
     # It will later be defaulted to a more sane value
     component: nil,
     debug: false,
@@ -781,7 +780,6 @@ def parse_args(args)
     opts.on('--component COMPONENT', @components + ['all'], 'Component used with provided command (default: database)',
             "  (#{@components.join(', ')})") { |component|
       @options[:component] = component.to_sym
-      @component_provided = true
     }
 
     opts.on('-d', '--debug', 'Enable debug output') { |d| @options[:debug] = d }

--- a/msfdb
+++ b/msfdb
@@ -54,6 +54,7 @@ require 'msfenv'
 
 @components = %w(database webservice)
 @environments = %w(production development)
+@component_provided = false
 
 @options = {
     component: :database,
@@ -253,7 +254,24 @@ def update_db_port
   end
 end
 
-def ask_yn(question)
+def ask_yn_default(question, default_value)
+  return default_value if @options[:use_defaults]
+
+  print "#{'[?]'.blue.bold} #{question} [#{default_value}]: "
+  yn = STDIN.gets.strip
+  case yn
+  when /^[Yy]/
+    return true
+  when /^[Nn]/
+    return false
+  when nil, ''
+    return default_value
+  else
+    puts 'Please answer yes or no.'
+  end
+end
+
+def ask_yn_loop(question)
   loop do
     print "#{'[?]'.blue.bold} #{question}: "
     yn = STDIN.gets
@@ -269,6 +287,8 @@ def ask_yn(question)
 end
 
 def ask_value(question, default_value)
+  return default_value if @options[:use_defaults]
+
   print "#{'[?]'.blue.bold} #{question} [#{default_value}]: "
   input = STDIN.gets.strip
   if input.nil? || input.empty?
@@ -761,6 +781,7 @@ def parse_args(args)
     opts.on('--component COMPONENT', @components + ['all'], 'Component used with provided command (default: database)',
             "  (#{@components.join(', ')})") { |component|
       @options[:component] = component.to_sym
+      @component_provided = true
     }
 
     opts.on('-d', '--debug', 'Enable debug output') { |d| @options[:debug] = d }
@@ -944,7 +965,7 @@ end
 
 def should_delete
   return true if @options[:use_defaults]
-  ask_yn("Would you like to delete your existing data and configurations?")
+  ask_yn_loop("Would you like to delete your existing data and configurations?")
 end
 
 
@@ -978,6 +999,12 @@ if $PROGRAM_NAME == __FILE__
   }
 
   parse_args(ARGV)
+
+  unless @component_provided
+    if ask_yn_default('Would you also like to start up the webservice?', false)
+      @options[:component] = :all
+    end
+  end
 
   update_db_port
 


### PR DESCRIPTION
Changes the default behaviour from starting up both the webservice and database to just the database

# Verification
- [x] `./msfdb init` should create only the database (confirm that on booting `./msfconsole` it connects correctly with `db_status`)
- [x] `./msfdb init --component=webservice` should create the webservice without disrupting the database, check `msfconsole` now connects to the remote data service with `db_status`
- [x] `./msfdb reinit --component=all` should tear down and re-create both services