### PR TITLE
fix localization issue in linux_enum_network

### DIFF
--- a/modules/post/linux/gather/enum_network.rb
+++ b/modules/post/linux/gather/enum_network.rb
@@ -98,14 +98,14 @@ class MetasploitModule < Msf::Post
 
   def execute(cmd)
     verification_token = Rex::Text::rand_text_alpha(8)
-    print_status("Execute: #{cmd}")
+    vprint_status("Execute: #{cmd}")
     output = cmd_exec(cmd + " || echo #{verification_token}")
     return nil if output.include?(verification_token)
     return output
   end
 
   def cat_file(filename)
-    print_status("Download: #{filename}")
+    vprint_status("Download: #{filename}")
     output = read_file(filename)
     return output
   end
@@ -114,6 +114,7 @@ class MetasploitModule < Msf::Post
     keys = []
 
     #Look for .ssh folder, "~/" might not work everytime
+    vprint_status("Execute: /usr/bin/find / -maxdepth 3 -name .ssh")
     dirs = cmd_exec("/usr/bin/find / -maxdepth 3 -name .ssh").split("\n")
     ssh_base = ''
     dirs.each do |d|
@@ -127,6 +128,7 @@ class MetasploitModule < Msf::Post
     return [] if ssh_base == ''
 
     # List all the files under .ssh/
+    vprint_status("Execute: /bin/ls -a #{ssh_base}")
     files = cmd_exec("/bin/ls -a #{ssh_base}").chomp.split()
 
     files.each do |k|

--- a/modules/post/linux/gather/enum_network.rb
+++ b/modules/post/linux/gather/enum_network.rb
@@ -128,8 +128,7 @@ class MetasploitModule < Msf::Post
     return [] if ssh_base == ''
 
     # List all the files under .ssh/
-    vprint_status("Execute: /bin/ls -a #{ssh_base}")
-    files = cmd_exec("/bin/ls -a #{ssh_base}").chomp.split()
+    files = execute("/bin/ls -a #{ssh_base}").chomp.split()
 
     files.each do |k|
       next if k =~/^(\.+)$/


### PR DESCRIPTION
## Summary
This PR fixes a localization issue in `post/linux/enum_network` module. The strings `not found` and `cannot access` were being used to verify success of a command which might vary with locale. This might not work in English systems also because the target system might error out something like `permission denied`.

## Verification Steps
```
msf6 post(linux/gather/enum_network) > rerun 
[*] Reloading module...

[*] Running module against kali
[*] Module running as pingport80
[+] Info:
[+] 	Kali GNU/Linux Rolling
[+] 	Linux kali x86_64 GNU/Linux
[*] Collecting data...
[+] Network config stored in /home/pingport80/.msf4/loot/20210806223620_default_127.0.0.1_linux.enum.netwo_772172.txt
[+] Route table stored in /home/pingport80/.msf4/loot/20210806223620_default_127.0.0.1_linux.enum.netwo_195675.txt
[-] Unable to get data for Firewall config
[+] DNS config stored in /home/pingport80/.msf4/loot/20210806223620_default_127.0.0.1_linux.enum.netwo_244243.txt
[+] SSHD config stored in /home/pingport80/.msf4/loot/20210806223620_default_127.0.0.1_linux.enum.netwo_844806.txt
[+] Host file stored in /home/pingport80/.msf4/loot/20210806223620_default_127.0.0.1_linux.enum.netwo_350424.txt
[+] SSH keys stored in /home/pingport80/.msf4/loot/20210806223620_default_127.0.0.1_linux.enum.netwo_601744.txt
[+] Active connections stored in /home/pingport80/.msf4/loot/20210806223620_default_127.0.0.1_linux.enum.netwo_225286.txt
[+] Wireless information stored in /home/pingport80/.msf4/loot/20210806223620_default_127.0.0.1_linux.enum.netwo_463244.txt
[+] Listening ports stored in /home/pingport80/.msf4/loot/20210806223620_default_127.0.0.1_linux.enum.netwo_141390.txt
[+] If-Up/If-Down stored in /home/pingport80/.msf4/loot/20210806223620_default_127.0.0.1_linux.enum.netwo_779364.txt
[*] Post module execution completed
```