### PR TITLE
Debug cmd_exec again

### DIFF
--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -376,7 +376,7 @@ module Msf::Post::File
       fd.close
     elsif session.respond_to? :shell_command_token
       if session.platform == 'windows'
-        session.shell_command_token("echo #{data} > \"#{file_name}\"")
+        session.shell_command_token("echo | set /p=\"#{data}\"> \"#{file_name}\"")
       else
         _write_file_unix_shell(file_name, data)
       end

--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -362,21 +362,6 @@ module Msf::Post::File
     session.shell_command_token("while read line; do echo $line; done <#{file_name}")
   end
 
-  # Checks to see if there are non-ansi or newline characters in a given string
-  #
-  # @param data [String] String to check for non-ansi or newline chars
-  # @return bool
-  def is_safe?(data)
-    index = 0
-    data.each_char do |char|
-      index += 1
-      unless char.ascii_only? or char == '\n'
-        return false
-      end
-    end
-    return true
-  end
-
   # Platform-agnostic file write. Writes given object content to a remote file.
   #
   # @param file_name [String] Remote file name to write
@@ -389,82 +374,15 @@ module Msf::Post::File
       fd.close
     elsif session.respond_to? :shell_command_token
       if session.platform == 'windows'
-        if is_safe?(data)
-          return win_ansi_write_file(file_name, data)
+        if _can_echo?(data)
+          return _win_ansi_write_file(file_name, data)
         else
-          return win_bin_write_file(file_name, data)
+          return _win_bin_write_file(file_name, data)
         end
       else
         return _write_file_unix_shell(file_name, data)
       end
     end
-  end
-
-  # Windows ANSI file write for shell sessions. Writes given object content to a remote file.
-  #
-  # NOTE: *This is not binary-safe on Windows shell sessions!*
-  #
-  # @param file_name [String] Remote file name to write
-  # @param data [String] Contents to put in the file
-  # @param max_chunk [int] max size for the data chunk to write at a time
-  # @return [void]
-  def win_ansi_write_file(file_name, data, max_chunk = 5000)
-    start_index = 0
-    write_length =[max_chunk, data.length].min
-    session.shell_command_token("echo | set /p=\"#{data[0, write_length]}\"> \"#{file_name}\"")
-    if data.length > write_length
-      # just use append to finish the rest
-      win_ansi_append_file(file_name, data[write_length, data.length], max_chunk)
-    end
-  end
-
-  # Windows ansi file append for shell sessions. Writes given object content to a remote file.
-  #
-  # NOTE: *This is not binary-safe on Windows shell sessions!*
-  #
-  # @param file_name [String] Remote file name to write
-  # @param data [String] Contents to put in the file
-  # @param max_chunk [int] max size for the data chunk to write at a time
-  # @return [void]
-  def win_ansi_append_file(file_name, data, max_chunk = 5000)
-    start_index = 0
-    write_length =[max_chunk, data.length].min
-    while start_index < data.length
-      session.shell_command_token("<nul set /p=\"#{data[start_index, write_length]}\" >> \"#{file_name}\"")
-      start_index = start_index + write_length
-      write_length = [max_chunk, data.length - start_index].min
-    end
-  end
-
-  # Windows binary file write for shell sessions. Writes given object content to a remote file.
-  #
-  # @param file_name [String] Remote file name to write
-  # @param data [String] Contents to put in the file
-  # @param max_chunk [int] max size for the data chunk to write at a time
-  # @return [void]
-  def win_bin_write_file(file_name, data, max_chunk = 5000)
-    b64_data = Base64.strict_encode64(data)
-    b64_filename = "#{file_name}.b64"
-    win_ansi_write_file(b64_filename, b64_data, max_chunk)
-    cmd_exec("certutil -decode #{b64_filename} #{file_name}")
-    file_rm(b64_filename)
-  end
-
-  # Windows binary file append for shell sessions. Appends given object content to a remote file.
-  #
-  # @param file_name [String] Remote file name to write
-  # @param data [String] Contents to put in the file
-  # @param max_chunk [int] max size for the data chunk to write at a time
-  # @return [void]
-  def win_bin_append_file(file_name, data, max_chunk = 5000)
-    b64_data = Base64.strict_encode64(data)
-    b64_filename = "#{file_name}.b64"
-    tmp_filename = "#{file_name}.tmp"
-    win_ansi_write_file(b64_filename, b64_data, max_chunk)
-    cmd_exec("certutil -decode #{b64_filename} #{tmp_filename}")
-    cmd_exec("copy /b #{file_name}+#{tmp_filename} #{file_name}")
-    file_rm(b64_filename)
-    file_rm(tmp_filename)
   end
 
   #
