### PR TITLE
guard for removed workspace

### DIFF
--- a/lib/metasploit/framework/data_service/proxy/workspace_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/workspace_data_proxy.rb
@@ -36,8 +36,9 @@ module WorkspaceDataProxy
 
   def workspace
     begin
-      if @current_workspace
-        @current_workspace
+      valid_workspace = find_workspace(@current_workspace.name) if @current_workspace
+      if valid_workspace
+        @current_workspace = valid_workspace
       else
         # This is mostly a failsafe to prevent bad things from happening. @current_workspace should always be set
         # outside of here, but this will save us from crashes/infinite loops if that happens


### PR DESCRIPTION
By caching the `current` workspace in the dataservice there is
introduced a possible case where the cached Rails entity may be
removed from the database by another console instance.

There are many possible edge cases for this however for now
if the workspace is missing fallback to existing guard behavior
and set the current cached workspace to be the `default` workspace.

**The proposed behavior is likely not the best option, reviewers please suggest other options
and possibly arguments for why they are better.**

Drawback of current behavior is that if `current` workspace in the console context is deleted and
the `default` workspace is populated data from a task could possibly end up stored in the `default`
workspace without warning.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] create a `testing` workspace
```
msf6 > workspace -a testing
[*] Added workspace: testing
[*] Workspace: testing
msf6 > hosts

Hosts
=====

address  mac  name  os_name  os_flavor  os_sp  purpose  info  comments
-------  ---  ----  -------  ---------  -----  -------  ----  --------

```
- [x] Open another console
- [x] Delete the `testing` workspace
```
msf6 > workspace -d testing
[*] Deleted workspace: testing
```
- [x] query `hosts` in original workspace
Current behavior:
```
msf6 > hosts
[-] Error while running command hosts: Couldn't find workspace testing

Call stack:
/metasploit/metasploit-framework/lib/msf/util/db_manager.rb:52:in `process_opts_workspace'
/metasploit/metasploit-framework/lib/msf/core/db_manager/event.rb:55:in `block in report_event'
/ruby-2.7.2@metasploit-framework/gems/activerecord-6.1.4.1/lib/active_record/connection_adapters/abstract/connection_pool.rb:462:in `with_connection'
/metasploit/metasploit-framework/lib/msf/core/db_manager/event.rb:54:in `report_event'
/metasploit/metasploit-framework/lib/metasploit/framework/data_service/proxy/event_data_proxy.rb:18:in `block in report_event'
/metasploit/metasploit-framework/lib/metasploit/framework/data_service/proxy/core.rb:164:in `data_service_operation'
/metasploit/metasploit-framework/lib/metasploit/framework/data_service/proxy/event_data_proxy.rb:16:in `report_event'
/metasploit/metasploit-framework/lib/msf/core/framework.rb:307:in `report_event'
/metasploit/metasploit-framework/lib/msf/core/framework.rb:356:in `on_ui_command'
/metasploit/metasploit-framework/lib/msf/core/event_dispatcher.rb:145:in `block in method_missing'
/metasploit/metasploit-framework/lib/msf/core/event_dispatcher.rb:143:in `each'
/metasploit/metasploit-framework/lib/msf/core/event_dispatcher.rb:143:in `method_missing'
/metasploit/metasploit-framework/lib/msf/ui/console/driver.rb:374:in `block in on_startup'
/metasploit/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:503:in `block in run_single'
/metasploit/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:498:in `each'
/metasploit/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:498:in `run_single'
/metasploit/metasploit-framework/lib/rex/ui/text/shell.rb:162:in `run'
/metasploit/metasploit-framework/lib/metasploit/framework/command/console.rb:48:in `start'
/metasploit/metasploit-framework/lib/metasploit/framework/command/base.rb:82:in `start'
./msfconsole:23:in `<main>'
```
Proposed revised behaviour:
```
msf6 > hosts

Hosts
=====

address  mac  name  os_name  os_flavor  os_sp  purpose  info  comments
-------  ---  ----  -------  ---------  -----  -------  ----  --------

msf6 > workspace
* default
```
