### PR TITLE
MeterpreterCommandDependencies rubocop rule ran against second batch of modules

### DIFF
--- a/modules/exploits/linux/local/abrt_raceabrt_priv_esc.rb
+++ b/modules/exploits/linux/local/abrt_raceabrt_priv_esc.rb
@@ -58,7 +58,16 @@ class MetasploitModule < Msf::Exploit::Local
           [ 'URL', 'https://bugzilla.redhat.com/show_bug.cgi?id=1211223' ],
           [ 'URL', 'https://bugzilla.redhat.com/show_bug.cgi?id=1211835' ],
           [ 'URL', 'https://bugzilla.redhat.com/show_bug.cgi?id=1218239' ]
-        ]
+        ],
+      'Compat' => {
+        'Meterpreter' => {
+          'Commands' => %w[
+            stdapi_fs_stat
+            stdapi_sys_process_close
+            stdapi_sys_process_execute
+          ]
+        }
+      }
     ))
     register_options(
       [

--- a/modules/exploits/linux/local/asan_suid_executable_priv_esc.rb
+++ b/modules/exploits/linux/local/asan_suid_executable_priv_esc.rb
@@ -69,7 +69,14 @@ class MetasploitModule < Msf::Exploit::Local
           'Reliability' => [ REPEATABLE_SESSION ],
           'Stability'   => [ CRASH_SAFE ]
         },
-      'DefaultTarget'  => 0))
+      'DefaultTarget'  => 0,
+      'Compat' => {
+        'Meterpreter' => {
+          'Commands' => %w[
+            stdapi_fs_delete_file
+          ]
+        }
+      }))
     register_options [
       OptString.new('SUID_EXECUTABLE', [true, 'Path to a SUID executable compiled with ASan', '']),
       OptInt.new('SPRAY_SIZE', [true, 'Number of PID symlinks to create', 50])

--- a/modules/exploits/linux/local/bpf_priv_esc.rb
+++ b/modules/exploits/linux/local/bpf_priv_esc.rb
@@ -74,7 +74,15 @@ class MetasploitModule < Msf::Exploit::Local
               'doubleput.c'
             ]
         },
-      'DefaultTarget'  => 1))
+      'DefaultTarget'  => 1,
+      'Compat' => {
+        'Meterpreter' => {
+          'Commands' => %w[
+            stdapi_fs_delete_file
+            stdapi_sys_process_execute
+          ]
+        }
+      }))
     register_options [
       OptEnum.new('COMPILE', [true, 'Compile on target', 'Auto', ['Auto', 'True', 'False']]),
       OptInt.new('MAXWAIT', [true, 'Max time to wait for decrementation in seconds', 120])

--- a/modules/exploits/linux/local/exim4_deliver_message_priv_esc.rb
+++ b/modules/exploits/linux/local/exim4_deliver_message_priv_esc.rb
@@ -53,7 +53,15 @@ class MetasploitModule < Msf::Exploit::Local
             [ 'CVE', '2019-10149' ],
             [ 'EDB', '46996' ],
             [ 'URL', 'https://www.openwall.com/lists/oss-security/2019/06/06/1' ]
-          ]
+          ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_fs_delete_file
+              stdapi_sys_process_close
+            ]
+          }
+        }
       )
     )
 

--- a/modules/exploits/linux/local/glibc_ld_audit_dso_load_priv_esc.rb
+++ b/modules/exploits/linux/local/glibc_ld_audit_dso_load_priv_esc.rb
@@ -73,7 +73,14 @@ class MetasploitModule < Msf::Exploit::Local
           [ 'URL', 'https://security-tracker.debian.org/tracker/CVE-2010-3856' ],
           [ 'URL', 'https://access.redhat.com/security/cve/CVE-2010-3847' ],
           [ 'URL', 'https://access.redhat.com/security/cve/CVE-2010-3856' ]
-        ]
+        ],
+      'Compat' => {
+        'Meterpreter' => {
+          'Commands' => %w[
+            stdapi_fs_delete_file
+          ]
+        }
+      }
     ))
     register_options [
       OptString.new('SUID_EXECUTABLE', [ true, 'Path to a SUID executable', '/bin/ping' ])

--- a/modules/exploits/linux/local/glibc_realpath_priv_esc.rb
+++ b/modules/exploits/linux/local/glibc_realpath_priv_esc.rb
@@ -59,7 +59,14 @@ class MetasploitModule < Msf::Exploit::Local
       'Notes' =>
           {
               'AKA' => ['RationalLove.c']
-          }
+          },
+      'Compat' => {
+        'Meterpreter' => {
+          'Commands' => %w[
+            stdapi_fs_delete_file
+          ]
+        }
+      }
     ))
     register_options [
       OptEnum.new('COMPILE', [ true, 'Compile on target', 'Auto', %w(Auto True False) ])

--- a/modules/exploits/linux/local/libuser_roothelper_priv_esc.rb
+++ b/modules/exploits/linux/local/libuser_roothelper_priv_esc.rb
@@ -72,7 +72,15 @@ class MetasploitModule < Msf::Exploit::Local
       'Notes' =>
           {
               'AKA' => ['roothelper.c']
-          }
+          },
+      'Compat' => {
+        'Meterpreter' => {
+          'Commands' => %w[
+            stdapi_sys_process_close
+            stdapi_sys_process_execute
+          ]
+        }
+      }
     ))
     register_options [
       OptEnum.new('COMPILE', [ true, 'Compile on target', 'Auto', %w(Auto True False) ]),

--- a/modules/exploits/linux/local/nested_namespace_idmap_limit_priv_esc.rb
+++ b/modules/exploits/linux/local/nested_namespace_idmap_limit_priv_esc.rb
@@ -77,7 +77,14 @@ class MetasploitModule < Msf::Exploit::Local
           'Reliability' => [ REPEATABLE_SESSION ],
           'Stability'   => [ CRASH_SAFE ]
         },
