### PR TITLE
Add Rubocop rule to enforce Meterpreter command requirements in modules

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -44,7 +44,7 @@ jobs:
           --health-retries 5
 
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         ruby:
           - 2.5

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,6 +21,7 @@ require:
   - ./lib/rubocop/cop/lint/module_disclosure_date_present.rb
   - ./lib/rubocop/cop/lint/deprecated_gem_version.rb
   - ./lib/rubocop/cop/lint/module_enforce_notes.rb
+  - ./lib/rubocop/cop/lint/meterpreter_commands_dependencies.rb
 
 Layout/SpaceBeforeBrackets:
   Description: >-
@@ -150,6 +151,18 @@ Layout/ModuleHashOnNewLine:
 
 Layout/ModuleDescriptionIndentation:
   Enabled: true
+
+Lint/MeterpreterCommandDependencies:
+  Enabled: true
+  Exclude:
+    - 'lib/rex/post/meterpreter/client_core.rb'
+    - 'lib/rex/post/meterpreter/extensions/priv/priv.rb'
+    - 'lib/rex/post/meterpreter/extensions/stdapi/fs/dir.rb'
+    - 'lib/rex/post/meterpreter/extensions/stdapi/sys/process.rb'
+    - 'lib/rex/post/meterpreter/extensions/stdapi/ui.rb'
+    - 'lib/rex/post/meterpreter/extensions/stdapi/webcam/webcam.rb'
+    - 'lib/rex/post/meterpreter/ui/console/command_dispatcher/*'
+    - 'lib/rex/ui/text/shell.rb'
 
 Lint/ModuleDisclosureDateFormat:
   Enabled: true

