### PR TITLE
Enhance command_exists? method so that it falls to `which` in case the `command` fails

### DIFF
--- a/lib/msf/core/post/common.rb
+++ b/lib/msf/core/post/common.rb
@@ -211,7 +211,7 @@ module Msf::Post::Common
       # https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/if
       cmd_exec("cmd /c where /q #{cmd} & if not errorlevel 1 echo true").to_s.include? 'true'
     else
-      cmd_exec("command -v #{cmd} && echo true").to_s.include? 'true'
+      cmd_exec("command -v #{cmd} || which #{cmd} && echo true").to_s.split("\n")[-1] == 'true'
     end
   rescue
     raise "Unable to check if command `#{cmd}' exists"

--- a/lib/msf/core/post/linux/priv.rb
+++ b/lib/msf/core/post/linux/priv.rb
@@ -41,21 +41,6 @@ module Priv
     cmd_exec("echo '#{file_origin}' > #{final_file}")
   end
 
-  def pids()
-    dir_proc = "/proc/"
-    pids = []
-
-    directories_proc = dir(dir_proc)
-    directories_proc.each do |elem|
-      elem.gsub( / *\n+/, "")
-      if elem[-1] == '1' || elem[-1] == '2' || elem[-1] == '3' || elem[-1] == '4' || elem[-1] == '5' || elem[-1] == '6' || elem[-1] == '7' || elem[-1] == '8' || elem[-1] == '9' || elem[-1] == '0'
-        pids.insert(-1, elem)
-      end
-    end
-
-    return pids.sort_by(&:to_i)
-  end
-
   def binary_of_pid(pid)
     binary = read_file("/proc/#{pid}/cmdline")
     if binary == "" #binary.empty?


### PR DESCRIPTION
## Summary
This PR adds a small enhancement to the `command_exists?` method under `post/common.rb`. Currently it is using the `command` command to check if some command is present on the target system but in some cases that utility might not be present(see [here](https://github.com/rapid7/metasploit-framework/pull/15000#discussion_r609760330) for an example). So in that case it will fall to some other alternative like `which`.

This PR also removes a method `pids` which was removed in the PR #15199 but while refactoring it's code in the new `process.rb` the change was missed.