@@ -480,10 +398,10 @@ module Msf::Post::File
       fd.close
     elsif session.respond_to? :shell_command_token
       if session.platform == 'windows'
-        if is_safe?(data)
-          return win_ansi_append_file(file_name, data)
+        if _can_echo?(data)
+          return _win_ansi_append_file(file_name, data)
         else
-          return win_bin_append_file(file_name, data)
+          return _win_bin_append_file(file_name, data)
         end
       else
         return _write_file_unix_shell(file_name, data)
@@ -605,6 +523,19 @@ module Msf::Post::File
 
 protected
 
+  # Checks to see if there are non-ansi or newline characters in a given string
+  #
+  # @param data [String] String to check for non-ansi or newline chars
+  # @return bool
+  def _can_echo?(data)
+    data.each_char do |char|
+      unless char.ascii_only? || char == '\n' || char == '"'
+        return false
+      end
+    end
+    return true
+  end
+
   #
   # Meterpreter-specific file read.  Returns contents of remote file
   # +file_name+ as a String or nil if there was an error
@@ -631,6 +562,88 @@ protected
   ensure
     fd.close if fd
   end
+  # Windows ANSI file write for shell sessions. Writes given object content to a remote file.
+  #
+  # NOTE: *This is not binary-safe on Windows shell sessions!*
+  #
+  # @param file_name [String] Remote file name to write
+  # @param data [String] Contents to put in the file
+  # @param chunk_size [int] max size for the data chunk to write at a time
+  # @return [void]
+  def _win_ansi_write_file(file_name, data, chunk_size = 5000)
+    start_index = 0
+    write_length =[chunk_size, data.length].min
+    session.shell_command_token("echo | set /p=\"#{data[0, write_length]}\"> \"#{file_name}\"")
+    if data.length > write_length
+      # just use append to finish the rest
+      _win_ansi_append_file(file_name, data[write_length, data.length], chunk_size)
+    end
+  end
+
+  # Windows ansi file append for shell sessions. Writes given object content to a remote file.
+  #
+  # NOTE: *This is not binary-safe on Windows shell sessions!*
+  #
+  # @param file_name [String] Remote file name to write
+  # @param data [String] Contents to put in the file
+  # @param chunk_size [int] max size for the data chunk to write at a time
+  # @return [void]
+  def _win_ansi_append_file(file_name, data, chunk_size = 5000)
+    start_index = 0
+    write_length =[chunk_size, data.length].min
+    while start_index < data.length
+      begin
+        session.shell_command_token("<nul set /p=\"#{data[start_index, write_length]}\" >> \"#{file_name}\"")
+        start_index = start_index + write_length
+        write_length = [chunk_size, data.length - start_index].min
+      rescue ::Exception => e
+        print_error("Exception while running #{__method__.to_s}: #{e.to_s}")
+        file_rm(file_name)
+      end
+    end
+  end
+
+  # Windows binary file write for shell sessions. Writes given object content to a remote file.
+  #
+  # @param file_name [String] Remote file name to write
+  # @param data [String] Contents to put in the file
+  # @param chunk_size [int] max size for the data chunk to write at a time
+  # @return [void]
+  def _win_bin_write_file(file_name, data, chunk_size = 5000)
+    b64_data = Base64.strict_encode64(data)
+    b64_filename = "#{file_name}.b64"
+    begin
+      _win_ansi_write_file(b64_filename, b64_data, chunk_size)
+      cmd_exec("certutil -decode #{b64_filename} #{file_name}")
+    rescue ::Exception => e
+      print_error("Exception while running #{__method__.to_s}: #{e.to_s}")
+    ensure
+      file_rm(b64_filename)
+    end
+  end
+
+  # Windows binary file append for shell sessions. Appends given object content to a remote file.
+  #
+  # @param file_name [String] Remote file name to write
+  # @param data [String] Contents to put in the file
+  # @param chunk_size [int] max size for the data chunk to write at a time
+  # @return [void]
+  def _win_bin_append_file(file_name, data, chunk_size = 5000)
+    b64_data = Base64.strict_encode64(data)
+    b64_filename = "#{file_name}.b64"
+    tmp_filename = "#{file_name}.tmp"
+    begin
+      _win_ansi_write_file(b64_filename, b64_data, chunk_size)
+      cmd_exec("certutil -decode #{b64_filename} #{tmp_filename}")
+      cmd_exec("copy /b #{file_name}+#{tmp_filename} #{file_name}")
+    rescue ::Exception => e
+      print_error("Exception while running #{__method__.to_s}: #{e.to_s}")
+    ensure
+      file_rm(b64_filename)
+      file_rm(tmp_filename)
+    end
+  end
+
 
   #
   # Write +data+ to the remote file +file_name+.

