### PR TITLE
Support spaces in user input for msfdb

### DIFF
--- a/lib/msfdb_helpers/pg_ctl.rb
+++ b/lib/msfdb_helpers/pg_ctl.rb
@@ -29,7 +29,7 @@ module MsfdbHelpers
 
       puts "Creating database at #{@db}"
       Dir.mkdir(@db)
-      run_cmd("initdb --auth-host=trust --auth-local=trust -E UTF8 #{@db}")
+      run_cmd("initdb --auth-host=trust --auth-local=trust -E UTF8 #{@db.shellescape}")
 
       File.open("#{@db}/postgresql.conf", 'a') do |f|
         f.puts "port = #{@options[:db_port]}"
@@ -66,15 +66,15 @@ module MsfdbHelpers
     end
 
     def start
-      if run_cmd("pg_ctl -o \"-p #{@options[:db_port]}\" -D #{@db} status") == 0
+      if run_cmd("pg_ctl -o \"-p #{@options[:db_port]}\" -D #{@db.shellescape} status") == 0
         puts "Database already started at #{@db}"
         return true
       end
 
       print "Starting database at #{@db}..."
-      run_cmd("pg_ctl -o \"-p #{@options[:db_port]}\" -D #{@db} -l #{@db}/log start")
+      run_cmd("pg_ctl -o \"-p #{@options[:db_port]}\" -D #{@db.shellescape} -l #{@db.shellescape}/log start")
       sleep(2)
-      if run_cmd("pg_ctl -o \"-p #{@options[:db_port]}\" -D #{@db} status") != 0
+      if run_cmd("pg_ctl -o \"-p #{@options[:db_port]}\" -D #{@db.shellescape} status") != 0
         puts 'failed'.red.bold.to_s
         false
       else
@@ -84,9 +84,9 @@ module MsfdbHelpers
     end
 
     def stop
-      if run_cmd("pg_ctl -o \"-p #{@options[:db_port]}\" -D #{@db} status") == 0
+      if run_cmd("pg_ctl -o \"-p #{@options[:db_port]}\" -D #{@db.shellescape} status") == 0
         puts "Stopping database at #{@db}"
-        run_cmd("pg_ctl -o \"-p #{@options[:db_port]}\" -D #{@db} stop")
+        run_cmd("pg_ctl -o \"-p #{@options[:db_port]}\" -D #{@db.shellescape} stop")
       else
         puts "Database is no longer running at #{@db}"
       end
@@ -99,7 +99,7 @@ module MsfdbHelpers
 
     def status
       if Dir.exist?(@db)
-        if run_cmd("pg_ctl -o \"-p #{@options[:db_port]}\" -D #{@db} status") == 0
+        if run_cmd("pg_ctl -o \"-p #{@options[:db_port]}\" -D #{@db.shellescape} status") == 0
           puts "Database started at #{@db}"
         else
           puts "Database is not running at #{@db}"
@@ -111,12 +111,12 @@ module MsfdbHelpers
 
     def create_db_users(msf_pass, msftest_pass)
       puts 'Creating database users'
-      run_psql("create user #{@options[:msf_db_user]} with password '#{msf_pass}'")
-      run_psql("create user #{@options[:msftest_db_user]} with password '#{msftest_pass}'")
-      run_psql("alter role #{@options[:msf_db_user]} createdb")
-      run_psql("alter role #{@options[:msftest_db_user]} createdb")
-      run_psql("alter role #{@options[:msf_db_user]} with password '#{msf_pass}'")
-      run_psql("alter role #{@options[:msftest_db_user]} with password '#{msftest_pass}'")
+      run_psql("create user #{@options[:msf_db_user].shellescape} with password '#{msf_pass}'")
+      run_psql("create user #{@options[:msftest_db_user].shellescape} with password '#{msftest_pass}'")
+      run_psql("alter role #{@options[:msf_db_user].shellescape} createdb")
+      run_psql("alter role #{@options[:msftest_db_user].shellescape} createdb")
+      run_psql("alter role #{@options[:msf_db_user].shellescape} with password '#{msf_pass}'")
+      run_psql("alter role #{@options[:msftest_db_user].shellescape} with password '#{msftest_pass}'")
 
       conn = PG.connect(host: @options[:db_host], dbname: 'postgres', port: @options[:db_port], user: @options[:msf_db_user], password: msf_pass)
       conn.exec("CREATE DATABASE #{@options[:msf_db_name]}")