-      'DefaultTarget'  => 0))
+      'DefaultTarget'  => 0,
+      'Compat' => {
+        'Meterpreter' => {
+          'Commands' => %w[
+            stdapi_sys_process_execute
+          ]
+        }
+      }))
     register_options [
       OptEnum.new('COMPILE', [true, 'Compile on target', 'Auto', %w[Auto True False]])
     ]

--- a/modules/exploits/linux/local/netfilter_priv_esc_ipv4.rb
+++ b/modules/exploits/linux/local/netfilter_priv_esc_ipv4.rb
@@ -58,7 +58,14 @@ class MetasploitModule < Msf::Exploit::Local
             'Reliability' => [ UNRELIABLE_SESSION ],
             'Stability'   => [ CRASH_OS_DOWN ],
           },
-        'DefaultTarget'  => 0))
+        'DefaultTarget'  => 0,
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_sys_process_close
+            ]
+          }
+        }))
     register_options [
       OptInt.new('MAXWAIT', [ true, 'Max seconds to wait for decrementation in seconds', 180 ]),
       OptBool.new('REEXPLOIT', [ true, 'desc already ran, no need to re-run, skip to running pwn',false]),

--- a/modules/exploits/linux/local/overlayfs_priv_esc.rb
+++ b/modules/exploits/linux/local/overlayfs_priv_esc.rb
@@ -53,7 +53,14 @@ class MetasploitModule < Msf::Exploit::Local
             [ 'EDB', '37292'], # CVE-2015-1328
             [ 'CVE', '2015-1328'],
             [ 'CVE', '2015-8660']
-          ]
+          ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_sys_process_close
+            ]
+          }
+        }
       ))
     register_options [
       OptEnum.new('COMPILE', [ true, 'Compile on target', 'Auto', ['Auto', 'True', 'False']])

--- a/modules/exploits/linux/local/ptrace_sudo_token_priv_esc.rb
+++ b/modules/exploits/linux/local/ptrace_sudo_token_priv_esc.rb
@@ -69,7 +69,14 @@ class MetasploitModule < Msf::Exploit::Local
           'PrependFork'      => true,
           'WfsDelay'         => 30
         },
-      'DefaultTarget'  => 0))
+      'DefaultTarget'  => 0,
+      'Compat' => {
+        'Meterpreter' => {
+          'Commands' => %w[
+            stdapi_fs_delete_file
+          ]
+        }
+      }))
     register_options [
       OptInt.new('TIMEOUT', [true, 'Process injection timeout (seconds)', '30'])
     ]

--- a/modules/exploits/linux/local/servu_ftp_server_prepareinstallation_priv_esc.rb
+++ b/modules/exploits/linux/local/servu_ftp_server_prepareinstallation_priv_esc.rb
@@ -72,7 +72,14 @@ class MetasploitModule < Msf::Exploit::Local
           'Reliability' => [ REPEATABLE_SESSION ],
           'Stability'   => [ CRASH_SAFE ]
         },
-      'DefaultTarget'  => 0))
+      'DefaultTarget'  => 0,
+      'Compat' => {
+        'Meterpreter' => {
+          'Commands' => %w[
+            stdapi_fs_delete_file
+          ]
+        }
+      }))
     register_options [
       OptString.new('SERVU_PATH', [true, 'Path to Serv-U executable', '/usr/local/Serv-U/Serv-U'])
     ]

--- a/modules/exploits/multi/local/xorg_x11_suid_server.rb
+++ b/modules/exploits/multi/local/xorg_x11_suid_server.rb
@@ -79,7 +79,14 @@ class MetasploitModule < Msf::Exploit::Local
           'PAYLOAD' => 'cmd/unix/reverse_openssl',
           'WfsDelay' => 120
         },
-      'DefaultTarget'  => 0))
+      'DefaultTarget'  => 0,
+      'Compat' => {
+        'Meterpreter' => {
+          'Commands' => %w[
+            stdapi_sys_process_execute
+          ]
+        }
+      }))
 
      register_advanced_options(
        [

--- a/modules/exploits/unix/local/opensmtpd_oob_read_lpe.rb
+++ b/modules/exploits/unix/local/opensmtpd_oob_read_lpe.rb
@@ -56,6 +56,13 @@ class MetasploitModule < Msf::Exploit::Local
           'Stability' => [CRASH_SERVICE_DOWN],
           'Reliability' => [REPEATABLE_SESSION],
           'SideEffects' => [IOC_IN_LOGS]
+        },
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_sys_process_close
+            ]
+          }
         }
       )
     )

