### PR TITLE
Bump rex-encoder in Gemfile.lock to 0.1.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -338,7 +338,7 @@ GEM
       rex-struct2
       rex-text
     rex-core (0.1.17)
-    rex-encoder (0.1.5)
+    rex-encoder (0.1.6)
       metasm
       rex-arch
       rex-text


### PR DESCRIPTION
Brings in changes from https://github.com/rapid7/rex-encoder/pull/2

## Verification

List the steps needed to make sure this thing works

- [x] Review the PR at https://github.com/rapid7/rex-encoder/pull/2 and make sure the changes make sense.
- [x] Make sure the automated tests pass.