### PR TITLE
Update rpc analyze command to support latest functionality

### DIFF
--- a/spec/api/json_rpc_spec.rb
+++ b/spec/api/json_rpc_spec.rb
@@ -9,22 +9,57 @@ require 'rack/protection'
 # response contract. These test should help catch such scenarios.
 RSpec.describe "Metasploit's json-rpc" do
   include Rack::Test::Methods
+  include_context 'Msf::DBManager'
   include_context 'Metasploit::Framework::Spec::Constants cleaner'
-  include_context 'Msf::Framework#threads cleaner'
+  include_context 'Msf::Framework#threads cleaner', verify_cleanup_required: false
 
-  let(:app) { subject }
   let(:health_check_url) { '/api/v1/health' }
   let(:rpc_url) { '/api/v1/json-rpc' }
-  let(:framework) { app.settings.framework }
   let(:module_name) { 'scanner/ssl/openssl_heartbleed' }
   let(:a_valid_result_uuid) { { result: hash_including({ uuid: match(/\w+/) }) } }
-  let(:app) do
-    # Lazy load to ensure that the json rpc app doesn't create an instance of framework out of band
-    ::Msf::WebServices::JsonRpcApp.new
-  end
+  let(:app) { ::Msf::WebServices::JsonRpcApp.new }
 
   before(:example) do
-    allow(framework.db).to receive(:active).and_return(false)
+    framework.modules.add_module_path(File.join(FILE_FIXTURES_PATH, 'json_rpc'))
+    app.settings.framework = framework
+  end
+
+  after(:example) do
+    # Sinatra's settings are implemented as a singleton, and must be explicitly reset between runs
+    app.settings.dispatchers.clear
+  end
+
+  def report_host(host)
+    post rpc_url, {
+      jsonrpc: '2.0',
+      method: 'db.report_host',
+      id: 1,
+      params: [
+        host
+      ]
+    }.to_json
+  end
+
+  def report_vuln(vuln)
+    post rpc_url, {
+      jsonrpc: '2.0',
+      method: 'db.report_vuln',
+      id: 1,
+      params: [
+        vuln
+      ]
+    }.to_json
+  end
+
+  def analyze_host(host)
+    post rpc_url, {
+      jsonrpc: '2.0',
+      method: 'db.analyze_host',
+      id: 1,
+      params: [
+        host
+      ]
+    }.to_json
   end
 
   def create_job
@@ -252,6 +287,8 @@ RSpec.describe "Metasploit's json-rpc" do
     end
 
     context 'when the check command has an unexpected error' do
+      include_context 'Msf::Framework#threads cleaner'
+
       before(:each) do
         allow_any_instance_of(::Msf::Auxiliary::Scanner).to receive(:check) do
           res = nil
@@ -370,6 +407,184 @@ RSpec.describe "Metasploit's json-rpc" do
           id: 1
         }
         expect(last_json_response).to include(expected_error_response)
