### PR TITLE
Add support for reading binary files for powershell session types

### DIFF
--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -254,6 +254,7 @@ module Msf::Post::File
     verification_token = Rex::Text::rand_text_alpha(8)
 
     if session.type == 'powershell'
+      return false if exists?(path)
       if file?(path)
         return cmd_exec("[System.IO.File]::OpenRead(\"#{path}\");if($?){echo\
           #{verification_token}}").include?(verification_token)

--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -370,7 +370,7 @@ module Msf::Post::File
     return unless %w[shell powershell].include?(session.type)
 
     if session.type == 'powershell'
-      return powershell_read_file(file_name)
+      return _read_file_powershell(file_name)
     end
 
     if session.platform == 'windows'
@@ -579,7 +579,7 @@ module Msf::Post::File
 
 protected
 
-  def powershell_read_file(file_name)
+  def _read_file_powershell(file_name)
     b64_data= cmd_exec("[convert]::ToBase64String(([IO.File]::ReadAllBytes(\"#{file_name}\")))")
     return Base64.decode64(b64_data)    
   end

--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -254,11 +254,11 @@ module Msf::Post::File
     verification_token = Rex::Text::rand_text_alpha(8)
     return false unless exists?(path)
     if session.type == 'powershell'
-      if file?(path)
+      unless directory?(path)
         return cmd_exec("[System.IO.File]::OpenRead(\"#{path}\");if($?){echo\
           #{verification_token}}").include?(verification_token)
-      elsif directory?(path)
-        return cmd_exec("Get-ChildItem -Path \"#{path}\"; if($?) {echo #{verification_token}}").include?(verification_token)
+      else
+        return cmd_exec("[System.IO.Directory]::GetFiles('#{path}'); if($?) {echo #{verification_token}}").include?(verification_token)
       end
     end
 

--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -252,16 +252,15 @@ module Msf::Post::File
   #
   def readable?(path)
     verification_token = Rex::Text::rand_text_alpha(8)
-
+    return false unless exists?(path)
     if session.type == 'powershell'
-      return false if exists?(path)
       if file?(path)
         return cmd_exec("[System.IO.File]::OpenRead(\"#{path}\");if($?){echo\
           #{verification_token}}").include?(verification_token)
       elsif directory?(path)
         return cmd_exec("Get-ChildItem -Path \"#{path}\"; if($?) {echo #{verification_token}}").include?(verification_token)
       end
-  	end
+    end
 
     raise "`readable?' method does not support Windows systems" if session.platform == 'windows'
 

--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -580,8 +580,16 @@ module Msf::Post::File
 protected
 
   def _read_file_powershell(file_name)
-    b64_data= cmd_exec("[convert]::ToBase64String(([IO.File]::ReadAllBytes(\"#{file_name}\")))")
-    return Base64.decode64(b64_data)    
+    puts file_name
+    b64_data= cmd_exec("$mstream = [System.IO.MemoryStream]::new();\
+      $gzipstream = [System.IO.Compression.GZipStream]::new($mstream, [System.IO.Compression.CompressionMode]::Compress);\
+      $get_bytes = [System.IO.File]::ReadAllBytes(\"#{file_name}\");\
+      $gzipstream.Write($get_bytes, 0 , $get_bytes.Length);\
+      $gzipstream.Close();\
+      [Convert]::ToBase64String($mstream.ToArray())")
+    puts b64_data
+    uncompressed_file = Zlib::GzipReader.new(StringIO.new(Base64.decode64(b64_data))).read
+    return uncompressed_file
   end
   # Checks to see if there are non-ansi or newline characters in a given string
   #

--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -582,7 +582,7 @@ protected
   def _read_file_powershell(filename)
     data = ''
     offset = 0
-    chunk_size = 1024
+    chunk_size = 65536
     loop do
       chunk = _read_file_powershell_fragment(filename, chunk_size, offset)
       break if chunk.nil?

--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -251,9 +251,20 @@ module Msf::Post::File
   # @return [Boolean] true if +path+ exists and is readable
   #
   def readable?(path)
+    verification_token = Rex::Text::rand_text_alpha(8)
+
+    if session.type == 'powershell'
+      if file?(path)
+        return cmd_exec("[System.IO.File]::OpenRead(\"#{path}\");if($?){echo\
+          #{verification_token}}").include?(verification_token)
+      elsif directory?(path)
+        return cmd_exec("Get-ChildItem -Path \"#{path}\"; if($?) {echo #{verification_token}}").include?(verification_token)
+      end
+  	end
+
     raise "`readable?' method does not support Windows systems" if session.platform == 'windows'
 
