### PR TITLE
Fix typo in doc comment.

### DIFF
--- a/lib/metasploit/framework/obfuscation/crandomizer/parser.rb
+++ b/lib/metasploit/framework/obfuscation/crandomizer/parser.rb
@@ -21,7 +21,7 @@ module Metasploit
 
           # Returns a parser.
           #
-          # @param template [String] Soure code to parse.
+          # @param template [String] Source code to parse.
           # @return [Metasm::C::Parser]
           def parse(template)
             main_parser = Metasploit::Framework::Obfuscation::CRandomizer::Utility.parse(template)


### PR DESCRIPTION
- [x] **Verify** the thing does what it should

It fixes an itty bitty typo! :D