### PR TITLE
Updates some notes on modules to satisfy Lint / Lint msftidy (2.5) test

### DIFF
--- a/modules/exploits/linux/local/sudo_baron_samedit.rb
+++ b/modules/exploits/linux/local/sudo_baron_samedit.rb
@@ -77,7 +77,8 @@ class MetasploitModule < Msf::Exploit::Local
         'Notes' => {
           'AKA' => [ 'Baron Samedit' ],
           'SideEffects' => [ARTIFACTS_ON_DISK, IOC_IN_LOGS],
-          'Reliability' => [REPEATABLE_SESSION]
+          'Reliability' => [REPEATABLE_SESSION],
+          'Stability' => [CRASH_SAFE]
         }
       )
     )

--- a/modules/exploits/osx/local/cfprefsd_race_condition.rb
+++ b/modules/exploits/osx/local/cfprefsd_race_condition.rb
@@ -45,7 +45,12 @@ class MetasploitModule < Msf::Exploit::Local
         'Targets' => [
           [ 'Mac OS X x64 (Native Payload)', {} ],
         ],
-        'DisclosureDate' => '2020-03-18'
+        'DisclosureDate' => '2020-03-18',
+        'Notes' => {
+          'SideEffects' => [ARTIFACTS_ON_DISK, CONFIG_CHANGES],
+          'Reliability' => [REPEATABLE_SESSION],
+          'Stability' => [CRASH_SAFE]
+        }
       )
     )
     register_advanced_options [

--- a/modules/exploits/windows/local/anyconnect_lpe.rb
+++ b/modules/exploits/windows/local/anyconnect_lpe.rb
@@ -72,6 +72,11 @@ class MetasploitModule < Msf::Exploit::Local
             ['CVE', '2020-3433']
           ],
         'DisclosureDate' => '2020-08-05',
+        'Notes' => {
+          'SideEffects' => [ARTIFACTS_ON_DISK],
+          'Reliability' => [REPEATABLE_SESSION],
+          'Stability' => [CRASH_SAFE]
+        },
         'DefaultTarget' => 0,
         'DefaultOptions' => {
           'PAYLOAD' => 'windows/meterpreter/reverse_tcp',


### PR DESCRIPTION
Just a simple PR to update some modules that were causing tests to fail on a separate [PR](https://github.com/rapid7/metasploit-framework/pull/15489) I already have up.

The modules were failing on `Lint / Lint msftidy (2.5)` of the GitHub actions tests due to not having one or more of the following in the notes section within the modules:
- Stability 
- Reliability
- SideEffects 

These are modules that were merged prior to a rubocop rule being added to check for this values, these have only now became an issue due to #15489 making changes to these files when adding Meterpreter command requirements.

I'm not super familiar with how these are defined per module. I just tried to use my best judgement based of the [Definition of Module Reliability, Side Effects, and Stability](https://github.com/rapid7/metasploit-framework/wiki/Definition-of-Module-Reliability,-Side-Effects,-and-Stability#allowed-values) and [Exploit Ranking](https://github.com/rapid7/metasploit-framework/wiki/Exploit-Ranking) wikis 😅 

So feel free to help me out with any of the definitions.

## Verification

List the steps needed to make sure this thing works

- [ ] Review the module and see if the allocated module definitions are accurate