### PR TITLE
Fix #15254, set dynamic cached size on powershell payloads

### DIFF
--- a/modules/payloads/singles/cmd/windows/powershell_bind_tcp.rb
+++ b/modules/payloads/singles/cmd/windows/powershell_bind_tcp.rb
@@ -6,7 +6,7 @@ require 'rex/powershell'
 
 module MetasploitModule
 
-  CachedSize = 1656
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Rex::Powershell::Command

--- a/modules/payloads/singles/cmd/windows/powershell_reverse_tcp.rb
+++ b/modules/payloads/singles/cmd/windows/powershell_reverse_tcp.rb
@@ -6,7 +6,7 @@ require 'rex/powershell'
 
 module MetasploitModule
 
-  CachedSize = 1652
+  CachedSize = :dynamic
 
   include Msf::Payload::Single
   include Rex::Powershell::Command

--- a/modules/payloads/singles/windows/powershell_bind_tcp.rb
+++ b/modules/payloads/singles/windows/powershell_bind_tcp.rb
@@ -11,7 +11,7 @@ require 'rex/powershell'
 ###
 module MetasploitModule
 
-  CachedSize = 1841
+  CachedSize = :dynamic
 
   include Msf::Payload::Windows::Exec
   include Rex::Powershell::Command

--- a/modules/payloads/singles/windows/powershell_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/powershell_reverse_tcp.rb
@@ -11,7 +11,7 @@ require 'rex/powershell'
 ###
 module MetasploitModule
 
-  CachedSize = 1837
+  CachedSize = :dynamic
 
   include Msf::Payload::Windows::Exec
   include Msf::Payload::Windows::Powershell

--- a/modules/payloads/singles/windows/x64/powershell_bind_tcp.rb
+++ b/modules/payloads/singles/windows/x64/powershell_bind_tcp.rb
@@ -11,7 +11,7 @@ require 'rex/powershell'
 ###
 module MetasploitModule
 
-  CachedSize = 1924
+  CachedSize = :dynamic
 
   include Msf::Payload::Windows::Exec_x64
   include Rex::Powershell::Command

--- a/modules/payloads/singles/windows/x64/powershell_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/x64/powershell_reverse_tcp.rb
@@ -11,7 +11,7 @@ require 'rex/powershell'
 ###
 module MetasploitModule
 
-  CachedSize = 1920
+  CachedSize = :dynamic
 
   include Msf::Payload::Windows::Exec_x64
   include Msf::Payload::Windows::Powershell

--- a/spec/modules/payloads_spec.rb
+++ b/spec/modules/payloads_spec.rb
@@ -1113,7 +1113,7 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/cmd/windows/powershell_bind_tcp'
                           ],
-                          dynamic_size: false,
+                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/windows/powershell_bind_tcp'
   end
@@ -4907,7 +4907,7 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                             'singles/windows/x64/powershell_bind_tcp'
                           ],
-                          dynamic_size: false,
+                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/x64/powershell_bind_tcp'
   end
@@ -5188,7 +5188,7 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                             'singles/windows/powershell_bind_tcp'
                           ],
-                          dynamic_size: false,
+                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/powershell_bind_tcp'
   end

--- a/spec/modules/payloads_spec.rb
+++ b/spec/modules/payloads_spec.rb
@@ -1123,7 +1123,7 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                               'singles/cmd/windows/powershell_reverse_tcp'
                           ],
-                          dynamic_size: false,
+                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'cmd/windows/powershell_reverse_tcp'
   end

--- a/spec/modules/payloads_spec.rb
+++ b/spec/modules/payloads_spec.rb
@@ -4917,7 +4917,7 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                             'singles/windows/x64/powershell_reverse_tcp'
                           ],
-                          dynamic_size: false,
+                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/x64/powershell_reverse_tcp'
   end
@@ -5198,7 +5198,7 @@ RSpec.describe 'modules/payloads', :content do
                           ancestor_reference_names: [
                             'singles/windows/powershell_reverse_tcp'
                           ],
-                          dynamic_size: false,
+                          dynamic_size: true,
                           modules_pathname: modules_pathname,
                           reference_name: 'windows/powershell_reverse_tcp'
   end


### PR DESCRIPTION
After landing https://github.com/rapid7/metasploit-framework/pull/15254 it seems some of the automated tests are failing intermittently.
This attempts to fix that by making the payloads a dynamic cached size.

```
rspec './spec/modules/payloads_spec.rb[1:469:1:1:3]' # modules/payloads windows/x64/powershell_bind_tcp it should behave like payload cached size is consistent windows/x64/powershell_bind_tcp has a valid cached_size
rspec './spec/modules/payloads_spec.rb[1:110:1:1:3]' # modules/payloads cmd/windows/powershell_bind_tcp it should behave like payload cached size is consistent cmd/windows/powershell_bind_tcp has a valid cached_size
rspec './spec/modules/payloads_spec.rb[1:495:1:1:3]' # modules/payloads windows/powershell_bind_tcp it should behave like payload cached size is consistent windows/powershell_bind_tcp has a valid cached_size
```

## Verification


- [x] Run `bundle exec rake rspec-rerun:spec SPEC_OPTS="--tag content"`
- [ ] Ensure tests pass
