### PR TITLE
Add file_stat to linux shell sessions

### DIFF
--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -1,6 +1,7 @@
 # -*- coding: binary -*-
 #
 require 'rex/post/meterpreter/extensions/stdapi/command_ids'
+require 'rex/post/file_stat'
 
 module Msf::Post::File
 
@@ -160,18 +161,8 @@ module Msf::Post::File
   #
   # @param path [String] Remote filename to check
   def setuid?(path)
-    if session.type == 'meterpreter'
-      stat = session.fs.file.stat(path) rescue nil
-      return false unless stat
-      return stat.setuid?
-    else
-      if session.platform != 'windows'
-        f = session.shell_command_token("test -u \"#{path}\" && echo true")
-      end
-      return false if f.nil? || f.empty?
-      return false unless f =~ /true/
-      true
-    end
+    stat = stat(path)
+    stat.setuid?
   end
 
   #
@@ -692,4 +683,41 @@ protected
 
     line_max
   end
+
+  def stat(filename)
+    if session.type == 'meterpreter'
+      return session.fs.file.stat(filename)
+    else
+      raise NotImplementedError if session.platform == 'windows'
+      raise "`stat' command doesn't exist on target system" unless command_exists?('stat')
+      return FileStat.new(filename, session)
+    end
+  end
+
+
+  class FileStat < Rex::Post::FileStat
+  
+    attr_accessor :stathash
+
+    def initialize(filename, session)
+      data = session.shell_command_token("stat --format='%d,%i,%h,%u,%g,%t,%s,%B,%o,%X,%Y,%Z,%f' '#{filename}'").to_s.chomp
+      raise 'format argument of stat command not behaving as expected' unless data =~ /(\d+,){12}\w+/
+      data = data.split(",")
+      @stathash = Hash.new
+      @stathash['st_dev'] = data[0].to_i
+      @stathash['st_ino'] = data[1].to_i
+      @stathash['st_nlink'] = data[2].to_i
+      @stathash['st_uid'] = data[3].to_i
+      @stathash['st_gid'] = data[4].to_i
+      @stathash['st_rdev'] = data[5].to_i
+      @stathash['st_size'] = data[6].to_i
+      @stathash['st_blksize'] = data[7].to_i
+      @stathash['st_blocks'] = data[8].to_i
+      @stathash['st_atime'] = data[9].to_i
+      @stathash['st_mtime'] = data[10].to_i
+      @stathash['st_ctime'] = data[11].to_i
+      @stathash['st_mode'] = data[12].to_i(16) #stat command returns hex value of mode" 
+    end
+  end
+
 end

--- a/lib/rex/post/file_stat.rb
+++ b/lib/rex/post/file_stat.rb
@@ -125,10 +125,10 @@ class FileStat
     filetype?(010000) # ??? fifo?
   end
   def socket?
-    filetype(0140000)
+    filetype?(0140000)
   end
   def symlink?
-    filetype(0120000)
+    filetype?(0120000)
   end
 
   def ftype


### PR DESCRIPTION
## Summary
This PR adds `FileStat` class for linux systems which can be used to create a stat object containing information about a specific file similar to stat in meterpreter file system API.

## Verification Steps
```
>> passwd = stat('/etc/passwd')
=> 
#<FileStat:0x00007fa2120db4f0
...
>> passwd.size
=> 2809
>> passwd.setuid?
=> false
>> passwd.atime
=> 2021-05-24 19:52:01.071081298 +0530
>> passwd.dev
=> 66309
>> passwd.ctime
=> 2021-04-03 14:55:18.615202365 +0530
>> passwd.mtime
=> 2021-04-03 14:55:18.611202365 +0530
```
```
>> mount = stat('/bin/mount')
=> 
#<FileStat:0x0000555af0a18fd8
...
>> mount.setuid?
=> true
>> mount.file?
=> true
>> mount.directory?
=> false
>> mount.symlink?
=> false
>> mount.socket?
=> false
>> mount.pipe?
=> false
>> mount.chardev?
=> false
>> mount.blockdev?
=> false

```
