### PR TITLE
Fix get_processes for some shell sessions

### DIFF
--- a/lib/msf/core/session/provider/single_command_shell.rb
+++ b/lib/msf/core/session/provider/single_command_shell.rb
@@ -61,7 +61,7 @@ module SingleCommandShell
             buf << tmp
 
             # see if we have the wanted idx
-            parts = buf.split(token, -1)
+            parts = buf.split("\n#{token}", -1).map { |part| "#{part}\n" }
 
             if parts.length == parts_needed
               # cause another prompt to appear (just in case)


### PR DESCRIPTION
This fixes instances where `#shell_read_until_token` would fail to return any output because the random token is included in the output. Since the token is random, this is very unlikely to happen with one exception and that is listing out processes. When the `ps aux` command is run, such as by the `get_processes` method, the command that executed it, including the random token as an argument, will be included in the response. This effectively breaks `get_processes` for shell commands where the `ps aux` command behaves this way.

From my testing, it looks like the native Linux shell payloads are not affected by this, presumably because their environment variables are different. This can be verified by running `session.shell_command_token('env')` and comparing it to other sessions.

The `python/shell_reverse_tcp` payload does appear to be affected by this issue however.

The proposed solution here is to leverage the fact that when the ending token is echoed, it will be directly preceded by a newline which is omitted when the token itself is returned in the output as part of the `ps aux` command.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] Obtain a session on a Linux host using the `python/shell_reverse_tcp` payload
    * The `exploit/multi/sshexec` module works nicely for this, or just generate a payload and run it, that works too
- [ ] Drop into `pry` and run `sessions[#].shell_command_token('ps aux')`, see output

## Issue Example
Notice how both sessions are on the same host, but the `env` lines is different.

```
msf6 > sessions

Active sessions
===============

  Id  Name  Type                 Information  Connection
  --  ----  ----                 -----------  ----------
  1         shell x64/linux                   192.168.159.128:4444 -> 192.168.159.115:37556 (192.168.159.115)
  4         shell python/python               192.168.159.128:4444 -> 192.168.159.115:37560 (192.168.159.115)

msf6 > pry
[*] Starting Pry shell...
[*] You are in the "framework" object

[1] pry(#<Msf::Framework>)> sessions[1].shell_command_token('env').split("\n").length
=> 1
[2] pry(#<Msf::Framework>)> sessions[1].shell_command_token('ps aux').length
=> 14814
[3] pry(#<Msf::Framework>)> sessions[4].shell_command_token('env').split("\n").length
=> 14
[4] pry(#<Msf::Framework>)> sessions[4].shell_command_token('ps aux').length
NoMethodError: undefined method `length' for nil:NilClass
from (pry):45:in `__pry__'
[5] pry(#<Msf::Framework>)> 
```