### PR TITLE
Revive: Explicitly target analyze results and determine payload compatibility

### DIFF
--- a/lib/msf/core/analyze/result.rb
+++ b/lib/msf/core/analyze/result.rb
@@ -87,6 +87,12 @@ class Msf::Analyze::Result
       @mod.datastore[k] = v
     end
 
+    target_idx = @mod.auto_targeted_index(@host)
+    if target_idx
+      @datastore['target'] = target_idx
+      @mod.datastore['target'] = target_idx
+    end
+
     @mod.validate
   rescue Msf::OptionValidateError => e
     unset_options = []

--- a/lib/msf/core/analyze/result.rb
+++ b/lib/msf/core/analyze/result.rb
@@ -98,7 +98,7 @@ class Msf::Analyze::Result
     # Must come after the target so we know we match the target we want.
     # TODO: feed available payloads into target selection
     if @wanted_payloads
-      if p = @wanted_payloads.select { |p|@mod.is_payload_compatible?(p) }.first
+      if p = @wanted_payloads.find { |p| @mod.is_payload_compatible?(p) }
         @datastore['payload'] = p
       else
         @missing << :payload_match

--- a/lib/msf/core/exploit/auto_target.rb
+++ b/lib/msf/core/exploit/auto_target.rb
@@ -23,8 +23,8 @@ module Msf
     #
     # @return [Integer] the index of the selected Target
     # @return [nil] if no target could be selected
-    def auto_targeted_index
-      selected_target = select_target
+    def auto_targeted_index(host=auto_target_host)
+      selected_target = select_target(host)
       return nil if selected_target.nil?
       targets.each_with_index do |target, index|
         return index if target == selected_target
@@ -36,11 +36,10 @@ module Msf
     # the targeted host.
     #
     # @return [Msf::Module::Target] the Target that our automatic routine selected
-    def select_target
+    def select_target(host)
+      return nil if host.nil?
       return nil unless auto_target?
-      host_record = auto_target_host
-      return nil if host_record.nil?
-      filtered_targets = filter_by_os(host_record)
+      filtered_targets = filter_by_os(host)
       filtered_targets.first
     end
 

--- a/lib/msf/core/exploit/auto_target.rb
+++ b/lib/msf/core/exploit/auto_target.rb
@@ -36,7 +36,7 @@ module Msf
     # the targeted host.
     #
     # @return [Msf::Module::Target] the Target that our automatic routine selected
-    def select_target(host)
+    def select_target(host=auto_target_host)
       return nil if host.nil?
       return nil unless auto_target?
       filtered_targets = filter_by_os(host)

--- a/lib/msf/ui/console/command_dispatcher/db/analyze.rb
+++ b/lib/msf/ui/console/command_dispatcher/db/analyze.rb
@@ -24,6 +24,8 @@ module Msf::Ui::Console::CommandDispatcher::Analyze
           return
         when '-a', '-v'
           print_empty = true
+        when '-p'
+          wanted_payloads = args.shift.split(',')
         else
           (arg_host_range(arg, host_ranges))
       end
@@ -56,7 +58,7 @@ module Msf::Ui::Console::CommandDispatcher::Analyze
         end
         found_vulns = true
 
-        host_result = framework.analyze.host(eval_host)
+        host_result = framework.analyze.host(eval_host, payloads: wanted_payloads)
         found_modules = host_result[:results]
         if found_modules.any?
           reported_module = true

--- a/spec/lib/msf/core/exploit/auto_target_spec.rb
+++ b/spec/lib/msf/core/exploit/auto_target_spec.rb
@@ -153,6 +153,12 @@ RSpec.describe Msf::Exploit::AutoTarget do
     end
 
     context '#select_target' do
+      it 'should return nil when the provided host is nil' do
+        windows_exploit.datastore['WORKSPACE'] = windows_xp_sp1_host.workspace.name
+        windows_exploit.datastore['RHOST'] = windows_xp_sp1_host.address
+        expect(windows_exploit.select_target(nil)).to be nil
+      end
+
       it 'should return the matching target on a precise match' do
         windows_exploit.datastore['WORKSPACE'] = windows_xp_sp1_host.workspace.name
         windows_exploit.datastore['RHOST'] = windows_xp_sp1_host.address
