### PR TITLE
fixed reference url

### DIFF
--- a/modules/auxiliary/scanner/http/binom3_login_config_pass_dump.rb
+++ b/modules/auxiliary/scanner/http/binom3_login_config_pass_dump.rb
@@ -22,7 +22,7 @@ class MetasploitModule < Msf::Auxiliary
       },
       'References' =>
         [
-          ['URL', 'https://ics-cert.us-cert.gov/advisories/ICSA-17-031-01']
+          ['URL', 'https://us-cert.cisa.gov/ics/advisories/ICSA-17-031-01A']
         ],
       'Author' =>
         [

--- a/modules/auxiliary/scanner/http/gavazzi_em_login_loot.rb
+++ b/modules/auxiliary/scanner/http/gavazzi_em_login_loot.rb
@@ -17,7 +17,8 @@ class MetasploitModule < Msf::Auxiliary
       },
       'References' =>
         [
-          ['URL', 'https://ics-cert.us-cert.gov/advisories/ICSA-17-012-03']
+          ['URL', 'https://ics-cert.us-cert.gov/advisories/ICSA-17-012-03'],
+          ['CVE', '2017-5146']
         ],
       'Author' =>
          [


### PR DESCRIPTION
fixed reference url

wondering why us-cert doesn't 302-forward when they update an advisory...