--- a/lib/msf/core/session/provider/single_command_shell.rb
+++ b/lib/msf/core/session/provider/single_command_shell.rb
@@ -59,19 +59,12 @@ module SingleCommandShell
         loop do
           if (tmp = shell_read(-1))
             buf << tmp
-            #print_line("tmp = #{tmp}")
-            #print_line("buf = #{buf}")
-            #print_line("wanted_idx = #{wanted_idx}")
-
             # see if we have the wanted idx
             unless buf.nil?
               # This should just be one regex....
               buf.gsub!("#{token}\n", "#{token}\r\n")
               parts = buf.split("#{token}\r\n", -1)
               if parts.length == parts_needed
-                #print_line("parts = #{parts.to_s}")
-                #print_line("parts.length = #{parts.length}")
-                #print_line("parts_needed = #{parts_needed}")
                 # cause another prompt to appear (just in case)
                 shell_write("\n")
                 return parts[wanted_idx]
@@ -141,8 +134,6 @@ module SingleCommandShell
     # NOTE: if the session echoes input we don't need to echo the token twice.
     shell_write(cmd + "&echo #{token}\n")
     res = shell_read_until_token(token, 1, timeout)
-    # I would like a better way to do this, but I don't know of one
-    #print_line("res = |#{res}|")
     res
   end
 

--- a/lib/msf/core/session/provider/single_command_shell.rb
+++ b/lib/msf/core/session/provider/single_command_shell.rb
@@ -59,14 +59,23 @@ module SingleCommandShell
         loop do
           if (tmp = shell_read(-1))
             buf << tmp
+            #print_line("tmp = #{tmp}")
+            #print_line("buf = #{buf}")
+            #print_line("wanted_idx = #{wanted_idx}")
 
             # see if we have the wanted idx
-            parts = buf.split("\n#{token}", -1).map { |part| "#{part}\n" }
-
-            if parts.length == parts_needed
-              # cause another prompt to appear (just in case)
-              shell_write("\n")
-              return parts[wanted_idx]
+            unless buf.nil?
+              # This should just be one regex....
+              buf.gsub!("#{token}\n", "#{token}\r\n")
+              parts = buf.split("#{token}\r\n", -1)
+              if parts.length == parts_needed
+                #print_line("parts = #{parts.to_s}")
+                #print_line("parts.length = #{parts.length}")
+                #print_line("parts_needed = #{parts_needed}")
+                # cause another prompt to appear (just in case)
+                shell_write("\n")
+                return parts[wanted_idx]
+              end
             end
           end
         end
@@ -133,7 +142,7 @@ module SingleCommandShell
     shell_write(cmd + "&echo #{token}\n")
     res = shell_read_until_token(token, 1, timeout)
     # I would like a better way to do this, but I don't know of one
-    res.reverse!.chomp!.reverse! # the presence of a leading newline is not consistent
+    #print_line("res = |#{res}|")
     res
   end
 

--- a/lib/msf/core/session/provider/single_command_shell.rb
+++ b/lib/msf/core/session/provider/single_command_shell.rb
@@ -61,7 +61,7 @@ module SingleCommandShell
             buf << tmp
             # see if we have the wanted idx
             unless buf.nil?
-              # This should just be one regex....
+              # normalize the line endings following the token and parse them
               buf.gsub!("#{token}\n", "#{token}\r\n")
               parts = buf.split("#{token}\r\n", -1)
               if parts.length == parts_needed

--- a/lib/msf/core/session/provider/single_command_shell.rb
+++ b/lib/msf/core/session/provider/single_command_shell.rb
@@ -73,10 +73,9 @@ module SingleCommandShell
           end
         end
       end
-    rescue
-      # nothing, just continue
+    rescue Timeout::Error
+      # This is expected in many cases
     end
-
     # failed to get any data or find the token!
     nil
   end


### PR DESCRIPTION
## ~Please wait for me to do some automated testing to verify this works across all supported Windows versions and no regressions were introduced to Linux.  Automated testing is easier on PRs, so I've only done some basic tests locally.  I'll leave it in draft until I finish the automated testing.~

This is yet another attempt to fix some of the bugs in cmd_exec.  I noticed that the cmd_exec tests were failing on Windows shells and after digging a bit, I don't think the `write_file` or `append_file` functionality ever worked except under some very contrived circumstances, namely, it would not work on binary files that contained non-ansi characters or any file larger than ~ 7K.

Further, because of some interesting sharing of code between *nix and windows shells, the tokenization is sloppy with regard to newlines- sometimes Windows newlines, sometimes *nix-style newlines, depending on whether we send the token, or Windows echos the token.  Rather than go back and split the code that sends the token, I just normalize the newlines before processing responses.  It is certainly feasible to fix this on the sending end, but this approach also works.  It also allows me to remove the abomination I added in https://github.com/rapid7/metasploit-framework/pull/12463 because the trailing newlines are corrected upstream. 🎉 