--- a/lib/msfdb_helpers/pg_ctlcluster.rb
+++ b/lib/msfdb_helpers/pg_ctlcluster.rb
@@ -33,7 +33,7 @@ module MsfdbHelpers
       puts "Creating database at #{@db}"
       Dir.mkdir(@db)
       FileUtils.mkdir_p(@pg_cluster_conf_root)
-      run_cmd("pg_createcluster --user=$(whoami) -l #{@db}/log -d #{@db} -s /tmp --encoding=UTF8 #{@pg_version} #{@options[:msf_db_name]} -- --username=$(whoami) --auth-host=trust --auth-local=trust")
+      run_cmd("pg_createcluster --user=$(whoami) -l #{@db.shellescape}/log -d #{@db.shellescape} -s /tmp --encoding=UTF8 #{@pg_version} #{@options[:msf_db_name].shellescape} -- --username=$(whoami) --auth-host=trust --auth-local=trust")
       File.open("#{@pg_cluster_conf_root}/#{@pg_version}/#{@options[:msf_db_name]}/postgresql.conf", 'a') do |f|
         f.puts "port = #{@options[:db_port]}"
       end
@@ -52,7 +52,7 @@ module MsfdbHelpers
 
         if @options[:delete_existing_data]
           puts "Deleting all data at #{@db}"
-          run_cmd("pg_dropcluster #{@pg_version} #{@options[:msf_db_name]}")
+          run_cmd("pg_dropcluster #{@pg_version} #{@options[:msf_db_name].shellescape}")
           FileUtils.rm_rf(@db)
           FileUtils.rm_rf("#{@localconf}/.local/etc/postgresql")
           File.delete(@db_conf)
@@ -69,7 +69,7 @@ module MsfdbHelpers
 
     def start
       print "Starting database at #{@db}..."
-      status = run_cmd("pg_ctlcluster #{@pg_version} #{@options[:msf_db_name]} start -- -o \"-p #{@options[:db_port]}\" -D #{@db} -l #{@db}/log")
+      status = run_cmd("pg_ctlcluster #{@pg_version} #{@options[:msf_db_name].shellescape} start -- -o \"-p #{@options[:db_port]}\" -D #{@db.shellescape} -l #{@db.shellescape}/log")
       case status
       when 0
         puts 'success'.green.bold.to_s
@@ -84,16 +84,16 @@ module MsfdbHelpers
     end
 
     def stop
-      run_cmd("pg_ctlcluster #{get_postgres_version} #{@options[:msf_db_name]} stop -- -o \"-p #{@options[:db_port]}\" -D #{@db}")
+      run_cmd("pg_ctlcluster #{get_postgres_version} #{@options[:msf_db_name].shellescape} stop -- -o \"-p #{@options[:db_port]}\" -D #{@db.shellescape}")
     end
 
     def restart
-      run_cmd("pg_ctlcluster #{@pg_version} #{@options[:msf_db_name]} reload -- -o \"-p #{@options[:db_port]}\" -D #{@db} -l #{@db}/log")
+      run_cmd("pg_ctlcluster #{@pg_version} #{@options[:msf_db_name].shellescape} reload -- -o \"-p #{@options[:db_port]}\" -D #{@db.shellescape} -l #{@db.shellescape}/log")
     end
 
     def status
       if Dir.exist?(@db)
-        if run_cmd("pg_ctlcluster #{@pg_version} #{@options[:msf_db_name]} status -- -o \"-p #{@options[:db_port]}\" -D #{@db}") == 0
+        if run_cmd("pg_ctlcluster #{@pg_version} #{@options[:msf_db_name].shellescape} status -- -o \"-p #{@options[:db_port]}\" -D #{@db.shellescape}") == 0
           puts "Database started at #{@db}"
         else
           puts "Database is not running at #{@db}"
