### PR TITLE
Redis extractor improvements

### DIFF
--- a/documentation/modules/auxiliary/gather/redis_extractor.md
+++ b/documentation/modules/auxiliary/gather/redis_extractor.md
@@ -39,6 +39,10 @@ echo 'auth abcde \n set key2 value2' | nc 127.0.0.1 6379 > /dev/null
 
 The password for the redis instance. This value will be ignored for instances with no password required.
 
+### **LIMITCOUNT**
+
+Stop after retrieving this number of keys, per datastore. Note that one redis instance may have more than one datastore. This modules also pulls values down in batches, so it may go slightly over this limit.
+
 ## Scenarios
 
 ### Check 

--- a/modules/auxiliary/gather/redis_extractor.rb
+++ b/modules/auxiliary/gather/redis_extractor.rb
@@ -19,6 +19,11 @@ class MetasploitModule < Msf::Auxiliary
         'References' => [['URL', 'https://redis.io/topics/protocol']]
       )
     )
+    register_options(
+      [
+        OptInt.new('LimitCount', [false, 'Stop after retrieving this many entries, per database', nil])
+      ]
+    )
   end
 
   MIN_REDIS_VERSION = '2.8.0'.freeze
@@ -33,34 +38,52 @@ class MetasploitModule < Msf::Auxiliary
     keys = parsed[1]
     results = []
     keys.each do |key|
-      results.push([key, value_for_key(key)])
+      value = value_for_key(key)
+      if value
+        results.push([key, value])
+      end
     end
     [new_offset, results]
   end
 
   def value_for_key(key)
     key_type = redis_command('TYPE', key)
+    return unless key_type
+
     key_type = parse_redis_response(key_type)
     case key_type
     when 'string'
       string_content = redis_command('get', key)
+      return unless string_content
+
       return parse_redis_response(string_content)
     when 'list'
       list_content = redis_command('LRANGE', key, '0', '-1')
+      return unless list_content
+
       return parse_redis_response(list_content)
     when 'set'
       set_content = redis_command('SMEMBERS', key)
+      return unless set_content
+
       return parse_redis_response(set_content)
     when 'zset'
       set_content = redis_command('ZRANGE', key, '0', '-1')
+      return unless set_content
+
       return parse_redis_response(set_content)
     when 'hash'
       hash_content = parse_redis_response(redis_command('HGETALL', key))
+      return unless hash_content
+
       result = {}
       (0..hash_content.length - 1).step(2) do |x|
         result[hash_content[x]] = hash_content[x + 1]
       end
       return result
+    when 'none'
+      # May have been deleted in the interim
+      return nil
     else
       return 'unknown key type ' + key_type
     end
@@ -142,14 +165,21 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     keyspace = get_keyspace
+    max_results = datastore['LimitCount']
     keyspace.each do |space|
-      print_status("Extracting about #{space[1]} keys from database #{space[0]}")
+      if max_results
+        amount = "#{[space[1].to_i, max_results].min} of #{space[1]}"
+      else
+        amount = (space[1]).to_s
+      end
+      print_status("Extracting about #{amount} keys from database #{space[0]}")
       redis_command('SELECT', space[0])
       new_offset = '0'
       all_results = []
       loop do
         new_offset, results = scan(new_offset)
         all_results.concat(results)
+        break if max_results && all_results.count >= max_results
         break if new_offset == '0'
       end
 


### PR DESCRIPTION
Fixed two bugs in the `redis_extractor` module:

- Long string values were truncated because the network didn't pull enough data, so parsing failed
- There was a race condition if a value was deleted between a scan and retrieval of its value.

Also now support retrieving a subset of keys (I was finding some redis instances had thousands of keys and I only needed a dozen or so).


## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use auxiliary/gather/redis_extractor`
- [x] Verify long value bugfix
- [x] Verify race condition bugfix
- [x] Verify limit of entry retrieval works as expected

Steps to reproduce for the issue with a long string value:

```
import redis
r = redis.Redis(host='localhost', port=6379, db=0)
r.hset('dict_key',mapping={'k':'v','k2':'v'*20000})
```

Before:

```
msf6 auxiliary(gather/redis_extractor) > run                                                                                                                                                                                         
                                                                                                                                                                                                                                     
[+] 192.168.1.1:6379  - Connected to Redis version 6.2.2                                                                                                                                                                         
[*] 192.168.1.1:6379  - Extracting about 3 keys from database 0                                                                                                                                                                  
[-] 192.168.1.1:6379  - Auxiliary failed: NoMethodError undefined method `[]' for nil:NilClass                                                                                                                                   
[-] 192.168.1.1:6379  - Call stack:                                                                                                                                                                                              
[-] 192.168.1.1:6379  -   /home/smash/git/metasploit-framework/lib/msf/core/auxiliary/redis.rb:164:in `parse_next'                                                                                                               
[-] 192.168.1.1:6379  -   /home/smash/git/metasploit-framework/lib/msf/core/auxiliary/redis.rb:135:in `block in parse_resp_array'                                                                                                
[-] 192.168.1.1:6379  -   /home/smash/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/activesupport-5.2.6/lib/active_support/core_ext/range/each.rb:9:in `each'                                                                   
[-] 192.168.1.1:6379  -   /home/smash/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/activesupport-5.2.6/lib/active_support/core_ext/range/each.rb:9:in `each'                                                                   
[-] 192.168.1.1:6379  -   /home/smash/git/metasploit-framework/lib/msf/core/auxiliary/redis.rb:134:in `parse_resp_array'                                                                                                         
[-] 192.168.1.1:6379  -   /home/smash/git/metasploit-framework/lib/msf/core/auxiliary/redis.rb:166:in `parse_next'                                                                                                               
[-] 192.168.1.1:6379  -   /home/smash/git/metasploit-framework/lib/msf/core/auxiliary/redis.rb:117:in `parse'                                                                                                                    
[-] 192.168.1.1:6379  -   /home/smash/git/metasploit-framework/lib/msf/core/auxiliary/redis.rb:81:in `parse_redis_response'                                                                                                      
[-] 192.168.1.1:6379  -   /home/smash/git/metasploit-framework/modules/auxiliary/gather/redis_extractor.rb:58:in `value_for_key'                                                                                                 
[-] 192.168.1.1:6379  -   /home/smash/git/metasploit-framework/modules/auxiliary/gather/redis_extractor.rb:36:in `block in scan'                                                                                                 
[-] 192.168.1.1:6379  -   /home/smash/git/metasploit-framework/modules/auxiliary/gather/redis_extractor.rb:35:in `each'                                                                                                          
[-] 192.168.1.1:6379  -   /home/smash/git/metasploit-framework/modules/auxiliary/gather/redis_extractor.rb:35:in `scan'                                                                                                          
[-] 192.168.1.1:6379  -   /home/smash/git/metasploit-framework/modules/auxiliary/gather/redis_extractor.rb:151:in `block (2 levels) in run_host'                                                                                 
[-] 192.168.1.1:6379  -   /home/smash/git/metasploit-framework/modules/auxiliary/gather/redis_extractor.rb:150:in `loop'                                                                                                         
[-] 192.168.1.1:6379  -   /home/smash/git/metasploit-framework/modules/auxiliary/gather/redis_extractor.rb:150:in `block in run_host'                                                                                            
[-] 192.168.1.1:6379  -   /home/smash/git/metasploit-framework/modules/auxiliary/gather/redis_extractor.rb:145:in `each'                                                                                                         
[-] 192.168.1.1:6379  -   /home/smash/git/metasploit-framework/modules/auxiliary/gather/redis_extractor.rb:145:in `run_host'                                                                                                     
[-] 192.168.1.1:6379  -   /home/smash/git/metasploit-framework/lib/msf/core/auxiliary/scanner.rb:121:in `block (2 levels) in run'                                                                                                
[-] 192.168.1.1:6379  -   /home/smash/git/metasploit-framework/lib/msf/core/thread_manager.rb:105:in `block in spawn'                                                                                                            
[*] Auxiliary module execution completed
```

After:

```
msf6 auxiliary(gather/redis_extractor) > run                                                                                                                                                                                [53/1902]
                                                                                                                                                                                                                                     
[+] 192.168.1.1:6379  - Connected to Redis version 6.2.2                                                                                                                                                                         
[*] 192.168.1.1:6379  - Extracting about 1 keys from database 0                                                                                                                                                                  
                                                                                                                                                                                                                                     
Data from 192.168.1.1:6379  database 0                                                                                                                                                                                           
==========================================                                                                                                                                                                                           
                                                                                                                                                                                                                                     
 Key       Value                                                                                                                                                                                                                     
 ---       -----                                                                                                                                                                                                                     
 dict_key  {"k2"=>"vvvvv...vv", "k"=>"v"}                                                                    
                                                                                                                                                                                                                                     
[+] 192.168.1.1:6379  - Redis data stored at /home/smash/.msf4/loot/20210603110805_default_192.168.1.1_redis.dump_db0_219319.txt                                                                                           
[*] 192.168.1.1:6379  - Scanned 1 of 1 hosts (100% complete)                                                                                                                                                                     
[*] Auxiliary module execution completed
```

Steps to reproduce for race condition:

```
while True:
  for k in 'abcdefghijklmnop':
    r.set(k,k)
  r.flushall()
```

That caused all sorts of crashes. Seem to be good now.