### PR TITLE
MeterpreterCommandDependencies rubocop rule ran against first batch of modules

### DIFF
--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -14,8 +14,9 @@ module Msf::Post::File
           'Compat' => {
             'Meterpreter' => {
               'Commands' => %w[
-                core_channel_*
+                core_channel_write
                 stdapi_fs_chdir
+                stdapi_fs_chmod
                 stdapi_fs_delete_dir
                 stdapi_fs_delete_file
                 stdapi_fs_file_expand_path
@@ -24,6 +25,7 @@ module Msf::Post::File
                 stdapi_fs_ls
                 stdapi_fs_mkdir
                 stdapi_fs_stat
+                stdapi_sys_process_close
               ]
             }
           }

--- a/lib/msf/core/post/windows/accounts.rb
+++ b/lib/msf/core/post/windows/accounts.rb
@@ -53,8 +53,8 @@ module Msf
               'Compat' => {
                 'Meterpreter' => {
                   'Commands' => %w[
-                    stdapi_sys_process_*
                     stdapi_railgun_*
+                    stdapi_sys_process_attach
                   ]
                 }
               }

--- a/lib/msf/core/post/windows/extapi.rb
+++ b/lib/msf/core/post/windows/extapi.rb
@@ -13,7 +13,6 @@ module ExtAPI
         'Compat' => {
           'Meterpreter' => {
             'Commands' => %w[
-              extapi_*
             ]
           }
         }

--- a/lib/msf/core/post/windows/file_system.rb
+++ b/lib/msf/core/post/windows/file_system.rb
@@ -15,9 +15,13 @@ module Msf
               'Compat' => {
                 'Meterpreter' => {
                   'Commands' => %w[
+                    core_native_arch
                     stdapi_fs_delete_dir
-                    stdapi_railgun_api*
-                    stdapi_sys_process_*
+                    stdapi_railgun_*
+                    stdapi_sys_process_attach
+                    stdapi_sys_process_close
+                    stdapi_sys_process_memory_allocate
+                    stdapi_sys_process_memory_write
                   ]
                 }
               }

--- a/lib/msf/core/post/windows/kiwi.rb
+++ b/lib/msf/core/post/windows/kiwi.rb
@@ -13,7 +13,7 @@ module Kiwi
         'Compat' => {
           'Meterpreter' => {
             'Commands' => %w[
-              kiwi_*
+              kiwi_exec_cmd
             ]
           }
         }

--- a/lib/msf/core/post/windows/ldap.rb
+++ b/lib/msf/core/post/windows/ldap.rb
@@ -91,6 +91,7 @@ module LDAP
           'Compat' => {
             'Meterpreter' => {
               'Commands' => %w[
+                extapi_adsi_domain_query
                 stdapi_railgun_*
               ]
             }

--- a/lib/msf/core/post/windows/mssql.rb
+++ b/lib/msf/core/post/windows/mssql.rb
@@ -19,11 +19,13 @@ module Msf
                 'Meterpreter' => {
                   'Commands' => %w[
                     core_migrate
-                    stdapi_sys_config_getprivs
-                    stdapi_sys_config_getuid
-                    stdapi_sys_process_*
                     incognito_impersonate_token
                     priv_elevate_getsystem
+                    stdapi_sys_config_getprivs
+                    stdapi_sys_config_getuid
+                    stdapi_sys_process_close
+                    stdapi_sys_process_execute
+                    stdapi_sys_process_get_processes
                   ]
                 }
               }

--- a/lib/msf/core/post/windows/powershell.rb
+++ b/lib/msf/core/post/windows/powershell.rb
@@ -17,7 +17,10 @@ module Msf
                 'Meterpreter' => {
                   'Commands' => %w[
                     stdapi_sys_config_sysinfo
-                    stdapi_sys_process_*
+                    stdapi_sys_process_close
+                    stdapi_sys_process_execute
+                    stdapi_sys_process_get_processes
+                    stdapi_sys_process_kill
                   ]
                 }
               }

--- a/lib/msf/core/post/windows/priv.rb
+++ b/lib/msf/core/post/windows/priv.rb
@@ -30,9 +30,12 @@ module Msf::Post::Windows::Priv
         'Compat' => {
           'Meterpreter' => {
             'Commands' => %w[
-              stdapi_sys_config_*
-              stdapi_sys_process_*
-              stdapi_registry_*
+              stdapi_railgun_*
+              stdapi_registry_open_key
+              stdapi_sys_config_getsid
+              stdapi_sys_config_steal_token
+              stdapi_sys_config_sysinfo
+              stdapi_sys_process_close
             ]
           }
         }

--- a/lib/msf/core/post/windows/process.rb
+++ b/lib/msf/core/post/windows/process.rb
@@ -17,8 +17,13 @@ module Process
         'Compat' => {
           'Meterpreter' => {
             'Commands' => %w[
-              core_channel_*
-              stdapi_sys_process_*
+              stdapi_sys_process_attach
+              stdapi_sys_process_execute
+              stdapi_sys_process_getpid
+              stdapi_sys_process_memory_allocate
+              stdapi_sys_process_memory_protect
+              stdapi_sys_process_memory_write
+              stdapi_sys_process_thread_create
             ]
           }
         }

--- a/lib/msf/core/post/windows/runas.rb
+++ b/lib/msf/core/post/windows/runas.rb
@@ -19,7 +19,7 @@ module Msf::Post::Windows::Runas
         'Compat' => {
           'Meterpreter' => {
             'Commands' => %w[
-              stdapi_railgun_api*
+              stdapi_railgun_*
             ]
           }
         }

