### PR TITLE
Fix a typo in a Meterpreter command requirement

### DIFF
--- a/lib/msf/core/post/windows/mssql.rb
+++ b/lib/msf/core/post/windows/mssql.rb
@@ -15,7 +15,7 @@ module Msf
           super(update_info(
             info,
             'Compat' => { 'Meterpreter' => { 'Commands' => %w{
-              core_migrate sys_config_getprivs stdapi_sys_config_getuid stdapi_sys_process_* incognito_impersonate_token priv_elevate_getsystem
+              core_migrate stdapi_sys_config_getprivs stdapi_sys_config_getuid stdapi_sys_process_* incognito_impersonate_token priv_elevate_getsystem
             } } }
           ))
         end


### PR DESCRIPTION
This fixes a typo in a required Meterpreter command that is defined for compatibility purposes.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] Open a Windows Meterpreter session (`windows/meterpreter/*` or `windows/x64/meterpreter/*`)
- [ ] Run the `post/windows/gather/credentials/mssql_local_hashdump`
- [ ] Do not see a RuntimeError stating that there were Meterpreter command wildcards that didn't match anything
- [ ] See the module run, it may fail but the module logic should at least start without a Runtime Error

cc: @jmartin-r7 