### PR TITLE
Fix external module encoding

### DIFF
--- a/lib/msf/core/data_store.rb
+++ b/lib/msf/core/data_store.rb
@@ -175,23 +175,23 @@ class DataStore < Hash
   end
 
   # Hack on a hack for the external modules
-  def to_nested_values
+  def to_external_message_h
     datastore_hash = {}
 
     array_nester = ->(arr) do
       if arr.first.is_a? Array
         arr.map &array_nester
       else
-        arr.map &:to_s
+        arr.map { |item| item.to_s.dup.force_encoding('UTF-8') }
       end
     end
 
     self.keys.each do |k|
       # TODO arbitrary depth
       if self[k].is_a? Array
-        datastore_hash[k.to_s] = array_nester.call(self[k])
+        datastore_hash[k.to_s.dup.force_encoding('UTF-8')] = array_nester.call(self[k])
       else
-        datastore_hash[k.to_s] = self[k].to_s
+        datastore_hash[k.to_s.dup.force_encoding('UTF-8')] = self[k].to_s.dup.force_encoding('UTF-8')
       end
     end
     datastore_hash
@@ -331,4 +331,3 @@ class DataStore < Hash
 end
 
 end
-

--- a/lib/msf/core/modules/external/message.rb
+++ b/lib/msf/core/modules/external/message.rb
@@ -29,8 +29,8 @@ class Msf::Modules::External::Message
 
   def to_json
     params =
-      if self.params.respond_to? :to_nested_values
-        self.params.to_nested_values
+      if self.params.respond_to? :to_external_message_h
+        self.params.to_external_message_h
       else
         self.params.to_h
       end

--- a/lib/msf/core/modules/external/python/metasploit/login_scanner.py
+++ b/lib/msf/core/modules/external/python/metasploit/login_scanner.py
@@ -13,7 +13,7 @@ def run_scanner(args, login_callback):
     rport = int(args['rport'])
     sleep_interval = float(args['sleep_interval'] or 0)
     # python 2/3 compatibility hack
-    if isinstance(userpass, str) or ('unicode' in vars(__builtins__) and isinstance(userpass, unicode)):
+    if isinstance(userpass, str) or ('unicode' in dir(__builtins__) and isinstance(userpass, unicode)):
         userpass = [ attempt.split(' ', 1) for attempt in userpass.splitlines() ]
 
     curr = 0


### PR DESCRIPTION
Fixes #15577

This PR properly handles encoding of UTF-8 characters.

It also makes a small correction to one of the relevant Python modules which was necessary to run the module.

### Before

```
[-] Auxiliary failed: Encoding::UndefinedConversionError "\xE4" from ASCII-8BIT to UTF-8
[-] Call stack:
[-]   /opt/metasploit-framework/embedded/lib/ruby/gems/2.7.0/gems/json-2.5.1/lib/json/common.rb:312:in `generate'
[-]   /opt/metasploit-framework/embedded/lib/ruby/gems/2.7.0/gems/json-2.5.1/lib/json/common.rb:312:in `generate'
[-]   /opt/metasploit-framework/embedded/framework/lib/msf/core/modules/external/message.rb:37:in `to_json'
[-]   /opt/metasploit-framework/embedded/framework/lib/msf/core/modules/external/bridge.rb:70:in `send'
[-]   /opt/metasploit-framework/embedded/framework/lib/msf/core/modules/external/bridge.rb:18:in `exec'
[-]   /opt/metasploit-framework/embedded/framework/lib/msf/core/modules/external.rb:25:in `exec'
[-]   /opt/metasploit-framework/embedded/framework/lib/msf/core/module/external.rb:8:in `execute_module'
```

### After

```
msf6 auxiliary(gather/python_gather) > run

[*] Starting server...
[*] 漢字
[*] Auxiliary module execution completed
```

In this example the UTF-8 encoded characters are simply output to the terminal for testing purposes.

## Verification

- [ ] Follow the steps from #15577