### PR TITLE
Update check command to store vuln details for CheckCode::Appears

### DIFF
--- a/lib/msf/ui/console/module_command_dispatcher.rb
+++ b/lib/msf/ui/console/module_command_dispatcher.rb
@@ -236,7 +236,7 @@ module ModuleCommandDispatcher
       end
 
       if (code && code.kind_of?(Msf::Exploit::CheckCode))
-        if (code == Msf::Exploit::CheckCode::Vulnerable)
+        if code == Msf::Exploit::CheckCode::Vulnerable || code == Msf::Exploit::CheckCode::Appears
           print_good("#{peer_msg}#{code[1]}")
           # Restore RHOST for report_vuln
           instance.datastore['RHOST'] ||= rhost


### PR DESCRIPTION
Additionally store vulns associated with a host when CheckCode::Appears is returned.

## Verification

Run vulnerable tomcat:
```
docker run --rm -p 8080:8080 -p 8009:8009 tomcat:8.5.32
```

Run the module:
```
use tomcat ghostcat
set RHOSTS 127.0.0.1
check
```

Run vulnerable thinkphp:
```
docker run -p 9001:80 vulhub/thinkphp:5.0.23
```

Run the module:
```
use unix/webapp/thinkphp_rce
set rhost 127.0.0.1
set ssl false
set rport 9001
set lhost 127.0.0.1
check
```

### Before

View hosts and vulns:
```
msf6 exploit(unix/webapp/thinkphp_rce) > hosts

Hosts
=====

address    mac  name  os_name  os_flavor  os_sp  purpose  info  comments
-------    ---  ----  -------  ---------  -----  -------  ----  --------
127.0.0.1

msf6 exploit(unix/webapp/thinkphp_rce) > vulns

Vulnerabilities
===============

Timestamp  Host  Name  References
---------  ----  ----  ----------
```

### After

Verify hosts and vulns are now populated:
```
msf6 exploit(unix/webapp/thinkphp_rce) > hosts

Hosts
=====

address          mac  name  os_name  os_flavor  os_sp  purpose  info  comments
-------          ---  ----  -------  ---------  -----  -------  ----  --------
127.0.0.1

msf6 exploit(unix/webapp/thinkphp_rce) > vulns

Vulnerabilities
===============

Timestamp                Host             Name                                  References
---------                ----             ----                                  ----------
2021-06-10 12:22:51 UTC  127.0.0.1        Ghostcat                              CVE-2020-1938
2021-06-10 12:23:35 UTC  127.0.0.1        ThinkPHP Multiple PHP Injection RCEs  CVE-2018-20062,CVE-2019-9082,URL-https://github.com/vulhub/vulhub/tree/master/thi
                                                                                nkphp/5-rce,URL-https://github.com/vulhub/vulhub/tree/master/thinkphp/5.0.23-rce


```