@@ -167,6 +173,12 @@ RSpec.describe Msf::Exploit::AutoTarget do
     end
 
     context '#auto_targeted_index' do
+      it 'should return nil when the provided host is nil' do
+        windows_exploit.datastore['WORKSPACE'] = windows_xp_sp1_host.workspace.name
+        windows_exploit.datastore['RHOST'] = windows_xp_sp1_host.address
+        expect(windows_exploit.auto_targeted_index(nil)).to be nil
+      end
+
       it 'should return the index of the selected target' do
         windows_exploit.datastore['WORKSPACE'] = windows_xp_sp1_host.workspace.name
         windows_exploit.datastore['RHOST'] = windows_xp_sp1_host.address


### PR DESCRIPTION
Reviving the original work of @acammack-r7, but with updating the tests to pass - https://github.com/rapid7/metasploit-framework/pull/15197

## Verification

I verified that the original analyze command's verification steps still work with the import script here:
https://github.com/rapid7/metasploit-framework/pull/11191

Working:
```
msf6 auxiliary(scanner/http/title) > db_import ~/Downloads/m3_report.xml
[... omitted ...]
msf6 auxiliary(scanner/http/title) > analyze
[*] Analysis for 192.168.18.118 ->
[*]   exploit/windows/smb/ms17_010_eternalblue - ready for testing
[*]   exploit/windows/smb/ms17_010_eternalblue_win8 - ready for testing
[*]   exploit/windows/smb/ms17_010_psexec - credentials are required
[*]   exploit/windows/smb/smb_doublepulsar_rce - ready for testing
[*] Analysis for 192.168.222.151 ->
[*]   exploit/windows/smb/ms17_010_eternalblue - ready for testing
[*]   exploit/windows/smb/ms17_010_eternalblue_win8 - ready for testing
[*]   exploit/windows/smb/ms17_010_psexec - credentials are required
[*]   exploit/windows/smb/smb_doublepulsar_rce - ready for testing
```

And using the new `-p` option with a valid match:
```
msf6 exploit(windows/smb/ms17_010_eternalblue) > analyze -p windows/x64/meterpreter/reverse_tcp
[*] Analysis for 192.168.18.118 ->
[*]   exploit/windows/smb/ms17_010_eternalblue - ready for testing
[*]   exploit/windows/smb/ms17_010_eternalblue_win8 - ready for testing
[*]   exploit/windows/smb/ms17_010_psexec - credentials are required
[*]   exploit/windows/smb/smb_doublepulsar_rce - ready for testing
[*] Analysis for 192.168.222.151 ->
[*]   exploit/windows/smb/ms17_010_eternalblue - ready for testing
[*]   exploit/windows/smb/ms17_010_eternalblue_win8 - ready for testing
[*]   exploit/windows/smb/ms17_010_psexec - credentials are required
[*]   exploit/windows/smb/smb_doublepulsar_rce - ready for testing
```

Using the new `-p` option with an invalid match:
```
msf6 auxiliary(scanner/http/title) > analyze -p payload/linux/x86/shell_reverse_tcp_ipv6
[*] Analysis for 192.168.18.118 ->
[*]   exploit/windows/smb/ms17_010_eternalblue - none of the requested payloads match
[*]   exploit/windows/smb/ms17_010_eternalblue_win8 - none of the requested payloads match
[*]   exploit/windows/smb/ms17_010_psexec - credentials are required, none of the requested payloads match
[*]   exploit/windows/smb/smb_doublepulsar_rce - none of the requested payloads match
[*] Analysis for 192.168.222.151 ->
[*]   exploit/windows/smb/ms17_010_eternalblue - none of the requested payloads match
[*]   exploit/windows/smb/ms17_010_eternalblue_win8 - none of the requested payloads match
[*]   exploit/windows/smb/ms17_010_psexec - credentials are required, none of the requested payloads match
[*]   exploit/windows/smb/smb_doublepulsar_rce - none of the requested payloads match
```

There was additional discussion on how to test this within the original PR:
> To verify this, we will likely need to use nmap imports/db_nmap should populate at least some of the necessary information. Also needs unit testing based on nmap information.
> https://github.com/rapid7/metasploit-framework/pull/15197#issuecomment-845136032

But I have only verified the steps that I listed previously