### PR TITLE
Update metasploit payloads gem to 2.0.48

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,7 +29,7 @@ PATH
       metasploit-concern (~> 3.0.0)
       metasploit-credential (~> 4.0.0)
       metasploit-model (~> 3.1.0)
-      metasploit-payloads (= 2.0.47)
+      metasploit-payloads (= 2.0.48)
       metasploit_data_models (~> 4.1.0)
       metasploit_payloads-mettle (= 1.0.10)
       mqtt
@@ -242,7 +242,7 @@ GEM
       activemodel (~> 5.2.2)
       activesupport (~> 5.2.2)
       railties (~> 5.2.2)
-    metasploit-payloads (2.0.47)
+    metasploit-payloads (2.0.48)
     metasploit_data_models (4.1.4)
       activerecord (~> 5.2.2)
       activesupport (~> 5.2.2)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -70,7 +70,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model', '~> 3.1.0'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '2.0.47'
+  spec.add_runtime_dependency 'metasploit-payloads', '2.0.48'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '1.0.10'
   # Needed by msfgui and other rpc components


### PR DESCRIPTION
This PR updates the payloads gem version to 2.0.48 to bring in the updates to mimikatz in https://github.com/rapid7/mimikatz/pull/5 and https://github.com/rapid7/metasploit-payloads/pull/490

## Verification

List the steps needed to make sure this thing works

- [x] Let built-in tests run
- [x] see verification steps in https://github.com/rapid7/mimikatz/pull/5