+      end
+    end
+  end
+
+  describe 'analyze' do
+    let(:host_ip) { '192.0.2.2' }
+    let(:host) do
+      {
+        workspace: 'default',
+        host: host_ip,
+        state: 'alive',
+        os_name: 'Windows',
+        os_flavor: 'Enterprize',
+        os_sp: 'SP2',
+        os_lang: 'English',
+        arch: 'ARCH_X86',
+        mac: '97-42-51-F2-A7-A7',
+        scope: 'eth2',
+        virtual_host: 'VMWare'
+      }
+    end
+
+    let(:vuln) do
+      {
+        workspace: 'default',
+        host: host_ip,
+        name: 'Exploit Name',
+        info: 'Human readable description of the vuln',
+        refs: vuln_refs
+      }
+    end
+
+    context 'when there are modules available' do
+      let(:vuln_refs) do
+        %w[
+          CVE-2017-0143
+          CVE-2016-3088
+        ]
+      end
+
+      before(:each) do
+        framework.modules.add_module_path('./modules')
+      end
+
+      context 'with no options' do
+        it 'returns the list of known modules associated with a reported host' do
+          report_host(host)
+          expect(last_response).to be_ok
+
+          report_vuln(vuln)
+          expect(last_response).to be_ok
+
+          expected_response = {
+            jsonrpc: '2.0',
+            result: {
+              host: [
+                {
+                  address: '192.0.2.2',
+                  modules: [
+                    {
+                      mname: 'exploit/multi/http/apache_activemq_upload_jsp',
+                      mtype: 'exploit'
+                    },
+                    {
+                      mtype: 'exploit',
+                      mname: 'exploit/windows/smb/ms17_010_eternalblue'
+                    },
+                    {
+                      mtype: 'exploit',
+                      mname: 'exploit/windows/smb/ms17_010_psexec',
+                    },
+                    {
+                      mtype: 'exploit',
+                      mname: 'exploit/windows/smb/smb_doublepulsar_rce',
+                    }
+                  ]
+                }
+              ]
+            },
+            id: 1
+          }
+
+          analyze_host(
+            {
+              workspace: 'default',
+              host: host_ip
+            }
+          )
+          expect(last_json_response).to include(expected_response)
+        end
+      end
+
+      context 'when payloads requirements are specified' do
+        it 'returns the list of known modules associated with a reported host' do
+          report_host(host)
+          expect(last_response).to be_ok
+
+          report_vuln(vuln)
+          expect(last_response).to be_ok
+
+          # Note: Currently the API doesn't return any differentiating output that a particular module is suitable
+          # with the requested payload
+          expected_response = {
+            jsonrpc: '2.0',
+            result: {
+              host: [
+                {
+                  address: '192.0.2.2',
+                  modules: [
+                    {
+                      mname: 'exploit/multi/http/apache_activemq_upload_jsp',
+                      mtype: 'exploit'
+                    },
+                    {
+                      mtype: 'exploit',
+                      mname: 'exploit/windows/smb/ms17_010_eternalblue'
+                    },
+                    {
+                      mtype: 'exploit',
+                      mname: 'exploit/windows/smb/ms17_010_psexec',
+                    },
+                    {
+                      mtype: 'exploit',
+                      mname: 'exploit/windows/smb/smb_doublepulsar_rce',
+                    }
+                  ]
+                }
+              ]
+            },
+            id: 1
+          }
+
+          analyze_host(
+            {
+              workspace: 'default',
+              host: host_ip,
+              payloads: [
+                'java/meterpreter/reverse_http'
+              ]
+            }
+          )
+          expect(last_json_response).to include(expected_response)
+        end
+      end
+    end
+
+    context 'when there are no modules found' do
+      let(:vuln_refs) do
+        ['CVE-NO-MATCHING-MODULES-1234']
+      end
+
+      it 'returns an empty list of modules' do
+        report_host(host)
+        expect(last_response).to be_ok
+
+        report_vuln(vuln)
+        expect(last_response).to be_ok
+
+        expected_response = {
+          jsonrpc: '2.0',
+          result: {
+            host: [
+              {
+                address: '192.0.2.2',
+                modules: []
+              }
+            ]
+          },
+          id: 1
+        }
+
+        analyze_host(
+          {
+            workspace: 'default',
+            host: host_ip
+          }
+        )
+        expect(last_json_response).to include(expected_response)
       end
     end
   end

--- a/spec/file_fixtures/json_rpc/auxiliary/scanner/ssl/openssl_heartbleed.rb
+++ b/spec/file_fixtures/json_rpc/auxiliary/scanner/ssl/openssl_heartbleed.rb
@@ -1,0 +1,34 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+###
+#
+# A placeholder module for json_rpc_spec.rb
+#
+###
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Auxiliary::Scanner
+  include Msf::Auxiliary::Report
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Placeholder openssl heartbleed module',
+        'Description' => 'Placeholder openssl heartbleed module',
+        'Author' => [],
+        'License' => MSF_LICENSE
+      )
+    )
+  end
+
+  def check_host(_ip)
+    # noop
+  end
+
+  def run_host(_ip)
+    # noop
+  end
+end