@@ -125,12 +125,12 @@ module MsfdbHelpers
 
     def create_db_users(msf_pass, msftest_pass)
       puts 'Creating database users'
-      run_psql("create user #{@options[:msf_db_user]} with password '#{msf_pass}'")
-      run_psql("create user #{@options[:msftest_db_user]} with password '#{msftest_pass}'")
-      run_psql("alter role #{@options[:msf_db_user]} createdb")
-      run_psql("alter role #{@options[:msftest_db_user]} createdb")
-      run_psql("alter role #{@options[:msf_db_user]} with password '#{msf_pass}'")
-      run_psql("alter role #{@options[:msftest_db_user]} with password '#{msftest_pass}'")
+      run_psql("create user #{@options[:msf_db_user].shellescape} with password '#{msf_pass}'")
+      run_psql("create user #{@options[:msftest_db_user].shellescape} with password '#{msftest_pass}'")
+      run_psql("alter role #{@options[:msf_db_user].shellescape} createdb")
+      run_psql("alter role #{@options[:msftest_db_user].shellescape} createdb")
+      run_psql("alter role #{@options[:msf_db_user].shellescape} with password '#{msf_pass}'")
+      run_psql("alter role #{@options[:msftest_db_user].shellescape} with password '#{msftest_pass}'")
 
       conn = PG.connect(host: @options[:db_host], dbname: 'postgres', port: @options[:db_port], user: @options[:msf_db_user], password: msf_pass)
       conn.exec("CREATE DATABASE #{@options[:msf_db_name]}")

--- a/msfdb
+++ b/msfdb
@@ -656,11 +656,11 @@ end
 
 # TODO: In the future this can be replaced by Msf::WebServices::HttpDBManagerService
 def thin_cmd
-  server_opts = "--rackup #{@ws_conf} --address #{@options[:address]} --port #{@options[:port]}"
-  ssl_opts = @options[:ssl] ? "--ssl --ssl-key-file #{@options[:ssl_key]} --ssl-cert-file #{@options[:ssl_cert]}" : ''
+  server_opts = "--rackup #{@ws_conf.shellescape} --address #{@options[:address].shellescape} --port #{@options[:port]}"
+  ssl_opts = @options[:ssl] ? "--ssl --ssl-key-file #{@options[:ssl_key].shellescape} --ssl-cert-file #{@options[:ssl_cert].shellescape}" : ''
   ssl_opts << ' --ssl-disable-verify' if skip_ssl_verify?
   adapter_opts = "--environment #{@options[:ws_env]}"
-  daemon_opts = "--daemonize --log #{@ws_log} --pid #{@ws_pid} --tag #{@ws_tag}" if @options[:daemon]
+  daemon_opts = "--daemonize --log #{@ws_log.shellescape} --pid #{@ws_pid.shellescape} --tag #{@ws_tag}" if @options[:daemon]
   all_opts = [server_opts, ssl_opts, adapter_opts, daemon_opts].reject(&:blank?).join(' ')
 
   "thin #{all_opts}"


### PR DESCRIPTION
Previously having spaces in the path to framework install would result in errors running msfdb, this PR addresses that issue along with having spaces in options passed into the script

Example of current functionality, you can see when running `reinit` which metasploit in a folder with spaces in the name it fails to complete
![image](https://user-images.githubusercontent.com/19910435/118260553-6103a180-b4aa-11eb-8dbe-957460dc2375.png)

and after:
![image](https://user-images.githubusercontent.com/19910435/118260929-d4a5ae80-b4aa-11eb-8c7d-90e78b5065d7.png)


# Verification
- [x] `./msfdb delete --component=all` # This is destructive if you have important data in your db do this in a VM
- [x] Create a folder with spaces in the name
- [x] place a copy of metasploit framework in there
- [x] `./msfdb reinit --component=all` # Both components should start with no issues
- [x] Also try with `--ssl-key-file` and `--ssl-cert-file` options where they lie in a path with a space in it