### PR TITLE
Fix hosts deletion

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -416,7 +416,6 @@ class Db
         mode << :add
       when '-d','--delete'
         mode << :delete
-        return
       when '-c','-C'
         list = args.shift
         if(!list)


### PR DESCRIPTION
Fixes #15287

## Verification

Run:

```
db_nmap 127.0.0.1
hosts 
hosts -d
hosts
```

Verify that the hosts table is now empty