### PR TITLE
Fix bug 15218 authentication issue in ssh_login_pubkey

### DIFF
--- a/modules/auxiliary/scanner/ssh/ssh_login_pubkey.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_login_pubkey.rb
@@ -175,7 +175,7 @@ class MetasploitModule < Msf::Auxiliary
           create_credential_login(credential_data)
           tmp_key = result.credential.private
           ssh_key = SSHKey.new tmp_key
-          session_setup(result, scanner, ssh_key.fingerprint, credential_core.private_id) if datastore['CreateSession']
+          session_setup(result, scanner, ssh_key.fingerprint, result.credential.private) if datastore['CreateSession']
           if datastore['GatherProof'] && scanner.get_platform(result.proof) == 'unknown'
             msg = "While a session may have opened, it may be bugged.  If you experience issues with it, re-run this module with"
             msg << " 'set gatherproof false'.  Also consider submitting an issue at github.com/rapid7/metasploit-framework with"

--- a/modules/auxiliary/scanner/ssh/ssh_login_pubkey.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_login_pubkey.rb
@@ -175,7 +175,13 @@ class MetasploitModule < Msf::Auxiliary
           create_credential_login(credential_data)
           tmp_key = result.credential.private
           ssh_key = SSHKey.new tmp_key
-          session_setup(result, scanner, ssh_key.fingerprint, result.credential.private) if datastore['CreateSession']
+          if datastore['CreateSession']
+            if credential_core.is_a? Metasploit::Credential::Core
+              session_setup(result, scanner, ssh_key.fingerprint, credential_core.private_id)
+            else
+              session_setup(result, scanner, ssh_key.fingerprint, nil)
+            end
+          end
           if datastore['GatherProof'] && scanner.get_platform(result.proof) == 'unknown'
             msg = "While a session may have opened, it may be bugged.  If you experience issues with it, re-run this module with"
             msg << " 'set gatherproof false'.  Also consider submitting an issue at github.com/rapid7/metasploit-framework with"


### PR DESCRIPTION
This fixes issue #15218 as reported by me - where attempting to use the `ssh_login_pubkey` module to access a ssh host using a valid username and key was interrupted with an error.

## Verification

The redacted example below shows the correct behaviour of the module when attempting to use a valid key to access a target host via ssh.

```
msf6 > use auxiliary/scanner/ssh/ssh_login_pubkey
msf6 auxiliary(scanner/ssh/ssh_login_pubkey) > set USERNAME root
USERNAME => root
msf6 auxiliary(scanner/ssh/ssh_login_pubkey) > set RHOSTS **REDACTED**
RHOSTS => **REDACTED**
msf6 auxiliary(scanner/ssh/ssh_login_pubkey) > set KEY_PATH /tmp/id_rsa_test
KEY_PATH => /tmp/id_rsa_test
msf6 auxiliary(scanner/ssh/ssh_login_pubkey) > exploit

[*] **REDACTED**:22 SSH - Testing Cleartext Keys
[*] **REDACTED**:22 - Testing 1 key from /tmp/id_rsa_test
[+] **REDACTED**:22 - Success: 'root:-----BEGIN RSA PRIVATE KEY-----
**REDACTED**
-----END RSA PRIVATE KEY-----
' 'uid=0(root) gid=0(root) groups=0(root) Linux **REDACTED** 5.4.0-29-generic #33-Ubuntu SMP Wed Apr 29 14:32:27 UTC 2020 x86_64 x86_64 x86_64 GNU/Linux '
[!] No active DB -- Credential data will not be saved!
[*] Command shell session 1 opened (**REDACTED**:50134 -> **REDACTED**:22) at 2021-06-22 11:26:45 +1000
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```
