### PR TITLE
Reformats modules so they're compatible with Rubocop Rule

### DIFF
--- a/lib/msf/core/post/common.rb
+++ b/lib/msf/core/post/common.rb
@@ -3,14 +3,20 @@
 module Msf::Post::Common
 
   def initialize(info = {})
-    super(update_info(
-      info,
-      'Compat' => { 'Meterpreter' => { 'Commands' => %w{
-        stdapi_sys_config_getenv
-        stdapi_sys_process_close
-        stdapi_sys_process_execute
-      } } }
-    ))
+    super(
+      update_info(
+        info,
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_sys_config_getenv
+              stdapi_sys_process_close
+              stdapi_sys_process_execute
+            ]
+          }
+        }
+      )
+    )
   end
 
   def clear_screen

--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -8,21 +8,27 @@ module Msf::Post::File
   include Msf::Post::Common
 
   def initialize(info = {})
-    super(update_info(
-      info,
-      'Compat' => { 'Meterpreter' => { 'Commands' => %w{
-        core_channel_*
-        stdapi_fs_chdir
-        stdapi_fs_delete_dir
-        stdapi_fs_delete_file
-        stdapi_fs_file_expand_path
-        stdapi_fs_file_move
-        stdapi_fs_getwd
-        stdapi_fs_ls
-        stdapi_fs_mkdir
-        stdapi_fs_stat
-      } } }
-    ))
+    super(
+      update_info(
+        info,
+          'Compat' => {
+            'Meterpreter' => {
+              'Commands' => %w[
+                core_channel_*
+                stdapi_fs_chdir
+                stdapi_fs_delete_dir
+                stdapi_fs_delete_file
+                stdapi_fs_file_expand_path
+                stdapi_fs_file_move
+                stdapi_fs_getwd
+                stdapi_fs_ls
+                stdapi_fs_mkdir
+                stdapi_fs_stat
+              ]
+            }
+          }
+        )
+      )
   end
 
   #

--- a/lib/msf/core/post/windows/accounts.rb
+++ b/lib/msf/core/post/windows/accounts.rb
@@ -47,10 +47,19 @@ module Msf
         ].freeze
 
         def initialize(info = {})
-          super(update_info(
-            info,
-            'Compat' => { 'Meterpreter' => { 'Commands' => %w{ stdapi_sys_process_* stdapi_railgun_* } } }
-          ))
+          super(
+            update_info(
+              info,
+              'Compat' => {
+                'Meterpreter' => {
+                  'Commands' => %w[
+                    stdapi_sys_process_*
+                    stdapi_railgun_*
+                  ]
+                }
+              }
+            )
+          )
         end
 
         ##

--- a/lib/msf/core/post/windows/eventlog.rb
+++ b/lib/msf/core/post/windows/eventlog.rb
@@ -6,10 +6,19 @@ module Windows
 module Eventlog
 
   def initialize(info = {})
-    super(update_info(
-      info,
-      'Compat' => { 'Meterpreter' => { 'Commands' => %w{ stdapi_sys_config_sysinfo stdapi_sys_eventlog_* } } }
-    ))
+    super(
+      update_info(
+        info,
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_sys_config_sysinfo
+              stdapi_sys_eventlog_*
+            ]
+          }
+        }
+      )
+    )
   end
 
   #

--- a/lib/msf/core/post/windows/extapi.rb
+++ b/lib/msf/core/post/windows/extapi.rb
@@ -7,10 +7,18 @@ module Windows
 module ExtAPI
 
   def initialize(info = {})
-    super(update_info(
-      info,
-      'Compat' => { 'Meterpreter' => { 'Commands' => %w{ extapi_* } } }
-    ))
+    super(
+      update_info(
+        info,
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              extapi_*
+            ]
+          }
+        }
+      )
+    )
   end
 
   def load_extapi

--- a/lib/msf/core/post/windows/file_info.rb
+++ b/lib/msf/core/post/windows/file_info.rb
@@ -6,10 +6,18 @@ module Windows
 module FileInfo
 
   def initialize(info = {})
