### PR TITLE
Disable wrapped table support for the loot command

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -1271,6 +1271,9 @@ class Db
     tbl = Rex::Text::Table.new({
         'Header'  => "Loot",
         'Columns' => [ 'host', 'service', 'type', 'name', 'content', 'info', 'path' ],
+        # For now, don't perform any word wrapping on the loot table as it breaks the workflow of
+        # copying paths and pasting them into applications
+        'WordWrap' => false,
       })
 
     # Sentinel value meaning all


### PR DESCRIPTION
Noticed a fellow developer having difficulties copy/pasting values within the loot command table, so let's disable it for now.
Most likely we'll want a consistent option across all the commands to disable word wrapping support.

In a similar vein, the search and creds table were disabled for the same reason previously.

## Verification

List the steps needed to make sure this thing works

Run msfconsole with a database and acquire some loot, for example with tomcat Ghostcat read:

```
docker run --rm -p 8080:8080 -p 8009:8009 tomcat:8.5.32
```

Open msfconsle
```
use auxiliary/admin/http/tomcat_ghostcat
set RHOSTS 127.0.0.1
run
loot
```

Verify the `loot` command allows you to safely copy/pasta paths without any effort
```
msf6 auxiliary(admin/http/tomcat_ghostcat) > loot

Loot
====

host       service  type              name                          content     info       path
----       -------  ----              ----                          -------     ----       ----
127.0.0.1           /WEB-INF/web.xml  Ghostcat File Read/Inclusion  text/plain  Read file  /Users/user/.msf4/loot/20210524004206_default_127.0.0.1_WEBINFweb.xml_609879.txt
```