### PR TITLE
Fix A Meterpreter Compatibility Error Message

### DIFF
--- a/lib/msf/core/post_mixin.rb
+++ b/lib/msf/core/post_mixin.rb
@@ -229,10 +229,10 @@ module Msf::PostMixin
         # If there are missing commands, try to load the necessary extension.
 
         # If core_loadlib isn't supported, then extensions can't be loaded
-        return 'missing Meterpreter features' unless s.commands.include?(Rex::Post::Meterpreter::COMMAND_ID_CORE_LOADLIB)
+        return 'missing Meterpreter features: core can not be extended' unless s.commands.include?(Rex::Post::Meterpreter::COMMAND_ID_CORE_LOADLIB)
 
         # Since core is already loaded, if the missing command is a core command then it's truly missing
-        return 'missing Meterpreter features' if missing_cmd_ids.any? do |cmd_id|
+        return 'missing Meterpreter features: core commands' if missing_cmd_ids.any? do |cmd_id|
           cmd_id.between?(
             Rex::Post::Meterpreter::ClientCore.extension_id,
             Rex::Post::Meterpreter::ClientCore.extension_id + Rex::Post::Meterpreter::COMMAND_ID_RANGE - 1
@@ -242,7 +242,7 @@ module Msf::PostMixin
         missing_extensions = missing_cmd_ids.map { |cmd_id| Rex::Post::Meterpreter::ExtensionMapper.get_extension_name(cmd_id) }.uniq
         missing_extensions.each do |ext_name|
           # If the extension is already loaded, the command is truly missing
-          return 'missing Meterpreter features' if s.ext.aliases.include?(ext_name)
+          return "missing Meterpreter features: extension commands" if s.ext.aliases.include?(ext_name)
 
           begin
             s.core.use(ext_name)
@@ -253,7 +253,7 @@ module Msf::PostMixin
       end
       missing_cmd_ids -= s.commands
 
-      return 'missing Meterpreter features' unless missing_cmd_ids.empty?
+      return "missing Meterpreter features: extension commands" unless missing_cmd_ids.empty?
     end
 
     # If we got here, we haven't found anything that definitely

--- a/lib/msf/core/post_mixin.rb
+++ b/lib/msf/core/post_mixin.rb
@@ -227,10 +227,21 @@ module Msf::PostMixin
       missing_cmd_ids = (cmd_ids - s.commands)
       unless missing_cmd_ids.empty?
         # If there are missing commands, try to load the necessary extension.
+
+        # If core_loadlib isn't supported, then extensions can't be loaded
         return 'missing Meterpreter features' unless s.commands.include?(Rex::Post::Meterpreter::COMMAND_ID_CORE_LOADLIB)
+
+        # Since core is already loaded, if the missing command is a core command then it's truly missing
+        return 'missing Meterpreter features' if missing_cmd_ids.any? do |cmd_id|
+          cmd_id.between?(
+            Rex::Post::Meterpreter::ClientCore.extension_id,
+            Rex::Post::Meterpreter::ClientCore.extension_id + Rex::Post::Meterpreter::COMMAND_ID_RANGE - 1
+          )
+        end
 
         missing_extensions = missing_cmd_ids.map { |cmd_id| Rex::Post::Meterpreter::ExtensionMapper.get_extension_name(cmd_id) }.uniq
         missing_extensions.each do |ext_name|
+          # If the extension is already loaded, the command is truly missing
           return 'missing Meterpreter features' if s.ext.aliases.include?(ext_name)
 
           begin


### PR DESCRIPTION
This fixes an error in the Meterpreter command ID compatibility checking. It previously didn't check if the command ID was a core command ID, it instead assumed it was provided by an extension. If any required core commands are missing, then Metasploit can't fix the issue by loading an extension because the core is already loaded. This resulted in an odd error saying that it couldn't load an extension but wouldn't display what the extension was.

## Old and broken
```
msf6 payload(python/meterpreter/reverse_tcp) > use post/linux/gather/checkvm 
msf6 post(linux/gather/checkvm) > run

[!] SESSION may not be compatible with this module (unloadable Meterpreter extension: )
[*] Gathering System info ....
[+] This appears to be a 'VMware' virtual machine
[*] Post module execution completed
msf6 post(linux/gather/checkvm) >
```

## New and fixed
```
msf6 payload(python/meterpreter/reverse_tcp) > use post/linux/gather/checkvm 
msf6 post(linux/gather/checkvm) > show options 

Module options (post/linux/gather/checkvm):

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   SESSION  -1               yes       The session to run this module on.

msf6 post(linux/gather/checkvm) > run

[!] SESSION may not be compatible with this module (missing Meterpreter features)
[*] Gathering System info ....
[+] This appears to be a 'VMware' virtual machine
[*] Post module execution completed
msf6 post(linux/gather/checkvm) >
```

## Verification

- [x] Open a Python Meterpreter session on a Linux system
    * The Python Meterpreter is apparently missing the `core_channel_seek` and `core_channel_tell` commands which causes it to be marked as incompatible by a number of libraries that now declare that they are dependent on `core_channel_*`. This should probably be fixed as well since it's likely overly specific but I'll submit a separate PR after I've tested it more thoroughly and likely fix it as I update all of the modules with their dependencies.
- [x] Run the `post/linux/gather/checkvm` module
- [x] See an error message that it's incompatible because of missing Meterpreter features, not that an extension couldn't be loaded.