### PR TITLE
Update local exploit suggester to handle nil targets

### DIFF
--- a/modules/post/multi/recon/local_exploit_suggester.rb
+++ b/modules/post/multi/recon/local_exploit_suggester.rb
@@ -120,38 +120,34 @@ class MetasploitModule < Msf::Post
     results = []
     @local_exploits.each do |m|
       begin
-        begin
-          checkcode = m.check
-        rescue => e
-          elog("#{m.shortname} failed to run", error: e)
-        end
+        checkcode = m.check
+      rescue => e
+        elog("#Local Exploit Suggester failed with: #{e.class} when using #{m.shortname}", error: e)
+        vprint_error "Check with module #{m.fullname} failed with error #{e.class}"
+        next
+      end
 
-        if checkcode.nil?
-          vprint_error "#{m.fullname}: Check failed"
-          next
-        end
+      if checkcode.nil?
+        vprint_error "Check failed with #{m.fullname} for unknown reasons"
+        next
+      end
 
-        # See def is_check_interesting?
-        unless is_check_interesting? checkcode
-          vprint_status "#{m.fullname}: #{checkcode.message}"
-          next
-        end
+      # See def is_check_interesting?
+      unless is_check_interesting? checkcode
+        vprint_status "#{m.fullname}: #{checkcode.message}"
+        next
+      end
 
-        # Prints the full name and the checkcode message for the exploit
-        print_good "#{m.fullname}: #{checkcode.message}"
-        results << [m.fullname, checkcode.message]
+      # Prints the full name and the checkcode message for the exploit
+      print_good "#{m.fullname}: #{checkcode.message}"
+      results << [m.fullname, checkcode.message]
 
-        # If the datastore option is true, a detailed description will show
-        next unless datastore['SHOWDESCRIPTION']
+      # If the datastore option is true, a detailed description will show
+      next unless datastore['SHOWDESCRIPTION']
 
-        # Formatting for the description text
-        Rex::Text.wordwrap(Rex::Text.compress(m.description), 2, 70).split(/\n/).each do |line|
-          print_line line
-        end
-      rescue Rex::Post::Meterpreter::RequestError => e
-        # Creates a log record in framework.log
-        elog("#{m.shortname} failed to run", error: e)
-        vprint_error "#{e.class} #{m.shortname} failed to run: #{e.message}"
+      # Formatting for the description text
+      Rex::Text.wordwrap(Rex::Text.compress(m.description), 2, 70).split(/\n/).each do |line|
+        print_line line
       end
     end
 

--- a/modules/post/multi/recon/local_exploit_suggester.rb
+++ b/modules/post/multi/recon/local_exploit_suggester.rb
@@ -50,6 +50,8 @@ class MetasploitModule < Msf::Post
 
   def is_module_platform?(mod)
     platform_obj = Msf::Module::Platform.find_platform session.platform
+    return false if mod.target.nil?
+
     module_platforms = mod.target.platform ? mod.target.platform.platforms : mod.platform.platforms
     module_platforms.include? platform_obj
   rescue ArgumentError => e
@@ -118,7 +120,11 @@ class MetasploitModule < Msf::Post
     results = []
     @local_exploits.each do |m|
       begin
-        checkcode = m.check
+        begin
+          checkcode = m.check
+        rescue => e
+          elog("#{m.shortname} failed to run", error: e)
+        end
 
         if checkcode.nil?
           vprint_error "#{m.fullname}: Check failed"


### PR DESCRIPTION
This PR fixes an issue with local_exploit_suggester, where it would crash if i encountered a module with a nil target property.

### Before
When a module returns a nil target:
![image](https://user-images.githubusercontent.com/85949464/126800529-4f8b8aeb-35ac-4d6c-91c1-99ddf4b1a64d.png)

### After
![image](https://user-images.githubusercontent.com/85949464/126797938-39908ca8-7f6f-4980-8968-0473e6a455e1.png)

## Verification

List the steps needed to make sure this thing works

- [ ] Apply this patch
```diff
diff --git a/lib/msf/core/exploit.rb b/lib/msf/core/exploit.rb
index 8f7891cef2..94b8bbdd86 100644
--- a/lib/msf/core/exploit.rb
+++ b/lib/msf/core/exploit.rb
@@ -634,6 +634,10 @@ class Exploit < Msf::Module
   # default target, that one will be automatically used.
   #
   def target
+    if self.fullname == "exploit/windows/local/ms10_092_schelevator"
+      return nil
+    end
     if self.respond_to?(:auto_targeted_index)
       if auto_target?
         auto_idx = auto_targeted_index
```
- [ ] Start `msfconsole`
- [ ] Get a session
- [ ] Use local_exploit_suggester
- [ ] **Verify** the exploit suggester doesn't crash
