### PR TITLE
Add OUTFILE and DATABASE options to zoomeye_search and enhance output saved

### DIFF
--- a/documentation/modules/auxiliary/gather/zoomeye_search.md
+++ b/documentation/modules/auxiliary/gather/zoomeye_search.md
@@ -78,5 +78,849 @@ use the correct data from your query and likely won't end up finding anything. A
 first, as mentioned previously, will not return any results, so be wary of this.
 
 ## Scenarios
-### Host Search with XXXXX and XXXX
-### Web Search On XXXX With XXXX
+
+### Host Search With No Database
+```
+msf6 payload(windows/x64/meterpreter/reverse_tcp) > use zoomeye_search
+
+Matching Modules
+================
+
+   #  Name                             Disclosure Date  Rank    Check  Description
+   -  ----                             ---------------  ----    -----  -----------
+   0  auxiliary/gather/zoomeye_search                   normal  No     ZoomEye Search
+
+
+Interact with a module by name or index. For example info 0, use 0 or use auxiliary/gather/zoomeye_search
+
+[*] Using auxiliary/gather/zoomeye_search
+msf6 auxiliary(gather/zoomeye_search) > show options
+
+Module options (auxiliary/gather/zoomeye_search):
+
+   Name          Current Setting  Required  Description
+   ----          ---------------  --------  -----------
+   DATABASE      false            no        Add search results to the database
+   FACETS                         no        A comma-separated list of properties to get summary information on query
+   MAXPAGE       1                yes       Max amount of pages to collect
+   OUTFILE                        no        Path to the file to store the resulting table of info
+   PASSWORD                       yes       The ZoomEye password
+   RESOURCE      host             yes       ZoomEye Resource Type (Accepted: host, web)
+   USERNAME                       yes       The ZoomEye username
+   ZOOMEYE_DORK                   yes       The ZoomEye dork
+
+msf6 auxiliary(gather/zoomeye_search) > set USERNAME mexig33784@mtlcz.com
+USERNAME => mexig33784@mtlcz.com
+msf6 auxiliary(gather/zoomeye_search) > set PASSWORD *redacted*
+PASSWORD => *redacted*
+msf6 auxiliary(gather/zoomeye_search) > show options
+
+Module options (auxiliary/gather/zoomeye_search):
+
+   Name          Current Setting       Required  Description
+   ----          ---------------       --------  -----------
+   DATABASE      false                 no        Add search results to the database
+   FACETS                              no        A comma-separated list of properties to get summary information on query
+   MAXPAGE       1                     yes       Max amount of pages to collect
+   OUTFILE                             no        Path to the file to store the resulting table of info
+   PASSWORD      *redacted*            yes       The ZoomEye password
+   RESOURCE      host                  yes       ZoomEye Resource Type (Accepted: host, web)
+   USERNAME      mexig33784@mtlcz.com  yes       The ZoomEye username
+   ZOOMEYE_DORK                        yes       The ZoomEye dork
+
+msf6 auxiliary(gather/zoomeye_search) > set ZOOMEYE_DORK 'app:"moxa OnCell G3470A-LTE-EU"'
+ZOOMEYE_DORK => app:"moxa OnCell G3470A-LTE-EU"
+msf6 auxiliary(gather/zoomeye_search) > run
+
+[-] Unable to resolve api.zoomeye.org
+[*] Auxiliary module execution completed
+msf6 auxiliary(gather/zoomeye_search) > run
+
+[*] Logged in to zoomeye
+[*] Total: 189 on 10 pages. Showing: 1 page(s)
+[*] Collecting data, please wait...
+Host search
+===========
+
+ IP:Port           Protocol  City                  Country      Hostname  OS  service  AppName            Version  Info
+ -------           --------  ----                  -------      --------  --  -------  -------            -------  ----
+ 138.188.35.215:8  tcp                             Switzerland                http     GoAhead WebServer
+ 0
+ 138.188.35.37:80  tcp                             Switzerland                http     GoAhead WebServer
+ 138.188.37.20:80  tcp                             Switzerland                http     GoAhead WebServer
+ 138.188.39.245:8  tcp                             Switzerland                http     GoAhead WebServer
+ 0
+ 138.188.39.249:8  tcp                             Switzerland                http     GoAhead WebServer
+ 0
+ 138.188.41.234:8  tcp                             Switzerland                http     GoAhead WebServer
+ 0
+ 138.188.41.65:80  tcp                             Switzerland                http     GoAhead WebServer
+ 138.188.42.12:80  tcp                             Switzerland                http     GoAhead WebServer
+ 138.188.43.252:8  tcp                             Switzerland                http     GoAhead WebServer
+ 0
+ 138.188.45.14:80  tcp                             Switzerland                http     GoAhead WebServer
+ 138.188.50.1:80   tcp                             Switzerland                http     GoAhead WebServer
+ 138.188.52.135:8  tcp                             Switzerland                http     GoAhead WebServer
+ 0
+ 138.188.55.140:8  tcp                             Switzerland                http     GoAhead WebServer
+ 0
+ 138.188.55.71:80  tcp                             Switzerland                http     GoAhead WebServer
+ 178.145.113.16:4  tcp                             Belgium                    https    GoAhead WebServer
+ 43
+ 178.182.239.27:8  tcp                             Poland                     http     GoAhead WebServer
+ 0
+ 183.171.15.197:4  tcp                             Malaysia                   https    GoAhead WebServer
+ 43
+ 183.171.15.221:4  tcp                             Malaysia                   https    GoAhead WebServer
+ 43
+ 62.79.16.38:80    tcp       Aalborg Municipality  Denmark                    https    GoAhead WebServer
+ 90.117.110.158:4  tcp                             France                     https    GoAhead WebServer
+ 43
+
+[*] Auxiliary module execution completed
+msf6 auxiliary(gather/zoomeye_search) >
+```
+
+### Host Search With No Database and Multiple Pages And Saving To Disk
+```
+msf6 payload(windows/x64/meterpreter/reverse_tcp) > use zoomeye_search
+
+Matching Modules
+================
+
+   #  Name                             Disclosure Date  Rank    Check  Description
+   -  ----                             ---------------  ----    -----  -----------
+   0  auxiliary/gather/zoomeye_search                   normal  No     ZoomEye Search
+
+
+Interact with a module by name or index. For example info 0, use 0 or use auxiliary/gather/zoomeye_search
+
+[*] Using auxiliary/gather/zoomeye_search
+msf6 auxiliary(gather/zoomeye_search) > show options
+
+Module options (auxiliary/gather/zoomeye_search):
+
+   Name          Current Setting  Required  Description
+   ----          ---------------  --------  -----------
+   DATABASE      false            no        Add search results to the database
+   FACETS                         no        A comma-separated list of properties to get summary information on query
+   MAXPAGE       1                yes       Max amount of pages to collect
+   OUTFILE                        no        Path to the file to store the resulting table of info
+   PASSWORD                       yes       The ZoomEye password
+   RESOURCE      host             yes       ZoomEye Resource Type (Accepted: host, web)
+   USERNAME                       yes       The ZoomEye username
+   ZOOMEYE_DORK                   yes       The ZoomEye dork
+
+msf6 auxiliary(gather/zoomeye_search) > set USERNAME mexig33784@mtlcz.com
+USERNAME => mexig33784@mtlcz.com
+msf6 auxiliary(gather/zoomeye_search) > set PASSWORD *redacted*
+PASSWORD => *redacted*
+msf6 auxiliary(gather/zoomeye_search) > set ZOOMEYE_DORK 'app:"moxa OnCell G3470A-LTE-EU"'
+ZOOMEYE_DORK => app:"moxa OnCell G3470A-LTE-EU"
+msf6 auxiliary(gather/zoomeye_search) >
+msf6 auxiliary(gather/zoomeye_search) > set MAXPAGE 5
+MAXPAGE => 5
+msf6 auxiliary(gather/zoomeye_search) > set OUTFILE /tmp/results.txt
+OUTFILE => /tmp/results.txt
+msf6 auxiliary(gather/zoomeye_search) > show options
+
+Module options (auxiliary/gather/zoomeye_search):
+
+   Name          Current Setting                  Required  Description
+   ----          ---------------                  --------  -----------
+   DATABASE      false                            no        Add search results to the database
+   FACETS                                         no        A comma-separated list of properties to get summary information on q
+                                                            uery
+   MAXPAGE       5                                yes       Max amount of pages to collect
+   OUTFILE       /tmp/results.txt                 no        Path to the file to store the resulting table of info
+   PASSWORD      *redacted*                       yes       The ZoomEye password
+   RESOURCE      host                             yes       ZoomEye Resource Type (Accepted: host, web)
+   USERNAME      mexig33784@mtlcz.com             yes       The ZoomEye username
+   ZOOMEYE_DORK  app:"moxa OnCell G3470A-LTE-EU"  yes       The ZoomEye dork
+
+msf6 auxiliary(gather/zoomeye_search) > run
+
+[*] Logged in to zoomeye
+[*] Total: 189 on 10 pages. Showing: 5 page(s)
+[*] Collecting data, please wait...
+Host search
+===========
+
+ IP:Port           Protocol  City                  Country             Hostname  OS  service  AppName            Version  Info
+ -------           --------  ----                  -------             --------  --  -------  -------            -------  ----
+ 123.209.112.240:  tcp       Sydney                Australia                         http     GoAhead WebServer
+ 80
+ 123.209.121.222:  tcp       Sydney                Australia                         https    GoAhead WebServer
+ 443
+ 123.209.198.169:  tcp       Sydney                Australia                         http     GoAhead WebServer
+ 80
+ 123.209.248.218:  tcp       Sydney                Australia                         https    GoAhead WebServer
+ 443
+ 123.209.248.218:  tcp       Sydney                Australia                         http     GoAhead WebServer
+ 80
+ 138.188.32.57:44  tcp                             Switzerland                       https    GoAhead WebServer
+ 3
+ 138.188.32.80:44  tcp                             Switzerland                       https    GoAhead WebServer
+ 3
+ 138.188.32.80:80  tcp                             Switzerland                       https    GoAhead WebServer
+ 138.188.33.104:4  tcp                             Switzerland                       https    GoAhead WebServer
+ 43
+ 138.188.33.104:8  tcp                             Switzerland                       http     GoAhead WebServer
+ 0
+ 138.188.33.134:4  tcp                             Switzerland                       https    GoAhead WebServer
+ 43
+ 138.188.34.129:4  tcp                             Switzerland                       https    GoAhead WebServer
+ 43
+ 138.188.34.129:8  tcp                             Switzerland                       http     GoAhead WebServer
+ 0
+ 138.188.34.217:4  tcp                             Switzerland                       https    GoAhead WebServer
+ 43
+ 138.188.34.21:44  tcp                             Switzerland                       https    GoAhead WebServer
+ 3
+ 138.188.34.21:80  tcp                             Switzerland                       http     GoAhead WebServer
+ 138.188.34.77:80  tcp                             Switzerland                       http     GoAhead WebServer
+ 138.188.35.215:8  tcp                             Switzerland                       http     GoAhead WebServer
+ 0
+ 138.188.35.37:80  tcp                             Switzerland                       http     GoAhead WebServer
+ 138.188.35.55:44  tcp                             Switzerland                       https    GoAhead WebServer
+ 3
+ 138.188.37.20:80  tcp                             Switzerland                       http     GoAhead WebServer
+ 138.188.38.11:44  tcp                             Switzerland                       https    GoAhead WebServer
+ 3
+ 138.188.39.0:443  tcp                             Switzerland                       https    GoAhead WebServer
+ 138.188.39.172:4  tcp                             Switzerland                       https    GoAhead WebServer
+ 43
+ 138.188.39.245:8  tcp                             Switzerland                       http     GoAhead WebServer
+ 0
+ 138.188.39.249:8  tcp                             Switzerland                       http     GoAhead WebServer
+ 0
+ 138.188.40.125:4  tcp                             Switzerland                       https    GoAhead WebServer
+ 43
+ 138.188.40.125:8  tcp                             Switzerland                       https    GoAhead WebServer
+ 0
+ 138.188.40.210:8  tcp                             Switzerland                       http     GoAhead WebServer
+ 0
+ 138.188.40.38:44  tcp                             Switzerland                       https    GoAhead WebServer
+ 3
+ 138.188.41.135:4  tcp                             Switzerland                       https    GoAhead WebServer
+ 43
+ 138.188.41.135:8  tcp                             Switzerland                       http     GoAhead WebServer
+ 0
+ 138.188.41.234:8  tcp                             Switzerland                       http     GoAhead WebServer
+ 0
+ 138.188.41.65:80  tcp                             Switzerland                       http     GoAhead WebServer
+ 138.188.42.12:80  tcp                             Switzerland                       http     GoAhead WebServer
+ 138.188.42.150:8  tcp                             Switzerland                       http     GoAhead WebServer
+ 0
+ 138.188.42.213:8  tcp                             Switzerland                       http     GoAhead WebServer
+ 0
+ 138.188.42.219:4  tcp                             Switzerland                       https    GoAhead WebServer
+ 43
+ 138.188.42.246:4  tcp                             Switzerland                       https    GoAhead WebServer
+ 43
+ 138.188.42.246:8  tcp                             Switzerland                       http     GoAhead WebServer
+ 0
+ 138.188.42.78:44  tcp                             Switzerland                       https    GoAhead WebServer
+ 3
+ 138.188.42.78:80  tcp                             Switzerland                       http     GoAhead WebServer
+ 138.188.43.205:4  tcp                             Switzerland                       https    GoAhead WebServer
+ 43
+ 138.188.43.231:4  tcp                             Switzerland                       https    GoAhead WebServer
+ 43
+ 138.188.43.252:8  tcp                             Switzerland                       http     GoAhead WebServer
+ 0
+ 138.188.44.151:4  tcp                             Switzerland                       https    GoAhead WebServer
+ 43
+ 138.188.44.92:80  tcp                             Switzerland                       http     GoAhead WebServer
+ 138.188.45.14:80  tcp                             Switzerland                       http     GoAhead WebServer
+ 138.188.46.196:4  tcp                             Switzerland                       https    GoAhead WebServer
+ 43
+ 138.188.46.196:8  tcp                             Switzerland                       http     GoAhead WebServer
+ 0
+ 138.188.46.197:4  tcp                             Switzerland                       https    GoAhead WebServer
+ 43
+ 138.188.46.197:8  tcp                             Switzerland                       http     GoAhead WebServer
+ 0
+ 138.188.47.158:4  tcp                             Switzerland                       https    GoAhead WebServer
+ 43
+ 138.188.47.158:8  tcp                             Switzerland                       http     GoAhead WebServer
+ 0
+ 138.188.47.215:4  tcp                             Switzerland                       https    GoAhead WebServer
+ 43
+ 138.188.47.215:8  tcp                             Switzerland                       http     GoAhead WebServer
+ 0
+ 138.188.48.206:4  tcp                             Switzerland                       https    GoAhead WebServer
+ 43
+ 138.188.48.206:8  tcp                             Switzerland                       http     GoAhead WebServer
+ 0
+ 138.188.48.217:8  tcp                             Switzerland                       http     GoAhead WebServer
+ 0
+ 138.188.48.23:80  tcp                             Switzerland                       http     GoAhead WebServer
+ 138.188.50.148:4  tcp                             Switzerland                       https    GoAhead WebServer
+ 43
+ 138.188.50.153:4  tcp                             Switzerland                       https    GoAhead WebServer
+ 43
+ 138.188.50.153:8  tcp                             Switzerland                       http     GoAhead WebServer
+ 0
+ 138.188.50.1:80   tcp                             Switzerland                       http     GoAhead WebServer
+ 138.188.51.169:8  tcp                             Switzerland                       http     GoAhead WebServer
+ 0
+ 138.188.52.135:8  tcp                             Switzerland                       http     GoAhead WebServer
+ 0
+ 138.188.52.18:44  tcp                             Switzerland                       https    GoAhead WebServer
+ 3
+ 138.188.52.239:4  tcp                             Switzerland                       https    GoAhead WebServer
+ 43
+ 138.188.53.51:44  tcp                             Switzerland                       https    GoAhead WebServer
+ 3
+ 138.188.54.188:4  tcp                             Switzerland                       https    GoAhead WebServer
+ 43
+ 138.188.54.237:8  tcp                             Switzerland                       https    GoAhead WebServer
+ 0
+ 138.188.54.247:4  tcp                             Switzerland                       https    GoAhead WebServer
+ 43
+ 138.188.54.247:8  tcp                             Switzerland                       http     GoAhead WebServer
+ 0
+ 138.188.54.71:80  tcp                             Switzerland                       http     GoAhead WebServer
+ 138.188.54.85:44  tcp                             Switzerland                       https    GoAhead WebServer
+ 3
+ 138.188.55.140:8  tcp                             Switzerland                       http     GoAhead WebServer
+ 0
+ 138.188.55.71:80  tcp                             Switzerland                       http     GoAhead WebServer
+ 176.118.19.96:80  tcp                             Russian Federation                http     GoAhead WebServer
+ 178.145.113.16:4  tcp                             Belgium                           https    GoAhead WebServer
+ 43
+ 178.182.239.27:8  tcp                             Poland                            http     GoAhead WebServer
+ 0
+ 178.182.239.28:4  tcp                             Poland                            https    GoAhead WebServer
+ 43
+ 178.182.239.30:8  tcp                             Poland                            http     GoAhead WebServer
+ 0
+ 178.183.132.209:  tcp                             Poland                            https    GoAhead WebServer
+ 443
+ 183.171.15.197:4  tcp                             Malaysia                          https    GoAhead WebServer
+ 43
+ 183.171.15.221:4  tcp                             Malaysia                          https    GoAhead WebServer
+ 43
+ 31.0.211.25:443   tcp                             Poland                            https    GoAhead WebServer
+ 31.173.131.227:4  tcp                             Russian Federation                https    GoAhead WebServer
+ 43
+ 37.184.151.252:4  tcp                             Belgium                           https    GoAhead WebServer
+ 43
+ 37.62.232.145:80  tcp                             Belgium                           http     GoAhead WebServer
+ 37.62.240.111:44  tcp                             Belgium                           https    GoAhead WebServer
+ 3
+ 37.84.125.16:443  tcp                             Germany                           https    GoAhead WebServer
+ 46.179.5.232:443  tcp                             Belgium                           https    GoAhead WebServer
+ 62.79.16.36:80    tcp       Aalborg Municipality  Denmark                           http     GoAhead WebServer
+ 62.79.16.38:80    tcp       Aalborg Municipality  Denmark                           https    GoAhead WebServer
+ 78.25.91.170:443  tcp                             Russian Federation                https    GoAhead WebServer
+ 80.251.198.20:80  tcp                             Denmark                           http     GoAhead WebServer
+ 85.26.192.153:44  tcp                             Russian Federation                https    GoAhead WebServer
+ 3
+ 90.117.100.109:8                                  France                            https    GoAhead WebServer
+ 080
+ 90.117.110.158:4  tcp                             France                            https    GoAhead WebServer
+ 43
+ 90.117.120.142:8  tcp                             France                            http     GoAhead WebServer
+ 0
+
+[*] Saved results in /tmp/results.txt
+[*] Auxiliary module execution completed
+msf6 auxiliary(gather/zoomeye_search) > cat /tmp/results.txt
+[*] exec: cat /tmp/results.txt
+
+Host search
+===========
+
+ IP:Port           Protocol  City                  Country             Hostname  OS  service  AppName            Version  Info
+ -------           --------  ----                  -------             --------  --  -------  -------            -------  ----
+ 123.209.112.240:  tcp       Sydney                Australia                         http     GoAhead WebServer
+ 80
+ 123.209.121.222:  tcp       Sydney                Australia                         https    GoAhead WebServer
+ 443
+ 123.209.198.169:  tcp       Sydney                Australia                         http     GoAhead WebServer
+ 80
+ 123.209.248.218:  tcp       Sydney                Australia                         https    GoAhead WebServer
+ 443
+ 123.209.248.218:  tcp       Sydney                Australia                         http     GoAhead WebServer
+ 80
+ 138.188.32.57:44  tcp                             Switzerland                       https    GoAhead WebServer
+ 3
+ 138.188.32.80:44  tcp                             Switzerland                       https    GoAhead WebServer
+ 3
+ 138.188.32.80:80  tcp                             Switzerland                       https    GoAhead WebServer
+ 138.188.33.104:4  tcp                             Switzerland                       https    GoAhead WebServer
+ 43
+ 138.188.33.104:8  tcp                             Switzerland                       http     GoAhead WebServer
+ 0
+ 138.188.33.134:4  tcp                             Switzerland                       https    GoAhead WebServer
+ 43
+ 138.188.34.129:4  tcp                             Switzerland                       https    GoAhead WebServer
+ 43
+ 138.188.34.129:8  tcp                             Switzerland                       http     GoAhead WebServer
+ 0
+ 138.188.34.217:4  tcp                             Switzerland                       https    GoAhead WebServer
+ 43
+ 138.188.34.21:44  tcp                             Switzerland                       https    GoAhead WebServer
+ 3
+ 138.188.34.21:80  tcp                             Switzerland                       http     GoAhead WebServer
+ 138.188.34.77:80  tcp                             Switzerland                       http     GoAhead WebServer
+ 138.188.35.215:8  tcp                             Switzerland                       http     GoAhead WebServer
+ 0
+ 138.188.35.37:80  tcp                             Switzerland                       http     GoAhead WebServer
+ 138.188.35.55:44  tcp                             Switzerland                       https    GoAhead WebServer
+ 3
+ 138.188.37.20:80  tcp                             Switzerland                       http     GoAhead WebServer
+ 138.188.38.11:44  tcp                             Switzerland                       https    GoAhead WebServer
+ 3
+ 138.188.39.0:443  tcp                             Switzerland                       https    GoAhead WebServer
+ 138.188.39.172:4  tcp                             Switzerland                       https    GoAhead WebServer
+ 43
+ 138.188.39.245:8  tcp                             Switzerland                       http     GoAhead WebServer
+ 0
+ 138.188.39.249:8  tcp                             Switzerland                       http     GoAhead WebServer
+ 0
+ 138.188.40.125:4  tcp                             Switzerland                       https    GoAhead WebServer
+ 43
+ 138.188.40.125:8  tcp                             Switzerland                       https    GoAhead WebServer
+ 0
+ 138.188.40.210:8  tcp                             Switzerland                       http     GoAhead WebServer
+ 0
+ 138.188.40.38:44  tcp                             Switzerland                       https    GoAhead WebServer
+ 3
+ 138.188.41.135:4  tcp                             Switzerland                       https    GoAhead WebServer
+ 43
+ 138.188.41.135:8  tcp                             Switzerland                       http     GoAhead WebServer
+ 0
+ 138.188.41.234:8  tcp                             Switzerland                       http     GoAhead WebServer
+ 0
+ 138.188.41.65:80  tcp                             Switzerland                       http     GoAhead WebServer
+ 138.188.42.12:80  tcp                             Switzerland                       http     GoAhead WebServer
+ 138.188.42.150:8  tcp                             Switzerland                       http     GoAhead WebServer
+ 0
+ 138.188.42.213:8  tcp                             Switzerland                       http     GoAhead WebServer
+ 0
+ 138.188.42.219:4  tcp                             Switzerland                       https    GoAhead WebServer
+ 43
+ 138.188.42.246:4  tcp                             Switzerland                       https    GoAhead WebServer
+ 43
+ 138.188.42.246:8  tcp                             Switzerland                       http     GoAhead WebServer
+ 0
+ 138.188.42.78:44  tcp                             Switzerland                       https    GoAhead WebServer
+ 3
+ 138.188.42.78:80  tcp                             Switzerland                       http     GoAhead WebServer
+ 138.188.43.205:4  tcp                             Switzerland                       https    GoAhead WebServer
+ 43
+ 138.188.43.231:4  tcp                             Switzerland                       https    GoAhead WebServer
+ 43
+ 138.188.43.252:8  tcp                             Switzerland                       http     GoAhead WebServer
+ 0
+ 138.188.44.151:4  tcp                             Switzerland                       https    GoAhead WebServer
+ 43
+ 138.188.44.92:80  tcp                             Switzerland                       http     GoAhead WebServer
+ 138.188.45.14:80  tcp                             Switzerland                       http     GoAhead WebServer
+ 138.188.46.196:4  tcp                             Switzerland                       https    GoAhead WebServer
+ 43
+ 138.188.46.196:8  tcp                             Switzerland                       http     GoAhead WebServer
+ 0
+ 138.188.46.197:4  tcp                             Switzerland                       https    GoAhead WebServer
+ 43
+ 138.188.46.197:8  tcp                             Switzerland                       http     GoAhead WebServer
+ 0
+ 138.188.47.158:4  tcp                             Switzerland                       https    GoAhead WebServer
+ 43
+ 138.188.47.158:8  tcp                             Switzerland                       http     GoAhead WebServer
+ 0
+ 138.188.47.215:4  tcp                             Switzerland                       https    GoAhead WebServer
+ 43
+ 138.188.47.215:8  tcp                             Switzerland                       http     GoAhead WebServer
+ 0
+ 138.188.48.206:4  tcp                             Switzerland                       https    GoAhead WebServer
+ 43
+ 138.188.48.206:8  tcp                             Switzerland                       http     GoAhead WebServer
+ 0
+ 138.188.48.217:8  tcp                             Switzerland                       http     GoAhead WebServer
+ 0
+ 138.188.48.23:80  tcp                             Switzerland                       http     GoAhead WebServer
+ 138.188.50.148:4  tcp                             Switzerland                       https    GoAhead WebServer
+ 43
+ 138.188.50.153:4  tcp                             Switzerland                       https    GoAhead WebServer
+ 43
+ 138.188.50.153:8  tcp                             Switzerland                       http     GoAhead WebServer
+ 0
+ 138.188.50.1:80   tcp                             Switzerland                       http     GoAhead WebServer
+ 138.188.51.169:8  tcp                             Switzerland                       http     GoAhead WebServer
+ 0
+ 138.188.52.135:8  tcp                             Switzerland                       http     GoAhead WebServer
+ 0
+ 138.188.52.18:44  tcp                             Switzerland                       https    GoAhead WebServer
+ 3
+ 138.188.52.239:4  tcp                             Switzerland                       https    GoAhead WebServer
+ 43
+ 138.188.53.51:44  tcp                             Switzerland                       https    GoAhead WebServer
+ 3
+ 138.188.54.188:4  tcp                             Switzerland                       https    GoAhead WebServer
+ 43
+ 138.188.54.237:8  tcp                             Switzerland                       https    GoAhead WebServer
+ 0
+ 138.188.54.247:4  tcp                             Switzerland                       https    GoAhead WebServer
+ 43
+ 138.188.54.247:8  tcp                             Switzerland                       http     GoAhead WebServer
+ 0
+ 138.188.54.71:80  tcp                             Switzerland                       http     GoAhead WebServer
+ 138.188.54.85:44  tcp                             Switzerland                       https    GoAhead WebServer
+ 3
+ 138.188.55.140:8  tcp                             Switzerland                       http     GoAhead WebServer
+ 0
+ 138.188.55.71:80  tcp                             Switzerland                       http     GoAhead WebServer
+ 176.118.19.96:80  tcp                             Russian Federation                http     GoAhead WebServer
+ 178.145.113.16:4  tcp                             Belgium                           https    GoAhead WebServer
+ 43
+ 178.182.239.27:8  tcp                             Poland                            http     GoAhead WebServer
+ 0
+ 178.182.239.28:4  tcp                             Poland                            https    GoAhead WebServer
+ 43
+ 178.182.239.30:8  tcp                             Poland                            http     GoAhead WebServer
+ 0
+ 178.183.132.209:  tcp                             Poland                            https    GoAhead WebServer
+ 443
+ 183.171.15.197:4  tcp                             Malaysia                          https    GoAhead WebServer
+ 43
+ 183.171.15.221:4  tcp                             Malaysia                          https    GoAhead WebServer
+ 43
+ 31.0.211.25:443   tcp                             Poland                            https    GoAhead WebServer
+ 31.173.131.227:4  tcp                             Russian Federation                https    GoAhead WebServer
+ 43
+ 37.184.151.252:4  tcp                             Belgium                           https    GoAhead WebServer
+ 43
+ 37.62.232.145:80  tcp                             Belgium                           http     GoAhead WebServer
+ 37.62.240.111:44  tcp                             Belgium                           https    GoAhead WebServer
+ 3
+ 37.84.125.16:443  tcp                             Germany                           https    GoAhead WebServer
+ 46.179.5.232:443  tcp                             Belgium                           https    GoAhead WebServer
+ 62.79.16.36:80    tcp       Aalborg Municipality  Denmark                           http     GoAhead WebServer
+ 62.79.16.38:80    tcp       Aalborg Municipality  Denmark                           https    GoAhead WebServer
+ 78.25.91.170:443  tcp                             Russian Federation                https    GoAhead WebServer
+ 80.251.198.20:80  tcp                             Denmark                           http     GoAhead WebServer
+ 85.26.192.153:44  tcp                             Russian Federation                https    GoAhead WebServer
+ 3
+ 90.117.100.109:8                                  France                            https    GoAhead WebServer
+ 080
+ 90.117.110.158:4  tcp                             France                            https    GoAhead WebServer
+ 43
+ 90.117.120.142:8  tcp                             France                            http     GoAhead WebServer
+ 0
+msf6 auxiliary(gather/zoomeye_search) >
+```
+
+### Hosts Search With Facets
+```
+msf6 payload(windows/x64/meterpreter/reverse_tcp) > use zoomeye_search
+
+Matching Modules
+================
+
+   #  Name                             Disclosure Date  Rank    Check  Description
+   -  ----                             ---------------  ----    -----  -----------
+   0  auxiliary/gather/zoomeye_search                   normal  No     ZoomEye Search
+
+
+Interact with a module by name or index. For example info 0, use 0 or use auxiliary/gather/zoomeye_search
+
+[*] Using auxiliary/gather/zoomeye_search
+msf6 auxiliary(gather/zoomeye_search) > show options
+
+Module options (auxiliary/gather/zoomeye_search):
+
+   Name          Current Setting  Required  Description
+   ----          ---------------  --------  -----------
+   DATABASE      false            no        Add search results to the database
+   FACETS                         no        A comma-separated list of properties to get summary information on query
+   MAXPAGE       1                yes       Max amount of pages to collect
+   OUTFILE                        no        Path to the file to store the resulting table of info
+   PASSWORD                       yes       The ZoomEye password
+   RESOURCE      host             yes       ZoomEye Resource Type (Accepted: host, web)
+   USERNAME                       yes       The ZoomEye username
+   ZOOMEYE_DORK                   yes       The ZoomEye dork
+
+msf6 auxiliary(gather/zoomeye_search) > set ZOOMEYE_DORK 'app:"moxa OnCell G3470A-LTE-EU"'
+ZOOMEYE_DORK => app:"moxa OnCell G3470A-LTE-EU"
+msf6 auxiliary(gather/zoomeye_search) > set USERNAME mexig33784@mtlcz.com
+USERNAME => mexig33784@mtlcz.com
+msf6 auxiliary(gather/zoomeye_search) > set PASSWORD *redacted*
+PASSWORD => *redacted*
+msf6 auxiliary(gather/zoomeye_search) > set FACETS os,port,country
+FACETS => os,port,country
+msf6 auxiliary(gather/zoomeye_search) > show options
+
+Module options (auxiliary/gather/zoomeye_search):
+
+   Name          Current Setting                  Required  Description
+   ----          ---------------                  --------  -----------
+   DATABASE      false                            no        Add search results to the database
+   FACETS        os,port,country                  no        A comma-separated list of properties to get summary information on q
+                                                            uery
+   MAXPAGE       1                                yes       Max amount of pages to collect
+   OUTFILE                                        no        Path to the file to store the resulting table of info
+   PASSWORD      *redacted*                       yes       The ZoomEye password
+   RESOURCE      host                             yes       ZoomEye Resource Type (Accepted: host, web)
+   USERNAME      mexig33784@mtlcz.com             yes       The ZoomEye username
+   ZOOMEYE_DORK  app:"moxa OnCell G3470A-LTE-EU"  yes       The ZoomEye dork
+
+msf6 auxiliary(gather/zoomeye_search) > run
+
+[*] Logged in to zoomeye
+[*] Total: 189 on 10 pages. Showing facets
+Facets
+======
+
+ Facet    Name                Count
+ -----    ----                -----
+ country  Switzerland         115
+ country  Poland              18
+ country  Belgium             13
+ country  Australia           12
+ country  Germany             8
+ country  Russian Federation  8
+ country  France              7
+ country  Denmark             3
+ country  Malaysia            3
+ country  Jersey              1
+ os                           189
+ port     80                  106
+ port     443                 80
+ port     8080                2
+ port     8081                1
+
+[*] Auxiliary module execution completed
+msf6 auxiliary(gather/zoomeye_search) >
+```
+
+
+### Web Search With Facets And OutFile
+```
+msf6 > use auxiliary/gather/zoomeye_search
+msf6 auxiliary(gather/zoomeye_search) > set ZOOMEYE_DORK 'app:"moxa OnCell G3470A-LTE-EU"'
+ZOOMEYE_DORK => app:"moxa OnCell G3470A-LTE-EU"
+msf6 auxiliary(gather/zoomeye_search) > set USERNAME mexig33784@mtlcz.com
+USERNAME => mexig33784@mtlcz.com
+msf6 auxiliary(gather/zoomeye_search) > set PASSWORD *redacted*
+PASSWORD => *redacted*
+msf6 auxiliary(gather/zoomeye_search) > set FACETS os,port,country
+FACETS => os,port,country
+msf6 auxiliary(gather/zoomeye_search) > show options
+
+Module options (auxiliary/gather/zoomeye_search):
+
+   Name          Current Setting                  Required  Description
+   ----          ---------------                  --------  -----------
+   DATABASE      false                            no        Add search results to the database
+   FACETS        os,port,country                  no        A comma-separated list of properties to get summary information on q
+                                                            uery
+   MAXPAGE       1                                yes       Max amount of pages to collect
+   OUTFILE                                        no        Path to the file to store the resulting table of info
+   PASSWORD      *redacted*                       yes       The ZoomEye password
+   RESOURCE      host                             yes       ZoomEye Resource Type (Accepted: host, web)
+   USERNAME      mexig33784@mtlcz.com             yes       The ZoomEye username
+   ZOOMEYE_DORK  app:"moxa OnCell G3470A-LTE-EU"  yes       The ZoomEye dork
+
+msf6 auxiliary(gather/zoomeye_search) > set RESOURCE web
+RESOURCE => web
+msf6 auxiliary(gather/zoomeye_search) > set OUTFILE /tmp/web.txt
+OUTFILE => /tmp/web.txt
+msf6 auxiliary(gather/zoomeye_search) > run
+
+[*] Logged in to zoomeye
+[*] Total: 9 on 1 pages. Showing facets
+Facets
+======
+
+ Facet    Name       Count
+ -----    ----       -----
+ country  Poland     3
+ country  Denmark    2
+ country  France     2
+ country  Australia  1
+ country  Austria    1
+ os       Windows    9
+
+[*] Saved results in /tmp/web.txt
+[*] Auxiliary module execution completed
+msf6 auxiliary(gather/zoomeye_search) > cat /tmp/web.txt
+[*] exec: cat /tmp/web.txt
+
+Facets
+======
+
+ Facet    Name       Count
+ -----    ----       -----
+ country  Poland     3
+ country  Denmark    2
+ country  France     2
+ country  Australia  1
+ country  Austria    1
+ os       Windows    9
+msf6 auxiliary(gather/zoomeye_search) >
+```
+
+### Hosts Search with Database And Outfile Options Set
+```
+msf6 auxiliary(gather/zoomeye_search) > show options
+
+Module options (auxiliary/gather/zoomeye_search):
+
+   Name          Current Setting                  Required  Description
+   ----          ---------------                  --------  -----------
+   DATABASE      true                             no        Add search results to the database
+   FACETS                                         no        A comma-separated list of properties to get summary information on q
+                                                            uery
+   MAXPAGE       1                                yes       Max amount of pages to collect
+   OUTFILE       /tmp/web.txt                     no        Path to the file to store the resulting table of info
+   PASSWORD      aNN9tMSs3e2fJ5U                  yes       The ZoomEye password
+   RESOURCE      host                             yes       ZoomEye Resource Type (Accepted: host, web)
+   USERNAME      mexig33784@mtlcz.com             yes       The ZoomEye username
+   ZOOMEYE_DORK  app:"moxa OnCell G3470A-LTE-EU"  yes       The ZoomEye dork
+
+msf6 auxiliary(gather/zoomeye_search) > run
+
+[*] Logged in to zoomeye
+[*] Total: 189 on 10 pages. Showing: 1 page(s)
+[*] Collecting data, please wait...
+Host search
+===========
+
+ IP:Port           Protocol  City                  Country      Hostname  OS  service  AppName            Version  Info
+ -------           --------  ----                  -------      --------  --  -------  -------            -------  ----
+ 138.188.35.215:8  tcp                             Switzerland                http     GoAhead WebServer
+ 0
+ 138.188.35.37:80  tcp                             Switzerland                http     GoAhead WebServer
+ 138.188.37.20:80  tcp                             Switzerland                http     GoAhead WebServer
+ 138.188.39.245:8  tcp                             Switzerland                http     GoAhead WebServer
+ 0
+ 138.188.39.249:8  tcp                             Switzerland                http     GoAhead WebServer
+ 0
+ 138.188.41.234:8  tcp                             Switzerland                http     GoAhead WebServer
+ 0
+ 138.188.41.65:80  tcp                             Switzerland                http     GoAhead WebServer
+ 138.188.42.12:80  tcp                             Switzerland                http     GoAhead WebServer
+ 138.188.43.252:8  tcp                             Switzerland                http     GoAhead WebServer
+ 0
+ 138.188.45.14:80  tcp                             Switzerland                http     GoAhead WebServer
+ 138.188.50.1:80   tcp                             Switzerland                http     GoAhead WebServer
+ 138.188.52.135:8  tcp                             Switzerland                http     GoAhead WebServer
+ 0
+ 138.188.55.140:8  tcp                             Switzerland                http     GoAhead WebServer
+ 0
+ 138.188.55.71:80  tcp                             Switzerland                http     GoAhead WebServer
+ 178.145.113.16:4  tcp                             Belgium                    https    GoAhead WebServer
+ 43
+ 178.182.239.27:8  tcp                             Poland                     http     GoAhead WebServer
+ 0
+ 183.171.15.197:4  tcp                             Malaysia                   https    GoAhead WebServer
+ 43
+ 183.171.15.221:4  tcp                             Malaysia                   https    GoAhead WebServer
+ 43
+ 62.79.16.38:80    tcp       Aalborg Municipality  Denmark                    https    GoAhead WebServer
+ 90.117.110.158:4  tcp                             France                     https    GoAhead WebServer
+ 43
+
+[*] Saved results in /tmp/web.txt
+[*] Auxiliary module execution completed
+msf6 auxiliary(gather/zoomeye_search) > cat /tmp/web.txt
+[*] exec: cat /tmp/web.txt
+
+Host search
+===========
+
+ IP:Port           Protocol  City                  Country      Hostname  OS  service  AppName            Version  Info
+ -------           --------  ----                  -------      --------  --  -------  -------            -------  ----
+ 138.188.35.215:8  tcp                             Switzerland                http     GoAhead WebServer
+ 0
+ 138.188.35.37:80  tcp                             Switzerland                http     GoAhead WebServer
+ 138.188.37.20:80  tcp                             Switzerland                http     GoAhead WebServer
+ 138.188.39.245:8  tcp                             Switzerland                http     GoAhead WebServer
+ 0
+ 138.188.39.249:8  tcp                             Switzerland                http     GoAhead WebServer
+ 0
+ 138.188.41.234:8  tcp                             Switzerland                http     GoAhead WebServer
+ 0
+ 138.188.41.65:80  tcp                             Switzerland                http     GoAhead WebServer
+ 138.188.42.12:80  tcp                             Switzerland                http     GoAhead WebServer
+ 138.188.43.252:8  tcp                             Switzerland                http     GoAhead WebServer
+ 0
+ 138.188.45.14:80  tcp                             Switzerland                http     GoAhead WebServer
+ 138.188.50.1:80   tcp                             Switzerland                http     GoAhead WebServer
+ 138.188.52.135:8  tcp                             Switzerland                http     GoAhead WebServer
+ 0
+ 138.188.55.140:8  tcp                             Switzerland                http     GoAhead WebServer
+ 0
+ 138.188.55.71:80  tcp                             Switzerland                http     GoAhead WebServer
+ 178.145.113.16:4  tcp                             Belgium                    https    GoAhead WebServer
+ 43
+ 178.182.239.27:8  tcp                             Poland                     http     GoAhead WebServer
+ 0
+ 183.171.15.197:4  tcp                             Malaysia                   https    GoAhead WebServer
+ 43
+ 183.171.15.221:4  tcp                             Malaysia                   https    GoAhead WebServer
+ 43
+ 62.79.16.38:80    tcp       Aalborg Municipality  Denmark                    https    GoAhead WebServer
+ 90.117.110.158:4  tcp                             France                     https    GoAhead WebServer
+ 43
+msf6 auxiliary(gather/zoomeye_search) > hosts
+
+Hosts
+=====
+
+address         mac  name  os_name  os_flavor  os_sp  purpose  info  comments
+-------         ---  ----  -------  ---------  -----  -------  ----  --------
+62.79.16.38                                           device         Added from Zoomeye
+90.117.110.158                                        device         Added from Zoomeye
+138.188.35.37                                         device         Added from Zoomeye
+138.188.35.215                                        device         Added from Zoomeye
+138.188.37.20                                         device         Added from Zoomeye
+138.188.39.245                                        device         Added from Zoomeye
+138.188.39.249                                        device         Added from Zoomeye
+138.188.41.65                                         device         Added from Zoomeye
+138.188.41.234                                        device         Added from Zoomeye
+138.188.42.12                                         device         Added from Zoomeye
+138.188.43.252                                        device         Added from Zoomeye
+138.188.45.14                                         device         Added from Zoomeye
+138.188.50.1                                          device         Added from Zoomeye
+138.188.52.135                                        device         Added from Zoomeye
+138.188.55.71                                         device         Added from Zoomeye
+138.188.55.140                                        device         Added from Zoomeye
+178.145.113.16                                        device         Added from Zoomeye
+178.182.239.27                                        device         Added from Zoomeye
+183.171.15.197                                        device         Added from Zoomeye
+183.171.15.221                                        device         Added from Zoomeye
+
+msf6 auxiliary(gather/zoomeye_search) > services
+Services
+========
+
+host            port  proto  name   state  info
+----            ----  -----  ----   -----  ----
+62.79.16.38     80    tcp    https  open   GoAhead WebServer running version:
+90.117.110.158  443   tcp    https  open   GoAhead WebServer running version:
+138.188.35.37   80    tcp    http   open   GoAhead WebServer running version:
+138.188.35.215  80    tcp    http   open   GoAhead WebServer running version:
+138.188.37.20   80    tcp    http   open   GoAhead WebServer running version:
+138.188.39.245  80    tcp    http   open   GoAhead WebServer running version:
+138.188.39.249  80    tcp    http   open   GoAhead WebServer running version:
+138.188.41.65   80    tcp    http   open   GoAhead WebServer running version:
+138.188.41.234  80    tcp    http   open   GoAhead WebServer running version:
+138.188.42.12   80    tcp    http   open   GoAhead WebServer running version:
+138.188.43.252  80    tcp    http   open   GoAhead WebServer running version:
+138.188.45.14   80    tcp    http   open   GoAhead WebServer running version:
+138.188.50.1    80    tcp    http   open   GoAhead WebServer running version:
+138.188.52.135  80    tcp    http   open   GoAhead WebServer running version:
+138.188.55.71   80    tcp    http   open   GoAhead WebServer running version:
+138.188.55.140  80    tcp    http   open   GoAhead WebServer running version:
+178.145.113.16  443   tcp    https  open   GoAhead WebServer running version:
+178.182.239.27  80    tcp    http   open   GoAhead WebServer running version:
+183.171.15.197  443   tcp    https  open   GoAhead WebServer running version:
+183.171.15.221  443   tcp    https  open   GoAhead WebServer running version:
+
+msf6 auxiliary(gather/zoomeye_search) >
+```