-    super(update_info(
-      info,
-      'Compat' => { 'Meterpreter' => { 'Commands' => %w{ stdapi_railgun_* } } }
-    ))
+    super(
+      update_info(
+        info,
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_railgun_*
+            ]
+          }
+        }
+      )
+    )
   end
 
   def hiword(num)

--- a/lib/msf/core/post/windows/file_system.rb
+++ b/lib/msf/core/post/windows/file_system.rb
@@ -9,10 +9,20 @@ module Msf
         include Msf::Post::Common
 
         def initialize(info = {})
-          super(update_info(
-            info,
-            'Compat' => { 'Meterpreter' => { 'Commands' => %w{ stdapi_fs_delete_dir stdapi_railgun_api* stdapi_sys_process_* } } }
-          ))
+          super(
+            update_info(
+              info,
+              'Compat' => {
+                'Meterpreter' => {
+                  'Commands' => %w[
+                    stdapi_fs_delete_dir
+                    stdapi_railgun_api*
+                    stdapi_sys_process_*
+                  ]
+                }
+              }
+            )
+          )
         end
 
         class String16 < BinData::String

--- a/lib/msf/core/post/windows/kiwi.rb
+++ b/lib/msf/core/post/windows/kiwi.rb
@@ -7,10 +7,18 @@ module Windows
 module Kiwi
 
   def initialize(info = {})
-    super(update_info(
-      info,
-      'Compat' => { 'Meterpreter' => { 'Commands' => %w{ kiwi_* } } }
-    ))
+    super(
+      update_info(
+        info,
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              kiwi_*
+            ]
+          }
+        }
+      )
+    )
   end
 
   def load_kiwi

--- a/lib/msf/core/post/windows/ldap.rb
+++ b/lib/msf/core/post/windows/ldap.rb
@@ -85,10 +85,18 @@ module LDAP
   }
 
     def initialize(info = {})
-      super(update_info(
-        info,
-        'Compat' => { 'Meterpreter' => { 'Commands' => %w{ stdapi_railgun_* } } }
-      ))
+      super(
+        update_info(
+          info,
+          'Compat' => {
+            'Meterpreter' => {
+              'Commands' => %w[
+                stdapi_railgun_*
+              ]
+            }
+          }
+        )
+      )
 
       register_options(
       [

--- a/lib/msf/core/post/windows/mssql.rb
+++ b/lib/msf/core/post/windows/mssql.rb
@@ -12,12 +12,23 @@ module Msf
         include Msf::Post::Windows::Priv
 
         def initialize(info = {})
-          super(update_info(
-            info,
-            'Compat' => { 'Meterpreter' => { 'Commands' => %w{
-              core_migrate stdapi_sys_config_getprivs stdapi_sys_config_getuid stdapi_sys_process_* incognito_impersonate_token priv_elevate_getsystem
-            } } }
-          ))
+          super(
+            update_info(
+              info,
+              'Compat' => {
+                'Meterpreter' => {
+                  'Commands' => %w[
+                    core_migrate
+                    stdapi_sys_config_getprivs
+                    stdapi_sys_config_getuid
+                    stdapi_sys_process_*
+                    incognito_impersonate_token
+                    priv_elevate_getsystem
+                  ]
+                }
+              }
+            )
+          )
         end
 
         # Identifies the Windows Service matching the SQL Server instance name

--- a/lib/msf/core/post/windows/net_api.rb
+++ b/lib/msf/core/post/windows/net_api.rb
@@ -23,12 +23,18 @@ module NetAPI
   NERR_UserNotFound = 2221
 
   def initialize(info = {})
-    super(update_info(
-      info,
-      'Compat' => { 'Meterpreter' => { 'Commands' => %w{
-        stdapi_railgun_*
-      } } }
-    ))
+    super(
+      update_info(
+        info,
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_railgun_*
+            ]
+          }
+        }
+      )
+    )
   end
 
   def UnicodeByteStringToAscii(str)

--- a/lib/msf/core/post/windows/powershell.rb
+++ b/lib/msf/core/post/windows/powershell.rb
@@ -10,10 +10,19 @@ module Msf
         include ::Msf::Post::Common
 
         def initialize(info = {})
