### PR TITLE
Fix RPORT tab completion crash when connected to remote dataservice

### DIFF
--- a/lib/msf/core/db_manager/host.rb
+++ b/lib/msf/core/db_manager/host.rb
@@ -127,14 +127,6 @@ module Msf::DBManager::Host
   }
   end
 
-  # Look for an address across all comms
-  def has_host?(wspace,addr)
-  ::ApplicationRecord.connection_pool.with_connection {
-    address, scope = addr.split('%', 2)
-    wspace.hosts.find_by_address(addr)
-  }
-  end
-
   # Returns a list of all hosts in the database
   def hosts(opts)
     ::ApplicationRecord.connection_pool.with_connection {

--- a/spec/support/shared/examples/msf/db_manager/host.rb
+++ b/spec/support/shared/examples/msf/db_manager/host.rb
@@ -3,7 +3,6 @@ RSpec.shared_examples_for 'Msf::DBManager::Host' do
   unless ENV['REMOTE_DB']
     it { is_expected.to respond_to :each_host }
     it { is_expected.to respond_to :del_host }
-    it { is_expected.to respond_to :has_host? }
   end
 
   it { is_expected.to respond_to :find_or_create_host }


### PR DESCRIPTION
Fixes https://github.com/rapid7/metasploit-framework/issues/15075


Removes usage of `has_host?`from the `option_values_target_ports` module of `module_option_tab_completion`. 

This is the last remaining use of the method in the code base, so I deleted the original method definition since it's breaking things and we don't want it being used in the future.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/ssh/ssh_login`
- [x] `set RHOSTS 1.1.1.1`
- [x] `set RPORT <TAB>`
- [x] Ensure that no error is thrown, and that a RPORT number is populated if appropriate