### PR TITLE
Fix syntax errors in auxiliary spec modules

### DIFF
--- a/spec/file_fixtures/modules/auxiliary/auxiliary_tidy.rb
+++ b/spec/file_fixtures/modules/auxiliary/auxiliary_tidy.rb
@@ -6,8 +6,8 @@
 class MetasploitModule < Msf::Auxiliary
   def initialize(info = {})
     super(update_info(info,
-      'Name'        => 'Tidy Auxiliary Module for RSpec'
-      'Description' => 'Test!'
+      'Name'        => 'Tidy Auxiliary Module for RSpec',
+      'Description' => 'Test!',
       'Author'      => 'Unknown',
       'License'     => MSF_LICENSE
     ))

--- a/spec/file_fixtures/modules/auxiliary/auxiliary_untidy.rb
+++ b/spec/file_fixtures/modules/auxiliary/auxiliary_untidy.rb
@@ -12,9 +12,8 @@ class MetasploitModule < Msf::Exploit
     super(
       update_info(
         info,
-        'Name'            => 'Untidy Auxiliary Module for RSpec'
-        'Description'     => 'Test!'
-        },
+        'Name'            => 'Untidy Auxiliary Module for RSpec',
+        'Description'     => 'Test!',
         'Author'         => %w(Unknown),
         'License'        => MSF_LICENSE,
       )


### PR DESCRIPTION
Noticed multiple of these warnings when running rspec with Ruby 3.0.1


```
/Users/user/Documents/code/metasploit-framework/spec/file_fixtures/modules/auxiliary/auxiliary_untidy.rb:16: warning: One-line pattern matching is experimental, and the behavior may change in future versions of Ruby!
/Users/user/Documents/code/metasploit-framework/spec/file_fixtures/modules/auxiliary/auxiliary_untidy.rb:18: warning: One-line pattern matching is experimental, and the behavior may change in future versions of Ruby!
```

The issue is caused by the module loader reading and eval'ing the intentionally broken `spec/file_fixtures/modules/auxiliary/auxiliary_tidy.rb` module, which ruby itself dumps out warnings during the loader's `module_eval` call

Replicated with:

```
content = File.read("./spec/file_fixtures/modules/auxiliary/auxiliary_tidy.rb")
> eval(content)
(eval):10: warning: One-line pattern matching is experimental, and the behavior may change in future versions of Ruby!
(eval):11: warning: One-line pattern matching is experimental, and the behavior may change in future versions of Ruby!
(eval):12: warning: One-line pattern matching is experimental, and the behavior may change in future versions of Ruby!
(irb):6:in `eval': (eval):10: syntax error, unexpected string literal, expecting ')' (SyntaxError)
      'Description' => 'Test!'
      ^
(eval):11: syntax error, unexpected ',', expecting `end'
...    'Author'      => 'Unknown',
...                              ^
(eval):13: syntax error, unexpected ')', expecting `end'
    ))
```

The solution is to fix the invalid Ruby code

## Verification

Ensure CI passes