### PR TITLE
Improve the `get_processes` API and remove `pids()` method from `post/linux/priv`

### DIFF
--- a/lib/msf/core/post/common.rb
+++ b/lib/msf/core/post/common.rb
@@ -2,6 +2,8 @@
 
 module Msf::Post::Common
 
+  include Msf::Post::File
+
   def clear_screen
     Gem.win_platform? ? (system "cls") : (system "clear")
   end
@@ -216,7 +218,7 @@ module Msf::Post::Common
 
   def get_processes
     if session.type == 'meterpreter'
-      return session.sys.process.get_processes.map {|p| p.slice('name', 'pid')}
+      return session.sys.process.get_processes.map { |p| p.slice('name', 'pid') }
     end
     processes = []
     if session.platform == 'windows'
@@ -243,18 +245,18 @@ module Msf::Post::Common
           processes.push(process)
         end
       elsif directory?('/proc')
-        dir_proc = "/proc/"
-        pids = []
-        directories_proc = dir(dir_proc)
+        directories_proc = dir('/proc/')
         directories_proc.each do |elem|
-          elem.to_s.gsub( / *\n+/, "")
-          if elem[-1].match? /\d/
-            process = {}
-            process['pid'] = elem.to_i
-            status = read_file("/proc/#{elem}/status") # will return nil if the process `elem` PID got vanished
-            process['name'] = status.split(/\n|\t/)[1] if status
-            processes.push(process) if status
-          end
+          elem.to_s.gsub(/ *\n+/, '')
+          next unless elem[-1].match? /\d/
+
+          process = {}
+          process['pid'] = elem.to_i
+          status = read_file("/proc/#{elem}/status") # will return nil if the process `elem` PID got vanished
+          next unless status
+
+          process['name'] = status.split(/\n|\t/)[1]
+          processes.push(process)
         end
       else
         raise "Can't enumerate processes because `ps' command and `/proc' directory doesn't exist."

--- a/lib/msf/core/post/common.rb
+++ b/lib/msf/core/post/common.rb
@@ -249,14 +249,11 @@ module Msf::Post::Common
         directories_proc.each do |elem|
           elem.gsub( / *\n+/, "")
           if elem[-1].match? /\d/
-            pids.insert(-1, elem)
+            process = {}
+            process['pid'] = elem.to_i
+            process['name'] = cmd_exec("cat /proc/#{elem}/status").split(/\n|\t/)[1]
+            processes.push(process)
           end
-        end
-        pids.each do |pid|
-          process = {}
-          process['pid'] = pid.to_i
-          process['name'] = cmd_exec("cat /proc/#{pid}/status").split(/\n|\t/)[1]
-          processes.push(process)
         end
       end
     end

--- a/lib/msf/core/post/common.rb
+++ b/lib/msf/core/post/common.rb
@@ -242,19 +242,22 @@ module Msf::Post::Common
           process['pid'] = properties[1].to_i
           processes.push(process)
         end
-      else
+      elsif directory?('/proc')
         dir_proc = "/proc/"
         pids = []
         directories_proc = dir(dir_proc)
         directories_proc.each do |elem|
-          elem.gsub( / *\n+/, "")
+          elem.to_s.gsub( / *\n+/, "")
           if elem[-1].match? /\d/
             process = {}
             process['pid'] = elem.to_i
-            process['name'] = cmd_exec("cat /proc/#{elem}/status").split(/\n|\t/)[1]
-            processes.push(process)
+            status = read_file("/proc/#{elem}/status")
+            process['name'] = status.split(/\n|\t/)[1] if status
+            processes.push(process) if status
           end
         end
+      else
+        raise "Can't enumerate processes becuase `ps' command and `/proc' directory doesn't exist."
       end
     end
     return processes

--- a/lib/msf/core/post/common.rb
+++ b/lib/msf/core/post/common.rb
@@ -251,13 +251,13 @@ module Msf::Post::Common
           if elem[-1].match? /\d/
             process = {}
             process['pid'] = elem.to_i
-            status = read_file("/proc/#{elem}/status")
+            status = read_file("/proc/#{elem}/status") # will return nil if the process `elem` PID got vanished
             process['name'] = status.split(/\n|\t/)[1] if status
             processes.push(process) if status
           end
         end
       else
-        raise "Can't enumerate processes becuase `ps' command and `/proc' directory doesn't exist."
+        raise "Can't enumerate processes because `ps' command and `/proc' directory doesn't exist."
       end
     end
     return processes

--- a/lib/msf/core/post/linux/priv.rb
+++ b/lib/msf/core/post/linux/priv.rb
@@ -41,21 +41,6 @@ module Priv
     cmd_exec("echo '#{file_origin}' > #{final_file}")
   end
 
-  def pids()
-    dir_proc = "/proc/"
-    pids = []
-
-    directories_proc = dir(dir_proc)
-    directories_proc.each do |elem|
-      elem.gsub( / *\n+/, "")
-      if elem[-1] == '1' || elem[-1] == '2' || elem[-1] == '3' || elem[-1] == '4' || elem[-1] == '5' || elem[-1] == '6' || elem[-1] == '7' || elem[-1] == '8' || elem[-1] == '9' || elem[-1] == '0'
-        pids.insert(-1, elem)
-      end
-    end
-
-    return pids.sort_by(&:to_i)
-  end
-
   def binary_of_pid(pid)
     binary = read_file("/proc/#{pid}/cmdline")
     if binary == "" #binary.empty?


### PR DESCRIPTION
## Summary
This PR improves the `get_processes` API for linux shell sessions by adding a way of getting the info from status files under `/proc` directory in case `ps_aux` fails.

This also removes a method `pids()` inside `post/linux/priv.rb` which was used to get the pids on the target system because `get_processes` can be used for the same task.

## Verification Steps
```
>> get_processes
=> 
[{"pid"=>1, "name"=>"systemd"},
 {"pid"=>9226, "name"=>"ssh-agent"},
..
..
..
 {"pid"=>1051, "name"=>"mate-settings-d"},
 {"pid"=>12331, "name"=>"bash"},
 {"pid"=>9908, "name"=>"sudo"},
 {"pid"=>9909, "name"=>"bash"}]
```