### PR TITLE
Update postgres_payload module to specify default payloads for targets

### DIFF
--- a/modules/exploits/linux/postgres/postgres_payload.rb
+++ b/modules/exploits/linux/postgres/postgres_payload.rb
@@ -48,8 +48,22 @@ class MetasploitModule < Msf::Exploit::Remote
         },
       'Targets'        =>
         [
-          [ 'Linux x86',       { 'Arch' => ARCH_X86 } ],
-          [ 'Linux x86_64',    { 'Arch' => ARCH_X64 } ],
+          [ 'Linux x86',
+            {
+              'Arch' => ARCH_X86,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'linux/x86/meterpreter/reverse_tcp'
+              }
+            }
+          ],
+          [ 'Linux x86_64',
+            {
+              'Arch' => ARCH_X64,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp'
+              }
+            }
+          ],
         ],
       'DefaultTarget'  => 0,
       'DisclosureDate' => '2007-06-05'

--- a/modules/exploits/windows/postgres/postgres_payload.rb
+++ b/modules/exploits/windows/postgres/postgres_payload.rb
@@ -40,8 +40,22 @@ class MetasploitModule < Msf::Exploit::Remote
       'Platform'       => 'win',
       'Targets'        =>
       [
-        [ 'Windows x86', { 'Arch' => ARCH_X86 } ],
-        [ 'Windows x64', { 'Arch' => ARCH_X64 } ],
+        [ 'Windows x86',
+          {
+            'Arch' => ARCH_X86,
+            'DefaultOptions' => {
+              'PAYLOAD' => 'windows/meterpreter/reverse_tcp'
+            }
+          }
+        ],
+        [ 'Windows x64',
+          {
+            'Arch' => ARCH_X64,
+            'DefaultOptions' => {
+              'PAYLOAD' => 'windows/x64/meterpreter/reverse_tcp'
+            }
+          }
+        ],
       ],
       'DefaultTarget'  => 0,
       'DisclosureDate' => '2009-04-10' # Date of Bernardo's BH Europe paper.


### PR DESCRIPTION
This PR makes the PostgreSQL payloads change when the user changes the target as payloads with mismatched architectures will fail to execute. Previously the user would have to set both the target and payload separately. This PR prevents issues such as #15557 where the user didn't realise wrong payload architecture caused them to not get a shell.

### Before

Setting the exploit target wouldn't update the payload option. This meant users could could set their target as `Linux x86_64`, and forget to update the payload from `linux/x86/meterpreter/reverse_tcp` to `linux/x64/meterpreter/reverse_tcp`

### After

The module now correctly updates the payload to 64 bit meterpreter when changing the target to `Linux x86_64`

### Verification

Run a docker container
```
docker run --rm -p 5500:5432 -e POSTGRES_PASSWORD=postgres postgres:13.1
```

- [ ] Start `msfconsole`
- [ ] `use exploit/linux/postgres/postgres_payload`
- [ ] `options` to verify that `linux/x86/meterpreter/reverse_tcp` is set
- [ ] `set target "Linux x86_64"`
- [ ] `options` to verify that payload is now set as `linux/x64/meterpreter/reverse_tcp`
- [ ] point the exploit at the docker service
- [ ] `run` and confirm you get a shell