--- a/modules/exploits/windows/local/alpc_taskscheduler.rb
+++ b/modules/exploits/windows/local/alpc_taskscheduler.rb
@@ -55,6 +55,17 @@ class MetasploitModule < Msf::Exploit::Local
         },
       'DisclosureDate' => '2018-08-27',
       'DefaultTarget'  => 0,
+      'Compat' => {
+        'Meterpreter' => {
+          'Commands' => %w[
+            stdapi_sys_process_attach
+            stdapi_sys_process_execute
+            stdapi_sys_process_memory_allocate
+            stdapi_sys_process_memory_write
+            stdapi_sys_process_thread_create
+          ]
+        }
+      },
     ))
 
     register_options([OptString.new('PROCESS',

--- a/modules/exploits/windows/local/anyconnect_lpe.rb
+++ b/modules/exploits/windows/local/anyconnect_lpe.rb
@@ -81,6 +81,13 @@ class MetasploitModule < Msf::Exploit::Local
         'DefaultOptions' => {
           'PAYLOAD' => 'windows/meterpreter/reverse_tcp',
           'FileDropperDelay' => 10
+        },
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              core_channel_open
+            ]
+          }
         }
       )
     )

--- a/modules/exploits/windows/local/applocker_bypass.rb
+++ b/modules/exploits/windows/local/applocker_bypass.rb
@@ -34,7 +34,14 @@ class MetasploitModule < Msf::Exploit::Local
       'References'    =>
         [
           ['URL', 'https://gist.github.com/subTee/fac6af078937dda81e57']
-        ]
+        ],
+      'Compat' => {
+        'Meterpreter' => {
+          'Commands' => %w[
+            stdapi_sys_process_execute
+          ]
+        }
+      }
     ))
 
   end

--- a/modules/exploits/windows/local/bits_ntlm_token_impersonation.rb
+++ b/modules/exploits/windows/local/bits_ntlm_token_impersonation.rb
@@ -103,7 +103,19 @@ class MetasploitModule < Msf::Exploit::Local
           ['URL', 'https://github.com/antonioCoco/RogueWinRM'],
         ],
           'DisclosureDate' => '2019-12-06',
-          'DefaultTarget' => 0
+          'DefaultTarget' => 0,
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_sys_config_getenv
+              stdapi_sys_config_getprivs
+              stdapi_sys_config_sysinfo
+              stdapi_sys_process_attach
+              stdapi_sys_process_execute
+              stdapi_sys_process_thread_create
+            ]
+          }
+        }
         }
       )
     )

--- a/modules/exploits/windows/local/bypassuac.rb
+++ b/modules/exploits/windows/local/bypassuac.rb
@@ -35,7 +35,14 @@ class MetasploitModule < Msf::Exploit::Local
       'References'    => [
         [ 'URL', 'http://www.trustedsec.com/december-2010/bypass-windows-uac/' ]
       ],
-      'DisclosureDate'=> '2010-12-31'
+      'DisclosureDate'=> '2010-12-31',
+      'Compat' => {
+        'Meterpreter' => {
+          'Commands' => %w[
+            stdapi_sys_process_kill
+          ]
+        }
+      }
     ))
 
     register_options([

--- a/modules/exploits/windows/local/bypassuac_comhijack.rb
+++ b/modules/exploits/windows/local/bypassuac_comhijack.rb
@@ -49,7 +49,14 @@ class MetasploitModule < Msf::Exploit::Local
         ['URL', 'https://wikileaks.org/ciav7p1/cms/page_13763373.html'],
         ['URL', 'https://github.com/FuzzySecurity/Defcon25/Defcon25_UAC-0day-All-Day_v1.2.pdf']
       ],
-      'DisclosureDate'=> '1900-01-01'
+      'DisclosureDate'=> '1900-01-01',
+      'Compat' => {
+        'Meterpreter' => {
+          'Commands' => %w[
+            stdapi_sys_process_execute
+          ]
+        }
+      }
     ))
   end
 

--- a/modules/exploits/windows/local/bypassuac_dotnet_profiler.rb
+++ b/modules/exploits/windows/local/bypassuac_dotnet_profiler.rb
@@ -44,7 +44,15 @@ class MetasploitModule < Msf::Exploit::Local
           ['URL', 'https://seclists.org/fulldisclosure/2017/Jul/11'],
           ['URL', 'https://offsec.provadys.com/UAC-bypass-dotnet.html']
         ],
-      'DisclosureDate' => '2017-03-17'
+      'DisclosureDate' => '2017-03-17',
+      'Compat' => {
+        'Meterpreter' => {
+          'Commands' => %w[
+            stdapi_sys_config_getenv
+            stdapi_sys_process_execute
+          ]
+        }
+      }
       )
     )
     register_options(

--- a/modules/exploits/windows/local/bypassuac_fodhelper.rb
+++ b/modules/exploits/windows/local/bypassuac_fodhelper.rb
@@ -55,7 +55,14 @@ class MetasploitModule < Msf::Exploit::Local
             ['URL', 'https://github.com/winscripting/UAC-bypass/blob/master/FodhelperBypass.ps1'],
             ['URL', 'https://www.bleepingcomputer.com/news/security/gootkit-malware-bypasses-windows-defender-by-setting-path-exclusions/']
           ],
