### PR TITLE
Remove Invalid Import Causing Crashes From FortiOS SSL VPN Credential Leak Module

### DIFF
--- a/modules/auxiliary/gather/fortios_vpnssl_traversal_creds_leak.rb
+++ b/modules/auxiliary/gather/fortios_vpnssl_traversal_creds_leak.rb
@@ -9,7 +9,6 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Report
   include Msf::Auxiliary::Scanner
   include Msf::Exploit::Remote::HttpClient
-  include Msf::Post::File
 
   def initialize(info = {})
     super(
@@ -112,6 +111,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def report_creds(creds)
+
     creds.each do |cred|
       cred = cred.gsub('"', '').gsub(/[{}:]/, '').split(', ')
       cred = cred.map do |h|

--- a/modules/auxiliary/gather/fortios_vpnssl_traversal_creds_leak.rb
+++ b/modules/auxiliary/gather/fortios_vpnssl_traversal_creds_leak.rb
@@ -111,7 +111,6 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def report_creds(creds)
-
     creds.each do |cred|
       cred = cred.gsub('"', '').gsub(/[{}:]/, '').split(', ')
       cred = cred.map do |h|


### PR DESCRIPTION
Removes the invalid `Msf::Post::File` import that wasn't being used from this exploit as it causes crashes due to the `session` variable not existing (since this isn't a post exploitation module).

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use auxiliary/gather/fortios_vpnssl_traversal_creds_leak`
- [ ] `set RHOSTS *ip*`
- [ ] `check`
- [ ] **Verify** that the module now states that it doesn't support the `check` method instead of crashing.
- [ ] `run`
- [ ] **Verify** that the module now operates correctly instead of crashing with a message about the undefined local variable `session`.

Please note for the purpose of testing this PR you don't need a FortiOS host, any old web server or even just a netcat listener will do.

CC @mekhalleh for reference since this module is his work and it may be good to retest this on an actual FortiOS host just to double check things.
