### PR TITLE
Bump metasploit-payloads gem to 2.0.47

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,7 +29,7 @@ PATH
       metasploit-concern (~> 3.0.0)
       metasploit-credential (~> 4.0.0)
       metasploit-model (~> 3.1.0)
-      metasploit-payloads (= 2.0.45)
+      metasploit-payloads (= 2.0.47)
       metasploit_data_models (~> 4.1.0)
       metasploit_payloads-mettle (= 1.0.10)
       mqtt
@@ -236,7 +236,7 @@ GEM
       activemodel (~> 5.2.2)
       activesupport (~> 5.2.2)
       railties (~> 5.2.2)
-    metasploit-payloads (2.0.45)
+    metasploit-payloads (2.0.47)
     metasploit_data_models (4.1.4)
       activerecord (~> 5.2.2)
       activesupport (~> 5.2.2)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -70,7 +70,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model', '~> 3.1.0'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '2.0.45'
+  spec.add_runtime_dependency 'metasploit-payloads', '2.0.47'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '1.0.10'
   # Needed by msfgui and other rpc components


### PR DESCRIPTION
Bump Metasploit Payloads gem from 2.0.45 to 2.0.47 bringing in the following changes:

https://github.com/rapid7/metasploit-payloads/pull/485
https://github.com/rapid7/metasploit-payloads/pull/488

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `irb`
- [x] Run `MetasploitPayloads.list_meterpreter_extension_suffixes('stdapi')`
- [x] **Verify** the output shows `["php", "jar", "x64.dll", "py", "x86.dll"]`