-        'DisclosureDate' => '2017-05-12'
+        'DisclosureDate' => '2017-05-12',
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_sys_process_execute
+            ]
+          }
+        }
       )
     )
   end

--- a/modules/exploits/windows/local/bypassuac_sdclt.rb
+++ b/modules/exploits/windows/local/bypassuac_sdclt.rb
@@ -44,7 +44,15 @@ class MetasploitModule < Msf::Exploit::Local
           ['URL', 'https://github.com/enigma0x3/Misc-PowerShell-Stuff/blob/master/Invoke-SDCLTBypass.ps1'],
           ['URL', 'https://blog.sevagas.com/?Yet-another-sdclt-UAC-bypass']
         ],
-      'DisclosureDate' => '2017-03-17'
+      'DisclosureDate' => '2017-03-17',
+      'Compat' => {
+        'Meterpreter' => {
+          'Commands' => %w[
+            stdapi_sys_config_getenv
+            stdapi_sys_process_execute
+          ]
+        }
+      }
       )
     )
     register_options(

--- a/modules/exploits/windows/local/bypassuac_sluihijack.rb
+++ b/modules/exploits/windows/local/bypassuac_sluihijack.rb
@@ -56,7 +56,14 @@ class MetasploitModule < Msf::Exploit::Local
             ['URL', 'https://github.com/bytecode-77/slui-file-handler-hijack-privilege-escalation'],
             ['URL', 'https://github.com/gushmazuko/WinBypass/blob/master/SluiHijackBypass.ps1']
           ],
-        'DisclosureDate' => '2018-01-15'
+        'DisclosureDate' => '2018-01-15',
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_sys_process_execute
+            ]
+          }
+        }
       )
     )
   end

--- a/modules/exploits/windows/local/bypassuac_windows_store_filesys.rb
+++ b/modules/exploits/windows/local/bypassuac_windows_store_filesys.rb
@@ -45,6 +45,15 @@ class MetasploitModule < Msf::Exploit::Local
           ['URL', 'https://github.com/sailay1996/UAC_bypass_windows_store'],
           ['URL', 'https://medium.com/tenable-techblog/uac-bypass-by-mocking-trusted-directories-24a96675f6e'],
         ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_fs_file_copy
+              stdapi_fs_mkdir
+              stdapi_sys_process_execute
+            ]
+          }
+        },
       )
     )
   end

--- a/modules/exploits/windows/local/bypassuac_windows_store_reg.rb
+++ b/modules/exploits/windows/local/bypassuac_windows_store_reg.rb
@@ -44,7 +44,15 @@ class MetasploitModule < Msf::Exploit::Local
           ['URL', 'https://www.activecyber.us/activelabs/windows-uac-bypass'],
           ['URL', 'https://heynowyouseeme.blogspot.com/2019/08/windows-10-lpe-uac-bypass-in-windows.html'],
           ['URL', 'https://github.com/sailay1996/UAC_bypass_windows_store'],
-        ]
+        ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_sys_config_getenv
+              stdapi_sys_process_execute
+            ]
+          }
+        }
       )
     )
     register_options(

--- a/modules/exploits/windows/local/comahawk.rb
+++ b/modules/exploits/windows/local/comahawk.rb
@@ -48,7 +48,14 @@ class MetasploitModule < Msf::Exploit::Local
       'DefaultOptions' =>
         {
           'DisablePayloadHandler' => false
+        },
+      'Compat' => {
+        'Meterpreter' => {
+          'Commands' => %w[
+            stdapi_sys_config_getenv
+          ]
         }
+      }
     ))
 
     register_options([

--- a/modules/exploits/windows/local/current_user_psexec.rb
+++ b/modules/exploits/windows/local/current_user_psexec.rb
@@ -44,7 +44,15 @@ class MetasploitModule < Msf::Exploit::Local
         'Platform'      => [ 'win' ],
         'SessionTypes'  => [ 'meterpreter' ],
         'Targets' => [ [ 'Universal', {} ] ],
-        'DefaultTarget' => 0
+        'DefaultTarget' => 0,
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_fs_mkdir
+              stdapi_sys_config_getenv
+            ]
+          }
+        }
       ))
 
     register_options([

--- a/modules/exploits/windows/local/cve_2017_8464_lnk_lpe.rb
+++ b/modules/exploits/windows/local/cve_2017_8464_lnk_lpe.rb
@@ -71,6 +71,13 @@ class MetasploitModule < Msf::Exploit::Local
             'Stability'   => [ CRASH_SERVICE_RESTARTS, ],
             'SideEffects' => [ ARTIFACTS_ON_DISK, ],
           },
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_sys_config_getenv
+            ]
+          }
+        },
       )
     )
 

