### PR TITLE
Ordering Output of 'msfconsole' 'options' Command

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -1441,7 +1441,7 @@ module Msf
               [ 'Prompt', framework.datastore['Prompt'] || Msf::Ui::Console::Driver::DefaultPrompt.to_s.gsub(/%.../,"") , "The prompt string" ],
               [ 'PromptChar', framework.datastore['PromptChar'] || Msf::Ui::Console::Driver::DefaultPromptChar.to_s.gsub(/%.../,""), "The prompt character" ],
               [ 'PromptTimeFormat', framework.datastore['PromptTimeFormat'] || Time::DATE_FORMATS[:db].to_s, 'Format for timestamp escapes in prompts' ],
-              [ 'MeterpreterPrompt', framework.datastore['MeterpreterPrompt'] || '%undmeterpreter%clr', 'The meterpreter prompt string' ],
+              [ 'MeterpreterPrompt', framework.datastore['MeterpreterPrompt'] || 'meterpreter', 'The meterpreter prompt string' ],
             ].each { |r| tbl << r }
 
             print(tbl.to_s)


### PR DESCRIPTION
When i use 'options' command in 'msfconsole', the output is not ordered right, after 'MeterpreterPrompt' option 'value',
'%undmeterpreter%clr', and before the description, should be more spaces, i think it's about a sorting function that can not work with underscores, idk, i just removed  the underscore, and it's ok now

## Verification

List the steps needed to see the global options list (where it happening)

- [1] Start `msfconsole`
- [2] `options`

## Version
Framework: 6.0.46-dev
Console  : 6.0.46-dev

i use kali with gnome terminal, Thank you