### PR TITLE
Add missing rex requires

### DIFF
--- a/lib/rex/post/meterpreter/channels/pools/stream_pool.rb
+++ b/lib/rex/post/meterpreter/channels/pools/stream_pool.rb
@@ -1,5 +1,6 @@
 # -*- coding: binary -*-
 
+require 'rex/io/stream_abstraction'
 require 'rex/post/meterpreter/channels/pool'
 require 'rex/post/meterpreter/extensions/stdapi/tlv'
 

--- a/lib/rex/post/meterpreter/command_mapper.rb
+++ b/lib/rex/post/meterpreter/command_mapper.rb
@@ -1,6 +1,7 @@
 # -*- coding: binary -*-
 
 require 'rex/post/meterpreter/extension_mapper'
+require 'rex/post/meterpreter/core_ids'
 
 module Rex
 module Post

--- a/lib/rex/post/meterpreter/extensions/sniffer/sniffer.rb
+++ b/lib/rex/post/meterpreter/extensions/sniffer/sniffer.rb
@@ -2,6 +2,7 @@
 
 require 'rex/post/meterpreter/extensions/sniffer/tlv'
 require 'rex/post/meterpreter/extensions/sniffer/command_ids'
+require 'rex/post/meterpreter/extension'
 
 module Rex
 module Post

--- a/lib/rex/post/meterpreter/extensions/sniffer/tlv.rb
+++ b/lib/rex/post/meterpreter/extensions/sniffer/tlv.rb
@@ -1,4 +1,6 @@
 # -*- coding: binary -*-
+require 'rex/post/meterpreter/packet'
+
 module Rex
 module Post
 module Meterpreter


### PR DESCRIPTION
This is a prerequisite to another [PR](https://github.com/rapid7/metasploit-framework/pull/15295).

Reformats modules so they can be run with the new `meterpreter_commands_dependencies.rb` rubocop rule, that will be implemented to handle any missing Meterpreter commands dependencies.

## Verification

List the steps needed to make sure this thing works

- [ ] Just a code review please