Finally, there was a rescue that hid everything rather than just the expected timeout errors, so when any number or errors got thrown, it defaulted to that stupid `no method reverse! for nil` message because it was the first thing following that empty rescue all.

One concern I have is that we're making a awful lot of files on target for binary file appends- file_name.b64, file_name.tmp, and file_name and I am slightly concerned we might run into some collisions, especially with the *.tmp.  I'd be curious to know what others think about that and if I'm just being overly paranoid.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use payload/windows/x64/shell_reverse_tcp`
- [ ] `generate -f exe -o <payloadname>`
- [ ] `to_handler`
- [ ] upload payload and launch it on Windows 7-10 target
- [ ] `loadpath test/modules`
- [ ] `use post/test/file`
- [ ] `set session <session>`
- [ ] `set verbose true`
- [ ] `run`
- [ ] **Verify** All tests pass


## Old and busted
```
msf6 payload(windows/x64/shell_reverse_tcp) > [*] Started reverse TCP handler on 192.168.135.197:4444 
[*] Command shell session 1 opened (192.168.135.197:4444 -> 192.168.132.125:49676) at 2021-06-22 11:30:48 -0500

msf6 payload(windows/x64/shell_reverse_tcp) > loadpath test/modules/
Loaded 37 modules:
    14 auxiliary modules
    13 exploit modules
    10 post modules
msf6 payload(windows/x64/shell_reverse_tcp) > use post/test/file 
msf6 post(test/file) > set session 1
session => 1
msf6 post(test/file) > set verbose truye
[-] The following options failed to validate: Value 'truye' is not valid for option 'VERBOSE'.
verbose => false
msf6 post(test/file) > set verbose true
verbose => true
msf6 post(test/file) > run

[-] Post failed: NoMethodError undefined method `reverse!' for nil:NilClass
[-] Call stack:
[-]   /home/tmoose/rapid7/metasploit-framework/lib/msf/core/session/provider/single_command_shell.rb:136:in `shell_command_token_win32'
[-]   /home/tmoose/rapid7/metasploit-framework/lib/msf/core/session/provider/single_command_shell.rb:84:in `shell_command_token'
[-]   /home/tmoose/rapid7/metasploit-framework/lib/msf/core/post/file.rb:56:in `pwd'
[-]   /home/tmoose/rapid7/metasploit-framework/test/modules/post/test/file.rb:38:in `setup'
[*] Cleanup: changing working directory back to 
[-] Post failed: NoMethodError undefined method `reverse!' for nil:NilClass
[-] Call stack:
[-]   /home/tmoose/rapid7/metasploit-framework/lib/msf/core/session/provider/single_command_shell.rb:136:in `shell_command_token_win32'
[-]   /home/tmoose/rapid7/metasploit-framework/lib/msf/core/session/provider/single_command_shell.rb:84:in `shell_command_token'
[-]   /home/tmoose/rapid7/metasploit-framework/lib/msf/core/post/file.rb:38:in `cd'
[-]   /home/tmoose/rapid7/metasploit-framework/test/modules/post/test/file.rb:172:in `cleanup'
msf6 post(test/file) > 

```

## New Hotness
```
msf6 payload(windows/x64/shell_reverse_tcp) > 
[*] Started reverse TCP handler on 192.168.135.197:4444 
[*] Command shell session 1 opened (192.168.135.197:4444 -> 192.168.132.185:49165) at 2021-06-22 09:51:13 -0500

msf6 payload(windows/x64/shell_reverse_tcp) > loadpath test/modules/
Loaded 37 modules:
    14 auxiliary modules
    13 exploit modules
    10 post modules
msf6 payload(windows/x64/shell_reverse_tcp) > use post/test/file 
msf6 post(test/file) > set session 1
session => 1
msf6 post(test/file) > set verbose true
verbose => true
msf6 post(test/file) > run

[*] Setup: changing working directory to %TEMP%
[*] Running against session 1
[*] Session type is shell and platform is windows
[+] should test for file existence
[+] should test for directory existence
[+] should create text files
[+] should read the text we just wrote
[+] should append text files
[+] should delete text files
[+] should move files
[*] Writing 39256 bytes
[*] Finished in 0.265905096
[+] should write binary data
[*] Read 39256 bytes
[+] should read the binary data we just wrote
[+] should delete binary files
[+] should append binary data
[*] Testing complete in 1.197730979
[*] Passed: 11; Failed: 0
[*] Cleanup: changing working directory back to C:\Users\msfuser\Desktop

[*] Post module execution completed
msf6 post(test/file) > sessions


```
Also, I just realized I need to update some copy/pasta comments.....