### PR TITLE
Fix RuboCop issues with sudo_baron_samedit.rb

### DIFF
--- a/modules/exploits/linux/local/sudo_baron_samedit.rb
+++ b/modules/exploits/linux/local/sudo_baron_samedit.rb
@@ -237,7 +237,6 @@ class MetasploitModule < Msf::Exploit::Local
         nil
       end
     end
-
   end
 
   def exploit_nss(resolved_target)


### PR DESCRIPTION
Minor fix that I noted whilst talking with @todb-r7 whereby some new rules might have been added that now cause `sudo_baron_samedit.rb` to fail RuboCop checks. This PR fixes those so that some of our backend builds can run successfully without failing.

## Verification

List the steps needed to make sure this thing works

- [x] Verify that `rubocop -a modules/exploits/linux/local/sudo_baron_samedit.rb` runs without returning any issues.