### PR TITLE
Generate machine readable msfvenom output when pipes are used

### DIFF
--- a/msfvenom
+++ b/msfvenom
@@ -52,6 +52,10 @@ def init_framework(create_opts={})
   end
 
   @framework = ::Msf::Simple::Framework.create(create_opts)
+
+  unless $stdout.tty?
+    Rex::Text::Table.unwrap_tables!
+  end
 end
 
 # Cached framework object


### PR DESCRIPTION
Adds support for detecting when msfvenom is being executed with pipes, and generates machine readable output

Closes https://github.com/rapid7/metasploit-framework/issues/15130

## Verification

Run msfvenom directly and see that tables are wrapped:

```
$ bundle exec msfvenom --list payloads

Framework Payloads (592 total) [--payload <value>]
==================================================

...
    windows/x64/vncinject/reverse_tcp_rc4               Inject a VNC Dll via a reflective loader (Windows x64) (staged). Connect back to
                                                        the attacker
    windows/x64/vncinject/reverse_tcp_uuid              Inject a VNC Dll via a reflective loader (Windows x64) (staged). Connect back to
                                                        the attacker with UUID Support (Windows x64)
    windows/x64/vncinject/reverse_winhttp               Inject a VNC Dll via a reflective loader (Windows x64) (staged). Tunnel communica
                                                        tion over HTTP (Windows x64 winhttp)
    windows/x64/vncinject/reverse_winhttps              Inject a VNC Dll via a reflective loader (Windows x64) (staged). Tunnel communica
                                                        tion over HTTPS (Windows x64 winhttp)

```

Run msfvenom and pipe to `cat` and see that tables are no longer wrapped

```
bundle exec msfvenom --list payloads | cat

Framework Payloads (592 total) [--payload <value>]
==================================================

    Name                                                Description
    ----                                                -----------
    windows/x64/vncinject/reverse_tcp_rc4               Inject a VNC Dll via a reflective loader (Windows x64) (staged). Connect back to the attacker
    windows/x64/vncinject/reverse_tcp_uuid              Inject a VNC Dll via a reflective loader (Windows x64) (staged). Connect back to the attacker with UUID Support (Windows x64)
    windows/x64/vncinject/reverse_winhttp               Inject a VNC Dll via a reflective loader (Windows x64) (staged). Tunnel communication over HTTP (Windows x64 winhttp)
    windows/x64/vncinject/reverse_winhttps              Inject a VNC Dll via a reflective loader (Windows x64) (staged). Tunnel communication over HTTPS (Windows x64 winhttp)
```
