### PR TITLE
Add rhost alias to rhosts option

### DIFF
--- a/lib/msf/core/opt.rb
+++ b/lib/msf/core/opt.rb
@@ -41,7 +41,7 @@ module Msf
 
     # @return [OptAddressRange]
     def self.RHOSTS(default=nil, required=true, desc="The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'")
-      Msf::OptAddressRange.new('RHOSTS', [ required, desc, default ])
+      Msf::OptAddressRange.new('RHOSTS', [ required, desc, default ], aliases: [ 'RHOST' ])
     end
 
     def self.RHOST(default=nil, required=true, desc="The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'")


### PR DESCRIPTION
For most modules on master you can interchangably set RHOST and RHOSTS within msfconsole, however in some scenarios - such as for some scanners - you must explicitly use RHOSTS only, and RHOST does not work. This PR updates the options to be interchangeable.

## Verification

Create a new aux module:

```ruby
$ cat modules/auxiliary/helloworld.rb 

class MetasploitModule < Msf::Auxiliary
  def initialize(info = {})
    super(
      update_info(
        info,
        'Name' => 'Sample Auxiliary Module',
        'Description' => 'Sample Auxiliary Module',
        'Author' => ['Joe Module <joem@example.com>'],
        'License' => MSF_LICENSE,
        # The action(s) that will run as background job
        'PassiveActions' => [
          'Another Action'
        ],
        'DefaultAction' => 'Default Action'
      )
    )

    register_options(
      [
        Opt::RHOSTS
      ]
    )
  end

  def check
    print_status("Checking with rhost: #{datastore['RHOSTS']}")
  end

  def run
    print_status("Running with rhost: #{datastore['RHOSTS']}")
  end
end
```

#### Master
Use the module, set the rhost, and attempt to run the module. It fails validation:
```
msf6 auxiliary(helloworld) > set rhost 127.0.0.1
rurhost => 127.0.0.1
msf6 auxiliary(helloworld) > run
[-] Auxiliary failed: Msf::OptionValidateError One or more options failed to validate: RHOSTS.
```

### This Branch

Use the module, set the rhost, and attempt to run the module. It passes validation and runs:

```
msf6 auxiliary(helloworld) > set rhost 127.0.0.1
rhost => 127.0.0.1
msf6 auxiliary(helloworld) > run
[*] Running module against 127.0.0.1

[*] Running with rhost: 127.0.0.1
[*] Auxiliary module execution completed
```