### PR TITLE
Fix localization issue in `windows/enum_hyperv_vms`

### DIFF
--- a/lib/msf/core/post/windows/powershell.rb
+++ b/lib/msf/core/post/windows/powershell.rb
@@ -342,7 +342,7 @@ module Msf
               return out
             end
             ps_output = get_ps_output(cmd_out, eof, datastore['Powershell::Post::timeout'])
-            ps_output = ps_output[/#{Regexp.escape(start)}(.*?)#{Regexp.escape(stop)}/m, 1].strip  #https://stackoverflow.com/a/9661504
+            ps_output = ps_output[/#{start}(.*?)#{stop}/m, 1].strip  #https://stackoverflow.com/a/9661504
             # Kill off the resulting processes if needed
             if ps_cleanup
               vprint_good "Cleaning up #{running_pids.join(', ')}"

--- a/lib/msf/core/post/windows/powershell.rb
+++ b/lib/msf/core/post/windows/powershell.rb
@@ -307,8 +307,10 @@ module Msf
           eof = Rex::Text.rand_text_alpha(8)
           # eof = "THIS__SCRIPT_HAS__COMPLETED_EXECUTION#{rand(100)}"
           env_suffix = Rex::Text.rand_text_alpha(8)
+          start = Rex::Text.rand_text_alpha(8)
+          stop = Rex::Text.rand_text_alpha(8)
+          script = "echo #{start};" + script + "; echo #{stop}"
           script = Rex::Powershell::Script.new(script) unless script.respond_to?(:compress_code)
-
           # Check to ensure base64 encoding - regex format and content length division
           unless script.to_s.match(/[A-Za-z0-9+\/]+={0,3}/)[0] == script.to_s && (script.to_s.length % 4).zero?
             script = encode_script(compress_script(script.to_s, eof), eof)
@@ -340,6 +342,7 @@ module Msf
               return out
             end
             ps_output = get_ps_output(cmd_out, eof, datastore['Powershell::Post::timeout'])
+            ps_output = ps_output[/#{Regexp.escape(start)}(.*?)#{Regexp.escape(stop)}/m, 1].strip  #https://stackoverflow.com/a/9661504
             # Kill off the resulting processes if needed
             if ps_cleanup
               vprint_good "Cleaning up #{running_pids.join(', ')}"

--- a/modules/post/windows/gather/enum_hyperv_vms.rb
+++ b/modules/post/windows/gather/enum_hyperv_vms.rb
@@ -37,8 +37,8 @@ class MetasploitModule < Msf::Post
     end
     get_vm = "try { Get-VM } catch {echo #{error_token}; echo $Error[0]}"
     results = psh_exec(get_vm)
-    if results =~ /#{error_token}/
-      results.delete!(error_token)
+    if results.starts_with?(error_token)
+      results = results.delete_prefix(error_token).strip
       print_error("Error running `Get-VM` command. \n #{results} ")
       return
     end

--- a/modules/post/windows/gather/enum_hyperv_vms.rb
+++ b/modules/post/windows/gather/enum_hyperv_vms.rb
@@ -30,11 +30,10 @@ class MetasploitModule < Msf::Post
     unless have_powershell?
       fail_with(Failure::NoAccess, "The target does not have PowerShell installed so we can't access the state of the Hyper-V VMs")
     end
-    results = psh_exec('Get-VM')
-    if results =~ /is not recognized as the name of a cmdlet/
-      print_error('The target is not a Hyper-V host')
-    elsif results =~ /do not have the required permission/
-      print_error('You need to be running as an elevated admin or a user of the Hyper-V Administrators group to run this module')
+    get_vm = 'try { Get-VM } catch { echo "false" }'
+    results = psh_exec(get_vm)
+    if results == 'false'
+      print_error('Error running `Get-VM` command. Either the target is not a hyper-V host or you do not have enough permissions!')
       return
     end
     vprint_status(results)

--- a/modules/post/windows/gather/enum_hyperv_vms.rb
+++ b/modules/post/windows/gather/enum_hyperv_vms.rb
@@ -39,7 +39,8 @@ class MetasploitModule < Msf::Post
     results = psh_exec(get_vm)
     if results.starts_with?(error_token)
       results = results.delete_prefix(error_token).strip
-      print_error("Error running `Get-VM` command. \n #{results} ")
+      print_error('Error running `Get-VM` command:')
+      print_line(results)
       return
     end
     vprint_status(results)

--- a/modules/post/windows/gather/enum_hyperv_vms.rb
+++ b/modules/post/windows/gather/enum_hyperv_vms.rb
@@ -30,10 +30,11 @@ class MetasploitModule < Msf::Post
     unless have_powershell?
       fail_with(Failure::NoAccess, "The target does not have PowerShell installed so we can't access the state of the Hyper-V VMs")
     end
-    get_vm = 'try { Get-VM } catch { echo "false" }'
+    get_vm = "try { Get-VM } catch {echo #{error_token}; echo $Error[0]}"
     results = psh_exec(get_vm)
-    if results == 'false'
-      print_error('Error running `Get-VM` command. Either the target is not a hyper-V host or you do not have enough permissions!')
+    if results =~ /#{error_token}/
+      results.delete!(error_token)
+      print_error("Error running `Get-VM` command. \n #{results} ")
       return
     end
     vprint_status(results)

--- a/modules/post/windows/gather/enum_hyperv_vms.rb
+++ b/modules/post/windows/gather/enum_hyperv_vms.rb
@@ -21,7 +21,12 @@ class MetasploitModule < Msf::Post
         'Author' =>
           [
             'gwillcox-r7' # Metasploit post module
-          ]
+          ],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => []
+        }
       )
       )
   end

--- a/modules/post/windows/gather/enum_hyperv_vms.rb
+++ b/modules/post/windows/gather/enum_hyperv_vms.rb
@@ -35,6 +35,7 @@ class MetasploitModule < Msf::Post
     unless have_powershell?
       fail_with(Failure::NoAccess, "The target does not have PowerShell installed so we can't access the state of the Hyper-V VMs")
     end
+    error_token = Rex::Text.rand_text_alpha(8)
     get_vm = "try { Get-VM } catch {echo #{error_token}; echo $Error[0]}"
     results = psh_exec(get_vm)
     if results.starts_with?(error_token)


### PR DESCRIPTION
## Summary

This PR fixes a localization issue in the module `post/windows/gather/enum_hyperv_vms`. There are two checks in the module which rely on the English error messages of powershell, which might vary with locale.
1) `/do not have the required permission/`
2) `/is not recognized as the name of a cmdlet/`

This PR also strips the unwanted output of the `psh_exec` method which was returning extra data on both the sides of the expected output.

## Before
```
>> psh_exec('whoami')

[+] Compressed size: 800
=> "#< CLIXML\r\user\\user\r\n<Objs Version=\"1.1.0.1\" xmlns=\"http://schemas.microsoft.com/powershell/2004/04\"><Obj S=\"progress\" RefId=\"0\"><TN RefId=\"0\"><T>System.Management.Automation.PSCustomObject</T><T>System.Object</T></TN><MS><I64 N=\"SourceId\">1</I64><PR N=\"Record\"><AV>Preparing modules for first use.</AV><AI>0</AI><Nil /><PI>-1</PI><PC>-1</PC><T>Completed</T><SR>-1</SR><SD> </SD></PR></MS></Obj></Objs>"
>> 
```
## After
```
>> psh_exec('whoami')

[+] Compressed size: 896
=> "user\\user"
>> 
```
## Note
I tested the module on my system which is not a hyper-V host and the results were as expected for that case. But I couldn't test it with an actual hyper-V host.
