### PR TITLE
sync Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -479,7 +479,6 @@ DEPENDENCIES
   rubocop
   ruby-prof (= 1.4.2)
   simplecov (= 0.18.2)
-  swagger-blocks
   timecop
   yard
 


### PR DESCRIPTION
Fix failing automation that expects Gemfile.lock to be pristine during tagging.

## Verification

List the steps needed to make sure this thing works

- [x] `bundle install` results in no changes to the repository tree.
