### PR TITLE
Add ssl setup documentation for gitlab

### DIFF
--- a/documentation/modules/exploit/multi/http/gitlab_file_read_rce.md
+++ b/documentation/modules/exploit/multi/http/gitlab_file_read_rce.md
@@ -29,9 +29,56 @@ sudo docker run \
 ```
 
 The application will be available on port 80 or 443. This may take a long time.
+
+#### Setting up SSL
+
+This step is **optional** and only required if you wish to enable HTTPS for an arbitrary test URL such as `gitlab.example.com`
+
+Connect to the running Gitlab instance:
+
+```
+sudo docker exec -it gitlab /bin/bash
+```
+
+Add these lines to `/etc/gitlab/gitlab.rb`:
+
+```
+external_url "https://gitlab.example.com"
+letsencrypt['enable'] = false
+```
+
+Use OpenSSL to create a self signed certificate and key:
+
+```
+mkdir -p /etc/gitlab/ssl
+chmod 755 /etc/gitlab/ssl
+cd /etc/gitlab/ssl
+openssl req -x509 -sha256 -nodes -days 365 -newkey rsa:2048 -keyout gitlab.example.com.key -out gitlab.example.com.crt
+```
+
+Reconfigure GitLab:
+
+```
+gitlab-ctl reconfigure
+```
+
+On your host machine modify your `/etc/hosts` file:
+
+```
+127.0.0.1 gitlab.example.com
+```
+
+Visit the test URL in your browser and either ignore the certificate warnings or add it to continue:
+
+```
+https://gitlab.example.com/
+```
+
+#### Creating a user
+
 You can either create a user account normally or programmatically as shown below.
 
-Connect to the running gitlab instance:
+Connect to the running Gitlab instance:
 
 ```
 sudo docker exec -it gitlab /bin/bash


### PR DESCRIPTION
Adds documentation for setting up a test gitlab instance with HTTPS enabled.

## Verification

Verify that the steps work