### PR TITLE
Explicitly target analyze results and determine payload compatibility

### DIFF
--- a/lib/msf/core/analyze/result.rb
+++ b/lib/msf/core/analyze/result.rb
@@ -87,6 +87,12 @@ class Msf::Analyze::Result
       @mod.datastore[k] = v
     end
 
+    target_idx = @mod.auto_targeted_index(@host)
+    if target_idx
+      @datastore['target'] = target_idx
+      @mod.datastore['target'] = target_idx
+    end
+
     @mod.validate
   rescue Msf::OptionValidateError => e
     unset_options = []

--- a/lib/msf/core/exploit/auto_target.rb
+++ b/lib/msf/core/exploit/auto_target.rb
@@ -23,8 +23,8 @@ module Msf
     #
     # @return [Integer] the index of the selected Target
     # @return [nil] if no target could be selected
-    def auto_targeted_index
-      selected_target = select_target
+    def auto_targeted_index(host=auto_target_host)
+      selected_target = select_target(host)
       return nil if selected_target.nil?
       targets.each_with_index do |target, index|
         return index if target == selected_target
@@ -36,11 +36,10 @@ module Msf
     # the targeted host.
     #
     # @return [Msf::Module::Target] the Target that our automatic routine selected
-    def select_target
+    def select_target(host)
+      return nil if host.nil?
       return nil unless auto_target?
-      host_record = auto_target_host
-      return nil if host_record.nil?
-      filtered_targets = filter_by_os(host_record)
+      filtered_targets = filter_by_os(host)
       filtered_targets.first
     end
 

--- a/lib/msf/ui/console/command_dispatcher/db/analyze.rb
+++ b/lib/msf/ui/console/command_dispatcher/db/analyze.rb
@@ -24,6 +24,8 @@ module Msf::Ui::Console::CommandDispatcher::Analyze
           return
         when '-a', '-v'
           print_empty = true
+        when '-p'
+          wanted_payloads = args.shift.split(',')
         else
           (arg_host_range(arg, host_ranges))
       end
@@ -56,7 +58,7 @@ module Msf::Ui::Console::CommandDispatcher::Analyze
         end
         found_vulns = true
 
-        host_result = framework.analyze.host(eval_host)
+        host_result = framework.analyze.host(eval_host, payloads: wanted_payloads)
         found_modules = host_result[:results]
         if found_modules.any?
           reported_module = true


### PR DESCRIPTION
First steps of using more fingerprinting to filter available targets. To deal with less-than-optimal OS names we will need to break out the Recog fingerprints to have a good chance of selecting appropriate targets.