-          super(update_info(
-            info,
-            'Compat' => { 'Meterpreter' => { 'Commands' => %w{ stdapi_sys_config_sysinfo stdapi_sys_process_* } } }
-          ))
+          super(
+            update_info(
+              info,
+              'Compat' => {
+                'Meterpreter' => {
+                  'Commands' => %w[
+                    stdapi_sys_config_sysinfo
+                    stdapi_sys_process_*
+                  ]
+                }
+              }
+            )
+          )
 
           register_advanced_options(
             [

--- a/lib/msf/core/post/windows/priv.rb
+++ b/lib/msf/core/post/windows/priv.rb
@@ -24,10 +24,20 @@ module Msf::Post::Windows::Priv
   UAC_DEFAULT = 5
 
   def initialize(info = {})
-    super(update_info(
-      info,
-      'Compat' => { 'Meterpreter' => { 'Commands' => %w{ stdapi_sys_config_* stdapi_sys_process_* stdapi_registry_* } } }
-    ))
+    super(
+      update_info(
+        info,
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_sys_config_*
+              stdapi_sys_process_*
+              stdapi_registry_*
+            ]
+          }
+        }
+      )
+    )
   end
 
   #

--- a/lib/msf/core/post/windows/process.rb
+++ b/lib/msf/core/post/windows/process.rb
@@ -11,10 +11,19 @@ module Process
   include Msf::Post::Process
 
   def initialize(info = {})
-    super(update_info(
-      info,
-      'Compat' => { 'Meterpreter' => { 'Commands' => %w{ core_channel_* stdapi_sys_process_* } } }
-    ))
+    super(
+      update_info(
+        info,
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              core_channel_*
+              stdapi_sys_process_*
+            ]
+          }
+        }
+      )
+    )
   end
 
   # Checks the architecture of a payload and PID are compatible

--- a/lib/msf/core/post/windows/runas.rb
+++ b/lib/msf/core/post/windows/runas.rb
@@ -13,10 +13,18 @@ module Msf::Post::Windows::Runas
   SW_HIDE = 0
 
   def initialize(info = {})
-    super(update_info(
-      info,
-      'Compat' => { 'Meterpreter' => { 'Commands' => %w{ stdapi_railgun_api* } } }
-    ))
+    super(
+      update_info(
+        info,
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_railgun_api*
+            ]
+          }
+        }
+      )
+    )
   end
 
   def shell_execute_exe(filename = nil, path = nil)

--- a/lib/msf/core/post/windows/services.rb
+++ b/lib/msf/core/post/windows/services.rb
@@ -42,10 +42,19 @@ module Services
   include ::Msf::Post::Windows::Registry
 
   def initialize(info = {})
-    super(update_info(
-      info,
-      'Compat' => { 'Meterpreter' => { 'Commands' => %w{ extapi_service_* stdapi_railgun_api* } } }
-    ))
+    super(
+      update_info(
+        info,
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              extapi_service_*
+              stdapi_railgun_api*
+            ]
+          }
+        }
+      )
+    )
   end
 
   def advapi32

--- a/lib/msf/core/post/windows/user_profiles.rb
+++ b/lib/msf/core/post/windows/user_profiles.rb
@@ -8,10 +8,19 @@ module UserProfiles
   include Msf::Post::Windows::Accounts
 
   def initialize(info = {})
-    super(update_info(
-      info,
-      'Compat' => { 'Meterpreter' => { 'Commands' => %w{ stdapi_fs_stat stdapi_fs_file_expand_path } } }
-    ))
+    super(
+      update_info(
+        info,
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_fs_stat
+              stdapi_fs_file_expand_path
+            ]
+          }
+        }
+      )
+    )
   end
 
   #

--- a/lib/msf/core/post/windows/wmic.rb
+++ b/lib/msf/core/post/windows/wmic.rb
@@ -11,10 +11,20 @@ module WMIC
   include Msf::Post::Windows::ExtAPI
 
   def initialize(info = {})