--- a/modules/exploits/windows/local/cve_2020_0787_bits_arbitrary_file_move.rb
+++ b/modules/exploits/windows/local/cve_2020_0787_bits_arbitrary_file_move.rb
@@ -69,7 +69,17 @@ class MetasploitModule < Msf::Exploit::Local
             'EXITFUNC' => 'thread',
             'PAYLOAD' => 'windows/x64/meterpreter/reverse_tcp',
             'WfsDelay' => 900
+          },
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_sys_config_getenv
+              stdapi_sys_process_attach
+              stdapi_sys_process_execute
+              stdapi_sys_process_thread_create
+            ]
           }
+        }
       )
     )
 

--- a/modules/exploits/windows/local/cve_2020_0796_smbghost.rb
+++ b/modules/exploits/windows/local/cve_2020_0796_smbghost.rb
@@ -59,6 +59,15 @@ class MetasploitModule < Msf::Exploit::Local
           'Stability' => [ CRASH_OS_RESTARTS, ],
           'Reliability' => [ REPEATABLE_SESSION, ],
           'RelatedModules' => [ 'exploit/windows/smb/cve_2020_0796_smbghost' ]
+        },
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_sys_process_attach
+              stdapi_sys_process_execute
+              stdapi_sys_process_thread_create
+            ]
+          }
         }
         }
       )

--- a/modules/exploits/windows/local/cve_2020_1048_printerdemon.rb
+++ b/modules/exploits/windows/local/cve_2020_1048_printerdemon.rb
@@ -48,7 +48,15 @@ class MetasploitModule < Msf::Exploit::Local
           {
             'DisablePayloadHandler' => true
           },
-        'SideEffects' => [ ARTIFACTS_ON_DISK, SCREEN_EFFECTS ]
+        'SideEffects' => [ ARTIFACTS_ON_DISK, SCREEN_EFFECTS ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_fs_delete_file
+              stdapi_sys_config_getenv
+            ]
+          }
+        }
       )
     )
 

--- a/modules/exploits/windows/local/cve_2020_1313_system_orchestrator.rb
+++ b/modules/exploits/windows/local/cve_2020_1313_system_orchestrator.rb
@@ -45,7 +45,14 @@ class MetasploitModule < Msf::Exploit::Local
         'DefaultOptions' =>
           {
             'DisablePayloadHandler' => true
+          },
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_sys_config_getenv
+            ]
           }
+        }
       )
     )
 

--- a/modules/exploits/windows/local/cve_2020_1337_printerdemon.rb
+++ b/modules/exploits/windows/local/cve_2020_1337_printerdemon.rb
@@ -56,7 +56,16 @@ class MetasploitModule < Msf::Exploit::Local
           {
             'DisablePayloadHandler' => true
           },
-        'SideEffects' => [ ARTIFACTS_ON_DISK, SCREEN_EFFECTS ]
+        'SideEffects' => [ ARTIFACTS_ON_DISK, SCREEN_EFFECTS ],
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              powershell_execute
+              stdapi_sys_config_getenv
+              stdapi_sys_power_exitwindows
+            ]
+          }
+        }
       )
     )
 

--- a/modules/exploits/windows/local/cve_2020_17136.rb
+++ b/modules/exploits/windows/local/cve_2020_17136.rb
@@ -66,7 +66,21 @@ class MetasploitModule < Msf::Exploit::Local
           {
             'EXITFUNC' => 'process',
             'PAYLOAD' => 'windows/x64/meterpreter/reverse_tcp'
+          },
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_sys_process_attach
+              stdapi_sys_process_execute
+              stdapi_sys_process_get_processes
+              stdapi_sys_process_getpid
+              stdapi_sys_process_kill
+              stdapi_sys_process_memory_allocate
+              stdapi_sys_process_memory_write
+              stdapi_sys_process_thread_create
+            ]
           }
+        }
       )
     )
     register_options(

--- a/modules/exploits/windows/local/dnsadmin_serverlevelplugindll.rb
+++ b/modules/exploits/windows/local/dnsadmin_serverlevelplugindll.rb
@@ -63,7 +63,16 @@ class MetasploitModule < Msf::Exploit::Local
             # non-optimal time or if the UNC path is typed in wrong.
             'SideEffects' => [CONFIG_CHANGES, IOC_IN_LOGS],
             'Reliability' => [REPEATABLE_SESSION]
+          },
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_fs_delete_file
+              stdapi_sys_config_getsid
+              stdapi_sys_config_getuid
+            ]
           }
+        }
       )
     )
 

--- a/modules/exploits/windows/local/ikeext_service.rb
+++ b/modules/exploits/windows/local/ikeext_service.rb
@@ -45,7 +45,14 @@ class MetasploitModule < Msf::Exploit::Local
           'WfsDelay' => 5,
           'ReverseConnectRetries' => 255
         },
