### PR TITLE
Rewrite ZoomEye auxiliary module

### DIFF
--- a/modules/auxiliary/gather/zoomeye_search.rb
+++ b/modules/auxiliary/gather/zoomeye_search.rb
@@ -1,6 +1,7 @@
 ##
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
+# Modified on Nixawk's code
 ##
 
 
@@ -8,32 +9,32 @@
 class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Report
 
-
   def initialize(info={})
     super(update_info(info,
-      'Name'        => 'ZoomEye Search',
-      'Description' => %q{
+                      'Name'        => 'ZoomEye Search',
+                      'Description' => %q{
         The module use the ZoomEye API to search ZoomEye. ZoomEye is a search
         engine for cyberspace that lets the user find specific network
         components(ip, services, etc.).
       },
-      'Author'      => [ 'Nixawk' ],
-      'References'  => [
-        ['URL', 'https://github.com/zoomeye/SDK'],
-        ['URL', 'https://www.zoomeye.org/api/doc'],
-        ['URL', 'https://www.zoomeye.org/help/manual']
-      ],
-      'License'     => MSF_LICENSE
-      ))
+                      'Author'      => [ 'wh0am1i' ],
+                      'References'  => [
+                        ['URL', 'https://www.zoomeye.org/api/doc'],
+                        ['URL', 'https://www.zoomeye.org/help/manual'],
+                        ['URL', 'https://github.com/knownsec/ZoomEye-python'],
+                      ],
+                      'License'     => MSF_LICENSE
+          ))
 
-      register_options(
-        [
-          OptString.new('USERNAME', [true, 'The ZoomEye username']),
-          OptString.new('PASSWORD', [true, 'The ZoomEye password']),
-          OptString.new('ZOOMEYE_DORK', [true, 'The ZoomEye dork']),
-          OptEnum.new('RESOURCE', [true, 'ZoomEye Resource Type', 'host', ['host', 'web']]),
-          OptInt.new('MAXPAGE', [true, 'Max amount of pages to collect', 1])
-        ])
+    register_options(
+      [
+        OptString.new('APIKEY', [true, 'The ZoomEye API KEY']),
+        OptString.new('DORK', [true, 'The ZoomEye dork']),
+        OptEnum.new('RESOURCE', [true, 'ZoomEye Resource Type', 'host', ['host', 'web']]),
+        OptInt.new('MAXPAGE', [true, 'Max amount of pages to collect', 1]),
+        OptBool.new('DATABASE', [false, 'Add search results to the database', false]),
+        OptBool.new('OUTFILE', [false, 'A filename to store ZoomEye search raw data']),
+      ])
   end
 
   # Check to see if api.zoomeye.org resolves properly
@@ -47,33 +48,7 @@ class MetasploitModule < Msf::Auxiliary
     true
   end
 
-  def login(username, password)
-    # See more: https://www.zoomeye.org/api/doc#login
-
-    access_token = ''
-    @cli = Rex::Proto::Http::Client.new('api.zoomeye.org', 443, {}, true)
-    @cli.connect
-
-    data = {'username' => username, 'password' => password}
-    req = @cli.request_cgi({
-      'uri'    => '/user/login',
-      'method' => 'POST',
-      'data'   => data.to_json
-    })
-
-    res = @cli.send_recv(req)
-
-    unless res
-      print_error('server_response_error')
-      return
-    end
-
-    records = ActiveSupport::JSON.decode(res.body)
-    access_token = records['access_token'] if records && records.key?('access_token')
-    access_token
-  end
-
-  def dork_search(dork, resource, page)
+  def dork_search(dork, resource, page, api_key)
     # param: dork
     #        ex: country:cn
     #        access https://www.zoomeye.org/search/dorks for more details.
@@ -85,20 +60,20 @@ class MetasploitModule < Msf::Auxiliary
     #        ex: [app, device]
     #         A comma-separated list of properties to get summary information
 
+    cli = Rex::Proto::Http::Client.new('api.zoomeye.org', 443, {}, true)
+    cli.connect
+
     begin
-      req = @cli.request_cgi({
-        'uri'      => "/#{resource}/search",
-        'method'   => 'GET',
-        'headers'  => { 'Authorization' => "JWT #{@zoomeye_token}" },
-        'vars_get' => {
-          'query'  => dork,
-          'page'   => page,
-          'facet'  => 'ip'
-        }
-      })
-
-      res = @cli.send_recv(req)
-
+      req = cli.request_cgi({
+                              'uri'      => "/#{resource}/search",
+                              'method'   => 'GET',
+                              'headers'  => { 'API-KEY' => " #{api_key}" },
+                              'vars_get' => {
+                                'query'  => dork,
+                                'page'   => page
+                              }
+                            })
+      res = cli.send_recv(req)
     rescue ::Rex::ConnectionError, Errno::ECONNREFUSED, Errno::ETIMEDOUT
       print_error("HTTP Connection Failed")
     end
@@ -122,22 +97,70 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def parse_host_records(records)
+    tbl = Rex::Text::Table.new(
+      'Header'  => 'Search Results',
+      'Indent'  => 1,
+      'Columns' => ['IP:Port', 'City', 'Country', 'Hostname']
+    )
     records.each do |match|
       host = match['ip']
       port = match['portinfo']['port']
