### PR TITLE
Stop raising a RuntimeError for invalid Meterpreter command wildcards

### DIFF
--- a/lib/msf/core/post_mixin.rb
+++ b/lib/msf/core/post_mixin.rb
@@ -207,7 +207,6 @@ module Msf::PostMixin
       unless unmatched_wildcards.empty?
         # This implies that there was a typo in one of the wildcards because it didn't match anything. This is a developer mistake.
         wlog("The #{fullname} module specified the following Meterpreter command wildcards that did not match anything: #{ unmatched_wildcards.join(', ') }")
-        raise RuntimeError, 'one or more of the specified Meterpreter command wildcards did not match anything'
       end
 
       cmd_ids = cmd_names.map { |name| Rex::Post::Meterpreter::CommandMapper.get_command_id(name) }


### PR DESCRIPTION
This removes an exception that would be raised when a Meterpreter command that was specified for compatibility purposes was itself incorrect. This was intended to make it easy for developers to identify their mistakes (typos) more quickly but is intrusive.

Removing it doesn't hurt anything. At worst a command that the developer intended to be identified as a requirement won't be checked for compatibility. This could lead to a module running with a session where it's incompatible, but the issue of the requirement itself being incorrect still needs to be addressed.

## Verification

- [ ] Start `msfconsole`
- [ ] Edit a post mixin or module, add an invalid command as a requirement, something like `doesnotexist*`
- [ ] Attempt to use the post module or a post module that uses the edited mixin.
- [ ] **Verify** a message is still logged to the framework log
- [ ] **Verify** no runtime error is raised that the command is invalid

cc: @jmartin-r7