### PR TITLE
fix version check for docker_credential_wincred

### DIFF
--- a/modules/exploits/windows/local/docker_credential_wincred.rb
+++ b/modules/exploits/windows/local/docker_credential_wincred.rb
@@ -55,7 +55,7 @@ class MetasploitModule < Msf::Exploit::Local
   def docker_version
     output = cmd_exec('cmd.exe', '/c docker -v')
     vprint_status(output)
-    version_string = output.match(/version (\d+\.)(\d+\.)(\d)/)[0]
+    version_string = output.match(/version (\d+\.\d+\.\d)/)[1]
     Rex::Version.new(version_string.split('.').map(&:to_i).join('.'))
   end
 

--- a/modules/exploits/windows/local/docker_credential_wincred.rb
+++ b/modules/exploits/windows/local/docker_credential_wincred.rb
@@ -53,7 +53,7 @@ class MetasploitModule < Msf::Exploit::Local
   def docker_version
     output = cmd_exec('cmd.exe', '/c docker -v')
     vprint_status(output)
-    version_string = output.match(/(\d+\.)(\d+\.)(\d)/)[0]
+    version_string = output.match(/version (\d+\.)(\d+\.)(\d)/)[0]
     Rex::Version.new(version_string.split('.').map(&:to_i).join('.'))
   end
 

--- a/modules/exploits/windows/local/docker_credential_wincred.rb
+++ b/modules/exploits/windows/local/docker_credential_wincred.rb
@@ -37,6 +37,8 @@ class MetasploitModule < Msf::Exploit::Local
         'DisclosureDate' => '2019-07-05',
         'Notes' =>
         {
+          'Stability' => [ CRASH_SAFE ],
+          'Reliability' => [ REPEATABLE_SESSION ],
           'SideEffects' => [ ARTIFACTS_ON_DISK ]
         },
         'References' => [


### PR DESCRIPTION
This PR fixes the version check for `docker_credential_wincred`.
Currently the check is done like this:
```rb
def docker_version
    output = cmd_exec('cmd.exe', '/c docker -v')
    vprint_status(output)
    version_string = output.match(/(\d+\.)(\d+\.)(\d)/)[0]
    Rex::Version.new(version_string.split('.').map(&:to_i).join('.'))
end
```

It usually works, but when `cmd` is started from an UNC path it writes some output before the command output:

```
\\192.168.192.129\samba
CMD.EXE was started with the above path as the current directory.
UNC paths are not supported. Defaulting to Windows directory.
Docker version 18.09.0, build 4d60db4
```

Using the regex `/(\d+\.)(\d+\.)(\d)/` to match 3 numbers separated by a dot, it will match the IP address from the UNC path (192.168.192) instead of the Docker version from the last line.

This PR changes the regex to `/Docker version (\d+\.)(\d+\.)(\d)/` so that we are sure the line with the Docker version is used.