### PR TITLE
Patch Meterpreter scripts to work again

### DIFF
--- a/lib/rex/script/meterpreter.rb
+++ b/lib/rex/script/meterpreter.rb
@@ -4,17 +4,24 @@ module Rex
 module Script
 class Meterpreter < Base
 
-begin
-  include Msf::Post::Windows::Priv
-  include Msf::Post::Windows::Eventlog
-  include Msf::Post::Common
-  include Msf::Post::Windows::Registry
-  include Msf::Post::File
-  include Msf::Post::Windows::Services
-  include Msf::Post::Windows::Accounts
-rescue ::LoadError
-end
+  begin
+    include Msf::Post::Windows::Priv
+    include Msf::Post::Windows::Eventlog
+    include Msf::Post::Common
+    include Msf::Post::Windows::Registry
+    include Msf::Post::File
+    include Msf::Post::Windows::Services
+    include Msf::Post::Windows::Accounts
+  rescue ::LoadError
+  end
 
+  def initialize(client, path)
+    # The mixins for `Msf::Post::*` now assume a single info argument is present,
+    # whilst `::Rex::Script::Base` assumes client and path are provided. Directly call
+    # the `::Rex::Script::Base` initialize method for now. In the future Rex scripts
+    # will need to be migrated to use post modules
+    ::Rex::Script::Base.instance_method(:initialize).bind(self).call(client, path)
+  end
 end
 end
 end


### PR DESCRIPTION
We have a separate internal ticket to look at properly migrating meterpreter scripts to depend on post modules. However, for now, they're broken. This PR adds a patch to ensure Meterpreter scripts work as expected.

### Before

Meterpreter scripts are broken:

```
meterpreter > run autoroute -s 192.200.200.0/24

[!] Meterpreter scripts are deprecated. Try post/multi/manage/autoroute.
[!] Example: run post/multi/manage/autoroute OPTION=value [...]
[-] Could not execute autoroute: ArgumentError wrong number of arguments (given 2, expected 0..1)
```

```
meterpreter > run arp_scanner -r 172.18.102.10/24

[-] Could not execute arp_scanner: ArgumentError wrong number of arguments (given 2, expected 0..1)
meterpreter > 
```

### After

The scripts work again, and the user is told that the script is deprecated:

```
meterpreter > run autoroute -s 192.200.200.0/24

[!] Meterpreter scripts are deprecated. Try post/multi/manage/autoroute.
[!] Example: run post/multi/manage/autoroute OPTION=value [...]
[*] Adding a route to 192.200.200.0/255.255.255.0...
[+] Added route to 192.200.200.0/255.255.255.0 via 192.168.123.13
[*] Use the -p option to list all active routes
```

```
meterpreter > run arp_scanner -r 172.18.102.10/24
[*] ARP Scanning 172.18.102.10/24
[...]
```

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] Open a shell against a windows target, potentially with psexec
- [ ] **verify** meterpreter scripts work as expected