### PR TITLE
Add autoload data field functionality from looted file in db.report_loot API method

### DIFF
--- a/lib/msf/core/rpc/v10/rpc_db.rb
+++ b/lib/msf/core/rpc/v10/rpc_db.rb
@@ -1549,6 +1549,12 @@ end
   def rpc_report_loot(xopts)
   ::ApplicationRecord.connection_pool.with_connection {
     opts, wspace = init_db_opts_workspace(xopts)
+    
+    if !opts[:data]
+      file = File.open(opts[:path], "rb")
+      opts[:data] = file.read
+    end
+    
     if opts[:host] && opts[:port] && opts[:proto]
       opts[:service] = self.framework.db.find_or_create_service(opts)
     end


### PR DESCRIPTION
If no data is sent to the "db.report_loot" endpoint, it will automatically fill that field with the content of the looted file, otherwise it will use the data sent in the request

## Verification

**Call the endpoint in this way:**

```
[ "db.report_loot","<token>",
	{
		"workspace"=> "workspace-name",
		"host"=> "192.168.0.66",
		"path"=> "/path/to/loot/file-name.txt,
		"type"=> "file",
		"name"=> "file-name.txt",
		"info"=> "test-info",
	}
]
```

**Check if data was saved correctly:**

```
[ "db.loots","<token>",
	{
		"workspace"=> "workspace-name",
	}
]
```

In the response the data field of each loot must contain the content of the file