### PR TITLE
Update json rpc spec tests

### DIFF
--- a/spec/api/json_rpc_spec.rb
+++ b/spec/api/json_rpc_spec.rb
@@ -412,7 +412,7 @@ RSpec.describe "Metasploit's json-rpc" do
   end
 
   describe 'analyze' do
-    let(:host_ip) { '192.0.2.2' }
+    let(:host_ip) { Faker::Internet.private_ip_v4_address }
     let(:host) do
       {
         workspace: 'default',
@@ -464,7 +464,7 @@ RSpec.describe "Metasploit's json-rpc" do
             result: {
               host: [
                 {
-                  address: '192.0.2.2',
+                  address: host_ip,
                   modules: [
                     {
                       mname: 'exploit/multi/http/apache_activemq_upload_jsp',
@@ -514,7 +514,7 @@ RSpec.describe "Metasploit's json-rpc" do
             result: {
               host: [
                 {
-                  address: '192.0.2.2',
+                  address: host_ip,
                   modules: [
                     {
                       mname: 'exploit/multi/http/apache_activemq_upload_jsp',
@@ -570,7 +570,7 @@ RSpec.describe "Metasploit's json-rpc" do
           result: {
             host: [
               {
-                address: '192.0.2.2',
+                address: host_ip,
                 modules: []
               }
             ]


### PR DESCRIPTION
The remote database tests can fail intermittently, as they are not run under a transactional fixture like the rest of the test suite:
https://github.com/rapid7/metasploit-framework/blob/be9dda40bd25dae438ba05f5d08fec9730295015/spec/spec_helper.rb#L79

This means that previous tests can leave stale information in the database which may impact other tests. This updates the json rpc spec tests to use a unique IP for each test run, long term the database should be cleaned up between test runs, or potentially this test could use unique workspaces.

## Verification

Ensure CI passes