-      'DefaultTarget'  => 0
+      'DefaultTarget'  => 0,
+      'Compat' => {
+        'Meterpreter' => {
+          'Commands' => %w[
+            stdapi_fs_mkdir
+          ]
+        }
+      }
     ))
 
     register_options([

--- a/modules/exploits/windows/local/mov_ss.rb
+++ b/modules/exploits/windows/local/mov_ss.rb
@@ -51,7 +51,17 @@ class MetasploitModule < Msf::Exploit::Local
       'DefaultOptions' =>
         {
           'DisablePayloadHandler' => false
+        },
+      'Compat' => {
+        'Meterpreter' => {
+          'Commands' => %w[
+            stdapi_sys_config_getenv
+            stdapi_sys_process_attach
+            stdapi_sys_process_execute
+            stdapi_sys_process_thread_create
+          ]
         }
+      }
     ))
 
     register_options([

--- a/modules/exploits/windows/local/ms10_015_kitrap0d.rb
+++ b/modules/exploits/windows/local/ms10_015_kitrap0d.rb
@@ -39,7 +39,16 @@ class MetasploitModule < Msf::Exploit::Local
         [ 'EDB', '11199' ],
         [ 'URL', 'https://seclists.org/fulldisclosure/2010/Jan/341' ]
       ],
-      'DisclosureDate'=> '2010-01-19'
+      'DisclosureDate'=> '2010-01-19',
+      'Compat' => {
+        'Meterpreter' => {
+          'Commands' => %w[
+            stdapi_sys_process_attach
+            stdapi_sys_process_execute
+            stdapi_sys_process_thread_create
+          ]
+        }
+      }
     ))
 
   end

--- a/modules/exploits/windows/local/ms16_014_wmi_recv_notif.rb
+++ b/modules/exploits/windows/local/ms16_014_wmi_recv_notif.rb
@@ -46,7 +46,16 @@ class MetasploitModule < Msf::Exploit::Local
         ['URL', 'https://technet.microsoft.com/en-us/library/security/ms16-014.aspx']
       ],
       'DisclosureDate'  => '2015-12-04',
-      'DefaultTarget'   => 0)
+      'DefaultTarget'   => 0,
+      'Compat' => {
+        'Meterpreter' => {
+          'Commands' => %w[
+            stdapi_sys_process_attach
+            stdapi_sys_process_execute
+            stdapi_sys_process_thread_create
+          ]
+        }
+      })
   )
   end
 

--- a/modules/exploits/windows/local/ms16_032_secondary_logon_handle_privesc.rb
+++ b/modules/exploits/windows/local/ms16_032_secondary_logon_handle_privesc.rb
@@ -55,7 +55,16 @@ class MetasploitModule < Msf::Exploit::Local
             # * Windows 2012
             [ 'Windows x64', { 'Arch' => ARCH_X64 } ]
           ],
-        'DefaultTarget' => 0
+        'DefaultTarget' => 0,
+      'Compat' => {
+        'Meterpreter' => {
+          'Commands' => %w[
+            core_channel_write
+            stdapi_sys_process_close
+            stdapi_sys_process_execute
+          ]
+        }
+      }
       ))
 
     register_advanced_options(

--- a/modules/exploits/windows/local/payload_inject.rb
+++ b/modules/exploits/windows/local/payload_inject.rb
@@ -31,7 +31,16 @@ class MetasploitModule < Msf::Exploit::Local
       'SessionTypes'    => [ 'meterpreter' ],
       'Targets'         => [ [ 'Windows', {} ] ],
       'DefaultTarget'   => 0,
-      'DisclosureDate'  => '2011-10-12'
+      'DisclosureDate'  => '2011-10-12',
+      'Compat' => {
+        'Meterpreter' => {
+          'Commands' => %w[
+            stdapi_sys_config_getenv
+            stdapi_sys_process_attach
+            stdapi_sys_process_execute
+          ]
+        }
+      }
     ))
 
     register_options(

--- a/modules/exploits/windows/local/persistence.rb
+++ b/modules/exploits/windows/local/persistence.rb
@@ -34,7 +34,16 @@ class MetasploitModule < Msf::Exploit::Local
       'DefaultOptions' =>
         {
           'DisablePayloadHandler' => true
+        },
+      'Compat' => {
+        'Meterpreter' => {
+          'Commands' => %w[
+            stdapi_sys_config_getenv
+            stdapi_sys_config_getuid
+            stdapi_sys_config_sysinfo
+          ]
         }
+      }
     ))
 
     register_options([

--- a/modules/exploits/windows/local/persistence_image_exec_options.rb
+++ b/modules/exploits/windows/local/persistence_image_exec_options.rb
@@ -41,7 +41,14 @@ class MetasploitModule < Msf::Exploit::Local
       'DefaultOptions' =>
         {
           'DisablePayloadHandler' => true
+        },
+      'Compat' => {
+        'Meterpreter' => {
+          'Commands' => %w[
+            stdapi_sys_config_getenv
+          ]
         }
+      }
     ))
     register_options([
       OptString.new('PAYLOAD_NAME',

--- a/modules/exploits/windows/local/persistence_service.rb
+++ b/modules/exploits/windows/local/persistence_service.rb
@@ -28,7 +28,18 @@ class MetasploitModule < Msf::Exploit::Local
       'References'    => [
         [ 'URL', 'https://github.com/rapid7/metasploit-framework/blob/master/external/source/metsvc/src/metsvc.cpp' ]
       ],
-      'DisclosureDate'=> '2018-10-20'
+      'DisclosureDate'=> '2018-10-20',
+      'Compat' => {
+        'Meterpreter' => {
+          'Commands' => %w[
+            core_channel_write
+            stdapi_sys_config_getenv
+            stdapi_sys_config_sysinfo
+            stdapi_sys_process_close
+            stdapi_sys_process_execute
+          ]
+        }
+      }
     ))
 
     register_options(

--- a/modules/exploits/windows/local/plantronics_hub_spokesupdateservice_privesc.rb
+++ b/modules/exploits/windows/local/plantronics_hub_spokesupdateservice_privesc.rb
@@ -49,7 +49,14 @@ class MetasploitModule < Msf::Exploit::Local
           'Reliability' => [ REPEATABLE_SESSION ],
           'Stability'   => [ CRASH_SAFE ]
         },
-      'DefaultTarget'  => 0))
+      'DefaultTarget'  => 0,
+      'Compat' => {
+        'Meterpreter' => {
+          'Commands' => %w[
+            stdapi_sys_config_getenv
+          ]
+        }
+      }))
     register_advanced_options [
       OptString.new('WritableDir', [false, 'A directory where we can write files (%TEMP% by default)', nil]),
     ]

