### PR TITLE
Correctly handle quoted console options and whitespace

### DIFF
--- a/plugins/alias.rb
+++ b/plugins/alias.rb
@@ -189,10 +189,7 @@ class Plugin::Alias < Msf::Plugin
           # insert any remaining parts of value and rebuild the line
           line = words.join(" ") + " " + value_words.join(" ") + " " + str
 
-          #print_good "passing (#{line.strip}) back to tab_complete"
-          # clear current tab_words
-          driver.tab_words = []
-          driver.tab_complete(line.strip)
+          [driver.tab_complete(line.strip), :override_completions]
         end
         # add a cmd_#{name}_help method
         define_method "cmd_#{name}_help" do |*args|

--- a/spec/lib/msf/ui/text/dispatcher_shell_spec.rb
+++ b/spec/lib/msf/ui/text/dispatcher_shell_spec.rb
@@ -1,32 +1,264 @@
 require 'spec_helper'
+require 'readline'
 
 RSpec.describe Rex::Ui::Text::DispatcherShell do
-  let(:prompt) { "%undmsf6%clr" }
-  let(:prompt_char) { "%clr>" }
+  let(:prompt) { '%undmsf6%clr' }
+  let(:prompt_char) { '%clr>' }
   let(:subject) do
     dummy_class = Class.new
     dummy_class.include described_class
     dummy_class.new(prompt, prompt_char)
   end
 
