### PR TITLE
Use the correct ssl key path instead of always the default

### DIFF
--- a/msfdb
+++ b/msfdb
@@ -432,9 +432,9 @@ def start_web_service(expect_auth: true)
 
   print 'Attempting to start MSF web service...'
 
-  unless File.file?(@ws_ssl_key_default)
+  unless File.file?(@options[:ssl_key])
     puts "#{'failed'.red.bold}"
-    print_error "The SSL Key needed for the webservice to connect to the database could not be found at #{@ws_ssl_key_default}."
+    print_error "The SSL Key needed for the webservice to connect to the database could not be found at #{@options[:ssl_key]}."
     print_error 'Has the webservice been initialized with "msfdb init"  or "msfdb init --component webservice"?'
     return false
   end


### PR DESCRIPTION
Quick PR to use the passed in ssl key path (if provided) instead of the default one which won't be there if you're passing one in :upside_down_face: 

https://github.com/rapid7/metasploit-framework/pull/15196#issuecomment-842514724

# Verification
- [ ] Ensure there is no key file at `~/.msf4/msf-ws-key.pem`
- [ ] Start up the webservice with the `--ssl-key-file`
- [ ] It should no longer break