### PR TITLE
Fixes issues with encrypted payloads by moving session bootstrap logic

### DIFF
--- a/lib/msf/base/serializer/readable_text.rb
+++ b/lib/msf/base/serializer/readable_text.rb
@@ -844,6 +844,7 @@ class ReadableText
     end
 
     sinfo = session.info.to_s
+    sinfo = sinfo.gsub(/[\r\n\t]+/, ' ')
     # Arbitrarily cut info at 80 columns
     if sinfo.length > 80
       sinfo = "#{sinfo[0,77]}..."

--- a/lib/msf/base/sessions/command_shell.rb
+++ b/lib/msf/base/sessions/command_shell.rb
@@ -125,6 +125,13 @@ Shell Banner:
       # Only populate +session.info+ with a captured banner if the shell is responsive and verified
       session.info = session_info
       session
+    else
+      # Encrypted shells need all information read before anything is written, so we read in the banner here. However we
+      # don't populate session.info with the captured value since without AutoVerify there's no way to be certain this
+      # actually is a banner and not junk/malicious input
+      if session.class == ::Msf::Sessions::EncryptedShell
+        shell_read(-1, 0.1)
+      end
     end
   end
 

--- a/lib/msf/base/sessions/command_shell.rb
+++ b/lib/msf/base/sessions/command_shell.rb
@@ -92,6 +92,27 @@ class CommandShell
     session = self
 
     if datastore['AutoVerifySession']
+      session_info = ''
+
+      # Read the initial output and mash it into a single line
+      # Timeout set to 1 to read in banner of all payload responses (may capture prompt as well)
+      # Encoding is not forced to support non ASCII shells
+      if session.info.nil? or session.info.empty?
+        banner = shell_read(-1, 1)
+        if banner && !banner.empty?
+          banner.gsub!(/[\x00-\x08\x0b\x0c\x0e-\x19\x7f-\xff]+/n, "_")
+          banner.strip!
+
+          banner = """
+Shell Banner:
+#{banner}
+-----
+          """
+
+          session_info = banner
+        end
+      end
+
       token = Rex::Text.rand_text_alphanumeric(8..24)
       response = shell_command("echo #{token}", 3)
       unless response&.include?(token)
@@ -100,6 +121,10 @@ class CommandShell
         session.kill
         return nil
       end
+
+      # Only populate +session.info+ with a captured banner if the shell is responsive and verified
+      session.info = session_info
+      session
     end
   end
 
@@ -729,20 +754,6 @@ class CommandShell
   # Execute any specified auto-run scripts for this session
   #
   def process_autoruns(datastore)
-    # Read the initial output and mash it into a single line
-    if (not self.info or self.info.empty?)
-      initial_output = shell_read(-1, 0.01)
-      if (initial_output)
-        initial_output.force_encoding("ASCII-8BIT") if initial_output.respond_to?(:force_encoding)
-        initial_output.gsub!(/[\x00-\x08\x0b\x0c\x0e-\x19\x7f-\xff]+/n,"_")
-        initial_output.gsub!(/[\r\n\t]+/, ' ')
-        initial_output.strip!
-
-        # Set the inital output to .info
-        self.info = initial_output
-      end
-    end
-
     if datastore['InitialAutoRunScript'] && !datastore['InitialAutoRunScript'].empty?
       args = Shellwords.shellwords( datastore['InitialAutoRunScript'] )
       print_status("Session ID #{sid} (#{tunnel_to_s}) processing InitialAutoRunScript '#{datastore['InitialAutoRunScript']}'")
@@ -779,6 +790,13 @@ protected
   #
   def _interact_stream
     fds = [rstream.fd, user_input.fd]
+
+    # Displays +info+ on all session startups
+    # +info+ is set to the shell banner and initial prompt in the +bootstrap+ method
+    user_output.print("#{self.info}\n") if (self.info && !self.info.empty?) && self.interacting
+
+    run_single(('').chomp("\n"))
+
     while self.interacting
       sd = Rex::ThreadSafe.select(fds, nil, fds, 0.5)
       next unless sd

--- a/lib/msf/base/sessions/command_shell.rb
+++ b/lib/msf/base/sessions/command_shell.rb
@@ -97,17 +97,17 @@ class CommandShell
       # Read the initial output and mash it into a single line
       # Timeout set to 1 to read in banner of all payload responses (may capture prompt as well)
       # Encoding is not forced to support non ASCII shells
-      if session.info.nil? or session.info.empty?
+      if session.info.nil? || session.info.empty?
         banner = shell_read(-1, 1)
         if banner && !banner.empty?
-          banner.gsub!(/[\x00-\x08\x0b\x0c\x0e-\x19\x7f-\xff]+/n, "_")
+          banner.gsub!(/[^[:print:][:space:]]+/n, "_")
           banner.strip!
 
-          banner = """
+          banner = %Q{
 Shell Banner:
 #{banner}
 -----
-          """
+          }
 
           session_info = banner
         end
@@ -802,7 +802,7 @@ protected
     # +info+ is set to the shell banner and initial prompt in the +bootstrap+ method
     user_output.print("#{self.info}\n") if (self.info && !self.info.empty?) && self.interacting
 
-    run_single(('').chomp("\n"))
+    run_single('')
 
     while self.interacting
       sd = Rex::ThreadSafe.select(fds, nil, fds, 0.5)

--- a/lib/msf/core/framework.rb
+++ b/lib/msf/core/framework.rb
@@ -191,11 +191,6 @@ class Framework
   #
   attr_reader   :features
 
-  #
-  # The framework instance's dependency
-  #
-  #
-  attr_accessor   :has_mingw
 
   #
   # The framework instance's data service proxy