--- a/modules/exploits/windows/local/ps_persist.rb
+++ b/modules/exploits/windows/local/ps_persist.rb
@@ -41,7 +41,18 @@ class MetasploitModule < Msf::Exploit::Local
       'SessionTypes'  => [ 'meterpreter' ],
       'Targets' => [ [ 'Universal', {} ] ],
       'DefaultTarget' => 0,
-      'DisclosureDate' => '2012-08-14'
+      'DisclosureDate' => '2012-08-14',
+      'Compat' => {
+        'Meterpreter' => {
+          'Commands' => %w[
+            stdapi_fs_delete_file
+            stdapi_fs_stat
+            stdapi_sys_config_getenv
+            stdapi_sys_config_getsid
+            stdapi_sys_process_execute
+          ]
+        }
+      }
 
     ))
 

--- a/modules/exploits/windows/local/pxeexploit.rb
+++ b/modules/exploits/windows/local/pxeexploit.rb
@@ -46,7 +46,21 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
       'Privileged'     => true,
       'Stance' => Msf::Exploit::Stance::Passive,
-      'DefaultTarget'  => 0
+      'DefaultTarget'  => 0,
+      'Compat' => {
+        'Meterpreter' => {
+          'Commands' => %w[
+            lanattacks_add_tftp_file
+            lanattacks_dhcp_log
+            lanattacks_reset_dhcp
+            lanattacks_set_dhcp_option
+            lanattacks_start_dhcp
+            lanattacks_start_tftp
+            lanattacks_stop_dhcp
+            lanattacks_stop_tftp
+          ]
+        }
+      }
     )
 
     register_options(

--- a/modules/exploits/windows/local/ricoh_driver_privesc.rb
+++ b/modules/exploits/windows/local/ricoh_driver_privesc.rb
@@ -64,7 +64,14 @@ class MetasploitModule < Msf::Exploit::Local
         'Stability'   =>  [ SERVICE_RESOURCE_LOSS ]
       },
       'DisclosureDate' => '2020-01-22',
-      'DefaultTarget'  => 0
+      'DefaultTarget'  => 0,
+      'Compat' => {
+        'Meterpreter' => {
+          'Commands' => %w[
+            stdapi_sys_process_execute
+          ]
+        }
+      }
     ))
 
     self.needs_cleanup = true

--- a/modules/exploits/windows/local/srclient_dll_hijacking.rb
+++ b/modules/exploits/windows/local/srclient_dll_hijacking.rb
@@ -55,7 +55,15 @@ class MetasploitModule < Msf::Exploit::Local
           {
             'Stability' => [ CRASH_SAFE, ],
             'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS, SCREEN_EFFECTS ]
+          },
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              stdapi_sys_config_getuid
+              stdapi_sys_process_get_processes
+            ]
           }
+        }
       )
       )
 

--- a/modules/exploits/windows/local/tokenmagic.rb
+++ b/modules/exploits/windows/local/tokenmagic.rb
@@ -53,7 +53,18 @@ class MetasploitModule < Msf::Exploit::Local
           {
             'PAYLOAD' => 'windows/x64/meterpreter/reverse_tcp',
             'WfsDelay' => 900
+          },
+        'Compat' => {
+          'Meterpreter' => {
+            'Commands' => %w[
+              powershell_execute
+              stdapi_sys_config_getenv
+              stdapi_sys_process_attach
+              stdapi_sys_process_execute
+              stdapi_sys_process_thread_create
+            ]
           }
+        }
       )
     )
 

--- a/modules/exploits/windows/local/vss_persistence.rb
+++ b/modules/exploits/windows/local/vss_persistence.rb
@@ -32,7 +32,14 @@ class MetasploitModule < Msf::Exploit::Local
         [ 'URL', 'http://pauldotcom.com/2011/11/safely-dumping-hashes-from-liv.html' ],
         [ 'URL', 'http://www.irongeek.com/i.php?page=videos/hack3rcon2/tim-tomes-and-mark-baggett-lurking-in-the-shadows']
       ],
