### PR TITLE
Fall to shell when meterpreter fails for some reason in `get_processes`

### DIFF
--- a/lib/msf/core/post/linux/system.rb
+++ b/lib/msf/core/post/linux/system.rb
@@ -228,27 +228,6 @@ module System
   end
 
   #
-  # Gets the process id(s) of `program`
-  # @return [Array]
-  #
-  def pidof(program)
-    pids = []
-    full = cmd_exec('ps aux').to_s
-    full.split("\n").each do |pid|
-      pids << pid.split(' ')[1].to_i if pid.include? program
-    end
-    pids
-  end
-
-  #
-  # Gets the uid of a pid
-  # @return [String]
-  #
-  def pid_uid(pid)
-    read_file("/proc/#{pid}/status").to_s
-  end
-
-  #
   # Checks if `file_path` is mounted on a noexec mount point
   # @return [Boolean]
   #

--- a/lib/msf/core/post/solaris/system.rb
+++ b/lib/msf/core/post/solaris/system.rb
@@ -115,19 +115,6 @@ module System
   end
 
   #
-  # Gets the process id(s) of `program`
-  # @return [Array]
-  #
-  def pidof(program)
-    pids = []
-    full = cmd_exec('ps -elf').to_s
-    full.split("\n").each do |pid|
-      pids << pid.split(' ')[3].to_i if pid.include? program
-    end
-    pids
-  end
-
-  #
   # Gets the mount point of `filepath`
   # @param [String] filepath The filepath to get the mount point
   # @return [String]

--- a/lib/msf/core/post/unix.rb
+++ b/lib/msf/core/post/unix.rb
@@ -99,8 +99,8 @@ module Msf::Post::Unix
   #
   def whoami
     shellpid = get_session_pid()
-    statuspid = pid_uid(shellpid)
-    statuspid.each_line do |line|
+    status = read_file("/proc/#{shellpid}/status") 
+    status.each_line do |line|
       split = line.split(":")
       if split[0] == "Uid"
         regex = /.*\s(.*)\s/

--- a/lib/msf/core/post/windows/process.rb
+++ b/lib/msf/core/post/windows/process.rb
@@ -134,25 +134,6 @@ module Process
     Rex.sleep(delay_sec)
   end
 
-  # Determines if a PID actually exists
-  def has_pid?(pid)
-    procs = []
-    begin
-      procs = client.sys.process.processes
-    rescue Rex::Post::Meterpreter::RequestError
-      print_error("Unable to enumerate processes")
-      return false
-    end
-
-    procs.each do |p|
-      found_pid = p['pid']
-      return true if found_pid == pid
-    end
-
-    print_error("PID #{pid.to_s} does not actually exist.")
-
-    return false
-  end
 end # Process
 end # Windows
 end # Post

--- a/modules/exploits/linux/local/ptrace_sudo_token_priv_esc.rb
+++ b/modules/exploits/linux/local/ptrace_sudo_token_priv_esc.rb
@@ -12,6 +12,7 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Post::Linux::System
   include Msf::Exploit::EXE
   include Msf::Exploit::FileDropper
+  include Msf::Post::Process
   prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})


### PR DESCRIPTION
## Summary
This adds error handling for `get_processes` method under `msf/core/post/process` mentioned in #15246  so in case meterpreter fails for some reason it will fall back to use shell's `get_processes`.
