### PR TITLE
Msf::Post::Linux::Kernel: Check kernel.unprivileged_bpf_disabled for values 1 or 2

### DIFF
--- a/lib/msf/core/post/linux/kernel.rb
+++ b/lib/msf/core/post/linux/kernel.rb
@@ -187,7 +187,8 @@ module Kernel
   # @return [Boolean]
   #
   def unprivileged_bpf_disabled?
-    cmd_exec('cat /proc/sys/kernel/unprivileged_bpf_disabled').to_s.strip.eql? '1'
+    unprivileged_bpf_disabled = cmd_exec('cat /proc/sys/kernel/unprivileged_bpf_disabled').to_s.strip
+    return (unprivileged_bpf_disabled == '1' || unprivileged_bpf_disabled == '2')
   rescue
     raise 'Could not determine kernel.unprivileged_bpf_disabled status'
   end


### PR DESCRIPTION
Updates `Msf::Post::Linux::Kernel.unprivileged_bpf_disabled?` to support new values supported by `kernel.unprivileged_bpf_disabled` introduced in Linux kernels since 5.13 and 5.14-rc+HEAD.

Prior to this PR `unprivileged_bpf_disabled?` checks if `/proc/sys/kernel/unprivileged_bpf_disabled` is equal to `1`.

https://github.com/rapid7/metasploit-framework/blob/5f6112766ad19e309f6a25a28b4c7e6266b89868/lib/msf/core/post/linux/kernel.rb#L184-L193

This approach was taken because older kernels may not support this sysctl. Any value other than `1` (including if the sysctl does not exist) implies unprivileged BPF is not disabled.

A new kernel config option [CONFIG_BPF_UNPRIV_DEFAULT_OFF](https://cateee.net/lkddb/web-lkddb/BPF_UNPRIV_DEFAULT_OFF.html) was [added in June 2021](https://www.spinics.net/linux/fedora/fedora-kernel/msg12405.html):

With it, `2` was added as a valid value for `kernel.unprivileged_bpf_disabled` :

```
0 | Unprivileged calls to bpf() are enabled
1 | Unprivileged calls to bpf() are disabled without recovery
2 | Unprivileged calls to bpf() are disabled
```

https://www.kernel.org/doc/html/latest/admin-guide/sysctl/kernel.html?highlight=modules_disabled#unprivileged-bpf-disabled