### PR TITLE
fix a localization issue and some other minor issues in `rename_file` method

### DIFF
--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -531,24 +531,34 @@ module Msf::Post::File
   alias :dir_rm :rm_rf
 
   #
-  # Rename a remote file.
+  # Renames a remote file and returns true on success and false
+  # on failure
   #
   # @param old_file [String] Remote file name to move
   # @param new_file [String] The new name for the remote file
   def rename_file(old_file, new_file)
+
+    verification_token = Rex::Text.rand_text_alphanumeric(8)
     if session.type == "meterpreter"
-      return (session.fs.file.mv(old_file, new_file).result == 0)
-    else
-      if session.platform == 'windows'
-        cmd_exec(%Q|move /y "#{old_file}" "#{new_file}"|) =~ /moved/
-      else
-        cmd_exec(%Q|mv -f "#{old_file}" "#{new_file}"|).empty?
+      begin
+        new_file = new_file + session.fs.file.separator + session.fs.file.basename(old_file) if directory?(new_file)
+        return (session.fs.file.mv(old_file, new_file).result == 0)
+      rescue Rex::Post::Meterpreter::RequestError => e
+        return false
       end
+    elsif session.type == 'powershell'
+      cmd_exec("Move-Item \"#{old_file}\" \"#{new_file}\" -Force; if($?){echo #{verification_token}}").include?(verification_token)
+    elsif session.platform == 'windows'
+      return false unless file?(old_file) # adding this because when the old_file is not present it hangs for a while, should be removed after this issue is fixed.
+      cmd_exec(%Q|move #{directory?(new_file) ? "" : "/y"} "#{old_file}" "#{new_file}" & if not errorlevel 1 echo #{verification_token}|).include?(verification_token)
+    else
+      cmd_exec(%Q|mv #{directory? ? "" : "-f"} "#{old_file}" "#{new_file}" && echo #{verification_token}|).include?(verification_token)
     end
   end
   alias :move_file :rename_file
   alias :mv_file :rename_file
 
+  #
   #
   # Copy a remote file.
   #


### PR DESCRIPTION
## Summary
This PR fixes a localization issue and 4 other minor issues in the `rename_file` method under `msf/core/post/file.rb`.

## Issues
1) Localization Issue : The method is using the string `moved` to verify if the file has moved correctly but that can vary with locale. 
```
cmd_exec(%Q|move /y "#{old_file}" "#{new_file}"|) =~ /moved/
```
2) The return value for windows shell sessions was an `Integer` whereas a `Boolean` is expected.
3) `move /y` is not compatible with powershell sessions.
4) The return value for the linux shell session is a false positive in cases where the error doesn't return to msf. Eg.
```
pingport80@kali:~/rapid7/metasploit-framework$ nc localhost 4445 -e /bin/bash
mv: cannot stat 'file_to_be_renamed': No such file or directory
```
5) `exist?` check for the file to be renamed was not present which causes a small delay and then a raise in case of windows shell sessions.( I am not sure why this is happening but I think there is not harm in adding a check)

## Verification Steps
1) Use it on non-English locales.
2) Check the return value of for windows shell sessions which should now be a `boolean`.
3) Check if it works with `powershell` session type.
4) Should work fine with both linux and windows shell sessions when the file does not exist.