### PR TITLE
Fix `dir` method for windows shell sessions

### DIFF
--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -53,7 +53,7 @@ module Msf::Post::File
       if session.platform == 'windows'
         # XXX: %CD% only exists on XP and newer, figure something out for NT4
         # and 2k
-        return session.shell_command_token("echo %CD%")
+        return session.shell_command_token("echo %CD%").to_s.strip
       else
         if command_exists?("pwd")
           return session.shell_command_token("pwd").to_s.strip
@@ -73,8 +73,14 @@ module Msf::Post::File
       return session.fs.dir.entries(directory)
     end
 
+    if session.type == 'powershell'
+      dir = session.shell_command_token("Get-ChildItem \"#{directory}\" | Format-Table Name").split(/[\r\n]+/)
+      dir.slice!(0..2)
+      return dir
+    end
+
     if session.platform == 'windows'
-      return session.shell_command_token("dir #{directory}").split(/[\r\n]+/)
+      return session.shell_command_token("dir /b \"#{directory}\"").split(/[\r\n]+/)
     end
 
     if command_exists?('ls')

--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -75,7 +75,7 @@ module Msf::Post::File
 
     if session.type == 'powershell'
       dir = session.shell_command_token("Get-ChildItem \"#{directory}\" | Format-Table Name").split(/[\r\n]+/)
-      dir.slice!(0..2)
+      dir.slice!(0..2) if dir.length > 2
       return dir
     end
 

--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -80,7 +80,7 @@ module Msf::Post::File
     end
 
     if session.platform == 'windows'
-      return session.shell_command_token("dir /b \"#{directory}\"").split(/[\r\n]+/)
+      return session.shell_command_token("dir /b \"#{directory}\"")&.split(/[\r\n]+/)
     end
 
     if command_exists?('ls')


### PR DESCRIPTION
## Summary
This PR fixes a bug in the `dir` method under `msf/core/post/file.rb`.

This method is expected to return a list of entries(files/directories) for the specified directory but for the `windows` platform(non-meterpreter) which also includes session type `powershell`, it seems inconsistent because it returns the output of `C:\Users> dir [directory]` command. Also the output for the `dir` command is different in case of `powershell` so they both should be parsed differently.

## Before
```ruby
>> dir '.'
=> 
[" Volume in drive Z is Computer",
 " Volume Serial Number is 23dsf92309",
 " Directory of Z:\\Users\\user\\Links",
 "06-06-2021  08.18 PM    <DIR>          .",
 "06-06-2021  08.18 PM    <DIR>          ..",
 "16-10-2020  01.48 PM               532 Desktop.lnk",
 "16-10-2020  01.48 PM               977 Downloads.lnk",
 "14-04-2021  12.27 PM             7,168 windows_shell_stage_64.exe",
 "12-04-2021  04.12 PM           250,368 windows_stage_tcp.exe",
 "               4 File(s)        259,045 bytes",
 "               2 Dir(s)  217,593,282,560 bytes free"]
>> 
```
## After
```ruby
>> dir '.'
=> ["Desktop.lnk", "Downloads.lnk", "windows_shell_stage_64.exe", "windows_stage_tcp.exe"]
>> 
```
## Note
I've not tested this for powershell session type because I was facing some issues while running the `reverse_powershell` payload.