### PR TITLE
Refactor as Msf::Post::Process

### DIFF
--- a/lib/msf/core/post/common.rb
+++ b/lib/msf/core/post/common.rb
@@ -6,7 +6,9 @@ module Msf::Post::Common
     super(update_info(
       info,
       'Compat' => { 'Meterpreter' => { 'Commands' => %w{
-        stdapi_sys_config_getenv stdapi_sys_process_close stdapi_sys_process_execute stdapi_sys_process_get_processes
+        stdapi_sys_config_getenv
+        stdapi_sys_process_close
+        stdapi_sys_process_execute
       } } }
     ))
   end
@@ -37,14 +39,6 @@ module Msf::Post::Common
 
   def peer
     "#{rhost}:#{rport}"
-  end
-
-  #
-  # Checks if the remote system has a process with ID +pid+
-  #
-  def has_pid?(pid)
-    pid_list = get_processes.collect { |e| e['pid'] }
-    pid_list.include?(pid)
   end
 
   #
@@ -223,53 +217,5 @@ module Msf::Post::Common
     raise "Unable to check if command `#{cmd}' exists"
   end
 
-  def get_processes
-    if session.type == 'meterpreter'
-      return session.sys.process.get_processes.map { |p| p.slice('name', 'pid') }
-    end
-    processes = []
-    if session.platform == 'windows'
-      tasklist = cmd_exec('tasklist').split("\n")
-      4.times { tasklist.delete_at(0) }
-      tasklist.each do |p|
-        properties = p.split
-        process = {}
-        process['name'] = properties[0]
-        process['pid'] = properties[1].to_i
-        processes.push(process)
-      end
-      # adding manually because this is common for all windows I think and splitting for this was causing problem for other processes.
-      processes.prepend({ 'name' => '[System Process]', 'pid' => 0 })
-    else
-      if command_exists?('ps')
-        ps_aux = cmd_exec('ps aux').split("\n")
-        ps_aux.delete_at(0)
-        ps_aux.each do |p|
-          properties = p.split
-          process = {}
-          process['name'] = properties[10].gsub(/\[|\]/,"")
-          process['pid'] = properties[1].to_i
-          processes.push(process)
-        end
-      elsif directory?('/proc')
-        directories_proc = dir('/proc/')
-        directories_proc.each do |elem|
-          elem.to_s.gsub(/ *\n+/, '')
-          next unless elem[-1].match? /\d/
-
-          process = {}
-          process['pid'] = elem.to_i
-          status = read_file("/proc/#{elem}/status") # will return nil if the process `elem` PID got vanished
-          next unless status
-
-          process['name'] = status.split(/\n|\t/)[1]
-          processes.push(process)
-        end
-      else
-        raise "Can't enumerate processes because `ps' command and `/proc' directory doesn't exist."
-      end
-    end
-    return processes
-  end
 
 end

--- a/lib/msf/core/post/process.rb
+++ b/lib/msf/core/post/process.rb
@@ -1,0 +1,72 @@
+module Msf::Post::Process
+
+  include Msf::Post::File
+
+  def initialize(info = {})
+    super(update_info(
+      info,
+      'Compat' => { 'Meterpreter' => { 'Commands' => %w{
+        stdapi_sys_process_get_processes
+      } } }
+    ))
+  end
+
+  #
+  # Checks if the remote system has a process with ID +pid+
+  #
+  def has_pid?(pid)
+    pid_list = get_processes.collect { |e| e['pid'] }
+    pid_list.include?(pid)
+  end
+
+  def get_processes
+    if session.type == 'meterpreter'
+      return session.sys.process.get_processes.map { |p| p.slice('name', 'pid') }
+    end
+    processes = []
+    if session.platform == 'windows'
+      tasklist = cmd_exec('tasklist').split("\n")
+      4.times { tasklist.delete_at(0) }
+      tasklist.each do |p|
+        properties = p.split
+        process = {}
+        process['name'] = properties[0]
+        process['pid'] = properties[1].to_i
+        processes.push(process)
+      end
+      # adding manually because this is common for all windows I think and splitting for this was causing problem for other processes.
+      processes.prepend({ 'name' => '[System Process]', 'pid' => 0 })
+    else
+      if command_exists?('ps')
+        ps_aux = cmd_exec('ps aux').split("\n")
+        ps_aux.delete_at(0)
+        ps_aux.each do |p|
+          properties = p.split
+          process = {}
+          process['name'] = properties[10].gsub(/\[|\]/,"")
+          process['pid'] = properties[1].to_i
+          processes.push(process)
+        end
+      elsif directory?('/proc')
+        directories_proc = dir('/proc/')
+        directories_proc.each do |elem|
+          elem.to_s.gsub(/ *\n+/, '')
+          next unless elem[-1].match? /\d/
+
+          process = {}
+          process['pid'] = elem.to_i
+          status = read_file("/proc/#{elem}/status") # will return nil if the process `elem` PID got vanished
+          next unless status
+
+          process['name'] = status.split(/\n|\t/)[1]
+          processes.push(process)
+        end
+      else
+        raise "Can't enumerate processes because `ps' command and `/proc' directory doesn't exist."
+      end
+    end
+    return processes
+  end
+
+
+end

--- a/modules/post/windows/capture/keylog_recorder.rb
+++ b/modules/post/windows/capture/keylog_recorder.rb
@@ -6,6 +6,7 @@
 class MetasploitModule < Msf::Post
   include Msf::Post::Windows::Priv
   include Msf::Post::Windows::Process
+  include Msf::Post::File
 
   def initialize(info={})
     super( update_info( info,

--- a/modules/post/windows/capture/keylog_recorder.rb
+++ b/modules/post/windows/capture/keylog_recorder.rb
@@ -5,7 +5,7 @@
 
 class MetasploitModule < Msf::Post
   include Msf::Post::Windows::Priv
-  include Msf::Post::File
+  include Msf::Post::Windows::Process
 
   def initialize(info={})
     super( update_info( info,

--- a/modules/post/windows/gather/checkvm.rb
+++ b/modules/post/windows/gather/checkvm.rb
@@ -4,6 +4,7 @@
 ##
 
 class MetasploitModule < Msf::Post
+  include Msf::Post::Process
   include Msf::Post::Windows::Registry
   include Msf::Auxiliary::Report
 


### PR DESCRIPTION
Incorporates #15199 change into a refactored `Msf::Post::Process` mixin to keep common mixin scoped limited.

Thank you @pingport80 for initial work that forms the basis for this revision.

## Verification

List the steps needed to make sure this thing works

- [x] #15096 vm identification `post/windows/gather/checkvm`
- [x] #15199 linux process list check
- [x] verify no regression in `post/windows/capture/keylog_recorder` against a Windows `meterpreter` session
- [x] verify no regression in the following unmodified modules evaluated as not impacted due to overriding includes and `meterpreter` session type restrictions:
```
exploit/windows/local/payload_inject
post/windows/capture/keylog_recorder
post/windows/manage/migrate
post/windows/manage/shellcode_inject
```
