### PR TITLE
Update psexec module to use SMBSHARE option name for consistency

### DIFF
--- a/documentation/modules/exploit/windows/smb/psexec.md
+++ b/documentation/modules/exploit/windows/smb/psexec.md
@@ -117,7 +117,7 @@ Powershell before it tries it; the manually set Powershell target won't do that.
 **Native Upload Target**
 
 The Native target will attempt to upload the payload (executable) to SYSTEM32 (which can be modified with the
-SHARE datastore option), and then execute it with psexec.
+SMBSHARE datastore option), and then execute it with psexec.
 
 This approach is generally reliable, but has a high chance of getting caught by antivirus on the target. To counter this, you can try to
 use a template by setting the EXE::Path and EXE::Template datastore options. Or, you can supply your own custom EXE by setting the

--- a/modules/exploits/windows/smb/psexec.rb
+++ b/modules/exploits/windows/smb/psexec.rb
@@ -74,7 +74,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
-        OptString.new('SHARE', [false, "The share to connect to, can be an admin share (ADMIN$,C$,...) or a normal read/write folder share", ''])
+        OptString.new('SMBSHARE', [false, "The share to connect to, can be an admin share (ADMIN$,C$,...) or a normal read/write folder share", ''], aliases: ['SHARE'])
       ])
 
     register_advanced_options(
@@ -135,8 +135,8 @@ class MetasploitModule < Msf::Exploit::Remote
     validate_service_stub_encoder!
 
     # automatically select an SMB share unless one is explicitly specified
-    if datastore['SHARE'] && !datastore['SHARE'].blank?
-      smbshare = datastore['SHARE']
+    if datastore['SMBSHARE'] && !datastore['SMBSHARE'].blank?
+      smbshare = datastore['SMBSHARE']
     elsif target.name == 'Command'
       smbshare = 'C$'
     else


### PR DESCRIPTION
Spotted this option name inconsistency as part of https://github.com/rapid7/metasploit-framework/pull/15253 - which explicitly sets the `SMBSHARE` option name when parsing

## Verification

- Open `msfconsole`
- Verify that both `set smbshare share_name` and `set share share_name` work interchangeably when running `options`
- `run` and verify you acquire a shell