### PR TITLE
Add limit to size of history files

### DIFF
--- a/lib/rex/ui/text/shell.rb
+++ b/lib/rex/ui/text/shell.rb
@@ -1,6 +1,5 @@
 # -*- coding: binary -*-
 require 'rex/text/color'
-require 'pry'
 
 module Rex
 module Ui

--- a/lib/rex/ui/text/shell.rb
+++ b/lib/rex/ui/text/shell.rb
@@ -1,5 +1,6 @@
 # -*- coding: binary -*-
 require 'rex/text/color'
+require 'pry'
 
 module Rex
 module Ui
@@ -122,6 +123,8 @@ module Shell
   # Run the command processing loop.
   #
   def run(&block)
+    # pry history will not be loaded when used pry is used as breakpoints like `binding.pry` by default now
+    Pry.config.history_load = false
 
     HistoryManager.push_context(history_file: histfile, name: name)
     self.hist_last_saved = Readline::HISTORY.length

--- a/lib/rex/ui/text/shell.rb
+++ b/lib/rex/ui/text/shell.rb
@@ -122,8 +122,13 @@ module Shell
   # Run the command processing loop.
   #
   def run(&block)
-    # pry history will not be loaded by default when pry is used as a breakpoint like `binding.pry`
-    Pry.config.history_load = false
+    begin
+      require 'pry'
+      # pry history will not be loaded by default when pry is used as a breakpoint like `binding.pry`
+      Pry.config.history_load = false
+    rescue LoadError
+      # Pry is a development dependency, if not available suppressing history_load can be safely ignored.
+    end
 
     HistoryManager.push_context(history_file: histfile, name: name)
     self.hist_last_saved = Readline::HISTORY.length

--- a/lib/rex/ui/text/shell.rb
+++ b/lib/rex/ui/text/shell.rb
@@ -166,6 +166,7 @@ module Shell
       retry
     ensure
       HistoryManager.pop_context
+      HistoryManager.flush
       self.hist_last_saved = Readline::HISTORY.length
     end
   end

--- a/lib/rex/ui/text/shell.rb
+++ b/lib/rex/ui/text/shell.rb
@@ -123,7 +123,7 @@ module Shell
   # Run the command processing loop.
   #
   def run(&block)
-    # pry history will not be loaded when used pry is used as breakpoints like `binding.pry` by default now
+    # pry history will not be loaded by default when pry is used as a breakpoint like `binding.pry`
     Pry.config.history_load = false
 
     HistoryManager.push_context(history_file: histfile, name: name)
@@ -493,4 +493,3 @@ private
 end
 
 end end end
-

--- a/lib/rex/ui/text/shell/history_manager.rb
+++ b/lib/rex/ui/text/shell/history_manager.rb
@@ -90,13 +90,17 @@ class HistoryManager
     end
 
     def switch_context(new_context, old_context=nil)
-      if old_context&.fetch(:history_file, nil)
-        store_history_file(old_context[:history_file], skip: @@original_history_length)
-      end
+      begin
+        if old_context&.fetch(:history_file, nil)
+          store_history_file(old_context[:history_file], skip: @@original_history_length)
+        end
 
-      if new_context&.fetch(:history_file, nil)
-        load_history_file(new_context[:history_file])
-      else
+        if new_context&.fetch(:history_file, nil)
+          load_history_file(new_context[:history_file])
+        else
+          clear_readline
+        end
+      rescue SignalException => e
         clear_readline
       end
     end

--- a/lib/rex/ui/text/shell/history_manager.rb
+++ b/lib/rex/ui/text/shell/history_manager.rb
@@ -62,7 +62,7 @@ class HistoryManager
     def load_history_file(history_file)
       clear_readline
       if commands = from_storage_queue(history_file)
-        commands.each do |c|
+        commands.reverse.each do |c|
           Readline::HISTORY << c
         end
       else

--- a/lib/rex/ui/text/shell/history_manager.rb
+++ b/lib/rex/ui/text/shell/history_manager.rb
@@ -56,8 +56,19 @@ class HistoryManager
 
     def load_history_file(history_file)
       clear_readline
-
       if File.exist?(history_file)
+        if File.readlines(history_file).length > 1000
+          lines = []
+          File.readlines(history_file)[-1000..-1].each do |e|
+            lines << e.chomp
+          end
+
+          File.open(history_file, 'w') do |file|
+            file.puts lines
+          end
+        end
+
+
         File.readlines(history_file).each do |e|
           Readline::HISTORY << e.chomp
         end

--- a/lib/rex/ui/text/shell/history_manager.rb
+++ b/lib/rex/ui/text/shell/history_manager.rb
@@ -52,6 +52,10 @@ class HistoryManager
     end
   end
 
+  def self.flush
+    sleep 0.1 until @@write_queue.empty?
+  end
+
   class << self
     private
 

--- a/lib/rex/ui/text/shell/history_manager.rb
+++ b/lib/rex/ui/text/shell/history_manager.rb
@@ -12,7 +12,7 @@ class HistoryManager
   @@contexts = []
 
   @@write_mutex = Mutex.new
-  @@write_quewue = {}
+  @@write_queue = {}
 
   def self.inspect
     "#<HistoryManager stack size: #{@@contexts.length}>"
@@ -100,7 +100,7 @@ class HistoryManager
 
     def write_history_file(history_file, cmds)
       @@write_mutex.synchronize do
-        @@write_quewue[history_file] = cmds
+        @@write_queue[history_file] = cmds
       end
 
       Rex::ThreadFactory.spawn("#{history_file} Writer", false) do
@@ -109,14 +109,14 @@ class HistoryManager
         end
 
         @@write_mutex.synchronize do
-          @@write_quewue.delete(history_file)
+          @@write_queue.delete(history_file)
         end
       end
     end
 
     def from_storage_queue(history_file)
       @@write_mutex.synchronize do
-        @@write_quewue[history_file]
+        @@write_queue[history_file]
       end
     end
   end

--- a/lib/rex/ui/text/shell/history_manager.rb
+++ b/lib/rex/ui/text/shell/history_manager.rb
@@ -57,9 +57,9 @@ class HistoryManager
     def load_history_file(history_file)
       clear_readline
       if File.exist?(history_file)
-        if File.readlines(history_file).length > 1000
+        if File.readlines(history_file).length > 2000
           lines = []
-          File.readlines(history_file)[-1000..-1].each do |e|
+          File.readlines(history_file)[-2000..-1].each do |e|
             lines << e.chomp
           end
 

--- a/lib/rex/ui/text/shell/history_manager.rb
+++ b/lib/rex/ui/text/shell/history_manager.rb
@@ -104,7 +104,7 @@ class HistoryManager
       end
 
       Rex::ThreadFactory.spawn("#{history_file} Writer", false) do
-        File.open(history_file, 'a+') do |f|
+        File.open(history_file, 'w+') do |f|
           f.puts(cmds.reverse)
         end
 


### PR DESCRIPTION
## Summary
Fixes #15360.
This PR adds a limit to the size of history files which would otherwise keep growing and lead to issues like hanging/crashing.(as mentioned in #15360 ) Also while hanging if the user gets impatient and interrupts the switching in between with `CTRL^C`, that will make things get out of sync and the framework might crash. Therefore limiting the size of history file should fix both the issues.

## Verification Steps
* The framework should not hang while switching bw various consoles/sub-consoles.
* The size of the history file should be 2000 after console is just loaded( it will increase while the console is being used and might cross 2000 but should be back to 2000 again when loading the console)
* The history manager should work as expected.