-    cmd_exec("test -r '#{path}' && echo true").to_s.include? 'true'
+    cmd_exec("test -r '#{path}' && echo #{verification_token}").to_s.include?(verification_token)
   end
 
   #

--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -594,7 +594,7 @@ protected
     return data
   end
 
-  def _read_file_powershell_fragement(start, stop, filename)
+  def _read_file_powershell_fragment(filename, chunk_size, offset=0)
     b64_data= cmd_exec("$mstream = [System.IO.MemoryStream]::new();\
       $gzipstream = [System.IO.Compression.GZipStream]::new($mstream, [System.IO.Compression.CompressionMode]::Compress);\
       $get_bytes = [System.IO.File]::ReadAllBytes(\"#{filename}\")[#{start}..#{stop - 1}];\

--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -586,7 +586,7 @@ protected
     chunk_size = 1024 * 1024
     loop do
       stop = start + chunk_size
-      stop = eof - 1 if stop >= eof
+      stop = eof if stop > eof
       data << _read_file_powershell_fragement(start, stop, filename)
       start += chunk_size
       break if start >= eof
@@ -597,7 +597,7 @@ protected
   def _read_file_powershell_fragement(start, stop, filename)
     b64_data= cmd_exec("$mstream = [System.IO.MemoryStream]::new();\
       $gzipstream = [System.IO.Compression.GZipStream]::new($mstream, [System.IO.Compression.CompressionMode]::Compress);\
-      $get_bytes = [System.IO.File]::ReadAllBytes(\"#{filename}\")[#{start}..#{stop}];\
+      $get_bytes = [System.IO.File]::ReadAllBytes(\"#{filename}\")[#{start}..#{stop - 1}];\
       $gzipstream.Write($get_bytes, 0 , $get_bytes.Length);\
       $gzipstream.Close();\
       [Convert]::ToBase64String($mstream.ToArray())")

--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -594,10 +594,10 @@ protected
     return data
   end
 
-  def _read_file_powershell_fragement(offset, chunk_size, filename)
+  def _read_file_powershell_fragement(start, stop, filename)
     b64_data= cmd_exec("$mstream = [System.IO.MemoryStream]::new();\
       $gzipstream = [System.IO.Compression.GZipStream]::new($mstream, [System.IO.Compression.CompressionMode]::Compress);\
-      $get_bytes = [System.IO.File]::ReadAllBytes(\"#{filename}\")[#{offset}..#{chunk_size}];\
+      $get_bytes = [System.IO.File]::ReadAllBytes(\"#{filename}\")[#{start}..#{stop}];\
       $gzipstream.Write($get_bytes, 0 , $get_bytes.Length);\
       $gzipstream.Close();\
       [Convert]::ToBase64String($mstream.ToArray())")

--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -370,8 +370,9 @@ module Msf::Post::File
     return unless %w[shell powershell].include?(session.type)
 
     if session.type == 'powershell'
-      return cmd_exec("Get-Content \"#{file_name}\"")
+      return powershell_read_file(file_name)
     end
+
     if session.platform == 'windows'
       return session.shell_command_token("type \"#{file_name}\"")
     end
@@ -578,6 +579,10 @@ module Msf::Post::File
 
 protected
 
+  def powershell_read_file(file_name)
+    b64_data= cmd_exec("[convert]::ToBase64String(([IO.File]::ReadAllBytes(\"#{file_name}\")))")
+    return Base64.decode64(b64_data)    
+  end
   # Checks to see if there are non-ansi or newline characters in a given string
   #
   # @param data [String] String to check for non-ansi or newline chars


### PR DESCRIPTION
## Summary
This PR adds support for reading binary files from the target system for the powershell session type. It compresses the file on the target system, encodes to base64 using `[convert]::ToBase64String(([IO.File]::ReadAllBytes(\"#{file_name}\")))`, fetches it and then decodes and decompresses it.

## Verification Steps
```
>> puts read_file('testfile')
expected_Data 
=> nil
>> puts read_file('windows_powershell_reverse.exe')
MZ����@���	�!�L�!This program cannot be run in DOS mode.
$9$�}E�}E�}E�Z��~E�}E~�E�t=�|E�t=�|E�Rich}E�PEd�}<�K�#
...
...
...
ReadToEnd()))"`G����xG0�G�GKERNEL32.dllXVirtualAllocExitProcess
```
### Verifying the MD5 checksum of the binary files
```
pwsh_data= read_file('windows_powershell_reverse.exe')
open('/tmp/test.bin', 'wb') {|file| BinData::String.new(pwsh_data).write(file) }
f08d368a588292033008b91b2d30b9b5  /home/.../windows_powershell_reverse.exe
f08d368a588292033008b91b2d30b9b5  /tmp/test.bin
```
