### PR TITLE
Load Net::SSH for eaton xpert backdoor module

### DIFF
--- a/modules/auxiliary/scanner/ssh/eaton_xpert_backdoor.rb
+++ b/modules/auxiliary/scanner/ssh/eaton_xpert_backdoor.rb
@@ -4,6 +4,7 @@
 ###
 
 # XXX: This shouldn't be necessary but is now
+require 'net/ssh'
 require 'net/ssh/command_stream'
 
 class MetasploitModule < Msf::Auxiliary


### PR DESCRIPTION
closes #15410

## Verification

On master open msfconsole and verify the following error:
```
msf6 > use auxiliary/scanner/ssh/eaton_xpert_backdoor
[-] Failed to load module: NameError uninitialized constant Net::SSH
msf6 > 
```

Repeat on this branch, and verify the error no longer appears