--- a/lib/msf/core/payload/windows/encrypted_reverse_tcp.rb
+++ b/lib/msf/core/payload/windows/encrypted_reverse_tcp.rb
@@ -24,7 +24,9 @@ module Payload::Windows::EncryptedReverseTcp
     # prevents checks running when module is initialized during msfconsole startup
     if framework
       unless framework.db.connection_established?
-        add_error("This module requires a database connection. Please run 'msfdb init' or 'msfdb start'.")
+        add_warning('A database connection is preferred for this module. If this is not possible, please make sure to'\
+        'take note of the ChachaKey & ChachaNonce options used during generation in order to set them correctly when'\
+        'calling a module handler.')
       end
 
       if self.arch.nil? || self.arch.empty?

--- a/lib/msf/core/payload/windows/encrypted_reverse_tcp.rb
+++ b/lib/msf/core/payload/windows/encrypted_reverse_tcp.rb
@@ -20,6 +20,25 @@ module Payload::Windows::EncryptedReverseTcp
 
   def initialize(*args)
     super
+
+    # prevents checks running when module is initialized during msfconsole startup
+    if framework
+      unless framework.db.connection_established?
+        add_error("This module requires a database connection. Please run 'msfdb init' or 'msfdb start'.")
+      end
+
+      if self.arch.nil? || self.arch.empty?
+        add_warning('Payload architecture could not be determined.')
+        return
+      end
+
+      if self.arch.include?('x86') && !::Metasploit::Framework::Compiler::Mingw::X86.available?
+        add_error("x86 Mingw installation is not available.")
+      end
+      if self.arch.include?('x64') && !::Metasploit::Framework::Compiler::Mingw::X64.available?
+        add_error("x64 Mingw installation is not available.")
+      end
+    end
   end
 
   def generate(opts={})

--- a/lib/msf/core/payload/windows/encrypted_reverse_tcp.rb
+++ b/lib/msf/core/payload/windows/encrypted_reverse_tcp.rb
@@ -24,8 +24,8 @@ module Payload::Windows::EncryptedReverseTcp
     # prevents checks running when module is initialized during msfconsole startup
     if framework
       unless framework.db.connection_established?
-        add_warning('A database connection is preferred for this module. If this is not possible, please make sure to'\
-        'take note of the ChachaKey & ChachaNonce options used during generation in order to set them correctly when'\
+        add_warning('A database connection is preferred for this module. If this is not possible, please make sure to '\
+        'take note of the ChachaKey & ChachaNonce options used during generation in order to set them correctly when '\
         'calling a module handler.')
       end
 


### PR DESCRIPTION
Fixes https://github.com/rapid7/metasploit-framework/issues/15145

![image](https://user-images.githubusercontent.com/54621924/132889184-0f192f02-05e7-413c-a2af-6ef4976cec8e.png)
The encrypted payloads make use of a ChaCha Cipher that, in this current implementation, depends on a read/write cycle. IE msfconsole writes, then it reads a response. Performing two writes or reads in a row will break the cipher during session setup. 

By moving the logic that gathers session info for the `command_shell`'s initial communication with msfconsole from the `process_autorun` method to the `bootstrap` method, we ensure that this functionality is always carried out before any commands are sent to a victim. This is better functionality for `command_shell`s in general.

This change also ensures that an encrypted shell will update it's cipher with a new key and nonce, before calling the inherited`command_shell` `bootstrap` method as `super` to read the initial communication from the victim correctly, and auto verify the session accurately if the datastore variable is set.

These changes also have the added benefit of populating the info field of a session. This means the information field is now populated for encrypted and regular shells when running the `sessions` command (it's cut off after 77 chars IIRC): 

![image](https://user-images.githubusercontent.com/54621924/132337447-0e95ee44-ada7-45c1-8102-783138e716b3.png)

This above functionality is a freebie.

The changes made to line 800-806 however are a new addition. It means that the banner will be displayed every time a session is interacted with **IF** it was captured correctly:
![image](https://user-images.githubusercontent.com/54621924/132337387-9fd12ed4-812e-4df7-b251-eda274522ca2.png)

Have also added warning to encrypted payloads that will warn the user that the DB is not available, and the required mingw install is not present:
![image](https://user-images.githubusercontent.com/54621924/132889184-0f192f02-05e7-413c-a2af-6ef4976cec8e.png)

Tested with the following payloads, each with `AutoVerifySession` set to true and false on Windows 7:
```
payload/windows/encrypted_shell/reverse_tcp
payload/windows/x64/encrypted_shell/reverse_tcp
payload/windows/encrypted_shell_reverse_tcp
payload/windows/x64/encrypted_shell_reverse_tcp
```

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] generate any of the above payloads
- [x] `to_handler` with `AutoVerifySession` set to true
- [x] execute payload 
- [x] ensure shell is created successfully
- [x] `jobs -K`
- [x] `to_handler` with `AutoVerifySession`  set to false
- [x] execute payload 
- [x] ensure shell is created successfully

Thanks to @space-r7 for the assists!

TODO:
- [X] Encrypted shells that have a listener generated with `to_handler` do not inform users that a session has been created
- [ ]Spamming enter on any of the above shells generates garbage output (Shell may break or may remain operational):
  - ![image](https://user-images.githubusercontent.com/54621924/131004133-0c4fd308-a238-4562-9a9c-1d8e98aad510.png)
- [X] `multi/handler` doesn't work with any of the above shells when using a `generic` payload
  - Not fixed, just determined that generic handlers can't work with these payloads since they'd need the `nonce` and `key` values and they don't handle them atm 
- [X] Upgrading encrypted sessions to meterpreter doesn't work
  - Not fixed, existing functionality and well sign posted when running `sessions -u` with an encrypted session  