### PR TITLE
Cookie jar fix for gitlab exploit module issues

### DIFF
--- a/lib/msf/core/exploit/remote/http/http_cookie.rb
+++ b/lib/msf/core/exploit/remote/http/http_cookie.rb
@@ -177,6 +177,14 @@ module Msf
             end
           end
 
+          def origin=(origin)
+            @cookie.origin = origin
+          end
+
+          def origin
+            @cookie.origin
+          end
+
           # Returns the cookie accessed_at value of type +Time+. accessed_at indicates when a cookie was last interacted
           # with.
           def accessed_at

--- a/lib/msf/core/exploit/remote/http/http_cookie.rb
+++ b/lib/msf/core/exploit/remote/http/http_cookie.rb
@@ -30,7 +30,7 @@ module Msf
             end
 
             attr_hash.each_pair do |k, v|
-              if k == 'max-age'
+              if k == 'max-age'.to_sym
                 self.max_age= v
               elsif respond_to?("#{k}=".to_sym)
                 self.send("#{k}=".to_sym, v)

--- a/lib/msf/core/exploit/remote/http/http_cookie_jar.rb
+++ b/lib/msf/core/exploit/remote/http/http_cookie_jar.rb
@@ -29,11 +29,7 @@ module Msf
           def add(cookie)
             raise TypeError, "Passed cookie is of class '#{cookie.class}' and not a subclass of '#{Msf::Exploit::Remote::HTTP::HttpCookie}" unless cookie.is_a?(Msf::Exploit::Remote::HTTP::HttpCookie)
 
-            begin
-              @cookie_jar.add(cookie)
-            rescue ArgumentError => e
-              elog("Cookie #{cookie.to_s} could not be added to jar. Error was thrown with following message:\n#{e.message}", error: e)
-            end
+            @cookie_jar.add(cookie)
             self
           end
 

--- a/lib/msf/core/exploit/remote/http/http_cookie_jar.rb
+++ b/lib/msf/core/exploit/remote/http/http_cookie_jar.rb
@@ -33,7 +33,7 @@ module Msf
               @cookie_jar.add(cookie)
               self
             rescue ArgumentError => e
-              elog("Cookie #{cookie.to_s} could not be added to jar. Error was thrown with following message:\n#{e.message}")
+              elog("Cookie #{cookie.to_s} could not be added to jar. Error was thrown with following message:\n#{e.message}", error: e)
             end
           end
 

--- a/lib/msf/core/exploit/remote/http/http_cookie_jar.rb
+++ b/lib/msf/core/exploit/remote/http/http_cookie_jar.rb
@@ -73,17 +73,19 @@ module Msf
           # Parses a Set-Cookie header value +set_cookie_header+ and returns an array of
           # +::Msf::Exploit::Remote::HTTP::HttpCookie+ objects. Parts (separated by commas) that are malformed or
           # considered unacceptable are silently ignored.
-          def parse(set_cookie_header)
+          def parse(set_cookie_header, origin_url)
             cookies = []
             ::HTTP::Cookie::Scanner.new(set_cookie_header).scan_set_cookie do |name, value, attrs|
               if name.nil? || name.empty?
                 next
               end
 
-              if attrs.is_a?(Hash)
+              if attrs && attrs.is_a?(Hash)
+                attrs = attrs.transform_keys(&:to_sym)
+                attrs[:origin] = origin_url
                 cookies << HttpCookie.new(name, value, **attrs)
               else
-                cookies << HttpCookie.new(name, value)
+                raise ArgumentError, "Cookie header could not be parsed by 'scan_set_cookie' successfully."
               end
             end
 
@@ -91,8 +93,8 @@ module Msf
           end
 
           # Same as +parse+, but each +::Msf::Exploit::Remote::HTTP::HttpCookie+ is also added to the jar.
-          def parse_and_merge(set_cookie_header)
-            cookies = parse(set_cookie_header)
+          def parse_and_merge(set_cookie_header, origin_url)
+            cookies = parse(set_cookie_header, origin_url)
             cookies.each { |c| add(c) }
             cookies
           end

