### PR TITLE
Fix TLS bug for gitlab file read RCE module to work on TLS enabled GitLab servers

### DIFF
--- a/modules/exploits/multi/http/gitlab_file_read_rce.rb
+++ b/modules/exploits/multi/http/gitlab_file_read_rce.rb
@@ -242,7 +242,6 @@ class MetasploitModule < Msf::Exploit::Remote
       elsif res.code != 302
         raise GitLabClientException, "Unexpected HTTP #{res.code} response."
       end
-      
       if http_client.ssl
         issue_id = res.body[%r{You are being <a href="https://.*#{create_issue_path}/(\d+)">redirected</a>}, 1]
       else

--- a/modules/exploits/multi/http/gitlab_file_read_rce.rb
+++ b/modules/exploits/multi/http/gitlab_file_read_rce.rb
@@ -242,8 +242,12 @@ class MetasploitModule < Msf::Exploit::Remote
       elsif res.code != 302
         raise GitLabClientException, "Unexpected HTTP #{res.code} response."
       end
-
-      issue_id = res.body[%r{You are being <a href="http://.*#{create_issue_path}/(\d+)">redirected</a>}, 1]
+      
+      if http_client.ssl
+        issue_id = res.body[%r{You are being <a href="https://.*#{create_issue_path}/(\d+)">redirected</a>}, 1]
+      else
+        issue_id = res.body[%r{You are being <a href="http://.*#{create_issue_path}/(\d+)">redirected</a>}, 1]
+      end
 
       issue.merge({
         'path' => "#{create_issue_path}/#{issue_id}",

--- a/modules/exploits/multi/http/gitlab_file_read_rce.rb
+++ b/modules/exploits/multi/http/gitlab_file_read_rce.rb
@@ -243,11 +243,7 @@ class MetasploitModule < Msf::Exploit::Remote
         raise GitLabClientException, "Unexpected HTTP #{res.code} response."
       end
 
-      if http_client.ssl
-        issue_id = res.body[%r{You are being <a href="https://.*#{create_issue_path}/(\d+)">redirected</a>}, 1]
-      else
-        issue_id = res.body[%r{You are being <a href="http://.*#{create_issue_path}/(\d+)">redirected</a>}, 1]
-      end
+issue_id = res.body[%r{You are being <a href="https?://.*#{create_issue_path}/(\d+)">redirected</a>}, 1]
 
       issue.merge({
         'path' => "#{create_issue_path}/#{issue_id}",

--- a/modules/exploits/multi/http/gitlab_file_read_rce.rb
+++ b/modules/exploits/multi/http/gitlab_file_read_rce.rb
@@ -242,6 +242,7 @@ class MetasploitModule < Msf::Exploit::Remote
       elsif res.code != 302
         raise GitLabClientException, "Unexpected HTTP #{res.code} response."
       end
+
       if http_client.ssl
         issue_id = res.body[%r{You are being <a href="https://.*#{create_issue_path}/(\d+)">redirected</a>}, 1]
       else

--- a/modules/exploits/multi/http/gitlab_file_read_rce.rb
+++ b/modules/exploits/multi/http/gitlab_file_read_rce.rb
@@ -243,7 +243,7 @@ class MetasploitModule < Msf::Exploit::Remote
         raise GitLabClientException, "Unexpected HTTP #{res.code} response."
       end
 
-issue_id = res.body[%r{You are being <a href="https?://.*#{create_issue_path}/(\d+)">redirected</a>}, 1]
+      issue_id = res.body[%r{You are being <a href="https?://.*#{create_issue_path}/(\d+)">redirected</a>}, 1]
 
       issue.merge({
         'path' => "#{create_issue_path}/#{issue_id}",


### PR DESCRIPTION
Fix bug that prevents the module from working on TLS enabled GitLab server

I encountered this issue when using Metasploit, I don't see any Github issue ID that is getting fixed with this pull request.

## Verification

- [x] Start `msfconsole`
- [x] `use exploit/multi/http/gitlab_file_read_rce`
- [x] `set rhost <IP of vuln server>`
- [x] `set username <username>`
- [x] `set password <password>`
- [x] `set lhost <IP of local machine>`
- [x] `run`
- [x] **Verify** Exploit should work properly on a non TLS enabled server, now test it on a TLS enabled server
- [x] `set RPORT 443`
- [x] `set SSL true`
- [x] `run`
- [x] **Verify** Exploit should work properly on a TLS enabled server and not raise a 404 error.

