### PR TITLE
Prevent TLD use in tests that use DomainName & remove HTTP::Cookie from Cookie initializer 

### DIFF
--- a/lib/msf/core/exploit/remote/http/http_cookie.rb
+++ b/lib/msf/core/exploit/remote/http/http_cookie.rb
@@ -11,11 +11,9 @@ module Msf
 
           # Returns a new +HttpCookie+.
           #
-          # Name can either be a string or an instance of +::HTTP::Cookie+.
-          # - If an instance of +::HTTP::Cookie+, all future method calls will return values and act on values of said
-          #   +::HTTP::Cookie+.
+          # Name can be a string.
           # - If a +String+, the name of the cookie is set to the passed +name+.
-          # 	- If a +String+ is passed as a +name+, the cookie is set as a session cookie.
+          # 	- If only a +String+ is passed to +name+, the cookie is set as a session cookie.
           #
           # Value can be a +String+ or +nil+.
           # - If a +String+, the value of the cookie is set as the passed +cookie+.
@@ -25,17 +23,17 @@ module Msf
           # +attr_hash+ can be used to set the values of +domain+, +path+, +max_age+, +expires+, +secure+, +httponly+,
           # +accessed_at+, +created_at+.
           def initialize(name, value = nil, **attr_hash)
-            if name.is_a?(::HTTP::Cookie)
-              @cookie = name
-            elsif value
+            if value
               @cookie = ::HTTP::Cookie.new(name, value)
             else
               @cookie = ::HTTP::Cookie.new(name)
             end
 
             attr_hash.each_pair do |k, v|
-              if respond_to?("#{k}=".to_sym)
-                send("#{k}=".to_sym, v)
+              if k == 'max-age'
+                self.max_age= v
+              elsif respond_to?("#{k}=".to_sym)
+                self.send("#{k}=".to_sym, v)
               end
             end
           end

--- a/lib/msf/core/exploit/remote/http/http_cookie_jar.rb
+++ b/lib/msf/core/exploit/remote/http/http_cookie_jar.rb
@@ -70,20 +70,27 @@ module Msf
             @cookie_jar.empty?
           end
 
-          # Parses a Set-Cookie header value +set_cookie_header+ assuming that it is sent from a source URI/URL
-          # +origin_url+, and returns an array of +::HTTP::Cookie+ (https://www.rubydoc.info/gems/http-cookie/1.0.3/HTTP/Cookie)
-          # objects.  Parts (separated by commas) that are malformed or considered unacceptable are silently ignored.
-          def parse(set_cookie_header, origin_url, options = nil)
-            ::HTTP::Cookie.parse(set_cookie_header, origin_url, options)
+          # Parses a Set-Cookie header value +set_cookie_header+ and returns an array of
+          # +::Msf::Exploit::Remote::HTTP::HttpCookie+ objects. Parts (separated by commas) that are malformed or
+          # considered unacceptable are silently ignored.
+          def parse(set_cookie_header)
+            cookies = []
+            ::HTTP::Cookie::Scanner.new(set_cookie_header).scan_set_cookie do |name, value, attrs|
+              if name.nil? || name.empty?
+                next
+              end
+
+              cookies << HttpCookie.new(name, value, attrs)
+            end
+
+            cookies
           end
 
-          # Same as +parse+, but each +::HTTP::Cookie+ (https://www.rubydoc.info/gems/http-cookie/1.0.3/HTTP/Cookie) is
-          # converted to +HttpCookie+ (https://github.com/rapid7/metasploit-framework/blob/master/lib/msf/core/exploit/remote/http/http_cookie.rb)
-          # and added to the jar.
-          def parse_and_merge(set_cookie_header, origin_url, options = nil)
-            parsed_cookies = ::HTTP::Cookie.parse(set_cookie_header, origin_url, options)
-            parsed_cookies.each { |c| add(Msf::Exploit::Remote::HTTP::HttpCookie.new(c)) }
-            parsed_cookies
+          # Same as +parse+, but each +::Msf::Exploit::Remote::HTTP::HttpCookie+ is also added to the jar.
+          def parse_and_merge(set_cookie_header)
+            cookies = parse(set_cookie_header)
+            cookies.each { |c| add(Msf::Exploit::Remote::HTTP::HttpCookie.new(c)) }
+            cookies
           end
 
           # Modules are replicated before running. This method ensures that the cookie jar from

--- a/lib/msf/core/exploit/remote/http_client.rb
+++ b/lib/msf/core/exploit/remote/http_client.rb
@@ -399,7 +399,7 @@ module Exploit::Remote::HttpClient
     return unless res
 
     if opts['keep_cookies'] && res.headers['Set-Cookie'].present?
-      cookie_jar.parse_and_merge(res.headers['Set-Cookie'], "http#{ssl ? 's' : ''}://#{vhost}:#{rport}")
+      cookie_jar.parse_and_merge(res.headers['Set-Cookie'])
     end
 
     res

--- a/spec/lib/msf/core/exploit/remote/remote/http/http_cookie_spec.rb
+++ b/spec/lib/msf/core/exploit/remote/remote/http/http_cookie_spec.rb
@@ -256,6 +256,17 @@ RSpec.describe Msf::Exploit::Remote::HTTP::HttpCookie do
   end
 
   describe 'domain' do
+    describe 'DomainName' do
+      it 'assigned to domain will result in a domain based on DomainName.hostname.' do
+        # big string length avoids potential TLD values
+        d = DomainName(random_string(30,35))
+
+        cookie.domain = d
+
+        expect(cookie.domain).to eql(d.hostname)
+      end
+    end
+
     describe 'nil' do
       it 'assigned to domain when origin is not set will result in a nil domain' do
         n = nil
@@ -267,12 +278,13 @@ RSpec.describe Msf::Exploit::Remote::HTTP::HttpCookie do
     end
 
     describe 'String' do
-      it 'assigned to domain will be converted to a DomainName and assigned' do
-        s = random_string
+      it 'assigned to domain will be parsed to a DomainName upon assignment. The hostname of that DomainName will be returned by the getter.' do
+        # big string length avoids potential TLD values
+        d = DomainName(random_string(30,35))
 
-        cookie.domain = s
+        cookie.domain = d
 
-        expect(cookie.domain).to eql(DomainName(s).domain)
+        expect(cookie.domain).to eql(DomainName(d).hostname)
       end
     end
   end


### PR DESCRIPTION
As stated above this PR is a combination of cleaning up some tests and removing an unneeded use of `HTTP::Cookie`.

Test Cleanup:
When you pass a Top Level Domain `(com/us/gov)` to the initializer of of `DomainName`, it will return `nil` and throw a false failure of the test. Since the list of TLDs is long and ever expanding, I changed all tests that send random strings to `DomainName` to ensure the string is at least 30 characters long since no TLD will approach that size.

`HTTP::Cookie`:
Originally the `HttpCookie` `initialize` method allowed the passing of a `HTTP::Cookie` instance to populate all cookie values. This was smelly for numerous reasons:
  - It's not future proof. The more modules that use this method of initializing a cookie, the more we're tied to the external `http-cookie` library (pointed out by @dwelch-r7).
  - It allows bypassing of our setter APIs
  - Can create a situation where a cookie can return different values depending on they are passed to the new instance.  

Thankfully there was only one instance of this feature being utilized in the code base. So I removed it and changed the `parse` & `parse_and_merge` `HttpCookieJar` methods that depended on this feature to instead extract the individual `name`, `value`, and `attributes` of each cookie in a header and pass it to the new more future proofed `HttpCookie` initializer. 