--- a/spec/file_fixtures/json_rpc/exploits/windows/smb/ms17_010_eternalblue.rb
+++ b/spec/file_fixtures/json_rpc/exploits/windows/smb/ms17_010_eternalblue.rb
@@ -1,0 +1,34 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+###
+#
+# A placeholder module for json_rpc_spec.rb
+#
+###
+class MetasploitModule < Msf::Exploit::Remote
+  include Msf::Exploit::Remote::DCERPC
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Placeholder ms17_010 module',
+        'Description' => 'Placeholder ms17_010 module',
+        'Author' => [],
+        'License' => MSF_LICENSE
+      )
+    )
+  end
+
+  def check
+    # noop
+  end
+
+  def run
+    # noop
+  end
+end

--- a/tools/dev/msfdb_ws
+++ b/tools/dev/msfdb_ws
@@ -2,7 +2,8 @@
 # -*- coding: binary -*-
 #
 # Starts the HTTP DB Service interface
-# TODO: This functionality exists within the top level msfdb.rb, and should be merged
+# TODO: This functionality exists within the top level msfdb.rb, and should be merged.
+# Note that this file is currently called by RSpec when REMOTE_DB is set
 
 require 'optparse'
 


### PR DESCRIPTION
**Draft PR to confirm the user facing API.**

Fixes a regression issue in the RPC analyze command. Adds automated integration tests to ensure it doesn't break in the future.

## Verification

- Ensure CI passes
- Testing manually with  curl requests

Run the json rpc service:
```
bundle exec thin --rackup msf-json-rpc.ru --address 0.0.0.0 --port 8081 --environment production --tag msf-json-rpc start
```

Report a host:
```bash
curl --request POST \
  --url http://localhost:8081/api/v1/json-rpc \
  --header 'Authorization: Bearer ' \
  --header 'Content-Type: application/json' \
  --data '{
	"jsonrpc": "2.0",
	"method": "db.report_host",
	"id": 1,
	"params": [
		{
			"workspace": "default",
			"host": "10.0.0.1",
			"state": "alive",
			"os_name": "Windows",
			"os_flavor": "Enterprize",
			"os_sp": "SP2",
			"os_lang": "English",
			"arch": "ARCH_X86",
			"mac": "97-42-51-F2-A7-A7",
			"scope": "eth2",
			"virtual_host": "VMWare"
		}	
	]
}'
```

Report the host's vulnerabilities:
```bash
curl --request POST \
  --url http://localhost:8081/api/v1/json-rpc \
  --header 'Authorization: Bearer ' \
  --header 'Content-Type: application/json' \
  --data '{
	"jsonrpc": "2.0",
	"method": "db.report_vuln",
	"id": 1,
	"params": [
		{
			"workspace": "default",
			"host": "10.0.0.1",
			"name": "Exploit Name",
			"info": "Human readable description of the vuln",
			"refs": [
				"CVE-2017-0143",
				"CVE-2017-0144",
				"CVE-2017-0145",
				"CVE-2017-0146",
				"CVE-2017-0147",
				"CVE-2017-0148"
			]
		}
	]
}'
```

Run the analyze command:
```
curl --request POST \
  --url http://localhost:8081/api/v1/json-rpc \
  --header 'Authorization: Bearer ' \
  --header 'Content-Type: application/json' \
  --data '{
	"jsonrpc": "2.0",
	"method": "db.analyze_host",
	"id": 1,
	"params": [
		{
			"workspace": "default",
			"host": "10.0.0.1"
		}
	]
}'
```

Specify payload requirements, note this currently does not change the resulting payload response:
```
curl --request POST \
  --url http://localhost:8081/api/v1/json-rpc \
  --header 'Authorization: Bearer ' \
  --header 'Content-Type: application/json' \
  --data '{
	"jsonrpc": "2.0",
	"method": "db.analyze_host",
	"id": 1,
	"params": [
		{
			"workspace": "default",
			"host": "10.0.0.1",
                         "payload": "payload/cmd/unix/reverse_bash"
		}
	]
}'
```

**verify** the analyze command results return ms17_010 modules as viable modules to run against the current target.