### PR TITLE
fix for a bug in shodan_search

### DIFF
--- a/modules/auxiliary/gather/shodan_search.rb
+++ b/modules/auxiliary/gather/shodan_search.rb
@@ -124,10 +124,6 @@ class MetasploitModule < Msf::Auxiliary
       end
       print_error(msg)
       return
-    else
-      while results[0]['matches'].nil?
-	results[0] = shodan_query(apikey, query, 1)
-      end
     end
 
     # Determine page count based on total results

--- a/modules/auxiliary/gather/shodan_search.rb
+++ b/modules/auxiliary/gather/shodan_search.rb
@@ -136,14 +136,14 @@ class MetasploitModule < Msf::Auxiliary
     # start printing out our query statistics
     print_status("Total: #{results[0]['total']} on #{tpages} " +
       "pages. Showing: #{maxpage} page(s)")
-
+    p = 1
     # If search results greater than 100, loop & get all results
     print_status('Collecting data, please wait...')
     if results[0]['total'] > 100
-      page = p = 1
+      page = 1
       while p < maxpage
         results[p] = shodan_query(query, apikey, page+1)
-        if results[page]['matches'].nil?
+        if results[p]['matches'].nil?
           next
         else
           p += 1

--- a/modules/auxiliary/gather/shodan_search.rb
+++ b/modules/auxiliary/gather/shodan_search.rb
@@ -114,7 +114,7 @@ class MetasploitModule < Msf::Auxiliary
 
     # results gets our results from shodan_query
     results = []
-    results[0] = shodan_query(query, apikey, 0)
+    results[0] = shodan_query(query, apikey, 1)
 
     if results[0]['total'].nil? || results[0]['total'] == 0
       msg = "No results."
@@ -142,7 +142,7 @@ class MetasploitModule < Msf::Auxiliary
     if results[0]['total'] > 100
       page = 1
       while page < maxpage
-        results[page] = shodan_query(query, apikey, page)
+        results[page] = shodan_query(query, apikey, page+1)
         page += 1
       end
     end
@@ -159,7 +159,7 @@ class MetasploitModule < Msf::Auxiliary
     regex = datastore['REGEX'] if datastore['REGEX']
     while p < maxpage
       if results[p]['matches'].nil?
-      	break
+        break
       end
       results[p]['matches'].each do |host|
         city = host['location']['city'] || 'N/A'

--- a/modules/auxiliary/gather/shodan_search.rb
+++ b/modules/auxiliary/gather/shodan_search.rb
@@ -124,6 +124,10 @@ class MetasploitModule < Msf::Auxiliary
       end
       print_error(msg)
       return
+    else
+      while results[0]['matches'].nil?
+	results[0] = shodan_query(apikey, query, 1)
+      end
     end
 
     # Determine page count based on total results
@@ -197,6 +201,7 @@ class MetasploitModule < Msf::Auxiliary
       page += 1
     end
     #Show data and maybe save it if needed
+    print_line()
     print_line("#{tbl}")
     save_output(tbl) if datastore['OUTFILE']
   end


### PR DESCRIPTION
I'm issuing this because I noticed that there often is a crash with the shodan_search module when using filters and mulitple pages, the reason (i believe) is that the filters are applied after having retrieved the results, trimming it, so that the arrays can be null while the maximum pages are making it scroll forward and it returns with a fault.
I am taking as basis to say that that when making a query with no filters, the count of an output file is about 100 times maxpages, while using filters, and using  this fix, the count is much lower.
Please feel free to double check that but really the  module is faulty.