--- a/documentation/modules/auxiliary/gather/zoomeye_search.md
+++ b/documentation/modules/auxiliary/gather/zoomeye_search.md
@@ -1,8 +1,12 @@
-## Introduction
-This module uses the zoomeye API to retrieve multiple informations from either 'host' or 'web' source, the latter being a search based on web servers only.
+## Vulnerable Application
+This module uses the ZoomEye API to conduct either a host search or a web search (web servers only),
+and output the information gathered into a table which can then be saved for later use.
 
 ## Note
-You need to register for zoomeye credentials with an email and mobile phone at zoomeye.org.
+You need to register for ZoomEye by creating an account with Telnet404. You can register for a temp email
+at https://temp-mail.org and get a temp phone number to recieve the SMS's needed to sign up at https://smsreceivefree.com.
+
+Then browse to https://www.zoomeye.org, click on the `Register` button, and follow the steps from there.
 
 ## Verification Steps
 
@@ -15,30 +19,64 @@ You need to register for zoomeye credentials with an email and mobile phone at z
 7. If you see 'Logged in to zoomeye', despite an internal error coming from the null dork, it means that the creds are valid.
 
 ## Options
- RESOURCE <host | web>
-  Look for any kind of servers or only web (http/https) servers.
- DATABASE <true | false>
-  Records the output to the database.
-  If using 'host' search, the ip, hostname, and os are recorded within the hosts table.
-  And the ip, port, protocol name, service+version, and additional infos are recorded into the services table.
- FACETS (host search) <app | device | service | os | port | country | city>
- FACETS (web search) <webapp | component | framework | frontend | server | waf | os | country | city>
-  Just show a summary of (all) the results concerning a particular facet.
- MAXPAGE <integer>:
-  The maximum number of pages to collect.
- OUTFILE <path>
-  Save the output to a file.
- USERNAME <your username>
-  The username.
- PASSWORD <your password>
-  The password.
- ZOOMEYE_DORK <zoomeye query>
-  This must be composed of keywords and search filters as listed here: "https://www.zoomeye.org/doc#search-filters"
-  The request must be enclose with single quotes and splited with double quotes, you must put the filters before any keyword as in :'country:"FR"+decathlon'.
-  Note that if you don't use double quotes to delimit your search filters, it will include the remining of the query and so probably wouldn't find anything, and puting the keyword first will just not return any results.
+
+### RESOURCE
+Can be set to either `host` or `web`. `host` looks for any kind of servers,
+whilst `web` restricts the search to only web (http/https) servers.
+
+### DATABASE
+Records the output to the database if set. If using `host` search, the ip, hostname, and
+OS are recorded within the `hosts` table. Additionally, the IP, port, protocol name,
+service name and version, and any additional information received are recorded into
+the `services` table.
+
+### FACETS
+Just show a summary of (all) the results concerning a particular facet.
+
+For host searches, you can filter results by using the following facets:
+  - app
+  - device
+  - service
+  - os
+  - port
+  - country
+  - city
+
+For web searches you can filter results by using the following facets:
+  - webapp
+  - component
+  - framework
+  - frontend
+  - server
+  - waf
+  - os
+  - country
+  - city
+
+### MAXPAGE
+The maximum number of pages to collect, expressed as an integer.
+
+### OUTFILE
+The file to save the output to, if specified.
+
+### USERNAME
+The username to log into ZoomEye as.
+
+### PASSWORD
+The password to log into ZoomEye as.
+
+### ZOOMEYE_DORK
+The query/dork to run on ZoomEye. This must be composed of keywords and search
+filters from the list located [here](https://www.zoomeye.org/doc#search-filters).
+
+The request must be enclosed with single quotes and any search terms that
+you want to match explicitly on must be enclosed within double quotes. You
+must put the filters before any keyword. An example would be: `'country:"FR"+decathlon'`.
+
+Note that if you don't use double quotes to delimit your search filters, then the search filters will not
+use the correct data from your query and likely won't end up finding anything. Additionally, putting keywords
+first, as mentioned previously, will not return any results, so be wary of this.
 
 ## Scenarios
- Host search:
-  It is better for a broad search and usually returns a higher amount of results, better when looking for services vulnerability since it lists them.
- Web search:
-  It works much like google dorks, targeting the web service and being able to search for http content via filters. The search will output the database application if any.
+### Host Search with XXXXX and XXXX
+### Web Search On XXXX With XXXX

--- a/documentation/modules/auxiliary/gather/zoomeye_search.md
+++ b/documentation/modules/auxiliary/gather/zoomeye_search.md
@@ -1,0 +1,44 @@
+## Introduction
+This module uses the zoomeye API to retrieve multiple informations from either 'host' or 'web' source, the latter being a search based on web servers only.
+
+## Note
+You need to register for zoomeye credentials with an email and mobile phone at zoomeye.org.
+
+## Verification Steps
+
+1. Start `msfconsole`
+2. Do: `use/auxiliary/gather/zoomeye`
+3. Do: `set USERNAME <your username>`
+4. Do: `set PASSWORD <your password>`
+5. Do: `set ZOOMEYE_DORK ''`
+6. Do: `run`
+7. If you see 'Logged in to zoomeye', despite an internal error coming from the null dork, it means that the creds are valid.
+
+## Options
+ RESOURCE <host | web>
+  Look for any kind of servers or only web (http/https) servers.
+ DATABASE <true | false>
+  Records the output to the database.
+  If using 'host' search, the ip, hostname, and os are recorded within the hosts table.
+  And the ip, port, protocol name, service+version, and additional infos are recorded into the services table.
+ FACETS (host search) <app | device | service | os | port | country | city>
+ FACETS (web search) <webapp | component | framework | frontend | server | waf | os | country | city>
+  Just show a summary of (all) the results concerning a particular facet.
+ MAXPAGE <integer>:
+  The maximum number of pages to collect.
+ OUTFILE <path>
+  Save the output to a file.
+ USERNAME <your username>
+  The username.
+ PASSWORD <your password>
+  The password.
+ ZOOMEYE_DORK <zoomeye query>
+  This must be composed of keywords and search filters as listed here: "https://www.zoomeye.org/doc#search-filters"
+  The request must be enclose with single quotes and splited with double quotes, you must put the filters before any keyword as in :'country:"FR"+decathlon'.
+  Note that if you don't use double quotes to delimit your search filters, it will include the remining of the query and so probably wouldn't find anything, and puting the keyword first will just not return any results.
+
+## Scenarios
+ Host search:
+  It is better for a broad search and usually returns a higher amount of results, better when looking for services vulnerability since it lists them.
+ Web search:
+  It works much like google dorks, targeting the web service and being able to search for http content via filters. The search will output the database application if any.

--- a/documentation/modules/auxiliary/gather/zoomeye_search.md
+++ b/documentation/modules/auxiliary/gather/zoomeye_search.md
@@ -924,3 +924,137 @@ host            port  proto  name   state  info
 
 msf6 auxiliary(gather/zoomeye_search) >
 ```
+
+### Web Search With Database
+```
+msf6 payload(windows/x64/meterpreter/reverse_tcp) > use auxiliary/gather/zoomeye_search
+msf6 auxiliary(gather/zoomeye_search) > show options
+
+Module options (auxiliary/gather/zoomeye_search):
+
+   Name          Current Setting  Required  Description
+   ----          ---------------  --------  -----------
+   DATABASE      false            no        Add search results to the database
+   FACETS                         no        A comma-separated list of properties to get summary information on query
+   MAXPAGE       1                yes       Max amount of pages to collect
+   OUTFILE                        no        Path to the file to store the resulting table of info
+   PASSWORD                       yes       The ZoomEye password
+   RESOURCE      host             yes       ZoomEye Resource Type (Accepted: host, web)
+   USERNAME                       yes       The ZoomEye username
+   ZOOMEYE_DORK                   yes       The ZoomEye dork
+
+msf6 auxiliary(gather/zoomeye_search) > set RESOURCE web
+RESOURCE => web
+msf6 auxiliary(gather/zoomeye_search) > set ZOOMEYE_DORK 'app:"moxa OnCell G3470A-LTE-EU"'
+ZOOMEYE_DORK => app:"moxa OnCell G3470A-LTE-EU"
+msf6 auxiliary(gather/zoomeye_search) > set USERNAME mexig33784@mtlcz.com
+USERNAME => mexig33784@mtlcz.com
+msf6 auxiliary(gather/zoomeye_search) > set PASSWORD aNN9tMSs3e2fJ5U
+PASSWORD => aNN9tMSs3e2fJ5U
+msf6 auxiliary(gather/zoomeye_search) > set OUTFILE /tmp/web-test.txt
+OUTFILE => /tmp/web-test.txt
+msf6 auxiliary(gather/zoomeye_search) > show options
+
+Module options (auxiliary/gather/zoomeye_search):
+
+   Name          Current Setting                  Required  Description
+   ----          ---------------                  --------  -----------
+   DATABASE      false                            no        Add search results to the database
+   FACETS                                         no        A comma-separated list of properties to get summary information on q
+                                                            uery
+   MAXPAGE       1                                yes       Max amount of pages to collect
+   OUTFILE       /tmp/web-test.txt                no        Path to the file to store the resulting table of info
+   PASSWORD      aNN9tMSs3e2fJ5U                  yes       The ZoomEye password
+   RESOURCE      web                              yes       ZoomEye Resource Type (Accepted: host, web)
+   USERNAME      mexig33784@mtlcz.com             yes       The ZoomEye username
+   ZOOMEYE_DORK  app:"moxa OnCell G3470A-LTE-EU"  yes       The ZoomEye dork
+
+msf6 auxiliary(gather/zoomeye_search) > set DATABASE true
+DATABASE => true
+msf6 auxiliary(gather/zoomeye_search) > hosts -d
+
+Hosts
+=====
+
+address         mac  name                                         os_name  os_flavor  os_sp  purpose  info  comments
+-------         ---  ----                                         -------  ---------  -----  -------  ----  --------
+31.0.211.25          apn-31-0-211-25.static.gprs.plus.pl                                                    Added from Zoomeye
+46.74.36.255         046074036255.atmpu0002.highway.a1.net                                                  Added from Zoomeye
+80.251.198.20        80.251.198.20                                                                          Added from Zoomeye
+90.117.106.196       90-117-106-196.mobile.abo.orange.fr                                                    Added from Zoomeye
+90.117.110.29        90-117-110-29.mobile.abo.orange.fr                                                     Added from Zoomeye
+123.209.125.20       61438337164.mobile.telstra.com                                                         Added from Zoomeye
+178.182.239.27       178.182.239.27.nat.umts.dynamic.t-mobile.pl                                            Added from Zoomeye
+178.182.244.68       178.182.244.68.nat.umts.dynamic.t-mobile.pl                                            Added from Zoomeye
+
+[*] Deleted 8 hosts
+msf6 auxiliary(gather/zoomeye_search) > services -d
+Services
+========
+
+host  port  proto  name  state  info
+----  ----  -----  ----  -----  ----
+
+msf6 auxiliary(gather/zoomeye_search) > run
+
+[*] Logged in to zoomeye
+[*] Total: 9 on 1 pages. Showing: 1 page(s)
+Web search
+==========
+
+ IP              Site                                         City    Country    DB:Version  WebApp:Version
+ --              ----                                         ----    -------    ----------  --------------
+ 31.0.211.25     apn-31-0-211-25.static.gprs.plus.pl                  Poland
+ 46.74.36.255    046074036255.atmpu0002.highway.a1.net        Vienna  Austria
+ 80.251.198.20   80.251.198.20.bredband.3.dk                          Denmark
+ 80.251.198.20   80.251.198.20                                        Denmark
+ 90.117.106.196  90-117-106-196.mobile.abo.orange.fr                  France
+ 90.117.110.29   90-117-110-29.mobile.abo.orange.fr                   France
+ 123.209.125.20  61438337164.mobile.telstra.com               Sydney  Australia
+ 178.182.239.27  178.182.239.27.nat.umts.dynamic.t-mobile.pl          Poland
+ 178.182.244.68  178.182.244.68.nat.umts.dynamic.t-mobile.pl          Poland
+
+[*] Saved results in /tmp/web-test.txt
+[*] Auxiliary module execution completed
+msf6 auxiliary(gather/zoomeye_search) > hosts
+
+Hosts
+=====
+
+address         mac  name                                         os_name  os_flavor  os_sp  purpose  info  comments
+-------         ---  ----                                         -------  ---------  -----  -------  ----  --------
+31.0.211.25          apn-31-0-211-25.static.gprs.plus.pl                                                    Added from Zoomeye
+46.74.36.255         046074036255.atmpu0002.highway.a1.net                                                  Added from Zoomeye
+80.251.198.20        80.251.198.20                                                                          Added from Zoomeye
+90.117.106.196       90-117-106-196.mobile.abo.orange.fr                                                    Added from Zoomeye
+90.117.110.29        90-117-110-29.mobile.abo.orange.fr                                                     Added from Zoomeye
+123.209.125.20       61438337164.mobile.telstra.com                                                         Added from Zoomeye
+178.182.239.27       178.182.239.27.nat.umts.dynamic.t-mobile.pl                                            Added from Zoomeye
+178.182.244.68       178.182.244.68.nat.umts.dynamic.t-mobile.pl                                            Added from Zoomeye
+
+msf6 auxiliary(gather/zoomeye_search) > services
+Services
+========
+
+host  port  proto  name  state  info
+----  ----  -----  ----  -----  ----
+
+msf6 auxiliary(gather/zoomeye_search) > cat /tmp/web-test.txt
+[*] exec: cat /tmp/web-test.txt
+
+Web search
+==========
+
+ IP              Site                                         City    Country    DB:Version  WebApp:Version
+ --              ----                                         ----    -------    ----------  --------------
+ 31.0.211.25     apn-31-0-211-25.static.gprs.plus.pl                  Poland
+ 46.74.36.255    046074036255.atmpu0002.highway.a1.net        Vienna  Austria
+ 80.251.198.20   80.251.198.20.bredband.3.dk                          Denmark
+ 80.251.198.20   80.251.198.20                                        Denmark
+ 90.117.106.196  90-117-106-196.mobile.abo.orange.fr                  France
+ 90.117.110.29   90-117-110-29.mobile.abo.orange.fr                   France
+ 123.209.125.20  61438337164.mobile.telstra.com               Sydney  Australia
+ 178.182.239.27  178.182.239.27.nat.umts.dynamic.t-mobile.pl          Poland
+ 178.182.244.68  178.182.244.68.nat.umts.dynamic.t-mobile.pl          Poland
+msf6 auxiliary(gather/zoomeye_search) >
+```

--- a/modules/auxiliary/gather/zoomeye_search.rb
+++ b/modules/auxiliary/gather/zoomeye_search.rb
@@ -6,44 +6,49 @@
 class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Report
 
-  def initialize(info={})
-    super(update_info(info,
-      'Name'        => 'ZoomEye Search',
-      'Description' => %q{
-        The module use the ZoomEye API to search ZoomEye. ZoomEye is a search
-        engine for cyberspace that lets the user find specific network
-        components(ip, services, etc.).
-        Mind to enclose the whole request with quotes and limit the span of filters:
-        `set zoomeye_dork 'country:"france"+some+query'`
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'ZoomEye Search',
+        'Description' => %q{
+          The module use the ZoomEye API to search ZoomEye. ZoomEye is a search
+          engine for cyberspace that lets the user find specific network
+          components(ip, services, etc.).
+          Mind to enclose the whole request with quotes and limit the span of filters:
+          `set zoomeye_dork 'country:"france"+some+query'`
 
-        Setting facets will output a simple report on the overall search. It's values are:
-        Host search: app, device, service, os, port, country, city
-        Web search: webapp, component, framework, frontend, server, waf, os, country, city
+          Setting facets will output a simple report on the overall search. It's values are:
+          Host search: app, device, service, os, port, country, city
+          Web search: webapp, component, framework, frontend, server, waf, os, country, city
 
-        Possible filters values are:
-        Host search: app, ver, device, os, service, ip, cidr, hostname, port, city, country, asn
-        Web search: app, header, keywords, desc, title, ip, site, city, country
-      },
-      'Author'      => [ 'Nixawk, modified by Yvain' ],
-      'References'  => [
-        ['URL', 'https://github.com/zoomeye/SDK'],
-        ['URL', 'https://www.zoomeye.org/api/doc'],
-        ['URL', 'https://www.zoomeye.org/help/manual']
-      ],
-      'License'     => MSF_LICENSE
-      ))
-      register_options(
-        [
-          OptString.new('USERNAME', [true, 'The ZoomEye username']),
-          OptString.new('PASSWORD', [true, 'The ZoomEye password']),
-          OptString.new('ZOOMEYE_DORK', [true, 'The ZoomEye dork']),
-          OptString.new('FACETS', [false, 'A comma-separated list of properties to get summary information on query', nil]),
-          OptEnum.new('RESOURCE', [true, 'ZoomEye Resource Type', 'host', ['host', 'web']]),
-          OptInt.new('MAXPAGE', [true, 'Max amount of pages to collect', 1]),
-          OptString.new('OUTFILE', [false, 'A filename to store the list of IPs']),
-          OptBool.new('DATABASE', [false, 'Add search results to the database', false])
-       ])
+          Possible filters values are:
+          Host search: app, ver, device, os, service, ip, cidr, hostname, port, city, country, asn
+          Web search: app, header, keywords, desc, title, ip, site, city, country
+        },
+        'Author' => [ 'Nixawk', 'Yvain' ],
+        'References' => [
+          ['URL', 'https://github.com/zoomeye/SDK'],
+          ['URL', 'https://www.zoomeye.org/api/doc'],
+          ['URL', 'https://www.zoomeye.org/help/manual']
+        ],
+        'License' => MSF_LICENSE
+      )
+    )
+    register_options(
+      [
+        OptString.new('USERNAME', [true, 'The ZoomEye username']),
+        OptString.new('PASSWORD', [true, 'The ZoomEye password']),
+        OptString.new('ZOOMEYE_DORK', [true, 'The ZoomEye dork']),
+        OptString.new('FACETS', [false, 'A comma-separated list of properties to get summary information on query', nil]),
+        OptEnum.new('RESOURCE', [true, 'ZoomEye Resource Type', 'host', ['host', 'web']]),
+        OptInt.new('MAXPAGE', [true, 'Max amount of pages to collect', 1]),
+        OptString.new('OUTFILE', [false, 'A filename to store the list of IPs']),
+        OptBool.new('DATABASE', [false, 'Add search results to the database', false])
+      ]
+    )
   end
+
   # save output to file
   def save_output(data)
     ::File.open(datastore['OUTFILE'], 'wb') do |f|
@@ -55,11 +60,11 @@ class MetasploitModule < Msf::Auxiliary
   # Check to see if api.zoomeye.org resolves properly
   def zoomeye_resolvable?
     begin
-      Rex::Socket.resolv_to_dotted("api.zoomeye.org")
+      Rex::Socket.resolv_to_dotted('api.zoomeye.org')
     rescue RuntimeError, SocketError
       return false
     end
-    return true
+    true
   end
 
   def login(username, password)
@@ -69,11 +74,11 @@ class MetasploitModule < Msf::Auxiliary
     @cli = Rex::Proto::Http::Client.new('api.zoomeye.org', 443, {}, true)
     @cli.connect
 
-    data = {'username' => username, 'password' => password}
+    data = { 'username' => username, 'password' => password }
     req = @cli.request_cgi({
-      'uri'    => '/user/login',
+      'uri' => '/user/login',
       'method' => 'POST',
-      'data'   => data.to_json
+      'data' => data.to_json
     })
 
     res = @cli.send_recv(req)
@@ -85,26 +90,25 @@ class MetasploitModule < Msf::Auxiliary
 
     records = ActiveSupport::JSON.decode(res.body)
     access_token = records['access_token'] if records && records.key?('access_token')
-    return access_token
+    access_token
   end
 
   def dork_search(resource, dork, page, facets)
     begin
       req = @cli.request_cgi({
-        'uri'      => "/#{resource}/search",
-        'method'   => 'GET',
-        'headers'  => { 'Authorization' => "JWT #{@zoomeye_token}" },
+        'uri' => "/#{resource}/search",
+        'method' => 'GET',
+        'headers' => { 'Authorization' => "JWT #{@zoomeye_token}" },
         'vars_get' => {
-          'query'  => dork,
-          'page'   => page,
-          'facets'  => facets
+          'query' => dork,
+          'page' => page,
+          'facets' => facets
         }
       })
 
       res = @cli.send_recv(req)
-
     rescue ::Rex::ConnectionError, Errno::ECONNREFUSED, Errno::ETIMEDOUT
-      print_error("HTTP Connection Failed")
+      print_error('HTTP Connection Failed')
     end
 
     unless res
@@ -117,7 +121,7 @@ class MetasploitModule < Msf::Auxiliary
     if res.body =~ /Invalid Token, /
       fail_with(Failure::BadConfig, '401 Unauthorized. Your ZOOMEYE_APIKEY is invalid')
     end
-    return ActiveSupport::JSON.decode(res.body)
+    res.get_json_document
   end
 
   def match_records?(records)
@@ -131,24 +135,25 @@ class MetasploitModule < Msf::Auxiliary
     facets = datastore['FACETS']
     # check to ensure api.zoomeye.org is resolvable
     unless zoomeye_resolvable?
-      print_error("Unable to resolve api.zoomeye.org")
+      print_error('Unable to resolve api.zoomeye.org')
       return
     end
 
     @zoomeye_token = login(datastore['USERNAME'], datastore['PASSWORD'])
     if @zoomeye_token.blank?
-      print_error("Unable to login api.zoomeye.org")
+      print_error('Unable to login api.zoomeye.org')
       return
     else
-      print_status("Logged in to zoomeye")
+      print_status('Logged in to zoomeye')
     end
 
+    first_page = 0
     results = []
-    results[0] = dork_search(resource, dork, 1, facets)
+    results[first_page] = dork_search(resource, dork, 1, facets)
 
-    if results[0]['total'].nil? || results[0]['total'] == 0
-      msg = "No results."
-      if results[0]['error'].to_s.length > 0
+    if results[first_page]['total'].nil? || results[first_page]['total'] == 0
+      msg = 'No results.'
+      if !results[first_page]['error'].to_s.empty?
         msg << " Error: #{results[0]['error']}"
       end
       print_error(msg)
@@ -156,52 +161,57 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     # Determine page count based on total results
-    if results[0]['total'] % 20 == 0
-      tpages = results[0]['total'] / 20
+    if results[first_page]['total'] % 20 == 0
+      tpages = results[first_page]['total'] / 20
     else
-      tpages = results[0]['total'] / 20 + 1
+      tpages = results[first_page]['total'] / 20 + 1
     end
     maxpage = tpages if datastore['MAXPAGE'] > tpages
 
-    print_status("Total: #{results[0]['total']} on #{tpages} " +
-      "pages. Showing: #{maxpage} page(s)")
-
-    # If search results greater than 20, loop & get all results
-    if results[0]['total'] > 20
-      print_status('Collecting data, please wait...')
-      page = 1
-      while page < maxpage
-        page_result = dork_search(resource, dork, page+1, facets)
-        if page_result['matches'].nil?
-          next
+    if facets
+      facets_tbl = Rex::Text::Table.new(
+        'Header' => 'Facets',
+        'Indent' => 1,
+        'Columns' => ['Facet', 'Name', 'Count']
+      )
+      print_status("Total: #{results[first_page]['total']} on #{tpages} " \
+        'pages. Showing facets')
+      facet = results[first_page]['facets']
+      facet.each do |name, list|
+        list.each do |f|
+          facets_tbl << [name.to_s, (f['name']).to_s, (f['count']).to_s]
         end
-        results[page] = page_result
-        page += 1
       end
-    end
-
-    tbl1 = Rex::Text::Table.new(
-      'Header'  => 'Search Results',
-      'Indent'  => 1,
-      'Columns' => ['IP:Port', 'City', 'Country', 'Hostname', 'OS', 'Service:Version', 'Info']
-    )
-    tbl2 = Rex::Text::Table.new(
-      'Header'  => 'Search Results',
-      'Indent'  => 1,
-      'Columns' => ['IP', 'Site', 'City', 'Country', 'DB:Version', 'WebApp:Version']
-    )
-    # scroll max pages from ZoomEye
-    results.each do |page|
-      if facets
-        fcets = page['facets']
-        fcets.each do |fac|
-          print_line("#{fac[0]}")
-          fac[1].each do |f|
-            print_line("#{f['name']} count=#{f['count']}")
+      print_line(facets_tbl.to_s)
+    else
+      print_status("Total: #{results[first_page]['total']} on #{tpages} " \
+        "pages. Showing: #{maxpage} page(s)")
+      # If search results greater than 20, loop & get all results
+      if results[first_page]['total'] > 20
+        print_status('Collecting data, please wait...')
+        page = 1
+        while page < maxpage
+          page_result = dork_search(resource, dork, page + 1, facets)
+          if page_result['matches'].nil?
+            next
           end
+          results[page] = page_result
+          page += 1
         end
-      else
-        page['matches'].each do |match|
+      end
+      tbl1 = Rex::Text::Table.new(
+        'Header' => 'Host search',
+        'Indent' => 1,
+        'Columns' => ['IP:Port', 'City', 'Country', 'Hostname', 'OS', 'Service:Version', 'Info']
+      )
+      tbl2 = Rex::Text::Table.new(
+        'Header' => 'Web search',
+        'Indent' => 1,
+        'Columns' => ['IP', 'Site', 'City', 'Country', 'DB:Version', 'WebApp:Version']
+      )
+      # scroll max pages from ZoomEye
+      results.each do |result|
+        result['matches'].each do |match|
           city = match['geoinfo']['city']['names']['en']
           country = match['geoinfo']['country']['names']['en']
           if resource.include?('host')
@@ -213,53 +223,41 @@ class MetasploitModule < Msf::Auxiliary
             name = match['portinfo']['name']
             version = match['portinfo']['version']
             info = match['portinfo']['extrainfo']
-            report_host(:host     => ip,
-                        :name     => hostname,
-                        :os_name  => os,
-                        :comments => 'Added from Zoomeye'
-                        ) if datastore['DATABASE']
-            report_service(:host => ip,
-                           :port => port,
-                           :proto => name,
-                           :name => "#{service}:#{version}",
-                           :info => info
-                           ) if datastore['DATABASE']
+            if datastore['DATABASE']
+              report_host(host: ip,
+                          name: hostname,
+                          os_name: os,
+                          comments: 'Added from Zoomeye')
+            end
+            if datastore['DATABASE']
+              report_service(host: ip,
+                             port: port,
+                             proto: name,
+                             name: "#{service}:#{version}",
+                             info: info)
+            end
             tbl1 << ["#{ip}:#{port}", city, country, hostname, os, "#{service}:#{version}", info]
           else
             ips = match['ip']
-            ipList = ''
-            ips.each do |ip|
-              ipList << "#{ip}\n"
-            end
             site = match['site']
             database = match['db']
-            dbInfo = ''
-            database.each do |db|
-              dbInfo << "#{db['name']}:"
-              dbInfo << "#{db['version']}\n"
-            end
+            db_info = database.map { |db| "#{db['name']}:#{db['version']}" }
             webapp = match['webapp']
-            waInfo = ''
-            webapp.each do |wa|
-              waInfo << "#{wa['name']}:"
-              waInfo << "#{wa['version']}\n"
+            wa_info = webapp.map { |wa| "#{wa['name']}:#{wa['version']}" }
+            if datastore['DATABASE']
+              report_host(host: ip,
+                          name: site,
+                          comments: 'Added from Zoomeye')
             end
-            report_host(:host     => ip,
-                        :name     => site,
-                        :comments => 'Added from Zoomeye'
-                        ) if datastore['DATABASE']
-            tbl2 << [ipList, site, city, country, dbInfo, waInfo]
+            tbl2 << [ips, site, city, country, db_info, wa_info]
           end
         end
       end
-      if facets
-        return
-      end
       if resource.include?('host')
-        print_line("#{tbl1}")
+        print_line(tbl1.to_s)
         save_output(tbl1) if datastore['OUTFILE']
       else
-        print_line("#{tbl2}")
+        print_line(tbl2.to_s)
         save_output(tbl2) if datastore['OUTFILE']
       end
     end

--- a/modules/auxiliary/gather/zoomeye_search.rb
+++ b/modules/auxiliary/gather/zoomeye_search.rb
@@ -43,7 +43,7 @@ class MetasploitModule < Msf::Auxiliary
         OptString.new('FACETS', [false, 'A comma-separated list of properties to get summary information on query', nil]),
         OptEnum.new('RESOURCE', [true, 'ZoomEye Resource Type', 'host', ['host', 'web']]),
         OptInt.new('MAXPAGE', [true, 'Max amount of pages to collect', 1]),
-        OptString.new('OUTFILE', [false, 'A filename to store the list of IPs']),
+        OptString.new('OUTFILE', [false, 'Path to the file to store the resulting table of info']),
         OptBool.new('DATABASE', [false, 'Add search results to the database', false])
       ]
     )
@@ -154,7 +154,7 @@ class MetasploitModule < Msf::Auxiliary
     if results[first_page]['total'].nil? || results[first_page]['total'] == 0
       msg = 'No results.'
       if !results[first_page]['error'].to_s.empty?
-        msg << " Error: #{results[0]['error']}"
+        msg << " Error: #{results[first_page]['error']}"
       end
       print_error(msg)
       return

--- a/modules/auxiliary/gather/zoomeye_search.rb
+++ b/modules/auxiliary/gather/zoomeye_search.rb
@@ -29,7 +29,7 @@ class MetasploitModule < Msf::Auxiliary
         'Author' => [
           'Nixawk', # Original Author
           'Yvain', # Initial improvements
-          'Grant Willcox' # Additional fixes to refine searches, fix broken functionality, and improve quality of info saved
+          'Grant Willcox' # Additional fixes to refine searches, improve quality of info saved and improve error handling.
         ],
         'References' => [
           ['URL', 'https://github.com/zoomeye/SDK'],
@@ -211,7 +211,7 @@ class MetasploitModule < Msf::Auxiliary
       tbl1 = Rex::Text::Table.new(
         'Header' => 'Host search',
         'Indent' => 1,
-        'Columns' => ['IP:Port', 'Protocol', 'City', 'Country', 'Hostname', 'OS', 'service', 'AppName', 'Version', 'Info']
+        'Columns' => ['IP:Port', 'Protocol', 'City', 'Country', 'Hostname', 'OS', 'Service', 'AppName', 'Version', 'Info']
       )
       tbl2 = Rex::Text::Table.new(
         'Header' => 'Web search',
@@ -252,17 +252,36 @@ class MetasploitModule < Msf::Auxiliary
             ips = match['ip']
             site = match['site']
             database = match['db']
-            db_info = database.map { |db| "#{db['name']}:#{db['version']}" }
+            if database.empty?
+              db_info = ""
+            else
+              db_info = database.map { |db|
+                if !db['name']&.empty? && !db['version']&.empty?
+                  "#{db['name']}:#{db['version']}"
+                else
+                  ""
+                end
+              }
+            end
             webapp = match['webapp']
-            wa_info = webapp.map { |wa| "#{wa['name']}:#{wa['version']}" }
+            if webapp.empty?
+              wa_info = ""
+            else
+              wa_info = webapp.map { |wa|
+                if !wa['name']&.empty? && !wa['version']&.empty?
+                  "#{wa['name']}:#{wa['version']}"
+                else
+                  ""
+                end
+              }
+            end
             if datastore['DATABASE']
               for ip in ips
                 report_host(host: ip, name: site, comments: 'Added from Zoomeye')
               end
-            else
-              for ip in ips
+            end
+            for ip in ips
                 tbl2 << [ip, site, city, country, db_info, wa_info]
-              end
             end
           end
         end

--- a/modules/auxiliary/gather/zoomeye_search.rb
+++ b/modules/auxiliary/gather/zoomeye_search.rb
@@ -3,11 +3,8 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-
-
 class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Report
-
 
   def initialize(info={})
     super(update_info(info,
@@ -31,9 +28,12 @@ class MetasploitModule < Msf::Auxiliary
           OptString.new('USERNAME', [true, 'The ZoomEye username']),
           OptString.new('PASSWORD', [true, 'The ZoomEye password']),
           OptString.new('ZOOMEYE_DORK', [true, 'The ZoomEye dork']),
+          OptString.new('FACETS', [false, 'A comma-separated list of properties to get summary information on query', nil, ['app', 'device', 'service', 'os', 'port', 'country', 'city']]),
           OptEnum.new('RESOURCE', [true, 'ZoomEye Resource Type', 'host', ['host', 'web']]),
-          OptInt.new('MAXPAGE', [true, 'Max amount of pages to collect', 1])
-        ])
+          OptInt.new('MAXPAGE', [true, 'Max amount of pages to collect', 1]),
+          OptString.new('OUTFILE', [false, 'A filename to store the list of IPs']),
+          OptBool.new('DATABASE', [false, 'Add search results to the database', false])
+       ])
   end
 
   # Check to see if api.zoomeye.org resolves properly
@@ -43,8 +43,7 @@ class MetasploitModule < Msf::Auxiliary
     rescue RuntimeError, SocketError
       return false
     end
-
-    true
+    return true
   end
 
   def login(username, password)
@@ -73,7 +72,7 @@ class MetasploitModule < Msf::Auxiliary
     access_token
   end
 
-  def dork_search(dork, resource, page)
+  def dork_search(resource, dork, page, facets)
     # param: dork
     #        ex: country:cn
     #        access https://www.zoomeye.org/search/dorks for more details.
@@ -93,7 +92,7 @@ class MetasploitModule < Msf::Auxiliary
         'vars_get' => {
           'query'  => dork,
           'page'   => page,
-          'facet'  => 'ip'
+          'facet'  => facets
         }
       })
 
@@ -121,27 +120,11 @@ class MetasploitModule < Msf::Auxiliary
     records && records.key?('matches')
   end
 
-  def parse_host_records(records)
-    records.each do |match|
-      host = match['ip']
-      port = match['portinfo']['port']
-
-      report_service(:host => host, :port => port)
-      print_good("Host: #{host} ,PORT: #{port}")
-    end
-  end
-
-  def parse_web_records(records)
-    records.each do |match|
-      host = match['ip'][0]
-      domains = match['domains']
-
-      report_host(:host => host)
-      print_good("Host: #{host}, Domains: #{domains}")
-    end
-  end
-
   def run
+    dork = datastore['ZOOMEYE_DORK']
+    resource = datastore['RESOURCE']
+    maxpage = datastore['MAXPAGE']
+    facets = datastore['FACETS']
     # check to ensure api.zoomeye.org is resolvable
     unless zoomeye_resolvable?
       print_error("Unable to resolve api.zoomeye.org")
@@ -154,25 +137,115 @@ class MetasploitModule < Msf::Auxiliary
       return
     end
 
-    # create ZoomEye request parameters
-    dork = datastore['ZOOMEYE_DORK']
-    resource = datastore['RESOURCE']
-    page = 1
-    maxpage = datastore['MAXPAGE']
+    results = []
+    results[0] = dork_search(resource, dork, 1, facets)
 
+    if results[0]['total'].nil? || results[0]['total'] == 0
+      msg = "No results."
+      if results[0]['error'].to_s.length > 0
+        msg << " Error: #{results[0]['error']}"
+      end
+      print_error(msg)
+      return
+    end
+
+    # Determine page count based on total results
+    if results[0]['total'] % 20 == 0
+      tpages = results[0]['total'] / 20
+    else
+      tpages = results[0]['total'] / 20 + 1
+    end
+    maxpage = tpages if datastore['MAXPAGE'] > tpages
+
+    print_status("Total: #{results[0]['total']} on #{tpages} " +
+      "pages. Showing: #{maxpage} page(s)")
+
+    # If search results greater than 100, loop & get all results
+    if results[0]['total'] > 20
+      print_status('Collecting data, please wait...')
+      page = 1
+      while page < maxpage
+        page_result = dork_search(resource, dork, page, facets)
+        if page_result['matches'].nil?
+          next
+        end
+        results[page] = page_result
+        page += 1
+      end
+    end
+
+    tbl1 = Rex::Text::Table.new(
+      'Header'  => 'Search Results',
+      'Indent'  => 1,
+      'Columns' => ['IP:Port', 'City', 'Country', 'Hostname', 'OS', 'Service:Version', 'Info']
+    )
+    tbl2 = Rex::Text::Table.new(
+      'Header'  => 'Search Results',
+      'Indent'  => 1,
+      'Columns' => ['IP', 'Site', 'City', 'Country', 'DB:Version', 'WebApp:Version']
+    )
+    page = 0
     # scroll max pages from ZoomEye
-    while page <= maxpage
-      print_status("ZoomEye #{resource} Search: #{dork} - page: #{page}")
-      results = dork_search(dork, resource, page) if dork
-      break unless match_records?(results)
-
-      matches = results['matches']
-      if resource.include?('web')
-        parse_web_records(matches)
-      else
-        parse_host_records(matches)
+    while page < maxpage
+      results.each do |records|
+        if resource.include?('host')
+          records['matches'].each do |match|
+            ip = match['ip']
+            port = match['portinfo']['port']
+            city = match['geoinfo']['city']['names']['en']
+            country = match['geoinfo']['country']['names']['en']
+            hostname = match['portinfo']['hostname']
+            os = match['portinfo']['os']
+            service = match['portinfo']['app']
+            version = match['portinfo']['version']
+            info = match['portinfo']['extrainfo']
+            report_host(:host     => ip,
+                        :name     => hostname,
+                        :os_name  => os,
+                        :comments => 'Added from Zoomeye'
+                        ) if datastore['DATABASE']
+            report_service(:host => ip,
+                           :port => port,
+                           :name => "#{service}:#{version}",
+                           :info => info
+                           ) if datastore['DATABASE']
+            tbl1 << ["#{ip}:#{port}", city, country, hostname, os, "#{service}:#{version}", info]
+          end
+        elsif resource.include?('web')
+          records['matches'].each do |match|
+            ip = match['ip']
+            site = match['site']
+            city = match['geoinfo']['city']['names']['en']
+            country = match['geoinfo']['country']['names']['en']
+            database = match['db']
+            dbInfo = ''
+            database.each do |db|
+              dbInfo << "#{db['name']}:"
+              dbInfo << "#{db['version']}\n"
+            end
+            webapp = match['webapp']
+            waInfo = ''
+            webapp.each do |wa|
+              waInfo << "#{wa['name']}:"
+              waInfo << "#{wa['version']}\n"
+            end
+            report_host(:host     => ip,
+                        :name     => site,
+                        :comments => 'Added from Zoomeye'
+                        ) if datastore['DATABASE']
+            tbl2 << [ip, site, city, country, dbInfo, waInfo]
+          end
+        end
       end
       page += 1
+    end
+    print_line()
+    if resource.include?('host')
+      print_line("#{tbl1}")
+      save_output(tbl1) if datastore['OUTFILE']
+    elsif resource.include?('web')
+      print_line("#{tbl2}")
+      save_output(tbl2) if datastore['OUTFILE']
     end
   end
 end

--- a/modules/auxiliary/gather/zoomeye_search.rb
+++ b/modules/auxiliary/gather/zoomeye_search.rb
@@ -182,7 +182,6 @@ class MetasploitModule < Msf::Auxiliary
           facets_tbl << [name.to_s, (f['name']).to_s, (f['count']).to_s]
         end
       end
-      print_line(facets_tbl.to_s)
     else
       print_status("Total: #{results[first_page]['total']} on #{tpages} " \
         "pages. Showing: #{maxpage} page(s)")
@@ -220,9 +219,8 @@ class MetasploitModule < Msf::Auxiliary
             hostname = match['portinfo']['hostname']
             os = match['portinfo']['os']
             service = match['portinfo']['app']
-            name = match['portinfo']['name']
             version = match['portinfo']['version']
-            info = match['portinfo']['extrainfo']
+            info = match['portinfo']['info']
             if datastore['DATABASE']
               report_host(host: ip,
                           name: hostname,
@@ -232,7 +230,6 @@ class MetasploitModule < Msf::Auxiliary
             if datastore['DATABASE']
               report_service(host: ip,
                              port: port,
-                             proto: name,
                              name: "#{service}:#{version}",
                              info: info)
             end
@@ -260,6 +257,10 @@ class MetasploitModule < Msf::Auxiliary
         print_line(tbl2.to_s)
         save_output(tbl2) if datastore['OUTFILE']
       end
+    end
+    if datastore['FACETS']
+      print_line(facets_tbl.to_s)
+      save_output(facets_tbl) if datastore['OUTFILE']
     end
   end
 end


### PR DESCRIPTION
This does enhance the zoomeye search module:
Added the option OUTFILE and DATABASE to be able to choose being only printing or also saving.
The results added in the database are a little bit more comprehensive than the original module, but the real enhancement is with the standard output (that would be saved when using outfile), depending on the resource type, either the focus is made on the webapps and database, or on the running services. In both cases we get the localisation (Country, City).

I heavily copied code from the modified shodan module #15267, so that the protocol is quite the same: we get the first page, with the total we count pages, clamp max pages, and will make sure that all the pages are fetched before parsing the results.
The facets parameter was set to 'ip' which is not a recognized facet, and was not parsed. Now with the FACETS option set, the output will just be from the page['facets'] and not page['matches'], since the matches are yielding complete results, while facets being only a synopsis.
