### PR TITLE
lock reline until decision on Fiddle can be made

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,6 +53,7 @@ PATH
       rb-readline
       recog
       redcarpet
+      reline (= 0.2.5)
       rex-arch
       rex-bin_tools
       rex-core

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -207,6 +207,8 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'hrr_rb_ssh', '0.3.0.pre2'
   # Needed for irb internal command
   spec.add_runtime_dependency 'irb'
+  # Lock reline version until Fiddle concerns are addressed
+  spec.add_runtime_dependency 'reline', '0.2.5'
 
   # AWS enumeration modules
   spec.add_runtime_dependency 'aws-sdk-s3'


### PR DESCRIPTION
reline 0.2.6 will introduce an issue related to `Fiddle` usage in a new terminfo.rb.  Lock version for now until.

```
$ rake spec
Please report a bug if this causes problems.
rake aborted!
NameError: uninitialized constant Fiddle::VERSION
/Users/jmartin/.rvm/gems/ruby-2.7.2@metasploit-framework/gems/reline-0.2.6/lib/reline/terminfo.rb:12:in `curses_dl'
/Users/jmartin/.rvm/gems/ruby-2.7.2@metasploit-framework/gems/reline-0.2.6/lib/reline/terminfo.rb:78:in `<top (required)>'
/Users/jmartin/.rvm/gems/ruby-2.7.2@metasploit-framework/gems/reline-0.2.6/lib/reline/ansi.rb:3:in `require_relative'
/Users/jmartin/.rvm/gems/ruby-2.7.2@metasploit-framework/gems/reline-0.2.6/lib/reline/ansi.rb:3:in `<top (required)>'
/Users/jmartin/.rvm/gems/ruby-2.7.2@metasploit-framework/gems/zeitwerk-2.4.2/lib/zeitwerk/kernel.rb:34:in `require'
/Users/jmartin/.rvm/gems/ruby-2.7.2@metasploit-framework/gems/zeitwerk-2.4.2/lib/zeitwerk/kernel.rb:34:in `require'
/Users/jmartin/.rvm/gems/ruby-2.7.2@metasploit-framework/gems/reline-0.2.6/lib/reline.rb:472:in `<top (required)>'
/Users/jmartin/.rvm/gems/ruby-2.7.2@metasploit-framework/gems/zeitwerk-2.4.2/lib/zeitwerk/kernel.rb:34:in `require'
/Users/jmartin/.rvm/gems/ruby-2.7.2@metasploit-framework/gems/zeitwerk-2.4.2/lib/zeitwerk/kernel.rb:34:in `require'
/Users/jmartin/.rvm/gems/ruby-2.7.2@metasploit-framework/gems/irb-1.3.6/lib/irb.rb:13:in `<top (required)>'
```