+  let(:mock_dispatcher) do
+    dispatcher = double :mock_dispatcher
+    allow(dispatcher).to receive(:tab_complete_helper) do |_current_word, _preceding_words|
+      ['username=']
+    end
+    dispatcher
+  end
+
+  describe '#tab_complete' do
+    let(:dispatcher_stack) do
+      [
+        mock_dispatcher
+      ]
+    end
+
+    before(:each) do
+      allow(subject).to receive(:dispatcher_stack).and_return(dispatcher_stack)
+    end
+
+    [
+      { input: '', expected: nil },
+      { input: '      ', expected: ['      username='] },
+      { input: '      u', expected: ['      username='] },
+      { input: 'password=abc user', expected: ['password=abc username='] },
+      { input: 'password=a\\ b\\ c user', expected: ['password=a\\ b\\ c username='] },
+      { input: "'password=a b c' user", expected: ["'password=a b c' username="] },
+      { input: "password='a b c' user", expected: ["password='a b c' username="] },
+      { input: "password='a b c'       user", expected: ["password='a b c'       username="] },
+      { input: 'username=', expected: ['username='] },
+      { input: 'password=abc ', expected: ['password=abc username='] }
+    ].each do |test|
+      it "provides completion for #{test[:input].inspect}" do
+        expect(subject.tab_complete(test[:input])).to eql(test[:expected])
+      end
+    end
+  end
+
   # Tests added to verify regex correctly returns correct values in various situations
   describe '#shellsplitex' do
     [
-      { input: "dir", expected: { quote: nil, words: ["dir"] } },
-      { input: "dir \"/\"", expected: {:quote=>nil, :words=>["dir", "/"]} },
-      { input: "dir \"/", expected: {:quote=>"\"", :words=>["dir", "/"]} },
-      { input: "dir \"/Program", expected: {:quote=>"\"", :words=>["dir", "/Program"]} },
-      { input: "dir \"/Program/", expected: {:quote=>"\"", :words=>["dir", "/Program/"]} },
-      { input: "dir C:\\Pro", expected: {:quote=>nil, :words=>["dir", "C:\\Pro"]} },
-      { input: "dir \"C:\\Pro\"", expected: {:quote=>nil, :words=>["dir", "C:\\Pro"]} },
-      { input: "dir 'C:\\Pro'", expected: {:quote=>nil, :words=>["dir", "C:\\Pro"]} },
-      { input: "dir 'C:\\ProgramData\\jim\\bob.rb'", expected: {:quote=>nil, :words=>["dir", "C:\\ProgramData\\jim\\bob.rb"]} },
-      { input: "dir 'C:\\ProgramData\\jim\\'", expected: {:quote=>nil, :words=>["dir", "C:\\ProgramData\\jim\\"]} },
-      { input: "dir \"C:\\Pro", expected: { quote: "\"", words: ["dir", "C:\\Pro"] } },
-      { input: "dir \"C: \\Pro", expected: { quote: "\"", words: ["dir", "C: \\Pro"] } },
-      { input: "dir \"C:\\Program F", expected: { quote: "\"", words: ["dir", "C:\\Program F"] } }
+      {
+        input: '',
+        expected: {
+          unbalanced_quote: nil,
+          tokens: [
+          ]
+        }
+      },
+
+      {
+        input: '        ',
+        focus: true,
+        expected: {
+          unbalanced_quote: nil,
+          tokens: [
+          ]
+        }
+      },
+
+      {
+        input: 'foo       bar',
+        focus: true,
+        expected: {
+          unbalanced_quote: nil,
+          tokens: [
+            { begin: 0, value: 'foo' },
+            { begin: 10, value: 'bar' }
+          ]
+        }
+      },
+
+      {
+        input: 'dir',
+        expected: {
+          unbalanced_quote: nil,
+          tokens: [
+            { begin: 0, value: 'dir' }
+          ]
+        }
+      },
+
+      {
+        input: 'dir "/"',
+        expected: {
+          unbalanced_quote: nil,
+          tokens: [
+            { begin: 0, value: 'dir' },
+            { begin: 4, value: '/' }
+          ]
+        }
+      },
+
+      {
+        input: 'dir "/',
+        expected: {
+          unbalanced_quote: '"',
+          tokens: [
+            { begin: 0, value: 'dir' },
+            { begin: 4, value: '/' }
+          ]
+        }
+      },
+
+      {
+        input: 'dir "/Program',
+        expected: {
+          unbalanced_quote: '"',
+          tokens: [
+            { begin: 0, value: 'dir' },
+            { begin: 4, value: '/Program' }
+          ]
+        }
+      },
+
+      {
+        input: 'dir "/Program/',
+        expected: {
+          unbalanced_quote: '"',
+          tokens: [
+            { begin: 0, value: 'dir' },
+            { begin: 4, value: '/Program/' }
+          ]
+        }
+      },
+
+      {
+        input: 'dir C:\\Pro',
+        expected: {
+          unbalanced_quote: nil,
+          tokens: [
+            { begin: 0, value: 'dir' },
+            { begin: 4, value: 'C:Pro' }
+          ]
+        }
+      },
+
+      {
+        input: 'dir "C:\\Pro"',
+        expected: {
+          unbalanced_quote: nil,
+          tokens: [
+            { begin: 0, value: 'dir' },
+            { begin: 4, value: 'C:\\Pro' }
+          ]
+        }
+      },
+
+      {
+        input: "dir 'C:\\Pro'",
+        expected: {
+          unbalanced_quote: nil,
+          tokens: [
+            { begin: 0, value: 'dir' },
+            { begin: 4, value: 'C:\\Pro' }
+          ]
+        }
+      },
+
+      {
+        input: "dir 'C:\\ProgramData\\jim\\bob.rb'",
+        expected: {
+          unbalanced_quote: nil,
+          tokens: [
+            { begin: 0, value: 'dir' },
+            { begin: 4, value: 'C:\\ProgramData\\jim\\bob.rb' }
+          ]
+        }
+      },
+
+      {
+        input: "dir 'C:\\ProgramData\\jim\\'",
+        expected: {
+          unbalanced_quote: nil,
+          tokens: [
+            { begin: 0, value: 'dir' },
+            { begin: 4, value: 'C:\\ProgramData\\jim\\' }
+          ]
+        }
+      },
+
+      {
+        input: 'dir "C:\\Pro',
+        expected: {
+          unbalanced_quote: '"',
+          tokens: [
+            { begin: 0, value: 'dir' },
+            { begin: 4, value: 'C:\\Pro' }
+          ]
+        }
+      },
+
+      {
+        input: 'dir "C: \\Pro',
+        expected: {
+          unbalanced_quote: '"',
+          tokens: [
+            { begin: 0, value: 'dir' },
+            { begin: 4, value: 'C: \\Pro' }
+          ]
+        }
+      },
+
+      {
+        input: 'dir "C:\\Program F',
+        expected: {
+          unbalanced_quote: '"',
+          tokens: [
+            { begin: 0, value: 'dir' },
+            { begin: 4, value: 'C:\\Program F' },
+          ]
+        }
+      },
+
+      {
+        input: 'pass=a\\ b\\ c user',
+        expected: {
+          unbalanced_quote: nil,
+          tokens: [
+            { begin: 0, value: 'pass=a b c' },
+            { begin: 13, value: 'user' },
+          ]
+        }
+      },
+
+      {
+        input: "'pass=a b' username=\"",
+        expected: {
+          unbalanced_quote: '"',
+          tokens: [
+            { begin: 0, value: 'pass=a b' },
+            { begin: 11, value: 'username=' },
+          ]
+        }
+      },
+
+      {
+        input: "pass='a b' user",
+        expected: {
+          unbalanced_quote: nil,
+          tokens: [
+            { begin: 0, value: 'pass=a b' },
+            { begin: 11, value: 'user' },
+          ]
+        }
+      },
     ].each do |test|
-      it { expect(subject.shellsplitex(test[:input])).to eql(test[:expected]) }
+      it "correctly parses #{test[:input]}" do
+        expect(subject.shellsplitex(test[:input])).to eql(test[:expected])
+      end
     end
   end
 end


### PR DESCRIPTION
Correctly handles quoted console options and whitespace. Closes https://github.com/rapid7/metasploit-framework/issues/15563

### Before

When the user performs tab completion, the entire string is entirely reconstructed, which can generate invalid commands, as this will get incorrectly parsed as `["run", "password=a", "b", "c", "username="]`:

Input:
```
use admin/postgres/postgres_sql
run password='a b c'      usern<tab>
```

Result:
```
run password=a b c username=<caret>
```

### After

Only the tab completed word is replaced.

Input:
```
use admin/postgres/postgres_sql
run password='a b c'      usern<tab>
```

Result:
```
run password='a b c'      username=<caret>
```

One new edgecase spotted, is tab completing option values with spaces already present will now continually autocomplete whitespace

```
set smbpass          <tab>
```

## Verification

Replicate the above example on master versus this branch., and tab complete additional scenarios that might represent edge cases.

Test: The alias plugin works as expected, and tab completion for windows/linux via meterpreter, specifically with paths with spaces, ensure that these verification steps still work https://github.com/rapid7/metasploit-framework/pull/15050