--- a/lib/msf/core/exploit/remote/http/http_cookie_jar.rb
+++ b/lib/msf/core/exploit/remote/http/http_cookie_jar.rb
@@ -29,8 +29,12 @@ module Msf
           def add(cookie)
             raise TypeError, "Passed cookie is of class '#{cookie.class}' and not a subclass of '#{Msf::Exploit::Remote::HTTP::HttpCookie}" unless cookie.is_a?(Msf::Exploit::Remote::HTTP::HttpCookie)
 
-            @cookie_jar.add(cookie)
-            self
+            begin
+              @cookie_jar.add(cookie)
+              self
+            rescue ArgumentError => e
+              elog("Cookie #{cookie.to_s} could not be added to jar. Error was thrown with following message:\n#{e.message}")
+            end
           end
 
           # Will remove any cookie from the jar that has the same +name+, +domain+ and +path+ as the passed +cookie+.
@@ -93,7 +97,7 @@ module Msf
           # Same as +parse+, but each +::Msf::Exploit::Remote::HTTP::HttpCookie+ is also added to the jar.
           def parse_and_merge(set_cookie_header)
             cookies = parse(set_cookie_header)
-            cookies.each { |c| add(Msf::Exploit::Remote::HTTP::HttpCookie.new(c)) }
+            cookies.each { |c| add(c) }
             cookies
           end
 

--- a/lib/msf/core/exploit/remote/http/http_cookie_jar.rb
+++ b/lib/msf/core/exploit/remote/http/http_cookie_jar.rb
@@ -31,10 +31,10 @@ module Msf
 
             begin
               @cookie_jar.add(cookie)
-              self
             rescue ArgumentError => e
               elog("Cookie #{cookie.to_s} could not be added to jar. Error was thrown with following message:\n#{e.message}", error: e)
             end
+            self
           end
 
           # Will remove any cookie from the jar that has the same +name+, +domain+ and +path+ as the passed +cookie+.

--- a/lib/msf/core/exploit/remote/http/http_cookie_jar.rb
+++ b/lib/msf/core/exploit/remote/http/http_cookie_jar.rb
@@ -80,7 +80,11 @@ module Msf
                 next
               end
 
-              cookies << HttpCookie.new(name, value, attrs)
+              if attrs.is_a?(Hash)
+                cookies << HttpCookie.new(name, value, **attrs)
+              else
+                cookies << HttpCookie.new(name, value)
+              end
             end
 
             cookies

--- a/lib/msf/core/exploit/remote/http_client.rb
+++ b/lib/msf/core/exploit/remote/http_client.rb
@@ -395,12 +395,7 @@ module Exploit::Remote::HttpClient
     return unless res
 
     if opts['keep_cookies'] && res.headers['Set-Cookie'].present?
-      cookies = cookie_jar.parse(res.headers['Set-Cookie'])
-
-      cookies.each do |c|
-        c.origin = "http#{ssl ? 's' : ''}://#{vhost}:#{rport}"
-        cookie_jar.add(c)
-      end
+      cookie_jar.parse_and_merge(res.headers['Set-Cookie'], "http#{ssl ? 's' : ''}://#{vhost}:#{rport}")
     end
 
     res

--- a/lib/msf/core/exploit/remote/http_client.rb
+++ b/lib/msf/core/exploit/remote/http_client.rb
@@ -395,7 +395,12 @@ module Exploit::Remote::HttpClient
     return unless res
 
     if opts['keep_cookies'] && res.headers['Set-Cookie'].present?
-      cookie_jar.parse_and_merge(res.headers['Set-Cookie'])
+      cookies = cookie_jar.parse(res.headers['Set-Cookie'])
+
+      cookies.each do |c|
+        c.origin = "http#{ssl ? 's' : ''}://#{vhost}:#{rport}"
+        cookie_jar.add(c)
+      end
     end
 
     res

--- a/spec/lib/msf/core/exploit/remote/remote/http/http_cookie_jar_spec.rb
+++ b/spec/lib/msf/core/exploit/remote/remote/http/http_cookie_jar_spec.rb
@@ -18,6 +18,18 @@ RSpec.describe Msf::Exploit::Remote::HTTP::HttpCookieJar do
     )
   end
 
+  def random_origin
+    domain = random_string(4,10)
+    path = "/#{random_string(4,10)}/"
+    url = "http://#{domain}#{path}"
+
+    {
+      'domain' => domain,
+      'path' => path,
+      'url' => url
+    }
+  end
+
   let(:cookie_jar) { described_class.new }
 
   before(:each) do
