### PR TITLE
Fix for file clean up in the Cisco Hyperflex file upload RCE module

### DIFF
--- a/modules/exploits/linux/http/cisco_hyperflex_file_upload_rce.rb
+++ b/modules/exploits/linux/http/cisco_hyperflex_file_upload_rce.rb
@@ -133,8 +133,8 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::UnexpectedReply, 'Payload upload attempt failed')
     end
 
-    register_file_for_cleanup('/var/lib/tomcat7/crossdomain.xml.war')
-    register_file_for_cleanup('/var/lib/tomcat7/crossdomain.xml/')
+    register_dir_for_cleanup('/var/lib/tomcat7/webapps/crossdomain.xml/')
+    register_file_for_cleanup('/var/lib/tomcat7/webapps/crossdomain.xml.war')
   end
 
   def execute_payload(url)


### PR DESCRIPTION
Fixes https://github.com/rapid7/metasploit-framework/pull/15333#discussion_r680146984.