### PR TITLE
Fix auxiliary/scanner/http/http_header

### DIFF
--- a/modules/auxiliary/scanner/http/http_header.rb
+++ b/modules/auxiliary/scanner/http/http_header.rb
@@ -23,7 +23,10 @@ class MetasploitModule < Msf::Auxiliary
           ['URL', 'http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html'],
           ['URL', 'http://en.wikipedia.org/wiki/List_of_HTTP_header_fields']
         ],
-        'License' => MSF_LICENSE
+        'License' => MSF_LICENSE,
+        'DefaultOptions' => {
+          'HttpClientTimeout' => 1
+        }
       )
     )
 
@@ -43,10 +46,11 @@ class MetasploitModule < Msf::Auxiliary
     uri = normalize_uri(target_uri.path)
     method = datastore['HTTP_METHOD']
     vprint_status("#{peer}: requesting #{uri} via #{method}")
-    res = send_request_raw({
+    res = send_request_raw(
       'method' => method,
-      'uri' => uri
-    })
+      'uri' => uri,
+      'partial' => true
+    )
 
     unless res
       vprint_error("#{peer}: connection timed out")

--- a/modules/auxiliary/scanner/http/http_header.rb
+++ b/modules/auxiliary/scanner/http/http_header.rb
@@ -7,26 +7,31 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::HttpClient
   include Msf::Auxiliary::Scanner
 
-  def initialize(info={})
-    super(update_info(info,
-      'Name'        => 'HTTP Header Detection',
-      'Description' => %q{ This module shows HTTP Headers returned by the scanned systems. },
-      'Author'      =>
-      [
-        'Christian Mehlmauer',
-        'rick2600'
-      ],
-      'References'  =>
-      [
-        ['URL', 'http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html'],
-        ['URL', 'http://en.wikipedia.org/wiki/List_of_HTTP_header_fields']
-      ],
-      'License'     => MSF_LICENSE
-    ))
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'HTTP Header Detection',
+        'Description' => %q{ This module shows HTTP Headers returned by the scanned systems. },
+        'Author' =>
+        [
+          'Christian Mehlmauer',
+          'rick2600'
+        ],
+        'References' =>
+        [
+          ['URL', 'http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html'],
+          ['URL', 'http://en.wikipedia.org/wiki/List_of_HTTP_header_fields']
+        ],
+        'License' => MSF_LICENSE
+      )
+    )
 
     register_options([
-      OptString.new('IGN_HEADER', [ true, 'List of headers to ignore, separated by comma',
-        'Vary,Date,Content-Length,Connection,Etag,Expires,Pragma,Accept-Ranges']),
+      OptString.new('IGN_HEADER', [
+        true, 'List of headers to ignore, separated by comma',
+        'Vary,Date,Content-Length,Connection,Etag,Expires,Pragma,Accept-Ranges'
+      ]),
       OptEnum.new('HTTP_METHOD', [ true, 'HTTP Method to use, HEAD or GET', 'HEAD', ['GET', 'HEAD'] ]),
       OptString.new('TARGETURI', [ true, 'The URI to use', '/'])
     ])
@@ -39,8 +44,8 @@ class MetasploitModule < Msf::Auxiliary
     method = datastore['HTTP_METHOD']
     vprint_status("#{peer}: requesting #{uri} via #{method}")
     res = send_request_raw({
-      'method'  => method,
-      'uri'     => uri
+      'method' => method,
+      'uri' => uri
     })
 
     unless res
@@ -55,31 +60,30 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     # Header Names are case insensitve so convert them to upcase
-    headers_uppercase = headers.inject({}) do |hash, keys|
+    headers_uppercase = headers.each_with_object({}) do |keys, hash|
       hash[keys[0].upcase] = keys[1]
-      hash
     end
 
     ignored_headers.each do |h|
-      if headers_uppercase.has_key?(h.upcase)
+      if headers_uppercase.key?(h.upcase)
         vprint_status("#{peer}: deleted header #{h}")
         headers_uppercase.delete(h.upcase)
       end
     end
     headers_uppercase.to_a.compact.sort
 
-    counter = 0;
+    counter = 0
     headers_uppercase.each do |h|
       header_string = "#{h[0]}: #{h[1]}"
       print_good "#{peer}: #{header_string}"
 
       report_note(
-        :type => "http.header.#{rport}.#{counter}",
-        :data => header_string,
-        :host => ip,
-        :port => rport
+        type: "http.header.#{rport}.#{counter}",
+        data: header_string,
+        host: ip,
+        port: rport
       )
-      counter = counter + 1
+      counter += 1
     end
     if counter == 0
       print_warning "#{peer}: all detected headers are defined in IGN_HEADER and were ignored "


### PR DESCRIPTION
https://github.com/rapid7/metasploit-framework/pull/15334/files?w=1

```
msf6 auxiliary(scanner/http/http_header) > run

[*] 93.184.216.34:80     : requesting / via HEAD
####################
# Request:
####################
HEAD / HTTP/1.1
Host: example.com
User-Agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)
Content-Length: 0


####################
# Response:
####################
HTTP/1.1 200 OK
Content-Encoding: gzip
Accept-Ranges: bytes
Age: 541460
Cache-Control: max-age=604800
Content-Type: text/html; charset=UTF-8
Date: Fri, 11 Jun 2021 23:06:39 GMT
Etag: "3147526947"
Expires: Fri, 18 Jun 2021 23:06:39 GMT
Last-Modified: Thu, 17 Oct 2019 07:18:26 GMT
Server: ECS (dab/4B86)
X-Cache: HIT
Content-Length: 648


[*] 93.184.216.34:80     : deleted header Date
[*] 93.184.216.34:80     : deleted header Content-Length
[*] 93.184.216.34:80     : deleted header Etag
[*] 93.184.216.34:80     : deleted header Expires
[*] 93.184.216.34:80     : deleted header Accept-Ranges
[+] 93.184.216.34:80     : AGE: 541460
[+] 93.184.216.34:80     : CACHE-CONTROL: max-age=604800
[+] 93.184.216.34:80     : CONTENT-ENCODING: gzip
[+] 93.184.216.34:80     : CONTENT-TYPE: text/html; charset=UTF-8
[+] 93.184.216.34:80     : LAST-MODIFIED: Thu, 17 Oct 2019 07:18:26 GMT
[+] 93.184.216.34:80     : SERVER: ECS (dab/4B86)
[+] 93.184.216.34:80     : X-CACHE: HIT
[+] 93.184.216.34:80     : detected 7 headers
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf6 auxiliary(scanner/http/http_header) >
```

#3865, #12510