### PR TITLE
Fix localization issue in `copy_file` method

### DIFF
--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -562,9 +562,9 @@ module Msf::Post::File
       cmd_exec("Copy-Item \"#{src_file}\" -Destination \"#{dst_file}\"; if($?){echo #{verification_token}}").include?(verification_token)
     else
       if session.platform == 'windows'
-        cmd_exec(%Q|copy /y "#{src_file}" "#{dst_file}"|) =~ /copied/
+        cmd_exec(%Q|copy /y "#{src_file}" "#{dst_file}" & if not errorlevel 1 echo #{verification_token}|).include?(verification_token)
       else
-        cmd_exec(%Q|cp -f "#{src_file}" "#{dst_file}"|).empty?
+        cmd_exec(%Q|cp -f "#{src_file}" "#{dst_file}" && echo #{verification_token}|).include?(verification_token)
       end
     end
   end


### PR DESCRIPTION
## Summary
This PR fixes a localization issue in the `copy_file` method.

## Verification Steps
#### Non-Windows
```
>> copy_file('/etc/passwd','/tmp/test')
=> true
>> copy_file('/etc/passwd','/tmp/')
=> false
>> copy_file('/etc/passwd','/etc/shadow')
=> false
>> copy_file('/root/.ssh/id_rsa', '/tmp/test')
=> false
>> copy_file('/etc/doesnotexist','/tmp/test')
=> false
```
#### Windows
```
>> copy_file "Dekk", "test"
=> false
>> copy_file "Desktop.lnk", "test_directory"
=> false
>> copy_file "Dekk", "Dekk1"
=> true
>> copy_file "test_directory", "Dekk1"
=> false
>> copy_file "test_directory", "test_dir2"
=> false
>> copy_file "Desktop", "../Desktop1"
=> true
```