### PR TITLE
Converts Python shebangs over to Python 3

### DIFF
--- a/lib/msf/core/modules/external/bridge.rb
+++ b/lib/msf/core/modules/external/bridge.rb
@@ -186,7 +186,7 @@ class Msf::Modules::External::PyBridge < Msf::Modules::External::Bridge
   def handle_exception(error)
     case error
     when Errno::ENOENT
-      LoadError.new('Failed to execute external Python module. Please ensure you have Python installed on your environment.')
+      LoadError.new('Failed to execute external Python module. Please ensure you have Python3 installed on your environment.')
     else
       super
     end

--- a/modules/auxiliary/admin/teradata/teradata_odbc_sql.py
+++ b/modules/auxiliary/admin/teradata/teradata_odbc_sql.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #2018-05-09 14-15
 

--- a/modules/auxiliary/dos/http/slowloris.py
+++ b/modules/auxiliary/dos/http/slowloris.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# Note, works with both python 2.7 and 3
+#!/usr/bin/env python3
 
 import random
 import socket

--- a/modules/auxiliary/dos/tcp/claymore_dos.py
+++ b/modules/auxiliary/dos/tcp/claymore_dos.py
@@ -1,6 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -
-# Note, works with both python 2.7 and 3
 
 
 import socket

--- a/modules/auxiliary/gather/get_user_spns.py
+++ b/modules/auxiliary/gather/get_user_spns.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import sys

--- a/modules/auxiliary/scanner/http/onion_omega2_login.py
+++ b/modules/auxiliary/scanner/http/onion_omega2_login.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # 2019-03-27 05-55
 

--- a/modules/auxiliary/scanner/smb/impacket/dcomexec.py
+++ b/modules/auxiliary/scanner/smb/impacket/dcomexec.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2003-2018 CORE Security Technologies
 #
 # This software is provided under under a slightly modified version
@@ -301,7 +301,7 @@ def run(args):
         return
 
     _msf_impacket.pre_run_hook(args)
-    executer = DCOMEXEC(args['COMMAND'], args['SMBUser'], args['SMBPass'], args['SMBDomain'], 
+    executer = DCOMEXEC(args['COMMAND'], args['SMBUser'], args['SMBPass'], args['SMBDomain'],
                         share='ADMIN$', noOutput=args['OUTPUT'] != 'true', dcomObject=args['OBJECT'])
     executer.run(args['rhost'])
 

--- a/modules/auxiliary/scanner/smb/impacket/secretsdump.py
+++ b/modules/auxiliary/scanner/smb/impacket/secretsdump.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2003-2018 CORE Security Technologies
 #
 # This software is provided under under a slightly modified version
@@ -101,7 +101,7 @@ class DumpSecrets:
         self.__canProcessSAMLSA = True
         self.__kdcHost = None
         self.__execMethod = execMethod
-        
+
 
     def connect(self):
         self.__smbConnection = SMBConnection(self.__remoteName, self.__remoteHost)

--- a/modules/auxiliary/scanner/smb/impacket/wmiexec.py
+++ b/modules/auxiliary/scanner/smb/impacket/wmiexec.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2003-2018 CORE Security Technologies
 #
 # This software is provided under under a slightly modified version
@@ -118,7 +118,7 @@ class RemoteShell(_msf_impacket.RemoteShell):
         super(RemoteShell, self).__init__(share, smbConnection)
 
     def execute_remote(self, data):
-        command = self._shell + data 
+        command = self._shell + data
         if self._noOutput is False:
             command += ' 1> ' + '\\\\127.0.0.1\\%s' % self._share + self._output  + ' 2>&1'
         self.__win32Process.Create(command.decode('utf-8'), self._pwd, None)
@@ -131,7 +131,7 @@ def run(args):
         return
 
     _msf_impacket.pre_run_hook(args)
-    executer = WMIEXEC(args['COMMAND'], args['SMBUser'], args['SMBPass'], args['SMBDomain'], 
+    executer = WMIEXEC(args['COMMAND'], args['SMBUser'], args['SMBPass'], args['SMBDomain'],
                         share='ADMIN$', noOutput=args['OUTPUT'] != 'true')
     executer.run(args['rhost'])
 

--- a/modules/auxiliary/scanner/teradata/teradata_odbc_login.py
+++ b/modules/auxiliary/scanner/teradata/teradata_odbc_login.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #2018-05-29 08-49
 

--- a/modules/exploits/linux/smtp/haraka.py
+++ b/modules/exploits/linux/smtp/haraka.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Vendor Homepage: https://haraka.github.io/
 # Software Link: https://github.com/haraka/Haraka

--- a/tools/hardware/killerbee_msfrelay.py
+++ b/tools/hardware/killerbee_msfrelay.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python2
+# Note: This module explicitly requires Python2 as KillerBee does not yet support Python3:
+# https://github.com/riverloopsec/killerbee/tree/cb04e169a635ad4bc0772b631e1b332320f7a8da#killerbee
+
 # KillerBee Metasploit relay server
 
 import re


### PR DESCRIPTION
This PR converts all Python shebangs that needed to be converted over to using the Python 3 shebang.

Converts:
```ruby
#!/usr/bin/env python
```
into:
```ruby
#!/usr/bin/env python3
```

The error message within `bridge.rb` that handles when a user is missing a runtime dependency has also been updated to reflect this change. 

### Note
My IDE done some clean up on whitespacing in some of the files I was making changes in, thought I'd leave it in, because why not ¯\\\_(ツ)_/¯

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] Test any of the altered modules
- [ ] **Verify** they work as expected