### PR TITLE
Ensure generated JSP variable names aren't Java keywords

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -357,7 +357,7 @@ GEM
       rex-random_identifier
       rex-text
       ruby-rc4
-    rex-random_identifier (0.1.5)
+    rex-random_identifier (0.1.7)
       rex-text
     rex-registry (0.1.4)
     rex-rop_builder (0.1.4)

--- a/lib/msf/core/payload/jsp.rb
+++ b/lib/msf/core/payload/jsp.rb
@@ -21,11 +21,12 @@ module Msf::Payload::JSP
   # @return [String] jsp code that executes bind TCP payload
   def jsp_bind_tcp
     # Modified from: http://www.security.org.sg/code/jspreverse.html
+    generator = Rex::RandomIdentifier::Generator.new({ language: :jsp })
 
-    var_is = Rex::Text.rand_text_alpha_lower(2)
-    var_os = Rex::Text.rand_text_alpha_lower(2)
-    var_in = Rex::Text.rand_text_alpha_lower(2)
-    var_out = Rex::Text.rand_text_alpha_lower(3)
+    var_is = generator.generate(2)
+    var_os = generator.generate(2)
+    var_in = generator.generate(2)
+    var_out = generator.generate(3)
 
     jsp = <<-EOS
 <%@page import="java.lang.*"%>
@@ -92,11 +93,12 @@ module Msf::Payload::JSP
   # @return [String] jsp code that executes reverse TCP payload
   def jsp_reverse_tcp
     # JSP Reverse Shell modified from: http://www.security.org.sg/code/jspreverse.html
+    generator = Rex::RandomIdentifier::Generator.new({ language: :jsp })
 
-    var_is = Rex::Text.rand_text_alpha_lower(2)
-    var_os = Rex::Text.rand_text_alpha_lower(2)
-    var_in = Rex::Text.rand_text_alpha_lower(2)
-    var_out = Rex::Text.rand_text_alpha_lower(3)
+    var_is = generator.generate(2)
+    var_os = generator.generate(2)
+    var_in = generator.generate(2)
+    var_out = generator.generate(3)
 
     jsp = <<-EOS
 <%@page import="java.lang.*"%>
@@ -205,5 +207,4 @@ if (System.getProperty("os.name").toLowerCase().indexOf("windows") == -1) {
 
     jsp
   end
-
 end


### PR DESCRIPTION
closes https://github.com/rapid7/metasploit-framework/issues/15434

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use payload/java/jsp_shell_bind_tcp`
- [x] `generate -f raw`
- [x] Verify the variable names in the output exploit code are not reserved Java keywords.