### PR TITLE
Allow Specifying The SSLVersion For Servers Too

### DIFF
--- a/lib/msf/core/exploit/remote/http_server.rb
+++ b/lib/msf/core/exploit/remote/http_server.rb
@@ -145,7 +145,8 @@ module Exploit::Remote::HttpServer
       opts['Comm'],
       datastore['SSLCert'],
       datastore['SSLCompression'],
-      datastore['SSLCipher']
+      datastore['SSLCipher'],
+      datastore['SSLVersion']
     )
 
     self.service.server_name = datastore['HTTP::server_name']

--- a/lib/msf/core/exploit/remote/tcp_server.rb
+++ b/lib/msf/core/exploit/remote/tcp_server.rb
@@ -28,7 +28,8 @@ module Exploit::Remote::TcpServer
       [
         OptString.new('ListenerComm', [ false, 'The specific communication channel to use for this service']),
         OptBool.new('SSLCompression', [ false, 'Enable SSL/TLS-level compression', false ]),
-        OptString.new('SSLCipher',    [ false, 'String for SSL cipher spec - "DHE-RSA-AES256-SHA" or "ADH"'])
+        OptString.new('SSLCipher',    [ false, 'String for SSL cipher spec - "DHE-RSA-AES256-SHA" or "ADH"']),
+        Opt::SSLVersion
       ], Msf::Exploit::Remote::TcpServer)
 
     register_evasion_options(
@@ -59,14 +60,15 @@ module Exploit::Remote::TcpServer
       comm = _determine_server_comm
 
       self.service = Rex::Socket::TcpServer.create(
-        'LocalHost' => srvhost,
-        'LocalPort' => srvport,
-        'SSL'       => ssl,
-        'SSLCert'   => ssl_cert,
-        'SSLCipher'   => ssl_cipher,
+        'LocalHost'      => srvhost,
+        'LocalPort'      => srvport,
+        'SSL'            => ssl,
+        'SSLCert'        => ssl_cert,
+        'SSLCipher'      => ssl_cipher,
         'SSLCompression' => ssl_compression,
-        'Comm'      => comm,
-        'Context'   =>
+        'SSLVersion'     => ssl_version,
+        'Comm'           => comm,
+        'Context'        =>
           {
             'Msf'        => framework,
             'MsfExploit' => self,
@@ -133,6 +135,13 @@ module Exploit::Remote::TcpServer
   # @return [Bool] enable SSL/TLS-level compression
   def ssl_compression
     datastore['SSLCompression']
+  end
+
+  #
+  # Returns the SSLVersion option
+  #
+  def ssl_version
+    datastore['SSLVersion']
   end
 
 end

--- a/lib/msf/core/handler/reverse/ssl.rb
+++ b/lib/msf/core/handler/reverse/ssl.rb
@@ -9,7 +9,8 @@ module Msf
           super
           register_advanced_options(
             [
-              OptPath.new('HandlerSSLCert', [false, "Path to a SSL certificate in unified PEM format"])
+              OptPath.new('HandlerSSLCert', [false, "Path to a SSL certificate in unified PEM format"]),
+              Opt::SSLVersion,
             ], Msf::Handler::Reverse::SSL)
 
         end

--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -212,7 +212,7 @@ module ReverseHttp
             'MsfExploit' => self,
           },
           nil,
-          (ssl?) ? datastore['HandlerSSLCert'] : nil
+          (ssl?) ? datastore['HandlerSSLCert'] : nil, nil, nil, datastore['SSLVersion']
         )
         local_addr = ip
       rescue

--- a/lib/msf/core/handler/reverse_tcp_double_ssl.rb
+++ b/lib/msf/core/handler/reverse_tcp_double_ssl.rb
@@ -76,11 +76,12 @@ module ReverseTcpDoubleSSL
       begin
 
         self.listener_sock = Rex::Socket::SslTcpServer.create(
-        'LocalHost' => ip,
-        'LocalPort' => local_port,
-        'Comm'      => comm,
-        'SSLCert'   => datastore['HandlerSSLCert'],
-        'Context'   =>
+        'LocalHost'  => ip,
+        'LocalPort'  => local_port,
+        'Comm'       => comm,
+        'SSLCert'    => datastore['HandlerSSLCert'],
+        'SSLVersion' => datastore['SSLVersion'],
+        'Context'    =>
           {
             'Msf'        => framework,
             'MsfPayload' => self,

--- a/lib/msf/core/handler/reverse_tcp_ssl.rb
+++ b/lib/msf/core/handler/reverse_tcp_ssl.rb
@@ -54,11 +54,12 @@ module ReverseTcpSsl
       begin
 
         self.listener_sock = Rex::Socket::SslTcpServer.create(
-          'LocalHost' => ip,
-          'LocalPort' => local_port,
-          'Comm'      => comm,
-          'SSLCert'   => datastore['HandlerSSLCert'],
-          'Context'   =>
+          'LocalHost'  => ip,
+          'LocalPort'  => local_port,
+          'Comm'       => comm,
+          'SSLCert'    => datastore['HandlerSSLCert'],
+          'SSLVersion' => datastore['SSLVersion'],
+          'Context'    =>
             {
               'Msf'        => framework,
               'MsfPayload' => self,

--- a/lib/rex/proto/http/server.rb
+++ b/lib/rex/proto/http/server.rb
@@ -100,7 +100,7 @@ class Server
   #
   def initialize(port = 80, listen_host = '0.0.0.0', ssl = false, context = {},
                  comm = nil, ssl_cert = nil, ssl_compression = false,
-                 ssl_cipher = nil)
+                 ssl_cipher = nil, ssl_version = nil)
     self.listen_host     = listen_host
     self.listen_port     = port
     self.ssl             = ssl
@@ -109,6 +109,7 @@ class Server
     self.ssl_cert        = ssl_cert
     self.ssl_compression = ssl_compression
     self.ssl_cipher      = ssl_cipher
+    self.ssl_version     = ssl_version
     self.listener        = nil
     self.resources       = {}
     self.server_name     = DefaultServer
@@ -142,14 +143,15 @@ class Server
   def start
 
     self.listener = Rex::Socket::TcpServer.create(
-      'LocalHost' => self.listen_host,
-      'LocalPort' => self.listen_port,
-      'Context'   => self.context,
-      'SSL'       => self.ssl,
-      'SSLCert'   => self.ssl_cert,
+      'LocalHost'      => self.listen_host,
+      'LocalPort'      => self.listen_port,
+      'Context'        => self.context,
+      'SSL'            => self.ssl,
+      'SSLCert'        => self.ssl_cert,
       'SSLCompression' => self.ssl_compression,
-      'SSLCipher' => self.ssl_cipher,
-      'Comm'      => self.comm
+      'SSLCipher'      => self.ssl_cipher,
+      'SSLVersion'     => self.ssl_version,
+      'Comm'           => self.comm
     )
 
     # Register callbacks
@@ -272,7 +274,7 @@ class Server
   end
 
   attr_accessor :listen_port, :listen_host, :server_name, :context, :comm
-  attr_accessor :ssl, :ssl_cert, :ssl_compression, :ssl_cipher
+  attr_accessor :ssl, :ssl_cert, :ssl_compression, :ssl_cipher, :ssl_version
   attr_accessor :listener, :resources
 
 protected


### PR DESCRIPTION
Currently, the `SSLVersion` datastore option is only supported for client-side sockets. This leads to some variations in what versions are supported for server-side sockets and causes issues when older versions required by some targets (such as Windows 7) are not supported. This along with rapid7/rex-socket#37 adds support for the user to specify the supported versions. It also defaults server sockets to version `SSLv23` which is the same as client sockets. Version `SSLv23` also provides maximum compatibility which is probably ideal for Metasploit since users will likely want to receive connections, sessions etc. from older targets.

I updated the SSL servers I am aware of, if I missed one please call it out. The servers fall under two pseudo categories, Mixin servers for modules and Handlers for sessions.

rapid7/rex-socket#37 is required, without those changes, this datastore option won't do anything.

Fixes #15435

## Verification

- [x] Install `sslscan` so you can enumerate the supported versions (pro-tip, you can speed things along using these options `--no-cipher-details --no-ciphersuites --no-compression --no-fallback --no-groups --no-heartbleed --no-renegotiation --no-sigs` which will only check what you need.
- [x] Start `msfconsole`
- [x] Use a payload with a handler that uses SSL (`reverse_tcp_ssl`, `reverse_tcp_double_ssl`, `reverse_https`)
- [x] Set the `SSLVersion` to a valid option
- [x] Use `sslscan` to check what versions the handler supports, make sure the minimum version is aligned with what the `SSLVersion` option was set to
- [x] Use a server module that uses SSL (`auxiliary/server/capture/http` works well)
- [x] Set the `SSLVersion` to a valid option
- [x] Use `sslscan` to check what versions the handler supports, make sure the minimum version is aligned with what the `SSLVersion` option was set to

