### PR TITLE
Default `simplify_module` to not load saved config

### DIFF
--- a/lib/msf/base/simple/auxiliary.rb
+++ b/lib/msf/base/simple/auxiliary.rb
@@ -45,7 +45,7 @@ module Auxiliary
 
     # Clone the module to prevent changes to the original instance
     mod = omod.replicant
-    Msf::Simple::Framework.simplify_module( mod, false )
+    Msf::Simple::Framework.simplify_module(mod)
     yield(mod) if block_given?
 
     # Import options from the OptionStr or Option hash.
@@ -109,7 +109,7 @@ module Auxiliary
   # 	The local output through which data can be displayed.
   #
   def self.check_simple(mod, opts, job_listener: Msf::Simple::NoopJobListener.instance)
-    Msf::Simple::Framework.simplify_module(mod, false)
+    Msf::Simple::Framework.simplify_module(mod)
 
     mod._import_extra_options(opts)
     if opts['LocalInput']

--- a/lib/msf/base/simple/evasion.rb
+++ b/lib/msf/base/simple/evasion.rb
@@ -13,7 +13,7 @@ module Evasion
     begin
       # Clone the module to prevent changes to the original instance
 
-      Msf::Simple::Framework.simplify_module( evasion, false )
+      Msf::Simple::Framework.simplify_module(evasion)
       yield(evasion) if block_given?
 
       # Import options from the OptionStr or Option hash.

--- a/lib/msf/base/simple/exploit.rb
+++ b/lib/msf/base/simple/exploit.rb
@@ -60,7 +60,7 @@ module Exploit
     begin
       # Clone the module to prevent changes to the original instance
 
-      Msf::Simple::Framework.simplify_module( exploit, false )
+      Msf::Simple::Framework.simplify_module(exploit)
       yield(exploit) if block_given?
 
       # Import options from the OptionStr or Option hash.
@@ -181,7 +181,7 @@ module Exploit
   # 	The local output through which data can be displayed.
   #
   def self.check_simple(mod, opts, job_listener: Msf::Simple::NoopJobListener.instance)
-    Msf::Simple::Framework.simplify_module(mod, false)
+    Msf::Simple::Framework.simplify_module(mod)
     mod._import_extra_options(opts)
 
     if opts['LocalInput']

--- a/lib/msf/base/simple/framework.rb
+++ b/lib/msf/base/simple/framework.rb
@@ -47,7 +47,7 @@ module Framework
   # Simplifies module instances when they're created.
   #
   def on_module_created(instance)
-    Msf::Simple::Framework.simplify_module(instance)
+    Msf::Simple::Framework.simplify_module(instance, load_saved_config: true)
   end
 
   ModuleSimplifiers =
@@ -131,7 +131,7 @@ module Framework
   # Simplifies a module instance if the type is supported by extending it
   # with the simplified module interface.
   #
-  def self.simplify_module(instance, load_saved_config = true)
+  def self.simplify_module(instance, load_saved_config: false)
     if ((ModuleSimplifiers[instance.type]) and
         (instance.class.include?(ModuleSimplifiers[instance.type]) == false))
       instance.extend(ModuleSimplifiers[instance.type])

--- a/lib/msf/base/simple/post.rb
+++ b/lib/msf/base/simple/post.rb
@@ -41,7 +41,7 @@ module Post
 
     # Clone the module to prevent changes to the original instance
     mod = omod.replicant
-    Msf::Simple::Framework.simplify_module( mod, false )
+    Msf::Simple::Framework.simplify_module(mod)
     yield(mod) if block_given?
 
     # Import options from the OptionStr or Option hash.

--- a/lib/msf/ui/console/module_command_dispatcher.rb
+++ b/lib/msf/ui/console/module_command_dispatcher.rb
@@ -87,7 +87,7 @@ module ModuleCommandDispatcher
           nmod = mod.replicant
           nmod.datastore['RHOST'] = thr_host[:address].dup
           nmod.datastore['VHOST'] = thr_host[:hostname].dup if nmod.options.include?('VHOST') && nmod.datastore['VHOST'].blank?
-          Msf::Simple::Framework.simplify_module(nmod, false)
+          Msf::Simple::Framework.simplify_module(nmod)
           check_simple(nmod)
         }
       end

--- a/spec/lib/msf/ui/console/command_dispatcher/auxiliary_spec.rb
+++ b/spec/lib/msf/ui/console/command_dispatcher/auxiliary_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Auxiliary do
     allow(mod).to receive(:framework).and_return(framework)
     allow(mod).to receive(:datastore).and_return(datastore)
     datastore.import_options(mod.options)
-    Msf::Simple::Framework.simplify_module(mod, false)
+    Msf::Simple::Framework.simplify_module(mod)
     mod
   end
 
@@ -90,7 +90,7 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Auxiliary do
     allow(mod).to receive(:framework).and_return(framework)
     allow(mod).to receive(:datastore).and_return(datastore)
     datastore.import_options(mod.options)
-    Msf::Simple::Framework.simplify_module(mod, false)
+    Msf::Simple::Framework.simplify_module(mod)
     mod
   end
 
@@ -141,7 +141,7 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Auxiliary do
     allow(mod).to receive(:framework).and_return(framework)
     allow(mod).to receive(:datastore).and_return(datastore)
     datastore.import_options(mod.options)
-    Msf::Simple::Framework.simplify_module(mod, false)
+    Msf::Simple::Framework.simplify_module(mod)
     mod
   end
 

--- a/spec/lib/msf/ui/console/command_dispatcher/exploit_spec.rb
+++ b/spec/lib/msf/ui/console/command_dispatcher/exploit_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Exploit do
     allow(mod).to receive(:framework).and_return(framework)
     allow(mod).to receive(:datastore).and_return(datastore)
     datastore.import_options(mod.options)
-    Msf::Simple::Framework.simplify_module(mod, false)
+    Msf::Simple::Framework.simplify_module(mod)
     mod
   end
 
@@ -90,7 +90,7 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Exploit do
     allow(mod).to receive(:framework).and_return(framework)
     allow(mod).to receive(:datastore).and_return(datastore)
     datastore.import_options(mod.options)
-    Msf::Simple::Framework.simplify_module(mod, false)
+    Msf::Simple::Framework.simplify_module(mod)
     mod
   end
 


### PR DESCRIPTION
Sometimes when generating a payload it would be created with an `LHOST` value different to what was set in the options, turns out it was always being generated with a value that was saved in the config (if it existed) rather than what was set in the options

I also flipped the logic around a little bit so calling `simplify_module` be default _won't_ load from config since all but one calls to it don't want that to happen and to me it feels more intuitive that way but I understand if people feel differently about that and I can switch it back if we feel strongly about it

# Verification
- [ ] Boot up console and use your favourite payload (I used `payload/python/meterpreter_reverse_tcp`)
- [ ] set your options with LHOST being `192.168.X.X` and then `save`
- [ ] now set your LHOST to something else like `127.0.0.1`
- [ ] run `to_handler` and you'll see the handler boot up on the correct interface
- [ ] `generate` your payload (example I used `generate -f raw -o py_met_4444.py`)
- [ ] Run your payload
- [ ] It should now have picked up the correct adress and connect, previously it would pick the one saved to the config