-      'DisclosureDate'=> '2011-10-21'
+      'DisclosureDate'=> '2011-10-21',
+      'Compat' => {
+        'Meterpreter' => {
+          'Commands' => %w[
+            stdapi_sys_config_sysinfo
+          ]
+        }
+      }
     ))
 
     register_options(

--- a/modules/post/apple_ios/gather/ios_image_gather.rb
+++ b/modules/post/apple_ios/gather/ios_image_gather.rb
@@ -17,7 +17,18 @@ class MetasploitModule < Msf::Post
       'License'       =>  MSF_LICENSE,
       'Author'        =>  [ 'Shelby Pace' ], # Metasploit Module
       'Platform'      =>  [ 'apple_ios' ],
-      'SessionTypes'  =>  [ 'meterpreter' ]
+      'SessionTypes'  =>  [ 'meterpreter' ],
+      'Compat' => {
+        'Meterpreter' => {
+          'Commands' => %w[
+            core_channel_close
+            core_channel_eof
+            core_channel_open
+            core_channel_read
+            stdapi_fs_stat
+          ]
+        }
+      }
     ))
   end
 


### PR DESCRIPTION
This PR builds upon work related to #15295.

First batch PR: #15479

This is the second batch of modules the new MeterpreterCommandDependencies rubocop rule is being ran against. 

To get these 40 files, I just ran the cop against the local exploits: 
```
rubocop -A --only Lint/MeterpreterCommandDependencies modules/exploits/*/local
``` 

This batch if the first 40 files that the cop amended from with the 107 files the command above made corrections to.
To get those 40 files I used the following command:
```
git diff --staged --name-only | head -n 40 | xargs
``` 

Command to skip modules with railgun api calls.
```
git diff --name-only | xargs grep -L 'railgun' | xargs grep -l "^      'Compat' => {"  | xargs git add
```


Then I just grab the result and passed it into my cop:
```
rubocop -A --only Lint/MeterpreterCommandDependencies modules/exploits/android/local/binder_uaf.rb modules/exploits/android/local/futex_requeue.rb modules/exploits/android/local/janus.rb modules/exploits/android/local/put_user_vroot.rb modules/exploits/linux/local/abrt_raceabrt_priv_esc.rb modules/exploits/linux/local/asan_suid_executable_priv_esc.rb modules/exploits/linux/local/bash_profile_persistence.rb modules/exploits/linux/local/bpf_priv_esc.rb modules/exploits/linux/local/exim4_deliver_message_priv_esc.rb modules/exploits/linux/local/glibc_ld_audit_dso_load_priv_esc.rb modules/exploits/linux/local/glibc_realpath_priv_esc.rb modules/exploits/linux/local/libuser_roothelper_priv_esc.rb modules/exploits/linux/local/nested_namespace_idmap_limit_priv_esc.rb modules/exploits/linux/local/netfilter_priv_esc_ipv4.rb modules/exploits/linux/local/ntfs3g_priv_esc.rb modules/exploits/linux/local/overlayfs_priv_esc.rb modules/exploits/linux/local/ptrace_sudo_token_priv_esc.rb modules/exploits/linux/local/servu_ftp_server_prepareinstallation_priv_esc.rb modules/exploits/linux/local/sudo_baron_samedit.rb modules/exploits/linux/local/udev_netlink.rb modules/exploits/multi/local/xorg_x11_suid_server.rb modules/exploits/osx/local/cfprefsd_race_condition.rb modules/exploits/unix/local/opensmtpd_oob_read_lpe.rb modules/exploits/windows/local/adobe_sandbox_adobecollabsync.rb modules/exploits/windows/local/agnitum_outpost_acs.rb modules/exploits/windows/local/alpc_taskscheduler.rb modules/exploits/windows/local/anyconnect_lpe.rb modules/exploits/windows/local/applocker_bypass.rb modules/exploits/windows/local/bits_ntlm_token_impersonation.rb modules/exploits/windows/local/bthpan.rb modules/exploits/windows/local/bypassuac.rb modules/exploits/windows/local/bypassuac_comhijack.rb modules/exploits/windows/local/bypassuac_dotnet_profiler.rb modules/exploits/windows/local/bypassuac_eventvwr.rb modules/exploits/windows/local/bypassuac_fodhelper.rb modules/exploits/windows/local/bypassuac_injection.rb modules/exploits/windows/local/bypassuac_injection_winsxs.rb modules/exploits/windows/local/bypassuac_sdclt.rb modules/exploits/windows/local/bypassuac_sluihijack.rb modules/exploits/windows/local/bypassuac_windows_store_filesys.rb
```

## Note
As seen in the tests in #15295, there is support to alter/add sections of methods depending on various situations. e.g. 
"The cop verifies if a there is an initialise method, if no initialise present, it should be generated and appended appropriately."

I have tried to identify as many of these scenarios as possible, but if there are anymore edge-cases that may not have been covered in the tests, please call them out and I can get tests added as needed 🕵️ 


## Verification

List the steps needed to make sure this thing works

- [ ] Code review.
- [ ] Verify no api calls have been missed.