--- a/lib/msf/core/post/windows/services.rb
+++ b/lib/msf/core/post/windows/services.rb
@@ -48,8 +48,9 @@ module Services
         'Compat' => {
           'Meterpreter' => {
             'Commands' => %w[
-              extapi_service_*
-              stdapi_railgun_api*
+              extapi_service_enum
+              extapi_service_query
+              stdapi_railgun_*
             ]
           }
         }

--- a/lib/msf/core/post/windows/user_profiles.rb
+++ b/lib/msf/core/post/windows/user_profiles.rb
@@ -14,8 +14,8 @@ module UserProfiles
         'Compat' => {
           'Meterpreter' => {
             'Commands' => %w[
-              stdapi_fs_stat
               stdapi_fs_file_expand_path
+              stdapi_fs_stat
             ]
           }
         }

--- a/lib/msf/core/post/windows/wmic.rb
+++ b/lib/msf/core/post/windows/wmic.rb
@@ -17,9 +17,11 @@ module WMIC
         'Compat' => {
           'Meterpreter' => {
             'Commands' => %w[
-              extapi_clipboard_[gs]et_data
-              stdapi_railgun_api*
-              stdapi_sys_process_*
+              extapi_clipboard_get_data
+              extapi_clipboard_set_data
+              stdapi_railgun_*
+              stdapi_sys_process_close
+              stdapi_sys_process_execute
             ]
           }
         }

--- a/modules/post/linux/gather/gnome_keyring_dump.rb
+++ b/modules/post/linux/gather/gnome_keyring_dump.rb
@@ -23,6 +23,8 @@ class MetasploitModule < Msf::Post
         'Compat' => {
           'Meterpreter' => {
             'Commands' => %w[
+              core_native_arch
+              stdapi_net_resolve_host
               stdapi_railgun_*
             ]
           }

--- a/modules/post/windows/gather/ntds_grabber.rb
+++ b/modules/post/windows/gather/ntds_grabber.rb
@@ -27,7 +27,9 @@ class MetasploitModule < Msf::Post
           'Meterpreter' => {
             'Commands' => %w[
               core_migrate
-              stdapi_railgun*
+              stdapi_railgun_*
+              stdapi_sys_process_execute
+              stdapi_sys_process_getpid
             ]
           }
         }


### PR DESCRIPTION
This PR builds upon work related to #15295.

This is the first batch of modules the new `MeterpreterCommandDependencies` rubocop rule is being ran against.

These files had been previous amended to add support for the Meterpreter command dependencies prior to this new rubocop rule. I thought it made sense to test my cop against these files first and get some feedback.

This first batch of modules includes the following files:
```
lib/msf/core/post/common.rb lib/msf/core/post/file.rb 
lib/msf/core/post/windows/accounts.rb 
lib/msf/core/post/windows/eventlog.rb 
lib/msf/core/post/windows/extapi.rb 
lib/msf/core/post/windows/file_info.rb 
lib/msf/core/post/windows/file_system.rb 
lib/msf/core/post/windows/kiwi.rb 
lib/msf/core/post/windows/ldap.rb 
lib/msf/core/post/windows/mssql.rb 
lib/msf/core/post/windows/net_api.rb 
lib/msf/core/post/windows/powershell.rb 
lib/msf/core/post/windows/priv.rb 
lib/msf/core/post/windows/process.rb 
lib/msf/core/post/windows/runas.rb 
lib/msf/core/post/windows/services.rb 
lib/msf/core/post/windows/user_profiles.rb 
lib/msf/core/post/windows/wmic.rb 
modules/post/linux/gather/gnome_keyring_dump.rb 
modules/post/windows/gather/ntds_grabber.rb
```

Command used:
```
rubocop -A --only Lint/MeterpreterCommandDependencies lib/msf/core/post/common.rb lib/msf/core/post/file.rb lib/msf/core/post/windows/accounts.rb lib/msf/core/post/windows/eventlog.rb lib/msf/core/post/windows/extapi.rb lib/msf/core/post/windows/file_info.rb lib/msf/core/post/windows/file_system.rb lib/msf/core/post/windows/kiwi.rb lib/msf/core/post/windows/ldap.rb lib/msf/core/post/windows/mssql.rb lib/msf/core/post/windows/net_api.rb lib/msf/core/post/windows/powershell.rb lib/msf/core/post/windows/priv.rb lib/msf/core/post/windows/process.rb lib/msf/core/post/windows/runas.rb lib/msf/core/post/windows/services.rb lib/msf/core/post/windows/user_profiles.rb lib/msf/core/post/windows/wmic.rb modules/post/linux/gather/gnome_keyring_dump.rb modules/post/windows/gather/ntds_grabber.rb
```

**_Just to call it out, the diff for this PR will mostly include amendments to already present Meterpreter command lists. As I'm just verifying if the cop is functioning as intended._**

## Note
As seen in the tests in #15295, there is support to alter/add sections of methods depending on various situations. e.g. 
"The cop verifies if a there is an initialise method, if no initialise present, it should be generated and appended appropriately."

I have tried to identify as many of these scenarios as possible, but if there are anymore edge-cases that may not have been covered in the tests, please call them out and I can get tests added as needed 🕵️ 


## Verification

List the steps needed to make sure this thing works

- [ ] Code review.
- [ ] Verify no api calls have been missed.

