### PR TITLE
Fix LDAP hashdump crash on null char 

### DIFF
--- a/lib/metasploit/framework/hashes/identify.rb
+++ b/lib/metasploit/framework/hashes/identify.rb
@@ -46,6 +46,8 @@ def identify_hash(hash)
       return 'ssha'
     when hash.start_with?(/{SHA512}/i)
       return 'raw-sha512'
+    when hash.start_with?(/{SHA256}/i)
+      return 'raw-sha256'
     when hash.start_with?(/{SHA}/i)
       return 'raw-sha1'
     when hash.start_with?(/{MD5}/i)

--- a/lib/metasploit/framework/password_crackers/cracker.rb
+++ b/lib/metasploit/framework/password_crackers/cracker.rb
@@ -190,6 +190,8 @@ module Metasploit
             '111'
           when 'raw-sha512'
             '1700'
+          when 'raw-sha256'
+            '1400'
           when 'raw-sha1'
             '100'
           when 'raw-md5'

--- a/lib/metasploit/framework/password_crackers/hashcat/formatter.rb
+++ b/lib/metasploit/framework/password_crackers/hashcat/formatter.rb
@@ -68,7 +68,7 @@ def hash_to_hashcat(cred)
          /sha512|sha-512/, /xsha|xsha512|PBKDF2-HMAC-SHA512/,
          /mediawiki|phpass|PBKDF2-HMAC-SHA1/,
          /android-sha1/, /android-samsung-sha1/, /android-md5/,
-         /ssha/, /raw-sha512/
+         /ssha/, /raw-sha512/, /raw-sha256/
       #            md5(crypt), des(crypt), b(crypt), sha256, sha512, xsha, xsha512, PBKDF2-HMAC-SHA512
       # hash-mode: 500          1500        3200      7400    1800   122   1722       7100
       #            mssql, mssql05, mssql12, mysql, mysql-sha1
@@ -77,8 +77,8 @@ def hash_to_hashcat(cred)
       # hash-mode: 3711,      400,    12001
       #            android-sha1
       # hash-mode: 5800
-      #            ssha, raw-sha512
-      # hash-mode: 111,  1700
+      #            ssha, raw-sha512, raw-sha256
+      # hash-mode: 111,  1700,       1400
       return cred.private.data
     when /^mscash$/
       # hash-mode: 1100

--- a/lib/metasploit/framework/password_crackers/jtr/formatter.rb
+++ b/lib/metasploit/framework/password_crackers/jtr/formatter.rb
@@ -73,6 +73,7 @@ def hash_to_jtr(cred)
       # /dynamic_82/
       # /ssha/
       # /raw-sha512/
+      # /raw-sha256/
       return "#{cred.public.username}:#{cred.private.data}:#{cred.id}:"
     end
   end

--- a/modules/auxiliary/gather/ldap_hashdump.rb
+++ b/modules/auxiliary/gather/ldap_hashdump.rb
@@ -299,6 +299,8 @@ class MetasploitModule < Msf::Auxiliary
          hash.start_with?('*****') ||
          hash.start_with?(/yyyyyy/i) ||
          hash == '*' ||
+         hash.end_with?('*LK*', # account locked
+                        '*NP*') || # password has never been set
          # reject {SASL} pass-through
          hash =~ /{sasl}/i ||
          hash.start_with?(/xxxxx/i) ||
@@ -346,8 +348,13 @@ class MetasploitModule < Msf::Auxiliary
         elsif hash.start_with?(/{crypt}/i) && hash.length == 20
           # handle {crypt}traditional_crypt case, i.e. explicitly set the hash format
           hash.slice!(/{crypt}/i)
-          hash_format = 'descrypt' # FIXME: what is the right jtr_hash - des,crypt or descrypt ?
-        # identify_hash returns des,crypt, while JtR acceppts descrypt
+          # FIXME: what is the right jtr_hash - des,crypt or descrypt ?
+          # identify_hash returns des,crypt, while JtR acceppts descrypt
+          hash_format = 'descrypt'
+        # TODO: not sure if we shall slice the prefixes here or in the JtR/Hashcat formatter
+        # elsif hash.start_with?(/{sha256}/i)
+        #  hash.slice!(/{sha256}/i)
+        #  hash_format = 'raw-sha256'
         else
           # handle vcenter vmdir binary hash format
           if hash[0].ord == 1 && hash.length == 81

--- a/modules/auxiliary/gather/ldap_hashdump.rb
+++ b/modules/auxiliary/gather/ldap_hashdump.rb
@@ -39,7 +39,8 @@ class MetasploitModule < Msf::Auxiliary
         },
         'Notes' => {
           'Stability' => [CRASH_SAFE],
-          'SideEffects' => [IOC_IN_LOGS]
+          'SideEffects' => [IOC_IN_LOGS],
+          'Reliability' => []
         }
       )
     )
@@ -220,7 +221,7 @@ class MetasploitModule < Msf::Auxiliary
       @rhost, # host
       ldif, # data
       nil, # filename
-      "Base DN: #{base_dn}" # info
+      "Base DN: #{base_dn.gsub(/[^[:print:]]/, '')}" # info, remove null char from base_dn
     )
 
     unless ldif_filename


### PR DESCRIPTION
Sometimes remote LDAP servers return a null character in the base_dn string, which makes the store_loot() to fail with `ArgumentError string contains null byte` deep down in `/usr/share/metasploit-framework/vendor/bundle/ruby/2.7.0/gems/activerecord-5.2.6/lib/active_record/connection_adapters/postgresql_adapter.rb:611:in `exec_params'`. Unfortunatelly this makes the whole Auxialirity module to stop and rest of the hosts scanned is not finished.

Below commit sanitize the base_dn for the store_loot() call

-----------------
Update: I have added also handling of sha256 hash and skipping for *LK* (locked account) and *NP* (no password) credentials