+      city = match['geoinfo']['city']['names']['en']
+      country = match['geoinfo']['country']['names']['en']
+      hostname = match['portinfo']['hostname']
+      service = match['portinfo']['service']
 
-      report_service(:host => host, :port => port)
-      print_good("Host: #{host} ,PORT: #{port}")
+      tbl << ["#{host}:#{port}", city, country, hostname]
+
+      report_host(:host     => host,
+                  :name     => hostname,
+                  :comments => 'Added from ZoomEye Host Search',
+                  :info     => "service: #{service}",
+                  ) if datastore['DATABASE']
+
+      report_service(:host => host,
+                     :port => port,
+                     :info => 'Added from ZoomEye Host Search'
+      ) if datastore['DATABASE']
     end
+    print_line("#{tbl}")
   end
 
   def parse_web_records(records)
+    tbl = Rex::Text::Table.new(
+      'Header'  => 'Search Results',
+      'Indent'  => 1,
+      'Columns' => ['IP', 'City', 'Country', 'Domains']
+    )
+
     records.each do |match|
       host = match['ip'][0]
       domains = match['domains']
+      city = match['geoinfo']['city']['names']['en']
+      country = match['geoinfo']['country']['names']['en']
 
-      report_host(:host => host)
-      print_good("Host: #{host}, Domains: #{domains}")
+      tbl << ["#{host}", city, country, domains]
+
+      report_host(:host     => host,
+                  :comments => 'Added from ZoomEye Web Search',
+                  :info     => "domains: #{domains}",
+                  ) if datastore['DATABASE']
+
+      report_service(:host => host,
+                     :domain => domains,
+                     :info => 'Added from ZoomEye Web Search'
+      ) if datastore['DATABASE']
+
+    end
+    print_line("#{tbl}")
+  end
+
+  # save ZoomEye raw data to file
+  def save_output(raw, dork, page)
+    name =dork.gsub(/[^a-zA-Z ]/,'_')
+    ::File.open("#{name}_#{page}.json", "wb") do |f|
+      f.write(ActiveSupport::JSON.encode(raw))
+      print_status("Saved results in #{datastore['OUTFILE']}")
     end
   end
 
@@ -148,23 +171,19 @@ class MetasploitModule < Msf::Auxiliary
       return
     end
 
-    @zoomeye_token = login(datastore['USERNAME'], datastore['PASSWORD'])
-    if @zoomeye_token.blank?
-      print_error("Unable to login api.zoomeye.org")
-      return
-    end
-
     # create ZoomEye request parameters
-    dork = datastore['ZOOMEYE_DORK']
+    dork = datastore['DORK']
     resource = datastore['RESOURCE']
     page = 1
     maxpage = datastore['MAXPAGE']
-
+    api_key = datastore['APIKEY']
+    results = {}
     # scroll max pages from ZoomEye
     while page <= maxpage
       print_status("ZoomEye #{resource} Search: #{dork} - page: #{page}")
-      results = dork_search(dork, resource, page) if dork
+      results = dork_search(dork, resource, page, api_key) if dork
       break unless match_records?(results)
+      save_output(results, dork, page) if datastore['OUTFILE']
 
       matches = results['matches']
       if resource.include?('web')
@@ -174,5 +193,14 @@ class MetasploitModule < Msf::Auxiliary
       end
       page += 1
     end
+    # calc current page
+    if results['total'] % 20 == 0
+      total_page = results['total'] / 20
+    else
+      total_page = results['total'] / 20 + 1
+    end
+    print_status("Total:#{results['total']} on #{total_page} Pages\n" +
+                   "Showing #{page - 1} page(s)."
+    )
   end
 end


### PR DESCRIPTION
Rewrite ZooEye auxiliary module

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] Do: `use  auxiliary/gather/zoomeye_search`
- [ ] Do: `set  APIKEY [APIKEY]` replacing `[APIKEY]` you ZoomEye API KEY
- [ ] Do: `set  DORK [DORK]`  replacing `[DORK]` with ZoomEYe Dork’ you need to search for
- [ ] Do: `run`

## Options
 - [] Do: `set RESOURCE host`, ZoomEye Resource Type, host or web, defautl host
 - [] Do: `set DATABASE true`,  Add search results to the database, default `false`
 - [] Do: `set OUTFILE [FILENAME]`, replacing `[FILENAME]`  with filename to store ZoomEye search raw data

## Scenarios
```
msf6 auxiliary(gather/zoomeye_search) > set APIKEY 7XXXXB1-XXXX-5XXX-fXXXX3-79XXXXXX8679
APIKEY => 7XXXXB1-XXXX-5XXX-fXXXX3-79XXXXXX8679
msf6 auxiliary(gather/zoomeye_search) > set RESOURCE web
RESOURCE => web
msf6 auxiliary(gather/zoomeye_search) > set DORK app:"django"
DORK => app:django
msf6 auxiliary(gather/zoomeye_search) > run 

 [*]ZoomEye web Search: app:django - page: 1
Search Results
==============

 IP               City           Country        Domains
 --               ----           -------        -------
 3.90.197.242     Ashburn        United States  []
 3.135.73.62      Dublin         United States  ["docs.amazonwebservices.com"]
 3.141.183.187    Dublin         United States  ["docs.amazonwebservices.com"]
 15.237.12.14     Paris          France         ["docs.amazonwebservices.com"]
...
```