### PR TITLE
Update metasploit payloads gem to 2.0.50

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,7 +29,7 @@ PATH
       metasploit-concern (~> 3.0.0)
       metasploit-credential (~> 4.0.0)
       metasploit-model (~> 3.1.0)
-      metasploit-payloads (= 2.0.48)
+      metasploit-payloads (= 2.0.50)
       metasploit_data_models (~> 4.1.0)
       metasploit_payloads-mettle (= 1.0.10)
       mqtt
@@ -242,7 +242,7 @@ GEM
       activemodel (~> 5.2.2)
       activesupport (~> 5.2.2)
       railties (~> 5.2.2)
-    metasploit-payloads (2.0.48)
+    metasploit-payloads (2.0.50)
     metasploit_data_models (4.1.4)
       activerecord (~> 5.2.2)
       activesupport (~> 5.2.2)

--- a/LICENSE_GEMS
+++ b/LICENSE_GEMS
@@ -70,7 +70,7 @@ metasploit-concern, 3.0.2, "New BSD"
 metasploit-credential, 4.0.5, "New BSD"
 metasploit-framework, 6.0.56, "New BSD"
 metasploit-model, 3.1.4, "New BSD"
-metasploit-payloads, 2.0.48, "3-clause (or ""modified"") BSD"
+metasploit-payloads, 2.0.50, "3-clause (or ""modified"") BSD"
 metasploit_data_models, 4.1.4, "New BSD"
 metasploit_payloads-mettle, 1.0.10, "3-clause (or ""modified"") BSD"
 method_source, 1.0.0, MIT

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -70,7 +70,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model', '~> 3.1.0'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '2.0.48'
+  spec.add_runtime_dependency 'metasploit-payloads', '2.0.50'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '1.0.10'
   # Needed by msfgui and other rpc components


### PR DESCRIPTION
This change bumps the metasploit payloads repo to 2.0.50, pulling in the following changes:

https://github.com/rapid7/metasploit-payloads/pull/493
https://github.com/rapid7/metasploit-payloads/pull/496

## Verification

List the steps needed to make sure this thing works

- [x] Get a python meterpreter session
- [x] **Verify** the cmd_exec tests still pass: `loadpath test/modules`, `use post/test/cmd_exec`, ...
- [x] **Verify** you can run `meterpreter > shell -t`, followed by the sudo command:

### Before
```
meterpreter > shell -t
Process 2531 created.
Channel 17 created.
bash: cannot set terminal process group (2477): Inappropriate ioctl for device
bash: no job control in this shell
user@ubuntu:~$ sudo id
sudo: no tty present and no askpass program specified
user@ubuntu:~$

```

### After
```
meterpreter > shell -t
Process 2133 created.
Channel 1 created.
user@ubuntu:~$ sudo id
[sudo] password for user: hunter2

uid=0(root) gid=0(root) groups=0(root)

```