@@ -28,7 +40,7 @@ RSpec.describe Msf::Exploit::Remote::HTTP::HttpCookieJar do
     Timecop.return
   end
 
-  describe 'empty?' do
+  describe '#empty?' do
     it 'will return true when no cookies are in a cookie_jar' do
       # cookie_jar made in before
 
@@ -47,7 +59,7 @@ RSpec.describe Msf::Exploit::Remote::HTTP::HttpCookieJar do
     end
   end
 
-  describe 'clear' do
+  describe '#clear' do
     it 'will make no changes to an empty cookiejar' do
       # empty cookie_jar made in before
 
@@ -66,7 +78,7 @@ RSpec.describe Msf::Exploit::Remote::HTTP::HttpCookieJar do
     end
   end
 
-  describe 'cookies' do
+  describe '#cookies' do
     it 'will return an empty array when no cookies have been added to the jar' do
       # cookie_jar made in before
 
@@ -91,7 +103,7 @@ RSpec.describe Msf::Exploit::Remote::HTTP::HttpCookieJar do
     end
   end
 
-  describe 'add' do
+  describe '#add' do
     it 'unacceptable cookie without a domain will throw an ArgumentError' do
       c = Msf::Exploit::Remote::HTTP::HttpCookie.new(
         random_string,
@@ -146,7 +158,7 @@ RSpec.describe Msf::Exploit::Remote::HTTP::HttpCookieJar do
     end
   end
 
-  describe 'delete' do
+  describe '#delete' do
     it 'used on an empty jar will return nil' do
       # cookie_jar made in before
 
@@ -201,7 +213,7 @@ RSpec.describe Msf::Exploit::Remote::HTTP::HttpCookieJar do
     end
   end
 
-  describe 'cleanup' do
+  describe '#cleanup' do
     it 'will make no changes to an empty cookiejar' do
       # empty cookie_jar made in before
 
@@ -255,6 +267,159 @@ RSpec.describe Msf::Exploit::Remote::HTTP::HttpCookieJar do
 
       expect(original.cookies.length).to be 5
       expect(dup.cookies.length).to be 2
+    end
+  end
+
+  describe '#parse' do
+    it 'silently ignores incorrectly built headers' do
+      header = ";;'//;;'"
+      origin = random_origin
+
+      cookies = cookie_jar.parse(header, origin['url'])
+
+      expect(cookies).to eq([])
+    end
+
+    it 'silently ignores name only cookie headers' do
+      header = "#{random_string(4,10)}"
+      origin = random_origin
+
+      cookies = cookie_jar.parse(header, origin['url'])
+
+      expect(cookies).to eq([])
+    end
+
+    it 'correctly parses cookie headers with name and value only' do
+      cookie_name = random_string(4,10)
+      cookie_value = random_string(4,10)
+      header = "#{cookie_name}=#{cookie_value};"
+      origin = random_origin
+
+      cookie = Msf::Exploit::Remote::HTTP::HttpCookie.new(cookie_name, cookie_value, {
+        :domain => origin['domain'],
+        :path => origin['path'],
+        :origin => origin['url']
+      })
+      header_cookie = cookie_jar.parse(header, origin['url']).first
+
+      expect(cookie).to eq(header_cookie)
+    end
+
+    it 'does not overwrite header domain values with a passed origin' do
+      cookie_domain = random_string(11,20)
+      header = "#{random_string(4,10)}=#{random_string(4,10)}; domain=#{cookie_domain}"
+      origin = random_origin
+
+      header_cookie = cookie_jar.parse(header, origin['url']).first
+
+      expect(header_cookie.domain).to eq(cookie_domain)
+      expect(header_cookie.domain).not_to eq(origin['domain'])
+    end
+
+    it 'does not overwrite header path values with a passed origin' do
+      cookie_path = "/#{random_string(11,20)}/"
+      header = "#{random_string(4,10)}=#{random_string(4,10)}; path=#{cookie_path}"
+      origin = random_origin
+
+      header_cookie = cookie_jar.parse(header, origin['url']).first
+
+      expect(header_cookie.path).to eq(cookie_path)
+      expect(header_cookie.path).not_to eq(origin['path'])
+    end
+
+    it 'sets max-age correctly' do
+      max_age = rand(100)
+      header = "#{random_string(4,10)}=#{random_string(4,10)}; max-age=#{max_age}"
+      origin = random_origin
+
+      header_cookie = cookie_jar.parse(header, origin['url']).first
+
+      expect(header_cookie.max_age).to eq(max_age)
+    end
+
+    it 'sets expires correctly' do
+      expires = Time.now.utc # Underlying +::HTTP::Cookie::Scanner#scan_set_cookie+ ignores timezones, instead storing expires values as UTC
+      time_str = expires.strftime '%Y-%b-%d %H:%M:%S' # Acceptable expires format as described in RFC 6265 5.1.1
+      header = "#{random_string(4,10)}=#{random_string(4,10)}; expires=#{time_str}"
+      origin = random_origin
+
+      header_cookie = cookie_jar.parse(header, origin['url']).first
+
+      expect(header_cookie.expires).to eq(expires)
+    end
+
+    it 'sets secure to false when not included in the header' do
+      header = "#{random_string(4,10)}=#{random_string(4,10)};"
+      origin = random_origin
+
+      header_cookie = cookie_jar.parse(header, origin['url']).first
+
+      expect(header_cookie.secure).to eq(false)
+    end
+
+    it 'sets secure to true when included in the header' do
+      header = "#{random_string(4,10)}=#{random_string(4,10)}; secure;"
+      origin = random_origin
+
+      header_cookie = cookie_jar.parse(header, origin['url']).first
+
+      expect(header_cookie.secure).to eq(true)
+    end
+
+    it 'sets httponly to false when not included in the header' do
+      header = "#{random_string(4,10)}=#{random_string(4,10)};"
+      origin = random_origin
+
+      header_cookie = cookie_jar.parse(header, origin['url']).first
+
+      expect(header_cookie.httponly).to eq(false)
+    end
+
+    it 'sets httponly to true when included in the header' do
+      header = "#{random_string(4,10)}=#{random_string(4,10)}; httponly;"
+      origin = random_origin
+
+      header_cookie = cookie_jar.parse(header, origin['url']).first
+
+      expect(header_cookie.httponly).to eq(true)
+    end
+
+    it 'depends on scan_set_cookie returning a hash' do
+      header = 'cookie-one=value-one;, cookie-two=value-two;'
+      origin = random_origin['url']
+
+      allow_any_instance_of(::HTTP::Cookie::Scanner).to receive(:scan_set_cookie).and_yield 'name', 'val', nil
+
+      expect do
+        cookie_jar.parse(header, origin)
+      end.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#parse_and_merge' do
+    it 'will merge valid cookie headers' do
+      cookie_name = random_string(4,10)
+      cookie_value = random_string(4,10)
+      header = "#{cookie_name}=#{cookie_value};"
+      origin = random_origin
+
+      cookie = Msf::Exploit::Remote::HTTP::HttpCookie.new(cookie_name, cookie_value, {
+        :domain => origin['domain'],
+        :path => origin['path'],
+        :origin => origin['url']
+      })
+      cookie_jar.parse_and_merge(header, origin['url']).first
+
+      expect(cookie_jar.cookies).to eq([cookie])
+    end
+
+    it 'will not merge invalid cookie headers' do
+      header = ";;;;|||;;;"
+      origin = random_origin
+
+      cookie_jar.parse_and_merge(header, origin['url']).first
+
+      expect(cookie_jar.cookies).to eq([])
     end
   end
 end

--- a/spec/lib/msf/core/exploit/remote/remote/http/http_cookie_spec.rb
+++ b/spec/lib/msf/core/exploit/remote/remote/http/http_cookie_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe Msf::Exploit::Remote::HTTP::HttpCookie do
     end
 
     describe 'nil' do
-      it 'assigned to value results in it being set to an empty string & expires is set UNIX_EPOCH' do
+      it 'assigned to value results in it being set to an empty string and expires is set UNIX_EPOCH' do
         v = nil
 
         cookie.value = v
@@ -398,7 +398,7 @@ RSpec.describe Msf::Exploit::Remote::HTTP::HttpCookie do
   end
 
   describe 'origin' do
-    describe 'String' do
+    context 'when assigned a String' do
       it 'is assigned to origin successfully' do
         n = random_string
 
@@ -416,10 +416,10 @@ RSpec.describe Msf::Exploit::Remote::HTTP::HttpCookie do
         end.to raise_error(ArgumentError)
       end
 
-      it 'representing a URI will be passed to origin successfully, and populate the domain & path fields correctly' do
+      it 'representing a http URI will be passed to origin successfully, and populate the domain and path fields correctly' do
         domain = random_string(5)
         path = "/#{random_string(5)}/"
-        protocol = "http#{rand(2) == 1 ? 's' : ''}"
+        protocol = "http"
         my_str = "#{protocol}://#{domain}#{path}"
 
         cookie.origin = my_str
@@ -427,7 +427,21 @@ RSpec.describe Msf::Exploit::Remote::HTTP::HttpCookie do
         expect(cookie.origin).to eql(URI(my_str))
         expect(cookie.domain).to eql(domain)
         expect(cookie.path).to eql(path)
-        expect(cookie.origin.class).to eql(protocol.end_with?('s') ? URI::HTTPS : URI::HTTP)
+        expect(cookie.origin.class).to eql(URI::HTTP)
+      end
+
+      it 'representing a https URI will be passed to origin successfully, and populate the domain and path fields correctly' do
+        domain = random_string(5)
+        path = "/#{random_string(5)}/"
+        protocol = "https"
+        my_str = "#{protocol}://#{domain}#{path}"
+
+        cookie.origin = my_str
+
+        expect(cookie.origin).to eql(URI(my_str))
+        expect(cookie.domain).to eql(domain)
+        expect(cookie.path).to eql(path)
+        expect(cookie.origin.class).to eql(URI::HTTPS)
       end
     end
 
@@ -443,7 +457,7 @@ RSpec.describe Msf::Exploit::Remote::HTTP::HttpCookie do
       end
     end
 
-    describe 'nil' do
+    context 'when assigned a nil value' do
       it 'assigned to name throws an ArgumentError' do
         n = nil
 
@@ -453,9 +467,8 @@ RSpec.describe Msf::Exploit::Remote::HTTP::HttpCookie do
       end
     end
 
-
     # If the Object A responds to to_str with a truthy Object, then origin is set to A
-    describe 'Complex Object' do
+    context 'when assigned a Complex Objext' do
       it 'which responds to to_str will be passed to origin successfully' do
         clazz = Class.new(String) do
         end
@@ -479,7 +492,7 @@ RSpec.describe Msf::Exploit::Remote::HTTP::HttpCookie do
         end.to raise_error(ArgumentError)
       end
 
-      it 'which is a kind of String representing a URI will be passed to origin successfully, and populate the domain & path fields correctly' do
+      it 'which is a kind of String representing a URI will be passed to origin successfully, and populate the domain and path fields correctly' do
         clazz = Class.new(String) do
         end
         domain = random_string(5)
@@ -645,7 +658,7 @@ RSpec.describe Msf::Exploit::Remote::HTTP::HttpCookie do
     end
 
     describe 'No-Arg' do
-      it 'call of expired? returns false when expires & max_age are set to nil' do
+      it 'call of expired? returns false when expires and max_age are set to nil' do
         n = nil
 
         cookie.expires = n

--- a/spec/lib/msf/core/exploit/remote/remote/http/http_cookie_spec.rb
+++ b/spec/lib/msf/core/exploit/remote/remote/http/http_cookie_spec.rb
@@ -397,6 +397,108 @@ RSpec.describe Msf::Exploit::Remote::HTTP::HttpCookie do
     end
   end
 
+  describe 'origin' do
+    describe 'String' do
+      it 'is assigned to origin successfully' do
+        n = random_string
+
+        cookie.origin = n
+
+        expect(cookie.origin).to eql(URI(n))
+        expect(cookie.origin.class).to eql(URI::Generic)
+      end
+
+      it 'that is empty is passed to name and throws an ArgumentError' do
+        n = ''
+
+        expect do
+          cookie.name = n
+        end.to raise_error(ArgumentError)
+      end
+
+      it 'representing a URI will be passed to origin successfully, and populate the domain & path fields correctly' do
+        domain = random_string(5)
+        path = "/#{random_string(5)}/"
+        protocol = "http#{rand(2) == 1 ? 's' : ''}"
+        my_str = "#{protocol}://#{domain}#{path}"
+
+        cookie.origin = my_str
+
+        expect(cookie.origin).to eql(URI(my_str))
+        expect(cookie.domain).to eql(domain)
+        expect(cookie.path).to eql(path)
+        expect(cookie.origin.class).to eql(protocol.end_with?('s') ? URI::HTTPS : URI::HTTP)
+      end
+    end
+
+    describe 'immutable' do
+      it 'when origin is set previously, assigning a value to it throws an ArgumentError' do
+        origin = random_string
+        unused_origin = random_string
+        cookie.origin = origin
+
+        expect do
+          cookie.origin = unused_origin
+        end.to raise_error(ArgumentError)
+      end
+    end
+
+    describe 'nil' do
+      it 'assigned to name throws an ArgumentError' do
+        n = nil
+
+        expect do
+          cookie.name = n
+        end.to raise_error(ArgumentError)
+      end
+    end
+
+
+    # If the Object A responds to to_str with a truthy Object, then origin is set to A
+    describe 'Complex Object' do
+      it 'which responds to to_str will be passed to origin successfully' do
+        clazz = Class.new(String) do
+        end
+        str = "#{random_string(5)}"
+        my_str = clazz.new(str)
+
+        cookie.origin = my_str
+
+        expect(cookie.origin).to eql(URI(my_str))
+        expect(cookie.domain).to eql(nil)
+        expect(cookie.path).to eql(nil)
+      end
+
+      it 'which does not respond to to_str will cause an ArgumentError to be thrown' do
+        clazz = Class.new do
+        end
+        my_str = clazz.new
+
+        expect do
+          cookie.origin = my_str
+        end.to raise_error(ArgumentError)
+      end
+
+      it 'which is a kind of String representing a URI will be passed to origin successfully, and populate the domain & path fields correctly' do
+        clazz = Class.new(String) do
+        end
+        domain = random_string(5)
+        path = "/#{random_string(5)}/"
+        protocol = "http#{rand(2) == 1 ? 's' : ''}"
+
+        str = "#{protocol}://#{domain}#{path}"
+        my_str = clazz.new(str)
+
+        cookie.origin = my_str
+
+        expect(cookie.origin).to eql(URI(my_str))
+        expect(cookie.domain).to eql(domain)
+        expect(cookie.path).to eql(path)
+        expect(cookie.origin.class).to eql(protocol.end_with?('s') ? URI::HTTPS : URI::HTTP)
+      end
+    end
+  end
+
   describe 'created_at' do
     describe 'Time' do
       it 'is returned by created_at after the cookie is initialized' do


### PR DESCRIPTION
Fixes https://github.com/rapid7/metasploit-framework/issues/15456

This fixes two issues with the cookie jar and it's use by the http client, one big and one small:
1) I incorrectly authored the http_cookie_jar `parse` method to create cookies without considering set-cookie headers with no additional attributes.
2) Requests made to an IP address without knowledge of said IP address' domain name (say for example when making requests via a VPN like the one's used in TryHackMe & HackTheBox), would result in the creation of a cookie without a domain attribute, which would cause the `http-cookie` library our jar is built on top of to throw an error. The work around for this is to create an origin for each cookie, which would populate the domain field **if a domain attribute isn't already specified by the server**. 

This may break in the future if the domain is set to the target rhost of a module and if the target server begins to interpret said domain incorrectly and create an error, since a IP address isn't a valid domain. However, in the two modules this PR fixes (`gitlab_file_read_rce` and `cacti_filter_sqli_rce`), said invalid domain is simply ignored and the cookie is treated as a default value, which is the desired functionality.  


List the steps needed to make sure this thing works

- [ ] Create a [cacti testing environment](https://github.com/rapid7/metasploit-framework/pull/15122/files#diff-82d7f56d21b1de07989f59e63089807c87cc1bf37b904175a70d62adbf195dcbR18-R24)
- [ ] `use exploit/unix/http/cacti_filter_sqli_rce`
- [ ] ensure module executes successfully

- [ ] Create a [gitlab testing environment](https://github.com/rapid7/metasploit-framework/pull/14422/files#diff-6d4d4dde676983baa2fc614c666b022663112cc36716bae64c28777fa9e41eeaR24-R29)
- [ ] `use exploit/multi/http/gitlab_file_read_rce`
- [ ] ensure module executes successfully