### PR TITLE
[Rust Shim] added support for rust .crs files

### DIFF
--- a/lib/msf/core/modules/external/bridge.rb
+++ b/lib/msf/core/modules/external/bridge.rb
@@ -238,12 +238,33 @@ class Msf::Modules::External::GoBridge < Msf::Modules::External::Bridge
   end
 end
 
+class Msf::Modules::External::RustBridge < Msf::Modules::External::Bridge
+  def self.applies?(module_name)
+    module_name.match? /\.crs$/
+  end
+
+  def initialize(module_path, framework: nil)
+    super
+    self.cmd = ['cargo', 'script', self.path]
+  end
+
+  def handle_exception(error)
+    case error
+    when Errno::ENOENT
+      LoadError.new('Failed to execute external Go module. Please ensure you have Go installed on your environment.')
+    else
+      super
+    end
+  end
+end
+
 class Msf::Modules::External::Bridge
 
   LOADERS = [
     Msf::Modules::External::PyBridge,
     Msf::Modules::External::RbBridge,
     Msf::Modules::External::GoBridge,
+    Msf::Modules::External::RustBridge,
     Msf::Modules::External::Bridge
   ]
 

--- a/lib/msf/core/modules/external/bridge.rb
+++ b/lib/msf/core/modules/external/bridge.rb
@@ -251,7 +251,7 @@ class Msf::Modules::External::RustBridge < Msf::Modules::External::Bridge
   def handle_exception(error)
     case error
     when Errno::ENOENT
-      LoadError.new('Failed to execute external Go module. Please ensure you have Go installed on your environment.')
+      LoadError.new('Failed to execute external Rust module. Please ensure you have cargo and cargo-script installed on your environment.')
     else
       super
     end


### PR DESCRIPTION
I added support for a rust shim that I wrote ([associated crates.io link](https://crates.io/crates/metasploit-shim)), to bridge.rb. 
This will allow msf to recognize '.crs' files and execute them using the `cargo script` ( subcommand [associated crates.io link](https://crates.io/crates/cargo-script)) which will build and execute modules written in rust such as the example pushed [here](https://github.com/deadjakk/metasploit-rust-shim/blob/main/example-module/src/example-module.crs).

## Verification

### Pre-requisite installation 
   - [ ]  Install cargo, the rust toolchain
   - [ ]  Install the `script` subcommand for cargo (you can install this using `cargo install cargo-script` once you have cargo installed.
### Run the module
   - [ ]  Replace the bridge.rb file located in /lib/msf/core/modules/external/bridge.rb with the file provided in this repo.
   - [ ]  Place the example .crs file in ~/.msf4/modules/exploits/, or wherever you'd like to store the module.
   - [ ]  Start `msfconsole`
   - [ ] Use the module as usual

The screenshot below shows the full code of an example module and the same module being run from msfconsole. (sorry about the weird dimensions).

![rust-shim-working](https://user-images.githubusercontent.com/30613497/125356426-ce597480-e32b-11eb-93f6-15e8508d73b3.png)

tagging @wvu-r7 per request