### PR TITLE
Align support for negative session ids

### DIFF
--- a/lib/msf/core/session_manager.rb
+++ b/lib/msf/core/session_manager.rb
@@ -262,10 +262,9 @@ class SessionManager < Hash
     session = nil
     sid = sid.to_i
 
-    if sid > 0
-      session = self[sid]
-    elsif sid == -1
-      sid = self.keys.max
+    if sid < 0
+      session = self[self.keys.sort[sid]]
+    elsif sid > 0
       session = self[sid]
     end
 
@@ -292,4 +291,3 @@ protected
 end
 
 end
-

--- a/lib/msf/ui/console/command_dispatcher/jobs.rb
+++ b/lib/msf/ui/console/command_dispatcher/jobs.rb
@@ -146,6 +146,10 @@ module Msf
                 job_id = val
               when "-p"
                 job_list = build_range_array(val)
+                if job_list.blank?
+                  print_error('Please specify valid job identifier(s)')
+                  return
+                end
                 job_list.each do |job_id|
                   add_persist_job(job_id)
                 end
@@ -223,12 +227,13 @@ module Msf
               end
 
               # Stop the job by job id.
-              job_list.map(&:to_s).each do |job|
-                if framework.jobs.key?(job)
-                  print_status("Stopping job #{job}")
-                  framework.jobs.stop_job(job)
+              job_list.map(&:to_s).each do |job_id|
+                job_id = job_id.to_i < 0 ? framework.jobs.keys[job_id.to_i] : job_id
+                if framework.jobs.key?(job_id)
+                  print_status("Stopping job #{job_id}")
+                  framework.jobs.stop_job(job_id)
                 else
-                  print_error("Invalid job identifier: #{job}")
+                  print_error("Invalid job identifier: #{job_id}")
                 end
               end
             end

--- a/spec/lib/msf/ui/console/command_dispatcher_spec.rb
+++ b/spec/lib/msf/ui/console/command_dispatcher_spec.rb
@@ -1,0 +1,45 @@
+require 'rspec'
+
+RSpec.describe Msf::Ui::Console::CommandDispatcher do
+  include_context 'Msf::DBManager'
+  include_context 'Msf::UIDriver'
+
+  let(:subject) do
+    dummy_class = Class.new
+    dummy_class.include described_class
+    dummy_class.new(driver)
+  end
+
+  describe '#build_range_array' do
+    [
+      { input: '1', expected: [1] },
+      { input: '123', expected: [123] },
+      { input: '-1', expected: [-1] },
+      { input: '-123', expected: [-123] },
+      { input: '1,2', expected: [1, 2] },
+      { input: '-1,2', expected: [-1, 2] },
+      { input: '2,-1', expected: [-1, 2] },
+      { input: '-1,-2', expected: [-2, -1] },
+      { input: '-1-', expected: nil },
+      { input: '-1-,2', expected: nil },
+      { input: '-1--,2', expected: nil },
+      { input: '---1', expected: nil },
+      { input: '1--', expected: nil },
+      { input: '1-3', expected: [1, 2, 3] },
+      { input: '-1-3', expected: nil },
+      { input: '-1--4', expected: nil },
+      { input: '1..4', expected: [1, 2, 3, 4] },
+      { input: '1..-4', expected: nil },
+      { input: '-1..4', expected: nil },
+      { input: '-1..-4', expected: nil },
+      { input: '-1,0-3', expected: [-1, 0, 1, 2, 3] },
+      { input: '-1,0,1,2', expected: [-1, 0, 1, 2] },
+      { input: '-1,-1', expected: [-1] },
+      { input: '-1,1..2', expected: [-1, 1, 2] }
+    ].each do |test|
+      it "returns #{test[:expected].inspect} for the input #{test[:input]}" do
+        expect(subject.build_range_array(test[:input])).to eq(test[:expected])
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Before

The syntax `sessions -u -1` isn't supported:
```
msf6 exploit(windows/smb/ms17_010_eternalblue) > sessions -u -1
[-] Please specify valid session identifier(s)
```

The syntax `jobs -k -1` isn't supported:
```
msf6 auxiliary(server/socks_proxy) > jobs -k -1
[-] Please specify valid job identifier(s)
```

### After

The last session is now upgraded as expected:
```
msf6 auxiliary(scanner/ssh/ssh_login) > sessions -u -1
[*] Executing 'post/multi/manage/shell_to_meterpreter' on session(s): [-1]

[*] Upgrading session ID: 1
[*] Starting exploit/multi/handler
[*] Started reverse TCP handler on 172.28.128.1:6969 
[-] Powershell is not installed on the target.
...etc...
```

The last job is now killed as expected:
```
msf6 auxiliary(server/socks_proxy) > jobs -k -1
[*] Stopping the following job(s): -1
[*] Stopping job 1
```

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] `use auxiliary/server/socks_proxy`
- [ ] `run -j`
- [ ] `jobs -k -1`
- [ ] The last job will be killed.
- [ ] `use auxiliary/scanner/ssh/ssh_login`
- [ ] `run`
- [ ] Background the session and run `sessions -u -1`
- [ ] The last session will be upgraded.