--- a/lib/rubocop/cop/lint/meterpreter_commands_dependencies.rb
+++ b/lib/rubocop/cop/lint/meterpreter_commands_dependencies.rb
@@ -1,0 +1,1167 @@
+require 'rex/post/meterpreter/command_mapper'
+
+module RuboCop
+  module Cop
+    module Lint
+      class MeterpreterCommandDependencies < Base
+        extend AutoCorrector
+        include Alignment
+
+        MSG = 'Convert meterpreter api calls into meterpreter command dependencies.'.freeze
+        MISSING_METHOD_CALL_FOR_COMMAND_MSG = 'Compatibility command does not have an associated method call.'.freeze
+        COMMAND_DUPLICATED_MSG = 'Command duplicated.'.freeze
+
+        CLIENT_OR_SESSION = '{(lvar {:session :client}) (send nil? {:session :client})}'.freeze
+        # Since a created process can have any name, match on anything
+        PROCESS = '{(lvar _) (send nil? _)}'.freeze
+
+        # Matchers for identifying what is current present in each module, so we can append required section at a later point
+        def_node_matcher :find_nested_update_info_node, <<~PATTERN
+          (def :initialize _args (begin (super (send nil? {:update_info :merge_info} (lvar :info) $(hash ...))) ...))
+        PATTERN
+
+        def_node_matcher :find_update_info_node, <<~PATTERN
+          (def :initialize _args (super (send nil? {:update_info :merge_info} (lvar :info) $(hash ...)) ...))
+        PATTERN
+
+        def_node_matcher :find_nested_info_node, <<~PATTERN
+          (def :initialize _args (super $(hash ...) ...))
+        PATTERN
+
+        def_node_matcher :find_info_node, <<~PATTERN
+          (def :initialize _args (begin (super $(hash ...)) ...))
+        PATTERN
+
+        def_node_matcher :find_command_array_node, <<~PATTERN
+          (hash (pair (str "Commands") $(array ...)))
+        PATTERN
+
+        def_node_matcher :initialize_present?, <<~PATTERN
+          (def :initialize __)
+        PATTERN
+
+        def_node_matcher :super_present?, <<~PATTERN
+          (begin (zsuper) ...)
+        PATTERN
+
+        class StackFrame
+          # Keeps track of nodes of interest
+          attr_accessor :nodes
+          # Keeps track of the visiting state, i.e. what we'll do next when we visit particular nodes
+          attr_accessor :visiting_state
+
+          # The list of commands identified in this stack frame
+          attr_accessor :identified_commands
+
+          def initialize
+            @nodes = {}
+            @visiting_state = :none
+            @identified_commands = []
+          end
+
+          # The currently registered commands
+          def current_commands
+            commands = []
+            return commands unless nodes[:commands_node]
+
+            nodes[:commands_node].value.each_child_node do |command|
+              commands << command.value
+            end
+
+            commands
+          end
+        end
+
+        def on_module(node)
+          enter_frame(node)
+        end
+
+        def after_module(node)
+          leave_frame(node)
+        end
+
+        def on_class(node)
+          enter_frame(node)
+        end
+
+        def after_class(node)
+          leave_frame(node)
+        end
+
+        # Allows us to handle scenarios of a module having multiple classes or modules present
+        def enter_frame(node)
+          # Frames can't be nested
+          if @current_frame
+            return
+          end
+
+          @current_frame = StackFrame.new
+          nodes[:investigated_node] = node
+        end
+
+        def subtract_arrays_and_leave_duplicates(first, second)
+          result = first.clone
+          second.each do |value|
+            index = result.index(value)
+            if index
+              result.delete_at(index)
+            end
+          end
+          result
+        end
+
+        def leave_frame(node)
+          unless nodes[:investigated_node] == node
+            return
+          end
+
+          # Ensure commands are sorted and unique
+          @current_frame.identified_commands = @current_frame.identified_commands.uniq.sort
+
+          # Calculate invalid values, but leave duplicates around so that they can be highlighted as being invalid
+          invalid_current_commands = subtract_arrays_and_leave_duplicates(@current_frame.current_commands, @current_frame.identified_commands)
+          if invalid_current_commands.any? && nodes[:commands_node]
+            nodes[:commands_node].value.each_child_node do |command_node|
+              command = command_node.source
+              is_missing_call = !@current_frame.identified_commands.include?(command)
+              has_duplicate_calls = (
+                @current_frame.current_commands.select { |c| c == command }.count > 1
+              )
+              if is_missing_call
+                add_offense(command_node, message: MISSING_METHOD_CALL_FOR_COMMAND_MSG)
+              elsif has_duplicate_calls
+                add_offense(command_node, message: COMMAND_DUPLICATED_MSG)
+              end
+            end
+          end
+
+          if @current_frame.identified_commands.empty? && invalid_current_commands.empty?
+            @current_frame = nil
+            return
+          elsif nodes[:compat_node] && nodes[:meterpreter_node] && nodes[:commands_node] && @current_frame.identified_commands == @current_frame.current_commands
+            # Happy path
+            @current_frame = nil
+            return
+          elsif nodes[:compat_node] && nodes[:meterpreter_node] && nodes[:commands_node] && @current_frame.identified_commands != @current_frame.current_commands
+            add_offense(nodes[:commands_node], &autocorrector)
+          elsif nodes[:compat_node] && nodes[:meterpreter_node] && nodes[:commands_node].nil?
+            add_offense(nodes[:meterpreter_node], &autocorrector)
+          elsif nodes[:compat_node] && nodes[:meterpreter_node].nil? && nodes[:commands_node].nil?
+            add_offense(nodes[:compat_node], &autocorrector)
+          elsif nodes[:initialize_node] && nodes[:super_node] && nodes[:info_node].nil?
+            add_offense(nodes[:super_node].children.first, &autocorrector)
+          elsif nodes[:compat_node].nil? && nodes[:meterpreter_node].nil? && nodes[:commands_node].nil? && !nodes[:initialize_node].nil?
+            add_offense(nodes[:info_node].children.last, &autocorrector)
+          elsif nodes[:initialize_node].nil?
+            add_offense(nodes[:investigated_node].identifier, &autocorrector)
+          else
+            raise 'Scenario not handled'
+          end
+
+          @current_frame = nil
+        end
+
+        def on_def(node)
+          return unless visiting_state == :none
+
+          if initialize_present?(node)
+            nodes[:initialize_node] = node
+          end
+
+          update_info_node = (
+            find_update_info_node(node) ||
+              find_nested_update_info_node(node) ||
+              find_info_node(node) ||
+              find_nested_info_node(node)
+          )
+          return if update_info_node.nil?
+
+          nodes[:info_node] = update_info_node
+
+          self.visiting_state = :looking_for_hash_keys
+        end
+
+        def after_def(_node)
+          if visiting_state == :looking_for_hash_keys
+            self.visiting_state = :finished
+          end
+        end
+
+        def on_begin(node)
+          if super_present?(node)
+            nodes[:super_node] = node
+          end
+        end
+
+        def visiting_state
+          @current_frame&.visiting_state || :none
+        end
+
+        def visiting_state=(state)
+          @current_frame.visiting_state = state
+        end
+
+        def nodes
+          @current_frame.nodes
+        end
+
+        def on_pair(node)
+          return unless visiting_state == :looking_for_hash_keys
+
+          if node.key.value == 'Compat'
+            nodes[:compat_node] = node
+          elsif node.key.value == 'Meterpreter'
+            nodes[:meterpreter_node] = node
+          elsif node.key.value == 'Commands'
+            nodes[:commands_node] = node
+          end
+        end
+
+        def hash_arg?(node)
+          node.type == :hash
+        end
+
+        # Generates AST matchers based upon Meterpreter API calls.
+        def node_pattern_for(value)
+          split_values = value.split('.')
+          split_values_length = split_values.length
+
+          node_matcher = '(send ' * (split_values_length - 1)
+
+          target, *methods = split_values
+          if target == 'session' || target == 'client'
+            node_matcher << CLIENT_OR_SESSION
+          elsif target == 'process'
+            node_matcher << PROCESS
+          else
+            raise "Unknown target in expression #{value}"
+          end
+
+          methods.each do |element|
+            node_matcher << ' :' + element + ' _*)'
+          end
+
+          NodePattern.new(node_matcher)
+        end
+
+        # Maps each Meterpreter API call to a command.
+        def mappings
+          return @mappings if @mappings
+
+          # Example of expressions to commands
+          expressions_to_commands = {
+            'session.fs.file.upload': [
+              'stdapi_fs_separator',
+              'core_channel_open',
+              'core_channel_write',
+              'core_channel_tell',
+              'core_channel_close'
+            ],
+
+            'session.fs.file.upload_file': [
+              'core_channel_open',
+              'core_channel_write',
+              'core_channel_tell',
+              'core_channel_close'
+            ],
+
+            'session.fs.file.download': [
+              'core_channel_open',
+              'stdapi_fs_stat',
+              'core_channel_read',
+              'core_channel_eof',
+              'core_channel_close'
+            ],
+
+            'session.fs.file.download_file': [
+              'core_channel_open',
+              'stdapi_fs_stat',
+              'core_channel_read',
+              'core_channel_eof',
+              'core_channel_close'
+            ]
+          }
+
+          core_channel_ids = {
+            core_channel_close: [
+            ],
+            core_channel_eof: [
+            ],
+            core_channel_interact: [
+            ],
+            core_channel_open: [
+              'client.net.socket.create'
+            ],
+            core_channel_read: [
+            ],
+            core_channel_seek: [
+            ],
+            core_channel_tell: [
+            ],
+            core_channel_write: [
+            ],
+            core_console_write: [
+            ],
+            core_enumextcmd: [
+            ],
+            core_get_session_guid: [
+            ],
+            core_loadlib: [
+            ],
+            core_machine_id: [
+            ],
+            core_migrate: [
+            ],
+            core_native_arch: [
+            ],
+            core_negotiate_tlv_encryption: [
+            ],
+            core_patch_url: [
+            ],
+            core_pivot_add: [
+            ],
+            core_pivot_remove: [
+            ],
+            core_pivot_session_died: [
+            ],
+            core_set_session_guid: [
+            ],
+            core_set_uuid: [
+            ],
+            core_shutdown: [
+            ],
+            core_transport_add: [
+            ],
+            core_transport_change: [
+            ],
+            core_transport_getcerthash: [
+            ],
+            core_transport_list: [
+            ],
+            core_transport_next: [
+            ],
+            core_transport_prev: [
+            ],
+            core_transport_remove: [
+            ],
+            core_transport_setcerthash: [
+            ],
+            core_transport_set_timeouts: [
+            ],
+            core_transport_sleep: [
+            ],
+            core_pivot_session_new: [
+            ]
+          }
+
+          stdapi_command_ids = {
+            "stdapi_fs_*": [
+              'session.fs.file.new'
+            ],
+            stdapi_fs_chdir: [
+              'session.fs.dir.chdir'
+            ],
+            stdapi_fs_chmod: [
+              'session.fs.file.chmod'
+            ],
+            stdapi_fs_delete_dir: [
+              'session.fs.dir.rmdir'
+            ],
+            stdapi_fs_delete_file: [
+              'session.fs.file.rm'
+            ],
+            stdapi_fs_file_copy: [
+              'session.fs.file.copy'
+            ],
+            stdapi_fs_file_expand_path: [
+              'client.fs.file.expand_path'
+            ],
+            stdapi_fs_file_move: [
+              'session.fs.file.mv'
+            ],
+            stdapi_fs_getwd: [
+              'session.fs.dir.getwd',
+              'client.fs.dir.getwd',
+              'client.fs.dir.pwd'
+            ],
+            stdapi_fs_ls: [
+              'session.fs.file.ls',
+              'client.fs.dir.entries',
+              'client.fs.dir.entries_with_info',
+              'client.fs.dir.match'
+            ],
+            stdapi_fs_md5: [
+              'client.fs.file.md5'
+            ],
+            stdapi_fs_mkdir: [
+              'client.fs.dir.mkdir'
+            ],
+            stdapi_fs_mount_show: [
+              'client.fs.mount.show_mount'
+            ],
+            stdapi_fs_search: [
+              'client.fs.file.search'
+            ],
+            stdapi_fs_separator: [
+              'session.fs.file.separator'
+            ],
+            stdapi_fs_sha1: [
+              'session.fs.file.sha1'
+            ],
+            stdapi_fs_stat: [
+              'client.fs.file.exist?',
+              'session.fs.file.stat',
+            ],
+            stdapi_net_config_add_route: [
+              'client.net.config.add_route'
+            ],
+            stdapi_net_config_get_arp_table: [
+              'client.net.config.arp_table',
+              'client.net.config.get_arp_table'
+            ],
+            stdapi_net_config_get_interfaces: [
+              'session.net.config.each_interface',
+            ],
+            stdapi_net_config_get_netstat: [
+              'client.net.config.netstat',
+              'client.net.config.get_netstat'
+            ],
+            stdapi_net_config_get_proxy: [
+              'client.net.config.get_proxy_config'
+            ],
+            stdapi_net_config_get_routes: [
+              'client.net.config.each_route',
+            ],
+            stdapi_net_config_remove_route: [
+              'client.net.config.remove_route'
+            ],
+            stdapi_net_resolve_host: [
+              'client.net.resolve.resolve_host'
+            ],
+            stdapi_net_resolve_hosts: [
+              'client.net.resolve.resolve_hosts'
+            ],
+            stdapi_net_socket_tcp_shutdown: [
+            ],
+            stdapi_net_tcp_channel_open: [
+            ],
+            "stdapi_railgun_*": [
+              'client.railgun'
+            ],
+            stdapi_registry_check_key_exists: [
+              'client.sys.registry.check_key_exists'
+            ],
+            stdapi_registry_close_key: [
+              'client.sys.registry.close_key'
+            ],
+            stdapi_registry_create_key: [
+              'session.sys.registry.create_key'
+            ],
+            stdapi_registry_delete_key: [
+              'session.sys.registry.delete_key'
+            ],
+            stdapi_registry_delete_value: [
+              'client.sys.registry.delete_value'
+            ],
+            stdapi_registry_enum_key: [
+              'client.sys.registry.enum_key'
+            ],
+            stdapi_registry_enum_key_direct: [
+              'client.sys.registry.enum_key_direct'
+            ],
+            stdapi_registry_enum_value: [
+              'client.sys.registry.enum_value'
+            ],
+            stdapi_registry_enum_value_direct: [
+              'session.sys.registry.enum_value_direct'
+            ],
+            stdapi_registry_load_key: [
+              'session.sys.registry.load_key'
+            ],
+            stdapi_registry_open_key: [
+              'client.sys.registry.open_key'
+            ],
+            stdapi_registry_open_remote_key: [
+              'session.sys.registry.open_remote_key'
+            ],
+            stdapi_registry_query_class: [
+              'client.sys.registry.query_class'
+            ],
+            stdapi_registry_query_value: [
+              'client.sys.registry.query_value'
+            ],
+            stdapi_registry_query_value_direct: [
+              'client.sys.registry.query_value_direct'
+            ],
+            stdapi_registry_set_value: [
+              'client.sys.registry.set_value'
+            ],
+            stdapi_registry_set_value_direct: [
+              'session.sys.registry.set_value_direct'
+            ],
+            stdapi_registry_unload_key: [
+              'client.sys.registry.unload_key'
+            ],
+            stdapi_sys_config_driver_list: [
+              'session.sys.config.getdrivers'
+            ],
+            stdapi_sys_config_drop_token: [
+              'client.sys.config.drop_token'
+            ],
+            stdapi_sys_config_getenv: [
+              'session.sys.config.getenv',
+              'client.sys.config.getenvs',
+            ],
+            stdapi_sys_config_getprivs: [
+              'client.sys.config.getprivs'
+            ],
+            stdapi_sys_config_getsid: [
+              'client.sys.config.is_system?',
+              'session.sys.config.getsid'
+            ],
+            stdapi_sys_config_getuid: [
+              'client.sys.config.getuid'
+            ],
+            stdapi_sys_config_localtime: [
+              'client.sys.config.localtime'
+            ],
+            stdapi_sys_config_rev2self: [
+              'session.sys.config.revert_to_self'
+            ],
+            stdapi_sys_config_steal_token: [
+              'client.sys.config.steal_token'
+            ],
+            stdapi_sys_config_sysinfo: [
+              'client.sys.config.sysinfo'
+            ],
+            "stdapi_sys_eventlog_*": [
+              'session.sys.eventlog'
+            ],
+            stdapi_sys_eventlog_clear: [
+            ],
+            stdapi_sys_eventlog_close: [
+            ],
+            stdapi_sys_eventlog_numrecords: [
+            ],
+            stdapi_sys_eventlog_oldest: [
+            ],
+            stdapi_sys_eventlog_read: [
+            ],
+            stdapi_sys_power_exitwindows: [
+              'client.sys.power.reboot'
+            ],
+            stdapi_sys_process_attach: [
+              'client.sys.process.open'
+            ],
+            stdapi_sys_process_close: [
+              'process.close'
+            ],
+            stdapi_sys_process_execute: [
+              'client.sys.process.execute'
+            ],
+            stdapi_sys_process_get_info: [
+              'client.sys.process.get_info'
+            ],
+            stdapi_sys_process_get_processes: [
+              'client.sys.process.get_processes',
+              'session.sys.process.each_process'
+            ],
+            stdapi_sys_process_getpid: [
+              'client.sys.process.getpid'
+            ],
+            stdapi_sys_process_image_get_images: [
+              'client.sys.process.image.get_images',
+              'client.sys.process.image.each_image'
+            ],
+            stdapi_sys_process_image_get_proc_address: [
+              'client.sys.process.image.get_procedure_address'
+            ],
+            stdapi_sys_process_image_load: [
+              'client.sys.process.image.load'
+            ],
+            stdapi_sys_process_image_unload: [
+              'client.sys.process.image.unload'
+            ],
+            stdapi_sys_process_kill: [
+              'client.sys.process.kill',
+              'process.kill'
+            ],
+            stdapi_sys_process_memory_allocate: [
+              'process.memory.allocate'
+            ],
+            stdapi_sys_process_memory_free: [
+              'process.memory.free'
+            ],
+            stdapi_sys_process_memory_lock: [
+              'client.sys.process.memory.lock'
+            ],
+            stdapi_sys_process_memory_protect: [
+              'process.memory.protect'
+            ],
+            stdapi_sys_process_memory_query: [
+              'process.memory.query'
+            ],
+            stdapi_sys_process_memory_read: [
+              'process.memory.read'
+            ],
+            stdapi_sys_process_memory_unlock: [
+              'client.sys.process.memory.unlock'
+            ],
+            stdapi_sys_process_memory_write: [
+              'process.memory.write'
+            ],
+            stdapi_sys_process_thread_close: [
+              'client.sys.process.thread.close'
+            ],
+            stdapi_sys_process_thread_create: [
+              'client.sys.process.thread.create',
+              'process.thread.create'
+            ],
+            stdapi_sys_process_thread_get_threads: [
+              'process.threads.get_threads',
+              'process.threads.each_thread'
+            ],
+            stdapi_sys_process_thread_open: [
+              'process.thread.open'
+            ],
+            stdapi_sys_process_thread_query_regs: [
+              'process.thread.query_regs'
+            ],
+            stdapi_sys_process_thread_resume: [
+              'process.thread.open.resume'
+            ],
+            stdapi_sys_process_thread_set_regs: [
+              'client.sys.process.thread.set_regs'
+            ],
+            stdapi_sys_process_thread_suspend: [
+              'process.thread.open.suspend'
+            ],
+            stdapi_sys_process_thread_terminate: [
+            ],
+            stdapi_sys_process_wait: [
+              'client.sys.thread.process.wait'
+            ],
+            stdapi_ui_desktop_enum: [
+              'client.ui.enum_desktops'
+            ],
+            stdapi_ui_desktop_get: [
+              'client.ui.get_desktop'
+            ],
+            stdapi_ui_desktop_screenshot: [
+              'session.ui.screenshot'
+            ],
+            stdapi_ui_desktop_set: [
+              'client.ui.set_desktop'
+            ],
+            stdapi_ui_enable_keyboard: [
+              'client.ui.enable_keyboard'
+            ],
+            stdapi_ui_enable_mouse: [
+              'client.ui.enable_mouse'
+            ],
+            stdapi_ui_get_idle_time: [
+              'session.ui.idle_time'
+            ],
+            stdapi_ui_get_keys_utf8: [
+              'session.ui.keyscan_dump'
+            ],
+            stdapi_ui_send_keyevent: [
+              'session.ui.keyevent_send'
+            ],
+            stdapi_ui_send_keys: [
+              'client.ui.keyboard_send'
+            ],
+            stdapi_ui_send_mouse: [
+              'client.ui.mouse'
+            ],
+            stdapi_ui_start_keyscan: [
+              'client.ui.keyscan_start'
+            ],
+            stdapi_ui_stop_keyscan: [
+              'client.ui.keyscan_stop'
+            ],
+            stdapi_ui_unlock_desktop: [
+              'client.ui.unlock_desktop'
+            ],
+            "stdapi_webcam_*": [
+              'session.webcam'
+            ],
+            stdapi_audio_mic_start: [
+              'client.mic.mic_start'
+            ],
+            stdapi_audio_mic_stop: [
+              'client.mic.mic_stop'
+            ],
+            stdapi_audio_mic_list: [
+              'client.mic.mic_list'
+            ]
+          }
+
+          priv_command_ids = {
+            priv_elevate_getsystem: [
+              'session.priv.getsystem',
+            ],
+            priv_fs_blank_directory_mace: [
+              'client.priv.fs.blank_directory_mace',
+            ],
+            priv_fs_blank_file_mace: [
+              'client.priv.fs.blank_file_mace'
+            ],
+            priv_fs_get_file_mace: [
+              'client.priv.fs.get_file_mace'
+            ],
+            priv_fs_set_file_mace: [
+              'session.priv.fs.set_file_mace'
+            ],
+            priv_fs_set_file_mace_from_file: [
+              'session.priv.fs.set_file_mace_from_file'
+            ],
+            priv_passwd_get_sam_hashes: [
+              'client.priv.sam_hashes'
+            ]
+          }
+
+          extapi_command_ids = {
+            extapi_adsi_domain_query: [
+              'session.extapi.adsi.domain_query'
+            ],
+            extapi_clipboard_get_data: [
+              'session.extapi.clipboard.get_data',
+            ],
+            extapi_clipboard_monitor_dump: [
+              'client.extapi.clipboard.monitor_dump',
+            ],
+            extapi_clipboard_monitor_pause: [
+              'client.extapi.clipboard.monitor_pause',
+            ],
+            extapi_clipboard_monitor_purge: [
+              'client.extapi.clipboard.monitor_purge',
+            ],
+            extapi_clipboard_monitor_resume: [
+              'client.extapi.clipboard.monitor_resume',
+            ],
+            extapi_clipboard_monitor_start: [
+              'client.extapi.clipboard.monitor_start'
+            ],
+            extapi_clipboard_monitor_stop: [
+              'client.extapi.clipboard.monitor_stop'
+            ],
+            extapi_clipboard_set_data: [
+              'session.extapi.clipboard.set_text',
+            ],
+            extapi_ntds_parse: [
+              'client.extapi.ntds.parse',
+              NodePattern.new('(send (const (const (const (const nil? :Metasploit) :Framework) :NTDS) :Parser) :new _*)')
+            ],
+            extapi_pageant_send_query: [
+              'session.extapi.pageant.forward',
+            ],
+            extapi_service_control: [
+              'client.extapi.service.control',
+            ],
+            extapi_service_enum: [
+              'session.extapi.service.enumerate',
+            ],
+            extapi_service_query: [
+              'session.extapi.service.query',
+            ],
+            extapi_window_enum: [
+              'client.extapi.window.enumerate',
+            ],
+            extapi_wmi_query: [
+              'session.extapi.wmi.query',
+            ]
+          }
+
+          android_command_ids = {
+            'android_*': [
+              'client.android'
+            ],
+            android_activity_start: [
+            ],
+            android_check_root: [
+            ],
+            android_device_shutdown: [
+            ],
+            android_dump_calllog: [
+            ],
+            android_dump_contacts: [
+            ],
+            android_dump_sms: [
+            ],
+            android_geolocate: [
+            ],
+            android_hide_app_icon: [
+            ],
+            android_interval_collect: [
+            ],
+            android_send_sms: [
+            ],
+            android_set_audio_mode: [
+            ],
+            android_set_wallpaper: [
+            ],
+            android_sqlite_query: [
+            ],
+            android_wakelock: [
+            ],
+            android_wlan_geolocate: [
+            ]
+          }
+
+          kiwi_command_ids = {
+            kiwi_exec_cmd: [
+              'session.kiwi',
+            ]
+          }
+
+          appapi_app_install_command_ids = {
+            appapi_app_install: [
+              'client.appapi.app_install'
+            ],
+            appapi_app_list: [
+              'client.appapi.app_list'
+            ],
+            appapi_app_run: [
+              'client.appapi.app_run'
+            ],
+            appapi_app_uninstall: [
+              'client.appapi.app_uninstall'
+            ]
+          }
+
+          espia_command_ids = {
+            espia_image_get_dev_screen: [
+              'client.espia.espia_image_get_dev_screen'
+            ]
+          }
+
+          incognito_command_ids = {
+            incognito_add_group_user: [
+              'session.incognito.incognito_add_group_user'
+            ],
+            incognito_add_localgroup_user: [
+              'session.incognito.incognito_add_localgroup_user'
+            ],
+            incognito_add_user: [
+              'session.incognito.incognito_add_user'
+            ],
+            incognito_impersonate_token: [
+              'session.incognito.incognito_impersonate_token'
+            ],
+            incognito_list_tokens: [
+              'session.incognito.incognito_list_tokens'
+            ],
+            incognito_snarf_hashes: [
+              'session.incognito.incognito_snarf_hashes'
+            ]
+          }
+
+          powershell_command_ids = {
+            powershell_assembly_load: [
+              'client.powershell.import_file'
+            ],
+            powershell_execute: [
+              'session.powershell.execute_string'
+            ],
+            powershell_session_remove: [
+              'client.powershell.session_remove'
+            ],
+            powershell_shell: [
+              'client.powershell.shell'
+            ]
+          }
+
+          lanattacks_command_ids = {
+            lanattacks_add_tftp_file: [
+              'session.lanattacks.tftp.add_file'
+            ],
+            lanattacks_dhcp_log: [
+              'session.lanattacks.dhcp.log'
+            ],
+            lanattacks_reset_dhcp: [
+              'client.lanattacks.dhcp.reset'
+            ],
+            lanattacks_reset_tftp: [
+              'client.lanattacks.tftp.reset'
+            ],
+            lanattacks_set_dhcp_option: [
+              'client.lanattacks.dhcp.set_option',
+              'client.lanattacks.dhcp.load_options'
+            ],
+            lanattacks_start_dhcp: [
+              'client.lanattacks.dhcp.start'
+            ],
+            lanattacks_start_tftp: [
+              'client.lanattacks.tftp.start'
+            ],
+            lanattacks_stop_dhcp: [
+              'client.lanattacks.dhcp.stop'
+            ],
+            lanattacks_stop_tftp: [
+              'client.lanattacks.tftp.stop'
+            ]
+          }
+
+          peinjector_command_ids = {
+            peinjector_inject_shellcode: [
+              'client.peinjector.inject_shellcode'
+            ]
+          }
+
+          python_command_ids = {
+            python_execute: [
+              'client.python.execute_string',
+              'client.python.import'
+            ],
+            python_reset: [
+              'client.python.reset'
+            ]
+          }
+
+          unhook_pe_command_ids = {
+            unhook_pe: [
+              'client.unhook.unhook_pe'
+            ]
+          }
+
+          sniffer_command_ids = {
+            sniffer_capture_dump: [
+              'client.sniffer.capture_dump'
+            ],
+            sniffer_capture_dump_read: [
+              'client.sniffer.capture_dump_read'
+            ],
+            sniffer_capture_release: [
+              'client.sniffer.capture_release'
+            ],
+            sniffer_capture_start: [
+              'client.sniffer.capture_start'
+            ],
+            sniffer_capture_stats: [
+              'client.sniffer.capture_start'
+            ],
+            sniffer_capture_stop: [
+              'client.sniffer.capture_stop'
+            ],
+            sniffer_interfaces: [
+              'client.sniffer.interfaces'
+            ]
+          }
+
+          winpmem_dump_ram_command_ids = {
+            winpmem_dump_ram: [
+              'client.winpmem.dump_ram'
+            ]
+          }
+
+          command_ids_to_expressions = {
+            **core_channel_ids,
+            **stdapi_command_ids,
+            **priv_command_ids,
+            **extapi_command_ids,
+            **android_command_ids,
+            **kiwi_command_ids,
+            **appapi_app_install_command_ids,
+            **espia_command_ids,
+            **incognito_command_ids,
+            **powershell_command_ids,
+            **lanattacks_command_ids,
+            **peinjector_command_ids,
+            **python_command_ids,
+            **sniffer_command_ids,
+            **unhook_pe_command_ids,
+            **winpmem_dump_ram_command_ids
+          }
+
+          command_ids_to_expressions_mappings = command_ids_to_expressions.flat_map do |command_id, matchers|
+            matchers.map do |value|
+              {
+                matcher: value.is_a?(NodePattern) ? value : node_pattern_for(value),
+                commands: [command_id.to_s]
+              }
+            end
+          end
+
+          expressions_to_commands_ids_mappings = expressions_to_commands.map do |matcher, command_ids|
+            {
+              matcher: node_pattern_for(matcher.to_s),
+              commands: command_ids
+            }
+          end
+
+          @mappings = command_ids_to_expressions_mappings + expressions_to_commands_ids_mappings
+        end
+
+        def on_send(node)
+          mappings.each do |mapping|
+            matcher = mapping[:matcher]
+            commands = mapping[:commands]
+            next unless matcher.match(node)
+
+            commands.each do |command|
+              unless @current_frame.identified_commands.include?(command)
+                @current_frame.identified_commands << command
+              end
+            end
+            # Add an offense, but don't provide an autocorrect.
+            # There will be a final autocorrect to fix all issues
+            commands.each do |command|
+              unless @current_frame.current_commands.include?(command)
+                add_offense(node)
+              end
+            end
+
+            break
+          end
+        end
+
+        def autocorrector
+          lambda do |corrector|
+            # Handles modules that no longer have api calls with the code but have a commands list present
+            if @current_frame.identified_commands.empty? && !@current_frame.current_commands.empty?
+              # White spacing handling based of node offsets
+              commands_whitespace = offset(nodes[:commands_node])
+              array_content_whitespace = commands_whitespace + '  '
+
+              # Formatting to add missing commands node when the method has a compat node & meterpreter node present
+              new_hash = "'Commands' => %w[\n"
+              new_hash <<= "#{array_content_whitespace}#{@current_frame.identified_commands.join("\n#{array_content_whitespace}")}\n" unless @current_frame.identified_commands.empty?
+              new_hash <<= "#{commands_whitespace}]"
+
+              corrector.replace(nodes[:commands_node], new_hash)
+
+              # Handles scenario where we have both compat & meterpreter hashes
+              # but no commands array present within a module
+            elsif nodes[:compat_node] && nodes[:meterpreter_node] && nodes[:commands_node].nil?
+              meterpreter_hash_node = nodes[:meterpreter_node].children[1]
+
+              # White spacing handling based of node offsets
+              meterpreter_whitespace = offset(nodes[:meterpreter_node])
+              commands_whitespace = meterpreter_whitespace + '  '
+              array_content_whitespace = commands_whitespace + '  '
+
+              # Formatting to add missing commands node when the method has a compat node & meterpreter node present
+              new_hash =
+                "{\n" \
+                "#{commands_whitespace}'Commands' => %w[" \
+                "\n#{array_content_whitespace}#{@current_frame.identified_commands.join("\n#{array_content_whitespace}")}\n" \
+                "#{commands_whitespace}]\n" \
+                "#{meterpreter_whitespace}}"
+
+              corrector.replace(meterpreter_hash_node, new_hash)
+
+              # Handles scenario when we have a compat hash, but no meterpreter hash
+              # and compats array present within a module
+            elsif nodes[:compat_node] && nodes[:meterpreter_node].nil? && nodes[:commands_node].nil?
+              # White spacing handling based of node offsets
+              compat_whitespace = offset(nodes[:compat_node])
+              meterpreter_whitespace = compat_whitespace + '  '
+              commands_whitespace = meterpreter_whitespace + '  '
+              array_content_whitespace = commands_whitespace + '  '
+
+              # Formatting to add missing commands node when the method has a compat node & meterpreter node present
+              new_hash =
+                "\n" \
+                "#{meterpreter_whitespace}'Meterpreter' => {\n" \
+                "#{commands_whitespace}'Commands' => %w[" \
+                "\n#{array_content_whitespace}#{@current_frame.identified_commands.join("\n#{array_content_whitespace}")}\n" \
+                "#{commands_whitespace}]\n" \
+                "#{meterpreter_whitespace}}" \
+
+              if !nodes[:compat_node].value.children.last.nil?
+                corrector.insert_after(nodes[:compat_node].value.children.last, new_hash)
+              else
+                alt_new_hash = '{'
+                alt_new_hash << new_hash
+                alt_new_hash << "\n#{compat_whitespace}}"
+                corrector.replace(nodes[:compat_node].value, alt_new_hash)
+              end
+
+            elsif !nodes[:initialize_node].nil? && !nodes[:super_node].nil? && nodes[:info_node].nil?
+              super_whitespace = offset(nodes[:super_node])
+              compat_whitespace = super_whitespace + '  '
+              meterpreter_whitespace = compat_whitespace + '  '
+              commands_whitespace = meterpreter_whitespace + '  '
+              array_content_whitespace = commands_whitespace + '  '
+
+              # Formatting to add missing commands node when the method has a compat node & meterpreter node present
+              new_hash =
+                "\n#{compat_whitespace}'Compat' => {\n" \
+                "#{meterpreter_whitespace}'Meterpreter' => {\n" \
+                "#{commands_whitespace}'Commands' => %w[" \
+                "\n#{array_content_whitespace}#{@current_frame.identified_commands.join("\n#{array_content_whitespace}")}\n" \
+                "#{commands_whitespace}]\n" \
+                "#{meterpreter_whitespace}}\n" \
+                "#{compat_whitespace}}"
+
+              corrector.insert_after(nodes[:super_node].children.first, new_hash)
+
+              # Handles scenario when we have no compats hash, no meterpreter hash
+              # and  no compats array present within the module, but we do have an initialize method present
+            elsif nodes[:compat_node].nil? && nodes[:meterpreter_node].nil? && nodes[:commands_node].nil? && !nodes[:initialize_node].nil?
+              # White spacing handling based of node offsets
+              compat_whitespace = offset(nodes[:info_node])
+              meterpreter_whitespace = compat_whitespace + '  '
+              commands_whitespace = meterpreter_whitespace + '  '
+              array_content_whitespace = commands_whitespace + '  '
+
+              # Formatting to add missing commands node when the method has a compat node & meterpreter node present
+              new_hash =
+                ",\n#{compat_whitespace}'Compat' => {\n" \
+                "#{meterpreter_whitespace}'Meterpreter' => {\n" \
+                "#{commands_whitespace}'Commands' => %w[" \
+                "\n#{array_content_whitespace}#{@current_frame.identified_commands.join("\n#{array_content_whitespace}")}\n" \
+                "#{commands_whitespace}]\n" \
+                "#{meterpreter_whitespace}}\n" \
+                "#{compat_whitespace}}"
+
+              corrector.insert_after(nodes[:info_node].children.last, new_hash)
+
+              # Handles scenario when we have no compats hash, no meterpreter hash
+              # and  no compats array present no initialize method present within the module
+            elsif nodes[:compat_node].nil? && nodes[:meterpreter_node].nil? && nodes[:commands_node].nil? && nodes[:initialize_node].nil?
+              # White spacing handling based of node offset
+              body = nodes[:investigated_node].body
+              def_whitespace = offset(body)
+              super_whitespace = def_whitespace + '  '
+              update_info_whitespace = super_whitespace + '  '
+              info_whitespace = update_info_whitespace + '  '
+              meterpreter_whitespace = info_whitespace + '  '
+              commands_whitespace = meterpreter_whitespace + '  '
+              array_content_whitespace = commands_whitespace + '  '
+
+              # Formatting to add missing commands node when the method has a compat node & meterpreter node present
+              new_hash =
+                'def initialize(info = {})' \
+                "\n#{super_whitespace}super(" \
+                "\n#{update_info_whitespace}update_info(" \
+                "\n#{info_whitespace}info," \
+                "\n#{info_whitespace}'Compat' => {" \
+                "\n#{meterpreter_whitespace}'Meterpreter' => {" \
+                "\n#{commands_whitespace}'Commands' => %w[" \
+                "\n#{array_content_whitespace}#{@current_frame.identified_commands.join("\n#{array_content_whitespace}")}" \
+                "\n#{commands_whitespace}]" \
+                "\n#{meterpreter_whitespace}}" \
+                "\n#{info_whitespace}}" \
+                "\n#{update_info_whitespace})" \
+                "\n#{super_whitespace})" \
+                "\n#{def_whitespace}end\n\n" \
+                "#{def_whitespace}"
+
+              corrector.insert_before(body, new_hash)
+
+            else
+              array_node = nodes[:commands_node].children[1]
+              commands_whitespace = offset(nodes[:commands_node])
+              array_whitespace = commands_whitespace + '  '
+
+              new_array = "%w[\n#{array_whitespace}#{@current_frame.identified_commands.join("\n#{array_whitespace}")}\n#{commands_whitespace}]"
+              corrector.replace(array_node, new_array)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/lint/meterpreter_commands_dependencies.rb
+++ b/lib/rubocop/cop/lint/meterpreter_commands_dependencies.rb
@@ -637,6 +637,7 @@ module RuboCop
               'process.thread.open.suspend'
             ],
             stdapi_sys_process_thread_terminate: [
+              'process.thread.open.terminate'
             ],
             stdapi_sys_process_wait: [
               'client.sys.thread.process.wait'

--- a/lib/rubocop/cop/lint/meterpreter_commands_dependencies.rb
+++ b/lib/rubocop/cop/lint/meterpreter_commands_dependencies.rb
@@ -472,6 +472,11 @@ module RuboCop
             stdapi_net_tcp_channel_open: [
             ],
             "stdapi_railgun_*": [
+              'client.railgun.memread',
+              'session.railgun.memwrite',
+              'session.railgun.util'
+            ],
+            "stdapi_railgun_api*": [
               'client.railgun'
             ],
             stdapi_registry_check_key_exists: [
@@ -1031,6 +1036,7 @@ module RuboCop
                 @current_frame.identified_commands << command
               end
             end
+
             # Add an offense, but don't provide an autocorrect.
             # There will be a final autocorrect to fix all issues
             commands.each do |command|
@@ -1045,6 +1051,11 @@ module RuboCop
 
         def autocorrector
           lambda do |corrector|
+            # Removes the railgun_api call if we are already calling railgun in its entirety.
+            if @current_frame.identified_commands.include?("stdapi_railgun_*") && @current_frame.identified_commands.include?("stdapi_railgun_api*")
+              @current_frame.identified_commands -= ["stdapi_railgun_api*"]
+            end
+
             # Handles modules that no longer have api calls with the code but have a commands list present
             if @current_frame.identified_commands.empty? && !@current_frame.current_commands.empty?
               # White spacing handling based of node offsets

--- a/spec/rubocop/cop/lint/meterpreter_commands_dependencies_spec.rb
+++ b/spec/rubocop/cop/lint/meterpreter_commands_dependencies_spec.rb
@@ -1043,7 +1043,7 @@ RSpec.describe RuboCop::Cop::Lint::MeterpreterCommandDependencies, :config do
               'Payload'        => {
                 'Compat'       =>
                 {
-                  'PayloadType' => 'cmd'
+                  'PayloadType' => 'cmd',
                   'Meterpreter' => {
                     'Commands' => %w[
                       stdapi_fs_delete_file
@@ -1189,110 +1189,110 @@ RSpec.describe RuboCop::Cop::Lint::MeterpreterCommandDependencies, :config do
 
   it 'handles `abrt_raceabrt_priv_esc.rb` edge cases that were not being matched for unknown reasons' do
     expect_offense(<<~RUBY)
-            class DummyModule
-              def initialize(info = {})
-                  super(update_info(info,
-                    'Name'           => 'ABRT raceabrt Privilege Escalation',
-                    'Description'    => %q{
-                      This module attempts to gain root privileges on Linux systems with
-                      a vulnerable version of Automatic Bug Reporting Tool (ABRT) configured
-                      as the crash handler.
+      class DummyModule
+        def initialize(info = {})
+            super(update_info(info,
+              'Name'           => 'ABRT raceabrt Privilege Escalation',
+              'Description'    => %q{
+                This module attempts to gain root privileges on Linux systems with
+                a vulnerable version of Automatic Bug Reporting Tool (ABRT) configured
+                as the crash handler.
 
-                      A race condition allows local users to change ownership of arbitrary
-                      files (CVE-2015-3315). This module uses a symlink attack on
-                      `/var/tmp/abrt/*/maps` to change the ownership of `/etc/passwd`,
-                      then adds a new user with UID=0 GID=0 to gain root privileges.
-                      Winning the race could take a few minutes.
+                A race condition allows local users to change ownership of arbitrary
+                files (CVE-2015-3315). This module uses a symlink attack on
+                `/var/tmp/abrt/*/maps` to change the ownership of `/etc/passwd`,
+                then adds a new user with UID=0 GID=0 to gain root privileges.
+                Winning the race could take a few minutes.
 
-                      This module has been tested successfully on:
+                This module has been tested successfully on:
 
-                      abrt 2.1.11-12.el7 on RHEL 7.0 x86_64;
-                      abrt 2.1.5-1.fc19 on Fedora Desktop 19 x86_64;
-                      abrt 2.2.1-1.fc19 on Fedora Desktop 19 x86_64;
-                      abrt 2.2.2-2.fc20 on Fedora Desktop 20 x86_64;
-                      abrt 2.3.0-3.fc21 on Fedora Desktop 21 x86_64.
-                    },
-                    'License'        => MSF_LICENSE,
-                    'Author'         =>
-                      [
-                        'Tavis Ormandy', # Discovery and C exploit
-                        'bcoles' # Metasploit
-                      ],
-                    'DisclosureDate' => '2015-04-14',
-                    'Platform'       => [ 'linux' ],
-                    'Arch'           => [ ARCH_X86, ARCH_X64 ],
-                    'SessionTypes'   => [ 'shell', 'meterpreter' ],
-                    'Compat' => {
-                      'Meterpreter' => {
-                        'Commands' => %w[
-                        ^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
-                          stdapi_sys_process_*
-                          ^^^^^^^^^^^^^^^^^^^^ Compatibility command does not have an associated method call.
-                        ]
-                      }
-                    }
-                  )
-                )
-              end
-              def run
-                session.sys.process.execute 'shell', "command"
-                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
-                passwd_stat = session.fs.file.stat(@chown_file).stathash
-                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
-              end
-            end
+                abrt 2.1.11-12.el7 on RHEL 7.0 x86_64;
+                abrt 2.1.5-1.fc19 on Fedora Desktop 19 x86_64;
+                abrt 2.2.1-1.fc19 on Fedora Desktop 19 x86_64;
+                abrt 2.2.2-2.fc20 on Fedora Desktop 20 x86_64;
+                abrt 2.3.0-3.fc21 on Fedora Desktop 21 x86_64.
+              },
+              'License'        => MSF_LICENSE,
+              'Author'         =>
+                [
+                  'Tavis Ormandy', # Discovery and C exploit
+                  'bcoles' # Metasploit
+                ],
+              'DisclosureDate' => '2015-04-14',
+              'Platform'       => [ 'linux' ],
+              'Arch'           => [ ARCH_X86, ARCH_X64 ],
+              'SessionTypes'   => [ 'shell', 'meterpreter' ],
+              'Compat' => {
+                'Meterpreter' => {
+                  'Commands' => %w[
+                  ^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+                    stdapi_sys_process_*
+                    ^^^^^^^^^^^^^^^^^^^^ Compatibility command does not have an associated method call.
+                  ]
+                }
+              }
+            )
+          )
+        end
+        def run
+          session.sys.process.execute 'shell', "command"
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+          passwd_stat = session.fs.file.stat(@chown_file).stathash
+                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        end
+      end
     RUBY
 
     expect_correction(<<~RUBY)
-            class DummyModule
-              def initialize(info = {})
-                  super(update_info(info,
-                    'Name'           => 'ABRT raceabrt Privilege Escalation',
-                    'Description'    => %q{
-                      This module attempts to gain root privileges on Linux systems with
-                      a vulnerable version of Automatic Bug Reporting Tool (ABRT) configured
-                      as the crash handler.
+      class DummyModule
+        def initialize(info = {})
+            super(update_info(info,
+              'Name'           => 'ABRT raceabrt Privilege Escalation',
+              'Description'    => %q{
+                This module attempts to gain root privileges on Linux systems with
+                a vulnerable version of Automatic Bug Reporting Tool (ABRT) configured
+                as the crash handler.
 
-                      A race condition allows local users to change ownership of arbitrary
-                      files (CVE-2015-3315). This module uses a symlink attack on
-                      `/var/tmp/abrt/*/maps` to change the ownership of `/etc/passwd`,
-                      then adds a new user with UID=0 GID=0 to gain root privileges.
-                      Winning the race could take a few minutes.
+                A race condition allows local users to change ownership of arbitrary
+                files (CVE-2015-3315). This module uses a symlink attack on
+                `/var/tmp/abrt/*/maps` to change the ownership of `/etc/passwd`,
+                then adds a new user with UID=0 GID=0 to gain root privileges.
+                Winning the race could take a few minutes.
 
-                      This module has been tested successfully on:
+                This module has been tested successfully on:
 
-                      abrt 2.1.11-12.el7 on RHEL 7.0 x86_64;
-                      abrt 2.1.5-1.fc19 on Fedora Desktop 19 x86_64;
-                      abrt 2.2.1-1.fc19 on Fedora Desktop 19 x86_64;
-                      abrt 2.2.2-2.fc20 on Fedora Desktop 20 x86_64;
-                      abrt 2.3.0-3.fc21 on Fedora Desktop 21 x86_64.
-                    },
-                    'License'        => MSF_LICENSE,
-                    'Author'         =>
-                      [
-                        'Tavis Ormandy', # Discovery and C exploit
-                        'bcoles' # Metasploit
-                      ],
-                    'DisclosureDate' => '2015-04-14',
-                    'Platform'       => [ 'linux' ],
-                    'Arch'           => [ ARCH_X86, ARCH_X64 ],
-                    'SessionTypes'   => [ 'shell', 'meterpreter' ],
-                    'Compat' => {
-                      'Meterpreter' => {
-                        'Commands' => %w[
-                          stdapi_fs_stat
-                          stdapi_sys_process_execute
-                        ]
-                      }
-                    }
-                  )
-                )
-              end
-              def run
-                session.sys.process.execute 'shell', "command"
-                passwd_stat = session.fs.file.stat(@chown_file).stathash
-              end
-            end
+                abrt 2.1.11-12.el7 on RHEL 7.0 x86_64;
+                abrt 2.1.5-1.fc19 on Fedora Desktop 19 x86_64;
+                abrt 2.2.1-1.fc19 on Fedora Desktop 19 x86_64;
+                abrt 2.2.2-2.fc20 on Fedora Desktop 20 x86_64;
+                abrt 2.3.0-3.fc21 on Fedora Desktop 21 x86_64.
+              },
+              'License'        => MSF_LICENSE,
+              'Author'         =>
+                [
+                  'Tavis Ormandy', # Discovery and C exploit
+                  'bcoles' # Metasploit
+                ],
+              'DisclosureDate' => '2015-04-14',
+              'Platform'       => [ 'linux' ],
+              'Arch'           => [ ARCH_X86, ARCH_X64 ],
+              'SessionTypes'   => [ 'shell', 'meterpreter' ],
+              'Compat' => {
+                'Meterpreter' => {
+                  'Commands' => %w[
+                    stdapi_fs_stat
+                    stdapi_sys_process_execute
+                  ]
+                }
+              }
+            )
+          )
+        end
+        def run
+          session.sys.process.execute 'shell', "command"
+          passwd_stat = session.fs.file.stat(@chown_file).stathash
+        end
+      end
     RUBY
   end
 
@@ -1481,8 +1481,69 @@ RSpec.describe RuboCop::Cop::Lint::MeterpreterCommandDependencies, :config do
     RUBY
   end
 
+  it 'verifies that `self.` calls are supported' do
+    expect_offense(<<~RUBY)
+      class DummyModule
+        def initialize(info = {})
+          super(
+            update_info(
+              info,
+              'Name' => 'Simple module name',
+              'Description' => 'Lorem ipsum dolor sit amet',
+              'Author' => [ 'example1', 'example2' ],
+              'License' => MSF_LICENSE,
+              'Platform' => 'win',
+              'Arch' => ARCH_X86,
+              'DisclosureDate' => 'January 5',
+              'Compat' => {
+                'Meterpreter' => {
+                  'Commands' => %w[
+                  ^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+                  ]
+                }
+              }
+            )
+          )
+        end
+        def run
+          self.core.native_arch
+          ^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class DummyModule
+        def initialize(info = {})
+          super(
+            update_info(
+              info,
+              'Name' => 'Simple module name',
+              'Description' => 'Lorem ipsum dolor sit amet',
+              'Author' => [ 'example1', 'example2' ],
+              'License' => MSF_LICENSE,
+              'Platform' => 'win',
+              'Arch' => ARCH_X86,
+              'DisclosureDate' => 'January 5',
+              'Compat' => {
+                'Meterpreter' => {
+                  'Commands' => %w[
+                    core_native_arch
+                  ]
+                }
+              }
+            )
+          )
+        end
+        def run
+          self.core.native_arch
+        end
+      end
+    RUBY
+  end
+
   it 'handles lots of examples' do
-    %w[client].each do |keyword|
+    %w[client session].each do |keyword|
       code_snippet_with_errors = <<-EOF
         %{keyword}.fs.file.rm(
         ^{keyword}^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
@@ -1693,6 +1754,38 @@ RSpec.describe RuboCop::Cop::Lint::MeterpreterCommandDependencies, :config do
         ^{keyword}^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
         %{keyword}.net.config.add_route(*args)
         ^{keyword}^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.core.migrate
+        ^{keyword}^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.core.load_library
+        ^{keyword}^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.core.shutdown
+        ^{keyword}^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.net.socket.create
+        ^{keyword}^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.core.machine_id
+        ^{keyword}^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.core.migrate
+        ^{keyword}^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.native_arch
+        ^{keyword}^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.core.negotiate_tlv_encryption
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.core.set_session_guid
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.core.transport_add
+        ^{keyword}^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.core.transport_change
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.core.transport_list
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.core.transport_next
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.core.transport_prev
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.core.transport_remove
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.core.transport_sleep
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
       EOF
 
       code_snippet_without_error_lines =
@@ -1728,6 +1821,20 @@ RSpec.describe RuboCop::Cop::Lint::MeterpreterCommandDependencies, :config do
                             core_channel_read
                             core_channel_tell
                             core_channel_write
+                            core_loadlib
+                            core_machine_id
+                            core_migrate
+                            core_native_arch
+                            core_negotiate_tlv_encryption
+                            core_set_session_guid
+                            core_shutdown
+                            core_transport_add
+                            core_transport_change
+                            core_transport_list
+                            core_transport_next
+                            core_transport_prev
+                            core_transport_remove
+                            core_transport_sleep
                             espia_image_get_dev_screen
                             extapi_adsi_domain_query
                             extapi_pageant_send_query
@@ -1748,7 +1855,6 @@ RSpec.describe RuboCop::Cop::Lint::MeterpreterCommandDependencies, :config do
                             priv_fs_get_file_mace
                             priv_fs_set_file_mace
                             priv_passwd_get_sam_hashes
-                            stdapi_fs_*
                             stdapi_fs_chmod
                             stdapi_fs_delete_dir
                             stdapi_fs_delete_file
@@ -1846,42 +1952,30 @@ RSpec.describe RuboCop::Cop::Lint::MeterpreterCommandDependencies, :config do
 
     # Remove known core command ids
     ignored_core_command_ids = [
-      'core_channel_interact',
-      'core_channel_seek',
-      'core_console_write',
-      'core_enumextcmd',
-      'core_get_session_guid',
-      'core_loadlib',
-      'core_machine_id',
-      'core_migrate',
-      'core_native_arch',
-      'core_negotiate_tlv_encryption',
-      'core_patch_url',
-      'core_pivot_add',
-      'core_pivot_remove',
-      'core_pivot_session_died',
-      'core_set_session_guid',
-      'core_set_uuid',
-      'core_shutdown',
-      'core_transport_add',
-      'core_transport_change',
-      'core_transport_getcerthash',
-      'core_transport_list',
-      'core_transport_next',
-      'core_transport_prev',
-      'core_transport_remove',
-      'core_transport_setcerthash',
-      'core_transport_set_timeouts',
-      'core_transport_sleep',
-      'core_pivot_session_new',
+      "core_channel_interact",
+      "core_channel_seek",
+      "core_console_write",
+      "core_enumextcmd",
+      "core_get_session_guid",
+      "core_patch_url",
+      "core_pivot_add",
+      "core_pivot_remove",
+      "core_pivot_session_died",
+      "core_pivot_session_new",
+      "core_set_uuid",
+      "core_transport_getcerthash",
+      "core_transport_set_timeouts",
+      "core_transport_setcerthash",
+      "stdapi_railgun_memread",
+      "stdapi_railgun_memwrite"
     ]
 
     api_commands_without_matchers -= ignored_core_command_ids
 
     # Remove additional command ids
     other_ignored_command_ids = [
-      'stdapi_net_tcp_channel_open',
-      'stdapi_net_socket_tcp_shutdown'
+      'stdapi_net_socket_tcp_shutdown',
+      'stdapi_net_tcp_channel_open'
     ]
 
     api_commands_without_matchers -= other_ignored_command_ids

--- a/spec/rubocop/cop/lint/meterpreter_commands_dependencies_spec.rb
+++ b/spec/rubocop/cop/lint/meterpreter_commands_dependencies_spec.rb
@@ -1,0 +1,1892 @@
+require 'spec_helper'
+require 'rubocop/cop/lint/meterpreter_commands_dependencies'
+
+RSpec.describe RuboCop::Cop::Lint::MeterpreterCommandDependencies, :config do
+  subject(:cop) { described_class.new(config) }
+  let(:config) { RuboCop::Config.new }
+
+  it 'accepts a valid command list' do
+    expect_no_offenses(<<~RUBY)
+      class DummyModule
+        def initialize(info = {})
+          super(
+            update_info(
+              info,
+              'Name' => 'Simple module name',
+              'Description' => 'Lorem ipsum dolor sit amet',
+              'Author' => [ 'example1', 'example2' ],
+              'License' => MSF_LICENSE,
+              'Platform' => 'win',
+              'Arch' => ARCH_X86,
+              'DisclosureDate' => 'January 5',
+              'Compat' => {
+                'Meterpreter' => {
+                  'Commands' => %w[
+                    stdapi_fs_delete_file
+                  ]
+                }
+              }
+            )
+          )
+        end
+        def run
+          session.fs.file.rm("some_file")
+        end
+      end
+    RUBY
+  end
+
+  it 'verifies that if no compat node is present and no method calls that it will not generate anything/alter the file' do
+    expect_no_offenses(<<~RUBY)
+      class DummyModule
+        def initialize
+          super(
+            'Name' => 'Simple module name',
+            'Description' => 'Lorem ipsum dolor sit amet',
+            'Author' => [ 'example1', 'example2' ],
+            'License' => MSF_LICENSE,
+            'Platform' => 'win',
+            'Arch' => ARCH_X86,
+            'DisclosureDate' => 'January 5',
+          )
+        end
+        def run
+        end
+      end
+    RUBY
+  end
+
+  it 'verifies that meterpreter method calls are matched and added to the commands array' do
+    expect_offense(<<~RUBY)
+      class DummyModule
+        def initialize(info = {})
+          super(
+            update_info(
+              info,
+              'Name' => 'Simple module name',
+              'Description' => 'Lorem ipsum dolor sit amet',
+              'Author' => [ 'example1', 'example2' ],
+              'License' => MSF_LICENSE,
+              'Platform' => 'win',
+              'Arch' => ARCH_X86,
+              'DisclosureDate' => 'January 5',
+              'Compat' => {
+                'Meterpreter' => {
+                  'Commands' => %w[
+                  ^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+                  ]
+                }
+              }
+            )
+          )
+        end
+        def run
+          session.fs.file.rm("some_file")
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class DummyModule
+        def initialize(info = {})
+          super(
+            update_info(
+              info,
+              'Name' => 'Simple module name',
+              'Description' => 'Lorem ipsum dolor sit amet',
+              'Author' => [ 'example1', 'example2' ],
+              'License' => MSF_LICENSE,
+              'Platform' => 'win',
+              'Arch' => ARCH_X86,
+              'DisclosureDate' => 'January 5',
+              'Compat' => {
+                'Meterpreter' => {
+                  'Commands' => %w[
+                    stdapi_fs_delete_file
+                  ]
+                }
+              }
+            )
+          )
+        end
+        def run
+          session.fs.file.rm("some_file")
+        end
+      end
+    RUBY
+  end
+
+  it 'verifies that is the command list has a command present but no corresponding call, the command should be removed' do
+    expect_offense(<<~RUBY)
+      class DummyModule
+        def initialize
+          super(
+            'Name' => 'Simple module name',
+            'Description' => 'Lorem ipsum dolor sit amet',
+            'Author' => [ 'example1', 'example2' ],
+            'License' => MSF_LICENSE,
+            'Platform' => 'win',
+            'Arch' => ARCH_X86,
+            'DisclosureDate' => 'January 5',
+            'Compat' => {
+              'Meterpreter' => {
+                'Commands' => %w[
+                ^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+                  stdapi_fs_delete_file
+                  ^^^^^^^^^^^^^^^^^^^^^ Compatibility command does not have an associated method call.
+                ]
+              }
+            }
+          )
+          register_options([])
+        end
+        def run
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class DummyModule
+        def initialize
+          super(
+            'Name' => 'Simple module name',
+            'Description' => 'Lorem ipsum dolor sit amet',
+            'Author' => [ 'example1', 'example2' ],
+            'License' => MSF_LICENSE,
+            'Platform' => 'win',
+            'Arch' => ARCH_X86,
+            'DisclosureDate' => 'January 5',
+            'Compat' => {
+              'Meterpreter' => {
+                'Commands' => %w[
+                ]
+              }
+            }
+          )
+          register_options([])
+        end
+        def run
+        end
+      end
+    RUBY
+  end
+
+  it 'generates a list of meterpreter command dependencies based off meterpreter api calls in modules that currently have an empty commands array' do
+    expect_offense(<<~RUBY)
+      class DummyModule
+        def initialize
+          super(
+            'Name' => 'Simple module name',
+            'Description' => 'Lorem ipsum dolor sit amet',
+            'Author' => [ 'example1', 'example2' ],
+            'License' => MSF_LICENSE,
+            'Platform' => 'win',
+            'Arch' => ARCH_X86,
+            'DisclosureDate' => 'January 5',
+            'Compat' => {
+              'Meterpreter' => {
+                'Commands' => %w[
+                ^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+                ]
+              }
+            }
+          )
+          register_options([])
+        end
+        def run
+          session.fs.file.rm("some_file")
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class DummyModule
+        def initialize
+          super(
+            'Name' => 'Simple module name',
+            'Description' => 'Lorem ipsum dolor sit amet',
+            'Author' => [ 'example1', 'example2' ],
+            'License' => MSF_LICENSE,
+            'Platform' => 'win',
+            'Arch' => ARCH_X86,
+            'DisclosureDate' => 'January 5',
+            'Compat' => {
+              'Meterpreter' => {
+                'Commands' => %w[
+                  stdapi_fs_delete_file
+                ]
+              }
+            }
+          )
+          register_options([])
+        end
+        def run
+          session.fs.file.rm("some_file")
+        end
+      end
+    RUBY
+  end
+
+  it 'removes a redundant command from the list of meterpreter command dependencies based off meterpreter api calls in modules that currently have a command that is no longer required' do
+    expect_offense(<<~RUBY)
+      class DummyModule
+        def initialize(info = {})
+          super(
+            update_info(
+              info,
+              'Name' => 'Simple module name',
+              'Description' => 'Lorem ipsum dolor sit amet',
+              'Author' => [ 'example1', 'example2' ],
+              'License' => MSF_LICENSE,
+              'Platform' => 'win',
+              'Arch' => ARCH_X86,
+              'DisclosureDate' => 'January 5',
+              'Compat' => {
+                'Meterpreter' => {
+                  'Commands' => %w[
+                  ^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+                    stdapi_fs_ls
+                    ^^^^^^^^^^^^ Compatibility command does not have an associated method call.
+                    stdapi_fs_delete_file
+                  ]
+                }
+              }
+            )
+          )
+        end
+        def run
+          session.fs.file.rm("some_file")
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class DummyModule
+        def initialize(info = {})
+          super(
+            update_info(
+              info,
+              'Name' => 'Simple module name',
+              'Description' => 'Lorem ipsum dolor sit amet',
+              'Author' => [ 'example1', 'example2' ],
+              'License' => MSF_LICENSE,
+              'Platform' => 'win',
+              'Arch' => ARCH_X86,
+              'DisclosureDate' => 'January 5',
+              'Compat' => {
+                'Meterpreter' => {
+                  'Commands' => %w[
+                    stdapi_fs_delete_file
+                  ]
+                }
+              }
+            )
+          )
+        end
+        def run
+          session.fs.file.rm("some_file")
+        end
+      end
+    RUBY
+  end
+
+  it 'verifies that the commands arrays contents are unique as well as being sorted alphabetically' do
+    expect_offense(<<~RUBY)
+      class DummyModule
+        def initialize(info = {})
+          super(
+            update_info(
+              info,
+              'Name' => 'Simple module name',
+              'Description' => 'Lorem ipsum dolor sit amet',
+              'Author' => [ 'example1', 'example2' ],
+              'License' => MSF_LICENSE,
+              'Platform' => 'win',
+              'Arch' => ARCH_X86,
+              'DisclosureDate' => 'January 5',
+              'Compat' => {
+                'Meterpreter' => {
+                  'Commands' => %w[
+                  ^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+                    stdapi_fs_delete_file
+                    ^^^^^^^^^^^^^^^^^^^^^ Command duplicated.
+                    stdapi_fs_delete_file
+                    ^^^^^^^^^^^^^^^^^^^^^ Command duplicated.
+                    stdapi_fs_ls
+                    ^^^^^^^^^^^^ Command duplicated.
+                    stdapi_fs_ls
+                    ^^^^^^^^^^^^ Command duplicated.
+                  ]
+                }
+              }
+            )
+          )
+        end
+        def run
+          session.fs.file.rm("some_file")
+          session.fs.file.ls("some_file")
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class DummyModule
+        def initialize(info = {})
+          super(
+            update_info(
+              info,
+              'Name' => 'Simple module name',
+              'Description' => 'Lorem ipsum dolor sit amet',
+              'Author' => [ 'example1', 'example2' ],
+              'License' => MSF_LICENSE,
+              'Platform' => 'win',
+              'Arch' => ARCH_X86,
+              'DisclosureDate' => 'January 5',
+              'Compat' => {
+                'Meterpreter' => {
+                  'Commands' => %w[
+                    stdapi_fs_delete_file
+                    stdapi_fs_ls
+                  ]
+                }
+              }
+            )
+          )
+        end
+        def run
+          session.fs.file.rm("some_file")
+          session.fs.file.ls("some_file")
+        end
+      end
+    RUBY
+  end
+
+  it 'ensures there are not duplicate entries in the commands list' do
+    expect_offense(<<~RUBY)
+      class DummyModule
+        def initialize(info = {})
+          super(
+            update_info(
+              info,
+              'Name' => 'Simple module name',
+              'Description' => 'Lorem ipsum dolor sit amet',
+              'Author' => [ 'example1', 'example2' ],
+              'License' => MSF_LICENSE,
+              'Platform' => 'win',
+              'Arch' => ARCH_X86,
+              'DisclosureDate' => 'January 5',
+              'Compat' => {
+                'Meterpreter' => {
+                  'Commands' => %w[
+                  ^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+                    stdapi_fs_ls
+                    ^^^^^^^^^^^^ Command duplicated.
+                    stdapi_fs_ls
+                    ^^^^^^^^^^^^ Command duplicated.
+                    stdapi_fs_ls
+                    ^^^^^^^^^^^^ Command duplicated.
+                  ]
+                }
+              }
+            )
+          )
+        end
+        def run
+         session.fs.file.ls("some_file")
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class DummyModule
+        def initialize(info = {})
+          super(
+            update_info(
+              info,
+              'Name' => 'Simple module name',
+              'Description' => 'Lorem ipsum dolor sit amet',
+              'Author' => [ 'example1', 'example2' ],
+              'License' => MSF_LICENSE,
+              'Platform' => 'win',
+              'Arch' => ARCH_X86,
+              'DisclosureDate' => 'January 5',
+              'Compat' => {
+                'Meterpreter' => {
+                  'Commands' => %w[
+                    stdapi_fs_ls
+                  ]
+                }
+              }
+            )
+          )
+        end
+        def run
+         session.fs.file.ls("some_file")
+        end
+      end
+    RUBY
+  end
+
+  it 'handles when there are two or more identical method calls ' do
+    expect_offense(<<~RUBY)
+      class DummyModule
+        def initialize(info = {})
+          super(
+            update_info(
+              info,
+              'Name' => 'Simple module name',
+              'Description' => 'Lorem ipsum dolor sit amet',
+              'Author' => [ 'example1', 'example2' ],
+              'License' => MSF_LICENSE,
+              'Platform' => 'win',
+              'Arch' => ARCH_X86,
+              'DisclosureDate' => 'January 5',
+              'Compat' => {
+                'Meterpreter' => {
+                  'Commands' => %w[
+                  ^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+                  ]
+                }
+              }
+            )
+          )
+        end
+        def run
+          session.fs.file.rm("some_file")
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+          session.fs.file.rm("some_file")
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class DummyModule
+        def initialize(info = {})
+          super(
+            update_info(
+              info,
+              'Name' => 'Simple module name',
+              'Description' => 'Lorem ipsum dolor sit amet',
+              'Author' => [ 'example1', 'example2' ],
+              'License' => MSF_LICENSE,
+              'Platform' => 'win',
+              'Arch' => ARCH_X86,
+              'DisclosureDate' => 'January 5',
+              'Compat' => {
+                'Meterpreter' => {
+                  'Commands' => %w[
+                    stdapi_fs_delete_file
+                  ]
+                }
+              }
+            )
+          )
+        end
+        def run
+          session.fs.file.rm("some_file")
+          session.fs.file.rm("some_file")
+        end
+      end
+    RUBY
+  end
+
+  it 'verifies if a commands array is not present within a module it will be generated and appended appropriately' do
+    expect_offense(<<~RUBY)
+      class DummyModule
+        def initialize(info = {})
+          super(
+            update_info(
+              info,
+              'Name' => 'Simple module name',
+              'Description' => 'Lorem ipsum dolor sit amet',
+              'Author' => [ 'example1', 'example2' ],
+              'License' => MSF_LICENSE,
+              'Platform' => 'win',
+              'Arch' => ARCH_X86,
+              'DisclosureDate' => 'January 5',
+              'Compat' => {
+                'Meterpreter' => {
+                ^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+                }
+              }
+            )
+          )
+        end
+        def run
+          session.fs.file.rm("some_file")
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class DummyModule
+        def initialize(info = {})
+          super(
+            update_info(
+              info,
+              'Name' => 'Simple module name',
+              'Description' => 'Lorem ipsum dolor sit amet',
+              'Author' => [ 'example1', 'example2' ],
+              'License' => MSF_LICENSE,
+              'Platform' => 'win',
+              'Arch' => ARCH_X86,
+              'DisclosureDate' => 'January 5',
+              'Compat' => {
+                'Meterpreter' => {
+                  'Commands' => %w[
+                    stdapi_fs_delete_file
+                  ]
+                }
+              }
+            )
+          )
+        end
+        def run
+          session.fs.file.rm("some_file")
+        end
+      end
+    RUBY
+  end
+
+  it 'verifies if a meterpreter hash and a commands array is present within the module, if not it should be generated and appended appropriately' do
+    expect_offense(<<~RUBY)
+      class DummyModule
+        def initialize(info = {})
+          super(
+            update_info(
+              info,
+              'Name' => 'Simple module name',
+              'Description' => 'Lorem ipsum dolor sit amet',
+              'Author' => [ 'example1', 'example2' ],
+              'License' => MSF_LICENSE,
+              'Platform' => 'win',
+              'Arch' => ARCH_X86,
+              'DisclosureDate' => 'January 5',
+              'Compat' => {
+              ^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+              }
+            )
+          )
+        end
+        def run
+          session.fs.file.rm("some_file")
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class DummyModule
+        def initialize(info = {})
+          super(
+            update_info(
+              info,
+              'Name' => 'Simple module name',
+              'Description' => 'Lorem ipsum dolor sit amet',
+              'Author' => [ 'example1', 'example2' ],
+              'License' => MSF_LICENSE,
+              'Platform' => 'win',
+              'Arch' => ARCH_X86,
+              'DisclosureDate' => 'January 5',
+              'Compat' => {
+                'Meterpreter' => {
+                  'Commands' => %w[
+                    stdapi_fs_delete_file
+                  ]
+                }
+              }
+            )
+          )
+        end
+        def run
+          session.fs.file.rm("some_file")
+        end
+      end
+    RUBY
+  end
+
+  it 'verifies if a compat hash, meterpreter hash and a commands array is present within the module, if not it should be generated and appended appropriately' do
+    expect_offense(<<~RUBY)
+      class DummyModule
+        def initialize(info = {})
+          super(
+            update_info(
+              info,
+              'Name' => 'Simple module name',
+              'Description' => 'Lorem ipsum dolor sit amet',
+              'Author' => [ 'example1', 'example2' ],
+              'License' => MSF_LICENSE,
+              'Platform' => 'win',
+              'Arch' => ARCH_X86,
+              'DisclosureDate' => 'January 5'
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+            )
+          )
+        end
+        def run
+          session.fs.file.rm("some_file")
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class DummyModule
+        def initialize(info = {})
+          super(
+            update_info(
+              info,
+              'Name' => 'Simple module name',
+              'Description' => 'Lorem ipsum dolor sit amet',
+              'Author' => [ 'example1', 'example2' ],
+              'License' => MSF_LICENSE,
+              'Platform' => 'win',
+              'Arch' => ARCH_X86,
+              'DisclosureDate' => 'January 5',
+              'Compat' => {
+                'Meterpreter' => {
+                  'Commands' => %w[
+                    stdapi_fs_delete_file
+                  ]
+                }
+              }
+            )
+          )
+        end
+        def run
+          session.fs.file.rm("some_file")
+        end
+      end
+    RUBY
+  end
+
+  it 'verifies that if `update_info(` is missing that the method calls are matched and added to the commands array ' do
+    expect_offense(<<~RUBY)
+      class DummyModule
+        def initialize
+          super(
+            'Name' => 'Simple module name',
+            'Description' => 'Lorem ipsum dolor sit amet',
+            'Author' => [ 'example1', 'example2' ],
+            'License' => MSF_LICENSE,
+            'Platform' => 'win',
+            'Arch' => ARCH_X86,
+            'DisclosureDate' => 'January 5',
+            'Compat' => {
+              'Meterpreter' => {
+                'Commands' => %w[
+                ^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+                ]
+              }
+            }
+          )
+        end
+        def run
+          session.fs.file.rm("some_file")
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class DummyModule
+        def initialize
+          super(
+            'Name' => 'Simple module name',
+            'Description' => 'Lorem ipsum dolor sit amet',
+            'Author' => [ 'example1', 'example2' ],
+            'License' => MSF_LICENSE,
+            'Platform' => 'win',
+            'Arch' => ARCH_X86,
+            'DisclosureDate' => 'January 5',
+            'Compat' => {
+              'Meterpreter' => {
+                'Commands' => %w[
+                  stdapi_fs_delete_file
+                ]
+              }
+            }
+          )
+        end
+        def run
+          session.fs.file.rm("some_file")
+        end
+      end
+    RUBY
+  end
+
+  it 'verifies that if `update_info(` is missing but initialize has `(info={})` that the method calls are matched and added to the commands array ' do
+    expect_offense(<<~RUBY)
+      class DummyModule
+        def initialize(info={})
+          super
+          ^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+          register_options([])
+        end
+        def run
+          session.fs.file.rm("some_file")
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class DummyModule
+        def initialize(info={})
+          super
+            'Compat' => {
+              'Meterpreter' => {
+                'Commands' => %w[
+                  stdapi_fs_delete_file
+                ]
+              }
+            }
+          register_options([])
+        end
+        def run
+          session.fs.file.rm("some_file")
+        end
+      end
+    RUBY
+  end
+
+  it 'verifies that if there are two classes, that it will successfully iterate over them and match the method calls in the appropriate class and generate a commands list' do
+    expect_offense(<<~RUBY)
+      class DummyModule
+        class HelperClass
+          def initialize
+            @foo = 123
+          end
+        end
+
+        def initialize
+          super(
+            'Name' => 'Simple module name',
+            'Description' => 'Lorem ipsum dolor sit amet',
+            'Author' => [ 'example1', 'example2' ],
+            'License' => MSF_LICENSE,
+            'Platform' => 'win',
+            'Arch' => ARCH_X86,
+            'DisclosureDate' => 'January 5',
+            'Compat' => {
+              'Meterpreter' => {
+                'Commands' => %w[
+                ^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+                ]
+              }
+            }
+          )
+        end
+
+        def run
+          session.fs.file.rm("some_file")
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class DummyModule
+        class HelperClass
+          def initialize
+            @foo = 123
+          end
+        end
+
+        def initialize
+          super(
+            'Name' => 'Simple module name',
+            'Description' => 'Lorem ipsum dolor sit amet',
+            'Author' => [ 'example1', 'example2' ],
+            'License' => MSF_LICENSE,
+            'Platform' => 'win',
+            'Arch' => ARCH_X86,
+            'DisclosureDate' => 'January 5',
+            'Compat' => {
+              'Meterpreter' => {
+                'Commands' => %w[
+                  stdapi_fs_delete_file
+                ]
+              }
+            }
+          )
+        end
+
+        def run
+          session.fs.file.rm("some_file")
+        end
+      end
+    RUBY
+  end
+
+  it 'verfies that the cop will also work with modules' do
+    expect_offense(<<~RUBY)
+      module Msf::Post::Process
+             ^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        def meterpreter_get_processes
+          begin
+            return session.sys.process.get_processes.map { |p| p.slice('name', 'pid') }
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+          rescue Rex::Post::Meterpreter::RequestError
+            shell_get_processes
+          end
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      module Msf::Post::Process
+        def initialize(info = {})
+          super(
+            update_info(
+              info,
+              'Compat' => {
+                'Meterpreter' => {
+                  'Commands' => %w[
+                    stdapi_sys_process_get_processes
+                  ]
+                }
+              }
+            )
+          )
+        end
+
+        def meterpreter_get_processes
+          begin
+            return session.sys.process.get_processes.map { |p| p.slice('name', 'pid') }
+          rescue Rex::Post::Meterpreter::RequestError
+            shell_get_processes
+          end
+        end
+      end
+    RUBY
+  end
+
+  it 'handles two classes being in the same file' do
+    expect_offense(<<~RUBY)
+      class DummyModuleOne
+        def initialize(info = {})
+          super(
+            update_info(
+              info,
+              'Name' => 'Simple module name',
+              'Description' => 'Lorem ipsum dolor sit amet',
+              'Author' => [ 'example1', 'example2' ],
+              'License' => MSF_LICENSE,
+              'Platform' => 'win',
+              'Arch' => ARCH_X86,
+              'DisclosureDate' => 'January 5',
+              'Compat' => {
+              ^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+              }
+            )
+          )
+        end
+        def run
+          session.fs.file.rm("some_file")
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        end
+      end
+
+      class DummyModuleTwo
+        def initialize(info = {})
+          super(
+            update_info(
+              info,
+              'Name' => 'Simple module name',
+              'Description' => 'Lorem ipsum dolor sit amet',
+              'Author' => [ 'example1', 'example2' ],
+              'License' => MSF_LICENSE,
+              'Platform' => 'win',
+              'Arch' => ARCH_X86,
+              'DisclosureDate' => 'January 5',
+              'Compat' => {
+              ^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+              }
+            )
+          )
+        end
+        def run
+         session.fs.file.ls("some_file")
+         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class DummyModuleOne
+        def initialize(info = {})
+          super(
+            update_info(
+              info,
+              'Name' => 'Simple module name',
+              'Description' => 'Lorem ipsum dolor sit amet',
+              'Author' => [ 'example1', 'example2' ],
+              'License' => MSF_LICENSE,
+              'Platform' => 'win',
+              'Arch' => ARCH_X86,
+              'DisclosureDate' => 'January 5',
+              'Compat' => {
+                'Meterpreter' => {
+                  'Commands' => %w[
+                    stdapi_fs_delete_file
+                  ]
+                }
+              }
+            )
+          )
+        end
+        def run
+          session.fs.file.rm("some_file")
+        end
+      end
+
+      class DummyModuleTwo
+        def initialize(info = {})
+          super(
+            update_info(
+              info,
+              'Name' => 'Simple module name',
+              'Description' => 'Lorem ipsum dolor sit amet',
+              'Author' => [ 'example1', 'example2' ],
+              'License' => MSF_LICENSE,
+              'Platform' => 'win',
+              'Arch' => ARCH_X86,
+              'DisclosureDate' => 'January 5',
+              'Compat' => {
+                'Meterpreter' => {
+                  'Commands' => %w[
+                    stdapi_fs_ls
+                  ]
+                }
+              }
+            )
+          )
+        end
+        def run
+         session.fs.file.ls("some_file")
+        end
+      end
+    RUBY
+  end
+
+  it 'verifies if a there is no initialise method, that it should be generated and appended appropriately' do
+    expect_offense(<<~RUBY)
+      class DummyModule
+            ^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        def run
+          session.fs.file.rm("some_file")
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class DummyModule
+        def initialize(info = {})
+          super(
+            update_info(
+              info,
+              'Compat' => {
+                'Meterpreter' => {
+                  'Commands' => %w[
+                    stdapi_fs_delete_file
+                  ]
+                }
+              }
+            )
+          )
+        end
+
+        def run
+          session.fs.file.rm("some_file")
+        end
+      end
+    RUBY
+  end
+
+  it 'verfies that if compat has another value, that the meterpreter hash will be appended onto it, not replace it' do
+    expect_offense(<<~RUBY)
+      class DummyModule
+        def initialize(info = {})
+          super(
+            update_info(
+              info,
+              'Payload'        => {
+                'Compat'       =>
+                ^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+                {
+                  'PayloadType' => 'cmd'
+                }
+              }
+            )
+          )
+        end
+
+        def run
+          session.fs.file.rm("some_file")
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class DummyModule
+        def initialize(info = {})
+          super(
+            update_info(
+              info,
+              'Payload'        => {
+                'Compat'       =>
+                {
+                  'PayloadType' => 'cmd'
+                  'Meterpreter' => {
+                    'Commands' => %w[
+                      stdapi_fs_delete_file
+                    ]
+                  }
+                }
+              }
+            )
+          )
+        end
+
+        def run
+          session.fs.file.rm("some_file")
+        end
+      end
+    RUBY
+  end
+
+  it 'successfully corrects helper methods too' do
+    expect_offense(<<~RUBY)
+      class DummyModule
+        def initialize
+          super(
+            'Name' => 'Simple module name',
+            'Description' => 'Lorem ipsum dolor sit amet',
+            'Author' => [ 'example1', 'example2' ],
+            'License' => MSF_LICENSE,
+            'Platform' => 'win',
+            'Arch' => ARCH_X86,
+            'DisclosureDate' => 'January 5',
+            'Compat' => {
+              'Meterpreter' => {
+                'Commands' => %w[
+                ^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+                ]
+              }
+            }
+          )
+        end
+
+        def run
+          some_helper_method(session)         
+        end
+
+        def some_helper_method(session)
+         session.fs.file.rm("some_file")
+         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class DummyModule
+        def initialize
+          super(
+            'Name' => 'Simple module name',
+            'Description' => 'Lorem ipsum dolor sit amet',
+            'Author' => [ 'example1', 'example2' ],
+            'License' => MSF_LICENSE,
+            'Platform' => 'win',
+            'Arch' => ARCH_X86,
+            'DisclosureDate' => 'January 5',
+            'Compat' => {
+              'Meterpreter' => {
+                'Commands' => %w[
+                  stdapi_fs_delete_file
+                ]
+              }
+            }
+          )
+        end
+
+        def run
+          some_helper_method(session)         
+        end
+
+        def some_helper_method(session)
+         session.fs.file.rm("some_file")
+        end
+      end
+    RUBY
+  end
+
+  it 'verifies that if NTDS parser object is called that it adds the correct command name' do
+    expect_offense(<<~RUBY)
+      class DummyModule
+        def initialize
+          super(
+            'Name' => 'Simple module name',
+            'Description' => 'Lorem ipsum dolor sit amet',
+            'Author' => [ 'example1', 'example2' ],
+            'License' => MSF_LICENSE,
+            'Platform' => 'win',
+            'Arch' => ARCH_X86,
+            'DisclosureDate' => 'January 5',
+            'Compat' => {
+              'Meterpreter' => {
+                'Commands' => %w[
+                ^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+                ]
+              }
+            }
+          )
+        end
+
+        def run
+          ntds_parser = Metasploit::Framework::NTDS::Parser.new(client, ntds_file)
+                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+          client.extapi.ntds.parse("some_file")
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class DummyModule
+        def initialize
+          super(
+            'Name' => 'Simple module name',
+            'Description' => 'Lorem ipsum dolor sit amet',
+            'Author' => [ 'example1', 'example2' ],
+            'License' => MSF_LICENSE,
+            'Platform' => 'win',
+            'Arch' => ARCH_X86,
+            'DisclosureDate' => 'January 5',
+            'Compat' => {
+              'Meterpreter' => {
+                'Commands' => %w[
+                  extapi_ntds_parse
+                ]
+              }
+            }
+          )
+        end
+
+        def run
+          ntds_parser = Metasploit::Framework::NTDS::Parser.new(client, ntds_file)
+          client.extapi.ntds.parse("some_file")
+        end
+      end
+    RUBY
+  end
+
+  it 'handles `abrt_raceabrt_priv_esc.rb` edge cases that were not being matched for unknown reasons' do
+    expect_offense(<<~RUBY)
+      class DummyModule
+        def initialize(info = {})
+            super(update_info(info,
+              'Name'           => 'ABRT raceabrt Privilege Escalation',
+              'Description'    => %q{
+                This module attempts to gain root privileges on Linux systems with
+                a vulnerable version of Automatic Bug Reporting Tool (ABRT) configured
+                as the crash handler.
+        
+                A race condition allows local users to change ownership of arbitrary
+                files (CVE-2015-3315). This module uses a symlink attack on
+                `/var/tmp/abrt/*/maps` to change the ownership of `/etc/passwd`,
+                then adds a new user with UID=0 GID=0 to gain root privileges.
+                Winning the race could take a few minutes.
+        
+                This module has been tested successfully on:
+        
+                abrt 2.1.11-12.el7 on RHEL 7.0 x86_64;
+                abrt 2.1.5-1.fc19 on Fedora Desktop 19 x86_64;
+                abrt 2.2.1-1.fc19 on Fedora Desktop 19 x86_64;
+                abrt 2.2.2-2.fc20 on Fedora Desktop 20 x86_64;
+                abrt 2.3.0-3.fc21 on Fedora Desktop 21 x86_64.
+              },
+              'License'        => MSF_LICENSE,
+              'Author'         =>
+                [
+                  'Tavis Ormandy', # Discovery and C exploit
+                  'bcoles' # Metasploit
+                ],
+              'DisclosureDate' => '2015-04-14',
+              'Platform'       => [ 'linux' ],
+              'Arch'           => [ ARCH_X86, ARCH_X64 ],
+              'SessionTypes'   => [ 'shell', 'meterpreter' ],
+              'Compat' => {
+                'Meterpreter' => {
+                  'Commands' => %w[
+                  ^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+                    stdapi_sys_process_*
+                    ^^^^^^^^^^^^^^^^^^^^ Compatibility command does not have an associated method call.
+                  ]
+                }
+              }
+            )
+          )
+        end
+        def run
+          session.sys.process.execute 'shell', "command"
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+          passwd_stat = session.fs.file.stat(@chown_file).stathash
+                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class DummyModule
+        def initialize(info = {})
+            super(update_info(info,
+              'Name'           => 'ABRT raceabrt Privilege Escalation',
+              'Description'    => %q{
+                This module attempts to gain root privileges on Linux systems with
+                a vulnerable version of Automatic Bug Reporting Tool (ABRT) configured
+                as the crash handler.
+        
+                A race condition allows local users to change ownership of arbitrary
+                files (CVE-2015-3315). This module uses a symlink attack on
+                `/var/tmp/abrt/*/maps` to change the ownership of `/etc/passwd`,
+                then adds a new user with UID=0 GID=0 to gain root privileges.
+                Winning the race could take a few minutes.
+        
+                This module has been tested successfully on:
+        
+                abrt 2.1.11-12.el7 on RHEL 7.0 x86_64;
+                abrt 2.1.5-1.fc19 on Fedora Desktop 19 x86_64;
+                abrt 2.2.1-1.fc19 on Fedora Desktop 19 x86_64;
+                abrt 2.2.2-2.fc20 on Fedora Desktop 20 x86_64;
+                abrt 2.3.0-3.fc21 on Fedora Desktop 21 x86_64.
+              },
+              'License'        => MSF_LICENSE,
+              'Author'         =>
+                [
+                  'Tavis Ormandy', # Discovery and C exploit
+                  'bcoles' # Metasploit
+                ],
+              'DisclosureDate' => '2015-04-14',
+              'Platform'       => [ 'linux' ],
+              'Arch'           => [ ARCH_X86, ARCH_X64 ],
+              'SessionTypes'   => [ 'shell', 'meterpreter' ],
+              'Compat' => {
+                'Meterpreter' => {
+                  'Commands' => %w[
+                    stdapi_fs_stat
+                    stdapi_sys_process_execute
+                  ]
+                }
+              }
+            )
+          )
+        end
+        def run
+          session.sys.process.execute 'shell', "command"
+          passwd_stat = session.fs.file.stat(@chown_file).stathash
+        end
+      end
+    RUBY
+  end
+
+  it 'tracks the use of processes' do
+    expect_offense(<<~RUBY)
+      class DummyModule
+        def initialize
+          super(
+            'Name' => 'Simple module name',
+            'Description' => 'Lorem ipsum dolor sit amet',
+            'Author' => [ 'example1', 'example2' ],
+            'License' => MSF_LICENSE,
+            'Platform' => 'win',
+            'Arch' => ARCH_X86,
+            'DisclosureDate' => 'January 5',
+            'Compat' => {
+              'Meterpreter' => {
+                'Commands' => %w[
+                ^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+                ]
+              }
+            }
+          )
+          register_options([])
+        end
+        def run
+          target = client.sys.process.open(notepad_process.pid, PROCESS_ALL_ACCESS)
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+          target.thread.create(exploit_mem + offset, param_ptr)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+
+          targetprocess = client.sys.process.open(pid, PROCESS_ALL_ACCESS)
+                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+          targetprocess.thread.each_thread do |x|
+            if resume
+              targetprocess.thread.open(x).resume
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+            else
+              targetprocess.thread.open(x).suspend
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+            end
+          end
+
+          calc = client.sys.process.open(pid, PROCESS_ALL_ACCESS)
+                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+          mem  = calc.memory.allocate(32)
+                 ^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+          calc.memory.write(mem, "1234")
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+          targetprocess.thread.open(x).resume
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        end
+
+        def helper(process)
+          shellcode_mem = process.memory.allocate(shellcode_size)
+                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+          process.memory.protect(shellcode_mem)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+          process.memory.write(shellcode_mem, shellcode)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class DummyModule
+        def initialize
+          super(
+            'Name' => 'Simple module name',
+            'Description' => 'Lorem ipsum dolor sit amet',
+            'Author' => [ 'example1', 'example2' ],
+            'License' => MSF_LICENSE,
+            'Platform' => 'win',
+            'Arch' => ARCH_X86,
+            'DisclosureDate' => 'January 5',
+            'Compat' => {
+              'Meterpreter' => {
+                'Commands' => %w[
+                  stdapi_sys_process_attach
+                  stdapi_sys_process_memory_allocate
+                  stdapi_sys_process_memory_protect
+                  stdapi_sys_process_memory_write
+                  stdapi_sys_process_thread_create
+                  stdapi_sys_process_thread_open
+                  stdapi_sys_process_thread_resume
+                  stdapi_sys_process_thread_suspend
+                ]
+              }
+            }
+          )
+          register_options([])
+        end
+        def run
+          target = client.sys.process.open(notepad_process.pid, PROCESS_ALL_ACCESS)
+          target.thread.create(exploit_mem + offset, param_ptr)
+
+          targetprocess = client.sys.process.open(pid, PROCESS_ALL_ACCESS)
+          targetprocess.thread.each_thread do |x|
+            if resume
+              targetprocess.thread.open(x).resume
+            else
+              targetprocess.thread.open(x).suspend
+            end
+          end
+
+          calc = client.sys.process.open(pid, PROCESS_ALL_ACCESS)
+          mem  = calc.memory.allocate(32)
+          calc.memory.write(mem, "1234")
+          targetprocess.thread.open(x).resume
+        end
+
+        def helper(process)
+          shellcode_mem = process.memory.allocate(shellcode_size)
+          process.memory.protect(shellcode_mem)
+          process.memory.write(shellcode_mem, shellcode)
+        end
+      end
+    RUBY
+  end
+
+  it 'verfies that mapping commands to expressions also functions correctly' do
+    expect_offense(<<~RUBY)
+      class DummyModule
+        def initialize(info = {})
+          super(
+            update_info(
+              info,
+              'Name' => 'Simple module name',
+              'Description' => 'Lorem ipsum dolor sit amet',
+              'Author' => [ 'example1', 'example2' ],
+              'License' => MSF_LICENSE,
+              'Platform' => 'win',
+              'Arch' => ARCH_X86,
+              'DisclosureDate' => 'January 5',
+              'Compat' => {
+                'Meterpreter' => {
+                  'Commands' => %w[
+                  ^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+                  ]
+                }
+              }
+            )
+          )
+        end
+        def run
+          session.fs.file.upload(@paths['ff'] + new_file, tmp)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class DummyModule
+        def initialize(info = {})
+          super(
+            update_info(
+              info,
+              'Name' => 'Simple module name',
+              'Description' => 'Lorem ipsum dolor sit amet',
+              'Author' => [ 'example1', 'example2' ],
+              'License' => MSF_LICENSE,
+              'Platform' => 'win',
+              'Arch' => ARCH_X86,
+              'DisclosureDate' => 'January 5',
+              'Compat' => {
+                'Meterpreter' => {
+                  'Commands' => %w[
+                    core_channel_close
+                    core_channel_open
+                    core_channel_tell
+                    core_channel_write
+                    stdapi_fs_separator
+                  ]
+                }
+              }
+            )
+          )
+        end
+        def run
+          session.fs.file.upload(@paths['ff'] + new_file, tmp)
+        end
+      end
+    RUBY
+  end
+
+  it 'handles lots of examples' do
+    %w[client].each do |keyword|
+      code_snippet_with_errors = <<-EOF
+        %{keyword}.fs.file.rm(
+        ^{keyword}^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+            "some_file"
+        )
+        %{keyword}.sys.process.get_processes
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.fs.file.ls("file")
+        ^{keyword}^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.sys.registry.load_key(root_key, base_key, file)
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.sys.registry.unload_key(root_key,base_key)
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.sys.config.getprivs()
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.sys.registry.create_key(root_key, base_key, perms)
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.sys.registry.open_key(root_key, base_key, perms)
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.sys.registry.delete_key(root_key, base_key, perms)
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.sys.registry.enum_key_direct(root_key, base_key, perms)
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.sys.registry.enum_value_direct(root_key, base_key, perms)
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.sys.registry.query_value_direct(root_key, base_key, valname, perms)
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.sys.registry.set_value_direct(root_key, base_key, valname, %{keyword}.sys.registry.type2str(type), data, perms)
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^{keyword}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.sys.registry.check_key_exists(root_key, base_key)
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.fs.dir.getwd
+        ^{keyword}^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.appapi.app_install(out_apk)
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.sys.process.execute
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.fs.file.stat(@chown_file)
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.sys.config.sysinfo["Computer"]
+        ^{keyword}^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.sys.process.get_processes
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.sys.config.getenv('TEMP')
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.railgun.memread(@addresses['AcroRd32.exe'] + target['AdobeCollabSyncTrigger'], target['AdobeCollabSyncTriggerSignature'].length)
+        ^{keyword}^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.sys.process.open
+        ^{keyword}^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.net.socket.create
+        ^{keyword}^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.sys.config.getprivs
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.sys.config.getenv('windir')
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.fs.file.copy("C:\\Windows\\System32\\WSReset.exe", exploit_file)
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.sys.config.getdrivers
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.fs.file.md5(d[:filename])
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.fs.dir.mkdir(share_dir)
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.sys.power.reboot
+        ^{keyword}^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.sys.config.getuid
+        ^{keyword}^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.fs.file.new(taskfile, "wb")
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.fs.file.stat(@chown_file).stathash
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.android.activity_start('intent:#Intent;launchFlags=0x8000;component=com.android.settings/.ChooseLockGeneric;i.lockscreen.password_type=0;B.confirm_credentials=false;end')
+        ^{keyword}^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.net.resolve.resolve_host(name)[:ip]
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.fs.file.separator
+        ^{keyword}^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.fs.file.exist?(@paths['ff'] + temp_file) && !%{keyword}.fs.file.exist?(@paths['ff'] + org_file)
+        _{keyword}                                              ^{keyword}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.fs.file.search(path, "config.xml", true, -1)
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.android.wlan_geolocate
+        ^{keyword}^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.webcam.record_mic(datastore['DURATION'])
+        ^{keyword}^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.espia.espia_image_get_dev_screen
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.android.set_wallpaper(File.binread(file))
+        ^{keyword}^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.sys.config.steal_token(pid)
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.sys.config.revert_to_self
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.net.config.each_route
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.net.config.each_interface
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.fs.dir.pwd
+        ^{keyword}^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.priv.getsystem(technique)
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.kiwi.golden_ticket_create(ticket)
+        ^{keyword}^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.kiwi.kerberos_ticket_use(ticket)
+        ^{keyword}^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.priv.sam_hashes
+        ^{keyword}^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.incognito.incognito_list_tokens(0)
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.fs.dir.entries(v)
+        ^{keyword}^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.kiwi.get_debug_privilege
+        ^{keyword}^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.kiwi.creds_all
+        ^{keyword}^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.sys.config.is_system?
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.extapi.wmi.query("SELECT HotFixID, InstalledOn FROM Win32_QuickFixEngineering")
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.sys.registry.open_remote_key(datastore['RHOST'], root_key)
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.priv.getsystem
+        ^{keyword}^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.extapi.adsi.domain_query(domain, adsi_filter, 255, 255, adsi_fields)
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.priv.fs.get_file_mace(datastore['FILE'])
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.priv.fs.set_file_mace(datastore['FILE'], mace["Modified"], mace["Accessed"], mace["Created"], mace["Entry Modified"])
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.extapi.pageant.forward(socket_request_data.first, socket_request_data.first.size)
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.lanattacks.dhcp.reset
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.lanattacks.dhcp.load_options(datastore)
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.lanattacks.tftp.start
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.lanattacks.dhcp.start
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.lanattacks.tftp.stop
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.lanattacks.dhcp.stop
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.webcam.webcam_start(datastore['INDEX'])
+        ^{keyword}^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.webcam.webcam_get_frame(datastore['QUALITY'])
+        ^{keyword}^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.webcam.webcam_stop
+        ^{keyword}^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.webcam.webcam_list
+        ^{keyword}^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.incognito.incognito_impersonate_token(domain_user)
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.fs.file.expand_path(path)
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.peinjector.inject_shellcode(param)
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.lanattacks.dhcp.load_options(datastore)
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.sys.config.getenvs('SYSTEMDRIVE', 'HOMEDRIVE', 'ProgramFiles', 'ProgramFiles(x86)', 'ProgramW6432')
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.fs.file.exist?(net_sarang_path_5)
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.lanattacks.dhcp.log.each
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.fs.dir.rmdir(datastore['PATH'])
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.sys.process.open.name
+        ^{keyword}^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.sys.process.get_processes
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.sys.process.getpid
+        ^{keyword}^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.sys.process.open(pid, PROCESS_ALL_ACCESS)
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.sys.process.get_processes()
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.sys.process.kill(process['pid'])
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.sys.process.execute(cmd, nil, {'Hidden' => true})
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.sys.process.each_process.find
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.sys.process.open.pid
+        ^{keyword}^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.sys.process.execute 'script', "command"
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.fs.file.download("test", "file", opts)
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.fs.file.upload(dst_item, src_item)
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.fs.file.upload_file(@paths['ff'] + new_file, tmp)
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.lanattacks.tftp.add_file("update_test",contents)
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.fs.file.download_file("local_path/img", "f_path/img", opts)
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.sys.process.execute '/bin/sh', "-c \\"chown root:root \#{@chown_file}\\""
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.fs.file.chmod(path, mode)
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.fs.file.mv(src_name, dst_name)
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.fs.file.sha1(remote)
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.fs.mount.show_mount
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+        %{keyword}.net.config.add_route(*args)
+        ^{keyword}^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+      EOF
+
+      code_snippet_without_error_lines = (
+        code_snippet_with_errors
+          .lines
+          .reject { |line| line.lstrip.start_with?('^{keyword}') || line.lstrip.start_with?('_{keyword}')}
+          .join
+          .gsub('%{keyword}', keyword)
+      )
+
+      expect_offense(<<~RUBY, keyword: keyword)
+        class DummyModule
+              ^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+          def run
+  #{code_snippet_with_errors}
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class DummyModule
+          def initialize(info = {})
+            super(
+              update_info(
+                info,
+                'Compat' => {
+                  'Meterpreter' => {
+                    'Commands' => %w[
+                      android_*
+                      appapi_app_install
+                      core_channel_close
+                      core_channel_eof
+                      core_channel_open
+                      core_channel_read
+                      core_channel_tell
+                      core_channel_write
+                      espia_image_get_dev_screen
+                      extapi_adsi_domain_query
+                      extapi_pageant_send_query
+                      extapi_wmi_query
+                      incognito_impersonate_token
+                      incognito_list_tokens
+                      kiwi_exec_cmd
+                      lanattacks_add_tftp_file
+                      lanattacks_dhcp_log
+                      lanattacks_reset_dhcp
+                      lanattacks_set_dhcp_option
+                      lanattacks_start_dhcp
+                      lanattacks_start_tftp
+                      lanattacks_stop_dhcp
+                      lanattacks_stop_tftp
+                      peinjector_inject_shellcode
+                      priv_elevate_getsystem
+                      priv_fs_get_file_mace
+                      priv_fs_set_file_mace
+                      priv_passwd_get_sam_hashes
+                      stdapi_fs_*
+                      stdapi_fs_chmod
+                      stdapi_fs_delete_dir
+                      stdapi_fs_delete_file
+                      stdapi_fs_file_copy
+                      stdapi_fs_file_expand_path
+                      stdapi_fs_file_move
+                      stdapi_fs_getwd
+                      stdapi_fs_ls
+                      stdapi_fs_md5
+                      stdapi_fs_mkdir
+                      stdapi_fs_mount_show
+                      stdapi_fs_search
+                      stdapi_fs_separator
+                      stdapi_fs_sha1
+                      stdapi_fs_stat
+                      stdapi_net_config_add_route
+                      stdapi_net_config_get_interfaces
+                      stdapi_net_config_get_routes
+                      stdapi_net_resolve_host
+                      stdapi_railgun_*
+                      stdapi_registry_check_key_exists
+                      stdapi_registry_create_key
+                      stdapi_registry_delete_key
+                      stdapi_registry_enum_key_direct
+                      stdapi_registry_enum_value_direct
+                      stdapi_registry_load_key
+                      stdapi_registry_open_key
+                      stdapi_registry_open_remote_key
+                      stdapi_registry_query_value_direct
+                      stdapi_registry_set_value_direct
+                      stdapi_registry_unload_key
+                      stdapi_sys_config_driver_list
+                      stdapi_sys_config_getenv
+                      stdapi_sys_config_getprivs
+                      stdapi_sys_config_getsid
+                      stdapi_sys_config_getuid
+                      stdapi_sys_config_rev2self
+                      stdapi_sys_config_steal_token
+                      stdapi_sys_config_sysinfo
+                      stdapi_sys_power_exitwindows
+                      stdapi_sys_process_attach
+                      stdapi_sys_process_execute
+                      stdapi_sys_process_get_processes
+                      stdapi_sys_process_getpid
+                      stdapi_sys_process_kill
+                      stdapi_webcam_*
+                    ]
+                  }
+                }
+              )
+            )
+          end
+
+          def run
+  #{code_snippet_without_error_lines}
+          end
+        end
+      RUBY
+    end
+  end
+
+  it 'autocorrects only valid meterpreter commands' do
+    ignored_commands = []
+    valid_meterpreter_command_names = Rex::Post::Meterpreter::CommandMapper.get_command_names
+    autocorrected_meterpreter_command_names = described_class.new.mappings.flat_map { |mapping| mapping[:commands] }.flatten.uniq
+
+    # This allows entire libraries to be ignore if the commands are being called with a wildcard
+    autocorrected_meterpreter_command_names.each do |command|
+      ignored_commands << command if command.end_with?('_*')
+    end
+
+    invalid_autocorrected_command_names = autocorrected_meterpreter_command_names - valid_meterpreter_command_names - ignored_commands
+    expect(invalid_autocorrected_command_names).to be_empty
+  end
+
+  it 'verifies that each command ID has an associated matcher' do
+    valid_meterpreter_command_names = Rex::Post::Meterpreter::CommandMapper.get_command_names
+    autocorrected_meterpreter_command_names = described_class.new.mappings.flat_map { |mapping| mapping[:commands] }
+    api_commands_without_matchers = valid_meterpreter_command_names - autocorrected_meterpreter_command_names.flatten.uniq
+
+    # Handle wildcard matchers, i.e. `stdapi_railgun_*`
+    api_commands_handled_via_wildcards = []
+    autocorrected_meterpreter_command_names.each do |command|
+      if command.end_with?('_*')
+        prefix = command.gsub("_*", "")
+        api_commands_without_matchers.each do |unmatched_command|
+          if unmatched_command.start_with?(prefix)
+            api_commands_handled_via_wildcards << unmatched_command
+          end
+        end
+      end
+    end
+
+    api_commands_without_matchers -= api_commands_handled_via_wildcards
+
+    # Remove known core command ids
+    ignored_core_command_ids = [
+       "core_channel_interact",
+       "core_channel_seek",
+       "core_console_write",
+       "core_enumextcmd",
+       "core_get_session_guid",
+       "core_loadlib",
+       "core_machine_id",
+       "core_migrate",
+       "core_native_arch",
+       "core_negotiate_tlv_encryption",
+       "core_patch_url",
+       "core_pivot_add",
+       "core_pivot_remove",
+       "core_pivot_session_died",
+       "core_set_session_guid",
+       "core_set_uuid",
+       "core_shutdown",
+       "core_transport_add",
+       "core_transport_change",
+       "core_transport_getcerthash",
+       "core_transport_list",
+       "core_transport_next",
+       "core_transport_prev",
+       "core_transport_remove",
+       "core_transport_setcerthash",
+       "core_transport_set_timeouts",
+       "core_transport_sleep",
+       "core_pivot_session_new",
+    ]
+
+    api_commands_without_matchers -= ignored_core_command_ids
+
+    # Remove additional command ids
+    other_ignored_command_ids = [
+      "stdapi_net_tcp_channel_open",
+      "stdapi_net_socket_tcp_shutdown"
+    ]
+
+    api_commands_without_matchers -= other_ignored_command_ids
+    expect(api_commands_without_matchers).to be_empty
+  end
+end
+

--- a/spec/rubocop/cop/lint/meterpreter_commands_dependencies_spec.rb
+++ b/spec/rubocop/cop/lint/meterpreter_commands_dependencies_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe RuboCop::Cop::Lint::MeterpreterCommandDependencies, :config do
     RUBY
   end
 
-  it 'verifies that if no compat node is present and no method calls that it will not generate anything/alter the file' do
+  it 'verifies that if no compat node is present and no method calls are present that nothing will be generated/alter the file' do
     expect_no_offenses(<<~RUBY)
       class DummyModule
         def initialize
@@ -117,7 +117,7 @@ RSpec.describe RuboCop::Cop::Lint::MeterpreterCommandDependencies, :config do
     RUBY
   end
 
-  it 'verifies that is the command list has a command present but no corresponding call, the command should be removed' do
+  it 'verifies that if the command list has a command present but no corresponding call, the command should be removed' do
     expect_offense(<<~RUBY)
       class DummyModule
         def initialize
@@ -172,7 +172,7 @@ RSpec.describe RuboCop::Cop::Lint::MeterpreterCommandDependencies, :config do
     RUBY
   end
 
-  it 'generates a list of meterpreter command dependencies based off meterpreter api calls in modules that currently have an empty commands array' do
+  it 'generates a list of meterpreter command dependencies based off the meterpreter api calls, in modules that currently have an empty commands array' do
     expect_offense(<<~RUBY)
       class DummyModule
         def initialize
@@ -229,7 +229,7 @@ RSpec.describe RuboCop::Cop::Lint::MeterpreterCommandDependencies, :config do
     RUBY
   end
 
-  it 'removes a redundant command from the list of meterpreter command dependencies based off meterpreter api calls in modules that currently have a command that is no longer required' do
+  it 'removes a redundant command from the list of meterpreter command dependencies f there is no longer an associated api call present in the module' do
     expect_offense(<<~RUBY)
       class DummyModule
         def initialize(info = {})
@@ -363,7 +363,7 @@ RSpec.describe RuboCop::Cop::Lint::MeterpreterCommandDependencies, :config do
     RUBY
   end
 
-  it 'ensures there are not duplicate entries in the commands list' do
+  it 'ensures there are no duplicate entries in the commands list' do
     expect_offense(<<~RUBY)
       class DummyModule
         def initialize(info = {})
@@ -429,7 +429,7 @@ RSpec.describe RuboCop::Cop::Lint::MeterpreterCommandDependencies, :config do
     RUBY
   end
 
-  it 'handles when there are two or more identical method calls ' do
+  it 'ensures that even with two identical api calls present in a module, that only one command will be generated' do
     expect_offense(<<~RUBY)
       class DummyModule
         def initialize(info = {})
@@ -664,7 +664,7 @@ RSpec.describe RuboCop::Cop::Lint::MeterpreterCommandDependencies, :config do
     RUBY
   end
 
-  it 'verifies that if `update_info(` is missing that the method calls are matched and added to the commands array ' do
+  it 'verifies that if `update_info(` is missing, that it will be appended appropriately' do
     expect_offense(<<~RUBY)
       class DummyModule
         def initialize
@@ -974,7 +974,7 @@ RSpec.describe RuboCop::Cop::Lint::MeterpreterCommandDependencies, :config do
     RUBY
   end
 
-  it 'verifies if a there is no initialise method, that it should be generated and appended appropriately' do
+  it 'verifies if a there is an initialise method, if no initialise present, it should be generated and appended appropriately' do
     expect_offense(<<~RUBY)
       class DummyModule
             ^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
@@ -1085,7 +1085,7 @@ RSpec.describe RuboCop::Cop::Lint::MeterpreterCommandDependencies, :config do
         end
 
         def run
-          some_helper_method(session)         
+          some_helper_method(session)
         end
 
         def some_helper_method(session)
@@ -1117,7 +1117,7 @@ RSpec.describe RuboCop::Cop::Lint::MeterpreterCommandDependencies, :config do
         end
 
         def run
-          some_helper_method(session)         
+          some_helper_method(session)
         end
 
         def some_helper_method(session)
@@ -1189,114 +1189,114 @@ RSpec.describe RuboCop::Cop::Lint::MeterpreterCommandDependencies, :config do
 
   it 'handles `abrt_raceabrt_priv_esc.rb` edge cases that were not being matched for unknown reasons' do
     expect_offense(<<~RUBY)
-      class DummyModule
-        def initialize(info = {})
-            super(update_info(info,
-              'Name'           => 'ABRT raceabrt Privilege Escalation',
-              'Description'    => %q{
-                This module attempts to gain root privileges on Linux systems with
-                a vulnerable version of Automatic Bug Reporting Tool (ABRT) configured
-                as the crash handler.
-        
-                A race condition allows local users to change ownership of arbitrary
-                files (CVE-2015-3315). This module uses a symlink attack on
-                `/var/tmp/abrt/*/maps` to change the ownership of `/etc/passwd`,
-                then adds a new user with UID=0 GID=0 to gain root privileges.
-                Winning the race could take a few minutes.
-        
-                This module has been tested successfully on:
-        
-                abrt 2.1.11-12.el7 on RHEL 7.0 x86_64;
-                abrt 2.1.5-1.fc19 on Fedora Desktop 19 x86_64;
-                abrt 2.2.1-1.fc19 on Fedora Desktop 19 x86_64;
-                abrt 2.2.2-2.fc20 on Fedora Desktop 20 x86_64;
-                abrt 2.3.0-3.fc21 on Fedora Desktop 21 x86_64.
-              },
-              'License'        => MSF_LICENSE,
-              'Author'         =>
-                [
-                  'Tavis Ormandy', # Discovery and C exploit
-                  'bcoles' # Metasploit
-                ],
-              'DisclosureDate' => '2015-04-14',
-              'Platform'       => [ 'linux' ],
-              'Arch'           => [ ARCH_X86, ARCH_X64 ],
-              'SessionTypes'   => [ 'shell', 'meterpreter' ],
-              'Compat' => {
-                'Meterpreter' => {
-                  'Commands' => %w[
-                  ^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
-                    stdapi_sys_process_*
-                    ^^^^^^^^^^^^^^^^^^^^ Compatibility command does not have an associated method call.
-                  ]
-                }
-              }
-            )
-          )
-        end
-        def run
-          session.sys.process.execute 'shell', "command"
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
-          passwd_stat = session.fs.file.stat(@chown_file).stathash
-                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
-        end
-      end
+            class DummyModule
+              def initialize(info = {})
+                  super(update_info(info,
+                    'Name'           => 'ABRT raceabrt Privilege Escalation',
+                    'Description'    => %q{
+                      This module attempts to gain root privileges on Linux systems with
+                      a vulnerable version of Automatic Bug Reporting Tool (ABRT) configured
+                      as the crash handler.
+
+                      A race condition allows local users to change ownership of arbitrary
+                      files (CVE-2015-3315). This module uses a symlink attack on
+                      `/var/tmp/abrt/*/maps` to change the ownership of `/etc/passwd`,
+                      then adds a new user with UID=0 GID=0 to gain root privileges.
+                      Winning the race could take a few minutes.
+
+                      This module has been tested successfully on:
+
+                      abrt 2.1.11-12.el7 on RHEL 7.0 x86_64;
+                      abrt 2.1.5-1.fc19 on Fedora Desktop 19 x86_64;
+                      abrt 2.2.1-1.fc19 on Fedora Desktop 19 x86_64;
+                      abrt 2.2.2-2.fc20 on Fedora Desktop 20 x86_64;
+                      abrt 2.3.0-3.fc21 on Fedora Desktop 21 x86_64.
+                    },
+                    'License'        => MSF_LICENSE,
+                    'Author'         =>
+                      [
+                        'Tavis Ormandy', # Discovery and C exploit
+                        'bcoles' # Metasploit
+                      ],
+                    'DisclosureDate' => '2015-04-14',
+                    'Platform'       => [ 'linux' ],
+                    'Arch'           => [ ARCH_X86, ARCH_X64 ],
+                    'SessionTypes'   => [ 'shell', 'meterpreter' ],
+                    'Compat' => {
+                      'Meterpreter' => {
+                        'Commands' => %w[
+                        ^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+                          stdapi_sys_process_*
+                          ^^^^^^^^^^^^^^^^^^^^ Compatibility command does not have an associated method call.
+                        ]
+                      }
+                    }
+                  )
+                )
+              end
+              def run
+                session.sys.process.execute 'shell', "command"
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+                passwd_stat = session.fs.file.stat(@chown_file).stathash
+                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+              end
+            end
     RUBY
 
     expect_correction(<<~RUBY)
-      class DummyModule
-        def initialize(info = {})
-            super(update_info(info,
-              'Name'           => 'ABRT raceabrt Privilege Escalation',
-              'Description'    => %q{
-                This module attempts to gain root privileges on Linux systems with
-                a vulnerable version of Automatic Bug Reporting Tool (ABRT) configured
-                as the crash handler.
-        
-                A race condition allows local users to change ownership of arbitrary
-                files (CVE-2015-3315). This module uses a symlink attack on
-                `/var/tmp/abrt/*/maps` to change the ownership of `/etc/passwd`,
-                then adds a new user with UID=0 GID=0 to gain root privileges.
-                Winning the race could take a few minutes.
-        
-                This module has been tested successfully on:
-        
-                abrt 2.1.11-12.el7 on RHEL 7.0 x86_64;
-                abrt 2.1.5-1.fc19 on Fedora Desktop 19 x86_64;
-                abrt 2.2.1-1.fc19 on Fedora Desktop 19 x86_64;
-                abrt 2.2.2-2.fc20 on Fedora Desktop 20 x86_64;
-                abrt 2.3.0-3.fc21 on Fedora Desktop 21 x86_64.
-              },
-              'License'        => MSF_LICENSE,
-              'Author'         =>
-                [
-                  'Tavis Ormandy', # Discovery and C exploit
-                  'bcoles' # Metasploit
-                ],
-              'DisclosureDate' => '2015-04-14',
-              'Platform'       => [ 'linux' ],
-              'Arch'           => [ ARCH_X86, ARCH_X64 ],
-              'SessionTypes'   => [ 'shell', 'meterpreter' ],
-              'Compat' => {
-                'Meterpreter' => {
-                  'Commands' => %w[
-                    stdapi_fs_stat
-                    stdapi_sys_process_execute
-                  ]
-                }
-              }
-            )
-          )
-        end
-        def run
-          session.sys.process.execute 'shell', "command"
-          passwd_stat = session.fs.file.stat(@chown_file).stathash
-        end
-      end
+            class DummyModule
+              def initialize(info = {})
+                  super(update_info(info,
+                    'Name'           => 'ABRT raceabrt Privilege Escalation',
+                    'Description'    => %q{
+                      This module attempts to gain root privileges on Linux systems with
+                      a vulnerable version of Automatic Bug Reporting Tool (ABRT) configured
+                      as the crash handler.
+
+                      A race condition allows local users to change ownership of arbitrary
+                      files (CVE-2015-3315). This module uses a symlink attack on
+                      `/var/tmp/abrt/*/maps` to change the ownership of `/etc/passwd`,
+                      then adds a new user with UID=0 GID=0 to gain root privileges.
+                      Winning the race could take a few minutes.
+
+                      This module has been tested successfully on:
+
+                      abrt 2.1.11-12.el7 on RHEL 7.0 x86_64;
+                      abrt 2.1.5-1.fc19 on Fedora Desktop 19 x86_64;
+                      abrt 2.2.1-1.fc19 on Fedora Desktop 19 x86_64;
+                      abrt 2.2.2-2.fc20 on Fedora Desktop 20 x86_64;
+                      abrt 2.3.0-3.fc21 on Fedora Desktop 21 x86_64.
+                    },
+                    'License'        => MSF_LICENSE,
+                    'Author'         =>
+                      [
+                        'Tavis Ormandy', # Discovery and C exploit
+                        'bcoles' # Metasploit
+                      ],
+                    'DisclosureDate' => '2015-04-14',
+                    'Platform'       => [ 'linux' ],
+                    'Arch'           => [ ARCH_X86, ARCH_X64 ],
+                    'SessionTypes'   => [ 'shell', 'meterpreter' ],
+                    'Compat' => {
+                      'Meterpreter' => {
+                        'Commands' => %w[
+                          stdapi_fs_stat
+                          stdapi_sys_process_execute
+                        ]
+                      }
+                    }
+                  )
+                )
+              end
+              def run
+                session.sys.process.execute 'shell', "command"
+                passwd_stat = session.fs.file.stat(@chown_file).stathash
+              end
+            end
     RUBY
   end
 
-  it 'tracks the use of processes' do
+  it 'tracks the use of processes when api calls are being called against a process variable' do
     expect_offense(<<~RUBY)
       class DummyModule
         def initialize
@@ -1695,118 +1695,117 @@ RSpec.describe RuboCop::Cop::Lint::MeterpreterCommandDependencies, :config do
         ^{keyword}^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
       EOF
 
-      code_snippet_without_error_lines = (
+      code_snippet_without_error_lines =
         code_snippet_with_errors
-          .lines
-          .reject { |line| line.lstrip.start_with?('^{keyword}') || line.lstrip.start_with?('_{keyword}')}
-          .join
-          .gsub('%{keyword}', keyword)
-      )
+        .lines
+        .reject { |line| line.lstrip.start_with?('^{keyword}') || line.lstrip.start_with?('_{keyword}') }
+        .join
+        .gsub('%{keyword}', keyword)
 
       expect_offense(<<~RUBY, keyword: keyword)
-        class DummyModule
-              ^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
-          def run
-  #{code_snippet_with_errors}
-          end
-        end
+              class DummyModule
+                    ^^^^^^^^^^^ Convert meterpreter api calls into meterpreter command dependencies.
+                def run
+        #{code_snippet_with_errors}
+                end
+              end
       RUBY
 
       expect_correction(<<~RUBY)
-        class DummyModule
-          def initialize(info = {})
-            super(
-              update_info(
-                info,
-                'Compat' => {
-                  'Meterpreter' => {
-                    'Commands' => %w[
-                      android_*
-                      appapi_app_install
-                      core_channel_close
-                      core_channel_eof
-                      core_channel_open
-                      core_channel_read
-                      core_channel_tell
-                      core_channel_write
-                      espia_image_get_dev_screen
-                      extapi_adsi_domain_query
-                      extapi_pageant_send_query
-                      extapi_wmi_query
-                      incognito_impersonate_token
-                      incognito_list_tokens
-                      kiwi_exec_cmd
-                      lanattacks_add_tftp_file
-                      lanattacks_dhcp_log
-                      lanattacks_reset_dhcp
-                      lanattacks_set_dhcp_option
-                      lanattacks_start_dhcp
-                      lanattacks_start_tftp
-                      lanattacks_stop_dhcp
-                      lanattacks_stop_tftp
-                      peinjector_inject_shellcode
-                      priv_elevate_getsystem
-                      priv_fs_get_file_mace
-                      priv_fs_set_file_mace
-                      priv_passwd_get_sam_hashes
-                      stdapi_fs_*
-                      stdapi_fs_chmod
-                      stdapi_fs_delete_dir
-                      stdapi_fs_delete_file
-                      stdapi_fs_file_copy
-                      stdapi_fs_file_expand_path
-                      stdapi_fs_file_move
-                      stdapi_fs_getwd
-                      stdapi_fs_ls
-                      stdapi_fs_md5
-                      stdapi_fs_mkdir
-                      stdapi_fs_mount_show
-                      stdapi_fs_search
-                      stdapi_fs_separator
-                      stdapi_fs_sha1
-                      stdapi_fs_stat
-                      stdapi_net_config_add_route
-                      stdapi_net_config_get_interfaces
-                      stdapi_net_config_get_routes
-                      stdapi_net_resolve_host
-                      stdapi_railgun_*
-                      stdapi_registry_check_key_exists
-                      stdapi_registry_create_key
-                      stdapi_registry_delete_key
-                      stdapi_registry_enum_key_direct
-                      stdapi_registry_enum_value_direct
-                      stdapi_registry_load_key
-                      stdapi_registry_open_key
-                      stdapi_registry_open_remote_key
-                      stdapi_registry_query_value_direct
-                      stdapi_registry_set_value_direct
-                      stdapi_registry_unload_key
-                      stdapi_sys_config_driver_list
-                      stdapi_sys_config_getenv
-                      stdapi_sys_config_getprivs
-                      stdapi_sys_config_getsid
-                      stdapi_sys_config_getuid
-                      stdapi_sys_config_rev2self
-                      stdapi_sys_config_steal_token
-                      stdapi_sys_config_sysinfo
-                      stdapi_sys_power_exitwindows
-                      stdapi_sys_process_attach
-                      stdapi_sys_process_execute
-                      stdapi_sys_process_get_processes
-                      stdapi_sys_process_getpid
-                      stdapi_sys_process_kill
-                      stdapi_webcam_*
-                    ]
-                  }
-                }
-              )
-            )
-          end
+              class DummyModule
+                def initialize(info = {})
+                  super(
+                    update_info(
+                      info,
+                      'Compat' => {
+                        'Meterpreter' => {
+                          'Commands' => %w[
+                            android_*
+                            appapi_app_install
+                            core_channel_close
+                            core_channel_eof
+                            core_channel_open
+                            core_channel_read
+                            core_channel_tell
+                            core_channel_write
+                            espia_image_get_dev_screen
+                            extapi_adsi_domain_query
+                            extapi_pageant_send_query
+                            extapi_wmi_query
+                            incognito_impersonate_token
+                            incognito_list_tokens
+                            kiwi_exec_cmd
+                            lanattacks_add_tftp_file
+                            lanattacks_dhcp_log
+                            lanattacks_reset_dhcp
+                            lanattacks_set_dhcp_option
+                            lanattacks_start_dhcp
+                            lanattacks_start_tftp
+                            lanattacks_stop_dhcp
+                            lanattacks_stop_tftp
+                            peinjector_inject_shellcode
+                            priv_elevate_getsystem
+                            priv_fs_get_file_mace
+                            priv_fs_set_file_mace
+                            priv_passwd_get_sam_hashes
+                            stdapi_fs_*
+                            stdapi_fs_chmod
+                            stdapi_fs_delete_dir
+                            stdapi_fs_delete_file
+                            stdapi_fs_file_copy
+                            stdapi_fs_file_expand_path
+                            stdapi_fs_file_move
+                            stdapi_fs_getwd
+                            stdapi_fs_ls
+                            stdapi_fs_md5
+                            stdapi_fs_mkdir
+                            stdapi_fs_mount_show
+                            stdapi_fs_search
+                            stdapi_fs_separator
+                            stdapi_fs_sha1
+                            stdapi_fs_stat
+                            stdapi_net_config_add_route
+                            stdapi_net_config_get_interfaces
+                            stdapi_net_config_get_routes
+                            stdapi_net_resolve_host
+                            stdapi_railgun_*
+                            stdapi_registry_check_key_exists
+                            stdapi_registry_create_key
+                            stdapi_registry_delete_key
+                            stdapi_registry_enum_key_direct
+                            stdapi_registry_enum_value_direct
+                            stdapi_registry_load_key
+                            stdapi_registry_open_key
+                            stdapi_registry_open_remote_key
+                            stdapi_registry_query_value_direct
+                            stdapi_registry_set_value_direct
+                            stdapi_registry_unload_key
+                            stdapi_sys_config_driver_list
+                            stdapi_sys_config_getenv
+                            stdapi_sys_config_getprivs
+                            stdapi_sys_config_getsid
+                            stdapi_sys_config_getuid
+                            stdapi_sys_config_rev2self
+                            stdapi_sys_config_steal_token
+                            stdapi_sys_config_sysinfo
+                            stdapi_sys_power_exitwindows
+                            stdapi_sys_process_attach
+                            stdapi_sys_process_execute
+                            stdapi_sys_process_get_processes
+                            stdapi_sys_process_getpid
+                            stdapi_sys_process_kill
+                            stdapi_webcam_*
+                          ]
+                        }
+                      }
+                    )
+                  )
+                end
 
-          def run
-  #{code_snippet_without_error_lines}
-          end
-        end
+                def run
+        #{code_snippet_without_error_lines}
+                end
+              end
       RUBY
     end
   end
@@ -1833,12 +1832,12 @@ RSpec.describe RuboCop::Cop::Lint::MeterpreterCommandDependencies, :config do
     # Handle wildcard matchers, i.e. `stdapi_railgun_*`
     api_commands_handled_via_wildcards = []
     autocorrected_meterpreter_command_names.each do |command|
-      if command.end_with?('_*')
-        prefix = command.gsub("_*", "")
-        api_commands_without_matchers.each do |unmatched_command|
-          if unmatched_command.start_with?(prefix)
-            api_commands_handled_via_wildcards << unmatched_command
-          end
+      next unless command.end_with?('_*')
+
+      prefix = command.gsub('_*', '')
+      api_commands_without_matchers.each do |unmatched_command|
+        if unmatched_command.start_with?(prefix)
+          api_commands_handled_via_wildcards << unmatched_command
         end
       end
     end
@@ -1847,46 +1846,45 @@ RSpec.describe RuboCop::Cop::Lint::MeterpreterCommandDependencies, :config do
 
     # Remove known core command ids
     ignored_core_command_ids = [
-       "core_channel_interact",
-       "core_channel_seek",
-       "core_console_write",
-       "core_enumextcmd",
-       "core_get_session_guid",
-       "core_loadlib",
-       "core_machine_id",
-       "core_migrate",
-       "core_native_arch",
-       "core_negotiate_tlv_encryption",
-       "core_patch_url",
-       "core_pivot_add",
-       "core_pivot_remove",
-       "core_pivot_session_died",
-       "core_set_session_guid",
-       "core_set_uuid",
-       "core_shutdown",
-       "core_transport_add",
-       "core_transport_change",
-       "core_transport_getcerthash",
-       "core_transport_list",
-       "core_transport_next",
-       "core_transport_prev",
-       "core_transport_remove",
-       "core_transport_setcerthash",
-       "core_transport_set_timeouts",
-       "core_transport_sleep",
-       "core_pivot_session_new",
+      'core_channel_interact',
+      'core_channel_seek',
+      'core_console_write',
+      'core_enumextcmd',
+      'core_get_session_guid',
+      'core_loadlib',
+      'core_machine_id',
+      'core_migrate',
+      'core_native_arch',
+      'core_negotiate_tlv_encryption',
+      'core_patch_url',
+      'core_pivot_add',
+      'core_pivot_remove',
+      'core_pivot_session_died',
+      'core_set_session_guid',
+      'core_set_uuid',
+      'core_shutdown',
+      'core_transport_add',
+      'core_transport_change',
+      'core_transport_getcerthash',
+      'core_transport_list',
+      'core_transport_next',
+      'core_transport_prev',
+      'core_transport_remove',
+      'core_transport_setcerthash',
+      'core_transport_set_timeouts',
+      'core_transport_sleep',
+      'core_pivot_session_new',
     ]
 
     api_commands_without_matchers -= ignored_core_command_ids
 
     # Remove additional command ids
     other_ignored_command_ids = [
-      "stdapi_net_tcp_channel_open",
-      "stdapi_net_socket_tcp_shutdown"
+      'stdapi_net_tcp_channel_open',
+      'stdapi_net_socket_tcp_shutdown'
     ]
 
     api_commands_without_matchers -= other_ignored_command_ids
     expect(api_commands_without_matchers).to be_empty
   end
 end
-


### PR DESCRIPTION
# WIP
Continuation from work started in #15079

This PR adds a new Rubocop rule along with tests. The cop will enforce that when ran against Metasploit modules, it will generate a Meterpreter commands list if there are any Meterpreter api calls present within said module.

The current plan is to leave this PR open and run the cop against subsections of modules and have those reviewed and landed. Then any feedback can be implemented in this PR. Once the cop has been ran against the necessary modules we can then come back and review/land this PR as a final step.

## Note
As seen in the tests, there is support to alter/add sections of methods depending on various situations. e.g. 
"The cop verifies if a there is an initialise method, if no initialise present, it should be generated and appended appropriately."

I have tried to identify as many of these scenarios as possible, but if there are anymore edge-cases that may not have been covered in the tests, please call them out and I can get tests added as needed 🕵️ 
