### PR TITLE
Redefine powershell support for some file system methods 

### DIFF
--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -548,13 +548,14 @@ module Msf::Post::File
   #
   # @param src_file [String] Remote source file name to copy
   # @param dst_file [String] The name for the remote destination file
+  # @return [Boolean] Return true on success and false on failure
   def copy_file(src_file, dst_file)
     return false if directory?(dst_file) or directory?(src_file)
     verification_token = Rex::Text.rand_text_alpha_upper(8)
     if session.type == "meterpreter"
       begin
         return (session.fs.file.cp(src_file, dst_file).result == 0)
-      rescue # when the source file is not present meterpreter will raise an error
+      rescue Rex::Post::Meterpreter::RequestError => e # when the source file is not present meterpreter will raise an error
         return false
       end
     elsif session.type == 'powershell'

--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -35,7 +35,7 @@ module Msf::Post::File
     if session.type == "meterpreter"
       session.fs.dir.chdir(e_path)
     elsif session.type == 'powershell'
-      session.shell_command_token("cd \"#{e_path}\"")
+      cmd_exec("Set-Location -Path \"#{e_path}\"")
     else
       session.shell_command_token("cd \"#{e_path}\"")
     end
@@ -133,7 +133,7 @@ module Msf::Post::File
       return false unless stat
       return stat.directory?
     elsif session.type == 'powershell'
-      return cmd_exec("Test-Path -Path \"#{path}\" -PathType Container")
+      return cmd_exec("Test-Path -Path \"#{path}\" -PathType Container").include?('True')
     else
       if session.platform == 'windows'
         f = cmd_exec("cmd.exe /C IF exist \"#{path}\\*\" ( echo true )")
@@ -364,7 +364,7 @@ module Msf::Post::File
 
     if session.type == 'powershell'
       return cmd_exec("Get-Content \"#{file_name}\"")
-
+    end
     if session.platform == 'windows'
       return session.shell_command_token("type \"#{file_name}\"")
     end
@@ -551,7 +551,7 @@ module Msf::Post::File
     if session.type == "meterpreter"
       return (session.fs.file.cp(src_file, dst_file).result == 0)
     elsif session.type == 'powershell'
-      cmd_exec("Copy-Item \"#{src_file}\" -Destination \"#{dst_file}\""}
+      cmd_exec("Copy-Item \"#{src_file}\" -Destination \"#{dst_file}\"")
     else
       if session.platform == 'windows'
         cmd_exec(%Q|copy /y "#{src_file}" "#{dst_file}"|) =~ /copied/

--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -155,7 +155,7 @@ module Msf::Post::File
     if session.type == "meterpreter"
       return session.fs.file.expand_path(path)
     elsif session.type == 'powershell'
-      return cmd_exec("(Resolve-Path #{path}).Path")
+      return cmd_exec("(Resolve-Path \"#{path}\").Path")
     else
       return cmd_exec("echo #{path}")
     end

--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -39,7 +39,7 @@ module Msf::Post::File
     else
       session.shell_command_token("cd \"#{e_path}\"")
     end
-    return
+    nil
   end
 
   #

--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -155,7 +155,7 @@ module Msf::Post::File
     if session.type == "meterpreter"
       return session.fs.file.expand_path(path)
     elsif session.type == 'powershell'
-      return cmd_exec("$ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath(\"#{path}\")")
+      return cmd_exec("[Environment]::ExpandEnvironmentVariables(\"#{path}\")")
     else
       return cmd_exec("echo #{path}")
     end

--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -155,7 +155,7 @@ module Msf::Post::File
     if session.type == "meterpreter"
       return session.fs.file.expand_path(path)
     elsif session.type == 'powershell'
-      return cmd_exec("(Resolve-Path \"#{path}\").Path")
+      return cmd_exec("$ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath(\"#{path}\")")
     else
       return cmd_exec("echo #{path}")
     end

--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -39,6 +39,7 @@ module Msf::Post::File
     else
       session.shell_command_token("cd \"#{e_path}\"")
     end
+    return
   end
 
   #


### PR DESCRIPTION
## Summary
Some methods used in post exploitation for file_system operations like `mkdir`, `cd` etc use the commands of shell_session for operations even when the session type is powershell. This PR separates the support for powershell  by using powershell `cmdlets` for all operations.

## Verification Steps
```
>> pwd
=> "C:\\Users\\User\\Links"
>> cd '../'
=> ""
>> pwd
=> "C:\\Users\\User"

>> copy_file('Desktop.lnk','../Desktop_copy')
=> ""

>> file?(expand_path('/'))
=> false

>> read_file('Desktop.lnk')
...
...
...
>> mkdir 'test'
>> directory? 'test'
=> true
>> directory? 'desktop.lnk'
=> false

```