-    super(update_info(
-      info,
-      'Compat' => { 'Meterpreter' => { 'Commands' => %w{ extapi_clipboard_[gs]et_data stdapi_railgun_api* stdapi_sys_process_* } } }
-    ))
+    super(
+      update_info(
+        info,
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              extapi_clipboard_[gs]et_data
+              stdapi_railgun_api*
+              stdapi_sys_process_*
+            ]
+          }
+        }
+      )
+    )
 
     register_options([
                          OptString.new('SMBUser', [ false, 'The username to authenticate as' ]),

--- a/modules/post/linux/gather/gnome_keyring_dump.rb
+++ b/modules/post/linux/gather/gnome_keyring_dump.rb
@@ -8,18 +8,27 @@ require 'bindata'
 class MetasploitModule < Msf::Post
 
   def initialize(info={})
-    super(update_info(info,
-      'Name'           => 'Gnome-Keyring Dump',
-      'Description'    => %q{
-        Use libgnome-keyring to extract network passwords for the current user.
-        This module does not require root privileges to run.
-      },
-      'Author'        => 'Spencer McIntyre',
-      'License'       => MSF_LICENSE,
-      'Platform'      => [ 'linux' ],
-      'SessionTypes'  => [ 'meterpreter' ],
-      'Compat' => { 'Meterpreter' => { 'Commands' => %w{ stdapi_railgun_* } } }
-    ))
+    super(
+      update_info(
+        info,
+        'Name'           => 'Gnome-Keyring Dump',
+        'Description'    => %q{
+          Use libgnome-keyring to extract network passwords for the current user.
+          This module does not require root privileges to run.
+        },
+        'Author'        => 'Spencer McIntyre',
+        'License'       => MSF_LICENSE,
+        'Platform'      => [ 'linux' ],
+        'SessionTypes'  => [ 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_railgun_*
+            ]
+          }
+        }
+      )
+    )
   end
 
   class GList_x64 < BinData::Record

--- a/modules/post/windows/gather/ntds_grabber.rb
+++ b/modules/post/windows/gather/ntds_grabber.rb
@@ -11,20 +11,28 @@ class MetasploitModule < Msf::Post
   include Msf::Post::Common
 
   def initialize(info = {})
-    super(update_info(
-      info,
-      'Name' => 'NTDS Grabber',
-      'Description' => %q(This module uses a powershell script to obtain a copy of the ntds,dit SAM and SYSTEM files on a domain controller.
-                          It compresses all these files in a cabinet file called All.cab.),
-      'License' => MSF_LICENSE,
-      'Author' => ['Koen Riepe (koen.riepe@fox-it.com)'],
-      'References' => [''],
-      'Platform' => [ 'win' ],
-      'Arch' => [ 'x86', 'x64' ],
-      'SessionTypes' => [ 'meterpreter' ],
-      'Compat' => { 'Meterpreter' => { 'Commands' => %w{ core_migrate stdapi_railgun* } } }
+    super(
+      update_info(
+        info,
+        'Name' => 'NTDS Grabber',
+        'Description' => %q(This module uses a powershell script to obtain a copy of the ntds,dit SAM and SYSTEM files on a domain controller.
+                            It compresses all these files in a cabinet file called All.cab.),
+        'License' => MSF_LICENSE,
+        'Author' => ['Koen Riepe (koen.riepe@fox-it.com)'],
+        'References' => [''],
+        'Platform' => [ 'win' ],
+        'Arch' => [ 'x86', 'x64' ],
+        'SessionTypes' => [ 'meterpreter' ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              core_migrate
+              stdapi_railgun*
+            ]
+          }
+        }
+      )
     )
-  )
 
     register_options(
       [


### PR DESCRIPTION
This is a prerequisite to another [PR](https://github.com/rapid7/metasploit-framework/pull/15295).

Reformats modules so they can be run with the new `meterpreter_commands_dependencies.rb` rubocop rule, that will be implemented to handle any missing Meterpreter commands dependencies.

## Verification

List the steps needed to make sure this thing works

- [ ] Just a code review please