### PR TITLE
Update metasploit payloads version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,7 +29,7 @@ PATH
       metasploit-concern
       metasploit-credential
       metasploit-model
-      metasploit-payloads (= 2.0.50)
+      metasploit-payloads (= 2.0.54)
       metasploit_data_models
       metasploit_payloads-mettle (= 1.0.10)
       mqtt
@@ -256,7 +256,7 @@ GEM
       activemodel (~> 6.0)
       activesupport (~> 6.0)
       railties (~> 6.0)
-    metasploit-payloads (2.0.50)
+    metasploit-payloads (2.0.54)
     metasploit_data_models (5.0.3)
       activerecord (~> 6.0)
       activesupport (~> 6.0)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -70,7 +70,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '2.0.50'
+  spec.add_runtime_dependency 'metasploit-payloads', '2.0.54'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '1.0.10'
   # Needed by msfgui and other rpc components

--- a/modules/payloads/singles/python/meterpreter_bind_tcp.rb
+++ b/modules/payloads/singles/python/meterpreter_bind_tcp.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 112749
+  CachedSize = 113569
 
   include Msf::Payload::Single
   include Msf::Payload::Python

--- a/modules/payloads/singles/python/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/python/meterpreter_reverse_http.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 112717
+  CachedSize = 113537
 
   include Msf::Payload::Single
   include Msf::Payload::Python

--- a/modules/payloads/singles/python/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/python/meterpreter_reverse_https.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 112717
+  CachedSize = 113537
 
   include Msf::Payload::Single
   include Msf::Payload::Python

--- a/modules/payloads/singles/python/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/python/meterpreter_reverse_tcp.rb
@@ -6,7 +6,7 @@
 
 module MetasploitModule
 
-  CachedSize = 112645
+  CachedSize = 113469
 
   include Msf::Payload::Single
   include Msf::Payload::Python


### PR DESCRIPTION
Pulling in
https://github.com/rapid7/metasploit-payloads/pull/501 - Cleanup the process object
https://github.com/rapid7/metasploit-payloads/pull/500 - Handle missing command ids in Python
https://github.com/rapid7/metasploit-payloads/pull/498 - fix windows meterpreter mingw build
https://github.com/rapid7/metasploit-payloads/pull/497 - Fix windows meterpreter expiration


## Verification

List the steps needed to make sure this thing works

- verify python reverse shell works
- verify windows reverse shell works